### PR TITLE
[FLINK-23624][metrics] Migrate TaskManagerMG instatiations to factory method

### DIFF
--- a/flink-metrics/flink-metrics-prometheus/src/test/java/org/apache/flink/metrics/prometheus/PrometheusReporterTaskScopeTest.java
+++ b/flink-metrics/flink-metrics-prometheus/src/test/java/org/apache/flink/metrics/prometheus/PrometheusReporterTaskScopeTest.java
@@ -26,6 +26,7 @@ import org.apache.flink.metrics.Meter;
 import org.apache.flink.metrics.SimpleCounter;
 import org.apache.flink.metrics.util.TestHistogram;
 import org.apache.flink.metrics.util.TestMeter;
+import org.apache.flink.runtime.clusterframework.types.ResourceID;
 import org.apache.flink.runtime.executiongraph.ExecutionAttemptID;
 import org.apache.flink.runtime.jobgraph.JobVertexID;
 import org.apache.flink.runtime.metrics.MetricRegistryImpl;
@@ -118,7 +119,8 @@ public class PrometheusReporterTaskScopeTest {
         reporter = (PrometheusReporter) registry.getReporters().get(0);
 
         TaskManagerMetricGroup tmMetricGroup =
-                new TaskManagerMetricGroup(registry, TASK_MANAGER_HOST, TASK_MANAGER_ID);
+                TaskManagerMetricGroup.createTaskManagerMetricGroup(
+                        registry, TASK_MANAGER_HOST, new ResourceID(TASK_MANAGER_ID));
         TaskManagerJobMetricGroup tmJobMetricGroup =
                 new TaskManagerJobMetricGroup(registry, tmMetricGroup, jobId, JOB_NAME);
         taskMetricGroup1 =

--- a/flink-metrics/flink-metrics-prometheus/src/test/java/org/apache/flink/metrics/prometheus/PrometheusReporterTest.java
+++ b/flink-metrics/flink-metrics-prometheus/src/test/java/org/apache/flink/metrics/prometheus/PrometheusReporterTest.java
@@ -28,6 +28,7 @@ import org.apache.flink.metrics.MetricConfig;
 import org.apache.flink.metrics.SimpleCounter;
 import org.apache.flink.metrics.util.TestHistogram;
 import org.apache.flink.metrics.util.TestMeter;
+import org.apache.flink.runtime.clusterframework.types.ResourceID;
 import org.apache.flink.runtime.metrics.MetricRegistryImpl;
 import org.apache.flink.runtime.metrics.MetricRegistryTestUtils;
 import org.apache.flink.runtime.metrics.ReporterSetup;
@@ -91,7 +92,8 @@ public class PrometheusReporterTest extends TestLogger {
         metricGroup =
                 new FrontMetricGroup<>(
                         createReporterScopedSettings(),
-                        new TaskManagerMetricGroup(registry, HOST_NAME, TASK_MANAGER));
+                        TaskManagerMetricGroup.createTaskManagerMetricGroup(
+                                registry, HOST_NAME, new ResourceID(TASK_MANAGER)));
         reporter = (PrometheusReporter) registry.getReporters().get(0);
     }
 
