### PR TITLE
[FLINK-23507] Use IP address of a kubernetes node when constructing node port connection string for the REST gateway.

### DIFF
--- a/docs/content.zh/docs/deployment/resource-providers/native_kubernetes.md
+++ b/docs/content.zh/docs/deployment/resource-providers/native_kubernetes.md
@@ -191,8 +191,6 @@ $ kubectl port-forward service/<ServiceName> 8081
 
 - **NodePort**: Exposes the service on each Node’s IP at a static port (the `NodePort`).
   `<NodeIP>:<NodePort>` can be used to contact the JobManager service.
-  `NodeIP` can also be replaced with the Kubernetes ApiServer address. 
-  You can find its address in your kube config file.
 
 - **LoadBalancer**: Exposes the service externally using a cloud provider’s load balancer.
   Since the cloud provider and Kubernetes needs some time to prepare the load balancer, you may get a `NodePort` JobManager Web Interface in the client log.

--- a/docs/content/docs/deployment/resource-providers/native_kubernetes.md
+++ b/docs/content/docs/deployment/resource-providers/native_kubernetes.md
@@ -191,8 +191,6 @@ $ kubectl port-forward service/<ServiceName> 8081
 
 - **NodePort**: Exposes the service on each Node’s IP at a static port (the `NodePort`).
   `<NodeIP>:<NodePort>` can be used to contact the JobManager service.
-  `NodeIP` can also be replaced with the Kubernetes ApiServer address. 
-  You can find its address in your kube config file.
 
 - **LoadBalancer**: Exposes the service externally using a cloud provider’s load balancer.
   Since the cloud provider and Kubernetes needs some time to prepare the load balancer, you may get a `NodePort` JobManager Web Interface in the client log.

--- a/docs/layouts/shortcodes/generated/kubernetes_config_configuration.html
+++ b/docs/layouts/shortcodes/generated/kubernetes_config_configuration.html
@@ -165,6 +165,12 @@
             <td>The user-specified annotations that are set to the rest Service. The value should be in the form of a1:v1,a2:v2</td>
         </tr>
         <tr>
+            <td><h5>kubernetes.rest-service.exposed.node-port-address-type</h5></td>
+            <td style="word-wrap: break-word;">InternalIP</td>
+            <td><p>Enum</p></td>
+            <td>The user-specified <a href="https://kubernetes.io/docs/concepts/architecture/nodes/#addresses">address type</a> that is used for filtering node IPs when constructing a <a href="https://kubernetes.io/docs/concepts/services-networking/service/#nodeport">node port</a> connection string. This option is only considered when 'kubernetes.rest-service.exposed.type' is set to 'NodePort'.<br /><br />Possible values:<ul><li>"InternalIP"</li><li>"ExternalIP"</li></ul></td>
+        </tr>
+        <tr>
             <td><h5>kubernetes.rest-service.exposed.type</h5></td>
             <td style="word-wrap: break-word;">LoadBalancer</td>
             <td><p>Enum</p></td>

