### PR TITLE
[FLINK-23402][streaming-java] Simplify shuffle mode for batch execution

### DIFF
--- a/docs/layouts/shortcodes/generated/execution_configuration.html
+++ b/docs/layouts/shortcodes/generated/execution_configuration.html
@@ -9,6 +9,12 @@
     </thead>
     <tbody>
         <tr>
+            <td><h5>execution.batch-shuffle-mode</h5></td>
+            <td style="word-wrap: break-word;">ALL_EXCHANGES_BLOCKING</td>
+            <td><p>Enum</p></td>
+            <td>Defines how data is exchanged between tasks in batch 'execution.runtime-mode' if the shuffling behavior has not been set explicitly for an individual exchange.<br />With pipelined exchanges, upstream and downstream tasks run simultaneously. In order to achieve lower latency, a result record is immediately sent to and processed by the downstream task. Thus, the receiver back-pressures the sender. The streaming mode always uses this exchange.<br />With blocking exchanges, upstream and downstream tasks run in stages. Records are persisted to some storage between stages. Downstream tasks then fetch these records after the upstream tasks finished. Such an exchange reduces the resources required to execute the job as it does not need to run upstream and downstream tasks simultaneously.<br /><br />Possible values:<ul><li>"ALL_EXCHANGES_PIPELINED": Upstream and downstream tasks run simultaneously. This leads to lower latency and more evenly distributed (but higher) resource usage across tasks.</li><li>"ALL_EXCHANGES_BLOCKING": Upstream and downstream tasks run subsequently. This reduces the resource usage as downstream tasks are started after upstream tasks finished.</li></ul></td>
+        </tr>
+        <tr>
             <td><h5>execution.buffer-timeout</h5></td>
             <td style="word-wrap: break-word;">100 ms</td>
             <td>Duration</td>
@@ -25,12 +31,6 @@
             <td style="word-wrap: break-word;">STREAMING</td>
             <td><p>Enum</p></td>
             <td>Runtime execution mode of DataStream programs. Among other things, this controls task scheduling, network shuffle behavior, and time semantics.<br /><br />Possible values:<ul><li>"STREAMING"</li><li>"BATCH"</li><li>"AUTOMATIC"</li></ul></td>
-        </tr>
-        <tr>
-            <td><h5>execution.shuffle-mode</h5></td>
-            <td style="word-wrap: break-word;">AUTOMATIC</td>
-            <td><p>Enum</p></td>
-            <td>Mode that defines how data is exchanged between tasks if the shuffling behavior has not been set explicitly for an individual exchange. The shuffle mode depends on the configured 'execution.runtime-mode' and is only relevant for batch executions on bounded streams.<br />In streaming mode, upstream and downstream tasks run simultaneously to achieve low latency. An exchange is always pipelined (i.e. a result record is immediately sent to and processed by the downstream task). Thus, the receiver back-pressures the sender.<br />In batch mode, upstream and downstream tasks can run in stages. Blocking exchanges persist records to some storage. Downstream tasks then fetch these records after the upstream tasks finished. Such an exchange reduces the resources required to execute the job as it does not need to run upstream and downstream tasks simultaneously.<br /><br />Possible values:<ul><li>"ALL_EXCHANGES_PIPELINED": Upstream and downstream tasks run simultaneously. This leads to lower latency and more evenly distributed (but higher) resource usage across tasks in batch mode. This is the only supported shuffle behavior in streaming mode.</li><li>"ALL_EXCHANGES_BLOCKING": Upstream and downstream tasks run subsequently. This reduces the resource usage in batch mode as downstream tasks are started after upstream tasks finished. This shuffle behavior is not supported in streaming mode.</li><li>"AUTOMATIC": The framework chooses an appropriate shuffle behavior based on the runtime mode and slot assignment.</li></ul></td>
         </tr>
     </tbody>
 </table>

