### PR TITLE
[FLINK-23190] Improve slot-sharing allocation

### DIFF
--- a/flink-runtime/src/main/java/org/apache/flink/runtime/jobmaster/SlotRequestId.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/jobmaster/SlotRequestId.java
@@ -18,10 +18,14 @@
 
 package org.apache.flink.runtime.jobmaster;
 
+import org.apache.flink.runtime.jobgraph.JobVertexID;
 import org.apache.flink.runtime.jobmaster.slotpool.PhysicalSlot;
 import org.apache.flink.runtime.jobmaster.slotpool.PhysicalSlotProvider;
 import org.apache.flink.runtime.jobmaster.slotpool.SlotPool;
 import org.apache.flink.util.AbstractID;
+
+import javax.annotation.Nullable;
+import java.util.Set;
 
 /**
  * This ID identifies the request for a slot from the Execution to the {@link SlotPool} or {@link
@@ -36,11 +40,22 @@ public final class SlotRequestId extends AbstractID {
 
     private static final long serialVersionUID = -6072105912250154283L;
 
+    @Nullable private Set<JobVertexID> jobVertexSharingGroup;
+
     public SlotRequestId(long lowerPart, long upperPart) {
         super(lowerPart, upperPart);
     }
 
     public SlotRequestId() {}
+
+    public SlotRequestId(Set<JobVertexID> jobVertexSharingGroup) {
+        this.jobVertexSharingGroup = jobVertexSharingGroup;
+    }
+
+    @Nullable
+    public Set<JobVertexID> getJobVertexSharingGroup() {
+        return jobVertexSharingGroup;
+    }
 
     @Override
     public String toString() {

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/scheduler/ExecutionSlotSharingGroup.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/scheduler/ExecutionSlotSharingGroup.java
@@ -19,12 +19,14 @@
 package org.apache.flink.runtime.scheduler;
 
 import org.apache.flink.runtime.clusterframework.types.ResourceProfile;
+import org.apache.flink.runtime.jobgraph.JobVertexID;
 import org.apache.flink.runtime.scheduler.strategy.ExecutionVertexID;
 import org.apache.flink.util.Preconditions;
 
 import java.util.Collections;
 import java.util.HashSet;
 import java.util.Set;
+import java.util.stream.Collectors;
 
 /** Represents execution vertices that will run the same shared slot. */
 class ExecutionSlotSharingGroup {
@@ -43,6 +45,11 @@ class ExecutionSlotSharingGroup {
 
     void setResourceProfile(ResourceProfile resourceProfile) {
         this.resourceProfile = Preconditions.checkNotNull(resourceProfile);
+    }
+
+    Set<JobVertexID> getJobVertexSharingGroup() {
+        return executionVertexIds.stream()
+                .map(ExecutionVertexID::getJobVertexId).collect(Collectors.toSet());
     }
 
     ResourceProfile getResourceProfile() {

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/scheduler/SlotSharingExecutionSlotAllocator.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/scheduler/SlotSharingExecutionSlotAllocator.java
@@ -199,7 +199,7 @@ class SlotSharingExecutionSlotAllocator implements ExecutionSlotAllocator {
         return sharedSlots.computeIfAbsent(
                 executionSlotSharingGroup,
                 group -> {
-                    SlotRequestId physicalSlotRequestId = new SlotRequestId();
+                    SlotRequestId physicalSlotRequestId = new SlotRequestId(group.getJobVertexSharingGroup());
                     ResourceProfile physicalSlotResourceProfile =
                             getPhysicalSlotResourceProfile(group);
                     SlotProfile slotProfile =


### PR DESCRIPTION
## What is the purpose of the change

This pr could improve to a certain extent for slot-sharing allocation,and it mainly show the feasibility for the discuss **FLINK-23190**.

## Brief change log

*(for example:)*
  - *Make DefaultScheduler and AdaptiveScheduler allocate slots more even*

## Verifying this change

*(Please pick either of the following options)*

This change is a trivial rework / code cleanup without any test coverage.

no

This change is already covered by existing tests, such as *(please describe tests)*.

no

This change added tests and can be verified as follows:
no

## Does this pull request potentially affect one of the following parts:

  - Dependencies (does it add or upgrade a dependency): (no)
  - The public API, i.e., is any changed class annotated with `@Public(Evolving)`: (no)
  - The serializers: (no)
  - The runtime per-record code paths (performance sensitive): (no)
  - Anything that affects deployment or recovery: JobManager (and its components), Checkpointing, Kubernetes/Yarn, ZooKeeper: (yes)
  - The S3 file system connector: (no)

## Documentation

  - Does this pull request introduce a new feature? (no)
