### PR TITLE
[FLINK-22912][python] Support state ttl in Python DataStream API

### DIFF
--- a/docs/content.zh/docs/dev/datastream/fault-tolerance/state.md
+++ b/docs/content.zh/docs/dev/datastream/fault-tolerance/state.md
@@ -342,6 +342,22 @@ val stateDescriptor = new ValueStateDescriptor[String]("text state", classOf[Str
 stateDescriptor.enableTimeToLive(ttlConfig)
 ```
 {{< /tab >}}
+{{< tab "Python" >}}
+```python
+from pyflink.common.time import Time
+from pyflink.common.typeinfo import Types
+from pyflink.datastream.state import ValueStateDescriptor, StateTtlConfig
+
+ttl_config = StateTtlConfig \
+  .new_builder(Time.seconds(1)) \
+  .set_update_type(StateTtlConfig.UpdateType.OnCreateAndWrite) \
+  .set_state_visibility(StateTtlConfig.StateVisibility.NeverReturnExpired) \
+  .build()
+
+state_descriptor = ValueStateDescriptor("text state", Types.STRING())
+state_descriptor.enable_time_to_live(ttl_config)
+```
+{{< /tab >}}
 {{< /tabs >}}
 
 TTL 配置有以下几个选项：
@@ -404,7 +420,13 @@ val ttlConfig = StateTtlConfig
 {{< /tab >}}
 {{< tab "Python" >}}
 ```python
-State TTL 当前在 PyFlink DataStream API 中还不支持。
+from pyflink.common.time import Time
+from pyflink.datastream.state import StateTtlConfig
+
+ttl_config = StateTtlConfig \
+  .new_builder(Time.seconds(1)) \
+  .disable_cleanup_in_background() \
+  .build()
 ```
 {{< /tab >}}
 {{< /tabs >}}
@@ -441,7 +463,13 @@ val ttlConfig = StateTtlConfig
 {{< /tab >}}
 {{< tab "Python" >}}
 ```python
-State TTL 当前在 PyFlink DataStream API 中还不支持。
+from pyflink.common.time import Time
+from pyflink.datastream.state import StateTtlConfig
+
+ttl_config = StateTtlConfig \
+  .new_builder(Time.seconds(1)) \
+  .cleanup_full_snapshot() \
+  .build()
 ```
 {{< /tab >}}
 {{< /tabs >}}
@@ -479,7 +507,13 @@ val ttlConfig = StateTtlConfig
 {{< /tab >}}
 {{< tab "Python" >}}
 ```python
-State TTL 当前在 PyFlink DataStream API 中还不支持。
+from pyflink.common.time import Time
+from pyflink.datastream.state import StateTtlConfig
+
+ttl_config = StateTtlConfig \
+  .new_builder(Time.seconds(1)) \
+  .cleanup_incrementally(10, True) \
+  .build()
 ```
 {{< /tab >}}
 {{< /tabs >}}
@@ -524,7 +558,13 @@ val ttlConfig = StateTtlConfig
 {{< /tab >}}
 {{< tab "Python" >}}
 ```python
-State TTL 当前在 PyFlink DataStream API 中还不支持。
+from pyflink.common.time import Time
+from pyflink.datastream.state import StateTtlConfig
+
+ttl_config = StateTtlConfig \
+  .new_builder(Time.seconds(1)) \
+  .cleanup_in_rocksdb_compact_filter(1000) \
+  .build()
 ```
 {{< /tab >}}
 {{< /tabs >}}

--- a/docs/content/docs/dev/datastream/fault-tolerance/state.md
+++ b/docs/content/docs/dev/datastream/fault-tolerance/state.md
@@ -369,6 +369,22 @@ val stateDescriptor = new ValueStateDescriptor[String]("text state", classOf[Str
 stateDescriptor.enableTimeToLive(ttlConfig)
 ```
 {{< /tab >}}
+{{< tab "Python" >}}
+```python
+from pyflink.common.time import Time
+from pyflink.common.typeinfo import Types
+from pyflink.datastream.state import ValueStateDescriptor, StateTtlConfig
+
+ttl_config = StateTtlConfig \
+  .new_builder(Time.seconds(1)) \
+  .set_update_type(StateTtlConfig.UpdateType.OnCreateAndWrite) \
+  .set_state_visibility(StateTtlConfig.StateVisibility.NeverReturnExpired) \
+  .build()
+
+state_descriptor = ValueStateDescriptor("text state", Types.STRING())
+state_descriptor.enable_time_to_live(ttl_config)
+```
+{{< /tab >}}
 {{< /tabs >}}
 
 The configuration has several options to consider:
@@ -438,7 +454,13 @@ val ttlConfig = StateTtlConfig
 {{< /tab >}}
 {{< tab "Python" >}}
 ```python
-State TTL is still not supported in PyFlink DataStream API.
+from pyflink.common.time import Time
+from pyflink.datastream.state import StateTtlConfig
+
+ttl_config = StateTtlConfig \
+  .new_builder(Time.seconds(1)) \
+  .disable_cleanup_in_background() \
+  .build()
 ```
 {{< /tab >}}
 {{< /tabs >}}
@@ -478,7 +500,13 @@ val ttlConfig = StateTtlConfig
 {{< /tab >}}
 {{< tab "Python" >}}
 ```python
-State TTL is still not supported in PyFlink DataStream API.
+from pyflink.common.time import Time
+from pyflink.datastream.state import StateTtlConfig
+
+ttl_config = StateTtlConfig \
+  .new_builder(Time.seconds(1)) \
+  .cleanup_full_snapshot() \
+  .build()
 ```
 {{< /tab >}}
 {{< /tabs >}}
@@ -522,7 +550,13 @@ val ttlConfig = StateTtlConfig
 {{< /tab >}}
 {{< tab "Python" >}}
 ```python
-State TTL is still not supported in PyFlink DataStream API.
+from pyflink.common.time import Time
+from pyflink.datastream.state import StateTtlConfig
+
+ttl_config = StateTtlConfig \
+  .new_builder(Time.seconds(1)) \
+  .cleanup_incrementally(10, True) \
+  .build()
 ```
 {{< /tab >}}
 {{< /tabs >}}
@@ -574,7 +608,13 @@ val ttlConfig = StateTtlConfig
 {{< /tab >}}
 {{< tab "Python" >}}
 ```python
-State TTL is still not supported in PyFlink DataStream API.
+from pyflink.common.time import Time
+from pyflink.datastream.state import StateTtlConfig
+
+ttl_config = StateTtlConfig \
+  .new_builder(Time.seconds(1)) \
+  .cleanup_in_rocksdb_compact_filter(1000) \
+  .build()
 ```
 {{< /tab >}}
 {{< /tabs >}}

--- a/flink-python/pyflink/common/__init__.py
+++ b/flink-python/pyflink/common/__init__.py
@@ -35,7 +35,7 @@ from pyflink.common.job_status import JobStatus
 from pyflink.common.restart_strategy import RestartStrategies, RestartStrategyConfiguration
 from pyflink.common.typeinfo import Types, TypeInformation
 from pyflink.common.types import Row, RowKind
-from pyflink.common.time import Duration, Instant
+from pyflink.common.time import Duration, Instant, Time
 from pyflink.common.watermark_strategy import WatermarkStrategy
 
 __all__ = [
@@ -59,4 +59,5 @@ __all__ = [
     "Types",
     "TypeInformation",
     "Instant",
+    "Time"
 ]

--- a/flink-python/pyflink/common/time.py
+++ b/flink-python/pyflink/common/time.py
@@ -17,7 +17,7 @@
 ################################################################################
 from pyflink.java_gateway import get_gateway
 
-__all__ = ['Duration', 'Instant']
+__all__ = ['Duration', 'Instant', 'Time']
 
 
 class Duration(object):
@@ -83,3 +83,42 @@ class Instant(object):
 
     def __repr__(self):
         return 'Instant<{}, {}>'.format(self.seconds, self.nanos)
+
+
+class Time(object):
+    """
+    The definition of a time interval.
+    """
+
+    def __init__(self, milliseconds: int):
+        self._milliseconds = milliseconds
+
+    def to_milliseconds(self) -> int:
+        return self._milliseconds
+
+    @staticmethod
+    def milliseconds(milliseconds: int):
+        return Time(milliseconds)
+
+    @staticmethod
+    def seconds(seconds: int):
+        return Time.milliseconds(seconds * 1000)
+
+    @staticmethod
+    def minutes(minutes: int):
+        return Time.seconds(minutes * 60)
+
+    @staticmethod
+    def hours(hours: int):
+        return Time.minutes(hours * 60)
+
+    @staticmethod
+    def days(days: int):
+        return Time.hours(days * 24)
+
+    def __eq__(self, other):
+        return (self.__class__ == other.__class__ and
+                self._milliseconds == other._milliseconds)
+
+    def __str__(self):
+        return "{} ms".format(self._milliseconds)

--- a/flink-python/pyflink/datastream/state.py
+++ b/flink-python/pyflink/datastream/state.py
@@ -443,22 +443,13 @@ class StateTtlConfig(object):
 
         def _to_proto(self):
             from pyflink.fn_execution.flink_fn_execution_pb2 import StateDescriptor
-            if self.value == StateTtlConfig.UpdateType.Disabled.value:
-                return StateDescriptor.StateTTLConfig.UpdateType.Disabled
-            elif self.value == StateTtlConfig.UpdateType.OnCreateAndWrite.value:
-                return StateDescriptor.StateTTLConfig.UpdateType.OnCreateAndWrite
-            else:
-                return StateDescriptor.StateTTLConfig.UpdateType.OnReadAndWrite
+            return getattr(StateDescriptor.StateTTLConfig.UpdateType, self.name)
 
         @staticmethod
         def _from_proto(proto):
             from pyflink.fn_execution.flink_fn_execution_pb2 import StateDescriptor
-            if proto == StateDescriptor.StateTTLConfig.UpdateType.Disabled:
-                return StateTtlConfig.UpdateType.Disabled
-            elif proto == StateDescriptor.StateTTLConfig.UpdateType.OnCreateAndWrite:
-                return StateTtlConfig.UpdateType.OnCreateAndWrite
-            else:
-                return StateTtlConfig.UpdateType.OnReadAndWrite
+            update_type_name = StateDescriptor.StateTTLConfig.UpdateType.Name(proto)
+            return StateTtlConfig.UpdateType[update_type_name]
 
     class StateVisibility(Enum):
         """
@@ -477,18 +468,13 @@ class StateTtlConfig(object):
 
         def _to_proto(self):
             from pyflink.fn_execution.flink_fn_execution_pb2 import StateDescriptor
-            if self.value == StateTtlConfig.StateVisibility.ReturnExpiredIfNotCleanedUp.value:
-                return StateDescriptor.StateTTLConfig.StateVisibility.ReturnExpiredIfNotCleanedUp
-            elif self.value == StateTtlConfig.StateVisibility.NeverReturnExpired.value:
-                return StateDescriptor.StateTTLConfig.StateVisibility.NeverReturnExpired
+            return getattr(StateDescriptor.StateTTLConfig.StateVisibility, self.name)
 
         @staticmethod
         def _from_proto(proto):
             from pyflink.fn_execution.flink_fn_execution_pb2 import StateDescriptor
-            if proto == StateDescriptor.StateTTLConfig.StateVisibility.ReturnExpiredIfNotCleanedUp:
-                return StateTtlConfig.StateVisibility.ReturnExpiredIfNotCleanedUp
-            elif proto == StateDescriptor.StateTTLConfig.StateVisibility.NeverReturnExpired:
-                return StateTtlConfig.StateVisibility.NeverReturnExpired
+            state_visibility_name = StateDescriptor.StateTTLConfig.StateVisibility.Name(proto)
+            return StateTtlConfig.StateVisibility[state_visibility_name]
 
     class TtlTimeCharacteristic(Enum):
         """
@@ -502,11 +488,14 @@ class StateTtlConfig(object):
 
         def _to_proto(self):
             from pyflink.fn_execution.flink_fn_execution_pb2 import StateDescriptor
-            return StateDescriptor.StateTTLConfig.TtlTimeCharacteristic.ProcessingTime
+            return getattr(StateDescriptor.StateTTLConfig.TtlTimeCharacteristic, self.name)
 
         @staticmethod
         def _from_proto(proto):
-            return StateTtlConfig.TtlTimeCharacteristic.ProcessingTime
+            from pyflink.fn_execution.flink_fn_execution_pb2 import StateDescriptor
+            ttl_time_characteristic_name = \
+                StateDescriptor.StateTTLConfig.TtlTimeCharacteristic.Name(proto)
+            return StateTtlConfig.TtlTimeCharacteristic[ttl_time_characteristic_name]
 
     def __init__(self,
                  update_type: UpdateType,
@@ -764,26 +753,15 @@ class StateTtlConfig(object):
 
             def _to_proto(self):
                 from pyflink.fn_execution.flink_fn_execution_pb2 import StateDescriptor
-                Strategies = StateTtlConfig.CleanupStrategies.Strategies
-                DescriptorStrategies = StateDescriptor.StateTTLConfig.CleanupStrategies.Strategies
-                if self.value == Strategies.FULL_STATE_SCAN_SNAPSHOT.value:
-                    return DescriptorStrategies.FULL_STATE_SCAN_SNAPSHOT
-                elif self.value == Strategies.INCREMENTAL_CLEANUP.value:
-                    return DescriptorStrategies.INCREMENTAL_CLEANUP
-                else:
-                    return DescriptorStrategies.ROCKSDB_COMPACTION_FILTER
+                return getattr(
+                    StateDescriptor.StateTTLConfig.CleanupStrategies.Strategies, self.name)
 
             @staticmethod
             def _from_proto(proto):
                 from pyflink.fn_execution.flink_fn_execution_pb2 import StateDescriptor
-                Strategies = StateTtlConfig.CleanupStrategies.Strategies
-                DescriptorStrategies = StateDescriptor.StateTTLConfig.CleanupStrategies.Strategies
-                if proto == DescriptorStrategies.FULL_STATE_SCAN_SNAPSHOT:
-                    return Strategies.FULL_STATE_SCAN_SNAPSHOT
-                elif proto == DescriptorStrategies.INCREMENTAL_CLEANUP:
-                    return Strategies.INCREMENTAL_CLEANUP
-                else:
-                    return Strategies.ROCKSDB_COMPACTION_FILTER
+                strategies_name = \
+                    StateDescriptor.StateTTLConfig.CleanupStrategies.Strategies.Name(proto)
+                return StateTtlConfig.CleanupStrategies.Strategies[strategies_name]
 
         class CleanupStrategy(ABC):
             """
@@ -842,7 +820,7 @@ class StateTtlConfig(object):
                     StateTtlConfig.CleanupStrategies.IncrementalCleanupStrategy(5, False)
             else:
                 default_strategy = None
-            return self._strategies.get(    # type: ignore
+            return self._strategies.get(  # type: ignore
                 StateTtlConfig.CleanupStrategies.Strategies.INCREMENTAL_CLEANUP,
                 default_strategy)
 
@@ -853,7 +831,7 @@ class StateTtlConfig(object):
                     StateTtlConfig.CleanupStrategies.RocksdbCompactFilterCleanupStrategy(1000)
             else:
                 default_strategy = None
-            return self._strategies.get(    # type: ignore
+            return self._strategies.get(  # type: ignore
                 StateTtlConfig.CleanupStrategies.Strategies.ROCKSDB_COMPACTION_FILTER,
                 default_strategy)
 

--- a/flink-python/pyflink/datastream/state.py
+++ b/flink-python/pyflink/datastream/state.py
@@ -16,10 +16,12 @@
 # limitations under the License.
 ################################################################################
 from abc import ABC, abstractmethod
+from enum import Enum
 
-from typing import TypeVar, Generic, Iterable, List, Iterator, Dict, Tuple
+from typing import TypeVar, Generic, Iterable, List, Iterator, Dict, Tuple, Optional
 
 from pyflink.common.typeinfo import TypeInformation, Types
+from pyflink.common.time import Time
 
 __all__ = [
     'ValueStateDescriptor',
@@ -31,7 +33,8 @@ __all__ = [
     'ReducingStateDescriptor',
     'ReducingState',
     'AggregatingStateDescriptor',
-    'AggregatingState'
+    'AggregatingState',
+    'StateTtlConfig'
 ]
 
 T = TypeVar('T')
@@ -293,6 +296,7 @@ class StateDescriptor(ABC):
         """
         self.name = name
         self.type_info = type_info
+        self._ttl_config = None  # type: Optional[StateTtlConfig]
 
     def get_name(self) -> str:
         """
@@ -301,6 +305,17 @@ class StateDescriptor(ABC):
         :return: The name of the state.
         """
         return self.name
+
+    def enable_time_to_live(self, ttl_config: 'StateTtlConfig'):
+        """
+        Configures optional activation of state time-to-live (TTL).
+
+        State user value will expire, become unavailable and be cleaned up in storage depending on
+        configured StateTtlConfig.
+
+        :param ttl_config: Configuration of state TTL
+        """
+        self._ttl_config = ttl_config
 
 
 class ValueStateDescriptor(StateDescriptor):
@@ -402,3 +417,494 @@ class AggregatingStateDescriptor(StateDescriptor):
 
     def get_agg_function(self):
         return self._agg_function
+
+
+class StateTtlConfig(object):
+    class UpdateType(Enum):
+        """
+        This option value configures when to update last access timestamp which prolongs state TTL.
+        """
+
+        Disabled = 0
+        """
+        TTL is disabled. State does not expire.
+        """
+
+        OnCreateAndWrite = 1
+        """
+        Last access timestamp is initialised when state is created and updated on every write
+        operation.
+        """
+
+        OnReadAndWrite = 2
+        """
+        The same as OnCreateAndWrite but also updated on read.
+        """
+
+        def _to_proto(self):
+            from pyflink.fn_execution.flink_fn_execution_pb2 import StateDescriptor
+            if self.value == StateTtlConfig.UpdateType.Disabled.value:
+                return StateDescriptor.StateTTLConfig.UpdateType.Disabled
+            elif self.value == StateTtlConfig.UpdateType.OnCreateAndWrite.value:
+                return StateDescriptor.StateTTLConfig.UpdateType.OnCreateAndWrite
+            else:
+                return StateDescriptor.StateTTLConfig.UpdateType.OnReadAndWrite
+
+        @staticmethod
+        def _from_proto(proto):
+            from pyflink.fn_execution.flink_fn_execution_pb2 import StateDescriptor
+            if proto == StateDescriptor.StateTTLConfig.UpdateType.Disabled:
+                return StateTtlConfig.UpdateType.Disabled
+            elif proto == StateDescriptor.StateTTLConfig.UpdateType.OnCreateAndWrite:
+                return StateTtlConfig.UpdateType.OnCreateAndWrite
+            else:
+                return StateTtlConfig.UpdateType.OnReadAndWrite
+
+    class StateVisibility(Enum):
+        """
+        This option configures whether expired user value can be returned or not.
+        """
+
+        ReturnExpiredIfNotCleanedUp = 0
+        """
+        Return expired user value if it is not cleaned up yet.
+        """
+
+        NeverReturnExpired = 1
+        """
+        Never return expired user value.
+        """
+
+        def _to_proto(self):
+            from pyflink.fn_execution.flink_fn_execution_pb2 import StateDescriptor
+            if self.value == StateTtlConfig.StateVisibility.ReturnExpiredIfNotCleanedUp.value:
+                return StateDescriptor.StateTTLConfig.StateVisibility.ReturnExpiredIfNotCleanedUp
+            elif self.value == StateTtlConfig.StateVisibility.NeverReturnExpired.value:
+                return StateDescriptor.StateTTLConfig.StateVisibility.NeverReturnExpired
+
+        @staticmethod
+        def _from_proto(proto):
+            from pyflink.fn_execution.flink_fn_execution_pb2 import StateDescriptor
+            if proto == StateDescriptor.StateTTLConfig.StateVisibility.ReturnExpiredIfNotCleanedUp:
+                return StateTtlConfig.StateVisibility.ReturnExpiredIfNotCleanedUp
+            elif proto == StateDescriptor.StateTTLConfig.StateVisibility.NeverReturnExpired:
+                return StateTtlConfig.StateVisibility.NeverReturnExpired
+
+    class TtlTimeCharacteristic(Enum):
+        """
+        This option configures time scale to use for ttl.
+        """
+
+        ProcessingTime = 0
+        """
+        Processing time
+        """
+
+        def _to_proto(self):
+            from pyflink.fn_execution.flink_fn_execution_pb2 import StateDescriptor
+            return StateDescriptor.StateTTLConfig.TtlTimeCharacteristic.ProcessingTime
+
+        @staticmethod
+        def _from_proto(proto):
+            return StateTtlConfig.TtlTimeCharacteristic.ProcessingTime
+
+    def __init__(self,
+                 update_type: UpdateType,
+                 state_visibility: StateVisibility,
+                 ttl_time_characteristic: TtlTimeCharacteristic,
+                 ttl: Time,
+                 cleanup_strategies: 'StateTtlConfig.CleanupStrategies'):
+        self._update_type = update_type
+        self._state_visibility = state_visibility
+        self._ttl_time_characteristic = ttl_time_characteristic
+        self._ttl = ttl
+        self._cleanup_strategies = cleanup_strategies
+
+    @staticmethod
+    def new_builder(ttl: Time):
+        return StateTtlConfig.Builder(ttl)
+
+    def get_update_type(self) -> 'StateTtlConfig.UpdateType':
+        return self._update_type
+
+    def get_state_visibility(self) -> 'StateTtlConfig.StateVisibility':
+        return self._state_visibility
+
+    def get_ttl(self) -> Time:
+        return self._ttl
+
+    def get_ttl_time_characteristic(self) -> 'StateTtlConfig.TtlTimeCharacteristic':
+        return self._ttl_time_characteristic
+
+    def is_enabled(self) -> bool:
+        return self._update_type.value != StateTtlConfig.UpdateType.Disabled.value
+
+    def get_cleanup_strategies(self) -> 'StateTtlConfig.CleanupStrategies':
+        return self._cleanup_strategies
+
+    def _to_proto(self):
+        from pyflink.fn_execution.flink_fn_execution_pb2 import StateDescriptor
+        state_ttl_config = StateDescriptor.StateTTLConfig()
+        state_ttl_config.update_type = self._update_type._to_proto()
+        state_ttl_config.state_visibility = self._state_visibility._to_proto()
+        state_ttl_config.ttl_time_characteristic = self._ttl_time_characteristic._to_proto()
+        state_ttl_config.ttl = self._ttl.to_milliseconds()
+        state_ttl_config.cleanup_strategies.CopyFrom(self._cleanup_strategies._to_proto())
+        return state_ttl_config
+
+    @staticmethod
+    def _from_proto(proto):
+        update_type = StateTtlConfig.UpdateType._from_proto(proto.update_type)
+        state_visibility = StateTtlConfig.StateVisibility._from_proto(proto.state_visibility)
+        ttl_time_characteristic = \
+            StateTtlConfig.TtlTimeCharacteristic._from_proto(proto.ttl_time_characteristic)
+        ttl = Time.milliseconds(proto.ttl)
+        cleanup_strategies = StateTtlConfig.CleanupStrategies._from_proto(proto.cleanup_strategies)
+        builder = StateTtlConfig.new_builder(ttl) \
+            .set_update_type(update_type) \
+            .set_state_visibility(state_visibility) \
+            .set_ttl_time_characteristic(ttl_time_characteristic)
+        builder._strategies = cleanup_strategies._strategies
+        builder._is_cleanup_in_background = cleanup_strategies._is_cleanup_in_background
+        return builder.build()
+
+    def __repr__(self):
+        return "StateTtlConfig<" \
+               "update_type={}," \
+               " state_visibility={}," \
+               "ttl_time_characteristic ={}," \
+               "ttl={}>".format(self._update_type,
+                                self._state_visibility,
+                                self._ttl_time_characteristic,
+                                self._ttl)
+
+    class Builder(object):
+        """
+        Builder for the StateTtlConfig.
+        """
+
+        def __init__(self, ttl: Time):
+            self._ttl = ttl
+            self._update_type = StateTtlConfig.UpdateType.OnCreateAndWrite
+            self._state_visibility = StateTtlConfig.StateVisibility.NeverReturnExpired
+            self._ttl_time_characteristic = StateTtlConfig.TtlTimeCharacteristic.ProcessingTime
+            self._is_cleanup_in_background = True
+            self._strategies = {}  # type: Dict
+
+        def set_update_type(self,
+                            update_type: 'StateTtlConfig.UpdateType') -> 'StateTtlConfig.Builder':
+            """
+            Sets the ttl update type.
+
+            :param update_type: The ttl update type configures when to update last access timestamp
+                which prolongs state TTL.
+            """
+            self._update_type = update_type
+            return self
+
+        def update_ttl_on_create_and_write(self) -> 'StateTtlConfig.Builder':
+            return self.set_update_type(StateTtlConfig.UpdateType.OnCreateAndWrite)
+
+        def update_ttl_on_read_and_write(self) -> 'StateTtlConfig.Builder':
+            return self.set_update_type(StateTtlConfig.UpdateType.OnReadAndWrite)
+
+        def set_state_visibility(
+                self,
+                state_visibility: 'StateTtlConfig.StateVisibility') -> 'StateTtlConfig.Builder':
+            """
+            Sets the state visibility.
+
+            :param state_visibility: The state visibility configures whether expired user value can
+                be returned or not.
+            """
+
+            self._state_visibility = state_visibility
+            return self
+
+        def return_expired_if_not_cleaned_up(self) -> 'StateTtlConfig.Builder':
+            return self.set_state_visibility(
+                StateTtlConfig.StateVisibility.ReturnExpiredIfNotCleanedUp)
+
+        def never_return_expired(self) -> 'StateTtlConfig.Builder':
+            return self.set_state_visibility(StateTtlConfig.StateVisibility.NeverReturnExpired)
+
+        def set_ttl_time_characteristic(
+                self,
+                ttl_time_characteristic: 'StateTtlConfig.TtlTimeCharacteristic') \
+                -> 'StateTtlConfig.Builder':
+            """
+            Sets the time characteristic.
+
+            :param ttl_time_characteristic: The time characteristic configures time scale to use for
+                ttl.
+            """
+            self._ttl_time_characteristic = ttl_time_characteristic
+            return self
+
+        def use_processing_time(self) -> 'StateTtlConfig.Builder':
+            return self.set_ttl_time_characteristic(
+                StateTtlConfig.TtlTimeCharacteristic.ProcessingTime)
+
+        def cleanup_full_snapshot(self) -> 'StateTtlConfig.Builder':
+            """
+            Cleanup expired state in full snapshot on checkpoint.
+            """
+            self._strategies[
+                StateTtlConfig.CleanupStrategies.Strategies.FULL_STATE_SCAN_SNAPSHOT] = \
+                StateTtlConfig.CleanupStrategies.EMPTY_STRATEGY
+            return self
+
+        def cleanup_incrementally(self,
+                                  cleanup_size: int,
+                                  run_cleanup_for_every_record) -> 'StateTtlConfig.Builder':
+            """
+            Cleanup expired state incrementally cleanup local state.
+
+            Upon every state access this cleanup strategy checks a bunch of state keys for
+            expiration and cleans up expired ones. It keeps a lazy iterator through all keys with
+            relaxed consistency if backend supports it. This way all keys should be regularly
+            checked and cleaned eventually over time if any state is constantly being accessed.
+
+            Additionally to the incremental cleanup upon state access, it can also run per every
+            record. Caution: if there are a lot of registered states using this option, they all
+            will be iterated for every record to check if there is something to cleanup.
+
+            if no access happens to this state or no records are processed in case of
+            run_cleanup_for_every_record, expired state will persist.
+
+            Time spent for the incremental cleanup increases record processing latency.
+
+            Note:
+
+            At the moment incremental cleanup is implemented only for Heap state backend.
+            Setting it for RocksDB will have no effect.
+
+            Note:
+
+            If heap state backend is used with synchronous snapshotting, the global iterator keeps a
+            copy of all keys while iterating because of its specific implementation which does not
+            support concurrent modifications. Enabling of this feature will increase memory
+            consumption then. Asynchronous snapshotting does not have this problem.
+
+            :param cleanup_size: max number of keys pulled from queue for clean up upon state touch
+                for any key
+            :param run_cleanup_for_every_record: run incremental cleanup per each processed record
+            """
+            self._strategies[StateTtlConfig.CleanupStrategies.Strategies.INCREMENTAL_CLEANUP] = \
+                StateTtlConfig.CleanupStrategies.IncrementalCleanupStrategy(
+                    cleanup_size, run_cleanup_for_every_record)
+            return self
+
+        def cleanup_in_rocksdb_compact_filter(
+                self,
+                query_time_after_num_entries) -> 'StateTtlConfig.Builder':
+            """
+            Cleanup expired state while Rocksdb compaction is running.
+
+            RocksDB compaction filter will query current timestamp, used to check expiration, from
+            Flink every time after processing {@code queryTimeAfterNumEntries} number of state
+            entries. Updating the timestamp more often can improve cleanup speed but it decreases
+            compaction performance because it uses JNI call from native code.
+
+            :param query_time_after_num_entries:  number of state entries to process by compaction
+                filter before updating current timestamp
+            :return:
+            """
+            self._strategies[
+                StateTtlConfig.CleanupStrategies.Strategies.ROCKSDB_COMPACTION_FILTER] = \
+                StateTtlConfig.CleanupStrategies.RocksdbCompactFilterCleanupStrategy(
+                    query_time_after_num_entries)
+            return self
+
+        def disable_cleanup_in_background(self) -> 'StateTtlConfig.Builder':
+            """
+            Disable default cleanup of expired state in background (enabled by default).
+
+            If some specific cleanup is configured, e.g. :func:`cleanup_incrementally` or
+            :func:`cleanup_in_rocksdb_compact_filter`, this setting does not disable it.
+            """
+            self._is_cleanup_in_background = False
+            return self
+
+        def set_ttl(self, ttl: Time) -> 'StateTtlConfig.Builder':
+            """
+            Sets the ttl time.
+
+            :param ttl: The ttl time.
+            """
+            self._ttl = ttl
+            return self
+
+        def build(self) -> 'StateTtlConfig':
+            return StateTtlConfig(
+                self._update_type,
+                self._state_visibility,
+                self._ttl_time_characteristic,
+                self._ttl,
+                StateTtlConfig.CleanupStrategies(self._strategies, self._is_cleanup_in_background)
+            )
+
+    class CleanupStrategies(object):
+        """
+        TTL cleanup strategies.
+
+        This class configures when to cleanup expired state with TTL. By default, state is always
+        cleaned up on explicit read access if found expired. Currently cleanup of state full
+        snapshot can be additionally activated.
+        """
+
+        class Strategies(Enum):
+            """
+            Fixed strategies ordinals in strategies config field.
+            """
+
+            FULL_STATE_SCAN_SNAPSHOT = 0
+            INCREMENTAL_CLEANUP = 1
+            ROCKSDB_COMPACTION_FILTER = 2
+
+            def _to_proto(self):
+                from pyflink.fn_execution.flink_fn_execution_pb2 import StateDescriptor
+                Strategies = StateTtlConfig.CleanupStrategies.Strategies
+                DescriptorStrategies = StateDescriptor.StateTTLConfig.CleanupStrategies.Strategies
+                if self.value == Strategies.FULL_STATE_SCAN_SNAPSHOT.value:
+                    return DescriptorStrategies.FULL_STATE_SCAN_SNAPSHOT
+                elif self.value == Strategies.INCREMENTAL_CLEANUP.value:
+                    return DescriptorStrategies.INCREMENTAL_CLEANUP
+                else:
+                    return DescriptorStrategies.ROCKSDB_COMPACTION_FILTER
+
+            @staticmethod
+            def _from_proto(proto):
+                from pyflink.fn_execution.flink_fn_execution_pb2 import StateDescriptor
+                Strategies = StateTtlConfig.CleanupStrategies.Strategies
+                DescriptorStrategies = StateDescriptor.StateTTLConfig.CleanupStrategies.Strategies
+                if proto == DescriptorStrategies.FULL_STATE_SCAN_SNAPSHOT:
+                    return Strategies.FULL_STATE_SCAN_SNAPSHOT
+                elif proto == DescriptorStrategies.INCREMENTAL_CLEANUP:
+                    return Strategies.INCREMENTAL_CLEANUP
+                else:
+                    return Strategies.ROCKSDB_COMPACTION_FILTER
+
+        class CleanupStrategy(ABC):
+            """
+            Base interface for cleanup strategies configurations.
+            """
+            pass
+
+        class EmptyCleanupStrategy(CleanupStrategy):
+            pass
+
+        class IncrementalCleanupStrategy(CleanupStrategy):
+            """
+            Configuration of cleanup strategy while taking the full snapshot.
+            """
+
+            def __init__(self, cleanup_size: int, run_cleanup_for_every_record: int):
+                self._cleanup_size = cleanup_size
+                self._run_cleanup_for_every_record = run_cleanup_for_every_record
+
+            def get_cleanup_size(self) -> int:
+                return self._cleanup_size
+
+            def run_cleanup_for_every_record(self) -> int:
+                return self._run_cleanup_for_every_record
+
+        class RocksdbCompactFilterCleanupStrategy(CleanupStrategy):
+            """
+            Configuration of cleanup strategy using custom compaction filter in RocksDB.
+            """
+
+            def __init__(self, query_time_after_num_entries: int):
+                self._query_time_after_num_entries = query_time_after_num_entries
+
+            def get_query_time_after_num_entries(self) -> int:
+                return self._query_time_after_num_entries
+
+        EMPTY_STRATEGY = EmptyCleanupStrategy()
+
+        def __init__(self,
+                     strategies: Dict[Strategies, CleanupStrategy],
+                     is_cleanup_in_background: bool):
+            self._strategies = strategies
+            self._is_cleanup_in_background = is_cleanup_in_background
+
+        def is_cleanup_in_background(self) -> bool:
+            return self._is_cleanup_in_background
+
+        def in_full_snapshot(self) -> bool:
+            return (StateTtlConfig.CleanupStrategies.Strategies.FULL_STATE_SCAN_SNAPSHOT in
+                    self._strategies)
+
+        def get_incremental_cleanup_strategy(self) \
+                -> 'StateTtlConfig.CleanupStrategies.IncrementalCleanupStrategy':
+            if self._is_cleanup_in_background:
+                default_strategy = \
+                    StateTtlConfig.CleanupStrategies.IncrementalCleanupStrategy(5, False)
+            else:
+                default_strategy = None
+            return self._strategies.get(    # type: ignore
+                StateTtlConfig.CleanupStrategies.Strategies.INCREMENTAL_CLEANUP,
+                default_strategy)
+
+        def get_rocksdb_compact_filter_cleanup_strategy(self) \
+                -> 'StateTtlConfig.CleanupStrategies.RocksdbCompactFilterCleanupStrategy':
+            if self._is_cleanup_in_background:
+                default_strategy = \
+                    StateTtlConfig.CleanupStrategies.RocksdbCompactFilterCleanupStrategy(1000)
+            else:
+                default_strategy = None
+            return self._strategies.get(    # type: ignore
+                StateTtlConfig.CleanupStrategies.Strategies.ROCKSDB_COMPACTION_FILTER,
+                default_strategy)
+
+        def _to_proto(self):
+            from pyflink.fn_execution.flink_fn_execution_pb2 import StateDescriptor
+            DescriptorCleanupStrategies = StateDescriptor.StateTTLConfig.CleanupStrategies
+            CleanupStrategies = StateTtlConfig.CleanupStrategies
+
+            cleanup_strategies = StateDescriptor.StateTTLConfig.CleanupStrategies()
+            cleanup_strategies.is_cleanup_in_background = self._is_cleanup_in_background
+            for k, v in self._strategies.items():
+                cleanup_strategy = cleanup_strategies.strategies.add()
+                cleanup_strategy.strategy = k._to_proto()
+                if isinstance(v, CleanupStrategies.EmptyCleanupStrategy):
+                    empty_strategy = DescriptorCleanupStrategies.EmptyCleanupStrategy.EMPTY_STRATEGY
+                    cleanup_strategy.empty_strategy = empty_strategy
+                elif isinstance(v, CleanupStrategies.IncrementalCleanupStrategy):
+                    incremental_cleanup_strategy = \
+                        DescriptorCleanupStrategies.IncrementalCleanupStrategy()
+                    incremental_cleanup_strategy.cleanup_size = v._cleanup_size
+                    incremental_cleanup_strategy.run_cleanup_for_every_record = \
+                        v._run_cleanup_for_every_record
+                    cleanup_strategy.incremental_cleanup_strategy.CopyFrom(
+                        incremental_cleanup_strategy)
+                elif isinstance(v, CleanupStrategies.RocksdbCompactFilterCleanupStrategy):
+                    rocksdb_compact_filter_cleanup_strategy = \
+                        DescriptorCleanupStrategies.RocksdbCompactFilterCleanupStrategy()
+                    rocksdb_compact_filter_cleanup_strategy.query_time_after_num_entries = \
+                        v._query_time_after_num_entries
+                    cleanup_strategy.rocksdb_compact_filter_cleanup_strategy.CopyFrom(
+                        rocksdb_compact_filter_cleanup_strategy)
+            return cleanup_strategies
+
+        @staticmethod
+        def _from_proto(proto):
+            CleanupStrategies = StateTtlConfig.CleanupStrategies
+
+            strategies = {}
+            is_cleanup_in_background = proto.is_cleanup_in_background
+            for strategy_entry in proto.strategies:
+                strategy = CleanupStrategies.Strategies._from_proto(strategy_entry.strategy)
+                if strategy_entry.HasField('empty_strategy'):
+                    strategies[strategy] = CleanupStrategies.EmptyCleanupStrategy
+                elif strategy_entry.HasField('incremental_cleanup_strategy'):
+                    incremental_cleanup_strategy = strategy_entry.incremental_cleanup_strategy
+                    strategies[strategy] = CleanupStrategies.IncrementalCleanupStrategy(
+                        incremental_cleanup_strategy.cleanup_size,
+                        incremental_cleanup_strategy.run_cleanup_for_every_record)
+                elif strategy_entry.HasField('rocksdb_compact_filter_cleanup_strategy'):
+                    rocksdb_compact_filter_cleanup_strategy = \
+                        strategy_entry.rocksdb_compact_filter_cleanup_strategy
+                    strategies[strategy] = CleanupStrategies.RocksdbCompactFilterCleanupStrategy(
+                        rocksdb_compact_filter_cleanup_strategy.query_time_after_num_entries)
+            return CleanupStrategies(strategies, is_cleanup_in_background)

--- a/flink-python/pyflink/fn_execution/datastream/runtime_context.py
+++ b/flink-python/pyflink/fn_execution/datastream/runtime_context.py
@@ -105,7 +105,9 @@ class StreamingRuntimeContext(RuntimeContext):
     def get_state(self, state_descriptor: ValueStateDescriptor) -> ValueState:
         if self._keyed_state_backend:
             return self._keyed_state_backend.get_value_state(
-                state_descriptor.name, from_type_info(state_descriptor.type_info))
+                state_descriptor.name,
+                from_type_info(state_descriptor.type_info),
+                state_descriptor._ttl_config)
         else:
             raise Exception("This state is only accessible by functions executed on a KeyedStream.")
 
@@ -113,7 +115,9 @@ class StreamingRuntimeContext(RuntimeContext):
         if self._keyed_state_backend:
             array_coder = from_type_info(state_descriptor.type_info)  # type: GenericArrayCoder
             return self._keyed_state_backend.get_list_state(
-                state_descriptor.name, array_coder._elem_coder)
+                state_descriptor.name,
+                array_coder._elem_coder,
+                state_descriptor._ttl_config)
         else:
             raise Exception("This state is only accessible by functions executed on a KeyedStream.")
 
@@ -123,7 +127,10 @@ class StreamingRuntimeContext(RuntimeContext):
             key_coder = map_coder._key_coder
             value_coder = map_coder._value_coder
             return self._keyed_state_backend.get_map_state(
-                state_descriptor.name, key_coder, value_coder)
+                state_descriptor.name,
+                key_coder,
+                value_coder,
+                state_descriptor._ttl_config)
         else:
             raise Exception("This state is only accessible by functions executed on a KeyedStream.")
 
@@ -132,7 +139,8 @@ class StreamingRuntimeContext(RuntimeContext):
             return self._keyed_state_backend.get_reducing_state(
                 state_descriptor.get_name(),
                 from_type_info(state_descriptor.type_info),
-                state_descriptor.get_reduce_function())
+                state_descriptor.get_reduce_function(),
+                state_descriptor._ttl_config)
         else:
             raise Exception("This state is only accessible by functions executed on a KeyedStream.")
 
