### PR TITLE
[FLINK-23450][avro-confluent-registry] Set properties map for DebeziumAvroFormat

### DIFF
--- a/flink-connectors/flink-connector-kafka/src/test/java/org/apache/flink/streaming/connectors/kafka/table/KafkaDynamicTableFactoryTest.java
+++ b/flink-connectors/flink-connector-kafka/src/test/java/org/apache/flink/streaming/connectors/kafka/table/KafkaDynamicTableFactoryTest.java
@@ -619,7 +619,7 @@ public class KafkaDynamicTableFactoryTest extends TestLogger {
 
     private SerializationSchema<RowData> createDebeziumAvroSerSchema(
             RowType rowType, String subject) {
-        return new DebeziumAvroSerializationSchema(rowType, TEST_REGISTRY_URL, subject);
+        return new DebeziumAvroSerializationSchema(rowType, TEST_REGISTRY_URL, subject, null);
     }
 
     // --------------------------------------------------------------------------------------------

--- a/flink-formats/flink-avro-confluent-registry/src/main/java/org/apache/flink/formats/avro/registry/confluent/RegistryAvroFormatFactory.java
+++ b/flink-formats/flink-avro-confluent-registry/src/main/java/org/apache/flink/formats/avro/registry/confluent/RegistryAvroFormatFactory.java
@@ -42,6 +42,8 @@ import org.apache.flink.table.factories.SerializationFormatFactory;
 import org.apache.flink.table.types.DataType;
 import org.apache.flink.table.types.logical.RowType;
 
+import javax.annotation.Nullable;
+
 import java.util.HashMap;
 import java.util.HashSet;
 import java.util.Map;
@@ -85,14 +87,10 @@ public class RegistryAvroFormatFactory
                 final TypeInformation<RowData> rowDataTypeInfo =
                         context.createTypeInformation(producedDataType);
                 return new AvroRowDataDeserializationSchema(
-                        optionalPropertiesMap.isEmpty()
-                                ? ConfluentRegistryAvroDeserializationSchema.forGeneric(
-                                        AvroSchemaConverter.convertToSchema(rowType),
-                                        schemaRegistryURL)
-                                : ConfluentRegistryAvroDeserializationSchema.forGeneric(
-                                        AvroSchemaConverter.convertToSchema(rowType),
-                                        schemaRegistryURL,
-                                        optionalPropertiesMap),
+                        ConfluentRegistryAvroDeserializationSchema.forGeneric(
+                                AvroSchemaConverter.convertToSchema(rowType),
+                                schemaRegistryURL,
+                                optionalPropertiesMap),
                         AvroToRowDataConverters.createRowConverter(rowType),
                         rowDataTypeInfo);
             }
@@ -127,16 +125,11 @@ public class RegistryAvroFormatFactory
                 final RowType rowType = (RowType) consumedDataType.getLogicalType();
                 return new AvroRowDataSerializationSchema(
                         rowType,
-                        optionalPropertiesMap.isEmpty()
-                                ? ConfluentRegistryAvroSerializationSchema.forGeneric(
-                                        subject.get(),
-                                        AvroSchemaConverter.convertToSchema(rowType),
-                                        schemaRegistryURL)
-                                : ConfluentRegistryAvroSerializationSchema.forGeneric(
-                                        subject.get(),
-                                        AvroSchemaConverter.convertToSchema(rowType),
-                                        schemaRegistryURL,
-                                        optionalPropertiesMap),
+                        ConfluentRegistryAvroSerializationSchema.forGeneric(
+                                subject.get(),
+                                AvroSchemaConverter.convertToSchema(rowType),
+                                schemaRegistryURL,
+                                optionalPropertiesMap),
                         RowDataToAvroConverters.createConverter(rowType));
             }
 
@@ -175,7 +168,8 @@ public class RegistryAvroFormatFactory
         return options;
     }
 
