### PR TITLE
[FLINK-23279][tests] Randomly use Changelog Backend in tests

### DIFF
--- a/docs/layouts/shortcodes/generated/checkpointing_configuration.html
+++ b/docs/layouts/shortcodes/generated/checkpointing_configuration.html
@@ -18,7 +18,7 @@
             <td><h5>state.backend.changelog.storage</h5></td>
             <td style="word-wrap: break-word;">"memory"</td>
             <td>String</td>
-            <td>The storage to be used to store state changelog.<br />The implementation can be specified via their shortcut name.<br />The list of recognized shortcut names currently includes 'memory' only.</td>
+            <td>The storage to be used to store state changelog.<br />The implementation can be specified via their shortcut name.<br />The list of recognized shortcut names currently includes 'memory' and 'filesystem'.</td>
         </tr>
         <tr>
             <td><h5>state.backend.incremental</h5></td>

--- a/docs/layouts/shortcodes/generated/common_state_backends_section.html
+++ b/docs/layouts/shortcodes/generated/common_state_backends_section.html
@@ -42,7 +42,7 @@
             <td><h5>state.backend.changelog.storage</h5></td>
             <td style="word-wrap: break-word;">"memory"</td>
             <td>String</td>
-            <td>The storage to be used to store state changelog.<br />The implementation can be specified via their shortcut name.<br />The list of recognized shortcut names currently includes 'memory' only.</td>
+            <td>The storage to be used to store state changelog.<br />The implementation can be specified via their shortcut name.<br />The list of recognized shortcut names currently includes 'memory' and 'filesystem'.</td>
         </tr>
         <tr>
             <td><h5>state.backend.incremental</h5></td>

--- a/flink-core/src/main/java/org/apache/flink/configuration/CheckpointingOptions.java
+++ b/flink-core/src/main/java/org/apache/flink/configuration/CheckpointingOptions.java
@@ -135,7 +135,7 @@ public class CheckpointingOptions {
                                     .linebreak()
                                     .text(
                                             "The list of recognized shortcut names currently includes"
-                                                    + " 'memory' only.")
+                                                    + " 'memory' and 'filesystem'.")
                                     .build());
 
     /** The maximum number of completed checkpoints to retain. */

--- a/flink-dstl/flink-dstl-dfs/src/main/java/org/apache/flink/changelog/fs/FsStateChangelogStorageFactory.java
+++ b/flink-dstl/flink-dstl-dfs/src/main/java/org/apache/flink/changelog/fs/FsStateChangelogStorageFactory.java
@@ -22,19 +22,30 @@ import org.apache.flink.configuration.Configuration;
 import org.apache.flink.runtime.state.changelog.StateChangelogStorage;
 import org.apache.flink.runtime.state.changelog.StateChangelogStorageFactory;
 
+import java.io.File;
 import java.io.IOException;
+
+import static org.apache.flink.changelog.fs.FsStateChangelogOptions.BASE_PATH;
+import static org.apache.flink.configuration.CheckpointingOptions.STATE_CHANGE_LOG_STORAGE;
 
 /** {@link FsStateChangelogStorage} factory. */
 @Internal
 public class FsStateChangelogStorageFactory implements StateChangelogStorageFactory {
 
+    public static final String IDENTIFIER = "filesystem";
+
     @Override
     public String getIdentifier() {
-        return "filesystem";
+        return IDENTIFIER;
     }
 
     @Override
     public StateChangelogStorage<?> createStorage(Configuration configuration) throws IOException {
         return new FsStateChangelogStorage(configuration);
+    }
+
+    public static void configure(Configuration configuration, File newFolder) {
+        configuration.setString(STATE_CHANGE_LOG_STORAGE, IDENTIFIER);
+        configuration.setString(BASE_PATH, newFolder.getAbsolutePath());
     }
 }

--- a/flink-dstl/flink-dstl-dfs/src/main/java/org/apache/flink/changelog/fs/FsStateChangelogStorageFactory.java
+++ b/flink-dstl/flink-dstl-dfs/src/main/java/org/apache/flink/changelog/fs/FsStateChangelogStorageFactory.java
@@ -17,13 +17,16 @@
 
 package org.apache.flink.changelog.fs;
 