@@ -142,7 +150,8 @@ class StreamingRuntimeContext(RuntimeContext):
             return self._keyed_state_backend.get_aggregating_state(
                 state_descriptor.get_name(),
                 from_type_info(state_descriptor.type_info),
-                state_descriptor.get_agg_function())
+                state_descriptor.get_agg_function(),
+                state_descriptor._ttl_config)
         else:
             raise Exception("This state is only accessible by functions executed on a KeyedStream.")
 

--- a/flink-python/pyflink/fn_execution/flink_fn_execution_pb2.py
+++ b/flink-python/pyflink/fn_execution/flink_fn_execution_pb2.py
@@ -36,7 +36,7 @@ DESCRIPTOR = _descriptor.FileDescriptor(
   name='flink-fn-execution.proto',
   package='org.apache.flink.fn_execution.v1',
   syntax='proto3',
-  serialized_pb=_b('\n\x18\x66link-fn-execution.proto\x12 org.apache.flink.fn_execution.v1\"\x86\x01\n\x05Input\x12\x44\n\x03udf\x18\x01 \x01(\x0b\x32\x35.org.apache.flink.fn_execution.v1.UserDefinedFunctionH\x00\x12\x15\n\x0binputOffset\x18\x02 \x01(\x05H\x00\x12\x17\n\rinputConstant\x18\x03 \x01(\x0cH\x00\x42\x07\n\x05input\"\xa8\x01\n\x13UserDefinedFunction\x12\x0f\n\x07payload\x18\x01 \x01(\x0c\x12\x37\n\x06inputs\x18\x02 \x03(\x0b\x32\'.org.apache.flink.fn_execution.v1.Input\x12\x14\n\x0cwindow_index\x18\x03 \x01(\x05\x12\x1a\n\x12takes_row_as_input\x18\x04 \x01(\x08\x12\x15\n\ris_pandas_udf\x18\x05 \x01(\x08\"\xcb\x01\n\x14UserDefinedFunctions\x12\x43\n\x04udfs\x18\x01 \x03(\x0b\x32\x35.org.apache.flink.fn_execution.v1.UserDefinedFunction\x12\x16\n\x0emetric_enabled\x18\x02 \x01(\x08\x12=\n\x07windows\x18\x03 \x03(\x0b\x32,.org.apache.flink.fn_execution.v1.OverWindow\x12\x17\n\x0fprofile_enabled\x18\x04 \x01(\x08\"\xdd\x02\n\nOverWindow\x12L\n\x0bwindow_type\x18\x01 \x01(\x0e\x32\x37.org.apache.flink.fn_execution.v1.OverWindow.WindowType\x12\x16\n\x0elower_boundary\x18\x02 \x01(\x03\x12\x16\n\x0eupper_boundary\x18\x03 \x01(\x03\"\xd0\x01\n\nWindowType\x12\x13\n\x0fRANGE_UNBOUNDED\x10\x00\x12\x1d\n\x19RANGE_UNBOUNDED_PRECEDING\x10\x01\x12\x1d\n\x19RANGE_UNBOUNDED_FOLLOWING\x10\x02\x12\x11\n\rRANGE_SLIDING\x10\x03\x12\x11\n\rROW_UNBOUNDED\x10\x04\x12\x1b\n\x17ROW_UNBOUNDED_PRECEDING\x10\x05\x12\x1b\n\x17ROW_UNBOUNDED_FOLLOWING\x10\x06\x12\x0f\n\x0bROW_SLIDING\x10\x07\"\x8b\x06\n\x1cUserDefinedAggregateFunction\x12\x0f\n\x07payload\x18\x01 \x01(\x0c\x12\x37\n\x06inputs\x18\x02 \x03(\x0b\x32\'.org.apache.flink.fn_execution.v1.Input\x12Z\n\x05specs\x18\x03 \x03(\x0b\x32K.org.apache.flink.fn_execution.v1.UserDefinedAggregateFunction.DataViewSpec\x12\x12\n\nfilter_arg\x18\x04 \x01(\x05\x12\x10\n\x08\x64istinct\x18\x05 \x01(\x08\x12\x1a\n\x12takes_row_as_input\x18\x06 \x01(\x08\x1a\x82\x04\n\x0c\x44\x61taViewSpec\x12\x0c\n\x04name\x18\x01 \x01(\t\x12\x13\n\x0b\x66ield_index\x18\x02 \x01(\x05\x12i\n\tlist_view\x18\x03 \x01(\x0b\x32T.org.apache.flink.fn_execution.v1.UserDefinedAggregateFunction.DataViewSpec.ListViewH\x00\x12g\n\x08map_view\x18\x04 \x01(\x0b\x32S.org.apache.flink.fn_execution.v1.UserDefinedAggregateFunction.DataViewSpec.MapViewH\x00\x1aT\n\x08ListView\x12H\n\x0c\x65lement_type\x18\x01 \x01(\x0b\x32\x32.org.apache.flink.fn_execution.v1.Schema.FieldType\x1a\x97\x01\n\x07MapView\x12\x44\n\x08key_type\x18\x01 \x01(\x0b\x32\x32.org.apache.flink.fn_execution.v1.Schema.FieldType\x12\x46\n\nvalue_type\x18\x02 \x01(\x0b\x32\x32.org.apache.flink.fn_execution.v1.Schema.FieldTypeB\x0b\n\tdata_view\"\xac\x04\n\x0bGroupWindow\x12M\n\x0bwindow_type\x18\x01 \x01(\x0e\x32\x38.org.apache.flink.fn_execution.v1.GroupWindow.WindowType\x12\x16\n\x0eis_time_window\x18\x02 \x01(\x08\x12\x14\n\x0cwindow_slide\x18\x03 \x01(\x03\x12\x13\n\x0bwindow_size\x18\x04 \x01(\x03\x12\x12\n\nwindow_gap\x18\x05 \x01(\x03\x12\x13\n\x0bis_row_time\x18\x06 \x01(\x08\x12\x18\n\x10time_field_index\x18\x07 \x01(\x05\x12\x17\n\x0f\x61llowedLateness\x18\x08 \x01(\x03\x12U\n\x0fnamedProperties\x18\t \x03(\x0e\x32<.org.apache.flink.fn_execution.v1.GroupWindow.WindowProperty\x12\x16\n\x0eshift_timezone\x18\n \x01(\t\"[\n\nWindowType\x12\x19\n\x15TUMBLING_GROUP_WINDOW\x10\x00\x12\x18\n\x14SLIDING_GROUP_WINDOW\x10\x01\x12\x18\n\x14SESSION_GROUP_WINDOW\x10\x02\"c\n\x0eWindowProperty\x12\x10\n\x0cWINDOW_START\x10\x00\x12\x0e\n\nWINDOW_END\x10\x01\x12\x16\n\x12ROW_TIME_ATTRIBUTE\x10\x02\x12\x17\n\x13PROC_TIME_ATTRIBUTE\x10\x03\"\x96\x04\n\x1dUserDefinedAggregateFunctions\x12L\n\x04udfs\x18\x01 \x03(\x0b\x32>.org.apache.flink.fn_execution.v1.UserDefinedAggregateFunction\x12\x16\n\x0emetric_enabled\x18\x02 \x01(\x08\x12\x10\n\x08grouping\x18\x03 \x03(\x05\x12\x1e\n\x16generate_update_before\x18\x04 \x01(\x08\x12\x44\n\x08key_type\x18\x05 \x01(\x0b\x32\x32.org.apache.flink.fn_execution.v1.Schema.FieldType\x12\x1b\n\x13index_of_count_star\x18\x06 \x01(\x05\x12\x1e\n\x16state_cleaning_enabled\x18\x07 \x01(\x08\x12\x18\n\x10state_cache_size\x18\x08 \x01(\x05\x12!\n\x19map_state_read_cache_size\x18\t \x01(\x05\x12\"\n\x1amap_state_write_cache_size\x18\n \x01(\x05\x12\x1b\n\x13\x63ount_star_inserted\x18\x0b \x01(\x08\x12\x43\n\x0cgroup_window\x18\x0c \x01(\x0b\x32-.org.apache.flink.fn_execution.v1.GroupWindow\x12\x17\n\x0fprofile_enabled\x18\r \x01(\x08\"\xec\x0f\n\x06Schema\x12>\n\x06\x66ields\x18\x01 \x03(\x0b\x32..org.apache.flink.fn_execution.v1.Schema.Field\x1a\x97\x01\n\x07MapInfo\x12\x44\n\x08key_type\x18\x01 \x01(\x0b\x32\x32.org.apache.flink.fn_execution.v1.Schema.FieldType\x12\x46\n\nvalue_type\x18\x02 \x01(\x0b\x32\x32.org.apache.flink.fn_execution.v1.Schema.FieldType\x1a\x1d\n\x08TimeInfo\x12\x11\n\tprecision\x18\x01 \x01(\x05\x1a\"\n\rTimestampInfo\x12\x11\n\tprecision\x18\x01 \x01(\x05\x1a,\n\x17LocalZonedTimestampInfo\x12\x11\n\tprecision\x18\x01 \x01(\x05\x1a\'\n\x12ZonedTimestampInfo\x12\x11\n\tprecision\x18\x01 \x01(\x05\x1a/\n\x0b\x44\x65\x63imalInfo\x12\x11\n\tprecision\x18\x01 \x01(\x05\x12\r\n\x05scale\x18\x02 \x01(\x05\x1a\x1c\n\nBinaryInfo\x12\x0e\n\x06length\x18\x01 \x01(\x05\x1a\x1f\n\rVarBinaryInfo\x12\x0e\n\x06length\x18\x01 \x01(\x05\x1a\x1a\n\x08\x43harInfo\x12\x0e\n\x06length\x18\x01 \x01(\x05\x1a\x1d\n\x0bVarCharInfo\x12\x0e\n\x06length\x18\x01 \x01(\x05\x1a\xb0\x08\n\tFieldType\x12\x44\n\ttype_name\x18\x01 \x01(\x0e\x32\x31.org.apache.flink.fn_execution.v1.Schema.TypeName\x12\x10\n\x08nullable\x18\x02 \x01(\x08\x12U\n\x17\x63ollection_element_type\x18\x03 \x01(\x0b\x32\x32.org.apache.flink.fn_execution.v1.Schema.FieldTypeH\x00\x12\x44\n\x08map_info\x18\x04 \x01(\x0b\x32\x30.org.apache.flink.fn_execution.v1.Schema.MapInfoH\x00\x12>\n\nrow_schema\x18\x05 \x01(\x0b\x32(.org.apache.flink.fn_execution.v1.SchemaH\x00\x12L\n\x0c\x64\x65\x63imal_info\x18\x06 \x01(\x0b\x32\x34.org.apache.flink.fn_execution.v1.Schema.DecimalInfoH\x00\x12\x46\n\ttime_info\x18\x07 \x01(\x0b\x32\x31.org.apache.flink.fn_execution.v1.Schema.TimeInfoH\x00\x12P\n\x0etimestamp_info\x18\x08 \x01(\x0b\x32\x36.org.apache.flink.fn_execution.v1.Schema.TimestampInfoH\x00\x12\x66\n\x1alocal_zoned_timestamp_info\x18\t \x01(\x0b\x32@.org.apache.flink.fn_execution.v1.Schema.LocalZonedTimestampInfoH\x00\x12[\n\x14zoned_timestamp_info\x18\n \x01(\x0b\x32;.org.apache.flink.fn_execution.v1.Schema.ZonedTimestampInfoH\x00\x12J\n\x0b\x62inary_info\x18\x0b \x01(\x0b\x32\x33.org.apache.flink.fn_execution.v1.Schema.BinaryInfoH\x00\x12Q\n\x0fvar_binary_info\x18\x0c \x01(\x0b\x32\x36.org.apache.flink.fn_execution.v1.Schema.VarBinaryInfoH\x00\x12\x46\n\tchar_info\x18\r \x01(\x0b\x32\x31.org.apache.flink.fn_execution.v1.Schema.CharInfoH\x00\x12M\n\rvar_char_info\x18\x0e \x01(\x0b\x32\x34.org.apache.flink.fn_execution.v1.Schema.VarCharInfoH\x00\x42\x0b\n\ttype_info\x1al\n\x05\x46ield\x12\x0c\n\x04name\x18\x01 \x01(\t\x12\x13\n\x0b\x64\x65scription\x18\x02 \x01(\t\x12@\n\x04type\x18\x03 \x01(\x0b\x32\x32.org.apache.flink.fn_execution.v1.Schema.FieldType\"\xa1\x02\n\x08TypeName\x12\x07\n\x03ROW\x10\x00\x12\x0b\n\x07TINYINT\x10\x01\x12\x0c\n\x08SMALLINT\x10\x02\x12\x07\n\x03INT\x10\x03\x12\n\n\x06\x42IGINT\x10\x04\x12\x0b\n\x07\x44\x45\x43IMAL\x10\x05\x12\t\n\x05\x46LOAT\x10\x06\x12\n\n\x06\x44OUBLE\x10\x07\x12\x08\n\x04\x44\x41TE\x10\x08\x12\x08\n\x04TIME\x10\t\x12\r\n\tTIMESTAMP\x10\n\x12\x0b\n\x07\x42OOLEAN\x10\x0b\x12\n\n\x06\x42INARY\x10\x0c\x12\r\n\tVARBINARY\x10\r\x12\x08\n\x04\x43HAR\x10\x0e\x12\x0b\n\x07VARCHAR\x10\x0f\x12\x0f\n\x0b\x42\x41SIC_ARRAY\x10\x10\x12\x07\n\x03MAP\x10\x11\x12\x0c\n\x08MULTISET\x10\x12\x12\x19\n\x15LOCAL_ZONED_TIMESTAMP\x10\x13\x12\x13\n\x0fZONED_TIMESTAMP\x10\x14\"\xf7\x08\n\x08TypeInfo\x12\x46\n\ttype_name\x18\x01 \x01(\x0e\x32\x33.org.apache.flink.fn_execution.v1.TypeInfo.TypeName\x12M\n\x17\x63ollection_element_type\x18\x02 \x01(\x0b\x32*.org.apache.flink.fn_execution.v1.TypeInfoH\x00\x12O\n\rrow_type_info\x18\x03 \x01(\x0b\x32\x36.org.apache.flink.fn_execution.v1.TypeInfo.RowTypeInfoH\x00\x12S\n\x0ftuple_type_info\x18\x04 \x01(\x0b\x32\x38.org.apache.flink.fn_execution.v1.TypeInfo.TupleTypeInfoH\x00\x12O\n\rmap_type_info\x18\x05 \x01(\x0b\x32\x36.org.apache.flink.fn_execution.v1.TypeInfo.MapTypeInfoH\x00\x1a\x8b\x01\n\x0bMapTypeInfo\x12<\n\x08key_type\x18\x01 \x01(\x0b\x32*.org.apache.flink.fn_execution.v1.TypeInfo\x12>\n\nvalue_type\x18\x02 \x01(\x0b\x32*.org.apache.flink.fn_execution.v1.TypeInfo\x1a\xb8\x01\n\x0bRowTypeInfo\x12L\n\x06\x66ields\x18\x01 \x03(\x0b\x32<.org.apache.flink.fn_execution.v1.TypeInfo.RowTypeInfo.Field\x1a[\n\x05\x46ield\x12\x12\n\nfield_name\x18\x01 \x01(\t\x12>\n\nfield_type\x18\x02 \x01(\x0b\x32*.org.apache.flink.fn_execution.v1.TypeInfo\x1aP\n\rTupleTypeInfo\x12?\n\x0b\x66ield_types\x18\x01 \x03(\x0b\x32*.org.apache.flink.fn_execution.v1.TypeInfo\"\xb4\x02\n\x08TypeName\x12\x07\n\x03ROW\x10\x00\x12\n\n\x06STRING\x10\x01\x12\x08\n\x04\x42YTE\x10\x02\x12\x0b\n\x07\x42OOLEAN\x10\x03\x12\t\n\x05SHORT\x10\x04\x12\x07\n\x03INT\x10\x05\x12\x08\n\x04LONG\x10\x06\x12\t\n\x05\x46LOAT\x10\x07\x12\n\n\x06\x44OUBLE\x10\x08\x12\x08\n\x04\x43HAR\x10\t\x12\x0b\n\x07\x42IG_INT\x10\n\x12\x0b\n\x07\x42IG_DEC\x10\x0b\x12\x0c\n\x08SQL_DATE\x10\x0c\x12\x0c\n\x08SQL_TIME\x10\r\x12\x11\n\rSQL_TIMESTAMP\x10\x0e\x12\x0f\n\x0b\x42\x41SIC_ARRAY\x10\x0f\x12\x13\n\x0fPRIMITIVE_ARRAY\x10\x10\x12\t\n\x05TUPLE\x10\x11\x12\x08\n\x04LIST\x10\x12\x12\x07\n\x03MAP\x10\x13\x12\x11\n\rPICKLED_BYTES\x10\x14\x12\x10\n\x0cOBJECT_ARRAY\x10\x15\x12\x0b\n\x07INSTANT\x10\x16\x42\x0b\n\ttype_info\"\xe6\x06\n\x1dUserDefinedDataStreamFunction\x12\x63\n\rfunction_type\x18\x01 \x01(\x0e\x32L.org.apache.flink.fn_execution.v1.UserDefinedDataStreamFunction.FunctionType\x12g\n\x0fruntime_context\x18\x02 \x01(\x0b\x32N.org.apache.flink.fn_execution.v1.UserDefinedDataStreamFunction.RuntimeContext\x12\x0f\n\x07payload\x18\x03 \x01(\x0c\x12\x16\n\x0emetric_enabled\x18\x04 \x01(\x08\x12\x41\n\rkey_type_info\x18\x05 \x01(\x0b\x32*.org.apache.flink.fn_execution.v1.TypeInfo\x12\x17\n\x0fprofile_enabled\x18\x06 \x01(\x08\x1a*\n\x0cJobParameter\x12\x0b\n\x03key\x18\x01 \x01(\t\x12\r\n\x05value\x18\x02 \x01(\t\x1a\xd0\x02\n\x0eRuntimeContext\x12\x11\n\ttask_name\x18\x01 \x01(\t\x12\x1f\n\x17task_name_with_subtasks\x18\x02 \x01(\t\x12#\n\x1bnumber_of_parallel_subtasks\x18\x03 \x01(\x05\x12\'\n\x1fmax_number_of_parallel_subtasks\x18\x04 \x01(\x05\x12\x1d\n\x15index_of_this_subtask\x18\x05 \x01(\x05\x12\x16\n\x0e\x61ttempt_number\x18\x06 \x01(\x05\x12\x64\n\x0ejob_parameters\x18\x07 \x03(\x0b\x32L.org.apache.flink.fn_execution.v1.UserDefinedDataStreamFunction.JobParameter\x12\x1f\n\x17in_batch_execution_mode\x18\x08 \x01(\x08\"s\n\x0c\x46unctionType\x12\x0b\n\x07PROCESS\x10\x00\x12\x0e\n\nCO_PROCESS\x10\x01\x12\x11\n\rKEYED_PROCESS\x10\x02\x12\x14\n\x10KEYED_CO_PROCESS\x10\x03\x12\n\n\x06WINDOW\x10\x04\x12\x11\n\rREVISE_OUTPUT\x10\x64\"\xf1\x07\n\x13\x43oderInfoDescriptor\x12`\n\x10\x66latten_row_type\x18\x01 \x01(\x0b\x32\x44.org.apache.flink.fn_execution.v1.CoderInfoDescriptor.FlattenRowTypeH\x00\x12Q\n\x08row_type\x18\x02 \x01(\x0b\x32=.org.apache.flink.fn_execution.v1.CoderInfoDescriptor.RowTypeH\x00\x12U\n\narrow_type\x18\x03 \x01(\x0b\x32?.org.apache.flink.fn_execution.v1.CoderInfoDescriptor.ArrowTypeH\x00\x12k\n\x16over_window_arrow_type\x18\x04 \x01(\x0b\x32I.org.apache.flink.fn_execution.v1.CoderInfoDescriptor.OverWindowArrowTypeH\x00\x12Q\n\x08raw_type\x18\x05 \x01(\x0b\x32=.org.apache.flink.fn_execution.v1.CoderInfoDescriptor.RawTypeH\x00\x12H\n\x04mode\x18\x06 \x01(\x0e\x32:.org.apache.flink.fn_execution.v1.CoderInfoDescriptor.Mode\x12\"\n\x1aseparated_with_end_message\x18\x07 \x01(\x08\x1aJ\n\x0e\x46lattenRowType\x12\x38\n\x06schema\x18\x01 \x01(\x0b\x32(.org.apache.flink.fn_execution.v1.Schema\x1a\x43\n\x07RowType\x12\x38\n\x06schema\x18\x01 \x01(\x0b\x32(.org.apache.flink.fn_execution.v1.Schema\x1a\x45\n\tArrowType\x12\x38\n\x06schema\x18\x01 \x01(\x0b\x32(.org.apache.flink.fn_execution.v1.Schema\x1aO\n\x13OverWindowArrowType\x12\x38\n\x06schema\x18\x01 \x01(\x0b\x32(.org.apache.flink.fn_execution.v1.Schema\x1aH\n\x07RawType\x12=\n\ttype_info\x18\x01 \x01(\x0b\x32*.org.apache.flink.fn_execution.v1.TypeInfo\" \n\x04Mode\x12\n\n\x06SINGLE\x10\x00\x12\x0c\n\x08MULTIPLE\x10\x01\x42\x0b\n\tdata_typeB-\n\x1forg.apache.flink.fnexecution.v1B\nFlinkFnApib\x06proto3')
+  serialized_pb=_b('\n\x18\x66link-fn-execution.proto\x12 org.apache.flink.fn_execution.v1\"\x86\x01\n\x05Input\x12\x44\n\x03udf\x18\x01 \x01(\x0b\x32\x35.org.apache.flink.fn_execution.v1.UserDefinedFunctionH\x00\x12\x15\n\x0binputOffset\x18\x02 \x01(\x05H\x00\x12\x17\n\rinputConstant\x18\x03 \x01(\x0cH\x00\x42\x07\n\x05input\"\xa8\x01\n\x13UserDefinedFunction\x12\x0f\n\x07payload\x18\x01 \x01(\x0c\x12\x37\n\x06inputs\x18\x02 \x03(\x0b\x32\'.org.apache.flink.fn_execution.v1.Input\x12\x14\n\x0cwindow_index\x18\x03 \x01(\x05\x12\x1a\n\x12takes_row_as_input\x18\x04 \x01(\x08\x12\x15\n\ris_pandas_udf\x18\x05 \x01(\x08\"\xcb\x01\n\x14UserDefinedFunctions\x12\x43\n\x04udfs\x18\x01 \x03(\x0b\x32\x35.org.apache.flink.fn_execution.v1.UserDefinedFunction\x12\x16\n\x0emetric_enabled\x18\x02 \x01(\x08\x12=\n\x07windows\x18\x03 \x03(\x0b\x32,.org.apache.flink.fn_execution.v1.OverWindow\x12\x17\n\x0fprofile_enabled\x18\x04 \x01(\x08\"\xdd\x02\n\nOverWindow\x12L\n\x0bwindow_type\x18\x01 \x01(\x0e\x32\x37.org.apache.flink.fn_execution.v1.OverWindow.WindowType\x12\x16\n\x0elower_boundary\x18\x02 \x01(\x03\x12\x16\n\x0eupper_boundary\x18\x03 \x01(\x03\"\xd0\x01\n\nWindowType\x12\x13\n\x0fRANGE_UNBOUNDED\x10\x00\x12\x1d\n\x19RANGE_UNBOUNDED_PRECEDING\x10\x01\x12\x1d\n\x19RANGE_UNBOUNDED_FOLLOWING\x10\x02\x12\x11\n\rRANGE_SLIDING\x10\x03\x12\x11\n\rROW_UNBOUNDED\x10\x04\x12\x1b\n\x17ROW_UNBOUNDED_PRECEDING\x10\x05\x12\x1b\n\x17ROW_UNBOUNDED_FOLLOWING\x10\x06\x12\x0f\n\x0bROW_SLIDING\x10\x07\"\x8b\x06\n\x1cUserDefinedAggregateFunction\x12\x0f\n\x07payload\x18\x01 \x01(\x0c\x12\x37\n\x06inputs\x18\x02 \x03(\x0b\x32\'.org.apache.flink.fn_execution.v1.Input\x12Z\n\x05specs\x18\x03 \x03(\x0b\x32K.org.apache.flink.fn_execution.v1.UserDefinedAggregateFunction.DataViewSpec\x12\x12\n\nfilter_arg\x18\x04 \x01(\x05\x12\x10\n\x08\x64istinct\x18\x05 \x01(\x08\x12\x1a\n\x12takes_row_as_input\x18\x06 \x01(\x08\x1a\x82\x04\n\x0c\x44\x61taViewSpec\x12\x0c\n\x04name\x18\x01 \x01(\t\x12\x13\n\x0b\x66ield_index\x18\x02 \x01(\x05\x12i\n\tlist_view\x18\x03 \x01(\x0b\x32T.org.apache.flink.fn_execution.v1.UserDefinedAggregateFunction.DataViewSpec.ListViewH\x00\x12g\n\x08map_view\x18\x04 \x01(\x0b\x32S.org.apache.flink.fn_execution.v1.UserDefinedAggregateFunction.DataViewSpec.MapViewH\x00\x1aT\n\x08ListView\x12H\n\x0c\x65lement_type\x18\x01 \x01(\x0b\x32\x32.org.apache.flink.fn_execution.v1.Schema.FieldType\x1a\x97\x01\n\x07MapView\x12\x44\n\x08key_type\x18\x01 \x01(\x0b\x32\x32.org.apache.flink.fn_execution.v1.Schema.FieldType\x12\x46\n\nvalue_type\x18\x02 \x01(\x0b\x32\x32.org.apache.flink.fn_execution.v1.Schema.FieldTypeB\x0b\n\tdata_view\"\xac\x04\n\x0bGroupWindow\x12M\n\x0bwindow_type\x18\x01 \x01(\x0e\x32\x38.org.apache.flink.fn_execution.v1.GroupWindow.WindowType\x12\x16\n\x0eis_time_window\x18\x02 \x01(\x08\x12\x14\n\x0cwindow_slide\x18\x03 \x01(\x03\x12\x13\n\x0bwindow_size\x18\x04 \x01(\x03\x12\x12\n\nwindow_gap\x18\x05 \x01(\x03\x12\x13\n\x0bis_row_time\x18\x06 \x01(\x08\x12\x18\n\x10time_field_index\x18\x07 \x01(\x05\x12\x17\n\x0f\x61llowedLateness\x18\x08 \x01(\x03\x12U\n\x0fnamedProperties\x18\t \x03(\x0e\x32<.org.apache.flink.fn_execution.v1.GroupWindow.WindowProperty\x12\x16\n\x0eshift_timezone\x18\n \x01(\t\"[\n\nWindowType\x12\x19\n\x15TUMBLING_GROUP_WINDOW\x10\x00\x12\x18\n\x14SLIDING_GROUP_WINDOW\x10\x01\x12\x18\n\x14SESSION_GROUP_WINDOW\x10\x02\"c\n\x0eWindowProperty\x12\x10\n\x0cWINDOW_START\x10\x00\x12\x0e\n\nWINDOW_END\x10\x01\x12\x16\n\x12ROW_TIME_ATTRIBUTE\x10\x02\x12\x17\n\x13PROC_TIME_ATTRIBUTE\x10\x03\"\x96\x04\n\x1dUserDefinedAggregateFunctions\x12L\n\x04udfs\x18\x01 \x03(\x0b\x32>.org.apache.flink.fn_execution.v1.UserDefinedAggregateFunction\x12\x16\n\x0emetric_enabled\x18\x02 \x01(\x08\x12\x10\n\x08grouping\x18\x03 \x03(\x05\x12\x1e\n\x16generate_update_before\x18\x04 \x01(\x08\x12\x44\n\x08key_type\x18\x05 \x01(\x0b\x32\x32.org.apache.flink.fn_execution.v1.Schema.FieldType\x12\x1b\n\x13index_of_count_star\x18\x06 \x01(\x05\x12\x1e\n\x16state_cleaning_enabled\x18\x07 \x01(\x08\x12\x18\n\x10state_cache_size\x18\x08 \x01(\x05\x12!\n\x19map_state_read_cache_size\x18\t \x01(\x05\x12\"\n\x1amap_state_write_cache_size\x18\n \x01(\x05\x12\x1b\n\x13\x63ount_star_inserted\x18\x0b \x01(\x08\x12\x43\n\x0cgroup_window\x18\x0c \x01(\x0b\x32-.org.apache.flink.fn_execution.v1.GroupWindow\x12\x17\n\x0fprofile_enabled\x18\r \x01(\x08\"\xec\x0f\n\x06Schema\x12>\n\x06\x66ields\x18\x01 \x03(\x0b\x32..org.apache.flink.fn_execution.v1.Schema.Field\x1a\x97\x01\n\x07MapInfo\x12\x44\n\x08key_type\x18\x01 \x01(\x0b\x32\x32.org.apache.flink.fn_execution.v1.Schema.FieldType\x12\x46\n\nvalue_type\x18\x02 \x01(\x0b\x32\x32.org.apache.flink.fn_execution.v1.Schema.FieldType\x1a\x1d\n\x08TimeInfo\x12\x11\n\tprecision\x18\x01 \x01(\x05\x1a\"\n\rTimestampInfo\x12\x11\n\tprecision\x18\x01 \x01(\x05\x1a,\n\x17LocalZonedTimestampInfo\x12\x11\n\tprecision\x18\x01 \x01(\x05\x1a\'\n\x12ZonedTimestampInfo\x12\x11\n\tprecision\x18\x01 \x01(\x05\x1a/\n\x0b\x44\x65\x63imalInfo\x12\x11\n\tprecision\x18\x01 \x01(\x05\x12\r\n\x05scale\x18\x02 \x01(\x05\x1a\x1c\n\nBinaryInfo\x12\x0e\n\x06length\x18\x01 \x01(\x05\x1a\x1f\n\rVarBinaryInfo\x12\x0e\n\x06length\x18\x01 \x01(\x05\x1a\x1a\n\x08\x43harInfo\x12\x0e\n\x06length\x18\x01 \x01(\x05\x1a\x1d\n\x0bVarCharInfo\x12\x0e\n\x06length\x18\x01 \x01(\x05\x1a\xb0\x08\n\tFieldType\x12\x44\n\ttype_name\x18\x01 \x01(\x0e\x32\x31.org.apache.flink.fn_execution.v1.Schema.TypeName\x12\x10\n\x08nullable\x18\x02 \x01(\x08\x12U\n\x17\x63ollection_element_type\x18\x03 \x01(\x0b\x32\x32.org.apache.flink.fn_execution.v1.Schema.FieldTypeH\x00\x12\x44\n\x08map_info\x18\x04 \x01(\x0b\x32\x30.org.apache.flink.fn_execution.v1.Schema.MapInfoH\x00\x12>\n\nrow_schema\x18\x05 \x01(\x0b\x32(.org.apache.flink.fn_execution.v1.SchemaH\x00\x12L\n\x0c\x64\x65\x63imal_info\x18\x06 \x01(\x0b\x32\x34.org.apache.flink.fn_execution.v1.Schema.DecimalInfoH\x00\x12\x46\n\ttime_info\x18\x07 \x01(\x0b\x32\x31.org.apache.flink.fn_execution.v1.Schema.TimeInfoH\x00\x12P\n\x0etimestamp_info\x18\x08 \x01(\x0b\x32\x36.org.apache.flink.fn_execution.v1.Schema.TimestampInfoH\x00\x12\x66\n\x1alocal_zoned_timestamp_info\x18\t \x01(\x0b\x32@.org.apache.flink.fn_execution.v1.Schema.LocalZonedTimestampInfoH\x00\x12[\n\x14zoned_timestamp_info\x18\n \x01(\x0b\x32;.org.apache.flink.fn_execution.v1.Schema.ZonedTimestampInfoH\x00\x12J\n\x0b\x62inary_info\x18\x0b \x01(\x0b\x32\x33.org.apache.flink.fn_execution.v1.Schema.BinaryInfoH\x00\x12Q\n\x0fvar_binary_info\x18\x0c \x01(\x0b\x32\x36.org.apache.flink.fn_execution.v1.Schema.VarBinaryInfoH\x00\x12\x46\n\tchar_info\x18\r \x01(\x0b\x32\x31.org.apache.flink.fn_execution.v1.Schema.CharInfoH\x00\x12M\n\rvar_char_info\x18\x0e \x01(\x0b\x32\x34.org.apache.flink.fn_execution.v1.Schema.VarCharInfoH\x00\x42\x0b\n\ttype_info\x1al\n\x05\x46ield\x12\x0c\n\x04name\x18\x01 \x01(\t\x12\x13\n\x0b\x64\x65scription\x18\x02 \x01(\t\x12@\n\x04type\x18\x03 \x01(\x0b\x32\x32.org.apache.flink.fn_execution.v1.Schema.FieldType\"\xa1\x02\n\x08TypeName\x12\x07\n\x03ROW\x10\x00\x12\x0b\n\x07TINYINT\x10\x01\x12\x0c\n\x08SMALLINT\x10\x02\x12\x07\n\x03INT\x10\x03\x12\n\n\x06\x42IGINT\x10\x04\x12\x0b\n\x07\x44\x45\x43IMAL\x10\x05\x12\t\n\x05\x46LOAT\x10\x06\x12\n\n\x06\x44OUBLE\x10\x07\x12\x08\n\x04\x44\x41TE\x10\x08\x12\x08\n\x04TIME\x10\t\x12\r\n\tTIMESTAMP\x10\n\x12\x0b\n\x07\x42OOLEAN\x10\x0b\x12\n\n\x06\x42INARY\x10\x0c\x12\r\n\tVARBINARY\x10\r\x12\x08\n\x04\x43HAR\x10\x0e\x12\x0b\n\x07VARCHAR\x10\x0f\x12\x0f\n\x0b\x42\x41SIC_ARRAY\x10\x10\x12\x07\n\x03MAP\x10\x11\x12\x0c\n\x08MULTISET\x10\x12\x12\x19\n\x15LOCAL_ZONED_TIMESTAMP\x10\x13\x12\x13\n\x0fZONED_TIMESTAMP\x10\x14\"\xf7\x08\n\x08TypeInfo\x12\x46\n\ttype_name\x18\x01 \x01(\x0e\x32\x33.org.apache.flink.fn_execution.v1.TypeInfo.TypeName\x12M\n\x17\x63ollection_element_type\x18\x02 \x01(\x0b\x32*.org.apache.flink.fn_execution.v1.TypeInfoH\x00\x12O\n\rrow_type_info\x18\x03 \x01(\x0b\x32\x36.org.apache.flink.fn_execution.v1.TypeInfo.RowTypeInfoH\x00\x12S\n\x0ftuple_type_info\x18\x04 \x01(\x0b\x32\x38.org.apache.flink.fn_execution.v1.TypeInfo.TupleTypeInfoH\x00\x12O\n\rmap_type_info\x18\x05 \x01(\x0b\x32\x36.org.apache.flink.fn_execution.v1.TypeInfo.MapTypeInfoH\x00\x1a\x8b\x01\n\x0bMapTypeInfo\x12<\n\x08key_type\x18\x01 \x01(\x0b\x32*.org.apache.flink.fn_execution.v1.TypeInfo\x12>\n\nvalue_type\x18\x02 \x01(\x0b\x32*.org.apache.flink.fn_execution.v1.TypeInfo\x1a\xb8\x01\n\x0bRowTypeInfo\x12L\n\x06\x66ields\x18\x01 \x03(\x0b\x32<.org.apache.flink.fn_execution.v1.TypeInfo.RowTypeInfo.Field\x1a[\n\x05\x46ield\x12\x12\n\nfield_name\x18\x01 \x01(\t\x12>\n\nfield_type\x18\x02 \x01(\x0b\x32*.org.apache.flink.fn_execution.v1.TypeInfo\x1aP\n\rTupleTypeInfo\x12?\n\x0b\x66ield_types\x18\x01 \x03(\x0b\x32*.org.apache.flink.fn_execution.v1.TypeInfo\"\xb4\x02\n\x08TypeName\x12\x07\n\x03ROW\x10\x00\x12\n\n\x06STRING\x10\x01\x12\x08\n\x04\x42YTE\x10\x02\x12\x0b\n\x07\x42OOLEAN\x10\x03\x12\t\n\x05SHORT\x10\x04\x12\x07\n\x03INT\x10\x05\x12\x08\n\x04LONG\x10\x06\x12\t\n\x05\x46LOAT\x10\x07\x12\n\n\x06\x44OUBLE\x10\x08\x12\x08\n\x04\x43HAR\x10\t\x12\x0b\n\x07\x42IG_INT\x10\n\x12\x0b\n\x07\x42IG_DEC\x10\x0b\x12\x0c\n\x08SQL_DATE\x10\x0c\x12\x0c\n\x08SQL_TIME\x10\r\x12\x11\n\rSQL_TIMESTAMP\x10\x0e\x12\x0f\n\x0b\x42\x41SIC_ARRAY\x10\x0f\x12\x13\n\x0fPRIMITIVE_ARRAY\x10\x10\x12\t\n\x05TUPLE\x10\x11\x12\x08\n\x04LIST\x10\x12\x12\x07\n\x03MAP\x10\x13\x12\x11\n\rPICKLED_BYTES\x10\x14\x12\x10\n\x0cOBJECT_ARRAY\x10\x15\x12\x0b\n\x07INSTANT\x10\x16\x42\x0b\n\ttype_info\"\xe6\x06\n\x1dUserDefinedDataStreamFunction\x12\x63\n\rfunction_type\x18\x01 \x01(\x0e\x32L.org.apache.flink.fn_execution.v1.UserDefinedDataStreamFunction.FunctionType\x12g\n\x0fruntime_context\x18\x02 \x01(\x0b\x32N.org.apache.flink.fn_execution.v1.UserDefinedDataStreamFunction.RuntimeContext\x12\x0f\n\x07payload\x18\x03 \x01(\x0c\x12\x16\n\x0emetric_enabled\x18\x04 \x01(\x08\x12\x41\n\rkey_type_info\x18\x05 \x01(\x0b\x32*.org.apache.flink.fn_execution.v1.TypeInfo\x12\x17\n\x0fprofile_enabled\x18\x06 \x01(\x08\x1a*\n\x0cJobParameter\x12\x0b\n\x03key\x18\x01 \x01(\t\x12\r\n\x05value\x18\x02 \x01(\t\x1a\xd0\x02\n\x0eRuntimeContext\x12\x11\n\ttask_name\x18\x01 \x01(\t\x12\x1f\n\x17task_name_with_subtasks\x18\x02 \x01(\t\x12#\n\x1bnumber_of_parallel_subtasks\x18\x03 \x01(\x05\x12\'\n\x1fmax_number_of_parallel_subtasks\x18\x04 \x01(\x05\x12\x1d\n\x15index_of_this_subtask\x18\x05 \x01(\x05\x12\x16\n\x0e\x61ttempt_number\x18\x06 \x01(\x05\x12\x64\n\x0ejob_parameters\x18\x07 \x03(\x0b\x32L.org.apache.flink.fn_execution.v1.UserDefinedDataStreamFunction.JobParameter\x12\x1f\n\x17in_batch_execution_mode\x18\x08 \x01(\x08\"s\n\x0c\x46unctionType\x12\x0b\n\x07PROCESS\x10\x00\x12\x0e\n\nCO_PROCESS\x10\x01\x12\x11\n\rKEYED_PROCESS\x10\x02\x12\x14\n\x10KEYED_CO_PROCESS\x10\x03\x12\n\n\x06WINDOW\x10\x04\x12\x11\n\rREVISE_OUTPUT\x10\x64\"\xe4\x0e\n\x0fStateDescriptor\x12\x12\n\nstate_name\x18\x01 \x01(\t\x12Z\n\x10state_ttl_config\x18\x02 \x01(\x0b\x32@.org.apache.flink.fn_execution.v1.StateDescriptor.StateTTLConfig\x1a\xe0\r\n\x0eStateTTLConfig\x12`\n\x0bupdate_type\x18\x01 \x01(\x0e\x32K.org.apache.flink.fn_execution.v1.StateDescriptor.StateTTLConfig.UpdateType\x12j\n\x10state_visibility\x18\x02 \x01(\x0e\x32P.org.apache.flink.fn_execution.v1.StateDescriptor.StateTTLConfig.StateVisibility\x12w\n\x17ttl_time_characteristic\x18\x03 \x01(\x0e\x32V.org.apache.flink.fn_execution.v1.StateDescriptor.StateTTLConfig.TtlTimeCharacteristic\x12\x0b\n\x03ttl\x18\x04 \x01(\x03\x12n\n\x12\x63leanup_strategies\x18\x05 \x01(\x0b\x32R.org.apache.flink.fn_execution.v1.StateDescriptor.StateTTLConfig.CleanupStrategies\x1a\xca\x08\n\x11\x43leanupStrategies\x12 \n\x18is_cleanup_in_background\x18\x01 \x01(\x08\x12y\n\nstrategies\x18\x02 \x03(\x0b\x32\x65.org.apache.flink.fn_execution.v1.StateDescriptor.StateTTLConfig.CleanupStrategies.MapStrategiesEntry\x1aX\n\x1aIncrementalCleanupStrategy\x12\x14\n\x0c\x63leanup_size\x18\x01 \x01(\x05\x12$\n\x1crun_cleanup_for_every_record\x18\x02 \x01(\x08\x1aK\n#RocksdbCompactFilterCleanupStrategy\x12$\n\x1cquery_time_after_num_entries\x18\x01 \x01(\x03\x1a\xe0\x04\n\x12MapStrategiesEntry\x12o\n\x08strategy\x18\x01 \x01(\x0e\x32].org.apache.flink.fn_execution.v1.StateDescriptor.StateTTLConfig.CleanupStrategies.Strategies\x12\x81\x01\n\x0e\x65mpty_strategy\x18\x02 \x01(\x0e\x32g.org.apache.flink.fn_execution.v1.StateDescriptor.StateTTLConfig.CleanupStrategies.EmptyCleanupStrategyH\x00\x12\x95\x01\n\x1cincremental_cleanup_strategy\x18\x03 \x01(\x0b\x32m.org.apache.flink.fn_execution.v1.StateDescriptor.StateTTLConfig.CleanupStrategies.IncrementalCleanupStrategyH\x00\x12\xa9\x01\n\'rocksdb_compact_filter_cleanup_strategy\x18\x04 \x01(\x0b\x32v.org.apache.flink.fn_execution.v1.StateDescriptor.StateTTLConfig.CleanupStrategies.RocksdbCompactFilterCleanupStrategyH\x00\x42\x11\n\x0f\x43leanupStrategy\"b\n\nStrategies\x12\x1c\n\x18\x46ULL_STATE_SCAN_SNAPSHOT\x10\x00\x12\x17\n\x13INCREMENTAL_CLEANUP\x10\x01\x12\x1d\n\x19ROCKSDB_COMPACTION_FILTER\x10\x02\"*\n\x14\x45mptyCleanupStrategy\x12\x12\n\x0e\x45MPTY_STRATEGY\x10\x00\"D\n\nUpdateType\x12\x0c\n\x08\x44isabled\x10\x00\x12\x14\n\x10OnCreateAndWrite\x10\x01\x12\x12\n\x0eOnReadAndWrite\x10\x02\"J\n\x0fStateVisibility\x12\x1f\n\x1bReturnExpiredIfNotCleanedUp\x10\x00\x12\x16\n\x12NeverReturnExpired\x10\x01\"+\n\x15TtlTimeCharacteristic\x12\x12\n\x0eProcessingTime\x10\x00\"\xf1\x07\n\x13\x43oderInfoDescriptor\x12`\n\x10\x66latten_row_type\x18\x01 \x01(\x0b\x32\x44.org.apache.flink.fn_execution.v1.CoderInfoDescriptor.FlattenRowTypeH\x00\x12Q\n\x08row_type\x18\x02 \x01(\x0b\x32=.org.apache.flink.fn_execution.v1.CoderInfoDescriptor.RowTypeH\x00\x12U\n\narrow_type\x18\x03 \x01(\x0b\x32?.org.apache.flink.fn_execution.v1.CoderInfoDescriptor.ArrowTypeH\x00\x12k\n\x16over_window_arrow_type\x18\x04 \x01(\x0b\x32I.org.apache.flink.fn_execution.v1.CoderInfoDescriptor.OverWindowArrowTypeH\x00\x12Q\n\x08raw_type\x18\x05 \x01(\x0b\x32=.org.apache.flink.fn_execution.v1.CoderInfoDescriptor.RawTypeH\x00\x12H\n\x04mode\x18\x06 \x01(\x0e\x32:.org.apache.flink.fn_execution.v1.CoderInfoDescriptor.Mode\x12\"\n\x1aseparated_with_end_message\x18\x07 \x01(\x08\x1aJ\n\x0e\x46lattenRowType\x12\x38\n\x06schema\x18\x01 \x01(\x0b\x32(.org.apache.flink.fn_execution.v1.Schema\x1a\x43\n\x07RowType\x12\x38\n\x06schema\x18\x01 \x01(\x0b\x32(.org.apache.flink.fn_execution.v1.Schema\x1a\x45\n\tArrowType\x12\x38\n\x06schema\x18\x01 \x01(\x0b\x32(.org.apache.flink.fn_execution.v1.Schema\x1aO\n\x13OverWindowArrowType\x12\x38\n\x06schema\x18\x01 \x01(\x0b\x32(.org.apache.flink.fn_execution.v1.Schema\x1aH\n\x07RawType\x12=\n\ttype_info\x18\x01 \x01(\x0b\x32*.org.apache.flink.fn_execution.v1.TypeInfo\" \n\x04Mode\x12\n\n\x06SINGLE\x10\x00\x12\x0c\n\x08MULTIPLE\x10\x01\x42\x0b\n\tdata_typeB-\n\x1forg.apache.flink.fnexecution.v1B\nFlinkFnApib\x06proto3')
 )
 
 
