### PR TITLE
[FLINK-23460] Add a global flag for enabling/disabling final checkpoints

### DIFF
--- a/flink-core/src/main/java/org/apache/flink/configuration/ExecutionOptions.java
+++ b/flink-core/src/main/java/org/apache/flink/configuration/ExecutionOptions.java
@@ -97,6 +97,18 @@ public class ExecutionOptions {
                                                             + "throughput"))
                                     .build());
 
+    /**
+     * Should be moved to {@code ExecutionCheckpointingOptions}. Once CheckpointCoordinator has
+     * access to those options.
+     */
+    @Documentation.ExcludeFromDocumentation("This is a feature toggle")
+    public static final ConfigOption<Boolean> ENABLE_CHECKPOINTS_AFTER_TASKS_FINISH =
+            ConfigOptions.key("execution.checkpointing.checkpoints-after-tasks-finish.enabled")
+                    .booleanType()
+                    .defaultValue(false)
+                    .withDescription(
+                            "Feature toggle for enabling checkpointing after tasks finish.");
+
     @Documentation.ExcludeFromDocumentation(
             "This is an expert option, that we do not want to expose in" + " the documentation")
     public static final ConfigOption<Boolean> SORT_INPUTS =

--- a/flink-core/src/main/java/org/apache/flink/configuration/ExecutionOptions.java
+++ b/flink-core/src/main/java/org/apache/flink/configuration/ExecutionOptions.java
@@ -97,18 +97,6 @@ public class ExecutionOptions {
                                                             + "throughput"))
                                     .build());
 
-    /**
-     * Should be moved to {@code ExecutionCheckpointingOptions}. Once CheckpointCoordinator has
-     * access to those options.
-     */
-    @Documentation.ExcludeFromDocumentation("This is a feature toggle")
-    public static final ConfigOption<Boolean> ENABLE_CHECKPOINTS_AFTER_TASKS_FINISH =
-            ConfigOptions.key("execution.checkpointing.checkpoints-after-tasks-finish.enabled")
-                    .booleanType()
-                    .defaultValue(false)
-                    .withDescription(
-                            "Feature toggle for enabling checkpointing after tasks finish.");
-
     @Documentation.ExcludeFromDocumentation(
             "This is an expert option, that we do not want to expose in" + " the documentation")
     public static final ConfigOption<Boolean> SORT_INPUTS =

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/checkpoint/DefaultCheckpointPlanCalculator.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/checkpoint/DefaultCheckpointPlanCalculator.java
@@ -60,20 +60,17 @@ public class DefaultCheckpointPlanCalculator implements CheckpointPlanCalculator
 
     private final List<ExecutionVertex> sourceTasks = new ArrayList<>();
 
-    /**
-     * TODO Temporary flag to allow checkpoints after tasks finished. This is disabled for regular
-     * jobs to keep the current behavior but we want to allow it in tests. This should be removed
-     * once all parts of the stack support checkpoints after some tasks finished.
-     */
-    private boolean allowCheckpointsAfterTasksFinished;
+    private final boolean allowCheckpointsAfterTasksFinished;
 
     public DefaultCheckpointPlanCalculator(
             JobID jobId,
             CheckpointPlanCalculatorContext context,
-            Iterable<ExecutionJobVertex> jobVerticesInTopologyOrderIterable) {
+            Iterable<ExecutionJobVertex> jobVerticesInTopologyOrderIterable,
+            boolean allowCheckpointsAfterTasksFinished) {
 
         this.jobId = checkNotNull(jobId);
         this.context = checkNotNull(context);
+        this.allowCheckpointsAfterTasksFinished = allowCheckpointsAfterTasksFinished;
 
         checkNotNull(jobVerticesInTopologyOrderIterable);
         jobVerticesInTopologyOrderIterable.forEach(
@@ -85,10 +82,6 @@ public class DefaultCheckpointPlanCalculator implements CheckpointPlanCalculator
                         sourceTasks.addAll(Arrays.asList(jobVertex.getTaskVertices()));
                     }
                 });
-    }
-
-    public void setAllowCheckpointsAfterTasksFinished(boolean allowCheckpointsAfterTasksFinished) {
-        this.allowCheckpointsAfterTasksFinished = allowCheckpointsAfterTasksFinished;
     }
 
     @Override

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/executiongraph/DefaultExecutionGraph.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/executiongraph/DefaultExecutionGraph.java
@@ -444,7 +444,8 @@ public class DefaultExecutionGraph implements ExecutionGraph, InternalExecutionG
                         new ScheduledExecutorServiceAdapter(checkpointCoordinatorTimer),
                         SharedStateRegistry.DEFAULT_FACTORY,
                         failureManager,
-                        createCheckpointPlanCalculator(),
+                        createCheckpointPlanCalculator(
+                                chkConfig.isEnableCheckpointsAfterTasksFinish()),
                         new ExecutionAttemptMappingProvider(getAllExecutionVertices()));
 
         // register the master hooks on the checkpoint coordinator
@@ -468,11 +469,13 @@ public class DefaultExecutionGraph implements ExecutionGraph, InternalExecutionG
         this.checkpointStorageName = checkpointStorage.getClass().getSimpleName();
     }
 
