### PR TITLE
[FLINK-23587] Set Deployment's Annotation when using native kubernetes

### DIFF
--- a/flink-kubernetes/src/main/java/org/apache/flink/kubernetes/kubeclient/factory/KubernetesJobManagerFactory.java
+++ b/flink-kubernetes/src/main/java/org/apache/flink/kubernetes/kubeclient/factory/KubernetesJobManagerFactory.java
@@ -106,6 +106,7 @@ public class KubernetesJobManagerFactory {
                 .withName(
                         KubernetesUtils.getDeploymentName(
                                 kubernetesJobManagerParameters.getClusterId()))
+                .withAnnotations(kubernetesJobManagerParameters.getAnnotations())
                 .withLabels(kubernetesJobManagerParameters.getLabels())
                 .withOwnerReferences(
                         kubernetesJobManagerParameters.getOwnerReference().stream()

--- a/flink-kubernetes/src/test/java/org/apache/flink/kubernetes/kubeclient/KubernetesJobManagerTestBase.java
+++ b/flink-kubernetes/src/test/java/org/apache/flink/kubernetes/kubeclient/KubernetesJobManagerTestBase.java
@@ -54,6 +54,7 @@ public class KubernetesJobManagerTestBase extends KubernetesPodTestBase {
                         this.flinkConfig.setString(
                                 ResourceManagerOptions.CONTAINERIZED_MASTER_ENV_PREFIX + k, v));
         this.flinkConfig.set(KubernetesConfigOptions.JOB_MANAGER_LABELS, userLabels);
+        this.flinkConfig.set(KubernetesConfigOptions.JOB_MANAGER_ANNOTATIONS, userAnnotations);
         this.flinkConfig.set(KubernetesConfigOptions.JOB_MANAGER_NODE_SELECTOR, nodeSelector);
         this.flinkConfig.set(
                 JobManagerOptions.TOTAL_PROCESS_MEMORY, MemorySize.ofMebiBytes(JOB_MANAGER_MEMORY));

--- a/flink-kubernetes/src/test/java/org/apache/flink/kubernetes/kubeclient/KubernetesPodTestBase.java
+++ b/flink-kubernetes/src/test/java/org/apache/flink/kubernetes/kubeclient/KubernetesPodTestBase.java
@@ -42,6 +42,14 @@ public class KubernetesPodTestBase extends KubernetesTestBase {
                 }
             };
 
+    protected final Map<String, String> userAnnotations =
+            new HashMap<String, String>() {
+                {
+                    put("annotation1", "value1");
+                    put("annotation2", "value2");
+                }
+            };
+
     protected final Map<String, String> nodeSelector =
             new HashMap<String, String>() {
                 {

--- a/flink-kubernetes/src/test/java/org/apache/flink/kubernetes/kubeclient/factory/KubernetesJobManagerFactoryTest.java
+++ b/flink-kubernetes/src/test/java/org/apache/flink/kubernetes/kubeclient/factory/KubernetesJobManagerFactoryTest.java
@@ -63,6 +63,7 @@ import static org.apache.flink.configuration.GlobalConfiguration.FLINK_CONF_FILE
 import static org.apache.flink.kubernetes.utils.Constants.CONFIG_FILE_LOG4J_NAME;
 import static org.apache.flink.kubernetes.utils.Constants.CONFIG_FILE_LOGBACK_NAME;
 import static org.hamcrest.MatcherAssert.assertThat;
+import static org.hamcrest.Matchers.equalTo;
 import static org.hamcrest.Matchers.is;
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertFalse;
@@ -139,6 +140,8 @@ public class KubernetesJobManagerFactoryTest extends KubernetesJobManagerTestBas
         expectedLabels.putAll(userLabels);
         assertEquals(expectedLabels, resultDeployment.getMetadata().getLabels());
 
+        assertThat(resultDeployment.getMetadata().getAnnotations(), equalTo(userAnnotations));
+
         assertThat(
                 resultDeployment.getMetadata().getOwnerReferences(),
                 Matchers.containsInAnyOrder(OWNER_REFERENCES.toArray()));
@@ -160,6 +163,10 @@ public class KubernetesJobManagerFactoryTest extends KubernetesJobManagerTestBas
 
         assertEquals(expectedLabels, resultDeploymentSpec.getTemplate().getMetadata().getLabels());
         assertEquals(expectedLabels, resultDeploymentSpec.getSelector().getMatchLabels());
+
+        assertThat(
+                resultDeploymentSpec.getTemplate().getMetadata().getAnnotations(),
+                equalTo(userAnnotations));
 
         assertNotNull(resultDeploymentSpec.getTemplate().getSpec());
     }


### PR DESCRIPTION
What is the purpose of the change
This pull requests configs the deployment's annotations as pods' used when deploying with native kubernetes.

Brief change log
The Jobmanager deployment will pick up the annotations when using "kubernetes.jobmanager.annotations".

Verifying this change
This change is already covered by existing tests, such as org.apache.flink.kubernetes.kubeclient.factory.KubernetesJobManagerFactoryTest.

Does this pull request potentially affect one of the following parts:
Anything that affects deployment or recovery: JobManager , Kubernetes
Documentation
Does this pull request introduce a new feature? (yes)
If yes, how is the feature documented? (docs)
"kubernetes.jobmanager.annotations" will also set the jobmanager deployment's annotations.

@wangyang0918 I recreated the PR, please review again. Thank You!