@@ -385,6 +385,116 @@ _USERDEFINEDDATASTREAMFUNCTION_FUNCTIONTYPE = _descriptor.EnumDescriptor(
 )
 _sym_db.RegisterEnumDescriptor(_USERDEFINEDDATASTREAMFUNCTION_FUNCTIONTYPE)
 
+_STATEDESCRIPTOR_STATETTLCONFIG_CLEANUPSTRATEGIES_STRATEGIES = _descriptor.EnumDescriptor(
+  name='Strategies',
+  full_name='org.apache.flink.fn_execution.v1.StateDescriptor.StateTTLConfig.CleanupStrategies.Strategies',
+  filename=None,
+  file=DESCRIPTOR,
+  values=[
+    _descriptor.EnumValueDescriptor(
+      name='FULL_STATE_SCAN_SNAPSHOT', index=0, number=0,
+      options=None,
+      type=None),
+    _descriptor.EnumValueDescriptor(
+      name='INCREMENTAL_CLEANUP', index=1, number=1,
+      options=None,
+      type=None),
+    _descriptor.EnumValueDescriptor(
+      name='ROCKSDB_COMPACTION_FILTER', index=2, number=2,
+      options=None,
+      type=None),
+  ],
+  containing_type=None,
+  options=None,
+  serialized_start=8416,
+  serialized_end=8514,
+)
+_sym_db.RegisterEnumDescriptor(_STATEDESCRIPTOR_STATETTLCONFIG_CLEANUPSTRATEGIES_STRATEGIES)
+
+_STATEDESCRIPTOR_STATETTLCONFIG_CLEANUPSTRATEGIES_EMPTYCLEANUPSTRATEGY = _descriptor.EnumDescriptor(
+  name='EmptyCleanupStrategy',
+  full_name='org.apache.flink.fn_execution.v1.StateDescriptor.StateTTLConfig.CleanupStrategies.EmptyCleanupStrategy',
+  filename=None,
+  file=DESCRIPTOR,
+  values=[
+    _descriptor.EnumValueDescriptor(
+      name='EMPTY_STRATEGY', index=0, number=0,
+      options=None,
+      type=None),
+  ],
+  containing_type=None,
+  options=None,
+  serialized_start=8516,
+  serialized_end=8558,
+)
+_sym_db.RegisterEnumDescriptor(_STATEDESCRIPTOR_STATETTLCONFIG_CLEANUPSTRATEGIES_EMPTYCLEANUPSTRATEGY)
+
+_STATEDESCRIPTOR_STATETTLCONFIG_UPDATETYPE = _descriptor.EnumDescriptor(
+  name='UpdateType',
+  full_name='org.apache.flink.fn_execution.v1.StateDescriptor.StateTTLConfig.UpdateType',
+  filename=None,
+  file=DESCRIPTOR,
+  values=[
+    _descriptor.EnumValueDescriptor(
+      name='Disabled', index=0, number=0,
+      options=None,
+      type=None),
+    _descriptor.EnumValueDescriptor(
+      name='OnCreateAndWrite', index=1, number=1,
+      options=None,
+      type=None),
+    _descriptor.EnumValueDescriptor(
+      name='OnReadAndWrite', index=2, number=2,
+      options=None,
+      type=None),
+  ],
+  containing_type=None,
+  options=None,
+  serialized_start=8560,
+  serialized_end=8628,
+)
+_sym_db.RegisterEnumDescriptor(_STATEDESCRIPTOR_STATETTLCONFIG_UPDATETYPE)
+
+_STATEDESCRIPTOR_STATETTLCONFIG_STATEVISIBILITY = _descriptor.EnumDescriptor(
+  name='StateVisibility',
+  full_name='org.apache.flink.fn_execution.v1.StateDescriptor.StateTTLConfig.StateVisibility',
+  filename=None,
+  file=DESCRIPTOR,
+  values=[
+    _descriptor.EnumValueDescriptor(
+      name='ReturnExpiredIfNotCleanedUp', index=0, number=0,
+      options=None,
+      type=None),
+    _descriptor.EnumValueDescriptor(
+      name='NeverReturnExpired', index=1, number=1,
+      options=None,
+      type=None),
+  ],
+  containing_type=None,
+  options=None,
+  serialized_start=8630,
+  serialized_end=8704,
+)
+_sym_db.RegisterEnumDescriptor(_STATEDESCRIPTOR_STATETTLCONFIG_STATEVISIBILITY)
+
+_STATEDESCRIPTOR_STATETTLCONFIG_TTLTIMECHARACTERISTIC = _descriptor.EnumDescriptor(
+  name='TtlTimeCharacteristic',
+  full_name='org.apache.flink.fn_execution.v1.StateDescriptor.StateTTLConfig.TtlTimeCharacteristic',
+  filename=None,
+  file=DESCRIPTOR,
+  values=[
+    _descriptor.EnumValueDescriptor(
+      name='ProcessingTime', index=0, number=0,
+      options=None,
+      type=None),
+  ],
+  containing_type=None,
+  options=None,
+  serialized_start=8706,
+  serialized_end=8749,
+)
+_sym_db.RegisterEnumDescriptor(_STATEDESCRIPTOR_STATETTLCONFIG_TTLTIMECHARACTERISTIC)
+
 _CODERINFODESCRIPTOR_MODE = _descriptor.EnumDescriptor(
   name='Mode',
   full_name='org.apache.flink.fn_execution.v1.CoderInfoDescriptor.Mode',
@@ -402,8 +512,8 @@ _CODERINFODESCRIPTOR_MODE = _descriptor.EnumDescriptor(
   ],
   containing_type=None,
   options=None,
-  serialized_start=7821,
-  serialized_end=7853,
+  serialized_start=9716,
+  serialized_end=9748,
 )
 _sym_db.RegisterEnumDescriptor(_CODERINFODESCRIPTOR_MODE)
 
