### PR TITLE
[FLINK-23475][runtime][checkpoint] Supports repartition partly finished broacast states

### DIFF
--- a/flink-runtime/src/main/java/org/apache/flink/runtime/checkpoint/RoundRobinOperatorStateRepartitioner.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/checkpoint/RoundRobinOperatorStateRepartitioner.java
@@ -82,6 +82,10 @@ public class RoundRobinOperatorStateRepartitioner
             mergeMapList = initMergeMapList(previousParallelSubtaskStates);
 
             repartitionUnionState(unionStates, mergeMapList);
+
+            // TODO: Currently if some tasks is finished, we would rescale the
+            // remaining state. A better solution would be not touch the non-empty
+            // subtask state and only fix the empty ones.
             repartitionBroadcastState(partlyFinishedBroadcastStates, mergeMapList);
         } else {
 


### PR DESCRIPTION
## What is the purpose of the change

This PR supports partition the partly finished broadcast state on restoring.

**The current repartition logic**

For the operator states, the state of each subtask composes of a list of `OperatorStateHandle`. An `OperatorStateHandle` represents an underlying file(`StreamStateHandle getDelegateStateHandle()`), inside the file there might be multiple states. Each state has a name and list of offset for its contained elements (`Map<String, StateMetaInfo> getStateNameToPartitionOffsets()`). 

Currently there are two cases:

If the parallelism is not change, then we only need to repartition the union list states. If there are indeed union list states, the current implementation will first acquire all the union list states and its underlying `StateMetaInfo` from all the subtasks into `Map<String, List<Tuple2<StreamStateHandle, OperatorStateHandle.StateMetaInfo>>>`, then for each union list state, it will add ensures each subtask have all the `StateMetaInfo`. Since these `StateMetaInfo` are located in different files (`StreamStateHandle`) and each file requires a new `OperatorStateHandle`, it needs to add new `OperatorStateHandle` to the list of each subtask.

If the parallelism is changed, the implementation would partition each type of state separately. For each type of states, similarly they will be first collected into `Map<String, List<Tuple2<StreamStateHandle, OperatorStateHandle.StateMetaInfo>>>` and partitioned according to the requirement of each type. 

Therefore, if we have a partly finished broadcast state, there should be in fact no problem if the parallelism is changed: the `StateMetaInfo` in different files would be collected first, thus the empty state is filtered during this process. When repartition each new subtask would choose the state only from `List<Tuple2<StreamStateHandle, OperatorStateHandle.StateMetaInfo>>`, which must not be empty. 

But there is still an issue if the parallelism is not change: there would be no partition for the broadcast state and each subtask would keep the state from the last run. If some tasks finished, the new tasks would have the empty states. 

Thus we only need to deal with the case that the parallelism is not change. 

**The modification**

Similar to the union list state, we first collect all the partly finished broadcast state into `Map<String, List<Tuple2<StreamStateHandle, OperatorStateHandle.StateMetaInfo>>>`, which contains only the empty states. Then we directly reuse the `repartitionBroadcastState` method from when the parallelism is changed. 

## Brief change log

- b0aedbfae3d9ce6823d24745d6b8b666b60a26a4 implements as the above description.

## Verifying this change

This change is verified via the added UT.

## Does this pull request potentially affect one of the following parts:

  - Dependencies (does it add or upgrade a dependency): **no**
  - The public API, i.e., is any changed class annotated with `@Public(Evolving)`: **no**
  - The serializers: **no**
  - The runtime per-record code paths (performance sensitive): **no**
  - Anything that affects deployment or recovery: JobManager (and its components), Checkpointing, Kubernetes/Yarn, ZooKeeper: **yes**
  - The S3 file system connector: **no**

## Documentation

  - Does this pull request introduce a new feature? **no**
  - If yes, how is the feature documented? **not applicable**
