### PR TITLE
[FLINK-23542][build] Upgrade Checkstyle to 8.43

### DIFF
--- a/docs/content.zh/docs/flinkDev/ide_setup.md
+++ b/docs/content.zh/docs/flinkDev/ide_setup.md
@@ -103,7 +103,7 @@ IntelliJ 使用 Checkstyle-IDEA 插件在 IDE 中支持 checkstyle。
 1. 从 IntelliJ 插件存储库中安装 "Checkstyle-IDEA" 插件。
 2. 通过 Settings → Tools → Checkstyle 配置插件。
 3. 将 "Scan Scope" 设置为仅 Java 源（包括测试）。
-4. 在 "Checkstyle Version" 下拉菜单中选择 _8.14_ 版本，然后单击 "apply"。**此步骤很重要，请勿跳过！**
+4. 在 "Checkstyle Version" 下拉菜单中选择 _8.43_ 版本，然后单击 "apply"。**此步骤很重要，请勿跳过！**
 5. 在 "Configuration File" 窗格中，点击 "+" 图标添加新配置：
     1. 将 "Description" 设置为 Flink。
     2. 选择 "Use a local Checkstyle file" ，然后将其指向你存储库中 `"tools/maven/checkstyle.xml"` 文件。

--- a/docs/content/docs/flinkDev/ide_setup.md
+++ b/docs/content/docs/flinkDev/ide_setup.md
@@ -120,7 +120,7 @@ IntelliJ supports checkstyle within the IDE using the Checkstyle-IDEA plugin.
 1. Install the "Checkstyle-IDEA" plugin from the IntelliJ plugin repository.
 2. Configure the plugin by going to Settings → Tools → Checkstyle.
 3. Set the "Scan Scope" to "Only Java sources (including tests)".
-4. Select _8.14_ in the "Checkstyle Version" dropdown and click apply. **This step is important,
+4. Select _8.43_ in the "Checkstyle Version" dropdown and click apply. **This step is important,
    don't skip it!**
 5. In the "Configuration File" pane, add a new configuration using the plus icon:
     1. Set the "Description" to "Flink".

--- a/flink-core/src/main/java/org/apache/flink/core/memory/ByteArrayOutputStreamWithPos.java
+++ b/flink-core/src/main/java/org/apache/flink/core/memory/ByteArrayOutputStreamWithPos.java
@@ -88,7 +88,7 @@ public class ByteArrayOutputStreamWithPos extends OutputStream {
         count = 0;
     }
 
