### PR TITLE
[FLINK-23560][task] Fix performance regression by unnecessary throughput calculations

### DIFF
--- a/flink-streaming-java/src/test/java/org/apache/flink/streaming/util/MockStreamTask.java
+++ b/flink-streaming-java/src/test/java/org/apache/flink/streaming/util/MockStreamTask.java
@@ -35,7 +35,13 @@ import org.apache.flink.util.FatalExitExceptionHandler;
 
 import java.util.function.BiConsumer;
 
-/** A settable testing {@link StreamTask}. */
+/**
+ * A settable testing {@link StreamTask}.
+ *
+ * @deprecated This class is deprecated in favour of using {@link
+ *     org.apache.flink.streaming.runtime.tasks.StreamTaskMailboxTestHarnessBuilder}.
+ */
+@Deprecated
 public class MockStreamTask<OUT, OP extends StreamOperator<OUT>> extends StreamTask<OUT, OP> {
 
     private final Object checkpointLock;

--- a/flink-streaming-java/src/test/java/org/apache/flink/streaming/util/MockStreamTaskBuilder.java
+++ b/flink-streaming-java/src/test/java/org/apache/flink/streaming/util/MockStreamTaskBuilder.java
@@ -38,7 +38,13 @@ import javax.annotation.Nullable;
 
 import java.util.function.BiConsumer;
 
-/** A builder of {@link MockStreamTask}. */
+/**
+ * A builder of {@link MockStreamTask}.
+ *
+ * @deprecated This class is deprecated in favour of using {@link
+ *     org.apache.flink.streaming.runtime.tasks.StreamTaskMailboxTestHarnessBuilder}.
+ */
+@Deprecated
 public class MockStreamTaskBuilder {
     private final Environment environment;
     private Object checkpointLock = new Object();


### PR DESCRIPTION
If there are no input gates, there is no point of calculating the throughput and running the debloater. At the same time, for SourceStreamTask using legacy sources and checkpoint lock, enqueuing even a single mailbox action can cause performance regression. This is especially visible in batch, with disabled checkpointing and no processing time timers.

Pending benchmark request:
http://codespeed.dak8s.net:8080/job/flink-benchmark-request/358

## Does this pull request potentially affect one of the following parts:

  - Dependencies (does it add or upgrade a dependency): (yes / **no**)
  - The public API, i.e., is any changed class annotated with `@Public(Evolving)`: (yes / **no**)
  - The serializers: (yes / **no** / don't know)
  - The runtime per-record code paths (performance sensitive): (**yes** / no / don't know)
  - Anything that affects deployment or recovery: JobManager (and its components), Checkpointing, Kubernetes/Yarn, ZooKeeper: (yes / **no** / don't know)
  - The S3 file system connector: (yes / **no** / don't know)

## Documentation

  - Does this pull request introduce a new feature? (yes / **no**)
  - If yes, how is the feature documented? (**not applicable** / docs / JavaDocs / not documented)
