### PR TITLE
[FLINK-23591][docs] Fix the link to page deployment/config for page d…

### DIFF
--- a/docs/content.zh/docs/deployment/memory/mem_tuning.md
+++ b/docs/content.zh/docs/deployment/memory/mem_tuning.md
@@ -34,7 +34,7 @@ under the License.
 ## 独立部署模式（Standalone Deployment）下的内存配置
 
 [独立部署模式]({{< ref "docs/deployment/resource-providers/standalone/overview" >}})下，我们通常更关注 Flink 应用本身使用的内存大小。
-建议配置 [Flink 总内存]({{< ref "docs/deployment/memory/mem_setup" >}}#configure-total-memory)（[`taskmanager.memory.flink.size`]({{< ref "docs/deployment/config" >}}#taskmanager-memory-flink-size) 或者 [`jobmanager.memory.flink.size`]({{< ref "docs/deployment/config" >}}#jobmanager-memory-flink-size" >}})）或其组成部分。
+建议配置 [Flink 总内存]({{< ref "docs/deployment/memory/mem_setup" >}}#configure-total-memory)（[`taskmanager.memory.flink.size`]({{< ref "docs/deployment/config" >}}#taskmanager-memory-flink-size) 或者 [`jobmanager.memory.flink.size`]({{< ref "docs/deployment/config" >}}#jobmanager-memory-flink-size)）或其组成部分。
 此外，如果出现 [Metaspace 不足的问题]({{< ref "docs/deployment/memory/mem_trouble" >}}#outofmemoryerror-metaspace)，可以调整 *JVM Metaspace* 的大小。
 
 这种情况下通常无需配置*进程总内存*，因为不管是 Flink 还是部署环境都不会对 *JVM 开销* 进行限制，它只与机器的物理资源相关。

--- a/docs/content/docs/deployment/memory/mem_tuning.md
+++ b/docs/content/docs/deployment/memory/mem_tuning.md
@@ -54,6 +54,7 @@ to derive the *total process memory* and request a container with the memory of 
   <strong>Warning:</strong> If Flink or user code allocates unmanaged off-heap (native) memory beyond the container size
   the job can fail because the deployment environment can kill the offending containers.
 </div>
+
 See also description of [container memory exceeded]({{< ref "docs/deployment/memory/mem_trouble" >}}#container-memory-exceeded) failure.
 
 ## Configure memory for state backends


### PR DESCRIPTION


```bash
[DOCS]The link to the 'deployment/config' page is invalid because several characters are written in page 'deployment/memory/mem_tuning/'
```

1、 https://ci.apache.org/projects/flink/flink-docs-master/zh/docs/deployment/memory/mem_tuning/

2、 docs/content.zh/docs/deployment/memory/mem_tuning.md

 

3、The wrong link is below：

```
[`jobmanager.memory.flink.size`]({{< ref "docs/deployment/config" >}}#jobmanager-memory-flink-size" >}})
```


4、It should be modified as follows

```
[`jobmanager.memory.flink.size`]({{< ref "docs/deployment/config" >}}#jobmanager-memory-flink-size)
```

 

 