### PR TITLE
[FLINK-22767][coordination] Optimize the initialization of LocalInputPreferredSlotSharingStrategy

### DIFF
--- a/flink-runtime/src/main/java/org/apache/flink/runtime/scheduler/LocalInputPreferredSlotSharingStrategy.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/scheduler/LocalInputPreferredSlotSharingStrategy.java
@@ -19,27 +19,30 @@
 package org.apache.flink.runtime.scheduler;
 
 import org.apache.flink.runtime.instance.SlotSharingGroupId;
+import org.apache.flink.runtime.jobgraph.IntermediateResultPartitionID;
 import org.apache.flink.runtime.jobgraph.JobVertexID;
 import org.apache.flink.runtime.jobmanager.scheduler.CoLocationConstraint;
 import org.apache.flink.runtime.jobmanager.scheduler.CoLocationGroup;
 import org.apache.flink.runtime.jobmanager.scheduler.SlotSharingGroup;
+import org.apache.flink.runtime.scheduler.adapter.DefaultExecutionTopology;
+import org.apache.flink.runtime.scheduler.strategy.ConsumedPartitionGroup;
 import org.apache.flink.runtime.scheduler.strategy.ExecutionVertexID;
 import org.apache.flink.runtime.scheduler.strategy.SchedulingExecutionVertex;
-import org.apache.flink.runtime.scheduler.strategy.SchedulingResultPartition;
 import org.apache.flink.runtime.scheduler.strategy.SchedulingTopology;
 
 import java.util.ArrayList;
 import java.util.HashMap;
 import java.util.HashSet;
 import java.util.IdentityHashMap;
+import java.util.Iterator;
 import java.util.LinkedHashMap;
+import java.util.LinkedHashSet;
 import java.util.List;
 import java.util.Map;
 import java.util.Objects;
 import java.util.Set;
 
 import static org.apache.flink.util.Preconditions.checkNotNull;
