### PR TITLE
[FLINK-23531][table]Allow skip all change log for row-time deduplicate mini-batch

### DIFF
--- a/flink-table/flink-table-planner/src/main/java/org/apache/flink/table/planner/plan/nodes/exec/stream/StreamExecDeduplicate.java
+++ b/flink-table/flink-table-planner/src/main/java/org/apache/flink/table/planner/plan/nodes/exec/stream/StreamExecDeduplicate.java
@@ -97,10 +97,10 @@ public class StreamExecDeduplicate extends ExecNodeBase<RowData>
                     .booleanType()
                     .defaultValue(false)
                     .withDescription(
-                            "Set whether send all change log for row-time mini-batch."
-                                    + "If true, Flink will only send the latest change log to downstream like proc-time."
-                                    + "If false, Flink will send all change log to downstream."
-                                    + "Notes: If downstream is Versioned Table Views, this optimization can not be enabled.");
+                            "Set whether to compact the changes sent downstream in row-time mini-batch. "
+                                    + "If true, Flink will compact changes, only send the latest change to downstream. "
+                                    + "Notes: If the downstream needs the details of versioned data, this optimization cannot be opened. "
+                                    + "If false, Flink will send all changes to downstream just like when the mini-batch is not on.");
 
     @JsonProperty(FIELD_NAME_UNIQUE_KEYS)
     private final int[] uniqueKeys;

--- a/flink-table/flink-table-planner/src/test/scala/org/apache/flink/table/planner/runtime/stream/sql/DeduplicateITCase.scala
+++ b/flink-table/flink-table-planner/src/test/scala/org/apache/flink/table/planner/runtime/stream/sql/DeduplicateITCase.scala
@@ -23,14 +23,14 @@ import org.apache.flink.streaming.api.functions.timestamps.AscendingTimestampExt
 import org.apache.flink.table.api._
 import org.apache.flink.table.api.bridge.scala._
 import org.apache.flink.table.planner.factories.TestValuesTableFactory
-import org.apache.flink.table.planner.runtime.utils.StreamingWithMiniBatchTestBase.MiniBatchMode
+import org.apache.flink.table.planner.plan.nodes.exec.stream.StreamExecDeduplicate
+import org.apache.flink.table.planner.runtime.utils.StreamingWithMiniBatchTestBase.{MiniBatchMode, MiniBatchOn}
 import org.apache.flink.table.planner.runtime.utils.StreamingWithStateTestBase.StateBackendMode
 import org.apache.flink.table.planner.runtime.utils._
 import org.apache.flink.table.utils.LegacyRowResource
 import org.apache.flink.types.Row
-
 import org.junit.Assert._
-import org.junit.{Rule, Test}
+import org.junit.{Assume, Rule, Test}
 import org.junit.runner.RunWith
 import org.junit.runners.Parameterized
 
@@ -190,6 +190,40 @@ class DeduplicateITCase(miniBatch: MiniBatchMode, mode: StateBackendMode)
   }
 
   @Test
+  def testFirstRowWithoutAllChangelogOnRowtime(): Unit = {
+    Assume.assumeTrue("Without all change log only for minibatch.", miniBatch == MiniBatchOn)
+    tEnv.getConfig.getConfiguration.setBoolean(
+      StreamExecDeduplicate.TABLE_EXEC_DEDUPLICATE_MINIBATCH_ALL_CHANGELOG_ENABLED, false)
+    val t = env.fromCollection(rowtimeTestData)
+      .assignTimestampsAndWatermarks(new RowtimeExtractor)
+      .toTable(tEnv, 'a, 'b, 'c, 'rowtime.rowtime())
+    tEnv.registerTable("T", t)
+    createSinkTable("rowtime_sink")
+
+    val sql =
+      """
+        |INSERT INTO rowtime_sink
+        | SELECT a, b, c, rowtime
+        | FROM (
+        |   SELECT *,
+        |     ROW_NUMBER() OVER (PARTITION BY a ORDER BY rowtime) as rowNum
+        |   FROM T
+        | )
+        | WHERE rowNum = 1
+      """.stripMargin
+
+    tEnv.executeSql(sql).await()
+    val rawResult = TestValuesTableFactory.getRawResults("rowtime_sink")
+
+    val expected = List(
+      "+I(1,1,Hi,1970-01-01T00:00:00.001)",
+      "+I(2,3,I am fine.,1970-01-01T00:00:00.003)",
+      "+I(3,4,Comment#2,1970-01-01T00:00:00.004)",
+      "+I(4,4,Comment#3,1970-01-01T00:00:00.004)")
+    assertEquals(expected.sorted, rawResult.sorted)
+  }
+
+  @Test
   def testFirstRowOnRowTimeFollowedByUnboundedAgg(): Unit = {
     val t = env.fromCollection(rowtimeTestData)
       .assignTimestampsAndWatermarks(new RowtimeExtractor)
@@ -259,6 +293,42 @@ class DeduplicateITCase(miniBatch: MiniBatchMode, mode: StateBackendMode)
       "+I(3,4,Comment#2,1970-01-01T00:00:00.004)",
       "-U(3,4,Comment#2,1970-01-01T00:00:00.004)",
       "+U(4,4,Comment#3,1970-01-01T00:00:00.004)")