--- a/flink-core/src/main/java/org/apache/flink/api/common/BatchShuffleMode.java
+++ b/flink-core/src/main/java/org/apache/flink/api/common/BatchShuffleMode.java
@@ -25,65 +25,46 @@ import org.apache.flink.configuration.description.InlineElement;
 import static org.apache.flink.configuration.description.TextElement.text;
 
 /**
- * Mode that defines how data is exchanged between tasks if the shuffling behavior has not been set
- * explicitly for an individual exchange.
+ * Defines how data is exchanged between tasks in batch {@link ExecutionOptions#RUNTIME_MODE} if the
+ * shuffling behavior has not been set explicitly for an individual exchange.
  *
- * <p>The shuffle mode depends on the configured {@link ExecutionOptions#RUNTIME_MODE} and is only
- * relevant for batch executions on bounded streams.
+ * <p>With pipelined exchanges, upstream and downstream tasks run simultaneously. In order to
+ * achieve lower latency, a result record is immediately sent to and processed by the downstream
+ * task. Thus, the receiver back-pressures the sender. The streaming mode always uses this exchange.
  *
- * <p>In streaming mode, upstream and downstream tasks run simultaneously to achieve low latency. An
- * exchange is always pipelined (i.e. a result record is immediately sent to and processed by the
- * downstream task). Thus, the receiver back-pressures the sender.
- *
- * <p>In batch mode, upstream and downstream tasks can run in stages. Blocking exchanges persist
- * records to some storage. Downstream tasks then fetch these records after the upstream tasks
+ * <p>With blocking exchanges, upstream and downstream tasks run in stages. Records are persisted to
+ * some storage between stages. Downstream tasks then fetch these records after the upstream tasks
  * finished. Such an exchange reduces the resources required to execute the job as it does not need
  * to run upstream and downstream tasks simultaneously.
  */
 @PublicEvolving
-public enum ShuffleMode implements DescribedEnum {
+public enum BatchShuffleMode implements DescribedEnum {
 
     /**
      * Upstream and downstream tasks run simultaneously.
      *
      * <p>This leads to lower latency and more evenly distributed (but higher) resource usage across
-     * tasks in batch mode.
-     *
-     * <p>This is the only supported shuffle behavior in streaming mode.
+     * tasks.
      */
     ALL_EXCHANGES_PIPELINED(
             text(
                     "Upstream and downstream tasks run simultaneously. This leads to lower latency "
-                            + "and more evenly distributed (but higher) resource usage across tasks "
-                            + "in batch mode. This is the only supported shuffle behavior in streaming "
-                            + "mode.")),
+                            + "and more evenly distributed (but higher) resource usage across tasks.")),
 
     /**
      * Upstream and downstream tasks run subsequently.
      *
-     * <p>This reduces the resource usage in batch mode as downstream tasks are started after
-     * upstream tasks finished.
-     *
-     * <p>This shuffle behavior is not supported in streaming mode.
+     * <p>This reduces the resource usage as downstream tasks are started after upstream tasks
+     * finished.
      */
     ALL_EXCHANGES_BLOCKING(
             text(
                     "Upstream and downstream tasks run subsequently. This reduces the resource usage "
-                            + "in batch mode as downstream tasks are started after upstream tasks "
-                            + "finished. This shuffle behavior is not supported in streaming mode.")),
-
-    /**
-     * The framework chooses an appropriate shuffle behavior based on the {@link
-     * ExecutionOptions#RUNTIME_MODE} and slot assignment.
-     */
-    AUTOMATIC(
-            text(
-                    "The framework chooses an appropriate shuffle behavior based on the runtime mode "
-                            + "and slot assignment."));
+                            + "as downstream tasks are started after upstream tasks finished."));
 
     private final InlineElement description;
 
