### PR TITLE
[FLINK-23500][akka] Create tmp dir if it doesn't exist

### DIFF
--- a/flink-rpc/flink-rpc-akka-loader/pom.xml
+++ b/flink-rpc/flink-rpc-akka-loader/pom.xml
@@ -63,6 +63,11 @@ under the License.
 				</exclusion>
 			</exclusions>
 		</dependency>
+
+		<dependency>
+			<groupId>org.apache.flink</groupId>
+			<artifactId>flink-test-utils-junit</artifactId>
+		</dependency>
 	</dependencies>
 
 	<build>

--- a/flink-rpc/flink-rpc-akka-loader/src/main/java/org/apache/flink/runtime/rpc/akka/AkkaRpcSystemLoader.java
+++ b/flink-rpc/flink-rpc-akka-loader/src/main/java/org/apache/flink/runtime/rpc/akka/AkkaRpcSystemLoader.java
@@ -47,11 +47,11 @@ public class AkkaRpcSystemLoader implements RpcSystemLoader {
         try {
             final ClassLoader flinkClassLoader = RpcSystem.class.getClassLoader();
 
-            final String tmpDirectory = ConfigurationUtils.parseTempDirectories(config)[0];
+            final Path tmpDirectory = Paths.get(ConfigurationUtils.parseTempDirectories(config)[0]);
+            Files.createDirectories(tmpDirectory);
             final Path tempFile =
                     Files.createFile(
-                            Paths.get(
-                                    tmpDirectory, "_flink-rpc-akka_" + UUID.randomUUID() + ".jar"));
+                            tmpDirectory.resolve("flink-rpc-akka_" + UUID.randomUUID() + ".jar"));
 
             final InputStream resourceStream =
                     flinkClassLoader.getResourceAsStream("flink-rpc-akka.jar");

--- a/flink-rpc/flink-rpc-akka-loader/src/test/java/org/apache/flink/runtime/rpc/akka/AkkaRpcSystemLoaderTest.java
+++ b/flink-rpc/flink-rpc-akka-loader/src/test/java/org/apache/flink/runtime/rpc/akka/AkkaRpcSystemLoaderTest.java
@@ -1,0 +1,57 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.flink.runtime.rpc.akka;
+
+import org.apache.flink.configuration.Configuration;
+import org.apache.flink.configuration.CoreOptions;
+import org.apache.flink.runtime.rpc.RpcSystem;
+import org.apache.flink.util.TestLogger;
+
+import org.junit.ClassRule;
+import org.junit.Test;
+import org.junit.rules.TemporaryFolder;
+
+import java.nio.file.Paths;
+
+import static org.hamcrest.CoreMatchers.not;
+import static org.hamcrest.CoreMatchers.nullValue;
+import static org.hamcrest.MatcherAssert.assertThat;
+
+/** Tests for the {@link AkkaRpcSystemLoader}. */
+public class AkkaRpcSystemLoaderTest extends TestLogger {
+
+    private static final AkkaRpcSystemLoader LOADER = new AkkaRpcSystemLoader();
+
+    @ClassRule public static final TemporaryFolder TMP_DIR = new TemporaryFolder();
+
+    @Test
+    public void testServiceLoadingWithDefaultConfig() {
+        assertThat(LOADER.loadRpcSystem(new Configuration()), not(nullValue()));
+    }
+
+    @Test
+    public void testServiceLoadingWithNonExistingPath() {
+        final Configuration config = new Configuration();
+        config.set(
+                CoreOptions.TMP_DIRS,
+                TMP_DIR.getRoot().toPath().resolve(Paths.get("some", "directory")).toString());
+        try (final RpcSystem rpcSystem = LOADER.loadRpcSystem(config)) {
+            assertThat(rpcSystem, not(nullValue()));
+        }
+    }
+}

--- a/flink-rpc/flink-rpc-akka-loader/src/test/java/org/apache/flink/runtime/rpc/akka/AkkaRpcSystemLoaderTest.java
+++ b/flink-rpc/flink-rpc-akka-loader/src/test/java/org/apache/flink/runtime/rpc/akka/AkkaRpcSystemLoaderTest.java
@@ -41,7 +41,10 @@ public class AkkaRpcSystemLoaderTest extends TestLogger {
 
     @Test
     public void testServiceLoadingWithDefaultConfig() {
-        assertThat(LOADER.loadRpcSystem(new Configuration()), not(nullValue()));
+        final Configuration config = new Configuration();
+        try (final RpcSystem rpcSystem = LOADER.loadRpcSystem(config)) {
+            assertThat(rpcSystem, not(nullValue()));
+        }
     }
 
     @Test


### PR DESCRIPTION
The `AkkaRpcSystemLoader` no longer requires the configured tmp directory to be present. This just makes it easier to work with.