@@ -1905,6 +2015,265 @@ _USERDEFINEDDATASTREAMFUNCTION = _descriptor.Descriptor(
 )
 
 
+_STATEDESCRIPTOR_STATETTLCONFIG_CLEANUPSTRATEGIES_INCREMENTALCLEANUPSTRATEGY = _descriptor.Descriptor(
+  name='IncrementalCleanupStrategy',
+  full_name='org.apache.flink.fn_execution.v1.StateDescriptor.StateTTLConfig.CleanupStrategies.IncrementalCleanupStrategy',
+  filename=None,
+  file=DESCRIPTOR,
+  containing_type=None,
+  fields=[
+    _descriptor.FieldDescriptor(
+      name='cleanup_size', full_name='org.apache.flink.fn_execution.v1.StateDescriptor.StateTTLConfig.CleanupStrategies.IncrementalCleanupStrategy.cleanup_size', index=0,
+      number=1, type=5, cpp_type=1, label=1,
+      has_default_value=False, default_value=0,
+      message_type=None, enum_type=None, containing_type=None,
+      is_extension=False, extension_scope=None,
+      options=None, file=DESCRIPTOR),
+    _descriptor.FieldDescriptor(
+      name='run_cleanup_for_every_record', full_name='org.apache.flink.fn_execution.v1.StateDescriptor.StateTTLConfig.CleanupStrategies.IncrementalCleanupStrategy.run_cleanup_for_every_record', index=1,
+      number=2, type=8, cpp_type=7, label=1,
+      has_default_value=False, default_value=False,
+      message_type=None, enum_type=None, containing_type=None,
+      is_extension=False, extension_scope=None,
+      options=None, file=DESCRIPTOR),
+  ],
+  extensions=[
+  ],
+  nested_types=[],
+  enum_types=[
+  ],
+  options=None,
+  is_extendable=False,
+  syntax='proto3',
+  extension_ranges=[],
+  oneofs=[
+  ],
+  serialized_start=7638,
+  serialized_end=7726,
+)
+
+_STATEDESCRIPTOR_STATETTLCONFIG_CLEANUPSTRATEGIES_ROCKSDBCOMPACTFILTERCLEANUPSTRATEGY = _descriptor.Descriptor(
+  name='RocksdbCompactFilterCleanupStrategy',
+  full_name='org.apache.flink.fn_execution.v1.StateDescriptor.StateTTLConfig.CleanupStrategies.RocksdbCompactFilterCleanupStrategy',
+  filename=None,
+  file=DESCRIPTOR,
+  containing_type=None,
+  fields=[
+    _descriptor.FieldDescriptor(
+      name='query_time_after_num_entries', full_name='org.apache.flink.fn_execution.v1.StateDescriptor.StateTTLConfig.CleanupStrategies.RocksdbCompactFilterCleanupStrategy.query_time_after_num_entries', index=0,
+      number=1, type=3, cpp_type=2, label=1,
+      has_default_value=False, default_value=0,
+      message_type=None, enum_type=None, containing_type=None,
+      is_extension=False, extension_scope=None,
+      options=None, file=DESCRIPTOR),
+  ],
+  extensions=[
+  ],
+  nested_types=[],
+  enum_types=[
+  ],
+  options=None,
+  is_extendable=False,
+  syntax='proto3',
+  extension_ranges=[],
+  oneofs=[
+  ],
+  serialized_start=7728,
+  serialized_end=7803,
+)
+
+_STATEDESCRIPTOR_STATETTLCONFIG_CLEANUPSTRATEGIES_MAPSTRATEGIESENTRY = _descriptor.Descriptor(
+  name='MapStrategiesEntry',
+  full_name='org.apache.flink.fn_execution.v1.StateDescriptor.StateTTLConfig.CleanupStrategies.MapStrategiesEntry',
+  filename=None,
+  file=DESCRIPTOR,
+  containing_type=None,
+  fields=[
+    _descriptor.FieldDescriptor(
+      name='strategy', full_name='org.apache.flink.fn_execution.v1.StateDescriptor.StateTTLConfig.CleanupStrategies.MapStrategiesEntry.strategy', index=0,
+      number=1, type=14, cpp_type=8, label=1,
+      has_default_value=False, default_value=0,
+      message_type=None, enum_type=None, containing_type=None,
+      is_extension=False, extension_scope=None,
+      options=None, file=DESCRIPTOR),
+    _descriptor.FieldDescriptor(
+      name='empty_strategy', full_name='org.apache.flink.fn_execution.v1.StateDescriptor.StateTTLConfig.CleanupStrategies.MapStrategiesEntry.empty_strategy', index=1,
+      number=2, type=14, cpp_type=8, label=1,
+      has_default_value=False, default_value=0,
+      message_type=None, enum_type=None, containing_type=None,
+      is_extension=False, extension_scope=None,
+      options=None, file=DESCRIPTOR),
+    _descriptor.FieldDescriptor(
+      name='incremental_cleanup_strategy', full_name='org.apache.flink.fn_execution.v1.StateDescriptor.StateTTLConfig.CleanupStrategies.MapStrategiesEntry.incremental_cleanup_strategy', index=2,
+      number=3, type=11, cpp_type=10, label=1,
+      has_default_value=False, default_value=None,
+      message_type=None, enum_type=None, containing_type=None,
+      is_extension=False, extension_scope=None,
+      options=None, file=DESCRIPTOR),
+    _descriptor.FieldDescriptor(
+      name='rocksdb_compact_filter_cleanup_strategy', full_name='org.apache.flink.fn_execution.v1.StateDescriptor.StateTTLConfig.CleanupStrategies.MapStrategiesEntry.rocksdb_compact_filter_cleanup_strategy', index=3,
+      number=4, type=11, cpp_type=10, label=1,
+      has_default_value=False, default_value=None,
+      message_type=None, enum_type=None, containing_type=None,
+      is_extension=False, extension_scope=None,
+      options=None, file=DESCRIPTOR),
+  ],
+  extensions=[
+  ],
+  nested_types=[],
+  enum_types=[
+  ],
+  options=None,
+  is_extendable=False,
+  syntax='proto3',
+  extension_ranges=[],
+  oneofs=[
+    _descriptor.OneofDescriptor(
+      name='CleanupStrategy', full_name='org.apache.flink.fn_execution.v1.StateDescriptor.StateTTLConfig.CleanupStrategies.MapStrategiesEntry.CleanupStrategy',
+      index=0, containing_type=None, fields=[]),
+  ],
+  serialized_start=7806,
+  serialized_end=8414,
+)
+
+_STATEDESCRIPTOR_STATETTLCONFIG_CLEANUPSTRATEGIES = _descriptor.Descriptor(
+  name='CleanupStrategies',
+  full_name='org.apache.flink.fn_execution.v1.StateDescriptor.StateTTLConfig.CleanupStrategies',
+  filename=None,
+  file=DESCRIPTOR,
+  containing_type=None,
+  fields=[
+    _descriptor.FieldDescriptor(
+      name='is_cleanup_in_background', full_name='org.apache.flink.fn_execution.v1.StateDescriptor.StateTTLConfig.CleanupStrategies.is_cleanup_in_background', index=0,
+      number=1, type=8, cpp_type=7, label=1,
+      has_default_value=False, default_value=False,
+      message_type=None, enum_type=None, containing_type=None,
+      is_extension=False, extension_scope=None,
+      options=None, file=DESCRIPTOR),
+    _descriptor.FieldDescriptor(
+      name='strategies', full_name='org.apache.flink.fn_execution.v1.StateDescriptor.StateTTLConfig.CleanupStrategies.strategies', index=1,
+      number=2, type=11, cpp_type=10, label=3,
+      has_default_value=False, default_value=[],
+      message_type=None, enum_type=None, containing_type=None,
+      is_extension=False, extension_scope=None,
+      options=None, file=DESCRIPTOR),
+  ],
+  extensions=[
+  ],
+  nested_types=[_STATEDESCRIPTOR_STATETTLCONFIG_CLEANUPSTRATEGIES_INCREMENTALCLEANUPSTRATEGY, _STATEDESCRIPTOR_STATETTLCONFIG_CLEANUPSTRATEGIES_ROCKSDBCOMPACTFILTERCLEANUPSTRATEGY, _STATEDESCRIPTOR_STATETTLCONFIG_CLEANUPSTRATEGIES_MAPSTRATEGIESENTRY, ],
+  enum_types=[
+    _STATEDESCRIPTOR_STATETTLCONFIG_CLEANUPSTRATEGIES_STRATEGIES,
+    _STATEDESCRIPTOR_STATETTLCONFIG_CLEANUPSTRATEGIES_EMPTYCLEANUPSTRATEGY,
+  ],
+  options=None,
+  is_extendable=False,
+  syntax='proto3',
+  extension_ranges=[],
+  oneofs=[
+  ],
+  serialized_start=7460,
+  serialized_end=8558,
+)
+
+_STATEDESCRIPTOR_STATETTLCONFIG = _descriptor.Descriptor(
+  name='StateTTLConfig',
+  full_name='org.apache.flink.fn_execution.v1.StateDescriptor.StateTTLConfig',
+  filename=None,
+  file=DESCRIPTOR,
+  containing_type=None,
+  fields=[
+    _descriptor.FieldDescriptor(
+      name='update_type', full_name='org.apache.flink.fn_execution.v1.StateDescriptor.StateTTLConfig.update_type', index=0,
+      number=1, type=14, cpp_type=8, label=1,
+      has_default_value=False, default_value=0,
+      message_type=None, enum_type=None, containing_type=None,
+      is_extension=False, extension_scope=None,
+      options=None, file=DESCRIPTOR),
+    _descriptor.FieldDescriptor(
+      name='state_visibility', full_name='org.apache.flink.fn_execution.v1.StateDescriptor.StateTTLConfig.state_visibility', index=1,
+      number=2, type=14, cpp_type=8, label=1,
+      has_default_value=False, default_value=0,
+      message_type=None, enum_type=None, containing_type=None,
+      is_extension=False, extension_scope=None,
+      options=None, file=DESCRIPTOR),
+    _descriptor.FieldDescriptor(
+      name='ttl_time_characteristic', full_name='org.apache.flink.fn_execution.v1.StateDescriptor.StateTTLConfig.ttl_time_characteristic', index=2,
+      number=3, type=14, cpp_type=8, label=1,
+      has_default_value=False, default_value=0,
+      message_type=None, enum_type=None, containing_type=None,
+      is_extension=False, extension_scope=None,
+      options=None, file=DESCRIPTOR),
+    _descriptor.FieldDescriptor(
+      name='ttl', full_name='org.apache.flink.fn_execution.v1.StateDescriptor.StateTTLConfig.ttl', index=3,
+      number=4, type=3, cpp_type=2, label=1,
+      has_default_value=False, default_value=0,
+      message_type=None, enum_type=None, containing_type=None,
+      is_extension=False, extension_scope=None,
+      options=None, file=DESCRIPTOR),
+    _descriptor.FieldDescriptor(
+      name='cleanup_strategies', full_name='org.apache.flink.fn_execution.v1.StateDescriptor.StateTTLConfig.cleanup_strategies', index=4,
+      number=5, type=11, cpp_type=10, label=1,
+      has_default_value=False, default_value=None,
+      message_type=None, enum_type=None, containing_type=None,
+      is_extension=False, extension_scope=None,
+      options=None, file=DESCRIPTOR),
+  ],
+  extensions=[
+  ],
+  nested_types=[_STATEDESCRIPTOR_STATETTLCONFIG_CLEANUPSTRATEGIES, ],
+  enum_types=[
+    _STATEDESCRIPTOR_STATETTLCONFIG_UPDATETYPE,
+    _STATEDESCRIPTOR_STATETTLCONFIG_STATEVISIBILITY,
+    _STATEDESCRIPTOR_STATETTLCONFIG_TTLTIMECHARACTERISTIC,
+  ],
+  options=None,
+  is_extendable=False,
+  syntax='proto3',
+  extension_ranges=[],
+  oneofs=[
+  ],
+  serialized_start=6989,
+  serialized_end=8749,
+)
+
+_STATEDESCRIPTOR = _descriptor.Descriptor(
+  name='StateDescriptor',
+  full_name='org.apache.flink.fn_execution.v1.StateDescriptor',
+  filename=None,
+  file=DESCRIPTOR,
+  containing_type=None,
+  fields=[
+    _descriptor.FieldDescriptor(
+      name='state_name', full_name='org.apache.flink.fn_execution.v1.StateDescriptor.state_name', index=0,
+      number=1, type=9, cpp_type=9, label=1,
+      has_default_value=False, default_value=_b("").decode('utf-8'),
+      message_type=None, enum_type=None, containing_type=None,
+      is_extension=False, extension_scope=None,
+      options=None, file=DESCRIPTOR),
+    _descriptor.FieldDescriptor(
+      name='state_ttl_config', full_name='org.apache.flink.fn_execution.v1.StateDescriptor.state_ttl_config', index=1,
+      number=2, type=11, cpp_type=10, label=1,
+      has_default_value=False, default_value=None,
+      message_type=None, enum_type=None, containing_type=None,
+      is_extension=False, extension_scope=None,
+      options=None, file=DESCRIPTOR),
+  ],
+  extensions=[
+  ],
+  nested_types=[_STATEDESCRIPTOR_STATETTLCONFIG, ],
+  enum_types=[
+  ],
+  options=None,
+  is_extendable=False,
+  syntax='proto3',
+  extension_ranges=[],
+  oneofs=[
+  ],
+  serialized_start=6857,
+  serialized_end=8749,
+)
+
+
 _CODERINFODESCRIPTOR_FLATTENROWTYPE = _descriptor.Descriptor(
   name='FlattenRowType',
   full_name='org.apache.flink.fn_execution.v1.CoderInfoDescriptor.FlattenRowType',
@@ -1931,8 +2300,8 @@ _CODERINFODESCRIPTOR_FLATTENROWTYPE = _descriptor.Descriptor(
   extension_ranges=[],
   oneofs=[
   ],
-  serialized_start=7450,
-  serialized_end=7524,
+  serialized_start=9345,
+  serialized_end=9419,
 )
 
 _CODERINFODESCRIPTOR_ROWTYPE = _descriptor.Descriptor(
@@ -1961,8 +2330,8 @@ _CODERINFODESCRIPTOR_ROWTYPE = _descriptor.Descriptor(
   extension_ranges=[],
   oneofs=[
   ],
-  serialized_start=7526,
-  serialized_end=7593,
+  serialized_start=9421,
+  serialized_end=9488,
 )
 
 _CODERINFODESCRIPTOR_ARROWTYPE = _descriptor.Descriptor(
@@ -1991,8 +2360,8 @@ _CODERINFODESCRIPTOR_ARROWTYPE = _descriptor.Descriptor(
   extension_ranges=[],
   oneofs=[
   ],
-  serialized_start=7595,
-  serialized_end=7664,
+  serialized_start=9490,
+  serialized_end=9559,
 )
 
 _CODERINFODESCRIPTOR_OVERWINDOWARROWTYPE = _descriptor.Descriptor(
@@ -2021,8 +2390,8 @@ _CODERINFODESCRIPTOR_OVERWINDOWARROWTYPE = _descriptor.Descriptor(
   extension_ranges=[],
   oneofs=[
   ],
-  serialized_start=7666,
-  serialized_end=7745,
+  serialized_start=9561,
+  serialized_end=9640,
 )
 
 _CODERINFODESCRIPTOR_RAWTYPE = _descriptor.Descriptor(
@@ -2051,8 +2420,8 @@ _CODERINFODESCRIPTOR_RAWTYPE = _descriptor.Descriptor(
   extension_ranges=[],
   oneofs=[
   ],
-  serialized_start=7747,
-  serialized_end=7819,
+  serialized_start=9642,
+  serialized_end=9714,
 )
 
 _CODERINFODESCRIPTOR = _descriptor.Descriptor(
@@ -2127,8 +2496,8 @@ _CODERINFODESCRIPTOR = _descriptor.Descriptor(
       name='data_type', full_name='org.apache.flink.fn_execution.v1.CoderInfoDescriptor.data_type',
       index=0, containing_type=None, fields=[]),
   ],
-  serialized_start=6857,
-  serialized_end=7866,
+  serialized_start=8752,
+  serialized_end=9761,
 )
 
 _INPUT.fields_by_name['udf'].message_type = _USERDEFINEDFUNCTION
@@ -2269,6 +2638,35 @@ _USERDEFINEDDATASTREAMFUNCTION.fields_by_name['function_type'].enum_type = _USER
 _USERDEFINEDDATASTREAMFUNCTION.fields_by_name['runtime_context'].message_type = _USERDEFINEDDATASTREAMFUNCTION_RUNTIMECONTEXT
 _USERDEFINEDDATASTREAMFUNCTION.fields_by_name['key_type_info'].message_type = _TYPEINFO
 _USERDEFINEDDATASTREAMFUNCTION_FUNCTIONTYPE.containing_type = _USERDEFINEDDATASTREAMFUNCTION
+_STATEDESCRIPTOR_STATETTLCONFIG_CLEANUPSTRATEGIES_INCREMENTALCLEANUPSTRATEGY.containing_type = _STATEDESCRIPTOR_STATETTLCONFIG_CLEANUPSTRATEGIES
+_STATEDESCRIPTOR_STATETTLCONFIG_CLEANUPSTRATEGIES_ROCKSDBCOMPACTFILTERCLEANUPSTRATEGY.containing_type = _STATEDESCRIPTOR_STATETTLCONFIG_CLEANUPSTRATEGIES
+_STATEDESCRIPTOR_STATETTLCONFIG_CLEANUPSTRATEGIES_MAPSTRATEGIESENTRY.fields_by_name['strategy'].enum_type = _STATEDESCRIPTOR_STATETTLCONFIG_CLEANUPSTRATEGIES_STRATEGIES
+_STATEDESCRIPTOR_STATETTLCONFIG_CLEANUPSTRATEGIES_MAPSTRATEGIESENTRY.fields_by_name['empty_strategy'].enum_type = _STATEDESCRIPTOR_STATETTLCONFIG_CLEANUPSTRATEGIES_EMPTYCLEANUPSTRATEGY
+_STATEDESCRIPTOR_STATETTLCONFIG_CLEANUPSTRATEGIES_MAPSTRATEGIESENTRY.fields_by_name['incremental_cleanup_strategy'].message_type = _STATEDESCRIPTOR_STATETTLCONFIG_CLEANUPSTRATEGIES_INCREMENTALCLEANUPSTRATEGY
+_STATEDESCRIPTOR_STATETTLCONFIG_CLEANUPSTRATEGIES_MAPSTRATEGIESENTRY.fields_by_name['rocksdb_compact_filter_cleanup_strategy'].message_type = _STATEDESCRIPTOR_STATETTLCONFIG_CLEANUPSTRATEGIES_ROCKSDBCOMPACTFILTERCLEANUPSTRATEGY
+_STATEDESCRIPTOR_STATETTLCONFIG_CLEANUPSTRATEGIES_MAPSTRATEGIESENTRY.containing_type = _STATEDESCRIPTOR_STATETTLCONFIG_CLEANUPSTRATEGIES
+_STATEDESCRIPTOR_STATETTLCONFIG_CLEANUPSTRATEGIES_MAPSTRATEGIESENTRY.oneofs_by_name['CleanupStrategy'].fields.append(
+  _STATEDESCRIPTOR_STATETTLCONFIG_CLEANUPSTRATEGIES_MAPSTRATEGIESENTRY.fields_by_name['empty_strategy'])
+_STATEDESCRIPTOR_STATETTLCONFIG_CLEANUPSTRATEGIES_MAPSTRATEGIESENTRY.fields_by_name['empty_strategy'].containing_oneof = _STATEDESCRIPTOR_STATETTLCONFIG_CLEANUPSTRATEGIES_MAPSTRATEGIESENTRY.oneofs_by_name['CleanupStrategy']
+_STATEDESCRIPTOR_STATETTLCONFIG_CLEANUPSTRATEGIES_MAPSTRATEGIESENTRY.oneofs_by_name['CleanupStrategy'].fields.append(
+  _STATEDESCRIPTOR_STATETTLCONFIG_CLEANUPSTRATEGIES_MAPSTRATEGIESENTRY.fields_by_name['incremental_cleanup_strategy'])
+_STATEDESCRIPTOR_STATETTLCONFIG_CLEANUPSTRATEGIES_MAPSTRATEGIESENTRY.fields_by_name['incremental_cleanup_strategy'].containing_oneof = _STATEDESCRIPTOR_STATETTLCONFIG_CLEANUPSTRATEGIES_MAPSTRATEGIESENTRY.oneofs_by_name['CleanupStrategy']
+_STATEDESCRIPTOR_STATETTLCONFIG_CLEANUPSTRATEGIES_MAPSTRATEGIESENTRY.oneofs_by_name['CleanupStrategy'].fields.append(
+  _STATEDESCRIPTOR_STATETTLCONFIG_CLEANUPSTRATEGIES_MAPSTRATEGIESENTRY.fields_by_name['rocksdb_compact_filter_cleanup_strategy'])
+_STATEDESCRIPTOR_STATETTLCONFIG_CLEANUPSTRATEGIES_MAPSTRATEGIESENTRY.fields_by_name['rocksdb_compact_filter_cleanup_strategy'].containing_oneof = _STATEDESCRIPTOR_STATETTLCONFIG_CLEANUPSTRATEGIES_MAPSTRATEGIESENTRY.oneofs_by_name['CleanupStrategy']
+_STATEDESCRIPTOR_STATETTLCONFIG_CLEANUPSTRATEGIES.fields_by_name['strategies'].message_type = _STATEDESCRIPTOR_STATETTLCONFIG_CLEANUPSTRATEGIES_MAPSTRATEGIESENTRY
+_STATEDESCRIPTOR_STATETTLCONFIG_CLEANUPSTRATEGIES.containing_type = _STATEDESCRIPTOR_STATETTLCONFIG
+_STATEDESCRIPTOR_STATETTLCONFIG_CLEANUPSTRATEGIES_STRATEGIES.containing_type = _STATEDESCRIPTOR_STATETTLCONFIG_CLEANUPSTRATEGIES
+_STATEDESCRIPTOR_STATETTLCONFIG_CLEANUPSTRATEGIES_EMPTYCLEANUPSTRATEGY.containing_type = _STATEDESCRIPTOR_STATETTLCONFIG_CLEANUPSTRATEGIES
+_STATEDESCRIPTOR_STATETTLCONFIG.fields_by_name['update_type'].enum_type = _STATEDESCRIPTOR_STATETTLCONFIG_UPDATETYPE
+_STATEDESCRIPTOR_STATETTLCONFIG.fields_by_name['state_visibility'].enum_type = _STATEDESCRIPTOR_STATETTLCONFIG_STATEVISIBILITY
+_STATEDESCRIPTOR_STATETTLCONFIG.fields_by_name['ttl_time_characteristic'].enum_type = _STATEDESCRIPTOR_STATETTLCONFIG_TTLTIMECHARACTERISTIC
+_STATEDESCRIPTOR_STATETTLCONFIG.fields_by_name['cleanup_strategies'].message_type = _STATEDESCRIPTOR_STATETTLCONFIG_CLEANUPSTRATEGIES
+_STATEDESCRIPTOR_STATETTLCONFIG.containing_type = _STATEDESCRIPTOR
+_STATEDESCRIPTOR_STATETTLCONFIG_UPDATETYPE.containing_type = _STATEDESCRIPTOR_STATETTLCONFIG
+_STATEDESCRIPTOR_STATETTLCONFIG_STATEVISIBILITY.containing_type = _STATEDESCRIPTOR_STATETTLCONFIG
+_STATEDESCRIPTOR_STATETTLCONFIG_TTLTIMECHARACTERISTIC.containing_type = _STATEDESCRIPTOR_STATETTLCONFIG
+_STATEDESCRIPTOR.fields_by_name['state_ttl_config'].message_type = _STATEDESCRIPTOR_STATETTLCONFIG
 _CODERINFODESCRIPTOR_FLATTENROWTYPE.fields_by_name['schema'].message_type = _SCHEMA
 _CODERINFODESCRIPTOR_FLATTENROWTYPE.containing_type = _CODERINFODESCRIPTOR
 _CODERINFODESCRIPTOR_ROWTYPE.fields_by_name['schema'].message_type = _SCHEMA
@@ -2311,6 +2709,7 @@ DESCRIPTOR.message_types_by_name['UserDefinedAggregateFunctions'] = _USERDEFINED
 DESCRIPTOR.message_types_by_name['Schema'] = _SCHEMA
 DESCRIPTOR.message_types_by_name['TypeInfo'] = _TYPEINFO
 DESCRIPTOR.message_types_by_name['UserDefinedDataStreamFunction'] = _USERDEFINEDDATASTREAMFUNCTION
+DESCRIPTOR.message_types_by_name['StateDescriptor'] = _STATEDESCRIPTOR
 DESCRIPTOR.message_types_by_name['CoderInfoDescriptor'] = _CODERINFODESCRIPTOR
 _sym_db.RegisterFileDescriptor(DESCRIPTOR)
 
@@ -2551,6 +2950,53 @@ UserDefinedDataStreamFunction = _reflection.GeneratedProtocolMessageType('UserDe
 _sym_db.RegisterMessage(UserDefinedDataStreamFunction)
 _sym_db.RegisterMessage(UserDefinedDataStreamFunction.JobParameter)
 _sym_db.RegisterMessage(UserDefinedDataStreamFunction.RuntimeContext)
+
+StateDescriptor = _reflection.GeneratedProtocolMessageType('StateDescriptor', (_message.Message,), dict(
+
+  StateTTLConfig = _reflection.GeneratedProtocolMessageType('StateTTLConfig', (_message.Message,), dict(
+
+    CleanupStrategies = _reflection.GeneratedProtocolMessageType('CleanupStrategies', (_message.Message,), dict(
+
+      IncrementalCleanupStrategy = _reflection.GeneratedProtocolMessageType('IncrementalCleanupStrategy', (_message.Message,), dict(
+        DESCRIPTOR = _STATEDESCRIPTOR_STATETTLCONFIG_CLEANUPSTRATEGIES_INCREMENTALCLEANUPSTRATEGY,
+        __module__ = 'flink_fn_execution_pb2'
+        # @@protoc_insertion_point(class_scope:org.apache.flink.fn_execution.v1.StateDescriptor.StateTTLConfig.CleanupStrategies.IncrementalCleanupStrategy)
+        ))
+      ,
+
+      RocksdbCompactFilterCleanupStrategy = _reflection.GeneratedProtocolMessageType('RocksdbCompactFilterCleanupStrategy', (_message.Message,), dict(
+        DESCRIPTOR = _STATEDESCRIPTOR_STATETTLCONFIG_CLEANUPSTRATEGIES_ROCKSDBCOMPACTFILTERCLEANUPSTRATEGY,
+        __module__ = 'flink_fn_execution_pb2'
+        # @@protoc_insertion_point(class_scope:org.apache.flink.fn_execution.v1.StateDescriptor.StateTTLConfig.CleanupStrategies.RocksdbCompactFilterCleanupStrategy)
+        ))
+      ,
+
+      MapStrategiesEntry = _reflection.GeneratedProtocolMessageType('MapStrategiesEntry', (_message.Message,), dict(
+        DESCRIPTOR = _STATEDESCRIPTOR_STATETTLCONFIG_CLEANUPSTRATEGIES_MAPSTRATEGIESENTRY,
+        __module__ = 'flink_fn_execution_pb2'
+        # @@protoc_insertion_point(class_scope:org.apache.flink.fn_execution.v1.StateDescriptor.StateTTLConfig.CleanupStrategies.MapStrategiesEntry)
+        ))
+      ,
+      DESCRIPTOR = _STATEDESCRIPTOR_STATETTLCONFIG_CLEANUPSTRATEGIES,
+      __module__ = 'flink_fn_execution_pb2'
+      # @@protoc_insertion_point(class_scope:org.apache.flink.fn_execution.v1.StateDescriptor.StateTTLConfig.CleanupStrategies)
+      ))
+    ,
+    DESCRIPTOR = _STATEDESCRIPTOR_STATETTLCONFIG,
+    __module__ = 'flink_fn_execution_pb2'
+    # @@protoc_insertion_point(class_scope:org.apache.flink.fn_execution.v1.StateDescriptor.StateTTLConfig)
+    ))
+  ,
+  DESCRIPTOR = _STATEDESCRIPTOR,
+  __module__ = 'flink_fn_execution_pb2'
+  # @@protoc_insertion_point(class_scope:org.apache.flink.fn_execution.v1.StateDescriptor)
+  ))
+_sym_db.RegisterMessage(StateDescriptor)
+_sym_db.RegisterMessage(StateDescriptor.StateTTLConfig)
+_sym_db.RegisterMessage(StateDescriptor.StateTTLConfig.CleanupStrategies)
+_sym_db.RegisterMessage(StateDescriptor.StateTTLConfig.CleanupStrategies.IncrementalCleanupStrategy)
+_sym_db.RegisterMessage(StateDescriptor.StateTTLConfig.CleanupStrategies.RocksdbCompactFilterCleanupStrategy)
+_sym_db.RegisterMessage(StateDescriptor.StateTTLConfig.CleanupStrategies.MapStrategiesEntry)
 
 CoderInfoDescriptor = _reflection.GeneratedProtocolMessageType('CoderInfoDescriptor', (_message.Message,), dict(
 

--- a/flink-python/pyflink/fn_execution/state_impl.py
+++ b/flink-python/pyflink/fn_execution/state_impl.py
@@ -947,7 +947,6 @@ class RemoteKeyedStateBackend(object):
                 transform_id="clear_iterators",
                 side_input_id="clear_iterators",
                 key=self._encoded_current_key))
-        self._created_states = set()
 
     def get_list_state(self, name, element_coder, ttl_config=None):
         return self._wrap_internal_bag_state(
@@ -1066,10 +1065,8 @@ class RemoteKeyedStateBackend(object):
         from pyflink.fn_execution.flink_fn_execution_pb2 import StateDescriptor
         state_proto = StateDescriptor()
         state_proto.state_name = name
-        if name not in self._created_states:
-            self._created_states.add(name)
-            if ttl_config is not None:
-                state_proto.state_ttl_config.CopyFrom(ttl_config._to_proto())
+        if ttl_config is not None:
+            state_proto.state_ttl_config.CopyFrom(ttl_config._to_proto())
         state_key = beam_fn_api_pb2.StateKey(
             multimap_side_input=beam_fn_api_pb2.StateKey.MultimapSideInput(
                 transform_id="",
@@ -1165,10 +1162,8 @@ class RemoteKeyedStateBackend(object):
         from pyflink.fn_execution.flink_fn_execution_pb2 import StateDescriptor
         state_proto = StateDescriptor()
         state_proto.state_name = name
-        if name not in self._created_states:
-            self._created_states.add(name)
-            if ttl_config is not None:
-                state_proto.state_ttl_config.CopyFrom(ttl_config._to_proto())
+        if ttl_config is not None:
+            state_proto.state_ttl_config.CopyFrom(ttl_config._to_proto())
         return beam_fn_api_pb2.StateKey(
             bag_user_state=beam_fn_api_pb2.StateKey.BagUserState(
                 transform_id="",

--- a/flink-python/pyflink/fn_execution/state_impl.py
+++ b/flink-python/pyflink/fn_execution/state_impl.py
@@ -15,6 +15,7 @@
 #  See the License for the specific language governing permissions and
 # limitations under the License.
 ################################################################################
+import base64
 import collections
 from abc import ABC, abstractmethod
 from enum import Enum
@@ -29,6 +30,7 @@ from typing import List, Tuple, Any, Dict, Collection
 
 from pyflink.datastream import ReduceFunction
 from pyflink.datastream.functions import AggregateFunction
+from pyflink.datastream.state import StateTtlConfig
 from pyflink.fn_execution.beam.beam_coders import FlinkCoder
 from pyflink.fn_execution.coders import FieldCoder
 from pyflink.fn_execution.internal_state import InternalKvState, N, InternalValueState, \
@@ -96,6 +98,7 @@ class SynchronousKvRuntimeState(InternalKvState, ABC):
         self._remote_state_backend = remote_state_backend
         self._internal_state = None
         self.namespace = None
+        self._ttl_config = None
 
     def set_current_namespace(self, namespace: N) -> None:
         if namespace == self.namespace:
@@ -105,6 +108,9 @@ class SynchronousKvRuntimeState(InternalKvState, ABC):
                 self._remote_state_backend._encoded_current_key, self)
         self.namespace = namespace
         self._internal_state = None
+
+    def enable_time_to_live(self, ttl_config: StateTtlConfig):
+        self._ttl_config = ttl_config
 
     @abstractmethod
     def get_internal_state(self):
@@ -122,7 +128,7 @@ class SynchronousBagKvRuntimeState(SynchronousKvRuntimeState, ABC):
     def get_internal_state(self):
         if self._internal_state is None:
             self._internal_state = self._remote_state_backend._get_internal_bag_state(
-                self.name, self.namespace, self._value_coder)
+                self.name, self.namespace, self._value_coder, self._ttl_config)
         return self._internal_state
 
 
@@ -158,7 +164,7 @@ class SynchronousMergingRuntimeState(SynchronousBagKvRuntimeState, InternalMergi
             name, value_coder, remote_state_backend)
 
     def merge_namespaces(self, target: N, sources: Collection[N]) -> None:
-        self._remote_state_backend.merge_namespaces(self, target, sources)
+        self._remote_state_backend.merge_namespaces(self, target, sources, self._ttl_config)
 
 
 class SynchronousListRuntimeState(SynchronousMergingRuntimeState, InternalListState):
@@ -867,7 +873,11 @@ class SynchronousMapRuntimeState(SynchronousKvRuntimeState, InternalMapState):
     def get_internal_state(self):
         if self._internal_state is None:
             self._internal_state = self._remote_state_backend._get_internal_map_state(
-                self.name, self.namespace, self._map_key_coder, self._map_value_coder)
+                self.name,
+                self.namespace,
+                self._map_key_coder,
+                self._map_value_coder,
+                self._ttl_config)
         return self._internal_state
 
     def get(self, key):
@@ -938,31 +948,47 @@ class RemoteKeyedStateBackend(object):
                 side_input_id="clear_iterators",
                 key=self._encoded_current_key))
 
-    def get_list_state(self, name, element_coder):
+    def get_list_state(self, name, element_coder, ttl_config=None):
         return self._wrap_internal_bag_state(
-            name, element_coder, SynchronousListRuntimeState, SynchronousListRuntimeState)
+            name,
+            element_coder,
+            SynchronousListRuntimeState,
+            SynchronousListRuntimeState,
+            ttl_config)
 
-    def get_value_state(self, name, value_coder):
+    def get_value_state(self, name, value_coder, ttl_config=None):
         return self._wrap_internal_bag_state(
-            name, value_coder, SynchronousValueRuntimeState, SynchronousValueRuntimeState)
+            name,
+            value_coder,
+            SynchronousValueRuntimeState,
+            SynchronousValueRuntimeState,
+            ttl_config)
 
-    def get_map_state(self, name, map_key_coder, map_value_coder):
+    def get_map_state(self, name, map_key_coder, map_value_coder, ttl_config=None):
         if name in self._all_states:
             self.validate_map_state(name, map_key_coder, map_value_coder)
             return self._all_states[name]
         map_state = SynchronousMapRuntimeState(name, map_key_coder, map_value_coder, self)
+        if ttl_config is not None:
+            map_state.enable_time_to_live(ttl_config)
         self._all_states[name] = map_state
         return map_state
 
-    def get_reducing_state(self, name, coder, reduce_function):
+    def get_reducing_state(self, name, coder, reduce_function, ttl_config=None):
         return self._wrap_internal_bag_state(
-            name, coder, SynchronousReducingRuntimeState,
-            partial(SynchronousReducingRuntimeState, reduce_function=reduce_function))
+            name,
+            coder,
+            SynchronousReducingRuntimeState,
+            partial(SynchronousReducingRuntimeState, reduce_function=reduce_function),
+            ttl_config)
 
-    def get_aggregating_state(self, name, coder, agg_function):
+    def get_aggregating_state(self, name, coder, agg_function, ttl_config=None):
         return self._wrap_internal_bag_state(
-            name, coder, SynchronousAggregatingRuntimeState,
-            partial(SynchronousAggregatingRuntimeState, agg_function=agg_function))
+            name,
+            coder,
+            SynchronousAggregatingRuntimeState,
+            partial(SynchronousAggregatingRuntimeState, agg_function=agg_function),
+            ttl_config)
 
     def validate_state(self, name, coder, expected_type):
         if name in self._all_states:
@@ -983,15 +1009,18 @@ class RemoteKeyedStateBackend(object):
                     state._map_value_coder != map_value_coder:
                 raise Exception("State name corrupted: %s" % name)
 
-    def _wrap_internal_bag_state(self, name, element_coder, wrapper_type, wrap_method):
+    def _wrap_internal_bag_state(
+            self, name, element_coder, wrapper_type, wrap_method, ttl_config):
         if name in self._all_states:
             self.validate_state(name, element_coder, wrapper_type)
             return self._all_states[name]
         wrapped_state = wrap_method(name, element_coder, self)
+        if ttl_config is not None:
+            wrapped_state.enable_time_to_live(ttl_config)
         self._all_states[name] = wrapped_state
         return wrapped_state
 
-    def _get_internal_bag_state(self, name, namespace, element_coder):
+    def _get_internal_bag_state(self, name, namespace, element_coder, ttl_config):
         encoded_namespace = self._encode_namespace(namespace)
         cached_state = self._internal_state_cache.get(
             (name, self._encoded_current_key, encoded_namespace))
@@ -1004,39 +1033,45 @@ class RemoteKeyedStateBackend(object):
         if isinstance(element_coder, FieldCoder):
             element_coder = FlinkCoder(element_coder)
         state_spec = userstate.BagStateSpec(name, element_coder)
-        internal_state = self._create_bag_state(state_spec, encoded_namespace)
+        internal_state = self._create_bag_state(state_spec, encoded_namespace, ttl_config)
         return internal_state
 
-    def _get_internal_map_state(self, name, namespace, map_key_coder, map_value_coder):
+    def _get_internal_map_state(self, name, namespace, map_key_coder, map_value_coder, ttl_config):
         encoded_namespace = self._encode_namespace(namespace)
         cached_state = self._internal_state_cache.get(
             (name, self._encoded_current_key, encoded_namespace))
         if cached_state is not None:
             return cached_state
         internal_map_state = self._create_internal_map_state(
-            name, encoded_namespace, map_key_coder, map_value_coder)
+            name, encoded_namespace, map_key_coder, map_value_coder, ttl_config)
         return internal_map_state
 
