### PR TITLE
[FLINK-23512][runtime][checkpoint] Check for illegal modifications of JobGraph with partially finished operators

### DIFF
--- a/flink-runtime/src/main/java/org/apache/flink/runtime/checkpoint/CheckpointCoordinator.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/checkpoint/CheckpointCoordinator.java
@@ -21,14 +21,12 @@ package org.apache.flink.runtime.checkpoint;
 import org.apache.flink.annotation.VisibleForTesting;
 import org.apache.flink.api.common.JobID;
 import org.apache.flink.api.java.tuple.Tuple2;
-import org.apache.flink.runtime.OperatorIDPair;
 import org.apache.flink.runtime.checkpoint.CheckpointType.PostCheckpointAction;
 import org.apache.flink.runtime.checkpoint.hooks.MasterHooks;
 import org.apache.flink.runtime.executiongraph.Execution;
 import org.apache.flink.runtime.executiongraph.ExecutionAttemptID;
 import org.apache.flink.runtime.executiongraph.ExecutionJobVertex;
 import org.apache.flink.runtime.executiongraph.ExecutionVertex;
-import org.apache.flink.runtime.executiongraph.IntermediateResult;
 import org.apache.flink.runtime.executiongraph.JobStatusListener;
 import org.apache.flink.runtime.jobgraph.JobVertexID;
 import org.apache.flink.runtime.jobgraph.OperatorID;
@@ -84,7 +82,6 @@ import java.util.concurrent.ThreadLocalRandom;
 import java.util.concurrent.TimeUnit;
 import java.util.concurrent.atomic.AtomicInteger;
 import java.util.function.Predicate;
-import java.util.stream.Collectors;
 import java.util.stream.Stream;
 
 import static java.util.stream.Collectors.toMap;
