### PR TITLE
[FLINK-23583][table-common] Introduce SubRowData

### DIFF
--- a/flink-table/flink-table-common/src/main/java/org/apache/flink/table/connector/sink/abilities/SupportsWritingMetadata.java
+++ b/flink-table/flink-table-common/src/main/java/org/apache/flink/table/connector/sink/abilities/SupportsWritingMetadata.java
@@ -22,6 +22,7 @@ import org.apache.flink.annotation.PublicEvolving;
 import org.apache.flink.table.connector.format.EncodingFormat;
 import org.apache.flink.table.connector.sink.DynamicTableSink;
 import org.apache.flink.table.data.RowData;
+import org.apache.flink.table.data.utils.SubRowData;
 import org.apache.flink.table.factories.Factory;
 import org.apache.flink.table.types.DataType;
 import org.apache.flink.table.types.logical.LogicalType;
@@ -61,7 +62,8 @@ import java.util.Map;
  * <p>The planner will select required metadata columns and will call {@link
  * #applyWritableMetadata(List, DataType)} with a list of metadata keys. An implementation must
  * ensure that metadata columns are accepted at the end of the physical row in the order of the
- * provided list after the apply method has been called.
+ * provided list after the apply method has been called. You can use {@link SubRowData} to reduce a
+ * row to its non-metadata fields.
  *
  * <p>The metadata column's data type must match with {@link #listWritableMetadata()}. For the
  * examples above, this means that a table sink for `t2` accepts a TIMESTAMP and not INT. The

--- a/flink-table/flink-table-common/src/main/java/org/apache/flink/table/data/utils/SubRowData.java
+++ b/flink-table/flink-table-common/src/main/java/org/apache/flink/table/data/utils/SubRowData.java
@@ -1,0 +1,203 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.flink.table.data.utils;
+
+import org.apache.flink.annotation.PublicEvolving;
+import org.apache.flink.table.data.ArrayData;
+import org.apache.flink.table.data.DecimalData;
+import org.apache.flink.table.data.MapData;
+import org.apache.flink.table.data.RawValueData;
+import org.apache.flink.table.data.RowData;
+import org.apache.flink.table.data.StringData;
+import org.apache.flink.table.data.TimestampData;
+import org.apache.flink.types.RowKind;
+
+import java.util.Objects;
+
+/** An implementation of {@link RowData} which projects a source {@link RowData} to a subset. */
+@PublicEvolving
+public class SubRowData implements RowData {
+
+    private final RowData rowData;
+    private final int startIndex;
+    private final int endIndex;
+
+    /**
+     * Construct a {@link RowData} which represents a subset of a given source {@link RowData}.
+     *
+     * <p>The range is inclusive on the left, and exclusive on the right. This means that the value
+     * at {@param startIndexInclusive} in the source row is the first value in the returned row, but
+     * the value at {@param endIndexExclusive} is not part of the returned {@link RowData}.
+     *
+     * <p>Example:
+     *
+     * <pre>{@code
+     * // 1, 2, 3, 4, 5 (Arity 5)
+     * final RowData sourceRow = GenericRowData.of(1, 2, 3, 4, 5);
+     *
+     * // 2, 3 (Arity 2)
+     * final RowData subRow = new SubRowData(sourceRow, 1, 3);
+     * }</pre>
+     */
+    public SubRowData(RowData rowData, int startIndexInclusive, int endIndexExclusive) {
+        this.rowData = rowData;
+        this.startIndex = startIndexInclusive;
+        this.endIndex = endIndexExclusive;
+
+        if (startIndexInclusive < 0 || startIndexInclusive >= rowData.getArity()) {
+            throw new IllegalArgumentException("startIndex must be within bounds.");
+        }
+
+        if (endIndexExclusive < 0
+                || endIndexExclusive > rowData.getArity()
+                || endIndexExclusive < startIndexInclusive) {
+            throw new IllegalArgumentException("endIndex must be within bounds.");
+        }
+    }
+
+    @Override
+    public int getArity() {
+        return endIndex - startIndex;
+    }
+
+    @Override
+    public RowKind getRowKind() {
+        return rowData.getRowKind();
+    }
+
+    @Override
+    public void setRowKind(RowKind kind) {
+        rowData.setRowKind(kind);
+    }
+
+    @Override
+    public boolean isNullAt(int pos) {
+        return rowData.isNullAt(convertPos(pos));
+    }
+
+    @Override
+    public boolean getBoolean(int pos) {
+        return rowData.getBoolean(convertPos(pos));
+    }
+
+    @Override
+    public byte getByte(int pos) {
+        return rowData.getByte(convertPos(pos));
+    }
+
+    @Override
+    public short getShort(int pos) {
+        return rowData.getShort(convertPos(pos));
+    }
+
+    @Override
+    public int getInt(int pos) {
+        return rowData.getInt(convertPos(pos));
+    }
+
+    @Override
+    public long getLong(int pos) {
+        return rowData.getLong(convertPos(pos));
+    }
+
+    @Override
+    public float getFloat(int pos) {
+        return rowData.getFloat(convertPos(pos));
+    }
+
+    @Override
+    public double getDouble(int pos) {
+        return rowData.getDouble(convertPos(pos));
+    }
+
+    @Override
+    public StringData getString(int pos) {
+        return rowData.getString(convertPos(pos));
+    }
+
+    @Override
+    public DecimalData getDecimal(int pos, int precision, int scale) {
+        return rowData.getDecimal(convertPos(pos), precision, scale);
+    }
+
+    @Override
+    public TimestampData getTimestamp(int pos, int precision) {
+        return rowData.getTimestamp(convertPos(pos), precision);
+    }
+
+    @Override
+    public <T> RawValueData<T> getRawValue(int pos) {
+        return rowData.getRawValue(convertPos(pos));
+    }
+
+    @Override
+    public byte[] getBinary(int pos) {
+        return rowData.getBinary(convertPos(pos));
+    }
+
+    @Override
+    public ArrayData getArray(int pos) {
+        return rowData.getArray(convertPos(pos));
+    }
+
+    @Override
+    public MapData getMap(int pos) {
+        return rowData.getMap(convertPos(pos));
+    }
+
+    @Override
+    public RowData getRow(int pos, int numFields) {
+        return rowData.getRow(convertPos(pos), numFields);
+    }
+
+    // ---------------------------------------------------------------------------------------------
+
+    @Override
+    public boolean equals(Object other) {
+        if (this == other) {
+            return true;
+        }
+
+        if (!(other instanceof RowData)) {
+            return false;
+        }
+
+        final SubRowData that = (SubRowData) other;
+        return startIndex == that.startIndex
+                && endIndex == that.endIndex
+                && Objects.equals(rowData, that.rowData);
+    }
+
+    @Override
+    public int hashCode() {
+        return Objects.hash(rowData, startIndex, endIndex);
+    }
+
+    // ---------------------------------------------------------------------------------------------
+
+    private int convertPos(int pos) {
+        final int convertedPos = pos + startIndex;
+        if (convertedPos >= endIndex) {
+            throw new IllegalArgumentException(
+                    String.format("Position '%d' is out of bounds.", pos));
+        }
+
+        return convertedPos;
+    }
+}

--- a/flink-table/flink-table-common/src/test/java/org/apache/flink/table/data/utils/SubRowDataTest.java
+++ b/flink-table/flink-table-common/src/test/java/org/apache/flink/table/data/utils/SubRowDataTest.java
@@ -1,0 +1,130 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.flink.table.data.utils;
+
+import org.apache.flink.table.data.GenericRowData;
+import org.apache.flink.table.data.RowData;
+import org.apache.flink.types.RowKind;
+
+import org.junit.Test;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.fail;
+
+/** Tests for {@link SubRowData}. */
+public class SubRowDataTest {
+    @Test
+    public void testProjection() {
+        final RowData sourceRow = GenericRowData.of(1, 2, 3, 4, 5);
+        final RowData subRow = new SubRowData(sourceRow, 1, 3);
+        assertSubRow(subRow, 2, 3);
+    }
+
+    @Test
+    public void testRowKind() {
+        final RowData sourceRow = GenericRowData.ofKind(RowKind.DELETE, 1, 2, 3);
+        final RowData subRow = new SubRowData(sourceRow, 0, 3);
+        assertSubRow(subRow, 1, 2, 3);
+        assertEquals(RowKind.DELETE, subRow.getRowKind());
+    }
+
+    @Test
+    public void testEdgeCases() {
+        final RowData sourceRow = GenericRowData.of(1, 2, 3);
+
+        // Complete row
+        assertSubRow(new SubRowData(sourceRow, 0, 3), 1, 2, 3);
+
+        // Left edge
+        assertSubRow(new SubRowData(sourceRow, 0, 1), 1);
+
+        // Right edge
+        assertSubRow(new SubRowData(sourceRow, 2, 3), 3);
+
+        // Empty
+        assertEquals(0, new SubRowData(sourceRow, 0, 0).getArity());
+        assertEquals(0, new SubRowData(sourceRow, 2, 2).getArity());
+    }
+
+    @Test
+    public void testInvalidCases() {
+        final RowData sourceRow = GenericRowData.of(1, 2, 3);
+
+        // startIndex < 0
+        assertThrows(
+                () -> new SubRowData(sourceRow, -1, 1),
+                IllegalArgumentException.class,
+                "startIndex must be within bounds.");
+
+        // startIndex >= arity
+        assertThrows(
+                () -> new SubRowData(sourceRow, 3, 2),
+                IllegalArgumentException.class,
+                "startIndex must be within bounds.");
+
+        // endIndex < 0
+        assertThrows(
+                () -> new SubRowData(sourceRow, 1, -1),
+                IllegalArgumentException.class,
+                "endIndex must be within bounds.");
+
+        // endIndex > arity
+        assertThrows(
+                () -> new SubRowData(sourceRow, 2, 4),
+                IllegalArgumentException.class,
+                "endIndex must be within bounds.");
+
+        // endIndex < startIndex
+        assertThrows(
+                () -> new SubRowData(sourceRow, 2, 1),
+                IllegalArgumentException.class,
+                "endIndex must be within bounds.");
+
+        // Out of bounds read
+        assertThrows(
+                () -> new SubRowData(sourceRow, 0, 1).getInt(1),
+                IllegalArgumentException.class,
+                "Position '1' is out of bounds.");
+    }
+
+    private void assertSubRow(RowData subRow, int... expectedValues) {
+        assertEquals(expectedValues.length, subRow.getArity());
+        for (int i = 0; i < expectedValues.length; i++) {
+            assertEquals(expectedValues[i], subRow.getInt(i));
+        }
+    }
+
+    private <E extends Exception> void assertThrows(
+            Runnable runnable, Class<E> clazz, String expectedMessage) {
+        try {
+            runnable.run();
+
+            fail(
+                    String.format(
+                            "Expected '%s: %s', but no exception occurred.",
+                            clazz.getSimpleName(), expectedMessage));
+        } catch (Exception e) {
+            if (clazz.isAssignableFrom(e.getClass())) {
+                assertEquals(expectedMessage, e.getMessage());
+            } else {
+                throw e;
+            }
+        }
+    }
+}


### PR DESCRIPTION
## What is the purpose of the change

This introduced `SubRowData`, a counterpart to `JoinedRowData`, which allows reducing a `RowData` to a subset. The need for this arises naturally e.g. when implementing sink connectors with a format and metadata as the sink receives a row with appended metadata, but needs to serialize only the part without the metadata

## Verifying this change

This change added tests and can be verified as follows:

* SubRowDataTest

## Does this pull request potentially affect one of the following parts:

  - Dependencies (does it add or upgrade a dependency): no
  - The public API, i.e., is any changed class annotated with `@Public(Evolving)`: yes
  - The serializers: no
  - The runtime per-record code paths (performance sensitive): no
  - Anything that affects deployment or recovery: JobManager (and its components), Checkpointing, Kubernetes/Yarn, ZooKeeper: no
  - The S3 file system connector: no

## Documentation

  - Does this pull request introduce a new feature? yes
  - If yes, how is the feature documented? JavaDocs
