### PR TITLE
[FLINK-23581][docs] Change site.download_url to https://flink.apache.…

### DIFF
--- a/docs/README.md
+++ b/docs/README.md
@@ -52,7 +52,7 @@ In addition to Markdown, every page contains a Jekyll front matter, which specif
     ---
     title: "Title of the Page"
     ---
-
+    
     ---
     title: "Title of the Page" <-- Title rendered in the side nave
     weight: 1 <-- Weight controls the ordering of pages in the side nav. 
@@ -124,7 +124,7 @@ This will be replaced by a back to top link. It is recommended to use these link
 	{{< hint info >}}
 	Some interesting information
 	{{< /hint >}}
-	
+
 The hint will be rendered in a blue box. This hint is useful when providing 
 additional information for the user that does not fit into the flow of the documentation.
 
@@ -150,20 +150,20 @@ functionality.
 #### Label
 
     {{< label "My Label" >}}
-    
+
 The label will be rendered in an inlined blue box. This is useful for labeling functionality
 such as whether a SQL feature works for only batch or streaming execution. 
 
 #### Flink version 
 
     {{< version >}}
-    
+
 Interpolates the current Flink version
 
 #### Scala Version
 
     {{< scala_verison >}}
-    
+
 Interpolates the default scala version
 
 #### Stable
@@ -171,7 +171,7 @@ Interpolates the default scala version
     {{< stable >}}
      Some content
     {{< /stable >}}
-    
+
 This shortcode will only render its content if the site is marked as stable. 
 
 #### Unstable 
@@ -179,13 +179,13 @@ This shortcode will only render its content if the site is marked as stable.
     {{< unstable >}}
     Some content 
     {{< /unstable >}}
-    
+
 This shortcode will only render its content if the site is marked as unstable. 
 
 #### Query State Warning
 
     {{< query_state_warning >}}
-    
+
 Will render a warning the current SQL feature may have unbounded state requirements.
 
 #### tab
@@ -202,22 +202,22 @@ Will render a warning the current SQL feature may have unbounded state requireme
     ```
     {< /tab >}}
     {{< /tabs }}
-    
+
 Prints the content in tabs. IMPORTANT: The label in the outermost "tabs" shortcode must
 be unique for the page. 
 
 #### Github Repo
 
     {{< github_repo >}}
-    
+
 Renders a link to the apache flink repo. 
 
 #### Github Link
 
     {{< gh_link file="/some/file.java" name="Some file" >}}
-    
+
 Renders a link to a file in the Apache Flink repo with a given name. 
- 
+
 #### JavaDocs Link
     {{< javadoc file="some/file" name="Some file" >}}
 
@@ -227,3 +227,11 @@ Renders a link to a file in the Apache Flink Java Documentation.
     {< pythondoc file="some/file" name="Some file" >}}
 
 Renders a link to a file in the Apache Flink Python Documentation. 
+
+#### FlinkDownloads Link
+
+```
+{{< downloads >}}
+```
+
+Renders a link to the apache flink download page. 

--- a/docs/config.toml
+++ b/docs/config.toml
@@ -24,8 +24,8 @@ pygmentsUseClasses = true
 [params]
   # Flag whether this is a stable version or not.
   # Used for the quickstart page.
-  IsStable = false 
-  
+  IsStable = false
+
   # Flag to indicate whether an outdated warning should be shown.
   ShowOutDatedWarning = false
 
@@ -48,13 +48,17 @@ pygmentsUseClasses = true
 
   GithubRepo = "https://github.com/apache/flink.git"
 
-  # Flink training exercises 
+  # Flink training exercises
   TrainingExercises = "//github.com/apache/flink-training"
 
   # This suffix is appended to the Scala-dependent Maven artifact names
   ScalaVersion = "_2.11"
 
   ProjectHomepage = "//flink.apache.org"
+
+  DownloadPage = "//flink.apache.org/downloads.html"
+
+  ZhDownloadPage = "//flink.apache.org/zh/downloads.html"
 
   JavaDocs = "//ci.apache.org/projects/flink/flink-docs-master/api/java/"
 

--- a/docs/content.zh/docs/deployment/resource-providers/standalone/overview.md
+++ b/docs/content.zh/docs/deployment/resource-providers/standalone/overview.md
@@ -69,7 +69,7 @@ Flink 需要 master 和所有 worker 节点设置 `JAVA_HOME` 环境变量，并
 
 ## Flink 设置
 
-前往 [下载页面](https://flink.apache.org/zh/downloads.html) 获取可运行的软件包。
+前往 [下载页面]({{< param "ZhDownloadPage" >}}) 获取可运行的软件包。
 
 在下载完最新的发布版本后，复制压缩文件到 master 节点并解压：
 

--- a/docs/content.zh/docs/deployment/resource-providers/standalone/overview.md
+++ b/docs/content.zh/docs/deployment/resource-providers/standalone/overview.md
@@ -69,7 +69,7 @@ Flink 需要 master 和所有 worker 节点设置 `JAVA_HOME` 环境变量，并
 
 ## Flink 设置
 
-前往 [下载页面]({{ site.zh_download_url }}) 获取可运行的软件包。
+前往 [下载页面](https://flink.apache.org/zh/downloads.html) 获取可运行的软件包。
 
 在下载完最新的发布版本后，复制压缩文件到 master 节点并解压：
 

--- a/docs/content.zh/docs/deployment/resource-providers/standalone/overview.md
+++ b/docs/content.zh/docs/deployment/resource-providers/standalone/overview.md
@@ -69,7 +69,7 @@ Flink 需要 master 和所有 worker 节点设置 `JAVA_HOME` 环境变量，并
 
 ## Flink 设置
 
-前往 [下载页面]({{< param "ZhDownloadPage" >}}) 获取可运行的软件包。
+前往 [下载页面]({{< downloads >}}) 获取可运行的软件包。
 
 在下载完最新的发布版本后，复制压缩文件到 master 节点并解压：
 

--- a/docs/content.zh/docs/deployment/resource-providers/yarn.md
+++ b/docs/content.zh/docs/deployment/resource-providers/yarn.md
@@ -43,7 +43,7 @@ Flink can dynamically allocate and de-allocate TaskManager resources depending o
 This *Getting Started* section assumes a functional YARN environment, starting from version 2.4.1. YARN environments are provided most conveniently through services such as Amazon EMR, Google Cloud DataProc or products like Cloudera. [Manually setting up a YARN environment locally](https://hadoop.apache.org/docs/current/hadoop-project-dist/hadoop-common/SingleCluster.html) or [on a cluster](https://hadoop.apache.org/docs/current/hadoop-project-dist/hadoop-common/ClusterSetup.html) is not recommended for following through this *Getting Started* tutorial. 
 
 - Make sure your YARN cluster is ready for accepting Flink applications by running `yarn top`. It should show no error messages.
-- Download a recent Flink distribution from the [download page](https://flink.apache.org/downloads.html) and unpack it.
+- Download a recent Flink distribution from the [download page]({{< param "DownloadPage" >}}) and unpack it.
 - **Important** Make sure that the `HADOOP_CLASSPATH` environment variable is set up (it can be checked by running `echo $HADOOP_CLASSPATH`). If not, set it up using 
 
 ```bash
