### PR TITLE
[FLINK-23534] Fix flink-dstl-dfs version used in changelog statebackend

### DIFF
--- a/flink-state-backends/flink-statebackend-changelog/pom.xml
+++ b/flink-state-backends/flink-statebackend-changelog/pom.xml
@@ -66,7 +66,7 @@ under the License.
 
 		<dependency>
 			<groupId>org.apache.flink</groupId>
-			<artifactId>flink-dstl-dfs_2.11</artifactId>
+			<artifactId>flink-dstl-dfs_${scala.binary.version}</artifactId>
 			<version>${project.version}</version>
 			<scope>test</scope>
 		</dependency>


### PR DESCRIPTION
## What is the purpose of the change

Fix FLINK-23534: 

```
[INFO] --- maven-enforcer-plugin:3.0.0-M1:enforce (enforce-versions) @ flink-statebackend-changelog ---
[WARNING] Rule 0: org.apache.maven.plugins.enforcer.BannedDependencies failed with message:
Found Banned Dependency: org.apache.flink:flink-streaming-java_2.11:jar:1.14-SNAPSHOT
Found Banned Dependency: org.apache.flink:flink-streaming-java_2.11:test-jar:tests:1.14-SNAPSHOT
Found Banned Dependency: com.twitter:chill_2.11:jar:0.7.6
Found Banned Dependency: org.apache.flink:flink-scala_2.11:jar:1.14-SNAPSHOT
Found Banned Dependency: org.apache.flink:flink-dstl-dfs_2.11:jar:1.14-SNAPSHOT
Use 'mvn dependency:tree' to locate the source of the banned dependencies.
```

## Does this pull request potentially affect one of the following parts:

  - Dependencies (does it add or upgrade a dependency): no
  - The public API, i.e., is any changed class annotated with `@Public(Evolving)`: no
  - The serializers: no
  - The runtime per-record code paths (performance sensitive): no
  - Anything that affects deployment or recovery: JobManager (and its components), Checkpointing, Kubernetes/Yarn/Mesos, ZooKeeper: no
  - The S3 file system connector: no

## Documentation

  - Does this pull request introduce a new feature? no
  - If yes, how is the feature documented? no
