### PR TITLE
Revert "[FLINK-22054][dist] Suppress the verbose log in kubernetes in…

### DIFF
--- a/flink-dist/src/main/flink-bin/conf/log4j-console.properties
+++ b/flink-dist/src/main/flink-bin/conf/log4j-console.properties
@@ -66,7 +66,3 @@ appender.rolling.strategy.max = ${env:MAX_LOG_FILE_NUMBER:-10}
 # Suppress the irrelevant (wrong) warnings from the Netty channel handler
 logger.netty.name = org.jboss.netty.channel.DefaultChannelPipeline
 logger.netty.level = OFF
-
-# Suppress the verbose log in kubernetes informer
-logger.kube.name = io.fabric8.kubernetes.client.informers.cache.ReflectorWatcher
-logger.kube.level = ERROR

--- a/flink-dist/src/main/flink-bin/conf/log4j-session.properties
+++ b/flink-dist/src/main/flink-bin/conf/log4j-session.properties
@@ -40,7 +40,3 @@ logger.runtimeutils.name= org.apache.flink.runtime.util.ZooKeeperUtils
 logger.runtimeutils.level = WARN
 logger.runtimeleader.name = org.apache.flink.runtime.leaderretrieval.ZooKeeperLeaderRetrievalDriver
 logger.runtimeleader.level = WARN
-
-# Suppress the verbose log in kubernetes informer
-logger.kube.name = io.fabric8.kubernetes.client.informers.cache.ReflectorWatcher
-logger.kube.level = ERROR

--- a/flink-dist/src/main/flink-bin/conf/log4j.properties
+++ b/flink-dist/src/main/flink-bin/conf/log4j.properties
@@ -59,7 +59,3 @@ appender.main.strategy.max = ${env:MAX_LOG_FILE_NUMBER:-10}
 # Suppress the irrelevant (wrong) warnings from the Netty channel handler
 logger.netty.name = org.jboss.netty.channel.DefaultChannelPipeline
 logger.netty.level = OFF
-
-# Suppress the verbose log in kubernetes informer
-logger.kube.name = io.fabric8.kubernetes.client.informers.cache.ReflectorWatcher
-logger.kube.level = ERROR

--- a/flink-dist/src/main/flink-bin/conf/logback-console.xml
+++ b/flink-dist/src/main/flink-bin/conf/logback-console.xml
@@ -61,7 +61,4 @@
 
     <!-- Suppress the irrelevant (wrong) warnings from the Netty channel handler -->
     <logger name="org.jboss.netty.channel.DefaultChannelPipeline" level="ERROR"/>
-
-    <!-- Suppress the verbose log in kubernetes informer -->
-    <logger name="io.fabric8.kubernetes.client.informers.cache.ReflectorWatcher" level="ERROR"/>
 </configuration>

--- a/flink-dist/src/main/flink-bin/conf/logback-session.xml
+++ b/flink-dist/src/main/flink-bin/conf/logback-session.xml
@@ -36,10 +36,4 @@
         <appender-ref ref="file"/>
         <appender-ref ref="console"/>
     </root>
-
-    <!-- Suppress the verbose log in kubernetes informer -->
-    <logger name="io.fabric8.kubernetes.client.informers.cache.ReflectorWatcher" level="ERROR">
-        <appender-ref ref="file"/>
-        <appender-ref ref="console"/>
-    </logger>
 </configuration>

--- a/flink-dist/src/main/flink-bin/conf/logback.xml
+++ b/flink-dist/src/main/flink-bin/conf/logback.xml
@@ -55,10 +55,4 @@
     <logger name="org.jboss.netty.channel.DefaultChannelPipeline" level="ERROR">
         <appender-ref ref="file"/>
     </logger>
-
-    <!-- Suppress the verbose log in kubernetes informer -->
-    <logger name="io.fabric8.kubernetes.client.informers.cache.ReflectorWatcher" level="ERROR">
-        <appender-ref ref="file"/>
-    </logger>
-
 </configuration>


### PR DESCRIPTION
…former"

In FLINK-22802, the fabric8 Kubernetes client has been upgraded to 5.5.0,
the verbose log level has been changed to Debug, so we don't need to
suppress it manually.

This reverts commit dfb4c003c84df6c4e3bf37dd506a0061fd3228f2.