-    private Map<String, String> buildOptionalPropertiesMap(ReadableConfig formatOptions) {
+    public static @Nullable Map<String, String> buildOptionalPropertiesMap(
+            ReadableConfig formatOptions) {
         final Map<String, String> properties = new HashMap<>();
 
         formatOptions.getOptional(PROPERTIES).ifPresent(properties::putAll);
@@ -205,6 +199,9 @@ public class RegistryAvroFormatFactory
                 .getOptional(BEARER_AUTH_TOKEN)
                 .ifPresent(v -> properties.put("bearer.auth.token", v));
 
+        if (properties.isEmpty()) {
+            return null;
+        }
         return properties;
     }
 }

--- a/flink-formats/flink-avro-confluent-registry/src/main/java/org/apache/flink/formats/avro/registry/confluent/debezium/DebeziumAvroDeserializationSchema.java
+++ b/flink-formats/flink-avro-confluent-registry/src/main/java/org/apache/flink/formats/avro/registry/confluent/debezium/DebeziumAvroDeserializationSchema.java
@@ -34,7 +34,10 @@ import org.apache.flink.table.types.logical.RowType;
 import org.apache.flink.types.RowKind;
 import org.apache.flink.util.Collector;
 
+import javax.annotation.Nullable;
+
 import java.io.IOException;
+import java.util.Map;
 import java.util.Objects;
 
 import static java.lang.String.format;
@@ -74,7 +77,10 @@ public final class DebeziumAvroDeserializationSchema implements DeserializationS
     private final TypeInformation<RowData> producedTypeInfo;
 
     public DebeziumAvroDeserializationSchema(
-            RowType rowType, TypeInformation<RowData> producedTypeInfo, String schemaRegistryUrl) {
+            RowType rowType,
+            TypeInformation<RowData> producedTypeInfo,
+            String schemaRegistryUrl,
+            @Nullable Map<String, ?> registryConfigs) {
         this.producedTypeInfo = producedTypeInfo;
         RowType debeziumAvroRowType = createDebeziumAvroRowType(fromLogicalToDataType(rowType));
 
@@ -82,7 +88,8 @@ public final class DebeziumAvroDeserializationSchema implements DeserializationS
                 new AvroRowDataDeserializationSchema(
                         ConfluentRegistryAvroDeserializationSchema.forGeneric(
                                 AvroSchemaConverter.convertToSchema(debeziumAvroRowType),
-                                schemaRegistryUrl),
+                                schemaRegistryUrl,
+                                registryConfigs),
                         AvroToRowDataConverters.createRowConverter(debeziumAvroRowType),
                         producedTypeInfo);
     }

--- a/flink-formats/flink-avro-confluent-registry/src/main/java/org/apache/flink/formats/avro/registry/confluent/debezium/DebeziumAvroSerializationSchema.java
+++ b/flink-formats/flink-avro-confluent-registry/src/main/java/org/apache/flink/formats/avro/registry/confluent/debezium/DebeziumAvroSerializationSchema.java
@@ -18,6 +18,7 @@
 
 package org.apache.flink.formats.avro.registry.confluent.debezium;
 
+import org.apache.flink.annotation.Internal;
 import org.apache.flink.annotation.VisibleForTesting;
 import org.apache.flink.api.common.serialization.SerializationSchema;
 import org.apache.flink.formats.avro.AvroRowDataSerializationSchema;
@@ -31,6 +32,9 @@ import org.apache.flink.table.data.StringData;
 import org.apache.flink.table.types.DataType;
 import org.apache.flink.table.types.logical.RowType;
 
+import javax.annotation.Nullable;
+
+import java.util.Map;
 import java.util.Objects;
 
 import static java.lang.String.format;
@@ -40,6 +44,7 @@ import static org.apache.flink.table.types.utils.TypeConversions.fromLogicalToDa
  * Serialization schema from Flink Table/SQL internal data structure {@link RowData} to Debezium
  * Avro.
  */