-import static org.apache.flink.util.Preconditions.checkState;
 
 /**
  * This strategy tries to reduce remote data exchanges. Execution vertices, which are connected and
@@ -94,12 +97,49 @@ class LocalInputPreferredSlotSharingStrategy implements SlotSharingStrategy {
         private final Map<ExecutionVertexID, ExecutionSlotSharingGroup>
                 executionSlotSharingGroupMap;
 
-        final Map<CoLocationConstraint, ExecutionSlotSharingGroup>
+        private final Map<CoLocationConstraint, ExecutionSlotSharingGroup>
                 constraintToExecutionSlotSharingGroupMap;
 
-        final Map<SlotSharingGroupId, List<ExecutionSlotSharingGroup>> executionSlotSharingGroups;
+        private final Map<SlotSharingGroupId, List<ExecutionSlotSharingGroup>>
+                executionSlotSharingGroups;
 
-        private final Map<ExecutionSlotSharingGroup, Set<JobVertexID>> assignedJobVerticesForGroups;
+        /**
+         * A JobVertex only belongs to one {@link SlotSharingGroup}. A SlotSharingGroup is
+         * corresponding to a set of {@link ExecutionSlotSharingGroup}s. We can maintain available
+         * ExecutionSlotSharingGroups for each JobVertex.
+         *
+         * <p>Once an ExecutionSlotSharingGroup is created, it becomes available for all JobVertices
+         * in the corresponding SlotSharingGroup in the beginning.
+         *
+         * <p>Once a SchedulingExecutionVertex is added to the ExecutionSlotSharingGroup, the group
+         * is no longer available for other SchedulingExecutionVertices with the same JobVertexID.
+         *
+         * <p>Here we use {@link LinkedHashSet} to reserve the order the same as the
+         * SchedulingVertices are traversed.
+         */
+        private final Map<JobVertexID, LinkedHashSet<ExecutionSlotSharingGroup>>
+                availableGroupsForJobVertex;
+
+        /**
+         * Maintains the candidate {@link ExecutionSlotSharingGroup}s for every {@link
+         * ConsumedPartitionGroup}. The ConsumedPartitionGroup represents a group of partitions that
+         * is consumed by the same ExecutionVertices. These ExecutionVertices belong to one consumer
+         * JobVertex. Thus, we can say, a ConsumedPartitionGroup is corresponding to one consumer
+         * JobVertex.
+         *
+         * <p>This mapping is used to find an available producer ExecutionSlotSharingGroup for the
+         * consumer vertex. If a candidate group is available for this consumer vertex, it will be
+         * assigned to this vertex.
+         *
+         * <p>The candidate groups are computed in {@link
+         * #computeAllCandidateGroupsForConsumedPartitionGroup} when the ConsumedPartitionGroup is
+         * traversed for the first time.
+         *
+         * <p>Here we use {@link LinkedHashSet} to reserve the order the same as the
+         * SchedulingVertices are traversed.
+         */
+        private final Map<ConsumedPartitionGroup, LinkedHashSet<ExecutionSlotSharingGroup>>
+                candidateGroupsForConsumedPartitionGroup;
 
         private ExecutionSlotSharingGroupBuilder(
                 final SchedulingTopology topology,
@@ -125,7 +165,8 @@ class LocalInputPreferredSlotSharingStrategy implements SlotSharingStrategy {
             executionSlotSharingGroupMap = new HashMap<>();
             constraintToExecutionSlotSharingGroupMap = new HashMap<>();
             executionSlotSharingGroups = new HashMap<>();
-            assignedJobVerticesForGroups = new IdentityHashMap<>();
+            availableGroupsForJobVertex = new HashMap<>();
+            candidateGroupsForConsumedPartitionGroup = new IdentityHashMap<>();
         }
 
         /**
@@ -159,6 +200,10 @@ class LocalInputPreferredSlotSharingStrategy implements SlotSharingStrategy {
             return executionSlotSharingGroupMap;
         }
 
+        /**
+         * The vertices are topologically sorted since {@link DefaultExecutionTopology#getVertices}
+         * are topologically sorted.
+         */
         private LinkedHashMap<JobVertexID, List<SchedulingExecutionVertex>> getExecutionVertices() {
             final LinkedHashMap<JobVertexID, List<SchedulingExecutionVertex>> vertices =
                     new LinkedHashMap<>();
@@ -214,85 +259,131 @@ class LocalInputPreferredSlotSharingStrategy implements SlotSharingStrategy {
 
             final ExecutionVertexID executionVertexId = executionVertex.getId();
 
-            for (SchedulingResultPartition partition : executionVertex.getConsumedResults()) {
-                final ExecutionVertexID producerVertexId = partition.getProducer().getId();
-                if (!inSameLogicalSlotSharingGroup(producerVertexId, executionVertexId)) {
-                    continue;
-                }
+            for (ConsumedPartitionGroup consumedPartitionGroup :
+                    executionVertex.getConsumedPartitionGroups()) {
 
-                final ExecutionSlotSharingGroup producerGroup =
-                        executionSlotSharingGroupMap.get(producerVertexId);
+                Set<ExecutionSlotSharingGroup> candidateGroups =
+                        candidateGroupsForConsumedPartitionGroup.computeIfAbsent(
+                                consumedPartitionGroup,
+                                group ->
+                                        computeAllCandidateGroupsForConsumedPartitionGroup(
+                                                executionVertexId.getJobVertexId(), group));
 
-                checkState(producerGroup != null);
-                if (isGroupAvailableForVertex(producerGroup, executionVertexId)) {
-                    return producerGroup;
+                Iterator<ExecutionSlotSharingGroup> candidateIterator = candidateGroups.iterator();
+
+                while (candidateIterator.hasNext()) {
+                    ExecutionSlotSharingGroup candidateGroup = candidateIterator.next();
+                    // There are two cases for this candidate group:
+                    //
+                    // 1. The group is available for this vertex, and it will be assigned to this
+                    // vertex;
+                    // 2. The group is not available for this vertex, because it's already assigned
+                    // to another vertex with the same JobVertexID.
+                    //
+                    // No matter what case it is, the candidate group is no longer a candidate and
+                    // should be removed.
+                    candidateIterator.remove();
+                    if (isExecutionSlotSharingGroupAvailableForVertex(
+                            candidateGroup, executionVertexId)) {
+                        return candidateGroup;
+                    }
                 }
             }
 
             return null;
         }
 
+        private boolean isExecutionSlotSharingGroupAvailableForVertex(
+                ExecutionSlotSharingGroup executionSlotSharingGroup, ExecutionVertexID vertexId) {
+
+            Set<ExecutionSlotSharingGroup> availableGroupsForCurrentVertex =
+                    availableGroupsForJobVertex.get(vertexId.getJobVertexId());
+
+            return availableGroupsForCurrentVertex != null
+                    && availableGroupsForCurrentVertex.contains(executionSlotSharingGroup);
+        }
+
         private boolean inSameLogicalSlotSharingGroup(
-                final ExecutionVertexID executionVertexId1,
-                final ExecutionVertexID executionVertexId2) {
+                final JobVertexID jobVertexId1, final JobVertexID jobVertexId2) {
 
             return Objects.equals(
-                    getSlotSharingGroup(executionVertexId1).getSlotSharingGroupId(),
-                    getSlotSharingGroup(executionVertexId2).getSlotSharingGroupId());
+                    getSlotSharingGroup(jobVertexId1).getSlotSharingGroupId(),
+                    getSlotSharingGroup(jobVertexId2).getSlotSharingGroupId());
         }
 
-        private SlotSharingGroup getSlotSharingGroup(final ExecutionVertexID executionVertexId) {
+        private SlotSharingGroup getSlotSharingGroup(final JobVertexID jobVertexId) {
             // slot sharing group of a vertex would never be null in production
-            return checkNotNull(slotSharingGroupMap.get(executionVertexId.getJobVertexId()));
-        }
-
-        private boolean isGroupAvailableForVertex(
-                final ExecutionSlotSharingGroup executionSlotSharingGroup,
-                final ExecutionVertexID executionVertexId) {
-
-            final Set<JobVertexID> assignedVertices =
-                    assignedJobVerticesForGroups.get(executionSlotSharingGroup);
-            return assignedVertices == null
-                    || !assignedVertices.contains(executionVertexId.getJobVertexId());
+            return checkNotNull(slotSharingGroupMap.get(jobVertexId));
         }
 
         private void addVertexToExecutionSlotSharingGroup(
                 final SchedulingExecutionVertex vertex, final ExecutionSlotSharingGroup group) {
 
-            group.addVertex(vertex.getId());
-            executionSlotSharingGroupMap.put(vertex.getId(), group);
-            assignedJobVerticesForGroups
-                    .computeIfAbsent(group, k -> new HashSet<>())
-                    .add(vertex.getId().getJobVertexId());
+            ExecutionVertexID executionVertexId = vertex.getId();
+            group.addVertex(executionVertexId);
+            executionSlotSharingGroupMap.put(executionVertexId, group);
+
+            // The ExecutionSlotSharingGroup is no longer available for the JobVertex
+            Set<ExecutionSlotSharingGroup> availableExecutionSlotSharingGroups =
+                    availableGroupsForJobVertex.get(executionVertexId.getJobVertexId());
+            if (availableExecutionSlotSharingGroups != null) {
+                availableExecutionSlotSharingGroups.remove(group);
+            }
         }
 
         private void findAvailableOrCreateNewExecutionSlotSharingGroupFor(
                 final List<SchedulingExecutionVertex> executionVertices) {
 
             for (SchedulingExecutionVertex executionVertex : executionVertices) {
-                final SlotSharingGroup slotSharingGroup =
-                        getSlotSharingGroup(executionVertex.getId());
-                final List<ExecutionSlotSharingGroup> groups =
-                        executionSlotSharingGroups.computeIfAbsent(
-                                slotSharingGroup.getSlotSharingGroupId(), k -> new ArrayList<>());
 
-                ExecutionSlotSharingGroup group = null;
-                for (ExecutionSlotSharingGroup executionSlotSharingGroup : groups) {
-                    if (isGroupAvailableForVertex(
-                            executionSlotSharingGroup, executionVertex.getId())) {
-                        group = executionSlotSharingGroup;
-                        break;
-                    }
-                }
+                ExecutionSlotSharingGroup group =
+                        tryFindAvailableExecutionSlotSharingGroupFor(executionVertex);
 
                 if (group == null) {
-                    group = new ExecutionSlotSharingGroup();
-                    group.setResourceProfile(slotSharingGroup.getResourceProfile());
-                    groups.add(group);
+                    group = createNewExecutionSlotSharingGroup(executionVertex.getId());
                 }
 
                 addVertexToExecutionSlotSharingGroup(executionVertex, group);
             }
+        }
+
+        private ExecutionSlotSharingGroup tryFindAvailableExecutionSlotSharingGroupFor(
+                SchedulingExecutionVertex executionVertex) {
+
+            Set<ExecutionSlotSharingGroup> availableGroupsForCurrentVertex =
+                    availableGroupsForJobVertex.get(executionVertex.getId().getJobVertexId());
+
+            if (availableGroupsForCurrentVertex != null
+                    && !availableGroupsForCurrentVertex.isEmpty()) {
+                return availableGroupsForCurrentVertex.iterator().next();
+            }
+
+            return null;
+        }
+
+        private ExecutionSlotSharingGroup createNewExecutionSlotSharingGroup(
+                ExecutionVertexID executionVertexId) {
+            final SlotSharingGroup slotSharingGroup =
+                    getSlotSharingGroup(executionVertexId.getJobVertexId());
+            final List<ExecutionSlotSharingGroup> correspondingExecutionSlotSharingGroups =
+                    executionSlotSharingGroups.computeIfAbsent(
+                            slotSharingGroup.getSlotSharingGroupId(), k -> new ArrayList<>());
+
+            final ExecutionSlotSharingGroup newGroup = new ExecutionSlotSharingGroup();
+            newGroup.setResourceProfile(slotSharingGroup.getResourceProfile());
+
+            correspondingExecutionSlotSharingGroups.add(newGroup);
+
+            // Once a new ExecutionSlotSharingGroup is created, it's available for all JobVertices
+            // in this SlotSharingGroup
+            for (JobVertexID jobVertexId : slotSharingGroup.getJobVertexIds()) {
+                Set<ExecutionSlotSharingGroup> availableExecutionSlotSharingGroups =
+                        availableGroupsForJobVertex.computeIfAbsent(
+                                jobVertexId, ignore -> new LinkedHashSet<>());
+                availableExecutionSlotSharingGroups.add(newGroup);
+            }
+
+            return newGroup;
         }
 
         private void updateConstraintToExecutionSlotSharingGroupMap(
@@ -311,6 +402,45 @@ class LocalInputPreferredSlotSharingStrategy implements SlotSharingStrategy {
                             constraint, executionSlotSharingGroupMap.get(executionVertexId));
                 }
             }
+        }
+
+        private LinkedHashSet<ExecutionSlotSharingGroup>
+                computeAllCandidateGroupsForConsumedPartitionGroup(
+                        JobVertexID consumerJobVertexId,
+                        ConsumedPartitionGroup consumedPartitionGroup) {
+
+            // We tend to reserve the order of ExecutionSlotSharingGroups as they are traversed
+            // topologically
+            final LinkedHashSet<ExecutionSlotSharingGroup> candidateExecutionSlotSharingGroups =
+                    new LinkedHashSet<>();
+
+            JobVertexID producerJobVertexId =
+                    topology.getResultPartition(consumedPartitionGroup.getFirst())
+                            .getProducer()
+                            .getId()
+                            .getJobVertexId();
+
+            // Check if the producer JobVertex and the consumer JobVertex are in the same
+            // SlotSharingGroup
+            if (inSameLogicalSlotSharingGroup(producerJobVertexId, consumerJobVertexId)) {
+
+                // Iterate over the producer ExecutionVertices of all the partitions in the
+                // ConsumedPartitionGroup
+                for (IntermediateResultPartitionID consumedPartition : consumedPartitionGroup) {
+
+                    ExecutionVertexID producerExecutionVertexId =
+                            topology.getResultPartition(consumedPartition).getProducer().getId();
+
+                    ExecutionSlotSharingGroup assignedGroupForProducerExecutionVertex =
+                            executionSlotSharingGroupMap.get(producerExecutionVertexId);
+                    checkNotNull(assignedGroupForProducerExecutionVertex);
+
+                    candidateExecutionSlotSharingGroups.add(
+                            assignedGroupForProducerExecutionVertex);
+                }
+            }
+
+            return candidateExecutionSlotSharingGroups;
         }
     }
 }