+    assertEquals(expected.sorted, rawResult.sorted)
+  }
+
+  @Test
+  def testLastRowWithoutAllChangelogOnRowtime(): Unit = {
+    Assume.assumeTrue("Without all change log only for minibatch.", miniBatch == MiniBatchOn)
+    tEnv.getConfig.getConfiguration.setBoolean(
+      StreamExecDeduplicate.TABLE_EXEC_DEDUPLICATE_MINIBATCH_ALL_CHANGELOG_ENABLED, false)
+    val t = env.fromCollection(rowtimeTestData)
+      .assignTimestampsAndWatermarks(new RowtimeExtractor)
+      .toTable(tEnv, 'a, 'b, 'c, 'rowtime.rowtime())
+    tEnv.registerTable("T", t)
+    createSinkTable("rowtime_sink")
+
+    val sql =
+      """
+        |INSERT INTO rowtime_sink
+        | SELECT a, b, c, rowtime
+        | FROM (
+        |   SELECT *,
+        |     ROW_NUMBER() OVER (PARTITION BY b ORDER BY rowtime DESC) as rowNum
+        |   FROM T
+        | )
+        | WHERE rowNum = 1
+      """.stripMargin
+
+    tEnv.executeSql(sql).await()
+    val rawResult = TestValuesTableFactory.getRawResults("rowtime_sink")
+
+    val expected = List(
+      "+I(1,1,Hi,1970-01-01T00:00:00.001)",
+      "+I(1,2,Hello world,1970-01-01T00:00:00.002)",
+      "+I(2,3,I am fine.,1970-01-01T00:00:00.003)",
+      "+I(2,6,Comment#1,1970-01-01T00:00:00.006)",
+      "+I(3,5,Comment#2,1970-01-01T00:00:00.005)",
+      "+I(4,4,Comment#3,1970-01-01T00:00:00.004)")
     assertEquals(expected.sorted, rawResult.sorted)
   }
 

--- a/flink-table/flink-table-planner/src/test/scala/org/apache/flink/table/planner/runtime/stream/sql/DeduplicateITCase.scala
+++ b/flink-table/flink-table-planner/src/test/scala/org/apache/flink/table/planner/runtime/stream/sql/DeduplicateITCase.scala
@@ -193,7 +193,7 @@ class DeduplicateITCase(miniBatch: MiniBatchMode, mode: StateBackendMode)
   def testFirstRowWithoutAllChangelogOnRowtime(): Unit = {
     Assume.assumeTrue("Without all change log only for minibatch.", miniBatch == MiniBatchOn)
     tEnv.getConfig.getConfiguration.setBoolean(
-      StreamExecDeduplicate.TABLE_EXEC_DEDUPLICATE_MINIBATCH_ALL_CHANGELOG_ENABLED, false)
+      StreamExecDeduplicate.TABLE_EXEC_DEDUPLICATE_MINIBATCH_COMPACT_CHANGES, true)
     val t = env.fromCollection(rowtimeTestData)
       .assignTimestampsAndWatermarks(new RowtimeExtractor)
       .toTable(tEnv, 'a, 'b, 'c, 'rowtime.rowtime())
@@ -300,7 +300,7 @@ class DeduplicateITCase(miniBatch: MiniBatchMode, mode: StateBackendMode)
   def testLastRowWithoutAllChangelogOnRowtime(): Unit = {
     Assume.assumeTrue("Without all change log only for minibatch.", miniBatch == MiniBatchOn)
     tEnv.getConfig.getConfiguration.setBoolean(
-      StreamExecDeduplicate.TABLE_EXEC_DEDUPLICATE_MINIBATCH_ALL_CHANGELOG_ENABLED, false)
+      StreamExecDeduplicate.TABLE_EXEC_DEDUPLICATE_MINIBATCH_COMPACT_CHANGES, true)
     val t = env.fromCollection(rowtimeTestData)
       .assignTimestampsAndWatermarks(new RowtimeExtractor)
       .toTable(tEnv, 'a, 'b, 'c, 'rowtime.rowtime())