-    ShuffleMode(InlineElement description) {
+    BatchShuffleMode(InlineElement description) {
         this.description = description;
     }
 

--- a/flink-core/src/main/java/org/apache/flink/configuration/ExecutionOptions.java
+++ b/flink-core/src/main/java/org/apache/flink/configuration/ExecutionOptions.java
@@ -20,8 +20,8 @@ package org.apache.flink.configuration;
 
 import org.apache.flink.annotation.PublicEvolving;
 import org.apache.flink.annotation.docs.Documentation;
+import org.apache.flink.api.common.BatchShuffleMode;
 import org.apache.flink.api.common.RuntimeExecutionMode;
-import org.apache.flink.api.common.ShuffleMode;
 import org.apache.flink.configuration.description.Description;
 
 import java.time.Duration;
@@ -40,30 +40,31 @@ public class ExecutionOptions {
                             "Runtime execution mode of DataStream programs. Among other things, "
                                     + "this controls task scheduling, network shuffle behavior, and time semantics.");
 
-    public static final ConfigOption<ShuffleMode> SHUFFLE_MODE =
-            ConfigOptions.key("execution.shuffle-mode")
-                    .enumType(ShuffleMode.class)
-                    .defaultValue(ShuffleMode.AUTOMATIC)
+    public static final ConfigOption<BatchShuffleMode> BATCH_SHUFFLE_MODE =
+            ConfigOptions.key("execution.batch-shuffle-mode")
+                    .enumType(BatchShuffleMode.class)
+                    .defaultValue(BatchShuffleMode.ALL_EXCHANGES_BLOCKING)
                     .withDescription(
                             Description.builder()
                                     .text(
-                                            "Mode that defines how data is exchanged between tasks if the shuffling "
-                                                    + "behavior has not been set explicitly for an individual exchange. "
-                                                    + "The shuffle mode depends on the configured '%s' and is only "
-                                                    + "relevant for batch executions on bounded streams.",
+                                            "Defines how data is exchanged between tasks in batch '%s' if the shuffling "
+                                                    + "behavior has not been set explicitly for an individual exchange.",
                                             text(RUNTIME_MODE.key()))
                                     .linebreak()
                                     .text(
-                                            "In streaming mode, upstream and downstream tasks run simultaneously to achieve low latency. "
-                                                    + "An exchange is always pipelined (i.e. a result record is immediately sent to and "
-                                                    + "processed by the downstream task). Thus, the receiver back-pressures the sender.")
+                                            "With pipelined exchanges, upstream and downstream tasks run simultaneously. "
+                                                    + "In order to achieve lower latency, a result record is immediately "
+                                                    + "sent to and processed by the downstream task. Thus, the receiver "
+                                                    + "back-pressures the sender. The streaming mode always uses this "
+                                                    + "exchange.")
                                     .linebreak()
                                     .text(
-                                            "In batch mode, upstream and downstream tasks can run in stages. Blocking exchanges persist "
-                                                    + "records to some storage. Downstream tasks then fetch these records after the "
-                                                    + "upstream tasks finished. Such an exchange reduces the resources required to "
-                                                    + "execute the job as it does not need to run upstream and downstream tasks "
-                                                    + "simultaneously.")
+                                            "With blocking exchanges, upstream and downstream tasks run in stages. "
+                                                    + "Records are persisted to some storage between stages. Downstream "
+                                                    + "tasks then fetch these records after the upstream tasks finished. "
+                                                    + "Such an exchange reduces the resources required to execute the "
+                                                    + "job as it does not need to run upstream and downstream "
+                                                    + "tasks simultaneously.")
                                     .build());
 
     /**

--- a/flink-streaming-java/src/main/java/org/apache/flink/streaming/api/environment/StreamExecutionEnvironment.java
+++ b/flink-streaming-java/src/main/java/org/apache/flink/streaming/api/environment/StreamExecutionEnvironment.java
@@ -989,10 +989,11 @@ public class StreamExecutionEnvironment {
                                 this.configuration.set(ExecutionOptions.RUNTIME_MODE, runtimeMode));
 
         configuration
-                .getOptional(ExecutionOptions.SHUFFLE_MODE)
+                .getOptional(ExecutionOptions.BATCH_SHUFFLE_MODE)
                 .ifPresent(
                         shuffleMode ->
-                                this.configuration.set(ExecutionOptions.SHUFFLE_MODE, shuffleMode));
+                                this.configuration.set(
+                                        ExecutionOptions.BATCH_SHUFFLE_MODE, shuffleMode));
 
         configuration
                 .getOptional(ExecutionOptions.SORT_INPUTS)

--- a/flink-table/flink-table-api-java/src/main/java/org/apache/flink/table/api/config/ExecutionConfigOptions.java
+++ b/flink-table/flink-table-api-java/src/main/java/org/apache/flink/table/api/config/ExecutionConfigOptions.java
@@ -337,7 +337,7 @@ public class ExecutionConfigOptions {
                                     + "\"SortMergeJoin\", \"HashAgg\", \"SortAgg\".\n"
                                     + "By default no operator is disabled.");
 
-    /** @deprecated Use {@link ExecutionOptions#SHUFFLE_MODE} instead. */
+    /** @deprecated Use {@link ExecutionOptions#BATCH_SHUFFLE_MODE} instead. */
     @Deprecated
     @Documentation.TableOption(execMode = Documentation.ExecMode.BATCH)
     public static final ConfigOption<String> TABLE_EXEC_SHUFFLE_MODE =

