### PR TITLE
[FLINK-23453][streaming] Created the buffer size calculator for the ability to automatically change the buffer size based on the throughput. 

### DIFF
--- a/docs/layouts/shortcodes/generated/all_taskmanager_network_section.html
+++ b/docs/layouts/shortcodes/generated/all_taskmanager_network_section.html
@@ -27,22 +27,22 @@
             <td>Boolean flag to enable/disable more detailed metrics about inbound/outbound network queue lengths.</td>
         </tr>
         <tr>
-            <td><h5>taskmanager.network.memory.automatic-buffer-adjustment.period</h5></td>
-            <td style="word-wrap: break-word;">500</td>
-            <td>Integer</td>
-            <td>The minimum period of time after which the buffer size will be automatically adjusted to a new value if required. The low value provides a fast reaction to the load fluctuation but can influence the performance.</td>
-        </tr>
-        <tr>
-            <td><h5>taskmanager.network.memory.automatic-buffer-adjustment.samples</h5></td>
-            <td style="word-wrap: break-word;">20</td>
-            <td>Integer</td>
-            <td>The number of the last buffer size values that will be taken for the correct calculation of the new one.</td>
-        </tr>
-        <tr>
             <td><h5>taskmanager.network.memory.buffer-debloat.enabled</h5></td>
             <td style="word-wrap: break-word;">false</td>
             <td>Boolean</td>
             <td>The switch of the automatic buffered debloating feature. If enabled the amount of in-flight data will be adjusted automatically accordingly to the measured throughput.</td>
+        </tr>
+        <tr>
+            <td><h5>taskmanager.network.memory.buffer-debloat.period</h5></td>
+            <td style="word-wrap: break-word;">500 ms</td>
+            <td>Duration</td>
+            <td>The minimum period of time after which the buffer size will be debloated if required. The low value provides a fast reaction to the load fluctuation but can influence the performance.</td>
+        </tr>
+        <tr>
+            <td><h5>taskmanager.network.memory.buffer-debloat.samples</h5></td>
+            <td style="word-wrap: break-word;">20</td>
+            <td>Integer</td>
+            <td>The number of the last buffer size values that will be taken for the correct calculation of the new one.</td>
         </tr>
         <tr>
             <td><h5>taskmanager.network.memory.buffer-debloat.target</h5></td>

--- a/docs/layouts/shortcodes/generated/all_taskmanager_network_section.html
+++ b/docs/layouts/shortcodes/generated/all_taskmanager_network_section.html
@@ -39,6 +39,24 @@
             <td>The number of the last buffer size values that will be taken for the correct calculation of the new one.</td>
         </tr>
         <tr>
+            <td><h5>taskmanager.network.memory.buffer-debloat.enabled</h5></td>
+            <td style="word-wrap: break-word;">false</td>
+            <td>Boolean</td>
+            <td>The switch of the automatic buffered debloating feature. If enabled the amount of in-flight data will be adjusted automatically accordingly to the measured throughput.</td>
+        </tr>
+        <tr>
+            <td><h5>taskmanager.network.memory.buffer-debloat.target</h5></td>
+            <td style="word-wrap: break-word;">1 s</td>
+            <td>Duration</td>
+            <td>The target total time after which buffered in-flight data should be fully consumed. This configuration option will be used, in combination with the measured throughput, to adjust the amount of in-flight data.</td>
+        </tr>
+        <tr>
+            <td><h5>taskmanager.network.memory.buffer-debloat.threshold-percentages</h5></td>
+            <td style="word-wrap: break-word;">50</td>
+            <td>Integer</td>
+            <td>The minimum difference in percentage between the newly calculated buffer size and the old one to announce the new value. Can be used to avoid constant back and forth small adjustments.</td>
+        </tr>
+        <tr>
             <td><h5>taskmanager.network.memory.buffers-per-channel</h5></td>
             <td style="word-wrap: break-word;">2</td>
             <td>Integer</td>

--- a/docs/layouts/shortcodes/generated/all_taskmanager_section.html
+++ b/docs/layouts/shortcodes/generated/all_taskmanager_section.html
@@ -63,6 +63,12 @@
             <td>Whether to kill the TaskManager when the task thread throws an OutOfMemoryError.</td>
         </tr>
         <tr>
+            <td><h5>taskmanager.memory.min-segment-size</h5></td>
+            <td style="word-wrap: break-word;">1 kb</td>
+            <td>MemorySize</td>
+            <td>Minimum possible size of memory buffers used by the network stack and the memory manager. ex. can be used for automatic buffer size adjustment.</td>
+        </tr>
+        <tr>
             <td><h5>taskmanager.memory.segment-size</h5></td>
             <td style="word-wrap: break-word;">32 kb</td>
             <td>MemorySize</td>

--- a/docs/layouts/shortcodes/generated/task_manager_configuration.html
+++ b/docs/layouts/shortcodes/generated/task_manager_configuration.html
@@ -64,22 +64,22 @@
 <ul><li>"name" - uses hostname as binding address</li><li>"ip" - uses host's ip address as binding address</li></ul></td>
         </tr>
         <tr>
-            <td><h5>taskmanager.network.memory.automatic-buffer-adjustment.period</h5></td>
-            <td style="word-wrap: break-word;">500</td>
-            <td>Integer</td>
-            <td>The minimum period of time after which the buffer size will be automatically adjusted to a new value if required. The low value provides a fast reaction to the load fluctuation but can influence the performance.</td>
-        </tr>
-        <tr>
-            <td><h5>taskmanager.network.memory.automatic-buffer-adjustment.samples</h5></td>
-            <td style="word-wrap: break-word;">20</td>
-            <td>Integer</td>
-            <td>The number of the last buffer size values that will be taken for the correct calculation of the new one.</td>
-        </tr>
-        <tr>
             <td><h5>taskmanager.network.memory.buffer-debloat.enabled</h5></td>
             <td style="word-wrap: break-word;">false</td>
             <td>Boolean</td>
             <td>The switch of the automatic buffered debloating feature. If enabled the amount of in-flight data will be adjusted automatically accordingly to the measured throughput.</td>
+        </tr>
+        <tr>
+            <td><h5>taskmanager.network.memory.buffer-debloat.period</h5></td>
+            <td style="word-wrap: break-word;">500 ms</td>
+            <td>Duration</td>
+            <td>The minimum period of time after which the buffer size will be debloated if required. The low value provides a fast reaction to the load fluctuation but can influence the performance.</td>
+        </tr>
+        <tr>
+            <td><h5>taskmanager.network.memory.buffer-debloat.samples</h5></td>
+            <td style="word-wrap: break-word;">20</td>
+            <td>Integer</td>
+            <td>The number of the last buffer size values that will be taken for the correct calculation of the new one.</td>
         </tr>
         <tr>
             <td><h5>taskmanager.network.memory.buffer-debloat.target</h5></td>

--- a/docs/layouts/shortcodes/generated/task_manager_configuration.html
+++ b/docs/layouts/shortcodes/generated/task_manager_configuration.html
@@ -76,6 +76,24 @@
             <td>The number of the last buffer size values that will be taken for the correct calculation of the new one.</td>
         </tr>
         <tr>
+            <td><h5>taskmanager.network.memory.buffer-debloat.enabled</h5></td>
+            <td style="word-wrap: break-word;">false</td>
+            <td>Boolean</td>
+            <td>The switch of the automatic buffered debloating feature. If enabled the amount of in-flight data will be adjusted automatically accordingly to the measured throughput.</td>
+        </tr>
+        <tr>
+            <td><h5>taskmanager.network.memory.buffer-debloat.target</h5></td>
+            <td style="word-wrap: break-word;">1 s</td>
+            <td>Duration</td>
+            <td>The target total time after which buffered in-flight data should be fully consumed. This configuration option will be used, in combination with the measured throughput, to adjust the amount of in-flight data.</td>
+        </tr>
+        <tr>
+            <td><h5>taskmanager.network.memory.buffer-debloat.threshold-percentages</h5></td>
+            <td style="word-wrap: break-word;">50</td>
+            <td>Integer</td>
+            <td>The minimum difference in percentage between the newly calculated buffer size and the old one to announce the new value. Can be used to avoid constant back and forth small adjustments.</td>
+        </tr>
+        <tr>
             <td><h5>taskmanager.numberOfTaskSlots</h5></td>
             <td style="word-wrap: break-word;">1</td>
             <td>Integer</td>

