### PR TITLE
[FLINK-22893][zookeeper] Replace NodeCache with TreeCache

### DIFF
--- a/flink-runtime/src/main/java/org/apache/flink/runtime/leaderelection/ZooKeeperLeaderElectionDriver.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/leaderelection/ZooKeeperLeaderElectionDriver.java
@@ -26,8 +26,7 @@ import org.apache.flink.util.ExceptionUtils;
 import org.apache.flink.shaded.curator4.org.apache.curator.framework.CuratorFramework;
 import org.apache.flink.shaded.curator4.org.apache.curator.framework.api.UnhandledErrorListener;
 import org.apache.flink.shaded.curator4.org.apache.curator.framework.recipes.cache.ChildData;
-import org.apache.flink.shaded.curator4.org.apache.curator.framework.recipes.cache.NodeCache;
-import org.apache.flink.shaded.curator4.org.apache.curator.framework.recipes.cache.NodeCacheListener;
+import org.apache.flink.shaded.curator4.org.apache.curator.framework.recipes.cache.TreeCache;
 import org.apache.flink.shaded.curator4.org.apache.curator.framework.recipes.leader.LeaderLatch;
 import org.apache.flink.shaded.curator4.org.apache.curator.framework.recipes.leader.LeaderLatchListener;
 import org.apache.flink.shaded.curator4.org.apache.curator.framework.state.ConnectionState;
@@ -53,10 +52,7 @@ import static org.apache.flink.util.Preconditions.checkNotNull;
  * ZooKeeper.
  */
 public class ZooKeeperLeaderElectionDriver