+import org.apache.flink.annotation.Internal;
 import org.apache.flink.configuration.Configuration;
 import org.apache.flink.runtime.state.changelog.StateChangelogStorage;
 import org.apache.flink.runtime.state.changelog.StateChangelogStorageFactory;
 
 import java.io.IOException;
 
-class FsStateChangelogStorageFactory implements StateChangelogStorageFactory {
+/** {@link FsStateChangelogStorage} factory. */
+@Internal
+public class FsStateChangelogStorageFactory implements StateChangelogStorageFactory {
 
     @Override
     public String getIdentifier() {

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/minicluster/MiniCluster.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/minicluster/MiniCluster.java
@@ -658,6 +658,11 @@ public class MiniCluster implements AutoCloseableAsync {
         return miniClusterConfiguration.getNumTaskManagers() == 1;
     }
 
+    @VisibleForTesting
+    public Configuration getConfiguration() {
+        return miniClusterConfiguration.getConfiguration();
+    }
+
     @GuardedBy("lock")
     private Collection<? extends CompletableFuture<Void>> terminateTaskManagers() {
         final Collection<CompletableFuture<Void>> terminationFutures =

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/state/changelog/ChangelogStateHandleStreamImpl.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/state/changelog/ChangelogStateHandleStreamImpl.java
@@ -80,8 +80,15 @@ public final class ChangelogStateHandleStreamImpl implements ChangelogStateHandl
 
     @Override
     public void discardState() {
-        handlesAndOffsets.forEach(
-                handleAndOffset -> stateRegistry.unregisterReference(getKey(handleAndOffset.f0)));
+        if (stateRegistry == null) {
+            // todo: discard private state (FLINK-23139)
+            // discarding the state here will fail some tests
+            // by invalidating checkpoints on abortion
+        } else {
+            handlesAndOffsets.forEach(
+                    handleAndOffset ->
+                            stateRegistry.unregisterReference(getKey(handleAndOffset.f0)));
+        }
     }
 
     @Override

--- a/flink-runtime/src/test/java/org/apache/flink/runtime/state/StateBackendTestBase.java
+++ b/flink-runtime/src/test/java/org/apache/flink/runtime/state/StateBackendTestBase.java
@@ -3621,6 +3621,24 @@ public abstract class StateBackendTestBase<B extends AbstractStateBackend> exten
 
             state.clear();
             assertEquals("Hello", state.value());
+
+            backend =
+                    restoreKeyedBackend(
+                            IntSerializer.INSTANCE,
+                            runSnapshot(
+                                    backend.snapshot(
+                                            1L,
+                                            1L,
+                                            createStreamFactory(),
+                                            CheckpointOptions.forCheckpointWithDefaultLocation()),
+                                    new SharedStateRegistry()));
+            state =
+                    backend.getPartitionedState(
+                            VoidNamespace.INSTANCE, VoidNamespaceSerializer.INSTANCE, kvId);
+
+            backend.setCurrentKey(1);
+            assertEquals("Hello", state.value());
+
         } finally {
             IOUtils.closeQuietly(backend);
             backend.dispose();

--- a/flink-state-backends/flink-statebackend-changelog/src/main/java/org/apache/flink/state/changelog/ChangelogKeyedStateBackend.java
+++ b/flink-state-backends/flink-statebackend-changelog/src/main/java/org/apache/flink/state/changelog/ChangelogKeyedStateBackend.java
@@ -505,7 +505,8 @@ public class ChangelogKeyedStateBackend<K>
                         keyedStateBackend.getKeyContext(),
                         stateChangelogWriter,
                         meta,
-                        stateDesc.getTtlConfig());
+                        stateDesc.getTtlConfig(),
+                        stateDesc.getDefaultValue());
         IS is =
                 stateFactory.create(
                         state,

--- a/flink-state-backends/flink-statebackend-changelog/src/main/java/org/apache/flink/state/changelog/KvStateChangeLoggerImpl.java
+++ b/flink-state-backends/flink-statebackend-changelog/src/main/java/org/apache/flink/state/changelog/KvStateChangeLoggerImpl.java
@@ -24,9 +24,11 @@ import org.apache.flink.runtime.state.RegisteredStateMetaInfoBase;
 import org.apache.flink.runtime.state.changelog.StateChangelogWriter;
 import org.apache.flink.runtime.state.heap.InternalKeyContext;
 
+import javax.annotation.Nullable;
 import javax.annotation.concurrent.NotThreadSafe;
 
 import java.io.IOException;
+import java.io.ObjectOutputStream;
 import java.util.Collection;
 
 import static org.apache.flink.state.changelog.StateChangeOperation.MERGE_NS;
@@ -39,6 +41,8 @@ class KvStateChangeLoggerImpl<Key, Value, Ns> extends AbstractStateChangeLogger<
     private final TypeSerializer<Ns> namespaceSerializer;
     protected final TypeSerializer<Key> keySerializer;
     private final TypeSerializer<Value> valueSerializer;
+    private final StateTtlConfig ttlConfig;
+    @Nullable private final Value defaultValue;
 
     KvStateChangeLoggerImpl(
             TypeSerializer<Key> keySerializer,
@@ -47,11 +51,14 @@ class KvStateChangeLoggerImpl<Key, Value, Ns> extends AbstractStateChangeLogger<
             InternalKeyContext<Key> keyContext,
             StateChangelogWriter<?> stateChangelogWriter,
             RegisteredStateMetaInfoBase metaInfo,
-            StateTtlConfig ttlConfig) {
-        super(stateChangelogWriter, keyContext, metaInfo, ttlConfig);
+            StateTtlConfig ttlConfig,
+            @Nullable Value defaultValue) {
+        super(stateChangelogWriter, keyContext, metaInfo);
         this.keySerializer = checkNotNull(keySerializer);
         this.valueSerializer = checkNotNull(valueSerializer);
         this.namespaceSerializer = checkNotNull(namespaceSerializer);
+        this.ttlConfig = checkNotNull(ttlConfig);
+        this.defaultValue = defaultValue;
     }
 
     @Override
@@ -77,5 +84,18 @@ class KvStateChangeLoggerImpl<Key, Value, Ns> extends AbstractStateChangeLogger<
     protected void serializeScope(Ns ns, DataOutputViewStreamWrapper out) throws IOException {
         keySerializer.serialize(keyContext.getCurrentKey(), out);
         namespaceSerializer.serialize(ns, out);
+    }
+
+    protected void writeDefaultValueAndTtl(DataOutputViewStreamWrapper out) throws IOException {
+        out.writeBoolean(ttlConfig.isEnabled());
+        if (ttlConfig.isEnabled()) {
+            try (ObjectOutputStream o = new ObjectOutputStream(out)) {
+                o.writeObject(ttlConfig);
+            }
+        }
+        out.writeBoolean(defaultValue != null);
+        if (defaultValue != null) {
+            serializeValue(defaultValue, out);
+        }
     }
 }

--- a/flink-state-backends/flink-statebackend-changelog/src/main/java/org/apache/flink/state/changelog/PriorityQueueStateChangeLoggerImpl.java
+++ b/flink-state-backends/flink-statebackend-changelog/src/main/java/org/apache/flink/state/changelog/PriorityQueueStateChangeLoggerImpl.java
@@ -17,7 +17,6 @@
 
 package org.apache.flink.state.changelog;
 
-import org.apache.flink.api.common.state.StateTtlConfig;
 import org.apache.flink.api.common.typeutils.TypeSerializer;
 import org.apache.flink.core.memory.DataOutputViewStreamWrapper;
 import org.apache.flink.runtime.state.RegisteredPriorityQueueStateBackendMetaInfo;
@@ -37,7 +36,7 @@ class PriorityQueueStateChangeLoggerImpl<K, T> extends AbstractStateChangeLogger
             InternalKeyContext<K> keyContext,
             StateChangelogWriter<?> stateChangelogWriter,
             RegisteredPriorityQueueStateBackendMetaInfo<T> meta) {
-        super(stateChangelogWriter, keyContext, meta, StateTtlConfig.DISABLED);
+        super(stateChangelogWriter, keyContext, meta);
         this.serializer = checkNotNull(serializer);
     }
 

--- a/flink-state-backends/flink-statebackend-changelog/src/test/java/org/apache/flink/state/changelog/KvStateChangeLoggerImplTest.java
+++ b/flink-state-backends/flink-statebackend-changelog/src/test/java/org/apache/flink/state/changelog/KvStateChangeLoggerImplTest.java
@@ -49,7 +49,8 @@ public class KvStateChangeLoggerImplTest extends StateChangeLoggerTestBase<Strin
                 keyContext,
                 writer,
                 metaInfo,
-                StateTtlConfig.DISABLED);
+                StateTtlConfig.DISABLED,
+                "default");
     }
 
     @Override

