### PR TITLE
[FLINK-23418][e2e] Increase the timeout to make kubernetes application ha test more stable

### DIFF
--- a/flink-end-to-end-tests/test-scripts/common_kubernetes.sh
+++ b/flink-end-to-end-tests/test-scripts/common_kubernetes.sh
@@ -171,14 +171,14 @@ function wait_num_checkpoints {
 function wait_for_logs {
   local jm_pod_name=$1
   local successful_response_regex=$2
+  local timeout=${3:-30}
 
   echo "Waiting for jobmanager pod ${jm_pod_name} ready."
-  kubectl wait --for=condition=Ready --timeout=30s pod/$jm_pod_name || exit 1
+  kubectl wait --for=condition=Ready --timeout=${timeout}s pod/$jm_pod_name || exit 1
 
-  # wait at most 30 seconds until the log shows up
-  local TIMEOUT=30
+  # wait or timeout until the log shows up
   echo "Waiting for log \"$2\"..."
-  for i in $(seq 1 ${TIMEOUT}); do
+  for i in $(seq 1 ${timeout}); do
     if check_logs_output $jm_pod_name $successful_response_regex; then
       echo "Log \"$2\" shows up."
       return
@@ -186,7 +186,7 @@ function wait_for_logs {
 
     sleep 1
   done
-  echo "Log $2 does not show up within a timeout of ${TIMEOUT} sec"
+  echo "Log $2 does not show up within a timeout of ${timeout} sec"
   exit 1
 }
 

--- a/flink-end-to-end-tests/test-scripts/test_kubernetes_application_ha.sh
+++ b/flink-end-to-end-tests/test-scripts/test_kubernetes_application_ha.sh
@@ -74,7 +74,7 @@ job_id=$(kubectl logs $jm_pod_name | grep -E -o 'Job [a-z0-9]+ is submitted' | a
 kubectl exec $jm_pod_name -- /bin/sh -c "kill 1"
 
 # Check the new JobManager recovering from latest successful checkpoint
-wait_for_logs $jm_pod_name "Restoring job $job_id from Checkpoint"
+wait_for_logs $jm_pod_name "Restoring job $job_id from Checkpoint" 120
 wait_num_checkpoints $jm_pod_name 1
 
 "$FLINK_DIR"/bin/flink cancel -t kubernetes-application -Dkubernetes.cluster-id=${CLUSTER_ID} $job_id


### PR DESCRIPTION
<!--
*Thank you very much for contributing to Apache Flink - we are happy that you want to help us improve Flink. To help the community review your contribution in the best possible way, please go through the checklist below, which will get the contribution into a shape in which it can be best reviewed.*

*Please understand that we do not do this to make contributions to Flink a hassle. In order to uphold a high standard of quality for code contributions, while at the same time managing a large number of contributions, we need contributors to prepare the contributions well, and give reviewers enough contextual information for the review. Please also understand that contributions that do not follow this guide will take longer to review and thus typically be picked up with lower priority by the community.*

## Contribution Checklist

  - Make sure that the pull request corresponds to a [JIRA issue](https://issues.apache.org/jira/projects/FLINK/issues). Exceptions are made for typos in JavaDoc or documentation files, which need no JIRA issue.
  
  - Name the pull request in the form "[FLINK-XXXX] [component] Title of the pull request", where *FLINK-XXXX* should be replaced by the actual issue number. Skip *component* if you are unsure about which is the best component.
  Typo fixes that have no associated JIRA issue should be named following this pattern: `[hotfix] [docs] Fix typo in event time introduction` or `[hotfix] [javadocs] Expand JavaDoc for PuncuatedWatermarkGenerator`.

  - Fill out the template below to describe the changes contributed by the pull request. That will give reviewers the context they need to do the review.
  
  - Make sure that the change passes the automated tests, i.e., `mvn clean verify` passes. You can set up Azure Pipelines CI to do that following [this guide](https://cwiki.apache.org/confluence/display/FLINK/Azure+Pipelines#AzurePipelines-Tutorial:SettingupAzurePipelinesforaforkoftheFlinkrepository).

  - Each pull request should address only one issue, not mix up code from multiple issues.
  
  - Each commit in the pull request has a meaningful commit message (including the JIRA id)

  - Once all items of the checklist are addressed, remove the above text and this checklist, leaving only the filled out template below.


**(The sections below can be removed for hotfixes of typos)**
-->

## What is the purpose of the change

The test `test_kubernetes_application_ha.sh` could fail because of timeout(30s) waiting for log `Restoring job 00000000000000000000000000000000 from Checkpoint`. I did not find any exceptions, potential bugs for Kubernetes HA and recovery process. It just seems that the JobManager started and recovered slowly. This PR will increase the timeout to 120s to make the test more stable.


## Brief change log

* Increase the timeout to make kubernetes application ha test more stable


## Verifying this change

* Already covered by `test_kubernetes_application_ha.sh`

## Does this pull request potentially affect one of the following parts:

  - Dependencies (does it add or upgrade a dependency): (yes / **no**)
  - The public API, i.e., is any changed class annotated with `@Public(Evolving)`: (yes / **no**)
  - The serializers: (yes / **no** / don't know)
  - The runtime per-record code paths (performance sensitive): (yes / **no** / don't know)
  - Anything that affects deployment or recovery: JobManager (and its components), Checkpointing, Kubernetes/Yarn, ZooKeeper: (yes / **no** / don't know)
  - The S3 file system connector: (yes / **no** / don't know)

## Documentation

  - Does this pull request introduce a new feature? (yes / **no**)
  - If yes, how is the feature documented? (**not applicable** / docs / JavaDocs / not documented)
