### PR TITLE
[BP-1.13][FLINK-22382][tests] Harden ProcessFailureCancelingITCase.testCancelingOnProcessFailure

### DIFF
--- a/flink-tests/src/test/java/org/apache/flink/test/recovery/ProcessFailureCancelingITCase.java
+++ b/flink-tests/src/test/java/org/apache/flink/test/recovery/ProcessFailureCancelingITCase.java
@@ -140,7 +140,7 @@ public class ProcessFailureCancelingITCase extends TestLogger {
                             rpcService,
                             haServices,
                             blobServerResource.getBlobServer(),
-                            new HeartbeatServices(100L, 1000L),
+                            new HeartbeatServices(100L, 10000L),
                             NoOpMetricRegistry.INSTANCE,
                             new MemoryExecutionGraphInfoStore(),
                             VoidMetricQueryServiceRetriever.INSTANCE,


### PR DESCRIPTION
This commit hardens the ProcessFailureCancelingITCase.testCancelingOnProcessFailure by increasing the
accepted heartbeat timeout.