@@ -214,7 +216,8 @@ public class PrometheusReporterTest extends TestLogger {
     @Test
     public void metricIsRemovedWhenCollectorIsNotUnregisteredYet() throws UnirestException {
         TaskManagerMetricGroup tmMetricGroup =
-                new TaskManagerMetricGroup(registry, HOST_NAME, TASK_MANAGER);
+                TaskManagerMetricGroup.createTaskManagerMetricGroup(
+                        registry, HOST_NAME, new ResourceID(TASK_MANAGER));
 
         String metricName = "metric";
 

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/metrics/groups/TaskManagerMetricGroup.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/metrics/groups/TaskManagerMetricGroup.java
@@ -21,6 +21,7 @@ package org.apache.flink.runtime.metrics.groups;
 import org.apache.flink.annotation.Internal;
 import org.apache.flink.api.common.JobID;
 import org.apache.flink.metrics.CharacterFilter;
+import org.apache.flink.runtime.clusterframework.types.ResourceID;
 import org.apache.flink.runtime.executiongraph.ExecutionAttemptID;
 import org.apache.flink.runtime.jobgraph.JobVertexID;
 import org.apache.flink.runtime.metrics.MetricRegistry;
@@ -46,7 +47,7 @@ public class TaskManagerMetricGroup extends ComponentMetricGroup<TaskManagerMetr
 
     private final String taskManagerId;
 
-    public TaskManagerMetricGroup(MetricRegistry registry, String hostname, String taskManagerId) {
+    TaskManagerMetricGroup(MetricRegistry registry, String hostname, String taskManagerId) {
         super(
                 registry,
                 registry.getScopeFormats()
@@ -55,6 +56,11 @@ public class TaskManagerMetricGroup extends ComponentMetricGroup<TaskManagerMetr
                 null);
         this.hostname = hostname;
         this.taskManagerId = taskManagerId;
+    }
+
+    public static TaskManagerMetricGroup createTaskManagerMetricGroup(
+            MetricRegistry metricRegistry, String hostName, ResourceID resourceID) {
+        return new TaskManagerMetricGroup(metricRegistry, hostName, resourceID.toString());
     }
 
     public String hostname() {

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/metrics/util/MetricUtils.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/metrics/util/MetricUtils.java
@@ -99,18 +99,14 @@ public class MetricUtils {
         return processMetricGroup;
     }
 
-    public static TaskManagerMetricGroup createTaskManagerMetricGroup(
-            MetricRegistry metricRegistry, String hostName, ResourceID resourceID) {
-        return new TaskManagerMetricGroup(metricRegistry, hostName, resourceID.toString());
-    }
-
     public static Tuple2<TaskManagerMetricGroup, MetricGroup> instantiateTaskManagerMetricGroup(
             MetricRegistry metricRegistry,
             String hostName,
             ResourceID resourceID,
             Optional<Time> systemResourceProbeInterval) {
         final TaskManagerMetricGroup taskManagerMetricGroup =
-                createTaskManagerMetricGroup(metricRegistry, hostName, resourceID);
+                TaskManagerMetricGroup.createTaskManagerMetricGroup(
+                        metricRegistry, hostName, resourceID);
 
         MetricGroup statusGroup = createAndInitializeStatusMetricGroup(taskManagerMetricGroup);
 

--- a/flink-runtime/src/test/java/org/apache/flink/runtime/metrics/MetricRegistryImplTest.java
+++ b/flink-runtime/src/test/java/org/apache/flink/runtime/metrics/MetricRegistryImplTest.java
@@ -235,7 +235,9 @@ public class MetricRegistryImplTest extends TestLogger {
                                 ReporterSetup.forReporter("test1", new TestReporter6()),
                                 ReporterSetup.forReporter("test2", new TestReporter7())));
 
-        TaskManagerMetricGroup root = new TaskManagerMetricGroup(registry, "host", "id");
+        TaskManagerMetricGroup root =
+                TaskManagerMetricGroup.createTaskManagerMetricGroup(
+                        registry, "host", new ResourceID("id"));
         root.counter("rootCounter");
 
         assertTrue(TestReporter6.addedMetric instanceof Counter);
@@ -332,7 +334,9 @@ public class MetricRegistryImplTest extends TestLogger {
                         MetricRegistryTestUtils.fromConfiguration(config),
                         ReporterSetup.fromConfiguration(config, null));
 
-        TaskManagerMetricGroup tmGroup = new TaskManagerMetricGroup(registry, "host", "id");
+        TaskManagerMetricGroup tmGroup =
+                TaskManagerMetricGroup.createTaskManagerMetricGroup(
+                        registry, "host", new ResourceID("id"));
         assertEquals("A_B_C_D_E_name", tmGroup.getMetricIdentifier("name"));
 
         registry.shutdown().get();
@@ -434,7 +438,9 @@ public class MetricRegistryImplTest extends TestLogger {
         ((TestReporter8) reporters.get(3)).expectedDelimiter =
                 GLOBAL_DEFAULT_DELIMITER; // for test4 reporter use global delimiter
 
-        TaskManagerMetricGroup group = new TaskManagerMetricGroup(registry, "host", "id");
+        TaskManagerMetricGroup group =
+                TaskManagerMetricGroup.createTaskManagerMetricGroup(
+                        registry, "host", new ResourceID("id"));
         group.counter("C");
         group.close();
         registry.shutdown().get();

--- a/flink-runtime/src/test/java/org/apache/flink/runtime/metrics/groups/AbstractMetricGroupTest.java
+++ b/flink-runtime/src/test/java/org/apache/flink/runtime/metrics/groups/AbstractMetricGroupTest.java
@@ -27,6 +27,7 @@ import org.apache.flink.metrics.Metric;
 import org.apache.flink.metrics.MetricConfig;
 import org.apache.flink.metrics.MetricGroup;
 import org.apache.flink.metrics.reporter.MetricReporter;
+import org.apache.flink.runtime.clusterframework.types.ResourceID;
 import org.apache.flink.runtime.metrics.MetricRegistry;
 import org.apache.flink.runtime.metrics.MetricRegistryImpl;
 import org.apache.flink.runtime.metrics.MetricRegistryTestUtils;
@@ -186,7 +187,9 @@ public class AbstractMetricGroupTest extends TestLogger {
                                 ReporterSetup.forReporter(
                                         "test2", metricConfig2, new TestReporter2())));
         try {
-            MetricGroup tmGroup = new TaskManagerMetricGroup(testRegistry, "host", "id");
+            MetricGroup tmGroup =
+                    TaskManagerMetricGroup.createTaskManagerMetricGroup(
+                            testRegistry, "host", new ResourceID("id"));
             tmGroup.counter("1");
             assertEquals(
                     "Reporters were not properly instantiated",
@@ -213,7 +216,8 @@ public class AbstractMetricGroupTest extends TestLogger {
                                 ReporterSetup.forReporter("test2", new LogicalScopeReporter2())));
         try {
             MetricGroup tmGroup =
-                    new TaskManagerMetricGroup(testRegistry, "host", "id")
+                    TaskManagerMetricGroup.createTaskManagerMetricGroup(
+                                    testRegistry, "host", new ResourceID("id"))
                             .addGroup("B")
                             .addGroup("C");
             tmGroup.counter("1");
@@ -344,7 +348,9 @@ public class AbstractMetricGroupTest extends TestLogger {
                 new MetricRegistryImpl(MetricRegistryTestUtils.fromConfiguration(config));
 
         try {
-            TaskManagerMetricGroup group = new TaskManagerMetricGroup(testRegistry, "host", "id");
+            TaskManagerMetricGroup group =
+                    TaskManagerMetricGroup.createTaskManagerMetricGroup(
+                            testRegistry, "host", new ResourceID("id"));
             assertEquals(
                     "MetricReporters list should be empty", 0, testRegistry.getReporters().size());
 

--- a/flink-runtime/src/test/java/org/apache/flink/runtime/metrics/groups/MetricGroupRegistrationTest.java
+++ b/flink-runtime/src/test/java/org/apache/flink/runtime/metrics/groups/MetricGroupRegistrationTest.java
@@ -25,6 +25,7 @@ import org.apache.flink.metrics.Histogram;
 import org.apache.flink.metrics.HistogramStatistics;
 import org.apache.flink.metrics.Metric;
 import org.apache.flink.metrics.MetricGroup;
+import org.apache.flink.runtime.clusterframework.types.ResourceID;
 import org.apache.flink.runtime.metrics.MetricRegistryImpl;
 import org.apache.flink.runtime.metrics.MetricRegistryTestUtils;
 import org.apache.flink.runtime.metrics.ReporterSetup;
@@ -49,7 +50,9 @@ public class MetricGroupRegistrationTest extends TestLogger {
                         Collections.singletonList(
                                 ReporterSetup.forReporter("test", new TestReporter1())));
 
-        MetricGroup root = new TaskManagerMetricGroup(registry, "host", "id");
+        MetricGroup root =
+                TaskManagerMetricGroup.createTaskManagerMetricGroup(
+                        registry, "host", new ResourceID("id"));
 
         Counter counter = root.counter("counter");
         assertEquals(counter, TestReporter1.lastPassedMetric);
@@ -115,7 +118,9 @@ public class MetricGroupRegistrationTest extends TestLogger {
         MetricRegistryImpl registry =
                 new MetricRegistryImpl(MetricRegistryTestUtils.fromConfiguration(config));
 
-        MetricGroup root = new TaskManagerMetricGroup(registry, "host", "id");
+        MetricGroup root =
+                TaskManagerMetricGroup.createTaskManagerMetricGroup(
+                        registry, "host", new ResourceID("id"));
 
         MetricGroup group1 = root.addGroup("group");
         MetricGroup group2 = root.addGroup("group");

--- a/flink-runtime/src/test/java/org/apache/flink/runtime/metrics/groups/MetricGroupTest.java
+++ b/flink-runtime/src/test/java/org/apache/flink/runtime/metrics/groups/MetricGroupTest.java
@@ -25,6 +25,7 @@ import org.apache.flink.metrics.CharacterFilter;
 import org.apache.flink.metrics.Gauge;
 import org.apache.flink.metrics.Metric;
 import org.apache.flink.metrics.MetricGroup;
+import org.apache.flink.runtime.clusterframework.types.ResourceID;
 import org.apache.flink.runtime.executiongraph.ExecutionAttemptID;
 import org.apache.flink.runtime.jobgraph.JobVertexID;
 import org.apache.flink.runtime.metrics.MetricRegistry;
@@ -337,7 +338,9 @@ public class MetricGroupTest extends TestLogger {
         JobVertexID vid = new JobVertexID();
         ExecutionAttemptID eid = new ExecutionAttemptID();
         MetricRegistryImpl registry = new MetricRegistryImpl(defaultMetricRegistryConfiguration);
-        TaskManagerMetricGroup tm = new TaskManagerMetricGroup(registry, "host", "id");
+        TaskManagerMetricGroup tm =
+                TaskManagerMetricGroup.createTaskManagerMetricGroup(
+                        registry, "host", new ResourceID("id"));
         TaskManagerJobMetricGroup job = new TaskManagerJobMetricGroup(registry, tm, jid, "jobname");
         TaskMetricGroup task = new TaskMetricGroup(registry, job, vid, eid, "taskName", 4, 5);
         GenericMetricGroup userGroup1 = new GenericMetricGroup(registry, task, "hello");

--- a/flink-runtime/src/test/java/org/apache/flink/runtime/metrics/groups/OperatorGroupTest.java
+++ b/flink-runtime/src/test/java/org/apache/flink/runtime/metrics/groups/OperatorGroupTest.java
@@ -21,6 +21,7 @@ package org.apache.flink.runtime.metrics.groups;
 import org.apache.flink.api.common.JobID;
 import org.apache.flink.configuration.Configuration;
 import org.apache.flink.configuration.MetricOptions;
+import org.apache.flink.runtime.clusterframework.types.ResourceID;
 import org.apache.flink.runtime.executiongraph.ExecutionAttemptID;
 import org.apache.flink.runtime.jobgraph.JobVertexID;
 import org.apache.flink.runtime.jobgraph.OperatorID;
@@ -63,7 +64,8 @@ public class OperatorGroupTest extends TestLogger {
     @Test
     public void testGenerateScopeDefault() throws Exception {
         TaskManagerMetricGroup tmGroup =
-                new TaskManagerMetricGroup(registry, "theHostName", "test-tm-id");
+                TaskManagerMetricGroup.createTaskManagerMetricGroup(
+                        registry, "theHostName", new ResourceID("test-tm-id"));
         TaskManagerJobMetricGroup jmGroup =
                 new TaskManagerJobMetricGroup(registry, tmGroup, new JobID(), "myJobName");
         TaskMetricGroup taskGroup =
@@ -105,7 +107,8 @@ public class OperatorGroupTest extends TestLogger {
             String operatorName = "operatorName";
 
             OperatorMetricGroup operatorGroup =
-                    new TaskManagerMetricGroup(registry, "theHostName", tmID)
+                    TaskManagerMetricGroup.createTaskManagerMetricGroup(
+                                    registry, "theHostName", new ResourceID(tmID))
                             .addTaskForJob(
                                     jid,
                                     "myJobName",
@@ -138,7 +141,8 @@ public class OperatorGroupTest extends TestLogger {
     @Test
     public void testIOMetricGroupInstantiation() throws Exception {
         TaskManagerMetricGroup tmGroup =
-                new TaskManagerMetricGroup(registry, "theHostName", "test-tm-id");
+                TaskManagerMetricGroup.createTaskManagerMetricGroup(
+                        registry, "theHostName", new ResourceID("test-tm-id"));
         TaskManagerJobMetricGroup jmGroup =
                 new TaskManagerJobMetricGroup(registry, tmGroup, new JobID(), "myJobName");
         TaskMetricGroup taskGroup =
@@ -166,7 +170,8 @@ public class OperatorGroupTest extends TestLogger {
         OperatorID oid = new OperatorID();
 
         TaskManagerMetricGroup tmGroup =
-                new TaskManagerMetricGroup(registry, "theHostName", "test-tm-id");
+                TaskManagerMetricGroup.createTaskManagerMetricGroup(
+                        registry, "theHostName", new ResourceID("test-tm-id"));
         TaskManagerJobMetricGroup jmGroup =
                 new TaskManagerJobMetricGroup(registry, tmGroup, jid, "myJobName");
         TaskMetricGroup taskGroup =
@@ -201,7 +206,9 @@ public class OperatorGroupTest extends TestLogger {
         JobVertexID vid = new JobVertexID();
         ExecutionAttemptID eid = new ExecutionAttemptID();
         OperatorID oid = new OperatorID();
-        TaskManagerMetricGroup tm = new TaskManagerMetricGroup(registry, "host", "id");
+        TaskManagerMetricGroup tm =
+                TaskManagerMetricGroup.createTaskManagerMetricGroup(
+                        registry, "host", new ResourceID("id"));
         TaskManagerJobMetricGroup job = new TaskManagerJobMetricGroup(registry, tm, jid, "jobname");
         TaskMetricGroup task = new TaskMetricGroup(registry, job, vid, eid, "taskName", 4, 5);
         OperatorMetricGroup operator = new OperatorMetricGroup(registry, task, oid, "operator");

--- a/flink-runtime/src/test/java/org/apache/flink/runtime/metrics/groups/TaskManagerGroupTest.java
+++ b/flink-runtime/src/test/java/org/apache/flink/runtime/metrics/groups/TaskManagerGroupTest.java
@@ -21,6 +21,7 @@ package org.apache.flink.runtime.metrics.groups;
 import org.apache.flink.api.common.JobID;
 import org.apache.flink.configuration.Configuration;
 import org.apache.flink.configuration.MetricOptions;
+import org.apache.flink.runtime.clusterframework.types.ResourceID;
 import org.apache.flink.runtime.executiongraph.ExecutionAttemptID;
 import org.apache.flink.runtime.jobgraph.JobVertexID;
 import org.apache.flink.runtime.metrics.MetricRegistryImpl;
@@ -67,7 +68,8 @@ public class TaskManagerGroupTest extends TestLogger {
     @Test
     public void addAndRemoveJobs() throws IOException {
         final TaskManagerMetricGroup group =
-                new TaskManagerMetricGroup(registry, "localhost", new AbstractID().toString());
+                TaskManagerMetricGroup.createTaskManagerMetricGroup(
+                        registry, "localhost", ResourceID.generate());
 
         final JobID jid1 = new JobID();
         final JobID jid2 = new JobID();
@@ -125,7 +127,8 @@ public class TaskManagerGroupTest extends TestLogger {
     @Test
     public void testCloseClosesAll() throws IOException {
         final TaskManagerMetricGroup group =
-                new TaskManagerMetricGroup(registry, "localhost", new AbstractID().toString());
+                TaskManagerMetricGroup.createTaskManagerMetricGroup(
+                        registry, "localhost", new ResourceID(new AbstractID().toString()));
 
         final JobID jid1 = new JobID();
         final JobID jid2 = new JobID();
@@ -161,7 +164,9 @@ public class TaskManagerGroupTest extends TestLogger {
 
     @Test
     public void testGenerateScopeDefault() {
-        TaskManagerMetricGroup group = new TaskManagerMetricGroup(registry, "localhost", "id");
+        TaskManagerMetricGroup group =
+                TaskManagerMetricGroup.createTaskManagerMetricGroup(
+                        registry, "localhost", new ResourceID("id"));
 
         assertArrayEquals(
                 new String[] {"localhost", "taskmanager", "id"}, group.getScopeComponents());
@@ -174,7 +179,9 @@ public class TaskManagerGroupTest extends TestLogger {
         cfg.setString(MetricOptions.SCOPE_NAMING_TM, "constant.<host>.foo.<host>");
         MetricRegistryImpl registry =
                 new MetricRegistryImpl(MetricRegistryTestUtils.fromConfiguration(cfg));
-        TaskManagerMetricGroup group = new TaskManagerMetricGroup(registry, "host", "id");
+        TaskManagerMetricGroup group =
+                TaskManagerMetricGroup.createTaskManagerMetricGroup(
+                        registry, "host", new ResourceID("id"));
 
         assertArrayEquals(
                 new String[] {"constant", "host", "foo", "host"}, group.getScopeComponents());
@@ -184,7 +191,9 @@ public class TaskManagerGroupTest extends TestLogger {
 
     @Test
     public void testCreateQueryServiceMetricInfo() {
-        TaskManagerMetricGroup tm = new TaskManagerMetricGroup(registry, "host", "id");
+        TaskManagerMetricGroup tm =
+                TaskManagerMetricGroup.createTaskManagerMetricGroup(
+                        registry, "host", new ResourceID("id"));
 
         QueryScopeInfo.TaskManagerQueryScopeInfo info =
                 tm.createQueryServiceMetricInfo(new DummyCharacterFilter());

--- a/flink-runtime/src/test/java/org/apache/flink/runtime/metrics/groups/TaskManagerJobGroupTest.java
+++ b/flink-runtime/src/test/java/org/apache/flink/runtime/metrics/groups/TaskManagerJobGroupTest.java
@@ -21,6 +21,7 @@ package org.apache.flink.runtime.metrics.groups;
 import org.apache.flink.api.common.JobID;
 import org.apache.flink.configuration.Configuration;
 import org.apache.flink.configuration.MetricOptions;
+import org.apache.flink.runtime.clusterframework.types.ResourceID;
 import org.apache.flink.runtime.metrics.MetricRegistryImpl;
 import org.apache.flink.runtime.metrics.MetricRegistryTestUtils;
 import org.apache.flink.runtime.metrics.dump.QueryScopeInfo;
@@ -56,7 +57,8 @@ public class TaskManagerJobGroupTest extends TestLogger {
     @Test
     public void testGenerateScopeDefault() {
         TaskManagerMetricGroup tmGroup =
-                new TaskManagerMetricGroup(registry, "theHostName", "test-tm-id");
+                TaskManagerMetricGroup.createTaskManagerMetricGroup(
+                        registry, "theHostName", new ResourceID("test-tm-id"));
         JobMetricGroup jmGroup =
                 new TaskManagerJobMetricGroup(registry, tmGroup, new JobID(), "myJobName");
 
@@ -80,7 +82,8 @@ public class TaskManagerJobGroupTest extends TestLogger {
         JobID jid = new JobID();
 
         TaskManagerMetricGroup tmGroup =
-                new TaskManagerMetricGroup(registry, "theHostName", "test-tm-id");
+                TaskManagerMetricGroup.createTaskManagerMetricGroup(
+                        registry, "theHostName", new ResourceID("test-tm-id"));
         JobMetricGroup jmGroup = new TaskManagerJobMetricGroup(registry, tmGroup, jid, "myJobName");
 
         assertArrayEquals(
@@ -101,7 +104,8 @@ public class TaskManagerJobGroupTest extends TestLogger {
         JobID jid = new JobID();
 
         TaskManagerMetricGroup tmGroup =
-                new TaskManagerMetricGroup(registry, "theHostName", "test-tm-id");
+                TaskManagerMetricGroup.createTaskManagerMetricGroup(
+                        registry, "theHostName", new ResourceID("test-tm-id"));
         JobMetricGroup jmGroup = new TaskManagerJobMetricGroup(registry, tmGroup, jid, "myJobName");
 
         assertArrayEquals(
@@ -117,7 +121,9 @@ public class TaskManagerJobGroupTest extends TestLogger {
     @Test
     public void testCreateQueryServiceMetricInfo() {
         JobID jid = new JobID();
-        TaskManagerMetricGroup tm = new TaskManagerMetricGroup(registry, "host", "id");
+        TaskManagerMetricGroup tm =
+                TaskManagerMetricGroup.createTaskManagerMetricGroup(
+                        registry, "host", new ResourceID("id"));
         TaskManagerJobMetricGroup job = new TaskManagerJobMetricGroup(registry, tm, jid, "jobname");
 
         QueryScopeInfo.JobQueryScopeInfo info =

--- a/flink-runtime/src/test/java/org/apache/flink/runtime/metrics/groups/TaskMetricGroupTest.java
+++ b/flink-runtime/src/test/java/org/apache/flink/runtime/metrics/groups/TaskMetricGroupTest.java
@@ -22,6 +22,7 @@ import org.apache.flink.api.common.JobID;
 import org.apache.flink.configuration.Configuration;
 import org.apache.flink.configuration.MetricOptions;
 import org.apache.flink.metrics.Metric;
+import org.apache.flink.runtime.clusterframework.types.ResourceID;
 import org.apache.flink.runtime.executiongraph.ExecutionAttemptID;
 import org.apache.flink.runtime.jobgraph.JobVertexID;
 import org.apache.flink.runtime.metrics.MetricRegistryImpl;
@@ -69,7 +70,8 @@ public class TaskMetricGroupTest extends TestLogger {
         ExecutionAttemptID executionId = new ExecutionAttemptID();
 
         TaskManagerMetricGroup tmGroup =
-                new TaskManagerMetricGroup(registry, "theHostName", "test-tm-id");
+                TaskManagerMetricGroup.createTaskManagerMetricGroup(
+                        registry, "theHostName", new ResourceID("test-tm-id"));
         TaskManagerJobMetricGroup jmGroup =
                 new TaskManagerJobMetricGroup(registry, tmGroup, new JobID(), "myJobName");
         TaskMetricGroup taskGroup =
@@ -101,7 +103,8 @@ public class TaskMetricGroupTest extends TestLogger {
         ExecutionAttemptID executionId = new ExecutionAttemptID();
 
         TaskManagerMetricGroup tmGroup =
-                new TaskManagerMetricGroup(registry, "theHostName", "test-tm-id");
+                TaskManagerMetricGroup.createTaskManagerMetricGroup(
+                        registry, "theHostName", new ResourceID("test-tm-id"));
         TaskManagerJobMetricGroup jmGroup =
                 new TaskManagerJobMetricGroup(registry, tmGroup, jid, "myJobName");
         TaskMetricGroup taskGroup =
@@ -129,7 +132,8 @@ public class TaskMetricGroupTest extends TestLogger {
         ExecutionAttemptID executionId = new ExecutionAttemptID();
 
         TaskManagerMetricGroup tmGroup =
-                new TaskManagerMetricGroup(registry, "theHostName", "test-tm-id");
+                TaskManagerMetricGroup.createTaskManagerMetricGroup(
+                        registry, "theHostName", new ResourceID("test-tm-id"));
         TaskManagerJobMetricGroup jmGroup =
                 new TaskManagerJobMetricGroup(registry, tmGroup, new JobID(), "myJobName");
 
@@ -159,7 +163,9 @@ public class TaskMetricGroupTest extends TestLogger {
         JobID jid = new JobID();
         JobVertexID vid = new JobVertexID();
         ExecutionAttemptID eid = new ExecutionAttemptID();
-        TaskManagerMetricGroup tm = new TaskManagerMetricGroup(registry, "host", "id");
+        TaskManagerMetricGroup tm =
+                TaskManagerMetricGroup.createTaskManagerMetricGroup(
+                        registry, "host", new ResourceID("id"));
         TaskManagerJobMetricGroup job = new TaskManagerJobMetricGroup(registry, tm, jid, "jobname");
         TaskMetricGroup task = new TaskMetricGroup(registry, job, vid, eid, "taskName", 4, 5);
 
@@ -175,7 +181,8 @@ public class TaskMetricGroupTest extends TestLogger {
     public void testTaskMetricGroupCleanup() throws Exception {
         CountingMetricRegistry registry = new CountingMetricRegistry(new Configuration());
         TaskManagerMetricGroup taskManagerMetricGroup =
-                new TaskManagerMetricGroup(registry, "localhost", "0");
+                TaskManagerMetricGroup.createTaskManagerMetricGroup(
+                        registry, "localhost", new ResourceID("0"));
         TaskManagerJobMetricGroup taskManagerJobMetricGroup =
                 new TaskManagerJobMetricGroup(registry, taskManagerMetricGroup, new JobID(), "job");
         TaskMetricGroup taskMetricGroup =
@@ -205,7 +212,9 @@ public class TaskMetricGroupTest extends TestLogger {
         cfg.setString(MetricOptions.SCOPE_NAMING_OPERATOR, ScopeFormat.SCOPE_OPERATOR_NAME);
         MetricRegistryImpl registry =
                 new MetricRegistryImpl(MetricRegistryTestUtils.fromConfiguration(cfg));
-        TaskManagerMetricGroup tm = new TaskManagerMetricGroup(registry, "host", "id");
+        TaskManagerMetricGroup tm =
+                TaskManagerMetricGroup.createTaskManagerMetricGroup(
+                        registry, "host", new ResourceID("id"));
         TaskManagerJobMetricGroup job =
                 new TaskManagerJobMetricGroup(registry, tm, new JobID(), "jobname");
         TaskMetricGroup taskMetricGroup =

--- a/flink-streaming-java/src/test/java/org/apache/flink/streaming/runtime/tasks/StreamTaskTestHarness.java
+++ b/flink-streaming-java/src/test/java/org/apache/flink/streaming/runtime/tasks/StreamTaskTestHarness.java
@@ -39,8 +39,8 @@ import org.apache.flink.runtime.mailbox.MailboxExecutor;
 import org.apache.flink.runtime.memory.MemoryManager;
 import org.apache.flink.runtime.metrics.NoOpMetricRegistry;
 import org.apache.flink.runtime.metrics.groups.AbstractMetricGroup;
+import org.apache.flink.runtime.metrics.groups.TaskManagerMetricGroup;
 import org.apache.flink.runtime.metrics.groups.TaskMetricGroup;
-import org.apache.flink.runtime.metrics.util.MetricUtils;
 import org.apache.flink.runtime.operators.testutils.MockInputSplitProvider;
 import org.apache.flink.runtime.state.LocalRecoveryConfig;
 import org.apache.flink.runtime.state.LocalRecoveryDirectoryProviderImpl;
@@ -511,7 +511,7 @@ public class StreamTaskTestHarness<OUT> {
     }
 
     static TaskMetricGroup createTaskMetricGroup(Map<String, Metric> metrics) {
-        return MetricUtils.createTaskManagerMetricGroup(
+        return TaskManagerMetricGroup.createTaskManagerMetricGroup(
                         new TestMetricRegistry(metrics), "localhost", ResourceID.generate())
                 .addTaskForJob(
                         new JobID(),


### PR DESCRIPTION
Modify all existing usages of the TaskManagerMG constructor to use the (moved) MetricUtils factory method, for consistency and to make constructor changes easier.
