### PR TITLE
[FLINK-23541] Call StreamOperator#finish on EndOfData

### DIFF
--- a/flink-connectors/flink-connector-kinesis/src/test/java/org/apache/flink/streaming/connectors/kinesis/FlinkKinesisITCase.java
+++ b/flink-connectors/flink-connector-kinesis/src/test/java/org/apache/flink/streaming/connectors/kinesis/FlinkKinesisITCase.java
@@ -32,6 +32,7 @@ import org.apache.flink.util.TestLogger;
 
 import org.junit.Before;
 import org.junit.ClassRule;
+import org.junit.Ignore;
 import org.junit.Rule;
 import org.junit.Test;
 import org.junit.rules.TemporaryFolder;
@@ -52,6 +53,7 @@ import static org.hamcrest.Matchers.lessThan;
 import static org.junit.Assert.assertThat;
 
 /** IT cases for using Kinesis consumer/producer based on Kinesalite. */
+@Ignore("See FLINK-23528")
 public class FlinkKinesisITCase extends TestLogger {
     public static final String TEST_STREAM = "test_stream";
 

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/checkpoint/CheckpointType.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/checkpoint/CheckpointType.java
@@ -62,6 +62,10 @@ public enum CheckpointType {
     }
 
     public boolean shouldAdvanceToEndOfTime() {
+        return shouldDrain();
+    }
+
+    public boolean shouldDrain() {
         return getPostCheckpointAction() == PostCheckpointAction.TERMINATE;
     }
 

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/io/PullingAsyncDataInput.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/io/PullingAsyncDataInput.java
@@ -59,4 +59,10 @@ public interface PullingAsyncDataInput<T> extends AvailabilityProvider {
 
     /** @return true if is finished and for example end of input was reached, false otherwise. */
     boolean isFinished();
+
+    /**
+     * @return true if the input has seen all data. It might see only control events after that
+     *     point
+     */
+    boolean hasReceivedEndOfData();
 }

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/io/network/api/EndOfData.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/io/network/api/EndOfData.java
@@ -27,21 +27,21 @@ import java.io.IOException;
 /**
  * This event indicates there will be no more data records in a subpartition. There still might be
  * other events, in particular {@link CheckpointBarrier CheckpointBarriers} traveling. The {@link
- * EndOfUserRecordsEvent} is acknowledged by the downstream task. That way we can safely assume the
- * downstream task has consumed all the produced records and therefore we can perform a final
- * checkpoint for the upstream task.
+ * EndOfData} is acknowledged by the downstream task. That way we can safely assume the downstream
+ * task has consumed all the produced records and therefore we can perform a final checkpoint for
+ * the upstream task.
  *
  * @see <a href="https://cwiki.apache.org/confluence/x/mw-ZCQ">FLIP-147</a>
  */
-public class EndOfUserRecordsEvent extends RuntimeEvent {
+public class EndOfData extends RuntimeEvent {
 
     /** The singleton instance of this event. */
-    public static final EndOfUserRecordsEvent INSTANCE = new EndOfUserRecordsEvent();
+    public static final EndOfData INSTANCE = new EndOfData();
 
     // ------------------------------------------------------------------------
 
     // not instantiable
-    private EndOfUserRecordsEvent() {}
+    private EndOfData() {}
 
     // ------------------------------------------------------------------------
 
@@ -60,7 +60,7 @@ public class EndOfUserRecordsEvent extends RuntimeEvent {
 
     @Override
     public boolean equals(Object obj) {
-        return obj != null && obj.getClass() == EndOfUserRecordsEvent.class;
+        return obj != null && obj.getClass() == EndOfData.class;
     }
 
     @Override

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/io/network/api/serialization/EventSerializer.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/io/network/api/serialization/EventSerializer.java
@@ -27,9 +27,9 @@ import org.apache.flink.runtime.checkpoint.CheckpointType;
 import org.apache.flink.runtime.event.AbstractEvent;
 import org.apache.flink.runtime.io.network.api.CancelCheckpointMarker;
 import org.apache.flink.runtime.io.network.api.CheckpointBarrier;
+import org.apache.flink.runtime.io.network.api.EndOfData;
 import org.apache.flink.runtime.io.network.api.EndOfPartitionEvent;
 import org.apache.flink.runtime.io.network.api.EndOfSuperstepEvent;
-import org.apache.flink.runtime.io.network.api.EndOfUserRecordsEvent;
 import org.apache.flink.runtime.io.network.api.EventAnnouncement;
 import org.apache.flink.runtime.io.network.api.SubtaskConnectionDescriptor;
 import org.apache.flink.runtime.io.network.buffer.Buffer;
@@ -93,7 +93,7 @@ public class EventSerializer {
             return ByteBuffer.wrap(new byte[] {0, 0, 0, END_OF_SUPERSTEP_EVENT});
         } else if (eventClass == EndOfChannelStateEvent.class) {
             return ByteBuffer.wrap(new byte[] {0, 0, 0, END_OF_CHANNEL_STATE_EVENT});
-        } else if (eventClass == EndOfUserRecordsEvent.class) {
+        } else if (eventClass == EndOfData.class) {
             return ByteBuffer.wrap(new byte[] {0, 0, 0, END_OF_USER_RECORDS_EVENT});
         } else if (eventClass == CancelCheckpointMarker.class) {
             CancelCheckpointMarker marker = (CancelCheckpointMarker) event;
@@ -157,7 +157,7 @@ public class EventSerializer {
             } else if (type == END_OF_CHANNEL_STATE_EVENT) {
                 return EndOfChannelStateEvent.INSTANCE;
             } else if (type == END_OF_USER_RECORDS_EVENT) {
-                return EndOfUserRecordsEvent.INSTANCE;
+                return EndOfData.INSTANCE;
             } else if (type == CANCEL_CHECKPOINT_MARKER_EVENT) {
                 long id = buffer.getLong();
                 return new CancelCheckpointMarker(id);

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/io/network/api/writer/ResultPartitionWriter.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/io/network/api/writer/ResultPartitionWriter.java
@@ -70,13 +70,13 @@ public interface ResultPartitionWriter extends AutoCloseable, AvailabilityProvid
      * Notifies the downstream tasks that this {@code ResultPartitionWriter} have emitted all the
      * user records.
      */
-    void notifyEndOfUserRecords() throws IOException;
+    void notifyEndOfData() throws IOException;
 
     /**
      * Gets the future indicating whether all the records has been processed by the downstream
      * tasks.
      */
-    CompletableFuture<Void> getAllRecordsProcessedFuture();
+    CompletableFuture<Void> getAllDataProcessedFuture();
 
     /** Sets the metric group for the {@link ResultPartitionWriter}. */
     void setMetricGroup(TaskIOMetricGroup metrics);

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/io/network/netty/CreditBasedSequenceNumberingViewReader.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/io/network/netty/CreditBasedSequenceNumberingViewReader.java
@@ -118,7 +118,7 @@ class CreditBasedSequenceNumberingViewReader
 
     @Override
     public void acknowledgeAllRecordsProcessed() {
-        subpartitionView.acknowledgeAllRecordsProcessed();
+        subpartitionView.acknowledgeAllDataProcessed();
     }
 
     @Override

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/io/network/partition/BoundedBlockingSubpartitionDirectTransferReader.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/io/network/partition/BoundedBlockingSubpartitionDirectTransferReader.java
@@ -159,7 +159,7 @@ public class BoundedBlockingSubpartitionDirectTransferReader implements ResultSu
     }
 
     @Override
-    public void acknowledgeAllRecordsProcessed() {
+    public void acknowledgeAllDataProcessed() {
         throw new UnsupportedOperationException("Method should never be called.");
     }
 

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/io/network/partition/BoundedBlockingSubpartitionDirectTransferReader.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/io/network/partition/BoundedBlockingSubpartitionDirectTransferReader.java
@@ -62,7 +62,12 @@ public class BoundedBlockingSubpartitionDirectTransferReader implements ResultSu
             int numDataBuffers,
             int numDataAndEventBuffers)
             throws IOException {
-        checkArgument(numDataAndEventBuffers - numDataBuffers == 1, "Too many event buffers.");
+        int numEvents = numDataAndEventBuffers - numDataBuffers;
+        checkArgument(
+                numEvents == 1
+                        || numEvents
+                                == 2 /* EndOfData might not be generated e.g. in DataSet API */,
+                "Too many event buffers.");
         this.parent = checkNotNull(parent);
 
         checkNotNull(filePath);
@@ -160,7 +165,8 @@ public class BoundedBlockingSubpartitionDirectTransferReader implements ResultSu
 
     @Override
     public void acknowledgeAllDataProcessed() {
-        throw new UnsupportedOperationException("Method should never be called.");
+        // in case of bounded partitions there is no upstream to acknowledge, we simply ignore
+        // the ack, as there are no checkpoints
     }
 
     @Override

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/io/network/partition/BoundedBlockingSubpartitionReader.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/io/network/partition/BoundedBlockingSubpartitionReader.java
@@ -156,7 +156,8 @@ final class BoundedBlockingSubpartitionReader implements ResultSubpartitionView 
 
     @Override
     public void acknowledgeAllDataProcessed() {
-        throw new UnsupportedOperationException("Method should never be called.");
+        // in case of bounded partitions there is no upstream to acknowledge, we simply ignore
+        // the ack, as there are no checkpoints
     }
 
     @Override

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/io/network/partition/BoundedBlockingSubpartitionReader.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/io/network/partition/BoundedBlockingSubpartitionReader.java
@@ -155,7 +155,7 @@ final class BoundedBlockingSubpartitionReader implements ResultSubpartitionView 
     }
 
     @Override
-    public void acknowledgeAllRecordsProcessed() {
+    public void acknowledgeAllDataProcessed() {
         throw new UnsupportedOperationException("Method should never be called.");
     }
 

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/io/network/partition/NoOpResultSubpartitionView.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/io/network/partition/NoOpResultSubpartitionView.java
@@ -43,7 +43,7 @@ public class NoOpResultSubpartitionView implements ResultSubpartitionView {
     public void resumeConsumption() {}
 
     @Override
-    public void acknowledgeAllRecordsProcessed() {}
+    public void acknowledgeAllDataProcessed() {}
 
     @Override
     public Throwable getFailureCause() {

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/io/network/partition/PipelinedResultPartition.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/io/network/partition/PipelinedResultPartition.java
@@ -19,7 +19,7 @@
 package org.apache.flink.runtime.io.network.partition;
 
 import org.apache.flink.runtime.checkpoint.channel.ChannelStateWriter;
-import org.apache.flink.runtime.io.network.api.EndOfUserRecordsEvent;
+import org.apache.flink.runtime.io.network.api.EndOfData;
 import org.apache.flink.runtime.io.network.buffer.BufferCompressor;
 import org.apache.flink.runtime.io.network.buffer.BufferPool;
 import org.apache.flink.util.function.SupplierWithException;
@@ -193,22 +193,22 @@ public class PipelinedResultPartition extends BufferWritingResultPartition
     }
 
     @Override
-    public void notifyEndOfUserRecords() throws IOException {
+    public void notifyEndOfData() throws IOException {
         synchronized (lock) {
             if (!hasNotifiedEndOfUserRecords) {
-                broadcastEvent(EndOfUserRecordsEvent.INSTANCE, false);
+                broadcastEvent(EndOfData.INSTANCE, false);
                 hasNotifiedEndOfUserRecords = true;
             }
         }
     }
 
     @Override
-    public CompletableFuture<Void> getAllRecordsProcessedFuture() {
+    public CompletableFuture<Void> getAllDataProcessedFuture() {
         return allRecordsProcessedFuture;
     }
 
     @Override
-    public void onSubpartitionAllRecordsProcessed(int subpartition) {
+    public void onSubpartitionAllDataProcessed(int subpartition) {
         synchronized (lock) {
             if (allRecordsProcessedSubpartitions[subpartition]) {
                 return;

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/io/network/partition/PipelinedSubpartition.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/io/network/partition/PipelinedSubpartition.java
@@ -380,8 +380,8 @@ public class PipelinedSubpartition extends ResultSubpartition
         }
     }
 
-    public void acknowledgeAllRecordsProcessed() {
-        parent.onSubpartitionAllRecordsProcessed(subpartitionInfo.getSubPartitionIdx());
+    public void acknowledgeAllDataProcessed() {
+        parent.onSubpartitionAllDataProcessed(subpartitionInfo.getSubPartitionIdx());
     }
 
     @Override

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/io/network/partition/PipelinedSubpartitionView.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/io/network/partition/PipelinedSubpartitionView.java
@@ -80,8 +80,8 @@ public class PipelinedSubpartitionView implements ResultSubpartitionView {
     }
 
     @Override
-    public void acknowledgeAllRecordsProcessed() {
-        parent.acknowledgeAllRecordsProcessed();
+    public void acknowledgeAllDataProcessed() {
+        parent.acknowledgeAllDataProcessed();
     }
 
     @Override

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/io/network/partition/ResultPartition.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/io/network/partition/ResultPartition.java
@@ -22,6 +22,7 @@ import org.apache.flink.annotation.VisibleForTesting;
 import org.apache.flink.metrics.Counter;
 import org.apache.flink.metrics.SimpleCounter;
 import org.apache.flink.runtime.executiongraph.IntermediateResultPartition;
+import org.apache.flink.runtime.io.network.api.EndOfData;
 import org.apache.flink.runtime.io.network.api.writer.ResultPartitionWriter;
 import org.apache.flink.runtime.io.network.buffer.Buffer;
 import org.apache.flink.runtime.io.network.buffer.BufferCompressor;
@@ -191,12 +192,12 @@ public abstract class ResultPartition implements ResultPartitionWriter {
     // ------------------------------------------------------------------------
 
     @Override
-    public void notifyEndOfUserRecords() throws IOException {
+    public void notifyEndOfData() throws IOException {
         throw new UnsupportedOperationException();
     }
 
     @Override
-    public CompletableFuture<Void> getAllRecordsProcessedFuture() {
+    public CompletableFuture<Void> getAllDataProcessedFuture() {
         throw new UnsupportedOperationException();
     }
 
@@ -204,10 +205,10 @@ public abstract class ResultPartition implements ResultPartitionWriter {
      * The subpartition notifies that the corresponding downstream task have processed all the user
      * records.
      *
-     * @see org.apache.flink.runtime.io.network.api.EndOfUserRecordsEvent
+     * @see EndOfData
      * @param subpartition The index of the subpartition sending the notification.
      */
-    public void onSubpartitionAllRecordsProcessed(int subpartition) {}
+    public void onSubpartitionAllDataProcessed(int subpartition) {}
 
     /**
      * Finishes the result partition.

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/io/network/partition/ResultSubpartitionView.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/io/network/partition/ResultSubpartitionView.java
@@ -53,7 +53,7 @@ public interface ResultSubpartitionView {
 
     void resumeConsumption();
 
-    void acknowledgeAllRecordsProcessed();
+    void acknowledgeAllDataProcessed();
 
     Throwable getFailureCause();
 

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/io/network/partition/SortMergeSubpartitionReader.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/io/network/partition/SortMergeSubpartitionReader.java
@@ -205,7 +205,8 @@ class SortMergeSubpartitionReader
 
     @Override
     public void acknowledgeAllDataProcessed() {
-        throw new UnsupportedOperationException("Method should never be called.");
+        // in case of bounded partitions there is no upstream to acknowledge, we simply ignore
+        // the ack, as there are no checkpoints
     }
 
     @Override

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/io/network/partition/SortMergeSubpartitionReader.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/io/network/partition/SortMergeSubpartitionReader.java
@@ -204,7 +204,7 @@ class SortMergeSubpartitionReader
     }
 
     @Override
-    public void acknowledgeAllRecordsProcessed() {
+    public void acknowledgeAllDataProcessed() {
         throw new UnsupportedOperationException("Method should never be called.");
     }
 

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/io/network/partition/consumer/InputChannel.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/io/network/partition/consumer/InputChannel.java
@@ -24,6 +24,7 @@ import org.apache.flink.runtime.checkpoint.channel.InputChannelInfo;
 import org.apache.flink.runtime.event.TaskEvent;
 import org.apache.flink.runtime.execution.CancelTaskException;
 import org.apache.flink.runtime.io.network.api.CheckpointBarrier;
+import org.apache.flink.runtime.io.network.api.EndOfData;
 import org.apache.flink.runtime.io.network.buffer.Buffer;
 import org.apache.flink.runtime.io.network.partition.PartitionException;
 import org.apache.flink.runtime.io.network.partition.ResultPartitionID;
@@ -131,8 +132,8 @@ public abstract class InputChannel {
     public abstract void resumeConsumption() throws IOException;
 
     /**
-     * When received {@link org.apache.flink.runtime.io.network.api.EndOfUserRecordsEvent} from one
-     * channel, it need to acknowledge after this event get processed.
+     * When received {@link EndOfData} from one channel, it need to acknowledge after this event get
+     * processed.
      */
     public abstract void acknowledgeAllRecordsProcessed() throws IOException;
 

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/io/network/partition/consumer/InputGate.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/io/network/partition/consumer/InputGate.java
@@ -98,6 +98,8 @@ public abstract class InputGate
 
     public abstract boolean isFinished();
 
+    public abstract boolean hasReceivedEndOfData();
+
     /**
      * Blocking call waiting for next {@link BufferOrEvent}.
      *

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/io/network/partition/consumer/LocalInputChannel.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/io/network/partition/consumer/LocalInputChannel.java
@@ -291,7 +291,7 @@ public class LocalInputChannel extends InputChannel implements BufferAvailabilit
     public void acknowledgeAllRecordsProcessed() throws IOException {
         checkState(!isReleased, "Channel released.");
 
-        subpartitionView.acknowledgeAllRecordsProcessed();
+        subpartitionView.acknowledgeAllDataProcessed();
     }
 
     // ------------------------------------------------------------------------

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/io/network/partition/consumer/SingleInputGate.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/io/network/partition/consumer/SingleInputGate.java
@@ -27,6 +27,7 @@ import org.apache.flink.runtime.clusterframework.types.ResourceID;
 import org.apache.flink.runtime.event.AbstractEvent;
 import org.apache.flink.runtime.event.TaskEvent;
 import org.apache.flink.runtime.execution.CancelTaskException;
+import org.apache.flink.runtime.io.network.api.EndOfData;
 import org.apache.flink.runtime.io.network.api.EndOfPartitionEvent;
 import org.apache.flink.runtime.io.network.api.serialization.EventSerializer;
 import org.apache.flink.runtime.io.network.buffer.Buffer;
@@ -160,6 +161,9 @@ public class SingleInputGate extends IndexedInputGate {
     private final BitSet channelsWithEndOfPartitionEvents;
 
     @GuardedBy("inputChannelsWithData")
+    private final BitSet channelsWithEndOfUserRecords;
+
+    @GuardedBy("inputChannelsWithData")
     private int[] lastPrioritySequenceNumber;
 
     /** The partition producer state listener. */
@@ -172,6 +176,8 @@ public class SingleInputGate extends IndexedInputGate {
     private BufferPool bufferPool;
 
     private boolean hasReceivedAllEndOfPartitionEvents;
+
+    private boolean hasReceivedEndOfData;
 
     /** Flag indicating whether partitions have been requested. */
     private boolean requestedPartitionsFlag;
@@ -227,6 +233,7 @@ public class SingleInputGate extends IndexedInputGate {
         this.inputChannels = new HashMap<>(numberOfInputChannels);
         this.channels = new InputChannel[numberOfInputChannels];
         this.channelsWithEndOfPartitionEvents = new BitSet(numberOfInputChannels);
+        this.channelsWithEndOfUserRecords = new BitSet(numberOfInputChannels);
         this.enqueuedInputChannelsWithData = new BitSet(numberOfInputChannels);
         this.lastPrioritySequenceNumber = new int[numberOfInputChannels];
         Arrays.fill(lastPrioritySequenceNumber, Integer.MIN_VALUE);
@@ -604,6 +611,11 @@ public class SingleInputGate extends IndexedInputGate {
     }
 
     @Override
+    public boolean hasReceivedEndOfData() {
+        return hasReceivedEndOfData;
+    }
+
+    @Override
     public String toString() {
         return "SingleInputGate{"
                 + "owningTaskName='"
@@ -768,6 +780,13 @@ public class SingleInputGate extends IndexedInputGate {
             }
 
             currentChannel.releaseAllResources();
+        } else if (event.getClass() == EndOfData.class) {
+            synchronized (inputChannelsWithData) {
+                checkState(!channelsWithEndOfUserRecords.get(currentChannel.getChannelIndex()));
+                channelsWithEndOfUserRecords.set(currentChannel.getChannelIndex());
+                hasReceivedEndOfData =
+                        channelsWithEndOfUserRecords.cardinality() == numberOfInputChannels;
+            }
         }
 
         return new BufferOrEvent(

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/taskmanager/ConsumableNotifyingResultPartitionWriterDecorator.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/taskmanager/ConsumableNotifyingResultPartitionWriterDecorator.java
@@ -149,13 +149,13 @@ public class ConsumableNotifyingResultPartitionWriterDecorator {
         }
 
         @Override
-        public void notifyEndOfUserRecords() throws IOException {
-            partitionWriter.notifyEndOfUserRecords();
+        public void notifyEndOfData() throws IOException {
+            partitionWriter.notifyEndOfData();
         }
 
         @Override
-        public CompletableFuture<Void> getAllRecordsProcessedFuture() {
-            return partitionWriter.getAllRecordsProcessedFuture();
+        public CompletableFuture<Void> getAllDataProcessedFuture() {
+            return partitionWriter.getAllDataProcessedFuture();
         }
 
         @Override

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/taskmanager/InputGateWithMetrics.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/taskmanager/InputGateWithMetrics.java
@@ -98,6 +98,11 @@ public class InputGateWithMetrics extends IndexedInputGate {
     }
 
     @Override
+    public boolean hasReceivedEndOfData() {
+        return inputGate.hasReceivedEndOfData();
+    }
+
+    @Override
     public void setup() throws IOException {
         inputGate.setup();
     }

--- a/flink-runtime/src/test/java/org/apache/flink/runtime/io/network/api/serialization/EventSerializerTest.java
+++ b/flink-runtime/src/test/java/org/apache/flink/runtime/io/network/api/serialization/EventSerializerTest.java
@@ -23,9 +23,9 @@ import org.apache.flink.runtime.checkpoint.CheckpointType;
 import org.apache.flink.runtime.event.AbstractEvent;
 import org.apache.flink.runtime.io.network.api.CancelCheckpointMarker;
 import org.apache.flink.runtime.io.network.api.CheckpointBarrier;
+import org.apache.flink.runtime.io.network.api.EndOfData;
 import org.apache.flink.runtime.io.network.api.EndOfPartitionEvent;
 import org.apache.flink.runtime.io.network.api.EndOfSuperstepEvent;
-import org.apache.flink.runtime.io.network.api.EndOfUserRecordsEvent;
 import org.apache.flink.runtime.io.network.api.EventAnnouncement;
 import org.apache.flink.runtime.io.network.api.SubtaskConnectionDescriptor;
 import org.apache.flink.runtime.io.network.buffer.Buffer;
@@ -49,7 +49,7 @@ public class EventSerializerTest {
     private final AbstractEvent[] events = {
         EndOfPartitionEvent.INSTANCE,
         EndOfSuperstepEvent.INSTANCE,
-        EndOfUserRecordsEvent.INSTANCE,
+        EndOfData.INSTANCE,
         new CheckpointBarrier(
                 1678L,
                 4623784L,

--- a/flink-runtime/src/test/java/org/apache/flink/runtime/io/network/netty/CancelPartitionRequestTest.java
+++ b/flink-runtime/src/test/java/org/apache/flink/runtime/io/network/netty/CancelPartitionRequestTest.java
@@ -229,7 +229,7 @@ public class CancelPartitionRequestTest {
         public void resumeConsumption() {}
 
         @Override
-        public void acknowledgeAllRecordsProcessed() {}
+        public void acknowledgeAllDataProcessed() {}
 
         @Override
         public AvailabilityWithBacklog getAvailabilityAndBacklog(int numCreditsAvailable) {

--- a/flink-runtime/src/test/java/org/apache/flink/runtime/io/network/netty/PartitionRequestServerHandlerTest.java
+++ b/flink-runtime/src/test/java/org/apache/flink/runtime/io/network/netty/PartitionRequestServerHandlerTest.java
@@ -127,9 +127,9 @@ public class PartitionRequestServerHandlerTest extends TestLogger {
         partitionRequestQueue.notifyReaderCreated(viewReader);
 
         // Write the message to acknowledge all records are processed to server
-        resultPartition.notifyEndOfUserRecords();
+        resultPartition.notifyEndOfData();
         CompletableFuture<Void> allRecordsProcessedFuture =
-                resultPartition.getAllRecordsProcessedFuture();
+                resultPartition.getAllDataProcessedFuture();
         assertFalse(allRecordsProcessedFuture.isDone());
         channel.writeInbound(new NettyMessage.AckAllUserRecordsProcessed(inputChannelID));
         channel.runPendingTasks();

--- a/flink-runtime/src/test/java/org/apache/flink/runtime/io/network/partition/MockResultPartitionWriter.java
+++ b/flink-runtime/src/test/java/org/apache/flink/runtime/io/network/partition/MockResultPartitionWriter.java
@@ -61,10 +61,10 @@ public class MockResultPartitionWriter implements ResultPartitionWriter {
     public void broadcastEvent(AbstractEvent event, boolean isPriorityEvent) throws IOException {}
 
     @Override
-    public void notifyEndOfUserRecords() throws IOException {}
+    public void notifyEndOfData() throws IOException {}
 
     @Override
-    public CompletableFuture<Void> getAllRecordsProcessedFuture() {
+    public CompletableFuture<Void> getAllDataProcessedFuture() {
         return CompletableFuture.completedFuture(null);
     }
 

--- a/flink-runtime/src/test/java/org/apache/flink/runtime/io/network/partition/consumer/SingleInputGateTest.java
+++ b/flink-runtime/src/test/java/org/apache/flink/runtime/io/network/partition/consumer/SingleInputGateTest.java
@@ -222,6 +222,8 @@ public class SingleInputGateTest extends InputGateTestBase {
         inputChannels[0].readBuffer();
         inputChannels[0].readBuffer();
         inputChannels[1].readBuffer();
+        inputChannels[1].readEndOfData();
+        inputChannels[0].readEndOfData();
         inputChannels[1].readEndOfPartitionEvent();
         inputChannels[0].readEndOfPartitionEvent();
 
@@ -232,9 +234,16 @@ public class SingleInputGateTest extends InputGateTestBase {
         verifyBufferOrEvent(inputGate, true, 1, true);
         verifyBufferOrEvent(inputGate, true, 0, true);
         verifyBufferOrEvent(inputGate, false, 1, true);
+        // we have received EndOfData on a single channel only
+        assertFalse(inputGate.hasReceivedEndOfData());
+        verifyBufferOrEvent(inputGate, false, 0, true);
+        assertFalse(inputGate.isFinished());
+        assertTrue(inputGate.hasReceivedEndOfData());
+        verifyBufferOrEvent(inputGate, false, 1, true);
         verifyBufferOrEvent(inputGate, false, 0, false);
 
         // Return null when the input gate has received all end-of-partition events
+        assertTrue(inputGate.hasReceivedEndOfData());
         assertTrue(inputGate.isFinished());
 
         for (TestInputChannel ic : inputChannels) {

--- a/flink-runtime/src/test/java/org/apache/flink/runtime/io/network/partition/consumer/TestInputChannel.java
+++ b/flink-runtime/src/test/java/org/apache/flink/runtime/io/network/partition/consumer/TestInputChannel.java
@@ -29,7 +29,6 @@ import org.apache.flink.runtime.io.network.partition.ResultPartitionID;
 import javax.annotation.Nullable;
 
 import java.io.IOException;
-import java.io.UnsupportedEncodingException;
 import java.util.ArrayList;
 import java.util.Collection;
 import java.util.Optional;
@@ -203,9 +202,7 @@ public class TestInputChannel extends InputChannel {
     }
 
     @Override
-    public void acknowledgeAllRecordsProcessed() throws IOException {
-        throw new UnsupportedEncodingException();
-    }
+    public void acknowledgeAllRecordsProcessed() throws IOException {}
 
     @Override
     protected void notifyChannelNonEmpty() {

--- a/flink-runtime/src/test/java/org/apache/flink/runtime/io/network/partition/consumer/TestInputChannel.java
+++ b/flink-runtime/src/test/java/org/apache/flink/runtime/io/network/partition/consumer/TestInputChannel.java
@@ -20,6 +20,7 @@ package org.apache.flink.runtime.io.network.partition.consumer;
 
 import org.apache.flink.metrics.SimpleCounter;
 import org.apache.flink.runtime.event.TaskEvent;
+import org.apache.flink.runtime.io.network.api.EndOfData;
 import org.apache.flink.runtime.io.network.api.EndOfPartitionEvent;
 import org.apache.flink.runtime.io.network.api.serialization.EventSerializer;
 import org.apache.flink.runtime.io.network.buffer.Buffer;
@@ -100,6 +101,16 @@ public class TestInputChannel extends InputChannel {
 
     TestInputChannel readBuffer(Buffer.DataType nextType) throws IOException, InterruptedException {
         return read(createBuffer(1), nextType);
+    }
+
+    TestInputChannel readEndOfData() throws IOException {
+        addBufferAndAvailability(
+                new BufferAndAvailability(
+                        EventSerializer.toBuffer(EndOfData.INSTANCE, false),
+                        Buffer.DataType.EVENT_BUFFER,
+                        0,
+                        sequenceNumber++));
+        return this;
     }
 
     TestInputChannel readEndOfPartitionEvent() {

--- a/flink-runtime/src/test/java/org/apache/flink/runtime/io/network/partition/consumer/UnionInputGateTest.java
+++ b/flink-runtime/src/test/java/org/apache/flink/runtime/io/network/partition/consumer/UnionInputGateTest.java
@@ -65,18 +65,26 @@ public class UnionInputGateTest extends InputGateTestBase {
                 };
 
         inputChannels[0][0].readBuffer(); // 0 => 0
+        inputChannels[0][0].readEndOfData(); // 0 => 0
         inputChannels[0][0].readEndOfPartitionEvent(); // 0 => 0
         inputChannels[1][2].readBuffer(); // 2 => 5
+        inputChannels[1][2].readEndOfData(); // 2 => 5
         inputChannels[1][2].readEndOfPartitionEvent(); // 2 => 5
         inputChannels[1][0].readBuffer(); // 0 => 3
         inputChannels[1][1].readBuffer(); // 1 => 4
         inputChannels[0][1].readBuffer(); // 1 => 1
         inputChannels[1][3].readBuffer(); // 3 => 6
+        inputChannels[0][1].readEndOfData(); // 1 => 1
+        inputChannels[1][3].readEndOfData(); // 3 => 6
         inputChannels[0][1].readEndOfPartitionEvent(); // 1 => 1
         inputChannels[1][3].readEndOfPartitionEvent(); // 3 => 6
         inputChannels[0][2].readBuffer(); // 1 => 2
+        inputChannels[0][2].readEndOfData(); // 1 => 2
         inputChannels[0][2].readEndOfPartitionEvent(); // 1 => 2
         inputChannels[1][4].readBuffer(); // 4 => 7
+        inputChannels[1][4].readEndOfData(); // 4 => 7
+        inputChannels[1][1].readEndOfData(); // 0 => 3
+        inputChannels[1][0].readEndOfData(); // 0 => 3
         inputChannels[1][4].readEndOfPartitionEvent(); // 4 => 7
         inputChannels[1][1].readEndOfPartitionEvent(); // 0 => 3
         inputChannels[1][0].readEndOfPartitionEvent(); // 0 => 3
@@ -102,6 +110,17 @@ public class UnionInputGateTest extends InputGateTestBase {
         verifyBufferOrEvent(union, false, 1, true); // gate 1, channel 1
         verifyBufferOrEvent(union, true, 7, true); // gate 2, channel 1
         verifyBufferOrEvent(union, false, 2, true); // gate 1, channel 2
+        verifyBufferOrEvent(union, false, 3, true); // gate 2, channel 0
+        verifyBufferOrEvent(union, false, 0, true); // gate 1, channel 0
+        verifyBufferOrEvent(union, false, 4, true); // gate 1, channel 1
+        verifyBufferOrEvent(union, false, 1, true); // gate 1, channel 1
+        assertFalse(union.hasReceivedEndOfData());
+        verifyBufferOrEvent(union, false, 5, true); // gate 2, channel 2
+        verifyBufferOrEvent(union, false, 2, true); // gate 1, channel 2
+        verifyBufferOrEvent(union, false, 6, true); // gate 2, channel 3
+        verifyBufferOrEvent(union, false, 7, true); // gate 2, channel 4
+        assertTrue(union.hasReceivedEndOfData());
+        assertFalse(union.isFinished());
         verifyBufferOrEvent(union, false, 3, true); // gate 2, channel 0
         verifyBufferOrEvent(union, false, 4, true); // gate 2, channel 1
         verifyBufferOrEvent(union, false, 5, true); // gate 2, channel 2

--- a/flink-streaming-java/src/main/java/org/apache/flink/streaming/api/operators/InputSelectable.java
+++ b/flink-streaming-java/src/main/java/org/apache/flink/streaming/api/operators/InputSelectable.java
@@ -31,10 +31,14 @@ import org.apache.flink.annotation.PublicEvolving;
  * that it does not currently want to process. Therefore, if an operator needs a strict convention,
  * it must cache the unexpected data itself and handle them correctly.
  *
- * <p>This interface also makes the following conventions: 1.The runtime must call {@code
- * nextSelection()} to determine the input to read the first record. 2.When the input being read
- * reaches the end, the runtime must call {@code nextSelection()} to determine the next input to be
- * read.
+ * <p>This interface also makes the following conventions:
+ *
+ * <ol>
+ *   <li>The runtime must call {@code nextSelection()} to determine the input to read the first
+ *       record.
+ *   <li>When the input being read reaches the end, the runtime must call {@code nextSelection()} to
+ *       determine the next input to be read.
+ * </ol>
  */
 @PublicEvolving
 public interface InputSelectable {

--- a/flink-streaming-java/src/main/java/org/apache/flink/streaming/api/operators/InputSelection.java
+++ b/flink-streaming-java/src/main/java/org/apache/flink/streaming/api/operators/InputSelection.java
@@ -83,7 +83,26 @@ public final class InputSelection implements Serializable {
      *     {@code inputMask} is empty or the inputs in {@code inputMask} are unavailable).
      */
     public int fairSelectNextIndexOutOf2(int availableInputsMask, int lastReadInputIndex) {
-        int selectionMask = (int) inputMask;
+        return fairSelectNextIndexOutOf2((int) inputMask, availableInputsMask, lastReadInputIndex);
+    }
+
+    /**
+     * Fairly select one of the two inputs for reading. When {@code inputMask} includes two inputs
+     * and both inputs are available, alternately select one of them. Otherwise, select the
+     * available one of {@code inputMask}, or return {@link InputSelection#NONE_AVAILABLE} to
+     * indicate no input is selected.
+     *
+     * <p>Note that this supports only two inputs for performance reasons.
+     *
+     * @param selectionMask The mask of inputs that are selected. Note -1 for this is interpreted as
+     *     all of the 32 inputs are available.
+     * @param availableInputsMask The mask of all available inputs.
+     * @param lastReadInputIndex The index of last read input.
+     * @return the index of the input for reading or {@link InputSelection#NONE_AVAILABLE} (if
+     *     {@code inputMask} is empty or the inputs in {@code inputMask} are unavailable).
+     */
+    public static int fairSelectNextIndexOutOf2(
+            int selectionMask, int availableInputsMask, int lastReadInputIndex) {
         int combineMask = availableInputsMask & selectionMask;
 
         if (combineMask == 3) {
@@ -105,6 +124,22 @@ public final class InputSelection implements Serializable {
      *     {@code inputMask} is empty or the inputs in {@code inputMask} are unavailable).
      */
     public int fairSelectNextIndex(long availableInputsMask, int lastReadInputIndex) {
+        return fairSelectNextIndex(inputMask, availableInputsMask, lastReadInputIndex);
+    }
+
+    /**
+     * Fairly select one of the available inputs for reading.
+     *
+     * @param inputMask The mask of inputs that are selected. Note -1 for this is interpreted as all
+     *     of the 32 inputs are available.
+     * @param availableInputsMask The mask of all available inputs. Note -1 for this is interpreted
+     *     as all of the 32 inputs are available.
+     * @param lastReadInputIndex The index of last read input.
+     * @return the index of the input for reading or {@link InputSelection#NONE_AVAILABLE} (if
+     *     {@code inputMask} is empty or the inputs in {@code inputMask} are unavailable).
+     */
+    public static int fairSelectNextIndex(
+            long inputMask, long availableInputsMask, int lastReadInputIndex) {
         long combineMask = availableInputsMask & inputMask;
 
         if (combineMask == 0) {
@@ -118,7 +153,7 @@ public final class InputSelection implements Serializable {
         return selectFirstBitRightFromNext(combineMask, 0);
     }
 
-    private int selectFirstBitRightFromNext(long bits, int next) {
+    private static int selectFirstBitRightFromNext(long bits, int next) {
         if (next >= 64) {
             return NONE_AVAILABLE;
         }

--- a/flink-streaming-java/src/main/java/org/apache/flink/streaming/api/operators/SourceOperator.java
+++ b/flink-streaming-java/src/main/java/org/apache/flink/streaming/api/operators/SourceOperator.java
@@ -32,6 +32,7 @@ import org.apache.flink.configuration.Configuration;
 import org.apache.flink.core.io.InputStatus;
 import org.apache.flink.core.io.SimpleVersionedSerializer;
 import org.apache.flink.metrics.MetricGroup;
+import org.apache.flink.runtime.io.AvailabilityProvider;
 import org.apache.flink.runtime.operators.coordination.OperatorEvent;
 import org.apache.flink.runtime.operators.coordination.OperatorEventGateway;
 import org.apache.flink.runtime.operators.coordination.OperatorEventHandler;
@@ -128,7 +129,18 @@ public class SourceOperator<OUT, SplitT extends SourceSplit> extends AbstractStr
      */
     private TimestampsAndWatermarks<OUT> eventTimeLogic;
 
-    private boolean dataFinished = false;
+    /** A mode to control the behaviour of the {@link #emitNext(DataOutput)} method. */
+    private OperatingMode operatingMode;
+
+    private final CompletableFuture<Void> emittedEndOfData = new CompletableFuture<>();
+    private final CompletableFuture<Void> forcedStop = new CompletableFuture<>();
+
+    private enum OperatingMode {
+        OUTPUT_NOT_INITIALIZED,
+        READING,
+        SOURCE_STOPPED,
+        DATA_FINISHED
+    }
 
     public SourceOperator(
             FunctionWithException<SourceReaderContext, SourceReader<OUT, SplitT>, Exception>
@@ -149,6 +161,7 @@ public class SourceOperator<OUT, SplitT extends SourceSplit> extends AbstractStr
         this.configuration = checkNotNull(configuration);
         this.localHostname = checkNotNull(localHostname);
         this.emitProgressiveWatermarks = emitProgressiveWatermarks;
+        this.operatingMode = OperatingMode.OUTPUT_NOT_INITIALIZED;
     }
 
     /**
@@ -270,6 +283,17 @@ public class SourceOperator<OUT, SplitT extends SourceSplit> extends AbstractStr
         super.finish();
     }
 
+    public CompletableFuture<Void> stop() {
+        switch (operatingMode) {
+            case OUTPUT_NOT_INITIALIZED:
+            case READING:
+                this.operatingMode = OperatingMode.SOURCE_STOPPED;
+                forcedStop.complete(null);
+                break;
+        }
+        return emittedEndOfData;
+    }
+
     @Override
     public void close() throws Exception {
         if (sourceReader != null) {
@@ -283,17 +307,29 @@ public class SourceOperator<OUT, SplitT extends SourceSplit> extends AbstractStr
         // guarding an assumptions we currently make due to the fact that certain classes
         // assume a constant output, this assumption does not need to stand if we emitted all
         // records. In that case the output will change to FinishedDataOutput
-        assert lastInvokedOutput == output || lastInvokedOutput == null || dataFinished;
+        assert lastInvokedOutput == output
+                || lastInvokedOutput == null
+                || this.operatingMode == OperatingMode.DATA_FINISHED;
 
-        // short circuit the common case (every invocation except the first)
-        if (currentMainOutput != null) {
-            return convertToInternalStatus(sourceReader.pollNext(currentMainOutput));
+        switch (operatingMode) {
+            case OUTPUT_NOT_INITIALIZED:
+                // this creates a batch or streaming output based on the runtime mode
+                currentMainOutput = eventTimeLogic.createMainOutput(output);
+                lastInvokedOutput = output;
+                this.operatingMode = OperatingMode.READING;
+                return convertToInternalStatus(sourceReader.pollNext(currentMainOutput));
+            case READING:
+                // short circuit the common case (every invocation except the first)
+                return convertToInternalStatus(sourceReader.pollNext(currentMainOutput));
+            case SOURCE_STOPPED:
+                this.operatingMode = OperatingMode.DATA_FINISHED;
+                emittedEndOfData.complete(null);
+                return DataInputStatus.END_OF_DATA;
+            case DATA_FINISHED:
+                return DataInputStatus.END_OF_INPUT;
+            default:
+                throw new IllegalStateException("Unknown operating mode: " + operatingMode);
         }
-
-        // this creates a batch or streaming output based on the runtime mode
-        currentMainOutput = eventTimeLogic.createMainOutput(output);
-        lastInvokedOutput = output;
-        return convertToInternalStatus(sourceReader.pollNext(currentMainOutput));
     }
 
     private DataInputStatus convertToInternalStatus(InputStatus inputStatus) {
@@ -303,12 +339,9 @@ public class SourceOperator<OUT, SplitT extends SourceSplit> extends AbstractStr
             case NOTHING_AVAILABLE:
                 return DataInputStatus.NOTHING_AVAILABLE;
             case END_OF_INPUT:
-                if (dataFinished) {
-                    return DataInputStatus.END_OF_INPUT;
-                } else {
-                    dataFinished = true;
-                    return DataInputStatus.END_OF_DATA;
-                }
+                this.operatingMode = OperatingMode.DATA_FINISHED;
+                emittedEndOfData.complete(null);
+                return DataInputStatus.END_OF_DATA;
             default:
                 throw new IllegalArgumentException("Unknown input status: " + inputStatus);
         }
@@ -323,7 +356,19 @@ public class SourceOperator<OUT, SplitT extends SourceSplit> extends AbstractStr
 
     @Override
     public CompletableFuture<?> getAvailableFuture() {
-        return sourceReader.isAvailable();
+        switch (operatingMode) {
+            case OUTPUT_NOT_INITIALIZED:
+            case READING:
+                CompletableFuture<Void> sourceReaderAvailable = sourceReader.isAvailable();
+                return sourceReaderAvailable == AvailabilityProvider.AVAILABLE
+                        ? sourceReaderAvailable
+                        : CompletableFuture.anyOf(sourceReaderAvailable, forcedStop);
+            case SOURCE_STOPPED:
+            case DATA_FINISHED:
+                return AvailabilityProvider.AVAILABLE;
+            default:
+                throw new IllegalStateException("Unknown operating mode: " + operatingMode);
+        }
     }
 
     @Override

--- a/flink-streaming-java/src/main/java/org/apache/flink/streaming/api/operators/collect/AbstractCollectResultBuffer.java
+++ b/flink-streaming-java/src/main/java/org/apache/flink/streaming/api/operators/collect/AbstractCollectResultBuffer.java
@@ -128,6 +128,9 @@ public abstract class AbstractCollectResultBuffer<T> {
         if (!results.isEmpty()) {
             // response contains some data, add them to buffer
             int addStart = (int) (offset - responseOffset);
+            if (addStart > results.size()) {
+                return;
+            }
             List<T> addedResults = results.subList(addStart, results.size());
             buffer.addAll(addedResults);
             offset += addedResults.size();

--- a/flink-streaming-java/src/main/java/org/apache/flink/streaming/api/operators/sort/SortingDataInput.java
+++ b/flink-streaming-java/src/main/java/org/apache/flink/streaming/api/operators/sort/SortingDataInput.java
@@ -188,7 +188,7 @@ public final class SortingDataInput<T, K> implements StreamTaskInput<T> {
         }
 
         DataInputStatus inputStatus = wrappedInput.emitNext(forwardingDataOutput);
-        if (inputStatus == DataInputStatus.END_OF_INPUT) {
+        if (inputStatus == DataInputStatus.END_OF_DATA) {
             endSorting();
             return emitNextSortedRecord(output);
         }
@@ -211,7 +211,7 @@ public final class SortingDataInput<T, K> implements StreamTaskInput<T> {
             if (watermarkSeen > Long.MIN_VALUE) {
                 output.emitWatermark(new Watermark(watermarkSeen));
             }
-            return DataInputStatus.END_OF_INPUT;
+            return DataInputStatus.END_OF_DATA;
         }
     }
 

--- a/flink-streaming-java/src/main/java/org/apache/flink/streaming/runtime/io/AbstractStreamTaskNetworkInput.java
+++ b/flink-streaming-java/src/main/java/org/apache/flink/streaming/runtime/io/AbstractStreamTaskNetworkInput.java
@@ -20,6 +20,7 @@ package org.apache.flink.streaming.runtime.io;
 import org.apache.flink.api.common.typeutils.TypeSerializer;
 import org.apache.flink.runtime.checkpoint.channel.InputChannelInfo;
 import org.apache.flink.runtime.event.AbstractEvent;
+import org.apache.flink.runtime.io.network.api.EndOfData;
 import org.apache.flink.runtime.io.network.api.EndOfPartitionEvent;
 import org.apache.flink.runtime.io.network.api.serialization.RecordDeserializer;
 import org.apache.flink.runtime.io.network.partition.consumer.BufferOrEvent;
@@ -149,12 +150,17 @@ public abstract class AbstractStreamTaskNetworkInput<
     protected DataInputStatus processEvent(BufferOrEvent bufferOrEvent) {
         // Event received
         final AbstractEvent event = bufferOrEvent.getEvent();
-        // TODO: with checkpointedInputGate.isFinished() we might not need to support any events on
-        // this level.
-        if (event.getClass() == EndOfPartitionEvent.class) {
+        if (event.getClass() == EndOfData.class) {
+            if (checkpointedInputGate.hasReceivedEndOfData()) {
+                return DataInputStatus.END_OF_DATA;
+            }
+        } else if (event.getClass() == EndOfPartitionEvent.class) {
             // release the record deserializer immediately,
             // which is very valuable in case of bounded stream
             releaseDeserializer(bufferOrEvent.getChannelInfo());
+            if (checkpointedInputGate.isFinished()) {
+                return DataInputStatus.END_OF_INPUT;
+            }
         } else if (event.getClass() == EndOfChannelStateEvent.class) {
             if (checkpointedInputGate.allChannelsRecovered()) {
                 return DataInputStatus.END_OF_RECOVERY;

--- a/flink-streaming-java/src/main/java/org/apache/flink/streaming/runtime/io/DataInputStatus.java
+++ b/flink-streaming-java/src/main/java/org/apache/flink/streaming/runtime/io/DataInputStatus.java
@@ -45,5 +45,11 @@ public enum DataInputStatus {
     END_OF_RECOVERY,
 
     /** Indicator that the input has reached the end of data. */
+    END_OF_DATA,
+
+    /**
+     * Indicator that the input has reached the end of data and control events. The input is about
+     * to close.
+     */
     END_OF_INPUT
 }

--- a/flink-streaming-java/src/main/java/org/apache/flink/streaming/runtime/io/FinishedDataOutput.java
+++ b/flink-streaming-java/src/main/java/org/apache/flink/streaming/runtime/io/FinishedDataOutput.java
@@ -1,0 +1,56 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.flink.streaming.runtime.io;
+
+import org.apache.flink.streaming.api.watermark.Watermark;
+import org.apache.flink.streaming.runtime.streamrecord.LatencyMarker;
+import org.apache.flink.streaming.runtime.streamrecord.StreamRecord;
+import org.apache.flink.streaming.runtime.streamstatus.StreamStatus;
+
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+/**
+ * An empty {@link PushingAsyncDataInput.DataOutput} which is used by {@link
+ * StreamOneInputProcessor} once an {@link DataInputStatus#END_OF_DATA} is received.
+ */
+public class FinishedDataOutput<IN> implements PushingAsyncDataInput.DataOutput<IN> {
+
+    private static final Logger LOG = LoggerFactory.getLogger(FinishedDataOutput.class);
+
+    @Override
+    public void emitRecord(StreamRecord<IN> streamRecord) throws Exception {
+        LOG.debug("Unexpected record after finish() received.");
+    }
+
+    @Override
+    public void emitWatermark(Watermark watermark) throws Exception {
+        LOG.debug("Unexpected watermark after finish() received.");
+    }
+
+    @Override
+    public void emitStreamStatus(StreamStatus streamStatus) throws Exception {
+        LOG.debug("Unexpected stream status after finish() received.");
+    }
+
+    @Override
+    public void emitLatencyMarker(LatencyMarker latencyMarker) throws Exception {
+        LOG.debug("Unexpected latency marker after finish() received.");
+    }
+}

--- a/flink-streaming-java/src/main/java/org/apache/flink/streaming/runtime/io/StreamMultipleInputProcessor.java
+++ b/flink-streaming-java/src/main/java/org/apache/flink/streaming/runtime/io/StreamMultipleInputProcessor.java
@@ -84,8 +84,7 @@ public final class StreamMultipleInputProcessor implements StreamInputProcessor 
 
         lastReadInputIndex = readingInputIndex;
         DataInputStatus inputStatus = inputProcessors[readingInputIndex].processInput();
-        inputSelectionHandler.nextSelection();
-        return inputSelectionHandler.updateStatus(inputStatus, readingInputIndex);
+        return inputSelectionHandler.updateStatusAndSelection(inputStatus, readingInputIndex);
     }
 
     private int selectFirstReadingInputIndex() {

--- a/flink-streaming-java/src/main/java/org/apache/flink/streaming/runtime/io/StreamOneInputProcessor.java
+++ b/flink-streaming-java/src/main/java/org/apache/flink/streaming/runtime/io/StreamOneInputProcessor.java
@@ -43,7 +43,7 @@ public final class StreamOneInputProcessor<IN> implements StreamInputProcessor {
     private static final Logger LOG = LoggerFactory.getLogger(StreamOneInputProcessor.class);
 
     private StreamTaskInput<IN> input;
-    private final DataOutput<IN> output;
+    private DataOutput<IN> output;
 
     private final BoundedMultiInput endOfInputAware;
 
@@ -64,8 +64,9 @@ public final class StreamOneInputProcessor<IN> implements StreamInputProcessor {
     public DataInputStatus processInput() throws Exception {
         DataInputStatus status = input.emitNext(output);
 
-        if (status == DataInputStatus.END_OF_INPUT) {
+        if (status == DataInputStatus.END_OF_DATA) {
             endOfInputAware.endInput(input.getInputIndex() + 1);
+            output = new FinishedDataOutput<>();
         } else if (status == DataInputStatus.END_OF_RECOVERY) {
             if (input instanceof RecoverableStreamTaskInput) {
                 input = ((RecoverableStreamTaskInput<IN>) input).finishRecovery();

--- a/flink-streaming-java/src/main/java/org/apache/flink/streaming/runtime/io/StreamTaskSourceInput.java
+++ b/flink-streaming-java/src/main/java/org/apache/flink/streaming/runtime/io/StreamTaskSourceInput.java
@@ -153,4 +153,8 @@ public class StreamTaskSourceInput<T> implements StreamTaskInput<T>, Checkpointa
     public OperatorID getOperatorID() {
         return operator.getOperatorID();
     }
+
+    public SourceOperator<T, ?> getOperator() {
+        return operator;
+    }
 }

--- a/flink-streaming-java/src/main/java/org/apache/flink/streaming/runtime/io/checkpointing/CheckpointedInputGate.java
+++ b/flink-streaming-java/src/main/java/org/apache/flink/streaming/runtime/io/checkpointing/CheckpointedInputGate.java
@@ -222,6 +222,11 @@ public class CheckpointedInputGate implements PullingAsyncDataInput<BufferOrEven
         return isFinished;
     }
 
+    @Override
+    public boolean hasReceivedEndOfData() {
+        return inputGate.hasReceivedEndOfData();
+    }
+
     /**
      * Cleans up all internally held resources.
      *

--- a/flink-streaming-java/src/main/java/org/apache/flink/streaming/runtime/io/checkpointing/CheckpointedInputGate.java
+++ b/flink-streaming-java/src/main/java/org/apache/flink/streaming/runtime/io/checkpointing/CheckpointedInputGate.java
@@ -24,8 +24,8 @@ import org.apache.flink.runtime.event.AbstractEvent;
 import org.apache.flink.runtime.io.PullingAsyncDataInput;
 import org.apache.flink.runtime.io.network.api.CancelCheckpointMarker;
 import org.apache.flink.runtime.io.network.api.CheckpointBarrier;
+import org.apache.flink.runtime.io.network.api.EndOfData;
 import org.apache.flink.runtime.io.network.api.EndOfPartitionEvent;
-import org.apache.flink.runtime.io.network.api.EndOfUserRecordsEvent;
 import org.apache.flink.runtime.io.network.api.EventAnnouncement;
 import org.apache.flink.runtime.io.network.partition.consumer.BufferOrEvent;
 import org.apache.flink.runtime.io.network.partition.consumer.EndOfChannelStateEvent;
@@ -183,7 +183,7 @@ public class CheckpointedInputGate implements PullingAsyncDataInput<BufferOrEven
             barrierHandler.processCancellationBarrier(
                     (CancelCheckpointMarker) bufferOrEvent.getEvent(),
                     bufferOrEvent.getChannelInfo());
-        } else if (eventClass == EndOfUserRecordsEvent.class) {
+        } else if (eventClass == EndOfData.class) {
             inputGate.acknowledgeAllRecordsProcessed(bufferOrEvent.getChannelInfo());
         } else if (eventClass == EndOfPartitionEvent.class) {
             barrierHandler.processEndOfPartition(bufferOrEvent.getChannelInfo());

--- a/flink-streaming-java/src/main/java/org/apache/flink/streaming/runtime/tasks/OperatorChain.java
+++ b/flink-streaming-java/src/main/java/org/apache/flink/streaming/runtime/tasks/OperatorChain.java
@@ -133,8 +133,6 @@ public class OperatorChain<OUT, OP extends StreamOperator<OUT>>
 
     private final OperatorEventDispatcherImpl operatorEventDispatcher;
 
-    private boolean ignoreEndOfInput;
-
     private final Closer closer = Closer.create();
 
     public OperatorChain(
@@ -425,7 +423,7 @@ public class OperatorChain<OUT, OP extends StreamOperator<OUT>>
      */
     @Override
     public void endInput(int inputId) throws Exception {
-        if (mainOperatorWrapper != null && !ignoreEndOfInput) {
+        if (mainOperatorWrapper != null) {
             mainOperatorWrapper.endOperatorInput(inputId);
         }
     }
@@ -459,7 +457,7 @@ public class OperatorChain<OUT, OP extends StreamOperator<OUT>>
         }
 
         if (firstOperatorWrapper != null) {
-            firstOperatorWrapper.finish(actionExecutor, ignoreEndOfInput);
+            firstOperatorWrapper.finish(actionExecutor);
         }
     }
 
@@ -799,10 +797,6 @@ public class OperatorChain<OUT, OP extends StreamOperator<OUT>>
     @Nullable
     StreamOperator<?> getTailOperator() {
         return (tailOperatorWrapper == null) ? null : tailOperatorWrapper.getStreamOperator();
-    }
-
-    public void setIgnoreEndOfInput(boolean ignoreEndOfInput) {
-        this.ignoreEndOfInput = ignoreEndOfInput;
     }
 
     /** Wrapper class to access the chained sources and their's outputs. */

--- a/flink-streaming-java/src/main/java/org/apache/flink/streaming/runtime/tasks/SourceStreamTask.java
+++ b/flink-streaming-java/src/main/java/org/apache/flink/streaming/runtime/tasks/SourceStreamTask.java
@@ -37,7 +37,7 @@ import org.apache.flink.util.FlinkException;
 import org.apache.flink.util.Preconditions;
 
 import java.util.concurrent.CompletableFuture;
-import java.util.concurrent.Future;
+import java.util.concurrent.ExecutionException;
 
 /**
  * {@link StreamTask} for executing a {@link StreamSource}.
@@ -63,11 +63,30 @@ public class SourceStreamTask<
 
     private volatile boolean externallyInducedCheckpoints;
 
+    private enum FinishingReason {
+        END_OF_DATA(true),
+        STOP_WITH_SAVEPOINT_DRAIN(true),
+        STOP_WITH_SAVEPOINT_NO_DRAIN(false);
+
+        private final boolean shouldCallFinish;
+
+        FinishingReason(boolean shouldCallFinish) {
+            this.shouldCallFinish = shouldCallFinish;
+        }
+
+        boolean shouldCallFinish() {
+            return this.shouldCallFinish;
+        }
+    }
+
     /**
-     * Indicates whether this Task was purposefully finished (by finishTask()), in this case we want
-     * to ignore exceptions thrown after finishing, to ensure shutdown works smoothly.
+     * Indicates whether this Task was purposefully finished, in this case we want to ignore
+     * exceptions thrown after finishing, to ensure shutdown works smoothly.
+     *
+     * <p>Moreover we differentiate drain and no drain cases to see if we need to call finish() on
+     * the operators.
      */
-    private volatile boolean wasStoppedExternally = false;
+    private volatile FinishingReason finishingReason = FinishingReason.END_OF_DATA;
 
     public SourceStreamTask(Environment env) throws Exception {
         this(env, new Object());
@@ -184,12 +203,12 @@ public class SourceStreamTask<
 
     @Override
     protected void cancelTask() {
-        cancelTask(true);
+        cancelOperator(true);
     }
 
     @Override
     protected void finishTask() {
-        wasStoppedExternally = true;
+        this.finishingReason = FinishingReason.STOP_WITH_SAVEPOINT_NO_DRAIN;
         /**
          * Currently stop with savepoint relies on the EndOfPartitionEvents propagation and performs
          * clean shutdown after the stop with savepoint (which can produce some records to process
@@ -197,16 +216,16 @@ public class SourceStreamTask<
          * network stack in an inconsistent state. So, if we want to relay on the clean shutdown, we
          * can not interrupt the source thread.
          */
-        cancelTask(false);
+        cancelOperator(false);
     }
 
-    private void cancelTask(boolean interrupt) {
+    private void cancelOperator(boolean interruptThread) {
         try {
             if (mainOperator != null) {
                 mainOperator.cancel();
             }
         } finally {
-            interruptSourceThread(interrupt);
+            interruptSourceThread(interruptThread);
         }
     }
 
@@ -236,15 +255,45 @@ public class SourceStreamTask<
     // ------------------------------------------------------------------------
 
     @Override
-    public Future<Boolean> triggerCheckpointAsync(
+    public CompletableFuture<Boolean> triggerCheckpointAsync(
             CheckpointMetaData checkpointMetaData, CheckpointOptions checkpointOptions) {
         if (!externallyInducedCheckpoints) {
-            return super.triggerCheckpointAsync(checkpointMetaData, checkpointOptions);
+            if (checkpointOptions.getCheckpointType().shouldDrain()) {
+                return triggerStopWithSavepointWithDrainAsync(
+                        checkpointMetaData, checkpointOptions);
+            } else {
+                return super.triggerCheckpointAsync(checkpointMetaData, checkpointOptions);
+            }
         } else {
             // we do not trigger checkpoints here, we simply state whether we can trigger them
             synchronized (lock) {
                 return CompletableFuture.completedFuture(isRunning());
             }
+        }
+    }
+
+    private CompletableFuture<Boolean> triggerStopWithSavepointWithDrainAsync(
+            CheckpointMetaData checkpointMetaData, CheckpointOptions checkpointOptions) {
+        mainMailboxExecutor.execute(
+                () ->
+                        stopOperatorForStopWithSavepointWithDrain(
+                                checkpointMetaData.getCheckpointId()),
+                "stop legacy source for stop-with-savepoint --drain");
+        return assertTriggeringCheckpointExceptions(
+                sourceThread
+                        .getCompletionFuture()
+                        .thenCompose(
+                                ignore ->
+                                        super.triggerCheckpointAsync(
+                                                checkpointMetaData, checkpointOptions)),
+                checkpointMetaData.getCheckpointId());
+    }
+
+    private void stopOperatorForStopWithSavepointWithDrain(long checkpointId) {
+        setSynchronousSavepoint(checkpointId, true);
+        finishingReason = FinishingReason.STOP_WITH_SAVEPOINT_DRAIN;
+        if (mainOperator != null) {
+            mainOperator.stop();
         }
     }
 
@@ -273,36 +322,36 @@ public class SourceStreamTask<
                             getTaskNameWithSubtaskAndId());
                     mainOperator.run(lock, operatorChain);
                 }
-                if (!wasStoppedExternally && !isCanceled() && !isFailing()) {
-                    synchronized (lock) {
-                        operatorChain.setIgnoreEndOfInput(false);
-                    }
-                    CompletableFuture<Void> endOfDataProcessed = new CompletableFuture<>();
-                    mainMailboxExecutor.execute(
-                            () -> {
-                                endData();
-                                endOfDataProcessed.complete(null);
-                            },
-                            "SourceStreamTask finished processing data.");
-
-                    // wait until all operators are finished
-                    endOfDataProcessed.get();
-                }
+                completeProcessing();
                 completionFuture.complete(null);
             } catch (Throwable t) {
                 // Note, t can be also an InterruptedException
-                completionFuture.completeExceptionally(t);
                 if (isCanceled()
                         && ExceptionUtils.findThrowable(t, InterruptedException.class)
                                 .isPresent()) {
                     completionFuture.completeExceptionally(new CancelTaskException(t));
-                } else if (wasStoppedExternally) {
-                    // swallow all exceptions if the source was stopped externally
+                } else if (finishingReason == FinishingReason.STOP_WITH_SAVEPOINT_NO_DRAIN) {
+                    // swallow all exceptions if the source was stopped without drain
                     completionFuture.complete(null);
                 } else {
                     completionFuture.completeExceptionally(t);
                 }
             }
+        }
+
+        private void completeProcessing() throws InterruptedException, ExecutionException {
+            if (finishingReason.shouldCallFinish() && !isCanceled() && !isFailing()) {
+                mainMailboxExecutor
+                        .submit(
+                                () -> {
+                                    // theoretically the StreamSource can implement BoundedOneInput,
+                                    // so we
+                                    // need to call it here
+                                    operatorChain.endInput(1);
+                                    endData();
+                                },
+                                "SourceStreamTask finished processing data.")
+                        .get();
             }
         }
 

--- a/flink-streaming-java/src/main/java/org/apache/flink/streaming/runtime/tasks/StreamOperatorWrapper.java
+++ b/flink-streaming-java/src/main/java/org/apache/flink/streaming/runtime/tasks/StreamOperatorWrapper.java
@@ -39,8 +39,8 @@ import static org.apache.flink.util.Preconditions.checkNotNull;
  * This class handles the finish, endInput and other related logic of a {@link StreamOperator}. It
  * also automatically propagates the finish operation to the next wrapper that the {@link #next}
  * points to, so we can use {@link #next} to link all operator wrappers in the operator chain and
- * finish all operators only by calling the {@link #finish(StreamTaskActionExecutor, boolean)}
- * method of the header operator wrapper.
+ * finish all operators only by calling the {@link #finish(StreamTaskActionExecutor)} method of the
+ * header operator wrapper.
  */
 @Internal
 public class StreamOperatorWrapper<OUT, OP extends StreamOperator<OUT>> {
@@ -120,9 +120,8 @@ public class StreamOperatorWrapper<OUT, OP extends StreamOperator<OUT>> {
      * MailboxExecutor#yield()} to take the mails of closing operator and running timers and run
      * them.
      */
-    public void finish(StreamTaskActionExecutor actionExecutor, boolean isStoppingBySyncSavepoint)
-            throws Exception {
-        if (!isHead && !isStoppingBySyncSavepoint) {
+    public void finish(StreamTaskActionExecutor actionExecutor) throws Exception {
+        if (!isHead) {
             // NOTE: This only do for the case where the operator is one-input operator. At present,
             // any non-head operator on the operator chain is one-input operator.
             actionExecutor.runThrowing(() -> endOperatorInput(1));
@@ -132,7 +131,7 @@ public class StreamOperatorWrapper<OUT, OP extends StreamOperator<OUT>> {
 
         // propagate the close operation to the next wrapper
         if (next != null) {
-            next.finish(actionExecutor, isStoppingBySyncSavepoint);
+            next.finish(actionExecutor);
         }
     }
 

--- a/flink-streaming-java/src/main/java/org/apache/flink/streaming/runtime/tasks/StreamTask.java
+++ b/flink-streaming-java/src/main/java/org/apache/flink/streaming/runtime/tasks/StreamTask.java
@@ -152,8 +152,8 @@ import static org.apache.flink.util.concurrent.FutureUtils.assertNoException;
  *       +----> initialize-operator-states()
  *       +----> open-operators()
  *       +----> run()
+ *       +----> finish-operators()
  *       +----> close-operators()
- *       +----> dispose-operators()
  *       +----> common cleanup
  *       +----> task specific cleanup()
  * }</pre>

--- a/flink-streaming-java/src/main/java/org/apache/flink/streaming/runtime/tasks/StreamTask.java
+++ b/flink-streaming-java/src/main/java/org/apache/flink/streaming/runtime/tasks/StreamTask.java
@@ -757,9 +757,8 @@ public abstract class StreamTask<OUT, OP extends StreamOperator<OUT>> extends Ab
 
             List<CompletableFuture<Void>> partitionRecordsProcessedFutures = new ArrayList<>();
             for (ResultPartitionWriter partitionWriter : getEnvironment().getAllWriters()) {
-                partitionWriter.notifyEndOfUserRecords();
-                partitionRecordsProcessedFutures.add(
-                        partitionWriter.getAllRecordsProcessedFuture());
+                partitionWriter.notifyEndOfData();
+                partitionRecordsProcessedFutures.add(partitionWriter.getAllDataProcessedFuture());
             }
             allRecordsProcessedFuture = FutureUtils.waitForAll(partitionRecordsProcessedFutures);
         } else {

--- a/flink-streaming-java/src/main/java/org/apache/flink/streaming/runtime/tasks/StreamTask.java
+++ b/flink-streaming-java/src/main/java/org/apache/flink/streaming/runtime/tasks/StreamTask.java
@@ -90,10 +90,12 @@ import org.apache.flink.streaming.runtime.tasks.mailbox.TaskMailboxImpl;
 import org.apache.flink.util.ExceptionUtils;
 import org.apache.flink.util.FatalExitExceptionHandler;
 import org.apache.flink.util.FlinkException;
+import org.apache.flink.util.FlinkRuntimeException;
 import org.apache.flink.util.InstantiationUtil;
 import org.apache.flink.util.Preconditions;
 import org.apache.flink.util.SerializedValue;
 import org.apache.flink.util.TernaryBoolean;
+import org.apache.flink.util.WrappingRuntimeException;
 import org.apache.flink.util.concurrent.ExecutorThreadFactory;
 import org.apache.flink.util.concurrent.FutureUtils;
 import org.apache.flink.util.function.RunnableWithException;
@@ -258,8 +260,10 @@ public abstract class StreamTask<OUT, OP extends StreamOperator<OUT>> extends Ab
     /** TODO it might be replaced by the global IO executor on TaskManager level future. */
     private final ExecutorService channelIOExecutor;
 
-    private Long syncSavepointId = null;
-    private Long activeSyncSavepointId = null;
+    private Long syncSavepointWithoutDrain = null;
+
+    private Long syncSavepointWithDrain = null;
+    private CompletableFuture<Void> syncSavepointWithDrainCompletionFuture = null;
 
     private long latestReportCheckpointId = -1;
 
@@ -460,7 +464,6 @@ public abstract class StreamTask<OUT, OP extends StreamOperator<OUT>> extends Ab
                 throw new IllegalStateException("We should not receive this event here.");
             case END_OF_DATA:
                 endData();
-
                 return;
             case END_OF_INPUT:
                 // Suspend the mailbox processor, it would be resumed in afterInvoke and finished
@@ -490,6 +493,7 @@ public abstract class StreamTask<OUT, OP extends StreamOperator<OUT>> extends Ab
     }
 
     protected void endData() throws Exception {
+        advanceToEndOfEventTime();
         // finish all operators in a chain effect way
         operatorChain.finishOperators(actionExecutor);
         this.finishedOperators = true;
@@ -501,40 +505,48 @@ public abstract class StreamTask<OUT, OP extends StreamOperator<OUT>> extends Ab
         this.endOfDataReceived = true;
     }
 
-    private void resetSynchronousSavepointId(long id, boolean succeeded) {
-        if (!succeeded && activeSyncSavepointId != null && activeSyncSavepointId == id) {
-            // allow to process further EndOfPartition events
-            activeSyncSavepointId = null;
-            operatorChain.setIgnoreEndOfInput(false);
-        }
-        syncSavepointId = null;
-    }
-
-    private void setSynchronousSavepointId(long checkpointId, boolean ignoreEndOfInput) {
+    protected void setSynchronousSavepoint(long checkpointId, boolean isDrain) {
         checkState(
-                syncSavepointId == null,
+                syncSavepointWithoutDrain == null
+                        && (syncSavepointWithDrain == null
+                                || (isDrain && syncSavepointWithDrain == checkpointId)),
                 "at most one stop-with-savepoint checkpoint at a time is allowed");
-        syncSavepointId = checkpointId;
-        activeSyncSavepointId = checkpointId;
-        operatorChain.setIgnoreEndOfInput(ignoreEndOfInput);
+        if (isDrain) {
+            if (syncSavepointWithDrain == null) {
+                syncSavepointWithDrain = checkpointId;
+                syncSavepointWithDrainCompletionFuture = new CompletableFuture<>();
+            }
+        } else {
+            syncSavepointWithoutDrain = checkpointId;
+        }
     }
 
     @VisibleForTesting
     OptionalLong getSynchronousSavepointId() {
-        return syncSavepointId != null ? OptionalLong.of(syncSavepointId) : OptionalLong.empty();
+        if (syncSavepointWithoutDrain != null) {
+            return OptionalLong.of(syncSavepointWithoutDrain);
+        } else if (syncSavepointWithDrain != null) {
+            return OptionalLong.of(syncSavepointWithDrain);
+        } else {
+            return OptionalLong.empty();
+        }
     }
 
-    private boolean isSynchronousSavepointId(long checkpointId) {
-        return syncSavepointId != null && syncSavepointId == checkpointId;
+    private boolean isCurrentSavepointWithDrain(long checkpointId) {
+        return syncSavepointWithDrain != null && syncSavepointWithDrain == checkpointId;
+    }
+
+    private boolean isCurrentSavepointWithoutDrain(long checkpointId) {
+        return syncSavepointWithoutDrain != null && syncSavepointWithoutDrain == checkpointId;
     }
 
     private void runSynchronousSavepointMailboxLoop() throws Exception {
-        assert syncSavepointId != null;
+        assert syncSavepointWithoutDrain != null;
 
         MailboxExecutor mailboxExecutor =
                 mailboxProcessor.getMailboxExecutor(TaskMailbox.MAX_PRIORITY);
 
-        while (!canceled && syncSavepointId != null) {
+        while (!canceled && syncSavepointWithoutDrain != null) {
             mailboxExecutor.yield();
         }
     }
@@ -765,22 +777,24 @@ public abstract class StreamTask<OUT, OP extends StreamOperator<OUT>> extends Ab
         LOG.debug("Finished task {}", getName());
         getCompletionFuture().exceptionally(unused -> null).join();
 
+        List<CompletableFuture<Void>> terminationConditions = new ArrayList<>();
         // If checkpoints are enabled, waits for all the records get processed by the downstream
         // tasks. During this process, this task could coordinate with its downstream tasks to
         // continue perform checkpoints.
-        CompletableFuture<Void> allRecordsProcessedFuture;
         if (endOfDataReceived && areCheckpointsWithFinishedTasksEnabled()) {
             LOG.debug("Waiting for all the records processed by the downstream tasks.");
 
-            List<CompletableFuture<Void>> partitionRecordsProcessedFutures = new ArrayList<>();
             for (ResultPartitionWriter partitionWriter : getEnvironment().getAllWriters()) {
-                partitionRecordsProcessedFutures.add(partitionWriter.getAllDataProcessedFuture());
+                terminationConditions.add(partitionWriter.getAllDataProcessedFuture());
             }
-            allRecordsProcessedFuture = FutureUtils.waitForAll(partitionRecordsProcessedFutures);
-        } else {
-            allRecordsProcessedFuture = CompletableFuture.completedFuture(null);
         }
-        allRecordsProcessedFuture.thenRun(mailboxProcessor::allActionsCompleted);
+
+        if (syncSavepointWithDrainCompletionFuture != null) {
+            terminationConditions.add(syncSavepointWithDrainCompletionFuture);
+        }
+
+        FutureUtils.waitForAll(terminationConditions)
+                .thenRun(mailboxProcessor::allActionsCompleted);
 
         // Resumes the mailbox processor. The mailbox processor would be completed
         // after all records are processed by the downstream tasks.
@@ -808,7 +822,8 @@ public abstract class StreamTask<OUT, OP extends StreamOperator<OUT>> extends Ab
         // the queued checkpoint requirements could be triggered normally.
         actionExecutor.runThrowing(
                 () -> {
-                    // only set the StreamTask to not running after all operators have been closed!
+                    // only set the StreamTask to not running after all operators have been
+                    // finished!
                     // See FLINK-7430
                     isRunning = false;
                 });
@@ -817,7 +832,7 @@ public abstract class StreamTask<OUT, OP extends StreamOperator<OUT>> extends Ab
         timersFinishedFuture.get();
         systemTimersFinishedFuture.get();
 
-        LOG.debug("Closed operators for task {}", getName());
+        LOG.debug("Finished operators for task {}", getName());
 
         // make sure all buffered data is flushed
         operatorChain.flushOutputs();
@@ -1043,7 +1058,7 @@ public abstract class StreamTask<OUT, OP extends StreamOperator<OUT>> extends Ab
     // ------------------------------------------------------------------------
 
     @Override
-    public Future<Boolean> triggerCheckpointAsync(
+    public CompletableFuture<Boolean> triggerCheckpointAsync(
             CheckpointMetaData checkpointMetaData, CheckpointOptions checkpointOptions) {
 
         CompletableFuture<Boolean> result = new CompletableFuture<>();
@@ -1151,6 +1166,28 @@ public abstract class StreamTask<OUT, OP extends StreamOperator<OUT>> extends Ab
         return true;
     }
 
+    protected final CompletableFuture<Boolean> assertTriggeringCheckpointExceptions(
+            CompletableFuture<Boolean> triggerFuture, long checkpointId) {
+        CompletableFuture<Boolean> checkpointTriggered =
+                triggerFuture.exceptionally(
+                        error -> {
+                            if (error instanceof RejectedExecutionException) {
+                                // This may happen if the mailbox is closed. It means that
+                                // the task is shutting
+                                // down, so we just ignore it.
+                                LOG.debug(
+                                        "Triggering checkpoint {} for {} was rejected by the mailbox",
+                                        checkpointId,
+                                        getTaskNameWithSubtaskAndId());
+                            } else {
+                                throw new WrappingRuntimeException(error);
+                            }
+                            return null;
+                        });
+        FutureUtils.assertNoException(checkpointTriggered);
+        return checkpointTriggered;
+    }
+
     /**
      * Acquires the optional {@link CheckpointBarrierHandler} associated with this stream task. The
      * {@code CheckpointBarrierHandler} should exist if the task has data inputs and requires to
@@ -1170,7 +1207,7 @@ public abstract class StreamTask<OUT, OP extends StreamOperator<OUT>> extends Ab
         FlinkSecurityManager.monitorUserSystemExitForCurrentThread();
         try {
             if (performCheckpoint(checkpointMetaData, checkpointOptions, checkpointMetrics)) {
-                if (isSynchronousSavepointId(checkpointMetaData.getCheckpointId())) {
+                if (isCurrentSavepointWithoutDrain(checkpointMetaData.getCheckpointId())) {
                     runSynchronousSavepointMailboxLoop();
                 }
             }
@@ -1196,7 +1233,11 @@ public abstract class StreamTask<OUT, OP extends StreamOperator<OUT>> extends Ab
     @Override
     public void abortCheckpointOnBarrier(long checkpointId, CheckpointException cause)
             throws IOException {
-        resetSynchronousSavepointId(checkpointId, false);
+        if (isCurrentSavepointWithoutDrain(checkpointId)) {
+            syncSavepointWithoutDrain = null;
+        } else if (isCurrentSavepointWithDrain(checkpointId)) {
+            throw new FlinkRuntimeException("Stop-with-savepoint --drain failed.");
+        }
         subtaskCheckpointCoordinator.abortCheckpointOnBarrier(checkpointId, cause, operatorChain);
     }
 
@@ -1216,17 +1257,9 @@ public abstract class StreamTask<OUT, OP extends StreamOperator<OUT>> extends Ab
             actionExecutor.runThrowing(
                     () -> {
                         if (checkpointOptions.getCheckpointType().isSynchronous()) {
-                            setSynchronousSavepointId(
+                            setSynchronousSavepoint(
                                     checkpointMetaData.getCheckpointId(),
-                                    checkpointOptions.getCheckpointType().shouldIgnoreEndOfInput());
-
-                            if (checkpointOptions.getCheckpointType().shouldAdvanceToEndOfTime()) {
-                                advanceToEndOfEventTime();
-                            }
-                        } else if (activeSyncSavepointId != null
-                                && activeSyncSavepointId < checkpointMetaData.getCheckpointId()) {
-                            activeSyncSavepointId = null;
-                            operatorChain.setIgnoreEndOfInput(false);
+                                    checkpointOptions.getCheckpointType().shouldDrain());
                         }
 
                         subtaskCheckpointCoordinator.checkpointState(
@@ -1287,7 +1320,11 @@ public abstract class StreamTask<OUT, OP extends StreamOperator<OUT>> extends Ab
                         notifyCheckpointComplete(latestCompletedCheckpointId);
                     }
 
-                    resetSynchronousSavepointId(checkpointId, false);
+                    if (isCurrentSavepointWithoutDrain(checkpointId)) {
+                        syncSavepointWithoutDrain = null;
+                    } else if (isCurrentSavepointWithDrain(checkpointId)) {
+                        throw new FlinkRuntimeException("Stop-with-savepoint --drain failed.");
+                    }
                     subtaskCheckpointCoordinator.notifyCheckpointAborted(
                             checkpointId, operatorChain, this::isRunning);
                 },
@@ -1322,10 +1359,14 @@ public abstract class StreamTask<OUT, OP extends StreamOperator<OUT>> extends Ab
 
         subtaskCheckpointCoordinator.notifyCheckpointComplete(
                 checkpointId, operatorChain, this::isRunning);
-        if (isRunning && isSynchronousSavepointId(checkpointId)) {
-            finishTask();
-            // Reset to "notify" the internal synchronous savepoint mailbox loop.
-            resetSynchronousSavepointId(checkpointId, true);
+        if (isRunning) {
+            if (isCurrentSavepointWithoutDrain(checkpointId)) {
+                finishTask();
+                // Reset to "notify" the internal synchronous savepoint mailbox loop.
+                syncSavepointWithoutDrain = null;
+            } else if (isCurrentSavepointWithDrain(checkpointId)) {
+                syncSavepointWithDrainCompletionFuture.complete(null);
+            }
         }
     }
 

--- a/flink-streaming-java/src/main/java/org/apache/flink/streaming/runtime/tasks/StreamTaskFinishedOnRestoreSourceInput.java
+++ b/flink-streaming-java/src/main/java/org/apache/flink/streaming/runtime/tasks/StreamTaskFinishedOnRestoreSourceInput.java
@@ -30,6 +30,8 @@ import java.util.concurrent.CompletableFuture;
  */
 public class StreamTaskFinishedOnRestoreSourceInput<T> extends StreamTaskSourceInput<T> {
 
+    private boolean emittedEndOfData = false;
+
     public StreamTaskFinishedOnRestoreSourceInput(
             SourceOperator<T, ?> operator, int inputGateIndex, int inputIndex) {
         super(operator, inputGateIndex, inputIndex);
@@ -37,7 +39,12 @@ public class StreamTaskFinishedOnRestoreSourceInput<T> extends StreamTaskSourceI
 
     @Override
     public DataInputStatus emitNext(DataOutput<T> output) throws Exception {
-        return DataInputStatus.END_OF_INPUT;
+        if (emittedEndOfData) {
+            return DataInputStatus.END_OF_INPUT;
+        } else {
+            emittedEndOfData = true;
+            return DataInputStatus.END_OF_DATA;
+        }
     }
 
     @Override

--- a/flink-streaming-java/src/test/java/org/apache/flink/streaming/api/operators/SourceOperatorTest.java
+++ b/flink-streaming-java/src/test/java/org/apache/flink/streaming/api/operators/SourceOperatorTest.java
@@ -42,7 +42,9 @@ import org.apache.flink.runtime.state.StateInitializationContextImpl;
 import org.apache.flink.runtime.state.StateSnapshotContextSynchronousImpl;
 import org.apache.flink.runtime.state.TestTaskStateManager;
 import org.apache.flink.runtime.state.memory.MemoryStateBackend;
+import org.apache.flink.streaming.api.operators.source.CollectingDataOutput;
 import org.apache.flink.streaming.api.operators.source.TestingSourceOperator;
+import org.apache.flink.streaming.runtime.io.DataInputStatus;
 import org.apache.flink.streaming.runtime.tasks.SourceOperatorStreamTask;
 import org.apache.flink.streaming.runtime.tasks.StreamMockEnvironment;
 import org.apache.flink.streaming.util.MockOutput;
@@ -57,8 +59,10 @@ import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.Collections;
 import java.util.List;
+import java.util.concurrent.CompletableFuture;
 
 import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertFalse;
 import static org.junit.Assert.assertNotNull;
 import static org.junit.Assert.assertTrue;
 
@@ -125,6 +129,26 @@ public class SourceOperatorTest {
         OperatorEvent operatorEvent = mockGateway.getEventsSent().get(0);
         assertTrue(operatorEvent instanceof ReaderRegistrationEvent);
         assertEquals(SUBTASK_INDEX, ((ReaderRegistrationEvent) operatorEvent).subtaskId());
+    }
+
+    @Test
+    public void testStop() throws Exception {
+        // Initialize the operator.
+        operator.initializeState(getStateContext());
+        // Open the operator.
+        operator.open();
+        // The source reader should have been assigned a split.
+        assertEquals(Collections.singletonList(MOCK_SPLIT), mockSourceReader.getAssignedSplits());
+
+        CollectingDataOutput<Integer> dataOutput = new CollectingDataOutput<>();
+        assertEquals(DataInputStatus.NOTHING_AVAILABLE, operator.emitNext(dataOutput));
+        assertFalse(operator.isAvailable());
+
+        CompletableFuture<Void> sourceStopped = operator.stop();
+        assertTrue(operator.isAvailable());
+        assertFalse(sourceStopped.isDone());
+        assertEquals(DataInputStatus.END_OF_DATA, operator.emitNext(dataOutput));
+        assertTrue(sourceStopped.isDone());
     }
 
     @Test

--- a/flink-streaming-java/src/test/java/org/apache/flink/streaming/api/operators/collect/CollectResultBufferTest.java
+++ b/flink-streaming-java/src/test/java/org/apache/flink/streaming/api/operators/collect/CollectResultBufferTest.java
@@ -159,8 +159,27 @@ public class CollectResultBufferTest {
             Assert.assertEquals(expectedValue, buffer.next());
         }
 
+        // send some uncommitted data
+        response =
+                new CollectCoordinationResponse(
+                        version, 6, createSerializedResults(Arrays.asList(8, 9, 10)));
+        buffer.dealWithResponse(response, 7);
+        // send some committed data, but less than uncommitted data we've already sent
+        expected = Arrays.asList(7);
+        response =
+                new CollectCoordinationResponse(
+                        version, 7, createSerializedResults(Arrays.asList(8, 9)));
+        buffer.dealWithResponse(response, 7);
+        // results before checkpoint can be seen now
+        for (Integer expectedValue : expected) {
+            Assert.assertEquals(expectedValue, buffer.next());
+        }
+
         buffer.complete();
-        Assert.assertEquals((Integer) 7, buffer.next());
+        expected = Arrays.asList(8, 9, 10);
+        for (Integer expectedValue : expected) {
+            Assert.assertEquals(expectedValue, buffer.next());
+        }
         Assert.assertNull(buffer.next());
     }
 

--- a/flink-streaming-java/src/test/java/org/apache/flink/streaming/api/operators/sort/CollectionDataInput.java
+++ b/flink-streaming-java/src/test/java/org/apache/flink/streaming/api/operators/sort/CollectionDataInput.java
@@ -34,6 +34,7 @@ import java.util.concurrent.CompletableFuture;
 final class CollectionDataInput<E> implements StreamTaskInput<E> {
     private final Iterator<StreamElement> elementsIterator;
     private final int inputIdx;
+    private boolean endOfInput = false;
 
     CollectionDataInput(Collection<StreamElement> elements) {
         this(elements, 0);
@@ -56,9 +57,14 @@ final class CollectionDataInput<E> implements StreamTaskInput<E> {
                 throw new IllegalStateException("Unsupported element type: " + streamElement);
             }
         }
-        return elementsIterator.hasNext()
-                ? DataInputStatus.MORE_AVAILABLE
-                : DataInputStatus.END_OF_INPUT;
+        if (elementsIterator.hasNext()) {
+            return DataInputStatus.MORE_AVAILABLE;
+        } else if (endOfInput) {
+            return DataInputStatus.END_OF_INPUT;
+        } else {
+            endOfInput = true;
+            return DataInputStatus.END_OF_DATA;
+        }
     }
 
     @Override

--- a/flink-streaming-java/src/test/java/org/apache/flink/streaming/api/operators/sort/LargeSortingDataInputITCase.java
+++ b/flink-streaming-java/src/test/java/org/apache/flink/streaming/api/operators/sort/LargeSortingDataInputITCase.java
@@ -252,15 +252,18 @@ public class LargeSortingDataInputITCase {
         @Override
         public DataInputStatus emitNext(DataOutput<Tuple3<Integer, String, byte[]>> output)
                 throws Exception {
-            if (recordsGenerated >= numberOfRecords) {
+            if (recordsGenerated == numberOfRecords) {
+                recordsGenerated++;
+                return DataInputStatus.END_OF_DATA;
+            } else if (recordsGenerated > numberOfRecords) {
                 return DataInputStatus.END_OF_INPUT;
             }
 
             output.emitRecord(
                     new StreamRecord<>(
                             Tuple3.of(rnd.nextInt(), randomString(rnd.nextInt(256)), buffer), 1));
-            if (recordsGenerated++ >= numberOfRecords) {
-                return DataInputStatus.END_OF_INPUT;
+            if (recordsGenerated++ == numberOfRecords) {
+                return DataInputStatus.END_OF_DATA;
             } else {
                 return DataInputStatus.MORE_AVAILABLE;
             }

--- a/flink-streaming-java/src/test/java/org/apache/flink/streaming/api/operators/source/CollectingDataOutput.java
+++ b/flink-streaming-java/src/test/java/org/apache/flink/streaming/api/operators/source/CollectingDataOutput.java
@@ -31,7 +31,7 @@ import java.util.List;
  * A test utility implementation of {@link PushingAsyncDataInput.DataOutput} that collects all
  * events.
  */
-final class CollectingDataOutput<E> implements PushingAsyncDataInput.DataOutput<E> {
+public final class CollectingDataOutput<E> implements PushingAsyncDataInput.DataOutput<E> {
 
     final List<Object> events = new ArrayList<>();
 

--- a/flink-streaming-java/src/test/java/org/apache/flink/streaming/runtime/io/MockIndexedInputGate.java
+++ b/flink-streaming-java/src/test/java/org/apache/flink/streaming/runtime/io/MockIndexedInputGate.java
@@ -96,6 +96,11 @@ public class MockIndexedInputGate extends IndexedInputGate {
     }
 
     @Override
+    public boolean hasReceivedEndOfData() {
+        return false;
+    }
+
+    @Override
     public Optional<BufferOrEvent> getNext() {
         throw new UnsupportedOperationException();
     }

--- a/flink-streaming-java/src/test/java/org/apache/flink/streaming/runtime/io/MockInputGate.java
+++ b/flink-streaming-java/src/test/java/org/apache/flink/streaming/runtime/io/MockInputGate.java
@@ -114,6 +114,11 @@ public class MockInputGate extends IndexedInputGate {
     }
 
     @Override
+    public boolean hasReceivedEndOfData() {
+        throw new UnsupportedOperationException("Not implemented yet");
+    }
+
+    @Override
     public Optional<BufferOrEvent> getNext() {
         BufferOrEvent next = bufferOrEvents.poll();
         if (!finishAfterLastBuffer && bufferOrEvents.isEmpty()) {

--- a/flink-streaming-java/src/test/java/org/apache/flink/streaming/runtime/io/checkpointing/AlignedCheckpointsMassiveRandomTest.java
+++ b/flink-streaming-java/src/test/java/org/apache/flink/streaming/runtime/io/checkpointing/AlignedCheckpointsMassiveRandomTest.java
@@ -168,6 +168,11 @@ public class AlignedCheckpointsMassiveRandomTest {
         }
 
         @Override
+        public boolean hasReceivedEndOfData() {
+            return false;
+        }
+
+        @Override
         public InputChannel getChannel(int channelIndex) {
             throw new UnsupportedOperationException();
         }

--- a/flink-streaming-java/src/test/java/org/apache/flink/streaming/runtime/operators/StreamSourceOperatorLatencyMetricsTest.java
+++ b/flink-streaming-java/src/test/java/org/apache/flink/streaming/runtime/operators/StreamSourceOperatorLatencyMetricsTest.java
@@ -195,15 +195,13 @@ public class StreamSourceOperatorLatencyMetricsTest extends TestLogger {
             operatorChain.close();
         }
 
-        assertEquals(
-                numberLatencyMarkers + 1, // + 1 is the final watermark element
-                output.size());
+        assertEquals(numberLatencyMarkers, output.size());
 
         long timestamp = 0L;
         int expectedLatencyIndex = 0;
 
         int i = 0;
-        // verify that its only latency markers + a final watermark
+        // verify that its only latency markers
         for (; i < numberLatencyMarkers; i++) {
             StreamElement se = output.get(i);
             Assert.assertTrue(se.isLatencyMarker());
@@ -222,8 +220,6 @@ public class StreamSourceOperatorLatencyMetricsTest extends TestLogger {
 
             timestamp += latencyMarkInterval;
         }
-
-        Assert.assertTrue(output.get(i).isWatermark());
     }
 
     // ------------------------------------------------------------------------

--- a/flink-streaming-java/src/test/java/org/apache/flink/streaming/runtime/tasks/MultipleInputStreamTaskChainedSourcesCheckpointingTest.java
+++ b/flink-streaming-java/src/test/java/org/apache/flink/streaming/runtime/tasks/MultipleInputStreamTaskChainedSourcesCheckpointingTest.java
@@ -334,7 +334,7 @@ public class MultipleInputStreamTaskChainedSourcesCheckpointingTest {
                         .thenAccept(
                                 (ignored) -> {
                                     for (ResultPartition resultPartition : partitionWriters) {
-                                        resultPartition.onSubpartitionAllRecordsProcessed(0);
+                                        resultPartition.onSubpartitionAllDataProcessed(0);
                                     }
                                 });
 

--- a/flink-streaming-java/src/test/java/org/apache/flink/streaming/runtime/tasks/MultipleInputStreamTaskTest.java
+++ b/flink-streaming-java/src/test/java/org/apache/flink/streaming/runtime/tasks/MultipleInputStreamTaskTest.java
@@ -967,7 +967,7 @@ public class MultipleInputStreamTaskTest {
                         .thenAccept(
                                 (ignored) -> {
                                     for (ResultPartition resultPartition : partitionWriters) {
-                                        resultPartition.onSubpartitionAllRecordsProcessed(0);
+                                        resultPartition.onSubpartitionAllDataProcessed(0);
                                     }
                                 });
 

--- a/flink-streaming-java/src/test/java/org/apache/flink/streaming/runtime/tasks/MultipleInputStreamTaskTest.java
+++ b/flink-streaming-java/src/test/java/org/apache/flink/streaming/runtime/tasks/MultipleInputStreamTaskTest.java
@@ -43,6 +43,7 @@ import org.apache.flink.metrics.Metric;
 import org.apache.flink.runtime.checkpoint.CheckpointOptions;
 import org.apache.flink.runtime.io.network.api.CancelCheckpointMarker;
 import org.apache.flink.runtime.io.network.api.CheckpointBarrier;
+import org.apache.flink.runtime.io.network.api.EndOfData;
 import org.apache.flink.runtime.io.network.api.EndOfPartitionEvent;
 import org.apache.flink.runtime.io.network.api.writer.ResultPartitionWriter;
 import org.apache.flink.runtime.io.network.partition.PartitionTestUtils;
@@ -846,8 +847,8 @@ public class MultipleInputStreamTaskTest {
 
             finishAddingRecords(testHarness, 1);
             testHarness.endInput();
-            testHarness.finishProcessing();
             testHarness.waitForTaskCompletion();
+            testHarness.finishProcessing();
         }
     }
 
@@ -948,12 +949,15 @@ public class MultipleInputStreamTaskTest {
                 assertEquals(2, testHarness.getTaskStateManager().getReportedCheckpointId());
 
                 // Tests triggering checkpoint after some inputs have received EndOfPartition.
+                testHarness.processEvent(EndOfData.INSTANCE, 0, 0);
                 testHarness.processEvent(EndOfPartitionEvent.INSTANCE, 0, 0);
                 checkpointFuture = triggerCheckpoint(testHarness, 4);
                 processMailTillCheckpointSucceeds(testHarness, checkpointFuture);
                 assertEquals(4, testHarness.getTaskStateManager().getReportedCheckpointId());
 
                 // Tests triggering checkpoint after all the inputs have received EndOfPartition.
+                testHarness.processEvent(EndOfData.INSTANCE, 1, 0);
+                testHarness.processEvent(EndOfData.INSTANCE, 2, 0);
                 testHarness.processEvent(EndOfPartitionEvent.INSTANCE, 1, 0);
                 testHarness.processEvent(EndOfPartitionEvent.INSTANCE, 2, 0);
                 checkpointFuture = triggerCheckpoint(testHarness, 6);

--- a/flink-streaming-java/src/test/java/org/apache/flink/streaming/runtime/tasks/SourceOperatorStreamTaskTest.java
+++ b/flink-streaming-java/src/test/java/org/apache/flink/streaming/runtime/tasks/SourceOperatorStreamTaskTest.java
@@ -394,10 +394,11 @@ public class SourceOperatorStreamTaskTest extends SourceStreamTaskTestBase {
 
         @Override
         public InputStatus pollNext(ReaderOutput<Integer> output) throws Exception {
-            numEmittedEvents++;
-            if (numEmittedEvents == numEventsBeforeCheckpoint) {
+            if (numEmittedEvents == numEventsBeforeCheckpoint - 1) {
+                numEmittedEvents++;
                 return InputStatus.NOTHING_AVAILABLE;
             } else if (numEmittedEvents < totalNumEvents) {
+                numEmittedEvents++;
                 return InputStatus.MORE_AVAILABLE;
             } else {
                 return InputStatus.END_OF_INPUT;

--- a/flink-streaming-java/src/test/java/org/apache/flink/streaming/runtime/tasks/SourceStreamTaskTest.java
+++ b/flink-streaming-java/src/test/java/org/apache/flink/streaming/runtime/tasks/SourceStreamTaskTest.java
@@ -638,7 +638,7 @@ public class SourceStreamTaskTest extends SourceStreamTaskTestBase {
                         .thenAccept(
                                 (ignored) -> {
                                     for (ResultPartition resultPartition : partitionWriters) {
-                                        resultPartition.onSubpartitionAllRecordsProcessed(0);
+                                        resultPartition.onSubpartitionAllDataProcessed(0);
                                     }
                                 });
 

--- a/flink-streaming-java/src/test/java/org/apache/flink/streaming/runtime/tasks/SourceStreamTaskTest.java
+++ b/flink-streaming-java/src/test/java/org/apache/flink/streaming/runtime/tasks/SourceStreamTaskTest.java
@@ -19,8 +19,10 @@
 package org.apache.flink.streaming.runtime.tasks;
 
 import org.apache.flink.api.common.ExecutionConfig;
+import org.apache.flink.api.common.JobID;
 import org.apache.flink.api.common.typeinfo.BasicTypeInfo;
 import org.apache.flink.api.common.typeutils.TypeSerializer;
+import org.apache.flink.api.common.typeutils.base.IntSerializer;
 import org.apache.flink.api.common.typeutils.base.StringSerializer;
 import org.apache.flink.api.java.tuple.Tuple2;
 import org.apache.flink.api.java.typeutils.TupleTypeInfo;
@@ -28,17 +30,22 @@ import org.apache.flink.configuration.Configuration;
 import org.apache.flink.core.testutils.MultiShotLatch;
 import org.apache.flink.core.testutils.OneShotLatch;
 import org.apache.flink.runtime.checkpoint.CheckpointMetaData;
+import org.apache.flink.runtime.checkpoint.CheckpointMetrics;
 import org.apache.flink.runtime.checkpoint.CheckpointOptions;
 import org.apache.flink.runtime.checkpoint.TaskStateSnapshot;
 import org.apache.flink.runtime.execution.CancelTaskException;
+import org.apache.flink.runtime.executiongraph.ExecutionAttemptID;
 import org.apache.flink.runtime.io.network.NettyShuffleEnvironment;
 import org.apache.flink.runtime.io.network.NettyShuffleEnvironmentBuilder;
+import org.apache.flink.runtime.io.network.api.EndOfData;
+import org.apache.flink.runtime.io.network.api.writer.RecordOrEventCollectingResultPartitionWriter;
 import org.apache.flink.runtime.io.network.api.writer.ResultPartitionWriter;
 import org.apache.flink.runtime.io.network.partition.PartitionTestUtils;
 import org.apache.flink.runtime.io.network.partition.ResultPartition;
 import org.apache.flink.runtime.io.network.partition.ResultPartitionType;
 import org.apache.flink.runtime.jobgraph.OperatorID;
 import org.apache.flink.runtime.operators.testutils.ExpectedTestException;
+import org.apache.flink.runtime.taskmanager.TestCheckpointResponder;
 import org.apache.flink.streaming.api.TimeCharacteristic;
 import org.apache.flink.streaming.api.checkpoint.ListCheckpointed;
 import org.apache.flink.streaming.api.environment.ExecutionCheckpointingOptions;
@@ -50,6 +57,9 @@ import org.apache.flink.streaming.api.graph.StreamConfig;
 import org.apache.flink.streaming.api.operators.BoundedOneInput;
 import org.apache.flink.streaming.api.operators.SimpleOperatorFactory;
 import org.apache.flink.streaming.api.operators.StreamSource;
+import org.apache.flink.streaming.api.watermark.Watermark;
+import org.apache.flink.streaming.runtime.streamrecord.StreamElement;
+import org.apache.flink.streaming.runtime.streamrecord.StreamElementSerializer;
 import org.apache.flink.streaming.runtime.streamrecord.StreamRecord;
 import org.apache.flink.streaming.runtime.tasks.LifeCycleMonitor.LifeCyclePhase;
 import org.apache.flink.streaming.util.TestHarnessUtil;
@@ -87,6 +97,8 @@ import static org.apache.flink.runtime.state.CheckpointStorageLocationReference.
 import static org.apache.flink.streaming.runtime.tasks.StreamTaskFinalCheckpointsTest.triggerCheckpoint;
 import static org.apache.flink.util.Preconditions.checkState;
 import static org.hamcrest.CoreMatchers.is;
+import static org.hamcrest.MatcherAssert.assertThat;
+import static org.hamcrest.Matchers.contains;
 import static org.junit.Assert.assertArrayEquals;
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertFalse;
@@ -266,11 +278,12 @@ public class SourceStreamTaskTest extends SourceStreamTaskTestBase {
         testHarness.invoke();
         testHarness.waitForTaskCompletion();
 
-        ArrayList<StreamRecord<String>> expected = new ArrayList<>();
+        ArrayList<StreamElement> expected = new ArrayList<>();
         Collections.addAll(
                 expected,
                 new StreamRecord<>("Hello"),
                 new StreamRecord<>("[Source0]: End of input"),
+                Watermark.MAX_WATERMARK,
                 new StreamRecord<>("[Source0]: Finish"),
                 new StreamRecord<>("[Operator1]: End of input"),
                 new StreamRecord<>("[Operator1]: Finish"),
@@ -608,6 +621,7 @@ public class SourceStreamTaskTest extends SourceStreamTaskTestBase {
                 partitionWriters[i].setup();
             }
 
+            final CompletableFuture<Long> checkpointCompleted = new CompletableFuture<>();
             try (StreamTaskMailboxTestHarness<String> testHarness =
                     new StreamTaskMailboxTestHarnessBuilder<>(
                                     SourceStreamTask::new, BasicTypeInfo.STRING_TYPE_INFO)
@@ -620,13 +634,35 @@ public class SourceStreamTaskTest extends SourceStreamTaskTestBase {
                                                                 .ENABLE_CHECKPOINTS_AFTER_TASKS_FINISH,
                                                         true);
                                     })
+                            .setCheckpointResponder(
+                                    new TestCheckpointResponder() {
+                                        @Override
+                                        public void acknowledgeCheckpoint(
+                                                JobID jobID,
+                                                ExecutionAttemptID executionAttemptID,
+                                                long checkpointId,
+                                                CheckpointMetrics checkpointMetrics,
+                                                TaskStateSnapshot subtaskState) {
+                                            super.acknowledgeCheckpoint(
+                                                    jobID,
+                                                    executionAttemptID,
+                                                    checkpointId,
+                                                    checkpointMetrics,
+                                                    subtaskState);
+                                            checkpointCompleted.complete(checkpointId);
+                                        }
+                                    })
                             .addAdditionalOutput(partitionWriters)
                             .setupOperatorChain(new StreamSource<>(new MockSource(0, 0, 1)))
                             .finishForSingletonOperatorChain(StringSerializer.INSTANCE)
                             .build()) {
 
                 testHarness.processAll();
-                testHarness.getStreamTask().getCompletionFuture().get();
+                CompletableFuture<Void> taskFinished =
+                        testHarness.getStreamTask().getCompletionFuture();
+                do {
+                    testHarness.processAll();
+                } while (!taskFinished.isDone());
 
                 Future<Boolean> checkpointFuture = triggerCheckpoint(testHarness, 2);
                 // Notifies the result partition that all records are processed after the
@@ -642,6 +678,9 @@ public class SourceStreamTaskTest extends SourceStreamTaskTestBase {
                                     }
                                 });
 
+                checkpointCompleted.whenComplete(
+                        (id, error) ->
+                                testHarness.getStreamTask().notifyCheckpointCompleteAsync(2));
                 testHarness.finishProcessing();
                 assertTrue(checkpointFuture.isDone());
 
@@ -663,13 +702,26 @@ public class SourceStreamTaskTest extends SourceStreamTaskTestBase {
     @Test
     public void testClosedOnRestoreSourceSkipExecution() throws Exception {
         LifeCycleMonitorSource testSource = new LifeCycleMonitorSource();
+        List<Object> output = new ArrayList<>();
         try (StreamTaskMailboxTestHarness<String> harness =
                 new StreamTaskMailboxTestHarnessBuilder<>(SourceStreamTask::new, STRING_TYPE_INFO)
                         .setTaskStateSnapshot(1, TaskStateSnapshot.FINISHED_ON_RESTORE)
+                        .addAdditionalOutput(
+                                new RecordOrEventCollectingResultPartitionWriter<StreamElement>(
+                                        output,
+                                        new StreamElementSerializer<>(IntSerializer.INSTANCE)) {
+                                    @Override
+                                    public void notifyEndOfData() throws IOException {
+                                        broadcastEvent(EndOfData.INSTANCE, false);
+                                    }
+                                })
                         .setupOutputForSingletonOperatorChain(new StreamSource<>(testSource))
                         .build()) {
             harness.getStreamTask().invoke();
-            harness.waitForTaskCompletion();
+            harness.processAll();
+            harness.streamTask.getCompletionFuture().get();
+
+            assertThat(output, contains(Watermark.MAX_WATERMARK, EndOfData.INSTANCE));
 
             LifeCycleMonitorSource source =
                     (LifeCycleMonitorSource)

--- a/flink-streaming-java/src/test/java/org/apache/flink/streaming/runtime/tasks/SourceTaskTerminationTest.java
+++ b/flink-streaming-java/src/test/java/org/apache/flink/streaming/runtime/tasks/SourceTaskTerminationTest.java
@@ -119,7 +119,9 @@ public class SourceTaskTerminationTest extends TestLogger {
         assertTrue(srcTask.getSynchronousSavepointId().isPresent());
 
         srcTask.notifyCheckpointCompleteAsync(syncSavepointId).get();
-        assertFalse(srcTask.getSynchronousSavepointId().isPresent());
+        if (!shouldTerminate) {
+            assertFalse(srcTask.getSynchronousSavepointId().isPresent());
+        }
 
         executionThread.join();
     }
@@ -192,8 +194,10 @@ public class SourceTaskTerminationTest extends TestLogger {
 
             while (isRunning) {
                 runLoopStart.await();
-                ctx.emitWatermark(new Watermark(element));
-                ctx.collect(element++);
+                if (isRunning) {
+                    ctx.emitWatermark(new Watermark(element));
+                    ctx.collect(element++);
+                }
                 runLoopEnd.trigger();
             }
         }

--- a/flink-streaming-java/src/test/java/org/apache/flink/streaming/runtime/tasks/StreamOperatorWrapperTest.java
+++ b/flink-streaming-java/src/test/java/org/apache/flink/streaming/runtime/tasks/StreamOperatorWrapperTest.java
@@ -133,7 +133,7 @@ public class StreamOperatorWrapperTest extends TestLogger {
     @Test
     public void testFinish() throws Exception {
         output.clear();
-        operatorWrappers.get(0).finish(containingTask.getActionExecutor(), false);
+        operatorWrappers.get(0).finish(containingTask.getActionExecutor());
 
         List<Object> expected = new ArrayList<>();
         for (int i = 0; i < operatorWrappers.size(); i++) {
@@ -172,7 +172,7 @@ public class StreamOperatorWrapperTest extends TestLogger {
                         true);
 
         try {
-            operatorWrapper.finish(containingTask.getActionExecutor(), false);
+            operatorWrapper.finish(containingTask.getActionExecutor());
             fail("should throw an exception");
         } catch (Throwable t) {
             Optional<Throwable> optional =

--- a/flink-streaming-java/src/test/java/org/apache/flink/streaming/runtime/tasks/StreamTaskFinalCheckpointsTest.java
+++ b/flink-streaming-java/src/test/java/org/apache/flink/streaming/runtime/tasks/StreamTaskFinalCheckpointsTest.java
@@ -181,7 +181,7 @@ public class StreamTaskFinalCheckpointsTest {
                         .thenAccept(
                                 (ignored) -> {
                                     for (ResultPartition resultPartition : partitionWriters) {
-                                        resultPartition.onSubpartitionAllRecordsProcessed(0);
+                                        resultPartition.onSubpartitionAllDataProcessed(0);
                                     }
                                 });
 
@@ -257,7 +257,7 @@ public class StreamTaskFinalCheckpointsTest {
                         .thenAccept(
                                 (ignored) -> {
                                     for (ResultPartition resultPartition : partitionWriters) {
-                                        resultPartition.onSubpartitionAllRecordsProcessed(0);
+                                        resultPartition.onSubpartitionAllDataProcessed(0);
                                     }
                                 });
                 testHarness.finishProcessing();

--- a/flink-streaming-java/src/test/java/org/apache/flink/streaming/runtime/tasks/StreamTaskMailboxTestHarness.java
+++ b/flink-streaming-java/src/test/java/org/apache/flink/streaming/runtime/tasks/StreamTaskMailboxTestHarness.java
@@ -133,14 +133,18 @@ public class StreamTaskMailboxTestHarness<OUT> implements AutoCloseable {
     }
 
     public void endInput() {
+        endInput(true);
+    }
+
+    public void endInput(boolean allDataProcessed) {
         for (int i = 0; i < inputGates.length; i++) {
-            endInput(i);
+            endInput(i, allDataProcessed);
         }
     }
 
-    public void endInput(int inputIndex) {
+    public void endInput(int inputIndex, boolean emitEndOfData) {
         if (!inputGateEnded[inputIndex]) {
-            inputGates[inputIndex].endInput();
+            inputGates[inputIndex].endInput(emitEndOfData);
             inputGateEnded[inputIndex] = true;
         }
     }

--- a/flink-streaming-java/src/test/java/org/apache/flink/streaming/runtime/tasks/StreamTaskTestHarness.java
+++ b/flink-streaming-java/src/test/java/org/apache/flink/streaming/runtime/tasks/StreamTaskTestHarness.java
@@ -31,6 +31,7 @@ import org.apache.flink.runtime.event.AbstractEvent;
 import org.apache.flink.runtime.execution.CancelTaskException;
 import org.apache.flink.runtime.execution.Environment;
 import org.apache.flink.runtime.executiongraph.ExecutionAttemptID;
+import org.apache.flink.runtime.io.network.api.EndOfData;
 import org.apache.flink.runtime.io.network.api.EndOfPartitionEvent;
 import org.apache.flink.runtime.io.network.partition.consumer.StreamTestSingleInputGate;
 import org.apache.flink.runtime.jobgraph.JobVertexID;
@@ -462,6 +463,13 @@ public class StreamTaskTestHarness<OUT> {
      * arrive.
      */
     public void endInput(int gateIndex, int channelIndex) {
+        endInput(gateIndex, channelIndex, true);
+    }
+
+    public void endInput(int gateIndex, int channelIndex, boolean emitEndOfData) {
+        if (emitEndOfData) {
+            inputGates[gateIndex].sendEvent(EndOfData.INSTANCE, channelIndex);
+        }
         inputGates[gateIndex].sendEvent(EndOfPartitionEvent.INSTANCE, channelIndex);
     }
 

--- a/flink-streaming-java/src/test/java/org/apache/flink/streaming/runtime/tasks/SynchronousCheckpointITCase.java
+++ b/flink-streaming-java/src/test/java/org/apache/flink/streaming/runtime/tasks/SynchronousCheckpointITCase.java
@@ -153,11 +153,11 @@ public class SynchronousCheckpointITCase {
         }
 
         @Override
-        public Future<Boolean> triggerCheckpointAsync(
+        public CompletableFuture<Boolean> triggerCheckpointAsync(
                 CheckpointMetaData checkpointMetaData, CheckpointOptions checkpointOptions) {
             try {
                 eventQueue.put(Event.PRE_TRIGGER_CHECKPOINT);
-                Future<Boolean> result =
+                CompletableFuture<Boolean> result =
                         super.triggerCheckpointAsync(checkpointMetaData, checkpointOptions);
                 eventQueue.put(Event.POST_TRIGGER_CHECKPOINT);
                 return result;

--- a/flink-tests/src/test/java/org/apache/flink/runtime/jobmaster/JobMasterStopWithSavepointITCase.java
+++ b/flink-tests/src/test/java/org/apache/flink/runtime/jobmaster/JobMasterStopWithSavepointITCase.java
@@ -105,12 +105,6 @@ public class JobMasterStopWithSavepointITCase extends AbstractTestBase {
         stopWithSavepointNormalExecutionHelper(false);
     }
 
-    @Test
-    public void terminateWithSavepointWithoutComplicationsShouldSucceedAndLeadJobToFinished()
-            throws Exception {
-        stopWithSavepointNormalExecutionHelper(true);
-    }
-
     private void stopWithSavepointNormalExecutionHelper(final boolean terminate) throws Exception {
         setUpJobGraph(NoOpBlockingStreamTask.class, RestartStrategies.noRestart());
 
@@ -347,7 +341,7 @@ public class JobMasterStopWithSavepointITCase extends AbstractTestBase {
         }
 
         @Override
-        public Future<Boolean> triggerCheckpointAsync(
+        public CompletableFuture<Boolean> triggerCheckpointAsync(
                 CheckpointMetaData checkpointMetaData, CheckpointOptions checkpointOptions) {
             final long checkpointId = checkpointMetaData.getCheckpointId();
             final CheckpointType checkpointType = checkpointOptions.getCheckpointType();
@@ -443,7 +437,7 @@ public class JobMasterStopWithSavepointITCase extends AbstractTestBase {
         }
 
         @Override
-        public Future<Boolean> triggerCheckpointAsync(
+        public CompletableFuture<Boolean> triggerCheckpointAsync(
                 final CheckpointMetaData checkpointMetaData,
                 final CheckpointOptions checkpointOptions) {
             final long taskIndex = getEnvironment().getTaskInfo().getIndexOfThisSubtask();

--- a/flink-tests/src/test/java/org/apache/flink/test/streaming/runtime/TimestampITCase.java
+++ b/flink-tests/src/test/java/org/apache/flink/test/streaming/runtime/TimestampITCase.java
@@ -639,7 +639,8 @@ public class TimestampITCase extends TestLogger {
 
     /**
      * This verifies that an event time source works when setting stream time characteristic to
-     * processing time. In this case, the watermarks should just be swallowed.
+     * processing time. In this case, the watermarks should just be swallowed apart from the last
+     * final watermark marking the end of time.
      */
     @Test
     public void testEventTimeSourceWithProcessingTime() throws Exception {
@@ -658,7 +659,8 @@ public class TimestampITCase extends TestLogger {
 
         // verify that we don't get any watermarks, the source is used as watermark source in
         // other tests, so it normally emits watermarks
-        Assert.assertTrue(CustomOperator.finalWatermarks[0].size() == 0);
+        Assert.assertTrue(CustomOperator.finalWatermarks[0].size() == 1);
+        Assert.assertEquals(Watermark.MAX_WATERMARK, CustomOperator.finalWatermarks[0].get(0));
     }
 
     @Test
@@ -768,8 +770,8 @@ public class TimestampITCase extends TestLogger {
         }
 
         @Override
-        public void finish() throws Exception {
-            super.finish();
+        public void close() throws Exception {
+            super.close();
             finalWatermarks[getRuntimeContext().getIndexOfThisSubtask()] = watermarks;
         }
     }


### PR DESCRIPTION
## What is the purpose of the change

We want to be able to bring the entire topology with a single checkpoint/savepoint. In order to do that we must be able to call finish on all operators before such a checkpoint is triggered. The idea is to emit EndOfData, which once received, triggers finish()/endInput(). After such a sequence we can trigger a checkpoint/savepoint which meets the aforementioned criteria.

This PR reworks the `stop-with-savepoint --drain` a bit so that it works correctly with the EndOfData already. Moreover it stops the legacy sources before triggering the final savepoint, so that it includes all records.


## Brief change log

See commit messages

## Verifying this change

All tests pass, especially around savepoints, such as e.g. SavepointITCase. Added a couple of additional tests.

## Does this pull request potentially affect one of the following parts:

  - Dependencies (does it add or upgrade a dependency): (yes / **no**)
  - The public API, i.e., is any changed class annotated with `@Public(Evolving)`: (yes / **no**)
  - The serializers: (yes / **no** / don't know)
  - The runtime per-record code paths (performance sensitive): (**yes** / no / don't know)
  - Anything that affects deployment or recovery: JobManager (and its components), Checkpointing, Kubernetes/Yarn, ZooKeeper: (**yes** / no / don't know)
  - The S3 file system connector: (yes / **no** / don't know)

## Documentation

  - Does this pull request introduce a new feature? (yes / **no**)
  - If yes, how is the feature documented? (not applicable / docs / **JavaDocs** / not documented)
