### PR TITLE
[FLINK-23408][task] Add metrics for buffer debloating

### DIFF
--- a/docs/content.zh/docs/ops/metrics.md
+++ b/docs/content.zh/docs/ops/metrics.md
@@ -1275,6 +1275,17 @@ Certain RocksDB native metrics are available but disabled by default, you can fi
       <td>Meter</td>
     </tr>
     <tr>
+      <td rowspan="2"><strong>Task (only if buffer debloating is enabled and in non-source tasks)</strong></td>
+      <td>estimatedTimeToConsumerBuffersMs</td>
+      <td>The estimated time (in milliseconds) by the buffer debloater to consume all of the buffered data in the network exchange preceding this task. This value is calculated by approximated amount of the in-flight data and calculated throughput.</td>
+      <td>Gauge</td>
+    </tr>
+    <tr>
+      <td>debloatedBufferSize</td>
+      <td>The desired buffer size (in bytes) calculated by the buffer debloater. Buffer debloater is trying to reduce buffer size when the ammount of in-flight data (after taking into account current throughput) exceeds the configured target value.</td>
+      <td>Gauge</td>
+    </tr>
+    <tr>
       <th rowspan="6"><strong>Task/Operator</strong></th>
       <td>numRecordsIn</td>
       <td>The total number of records this operator/task has received.</td>

--- a/docs/content/docs/ops/metrics.md
+++ b/docs/content/docs/ops/metrics.md
@@ -1274,6 +1274,17 @@ Certain RocksDB native metrics are available but disabled by default, you can fi
       <td>Meter</td>
     </tr>
     <tr>
+      <td rowspan="2"><strong>Task (only if buffer debloating is enabled and in non-source tasks)</strong></td>
+      <td>estimatedTimeToConsumerBuffersMs</td>
+      <td>The estimated time (in milliseconds) by the buffer debloater to consume all of the buffered data in the network exchange preceding this task. This value is calculated by approximated amount of the in-flight data and calculated throughput.</td>
+      <td>Gauge</td>
+    </tr>
+    <tr>
+      <td>debloatedBufferSize</td>
+      <td>The desired buffer size (in bytes) calculated by the buffer debloater. Buffer debloater is trying to reduce buffer size when the ammount of in-flight data (after taking into account current throughput) exceeds the configured target value.</td>
+      <td>Gauge</td>
+    </tr>
+    <tr>
       <th rowspan="6"><strong>Task/Operator</strong></th>
       <td>numRecordsIn</td>
       <td>The total number of records this operator/task has received.</td>

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/metrics/MetricNames.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/metrics/MetricNames.java
@@ -71,4 +71,8 @@ public class MetricNames {
     public static final String TASK_IDLE_TIME = "idleTimeMs" + SUFFIX_RATE;
     public static final String TASK_BUSY_TIME = "busyTimeMs" + SUFFIX_RATE;
     public static final String TASK_BACK_PRESSURED_TIME = "backPressuredTimeMs" + SUFFIX_RATE;
+
+    public static final String ESTIMATED_TIME_TO_CONSUME_BUFFERS =
+            "estimatedTimeToConsumerBuffersMs";
+    public static final String DEBLOATED_BUFFER_SIZE = "debloatedBufferSize";
 }

--- a/flink-streaming-java/src/main/java/org/apache/flink/streaming/runtime/tasks/StreamTask.java
+++ b/flink-streaming-java/src/main/java/org/apache/flink/streaming/runtime/tasks/StreamTask.java
@@ -712,13 +712,18 @@ public abstract class StreamTask<OUT, OP extends StreamOperator<OUT>> extends Ab
                 timestamp ->
                         mainMailboxExecutor.submit(
                                 () -> {
-                                    long throughput = throughputCalculator.calculateThroughput();
-                                    if (bufferDebloater != null) {
-                                        bufferDebloater.recalculateBufferSize(throughput);
-                                    }
+                                    debloat();
                                     scheduleBufferDebloater();
                                 },
                                 "Buffer size recalculation"));
