### PR TITLE
[FLINK-22985][table-runtime-blink] Fix NullPointerException when comparing temporal type with invalid string literal

### DIFF
--- a/flink-table/flink-table-planner-blink/src/main/scala/org/apache/flink/table/planner/codegen/calls/ScalarOperatorGens.scala
+++ b/flink-table/flink-table-planner-blink/src/main/scala/org/apache/flink/table/planner/codegen/calls/ScalarOperatorGens.scala
@@ -25,9 +25,9 @@ import org.apache.flink.table.data.writer.{BinaryArrayWriter, BinaryRowWriter}
 import org.apache.flink.table.planner.codegen.CodeGenUtils.{binaryRowFieldSetAccess, binaryRowSetNull, binaryWriterWriteField, binaryWriterWriteNull, _}
 import org.apache.flink.table.planner.codegen.GenerateUtils._
 import org.apache.flink.table.planner.codegen.GeneratedExpression.{ALWAYS_NULL, NEVER_NULL, NO_CODE}
-import org.apache.flink.table.planner.codegen.{CodeGenException, CodeGeneratorContext, GeneratedExpression}
+import org.apache.flink.table.planner.codegen.{CodeGenException, CodeGenUtils, CodeGeneratorContext, GeneratedExpression}
 import org.apache.flink.table.planner.utils.JavaScalaConversionUtil.toScala
-import org.apache.flink.table.runtime.functions.SqlFunctionUtils
+import org.apache.flink.table.runtime.functions.{SqlDateTimeUtils, SqlFunctionUtils}
 import org.apache.flink.table.runtime.types.LogicalTypeDataTypeConverter.fromLogicalTypeToDataType
 import org.apache.flink.table.runtime.types.PlannerTypeUtils
 import org.apache.flink.table.runtime.types.PlannerTypeUtils.{isInteroperable, isPrimitive}
@@ -1956,14 +1956,37 @@ object ScalarOperatorGens {
       stringLiteral: GeneratedExpression,
       expectType: LogicalType): GeneratedExpression = {
     checkArgument(stringLiteral.literal)
-    val rightTerm = stringLiteral.resultTerm
+    if (java.lang.Boolean.valueOf(stringLiteral.nullTerm)) {
+      return generateNullLiteral(expectType, nullCheck = true)
+    }
+
+    val stringValue = stringLiteral.literalValue.get.toString
+    val literalCode = expectType.getTypeRoot match {
+      case DATE =>
+        SqlDateTimeUtils.dateStringToUnixDate(stringValue) match {
+          case null => throw new ValidationException(s"String '$stringValue' is not a valid date")
+          case v => v
+        }
+      case TIME_WITHOUT_TIME_ZONE =>
+        SqlDateTimeUtils.timeStringToUnixDate(stringValue) match {
+          case null => throw new ValidationException(s"String '$stringValue' is not a valid time")
+          case v => v
+        }
+      case TIMESTAMP_WITHOUT_TIME_ZONE =>
+        SqlDateTimeUtils.toTimestampData(stringValue) match {
+          case null =>
+            throw new ValidationException(s"String '$stringValue' is not a valid timestamp")
+          case v => s"${CodeGenUtils.TIMESTAMP_DATA}.fromEpochMillis(" +
+            s"${v.getMillisecond}L, ${v.getNanoOfMillisecond})"
+        }
+      case _ => throw new UnsupportedOperationException
+    }
+
     val typeTerm = primitiveTypeTermForType(expectType)
-    val defaultTerm = primitiveDefaultValue(expectType)
-    val term = newName("stringToTime")
-    val code = stringToLocalTimeCode(expectType, rightTerm)
-    val stmt = s"$typeTerm $term = ${stringLiteral.nullTerm} ? $defaultTerm : $code;"
+    val resultTerm = newName("stringToTime")
+    val stmt = s"$typeTerm $resultTerm = $literalCode;"
     ctx.addReusableMember(stmt)
-    stringLiteral.copy(resultType = expectType, resultTerm = term)
+    GeneratedExpression(resultTerm, "false", "", expectType)
   }
 
   private def generateCastArrayToString(
@@ -2390,21 +2413,6 @@ object ScalarOperatorGens {
       throw new CodeGenException(s"Unsupported casting from $operandType to $resultType.")
     }
   }
-
-  private def stringToLocalTimeCode(
-      targetType: LogicalType,
-      operandTerm: String): String =
-    targetType.getTypeRoot match {
-      case DATE =>
-        s"${qualifyMethod(BuiltInMethods.STRING_TO_DATE)}($operandTerm.toString())"
-      case TIME_WITHOUT_TIME_ZONE =>
-        s"${qualifyMethod(BuiltInMethods.STRING_TO_TIME)}($operandTerm.toString())"
-      case TIMESTAMP_WITHOUT_TIME_ZONE =>
-        s"""
-           |${qualifyMethod(BuiltInMethods.STRING_TO_TIMESTAMP)}($operandTerm.toString())
-           |""".stripMargin
-      case _ => throw new UnsupportedOperationException
-    }
 
   private def localTimeToStringCode(
       ctx: CodeGeneratorContext,

--- a/flink-table/flink-table-planner-blink/src/test/scala/org/apache/flink/table/planner/expressions/ScalarOperatorsTest.scala
+++ b/flink-table/flink-table-planner-blink/src/test/scala/org/apache/flink/table/planner/expressions/ScalarOperatorsTest.scala
@@ -198,4 +198,28 @@ class ScalarOperatorsTest extends ScalarOperatorsTestBase {
     testSqlApi("-f17", "-10.0")
     testSqlApi("+f17", "10.0")
   }
+
+  @Test
+  def testTemporalTypeEqualsStringLiteral(): Unit = {
+    testSqlApi("f15 = '1996-11-10'", "true")
+    testSqlApi("f15 = '1996-11-11'", "false")
+    testSqlApi("f15 = cast(null as string)", "null")
+    testSqlApi("'1996-11-10' = f15", "true")
+    testSqlApi("'1996-11-11' = f15", "false")
+    testSqlApi("cast(null as string) = f15", "null")
+
+    testSqlApi("f21 = '12:34:56'", "true")
+    testSqlApi("f21 = '13:34:56'", "false")
+    testSqlApi("f21 = cast(null as string)", "null")
+    testSqlApi("'12:34:56' = f21", "true")
+    testSqlApi("'13:34:56' = f21", "false")
+    testSqlApi("cast(null as string) = f21", "null")
+
+    testSqlApi("f22 = '1996-11-10 12:34:56'", "true")
+    testSqlApi("f22 = '1996-11-10 12:34:57'", "false")
+    testSqlApi("f22 = cast(null as string)", "null")
+    testSqlApi("'1996-11-10 12:34:56' = f22", "true")
+    testSqlApi("'1996-11-10 12:34:57' = f22", "false")
+    testSqlApi("cast(null as string) = f22", "null")
+  }
 }

