### PR TITLE
[FLINK-23324][connector/jdbc] Make Postgres case-sensitive.

### DIFF
--- a/flink-connectors/flink-connector-jdbc/src/main/java/org/apache/flink/connector/jdbc/catalog/AbstractJdbcCatalog.java
+++ b/flink-connectors/flink-connector-jdbc/src/main/java/org/apache/flink/connector/jdbc/catalog/AbstractJdbcCatalog.java
@@ -237,7 +237,7 @@ public abstract class AbstractJdbcCatalog extends AbstractCatalog {
 
             PreparedStatement ps =
                     conn.prepareStatement(
-                            String.format("SELECT * FROM %s;", getSchemaTableName(tablePath)));
+                            String.format("SELECT * FROM %s;", getSchemaTableNameWithQuote(tablePath)));
 
             ResultSetMetaData resultSetMetaData = ps.getMetaData();
 
@@ -514,6 +514,10 @@ public abstract class AbstractJdbcCatalog extends AbstractCatalog {
     }
 
     protected String getSchemaTableName(ObjectPath tablePath) {
+        throw new UnsupportedOperationException();
+    }
+
+    protected String getSchemaTableNameWithQuote(ObjectPath tablePath) {
         throw new UnsupportedOperationException();
     }
 }

--- a/flink-connectors/flink-connector-jdbc/src/main/java/org/apache/flink/connector/jdbc/catalog/MySqlCatalog.java
+++ b/flink-connectors/flink-connector-jdbc/src/main/java/org/apache/flink/connector/jdbc/catalog/MySqlCatalog.java
@@ -159,4 +159,9 @@ public class MySqlCatalog extends AbstractJdbcCatalog {
     protected String getSchemaTableName(ObjectPath tablePath) {
         return tablePath.getObjectName();
     }
+
+    @Override
+    protected String getSchemaTableNameWithQuote(ObjectPath tablePath) {
+        return tablePath.getObjectName();
+    }
 }

--- a/flink-connectors/flink-connector-jdbc/src/main/java/org/apache/flink/connector/jdbc/catalog/PostgresCatalog.java
+++ b/flink-connectors/flink-connector-jdbc/src/main/java/org/apache/flink/connector/jdbc/catalog/PostgresCatalog.java
@@ -173,4 +173,9 @@ public class PostgresCatalog extends AbstractJdbcCatalog {
     protected String getSchemaTableName(ObjectPath tablePath) {
         return PostgresTablePath.fromFlinkTableName(tablePath.getObjectName()).getFullPath();
     }
+
+    @Override
+    protected String getSchemaTableNameWithQuote(ObjectPath tablePath) {
+        return PostgresTablePath.fromFlinkTableName(tablePath.getObjectName()).getQuoteFullPath();
+    }
 }

--- a/flink-connectors/flink-connector-jdbc/src/main/java/org/apache/flink/connector/jdbc/catalog/PostgresTablePath.java
+++ b/flink-connectors/flink-connector-jdbc/src/main/java/org/apache/flink/connector/jdbc/catalog/PostgresTablePath.java
@@ -18,6 +18,8 @@
 
 package org.apache.flink.connector.jdbc.catalog;
 
+import org.apache.flink.connector.jdbc.dialect.JdbcDialect;
+import org.apache.flink.connector.jdbc.dialect.psql.PostgresDialect;
 import org.apache.flink.util.StringUtils;
 
 import java.util.Objects;