-    public byte toByteArray()[] {
+    public byte[] toByteArray() {
         return Arrays.copyOf(buffer, count);
     }
 

--- a/flink-libraries/flink-gelly/src/main/java/org/apache/flink/graph/asm/degree/annotate/package-info.java
+++ b/flink-libraries/flink-gelly/src/main/java/org/apache/flink/graph/asm/degree/annotate/package-info.java
@@ -23,17 +23,17 @@
  * <p>Undirected graphs have the property that for every vertex the in-degree is equivalent to the
  * out-degree.
  *
- * <p>The undirected graph algorithms are: {@code VertexDegree} annotates vertices as <v, deg(v)>
- * {@code EdgeSourceDegree} annotates edges as <s, t, (EV, deg(s))> {@code EdgeTargetDegree}
- * annotates edges as <s, t, (EV, deg(t))> {@code EdgeDegreePair} annotates edges as <s, t, (EV,
- * deg(s), deg(t))>
+ * <p>The undirected graph algorithms are: {@code VertexDegree} annotates vertices as {@code <v,
+ * deg(v)>} {@code EdgeSourceDegree} annotates edges as {@code <s, t, (EV, deg(s))>} {@code
+ * EdgeTargetDegree} annotates edges as {@code <s, t, (EV, deg(t))>} {@code EdgeDegreePair}
+ * annotates edges as {@code <s, t, (EV, deg(s), deg(t))>}
  *
- * <p>The directed graph algorithms are: {@code VertexDegrees} annotates vertices as <v, (deg(v),
- * out(v), in(v))> {@code VertexOutDegree} annotates vertices as <v, out(v)> {@code VertexInDegree}
- * annotates vertices as <v, in(v)> {@code EdgeSourceDegrees} annotates edges as <s, t, (deg(s),
- * out(s), in(s))> {@code EdgeTargetDegrees} annotates edges as <s, t, (deg(t), out(t), in(t))>
- * {@code EdgeDegreesPair} annotates edges as <s, t, ((deg(s), out(s), in(s)), (deg(t), out(t),
- * in(t)))>
+ * <p>The directed graph algorithms are: {@code VertexDegrees} annotates vertices as {@code <v,
+ * (deg(v), out(v), in(v))>} {@code VertexOutDegree} annotates vertices as {@code <v, out(v)>}
+ * {@code VertexInDegree} annotates vertices as {@code <v, in(v)>} {@code EdgeSourceDegrees}
+ * annotates edges as {@code <s, t, (deg(s), out(s), in(s))>} {@code EdgeTargetDegrees} annotates
+ * edges as {@code <s, t, (deg(t), out(t), in(t))>} {@code EdgeDegreesPair} annotates edges as
+ * {@code <s, t, ((deg(s), out(s), in(s)), (deg(t), out(t), in(t)))>}
  *
  * <p>where: EV is the original edge value deg(x) is the number of vertex neighbors out(x) is the
  * number of vertex neighbors connected by an out-edge in(x) is the number of vertex neighbors

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/checkpoint/channel/SequentialChannelStateReader.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/checkpoint/channel/SequentialChannelStateReader.java
@@ -1,4 +1,3 @@
-package org.apache.flink.runtime.checkpoint.channel;
 /*
  * Licensed to the Apache Software Foundation (ASF) under one or more
  * contributor license agreements.  See the NOTICE file distributed with
@@ -15,6 +14,8 @@ package org.apache.flink.runtime.checkpoint.channel;
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
+
+package org.apache.flink.runtime.checkpoint.channel;
 
 import org.apache.flink.annotation.Internal;
 import org.apache.flink.runtime.io.network.api.writer.ResultPartitionWriter;

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/rest/handler/job/JobPlanHandler.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/rest/handler/job/JobPlanHandler.java
@@ -1,4 +1,3 @@
-package org.apache.flink.runtime.rest.handler.job;
 /*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
@@ -16,6 +15,8 @@ package org.apache.flink.runtime.rest.handler.job;
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
+
+package org.apache.flink.runtime.rest.handler.job;
 
 import org.apache.flink.api.common.time.Time;
 import org.apache.flink.runtime.executiongraph.AccessExecutionGraph;

--- a/flink-state-backends/flink-statebackend-changelog/src/main/java/org/apache/flink/state/changelog/ChangelogState.java
+++ b/flink-state-backends/flink-statebackend-changelog/src/main/java/org/apache/flink/state/changelog/ChangelogState.java
@@ -1,4 +1,3 @@
-package org.apache.flink.state.changelog;
 /*
  * Licensed to the Apache Software Foundation (ASF) under one or more
  * contributor license agreements.  See the NOTICE file distributed with
@@ -15,6 +14,8 @@ package org.apache.flink.state.changelog;
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
+
+package org.apache.flink.state.changelog;
 
 import org.apache.flink.annotation.Internal;
 import org.apache.flink.state.changelog.restore.ChangelogApplierFactory;

--- a/pom.xml
+++ b/pom.xml
@@ -1824,13 +1824,13 @@ under the License.
 				<plugin>
 					<groupId>org.apache.maven.plugins</groupId>
 					<artifactId>maven-checkstyle-plugin</artifactId>
-					<version>2.17</version>
+					<version>3.1.2</version>
 					<dependencies>
 						<dependency>
 							<groupId>com.puppycrawl.tools</groupId>
 							<artifactId>checkstyle</artifactId>
 							<!-- Note: match version with docs/flinkDev/ide_setup.md -->
-							<version>8.14</version>
+							<version>8.43</version>
 						</dependency>
 					</dependencies>
 					<executions>

--- a/tools/maven/checkstyle.xml
+++ b/tools/maven/checkstyle.xml
@@ -271,16 +271,10 @@ This file is based on the checkstyle file of Apache Beam.
 		<!-- Checks for Javadoc comments.                     -->
 		<!-- See http://checkstyle.sf.net/config_javadoc.html -->
 		<module name="JavadocMethod">
-			<property name="scope" value="protected"/>
+			<property name="accessModifiers" value="protected"/>
 			<property name="severity" value="error"/>
-			<property name="allowMissingJavadoc" value="true"/>
 			<property name="allowMissingParamTags" value="true"/>
 			<property name="allowMissingReturnTag" value="true"/>
-			<property name="allowMissingThrowsTags" value="true"/>
-			<property name="allowThrowsTagsForSubclasses" value="true"/>
-			<property name="allowUndeclaredRTE" value="true"/>
-			<!-- This check sometimes failed for with "Unable to get class information for @throws tag" for custom exceptions -->
-			<property name="suppressLoadErrors" value="true"/>
 		</module>
 
 		<!-- Check that paragraph tags are used correctly in Javadoc. -->


### PR DESCRIPTION
## What is the purpose of the change

Upgrading Checkstyle to 8.43 because Checkstyle version < 8.29 is still vulnerable to XML External Entity (XXE) Processing due to an incomplete fix for CVE-2019-9658.

We can't upgrade to 8.44 (which is the latest) because that contains a [bug](https://github.com/checkstyle/checkstyle/issues/10215)

## Brief change log

* Upgraded checkstyle from 8.14 to 8.43
* Upgraded maven-checkstyle-plugin from 2.17 to 3.12
* Changed checkstyle rules due to changed and/or removed properties. See [1](https://github.com/checkstyle/checkstyle/issues/7329), [2](https://github.com/checkstyle/checkstyle/issues/7417) and [3](https://github.com/checkstyle/checkstyle/issues/7096)
* Fixed several new checkstyle violations in separate commit

## Verifying this change

This change is a trivial rework / code cleanup without any test coverage.

## Does this pull request potentially affect one of the following parts:

  - Dependencies (does it add or upgrade a dependency): yes
  - The public API, i.e., is any changed class annotated with `@Public(Evolving)`: no
  - The serializers: no
  - The runtime per-record code paths (performance sensitive): no
  - Anything that affects deployment or recovery: JobManager (and its components), Checkpointing, Kubernetes/Yarn, ZooKeeper: no
  - The S3 file system connector: no

## Documentation

  - Does this pull request introduce a new feature? no
  - If yes, how is the feature documented? not applicable