--- a/flink-table/flink-table-planner-blink/src/test/scala/org/apache/flink/table/planner/expressions/utils/ScalarOperatorsTestBase.scala
+++ b/flink-table/flink-table-planner-blink/src/test/scala/org/apache/flink/table/planner/expressions/utils/ScalarOperatorsTestBase.scala
@@ -28,7 +28,7 @@ import org.apache.flink.types.Row
 abstract class ScalarOperatorsTestBase extends ExpressionTestBase {
 
   override def testData: Row = {
-    val testData = new Row(21)
+    val testData = new Row(23)
     testData.setField(0, 1: Byte)
     testData.setField(1, 1: Short)
     testData.setField(2, 1)
@@ -52,6 +52,8 @@ abstract class ScalarOperatorsTestBase extends ExpressionTestBase {
     testData.setField(18, "hello world".getBytes())
     testData.setField(19, "hello flink".getBytes())
     testData.setField(20, "who".getBytes())
+    testData.setField(21, localTime("12:34:56"))
+    testData.setField(22, localDateTime("1996-11-10 12:34:56"))
     testData
   }
 
@@ -80,7 +82,9 @@ abstract class ScalarOperatorsTestBase extends ExpressionTestBase {
         DataTypes.FIELD("f17", DataTypes.DECIMAL(19, 1)),
         DataTypes.FIELD("f18", DataTypes.BINARY(200)),
         DataTypes.FIELD("f19", DataTypes.VARBINARY(200)),
-        DataTypes.FIELD("f20", DataTypes.VARBINARY(200))
+        DataTypes.FIELD("f20", DataTypes.VARBINARY(200)),
+        DataTypes.FIELD("f21", DataTypes.TIME()),
+        DataTypes.FIELD("f22", DataTypes.TIMESTAMP())
     )
   }
 

--- a/flink-table/flink-table-planner-blink/src/test/scala/org/apache/flink/table/planner/expressions/validation/ScalarOperatorsValidationTest.scala
+++ b/flink-table/flink-table-planner-blink/src/test/scala/org/apache/flink/table/planner/expressions/validation/ScalarOperatorsValidationTest.scala
@@ -84,4 +84,28 @@ class ScalarOperatorsValidationTest extends ScalarOperatorsTestBase {
       "FAIL"
     )
   }
+
+  @Test
+  def testTemporalTypeEqualsInvalidStringLiteral(): Unit = {
+    testExpectedSqlException(
+      "f15 = 'invalid'", "is not a valid date",
+      classOf[ValidationException])
+    testExpectedSqlException(
+      "'invalid' = f15", "is not a valid date",
+      classOf[ValidationException])
+
+    testExpectedSqlException(
+      "f21 = 'invalid'", "is not a valid time",
+      classOf[ValidationException])
+    testExpectedSqlException(
+      "'invalid' = f21", "is not a valid time",
+      classOf[ValidationException])
+
+    testExpectedSqlException(
+      "f22 = 'invalid'", "is not a valid timestamp",
+      classOf[ValidationException])
+    testExpectedSqlException(
+      "'invalid' = f22", "is not a valid timestamp",
+      classOf[ValidationException])
+  }
 }


### PR DESCRIPTION
(This PR is cherry-picked from #16462.)

## What is the purpose of the change

Currently when comparing temporal type with invalid string literal, NullPointerException will be thrown as we'll first cast the string literal to the desired temporal type, resulting in a null value.

This PR fixes this issue.

In this PR, when the string literal is not in a valid date/time/timestamp format, an exception with message "String xxx is not a valid date/time/timestamp" will be thrown, otherwise the comparison code will be generated as normal.

The comparison result will be null if either operand is null, and will be true/false if both operands are not null.

## Brief change log

 - Fix NullPointerException when comparing temporal type with invalid string literal

## Verifying this change

This change added tests and can be verified by running the added tests.

## Does this pull request potentially affect one of the following parts:

  - Dependencies (does it add or upgrade a dependency): no
  - The public API, i.e., is any changed class annotated with `@Public(Evolving)`: no
  - The serializers: no
  - The runtime per-record code paths (performance sensitive): no
  - Anything that affects deployment or recovery: JobManager (and its components), Checkpointing, Kubernetes/Yarn, ZooKeeper: no
  - The S3 file system connector: no

## Documentation

  - Does this pull request introduce a new feature? no
  - If yes, how is the feature documented? not applicable
