### PR TITLE
[FLINK-23425][streaming-java] The impact of cpu cores on test results…

### DIFF
--- a/flink-streaming-java/src/test/java/org/apache/flink/streaming/api/graph/StreamingJobGraphGeneratorTest.java
+++ b/flink-streaming-java/src/test/java/org/apache/flink/streaming/api/graph/StreamingJobGraphGeneratorTest.java
@@ -1291,7 +1291,7 @@ public class StreamingJobGraphGeneratorTest extends TestLogger {
                 StreamGraphGenerator.DEFAULT_SLOT_SHARING_GROUP, resourceProfile);
 
         final StreamExecutionEnvironment env = StreamExecutionEnvironment.getExecutionEnvironment();
-        env.fromElements(1, 2, 3).map(x -> x + 1);
+        env.fromElements(1, 2, 3).map(x -> x + 1).setParallelism(2);
 
         final StreamGraph streamGraph = env.getStreamGraph();
         streamGraph.setSlotSharingGroupResource(slotSharingGroupResource);


### PR DESCRIPTION
… for StreamingJobGraphGeneratorTest#testSlotSharingResourceConfigurationWithDefaultSlotSharingGroup

## What is the purpose of the change

Fixed test failure of StreamingJobGraphGeneratorTest#testSlotSharingResourceConfigurationWithDefaultSlotSharingGroup.

The parallelism of fromElements is always 1 while the counterpart of map function is configurable(default is the number of available processors).

This issue were fixed it by assigning the parallelism explicitly.

## Brief change log

- flink-streaming-java/src/test/java/org/apache/flink/streaming/api/graph/StreamingJobGraphGeneratorTest.java

## Verifying this change

This change is a trivial rework / code cleanup without any test coverage.


## Does this pull request potentially affect one of the following parts:

  - Dependencies (does it add or upgrade a dependency): no
  - The public API, i.e., is any changed class annotated with `@Public(Evolving)`: no
  - The serializers: no
  - The runtime per-record code paths (performance sensitive): no
  - Anything that affects deployment or recovery: JobManager (and its components), Checkpointing, Kubernetes/Yarn, ZooKeeper: no
  - The S3 file system connector: no

## Documentation

  - Does this pull request introduce a new feature? no
