### PR TITLE
[FLINK-21504][checkpoint] Introduce notification of subsumed checkpoint

### DIFF
--- a/flink-core/src/main/java/org/apache/flink/api/common/state/InternalCheckpointListener.java
+++ b/flink-core/src/main/java/org/apache/flink/api/common/state/InternalCheckpointListener.java
@@ -1,0 +1,46 @@
+/*
+
+* Licensed to the Apache Software Foundation (ASF) under one
+* or more contributor license agreements.  See the NOTICE file
+* distributed with this work for additional information
+* regarding copyright ownership.  The ASF licenses this file
+* to you under the Apache License, Version 2.0 (the
+* "License"); you may not use this file except in compliance
+* with the License.  You may obtain a copy of the License at
+*
+* http://www.apache.org/licenses/LICENSE-2.0
+*
+* Unless required by applicable law or agreed to in writing, software
+* distributed under the License is distributed on an "AS IS" BASIS,
+* WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+* See the License for the specific language governing permissions and
+* limitations under the License.
+
+*/
+
+package org.apache.flink.api.common.state;
+
+import org.apache.flink.annotation.Internal;
+
+/**
+ * The internal checkpoint listener add another {@link #notifyCheckpointSubsumed(long)} interface
+ * for internal usage.
+ */
+@Internal
+public interface InternalCheckpointListener extends CheckpointListener {
+
+    /**
+     * This method is called as a notification once a distributed checkpoint has been subsumed.
+     *
+     * <p>These notifications are "best effort", meaning they can sometimes be skipped.
+     *
+     * <p>This method is very rarely necessary to implement. The "best effort" guarantee, together
+     * with the fact that this method should not result in discarding any data (per the "Checkpoint
+     * Subsuming Contract") means it is mainly useful for earlier cleanups of auxiliary resources.
+     *
+     * @param checkpointId The ID of the checkpoint that has been subsumed.
+     * @throws Exception This method can propagate exceptions, which leads to a failure/recovery for
+     *     the task or job.
+     */
+    void notifyCheckpointSubsumed(long checkpointId) throws Exception;
+}

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/checkpoint/CheckpointCoordinator.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/checkpoint/CheckpointCoordinator.java
@@ -1333,7 +1333,8 @@ public class CheckpointCoordinator {
         }
     }
 
