### PR TITLE
[FLINK-23139][state] Add TaskStateRegistry

### DIFF
--- a/flink-dstl/flink-dstl-dfs/src/main/java/org/apache/flink/changelog/fs/StateChangeUploader.java
+++ b/flink-dstl/flink-dstl-dfs/src/main/java/org/apache/flink/changelog/fs/StateChangeUploader.java
@@ -20,6 +20,7 @@ package org.apache.flink.changelog.fs;
 import org.apache.flink.configuration.ReadableConfig;
 import org.apache.flink.core.fs.Path;
 import org.apache.flink.runtime.state.changelog.SequenceNumber;
+import org.apache.flink.runtime.state.track.SharedTaskStateRegistry;
 
 import javax.annotation.concurrent.ThreadSafe;
 
@@ -67,7 +68,8 @@ interface StateChangeUploader extends AutoCloseable {
         }
     }
 
-    static StateChangeUploader fromConfig(ReadableConfig config) throws IOException {
+    static StateChangeUploader fromConfig(
+            ReadableConfig config, SharedTaskStateRegistry stateRegistry) throws IOException {
         Path basePath = new Path(config.get(BASE_PATH));
         long bytes = config.get(UPLOAD_BUFFER_SIZE).getBytes();
         checkArgument(bytes <= Integer.MAX_VALUE);
@@ -77,7 +79,8 @@ interface StateChangeUploader extends AutoCloseable {
                         basePath,
                         basePath.getFileSystem(),
                         config.get(COMPRESSION_ENABLED),
-                        bufferSize);
+                        bufferSize,
+                        stateRegistry);
         BatchingStateChangeUploader batchingStore =
                 new BatchingStateChangeUploader(
                         config.get(PERSIST_DELAY).toMillis(),

--- a/flink-dstl/flink-dstl-dfs/src/test/java/org/apache/flink/changelog/fs/FsStateChangelogStorageTest.java
+++ b/flink-dstl/flink-dstl-dfs/src/test/java/org/apache/flink/changelog/fs/FsStateChangelogStorageTest.java
@@ -20,11 +20,14 @@ package org.apache.flink.changelog.fs;
 import org.apache.flink.core.fs.Path;
 import org.apache.flink.runtime.state.changelog.StateChangelogStorage;
 import org.apache.flink.runtime.state.changelog.inmemory.StateChangelogStorageTest;
+import org.apache.flink.runtime.state.track.SharedTaskStateRegistry;
 
 import org.junit.runner.RunWith;
 import org.junit.runners.Parameterized;
 
 import java.io.IOException;
+
+import static org.apache.flink.util.concurrent.Executors.directExecutor;
 
 /** {@link FsStateChangelogStorage} test. */
 @RunWith(Parameterized.class)
@@ -39,6 +42,9 @@ public class FsStateChangelogStorageTest extends StateChangelogStorageTest {
     @Override
     protected StateChangelogStorage<?> getFactory() throws IOException {
         return new FsStateChangelogStorage(
-                Path.fromLocalFile(temporaryFolder.newFolder()), compression, 1024 * 1024 * 10);
+                Path.fromLocalFile(temporaryFolder.newFolder()),
+                compression,
+                1024 * 1024 * 10,
+                SharedTaskStateRegistry.create(directExecutor()));
     }
 }

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/state/CheckpointableKeyedStateBackend.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/state/CheckpointableKeyedStateBackend.java
@@ -45,5 +45,5 @@ public interface CheckpointableKeyedStateBackend<K>
      * write out a savepoint in the common/unified format.
      */
     @Nonnull
-    SavepointResources<K> savepoint() throws Exception;
+    SavepointResources<K> savepoint(long checkpointId) throws Exception;
 }

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/state/TaskExecutorStateChangelogStoragesManager.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/state/TaskExecutorStateChangelogStoragesManager.java
@@ -34,6 +34,7 @@ import java.io.IOException;
 import java.util.HashMap;
 import java.util.Map;
 import java.util.Optional;
+import java.util.concurrent.Executor;
 
 /**
  * This class holds the all {@link StateChangelogStorage} objects for a task executor (manager). No
@@ -68,7 +69,8 @@ public class TaskExecutorStateChangelogStoragesManager {
 
     @Nullable
     public StateChangelogStorage<?> stateChangelogStorageForJob(
-            @Nonnull JobID jobId, Configuration configuration) throws IOException {
+            @Nonnull JobID jobId, Configuration configuration, Executor ioExecutor)
+            throws IOException {
         if (closed) {
             throw new IllegalStateException(
                     "TaskExecutorStateChangelogStoragesManager is already closed and cannot "
@@ -79,7 +81,8 @@ public class TaskExecutorStateChangelogStoragesManager {
                 changelogStoragesByJobId.get(jobId);
 
         if (stateChangelogStorage == null) {
-            StateChangelogStorage<?> loaded = StateChangelogStorageLoader.load(configuration);
+            StateChangelogStorage<?> loaded =
+                    StateChangelogStorageLoader.load(configuration, ioExecutor);
             stateChangelogStorage = Optional.ofNullable(loaded);
             changelogStoragesByJobId.put(jobId, stateChangelogStorage);
 

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/state/changelog/StateChangelogStorage.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/state/changelog/StateChangelogStorage.java
@@ -20,6 +20,7 @@ package org.apache.flink.runtime.state.changelog;
 
 import org.apache.flink.annotation.Internal;
 import org.apache.flink.runtime.state.KeyGroupRange;
+import org.apache.flink.runtime.state.track.TaskStateRegistry;
 
 /**
  * A storage for changelog. Could produce {@link StateChangelogHandleReader} and {@link
@@ -35,4 +36,6 @@ public interface StateChangelogStorage<Handle extends ChangelogStateHandle> exte
 
     @Override
     default void close() throws Exception {}
+
+    TaskStateRegistry getStateChangeUsageTracker(String operatorIdentifier);
 }

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/state/changelog/StateChangelogStorageFactory.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/state/changelog/StateChangelogStorageFactory.java
@@ -22,6 +22,7 @@ import org.apache.flink.annotation.Internal;
 import org.apache.flink.configuration.Configuration;
 
 import java.io.IOException;
+import java.util.concurrent.Executor;
 
 /**
  * A factory for {@link StateChangelogStorage}. Please use {@link StateChangelogStorageLoader} to
@@ -33,5 +34,6 @@ public interface StateChangelogStorageFactory {
     String getIdentifier();
 
     /** Create the storage based on a configuration. */
-    StateChangelogStorage<?> createStorage(Configuration configuration) throws IOException;
+    StateChangelogStorage<?> createStorage(Configuration configuration, Executor ioExecutor)
+            throws IOException;
 }

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/state/changelog/StateChangelogStorageLoader.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/state/changelog/StateChangelogStorageLoader.java
@@ -31,6 +31,7 @@ import java.io.IOException;
 import java.util.HashMap;
 import java.util.Iterator;
 import java.util.ServiceLoader;
+import java.util.concurrent.Executor;
 
 import static org.apache.flink.shaded.guava30.com.google.common.collect.Iterators.concat;
 
@@ -82,7 +83,8 @@ public class StateChangelogStorageLoader {
     }
 
     @Nullable
-    public static StateChangelogStorage<?> load(Configuration configuration) throws IOException {
+    public static StateChangelogStorage<?> load(Configuration configuration, Executor ioExecutor)
+            throws IOException {
         final String identifier =
                 configuration
                         .getString(CheckpointingOptions.STATE_CHANGE_LOG_STORAGE)
@@ -94,7 +96,7 @@ public class StateChangelogStorageLoader {
             return null;
         } else {
             LOG.info("Creating a changelog storage with name '{}'.", identifier);
-            return factory.createStorage(configuration);
+            return factory.createStorage(configuration, ioExecutor);
         }
     }
 }

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/state/changelog/inmemory/InMemoryStateChangelogStorage.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/state/changelog/inmemory/InMemoryStateChangelogStorage.java
@@ -20,6 +20,7 @@ package org.apache.flink.runtime.state.changelog.inmemory;
 import org.apache.flink.runtime.state.KeyGroupRange;
 import org.apache.flink.runtime.state.changelog.StateChangelogHandleReader;
 import org.apache.flink.runtime.state.changelog.StateChangelogStorage;
+import org.apache.flink.runtime.state.track.TaskStateRegistry;
 import org.apache.flink.util.CloseableIterator;
 
 /** An in-memory (non-production) implementation of {@link StateChangelogStorage}. */
@@ -35,5 +36,10 @@ public class InMemoryStateChangelogStorage
     @Override
     public StateChangelogHandleReader<InMemoryChangelogStateHandle> createReader() {
         return handle -> CloseableIterator.fromList(handle.getChanges(), change -> {});
+    }
+
+    @Override
+    public TaskStateRegistry getStateChangeUsageTracker(String operatorIdentifier) {
+        return TaskStateRegistry.NO_OP;
     }
 }

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/state/changelog/inmemory/InMemoryStateChangelogStorageFactory.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/state/changelog/inmemory/InMemoryStateChangelogStorageFactory.java
@@ -21,6 +21,8 @@ import org.apache.flink.configuration.Configuration;
 import org.apache.flink.runtime.state.changelog.StateChangelogStorage;
 import org.apache.flink.runtime.state.changelog.StateChangelogStorageFactory;
 
+import java.util.concurrent.Executor;
+
 /** An {@link StateChangelogStorageFactory} for creating {@link InMemoryStateChangelogStorage}. */
 public class InMemoryStateChangelogStorageFactory implements StateChangelogStorageFactory {
 
@@ -32,7 +34,8 @@ public class InMemoryStateChangelogStorageFactory implements StateChangelogStora
     }
 
     @Override
