### PR TITLE
[FLINK-18562] Support for Hadoop ABFS  for Azure Datalake Gen2 accounts

### DIFF
--- a/docs/content/docs/deployment/filesystems/azure.md
+++ b/docs/content/docs/deployment/filesystems/azure.md
@@ -30,13 +30,31 @@ under the License.
 [Azure Blob Storage](https://docs.microsoft.com/en-us/azure/storage/) is a Microsoft-managed service providing cloud storage for a variety of use cases.
 You can use Azure Blob Storage with Flink for **reading** and **writing data** as well in conjunction with the [streaming **state backends**]({{< ref "docs/ops/state/state_backends" >}})  
 
+Flink supports accessing Azure Blob Storage using both [wasb://](https://hadoop.apache.org/docs/stable/hadoop-azure/index.html) or [abfs://](https://hadoop.apache.org/docs/stable/hadoop-azure/abfs.html).
+
+{{< hint info >}} 
+Azure recommends using abfs:// for accessing ADLS Gen2 storage accounts even though wasb:// works through backward compatibility.  
+{{< /hint >}}
+
+{{< hint warning >}}
+abfs:// can be used for accessing the ADLS Gen2 storage accounts only. Please visit Azure documentation on how to identify ADLS Gen2 storage account.  
+{{< /hint >}}
+
+
 You can use Azure Blob Storage objects like regular files by specifying paths in the following format:
 
 ```plain
+// WASB unencrypted access
 wasb://<your-container>@$<your-azure-account>.blob.core.windows.net/<object-path>
 
-// SSL encrypted access
+// WASB SSL encrypted access
 wasbs://<your-container>@$<your-azure-account>.blob.core.windows.net/<object-path>
+
+// ABFS unecrypted access
+abfs://<your-container>@$<your-azure-account>.dfs.core.windows.net/<object-path>
+
+// ABFS SSL encrypted access
+abfss://<your-container>@$<your-azure-account>.dfs.core.windows.net/<object-path>
 ```
 
 See below for how to use Azure Blob Storage in a Flink job:
@@ -63,9 +81,11 @@ cp ./opt/flink-azure-fs-hadoop-{{< version >}}.jar ./plugins/azure-fs-hadoop/
 
 `flink-azure-fs-hadoop` registers default FileSystem wrappers for URIs with the *wasb://* and *wasbs://* (SSL encrypted access) scheme.
 
-### Credentials Configuration
+## Credentials Configuration
 
-Hadoop's Azure Filesystem supports configuration of credentials via the Hadoop configuration as 
+### WASB
+
+Hadoop's WASB Azure Filesystem supports configuration of credentials via the Hadoop configuration as 
 outlined in the [Hadoop Azure Blob Storage documentation](https://hadoop.apache.org/docs/current/hadoop-azure/index.html#Configuring_Credentials).
 For convenience Flink forwards all Flink configurations with a key prefix of `fs.azure` to the 
 Hadoop configuration of the filesystem. Consequentially, the azure blob storage key can be configured 
@@ -81,6 +101,23 @@ environment variable `AZURE_STORAGE_KEY` by setting the following configuration 
 
 ```yaml
 fs.azure.account.keyprovider.<account_name>.blob.core.windows.net: org.apache.flink.fs.azurefs.EnvironmentVariableKeyProvider
+```
+
+### ABFS
+
+Hadoop's ABFS Azure Filesystem supports several ways of configuring authentication. Please visit the [Hadoop ABFS documentation](https://hadoop.apache.org/docs/stable/hadoop-azure/abfs.html#Authentication) documentation on how to configure.
+
+{{< hint info >}}
+Azure recommends using Azure managed identity to access the ADLS Gen2 storage accounts using abfs. Please refer to [Azure managed identities documentation](https://docs.microsoft.com/en-us/azure/active-directory/managed-identities-azure-resources/) for more details.
+
+Please visit the [page](https://docs.microsoft.com/en-us/azure/active-directory/managed-identities-azure-resources/services-support-managed-identities#azure-services-that-support-managed-identities-for-azure-resources) for the list of services that support Managed Identities. Flink clusters deployed in those Azure services can take advantage of Managed Identities.
+{{< /hint >}}
+
+##### Accessing ABFS using storage Keys (Discouraged)
+Azure blob storage key can be configured in `flink-conf.yaml` via:
+
+```yaml
+fs.azure.account.key.<account_name>.dfs.core.windows.net: <azure_storage_key>
 ```
 
 {{< top >}}

--- a/docs/content/docs/deployment/filesystems/overview.md
+++ b/docs/content/docs/deployment/filesystems/overview.md
@@ -56,9 +56,12 @@ The Apache Flink project supports the following file systems:
   - **[Aliyun Object Storage Service]({{< ref "docs/deployment/filesystems/oss" >}})** is supported by `flink-oss-fs-hadoop` and registered under the *oss://* URI scheme.
   The implementation is based on the [Hadoop Project](https://hadoop.apache.org/) but is self-contained with no dependency footprint.
 
+  - **[Azure Data Lake Store Gen2]({{< ref "docs/deployment/filesystems/azure" >}})** is supported by `flink-azure-fs-hadoop` and registered under the *abfs(s)://* URI schemes.
+    The implementation is based on the [Hadoop Project](https://hadoop.apache.org/) but is self-contained with no dependency footprint.
+
   - **[Azure Blob Storage]({{< ref "docs/deployment/filesystems/azure" >}})** is supported by `flink-azure-fs-hadoop` and registered under the *wasb(s)://* URI schemes.
   The implementation is based on the [Hadoop Project](https://hadoop.apache.org/) but is self-contained with no dependency footprint.
-    
+
   - **[Google Cloud Storage]({{< ref "docs/deployment/filesystems/gcs" >}})** is supported by `gcs-connector` and registered under the *gs://* URI scheme.
   The implementation is based on the [Hadoop Project](https://hadoop.apache.org/) but is self-contained with no dependency footprint.
 

--- a/flink-core/src/main/java/org/apache/flink/core/fs/FileSystem.java
+++ b/flink-core/src/main/java/org/apache/flink/core/fs/FileSystem.java
@@ -248,6 +248,8 @@ public abstract class FileSystem {
             ImmutableMultimap.<String, String>builder()
                     .put("wasb", "flink-fs-azure-hadoop")
                     .put("wasbs", "flink-fs-azure-hadoop")
+                    .put("abfs", "flink-fs-azure-hadoop")
+                    .put("abfss", "flink-fs-azure-hadoop")
                     .put("oss", "flink-oss-fs-hadoop")
                     .put("s3", "flink-s3-fs-hadoop")
                     .put("s3", "flink-s3-fs-presto")

--- a/flink-filesystems/flink-azure-fs-hadoop/src/main/java/org/apache/flink/fs/azurefs/AzureBlobStorageFSFactory.java
+++ b/flink-filesystems/flink-azure-fs-hadoop/src/main/java/org/apache/flink/fs/azurefs/AzureBlobStorageFSFactory.java
@@ -1,0 +1,36 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.flink.fs.azurefs;
+
+import org.apache.hadoop.fs.FileSystem;
+import org.apache.hadoop.fs.azure.NativeAzureFileSystem;
+
+/** A factory for the Azure file system over HTTP. */
+public class AzureBlobStorageFSFactory extends AbstractAzureFSFactory {
+
+    @Override
+    public String getScheme() {
+        return "wasb";
+    }
+
+    @Override
+    FileSystem createAzureFS() {
+        return new NativeAzureFileSystem();
+    }
+}

--- a/flink-filesystems/flink-azure-fs-hadoop/src/main/java/org/apache/flink/fs/azurefs/AzureDataLakeStoreGen2FSFactory.java
+++ b/flink-filesystems/flink-azure-fs-hadoop/src/main/java/org/apache/flink/fs/azurefs/AzureDataLakeStoreGen2FSFactory.java
@@ -1,0 +1,36 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.flink.fs.azurefs;
+
+import org.apache.hadoop.fs.FileSystem;
+import org.apache.hadoop.fs.azurebfs.AzureBlobFileSystem;
+
+/** Abfs azureFs implementation. */
+public class AzureDataLakeStoreGen2FSFactory extends AbstractAzureFSFactory {
+
+    @Override
+    public String getScheme() {
+        return "abfs";
+    }
+
+    @Override
+    FileSystem createAzureFS() {
+        return new AzureBlobFileSystem();
+    }
+}

--- a/flink-filesystems/flink-azure-fs-hadoop/src/main/java/org/apache/flink/fs/azurefs/SecureAzureBlobStorageFSFactory.java
+++ b/flink-filesystems/flink-azure-fs-hadoop/src/main/java/org/apache/flink/fs/azurefs/SecureAzureBlobStorageFSFactory.java
@@ -18,11 +18,19 @@
 
 package org.apache.flink.fs.azurefs;
 
-/** A factory for the Azure file system over HTTP. */
-public class AzureFSFactory extends AbstractAzureFSFactory {
+import org.apache.hadoop.fs.FileSystem;
+import org.apache.hadoop.fs.azure.NativeAzureFileSystem;
+
+/** A factory for the Azure file system over HTTPs. */
+public class SecureAzureBlobStorageFSFactory extends AbstractAzureFSFactory {
 
     @Override
     public String getScheme() {
-        return "wasb";
+        return "wasbs";
+    }
+
+    @Override
+    FileSystem createAzureFS() {
+        return new NativeAzureFileSystem();
     }
 }

--- a/flink-filesystems/flink-azure-fs-hadoop/src/main/java/org/apache/flink/fs/azurefs/SecureAzureDataLakeStoreGen2FSFactory.java
+++ b/flink-filesystems/flink-azure-fs-hadoop/src/main/java/org/apache/flink/fs/azurefs/SecureAzureDataLakeStoreGen2FSFactory.java
@@ -18,11 +18,19 @@
 
 package org.apache.flink.fs.azurefs;
 
-/** A factory for the Azure file system over HTTPs. */
-public class SecureAzureFSFactory extends AbstractAzureFSFactory {
+import org.apache.hadoop.fs.FileSystem;
+import org.apache.hadoop.fs.azurebfs.AzureBlobFileSystem;
+
+/** Secure ABFS AzureFS implementation. */
+public class SecureAzureDataLakeStoreGen2FSFactory extends AbstractAzureFSFactory {
 
     @Override
     public String getScheme() {
-        return "wasbs";
+        return "abfss";
+    }
+
+    @Override
+    FileSystem createAzureFS() {
+        return new AzureBlobFileSystem();
     }
 }

--- a/flink-filesystems/flink-azure-fs-hadoop/src/main/resources/META-INF/NOTICE
+++ b/flink-filesystems/flink-azure-fs-hadoop/src/main/resources/META-INF/NOTICE
@@ -9,13 +9,20 @@ This project bundles the following dependencies under the Apache Software Licens
 - com.fasterxml.jackson.core:jackson-annotations:2.12.1
 - com.fasterxml.jackson.core:jackson-core:2.12.1
 - com.fasterxml.jackson.core:jackson-databind:2.12.1
-- com.google.guava:guava:11.0.2
-- com.microsoft.azure:azure-keyvault-core:0.8.0
-- com.microsoft.azure:azure-storage:5.4.0
+- com.google.guava:guava:20.0
 - commons-codec:commons-codec:1.13
 - commons-logging:commons-logging:1.1.3
-- org.apache.hadoop:hadoop-azure:3.1.0
+- org.apache.hadoop:hadoop-azure:3.3.1
+- org.apache.hadoop.thirdparty:hadoop-shaded-guava:1.1.1
 - org.apache.httpcomponents:httpclient:4.5.13
 - org.apache.httpcomponents:httpcore:4.4.14
+- org.codehaus.jackson:jackson-mapper-asl:1.9.13
+- org.codehaus.jackson:jackson-core-asl:1.9.13
 - org.eclipse.jetty:jetty-util:9.3.24.v20180605
 - org.eclipse.jetty:jetty-util-ajax:9.3.24.v20180605
+- org.wildfly.openssl:wildfly-openssl:1.0.7.Final
+
+This project bundles the following dependencies under the MIT (https://opensource.org/licenses/MIT)
+
+- com.microsoft.azure:azure-keyvault-core:1.0.0
+- com.microsoft.azure:azure-storage:7.0.1

--- a/flink-filesystems/flink-azure-fs-hadoop/src/main/resources/META-INF/services/org.apache.flink.core.fs.FileSystemFactory
+++ b/flink-filesystems/flink-azure-fs-hadoop/src/main/resources/META-INF/services/org.apache.flink.core.fs.FileSystemFactory
@@ -13,5 +13,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-org.apache.flink.fs.azurefs.AzureFSFactory
-org.apache.flink.fs.azurefs.SecureAzureFSFactory
+org.apache.flink.fs.azurefs.AzureBlobStorageFSFactory
+org.apache.flink.fs.azurefs.SecureAzureBlobStorageFSFactory
+org.apache.flink.fs.azurefs.AzureDataLakeStoreGen2FSFactory
+org.apache.flink.fs.azurefs.SecureAzureDataLakeStoreGen2FSFactory

--- a/flink-filesystems/flink-azure-fs-hadoop/src/test/java/org/apache/flink/fs/azurefs/AzureBlobStorageFSFactoryTest.java
+++ b/flink-filesystems/flink-azure-fs-hadoop/src/test/java/org/apache/flink/fs/azurefs/AzureBlobStorageFSFactoryTest.java
@@ -1,0 +1,95 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.flink.fs.azurefs;
+
+import org.apache.flink.configuration.Configuration;
+import org.apache.flink.util.TestLogger;
+
+import org.apache.hadoop.fs.azure.AzureException;
+import org.junit.Rule;
+import org.junit.Test;
+import org.junit.rules.ExpectedException;
+import org.junit.runner.RunWith;
+import org.junit.runners.Parameterized;
+
+import java.net.URI;
+import java.util.Arrays;
+import java.util.List;
+
+/** Tests for the AzureFSFactory. */
+@RunWith(Parameterized.class)
+public class AzureBlobStorageFSFactoryTest extends TestLogger {
+
+    @Parameterized.Parameter public String scheme;
+
+    @Parameterized.Parameters(name = "Scheme = {0}")
+    public static List<String> parameters() {
+        return Arrays.asList("wasb", "wasbs");
+    }
+
+    @Rule public final ExpectedException exception = ExpectedException.none();
+
+    private AbstractAzureFSFactory getFactory(String scheme) {
+        return scheme.equals("wasb")
+                ? new AzureBlobStorageFSFactory()
+                : new SecureAzureBlobStorageFSFactory();
+    }
+
+    @Test
+    public void testNullFsURI() throws Exception {
+        URI uri = null;
+        AbstractAzureFSFactory factory = getFactory(scheme);
+
+        exception.expect(NullPointerException.class);
+        exception.expectMessage("passed file system URI object should not be null");
+
+        factory.create(uri);
+    }
+
+    // missing credentials
+    @Test
+    public void testCreateFsWithAuthorityMissingCreds() throws Exception {
+        String uriString =
+                String.format(
+                        "%s://yourcontainer@youraccount.blob.core.windows.net/testDir", scheme);
+        final URI uri = URI.create(uriString);
+
+        exception.expect(AzureException.class);
+
+        AbstractAzureFSFactory factory = getFactory(scheme);
+        Configuration config = new Configuration();
+        config.setInteger("fs.azure.io.retry.max.retries", 0);
+        factory.configure(config);
+        factory.create(uri);
+    }
+
+    @Test
+    public void testCreateFsWithMissingAuthority() throws Exception {
+        String uriString = String.format("%s:///my/path", scheme);
+        final URI uri = URI.create(uriString);
+
+        exception.expect(IllegalArgumentException.class);
+        exception.expectMessage(
+                "Cannot initialize WASB file system, URI authority not recognized.");
+
+        AbstractAzureFSFactory factory = getFactory(scheme);
+        factory.configure(new Configuration());
+        factory.create(uri);
+    }
+}

--- a/flink-filesystems/flink-azure-fs-hadoop/src/test/java/org/apache/flink/fs/azurefs/AzureDataLakeStoreGen2FSFactoryTest.java
+++ b/flink-filesystems/flink-azure-fs-hadoop/src/test/java/org/apache/flink/fs/azurefs/AzureDataLakeStoreGen2FSFactoryTest.java
@@ -19,9 +19,7 @@
 package org.apache.flink.fs.azurefs;
 
 import org.apache.flink.configuration.Configuration;
-import org.apache.flink.util.TestLogger;
 
-import org.apache.hadoop.fs.azure.AzureException;
 import org.junit.Rule;
 import org.junit.Test;
 import org.junit.rules.ExpectedException;
@@ -32,21 +30,22 @@ import java.net.URI;
 import java.util.Arrays;
 import java.util.List;
 
-/** Tests for the AzureFSFactory. */
+/** Tests for the ABFSAzureFSFactory. */
 @RunWith(Parameterized.class)
-public class AzureFSFactoryTest extends TestLogger {
-
+public class AzureDataLakeStoreGen2FSFactoryTest {
     @Parameterized.Parameter public String scheme;
 
     @Parameterized.Parameters(name = "Scheme = {0}")
     public static List<String> parameters() {
-        return Arrays.asList("wasb", "wasbs");
+        return Arrays.asList("abfs", "abfss");
     }
 
     @Rule public final ExpectedException exception = ExpectedException.none();
 
     private AbstractAzureFSFactory getFactory(String scheme) {
-        return scheme.equals("wasb") ? new AzureFSFactory() : new SecureAzureFSFactory();
+        return scheme.equals("abfs")
+                ? new AzureDataLakeStoreGen2FSFactory()
+                : new SecureAzureDataLakeStoreGen2FSFactory();
     }
 
     @Test
@@ -60,31 +59,13 @@ public class AzureFSFactoryTest extends TestLogger {
         factory.create(uri);
     }
 
-    // missing credentials
-    @Test
-    public void testCreateFsWithAuthorityMissingCreds() throws Exception {
-        String uriString =
-                String.format(
-                        "%s://yourcontainer@youraccount.blob.core.windows.net/testDir", scheme);
-        final URI uri = URI.create(uriString);
-
-        exception.expect(AzureException.class);
-
-        AbstractAzureFSFactory factory = getFactory(scheme);
-        Configuration config = new Configuration();
-        config.setInteger("fs.azure.io.retry.max.retries", 0);
-        factory.configure(config);
-        factory.create(uri);
-    }
-
     @Test
     public void testCreateFsWithMissingAuthority() throws Exception {
         String uriString = String.format("%s:///my/path", scheme);
         final URI uri = URI.create(uriString);
 
         exception.expect(IllegalArgumentException.class);
-        exception.expectMessage(
-                "Cannot initialize WASB file system, URI authority not recognized.");
+        exception.expectMessage(String.format("%s has invalid authority.", uriString));
 
         AbstractAzureFSFactory factory = getFactory(scheme);
         factory.configure(new Configuration());

--- a/flink-filesystems/flink-fs-hadoop-shaded/src/main/resources/META-INF/NOTICE
+++ b/flink-filesystems/flink-fs-hadoop-shaded/src/main/resources/META-INF/NOTICE
@@ -6,22 +6,43 @@ The Apache Software Foundation (http://www.apache.org/).
 
 This project bundles the following dependencies under the Apache Software License 2.0 (http://www.apache.org/licenses/LICENSE-2.0.txt)
 
-- org.apache.hadoop:hadoop-annotations:3.1.0
-- org.apache.hadoop:hadoop-auth:3.1.0
-- org.apache.hadoop:hadoop-common:3.1.0
+- org.apache.hadoop:hadoop-annotations:3.3.1
+- org.apache.hadoop:hadoop-auth:3.3.1
+- org.apache.hadoop:hadoop-common:3.3.1
+- org.apache.hadoop.thirdparty:hadoop-shaded-guava:1.1.1
+- org.apache.hadoop.thirdparty:hadoop-shaded-protobuf_3_7:1.1.1
 - org.apache.htrace:htrace-core4:4.1.0-incubating
+- org.apache.kerby:kerb-core:1.0.1
+- org.apache.kerby:kerby-pkix:1.0.1
+- org.apache.kerby:kerby-asn1:1.0.1
+- org.apache.kerby:kerby-util:1.0.1
 - org.apache.commons:commons-configuration2:2.1.1
 - org.apache.commons:commons-lang3:3.3.2
+- org.apache.commons:commons-text:1.4
+- org.xerial.snappy:snappy-java:1.1.8.3
 - commons-lang:commons-lang:2.6
 - commons-collections:commons-collections:3.2.2
 - commons-io:commons-io:2.8.0
 - commons-logging:commons-logging:1.1.3
 - commons-beanutils:commons-beanutils:1.9.4
-- com.google.guava:guava:11.0.2
+- com.google.guava:failureaccess:1.0
+- com.google.guava:guava:27.0-jre
+- com.google.guava:listenablefuture:9999.0-empty-to-avoid-conflict-with-guava
+- com.google.j2objc:j2objc-annotations:1.1
 - com.fasterxml.jackson.core:jackson-annotations:2.12.1
 - com.fasterxml.jackson.core:jackson-core:2.12.1
 - com.fasterxml.jackson.core:jackson-databind:2.12.1
-- com.fasterxml.woodstox:woodstox-core:5.0.3
+- com.fasterxml.woodstox:woodstox-core:5.3.0
+
+This project bundles the following dependencies under the MIT (https://opensource.org/licenses/MIT)
+
+- org.checkerframework:checker-qual:2.5.2
+- org.codehaus.mojo:animal-sniffer-annotations:1.17
+
+This project bundles the following dependencies under BSD-2 License (https://opensource.org/licenses/BSD-2-Clause).
+See bundled license files for details.
+
+- dnsjava:dnsjava:2.1.7
 
 This project bundles the following dependencies under the Go License (https://golang.org/LICENSE).
 See bundled license files for details.
@@ -31,9 +52,9 @@ See bundled license files for details.
 This project bundles the following dependencies under BSD License (https://opensource.org/licenses/bsd-license.php).
 See bundled license files for details.
 
-- org.codehaus.woodstox:stax2-api:3.1.4 (https://github.com/FasterXML/stax2-api/tree/stax2-api-3.1.4)
+- org.codehaus.woodstox:stax2-api:4.2.1 (https://github.com/FasterXML/stax2-api/tree/stax2-api-4.2.1)
 
-This project bundles org.apache.hadoop:*:3.1.0 from which it inherits the following notices:
+This project bundles org.apache.hadoop:*:3.3.1 from which it inherits the following notices:
 
 The Apache Hadoop project contains subcomponents with separate copyright
 notices and license terms. Your use of the source code for the these

--- a/flink-filesystems/flink-oss-fs-hadoop/src/main/resources/META-INF/NOTICE
+++ b/flink-filesystems/flink-oss-fs-hadoop/src/main/resources/META-INF/NOTICE
@@ -13,7 +13,7 @@ This project bundles the following dependencies under the Apache Software Licens
 - com.aliyun:aliyun-java-sdk-sts:3.0.0
 - commons-codec:commons-codec:1.13
 - commons-logging:commons-logging:1.1.3
-- org.apache.hadoop:hadoop-aliyun:3.1.0
+- org.apache.hadoop:hadoop-aliyun:3.3.1
 - org.apache.httpcomponents:httpclient:4.5.13
 - org.apache.httpcomponents:httpcore:4.4.14
 - org.codehaus.jettison:jettison:1.1

--- a/flink-filesystems/flink-s3-fs-hadoop/src/main/java/org/apache/flink/fs/s3hadoop/HadoopS3AccessHelper.java
+++ b/flink-filesystems/flink-s3-fs-hadoop/src/main/java/org/apache/flink/fs/s3hadoop/HadoopS3AccessHelper.java
@@ -30,10 +30,13 @@ import com.amazonaws.services.s3.model.PutObjectResult;
 import com.amazonaws.services.s3.model.UploadPartRequest;
 import com.amazonaws.services.s3.model.UploadPartResult;
 import org.apache.hadoop.conf.Configuration;
+import org.apache.hadoop.fs.FileSystem;
 import org.apache.hadoop.fs.Path;
 import org.apache.hadoop.fs.s3a.S3AFileSystem;
+import org.apache.hadoop.fs.s3a.S3AInstrumentation;
 import org.apache.hadoop.fs.s3a.S3AUtils;
 import org.apache.hadoop.fs.s3a.WriteOperationHelper;
+import org.apache.hadoop.fs.s3a.statistics.impl.BondedS3AStatisticsContext;
 
 import java.io.File;
 import java.io.FileOutputStream;
@@ -52,8 +55,22 @@ public class HadoopS3AccessHelper implements S3AccessHelper {
     private final InternalWriteOperationHelper s3accessHelper;
 
     public HadoopS3AccessHelper(S3AFileSystem s3a, Configuration conf) {
+        FileSystem.Statistics statistics = new FileSystem.Statistics(s3a.getScheme());
+        BondedS3AStatisticsContext statisticsContext =
+                new BondedS3AStatisticsContext(
+                        new BondedS3AStatisticsContext.S3AFSStatisticsSource() {
+                            public S3AInstrumentation getInstrumentation() {
+                                return s3a.getInstrumentation();
+                            }
+
+                            public FileSystem.Statistics getInstanceStatistics() {
+                                return statistics;
+                            }
+                        });
+
         this.s3accessHelper =
-                new InternalWriteOperationHelper(checkNotNull(s3a), checkNotNull(conf));
+                new InternalWriteOperationHelper(
+                        checkNotNull(s3a), checkNotNull(conf), statisticsContext);
         this.s3a = s3a;
     }
 
@@ -144,8 +161,11 @@ public class HadoopS3AccessHelper implements S3AccessHelper {
      */
     private static final class InternalWriteOperationHelper extends WriteOperationHelper {
 
-        InternalWriteOperationHelper(S3AFileSystem owner, Configuration conf) {
-            super(owner, conf);
+        InternalWriteOperationHelper(
+                S3AFileSystem owner,
+                Configuration conf,
+                BondedS3AStatisticsContext statisticsContext) {
+            super(owner, conf, statisticsContext);
         }
     }
 }

--- a/flink-filesystems/flink-s3-fs-hadoop/src/main/resources/META-INF/NOTICE
+++ b/flink-filesystems/flink-s3-fs-hadoop/src/main/resources/META-INF/NOTICE
@@ -13,8 +13,11 @@ This project bundles the following dependencies under the Apache Software Licens
 - com.fasterxml.jackson.core:jackson-core:2.12.1
 - com.fasterxml.jackson.core:jackson-databind:2.12.1
 - com.fasterxml.jackson.dataformat:jackson-dataformat-cbor:2.12.1
-- com.fasterxml.woodstox:woodstox-core:5.0.3
-- com.google.guava:guava:11.0.2
+- com.fasterxml.woodstox:woodstox-core:5.3.0
+- com.google.guava:failureaccess:1.0
+- com.google.guava:guava:27.0-jre
+- com.google.guava:listenablefuture:9999.0-empty-to-avoid-conflict-with-guava
+- com.google.j2objc:j2objc-annotations:1.1
 - commons-beanutils:commons-beanutils:1.9.4
 - commons-codec:commons-codec:1.13
 - commons-collections:commons-collections:3.2.2
@@ -24,14 +27,33 @@ This project bundles the following dependencies under the Apache Software Licens
 - joda-time:joda-time:2.5
 - org.apache.commons:commons-configuration2:2.1.1
 - org.apache.commons:commons-lang3:3.3.2
-- org.apache.hadoop:hadoop-auth:3.1.0
-- org.apache.hadoop:hadoop-annotations:3.1.0
-- org.apache.hadoop:hadoop-aws:3.1.0
-- org.apache.hadoop:hadoop-common:3.1.0
+- org.apache.commons:commons-text:1.4
+- org.apache.hadoop:hadoop-auth:3.3.1
+- org.apache.hadoop:hadoop-annotations:3.3.1
+- org.apache.hadoop:hadoop-aws:3.3.1
+- org.apache.hadoop:hadoop-common:3.3.1
+- org.apache.hadoop.thirdparty:hadoop-shaded-guava:1.1.1
+- org.apache.hadoop.thirdparty:hadoop-shaded-protobuf_3_7:1.1.1
 - org.apache.htrace:htrace-core4:4.1.0-incubating
-- org.apache.httpcomponents:httpcore:4.4.14
 - org.apache.httpcomponents:httpclient:4.5.13
+- org.apache.httpcomponents:httpcore:4.4.14
+- org.apache.kerby:kerb-core:1.0.1
+- org.apache.kerby:kerby-pkix:1.0.1
+- org.apache.kerby:kerby-asn1:1.0.1
+- org.apache.kerby:kerby-util:1.0.1
+- org.xerial.snappy:snappy-java:1.1.8.3
+- org.wildfly.openssl:wildfly-openssl:1.0.7.Final
 - software.amazon.ion:ion-java:1.0.2
+
+This project bundles the following dependencies under BSD-2 License (https://opensource.org/licenses/BSD-2-Clause).
+See bundled license files for details.
+
+- dnsjava:dnsjava:2.1.7
+
+This project bundles the following dependencies under the MIT (https://opensource.org/licenses/MIT)
+
+- org.checkerframework:checker-qual:2.5.2
+- org.codehaus.mojo:animal-sniffer-annotations:1.17
 
 This project bundles the following dependencies under the CDDL 1.1 license.
 See bundled license files for details.
@@ -46,4 +68,4 @@ See bundled license files for details.
 This project bundles the following dependencies under BSD License (https://opensource.org/licenses/bsd-license.php).
 See bundled license files for details.
 
-- org.codehaus.woodstox:stax2-api:3.1.4 (https://github.com/FasterXML/stax2-api/tree/stax2-api-3.1.4)
+- org.codehaus.woodstox:stax2-api:4.2.1 (https://github.com/FasterXML/stax2-api/tree/stax2-api-4.2.1)

--- a/flink-filesystems/flink-s3-fs-presto/src/main/resources/META-INF/NOTICE
+++ b/flink-filesystems/flink-s3-fs-presto/src/main/resources/META-INF/NOTICE
@@ -27,7 +27,7 @@ This project bundles the following dependencies under the Apache Software Licens
 - com.fasterxml.jackson.core:jackson-core:2.12.1
 - com.fasterxml.jackson.core:jackson-databind:2.12.1
 - com.fasterxml.jackson.dataformat:jackson-dataformat-cbor:2.12.1
-- com.fasterxml.woodstox:woodstox-core:5.0.3
+- com.fasterxml.woodstox:woodstox-core:5.3.0
 - com.google.guava:guava:26.0-jre
 - com.google.inject:guice:4.2.2
 - com.facebook.airlift:configuration:0.201
@@ -39,15 +39,29 @@ This project bundles the following dependencies under the Apache Software Licens
 - org.alluxio:alluxio-shaded-client:2.5.0-3
 - org.apache.commons:commons-configuration2:2.1.1
 - org.apache.commons:commons-lang3:3.3.2
-- org.apache.hadoop:hadoop-annotations:3.1.0
-- org.apache.hadoop:hadoop-aws:3.1.0
-- org.apache.hadoop:hadoop-auth:3.1.0
-- org.apache.hadoop:hadoop-common:3.1.0
+- org.apache.commons:commons-text:1.4
+- org.apache.hadoop:hadoop-annotations:3.3.1
+- org.apache.hadoop:hadoop-aws:3.3.1
+- org.apache.hadoop:hadoop-auth:3.3.1
+- org.apache.hadoop:hadoop-common:3.3.1
+- org.apache.hadoop.thirdparty:hadoop-shaded-guava:1.1.1
+- org.apache.hadoop.thirdparty:hadoop-shaded-protobuf_3_7:1.1.1
 - org.apache.htrace:htrace-core4:4.1.0-incubating
-- org.apache.httpcomponents:httpcore:4.4.14
 - org.apache.httpcomponents:httpclient:4.5.13
+- org.apache.httpcomponents:httpcore:4.4.14
+- org.apache.kerby:kerby-asn1:1.0.1
+- org.apache.kerby:kerb-core:1.0.1
+- org.apache.kerby:kerby-pkix:1.0.1
+- org.apache.kerby:kerby-util:1.0.1
+- org.xerial.snappy:snappy-java:1.1.8.3
 - org.weakref:jmxutils:1.19
+- org.wildfly.openssl:wildfly-openssl:1.0.7.Final
 - software.amazon.ion:ion-java:1.0.2
+
+This project bundles the following dependencies under BSD-2 License (https://opensource.org/licenses/BSD-2-Clause).
+See bundled license files for details.
+
+- dnsjava:dnsjava:2.1.7
 
 This project bundles the following dependencies under the Creative Commons CC0 1.0 Universal Public Domain Dedication License (http://creativecommons.org/publicdomain/zero/1.0/)
 See bundled license files for details.
@@ -67,7 +81,7 @@ See bundled license files for details.
 This project bundles the following dependencies under BSD License (https://opensource.org/licenses/bsd-license.php).
 See bundled license files for details.
 
-- org.codehaus.woodstox:stax2-api:3.1.4 (https://github.com/FasterXML/stax2-api/tree/stax2-api-3.1.4)
+- org.codehaus.woodstox:stax2-api:4.2.1 (https://github.com/FasterXML/stax2-api/tree/stax2-api-4.2.1)
 
 This project bundles the following dependencies under the Public Domain.
 See bundled license files for details.

--- a/flink-filesystems/pom.xml
+++ b/flink-filesystems/pom.xml
@@ -35,7 +35,7 @@ under the License.
 	<packaging>pom</packaging>
 
 	<properties>
-		<fs.hadoopshaded.version>3.1.0</fs.hadoopshaded.version>
+		<fs.hadoopshaded.version>3.3.1</fs.hadoopshaded.version>
 	</properties>
 
 	<modules>


### PR DESCRIPTION
<!--
*Thank you very much for contributing to Apache Flink - we are happy that you want to help us improve Flink. To help the community review your contribution in the best possible way, please go through the checklist below, which will get the contribution into a shape in which it can be best reviewed.*

*Please understand that we do not do this to make contributions to Flink a hassle. In order to uphold a high standard of quality for code contributions, while at the same time managing a large number of contributions, we need contributors to prepare the contributions well, and give reviewers enough contextual information for the review. Please also understand that contributions that do not follow this guide will take longer to review and thus typically be picked up with lower priority by the community.*

## Contribution Checklist

  - Make sure that the pull request corresponds to a [JIRA issue](https://issues.apache.org/jira/projects/FLINK/issues). Exceptions are made for typos in JavaDoc or documentation files, which need no JIRA issue.
  
  - Name the pull request in the form "[FLINK-XXXX] [component] Title of the pull request", where *FLINK-XXXX* should be replaced by the actual issue number. Skip *component* if you are unsure about which is the best component.
  Typo fixes that have no associated JIRA issue should be named following this pattern: `[hotfix] [docs] Fix typo in event time introduction` or `[hotfix] [javadocs] Expand JavaDoc for PuncuatedWatermarkGenerator`.

  - Fill out the template below to describe the changes contributed by the pull request. That will give reviewers the context they need to do the review.
  
  - Make sure that the change passes the automated tests, i.e., `mvn clean verify` passes. You can set up Azure Pipelines CI to do that following [this guide](https://cwiki.apache.org/confluence/display/FLINK/Azure+Pipelines#AzurePipelines-Tutorial:SettingupAzurePipelinesforaforkoftheFlinkrepository).

  - Each pull request should address only one issue, not mix up code from multiple issues.
  
  - Each commit in the pull request has a meaningful commit message (including the JIRA id)

  - Once all items of the checklist are addressed, remove the above text and this checklist, leaving only the filled out template below.


**(The sections below can be removed for hotfixes of typos)**
-->

## What is the purpose of the change

This pull request adds support for [abfs](https://hadoop.apache.org/docs/stable/hadoop-azure/abfs.html) to talk to ADLS Gen2 (Azure DataLake Gen2) storage accounts. These are newer storage account types that hierarchical namespaces, abfs takes advantage of this newer capability. Azure recommends using abfs for reading/writing to these newer storage accounts. 


## Brief change log
- Upgrade the hadoop version to latest. Existing version that flink depends on doesn't have hadoop abfs implementation. 
- Added support for two new schemes (abfs:// and abfss://)
- Added english documentation. 

## Verifying this change

- Ran existing tests to make sure there are no regressions
- Added few trivial unit tests. File system implementations are really hard to test using unit tests. Existing filesystems unit tests seems to be super thin. 
- Tested abfs, abfss manually using a flink clusters on AKS using the instructions [here](https://github.com/srinipunuru/flink-playground/blob/master/abfs-support/README.md)


## Does this pull request potentially affect one of the following parts:

  - Dependencies (does it add or upgrade a dependency): (**yes** / no)
  - The public API, i.e., is any changed class annotated with `@Public(Evolving)`: (yes / **no**)
  - The serializers: (yes / **no** / don't know)
  - The runtime per-record code paths (performance sensitive): (yes / **no** / don't know)
  - Anything that affects deployment or recovery: JobManager (and its components), Checkpointing, Kubernetes/Yarn, ZooKeeper: (**yes** / no / don't know)
  - The S3 file system connector: (**yes** / no / don't know) - Because of the upgrade of the hadoop version

## Documentation

  - Does this pull request introduce a new feature? (**yes** / no)
  - If yes, how is the feature documented? (not applicable / **docs** / JavaDocs / not documented) - Yes (English version)