--- a/flink-table/flink-table-planner/src/main/java/org/apache/flink/table/planner/utils/ExecutorUtils.java
+++ b/flink-table/flink-table-planner/src/main/java/org/apache/flink/table/planner/utils/ExecutorUtils.java
@@ -18,8 +18,8 @@
 
 package org.apache.flink.table.planner.utils;
 
+import org.apache.flink.api.common.BatchShuffleMode;
 import org.apache.flink.api.common.ExecutionConfig;
-import org.apache.flink.api.common.ShuffleMode;
 import org.apache.flink.api.common.operators.ResourceSpec;
 import org.apache.flink.api.dag.Transformation;
 import org.apache.flink.configuration.ExecutionOptions;
@@ -89,9 +89,9 @@ public class ExecutorUtils {
         // temporary solution until StreamGraphGenerator will take care of this setting
         // after enabling batch runtime mode
         if (exchangeMode == null) {
-            final ShuffleMode shuffleMode = configuration.get(ExecutionOptions.SHUFFLE_MODE);
-            if (shuffleMode == ShuffleMode.ALL_EXCHANGES_BLOCKING
-                    || shuffleMode == ShuffleMode.AUTOMATIC) {
+            final BatchShuffleMode shuffleMode =
+                    configuration.get(ExecutionOptions.BATCH_SHUFFLE_MODE);
+            if (shuffleMode == BatchShuffleMode.ALL_EXCHANGES_BLOCKING) {
                 exchangeMode = GlobalStreamExchangeMode.ALL_EDGES_BLOCKING;
             } else {
                 exchangeMode = GlobalStreamExchangeMode.ALL_EDGES_PIPELINED;

--- a/flink-table/flink-table-planner/src/main/java/org/apache/flink/table/planner/utils/StreamExchangeModeUtils.java
+++ b/flink-table/flink-table-planner/src/main/java/org/apache/flink/table/planner/utils/StreamExchangeModeUtils.java
@@ -19,7 +19,7 @@
 package org.apache.flink.table.planner.utils;
 
 import org.apache.flink.annotation.Internal;
-import org.apache.flink.api.common.ShuffleMode;
+import org.apache.flink.api.common.BatchShuffleMode;
 import org.apache.flink.configuration.ExecutionOptions;
 import org.apache.flink.configuration.ReadableConfig;
 import org.apache.flink.streaming.api.graph.GlobalStreamExchangeMode;
@@ -49,8 +49,8 @@ public class StreamExchangeModeUtils {
             return StreamExchangeMode.BATCH;
         }
 
-        final ShuffleMode shuffleMode = config.get(ExecutionOptions.SHUFFLE_MODE);
-        if (shuffleMode == ShuffleMode.ALL_EXCHANGES_BLOCKING) {
+        final BatchShuffleMode shuffleMode = config.get(ExecutionOptions.BATCH_SHUFFLE_MODE);
+        if (shuffleMode == BatchShuffleMode.ALL_EXCHANGES_BLOCKING) {
             return StreamExchangeMode.BATCH;
         }
 

--- a/flink-table/flink-table-planner/src/test/java/org/apache/flink/table/planner/utils/StreamExchangeModeUtilsTest.java
+++ b/flink-table/flink-table-planner/src/test/java/org/apache/flink/table/planner/utils/StreamExchangeModeUtilsTest.java
@@ -18,7 +18,7 @@
 
 package org.apache.flink.table.planner.utils;
 
-import org.apache.flink.api.common.ShuffleMode;
+import org.apache.flink.api.common.BatchShuffleMode;
 import org.apache.flink.configuration.Configuration;
 import org.apache.flink.configuration.ExecutionOptions;
 import org.apache.flink.streaming.api.graph.GlobalStreamExchangeMode;
@@ -38,15 +38,18 @@ public class StreamExchangeModeUtilsTest {
     public void testBatchStreamExchangeMode() {
         final Configuration configuration = new Configuration();
 
-        assertEquals(StreamExchangeMode.UNDEFINED, getBatchStreamExchangeMode(configuration, null));
-
-        configuration.set(ExecutionOptions.SHUFFLE_MODE, ShuffleMode.ALL_EXCHANGES_BLOCKING);
         assertEquals(StreamExchangeMode.BATCH, getBatchStreamExchangeMode(configuration, null));
 
-        configuration.set(ExecutionOptions.SHUFFLE_MODE, ShuffleMode.ALL_EXCHANGES_PIPELINED);
+        configuration.set(
+                ExecutionOptions.BATCH_SHUFFLE_MODE, BatchShuffleMode.ALL_EXCHANGES_BLOCKING);
+        assertEquals(StreamExchangeMode.BATCH, getBatchStreamExchangeMode(configuration, null));
+
+        configuration.set(
+                ExecutionOptions.BATCH_SHUFFLE_MODE, BatchShuffleMode.ALL_EXCHANGES_PIPELINED);
         assertEquals(StreamExchangeMode.UNDEFINED, getBatchStreamExchangeMode(configuration, null));
 
-        configuration.set(ExecutionOptions.SHUFFLE_MODE, ShuffleMode.ALL_EXCHANGES_PIPELINED);
+        configuration.set(
+                ExecutionOptions.BATCH_SHUFFLE_MODE, BatchShuffleMode.ALL_EXCHANGES_PIPELINED);
         assertEquals(
                 StreamExchangeMode.BATCH,
                 getBatchStreamExchangeMode(configuration, StreamExchangeMode.BATCH));
@@ -56,7 +59,8 @@ public class StreamExchangeModeUtilsTest {
     public void testBatchStreamExchangeModeLegacyPrecedence() {
         final Configuration configuration = new Configuration();
 
-        configuration.set(ExecutionOptions.SHUFFLE_MODE, ShuffleMode.ALL_EXCHANGES_PIPELINED);
+        configuration.set(
+                ExecutionOptions.BATCH_SHUFFLE_MODE, BatchShuffleMode.ALL_EXCHANGES_PIPELINED);
         configuration.setString(
                 ExecutionConfigOptions.TABLE_EXEC_SHUFFLE_MODE,
                 GlobalStreamExchangeMode.ALL_EDGES_BLOCKING.toString());

--- a/flink-table/flink-table-planner/src/test/scala/org/apache/flink/table/planner/plan/batch/sql/MultipleInputCreationTest.scala
+++ b/flink-table/flink-table-planner/src/test/scala/org/apache/flink/table/planner/plan/batch/sql/MultipleInputCreationTest.scala
@@ -18,7 +18,7 @@
 
 package org.apache.flink.table.planner.plan.batch.sql
 
-import org.apache.flink.api.common.ShuffleMode
+import org.apache.flink.api.common.BatchShuffleMode
 import org.apache.flink.api.common.eventtime.WatermarkStrategy
 import org.apache.flink.api.connector.source.Boundedness
 import org.apache.flink.api.connector.source.mocks.MockSource
@@ -34,7 +34,7 @@ import org.junit.runners.Parameterized.Parameters
 import org.junit.{Before, Test}
 
 @RunWith(classOf[Parameterized])
-class MultipleInputCreationTest(shuffleMode: ShuffleMode) extends TableTestBase {
+class MultipleInputCreationTest(shuffleMode: BatchShuffleMode) extends TableTestBase {
 
   private val util = batchTestUtil()
 
@@ -44,7 +44,7 @@ class MultipleInputCreationTest(shuffleMode: ShuffleMode) extends TableTestBase 
     util.addTableSource[(Int, Long, String, Int)]("y", 'd, 'e, 'f, 'ny)
     util.addTableSource[(Int, Long, String, Int)]("z", 'g, 'h, 'i, 'nz)
     util.addDataStream[(Int, Long, String)]("t", 'a, 'b, 'c)
-    util.tableConfig.getConfiguration.set(ExecutionOptions.SHUFFLE_MODE, shuffleMode)
+    util.tableConfig.getConfiguration.set(ExecutionOptions.BATCH_SHUFFLE_MODE, shuffleMode)
   }
 
   @Test
@@ -353,6 +353,6 @@ class MultipleInputCreationTest(shuffleMode: ShuffleMode) extends TableTestBase 
 object MultipleInputCreationTest {
 
   @Parameters(name = "shuffleMode: {0}")
-  def parameters: Array[ShuffleMode] =
-    Array(ShuffleMode.ALL_EXCHANGES_BLOCKING, ShuffleMode.ALL_EXCHANGES_PIPELINED)
+  def parameters: Array[BatchShuffleMode] =
+    Array(BatchShuffleMode.ALL_EXCHANGES_BLOCKING, BatchShuffleMode.ALL_EXCHANGES_PIPELINED)
 }

--- a/flink-table/flink-table-planner/src/test/scala/org/apache/flink/table/planner/runtime/batch/sql/MultipleInputITCase.scala
+++ b/flink-table/flink-table-planner/src/test/scala/org/apache/flink/table/planner/runtime/batch/sql/MultipleInputITCase.scala
@@ -18,7 +18,7 @@
 
 package org.apache.flink.table.planner.runtime.batch.sql
 
-import org.apache.flink.api.common.ShuffleMode
+import org.apache.flink.api.common.BatchShuffleMode
 import org.apache.flink.api.common.typeinfo.BasicTypeInfo.{INT_TYPE_INFO, LONG_TYPE_INFO, STRING_TYPE_INFO}
 import org.apache.flink.api.java.typeutils.RowTypeInfo
 import org.apache.flink.configuration.ExecutionOptions
@@ -43,7 +43,7 @@ import scala.util.Random
  * [[org.apache.flink.table.planner.plan.batch.sql.MultipleInputCreationTest]].
  */
 @RunWith(classOf[Parameterized])
-class MultipleInputITCase(shuffleMode: ShuffleMode) extends BatchTestBase {
+class MultipleInputITCase(shuffleMode: BatchShuffleMode) extends BatchTestBase {
 
   @Before
   override def before(): Unit = {
@@ -74,7 +74,7 @@ class MultipleInputITCase(shuffleMode: ShuffleMode) extends BatchTestBase {
       "a, b, c, nt",
       MultipleInputITCase.nullables)
 
-    tEnv.getConfig.getConfiguration.set(ExecutionOptions.SHUFFLE_MODE, shuffleMode)
+    tEnv.getConfig.getConfiguration.set(ExecutionOptions.BATCH_SHUFFLE_MODE, shuffleMode)
   }
 
   @Test
@@ -218,8 +218,8 @@ class MultipleInputITCase(shuffleMode: ShuffleMode) extends BatchTestBase {
 object MultipleInputITCase {
 
   @Parameters(name = "shuffleMode: {0}")
-  def parameters: Array[ShuffleMode] =
-    Array(ShuffleMode.ALL_EXCHANGES_BLOCKING, ShuffleMode.ALL_EXCHANGES_PIPELINED)
+  def parameters: Array[BatchShuffleMode] =
+    Array(BatchShuffleMode.ALL_EXCHANGES_BLOCKING, BatchShuffleMode.ALL_EXCHANGES_PIPELINED)
 
   def generateRandomData(): Seq[Row] = {
     val data = new java.util.ArrayList[Row]()

--- a/flink-table/flink-table-planner/src/test/scala/org/apache/flink/table/planner/runtime/utils/BatchTestBase.scala
+++ b/flink-table/flink-table-planner/src/test/scala/org/apache/flink/table/planner/runtime/utils/BatchTestBase.scala
@@ -18,7 +18,7 @@
 
 package org.apache.flink.table.planner.runtime.utils
 
-import org.apache.flink.api.common.ShuffleMode
+import org.apache.flink.api.common.BatchShuffleMode
 import org.apache.flink.api.common.typeinfo.TypeInformation
 import org.apache.flink.api.java.tuple.Tuple
 import org.apache.flink.configuration.ExecutionOptions
@@ -519,6 +519,7 @@ object BatchTestBase {
 
   def configForMiniCluster(conf: TableConfig): Unit = {
     conf.getConfiguration.setInteger(TABLE_EXEC_RESOURCE_DEFAULT_PARALLELISM, DEFAULT_PARALLELISM)
-    conf.getConfiguration.set(ExecutionOptions.SHUFFLE_MODE, ShuffleMode.ALL_EXCHANGES_PIPELINED)
+    conf.getConfiguration
+      .set(ExecutionOptions.BATCH_SHUFFLE_MODE, BatchShuffleMode.ALL_EXCHANGES_PIPELINED)
   }
 }

--- a/flink-table/flink-table-planner/src/test/scala/org/apache/flink/table/planner/utils/TableTestBase.scala
+++ b/flink-table/flink-table-planner/src/test/scala/org/apache/flink/table/planner/utils/TableTestBase.scala
@@ -17,22 +17,11 @@
  */
 package org.apache.flink.table.planner.utils
 
-import _root_.java.math.{BigDecimal => JBigDecimal}
-import _root_.java.util
-import java.io.{File, IOException}
-import java.nio.file.{Files, Paths}
-import java.time.Duration
-
-import org.apache.calcite.avatica.util.TimeUnit
-import org.apache.calcite.rel.RelNode
-import org.apache.calcite.sql.parser.SqlParserPos
-import org.apache.calcite.sql.{SqlExplainLevel, SqlIntervalQualifier}
-import org.apache.flink.api.common.ShuffleMode
+import org.apache.flink.api.common.BatchShuffleMode
 import org.apache.flink.api.common.typeinfo.{AtomicType, TypeInformation}
 import org.apache.flink.api.java.typeutils.{PojoTypeInfo, RowTypeInfo, TupleTypeInfo}
 import org.apache.flink.api.scala.typeutils.CaseClassTypeInfo
 import org.apache.flink.configuration.ExecutionOptions
-import org.apache.flink.shaded.jackson2.com.fasterxml.jackson.databind.{JsonNode, ObjectMapper}
 import org.apache.flink.streaming.api.datastream.DataStream
 import org.apache.flink.streaming.api.environment.{LocalStreamEnvironment, StreamExecutionEnvironment}
 import org.apache.flink.streaming.api.scala.{StreamExecutionEnvironment => ScalaStreamExecEnv}
@@ -75,9 +64,22 @@ import org.apache.flink.table.types.logical.LogicalType
 import org.apache.flink.table.types.utils.TypeConversions
 import org.apache.flink.table.typeutils.FieldInfoUtils
 import org.apache.flink.types.Row
+
+import org.apache.flink.shaded.jackson2.com.fasterxml.jackson.databind.{JsonNode, ObjectMapper}
+
+import org.apache.calcite.avatica.util.TimeUnit
+import org.apache.calcite.rel.RelNode
+import org.apache.calcite.sql.parser.SqlParserPos
+import org.apache.calcite.sql.{SqlExplainLevel, SqlIntervalQualifier}
 import org.junit.Assert.{assertEquals, assertTrue, fail}
 import org.junit.Rule
 import org.junit.rules.{ExpectedException, TemporaryFolder, TestName}
+
+import _root_.java.math.{BigDecimal => JBigDecimal}
+import _root_.java.util
+import java.io.{File, IOException}
+import java.nio.file.{Files, Paths}
+import java.time.Duration
 
 import _root_.scala.collection.JavaConversions._
 import _root_.scala.io.Source
@@ -1000,7 +1002,7 @@ abstract class TableTestUtil(
   val tableEnv: TableEnvironment = testingTableEnv
   tableEnv.getConfig
     .getConfiguration
-    .set(ExecutionOptions.SHUFFLE_MODE, ShuffleMode.ALL_EXCHANGES_PIPELINED)
+    .set(ExecutionOptions.BATCH_SHUFFLE_MODE, BatchShuffleMode.ALL_EXCHANGES_PIPELINED)
 
   private val env: StreamExecutionEnvironment = getPlanner.getExecEnv
 


### PR DESCRIPTION
## What is the purpose of the change

This simplifies the shuffle mode as discussed in FLINK-23402. 

## Brief change log

- `ShuffleMode` -> `BatchShuffleMode`
- Drop `AUTOMATIC` and make `ALL_EXCHANGES_BLOCKING` the default value
- Rename option key `execution.shuffle-mode` to `execution.batch-shuffle-mode`

## Verifying this change

Existing tests have been updated.

## Does this pull request potentially affect one of the following parts:

  - Dependencies (does it add or upgrade a dependency): no
  - The public API, i.e., is any changed class annotated with `@Public(Evolving)`: yes
  - The serializers: no
  - The runtime per-record code paths (performance sensitive): no
  - Anything that affects deployment or recovery: JobManager (and its components), Checkpointing, Kubernetes/Yarn, ZooKeeper: no
  - The S3 file system connector: no

## Documentation

  - Does this pull request introduce a new feature? no
  - If yes, how is the feature documented? not applicable