@@ -1569,7 +1566,9 @@ public class CheckpointCoordinator {
             // re-assign the task states
             final Map<OperatorID, OperatorState> operatorStates = extractOperatorStates(latest);
 
-            validateFinishedOperators(tasks, operatorStates);
+            VertexFinishedStateChecker vertexFinishedStateChecker =
+                    new VertexFinishedStateChecker(tasks, operatorStates);
+            vertexFinishedStateChecker.validateOperatorsFinishedState();
 
             StateAssignmentOperation stateAssignmentOperation =
                     new StateAssignmentOperation(
@@ -1608,83 +1607,6 @@ public class CheckpointCoordinator {
             }
 
             return OptionalLong.of(latest.getCheckpointID());
-        }
-    }
-
-    private static class VerticesFinishedCache {
-
-        private final Map<JobVertexID, Boolean> finishedCache = new HashMap<>();
-        private final Map<OperatorID, OperatorState> operatorStates;
-
-        private VerticesFinishedCache(Map<OperatorID, OperatorState> operatorStates) {
-            this.operatorStates = operatorStates;
-        }
-
-        public boolean getOrUpdate(ExecutionJobVertex vertex) {
-            return finishedCache.computeIfAbsent(
-                    vertex.getJobVertexId(),
-                    ignored -> calculateIfFinished(vertex, operatorStates));
-        }
-
-        private boolean calculateIfFinished(
-                ExecutionJobVertex vertex, Map<OperatorID, OperatorState> operatorStates) {
-            List<Boolean> operatorFinishedStates =
-                    vertex.getOperatorIDs().stream()
-                            .map(idPair -> checkOperatorFinished(operatorStates, idPair))
-                            .collect(Collectors.toList());
-
-            boolean anyFinished = operatorFinishedStates.stream().anyMatch(f -> f);
-            if (!anyFinished) {
-                return false;
-            } else {
-                boolean allFinished = operatorFinishedStates.stream().allMatch(f -> f);
-                if (!allFinished) {
-                    throw new FlinkRuntimeException(
-                            "Can not restore vertex "
-                                    + vertex.getName()
-                                    + "("
-                                    + vertex.getJobVertexId()
-                                    + ")"
-                                    + " which contain both finished and unfinished operators");
-                }
-                return true;
-            }
-        }
-
-        private boolean checkOperatorFinished(
-                Map<OperatorID, OperatorState> operatorStates, OperatorIDPair idPair) {
-            OperatorID operatorId =
-                    idPair.getUserDefinedOperatorID().orElse(idPair.getGeneratedOperatorID());
-            return Optional.ofNullable(operatorStates.get(operatorId))
-                    .map(OperatorState::isFullyFinished)
-                    .orElse(false);
-        }
-    }
-
-    private void validateFinishedOperators(
-            Set<ExecutionJobVertex> tasks, Map<OperatorID, OperatorState> operatorStates) {
-
-        VerticesFinishedCache verticesFinishedCache = new VerticesFinishedCache(operatorStates);
-        for (ExecutionJobVertex task : tasks) {
-            boolean vertexFinished = verticesFinishedCache.getOrUpdate(task);
-
-            if (vertexFinished) {
-                boolean allPredecessorsFinished =
-                        task.getInputs().stream()
-                                .map(IntermediateResult::getProducer)
-                                .allMatch(verticesFinishedCache::getOrUpdate);
-
-                if (!allPredecessorsFinished) {
-                    throw new FlinkRuntimeException(
-                            "Illegal JobGraph modification. Cannot run a program with finished"
-                                    + " vertices predeceased with running ones. Task vertex "
-                                    + task.getName()
-                                    + "("
-                                    + task.getJobVertexId()
-                                    + ")"
-                                    + " has a running predecessor");
-                }
-            }
         }
     }
 

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/checkpoint/CheckpointCoordinator.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/checkpoint/CheckpointCoordinator.java
@@ -1368,43 +1368,6 @@ public class CheckpointCoordinator {
     // --------------------------------------------------------------------------------------------
 
     /**
-     * Restores the latest checkpointed state.
-     *
-     * @param tasks Map of job vertices to restore. State for these vertices is restored via {@link
-     *     Execution#setInitialState(JobManagerTaskRestore)}.
-     * @param errorIfNoCheckpoint Fail if no completed checkpoint is available to restore from.
-     * @param allowNonRestoredState Allow checkpoint state that cannot be mapped to any job vertex
-     *     in tasks.
-     * @return <code>true</code> if state was restored, <code>false</code> otherwise.
-     * @throws IllegalStateException If the CheckpointCoordinator is shut down.
-     * @throws IllegalStateException If no completed checkpoint is available and the <code>
-     *     failIfNoCheckpoint</code> flag has been set.
-     * @throws IllegalStateException If the checkpoint contains state that cannot be mapped to any
-     *     job vertex in <code>tasks</code> and the <code>allowNonRestoredState</code> flag has not
-     *     been set.
-     * @throws IllegalStateException If the max parallelism changed for an operator that restores
-     *     state from this checkpoint.
-     * @throws IllegalStateException If the parallelism changed for an operator that restores
-     *     <i>non-partitioned</i> state from this checkpoint.
-     */
-    @Deprecated
-    public boolean restoreLatestCheckpointedState(
-            Map<JobVertexID, ExecutionJobVertex> tasks,
-            boolean errorIfNoCheckpoint,
-            boolean allowNonRestoredState)
-            throws Exception {
-
-        final OptionalLong restoredCheckpointId =
-                restoreLatestCheckpointedStateInternal(
-                        new HashSet<>(tasks.values()),
-                        OperatorCoordinatorRestoreBehavior.RESTORE_OR_RESET,
-                        errorIfNoCheckpoint,
-                        allowNonRestoredState);
-
-        return restoredCheckpointId.isPresent();
-    }
-
-    /**
      * Restores the latest checkpointed state to a set of subtasks. This method represents a "local"
      * or "regional" failover and does restore states to coordinators. Note that a regional failover
      * might still include all tasks.

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/checkpoint/CheckpointPlan.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/checkpoint/CheckpointPlan.java
@@ -30,7 +30,7 @@ import java.util.List;
  * The plan of one checkpoint, indicating which tasks to trigger, waiting for acknowledge or commit
  * for one specific checkpoint.
  */
-public interface CheckpointPlan extends PendingCheckpointFinishedTaskStateProvider {
+public interface CheckpointPlan extends FinishedTaskStateProvider {
 
     /** Returns the tasks who need to be sent a message when a checkpoint is started. */
     List<Execution> getTasksToTrigger();

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/checkpoint/CheckpointPlan.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/checkpoint/CheckpointPlan.java
@@ -18,17 +18,19 @@
 
 package org.apache.flink.runtime.checkpoint;
 
+import org.apache.flink.annotation.VisibleForTesting;
 import org.apache.flink.runtime.executiongraph.Execution;
 import org.apache.flink.runtime.executiongraph.ExecutionJobVertex;
 import org.apache.flink.runtime.executiongraph.ExecutionVertex;
 
+import java.util.Collection;
 import java.util.List;
 
 /**
  * The plan of one checkpoint, indicating which tasks to trigger, waiting for acknowledge or commit
  * for one specific checkpoint.
  */
-public interface CheckpointPlan {
+public interface CheckpointPlan extends PendingCheckpointFinishedTaskStateProvider {
 
     /** Returns the tasks who need to be sent a message when a checkpoint is started. */
     List<Execution> getTasksToTrigger();
@@ -46,7 +48,8 @@ public interface CheckpointPlan {
     List<Execution> getFinishedTasks();
 
     /** Returns the job vertices whose tasks are all finished when taking the checkpoint. */
-    List<ExecutionJobVertex> getFullyFinishedJobVertex();
+    @VisibleForTesting
+    Collection<ExecutionJobVertex> getFullyFinishedJobVertex();
 
     /** Returns whether we support checkpoints after some tasks finished. */
     boolean mayHaveFinishedTasks();

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/checkpoint/CheckpointPlan.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/checkpoint/CheckpointPlan.java
@@ -24,72 +24,30 @@ import org.apache.flink.runtime.executiongraph.ExecutionVertex;
 
 import java.util.List;
 
-import static org.apache.flink.util.Preconditions.checkNotNull;
-
 /**
  * The plan of one checkpoint, indicating which tasks to trigger, waiting for acknowledge or commit
  * for one specific checkpoint.
  */
-class CheckpointPlan {
+public interface CheckpointPlan {
 
-    /** Tasks who need to be sent a message when a checkpoint is started. */
-    private final List<Execution> tasksToTrigger;
+    /** Returns the tasks who need to be sent a message when a checkpoint is started. */
+    List<Execution> getTasksToTrigger();
 
-    /** Tasks who need to acknowledge a checkpoint before it succeeds. */
-    private final List<Execution> tasksToWaitFor;
+    /** Returns tasks who need to acknowledge a checkpoint before it succeeds. */
+    List<Execution> getTasksToWaitFor();
 
     /**
-     * Tasks that are still running when taking the checkpoint, these need to be sent a message when
-     * the checkpoint is confirmed.
+     * Returns tasks that are still running when taking the checkpoint, these need to be sent a
+     * message when the checkpoint is confirmed.
      */
-    private final List<ExecutionVertex> tasksToCommitTo;
+    List<ExecutionVertex> getTasksToCommitTo();
 
-    /** Tasks that have already been finished when taking the checkpoint. */
-    private final List<Execution> finishedTasks;
+    /** Returns tasks that have already been finished when taking the checkpoint. */
+    List<Execution> getFinishedTasks();
 
-    /** The job vertices whose tasks are all finished when taking the checkpoint. */
-    private final List<ExecutionJobVertex> fullyFinishedJobVertex;
+    /** Returns the job vertices whose tasks are all finished when taking the checkpoint. */
+    List<ExecutionJobVertex> getFullyFinishedJobVertex();
 
-    /** Whether we support checkpoints after some tasks finished. */
-    private final boolean mayHaveFinishedTasks;
-
-    CheckpointPlan(
-            List<Execution> tasksToTrigger,
-            List<Execution> tasksToWaitFor,
-            List<ExecutionVertex> tasksToCommitTo,
-            List<Execution> finishedTasks,
-            List<ExecutionJobVertex> fullyFinishedJobVertex,
-            boolean mayHaveFinishedTasks) {
-
-        this.tasksToTrigger = checkNotNull(tasksToTrigger);
-        this.tasksToWaitFor = checkNotNull(tasksToWaitFor);
-        this.tasksToCommitTo = checkNotNull(tasksToCommitTo);
-        this.finishedTasks = checkNotNull(finishedTasks);
-        this.fullyFinishedJobVertex = checkNotNull(fullyFinishedJobVertex);
-        this.mayHaveFinishedTasks = mayHaveFinishedTasks;
-    }
-
-    List<Execution> getTasksToTrigger() {
-        return tasksToTrigger;
-    }
-
-    List<Execution> getTasksToWaitFor() {
-        return tasksToWaitFor;
-    }
-
-    List<ExecutionVertex> getTasksToCommitTo() {
-        return tasksToCommitTo;
-    }
-
-    public List<Execution> getFinishedTasks() {
-        return finishedTasks;
-    }
-
-    public List<ExecutionJobVertex> getFullyFinishedJobVertex() {
-        return fullyFinishedJobVertex;
-    }
-
-    public boolean isMayHaveFinishedTasks() {
-        return mayHaveFinishedTasks;
-    }
+    /** Returns whether we support checkpoints after some tasks finished. */
+    boolean mayHaveFinishedTasks();
 }

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/checkpoint/DefaultCheckpointPlan.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/checkpoint/DefaultCheckpointPlan.java
@@ -1,0 +1,89 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.flink.runtime.checkpoint;
+
+import org.apache.flink.runtime.executiongraph.Execution;
+import org.apache.flink.runtime.executiongraph.ExecutionJobVertex;
+import org.apache.flink.runtime.executiongraph.ExecutionVertex;
+
+import java.util.List;
+
+import static org.apache.flink.util.Preconditions.checkNotNull;
+
+/** The default implementation of he {@link CheckpointPlan}. */
+public class DefaultCheckpointPlan implements CheckpointPlan {
+
+    private final List<Execution> tasksToTrigger;
+
+    private final List<Execution> tasksToWaitFor;
+
+    private final List<ExecutionVertex> tasksToCommitTo;
+
+    private final List<Execution> finishedTasks;
+
+    private final List<ExecutionJobVertex> fullyFinishedJobVertex;
+
+    private final boolean mayHaveFinishedTasks;
+
+    DefaultCheckpointPlan(
+            List<Execution> tasksToTrigger,
+            List<Execution> tasksToWaitFor,
+            List<ExecutionVertex> tasksToCommitTo,
+            List<Execution> finishedTasks,
+            List<ExecutionJobVertex> fullyFinishedJobVertex,
+            boolean mayHaveFinishedTasks) {
+
+        this.tasksToTrigger = checkNotNull(tasksToTrigger);
+        this.tasksToWaitFor = checkNotNull(tasksToWaitFor);
+        this.tasksToCommitTo = checkNotNull(tasksToCommitTo);
+        this.finishedTasks = checkNotNull(finishedTasks);
+        this.fullyFinishedJobVertex = checkNotNull(fullyFinishedJobVertex);
+        this.mayHaveFinishedTasks = mayHaveFinishedTasks;
+    }
+
+    @Override
+    public List<Execution> getTasksToTrigger() {
+        return tasksToTrigger;
+    }
+
+    @Override
+    public List<Execution> getTasksToWaitFor() {
+        return tasksToWaitFor;
+    }
+
+    @Override
+    public List<ExecutionVertex> getTasksToCommitTo() {
+        return tasksToCommitTo;
+    }
+
+    @Override
+    public List<Execution> getFinishedTasks() {
+        return finishedTasks;
+    }
+
+    @Override
+    public List<ExecutionJobVertex> getFullyFinishedJobVertex() {
+        return fullyFinishedJobVertex;
+    }
+
+    @Override
+    public boolean mayHaveFinishedTasks() {
+        return mayHaveFinishedTasks;
+    }
+}

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/checkpoint/DefaultCheckpointPlanCalculator.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/checkpoint/DefaultCheckpointPlanCalculator.java
@@ -165,7 +165,7 @@ public class DefaultCheckpointPlanCalculator implements CheckpointPlanCalculator
 
         List<Execution> tasksToWaitFor = createTaskToWaitFor(allTasks);
 
-        return new CheckpointPlan(
+        return new DefaultCheckpointPlan(
                 Collections.unmodifiableList(executionsToTrigger),
                 Collections.unmodifiableList(tasksToWaitFor),
                 Collections.unmodifiableList(allTasks),
@@ -233,7 +233,7 @@ public class DefaultCheckpointPlanCalculator implements CheckpointPlanCalculator
             }
         }
 
-        return new CheckpointPlan(
+        return new DefaultCheckpointPlan(
                 Collections.unmodifiableList(tasksToTrigger),
                 Collections.unmodifiableList(tasksToWaitFor),
                 Collections.unmodifiableList(tasksToCommitTo),

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/checkpoint/FinishedOperatorSubtaskState.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/checkpoint/FinishedOperatorSubtaskState.java
@@ -1,0 +1,53 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.flink.runtime.checkpoint;
+
+/**
+ * A specialized {@link OperatorSubtaskState} representing the subtask is finished. It is also
+ * read-only and could not have actual states.
+ */
+public class FinishedOperatorSubtaskState extends OperatorSubtaskState {
+
+    public static final FinishedOperatorSubtaskState INSTANCE = new FinishedOperatorSubtaskState();
+
+    private static final long serialVersionUID = 1L;
+
+    /** Disallow creating new instances. */
+    private FinishedOperatorSubtaskState() {}
+
+    @Override
+    public boolean isFinished() {
+        return true;
+    }
+
+    @Override
+    public int hashCode() {
+        return super.hashCode();
+    }
+
+    @Override
+    public boolean equals(Object o) {
+        return o instanceof FinishedOperatorSubtaskState;
+    }
+
+    @Override
+    public String toString() {
+        return "FinishedOperatorSubtaskState{}";
+    }
+}

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/checkpoint/FinishedTaskStateProvider.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/checkpoint/FinishedTaskStateProvider.java
@@ -24,7 +24,7 @@ import org.apache.flink.runtime.jobgraph.OperatorID;
 import java.util.Map;
 
 /** Collects and fulfills the finished state for the subtasks or operators. */
-public interface PendingCheckpointFinishedTaskStateProvider {
+public interface FinishedTaskStateProvider {
 
     /** Reports the {@code task} is finished on restoring. */
     void reportTaskFinishedOnRestore(ExecutionVertex task);

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/checkpoint/OperatorSubtaskState.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/checkpoint/OperatorSubtaskState.java
@@ -224,6 +224,10 @@ public class OperatorSubtaskState implements CompositeStateHandle {
         return stateSize;
     }
 
+    public boolean isFinished() {
+        return false;
+    }
+
     // --------------------------------------------------------------------------------------------
 
     @Override

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/checkpoint/PendingCheckpoint.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/checkpoint/PendingCheckpoint.java
@@ -23,19 +23,15 @@ import org.apache.flink.runtime.OperatorIDPair;
 import org.apache.flink.runtime.checkpoint.metadata.CheckpointMetadata;
 import org.apache.flink.runtime.executiongraph.Execution;
 import org.apache.flink.runtime.executiongraph.ExecutionAttemptID;
-import org.apache.flink.runtime.executiongraph.ExecutionJobVertex;
 import org.apache.flink.runtime.executiongraph.ExecutionVertex;
-import org.apache.flink.runtime.jobgraph.JobVertexID;
 import org.apache.flink.runtime.jobgraph.OperatorID;
 import org.apache.flink.runtime.operators.coordination.OperatorInfo;
 import org.apache.flink.runtime.state.CheckpointMetadataOutputStream;
 import org.apache.flink.runtime.state.CheckpointStorageLocation;
 import org.apache.flink.runtime.state.CompletedCheckpointStorageLocation;
-import org.apache.flink.runtime.state.OperatorStateHandle;
 import org.apache.flink.runtime.state.StateUtil;
 import org.apache.flink.runtime.state.memory.ByteStreamStateHandle;
 import org.apache.flink.util.ExceptionUtils;
-import org.apache.flink.util.FlinkRuntimeException;
 import org.apache.flink.util.Preconditions;
 
 import org.slf4j.Logger;
@@ -49,15 +45,12 @@ import java.util.Collection;
 import java.util.Collections;
 import java.util.HashMap;
 import java.util.HashSet;
-import java.util.IdentityHashMap;
 import java.util.List;
 import java.util.Map;
-import java.util.Objects;
 import java.util.Set;
 import java.util.concurrent.CompletableFuture;
 import java.util.concurrent.Executor;
 import java.util.concurrent.ScheduledFuture;
-import java.util.stream.Stream;
 
 import static org.apache.flink.util.Preconditions.checkArgument;
 import static org.apache.flink.util.Preconditions.checkNotNull;
@@ -108,10 +101,6 @@ public class PendingCheckpoint implements Checkpoint {
 
     /** Set of acknowledged tasks. */
     private final Set<ExecutionAttemptID> acknowledgedTasks;
-
-    private final Set<JobVertexID> fullyFinishedOrFinishedOnRestoreVertex;
-
-    private final IdentityHashMap<ExecutionJobVertex, Integer> vertexOperatorsFinishedTasksCount;
 
     /** The checkpoint properties. */
     private final CheckpointProperties props;
@@ -173,16 +162,6 @@ public class PendingCheckpoint implements Checkpoint {
                         ? Collections.emptySet()
                         : new HashSet<>(operatorCoordinatorsToConfirm);
         this.acknowledgedTasks = new HashSet<>(checkpointPlan.getTasksToWaitFor().size());
-
-        this.fullyFinishedOrFinishedOnRestoreVertex = new HashSet<>();
-        checkpointPlan
-                .getFullyFinishedJobVertex()
-                .forEach(
-                        jobVertex ->
-                                fullyFinishedOrFinishedOnRestoreVertex.add(
-                                        jobVertex.getJobVertexId()));
-        this.vertexOperatorsFinishedTasksCount = new IdentityHashMap<>();
-
         this.onCompletionPromise = checkNotNull(onCompletionPromise);
     }
 
@@ -333,20 +312,7 @@ public class PendingCheckpoint implements Checkpoint {
 
             // make sure we fulfill the promise with an exception if something fails
             try {
-                if (checkpointPlan.mayHaveFinishedTasks()) {
-                    Map<JobVertexID, ExecutionJobVertex> partlyFinishedVertex = new HashMap<>();
-                    for (Execution task : checkpointPlan.getFinishedTasks()) {
-                        JobVertexID jobVertexId = task.getVertex().getJobvertexId();
-                        if (!fullyFinishedOrFinishedOnRestoreVertex.contains(jobVertexId)) {
-                            partlyFinishedVertex.put(jobVertexId, task.getVertex().getJobVertex());
-                        }
-                    }
-
-                    checkNoPartlyFinishedVertexUsedUnionListState(partlyFinishedVertex);
-                    checkNoPartlyOperatorsFinishedVertexUsedUnionListState(partlyFinishedVertex);
-                }
-
-                fulfillFullyFinishedOperatorStates();
+                checkpointPlan.fulfillFinishedTaskStatus(operatorStates);
 
                 // write out the metadata
                 final CheckpointMetadata savepoint =
@@ -402,105 +368,6 @@ public class PendingCheckpoint implements Checkpoint {
     }
 
     /**
-     * If a job vertex using {@code UnionListState} has part of tasks FINISHED where others are
-     * still in RUNNING state, the checkpoint would be aborted since it might cause incomplete
-     * {@code UnionListState}.
-     */
-    private void checkNoPartlyFinishedVertexUsedUnionListState(
-            Map<JobVertexID, ExecutionJobVertex> partlyFinishedVertex) {
-        for (ExecutionJobVertex vertex : partlyFinishedVertex.values()) {
-            if (hasUsedUnionListState(vertex)) {
-                throw new FlinkRuntimeException(
-                        String.format(
-                                "The vertex %s (id = %s) has used"
-                                        + " UnionListState, but part of its tasks are FINISHED.",
-                                vertex.getName(), vertex.getJobVertexId()));
-            }
-        }
-    }
-
-    /**
-     * If a job vertex using {@code UnionListState} has all the tasks in RUNNING state, but part of
-     * the tasks have reported that the operators are finished, the checkpoint would be aborted.
-     * This is to force the fast tasks wait for the slow tasks so that their final checkpoints would
-     * be the same one, otherwise if the fast tasks finished, the slow tasks would be blocked
-     * forever since all the following checkpoints would be aborted.
-     */
-    private void checkNoPartlyOperatorsFinishedVertexUsedUnionListState(
-            Map<JobVertexID, ExecutionJobVertex> partlyFinishedVertex) {
-        for (Map.Entry<ExecutionJobVertex, Integer> entry :
-                vertexOperatorsFinishedTasksCount.entrySet()) {
-            ExecutionJobVertex vertex = entry.getKey();
-
-            // If the vertex is partly finished, then it must not used UnionListState
-            // due to it passed the previous check.
-            if (partlyFinishedVertex.containsKey(vertex.getJobVertexId())) {
-                continue;
-            }
-
-            if (entry.getValue() != vertex.getParallelism() && hasUsedUnionListState(vertex)) {
-                throw new FlinkRuntimeException(
-                        String.format(
-                                "The vertex %s (id = %s) has used"
-                                        + " UnionListState, but part of its tasks has called operators' finish method.",
-                                vertex.getName(), vertex.getJobVertexId()));
-            }
-        }
-    }
-
-    private boolean hasUsedUnionListState(ExecutionJobVertex vertex) {
-        for (OperatorIDPair operatorIDPair : vertex.getOperatorIDs()) {
-            OperatorState operatorState =
-                    operatorStates.get(operatorIDPair.getGeneratedOperatorID());
-            if (operatorState == null) {
-                continue;
-            }
-
-            for (OperatorSubtaskState operatorSubtaskState : operatorState.getStates()) {
-                boolean hasUnionListState =
-                        Stream.concat(
-                                        operatorSubtaskState.getManagedOperatorState().stream(),
-                                        operatorSubtaskState.getRawOperatorState().stream())
-                                .filter(Objects::nonNull)
-                                .flatMap(
-                                        operatorStateHandle ->
-                                                operatorStateHandle.getStateNameToPartitionOffsets()
-                                                        .values().stream())
-                                .anyMatch(
-                                        stateMetaInfo ->
-                                                stateMetaInfo.getDistributionMode()
-                                                        == OperatorStateHandle.Mode.UNION);
-
-                if (hasUnionListState) {
-                    return true;
-                }
-            }
-        }
-
-        return false;
-    }
-
-    private void fulfillFullyFinishedOperatorStates() {
-        // Completes the operator state for the fully finished operators
-        for (ExecutionJobVertex jobVertex : checkpointPlan.getFullyFinishedJobVertex()) {
-            for (OperatorIDPair operatorID : jobVertex.getOperatorIDs()) {
-                OperatorState operatorState =
-                        operatorStates.get(operatorID.getGeneratedOperatorID());
-                checkState(
-                        operatorState == null,
-                        "There should be no states reported for fully finished operators");
-
-                operatorState =
-                        new FullyFinishedOperatorState(
-                                operatorID.getGeneratedOperatorID(),
-                                jobVertex.getParallelism(),
-                                jobVertex.getMaxParallelism());
-                operatorStates.put(operatorID.getGeneratedOperatorID(), operatorState);
-            }
-        }
-    }
-
-    /**
      * Acknowledges the task with the given execution attempt id and the given subtask state.
      *
      * @param executionAttemptId of the acknowledged task
@@ -531,15 +398,18 @@ public class PendingCheckpoint implements Checkpoint {
                 acknowledgedTasks.add(executionAttemptId);
             }
 
-            List<OperatorIDPair> operatorIDs = vertex.getJobVertex().getOperatorIDs();
             long ackTimestamp = System.currentTimeMillis();
-
-            for (OperatorIDPair operatorID : operatorIDs) {
-                if (operatorSubtaskStates != null && operatorSubtaskStates.isFinishedOnRestore()) {
-                    updateFinishedOnRestoreOperatorState(vertex, operatorID);
-                } else {
+            if (operatorSubtaskStates != null && operatorSubtaskStates.isFinishedOnRestore()) {
+                checkpointPlan.reportTaskFinishedOnRestore(vertex);
+            } else {
+                List<OperatorIDPair> operatorIDs = vertex.getJobVertex().getOperatorIDs();
+                for (OperatorIDPair operatorID : operatorIDs) {
                     updateNonFinishedOnRestoreOperatorState(
                             vertex, operatorSubtaskStates, operatorID);
+                }
+
+                if (operatorSubtaskStates != null && operatorSubtaskStates.isOperatorsFinished()) {
+                    checkpointPlan.reportTaskHasFinishedOperators(vertex);
                 }
             }
 
@@ -584,30 +454,6 @@ public class PendingCheckpoint implements Checkpoint {
         }
     }
 
-    private void updateFinishedOnRestoreOperatorState(
-            ExecutionVertex vertex, OperatorIDPair operatorID) {
-        OperatorState operatorState = operatorStates.get(operatorID.getGeneratedOperatorID());
-
-        if (operatorState == null) {
-            operatorState =
-                    new FullyFinishedOperatorState(
-                            operatorID.getGeneratedOperatorID(),
-                            vertex.getTotalNumberOfParallelSubtasks(),
-                            vertex.getMaxParallelism());
-            operatorStates.put(operatorID.getGeneratedOperatorID(), operatorState);
-        } else {
-            checkState(
-                    operatorState.isFullyFinished(),
-                    String.format(
-                            "The task %s(vertex id = %s) received finished snapshot, "
-                                    + "but the vertex has also received non-finished snapshots previously, "
-                                    + "which is impossible.",
-                            vertex.getTaskNameWithSubtaskIndex(), vertex.getJobvertexId()));
-        }
-
-        fullyFinishedOrFinishedOnRestoreVertex.add(vertex.getJobvertexId());
-    }
-
     private void updateNonFinishedOnRestoreOperatorState(
             ExecutionVertex vertex,
             TaskStateSnapshot operatorSubtaskStates,
@@ -630,11 +476,6 @@ public class PendingCheckpoint implements Checkpoint {
 
         if (operatorSubtaskState != null) {
             operatorState.putState(vertex.getParallelSubtaskIndex(), operatorSubtaskState);
-        }
-
-        if (operatorSubtaskStates != null && operatorSubtaskStates.isOperatorsFinished()) {
-            vertexOperatorsFinishedTasksCount.compute(
-                    vertex.getJobVertex(), (k, v) -> v == null ? 1 : v + 1);
         }
     }
 

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/checkpoint/PendingCheckpoint.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/checkpoint/PendingCheckpoint.java
@@ -333,7 +333,7 @@ public class PendingCheckpoint implements Checkpoint {
 
             // make sure we fulfill the promise with an exception if something fails
             try {
-                if (checkpointPlan.isMayHaveFinishedTasks()) {
+                if (checkpointPlan.mayHaveFinishedTasks()) {
                     Map<JobVertexID, ExecutionJobVertex> partlyFinishedVertex = new HashMap<>();
                     for (Execution task : checkpointPlan.getFinishedTasks()) {
                         JobVertexID jobVertexId = task.getVertex().getJobvertexId();

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/checkpoint/PendingCheckpointFinishedTaskStateProvider.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/checkpoint/PendingCheckpointFinishedTaskStateProvider.java
@@ -1,0 +1,37 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.flink.runtime.checkpoint;
+
+import org.apache.flink.runtime.executiongraph.ExecutionVertex;
+import org.apache.flink.runtime.jobgraph.OperatorID;
+
+import java.util.Map;
+
+/** Collects and fulfills the finished state for the subtasks or operators. */
+public interface PendingCheckpointFinishedTaskStateProvider {
+
+    /** Reports the {@code task} is finished on restoring. */
+    void reportTaskFinishedOnRestore(ExecutionVertex task);
+
+    /** Reports the {@code task} has finished all the operators. */
+    void reportTaskHasFinishedOperators(ExecutionVertex task);
+
+    /** Fulfills the state for the finished subtasks and operators to indicate they are finished. */
+    void fulfillFinishedTaskStatus(Map<OperatorID, OperatorState> operatorStates);
+}

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/checkpoint/StateAssignmentOperation.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/checkpoint/StateAssignmentOperation.java
@@ -142,7 +142,7 @@ public class StateAssignmentOperation {
 
         // actually assign the state
         for (TaskStateAssignment stateAssignment : vertexAssignments.values()) {
-            if (stateAssignment.hasNonFinishedState || stateAssignment.isFinished) {
+            if (stateAssignment.hasNonFinishedState || stateAssignment.isFullyFinished) {
                 assignTaskStateToExecutionJobVertices(stateAssignment);
             }
         }
@@ -216,7 +216,7 @@ public class StateAssignmentOperation {
             Execution currentExecutionAttempt =
                     executionJobVertex.getTaskVertices()[subTaskIndex].getCurrentExecutionAttempt();
 
-            if (assignment.isFinished) {
+            if (assignment.isFullyFinished) {
                 assignFinishedStateToTask(currentExecutionAttempt);
             } else {
                 assignNonFinishedStateToTask(

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/checkpoint/TaskStateAssignment.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/checkpoint/TaskStateAssignment.java
@@ -63,7 +63,7 @@ class TaskStateAssignment {
     final ExecutionJobVertex executionJobVertex;
     final Map<OperatorID, OperatorState> oldState;
     final boolean hasNonFinishedState;
-    final boolean isFinished;
+    final boolean isFullyFinished;
     final boolean hasInputState;
     final boolean hasOutputState;
     final int newParallelism;
@@ -99,8 +99,8 @@ class TaskStateAssignment {
         this.hasNonFinishedState =
                 oldState.values().stream()
                         .anyMatch(operatorState -> operatorState.getNumberCollectedStates() > 0);
-        this.isFinished = oldState.values().stream().anyMatch(OperatorState::isFullyFinished);
-        if (isFinished) {
+        this.isFullyFinished = oldState.values().stream().anyMatch(OperatorState::isFullyFinished);
+        if (isFullyFinished) {
             checkState(
                     oldState.values().stream().allMatch(OperatorState::isFullyFinished),
                     "JobVertex could not have mixed finished and unfinished operators");

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/checkpoint/VertexFinishedStateChecker.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/checkpoint/VertexFinishedStateChecker.java
@@ -1,0 +1,217 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.flink.runtime.checkpoint;
+
+import org.apache.flink.annotation.VisibleForTesting;
+import org.apache.flink.runtime.OperatorIDPair;
+import org.apache.flink.runtime.executiongraph.ExecutionJobVertex;
+import org.apache.flink.runtime.executiongraph.IntermediateResult;
+import org.apache.flink.runtime.jobgraph.DistributionPattern;
+import org.apache.flink.runtime.jobgraph.JobEdge;
+import org.apache.flink.runtime.jobgraph.JobVertexID;
+import org.apache.flink.runtime.jobgraph.OperatorID;
+import org.apache.flink.util.FlinkRuntimeException;
+
+import java.util.HashMap;
+import java.util.Map;
+import java.util.Optional;
+import java.util.Set;
+import java.util.stream.Collectors;
+
+/**
+ * This class encapsulates the operation that checks if there are illegal modification to the
+ * JobGraph when restoring from a checkpoint with partially or fully finished operator states.
+ *
+ * <p>As a whole, it ensures
+ *
+ * <ol>
+ *   <li>All the operators inside a JobVertex have the same finished state.
+ *   <li>The predecessors of a fully finished vertex must also be fully finished.
+ *   <li>The predecessors of a partially finished vertex
+ *       <ul>
+ *         <li>If connected via ALL_TO_ALL edge, the predecessor must be fully finished.
+ *         <li>If connected via POINTWISE edge, the predecessor must be partially finished or fully
+ *             finished.
+ *       </ul>
+ * </ol>
+ */
+public class VertexFinishedStateChecker {
+
+    private final Set<ExecutionJobVertex> vertices;
+
+    private final Map<OperatorID, OperatorState> operatorStates;
+
+    public VertexFinishedStateChecker(
+            Set<ExecutionJobVertex> vertices, Map<OperatorID, OperatorState> operatorStates) {
+        this.vertices = vertices;
+        this.operatorStates = operatorStates;
+    }
+
+    public void validateOperatorsFinishedState() {
+        VerticesFinishedStatusCache verticesFinishedCache =
+                new VerticesFinishedStatusCache(operatorStates);
+        for (ExecutionJobVertex vertex : vertices) {
+            VertexFinishedState vertexFinishedState = verticesFinishedCache.getOrUpdate(vertex);
+
+            if (vertexFinishedState == VertexFinishedState.FULLY_FINISHED) {
+                checkPredecessorsOfFullyFinishedVertex(vertex, verticesFinishedCache);
+            } else if (vertexFinishedState == VertexFinishedState.PARTIALLY_FINISHED) {
+                checkPredecessorsOfPartiallyFinishedVertex(vertex, verticesFinishedCache);
+            }
+        }
+    }
+
+    private void checkPredecessorsOfFullyFinishedVertex(
+            ExecutionJobVertex vertex, VerticesFinishedStatusCache verticesFinishedStatusCache) {
+        boolean allPredecessorsFinished =
+                vertex.getInputs().stream()
+                        .map(IntermediateResult::getProducer)
+                        .allMatch(
+                                jobVertex ->
+                                        verticesFinishedStatusCache.getOrUpdate(jobVertex)
+                                                == VertexFinishedState.FULLY_FINISHED);
+
+        if (!allPredecessorsFinished) {
+            throw new FlinkRuntimeException(
+                    "Illegal JobGraph modification. Cannot run a program with fully finished"
+                            + " vertices predeceased with the ones not fully finished. Task vertex "
+                            + vertex.getName()
+                            + "("
+                            + vertex.getJobVertexId()
+                            + ")"
+                            + " has a predecessor not fully finished");
+        }
+    }
+
+    private void checkPredecessorsOfPartiallyFinishedVertex(
+            ExecutionJobVertex vertex, VerticesFinishedStatusCache verticesFinishedStatusCache) {
+        // Computes the distribution pattern from each predecessor. If there are multiple edges
+        // from a single predecessor, ALL_TO_ALL edges would have a higher priority since it
+        // implies stricter limitation (must be fully finished).
+        Map<JobVertexID, DistributionPattern> predecessorDistribution = new HashMap<>();
+        for (JobEdge jobEdge : vertex.getJobVertex().getInputs()) {
+            predecessorDistribution.compute(
+                    jobEdge.getSource().getProducer().getID(),
+                    (k, v) ->
+                            v == DistributionPattern.ALL_TO_ALL
+                                    ? v
+                                    : jobEdge.getDistributionPattern());
+        }
+
+        for (IntermediateResult dataset : vertex.getInputs()) {
+            ExecutionJobVertex predecessor = dataset.getProducer();
+            VertexFinishedState predecessorState =
+                    verticesFinishedStatusCache.getOrUpdate(predecessor);
+            DistributionPattern distribution =
+                    predecessorDistribution.get(predecessor.getJobVertexId());
+
+            if (distribution == DistributionPattern.ALL_TO_ALL
+                    && predecessorState != VertexFinishedState.FULLY_FINISHED) {
+                throw new FlinkRuntimeException(
+                        "Illegal JobGraph modification. Cannot run a program with partially finished"
+                                + " vertices predeceased with running or partially finished ones and"
+                                + " connected via the ALL_TO_ALL edges. Task vertex "
+                                + vertex.getName()
+                                + "("
+                                + vertex.getJobVertexId()
+                                + ")"
+                                + " has a "
+                                + (predecessorState == VertexFinishedState.ALL_RUNNING
+                                        ? "all running"
+                                        : "partially finished")
+                                + " predecessor");
+            } else if (distribution == DistributionPattern.POINTWISE
+                    && predecessorState == VertexFinishedState.ALL_RUNNING) {
+                throw new FlinkRuntimeException(
+                        "Illegal JobGraph modification. Cannot run a program with partially finished"
+                                + " vertices predeceased with all running ones. Task vertex "
+                                + vertex.getName()
+                                + "("
+                                + vertex.getJobVertexId()
+                                + ")"
+                                + " has a all running predecessor");
+            }
+        }
+    }
+
+    @VisibleForTesting
+    enum VertexFinishedState {
+        ALL_RUNNING,
+        PARTIALLY_FINISHED,
+        FULLY_FINISHED
+    }
+
+    private static class VerticesFinishedStatusCache {
+        private final Map<OperatorID, OperatorState> operatorStates;
+        private final Map<JobVertexID, VertexFinishedState> finishedCache = new HashMap<>();
+
+        private VerticesFinishedStatusCache(Map<OperatorID, OperatorState> operatorStates) {
+            this.operatorStates = operatorStates;
+        }
+
+        public VertexFinishedState getOrUpdate(ExecutionJobVertex vertex) {
+            return finishedCache.computeIfAbsent(
+                    vertex.getJobVertexId(),
+                    ignored -> calculateFinishedState(vertex, operatorStates));
+        }
+
+        private VertexFinishedState calculateFinishedState(
+                ExecutionJobVertex vertex, Map<OperatorID, OperatorState> operatorStates) {
+            Set<VertexFinishedState> operatorFinishedStates =
+                    vertex.getOperatorIDs().stream()
+                            .map(idPair -> checkOperatorFinishedStatus(operatorStates, idPair))
+                            .collect(Collectors.toSet());
+            if (operatorFinishedStates.size() != 1) {
+                throw new FlinkRuntimeException(
+                        "Can not restore vertex "
+                                + vertex.getName()
+                                + "("
+                                + vertex.getJobVertexId()
+                                + ")"
+                                + " which contain mixed operator finished state: "
+                                + operatorFinishedStates.stream()
+                                        .sorted()
+                                        .collect(Collectors.toList()));
+            }
+
+            return operatorFinishedStates.iterator().next();
+        }
+
+        private VertexFinishedState checkOperatorFinishedStatus(
+                Map<OperatorID, OperatorState> operatorStates, OperatorIDPair idPair) {
+            OperatorID operatorId =
+                    idPair.getUserDefinedOperatorID().orElse(idPair.getGeneratedOperatorID());
+            return Optional.ofNullable(operatorStates.get(operatorId))
+                    .map(
+                            operatorState -> {
+                                if (operatorState.isFullyFinished()) {
+                                    return VertexFinishedState.FULLY_FINISHED;
+                                }
+
+                                boolean hasFinishedSubtasks =
+                                        operatorState.getSubtaskStates().values().stream()
+                                                .anyMatch(OperatorSubtaskState::isFinished);
+                                return hasFinishedSubtasks
+                                        ? VertexFinishedState.PARTIALLY_FINISHED
+                                        : VertexFinishedState.ALL_RUNNING;
+                            })
+                    .orElse(VertexFinishedState.ALL_RUNNING);
+        }
+    }
+}

--- a/flink-runtime/src/test/java/org/apache/flink/runtime/checkpoint/CheckpointCoordinatorRestoringTest.java
+++ b/flink-runtime/src/test/java/org/apache/flink/runtime/checkpoint/CheckpointCoordinatorRestoringTest.java
@@ -1261,7 +1261,7 @@ public class CheckpointCoordinatorRestoringTest extends TestLogger {
                         + jobVertexID1
                         + ")"
                         + " which contain mixed operator finished state: [ALL_RUNNING, FULLY_FINISHED]");
-        coord.restoreLatestCheckpointedStateToAll(vertices, false);
+        coord.restoreInitialCheckpointIfPresent(vertices);
     }
 
     @Test
@@ -1468,7 +1468,8 @@ public class CheckpointCoordinatorRestoringTest extends TestLogger {
 
         thrown.expect(expectedExceptionalClass);
         thrown.expectMessage(expectedMessage);
-        coord.restoreLatestCheckpointedStateToAll(vertices, false);
+
+        coord.restoreInitialCheckpointIfPresent(vertices);
     }
 
     private OperatorState createOperatorState(

--- a/flink-runtime/src/test/java/org/apache/flink/runtime/checkpoint/CheckpointCoordinatorRestoringTest.java
+++ b/flink-runtime/src/test/java/org/apache/flink/runtime/checkpoint/CheckpointCoordinatorRestoringTest.java
@@ -22,6 +22,7 @@ import org.apache.flink.api.common.JobStatus;
 import org.apache.flink.api.java.tuple.Tuple2;
 import org.apache.flink.runtime.OperatorIDPair;
 import org.apache.flink.runtime.checkpoint.CheckpointCoordinatorTestingUtils.CheckpointCoordinatorBuilder;
+import org.apache.flink.runtime.checkpoint.VertexFinishedStateChecker.VertexFinishedState;
 import org.apache.flink.runtime.concurrent.ManuallyTriggeredScheduledExecutor;
 import org.apache.flink.runtime.executiongraph.Execution;
 import org.apache.flink.runtime.executiongraph.ExecutionGraph;
@@ -1259,31 +1260,185 @@ public class CheckpointCoordinatorRestoringTest extends TestLogger {
                         + "anon("
                         + jobVertexID1
                         + ")"
-                        + " which contain both finished and unfinished operators");
+                        + " which contain mixed operator finished state: [ALL_RUNNING, FULLY_FINISHED]");
         coord.restoreLatestCheckpointedStateToAll(vertices, false);
     }
 
     @Test
     public void testAddingRunningOperatorBeforeFinishedOneFails() throws Exception {
+        JobVertexID jobVertexID2 = new JobVertexID();
+
+        testAddingOperatorsBeforePartiallyOrFullyFinishedOne(
+                new JobVertexID(),
+                "vert1",
+                VertexFinishedState.ALL_RUNNING,
+                jobVertexID2,
+                "vert2",
+                VertexFinishedState.FULLY_FINISHED,
+                new DistributionPattern[] {DistributionPattern.ALL_TO_ALL},
+                FlinkRuntimeException.class,
+                "Illegal JobGraph modification. Cannot run a program with fully finished vertices"
+                        + " predeceased with the ones not fully finished. Task vertex vert2"
+                        + "("
+                        + jobVertexID2
+                        + ")"
+                        + " has a predecessor not fully finished");
+    }
+
+    @Test
+    public void testAddingPartiallyFinishedOperatorBeforeFinishedOneFails() throws Exception {
+        JobVertexID jobVertexID2 = new JobVertexID();
+
+        testAddingOperatorsBeforePartiallyOrFullyFinishedOne(
+                new JobVertexID(),
+                "vert1",
+                VertexFinishedState.PARTIALLY_FINISHED,
+                jobVertexID2,
+                "vert2",
+                VertexFinishedState.FULLY_FINISHED,
+                new DistributionPattern[] {DistributionPattern.ALL_TO_ALL},
+                FlinkRuntimeException.class,
+                "Illegal JobGraph modification. Cannot run a program with fully finished vertices"
+                        + " predeceased with the ones not fully finished. Task vertex vert2"
+                        + "("
+                        + jobVertexID2
+                        + ")"
+                        + " has a predecessor not fully finished");
+    }
+
+    @Test
+    public void testAddingAllRunningOperatorBeforePartiallyFinishedOneWithAllToAllFails()
+            throws Exception {
+        JobVertexID jobVertexID2 = new JobVertexID();
+
+        testAddingOperatorsBeforePartiallyOrFullyFinishedOne(
+                new JobVertexID(),
+                "vert1",
+                VertexFinishedState.ALL_RUNNING,
+                jobVertexID2,
+                "vert2",
+                VertexFinishedState.PARTIALLY_FINISHED,
+                new DistributionPattern[] {DistributionPattern.ALL_TO_ALL},
+                FlinkRuntimeException.class,
+                "Illegal JobGraph modification. Cannot run a program with partially finished vertices"
+                        + " predeceased with running or partially finished ones and connected via the ALL_TO_ALL edges. "
+                        + "Task vertex vert2"
+                        + "("
+                        + jobVertexID2
+                        + ")"
+                        + " has a all running predecessor");
+    }
+
+    @Test
+    public void testAddingPartiallyFinishedOperatorBeforePartiallyFinishedOneWithAllToAllFails()
+            throws Exception {
+        JobVertexID jobVertexID2 = new JobVertexID();
+
+        testAddingOperatorsBeforePartiallyOrFullyFinishedOne(
+                new JobVertexID(),
+                "vert1",
+                VertexFinishedState.PARTIALLY_FINISHED,
+                jobVertexID2,
+                "vert2",
+                VertexFinishedState.PARTIALLY_FINISHED,
+                new DistributionPattern[] {DistributionPattern.ALL_TO_ALL},
+                FlinkRuntimeException.class,
+                "Illegal JobGraph modification. Cannot run a program with partially finished vertices"
+                        + " predeceased with running or partially finished ones and connected via the ALL_TO_ALL edges. "
+                        + "Task vertex vert2"
+                        + "("
+                        + jobVertexID2
+                        + ")"
+                        + " has a partially finished predecessor");
+    }
+
+    @Test
+    public void
+            testAddingPartiallyFinishedOperatorBeforePartiallyFinishedOneWithPointwiseAndAllToAllFails()
+                    throws Exception {
+        JobVertexID jobVertexID2 = new JobVertexID();
+
+        testAddingOperatorsBeforePartiallyOrFullyFinishedOne(
+                new JobVertexID(),
+                "vert1",
+                VertexFinishedState.PARTIALLY_FINISHED,
+                jobVertexID2,
+                "vert2",
+                VertexFinishedState.PARTIALLY_FINISHED,
+                new DistributionPattern[] {
+                    DistributionPattern.POINTWISE, DistributionPattern.ALL_TO_ALL
+                },
+                FlinkRuntimeException.class,
+                "Illegal JobGraph modification. Cannot run a program with partially finished vertices"
+                        + " predeceased with running or partially finished ones and connected via the ALL_TO_ALL edges. "
+                        + "Task vertex vert2"
+                        + "("
+                        + jobVertexID2
+                        + ")"
+                        + " has a partially finished predecessor");
+    }
+
+    @Test
+    public void testAddingAllRunningOperatorBeforePartiallyFinishedOneFails() throws Exception {
+        JobVertexID jobVertexID2 = new JobVertexID();
+
+        testAddingOperatorsBeforePartiallyOrFullyFinishedOne(
+                new JobVertexID(),
+                "vert1",
+                VertexFinishedState.ALL_RUNNING,
+                jobVertexID2,
+                "vert2",
+                VertexFinishedState.PARTIALLY_FINISHED,
+                new DistributionPattern[] {DistributionPattern.POINTWISE},
+                FlinkRuntimeException.class,
+                "Illegal JobGraph modification. Cannot run a program with partially finished vertices"
+                        + " predeceased with all running ones. "
+                        + "Task vertex vert2"
+                        + "("
+                        + jobVertexID2
+                        + ")"
+                        + " has a all running predecessor");
+    }
+
+    private void testAddingOperatorsBeforePartiallyOrFullyFinishedOne(
+            JobVertexID firstVertexId,
+            String firstVertexName,
+            VertexFinishedState firstOperatorFinishedState,
+            JobVertexID secondVertexId,
+            String secondVertexName,
+            VertexFinishedState secondOperatorFinishedState,
+            DistributionPattern[] distributionPatterns,
+            Class<? extends Throwable> expectedExceptionalClass,
+            String expectedMessage)
+            throws Exception {
         OperatorIDPair op1 = OperatorIDPair.generatedIDOnly(new OperatorID());
         OperatorIDPair op2 = OperatorIDPair.generatedIDOnly(new OperatorID());
-        JobVertex vertex1 = new JobVertex("vert1", new JobVertexID(), singletonList(op1));
-        JobVertex vertex2 = new JobVertex("vert2", new JobVertexID(), singletonList(op2));
+        JobVertex vertex1 = new JobVertex(firstVertexName, firstVertexId, singletonList(op1));
+        JobVertex vertex2 = new JobVertex(secondVertexName, secondVertexId, singletonList(op2));
         vertex1.setInvokableClass(NoOpInvokable.class);
         vertex2.setInvokableClass(NoOpInvokable.class);
-        vertex2.connectNewDataSetAsInput(
-                vertex1, DistributionPattern.ALL_TO_ALL, ResultPartitionType.PIPELINED);
 
         final ExecutionGraph graph =
                 new CheckpointCoordinatorTestingUtils.CheckpointExecutionGraphBuilder()
                         .addJobVertex(vertex1, true)
                         .addJobVertex(vertex2, false)
+                        .setDistributionPattern(distributionPatterns[0])
                         .build();
+
+        // Adds the additional edges
+        for (int i = 1; i < distributionPatterns.length; ++i) {
+            vertex2.connectNewDataSetAsInput(
+                    vertex1, distributionPatterns[i], ResultPartitionType.PIPELINED);
+        }
 
         Map<OperatorID, OperatorState> operatorStates = new HashMap<>();
         operatorStates.put(
+                op1.getGeneratedOperatorID(),
+                createOperatorState(op1.getGeneratedOperatorID(), firstOperatorFinishedState));
+        operatorStates.put(
                 op2.getGeneratedOperatorID(),
-                new FullyFinishedOperatorState(op1.getGeneratedOperatorID(), 1, 1));
+                createOperatorState(op2.getGeneratedOperatorID(), secondOperatorFinishedState));
+
         CompletedCheckpointStore store = new EmbeddedCompletedCheckpointStore();
         store.addCheckpoint(
                 new CompletedCheckpoint(
@@ -1311,15 +1466,25 @@ public class CheckpointCoordinatorRestoringTest extends TestLogger {
         vertices.add(graph.getJobVertex(vertex1.getID()));
         vertices.add(graph.getJobVertex(vertex2.getID()));
 
-        thrown.expect(FlinkRuntimeException.class);
-        thrown.expectMessage(
-                "Illegal JobGraph modification. Cannot run a program with finished vertices"
-                        + " predeceased with running ones. Task vertex "
-                        + vertex2.getName()
-                        + "("
-                        + vertex2.getID()
-                        + ")"
-                        + " has a running predecessor");
+        thrown.expect(expectedExceptionalClass);
+        thrown.expectMessage(expectedMessage);
         coord.restoreLatestCheckpointedStateToAll(vertices, false);
+    }
+
+    private OperatorState createOperatorState(
+            OperatorID operatorId, VertexFinishedState finishedState) {
+        switch (finishedState) {
+            case ALL_RUNNING:
+                return new OperatorState(operatorId, 2, 2);
+            case PARTIALLY_FINISHED:
+                OperatorState operatorState = new OperatorState(operatorId, 2, 2);
+                operatorState.putState(0, FinishedOperatorSubtaskState.INSTANCE);
+                return operatorState;
+            case FULLY_FINISHED:
+                return new FullyFinishedOperatorState(operatorId, 2, 2);
+            default:
+                throw new UnsupportedOperationException(
+                        "Not supported finished state: " + finishedState);
+        }
     }
 }

--- a/flink-runtime/src/test/java/org/apache/flink/runtime/checkpoint/CheckpointCoordinatorTestingUtils.java
+++ b/flink-runtime/src/test/java/org/apache/flink/runtime/checkpoint/CheckpointCoordinatorTestingUtils.java
@@ -571,11 +571,13 @@ public class CheckpointCoordinatorTestingUtils {
     static class CheckpointExecutionGraphBuilder {
         private final List<JobVertex> sourceVertices = new ArrayList<>();
         private final List<JobVertex> nonSourceVertices = new ArrayList<>();
+        private DistributionPattern distributionPattern;
         private boolean transitToRunning;
         private TaskManagerGateway taskManagerGateway;
         private ComponentMainThreadExecutor mainThreadExecutor;
 
         CheckpointExecutionGraphBuilder() {
+            this.distributionPattern = DistributionPattern.ALL_TO_ALL;
             this.transitToRunning = true;
             this.mainThreadExecutor = ComponentMainThreadExecutorServiceAdapter.forMainThread();
         }
@@ -627,6 +629,12 @@ public class CheckpointCoordinatorTestingUtils {
             return this;
         }
 
+        public CheckpointExecutionGraphBuilder setDistributionPattern(
+                DistributionPattern distributionPattern) {
+            this.distributionPattern = distributionPattern;
+            return this;
+        }
+
         public CheckpointExecutionGraphBuilder setTransitToRunning(boolean transitToRunning) {
             this.transitToRunning = transitToRunning;
             return this;
@@ -643,7 +651,7 @@ public class CheckpointCoordinatorTestingUtils {
             for (JobVertex source : sourceVertices) {
                 for (JobVertex nonSource : nonSourceVertices) {
                     nonSource.connectNewDataSetAsInput(
-                            source, DistributionPattern.ALL_TO_ALL, ResultPartitionType.PIPELINED);
+                            source, distributionPattern, ResultPartitionType.PIPELINED);
                 }
             }
 

--- a/flink-runtime/src/test/java/org/apache/flink/runtime/checkpoint/CheckpointCoordinatorTestingUtils.java
+++ b/flink-runtime/src/test/java/org/apache/flink/runtime/checkpoint/CheckpointCoordinatorTestingUtils.java
@@ -426,22 +426,21 @@ public class CheckpointCoordinatorTestingUtils {
     public static TaskStateSnapshot createSnapshotWithUnionListState(
             File stateFile, OperatorID operatorId, boolean isOperatorsFinished) throws IOException {
         TaskStateSnapshot taskStateSnapshot = new TaskStateSnapshot(1, isOperatorsFinished);
-
-        OperatorSubtaskState operatorSubtaskState =
-                OperatorSubtaskState.builder()
-                        .setManagedOperatorState(
-                                new OperatorStreamStateHandle(
-                                        Collections.singletonMap(
-                                                "test",
-                                                new OperatorStateHandle.StateMetaInfo(
-                                                        new long[0],
-                                                        OperatorStateHandle.Mode.UNION)),
-                                        new FileStateHandle(
-                                                new Path(stateFile.getAbsolutePath()), 0L)))
-                        .build();
-
-        taskStateSnapshot.putSubtaskStateByOperatorID(operatorId, operatorSubtaskState);
+        taskStateSnapshot.putSubtaskStateByOperatorID(
+                operatorId, createSubtaskStateWithUnionListState(stateFile));
         return taskStateSnapshot;
+    }
+
+    public static OperatorSubtaskState createSubtaskStateWithUnionListState(File stateFile) {
+        return OperatorSubtaskState.builder()
+                .setManagedOperatorState(
+                        new OperatorStreamStateHandle(
+                                Collections.singletonMap(
+                                        "test",
+                                        new OperatorStateHandle.StateMetaInfo(
+                                                new long[0], OperatorStateHandle.Mode.UNION)),
+                                new FileStateHandle(new Path(stateFile.getAbsolutePath()), 0L)))
+                .build();
     }
 
     static class TriggeredCheckpoint {

--- a/flink-runtime/src/test/java/org/apache/flink/runtime/checkpoint/DefaultCheckpointPlanTest.java
+++ b/flink-runtime/src/test/java/org/apache/flink/runtime/checkpoint/DefaultCheckpointPlanTest.java
@@ -1,0 +1,176 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.flink.runtime.checkpoint;
+
+import org.apache.flink.api.common.JobID;
+import org.apache.flink.runtime.OperatorIDPair;
+import org.apache.flink.runtime.executiongraph.ExecutionGraph;
+import org.apache.flink.runtime.executiongraph.ExecutionGraphCheckpointPlanCalculatorContext;
+import org.apache.flink.runtime.executiongraph.ExecutionVertex;
+import org.apache.flink.runtime.jobgraph.JobVertexID;
+import org.apache.flink.runtime.jobgraph.OperatorID;
+import org.apache.flink.util.FlinkRuntimeException;
+
+import org.junit.ClassRule;
+import org.junit.Rule;
+import org.junit.Test;
+import org.junit.rules.ExpectedException;
+import org.junit.rules.TemporaryFolder;
+
+import java.util.Arrays;
+import java.util.Collections;
+import java.util.HashMap;
+import java.util.Map;
+
+import static org.apache.flink.runtime.checkpoint.CheckpointCoordinatorTestingUtils.createSubtaskStateWithUnionListState;
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertTrue;
+
+/** Tests the behavior of the {@link DefaultCheckpointPlan}. */
+public class DefaultCheckpointPlanTest {
+
+    @ClassRule public static final TemporaryFolder TEMPORARY_FOLDER = new TemporaryFolder();
+
+    @Rule public final ExpectedException expectedException = ExpectedException.none();
+
+    @Test
+    public void testAbortionIfPartiallyFinishedVertexUsedUnionListState() throws Exception {
+        JobVertexID jobVertexId = new JobVertexID();
+        OperatorID operatorId = new OperatorID();
+
+        ExecutionGraph executionGraph =
+                new CheckpointCoordinatorTestingUtils.CheckpointExecutionGraphBuilder()
+                        .addJobVertex(
+                                jobVertexId,
+                                2,
+                                2,
+                                Collections.singletonList(
+                                        OperatorIDPair.generatedIDOnly(operatorId)),
+                                true)
+                        .build();
+        ExecutionVertex[] tasks = executionGraph.getJobVertex(jobVertexId).getTaskVertices();
+        tasks[0].getCurrentExecutionAttempt().markFinished();
+
+        CheckpointPlan checkpointPlan = createCheckpointPlan(executionGraph);
+
+        Map<OperatorID, OperatorState> operatorStates = new HashMap<>();
+        OperatorState operatorState = new OperatorState(operatorId, 2, 2);
+        operatorState.putState(0, createSubtaskStateWithUnionListState(TEMPORARY_FOLDER.newFile()));
+        operatorStates.put(operatorId, operatorState);
+
+        expectedException.expect(FlinkRuntimeException.class);
+        expectedException.expectMessage(
+                String.format(
+                        "The vertex %s (id = %s) has "
+                                + "used UnionListState, but part of its tasks are FINISHED",
+                        executionGraph.getJobVertex(jobVertexId).getName(), jobVertexId));
+        checkpointPlan.fulfillFinishedTaskStatus(operatorStates);
+    }
+
+    @Test
+    public void testAbortionIfPartiallyOperatorsFinishedVertexUsedUnionListState()
+            throws Exception {
+        JobVertexID jobVertexId = new JobVertexID();
+        OperatorID operatorId = new OperatorID();
+
+        ExecutionGraph executionGraph =
+                new CheckpointCoordinatorTestingUtils.CheckpointExecutionGraphBuilder()
+                        .addJobVertex(
+                                jobVertexId,
+                                2,
+                                2,
+                                Collections.singletonList(
+                                        OperatorIDPair.generatedIDOnly(operatorId)),
+                                true)
+                        .build();
+        ExecutionVertex[] tasks = executionGraph.getJobVertex(jobVertexId).getTaskVertices();
+
+        CheckpointPlan checkpointPlan = createCheckpointPlan(executionGraph);
+
+        Map<OperatorID, OperatorState> operatorStates = new HashMap<>();
+        OperatorState operatorState = new OperatorState(operatorId, 2, 2);
+        operatorState.putState(0, createSubtaskStateWithUnionListState(TEMPORARY_FOLDER.newFile()));
+
+        operatorState.putState(1, createSubtaskStateWithUnionListState(TEMPORARY_FOLDER.newFile()));
+        checkpointPlan.reportTaskHasFinishedOperators(tasks[1]);
+        operatorStates.put(operatorId, operatorState);
+
+        expectedException.expect(FlinkRuntimeException.class);
+        expectedException.expectMessage(
+                String.format(
+                        "The vertex %s (id = %s) has "
+                                + "used UnionListState, but part of its tasks has called operators' finish method.",
+                        executionGraph.getJobVertex(jobVertexId).getName(), jobVertexId));
+        checkpointPlan.fulfillFinishedTaskStatus(operatorStates);
+    }
+
+    @Test
+    public void testFulfillFinishedStates() throws Exception {
+        JobVertexID fullyFinishedVertexId = new JobVertexID();
+        JobVertexID finishedOnRestoreVertexId = new JobVertexID();
+        OperatorID fullyFinishedOperatorId = new OperatorID();
+        OperatorID finishedOnRestoreOperatorId = new OperatorID();
+
+        ExecutionGraph executionGraph =
+                new CheckpointCoordinatorTestingUtils.CheckpointExecutionGraphBuilder()
+                        .addJobVertex(
+                                fullyFinishedVertexId,
+                                2,
+                                2,
+                                Collections.singletonList(
+                                        OperatorIDPair.generatedIDOnly(fullyFinishedOperatorId)),
+                                true)
+                        .addJobVertex(
+                                finishedOnRestoreVertexId,
+                                2,
+                                2,
+                                Collections.singletonList(
+                                        OperatorIDPair.generatedIDOnly(
+                                                finishedOnRestoreOperatorId)),
+                                true)
+                        .build();
+        ExecutionVertex[] fullyFinishedVertexTasks =
+                executionGraph.getJobVertex(fullyFinishedVertexId).getTaskVertices();
+        ExecutionVertex[] finishedOnRestoreVertexTasks =
+                executionGraph.getJobVertex(finishedOnRestoreVertexId).getTaskVertices();
+        Arrays.stream(fullyFinishedVertexTasks)
+                .forEach(task -> task.getCurrentExecutionAttempt().markFinished());
+
+        CheckpointPlan checkpointPlan = createCheckpointPlan(executionGraph);
+        Arrays.stream(finishedOnRestoreVertexTasks)
+                .forEach(checkpointPlan::reportTaskFinishedOnRestore);
+
+        Map<OperatorID, OperatorState> operatorStates = new HashMap<>();
+        checkpointPlan.fulfillFinishedTaskStatus(operatorStates);
+
+        assertEquals(2, operatorStates.size());
+        assertTrue(operatorStates.get(fullyFinishedOperatorId).isFullyFinished());
+        assertTrue(operatorStates.get(finishedOnRestoreOperatorId).isFullyFinished());
+    }
+
+    private CheckpointPlan createCheckpointPlan(ExecutionGraph executionGraph) throws Exception {
+        CheckpointPlanCalculator checkpointPlanCalculator =
+                new DefaultCheckpointPlanCalculator(
+                        new JobID(),
+                        new ExecutionGraphCheckpointPlanCalculatorContext(executionGraph),
+                        executionGraph.getVerticesTopologically(),
+                        true);
+        return checkpointPlanCalculator.calculateCheckpointPlan().get();
+    }
+}

--- a/flink-runtime/src/test/java/org/apache/flink/runtime/checkpoint/PendingCheckpointTest.java
+++ b/flink-runtime/src/test/java/org/apache/flink/runtime/checkpoint/PendingCheckpointTest.java
@@ -28,8 +28,6 @@ import org.apache.flink.runtime.checkpoint.PendingCheckpoint.TaskAcknowledgeResu
 import org.apache.flink.runtime.checkpoint.hooks.MasterHooks;
 import org.apache.flink.runtime.executiongraph.Execution;
 import org.apache.flink.runtime.executiongraph.ExecutionAttemptID;
-import org.apache.flink.runtime.executiongraph.ExecutionGraph;
-import org.apache.flink.runtime.executiongraph.ExecutionGraphCheckpointPlanCalculatorContext;
 import org.apache.flink.runtime.executiongraph.ExecutionJobVertex;
 import org.apache.flink.runtime.executiongraph.ExecutionVertex;
 import org.apache.flink.runtime.jobgraph.JobVertexID;
@@ -41,7 +39,6 @@ import org.apache.flink.runtime.state.SharedStateRegistry;
 import org.apache.flink.runtime.state.TestingStreamStateHandle;
 import org.apache.flink.runtime.state.filesystem.FsCheckpointStorageLocation;
 import org.apache.flink.runtime.state.memory.ByteStreamStateHandle;
-import org.apache.flink.util.FlinkRuntimeException;
 import org.apache.flink.util.concurrent.Executors;
 
 import org.junit.Assert;
@@ -66,11 +63,9 @@ import java.util.Queue;
 import java.util.concurrent.CompletableFuture;
 import java.util.concurrent.Executor;
 import java.util.concurrent.ScheduledFuture;
-import java.util.stream.Collectors;
 
-import static org.apache.flink.runtime.checkpoint.CheckpointCoordinatorTestingUtils.createSnapshotWithUnionListState;
 import static org.apache.flink.util.Preconditions.checkNotNull;
-import static org.hamcrest.CoreMatchers.is;
+import static org.hamcrest.Matchers.contains;
 import static org.hamcrest.Matchers.containsInAnyOrder;
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertFalse;
@@ -554,238 +549,33 @@ public class PendingCheckpointTest {
     }
 
     @Test
-    public void testFinalizeCheckpointWithFullyFinishedOperators() throws Exception {
-        JobVertexID finishedJobVertexID = new JobVertexID();
-        JobVertexID runningJobVertexID = new JobVertexID();
-        OperatorID finishedOperatorID = new OperatorID();
-        OperatorID runningOperatorID = new OperatorID();
-
-        ExecutionGraph executionGraph =
-                new CheckpointCoordinatorTestingUtils.CheckpointExecutionGraphBuilder()
-                        .addJobVertex(
-                                finishedJobVertexID,
-                                1,
-                                256,
-                                Collections.singletonList(
-                                        OperatorIDPair.generatedIDOnly(finishedOperatorID)),
-                                true)
-                        .addJobVertex(
-                                runningJobVertexID,
-                                1,
-                                256,
-                                Collections.singletonList(
-                                        OperatorIDPair.generatedIDOnly(runningOperatorID)),
-                                true)
-                        .build();
-        executionGraph
-                .getJobVertex(finishedJobVertexID)
-                .getTaskVertices()[0]
-                .getCurrentExecutionAttempt()
-                .markFinished();
-        PendingCheckpoint pendingCheckpoint = createPendingCheckpoint(executionGraph);
-        assertThat(pendingCheckpoint.getCheckpointPlan().getFullyFinishedJobVertex().size(), is(1));
+    public void testReportTaskFinishedOnRestore() throws IOException {
+        RecordCheckpointPlan recordCheckpointPlan =
+                new RecordCheckpointPlan(new ArrayList<>(ACK_TASKS));
+        PendingCheckpoint checkpoint = createPendingCheckpoint(recordCheckpointPlan);
+        checkpoint.acknowledgeTask(
+                ACK_TASKS.get(0).getAttemptId(),
+                TaskStateSnapshot.FINISHED_ON_RESTORE,
+                new CheckpointMetrics(),
+                null);
         assertThat(
-                pendingCheckpoint
-                        .getCheckpointPlan()
-                        .getFullyFinishedJobVertex()
-                        .get(0)
-                        .getJobVertexId(),
-                is(finishedJobVertexID));
-
-        // Report the state for the running operator
-        ExecutionAttemptID runningTaskId =
-                executionGraph
-                        .getJobVertex(runningJobVertexID)
-                        .getTaskVertices()[0]
-                        .getCurrentExecutionAttempt()
-                        .getAttemptId();
-        TaskStateSnapshot taskStateSnapshot = new TaskStateSnapshot();
-        taskStateSnapshot.putSubtaskStateByOperatorID(
-                runningOperatorID, new OperatorSubtaskState());
-        TaskAcknowledgeResult result =
-                pendingCheckpoint.acknowledgeTask(
-                        runningTaskId, taskStateSnapshot, new CheckpointMetrics(), null);
-        assertThat(result, is(TaskAcknowledgeResult.SUCCESS));
-
-        CompletedCheckpoint completedCheckpoint =
-                pendingCheckpoint.finalizeCheckpoint(
-                        new CheckpointsCleaner(), () -> {}, Executors.directExecutor(), null);
-        assertThat(completedCheckpoint.getOperatorStates().size(), is(2));
-        OperatorState finishedOperatorState =
-                completedCheckpoint.getOperatorStates().get(finishedOperatorID);
-        assertThat(finishedOperatorState.isFullyFinished(), is(true));
+                recordCheckpointPlan.getReportedFinishedOnRestoreTasks(),
+                contains(ACK_TASKS.get(0).getVertex()));
     }
 
     @Test
-    public void testReportFinishSnapshots() throws Exception {
-        JobVertexID jobVertexId = new JobVertexID();
-        OperatorID operatorId1 = new OperatorID();
-        OperatorID operatorId2 = new OperatorID();
-
-        ExecutionGraph executionGraph =
-                new CheckpointCoordinatorTestingUtils.CheckpointExecutionGraphBuilder()
-                        .addJobVertex(
-                                jobVertexId,
-                                2,
-                                2,
-                                Arrays.asList(
-                                        OperatorIDPair.generatedIDOnly(operatorId1),
-                                        OperatorIDPair.generatedIDOnly(operatorId2)),
-                                true)
-                        .build();
-        List<ExecutionAttemptID> runningTaskIds =
-                Arrays.stream(executionGraph.getJobVertex(jobVertexId).getTaskVertices())
-                        .map(task -> task.getCurrentExecutionAttempt().getAttemptId())
-                        .collect(Collectors.toList());
-        assertEquals(2, runningTaskIds.size());
-
-        PendingCheckpoint pendingCheckpoint = createPendingCheckpoint(executionGraph);
-
-        for (ExecutionAttemptID attemptId : runningTaskIds) {
-            TaskAcknowledgeResult result =
-                    pendingCheckpoint.acknowledgeTask(
-                            attemptId,
-                            TaskStateSnapshot.FINISHED_ON_RESTORE,
-                            new CheckpointMetrics(),
-                            null);
-            assertEquals(TaskAcknowledgeResult.SUCCESS, result);
-        }
-
-        // Here we should collect the snapshots of all the tasks
-        assertTrue(pendingCheckpoint.isFullyAcknowledged());
-        CompletedCheckpoint completedCheckpoint =
-                pendingCheckpoint.finalizeCheckpoint(
-                        new CheckpointsCleaner(), () -> {}, Executors.directExecutor(), null);
-
-        // Check that the operators are fully finished.
+    public void testReportTaskFinishedOperators() throws IOException {
+        RecordCheckpointPlan recordCheckpointPlan =
+                new RecordCheckpointPlan(new ArrayList<>(ACK_TASKS));
+        PendingCheckpoint checkpoint = createPendingCheckpoint(recordCheckpointPlan);
+        checkpoint.acknowledgeTask(
+                ACK_TASKS.get(0).getAttemptId(),
+                new TaskStateSnapshot(10, true),
+                new CheckpointMetrics(),
+                null);
         assertThat(
-                completedCheckpoint.getOperatorStates().keySet(),
-                containsInAnyOrder(operatorId1, operatorId2));
-        assertTrue(completedCheckpoint.getOperatorStates().get(operatorId1).isFullyFinished());
-        assertTrue(completedCheckpoint.getOperatorStates().get(operatorId2).isFullyFinished());
-    }
-
-    @Test
-    public void testAbortionIfPartlyFinishedVertexUsedUnionListState() throws Exception {
-        JobVertexID jobVertexId = new JobVertexID();
-        OperatorID operatorId = new OperatorID();
-
-        ExecutionGraph executionGraph =
-                new CheckpointCoordinatorTestingUtils.CheckpointExecutionGraphBuilder()
-                        .addJobVertex(
-                                jobVertexId,
-                                2,
-                                2,
-                                Collections.singletonList(
-                                        OperatorIDPair.generatedIDOnly(operatorId)),
-                                true)
-                        .build();
-        ExecutionVertex[] tasks = executionGraph.getJobVertex(jobVertexId).getTaskVertices();
-        tasks[0].getCurrentExecutionAttempt().markFinished();
-
-        PendingCheckpoint pendingCheckpoint = createPendingCheckpoint(executionGraph);
-        pendingCheckpoint.acknowledgeTask(
-                tasks[1].getCurrentExecutionAttempt().getAttemptId(),
-                createSnapshotWithUnionListState(tmpFolder.newFile(), operatorId, false),
-                new CheckpointMetrics(),
-                null);
-
-        assertTrue(pendingCheckpoint.isFullyAcknowledged());
-
-        expectedException.expect(FlinkRuntimeException.class);
-        expectedException.expectMessage(
-                String.format(
-                        "The vertex %s (id = %s) has "
-                                + "used UnionListState, but part of its tasks are FINISHED",
-                        executionGraph.getJobVertex(jobVertexId).getName(), jobVertexId));
-        pendingCheckpoint.finalizeCheckpoint(
-                new CheckpointsCleaner(), () -> {}, Executors.directExecutor(), null);
-    }
-
-    @Test
-    public void testAbortionIfPartlyOperatorsFinishedVertexUsedUnionListState() throws Exception {
-        JobVertexID jobVertexId = new JobVertexID();
-        OperatorID operatorId = new OperatorID();
-
-        ExecutionGraph executionGraph =
-                new CheckpointCoordinatorTestingUtils.CheckpointExecutionGraphBuilder()
-                        .addJobVertex(
-                                jobVertexId,
-                                2,
-                                2,
-                                Collections.singletonList(
-                                        OperatorIDPair.generatedIDOnly(operatorId)),
-                                true)
-                        .build();
-        List<ExecutionAttemptID> runningTaskIds =
-                Arrays.stream(executionGraph.getJobVertex(jobVertexId).getTaskVertices())
-                        .map(task -> task.getCurrentExecutionAttempt().getAttemptId())
-                        .collect(Collectors.toList());
-        assertEquals(2, runningTaskIds.size());
-
-        PendingCheckpoint pendingCheckpoint = createPendingCheckpoint(executionGraph);
-        pendingCheckpoint.acknowledgeTask(
-                runningTaskIds.get(0),
-                createSnapshotWithUnionListState(tmpFolder.newFile(), operatorId, true),
-                new CheckpointMetrics(),
-                null);
-        pendingCheckpoint.acknowledgeTask(
-                runningTaskIds.get(1),
-                createSnapshotWithUnionListState(tmpFolder.newFile(), operatorId, false),
-                new CheckpointMetrics(),
-                null);
-
-        assertTrue(pendingCheckpoint.isFullyAcknowledged());
-
-        expectedException.expect(FlinkRuntimeException.class);
-        expectedException.expectMessage(
-                String.format(
-                        "The vertex %s (id = %s) has "
-                                + "used UnionListState, but part of its tasks has called operators' finish method.",
-                        executionGraph.getJobVertex(jobVertexId).getName(), jobVertexId));
-        pendingCheckpoint.finalizeCheckpoint(
-                new CheckpointsCleaner(), () -> {}, Executors.directExecutor(), null);
-    }
-
-    @Test
-    public void testPendingCheckpointCompletesIfAllReportsOperatorsFinished() throws Exception {
-        JobVertexID jobVertexId = new JobVertexID();
-        OperatorID operatorId = new OperatorID();
-
-        ExecutionGraph executionGraph =
-                new CheckpointCoordinatorTestingUtils.CheckpointExecutionGraphBuilder()
-                        .addJobVertex(
-                                jobVertexId,
-                                2,
-                                2,
-                                Collections.singletonList(
-                                        OperatorIDPair.generatedIDOnly(operatorId)),
-                                true)
-                        .build();
-        List<ExecutionAttemptID> runningTaskIds =
-                Arrays.stream(executionGraph.getJobVertex(jobVertexId).getTaskVertices())
-                        .map(task -> task.getCurrentExecutionAttempt().getAttemptId())
-                        .collect(Collectors.toList());
-        assertEquals(2, runningTaskIds.size());
-
-        PendingCheckpoint pendingCheckpoint = createPendingCheckpoint(executionGraph);
-        pendingCheckpoint.acknowledgeTask(
-                runningTaskIds.get(0),
-                createSnapshotWithUnionListState(tmpFolder.newFile(), operatorId, true),
-                new CheckpointMetrics(),
-                null);
-        pendingCheckpoint.acknowledgeTask(
-                runningTaskIds.get(1),
-                createSnapshotWithUnionListState(tmpFolder.newFile(), operatorId, true),
-                new CheckpointMetrics(),
-                null);
-
-        assertTrue(pendingCheckpoint.isFullyAcknowledged());
-
-        pendingCheckpoint.finalizeCheckpoint(
-                new CheckpointsCleaner(), () -> {}, Executors.directExecutor(), null);
-        assertTrue(pendingCheckpoint.getCompletionFuture().isDone());
-        assertFalse(pendingCheckpoint.getCompletionFuture().isCompletedExceptionally());
+                recordCheckpointPlan.getReportedOperatorsFinishedTasks(),
+                contains(ACK_TASKS.get(0).getVertex()));
     }
 
     // ------------------------------------------------------------------------
@@ -810,6 +600,17 @@ public class PendingCheckpointTest {
             throws IOException {
         return createPendingCheckpoint(
                 props, Collections.emptyList(), masterStateIdentifiers, Executors.directExecutor());
+    }
+
+    private PendingCheckpoint createPendingCheckpoint(CheckpointPlan checkpointPlan)
+            throws IOException {
+        return createPendingCheckpoint(
+                CheckpointProperties.forCheckpoint(
+                        CheckpointRetentionPolicy.NEVER_RETAIN_AFTER_TERMINATION),
+                Collections.emptyList(),
+                Collections.emptyList(),
+                checkpointPlan,
+                Executors.directExecutor());
     }
 
     private PendingCheckpoint createPendingCheckpointWithCoordinators(OperatorInfo... coordinators)
@@ -849,24 +650,12 @@ public class PendingCheckpointTest {
             Executor executor)
             throws IOException {
 
-        final Path checkpointDir = new Path(tmpFolder.newFolder().toURI());
-        final FsCheckpointStorageLocation location =
-                new FsCheckpointStorageLocation(
-                        LocalFileSystem.getSharedInstance(),
-                        checkpointDir,
-                        checkpointDir,
-                        checkpointDir,
-                        CheckpointStorageLocationReference.getDefault(),
-                        1024,
-                        4096);
-
         final List<Execution> ackTasks = new ArrayList<>(ACK_TASKS);
         final List<ExecutionVertex> tasksToCommit = new ArrayList<>(TASKS_TO_COMMIT);
-
-        return new PendingCheckpoint(
-                new JobID(),
-                0,
-                1,
+        return createPendingCheckpoint(
+                props,
+                operatorCoordinators,
+                masterStateIdentifiers,
                 new DefaultCheckpointPlan(
                         Collections.emptyList(),
                         ackTasks,
@@ -874,22 +663,16 @@ public class PendingCheckpointTest {
                         Collections.emptyList(),
                         Collections.emptyList(),
                         true),
-                operatorCoordinators,
-                masterStateIdentifiers,
-                props,
-                location,
-                new CompletableFuture<>());
+                executor);
     }
 
-    private PendingCheckpoint createPendingCheckpoint(ExecutionGraph executionGraph)
-            throws Exception {
-        DefaultCheckpointPlanCalculator checkpointPlanCalculator =
-                new DefaultCheckpointPlanCalculator(
-                        new JobID(),
-                        new ExecutionGraphCheckpointPlanCalculatorContext(executionGraph),
-                        executionGraph.getVerticesTopologically(),
-                        true);
-        CheckpointPlan checkpointPlan = checkpointPlanCalculator.calculateCheckpointPlan().get();
+    private PendingCheckpoint createPendingCheckpoint(
+            CheckpointProperties props,
+            Collection<OperatorID> operatorCoordinators,
+            Collection<String> masterStateIdentifiers,
+            CheckpointPlan checkpointPlan,
+            Executor executor)
+            throws IOException {
 
         final Path checkpointDir = new Path(tmpFolder.newFolder().toURI());
         final FsCheckpointStorageLocation location =
@@ -903,14 +686,13 @@ public class PendingCheckpointTest {
                         4096);
 
         return new PendingCheckpoint(
-                executionGraph.getJobID(),
+                new JobID(),
                 0,
                 1,
                 checkpointPlan,
-                Collections.emptyList(),
-                Collections.emptyList(),
-                CheckpointProperties.forCheckpoint(
-                        CheckpointRetentionPolicy.NEVER_RETAIN_AFTER_TERMINATION),
+                operatorCoordinators,
+                masterStateIdentifiers,
+                props,
                 location,
                 new CompletableFuture<>());
     }
@@ -993,6 +775,43 @@ public class PendingCheckpointTest {
         @Override
         public SimpleVersionedSerializer<String> createCheckpointDataSerializer() {
             return new StringSerializer();
+        }
+    }
+
+    private static class RecordCheckpointPlan extends DefaultCheckpointPlan {
+
+        private List<ExecutionVertex> reportedFinishedOnRestoreTasks = new ArrayList<>();
+
+        private List<ExecutionVertex> reportedOperatorsFinishedTasks = new ArrayList<>();
+
+        public RecordCheckpointPlan(List<Execution> tasksToWaitFor) {
+            super(
+                    Collections.emptyList(),
+                    tasksToWaitFor,
+                    Collections.emptyList(),
+                    Collections.emptyList(),
+                    Collections.emptyList(),
+                    true);
+        }
+
+        @Override
+        public void reportTaskFinishedOnRestore(ExecutionVertex task) {
+            super.reportTaskFinishedOnRestore(task);
+            reportedFinishedOnRestoreTasks.add(task);
+        }
+
+        @Override
+        public void reportTaskHasFinishedOperators(ExecutionVertex task) {
+            super.reportTaskHasFinishedOperators(task);
+            reportedOperatorsFinishedTasks.add(task);
+        }
+
+        public List<ExecutionVertex> getReportedFinishedOnRestoreTasks() {
+            return reportedFinishedOnRestoreTasks;
+        }
+
+        public List<ExecutionVertex> getReportedOperatorsFinishedTasks() {
+            return reportedOperatorsFinishedTasks;
         }
     }
 }

--- a/flink-runtime/src/test/java/org/apache/flink/runtime/checkpoint/PendingCheckpointTest.java
+++ b/flink-runtime/src/test/java/org/apache/flink/runtime/checkpoint/PendingCheckpointTest.java
@@ -867,7 +867,7 @@ public class PendingCheckpointTest {
                 new JobID(),
                 0,
                 1,
-                new CheckpointPlan(
+                new DefaultCheckpointPlan(
                         Collections.emptyList(),
                         ackTasks,
                         tasksToCommit,

--- a/flink-runtime/src/test/java/org/apache/flink/runtime/checkpoint/metadata/CheckpointMetadataTest.java
+++ b/flink-runtime/src/test/java/org/apache/flink/runtime/checkpoint/metadata/CheckpointMetadataTest.java
@@ -44,7 +44,7 @@ public class CheckpointMetadataTest {
 
         Collection<OperatorState> taskStates =
                 CheckpointTestUtils.createOperatorStates(
-                        rnd, null, numTaskStates, 0, numSubtaskStates);
+                        rnd, null, numTaskStates, 0, 0, numSubtaskStates);
 
         Collection<MasterState> masterStates =
                 CheckpointTestUtils.createRandomMasterStates(rnd, numMasterStates);

--- a/flink-runtime/src/test/java/org/apache/flink/runtime/checkpoint/metadata/CheckpointTestUtils.java
+++ b/flink-runtime/src/test/java/org/apache/flink/runtime/checkpoint/metadata/CheckpointTestUtils.java
@@ -20,6 +20,7 @@ package org.apache.flink.runtime.checkpoint.metadata;
 
 import org.apache.flink.configuration.ConfigConstants;
 import org.apache.flink.core.fs.Path;
+import org.apache.flink.runtime.checkpoint.FinishedOperatorSubtaskState;
 import org.apache.flink.runtime.checkpoint.FullyFinishedOperatorState;
 import org.apache.flink.runtime.checkpoint.MasterState;
 import org.apache.flink.runtime.checkpoint.OperatorState;
@@ -48,6 +49,7 @@ import java.util.List;
 import java.util.Map;
 import java.util.Random;
 import java.util.UUID;
+import java.util.stream.IntStream;
 
 import static org.apache.flink.runtime.checkpoint.StateHandleDummyUtil.createNewInputChannelStateHandle;
 import static org.apache.flink.runtime.checkpoint.StateHandleDummyUtil.createNewResultSubpartitionStateHandle;
@@ -67,117 +69,143 @@ public class CheckpointTestUtils {
      * handles.
      *
      * @param basePath The basePath for savepoint, will be null for checkpoint.
-     * @param numTaskStates Number of tasks.
-     * @param numSubtasksPerTask Number of subtask for each task.
+     * @param numAllRunningTaskStates Number of tasks belong to all running vertex.
+     * @param numPartlyFinishedTaskStates Number of tasks belong to partly finished vertex.
+     * @param numFullyFinishedTaskStates Number of tasks belong to fully finished vertex.
+     * @param numSubtasksPerTask Number of subtasks for each task.
      */
     public static Collection<OperatorState> createOperatorStates(
             Random random,
             @Nullable String basePath,
-            int numTaskStates,
-            int numFinishedTaskStates,
+            int numAllRunningTaskStates,
+            int numPartlyFinishedTaskStates,
+            int numFullyFinishedTaskStates,
             int numSubtasksPerTask) {
 
-        List<OperatorState> taskStates = new ArrayList<>(numTaskStates);
+        List<OperatorState> taskStates =
+                new ArrayList<>(
+                        numAllRunningTaskStates
+                                + numPartlyFinishedTaskStates
+                                + numFullyFinishedTaskStates);
 
-        for (int stateIdx = 0; stateIdx < numFinishedTaskStates; ++stateIdx) {
+        for (int stateIdx = 0; stateIdx < numAllRunningTaskStates; ++stateIdx) {
+            OperatorState taskState = new OperatorState(new OperatorID(), numSubtasksPerTask, 128);
+            randomlySetCoordinatorState(taskState, random);
+            randomlySetSubtaskState(
+                    taskState, IntStream.range(0, numSubtasksPerTask).toArray(), random, basePath);
+            taskStates.add(taskState);
+        }
+
+        for (int stateIdx = 0; stateIdx < numPartlyFinishedTaskStates; ++stateIdx) {
+            OperatorState taskState = new OperatorState(new OperatorID(), numSubtasksPerTask, 128);
+            randomlySetCoordinatorState(taskState, random);
+            randomlySetSubtaskState(
+                    taskState,
+                    IntStream.range(0, numSubtasksPerTask / 2).toArray(),
+                    random,
+                    basePath);
+            IntStream.range(numSubtasksPerTask / 2, numSubtasksPerTask)
+                    .forEach(
+                            index ->
+                                    taskState.putState(
+                                            index, FinishedOperatorSubtaskState.INSTANCE));
+            taskStates.add(taskState);
+        }
+
+        for (int stateIdx = 0; stateIdx < numFullyFinishedTaskStates; ++stateIdx) {
             taskStates.add(
                     new FullyFinishedOperatorState(new OperatorID(), numSubtasksPerTask, 128));
         }
 
-        for (int stateIdx = numFinishedTaskStates; stateIdx < numTaskStates; ++stateIdx) {
-
-            OperatorState taskState = new OperatorState(new OperatorID(), numSubtasksPerTask, 128);
-
-            final boolean hasCoordinatorState = random.nextBoolean();
-            if (hasCoordinatorState) {
-                final ByteStreamStateHandle stateHandle =
-                        createDummyByteStreamStreamStateHandle(random);
-                taskState.setCoordinatorState(stateHandle);
-            }
-
-            boolean hasOperatorStateBackend = random.nextBoolean();
-            boolean hasOperatorStateStream = random.nextBoolean();
-
-            boolean hasKeyedBackend = random.nextInt(4) != 0;
-            boolean hasKeyedStream = random.nextInt(4) != 0;
-            boolean isIncremental = random.nextInt(3) == 0;
-
-            for (int subtaskIdx = 0; subtaskIdx < numSubtasksPerTask; subtaskIdx++) {
-
-                StreamStateHandle operatorStateBackend =
-                        new ByteStreamStateHandle(
-                                "b", ("Beautiful").getBytes(ConfigConstants.DEFAULT_CHARSET));
-                StreamStateHandle operatorStateStream =
-                        new ByteStreamStateHandle(
-                                "b", ("Beautiful").getBytes(ConfigConstants.DEFAULT_CHARSET));
-
-                Map<String, OperatorStateHandle.StateMetaInfo> offsetsMap = new HashMap<>();
-                offsetsMap.put(
-                        "A",
-                        new OperatorStateHandle.StateMetaInfo(
-                                new long[] {0, 10, 20}, OperatorStateHandle.Mode.SPLIT_DISTRIBUTE));
-                offsetsMap.put(
-                        "B",
-                        new OperatorStateHandle.StateMetaInfo(
-                                new long[] {30, 40, 50},
-                                OperatorStateHandle.Mode.SPLIT_DISTRIBUTE));
-                offsetsMap.put(
-                        "C",
-                        new OperatorStateHandle.StateMetaInfo(
-                                new long[] {60, 70, 80}, OperatorStateHandle.Mode.UNION));
-
-                final OperatorSubtaskState.Builder state = OperatorSubtaskState.builder();
-                if (hasOperatorStateBackend) {
-                    state.setManagedOperatorState(
-                            new OperatorStreamStateHandle(offsetsMap, operatorStateBackend));
-                }
-
-                if (hasOperatorStateStream) {
-                    state.setRawOperatorState(
-                            new OperatorStreamStateHandle(offsetsMap, operatorStateStream));
-                }
-
-                if (hasKeyedBackend) {
-                    final KeyedStateHandle stateHandle;
-                    if (isSavepoint(basePath)) {
-                        stateHandle = createDummyKeyGroupSavepointStateHandle(random, basePath);
-                    } else if (isIncremental) {
-                        stateHandle = createDummyIncrementalKeyedStateHandle(random);
-                    } else {
-                        stateHandle = createDummyKeyGroupStateHandle(random, null);
-                    }
-                    state.setRawKeyedState(stateHandle);
-                }
-
-                if (hasKeyedStream) {
-                    final KeyedStateHandle stateHandle;
-                    if (isSavepoint(basePath)) {
-                        stateHandle = createDummyKeyGroupSavepointStateHandle(random, basePath);
-                    } else {
-                        stateHandle = createDummyKeyGroupStateHandle(random, null);
-                    }
-                    state.setManagedKeyedState(stateHandle);
-                }
-
-                state.setInputChannelState(
-                        (random.nextBoolean() && !isSavepoint(basePath))
-                                ? singleton(
-                                        createNewInputChannelStateHandle(random.nextInt(5), random))
-                                : empty());
-                state.setResultSubpartitionState(
-                        (random.nextBoolean() && !isSavepoint(basePath))
-                                ? singleton(
-                                        createNewResultSubpartitionStateHandle(
-                                                random.nextInt(5), random))
-                                : empty());
-
-                taskState.putState(subtaskIdx, state.build());
-            }
-
-            taskStates.add(taskState);
-        }
-
         return taskStates;
+    }
+
+    private static void randomlySetCoordinatorState(OperatorState taskState, Random random) {
+        final boolean hasCoordinatorState = random.nextBoolean();
+        if (hasCoordinatorState) {
+            final ByteStreamStateHandle stateHandle =
+                    createDummyByteStreamStreamStateHandle(random);
+            taskState.setCoordinatorState(stateHandle);
+        }
+    }
+
+    private static void randomlySetSubtaskState(
+            OperatorState taskState, int[] subtasksToSet, Random random, String basePath) {
+        boolean hasOperatorStateBackend = random.nextBoolean();
+        boolean hasOperatorStateStream = random.nextBoolean();
+
+        boolean hasKeyedBackend = random.nextInt(4) != 0;
+        boolean hasKeyedStream = random.nextInt(4) != 0;
+        boolean isIncremental = random.nextInt(3) == 0;
+
+        for (int subtaskIdx : subtasksToSet) {
+            StreamStateHandle operatorStateBackend =
+                    new ByteStreamStateHandle(
+                            "b", ("Beautiful").getBytes(ConfigConstants.DEFAULT_CHARSET));
+            StreamStateHandle operatorStateStream =
+                    new ByteStreamStateHandle(
+                            "b", ("Beautiful").getBytes(ConfigConstants.DEFAULT_CHARSET));
+
+            Map<String, OperatorStateHandle.StateMetaInfo> offsetsMap = new HashMap<>();
+            offsetsMap.put(
+                    "A",
+                    new OperatorStateHandle.StateMetaInfo(
+                            new long[] {0, 10, 20}, OperatorStateHandle.Mode.SPLIT_DISTRIBUTE));
+            offsetsMap.put(
+                    "B",
+                    new OperatorStateHandle.StateMetaInfo(
+                            new long[] {30, 40, 50}, OperatorStateHandle.Mode.SPLIT_DISTRIBUTE));
+            offsetsMap.put(
+                    "C",
+                    new OperatorStateHandle.StateMetaInfo(
+                            new long[] {60, 70, 80}, OperatorStateHandle.Mode.UNION));
+
+            final OperatorSubtaskState.Builder state = OperatorSubtaskState.builder();
+            if (hasOperatorStateBackend) {
+                state.setManagedOperatorState(
+                        new OperatorStreamStateHandle(offsetsMap, operatorStateBackend));
+            }
+
+            if (hasOperatorStateStream) {
+                state.setRawOperatorState(
+                        new OperatorStreamStateHandle(offsetsMap, operatorStateStream));
+            }
+
+            if (hasKeyedBackend) {
+                final KeyedStateHandle stateHandle;
+                if (isSavepoint(basePath)) {
+                    stateHandle = createDummyKeyGroupSavepointStateHandle(random, basePath);
+                } else if (isIncremental) {
+                    stateHandle = createDummyIncrementalKeyedStateHandle(random);
+                } else {
+                    stateHandle = createDummyKeyGroupStateHandle(random, null);
+                }
+                state.setRawKeyedState(stateHandle);
+            }
+
+            if (hasKeyedStream) {
+                final KeyedStateHandle stateHandle;
+                if (isSavepoint(basePath)) {
+                    stateHandle = createDummyKeyGroupSavepointStateHandle(random, basePath);
+                } else {
+                    stateHandle = createDummyKeyGroupStateHandle(random, null);
+                }
+                state.setManagedKeyedState(stateHandle);
+            }
+
+            state.setInputChannelState(
+                    (random.nextBoolean() && !isSavepoint(basePath))
+                            ? singleton(createNewInputChannelStateHandle(random.nextInt(5), random))
+                            : empty());
+            state.setResultSubpartitionState(
+                    (random.nextBoolean() && !isSavepoint(basePath))
+                            ? singleton(
+                                    createNewResultSubpartitionStateHandle(
+                                            random.nextInt(5), random))
+                            : empty());
+
+            taskState.putState(subtaskIdx, state.build());
+        }
     }
 
     private static boolean isSavepoint(String basePath) {

--- a/flink-runtime/src/test/java/org/apache/flink/runtime/checkpoint/metadata/MetadataV3SerializerTest.java
+++ b/flink-runtime/src/test/java/org/apache/flink/runtime/checkpoint/metadata/MetadataV3SerializerTest.java
@@ -110,7 +110,7 @@ public class MetadataV3SerializerTest {
             final int numSubtasks = rnd.nextInt(maxNumSubtasks) + 1;
             final Collection<OperatorState> taskStates =
                     CheckpointTestUtils.createOperatorStates(
-                            rnd, basePath, numTasks, 0, numSubtasks);
+                            rnd, basePath, numTasks, 0, 0, numSubtasks);
 
             final Collection<MasterState> masterStates = Collections.emptyList();
 
@@ -142,7 +142,7 @@ public class MetadataV3SerializerTest {
             final int numSubtasks = rnd.nextInt(maxNumSubtasks) + 1;
             final Collection<OperatorState> taskStates =
                     CheckpointTestUtils.createOperatorStates(
-                            rnd, basePath, numTasks, 0, numSubtasks);
+                            rnd, basePath, numTasks, 0, 0, numSubtasks);
 
             final int numMasterStates = rnd.nextInt(maxNumMasterStates) + 1;
             final Collection<MasterState> masterStates =
@@ -166,18 +166,26 @@ public class MetadataV3SerializerTest {
         final Random rnd = new Random();
 
         final int maxNumMasterStates = 5;
-        final int maxTaskStates = 20;
         final int maxNumSubtasks = 20;
-        final int maxFinishedSubtasks = 10;
+
+        final int maxAllRunningTaskStates = 20;
+        final int maxPartlyFinishedStates = 10;
+        final int maxFullyFinishedSubtasks = 10;
 
         final long checkpointId = rnd.nextLong() & 0x7fffffffffffffffL;
 
-        final int numTasks = rnd.nextInt(maxTaskStates) + 1;
         final int numSubtasks = rnd.nextInt(maxNumSubtasks) + 1;
-        final int numFinished = rnd.nextInt(maxFinishedSubtasks) + 1;
+        final int numAllRunningTasks = rnd.nextInt(maxAllRunningTaskStates) + 1;
+        final int numPartlyFinishedTasks = rnd.nextInt(maxPartlyFinishedStates) + 1;
+        final int numFullyFinishedTasks = rnd.nextInt(maxFullyFinishedSubtasks) + 1;
         final Collection<OperatorState> taskStates =
                 CheckpointTestUtils.createOperatorStates(
-                        rnd, basePath, numTasks, numFinished, numSubtasks);
+                        rnd,
+                        basePath,
+                        numAllRunningTasks,
+                        numPartlyFinishedTasks,
+                        numFullyFinishedTasks,
+                        numSubtasks);
 
         final int numMasterStates = rnd.nextInt(maxNumMasterStates) + 1;
         final Collection<MasterState> masterStates =


### PR DESCRIPTION
## What is the purpose of the change

This PR checks the illegal modification when restoring from a checkpoint with partly-finished operators.

**Bookkeeper the finished task state** 

To implement this PR, we need first store the subtask finished state in the checkpoint. We could not directly use null state as flags of finished, since it could not distinguish the finished one with the operators without state and do not chained with other stateful operators. Another possible options might be let task always report an empty state, but we might not want to affect the normal checkpoints without the finished tasks.

The current implementation stores an explicit flag for the finished tasks, but it seems both of the two options is ok to me. 

**Check the illegal modification**

The check is mainly to avoid that for keyed state, after some tasks finished and the corresponding keyed state is discarded, the topology is modified and a new predecessor is added and re-emitted the records with the discarded keys. The currently logic is that:

1. The predecessors of a fully finished vertex must also be fully finished.
2. The predecessors of a partly finished vertex connected via ALL_TO_ALL edges must be fully finished if the vertex is partly finished.
3. The predecessors of a partly finished vertex connected via POINTWISE edges must be partly finished or fully finished if the vertex is partly finished.

The logic of the check is to ensure:
1. If there is no change and only rescaling, the check must be passed.
2. If there are changes to the topology that causes records to the discarded keys, it must be forbid. But the forbidden operations might not indeed cause records to the discarded keys. 

Currently there is only one bad case is that for a graph composed of `source1 -> forward() -> map1` and `source2 -> forword with key -> map2[with keyed state]` and `source2` and `map2` are connected via `DataStreamUtils#reinterpretAsKeyedStream()`, and after all the vertices become partly finished, users create a new graph with `source1 -> forward with key -> map2[with keyed state]`. It is not very easy to judge this situation, however, in considering the probability of this case is extremely low and the API is only for sophisticated users, perhaps we could first only tip this in the document. 

## Brief change log

- e4992b55912beb45273b8555393bbd9709eb7529 including the finished flag for the finished subtask in the checkpoint.
- cafe182574694b1f708cb9e8318fd54d4ef5ce9f checks for the illegal modification when restoring with partly-finished state.


## Verifying this change

This change added tests and can be verified with the added UT.

## Does this pull request potentially affect one of the following parts:

  - Dependencies (does it add or upgrade a dependency): **no**
  - The public API, i.e., is any changed class annotated with `@Public(Evolving)`: **no**
  - The serializers: **no**
  - The runtime per-record code paths (performance sensitive): **no**
  - Anything that affects deployment or recovery: JobManager (and its components), Checkpointing, Kubernetes/Yarn, ZooKeeper: **yes**
  - The S3 file system connector: **no**

## Documentation

  - Does this pull request introduce a new feature? **no**
  - If yes, how is the feature documented? **not applicable**