### PR TITLE
[FLINK-23646][streaming-java][table] Use pipeline name consistently across DataStream API and Table API

### DIFF
--- a/flink-python/pyflink/datastream/tests/test_data_stream.py
+++ b/flink-python/pyflink/datastream/tests/test_data_stream.py
@@ -1040,7 +1040,7 @@ class StreamingModeDataStreamTests(DataStreamTests, PyFlinkStreamingTestCase):
             .add_sink(self.test_sink)
 
         j_generated_stream_graph = self.env._j_stream_execution_environment \
-            .getStreamGraph("test start new_chain", True)
+            .getStreamGraph(True)
 
         j_stream_nodes = list(j_generated_stream_graph.getStreamNodes().toArray())
         for j_stream_node in j_stream_nodes:
@@ -1082,7 +1082,7 @@ class StreamingModeDataStreamTests(DataStreamTests, PyFlinkStreamingTestCase):
         # ship_strategy for map_operator_0 and map_operator_1 is FORWARD, so the map_operator_1
         # can be chained with map_operator_0 and map_operator_2.
         j_generated_stream_graph = self.env._j_stream_execution_environment\
-            .getStreamGraph("test start new_chain", True)
+            .getStreamGraph(True)
         assert_chainable(j_generated_stream_graph, True, True)
 
         ds = self.env.from_collection([1, 2, 3])
@@ -1093,7 +1093,7 @@ class StreamingModeDataStreamTests(DataStreamTests, PyFlinkStreamingTestCase):
             .add_sink(self.test_sink)
 
         j_generated_stream_graph = self.env._j_stream_execution_environment \
-            .getStreamGraph("test start new_chain", True)
+            .getStreamGraph(True)
         # We start a new chain for map operator, therefore, it cannot be chained with upstream
         # operator, but can be chained with downstream operator.
         assert_chainable(j_generated_stream_graph, False, True)
@@ -1106,7 +1106,7 @@ class StreamingModeDataStreamTests(DataStreamTests, PyFlinkStreamingTestCase):
             .add_sink(self.test_sink)
 
         j_generated_stream_graph = self.env._j_stream_execution_environment \
-            .getStreamGraph("test start new_chain", True)
+            .getStreamGraph(True)
         # We disable chaining for map_operator_1, therefore, it cannot be chained with
         # upstream and downstream operators.
         assert_chainable(j_generated_stream_graph, False, False)

--- a/flink-python/pyflink/datastream/tests/test_stream_execution_environment.py
+++ b/flink-python/pyflink/datastream/tests/test_stream_execution_environment.py
@@ -686,7 +686,7 @@ class StreamExecutionEnvironmentTests(PyFlinkTestCase):
             .add_sink(self.test_sink)
 
         j_generated_stream_graph = self.env._j_stream_execution_environment \