-        implements LeaderElectionDriver,
-                LeaderLatchListener,
-                NodeCacheListener,
-                UnhandledErrorListener {
+        implements LeaderElectionDriver, LeaderLatchListener, UnhandledErrorListener {
 
     private static final Logger LOG = LoggerFactory.getLogger(ZooKeeperLeaderElectionDriver.class);
 
@@ -67,7 +63,7 @@ public class ZooKeeperLeaderElectionDriver
     private final LeaderLatch leaderLatch;
 
     /** Curator recipe to watch a given ZooKeeper node for changes. */
-    private final NodeCache cache;
+    private final TreeCache cache;
 
     /** ZooKeeper path of the node which stores the current leader information. */
     private final String connectionInformationPath;
@@ -107,7 +103,11 @@ public class ZooKeeperLeaderElectionDriver
         this.leaderContenderDescription = checkNotNull(leaderContenderDescription);
 
         leaderLatch = new LeaderLatch(client, ZooKeeperUtils.generateLeaderLatchPath(path));
-        cache = new NodeCache(client, connectionInformationPath);
+        this.cache =
+                ZooKeeperUtils.createTreeCache(
+                        client,
+                        connectionInformationPath,
+                        this::retrieveLeaderInformationFromZooKeeper);
 
         client.getUnhandledErrorListenable().addListener(this);
 
@@ -116,7 +116,6 @@ public class ZooKeeperLeaderElectionDriver
         leaderLatch.addListener(this);
         leaderLatch.start();
 
-        cache.getListenable().addListener(this);
         cache.start();
 
         client.getConnectionStateListenable().addListener(listener);
@@ -171,10 +170,9 @@ public class ZooKeeperLeaderElectionDriver
         leaderElectionEventHandler.onRevokeLeadership();
     }
 
-    @Override
-    public void nodeChanged() throws Exception {
+    private void retrieveLeaderInformationFromZooKeeper() throws Exception {
         if (leaderLatch.hasLeadership()) {
-            ChildData childData = cache.getCurrentData();
+            ChildData childData = cache.getCurrentData(connectionInformationPath);
             if (childData != null) {
                 final byte[] data = childData.getData();
                 if (data != null && data.length > 0) {

--- a/flink-runtime/src/test/java/org/apache/flink/runtime/util/ZooKeeperUtilsTreeCacheTest.java
+++ b/flink-runtime/src/test/java/org/apache/flink/runtime/util/ZooKeeperUtilsTreeCacheTest.java
@@ -1,0 +1,158 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.flink.runtime.util;
+
+import org.apache.flink.configuration.Configuration;
+import org.apache.flink.configuration.HighAvailabilityOptions;
+import org.apache.flink.core.testutils.FlinkMatchers;
+import org.apache.flink.util.TestLogger;
+
+import org.apache.flink.shaded.curator4.org.apache.curator.framework.CuratorFramework;
+import org.apache.flink.shaded.curator4.org.apache.curator.framework.recipes.cache.TreeCache;
+import org.apache.flink.shaded.curator4.org.apache.curator.framework.recipes.cache.TreeCacheEvent;
+import org.apache.flink.shaded.curator4.org.apache.curator.framework.recipes.cache.TreeCacheListener;
+import org.apache.flink.shaded.guava18.com.google.common.io.Closer;
+
+import org.apache.curator.test.TestingServer;
+import org.junit.After;
+import org.junit.Before;
+import org.junit.Test;
+
+import java.time.Duration;
+import java.util.concurrent.CompletableFuture;
+import java.util.concurrent.atomic.AtomicReference;
+
+import static org.hamcrest.MatcherAssert.assertThat;
+
+/**
+ * Tests for {@link ZooKeeperUtils#createTreeCache(CuratorFramework, String,
+ * org.apache.flink.util.function.RunnableWithException)}.
+ */
+public class ZooKeeperUtilsTreeCacheTest extends TestLogger {
+
+    private static final String PARENT_PATH = "/foo";
+    private static final String CHILD_PATH = PARENT_PATH + "/bar";
+
+    private Closer closer;
+    private CuratorFramework client;
+
+    private final AtomicReference<CompletableFuture<Void>> callbackFutureReference =
+            new AtomicReference<>();
+
+    @Before
+    public void setUp() throws Exception {
+        closer = Closer.create();
+        final TestingServer testingServer = closer.register(new TestingServer());
+
+        Configuration configuration = new Configuration();
+        configuration.set(
+                HighAvailabilityOptions.HA_ZOOKEEPER_QUORUM, testingServer.getConnectString());
+
+        client = closer.register(ZooKeeperUtils.startCuratorFramework(configuration));
+        client = closer.register(ZooKeeperUtils.startCuratorFramework(configuration));
+        final TreeCache cache =
+                closer.register(
+                        ZooKeeperUtils.createTreeCache(
+                                client,
+                                CHILD_PATH,
+                                () -> callbackFutureReference.get().complete(null)));
+        cache.start();
+    }
+
+    @After
+    public void tearDown() throws Exception {
+        closer.close();
+        callbackFutureReference.set(null);
+    }
+
+    @Test
+    public void testCallbackCalledOnNodeCreation() throws Exception {
+        client.create().forPath(PARENT_PATH);
+        callbackFutureReference.set(new CompletableFuture<>());
+        client.create().forPath(CHILD_PATH);
+        callbackFutureReference.get().get();
+    }
+
+    @Test
+    public void testCallbackCalledOnNodeModification() throws Exception {
+        testCallbackCalledOnNodeCreation();
+
+        callbackFutureReference.set(new CompletableFuture<>());
+        client.setData().forPath(CHILD_PATH, new byte[1]);
+        callbackFutureReference.get().get();
+    }
+
+    @Test
+    public void testCallbackCalledOnNodeDeletion() throws Exception {
+        testCallbackCalledOnNodeCreation();
+
+        callbackFutureReference.set(new CompletableFuture<>());
+        client.delete().forPath(CHILD_PATH);
+        callbackFutureReference.get().get();
+    }
+
+    @Test
+    public void testCallbackNotCalledOnCreationOfParents() throws Exception {
+        callbackFutureReference.set(new CompletableFuture<>());
+        client.create().forPath(PARENT_PATH);
+        assertThat(
+                callbackFutureReference.get(),
+                FlinkMatchers.willNotComplete(Duration.ofMillis(20)));
+    }
+
+    @Test
+    public void testCallbackNotCalledOnCreationOfChildren() throws Exception {
+        testCallbackCalledOnNodeCreation();
+
+        callbackFutureReference.set(new CompletableFuture<>());
+        client.create().forPath(CHILD_PATH + "/baz");
+        assertThat(
+                callbackFutureReference.get(),
+                FlinkMatchers.willNotComplete(Duration.ofMillis(20)));
+    }
+
+    @Test
+    public void testCallbackNotCalledOnCreationOfSimilarPaths() throws Exception {
+        callbackFutureReference.set(new CompletableFuture<>());
+        client.create()
+                .creatingParentContainersIfNeeded()
+                .forPath(CHILD_PATH.substring(0, CHILD_PATH.length() - 1));
+        assertThat(
+                callbackFutureReference.get(),
+                FlinkMatchers.willNotComplete(Duration.ofMillis(20)));
+    }
+
+    @Test
+    public void testCallbackNotCalledOnConnectionOrInitializationEvents() throws Exception {
+        final TreeCacheListener treeCacheListener =
+                ZooKeeperUtils.createTreeCacheListener(
+                        () -> {
+                            throw new AssertionError("Should not be called.");
+                        });
+
+        treeCacheListener.childEvent(
+                client, new TreeCacheEvent(TreeCacheEvent.Type.INITIALIZED, null));
+        treeCacheListener.childEvent(
+                client, new TreeCacheEvent(TreeCacheEvent.Type.CONNECTION_RECONNECTED, null));
+        treeCacheListener.childEvent(
+                client, new TreeCacheEvent(TreeCacheEvent.Type.CONNECTION_LOST, null));
+        treeCacheListener.childEvent(
+                client, new TreeCacheEvent(TreeCacheEvent.Type.CONNECTION_SUSPENDED, null));
+    }
+}


### PR DESCRIPTION
Replaces usages of the `NodeCache` with a `TreeCache`.

The core issue is that the `NodeCache` tries to ensure that the parents to the observed node exist. This can result in curator exceptions that crash the TM if concurrently the path is being deleted. Originally I tried to create a modified `NodeCache` implementation, but got a bad feeling when it came to maintaining said class.

I then looked at other curator caching recipes; the `PathChildrenCache` initially looked neat because it's very purpose is handling entire paths and not single nodes, but it has the same behavior as the `NodeCache` w.r.t. creating parents. 

Then I stumbled on the `TreeCache`, which after some experimenting turned out to be an incredibly flexible class. It _can_ create parent nodes, but its opt-in. It _can_ observe a node tree, but can also be configured to only consider a single node.
Even the listener interface is superior, providing more information as to the node change (added/modified/removed) _and_ connection issues (which this PR makes no use of, but still, _pretty neat_).