### PR TITLE
[FLINK-23437][jdbc] Add an option to (dis)allow XA transaction multiplexing

### DIFF
--- a/flink-connectors/flink-connector-jdbc/src/main/java/org/apache/flink/connector/jdbc/JdbcExactlyOnceOptions.java
+++ b/flink-connectors/flink-connector-jdbc/src/main/java/org/apache/flink/connector/jdbc/JdbcExactlyOnceOptions.java
@@ -53,21 +53,25 @@ public class JdbcExactlyOnceOptions implements Serializable {
     private static final boolean DEFAULT_RECOVERED_AND_ROLLBACK = true;
     private static final int DEFAULT_MAX_COMMIT_ATTEMPTS = 3;
     private static final boolean DEFAULT_ALLOW_OUT_OF_ORDER_COMMITS = false;
+    public static final boolean DEFAULT_TRANSACTION_PER_CONNECTION = false;
 
     private final boolean discoverAndRollbackOnRecovery;
     private final int maxCommitAttempts;
     private final boolean allowOutOfOrderCommits;
     private final Integer timeoutSec;
+    private final boolean transactionPerConnection;
 
     private JdbcExactlyOnceOptions(
             boolean discoverAndRollbackOnRecovery,
             int maxCommitAttempts,
             boolean allowOutOfOrderCommits,
-            Optional<Integer> timeoutSec) {
+            Optional<Integer> timeoutSec,
+            boolean transactionPerConnection) {
         this.discoverAndRollbackOnRecovery = discoverAndRollbackOnRecovery;
         this.maxCommitAttempts = maxCommitAttempts;
         this.allowOutOfOrderCommits = allowOutOfOrderCommits;
         this.timeoutSec = timeoutSec.orElse(null);
+        this.transactionPerConnection = transactionPerConnection;
         Preconditions.checkArgument(this.maxCommitAttempts > 0, "maxCommitAttempts should be > 0");
     }
 
@@ -91,6 +95,10 @@ public class JdbcExactlyOnceOptions implements Serializable {
         return timeoutSec;
     }
 
+    public boolean isTransactionPerConnection() {
+        return transactionPerConnection;
+    }
+
     public static JDBCExactlyOnceOptionsBuilder builder() {
         return new JDBCExactlyOnceOptionsBuilder();
     }
@@ -101,6 +109,7 @@ public class JdbcExactlyOnceOptions implements Serializable {
         private int maxCommitAttempts = DEFAULT_MAX_COMMIT_ATTEMPTS;
         private boolean allowOutOfOrderCommits = DEFAULT_ALLOW_OUT_OF_ORDER_COMMITS;
         private Optional<Integer> timeoutSec = Optional.empty();
+        private boolean transactionPerConnection = DEFAULT_TRANSACTION_PER_CONNECTION;
 
         /**
          * Toggle discovery and rollback of prepared transactions upon recovery to prevent new
@@ -138,9 +147,33 @@ public class JdbcExactlyOnceOptions implements Serializable {
             return this;
         }
 
+        /**
+         * Set whether the same connection can be used for multiple XA transactions. A transaction
+         * is prepared each time a checkpoint is performed; it is committed once the checkpoint is
+         * confirmed. There can be multiple un-confirmed checkpoints and therefore multiple prepared
+         * transactions.
+         *
+         * <p>Some databases support this natively (e.g. Oracle); while others only allow a single
+         * XA transaction per connection (e.g. MySQL, PostgreSQL).
+         *
+         * <p>If enabled, each transaction uses a separate connection from a pool. The database
+         * limit of open connections might need to be adjusted.
+         *
+         * <p>Disabled by default.
+         */
+        public JDBCExactlyOnceOptionsBuilder withTransactionPerConnection(
+                boolean transactionPerConnection) {
+            this.transactionPerConnection = transactionPerConnection;
+            return this;
+        }
+
         public JdbcExactlyOnceOptions build() {
             return new JdbcExactlyOnceOptions(
-                    recoveredAndRollback, maxCommitAttempts, allowOutOfOrderCommits, timeoutSec);
+                    recoveredAndRollback,
+                    maxCommitAttempts,
+                    allowOutOfOrderCommits,
+                    timeoutSec,
+                    transactionPerConnection);
         }
     }
 }