@@ -34,6 +36,7 @@ public class PostgresTablePath {
 
     private final String pgSchemaName;
     private final String pgTableName;
+    private final JdbcDialect dialect;
 
     public PostgresTablePath(String pgSchemaName, String pgTableName) {
         checkArgument(!StringUtils.isNullOrWhitespaceOnly(pgSchemaName));
@@ -41,6 +44,7 @@ public class PostgresTablePath {
 
         this.pgSchemaName = pgSchemaName;
         this.pgTableName = pgTableName;
+        this.dialect = new PostgresDialect();
     }
 
     public static PostgresTablePath fromFlinkTableName(String flinkTableName) {
@@ -65,6 +69,12 @@ public class PostgresTablePath {
 
     public String getFullPath() {
         return String.format("%s.%s", pgSchemaName, pgTableName);
+    }
+
+    public String getQuoteFullPath() {
+        return String.format(
+                "%s.%s",
+                dialect.quoteIdentifier(pgSchemaName), dialect.quoteIdentifier(pgTableName));
     }
 
     public String getPgTableName() {

--- a/flink-connectors/flink-connector-jdbc/src/main/java/org/apache/flink/connector/jdbc/dialect/psql/PostgresDialect.java
+++ b/flink-connectors/flink-connector-jdbc/src/main/java/org/apache/flink/connector/jdbc/dialect/psql/PostgresDialect.java
@@ -18,6 +18,7 @@
 
 package org.apache.flink.connector.jdbc.dialect.psql;
 
+import org.apache.flink.connector.jdbc.catalog.PostgresTablePath;
 import org.apache.flink.connector.jdbc.converter.JdbcRowConverter;
 import org.apache.flink.connector.jdbc.dialect.AbstractDialect;
 import org.apache.flink.connector.jdbc.internal.converter.PostgresRowConverter;
@@ -83,7 +84,11 @@ public class PostgresDialect extends AbstractDialect {
 
     @Override
     public String quoteIdentifier(String identifier) {
-        return identifier;
+        if (identifier.contains(".")) {
+            return PostgresTablePath.fromFlinkTableName(identifier).getQuoteFullPath();
+        } else {
+            return "\"" + identifier + "\"";
+        }
     }
 
     @Override

--- a/flink-connectors/flink-connector-jdbc/src/test/java/org/apache/flink/connector/jdbc/catalog/PostgresCatalogITCase.java
+++ b/flink-connectors/flink-connector-jdbc/src/test/java/org/apache/flink/connector/jdbc/catalog/PostgresCatalogITCase.java
@@ -193,4 +193,18 @@ public class PostgresCatalogITCase extends PostgresCatalogTestBase {
                         + "9223372036854775807]]",
                 results.toString());
     }
+
+    @Test
+    public void testUpper() {
+        List<Row> results =
+                CollectionUtil.iteratorToList(
+                        tEnv.sqlQuery(
+                                        String.format(
+                                                "select * from `%s.%s`",
+                                                TEST_UPPER_SCHEMA, TABLE_UPPER_NAME))
+                                .execute()
+                                .collect());
+
+        assertEquals("[+I[1]]", results.toString());
+    }
 }

--- a/flink-connectors/flink-connector-jdbc/src/test/java/org/apache/flink/connector/jdbc/catalog/PostgresCatalogITCase.java
+++ b/flink-connectors/flink-connector-jdbc/src/test/java/org/apache/flink/connector/jdbc/catalog/PostgresCatalogITCase.java
@@ -207,4 +207,31 @@ public class PostgresCatalogITCase extends PostgresCatalogTestBase {
 
         assertEquals("[+I[1]]", results.toString());
     }
+
+    @Test
+    public void testUpperTable() {
+        List<Row> results =
+                CollectionUtil.iteratorToList(
+                        tEnv.sqlQuery(
+                                        String.format(
+                                                "select * from %s", TABLE_UPPER_NAME))
+                                .execute()
+                                .collect());
+
+        assertEquals("[+I[1]]", results.toString());
+    }
+
+    @Test
+    public void testUpperSchema() {
+        List<Row> results =
+                CollectionUtil.iteratorToList(
+                        tEnv.sqlQuery(
+                                        String.format(
+                                                "select * from `%s.%s`",
+                                                TEST_UPPER_SCHEMA, TABLE2))
+                                .execute()
+                                .collect());
+
+        assertEquals("[+I[1]]", results.toString());
+    }
 }

--- a/flink-connectors/flink-connector-jdbc/src/test/java/org/apache/flink/connector/jdbc/catalog/PostgresCatalogTest.java
+++ b/flink-connectors/flink-connector-jdbc/src/test/java/org/apache/flink/connector/jdbc/catalog/PostgresCatalogTest.java
@@ -73,7 +73,8 @@ public class PostgresCatalogTest extends PostgresCatalogTestBase {
                         "public.serial_table",
                         "public.t1",
                         "public.t4",
-                        "public.t5"),
+                        "public.t5",
+                        "upper_Schema.upper_Table"),
                 actual);
 
         actual = catalog.listTables(TEST_DB);

--- a/flink-connectors/flink-connector-jdbc/src/test/java/org/apache/flink/connector/jdbc/catalog/PostgresCatalogTest.java
+++ b/flink-connectors/flink-connector-jdbc/src/test/java/org/apache/flink/connector/jdbc/catalog/PostgresCatalogTest.java
@@ -74,7 +74,9 @@ public class PostgresCatalogTest extends PostgresCatalogTestBase {
                         "public.t1",
                         "public.t4",
                         "public.t5",
-                        "upper_Schema.upper_Table"),
+                        "public.upper_T1",
+                        "upper_Schema.t2",
+                        "upper_Schema.upper_T1"),
                 actual);
 
         actual = catalog.listTables(TEST_DB);

