### PR TITLE
[FLINK-23499][Runtime][Configuration]Eliminate the influence of scheme on splitting paths

### DIFF
--- a/flink-core/src/main/java/org/apache/flink/configuration/ConfigurationUtils.java
+++ b/flink-core/src/main/java/org/apache/flink/configuration/ConfigurationUtils.java
@@ -178,7 +178,10 @@ public class ConfigurationUtils {
 
 	@Nonnull
 	public static String[] splitPaths(@Nonnull String separatedPaths) {
-		return separatedPaths.length() > 0 ? separatedPaths.split(",|" + File.pathSeparator) : EMPTY;
+		String separator = String.format(",|((?!%s//)%s)", File.pathSeparator, File.pathSeparator);
+		return separatedPaths.length() > 0
+			? separatedPaths.split(separator)
+			: EMPTY;
 	}
 
 	@VisibleForTesting

--- a/flink-core/src/test/java/org/apache/flink/configuration/ConfigurationUtilsTest.java
+++ b/flink-core/src/test/java/org/apache/flink/configuration/ConfigurationUtilsTest.java
@@ -74,4 +74,12 @@ public class ConfigurationUtilsTest extends TestLogger {
 		assertThat(hiddenSensitiveValues, is(equalTo(expectedKeyValuePairs)));
 	}
 
+	@Test
+	public void testSplitPaths() {
+		final String file =
+			"file:///home/user/file/:file:///dir,s3://dir/a:hdfs://nameservice/dir1/file1,/hello:/world";
+
+		assertThat(ConfigurationUtils.splitPaths(file).length, is(equalTo(6)));
+	}
+
 }


### PR DESCRIPTION
## What is the purpose of the change

ConfigurationUtils#splitPaths can split a path that contains a scheme (e.g., file:///tmp) into 2 paths, because : is commonly used as File.pathSeparator, it will result in an unexpected output, so we need to fix it

## Brief change log

* use new split character

## Verifying this change

This change is covered by the new tests, `ConfigurationUtilsTest.testSplitPaths()`

## Does this pull request potentially affect one of the following parts:

  - Dependencies (does it add or upgrade a dependency): no
  - The public API, i.e., is any changed class annotated with `@Public(Evolving)`: no
  - The serializers: no
  - The runtime per-record code paths (performance sensitive): no
  - Anything that affects deployment or recovery: JobManager (and its components), Checkpointing, Kubernetes/Yarn/Mesos, ZooKeeper: yes
  - The S3 file system connector: no

## Documentation

  - Does this pull request introduce a new feature? no
  - If yes, how is the feature documented? no