-    public StateChangelogStorage<?> createStorage(Configuration configuration) {
+    public StateChangelogStorage<?> createStorage(
+            Configuration configuration, Executor ioExecutor) {
         return new InMemoryStateChangelogStorage();
     }
 }

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/state/heap/HeapKeyedStateBackend.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/state/heap/HeapKeyedStateBackend.java
@@ -318,7 +318,7 @@ public class HeapKeyedStateBackend<K> extends AbstractKeyedStateBackend<K> {
 
     @Nonnull
     @Override
-    public SavepointResources<K> savepoint() {
+    public SavepointResources<K> savepoint(long checkpointId) {
 
         HeapSnapshotResources<K> snapshotResources =
                 HeapSnapshotResources.create(

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/state/track/BackendStateRegistry.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/state/track/BackendStateRegistry.java
@@ -1,0 +1,226 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.flink.runtime.state.track;
+
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import javax.annotation.Nullable;
+import javax.annotation.concurrent.NotThreadSafe;
+
+import java.util.ArrayList;
+import java.util.Collection;
+import java.util.HashMap;
+import java.util.HashSet;
+import java.util.List;
+import java.util.Map;
+import java.util.NavigableMap;
+import java.util.NavigableSet;
+import java.util.Set;
+import java.util.TreeMap;
+import java.util.TreeSet;
+
+import static org.apache.flink.util.Preconditions.checkState;
+
+/**
+ * A per-StateBackend StateRegistry. Tracks the usage of {@link StateEntry} by backend and its
+ * snapshots. {@link StateEntry} will discard its state once all such registries are not using it.
+ *
+ * <p>Explicitly aware of checkpointing so that tracking of associations between checkpoints and
+ * snapshots can be reused (instead of implementing in each backend).
+ *
+ * <h1>Tracking lifecycle</h1>
+ *
+ * <ol>
+ *   <li>Upon {@link #stateUsed(Collection) registration}, {@link StateEntry} is added to {@link
+ *       #currentState}
+ *   <li>Once {@link #stateNotUsed(Set) not actively used} (usually after materialization), it is
+ *       moved to {@link #previousStatesByHighestUsedCheckpoint} (if used by checkpoints; otherwise
+ *       this step is skipped). At this point, <strong>any pending checkpoint is considered as
+ *       potentially using the state</strong>
+ *   <li>Once all checkpoint potentially using it are {@link #checkpointSubsumed(long) subsumed},
+ *       tracking stops (i.e. it is removed from {@link #previousStatesByHighestUsedCheckpoint}).
+ * </ol>
+ *
+ * On each step, the entry is notified about the event. When tracking stops it might decide to
+ * discard the state.
+ *
+ * <h1>Checkpoint lifecycle</h1>
+ *
+ * Upon {@link #checkpointStarting(long) start}, every checkpoint first updates {@link
+ * #lastStartedCheckpoint} and is added {@link #notSubsumedCheckpoints}.
+ *
+ * <h1>Thread safety</h1>
+ *
+ * The class is not thread-safe. Furthermore, it uses {@link StateEntry} potentially shared with
+ * other instances used by other threads - so external synchronization required.
+ *
+ * @param <K> type of state identifier
+ */
+@NotThreadSafe
+class BackendStateRegistry<K> {
+    private final Logger LOG = LoggerFactory.getLogger(BackendStateRegistry.class);
+
+    private final String backendId;
+
+    private long lastStartedCheckpoint = -1L;
+    private final NavigableSet<Long> notSubsumedCheckpoints = new TreeSet<>();
+
+    private long lastSnapshottedCheckpoint = -1L;
+    @Nullable private Set<K> lastSnapshot = null;
+
+    private final Map<K, StateEntry<K>> currentState = new HashMap<>();
+    private final NavigableMap<Long, List<StateEntry<K>>> previousStatesByHighestUsedCheckpoint =
+            new TreeMap<>();
+
+    public BackendStateRegistry(String backendId) {
+        this.backendId = backendId;
+    }
+
+    public void stateUsed(Collection<StateEntry<K>> entries) {
+        LOG.debug("State used, backend: {}, state: {}", backendId, entries);
+        entries.forEach(e -> currentState.put(e.getKey(), e));
+    }
+
+    public void stateNotUsed(Set<K> stateIDs) {
+        stateNotUsedInternal(stateIDs, notSubsumedCheckpoints);
+    }
+
+    private void stateNotUsedInternal(Set<K> stateIDs, NavigableSet<Long> pendingCheckpoints) {
+        for (K key : stateIDs) {
+            StateEntry<K> entry = currentState.remove(key);
+            if (entry != null) {
+                entry.notActivelyUsed(backendId, new TreeSet<>(pendingCheckpoints));
+                trackNotActivelyUsedEntry(entry);
+            }
+        }
+    }
+
+    private void trackNotActivelyUsedEntry(StateEntry<K> entry) {
+        Long highestUsingCheckpoint = entry.getHighestUsingCheckpoint(backendId);
+        if (highestUsingCheckpoint == null) {
+            LOG.debug("State entry not used, backend: {}, state: {}", backendId, entry);
+        } else {
+            previousStatesByHighestUsedCheckpoint
+                    .computeIfAbsent(highestUsingCheckpoint, ign -> new ArrayList<>())
+                    .add(entry);
+            LOG.debug(
+                    "State entry not used but {} pending checkpoints exist, backend: {}",
+                    notSubsumedCheckpoints.size(),
+                    backendId);
+        }
+    }
+
+    public void checkpointStarting(long checkpointId) {
+        LOG.debug("Checkpoint started, backend: {}, checkpoint: {}", backendId, checkpointId);
+        checkState(
+                lastStartedCheckpoint < checkpointId,
+                "Out of order checkpoint: %s, backend: %s, previous: %s",
+                checkpointId,
+                backendId,
+                lastStartedCheckpoint);
+        notSubsumedCheckpoints.add(checkpointId);
+        lastStartedCheckpoint = checkpointId;
+    }
+
+    public void stateSnapshotCreated(long checkpointId, Set<K> newStateKeys) {
+        LOG.debug(
+                "Checkpoint performed, backend: {}, checkpoint: {}, state objects: {}",
+                backendId,
+                checkpointId,
+                newStateKeys);
+        if (notSubsumedCheckpoints.contains(checkpointId)) {
+            // note that we don't remove this checkpoint from pending for now - wait
+            // until subsumed
+            snapshotSentForCheckpoint(checkpointId, newStateKeys);
+        } else {
+            throw new IllegalStateException(
+                    String.format("Unknown checkpoint %d for backend %s", checkpointId, backendId));
+        }
+    }
+
+    private void snapshotSentForCheckpoint(long checkpointId, Set<K> newStateKeys) {
+        if (lastSnapshottedCheckpoint < checkpointId) {
+            if (lastSnapshot != null) {
+                lastSnapshot.removeAll(newStateKeys);
+                stateNotUsedInternal(
+                        lastSnapshot, notSubsumedCheckpoints.headSet(checkpointId, false));
+            }
+            lastSnapshot = newStateKeys;
+            lastSnapshottedCheckpoint = checkpointId;
+        } else if (lastSnapshottedCheckpoint > checkpointId) {
+            LOG.warn(
+                    "Out of order snapshot (ignoring), checkpointId: {}, latest: {}, backendId: {}",
+                    checkpointId,
+                    lastSnapshottedCheckpoint,
+                    backendId);
+        } else {
+            throw new IllegalStateException(
+                    String.format(
+                            "Backend %s reported checkpoint %d twice", backendId, checkpointId));
+        }
+    }
+
+    public void checkpointSubsumed(long checkpointId) {
+        LOG.debug("Checkpoint subsumed, backend: {}, checkpoint: {}", backendId, checkpointId);
+        notSubsumedCheckpoints.headSet(checkpointId, true).clear();
+        Collection<List<StateEntry<K>>> subsumed =
+                previousStatesByHighestUsedCheckpoint.headMap(checkpointId, true).values();
+        for (List<StateEntry<K>> entries : subsumed) {
+            for (StateEntry<K> entry : entries) {
+                entry.checkpointSubsumed(backendId, checkpointId);
+            }
+        }
+        subsumed.clear();
+    }
+
+    public void checkpointAborted(long checkpointId) {
+        if (notSubsumedCheckpoints.remove(checkpointId)) {
+            LOG.debug("Checkpoint aborted, backend: {}, checkpoint: {}", backendId, checkpointId);
+            for (List<StateEntry<K>> v :
+                    previousStatesByHighestUsedCheckpoint.headMap(checkpointId, true).values()) {
+                for (StateEntry<K> entry : v) {
+                    entry.checkpointAborted(backendId, checkpointId);
+                }
+            }
+        } else {
+            LOG.debug(
+                    "Unknown checkpoint aborted, backend: {}, checkpoint: {} (probably subsumed)",
+                    backendId,
+                    checkpointId);
+        }
+    }
+
+    public void close() {
+        LOG.debug("Close, backendId: {}", backendId);
+        // State of completed checkpoints is discarded on JM if needed (e.g. job cancellation). All
+        // pending checkpoints in TM are considered completed because the completion notification
+        // might be missing (the only exception is currently stop-with-savepoint when
+        // it's guaranteed to be received). So we only need to discard the state not used in any
+        // checkpoints:
+        stateNotUsed(new HashSet<>(currentState.keySet()));
+        notSubsumedCheckpoints.clear();
+        currentState.clear();
+        previousStatesByHighestUsedCheckpoint.clear();
+        lastSnapshot = null;
+    }
+
+    long getLastSnapshottedCheckpoint() {
+        return lastSnapshottedCheckpoint;
+    }
+}

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/state/track/PrivateTaskStateRegistry.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/state/track/PrivateTaskStateRegistry.java
@@ -1,0 +1,134 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.flink.runtime.state.track;
+
+import org.apache.flink.annotation.Internal;
+import org.apache.flink.runtime.state.StateObject;
+import org.apache.flink.runtime.state.track.SharedTaskStateRegistry.StateObjectIDExtractor;
+
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import javax.annotation.concurrent.NotThreadSafe;
+
+import java.util.ArrayList;
+import java.util.Collection;
+import java.util.HashSet;
+import java.util.List;
+import java.util.Map;
+import java.util.Set;
+import java.util.concurrent.Executor;
+
+import static java.util.Collections.singleton;
+import static org.apache.flink.runtime.state.track.SharedTaskStateRegistry.StateObjectIDExtractor.IDENTITY;
+import static org.apache.flink.util.Preconditions.checkArgument;
+import static org.apache.flink.util.Preconditions.checkNotNull;
+
+/**
+ * A thin wrapper around {@link BackendStateRegistry} to provide single-backend {@link
+ * TaskStateRegistry} implementation.
+ *
+ * @param <K> state object ID type (for {@link #distributedState}).
+ */
+@NotThreadSafe
+@Internal
+class PrivateTaskStateRegistry<K> implements TaskStateRegistry {
+    private static final Logger LOG = LoggerFactory.getLogger(PrivateTaskStateRegistry.class);
+
+    private final TaskStateCleaner cleaner;
+    private final StateObjectIDExtractor<K> keyExtractor;
+
+    private final Set<K> distributedState = new HashSet<>();
+    private final String backendId;
+    private final BackendStateRegistry<K> registry;
+
+    PrivateTaskStateRegistry(
+            String backendId, TaskStateCleaner cleaner, StateObjectIDExtractor<K> keyExtractor) {
+        checkArgument(backendId != null && !backendId.isEmpty());
+        this.cleaner = checkNotNull(cleaner);
+        this.keyExtractor = checkNotNull(keyExtractor);
+        this.backendId = backendId;
+        this.registry = new BackendStateRegistry<>(backendId);
+    }
+
+    @Override
+    public void stateUsed(Collection<StateObject> states) {
+        stateUsedInternal(states);
+    }
+
+    @Override
+    public void stateNotUsed(StateObject state) {
+        registry.stateNotUsed(keyExtractor.apply(state).keySet());
+    }
+
+    @Override
+    public void checkpointStarting(long checkpointId) {
+        registry.checkpointStarting(checkpointId);
+    }
+
+    @Override
+    public void stateSnapshotCreated(StateObject state, long checkpointId) {
+        if (checkpointId > registry.getLastSnapshottedCheckpoint()) {
+            stateUsedInternal(singleton(state));
+            registry.stateSnapshotCreated(checkpointId, keyExtractor.apply(state).keySet());
+        }
+    }
+
+    @Override
+    public void checkpointSubsumed(long checkpointId) {
+        registry.checkpointSubsumed(checkpointId);
+    }
+
+    @Override
+    public void checkpointAborted(long checkpointId) {
+        registry.checkpointAborted(checkpointId);
+    }
+
+    @Override
+    public void close() throws Exception {
+        LOG.debug("Close, backendId: {}", backendId);
+        distributedState.clear();
+        registry.close();
+        cleaner.close();
+    }
+
+    // todo: move to interface? (when rebased)
+    public void addDistributedState(Set<K> distributedState) {
+        this.distributedState.addAll(distributedState);
+    }
+
+    public static PrivateTaskStateRegistry<?> create(String backendId, Executor ioExecutor) {
+        /* todo: replace IDENTITY with a real implementation after FLINK-23342 merged */
+        return new PrivateTaskStateRegistry<>(
+                backendId, TaskStateCleaner.create(ioExecutor), IDENTITY);
+    }
+
+    private void stateUsedInternal(Collection<StateObject> states) {
+        List<StateEntry<K>> entries = new ArrayList<>();
+        for (StateObject stateObject : states) {
+            for (Map.Entry<K, StateObject> entry : keyExtractor.apply(stateObject).entrySet()) {
+                K stateKey = entry.getKey();
+                StateObject state = entry.getValue();
+                if (!distributedState.contains(stateKey)) {
+                    entries.add(new StateEntry<>(stateKey, state, 1, cleaner, unused -> {}));
+                }
+            }
+        }
+        registry.stateUsed(entries);
+    }
+}

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/state/track/SharedTaskStateRegistry.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/state/track/SharedTaskStateRegistry.java
@@ -1,0 +1,238 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.flink.runtime.state.track;
+
+import org.apache.flink.annotation.Internal;
+import org.apache.flink.runtime.state.StateObject;
+import org.apache.flink.util.function.ThrowingConsumer;
+
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import javax.annotation.concurrent.GuardedBy;
+import javax.annotation.concurrent.ThreadSafe;
+
+import java.util.ArrayList;
+import java.util.Collection;
+import java.util.HashMap;
+import java.util.HashSet;
+import java.util.IdentityHashMap;
+import java.util.List;
+import java.util.Map;
+import java.util.NoSuchElementException;
+import java.util.Set;
+import java.util.concurrent.Executor;
+import java.util.function.Function;
+
+import static java.lang.Thread.holdsLock;
+import static java.util.Collections.singleton;
+import static org.apache.flink.runtime.state.track.SharedTaskStateRegistry.StateObjectIDExtractor.IDENTITY;
+import static org.apache.flink.util.Preconditions.checkArgument;
+import static org.apache.flink.util.Preconditions.checkNotNull;
+import static org.apache.flink.util.Preconditions.checkState;
+
+/** @param <K> state object ID type (for {@link #distributedState}). */
+@ThreadSafe
+@Internal
+public class SharedTaskStateRegistry<K> implements AutoCloseable {
+    private static final Logger LOG = LoggerFactory.getLogger(SharedTaskStateRegistry.class);
+
+    private final TaskStateCleaner cleaner;
+    private final StateObjectIDExtractor<K> keyExtractor;
+
+    // Synchronization is to prevent issues inside backend registries, not just Map modification.
+    // E.g. backends may share State Entries and otherwise, would update them concurrently.
+    @GuardedBy("lock")
+    private final Map<String, BackendStateRegistry<K>> backendStateRegistries = new HashMap<>();
+
+    @GuardedBy("lock")
+    private final Set<K> usedState = new HashSet<>();
+
+    // Synchronization is just to prevent concurrent Map modification issues.
+    @GuardedBy("lock")
+    private final Set<K> distributedState = new HashSet<>();
+
+    private final Object lock = new Object();
+
+    SharedTaskStateRegistry(TaskStateCleaner cleaner, StateObjectIDExtractor<K> keyExtractor) {
+        this.cleaner = checkNotNull(cleaner);
+        this.keyExtractor = checkNotNull(keyExtractor);
+    }
+
+    public void stateUsed(Set<String> backendIds, Collection<StateObject> states) {
+        synchronized (lock) {
+            stateUsedInternal(backendIds, states);
+        }
+    }
+
+    private void stateUsedInternal(Set<String> backendIds, Collection<StateObject> states) {
+        checkState(holdsLock(lock));
+        List<StateEntry<K>> entries = toStateEntries(states, backendIds.size());
+        if (!entries.isEmpty()) {
+            for (StateEntry<K> e : entries) {
+                usedState.add(e.getKey());
+            }
+            for (String backendId : backendIds) {
+                withRegistry(backendId, registry -> registry.stateUsed(entries));
+            }
+        }
+    }
+
+    private List<StateEntry<K>> toStateEntries(Collection<StateObject> states, int numBackends) {
+        checkState(holdsLock(lock));
+        List<StateEntry<K>> entries = new ArrayList<>();
+        for (StateObject stateObject : states) {
+            for (Map.Entry<K, StateObject> entry : keyExtractor.apply(stateObject).entrySet()) {
+                K stateKey = entry.getKey();
+                StateObject state = entry.getValue();
+                if (shouldTrack(stateKey)) {
+                    entries.add(
+                            new StateEntry<>(
+                                    stateKey, state, numBackends, cleaner, usedState::remove));
+                }
+            }
+        }
+        return entries;
+    }
+
+    private boolean shouldTrack(K k) {
+        return !usedState.contains(k) && !distributedState.contains(k);
+    }
+
+    void stateNotUsed(String backendId, StateObject state) {
+        Set<K> keys = keyExtractor.apply(state).keySet();
+        if (!keys.isEmpty()) {
+            withRegistry(backendId, registry -> registry.stateNotUsed(keys));
+        }
+    }
+
+    void checkpointStarting(String backendId, long checkpointId) {
+        withRegistry(backendId, registry -> registry.checkpointStarting(checkpointId));
+    }
+
+    void stateSnapshotCreated(String backendId, StateObject state, long checkpointId) {
+        withRegistry(
+                backendId,
+                registry -> {
+                    if (checkpointId > registry.getLastSnapshottedCheckpoint()) {
+                        stateUsedInternal(singleton(backendId), singleton(state));
+                        registry.stateSnapshotCreated(
+                                checkpointId, keyExtractor.apply(state).keySet());
+                    }
+                });
+    }
+
+    void checkpointSubsumed(String backendId, long checkpointId) {
+        withRegistry(backendId, registry -> registry.checkpointSubsumed(checkpointId));
+    }
+
+    void checkpointAborted(String backendId, long checkpointId) {
+        withRegistry(backendId, registry -> registry.checkpointAborted(checkpointId));
+    }
+
+    private void closeForBackend(String backendId) {
+        withRegistry(backendId, BackendStateRegistry::close);
+        backendStateRegistries.remove(backendId);
+    }
+
+    public void close() throws Exception {
+        LOG.debug("Close, num backendStateRegistries: {}", backendStateRegistries.size());
+        synchronized (lock) {
+            backendStateRegistries.values().forEach(BackendStateRegistry::close);
+            backendStateRegistries.clear();
+            distributedState.clear();
+        }
+        cleaner.close();
+    }
+
+    public TaskStateRegistry forBackend(String backendId) {
+        LOG.debug("Create TaskStateRegistry for backend {}", backendId);
+        checkArgument(!backendStateRegistries.containsKey(backendId));
+        return new TaskStateRegistry() {
+            @Override
+            public void stateUsed(Collection<StateObject> states) {
+                SharedTaskStateRegistry.this.stateUsed(singleton(backendId), states);
+            }
+
+            @Override
+            public void stateNotUsed(StateObject state) {
+                SharedTaskStateRegistry.this.stateNotUsed(backendId, state);
+            }
+
+            @Override
+            public void checkpointStarting(long checkpointId) {
+                SharedTaskStateRegistry.this.checkpointStarting(backendId, checkpointId);
+            }
+
+            @Override
+            public void stateSnapshotCreated(StateObject state, long checkpointId)
+                    throws NoSuchElementException, IllegalStateException {
+                SharedTaskStateRegistry.this.stateSnapshotCreated(backendId, state, checkpointId);
+            }
+
+            @Override
+            public void checkpointAborted(long checkpointId) {
+                SharedTaskStateRegistry.this.checkpointAborted(backendId, checkpointId);
+            }
+
+            @Override
+            public void checkpointSubsumed(long checkpointId) {
+                SharedTaskStateRegistry.this.checkpointSubsumed(backendId, checkpointId);
+            }
+
+            @Override
+            public void close() {
+                SharedTaskStateRegistry.this.closeForBackend(backendId);
+            }
+        };
+    }
+
+    // todo: move to interface? (when rebased)
+    public void addDistributedState(Set<K> distributedState) {
+        synchronized (lock) {
+            this.distributedState.addAll(distributedState);
+        }
+    }
+
+    private <E extends RuntimeException> void withRegistry(
+            String backendId, ThrowingConsumer<BackendStateRegistry<K>, E> action) throws E {
+        checkArgument(backendId != null && !backendId.isEmpty());
+        synchronized (lock) {
+            BackendStateRegistry<K> backendStateRegistry =
+                    backendStateRegistries.computeIfAbsent(
+                            backendId, ign -> new BackendStateRegistry<>(backendId));
+            action.accept(backendStateRegistry);
+        }
+    }
+
+    /** The returned map should be modifiable. */
+    @ThreadSafe
+    public interface StateObjectIDExtractor<T> extends Function<StateObject, Map<T, StateObject>> {
+        StateObjectIDExtractor<StateObject> IDENTITY =
+                stateObject -> {
+                    Map<StateObject, StateObject> map = new IdentityHashMap<>();
+                    map.put(stateObject, stateObject);
+                    return map;
+                };
+    }
+
+    public static SharedTaskStateRegistry<?> create(Executor ioExecutor) {
+        /* todo: replace IDENTITY with a real implementation after FLINK-23342 merged */
+        return new SharedTaskStateRegistry<>(TaskStateCleaner.create(ioExecutor), IDENTITY);
+    }
+}

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/state/track/StateEntry.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/state/track/StateEntry.java
@@ -1,0 +1,188 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.flink.runtime.state.track;
+
+import org.apache.flink.runtime.state.StateObject;
+
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import javax.annotation.Nullable;
+import javax.annotation.concurrent.NotThreadSafe;
+
+import java.util.HashMap;
+import java.util.Map;
+import java.util.NavigableSet;
+import java.util.NoSuchElementException;
+import java.util.Set;
+import java.util.function.Consumer;
+
+import static org.apache.flink.util.Preconditions.checkArgument;
+import static org.apache.flink.util.Preconditions.checkNotNull;
+import static org.apache.flink.util.Preconditions.checkState;
+
+/**
+ * StateEntry holds the tracking information about the state to eventually discard it.
+ *
+ * <p>Lifecycle
+ *
+ * <ol>
+ *   <li>Initially, the state is in active use, potentially by multiple state backends, as reflected
+ *       by {@link #activelyUsingBackends}.
+ *   <li>Once not actively used by a backend, the above counter is decremented and {@link
+ *       #pendingCheckpointsByBackend} are updated
+ *   <li>Each backend notifies it about the corresponding checkpoint updates (shrinking the above
+ *       maps)
+ *   <li>{@link #discardIfNotUsed()} Once no backend is actively using this entry, and no checkpoint
+ *       is using it, the state is discarded
+ * </ol>
+ *
+ * One can think of {@link #pendingCheckpointsByBackend} and {@link #activelyUsingBackends} as
+ * potential usages in the past and in the future respectively.
+ *
+ * @param <K> type of state identifier
+ */
+@NotThreadSafe
+class StateEntry<K> {
+    private static final Logger LOG = LoggerFactory.getLogger(StateEntry.class);
+
+    private final K key;
+    private final StateObject state;
+    private final TaskStateCleaner cleaner;
+    private final Consumer<K> discardCallback;
+
+    /** Number of state backends that may use this state in future checkpoints. */
+    private int activelyUsingBackends;
+
+    /**
+     * Not yet subsumed checkpoints by backend potentially using this {@link #state}. Entries
+     * (checkpoint IDs) for a backend are added once it stops using it and are removed on
+     * subsumption and {@link #checkpointAborted(String, long) abortion}. Once it's empty and {@link
+     * #activelyUsingBackends} is zero, {@link #state} can be discarded.
+     *
+     * <p>INVARIANT: does not contain empty sets or nulls.
+     *
+     * <p>Set instead of a single highest checkpoint ID is used to handle abortions; NavigableSet is
+     * used to get this highest ID (a number would suffice at the cost of readability).
+     */
+    private final Map<String, NavigableSet<Long>> pendingCheckpointsByBackend = new HashMap<>();
+
+    private boolean discarded = false;
+
+    StateEntry(
+            K key,
+            StateObject state,
+            int activelyUsingBackends,
+            TaskStateCleaner cleaner,
+            Consumer<K> discardCallback) {
+        checkArgument(activelyUsingBackends > 0);
+        this.key = checkNotNull(key);
+        this.state = checkNotNull(state);
+        this.cleaner = checkNotNull(cleaner);
+        this.activelyUsingBackends = activelyUsingBackends;
+        this.discardCallback = checkNotNull(discardCallback);
+    }
+
+    /**
+     * Mark this entry as NOT used for future checkpoints by the given backend. Older checkpoints
+     * may still use it.
+     *
+     * @param usingCheckpoints checkpoints that may be using this state - mutable for abortion
+     */
+    public void notActivelyUsed(String backendId, NavigableSet<Long> usingCheckpoints) {
+        LOG.trace(
+                "Update state entry usage, backendId: {}, usingCheckpoints: {}",
+                backendId,
+                usingCheckpoints);
+        checkState(!discarded && --activelyUsingBackends >= 0);
+        putOnceIfNonEmpty(pendingCheckpointsByBackend, usingCheckpoints, backendId);
+        discardIfNotUsed();
+    }
+
+    private void discard() {
+        if (discarded) {
+            LOG.trace("Not discarding state entry - already discarded: {}", this);
+            return;
+        }
+        discarded = true;
+        discardCallback.accept(key);
+        LOG.trace("Discarding state entry: {}", this);
+        cleaner.discardAsync(state);
+    }
+
+    public void checkpointSubsumed(String backendId, long checkpointId) {
+        // It's enough to simply clear remainingCheckpoints for this backend because it should
+        // already track the highest checkpoint. But we'll check the remainingCheckpoints explicitly
+        // - for robustness and clarity
+        NavigableSet<Long> remainingCheckpoints = pendingCheckpointsByBackend.get(backendId);
+        if (remainingCheckpoints != null
+                && !remainingCheckpoints.isEmpty()
+                && remainingCheckpoints.last() <= checkpointId) {
+            pendingCheckpointsByBackend.remove(backendId);
+            discardIfNotUsed();
+        }
+    }
+
+    public void checkpointAborted(String backendId, long checkpointId) {
+        Set<Long> remaining = pendingCheckpointsByBackend.get(backendId);
+        if (remaining != null) {
+            remaining.remove(checkpointId);
+            discardIfNotUsed();
+        }
+    }
+
+    private void discardIfNotUsed() {
+        if (activelyUsingBackends == 0 && pendingCheckpointsByBackend.isEmpty()) {
+            discard();
+        }
+    }
+
+    @Nullable
+    public Long getHighestUsingCheckpoint(String backendId) throws NoSuchElementException {
+        return last(pendingCheckpointsByBackend.get(backendId));
+    }
+
+    public K getKey() {
+        return key;
+    }
+
+    @Override
+    public String toString() {
+        return String.format(
+                "key=%s, state=%s, discarded=%s, backendCount=%d",
+                key, state, discarded, activelyUsingBackends);
+    }
+
+    private void putOnceIfNonEmpty(
+            Map<String, NavigableSet<Long>> target, NavigableSet<Long> set, String backendId) {
+        if (set != null && !set.isEmpty()) {
+            NavigableSet<Long> prev = target.put(backendId, set);
+            if (prev != null) {
+                throw new RuntimeException(
+                        String.format(
+                                "Backend %s has already reported no active use of %s",
+                                backendId, this));
+            }
+        }
+    }
+
+    @Nullable
+    private static Long last(NavigableSet<Long> longs) {
+        return longs == null || longs.isEmpty() ? null : longs.last();
+    }
+}

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/state/track/TaskStateCleaner.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/state/track/TaskStateCleaner.java
@@ -1,0 +1,43 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.flink.runtime.state.track;
+
+import org.apache.flink.annotation.Internal;
+import org.apache.flink.runtime.state.StateObject;
+
+import java.util.concurrent.Executor;
+
+@Internal
+interface TaskStateCleaner extends AutoCloseable {
+    /**
+     * Recursively and asynchronously discard the given object. May or may not exert back-pressure.
+     */
+    void discardAsync(StateObject state);
+
+    TaskStateCleaner NO_OP =
+            new TaskStateCleaner() {
+                @Override
+                public void discardAsync(StateObject state) {}
+
+                @Override
+                public void close() {}
+            };
+
+    static TaskStateCleaner create(Executor executor) {
+        return new TaskStateCleanerImpl(executor);
+    }
+}

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/state/track/TaskStateCleanerImpl.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/state/track/TaskStateCleanerImpl.java
@@ -1,0 +1,49 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.flink.runtime.state.track;
+
+import org.apache.flink.runtime.state.StateObject;
+
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import java.util.concurrent.Executor;
+
+class TaskStateCleanerImpl implements TaskStateCleaner {
+    private static final Logger LOG = LoggerFactory.getLogger(TaskStateCleanerImpl.class);
+    private final Executor executor;
+
+    public TaskStateCleanerImpl(Executor executor) {
+        this.executor = executor;
+    }
+
+    @Override
+    public void discardAsync(StateObject state) {
+        executor.execute(
+                () -> {
+                    try {
+                        state.discardState();
+                    } catch (Exception e) {
+                        LOG.error("Unable do discard state: {}", state, e);
+                    }
+                });
+    }
+
+    @Override
+    public void close() {}
+}

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/state/track/TaskStateRegistry.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/state/track/TaskStateRegistry.java
@@ -1,0 +1,212 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.flink.runtime.state.track;
+
+import org.apache.flink.annotation.Internal;
+import org.apache.flink.runtime.state.StateObject;
+
+import java.util.Collection;
+import java.util.NoSuchElementException;
+
+/**
+ * A component responsible for managing state that is not shared across different TMs (i.e. not
+ * managed by JM). Managing state here means {@link StateObject#discardState() deletion} once not
+ * used.
+ *
+ * <p>Must not be shared between different jobs.
+ *
+ * <p>Explicitly aware of checkpointing so that tracking of associations between checkpoints and
+ * snapshots can be reused (instead of implementing in each backend).
+ *
+ * <h1>State sharing inside TM</h1>
+ *
+ * <p>Inside each TM, the registry <strong>must</strong> be shared across state backends on the same
+ * level as their state is, or higher. For example, if all state backends of operators of the same
+ * job in TM use the same file on DFS then they <strong>must</strong> share the same registry. OTH,
+ * if nothing is shared then the Registry can be per-backend (or shared).
+ *
+ * <h1>State sharing across TMs</h1>
+ *
+ * If a rescaling operation (or recovery with state sharing inside TM) results in some state being
+ * shared by multiple TMs (or TaskStateRegistries), such relevant shared states must be communicated
+ * to the registry so that it can ignore them. Implementations <strong>must</strong> ignore such
+ * shared states.
+ *
+ * <h1>State identity</h1>
+ *
+ * For the purpose of matching state objects from the different calls (and from previous runs),
+ * state can be identified by {@link StateObjectID}. A collection of such IDs can be obtained from
+ * the {@link StateObject} by recursively traversing it. This is implementation specific; however,
+ * it must be consistent across attempts, registries and backends.
+ *
+ * <h1>Basic usage</h1>
+ *
+ * <ol>
+ *   <li>{@link #stateUsed(Collection) register state usage}
+ *   <li>{@link #checkpointStarting(long) start checkpoint 1}
+ *   <li>{@link #stateNotUsed(StateObject) unregister state usage}
+ *   <li>{@link #checkpointStarting(long) start checkpoint 2} (state is not used as it was
+ *       unregistered)
+ *   <li>{@link #checkpointSubsumed(long) subsume checkpoint 1} (state can be discarded)
+ * </ol>
+ *
+ * <p>It is not required to register state usage strictly before starting a checkpoint (mostly
+ * because it is usually not known which state will be included into the snapshot when the
+ * checkpoint starts).
+ *
+ * <p>Usually, state registration and un-registration is done automatically via {@link
+ * #stateSnapshotCreated(StateObject, long)}.
+ *
+ * <h1>Consistency and dangling state</h1>
+ *
+ * There are several factors that can impact consistency: incremental checkpoints; out-of-order
+ * calls from a single backend; multiple backends; multiple concurrent checkpoint. Potential issues
+ * include:
+ *
+ * <ul>
+ *   <li>Incremental checkpoint subsumption: if some state is shared across checkpoints then
+ *       discarding an older checkpoint might invalidate subsequent checkpoints
+ *   <li>Out-of-order checkpoint completion by a single backend: if a reported snapshot doesn't
+ *       include some state anymore then that state can be discarded. Any <strong>earlier</strong>
+ *       snapshots reported <strong>later</strong> still using this state later will be invalid
+ *   <li>Out-of-order state (un)registration by multiple backends: if some state is shared then some
+ *       backend might register and unregister its usage before the other starts using it. The
+ *       other's backend snapshots with this state may be invalid.
+ *   <li>With RETAIN_ON_CANCELLATION policy, last num-retained checkpoints shouldn't be discarded
+ *       even if the job is cancelled (NOT IMPLEMENTED)
+ * </ul>
+ *
+ * To allow implementations to address the above issues, client MUST:
+ *
+ * <ul>
+ *   <li>list all the backends {@link #stateUsed(Collection) using some state} at once
+ *   <li>list all state objects {@link #stateSnapshotCreated(StateObject, long) used in a snapshot}
+ *       at once
+ *   <li>notify that the checkpoint is {@link #checkpointStarting(long) started} before {@link
+ *       #stateNotUsed(StateObject) unregistering} any state this checkpoint might be using (if a
+ *       state was unregistered after a checkpoint was started it can still be included into the
+ *       snapshot)
+ *   <li>in particular, report the {@link #stateSnapshotCreated(StateObject, long)} snapshot} for a
+ *       checkpoint only after notifying about its start
+ *   <li>not {@link #checkpointStarting(long) start any checkpoint} that may have been {@link
+ *       #checkpointSubsumed(long) subsumed}
+ *   <li>for checkpoints, call either {@link #checkpointSubsumed(long) subsumed} or {@link
+ *       #checkpointAborted(long) aborted} (otherwise, state won't be deleted until the job is
+ *       terminated)
+ * </ul>
+ *
+ * <h1>Thread safety</h1>
+ *
+ * Thread safety depends on the implementation. An implementation shared across different tasks (in
+ * a single TM) MUST be thread-safe.
+ *
+ * <h1>Asynchronous discarding</h1>
+ *
+ * Production implementations might choose to discard the state asynchronously; however, they might
+ * choose to block the caller if they don't keep up.
+ */
+@Internal
+public interface TaskStateRegistry extends AutoCloseable {
+
+    /**
+     * Mark the given state as used by the given state backends. Should be called upon initial
+     * creation of state object (e.g. upload to DFS). It can be called before or after {@link
+     * #checkpointStarting(long) starting} a checkpoint using it.
+     */
+    void stateUsed(Collection<StateObject> states);
+
+    /**
+     * Mark the given state as not used anymore by the given backend (i.e. it will not be included
+     * into any <strong>future</strong> snapshots); discard if not used by any other backend or
+     * checkpoint. When using incremental checkpoints, it should be called upon materialization;
+     * otherwise, on checkpoint subsumption (in addition to {@link #checkpointSubsumed(long)}. The
+     * method does nothing if the state is not marked as used.
+     *
+     * <p>Note that there is no need to call this method during the shutdown - any state is
+     * considered unused as no future checkpoints will be made.
+     */
+    void stateNotUsed(StateObject state);
+
+    /**
+     * Notify that the checkpoint is about to start. Until {@link #stateSnapshotCreated(StateObject,
+     * long)} notified explicitly}, any state that is still in use by the backend is considered as
+     * potentially used by this checkpoint.
+     */
+    void checkpointStarting(long checkpointId);
+
+    /**
+     * Notify about the state used in a snapshot for the given checkpoint (before or after sending
+     * to JM). All state should be reported at once. The method serves the following goals:
+     *
+     * <ul>
+     *   <li>more fine-grained tracking of state usage by checkpoints to allow deletion
+     *   <li>automatic tracking of state usage (see below)
+     * </ul>
+     *
+     * Must be called <strong>after</strong> the corresponding {@link #checkpointStarting(long)}.
+     *
+     * @throws NoSuchElementException if the state is not registered
+     * @throws IllegalStateException if the given checkpoint was already performed
+     */
+    void stateSnapshotCreated(StateObject state, long checkpointId)
+            throws NoSuchElementException, IllegalStateException;
+    /**
+     * Un-mark any states previously {@link #stateSnapshotCreated(StateObject, long) marked} as used
+     * by given backend in the given checkpoint. Doesn't affect any other checkpoints. All state
+     * objects that become unused are discarded.
+     */
+    void checkpointAborted(long checkpointId);
+
+    /**
+     * Un-mark any states previously {@link #stateSnapshotCreated(StateObject, long) marked} as used
+     * by given backend in the given checkpoint. All earlier checkpoints of <strong>this
+     * backend</strong> are also considered as subsumed. All state objects that become unused by any
+     * backend or checkpoint anymore are discarded.
+     *
+     * <p>If the job is being finished (including stop-with-savepoint) then this method should be
+     * called with the latest known info so that no extra checkpoints are left.
+     */
+    // TODO: call with the final subsumption info
+    void checkpointSubsumed(long checkpointId);
+
+    TaskStateRegistry NO_OP =
+            new TaskStateRegistry() {
+
+                @Override
+                public void stateUsed(Collection<StateObject> state) {}
+
+                @Override
+                public void stateNotUsed(StateObject state) {}
+
+                @Override
+                public void checkpointStarting(long checkpointId) {}
+
+                @Override
+                public void stateSnapshotCreated(StateObject state, long checkpointId)
+                        throws NoSuchElementException, IllegalStateException {}
+
+                @Override
+                public void checkpointAborted(long checkpointId) {}
+
+                @Override
+                public void checkpointSubsumed(long checkpointId) {}
+
+                @Override
+                public void close() {}
+            };
+}

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/taskexecutor/TaskExecutor.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/taskexecutor/TaskExecutor.java
@@ -682,7 +682,7 @@ public class TaskExecutor extends RpcEndpoint implements TaskExecutorGateway {
             try {
                 changelogStorage =
                         changelogStoragesManager.stateChangelogStorageForJob(
-                                jobId, taskManagerConfiguration.getConfiguration());
+                                jobId, taskManagerConfiguration.getConfiguration(), ioExecutor);
             } catch (IOException e) {
                 throw new TaskSubmissionException(e);
             }

--- a/flink-runtime/src/test/java/org/apache/flink/runtime/state/StateUtilTest.java
+++ b/flink-runtime/src/test/java/org/apache/flink/runtime/state/StateUtilTest.java
@@ -101,12 +101,18 @@ public class StateUtilTest {
         };
     }
 
-    private static class TestStateObject implements StateObject {
+    public static class TestStateObject implements StateObject {
         private static final long serialVersionUID = -8070326169926626355L;
         private final int size;
+        private final String name;
 
-        private TestStateObject(int size) {
+        public TestStateObject(int size) {
+            this("test", size);
+        }
+
+        public TestStateObject(String name, int size) {
             this.size = size;
+            this.name = name;
         }
 
         @Override
@@ -116,5 +122,10 @@ public class StateUtilTest {
 
         @Override
         public void discardState() {}
+
+        @Override
+        public String toString() {
+            return name + ", size=" + size;
+        }
     }
 }

--- a/flink-runtime/src/test/java/org/apache/flink/runtime/state/track/SharedTaskStateRegistryTest.java
+++ b/flink-runtime/src/test/java/org/apache/flink/runtime/state/track/SharedTaskStateRegistryTest.java
@@ -1,0 +1,382 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.flink.runtime.state.track;
+
+import org.apache.flink.runtime.state.StateObject;
+import org.apache.flink.runtime.state.StateUtilTest.TestStateObject;
+import org.apache.flink.runtime.state.track.SharedTaskStateRegistry.StateObjectIDExtractor;
+import org.apache.flink.util.function.BiConsumerWithException;
+
+import org.junit.Test;
+
+import java.util.ArrayList;
+import java.util.HashSet;
+import java.util.List;
+
+import static java.util.Arrays.asList;
+import static java.util.Collections.singleton;
+import static java.util.Collections.singletonList;
+import static java.util.Collections.unmodifiableList;
+import static org.apache.flink.runtime.state.track.SharedTaskStateRegistry.StateObjectIDExtractor.IDENTITY;
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertTrue;
+
+/** {@link SharedTaskStateRegistry} test. */
+public class SharedTaskStateRegistryTest {
+    private static final String BACKEND_ID_1 = "b1";
+    private static final String BACKEND_ID_2 = "b2";
+    private static final long CP_ID_1 = 1L;
+    private static final long CP_ID_2 = 2L;
+    private static final long CP_ID_3 = 3L;
+    private static final StateObject STATE_OBJECT_1 = new TestStateObject("s1", 1);
+    private static final StateObject STATE_OBJECT_2 = new TestStateObject("s2", 1);
+
+    @Test
+    public void testIgnoreUnknownObject() throws Exception {
+        runWith(
+                (registry, cleaner) -> {
+                    register(STATE_OBJECT_1, registry, BACKEND_ID_1);
+                    registry.stateNotUsed(BACKEND_ID_1, STATE_OBJECT_2);
+                });
+    }
+
+    @Test
+    public void testIgnoreUnknownCheckpointOnSubsumption() throws Exception {
+        runWith(
+                (registry, cleaner) -> {
+                    registry.checkpointSubsumed(BACKEND_ID_1, CP_ID_1);
+                    register(STATE_OBJECT_1, registry, BACKEND_ID_1);
+                    registry.checkpointStarting(BACKEND_ID_1, CP_ID_2);
+                    registry.stateSnapshotCreated(BACKEND_ID_1, STATE_OBJECT_1, CP_ID_2);
+                    registry.checkpointSubsumed(BACKEND_ID_1, CP_ID_2);
+                    registry.checkpointSubsumed(BACKEND_ID_1, CP_ID_2);
+                });
+    }
+
+    @Test
+    public void testIgnoreDistributedState() throws Exception {
+        runWith(
+                (registry, cleaner) -> {
+                    registry.addDistributedState(
+                            new HashSet<>(asList(STATE_OBJECT_1, STATE_OBJECT_2)));
+
+                    register(STATE_OBJECT_1, registry, BACKEND_ID_1);
+                    registry.stateNotUsed(BACKEND_ID_1, STATE_OBJECT_1);
+
+                    checkpoint(BACKEND_ID_1, CP_ID_1, STATE_OBJECT_2, registry);
+                    registry.checkpointAborted(BACKEND_ID_1, CP_ID_1);
+                    registry.checkpointSubsumed(BACKEND_ID_1, CP_ID_1);
+                    registry.stateNotUsed(BACKEND_ID_1, STATE_OBJECT_2);
+                });
+    }
+
+    @Test
+    public void testDiscardWhenUnregistered() throws Exception {
+        runWith(
+                (registry, cleaner) -> {
+                    register(STATE_OBJECT_1, registry, BACKEND_ID_1);
+                    registry.stateNotUsed(BACKEND_ID_1, STATE_OBJECT_1);
+                },
+                STATE_OBJECT_1);
+    }
+
+    @Test
+    public void testDiscardWhenUnusedImplicitly() throws Exception {
+        runWith(
+                (registry, cleaner) -> {
+                    // cp1 uses state1
+                    // cp2 doesn't; but this is not known at the time when it starts
+                    // cp3 starts after cp2 snapshot is reported
+                    // so cp3 is guaranteed to not use state1
+                    // therefore, state1 can discarded after subsuming cp2
+
+                    registry.checkpointStarting(BACKEND_ID_1, CP_ID_1);
+                    registry.checkpointStarting(BACKEND_ID_1, CP_ID_2);
+                    register(STATE_OBJECT_1, registry, BACKEND_ID_1);
+                    registry.stateSnapshotCreated(BACKEND_ID_1, STATE_OBJECT_1, CP_ID_1);
+                    register(STATE_OBJECT_2, registry, BACKEND_ID_1);
+                    registry.stateSnapshotCreated(BACKEND_ID_1, STATE_OBJECT_2, CP_ID_2);
+
+                    registry.checkpointStarting(BACKEND_ID_1, CP_ID_3);
+                    registry.stateSnapshotCreated(BACKEND_ID_1, STATE_OBJECT_2, CP_ID_3);
+                    registry.checkpointSubsumed(BACKEND_ID_1, CP_ID_1);
+                },
+                STATE_OBJECT_1);
+    }
+
+    @Test
+    public void testDiscardWhenSubsumed() throws Exception {
+        runWith(
+                (registry, cleaner) -> {
+                    checkpoint(BACKEND_ID_1, CP_ID_1, STATE_OBJECT_1, registry);
+                    registry.stateNotUsed(BACKEND_ID_1, STATE_OBJECT_1);
+                    registry.checkpointSubsumed(BACKEND_ID_1, CP_ID_1);
+                },
+                STATE_OBJECT_1);
+        runWith(
+                (registry, cleaner) -> {
+                    checkpoint(BACKEND_ID_1, CP_ID_1, STATE_OBJECT_1, registry);
+                    registry.checkpointSubsumed(BACKEND_ID_1, CP_ID_1);
+                    registry.stateNotUsed(BACKEND_ID_1, STATE_OBJECT_1);
+                },
+                STATE_OBJECT_1);
+    }
+
+    @Test
+    public void testDiscardWhenLaterCheckpointSubsumed() throws Exception {
+        int numCheckpoints = 10;
+        StateObject[] checkpointStates = new StateObject[numCheckpoints];
+        for (int i = 0; i < numCheckpoints; i++) {
+            checkpointStates[i] = new TestStateObject(Integer.toString(i), 1);
+        }
+        runWith(
+                (registry, cleaner) -> {
+                    for (int i = 0; i < numCheckpoints; i++) {
+                        checkpoint(BACKEND_ID_1, i, checkpointStates[i], registry);
+                        registry.stateNotUsed(BACKEND_ID_1, checkpointStates[i]);
+                    }
+                    registry.checkpointSubsumed(BACKEND_ID_1, numCheckpoints - 1);
+                },
+                checkpointStates);
+    }
+
+    @Test
+    public void testDiscardWithMultipleBackends() throws Exception {
+        runWith(
+                (registry, cleaner) -> {
+                    register(STATE_OBJECT_1, registry, BACKEND_ID_1, BACKEND_ID_2);
+                    registry.stateNotUsed(BACKEND_ID_1, STATE_OBJECT_1);
+                    assertNotDiscarded(cleaner);
+                    registry.stateNotUsed(BACKEND_ID_2, STATE_OBJECT_1);
+                },
+                STATE_OBJECT_1);
+    }
+
+    @Test
+    public void testDiscardWhenCheckpointAborted() throws Exception {
+        runWith(
+                (registry, cleaner) -> {
+                    register(STATE_OBJECT_1, registry, BACKEND_ID_1);
+                    registry.checkpointStarting(BACKEND_ID_1, CP_ID_1);
+                    registry.checkpointAborted(BACKEND_ID_1, CP_ID_1);
+                    assertNotDiscarded(cleaner);
+                    registry.stateNotUsed(BACKEND_ID_1, STATE_OBJECT_1);
+                },
+                STATE_OBJECT_1);
+    }
+
+    @Test
+    public void testDiscardOnClose() throws Exception {
+        runWith(
+                (registry, cleaner) -> {
+                    register(STATE_OBJECT_1, registry, BACKEND_ID_1);
+                    // starting and not subsuming any checkpoint at any point prevents deletion as
+                    // such a checkpoint should be treated as potentially completed
+                },
+                IDENTITY,
+                AssertionPoint.AFTER_CLOSE,
+                STATE_OBJECT_1);
+    }
+
+    @Test
+    public void testDiscardOnCloseSubsumed() throws Exception {
+        runWith(
+                (registry, cleaner) -> {
+                    registry.checkpointStarting(BACKEND_ID_1, CP_ID_1);
+                    register(STATE_OBJECT_1, registry, BACKEND_ID_1);
+                    registry.checkpointSubsumed(BACKEND_ID_1, CP_ID_1);
+                },
+                IDENTITY,
+                AssertionPoint.AFTER_CLOSE,
+                STATE_OBJECT_1);
+    }
+
+    @Test
+    public void testNoDiscardIfStillUsed() throws Exception {
+        runWith(
+                (registry, cleaner) -> {
+                    checkpoint(BACKEND_ID_1, CP_ID_1, STATE_OBJECT_1, registry);
+                    registry.checkpointSubsumed(BACKEND_ID_1, CP_ID_1);
+                });
+    }
+
+    @Test
+    public void testNoDiscardIfWasCheckpointed() throws Exception {
+        runWith(
+                (registry, cleaner) -> {
+                    checkpoint(BACKEND_ID_1, CP_ID_1, STATE_OBJECT_1, registry);
+                    registry.stateNotUsed(BACKEND_ID_1, STATE_OBJECT_1);
+                });
+    }
+
+    @Test
+    public void testNoDiscardIfCheckpointNotSubsumed() throws Exception {
+        runWith(
+                (registry, cleaner) -> {
+                    checkpoint(BACKEND_ID_1, CP_ID_1, STATE_OBJECT_1, registry);
+                    registry.checkpointStarting(BACKEND_ID_1, CP_ID_2);
+                    registry.stateSnapshotCreated(BACKEND_ID_1, STATE_OBJECT_1, CP_ID_2);
+                    registry.checkpointSubsumed(BACKEND_ID_1, CP_ID_1);
+                    registry.stateNotUsed(BACKEND_ID_1, STATE_OBJECT_1);
+                });
+    }
+
+    @Test
+    public void testNoDiscardOnClose() throws Exception {
+        runWith(
+                (registry, cleaner) -> {
+                    registry.stateUsed(singleton(BACKEND_ID_1), singletonList(STATE_OBJECT_1));
+                    registry.checkpointStarting(BACKEND_ID_1, CP_ID_1);
+                },
+                IDENTITY,
+                AssertionPoint.AFTER_CLOSE);
+    }
+
+    @Test(expected = IllegalStateException.class)
+    public void testRequiresStart() throws Exception {
+        runWith(
+                (registry, cleaner) ->
+                        registry.stateSnapshotCreated(BACKEND_ID_1, STATE_OBJECT_1, CP_ID_1));
+    }
+
+    @Test(expected = IllegalStateException.class)
+    public void testNoDoubleStart() throws Exception {
+        runWith(
+                (registry, cleaner) -> {
+                    registry.checkpointStarting(BACKEND_ID_1, CP_ID_1);
+                    registry.checkpointStarting(BACKEND_ID_1, CP_ID_1);
+                });
+    }
+
+    @Test(expected = IllegalStateException.class)
+    public void testNoDoubleSnapshot() throws Exception {
+        runWith(
+                (registry, cleaner) -> {
+                    registry.checkpointStarting(BACKEND_ID_1, CP_ID_1);
+                    checkpoint(BACKEND_ID_1, CP_ID_1, STATE_OBJECT_1, registry);
+                    registry.stateSnapshotCreated(BACKEND_ID_1, STATE_OBJECT_1, CP_ID_1);
+                });
+    }
+
+    @Test
+    public void testPendingCheckpointPreventsDiscard() throws Exception {
+        runWith(
+                (registry, cleaner) -> {
+                    register(STATE_OBJECT_1, registry, BACKEND_ID_1, BACKEND_ID_2);
+                    registry.checkpointStarting(BACKEND_ID_2, CP_ID_1);
+                    registry.stateNotUsed(BACKEND_ID_1, STATE_OBJECT_1);
+                });
+    }
+
+    @Test
+    public void testDiscardWhenPendingCheckpointSubsumed() throws Exception {
+        runWith(
+                (registry, cleaner) -> {
+                    register(STATE_OBJECT_1, registry, BACKEND_ID_1);
+                    registry.checkpointStarting(BACKEND_ID_2, CP_ID_1);
+                    registry.stateNotUsed(BACKEND_ID_1, STATE_OBJECT_1);
+                    registry.checkpointSubsumed(BACKEND_ID_2, CP_ID_1);
+                },
+                STATE_OBJECT_1);
+    }
+
+    @Test
+    public void testOutOfOrder() throws Exception {
+        runWith(
+                (registry, cleaner) -> {
+                    checkpoint(BACKEND_ID_1, CP_ID_1, STATE_OBJECT_1, registry);
+                    registry.stateNotUsed(BACKEND_ID_1, STATE_OBJECT_1);
+                    registry.checkpointStarting(BACKEND_ID_1, CP_ID_2);
+                    registry.stateSnapshotCreated(BACKEND_ID_1, STATE_OBJECT_1, CP_ID_2);
+                });
+    }
+
+    private void runWith(
+            BiConsumerWithException<
+                            SharedTaskStateRegistry<StateObject>, TestTaskStateCleaner, Exception>
+                    test,
+            StateObject... expectDiscarded)
+            throws Exception {
+        runWith(test, IDENTITY, AssertionPoint.BEFORE_CLOSE, expectDiscarded);
+    }
+
+    private <T> void runWith(
+            BiConsumerWithException<SharedTaskStateRegistry<T>, TestTaskStateCleaner, Exception>
+                    test,
+            StateObjectIDExtractor<T> idExtractor,
+            AssertionPoint assertionPoint,
+            StateObject... expectDiscarded)
+            throws Exception {
+        HashSet<StateObject> actual = null;
+        try (TestTaskStateCleaner cleaner = new TestTaskStateCleaner()) {
+            try (SharedTaskStateRegistry<T> registry =
+                    new SharedTaskStateRegistry<>(cleaner, idExtractor)) {
+                test.accept(registry, cleaner);
+                if (assertionPoint == AssertionPoint.BEFORE_CLOSE) {
+                    actual = new HashSet<>(cleaner.getDiscarded());
+                }
+            }
+            if (assertionPoint == AssertionPoint.AFTER_CLOSE) {
+                actual = new HashSet<>(cleaner.getDiscarded());
+            }
+        }
+        assertEquals("Discarded state differs", new HashSet<>(asList(expectDiscarded)), actual);
+    }
+
+    private static class TestTaskStateCleaner implements TaskStateCleaner {
+        private final List<StateObject> discarded = new ArrayList<>();
+
+        @Override
+        public void discardAsync(StateObject state) {
+            discarded.add(state);
+        }
+
+        public List<StateObject> getDiscarded() {
+            return unmodifiableList(discarded);
+        }
+
+        @Override
+        public void close() {}
+    }
+
+    private void checkpoint(
+            String backendId,
+            long checkpointId,
+            StateObject state,
+            SharedTaskStateRegistry<StateObject> registry) {
+        register(state, registry, backendId);
+        registry.checkpointStarting(backendId, checkpointId);
+        registry.stateSnapshotCreated(backendId, state, checkpointId);
+    }
+
+    private void register(
+            StateObject state,
+            SharedTaskStateRegistry<StateObject> registry,
+            String... backendIds) {
+        registry.stateUsed(new HashSet<>(asList(backendIds)), singletonList(state));
+    }
+
+    private void assertNotDiscarded(TestTaskStateCleaner cleaner) {
+        assertTrue(cleaner.getDiscarded().isEmpty());
+    }
+
+    private enum AssertionPoint {
+        BEFORE_CLOSE,
+        AFTER_CLOSE
+    }
+}

--- a/flink-runtime/src/test/java/org/apache/flink/runtime/state/ttl/mock/MockKeyedStateBackend.java
+++ b/flink-runtime/src/test/java/org/apache/flink/runtime/state/ttl/mock/MockKeyedStateBackend.java
@@ -228,7 +228,7 @@ public class MockKeyedStateBackend<K> extends AbstractKeyedStateBackend<K> {
 
     @Nonnull
     @Override
-    public SavepointResources<K> savepoint() throws Exception {
+    public SavepointResources<K> savepoint(long checkpointId) throws Exception {
         throw new UnsupportedOperationException(
                 "Unified savepoints are not supported on this testing StateBackend.");
     }

--- a/flink-state-backends/flink-statebackend-changelog/src/main/java/org/apache/flink/state/changelog/ChangelogKeyedStateBackend.java
+++ b/flink-state-backends/flink-statebackend-changelog/src/main/java/org/apache/flink/state/changelog/ChangelogKeyedStateBackend.java
@@ -55,6 +55,7 @@ import org.apache.flink.runtime.state.heap.InternalKeyContext;
 import org.apache.flink.runtime.state.internal.InternalKvState;
 import org.apache.flink.runtime.state.metainfo.StateMetaInfoSnapshot.BackendStateType;
 import org.apache.flink.runtime.state.metrics.LatencyTrackingStateFactory;
+import org.apache.flink.runtime.state.track.TaskStateRegistry;
 import org.apache.flink.runtime.state.ttl.TtlStateFactory;
 import org.apache.flink.runtime.state.ttl.TtlTimeProvider;
 import org.apache.flink.state.changelog.restore.FunctionDelegationHelper;
@@ -190,6 +191,8 @@ public class ChangelogKeyedStateBackend<K>
 
     private final ExecutorService asyncOperationsThreadPool;
 
+    private final TaskStateRegistry taskStateRegistry;
+
     public ChangelogKeyedStateBackend(
             AbstractKeyedStateBackend<K> keyedStateBackend,
             ExecutionConfig executionConfig,
@@ -197,7 +200,8 @@ public class ChangelogKeyedStateBackend<K>
             StateChangelogWriter<ChangelogStateHandle> stateChangelogWriter,
             Collection<ChangelogStateBackendHandle> initialState,
             MailboxExecutor mainMailboxExecutor,
-            ExecutorService asyncOperationsThreadPool) {
+            ExecutorService asyncOperationsThreadPool,
+            TaskStateRegistry taskStateRegistry) {
         this.keyedStateBackend = keyedStateBackend;
         this.executionConfig = executionConfig;
         this.ttlTimeProvider = ttlTimeProvider;
@@ -208,6 +212,7 @@ public class ChangelogKeyedStateBackend<K>
         this.changelogStates = new HashMap<>();
         this.mainMailboxExecutor = checkNotNull(mainMailboxExecutor);
         this.asyncOperationsThreadPool = checkNotNull(asyncOperationsThreadPool);
+        this.taskStateRegistry = checkNotNull(taskStateRegistry);
         this.completeRestore(initialState);
     }
 

--- a/flink-state-backends/flink-statebackend-changelog/src/main/java/org/apache/flink/state/changelog/ChangelogKeyedStateBackend.java
+++ b/flink-state-backends/flink-statebackend-changelog/src/main/java/org/apache/flink/state/changelog/ChangelogKeyedStateBackend.java
@@ -403,8 +403,8 @@ public class ChangelogKeyedStateBackend<K>
 
     @Nonnull
     @Override
-    public SavepointResources<K> savepoint() throws Exception {
-        return keyedStateBackend.savepoint();
+    public SavepointResources<K> savepoint(long checkpointId) throws Exception {
+        return keyedStateBackend.savepoint(checkpointId);
     }
 
     // -------------------- CheckpointListener --------------------------------

--- a/flink-state-backends/flink-statebackend-changelog/src/main/java/org/apache/flink/state/changelog/ChangelogStateBackend.java
+++ b/flink-state-backends/flink-statebackend-changelog/src/main/java/org/apache/flink/state/changelog/ChangelogStateBackend.java
@@ -223,7 +223,8 @@ public class ChangelogStateBackend implements DelegatingStateBackend, Configurab
                                 changelogStorage.createWriter(operatorIdentifier, keyGroupRange),
                                 baseState,
                                 env.getMainMailboxExecutor(),
-                                env.getAsyncOperationsThreadPool()));
+                                env.getAsyncOperationsThreadPool(),
+                                changelogStorage.getStateChangeUsageTracker(operatorIdentifier)));
     }
 
     private Collection<ChangelogStateBackendHandle> castHandles(

--- a/flink-state-backends/flink-statebackend-changelog/src/test/java/org/apache/flink/state/changelog/ChangelogStateBackendTestUtils.java
+++ b/flink-state-backends/flink-statebackend-changelog/src/test/java/org/apache/flink/state/changelog/ChangelogStateBackendTestUtils.java
@@ -30,11 +30,14 @@ import org.apache.flink.runtime.state.CheckpointableKeyedStateBackend;
 import org.apache.flink.runtime.state.KeyGroupRange;
 import org.apache.flink.runtime.state.StateBackend;
 import org.apache.flink.runtime.state.TestTaskStateManager;
+import org.apache.flink.runtime.state.track.SharedTaskStateRegistry;
 import org.apache.flink.runtime.state.ttl.TtlTimeProvider;
 
 import java.io.File;
 import java.io.IOException;
 import java.util.Collections;
+
+import static org.apache.flink.util.concurrent.Executors.directExecutor;
 
 /** Test Utilities for Changelog StateBackend. */
 public class ChangelogStateBackendTestUtils {
@@ -73,7 +76,10 @@ public class ChangelogStateBackendTestUtils {
         return TestTaskStateManager.builder()
                 .setStateChangelogStorage(
                         new FsStateChangelogStorage(
-                                Path.fromLocalFile(changelogStoragePath), false, 1024))
+                                Path.fromLocalFile(changelogStoragePath),
+                                false,
+                                1024,
+                                SharedTaskStateRegistry.create(directExecutor())))
                 .build();
     }
 }

--- a/flink-state-backends/flink-statebackend-rocksdb/src/main/java/org/apache/flink/contrib/streaming/state/RocksDBKeyedStateBackend.java
+++ b/flink-state-backends/flink-statebackend-rocksdb/src/main/java/org/apache/flink/contrib/streaming/state/RocksDBKeyedStateBackend.java
@@ -553,7 +553,7 @@ public class RocksDBKeyedStateBackend<K> extends AbstractKeyedStateBackend<K> {
 
     @Nonnull
     @Override
-    public SavepointResources<K> savepoint() throws Exception {
+    public SavepointResources<K> savepoint(long checkpointId) throws Exception {
 
         // flush everything into db before taking a snapshot
         writeBatchWrapper.flush();

--- a/flink-streaming-java/src/main/java/org/apache/flink/streaming/api/operators/StreamOperatorStateHandler.java
+++ b/flink-streaming-java/src/main/java/org/apache/flink/streaming/api/operators/StreamOperatorStateHandler.java
@@ -230,7 +230,9 @@ public class StreamOperatorStateHandler {
             if (null != keyedStateBackend) {
                 if (checkpointOptions.getCheckpointType().isSavepoint()) {
                     SnapshotStrategyRunner<KeyedStateHandle, ? extends FullSnapshotResources<?>>
-                            snapshotRunner = prepareSavepoint(keyedStateBackend, closeableRegistry);
+                            snapshotRunner =
+                                    prepareSavepoint(
+                                            keyedStateBackend, closeableRegistry, checkpointId);
 
                     snapshotInProgress.setKeyedStateManagedFuture(
                             snapshotRunner.snapshot(
@@ -272,9 +274,10 @@ public class StreamOperatorStateHandler {
     public static SnapshotStrategyRunner<KeyedStateHandle, ? extends FullSnapshotResources<?>>
             prepareSavepoint(
                     CheckpointableKeyedStateBackend<?> keyedStateBackend,
-                    CloseableRegistry closeableRegistry)
+                    CloseableRegistry closeableRegistry,
+                    long checkpointId)
                     throws Exception {
-        SavepointResources<?> savepointResources = keyedStateBackend.savepoint();
+        SavepointResources<?> savepointResources = keyedStateBackend.savepoint(checkpointId);
 
         SavepointSnapshotStrategy<?> savepointSnapshotStrategy =
                 new SavepointSnapshotStrategy<>(savepointResources.getSnapshotResources());

--- a/flink-streaming-java/src/main/java/org/apache/flink/streaming/api/operators/sorted/state/BatchExecutionKeyedStateBackend.java
+++ b/flink-streaming-java/src/main/java/org/apache/flink/streaming/api/operators/sorted/state/BatchExecutionKeyedStateBackend.java
@@ -275,7 +275,7 @@ public class BatchExecutionKeyedStateBackend<K> implements CheckpointableKeyedSt
 
     @Nonnull
     @Override
-    public SavepointResources<K> savepoint() throws Exception {
+    public SavepointResources<K> savepoint(long checkpointId) throws Exception {
         throw new UnsupportedOperationException(
                 "Savepoints are not supported in BATCH runtime mode.");
     }

--- a/flink-tests/src/test/java/org/apache/flink/test/state/SavepointStateBackendSwitchTestBase.java
+++ b/flink-tests/src/test/java/org/apache/flink/test/state/SavepointStateBackendSwitchTestBase.java
@@ -234,7 +234,7 @@ public abstract class SavepointStateBackendSwitchTestBase {
         SnapshotStrategyRunner<KeyedStateHandle, ? extends FullSnapshotResources<?>>
                 savepointRunner =
                         StreamOperatorStateHandler.prepareSavepoint(
-                                keyedBackend, new CloseableRegistry());
+                                keyedBackend, new CloseableRegistry(), 1);
 
         RunnableFuture<SnapshotResult<KeyedStateHandle>> snapshot =
                 savepointRunner.snapshot(


### PR DESCRIPTION
## What is the purpose of the change

Implement private state management for the ChangelogStateBackend.

[Detailed design doc](https://docs.google.com/document/d/1Nt95g5eWBkY5mFueF3dj639_4YHjhuGr_rn_6rmEjGw/edit?usp=sharing)
[Higher level design](https://docs.google.com/document/d/1NJJQ30P27BmUvD7oa4FChvkYxMEgjRPTVdO1dHLl_9I/edit#heading=h.9dxopqajsy7)

Completed parts:
- core classes (`package org.apache.flink.runtime.state.track;`)
- creation and injection into the `ChangelogKeyedStateBackend`
- most calls from the backend

Missing parts:
 - call `checkpointSubsumed` on subsumption (requires FLINK-21504)
 - ~call `stateUsed` on materialization (requires FLINK-21357)~ - FLINK-23344
 - call `stateUsed` on upload from DFS Changelog Writer (requires rebase as FLINK-21353 is now merged)
 - implement `getStateChangeUsageTracker` by DFS `StateChangelogStorage` (requires rebase as FLINK-21353 is now merged)

## Verifying this change

- Added `TaskStateRegistryImplTest` unit tests
- TBD: integration tests (after subsumption notification)

## Does this pull request potentially affect one of the following parts:

  - Dependencies (does it add or upgrade a dependency): no
  - The public API, i.e., is any changed class annotated with `@Public(Evolving)`: no
  - The serializers: no
  - The runtime per-record code paths (performance sensitive): no
  - Anything that affects deployment or recovery: JobManager (and its components), Checkpointing, Kubernetes/Yarn/Mesos, ZooKeeper: yes
  - The S3 file system connector: no

## Documentation

  - Does this pull request introduce a new feature? no
  - If yes, how is the feature documented? no