-    def _create_bag_state(self, state_spec: userstate.StateSpec, encoded_namespace) \
+    def _create_bag_state(self, state_spec: userstate.StateSpec, encoded_namespace, ttl_config) \
             -> userstate.AccumulatingRuntimeState:
         if isinstance(state_spec, userstate.BagStateSpec):
             bag_state = SynchronousBagRuntimeState(
                 self._state_handler,
                 state_key=self.get_bag_state_key(
-                    state_spec.name, self._encoded_current_key, encoded_namespace),
+                    state_spec.name, self._encoded_current_key, encoded_namespace, ttl_config),
                 value_coder=state_spec.coder)
             return bag_state
         else:
             raise NotImplementedError(state_spec)
 
-    def _create_internal_map_state(self, name, encoded_namespace, map_key_coder, map_value_coder):
+    def _create_internal_map_state(
+            self, name, encoded_namespace, map_key_coder, map_value_coder, ttl_config):
         # Currently the `beam_fn_api.proto` does not support MapState, so we use the
         # the `MultimapSideInput` message to mark the state as a MapState for now.
+        from pyflink.fn_execution.flink_fn_execution_pb2 import StateDescriptor
+        state_proto = StateDescriptor()
+        state_proto.state_name = name
+        if ttl_config is not None:
+            state_proto.state_ttl_config.CopyFrom(ttl_config._to_proto())
         state_key = beam_fn_api_pb2.StateKey(
             multimap_side_input=beam_fn_api_pb2.StateKey.MultimapSideInput(
                 transform_id="",
                 window=encoded_namespace,
-                side_input_id=name,
+                side_input_id=base64.b64encode(state_proto.SerializeToString()),
                 key=self._encoded_current_key))
         return InternalSynchronousMapRuntimeState(
             self._map_state_handler,
@@ -1087,7 +1122,7 @@ class RemoteKeyedStateBackend(object):
             self._clear_iterator_mark.multimap_side_input.key = self._encoded_current_key
             self._map_state_handler.clear(self._clear_iterator_mark)
 
-    def merge_namespaces(self, state: SynchronousMergingRuntimeState, target, sources):
+    def merge_namespaces(self, state: SynchronousMergingRuntimeState, target, sources, ttl_config):
         state.set_current_namespace(target)
         self.commit_internal_state(state.get_internal_state())
         encoded_target_namespace = self._encode_namespace(target)
@@ -1097,7 +1132,7 @@ class RemoteKeyedStateBackend(object):
         self.clear_state_cache(state, encoded_namespaces)
 
         state_key = self.get_bag_state_key(
-            state.name, self._encoded_current_key, encoded_target_namespace)
+            state.name, self._encoded_current_key, encoded_target_namespace, ttl_config)
         state_key.bag_user_state.transform_id = self.MERGE_NAMESAPCES_MARK
 
         encoded_namespaces_writer = BytesIO()
