### PR TITLE
[FLINK-23629][FLINK-23630][tests] Some fixes to EventTimeWindowCheckpointingITCase

### DIFF
--- a/flink-tests/src/test/java/org/apache/flink/test/checkpointing/EventTimeWindowCheckpointingITCase.java
+++ b/flink-tests/src/test/java/org/apache/flink/test/checkpointing/EventTimeWindowCheckpointingITCase.java
@@ -174,8 +174,8 @@ public class EventTimeWindowCheckpointingITCase extends TestLogger {
                 break;
             case FILE:
                 {
-                    String backups = tempFolder.newFolder().getAbsolutePath();
-                    this.stateBackend = new FsStateBackend("file://" + backups);
+                    final File backups = tempFolder.newFolder().getAbsoluteFile();
+                    this.stateBackend = new FsStateBackend(Path.fromLocalFile(backups));
                     break;
                 }
             case ROCKSDB_FULL:
@@ -209,14 +209,13 @@ public class EventTimeWindowCheckpointingITCase extends TestLogger {
                 TaskManagerOptions.MANAGED_MEMORY_SIZE,
                 MemorySize.ofMebiBytes(PARALLELISM / NUM_OF_TASK_MANAGERS * 64));
 
-        String rocksDb = tempFolder.newFolder().getAbsolutePath();
-        String backups = tempFolder.newFolder().getAbsolutePath();
+        final String rocksDb = tempFolder.newFolder().getAbsolutePath();
+        final File backups = tempFolder.newFolder().getAbsoluteFile();
         // we use the fs backend with small threshold here to test the behaviour with file
         // references, not self contained byte handles
         RocksDBStateBackend rdb =
                 new RocksDBStateBackend(
-                        new FsStateBackend(
-                                new Path("file://" + backups).toUri(), fileSizeThreshold),
+                        new FsStateBackend(Path.fromLocalFile(backups).toUri(), fileSizeThreshold),
                         incrementalCheckpoints);
         rdb.setDbStoragePath(rocksDb);
         this.stateBackend = rdb;

--- a/flink-tests/src/test/java/org/apache/flink/test/checkpointing/EventTimeWindowCheckpointingITCase.java
+++ b/flink-tests/src/test/java/org/apache/flink/test/checkpointing/EventTimeWindowCheckpointingITCase.java
@@ -110,11 +110,9 @@ public class EventTimeWindowCheckpointingITCase extends TestLogger {
     enum StateBackendEnum {
         MEM,
         FILE,
-        ROCKSDB_FULLY_ASYNC,
+        ROCKSDB_FULL,
         ROCKSDB_INCREMENTAL,
         ROCKSDB_INCREMENTAL_ZK,
-        MEM_ASYNC,
-        FILE_ASYNC
     }
 
     @Parameterized.Parameters(name = "statebackend type ={0}, buffersPerChannel = {1}")
@@ -172,24 +170,15 @@ public class EventTimeWindowCheckpointingITCase extends TestLogger {
 
         switch (stateBackendEnum) {
             case MEM:
-                this.stateBackend = new MemoryStateBackend(MAX_MEM_STATE_SIZE, false);
+                this.stateBackend = new MemoryStateBackend(MAX_MEM_STATE_SIZE);
                 break;
             case FILE:
                 {
                     String backups = tempFolder.newFolder().getAbsolutePath();
-                    this.stateBackend = new FsStateBackend("file://" + backups, false);
+                    this.stateBackend = new FsStateBackend("file://" + backups);
                     break;
                 }
-            case MEM_ASYNC:
-                this.stateBackend = new MemoryStateBackend(MAX_MEM_STATE_SIZE, true);
-                break;
-            case FILE_ASYNC:
-                {
-                    String backups = tempFolder.newFolder().getAbsolutePath();
-                    this.stateBackend = new FsStateBackend("file://" + backups, true);
-                    break;
-                }
-            case ROCKSDB_FULLY_ASYNC:
+            case ROCKSDB_FULL:
                 {
                     setupRocksDB(config, -1, false);
                     break;

--- a/flink-tests/src/test/java/org/apache/flink/test/checkpointing/LocalRecoveryITCase.java
+++ b/flink-tests/src/test/java/org/apache/flink/test/checkpointing/LocalRecoveryITCase.java
@@ -34,8 +34,8 @@ import java.util.Arrays;
 import java.util.Collection;
 
 import static org.apache.flink.test.checkpointing.EventTimeWindowCheckpointingITCase.StateBackendEnum;
-import static org.apache.flink.test.checkpointing.EventTimeWindowCheckpointingITCase.StateBackendEnum.FILE_ASYNC;
-import static org.apache.flink.test.checkpointing.EventTimeWindowCheckpointingITCase.StateBackendEnum.ROCKSDB_FULLY_ASYNC;
+import static org.apache.flink.test.checkpointing.EventTimeWindowCheckpointingITCase.StateBackendEnum.FILE;
+import static org.apache.flink.test.checkpointing.EventTimeWindowCheckpointingITCase.StateBackendEnum.ROCKSDB_FULL;
 import static org.apache.flink.test.checkpointing.EventTimeWindowCheckpointingITCase.StateBackendEnum.ROCKSDB_INCREMENTAL_ZK;
 
 /**
@@ -54,7 +54,7 @@ public class LocalRecoveryITCase extends TestLogger {
 
     @Parameterized.Parameters(name = "statebackend type ={0}")
     public static Collection<StateBackendEnum> parameter() {
-        return Arrays.asList(ROCKSDB_FULLY_ASYNC, ROCKSDB_INCREMENTAL_ZK, FILE_ASYNC);
+        return Arrays.asList(ROCKSDB_FULL, ROCKSDB_INCREMENTAL_ZK, FILE);
     }
 
     @Test


### PR DESCRIPTION
## What is the purpose of the change

Fixes `EventTimeWindowCheckpointingITCase` and `LocalRecoveryITCase` to run on Windows and speeds up  `EventTimeWindowCheckpointingITCase` by removing unnecessary cases.

## Brief Changelog

  - [FLINK-23629][tests] Remove redundant file-async and mem-async test runs from `EventTimeWindowCheckpointingITCase`

    Because all snapshots are async, the MEM and MEM_ASYNC, as well as FILE and FILE_ASYNC are now the same. This removes unnecessary cases to save testing time.

  - [FLINK-23630][tests] Make `EventTimeWindowCheckpointingITCase`and `LocalRecoveryITCase` run on Windows.

This fixes the creation of Paths to be properly platform independent.

## Verifying this change

This PR fixes tests, no additional tests are added.

## Does this pull request potentially affect one of the following parts:

  - Dependencies (does it add or upgrade a dependency): **no**
  - The public API, i.e., is any changed class annotated with `@Public(Evolving)`: **no**
  - The serializers: **no**
  - The runtime per-record code paths (performance sensitive): **no**
  - Anything that affects deployment or recovery: JobManager (and its components), Checkpointing, Kubernetes/Yarn, ZooKeeper: **no**
  - The S3 file system connector: **no**

## Documentation

  - Does this pull request introduce a new feature? **no**
  - If yes, how is the feature documented? **not applicable**
