### PR TITLE
[FLINK-23474] Extract internal version of InputStatus

### DIFF
--- a/flink-streaming-java/src/main/java/org/apache/flink/streaming/api/operators/sort/MultiInputSortingDataInput.java
+++ b/flink-streaming-java/src/main/java/org/apache/flink/streaming/api/operators/sort/MultiInputSortingDataInput.java
@@ -23,7 +23,6 @@ import org.apache.flink.api.java.functions.KeySelector;
 import org.apache.flink.api.java.tuple.Tuple2;
 import org.apache.flink.configuration.AlgorithmOptions;
 import org.apache.flink.configuration.Configuration;
-import org.apache.flink.core.io.InputStatus;
 import org.apache.flink.core.memory.DataOutputSerializer;
 import org.apache.flink.runtime.checkpoint.channel.ChannelStateWriter;
 import org.apache.flink.runtime.io.AvailabilityProvider;
@@ -37,6 +36,7 @@ import org.apache.flink.streaming.api.operators.BoundedMultiInput;
 import org.apache.flink.streaming.api.operators.InputSelectable;
 import org.apache.flink.streaming.api.operators.InputSelection;
 import org.apache.flink.streaming.api.watermark.Watermark;
+import org.apache.flink.streaming.runtime.io.DataInputStatus;
 import org.apache.flink.streaming.runtime.io.PushingAsyncDataInput;
 import org.apache.flink.streaming.runtime.io.StreamInputProcessor;
 import org.apache.flink.streaming.runtime.io.StreamTaskInput;
@@ -255,13 +255,13 @@ public final class MultiInputSortingDataInput<IN, K> implements StreamTaskInput<
     }
 
     @Override
