### PR TITLE
[FLINK-23529][core] Add 1.13 & 1.14 MigrationVersion

### DIFF
--- a/flink-core/src/test/java/org/apache/flink/api/common/typeutils/TypeSerializerUpgradeTestBase.java
+++ b/flink-core/src/test/java/org/apache/flink/api/common/typeutils/TypeSerializerUpgradeTestBase.java
@@ -54,7 +54,7 @@ public abstract class TypeSerializerUpgradeTestBase<PreviousElementT, UpgradedEl
     public static final MigrationVersion[] MIGRATION_VERSIONS =
             MigrationVersion.v1_11.orHigher().toArray(new MigrationVersion[0]);
 
-    public static final MigrationVersion CURRENT_VERSION = MigrationVersion.v1_12;
+    public static final MigrationVersion CURRENT_VERSION = MigrationVersion.v1_14;
 
     private final TestSpecification<PreviousElementT, UpgradedElementT> testSpecification;
 

--- a/flink-core/src/test/java/org/apache/flink/testutils/migration/MigrationVersion.java
+++ b/flink-core/src/test/java/org/apache/flink/testutils/migration/MigrationVersion.java
@@ -44,7 +44,9 @@ public enum MigrationVersion {
     v1_9("1.9"),
     v1_10("1.10"),
     v1_11("1.11"),
-    v1_12("1.12");
+    v1_12("1.12"),
+    v1_13("1.13"),
+    v1_14("1.14");
 
     private final String versionStr;
 


### PR DESCRIPTION
## What is the purpose of the change

Currently the largest `MigrationVersion` is 1.12. We need newer versions to add more serializer compatibility tests.

This PR adds 1.13 & 1.14 `MigrationVersion`.

## Brief change log

- Add 1.13 & 1.14 MigrationVersion

## Verifying this change

This change is a trivial rework / code cleanup without any test coverage.

## Does this pull request potentially affect one of the following parts:

  - Dependencies (does it add or upgrade a dependency): no
  - The public API, i.e., is any changed class annotated with `@Public(Evolving)`: no
  - The serializers: no
  - The runtime per-record code paths (performance sensitive): no
  - Anything that affects deployment or recovery: JobManager (and its components), Checkpointing, Kubernetes/Yarn, ZooKeeper: no
  - The S3 file system connector: no

## Documentation

  - Does this pull request introduce a new feature? no
  - If yes, how is the feature documented? not applicable