@@ -225,7 +225,7 @@ For providing Flink with the required Hadoop dependencies, we recommend setting 
 
 If that is not possible, the dependencies can also be put into the `lib/` folder of Flink. 
 
-Flink also offers pre-bundled Hadoop fat jars for placing them in the `lib/` folder, on the [Downloads / Additional Components](https://flink.apache.org/downloads.html#additional-components) section of the website. These pre-bundled fat jars are shaded to avoid dependency conflicts with common libraries. The Flink community is not testing the YARN integration against these pre-bundled jars. 
+Flink also offers pre-bundled Hadoop fat jars for placing them in the `lib/` folder, on the [Downloads / Additional Components]({{< param "DownloadPage" >}}#additional-components) section of the website. These pre-bundled fat jars are shaded to avoid dependency conflicts with common libraries. The Flink community is not testing the YARN integration against these pre-bundled jars. 
 
 ### Running Flink on YARN behind Firewalls
 

--- a/docs/content.zh/docs/deployment/resource-providers/yarn.md
+++ b/docs/content.zh/docs/deployment/resource-providers/yarn.md
@@ -43,7 +43,7 @@ Flink can dynamically allocate and de-allocate TaskManager resources depending o
 This *Getting Started* section assumes a functional YARN environment, starting from version 2.4.1. YARN environments are provided most conveniently through services such as Amazon EMR, Google Cloud DataProc or products like Cloudera. [Manually setting up a YARN environment locally](https://hadoop.apache.org/docs/current/hadoop-project-dist/hadoop-common/SingleCluster.html) or [on a cluster](https://hadoop.apache.org/docs/current/hadoop-project-dist/hadoop-common/ClusterSetup.html) is not recommended for following through this *Getting Started* tutorial. 
 
 - Make sure your YARN cluster is ready for accepting Flink applications by running `yarn top`. It should show no error messages.
-- Download a recent Flink distribution from the [download page]({{ site.download_url }}) and unpack it.
+- Download a recent Flink distribution from the [download page](https://flink.apache.org/downloads.html) and unpack it.
 - **Important** Make sure that the `HADOOP_CLASSPATH` environment variable is set up (it can be checked by running `echo $HADOOP_CLASSPATH`). If not, set it up using 
 
 ```bash
@@ -225,7 +225,7 @@ For providing Flink with the required Hadoop dependencies, we recommend setting 
 
 If that is not possible, the dependencies can also be put into the `lib/` folder of Flink. 
 
-Flink also offers pre-bundled Hadoop fat jars for placing them in the `lib/` folder, on the [Downloads / Additional Components]({{site.download_url}}#additional-components) section of the website. These pre-bundled fat jars are shaded to avoid dependency conflicts with common libraries. The Flink community is not testing the YARN integration against these pre-bundled jars. 
+Flink also offers pre-bundled Hadoop fat jars for placing them in the `lib/` folder, on the [Downloads / Additional Components](https://flink.apache.org/downloads.html#additional-components) section of the website. These pre-bundled fat jars are shaded to avoid dependency conflicts with common libraries. The Flink community is not testing the YARN integration against these pre-bundled jars. 
 
 ### Running Flink on YARN behind Firewalls
 

--- a/docs/content.zh/docs/deployment/resource-providers/yarn.md
+++ b/docs/content.zh/docs/deployment/resource-providers/yarn.md
@@ -43,7 +43,7 @@ Flink can dynamically allocate and de-allocate TaskManager resources depending o
 This *Getting Started* section assumes a functional YARN environment, starting from version 2.4.1. YARN environments are provided most conveniently through services such as Amazon EMR, Google Cloud DataProc or products like Cloudera. [Manually setting up a YARN environment locally](https://hadoop.apache.org/docs/current/hadoop-project-dist/hadoop-common/SingleCluster.html) or [on a cluster](https://hadoop.apache.org/docs/current/hadoop-project-dist/hadoop-common/ClusterSetup.html) is not recommended for following through this *Getting Started* tutorial. 
 
 - Make sure your YARN cluster is ready for accepting Flink applications by running `yarn top`. It should show no error messages.
-- Download a recent Flink distribution from the [download page]({{< param "DownloadPage" >}}) and unpack it.
+- Download a recent Flink distribution from the [download page]({{< downloads >}}) and unpack it.
 - **Important** Make sure that the `HADOOP_CLASSPATH` environment variable is set up (it can be checked by running `echo $HADOOP_CLASSPATH`). If not, set it up using 
 
 ```bash
@@ -225,7 +225,7 @@ For providing Flink with the required Hadoop dependencies, we recommend setting 
 
 If that is not possible, the dependencies can also be put into the `lib/` folder of Flink. 
 
-Flink also offers pre-bundled Hadoop fat jars for placing them in the `lib/` folder, on the [Downloads / Additional Components]({{< param "DownloadPage" >}}#additional-components) section of the website. These pre-bundled fat jars are shaded to avoid dependency conflicts with common libraries. The Flink community is not testing the YARN integration against these pre-bundled jars. 
+Flink also offers pre-bundled Hadoop fat jars for placing them in the `lib/` folder, on the [Downloads / Additional Components]({{< downloads >}}#additional-components) section of the website. These pre-bundled fat jars are shaded to avoid dependency conflicts with common libraries. The Flink community is not testing the YARN integration against these pre-bundled jars. 
 
 ### Running Flink on YARN behind Firewalls
 

--- a/docs/content.zh/docs/dev/datastream/fault-tolerance/queryable_state.md
+++ b/docs/content.zh/docs/dev/datastream/fault-tolerance/queryable_state.md
@@ -56,7 +56,7 @@ under the License.
 为了在 Flink 集群上使用 queryable state，需要进行以下操作：
 
  1. 将 `flink-queryable-state-runtime{{< scala_version >}}-{{< version >}}.jar`
-从 [Flink distribution](https://flink.apache.org/downloads.html "Apache Flink: Downloads") 的 `opt/` 目录拷贝到 `lib/` 目录；
+从 [Flink distribution]({{< param "ZhDownloadPage" >}} "Apache Flink: Downloads") 的 `opt/` 目录拷贝到 `lib/` 目录；
  2. 将参数 `queryable-state.enable` 设置为 `true`。详细信息以及其它配置可参考文档 [Configuration]({{< ref "docs/deployment/config" >}}#queryable-state)。
 
 为了验证集群的 queryable state 已经被激活，可以检查任意 task manager 的日志中是否包含 "Started the Queryable State Proxy Server @ ..."。

--- a/docs/content.zh/docs/dev/datastream/fault-tolerance/queryable_state.md
+++ b/docs/content.zh/docs/dev/datastream/fault-tolerance/queryable_state.md
@@ -56,7 +56,7 @@ under the License.
 为了在 Flink 集群上使用 queryable state，需要进行以下操作：
 
  1. 将 `flink-queryable-state-runtime{{< scala_version >}}-{{< version >}}.jar`
-从 [Flink distribution]({{< param "ZhDownloadPage" >}} "Apache Flink: Downloads") 的 `opt/` 目录拷贝到 `lib/` 目录；
+从 [Flink distribution]({{< downloads >}} "Apache Flink: Downloads") 的 `opt/` 目录拷贝到 `lib/` 目录；
  2. 将参数 `queryable-state.enable` 设置为 `true`。详细信息以及其它配置可参考文档 [Configuration]({{< ref "docs/deployment/config" >}}#queryable-state)。
 
 为了验证集群的 queryable state 已经被激活，可以检查任意 task manager 的日志中是否包含 "Started the Queryable State Proxy Server @ ..."。

--- a/docs/content.zh/docs/flinkDev/building.md
+++ b/docs/content.zh/docs/flinkDev/building.md
@@ -33,7 +33,7 @@ under the License.
 
 ## 构建 Flink
 
-首先需要准备源码。可以[从发布版本下载源码](https://flink.apache.org/downloads.html) 或者[从 Git 库克隆 Flink 源码]({{< github_repo >}})。
+首先需要准备源码。可以[从发布版本下载源码]({{< param "ZhDownloadPage" >}}) 或者[从 Git 库克隆 Flink 源码]({{< github_repo >}})。
 
 还需要准备 **Maven 3** 和 **JDK** (Java开发套件)。Flink 依赖 **Java 8** 或更新的版本来进行构建。
 

--- a/docs/content.zh/docs/flinkDev/building.md
+++ b/docs/content.zh/docs/flinkDev/building.md
@@ -33,7 +33,7 @@ under the License.
 
 ## 构建 Flink
 
-首先需要准备源码。可以[从发布版本下载源码]({{< param "ZhDownloadPage" >}}) 或者[从 Git 库克隆 Flink 源码]({{< github_repo >}})。
+首先需要准备源码。可以[从发布版本下载源码]({{< downloads >}}) 或者[从 Git 库克隆 Flink 源码]({{< github_repo >}})。
 
 还需要准备 **Maven 3** 和 **JDK** (Java开发套件)。Flink 依赖 **Java 8** 或更新的版本来进行构建。
 

--- a/docs/content.zh/docs/libs/gelly/overview.md
+++ b/docs/content.zh/docs/libs/gelly/overview.md
@@ -60,7 +60,7 @@ The remaining sections provide a description of available methods and present se
 Running Gelly Examples
 ----------------------
 
-The Gelly library jars are provided in the [Flink distribution](https://flink.apache.org/downloads.html "Apache Flink: Downloads")
+The Gelly library jars are provided in the [Flink distribution]({{< param "DownloadPage" >}} "Apache Flink: Downloads")
 in the **opt** directory (for versions older than Flink 1.2 these can be manually downloaded from
 [Maven Central](http://search.maven.org/#search|ga|1|flink%20gelly)). To run the Gelly examples the **flink-gelly** (for
 Java) or **flink-gelly-scala** (for Scala) jar must be copied to Flink's **lib** directory.

--- a/docs/content.zh/docs/libs/gelly/overview.md
+++ b/docs/content.zh/docs/libs/gelly/overview.md
@@ -60,7 +60,7 @@ The remaining sections provide a description of available methods and present se
 Running Gelly Examples
 ----------------------
 
-The Gelly library jars are provided in the [Flink distribution]({{< param "DownloadPage" >}} "Apache Flink: Downloads")
+The Gelly library jars are provided in the [Flink distribution]({{< downloads >}} "Apache Flink: Downloads")
 in the **opt** directory (for versions older than Flink 1.2 these can be manually downloaded from
 [Maven Central](http://search.maven.org/#search|ga|1|flink%20gelly)). To run the Gelly examples the **flink-gelly** (for
 Java) or **flink-gelly-scala** (for Scala) jar must be copied to Flink's **lib** directory.

--- a/docs/content.zh/docs/try-flink/local_installation.md
+++ b/docs/content.zh/docs/try-flink/local_installation.md
@@ -48,7 +48,7 @@ under the License.
 java -version
 ```
 
-[下载](https://flink.apache.org/downloads.html) release {{< version >}} 并解压。
+[下载]({{< param "ZhDownloadPage" >}}) release {{< version >}} 并解压。
 
 ```bash
 $ tar -xzf flink-{{< version >}}-bin-scala{{< scala_version >}}.tgz

--- a/docs/content.zh/docs/try-flink/local_installation.md
+++ b/docs/content.zh/docs/try-flink/local_installation.md
@@ -48,7 +48,7 @@ under the License.
 java -version
 ```
 
-[下载]({{< param "ZhDownloadPage" >}}) release {{< version >}} 并解压。
+[下载]({{< downloads >}}) release {{< version >}} 并解压。
 
 ```bash
 $ tar -xzf flink-{{< version >}}-bin-scala{{< scala_version >}}.tgz

--- a/docs/content.zh/release-notes/flink-1.8.md
+++ b/docs/content.zh/release-notes/flink-1.8.md
@@ -88,7 +88,7 @@ Convenience binaries that include hadoop are no longer released.
 If a deployment relies on `flink-shaded-hadoop2` being included in
 `flink-dist`, then you must manually download a pre-packaged Hadoop
 jar from the optional components section of the [download
-page]({{< param "DownloadPage" >}}) and copy it into the
+page]({{< downloads >}}) and copy it into the
 `/lib` directory.  Alternatively, a Flink distribution that includes
 hadoop can be built by packaging `flink-dist` and activating the
 `include-hadoop` maven profile.

--- a/docs/content.zh/release-notes/flink-1.8.md
+++ b/docs/content.zh/release-notes/flink-1.8.md
@@ -88,7 +88,7 @@ Convenience binaries that include hadoop are no longer released.
 If a deployment relies on `flink-shaded-hadoop2` being included in
 `flink-dist`, then you must manually download a pre-packaged Hadoop
 jar from the optional components section of the [download
-page](https://flink.apache.org/downloads.html) and copy it into the
+page]({{< param "DownloadPage" >}}) and copy it into the
 `/lib` directory.  Alternatively, a Flink distribution that includes
 hadoop can be built by packaging `flink-dist` and activating the
 `include-hadoop` maven profile.

--- a/docs/content/docs/deployment/resource-providers/standalone/overview.md
+++ b/docs/content/docs/deployment/resource-providers/standalone/overview.md
@@ -49,7 +49,7 @@ In the additional subpages of the standalone mode resource provider, we describe
 Flink runs on all *UNIX-like environments*, e.g. **Linux**, **Mac OS X**, and **Cygwin** (for Windows). Before you start to setup the system, make sure your system fulfils the following requirements.
 
 - **Java 1.8.x** or higher installed,
-- Downloaded a recent Flink distribution from the [download page]({{ site.download_url }}) and unpacked it.
+- Downloaded a recent Flink distribution from the [download page](https://flink.apache.org/downloads.html) and unpacked it.
 
 ### Starting a Standalone Cluster (Session Mode)
 

--- a/docs/content/docs/deployment/resource-providers/standalone/overview.md
+++ b/docs/content/docs/deployment/resource-providers/standalone/overview.md
@@ -49,7 +49,7 @@ In the additional subpages of the standalone mode resource provider, we describe
 Flink runs on all *UNIX-like environments*, e.g. **Linux**, **Mac OS X**, and **Cygwin** (for Windows). Before you start to setup the system, make sure your system fulfils the following requirements.
 
 - **Java 1.8.x** or higher installed,
-- Downloaded a recent Flink distribution from the [download page](https://flink.apache.org/downloads.html) and unpacked it.
+- Downloaded a recent Flink distribution from the [download page]({{< param "DownloadPage" >}}) and unpacked it.
 
 ### Starting a Standalone Cluster (Session Mode)
 

--- a/docs/content/docs/deployment/resource-providers/standalone/overview.md
+++ b/docs/content/docs/deployment/resource-providers/standalone/overview.md
@@ -49,7 +49,7 @@ In the additional subpages of the standalone mode resource provider, we describe
 Flink runs on all *UNIX-like environments*, e.g. **Linux**, **Mac OS X**, and **Cygwin** (for Windows). Before you start to setup the system, make sure your system fulfils the following requirements.
 
 - **Java 1.8.x** or higher installed,
-- Downloaded a recent Flink distribution from the [download page]({{< param "DownloadPage" >}}) and unpacked it.
+- Downloaded a recent Flink distribution from the [download page]({{< downloads >}}) and unpacked it.
 
 ### Starting a Standalone Cluster (Session Mode)
 

--- a/docs/content/docs/deployment/resource-providers/yarn.md
+++ b/docs/content/docs/deployment/resource-providers/yarn.md
@@ -43,7 +43,7 @@ Flink can dynamically allocate and de-allocate TaskManager resources depending o
 This *Getting Started* section assumes a functional YARN environment, starting from version 2.4.1. YARN environments are provided most conveniently through services such as Amazon EMR, Google Cloud DataProc or products like Cloudera. [Manually setting up a YARN environment locally](https://hadoop.apache.org/docs/current/hadoop-project-dist/hadoop-common/SingleCluster.html) or [on a cluster](https://hadoop.apache.org/docs/current/hadoop-project-dist/hadoop-common/ClusterSetup.html) is not recommended for following through this *Getting Started* tutorial. 
 
 - Make sure your YARN cluster is ready for accepting Flink applications by running `yarn top`. It should show no error messages.
-- Download a recent Flink distribution from the [download page](https://flink.apache.org/downloads.html) and unpack it.
+- Download a recent Flink distribution from the [download page]({{< param "DownloadPage" >}}) and unpack it.
 - **Important** Make sure that the `HADOOP_CLASSPATH` environment variable is set up (it can be checked by running `echo $HADOOP_CLASSPATH`). If not, set it up using 
 
 ```bash
@@ -225,7 +225,7 @@ For providing Flink with the required Hadoop dependencies, we recommend setting 
 
 If that is not possible, the dependencies can also be put into the `lib/` folder of Flink. 
 
-Flink also offers pre-bundled Hadoop fat jars for placing them in the `lib/` folder, on the [Downloads / Additional Components](https://flink.apache.org/downloads.html#additional-components) section of the website. These pre-bundled fat jars are shaded to avoid dependency conflicts with common libraries. The Flink community is not testing the YARN integration against these pre-bundled jars. 
+Flink also offers pre-bundled Hadoop fat jars for placing them in the `lib/` folder, on the [Downloads / Additional Components]({{< param "DownloadPage" >}}#additional-components) section of the website. These pre-bundled fat jars are shaded to avoid dependency conflicts with common libraries. The Flink community is not testing the YARN integration against these pre-bundled jars. 
 
 ### Running Flink on YARN behind Firewalls
 

--- a/docs/content/docs/deployment/resource-providers/yarn.md
+++ b/docs/content/docs/deployment/resource-providers/yarn.md
@@ -38,12 +38,14 @@ Flink services are submitted to YARN's ResourceManager, which spawns containers 
 
 Flink can dynamically allocate and de-allocate TaskManager resources depending on the number of processing slots required by the job(s) running on the JobManager.
 
+ [测试]({{< downloads >}}) 
+
 ### Preparation
 
 This *Getting Started* section assumes a functional YARN environment, starting from version 2.4.1. YARN environments are provided most conveniently through services such as Amazon EMR, Google Cloud DataProc or products like Cloudera. [Manually setting up a YARN environment locally](https://hadoop.apache.org/docs/current/hadoop-project-dist/hadoop-common/SingleCluster.html) or [on a cluster](https://hadoop.apache.org/docs/current/hadoop-project-dist/hadoop-common/ClusterSetup.html) is not recommended for following through this *Getting Started* tutorial. 
 
 - Make sure your YARN cluster is ready for accepting Flink applications by running `yarn top`. It should show no error messages.
-- Download a recent Flink distribution from the [download page]({{< param "DownloadPage" >}}) and unpack it.
+- Download a recent Flink distribution from the [download page]({{< downloads >}}) and unpack it.
 - **Important** Make sure that the `HADOOP_CLASSPATH` environment variable is set up (it can be checked by running `echo $HADOOP_CLASSPATH`). If not, set it up using 
 
 ```bash
@@ -225,7 +227,7 @@ For providing Flink with the required Hadoop dependencies, we recommend setting 
 
 If that is not possible, the dependencies can also be put into the `lib/` folder of Flink. 
 
-Flink also offers pre-bundled Hadoop fat jars for placing them in the `lib/` folder, on the [Downloads / Additional Components]({{< param "DownloadPage" >}}#additional-components) section of the website. These pre-bundled fat jars are shaded to avoid dependency conflicts with common libraries. The Flink community is not testing the YARN integration against these pre-bundled jars. 
+Flink also offers pre-bundled Hadoop fat jars for placing them in the `lib/` folder, on the [Downloads / Additional Components]({{< downloads >}}#additional-components) section of the website. These pre-bundled fat jars are shaded to avoid dependency conflicts with common libraries. The Flink community is not testing the YARN integration against these pre-bundled jars. 
 
 ### Running Flink on YARN behind Firewalls
 

--- a/docs/content/docs/deployment/resource-providers/yarn.md
+++ b/docs/content/docs/deployment/resource-providers/yarn.md
@@ -43,7 +43,7 @@ Flink can dynamically allocate and de-allocate TaskManager resources depending o
 This *Getting Started* section assumes a functional YARN environment, starting from version 2.4.1. YARN environments are provided most conveniently through services such as Amazon EMR, Google Cloud DataProc or products like Cloudera. [Manually setting up a YARN environment locally](https://hadoop.apache.org/docs/current/hadoop-project-dist/hadoop-common/SingleCluster.html) or [on a cluster](https://hadoop.apache.org/docs/current/hadoop-project-dist/hadoop-common/ClusterSetup.html) is not recommended for following through this *Getting Started* tutorial. 
 
 - Make sure your YARN cluster is ready for accepting Flink applications by running `yarn top`. It should show no error messages.
-- Download a recent Flink distribution from the [download page]({{ site.download_url }}) and unpack it.
+- Download a recent Flink distribution from the [download page](https://flink.apache.org/downloads.html) and unpack it.
 - **Important** Make sure that the `HADOOP_CLASSPATH` environment variable is set up (it can be checked by running `echo $HADOOP_CLASSPATH`). If not, set it up using 
 
 ```bash
@@ -225,7 +225,7 @@ For providing Flink with the required Hadoop dependencies, we recommend setting 
 
 If that is not possible, the dependencies can also be put into the `lib/` folder of Flink. 
 
-Flink also offers pre-bundled Hadoop fat jars for placing them in the `lib/` folder, on the [Downloads / Additional Components]({{site.download_url}}#additional-components) section of the website. These pre-bundled fat jars are shaded to avoid dependency conflicts with common libraries. The Flink community is not testing the YARN integration against these pre-bundled jars. 
+Flink also offers pre-bundled Hadoop fat jars for placing them in the `lib/` folder, on the [Downloads / Additional Components](https://flink.apache.org/downloads.html#additional-components) section of the website. These pre-bundled fat jars are shaded to avoid dependency conflicts with common libraries. The Flink community is not testing the YARN integration against these pre-bundled jars. 
 
 ### Running Flink on YARN behind Firewalls
 

--- a/docs/content/docs/dev/datastream/fault-tolerance/queryable_state.md
+++ b/docs/content/docs/dev/datastream/fault-tolerance/queryable_state.md
@@ -72,7 +72,7 @@ response back to the client.
 To enable queryable state on your Flink cluster, you need to do the following:
 
  1. copy the `flink-queryable-state-runtime{{< scala_version >}}-{{< version >}}.jar`
-from the `opt/` folder of your [Flink distribution](https://flink.apache.org/downloads.html "Apache Flink: Downloads"), 
+from the `opt/` folder of your [Flink distribution]({{< param "DownloadPage" >}} "Apache Flink: Downloads"), 
 to the `lib/` folder.
  2. set the property `queryable-state.enable` to `true`. See the [Configuration]({{< ref "docs/deployment/config" >}}#queryable-state) documentation for details and additional parameters.
 

--- a/docs/content/docs/dev/datastream/fault-tolerance/queryable_state.md
+++ b/docs/content/docs/dev/datastream/fault-tolerance/queryable_state.md
@@ -72,7 +72,7 @@ response back to the client.
 To enable queryable state on your Flink cluster, you need to do the following:
 
  1. copy the `flink-queryable-state-runtime{{< scala_version >}}-{{< version >}}.jar`
-from the `opt/` folder of your [Flink distribution]({{< param "DownloadPage" >}} "Apache Flink: Downloads"), 
+from the `opt/` folder of your [Flink distribution]({{< downloads >}} "Apache Flink: Downloads"), 
 to the `lib/` folder.
  2. set the property `queryable-state.enable` to `true`. See the [Configuration]({{< ref "docs/deployment/config" >}}#queryable-state) documentation for details and additional parameters.
 

--- a/docs/content/docs/flinkDev/building.md
+++ b/docs/content/docs/flinkDev/building.md
@@ -31,7 +31,7 @@ This page covers how to build Flink {{< version >}} from sources.
 
 ## Build Flink
 
-In order to build Flink you need the source code. Either [download the source of a release](https://flink.apache.org/downloads.html) or [clone the git repository]({{< github_repo >}}).
+In order to build Flink you need the source code. Either [download the source of a release]({{< param "DownloadPage" >}}) or [clone the git repository]({{< github_repo >}}).
 
 In addition you need **Maven 3** and a **JDK** (Java Development Kit). Flink requires **at least Java 8** to build.
 

--- a/docs/content/docs/flinkDev/building.md
+++ b/docs/content/docs/flinkDev/building.md
@@ -31,7 +31,7 @@ This page covers how to build Flink {{< version >}} from sources.
 
 ## Build Flink
 
-In order to build Flink you need the source code. Either [download the source of a release]({{< param "DownloadPage" >}}) or [clone the git repository]({{< github_repo >}}).
+In order to build Flink you need the source code. Either [download the source of a release]({{< downloads >}}) or [clone the git repository]({{< github_repo >}}).
 
 In addition you need **Maven 3** and a **JDK** (Java Development Kit). Flink requires **at least Java 8** to build.
 

--- a/docs/content/docs/libs/gelly/overview.md
+++ b/docs/content/docs/libs/gelly/overview.md
@@ -60,7 +60,7 @@ The remaining sections provide a description of available methods and present se
 Running Gelly Examples
 ----------------------
 
-The Gelly library jars are provided in the [Flink distribution](https://flink.apache.org/downloads.html "Apache Flink: Downloads")
+The Gelly library jars are provided in the [Flink distribution]({{< param "DownloadPage" >}} "Apache Flink: Downloads")
 in the **opt** directory (for versions older than Flink 1.2 these can be manually downloaded from
 [Maven Central](http://search.maven.org/#search|ga|1|flink%20gelly)). To run the Gelly examples the **flink-gelly** (for
 Java) or **flink-gelly-scala** (for Scala) jar must be copied to Flink's **lib** directory.

--- a/docs/content/docs/libs/gelly/overview.md
+++ b/docs/content/docs/libs/gelly/overview.md
@@ -60,7 +60,7 @@ The remaining sections provide a description of available methods and present se
 Running Gelly Examples
 ----------------------
 
-The Gelly library jars are provided in the [Flink distribution]({{< param "DownloadPage" >}} "Apache Flink: Downloads")
+The Gelly library jars are provided in the [Flink distribution]({{< downloads >}} "Apache Flink: Downloads")
 in the **opt** directory (for versions older than Flink 1.2 these can be manually downloaded from
 [Maven Central](http://search.maven.org/#search|ga|1|flink%20gelly)). To run the Gelly examples the **flink-gelly** (for
 Java) or **flink-gelly-scala** (for Scala) jar must be copied to Flink's **lib** directory.

--- a/docs/content/docs/try-flink/local_installation.md
+++ b/docs/content/docs/try-flink/local_installation.md
@@ -46,7 +46,7 @@ to have __Java 8 or 11__ installed. To check the Java version installed, type in
 $ java -version
 ```
 
-Next, [download the latest binary release](https://flink.apache.org/downloads.html) of Flink, 
+Next, [download the latest binary release]({{< param "DownloadPage" >}}) of Flink, 
 then extract the archive: 
 
 ```bash

--- a/docs/content/docs/try-flink/local_installation.md
+++ b/docs/content/docs/try-flink/local_installation.md
@@ -46,7 +46,7 @@ to have __Java 8 or 11__ installed. To check the Java version installed, type in
 $ java -version
 ```
 
-Next, [download the latest binary release]({{< param "DownloadPage" >}}) of Flink, 
+Next, [download the latest binary release]({{< downloads >}}) of Flink, 
 then extract the archive: 
 
 ```bash

--- a/docs/content/release-notes/flink-1.8.md
+++ b/docs/content/release-notes/flink-1.8.md
@@ -88,7 +88,7 @@ Convenience binaries that include hadoop are no longer released.
 If a deployment relies on `flink-shaded-hadoop2` being included in
 `flink-dist`, then you must manually download a pre-packaged Hadoop
 jar from the optional components section of the [download
-page]({{< param "DownloadPage" >}}) and copy it into the
+page]({{< downloads >}}) and copy it into the
 `/lib` directory.  Alternatively, a Flink distribution that includes
 hadoop can be built by packaging `flink-dist` and activating the
 `include-hadoop` maven profile.

--- a/docs/content/release-notes/flink-1.8.md
+++ b/docs/content/release-notes/flink-1.8.md
@@ -88,7 +88,7 @@ Convenience binaries that include hadoop are no longer released.
 If a deployment relies on `flink-shaded-hadoop2` being included in
 `flink-dist`, then you must manually download a pre-packaged Hadoop
 jar from the optional components section of the [download
-page](https://flink.apache.org/downloads.html) and copy it into the
+page]({{< param "DownloadPage" >}}) and copy it into the
 `/lib` directory.  Alternatively, a Flink distribution that includes
 hadoop can be built by packaging `flink-dist` and activating the
 `include-hadoop` maven profile.

--- a/docs/layouts/shortcodes/downloads.html
+++ b/docs/layouts/shortcodes/downloads.html
@@ -1,0 +1,28 @@
+{{/*
+Licensed to the Apache Software Foundation (ASF) under one
+or more contributor license agreements.  See the NOTICE file
+distributed with this work for additional information
+regarding copyright ownership.  The ASF licenses this file
+to you under the Apache License, Version 2.0 (the
+"License"); you may not use this file except in compliance
+with the License.  You may obtain a copy of the License at
+
+http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing,
+software distributed under the License is distributed on an
+"AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+KIND, either express or implied.  See the License for the
+specific language governing permissions and limitations
+under the License.
+*/}}{{/*
+    Shortcode for linking to Flink's download page.
+
+    This way the English and Chinese docs will always point to the correct page.
+
+*/}}
+{{ if eq "/zh" .Site.LanguagePrefix }}
+    {{ .Site.Params.ZhDownloadPage }}
+{{ else }}
+    {{ .Site.Params.DownloadPage }}
+{{ end }}


### PR DESCRIPTION
The url of the download link is not written correctly, so the link is invalid.

The wrong link information is as follows：
 `[download page]({{ site.download_url }}) `
It should be modified as follows：
 `[download page](https://flink.apache.org/downloads.html) `





**The modifications involved are as follows：**

```bash
1.  [download page]({{ site.download_url }})   
Modified as follows: 
[download page](https://flink.apache.org/downloads.html)
 
2. [下载页面]({{ site.zh_download_url }}) 
Modified as follows: 
[下载页面](https://flink.apache.org/zh/downloads.html)
  
3. [Downloads / Additional Components]({{site.download_url}}#additional-components)
Modified as follows: 
[Downloads / Additional Components](https://flink.apache.org/downloads.html#additional-components)

```



