### PR TITLE
[FLINK-23602][table-runtime] Fix comparison between Decimal and string literal

### DIFF
--- a/flink-table/flink-table-runtime/src/main/java/org/apache/flink/table/data/DecimalDataUtils.java
+++ b/flink-table/flink-table-runtime/src/main/java/org/apache/flink/table/data/DecimalDataUtils.java
@@ -18,6 +18,8 @@
 
 package org.apache.flink.table.data;
 
+import org.apache.flink.table.data.binary.BinaryStringData;
+import org.apache.flink.table.data.binary.BinaryStringDataUtil;
 import org.apache.flink.table.types.logical.DecimalType;
 
 import java.math.BigDecimal;
@@ -261,11 +263,23 @@ public final class DecimalDataUtils {
         return Double.compare(doubleValue(b1), n2);
     }
 
+    public static int compare(DecimalData b1, BinaryStringData n2) {
+        Double doubleValue = BinaryStringDataUtil.toDouble(n2);
+        if (doubleValue == null) {
+            throw new NumberFormatException("Cannot cast BinaryStringData: " + n2 + "to double");
+        }
+        return compare(b1, doubleValue);
+    }
+
     public static int compare(long n1, DecimalData b2) {
         return -compare(b2, n1);
     }
 
     public static int compare(double n1, DecimalData b2) {
+        return -compare(b2, n1);
+    }
+
+    public static int compare(BinaryStringData n1, DecimalData b2) {
         return -compare(b2, n1);
     }
 

--- a/flink-table/flink-table-runtime/src/test/java/org/apache/flink/table/data/DecimalDataTest.java
+++ b/flink-table/flink-table-runtime/src/test/java/org/apache/flink/table/data/DecimalDataTest.java
@@ -18,6 +18,8 @@
 
 package org.apache.flink.table.data;
 
+import org.apache.flink.table.data.binary.BinaryStringData;
+
 import org.junit.Test;
 
 import java.math.BigDecimal;
@@ -47,6 +49,7 @@ import static org.apache.flink.table.data.DecimalDataUtils.subtract;
 import static org.junit.Assert.assertArrayEquals;
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertNull;
+import static org.junit.Assert.assertThrows;
 import static org.junit.Assert.assertTrue;
 
 /** Test for {@link DecimalData}. */
@@ -176,5 +179,19 @@ public class DecimalDataTest {
         assertEquals(val, castFrom(val, 39, val.length() - 2).toString());
         val = "123456789012345678901234567890123456789";
         assertEquals(val, castFrom(val, 39, 0).toString());
+    }
+
+    @Test
+    public void testCompareToBinaryStringData() {
+        BinaryStringData validLarger = BinaryStringData.fromString("12345.12345");
+        BinaryStringData validEqual = BinaryStringData.fromString("12345.12300");
+        BinaryStringData validLess = BinaryStringData.fromString("12345.12245");
+        BinaryStringData invalid = BinaryStringData.fromString("12345abcde");
+
+        DecimalData decimalData = DecimalData.fromBigDecimal(new BigDecimal("12345.123"), 20, 3);
+        assertTrue(compare(decimalData, validLarger) < 0);
+        assertTrue(compare(decimalData, validLess) > 0);
+        assertEquals(0, compare(decimalData, validEqual));
+        assertThrows(NumberFormatException.class, () -> compare(decimalData, invalid));
     }
 }


### PR DESCRIPTION
…: Line 84, Column 78: No applicable constructor/method found for actual parameters org.apache.flink.table.data.DecimalData

## What is the purpose of the change

Fixed No applicable constructor/method found for actual parameters "org.apache.flink.table.data.DecimalData, org.apache.flink.table.data.binary.BinaryStringData" when SQL needs implicit comparison between Decimal and string literal.


## Brief change log

- flink-table/flink-table-runtime/src/main/java/org/apache/flink/table/data/DecimalDataUtils.java

## Verifying this change

This change added tests and can be verified as follows:

- testCompareToBinaryStringData method in flink-table/flink-table-runtime/src/test/java/org/apache/flink/table/data/DecimalDataTest.java


## Does this pull request potentially affect one of the following parts:

  - Dependencies (does it add or upgrade a dependency): no
  - The public API, i.e., is any changed class annotated with `@Public(Evolving)`: no
  - The serializers: no
  - The runtime per-record code paths (performance sensitive): no
  - Anything that affects deployment or recovery: JobManager (and its components), Checkpointing, Kubernetes/Yarn, ZooKeeper: no
  - The S3 file system connector: no

## Documentation

  - Does this pull request introduce a new feature? no
