### PR TITLE
[FLINK-23492][runtime] harden testCachedStatsCleanedAfterCleanupInterval

### DIFF
--- a/flink-runtime/src/main/java/org/apache/flink/runtime/webmonitor/threadinfo/JobVertexThreadInfoTracker.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/webmonitor/threadinfo/JobVertexThreadInfoTracker.java
@@ -35,7 +35,6 @@ import org.apache.flink.runtime.webmonitor.stats.JobVertexStatsTracker;
 import org.apache.flink.runtime.webmonitor.stats.Statistics;
 
 import org.apache.flink.shaded.guava30.com.google.common.cache.Cache;
-import org.apache.flink.shaded.guava30.com.google.common.cache.CacheBuilder;
 
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
@@ -113,7 +112,8 @@ public class JobVertexThreadInfoTracker<T extends Statistics> implements JobVert
             Duration statsRefreshInterval,
             Duration delayBetweenSamples,
             int maxStackTraceDepth,
-            Time rpcTimeout) {
+            Time rpcTimeout,
+            Cache<Key, T> vertexStatsCache) {
 
         this.coordinator = checkNotNull(coordinator, "Thread info samples coordinator");
         this.resourceManagerGatewayRetriever =
@@ -138,11 +138,7 @@ public class JobVertexThreadInfoTracker<T extends Statistics> implements JobVert
         checkArgument(maxStackTraceDepth > 0, "Max stack trace depth must be greater than 0");
         this.maxThreadInfoDepth = maxStackTraceDepth;
 
-        this.vertexStatsCache =
-                CacheBuilder.newBuilder()
-                        .concurrencyLevel(1)
-                        .expireAfterAccess(cleanUpInterval.toMillis(), TimeUnit.MILLISECONDS)
-                        .build();
+        this.vertexStatsCache = checkNotNull(vertexStatsCache, "Vertex stats cache");
 
         executor.scheduleWithFixedDelay(
                 this::cleanUpVertexStatsCache,
@@ -268,7 +264,7 @@ public class JobVertexThreadInfoTracker<T extends Statistics> implements JobVert
         return new Key(jobId, vertex.getJobVertexId());
     }
 
-    private static class Key {
+    static class Key {
         private final JobID jobId;
         private final JobVertexID jobVertexId;
 

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/webmonitor/threadinfo/JobVertexThreadInfoTracker.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/webmonitor/threadinfo/JobVertexThreadInfoTracker.java
@@ -311,8 +311,8 @@ public class JobVertexThreadInfoTracker<T extends Statistics> implements JobVert
                         return;
                     }
                     if (threadInfoStats != null) {
-                        resultAvailableFuture.complete(null);
                         vertexStatsCache.put(key, createStatsFn.apply(threadInfoStats));
+                        resultAvailableFuture.complete(null);
                     } else {
                         LOG.debug(
                                 "Failed to gather a thread info sample for {}",

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/webmonitor/threadinfo/JobVertexThreadInfoTrackerBuilder.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/webmonitor/threadinfo/JobVertexThreadInfoTrackerBuilder.java
@@ -17,6 +17,7 @@
 
 package org.apache.flink.runtime.webmonitor.threadinfo;
 
+import org.apache.flink.annotation.VisibleForTesting;
 import org.apache.flink.api.common.time.Time;
 import org.apache.flink.runtime.resourcemanager.ResourceManagerGateway;
 import org.apache.flink.runtime.webmonitor.retriever.GatewayRetriever;
@@ -136,14 +137,14 @@ public class JobVertexThreadInfoTrackerBuilder<T extends Statistics> {
     }
 
     /**
-     * Sets {@code vertexStatsCache}.
+     * Sets {@code vertexStatsCache}. This is currently only used for testing.
      *
      * @param vertexStatsCache The Cache instance to use for caching statistics. Will use the
      *     default defined in {@link JobVertexThreadInfoTrackerBuilder#defaultCache()} if not set.
      * @return Builder.
      */
-    public JobVertexThreadInfoTrackerBuilder<T> setVertexStatsCache(
-            Cache<Key, T> vertexStatsCache) {
+    @VisibleForTesting
+    JobVertexThreadInfoTrackerBuilder<T> setVertexStatsCache(Cache<Key, T> vertexStatsCache) {
         this.vertexStatsCache = vertexStatsCache;
         return this;
     }

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/webmonitor/threadinfo/JobVertexThreadInfoTrackerBuilder.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/webmonitor/threadinfo/JobVertexThreadInfoTrackerBuilder.java
@@ -21,10 +21,17 @@ import org.apache.flink.api.common.time.Time;
 import org.apache.flink.runtime.resourcemanager.ResourceManagerGateway;
 import org.apache.flink.runtime.webmonitor.retriever.GatewayRetriever;
 import org.apache.flink.runtime.webmonitor.stats.Statistics;
+import org.apache.flink.runtime.webmonitor.threadinfo.JobVertexThreadInfoTracker.Key;
+
+import org.apache.flink.shaded.guava30.com.google.common.cache.Cache;
+import org.apache.flink.shaded.guava30.com.google.common.cache.CacheBuilder;
 
 import java.time.Duration;
 import java.util.concurrent.ScheduledExecutorService;
+import java.util.concurrent.TimeUnit;
 import java.util.function.Function;
+
+import static org.apache.flink.util.Preconditions.checkArgument;
 
 /**
  * Builder for {@link JobVertexThreadInfoTracker}.
@@ -44,6 +51,7 @@ public class JobVertexThreadInfoTrackerBuilder<T extends Statistics> {
     private Duration statsRefreshInterval;
     private Duration delayBetweenSamples;
     private int maxThreadInfoDepth;
+    private Cache<Key, T> vertexStatsCache;
 
     JobVertexThreadInfoTrackerBuilder(
             GatewayRetriever<ResourceManagerGateway> resourceManagerGatewayRetriever,
@@ -128,11 +136,27 @@ public class JobVertexThreadInfoTrackerBuilder<T extends Statistics> {
     }
 
     /**
+     * Sets {@code vertexStatsCache}.
+     *
+     * @param vertexStatsCache The Cache instance to use for caching statistics. Will use the
+     *     default defined in {@link JobVertexThreadInfoTrackerBuilder#defaultCache()} if not set.
+     * @return Builder.
+     */
+    public JobVertexThreadInfoTrackerBuilder<T> setVertexStatsCache(
+            Cache<Key, T> vertexStatsCache) {
+        this.vertexStatsCache = vertexStatsCache;
+        return this;
+    }
+
+    /**
      * Constructs a new {@link JobVertexThreadInfoTracker}.
      *
      * @return a new {@link JobVertexThreadInfoTracker} instance.
      */
     public JobVertexThreadInfoTracker<T> build() {
+        if (vertexStatsCache == null) {
+            vertexStatsCache = defaultCache();
+        }
         return new JobVertexThreadInfoTracker<>(
                 coordinator,
                 resourceManagerGatewayRetriever,
@@ -143,7 +167,16 @@ public class JobVertexThreadInfoTrackerBuilder<T extends Statistics> {
                 statsRefreshInterval,
                 delayBetweenSamples,
                 maxThreadInfoDepth,
-                restTimeout);
+                restTimeout,
+                vertexStatsCache);
+    }
+
+    private Cache<Key, T> defaultCache() {
+        checkArgument(cleanUpInterval.toMillis() > 0, "Clean up interval must be greater than 0");
+        return CacheBuilder.newBuilder()
+                .concurrencyLevel(1)
+                .expireAfterAccess(cleanUpInterval.toMillis(), TimeUnit.MILLISECONDS)
+                .build();
     }
 
     /**

--- a/flink-runtime/src/test/java/org/apache/flink/runtime/webmonitor/threadinfo/JobVertexThreadInfoTrackerTest.java
+++ b/flink-runtime/src/test/java/org/apache/flink/runtime/webmonitor/threadinfo/JobVertexThreadInfoTrackerTest.java
@@ -206,7 +206,7 @@ public class JobVertexThreadInfoTrackerTest extends TestLogger {
         // no stats yet, but the request triggers async collection of stats
         assertFalse(tracker.getVertexStats(JOB_ID, EXECUTION_JOB_VERTEX).isPresent());
         // wait until one eviction was registered, with generous buffer
-        assertTrue(cacheExpired.await(1000, TimeUnit.MILLISECONDS));
+        assertTrue(cacheExpired.await());
 
         assertFalse(tracker.getVertexStats(JOB_ID, EXECUTION_JOB_VERTEX).isPresent());
     }

--- a/flink-runtime/src/test/java/org/apache/flink/runtime/webmonitor/threadinfo/JobVertexThreadInfoTrackerTest.java
+++ b/flink-runtime/src/test/java/org/apache/flink/runtime/webmonitor/threadinfo/JobVertexThreadInfoTrackerTest.java
@@ -179,7 +179,7 @@ public class JobVertexThreadInfoTrackerTest extends TestLogger {
                 initialThreadInfoStats, tracker.getVertexStats(JOB_ID, EXECUTION_JOB_VERTEX));
 
         // wait until the entry is refreshed, with generous buffer
-        assertTrue(cacheRefreshed.await(500, TimeUnit.MILLISECONDS));
+        assertTrue(cacheRefreshed.await());
 
         // verify that we get the second result on the next request
         Optional<JobVertexThreadInfoStats> result =

--- a/flink-runtime/src/test/java/org/apache/flink/runtime/webmonitor/threadinfo/JobVertexThreadInfoTrackerTest.java
+++ b/flink-runtime/src/test/java/org/apache/flink/runtime/webmonitor/threadinfo/JobVertexThreadInfoTrackerTest.java
@@ -178,8 +178,8 @@ public class JobVertexThreadInfoTrackerTest extends TestLogger {
         assertExpectedEqualsReceived(
                 initialThreadInfoStats, tracker.getVertexStats(JOB_ID, EXECUTION_JOB_VERTEX));
 
-        // wait until the entry is refreshed, with generous buffer
-        assertTrue(cacheRefreshed.await());
+        // wait until the entry is refreshed
+        cacheRefreshed.await();
 
         // verify that we get the second result on the next request
         Optional<JobVertexThreadInfoStats> result =
@@ -205,8 +205,8 @@ public class JobVertexThreadInfoTrackerTest extends TestLogger {
 
         // no stats yet, but the request triggers async collection of stats
         assertFalse(tracker.getVertexStats(JOB_ID, EXECUTION_JOB_VERTEX).isPresent());
-        // wait until one eviction was registered, with generous buffer
-        assertTrue(cacheExpired.await());
+        // wait until one eviction was registered
+        cacheExpired.await();
 
         assertFalse(tracker.getVertexStats(JOB_ID, EXECUTION_JOB_VERTEX).isPresent());
     }

--- a/flink-runtime/src/test/java/org/apache/flink/runtime/webmonitor/threadinfo/JobVertexThreadInfoTrackerTest.java
+++ b/flink-runtime/src/test/java/org/apache/flink/runtime/webmonitor/threadinfo/JobVertexThreadInfoTrackerTest.java
@@ -143,7 +143,7 @@ public class JobVertexThreadInfoTrackerTest extends TestLogger {
     }
 
     /** Tests that cached result is NOT reused after refresh interval. */
-    @Test(timeout = 1000)
+    @Test
     public void testCachedStatsUpdatedAfterRefreshInterval() throws Exception {
         final Duration threadInfoStatsRefreshInterval2 = Duration.ofMillis(1);
 
@@ -178,8 +178,8 @@ public class JobVertexThreadInfoTrackerTest extends TestLogger {
         assertExpectedEqualsReceived(
                 threadInfoStats, tracker.getVertexStats(JOB_ID, EXECUTION_JOB_VERTEX));
 
-        // wait until the entry is refreshed
-        latch.await();
+        // wait until the entry is refreshed, with generous buffer
+        assertTrue(latch.await(500, TimeUnit.MILLISECONDS));
 
         // verify that we get the second result on the next request
         Optional<JobVertexThreadInfoStats> result =
@@ -188,7 +188,7 @@ public class JobVertexThreadInfoTrackerTest extends TestLogger {
     }
 
     /** Tests that cached results are removed within the cleanup interval. */
-    @Test(timeout = 1000)
+    @Test
     public void testCachedStatsCleanedAfterCleanupInterval() throws Exception {
         final Duration cleanUpInterval2 = Duration.ofMillis(1);
 
@@ -205,8 +205,8 @@ public class JobVertexThreadInfoTrackerTest extends TestLogger {
 
         // no stats yet, but the request triggers async collection of stats
         assertFalse(tracker.getVertexStats(JOB_ID, EXECUTION_JOB_VERTEX).isPresent());
-        // wait until one eviction was registered
-        latch.await();
+        // wait until one eviction was registered, with generous buffer
+        assertTrue(latch.await(1000, TimeUnit.MILLISECONDS));
 
         assertFalse(tracker.getVertexStats(JOB_ID, EXECUTION_JOB_VERTEX).isPresent());
     }

--- a/flink-runtime/src/test/java/org/apache/flink/runtime/webmonitor/threadinfo/JobVertexThreadInfoTrackerTest.java
+++ b/flink-runtime/src/test/java/org/apache/flink/runtime/webmonitor/threadinfo/JobVertexThreadInfoTrackerTest.java
@@ -139,7 +139,7 @@ public class JobVertexThreadInfoTrackerTest extends TestLogger {
     /** Tests that cached result is NOT reused after refresh interval. */
     @Test
     public void testCachedStatsUpdatedAfterRefreshInterval() throws Exception {
-        final Duration threadInfoStatsRefreshInterval2 = Duration.ofMillis(10);
+        final Duration threadInfoStatsRefreshInterval2 = Duration.ofMillis(1);
         final long waitingTime = threadInfoStatsRefreshInterval2.toMillis() + 10;
 
         final int requestId2 = 1;

--- a/flink-runtime/src/test/java/org/apache/flink/runtime/webmonitor/threadinfo/JobVertexThreadInfoTrackerTest.java
+++ b/flink-runtime/src/test/java/org/apache/flink/runtime/webmonitor/threadinfo/JobVertexThreadInfoTrackerTest.java
@@ -34,6 +34,9 @@ import org.apache.flink.runtime.testutils.TestingUtils;
 import org.apache.flink.runtime.util.JvmUtils;
 import org.apache.flink.util.TestLogger;
 
+import org.apache.flink.shaded.guava30.com.google.common.cache.Cache;
+import org.apache.flink.shaded.guava30.com.google.common.cache.CacheBuilder;
+
 import org.junit.AfterClass;
 import org.junit.BeforeClass;
 import org.junit.Rule;
@@ -124,10 +127,7 @@ public class JobVertexThreadInfoTrackerTest extends TestLogger {
 
         final JobVertexThreadInfoTracker<JobVertexThreadInfoStats> tracker =
                 createThreadInfoTracker(
-                        CLEAN_UP_INTERVAL,
-                        STATS_REFRESH_INTERVAL,
-                        threadInfoStatsDefaultSample,
-                        threadInfoStats2);
+                        STATS_REFRESH_INTERVAL, threadInfoStatsDefaultSample, threadInfoStats2);
         // stores threadInfoStatsDefaultSample in cache
         doInitialRequestAndVerifyResult(tracker);
         Optional<JobVertexThreadInfoStats> result =
@@ -149,7 +149,6 @@ public class JobVertexThreadInfoTrackerTest extends TestLogger {
 
         final JobVertexThreadInfoTracker<JobVertexThreadInfoStats> tracker =
                 createThreadInfoTracker(
-                        CLEAN_UP_INTERVAL,
                         threadInfoStatsRefreshInterval2,
                         threadInfoStatsDefaultSample,
                         threadInfoStats2);
@@ -169,20 +168,32 @@ public class JobVertexThreadInfoTrackerTest extends TestLogger {
     /** Tests that cached results are removed within the cleanup interval. */
     @Test
     public void testCachedStatsCleanedAfterCleanupInterval() throws Exception {
-        final Duration cleanUpInterval2 = Duration.ofMillis(10);
+        final Duration cleanUpInterval2 = Duration.ofMillis(1);
         final long waitingTime = cleanUpInterval2.toMillis() + 10;
 
+        // use cache recording stats so we can check later that it evicted the entry
+        Cache<JobVertexThreadInfoTracker.Key, JobVertexThreadInfoStats> vertexStatsCache =
+                CacheBuilder.newBuilder()
+                        .concurrencyLevel(1)
+                        .expireAfterAccess(cleanUpInterval2.toMillis(), TimeUnit.MILLISECONDS)
+                        .recordStats()
+                        .build();
         final JobVertexThreadInfoTracker<JobVertexThreadInfoStats> tracker =
                 createThreadInfoTracker(
-                        cleanUpInterval2, STATS_REFRESH_INTERVAL, threadInfoStatsDefaultSample);
-        doInitialRequestAndVerifyResult(tracker);
+                        cleanUpInterval2,
+                        STATS_REFRESH_INTERVAL,
+                        vertexStatsCache,
+                        threadInfoStatsDefaultSample);
 
-        // wait until we are ready to cleanup
+        // no stats yet, but the request triggers async collection of stats
+        assertFalse(tracker.getVertexStats(JOB_ID, EXECUTION_JOB_VERTEX).isPresent());
+        // wait until the result is available
+        tracker.getResultAvailableFuture().get();
+        // wait for the cleanup time plus a little buffer
         Thread.sleep(waitingTime);
 
-        // cleanup the cached thread info stats
-        tracker.cleanUpVertexStatsCache();
         assertFalse(tracker.getVertexStats(JOB_ID, EXECUTION_JOB_VERTEX).isPresent());
+        assertEquals(1, vertexStatsCache.stats().evictionCount());
     }
 
     /** Tests that cached results are NOT removed within the cleanup interval. */
@@ -218,6 +229,7 @@ public class JobVertexThreadInfoTrackerTest extends TestLogger {
     private void doInitialRequestAndVerifyResult(
             JobVertexThreadInfoTracker<JobVertexThreadInfoStats> tracker)
             throws InterruptedException, ExecutionException {
+        // no stats yet, but the request triggers async collection of stats
         assertFalse(tracker.getVertexStats(JOB_ID, EXECUTION_JOB_VERTEX).isPresent());
         // block until the async call completes and the first result is available
         tracker.getResultAvailableFuture().get();
@@ -242,15 +254,19 @@ public class JobVertexThreadInfoTrackerTest extends TestLogger {
     }
 
     private JobVertexThreadInfoTracker<JobVertexThreadInfoStats> createThreadInfoTracker() {
-        return createThreadInfoTracker(
-                CLEAN_UP_INTERVAL, STATS_REFRESH_INTERVAL, threadInfoStatsDefaultSample);
+        return createThreadInfoTracker(STATS_REFRESH_INTERVAL, threadInfoStatsDefaultSample);
+    }
+
+    private JobVertexThreadInfoTracker<JobVertexThreadInfoStats> createThreadInfoTracker(
+            Duration statsRefreshInterval, JobVertexThreadInfoStats... stats) {
+        return createThreadInfoTracker(CLEAN_UP_INTERVAL, statsRefreshInterval, null, stats);
     }
 
     private JobVertexThreadInfoTracker<JobVertexThreadInfoStats> createThreadInfoTracker(
             Duration cleanUpInterval,
-            Duration threadInfoStatsRefreshInterval,
+            Duration statsRefreshInterval,
+            Cache<JobVertexThreadInfoTracker.Key, JobVertexThreadInfoStats> vertexStatsCache,
             JobVertexThreadInfoStats... stats) {
-
         final ThreadInfoRequestCoordinator coordinator =
                 new TestingThreadInfoRequestCoordinator(Runnable::run, REQUEST_TIMEOUT, stats);
 
@@ -262,9 +278,10 @@ public class JobVertexThreadInfoTrackerTest extends TestLogger {
                 .setCoordinator(coordinator)
                 .setCleanUpInterval(cleanUpInterval)
                 .setNumSamples(NUMBER_OF_SAMPLES)
-                .setStatsRefreshInterval(threadInfoStatsRefreshInterval)
+                .setStatsRefreshInterval(statsRefreshInterval)
                 .setDelayBetweenSamples(DELAY_BETWEEN_SAMPLES)
                 .setMaxThreadInfoDepth(MAX_STACK_TRACE_DEPTH)
+                .setVertexStatsCache(vertexStatsCache)
                 .build();
     }
 


### PR DESCRIPTION
## What is the purpose of the change

This pull request changes JobVertexThreadInfoTrackerTest#testCachedStatsCleanedAfterCleanupInterval so that unfortunate timings no longer lead to potential failures.
Before, if the provided JobVertexThreadInfoStats object was evicted from cache before we could fetch it, the test would fail. Now, we do not fetch it at all, but simply verify that one item was evicted from cache. 

## Brief change log
- *JobVertexThreadInfoTracker can be instantiated with a provided Cache instance. If none is provided to JobVertexThreadInfoTrackerBuilder, it will use an identical one to that used so far*
- *testCachedStatsCleanedAfterCleanupInterval uses this to configure the cache to track statistics and verify the eviction*
- *unnecessary wait times in testCachedStatsCleanedAfterCleanupInterval and testCachedStatsUpdatedAfterRefreshInterval are reduced

## Verifying this change

*(Please pick either of the following options)*

This change is already covered by existing tests, such as JobVertexThreadInfoTrackerTest.
The instability was no longer observable locally.

## Does this pull request potentially affect one of the following parts:

  - Dependencies (does it add or upgrade a dependency): no
  - The public API, i.e., is any changed class annotated with `@Public(Evolving)`: no
  - The serializers: no
  - The runtime per-record code paths (performance sensitive): no
  - Anything that affects deployment or recovery: JobManager (and its components), Checkpointing, Kubernetes/Yarn, ZooKeeper: no
  - The S3 file system connector: no

## Documentation

  - Does this pull request introduce a new feature? no
  - If yes, how is the feature documented? not applicable
