### PR TITLE
[FLINK-23537][table-common] Make JoinedRowData public

### DIFF
--- a/flink-table/flink-table-common/src/main/java/org/apache/flink/table/connector/source/abilities/SupportsReadingMetadata.java
+++ b/flink-table/flink-table-common/src/main/java/org/apache/flink/table/connector/source/abilities/SupportsReadingMetadata.java
@@ -24,6 +24,7 @@ import org.apache.flink.table.api.TableSchema;
 import org.apache.flink.table.connector.format.DecodingFormat;
 import org.apache.flink.table.connector.source.ScanTableSource;
 import org.apache.flink.table.data.RowData;
+import org.apache.flink.table.data.utils.JoinedRowData;
 import org.apache.flink.table.factories.Factory;
 import org.apache.flink.table.types.DataType;
 import org.apache.flink.table.types.logical.LogicalType;
@@ -60,7 +61,8 @@ import java.util.Map;
  * <p>The planner will select required metadata columns (i.e. perform projection push down) and will
  * call {@link #applyReadableMetadata(List, DataType)} with a list of metadata keys. An
  * implementation must ensure that metadata columns are appended at the end of the physical row in
- * the order of the provided list after the apply method has been called.
+ * the order of the provided list after the apply method has been called, e.g. using {@link
+ * JoinedRowData}.
  *
  * <p>Note: The final output data type emitted by a source changes from the physically produced data
  * type to a data type with metadata columns. {@link #applyReadableMetadata(List, DataType)} will

--- a/flink-table/flink-table-common/src/test/java/org/apache/flink/table/data/utils/JoinedRowDataTest.java
+++ b/flink-table/flink-table-common/src/test/java/org/apache/flink/table/data/utils/JoinedRowDataTest.java
@@ -1,0 +1,67 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.flink.table.data.utils;
+
+import org.apache.flink.table.data.GenericRowData;
+import org.apache.flink.table.data.RowData;
+import org.apache.flink.table.data.StringData;
+import org.apache.flink.types.RowKind;
+
+import org.junit.Test;
+
+import static org.junit.Assert.assertEquals;
+
+/** Tests for {@link JoinedRowData}. */
+public class JoinedRowDataTest {
+
+    @Test
+    public void testJoinedRows() {
+        final RowData row1 = GenericRowData.of(1L, 2L);
+        final RowData row2 = GenericRowData.of(3L, StringData.fromString("4"));
+        final RowData joinedRow = new JoinedRowData(row1, row2);
+
+        assertEquals(RowKind.INSERT, joinedRow.getRowKind());
+        assertEquals(4, joinedRow.getArity());
+        assertEquals(1L, joinedRow.getLong(0));
+        assertEquals(2L, joinedRow.getLong(1));
+        assertEquals(3L, joinedRow.getLong(2));
+        assertEquals("4", joinedRow.getString(3).toString());
+    }
+
+    @Test
+    public void testJoinedRowKind() {
+        final RowData joinedRow =
+                new JoinedRowData(RowKind.DELETE, GenericRowData.of(), GenericRowData.of());
+        assertEquals(RowKind.DELETE, joinedRow.getRowKind());
+    }
+
+    @Test
+    public void testReplace() {
+        final RowData row1 = GenericRowData.of(1L);
+        final RowData row2 = GenericRowData.of(2L);
+        final JoinedRowData joinedRow = new JoinedRowData(row1, row2);
+        assertEquals(2, joinedRow.getArity());
+
+        joinedRow.replace(GenericRowData.of(3L), GenericRowData.of(4L, 5L));
+        assertEquals(3, joinedRow.getArity());
+        assertEquals(3L, joinedRow.getLong(0));
+        assertEquals(4L, joinedRow.getLong(1));
+        assertEquals(5L, joinedRow.getLong(2));
+    }
+}


### PR DESCRIPTION
## What is the purpose of the change

This exposes `JoinedRowData` as public API. When implementing Table API connectors, the need to join `RowData` arises naturally from having to append metadata to the produced physical row. We should therefore make it easy for implementors to do so without relying on internal APIs.

This PR makes the class public, updates its documentation and adds some basic tests for it.

## Verifying this change

This change is already covered by existing tests. However, `JoinedRowDataTest` has also been added.

## Does this pull request potentially affect one of the following parts:

  - Dependencies (does it add or upgrade a dependency): no
  - The public API, i.e., is any changed class annotated with `@Public(Evolving)`: yes
  - The serializers: no
  - The runtime per-record code paths (performance sensitive): "yes", but no actual runtime behavior has been changed
  - Anything that affects deployment or recovery: JobManager (and its components), Checkpointing, Kubernetes/Yarn, ZooKeeper: no
  - The S3 file system connector: no

## Documentation

  - Does this pull request introduce a new feature? no
  - If yes, how is the feature documented? JavaDocs