+@Internal
 public class DebeziumAvroSerializationSchema implements SerializationSchema<RowData> {
     private static final long serialVersionUID = 1L;
 
@@ -54,7 +59,10 @@ public class DebeziumAvroSerializationSchema implements SerializationSchema<RowD
     private transient GenericRowData outputReuse;
 
     public DebeziumAvroSerializationSchema(
-            RowType rowType, String schemaRegistryUrl, String schemaRegistrySubject) {
+            RowType rowType,
+            String schemaRegistryUrl,
+            String schemaRegistrySubject,
+            @Nullable Map<String, ?> registryConfigs) {
         RowType debeziumAvroRowType = createDebeziumAvroRowType(fromLogicalToDataType(rowType));
 
         this.avroSerializer =
@@ -63,7 +71,8 @@ public class DebeziumAvroSerializationSchema implements SerializationSchema<RowD
                         ConfluentRegistryAvroSerializationSchema.forGeneric(
                                 schemaRegistrySubject,
                                 AvroSchemaConverter.convertToSchema(debeziumAvroRowType),
-                                schemaRegistryUrl),
+                                schemaRegistryUrl,
+                                registryConfigs),
                         RowDataToAvroConverters.createConverter(debeziumAvroRowType));
     }
 

--- a/flink-formats/flink-avro-confluent-registry/src/test/java/org/apache/flink/formats/avro/registry/confluent/debezium/DebeziumAvroFormatFactoryTest.java
+++ b/flink-formats/flink-avro-confluent-registry/src/test/java/org/apache/flink/formats/avro/registry/confluent/debezium/DebeziumAvroFormatFactoryTest.java
@@ -67,14 +67,19 @@ public class DebeziumAvroFormatFactoryTest extends TestLogger {
     public void testSeDeSchema() {
         final Map<String, String> options = getAllOptions();
 
+        final Map<String, String> registryConfigs = new HashMap<>();
+        registryConfigs.put("basic.auth.user.info", "something1");
+        registryConfigs.put("basic.auth.credentials.source", "something2");
+
         DebeziumAvroDeserializationSchema expectedDeser =
                 new DebeziumAvroDeserializationSchema(
-                        ROW_TYPE, InternalTypeInfo.of(ROW_TYPE), REGISTRY_URL);
+                        ROW_TYPE, InternalTypeInfo.of(ROW_TYPE), REGISTRY_URL, registryConfigs);
         DeserializationSchema<RowData> actualDeser = createDeserializationSchema(options);
         assertEquals(expectedDeser, actualDeser);
 
         DebeziumAvroSerializationSchema expectedSer =
-                new DebeziumAvroSerializationSchema(ROW_TYPE, REGISTRY_URL, SUBJECT);
+                new DebeziumAvroSerializationSchema(
+                        ROW_TYPE, REGISTRY_URL, SUBJECT, registryConfigs);
         SerializationSchema<RowData> actualSer = createSerializationSchema(options);
         Assert.assertEquals(expectedSer, actualSer);
     }
@@ -88,6 +93,8 @@ public class DebeziumAvroFormatFactoryTest extends TestLogger {
         options.put("format", DebeziumAvroFormatFactory.IDENTIFIER);
         options.put("debezium-avro-confluent.url", REGISTRY_URL);
         options.put("debezium-avro-confluent.subject", SUBJECT);
+        options.put("debezium-avro-confluent.basic-auth.user-info", "something1");
+        options.put("debezium-avro-confluent.basic-auth.credentials-source", "something2");
         return options;
     }
 


### PR DESCRIPTION
## What is the purpose of the change

We forgot to propagate the properties map for DebeziumAvroFormat.


## Brief change log

Set the map accordingly.

## Verifying this change

This change added tests and can be verified as follows: `DebeziumAvroFormatFactoryTest`

## Does this pull request potentially affect one of the following parts:

  - Dependencies (does it add or upgrade a dependency): no
  - The public API, i.e., is any changed class annotated with `@Public(Evolving)`: no
  - The serializers: no
  - The runtime per-record code paths (performance sensitive): no
  - Anything that affects deployment or recovery: JobManager (and its components), Checkpointing, Kubernetes/Yarn, ZooKeeper: no
  - The S3 file system connector: no

## Documentation

  - Does this pull request introduce a new feature? no
  - If yes, how is the feature documented? not applicable