--- a/flink-connectors/flink-connector-jdbc/src/main/java/org/apache/flink/connector/jdbc/JdbcSink.java
+++ b/flink-connectors/flink-connector-jdbc/src/main/java/org/apache/flink/connector/jdbc/JdbcSink.java
@@ -103,7 +103,9 @@ public class JdbcSink {
                 sql,
                 statementBuilder,
                 XaFacade.fromXaDataSourceSupplier(
-                        dataSourceSupplier, exactlyOnceOptions.getTimeoutSec()),
+                        dataSourceSupplier,
+                        exactlyOnceOptions.getTimeoutSec(),
+                        exactlyOnceOptions.isTransactionPerConnection()),
                 executionOptions,
                 exactlyOnceOptions);
     }

--- a/flink-connectors/flink-connector-jdbc/src/main/java/org/apache/flink/connector/jdbc/xa/XaFacade.java
+++ b/flink-connectors/flink-connector-jdbc/src/main/java/org/apache/flink/connector/jdbc/xa/XaFacade.java
@@ -51,8 +51,12 @@ public interface XaFacade extends JdbcConnectionProvider, Serializable, AutoClos
 
     /** @return a non-serializable instance. */
     static XaFacade fromXaDataSourceSupplier(
-            Supplier<XADataSource> dataSourceSupplier, Integer timeoutSec) {
-        return new XaFacadePoolingImpl(() -> new XaFacadeImpl(dataSourceSupplier, timeoutSec));
+            Supplier<XADataSource> dataSourceSupplier,
+            Integer timeoutSec,
+            boolean transactionPerConnection) {
+        return transactionPerConnection
+                ? new XaFacadePoolingImpl(() -> new XaFacadeImpl(dataSourceSupplier, timeoutSec))
+                : new XaFacadeImpl(dataSourceSupplier, timeoutSec);
     }
 
     void open() throws Exception;

--- a/flink-connectors/flink-connector-jdbc/src/test/java/org/apache/flink/connector/jdbc/xa/JdbcExactlyOnceSinkE2eTest.java
+++ b/flink-connectors/flink-connector-jdbc/src/test/java/org/apache/flink/connector/jdbc/xa/JdbcExactlyOnceSinkE2eTest.java
@@ -195,7 +195,9 @@ public class JdbcExactlyOnceSinkE2eTest extends JdbcTestBase {
                                 String.format(INSERT_TEMPLATE, INPUT_TABLE),
                                 JdbcITCase.TEST_ENTRY_JDBC_STATEMENT_BUILDER,
                                 JdbcExecutionOptions.builder().build(),
-                                JdbcExactlyOnceOptions.defaults(),
+                                JdbcExactlyOnceOptions.builder()
+                                        .withTransactionPerConnection(true)
+                                        .build(),
                                 this.dbEnv.getDataSourceSupplier()));
 
         env.execute();


### PR DESCRIPTION
## What is the purpose of the change

Currently, JDBC XA sink creates/uses a connection per transaction.
This is to support databases with a single transaction-per-connection drivers.
However, it has an overhead and can lead to exceeding connection limits.

This change disables this feature by default and adds an option to enable it.

## Verifying this change

This is a trivial change without any test coverage.

## Does this pull request potentially affect one of the following parts:

  - Dependencies (does it add or upgrade a dependency): no
  - The public API, i.e., is any changed class annotated with `@Public(Evolving)`: no
  - The serializers: no
  - The runtime per-record code paths (performance sensitive): no
  - Anything that affects deployment or recovery: JobManager (and its components), Checkpointing, Kubernetes/Yarn/Mesos, ZooKeeper: no
  - The S3 file system connector: no

## Documentation

  - Does this pull request introduce a new feature? no
  - If yes, how is the feature documented? no
