### PR TITLE
[FLINK-23478][k8s] Guarantee the watching event handling order

### DIFF
--- a/flink-kubernetes/src/main/java/org/apache/flink/kubernetes/kubeclient/resources/KubernetesSharedInformer.java
+++ b/flink-kubernetes/src/main/java/org/apache/flink/kubernetes/kubeclient/resources/KubernetesSharedInformer.java
@@ -124,19 +124,19 @@ public abstract class KubernetesSharedInformer<
 
         @Override
         public void onAdd(T obj) {
-            executorService.submit(
+            executorService.execute(
                     () -> findHandler(obj).ifPresent(EventHandler::handleResourceEvent));
         }
 
         @Override
         public void onUpdate(T oldObj, T newObj) {
-            executorService.submit(
+            executorService.execute(
                     () -> findHandler(newObj).ifPresent(EventHandler::handleResourceEvent));
         }
 
         @Override
         public void onDelete(T obj, boolean deletedFinalStateUnknown) {
-            executorService.submit(
+            executorService.execute(
                     () -> findHandler(obj).ifPresent(EventHandler::handleResourceEvent));
         }
 
@@ -149,7 +149,7 @@ public abstract class KubernetesSharedInformer<
             final String resourceKey = getResourceKey(name);
             final String watchId = UUID.randomUUID().toString();
             final CompletableFuture<Void> closeFuture = new CompletableFuture<>();
-            executorService.submit(
+            executorService.execute(
                     () -> {
                         final EventHandler eventHandler =
                                 handlers.computeIfAbsent(
@@ -266,7 +266,7 @@ public abstract class KubernetesSharedInformer<
             if (this.executorService == null) {
                 handlerConsumer.accept(handler);
             } else {
-                this.executorService.submit(
+                this.executorService.execute(
                         () -> {
                             callbackLock.lock();
                             try {

--- a/flink-kubernetes/src/main/java/org/apache/flink/kubernetes/kubeclient/resources/KubernetesSharedInformer.java
+++ b/flink-kubernetes/src/main/java/org/apache/flink/kubernetes/kubeclient/resources/KubernetesSharedInformer.java
@@ -42,10 +42,11 @@ import java.util.List;
 import java.util.Map;
 import java.util.Optional;
 import java.util.UUID;
+import java.util.concurrent.BlockingQueue;
 import java.util.concurrent.CompletableFuture;
 import java.util.concurrent.ExecutorService;
 import java.util.concurrent.Executors;
-import java.util.concurrent.locks.ReentrantLock;
+import java.util.concurrent.LinkedBlockingQueue;
 import java.util.function.Consumer;
 import java.util.function.Function;
 
@@ -247,11 +248,9 @@ public abstract class KubernetesSharedInformer<
     }
 
     private static final class WatchCallback<T> {
-        /**
-         * A fair lock, that ensures events for a single {@link WatchCallbackHandler} are processed
-         * in the order they've arrived in.
-         */
-        private final ReentrantLock callbackLock = new ReentrantLock(true);
+        private final Object callbackLock = new Object();
+        private final BlockingQueue<Consumer<WatchCallbackHandler<T>>> callbackQueue =
+                new LinkedBlockingQueue<>();
 
         private final WatchCallbackHandler<T> handler;
         private final ExecutorService executorService;
@@ -263,19 +262,20 @@ public abstract class KubernetesSharedInformer<
         }
 
         private void run(Consumer<WatchCallbackHandler<T>> handlerConsumer) {
-            if (this.executorService == null) {
+            if (executorService == null) {
                 handlerConsumer.accept(handler);
-            } else {
-                this.executorService.execute(
-                        () -> {
-                            callbackLock.lock();
-                            try {
-                                handlerConsumer.accept(handler);
-                            } finally {
-                                callbackLock.unlock();
-                            }
-                        });
+                return;
             }
+            Preconditions.checkState(
+                    callbackQueue.add(handlerConsumer), "Unable to put callback into a queue.");
+            executorService.execute(
+                    () -> {
+                        synchronized (callbackLock) {
+                            Preconditions.checkNotNull(
+                                            callbackQueue.poll(), "Callback queue is empty")
+                                    .accept(handler);
+                        }
+                    });
         }
     }
 }

--- a/flink-kubernetes/src/test/java/org/apache/flink/kubernetes/kubeclient/resources/KubernetesSharedInformerITCase.java
+++ b/flink-kubernetes/src/test/java/org/apache/flink/kubernetes/kubeclient/resources/KubernetesSharedInformerITCase.java
@@ -74,7 +74,7 @@ public class KubernetesSharedInformerITCase extends TestLogger {
         client.deleteConfigMapsByLabels(labels).get();
     }
 
-    @Test(timeout = 60000)
+    @Test(timeout = 120000)
     public void testWatch() throws Exception {
 
         try (KubernetesConfigMapSharedWatcher watcher =
@@ -121,7 +121,7 @@ public class KubernetesSharedInformerITCase extends TestLogger {
                 client.createConfigMapSharedWatcher(labels)) {
             watcher.run();
 
-            final String configMapName = getConfigMapName(0);
+            final String configMapName = getConfigMapName(System.currentTimeMillis());
             final long block = 500;
             final long maxUpdateVal = 30;
             final TestingBlockCallbackHandler handler =
@@ -132,7 +132,7 @@ public class KubernetesSharedInformerITCase extends TestLogger {
                 updateConfigMap(configMapName, ImmutableMap.of("val", String.valueOf(i)));
             }
             try {
-                handler.expectedFuture.get(60, TimeUnit.SECONDS);
+                handler.expectedFuture.get(120, TimeUnit.SECONDS);
             } catch (TimeoutException e) {
                 fail("expected value: " + maxUpdateVal + ", actual: " + handler.val);
             }
@@ -197,7 +197,7 @@ public class KubernetesSharedInformerITCase extends TestLogger {
         }
     }
 
-    private String getConfigMapName(int id) {
+    private String getConfigMapName(long id) {
         return "shared-informer-test-cluster-" + id;
     }
 
@@ -274,15 +274,15 @@ public class KubernetesSharedInformerITCase extends TestLogger {
 
         @Override
         public void onAdded(List<KubernetesConfigMap> resources) {
-            onAddOrUpdated(resources);
+            onAddedOrModified(resources);
         }
 
         @Override
         public void onModified(List<KubernetesConfigMap> resources) {
-            onAddOrUpdated(resources);
+            onAddedOrModified(resources);
         }
 
-        private void onAddOrUpdated(List<KubernetesConfigMap> resources) {
+        private void onAddedOrModified(List<KubernetesConfigMap> resources) {
             final KubernetesConfigMap kubernetesConfigMap = resources.get(0);
             final String valData = kubernetesConfigMap.getData().get("val");
             if (valData == null) {


### PR DESCRIPTION
<!--
*Thank you very much for contributing to Apache Flink - we are happy that you want to help us improve Flink. To help the community review your contribution in the best possible way, please go through the checklist below, which will get the contribution into a shape in which it can be best reviewed.*

*Please understand that we do not do this to make contributions to Flink a hassle. In order to uphold a high standard of quality for code contributions, while at the same time managing a large number of contributions, we need contributors to prepare the contributions well, and give reviewers enough contextual information for the review. Please also understand that contributions that do not follow this guide will take longer to review and thus typically be picked up with lower priority by the community.*

## Contribution Checklist

  - Make sure that the pull request corresponds to a [JIRA issue](https://issues.apache.org/jira/projects/FLINK/issues). Exceptions are made for typos in JavaDoc or documentation files, which need no JIRA issue.
  
  - Name the pull request in the form "[FLINK-XXXX] [component] Title of the pull request", where *FLINK-XXXX* should be replaced by the actual issue number. Skip *component* if you are unsure about which is the best component.
  Typo fixes that have no associated JIRA issue should be named following this pattern: `[hotfix] [docs] Fix typo in event time introduction` or `[hotfix] [javadocs] Expand JavaDoc for PuncuatedWatermarkGenerator`.

  - Fill out the template below to describe the changes contributed by the pull request. That will give reviewers the context they need to do the review.
  
  - Make sure that the change passes the automated tests, i.e., `mvn clean verify` passes. You can set up Azure Pipelines CI to do that following [this guide](https://cwiki.apache.org/confluence/display/FLINK/Azure+Pipelines#AzurePipelines-Tutorial:SettingupAzurePipelinesforaforkoftheFlinkrepository).

  - Each pull request should address only one issue, not mix up code from multiple issues.
  
  - Each commit in the pull request has a meaningful commit message (including the JIRA id)

  - Once all items of the checklist are addressed, remove the above text and this checklist, leaving only the filled out template below.


**(The sections below can be removed for hotfixes of typos)**
-->

## What is the purpose of the change

Guarantee the watching event handling order manually in KubernetesSharedInformer instead of depending on a lock.


## Brief change log


## Verifying this change

This change is already covered by existing tests, such as `KubernetesSharedInformerITCase`.

## Does this pull request potentially affect one of the following parts:

  - Dependencies (does it add or upgrade a dependency): (no)
  - The public API, i.e., is any changed class annotated with `@Public(Evolving)`: (no)
  - The serializers: (no)
  - The runtime per-record code paths (performance sensitive): (no)
  - Anything that affects deployment or recovery: JobManager (and its components), Checkpointing, Kubernetes/Yarn, ZooKeeper: (no)
  - The S3 file system connector: (no)

## Documentation

  - Does this pull request introduce a new feature? (no)
  - If yes, how is the feature documented? (not applicable)