-    private CheckpointPlanCalculator createCheckpointPlanCalculator() {
+    private CheckpointPlanCalculator createCheckpointPlanCalculator(
+            boolean enableCheckpointsAfterTasksFinish) {
         return new DefaultCheckpointPlanCalculator(
                 getJobID(),
                 new ExecutionGraphCheckpointPlanCalculatorContext(this),
-                getVerticesTopologically());
+                getVerticesTopologically(),
+                enableCheckpointsAfterTasksFinish);
     }
 
     @Override

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/jobgraph/tasks/CheckpointCoordinatorConfiguration.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/jobgraph/tasks/CheckpointCoordinatorConfiguration.java
@@ -66,6 +66,8 @@ public class CheckpointCoordinatorConfiguration implements Serializable {
 
     private final long checkpointIdOfIgnoredInFlightData;
 
+    private final boolean enableCheckpointsAfterTasksFinish;
+
     /** @deprecated use {@link #builder()}. */
     @Deprecated
     @VisibleForTesting
@@ -91,7 +93,8 @@ public class CheckpointCoordinatorConfiguration implements Serializable {
                 tolerableCpFailureNumber,
                 isUnalignedCheckpoint,
                 0,
-                checkpointIdOfIgnoredInFlightData);
+                checkpointIdOfIgnoredInFlightData,
+                false);
     }
 
     private CheckpointCoordinatorConfiguration(
@@ -105,7 +108,8 @@ public class CheckpointCoordinatorConfiguration implements Serializable {
             int tolerableCpFailureNumber,
             boolean isUnalignedCheckpointsEnabled,
             long alignedCheckpointTimeout,
-            long checkpointIdOfIgnoredInFlightData) {
+            long checkpointIdOfIgnoredInFlightData,
+            boolean enableCheckpointsAfterTasksFinish) {
 
         // sanity checks
         if (checkpointInterval < MINIMAL_CHECKPOINT_TIME
@@ -130,6 +134,7 @@ public class CheckpointCoordinatorConfiguration implements Serializable {
         this.isUnalignedCheckpointsEnabled = isUnalignedCheckpointsEnabled;
         this.alignedCheckpointTimeout = alignedCheckpointTimeout;
         this.checkpointIdOfIgnoredInFlightData = checkpointIdOfIgnoredInFlightData;
+        this.enableCheckpointsAfterTasksFinish = enableCheckpointsAfterTasksFinish;
     }
 
     public long getCheckpointInterval() {
@@ -176,6 +181,10 @@ public class CheckpointCoordinatorConfiguration implements Serializable {
         return checkpointIdOfIgnoredInFlightData;
     }
 
+    public boolean isEnableCheckpointsAfterTasksFinish() {
+        return enableCheckpointsAfterTasksFinish;
+    }
+
     @Override
     public boolean equals(Object o) {
         if (this == o) {
@@ -195,7 +204,8 @@ public class CheckpointCoordinatorConfiguration implements Serializable {
                 && checkpointRetentionPolicy == that.checkpointRetentionPolicy
                 && isPreferCheckpointForRecovery == that.isPreferCheckpointForRecovery
                 && tolerableCheckpointFailureNumber == that.tolerableCheckpointFailureNumber
-                && checkpointIdOfIgnoredInFlightData == that.checkpointIdOfIgnoredInFlightData;
+                && checkpointIdOfIgnoredInFlightData == that.checkpointIdOfIgnoredInFlightData
+                && enableCheckpointsAfterTasksFinish == that.enableCheckpointsAfterTasksFinish;
     }
 
     @Override
@@ -211,7 +221,8 @@ public class CheckpointCoordinatorConfiguration implements Serializable {
                 alignedCheckpointTimeout,
                 isPreferCheckpointForRecovery,
                 tolerableCheckpointFailureNumber,
-                checkpointIdOfIgnoredInFlightData);
+                checkpointIdOfIgnoredInFlightData,
+                enableCheckpointsAfterTasksFinish);
     }
 
     @Override
@@ -239,6 +250,8 @@ public class CheckpointCoordinatorConfiguration implements Serializable {
                 + tolerableCheckpointFailureNumber
                 + ", checkpointIdOfIgnoredInFlightData="
                 + checkpointIdOfIgnoredInFlightData
+                + ", enableCheckpointsAfterTasksFinish="
+                + enableCheckpointsAfterTasksFinish
                 + '}';
     }
 
@@ -260,6 +273,7 @@ public class CheckpointCoordinatorConfiguration implements Serializable {
         private boolean isUnalignedCheckpointsEnabled;
         private long alignedCheckpointTimeout = 0;
         private long checkpointIdOfIgnoredInFlightData;
+        private boolean enableCheckpointsAfterTasksFinish;
 
         public CheckpointCoordinatorConfiguration build() {
             return new CheckpointCoordinatorConfiguration(
@@ -273,7 +287,8 @@ public class CheckpointCoordinatorConfiguration implements Serializable {
                     tolerableCheckpointFailureNumber,
                     isUnalignedCheckpointsEnabled,
                     alignedCheckpointTimeout,
-                    checkpointIdOfIgnoredInFlightData);
+                    checkpointIdOfIgnoredInFlightData,
+                    enableCheckpointsAfterTasksFinish);
         }
 
         public CheckpointCoordinatorConfigurationBuilder setCheckpointInterval(
@@ -338,6 +353,12 @@ public class CheckpointCoordinatorConfiguration implements Serializable {
         public CheckpointCoordinatorConfigurationBuilder setCheckpointIdOfIgnoredInFlightData(
                 long checkpointIdOfIgnoredInFlightData) {
             this.checkpointIdOfIgnoredInFlightData = checkpointIdOfIgnoredInFlightData;
+            return this;
+        }
+
+        public CheckpointCoordinatorConfigurationBuilder setEnableCheckpointsAfterTasksFinish(
+                boolean enableCheckpointsAfterTasksFinish) {
+            this.enableCheckpointsAfterTasksFinish = enableCheckpointsAfterTasksFinish;
             return this;
         }
     }

--- a/flink-runtime/src/test/java/org/apache/flink/runtime/checkpoint/CheckpointCoordinatorMasterHooksTest.java
+++ b/flink-runtime/src/test/java/org/apache/flink/runtime/checkpoint/CheckpointCoordinatorMasterHooksTest.java
@@ -492,7 +492,8 @@ public class CheckpointCoordinatorMasterHooksTest {
                 new DefaultCheckpointPlanCalculator(
                         graph.getJobID(),
                         new ExecutionGraphCheckpointPlanCalculatorContext(graph),
-                        graph.getVerticesTopologically()),
+                        graph.getVerticesTopologically(),
+                        false),
                 new ExecutionAttemptMappingProvider(graph.getAllExecutionVertices()));
     }
 

--- a/flink-runtime/src/test/java/org/apache/flink/runtime/checkpoint/CheckpointCoordinatorTestingUtils.java
+++ b/flink-runtime/src/test/java/org/apache/flink/runtime/checkpoint/CheckpointCoordinatorTestingUtils.java
@@ -766,9 +766,8 @@ public class CheckpointCoordinatorTestingUtils {
                     new DefaultCheckpointPlanCalculator(
                             executionGraph.getJobID(),
                             new ExecutionGraphCheckpointPlanCalculatorContext(executionGraph),
-                            executionGraph.getVerticesTopologically());
-            checkpointPlanCalculator.setAllowCheckpointsAfterTasksFinished(
-                    allowCheckpointsAfterTasksFinished);
+                            executionGraph.getVerticesTopologically(),
+                            allowCheckpointsAfterTasksFinished);
 
             return new CheckpointCoordinator(
                     executionGraph.getJobID(),

--- a/flink-runtime/src/test/java/org/apache/flink/runtime/checkpoint/DefaultCheckpointPlanCalculatorTest.java
+++ b/flink-runtime/src/test/java/org/apache/flink/runtime/checkpoint/DefaultCheckpointPlanCalculatorTest.java
@@ -329,8 +329,8 @@ public class DefaultCheckpointPlanCalculatorTest {
                 new DefaultCheckpointPlanCalculator(
                         graph.getJobID(),
                         new ExecutionGraphCheckpointPlanCalculatorContext(graph),
-                        graph.getVerticesTopologically());
-        checkpointPlanCalculator.setAllowCheckpointsAfterTasksFinished(true);
+                        graph.getVerticesTopologically(),
+                        true);
         return checkpointPlanCalculator;
     }
 

--- a/flink-runtime/src/test/java/org/apache/flink/runtime/checkpoint/FailoverStrategyCheckpointCoordinatorTest.java
+++ b/flink-runtime/src/test/java/org/apache/flink/runtime/checkpoint/FailoverStrategyCheckpointCoordinatorTest.java
@@ -88,7 +88,8 @@ public class FailoverStrategyCheckpointCoordinatorTest extends TestLogger {
                         new DefaultCheckpointPlanCalculator(
                                 graph.getJobID(),
                                 new ExecutionGraphCheckpointPlanCalculatorContext(graph),
-                                graph.getVerticesTopologically()),
+                                graph.getVerticesTopologically(),
+                                false),
                         new ExecutionAttemptMappingProvider(graph.getAllExecutionVertices()));
 
         // switch current execution's state to running to allow checkpoint could be triggered.

--- a/flink-runtime/src/test/java/org/apache/flink/runtime/checkpoint/PendingCheckpointTest.java
+++ b/flink-runtime/src/test/java/org/apache/flink/runtime/checkpoint/PendingCheckpointTest.java
@@ -755,8 +755,8 @@ public class PendingCheckpointTest {
                 new DefaultCheckpointPlanCalculator(
                         new JobID(),
                         new ExecutionGraphCheckpointPlanCalculatorContext(executionGraph),
-                        executionGraph.getVerticesTopologically());
-        checkpointPlanCalculator.setAllowCheckpointsAfterTasksFinished(true);
+                        executionGraph.getVerticesTopologically(),
+                        true);
         CheckpointPlan checkpointPlan = checkpointPlanCalculator.calculateCheckpointPlan().get();
 
         final Path checkpointDir = new Path(tmpFolder.newFolder().toURI());

--- a/flink-streaming-java/src/main/java/org/apache/flink/streaming/api/environment/ExecutionCheckpointingOptions.java
+++ b/flink-streaming-java/src/main/java/org/apache/flink/streaming/api/environment/ExecutionCheckpointingOptions.java
@@ -19,6 +19,7 @@
 package org.apache.flink.streaming.api.environment;
 
 import org.apache.flink.annotation.PublicEvolving;
+import org.apache.flink.annotation.docs.Documentation;
 import org.apache.flink.configuration.CheckpointingOptions;
 import org.apache.flink.configuration.ConfigOption;
 import org.apache.flink.configuration.ConfigOptions;
@@ -238,4 +239,12 @@ public class ExecutionCheckpointingOptions {
                                                     + "the specific checkpoint without in-flight data.")
                                     .linebreak()
                                     .build());
+
+    @Documentation.ExcludeFromDocumentation("This is a feature toggle")
+    public static final ConfigOption<Boolean> ENABLE_CHECKPOINTS_AFTER_TASKS_FINISH =
+            ConfigOptions.key("execution.checkpointing.checkpoints-after-tasks-finish.enabled")
+                    .booleanType()
+                    .defaultValue(false)
+                    .withDescription(
+                            "Feature toggle for enabling checkpointing after tasks finish.");
 }

--- a/flink-streaming-java/src/main/java/org/apache/flink/streaming/api/environment/StreamExecutionEnvironment.java
+++ b/flink-streaming-java/src/main/java/org/apache/flink/streaming/api/environment/StreamExecutionEnvironment.java
@@ -987,6 +987,16 @@ public class StreamExecutionEnvironment {
         configuration
                 .getOptional(PipelineOptions.NAME)
                 .ifPresent(jobName -> this.getConfiguration().set(PipelineOptions.NAME, jobName));
+        configuration
+                .getOptional(ExecutionCheckpointingOptions.ENABLE_CHECKPOINTS_AFTER_TASKS_FINISH)
+                .ifPresent(
+                        flag ->
+                                this.getConfiguration()
+                                        .set(
+                                                ExecutionCheckpointingOptions
+                                                        .ENABLE_CHECKPOINTS_AFTER_TASKS_FINISH,
+                                                flag));
+
         config.configure(configuration, classLoader);
         checkpointCfg.configure(configuration);
     }

--- a/flink-streaming-java/src/main/java/org/apache/flink/streaming/api/graph/StreamGraph.java
+++ b/flink-streaming-java/src/main/java/org/apache/flink/streaming/api/graph/StreamGraph.java
@@ -106,6 +106,8 @@ public class StreamGraph implements Pipeline {
 
     private GlobalStreamExchangeMode globalExchangeMode;
 
+    private boolean enableCheckpointsAfterTasksFinish;
+
     /** Flag to indicate whether to put all vertices into the same slot sharing group by default. */
     private boolean allVerticesInSameSlotSharingGroupByDefault = true;
 
@@ -278,6 +280,14 @@ public class StreamGraph implements Pipeline {
      */
     public boolean isAllVerticesInSameSlotSharingGroupByDefault() {
         return allVerticesInSameSlotSharingGroupByDefault;
+    }
+
+    public boolean isEnableCheckpointsAfterTasksFinish() {
+        return enableCheckpointsAfterTasksFinish;
+    }
+
+    public void setEnableCheckpointsAfterTasksFinish(boolean enableCheckpointsAfterTasksFinish) {
+        this.enableCheckpointsAfterTasksFinish = enableCheckpointsAfterTasksFinish;
     }
 
     // Checkpointing

--- a/flink-streaming-java/src/main/java/org/apache/flink/streaming/api/graph/StreamGraphGenerator.java
+++ b/flink-streaming-java/src/main/java/org/apache/flink/streaming/api/graph/StreamGraphGenerator.java
@@ -314,6 +314,8 @@ public class StreamGraphGenerator {
 
     public StreamGraph generate() {
         streamGraph = new StreamGraph(executionConfig, checkpointConfig, savepointRestoreSettings);
+        streamGraph.setEnableCheckpointsAfterTasksFinish(
+                configuration.get(ExecutionOptions.ENABLE_CHECKPOINTS_AFTER_TASKS_FINISH));
         shouldExecuteInBatchMode = shouldExecuteInBatchMode(runtimeExecutionMode);
         configureStreamGraph(streamGraph);
 

--- a/flink-streaming-java/src/main/java/org/apache/flink/streaming/api/graph/StreamGraphGenerator.java
+++ b/flink-streaming-java/src/main/java/org/apache/flink/streaming/api/graph/StreamGraphGenerator.java
@@ -43,6 +43,7 @@ import org.apache.flink.runtime.state.KeyGroupRangeAssignment;
 import org.apache.flink.runtime.state.StateBackend;
 import org.apache.flink.streaming.api.TimeCharacteristic;
 import org.apache.flink.streaming.api.environment.CheckpointConfig;
+import org.apache.flink.streaming.api.environment.ExecutionCheckpointingOptions;
 import org.apache.flink.streaming.api.operators.sorted.state.BatchExecutionCheckpointStorage;
 import org.apache.flink.streaming.api.operators.sorted.state.BatchExecutionInternalTimeServiceManager;
 import org.apache.flink.streaming.api.operators.sorted.state.BatchExecutionStateBackend;
@@ -315,7 +316,8 @@ public class StreamGraphGenerator {
     public StreamGraph generate() {
         streamGraph = new StreamGraph(executionConfig, checkpointConfig, savepointRestoreSettings);
         streamGraph.setEnableCheckpointsAfterTasksFinish(
-                configuration.get(ExecutionOptions.ENABLE_CHECKPOINTS_AFTER_TASKS_FINISH));
+                configuration.get(
+                        ExecutionCheckpointingOptions.ENABLE_CHECKPOINTS_AFTER_TASKS_FINISH));
         shouldExecuteInBatchMode = shouldExecuteInBatchMode(runtimeExecutionMode);
         configureStreamGraph(streamGraph);
 

--- a/flink-streaming-java/src/main/java/org/apache/flink/streaming/api/graph/StreamingJobGraphGenerator.java
+++ b/flink-streaming-java/src/main/java/org/apache/flink/streaming/api/graph/StreamingJobGraphGenerator.java
@@ -26,6 +26,7 @@ import org.apache.flink.api.common.operators.ResourceSpec;
 import org.apache.flink.api.common.typeutils.TypeSerializer;
 import org.apache.flink.api.java.tuple.Tuple2;
 import org.apache.flink.configuration.Configuration;
+import org.apache.flink.configuration.ExecutionOptions;
 import org.apache.flink.configuration.IllegalConfigurationException;
 import org.apache.flink.core.memory.ManagedMemoryUseCase;
 import org.apache.flink.runtime.OperatorIDPair;
@@ -726,6 +727,10 @@ public class StreamingJobGraphGenerator {
         config.setGraphContainingLoops(streamGraph.isIterative());
         config.setTimerServiceProvider(streamGraph.getTimerServiceProvider());
         config.setCheckpointingEnabled(checkpointCfg.isCheckpointingEnabled());
+        config.getConfiguration()
+                .set(
+                        ExecutionOptions.ENABLE_CHECKPOINTS_AFTER_TASKS_FINISH,
+                        streamGraph.isEnableCheckpointsAfterTasksFinish());
         config.setCheckpointMode(getCheckpointingMode(checkpointCfg));
         config.setUnalignedCheckpointsEnabled(checkpointCfg.isUnalignedCheckpointsEnabled());
         config.setAlignedCheckpointTimeout(checkpointCfg.getAlignedCheckpointTimeout());

--- a/flink-streaming-java/src/main/java/org/apache/flink/streaming/api/graph/StreamingJobGraphGenerator.java
+++ b/flink-streaming-java/src/main/java/org/apache/flink/streaming/api/graph/StreamingJobGraphGenerator.java
@@ -26,7 +26,6 @@ import org.apache.flink.api.common.operators.ResourceSpec;
 import org.apache.flink.api.common.typeutils.TypeSerializer;
 import org.apache.flink.api.java.tuple.Tuple2;
 import org.apache.flink.configuration.Configuration;
-import org.apache.flink.configuration.ExecutionOptions;
 import org.apache.flink.configuration.IllegalConfigurationException;
 import org.apache.flink.core.memory.ManagedMemoryUseCase;
 import org.apache.flink.runtime.OperatorIDPair;
@@ -57,6 +56,7 @@ import org.apache.flink.runtime.util.config.memory.ManagedMemoryUtils;
 import org.apache.flink.streaming.api.CheckpointingMode;
 import org.apache.flink.streaming.api.checkpoint.WithMasterCheckpointHook;
 import org.apache.flink.streaming.api.environment.CheckpointConfig;
+import org.apache.flink.streaming.api.environment.ExecutionCheckpointingOptions;
 import org.apache.flink.streaming.api.operators.ChainingStrategy;
 import org.apache.flink.streaming.api.operators.InputSelectable;
 import org.apache.flink.streaming.api.operators.SourceOperatorFactory;
@@ -729,7 +729,7 @@ public class StreamingJobGraphGenerator {
         config.setCheckpointingEnabled(checkpointCfg.isCheckpointingEnabled());
         config.getConfiguration()
                 .set(
-                        ExecutionOptions.ENABLE_CHECKPOINTS_AFTER_TASKS_FINISH,
+                        ExecutionCheckpointingOptions.ENABLE_CHECKPOINTS_AFTER_TASKS_FINISH,
                         streamGraph.isEnableCheckpointsAfterTasksFinish());
         config.setCheckpointMode(getCheckpointingMode(checkpointCfg));
         config.setUnalignedCheckpointsEnabled(checkpointCfg.isUnalignedCheckpointsEnabled());
@@ -1322,6 +1322,8 @@ public class StreamingJobGraphGenerator {
                                         cfg.getCheckpointIdOfIgnoredInFlightData())
                                 .setAlignedCheckpointTimeout(
                                         cfg.getAlignedCheckpointTimeout().toMillis())
+                                .setEnableCheckpointsAfterTasksFinish(
+                                        streamGraph.isEnableCheckpointsAfterTasksFinish())
                                 .build(),
                         serializedStateBackend,
                         streamGraph.isChangelogStateBackendEnabled(),

--- a/flink-streaming-java/src/main/java/org/apache/flink/streaming/runtime/io/checkpointing/CheckpointBarrierHandler.java
+++ b/flink-streaming-java/src/main/java/org/apache/flink/streaming/runtime/io/checkpointing/CheckpointBarrierHandler.java
@@ -72,19 +72,19 @@ public abstract class CheckpointBarrierHandler implements Closeable {
 
     private CompletableFuture<Long> latestBytesProcessedDuringAlignment = new CompletableFuture<>();
 
-    /**
-     * TODO Whether enables checkpoints after tasks finished. This is a temporary flag and will be
-     * removed in the last PR.
-     */
-    protected boolean enableCheckpointAfterTasksFinished;
+    private final boolean enableCheckpointAfterTasksFinished;
 
-    public CheckpointBarrierHandler(AbstractInvokable toNotifyOnCheckpoint, Clock clock) {
+    public CheckpointBarrierHandler(
+            AbstractInvokable toNotifyOnCheckpoint,
+            Clock clock,
+            boolean enableCheckpointAfterTasksFinished) {
         this.toNotifyOnCheckpoint = checkNotNull(toNotifyOnCheckpoint);
         this.clock = checkNotNull(clock);
+        this.enableCheckpointAfterTasksFinished = enableCheckpointAfterTasksFinished;
     }
 
-    public void setEnableCheckpointAfterTasksFinished(boolean enableCheckpointAfterTasksFinished) {
-        this.enableCheckpointAfterTasksFinished = enableCheckpointAfterTasksFinished;
+    boolean isCheckpointAfterTasksFinishedEnabled() {
+        return enableCheckpointAfterTasksFinished;
     }
 
     @Override

--- a/flink-streaming-java/src/main/java/org/apache/flink/streaming/runtime/io/checkpointing/CheckpointBarrierTracker.java
+++ b/flink-streaming-java/src/main/java/org/apache/flink/streaming/runtime/io/checkpointing/CheckpointBarrierTracker.java
@@ -81,8 +81,11 @@ public class CheckpointBarrierTracker extends CheckpointBarrierHandler {
     private long latestPendingCheckpointID = -1;
 
     public CheckpointBarrierTracker(
-            int totalNumberOfInputChannels, AbstractInvokable toNotifyOnCheckpoint, Clock clock) {
-        super(toNotifyOnCheckpoint, clock);
+            int totalNumberOfInputChannels,
+            AbstractInvokable toNotifyOnCheckpoint,
+            Clock clock,
+            boolean enableCheckpointAfterTasksFinished) {
+        super(toNotifyOnCheckpoint, clock, enableCheckpointAfterTasksFinished);
         this.numOpenChannels = totalNumberOfInputChannels;
         this.pendingCheckpoints = new ArrayDeque<>();
     }
@@ -233,7 +236,7 @@ public class CheckpointBarrierTracker extends CheckpointBarrierHandler {
     public void processEndOfPartition(InputChannelInfo channelInfo) throws IOException {
         numOpenChannels--;
 
-        if (!enableCheckpointAfterTasksFinished) {
+        if (!isCheckpointAfterTasksFinishedEnabled()) {
             while (!pendingCheckpoints.isEmpty()) {
                 CheckpointBarrierCount barrierCount = pendingCheckpoints.removeFirst();
                 if (barrierCount.markAborted()) {

--- a/flink-streaming-java/src/main/java/org/apache/flink/streaming/runtime/io/checkpointing/InputProcessorUtil.java
+++ b/flink-streaming-java/src/main/java/org/apache/flink/streaming/runtime/io/checkpointing/InputProcessorUtil.java
@@ -18,7 +18,6 @@
 package org.apache.flink.streaming.runtime.io.checkpointing;
 
 import org.apache.flink.annotation.Internal;
-import org.apache.flink.configuration.ExecutionOptions;
 import org.apache.flink.runtime.io.network.partition.consumer.CheckpointableInput;
 import org.apache.flink.runtime.io.network.partition.consumer.IndexedInputGate;
 import org.apache.flink.runtime.io.network.partition.consumer.InputGate;
@@ -26,6 +25,7 @@ import org.apache.flink.runtime.jobgraph.tasks.AbstractInvokable;
 import org.apache.flink.runtime.mailbox.MailboxExecutor;
 import org.apache.flink.runtime.metrics.MetricNames;
 import org.apache.flink.runtime.metrics.groups.TaskIOMetricGroup;
+import org.apache.flink.streaming.api.environment.ExecutionCheckpointingOptions;
 import org.apache.flink.streaming.api.graph.StreamConfig;
 import org.apache.flink.streaming.runtime.io.InputGateUtil;
 import org.apache.flink.streaming.runtime.io.StreamOneInputProcessor;
@@ -132,7 +132,9 @@ public class InputProcessorUtil {
                         toNotifyOnCheckpoint,
                         clock,
                         config.getConfiguration()
-                                .get(ExecutionOptions.ENABLE_CHECKPOINTS_AFTER_TASKS_FINISH));
+                                .get(
+                                        ExecutionCheckpointingOptions
+                                                .ENABLE_CHECKPOINTS_AFTER_TASKS_FINISH));
             default:
                 throw new UnsupportedOperationException(
                         "Unrecognized Checkpointing Mode: " + config.getCheckpointMode());
@@ -151,7 +153,7 @@ public class InputProcessorUtil {
             int numberOfChannels) {
         boolean enableCheckpointAfterTasksFinished =
                 config.getConfiguration()
-                        .get(ExecutionOptions.ENABLE_CHECKPOINTS_AFTER_TASKS_FINISH);
+                        .get(ExecutionCheckpointingOptions.ENABLE_CHECKPOINTS_AFTER_TASKS_FINISH);
         if (config.isUnalignedCheckpointsEnabled()) {
             return SingleCheckpointBarrierHandler.alternating(
                     taskName,

--- a/flink-streaming-java/src/main/java/org/apache/flink/streaming/runtime/tasks/StreamTask.java
+++ b/flink-streaming-java/src/main/java/org/apache/flink/streaming/runtime/tasks/StreamTask.java
@@ -19,6 +19,7 @@ package org.apache.flink.streaming.runtime.tasks;
 
 import org.apache.flink.annotation.Internal;
 import org.apache.flink.annotation.VisibleForTesting;
+import org.apache.flink.configuration.ExecutionOptions;
 import org.apache.flink.configuration.TaskManagerOptions;
 import org.apache.flink.core.fs.CloseableRegistry;
 import org.apache.flink.core.fs.Path;
@@ -715,7 +716,10 @@ public abstract class StreamTask<OUT, OP extends StreamOperator<OUT>> extends Ab
         // tasks. During this process, this task could coordinate with its downstream tasks to
         // continue perform checkpoints.
         CompletableFuture<Void> allRecordsProcessedFuture;
-        if (configuration.isCheckpointingEnabled()) {
+        if (configuration
+                        .getConfiguration()
+                        .get(ExecutionOptions.ENABLE_CHECKPOINTS_AFTER_TASKS_FINISH)
+                && configuration.isCheckpointingEnabled()) {
             LOG.debug("Waiting for all the records processed by the downstream tasks.");
 
             List<CompletableFuture<Void>> partitionRecordsProcessedFutures = new ArrayList<>();

--- a/flink-streaming-java/src/main/java/org/apache/flink/streaming/runtime/tasks/StreamTask.java
+++ b/flink-streaming-java/src/main/java/org/apache/flink/streaming/runtime/tasks/StreamTask.java
@@ -19,7 +19,6 @@ package org.apache.flink.streaming.runtime.tasks;
 
 import org.apache.flink.annotation.Internal;
 import org.apache.flink.annotation.VisibleForTesting;
-import org.apache.flink.configuration.ExecutionOptions;
 import org.apache.flink.configuration.TaskManagerOptions;
 import org.apache.flink.core.fs.CloseableRegistry;
 import org.apache.flink.core.fs.Path;
@@ -64,6 +63,7 @@ import org.apache.flink.runtime.state.StateBackendLoader;
 import org.apache.flink.runtime.state.ttl.TtlTimeProvider;
 import org.apache.flink.runtime.taskmanager.DispatcherThreadFactory;
 import org.apache.flink.streaming.api.TimeCharacteristic;
+import org.apache.flink.streaming.api.environment.ExecutionCheckpointingOptions;
 import org.apache.flink.streaming.api.graph.StreamConfig;
 import org.apache.flink.streaming.api.graph.StreamEdge;
 import org.apache.flink.streaming.api.operators.InternalTimeServiceManager;
@@ -718,7 +718,7 @@ public abstract class StreamTask<OUT, OP extends StreamOperator<OUT>> extends Ab
         CompletableFuture<Void> allRecordsProcessedFuture;
         if (configuration
                         .getConfiguration()
-                        .get(ExecutionOptions.ENABLE_CHECKPOINTS_AFTER_TASKS_FINISH)
+                        .get(ExecutionCheckpointingOptions.ENABLE_CHECKPOINTS_AFTER_TASKS_FINISH)
                 && configuration.isCheckpointingEnabled()) {
             LOG.debug("Waiting for all the records processed by the downstream tasks.");
 

--- a/flink-streaming-java/src/main/java/org/apache/flink/streaming/runtime/tasks/SubtaskCheckpointCoordinator.java
+++ b/flink-streaming-java/src/main/java/org/apache/flink/streaming/runtime/tasks/SubtaskCheckpointCoordinator.java
@@ -43,12 +43,6 @@ import java.util.function.Supplier;
 @Internal
 public interface SubtaskCheckpointCoordinator extends Closeable {
 
-    /**
-     * TODO Whether enables checkpoints after tasks finished. This is a temporary flag and will be
-     * removed in the last PR.
-     */
-    void setEnableCheckpointAfterTasksFinished(boolean enableCheckpointAfterTasksFinished);
-
     /** Initialize new checkpoint. */
     void initInputsCheckpoint(long id, CheckpointOptions checkpointOptions)
             throws CheckpointException;

--- a/flink-streaming-java/src/main/java/org/apache/flink/streaming/runtime/tasks/SubtaskCheckpointCoordinatorImpl.java
+++ b/flink-streaming-java/src/main/java/org/apache/flink/streaming/runtime/tasks/SubtaskCheckpointCoordinatorImpl.java
@@ -76,11 +76,7 @@ class SubtaskCheckpointCoordinatorImpl implements SubtaskCheckpointCoordinator {
 
     private static final int CHECKPOINT_EXECUTION_DELAY_LOG_THRESHOLD_MS = 30_000;
 
-    /**
-     * TODO Whether enables checkpoints after tasks finished. This is a temporary flag and will be
-     * removed in the last PR.
-     */
-    private boolean enableCheckpointAfterTasksFinished;
+    private final boolean enableCheckpointAfterTasksFinished;
 
     private final CachingCheckpointStorageWorkerView checkpointStorage;
     private final String taskName;
@@ -116,6 +112,7 @@ class SubtaskCheckpointCoordinatorImpl implements SubtaskCheckpointCoordinator {
             Environment env,
             AsyncExceptionHandler asyncExceptionHandler,
             boolean unalignedCheckpointEnabled,
+            boolean enableCheckpointAfterTasksFinished,
             BiFunctionWithException<
                             ChannelStateWriter, Long, CompletableFuture<Void>, CheckpointException>
                     prepareInputSnapshot)
@@ -129,6 +126,7 @@ class SubtaskCheckpointCoordinatorImpl implements SubtaskCheckpointCoordinator {
                 env,
                 asyncExceptionHandler,
                 unalignedCheckpointEnabled,
+                enableCheckpointAfterTasksFinished,
                 prepareInputSnapshot,
                 DEFAULT_MAX_RECORD_ABORTED_CHECKPOINTS);
     }
@@ -142,6 +140,7 @@ class SubtaskCheckpointCoordinatorImpl implements SubtaskCheckpointCoordinator {
             Environment env,
             AsyncExceptionHandler asyncExceptionHandler,
             boolean unalignedCheckpointEnabled,
+            boolean enableCheckpointAfterTasksFinished,
             BiFunctionWithException<
                             ChannelStateWriter, Long, CompletableFuture<Void>, CheckpointException>
                     prepareInputSnapshot,
@@ -159,7 +158,8 @@ class SubtaskCheckpointCoordinatorImpl implements SubtaskCheckpointCoordinator {
                 maxRecordAbortedCheckpoints,
                 unalignedCheckpointEnabled
                         ? openChannelStateWriter(taskName, checkpointStorage, env)
-                        : ChannelStateWriter.NO_OP);
+                        : ChannelStateWriter.NO_OP,
+                enableCheckpointAfterTasksFinished);
     }
 
     @VisibleForTesting
@@ -175,7 +175,8 @@ class SubtaskCheckpointCoordinatorImpl implements SubtaskCheckpointCoordinator {
                             ChannelStateWriter, Long, CompletableFuture<Void>, CheckpointException>
                     prepareInputSnapshot,
             int maxRecordAbortedCheckpoints,
-            ChannelStateWriter channelStateWriter)
+            ChannelStateWriter channelStateWriter,
+            boolean enableCheckpointAfterTasksFinished)
             throws IOException {
         this.checkpointStorage =
                 new CachingCheckpointStorageWorkerView(checkNotNull(checkpointStorage));
@@ -193,6 +194,7 @@ class SubtaskCheckpointCoordinatorImpl implements SubtaskCheckpointCoordinator {
         this.lastCheckpointId = -1L;
         closeableRegistry.registerCloseable(this);
         this.closed = false;
+        this.enableCheckpointAfterTasksFinished = enableCheckpointAfterTasksFinished;
     }
 
     private static ChannelStateWriter openChannelStateWriter(
@@ -202,11 +204,6 @@ class SubtaskCheckpointCoordinatorImpl implements SubtaskCheckpointCoordinator {
                         taskName, env.getTaskInfo().getIndexOfThisSubtask(), checkpointStorage);
         writer.open();
         return writer;
-    }
-
-    @Override
-    public void setEnableCheckpointAfterTasksFinished(boolean enableCheckpointAfterTasksFinished) {
-        this.enableCheckpointAfterTasksFinished = enableCheckpointAfterTasksFinished;
     }
 
     @Override

--- a/flink-streaming-java/src/test/java/org/apache/flink/streaming/runtime/io/StreamTaskNetworkInputTest.java
+++ b/flink-streaming-java/src/test/java/org/apache/flink/streaming/runtime/io/StreamTaskNetworkInputTest.java
@@ -156,6 +156,7 @@ public class StreamTaskNetworkInputTest {
                                                 "test",
                                                 new DummyCheckpointInvokable(),
                                                 SystemClock.getInstance(),
+                                                false,
                                                 inputGate.getInputGate()),
                                 new SyncMailboxExecutor()),
                         inSerializer,
@@ -258,7 +259,7 @@ public class StreamTaskNetworkInputTest {
         return new CheckpointedInputGate(
                 inputGate,
                 new CheckpointBarrierTracker(
-                        1, new DummyCheckpointInvokable(), SystemClock.getInstance()),
+                        1, new DummyCheckpointInvokable(), SystemClock.getInstance(), false),
                 new SyncMailboxExecutor(),
                 UpstreamRecoveryTracker.forInputGate(inputGate));
     }

--- a/flink-streaming-java/src/test/java/org/apache/flink/streaming/runtime/io/checkpointing/AlignedCheckpointsMassiveRandomTest.java
+++ b/flink-streaming-java/src/test/java/org/apache/flink/streaming/runtime/io/checkpointing/AlignedCheckpointsMassiveRandomTest.java
@@ -77,6 +77,7 @@ public class AlignedCheckpointsMassiveRandomTest {
                                     SystemClock.getInstance(),
                                     myIG.getNumberOfInputChannels(),
                                     (callable, duration) -> () -> {},
+                                    true,
                                     myIG),
                             new SyncMailboxExecutor());
 

--- a/flink-streaming-java/src/test/java/org/apache/flink/streaming/runtime/io/checkpointing/AlternatingCheckpointsTest.java
+++ b/flink-streaming-java/src/test/java/org/apache/flink/streaming/runtime/io/checkpointing/AlternatingCheckpointsTest.java
@@ -900,7 +900,6 @@ public class AlternatingCheckpointsTest {
                         .withRemoteChannels()
                         .withMailboxExecutor()
                         .build()) {
-            gate.getCheckpointBarrierHandler().setEnableCheckpointAfterTasksFinished(true);
 
             getChannel(gate, 0)
                     .onBuffer(

--- a/flink-streaming-java/src/test/java/org/apache/flink/streaming/runtime/io/checkpointing/CheckpointBarrierTrackerTest.java
+++ b/flink-streaming-java/src/test/java/org/apache/flink/streaming/runtime/io/checkpointing/CheckpointBarrierTrackerTest.java
@@ -600,7 +600,6 @@ public class CheckpointBarrierTrackerTest {
 
         CheckpointBarrierTracker checkpointBarrierTracker =
                 (CheckpointBarrierTracker) inputGate.getCheckpointBarrierHandler();
-        checkpointBarrierTracker.setEnableCheckpointAfterTasksFinished(true);
 
         for (BufferOrEvent boe : sequence) {
             assertEquals(boe, inputGate.pollNext().get());
@@ -624,10 +623,6 @@ public class CheckpointBarrierTrackerTest {
 
         ValidatingCheckpointHandler validator = new ValidatingCheckpointHandler(-1);
         inputGate = createCheckpointedInputGate(3, sequence, validator);
-
-        CheckpointBarrierTracker checkpointBarrierTracker =
-                (CheckpointBarrierTracker) inputGate.getCheckpointBarrierHandler();
-        checkpointBarrierTracker.setEnableCheckpointAfterTasksFinished(true);
 
         for (int i = 0; i <= 2; ++i) {
             assertEquals(sequence[i], inputGate.pollNext().get());
@@ -656,10 +651,6 @@ public class CheckpointBarrierTrackerTest {
         ValidatingCheckpointHandler validator = new ValidatingCheckpointHandler(-1);
         inputGate = createCheckpointedInputGate(3, sequence, validator);
 
-        CheckpointBarrierTracker checkpointBarrierTracker =
-                (CheckpointBarrierTracker) inputGate.getCheckpointBarrierHandler();
-        checkpointBarrierTracker.setEnableCheckpointAfterTasksFinished(true);
-
         for (BufferOrEvent boe : sequence) {
             assertEquals(boe, inputGate.pollNext().get());
         }
@@ -676,10 +667,6 @@ public class CheckpointBarrierTrackerTest {
 
         ValidatingCheckpointHandler validator = new ValidatingCheckpointHandler();
         inputGate = createCheckpointedInputGate(2, sequence, validator);
-
-        CheckpointBarrierTracker checkpointBarrierTracker =
-                (CheckpointBarrierTracker) inputGate.getCheckpointBarrierHandler();
-        checkpointBarrierTracker.setEnableCheckpointAfterTasksFinished(true);
 
         for (BufferOrEvent boe : sequence) {
             assertEquals(boe, inputGate.pollNext().get());
@@ -704,7 +691,6 @@ public class CheckpointBarrierTrackerTest {
 
         CheckpointBarrierTracker checkpointBarrierTracker =
                 (CheckpointBarrierTracker) inputGate.getCheckpointBarrierHandler();
-        checkpointBarrierTracker.setEnableCheckpointAfterTasksFinished(true);
 
         for (BufferOrEvent boe : sequence) {
             assertEquals(boe, inputGate.pollNext().get());
@@ -731,10 +717,6 @@ public class CheckpointBarrierTrackerTest {
         ValidatingCheckpointHandler validator = new ValidatingCheckpointHandler(-1);
         inputGate = createCheckpointedInputGate(3, sequence, validator);
 
-        CheckpointBarrierTracker checkpointBarrierTracker =
-                (CheckpointBarrierTracker) inputGate.getCheckpointBarrierHandler();
-        checkpointBarrierTracker.setEnableCheckpointAfterTasksFinished(true);
-
         for (BufferOrEvent boe : sequence) {
             assertEquals(boe, inputGate.pollNext().get());
         }
@@ -751,7 +733,6 @@ public class CheckpointBarrierTrackerTest {
 
         ValidatingCheckpointHandler checkpointHandler = new ValidatingCheckpointHandler();
         inputGate = createCheckpointedInputGate(2, sequence, checkpointHandler);
-        inputGate.getCheckpointBarrierHandler().setEnableCheckpointAfterTasksFinished(true);
 
         for (BufferOrEvent boe : sequence) {
             assertEquals(boe, inputGate.pollNext().get());
@@ -854,7 +835,7 @@ public class CheckpointBarrierTrackerTest {
         return new CheckpointedInputGate(
                 inputGate,
                 new CheckpointBarrierTracker(
-                        inputGate.getNumberOfInputChannels(), toNotifyOnCheckpoint, clock),
+                        inputGate.getNumberOfInputChannels(), toNotifyOnCheckpoint, clock, true),
                 new SyncMailboxExecutor());
     }
 

--- a/flink-streaming-java/src/test/java/org/apache/flink/streaming/runtime/io/checkpointing/CheckpointedInputGateTest.java
+++ b/flink-streaming-java/src/test/java/org/apache/flink/streaming/runtime/io/checkpointing/CheckpointedInputGateTest.java
@@ -342,7 +342,8 @@ public class CheckpointedInputGateTest {
                             @Override
                             public void invoke() {}
                         },
-                        SystemClock.getInstance());
+                        SystemClock.getInstance(),
+                        true);
 
         CheckpointedInputGate checkpointedInputGate =
                 new CheckpointedInputGate(

--- a/flink-streaming-java/src/test/java/org/apache/flink/streaming/runtime/io/checkpointing/TestBarrierHandlerFactory.java
+++ b/flink-streaming-java/src/test/java/org/apache/flink/streaming/runtime/io/checkpointing/TestBarrierHandlerFactory.java
@@ -37,6 +37,7 @@ public class TestBarrierHandlerFactory {
     private BiFunction<Callable<?>, Duration, Cancellable> actionRegistration =
             (callable, delay) -> () -> {};
     private Clock clock = SystemClock.getInstance();
+    private boolean enableCheckpointsAfterTasksFinish = true;
 
     private TestBarrierHandlerFactory(AbstractInvokable target) {
         this.target = target;
@@ -57,6 +58,11 @@ public class TestBarrierHandlerFactory {
         return this;
     }
 
+    public TestBarrierHandlerFactory disableCheckpointsAfterTasksFinish() {
+        this.enableCheckpointsAfterTasksFinish = false;
+        return this;
+    }
+
     public SingleCheckpointBarrierHandler create(SingleInputGate inputGate) {
         return create(inputGate, new RecordingChannelStateWriter());
     }
@@ -71,6 +77,7 @@ public class TestBarrierHandlerFactory {
                 clock,
                 inputGate.getNumberOfInputChannels(),
                 actionRegistration,
+                enableCheckpointsAfterTasksFinish,
                 inputGate);
     }
 }

--- a/flink-streaming-java/src/test/java/org/apache/flink/streaming/runtime/io/checkpointing/UnalignedCheckpointsCancellationTest.java
+++ b/flink-streaming-java/src/test/java/org/apache/flink/streaming/runtime/io/checkpointing/UnalignedCheckpointsCancellationTest.java
@@ -99,6 +99,7 @@ public class UnalignedCheckpointsCancellationTest {
                         "test",
                         invokable,
                         SystemClock.getInstance(),
+                        true,
                         inputGate);
 
         for (RuntimeEvent e : events) {

--- a/flink-streaming-java/src/test/java/org/apache/flink/streaming/runtime/tasks/MockSubtaskCheckpointCoordinatorBuilder.java
+++ b/flink-streaming-java/src/test/java/org/apache/flink/streaming/runtime/tasks/MockSubtaskCheckpointCoordinatorBuilder.java
@@ -49,6 +49,7 @@ public class MockSubtaskCheckpointCoordinatorBuilder {
             prepareInputSnapshot = (channelStateWriter, aLong) -> FutureUtils.completedVoidFuture();
     private boolean unalignedCheckpointEnabled;
     private int maxRecordAbortedCheckpoints = 10;
+    private boolean enableCheckpointAfterTasksFinished = true;
 
     public MockSubtaskCheckpointCoordinatorBuilder setEnvironment(Environment environment) {
         this.environment = environment;
@@ -80,6 +81,12 @@ public class MockSubtaskCheckpointCoordinatorBuilder {
         return this;
     }
 
+    public MockSubtaskCheckpointCoordinatorBuilder setEnableCheckpointAfterTasksFinished(
+            boolean enableCheckpointAfterTasksFinished) {
+        this.enableCheckpointAfterTasksFinished = enableCheckpointAfterTasksFinished;
+        return this;
+    }
+
     SubtaskCheckpointCoordinator build() throws IOException {
         if (environment == null) {
             this.environment = MockEnvironment.builder().build();
@@ -102,6 +109,7 @@ public class MockSubtaskCheckpointCoordinatorBuilder {
                 environment,
                 asyncExceptionHandler,
                 unalignedCheckpointEnabled,
+                enableCheckpointAfterTasksFinished,
                 prepareInputSnapshot,
                 maxRecordAbortedCheckpoints);
     }

--- a/flink-streaming-java/src/test/java/org/apache/flink/streaming/runtime/tasks/MultipleInputStreamTaskChainedSourcesCheckpointingTest.java
+++ b/flink-streaming-java/src/test/java/org/apache/flink/streaming/runtime/tasks/MultipleInputStreamTaskChainedSourcesCheckpointingTest.java
@@ -24,7 +24,6 @@ import org.apache.flink.api.common.typeinfo.BasicTypeInfo;
 import org.apache.flink.api.common.typeutils.base.StringSerializer;
 import org.apache.flink.api.connector.source.Boundedness;
 import org.apache.flink.api.connector.source.mocks.MockSource;
-import org.apache.flink.configuration.ExecutionOptions;
 import org.apache.flink.runtime.checkpoint.CheckpointMetaData;
 import org.apache.flink.runtime.checkpoint.CheckpointOptions;
 import org.apache.flink.runtime.checkpoint.CheckpointType;
@@ -38,6 +37,7 @@ import org.apache.flink.runtime.io.network.partition.ResultPartitionType;
 import org.apache.flink.runtime.jobgraph.OperatorID;
 import org.apache.flink.runtime.state.CheckpointStorageLocationReference;
 import org.apache.flink.runtime.state.StateInitializationContext;
+import org.apache.flink.streaming.api.environment.ExecutionCheckpointingOptions;
 import org.apache.flink.streaming.api.graph.StreamConfig;
 import org.apache.flink.streaming.api.operators.AbstractStreamOperatorFactory;
 import org.apache.flink.streaming.api.operators.SourceOperator;
@@ -285,7 +285,7 @@ public class MultipleInputStreamTaskChainedSourcesCheckpointingTest {
                                         config.setCheckpointingEnabled(true);
                                         config.getConfiguration()
                                                 .set(
-                                                        ExecutionOptions
+                                                        ExecutionCheckpointingOptions
                                                                 .ENABLE_CHECKPOINTS_AFTER_TASKS_FINISH,
                                                         true);
                                     })

--- a/flink-streaming-java/src/test/java/org/apache/flink/streaming/runtime/tasks/MultipleInputStreamTaskChainedSourcesCheckpointingTest.java
+++ b/flink-streaming-java/src/test/java/org/apache/flink/streaming/runtime/tasks/MultipleInputStreamTaskChainedSourcesCheckpointingTest.java
@@ -311,10 +311,6 @@ public class MultipleInputStreamTaskChainedSourcesCheckpointingTest {
                             .finishForSingletonOperatorChain(StringSerializer.INSTANCE)
                             .build()) {
 
-                testHarness
-                        .getStreamTask()
-                        .getCheckpointCoordinator()
-                        .setEnableCheckpointAfterTasksFinished(true);
                 testHarness.getStreamTask().getCheckpointBarrierHandler().get();
 
                 Future<Boolean> checkpointFuture = triggerCheckpoint(testHarness, 2);

--- a/flink-streaming-java/src/test/java/org/apache/flink/streaming/runtime/tasks/MultipleInputStreamTaskTest.java
+++ b/flink-streaming-java/src/test/java/org/apache/flink/streaming/runtime/tasks/MultipleInputStreamTaskTest.java
@@ -35,7 +35,6 @@ import org.apache.flink.api.connector.source.mocks.MockSource;
 import org.apache.flink.api.connector.source.mocks.MockSourceReader;
 import org.apache.flink.api.connector.source.mocks.MockSourceSplit;
 import org.apache.flink.api.connector.source.mocks.MockSourceSplitSerializer;
-import org.apache.flink.configuration.ExecutionOptions;
 import org.apache.flink.core.memory.DataInputView;
 import org.apache.flink.core.memory.DataOutputView;
 import org.apache.flink.metrics.Counter;
@@ -60,6 +59,7 @@ import org.apache.flink.runtime.metrics.util.InterceptingOperatorMetricGroup;
 import org.apache.flink.runtime.metrics.util.InterceptingTaskMetricGroup;
 import org.apache.flink.runtime.source.event.AddSplitEvent;
 import org.apache.flink.runtime.source.event.NoMoreSplitsEvent;
+import org.apache.flink.streaming.api.environment.ExecutionCheckpointingOptions;
 import org.apache.flink.streaming.api.graph.StreamConfig;
 import org.apache.flink.streaming.api.operators.AbstractInput;
 import org.apache.flink.streaming.api.operators.AbstractStreamOperator;
@@ -932,7 +932,7 @@ public class MultipleInputStreamTaskTest {
                                         config.setCheckpointingEnabled(true);
                                         config.getConfiguration()
                                                 .set(
-                                                        ExecutionOptions
+                                                        ExecutionCheckpointingOptions
                                                                 .ENABLE_CHECKPOINTS_AFTER_TASKS_FINISH,
                                                         true);
                                     })

--- a/flink-streaming-java/src/test/java/org/apache/flink/streaming/runtime/tasks/MultipleInputStreamTaskTest.java
+++ b/flink-streaming-java/src/test/java/org/apache/flink/streaming/runtime/tasks/MultipleInputStreamTaskTest.java
@@ -940,10 +940,6 @@ public class MultipleInputStreamTaskTest {
                             .finishForSingletonOperatorChain(StringSerializer.INSTANCE)
                             .build()) {
 
-                testHarness
-                        .getStreamTask()
-                        .getCheckpointCoordinator()
-                        .setEnableCheckpointAfterTasksFinished(true);
                 testHarness.getStreamTask().getCheckpointBarrierHandler().get();
 
                 // Tests triggering checkpoint when all the inputs are alive.

--- a/flink-streaming-java/src/test/java/org/apache/flink/streaming/runtime/tasks/StreamTaskFinalCheckpointsTest.java
+++ b/flink-streaming-java/src/test/java/org/apache/flink/streaming/runtime/tasks/StreamTaskFinalCheckpointsTest.java
@@ -151,10 +151,6 @@ public class StreamTaskFinalCheckpointsTest {
                             .setupOperatorChain(new EmptyOperator())
                             .finishForSingletonOperatorChain(StringSerializer.INSTANCE)
                             .build()) {
-                testHarness
-                        .getStreamTask()
-                        .getCheckpointCoordinator()
-                        .setEnableCheckpointAfterTasksFinished(true);
                 testHarness.getStreamTask().getCheckpointBarrierHandler().get();
 
                 // Tests triggering checkpoint when all the inputs are alive.
@@ -265,18 +261,19 @@ public class StreamTaskFinalCheckpointsTest {
                                                         BasicTypeInfo.STRING_TYPE_INFO)
                                                 .addInput(BasicTypeInfo.STRING_TYPE_INFO, 3)
                                                 .modifyStreamConfig(
-                                                        config ->
-                                                                config.setCheckpointingEnabled(
-                                                                        true))
+                                                        config -> {
+                                                            config.setCheckpointingEnabled(true);
+                                                            config.getConfiguration()
+                                                                    .set(
+                                                                            ExecutionCheckpointingOptions
+                                                                                    .ENABLE_CHECKPOINTS_AFTER_TASKS_FINISH,
+                                                                            true);
+                                                        })
                                                 .setCheckpointResponder(responder)
                                                 .setupOperatorChain(new EmptyOperator())
                                                 .finishForSingletonOperatorChain(
                                                         StringSerializer.INSTANCE)
                                                 .build()) {
-
-                                    harness.streamTask
-                                            .getCheckpointCoordinator()
-                                            .setEnableCheckpointAfterTasksFinished(true);
 
                                     harness.streamTask.triggerCheckpointOnBarrier(
                                             new CheckpointMetaData(1, 101),

--- a/flink-streaming-java/src/test/java/org/apache/flink/streaming/runtime/tasks/StreamTaskFinalCheckpointsTest.java
+++ b/flink-streaming-java/src/test/java/org/apache/flink/streaming/runtime/tasks/StreamTaskFinalCheckpointsTest.java
@@ -21,7 +21,6 @@ package org.apache.flink.streaming.runtime.tasks;
 import org.apache.flink.api.common.JobID;
 import org.apache.flink.api.common.typeinfo.BasicTypeInfo;
 import org.apache.flink.api.common.typeutils.base.StringSerializer;
-import org.apache.flink.configuration.ExecutionOptions;
 import org.apache.flink.core.testutils.OneShotLatch;
 import org.apache.flink.runtime.checkpoint.CheckpointMetaData;
 import org.apache.flink.runtime.checkpoint.CheckpointMetrics;
@@ -40,6 +39,7 @@ import org.apache.flink.runtime.state.CheckpointStorageLocationReference;
 import org.apache.flink.runtime.state.StateInitializationContext;
 import org.apache.flink.runtime.state.StateSnapshotContext;
 import org.apache.flink.runtime.taskmanager.TestCheckpointResponder;
+import org.apache.flink.streaming.api.environment.ExecutionCheckpointingOptions;
 import org.apache.flink.streaming.api.operators.AbstractStreamOperator;
 import org.apache.flink.streaming.api.operators.OneInputStreamOperator;
 import org.apache.flink.streaming.runtime.streamrecord.StreamRecord;
@@ -144,7 +144,7 @@ public class StreamTaskFinalCheckpointsTest {
                                         config.setCheckpointingEnabled(true);
                                         config.getConfiguration()
                                                 .set(
-                                                        ExecutionOptions
+                                                        ExecutionCheckpointingOptions
                                                                 .ENABLE_CHECKPOINTS_AFTER_TASKS_FINISH,
                                                         true);
                                     })

--- a/flink-streaming-java/src/test/java/org/apache/flink/streaming/runtime/tasks/SubtaskCheckpointCoordinatorTest.java
+++ b/flink-streaming-java/src/test/java/org/apache/flink/streaming/runtime/tasks/SubtaskCheckpointCoordinatorTest.java
@@ -631,6 +631,7 @@ public class SubtaskCheckpointCoordinatorTest {
                 (message, unused) -> fail(message),
                 (unused1, unused2) -> CompletableFuture.completedFuture(null),
                 0,
-                channelStateWriter);
+                channelStateWriter,
+                true);
     }
 }

--- a/flink-streaming-java/src/test/java/org/apache/flink/streaming/runtime/tasks/TestSubtaskCheckpointCoordinator.java
+++ b/flink-streaming-java/src/test/java/org/apache/flink/streaming/runtime/tasks/TestSubtaskCheckpointCoordinator.java
@@ -53,9 +53,6 @@ public class TestSubtaskCheckpointCoordinator implements SubtaskCheckpointCoordi
     }
 
     @Override
-    public void setEnableCheckpointAfterTasksFinished(boolean enableCheckpointAfterTasksFinished) {}
-
-    @Override
     public void initInputsCheckpoint(long id, CheckpointOptions checkpointOptions) {
         channelStateWriter.start(id, checkpointOptions);
     }


### PR DESCRIPTION
## What is the purpose of the change

We should have a feature toggle for enabling/disabling checkpoints after tasks finished. The final checkpoint will be a new feature so users should have an option to fallback to the old behaviour if necessary.


## Verifying this change

All existing tests should pass when configured via the feature flag

## Does this pull request potentially affect one of the following parts:

  - Dependencies (does it add or upgrade a dependency): (yes / **no**)
  - The public API, i.e., is any changed class annotated with `@Public(Evolving)`: (**yes** / no)
  - The serializers: (yes / **no** / don't know)
  - The runtime per-record code paths (performance sensitive): (yes / **no** / don't know)
  - Anything that affects deployment or recovery: JobManager (and its components), Checkpointing, Kubernetes/Yarn, ZooKeeper: (**yes** / no / don't know)
  - The S3 file system connector: (yes / **no** / don't know)

## Documentation

  - Does this pull request introduce a new feature? (yes / **no**)
  - If yes, how is the feature documented? (not applicable / docs / **JavaDocs** / not documented)
