### PR TITLE
[FLINK-23189][checkpoint]Count and fail the task when the disk is error on JobManager

### DIFF
--- a/flink-runtime/src/main/java/org/apache/flink/runtime/checkpoint/CheckpointCoordinator.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/checkpoint/CheckpointCoordinator.java
@@ -2132,10 +2132,16 @@ public class CheckpointCoordinator {
     private static CheckpointException getCheckpointException(
             CheckpointFailureReason defaultReason, Throwable throwable) {
 
-        final Optional<CheckpointException> checkpointExceptionOptional =
-                findThrowable(throwable, CheckpointException.class);
-        return checkpointExceptionOptional.orElseGet(
-                () -> new CheckpointException(defaultReason, throwable));
+        final Optional<IOException> ioExceptionOptional =
+                findThrowable(throwable, IOException.class);
+        if (ioExceptionOptional.isPresent()) {
+            return new CheckpointException(CheckpointFailureReason.IO_EXCEPTION, throwable);
+        } else {
+            final Optional<CheckpointException> checkpointExceptionOptional =
+                    findThrowable(throwable, CheckpointException.class);
+            return checkpointExceptionOptional.orElseGet(
+                    () -> new CheckpointException(defaultReason, throwable));
+        }
     }
 
     private static class CheckpointIdAndStorageLocation {

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/checkpoint/CheckpointFailureManager.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/checkpoint/CheckpointFailureManager.java
@@ -127,7 +127,6 @@ public class CheckpointFailureManager {
             case CHECKPOINT_DECLINED_SUBSUMED:
             case CHECKPOINT_DECLINED_INPUT_END_OF_STREAM:
 
-            case EXCEPTION:
             case TASK_FAILURE:
             case TASK_CHECKPOINT_FAILURE:
             case UNKNOWN_TASK_CHECKPOINT_NOTIFICATION_FAILURE:

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/checkpoint/CheckpointFailureManager.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/checkpoint/CheckpointFailureManager.java
@@ -136,6 +136,7 @@ public class CheckpointFailureManager {
                 // ignore
                 break;
 
+            case IO_EXCEPTION:
             case CHECKPOINT_ASYNC_EXCEPTION:
             case CHECKPOINT_DECLINED:
             case CHECKPOINT_EXPIRED:

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/checkpoint/CheckpointFailureReason.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/checkpoint/CheckpointFailureReason.java
@@ -81,7 +81,10 @@ public enum CheckpointFailureReason {
 
     FINALIZE_CHECKPOINT_FAILURE(false, "Failure to finalize checkpoint."),
 
-    TRIGGER_CHECKPOINT_FAILURE(false, "Trigger checkpoint failure.");
+    TRIGGER_CHECKPOINT_FAILURE(false, "Trigger checkpoint failure."),
+
+    IO_EXCEPTION(
+            false, "An Exception occurred while triggering the checkpoint. IO-problem detected.");
 
     // ------------------------------------------------------------------------
 

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/checkpoint/CheckpointFailureReason.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/checkpoint/CheckpointFailureReason.java
@@ -34,7 +34,8 @@ public enum CheckpointFailureReason {
 
     NOT_ALL_REQUIRED_TASKS_RUNNING(true, "Not all required tasks are currently running."),
 
-    EXCEPTION(true, "An Exception occurred while triggering the checkpoint."),
+    IO_EXCEPTION(
+            true, "An Exception occurred while triggering the checkpoint. IO-problem detected."),
 
     CHECKPOINT_ASYNC_EXCEPTION(false, "Asynchronous task checkpoint failed."),
 
@@ -81,10 +82,7 @@ public enum CheckpointFailureReason {
 
     FINALIZE_CHECKPOINT_FAILURE(false, "Failure to finalize checkpoint."),
 
-    TRIGGER_CHECKPOINT_FAILURE(false, "Trigger checkpoint failure."),
-
-    IO_EXCEPTION(
-            false, "An Exception occurred while triggering the checkpoint. IO-problem detected.");
+    TRIGGER_CHECKPOINT_FAILURE(false, "Trigger checkpoint failure.");
 
     // ------------------------------------------------------------------------
 

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/checkpoint/OperatorCoordinatorCheckpoints.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/checkpoint/OperatorCoordinatorCheckpoints.java
@@ -21,10 +21,13 @@ package org.apache.flink.runtime.checkpoint;
 import org.apache.flink.runtime.operators.coordination.OperatorCoordinator;
 import org.apache.flink.runtime.operators.coordination.OperatorInfo;
 import org.apache.flink.runtime.state.memory.ByteStreamStateHandle;
+import org.apache.flink.util.ExceptionUtils;
 import org.apache.flink.util.concurrent.FutureUtils;
 
+import java.io.IOException;
 import java.util.ArrayList;
 import java.util.Collection;
+import java.util.Optional;
 import java.util.concurrent.CompletableFuture;
 import java.util.concurrent.CompletionException;
 import java.util.concurrent.Executor;
@@ -121,14 +124,17 @@ final class OperatorCoordinatorCheckpoints {
                 final Throwable error =
                         checkpoint.isDisposed() ? checkpoint.getFailureCause() : null;
 
+                CheckpointFailureReason reason = CheckpointFailureReason.TRIGGER_CHECKPOINT_FAILURE;
                 if (error != null) {
-                    throw new CheckpointException(
-                            errorMessage,
-                            CheckpointFailureReason.TRIGGER_CHECKPOINT_FAILURE,
-                            error);
+                    final Optional<IOException> ioExceptionOptional =
+                            ExceptionUtils.findThrowable(error, IOException.class);
+                    if (ioExceptionOptional.isPresent()) {
+                        reason = CheckpointFailureReason.IO_EXCEPTION;
+                    }
+
+                    throw new CheckpointException(errorMessage, reason, error);
                 } else {
-                    throw new CheckpointException(
-                            errorMessage, CheckpointFailureReason.TRIGGER_CHECKPOINT_FAILURE);
+                    throw new CheckpointException(errorMessage, reason);
                 }
             }
         }

--- a/flink-runtime/src/test/java/org/apache/flink/runtime/checkpoint/CheckpointFailureManagerTest.java
+++ b/flink-runtime/src/test/java/org/apache/flink/runtime/checkpoint/CheckpointFailureManagerTest.java
@@ -71,7 +71,7 @@ public class CheckpointFailureManagerTest extends TestLogger {
         CheckpointFailureManager failureManager = new CheckpointFailureManager(2, callback);
 
         failureManager.handleJobLevelCheckpointException(
-                new CheckpointException(CheckpointFailureReason.EXCEPTION), 1);
+                new CheckpointException(CheckpointFailureReason.IO_EXCEPTION), 1);
         failureManager.handleJobLevelCheckpointException(
                 new CheckpointException(CheckpointFailureReason.CHECKPOINT_DECLINED), 2);
 

--- a/flink-runtime/src/test/java/org/apache/flink/runtime/checkpoint/CheckpointFailureManagerTest.java
+++ b/flink-runtime/src/test/java/org/apache/flink/runtime/checkpoint/CheckpointFailureManagerTest.java
@@ -95,8 +95,8 @@ public class CheckpointFailureManagerTest extends TestLogger {
             failureManager.handleJobLevelCheckpointException(new CheckpointException(reason), -1);
         }
 
-        // CHECKPOINT_DECLINED, CHECKPOINT_EXPIRED and CHECKPOINT_ASYNC_EXCEPTION
-        assertEquals(3, callback.getInvokeCounter());
+        // IO_EXCEPTION, CHECKPOINT_DECLINED, CHECKPOINT_EXPIRED and CHECKPOINT_ASYNC_EXCEPTION
+        assertEquals(4, callback.getInvokeCounter());
     }
 
     @Test

--- a/flink-streaming-java/src/main/java/org/apache/flink/streaming/runtime/io/StreamTaskNetworkInput.java
+++ b/flink-streaming-java/src/main/java/org/apache/flink/streaming/runtime/io/StreamTaskNetworkInput.java
@@ -106,7 +106,7 @@ public final class StreamTaskNetworkInput<T>
                         ChannelStateWriter.SEQUENCE_NUMBER_UNKNOWN,
                         e.getValue().getUnconsumedBuffer());
             } catch (IOException ioException) {
-                throw new CheckpointException(CheckpointFailureReason.EXCEPTION, ioException);
+                throw new CheckpointException(CheckpointFailureReason.IO_EXCEPTION, ioException);
             }
         }
         return checkpointedInputGate.getAllBarriersReceivedFuture(checkpointId);

--- a/flink-tests/src/test/java/org/apache/flink/runtime/jobmaster/JobMasterStopWithSavepointITCase.java
+++ b/flink-tests/src/test/java/org/apache/flink/runtime/jobmaster/JobMasterStopWithSavepointITCase.java
@@ -226,8 +226,7 @@ public class JobMasterStopWithSavepointITCase extends AbstractTestBase {
             String exceptionMessage = checkpointExceptionOptional.get().getMessage();
             assertTrue(
                     "Stop with savepoint failed because of another cause " + exceptionMessage,
-                    exceptionMessage.contains(
-                            CheckpointFailureReason.TRIGGER_CHECKPOINT_FAILURE.message()));
+                    exceptionMessage.contains(CheckpointFailureReason.IO_EXCEPTION.message()));
         }
 
         final JobStatus jobStatus =


### PR DESCRIPTION
## What is the purpose of the change

This pull request make some kinds of failures be checked against CheckpointFailureManager and be deciding whether these errors should be just logged or checked against the number of tolerable failures and maybe fail the job. So it separate IO_EXCEPTION from TRIGGER_CHECKPOINT_FAILURE enum and add IO_EXCEPTION to the reason which will checked against the number of tolerable failures. With this we can let users perceived some unrecoverable error faster. Also it Migrate from EXCEPTION enum to IO_EXCEPTION because according to the code it is exactly IO_EXCEPTION.


## Brief change log

  - *Separate IO_EXCEPTION from TRIGGER_CHECKPOINT_FAILURE enum*
  - *Add IO_EXCEPTION to identify the disk error and increase the number of failure count*
  - *Add a unit test case for IO_EXCEPTION scene*
  - *Migrate from EXCEPTION enum to IO_EXCEPTION*


## Verifying this change

  - *Added IO_EXCEPTION scene to CheckpointCoordinatorTest and modify the number of CheckpointFailureManagerTest*
  - *Add unit test case in CheckpointCoordinatorTest for IO_EXCEPTION scene*
  - *Modify JobMasterStopWithSavepointITCase for IO_EXCEPTION scene*

## Does this pull request potentially affect one of the following parts:

  - Dependencies (does it add or upgrade a dependency): (no)
  - The public API, i.e., is any changed class annotated with `@Public(Evolving)`: (no)
  - The serializers: (no)
  - The runtime per-record code paths (performance sensitive): (no)
  - Anything that affects deployment or recovery: JobManager (and its components), Checkpointing, Kubernetes/Yarn, ZooKeeper: (yes)
  - The S3 file system connector: (no)

## Documentation

  - Does this pull request introduce a new feature? (no)
  - If yes, how is the feature documented? (not applicable)
