### PR TITLE
[FLINK-23546][dist] Supress error messages on macOS

### DIFF
--- a/flink-dist/src/main/flink-bin/bin/flink-daemon.sh
+++ b/flink-dist/src/main/flink-bin/bin/flink-daemon.sh
@@ -97,7 +97,7 @@ function guaranteed_kill {
   # if timeout exists, use it
   if command -v timeout &> /dev/null ; then
     # wait 10 seconds for process to stop. By default, Flink kills the JVM 5 seconds after sigterm.
-    timeout 10 tail --pid=$to_stop_pid -f /dev/null
+    timeout 10 tail --pid=$to_stop_pid -f /dev/null &> /dev/null
     if [ "$?" -eq 124 ]; then
       echo "Daemon $daemon didn't stop within 10 seconds. Killing it."
       # send sigkill


### PR DESCRIPTION
On macOS, I got the following errors from the stop-cluster.sh script:

```
❰robert❙/tmp/flink-1.14-SNAPSHOT❱✔≻ ./bin/start-cluster.sh
Starting cluster.
Starting standalonesession daemon on host MacBook-Pro-2.localdomain.
Starting taskexecutor daemon on host MacBook-Pro-2.localdomain.
❰robert❙/tmp/flink-1.14-SNAPSHOT❱✔≻ ./bin/stop-cluster.sh
Stopping taskexecutor daemon (pid: 50044) on host MacBook-Pro-2.localdomain.
tail: illegal option -- -
usage: tail [-F | -f | -r] [-q] [-b # | -c # | -n #] [file ...]
Stopping standalonesession daemon (pid: 49812) on host MacBook-Pro-2.localdomain.
tail: illegal option -- -
usage: tail [-F | -f | -r] [-q] [-b # | -c # | -n #] [file ...]
```

With this change any error message from the `tail` command gets swallowed, since this timeout operation is anyways optional.