--- a/flink-tests/pom.xml
+++ b/flink-tests/pom.xml
@@ -255,6 +255,13 @@ under the License.
 		</dependency>
 
 		<dependency>
+			<groupId>org.apache.flink</groupId>
+			<artifactId>flink-dstl-dfs_${scala.binary.version}</artifactId>
+			<version>${project.version}</version>
+			<scope>test</scope>
+        </dependency>
+
+        <dependency>
 			<groupId>com.github.oshi</groupId>
 			<artifactId>oshi-core</artifactId>
 			<scope>test</scope>

--- a/flink-tests/src/test/java/org/apache/flink/test/checkpointing/EventTimeWindowCheckpointingITCase.java
+++ b/flink-tests/src/test/java/org/apache/flink/test/checkpointing/EventTimeWindowCheckpointingITCase.java
@@ -25,6 +25,7 @@ import org.apache.flink.api.common.state.ValueStateDescriptor;
 import org.apache.flink.api.java.tuple.Tuple;
 import org.apache.flink.api.java.tuple.Tuple2;
 import org.apache.flink.api.java.tuple.Tuple4;
+import org.apache.flink.changelog.fs.FsStateChangelogStorageFactory;
 import org.apache.flink.configuration.AkkaOptions;
 import org.apache.flink.configuration.Configuration;
 import org.apache.flink.configuration.HighAvailabilityOptions;
