### PR TITLE
[FLINK-23545] Use new schema in SqlCreateTableConverter

### DIFF
--- a/flink-table/flink-table-planner/src/main/java/org/apache/flink/table/planner/operations/SqlCreateTableConverter.java
+++ b/flink-table/flink-table-planner/src/main/java/org/apache/flink/table/planner/operations/SqlCreateTableConverter.java
@@ -126,7 +126,7 @@ class SqlCreateTableConverter {
                         sourcePartitionKeys,
                         sqlCreateTable.getPartitionKeyList(),
                         mergingStrategies);
-        //        verifyPartitioningColumnsExist(mergedSchema, partitionKeys);
+        verifyPartitioningColumnsExist(mergedSchema, partitionKeys);
 
         //        Schema.newBuilder().fromSchema(sourceTableSchema, derivedSchema);
         String tableComment =
@@ -163,20 +163,21 @@ class SqlCreateTableConverter {
         return (CatalogTable) lookupResult.getTable();
     }
 
-    //        private void verifyPartitioningColumnsExist(
-    //                Schema mergedSchema, List<String> partitionKeys) {
-    //            for (String partitionKey : partitionKeys) {
-    //                if (!mergedSchema.getTableColumn(partitionKey).isPresent()) {
-    //                    throw new ValidationException(
-    //                            String.format(
-    //                                    "Partition column '%s' not defined in the table schema.
-    //     Available columns: [%s]",
-    //                                    partitionKey,
-    //                                    Arrays.stream(mergedSchema.getFieldNames())
-    //                                            .collect(Collectors.joining("', '", "'", "'"))));
-    //                }
-    //            }
-    //        }
+    private void verifyPartitioningColumnsExist(Schema mergedSchema, List<String> partitionKeys) {
+        List<String> fieldNames =
+                mergedSchema.getColumns().stream()
+                        .map(c -> c.getName())
+                        .collect(Collectors.toList());
+        for (String partitionKey : partitionKeys) {
+            if (!fieldNames.contains(partitionKey)) {
+                throw new ValidationException(
+                        String.format(
+                                "Partition column '%s' not defined in the table schema. Available columns: [%s]",
+                                partitionKey,
+                                fieldNames.stream().collect(Collectors.joining("', '", "'", "'"))));
+            }
+        }
+    }
 
     private List<String> mergePartitions(
             List<String> sourcePartitionKeys,

--- a/flink-table/flink-table-planner/src/main/java/org/apache/flink/table/planner/plan/FlinkCalciteCatalogReader.java
+++ b/flink-table/flink-table-planner/src/main/java/org/apache/flink/table/planner/plan/FlinkCalciteCatalogReader.java
@@ -199,9 +199,9 @@ public class FlinkCalciteCatalogReader extends CalciteCatalogReader {
             RelDataType rowType,
             ResolvedCatalogTable catalogTable,
             CatalogSchemaTable schemaTable) {
-        if (isLegacySourceOptions(catalogTable.getOrigin(), schemaTable)) {
+        if (isLegacySourceOptions(catalogTable, schemaTable)) {
             return new LegacyCatalogSourceTable<>(
-                    relOptSchema, names, rowType, schemaTable, catalogTable.getOrigin());
+                    relOptSchema, names, rowType, schemaTable, catalogTable);
         } else {
             return new CatalogSourceTable(relOptSchema, names, rowType, schemaTable, catalogTable);
         }

--- a/flink-table/flink-table-planner/src/main/scala/org/apache/flink/table/planner/delegation/PlannerBase.scala
+++ b/flink-table/flink-table-planner/src/main/scala/org/apache/flink/table/planner/delegation/PlannerBase.scala
@@ -372,11 +372,11 @@ abstract class PlannerBase(
         }
         val catalog = catalogManager.getCatalog(objectIdentifier.getCatalogName)
         val isTemporary = lookupResult.isTemporary
-        if (isLegacyConnectorOptions(objectIdentifier, resolvedTable.getOrigin, isTemporary)) {
+        if (isLegacyConnectorOptions(objectIdentifier, resolvedTable, isTemporary)) {
           val tableSink = TableFactoryUtil.findAndCreateTableSink(
             catalog.orElse(null),
             objectIdentifier,
-            tableToFind.getOrigin,
+            tableToFind,
             getTableConfig.getConfiguration,
             isStreamingMode,
             isTemporary)

--- a/flink-table/flink-table-planner/src/test/scala/org/apache/flink/table/planner/plan/stream/sql/LegacyTableSourceTest.scala
+++ b/flink-table/flink-table-planner/src/test/scala/org/apache/flink/table/planner/plan/stream/sql/LegacyTableSourceTest.scala
@@ -155,10 +155,9 @@ class LegacyTableSourceTest extends TableTestBase {
         |  id INT,
         |  val BIGINT,
         |  name STRING,
-        |  `proctime` TIMESTAMP_LTZ(3)
+        |  `proctime` AS PROCTIME()
         |) WITH (
-        |  'connector.type' = 'TestTableSourceWithTime',
-        |  'schema.3.proctime' = 'true'
+        |  'connector.type' = 'TestTableSourceWithTime'
         |)
         |""".stripMargin)
 

--- a/flink-table/flink-table-planner/src/test/scala/org/apache/flink/table/planner/plan/stream/sql/UnionTest.scala
+++ b/flink-table/flink-table-planner/src/test/scala/org/apache/flink/table/planner/plan/stream/sql/UnionTest.scala
@@ -43,7 +43,6 @@ class UnionTest extends TableTestBase {
          |  name string,
          |  timestamp_col timestamp(3),
          |  val bigint,
-         |  name varchar(32),
          |  timestamp_ltz_col as TO_TIMESTAMP_LTZ(ts, 3),
          |  watermark for timestamp_col as timestamp_col
          |) WITH (


### PR DESCRIPTION
<!--
*Thank you very much for contributing to Apache Flink - we are happy that you want to help us improve Flink. To help the community review your contribution in the best possible way, please go through the checklist below, which will get the contribution into a shape in which it can be best reviewed.*

*Please understand that we do not do this to make contributions to Flink a hassle. In order to uphold a high standard of quality for code contributions, while at the same time managing a large number of contributions, we need contributors to prepare the contributions well, and give reviewers enough contextual information for the review. Please also understand that contributions that do not follow this guide will take longer to review and thus typically be picked up with lower priority by the community.*

## Contribution Checklist

  - Make sure that the pull request corresponds to a [JIRA issue](https://issues.apache.org/jira/projects/FLINK/issues). Exceptions are made for typos in JavaDoc or documentation files, which need no JIRA issue.
  
  - Name the pull request in the form "[FLINK-XXXX] [component] Title of the pull request", where *FLINK-XXXX* should be replaced by the actual issue number. Skip *component* if you are unsure about which is the best component.
  Typo fixes that have no associated JIRA issue should be named following this pattern: `[hotfix] [docs] Fix typo in event time introduction` or `[hotfix] [javadocs] Expand JavaDoc for PuncuatedWatermarkGenerator`.

  - Fill out the template below to describe the changes contributed by the pull request. That will give reviewers the context they need to do the review.
  
  - Make sure that the change passes the automated tests, i.e., `mvn clean verify` passes. You can set up Azure Pipelines CI to do that following [this guide](https://cwiki.apache.org/confluence/display/FLINK/Azure+Pipelines#AzurePipelines-Tutorial:SettingupAzurePipelinesforaforkoftheFlinkrepository).

  - Each pull request should address only one issue, not mix up code from multiple issues.
  
  - Each commit in the pull request has a meaningful commit message (including the JIRA id)

  - Once all items of the checklist are addressed, remove the above text and this checklist, leaving only the filled out template below.


**(The sections below can be removed for hotfixes of typos)**
-->

## What is the purpose of the change

*(For example: This pull request makes task deployment go through the blob server, rather than through RPC. That way we avoid re-transferring them on each deployment (during recovery).)*


## Brief change log

*(for example:)*
  - *The TaskInfo is stored in the blob store on job creation time as a persistent artifact*
  - *Deployments RPC transmits only the blob storage reference*
  - *TaskManagers retrieve the TaskInfo from the blob cache*


## Verifying this change

*(Please pick either of the following options)*

This change is a trivial rework / code cleanup without any test coverage.

*(or)*

This change is already covered by existing tests, such as *(please describe tests)*.

*(or)*

This change added tests and can be verified as follows:

*(example:)*
  - *Added integration tests for end-to-end deployment with large payloads (100MB)*
  - *Extended integration test for recovery after master (JobManager) failure*
  - *Added test that validates that TaskInfo is transferred only once across recoveries*
  - *Manually verified the change by running a 4 node cluser with 2 JobManagers and 4 TaskManagers, a stateful streaming program, and killing one JobManager and two TaskManagers during the execution, verifying that recovery happens correctly.*

## Does this pull request potentially affect one of the following parts:

  - Dependencies (does it add or upgrade a dependency): (yes / no)
  - The public API, i.e., is any changed class annotated with `@Public(Evolving)`: (yes / no)
  - The serializers: (yes / no / don't know)
  - The runtime per-record code paths (performance sensitive): (yes / no / don't know)
  - Anything that affects deployment or recovery: JobManager (and its components), Checkpointing, Kubernetes/Yarn, ZooKeeper: (yes / no / don't know)
  - The S3 file system connector: (yes / no / don't know)

## Documentation

  - Does this pull request introduce a new feature? (yes / no)
  - If yes, how is the feature documented? (not applicable / docs / JavaDocs / not documented)