--- a/flink-table/flink-table-runtime/src/main/java/org/apache/flink/table/runtime/operators/deduplicate/RowTimeMiniBatchLatestChangeDeduplicateFunction.java
+++ b/flink-table/flink-table-runtime/src/main/java/org/apache/flink/table/runtime/operators/deduplicate/RowTimeMiniBatchLatestChangeDeduplicateFunction.java
@@ -35,7 +35,7 @@ import static org.apache.flink.table.runtime.operators.deduplicate.DeduplicateFu
  * This function is used to get the first or last row for every key partition in miniBatch mode. But
  * only send latest change log to downstream.
  */
-public class RowTimeMiniBatchLatestChangelogDeduplicateFunction
+public class RowTimeMiniBatchLatestChangeDeduplicateFunction
         extends MiniBatchDeduplicateFunctionBase<RowData, RowData, RowData, RowData, RowData> {
 
     private static final long serialVersionUID = 1L;
@@ -46,7 +46,7 @@ public class RowTimeMiniBatchLatestChangelogDeduplicateFunction
     private final int rowtimeIndex;
     private final boolean keepLastRow;
 
-    public RowTimeMiniBatchLatestChangelogDeduplicateFunction(
+    public RowTimeMiniBatchLatestChangeDeduplicateFunction(
             InternalTypeInfo<RowData> typeInfo,
             TypeSerializer<RowData> serializer,
             long minRetentionTime,
@@ -78,9 +78,6 @@ public class RowTimeMiniBatchLatestChangelogDeduplicateFunction
             RowData bufferedRow = entry.getValue();
             ctx.setCurrentKey(currentKey);
             RowData preRow = state.value();
-            // Note: we output all changelog here rather than comparing the first and the last
-            // record in buffer then output at most two changelog.
-            // The motivation is we need all changelog in versioned table of temporal join.
             checkInsertOnly(bufferedRow);
             if (isDuplicate(preRow, bufferedRow, rowtimeIndex, keepLastRow)) {
                 updateDeduplicateResult(

--- a/flink-table/flink-table-runtime/src/main/java/org/apache/flink/table/runtime/operators/deduplicate/RowTimeMiniBatchLatestChangelogDeduplicateFunction.java
+++ b/flink-table/flink-table-runtime/src/main/java/org/apache/flink/table/runtime/operators/deduplicate/RowTimeMiniBatchLatestChangelogDeduplicateFunction.java
@@ -1,0 +1,92 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.flink.table.runtime.operators.deduplicate;
+
+import org.apache.flink.api.common.typeutils.TypeSerializer;
+import org.apache.flink.table.data.RowData;
+import org.apache.flink.table.runtime.typeutils.InternalTypeInfo;
+import org.apache.flink.util.Collector;
+
+import javax.annotation.Nullable;
+
+import java.util.Map;
+
+import static org.apache.flink.table.runtime.operators.deduplicate.DeduplicateFunctionHelper.checkInsertOnly;
+import static org.apache.flink.table.runtime.operators.deduplicate.DeduplicateFunctionHelper.isDuplicate;
+import static org.apache.flink.table.runtime.operators.deduplicate.DeduplicateFunctionHelper.updateDeduplicateResult;
+
+/**
+ * This function is used to get the first or last row for every key partition in miniBatch mode. But
+ * only send latest change log to downstream.
+ */
+public class RowTimeMiniBatchLatestChangelogDeduplicateFunction
+        extends MiniBatchDeduplicateFunctionBase<RowData, RowData, RowData, RowData, RowData> {
+
+    private static final long serialVersionUID = 1L;
+
+    private final TypeSerializer<RowData> serializer;
+    private final boolean generateUpdateBefore;
+    private final boolean generateInsert;
+    private final int rowtimeIndex;
+    private final boolean keepLastRow;
+
+    public RowTimeMiniBatchLatestChangelogDeduplicateFunction(
+            InternalTypeInfo<RowData> typeInfo,
+            TypeSerializer<RowData> serializer,
+            long minRetentionTime,
+            int rowtimeIndex,
+            boolean generateUpdateBefore,
+            boolean generateInsert,
+            boolean keepLastRow) {
+        super(typeInfo, minRetentionTime);
+        this.serializer = serializer;
+        this.generateUpdateBefore = generateUpdateBefore;
+        this.generateInsert = generateInsert;
+        this.rowtimeIndex = rowtimeIndex;
+        this.keepLastRow = keepLastRow;
+    }
+
+    @Override
+    public RowData addInput(@Nullable RowData value, RowData input) throws Exception {
+        if (isDuplicate(value, input, rowtimeIndex, keepLastRow)) {
+            return serializer.copy(input);
+        }
+        return value;
+    }
+
+    @Override
+    public void finishBundle(Map<RowData, RowData> buffer, Collector<RowData> out)
+            throws Exception {
+        for (Map.Entry<RowData, RowData> entry : buffer.entrySet()) {
+            RowData currentKey = entry.getKey();
+            RowData bufferedRow = entry.getValue();
+            ctx.setCurrentKey(currentKey);
+            RowData preRow = state.value();
+            // Note: we output all changelog here rather than comparing the first and the last
+            // record in buffer then output at most two changelog.
+            // The motivation is we need all changelog in versioned table of temporal join.
+            checkInsertOnly(bufferedRow);
+            if (isDuplicate(preRow, bufferedRow, rowtimeIndex, keepLastRow)) {
+                updateDeduplicateResult(
+                        generateUpdateBefore, generateInsert, preRow, bufferedRow, out);
+                state.update(bufferedRow);
+            }
+        }
+    }
+}

--- a/flink-table/flink-table-runtime/src/test/java/org/apache/flink/table/runtime/operators/deduplicate/RowTimeDeduplicateFunctionTestBase.java
+++ b/flink-table/flink-table-runtime/src/test/java/org/apache/flink/table/runtime/operators/deduplicate/RowTimeDeduplicateFunctionTestBase.java
@@ -1,0 +1,68 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.flink.table.runtime.operators.deduplicate;
+
+import org.apache.flink.api.common.time.Time;
+import org.apache.flink.api.common.typeutils.TypeSerializer;
+import org.apache.flink.streaming.api.operators.KeyedProcessOperator;
+import org.apache.flink.streaming.util.KeyedOneInputStreamOperatorTestHarness;
+import org.apache.flink.streaming.util.OneInputStreamOperatorTestHarness;
+import org.apache.flink.table.data.RowData;
+import org.apache.flink.table.runtime.keyselector.RowDataKeySelector;
+import org.apache.flink.table.runtime.operators.bundle.KeyedMapBundleOperator;
+import org.apache.flink.table.runtime.typeutils.InternalTypeInfo;
+import org.apache.flink.table.runtime.util.GenericRowRecordSortComparator;
+import org.apache.flink.table.runtime.util.RowDataHarnessAssertor;
+import org.apache.flink.table.types.logical.BigIntType;
+import org.apache.flink.table.types.logical.IntType;
+import org.apache.flink.table.types.logical.VarCharType;
+import org.apache.flink.table.utils.HandwrittenSelectorUtil;
+
+/** Base class of tests for all kinds of row-time DeduplicateFunction. */
+abstract class RowTimeDeduplicateFunctionTestBase {
+
+    protected final long miniBatchSize = 4L;
+    protected Time minTtlTime = Time.milliseconds(10);
+    protected InternalTypeInfo inputRowType =
+            InternalTypeInfo.ofFields(
+                    new VarCharType(VarCharType.MAX_LENGTH), new IntType(), new BigIntType());
+    protected TypeSerializer<RowData> serializer = inputRowType.toSerializer();
+    protected int rowTimeIndex = 2;
+    protected int rowKeyIndex = 0;
+    protected RowDataKeySelector rowKeySelector =
+            HandwrittenSelectorUtil.getRowDataSelector(
+                    new int[] {rowKeyIndex}, inputRowType.toRowFieldTypes());
+    protected RowDataHarnessAssertor assertor =
+            new RowDataHarnessAssertor(
+                    inputRowType.toRowFieldTypes(),
+                    new GenericRowRecordSortComparator(
+                            rowKeyIndex, inputRowType.toRowFieldTypes()[rowKeyIndex]));
+
+    protected OneInputStreamOperatorTestHarness<RowData, RowData> createTestHarness(
+            KeyedProcessOperator<RowData, RowData, RowData> operator) throws Exception {
+        return new KeyedOneInputStreamOperatorTestHarness<>(
+                operator, rowKeySelector, rowKeySelector.getProducedType());
+    }
+
+    protected OneInputStreamOperatorTestHarness<RowData, RowData> createTestHarness(
+            KeyedMapBundleOperator<RowData, RowData, RowData, RowData> operator) throws Exception {
+        return new KeyedOneInputStreamOperatorTestHarness<>(
+                operator, rowKeySelector, rowKeySelector.getProducedType());
+    }
+}

--- a/flink-table/flink-table-runtime/src/test/java/org/apache/flink/table/runtime/operators/deduplicate/RowTimeMiniBatchLatestChangeDeduplicateFunctionTest.java
+++ b/flink-table/flink-table-runtime/src/test/java/org/apache/flink/table/runtime/operators/deduplicate/RowTimeMiniBatchLatestChangeDeduplicateFunctionTest.java
@@ -1,0 +1,328 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.flink.table.runtime.operators.deduplicate;
+
+import org.apache.flink.streaming.api.watermark.Watermark;
+import org.apache.flink.streaming.util.OneInputStreamOperatorTestHarness;
+import org.apache.flink.table.data.RowData;
+import org.apache.flink.table.runtime.operators.bundle.KeyedMapBundleOperator;
+import org.apache.flink.table.runtime.operators.bundle.trigger.CountBundleTrigger;
+
+import org.junit.Assert;
+import org.junit.Test;
+
+import java.util.ArrayList;
+import java.util.List;
+
+import static org.apache.flink.table.runtime.util.StreamRecordUtils.insertRecord;
+import static org.apache.flink.table.runtime.util.StreamRecordUtils.updateAfterRecord;
+import static org.apache.flink.table.runtime.util.StreamRecordUtils.updateBeforeRecord;
+
+/** Harness tests for {@link RowTimeMiniBatchLatestChangeDeduplicateFunction} */
+public class RowTimeMiniBatchLatestChangeDeduplicateFunctionTest
+        extends RowTimeDeduplicateFunctionTestBase {
+
+    @Test
+    public void testKeepLastRowWithoutGenerateUpdateBeforeAndWithGenerateInsert() throws Exception {
+        OneInputStreamOperatorTestHarness<RowData, RowData> testHarness =
+                createTestHarness(false, true, true);
+        testHarness.open();
+        testHarness.processElement(insertRecord("book", 10, 1L));
+        testHarness.processElement(insertRecord("book", 11, 2L));
+        testHarness.processElement(insertRecord("book", 13, 1L));
+        // output is empty because bundle not trigger yet.
+        Assert.assertTrue(testHarness.getOutput().isEmpty());
+        // bundle trigger emit.
+        testHarness.processElement(insertRecord("book", 12, 1L));
+        List<Object> expectedOutput = new ArrayList<>();
+        expectedOutput.add(insertRecord("book", 11, 2L));
+        assertor.assertOutputEqualsSorted("output wrong.", expectedOutput, testHarness.getOutput());
+
+        testHarness.processElement(insertRecord("book", 14, 3L));
+        testHarness.processElement(insertRecord("book", 15, 1L));
+        // watermark trigger emit.
+        testHarness.processWatermark(new Watermark(3L));
+        expectedOutput.add(updateAfterRecord("book", 14, 3L));
+        expectedOutput.add(new Watermark(3L));
+        testHarness.close();
+        assertor.assertOutputEqualsSorted("output wrong.", expectedOutput, testHarness.getOutput());
+    }
+
+    @Test
+    public void testKeepLastRowWithoutGenerateUpdateBeforeAndWithoutGenerateInsert()
+            throws Exception {
+        OneInputStreamOperatorTestHarness<RowData, RowData> testHarness =
+                createTestHarness(false, false, true);
+        testHarness.open();
+        testHarness.processElement(insertRecord("book", 10, 1L));
+        testHarness.processElement(insertRecord("book", 11, 2L));
+        testHarness.processElement(insertRecord("book", 13, 1L));
+        // output is empty because bundle not trigger yet.
+        Assert.assertTrue(testHarness.getOutput().isEmpty());
+        // bundle trigger emit.
+        testHarness.processElement(insertRecord("book", 12, 1L));
+        List<Object> expectedOutput = new ArrayList<>();
+        expectedOutput.add(updateAfterRecord("book", 11, 2L));
+        assertor.assertOutputEqualsSorted("output wrong.", expectedOutput, testHarness.getOutput());
+
+        testHarness.processElement(insertRecord("book", 14, 3L));
+        testHarness.processElement(insertRecord("book", 15, 1L));
+        // watermark trigger emit.
+        testHarness.processWatermark(new Watermark(3L));
+        expectedOutput.add(updateAfterRecord("book", 14, 3L));
+        expectedOutput.add(new Watermark(3L));
+        testHarness.close();
+        assertor.assertOutputEqualsSorted("output wrong.", expectedOutput, testHarness.getOutput());
+    }
+
+    @Test
+    public void testKeepLastRowWithGenerateUpdateBeforeAndWithGenerateInsert() throws Exception {
+        OneInputStreamOperatorTestHarness<RowData, RowData> testHarness =
+                createTestHarness(true, true, true);
+        testHarness.open();
+        testHarness.processElement(insertRecord("book", 10, 1L));
+        testHarness.processElement(insertRecord("book", 11, 2L));
+        testHarness.processElement(insertRecord("book", 13, 1L));
+        // output is empty because bundle not trigger yet.
+        Assert.assertTrue(testHarness.getOutput().isEmpty());
+        // bundle trigger emit.
+        testHarness.processElement(insertRecord("book", 12, 1L));
+        List<Object> expectedOutput = new ArrayList<>();
+        expectedOutput.add(insertRecord("book", 11, 2L));
+        assertor.assertOutputEqualsSorted("output wrong.", expectedOutput, testHarness.getOutput());
+
+        testHarness.processElement(insertRecord("book", 14, 3L));
+        testHarness.processElement(insertRecord("book", 15, 1L));
+        // watermark trigger emit.
+        testHarness.processWatermark(new Watermark(3L));
+        expectedOutput.add(updateBeforeRecord("book", 11, 2L));
+        expectedOutput.add(updateAfterRecord("book", 14, 3L));
+        expectedOutput.add(new Watermark(3L));
+        testHarness.close();
+        assertor.assertOutputEqualsSorted("output wrong.", expectedOutput, testHarness.getOutput());
+    }
+
+    @Test
+    public void testKeepLastRowWithGenerateUpdateBeforeAndWithoutGenerateInsert() throws Exception {
+        OneInputStreamOperatorTestHarness<RowData, RowData> testHarness =
+                createTestHarness(true, false, true);
+        testHarness.open();
+        testHarness.processElement(insertRecord("book", 10, 1L));
+        testHarness.processElement(insertRecord("book", 11, 2L));
+        testHarness.processElement(insertRecord("book", 13, 1L));
+        // output is empty because bundle not trigger yet.
+        Assert.assertTrue(testHarness.getOutput().isEmpty());
+        // bundle trigger emit.
+        testHarness.processElement(insertRecord("book", 12, 1L));
+        List<Object> expectedOutput = new ArrayList<>();
+        expectedOutput.add(insertRecord("book", 11, 2L));
+        assertor.assertOutputEqualsSorted("output wrong.", expectedOutput, testHarness.getOutput());
+
+        testHarness.processElement(insertRecord("book", 14, 3L));
+        testHarness.processElement(insertRecord("book", 15, 1L));
+        // watermark trigger emit.
+        testHarness.processWatermark(new Watermark(3L));
+        expectedOutput.add(updateBeforeRecord("book", 11, 2L));
+        expectedOutput.add(updateAfterRecord("book", 14, 3L));
+        expectedOutput.add(new Watermark(3L));
+        testHarness.close();
+        assertor.assertOutputEqualsSorted("output wrong.", expectedOutput, testHarness.getOutput());
+    }
+
+    @Test
+    public void testKeepLastRowWithGenerateUpdateBeforeAndWithGenerateInsertAndStateTtl()
+            throws Exception {
+        OneInputStreamOperatorTestHarness<RowData, RowData> testHarness =
+                createTestHarness(true, true, true);
+        testHarness.open();
+        testHarness.processElement(insertRecord("book", 10, 1L));
+        testHarness.processElement(insertRecord("book", 11, 2L));
+        testHarness.processElement(insertRecord("book", 13, 1L));
+        // output is empty because bundle not trigger yet.
+        Assert.assertTrue(testHarness.getOutput().isEmpty());
+        // bundle trigger emit.
+        testHarness.processElement(insertRecord("book", 12, 1L));
+        List<Object> expectedOutput = new ArrayList<>();
+        expectedOutput.add(insertRecord("book", 11, 2L));
+        assertor.assertOutputEqualsSorted("output wrong.", expectedOutput, testHarness.getOutput());
+
+        // clear state.
+        testHarness.setStateTtlProcessingTime(10);
+
+        testHarness.processElement(insertRecord("book", 14, 3L));
+        testHarness.processElement(insertRecord("book", 15, 1L));
+        // watermark trigger emit.
+        testHarness.processWatermark(new Watermark(3L));
+        expectedOutput.add(insertRecord("book", 14, 3L));
+        expectedOutput.add(new Watermark(3L));
+        testHarness.close();
+        assertor.assertOutputEqualsSorted("output wrong.", expectedOutput, testHarness.getOutput());
+    }
+
+    @Test
+    public void testKeepFirstRowWithoutGenerateUpdateBeforeAndWithGenerateInsert()
+            throws Exception {
+        OneInputStreamOperatorTestHarness<RowData, RowData> testHarness =
+                createTestHarness(false, true, false);
+        testHarness.open();
+        testHarness.processElement(insertRecord("book", 10, 1L));
+        testHarness.processElement(insertRecord("book", 11, 2L));
+        testHarness.processElement(insertRecord("book", 13, 1L));
+        // output is empty because bundle not trigger yet.
+        Assert.assertTrue(testHarness.getOutput().isEmpty());
+        // bundle trigger emit.
+        testHarness.processElement(insertRecord("book", 12, 1L));
+        List<Object> expectedOutput = new ArrayList<>();
+        expectedOutput.add(insertRecord("book", 10, 1L));
+        assertor.assertOutputEqualsSorted("output wrong.", expectedOutput, testHarness.getOutput());
+
+        testHarness.processElement(insertRecord("book", 14, 3L));
+        testHarness.processElement(insertRecord("book", 15, 1L));
+        // watermark trigger emit.
+        testHarness.processWatermark(new Watermark(3L));
+        expectedOutput.add(new Watermark(3L));
+        testHarness.close();
+        assertor.assertOutputEqualsSorted("output wrong.", expectedOutput, testHarness.getOutput());
+    }
+
+    @Test
+    public void testKeepFirstRowWithoutGenerateUpdateBeforeAndWithoutGenerateInsert()
+            throws Exception {
+        OneInputStreamOperatorTestHarness<RowData, RowData> testHarness =
+                createTestHarness(false, false, false);
+        testHarness.open();
+        testHarness.processElement(insertRecord("book", 10, 1L));
+        testHarness.processElement(insertRecord("book", 11, 2L));
+        testHarness.processElement(insertRecord("book", 13, 1L));
+        // output is empty because bundle not trigger yet.
+        Assert.assertTrue(testHarness.getOutput().isEmpty());
+        // bundle trigger emit.
+        testHarness.processElement(insertRecord("book", 12, 1L));
+        List<Object> expectedOutput = new ArrayList<>();
+        expectedOutput.add(updateAfterRecord("book", 10, 1L));
+        assertor.assertOutputEqualsSorted("output wrong.", expectedOutput, testHarness.getOutput());
+
+        testHarness.processElement(insertRecord("book", 14, 3L));
+        testHarness.processElement(insertRecord("book", 15, 1L));
+        // watermark trigger emit.
+        testHarness.processWatermark(new Watermark(3L));
+        expectedOutput.add(new Watermark(3L));
+        testHarness.close();
+        assertor.assertOutputEqualsSorted("output wrong.", expectedOutput, testHarness.getOutput());
+    }
+
+    @Test
+    public void testKeepFirstRowWithGenerateUpdateBeforeAndWithGenerateInsert() throws Exception {
+        OneInputStreamOperatorTestHarness<RowData, RowData> testHarness =
+                createTestHarness(true, true, false);
+        testHarness.open();
+        testHarness.processElement(insertRecord("book", 10, 1L));
+        testHarness.processElement(insertRecord("book", 11, 2L));
+        testHarness.processElement(insertRecord("book", 13, 1L));
+        // output is empty because bundle not trigger yet.
+        Assert.assertTrue(testHarness.getOutput().isEmpty());
+        // bundle trigger emit.
+        testHarness.processElement(insertRecord("book", 12, 1L));
+        List<Object> expectedOutput = new ArrayList<>();
+        expectedOutput.add(insertRecord("book", 10, 1L));
+        assertor.assertOutputEqualsSorted("output wrong.", expectedOutput, testHarness.getOutput());
+
+        testHarness.processElement(insertRecord("book", 14, 3L));
+        testHarness.processElement(insertRecord("book", 15, 1L));
+        // watermark trigger emit.
+        testHarness.processWatermark(new Watermark(3L));
+        expectedOutput.add(new Watermark(3L));
+        testHarness.close();
+        assertor.assertOutputEqualsSorted("output wrong.", expectedOutput, testHarness.getOutput());
+    }
+
+    @Test
+    public void testKeepFirstRowWithGenerateUpdateBeforeAndWithoutGenerateInsert()
+            throws Exception {
+        OneInputStreamOperatorTestHarness<RowData, RowData> testHarness =
+                createTestHarness(true, false, false);
+        testHarness.open();
+        testHarness.processElement(insertRecord("book", 10, 1L));
+        testHarness.processElement(insertRecord("book", 11, 2L));
+        testHarness.processElement(insertRecord("book", 13, 1L));
+        // output is empty because bundle not trigger yet.
+        Assert.assertTrue(testHarness.getOutput().isEmpty());
+        // bundle trigger emit.
+        testHarness.processElement(insertRecord("book", 12, 1L));
+        List<Object> expectedOutput = new ArrayList<>();
+        expectedOutput.add(insertRecord("book", 10, 1L));
+        assertor.assertOutputEqualsSorted("output wrong.", expectedOutput, testHarness.getOutput());
+
+        testHarness.processElement(insertRecord("book", 14, 3L));
+        testHarness.processElement(insertRecord("book", 15, 1L));
+        // watermark trigger emit.
+        testHarness.processWatermark(new Watermark(3L));
+        expectedOutput.add(new Watermark(3L));
+        testHarness.close();
+        assertor.assertOutputEqualsSorted("output wrong.", expectedOutput, testHarness.getOutput());
+    }
+
+    @Test
+    public void testKeepFirstRowWithGenerateUpdateBeforeAndWithGenerateInsertAndStateTtl()
+            throws Exception {
+        OneInputStreamOperatorTestHarness<RowData, RowData> testHarness =
+                createTestHarness(true, true, false);
+        testHarness.open();
+        testHarness.processElement(insertRecord("book", 10, 1L));
+        testHarness.processElement(insertRecord("book", 11, 2L));
+        testHarness.processElement(insertRecord("book", 13, 1L));
+        // output is empty because bundle not trigger yet.
+        Assert.assertTrue(testHarness.getOutput().isEmpty());
+        // bundle trigger emit.
+        testHarness.processElement(insertRecord("book", 12, 1L));
+        List<Object> expectedOutput = new ArrayList<>();
+        expectedOutput.add(insertRecord("book", 10, 1L));
+        assertor.assertOutputEqualsSorted("output wrong.", expectedOutput, testHarness.getOutput());
+
+        // clear state.
+        testHarness.setStateTtlProcessingTime(10);
+
+        testHarness.processElement(insertRecord("book", 14, 3L));
+        testHarness.processElement(insertRecord("book", 15, 1L));
+        // watermark trigger emit.
+        testHarness.processWatermark(new Watermark(3L));
+        expectedOutput.add(insertRecord("book", 15, 1L));
+        expectedOutput.add(new Watermark(3L));
+        testHarness.close();
+        assertor.assertOutputEqualsSorted("output wrong.", expectedOutput, testHarness.getOutput());
+    }
+
+    private OneInputStreamOperatorTestHarness<RowData, RowData> createTestHarness(
+            boolean generateUpdateBefore, boolean generateInsert, boolean keepLastRow)
+            throws Exception {
+        RowTimeMiniBatchLatestChangeDeduplicateFunction func =
+                new RowTimeMiniBatchLatestChangeDeduplicateFunction(
+                        inputRowType,
+                        serializer,
+                        minTtlTime.toMilliseconds(),
+                        rowTimeIndex,
+                        generateUpdateBefore,
+                        generateInsert,
+                        keepLastRow);
+        CountBundleTrigger trigger = new CountBundleTrigger<RowData>(miniBatchSize);
+        KeyedMapBundleOperator<RowData, RowData, RowData, RowData> keyedMapBundleOperator =
+                new KeyedMapBundleOperator(func, trigger);
+        return createTestHarness(keyedMapBundleOperator);
+    }
+}

--- a/flink-table/flink-table-runtime/src/test/java/org/apache/flink/table/runtime/operators/deduplicate/RowTimeMiniBatchLatestChangeDeduplicateFunctionTest.java
+++ b/flink-table/flink-table-runtime/src/test/java/org/apache/flink/table/runtime/operators/deduplicate/RowTimeMiniBatchLatestChangeDeduplicateFunctionTest.java
@@ -34,7 +34,7 @@ import static org.apache.flink.table.runtime.util.StreamRecordUtils.insertRecord
 import static org.apache.flink.table.runtime.util.StreamRecordUtils.updateAfterRecord;
 import static org.apache.flink.table.runtime.util.StreamRecordUtils.updateBeforeRecord;
 
-/** Harness tests for {@link RowTimeMiniBatchLatestChangeDeduplicateFunction} */
+/** Harness tests for {@link RowTimeMiniBatchLatestChangeDeduplicateFunction}. */
 public class RowTimeMiniBatchLatestChangeDeduplicateFunctionTest
         extends RowTimeDeduplicateFunctionTestBase {
 


### PR DESCRIPTION
## What is the purpose of the change

current we keep all change log for row-time deduplicate mini-batch,
we need buffer all record on heap.
In some cases, users do not need all change logs;
In this way, the memory pressure and the calculation pressure of downstream operators can be reduced.


## Brief change log

add new impl `RowTimeMiniBatchLatestChangelogDeduplicateFunction`;


## Verifying this change

Added test that validates that row-time deduplicate mini-batch disable send all change logs, the result is as expected.

## Does this pull request potentially affect one of the following parts:

  - Dependencies (does it add or upgrade a dependency): (no)
  - The public API, i.e., is any changed class annotated with `@Public(Evolving)`: (no)
  - The serializers: (no)
  - The runtime per-record code paths (performance sensitive): (no)
  - Anything that affects deployment or recovery: JobManager (and its components), Checkpointing, Kubernetes/Yarn, ZooKeeper: (no)
  - The S3 file system connector: (no)

## Documentation

  - Does this pull request introduce a new feature? (no)
  - If yes, how is the feature documented? (not documented)