@@ -209,6 +210,12 @@ public class EventTimeWindowCheckpointingITCase extends TestLogger {
             default:
                 throw new IllegalStateException("No backend selected.");
         }
+        // Configure DFS DSTL for this test as it might produce too much GC pressure if
+        // ChangelogStateBackend is used.
+        // Doing it on cluster level unconditionally as randomization currently happens on the job
+        // level (environment); while this factory can only be set on the cluster level.
+        FsStateChangelogStorageFactory.configure(config, tempFolder.newFolder());
+
         return config;
     }
 

--- a/flink-tests/src/test/java/org/apache/flink/test/checkpointing/ResumeCheckpointManuallyITCase.java
+++ b/flink-tests/src/test/java/org/apache/flink/test/checkpointing/ResumeCheckpointManuallyITCase.java
@@ -27,6 +27,7 @@ import org.apache.flink.api.common.eventtime.WatermarkGenerator;
 import org.apache.flink.api.common.eventtime.WatermarkGeneratorSupplier;
 import org.apache.flink.api.common.eventtime.WatermarkStrategy;
 import org.apache.flink.api.java.tuple.Tuple2;
+import org.apache.flink.changelog.fs.FsStateChangelogStorageFactory;
 import org.apache.flink.client.program.ClusterClient;
 import org.apache.flink.configuration.CheckpointingOptions;
 import org.apache.flink.configuration.Configuration;
@@ -244,6 +245,12 @@ public class ResumeCheckpointManuallyITCase extends TestLogger {
                 CheckpointingOptions.CHECKPOINTS_DIRECTORY, checkpointDir.toURI().toString());
         config.setString(CheckpointingOptions.SAVEPOINT_DIRECTORY, savepointDir.toURI().toString());
         config.setBoolean(CheckpointingOptions.LOCAL_RECOVERY, localRecovery);
