### PR TITLE
[FLINK-22483][flink-runtime] Remove CompletedCheckpointStore#recover(…

### DIFF
--- a/flink-kubernetes/src/main/java/org/apache/flink/kubernetes/highavailability/KubernetesCheckpointRecoveryFactory.java
+++ b/flink-kubernetes/src/main/java/org/apache/flink/kubernetes/highavailability/KubernetesCheckpointRecoveryFactory.java
@@ -70,7 +70,7 @@ public class KubernetesCheckpointRecoveryFactory implements CheckpointRecoveryFa
     }
 
     @Override
-    public CompletedCheckpointStore createCheckpointStore(
+    public CompletedCheckpointStore createRecoveredCompletedCheckpointStore(
             JobID jobID, int maxNumberOfCheckpointsToRetain, ClassLoader userClassLoader)
             throws Exception {
 

--- a/flink-kubernetes/src/main/java/org/apache/flink/kubernetes/utils/KubernetesUtils.java
+++ b/flink-kubernetes/src/main/java/org/apache/flink/kubernetes/utils/KubernetesUtils.java
@@ -33,6 +33,7 @@ import org.apache.flink.kubernetes.kubeclient.resources.KubernetesPod;
 import org.apache.flink.runtime.checkpoint.CompletedCheckpoint;
 import org.apache.flink.runtime.checkpoint.CompletedCheckpointStore;
 import org.apache.flink.runtime.checkpoint.DefaultCompletedCheckpointStore;
+import org.apache.flink.runtime.checkpoint.DefaultCompletedCheckpointStoreUtils;
 import org.apache.flink.runtime.highavailability.HighAvailabilityServicesUtils;
 import org.apache.flink.runtime.jobgraph.JobGraph;
 import org.apache.flink.runtime.jobmanager.DefaultJobGraphStore;
@@ -299,6 +300,8 @@ public class KubernetesUtils {
                 maxNumberOfCheckpointsToRetain,
                 stateHandleStore,
                 KubernetesCheckpointStoreUtil.INSTANCE,
+                DefaultCompletedCheckpointStoreUtils.retrieveCompletedCheckpoints(
+                        stateHandleStore, KubernetesCheckpointStoreUtil.INSTANCE),
                 executor);
     }
 

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/checkpoint/CheckpointCoordinator.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/checkpoint/CheckpointCoordinator.java
@@ -1521,15 +1521,10 @@ public class CheckpointCoordinator {
             }
 
             // We create a new shared state registry object, so that all pending async disposal
-            // requests from previous
-            // runs will go against the old object (were they can do no harm).
-            // This must happen under the checkpoint lock.
+            // requests from previous runs will go against the old object (were they can do no
+            // harm). This must happen under the checkpoint lock.
             sharedStateRegistry.close();
             sharedStateRegistry = sharedStateRegistryFactory.create(executor);
-
-            // Recover the checkpoints, TODO this could be done only when there is a new leader, not
-            // on each recovery
-            completedCheckpointStore.recover();
 
             // Now, we re-register all (shared) states from the checkpoint store with the new
             // registry

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/checkpoint/CheckpointRecoveryFactory.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/checkpoint/CheckpointRecoveryFactory.java
@@ -24,14 +24,16 @@ import org.apache.flink.api.common.JobID;
 public interface CheckpointRecoveryFactory {
 
     /**
-     * Creates a {@link CompletedCheckpointStore} instance for a job.
+     * Creates a RECOVERED {@link CompletedCheckpointStore} instance for a job. In this context,
+     * RECOVERED means, that if we already have completed checkpoints from previous runs, we should
+     * use them as the initial state.
      *
      * @param jobId Job ID to recover checkpoints for
      * @param maxNumberOfCheckpointsToRetain Maximum number of checkpoints to retain
      * @param userClassLoader User code class loader of the job
      * @return {@link CompletedCheckpointStore} instance for the job
      */
-    CompletedCheckpointStore createCheckpointStore(
+    CompletedCheckpointStore createRecoveredCompletedCheckpointStore(
             JobID jobId, int maxNumberOfCheckpointsToRetain, ClassLoader userClassLoader)
             throws Exception;
 

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/checkpoint/CompletedCheckpointStore.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/checkpoint/CompletedCheckpointStore.java
@@ -33,14 +33,6 @@ public interface CompletedCheckpointStore {
     Logger LOG = LoggerFactory.getLogger(CompletedCheckpointStore.class);
 
     /**
-     * Recover available {@link CompletedCheckpoint} instances.
-     *
-     * <p>After a call to this method, {@link #getLatestCheckpoint(boolean)} returns the latest
-     * available checkpoint.
-     */
-    void recover() throws Exception;
-
-    /**
      * Adds a {@link CompletedCheckpoint} instance to the list of completed checkpoints.
      *
      * <p>Only a bounded number of checkpoints is kept. When exceeding the maximum number of
@@ -107,7 +99,7 @@ public interface CompletedCheckpointStore {
      * or kept.
      *
      * @param jobStatus Job state on shut down
-     * @param checkpointsCleaner that will cleanup copmpleted checkpoints if needed
+     * @param checkpointsCleaner that will cleanup completed checkpoints if needed
      */
     void shutdown(JobStatus jobStatus, CheckpointsCleaner checkpointsCleaner) throws Exception;
 

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/checkpoint/DeactivatedCheckpointCompletedCheckpointStore.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/checkpoint/DeactivatedCheckpointCompletedCheckpointStore.java
@@ -31,11 +31,6 @@ public enum DeactivatedCheckpointCompletedCheckpointStore implements CompletedCh
     INSTANCE;
 
     @Override
-    public void recover() throws Exception {
-        throw unsupportedOperationException();
-    }
-
-    @Override
     public void addCheckpoint(
             CompletedCheckpoint checkpoint,
             CheckpointsCleaner checkpointsCleaner,

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/checkpoint/DefaultCompletedCheckpointStoreUtils.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/checkpoint/DefaultCompletedCheckpointStoreUtils.java
@@ -1,0 +1,117 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.flink.runtime.checkpoint;
+
+import org.apache.flink.api.java.tuple.Tuple2;
+import org.apache.flink.runtime.persistence.ResourceVersion;
+import org.apache.flink.runtime.persistence.StateHandleStore;
+import org.apache.flink.runtime.state.RetrievableStateHandle;
+import org.apache.flink.util.FlinkException;
+
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import java.io.IOException;
+import java.util.ArrayList;
+import java.util.Collection;
+import java.util.Collections;
+import java.util.Comparator;
+import java.util.List;
+
+import static org.apache.flink.util.Preconditions.checkNotNull;
+
+/** Helper methods related to {@link DefaultCompletedCheckpointStore}. */
+public class DefaultCompletedCheckpointStoreUtils {
+
+    private static final Logger LOG =
+            LoggerFactory.getLogger(DefaultCompletedCheckpointStoreUtils.class);
+
+    private DefaultCompletedCheckpointStoreUtils() {
+        // No-op.
+    }
+
+    /**
+     * Fetch all {@link CompletedCheckpoint completed checkpoints} from an {@link StateHandleStore
+     * external store}. This method is intended for retrieving an initial state of {@link
+     * DefaultCompletedCheckpointStore}.
+     *
+     * @param checkpointStateHandleStore Completed checkpoints in external store.
+     * @param completedCheckpointStoreUtil Utilities for completed checkpoint store.
+     * @param <R> Type of {@link ResourceVersion}
+     * @return Immutable collection of {@link CompletedCheckpoint completed checkpoints}.
+     * @throws Exception If we're not able to fetch checkpoints for some reason.
+     */
+    public static <R extends ResourceVersion<R>>
+            Collection<CompletedCheckpoint> retrieveCompletedCheckpoints(
+                    StateHandleStore<CompletedCheckpoint, R> checkpointStateHandleStore,
+                    CheckpointStoreUtil completedCheckpointStoreUtil)
+                    throws Exception {
+
+        LOG.info("Recovering checkpoints from {}.", checkpointStateHandleStore);
+
+        // Get all there is first.
+        final List<Tuple2<RetrievableStateHandle<CompletedCheckpoint>, String>> initialCheckpoints =
+                checkpointStateHandleStore.getAllAndLock();
+
+        // Sort checkpoints by name.
+        initialCheckpoints.sort(Comparator.comparing(o -> o.f1));
+
+        final int numberOfInitialCheckpoints = initialCheckpoints.size();
+
+        LOG.info(
+                "Found {} checkpoints in {}.",
+                numberOfInitialCheckpoints,
+                checkpointStateHandleStore);
+        final List<CompletedCheckpoint> retrievedCheckpoints =
+                new ArrayList<>(numberOfInitialCheckpoints);
+        LOG.info("Trying to fetch {} checkpoints from storage.", numberOfInitialCheckpoints);
+
+        for (Tuple2<RetrievableStateHandle<CompletedCheckpoint>, String> checkpointStateHandle :
+                initialCheckpoints) {
+            retrievedCheckpoints.add(
+                    checkNotNull(
+                            retrieveCompletedCheckpoint(
+                                    completedCheckpointStoreUtil, checkpointStateHandle)));
+        }
+        return Collections.unmodifiableList(retrievedCheckpoints);
+    }
+
+    private static CompletedCheckpoint retrieveCompletedCheckpoint(
+            CheckpointStoreUtil completedCheckpointStoreUtil,
+            Tuple2<RetrievableStateHandle<CompletedCheckpoint>, String> stateHandle)
+            throws FlinkException {
+        final long checkpointId = completedCheckpointStoreUtil.nameToCheckpointID(stateHandle.f1);
+        LOG.info("Trying to retrieve checkpoint {}.", checkpointId);
+        try {
+            return stateHandle.f0.retrieveState();
+        } catch (ClassNotFoundException exception) {
+            throw new FlinkException(
+                    String.format(
+                            "Could not retrieve checkpoint %d from state handle under %s. This indicates that you are trying to recover from state written by an older Flink version which is not compatible. Try cleaning the state handle store.",
+                            checkpointId, stateHandle.f1),
+                    exception);
+        } catch (IOException exception) {
+            throw new FlinkException(
+                    String.format(
+                            "Could not retrieve checkpoint %d from state handle under %s. This indicates that the retrieved state handle is broken. Try cleaning the state handle store.",
+                            checkpointId, stateHandle.f1),
+                    exception);
+        }
+    }
+}

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/checkpoint/PerJobCheckpointRecoveryFactory.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/checkpoint/PerJobCheckpointRecoveryFactory.java
@@ -21,46 +21,63 @@ package org.apache.flink.runtime.checkpoint;
 import org.apache.flink.annotation.VisibleForTesting;
 import org.apache.flink.api.common.JobID;
 
-import java.util.HashMap;
-import java.util.Map;
-import java.util.function.Function;
+import java.util.concurrent.ConcurrentHashMap;
+import java.util.concurrent.ConcurrentMap;
+import java.util.function.BiFunction;
+import java.util.function.IntFunction;
 import java.util.function.Supplier;
 
 /**
  * Simple {@link CheckpointRecoveryFactory} which creates and keeps separate {@link
  * CompletedCheckpointStore} and {@link CheckpointIDCounter} for each {@link JobID}.
  */
-public class PerJobCheckpointRecoveryFactory implements CheckpointRecoveryFactory {
-    private final Function<Integer, CompletedCheckpointStore> completedCheckpointStorePerJobFactory;
+public class PerJobCheckpointRecoveryFactory<T extends CompletedCheckpointStore>
+        implements CheckpointRecoveryFactory {
+
+    @VisibleForTesting
+    public static <T extends CompletedCheckpointStore>
+            CheckpointRecoveryFactory withoutCheckpointStoreRecovery(IntFunction<T> storeFn) {
+        return new PerJobCheckpointRecoveryFactory<>(
+                (maxCheckpoints, previous) -> {
+                    if (previous != null) {
+                        throw new UnsupportedOperationException(
+                                "Checkpoint store recovery is not supported.");
+                    }
+                    return storeFn.apply(maxCheckpoints);
+                });
+    }
+
+    private final BiFunction<Integer, T, T> completedCheckpointStorePerJobFactory;
     private final Supplier<CheckpointIDCounter> checkpointIDCounterPerJobFactory;
-    private final Map<JobID, CompletedCheckpointStore> store;
-    private final Map<JobID, CheckpointIDCounter> counter;
+    private final ConcurrentMap<JobID, T> store;
+    private final ConcurrentMap<JobID, CheckpointIDCounter> counter;
 
     public PerJobCheckpointRecoveryFactory(
-            Function<Integer, CompletedCheckpointStore> completedCheckpointStorePerJobFactory,
+            BiFunction<Integer, T, T> completedCheckpointStorePerJobFactory) {
+        this(completedCheckpointStorePerJobFactory, StandaloneCheckpointIDCounter::new);
+    }
+
+    public PerJobCheckpointRecoveryFactory(
+            BiFunction<Integer, T, T> completedCheckpointStorePerJobFactory,
             Supplier<CheckpointIDCounter> checkpointIDCounterPerJobFactory) {
         this.completedCheckpointStorePerJobFactory = completedCheckpointStorePerJobFactory;
         this.checkpointIDCounterPerJobFactory = checkpointIDCounterPerJobFactory;
-        this.store = new HashMap<>();
-        this.counter = new HashMap<>();
+        this.store = new ConcurrentHashMap<>();
+        this.counter = new ConcurrentHashMap<>();
     }
 
     @Override
-    public CompletedCheckpointStore createCheckpointStore(
+    public CompletedCheckpointStore createRecoveredCompletedCheckpointStore(
             JobID jobId, int maxNumberOfCheckpointsToRetain, ClassLoader userClassLoader) {
-        return store.computeIfAbsent(
+        return store.compute(
                 jobId,
-                jId -> completedCheckpointStorePerJobFactory.apply(maxNumberOfCheckpointsToRetain));
+                (key, previous) ->
+                        completedCheckpointStorePerJobFactory.apply(
+                                maxNumberOfCheckpointsToRetain, previous));
     }
 
     @Override
     public CheckpointIDCounter createCheckpointIDCounter(JobID jobId) {
         return counter.computeIfAbsent(jobId, jId -> checkpointIDCounterPerJobFactory.get());
-    }
-
-    @VisibleForTesting
-    public static CheckpointRecoveryFactory useSameServicesForAllJobs(
-            CompletedCheckpointStore store, CheckpointIDCounter counter) {
-        return new PerJobCheckpointRecoveryFactory(n -> store, () -> counter);
     }
 }

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/checkpoint/StandaloneCheckpointRecoveryFactory.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/checkpoint/StandaloneCheckpointRecoveryFactory.java
@@ -25,7 +25,7 @@ import org.apache.flink.runtime.jobmanager.HighAvailabilityMode;
 public class StandaloneCheckpointRecoveryFactory implements CheckpointRecoveryFactory {
 
     @Override
-    public CompletedCheckpointStore createCheckpointStore(
+    public CompletedCheckpointStore createRecoveredCompletedCheckpointStore(
             JobID jobId, int maxNumberOfCheckpointsToRetain, ClassLoader userClassLoader)
             throws Exception {
 

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/checkpoint/StandaloneCompletedCheckpointStore.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/checkpoint/StandaloneCompletedCheckpointStore.java
@@ -57,11 +57,6 @@ public class StandaloneCompletedCheckpointStore implements CompletedCheckpointSt
     }
 
     @Override
-    public void recover() throws Exception {
-        // Nothing to do
-    }
-
-    @Override
     public void addCheckpoint(
             CompletedCheckpoint checkpoint,
             CheckpointsCleaner checkpointsCleaner,

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/checkpoint/ZooKeeperCheckpointRecoveryFactory.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/checkpoint/ZooKeeperCheckpointRecoveryFactory.java
@@ -46,7 +46,7 @@ public class ZooKeeperCheckpointRecoveryFactory implements CheckpointRecoveryFac
     }
 
     @Override
-    public CompletedCheckpointStore createCheckpointStore(
+    public CompletedCheckpointStore createRecoveredCompletedCheckpointStore(
             JobID jobId, int maxNumberOfCheckpointsToRetain, ClassLoader userClassLoader)
             throws Exception {
 

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/minicluster/MiniCluster.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/minicluster/MiniCluster.java
@@ -503,7 +503,7 @@ public class MiniCluster implements AutoCloseableAsync {
                 return HighAvailabilityServicesUtils.createAvailableOrEmbeddedServices(
                         configuration, executor);
             default:
-                throw new IllegalConfigurationException("Unkown HA Services " + haServices);
+                throw new IllegalConfigurationException("Unknown HA Services " + haServices);
         }
     }
 

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/scheduler/SchedulerUtils.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/scheduler/SchedulerUtils.java
@@ -88,7 +88,7 @@ public final class SchedulerUtils {
                     CheckpointingOptions.MAX_RETAINED_CHECKPOINTS.defaultValue();
         }
 
-        return recoveryFactory.createCheckpointStore(
+        return recoveryFactory.createRecoveredCompletedCheckpointStore(
                 jobId, maxNumberOfCheckpointsToRetain, classLoader);
     }
 

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/util/ZooKeeperUtils.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/util/ZooKeeperUtils.java
@@ -27,6 +27,7 @@ import org.apache.flink.configuration.SecurityOptions;
 import org.apache.flink.runtime.checkpoint.CompletedCheckpoint;
 import org.apache.flink.runtime.checkpoint.CompletedCheckpointStore;
 import org.apache.flink.runtime.checkpoint.DefaultCompletedCheckpointStore;
+import org.apache.flink.runtime.checkpoint.DefaultCompletedCheckpointStoreUtils;
 import org.apache.flink.runtime.checkpoint.DefaultLastStateConnectionStateListener;
 import org.apache.flink.runtime.checkpoint.ZooKeeperCheckpointIDCounter;
 import org.apache.flink.runtime.checkpoint.ZooKeeperCheckpointStoreUtil;
@@ -439,6 +440,9 @@ public class ZooKeeperUtils {
                         maxNumberOfCheckpointsToRetain,
                         completedCheckpointStateHandleStore,
                         ZooKeeperCheckpointStoreUtil.INSTANCE,
+                        DefaultCompletedCheckpointStoreUtils.retrieveCompletedCheckpoints(
+                                completedCheckpointStateHandleStore,
+                                ZooKeeperCheckpointStoreUtil.INSTANCE),
                         executor);
 
         LOG.info(

--- a/flink-runtime/src/test/java/org/apache/flink/runtime/checkpoint/CheckpointCoordinatorFailureTest.java
+++ b/flink-runtime/src/test/java/org/apache/flink/runtime/checkpoint/CheckpointCoordinatorFailureTest.java
@@ -255,11 +255,6 @@ public class CheckpointCoordinatorFailureTest extends TestLogger {
         }
 
         @Override
-        public void recover() throws Exception {
-            throw new UnsupportedOperationException("Not implemented.");
-        }
-
-        @Override
         public void addCheckpoint(
                 CompletedCheckpoint checkpoint,
                 CheckpointsCleaner checkpointsCleaner,

--- a/flink-runtime/src/test/java/org/apache/flink/runtime/checkpoint/CheckpointCoordinatorTestingUtils.java
+++ b/flink-runtime/src/test/java/org/apache/flink/runtime/checkpoint/CheckpointCoordinatorTestingUtils.java
@@ -218,6 +218,15 @@ public class CheckpointCoordinatorTestingUtils {
         return new Tuple2<>(allSerializedValuesConcatenated, offsets);
     }
 
+    public static void verifyStateRestore(ExecutionJobVertex executionJobVertex) throws Exception {
+        verifyStateRestore(
+                executionJobVertex.getJobVertexId(),
+                executionJobVertex,
+                StateAssignmentOperation.createKeyGroupPartitions(
+                        executionJobVertex.getMaxParallelism(),
+                        executionJobVertex.getParallelism()));
+    }
+
     public static void verifyStateRestore(
             JobVertexID jobVertexID,
             ExecutionJobVertex executionJobVertex,

--- a/flink-runtime/src/test/java/org/apache/flink/runtime/checkpoint/CompletedCheckpointStoreTest.java
+++ b/flink-runtime/src/test/java/org/apache/flink/runtime/checkpoint/CompletedCheckpointStoreTest.java
@@ -45,12 +45,12 @@ import static org.junit.Assert.assertTrue;
 public abstract class CompletedCheckpointStoreTest extends TestLogger {
 
     /** Creates the {@link CompletedCheckpointStore} implementation to be tested. */
-    protected abstract CompletedCheckpointStore createCompletedCheckpoints(
+    protected abstract CompletedCheckpointStore createRecoveredCompletedCheckpointStore(
             int maxNumberOfCheckpointsToRetain, Executor executor) throws Exception;
 
-    protected CompletedCheckpointStore createCompletedCheckpoints(
+    protected CompletedCheckpointStore createRecoveredCompletedCheckpointStore(
             int maxNumberOfCheckpointsToRetain) throws Exception {
-        return createCompletedCheckpoints(
+        return createRecoveredCompletedCheckpointStore(
                 maxNumberOfCheckpointsToRetain, Executors.directExecutor());
     }
 
@@ -59,14 +59,14 @@ public abstract class CompletedCheckpointStoreTest extends TestLogger {
     /** Tests that at least one checkpoint needs to be retained. */
     @Test(expected = Exception.class)
     public void testExceptionOnNoRetainedCheckpoints() throws Exception {
-        createCompletedCheckpoints(0);
+        createRecoveredCompletedCheckpointStore(0);
     }
 
     /** Tests adding and getting a checkpoint. */
     @Test
     public void testAddAndGetLatestCheckpoint() throws Exception {
         SharedStateRegistry sharedStateRegistry = new SharedStateRegistry();
-        CompletedCheckpointStore checkpoints = createCompletedCheckpoints(4);
+        CompletedCheckpointStore checkpoints = createRecoveredCompletedCheckpointStore(4);
 
         // Empty state
         assertEquals(0, checkpoints.getNumberOfRetainedCheckpoints());
@@ -95,7 +95,7 @@ public abstract class CompletedCheckpointStoreTest extends TestLogger {
     @Test
     public void testAddCheckpointMoreThanMaxRetained() throws Exception {
         SharedStateRegistry sharedStateRegistry = new SharedStateRegistry();
-        CompletedCheckpointStore checkpoints = createCompletedCheckpoints(1);
+        CompletedCheckpointStore checkpoints = createRecoveredCompletedCheckpointStore(1);
 
         TestCompletedCheckpoint[] expected =
                 new TestCompletedCheckpoint[] {
@@ -131,7 +131,7 @@ public abstract class CompletedCheckpointStoreTest extends TestLogger {
      */
     @Test
     public void testEmptyState() throws Exception {
-        CompletedCheckpointStore checkpoints = createCompletedCheckpoints(1);
+        CompletedCheckpointStore checkpoints = createRecoveredCompletedCheckpointStore(1);
 
         assertNull(checkpoints.getLatestCheckpoint(false));
         assertEquals(0, checkpoints.getAllCheckpoints().size());
@@ -142,7 +142,7 @@ public abstract class CompletedCheckpointStoreTest extends TestLogger {
     @Test
     public void testGetAllCheckpoints() throws Exception {
         SharedStateRegistry sharedStateRegistry = new SharedStateRegistry();
-        CompletedCheckpointStore checkpoints = createCompletedCheckpoints(4);
+        CompletedCheckpointStore checkpoints = createRecoveredCompletedCheckpointStore(4);
 
         TestCompletedCheckpoint[] expected =
                 new TestCompletedCheckpoint[] {
@@ -169,7 +169,7 @@ public abstract class CompletedCheckpointStoreTest extends TestLogger {
     @Test
     public void testDiscardAllCheckpoints() throws Exception {
         SharedStateRegistry sharedStateRegistry = new SharedStateRegistry();
-        CompletedCheckpointStore checkpoints = createCompletedCheckpoints(4);
+        CompletedCheckpointStore checkpoints = createRecoveredCompletedCheckpointStore(4);
 
         TestCompletedCheckpoint[] expected =
                 new TestCompletedCheckpoint[] {
@@ -201,7 +201,7 @@ public abstract class CompletedCheckpointStoreTest extends TestLogger {
     @Test
     public void testAcquireLatestCompletedCheckpointId() throws Exception {
         SharedStateRegistry sharedStateRegistry = new SharedStateRegistry();
-        CompletedCheckpointStore checkpoints = createCompletedCheckpoints(1);
+        CompletedCheckpointStore checkpoints = createRecoveredCompletedCheckpointStore(1);
         assertEquals(0, checkpoints.getLatestCheckpointId());
 
         checkpoints.addCheckpoint(

--- a/flink-runtime/src/test/java/org/apache/flink/runtime/checkpoint/DefaultCompletedCheckpointStoreUtilsTest.java
+++ b/flink-runtime/src/test/java/org/apache/flink/runtime/checkpoint/DefaultCompletedCheckpointStoreUtilsTest.java
@@ -1,0 +1,138 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.flink.runtime.checkpoint;
+
+import org.apache.flink.api.common.JobID;
+import org.apache.flink.api.java.tuple.Tuple2;
+import org.apache.flink.runtime.persistence.TestingStateHandleStore;
+import org.apache.flink.runtime.state.RetrievableStateHandle;
+import org.apache.flink.runtime.state.testutils.TestCompletedCheckpointStorageLocation;
+import org.apache.flink.util.FlinkException;
+import org.apache.flink.util.TestLogger;
+
+import org.junit.Test;
+
+import java.io.IOException;
+import java.io.Serializable;
+import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.Collection;
+import java.util.Collections;
+import java.util.HashMap;
+import java.util.List;
+import java.util.stream.Collectors;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertThrows;
+
+/** Tests related to {@link DefaultCompletedCheckpointStoreUtils}. */
+public class DefaultCompletedCheckpointStoreUtilsTest extends TestLogger {
+
+    private static CompletedCheckpoint createCompletedCheckpoint(long checkpointId) {
+        return new CompletedCheckpoint(
+                new JobID(),
+                checkpointId,
+                0,
+                1,
+                new HashMap<>(),
+                Collections.emptyList(),
+                CheckpointProperties.forCheckpoint(CheckpointRetentionPolicy.RETAIN_ON_FAILURE),
+                new TestCompletedCheckpointStorageLocation());
+    }
+
+    private static class FailingRetrievableStateHandle<T extends Serializable>
+            implements RetrievableStateHandle<T> {
+
+        private static final int serialVersionUID = 1;
+
+        @Override
+        public T retrieveState() throws IOException, ClassNotFoundException {
+            throw new IOException("Test exception.");
+        }
+
+        @Override
+        public void discardState() throws Exception {
+            // No-op.
+        }
+
+        @Override
+        public long getStateSize() {
+            return 0;
+        }
+    }
+
+    private static class SimpleCheckpointStoreUtil implements CheckpointStoreUtil {
+
+        @Override
+        public String checkpointIDToName(long checkpointId) {
+            return "checkpoint-" + checkpointId;
+        }
+
+        @Override
+        public long nameToCheckpointID(String name) {
+            return Long.parseLong(name.split("-")[1]);
+        }
+    }
+
+    @Test
+    public void testRetrievedCheckpointsAreOrderedChronologically() throws Exception {
+        final TestingRetrievableStateStorageHelper<CompletedCheckpoint> storageHelper =
+                new TestingRetrievableStateStorageHelper<>();
+        final List<Tuple2<RetrievableStateHandle<CompletedCheckpoint>, String>> handles =
+                new ArrayList<>();
+        handles.add(Tuple2.of(storageHelper.store(createCompletedCheckpoint(0L)), "checkpoint-0"));
+        handles.add(Tuple2.of(storageHelper.store(createCompletedCheckpoint(1L)), "checkpoint-1"));
+        handles.add(Tuple2.of(storageHelper.store(createCompletedCheckpoint(2L)), "checkpoint-2"));
+        Collections.shuffle(handles);
+        final TestingStateHandleStore<CompletedCheckpoint> stateHandleStore =
+                TestingStateHandleStore.<CompletedCheckpoint>newBuilder()
+                        .setGetAllSupplier(() -> handles)
+                        .build();
+        final Collection<CompletedCheckpoint> completedCheckpoints =
+                DefaultCompletedCheckpointStoreUtils.retrieveCompletedCheckpoints(
+                        stateHandleStore, new SimpleCheckpointStoreUtil());
+        // Make sure checkpoints are ordered from earliest to latest.
+        assertEquals(
+                Arrays.asList(0L, 1L, 2L),
+                completedCheckpoints.stream()
+                        .map(CompletedCheckpoint::getCheckpointID)
+                        .collect(Collectors.toList()));
+    }
+
+    @Test
+    public void testRetrievingCheckpointsFailsIfRetrievalOfAnyCheckpointFails() throws Exception {
+        final TestingRetrievableStateStorageHelper<CompletedCheckpoint> storageHelper =
+                new TestingRetrievableStateStorageHelper<>();
+        final List<Tuple2<RetrievableStateHandle<CompletedCheckpoint>, String>> handles =
+                new ArrayList<>();
+        handles.add(Tuple2.of(storageHelper.store(createCompletedCheckpoint(0L)), "checkpoint-0"));
+        handles.add(Tuple2.of(new FailingRetrievableStateHandle<>(), "checkpoint-1"));
+        handles.add(Tuple2.of(storageHelper.store(createCompletedCheckpoint(2L)), "checkpoint-2"));
+        Collections.shuffle(handles);
+        final TestingStateHandleStore<CompletedCheckpoint> stateHandleStore =
+                TestingStateHandleStore.<CompletedCheckpoint>newBuilder()
+                        .setGetAllSupplier(() -> handles)
+                        .build();
+        assertThrows(
+                FlinkException.class,
+                () ->
+                        DefaultCompletedCheckpointStoreUtils.retrieveCompletedCheckpoints(
+                                stateHandleStore, new SimpleCheckpointStoreUtil()));
+    }
+}

--- a/flink-runtime/src/test/java/org/apache/flink/runtime/checkpoint/PerJobCheckpointRecoveryTest.java
+++ b/flink-runtime/src/test/java/org/apache/flink/runtime/checkpoint/PerJobCheckpointRecoveryTest.java
@@ -1,0 +1,58 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.flink.runtime.checkpoint;
+
+import org.apache.flink.api.common.JobID;
+import org.apache.flink.util.TestLogger;
+
+import org.junit.Test;
+
+import java.util.concurrent.CompletableFuture;
+
+import static org.junit.Assert.assertSame;
+import static org.junit.Assert.assertThrows;
+
+/** Tests related to {@link PerJobCheckpointRecoveryFactory}. */
+public class PerJobCheckpointRecoveryTest extends TestLogger {
+
+    @Test
+    public void testFactoryWithoutCheckpointStoreRecovery() throws Exception {
+        final TestingCompletedCheckpointStore store =
+                new TestingCompletedCheckpointStore(new CompletableFuture<>());
+        final CheckpointRecoveryFactory factory =
+                PerJobCheckpointRecoveryFactory.withoutCheckpointStoreRecovery(
+                        maxCheckpoints -> store);
+        final ClassLoader classLoader = Thread.currentThread().getContextClassLoader();
+
+        final JobID firstJobId = new JobID();
+        assertSame(
+                store, factory.createRecoveredCompletedCheckpointStore(firstJobId, 1, classLoader));
+        assertThrows(
+                UnsupportedOperationException.class,
+                () -> factory.createRecoveredCompletedCheckpointStore(firstJobId, 1, classLoader));
+
+        final JobID secondJobId = new JobID();
+        assertSame(
+                store,
+                factory.createRecoveredCompletedCheckpointStore(secondJobId, 1, classLoader));
+        assertThrows(
+                UnsupportedOperationException.class,
+                () -> factory.createRecoveredCompletedCheckpointStore(secondJobId, 1, classLoader));
+    }
+}

--- a/flink-runtime/src/test/java/org/apache/flink/runtime/checkpoint/StandaloneCompletedCheckpointStoreTest.java
+++ b/flink-runtime/src/test/java/org/apache/flink/runtime/checkpoint/StandaloneCompletedCheckpointStoreTest.java
@@ -41,9 +41,8 @@ import static org.junit.Assert.assertTrue;
 public class StandaloneCompletedCheckpointStoreTest extends CompletedCheckpointStoreTest {
 
     @Override
-    protected CompletedCheckpointStore createCompletedCheckpoints(
+    protected CompletedCheckpointStore createRecoveredCompletedCheckpointStore(
             int maxNumberOfCheckpointsToRetain, Executor executor) throws Exception {
-
         return new StandaloneCompletedCheckpointStore(maxNumberOfCheckpointsToRetain);
     }
 
@@ -51,7 +50,7 @@ public class StandaloneCompletedCheckpointStoreTest extends CompletedCheckpointS
     @Test
     public void testShutdownDiscardsCheckpoints() throws Exception {
         SharedStateRegistry sharedStateRegistry = new SharedStateRegistry();
-        CompletedCheckpointStore store = createCompletedCheckpoints(1);
+        CompletedCheckpointStore store = createRecoveredCompletedCheckpointStore(1);
         TestCompletedCheckpoint checkpoint = createCheckpoint(0, sharedStateRegistry);
         Collection<OperatorState> operatorStates = checkpoint.getOperatorStates().values();
 
@@ -72,7 +71,7 @@ public class StandaloneCompletedCheckpointStoreTest extends CompletedCheckpointS
     @Test
     public void testSuspendDiscardsCheckpoints() throws Exception {
         SharedStateRegistry sharedStateRegistry = new SharedStateRegistry();
-        CompletedCheckpointStore store = createCompletedCheckpoints(1);
+        CompletedCheckpointStore store = createRecoveredCompletedCheckpointStore(1);
         TestCompletedCheckpoint checkpoint = createCheckpoint(0, sharedStateRegistry);
         Collection<OperatorState> taskStates = checkpoint.getOperatorStates().values();
 
@@ -95,7 +94,8 @@ public class StandaloneCompletedCheckpointStoreTest extends CompletedCheckpointS
 
         final int numCheckpointsToRetain = 1;
         CompletedCheckpointStore store =
-                createCompletedCheckpoints(numCheckpointsToRetain, Executors.directExecutor());
+                createRecoveredCompletedCheckpointStore(
+                        numCheckpointsToRetain, Executors.directExecutor());
 
         CountDownLatch discardAttempted = new CountDownLatch(1);
         for (long i = 0; i < numCheckpointsToRetain + 1; ++i) {

--- a/flink-runtime/src/test/java/org/apache/flink/runtime/checkpoint/TestingCheckpointRecoveryFactory.java
+++ b/flink-runtime/src/test/java/org/apache/flink/runtime/checkpoint/TestingCheckpointRecoveryFactory.java
@@ -32,7 +32,7 @@ public class TestingCheckpointRecoveryFactory implements CheckpointRecoveryFacto
     }
 
     @Override
-    public CompletedCheckpointStore createCheckpointStore(
+    public CompletedCheckpointStore createRecoveredCompletedCheckpointStore(
             JobID jobId, int maxNumberOfCheckpointsToRetain, ClassLoader userClassLoader) {
         return store;
     }

--- a/flink-runtime/src/test/java/org/apache/flink/runtime/checkpoint/TestingCompletedCheckpointStore.java
+++ b/flink-runtime/src/test/java/org/apache/flink/runtime/checkpoint/TestingCompletedCheckpointStore.java
@@ -33,9 +33,6 @@ public final class TestingCompletedCheckpointStore implements CompletedCheckpoin
     }
 
     @Override
-    public void recover() {}
-
-    @Override
     public void addCheckpoint(
             CompletedCheckpoint checkpoint,
             CheckpointsCleaner checkpointsCleaner,

--- a/flink-runtime/src/test/java/org/apache/flink/runtime/checkpoint/ZooKeeperCompletedCheckpointStoreMockitoTest.java
+++ b/flink-runtime/src/test/java/org/apache/flink/runtime/checkpoint/ZooKeeperCompletedCheckpointStoreMockitoTest.java
@@ -170,9 +170,9 @@ public class ZooKeeperCompletedCheckpointStoreMockitoTest extends TestLogger {
                         numCheckpointsToRetain,
                         zooKeeperStateHandleStoreMock,
                         zooKeeperCheckpointStoreUtil,
+                        DefaultCompletedCheckpointStoreUtils.retrieveCompletedCheckpoints(
+                                zooKeeperStateHandleStoreMock, zooKeeperCheckpointStoreUtil),
                         Executors.directExecutor());
-
-        zooKeeperCompletedCheckpointStore.recover();
 
         CompletedCheckpoint latestCompletedCheckpoint =
                 zooKeeperCompletedCheckpointStore.getLatestCheckpoint(false);
@@ -306,9 +306,9 @@ public class ZooKeeperCompletedCheckpointStoreMockitoTest extends TestLogger {
                         numCheckpointsToRetain,
                         zooKeeperStateHandleStoreMock,
                         zooKeeperCheckpointStoreUtil,
+                        DefaultCompletedCheckpointStoreUtils.retrieveCompletedCheckpoints(
+                                zooKeeperStateHandleStoreMock, zooKeeperCheckpointStoreUtil),
                         Executors.directExecutor());
-
-        zooKeeperCompletedCheckpointStore.recover();
 
         CompletedCheckpoint latestCompletedCheckpoint =
                 zooKeeperCompletedCheckpointStore.getLatestCheckpoint(true);

--- a/flink-runtime/src/test/java/org/apache/flink/runtime/jobmanager/DefaultJobGraphStoreTest.java
+++ b/flink-runtime/src/test/java/org/apache/flink/runtime/jobmanager/DefaultJobGraphStoreTest.java
@@ -68,7 +68,7 @@ public class DefaultJobGraphStoreTest extends TestLogger {
 
     @Before
     public void setup() {
-        builder = TestingStateHandleStore.builder();
+        builder = TestingStateHandleStore.newBuilder();
         testingJobGraphStoreWatcher = new TestingJobGraphStoreWatcher();
         testingJobGraphListener = new TestingJobGraphListener();
         jobGraphStorageHelper = new TestingRetrievableStateStorageHelper<>();

--- a/flink-runtime/src/test/java/org/apache/flink/runtime/jobmaster/JobExecutionITCase.java
+++ b/flink-runtime/src/test/java/org/apache/flink/runtime/jobmaster/JobExecutionITCase.java
@@ -51,7 +51,7 @@ public class JobExecutionITCase extends TestLogger {
         final JobGraph jobGraph = createJobGraph(parallelism);
 
         final TestingMiniClusterConfiguration miniClusterConfiguration =
-                new TestingMiniClusterConfiguration.Builder()
+                TestingMiniClusterConfiguration.newBuilder()
                         .setNumSlotsPerTaskManager(numSlotsPerTaskExecutor)
                         .setNumTaskManagers(numTaskExecutors)
                         .setLocalCommunication(true)

--- a/flink-runtime/src/test/java/org/apache/flink/runtime/jobmaster/JobMasterTest.java
+++ b/flink-runtime/src/test/java/org/apache/flink/runtime/jobmaster/JobMasterTest.java
@@ -41,7 +41,7 @@ import org.apache.flink.runtime.checkpoint.CheckpointRecoveryFactory;
 import org.apache.flink.runtime.checkpoint.CheckpointRetentionPolicy;
 import org.apache.flink.runtime.checkpoint.CheckpointsCleaner;
 import org.apache.flink.runtime.checkpoint.CompletedCheckpoint;
-import org.apache.flink.runtime.checkpoint.StandaloneCheckpointIDCounter;
+import org.apache.flink.runtime.checkpoint.PerJobCheckpointRecoveryFactory;
 import org.apache.flink.runtime.checkpoint.StandaloneCheckpointRecoveryFactory;
 import org.apache.flink.runtime.checkpoint.StandaloneCompletedCheckpointStore;
 import org.apache.flink.runtime.clusterframework.types.AllocationID;
@@ -159,7 +159,6 @@ import java.util.function.Supplier;
 import java.util.stream.Collectors;
 import java.util.stream.IntStream;
 
-import static org.apache.flink.runtime.checkpoint.PerJobCheckpointRecoveryFactory.useSameServicesForAllJobs;
 import static org.hamcrest.MatcherAssert.assertThat;
 import static org.hamcrest.Matchers.anyOf;
 import static org.hamcrest.Matchers.containsInAnyOrder;
@@ -798,8 +797,8 @@ public class JobMasterTest extends TestLogger {
         final StandaloneCompletedCheckpointStore completedCheckpointStore =
                 new StandaloneCompletedCheckpointStore(1);
         final CheckpointRecoveryFactory testingCheckpointRecoveryFactory =
-                useSameServicesForAllJobs(
-                        completedCheckpointStore, new StandaloneCheckpointIDCounter());
+                PerJobCheckpointRecoveryFactory.withoutCheckpointStoreRecovery(
+                        maxCheckpoints -> completedCheckpointStore);
         haServices.setCheckpointRecoveryFactory(testingCheckpointRecoveryFactory);
 
         final JobMaster jobMaster =
@@ -873,8 +872,8 @@ public class JobMasterTest extends TestLogger {
         completedCheckpointStore.addCheckpoint(
                 completedCheckpoint, new CheckpointsCleaner(), () -> {});
         final CheckpointRecoveryFactory testingCheckpointRecoveryFactory =
-                useSameServicesForAllJobs(
-                        completedCheckpointStore, new StandaloneCheckpointIDCounter());
+                PerJobCheckpointRecoveryFactory.withoutCheckpointStoreRecovery(
+                        maxCheckpoints -> completedCheckpointStore);
         haServices.setCheckpointRecoveryFactory(testingCheckpointRecoveryFactory);
 
         final JobMaster jobMaster = new JobMasterBuilder(jobGraph, rpcService).createJobMaster();

--- a/flink-runtime/src/test/java/org/apache/flink/runtime/leaderelection/LeaderChangeClusterComponentsTest.java
+++ b/flink-runtime/src/test/java/org/apache/flink/runtime/leaderelection/LeaderChangeClusterComponentsTest.java
@@ -81,7 +81,7 @@ public class LeaderChangeClusterComponentsTest extends TestLogger {
 
         miniCluster =
                 new TestingMiniCluster(
-                        new TestingMiniClusterConfiguration.Builder()
+                        TestingMiniClusterConfiguration.newBuilder()
                                 .setNumTaskManagers(NUM_TMS)
                                 .setNumSlotsPerTaskManager(SLOTS_PER_TM)
                                 .build(),

--- a/flink-runtime/src/test/java/org/apache/flink/runtime/minicluster/TestingMiniClusterConfiguration.java
+++ b/flink-runtime/src/test/java/org/apache/flink/runtime/minicluster/TestingMiniClusterConfiguration.java
@@ -30,6 +30,15 @@ import static org.apache.flink.runtime.minicluster.RpcServiceSharing.SHARED;
 /** Configuration for the {@link TestingMiniCluster}. */
 public class TestingMiniClusterConfiguration extends MiniClusterConfiguration {
 
+    /**
+     * Create a new {@link Builder builder} for {@link TestingMiniClusterConfiguration}.
+     *
+     * @return New builder instance.
+     */
+    public static Builder newBuilder() {
+        return new Builder();
+    }
+
     private final int numberDispatcherResourceManagerComponents;
 
     private final boolean localCommunication;
@@ -70,8 +79,12 @@ public class TestingMiniClusterConfiguration extends MiniClusterConfiguration {
 
         @Nullable private String commonBindAddress = null;
 
-        public Builder setConfiguration(Configuration configuration1) {
-            this.configuration = Preconditions.checkNotNull(configuration1);
+        private Builder() {
+            // No-op.
+        }
+
+        public Builder setConfiguration(Configuration configuration) {
+            this.configuration = Preconditions.checkNotNull(configuration);
             return this;
         }
 

--- a/flink-runtime/src/test/java/org/apache/flink/runtime/persistence/TestingStateHandleStore.java
+++ b/flink-runtime/src/test/java/org/apache/flink/runtime/persistence/TestingStateHandleStore.java
@@ -141,7 +141,7 @@ public class TestingStateHandleStore<T extends Serializable>
         releaseAllHandlesRunnable.run();
     }
 
-    public static <T extends Serializable> Builder<T> builder() {
+    public static <T extends Serializable> Builder<T> newBuilder() {
         return new Builder<>();
     }
 

--- a/flink-tests/src/test/java/org/apache/flink/test/checkpointing/NotifyCheckpointAbortedITCase.java
+++ b/flink-tests/src/test/java/org/apache/flink/test/checkpointing/NotifyCheckpointAbortedITCase.java
@@ -39,12 +39,11 @@ import org.apache.flink.runtime.checkpoint.CheckpointRecoveryFactory;
 import org.apache.flink.runtime.checkpoint.CheckpointsCleaner;
 import org.apache.flink.runtime.checkpoint.CompletedCheckpoint;
 import org.apache.flink.runtime.checkpoint.PerJobCheckpointRecoveryFactory;
-import org.apache.flink.runtime.checkpoint.StandaloneCheckpointIDCounter;
 import org.apache.flink.runtime.checkpoint.StandaloneCompletedCheckpointStore;
 import org.apache.flink.runtime.execution.Environment;
 import org.apache.flink.runtime.highavailability.HighAvailabilityServices;
 import org.apache.flink.runtime.highavailability.HighAvailabilityServicesFactory;
-import org.apache.flink.runtime.highavailability.nonha.embedded.EmbeddedHaServices;
+import org.apache.flink.runtime.highavailability.nonha.embedded.EmbeddedHaServicesWithLeadershipControl;
 import org.apache.flink.runtime.jobgraph.JobGraph;
 import org.apache.flink.runtime.operators.testutils.ExpectedTestException;
 import org.apache.flink.runtime.state.BackendBuildingException;
@@ -417,20 +416,6 @@ public class NotifyCheckpointAbortedITCase extends TestLogger {
         }
     }
 
-    private static class TestingHaServices extends EmbeddedHaServices {
-        private final CheckpointRecoveryFactory checkpointRecoveryFactory;
-
-        TestingHaServices(CheckpointRecoveryFactory checkpointRecoveryFactory, Executor executor) {
-            super(executor);
-            this.checkpointRecoveryFactory = checkpointRecoveryFactory;
-        }
-
-        @Override
-        public CheckpointRecoveryFactory getCheckpointRecoveryFactory() {
-            return checkpointRecoveryFactory;
-        }
-    }
-
     /** An extension of {@link StandaloneCompletedCheckpointStore}. */
     private static class TestingCompletedCheckpointStore
             extends StandaloneCompletedCheckpointStore {
@@ -471,11 +456,10 @@ public class NotifyCheckpointAbortedITCase extends TestLogger {
         @Override
         public HighAvailabilityServices createHAServices(
                 Configuration configuration, Executor executor) {
-            return new TestingHaServices(
-                    PerJobCheckpointRecoveryFactory.useSameServicesForAllJobs(
-                            new TestingCompletedCheckpointStore(),
-                            new StandaloneCheckpointIDCounter()),
-                    executor);
+            final CheckpointRecoveryFactory checkpointRecoveryFactory =
+                    PerJobCheckpointRecoveryFactory.withoutCheckpointStoreRecovery(
+                            maxCheckpoints -> new TestingCompletedCheckpointStore());
+            return new EmbeddedHaServicesWithLeadershipControl(executor, checkpointRecoveryFactory);
         }
     }
 }

--- a/flink-tests/src/test/java/org/apache/flink/test/checkpointing/RegionFailoverITCase.java
+++ b/flink-tests/src/test/java/org/apache/flink/test/checkpointing/RegionFailoverITCase.java
@@ -35,11 +35,10 @@ import org.apache.flink.runtime.checkpoint.CheckpointRecoveryFactory;
 import org.apache.flink.runtime.checkpoint.CheckpointsCleaner;
 import org.apache.flink.runtime.checkpoint.CompletedCheckpoint;
 import org.apache.flink.runtime.checkpoint.PerJobCheckpointRecoveryFactory;
-import org.apache.flink.runtime.checkpoint.StandaloneCheckpointIDCounter;
 import org.apache.flink.runtime.checkpoint.StandaloneCompletedCheckpointStore;
 import org.apache.flink.runtime.highavailability.HighAvailabilityServices;
 import org.apache.flink.runtime.highavailability.HighAvailabilityServicesFactory;
-import org.apache.flink.runtime.highavailability.nonha.embedded.EmbeddedHaServices;
+import org.apache.flink.runtime.highavailability.nonha.embedded.EmbeddedHaServicesWithLeadershipControl;
 import org.apache.flink.runtime.jobgraph.JobGraph;
 import org.apache.flink.runtime.state.FunctionInitializationContext;
 import org.apache.flink.runtime.state.FunctionSnapshotContext;
@@ -440,20 +439,6 @@ public class RegionFailoverITCase extends TestLogger {
         private static final long serialVersionUID = 1L;
     }
 
-    private static class TestingHaServices extends EmbeddedHaServices {
-        private final CheckpointRecoveryFactory checkpointRecoveryFactory;
-
-        TestingHaServices(CheckpointRecoveryFactory checkpointRecoveryFactory, Executor executor) {
-            super(executor);
-            this.checkpointRecoveryFactory = checkpointRecoveryFactory;
-        }
-
-        @Override
-        public CheckpointRecoveryFactory getCheckpointRecoveryFactory() {
-            return checkpointRecoveryFactory;
-        }
-    }
-
     /**
      * An extension of {@link StandaloneCompletedCheckpointStore} which would record information of
      * last completed checkpoint id and the number of completed checkpoints.
@@ -486,11 +471,10 @@ public class RegionFailoverITCase extends TestLogger {
         @Override
         public HighAvailabilityServices createHAServices(
                 Configuration configuration, Executor executor) {
-            return new TestingHaServices(
-                    PerJobCheckpointRecoveryFactory.useSameServicesForAllJobs(
-                            new TestingCompletedCheckpointStore(),
-                            new StandaloneCheckpointIDCounter()),
-                    executor);
+            final CheckpointRecoveryFactory checkpointRecoveryFactory =
+                    PerJobCheckpointRecoveryFactory.withoutCheckpointStoreRecovery(
+                            maxCheckpoints -> new TestingCompletedCheckpointStore());
+            return new EmbeddedHaServicesWithLeadershipControl(executor, checkpointRecoveryFactory);
         }
     }
 }

--- a/flink-tests/src/test/java/org/apache/flink/test/runtime/leaderelection/ZooKeeperLeaderElectionITCase.java
+++ b/flink-tests/src/test/java/org/apache/flink/test/runtime/leaderelection/ZooKeeperLeaderElectionITCase.java
@@ -98,7 +98,7 @@ public class ZooKeeperLeaderElectionITCase extends TestLogger {
         configuration.setLong(ClusterOptions.REFUSED_REGISTRATION_DELAY, 50L);
 
         final TestingMiniClusterConfiguration miniClusterConfiguration =
-                new TestingMiniClusterConfiguration.Builder()
+                TestingMiniClusterConfiguration.newBuilder()
                         .setConfiguration(configuration)
                         .setNumberDispatcherResourceManagerComponents(numDispatchers)
                         .setNumTaskManagers(numTMs)


### PR DESCRIPTION
## What is the purpose of the change

Decoupling recovery of CompletedCheckpointStore from execution graph. We only need to recover it once, when JobMasterRunner gains leadership.
## Brief change log

- Removing `CompletedCheckpointStore#recover()` method
- Replacing `CheckpointRecoveryFactory#createCompletedCheckpointStore` with `CheckpointRecoveryFactory#createRecoveredCompletedCheckpointStore`
- 
- ## Verifying this change

* All existing tests should be passing.

## Does this pull request potentially affect one of the following parts:

  - Anything that affects deployment or recovery: JobManager (and its components), Checkpointing, Kubernetes/Yarn, ZooKeeper: (yes)

## Documentation
  - It's a breaking change, so we should mention this in the release notes.