### PR TITLE
[FLINK-21080][runtime][checkpoint] Handle UnionListState with finished operators

### DIFF
--- a/flink-runtime/src/main/java/org/apache/flink/runtime/checkpoint/CheckpointCoordinator.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/checkpoint/CheckpointCoordinator.java
@@ -1314,6 +1314,9 @@ public class CheckpointCoordinator {
 
     private void sendAbortedMessages(
             List<ExecutionVertex> tasksToAbort, long checkpointId, long timeStamp) {
+        assert (Thread.holdsLock(lock));
+        long latestCompletedCheckpointId = completedCheckpointStore.getLatestCheckpointId();
+
         // send notification of aborted checkpoints asynchronously.
         executor.execute(
                 () -> {
@@ -1321,7 +1324,8 @@ public class CheckpointCoordinator {
                     for (ExecutionVertex ev : tasksToAbort) {
                         Execution ee = ev.getCurrentExecutionAttempt();
                         if (ee != null) {
-                            ee.notifyCheckpointAborted(checkpointId, timeStamp);
+                            ee.notifyCheckpointAborted(
+                                    checkpointId, latestCompletedCheckpointId, timeStamp);
                         }
                     }
                 });

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/checkpoint/CheckpointPlan.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/checkpoint/CheckpointPlan.java
@@ -50,18 +50,23 @@ class CheckpointPlan {
     /** The job vertices whose tasks are all finished when taking the checkpoint. */
     private final List<ExecutionJobVertex> fullyFinishedJobVertex;
 
+    /** Whether we support checkpoints after some tasks finished. */
+    private final boolean mayHaveFinishedTasks;
+
     CheckpointPlan(
             List<Execution> tasksToTrigger,
             List<Execution> tasksToWaitFor,
             List<ExecutionVertex> tasksToCommitTo,
             List<Execution> finishedTasks,
-            List<ExecutionJobVertex> fullyFinishedJobVertex) {
+            List<ExecutionJobVertex> fullyFinishedJobVertex,
+            boolean mayHaveFinishedTasks) {
 
         this.tasksToTrigger = checkNotNull(tasksToTrigger);
         this.tasksToWaitFor = checkNotNull(tasksToWaitFor);
         this.tasksToCommitTo = checkNotNull(tasksToCommitTo);
         this.finishedTasks = checkNotNull(finishedTasks);
         this.fullyFinishedJobVertex = checkNotNull(fullyFinishedJobVertex);
+        this.mayHaveFinishedTasks = mayHaveFinishedTasks;
     }
 
     List<Execution> getTasksToTrigger() {
@@ -82,5 +87,9 @@ class CheckpointPlan {
 
     public List<ExecutionJobVertex> getFullyFinishedJobVertex() {
         return fullyFinishedJobVertex;
+    }
+
+    public boolean isMayHaveFinishedTasks() {
+        return mayHaveFinishedTasks;
     }
 }

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/checkpoint/CompletedCheckpointStore.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/checkpoint/CompletedCheckpointStore.java
@@ -85,6 +85,21 @@ public interface CompletedCheckpointStore {
         return lastCompleted;
     }
 
+    /** Returns the id of the latest completed checkpoints. */
+    default long getLatestCheckpointId() {
+        try {
+            List<CompletedCheckpoint> allCheckpoints = getAllCheckpoints();
+            if (allCheckpoints.isEmpty()) {
+                return 0;
+            }
+
+            return allCheckpoints.get(allCheckpoints.size() - 1).getCheckpointID();
+        } catch (Throwable throwable) {
+            LOG.warn("Get the latest completed checkpoints failed", throwable);
+            return 0;
+        }
+    }
+
     /**
      * Shuts down the store.
      *

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/checkpoint/DefaultCheckpointPlanCalculator.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/checkpoint/DefaultCheckpointPlanCalculator.java
@@ -170,7 +170,8 @@ public class DefaultCheckpointPlanCalculator implements CheckpointPlanCalculator
                 Collections.unmodifiableList(tasksToWaitFor),
                 Collections.unmodifiableList(allTasks),
                 Collections.emptyList(),
-                Collections.emptyList());
+                Collections.emptyList(),
+                allowCheckpointsAfterTasksFinished);
     }
 
     /**
@@ -237,7 +238,8 @@ public class DefaultCheckpointPlanCalculator implements CheckpointPlanCalculator
                 Collections.unmodifiableList(tasksToWaitFor),
                 Collections.unmodifiableList(tasksToCommitTo),
                 Collections.unmodifiableList(finishedTasks),
-                Collections.unmodifiableList(fullyFinishedJobVertex));
+                Collections.unmodifiableList(fullyFinishedJobVertex),
+                allowCheckpointsAfterTasksFinished);
     }
 
     private boolean someTasksMustBeTriggered(

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/checkpoint/PendingCheckpoint.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/checkpoint/PendingCheckpoint.java
@@ -423,10 +423,11 @@ public class PendingCheckpoint implements Checkpoint {
             long ackTimestamp = System.currentTimeMillis();
 
             for (OperatorIDPair operatorID : operatorIDs) {
-                if (operatorSubtaskStates != null && operatorSubtaskStates.isFinished()) {
-                    updateFinishedOperatorState(vertex, operatorID);
+                if (operatorSubtaskStates != null && operatorSubtaskStates.isFinishedOnRestore()) {
+                    updateFinishedOnRestoreOperatorState(vertex, operatorID);
                 } else {
-                    updateNonFinishedOperatorState(vertex, operatorSubtaskStates, operatorID);
+                    updateNonFinishedOnRestoreOperatorState(
+                            vertex, operatorSubtaskStates, operatorID);
                 }
             }
 
@@ -471,7 +472,8 @@ public class PendingCheckpoint implements Checkpoint {
         }
     }
 
-    private void updateFinishedOperatorState(ExecutionVertex vertex, OperatorIDPair operatorID) {
+    private void updateFinishedOnRestoreOperatorState(
+            ExecutionVertex vertex, OperatorIDPair operatorID) {
         OperatorState operatorState = operatorStates.get(operatorID.getGeneratedOperatorID());
 
         if (operatorState == null) {
@@ -492,7 +494,7 @@ public class PendingCheckpoint implements Checkpoint {
         }
     }
 
-    private void updateNonFinishedOperatorState(
+    private void updateNonFinishedOnRestoreOperatorState(
             ExecutionVertex vertex,
             TaskStateSnapshot operatorSubtaskStates,
             OperatorIDPair operatorID) {

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/checkpoint/PendingCheckpoint.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/checkpoint/PendingCheckpoint.java
@@ -25,14 +25,17 @@ import org.apache.flink.runtime.executiongraph.Execution;
 import org.apache.flink.runtime.executiongraph.ExecutionAttemptID;
 import org.apache.flink.runtime.executiongraph.ExecutionJobVertex;
 import org.apache.flink.runtime.executiongraph.ExecutionVertex;
+import org.apache.flink.runtime.jobgraph.JobVertexID;
 import org.apache.flink.runtime.jobgraph.OperatorID;
 import org.apache.flink.runtime.operators.coordination.OperatorInfo;
 import org.apache.flink.runtime.state.CheckpointMetadataOutputStream;
 import org.apache.flink.runtime.state.CheckpointStorageLocation;
 import org.apache.flink.runtime.state.CompletedCheckpointStorageLocation;
+import org.apache.flink.runtime.state.OperatorStateHandle;
 import org.apache.flink.runtime.state.StateUtil;
 import org.apache.flink.runtime.state.memory.ByteStreamStateHandle;
 import org.apache.flink.util.ExceptionUtils;
+import org.apache.flink.util.FlinkRuntimeException;
 import org.apache.flink.util.Preconditions;
 
 import org.slf4j.Logger;
@@ -46,12 +49,15 @@ import java.util.Collection;
 import java.util.Collections;
 import java.util.HashMap;
 import java.util.HashSet;
+import java.util.IdentityHashMap;
 import java.util.List;
 import java.util.Map;
+import java.util.Objects;
 import java.util.Set;
 import java.util.concurrent.CompletableFuture;
 import java.util.concurrent.Executor;
 import java.util.concurrent.ScheduledFuture;
+import java.util.stream.Stream;
 
 import static org.apache.flink.util.Preconditions.checkArgument;
 import static org.apache.flink.util.Preconditions.checkNotNull;
@@ -102,6 +108,10 @@ public class PendingCheckpoint implements Checkpoint {
 
     /** Set of acknowledged tasks. */
     private final Set<ExecutionAttemptID> acknowledgedTasks;
+
+    private final Set<JobVertexID> fullyFinishedOrFinishedOnRestoreVertex;
+
+    private final IdentityHashMap<ExecutionJobVertex, Integer> vertexOperatorsFinishedTasksCount;
 
     /** The checkpoint properties. */
     private final CheckpointProperties props;
@@ -163,6 +173,16 @@ public class PendingCheckpoint implements Checkpoint {
                         ? Collections.emptySet()
                         : new HashSet<>(operatorCoordinatorsToConfirm);
         this.acknowledgedTasks = new HashSet<>(checkpointPlan.getTasksToWaitFor().size());
+
+        this.fullyFinishedOrFinishedOnRestoreVertex = new HashSet<>();
+        checkpointPlan
+                .getFullyFinishedJobVertex()
+                .forEach(
+                        jobVertex ->
+                                fullyFinishedOrFinishedOnRestoreVertex.add(
+                                        jobVertex.getJobVertexId()));
+        this.vertexOperatorsFinishedTasksCount = new IdentityHashMap<>();
+
         this.onCompletionPromise = checkNotNull(onCompletionPromise);
     }
 
@@ -313,6 +333,19 @@ public class PendingCheckpoint implements Checkpoint {
 
             // make sure we fulfill the promise with an exception if something fails
             try {
+                if (checkpointPlan.isMayHaveFinishedTasks()) {
+                    Map<JobVertexID, ExecutionJobVertex> partlyFinishedVertex = new HashMap<>();
+                    for (Execution task : checkpointPlan.getFinishedTasks()) {
+                        JobVertexID jobVertexId = task.getVertex().getJobvertexId();
+                        if (!fullyFinishedOrFinishedOnRestoreVertex.contains(jobVertexId)) {
+                            partlyFinishedVertex.put(jobVertexId, task.getVertex().getJobVertex());
+                        }
+                    }
+
+                    checkNoPartlyFinishedVertexUsedUnionListState(partlyFinishedVertex);
+                    checkNoPartlyOperatorsFinishedVertexUsedUnionListState(partlyFinishedVertex);
+                }
+
                 fulfillFullyFinishedOperatorStates();
 
                 // write out the metadata
@@ -366,6 +399,85 @@ public class PendingCheckpoint implements Checkpoint {
                 return null; // silence the compiler
             }
         }
+    }
+
+    /**
+     * If a job vertex using {@code UnionListState} has part of tasks FINISHED where others are
+     * still in RUNNING state, the checkpoint would be aborted since it might cause incomplete
+     * {@code UnionListState}.
+     */
+    private void checkNoPartlyFinishedVertexUsedUnionListState(
+            Map<JobVertexID, ExecutionJobVertex> partlyFinishedVertex) {
+        for (ExecutionJobVertex vertex : partlyFinishedVertex.values()) {
+            if (hasUsedUnionListState(vertex)) {
+                throw new FlinkRuntimeException(
+                        String.format(
+                                "The vertex %s (id = %s) has used"
+                                        + " UnionListState, but part of its tasks are FINISHED.",
+                                vertex.getName(), vertex.getJobVertexId()));
+            }
+        }
+    }
+
+    /**
+     * If a job vertex using {@code UnionListState} has all the tasks in RUNNING state, but part of
+     * the tasks have reported that the operators are finished, the checkpoint would be aborted.
+     * This is to force the fast tasks wait for the slow tasks so that their final checkpoints would
+     * be the same one, otherwise if the fast tasks finished, the slow tasks would be blocked
+     * forever since all the following checkpoints would be aborted.
+     */
+    private void checkNoPartlyOperatorsFinishedVertexUsedUnionListState(
+            Map<JobVertexID, ExecutionJobVertex> partlyFinishedVertex) {
+        for (Map.Entry<ExecutionJobVertex, Integer> entry :
+                vertexOperatorsFinishedTasksCount.entrySet()) {
+            ExecutionJobVertex vertex = entry.getKey();
+
+            // If the vertex is partly finished, then it must not used UnionListState
+            // due to it passed the previous check.
+            if (partlyFinishedVertex.containsKey(vertex.getJobVertexId())) {
+                continue;
+            }
+
+            if (entry.getValue() != vertex.getParallelism() && hasUsedUnionListState(vertex)) {
+                throw new FlinkRuntimeException(
+                        String.format(
+                                "The vertex %s (id = %s) has used"
+                                        + " UnionListState, but part of its tasks has called operators' finish method.",
+                                vertex.getName(), vertex.getJobVertexId()));
+            }
+        }
+    }
+
+    private boolean hasUsedUnionListState(ExecutionJobVertex vertex) {
+        for (OperatorIDPair operatorIDPair : vertex.getOperatorIDs()) {
+            OperatorState operatorState =
+                    operatorStates.get(operatorIDPair.getGeneratedOperatorID());
+            if (operatorState == null) {
+                continue;
+            }
+
+            for (OperatorSubtaskState operatorSubtaskState : operatorState.getStates()) {
+                boolean hasUnionListState =
+                        Stream.concat(
+                                        operatorSubtaskState.getManagedOperatorState().stream(),
+                                        operatorSubtaskState.getRawOperatorState().stream())
+                                .filter(Objects::nonNull)
+                                .flatMap(
+                                        operatorStateHandle ->
+                                                operatorStateHandle.getStateNameToPartitionOffsets()
+                                                        .values().stream())
+                                .anyMatch(
+                                        stateMetaInfo ->
+                                                stateMetaInfo.getDistributionMode()
+                                                        == OperatorStateHandle.Mode.UNION);
+
+                if (hasUnionListState) {
+                    return true;
+                }
+            }
+        }
+
+        return false;
     }
 
     private void fulfillFullyFinishedOperatorStates() {
@@ -492,6 +604,8 @@ public class PendingCheckpoint implements Checkpoint {
                                     + "which is impossible.",
                             vertex.getTaskNameWithSubtaskIndex(), vertex.getJobvertexId()));
         }
+
+        fullyFinishedOrFinishedOnRestoreVertex.add(vertex.getJobvertexId());
     }
 
     private void updateNonFinishedOnRestoreOperatorState(
@@ -516,6 +630,11 @@ public class PendingCheckpoint implements Checkpoint {
 
         if (operatorSubtaskState != null) {
             operatorState.putState(vertex.getParallelSubtaskIndex(), operatorSubtaskState);
+        }
+
+        if (operatorSubtaskStates != null && operatorSubtaskStates.isOperatorsFinished()) {
+            vertexOperatorsFinishedTasksCount.compute(
+                    vertex.getJobVertex(), (k, v) -> v == null ? 1 : v + 1);
         }
     }
 

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/checkpoint/StateAssignmentOperation.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/checkpoint/StateAssignmentOperation.java
@@ -227,7 +227,8 @@ public class StateAssignmentOperation {
 
     private void assignFinishedStateToTask(Execution currentExecutionAttempt) {
         JobManagerTaskRestore taskRestore =
-                new JobManagerTaskRestore(restoreCheckpointId, TaskStateSnapshot.FINISHED);
+                new JobManagerTaskRestore(
+                        restoreCheckpointId, TaskStateSnapshot.FINISHED_ON_RESTORE);
         currentExecutionAttempt.setInitialState(taskRestore);
     }
 

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/checkpoint/StateAssignmentOperation.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/checkpoint/StateAssignmentOperation.java
@@ -237,7 +237,7 @@ public class StateAssignmentOperation {
             List<OperatorIDPair> operatorIDs,
             int subTaskIndex,
             Execution currentExecutionAttempt) {
-        TaskStateSnapshot taskState = new TaskStateSnapshot(operatorIDs.size());
+        TaskStateSnapshot taskState = new TaskStateSnapshot(operatorIDs.size(), false);
         boolean statelessTask = true;
 
         for (OperatorIDPair operatorID : operatorIDs) {

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/checkpoint/TaskStateSnapshot.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/checkpoint/TaskStateSnapshot.java
@@ -57,12 +57,13 @@ public class TaskStateSnapshot implements CompositeStateHandle {
 
     private static final long serialVersionUID = 1L;
 
-    public static final TaskStateSnapshot FINISHED = new TaskStateSnapshot(new HashMap<>(), true);
+    public static final TaskStateSnapshot FINISHED_ON_RESTORE =
+            new TaskStateSnapshot(new HashMap<>(), true);
 
     /** Mapping from an operator id to the state of one subtask of this operator. */
     private final Map<OperatorID, OperatorSubtaskState> subtaskStatesByOperatorID;
 
-    private final boolean isFinished;
+    private final boolean isFinishedOnRestore;
 
     public TaskStateSnapshot() {
         this(10);
@@ -77,14 +78,15 @@ public class TaskStateSnapshot implements CompositeStateHandle {
     }
 
     private TaskStateSnapshot(
-            Map<OperatorID, OperatorSubtaskState> subtaskStatesByOperatorID, boolean isFinished) {
+            Map<OperatorID, OperatorSubtaskState> subtaskStatesByOperatorID,
+            boolean isFinishedOnRestore) {
         this.subtaskStatesByOperatorID = Preconditions.checkNotNull(subtaskStatesByOperatorID);
-        this.isFinished = isFinished;
+        this.isFinishedOnRestore = isFinishedOnRestore;
     }
 
-    /** Returns whether all the operators of the task are finished. */
-    public boolean isFinished() {
-        return isFinished;
+    /** Returns whether all the operators of the task are already finished on restoring. */
+    public boolean isFinishedOnRestore() {
+        return isFinishedOnRestore;
     }
 
     /** Returns the subtask state for the given operator id (or null if not contained). */
@@ -118,7 +120,7 @@ public class TaskStateSnapshot implements CompositeStateHandle {
                 return true;
             }
         }
-        return isFinished;
+        return isFinishedOnRestore;
     }
 
     /**
@@ -176,12 +178,12 @@ public class TaskStateSnapshot implements CompositeStateHandle {
         TaskStateSnapshot that = (TaskStateSnapshot) o;
 
         return subtaskStatesByOperatorID.equals(that.subtaskStatesByOperatorID)
-                && isFinished == that.isFinished;
+                && isFinishedOnRestore == that.isFinishedOnRestore;
     }
 
     @Override
     public int hashCode() {
-        return Objects.hash(subtaskStatesByOperatorID, isFinished);
+        return Objects.hash(subtaskStatesByOperatorID, isFinishedOnRestore);
     }
 
     @Override
@@ -190,7 +192,7 @@ public class TaskStateSnapshot implements CompositeStateHandle {
                 + "subtaskStatesByOperatorID="
                 + subtaskStatesByOperatorID
                 + ", isFinished="
-                + isFinished
+                + isFinishedOnRestore
                 + '}';
     }
 

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/checkpoint/TaskStateSnapshot.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/checkpoint/TaskStateSnapshot.java
@@ -58,35 +58,44 @@ public class TaskStateSnapshot implements CompositeStateHandle {
     private static final long serialVersionUID = 1L;
 
     public static final TaskStateSnapshot FINISHED_ON_RESTORE =
-            new TaskStateSnapshot(new HashMap<>(), true);
+            new TaskStateSnapshot(new HashMap<>(), true, true);
 
     /** Mapping from an operator id to the state of one subtask of this operator. */
     private final Map<OperatorID, OperatorSubtaskState> subtaskStatesByOperatorID;
 
     private final boolean isFinishedOnRestore;
 
+    private final boolean isOperatorsFinished;
+
     public TaskStateSnapshot() {
-        this(10);
+        this(10, false);
     }
 
-    public TaskStateSnapshot(int size) {
-        this(new HashMap<>(size));
+    public TaskStateSnapshot(int size, boolean isOperatorsFinished) {
+        this(new HashMap<>(size), false, isOperatorsFinished);
     }
 
     public TaskStateSnapshot(Map<OperatorID, OperatorSubtaskState> subtaskStatesByOperatorID) {
-        this(subtaskStatesByOperatorID, false);
+        this(subtaskStatesByOperatorID, false, false);
     }
 
     private TaskStateSnapshot(
             Map<OperatorID, OperatorSubtaskState> subtaskStatesByOperatorID,
-            boolean isFinishedOnRestore) {
+            boolean isFinishedOnRestore,
+            boolean isOperatorsFinished) {
         this.subtaskStatesByOperatorID = Preconditions.checkNotNull(subtaskStatesByOperatorID);
         this.isFinishedOnRestore = isFinishedOnRestore;
+        this.isOperatorsFinished = isOperatorsFinished;
     }
 
     /** Returns whether all the operators of the task are already finished on restoring. */
     public boolean isFinishedOnRestore() {
         return isFinishedOnRestore;
+    }
+
+    /** Returns whether all the operators of the task have called finished methods. */
+    public boolean isOperatorsFinished() {
+        return isOperatorsFinished;
     }
 
     /** Returns the subtask state for the given operator id (or null if not contained). */
@@ -178,12 +187,13 @@ public class TaskStateSnapshot implements CompositeStateHandle {
         TaskStateSnapshot that = (TaskStateSnapshot) o;
 
         return subtaskStatesByOperatorID.equals(that.subtaskStatesByOperatorID)
-                && isFinishedOnRestore == that.isFinishedOnRestore;
+                && isFinishedOnRestore == that.isFinishedOnRestore
+                && isOperatorsFinished == that.isOperatorsFinished;
     }
 
     @Override
     public int hashCode() {
-        return Objects.hash(subtaskStatesByOperatorID, isFinishedOnRestore);
+        return Objects.hash(subtaskStatesByOperatorID, isFinishedOnRestore, isOperatorsFinished);
     }
 
     @Override
@@ -193,6 +203,8 @@ public class TaskStateSnapshot implements CompositeStateHandle {
                 + subtaskStatesByOperatorID
                 + ", isFinished="
                 + isFinishedOnRestore
+                + ", isOperatorsFinished="
+                + isOperatorsFinished
                 + '}';
     }
 

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/executiongraph/Execution.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/executiongraph/Execution.java
@@ -796,16 +796,22 @@ public class Execution
      * Notify the task of this execution about a aborted checkpoint.
      *
      * @param abortCheckpointId of the subsumed checkpoint
+     * @param latestCompletedCheckpointId of the latest completed checkpoint
      * @param timestamp of the subsumed checkpoint
      */
-    public void notifyCheckpointAborted(long abortCheckpointId, long timestamp) {
+    public void notifyCheckpointAborted(
+            long abortCheckpointId, long latestCompletedCheckpointId, long timestamp) {
         final LogicalSlot slot = assignedResource;
 
         if (slot != null) {
             final TaskManagerGateway taskManagerGateway = slot.getTaskManagerGateway();
 
             taskManagerGateway.notifyCheckpointAborted(
-                    attemptId, getVertex().getJobId(), abortCheckpointId, timestamp);
+                    attemptId,
+                    getVertex().getJobId(),
+                    abortCheckpointId,
+                    latestCompletedCheckpointId,
+                    timestamp);
         } else {
             LOG.debug(
                     "The execution has no slot assigned. This indicates that the execution is "

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/jobgraph/tasks/AbstractInvokable.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/jobgraph/tasks/AbstractInvokable.java
@@ -282,9 +282,11 @@ public abstract class AbstractInvokable {
      * notification.
      *
      * @param checkpointId The ID of the checkpoint that is aborted.
+     * @param latestCompletedCheckpointId The ID of the latest completed checkpoint.
      * @return future that completes when the notification has been processed by the task.
      */
-    public Future<Void> notifyCheckpointAbortAsync(long checkpointId) {
+    public Future<Void> notifyCheckpointAbortAsync(
+            long checkpointId, long latestCompletedCheckpointId) {
         throw new UnsupportedOperationException(
                 String.format(
                         "notifyCheckpointAbortAsync not supported by %s",

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/jobmanager/slots/TaskManagerGateway.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/jobmanager/slots/TaskManagerGateway.java
@@ -102,10 +102,15 @@ public interface TaskManagerGateway extends TaskExecutorOperatorEventGateway {
      * @param executionAttemptID identifying the task
      * @param jobId identifying the job to which the task belongs
      * @param checkpointId of the subsumed checkpoint
+     * @param latestCompletedCheckpointId of the latest completed checkpoint
      * @param timestamp of the subsumed checkpoint
      */
     void notifyCheckpointAborted(
-            ExecutionAttemptID executionAttemptID, JobID jobId, long checkpointId, long timestamp);
+            ExecutionAttemptID executionAttemptID,
+            JobID jobId,
+            long checkpointId,
+            long latestCompletedCheckpointId,
+            long timestamp);
 
     /**
      * Trigger for the given task a checkpoint.

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/jobmaster/RpcTaskManagerGateway.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/jobmaster/RpcTaskManagerGateway.java
@@ -87,8 +87,13 @@ public class RpcTaskManagerGateway implements TaskManagerGateway {
 
     @Override
     public void notifyCheckpointAborted(
-            ExecutionAttemptID executionAttemptID, JobID jobId, long checkpointId, long timestamp) {
-        taskExecutorGateway.abortCheckpoint(executionAttemptID, checkpointId, timestamp);
+            ExecutionAttemptID executionAttemptID,
+            JobID jobId,
+            long checkpointId,
+            long latestCompletedCheckpointId,
+            long timestamp) {
+        taskExecutorGateway.abortCheckpoint(
+                executionAttemptID, checkpointId, latestCompletedCheckpointId, timestamp);
     }
 
     @Override

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/state/TaskLocalStateStoreImpl.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/state/TaskLocalStateStoreImpl.java
@@ -57,7 +57,7 @@ public class TaskLocalStateStoreImpl implements OwnedTaskLocalStateStore {
     private static final Logger LOG = LoggerFactory.getLogger(TaskLocalStateStoreImpl.class);
 
     /** Dummy value to use instead of null to satisfy {@link ConcurrentHashMap}. */
-    @VisibleForTesting static final TaskStateSnapshot NULL_DUMMY = new TaskStateSnapshot(0);
+    @VisibleForTesting static final TaskStateSnapshot NULL_DUMMY = new TaskStateSnapshot(0, false);
 
     /** JobID from the owning subtask. */
     @Nonnull private final JobID jobID;

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/state/TaskStateManagerImpl.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/state/TaskStateManagerImpl.java
@@ -160,7 +160,7 @@ public class TaskStateManagerImpl implements TaskStateManager {
             return false;
         }
 
-        return jobManagerTaskRestore.getTaskStateSnapshot().isFinished();
+        return jobManagerTaskRestore.getTaskStateSnapshot().isFinishedOnRestore();
     }
 
     @Override

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/taskexecutor/TaskExecutor.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/taskexecutor/TaskExecutor.java
@@ -1000,7 +1000,10 @@ public class TaskExecutor extends RpcEndpoint implements TaskExecutorGateway {
 
     @Override
     public CompletableFuture<Acknowledge> abortCheckpoint(
-            ExecutionAttemptID executionAttemptID, long checkpointId, long checkpointTimestamp) {
+            ExecutionAttemptID executionAttemptID,
+            long checkpointId,
+            long latestCompletedCheckpointId,
+            long checkpointTimestamp) {
         log.debug(
                 "Abort checkpoint {}@{} for {}.",
                 checkpointId,
@@ -1010,7 +1013,7 @@ public class TaskExecutor extends RpcEndpoint implements TaskExecutorGateway {
         final Task task = taskSlotTable.getTask(executionAttemptID);
 
         if (task != null) {
-            task.notifyCheckpointAborted(checkpointId);
+            task.notifyCheckpointAborted(checkpointId, latestCompletedCheckpointId);
 
             return CompletableFuture.completedFuture(Acknowledge.get());
         } else {

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/taskexecutor/TaskExecutorGateway.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/taskexecutor/TaskExecutorGateway.java
@@ -156,11 +156,15 @@ public interface TaskExecutorGateway
      *
      * @param executionAttemptID identifying the task
      * @param checkpointId unique id for the checkpoint
+     * @param latestCompletedCheckpointId the id of the latest completed checkpoint
      * @param checkpointTimestamp is the timestamp when the checkpoint has been initiated
      * @return Future acknowledge if the checkpoint has been successfully confirmed
      */
     CompletableFuture<Acknowledge> abortCheckpoint(
-            ExecutionAttemptID executionAttemptID, long checkpointId, long checkpointTimestamp);
+            ExecutionAttemptID executionAttemptID,
+            long checkpointId,
+            long latestCompletedCheckpointId,
+            long checkpointTimestamp);
 
     /**
      * Cancel the given task.

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/taskexecutor/TaskExecutorGatewayDecoratorBase.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/taskexecutor/TaskExecutorGatewayDecoratorBase.java
@@ -138,9 +138,12 @@ public class TaskExecutorGatewayDecoratorBase implements TaskExecutorGateway {
 
     @Override
     public CompletableFuture<Acknowledge> abortCheckpoint(
-            ExecutionAttemptID executionAttemptID, long checkpointId, long checkpointTimestamp) {
+            ExecutionAttemptID executionAttemptID,
+            long checkpointId,
+            long latestCompletedCheckpointId,
+            long checkpointTimestamp) {
         return originalGateway.abortCheckpoint(
-                executionAttemptID, checkpointId, checkpointTimestamp);
+                executionAttemptID, checkpointId, latestCompletedCheckpointId, checkpointTimestamp);
     }
 
     @Override

--- a/flink-runtime/src/test/java/org/apache/flink/runtime/checkpoint/CheckpointCoordinatorTestingUtils.java
+++ b/flink-runtime/src/test/java/org/apache/flink/runtime/checkpoint/CheckpointCoordinatorTestingUtils.java
@@ -501,7 +501,11 @@ public class CheckpointCoordinatorTestingUtils {
 
         @Override
         public void notifyCheckpointAborted(
-                ExecutionAttemptID attemptId, JobID jobId, long checkpointId, long timestamp) {
+                ExecutionAttemptID attemptId,
+                JobID jobId,
+                long checkpointId,
+                long latestCompletedCheckpointId,
+                long timestamp) {
             notifiedAbortCheckpoints
                     .computeIfAbsent(attemptId, k -> new ArrayList<>())
                     .add(new NotifiedCheckpoint(jobId, checkpointId, timestamp));

--- a/flink-runtime/src/test/java/org/apache/flink/runtime/checkpoint/CheckpointCoordinatorTestingUtils.java
+++ b/flink-runtime/src/test/java/org/apache/flink/runtime/checkpoint/CheckpointCoordinatorTestingUtils.java
@@ -21,6 +21,7 @@ package org.apache.flink.runtime.checkpoint;
 import org.apache.flink.api.common.JobID;
 import org.apache.flink.api.java.tuple.Tuple2;
 import org.apache.flink.core.fs.FSDataInputStream;
+import org.apache.flink.core.fs.Path;
 import org.apache.flink.core.io.SimpleVersionedSerializer;
 import org.apache.flink.runtime.OperatorIDPair;
 import org.apache.flink.runtime.concurrent.ComponentMainThreadExecutor;
@@ -54,6 +55,7 @@ import org.apache.flink.runtime.state.OperatorStateHandle;
 import org.apache.flink.runtime.state.OperatorStreamStateHandle;
 import org.apache.flink.runtime.state.SharedStateRegistry;
 import org.apache.flink.runtime.state.SharedStateRegistryFactory;
+import org.apache.flink.runtime.state.filesystem.FileStateHandle;
 import org.apache.flink.runtime.state.memory.ByteStreamStateHandle;
 import org.apache.flink.runtime.state.memory.MemoryStateBackend;
 import org.apache.flink.runtime.testtasks.NoOpInvokable;
@@ -67,6 +69,7 @@ import org.junit.Assert;
 
 import javax.annotation.Nullable;
 
+import java.io.File;
 import java.io.IOException;
 import java.io.Serializable;
 import java.nio.charset.StandardCharsets;
@@ -409,6 +412,27 @@ public class CheckpointCoordinatorTestingUtils {
                 generateByteStreamStateHandle(serializedDataWithOffsets.f0);
 
         return new KeyGroupsStateHandle(keyGroupRangeOffsets, allSerializedStatesHandle);
+    }
+
+    public static TaskStateSnapshot createSnapshotWithUnionListState(
+            File stateFile, OperatorID operatorId, boolean isOperatorsFinished) throws IOException {
+        TaskStateSnapshot taskStateSnapshot = new TaskStateSnapshot(1, isOperatorsFinished);
+
+        OperatorSubtaskState operatorSubtaskState =
+                OperatorSubtaskState.builder()
+                        .setManagedOperatorState(
+                                new OperatorStreamStateHandle(
+                                        Collections.singletonMap(
+                                                "test",
+                                                new OperatorStateHandle.StateMetaInfo(
+                                                        new long[0],
+                                                        OperatorStateHandle.Mode.UNION)),
+                                        new FileStateHandle(
+                                                new Path(stateFile.getAbsolutePath()), 0L)))
+                        .build();
+
+        taskStateSnapshot.putSubtaskStateByOperatorID(operatorId, operatorSubtaskState);
+        return taskStateSnapshot;
     }
 
     static class TriggeredCheckpoint {

--- a/flink-runtime/src/test/java/org/apache/flink/runtime/checkpoint/CompletedCheckpointStoreTest.java
+++ b/flink-runtime/src/test/java/org/apache/flink/runtime/checkpoint/CompletedCheckpointStoreTest.java
@@ -198,6 +198,21 @@ public abstract class CompletedCheckpointStoreTest extends TestLogger {
         }
     }
 
+    @Test
+    public void testAcquireLatestCompletedCheckpointId() throws Exception {
+        SharedStateRegistry sharedStateRegistry = new SharedStateRegistry();
+        CompletedCheckpointStore checkpoints = createCompletedCheckpoints(1);
+        assertEquals(0, checkpoints.getLatestCheckpointId());
+
+        checkpoints.addCheckpoint(
+                createCheckpoint(2, sharedStateRegistry), new CheckpointsCleaner(), () -> {});
+        assertEquals(2, checkpoints.getLatestCheckpointId());
+
+        checkpoints.addCheckpoint(
+                createCheckpoint(4, sharedStateRegistry), new CheckpointsCleaner(), () -> {});
+        assertEquals(4, checkpoints.getLatestCheckpointId());
+    }
+
     // ---------------------------------------------------------------------------------------------
 
     public static TestCompletedCheckpoint createCheckpoint(

--- a/flink-runtime/src/test/java/org/apache/flink/runtime/checkpoint/PendingCheckpointTest.java
+++ b/flink-runtime/src/test/java/org/apache/flink/runtime/checkpoint/PendingCheckpointTest.java
@@ -41,11 +41,13 @@ import org.apache.flink.runtime.state.SharedStateRegistry;
 import org.apache.flink.runtime.state.TestingStreamStateHandle;
 import org.apache.flink.runtime.state.filesystem.FsCheckpointStorageLocation;
 import org.apache.flink.runtime.state.memory.ByteStreamStateHandle;
+import org.apache.flink.util.FlinkRuntimeException;
 import org.apache.flink.util.concurrent.Executors;
 
 import org.junit.Assert;
 import org.junit.Rule;
 import org.junit.Test;
+import org.junit.rules.ExpectedException;
 import org.junit.rules.TemporaryFolder;
 import org.mockito.Mockito;
 
@@ -66,6 +68,7 @@ import java.util.concurrent.Executor;
 import java.util.concurrent.ScheduledFuture;
 import java.util.stream.Collectors;
 
+import static org.apache.flink.runtime.checkpoint.CheckpointCoordinatorTestingUtils.createSnapshotWithUnionListState;
 import static org.apache.flink.util.Preconditions.checkNotNull;
 import static org.hamcrest.CoreMatchers.is;
 import static org.hamcrest.Matchers.containsInAnyOrder;
@@ -114,6 +117,8 @@ public class PendingCheckpointTest {
     }
 
     @Rule public final TemporaryFolder tmpFolder = new TemporaryFolder();
+
+    @Rule public final ExpectedException expectedException = ExpectedException.none();
 
     /** Tests that pending checkpoints can be subsumed iff they are forced. */
     @Test
@@ -660,6 +665,129 @@ public class PendingCheckpointTest {
         assertTrue(completedCheckpoint.getOperatorStates().get(operatorId2).isFullyFinished());
     }
 
+    @Test
+    public void testAbortionIfPartlyFinishedVertexUsedUnionListState() throws Exception {
+        JobVertexID jobVertexId = new JobVertexID();
+        OperatorID operatorId = new OperatorID();
+
+        ExecutionGraph executionGraph =
+                new CheckpointCoordinatorTestingUtils.CheckpointExecutionGraphBuilder()
+                        .addJobVertex(
+                                jobVertexId,
+                                2,
+                                2,
+                                Collections.singletonList(
+                                        OperatorIDPair.generatedIDOnly(operatorId)),
+                                true)
+                        .build();
+        ExecutionVertex[] tasks = executionGraph.getJobVertex(jobVertexId).getTaskVertices();
+        tasks[0].getCurrentExecutionAttempt().markFinished();
+
+        PendingCheckpoint pendingCheckpoint = createPendingCheckpoint(executionGraph);
+        pendingCheckpoint.acknowledgeTask(
+                tasks[1].getCurrentExecutionAttempt().getAttemptId(),
+                createSnapshotWithUnionListState(tmpFolder.newFile(), operatorId, false),
+                new CheckpointMetrics(),
+                null);
+
+        assertTrue(pendingCheckpoint.isFullyAcknowledged());
+
+        expectedException.expect(FlinkRuntimeException.class);
+        expectedException.expectMessage(
+                String.format(
+                        "The vertex %s (id = %s) has "
+                                + "used UnionListState, but part of its tasks are FINISHED",
+                        executionGraph.getJobVertex(jobVertexId).getName(), jobVertexId));
+        pendingCheckpoint.finalizeCheckpoint(
+                new CheckpointsCleaner(), () -> {}, Executors.directExecutor(), null);
+    }
+
+    @Test
+    public void testAbortionIfPartlyOperatorsFinishedVertexUsedUnionListState() throws Exception {
+        JobVertexID jobVertexId = new JobVertexID();
+        OperatorID operatorId = new OperatorID();
+
+        ExecutionGraph executionGraph =
+                new CheckpointCoordinatorTestingUtils.CheckpointExecutionGraphBuilder()
+                        .addJobVertex(
+                                jobVertexId,
+                                2,
+                                2,
+                                Collections.singletonList(
+                                        OperatorIDPair.generatedIDOnly(operatorId)),
+                                true)
+                        .build();
+        List<ExecutionAttemptID> runningTaskIds =
+                Arrays.stream(executionGraph.getJobVertex(jobVertexId).getTaskVertices())
+                        .map(task -> task.getCurrentExecutionAttempt().getAttemptId())
+                        .collect(Collectors.toList());
+        assertEquals(2, runningTaskIds.size());
+
+        PendingCheckpoint pendingCheckpoint = createPendingCheckpoint(executionGraph);
+        pendingCheckpoint.acknowledgeTask(
+                runningTaskIds.get(0),
+                createSnapshotWithUnionListState(tmpFolder.newFile(), operatorId, true),
+                new CheckpointMetrics(),
+                null);
+        pendingCheckpoint.acknowledgeTask(
+                runningTaskIds.get(1),
+                createSnapshotWithUnionListState(tmpFolder.newFile(), operatorId, false),
+                new CheckpointMetrics(),
+                null);
+
+        assertTrue(pendingCheckpoint.isFullyAcknowledged());
+
+        expectedException.expect(FlinkRuntimeException.class);
+        expectedException.expectMessage(
+                String.format(
+                        "The vertex %s (id = %s) has "
+                                + "used UnionListState, but part of its tasks has called operators' finish method.",
+                        executionGraph.getJobVertex(jobVertexId).getName(), jobVertexId));
+        pendingCheckpoint.finalizeCheckpoint(
+                new CheckpointsCleaner(), () -> {}, Executors.directExecutor(), null);
+    }
+
+    @Test
+    public void testPendingCheckpointCompletesIfAllReportsOperatorsFinished() throws Exception {
+        JobVertexID jobVertexId = new JobVertexID();
+        OperatorID operatorId = new OperatorID();
+
+        ExecutionGraph executionGraph =
+                new CheckpointCoordinatorTestingUtils.CheckpointExecutionGraphBuilder()
+                        .addJobVertex(
+                                jobVertexId,
+                                2,
+                                2,
+                                Collections.singletonList(
+                                        OperatorIDPair.generatedIDOnly(operatorId)),
+                                true)
+                        .build();
+        List<ExecutionAttemptID> runningTaskIds =
+                Arrays.stream(executionGraph.getJobVertex(jobVertexId).getTaskVertices())
+                        .map(task -> task.getCurrentExecutionAttempt().getAttemptId())
+                        .collect(Collectors.toList());
+        assertEquals(2, runningTaskIds.size());
+
+        PendingCheckpoint pendingCheckpoint = createPendingCheckpoint(executionGraph);
+        pendingCheckpoint.acknowledgeTask(
+                runningTaskIds.get(0),
+                createSnapshotWithUnionListState(tmpFolder.newFile(), operatorId, true),
+                new CheckpointMetrics(),
+                null);
+        pendingCheckpoint.acknowledgeTask(
+                runningTaskIds.get(1),
+                createSnapshotWithUnionListState(tmpFolder.newFile(), operatorId, true),
+                new CheckpointMetrics(),
+                null);
+
+        assertTrue(pendingCheckpoint.isFullyAcknowledged());
+
+        pendingCheckpoint.finalizeCheckpoint(
+                new CheckpointsCleaner(), () -> {}, Executors.directExecutor(), null);
+        assertTrue(pendingCheckpoint.getCompletionFuture().isDone());
+        assertFalse(pendingCheckpoint.getCompletionFuture().isCompletedExceptionally());
+    }
+
     // ------------------------------------------------------------------------
 
     private PendingCheckpoint createPendingCheckpoint(CheckpointProperties props)
@@ -744,7 +872,8 @@ public class PendingCheckpointTest {
                         ackTasks,
                         tasksToCommit,
                         Collections.emptyList(),
-                        Collections.emptyList()),
+                        Collections.emptyList(),
+                        true),
                 operatorCoordinators,
                 masterStateIdentifiers,
                 props,

--- a/flink-runtime/src/test/java/org/apache/flink/runtime/checkpoint/PendingCheckpointTest.java
+++ b/flink-runtime/src/test/java/org/apache/flink/runtime/checkpoint/PendingCheckpointTest.java
@@ -639,7 +639,10 @@ public class PendingCheckpointTest {
         for (ExecutionAttemptID attemptId : runningTaskIds) {
             TaskAcknowledgeResult result =
                     pendingCheckpoint.acknowledgeTask(
-                            attemptId, TaskStateSnapshot.FINISHED, new CheckpointMetrics(), null);
+                            attemptId,
+                            TaskStateSnapshot.FINISHED_ON_RESTORE,
+                            new CheckpointMetrics(),
+                            null);
             assertEquals(TaskAcknowledgeResult.SUCCESS, result);
         }
 

--- a/flink-runtime/src/test/java/org/apache/flink/runtime/checkpoint/StateAssignmentOperationTest.java
+++ b/flink-runtime/src/test/java/org/apache/flink/runtime/checkpoint/StateAssignmentOperationTest.java
@@ -705,14 +705,14 @@ public class StateAssignmentOperationTest extends TestLogger {
         ExecutionJobVertex jobVertexWithFinishedOperator = vertices.get(operatorIds.get(0));
         for (ExecutionVertex task : jobVertexWithFinishedOperator.getTaskVertices()) {
             JobManagerTaskRestore taskRestore = task.getCurrentExecutionAttempt().getTaskRestore();
-            Assert.assertTrue(taskRestore.getTaskStateSnapshot().isFinished());
+            Assert.assertTrue(taskRestore.getTaskStateSnapshot().isFinishedOnRestore());
         }
 
         // Check the job vertex without finished operator.
         ExecutionJobVertex jobVertexWithoutFinishedOperator = vertices.get(operatorIds.get(1));
         for (ExecutionVertex task : jobVertexWithoutFinishedOperator.getTaskVertices()) {
             JobManagerTaskRestore taskRestore = task.getCurrentExecutionAttempt().getTaskRestore();
-            Assert.assertFalse(taskRestore.getTaskStateSnapshot().isFinished());
+            Assert.assertFalse(taskRestore.getTaskStateSnapshot().isFinishedOnRestore());
         }
     }
 

--- a/flink-runtime/src/test/java/org/apache/flink/runtime/executiongraph/utils/SimpleAckingTaskManagerGateway.java
+++ b/flink-runtime/src/test/java/org/apache/flink/runtime/executiongraph/utils/SimpleAckingTaskManagerGateway.java
@@ -137,6 +137,7 @@ public class SimpleAckingTaskManagerGateway implements TaskManagerGateway {
             ExecutionAttemptID executionAttemptID,
             JobID jobId,
             long checkpointId,
+            long latestCompletedCheckpointId,
             long timestamp) {}
 
     @Override

--- a/flink-runtime/src/test/java/org/apache/flink/runtime/operators/coordination/CoordinatorEventsExactlyOnceITCase.java
+++ b/flink-runtime/src/test/java/org/apache/flink/runtime/operators/coordination/CoordinatorEventsExactlyOnceITCase.java
@@ -604,7 +604,8 @@ public class CoordinatorEventsExactlyOnceITCase extends TestLogger {
         }
 
         @Override
-        public Future<Void> notifyCheckpointAbortAsync(long checkpointId) {
+        public Future<Void> notifyCheckpointAbortAsync(
+                long checkpointId, long latestCompletedCheckpointId) {
             return CompletableFuture.completedFuture(null);
         }
 

--- a/flink-runtime/src/test/java/org/apache/flink/runtime/state/TaskStateManagerImplTest.java
+++ b/flink-runtime/src/test/java/org/apache/flink/runtime/state/TaskStateManagerImplTest.java
@@ -270,7 +270,7 @@ public class TaskStateManagerImplTest extends TestLogger {
 
     @Test
     public void testStateRetrievingWithFinishedOperator() {
-        TaskStateSnapshot taskStateSnapshot = TaskStateSnapshot.FINISHED;
+        TaskStateSnapshot taskStateSnapshot = TaskStateSnapshot.FINISHED_ON_RESTORE;
 
         JobManagerTaskRestore jobManagerTaskRestore =
                 new JobManagerTaskRestore(2, taskStateSnapshot);

--- a/flink-runtime/src/test/java/org/apache/flink/runtime/state/TestTaskStateManager.java
+++ b/flink-runtime/src/test/java/org/apache/flink/runtime/state/TestTaskStateManager.java
@@ -149,7 +149,7 @@ public class TestTaskStateManager implements TaskStateManager {
     public boolean isFinishedOnRestore() {
         TaskStateSnapshot jmTaskStateSnapshot = getLastJobManagerTaskStateSnapshot();
         if (jmTaskStateSnapshot != null) {
-            return jmTaskStateSnapshot.isFinished();
+            return jmTaskStateSnapshot.isFinishedOnRestore();
         }
 
         return false;

--- a/flink-runtime/src/test/java/org/apache/flink/runtime/taskexecutor/TestingTaskExecutorGateway.java
+++ b/flink-runtime/src/test/java/org/apache/flink/runtime/taskexecutor/TestingTaskExecutorGateway.java
@@ -229,7 +229,10 @@ public class TestingTaskExecutorGateway implements TaskExecutorGateway {
 
     @Override
     public CompletableFuture<Acknowledge> abortCheckpoint(
-            ExecutionAttemptID executionAttemptID, long checkpointId, long checkpointTimestamp) {
+            ExecutionAttemptID executionAttemptID,
+            long checkpointId,
+            long latestCompletedCheckpointId,
+            long checkpointTimestamp) {
         return CompletableFuture.completedFuture(Acknowledge.get());
     }
 

--- a/flink-streaming-java/src/main/java/org/apache/flink/streaming/runtime/tasks/AsyncCheckpointRunnable.java
+++ b/flink-streaming-java/src/main/java/org/apache/flink/streaming/runtime/tasks/AsyncCheckpointRunnable.java
@@ -115,7 +115,9 @@ final class AsyncCheckpointRunnable implements Runnable, Closeable {
             SnapshotsFinalizeResult snapshotsFinalizeResult =
                     isFinishedOnRestore
                             ? new SnapshotsFinalizeResult(
-                                    TaskStateSnapshot.FINISHED, TaskStateSnapshot.FINISHED, 0L)
+                                    TaskStateSnapshot.FINISHED_ON_RESTORE,
+                                    TaskStateSnapshot.FINISHED_ON_RESTORE,
+                                    0L)
                             : finalizeNonFinishedSnapshots();
 
             final long asyncEndNanos = System.nanoTime();

--- a/flink-streaming-java/src/main/java/org/apache/flink/streaming/runtime/tasks/AsyncCheckpointRunnable.java
+++ b/flink-streaming-java/src/main/java/org/apache/flink/streaming/runtime/tasks/AsyncCheckpointRunnable.java
@@ -53,6 +53,7 @@ final class AsyncCheckpointRunnable implements Runnable, Closeable {
     private final String taskName;
     private final Consumer<AsyncCheckpointRunnable> unregisterConsumer;
     private final boolean isFinishedOnRestore;
+    private final boolean isOperatorsFinished;
     private final Supplier<Boolean> isTaskRunning;
     private final Environment taskEnvironment;
     private final CompletableFuture<Void> finishedFuture = new CompletableFuture<>();
@@ -85,6 +86,7 @@ final class AsyncCheckpointRunnable implements Runnable, Closeable {
             Environment taskEnvironment,
             AsyncExceptionHandler asyncExceptionHandler,
             boolean isFinishedOnRestore,
+            boolean isOperatorsFinished,
             Supplier<Boolean> isTaskRunning) {
 
         this.operatorSnapshotsInProgress = checkNotNull(operatorSnapshotsInProgress);
@@ -96,6 +98,7 @@ final class AsyncCheckpointRunnable implements Runnable, Closeable {
         this.taskEnvironment = checkNotNull(taskEnvironment);
         this.asyncExceptionHandler = checkNotNull(asyncExceptionHandler);
         this.isFinishedOnRestore = isFinishedOnRestore;
+        this.isOperatorsFinished = isOperatorsFinished;
         this.isTaskRunning = isTaskRunning;
     }
 
@@ -159,9 +162,9 @@ final class AsyncCheckpointRunnable implements Runnable, Closeable {
 
     private SnapshotsFinalizeResult finalizeNonFinishedSnapshots() throws Exception {
         TaskStateSnapshot jobManagerTaskOperatorSubtaskStates =
-                new TaskStateSnapshot(operatorSnapshotsInProgress.size());
+                new TaskStateSnapshot(operatorSnapshotsInProgress.size(), isOperatorsFinished);
         TaskStateSnapshot localTaskOperatorSubtaskStates =
-                new TaskStateSnapshot(operatorSnapshotsInProgress.size());
+                new TaskStateSnapshot(operatorSnapshotsInProgress.size(), isOperatorsFinished);
 
         long bytesPersistedDuringAlignment = 0;
         for (Map.Entry<OperatorID, OperatorSnapshotFutures> entry :

--- a/flink-streaming-java/src/main/java/org/apache/flink/streaming/runtime/tasks/StreamTask.java
+++ b/flink-streaming-java/src/main/java/org/apache/flink/streaming/runtime/tasks/StreamTask.java
@@ -241,6 +241,9 @@ public abstract class StreamTask<OUT, OP extends StreamOperator<OUT>> extends Ab
      */
     private volatile boolean failing;
 
+    /** Flags indicating the finished method of all the operators are called. */
+    private boolean finishedOperators;
+
     private boolean closedOperators;
 
     /** Thread pool for async snapshot workers. */
@@ -741,6 +744,7 @@ public abstract class StreamTask<OUT, OP extends StreamOperator<OUT>> extends Ab
 
         // close all operators in a chain effect way
         operatorChain.finishOperators(actionExecutor);
+        finishedOperators = true;
 
         // If checkpoints are enabled, waits for all the records get processed by the downstream
         // tasks. During this process, this task could coordinate with its downstream tasks to
@@ -1211,6 +1215,7 @@ public abstract class StreamTask<OUT, OP extends StreamOperator<OUT>> extends Ab
                                 checkpointOptions,
                                 checkpointMetrics,
                                 operatorChain,
+                                finishedOperators,
                                 this::isRunning);
                     });
 

--- a/flink-streaming-java/src/main/java/org/apache/flink/streaming/runtime/tasks/SubtaskCheckpointCoordinator.java
+++ b/flink-streaming-java/src/main/java/org/apache/flink/streaming/runtime/tasks/SubtaskCheckpointCoordinator.java
@@ -61,6 +61,7 @@ public interface SubtaskCheckpointCoordinator extends Closeable {
             CheckpointOptions checkpointOptions,
             CheckpointMetricsBuilder checkpointMetrics,
             OperatorChain<?, ?> operatorChain,
+            boolean isOperatorsFinished,
             Supplier<Boolean> isRunning)
             throws Exception;
 

--- a/flink-streaming-java/src/main/java/org/apache/flink/streaming/runtime/tasks/SubtaskCheckpointCoordinatorImpl.java
+++ b/flink-streaming-java/src/main/java/org/apache/flink/streaming/runtime/tasks/SubtaskCheckpointCoordinatorImpl.java
@@ -250,6 +250,7 @@ class SubtaskCheckpointCoordinatorImpl implements SubtaskCheckpointCoordinator {
             CheckpointOptions options,
             CheckpointMetricsBuilder metrics,
             OperatorChain<?, ?> operatorChain,
+            boolean isOperatorsFinished,
             Supplier<Boolean> isRunning)
             throws Exception {
 
@@ -323,6 +324,7 @@ class SubtaskCheckpointCoordinatorImpl implements SubtaskCheckpointCoordinator {
                         metadata,
                         metrics,
                         operatorChain.isFinishedOnRestore(),
+                        isOperatorsFinished,
                         isRunning);
             } else {
                 cleanup(snapshotFutures, metadata, metrics, new Exception("Checkpoint declined"));
@@ -568,6 +570,7 @@ class SubtaskCheckpointCoordinatorImpl implements SubtaskCheckpointCoordinator {
             CheckpointMetaData metadata,
             CheckpointMetricsBuilder metrics,
             boolean isFinishedOnRestore,
+            boolean isOperatorsFinished,
             Supplier<Boolean> isRunning)
             throws IOException {
         AsyncCheckpointRunnable asyncCheckpointRunnable =
@@ -581,6 +584,7 @@ class SubtaskCheckpointCoordinatorImpl implements SubtaskCheckpointCoordinator {
                         env,
                         asyncExceptionHandler,
                         isFinishedOnRestore,
+                        isOperatorsFinished,
                         isRunning);
 
         registerAsyncCheckpointRunnable(

--- a/flink-streaming-java/src/test/java/org/apache/flink/streaming/runtime/tasks/AsyncCheckpointRunnableTest.java
+++ b/flink-streaming-java/src/test/java/org/apache/flink/streaming/runtime/tasks/AsyncCheckpointRunnableTest.java
@@ -59,6 +59,7 @@ public class AsyncCheckpointRunnableTest {
                         env,
                         (msg, ex) -> {},
                         false,
+                        false,
                         () -> true)
                 .close();
         assertEquals(
@@ -165,6 +166,7 @@ public class AsyncCheckpointRunnableTest {
                 environment,
                 (msg, ex) -> {},
                 isFinishedOnRestore,
+                false,
                 () -> isTaskRunning);
     }
 

--- a/flink-streaming-java/src/test/java/org/apache/flink/streaming/runtime/tasks/AsyncCheckpointRunnableTest.java
+++ b/flink-streaming-java/src/test/java/org/apache/flink/streaming/runtime/tasks/AsyncCheckpointRunnableTest.java
@@ -140,10 +140,10 @@ public class AsyncCheckpointRunnableTest {
                 asyncCheckpointRunnable.getCheckpointId(),
                 testTaskStateManager.getReportedCheckpointId());
         assertEquals(
-                TaskStateSnapshot.FINISHED,
+                TaskStateSnapshot.FINISHED_ON_RESTORE,
                 testTaskStateManager.getLastJobManagerTaskStateSnapshot());
         assertEquals(
-                TaskStateSnapshot.FINISHED,
+                TaskStateSnapshot.FINISHED_ON_RESTORE,
                 testTaskStateManager.getLastTaskManagerTaskStateSnapshot());
         assertTrue(asyncCheckpointRunnable.getFinishedFuture().isDone());
     }

--- a/flink-streaming-java/src/test/java/org/apache/flink/streaming/runtime/tasks/LocalStateForwardingTest.java
+++ b/flink-streaming-java/src/test/java/org/apache/flink/streaming/runtime/tasks/LocalStateForwardingTest.java
@@ -128,6 +128,7 @@ public class LocalStateForwardingTest extends TestLogger {
                         testStreamTask.getEnvironment(),
                         testStreamTask,
                         false,
+                        false,
                         () -> true);
 
         checkpointMetrics.setAlignmentDurationNanos(0L);

--- a/flink-streaming-java/src/test/java/org/apache/flink/streaming/runtime/tasks/MultipleInputStreamTaskChainedSourcesCheckpointingTest.java
+++ b/flink-streaming-java/src/test/java/org/apache/flink/streaming/runtime/tasks/MultipleInputStreamTaskChainedSourcesCheckpointingTest.java
@@ -384,7 +384,7 @@ public class MultipleInputStreamTaskChainedSourcesCheckpointingTest {
                                                 Boundedness.CONTINUOUS_UNBOUNDED, 1),
                                         WatermarkStrategy.noWatermarks()),
                                 BasicTypeInfo.INT_TYPE_INFO)
-                        .setTaskStateSnapshot(1, TaskStateSnapshot.FINISHED)
+                        .setTaskStateSnapshot(1, TaskStateSnapshot.FINISHED_ON_RESTORE)
                         .setupOperatorChain(
                                 nonSourceOperatorId,
                                 new LifeCycleMonitorMultipleInputOperatorFactory())

--- a/flink-streaming-java/src/test/java/org/apache/flink/streaming/runtime/tasks/SourceOperatorStreamTaskTest.java
+++ b/flink-streaming-java/src/test/java/org/apache/flink/streaming/runtime/tasks/SourceOperatorStreamTaskTest.java
@@ -168,7 +168,7 @@ public class SourceOperatorStreamTaskTest extends SourceStreamTaskTestBase {
 
     @Test
     public void testSkipExecutionIfFinishedOnRestore() throws Exception {
-        TaskStateSnapshot taskStateSnapshot = TaskStateSnapshot.FINISHED;
+        TaskStateSnapshot taskStateSnapshot = TaskStateSnapshot.FINISHED_ON_RESTORE;
 
         LifeCycleMonitorSource testingSource =
                 new LifeCycleMonitorSource(Boundedness.CONTINUOUS_UNBOUNDED, 10);

--- a/flink-streaming-java/src/test/java/org/apache/flink/streaming/runtime/tasks/SourceStreamTaskTest.java
+++ b/flink-streaming-java/src/test/java/org/apache/flink/streaming/runtime/tasks/SourceStreamTaskTest.java
@@ -665,7 +665,7 @@ public class SourceStreamTaskTest extends SourceStreamTaskTestBase {
         LifeCycleMonitorSource testSource = new LifeCycleMonitorSource();
         try (StreamTaskMailboxTestHarness<String> harness =
                 new StreamTaskMailboxTestHarnessBuilder<>(SourceStreamTask::new, STRING_TYPE_INFO)
-                        .setTaskStateSnapshot(1, TaskStateSnapshot.FINISHED)
+                        .setTaskStateSnapshot(1, TaskStateSnapshot.FINISHED_ON_RESTORE)
                         .setupOutputForSingletonOperatorChain(new StreamSource<>(testSource))
                         .build()) {
             harness.getStreamTask().invoke();

--- a/flink-streaming-java/src/test/java/org/apache/flink/streaming/runtime/tasks/StreamTaskFinalCheckpointsTest.java
+++ b/flink-streaming-java/src/test/java/org/apache/flink/streaming/runtime/tasks/StreamTaskFinalCheckpointsTest.java
@@ -310,7 +310,7 @@ public class StreamTaskFinalCheckpointsTest {
                 new StreamTaskMailboxTestHarnessBuilder<>(
                                 OneInputStreamTask::new, BasicTypeInfo.STRING_TYPE_INFO)
                         .addInput(BasicTypeInfo.STRING_TYPE_INFO, 3)
-                        .setTaskStateSnapshot(1, TaskStateSnapshot.FINISHED)
+                        .setTaskStateSnapshot(1, TaskStateSnapshot.FINISHED_ON_RESTORE)
                         .setupOutputForSingletonOperatorChain(new LifeCycleMonitorOperator<>())
                         .build()) {
             // Finish the restore, including state initialization and open.

--- a/flink-streaming-java/src/test/java/org/apache/flink/streaming/runtime/tasks/StreamTaskFinalCheckpointsTest.java
+++ b/flink-streaming-java/src/test/java/org/apache/flink/streaming/runtime/tasks/StreamTaskFinalCheckpointsTest.java
@@ -406,7 +406,7 @@ public class StreamTaskFinalCheckpointsTest {
 
             // Checkpoint notification.
             harness.streamTask.notifyCheckpointCompleteAsync(2);
-            harness.streamTask.notifyCheckpointAbortAsync(3);
+            harness.streamTask.notifyCheckpointAbortAsync(3, 2);
             harness.processAll();
 
             // Finish & close operators.

--- a/flink-streaming-java/src/test/java/org/apache/flink/streaming/runtime/tasks/StreamTaskFinalCheckpointsTest.java
+++ b/flink-streaming-java/src/test/java/org/apache/flink/streaming/runtime/tasks/StreamTaskFinalCheckpointsTest.java
@@ -19,6 +19,8 @@
 package org.apache.flink.streaming.runtime.tasks;
 
 import org.apache.flink.api.common.JobID;
+import org.apache.flink.api.common.state.ListState;
+import org.apache.flink.api.common.state.ListStateDescriptor;
 import org.apache.flink.api.common.typeinfo.BasicTypeInfo;
 import org.apache.flink.api.common.typeutils.base.StringSerializer;
 import org.apache.flink.core.testutils.OneShotLatch;
@@ -194,6 +196,81 @@ public class StreamTaskFinalCheckpointsTest {
                     assertEquals(4, resultPartition.getNumberOfQueuedBuffers());
                 }
             }
+        } finally {
+            for (ResultPartitionWriter writer : partitionWriters) {
+                if (writer != null) {
+                    writer.close();
+                }
+            }
+        }
+    }
+
+    @Test
+    public void testReportOperatorsFinishedInCheckpoint() throws Exception {
+        ResultPartition[] partitionWriters = new ResultPartition[2];
+        try {
+            for (int i = 0; i < partitionWriters.length; ++i) {
+                partitionWriters[i] =
+                        PartitionTestUtils.createPartition(ResultPartitionType.PIPELINED_BOUNDED);
+                partitionWriters[i].setup();
+            }
+
+            try (StreamTaskMailboxTestHarness<String> testHarness =
+                    new StreamTaskMailboxTestHarnessBuilder<>(
+                                    OneInputStreamTask::new, BasicTypeInfo.STRING_TYPE_INFO)
+                            .addInput(BasicTypeInfo.STRING_TYPE_INFO, 1)
+                            .addAdditionalOutput(partitionWriters)
+                            .modifyStreamConfig(
+                                    config -> {
+                                        config.setCheckpointingEnabled(true);
+                                        config.getConfiguration()
+                                                .set(
+                                                        ExecutionCheckpointingOptions
+                                                                .ENABLE_CHECKPOINTS_AFTER_TASKS_FINISH,
+                                                        true);
+                                    })
+                            .setupOperatorChain(new StatefulOperator())
+                            .finishForSingletonOperatorChain(StringSerializer.INSTANCE)
+                            .build()) {
+
+                // Trigger the first checkpoint before we call operators' finish method.
+                Future<Boolean> checkpointFuture = triggerCheckpoint(testHarness, 2);
+                processMailTillCheckpointSucceeds(testHarness, checkpointFuture);
+                assertEquals(2, testHarness.getTaskStateManager().getReportedCheckpointId());
+                assertFalse(
+                        testHarness
+                                .getTaskStateManager()
+                                .getJobManagerTaskStateSnapshotsByCheckpointId()
+                                .get(2L)
+                                .isOperatorsFinished());
+
+                // Trigger the first checkpoint after we call operators' finish method.
+                // The checkpoint is added to the mailbox and will be processed in the
+                // mailbox loop after call operators' finish method in the afterInvoke()
+                // method.
+                testHarness.processEvent(EndOfPartitionEvent.INSTANCE, 0, 0);
+                checkpointFuture = triggerCheckpoint(testHarness, 4);
+                checkState(
+                        checkpointFuture instanceof CompletableFuture,
+                        "The trigger future should " + " be also CompletableFuture.");
+                ((CompletableFuture<?>) checkpointFuture)
+                        .thenAccept(
+                                (ignored) -> {
+                                    for (ResultPartition resultPartition : partitionWriters) {
+                                        resultPartition.onSubpartitionAllRecordsProcessed(0);
+                                    }
+                                });
+                testHarness.finishProcessing();
+                assertTrue(checkpointFuture.isDone());
+                testHarness.getTaskStateManager().getWaitForReportLatch().await();
+                assertTrue(
+                        testHarness
+                                .getTaskStateManager()
+                                .getJobManagerTaskStateSnapshotsByCheckpointId()
+                                .get(4L)
+                                .isOperatorsFinished());
+            }
+
         } finally {
             for (ResultPartitionWriter writer : partitionWriters) {
                 if (writer != null) {
@@ -416,5 +493,22 @@ public class StreamTaskFinalCheckpointsTest {
         public LifeCycleMonitor getLifeCycleMonitor() {
             return lifeCycleMonitor;
         }
+    }
+
+    private static class StatefulOperator extends AbstractStreamOperator<String>
+            implements OneInputStreamOperator<String, String> {
+
+        private ListState<Integer> state;
+
+        @Override
+        public void initializeState(StateInitializationContext context) throws Exception {
+            super.initializeState(context);
+            state =
+                    context.getOperatorStateStore()
+                            .getUnionListState(new ListStateDescriptor<>("test", Integer.class));
+        }
+
+        @Override
+        public void processElement(StreamRecord<String> element) throws Exception {}
     }
 }

--- a/flink-streaming-java/src/test/java/org/apache/flink/streaming/runtime/tasks/SubtaskCheckpointCoordinatorTest.java
+++ b/flink-streaming-java/src/test/java/org/apache/flink/streaming/runtime/tasks/SubtaskCheckpointCoordinatorTest.java
@@ -176,6 +176,7 @@ public class SubtaskCheckpointCoordinatorTest {
                             SAVEPOINT, CheckpointStorageLocationReference.getDefault()),
                     new CheckpointMetricsBuilder(),
                     operatorChain,
+                    false,
                     () -> true);
 
             assertEquals(false, broadcastedPriorityEvent.get());
@@ -223,6 +224,7 @@ public class SubtaskCheckpointCoordinatorTest {
                     forcedAlignedOptions,
                     new CheckpointMetricsBuilder(),
                     operatorChain,
+                    false,
                     () -> true);
 
             assertEquals(true, broadcastedPriorityEvent.get());
@@ -249,6 +251,7 @@ public class SubtaskCheckpointCoordinatorTest {
                             new NoOpStreamTask<>(new DummyEnvironment()),
                             new NonRecordWriter<>(),
                             false),
+                    false,
                     () -> true);
         }
     }
@@ -308,6 +311,7 @@ public class SubtaskCheckpointCoordinatorTest {
                     CheckpointOptions.forCheckpointWithDefaultLocation(),
                     new CheckpointMetricsBuilder(),
                     operatorChain,
+                    false,
                     () -> false);
             assertFalse(checkpointOperator.isCheckpointed());
             assertEquals(-1, stateManager.getReportedCheckpointId());
@@ -362,6 +366,7 @@ public class SubtaskCheckpointCoordinatorTest {
                     CheckpointOptions.forCheckpointWithDefaultLocation(),
                     new CheckpointMetricsBuilder(),
                     operatorChain,
+                    false,
                     () -> false);
 
             assertEquals(1, recordOrEvents.size());
@@ -418,6 +423,7 @@ public class SubtaskCheckpointCoordinatorTest {
                     CheckpointOptions.forCheckpointWithDefaultLocation(),
                     new CheckpointMetricsBuilder(),
                     operatorChain,
+                    false,
                     () -> false);
             rawKeyedStateHandleFuture.awaitRun();
             assertEquals(1, subtaskCheckpointCoordinator.getAsyncCheckpointRunnableSize());
@@ -449,6 +455,7 @@ public class SubtaskCheckpointCoordinatorTest {
                     CheckpointOptions.forCheckpointWithDefaultLocation(),
                     new CheckpointMetricsBuilder(),
                     operatorChain,
+                    false,
                     () -> false);
             subtaskCheckpointCoordinator.notifyCheckpointAborted(
                     checkpointId, operatorChain, () -> true);

--- a/flink-streaming-java/src/test/java/org/apache/flink/streaming/runtime/tasks/SynchronousCheckpointITCase.java
+++ b/flink-streaming-java/src/test/java/org/apache/flink/streaming/runtime/tasks/SynchronousCheckpointITCase.java
@@ -181,7 +181,8 @@ public class SynchronousCheckpointITCase {
         }
 
         @Override
-        public Future<Void> notifyCheckpointAbortAsync(long checkpointId) {
+        public Future<Void> notifyCheckpointAbortAsync(
+                long checkpointId, long latestCompletedCheckpointId) {
             return CompletableFuture.completedFuture(null);
         }
 

--- a/flink-streaming-java/src/test/java/org/apache/flink/streaming/runtime/tasks/TestSubtaskCheckpointCoordinator.java
+++ b/flink-streaming-java/src/test/java/org/apache/flink/streaming/runtime/tasks/TestSubtaskCheckpointCoordinator.java
@@ -79,6 +79,7 @@ public class TestSubtaskCheckpointCoordinator implements SubtaskCheckpointCoordi
             CheckpointOptions checkpointOptions,
             CheckpointMetricsBuilder checkpointMetrics,
             OperatorChain<?, ?> operatorChain,
+            boolean isOperatorsFinished,
             Supplier<Boolean> isRunning) {}
 
     @Override

--- a/flink-tests/src/test/java/org/apache/flink/runtime/jobmaster/JobMasterStopWithSavepointITCase.java
+++ b/flink-tests/src/test/java/org/apache/flink/runtime/jobmaster/JobMasterStopWithSavepointITCase.java
@@ -371,7 +371,8 @@ public class JobMasterStopWithSavepointITCase extends AbstractTestBase {
         }
 
         @Override
-        public Future<Void> notifyCheckpointAbortAsync(long checkpointId) {
+        public Future<Void> notifyCheckpointAbortAsync(
+                long checkpointId, long latestCompletedCheckpointId) {
             return CompletableFuture.completedFuture(null);
         }
 

--- a/flink-tests/src/test/java/org/apache/flink/runtime/jobmaster/JobMasterTriggerSavepointITCase.java
+++ b/flink-tests/src/test/java/org/apache/flink/runtime/jobmaster/JobMasterTriggerSavepointITCase.java
@@ -264,7 +264,8 @@ public class JobMasterTriggerSavepointITCase extends AbstractTestBase {
         }
 
         @Override
-        public Future<Void> notifyCheckpointAbortAsync(long checkpointId) {
+        public Future<Void> notifyCheckpointAbortAsync(
+                long checkpointId, long latestCompletedCheckpointId) {
             return CompletableFuture.completedFuture(null);
         }
     }


### PR DESCRIPTION
## What is the purpose of the change

This PR avoids that for a checkpoint, if an operator has used `UnionListState`, we would expected to include the state of all the subtasks to avoid possible issues. We achieve this by abort checkpoints if we found that
1. Part of tasks of a vertex has turn into FINISHED, and remaining tasks have reported `UnionListState`. 
2. All of the tasks of a vertex are running, but some tasks have called operators.finish() and others are not. 

Then

1. If for a vertex it does not wait for the final checkpoint (due to the possible optimization), it might come across both case 1 and case 2. After all the tasks of this vertex are finished, the checkpoint would recover. 
2. If for a vertex it waits for the final checkpoint, then the finished tasks would be blocked before waiting the final checkpoints since checkpoints are aborted. Until all the subtasks reach this position, the checkpoint would be successful, then one checkpoint would unblock all these tasks. 


## Brief change log

- 7a73395b692c6e8fa5d1964ec0b0919c617be1f0 Unified the terminology for `finishedOnRestore` to distinguish with `operatorsFinished`. 
- 4af31ccbdab3f24476c7b887528a47a9edf5e9a9 The task reports if its have called operators' finished method in snapshot.
- 981d6981f9dacfd285cb992d630a165a7338c558 When finalize checkpoint, check if there are vertices that used UnionListState is partly finished, or have part of tasks report operators finished.
- aedb0fe1f96c4a7acdf5b5e49d45008354b3963e If notification of checkpoint complete loss for vertex that have used UnionListState and report operators' finished, cause task failover in case the task would hang forever to wait for the final checkpoint, but which would never succeed again.

## Verifying this change

This PR is verified by the added UT. 

## Does this pull request potentially affect one of the following parts:

  - Dependencies (does it add or upgrade a dependency): **no**
  - The public API, i.e., is any changed class annotated with `@Public(Evolving)`: **no**
  - The serializers: **no**
  - The runtime per-record code paths (performance sensitive): **no**
  - Anything that affects deployment or recovery: JobManager (and its components), Checkpointing, Kubernetes/Yarn, ZooKeeper: **no**
  - The S3 file system connector: **no**

## Documentation

  - Does this pull request introduce a new feature?  **no**
  - If yes, how is the feature documented? **not applicable**