@@ -1124,12 +1159,17 @@ class RemoteKeyedStateBackend(object):
                 self._map_state_handler.clear_read_cache(state_key)
 
     @staticmethod
-    def get_bag_state_key(name, encoded_key, encoded_namespace):
+    def get_bag_state_key(name, encoded_key, encoded_namespace, ttl_config):
+        from pyflink.fn_execution.flink_fn_execution_pb2 import StateDescriptor
+        state_proto = StateDescriptor()
+        state_proto.state_name = name
+        if ttl_config is not None:
+            state_proto.state_ttl_config.CopyFrom(ttl_config._to_proto())
         return beam_fn_api_pb2.StateKey(
             bag_user_state=beam_fn_api_pb2.StateKey.BagUserState(
                 transform_id="",
                 window=encoded_namespace,
-                user_state_id=name,
+                user_state_id=base64.b64encode(state_proto.SerializeToString()),
                 key=encoded_key))
 
     @staticmethod

--- a/flink-python/pyflink/proto/flink-fn-execution.proto
+++ b/flink-python/pyflink/proto/flink-fn-execution.proto
@@ -373,6 +373,95 @@ message UserDefinedDataStreamFunction {
   bool profile_enabled = 6;
 }
 
+// A representation of State
+message StateDescriptor {
+  message StateTTLConfig {
+    // This option value configures when to update last access timestamp which prolongs state TTL.
+    enum UpdateType {
+      // TTL is disabled. State does not expire.
+      Disabled = 0;
+
+      // Last access timestamp is initialised when state is created and updated on every write operation.
+      OnCreateAndWrite = 1;
+
+      // The same as OnCreateAndWrite but also updated on read.
+      OnReadAndWrite = 2;
+    }
+
+    // This option configures whether expired user value can be returned or not.
+    enum StateVisibility {
+      // Return expired user value if it is not cleaned up yet.
+      ReturnExpiredIfNotCleanedUp = 0;
+
+      // Never return expired user value.
+      NeverReturnExpired = 1;
+    }
+
+    // This option configures time scale to use for ttl.
+    enum TtlTimeCharacteristic {
+      // Processing time
+      ProcessingTime = 0;
+    }
+
+    // TTL cleanup strategies.
+    message CleanupStrategies {
+      // Fixed strategies ordinals in strategies config field.
+      enum Strategies {
+        FULL_STATE_SCAN_SNAPSHOT = 0;
+        INCREMENTAL_CLEANUP = 1;
+        ROCKSDB_COMPACTION_FILTER = 2;
+      }
+
+      enum EmptyCleanupStrategy {
+        EMPTY_STRATEGY = 0;
+      }
+
+      // Configuration of cleanup strategy while taking the full snapshot.
+      message IncrementalCleanupStrategy {
+        // Max number of keys pulled from queue for clean up upon state touch for any key.
+        int32 cleanup_size = 1;
+
+        // Whether to run incremental cleanup per each processed record.
+        bool run_cleanup_for_every_record = 2;
+      }
+
+      // Configuration of cleanup strategy using custom compaction filter in RocksDB.
+      message RocksdbCompactFilterCleanupStrategy {
+        // Number of state entries to process by compaction filter before updating current timestamp.
+        int64 query_time_after_num_entries = 1;
+      }
+
+      message MapStrategiesEntry {
+        Strategies strategy = 1;
+
+        oneof CleanupStrategy {
+          EmptyCleanupStrategy empty_strategy = 2;
+          IncrementalCleanupStrategy incremental_cleanup_strategy = 3;
+          RocksdbCompactFilterCleanupStrategy rocksdb_compact_filter_cleanup_strategy = 4;
+        }
+      }
+
+      bool is_cleanup_in_background = 1;
+
+      repeated MapStrategiesEntry strategies = 2;
+    }
+
+    UpdateType update_type = 1;
+
+    StateVisibility state_visibility = 2;
+
+    TtlTimeCharacteristic ttl_time_characteristic = 3;
+
+    int64 ttl = 4;
+
+    CleanupStrategies cleanup_strategies = 5;
+  }
+
+  string state_name = 1;
+
+  StateTTLConfig state_ttl_config = 2;
+}
+
 // ------------------------------------------------------------------------
 // Common of Table API and DataStream API
 // ------------------------------------------------------------------------

