### PR TITLE
FLINK-23454 The upstream sends the buffer of the right size for unicast case

### DIFF
--- a/flink-libraries/flink-state-processing-api/src/main/java/org/apache/flink/state/api/runtime/SavepointEnvironment.java
+++ b/flink-libraries/flink-state-processing-api/src/main/java/org/apache/flink/state/api/runtime/SavepointEnvironment.java
@@ -288,7 +288,7 @@ public class SavepointEnvironment implements Environment {
     }
 
     @Override
-    public ThroughputCalculator getThroughputMeter() {
+    public ThroughputCalculator getThroughputCalculator() {
         // The throughput calculator doesn't make sense for savepoint but the not null value is
         // preferable when StreamTask is instantiated.
         return new ThroughputCalculator(SystemClock.getInstance(), 10);

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/execution/Environment.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/execution/Environment.java
@@ -241,7 +241,7 @@ public interface Environment {
      *
      * @return the throughput calculation service.
      */
-    ThroughputCalculator getThroughputMeter();
+    ThroughputCalculator getThroughputCalculator();
 
     // --------------------------------------------------------------------------------------------
     //  Fields set in the StreamTask to provide access to mailbox and other runtime resources

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/io/network/NetworkSequenceViewReader.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/io/network/NetworkSequenceViewReader.java
@@ -82,4 +82,6 @@ public interface NetworkSequenceViewReader {
     Throwable getFailureCause();
 
     InputChannelID getReceiverId();
+
+    void notifyNewBufferSize(int newBufferSize);
 }

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/io/network/netty/CreditBasedSequenceNumberingViewReader.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/io/network/netty/CreditBasedSequenceNumberingViewReader.java
@@ -172,6 +172,11 @@ class CreditBasedSequenceNumberingViewReader
         return receiverId;
     }
 
+    @Override
+    public void notifyNewBufferSize(int newBufferSize) {
+        subpartitionView.notifyNewBufferSize(newBufferSize);
+    }
+
     @VisibleForTesting
     int getNumCreditsAvailable() {
         return numCreditsAvailable;

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/io/network/netty/NettyMessage.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/io/network/netty/NettyMessage.java
@@ -849,11 +849,11 @@ public abstract class NettyMessage {
 
         private static final byte ID = 10;
 
-        final long bufferSize;
+        final int bufferSize;
 
         final InputChannelID receiverId;
 
-        NewBufferSize(long bufferSize, InputChannelID receiverId) {
+        NewBufferSize(int bufferSize, InputChannelID receiverId) {
             checkArgument(bufferSize > 0, "The new buffer size should be greater than 0");
             this.bufferSize = bufferSize;
             this.receiverId = receiverId;
@@ -867,8 +867,8 @@ public abstract class NettyMessage {
             try {
                 result =
                         allocateBuffer(
-                                allocator, ID, Long.BYTES + InputChannelID.getByteBufLength());
-                result.writeLong(bufferSize);
+                                allocator, ID, Integer.BYTES + InputChannelID.getByteBufLength());
+                result.writeInt(bufferSize);
                 receiverId.writeTo(result);
 
                 out.write(result, promise);
@@ -878,7 +878,7 @@ public abstract class NettyMessage {
         }
 
         static NewBufferSize readFrom(ByteBuf buffer) {
-            long bufferSize = buffer.readLong();
+            int bufferSize = buffer.readInt();
             InputChannelID receiverId = InputChannelID.fromByteBuf(buffer);
 
             return new NewBufferSize(bufferSize, receiverId);

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/io/network/netty/PartitionRequestQueue.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/io/network/netty/PartitionRequestQueue.java
@@ -166,15 +166,10 @@ class PartitionRequestQueue extends ChannelInboundHandlerAdapter {
             return;
         }
 
-        NetworkSequenceViewReader reader = allReaders.get(receiverId);
-        if (reader != null) {
-            operation.accept(reader);
+        NetworkSequenceViewReader reader = obtainReader(receiverId);
 
-            enqueueAvailableReader(reader);
-        } else {
-            throw new IllegalStateException(
-                    "No reader for receiverId = " + receiverId + " exists.");
-        }
+        operation.accept(reader);
+        enqueueAvailableReader(reader);
     }
 
     void acknowledgeAllRecordsProcessed(InputChannelID receiverId) {
@@ -182,13 +177,17 @@ class PartitionRequestQueue extends ChannelInboundHandlerAdapter {
             return;
         }
 
+        obtainReader(receiverId).acknowledgeAllRecordsProcessed();
+    }
+
+    NetworkSequenceViewReader obtainReader(InputChannelID receiverId) {
         NetworkSequenceViewReader reader = allReaders.get(receiverId);
-        if (reader != null) {
-            reader.acknowledgeAllRecordsProcessed();
-        } else {
+        if (reader == null) {
             throw new IllegalStateException(
                     "No reader for receiverId = " + receiverId + " exists.");
         }
+
+        return reader;
     }
 
     /**

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/io/network/netty/PartitionRequestQueue.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/io/network/netty/PartitionRequestQueue.java
@@ -180,6 +180,14 @@ class PartitionRequestQueue extends ChannelInboundHandlerAdapter {
         obtainReader(receiverId).acknowledgeAllRecordsProcessed();
     }
 
+    void notifyNewBufferSize(InputChannelID receiverId, int newBufferSize) {
+        if (fatalError) {
+            return;
+        }
+
+        obtainReader(receiverId).notifyNewBufferSize(newBufferSize);
+    }
+
     NetworkSequenceViewReader obtainReader(InputChannelID receiverId) {
         NetworkSequenceViewReader reader = allReaders.get(receiverId);
         if (reader == null) {

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/io/network/netty/PartitionRequestServerHandler.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/io/network/netty/PartitionRequestServerHandler.java
@@ -131,6 +131,7 @@ class PartitionRequestServerHandler extends SimpleChannelInboundHandler<NettyMes
             } else if (msgClazz == NewBufferSize.class) {
                 NewBufferSize request = (NewBufferSize) msg;
 
+                outboundQueue.notifyNewBufferSize(request.receiverId, request.bufferSize);
             } else {
                 LOG.warn("Received unexpected client request: {}", msg);
             }

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/io/network/partition/BoundedBlockingSubpartition.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/io/network/partition/BoundedBlockingSubpartition.java
@@ -120,15 +120,15 @@ final class BoundedBlockingSubpartition extends ResultSubpartition {
     }
 
     @Override
-    public boolean add(BufferConsumer bufferConsumer, int partialRecordLength) throws IOException {
+    public int add(BufferConsumer bufferConsumer, int partialRecordLength) throws IOException {
         if (isFinished()) {
             bufferConsumer.close();
-            return false;
+            return -1;
         }
 
         flushCurrentBuffer();
         currentBuffer = bufferConsumer;
-        return true;
+        return Integer.MAX_VALUE;
     }
 
     @Override
@@ -269,6 +269,11 @@ final class BoundedBlockingSubpartition extends ResultSubpartition {
     @Override
     public int getNumberOfQueuedBuffers() {
         return 0;
+    }
+
+    @Override
+    public void bufferSize(int desirableNewBufferSize) {
+        // not supported.
     }
 
     @Override

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/io/network/partition/BoundedBlockingSubpartitionDirectTransferReader.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/io/network/partition/BoundedBlockingSubpartitionDirectTransferReader.java
@@ -154,6 +154,11 @@ public class BoundedBlockingSubpartitionDirectTransferReader implements ResultSu
     }
 
     @Override
+    public void notifyNewBufferSize(int newBufferSize) {
+        parent.bufferSize(newBufferSize);
+    }
+
+    @Override
     public void notifyDataAvailable() {
         throw new UnsupportedOperationException("Method should never be called.");
     }

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/io/network/partition/BoundedBlockingSubpartitionReader.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/io/network/partition/BoundedBlockingSubpartitionReader.java
@@ -187,6 +187,11 @@ final class BoundedBlockingSubpartitionReader implements ResultSubpartitionView 
     }
 
     @Override
+    public void notifyNewBufferSize(int newBufferSize) {
+        parent.bufferSize(newBufferSize);
+    }
+
+    @Override
     public String toString() {
         return String.format(
                 "Blocking Subpartition Reader: ID=%s, index=%d",

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/io/network/partition/NoOpResultSubpartitionView.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/io/network/partition/NoOpResultSubpartitionView.java
@@ -64,4 +64,7 @@ public class NoOpResultSubpartitionView implements ResultSubpartitionView {
     public int getNumberOfQueuedBuffers() {
         return 0;
     }
+
+    @Override
+    public void notifyNewBufferSize(int newBufferSize) {}
 }

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/io/network/partition/PipelinedSubpartitionView.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/io/network/partition/PipelinedSubpartitionView.java
@@ -105,6 +105,11 @@ public class PipelinedSubpartitionView implements ResultSubpartitionView {
     }
 
     @Override
+    public void notifyNewBufferSize(int newBufferSize) {
+        parent.bufferSize(newBufferSize);
+    }
+
+    @Override
     public String toString() {
         return String.format(
                 "%s(index: %d) of ResultPartition %s",

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/io/network/partition/ResultSubpartition.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/io/network/partition/ResultSubpartition.java
@@ -62,7 +62,7 @@ public abstract class ResultSubpartition {
     }
 
     @VisibleForTesting
-    public final boolean add(BufferConsumer bufferConsumer) throws IOException {
+    public final int add(BufferConsumer bufferConsumer) throws IOException {
         return add(bufferConsumer, 0);
     }
 
@@ -80,10 +80,10 @@ public abstract class ResultSubpartition {
      * @param bufferConsumer the buffer to add (transferring ownership to this writer)
      * @param partialRecordLength the length of bytes to skip in order to start with a complete
      *     record, from position index 0 of the underlying {@cite MemorySegment}.
-     * @return true if operation succeeded and bufferConsumer was enqueued for consumption.
+     * @return the preferable buffer size for this subpartition or -1 if the add operation fails.
      * @throws IOException thrown in case of errors while adding the buffer
      */
-    public abstract boolean add(BufferConsumer bufferConsumer, int partialRecordLength)
+    public abstract int add(BufferConsumer bufferConsumer, int partialRecordLength)
             throws IOException;
 
     public abstract void flush();
@@ -108,6 +108,8 @@ public abstract class ResultSubpartition {
 
     /** Get the current size of the queue. */
     public abstract int getNumberOfQueuedBuffers();
+
+    public abstract void bufferSize(int desirableNewBufferSize);
 
     // ------------------------------------------------------------------------
 

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/io/network/partition/ResultSubpartitionView.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/io/network/partition/ResultSubpartitionView.java
@@ -63,6 +63,8 @@ public interface ResultSubpartitionView {
 
     int getNumberOfQueuedBuffers();
 
+    void notifyNewBufferSize(int newBufferSize);
+
     /**
      * Availability of the {@link ResultSubpartitionView} and the backlog in the corresponding
      * {@link ResultSubpartition}.

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/io/network/partition/SortMergeSubpartitionReader.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/io/network/partition/SortMergeSubpartitionReader.java
@@ -241,4 +241,7 @@ class SortMergeSubpartitionReader
             return buffersRead.size();
         }
     }
+
+    @Override
+    public void notifyNewBufferSize(int newBufferSize) {}
 }

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/io/network/partition/consumer/LocalInputChannel.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/io/network/partition/consumer/LocalInputChannel.java
@@ -338,7 +338,10 @@ public class LocalInputChannel extends InputChannel implements BufferAvailabilit
 
     @Override
     void announceBufferSize(int newBufferSize) {
-        // Not supported.
+        checkState(!isReleased, "Channel released.");
+
+        ResultSubpartitionView subpartitionView = checkNotNull(this.subpartitionView);
+        subpartitionView.notifyNewBufferSize(newBufferSize);
     }
 
     @Override

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/taskmanager/RuntimeEnvironment.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/taskmanager/RuntimeEnvironment.java
@@ -345,7 +345,7 @@ public class RuntimeEnvironment implements Environment {
     }
 
     @Override
-    public ThroughputCalculator getThroughputMeter() {
+    public ThroughputCalculator getThroughputCalculator() {
         return throughputCalculator;
     }
 }

--- a/flink-runtime/src/test/java/org/apache/flink/runtime/io/network/buffer/BufferBuilderAndConsumerTest.java
+++ b/flink-runtime/src/test/java/org/apache/flink/runtime/io/network/buffer/BufferBuilderAndConsumerTest.java
@@ -264,6 +264,48 @@ public class BufferBuilderAndConsumerTest {
         assertEquals(1, recycler.recycleInvocationCounter);
     }
 
+    @Test
+    public void trimToAvailableSize() {
+        BufferBuilder bufferBuilder = createBufferBuilder();
+        assertEquals(BUFFER_SIZE, bufferBuilder.getMaxCapacity());
+
+        bufferBuilder.trim(BUFFER_SIZE / 2);
+        assertEquals(BUFFER_SIZE / 2, bufferBuilder.getMaxCapacity());
+
+        bufferBuilder.trim(0);
+        assertEquals(0, bufferBuilder.getMaxCapacity());
+    }
+
+    @Test
+    public void trimToNegativeSize() {
+        BufferBuilder bufferBuilder = createBufferBuilder();
+        assertEquals(BUFFER_SIZE, bufferBuilder.getMaxCapacity());
+
+        bufferBuilder.trim(-1);
+        assertEquals(0, bufferBuilder.getMaxCapacity());
+    }
+
+    @Test
+    public void trimToSizeLessThanWritten() {
+        BufferBuilder bufferBuilder = createBufferBuilder();
+        assertEquals(BUFFER_SIZE, bufferBuilder.getMaxCapacity());
+
+        bufferBuilder.append(toByteBuffer(1, 2, 3));
+
+        bufferBuilder.trim(4);
+        // Should be minimum possible size = 3 * int == 12.
+        assertEquals(12, bufferBuilder.getMaxCapacity());
+    }
+
+    @Test
+    public void trimToSizeGreaterThanMax() {
+        BufferBuilder bufferBuilder = createBufferBuilder();
+        assertEquals(BUFFER_SIZE, bufferBuilder.getMaxCapacity());
+
+        bufferBuilder.trim(BUFFER_SIZE + 1);
+        assertEquals(BUFFER_SIZE, bufferBuilder.getMaxCapacity());
+    }
+
     private static void testIsFinished(int writes) {
         BufferBuilder bufferBuilder = createBufferBuilder();
         BufferConsumer bufferConsumer = bufferBuilder.createBufferConsumer();

--- a/flink-runtime/src/test/java/org/apache/flink/runtime/io/network/netty/CancelPartitionRequestTest.java
+++ b/flink-runtime/src/test/java/org/apache/flink/runtime/io/network/netty/CancelPartitionRequestTest.java
@@ -247,6 +247,9 @@ public class CancelPartitionRequestTest {
         }
 
         @Override
+        public void notifyNewBufferSize(int newBufferSize) {}
+
+        @Override
         public Throwable getFailureCause() {
             return null;
         }

--- a/flink-runtime/src/test/java/org/apache/flink/runtime/io/network/netty/CreditBasedPartitionRequestClientHandlerTest.java
+++ b/flink-runtime/src/test/java/org/apache/flink/runtime/io/network/netty/CreditBasedPartitionRequestClientHandlerTest.java
@@ -711,11 +711,11 @@ public class CreditBasedPartitionRequestClientHandlerTest {
             NettyMessage.NewBufferSize readOutbound = channel.readOutbound();
             assertThat(readOutbound, instanceOf(NettyMessage.NewBufferSize.class));
             assertThat(readOutbound.receiverId, is(inputChannels[0].getInputChannelId()));
-            assertThat(readOutbound.bufferSize, is(333L));
+            assertThat(readOutbound.bufferSize, is(333));
 
             readOutbound = channel.readOutbound();
             assertThat(readOutbound.receiverId, is(inputChannels[1].getInputChannelId()));
-            assertThat(readOutbound.bufferSize, is(333L));
+            assertThat(readOutbound.bufferSize, is(333));
 
         } finally {
             releaseResource(inputGate, networkBufferPool);

--- a/flink-runtime/src/test/java/org/apache/flink/runtime/io/network/netty/NettyMessageServerSideSerializationTest.java
+++ b/flink-runtime/src/test/java/org/apache/flink/runtime/io/network/netty/NettyMessageServerSideSerializationTest.java
@@ -140,7 +140,7 @@ public class NettyMessageServerSideSerializationTest extends TestLogger {
     public void testNewBufferSize() {
         NettyMessage.NewBufferSize expected =
                 new NettyMessage.NewBufferSize(
-                        random.nextInt(Integer.MAX_VALUE) + 1L, new InputChannelID());
+                        random.nextInt(Integer.MAX_VALUE), new InputChannelID());
         NettyMessage.NewBufferSize actual = encodeAndDecode(expected, channel);
 
         assertEquals(expected.bufferSize, actual.bufferSize);

--- a/flink-runtime/src/test/java/org/apache/flink/runtime/io/network/netty/PartitionRequestServerHandlerTest.java
+++ b/flink-runtime/src/test/java/org/apache/flink/runtime/io/network/netty/PartitionRequestServerHandlerTest.java
@@ -42,6 +42,7 @@ import java.util.concurrent.CompletableFuture;
 
 import static org.hamcrest.Matchers.instanceOf;
 import static org.hamcrest.Matchers.is;
+import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertFalse;
 import static org.junit.Assert.assertThat;
 import static org.junit.Assert.assertTrue;
@@ -138,8 +139,30 @@ public class PartitionRequestServerHandlerTest extends TestLogger {
         assertFalse(allRecordsProcessedFuture.isCompletedExceptionally());
     }
 
+    @Test
+    public void testNewBufferSize() {
+        final InputChannelID inputChannelID = new InputChannelID();
+        final PartitionRequestQueue partitionRequestQueue = new PartitionRequestQueue();
+        final TestViewReader testViewReader =
+                new TestViewReader(inputChannelID, 2, partitionRequestQueue);
+        final PartitionRequestServerHandler serverHandler =
+                new PartitionRequestServerHandler(
+                        new ResultPartitionManager(),
+                        new TaskEventDispatcher(),
+                        partitionRequestQueue);
+        final EmbeddedChannel channel = new EmbeddedChannel(serverHandler);
+        partitionRequestQueue.notifyReaderCreated(testViewReader);
+
+        // Write the message of new buffer size to server
+        channel.writeInbound(new NettyMessage.NewBufferSize(666, inputChannelID));
+        channel.runPendingTasks();
+
+        assertEquals(666, testViewReader.bufferSize);
+    }
+
     private static class TestViewReader extends CreditBasedSequenceNumberingViewReader {
         private boolean consumptionResumed = false;
+        private int bufferSize;
 
         TestViewReader(
                 InputChannelID receiverId, int initialCredit, PartitionRequestQueue requestQueue) {
@@ -149,6 +172,11 @@ public class PartitionRequestServerHandlerTest extends TestLogger {
         @Override
         public void resumeConsumption() {
             consumptionResumed = true;
+        }
+
+        @Override
+        public void notifyNewBufferSize(int newBufferSize) {
+            bufferSize = newBufferSize;
         }
     }
 }

--- a/flink-runtime/src/test/java/org/apache/flink/runtime/io/network/partition/PipelinedSubpartitionTest.java
+++ b/flink-runtime/src/test/java/org/apache/flink/runtime/io/network/partition/PipelinedSubpartitionTest.java
@@ -300,6 +300,42 @@ public class PipelinedSubpartitionTest extends SubpartitionTestBase {
         assertEquals(1, subpartition.getNumberOfQueuedBuffers());
     }
 
+    @Test
+    public void testNewBufferSize() throws Exception {
+        // given: Buffer size equal to integer max value by default.
+        final PipelinedSubpartition subpartition = createSubpartition();
+        assertEquals(Integer.MAX_VALUE, subpartition.add(createFilledFinishedBufferConsumer(4)));
+
+        // when: Changing buffer size.
+        subpartition.bufferSize(42);
+
+        // then: Changes successfully applied.
+        assertEquals(42, subpartition.add(createFilledFinishedBufferConsumer(4)));
+    }
+
+    @Test(expected = IllegalArgumentException.class)
+    public void testNegativeNewBufferSize() throws Exception {
+        // given: Buffer size equal to integer max value by default.
+        final PipelinedSubpartition subpartition = createSubpartition();
+        assertEquals(Integer.MAX_VALUE, subpartition.add(createFilledFinishedBufferConsumer(4)));
+
+        // when: Changing buffer size to the negative value.
+        subpartition.bufferSize(-1);
+    }
+
+    @Test
+    public void testNegativeBufferSizeAsSignOfAddingFail() throws Exception {
+        // given: Buffer size equal to integer max value by default.
+        final PipelinedSubpartition subpartition = createSubpartition();
+        assertEquals(Integer.MAX_VALUE, subpartition.add(createFilledFinishedBufferConsumer(4)));
+
+        // when: Finishing the subpartition which make following adding impossible.
+        subpartition.finish();
+
+        // then: -1 should be return because the add operation fails.
+        assertEquals(-1, subpartition.add(createFilledFinishedBufferConsumer(4)));
+    }
+
     private void verifyViewReleasedAfterParentRelease(ResultSubpartition partition)
             throws Exception {
         // Add a bufferConsumer

--- a/flink-runtime/src/test/java/org/apache/flink/runtime/io/network/partition/PipelinedSubpartitionTest.java
+++ b/flink-runtime/src/test/java/org/apache/flink/runtime/io/network/partition/PipelinedSubpartitionTest.java
@@ -365,4 +365,8 @@ public class PipelinedSubpartitionTest extends SubpartitionTestBase {
 
         return new PipelinedSubpartition(0, 2, parent);
     }
+
+    public static PipelinedSubpartition createPipelinedSubpartition(ResultPartition parent) {
+        return new PipelinedSubpartition(0, 2, parent);
+    }
 }

--- a/flink-runtime/src/test/java/org/apache/flink/runtime/io/network/partition/SubpartitionTestBase.java
+++ b/flink-runtime/src/test/java/org/apache/flink/runtime/io/network/partition/SubpartitionTestBase.java
@@ -65,7 +65,7 @@ public abstract class SubpartitionTestBase extends TestLogger {
 
             BufferConsumer bufferConsumer = createFilledFinishedBufferConsumer(4096);
 
-            assertFalse(subpartition.add(bufferConsumer));
+            assertEquals(-1, subpartition.add(bufferConsumer));
             assertTrue(bufferConsumer.isRecycled());
 
             assertEquals(1, subpartition.getTotalNumberOfBuffers());
@@ -86,7 +86,7 @@ public abstract class SubpartitionTestBase extends TestLogger {
 
             BufferConsumer bufferConsumer = createFilledFinishedBufferConsumer(4096);
 
-            assertFalse(subpartition.add(bufferConsumer));
+            assertEquals(-1, subpartition.add(bufferConsumer));
             assertTrue(bufferConsumer.isRecycled());
 
         } finally {

--- a/flink-runtime/src/test/java/org/apache/flink/runtime/operators/testutils/DummyEnvironment.java
+++ b/flink-runtime/src/test/java/org/apache/flink/runtime/operators/testutils/DummyEnvironment.java
@@ -252,7 +252,7 @@ public class DummyEnvironment implements Environment {
     }
 
     @Override
-    public ThroughputCalculator getThroughputMeter() {
+    public ThroughputCalculator getThroughputCalculator() {
         return new ThroughputCalculator(SystemClock.getInstance(), 10);
     }
 

--- a/flink-runtime/src/test/java/org/apache/flink/runtime/operators/testutils/MockEnvironment.java
+++ b/flink-runtime/src/test/java/org/apache/flink/runtime/operators/testutils/MockEnvironment.java
@@ -318,7 +318,7 @@ public class MockEnvironment implements Environment, AutoCloseable {
     }
 
     @Override
-    public ThroughputCalculator getThroughputMeter() {
+    public ThroughputCalculator getThroughputCalculator() {
         return throughputCalculator;
     }
 

--- a/flink-runtime/src/test/java/org/apache/flink/runtime/operators/testutils/MockEnvironmentBuilder.java
+++ b/flink-runtime/src/test/java/org/apache/flink/runtime/operators/testutils/MockEnvironmentBuilder.java
@@ -163,7 +163,8 @@ public class MockEnvironmentBuilder {
         return this;
     }
 
-    public MockEnvironmentBuilder setThroughputMeter(ThroughputCalculator throughputCalculator) {
+    public MockEnvironmentBuilder setThroughputCalculator(
+            ThroughputCalculator throughputCalculator) {
         this.throughputCalculator = throughputCalculator;
         return this;
     }

--- a/flink-streaming-java/src/main/java/org/apache/flink/streaming/runtime/tasks/StreamTask.java
+++ b/flink-streaming-java/src/main/java/org/apache/flink/streaming/runtime/tasks/StreamTask.java
@@ -395,7 +395,7 @@ public abstract class StreamTask<OUT, OP extends StreamOperator<OUT>> extends Ab
         injectChannelStateWriterIntoChannels();
 
         environment.getMetricGroup().getIOMetricGroup().setEnableBusyTime(true);
-        this.throughputCalculator = environment.getThroughputMeter();
+        this.throughputCalculator = environment.getThroughputCalculator();
         this.bufferDebloatPeriod = getTaskConfiguration().get(BUFFER_DEBLOAT_PERIOD).toMillis();
 
         if (getTaskConfiguration().get(TaskManagerOptions.BUFFER_DEBLOAT_ENABLED)) {

--- a/flink-streaming-java/src/main/java/org/apache/flink/streaming/runtime/tasks/StreamTask.java
+++ b/flink-streaming-java/src/main/java/org/apache/flink/streaming/runtime/tasks/StreamTask.java
@@ -20,6 +20,7 @@ package org.apache.flink.streaming.runtime.tasks;
 import org.apache.flink.annotation.Internal;
 import org.apache.flink.annotation.VisibleForTesting;
 import org.apache.flink.api.common.operators.MailboxExecutor;
+import org.apache.flink.configuration.Configuration;
 import org.apache.flink.configuration.TaskManagerOptions;
 import org.apache.flink.core.fs.CloseableRegistry;
 import org.apache.flink.core.fs.Path;
@@ -396,12 +397,13 @@ public abstract class StreamTask<OUT, OP extends StreamOperator<OUT>> extends Ab
 
         environment.getMetricGroup().getIOMetricGroup().setEnableBusyTime(true);
         this.throughputCalculator = environment.getThroughputCalculator();
-        this.bufferDebloatPeriod = getTaskConfiguration().get(BUFFER_DEBLOAT_PERIOD).toMillis();
+        Configuration taskManagerConf = environment.getTaskManagerInfo().getConfiguration();
 
-        if (getTaskConfiguration().get(TaskManagerOptions.BUFFER_DEBLOAT_ENABLED)) {
+        this.bufferDebloatPeriod = taskManagerConf.get(BUFFER_DEBLOAT_PERIOD).toMillis();
+
+        if (taskManagerConf.get(TaskManagerOptions.BUFFER_DEBLOAT_ENABLED)) {
             this.bufferDebloater =
-                    new BufferDebloater(
-                            getTaskConfiguration(), getEnvironment().getAllInputGates());
+                    new BufferDebloater(taskManagerConf, getEnvironment().getAllInputGates());
             environment
                     .getMetricGroup()
                     .gauge(

--- a/flink-streaming-java/src/test/java/org/apache/flink/streaming/runtime/tasks/StreamMockEnvironment.java
+++ b/flink-streaming-java/src/test/java/org/apache/flink/streaming/runtime/tasks/StreamMockEnvironment.java
@@ -309,7 +309,7 @@ public class StreamMockEnvironment implements Environment {
     }
 
     @Override
-    public ThroughputCalculator getThroughputMeter() {
+    public ThroughputCalculator getThroughputCalculator() {
         return throughputCalculator;
     }
 

--- a/flink-streaming-java/src/test/java/org/apache/flink/streaming/runtime/tasks/StreamTaskMailboxTestHarnessBuilder.java
+++ b/flink-streaming-java/src/test/java/org/apache/flink/streaming/runtime/tasks/StreamTaskMailboxTestHarnessBuilder.java
@@ -126,7 +126,7 @@ public class StreamTaskMailboxTestHarnessBuilder<OUT> {
         return this;
     }
 
-    public <T> StreamTaskMailboxTestHarnessBuilder<OUT> setThroughputMeter(
+    public <T> StreamTaskMailboxTestHarnessBuilder<OUT> setThroughputCalculator(
             ThroughputCalculator throughputCalculator) {
         this.throughputCalculator = throughputCalculator;
         return this;

--- a/flink-streaming-java/src/test/java/org/apache/flink/streaming/runtime/tasks/StreamTaskMailboxTestHarnessBuilder.java
+++ b/flink-streaming-java/src/test/java/org/apache/flink/streaming/runtime/tasks/StreamTaskMailboxTestHarnessBuilder.java
@@ -38,8 +38,10 @@ import org.apache.flink.runtime.state.TestLocalRecoveryConfig;
 import org.apache.flink.runtime.state.TestTaskStateManager;
 import org.apache.flink.runtime.state.TestTaskStateManagerBuilder;
 import org.apache.flink.runtime.taskmanager.CheckpointResponder;
+import org.apache.flink.runtime.taskmanager.TaskManagerRuntimeInfo;
 import org.apache.flink.runtime.taskmanager.TestCheckpointResponder;
 import org.apache.flink.runtime.throughput.ThroughputCalculator;
+import org.apache.flink.runtime.util.TestingTaskManagerRuntimeInfo;
 import org.apache.flink.streaming.api.TimeCharacteristic;
 import org.apache.flink.streaming.api.graph.StreamConfig;
 import org.apache.flink.streaming.api.graph.StreamConfig.InputConfig;
@@ -100,6 +102,8 @@ public class StreamTaskMailboxTestHarnessBuilder<OUT> {
     private ThroughputCalculator throughputCalculator =
             new ThroughputCalculator(SystemClock.getInstance(), 10);
 
+    private TaskManagerRuntimeInfo taskManagerRuntimeInfo = new TestingTaskManagerRuntimeInfo();
+
     public StreamTaskMailboxTestHarnessBuilder(
             FunctionWithException<Environment, ? extends StreamTask<OUT, ?>, Exception> taskFactory,
             TypeInformation<OUT> outputType) {
@@ -129,6 +133,12 @@ public class StreamTaskMailboxTestHarnessBuilder<OUT> {
     public <T> StreamTaskMailboxTestHarnessBuilder<OUT> setThroughputCalculator(
             ThroughputCalculator throughputCalculator) {
         this.throughputCalculator = throughputCalculator;
+        return this;
+    }
+
+    public <T> StreamTaskMailboxTestHarnessBuilder<OUT> setTaskManagerRuntimeInfo(
+            TaskManagerRuntimeInfo taskManagerRuntimeInfo) {
+        this.taskManagerRuntimeInfo = taskManagerRuntimeInfo;
         return this;
     }
 
@@ -217,6 +227,7 @@ public class StreamTaskMailboxTestHarnessBuilder<OUT> {
 
         streamMockEnvironment.setCheckpointResponder(taskStateManager.getCheckpointResponder());
         initializeInputs(streamMockEnvironment);
+        streamMockEnvironment.setTaskManagerInfo(taskManagerRuntimeInfo);
 
         checkState(inputGates != null, "InputGates hasn't been initialised");
 

--- a/flink-streaming-java/src/test/java/org/apache/flink/streaming/runtime/tasks/StreamTaskTest.java
+++ b/flink-streaming-java/src/test/java/org/apache/flink/streaming/runtime/tasks/StreamTaskTest.java
@@ -1547,7 +1547,7 @@ public class StreamTaskTest extends TestLogger {
                             .build();
             TaskIOMetricGroup ioMetricGroup =
                     task.getEnvironment().getMetricGroup().getIOMetricGroup();
-            ThroughputCalculator throughputCalculator = environment.getThroughputMeter();
+            ThroughputCalculator throughputCalculator = environment.getThroughputCalculator();
 
             final MailboxExecutor executor = task.mailboxProcessor.getMainMailboxExecutor();
             final RunnableWithException completeFutureTask =
@@ -1828,7 +1828,7 @@ public class StreamTaskTest extends TestLogger {
                         .addInput(STRING_TYPE_INFO)
                         .setupOutputForSingletonOperatorChain(
                                 new TestBoundedOneInputStreamOperator())
-                        .setThroughputMeter(
+                        .setThroughputCalculator(
                                 new ThroughputCalculator(SystemClock.getInstance(), 10) {
                                     @Override
                                     public long calculateThroughput() {
@@ -1901,7 +1901,7 @@ public class StreamTaskTest extends TestLogger {
                         .addInput(STRING_TYPE_INFO, inputChannels)
                         .setupOutputForSingletonOperatorChain(
                                 new TestBoundedOneInputStreamOperator())
-                        .setThroughputMeter(
+                        .setThroughputCalculator(
                                 new ThroughputCalculator(SystemClock.getInstance(), 10) {
                                     @Override
                                     public long calculateThroughput() {

--- a/flink-streaming-java/src/test/java/org/apache/flink/streaming/runtime/tasks/StreamTaskTest.java
+++ b/flink-streaming-java/src/test/java/org/apache/flink/streaming/runtime/tasks/StreamTaskTest.java
@@ -98,6 +98,7 @@ import org.apache.flink.runtime.taskmanager.TaskManagerActions;
 import org.apache.flink.runtime.taskmanager.TestTaskBuilder;
 import org.apache.flink.runtime.throughput.ThroughputCalculator;
 import org.apache.flink.runtime.util.NettyShuffleDescriptorBuilder;
+import org.apache.flink.runtime.util.TestingTaskManagerRuntimeInfo;
 import org.apache.flink.streaming.api.TimeCharacteristic;
 import org.apache.flink.streaming.api.checkpoint.CheckpointedFunction;
 import org.apache.flink.streaming.api.environment.ExecutionCheckpointingOptions;
@@ -1883,20 +1884,21 @@ public class StreamTaskTest extends TestLogger {
     public void testBufferSizeRecalculationStartSuccessfully() throws Exception {
         int expectedThroughput = 13333;
         int inputChannels = 3;
-        Consumer<StreamConfig> configuration =
-                (config) -> {
-                    // debloat period doesn't matter, we will schedule debloating manually
-                    config.getConfiguration().set(BUFFER_DEBLOAT_PERIOD, Duration.ofHours(10));
-                    config.getConfiguration().set(BUFFER_DEBLOAT_TARGET, Duration.ofSeconds(1));
-                    config.getConfiguration().set(BUFFER_DEBLOAT_ENABLED, true);
-                };
+
+        // debloat period doesn't matter, we will schedule debloating manually
+        Configuration config =
+                new Configuration()
+                        .set(BUFFER_DEBLOAT_PERIOD, Duration.ofHours(10))
+                        .set(BUFFER_DEBLOAT_TARGET, Duration.ofSeconds(1))
+                        .set(BUFFER_DEBLOAT_ENABLED, true);
+
         Map<String, Metric> metrics = new ConcurrentHashMap<>();
         final TaskMetricGroup taskMetricGroup =
                 StreamTaskTestHarness.createTaskMetricGroup(metrics);
 
         try (StreamTaskMailboxTestHarness<String> harness =
                 new StreamTaskMailboxTestHarnessBuilder<>(OneInputStreamTask::new, STRING_TYPE_INFO)
-                        .modifyStreamConfig(configuration)
+                        .setTaskManagerRuntimeInfo(new TestingTaskManagerRuntimeInfo(config))
                         .setTaskMetricGroup(taskMetricGroup)
                         .addInput(STRING_TYPE_INFO, inputChannels)
                         .setupOutputForSingletonOperatorChain(


### PR DESCRIPTION
<!--
*Thank you very much for contributing to Apache Flink - we are happy that you want to help us improve Flink. To help the community review your contribution in the best possible way, please go through the checklist below, which will get the contribution into a shape in which it can be best reviewed.*

*Please understand that we do not do this to make contributions to Flink a hassle. In order to uphold a high standard of quality for code contributions, while at the same time managing a large number of contributions, we need contributors to prepare the contributions well, and give reviewers enough contextual information for the review. Please also understand that contributions that do not follow this guide will take longer to review and thus typically be picked up with lower priority by the community.*

## Contribution Checklist

  - Make sure that the pull request corresponds to a [JIRA issue](https://issues.apache.org/jira/projects/FLINK/issues). Exceptions are made for typos in JavaDoc or documentation files, which need no JIRA issue.
  
  - Name the pull request in the form "[FLINK-XXXX] [component] Title of the pull request", where *FLINK-XXXX* should be replaced by the actual issue number. Skip *component* if you are unsure about which is the best component.
  Typo fixes that have no associated JIRA issue should be named following this pattern: `[hotfix] [docs] Fix typo in event time introduction` or `[hotfix] [javadocs] Expand JavaDoc for PuncuatedWatermarkGenerator`.

  - Fill out the template below to describe the changes contributed by the pull request. That will give reviewers the context they need to do the review.
  
  - Make sure that the change passes the automated tests, i.e., `mvn clean verify` passes. You can set up Azure Pipelines CI to do that following [this guide](https://cwiki.apache.org/confluence/display/FLINK/Azure+Pipelines#AzurePipelines-Tutorial:SettingupAzurePipelinesforaforkoftheFlinkrepository).

  - Each pull request should address only one issue, not mix up code from multiple issues.
  
  - Each commit in the pull request has a meaningful commit message (including the JIRA id)

  - Once all items of the checklist are addressed, remove the above text and this checklist, leaving only the filled out template below.


**(The sections below can be removed for hotfixes of typos)**
-->

## What is the purpose of the change

*This PR implements the reaction on NewBufferSize. It changes the size of output buffers corresponded to the received information.*


## Brief change log

  - *Added the support of changing the max capacity to BufferBuilder*
  - *Subpartition is able to notify the desirable buffer size for input buffer consumer.*
  - *Notifying the subpartitions about the new received buffer size.*
  - *LocalInputChannel notifying the subpartition about the new buffer size directly. *
  - *ResultPartition changes the BufferBuilder size according to the desirable buffer size of each subpartition. *


## Verifying this change

  - *Added unit tests for each classes which behaviour was changed*
## Does this pull request potentially affect one of the following parts:

  - Dependencies (does it add or upgrade a dependency): (yes / **no**)
  - The public API, i.e., is any changed class annotated with `@Public(Evolving)`: (yes / **no**)
  - The serializers: (yes / **no** / don't know)
  - The runtime per-record code paths (performance sensitive): (**yes** / no / don't know)
  - Anything that affects deployment or recovery: JobManager (and its components), Checkpointing, Kubernetes/Yarn, ZooKeeper: (yes / **no** / don't know)
  - The S3 file system connector: (yes / **no** / don't know)

## Documentation

  - Does this pull request introduce a new feature? (yes / **no**)
  - If yes, how is the feature documented? (not applicable / docs / JavaDocs / not documented)