--- a/docs/layouts/shortcodes/generated/task_manager_memory_configuration.html
+++ b/docs/layouts/shortcodes/generated/task_manager_memory_configuration.html
@@ -75,6 +75,12 @@
             <td>Managed Memory size for TaskExecutors. This is the size of off-heap memory managed by the memory manager, reserved for sorting, hash tables, caching of intermediate results and RocksDB state backend. Memory consumers can either allocate memory from the memory manager in the form of MemorySegments, or reserve bytes from the memory manager and keep their memory usage within that boundary. If unspecified, it will be derived to make up the configured fraction of the Total Flink Memory.</td>
         </tr>
         <tr>
+            <td><h5>taskmanager.memory.min-segment-size</h5></td>
+            <td style="word-wrap: break-word;">1 kb</td>
+            <td>MemorySize</td>
+            <td>Minimum possible size of memory buffers used by the network stack and the memory manager. ex. can be used for automatic buffer size adjustment.</td>
+        </tr>
+        <tr>
             <td><h5>taskmanager.memory.network.fraction</h5></td>
             <td style="word-wrap: break-word;">0.1</td>
             <td>Float</td>

--- a/flink-core/src/main/java/org/apache/flink/configuration/TaskManagerOptions.java
+++ b/flink-core/src/main/java/org/apache/flink/configuration/TaskManagerOptions.java
@@ -277,6 +277,16 @@ public class TaskManagerOptions {
                     .withDescription(
                             "Size of memory buffers used by the network stack and the memory manager.");
 
+    /** Minimum possible size of memory buffers used by the network stack and the memory manager. */
+    @Documentation.Section(Documentation.Sections.ALL_TASK_MANAGER)
+    public static final ConfigOption<MemorySize> MIN_MEMORY_SEGMENT_SIZE =
+            key("taskmanager.memory.min-segment-size")
+                    .memoryType()
+                    .defaultValue(MemorySize.parse("1kb"))
+                    .withDescription(
+                            "Minimum possible size of memory buffers used by the network stack and the memory manager. "
+                                    + "ex. can be used for automatic buffer size adjustment.");
+
     /**
      * The config parameter for automatically defining the TaskManager's binding address, if {@link
      * #HOST} configuration option is not set.
@@ -530,6 +540,37 @@ public class TaskManagerOptions {
                     .defaultValue(20)
                     .withDescription(
                             "The number of the last buffer size values that will be taken for the correct calculation of the new one.");
+
+    /** The total time for which automated adjusted buffers should be fully consumed. */
+    @Documentation.Section(Documentation.Sections.ALL_TASK_MANAGER_NETWORK)
+    public static final ConfigOption<Duration> BUFFER_DEBLOAT_TARGET =
+            ConfigOptions.key("taskmanager.network.memory.buffer-debloat.target")
+                    .durationType()
+                    .defaultValue(Duration.ofSeconds(1))
+                    .withDescription(
+                            "The target total time after which buffered in-flight data should be fully consumed. "
+                                    + "This configuration option will be used, in combination with the measured throughput, to adjust the amount of in-flight data.");
+
+    @Documentation.Section(Documentation.Sections.ALL_TASK_MANAGER_NETWORK)
+    public static final ConfigOption<Boolean> BUFFER_DEBLOAT_ENABLED =
+            ConfigOptions.key("taskmanager.network.memory.buffer-debloat.enabled")
+                    .booleanType()
+                    .defaultValue(false)
+                    .withDescription(
+                            "The switch of the automatic buffered debloating feature. "
+                                    + "If enabled the amount of in-flight data will be adjusted automatically accordingly to the measured throughput.");
+
+    /**
+     * Difference between the new and the old buffer size for applying the new value(in percent).
+     */
+    @Documentation.Section(Documentation.Sections.ALL_TASK_MANAGER_NETWORK)
+    public static final ConfigOption<Integer> BUFFER_DEBLOAT_THRESHOLD_PERCENTAGES =
+            ConfigOptions.key("taskmanager.network.memory.buffer-debloat.threshold-percentages")
+                    .intType()
+                    .defaultValue(50)
+                    .withDescription(
+                            "The minimum difference in percentage between the newly calculated buffer size and the old one to announce the new value. "
+                                    + "Can be used to avoid constant back and forth small adjustments.");
 
     /**
      * Size of direct memory used by blocking shuffle for shuffle data read (currently only used by

--- a/flink-core/src/main/java/org/apache/flink/configuration/TaskManagerOptions.java
+++ b/flink-core/src/main/java/org/apache/flink/configuration/TaskManagerOptions.java
@@ -524,18 +524,18 @@ public class TaskManagerOptions {
 
     /** The period between recalculation the relevant size of the buffer. */
     @Documentation.Section(Documentation.Sections.ALL_TASK_MANAGER_NETWORK)
-    public static final ConfigOption<Integer> AUTOMATIC_BUFFER_ADJUSTMENT_PERIOD =
-            ConfigOptions.key("taskmanager.network.memory.automatic-buffer-adjustment.period")
-                    .intType()
-                    .defaultValue(500)
+    public static final ConfigOption<Duration> BUFFER_DEBLOAT_PERIOD =
+            ConfigOptions.key("taskmanager.network.memory.buffer-debloat.period")
+                    .durationType()
+                    .defaultValue(Duration.ofMillis(500))
                     .withDescription(
-                            "The minimum period of time after which the buffer size will be automatically adjusted to a new value if required. "
+                            "The minimum period of time after which the buffer size will be debloated if required. "
                                     + "The low value provides a fast reaction to the load fluctuation but can influence the performance.");
 
     /** The number of samples requires for the buffer size adjustment. */
     @Documentation.Section(Documentation.Sections.ALL_TASK_MANAGER_NETWORK)
-    public static final ConfigOption<Integer> AUTOMATIC_BUFFER_ADJUSTMENT_SAMPLES =
-            ConfigOptions.key("taskmanager.network.memory.automatic-buffer-adjustment.samples")
+    public static final ConfigOption<Integer> BUFFER_DEBLOAT_SAMPLES =
+            ConfigOptions.key("taskmanager.network.memory.buffer-debloat.samples")
                     .intType()
                     .defaultValue(20)
                     .withDescription(

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/io/network/NetworkClientHandler.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/io/network/NetworkClientHandler.java
@@ -49,6 +49,14 @@ public interface NetworkClientHandler extends ChannelHandler {
     void notifyCreditAvailable(final RemoteInputChannel inputChannel);
 
     /**
+     * The new size should be announced after it was calculated on the receiver side.
+     *
+     * @param inputChannel The input channel with new buffer size.
+     * @param bufferSize The new buffer size.
+     */
+    void notifyNewBufferSize(final RemoteInputChannel inputChannel, int bufferSize);
+
+    /**
      * Resumes data consumption from the producer after an exactly once checkpoint.
      *
      * @param inputChannel The input channel to resume data consumption.

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/io/network/PartitionRequestClient.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/io/network/PartitionRequestClient.java
@@ -50,6 +50,14 @@ public interface PartitionRequestClient {
     void notifyCreditAvailable(RemoteInputChannel inputChannel);
 
     /**
+     * Notifies new buffer size from one remote input channel.
+     *
+     * @param inputChannel The remote input channel who announces the new buffer size.
+     * @param bufferSize The new buffer size.
+     */
+    void notifyNewBufferSize(RemoteInputChannel inputChannel, int bufferSize);
+
+    /**
      * Requests to resume data consumption from one remote input channel.
      *
      * @param inputChannel The remote input channel who is ready to resume data consumption.

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/io/network/netty/NettyMessage.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/io/network/netty/NettyMessage.java
@@ -236,6 +236,9 @@ public abstract class NettyMessage {
                     case AckAllUserRecordsProcessed.ID:
                         decodedMsg = AckAllUserRecordsProcessed.readFrom(msg);
                         break;
+                    case NewBufferSize.ID:
+                        decodedMsg = NewBufferSize.readFrom(msg);
+                        break;
                     default:
                         throw new ProtocolException(
                                 "Received unknown message from producer: " + msg);
@@ -838,6 +841,52 @@ public abstract class NettyMessage {
         @Override
         public String toString() {
             return String.format("BacklogAnnouncement(%d : %s)", backlog, receiverId);
+        }
+    }
+
+    /** Message to notify producer about new buffer size. */
+    static class NewBufferSize extends NettyMessage {
+
+        private static final byte ID = 10;
+
+        final long bufferSize;
+
+        final InputChannelID receiverId;
+
+        NewBufferSize(long bufferSize, InputChannelID receiverId) {
+            checkArgument(bufferSize > 0, "The new buffer size should be greater than 0");
+            this.bufferSize = bufferSize;
+            this.receiverId = receiverId;
+        }
+
+        @Override
+        void write(ChannelOutboundInvoker out, ChannelPromise promise, ByteBufAllocator allocator)
+                throws IOException {
+            ByteBuf result = null;
+
+            try {
+                result =
+                        allocateBuffer(
+                                allocator, ID, Long.BYTES + InputChannelID.getByteBufLength());
+                result.writeLong(bufferSize);
+                receiverId.writeTo(result);
+
+                out.write(result, promise);
+            } catch (Throwable t) {
+                handleException(result, null, t);
+            }
+        }
+
+        static NewBufferSize readFrom(ByteBuf buffer) {
+            long bufferSize = buffer.readLong();
+            InputChannelID receiverId = InputChannelID.fromByteBuf(buffer);
+
+            return new NewBufferSize(bufferSize, receiverId);
+        }
+
+        @Override
+        public String toString() {
+            return String.format("NewBufferSize(%s : %d)", receiverId, bufferSize);
         }
     }
 

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/io/network/netty/NettyPartitionRequestClient.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/io/network/netty/NettyPartitionRequestClient.java
@@ -199,6 +199,11 @@ public class NettyPartitionRequestClient implements PartitionRequestClient {
     }
 
     @Override
+    public void notifyNewBufferSize(RemoteInputChannel inputChannel, int bufferSize) {
+        clientHandler.notifyNewBufferSize(inputChannel, bufferSize);
+    }
+
+    @Override
     public void resumeConsumption(RemoteInputChannel inputChannel) {
         clientHandler.resumeConsumption(inputChannel);
     }

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/io/network/netty/PartitionRequestServerHandler.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/io/network/netty/PartitionRequestServerHandler.java
@@ -24,6 +24,7 @@ import org.apache.flink.runtime.io.network.netty.NettyMessage.AckAllUserRecordsP
 import org.apache.flink.runtime.io.network.netty.NettyMessage.AddCredit;
 import org.apache.flink.runtime.io.network.netty.NettyMessage.CancelPartitionRequest;
 import org.apache.flink.runtime.io.network.netty.NettyMessage.CloseRequest;
+import org.apache.flink.runtime.io.network.netty.NettyMessage.NewBufferSize;
 import org.apache.flink.runtime.io.network.netty.NettyMessage.PartitionRequest;
 import org.apache.flink.runtime.io.network.netty.NettyMessage.ResumeConsumption;
 import org.apache.flink.runtime.io.network.netty.NettyMessage.TaskEventRequest;
@@ -127,6 +128,9 @@ class PartitionRequestServerHandler extends SimpleChannelInboundHandler<NettyMes
                 AckAllUserRecordsProcessed request = (AckAllUserRecordsProcessed) msg;
 
                 outboundQueue.acknowledgeAllRecordsProcessed(request.receiverId);
+            } else if (msgClazz == NewBufferSize.class) {
+                NewBufferSize request = (NewBufferSize) msg;
+
             } else {
                 LOG.warn("Received unexpected client request: {}", msg);
             }

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/io/network/partition/BoundedBlockingSubpartition.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/io/network/partition/BoundedBlockingSubpartition.java
@@ -267,6 +267,11 @@ final class BoundedBlockingSubpartition extends ResultSubpartition {
     }
 
     @Override
+    public int getNumberOfQueuedBuffers() {
+        return 0;
+    }
+
+    @Override
     protected long getTotalNumberOfBuffers() {
         return numBuffersAndEventsWritten;
     }

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/io/network/partition/BoundedBlockingSubpartitionDirectTransferReader.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/io/network/partition/BoundedBlockingSubpartitionDirectTransferReader.java
@@ -149,6 +149,11 @@ public class BoundedBlockingSubpartitionDirectTransferReader implements ResultSu
     }
 
     @Override
+    public int getNumberOfQueuedBuffers() {
+        return parent.getNumberOfQueuedBuffers();
+    }
+
+    @Override
     public void notifyDataAvailable() {
         throw new UnsupportedOperationException("Method should never be called.");
     }

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/io/network/partition/BoundedBlockingSubpartitionReader.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/io/network/partition/BoundedBlockingSubpartitionReader.java
@@ -182,6 +182,11 @@ final class BoundedBlockingSubpartitionReader implements ResultSubpartitionView 
     }
 
     @Override
