### PR TITLE
[FLINK-23518][tests] Wait until curator has connected

### DIFF
--- a/flink-runtime/src/test/java/org/apache/flink/runtime/leaderelection/ZooKeeperLeaderElectionConnectionHandlingTest.java
+++ b/flink-runtime/src/test/java/org/apache/flink/runtime/leaderelection/ZooKeeperLeaderElectionConnectionHandlingTest.java
@@ -75,6 +75,7 @@ public class ZooKeeperLeaderElectionConnectionHandlingTest extends TestLogger {
                 HighAvailabilityOptions.HA_ZOOKEEPER_QUORUM, testingServer.getConnectString());
 
         zooKeeperClient = ZooKeeperUtils.startCuratorFramework(config);
+        zooKeeperClient.blockUntilConnected();
     }
 
     @After


### PR DESCRIPTION
Because starting curator is an asynchronous operation it can happen that curator has not yet connected to zookeeper when we restart the server, so the connection technically never gets suspended.