### PR TITLE
[FLINK-22382][tests] Harden ProcessFailureCancelingITCase.testCancelingOnProcessFailure

### DIFF
--- a/flink-tests/src/test/java/org/apache/flink/test/recovery/ProcessFailureCancelingITCase.java
+++ b/flink-tests/src/test/java/org/apache/flink/test/recovery/ProcessFailureCancelingITCase.java
@@ -142,7 +142,7 @@ public class ProcessFailureCancelingITCase extends TestLogger {
                             rpcService,
                             haServices,
                             blobServerResource.getBlobServer(),
-                            new HeartbeatServices(100L, 1000L),
+                            new HeartbeatServices(100L, 10000L, 2),
                             NoOpMetricRegistry.INSTANCE,
                             new MemoryExecutionGraphInfoStore(),
                             VoidMetricQueryServiceRetriever.INSTANCE,


### PR DESCRIPTION
This commit hardens the ProcessFailureCancelingITCase.testCancelingOnProcessFailure by increasing the
accepted heartbeat timeout. To mitigate the increase heartbeat timeout, this PR also sets the number
of acceptable failed heartbeat requests to 2 before marking a TM as dead.