-    private void sendAcknowledgeMessages(
+    @VisibleForTesting
+    void sendAcknowledgeMessages(
             List<ExecutionVertex> tasksToCommit,
             long completedCheckpointId,
             long completedTimestamp,

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/checkpoint/CheckpointSubsumeHelper.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/checkpoint/CheckpointSubsumeHelper.java
@@ -46,18 +46,25 @@ import java.util.Optional;
 class CheckpointSubsumeHelper {
     private static final Logger LOG = LoggerFactory.getLogger(CheckpointSubsumeHelper.class);
 
-    public static void subsume(
+    public static Optional<CompletedCheckpoint> subsume(
             Deque<CompletedCheckpoint> checkpoints, int numRetain, SubsumeAction subsumeAction)
             throws Exception {
         if (checkpoints.isEmpty() || checkpoints.size() <= numRetain) {
-            return;
+            return Optional.empty();
         }
         CompletedCheckpoint latest = checkpoints.peekLast();
+        Optional<CompletedCheckpoint> lastSubsumedCheckpoint = Optional.empty();
         Optional<CompletedCheckpoint> latestNotSavepoint = getLatestNotSavepoint(checkpoints);
         Iterator<CompletedCheckpoint> iterator = checkpoints.iterator();
         while (checkpoints.size() > numRetain && iterator.hasNext()) {
             CompletedCheckpoint next = iterator.next();
             if (canSubsume(next, latest, latestNotSavepoint)) {
+                // always return the subsumed checkpoint with larger checkpoint id.
+                if (!lastSubsumedCheckpoint.isPresent()
+                        || next.getCheckpointID()
+                                > lastSubsumedCheckpoint.get().getCheckpointID()) {
+                    lastSubsumedCheckpoint = Optional.of(next);
+                }
                 iterator.remove();
                 try {
                     subsumeAction.subsume(next);
@@ -67,6 +74,7 @@ class CheckpointSubsumeHelper {
             }
             // Don't break out from the loop to subsume intermediate savepoints
         }
+        return lastSubsumedCheckpoint;
     }
 
     private static Optional<CompletedCheckpoint> getLatestNotSavepoint(

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/checkpoint/CompletedCheckpointStore.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/checkpoint/CompletedCheckpointStore.java
@@ -23,6 +23,8 @@ import org.apache.flink.api.common.JobStatus;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
+import javax.annotation.Nullable;
+
 import java.util.List;
 
 /** A bounded LIFO-queue of {@link CompletedCheckpoint} instances. */
@@ -35,8 +37,12 @@ public interface CompletedCheckpointStore {
      *
      * <p>Only a bounded number of checkpoints is kept. When exceeding the maximum number of
      * retained checkpoints, the oldest one will be discarded.
+     *
+     * @return the subsumed oldest completed checkpoint if possible, return null if no checkpoint
+     *     needs to be discarded on subsume.
      */
-    void addCheckpoint(
+    @Nullable
+    CompletedCheckpoint addCheckpointAndSubsumeOldestOne(
             CompletedCheckpoint checkpoint,
             CheckpointsCleaner checkpointsCleaner,
             Runnable postCleanup)

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/checkpoint/DeactivatedCheckpointCompletedCheckpointStore.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/checkpoint/DeactivatedCheckpointCompletedCheckpointStore.java
@@ -31,7 +31,7 @@ public enum DeactivatedCheckpointCompletedCheckpointStore implements CompletedCh
     INSTANCE;
 
     @Override
-    public void addCheckpoint(
+    public CompletedCheckpoint addCheckpointAndSubsumeOldestOne(
             CompletedCheckpoint checkpoint,
             CheckpointsCleaner checkpointsCleaner,
             Runnable postCleanup)

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/checkpoint/EmbeddedCompletedCheckpointStore.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/checkpoint/EmbeddedCompletedCheckpointStore.java
@@ -60,7 +60,7 @@ public class EmbeddedCompletedCheckpointStore implements CompletedCheckpointStor
     }
 
     @Override
-    public void addCheckpoint(
+    public CompletedCheckpoint addCheckpointAndSubsumeOldestOne(
             CompletedCheckpoint checkpoint,
             CheckpointsCleaner checkpointsCleaner,
             Runnable postCleanup)
@@ -69,8 +69,10 @@ public class EmbeddedCompletedCheckpointStore implements CompletedCheckpointStor
             throwAlreadyShutdownException(shutdownStatus.get());
         }
         checkpoints.addLast(checkpoint);
-        CheckpointSubsumeHelper.subsume(
-                checkpoints, maxRetainedCheckpoints, CompletedCheckpoint::discardOnSubsume);
+
+        return CheckpointSubsumeHelper.subsume(
+                        checkpoints, maxRetainedCheckpoints, CompletedCheckpoint::discardOnSubsume)
+                .orElse(null);
     }
 
     @VisibleForTesting

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/checkpoint/StandaloneCompletedCheckpointStore.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/checkpoint/StandaloneCompletedCheckpointStore.java
@@ -24,6 +24,8 @@ import org.apache.flink.runtime.jobmanager.HighAvailabilityMode;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
+import javax.annotation.Nullable;
+
 import java.util.ArrayDeque;
 import java.util.ArrayList;
 import java.util.List;
@@ -56,8 +58,9 @@ public class StandaloneCompletedCheckpointStore implements CompletedCheckpointSt
         this.checkpoints = new ArrayDeque<>(maxNumberOfCheckpointsToRetain + 1);
     }
 
+    @Nullable
     @Override
-    public void addCheckpoint(
+    public CompletedCheckpoint addCheckpointAndSubsumeOldestOne(
             CompletedCheckpoint checkpoint,
             CheckpointsCleaner checkpointsCleaner,
             Runnable postCleanup)
@@ -65,8 +68,11 @@ public class StandaloneCompletedCheckpointStore implements CompletedCheckpointSt
 
         checkpoints.addLast(checkpoint);
 
-        CheckpointSubsumeHelper.subsume(
-                checkpoints, maxNumberOfCheckpointsToRetain, CompletedCheckpoint::discardOnSubsume);
+        return CheckpointSubsumeHelper.subsume(
+                        checkpoints,
+                        maxNumberOfCheckpointsToRetain,
+                        CompletedCheckpoint::discardOnSubsume)
+                .orElse(null);
     }
 
     @Override

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/executiongraph/Execution.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/executiongraph/Execution.java
@@ -777,19 +777,28 @@ public class Execution
     }
 
     /**
-     * Notify the task of this execution about a completed checkpoint.
+     * Notify the task of this execution about a completed checkpoint and the last subsumed
+     * checkpoint id if possible.
      *
-     * @param checkpointId of the completed checkpoint
-     * @param timestamp of the completed checkpoint
+     * @param completedCheckpointId of the completed checkpoint
+     * @param completedTimestamp of the completed checkpoint
+     * @param lastSubsumedCheckpointId of the last subsumed checkpoint, a value of {@link
+     *     org.apache.flink.runtime.checkpoint.CheckpointStoreUtil#INVALID_CHECKPOINT_ID} means no
+     *     checkpoint has been subsumed.
      */
-    public void notifyCheckpointComplete(long checkpointId, long timestamp) {
+    public void notifyCheckpointOnComplete(
+            long completedCheckpointId, long completedTimestamp, long lastSubsumedCheckpointId) {
         final LogicalSlot slot = assignedResource;
 
         if (slot != null) {
             final TaskManagerGateway taskManagerGateway = slot.getTaskManagerGateway();
 
-            taskManagerGateway.notifyCheckpointComplete(
-                    attemptId, getVertex().getJobId(), checkpointId, timestamp);
+            taskManagerGateway.notifyCheckpointOnComplete(
+                    attemptId,
+                    getVertex().getJobId(),
+                    completedCheckpointId,
+                    completedTimestamp,
+                    lastSubsumedCheckpointId);
         } else {
             LOG.debug(
                     "The execution has no slot assigned. This indicates that the execution is "

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/jobgraph/tasks/AbstractInvokable.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/jobgraph/tasks/AbstractInvokable.java
@@ -208,6 +208,13 @@ public abstract class AbstractInvokable
     }
 
     @Override
+    public Future<Void> notifyCheckpointSubsumedAsync(long checkpointId) {
+        throw new UnsupportedOperationException(
+                String.format(
+                        "notifyCheckpointSubsumeAsync not supported by %s",
+                        this.getClass().getName()));
+    }
+
     public void dispatchOperatorEvent(OperatorID operator, SerializedValue<OperatorEvent> event)
             throws FlinkException {
         throw new UnsupportedOperationException(

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/jobgraph/tasks/CheckpointableTask.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/jobgraph/tasks/CheckpointableTask.java
@@ -88,6 +88,15 @@ public interface CheckpointableTask {
     Future<Void> notifyCheckpointAbortAsync(long checkpointId, long latestCompletedCheckpointId);
 
     /**
+     * Invoked when a checkpoint has been subsumed, i.e., when the checkpoint coordinator has
+     * confirmed one checkpoint has been finished, and try to remove the first previous checkpoint.
+     *
+     * @param checkpointId The ID of the checkpoint that is subsumed.
+     * @return future that completes when the notification has been processed by the task.
+     */
+    Future<Void> notifyCheckpointSubsumedAsync(long checkpointId);
+
+    /**
      * Aborts a checkpoint as the result of receiving possibly some checkpoint barriers, but at
      * least one {@link org.apache.flink.runtime.io.network.api.CancelCheckpointMarker}.
      *

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/jobmanager/slots/TaskManagerGateway.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/jobmanager/slots/TaskManagerGateway.java
@@ -86,15 +86,21 @@ public interface TaskManagerGateway extends TaskExecutorOperatorEventGateway {
     void releasePartitions(JobID jobId, Set<ResultPartitionID> partitionIds);
 
     /**
-     * Notify the given task about a completed checkpoint.
+     * Notify the given task about a completed checkpoint and the last subsumed checkpoint id if
+     * possible.
      *
      * @param executionAttemptID identifying the task
      * @param jobId identifying the job to which the task belongs
-     * @param checkpointId of the completed checkpoint
-     * @param timestamp of the completed checkpoint
+     * @param completedCheckpointId of the completed checkpoint
+     * @param completedTimestamp of the completed checkpoint
+     * @param lastSubsumedCheckpointId of the last subsumed checkpoint id,
      */
-    void notifyCheckpointComplete(
-            ExecutionAttemptID executionAttemptID, JobID jobId, long checkpointId, long timestamp);
+    void notifyCheckpointOnComplete(
+            ExecutionAttemptID executionAttemptID,
+            JobID jobId,
+            long completedCheckpointId,
+            long completedTimestamp,
+            long lastSubsumedCheckpointId);
 
     /**
      * Notify the given task about a aborted checkpoint.

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/jobmaster/RpcTaskManagerGateway.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/jobmaster/RpcTaskManagerGateway.java
@@ -80,9 +80,17 @@ public class RpcTaskManagerGateway implements TaskManagerGateway {
     }
 
     @Override
-    public void notifyCheckpointComplete(
-            ExecutionAttemptID executionAttemptID, JobID jobId, long checkpointId, long timestamp) {
-        taskExecutorGateway.confirmCheckpoint(executionAttemptID, checkpointId, timestamp);
+    public void notifyCheckpointOnComplete(
+            ExecutionAttemptID executionAttemptID,
+            JobID jobId,
+            long completedCheckpointId,
+            long completedTimestamp,
+            long lastSubsumedCheckpointId) {
+        taskExecutorGateway.confirmCheckpoint(
+                executionAttemptID,
+                completedCheckpointId,
+                completedTimestamp,
+                lastSubsumedCheckpointId);
     }
 
     @Override

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/state/AbstractKeyedStateBackend.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/state/AbstractKeyedStateBackend.java
@@ -20,7 +20,7 @@ package org.apache.flink.runtime.state;
 
 import org.apache.flink.annotation.VisibleForTesting;
 import org.apache.flink.api.common.ExecutionConfig;
-import org.apache.flink.api.common.state.CheckpointListener;
+import org.apache.flink.api.common.state.InternalCheckpointListener;
 import org.apache.flink.api.common.state.State;
 import org.apache.flink.api.common.state.StateDescriptor;
 import org.apache.flink.api.common.typeutils.TypeSerializer;
@@ -52,7 +52,7 @@ import static org.apache.flink.util.Preconditions.checkNotNull;
  */
 public abstract class AbstractKeyedStateBackend<K>
         implements CheckpointableKeyedStateBackend<K>,
-                CheckpointListener,
+                InternalCheckpointListener,
                 TestableKeyedStateBackend<K>,
                 InternalKeyContext<K> {
 
@@ -163,6 +163,9 @@ public abstract class AbstractKeyedStateBackend<K>
             return UncompressedStreamCompressionDecorator.INSTANCE;
         }
     }
+
+    @Override
+    public void notifyCheckpointSubsumed(long checkpointId) throws Exception {}
 
     /**
      * Closes the state backend, releasing all internal resources, but does not delete any

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/taskexecutor/TaskExecutor.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/taskexecutor/TaskExecutor.java
@@ -981,18 +981,23 @@ public class TaskExecutor extends RpcEndpoint implements TaskExecutorGateway {
 
     @Override
     public CompletableFuture<Acknowledge> confirmCheckpoint(
-            ExecutionAttemptID executionAttemptID, long checkpointId, long checkpointTimestamp) {
+            ExecutionAttemptID executionAttemptID,
+            long completedCheckpointId,
+            long completedCheckpointTimestamp,
+            long lastSubsumedCheckpointId) {
         log.debug(
-                "Confirm checkpoint {}@{} for {}.",
-                checkpointId,
-                checkpointTimestamp,
+                "Confirm completed checkpoint {}@{} and last subsumed checkpoint {} for {}.",
+                completedCheckpointId,
+                completedCheckpointTimestamp,
+                lastSubsumedCheckpointId,
                 executionAttemptID);
 
         final Task task = taskSlotTable.getTask(executionAttemptID);
 
         if (task != null) {
-            task.notifyCheckpointComplete(checkpointId);
+            task.notifyCheckpointComplete(completedCheckpointId);
 
+            task.notifyCheckpointSubsumed(lastSubsumedCheckpointId);
             return CompletableFuture.completedFuture(Acknowledge.get());
         } else {
             final String message =

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/taskexecutor/TaskExecutorGateway.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/taskexecutor/TaskExecutorGateway.java
@@ -143,12 +143,16 @@ public interface TaskExecutorGateway
      * and the checkpoint timestamp.
      *
      * @param executionAttemptID identifying the task
-     * @param checkpointId unique id for the checkpoint
-     * @param checkpointTimestamp is the timestamp when the checkpoint has been initiated
+     * @param completedCheckpointId unique id for the completed checkpoint
+     * @param completedCheckpointTimestamp is the timestamp when the checkpoint has been initiated
+     * @param lastSubsumedCheckpointId unique id for the checkpoint to be subsumed
      * @return Future acknowledge if the checkpoint has been successfully confirmed
      */
     CompletableFuture<Acknowledge> confirmCheckpoint(
-            ExecutionAttemptID executionAttemptID, long checkpointId, long checkpointTimestamp);
+            ExecutionAttemptID executionAttemptID,
+            long completedCheckpointId,
+            long completedCheckpointTimestamp,
+            long lastSubsumedCheckpointId);
 
     /**
      * Abort a checkpoint for the given task. The checkpoint is identified by the checkpoint ID and

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/taskexecutor/TaskExecutorGatewayDecoratorBase.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/taskexecutor/TaskExecutorGatewayDecoratorBase.java
@@ -131,9 +131,15 @@ public class TaskExecutorGatewayDecoratorBase implements TaskExecutorGateway {
 
     @Override
     public CompletableFuture<Acknowledge> confirmCheckpoint(
-            ExecutionAttemptID executionAttemptID, long checkpointId, long checkpointTimestamp) {
+            ExecutionAttemptID executionAttemptID,
+            long completedCheckpointId,
+            long completedCheckpointTimestamp,
+            long lastSubsumedCheckpointId) {
         return originalGateway.confirmCheckpoint(
-                executionAttemptID, checkpointId, checkpointTimestamp);
+                executionAttemptID,
+                completedCheckpointId,
+                completedCheckpointTimestamp,
+                lastSubsumedCheckpointId);
     }
 
     @Override

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/taskmanager/Task.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/taskmanager/Task.java
@@ -36,6 +36,7 @@ import org.apache.flink.runtime.checkpoint.CheckpointException;
 import org.apache.flink.runtime.checkpoint.CheckpointFailureReason;
 import org.apache.flink.runtime.checkpoint.CheckpointMetaData;
 import org.apache.flink.runtime.checkpoint.CheckpointOptions;
+import org.apache.flink.runtime.checkpoint.CheckpointStoreUtil;
 import org.apache.flink.runtime.clusterframework.types.AllocationID;
 import org.apache.flink.runtime.deployment.InputGateDeploymentDescriptor;
 import org.apache.flink.runtime.deployment.ResultPartitionDeploymentDescriptor;
@@ -1395,59 +1396,80 @@ public class Task
     }
 
     public void notifyCheckpointComplete(final long checkpointID) {
-        final TaskInvokable invokable = this.invokable;
-
-        if (executionState == ExecutionState.RUNNING) {
-            checkState(invokable instanceof CheckpointableTask, "invokable is not checkpointable");
-            try {
-                ((CheckpointableTask) invokable).notifyCheckpointCompleteAsync(checkpointID);
-            } catch (RejectedExecutionException ex) {
-                // This may happen if the mailbox is closed. It means that the task is shutting
-                // down, so we just ignore it.
-                LOG.debug(
-                        "Notify checkpoint complete {} for {} ({}) was rejected by the mailbox",
-                        checkpointID,
-                        taskNameWithSubtask,
-                        executionId);
-            } catch (Throwable t) {
-                if (getExecutionState() == ExecutionState.RUNNING) {
-                    // fail task if checkpoint confirmation failed.
-                    failExternally(new RuntimeException("Error while confirming checkpoint", t));
-                }
-            }
-        } else {
-            LOG.debug(
-                    "Ignoring checkpoint commit notification for non-running task {}.",
-                    taskNameWithSubtask);
-        }
+        notifyCheckpoint(
+                checkpointID,
+                CheckpointStoreUtil.INVALID_CHECKPOINT_ID,
+                NotifyCheckpointOperation.COMPLETE);
     }
 
     public void notifyCheckpointAborted(
             final long checkpointID, final long latestCompletedCheckpointId) {
-        final TaskInvokable invokable = this.invokable;
+        notifyCheckpoint(
+                checkpointID, latestCompletedCheckpointId, NotifyCheckpointOperation.ABORT);
+    }
 
-        if (executionState == ExecutionState.RUNNING) {
+    public void notifyCheckpointSubsumed(long checkpointID) {
+        notifyCheckpoint(
+                checkpointID,
+                CheckpointStoreUtil.INVALID_CHECKPOINT_ID,
+                NotifyCheckpointOperation.SUBSUME);
+    }
+
+    private void notifyCheckpoint(
+            long checkpointId,
+            long latestCompletedCheckpointId,
+            NotifyCheckpointOperation notifyCheckpointOperation) {
+        TaskInvokable invokable = this.invokable;
+
+        if (executionState == ExecutionState.RUNNING && invokable != null) {
             checkState(invokable instanceof CheckpointableTask, "invokable is not checkpointable");
             try {
-                ((CheckpointableTask) invokable)
-                        .notifyCheckpointAbortAsync(checkpointID, latestCompletedCheckpointId);
+                switch (notifyCheckpointOperation) {
+                    case ABORT:
+                        ((CheckpointableTask) invokable)
+                                .notifyCheckpointAbortAsync(
+                                        checkpointId, latestCompletedCheckpointId);
+                        break;
+                    case COMPLETE:
+                        ((CheckpointableTask) invokable)
+                                .notifyCheckpointCompleteAsync(checkpointId);
+                        break;
+                    case SUBSUME:
+                        ((CheckpointableTask) invokable)
+                                .notifyCheckpointSubsumedAsync(checkpointId);
+                }
             } catch (RejectedExecutionException ex) {
                 // This may happen if the mailbox is closed. It means that the task is shutting
                 // down, so we just ignore it.
                 LOG.debug(
-                        "Notify checkpoint abort {} for {} ({}) was rejected by the mailbox",
-                        checkpointID,
+                        "Notify checkpoint {}} {} for {} ({}) was rejected by the mailbox.",
+                        notifyCheckpointOperation,
+                        checkpointId,
                         taskNameWithSubtask,
                         executionId);
             } catch (Throwable t) {
-                if (getExecutionState() == ExecutionState.RUNNING) {
-                    // fail task if checkpoint aborted notification failed.
-                    failExternally(new RuntimeException("Error while aborting checkpoint", t));
+                switch (notifyCheckpointOperation) {
+                    case ABORT:
+                    case COMPLETE:
+                        if (getExecutionState() == ExecutionState.RUNNING) {
+                            failExternally(
+                                    new RuntimeException(
+                                            String.format(
+                                                    "Error while notify checkpoint %s.",
+                                                    notifyCheckpointOperation),
+                                            t));
+                        }
+                        break;
+                    case SUBSUME:
+                        // just rethrow the throwable out as we do not expect notification of
+                        // subsume could fail the task.
+                        ExceptionUtils.rethrow(t);
                 }
             }
         } else {
             LOG.info(
-                    "Ignoring checkpoint aborted notification for non-running task {}.",
+                    "Ignoring checkpoint {} notification for non-running task {}.",
+                    notifyCheckpointOperation,
                     taskNameWithSubtask);
         }
     }
@@ -1788,5 +1810,12 @@ public class Task
                 action,
                 timeoutMs / 1000,
                 stackTraceStr);
+    }
+
+    /** Various operation of notify checkpoint. */
+    public enum NotifyCheckpointOperation {
+        ABORT,
+        COMPLETE,
+        SUBSUME
     }
 }

--- a/flink-runtime/src/test/java/org/apache/flink/runtime/checkpoint/CheckpointCoordinatorFailureTest.java
+++ b/flink-runtime/src/test/java/org/apache/flink/runtime/checkpoint/CheckpointCoordinatorFailureTest.java
@@ -255,7 +255,7 @@ public class CheckpointCoordinatorFailureTest extends TestLogger {
         }
 
         @Override
-        public void addCheckpoint(
+        public CompletedCheckpoint addCheckpointAndSubsumeOldestOne(
                 CompletedCheckpoint checkpoint,
                 CheckpointsCleaner checkpointsCleaner,
                 Runnable postCleanup)
@@ -276,7 +276,7 @@ public class CheckpointCoordinatorFailureTest extends TestLogger {
 
         @Override
         public List<CompletedCheckpoint> getAllCheckpoints() throws Exception {
-            throw new UnsupportedOperationException("Not implemented.");
+            return Collections.emptyList();
         }
 
         @Override

--- a/flink-runtime/src/test/java/org/apache/flink/runtime/checkpoint/CheckpointCoordinatorMasterHooksTest.java
+++ b/flink-runtime/src/test/java/org/apache/flink/runtime/checkpoint/CheckpointCoordinatorMasterHooksTest.java
@@ -308,7 +308,8 @@ public class CheckpointCoordinatorMasterHooksTest {
         cc.addMasterHook(statelessHook);
         cc.addMasterHook(statefulHook2);
 
-        cc.getCheckpointStore().addCheckpoint(checkpoint, new CheckpointsCleaner(), () -> {});
+        cc.getCheckpointStore()
+                .addCheckpointAndSubsumeOldestOne(checkpoint, new CheckpointsCleaner(), () -> {});
         cc.restoreLatestCheckpointedStateToAll(Collections.emptySet(), false);
 
         verify(statefulHook1, times(1)).restoreCheckpoint(eq(checkpointId), eq(state1));
@@ -367,7 +368,8 @@ public class CheckpointCoordinatorMasterHooksTest {
         cc.addMasterHook(statefulHook);
         cc.addMasterHook(statelessHook);
 
-        cc.getCheckpointStore().addCheckpoint(checkpoint, new CheckpointsCleaner(), () -> {});
+        cc.getCheckpointStore()
+                .addCheckpointAndSubsumeOldestOne(checkpoint, new CheckpointsCleaner(), () -> {});
 
         // since we have unmatched state, this should fail
         try {

--- a/flink-runtime/src/test/java/org/apache/flink/runtime/checkpoint/CheckpointCoordinatorRestoringTest.java
+++ b/flink-runtime/src/test/java/org/apache/flink/runtime/checkpoint/CheckpointCoordinatorRestoringTest.java
@@ -941,7 +941,8 @@ public class CheckpointCoordinatorRestoringTest extends TestLogger {
                 new StandaloneCompletedCheckpointStore(checkpoints.length);
         CheckpointsCleaner checkpointsCleaner = new CheckpointsCleaner();
         for (final CompletedCheckpoint checkpoint : checkpoints) {
-            store.addCheckpoint(checkpoint, checkpointsCleaner, postCleanupAction);
+            store.addCheckpointAndSubsumeOldestOne(
+                    checkpoint, checkpointsCleaner, postCleanupAction);
         }
         return store;
     }
@@ -1082,7 +1083,7 @@ public class CheckpointCoordinatorRestoringTest extends TestLogger {
                         CheckpointProperties.forCheckpoint(
                                 CheckpointRetentionPolicy.NEVER_RETAIN_AFTER_TERMINATION),
                         new TestCompletedCheckpointStorageLocation());
-        completedCheckpointStore.addCheckpoint(
+        completedCheckpointStore.addCheckpointAndSubsumeOldestOne(
                 completedCheckpoint, new CheckpointsCleaner(), () -> {});
 
         CheckpointCoordinator coord =
@@ -1141,7 +1142,7 @@ public class CheckpointCoordinatorRestoringTest extends TestLogger {
                 op2.getGeneratedOperatorID(),
                 new OperatorState(op2.getGeneratedOperatorID(), 1, 1));
         CompletedCheckpointStore store = new EmbeddedCompletedCheckpointStore();
-        store.addCheckpoint(
+        store.addCheckpointAndSubsumeOldestOne(
                 new CompletedCheckpoint(
                         graph.getJobID(),
                         2,
@@ -1352,7 +1353,7 @@ public class CheckpointCoordinatorRestoringTest extends TestLogger {
                 createOperatorState(op2.getGeneratedOperatorID(), secondOperatorFinishedState));
 
         CompletedCheckpointStore store = new EmbeddedCompletedCheckpointStore();
-        store.addCheckpoint(
+        store.addCheckpointAndSubsumeOldestOne(
                 new CompletedCheckpoint(
                         graph.getJobID(),
                         2,

--- a/flink-runtime/src/test/java/org/apache/flink/runtime/checkpoint/CheckpointCoordinatorTest.java
+++ b/flink-runtime/src/test/java/org/apache/flink/runtime/checkpoint/CheckpointCoordinatorTest.java
@@ -2771,7 +2771,7 @@ public class CheckpointCoordinatorTest extends TestLogger {
                         .setCheckpointStatsTracker(tracker)
                         .build();
 
-        store.addCheckpoint(
+        store.addCheckpointAndSubsumeOldestOne(
                 new CompletedCheckpoint(
                         new JobID(),
                         0,

--- a/flink-runtime/src/test/java/org/apache/flink/runtime/checkpoint/CheckpointCoordinatorTestingUtils.java
+++ b/flink-runtime/src/test/java/org/apache/flink/runtime/checkpoint/CheckpointCoordinatorTestingUtils.java
@@ -501,11 +501,15 @@ public class CheckpointCoordinatorTestingUtils {
         }
 
         @Override
-        public void notifyCheckpointComplete(
-                ExecutionAttemptID attemptId, JobID jobId, long checkpointId, long timestamp) {
+        public void notifyCheckpointOnComplete(
+                ExecutionAttemptID attemptId,
+                JobID jobId,
+                long completedCheckpointId,
+                long completedTimestamp,
+                long lastSubsumedCheckpointId) {
             notifiedCompletedCheckpoints
                     .computeIfAbsent(attemptId, k -> new ArrayList<>())
-                    .add(new NotifiedCheckpoint(jobId, checkpointId, timestamp));
+                    .add(new NotifiedCheckpoint(jobId, completedCheckpointId, completedTimestamp));
         }
 
         @Override

--- a/flink-runtime/src/test/java/org/apache/flink/runtime/checkpoint/CheckpointStateRestoreTest.java
+++ b/flink-runtime/src/test/java/org/apache/flink/runtime/checkpoint/CheckpointStateRestoreTest.java
@@ -241,7 +241,8 @@ public class CheckpointStateRestoreTest {
                                 CheckpointRetentionPolicy.NEVER_RETAIN_AFTER_TERMINATION),
                         new TestCompletedCheckpointStorageLocation());
 
-        coord.getCheckpointStore().addCheckpoint(checkpoint, new CheckpointsCleaner(), () -> {});
+        coord.getCheckpointStore()
+                .addCheckpointAndSubsumeOldestOne(checkpoint, new CheckpointsCleaner(), () -> {});
 
         assertTrue(coord.restoreLatestCheckpointedStateToAll(tasks, false));
         assertTrue(coord.restoreLatestCheckpointedStateToAll(tasks, true));
@@ -270,7 +271,8 @@ public class CheckpointStateRestoreTest {
                                 CheckpointRetentionPolicy.NEVER_RETAIN_AFTER_TERMINATION),
                         new TestCompletedCheckpointStorageLocation());
 
-        coord.getCheckpointStore().addCheckpoint(checkpoint, new CheckpointsCleaner(), () -> {});
+        coord.getCheckpointStore()
+                .addCheckpointAndSubsumeOldestOne(checkpoint, new CheckpointsCleaner(), () -> {});
 
         // (i) Allow non restored state (should succeed)
         final boolean restored = coord.restoreLatestCheckpointedStateToAll(tasks, true);

--- a/flink-runtime/src/test/java/org/apache/flink/runtime/checkpoint/CompletedCheckpointStoreTest.java
+++ b/flink-runtime/src/test/java/org/apache/flink/runtime/checkpoint/CompletedCheckpointStoreTest.java
@@ -79,11 +79,13 @@ public abstract class CompletedCheckpointStoreTest extends TestLogger {
                 };
 
         // Add and get latest
-        checkpoints.addCheckpoint(expected[0], new CheckpointsCleaner(), () -> {});
+        checkpoints.addCheckpointAndSubsumeOldestOne(
+                expected[0], new CheckpointsCleaner(), () -> {});
         assertEquals(1, checkpoints.getNumberOfRetainedCheckpoints());
         verifyCheckpoint(expected[0], checkpoints.getLatestCheckpoint());
 
-        checkpoints.addCheckpoint(expected[1], new CheckpointsCleaner(), () -> {});
+        checkpoints.addCheckpointAndSubsumeOldestOne(
+                expected[1], new CheckpointsCleaner(), () -> {});
         assertEquals(2, checkpoints.getNumberOfRetainedCheckpoints());
         verifyCheckpoint(expected[1], checkpoints.getLatestCheckpoint());
     }
@@ -106,11 +108,13 @@ public abstract class CompletedCheckpointStoreTest extends TestLogger {
                 };
 
         // Add checkpoints
-        checkpoints.addCheckpoint(expected[0], new CheckpointsCleaner(), () -> {});
+        checkpoints.addCheckpointAndSubsumeOldestOne(
+                expected[0], new CheckpointsCleaner(), () -> {});
         assertEquals(1, checkpoints.getNumberOfRetainedCheckpoints());
 
         for (int i = 1; i < expected.length; i++) {
-            checkpoints.addCheckpoint(expected[i], new CheckpointsCleaner(), () -> {});
+            checkpoints.addCheckpointAndSubsumeOldestOne(
+                    expected[i], new CheckpointsCleaner(), () -> {});
 
             // The ZooKeeper implementation discards asynchronously
             expected[i - 1].awaitDiscard();
@@ -152,7 +156,8 @@ public abstract class CompletedCheckpointStoreTest extends TestLogger {
                 };
 
         for (TestCompletedCheckpoint checkpoint : expected) {
-            checkpoints.addCheckpoint(checkpoint, new CheckpointsCleaner(), () -> {});
+            checkpoints.addCheckpointAndSubsumeOldestOne(
+                    checkpoint, new CheckpointsCleaner(), () -> {});
         }
 
         List<CompletedCheckpoint> actual = checkpoints.getAllCheckpoints();
@@ -179,7 +184,8 @@ public abstract class CompletedCheckpointStoreTest extends TestLogger {
                 };
 
         for (TestCompletedCheckpoint checkpoint : expected) {
-            checkpoints.addCheckpoint(checkpoint, new CheckpointsCleaner(), () -> {});
+            checkpoints.addCheckpointAndSubsumeOldestOne(
+                    checkpoint, new CheckpointsCleaner(), () -> {});
         }
 
         checkpoints.shutdown(JobStatus.FINISHED, new CheckpointsCleaner());
@@ -203,11 +209,11 @@ public abstract class CompletedCheckpointStoreTest extends TestLogger {
         CompletedCheckpointStore checkpoints = createRecoveredCompletedCheckpointStore(1);
         assertEquals(0, checkpoints.getLatestCheckpointId());
 
-        checkpoints.addCheckpoint(
+        checkpoints.addCheckpointAndSubsumeOldestOne(
                 createCheckpoint(2, sharedStateRegistry), new CheckpointsCleaner(), () -> {});
         assertEquals(2, checkpoints.getLatestCheckpointId());
 
-        checkpoints.addCheckpoint(
+        checkpoints.addCheckpointAndSubsumeOldestOne(
                 createCheckpoint(4, sharedStateRegistry), new CheckpointsCleaner(), () -> {});
         assertEquals(4, checkpoints.getLatestCheckpointId());
     }

--- a/flink-runtime/src/test/java/org/apache/flink/runtime/checkpoint/DefaultCompletedCheckpointStoreTest.java
+++ b/flink-runtime/src/test/java/org/apache/flink/runtime/checkpoint/DefaultCompletedCheckpointStoreTest.java
@@ -127,7 +127,8 @@ public class DefaultCompletedCheckpointStoreTest extends TestLogger {
                 createCompletedCheckpointStore(stateHandleStore, numRetain);
 
         for (CompletedCheckpoint c : completed) {
-            completedCheckpointStore.addCheckpoint(c, new CheckpointsCleaner(), () -> {});
+            completedCheckpointStore.addCheckpointAndSubsumeOldestOne(
+                    c, new CheckpointsCleaner(), () -> {});
         }
         assertEquals(expectedRetained, completedCheckpointStore.getAllCheckpoints());
     }
@@ -199,7 +200,8 @@ public class DefaultCompletedCheckpointStoreTest extends TestLogger {
         final long ckpId = 100L;
         final CompletedCheckpoint ckp =
                 CompletedCheckpointStoreTest.createCheckpoint(ckpId, new SharedStateRegistry());
-        completedCheckpointStore.addCheckpoint(ckp, new CheckpointsCleaner(), () -> {});
+        completedCheckpointStore.addCheckpointAndSubsumeOldestOne(
+                ckp, new CheckpointsCleaner(), () -> {});
 
         // We should persist the completed checkpoint to state handle store.
         final CompletedCheckpoint addedCkp = addFuture.get(timeout, TimeUnit.MILLISECONDS);
@@ -233,7 +235,8 @@ public class DefaultCompletedCheckpointStoreTest extends TestLogger {
                 CompletedCheckpointStoreTest.createCheckpoint(ckpId, new SharedStateRegistry());
 
         try {
-            completedCheckpointStore.addCheckpoint(ckp, new CheckpointsCleaner(), () -> {});
+            completedCheckpointStore.addCheckpointAndSubsumeOldestOne(
+                    ckp, new CheckpointsCleaner(), () -> {});
             fail("We should get an exception when add checkpoint to failed..");
         } catch (FlinkException ex) {
             assertThat(ex, FlinkMatchers.containsMessage(errMsg));
@@ -313,7 +316,7 @@ public class DefaultCompletedCheckpointStoreTest extends TestLogger {
             assertThrows(
                     IllegalStateException.class,
                     () ->
-                            completedCheckpointStore.addCheckpoint(
+                            completedCheckpointStore.addCheckpointAndSubsumeOldestOne(
                                     CompletedCheckpointStoreTest.createCheckpoint(
                                             0L, new SharedStateRegistry()),
                                     checkpointsCleaner,

--- a/flink-runtime/src/test/java/org/apache/flink/runtime/checkpoint/StandaloneCompletedCheckpointStoreTest.java
+++ b/flink-runtime/src/test/java/org/apache/flink/runtime/checkpoint/StandaloneCompletedCheckpointStoreTest.java
@@ -52,7 +52,7 @@ public class StandaloneCompletedCheckpointStoreTest extends CompletedCheckpointS
         TestCompletedCheckpoint checkpoint = createCheckpoint(0, sharedStateRegistry);
         Collection<OperatorState> operatorStates = checkpoint.getOperatorStates().values();
 
-        store.addCheckpoint(checkpoint, new CheckpointsCleaner(), () -> {});
+        store.addCheckpointAndSubsumeOldestOne(checkpoint, new CheckpointsCleaner(), () -> {});
         assertEquals(1, store.getNumberOfRetainedCheckpoints());
         verifyCheckpointRegistered(operatorStates, sharedStateRegistry);
 
@@ -73,7 +73,7 @@ public class StandaloneCompletedCheckpointStoreTest extends CompletedCheckpointS
         TestCompletedCheckpoint checkpoint = createCheckpoint(0, sharedStateRegistry);
         Collection<OperatorState> taskStates = checkpoint.getOperatorStates().values();
 
-        store.addCheckpoint(checkpoint, new CheckpointsCleaner(), () -> {});
+        store.addCheckpointAndSubsumeOldestOne(checkpoint, new CheckpointsCleaner(), () -> {});
         assertEquals(1, store.getNumberOfRetainedCheckpoints());
         verifyCheckpointRegistered(taskStates, sharedStateRegistry);
 
@@ -114,7 +114,8 @@ public class StandaloneCompletedCheckpointStoreTest extends CompletedCheckpointS
                         }
                     };
             // should fail despite the exception
-            store.addCheckpoint(checkpointToAdd, new CheckpointsCleaner(), () -> {});
+            store.addCheckpointAndSubsumeOldestOne(
+                    checkpointToAdd, new CheckpointsCleaner(), () -> {});
         }
         discardAttempted.await();
     }

--- a/flink-runtime/src/test/java/org/apache/flink/runtime/checkpoint/TestingCompletedCheckpointStore.java
+++ b/flink-runtime/src/test/java/org/apache/flink/runtime/checkpoint/TestingCompletedCheckpointStore.java
@@ -33,7 +33,7 @@ public final class TestingCompletedCheckpointStore implements CompletedCheckpoin
     }
 
     @Override
-    public void addCheckpoint(
+    public CompletedCheckpoint addCheckpointAndSubsumeOldestOne(
             CompletedCheckpoint checkpoint,
             CheckpointsCleaner checkpointsCleaner,
             Runnable postCleanup) {

--- a/flink-runtime/src/test/java/org/apache/flink/runtime/checkpoint/ZooKeeperCompletedCheckpointStoreTest.java
+++ b/flink-runtime/src/test/java/org/apache/flink/runtime/checkpoint/ZooKeeperCompletedCheckpointStoreTest.java
@@ -131,12 +131,14 @@ public class ZooKeeperCompletedCheckpointStoreTest extends TestLogger {
             final CompletedCheckpointStoreTest.TestCompletedCheckpoint checkpoint1 =
                     CompletedCheckpointStoreTest.createCheckpoint(0, sharedStateRegistry);
 
-            checkpointStore.addCheckpoint(checkpoint1, new CheckpointsCleaner(), () -> {});
+            checkpointStore.addCheckpointAndSubsumeOldestOne(
+                    checkpoint1, new CheckpointsCleaner(), () -> {});
             assertThat(checkpointStore.getAllCheckpoints(), Matchers.contains(checkpoint1));
 
             final CompletedCheckpointStoreTest.TestCompletedCheckpoint checkpoint2 =
                     CompletedCheckpointStoreTest.createCheckpoint(1, sharedStateRegistry);
-            checkpointStore.addCheckpoint(checkpoint2, new CheckpointsCleaner(), () -> {});
+            checkpointStore.addCheckpointAndSubsumeOldestOne(
+                    checkpoint2, new CheckpointsCleaner(), () -> {});
             final List<CompletedCheckpoint> allCheckpoints = checkpointStore.getAllCheckpoints();
             assertThat(allCheckpoints, Matchers.contains(checkpoint2));
             assertThat(allCheckpoints, Matchers.not(Matchers.contains(checkpoint1)));
@@ -168,7 +170,8 @@ public class ZooKeeperCompletedCheckpointStoreTest extends TestLogger {
             final CompletedCheckpointStoreTest.TestCompletedCheckpoint checkpoint1 =
                     CompletedCheckpointStoreTest.createCheckpoint(0, sharedStateRegistry);
 
-            checkpointStore.addCheckpoint(checkpoint1, new CheckpointsCleaner(), () -> {});
+            checkpointStore.addCheckpointAndSubsumeOldestOne(
+                    checkpoint1, new CheckpointsCleaner(), () -> {});
             assertThat(checkpointStore.getAllCheckpoints(), Matchers.contains(checkpoint1));
 
             checkpointStore.shutdown(JobStatus.FINISHED, new CheckpointsCleaner());
@@ -250,7 +253,7 @@ public class ZooKeeperCompletedCheckpointStoreTest extends TestLogger {
                             CheckpointProperties.forCheckpoint(NEVER_RETAIN_AFTER_TERMINATION),
                             new TestCompletedCheckpointStorageLocation());
             // shouldn't fail despite the exception
-            store.addCheckpoint(
+            store.addCheckpointAndSubsumeOldestOne(
                     checkpointToAdd,
                     new CheckpointsCleaner(),
                     () -> {

--- a/flink-runtime/src/test/java/org/apache/flink/runtime/executiongraph/utils/SimpleAckingTaskManagerGateway.java
+++ b/flink-runtime/src/test/java/org/apache/flink/runtime/executiongraph/utils/SimpleAckingTaskManagerGateway.java
@@ -126,11 +126,12 @@ public class SimpleAckingTaskManagerGateway implements TaskManagerGateway {
     }
 
     @Override
-    public void notifyCheckpointComplete(
+    public void notifyCheckpointOnComplete(
             ExecutionAttemptID executionAttemptID,
             JobID jobId,
-            long checkpointId,
-            long timestamp) {}
+            long completedCheckpointId,
+            long completedTimestamp,
+            long lastSubsumedCheckpointId) {}
 
     @Override
     public void notifyCheckpointAborted(

--- a/flink-runtime/src/test/java/org/apache/flink/runtime/jobmaster/JobMasterTest.java
+++ b/flink-runtime/src/test/java/org/apache/flink/runtime/jobmaster/JobMasterTest.java
@@ -869,7 +869,7 @@ public class JobMasterTest extends TestLogger {
 
         final StandaloneCompletedCheckpointStore completedCheckpointStore =
                 new StandaloneCompletedCheckpointStore(1);
-        completedCheckpointStore.addCheckpoint(
+        completedCheckpointStore.addCheckpointAndSubsumeOldestOne(
                 completedCheckpoint, new CheckpointsCleaner(), () -> {});
         final CheckpointRecoveryFactory testingCheckpointRecoveryFactory =
                 PerJobCheckpointRecoveryFactory.withoutCheckpointStoreRecovery(

--- a/flink-runtime/src/test/java/org/apache/flink/runtime/taskexecutor/TestingTaskExecutorGateway.java
+++ b/flink-runtime/src/test/java/org/apache/flink/runtime/taskexecutor/TestingTaskExecutorGateway.java
@@ -247,7 +247,10 @@ public class TestingTaskExecutorGateway implements TaskExecutorGateway {
 
     @Override
     public CompletableFuture<Acknowledge> confirmCheckpoint(
-            ExecutionAttemptID executionAttemptID, long checkpointId, long checkpointTimestamp) {
+            ExecutionAttemptID executionAttemptID,
+            long checkpointId,
+            long checkpointTimestamp,
+            long lastSubsumedCheckpointId) {
         return confirmCheckpointFunction.apply(
                 executionAttemptID, checkpointId, checkpointTimestamp);
     }

--- a/flink-streaming-java/src/main/java/org/apache/flink/streaming/api/operators/AbstractStreamOperator.java
+++ b/flink-streaming-java/src/main/java/org/apache/flink/streaming/api/operators/AbstractStreamOperator.java
@@ -434,7 +434,6 @@ public abstract class AbstractStreamOperator<OUT>
         return runtimeContext;
     }
 
-    @VisibleForTesting
     public <K> KeyedStateBackend<K> getKeyedStateBackend() {
         return stateHandler.getKeyedStateBackend();
     }

--- a/flink-streaming-java/src/main/java/org/apache/flink/streaming/api/operators/AbstractStreamOperatorV2.java
+++ b/flink-streaming-java/src/main/java/org/apache/flink/streaming/api/operators/AbstractStreamOperatorV2.java
@@ -373,10 +373,8 @@ public abstract class AbstractStreamOperatorV2<OUT>
         return runtimeContext;
     }
 
-    @SuppressWarnings("unchecked")
-    @VisibleForTesting
     public <K> KeyedStateBackend<K> getKeyedStateBackend() {
-        return (KeyedStateBackend<K>) stateHandler.getKeyedStateBackend();
+        return stateHandler.getKeyedStateBackend();
     }
 
     @VisibleForTesting

--- a/flink-streaming-java/src/main/java/org/apache/flink/streaming/runtime/tasks/FinishedOperatorChain.java
+++ b/flink-streaming-java/src/main/java/org/apache/flink/streaming/runtime/tasks/FinishedOperatorChain.java
@@ -87,6 +87,9 @@ public class FinishedOperatorChain<OUT, OP extends StreamOperator<OUT>>
     public void notifyCheckpointAborted(long checkpointId) throws Exception {}
 
     @Override
+    public void notifyCheckpointSubsumed(long checkpointId) throws Exception {}
+
+    @Override
     public boolean isClosed() {
         return isClosed;
     }

--- a/flink-streaming-java/src/main/java/org/apache/flink/streaming/runtime/tasks/OperatorChain.java
+++ b/flink-streaming-java/src/main/java/org/apache/flink/streaming/runtime/tasks/OperatorChain.java
@@ -308,6 +308,8 @@ public abstract class OperatorChain<OUT, OP extends StreamOperator<OUT>>
 
     public abstract void notifyCheckpointAborted(long checkpointId) throws Exception;
 
+    public abstract void notifyCheckpointSubsumed(long checkpointId) throws Exception;
+
     public abstract void snapshotState(
             Map<OperatorID, OperatorSnapshotFutures> operatorSnapshotsInProgress,
             CheckpointMetaData checkpointMetaData,

--- a/flink-streaming-java/src/main/java/org/apache/flink/streaming/runtime/tasks/RegularOperatorChain.java
+++ b/flink-streaming-java/src/main/java/org/apache/flink/streaming/runtime/tasks/RegularOperatorChain.java
@@ -173,6 +173,19 @@ public class RegularOperatorChain<OUT, OP extends StreamOperator<OUT>>
     }
 
     @Override
+    public void notifyCheckpointSubsumed(long checkpointId) throws Exception {
+        Exception previousException = null;
+        for (StreamOperatorWrapper<?, ?> operatorWrapper : getAllOperators(true)) {
+            try {
+                operatorWrapper.notifyCheckpointSubsumed(checkpointId);
+            } catch (Exception e) {
+                previousException = ExceptionUtils.firstOrSuppressed(e, previousException);
+            }
+        }
+        ExceptionUtils.tryRethrowException(previousException);
+    }
+
+    @Override
     public void snapshotState(
             Map<OperatorID, OperatorSnapshotFutures> operatorSnapshotsInProgress,
             CheckpointMetaData checkpointMetaData,

--- a/flink-streaming-java/src/main/java/org/apache/flink/streaming/runtime/tasks/StreamTask.java
+++ b/flink-streaming-java/src/main/java/org/apache/flink/streaming/runtime/tasks/StreamTask.java
@@ -1309,6 +1309,15 @@ public abstract class StreamTask<OUT, OP extends StreamOperator<OUT>>
                 String.format("checkpoint %d aborted", checkpointId));
     }
 
+    @Override
+    public Future<Void> notifyCheckpointSubsumedAsync(long checkpointId) {
+        return notifyCheckpointOperation(
+                () ->
+                        subtaskCheckpointCoordinator.notifyCheckpointSubsumed(
+                                checkpointId, operatorChain, this::isRunning),
+                String.format("checkpoint %d subsumed", checkpointId));
+    }
+
     private Future<Void> notifyCheckpointOperation(
             RunnableWithException runnable, String description) {
         CompletableFuture<Void> result = new CompletableFuture<>();

--- a/flink-streaming-java/src/main/java/org/apache/flink/streaming/runtime/tasks/SubtaskCheckpointCoordinator.java
+++ b/flink-streaming-java/src/main/java/org/apache/flink/streaming/runtime/tasks/SubtaskCheckpointCoordinator.java
@@ -87,6 +87,17 @@ public interface SubtaskCheckpointCoordinator extends Closeable {
             long checkpointId, OperatorChain<?, ?> operatorChain, Supplier<Boolean> isRunning)
             throws Exception;
 
+    /**
+     * Notified on the task side once a distributed checkpoint has been subsumed.
+     *
+     * @param checkpointId The checkpoint id to notify as been subsumed.
+     * @param operatorChain The chain of operators executed by the task.
+     * @param isRunning Whether the task is running.
+     */
+    void notifyCheckpointSubsumed(
+            long checkpointId, OperatorChain<?, ?> operatorChain, Supplier<Boolean> isRunning)
+            throws Exception;
+
     /** Waits for all the pending checkpoints to finish their asynchronous step. */
     void waitForPendingCheckpoints() throws Exception;
 }

--- a/flink-streaming-java/src/main/java/org/apache/flink/streaming/runtime/tasks/SubtaskCheckpointCoordinatorImpl.java
+++ b/flink-streaming-java/src/main/java/org/apache/flink/streaming/runtime/tasks/SubtaskCheckpointCoordinatorImpl.java
@@ -34,7 +34,9 @@ import org.apache.flink.runtime.state.CheckpointStorageLocationReference;
 import org.apache.flink.runtime.state.CheckpointStorageWorkerView;
 import org.apache.flink.runtime.state.CheckpointStreamFactory;
 import org.apache.flink.runtime.taskmanager.AsyncExceptionHandler;
+import org.apache.flink.runtime.taskmanager.Task;
 import org.apache.flink.streaming.api.operators.OperatorSnapshotFutures;
+import org.apache.flink.util.ExceptionUtils;
 import org.apache.flink.util.FlinkRuntimeException;
 import org.apache.flink.util.IOUtils;
 import org.apache.flink.util.function.BiFunctionWithException;
@@ -335,22 +337,9 @@ class SubtaskCheckpointCoordinatorImpl implements SubtaskCheckpointCoordinator {
     public void notifyCheckpointComplete(
             long checkpointId, OperatorChain<?, ?> operatorChain, Supplier<Boolean> isRunning)
             throws Exception {
-        try {
-            if (!isRunning.get()) {
-                LOG.debug(
-                        "Ignoring notification of complete checkpoint {} for not-running task {}",
-                        checkpointId,
-                        taskName);
-            } else {
-                LOG.debug(
-                        "Notification of completed checkpoint {} for task {}",
-                        checkpointId,
-                        taskName);
-                operatorChain.notifyCheckpointComplete(checkpointId);
-            }
-        } finally {
-            env.getTaskStateManager().notifyCheckpointComplete(checkpointId);
-        }
+
+        notifyCheckpoint(
+                checkpointId, operatorChain, isRunning, Task.NotifyCheckpointOperation.COMPLETE);
     }
 
     @Override
@@ -358,37 +347,87 @@ class SubtaskCheckpointCoordinatorImpl implements SubtaskCheckpointCoordinator {
             long checkpointId, OperatorChain<?, ?> operatorChain, Supplier<Boolean> isRunning)
             throws Exception {
 
+        notifyCheckpoint(
+                checkpointId, operatorChain, isRunning, Task.NotifyCheckpointOperation.ABORT);
+    }
+
+    @Override
+    public void notifyCheckpointSubsumed(
+            long checkpointId, OperatorChain<?, ?> operatorChain, Supplier<Boolean> isRunning)
+            throws Exception {
+
+        notifyCheckpoint(
+                checkpointId, operatorChain, isRunning, Task.NotifyCheckpointOperation.SUBSUME);
+    }
+
+    private void notifyCheckpoint(
+            long checkpointId,
+            OperatorChain<?, ?> operatorChain,
+            Supplier<Boolean> isRunning,
+            Task.NotifyCheckpointOperation notifyCheckpointOperation)
+            throws Exception {
+
+        Exception previousException = null;
         try {
             if (!isRunning.get()) {
                 LOG.debug(
-                        "Ignoring notification of aborted checkpoint {} for not-running task {}",
+                        "Ignoring notification of checkpoint {} {} for not-running task {}",
+                        notifyCheckpointOperation,
                         checkpointId,
                         taskName);
             } else {
                 LOG.debug(
-                        "Notification of aborted checkpoint {} for task {}",
+                        "Notification of checkpoint {} {} for task {}",
+                        notifyCheckpointOperation,
                         checkpointId,
                         taskName);
 
-                boolean canceled = cancelAsyncCheckpointRunnable(checkpointId);
+                if (notifyCheckpointOperation.equals(Task.NotifyCheckpointOperation.ABORT)) {
+                    boolean canceled = cancelAsyncCheckpointRunnable(checkpointId);
 
-                if (!canceled) {
-                    if (checkpointId > lastCheckpointId) {
-                        // only record checkpoints that have not triggered on task side.
-                        abortedCheckpointIds.add(checkpointId);
+                    if (!canceled) {
+                        if (checkpointId > lastCheckpointId) {
+                            // only record checkpoints that have not triggered on task side.
+                            abortedCheckpointIds.add(checkpointId);
+                        }
                     }
+
+                    channelStateWriter.abort(
+                            checkpointId,
+                            new CancellationException("checkpoint aborted via notification"),
+                            false);
                 }
 
-                channelStateWriter.abort(
-                        checkpointId,
-                        new CancellationException("checkpoint aborted via notification"),
-                        false);
-
-                operatorChain.notifyCheckpointAborted(checkpointId);
+                try {
+                    switch (notifyCheckpointOperation) {
+                        case ABORT:
+                            operatorChain.notifyCheckpointAborted(checkpointId);
+                            break;
+                        case COMPLETE:
+                            operatorChain.notifyCheckpointComplete(checkpointId);
+                            break;
+                        case SUBSUME:
+                            operatorChain.notifyCheckpointSubsumed(checkpointId);
+                    }
+                } catch (Exception e) {
+                    previousException = ExceptionUtils.firstOrSuppressed(e, previousException);
+                }
             }
         } finally {
-            env.getTaskStateManager().notifyCheckpointAborted(checkpointId);
+            try {
+                switch (notifyCheckpointOperation) {
+                    case ABORT:
+                        env.getTaskStateManager().notifyCheckpointAborted(checkpointId);
+                        break;
+                    case COMPLETE:
+                        env.getTaskStateManager().notifyCheckpointComplete(checkpointId);
+                }
+            } catch (Exception e) {
+                previousException = ExceptionUtils.firstOrSuppressed(e, previousException);
+            }
         }
+
+        ExceptionUtils.tryRethrowException(previousException);
     }
 
     @Override

--- a/flink-streaming-java/src/test/java/org/apache/flink/streaming/runtime/tasks/OperatorChainTest.java
+++ b/flink-streaming-java/src/test/java/org/apache/flink/streaming/runtime/tasks/OperatorChainTest.java
@@ -18,6 +18,7 @@
 
 package org.apache.flink.streaming.runtime.tasks;
 
+import org.apache.flink.api.common.typeutils.base.StringSerializer;
 import org.apache.flink.configuration.Configuration;
 import org.apache.flink.runtime.jobgraph.OperatorID;
 import org.apache.flink.runtime.operators.testutils.MockEnvironment;
@@ -80,6 +81,8 @@ public class OperatorChainTest {
             final StreamTask<?, ?> containingTask = new MockStreamTaskBuilder(env).build();
 
             final StreamConfig cfg = new StreamConfig(new Configuration());
+            cfg.setOperatorID(new OperatorID());
+            cfg.setStateKeySerializer(new StringSerializer());
 
             final List<StreamOperatorWrapper<?, ?>> operatorWrappers = new ArrayList<>();
 

--- a/flink-streaming-java/src/test/java/org/apache/flink/streaming/runtime/tasks/SubtaskCheckpointCoordinatorTest.java
+++ b/flink-streaming-java/src/test/java/org/apache/flink/streaming/runtime/tasks/SubtaskCheckpointCoordinatorTest.java
@@ -54,6 +54,7 @@ import org.apache.flink.streaming.api.operators.OneInputStreamOperator;
 import org.apache.flink.streaming.api.operators.OperatorSnapshotFutures;
 import org.apache.flink.streaming.api.operators.StreamMap;
 import org.apache.flink.streaming.api.operators.StreamTaskStateInitializer;
+import org.apache.flink.streaming.api.operators.StreamTaskStateInitializerImpl;
 import org.apache.flink.streaming.api.watermark.Watermark;
 import org.apache.flink.streaming.runtime.streamrecord.LatencyMarker;
 import org.apache.flink.streaming.runtime.streamrecord.StreamElementSerializer;
@@ -249,6 +250,52 @@ public class SubtaskCheckpointCoordinatorTest {
                             new NoOpStreamTask<>(new DummyEnvironment()), new NonRecordWriter<>()),
                     false,
                     () -> true);
+        }
+    }
+
+    @Test
+    public void testNotifyCheckpointSubsumed() throws Exception {
+        TestTaskStateManager stateManager = new TestTaskStateManager();
+        MockEnvironment mockEnvironment =
+                MockEnvironment.builder().setTaskStateManager(stateManager).build();
+
+        try (SubtaskCheckpointCoordinatorImpl subtaskCheckpointCoordinator =
+                (SubtaskCheckpointCoordinatorImpl)
+                        new MockSubtaskCheckpointCoordinatorBuilder()
+                                .setEnvironment(mockEnvironment)
+                                .setUnalignedCheckpointEnabled(true)
+                                .build()) {
+
+            StreamMap<String, String> streamMap =
+                    new StreamMap<>((MapFunction<String, String>) value -> value);
+            streamMap.setProcessingTimeService(new TestProcessingTimeService());
+            final OperatorChain<String, AbstractStreamOperator<String>> operatorChain =
+                    operatorChain(streamMap);
+            StreamTaskStateInitializerImpl stateInitializer =
+                    new StreamTaskStateInitializerImpl(mockEnvironment, new TestStateBackend());
+            operatorChain.initializeStateAndOpenOperators(stateInitializer);
+
+            long checkpointId = 42L;
+
+            subtaskCheckpointCoordinator
+                    .getChannelStateWriter()
+                    .start(checkpointId, CheckpointOptions.forCheckpointWithDefaultLocation());
+            subtaskCheckpointCoordinator.checkpointState(
+                    new CheckpointMetaData(checkpointId, System.currentTimeMillis()),
+                    CheckpointOptions.forCheckpointWithDefaultLocation(),
+                    new CheckpointMetricsBuilder(),
+                    operatorChain,
+                    false,
+                    () -> false);
+
+            long notifySubsumeCheckpointId = checkpointId + 1L;
+            // notify checkpoint aborted before execution.
+            subtaskCheckpointCoordinator.notifyCheckpointSubsumed(
+                    notifySubsumeCheckpointId, operatorChain, () -> true);
+            assertEquals(
+                    notifySubsumeCheckpointId,
+                    ((TestStateBackend.TestKeyedStateBackend<?>) streamMap.getKeyedStateBackend())
+                            .getSubsumeCheckpointId());
         }
     }
 

--- a/flink-streaming-java/src/test/java/org/apache/flink/streaming/runtime/tasks/TestStateBackend.java
+++ b/flink-streaming-java/src/test/java/org/apache/flink/streaming/runtime/tasks/TestStateBackend.java
@@ -1,0 +1,225 @@
+/*
+
+* Licensed to the Apache Software Foundation (ASF) under one
+* or more contributor license agreements.  See the NOTICE file
+* distributed with this work for additional information
+* regarding copyright ownership.  The ASF licenses this file
+* to you under the Apache License, Version 2.0 (the
+* "License"); you may not use this file except in compliance
+* with the License.  You may obtain a copy of the License at
+*
+* http://www.apache.org/licenses/LICENSE-2.0
+*
+* Unless required by applicable law or agreed to in writing, software
+* distributed under the License is distributed on an "AS IS" BASIS,
+* WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+* See the License for the specific language governing permissions and
+* limitations under the License.
+
+*/
+
+package org.apache.flink.streaming.runtime.tasks;
+
+import org.apache.flink.api.common.ExecutionConfig;
+import org.apache.flink.api.common.JobID;
+import org.apache.flink.api.common.state.State;
+import org.apache.flink.api.common.state.StateDescriptor;
+import org.apache.flink.api.common.typeutils.TypeSerializer;
+import org.apache.flink.api.java.tuple.Tuple2;
+import org.apache.flink.core.fs.CloseableRegistry;
+import org.apache.flink.metrics.MetricGroup;
+import org.apache.flink.runtime.checkpoint.CheckpointOptions;
+import org.apache.flink.runtime.execution.Environment;
+import org.apache.flink.runtime.query.TaskKvStateRegistry;
+import org.apache.flink.runtime.state.AbstractKeyedStateBackend;
+import org.apache.flink.runtime.state.AbstractStateBackend;
+import org.apache.flink.runtime.state.CheckpointStreamFactory;
+import org.apache.flink.runtime.state.DefaultOperatorStateBackend;
+import org.apache.flink.runtime.state.KeyGroupRange;
+import org.apache.flink.runtime.state.KeyGroupedInternalPriorityQueue;
+import org.apache.flink.runtime.state.Keyed;
+import org.apache.flink.runtime.state.KeyedStateHandle;
+import org.apache.flink.runtime.state.OperatorStateBackend;
+import org.apache.flink.runtime.state.OperatorStateHandle;
+import org.apache.flink.runtime.state.PriorityComparable;
+import org.apache.flink.runtime.state.SavepointResources;
+import org.apache.flink.runtime.state.SnapshotExecutionType;
+import org.apache.flink.runtime.state.SnapshotResources;
+import org.apache.flink.runtime.state.SnapshotResult;
+import org.apache.flink.runtime.state.SnapshotStrategy;
+import org.apache.flink.runtime.state.SnapshotStrategyRunner;
+import org.apache.flink.runtime.state.StateSnapshotTransformer;
+import org.apache.flink.runtime.state.heap.HeapPriorityQueueElement;
+import org.apache.flink.runtime.state.heap.InternalKeyContext;
+import org.apache.flink.runtime.state.heap.InternalKeyContextImpl;
+import org.apache.flink.runtime.state.metrics.LatencyTrackingStateConfig;
+import org.apache.flink.runtime.state.ttl.TtlTimeProvider;
+
+import javax.annotation.Nonnull;
+
+import java.io.IOException;
+import java.util.Collection;
+import java.util.Collections;
+import java.util.concurrent.FutureTask;
+import java.util.concurrent.RunnableFuture;
+import java.util.stream.Stream;
+
+/** Testable state backend. */
+public class TestStateBackend extends AbstractStateBackend {
+    private static final long serialVersionUID = 1L;
+
+    @Override
+    public <K> AbstractKeyedStateBackend<K> createKeyedStateBackend(
+            Environment env,
+            JobID jobID,
+            String operatorIdentifier,
+            TypeSerializer<K> keySerializer,
+            int numberOfKeyGroups,
+            KeyGroupRange keyGroupRange,
+            TaskKvStateRegistry kvStateRegistry,
+            TtlTimeProvider ttlTimeProvider,
+            MetricGroup metricGroup,
+            @Nonnull Collection<KeyedStateHandle> stateHandles,
+            CloseableRegistry cancelStreamRegistry)
+            throws IOException {
+        return new TestKeyedStateBackend<>(
+                kvStateRegistry,
+                keySerializer,
+                Thread.currentThread().getContextClassLoader(),
+                env.getExecutionConfig(),
+                ttlTimeProvider,
+                LatencyTrackingStateConfig.newBuilder().build(),
+                cancelStreamRegistry,
+                new InternalKeyContextImpl<>(keyGroupRange, numberOfKeyGroups));
+    }
+
+    @Override
+    public OperatorStateBackend createOperatorStateBackend(
+            Environment env,
+            String operatorIdentifier,
+            @Nonnull Collection<OperatorStateHandle> stateHandles,
+            CloseableRegistry cancelStreamRegistry)
+            throws Exception {
+        return new DefaultOperatorStateBackend(
+                env.getExecutionConfig(),
+                cancelStreamRegistry,
+                Collections.emptyMap(),
+                Collections.emptyMap(),
+                Collections.emptyMap(),
+                Collections.emptyMap(),
+                new SnapshotStrategyRunner<>(
+                        "Async Failure State Backend",
+                        new SnapshotStrategy<OperatorStateHandle, SnapshotResources>() {
+
+                            @Override
+                            public SnapshotResources syncPrepareResources(long checkpointId) {
+                                return null;
+                            }
+
+                            @Override
+                            public SnapshotResultSupplier<OperatorStateHandle> asyncSnapshot(
+                                    SnapshotResources syncPartResource,
+                                    long checkpointId,
+                                    long timestamp,
+                                    @Nonnull CheckpointStreamFactory streamFactory,
+                                    @Nonnull CheckpointOptions checkpointOptions) {
+                                return null;
+                            }
+                        },
+                        new CloseableRegistry(),
+                        SnapshotExecutionType.ASYNCHRONOUS));
+    }
+
+    /**
+     * Testable keyed state backend for {@link
+     * SubtaskCheckpointCoordinatorTest#testNotifyCheckpointSubsumed()}.
+     */
+    static class TestKeyedStateBackend<K> extends AbstractKeyedStateBackend<K> {
+        private long subsumeCheckpointId = -1L;
+
+        public TestKeyedStateBackend(
+                TaskKvStateRegistry kvStateRegistry,
+                TypeSerializer<K> keySerializer,
+                ClassLoader userCodeClassLoader,
+                ExecutionConfig executionConfig,
+                TtlTimeProvider ttlTimeProvider,
+                LatencyTrackingStateConfig latencyTrackingStateConfig,
+                CloseableRegistry cancelStreamRegistry,
+                InternalKeyContext<K> keyContext) {
+            super(
+                    kvStateRegistry,
+                    keySerializer,
+                    userCodeClassLoader,
+                    executionConfig,
+                    ttlTimeProvider,
+                    latencyTrackingStateConfig,
+                    cancelStreamRegistry,
+                    keyContext);
+        }
+
+        @Override
+        public void notifyCheckpointComplete(long checkpointId) {}
+
+        @Override
+        public void notifyCheckpointSubsumed(long checkpointId) {
+            subsumeCheckpointId = checkpointId;
+        }
+
+        public long getSubsumeCheckpointId() {
+            return subsumeCheckpointId;
+        }
+
+        @Nonnull
+        @Override
+        public SavepointResources<K> savepoint() throws Exception {
+            throw new UnsupportedOperationException();
+        }
+
+        @Override
+        public <N> Stream<K> getKeys(String state, N namespace) {
+            throw new UnsupportedOperationException();
+        }
+
+        @Override
+        public <N> Stream<Tuple2<K, N>> getKeysAndNamespaces(String state) {
+            throw new UnsupportedOperationException();
+        }
+
+        @Nonnull
+        @Override
+        public <N, SV, SEV, S extends State, IS extends S> IS createInternalState(
+                @Nonnull TypeSerializer<N> namespaceSerializer,
+                @Nonnull StateDescriptor<S, SV> stateDesc,
+                @Nonnull
+                        StateSnapshotTransformer.StateSnapshotTransformFactory<SEV>
+                                snapshotTransformFactory)
+                throws Exception {
+            throw new UnsupportedOperationException();
+        }
+
+        @Nonnull
+        @Override
+        public <T extends HeapPriorityQueueElement & PriorityComparable<? super T> & Keyed<?>>
+                KeyGroupedInternalPriorityQueue<T> create(
+                        @Nonnull String stateName,
+                        @Nonnull TypeSerializer<T> byteOrderedElementSerializer) {
+            throw new UnsupportedOperationException();
+        }
+
+        @Nonnull
+        @Override
+        public RunnableFuture<SnapshotResult<KeyedStateHandle>> snapshot(
+                long checkpointId,
+                long timestamp,
+                @Nonnull CheckpointStreamFactory streamFactory,
+                @Nonnull CheckpointOptions checkpointOptions)
+                throws Exception {
+            return new FutureTask<>(SnapshotResult::empty);
+        }
+
+        @Override
+        public int numKeyValueStateEntries() {
+            return 0;
+        }
+    }
+}

--- a/flink-streaming-java/src/test/java/org/apache/flink/streaming/runtime/tasks/TestSubtaskCheckpointCoordinator.java
+++ b/flink-streaming-java/src/test/java/org/apache/flink/streaming/runtime/tasks/TestSubtaskCheckpointCoordinator.java
@@ -91,6 +91,10 @@ public class TestSubtaskCheckpointCoordinator implements SubtaskCheckpointCoordi
             long checkpointId, OperatorChain<?, ?> operatorChain, Supplier<Boolean> isRunning) {}
 
     @Override
+    public void notifyCheckpointSubsumed(
+            long checkpointId, OperatorChain<?, ?> operatorChain, Supplier<Boolean> isRunning) {}
+
+    @Override
     public void waitForPendingCheckpoints() throws Exception {}
 
     @Override

--- a/flink-tests/src/test/java/org/apache/flink/test/checkpointing/NotifyCheckpointAbortedITCase.java
+++ b/flink-tests/src/test/java/org/apache/flink/test/checkpointing/NotifyCheckpointAbortedITCase.java
@@ -427,13 +427,14 @@ public class NotifyCheckpointAbortedITCase extends TestLogger {
         }
 
         @Override
-        public void addCheckpoint(
+        public CompletedCheckpoint addCheckpointAndSubsumeOldestOne(
                 CompletedCheckpoint checkpoint,
                 CheckpointsCleaner checkpointsCleaner,
                 Runnable postCleanup)
                 throws Exception {
             if (abortCheckpointLatch.isTriggered()) {
-                super.addCheckpoint(checkpoint, checkpointsCleaner, postCleanup);
+                return super.addCheckpointAndSubsumeOldestOne(
+                        checkpoint, checkpointsCleaner, postCleanup);
             } else {
                 // tell main thread that all checkpoints on task side have been finished.
                 addCheckpointLatch.trigger();

--- a/flink-tests/src/test/java/org/apache/flink/test/checkpointing/RegionFailoverITCase.java
+++ b/flink-tests/src/test/java/org/apache/flink/test/checkpointing/RegionFailoverITCase.java
@@ -451,17 +451,20 @@ public class RegionFailoverITCase extends TestLogger {
         }
 
         @Override
-        public void addCheckpoint(
+        public CompletedCheckpoint addCheckpointAndSubsumeOldestOne(
                 CompletedCheckpoint checkpoint,
                 CheckpointsCleaner checkpointsCleaner,
                 Runnable postCleanup)
                 throws Exception {
-            super.addCheckpoint(checkpoint, checkpointsCleaner, postCleanup);
+            CompletedCheckpoint subsumedCheckpoint =
+                    super.addCheckpointAndSubsumeOldestOne(
+                            checkpoint, checkpointsCleaner, postCleanup);
             // we record the information when adding completed checkpoint instead of
             // 'notifyCheckpointComplete' invoked
             // on task side to avoid race condition. See FLINK-13601.
             lastCompletedCheckpointId.set(checkpoint.getCheckpointID());
             numCompletedCheckpoints.incrementAndGet();
+            return subsumedCheckpoint;
         }
     }
 

--- a/flink-tests/src/test/java/org/apache/flink/test/checkpointing/SavepointITCase.java
+++ b/flink-tests/src/test/java/org/apache/flink/test/checkpointing/SavepointITCase.java
@@ -796,7 +796,7 @@ public class SavepointITCase extends TestLogger {
         }
 
         @Override
-        public void addCheckpoint(
+        public CompletedCheckpoint addCheckpointAndSubsumeOldestOne(
                 CompletedCheckpoint checkpoint,
                 CheckpointsCleaner checkpointsCleaner,
                 Runnable postCleanup)
@@ -804,7 +804,8 @@ public class SavepointITCase extends TestLogger {
             if (checkpoint.getProperties().isSynchronous()) {
                 throw new ExpectedTestException();
             } else {
-                super.addCheckpoint(checkpoint, checkpointsCleaner, postCleanup);
+                return super.addCheckpointAndSubsumeOldestOne(
+                        checkpoint, checkpointsCleaner, postCleanup);
             }
         }
     }


### PR DESCRIPTION

## What is the purpose of the change
Introduce notification of subsumed checkpoint

## Brief change log

Introduce notification of subsumed checkpoint. Add a new `InternalCheckpointListener` and related implementations.

## Verifying this change

This change added tests and can be verified as follows:

SubtaskCheckpointCoordinatorTest

CheckpointCoordinatorTest


## Does this pull request potentially affect one of the following parts:

  - Dependencies (does it add or upgrade a dependency): no
  - The public API, i.e., is any changed class annotated with `@Public(Evolving)`: no
  - The serializers: no
  - The runtime per-record code paths (performance sensitive): no
  - Anything that affects deployment or recovery: JobManager (and its components), Checkpointing, Kubernetes/Yarn, ZooKeeper: no
  - The S3 file system connector: no

## Documentation

  - Does this pull request introduce a new feature? no
  - If yes, how is the feature documented? not applicable