+    public int getNumberOfQueuedBuffers() {
+        return parent.getNumberOfQueuedBuffers();
+    }
+
+    @Override
     public String toString() {
         return String.format(
                 "Blocking Subpartition Reader: ID=%s, index=%d",

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/io/network/partition/NoOpResultSubpartitionView.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/io/network/partition/NoOpResultSubpartitionView.java
@@ -59,4 +59,9 @@ public class NoOpResultSubpartitionView implements ResultSubpartitionView {
     public int unsynchronizedGetNumberOfQueuedBuffers() {
         return 0;
     }
+
+    @Override
+    public int getNumberOfQueuedBuffers() {
+        return 0;
+    }
 }

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/io/network/partition/PipelinedSubpartition.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/io/network/partition/PipelinedSubpartition.java
@@ -443,8 +443,11 @@ public class PipelinedSubpartition extends ResultSubpartition
 
     // ------------------------------------------------------------------------
 
-    int getCurrentNumberOfBuffers() {
-        return buffers.size();
+    @Override
+    public int getNumberOfQueuedBuffers() {
+        synchronized (buffers) {
+            return buffers.size();
+        }
     }
 
     // ------------------------------------------------------------------------

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/io/network/partition/PipelinedSubpartitionView.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/io/network/partition/PipelinedSubpartitionView.java
@@ -100,6 +100,11 @@ public class PipelinedSubpartitionView implements ResultSubpartitionView {
     }
 
     @Override
+    public int getNumberOfQueuedBuffers() {
+        return parent.getNumberOfQueuedBuffers();
+    }
+
+    @Override
     public String toString() {
         return String.format(
                 "%s(index: %d) of ResultPartition %s",

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/io/network/partition/ResultSubpartition.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/io/network/partition/ResultSubpartition.java
@@ -106,6 +106,9 @@ public abstract class ResultSubpartition {
      */
     public abstract int unsynchronizedGetNumberOfQueuedBuffers();
 
+    /** Get the current size of the queue. */
+    public abstract int getNumberOfQueuedBuffers();
+
     // ------------------------------------------------------------------------
 
     /**

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/io/network/partition/ResultSubpartitionView.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/io/network/partition/ResultSubpartitionView.java
@@ -61,6 +61,8 @@ public interface ResultSubpartitionView {
 
     int unsynchronizedGetNumberOfQueuedBuffers();
 
+    int getNumberOfQueuedBuffers();
+
     /**
      * Availability of the {@link ResultSubpartitionView} and the backlog in the corresponding
      * {@link ResultSubpartition}.

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/io/network/partition/SortMergeSubpartitionReader.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/io/network/partition/SortMergeSubpartitionReader.java
@@ -234,4 +234,11 @@ class SortMergeSubpartitionReader
     public int unsynchronizedGetNumberOfQueuedBuffers() {
         return Math.max(0, buffersRead.size());
     }
+
+    @Override
+    public int getNumberOfQueuedBuffers() {
+        synchronized (lock) {
+            return buffersRead.size();
+        }
+    }
 }

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/io/network/partition/consumer/BufferManager.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/io/network/partition/consumer/BufferManager.java
@@ -367,6 +367,12 @@ public class BufferManager implements BufferListener, BufferRecycler {
         return numRequiredBuffers;
     }
 
+    int getNumberOfRequiredBuffers() {
+        synchronized (bufferQueue) {
+            return numRequiredBuffers;
+        }
+    }
+
     @VisibleForTesting
     boolean unsynchronizedIsWaitingForFloatingBuffers() {
         return isWaitingForFloatingBuffers;

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/io/network/partition/consumer/IndexedInputGate.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/io/network/partition/consumer/IndexedInputGate.java
@@ -64,4 +64,8 @@ public abstract class IndexedInputGate extends InputGate implements Checkpointab
     public void convertToPriorityEvent(int channelIndex, int sequenceNumber) throws IOException {
         getChannel(channelIndex).convertToPriorityEvent(sequenceNumber);
     }
+
+    public abstract int getBuffersInUseCount();
+
+    public abstract void announceBufferSize(int bufferSize);
 }

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/io/network/partition/consumer/InputChannel.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/io/network/partition/consumer/InputChannel.java
@@ -211,6 +211,10 @@ public abstract class InputChannel {
     /** Releases all resources of the channel. */
     abstract void releaseAllResources() throws IOException;
 
+    abstract void announceBufferSize(int newBufferSize);
+
+    abstract int getBuffersInUseCount();
+
     // ------------------------------------------------------------------------
     // Error notification
     // ------------------------------------------------------------------------

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/io/network/partition/consumer/LocalInputChannel.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/io/network/partition/consumer/LocalInputChannel.java
@@ -337,6 +337,16 @@ public class LocalInputChannel extends InputChannel implements BufferAvailabilit
     }
 
     @Override
+    void announceBufferSize(int newBufferSize) {
+        // Not supported.
+    }
+
+    @Override
+    int getBuffersInUseCount() {
+        return subpartitionView.getNumberOfQueuedBuffers();
+    }
+
+    @Override
     public int unsynchronizedGetNumberOfQueuedBuffers() {
         ResultSubpartitionView view = subpartitionView;
 

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/io/network/partition/consumer/RecoveredInputChannel.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/io/network/partition/consumer/RecoveredInputChannel.java
@@ -201,6 +201,13 @@ public abstract class RecoveredInputChannel extends InputChannel implements Chan
     }
 
     @Override
+    int getBuffersInUseCount() {
+        synchronized (receivedBuffers) {
+            return receivedBuffers.size();
+        }
+    }
+
+    @Override
     public void resumeConsumption() {
         throw new UnsupportedOperationException("RecoveredInputChannel should never be blocked.");
     }
@@ -271,5 +278,10 @@ public abstract class RecoveredInputChannel extends InputChannel implements Chan
     @Override
     public void checkpointStarted(CheckpointBarrier barrier) throws CheckpointException {
         throw new CheckpointException(CHECKPOINT_DECLINED_TASK_NOT_READY);
+    }
+
+    @Override
+    void announceBufferSize(int newBufferSize) {
+        // Not supported.
     }
 }

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/io/network/partition/consumer/RemoteInputChannel.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/io/network/partition/consumer/RemoteInputChannel.java
@@ -39,6 +39,7 @@ import org.apache.flink.runtime.io.network.logger.NetworkActionsLogger;
 import org.apache.flink.runtime.io.network.partition.PartitionNotFoundException;
 import org.apache.flink.runtime.io.network.partition.PrioritizedDeque;
 import org.apache.flink.runtime.io.network.partition.ResultPartitionID;
+import org.apache.flink.util.ExceptionUtils;
 
 import org.apache.flink.shaded.guava30.com.google.common.collect.Iterators;
 
@@ -285,6 +286,21 @@ public class RemoteInputChannel extends InputChannel {
         }
     }
 
+    @Override
+    int getBuffersInUseCount() {
+        return getNumberOfQueuedBuffers()
+                + Math.max(0, bufferManager.getNumberOfRequiredBuffers() - initialCredit);
+    }
+
+    @Override
+    void announceBufferSize(int newBufferSize) {
+        try {
+            notifyNewBufferSize(newBufferSize);
+        } catch (Throwable t) {
+            ExceptionUtils.rethrow(t);
+        }
+    }
+
     private void failPartitionRequest() {
         setError(new PartitionNotFoundException(partitionId));
     }
@@ -305,6 +321,12 @@ public class RemoteInputChannel extends InputChannel {
         checkPartitionRequestQueueInitialized();
 
         partitionRequestClient.notifyCreditAvailable(this);
+    }
+
+    private void notifyNewBufferSize(int newBufferSize) throws IOException {
+        checkPartitionRequestQueueInitialized();
+
+        partitionRequestClient.notifyNewBufferSize(this, newBufferSize);
     }
 
     @VisibleForTesting

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/io/network/partition/consumer/SingleInputGate.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/io/network/partition/consumer/SingleInputGate.java
@@ -366,6 +366,22 @@ public class SingleInputGate extends IndexedInputGate {
         return unfinishedChannels;
     }
 
+    @Override
+    public int getBuffersInUseCount() {
+        int total = 0;
+        for (InputChannel channel : channels) {
+            total += Math.max(1, channel.getBuffersInUseCount());
+        }
+        return total;
+    }
+
+    @Override
+    public void announceBufferSize(int newBufferSize) {
+        for (InputChannel channel : channels) {
+            channel.announceBufferSize(newBufferSize);
+        }
+    }
+
     /**
      * Returns the type of this input channel's consumed result partition.
      *

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/io/network/partition/consumer/UnknownInputChannel.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/io/network/partition/consumer/UnknownInputChannel.java
@@ -131,6 +131,16 @@ class UnknownInputChannel extends InputChannel implements ChannelStateHolder {
     }
 
     @Override
+    void announceBufferSize(int newBufferSize) {
+        // Not supported.
+    }
+
+    @Override
+    int getBuffersInUseCount() {
+        return 0;
+    }
+
+    @Override
     public String toString() {
         return "UnknownInputChannel [" + partitionId + "]";
     }

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/taskmanager/InputGateWithMetrics.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/taskmanager/InputGateWithMetrics.java
@@ -93,6 +93,16 @@ public class InputGateWithMetrics extends IndexedInputGate {
     }
 
     @Override
+    public int getBuffersInUseCount() {
+        return inputGate.getBuffersInUseCount();
+    }
+
+    @Override
+    public void announceBufferSize(int bufferSize) {
+        inputGate.announceBufferSize(bufferSize);
+    }
+
+    @Override
     public boolean isFinished() {
         return inputGate.isFinished();
     }

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/taskmanager/Task.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/taskmanager/Task.java
@@ -113,7 +113,7 @@ import java.util.concurrent.atomic.AtomicBoolean;
 import java.util.concurrent.atomic.AtomicReferenceFieldUpdater;
 import java.util.function.Consumer;
 
-import static org.apache.flink.configuration.TaskManagerOptions.AUTOMATIC_BUFFER_ADJUSTMENT_SAMPLES;
+import static org.apache.flink.configuration.TaskManagerOptions.BUFFER_DEBLOAT_SAMPLES;
 import static org.apache.flink.util.Preconditions.checkArgument;
 import static org.apache.flink.util.Preconditions.checkNotNull;
 import static org.apache.flink.util.Preconditions.checkState;
@@ -420,8 +420,7 @@ public class Task
         this.inputGates = new IndexedInputGate[gates.length];
         this.throughputCalculator =
                 new ThroughputCalculator(
-                        SystemClock.getInstance(),
-                        taskConfiguration.get(AUTOMATIC_BUFFER_ADJUSTMENT_SAMPLES));
+                        SystemClock.getInstance(), taskConfiguration.get(BUFFER_DEBLOAT_SAMPLES));
         int counter = 0;
         for (IndexedInputGate gate : gates) {
             inputGates[counter++] =

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/throughput/ThroughputCalculator.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/throughput/ThroughputCalculator.java
@@ -29,7 +29,6 @@ public class ThroughputCalculator {
     private long currentAccumulatedDataSize;
     private long currentMeasurementTime;
     private long measurementStartTime = NOT_TRACKED;
-    private long lastThroughput;
 
     public ThroughputCalculator(Clock clock, int numberOfSamples) {
         this.clock = clock;
@@ -62,13 +61,13 @@ public class ThroughputCalculator {
             currentMeasurementTime += clock.relativeTimeMillis() - measurementStartTime;
         }
 
-        lastThroughput =
+        long throughput =
                 throughputEMA.calculateThroughput(
                         currentAccumulatedDataSize, currentMeasurementTime);
 
         measurementStartTime = clock.relativeTimeMillis();
         currentAccumulatedDataSize = currentMeasurementTime = 0;
 
-        return lastThroughput;
+        return throughput;
     }
 }

--- a/flink-runtime/src/test/java/org/apache/flink/runtime/io/network/TestingPartitionRequestClient.java
+++ b/flink-runtime/src/test/java/org/apache/flink/runtime/io/network/TestingPartitionRequestClient.java
@@ -39,6 +39,9 @@ public class TestingPartitionRequestClient implements PartitionRequestClient {
     public void notifyCreditAvailable(RemoteInputChannel inputChannel) {}
 
     @Override
+    public void notifyNewBufferSize(RemoteInputChannel inputChannel, int bufferSize) {}
+
+    @Override
     public void resumeConsumption(RemoteInputChannel inputChannel) {}
 
     @Override

--- a/flink-runtime/src/test/java/org/apache/flink/runtime/io/network/netty/CancelPartitionRequestTest.java
+++ b/flink-runtime/src/test/java/org/apache/flink/runtime/io/network/netty/CancelPartitionRequestTest.java
@@ -242,6 +242,11 @@ public class CancelPartitionRequestTest {
         }
 
         @Override
+        public int getNumberOfQueuedBuffers() {
+            return 0;
+        }
+
+        @Override
         public Throwable getFailureCause() {
             return null;
         }

--- a/flink-runtime/src/test/java/org/apache/flink/runtime/io/network/netty/CreditBasedPartitionRequestClientHandlerTest.java
+++ b/flink-runtime/src/test/java/org/apache/flink/runtime/io/network/netty/CreditBasedPartitionRequestClientHandlerTest.java
@@ -64,13 +64,14 @@ import java.io.IOException;
 import static org.apache.flink.runtime.io.network.netty.PartitionRequestQueueTest.blockChannel;
 import static org.apache.flink.runtime.io.network.partition.InputChannelTestUtils.createRemoteInputChannel;
 import static org.apache.flink.runtime.io.network.partition.InputChannelTestUtils.createSingleInputGate;
+import static org.hamcrest.CoreMatchers.is;
+import static org.hamcrest.MatcherAssert.assertThat;
 import static org.hamcrest.Matchers.instanceOf;
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertFalse;
 import static org.junit.Assert.assertNotNull;
 import static org.junit.Assert.assertNull;
 import static org.junit.Assert.assertSame;
-import static org.junit.Assert.assertThat;
 import static org.junit.Assert.assertTrue;
 import static org.junit.Assert.fail;
 import static org.mockito.Matchers.any;
@@ -81,6 +82,7 @@ import static org.mockito.Mockito.times;
 import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
 
+/** Test for {@link CreditBasedPartitionRequestClientHandler}. */
 public class CreditBasedPartitionRequestClientHandlerTest {
 
     /**
@@ -671,6 +673,53 @@ public class CreditBasedPartitionRequestClientHandlerTest {
                             cause, expectedClass));
         } catch (IOException e) {
             assertThat(e, instanceOf(expectedClass));
+        }
+    }
+
+    @Test
+    public void testAnnounceBufferSize() throws Exception {
+        final CreditBasedPartitionRequestClientHandler handler =
+                new CreditBasedPartitionRequestClientHandler();
+        final EmbeddedChannel channel = new EmbeddedChannel(handler);
+        final PartitionRequestClient client =
+                new NettyPartitionRequestClient(
+                        channel,
+                        handler,
+                        mock(ConnectionID.class),
+                        mock(PartitionRequestClientFactory.class));
+
+        final NetworkBufferPool networkBufferPool = new NetworkBufferPool(10, 32);
+        final SingleInputGate inputGate = createSingleInputGate(2, networkBufferPool);
+        final RemoteInputChannel[] inputChannels = new RemoteInputChannel[2];
+        inputChannels[0] = createRemoteInputChannel(inputGate, client);
+        inputChannels[1] = createRemoteInputChannel(inputGate, client);
+        try {
+            inputGate.setInputChannels(inputChannels);
+            final BufferPool bufferPool = networkBufferPool.createBufferPool(6, 6);
+            inputGate.setBufferPool(bufferPool);
+            inputGate.setupChannels();
+
+            inputChannels[0].requestSubpartition(0);
+            inputChannels[1].requestSubpartition(0);
+            channel.readOutbound();
+            channel.readOutbound();
+
+            inputGate.announceBufferSize(333);
+
+            channel.runPendingTasks();
+
+            NettyMessage.NewBufferSize readOutbound = channel.readOutbound();
+            assertThat(readOutbound, instanceOf(NettyMessage.NewBufferSize.class));
+            assertThat(readOutbound.receiverId, is(inputChannels[0].getInputChannelId()));
+            assertThat(readOutbound.bufferSize, is(333L));
+
+            readOutbound = channel.readOutbound();
+            assertThat(readOutbound.receiverId, is(inputChannels[1].getInputChannelId()));
+            assertThat(readOutbound.bufferSize, is(333L));
+
+        } finally {
+            releaseResource(inputGate, networkBufferPool);
+            channel.close();
         }
     }
 

--- a/flink-runtime/src/test/java/org/apache/flink/runtime/io/network/netty/NettyMessageServerSideSerializationTest.java
+++ b/flink-runtime/src/test/java/org/apache/flink/runtime/io/network/netty/NettyMessageServerSideSerializationTest.java
@@ -135,4 +135,15 @@ public class NettyMessageServerSideSerializationTest extends TestLogger {
 
         assertEquals(expected.receiverId, actual.receiverId);
     }
+
+    @Test
+    public void testNewBufferSize() {
+        NettyMessage.NewBufferSize expected =
+                new NettyMessage.NewBufferSize(
+                        random.nextInt(Integer.MAX_VALUE) + 1L, new InputChannelID());
+        NettyMessage.NewBufferSize actual = encodeAndDecode(expected, channel);
+
+        assertEquals(expected.bufferSize, actual.bufferSize);
+        assertEquals(expected.receiverId, actual.receiverId);
+    }
 }

--- a/flink-runtime/src/test/java/org/apache/flink/runtime/io/network/partition/InputGateFairnessTest.java
+++ b/flink-runtime/src/test/java/org/apache/flink/runtime/io/network/partition/InputGateFairnessTest.java
@@ -116,7 +116,7 @@ public class InputGateFairnessTest {
             int max = 0;
 
             for (PipelinedSubpartition source : sources) {
-                int size = source.getCurrentNumberOfBuffers();
+                int size = source.getNumberOfQueuedBuffers();
                 min = Math.min(min, size);
                 max = Math.max(max, size);
             }
@@ -181,7 +181,7 @@ public class InputGateFairnessTest {
                 int max = 0;
 
                 for (PipelinedSubpartition source : sources) {
-                    int size = source.getCurrentNumberOfBuffers();
+                    int size = source.getNumberOfQueuedBuffers();
                     min = Math.min(min, size);
                     max = Math.max(max, size);
                 }

--- a/flink-runtime/src/test/java/org/apache/flink/runtime/io/network/partition/PipelinedSubpartitionTest.java
+++ b/flink-runtime/src/test/java/org/apache/flink/runtime/io/network/partition/PipelinedSubpartitionTest.java
@@ -243,6 +243,8 @@ public class PipelinedSubpartitionTest extends SubpartitionTestBase {
         try {
             partition.add(buffer1);
             partition.add(buffer2);
+            assertEquals(2, partition.getNumberOfQueuedBuffers());
+
             // create the read view first
             ResultSubpartitionView view = null;
             if (createView) {
@@ -250,6 +252,7 @@ public class PipelinedSubpartitionTest extends SubpartitionTestBase {
             }
 
             partition.release();
+            assertEquals(0, partition.getNumberOfQueuedBuffers());
 
             assertTrue(partition.isReleased());
             if (createView) {
@@ -280,6 +283,21 @@ public class PipelinedSubpartitionTest extends SubpartitionTestBase {
     public void testReleaseParent() throws Exception {
         final ResultSubpartition partition = createSubpartition();
         verifyViewReleasedAfterParentRelease(partition);
+    }
+
+    @Test
+    public void testNumberOfQueueBuffers() throws Exception {
+        final PipelinedSubpartition subpartition = createSubpartition();
+
+        subpartition.add(createFilledFinishedBufferConsumer(4096));
+        assertEquals(1, subpartition.getNumberOfQueuedBuffers());
+
+        subpartition.add(createFilledFinishedBufferConsumer(4096));
+        assertEquals(2, subpartition.getNumberOfQueuedBuffers());
+
+        subpartition.getNextBuffer();
+
+        assertEquals(1, subpartition.getNumberOfQueuedBuffers());
     }
 
     private void verifyViewReleasedAfterParentRelease(ResultSubpartition partition)

--- a/flink-runtime/src/test/java/org/apache/flink/runtime/io/network/partition/ResultPartitionTest.java
+++ b/flink-runtime/src/test/java/org/apache/flink/runtime/io/network/partition/ResultPartitionTest.java
@@ -600,7 +600,7 @@ public class ResultPartitionTest {
             // emit the second record, record length = bufferSize
             bufferWritingResultPartition.emitRecord(ByteBuffer.allocate(bufferSize), 0);
         } finally {
-            assertEquals(2, pipelinedSubpartition.getCurrentNumberOfBuffers());
+            assertEquals(2, pipelinedSubpartition.getNumberOfQueuedBuffers());
             assertEquals(0, pipelinedSubpartition.getNextBuffer().getPartialRecordLength());
             assertEquals(
                     partialLength, pipelinedSubpartition.getNextBuffer().getPartialRecordLength());
@@ -623,7 +623,7 @@ public class ResultPartitionTest {
                     bufferWritingResultPartition.subpartitions) {
                 PipelinedSubpartition pipelinedSubpartition =
                         (PipelinedSubpartition) resultSubpartition;
-                assertEquals(2, pipelinedSubpartition.getCurrentNumberOfBuffers());
+                assertEquals(2, pipelinedSubpartition.getNumberOfQueuedBuffers());
                 assertEquals(0, pipelinedSubpartition.getNextBuffer().getPartialRecordLength());
                 assertEquals(
                         partialLength,

--- a/flink-runtime/src/test/java/org/apache/flink/runtime/io/network/partition/consumer/InputChannelTest.java
+++ b/flink-runtime/src/test/java/org/apache/flink/runtime/io/network/partition/consumer/InputChannelTest.java
@@ -156,5 +156,13 @@ public class InputChannelTest {
 
         @Override
         void releaseAllResources() throws IOException {}
+
+        @Override
+        void announceBufferSize(int newBufferSize) {}
+
+        @Override
+        int getBuffersInUseCount() {
+            return 0;
+        }
     }
 }

--- a/flink-runtime/src/test/java/org/apache/flink/runtime/io/network/partition/consumer/TestInputChannel.java
+++ b/flink-runtime/src/test/java/org/apache/flink/runtime/io/network/partition/consumer/TestInputChannel.java
@@ -60,6 +60,8 @@ public class TestInputChannel extends InputChannel {
 
     private int sequenceNumber;
 
+    private int currentBufferSize;
+
     public TestInputChannel(SingleInputGate inputGate, int channelIndex) {
         this(inputGate, channelIndex, true, false);
     }
@@ -184,6 +186,16 @@ public class TestInputChannel extends InputChannel {
     @Override
     void releaseAllResources() throws IOException {
         isReleased = true;
+    }
+
+    @Override
+    void announceBufferSize(int newBufferSize) {
+        currentBufferSize = newBufferSize;
+    }
+
+    @Override
+    int getBuffersInUseCount() {
+        return buffers.size();
     }
 
     @Override

--- a/flink-runtime/src/test/java/org/apache/flink/runtime/io/network/partition/consumer/TestInputChannel.java
+++ b/flink-runtime/src/test/java/org/apache/flink/runtime/io/network/partition/consumer/TestInputChannel.java
@@ -193,6 +193,10 @@ public class TestInputChannel extends InputChannel {
         currentBufferSize = newBufferSize;
     }
 
+    public int getCurrentBufferSize() {
+        return currentBufferSize;
+    }
+
     @Override
     int getBuffersInUseCount() {
         return buffers.size();

--- a/flink-streaming-java/src/main/java/org/apache/flink/streaming/runtime/tasks/StreamTask.java
+++ b/flink-streaming-java/src/main/java/org/apache/flink/streaming/runtime/tasks/StreamTask.java
@@ -119,7 +119,7 @@ import java.util.concurrent.Future;
 import java.util.concurrent.RejectedExecutionException;
 import java.util.concurrent.ThreadFactory;
 
-import static org.apache.flink.configuration.TaskManagerOptions.AUTOMATIC_BUFFER_ADJUSTMENT_PERIOD;
+import static org.apache.flink.configuration.TaskManagerOptions.BUFFER_DEBLOAT_PERIOD;
 import static org.apache.flink.util.ExceptionUtils.firstOrSuppressed;
 import static org.apache.flink.util.ExceptionUtils.rethrowException;
 import static org.apache.flink.util.Preconditions.checkState;
@@ -395,7 +395,7 @@ public abstract class StreamTask<OUT, OP extends StreamOperator<OUT>> extends Ab
 
         environment.getMetricGroup().getIOMetricGroup().setEnableBusyTime(true);
         this.throughputCalculator = environment.getThroughputMeter();
-        this.bufferDebloatPeriod = getTaskConfiguration().get(AUTOMATIC_BUFFER_ADJUSTMENT_PERIOD);
+        this.bufferDebloatPeriod = getTaskConfiguration().get(BUFFER_DEBLOAT_PERIOD).toMillis();
 
         this.bufferDebloater =
                 getTaskConfiguration().get(TaskManagerOptions.BUFFER_DEBLOAT_ENABLED)

--- a/flink-streaming-java/src/main/java/org/apache/flink/streaming/runtime/tasks/bufferdebloat/BufferDebloater.java
+++ b/flink-streaming-java/src/main/java/org/apache/flink/streaming/runtime/tasks/bufferdebloat/BufferDebloater.java
@@ -1,0 +1,99 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.flink.streaming.runtime.tasks.bufferdebloat;
+
+import org.apache.flink.configuration.Configuration;
+import org.apache.flink.configuration.TaskManagerOptions;
+import org.apache.flink.runtime.io.network.partition.consumer.IndexedInputGate;
+
+import static org.apache.flink.configuration.TaskManagerOptions.BUFFER_DEBLOAT_TARGET;
+import static org.apache.flink.configuration.TaskManagerOptions.BUFFER_DEBLOAT_THRESHOLD_PERCENTAGES;
+import static org.apache.flink.util.Preconditions.checkArgument;
+
+/**
+ * Class for automatic calculation of the buffer size based on the current throughput and
+ * configuration.
+ */
+public class BufferDebloater {
+    private static final double MILLIS_IN_SECOND = 1000.0;
+
+    /**
+     * How different should be the total buffer size compare to throughput (when it is 1.0 then
+     * bufferSize == throughput).
+     */
+    private final double targetBufferSizeFactor;
+
+    private final IndexedInputGate[] inputGates;
+    private final long maxBufferSize;
+    private final long minBufferSize;
+    private final int bufferDebloatThresholdPercentages;
+
+    private int lastBufferSize;
+
+    public BufferDebloater(Configuration taskConfig, IndexedInputGate[] inputGates) {
+        this.inputGates = inputGates;
+        this.targetBufferSizeFactor =
+                taskConfig.get(BUFFER_DEBLOAT_TARGET).toMillis() / MILLIS_IN_SECOND;
+        this.maxBufferSize = taskConfig.get(TaskManagerOptions.MEMORY_SEGMENT_SIZE).getBytes();
+        this.minBufferSize = taskConfig.get(TaskManagerOptions.MIN_MEMORY_SEGMENT_SIZE).getBytes();
+
+        this.bufferDebloatThresholdPercentages =
+                taskConfig.getInteger(BUFFER_DEBLOAT_THRESHOLD_PERCENTAGES);
+
+        this.lastBufferSize = (int) maxBufferSize;
+
+        // Right now the buffer size can not be grater than integer max value according to
+        // MemorySegment and buffer implementation.
+        checkArgument(maxBufferSize <= Integer.MAX_VALUE);
+        checkArgument(maxBufferSize > 0);
+        checkArgument(minBufferSize > 0);
+        checkArgument(maxBufferSize >= minBufferSize);
+        checkArgument(targetBufferSizeFactor > 0.0);
+    }
+
+    public void recalculateBufferSize(long currentThroughput) {
+        long desiredTotalBufferSizeInBytes = (long) (currentThroughput * targetBufferSizeFactor);
+
+        int totalNumber = 0;
+        for (IndexedInputGate inputGate : inputGates) {
+            totalNumber += Math.max(1, inputGate.getBuffersInUseCount());
+        }
+        int newSize =
+                (int)
+                        Math.max(
+                                minBufferSize,
+                                Math.min(
+                                        desiredTotalBufferSizeInBytes / totalNumber,
+                                        maxBufferSize));
+
+        boolean skipUpdate =
+                Math.abs(1 - ((double) lastBufferSize) / newSize) * 100
+                        < bufferDebloatThresholdPercentages;
+
+        // Skip update if the new value pretty close to the old one.
+        if (skipUpdate) {
+            return;
+        }
+
+        lastBufferSize = newSize;
+        for (IndexedInputGate inputGate : inputGates) {
+            inputGate.announceBufferSize(newSize);
+        }
+    }
+}

--- a/flink-streaming-java/src/test/java/org/apache/flink/streaming/runtime/io/MockIndexedInputGate.java
+++ b/flink-streaming-java/src/test/java/org/apache/flink/streaming/runtime/io/MockIndexedInputGate.java
@@ -120,4 +120,12 @@ public class MockIndexedInputGate extends IndexedInputGate {
     public List<InputChannelInfo> getUnfinishedChannels() {
         return Collections.emptyList();
     }
+
+    @Override
+    public int getBuffersInUseCount() {
+        return 0;
+    }
+
+    @Override
+    public void announceBufferSize(int bufferSize) {}
 }

--- a/flink-streaming-java/src/test/java/org/apache/flink/streaming/runtime/io/MockInputGate.java
+++ b/flink-streaming-java/src/test/java/org/apache/flink/streaming/runtime/io/MockInputGate.java
@@ -158,6 +158,14 @@ public class MockInputGate extends IndexedInputGate {
         }
     }
 
+    @Override
+    public int getBuffersInUseCount() {
+        return 0;
+    }
+
+    @Override
+    public void announceBufferSize(int bufferSize) {}
+
     public Set<Integer> getBlockedChannels() {
         return blockedChannels;
     }

--- a/flink-streaming-java/src/test/java/org/apache/flink/streaming/runtime/io/checkpointing/AlignedCheckpointsMassiveRandomTest.java
+++ b/flink-streaming-java/src/test/java/org/apache/flink/streaming/runtime/io/checkpointing/AlignedCheckpointsMassiveRandomTest.java
@@ -235,6 +235,14 @@ public class AlignedCheckpointsMassiveRandomTest {
         @Override
         public void checkpointStopped(long cancelledCheckpointId) {}
 
+        @Override
+        public int getBuffersInUseCount() {
+            return 0;
+        }
+
+        @Override
+        public void announceBufferSize(int bufferSize) {}
+
         public void acknowledgeAllRecordsProcessed(InputChannelInfo channelInfo)
                 throws IOException {}
 

--- a/flink-streaming-java/src/test/java/org/apache/flink/streaming/runtime/tasks/StreamTaskTest.java
+++ b/flink-streaming-java/src/test/java/org/apache/flink/streaming/runtime/tasks/StreamTaskTest.java
@@ -171,8 +171,8 @@ import static java.util.Arrays.asList;
 import static java.util.Collections.singletonList;
 import static org.apache.flink.api.common.typeinfo.BasicTypeInfo.STRING_TYPE_INFO;
 import static org.apache.flink.configuration.StateBackendOptions.STATE_BACKEND;
-import static org.apache.flink.configuration.TaskManagerOptions.AUTOMATIC_BUFFER_ADJUSTMENT_PERIOD;
 import static org.apache.flink.configuration.TaskManagerOptions.BUFFER_DEBLOAT_ENABLED;
+import static org.apache.flink.configuration.TaskManagerOptions.BUFFER_DEBLOAT_PERIOD;
 import static org.apache.flink.configuration.TaskManagerOptions.BUFFER_DEBLOAT_TARGET;
 import static org.apache.flink.runtime.checkpoint.CheckpointFailureReason.UNKNOWN_TASK_CHECKPOINT_NOTIFICATION_FAILURE;
 import static org.apache.flink.runtime.checkpoint.StateObjectCollection.singleton;
@@ -1819,7 +1819,8 @@ public class StreamTaskTest extends TestLogger {
         try (MockEnvironment mockEnvironment =
                 new MockEnvironmentBuilder()
                         .setTaskConfiguration(
-                                new Configuration().set(AUTOMATIC_BUFFER_ADJUSTMENT_PERIOD, 1))
+                                new Configuration()
+                                        .set(BUFFER_DEBLOAT_PERIOD, Duration.ofMillis(1)))
                         .setThroughputMeter(
                                 new ThroughputCalculator(SystemClock.getInstance(), 10) {
                                     @Override
@@ -1888,7 +1889,7 @@ public class StreamTaskTest extends TestLogger {
         int inputChannels = 3;
         Consumer<StreamConfig> configuration =
                 (config) -> {
-                    config.getConfiguration().set(AUTOMATIC_BUFFER_ADJUSTMENT_PERIOD, 10);
+                    config.getConfiguration().set(BUFFER_DEBLOAT_PERIOD, Duration.ofMillis(10));
                     config.getConfiguration().set(BUFFER_DEBLOAT_TARGET, Duration.ofSeconds(1));
                     config.getConfiguration().set(BUFFER_DEBLOAT_ENABLED, true);
                 };

--- a/flink-streaming-java/src/test/java/org/apache/flink/streaming/runtime/tasks/bufferdebloat/BufferDebloaterTest.java
+++ b/flink-streaming-java/src/test/java/org/apache/flink/streaming/runtime/tasks/bufferdebloat/BufferDebloaterTest.java
@@ -1,0 +1,163 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.flink.streaming.runtime.tasks.bufferdebloat;
+
+import org.apache.flink.configuration.Configuration;
+import org.apache.flink.configuration.MemorySize;
+import org.apache.flink.streaming.runtime.io.MockInputGate;
+import org.apache.flink.util.TestLogger;
+
+import org.junit.Test;
+
+import java.time.Duration;
+import java.util.Collections;
+import java.util.List;
+
+import static java.util.Arrays.asList;
+import static org.apache.flink.configuration.MemorySize.MemoryUnit.BYTES;
+import static org.apache.flink.configuration.TaskManagerOptions.BUFFER_DEBLOAT_ENABLED;
+import static org.apache.flink.configuration.TaskManagerOptions.BUFFER_DEBLOAT_TARGET;
+import static org.apache.flink.configuration.TaskManagerOptions.MEMORY_SEGMENT_SIZE;
+import static org.apache.flink.configuration.TaskManagerOptions.MIN_MEMORY_SEGMENT_SIZE;
+import static org.hamcrest.CoreMatchers.is;
+import static org.hamcrest.MatcherAssert.assertThat;
+
+/** Test for {@link BufferDebloater}. */
+public class BufferDebloaterTest extends TestLogger {
+
+    @Test
+    public void testZeroBuffersInUse() {
+        // if the gate returns the zero buffers in use it should be transformed to 1.
+        testBufferSizeCalculation(3, asList(0, 1, 0), 3333, 50, 2400, 1000, 1111);
+    }
+
+    @Test
+    public void testCorrectBufferSizeCalculation() {
+        testBufferSizeCalculation(3, asList(3, 5, 8), 3333, 50, 1100, 1200, 249);
+    }
+
+    @Test
+    public void testCalculatedBufferSizeLessThanMin() {
+        testBufferSizeCalculation(3, asList(3, 5, 8), 3333, 250, 1100, 1200, 250);
+    }
+
+    @Test
+    public void testCalculatedBufferSizeForThroughputZero() {
+        // When the throughput is zero then min buffer size will be taken.
+        testBufferSizeCalculation(3, asList(3, 5, 8), 0, 50, 1100, 1200, 50);
+    }
+
+    @Test
+    public void testConfiguredConsumptionTimeIsTooLow() {
+        // When the consumption time is low then min buffer size will be taken.
+        testBufferSizeCalculation(3, asList(3, 5, 8), 3333, 50, 1100, 7, 50);
+    }
+
+    @Test
+    public void testCalculatedBufferSizeGreaterThanMax() {
+        // New calculated buffer size should be more than max value it means that we should take max
+        // value which means that no updates should happen(-1 means that we take the initial value)
+        // because the old value equal to new value.
+        testBufferSizeCalculation(3, asList(3, 5, 8), 3333, 50, 248, 1200, -1);
+    }
+
+    @Test
+    public void testCalculatedBufferSlightlyDifferentFromCurrentOne() {
+        // New calculated buffer size should be a little less than current value(or max value which
+        // is the same) it means that no updates should happen(-1 means that we take the initial
+        // value) because the new value is not so different from the old one.
+        testBufferSizeCalculation(3, asList(3, 5, 8), 3333, 50, 250, 1200, -1);
+    }
+
+    @Test(expected = IllegalArgumentException.class)
+    public void testNegativeMinBufferSize() {
+        testBufferSizeCalculation(3, asList(3, 5, 8), 3333, -1, 248, 1200, 248);
+    }
+
+    @Test(expected = IllegalArgumentException.class)
+    public void testNegativeMaxBufferSize() {
+        testBufferSizeCalculation(3, asList(3, 5, 8), 3333, 50, -1, 1200, 248);
+    }
+
+    @Test(expected = IllegalArgumentException.class)
+    public void testMinGreaterThanMaxBufferSize() {
+        testBufferSizeCalculation(3, asList(3, 5, 8), 3333, 50, 49, 1200, 248);
+    }
+
+    @Test(expected = IllegalArgumentException.class)
+    public void testNegativeConsumptionTime() {
+        testBufferSizeCalculation(3, asList(3, 5, 8), 3333, 50, 1100, -1, 248);
+    }
+
+    private void testBufferSizeCalculation(
+            int numberOfGates,
+            List<Integer> numberOfBuffersInUse,
+            long throughput,
+            long minBufferSize,
+            long maxBufferSize,
+            int consumptionTime,
+            long expectedBufferSize) {
+        TestBufferSizeInputGate[] inputGates = new TestBufferSizeInputGate[numberOfGates];
+        for (int i = 0; i < numberOfGates; i++) {
+            inputGates[i] = new TestBufferSizeInputGate(numberOfBuffersInUse.get(i));
+        }
+
+        BufferDebloater bufferDebloater =
+                new BufferDebloater(
+                        new Configuration()
+                                .set(BUFFER_DEBLOAT_ENABLED, true)
+                                .set(BUFFER_DEBLOAT_TARGET, Duration.ofMillis(consumptionTime))
+                                .set(
+                                        MEMORY_SEGMENT_SIZE,
+                                        MemorySize.parse("" + maxBufferSize, BYTES))
+                                .set(
+                                        MIN_MEMORY_SEGMENT_SIZE,
+                                        MemorySize.parse("" + minBufferSize, BYTES)),
+                        inputGates);
+
+        // when: Buffer size is calculated.
+        bufferDebloater.recalculateBufferSize(throughput);
+
+        // then: Buffer size is in all gates should be as expected.
+        for (int i = 0; i < numberOfGates; i++) {
+            assertThat(inputGates[i].lastBufferSize, is(expectedBufferSize));
+        }
+    }
+
+    private static class TestBufferSizeInputGate extends MockInputGate {
+        private long lastBufferSize = -1;
+        private final int bufferInUseCount;
+
+        public TestBufferSizeInputGate(int bufferInUseCount) {
+            // Number of channels don't make sense here because
+            super(1, Collections.emptyList());
+            this.bufferInUseCount = bufferInUseCount;
+        }
+
+        @Override
+        public int getBuffersInUseCount() {
+            return bufferInUseCount;
+        }
+
+        @Override
+        public void announceBufferSize(int bufferSize) {
+            lastBufferSize = bufferSize;
+        }
+    }
+}

--- a/flink-test-utils-parent/flink-test-utils/src/main/java/org/apache/flink/streaming/util/TestStreamEnvironment.java
+++ b/flink-test-utils-parent/flink-test-utils/src/main/java/org/apache/flink/streaming/util/TestStreamEnvironment.java
@@ -19,6 +19,7 @@
 package org.apache.flink.streaming.util;
 
 import org.apache.flink.configuration.CheckpointingOptions;
+import org.apache.flink.configuration.TaskManagerOptions;
 import org.apache.flink.core.fs.Path;
 import org.apache.flink.runtime.minicluster.MiniCluster;
 import org.apache.flink.streaming.api.environment.ExecutionCheckpointingOptions;
@@ -42,6 +43,8 @@ public class TestStreamEnvironment extends StreamExecutionEnvironment {
             Boolean.parseBoolean(System.getProperty("checkpointing.randomization", "false"));
     private static final String STATE_CHANGE_LOG_CONFIG =
             System.getProperty("checkpointing.changelog", STATE_CHANGE_LOG_CONFIG_UNSET).trim();
+    private static final boolean RANDOMIZE_BUFFER_DEBLOAT_CONFIG =
+            Boolean.parseBoolean(System.getProperty("buffer-debloat.randomization", "false"));
 
     public TestStreamEnvironment(
             MiniCluster miniCluster,
@@ -96,6 +99,9 @@ public class TestStreamEnvironment extends StreamExecutionEnvironment {
                     } else if (STATE_CHANGE_LOG_CONFIG.equalsIgnoreCase(
                             STATE_CHANGE_LOG_CONFIG_RAND)) {
                         randomize(conf, CheckpointingOptions.ENABLE_STATE_CHANGE_LOG, true, false);
+                    }
+                    if (RANDOMIZE_BUFFER_DEBLOAT_CONFIG) {
+                        randomize(conf, TaskManagerOptions.BUFFER_DEBLOAT_ENABLED, true, false);
                     }
                     env.configure(conf, env.getUserClassloader());
                     return env;

--- a/pom.xml
+++ b/pom.xml
@@ -1529,6 +1529,7 @@ under the License.
 						<forkNumber>0${surefire.forkNumber}</forkNumber>
 						<hadoop.version>${hadoop.version}</hadoop.version>
 						<checkpointing.randomization>true</checkpointing.randomization>
+						<buffer-debloat.randomization>true</buffer-debloat.randomization>
 						<!-- on, unset, or random -->
 						<checkpointing.changelog>unset</checkpointing.changelog>
 						<project.basedir>${project.basedir}</project.basedir>


### PR DESCRIPTION
<!--
*Thank you very much for contributing to Apache Flink - we are happy that you want to help us improve Flink. To help the community review your contribution in the best possible way, please go through the checklist below, which will get the contribution into a shape in which it can be best reviewed.*

*Please understand that we do not do this to make contributions to Flink a hassle. In order to uphold a high standard of quality for code contributions, while at the same time managing a large number of contributions, we need contributors to prepare the contributions well, and give reviewers enough contextual information for the review. Please also understand that contributions that do not follow this guide will take longer to review and thus typically be picked up with lower priority by the community.*

## Contribution Checklist

  - Make sure that the pull request corresponds to a [JIRA issue](https://issues.apache.org/jira/projects/FLINK/issues). Exceptions are made for typos in JavaDoc or documentation files, which need no JIRA issue.
  
  - Name the pull request in the form "[FLINK-XXXX] [component] Title of the pull request", where *FLINK-XXXX* should be replaced by the actual issue number. Skip *component* if you are unsure about which is the best component.
  Typo fixes that have no associated JIRA issue should be named following this pattern: `[hotfix] [docs] Fix typo in event time introduction` or `[hotfix] [javadocs] Expand JavaDoc for PuncuatedWatermarkGenerator`.

  - Fill out the template below to describe the changes contributed by the pull request. That will give reviewers the context they need to do the review.
  
  - Make sure that the change passes the automated tests, i.e., `mvn clean verify` passes. You can set up Azure Pipelines CI to do that following [this guide](https://cwiki.apache.org/confluence/display/FLINK/Azure+Pipelines#AzurePipelines-Tutorial:SettingupAzurePipelinesforaforkoftheFlinkrepository).

  - Each pull request should address only one issue, not mix up code from multiple issues.
  
  - Each commit in the pull request has a meaningful commit message (including the JIRA id)

  - Once all items of the checklist are addressed, remove the above text and this checklist, leaving only the filled out template below.


**(The sections below can be removed for hotfixes of typos)**
-->

## What is the purpose of the change

This PR adds the ability to automatically calculate the buffer size based on the current throughput


## Brief change log

- BufferSizeCalculator integrated to StreamTask
- Created the buffer size calculator for the ability to automatically change the buffer size based on the throughput.
- Prepared Gates and Channels classes for either providing information for the calculation of buffer size and receiving the recalculated buffer size.
- Made a safe method for getting the number of buffers in the queue visible in the interface. 
- Added the rest configuration for automatic-buffer-adjustment 
-  Message for notification about new buffer size(NewBufferSize) was added


## Verifying this change

This change added tests and can be verified as follows:

*(example:)*
  - *Added the tests for checking correcntess of the calculation of the buffer size*
  - 
## Does this pull request potentially affect one of the following parts:

  - Dependencies (does it add or upgrade a dependency): (yes / **no**)
  - The public API, i.e., is any changed class annotated with `@Public(Evolving)`: (**yes** / no)
  - The serializers: (yes / **no** / don't know)
  - The runtime per-record code paths (performance sensitive): (**yes** / no / don't know)
  - Anything that affects deployment or recovery: JobManager (and its components), Checkpointing, Kubernetes/Yarn, ZooKeeper: (yes / **no** / don't know)
  - The S3 file system connector: (yes / **no** / don't know)

## Documentation

  - Does this pull request introduce a new feature? (**yes** / no)
  - If yes, how is the feature documented? (not applicable / **docs** / JavaDocs / not documented)
