### PR TITLE
[FLINK-19739][table-runtime-blink] Fix compile exception for window aggregate in batch jobs

### DIFF
--- a/flink-table/flink-table-planner-blink/src/main/scala/org/apache/flink/table/planner/codegen/agg/batch/HashWindowCodeGenerator.scala
+++ b/flink-table/flink-table-planner-blink/src/main/scala/org/apache/flink/table/planner/codegen/agg/batch/HashWindowCodeGenerator.scala
@@ -23,8 +23,9 @@ import org.apache.flink.api.java.typeutils.ListTypeInfo
 import org.apache.flink.runtime.operators.sort.QuickSort
 import org.apache.flink.streaming.api.operators.OneInputStreamOperator
 import org.apache.flink.table.api.Types
-import org.apache.flink.table.data.RowData
+import org.apache.flink.table.data.{GenericRowData, RowData}
 import org.apache.flink.table.data.binary.BinaryRowData
+import org.apache.flink.table.data.utils.JoinedRowData
 import org.apache.flink.table.planner.codegen.CodeGenUtils.{BINARY_ROW, newName}
 import org.apache.flink.table.planner.codegen.OperatorCodeGenerator.generateCollect
 import org.apache.flink.table.planner.codegen._
@@ -610,6 +611,14 @@ class HashWindowCodeGenerator(
        |  $endCode
        | }
        """.stripMargin
+  }
+
+  private def getOutputRowClass: Class[_ <: RowData] = {
+    if (namedProperties.isEmpty && grouping.isEmpty && isFinal) {
+      classOf[GenericRowData]
+    } else {
+      classOf[JoinedRowData]
+    }
   }
 
   private def genOutputDirectly(

--- a/flink-table/flink-table-planner-blink/src/main/scala/org/apache/flink/table/planner/codegen/agg/batch/WindowCodeGenerator.scala
+++ b/flink-table/flink-table-planner-blink/src/main/scala/org/apache/flink/table/planner/codegen/agg/batch/WindowCodeGenerator.scala
@@ -22,12 +22,12 @@ import org.apache.flink.api.java.tuple.{Tuple2 => JTuple2}
 import org.apache.flink.table.api.DataTypes
 import org.apache.flink.table.data.binary.BinaryRowData
 import org.apache.flink.table.data.utils.JoinedRowData
-import org.apache.flink.table.data.{GenericRowData, RowData}
+import org.apache.flink.table.data.GenericRowData
 import org.apache.flink.table.expressions.ExpressionUtils.extractValue
 import org.apache.flink.table.expressions.{Expression, ValueLiteralExpression}
 import org.apache.flink.table.functions.AggregateFunction
 import org.apache.flink.table.planner.JLong
-import org.apache.flink.table.planner.expressions.PlannerNamedWindowProperty;
+import org.apache.flink.table.planner.expressions.PlannerNamedWindowProperty
 import org.apache.flink.table.planner.calcite.FlinkTypeFactory
 import org.apache.flink.table.planner.codegen.CodeGenUtils.{BINARY_ROW, TIMESTAMP_DATA, boxedTypeTermForType, newName}
 import org.apache.flink.table.planner.codegen.GenerateUtils.generateFieldAccess
@@ -96,14 +96,6 @@ abstract class WindowCodeGenerator(
   private lazy val windowedGroupKeyType: RowType = RowType.of(
     (groupKeyRowType.getChildren :+ timestampInternalType).toArray,
     (groupKeyRowType.getFieldNames :+ "assignedTs$").toArray)
-
-  def getOutputRowClass: Class[_ <: RowData] = {
-    if (namedProperties.isEmpty && grouping.isEmpty) {
-      classOf[GenericRowData]
-    } else {
-      classOf[JoinedRowData]
-    }
-  }
 
   private[flink] def getWindowsGroupingElementInfo(
       enablePreAccumulate: Boolean = true): RowType = {

--- a/flink-table/flink-table-planner-blink/src/test/scala/org/apache/flink/table/planner/runtime/batch/sql/agg/GroupWindowITCase.scala
+++ b/flink-table/flink-table-planner-blink/src/test/scala/org/apache/flink/table/planner/runtime/batch/sql/agg/GroupWindowITCase.scala
@@ -22,13 +22,17 @@ import org.apache.flink.api.common.typeinfo.BasicTypeInfo.{INT_TYPE_INFO, LONG_T
 import org.apache.flink.api.common.typeinfo.LocalTimeTypeInfo.LOCAL_DATE_TIME
 import org.apache.flink.api.java.typeutils.RowTypeInfo
 import org.apache.flink.api.scala._
+import org.apache.flink.table.planner.factories.TestValuesTableFactory
 import org.apache.flink.table.planner.runtime.utils.BatchTestBase
 import org.apache.flink.table.planner.runtime.utils.BatchTestBase.row
 import org.apache.flink.table.planner.runtime.utils.TestData._
 import org.apache.flink.table.planner.utils.DateTimeTestUtil.localDateTime
 import org.apache.flink.table.planner.utils.{CountAggFunction, IntAvgAggFunction, IntSumAggFunction}
+import org.apache.flink.types.Row
 
 import org.junit.{Before, Test}
+
+import java.time.LocalDateTime
 
 class GroupWindowITCase extends BatchTestBase {
 
@@ -640,5 +644,38 @@ class GroupWindowITCase extends BatchTestBase {
         "GROUP BY SESSION(ts, INTERVAL '4' SECOND)"
 
     checkResult(sqlQuery, Seq())
+  }
+
+  @Test
+  def testLocalGlobalWindowAggregateWithoutGroupingAndNamedProperties(): Unit = {
+    val data: Seq[Row] = Seq(
+      row(1, LocalDateTime.of(2021, 7, 26, 0, 0, 0)),
+      row(2, LocalDateTime.of(2021, 7, 26, 0, 0, 3)),
+      row(3, LocalDateTime.of(2021, 7, 26, 0, 0, 6)),
+      row(4, LocalDateTime.of(2021, 7, 26, 0, 0, 4)),
+      row(5, LocalDateTime.of(2021, 7, 26, 0, 0, 5)),
+      row(6, LocalDateTime.of(2021, 7, 26, 0, 0, 8)),
+      row(7, LocalDateTime.of(2021, 7, 26, 0, 0, 10)))
+    val dataId = TestValuesTableFactory.registerData(data)
+    val ddl =
+      s"""
+         |CREATE TABLE MyTable (
+         |  a INT,
+         |  ts TIMESTAMP
+         |) WITH (
+         |  'connector' = 'values',
+         |  'data-id' = '$dataId',
+         |  'bounded' = 'true'
+         |)
+         |""".stripMargin
+
+    tEnv.executeSql(ddl)
+    checkResult(
+      """
+        |SELECT sum(a) FROM MyTable
+        |GROUP BY
+        |TUMBLE(ts, interval '5' seconds)
+        |""".stripMargin,
+      Seq(row(14), row(7), row(7)))
   }
 }


### PR DESCRIPTION
(This PR is cherry-picked from #16591.)

## What is the purpose of the change

Currently generated code for window aggregate in batch jobs will not compile if the aggregation has no grouping keys or any named properties (such as tumble_start). This PR fixes this issue.

## Brief change log

 - Fix compile exception for window aggregate in batch jobs

## Verifying this change

This change added tests and can be verified by running the added tests.

## Does this pull request potentially affect one of the following parts:

  - Dependencies (does it add or upgrade a dependency): no
  - The public API, i.e., is any changed class annotated with `@Public(Evolving)`: no
  - The serializers: no
  - The runtime per-record code paths (performance sensitive): no
  - Anything that affects deployment or recovery: JobManager (and its components), Checkpointing, Kubernetes/Yarn, ZooKeeper: no
  - The S3 file system connector: no

## Documentation

  - Does this pull request introduce a new feature? no
  - If yes, how is the feature documented? not applicable