--- a/flink-connectors/flink-connector-jdbc/src/test/java/org/apache/flink/connector/jdbc/catalog/PostgresCatalogTestBase.java
+++ b/flink-connectors/flink-connector-jdbc/src/test/java/org/apache/flink/connector/jdbc/catalog/PostgresCatalogTestBase.java
@@ -63,7 +63,7 @@ public class PostgresCatalogTestBase {
     protected static final String TABLE_PRIMITIVE_TYPE2 = "primitive_table2";
     protected static final String TABLE_ARRAY_TYPE = "array_table";
     protected static final String TABLE_SERIAL_TYPE = "serial_table";
-    protected static final String TABLE_UPPER_NAME = "upper_Table";
+    protected static final String TABLE_UPPER_NAME = "upper_T1";
 
     protected static String baseUrl;
     protected static PostgresCatalog catalog;
@@ -124,8 +124,15 @@ public class PostgresCatalogTestBase {
         createTable(
                 PostgresTablePath.fromFlinkTableName(TABLE_SERIAL_TYPE),
                 getSerialTable().pgSchemaSql);
+
         createQuoteTable(
                 new PostgresTablePath(TEST_UPPER_SCHEMA, TABLE_UPPER_NAME),
+                getUpperTable().pgSchemaSql);
+        createQuoteTable(
+                PostgresTablePath.fromFlinkTableName(TABLE_UPPER_NAME),
+                getUpperTable().pgSchemaSql);
+        createQuoteTable(
+                new PostgresTablePath(TEST_UPPER_SCHEMA, TABLE2),
                 getUpperTable().pgSchemaSql);
 
         executeSQL(
@@ -145,11 +152,25 @@ public class PostgresCatalogTestBase {
                 PostgresCatalog.DEFAULT_DATABASE,
                 String.format(
                         "insert into %s values (%s);", TABLE_SERIAL_TYPE, getSerialTable().values));
+
         executeSQL(
                 PostgresCatalog.DEFAULT_DATABASE,
                 String.format(
                         "insert into %s values (%s);",
                         new PostgresTablePath(TEST_UPPER_SCHEMA, TABLE_UPPER_NAME)
+                                .getQuoteFullPath(),
+                        getUpperTable().values));
+        executeSQL(
+                PostgresCatalog.DEFAULT_DATABASE,
+                String.format(
+                        "insert into public.\"%s\" values (%s);",
+                        TABLE_UPPER_NAME,
+                        getUpperTable().values));
+        executeSQL(
+                PostgresCatalog.DEFAULT_DATABASE,
+                String.format(
+                        "insert into %s values (%s);",
+                        new PostgresTablePath(TEST_UPPER_SCHEMA, TABLE2)
                                 .getQuoteFullPath(),
                         getUpperTable().values));
     }


### PR DESCRIPTION
## What is the purpose of the change

Flink can connect postgresql table which name and schema have uppercase. 

## Brief change log

PostgresCalalog can read table metadata, which name and schema have uppercase. 
PostgresDialect can generate correct SQL. 
For example: INSERT INTO "test_Schema"."test_Upper_name" ("foo_Bar") VALUES(1)

## Verifying this change

This change added tests and can be verified as follows:
Added integration tests to read postgresql table which name and schema have uppercase.

## Does this pull request potentially affect one of the following parts:

  - Dependencies (does it add or upgrade a dependency): (no)
  - The public API, i.e., is any changed class annotated with `@Public(Evolving)`: (no)
  - The serializers: (no)
  - The runtime per-record code paths (performance sensitive): (no)
  - Anything that affects deployment or recovery: JobManager (and its components), Checkpointing, Kubernetes/Yarn, ZooKeeper: (no)
  - The S3 file system connector: (no)

## Documentation

  - Does this pull request introduce a new feature? (no)
  - If yes, how is the feature documented? (no)