--- a/flink-runtime/src/test/java/org/apache/flink/runtime/scheduler/LocalInputPreferredSlotSharingStrategyTest.java
+++ b/flink-runtime/src/test/java/org/apache/flink/runtime/scheduler/LocalInputPreferredSlotSharingStrategyTest.java
@@ -19,12 +19,22 @@
 package org.apache.flink.runtime.scheduler;
 
 import org.apache.flink.runtime.clusterframework.types.ResourceProfile;
+import org.apache.flink.runtime.executiongraph.ExecutionGraph;
+import org.apache.flink.runtime.executiongraph.ExecutionVertex;
+import org.apache.flink.runtime.executiongraph.TestingDefaultExecutionGraphBuilder;
+import org.apache.flink.runtime.io.network.partition.ResultPartitionType;
+import org.apache.flink.runtime.jobgraph.DistributionPattern;
+import org.apache.flink.runtime.jobgraph.JobGraph;
+import org.apache.flink.runtime.jobgraph.JobGraphTestUtils;
+import org.apache.flink.runtime.jobgraph.JobVertex;
 import org.apache.flink.runtime.jobgraph.JobVertexID;
 import org.apache.flink.runtime.jobmanager.scheduler.CoLocationGroup;
 import org.apache.flink.runtime.jobmanager.scheduler.CoLocationGroupImpl;
 import org.apache.flink.runtime.jobmanager.scheduler.SlotSharingGroup;