-    public InputStatus emitNext(DataOutput<IN> output) throws Exception {
+    public DataInputStatus emitNext(DataOutput<IN> output) throws Exception {
         if (sortedInput != null) {
             return emitNextAfterSorting(output);
         }
 
-        InputStatus inputStatus = wrappedInput.emitNext(sortingPhaseDataOutput);
-        if (inputStatus == InputStatus.END_OF_INPUT) {
+        DataInputStatus inputStatus = wrappedInput.emitNext(sortingPhaseDataOutput);
+        if (inputStatus == DataInputStatus.END_OF_INPUT) {
             endSorting();
             return addNextToQueue(new HeadElement(idx), output);
         }
@@ -271,9 +271,9 @@ public final class MultiInputSortingDataInput<IN, K> implements StreamTaskInput<
 
     @Nonnull
     @SuppressWarnings({"unchecked"})
-    private InputStatus emitNextAfterSorting(DataOutput<IN> output) throws Exception {
+    private DataInputStatus emitNextAfterSorting(DataOutput<IN> output) throws Exception {
         if (commonContext.isFinishedEmitting(idx)) {
-            return InputStatus.END_OF_INPUT;
+            return DataInputStatus.END_OF_INPUT;
         } else if (commonContext.allSorted()) {
             HeadElement head = commonContext.getQueueOfHeads().peek();
             if (head != null && head.inputIndex == idx) {
@@ -281,10 +281,10 @@ public final class MultiInputSortingDataInput<IN, K> implements StreamTaskInput<
                 output.emitRecord((StreamRecord<IN>) headElement.streamElement.f1);
                 return addNextToQueue(headElement, output);
             } else {
-                return InputStatus.NOTHING_AVAILABLE;
+                return DataInputStatus.NOTHING_AVAILABLE;
             }
         } else {
-            return InputStatus.NOTHING_AVAILABLE;
+            return DataInputStatus.NOTHING_AVAILABLE;
         }
     }
 
@@ -298,7 +298,8 @@ public final class MultiInputSortingDataInput<IN, K> implements StreamTaskInput<
     }
 
     @Nonnull
-    private InputStatus addNextToQueue(HeadElement reuse, DataOutput<IN> output) throws Exception {
+    private DataInputStatus addNextToQueue(HeadElement reuse, DataOutput<IN> output)
+            throws Exception {
         Tuple2<byte[], StreamRecord<IN>> next = sortedInput.next();
         if (next != null) {
             reuse.streamElement = getAsObject(next);
@@ -308,19 +309,19 @@ public final class MultiInputSortingDataInput<IN, K> implements StreamTaskInput<
             if (seenWatermark > Long.MIN_VALUE) {
                 output.emitWatermark(new Watermark(seenWatermark));
             }
-            return InputStatus.END_OF_INPUT;
+            return DataInputStatus.END_OF_INPUT;
         }
 
         if (commonContext.allSorted()) {
             HeadElement headElement = commonContext.getQueueOfHeads().peek();
             if (headElement != null) {
                 if (headElement.inputIndex == idx) {
-                    return InputStatus.MORE_AVAILABLE;
+                    return DataInputStatus.MORE_AVAILABLE;
                 }
             }
         }
 
-        return InputStatus.NOTHING_AVAILABLE;
+        return DataInputStatus.NOTHING_AVAILABLE;
     }
 
     @SuppressWarnings({"rawtypes", "unchecked"})

--- a/flink-streaming-java/src/main/java/org/apache/flink/streaming/api/operators/sort/ObservableStreamTaskInput.java
+++ b/flink-streaming-java/src/main/java/org/apache/flink/streaming/api/operators/sort/ObservableStreamTaskInput.java
@@ -18,10 +18,10 @@
 
 package org.apache.flink.streaming.api.operators.sort;
 
-import org.apache.flink.core.io.InputStatus;
 import org.apache.flink.runtime.checkpoint.CheckpointException;
 import org.apache.flink.runtime.checkpoint.channel.ChannelStateWriter;
 import org.apache.flink.streaming.api.operators.BoundedMultiInput;
+import org.apache.flink.streaming.runtime.io.DataInputStatus;
 import org.apache.flink.streaming.runtime.io.StreamTaskInput;
 
 import java.io.IOException;
@@ -29,7 +29,7 @@ import java.util.concurrent.CompletableFuture;
 
 /**
  * A wrapping {@link StreamTaskInput} that invokes a given {@link BoundedMultiInput} when reaching
- * {@link InputStatus#END_OF_INPUT}.
+ * {@link DataInputStatus#END_OF_INPUT}.
  */
 class ObservableStreamTaskInput<T> implements StreamTaskInput<T> {
 
@@ -43,9 +43,9 @@ class ObservableStreamTaskInput<T> implements StreamTaskInput<T> {
     }
 
     @Override
-    public InputStatus emitNext(DataOutput<T> output) throws Exception {
-        InputStatus result = wrappedInput.emitNext(output);
-        if (result == InputStatus.END_OF_INPUT) {
+    public DataInputStatus emitNext(DataOutput<T> output) throws Exception {
+        DataInputStatus result = wrappedInput.emitNext(output);
+        if (result == DataInputStatus.END_OF_INPUT) {
             endOfInputObserver.endInput(wrappedInput.getInputIndex());
         }
         return result;

--- a/flink-streaming-java/src/main/java/org/apache/flink/streaming/runtime/io/AbstractStreamTaskNetworkInput.java
+++ b/flink-streaming-java/src/main/java/org/apache/flink/streaming/runtime/io/AbstractStreamTaskNetworkInput.java
@@ -18,7 +18,6 @@
 package org.apache.flink.streaming.runtime.io;
 
 import org.apache.flink.api.common.typeutils.TypeSerializer;
-import org.apache.flink.core.io.InputStatus;
 import org.apache.flink.runtime.checkpoint.channel.InputChannelInfo;
 import org.apache.flink.runtime.event.AbstractEvent;
 import org.apache.flink.runtime.io.network.api.EndOfPartitionEvent;
@@ -85,7 +84,7 @@ public abstract class AbstractStreamTaskNetworkInput<
     }
 
     @Override
-    public InputStatus emitNext(DataOutput<T> output) throws Exception {
+    public DataInputStatus emitNext(DataOutput<T> output) throws Exception {
 
         while (true) {
             // get the stream element from the deserializer
@@ -103,7 +102,7 @@ public abstract class AbstractStreamTaskNetworkInput<
 
                 if (result.isFullRecord()) {
                     processElement(deserializationDelegate.getInstance(), output);
-                    return InputStatus.MORE_AVAILABLE;
+                    return DataInputStatus.MORE_AVAILABLE;
                 }
             }
 
@@ -122,9 +121,9 @@ public abstract class AbstractStreamTaskNetworkInput<
                     checkState(
                             checkpointedInputGate.getAvailableFuture().isDone(),
                             "Finished BarrierHandler should be available");
-                    return InputStatus.END_OF_INPUT;
+                    return DataInputStatus.END_OF_INPUT;
                 }
-                return InputStatus.NOTHING_AVAILABLE;
+                return DataInputStatus.NOTHING_AVAILABLE;
             }
         }
     }
@@ -147,7 +146,7 @@ public abstract class AbstractStreamTaskNetworkInput<
         }
     }
 
-    protected InputStatus processEvent(BufferOrEvent bufferOrEvent) {
+    protected DataInputStatus processEvent(BufferOrEvent bufferOrEvent) {
         // Event received
         final AbstractEvent event = bufferOrEvent.getEvent();
         // TODO: with checkpointedInputGate.isFinished() we might not need to support any events on
@@ -158,10 +157,10 @@ public abstract class AbstractStreamTaskNetworkInput<
             releaseDeserializer(bufferOrEvent.getChannelInfo());
         } else if (event.getClass() == EndOfChannelStateEvent.class) {
             if (checkpointedInputGate.allChannelsRecovered()) {
-                return InputStatus.END_OF_RECOVERY;
+                return DataInputStatus.END_OF_RECOVERY;
             }
         }
-        return InputStatus.MORE_AVAILABLE;
+        return DataInputStatus.MORE_AVAILABLE;
     }
 
     protected void processBuffer(BufferOrEvent bufferOrEvent) throws IOException {

--- a/flink-streaming-java/src/main/java/org/apache/flink/streaming/runtime/io/DataInputStatus.java
+++ b/flink-streaming-java/src/main/java/org/apache/flink/streaming/runtime/io/DataInputStatus.java
@@ -15,28 +15,19 @@
  * limitations under the License.
  */
 
-package org.apache.flink.core.io;
+package org.apache.flink.streaming.runtime.io;
 
-import org.apache.flink.annotation.PublicEvolving;
+import org.apache.flink.annotation.Internal;
 
 /**
- * An {@code InputStatus} indicates the availability of data from an asynchronous input. When asking
- * an asynchronous input to produce data, it returns this status to indicate how to proceed.
+ * It is an internal equivalent of {@link org.apache.flink.core.io.InputStatus} that provides
+ * additional non public statuses.
  *
- * <p>When the input returns {@link InputStatus#NOTHING_AVAILABLE} it means that no data is
- * available at this time, but more will (most likely) be available in the future. The asynchronous
- * input will typically offer to register a <i>Notifier</i> or to obtain a <i>Future</i> that will
- * signal the availability of new data.
- *
- * <p>When the input returns {@link InputStatus#MORE_AVAILABLE}, it can be immediately asked again
- * to produce more data. That readers from the asynchronous input can bypass subscribing to a
- * Notifier or a Future for efficiency.
- *
- * <p>When the input returns {@link InputStatus#END_OF_INPUT}, then no data will be available again
- * from this input. It has reached the end of its bounded data.
+ * <p>An {@code InputStatus} indicates the availability of data from an asynchronous input. When
+ * asking an asynchronous input to produce data, it returns this status to indicate how to proceed.
  */
-@PublicEvolving
-public enum InputStatus {
+@Internal
+public enum DataInputStatus {
 
     /**
      * Indicator that more data is available and the input can be called immediately again to
@@ -49,6 +40,9 @@ public enum InputStatus {
      * again.
      */
     NOTHING_AVAILABLE,
+
+    /** Indicator that all persisted data of the data exchange has been successfully restored. */
+    END_OF_RECOVERY,
 
     /** Indicator that the input has reached the end of data. */
     END_OF_INPUT

--- a/flink-streaming-java/src/main/java/org/apache/flink/streaming/runtime/io/MultipleInputSelectionHandler.java
+++ b/flink-streaming-java/src/main/java/org/apache/flink/streaming/runtime/io/MultipleInputSelectionHandler.java
@@ -18,7 +18,6 @@
 package org.apache.flink.streaming.runtime.io;
 
 import org.apache.flink.annotation.Internal;
-import org.apache.flink.core.io.InputStatus;
 import org.apache.flink.streaming.api.operators.InputSelectable;
 import org.apache.flink.streaming.api.operators.InputSelection;
 
@@ -65,11 +64,12 @@ public class MultipleInputSelectionHandler {
                 inputCount);
     }
 
-    public InputStatus updateStatus(InputStatus inputStatus, int inputIndex) throws IOException {
+    public DataInputStatus updateStatus(DataInputStatus inputStatus, int inputIndex)
+            throws IOException {
         switch (inputStatus) {
             case MORE_AVAILABLE:
                 checkState(checkBitMask(availableInputsMask, inputIndex));
-                return InputStatus.MORE_AVAILABLE;
+                return DataInputStatus.MORE_AVAILABLE;
             case NOTHING_AVAILABLE:
                 availableInputsMask = unsetBitMask(availableInputsMask, inputIndex);
                 break;
@@ -82,13 +82,13 @@ public class MultipleInputSelectionHandler {
         return calculateOverallStatus();
     }
 
-    public InputStatus calculateOverallStatus() throws IOException {
+    public DataInputStatus calculateOverallStatus() throws IOException {
         if (areAllInputsFinished()) {
-            return InputStatus.END_OF_INPUT;
+            return DataInputStatus.END_OF_INPUT;
         }
 
         if (isAnyInputAvailable()) {
-            return InputStatus.MORE_AVAILABLE;
+            return DataInputStatus.MORE_AVAILABLE;
         } else {
             long selectedNotFinishedInputMask =
                     inputSelection.getInputMask() & notFinishedInputsMask;
@@ -96,7 +96,7 @@ public class MultipleInputSelectionHandler {
                 throw new IOException(
                         "Can not make a progress: all selected inputs are already finished");
             }
-            return InputStatus.NOTHING_AVAILABLE;
+            return DataInputStatus.NOTHING_AVAILABLE;
         }
     }
 

--- a/flink-streaming-java/src/main/java/org/apache/flink/streaming/runtime/io/PushingAsyncDataInput.java
+++ b/flink-streaming-java/src/main/java/org/apache/flink/streaming/runtime/io/PushingAsyncDataInput.java
@@ -18,7 +18,6 @@
 package org.apache.flink.streaming.runtime.io;
 
 import org.apache.flink.annotation.Internal;
-import org.apache.flink.core.io.InputStatus;
 import org.apache.flink.runtime.io.AvailabilityProvider;
 import org.apache.flink.runtime.io.PullingAsyncDataInput;
 import org.apache.flink.streaming.api.watermark.Watermark;
@@ -40,7 +39,7 @@ public interface PushingAsyncDataInput<T> extends AvailabilityProvider {
      *
      * <p>This method should be non blocking.
      */
-    InputStatus emitNext(DataOutput<T> output) throws Exception;
+    DataInputStatus emitNext(DataOutput<T> output) throws Exception;
 
     /**
      * Basic data output interface used in emitting the next element from data input.

--- a/flink-streaming-java/src/main/java/org/apache/flink/streaming/runtime/io/StreamInputProcessor.java
+++ b/flink-streaming-java/src/main/java/org/apache/flink/streaming/runtime/io/StreamInputProcessor.java
@@ -19,7 +19,6 @@
 package org.apache.flink.streaming.runtime.io;
 
 import org.apache.flink.annotation.Internal;
-import org.apache.flink.core.io.InputStatus;
 import org.apache.flink.runtime.checkpoint.CheckpointException;
 import org.apache.flink.runtime.checkpoint.channel.ChannelStateWriter;
 import org.apache.flink.runtime.io.AvailabilityProvider;
@@ -41,7 +40,7 @@ public interface StreamInputProcessor extends AvailabilityProvider, Closeable {
      *     there are no more records available at the moment and the caller should check finished
      *     state and/or {@link #getAvailableFuture()}.
      */
-    InputStatus processInput() throws Exception;
+    DataInputStatus processInput() throws Exception;
 
     CompletableFuture<Void> prepareSnapshot(
             ChannelStateWriter channelStateWriter, long checkpointId) throws CheckpointException;

--- a/flink-streaming-java/src/main/java/org/apache/flink/streaming/runtime/io/StreamMultipleInputProcessor.java
+++ b/flink-streaming-java/src/main/java/org/apache/flink/streaming/runtime/io/StreamMultipleInputProcessor.java
@@ -19,7 +19,6 @@
 package org.apache.flink.streaming.runtime.io;
 
 import org.apache.flink.annotation.Internal;
-import org.apache.flink.core.io.InputStatus;
 import org.apache.flink.runtime.checkpoint.CheckpointException;
 import org.apache.flink.runtime.checkpoint.channel.ChannelStateWriter;
 import org.apache.flink.streaming.api.operators.InputSelection;
@@ -70,7 +69,7 @@ public final class StreamMultipleInputProcessor implements StreamInputProcessor 
     }
 
     @Override
-    public InputStatus processInput() throws Exception {
+    public DataInputStatus processInput() throws Exception {
         int readingInputIndex;
         if (isPrepared) {
             readingInputIndex = selectNextReadingInputIndex();
@@ -80,11 +79,11 @@ public final class StreamMultipleInputProcessor implements StreamInputProcessor 
             readingInputIndex = selectFirstReadingInputIndex();
         }
         if (readingInputIndex == InputSelection.NONE_AVAILABLE) {
-            return InputStatus.NOTHING_AVAILABLE;
+            return DataInputStatus.NOTHING_AVAILABLE;
         }
 
         lastReadInputIndex = readingInputIndex;
-        InputStatus inputStatus = inputProcessors[readingInputIndex].processInput();
+        DataInputStatus inputStatus = inputProcessors[readingInputIndex].processInput();
         inputSelectionHandler.nextSelection();
         return inputSelectionHandler.updateStatus(inputStatus, readingInputIndex);
     }

--- a/flink-streaming-java/src/main/java/org/apache/flink/streaming/runtime/io/StreamOneInputProcessor.java
+++ b/flink-streaming-java/src/main/java/org/apache/flink/streaming/runtime/io/StreamOneInputProcessor.java
@@ -19,7 +19,6 @@
 package org.apache.flink.streaming.runtime.io;
 
 import org.apache.flink.annotation.Internal;
-import org.apache.flink.core.io.InputStatus;
 import org.apache.flink.runtime.checkpoint.CheckpointException;
 import org.apache.flink.runtime.checkpoint.channel.ChannelStateWriter;
 import org.apache.flink.streaming.api.operators.BoundedMultiInput;
@@ -62,16 +61,16 @@ public final class StreamOneInputProcessor<IN> implements StreamInputProcessor {
     }
 
     @Override
-    public InputStatus processInput() throws Exception {
-        InputStatus status = input.emitNext(output);
+    public DataInputStatus processInput() throws Exception {
+        DataInputStatus status = input.emitNext(output);
 
-        if (status == InputStatus.END_OF_INPUT) {
+        if (status == DataInputStatus.END_OF_INPUT) {
             endOfInputAware.endInput(input.getInputIndex() + 1);
-        } else if (status == InputStatus.END_OF_RECOVERY) {
+        } else if (status == DataInputStatus.END_OF_RECOVERY) {
             if (input instanceof RecoverableStreamTaskInput) {
                 input = ((RecoverableStreamTaskInput<IN>) input).finishRecovery();
             }
-            return InputStatus.MORE_AVAILABLE;
+            return DataInputStatus.MORE_AVAILABLE;
         }
 
         return status;

--- a/flink-streaming-java/src/main/java/org/apache/flink/streaming/runtime/io/StreamTaskExternallyInducedSourceInput.java
+++ b/flink-streaming-java/src/main/java/org/apache/flink/streaming/runtime/io/StreamTaskExternallyInducedSourceInput.java
@@ -19,7 +19,6 @@
 package org.apache.flink.streaming.runtime.io;
 
 import org.apache.flink.api.connector.source.ExternallyInducedSourceReader;
-import org.apache.flink.core.io.InputStatus;
 import org.apache.flink.streaming.api.operators.SourceOperator;
 
 import java.util.function.Consumer;
@@ -41,9 +40,9 @@ public class StreamTaskExternallyInducedSourceInput<T> extends StreamTaskSourceI
     }
 
     @Override
-    public InputStatus emitNext(DataOutput<T> output) throws Exception {
-        InputStatus status = super.emitNext(output);
-        if (status == InputStatus.NOTHING_AVAILABLE) {
+    public DataInputStatus emitNext(DataOutput<T> output) throws Exception {
+        DataInputStatus status = super.emitNext(output);
+        if (status == DataInputStatus.NOTHING_AVAILABLE) {
             sourceReader.shouldTriggerCheckpoint().ifPresent(checkpointTriggeringHook);
         }
         return status;

--- a/flink-streaming-java/src/main/java/org/apache/flink/streaming/runtime/io/StreamTaskSourceInput.java
+++ b/flink-streaming-java/src/main/java/org/apache/flink/streaming/runtime/io/StreamTaskSourceInput.java
@@ -19,7 +19,6 @@
 package org.apache.flink.streaming.runtime.io;
 
 import org.apache.flink.annotation.Internal;
-import org.apache.flink.core.io.InputStatus;
 import org.apache.flink.runtime.checkpoint.CheckpointException;
 import org.apache.flink.runtime.checkpoint.channel.ChannelStateWriter;
 import org.apache.flink.runtime.checkpoint.channel.InputChannelInfo;
@@ -37,8 +36,8 @@ import static org.apache.flink.util.Preconditions.checkNotNull;
 
 /**
  * Implementation of {@link StreamTaskInput} that reads data from the {@link SourceOperator} and
- * returns the {@link InputStatus} to indicate whether the source state is available, unavailable or
- * finished.
+ * returns the {@link DataInputStatus} to indicate whether the source state is available,
+ * unavailable or finished.
  */
 @Internal
 public class StreamTaskSourceInput<T> implements StreamTaskInput<T>, CheckpointableInput {
@@ -59,16 +58,16 @@ public class StreamTaskSourceInput<T> implements StreamTaskInput<T>, Checkpointa
     }
 
     @Override
-    public InputStatus emitNext(DataOutput<T> output) throws Exception {
+    public DataInputStatus emitNext(DataOutput<T> output) throws Exception {
         /**
          * Safe guard against best efforts availability checks. If despite being unavailable someone
          * polls the data from this source while it's blocked, it should return {@link
-         * InputStatus.NOTHING_AVAILABLE}.
+         * DataInputStatus.NOTHING_AVAILABLE}.
          */
         if (isBlockedAvailability.isApproximatelyAvailable()) {
             return operator.emitNext(output);
         }
-        return InputStatus.NOTHING_AVAILABLE;
+        return DataInputStatus.NOTHING_AVAILABLE;
     }
 
     @Override

--- a/flink-streaming-java/src/main/java/org/apache/flink/streaming/runtime/io/StreamTwoInputProcessor.java
+++ b/flink-streaming-java/src/main/java/org/apache/flink/streaming/runtime/io/StreamTwoInputProcessor.java
@@ -19,7 +19,6 @@
 package org.apache.flink.streaming.runtime.io;
 
 import org.apache.flink.annotation.Internal;
-import org.apache.flink.core.io.InputStatus;
 import org.apache.flink.runtime.checkpoint.CheckpointException;
 import org.apache.flink.runtime.checkpoint.channel.ChannelStateWriter;
 import org.apache.flink.runtime.io.AvailabilityProvider;
@@ -45,9 +44,9 @@ public final class StreamTwoInputProcessor<IN1, IN2> implements StreamInputProce
     private final StreamOneInputProcessor<IN2> processor2;
 
     /** Input status to keep track for determining whether the input is finished or not. */
-    private InputStatus firstInputStatus = InputStatus.MORE_AVAILABLE;
+    private DataInputStatus firstInputStatus = DataInputStatus.MORE_AVAILABLE;
 
-    private InputStatus secondInputStatus = InputStatus.MORE_AVAILABLE;
+    private DataInputStatus secondInputStatus = DataInputStatus.MORE_AVAILABLE;
 
     /** Always try to read from the first input. */
     private int lastReadInputIndex = 1;
@@ -75,7 +74,7 @@ public final class StreamTwoInputProcessor<IN1, IN2> implements StreamInputProce
     }
 
     @Override
-    public InputStatus processInput() throws Exception {
+    public DataInputStatus processInput() throws Exception {
         int readingInputIndex;
         if (isPrepared) {
             readingInputIndex = selectNextReadingInputIndex();
@@ -87,7 +86,7 @@ public final class StreamTwoInputProcessor<IN1, IN2> implements StreamInputProce
         // In case of double notification (especially with priority notification), there may not be
         // an input after all.
         if (readingInputIndex == InputSelection.NONE_AVAILABLE) {
-            return InputStatus.NOTHING_AVAILABLE;
+            return DataInputStatus.NOTHING_AVAILABLE;
         }
 
         lastReadInputIndex = readingInputIndex;
@@ -121,26 +120,26 @@ public final class StreamTwoInputProcessor<IN1, IN2> implements StreamInputProce
         return selectNextReadingInputIndex();
     }
 
-    private InputStatus getInputStatus() {
-        if (firstInputStatus == InputStatus.END_OF_INPUT
-                && secondInputStatus == InputStatus.END_OF_INPUT) {
-            return InputStatus.END_OF_INPUT;
+    private DataInputStatus getInputStatus() {
+        if (firstInputStatus == DataInputStatus.END_OF_INPUT
+                && secondInputStatus == DataInputStatus.END_OF_INPUT) {
+            return DataInputStatus.END_OF_INPUT;
         }
 
         if (inputSelectionHandler.areAllInputsSelected()) {
-            if (firstInputStatus == InputStatus.MORE_AVAILABLE
-                    || secondInputStatus == InputStatus.MORE_AVAILABLE) {
-                return InputStatus.MORE_AVAILABLE;
+            if (firstInputStatus == DataInputStatus.MORE_AVAILABLE
+                    || secondInputStatus == DataInputStatus.MORE_AVAILABLE) {
+                return DataInputStatus.MORE_AVAILABLE;
             } else {
-                return InputStatus.NOTHING_AVAILABLE;
+                return DataInputStatus.NOTHING_AVAILABLE;
             }
         }
 
-        InputStatus selectedStatus =
+        DataInputStatus selectedStatus =
                 inputSelectionHandler.isFirstInputSelected() ? firstInputStatus : secondInputStatus;
-        InputStatus otherStatus =
+        DataInputStatus otherStatus =
                 inputSelectionHandler.isFirstInputSelected() ? secondInputStatus : firstInputStatus;
-        return selectedStatus == InputStatus.END_OF_INPUT ? otherStatus : selectedStatus;
+        return selectedStatus == DataInputStatus.END_OF_INPUT ? otherStatus : selectedStatus;
     }
 
     @Override
@@ -186,12 +185,12 @@ public final class StreamTwoInputProcessor<IN1, IN2> implements StreamInputProce
             return;
         }
         if (inputSelectionHandler.isFirstInputSelected()
-                && firstInputStatus == InputStatus.END_OF_INPUT) {
+                && firstInputStatus == DataInputStatus.END_OF_INPUT) {
             throw new IOException(
                     "Can not make a progress: only first input is selected but it is already finished");
         }
         if (inputSelectionHandler.isSecondInputSelected()
-                && secondInputStatus == InputStatus.END_OF_INPUT) {
+                && secondInputStatus == DataInputStatus.END_OF_INPUT) {
             throw new IOException(
                     "Can not make a progress: only second input is selected but it is already finished");
         }
@@ -203,9 +202,9 @@ public final class StreamTwoInputProcessor<IN1, IN2> implements StreamInputProce
     }
 
     private void updateAvailability(
-            InputStatus status, StreamOneInputProcessor<?> input, int inputIdx) {
-        if (status == InputStatus.MORE_AVAILABLE
-                || (status != InputStatus.END_OF_INPUT && input.isApproximatelyAvailable())) {
+            DataInputStatus status, StreamOneInputProcessor<?> input, int inputIdx) {
+        if (status == DataInputStatus.MORE_AVAILABLE
+                || (status != DataInputStatus.END_OF_INPUT && input.isApproximatelyAvailable())) {
             inputSelectionHandler.setAvailableInput(inputIdx);
         } else {
             inputSelectionHandler.setUnavailableInput(inputIdx);
@@ -213,8 +212,8 @@ public final class StreamTwoInputProcessor<IN1, IN2> implements StreamInputProce
     }
 
     private void checkAndSetAvailable(int inputIndex) {
-        InputStatus status = (inputIndex == 0 ? firstInputStatus : secondInputStatus);
-        if (status == InputStatus.END_OF_INPUT) {
+        DataInputStatus status = (inputIndex == 0 ? firstInputStatus : secondInputStatus);
+        if (status == DataInputStatus.END_OF_INPUT) {
             return;
         }
 
@@ -228,11 +227,11 @@ public final class StreamTwoInputProcessor<IN1, IN2> implements StreamInputProce
     }
 
     private CompletableFuture<?> isAnyInputAvailable() {
-        if (firstInputStatus == InputStatus.END_OF_INPUT) {
+        if (firstInputStatus == DataInputStatus.END_OF_INPUT) {
             return processor2.getAvailableFuture();
         }
 
-        if (secondInputStatus == InputStatus.END_OF_INPUT) {
+        if (secondInputStatus == DataInputStatus.END_OF_INPUT) {
             return processor1.getAvailableFuture();
         }
 

--- a/flink-streaming-java/src/main/java/org/apache/flink/streaming/runtime/io/recovery/RescalingStreamTaskNetworkInput.java
+++ b/flink-streaming-java/src/main/java/org/apache/flink/streaming/runtime/io/recovery/RescalingStreamTaskNetworkInput.java
@@ -20,7 +20,6 @@ package org.apache.flink.streaming.runtime.io.recovery;
 import org.apache.flink.annotation.Internal;
 import org.apache.flink.api.common.TaskInfo;
 import org.apache.flink.api.common.typeutils.TypeSerializer;
-import org.apache.flink.core.io.InputStatus;
 import org.apache.flink.runtime.checkpoint.CheckpointException;
 import org.apache.flink.runtime.checkpoint.InflightDataRescalingDescriptor;
 import org.apache.flink.runtime.checkpoint.channel.ChannelStateWriter;
@@ -33,6 +32,7 @@ import org.apache.flink.runtime.io.network.api.serialization.SpillingAdaptiveSpa
 import org.apache.flink.runtime.io.network.partition.consumer.BufferOrEvent;
 import org.apache.flink.runtime.plugable.DeserializationDelegate;
 import org.apache.flink.streaming.runtime.io.AbstractStreamTaskNetworkInput;
+import org.apache.flink.streaming.runtime.io.DataInputStatus;
 import org.apache.flink.streaming.runtime.io.RecoverableStreamTaskInput;
 import org.apache.flink.streaming.runtime.io.StreamTaskInput;
 import org.apache.flink.streaming.runtime.io.StreamTaskNetworkInput;
@@ -173,13 +173,13 @@ public final class RescalingStreamTaskNetworkInput<T>
         return deserialier;
     }
 
-    protected InputStatus processEvent(BufferOrEvent bufferOrEvent) {
+    protected DataInputStatus processEvent(BufferOrEvent bufferOrEvent) {
         // Event received
         final AbstractEvent event = bufferOrEvent.getEvent();
         if (event instanceof SubtaskConnectionDescriptor) {
             getActiveSerializer(bufferOrEvent.getChannelInfo())
                     .select((SubtaskConnectionDescriptor) event);
-            return InputStatus.MORE_AVAILABLE;
+            return DataInputStatus.MORE_AVAILABLE;
         }
         return super.processEvent(bufferOrEvent);
     }

--- a/flink-streaming-java/src/main/java/org/apache/flink/streaming/runtime/tasks/StreamTask.java
+++ b/flink-streaming-java/src/main/java/org/apache/flink/streaming/runtime/tasks/StreamTask.java
@@ -22,7 +22,6 @@ import org.apache.flink.annotation.VisibleForTesting;
 import org.apache.flink.configuration.TaskManagerOptions;
 import org.apache.flink.core.fs.CloseableRegistry;
 import org.apache.flink.core.fs.Path;
-import org.apache.flink.core.io.InputStatus;
 import org.apache.flink.core.security.FlinkSecurityManager;
 import org.apache.flink.metrics.Counter;
 import org.apache.flink.metrics.SimpleCounter;
@@ -71,6 +70,7 @@ import org.apache.flink.streaming.api.operators.InternalTimeServiceManagerImpl;
 import org.apache.flink.streaming.api.operators.StreamOperator;
 import org.apache.flink.streaming.api.operators.StreamTaskStateInitializer;
 import org.apache.flink.streaming.api.operators.StreamTaskStateInitializerImpl;
+import org.apache.flink.streaming.runtime.io.DataInputStatus;
 import org.apache.flink.streaming.runtime.io.RecordWriterOutput;
 import org.apache.flink.streaming.runtime.io.StreamInputProcessor;
 import org.apache.flink.streaming.runtime.io.checkpointing.CheckpointBarrierHandler;
@@ -428,11 +428,11 @@ public abstract class StreamTask<OUT, OP extends StreamOperator<OUT>> extends Ab
      * @throws Exception on any problems in the action.
      */
     protected void processInput(MailboxDefaultAction.Controller controller) throws Exception {
-        InputStatus status = inputProcessor.processInput();
-        if (status == InputStatus.MORE_AVAILABLE && recordWriter.isAvailable()) {
+        DataInputStatus status = inputProcessor.processInput();
+        if (status == DataInputStatus.MORE_AVAILABLE && recordWriter.isAvailable()) {
             return;
         }
-        if (status == InputStatus.END_OF_INPUT) {
+        if (status == DataInputStatus.END_OF_INPUT) {
             // Suspend the mailbox processor, it would be resumed in afterInvoke and finished
             // after all records processed by the downstream tasks. We also suspend the default
             // actions to avoid repeat executing the empty default operation (namely process

--- a/flink-streaming-java/src/main/java/org/apache/flink/streaming/runtime/tasks/StreamTaskFinishedOnRestoreSourceInput.java
+++ b/flink-streaming-java/src/main/java/org/apache/flink/streaming/runtime/tasks/StreamTaskFinishedOnRestoreSourceInput.java
@@ -18,8 +18,8 @@
 
 package org.apache.flink.streaming.runtime.tasks;
 
-import org.apache.flink.core.io.InputStatus;
 import org.apache.flink.streaming.api.operators.SourceOperator;
+import org.apache.flink.streaming.runtime.io.DataInputStatus;
 import org.apache.flink.streaming.runtime.io.StreamTaskSourceInput;
 
 import java.util.concurrent.CompletableFuture;
@@ -36,8 +36,8 @@ public class StreamTaskFinishedOnRestoreSourceInput<T> extends StreamTaskSourceI
     }
 
     @Override
-    public InputStatus emitNext(DataOutput<T> output) throws Exception {
-        return InputStatus.END_OF_INPUT;
+    public DataInputStatus emitNext(DataOutput<T> output) throws Exception {
+        return DataInputStatus.END_OF_INPUT;
     }
 
     @Override

--- a/flink-streaming-java/src/test/java/org/apache/flink/streaming/api/operators/sort/CollectionDataInput.java
+++ b/flink-streaming-java/src/test/java/org/apache/flink/streaming/api/operators/sort/CollectionDataInput.java
@@ -18,10 +18,10 @@
 
 package org.apache.flink.streaming.api.operators.sort;
 
-import org.apache.flink.core.io.InputStatus;
 import org.apache.flink.runtime.checkpoint.CheckpointException;
 import org.apache.flink.runtime.checkpoint.channel.ChannelStateWriter;
 import org.apache.flink.streaming.api.watermark.Watermark;
+import org.apache.flink.streaming.runtime.io.DataInputStatus;
 import org.apache.flink.streaming.runtime.io.StreamTaskInput;
 import org.apache.flink.streaming.runtime.streamrecord.StreamElement;
 import org.apache.flink.streaming.runtime.streamrecord.StreamRecord;
@@ -45,7 +45,7 @@ final class CollectionDataInput<E> implements StreamTaskInput<E> {
     }
 
     @Override
-    public InputStatus emitNext(DataOutput<E> output) throws Exception {
+    public DataInputStatus emitNext(DataOutput<E> output) throws Exception {
         if (elementsIterator.hasNext()) {
             StreamElement streamElement = elementsIterator.next();
             if (streamElement instanceof StreamRecord) {
@@ -56,7 +56,9 @@ final class CollectionDataInput<E> implements StreamTaskInput<E> {
                 throw new IllegalStateException("Unsupported element type: " + streamElement);
             }
         }
-        return elementsIterator.hasNext() ? InputStatus.MORE_AVAILABLE : InputStatus.END_OF_INPUT;
+        return elementsIterator.hasNext()
+                ? DataInputStatus.MORE_AVAILABLE
+                : DataInputStatus.END_OF_INPUT;
     }
 
     @Override

--- a/flink-streaming-java/src/test/java/org/apache/flink/streaming/api/operators/sort/LargeSortingDataInputITCase.java
+++ b/flink-streaming-java/src/test/java/org/apache/flink/streaming/api/operators/sort/LargeSortingDataInputITCase.java
@@ -26,7 +26,6 @@ import org.apache.flink.api.java.functions.KeySelector;
 import org.apache.flink.api.java.tuple.Tuple3;
 import org.apache.flink.api.java.typeutils.runtime.TupleSerializer;
 import org.apache.flink.configuration.Configuration;
-import org.apache.flink.core.io.InputStatus;
 import org.apache.flink.runtime.checkpoint.CheckpointException;
 import org.apache.flink.runtime.checkpoint.channel.ChannelStateWriter;
 import org.apache.flink.runtime.io.AvailabilityProvider;
@@ -35,6 +34,7 @@ import org.apache.flink.runtime.operators.testutils.MockEnvironment;
 import org.apache.flink.streaming.api.operators.BoundedMultiInput;
 import org.apache.flink.streaming.api.operators.sort.MultiInputSortingDataInput.SelectableSortingInputs;
 import org.apache.flink.streaming.api.watermark.Watermark;
+import org.apache.flink.streaming.runtime.io.DataInputStatus;
 import org.apache.flink.streaming.runtime.io.MultipleInputSelectionHandler;
 import org.apache.flink.streaming.runtime.io.PushingAsyncDataInput;
 import org.apache.flink.streaming.runtime.io.StreamMultipleInputProcessor;
@@ -82,11 +82,11 @@ public class LargeSortingDataInputITCase {
                                 1.0,
                                 new Configuration(),
                                 new DummyInvokable())) {
-            InputStatus inputStatus;
+            DataInputStatus inputStatus;
             VerifyingOutput<Integer> output = new VerifyingOutput<>(keySelector);
             do {
                 inputStatus = sortingDataInput.emitNext(output);
-            } while (inputStatus != InputStatus.END_OF_INPUT);
+            } while (inputStatus != DataInputStatus.END_OF_INPUT);
 
             assertThat(output.getSeenRecords(), equalTo(numberOfRecords));
         }
@@ -110,11 +110,11 @@ public class LargeSortingDataInputITCase {
                                 1.0,
                                 new Configuration(),
                                 new DummyInvokable())) {
-            InputStatus inputStatus;
+            DataInputStatus inputStatus;
             VerifyingOutput<String> output = new VerifyingOutput<>(keySelector);
             do {
                 inputStatus = sortingDataInput.emitNext(output);
-            } while (inputStatus != InputStatus.END_OF_INPUT);
+            } while (inputStatus != DataInputStatus.END_OF_INPUT);
 
             assertThat(output.getSeenRecords(), equalTo(numberOfRecords));
         }
@@ -164,10 +164,10 @@ public class LargeSortingDataInputITCase {
                                     new StreamOneInputProcessor(
                                             sortedInput2, output, new DummyOperatorChain())
                                 });
-                InputStatus inputStatus;
+                DataInputStatus inputStatus;
                 do {
                     inputStatus = multiSortedProcessor.processInput();
-                } while (inputStatus != InputStatus.END_OF_INPUT);
+                } while (inputStatus != DataInputStatus.END_OF_INPUT);
 
                 assertThat(output.getSeenRecords(), equalTo(numberOfRecords * 2));
             }
@@ -250,19 +250,19 @@ public class LargeSortingDataInputITCase {
         }
 
         @Override
-        public InputStatus emitNext(DataOutput<Tuple3<Integer, String, byte[]>> output)
+        public DataInputStatus emitNext(DataOutput<Tuple3<Integer, String, byte[]>> output)
                 throws Exception {
             if (recordsGenerated >= numberOfRecords) {
-                return InputStatus.END_OF_INPUT;
+                return DataInputStatus.END_OF_INPUT;
             }
 
             output.emitRecord(
                     new StreamRecord<>(
                             Tuple3.of(rnd.nextInt(), randomString(rnd.nextInt(256)), buffer), 1));
             if (recordsGenerated++ >= numberOfRecords) {
-                return InputStatus.END_OF_INPUT;
+                return DataInputStatus.END_OF_INPUT;
             } else {
-                return InputStatus.MORE_AVAILABLE;
+                return DataInputStatus.MORE_AVAILABLE;
             }
         }
 

--- a/flink-streaming-java/src/test/java/org/apache/flink/streaming/api/operators/sort/MultiInputSortingDataInputsTest.java
+++ b/flink-streaming-java/src/test/java/org/apache/flink/streaming/api/operators/sort/MultiInputSortingDataInputsTest.java
@@ -22,12 +22,12 @@ import org.apache.flink.api.common.typeutils.TypeSerializer;
 import org.apache.flink.api.common.typeutils.base.IntSerializer;
 import org.apache.flink.api.java.functions.KeySelector;
 import org.apache.flink.configuration.Configuration;
-import org.apache.flink.core.io.InputStatus;
 import org.apache.flink.runtime.operators.testutils.DummyInvokable;
 import org.apache.flink.runtime.operators.testutils.MockEnvironment;
 import org.apache.flink.streaming.api.operators.BoundedMultiInput;
 import org.apache.flink.streaming.api.operators.sort.MultiInputSortingDataInput.SelectableSortingInputs;
 import org.apache.flink.streaming.api.watermark.Watermark;
+import org.apache.flink.streaming.runtime.io.DataInputStatus;
 import org.apache.flink.streaming.runtime.io.MultipleInputSelectionHandler;
 import org.apache.flink.streaming.runtime.io.StreamMultipleInputProcessor;
 import org.apache.flink.streaming.runtime.io.StreamOneInputProcessor;
@@ -121,10 +121,10 @@ public class MultiInputSortingDataInputsTest {
                 StreamMultipleInputProcessor processor =
                         new StreamMultipleInputProcessor(selectionHandler, inputProcessors);
 
-                InputStatus inputStatus;
+                DataInputStatus inputStatus;
                 do {
                     inputStatus = processor.processInput();
-                } while (inputStatus != InputStatus.END_OF_INPUT);
+                } while (inputStatus != DataInputStatus.END_OF_INPUT);
             }
         }
 
@@ -194,10 +194,10 @@ public class MultiInputSortingDataInputsTest {
                                             input2, collectingDataOutput, new DummyOperatorChain())
                                 });
 
-                InputStatus inputStatus;
+                DataInputStatus inputStatus;
                 do {
                     inputStatus = processor.processInput();
-                } while (inputStatus != InputStatus.END_OF_INPUT);
+                } while (inputStatus != DataInputStatus.END_OF_INPUT);
             }
         }
 
@@ -274,10 +274,10 @@ public class MultiInputSortingDataInputsTest {
                                             input2, collectingDataOutput, new DummyOperatorChain())
                                 });
 
-                InputStatus inputStatus;
+                DataInputStatus inputStatus;
                 do {
                     inputStatus = processor.processInput();
-                } while (inputStatus != InputStatus.END_OF_INPUT);
+                } while (inputStatus != DataInputStatus.END_OF_INPUT);
             }
         }
 

--- a/flink-streaming-java/src/test/java/org/apache/flink/streaming/api/operators/sort/SortingDataInputTest.java
+++ b/flink-streaming-java/src/test/java/org/apache/flink/streaming/api/operators/sort/SortingDataInputTest.java
@@ -22,10 +22,10 @@ import org.apache.flink.api.common.typeutils.base.IntSerializer;
 import org.apache.flink.api.common.typeutils.base.StringSerializer;
 import org.apache.flink.api.java.functions.KeySelector;
 import org.apache.flink.configuration.Configuration;
-import org.apache.flink.core.io.InputStatus;
 import org.apache.flink.runtime.operators.testutils.DummyInvokable;
 import org.apache.flink.runtime.operators.testutils.MockEnvironment;
 import org.apache.flink.streaming.api.watermark.Watermark;
+import org.apache.flink.streaming.runtime.io.DataInputStatus;
 import org.apache.flink.streaming.runtime.streamrecord.StreamRecord;
 
 import org.junit.Test;
@@ -68,10 +68,10 @@ public class SortingDataInputTest {
                         new Configuration(),
                         new DummyInvokable());
 
-        InputStatus inputStatus;
+        DataInputStatus inputStatus;
         do {
             inputStatus = sortingDataInput.emitNext(collectingDataOutput);
-        } while (inputStatus != InputStatus.END_OF_INPUT);
+        } while (inputStatus != DataInputStatus.END_OF_INPUT);
 
         assertThat(
                 collectingDataOutput.events,
@@ -117,10 +117,10 @@ public class SortingDataInputTest {
                         new Configuration(),
                         new DummyInvokable());
 
-        InputStatus inputStatus;
+        DataInputStatus inputStatus;
         do {
             inputStatus = sortingDataInput.emitNext(collectingDataOutput);
-        } while (inputStatus != InputStatus.END_OF_INPUT);
+        } while (inputStatus != DataInputStatus.END_OF_INPUT);
 
         assertThat(
                 collectingDataOutput.events,
@@ -161,10 +161,10 @@ public class SortingDataInputTest {
                         new Configuration(),
                         new DummyInvokable());
 
-        InputStatus inputStatus;
+        DataInputStatus inputStatus;
         do {
             inputStatus = sortingDataInput.emitNext(collectingDataOutput);
-        } while (inputStatus != InputStatus.END_OF_INPUT);
+        } while (inputStatus != DataInputStatus.END_OF_INPUT);
 
         assertThat(
                 collectingDataOutput.events,

--- a/flink-streaming-java/src/test/java/org/apache/flink/streaming/api/operators/source/SourceOperatorEventTimeTest.java
+++ b/flink-streaming-java/src/test/java/org/apache/flink/streaming/api/operators/source/SourceOperatorEventTimeTest.java
@@ -31,6 +31,7 @@ import org.apache.flink.runtime.state.StateInitializationContext;
 import org.apache.flink.runtime.state.StateInitializationContextImpl;
 import org.apache.flink.runtime.state.memory.MemoryStateBackend;
 import org.apache.flink.streaming.api.operators.SourceOperator;
+import org.apache.flink.streaming.runtime.io.DataInputStatus;
 import org.apache.flink.streaming.runtime.tasks.ProcessingTimeService;
 import org.apache.flink.streaming.runtime.tasks.TestProcessingTimeService;
 
@@ -210,7 +211,7 @@ public class SourceOperatorEventTimeTest {
                 createTestOperator(
                         reader, watermarkStrategy, timeService, emitProgressiveWatermarks);
 
-        while (sourceOperator.emitNext(out) != InputStatus.END_OF_INPUT) {
+        while (sourceOperator.emitNext(out) != DataInputStatus.END_OF_INPUT) {
             timeService.setCurrentTime(timeService.getCurrentProcessingTime() + 100);
         }
 

--- a/flink-streaming-java/src/test/java/org/apache/flink/streaming/runtime/io/StreamTaskNetworkInputTest.java
+++ b/flink-streaming-java/src/test/java/org/apache/flink/streaming/runtime/io/StreamTaskNetworkInputTest.java
@@ -19,7 +19,6 @@
 package org.apache.flink.streaming.runtime.io;
 
 import org.apache.flink.api.common.typeutils.base.LongSerializer;
-import org.apache.flink.core.io.InputStatus;
 import org.apache.flink.core.memory.DataOutputSerializer;
 import org.apache.flink.runtime.checkpoint.CheckpointException;
 import org.apache.flink.runtime.checkpoint.CheckpointOptions;
@@ -228,11 +227,11 @@ public class StreamTaskNetworkInputTest {
                         inputGate, inSerializer, numInputChannels, deserializers);
 
         inputGate.sendElement(new StreamRecord<>(42L), 0);
-        assertThat(input.emitNext(output), equalTo(InputStatus.MORE_AVAILABLE));
+        assertThat(input.emitNext(output), equalTo(DataInputStatus.MORE_AVAILABLE));
         inputGate.sendEvent(EndOfChannelStateEvent.INSTANCE, 0);
-        assertThat(input.emitNext(output), equalTo(InputStatus.MORE_AVAILABLE));
+        assertThat(input.emitNext(output), equalTo(DataInputStatus.MORE_AVAILABLE));
         inputGate.sendEvent(EndOfChannelStateEvent.INSTANCE, 1);
-        assertThat(input.emitNext(output), equalTo(InputStatus.END_OF_RECOVERY));
+        assertThat(input.emitNext(output), equalTo(DataInputStatus.END_OF_RECOVERY));
     }
 
     private BufferOrEvent createDataBuffer() throws IOException {
@@ -279,8 +278,8 @@ public class StreamTaskNetworkInputTest {
     private static <T> void assertHasNextElement(StreamTaskInput<T> input, DataOutput<T> output)
             throws Exception {
         assertTrue(input.getAvailableFuture().isDone());
-        InputStatus status = input.emitNext(output);
-        assertThat(status, is(InputStatus.MORE_AVAILABLE));
+        DataInputStatus status = input.emitNext(output);
+        assertThat(status, is(DataInputStatus.MORE_AVAILABLE));
     }
 
     private static class TestRecordDeserializer

--- a/flink-streaming-java/src/test/java/org/apache/flink/streaming/runtime/tasks/StreamTaskTest.java
+++ b/flink-streaming-java/src/test/java/org/apache/flink/streaming/runtime/tasks/StreamTaskTest.java
@@ -27,7 +27,6 @@ import org.apache.flink.api.common.typeutils.base.StringSerializer;
 import org.apache.flink.configuration.Configuration;
 import org.apache.flink.configuration.ReadableConfig;
 import org.apache.flink.core.fs.FSDataInputStream;
-import org.apache.flink.core.io.InputStatus;
 import org.apache.flink.core.testutils.OneShotLatch;
 import org.apache.flink.runtime.checkpoint.CheckpointException;
 import org.apache.flink.runtime.checkpoint.CheckpointMetaData;
@@ -110,6 +109,7 @@ import org.apache.flink.streaming.api.operators.StreamOperatorParameters;
 import org.apache.flink.streaming.api.operators.StreamOperatorStateContext;
 import org.apache.flink.streaming.api.operators.StreamSource;
 import org.apache.flink.streaming.api.operators.StreamTaskStateInitializer;
+import org.apache.flink.streaming.runtime.io.DataInputStatus;
 import org.apache.flink.streaming.runtime.io.StreamInputProcessor;
 import org.apache.flink.streaming.runtime.streamrecord.StreamRecord;
 import org.apache.flink.streaming.runtime.tasks.mailbox.MailboxDefaultAction;
@@ -1868,10 +1868,10 @@ public class StreamTaskTest extends TestLogger {
         }
 
         @Override
-        public InputStatus processInput() {
+        public DataInputStatus processInput() {
             return ++currentNumProcessCalls < totalProcessCalls
-                    ? InputStatus.MORE_AVAILABLE
-                    : InputStatus.END_OF_INPUT;
+                    ? DataInputStatus.MORE_AVAILABLE
+                    : DataInputStatus.END_OF_INPUT;
         }
 
         @Override
@@ -1898,10 +1898,10 @@ public class StreamTaskTest extends TestLogger {
         private final AvailabilityHelper availabilityProvider = new AvailabilityHelper();
 
         @Override
-        public InputStatus processInput() {
+        public DataInputStatus processInput() {
             return availabilityProvider.isAvailable()
-                    ? InputStatus.END_OF_INPUT
-                    : InputStatus.NOTHING_AVAILABLE;
+                    ? DataInputStatus.END_OF_INPUT
+                    : DataInputStatus.NOTHING_AVAILABLE;
         }
 
         @Override
@@ -2089,8 +2089,8 @@ public class StreamTaskTest extends TestLogger {
         }
 
         @Override
-        public InputStatus processInput() throws Exception {
-            return isFinished ? InputStatus.END_OF_INPUT : InputStatus.NOTHING_AVAILABLE;
+        public DataInputStatus processInput() throws Exception {
+            return isFinished ? DataInputStatus.END_OF_INPUT : DataInputStatus.NOTHING_AVAILABLE;
         }
 
         @Override
@@ -2712,8 +2712,8 @@ public class StreamTaskTest extends TestLogger {
             return new StreamInputProcessor() {
 
                 @Override
-                public InputStatus processInput() {
-                    return InputStatus.NOTHING_AVAILABLE;
+                public DataInputStatus processInput() {
+                    return DataInputStatus.NOTHING_AVAILABLE;
                 }
 
                 @Override


### PR DESCRIPTION

## What is the purpose of the change

This commit separates internal and user facing versions of InputStatus.
User sources should never return e.g. the END_OF_RECOVERY status and
thus we need an internal status.

## Verifying this change

This change is a trivial rework / code cleanup without any test coverage.

## Does this pull request potentially affect one of the following parts:

  - Dependencies (does it add or upgrade a dependency): (yes / **no**)
  - The public API, i.e., is any changed class annotated with `@Public(Evolving)`: (**yes** / no)
  - The serializers: (yes / **no** / don't know)
  - The runtime per-record code paths (performance sensitive): (**yes** / no / don't know)
  - Anything that affects deployment or recovery: JobManager (and its components), Checkpointing, Kubernetes/Yarn, ZooKeeper: (yes / **no** / don't know)
  - The S3 file system connector: (yes / **no** / don't know)

## Documentation

  - Does this pull request introduce a new feature? (yes / **no**)
  - If yes, how is the feature documented? (not applicable / docs / **JavaDocs** / not documented)