--- a/flink-python/src/main/java/org/apache/flink/streaming/api/utils/ProtoUtils.java
+++ b/flink-python/src/main/java/org/apache/flink/streaming/api/utils/ProtoUtils.java
@@ -325,6 +325,32 @@ public enum ProtoUtils {
                 separatedWithEndMessage);
     }
 
+    private static FlinkFnApi.CoderInfoDescriptor createCoderInfoDescriptorProto(
+            FlinkFnApi.CoderInfoDescriptor.FlattenRowType flattenRowType,
+            FlinkFnApi.CoderInfoDescriptor.RowType rowType,
+            FlinkFnApi.CoderInfoDescriptor.ArrowType arrowType,
+            FlinkFnApi.CoderInfoDescriptor.OverWindowArrowType overWindowArrowType,
+            FlinkFnApi.CoderInfoDescriptor.RawType rawType,
+            FlinkFnApi.CoderInfoDescriptor.Mode mode,
+            boolean separatedWithEndMessage) {
+        FlinkFnApi.CoderInfoDescriptor.Builder builder =
+                FlinkFnApi.CoderInfoDescriptor.newBuilder();
+        if (flattenRowType != null) {
+            builder.setFlattenRowType(flattenRowType);
+        } else if (rowType != null) {
+            builder.setRowType(rowType);
+        } else if (arrowType != null) {
+            builder.setArrowType(arrowType);
+        } else if (overWindowArrowType != null) {
+            builder.setOverWindowArrowType(overWindowArrowType);
+        } else if (rawType != null) {
+            builder.setRawType(rawType);
+        }
+        builder.setMode(mode);
+        builder.setSeparatedWithEndMessage(separatedWithEndMessage);
+        return builder.build();
+    }
+
     public static StateTtlConfig parseStateTtlConfigFromProto(
             FlinkFnApi.StateDescriptor.StateTTLConfig stateTTLConfigProto) {
         StateTtlConfig.Builder builder =
@@ -375,32 +401,6 @@ public enum ProtoUtils {
             }
         }
 