+
+        // Configure DFS DSTL for this test as it might produce too much GC pressure if
+        // ChangelogStateBackend is used.
+        // Doing it on cluster level unconditionally as randomization currently happens on the job
+        // level (environment); while this factory can only be set on the cluster level.
+        FsStateChangelogStorageFactory.configure(config, temporaryFolder.newFolder());
 
         // ZooKeeper recovery mode?
         if (zooKeeperQuorum != null) {

--- a/flink-tests/src/test/java/org/apache/flink/test/checkpointing/UnalignedCheckpointTestBase.java
+++ b/flink-tests/src/test/java/org/apache/flink/test/checkpointing/UnalignedCheckpointTestBase.java
@@ -40,6 +40,7 @@ import org.apache.flink.api.connector.source.SourceSplit;
 import org.apache.flink.api.connector.source.SplitEnumerator;
 import org.apache.flink.api.connector.source.SplitEnumeratorContext;
 import org.apache.flink.api.connector.source.SplitsAssignment;
+import org.apache.flink.changelog.fs.FsStateChangelogStorageFactory;
 import org.apache.flink.configuration.AkkaOptions;
 import org.apache.flink.configuration.CheckpointingOptions;
 import org.apache.flink.configuration.Configuration;
@@ -127,6 +128,12 @@ public abstract class UnalignedCheckpointTestBase extends TestLogger {
     protected File execute(UnalignedSettings settings) throws Exception {
         final File checkpointDir = temp.newFolder();
         Configuration conf = settings.getConfiguration(checkpointDir);
+
+        // Configure DFS DSTL for this test as it might produce too much GC pressure if
+        // ChangelogStateBackend is used.
+        // Doing it on cluster level unconditionally as randomization currently happens on the job
+        // level (environment); while this factory can only be set on the cluster level.
+        FsStateChangelogStorageFactory.configure(conf, temp.newFolder());
 
         final StreamGraph streamGraph = getStreamGraph(settings, conf);
         final int requiredSlots =

--- a/flink-tests/src/test/java/org/apache/flink/test/classloading/ClassLoaderITCase.java
+++ b/flink-tests/src/test/java/org/apache/flink/test/classloading/ClassLoaderITCase.java
@@ -61,6 +61,9 @@ import java.util.concurrent.TimeUnit;
 import scala.concurrent.duration.Deadline;
 import scala.concurrent.duration.FiniteDuration;
 
+import static org.apache.flink.changelog.fs.FsStateChangelogOptions.BASE_PATH;
+import static org.apache.flink.changelog.fs.FsStateChangelogStorageFactory.IDENTIFIER;
+import static org.apache.flink.configuration.CheckpointingOptions.STATE_CHANGE_LOG_STORAGE;
 import static org.junit.Assert.assertFalse;
 import static org.junit.Assert.assertNotNull;
 import static org.junit.Assert.assertTrue;
@@ -117,6 +120,13 @@ public class ClassLoaderITCase extends TestLogger {
 
         // required as we otherwise run out of memory
         config.set(TaskManagerOptions.MANAGED_MEMORY_SIZE, MemorySize.parse("80m"));
+
+        // If changelog backend is enabled then this test might run too slow with in-memory
+        // implementation - use fs-based instead.
+        // The randomization currently happens on the job level (environment); while this factory
+        // can only be set on the cluster level; so we do it unconditionally here.
+        config.setString(STATE_CHANGE_LOG_STORAGE, IDENTIFIER);
+        config.setString(BASE_PATH, FOLDER.newFolder().getAbsolutePath());
 
         miniClusterResource =
                 new MiniClusterResource(

--- a/pom.xml
+++ b/pom.xml
@@ -1531,7 +1531,7 @@ under the License.
 						<checkpointing.randomization>true</checkpointing.randomization>
 						<buffer-debloat.randomization>true</buffer-debloat.randomization>
 						<!-- on, unset, or random -->
-						<checkpointing.changelog>unset</checkpointing.changelog>
+						<checkpointing.changelog>random</checkpointing.changelog>
 						<project.basedir>${project.basedir}</project.basedir>
 						<!--suppress MavenModelInspection -->
 						<test.randomization.seed>${test.randomization.seed}</test.randomization.seed>


### PR DESCRIPTION
## What is the purpose of the change

Randomize whether ChangelogStateBackend is used in tests.

The option was added previously (#16290)
but it wasn't possible to turn it on before merging DFS changelog writer.

The adjustments are:
- use FS DSTL in some tests with heavy load
- don't discard changelog private state to avoid snapshot invalidation on abortion - will be addressed in FLINK-23139
- don't use changelog if local recovery is enabled (which is not supported ATM)
- **fix in changelog backend to write default value along with meadata**