-            .getStreamGraph("test start new_chain", True)
+            .getStreamGraph(True)
         j_resource_profile_1 = j_generated_stream_graph.getSlotSharingGroupResource(
             'slot_sharing_group_1').get()
         j_resource_profile_2 = j_generated_stream_graph.getSlotSharingGroupResource(

--- a/flink-python/src/main/java/org/apache/flink/python/util/PythonConfigUtil.java
+++ b/flink-python/src/main/java/org/apache/flink/python/util/PythonConfigUtil.java
@@ -22,7 +22,6 @@ import org.apache.flink.api.dag.Transformation;
 import org.apache.flink.api.java.ExecutionEnvironment;
 import org.apache.flink.api.java.tuple.Tuple2;
 import org.apache.flink.configuration.Configuration;
-import org.apache.flink.configuration.PipelineOptions;
 import org.apache.flink.core.memory.ManagedMemoryUseCase;
 import org.apache.flink.python.PythonConfig;
 import org.apache.flink.streaming.api.environment.StreamExecutionEnvironment;
@@ -102,11 +101,7 @@ public class PythonConfigUtil {
             throws IllegalAccessException, InvocationTargetException, NoSuchFieldException {
         configPythonOperator(env);
 
-        String jobName =
-                getEnvironmentConfig(env)
-                        .getString(
-                                PipelineOptions.NAME, StreamExecutionEnvironment.DEFAULT_JOB_NAME);
-        return env.getStreamGraph(jobName, clearTransformations);
+        return env.getStreamGraph(clearTransformations);
     }
 
     @SuppressWarnings("unchecked")

--- a/flink-state-backends/flink-statebackend-changelog/src/test/java/org/apache/flink/state/changelog/ChangelogStateBackendLoadingTest.java
+++ b/flink-state-backends/flink-statebackend-changelog/src/test/java/org/apache/flink/state/changelog/ChangelogStateBackendLoadingTest.java
@@ -350,8 +350,7 @@ public class ChangelogStateBackendLoadingTest {
             assertSame(rootStateBackendClass, env.getStateBackend().getClass());
         }
 
-        StreamGraph streamGraph =
-                env.getStreamGraph(StreamExecutionEnvironment.DEFAULT_JOB_NAME, false);
+        StreamGraph streamGraph = env.getStreamGraph(false);
         assertEquals(isChangelogEnabled, streamGraph.isChangelogStateBackendEnabled());
         if (rootStateBackendClass == null) {
             assertNull(streamGraph.getStateBackend());

--- a/flink-streaming-java/src/main/java/org/apache/flink/streaming/api/environment/StreamExecutionEnvironment.java
+++ b/flink-streaming-java/src/main/java/org/apache/flink/streaming/api/environment/StreamExecutionEnvironment.java
@@ -142,8 +142,13 @@ import static org.apache.flink.util.Preconditions.checkNotNull;
 @Public
 public class StreamExecutionEnvironment {
 
-    /** The default name to use for a streaming job if no other name has been specified. */
-    public static final String DEFAULT_JOB_NAME = "Flink Streaming Job";
+    /**
+     * The default name to use for a streaming job if no other name has been specified.
+     *
+     * @deprecated This constant does not fit well to batch runtime mode.
+     */
+    @Deprecated
+    public static final String DEFAULT_JOB_NAME = StreamGraphGenerator.DEFAULT_STREAMING_JOB_NAME;
 
     /** The time characteristic that is used if none other is set. */
     private static final TimeCharacteristic DEFAULT_TIME_CHARACTERISTIC =
@@ -1944,7 +1949,7 @@ public class StreamExecutionEnvironment {
      * @throws Exception which occurs during job execution.
      */
     public JobExecutionResult execute() throws Exception {
-        return execute(getJobName());
+        return execute(getStreamGraph());
     }
 
     /**
@@ -1960,8 +1965,9 @@ public class StreamExecutionEnvironment {
      */
     public JobExecutionResult execute(String jobName) throws Exception {
         Preconditions.checkNotNull(jobName, "Streaming Job name should not be null.");
-
-        return execute(getStreamGraph(jobName));
+        final StreamGraph streamGraph = getStreamGraph();
+        streamGraph.setJobName(jobName);
+        return execute(streamGraph);
     }
 
     /**
@@ -2036,7 +2042,7 @@ public class StreamExecutionEnvironment {
      */
     @PublicEvolving
     public final JobClient executeAsync() throws Exception {
-        return executeAsync(getJobName());
+        return executeAsync(getStreamGraph());
     }
 
     /**
@@ -2053,7 +2059,10 @@ public class StreamExecutionEnvironment {
      */
     @PublicEvolving
     public JobClient executeAsync(String jobName) throws Exception {
-        return executeAsync(getStreamGraph(checkNotNull(jobName)));
+        Preconditions.checkNotNull(jobName, "Streaming Job name should not be null.");
+        final StreamGraph streamGraph = getStreamGraph();
+        streamGraph.setJobName(jobName);
+        return executeAsync(streamGraph);
     }
 
     /**
@@ -2110,19 +2119,7 @@ public class StreamExecutionEnvironment {
      */
     @Internal
     public StreamGraph getStreamGraph() {
-        return getStreamGraph(getJobName());
-    }
-
-    /**
-     * Getter of the {@link org.apache.flink.streaming.api.graph.StreamGraph} of the streaming job.
-     * This call clears previously registered {@link Transformation transformations}.
-     *
-     * @param jobName Desired name of the job
-     * @return The streamgraph representing the transformations
-     */
-    @Internal
-    public StreamGraph getStreamGraph(String jobName) {
-        return getStreamGraph(jobName, true);
+        return getStreamGraph(true);
     }
 
     /**
@@ -2131,13 +2128,12 @@ public class StreamExecutionEnvironment {
      * transformations}. Clearing the transformations allows, for example, to not re-execute the
      * same operations when calling {@link #execute()} multiple times.
      *
-     * @param jobName Desired name of the job
      * @param clearTransformations Whether or not to clear previously registered transformations
      * @return The streamgraph representing the transformations
      */
     @Internal
-    public StreamGraph getStreamGraph(String jobName, boolean clearTransformations) {
-        StreamGraph streamGraph = getStreamGraphGenerator().setJobName(jobName).generate();
+    public StreamGraph getStreamGraph(boolean clearTransformations) {
+        final StreamGraph streamGraph = getStreamGraphGenerator().generate();
         if (clearTransformations) {
             this.transformations.clear();
         }
@@ -2172,7 +2168,7 @@ public class StreamExecutionEnvironment {
      * @return The execution plan of the program, as a JSON String.
      */
     public String getExecutionPlan() {
-        return getStreamGraph(getJobName(), false).getStreamingPlanAsJSON();
+        return getStreamGraph(false).getStreamingPlanAsJSON();
     }
 
     /**
@@ -2492,9 +2488,5 @@ public class StreamExecutionEnvironment {
             }
         }
         return (T) resolvedTypeInfo;
-    }
-
-    private String getJobName() {
-        return configuration.getString(PipelineOptions.NAME, DEFAULT_JOB_NAME);
     }
 }

--- a/flink-streaming-java/src/test/java/org/apache/flink/streaming/api/DataStreamTest.java
+++ b/flink-streaming-java/src/test/java/org/apache/flink/streaming/api/DataStreamTest.java
@@ -1634,7 +1634,7 @@ public class DataStreamTest extends TestLogger {
 
     /** Returns the StreamGraph without clearing the transformations. */
     private static StreamGraph getStreamGraph(StreamExecutionEnvironment sEnv) {
-        return sEnv.getStreamGraph(StreamExecutionEnvironment.DEFAULT_JOB_NAME, false);
+        return sEnv.getStreamGraph(false);
     }
 
     private static Integer createDownStreamId(DataStream<?> dataStream) {

--- a/flink-streaming-java/src/test/java/org/apache/flink/streaming/api/graph/SinkTransformationTranslatorTest.java
+++ b/flink-streaming-java/src/test/java/org/apache/flink/streaming/api/graph/SinkTransformationTranslatorTest.java
@@ -261,7 +261,7 @@ public class SinkTransformationTranslatorTest extends TestLogger {
         final DataStreamSource<Integer> src = env.fromElements(1, 2);
         final DataStreamSink<Integer> dataStreamSink = src.rebalance().sinkTo(sink);
         setSinkProperty(dataStreamSink);
-        return env.getStreamGraph("test");
+        return env.getStreamGraph();
     }
 
     private void setSinkProperty(DataStreamSink<Integer> dataStreamSink) {

--- a/flink-streaming-java/src/test/java/org/apache/flink/streaming/api/graph/StreamingJobGraphGeneratorTest.java
+++ b/flink-streaming-java/src/test/java/org/apache/flink/streaming/api/graph/StreamingJobGraphGeneratorTest.java
@@ -167,7 +167,7 @@ public class StreamingJobGraphGeneratorTest extends TestLogger {
 
         // --------- the job graph ---------
 
-        StreamGraph streamGraph = env.getStreamGraph("test job");
+        StreamGraph streamGraph = env.getStreamGraph();
         JobGraph jobGraph = streamGraph.getJobGraph();
         List<JobVertex> verticesSorted = jobGraph.getVerticesSortedTopologicallyFromSources();
 

--- a/flink-streaming-scala/src/main/scala/org/apache/flink/streaming/api/scala/StreamExecutionEnvironment.scala
+++ b/flink-streaming-scala/src/main/scala/org/apache/flink/streaming/api/scala/StreamExecutionEnvironment.scala
@@ -37,7 +37,9 @@ import org.apache.flink.runtime.state.StateBackend
 import org.apache.flink.streaming.api.environment.{CheckpointConfig, StreamExecutionEnvironment => JavaEnv}
 import org.apache.flink.streaming.api.functions.source.SourceFunction.SourceContext
 import org.apache.flink.streaming.api.functions.source._
+import org.apache.flink.streaming.api.graph.StreamGraph
 import org.apache.flink.streaming.api.{CheckpointingMode, TimeCharacteristic}
+import org.apache.flink.util.Preconditions.checkNotNull
 import org.apache.flink.util.{SplittableIterator, TernaryBoolean}
 
 import com.esotericsoftware.kryo.Serializer
@@ -950,18 +952,7 @@ class StreamExecutionEnvironment(javaEnv: JavaEnv) {
    * @return The StreamGraph representing the transformations
    */
   @Internal
-  def getStreamGraph = javaEnv.getStreamGraph
-
-  /**
-   * Getter of the [[org.apache.flink.streaming.api.graph.StreamGraph]] of the streaming job.
-   * This call clears previously registered
-   * [[org.apache.flink.api.dag.Transformation transformations]].
-   *
-   * @param jobName Desired name of the job
-   * @return The StreamGraph representing the transformations
-   */
-  @Internal
-  def getStreamGraph(jobName: String) = javaEnv.getStreamGraph(jobName)
+  def getStreamGraph: StreamGraph = javaEnv.getStreamGraph
 
   /**
    * Getter of the [[org.apache.flink.streaming.api.graph.StreamGraph]] of the streaming job
@@ -970,13 +961,13 @@ class StreamExecutionEnvironment(javaEnv: JavaEnv) {
    * allows, for example, to not re-execute the same operations when calling
    * [[execute()]] multiple times.
    *
-   * @param jobName Desired name of the job
    * @param clearTransformations Whether or not to clear previously registered transformations
    * @return The StreamGraph representing the transformations
    */
   @Internal
-  def getStreamGraph(jobName: String, clearTransformations: Boolean) =
-    javaEnv.getStreamGraph(jobName, clearTransformations)
+  def getStreamGraph(clearTransformations: Boolean): StreamGraph = {
+    javaEnv.getStreamGraph(clearTransformations)
+  }
 
   /**
    * Gives read-only access to the underlying configuration of this environment.

--- a/flink-streaming-scala/src/test/scala/org/apache/flink/streaming/api/scala/DataStreamTest.scala
+++ b/flink-streaming-scala/src/test/scala/org/apache/flink/streaming/api/scala/DataStreamTest.scala
@@ -676,14 +676,13 @@ class DataStreamTest extends AbstractTestBase {
   private def getOperatorForDataStream(dataStream: DataStream[_]): StreamOperator[_] = {
     dataStream.print()
     val env = dataStream.javaStream.getExecutionEnvironment
-    val streamGraph: StreamGraph =
-      env.getStreamGraph(JStreamExecutionEnvironment.DEFAULT_JOB_NAME, false)
+    val streamGraph: StreamGraph = env.getStreamGraph(false)
     streamGraph.getStreamNode(dataStream.getId).getOperator
   }
 
   /** Returns the StreamGraph without clearing the transformations. */
   private def getStreamGraph(sEnv: StreamExecutionEnvironment): StreamGraph = {
-    sEnv.getStreamGraph(JStreamExecutionEnvironment.DEFAULT_JOB_NAME, clearTransformations = false)
+    sEnv.getStreamGraph(false)
   }
 
   private def isPartitioned(edges: java.util.List[StreamEdge]) = {

--- a/flink-table/flink-table-api-java/src/main/java/org/apache/flink/table/api/internal/TableEnvironmentImpl.java
+++ b/flink-table/flink-table-api-java/src/main/java/org/apache/flink/table/api/internal/TableEnvironmentImpl.java
@@ -24,7 +24,6 @@ import org.apache.flink.api.common.JobExecutionResult;
 import org.apache.flink.api.dag.Pipeline;
 import org.apache.flink.api.dag.Transformation;
 import org.apache.flink.configuration.Configuration;
-import org.apache.flink.configuration.PipelineOptions;
 import org.apache.flink.core.execution.JobClient;
 import org.apache.flink.table.api.DataTypes;
 import org.apache.flink.table.api.EnvironmentSettings;
@@ -794,9 +793,10 @@ public class TableEnvironmentImpl implements TableEnvironmentInternal {
 
     private TableResult executeInternal(
             List<Transformation<?>> transformations, List<String> sinkIdentifierNames) {
-        String jobName = getJobName("insert-into_" + String.join(",", sinkIdentifierNames));
+        final String defaultJobName = "insert-into_" + String.join(",", sinkIdentifierNames);
         Pipeline pipeline =
-                execEnv.createPipeline(transformations, tableConfig.getConfiguration(), jobName);
+                execEnv.createPipeline(
+                        transformations, tableConfig.getConfiguration(), defaultJobName);
         try {
             JobClient jobClient = execEnv.executeAsync(pipeline);
             final List<Column> columns = new ArrayList<>();
@@ -831,9 +831,10 @@ public class TableEnvironmentImpl implements TableEnvironmentInternal {
                 new CollectModifyOperation(objectIdentifier, operation);
         List<Transformation<?>> transformations =
                 translate(Collections.singletonList(sinkOperation));
-        String jobName = getJobName("collect");
+        final String defaultJobName = "collect";
         Pipeline pipeline =
-                execEnv.createPipeline(transformations, tableConfig.getConfiguration(), jobName);
+                execEnv.createPipeline(
+                        transformations, tableConfig.getConfiguration(), defaultJobName);
         try {
             JobClient jobClient = execEnv.executeAsync(pipeline);
             CollectResultProvider resultProvider = sinkOperation.getSelectResultProvider();
@@ -1593,10 +1594,6 @@ public class TableEnvironmentImpl implements TableEnvironmentInternal {
                             }
                         })
                 .collect(Collectors.toList());
-    }
-
-    private String getJobName(String defaultJobName) {
-        return tableConfig.getConfiguration().getString(PipelineOptions.NAME, defaultJobName);
     }
 
     /** Get catalog from catalogName or throw a ValidationException if the catalog not exists. */

--- a/flink-table/flink-table-api-java/src/main/java/org/apache/flink/table/delegation/Executor.java
+++ b/flink-table/flink-table-api-java/src/main/java/org/apache/flink/table/delegation/Executor.java
@@ -22,6 +22,7 @@ import org.apache.flink.annotation.Internal;
 import org.apache.flink.api.common.JobExecutionResult;
 import org.apache.flink.api.dag.Pipeline;
 import org.apache.flink.api.dag.Transformation;
+import org.apache.flink.configuration.PipelineOptions;
 import org.apache.flink.configuration.ReadableConfig;
 import org.apache.flink.core.execution.JobClient;
 import org.apache.flink.table.api.TableEnvironment;
@@ -50,11 +51,13 @@ public interface Executor {
      *
      * @param transformations list of transformations
      * @param configuration configuration options
-     * @param jobName what should be the name of the job
+     * @param defaultJobName default job name if not specified via {@link PipelineOptions#NAME}
      * @return The pipeline representing the transformations.
      */
     Pipeline createPipeline(
-            List<Transformation<?>> transformations, ReadableConfig configuration, String jobName);
+            List<Transformation<?>> transformations,
+            ReadableConfig configuration,
+            String defaultJobName);
 
     /**
      * Executes the given pipeline.

--- a/flink-table/flink-table-api-java/src/test/java/org/apache/flink/table/utils/ExecutorMock.java
+++ b/flink-table/flink-table-api-java/src/test/java/org/apache/flink/table/utils/ExecutorMock.java
@@ -37,7 +37,9 @@ public class ExecutorMock implements Executor {
 
     @Override
     public Pipeline createPipeline(
-            List<Transformation<?>> transformations, ReadableConfig configuration, String jobName) {
+            List<Transformation<?>> transformations,
+            ReadableConfig configuration,
+            String defaultJobName) {
         return null;
     }
 

--- a/flink-table/flink-table-planner/src/main/java/org/apache/flink/table/planner/utils/DummyStreamExecutionEnvironment.java
+++ b/flink-table/flink-table-planner/src/main/java/org/apache/flink/table/planner/utils/DummyStreamExecutionEnvironment.java
@@ -294,12 +294,6 @@ public class DummyStreamExecutionEnvironment extends StreamExecutionEnvironment 
     }
 
     @Override
-    public StreamGraph getStreamGraph(String jobName) {
-        throw new UnsupportedOperationException(
-                "This is a dummy StreamExecutionEnvironment, getStreamGraph method is unsupported.");
-    }
-
-    @Override
     public String getExecutionPlan() {
         throw new UnsupportedOperationException(
                 "This is a dummy StreamExecutionEnvironment, getExecutionPlan method is unsupported.");

--- a/flink-tests/src/test/java/org/apache/flink/test/checkpointing/ResumeCheckpointManuallyITCase.java
+++ b/flink-tests/src/test/java/org/apache/flink/test/checkpointing/ResumeCheckpointManuallyITCase.java
@@ -374,7 +374,7 @@ public class ResumeCheckpointManuallyITCase extends TestLogger {
                 .reduce((value1, value2) -> Tuple2.of(value1.f0, value1.f1 + value2.f1))
                 .filter(value -> value.f0.startsWith("Tuple 0"));
 
-        StreamGraph streamGraph = env.getStreamGraph("Test");
+        StreamGraph streamGraph = env.getStreamGraph();
 
         JobGraph jobGraph = streamGraph.getJobGraph();
 

--- a/flink-tests/src/test/java/org/apache/flink/test/checkpointing/SavepointITCase.java
+++ b/flink-tests/src/test/java/org/apache/flink/test/checkpointing/SavepointITCase.java
@@ -1173,7 +1173,7 @@ public class SavepointITCase extends TestLogger {
 
         iteration.closeWith(iterationBody);
 
-        StreamGraph streamGraph = env.getStreamGraph("Test");
+        StreamGraph streamGraph = env.getStreamGraph();
 
         JobGraph jobGraph = streamGraph.getJobGraph();
 

--- a/flink-tests/src/test/java/org/apache/flink/test/checkpointing/TimersSavepointITCase.java
+++ b/flink-tests/src/test/java/org/apache/flink/test/checkpointing/TimersSavepointITCase.java
@@ -152,7 +152,7 @@ public class TimersSavepointITCase {
                 TMP_FOLDER.newFolder().toURI().toString());
         config.set(RocksDBOptions.TIMER_SERVICE_FACTORY, priorityQueueStateType);
         env.configure(config, this.getClass().getClassLoader());
-        return env.getStreamGraph("Test", false).getJobGraph();
+        return env.getStreamGraph(false).getJobGraph();
     }
 
     private static String getResourceFilename(String filename) {

--- a/flink-tests/src/test/java/org/apache/flink/test/streaming/runtime/IterateITCase.java
+++ b/flink-tests/src/test/java/org/apache/flink/test/streaming/runtime/IterateITCase.java
@@ -535,11 +535,7 @@ public class IterateITCase extends AbstractTestBase {
 
                 head.addSink(new TestSink()).setParallelism(1);
 
-                assertEquals(
-                        1,
-                        env.getStreamGraph(StreamExecutionEnvironment.DEFAULT_JOB_NAME, false)
-                                .getIterationSourceSinkPairs()
-                                .size());
+                assertEquals(1, env.getStreamGraph(false).getIterationSourceSinkPairs().size());
 
                 env.execute();
 

--- a/flink-tests/src/test/java/org/apache/flink/test/util/TestUtils.java
+++ b/flink-tests/src/test/java/org/apache/flink/test/util/TestUtils.java
@@ -44,7 +44,8 @@ public class TestUtils {
     public static void tryExecute(StreamExecutionEnvironment see, String name) throws Exception {
         JobClient jobClient = null;
         try {
-            StreamGraph graph = see.getStreamGraph(name);
+            StreamGraph graph = see.getStreamGraph();
+            graph.setJobName(name);
             jobClient = see.executeAsync(graph);
             jobClient.getJobExecutionResult().get();
         } catch (Throwable root) {


### PR DESCRIPTION
## What is the purpose of the change

This simplifies the code in `StreamExecutionEnvironment`, `TableEnvironment`, `StreamGraphGenerator` to set the pipeline option for the job name. This simplification also allows for more consistency as the pipeline option is always picked up (e.g. when using `StreamTableEnvironment.executeSql()`).

## Brief change log

- Clean up unused internal methods in `StreamExecutionEnvironment` and `StreamGraphGenerator`
- Rely only on the config option in `StreamGraphGenerator`
- Use the config option in Table API's `DefaultExecutor`


## Verifying this change

This change is already covered by existing tests + new tests for both DataStream API and Table API.

## Does this pull request potentially affect one of the following parts:

  - Dependencies (does it add or upgrade a dependency): no
  - The public API, i.e., is any changed class annotated with `@Public(Evolving)`: yes
  - The serializers: no
  - The runtime per-record code paths (performance sensitive): no
  - Anything that affects deployment or recovery: JobManager (and its components), Checkpointing, Kubernetes/Yarn, ZooKeeper: no
  - The S3 file system connector: no

## Documentation

  - Does this pull request introduce a new feature? no
  - If yes, how is the feature documented? not applicable
