### PR TITLE
[FLINK-23599] Remove JobVertex#connectIdInput

### DIFF
--- a/flink-runtime/src/main/java/org/apache/flink/runtime/jobgraph/JobVertex.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/jobgraph/JobVertex.java
@@ -68,7 +68,7 @@ public class JobVertex implements java.io.Serializable {
      *    C    E
      * </pre>
      *
-     * This is the same order that operators are stored in the {@code StreamTask}.
+     * <p>This is the same order that operators are stored in the {@code StreamTask}.
      */
     private final List<OperatorIDPair> operatorIDs;
 

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/jobgraph/JobVertex.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/jobgraph/JobVertex.java
@@ -500,11 +500,6 @@ public class JobVertex implements java.io.Serializable {
         return edge;
     }
 
-    public void connectIdInput(IntermediateDataSetID dataSetId, DistributionPattern distPattern) {
-        JobEdge edge = new JobEdge(dataSetId, this, distPattern);
-        this.inputs.add(edge);
-    }
-
     // --------------------------------------------------------------------------------------------
 
     public boolean isInputVertex() {

--- a/flink-runtime/src/test/java/org/apache/flink/runtime/executiongraph/DefaultExecutionGraphConstructionTest.java
+++ b/flink-runtime/src/test/java/org/apache/flink/runtime/executiongraph/DefaultExecutionGraphConstructionTest.java
@@ -101,7 +101,7 @@ public class DefaultExecutionGraphConstructionTest {
     }
 
     /**
-     * Creates a JobGraph of the following form:
+     * Creates a JobGraph of the following form.
      *
      * <pre>
      *  v1--->v2-->\
@@ -178,10 +178,8 @@ public class DefaultExecutionGraphConstructionTest {
 
         // create results for v2 and v3
         IntermediateDataSet v2result = v2.createAndAddResultDataSet(ResultPartitionType.PIPELINED);
-        IntermediateDataSet v3result_1 =
-                v3.createAndAddResultDataSet(ResultPartitionType.PIPELINED);
-        IntermediateDataSet v3result_2 =
-                v3.createAndAddResultDataSet(ResultPartitionType.PIPELINED);
+        IntermediateDataSet v3Result1 = v3.createAndAddResultDataSet(ResultPartitionType.PIPELINED);
+        IntermediateDataSet v3Result2 = v3.createAndAddResultDataSet(ResultPartitionType.PIPELINED);
 
         JobVertex v4 = new JobVertex("vertex4");
         JobVertex v5 = new JobVertex("vertex5");
@@ -192,10 +190,10 @@ public class DefaultExecutionGraphConstructionTest {
         v5.setInvokableClass(AbstractInvokable.class);
 
         v4.connectDataSetAsInput(v2result, DistributionPattern.ALL_TO_ALL);
-        v4.connectDataSetAsInput(v3result_1, DistributionPattern.ALL_TO_ALL);
+        v4.connectDataSetAsInput(v3Result1, DistributionPattern.ALL_TO_ALL);
         v5.connectNewDataSetAsInput(
                 v4, DistributionPattern.ALL_TO_ALL, ResultPartitionType.PIPELINED);
-        v5.connectDataSetAsInput(v3result_2, DistributionPattern.ALL_TO_ALL);
+        v5.connectDataSetAsInput(v3Result2, DistributionPattern.ALL_TO_ALL);
 
         List<JobVertex> ordered = Arrays.asList(v1, v2, v3);
 
@@ -246,10 +244,8 @@ public class DefaultExecutionGraphConstructionTest {
 
         // create results for v2 and v3
         IntermediateDataSet v2result = v2.createAndAddResultDataSet(ResultPartitionType.PIPELINED);
-        IntermediateDataSet v3result_1 =
-                v3.createAndAddResultDataSet(ResultPartitionType.PIPELINED);
-        IntermediateDataSet v3result_2 =
-                v3.createAndAddResultDataSet(ResultPartitionType.PIPELINED);
+        IntermediateDataSet v3result1 = v3.createAndAddResultDataSet(ResultPartitionType.PIPELINED);
+        IntermediateDataSet v3result2 = v3.createAndAddResultDataSet(ResultPartitionType.PIPELINED);
 
         // construct part two of the execution graph
         JobVertex v4 = new JobVertex("vertex4");
@@ -261,10 +257,10 @@ public class DefaultExecutionGraphConstructionTest {
         v5.setInvokableClass(AbstractInvokable.class);
 
         v4.connectIdInput(v2result.getId(), DistributionPattern.ALL_TO_ALL);
-        v4.connectIdInput(v3result_1.getId(), DistributionPattern.ALL_TO_ALL);
+        v4.connectIdInput(v3result1.getId(), DistributionPattern.ALL_TO_ALL);
         v5.connectNewDataSetAsInput(
                 v4, DistributionPattern.ALL_TO_ALL, ResultPartitionType.PIPELINED);
-        v5.connectIdInput(v3result_2.getId(), DistributionPattern.ALL_TO_ALL);
+        v5.connectIdInput(v3result2.getId(), DistributionPattern.ALL_TO_ALL);
 
         List<JobVertex> ordered = Arrays.asList(v1, v2, v3);
         List<JobVertex> ordered2 = Arrays.asList(v4, v5);

--- a/flink-runtime/src/test/java/org/apache/flink/runtime/executiongraph/DefaultExecutionGraphConstructionTest.java
+++ b/flink-runtime/src/test/java/org/apache/flink/runtime/executiongraph/DefaultExecutionGraphConstructionTest.java
@@ -27,7 +27,6 @@ import org.apache.flink.runtime.JobException;
 import org.apache.flink.runtime.io.network.partition.ResultPartitionType;
 import org.apache.flink.runtime.jobgraph.DistributionPattern;
 import org.apache.flink.runtime.jobgraph.IntermediateDataSet;
-import org.apache.flink.runtime.jobgraph.IntermediateDataSetID;
 import org.apache.flink.runtime.jobgraph.IntermediateResultPartitionID;
 import org.apache.flink.runtime.jobgraph.JobGraph;
 import org.apache.flink.runtime.jobgraph.JobVertex;
@@ -223,71 +222,6 @@ public class DefaultExecutionGraphConstructionTest {
         verifyTestGraph(eg, v1, v2, v3, v4, v5);
     }
 
-    @Test
-    public void testAttachViaIds() throws Exception {
-        // construct part one of the execution graph
-        JobVertex v1 = new JobVertex("vertex1");
-        JobVertex v2 = new JobVertex("vertex2");
-        JobVertex v3 = new JobVertex("vertex3");
-
-        v1.setParallelism(5);
-        v2.setParallelism(7);
-        v3.setParallelism(2);
-
-        v1.setInvokableClass(AbstractInvokable.class);
-        v2.setInvokableClass(AbstractInvokable.class);
-        v3.setInvokableClass(AbstractInvokable.class);
-
-        // this creates an intermediate result for v1
-        v2.connectNewDataSetAsInput(
-                v1, DistributionPattern.ALL_TO_ALL, ResultPartitionType.PIPELINED);
-
-        // create results for v2 and v3
-        IntermediateDataSet v2result = v2.createAndAddResultDataSet(ResultPartitionType.PIPELINED);
-        IntermediateDataSet v3result1 = v3.createAndAddResultDataSet(ResultPartitionType.PIPELINED);
-        IntermediateDataSet v3result2 = v3.createAndAddResultDataSet(ResultPartitionType.PIPELINED);
-
-        // construct part two of the execution graph
-        JobVertex v4 = new JobVertex("vertex4");
-        JobVertex v5 = new JobVertex("vertex5");
-        v4.setParallelism(11);
-        v5.setParallelism(4);
-
-        v4.setInvokableClass(AbstractInvokable.class);
-        v5.setInvokableClass(AbstractInvokable.class);
-
-        v4.connectIdInput(v2result.getId(), DistributionPattern.ALL_TO_ALL);
-        v4.connectIdInput(v3result1.getId(), DistributionPattern.ALL_TO_ALL);
-        v5.connectNewDataSetAsInput(
-                v4, DistributionPattern.ALL_TO_ALL, ResultPartitionType.PIPELINED);
-        v5.connectIdInput(v3result2.getId(), DistributionPattern.ALL_TO_ALL);
-
-        List<JobVertex> ordered = Arrays.asList(v1, v2, v3);
-        List<JobVertex> ordered2 = Arrays.asList(v4, v5);
-
-        ExecutionGraph eg =
-                createDefaultExecutionGraph(
-                        Stream.concat(ordered.stream(), ordered2.stream())
-                                .collect(Collectors.toList()));
-        try {
-            eg.attachJobGraph(ordered);
-        } catch (JobException e) {
-            e.printStackTrace();
-            fail("Job failed with exception: " + e.getMessage());
-        }
-
-        // attach the second part of the graph
-        try {
-            eg.attachJobGraph(ordered2);
-        } catch (JobException e) {
-            e.printStackTrace();
-            fail("Job failed with exception: " + e.getMessage());
-        }
-
-        // verify
-        verifyTestGraph(eg, v1, v2, v3, v4, v5);
-    }
-
     private void verifyTestGraph(
             ExecutionGraph eg,
             JobVertex v1,
@@ -305,41 +239,6 @@ public class DefaultExecutionGraphConstructionTest {
                 eg, v4, Arrays.asList(v2, v3), Collections.singletonList(v5));
         ExecutionGraphTestUtils.verifyGeneratedExecutionJobVertex(
                 eg, v5, Arrays.asList(v4, v3), null);
-    }
-
-    @Test
-    public void testCannotConnectMissingId() throws Exception {
-        // construct part one of the execution graph
-        JobVertex v1 = new JobVertex("vertex1");
-        v1.setParallelism(7);
-        v1.setInvokableClass(AbstractInvokable.class);
-
-        // construct part two of the execution graph
-        JobVertex v2 = new JobVertex("vertex2");
-        v2.setInvokableClass(AbstractInvokable.class);
-        v2.connectIdInput(new IntermediateDataSetID(), DistributionPattern.ALL_TO_ALL);
-
-        List<JobVertex> ordered = Arrays.asList(v1);
-        List<JobVertex> ordered2 = Arrays.asList(v2);
-
-        ExecutionGraph eg =
-                createDefaultExecutionGraph(
-                        Stream.concat(ordered.stream(), ordered2.stream())
-                                .collect(Collectors.toList()));
-        try {
-            eg.attachJobGraph(ordered);
-        } catch (JobException e) {
-            e.printStackTrace();
-            fail("Job failed with exception: " + e.getMessage());
-        }
-
-        // attach the second part of the graph
-        try {
-            eg.attachJobGraph(ordered2);
-            fail("Attached wrong jobgraph");
-        } catch (JobException e) {
-            // expected
-        }
     }
 
     @Test


### PR DESCRIPTION
## What is the purpose of the change

*JobVertex#connectIdInput is not used in production anymore. It's only used in the unit tests testAttachViaIds and testCannotConnectMissingId located in DefaultExecutionGraphConstructionTest. However, these two test cases are designed to test this method. Therefore, this method and its test cases can be removed. For more details please check FLINK-23599.*


## Brief change log

  - *Remove JobVertex#connectIdInput*
  - *Remove DefaultExecutionGraphConstructionTest#testAttachViaIds and testCannotConnectMissingId*
  - *Fix checkstyle in JobVertex.java and DefaultExecutionGraphConstructionTest.java*

## Verifying this change

This change is a trivial rework / code cleanup without any test coverage.

## Does this pull request potentially affect one of the following parts:

  - Dependencies (does it add or upgrade a dependency): (yes / **no**)
  - The public API, i.e., is any changed class annotated with `@Public(Evolving)`: (yes / **no**)
  - The serializers: (yes / **no** / don't know)
  - The runtime per-record code paths (performance sensitive): (yes / **no** / don't know)
  - Anything that affects deployment or recovery: JobManager (and its components), Checkpointing, Kubernetes/Yarn, ZooKeeper: (**yes** / no / don't know)
  - The S3 file system connector: (yes / **no** / don't know)

## Documentation

  - Does this pull request introduce a new feature? (yes / **no**)
  - If yes, how is the feature documented? (**not applicable** / docs / JavaDocs / not documented)