--- a/flink-kubernetes/src/main/java/org/apache/flink/kubernetes/KubernetesClusterDescriptor.java
+++ b/flink-kubernetes/src/main/java/org/apache/flink/kubernetes/KubernetesClusterDescriptor.java
@@ -108,9 +108,8 @@ public class KubernetesClusterDescriptor implements ClusterDescriptor<String> {
 
             try {
                 // Flink client will always use Kubernetes service to contact with jobmanager. So we
-                // have a pre-configured web
-                // monitor address. Using StandaloneClientHAServices to create RestClusterClient is
-                // reasonable.
+                // have a pre-configured web monitor address. Using StandaloneClientHAServices to
+                // create RestClusterClient is reasonable.
                 return new RestClusterClient<>(
                         configuration,
                         clusterId,

--- a/flink-kubernetes/src/main/java/org/apache/flink/kubernetes/configuration/KubernetesConfigOptions.java
+++ b/flink-kubernetes/src/main/java/org/apache/flink/kubernetes/configuration/KubernetesConfigOptions.java
@@ -34,6 +34,7 @@ import java.util.Map;
 import static org.apache.flink.configuration.ConfigOptions.key;
 import static org.apache.flink.configuration.description.LinkElement.link;
 import static org.apache.flink.configuration.description.TextElement.code;
+import static org.apache.flink.configuration.description.TextElement.text;
 
 /** This class holds configuration constants used by Flink's kubernetes runners. */
 @PublicEvolving
@@ -58,6 +59,25 @@ public class KubernetesConfigOptions {
                     .withDescription(
                             "The exposed type of the rest service. "
                                     + "The exposed rest service could be used to access the Flink’s Web UI and REST endpoint.");
+
+    public static final ConfigOption<NodePortAddressType>
+            REST_SERVICE_EXPOSED_NODE_PORT_ADDRESS_TYPE =
+                    key("kubernetes.rest-service.exposed.node-port-address-type")
+                            .enumType(NodePortAddressType.class)
+                            .defaultValue(NodePortAddressType.InternalIP)
+                            .withDescription(
+                                    Description.builder()
+                                            .text(
+                                                    "The user-specified %s that is used for filtering node IPs when constructing a %s connection string. This option is only considered when '%s' is set to '%s'.",
+                                                    link(
+                                                            "https://kubernetes.io/docs/concepts/architecture/nodes/#addresses",
+                                                            "address type"),
+                                                    link(
+                                                            "https://kubernetes.io/docs/concepts/services-networking/service/#nodeport",
+                                                            "node port"),
+                                                    text(REST_SERVICE_EXPOSED_TYPE.key()),
+                                                    text(ServiceExposedType.NodePort.name()))
+                                            .build());
 
     public static final ConfigOption<String> JOB_MANAGER_SERVICE_ACCOUNT =
             key("kubernetes.jobmanager.service-account")
@@ -453,6 +473,12 @@ public class KubernetesConfigOptions {
         ClusterIP,
         NodePort,
         LoadBalancer
+    }
+
+    /** The flink rest service exposed type. */
+    public enum NodePortAddressType {
+        InternalIP,
+        ExternalIP,
     }
 
     /** The container image pull policy. */

--- a/flink-kubernetes/src/test/java/org/apache/flink/kubernetes/KubernetesClientTestBase.java
+++ b/flink-kubernetes/src/test/java/org/apache/flink/kubernetes/KubernetesClientTestBase.java
@@ -21,10 +21,16 @@ package org.apache.flink.kubernetes;
 import org.apache.flink.kubernetes.configuration.KubernetesConfigOptions;
 import org.apache.flink.kubernetes.kubeclient.decorators.ExternalServiceDecorator;
 import org.apache.flink.kubernetes.utils.Constants;
+import org.apache.flink.util.Preconditions;
 
 import io.fabric8.kubernetes.api.model.ConfigMap;
 import io.fabric8.kubernetes.api.model.LoadBalancerIngress;
 import io.fabric8.kubernetes.api.model.LoadBalancerStatus;
+import io.fabric8.kubernetes.api.model.Node;
+import io.fabric8.kubernetes.api.model.NodeAddressBuilder;
+import io.fabric8.kubernetes.api.model.NodeBuilder;
+import io.fabric8.kubernetes.api.model.NodeListBuilder;
+import io.fabric8.kubernetes.api.model.NodeStatusBuilder;
 import io.fabric8.kubernetes.api.model.Service;
 import io.fabric8.kubernetes.api.model.ServiceBuilder;
 import io.fabric8.kubernetes.api.model.ServicePort;
@@ -41,6 +47,7 @@ import javax.annotation.Nullable;
 
 import java.util.ArrayList;
 import java.util.Collections;
+import java.util.List;
 import java.util.function.Function;
 
 /**
@@ -51,6 +58,32 @@ public class KubernetesClientTestBase extends KubernetesTestBase {
 
     protected static final int REST_PORT = 9021;
     protected static final int NODE_PORT = 31234;
+
+    protected void mockExpectedNodesFromServerSide(List<String> addresses) {
+        final List<Node> nodes = new ArrayList<>();
+        Collections.shuffle(addresses);
+        for (String address : addresses) {
+            final String[] parts = address.split(":");
+            Preconditions.checkState(
+                    parts.length == 2, "Address should be in format \"<type>:<ip>\".");
+            nodes.add(
+                    new NodeBuilder()
+                            .withStatus(
+                                    new NodeStatusBuilder()
+                                            .withAddresses(
+                                                    new NodeAddressBuilder()
+                                                            .withType(parts[0])
+                                                            .withAddress(parts[1])
+                                                            .build())
+                                            .build())
+                            .build());
+        }
+        server.expect()
+                .get()
+                .withPath("/api/v1/nodes")
+                .andReturn(200, new NodeListBuilder().withItems(nodes).build())
+                .always();
+    }
 
     protected void mockExpectedServiceFromServerSide(Service expectedService) {
         final String serviceName = expectedService.getMetadata().getName();


### PR DESCRIPTION
## What is the purpose of the change

Currently, we've been using kubernetes api server url, when constructing the connection string for REST gateway. While this might work in some cases (eg. api is not behind loadbalancer), this is wrong. The correct approach is to construct address in form of `<nodeIp>:<nodePort>`, where nodeIp can be ip of any kubernetes node (that is running kube-proxy).

See [kubernetes docs](https://kubernetes.io/docs/concepts/services-networking/service/#nodeport) for more details.

Unfortunately kubernetes nodes can have multiple IPs, with different type (external, internal), assigned to them and it's impossible to make this solution bullet proof without making assumptions about underlying infrastructure. Therefore I've introduced a new config option `kubernetes.rest-service.exposed.node-port-address-type`, that let's you choose which IP type you want to search for.

## Brief change log

- `Fabric8FlinkKubeClient#getLoadBalancerRestEndpoint` now searches for any node ip with matching address type, that is used for connection string construction
- nit: Fixed broken formatting due to deeply nested indentation


## Verifying this change

Added new unit tests for the change.

## Does this pull request potentially affect one of the following parts:

  - Anything that affects deployment or recovery: JobManager (and its components), Checkpointing, Kubernetes/Yarn, ZooKeeper: (yes)

## Documentation

  - Does this pull request introduce a new feature? (yes)
  - If yes, how is the feature documented? (docs)