-        return builder.build();
-    }
-
-    private static FlinkFnApi.CoderInfoDescriptor createCoderInfoDescriptorProto(
-            FlinkFnApi.CoderInfoDescriptor.FlattenRowType flattenRowType,
-            FlinkFnApi.CoderInfoDescriptor.RowType rowType,
-            FlinkFnApi.CoderInfoDescriptor.ArrowType arrowType,
-            FlinkFnApi.CoderInfoDescriptor.OverWindowArrowType overWindowArrowType,
-            FlinkFnApi.CoderInfoDescriptor.RawType rawType,
-            FlinkFnApi.CoderInfoDescriptor.Mode mode,
-            boolean separatedWithEndMessage) {
-        FlinkFnApi.CoderInfoDescriptor.Builder builder =
-                FlinkFnApi.CoderInfoDescriptor.newBuilder();
-        if (flattenRowType != null) {
-            builder.setFlattenRowType(flattenRowType);
-        } else if (rowType != null) {
-            builder.setRowType(rowType);
-        } else if (arrowType != null) {
-            builder.setArrowType(arrowType);
-        } else if (overWindowArrowType != null) {
-            builder.setOverWindowArrowType(overWindowArrowType);
-        } else if (rawType != null) {
-            builder.setRawType(rawType);
-        }
-        builder.setMode(mode);
-        builder.setSeparatedWithEndMessage(separatedWithEndMessage);
         return builder.build();
     }
 

--- a/flink-python/src/main/java/org/apache/flink/streaming/api/utils/ProtoUtils.java
+++ b/flink-python/src/main/java/org/apache/flink/streaming/api/utils/ProtoUtils.java
@@ -20,6 +20,8 @@ package org.apache.flink.streaming.api.utils;
 
 import org.apache.flink.annotation.Internal;
 import org.apache.flink.api.common.functions.RuntimeContext;
+import org.apache.flink.api.common.state.StateTtlConfig;
+import org.apache.flink.api.common.time.Time;
 import org.apache.flink.api.common.typeinfo.TypeInformation;
 import org.apache.flink.fnexecution.v1.FlinkFnApi;
 import org.apache.flink.streaming.api.functions.python.DataStreamPythonFunctionInfo;
@@ -41,7 +43,7 @@ import java.util.stream.Collectors;
 import static org.apache.flink.python.Constants.FLINK_CODER_URN;
 import static org.apache.flink.table.runtime.typeutils.PythonTypeUtils.toProtoType;
 
-/** Utilities used to construct protobuf objects. */
+/** Utilities used to construct protobuf objects or construct objects from protobuf objects. */
 @Internal
 public enum ProtoUtils {
     ;
@@ -323,6 +325,59 @@ public enum ProtoUtils {
                 separatedWithEndMessage);
     }
 
+    public static StateTtlConfig parseStateTtlConfigFromProto(
+            FlinkFnApi.StateDescriptor.StateTTLConfig stateTTLConfigProto) {
+        StateTtlConfig.Builder builder =
+                StateTtlConfig.newBuilder(Time.milliseconds(stateTTLConfigProto.getTtl()))
+                        .setUpdateType(
+                                parseUpdateTypeFromProto(stateTTLConfigProto.getUpdateType()))
+                        .setStateVisibility(
+                                parseStateVisibilityFromProto(
+                                        stateTTLConfigProto.getStateVisibility()))
+                        .setTtlTimeCharacteristic(
+                                parseTtlTimeCharacteristicFromProto(
+                                        stateTTLConfigProto.getTtlTimeCharacteristic()));
+
+        FlinkFnApi.StateDescriptor.StateTTLConfig.CleanupStrategies cleanupStrategiesProto =
+                stateTTLConfigProto.getCleanupStrategies();
+
+        if (!cleanupStrategiesProto.getIsCleanupInBackground()) {
+            builder.disableCleanupInBackground();
+        }
+
+        for (FlinkFnApi.StateDescriptor.StateTTLConfig.CleanupStrategies.MapStrategiesEntry
+                mapStrategiesEntry : cleanupStrategiesProto.getStrategiesList()) {
+            FlinkFnApi.StateDescriptor.StateTTLConfig.CleanupStrategies.Strategies strategyProto =
+                    mapStrategiesEntry.getStrategy();
+            if (strategyProto
+                    == FlinkFnApi.StateDescriptor.StateTTLConfig.CleanupStrategies.Strategies
+                            .FULL_STATE_SCAN_SNAPSHOT) {
+                builder.cleanupFullSnapshot();
+            } else if (strategyProto
+                    == FlinkFnApi.StateDescriptor.StateTTLConfig.CleanupStrategies.Strategies
+                            .INCREMENTAL_CLEANUP) {
+                FlinkFnApi.StateDescriptor.StateTTLConfig.CleanupStrategies
+                                .IncrementalCleanupStrategy
+                        incrementalCleanupStrategyProto =
+                                mapStrategiesEntry.getIncrementalCleanupStrategy();
+                builder.cleanupIncrementally(
+                        incrementalCleanupStrategyProto.getCleanupSize(),
+                        incrementalCleanupStrategyProto.getRunCleanupForEveryRecord());
+            } else if (strategyProto
+                    == FlinkFnApi.StateDescriptor.StateTTLConfig.CleanupStrategies.Strategies
+                            .ROCKSDB_COMPACTION_FILTER) {
+                FlinkFnApi.StateDescriptor.StateTTLConfig.CleanupStrategies
+                                .RocksdbCompactFilterCleanupStrategy
+                        rocksdbCompactFilterCleanupStrategyProto =
+                                mapStrategiesEntry.getRocksdbCompactFilterCleanupStrategy();
+                builder.cleanupInRocksdbCompactFilter(
+                        rocksdbCompactFilterCleanupStrategyProto.getQueryTimeAfterNumEntries());
+            }
+        }
+
+        return builder.build();
+    }
+
     private static FlinkFnApi.CoderInfoDescriptor createCoderInfoDescriptorProto(
             FlinkFnApi.CoderInfoDescriptor.FlattenRowType flattenRowType,
             FlinkFnApi.CoderInfoDescriptor.RowType rowType,
@@ -347,5 +402,41 @@ public enum ProtoUtils {
         builder.setMode(mode);
         builder.setSeparatedWithEndMessage(separatedWithEndMessage);
         return builder.build();
+    }
+
+    private static StateTtlConfig.UpdateType parseUpdateTypeFromProto(
+            FlinkFnApi.StateDescriptor.StateTTLConfig.UpdateType updateType) {
+        if (updateType == FlinkFnApi.StateDescriptor.StateTTLConfig.UpdateType.Disabled) {
+            return StateTtlConfig.UpdateType.Disabled;
+        } else if (updateType
+                == FlinkFnApi.StateDescriptor.StateTTLConfig.UpdateType.OnCreateAndWrite) {
+            return StateTtlConfig.UpdateType.OnCreateAndWrite;
+        } else if (updateType
+                == FlinkFnApi.StateDescriptor.StateTTLConfig.UpdateType.OnReadAndWrite) {
+            return StateTtlConfig.UpdateType.OnReadAndWrite;
+        }
+        throw new RuntimeException("Unknown UpdateType " + updateType);
+    }
+
+    private static StateTtlConfig.StateVisibility parseStateVisibilityFromProto(
+            FlinkFnApi.StateDescriptor.StateTTLConfig.StateVisibility stateVisibility) {
+        if (stateVisibility
+                == FlinkFnApi.StateDescriptor.StateTTLConfig.StateVisibility
+                        .ReturnExpiredIfNotCleanedUp) {
+            return StateTtlConfig.StateVisibility.ReturnExpiredIfNotCleanedUp;
+        } else if (stateVisibility
+                == FlinkFnApi.StateDescriptor.StateTTLConfig.StateVisibility.NeverReturnExpired) {
+            return StateTtlConfig.StateVisibility.NeverReturnExpired;
+        }
+        throw new RuntimeException("Unknown StateVisibility " + stateVisibility);
+    }
+
+    private static StateTtlConfig.TtlTimeCharacteristic parseTtlTimeCharacteristicFromProto(
+            FlinkFnApi.StateDescriptor.StateTTLConfig.TtlTimeCharacteristic ttlTimeCharacteristic) {
+        if (ttlTimeCharacteristic
+                == FlinkFnApi.StateDescriptor.StateTTLConfig.TtlTimeCharacteristic.ProcessingTime) {
+            return StateTtlConfig.TtlTimeCharacteristic.ProcessingTime;
+        }
+        throw new RuntimeException("Unknown TtlTimeCharacteristic " + ttlTimeCharacteristic);
     }
 }

--- a/flink-python/src/test/java/org/apache/flink/streaming/api/utils/ProtoUtilsTest.java
+++ b/flink-python/src/test/java/org/apache/flink/streaming/api/utils/ProtoUtilsTest.java
@@ -1,0 +1,122 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.flink.streaming.api.utils;
+
+import org.apache.flink.api.common.state.StateTtlConfig;
+import org.apache.flink.api.common.time.Time;
+import org.apache.flink.fnexecution.v1.FlinkFnApi;
+
+import org.junit.Test;
+
+import java.util.concurrent.TimeUnit;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertNotNull;
+import static org.junit.Assert.assertTrue;
+
+/**
+ * Test class for testing utilities used to construct protobuf objects or construct objects from
+ * protobuf objects.
+ */
+public class ProtoUtilsTest {
+    @Test
+    public void testParseStateTtlConfigFromProto() {
+        FlinkFnApi.StateDescriptor.StateTTLConfig.CleanupStrategies cleanupStrategiesProto =
+                FlinkFnApi.StateDescriptor.StateTTLConfig.CleanupStrategies.newBuilder()
+                        .setIsCleanupInBackground(true)
+                        .addStrategies(
+                                FlinkFnApi.StateDescriptor.StateTTLConfig.CleanupStrategies
+                                        .MapStrategiesEntry.newBuilder()
+                                        .setStrategy(
+                                                FlinkFnApi.StateDescriptor.StateTTLConfig
+                                                        .CleanupStrategies.Strategies
+                                                        .FULL_STATE_SCAN_SNAPSHOT)
+                                        .setEmptyStrategy(
+                                                FlinkFnApi.StateDescriptor.StateTTLConfig
+                                                        .CleanupStrategies.EmptyCleanupStrategy
+                                                        .EMPTY_STRATEGY))
+                        .addStrategies(
+                                FlinkFnApi.StateDescriptor.StateTTLConfig.CleanupStrategies
+                                        .MapStrategiesEntry.newBuilder()
+                                        .setStrategy(
+                                                FlinkFnApi.StateDescriptor.StateTTLConfig
+                                                        .CleanupStrategies.Strategies
+                                                        .INCREMENTAL_CLEANUP)
+                                        .setIncrementalCleanupStrategy(
+                                                FlinkFnApi.StateDescriptor.StateTTLConfig
+                                                        .CleanupStrategies
+                                                        .IncrementalCleanupStrategy.newBuilder()
+                                                        .setCleanupSize(10)
+                                                        .setRunCleanupForEveryRecord(true)
+                                                        .build()))
+                        .addStrategies(
+                                FlinkFnApi.StateDescriptor.StateTTLConfig.CleanupStrategies
+                                        .MapStrategiesEntry.newBuilder()
+                                        .setStrategy(
+                                                FlinkFnApi.StateDescriptor.StateTTLConfig
+                                                        .CleanupStrategies.Strategies
+                                                        .ROCKSDB_COMPACTION_FILTER)
+                                        .setRocksdbCompactFilterCleanupStrategy(
+                                                FlinkFnApi.StateDescriptor.StateTTLConfig
+                                                        .CleanupStrategies
+                                                        .RocksdbCompactFilterCleanupStrategy
+                                                        .newBuilder()
+                                                        .setQueryTimeAfterNumEntries(1000)
+                                                        .build()))
+                        .build();
+        FlinkFnApi.StateDescriptor.StateTTLConfig stateTTLConfigProto =
+                FlinkFnApi.StateDescriptor.StateTTLConfig.newBuilder()
+                        .setTtl(Time.of(1000, TimeUnit.MILLISECONDS).toMilliseconds())
+                        .setUpdateType(
+                                FlinkFnApi.StateDescriptor.StateTTLConfig.UpdateType
+                                        .OnCreateAndWrite)
+                        .setStateVisibility(
+                                FlinkFnApi.StateDescriptor.StateTTLConfig.StateVisibility
+                                        .NeverReturnExpired)
+                        .setCleanupStrategies(cleanupStrategiesProto)
+                        .build();
+
+        StateTtlConfig stateTTLConfig =
+                ProtoUtils.parseStateTtlConfigFromProto(stateTTLConfigProto);
+
+        assertEquals(stateTTLConfig.getUpdateType(), StateTtlConfig.UpdateType.OnCreateAndWrite);
+        assertEquals(
+                stateTTLConfig.getStateVisibility(),
+                StateTtlConfig.StateVisibility.NeverReturnExpired);
+        assertEquals(stateTTLConfig.getTtl(), Time.milliseconds(1000));
+        assertEquals(
+                stateTTLConfig.getTtlTimeCharacteristic(),
+                StateTtlConfig.TtlTimeCharacteristic.ProcessingTime);
+
+        StateTtlConfig.CleanupStrategies cleanupStrategies = stateTTLConfig.getCleanupStrategies();
+        assertTrue(cleanupStrategies.isCleanupInBackground());
+        assertTrue(cleanupStrategies.inFullSnapshot());
+
+        StateTtlConfig.IncrementalCleanupStrategy incrementalCleanupStrategy =
+                cleanupStrategies.getIncrementalCleanupStrategy();
+        assertNotNull(incrementalCleanupStrategy);
+        assertEquals(incrementalCleanupStrategy.getCleanupSize(), 10);
+        assertTrue(incrementalCleanupStrategy.runCleanupForEveryRecord());
+
+        StateTtlConfig.RocksdbCompactFilterCleanupStrategy rocksdbCompactFilterCleanupStrategy =
+                cleanupStrategies.getRocksdbCompactFilterCleanupStrategy();
+        assertNotNull(rocksdbCompactFilterCleanupStrategy);
+        assertEquals(rocksdbCompactFilterCleanupStrategy.getQueryTimeAfterNumEntries(), 1000);
+    }
+}


### PR DESCRIPTION
## What is the purpose of the change

*This pull request will support state ttl in Python DataStream API*


## Brief change log

  - *Add `StateTtlConfig`*
  - *Add public API `enable_time_to_live` in `StateDescriptor`*

## Verifying this change

This change added tests and can be verified as follows:

  - *Add java UT `ProtoUtilsTest.java`*
  - *Add python UT `test_state_ttl_config_proto` in `test_flink_fn_execution_pb2.py`*
  - *Change Current IT `test_keyed_process_function_with_state` and `test_aggregating_state` in `test_datastrea.py` to cover this new feature*

## Does this pull request potentially affect one of the following parts:

  - Dependencies (does it add or upgrade a dependency): (no)
  - The public API, i.e., is any changed class annotated with `@Public(Evolving)`: (no)
  - The serializers: (no)
  - The runtime per-record code paths (performance sensitive): (no)
  - Anything that affects deployment or recovery: JobManager (and its components), Checkpointing, Kubernetes/Yarn, ZooKeeper: (no)
  - The S3 file system connector: (no)

## Documentation

  - Does this pull request introduce a new feature? (yes)
  - If yes, how is the feature documented? (docs)
