### PR TITLE
[FLINK-23297] Upgrade Protobuf to 3.17.3

### DIFF
--- a/flink-python/pom.xml
+++ b/flink-python/pom.xml
@@ -405,7 +405,7 @@ under the License.
 			<plugin>
 				<groupId>com.github.os72</groupId>
 				<artifactId>protoc-jar-maven-plugin</artifactId>
-				<version>${protoc.version}</version>
+				<version>3.11.4</version>
 				<executions>
 					<execution>
 						<phase>generate-sources</phase>

--- a/flink-python/src/main/resources/META-INF/NOTICE
+++ b/flink-python/src/main/resources/META-INF/NOTICE
@@ -32,7 +32,7 @@ This project bundles the following dependencies under the BSD license.
 See bundled license files for details
 
 - net.sf.py4j:py4j:0.10.8.1
-- com.google.protobuf:protobuf-java:3.11.1
+- com.google.protobuf:protobuf-java:3.17.3
 
 This project bundles the following dependencies under the MIT license. (https://opensource.org/licenses/MIT)
 See bundled license files for details.

--- a/pom.xml
+++ b/pom.xml
@@ -130,7 +130,7 @@ under the License.
 		<hamcrest.version>1.3</hamcrest.version>
 		<py4j.version>0.10.8.1</py4j.version>
 		<beam.version>2.27.0</beam.version>
-		<protoc.version>3.11.1</protoc.version>
+		<protoc.version>3.17.3</protoc.version>
 		<arrow.version>0.16.0</arrow.version>
 		<okhttp.version>3.14.9</okhttp.version>
 		<lz4.version>1.8.0</lz4.version>


### PR DESCRIPTION
## What is the purpose of the change

* In order to support compilation with ARM (e.g. Apple M1 chip), we need to bump our Protobuf dependency to version 3.17.3.

## Brief change log

- Updated com.google.protobuf:protobuf-java from 3.11.1 to 3.17.3
- Hardcoded version for plugin protoc-jar-maven-plugin:protoc-jar-maven-plugin since that's not in sync with com.google.protobuf:protobuf-java to the latest available version
- Updated NOTICE files to deal with new version number

## Verifying this change

This change is a trivial rework / code cleanup without any test coverage.

## Does this pull request potentially affect one of the following parts:

  - Dependencies (does it add or upgrade a dependency): yes
  - The public API, i.e., is any changed class annotated with `@Public(Evolving)`: no
  - The serializers: yes
  - The runtime per-record code paths (performance sensitive): don't know
  - Anything that affects deployment or recovery: JobManager (and its components), Checkpointing, Kubernetes/Yarn, ZooKeeper: no
  - The S3 file system connector: no

## Documentation

  - Does this pull request introduce a new feature? no
  - If yes, how is the feature documented? not applicable
