### PR TITLE
[FLINK-19929] Upgrade Kinesis dependencies

### DIFF
--- a/flink-connectors/flink-connector-kinesis/pom.xml
+++ b/flink-connectors/flink-connector-kinesis/pom.xml
@@ -35,8 +35,8 @@ under the License.
 	<properties>
 		<aws.sdk.version>1.12.7</aws.sdk.version>
 		<aws.sdkv2.version>2.16.86</aws.sdkv2.version>
-		<aws.kinesis-kcl.version>1.11.2</aws.kinesis-kcl.version>
-		<aws.kinesis-kpl.version>0.14.0</aws.kinesis-kpl.version>
+		<aws.kinesis-kcl.version>1.14.1</aws.kinesis-kcl.version>
+		<aws.kinesis-kpl.version>0.14.1</aws.kinesis-kpl.version>
 		<aws.dynamodbstreams-kinesis-adapter.version>1.5.3</aws.dynamodbstreams-kinesis-adapter.version>
 		<httpclient.version>4.5.13</httpclient.version>
 		<httpcore.version>4.4.14</httpcore.version>

--- a/flink-connectors/flink-connector-kinesis/src/main/resources/META-INF/NOTICE
+++ b/flink-connectors/flink-connector-kinesis/src/main/resources/META-INF/NOTICE
@@ -6,8 +6,8 @@ The Apache Software Foundation (http://www.apache.org/).
 
 This project bundles the following dependencies under the Apache Software License 2.0. (http://www.apache.org/licenses/LICENSE-2.0.txt) 
 
-- com.amazonaws:amazon-kinesis-client:1.11.2
-- com.amazonaws:amazon-kinesis-producer:0.14.0
+- com.amazonaws:amazon-kinesis-client:1.14.1
+- com.amazonaws:amazon-kinesis-producer:0.14.1
 - com.amazonaws:aws-java-sdk-core:1.12.7
 - com.amazonaws:aws-java-sdk-dynamodb:1.12.7
 - com.amazonaws:aws-java-sdk-kinesis:1.12.7
@@ -54,7 +54,7 @@ This project bundles the following dependencies under the Apache Software Licens
 This project bundles the following dependencies under the BSD license.
 See bundled license files for details.
 
-- com.google.protobuf:protobuf-java:2.6.1
+- com.google.protobuf:protobuf-java:3.11.4
 
 This project bundles the following dependencies under the Creative Commons Zero license (https://creativecommons.org/publicdomain/zero/1.0/).
 

--- a/flink-end-to-end-tests/flink-glue-schema-registry-test/pom.xml
+++ b/flink-end-to-end-tests/flink-glue-schema-registry-test/pom.xml
@@ -33,10 +33,10 @@ under the License.
 	<packaging>jar</packaging>
 
 	<properties>
-		<aws.sdk.version>1.11.754</aws.sdk.version>
-		<aws.sdkv2.version>2.15.32</aws.sdkv2.version>
+		<aws.sdk.version>1.12.7</aws.sdk.version>
+		<aws.sdkv2.version>2.16.86</aws.sdkv2.version>
 		<reactivestreams.version>1.0.2</reactivestreams.version>
-		<netty.version>4.1.53.Final</netty.version>
+		<netty.version>4.1.63.Final</netty.version>
 		<guava.version>29.0-jre</guava.version>
 	</properties>
 

--- a/flink-end-to-end-tests/test-scripts/test_sql_client.sh
+++ b/flink-end-to-end-tests/test-scripts/test_sql_client.sh
@@ -61,7 +61,8 @@ for SQL_JAR in $SQL_JARS_DIR/*.jar; do
         ! [[ $EXTRACTED_FILE = "$EXTRACTED_JAR/org/apache/avro"* ]] && \
         # Following required by amazon-kinesis-producer in flink-connector-kinesis
         ! [[ $EXTRACTED_FILE = "$EXTRACTED_JAR/amazon-kinesis-producer-native-binaries"* ]] && \
-        ! [[ $EXTRACTED_FILE = "$EXTRACTED_JAR/cacerts"* ]] ; then
+        ! [[ $EXTRACTED_FILE = "$EXTRACTED_JAR/cacerts"* ]] && \
+        ! [[ $EXTRACTED_FILE = "$EXTRACTED_JAR/google"* ]] ; then
       echo "Bad file in JAR: $EXTRACTED_FILE"
       exit 1
     fi

--- a/flink-formats/flink-avro-glue-schema-registry/pom.xml
+++ b/flink-formats/flink-avro-glue-schema-registry/pom.xml
@@ -34,9 +34,9 @@ under the License.
 
 	<properties>
 		<glue.schema.registry.version>1.0.1</glue.schema.registry.version>
-		<aws.sdkv2.version>2.15.32</aws.sdkv2.version>
+		<aws.sdkv2.version>2.16.86</aws.sdkv2.version>
 		<reactivestreams.version>1.0.2</reactivestreams.version>
-		<netty.version>4.1.53.Final</netty.version>
+		<netty.version>4.1.63.Final</netty.version>
 	</properties>
 
 	<!-- ============================= -->


### PR DESCRIPTION
## What is the purpose of the change

* Our current Kinesis dependencies (amazon-kinesis-client, amazon-kinesis-producer) depend on protobuf 2.6.1, which are affected by CVE-2015-5237.

## Brief change log

- Updated com.amazonaws.amazon-kinesis-client from 1.11.2 to 1.14.1
- Updated com.amazonaws.amazon-kinesis-producer from 0.14.0 to 0.14.1
- Updated NOTICE files to deal with new version number

## Verifying this change

This change is a trivial rework / code cleanup without any test coverage.

## Does this pull request potentially affect one of the following parts:

  - Dependencies (does it add or upgrade a dependency): yes
  - The public API, i.e., is any changed class annotated with `@Public(Evolving)`: no
  - The serializers: don't know
  - The runtime per-record code paths (performance sensitive): don't know
  - Anything that affects deployment or recovery: JobManager (and its components), Checkpointing, Kubernetes/Yarn, ZooKeeper: no
  - The S3 file system connector: no

## Documentation

  - Does this pull request introduce a new feature? no
  - If yes, how is the feature documented? not applicable
