### PR TITLE
[FLINK-23524][tests] Harden AdaptiveSchedulerClusterITCase

### DIFF
--- a/flink-runtime/src/main/java/org/apache/flink/runtime/minicluster/MiniCluster.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/minicluster/MiniCluster.java
@@ -47,6 +47,7 @@ import org.apache.flink.runtime.entrypoint.component.DefaultDispatcherResourceMa
 import org.apache.flink.runtime.entrypoint.component.DispatcherResourceManagerComponent;
 import org.apache.flink.runtime.entrypoint.component.DispatcherResourceManagerComponentFactory;
 import org.apache.flink.runtime.executiongraph.AccessExecutionGraph;
+import org.apache.flink.runtime.executiongraph.ArchivedExecutionGraph;
 import org.apache.flink.runtime.externalresource.ExternalResourceInfoProvider;
 import org.apache.flink.runtime.heartbeat.HeartbeatServices;
 import org.apache.flink.runtime.highavailability.HighAvailabilityServices;
@@ -74,6 +75,7 @@ import org.apache.flink.runtime.rpc.FatalErrorHandler;
 import org.apache.flink.runtime.rpc.RpcService;
 import org.apache.flink.runtime.rpc.RpcSystem;
 import org.apache.flink.runtime.rpc.RpcUtils;
+import org.apache.flink.runtime.scheduler.ExecutionGraphInfo;
 import org.apache.flink.runtime.taskexecutor.TaskExecutor;
 import org.apache.flink.runtime.taskexecutor.TaskManagerRunner;
 import org.apache.flink.runtime.webmonitor.retriever.LeaderRetriever;
@@ -688,6 +690,14 @@ public class MiniCluster implements AutoCloseableAsync {
     // ------------------------------------------------------------------------
     //  Accessing jobs
     // ------------------------------------------------------------------------
+
+    public CompletableFuture<ArchivedExecutionGraph> getArchivedExecutionGraph(JobID jobId) {
+        return runDispatcherCommand(
+                dispatcherGateway ->
+                        dispatcherGateway
+                                .requestExecutionGraphInfo(jobId, rpcTimeout)
+                                .thenApply(ExecutionGraphInfo::getArchivedExecutionGraph));
+    }
 
     public CompletableFuture<Collection<JobStatusMessage>> listJobs() {
         return runDispatcherCommand(

--- a/flink-runtime/src/test/java/org/apache/flink/runtime/testtasks/OnceBlockingNoOpInvokable.java
+++ b/flink-runtime/src/test/java/org/apache/flink/runtime/testtasks/OnceBlockingNoOpInvokable.java
@@ -22,27 +22,25 @@ import org.apache.flink.runtime.execution.Environment;
 import org.apache.flink.runtime.jobgraph.tasks.AbstractInvokable;
 
 import java.util.concurrent.CompletableFuture;
-import java.util.concurrent.CountDownLatch;
 import java.util.concurrent.Future;
-import java.util.concurrent.atomic.AtomicInteger;
 
 /**
- * Simple {@link AbstractInvokable} which blocks the first time it is run. Moreover, one can wait
- * until n instances of this invokable are running by calling {@link #waitUntilOpsAreRunning()}.
+ * Mimics a task that is doing something until some external condition is fulfilled. {@link
+ * #unblock()} signals that no more work is to be done, unblocking all instances and allowing all
+ * future instances to immediately finish as well.
  *
- * <p>Before using this class it is important to call {@link #resetFor}.
+ * <p>The main use-case is keeping a task running while supporting restarts, until some condition is
+ * met, at which point it should finish.
+ *
+ * <p>Before using this class it is important to call {@link #reset}.
  */
 public class OnceBlockingNoOpInvokable extends AbstractInvokable {
 
-    private static final AtomicInteger instanceCount = new AtomicInteger(0);
-
-    private static volatile CountDownLatch numOpsPending = new CountDownLatch(1);
-
     private static volatile boolean isBlocking = true;
 
-    private final Object lock = new Object();
+    private static final Object lock = new Object();
 
-    private volatile boolean running = true;
+    private static volatile boolean running = true;
 
     public OnceBlockingNoOpInvokable(Environment environment) {
         super(environment);
@@ -50,17 +48,13 @@ public class OnceBlockingNoOpInvokable extends AbstractInvokable {
 
     @Override
     public void invoke() throws Exception {
-
-        instanceCount.incrementAndGet();
-        numOpsPending.countDown();
-
-        synchronized (lock) {
-            while (isBlocking && running) {
-                lock.wait();
+        if (isBlocking) {
+            synchronized (lock) {
+                while (running) {
+                    lock.wait();
+                }
             }
         }
-
-        isBlocking = false;
     }
 
     @Override
@@ -72,20 +66,16 @@ public class OnceBlockingNoOpInvokable extends AbstractInvokable {
         return CompletableFuture.completedFuture(null);
     }
 
-    public static void waitUntilOpsAreRunning() throws InterruptedException {
-        numOpsPending.await();
+    public static void unblock() {
+        running = false;
+        isBlocking = false;
+        synchronized (lock) {
+            lock.notifyAll();
+        }
     }
 
-    public static int getInstanceCount() {
-        return instanceCount.get();
-    }
-
-    public static void resetInstanceCount() {
-        instanceCount.set(0);
-    }
-
-    public static void resetFor(int parallelism) {
-        numOpsPending = new CountDownLatch(parallelism);
+    public static void reset() {
         isBlocking = true;
+        running = true;
     }
 }


### PR DESCRIPTION
The AdaptiveSchedulerClusterITCase assumed that only 1 rescaling occurs, but an eager scheduler might do it twice (when the second initial tm offers its slots, once when the intended scale up/down occurs).

We now no longer do any counting of created instances, and instead query the execution graph for the used parallelism.