### PR TITLE
[FLINK-21116][runtime] Harden DefaultDispatcherRunnerITCase#leaderCha…

### DIFF
--- a/flink-runtime/src/test/java/org/apache/flink/runtime/dispatcher/TestingJobManagerRunnerFactory.java
+++ b/flink-runtime/src/test/java/org/apache/flink/runtime/dispatcher/TestingJobManagerRunnerFactory.java
@@ -27,11 +27,13 @@ import org.apache.flink.runtime.jobmaster.TestingJobManagerRunner;
 import org.apache.flink.runtime.jobmaster.factories.JobManagerJobMetricGroupFactory;
 import org.apache.flink.runtime.rpc.FatalErrorHandler;
 import org.apache.flink.runtime.rpc.RpcService;
+import org.apache.flink.util.Preconditions;
 
 import javax.annotation.Nonnull;
 
 import java.util.concurrent.ArrayBlockingQueue;
 import java.util.concurrent.BlockingQueue;
+import java.util.concurrent.atomic.AtomicInteger;
 
 /**
  * Testing implementation of {@link JobManagerRunnerFactory} which returns a {@link
@@ -42,14 +44,14 @@ public class TestingJobManagerRunnerFactory implements JobManagerRunnerFactory {
     private final BlockingQueue<TestingJobManagerRunner> createdJobManagerRunner =
             new ArrayBlockingQueue<>(16);
 
-    private int numBlockingJobManagerRunners;
+    private final AtomicInteger numBlockingJobManagerRunners;
 
     public TestingJobManagerRunnerFactory() {
         this(0);
     }
 
     public TestingJobManagerRunnerFactory(int numBlockingJobManagerRunners) {
-        this.numBlockingJobManagerRunners = numBlockingJobManagerRunners;
+        this.numBlockingJobManagerRunners = new AtomicInteger(numBlockingJobManagerRunners);
     }
 
     @Override
@@ -66,22 +68,15 @@ public class TestingJobManagerRunnerFactory implements JobManagerRunnerFactory {
             throws Exception {
         final TestingJobManagerRunner testingJobManagerRunner =
                 createTestingJobManagerRunner(jobGraph);
-        createdJobManagerRunner.offer(testingJobManagerRunner);
-
+        Preconditions.checkState(
+                createdJobManagerRunner.offer(testingJobManagerRunner),
+                "Unable to persist created the new runner.");
         return testingJobManagerRunner;
     }
 
     @Nonnull
     private TestingJobManagerRunner createTestingJobManagerRunner(JobGraph jobGraph) {
-        final boolean blockingTermination;
-
-        if (numBlockingJobManagerRunners > 0) {
-            numBlockingJobManagerRunners--;
-            blockingTermination = true;
-        } else {
-            blockingTermination = false;
-        }
-
+        final boolean blockingTermination = numBlockingJobManagerRunners.getAndDecrement() > 0;
         return new TestingJobManagerRunner.Builder()
                 .setJobId(jobGraph.getJobID())
                 .setBlockingTermination(blockingTermination)


### PR DESCRIPTION
## What is the purpose of the change

Fixing a flaky test. Test could get stuck due to hard to reproduce memory-visibility issue in TestingnJobManagerRunnerFactory and race condition between job recovery and dispatcher runner termination.

Issue can be reproduced with following change.

```diff
diff --git a/flink-runtime/src/test/java/org/apache/flink/runtime/dispatcher/TestingJobManagerRunnerFactory.java b/flink-runtime/src/test/java/org/apache/flink/runtime/dispatcher/TestingJobManagerRunnerFactory.java
index 7b195f09294..47f9ac61734 100644
--- a/flink-runtime/src/test/java/org/apache/flink/runtime/dispatcher/TestingJobManagerRunnerFactory.java
+++ b/flink-runtime/src/test/java/org/apache/flink/runtime/dispatcher/TestingJobManagerRunnerFactory.java
@@ -30,6 +30,9 @@ import org.apache.flink.runtime.rpc.RpcService;
 
 import javax.annotation.Nonnull;
 
+import java.util.Collections;
+import java.util.HashSet;
+import java.util.Set;
 import java.util.concurrent.ArrayBlockingQueue;
 import java.util.concurrent.BlockingQueue;
 
@@ -71,11 +74,22 @@ public class TestingJobManagerRunnerFactory implements JobManagerRunnerFactory {
         return testingJobManagerRunner;
     }
 
+    private final Set<String> threads = Collections.synchronizedSet(new HashSet<>());
+
     @Nonnull
     private TestingJobManagerRunner createTestingJobManagerRunner(JobGraph jobGraph) {
         final boolean blockingTermination;
 
-        if (numBlockingJobManagerRunners > 0) {
+        final boolean memoryFlap = threads.add(Thread.currentThread().getName()) && threads.size() > 1;
+        System.out.println(
+                "FLAP: "
+                        + memoryFlap
+                        + ", THREAD: "
+                        + Thread.currentThread()
+                        + ", INSTANCE: "
+                        + System.identityHashCode(this)
+                        + threads);
+        if (numBlockingJobManagerRunners > 0 || memoryFlap) {
             numBlockingJobManagerRunners--;
             blockingTermination = true;
         } else {
```

## Brief change log

- TestingJobManagerRunnerFactory is now thread safe
- We're waiting for job recovery before closing DispatcherRunner