### PR TITLE
[FLINK-21569] Upgrade flink-shaded-jackson version to 2.12.1-13.0

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -123,7 +123,7 @@ under the License.
 		<zookeeper.version>3.4.14</zookeeper.version>
 		<!-- Only the curator2 TestingServer works with ZK 3.4 -->
 		<curator.version>2.12.0</curator.version>
-		<jackson.version>2.10.1</jackson.version>
+		<jackson.version>2.12.1</jackson.version>
 		<prometheus.version>0.8.1</prometheus.version>
 		<avro.version>1.10.0</avro.version>
 		<javax.activation.api.version>1.2.0</javax.activation.api.version>
@@ -285,13 +285,13 @@ under the License.
 			<dependency>
 				<groupId>org.apache.flink</groupId>
 				<artifactId>flink-shaded-jackson</artifactId>
-				<version>${jackson.version}-${flink.shaded.version}</version>
+				<version>${jackson.version}-13.0</version>
 			</dependency>
 
 			<dependency>
 				<groupId>org.apache.flink</groupId>
 				<artifactId>flink-shaded-jackson-module-jsonSchema</artifactId>
-				<version>${jackson.version}-${flink.shaded.version}</version>
+				<version>${jackson.version}-13.0</version>
 			</dependency>
 
 			<dependency>


### PR DESCRIPTION
## What is the purpose of the change

This PR aims to fix FLINK-21569, where reading specific csv files will cause the job to hang forever. This is actually caused by a bug in Jackson (https://github.com/FasterXML/jackson-dataformats-text/issues/191), so we're upgrading flink-shaded-jackson version in this fix.

## Brief change log

 - Upgrade flink-shaded-jackson version to 2.12.1-13.0

## Verifying this change

This change added tests and can be verified by running the added tests. It can also be tested by hand with the following steps.
1. Download [this csv file](https://issues.apache.org/jira/secure/attachment/13021472/airports.csv).
2. Add the following test to a model which relies both on `flink-csv` and `flink-table-planner-blink`. For example the `flink-sql-client` module. Don't forget to change the file path in the DDL.
```java
public class MyTest {

    @Test
    public void myTest() throws Exception {
        EnvironmentSettings settings = EnvironmentSettings.newInstance().inStreamingMode().build();
        TableEnvironment tEnv = TableEnvironmentImpl.create(settings);
        tEnv
                .getConfig()
                .getConfiguration()
                .setInteger(ExecutionConfigOptions.TABLE_EXEC_RESOURCE_DEFAULT_PARALLELISM, 2);
        tEnv
                .executeSql(
                        "CREATE TABLE `airports` (\n"
                                + "  `IATA_CODE` CHAR(3),\n"
                                + "  `AIRPORT` STRING,\n"
                                + "  `CITY` STRING,\n"
                                + "  `STATE` CHAR(2),\n"
                                + "  `COUNTRY` CHAR(3),\n"
                                + "  `LATITUDE` DOUBLE NULL,\n"
                                + "  `LONGITUDE` DOUBLE NULL,\n"
                                + "  PRIMARY KEY (`IATA_CODE`) NOT ENFORCED\n"
                                + ") WITH (\n"
                                + "  'connector' = 'filesystem',\n"
                                + "  'path' = 'file:///tmp/airports.csv',\n"
                                + "  'format' = 'csv',\n"
                                + "  'csv.allow-comments' = 'true',\n"
                                + "  'csv.ignore-parse-errors' = 'true',\n"
                                + "  'csv.null-literal' = ''\n"
                                + ")")
                .await();
        tEnv.executeSql("SELECT * FROM airports").print();
    }
}

```
3. Run the test. Before this fix the test will hang forever. After this fix the test will end successfully.

## Does this pull request potentially affect one of the following parts:

  - Dependencies (does it add or upgrade a dependency): **YES**
  - The public API, i.e., is any changed class annotated with `@Public(Evolving)`: no
  - The serializers: no
  - The runtime per-record code paths (performance sensitive): no
  - Anything that affects deployment or recovery: JobManager (and its components), Checkpointing, Kubernetes/Yarn, ZooKeeper: no
  - The S3 file system connector: no

## Documentation

  - Does this pull request introduce a new feature? no
  - If yes, how is the feature documented? not applicable
