### PR TITLE
[FLINK-23498][table] Introduce a full PlannerConfiguration

### DIFF
--- a/flink-clients/src/main/java/org/apache/flink/client/program/StreamContextEnvironment.java
+++ b/flink-clients/src/main/java/org/apache/flink/client/program/StreamContextEnvironment.java
@@ -97,11 +97,11 @@ public class StreamContextEnvironment extends StreamExecutionEnvironment {
         checkNotNull(jobClient);
 
         JobExecutionResult jobExecutionResult;
-        if (getConfiguration().getBoolean(DeploymentOptions.ATTACHED)) {
+        if (configuration.getBoolean(DeploymentOptions.ATTACHED)) {
             CompletableFuture<JobExecutionResult> jobExecutionResultFuture =
                     jobClient.getJobExecutionResult();
 
-            if (getConfiguration().getBoolean(DeploymentOptions.SHUTDOWN_IF_ATTACHED)) {
+            if (configuration.getBoolean(DeploymentOptions.SHUTDOWN_IF_ATTACHED)) {
                 Thread shutdownHook =
                         ShutdownHookUtil.addShutdownHook(
                                 () -> {

--- a/flink-core/src/main/java/org/apache/flink/configuration/Configuration.java
+++ b/flink-core/src/main/java/org/apache/flink/configuration/Configuration.java
@@ -767,10 +767,6 @@ public class Configuration extends ExecutionConfig.GlobalJobParameters
 
     // --------------------------------------------------------------------------------------------
 
-    <T> void setValueInternal(String key, T value) {
-        setValueInternal(key, value, false);
-    }
-
     <T> void setValueInternal(String key, T value, boolean canBePrefixMap) {
         if (key == null) {
             throw new NullPointerException("Key must not be null.");
@@ -785,6 +781,10 @@ public class Configuration extends ExecutionConfig.GlobalJobParameters
             }
             this.confData.put(key, value);
         }
+    }
+
+    private <T> void setValueInternal(String key, T value) {
+        setValueInternal(key, value, false);
     }
 
     private Optional<Object> getRawValue(String key) {

--- a/flink-core/src/main/java/org/apache/flink/configuration/UnmodifiableConfiguration.java
+++ b/flink-core/src/main/java/org/apache/flink/configuration/UnmodifiableConfiguration.java
@@ -59,7 +59,7 @@ public class UnmodifiableConfiguration extends Configuration {
     }
 
     @Override
-    final <T> void setValueInternal(String key, T value) {
+    final <T> void setValueInternal(String key, T value, boolean canBePrefixMap) {
         error();
     }
 

--- a/flink-core/src/test/java/org/apache/flink/configuration/DelegatingConfigurationTest.java
+++ b/flink-core/src/test/java/org/apache/flink/configuration/DelegatingConfigurationTest.java
@@ -80,7 +80,7 @@ public class DelegatingConfigurationTest {
     @Test
     public void testDelegationConfigurationWithNullPrefix() {
         Configuration backingConf = new Configuration();
-        backingConf.setValueInternal("test-key", "value");
+        backingConf.setValueInternal("test-key", "value", false);
 
         DelegatingConfiguration configuration = new DelegatingConfiguration(backingConf, null);
         Set<String> keySet = configuration.keySet();
@@ -97,7 +97,7 @@ public class DelegatingConfigurationTest {
          * Key matches the prefix
          */
         Configuration backingConf = new Configuration();
-        backingConf.setValueInternal(prefix + expectedKey, "value");
+        backingConf.setValueInternal(prefix + expectedKey, "value", false);
 
         DelegatingConfiguration configuration = new DelegatingConfiguration(backingConf, prefix);
         Set<String> keySet = configuration.keySet();
@@ -109,7 +109,7 @@ public class DelegatingConfigurationTest {
          * Key does not match the prefix
          */
         backingConf = new Configuration();
-        backingConf.setValueInternal("test-key", "value");
+        backingConf.setValueInternal("test-key", "value", false);
 
         configuration = new DelegatingConfiguration(backingConf, prefix);
         keySet = configuration.keySet();

--- a/flink-python/pyflink/datastream/tests/test_data_stream.py
+++ b/flink-python/pyflink/datastream/tests/test_data_stream.py
@@ -40,16 +40,15 @@ from pyflink.datastream.window import (CountWindowSerializer, MergingWindowAssig
                                        TimeWindowSerializer)
 from pyflink.java_gateway import get_gateway
 from pyflink.datastream.tests.test_util import DataStreamTestSinkFunction
-from pyflink.testing.test_case_utils import invoke_java_object_method, \
-    PyFlinkBatchTestCase, PyFlinkStreamingTestCase
+from pyflink.testing.test_case_utils import PyFlinkBatchTestCase, PyFlinkStreamingTestCase
+from pyflink.util.java_utils import get_j_env_configuration
 
 
 class DataStreamTests(object):
 
     def setUp(self) -> None:
         super(DataStreamTests, self).setUp()
-        config = invoke_java_object_method(
-            self.env._j_stream_execution_environment, "getConfiguration")
+        config = get_j_env_configuration(self.env._j_stream_execution_environment)
         config.setString("akka.ask.timeout", "20 s")
         self.test_sink = DataStreamTestSinkFunction()
 

--- a/flink-python/pyflink/datastream/tests/test_stream_execution_environment.py
+++ b/flink-python/pyflink/datastream/tests/test_stream_execution_environment.py
@@ -42,8 +42,7 @@ from pyflink.java_gateway import get_gateway
 from pyflink.pyflink_gateway_server import on_windows
 from pyflink.table import DataTypes, CsvTableSource, CsvTableSink, StreamTableEnvironment, \
     EnvironmentSettings
-from pyflink.testing.test_case_utils import PyFlinkTestCase, exec_insert_table, \
-    invoke_java_object_method
+from pyflink.testing.test_case_utils import PyFlinkTestCase, exec_insert_table
 from pyflink.util.java_utils import get_j_env_configuration
 
 
@@ -129,8 +128,7 @@ class StreamExecutionEnvironmentTests(PyFlinkTestCase):
     def test_set_runtime_mode(self):
         self.env.set_runtime_mode(RuntimeExecutionMode.BATCH)
 
-        config = invoke_java_object_method(
-            self.env._j_stream_execution_environment, "getConfiguration")
+        config = get_j_env_configuration(self.env._j_stream_execution_environment)
         runtime_mode = config.getValue(
             get_gateway().jvm.org.apache.flink.configuration.ExecutionOptions.RUNTIME_MODE)
 

--- a/flink-python/pyflink/datastream/tests/test_stream_execution_environment_completeness.py
+++ b/flink-python/pyflink/datastream/tests/test_stream_execution_environment_completeness.py
@@ -48,7 +48,7 @@ class StreamExecutionEnvironmentCompletenessTests(PythonAPICompletenessTestCase,
                 'createInput', 'createLocalEnvironmentWithWebUI', 'fromCollection',
                 'socketTextStream', 'initializeContextEnvironment', 'readTextFile',
                 'setNumberOfExecutionRetries', 'configure', 'executeAsync', 'registerJobListener',
-                'clearJobListeners', 'getJobListeners', "fromSequence"}
+                'clearJobListeners', 'getJobListeners', 'fromSequence', 'getConfiguration'}
 
 
 if __name__ == '__main__':

--- a/flink-python/pyflink/table/tests/test_table_environment_api.py
+++ b/flink-python/pyflink/table/tests/test_table_environment_api.py
@@ -43,7 +43,7 @@ from pyflink.table.udf import udf
 from pyflink.testing import source_sink_utils
 from pyflink.testing.test_case_utils import (
     PyFlinkBatchTableTestCase, PyFlinkStreamTableTestCase, PyFlinkTestCase,
-    _load_specific_flink_module_jars, invoke_java_object_method)
+    _load_specific_flink_module_jars)
 from pyflink.util.java_utils import get_j_env_configuration
 
 
@@ -246,8 +246,7 @@ class DataStreamConversionTestCases(PyFlinkTestCase):
         self.t_env = StreamTableEnvironment.create(self.env)
 
         self.env.set_parallelism(2)
-        config = invoke_java_object_method(
-            self.env._j_stream_execution_environment, "getConfiguration")
+        config = get_j_env_configuration(self.env._j_stream_execution_environment)
         config.setString("akka.ask.timeout", "20 s")
         self.t_env.get_config().get_configuration().set_string(
             "python.fn-execution.bundle.size", "1")

--- a/flink-python/pyflink/util/java_utils.py
+++ b/flink-python/pyflink/util/java_utils.py
@@ -84,11 +84,11 @@ def get_j_env_configuration(j_env):
     if is_instance_of(j_env, "org.apache.flink.api.java.ExecutionEnvironment"):
         return j_env.getConfiguration()
     else:
-        return invoke_method(
-            j_env,
-            "org.apache.flink.streaming.api.environment.StreamExecutionEnvironment",
-            "getConfiguration"
-        )
+        env_clazz = load_java_class(
+            "org.apache.flink.streaming.api.environment.StreamExecutionEnvironment")
+        field = env_clazz.getDeclaredField("configuration")
+        field.setAccessible(True)
+        return field.get(j_env)
 
 
 def invoke_method(obj, object_type, method_name, args=None, arg_types=None):

--- a/flink-python/src/test/java/org/apache/flink/python/util/PythonConfigUtilTest.java
+++ b/flink-python/src/test/java/org/apache/flink/python/util/PythonConfigUtilTest.java
@@ -36,7 +36,7 @@ public class PythonConfigUtilTest {
 
     @Test
     public void testGetEnvironmentConfig()
-            throws IllegalAccessException, NoSuchMethodException, InvocationTargetException {
+            throws IllegalAccessException, NoSuchFieldException, InvocationTargetException {
         StreamExecutionEnvironment executionEnvironment =
                 StreamExecutionEnvironment.getExecutionEnvironment();
         Configuration envConfig =
@@ -46,8 +46,7 @@ public class PythonConfigUtilTest {
 
     @Test
     public void testJobName()
-            throws IllegalAccessException, NoSuchMethodException, InvocationTargetException,
-                    NoSuchFieldException {
+            throws IllegalAccessException, InvocationTargetException, NoSuchFieldException {
         String jobName = "MyTestJob";
         Configuration config = new Configuration();
         config.set(PipelineOptions.NAME, jobName);

--- a/flink-scala-shell/src/main/java/org/apache/flink/api/java/ScalaShellStreamEnvironment.java
+++ b/flink-scala-shell/src/main/java/org/apache/flink/api/java/ScalaShellStreamEnvironment.java
@@ -74,7 +74,6 @@ public class ScalaShellStreamEnvironment extends StreamExecutionEnvironment {
     }
 
     private void updateDependencies() throws Exception {
-        final Configuration configuration = getConfiguration();
         checkState(
                 configuration.getBoolean(DeploymentOptions.ATTACHED),
                 "Only ATTACHED mode is supported by the scala shell.");
@@ -85,7 +84,7 @@ public class ScalaShellStreamEnvironment extends StreamExecutionEnvironment {
     }
 
     public Configuration getClientConfiguration() {
-        return getConfiguration();
+        return configuration;
     }
 
     private List<URL> getUpdatedJarFiles() throws MalformedURLException {

--- a/flink-streaming-java/src/main/java/org/apache/flink/streaming/api/environment/RemoteStreamEnvironment.java
+++ b/flink-streaming-java/src/main/java/org/apache/flink/streaming/api/environment/RemoteStreamEnvironment.java
@@ -220,8 +220,8 @@ public class RemoteStreamEnvironment extends StreamExecutionEnvironment {
 
     @Override
     public String toString() {
-        final String host = getConfiguration().getString(JobManagerOptions.ADDRESS);
-        final int port = getConfiguration().getInteger(JobManagerOptions.PORT);
+        final String host = configuration.getString(JobManagerOptions.ADDRESS);
+        final int port = configuration.getInteger(JobManagerOptions.PORT);
         final String parallelism = (getParallelism() == -1 ? "default" : "" + getParallelism());
 
         return "Remote Environment ("
@@ -239,7 +239,7 @@ public class RemoteStreamEnvironment extends StreamExecutionEnvironment {
      * @return The hostname of the master
      */
     public String getHost() {
-        return getConfiguration().getString(JobManagerOptions.ADDRESS);
+        return configuration.getString(JobManagerOptions.ADDRESS);
     }
 
     /**
@@ -248,12 +248,12 @@ public class RemoteStreamEnvironment extends StreamExecutionEnvironment {
      * @return The port of the master
      */
     public int getPort() {
-        return getConfiguration().getInteger(JobManagerOptions.PORT);
+        return configuration.getInteger(JobManagerOptions.PORT);
     }
 
     /** @deprecated This method is going to be removed in the next releases. */
     @Deprecated
     public Configuration getClientConfiguration() {
-        return getConfiguration();
+        return configuration;
     }
 }

--- a/flink-streaming-java/src/main/java/org/apache/flink/streaming/api/environment/StreamExecutionEnvironment.java
+++ b/flink-streaming-java/src/main/java/org/apache/flink/streaming/api/environment/StreamExecutionEnvironment.java
@@ -61,6 +61,7 @@ import org.apache.flink.configuration.MemorySize;
 import org.apache.flink.configuration.PipelineOptions;
 import org.apache.flink.configuration.ReadableConfig;
 import org.apache.flink.configuration.RestOptions;
+import org.apache.flink.configuration.UnmodifiableConfiguration;
 import org.apache.flink.core.execution.DefaultExecutorServiceLoader;
 import org.apache.flink.core.execution.DetachedJobExecutionResult;
 import org.apache.flink.core.execution.JobClient;
@@ -2185,6 +2186,22 @@ public class StreamExecutionEnvironment {
     public void addOperator(Transformation<?> transformation) {
         Preconditions.checkNotNull(transformation, "transformation must not be null.");
         this.transformations.add(transformation);
+    }
+
+    /**
+     * Gives read-only access to the underlying configuration of this environment.
+     *
+     * <p>Note that the returned configuration might not be complete. It only contains options that
+     * have initialized the environment via {@link #StreamExecutionEnvironment(Configuration)} or
+     * options that are not represented in dedicated configuration classes such as {@link
+     * ExecutionConfig} or {@link CheckpointConfig}.
+     *
+     * <p>Use {@link #configure(ReadableConfig, ClassLoader)} to set options that are specific to
+     * this environment.
+     */
+    @Internal
+    public ReadableConfig getConfiguration() {
+        return new UnmodifiableConfiguration(configuration);
     }
 
     // --------------------------------------------------------------------------------------------

--- a/flink-streaming-java/src/main/java/org/apache/flink/streaming/api/environment/StreamExecutionEnvironment.java
+++ b/flink-streaming-java/src/main/java/org/apache/flink/streaming/api/environment/StreamExecutionEnvironment.java
@@ -939,6 +939,21 @@ public class StreamExecutionEnvironment {
      * configuration}. If a key is not present, the current value of a field will remain untouched.
      *
      * @param configuration a configuration to read the values from
+     */
+    @PublicEvolving
+    public void configure(ReadableConfig configuration) {
+        configure(configuration, userClassloader);
+    }
+
+    /**
+     * Sets all relevant options contained in the {@link ReadableConfig} such as e.g. {@link
+     * StreamPipelineOptions#TIME_CHARACTERISTIC}. It will reconfigure {@link
+     * StreamExecutionEnvironment}, {@link ExecutionConfig} and {@link CheckpointConfig}.
+     *
+     * <p>It will change the value of a setting only if a corresponding option was set in the {@code
+     * configuration}. If a key is not present, the current value of a field will remain untouched.
+     *
+     * @param configuration a configuration to read the values from
      * @param classLoader a class loader to use when loading classes
      */
     @PublicEvolving

--- a/flink-streaming-scala/src/main/scala/org/apache/flink/streaming/api/scala/StreamExecutionEnvironment.scala
+++ b/flink-streaming-scala/src/main/scala/org/apache/flink/streaming/api/scala/StreamExecutionEnvironment.scala
@@ -572,6 +572,24 @@ class StreamExecutionEnvironment(javaEnv: JavaEnv) {
     javaEnv.configure(configuration, classLoader)
   }
 
+  /**
+   * Sets all relevant options contained in the [[ReadableConfig]] such as e.g.
+   * [[org.apache.flink.streaming.api.environment.StreamPipelineOptions#TIME_CHARACTERISTIC]].
+   * It will reconfigure [[StreamExecutionEnvironment]],
+   * [[org.apache.flink.api.common.ExecutionConfig]] and
+   * [[org.apache.flink.streaming.api.environment.CheckpointConfig]].
+   *
+   * It will change the value of a setting only if a corresponding option was set in the
+   * `configuration`. If a key is not present, the current value of a field will remain
+   * untouched.
+   *
+   * @param configuration a configuration to read the values from
+   */
+  @PublicEvolving
+  def configure(configuration: ReadableConfig): Unit = {
+    javaEnv.configure(configuration)
+  }
+
   // --------------------------------------------------------------------------------------------
   // Data stream creations
   // --------------------------------------------------------------------------------------------

--- a/flink-streaming-scala/src/main/scala/org/apache/flink/streaming/api/scala/StreamExecutionEnvironment.scala
+++ b/flink-streaming-scala/src/main/scala/org/apache/flink/streaming/api/scala/StreamExecutionEnvironment.scala
@@ -18,17 +18,15 @@
 
 package org.apache.flink.streaming.api.scala
 
-import java.net.URI
-import com.esotericsoftware.kryo.Serializer
 import org.apache.flink.annotation.{Experimental, Internal, Public, PublicEvolving}
-import org.apache.flink.api.common.RuntimeExecutionMode
+import org.apache.flink.api.common.{ExecutionConfig, RuntimeExecutionMode}
 import org.apache.flink.api.common.eventtime.WatermarkStrategy
 import org.apache.flink.api.common.io.{FileInputFormat, FilePathFilter, InputFormat}
 import org.apache.flink.api.common.operators.SlotSharingGroup
 import org.apache.flink.api.common.restartstrategy.RestartStrategies.RestartStrategyConfiguration
 import org.apache.flink.api.common.typeinfo.TypeInformation
-import org.apache.flink.api.connector.source.{Source, SourceSplit}
 import org.apache.flink.api.connector.source.lib.NumberSequenceSource
+import org.apache.flink.api.connector.source.{Source, SourceSplit}
 import org.apache.flink.api.java.typeutils.ResultTypeQueryable
 import org.apache.flink.api.java.typeutils.runtime.kryo.KryoSerializer
 import org.apache.flink.api.scala.ClosureCleaner
@@ -36,11 +34,15 @@ import org.apache.flink.configuration.{Configuration, ReadableConfig}
 import org.apache.flink.core.execution.{JobClient, JobListener}
 import org.apache.flink.core.fs.Path
 import org.apache.flink.runtime.state.StateBackend
-import org.apache.flink.streaming.api.environment.{StreamExecutionEnvironment => JavaEnv}
+import org.apache.flink.streaming.api.environment.{CheckpointConfig, StreamExecutionEnvironment => JavaEnv}
 import org.apache.flink.streaming.api.functions.source.SourceFunction.SourceContext
 import org.apache.flink.streaming.api.functions.source._
 import org.apache.flink.streaming.api.{CheckpointingMode, TimeCharacteristic}
 import org.apache.flink.util.{SplittableIterator, TernaryBoolean}
+
+import com.esotericsoftware.kryo.Serializer
+
+import java.net.URI
 
 import _root_.scala.language.implicitConversions
 import scala.collection.JavaConverters._
@@ -959,8 +961,20 @@ class StreamExecutionEnvironment(javaEnv: JavaEnv) {
     javaEnv.getStreamGraph(jobName, clearTransformations)
 
   /**
+   * Gives read-only access to the underlying configuration of this environment.
+   *
+   * Note that the returned configuration might not be complete. It only contains options that
+   * have initialized the environment or options that are not represented in dedicated configuration
+   * classes such as [[ExecutionConfig]] or [[CheckpointConfig]].
+   *
+   * Use [[configure]] to set options that are specific to this environment.
+   */
+  @Internal
+  def getConfiguration: ReadableConfig = javaEnv.getConfiguration
+
+  /**
    * Getter of the wrapped [[org.apache.flink.streaming.api.environment.StreamExecutionEnvironment]]
- *
+   *
    * @return The encased ExecutionEnvironment
    */
   @Internal

--- a/flink-table/flink-table-api-java-bridge/src/main/java/org/apache/flink/table/api/bridge/java/internal/StreamTableEnvironmentImpl.java
+++ b/flink-table/flink-table-api-java-bridge/src/main/java/org/apache/flink/table/api/bridge/java/internal/StreamTableEnvironmentImpl.java
@@ -445,8 +445,11 @@ public final class StreamTableEnvironmentImpl extends TableEnvironmentImpl
                 planner.translate(Collections.singletonList(modifyOperation));
 
         final Transformation<T> transformation = getTransformation(table, transformations);
-
         executionEnvironment.addOperator(transformation);
+
+        // reconfigure whenever planner transformations are added
+        executionEnvironment.configure(tableConfig.getConfiguration());
+
         return new DataStream<>(executionEnvironment, transformation);
     }
 

--- a/flink-table/flink-table-api-java/src/main/java/org/apache/flink/table/delegation/Executor.java
+++ b/flink-table/flink-table-api-java/src/main/java/org/apache/flink/table/delegation/Executor.java
@@ -22,7 +22,7 @@ import org.apache.flink.annotation.Internal;
 import org.apache.flink.api.common.JobExecutionResult;
 import org.apache.flink.api.dag.Pipeline;
 import org.apache.flink.api.dag.Transformation;
-import org.apache.flink.configuration.Configuration;
+import org.apache.flink.configuration.ReadableConfig;
 import org.apache.flink.core.execution.JobClient;
 import org.apache.flink.table.api.TableEnvironment;
 
@@ -33,10 +33,17 @@ import java.util.List;
  *
  * <p>This uncouples the {@link TableEnvironment} from any given runtime.
  *
+ * <p>Note that not every table program calls {@link #createPipeline(List, ReadableConfig, String)}
+ * or {@link #execute(Pipeline)}. When bridging to DataStream API, this interface serves as a
+ * communication layer to the final pipeline executor via {@code StreamExecutionEnvironment}.
+ *
  * @see ExecutorFactory
  */
 @Internal
 public interface Executor {
+
+    /** Gives read-only access to the configuration of the executor. */
+    ReadableConfig getConfiguration();
 
     /**
      * Translates the given transformations to a {@link Pipeline}.
@@ -47,7 +54,7 @@ public interface Executor {
      * @return The pipeline representing the transformations.
      */
     Pipeline createPipeline(
-            List<Transformation<?>> transformations, Configuration configuration, String jobName);
+            List<Transformation<?>> transformations, ReadableConfig configuration, String jobName);
 
     /**
      * Executes the given pipeline.

--- a/flink-table/flink-table-api-java/src/test/java/org/apache/flink/table/utils/ExecutorMock.java
+++ b/flink-table/flink-table-api-java/src/test/java/org/apache/flink/table/utils/ExecutorMock.java
@@ -21,7 +21,7 @@ package org.apache.flink.table.utils;
 import org.apache.flink.api.common.JobExecutionResult;
 import org.apache.flink.api.dag.Pipeline;
 import org.apache.flink.api.dag.Transformation;
-import org.apache.flink.configuration.Configuration;
+import org.apache.flink.configuration.ReadableConfig;
 import org.apache.flink.core.execution.JobClient;
 import org.apache.flink.table.delegation.Executor;
 
@@ -31,8 +31,13 @@ import java.util.List;
 public class ExecutorMock implements Executor {
 
     @Override
+    public ReadableConfig getConfiguration() {
+        return null;
+    }
+
+    @Override
     public Pipeline createPipeline(
-            List<Transformation<?>> transformations, Configuration configuration, String jobName) {
+            List<Transformation<?>> transformations, ReadableConfig configuration, String jobName) {
         return null;
     }
 

--- a/flink-table/flink-table-planner/src/main/java/org/apache/flink/table/planner/delegation/DefaultExecutor.java
+++ b/flink-table/flink-table-planner/src/main/java/org/apache/flink/table/planner/delegation/DefaultExecutor.java
@@ -23,8 +23,8 @@ import org.apache.flink.api.common.JobExecutionResult;
 import org.apache.flink.api.common.RuntimeExecutionMode;
 import org.apache.flink.api.dag.Pipeline;
 import org.apache.flink.api.dag.Transformation;
-import org.apache.flink.configuration.Configuration;
 import org.apache.flink.configuration.ExecutionOptions;
+import org.apache.flink.configuration.ReadableConfig;
 import org.apache.flink.core.execution.JobClient;
 import org.apache.flink.streaming.api.environment.StreamExecutionEnvironment;
 import org.apache.flink.streaming.api.graph.StreamGraph;
@@ -52,8 +52,18 @@ public class DefaultExecutor implements Executor {
     }
 
     @Override
+    public ReadableConfig getConfiguration() {
+        return executionEnvironment.getConfiguration();
+    }
+
+    @Override
     public Pipeline createPipeline(
-            List<Transformation<?>> transformations, Configuration configuration, String jobName) {
+            List<Transformation<?>> transformations, ReadableConfig configuration, String jobName) {
+
+        // reconfigure before a stream graph is generated
+        executionEnvironment.configure(configuration);
+
+        // create stream graph
         final RuntimeExecutionMode mode = configuration.get(ExecutionOptions.RUNTIME_MODE);
         final StreamGraph graph;
         switch (mode) {
@@ -82,7 +92,7 @@ public class DefaultExecutor implements Executor {
     }
 
     private StreamGraph createBatchGraph(
-            List<Transformation<?>> transformations, Configuration configuration) {
+            List<Transformation<?>> transformations, ReadableConfig configuration) {
         ExecutorUtils.setBatchProperties(executionEnvironment);
         StreamGraph graph =
                 ExecutorUtils.generateStreamGraph(executionEnvironment, transformations);

--- a/flink-table/flink-table-planner/src/main/java/org/apache/flink/table/planner/delegation/PlannerConfiguration.java
+++ b/flink-table/flink-table-planner/src/main/java/org/apache/flink/table/planner/delegation/PlannerConfiguration.java
@@ -1,0 +1,56 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.flink.table.planner.delegation;
+
+import org.apache.flink.annotation.Internal;
+import org.apache.flink.configuration.ConfigOption;
+import org.apache.flink.configuration.ReadableConfig;
+
+import java.util.Optional;
+
+/**
+ * Configuration view that combines the API specific table configuration and the executor
+ * configuration. The table configuration has precedence.
+ */
+@Internal
+public final class PlannerConfiguration implements ReadableConfig {
+
+    private final ReadableConfig tableConfig;
+
+    private final ReadableConfig executorConfig;
+
+    PlannerConfiguration(ReadableConfig tableConfig, ReadableConfig executorConfig) {
+        this.tableConfig = tableConfig;
+        this.executorConfig = executorConfig;
+    }
+
+    @Override
+    public <T> T get(ConfigOption<T> option) {
+        return tableConfig.getOptional(option).orElseGet(() -> executorConfig.get(option));
+    }
+
+    @Override
+    public <T> Optional<T> getOptional(ConfigOption<T> option) {
+        final Optional<T> tableValue = tableConfig.getOptional(option);
+        if (tableValue.isPresent()) {
+            return tableValue;
+        }
+        return executorConfig.getOptional(option);
+    }
+}

--- a/flink-table/flink-table-planner/src/main/java/org/apache/flink/table/planner/plan/nodes/exec/batch/BatchExecExchange.java
+++ b/flink-table/flink-table-planner/src/main/java/org/apache/flink/table/planner/plan/nodes/exec/batch/BatchExecExchange.java
@@ -141,8 +141,7 @@ public class BatchExecExchange extends CommonExecExchange implements BatchExecNo
         }
 
         final StreamExchangeMode exchangeMode =
-                getBatchStreamExchangeMode(
-                        planner.getTableConfig().getConfiguration(), requiredExchangeMode);
+                getBatchStreamExchangeMode(planner.getConfiguration(), requiredExchangeMode);
         final Transformation<RowData> transformation =
                 new PartitionTransformation<>(inputTransform, partitioner, exchangeMode);
         transformation.setParallelism(parallelism);

--- a/flink-table/flink-table-planner/src/main/java/org/apache/flink/table/planner/plan/nodes/exec/processor/DeadlockBreakupProcessor.java
+++ b/flink-table/flink-table-planner/src/main/java/org/apache/flink/table/planner/plan/nodes/exec/processor/DeadlockBreakupProcessor.java
@@ -44,7 +44,7 @@ public class DeadlockBreakupProcessor implements ExecNodeGraphProcessor {
                         execGraph.getRootNodes(),
                         InputProperty.DamBehavior.END_INPUT,
                         StreamExchangeMode.BATCH,
-                        context.getPlanner().getTableConfig().getConfiguration());
+                        context.getPlanner().getConfiguration());
         resolver.detectAndResolve();
         return execGraph;
     }

--- a/flink-table/flink-table-planner/src/main/java/org/apache/flink/table/planner/plan/nodes/exec/processor/MultipleInputNodeCreationProcessor.java
+++ b/flink-table/flink-table-planner/src/main/java/org/apache/flink/table/planner/plan/nodes/exec/processor/MultipleInputNodeCreationProcessor.java
@@ -79,7 +79,7 @@ public class MultipleInputNodeCreationProcessor implements ExecNodeGraphProcesso
                             execGraph.getRootNodes(),
                             InputProperty.DamBehavior.BLOCKING,
                             StreamExchangeMode.PIPELINED,
-                            context.getPlanner().getTableConfig().getConfiguration());
+                            context.getPlanner().getConfiguration());
             resolver.detectAndResolve();
         }
 

--- a/flink-table/flink-table-planner/src/main/java/org/apache/flink/table/planner/plan/nodes/exec/processor/utils/InputPriorityConflictResolver.java
+++ b/flink-table/flink-table-planner/src/main/java/org/apache/flink/table/planner/plan/nodes/exec/processor/utils/InputPriorityConflictResolver.java
@@ -19,7 +19,7 @@
 package org.apache.flink.table.planner.plan.nodes.exec.processor.utils;
 
 import org.apache.flink.annotation.Internal;
-import org.apache.flink.configuration.Configuration;
+import org.apache.flink.configuration.ReadableConfig;
 import org.apache.flink.streaming.api.transformations.StreamExchangeMode;
 import org.apache.flink.table.planner.plan.nodes.exec.ExecEdge;
 import org.apache.flink.table.planner.plan.nodes.exec.ExecNode;
@@ -43,7 +43,7 @@ import static org.apache.flink.table.planner.utils.StreamExchangeModeUtils.getBa
 public class InputPriorityConflictResolver extends InputPriorityGraphGenerator {
 
     private final StreamExchangeMode exchangeMode;
-    private final Configuration configuration;
+    private final ReadableConfig configuration;
 
     /**
      * Create a {@link InputPriorityConflictResolver} for the given {@link ExecNode} graph.
@@ -58,7 +58,7 @@ public class InputPriorityConflictResolver extends InputPriorityGraphGenerator {
             List<ExecNode<?>> roots,
             InputProperty.DamBehavior safeDamBehavior,
             StreamExchangeMode exchangeMode,
-            Configuration configuration) {
+            ReadableConfig configuration) {
         super(roots, Collections.emptySet(), safeDamBehavior);
         this.exchangeMode = exchangeMode;
         this.configuration = configuration;

--- a/flink-table/flink-table-planner/src/main/java/org/apache/flink/table/planner/utils/ExecutorUtils.java
+++ b/flink-table/flink-table-planner/src/main/java/org/apache/flink/table/planner/utils/ExecutorUtils.java
@@ -22,8 +22,8 @@ import org.apache.flink.api.common.ExecutionConfig;
 import org.apache.flink.api.common.ShuffleMode;
 import org.apache.flink.api.common.operators.ResourceSpec;
 import org.apache.flink.api.dag.Transformation;
-import org.apache.flink.configuration.Configuration;
 import org.apache.flink.configuration.ExecutionOptions;
+import org.apache.flink.configuration.ReadableConfig;
 import org.apache.flink.runtime.jobgraph.JobType;
 import org.apache.flink.streaming.api.environment.StreamExecutionEnvironment;
 import org.apache.flink.streaming.api.graph.GlobalStreamExchangeMode;
@@ -68,7 +68,7 @@ public class ExecutorUtils {
     }
 
     /** Sets batch properties for {@link StreamGraph}. */
-    public static void setBatchProperties(StreamGraph streamGraph, Configuration configuration) {
+    public static void setBatchProperties(StreamGraph streamGraph, ReadableConfig configuration) {
         streamGraph
                 .getStreamNodes()
                 .forEach(sn -> sn.setResources(ResourceSpec.UNKNOWN, ResourceSpec.UNKNOWN));

--- a/flink-table/flink-table-planner/src/main/scala/org/apache/flink/table/planner/delegation/BatchPlanner.scala
+++ b/flink-table/flink-table-planner/src/main/scala/org/apache/flink/table/planner/delegation/BatchPlanner.scala
@@ -167,9 +167,9 @@ class BatchPlanner(
   }
 
   override def validateAndOverrideConfiguration(): Unit = {
-    super.validateAndOverrideConfiguration();
-    if (!config.getConfiguration.get(ExecutionOptions.RUNTIME_MODE)
-      .equals(RuntimeExecutionMode.BATCH)) {
+    super.validateAndOverrideConfiguration()
+    val runtimeMode = getConfiguration.get(ExecutionOptions.RUNTIME_MODE)
+    if (runtimeMode != RuntimeExecutionMode.BATCH) {
       throw new IllegalArgumentException(
         "Mismatch between configured runtime mode and actual runtime mode. " +
           "Currently, the 'execution.runtime-mode' can only be set when instantiating the " +

--- a/flink-table/flink-table-planner/src/main/scala/org/apache/flink/table/planner/delegation/PlannerBase.scala
+++ b/flink-table/flink-table-planner/src/main/scala/org/apache/flink/table/planner/delegation/PlannerBase.scala
@@ -103,8 +103,6 @@ abstract class PlannerBase(
       getTraitDefs.toList
     )
 
-  private val sqlExprToRexConverterFactory = plannerContext.getSqlExprToRexConverterFactory
-
   /** Returns the [[FlinkRelBuilder]] of this TableEnvironment. */
   private[flink] def getRelBuilder: FlinkRelBuilder = {
     val currentCatalogName = catalogManager.getCurrentCatalog

--- a/flink-table/flink-table-planner/src/main/scala/org/apache/flink/table/planner/delegation/PlannerBase.scala
+++ b/flink-table/flink-table-planner/src/main/scala/org/apache/flink/table/planner/delegation/PlannerBase.scala
@@ -20,6 +20,7 @@ package org.apache.flink.table.planner.delegation
 
 import org.apache.flink.annotation.VisibleForTesting
 import org.apache.flink.api.dag.Transformation
+import org.apache.flink.configuration.{Configuration, ReadableConfig}
 import org.apache.flink.streaming.api.environment.StreamExecutionEnvironment
 import org.apache.flink.table.api.config.{ExecutionConfigOptions, TableConfigOptions}
 import org.apache.flink.table.api.{PlannerType, SqlDialect, TableConfig, TableEnvironment, TableException}
@@ -93,6 +94,10 @@ abstract class PlannerBase(
   private var parser: Parser = _
   private var currentDialect: SqlDialect = getTableConfig.getSqlDialect
 
+  private val plannerConfiguration: ReadableConfig = new PlannerConfiguration(
+    config.getConfiguration,
+    executor.getConfiguration)
+
   @VisibleForTesting
   private[flink] val plannerContext: PlannerContext =
     new PlannerContext(
@@ -131,9 +136,21 @@ abstract class PlannerBase(
 
   def getFlinkContext: FlinkContext = plannerContext.getFlinkContext
 
+  /**
+   * Gives access to both API specific table configuration and executor configuration.
+   *
+   * This configuration should be the main source of truth in the planner module.
+   */
+  def getConfiguration: ReadableConfig = plannerConfiguration
+
+  /**
+   * @deprecated Do not use this method anymore. Use [[getConfiguration]] to access options.
+   *             Create transformations without it. A [[StreamExecutionEnvironment]] is a mixture
+   *             of executor and stream graph generator/builder. In the long term, we would like
+   *             to avoid the need for it in the planner module.
+   */
+  @deprecated
   private[flink] def getExecEnv: StreamExecutionEnvironment = {
-    // this is technical debt that we should fix with a proper configuration story
-    // ideally, everything should be configurable via Configuration
     executor.asInstanceOf[DefaultExecutor].getExecutionEnvironment
   }
 

--- a/flink-table/flink-table-planner/src/main/scala/org/apache/flink/table/planner/delegation/StreamPlanner.scala
+++ b/flink-table/flink-table-planner/src/main/scala/org/apache/flink/table/planner/delegation/StreamPlanner.scala
@@ -176,8 +176,8 @@ class StreamPlanner(
 
   override def validateAndOverrideConfiguration(): Unit = {
     super.validateAndOverrideConfiguration()
-    if (!config.getConfiguration.get(ExecutionOptions.RUNTIME_MODE)
-      .equals(RuntimeExecutionMode.STREAMING)) {
+    val runtimeMode = getConfiguration.get(ExecutionOptions.RUNTIME_MODE)
+    if (runtimeMode != RuntimeExecutionMode.STREAMING) {
       throw new IllegalArgumentException(
         "Mismatch between configured runtime mode and actual runtime mode. " +
           "Currently, the 'execution.runtime-mode' can only be set when instantiating the " +


### PR DESCRIPTION
## What is the purpose of the change

This a preparation for enabling batch mode in FLINK-20897. It is an MVP version of a layered configuration of Executor and Table API.

It mostly clarifies concepts without fully reworking the stack. This should be future work.

## Brief change log

- Expose the executor config via `StreamExecutionEnvironment`
- Merge executor config and table config to a unified configuration for the planner module
- Access unified config e.g. for stream exchange mode.

## Verifying this change

This change is already covered by existing tests.

An additional test can be enabled once we pass the configuration to the stream graph generator.

## Does this pull request potentially affect one of the following parts:

  - Dependencies (does it add or upgrade a dependency): no
  - The public API, i.e., is any changed class annotated with `@Public(Evolving)`: yes
  - The serializers: no
  - The runtime per-record code paths (performance sensitive): no
  - Anything that affects deployment or recovery: JobManager (and its components), Checkpointing, Kubernetes/Yarn, ZooKeeper: no
  - The S3 file system connector: no

## Documentation

  - Does this pull request introduce a new feature? no
  - If yes, how is the feature documented? not applicable