+    }
+
+    @VisibleForTesting
+    void debloat() {
+        long throughput = throughputCalculator.calculateThroughput();
+        if (bufferDebloater != null) {
+            bufferDebloater.recalculateBufferSize(throughput);
+        }
     }
 
     private void runWithCleanUpOnFail(RunnableWithException run) throws Exception {

--- a/flink-streaming-java/src/main/java/org/apache/flink/streaming/runtime/tasks/bufferdebloat/BufferDebloater.java
+++ b/flink-streaming-java/src/main/java/org/apache/flink/streaming/runtime/tasks/bufferdebloat/BufferDebloater.java
@@ -42,6 +42,7 @@ public class BufferDebloater {
     private final int bufferDebloatThresholdPercentages;
 
     private int lastBufferSize;
+    private Duration lastEstimatedTimeToConsumeBuffers = Duration.ZERO;
 
     public BufferDebloater(Configuration taskConfig, IndexedInputGate[] inputGates) {
         this.inputGates = inputGates;
@@ -78,6 +79,9 @@ public class BufferDebloater {
                                 Math.min(
                                         desiredTotalBufferSizeInBytes / totalNumber,
                                         maxBufferSize));
+        lastEstimatedTimeToConsumeBuffers =
+                Duration.ofMillis(
+                        newSize * totalNumber * MILLIS_IN_SECOND / Math.max(1, currentThroughput));
 
         boolean skipUpdate =
                 Math.abs(1 - ((double) lastBufferSize) / newSize) * 100
@@ -92,5 +96,13 @@ public class BufferDebloater {
         for (IndexedInputGate inputGate : inputGates) {
             inputGate.announceBufferSize(newSize);
         }
+    }
+
+    public int getLastBufferSize() {
+        return lastBufferSize;
+    }
+
+    public Duration getLastEstimatedTimeToConsumeBuffers() {
+        return lastEstimatedTimeToConsumeBuffers;
     }
 }

--- a/flink-streaming-java/src/main/java/org/apache/flink/streaming/runtime/tasks/bufferdebloat/BufferDebloater.java
+++ b/flink-streaming-java/src/main/java/org/apache/flink/streaming/runtime/tasks/bufferdebloat/BufferDebloater.java
@@ -22,6 +22,8 @@ import org.apache.flink.configuration.Configuration;
 import org.apache.flink.configuration.TaskManagerOptions;
 import org.apache.flink.runtime.io.network.partition.consumer.IndexedInputGate;
 
+import java.time.Duration;
+
 import static org.apache.flink.configuration.TaskManagerOptions.BUFFER_DEBLOAT_TARGET;
 import static org.apache.flink.configuration.TaskManagerOptions.BUFFER_DEBLOAT_THRESHOLD_PERCENTAGES;
 import static org.apache.flink.util.Preconditions.checkArgument;
@@ -31,14 +33,9 @@ import static org.apache.flink.util.Preconditions.checkArgument;
  * configuration.
  */
 public class BufferDebloater {
-    private static final double MILLIS_IN_SECOND = 1000.0;
+    private static final long MILLIS_IN_SECOND = 1000;
 
-    /**
-     * How different should be the total buffer size compare to throughput (when it is 1.0 then
-     * bufferSize == throughput).
-     */
-    private final double targetBufferSizeFactor;
-
+    private final Duration targetTotalBufferSize;
     private final IndexedInputGate[] inputGates;
     private final long maxBufferSize;
     private final long minBufferSize;
@@ -48,8 +45,7 @@ public class BufferDebloater {
 
     public BufferDebloater(Configuration taskConfig, IndexedInputGate[] inputGates) {
         this.inputGates = inputGates;
-        this.targetBufferSizeFactor =
-                taskConfig.get(BUFFER_DEBLOAT_TARGET).toMillis() / MILLIS_IN_SECOND;
+        this.targetTotalBufferSize = taskConfig.get(BUFFER_DEBLOAT_TARGET);
         this.maxBufferSize = taskConfig.get(TaskManagerOptions.MEMORY_SEGMENT_SIZE).getBytes();
         this.minBufferSize = taskConfig.get(TaskManagerOptions.MIN_MEMORY_SEGMENT_SIZE).getBytes();
 
@@ -64,11 +60,12 @@ public class BufferDebloater {
         checkArgument(maxBufferSize > 0);
         checkArgument(minBufferSize > 0);
         checkArgument(maxBufferSize >= minBufferSize);
-        checkArgument(targetBufferSizeFactor > 0.0);
+        checkArgument(targetTotalBufferSize.toMillis() > 0.0);
     }
 
     public void recalculateBufferSize(long currentThroughput) {
-        long desiredTotalBufferSizeInBytes = (long) (currentThroughput * targetBufferSizeFactor);
+        long desiredTotalBufferSizeInBytes =
+                (currentThroughput * targetTotalBufferSize.toMillis()) / MILLIS_IN_SECOND;
 
         int totalNumber = 0;
         for (IndexedInputGate inputGate : inputGates) {

--- a/flink-streaming-java/src/test/java/org/apache/flink/streaming/runtime/tasks/StreamTaskTest.java
+++ b/flink-streaming-java/src/test/java/org/apache/flink/streaming/runtime/tasks/StreamTaskTest.java
@@ -29,6 +29,8 @@ import org.apache.flink.configuration.Configuration;
 import org.apache.flink.configuration.ReadableConfig;
 import org.apache.flink.core.fs.FSDataInputStream;
 import org.apache.flink.core.testutils.OneShotLatch;
+import org.apache.flink.metrics.Gauge;
+import org.apache.flink.metrics.Metric;
 import org.apache.flink.runtime.checkpoint.CheckpointException;
 import org.apache.flink.runtime.checkpoint.CheckpointMetaData;
 import org.apache.flink.runtime.checkpoint.CheckpointMetrics;
@@ -53,8 +55,10 @@ import org.apache.flink.runtime.io.network.partition.consumer.InputGate;
 import org.apache.flink.runtime.io.network.partition.consumer.TestInputChannel;
 import org.apache.flink.runtime.jobgraph.OperatorID;
 import org.apache.flink.runtime.jobgraph.tasks.AbstractInvokable;
+import org.apache.flink.runtime.metrics.MetricNames;
 import org.apache.flink.runtime.metrics.TimerGauge;
 import org.apache.flink.runtime.metrics.groups.TaskIOMetricGroup;
+import org.apache.flink.runtime.metrics.groups.TaskMetricGroup;
 import org.apache.flink.runtime.operators.testutils.DummyEnvironment;
 import org.apache.flink.runtime.operators.testutils.ExpectedTestException;
 import org.apache.flink.runtime.operators.testutils.MockEnvironment;
@@ -156,6 +160,7 @@ import java.util.List;
 import java.util.Map;
 import java.util.Optional;
 import java.util.concurrent.CompletableFuture;
+import java.util.concurrent.ConcurrentHashMap;
 import java.util.concurrent.CountDownLatch;
 import java.util.concurrent.ExecutionException;
 import java.util.concurrent.ExecutorService;
@@ -1885,10 +1890,14 @@ public class StreamTaskTest extends TestLogger {
                     config.getConfiguration().set(BUFFER_DEBLOAT_TARGET, Duration.ofSeconds(1));
                     config.getConfiguration().set(BUFFER_DEBLOAT_ENABLED, true);
                 };
+        Map<String, Metric> metrics = new ConcurrentHashMap<>();
+        final TaskMetricGroup taskMetricGroup =
+                StreamTaskTestHarness.createTaskMetricGroup(metrics);
 
         try (StreamTaskMailboxTestHarness<String> harness =
                 new StreamTaskMailboxTestHarnessBuilder<>(OneInputStreamTask::new, STRING_TYPE_INFO)
                         .modifyStreamConfig(configuration)
+                        .setTaskMetricGroup(taskMetricGroup)
                         .addInput(STRING_TYPE_INFO, inputChannels)
                         .setupOutputForSingletonOperatorChain(
                                 new TestBoundedOneInputStreamOperator())
@@ -1903,13 +1912,21 @@ public class StreamTaskTest extends TestLogger {
             harness.processAll();
             harness.streamTask.debloat();
 
+            int expectedBufferSize = expectedThroughput / inputChannels;
             for (InputGate inputGate : harness.streamTask.getEnvironment().getAllInputGates()) {
                 for (int i = 0; i < inputGate.getNumberOfInputChannels(); i++) {
                     assertThat(
                             ((TestInputChannel) inputGate.getChannel(i)).getCurrentBufferSize(),
-                            is(expectedThroughput / inputChannels));
+                            is(expectedBufferSize));
                 }
             }
+            assertThat(
+                    ((Gauge<Integer>) metrics.get(MetricNames.DEBLOATED_BUFFER_SIZE)).getValue(),
+                    is(expectedBufferSize));
+            assertThat(
+                    ((Gauge<Long>) metrics.get(MetricNames.ESTIMATED_TIME_TO_CONSUME_BUFFERS))
+                            .getValue(),
+                    is(999L));
         }
     }
 


### PR DESCRIPTION
This PR depends on https://github.com/apache/flink/pull/16710

Add metrics for buffer debloating

## Brief change log

Please check individual commits for the change log

## Verifying this change

Newly added metrics are tested in `StreamTaskTest#testBufferSizeRecalculationStartSuccessfully`

## Does this pull request potentially affect one of the following parts:

  - Dependencies (does it add or upgrade a dependency): (yes / **no**)
  - The public API, i.e., is any changed class annotated with `@Public(Evolving)`: (yes / **no**)
  - The serializers: (yes / **no** / don't know)
  - The runtime per-record code paths (performance sensitive): (yes / **no** / don't know)
  - Anything that affects deployment or recovery: JobManager (and its components), Checkpointing, Kubernetes/Yarn, ZooKeeper: (yes / **no** / don't know)
  - The S3 file system connector: (yes / **no** / don't know)

## Documentation

  - Does this pull request introduce a new feature? (**yes** / no)
  - If yes, how is the feature documented? (not applicable / **docs** / JavaDocs / not documented)
