### PR TITLE
[FLINK-23497][table-planner] Add dependency for scala-parser-combinators

### DIFF
--- a/flink-end-to-end-tests/test-scripts/test_table_shaded_dependencies.sh
+++ b/flink-end-to-end-tests/test-scripts/test_table_shaded_dependencies.sh
@@ -89,6 +89,7 @@ function checkAllowedPackages {
       grep -v "org/apache/calcite" |\
       grep -v "com/esri/core" |\
       grep -v "com/ibm/icu" |\
+      grep -v "scala/util/parsing" |\
       grep -v "org/apache/flink" > $CONTENTS_FILE
   if [[ `cat $CONTENTS_FILE | wc -l` -eq '0' ]]; then
       echo "Success: There are no unwanted classes in the ${JAR} jar."

--- a/flink-table/flink-table-planner/pom.xml
+++ b/flink-table/flink-table-planner/pom.xml
@@ -395,6 +395,9 @@ under the License.
 									<!-- Tools to unify display format for different languages -->
 									<include>com.ibm.icu:icu4j</include>
 
+									<!-- For legacy string expressions in Table API -->
+									<include>org.scala-lang.modules:scala-parser-combinators_${scala.binary.version}</include>
+
 									<include>org.reflections:reflections</include>
 								</includes>
 							</artifactSet>

--- a/flink-table/flink-table-planner/pom.xml
+++ b/flink-table/flink-table-planner/pom.xml
@@ -215,6 +215,12 @@ under the License.
 			<version>67.1</version>
 		</dependency>
 
+		<!-- For legacy string expressions in Table API -->
+		<dependency>
+			<groupId>org.scala-lang.modules</groupId>
+			<artifactId>scala-parser-combinators_${scala.binary.version}</artifactId>
+		</dependency>
+
 		<!-- test dependencies -->
 		<dependency>
 			<groupId>org.apache.flink</groupId>

--- a/flink-table/flink-table-planner/src/main/resources/META-INF/NOTICE
+++ b/flink-table/flink-table-planner/src/main/resources/META-INF/NOTICE
@@ -16,6 +16,7 @@ This project bundles the following dependencies under the Apache Software Licens
 - org.apache.calcite:calcite-core:1.26.0
 - org.apache.calcite:calcite-linq4j:1.26.0
 - org.apache.calcite.avatica:avatica-core:1.17.0
+- org.scala-lang.modules:scala-parser-combinators_2.11:1.1.1
 - commons-codec:commons-codec:1.13
 - commons-io:commons-io:2.8.0
 


### PR DESCRIPTION
## What is the purpose of the change

Ensures that the `flink-table-planner` module is compilable when using Scala 1.12.

It is likely that we can remove it again before releasing 1.14 by dropping the affected legacy `ExpressionParser`.


## Verifying this change

This change is a trivial rework / code cleanup without any test coverage.

## Does this pull request potentially affect one of the following parts:

  - Dependencies (does it add or upgrade a dependency): yes
  - The public API, i.e., is any changed class annotated with `@Public(Evolving)`: no
  - The serializers: no
  - The runtime per-record code paths (performance sensitive): no
  - Anything that affects deployment or recovery: JobManager (and its components), Checkpointing, Kubernetes/Yarn, ZooKeeper: no
  - The S3 file system connector: no

## Documentation

  - Does this pull request introduce a new feature? no
  - If yes, how is the feature documented? not applicable