+import org.apache.flink.runtime.scheduler.strategy.SchedulingTopology;
 import org.apache.flink.runtime.scheduler.strategy.TestingSchedulingExecutionVertex;
 import org.apache.flink.runtime.scheduler.strategy.TestingSchedulingTopology;
+import org.apache.flink.runtime.testtasks.NoOpInvokable;
 import org.apache.flink.util.TestLogger;
 
 import org.junit.Before;
@@ -34,12 +44,14 @@ import java.util.Arrays;
 import java.util.Collections;
 import java.util.HashSet;
 import java.util.List;
+import java.util.Objects;
 import java.util.Set;
 
 import static org.hamcrest.MatcherAssert.assertThat;
 import static org.hamcrest.Matchers.containsInAnyOrder;
 import static org.hamcrest.Matchers.equalTo;
 import static org.hamcrest.Matchers.hasSize;
+import static org.junit.Assert.assertEquals;
 
 /** Tests for {@link LocalInputPreferredSlotSharingStrategy}. */
 public class LocalInputPreferredSlotSharingStrategyTest extends TestLogger {
@@ -95,7 +107,7 @@ public class LocalInputPreferredSlotSharingStrategyTest extends TestLogger {
     }
 
     @Test
-    public void testInputLocalityIsRespected() {
+    public void testInputLocalityIsRespectedWithRescaleEdge() {
         final TestingSchedulingTopology topology = new TestingSchedulingTopology();
 
         final TestingSchedulingExecutionVertex ev11 =
@@ -128,6 +140,43 @@ public class LocalInputPreferredSlotSharingStrategyTest extends TestLogger {
         assertThat(
                 strategy.getExecutionSlotSharingGroup(ev23.getId()).getExecutionVertexIds(),
                 containsInAnyOrder(ev12.getId(), ev23.getId()));
+    }
+
+    @Test
+    public void testInputLocalityIsRespectedWithAllToAllEdge() {
+        final TestingSchedulingTopology topology = new TestingSchedulingTopology();
+
+        final List<TestingSchedulingExecutionVertex> producer =
+                topology.addExecutionVertices()
+                        .withParallelism(2)
+                        .withJobVertexID(JOB_VERTEX_ID_1)
+                        .finish();
+        final List<TestingSchedulingExecutionVertex> consumer =
+                topology.addExecutionVertices()
+                        .withParallelism(2)
+                        .withJobVertexID(JOB_VERTEX_ID_2)
+                        .finish();
+
+        topology.connectAllToAll(producer, consumer)
+                .withResultPartitionType(ResultPartitionType.BLOCKING)
+                .finish();
+
+        ev11 = producer.get(0);
+        ev12 = producer.get(1);
+
+        ev21 = consumer.get(0);
+        ev22 = consumer.get(1);
+
+        final SlotSharingStrategy strategy =
+                new LocalInputPreferredSlotSharingStrategy(
+                        topology, slotSharingGroups, Collections.emptySet());
+        assertThat(strategy.getExecutionSlotSharingGroups(), hasSize(2));
+        assertThat(
+                strategy.getExecutionSlotSharingGroup(ev21.getId()).getExecutionVertexIds(),
+                containsInAnyOrder(ev11.getId(), ev21.getId()));
+        assertThat(
+                strategy.getExecutionSlotSharingGroup(ev22.getId()).getExecutionVertexIds(),
+                containsInAnyOrder(ev12.getId(), ev22.getId()));
     }
 
     @Test
@@ -209,7 +258,58 @@ public class LocalInputPreferredSlotSharingStrategyTest extends TestLogger {
                 equalTo(resourceProfile2));
     }
 
-    private class TestingCoLocationGroup extends CoLocationGroupImpl {
+    /**
+     * In this test case, there are two JobEdges between two JobVertices. There will be no
+     * ExecutionSlotSharingGroup that contains two vertices with the same JobVertexID.
+     */
+    @Test
+    public void testInputLocalityIsRespectedWithTwoEdgesBetweenTwoVertices() throws Exception {
+        int parallelism = 4;
+
+        JobVertex v1 = createJobVertex("v1", JOB_VERTEX_ID_1, parallelism);
+        JobVertex v2 = createJobVertex("v2", JOB_VERTEX_ID_2, parallelism);
+
+        v2.connectNewDataSetAsInput(
+                v1, DistributionPattern.ALL_TO_ALL, ResultPartitionType.BLOCKING);
+        v2.connectNewDataSetAsInput(
+                v1, DistributionPattern.ALL_TO_ALL, ResultPartitionType.BLOCKING);
+
+        assertEquals(2, v1.getProducedDataSets().size());
+        assertEquals(2, v2.getInputs().size());
+
+        final JobGraph jobGraph = JobGraphTestUtils.batchJobGraph(v1, v2);
+        final ExecutionGraph executionGraph =
+                TestingDefaultExecutionGraphBuilder.newBuilder().setJobGraph(jobGraph).build();
+        final SchedulingTopology topology = executionGraph.getSchedulingTopology();
+
+        final SlotSharingStrategy strategy =
+                new LocalInputPreferredSlotSharingStrategy(
+                        topology, slotSharingGroups, Collections.emptySet());
+
+        assertThat(strategy.getExecutionSlotSharingGroups(), hasSize(4));
+
+        ExecutionVertex[] ev1 =
+                Objects.requireNonNull(executionGraph.getJobVertex(JOB_VERTEX_ID_1))
+                        .getTaskVertices();
+        ExecutionVertex[] ev2 =
+                Objects.requireNonNull(executionGraph.getJobVertex(JOB_VERTEX_ID_2))
+                        .getTaskVertices();
+        for (int i = 0; i < parallelism; i++) {
+            assertThat(
+                    strategy.getExecutionSlotSharingGroup(ev1[i].getID()).getExecutionVertexIds(),
+                    containsInAnyOrder(ev1[i].getID(), ev2[i].getID()));
+        }
+    }
+
+    private static JobVertex createJobVertex(
+            String vertexName, JobVertexID vertexId, int parallelism) {
+        JobVertex jobVertex = new JobVertex(vertexName, vertexId);
+        jobVertex.setParallelism(parallelism);
+        jobVertex.setInvokableClass(NoOpInvokable.class);
+        return jobVertex;
+    }
+
+    private static class TestingCoLocationGroup extends CoLocationGroupImpl {
 
         private final List<JobVertexID> vertexIDs;
 

--- a/flink-runtime/src/test/java/org/apache/flink/runtime/scheduler/LocalInputPreferredSlotSharingStrategyTest.java
+++ b/flink-runtime/src/test/java/org/apache/flink/runtime/scheduler/LocalInputPreferredSlotSharingStrategyTest.java
@@ -36,10 +36,10 @@ import java.util.HashSet;
 import java.util.List;
 import java.util.Set;
 
+import static org.hamcrest.MatcherAssert.assertThat;
 import static org.hamcrest.Matchers.containsInAnyOrder;
 import static org.hamcrest.Matchers.equalTo;
 import static org.hamcrest.Matchers.hasSize;
-import static org.junit.Assert.assertThat;
 
 /** Tests for {@link LocalInputPreferredSlotSharingStrategy}. */
 public class LocalInputPreferredSlotSharingStrategyTest extends TestLogger {

--- a/flink-runtime/src/test/java/org/apache/flink/runtime/scheduler/strategy/TestingSchedulingTopology.java
+++ b/flink-runtime/src/test/java/org/apache/flink/runtime/scheduler/strategy/TestingSchedulingTopology.java
@@ -387,12 +387,17 @@ public class TestingSchedulingTopology implements SchedulingTopology {
     /** Builder for {@link TestingSchedulingExecutionVertex}. */
     public class SchedulingExecutionVerticesBuilder {
 
-        private final JobVertexID jobVertexId = new JobVertexID();
+        private JobVertexID jobVertexId = new JobVertexID();
 
         private int parallelism = 1;
 
         public SchedulingExecutionVerticesBuilder withParallelism(final int parallelism) {
             this.parallelism = parallelism;
+            return this;
+        }
+
+        public SchedulingExecutionVerticesBuilder withJobVertexID(final JobVertexID jobVertexId) {
+            this.jobVertexId = jobVertexId;
             return this;
         }
 


### PR DESCRIPTION
## What is the purpose of the change

*This pull request aims to optimize the initialization of `LocalInputPreferredSlotSharingStrategy`. This will make its computation complexity decrease from O(N^2) to O(N). For more details please visit FLINK-22767.*


## Brief change log

  - *Optimize the initialization of LocalInputPreferredSlotSharingStrategy*

## Verifying this change

- *Two unit tests added, which covers two scenarios: 1. Two vertices connected with an ALL-TO-ALL edge; 2.Two vertices connected with two JobEdges.*
- *Manually verified the change by running an end-to-end test. The job has two JobVertices. One is source, while the other is sink. The parallelism is 8k. Both the all-to-all edge and pointwise edge are tested. Both streaming mode and batch mode are tested.*
- *Manually verified with TPCDS.*

## Does this pull request potentially affect one of the following parts:

  - Dependencies (does it add or upgrade a dependency): (yes / **no**)
  - The public API, i.e., is any changed class annotated with `@Public(Evolving)`: (yes / **no**)
  - The serializers: (yes / **no** / don't know)
  - The runtime per-record code paths (performance sensitive): (yes / **no** / don't know)
  - Anything that affects deployment or recovery: JobManager (and its components), Checkpointing, Kubernetes/Yarn, ZooKeeper: (**yes** / no / don't know)
  - The S3 file system connector: (yes / **no** / don't know)

## Documentation

  - Does this pull request introduce a new feature? (yes / **no**)
  - If yes, how is the feature documented? (**not applicable** / docs / JavaDocs / not documented)
