### PR TITLE
[FLINK-23612][table-runtime] Fix compile exception for ROUND function with some numeric input arguments

### DIFF
--- a/flink-table/flink-table-planner/src/main/scala/org/apache/flink/table/planner/codegen/calls/BuiltInMethods.scala
+++ b/flink-table/flink-table-planner/src/main/scala/org/apache/flink/table/planner/codegen/calls/BuiltInMethods.scala
@@ -150,6 +150,12 @@ object BuiltInMethods {
     classOf[Int])
   val ROUND_INT = Types.lookupMethod(classOf[SqlFunctions], "sround", classOf[Int], classOf[Int])
   val ROUND_LONG = Types.lookupMethod(classOf[SqlFunctions], "sround", classOf[Long], classOf[Int])
+  val ROUND_BYTE = Types.lookupMethod(classOf[SqlFunctionUtils], "sround",
+    classOf[Byte], classOf[Int])
+  val ROUND_SHORT = Types.lookupMethod(classOf[SqlFunctionUtils], "sround",
+    classOf[Short], classOf[Int])
+  val ROUND_FLOAT = Types.lookupMethod(classOf[SqlFunctionUtils], "sround",
+    classOf[Float], classOf[Int])
   val ROUND_DEC = Types.lookupMethod(classOf[SqlFunctionUtils], "sround",
     classOf[DecimalData], classOf[Int])
 
@@ -159,6 +165,12 @@ object BuiltInMethods {
     Types.lookupMethod(classOf[SqlFunctionUtils], "sround", classOf[Int])
   val ROUND_LONG_0 =
     Types.lookupMethod(classOf[SqlFunctionUtils], "sround", classOf[Long])
+  val ROUND_BYTE_0 =
+    Types.lookupMethod(classOf[SqlFunctionUtils], "sround", classOf[Byte])
+  val ROUND_SHORT_0 =
+    Types.lookupMethod(classOf[SqlFunctionUtils], "sround", classOf[Short])
+  val ROUND_FLOAT_0 =
+    Types.lookupMethod(classOf[SqlFunctionUtils], "sround", classOf[Float])
   val ROUND_DEC_0 =
     Types.lookupMethod(classOf[SqlFunctionUtils], "sround", classOf[DecimalData])
 

--- a/flink-table/flink-table-planner/src/main/scala/org/apache/flink/table/planner/codegen/calls/FunctionGenerator.scala
+++ b/flink-table/flink-table-planner/src/main/scala/org/apache/flink/table/planner/codegen/calls/FunctionGenerator.scala
@@ -255,6 +255,16 @@ class FunctionGenerator private(config: TableConfig) {
 
   addSqlFunctionMethod(
     ROUND,
+    Seq(TINYINT, INTEGER),
+    BuiltInMethods.ROUND_BYTE)
+
+  addSqlFunctionMethod(
+    ROUND,
+    Seq(SMALLINT, INTEGER),
+    BuiltInMethods.ROUND_SHORT)
+
+  addSqlFunctionMethod(
+    ROUND,
     Seq(BIGINT, INTEGER),
     BuiltInMethods.ROUND_LONG)
 
@@ -270,8 +280,23 @@ class FunctionGenerator private(config: TableConfig) {
 
   addSqlFunctionMethod(
     ROUND,
+    Seq(FLOAT, INTEGER),
+    BuiltInMethods.ROUND_FLOAT)
+
+  addSqlFunctionMethod(
+    ROUND,
     Seq(DOUBLE, INTEGER),
     BuiltInMethods.ROUND_DOUBLE)
+
+  addSqlFunctionMethod(
+    ROUND,
+    Seq(TINYINT),
+    BuiltInMethods.ROUND_BYTE_0)
+
+  addSqlFunctionMethod(
+    ROUND,
+    Seq(SMALLINT),
+    BuiltInMethods.ROUND_SHORT_0)
 
   addSqlFunctionMethod(
     ROUND,
@@ -287,6 +312,11 @@ class FunctionGenerator private(config: TableConfig) {
     ROUND,
     Seq(DECIMAL),
     BuiltInMethods.ROUND_DEC_0)
+
+  addSqlFunctionMethod(
+    ROUND,
+    Seq(FLOAT),
+    BuiltInMethods.ROUND_FLOAT_0)
 
   addSqlFunctionMethod(
     ROUND,

--- a/flink-table/flink-table-planner/src/test/scala/org/apache/flink/table/planner/expressions/ScalarFunctionsTest.scala
+++ b/flink-table/flink-table-planner/src/test/scala/org/apache/flink/table/planner/expressions/ScalarFunctionsTest.scala
@@ -2367,6 +2367,7 @@ class ScalarFunctionsTest extends ScalarTypesTestBase {
 
   @Test
   def testRound(): Unit = {
+    // behavior test
     testAllApis(
       'f29.round('f30),
       "f29.round(f30)",
@@ -2394,6 +2395,122 @@ class ScalarFunctionsTest extends ScalarTypesTestBase {
     testSqlApi(
       "ROUND(1.4, 1)",
       "1.4")
+
+    // type test
+    testAllApis(
+      123.cast(DataTypes.TINYINT).round(-2),
+      "123.cast(BYTE).round(-2)",
+      "ROUND(CAST(123 AS TINYINT), -2)",
+      "100")
+    testSqlApi("ROUND(CAST(123 AS TINYINT))", "123")
+    testAllApis(
+      nullOf(DataTypes.TINYINT).round(-2),
+      "nullOf(BYTE).round(-2)",
+      "ROUND(CAST(NULL AS TINYINT), -2)",
+      "null")
+    testAllApis(
+      123.cast(DataTypes.TINYINT).round(nullOf(DataTypes.INT)),
+      "123.cast(BYTE).round(nullOf(INT))",
+      "ROUND(CAST(123 AS TINYINT), CAST(NULL AS INT))",
+      "null")
+    testSqlApi("ROUND(CAST(NULL AS TINYINT))", "null")
+
+    testAllApis(
+      123.cast(DataTypes.SMALLINT).round(-2),
+      "123.cast(SHORT).round(-2)",
+      "ROUND(CAST(123 AS SMALLINT), -2)",
+      "100")
+    testSqlApi("ROUND(CAST(123 AS SMALLINT))", "123")
+    testAllApis(
+      nullOf(DataTypes.SMALLINT).round(-2),
+      "nullOf(SHORT).round(-2)",
+      "ROUND(CAST(NULL AS SMALLINT), -2)",
+      "null")
+    testAllApis(
+      123.cast(DataTypes.SMALLINT).round(nullOf(DataTypes.INT)),
+      "123.cast(SHORT).round(nullOf(INT))",
+      "ROUND(CAST(123 AS SMALLINT), CAST(NULL AS INT))",
+      "null")
+    testSqlApi("ROUND(CAST(NULL AS SMALLINT))", "null")
+
+    testAllApis(
+      123.cast(DataTypes.INT).round(-2),
+      "123.cast(INT).round(-2)",
+      "ROUND(CAST(123 AS INT), -2)",
+      "100")
+    testSqlApi("ROUND(CAST(123 AS INT))", "123")
+    testAllApis(
+      nullOf(DataTypes.INT).round(-2),
+      "nullOf(INT).round(-2)",
+      "ROUND(CAST(NULL AS INT), -2)",
+      "null")
+    testAllApis(
+      123.cast(DataTypes.INT).round(nullOf(DataTypes.INT)),
+      "123.cast(INT).round(nullOf(INT))",
+      "ROUND(CAST(123 AS INT), CAST(NULL AS INT))",
+      "null")
+    testSqlApi("ROUND(CAST(NULL AS INT))", "null")
+
+    testAllApis(
+      123.cast(DataTypes.BIGINT).round(-2),
+      "123.cast(LONG).round(-2)",
+      "ROUND(CAST(123 AS BIGINT), -2)",
+      "100")
+    testSqlApi("ROUND(CAST(123 AS BIGINT))", "123")
+    testAllApis(
+      nullOf(DataTypes.BIGINT).round(-2),
+      "nullOf(LONG).round(-2)",
+      "ROUND(CAST(NULL AS BIGINT), -2)",
+      "null")
+    testAllApis(
+      123.cast(DataTypes.BIGINT).round(nullOf(DataTypes.INT)),
+      "123.cast(LONG).round(nullOf(INT))",
+      "ROUND(CAST(123 AS BIGINT), CAST(NULL AS INT))",
+      "null")
+    testSqlApi("ROUND(CAST(NULL AS BIGINT))", "null")
+
+    testAllApis(
+      1.2345.cast(DataTypes.FLOAT).round(3),
+      "1.2345.cast(FLOAT).round(3)",
+      "ROUND(CAST(1.2345 AS FLOAT), 3)",
+      "1.235")
+    testSqlApi("ROUND(CAST(1.2345 AS FLOAT))", "1.0")
+    testAllApis(
+      nullOf(DataTypes.FLOAT).round(3),
+      "nullOf(FLOAT).round(3)",
+      "ROUND(CAST(NULL AS FLOAT), 3)",
+      "null")
+    testAllApis(
+      1.2345.cast(DataTypes.FLOAT).round(nullOf(DataTypes.INT)),
+      "1.2345.cast(FLOAT).round(nullOf(INT))",
+      "ROUND(CAST(1.2345 AS FLOAT), CAST(NULL AS INT))",
+      "null")
+    testSqlApi("ROUND(CAST(NULL AS FLOAT))", "null")
+
+    testAllApis(
+      1.2345.cast(DataTypes.DOUBLE).round(3),
+      "1.2345.cast(DOUBLE).round(3)",
+      "ROUND(CAST(1.2345 AS DOUBLE), 3)",
+      "1.235")
+    testSqlApi("ROUND(CAST(1.2345 AS DOUBLE))", "1.0")
+    testAllApis(
+      nullOf(DataTypes.DOUBLE).round(3),
+      "nullOf(DOUBLE).round(3)",
+      "ROUND(CAST(NULL AS DOUBLE), 3)",
+      "null")
+    testAllApis(
+      1.2345.cast(DataTypes.DOUBLE).round(nullOf(DataTypes.INT)),
+      "1.2345.cast(DOUBLE).round(nullOf(INT))",
+      "ROUND(CAST(1.2345 AS DOUBLE), CAST(NULL AS INT))",
+      "null")
+    testSqlApi("ROUND(CAST(NULL AS DOUBLE))", "null")
+
+    // table api string currently does not support decimal type
+    testSqlApi("ROUND(CAST(1.2345 AS DECIMAL(5, 4)), 3)", "1.235")
+    testSqlApi("ROUND(CAST(1.2345 AS DECIMAL(5, 4)))", "1")
+    testSqlApi("ROUND(CAST(NULL AS DECIMAL(5, 4)), 3)", "null")
+    testSqlApi("ROUND(CAST(1.2345 AS DECIMAL(5, 4)), CAST(NULL AS INT))", "null")
+    testSqlApi("ROUND(CAST(NULL AS DECIMAL(5, 4)))", "null")
   }
 
   @Test

--- a/flink-table/flink-table-runtime/src/main/java/org/apache/flink/table/runtime/functions/SqlFunctionUtils.java
+++ b/flink-table/flink-table-runtime/src/main/java/org/apache/flink/table/runtime/functions/SqlFunctionUtils.java
@@ -745,6 +745,26 @@ public class SqlFunctionUtils {
     }
 
     // SQL ROUND
+    /** SQL <code>ROUND</code> operator applied to byte values. */
+    public static byte sround(byte b0) {
+        return sround(b0, 0);
+    }
+
+    /** SQL <code>ROUND</code> operator applied to byte values. */
+    public static byte sround(byte b0, int b1) {
+        return sround(BigDecimal.valueOf(b0), b1).byteValue();
+    }
+
+    /** SQL <code>ROUND</code> operator applied to short values. */
+    public static short sround(short b0) {
+        return sround(b0, 0);
+    }
+
+    /** SQL <code>ROUND</code> operator applied to short values. */
+    public static short sround(short b0, int b1) {
+        return sround(BigDecimal.valueOf(b0), b1).shortValue();
+    }
+
     /** SQL <code>ROUND</code> operator applied to int values. */
     public static int sround(int b0) {
         return sround(b0, 0);
@@ -773,6 +793,16 @@ public class SqlFunctionUtils {
     /** SQL <code>ROUND</code> operator applied to BigDecimal values. */
     public static BigDecimal sround(BigDecimal b0, int b1) {
         return b0.movePointRight(b1).setScale(0, RoundingMode.HALF_UP).movePointLeft(b1);
+    }
+
+    /** SQL <code>ROUND</code> operator applied to float values. */
+    public static float sround(float b0) {
+        return sround(b0, 0);
+    }
+
+    /** SQL <code>ROUND</code> operator applied to float values. */
+    public static float sround(float b0, int b1) {
+        return sround(BigDecimal.valueOf(b0), b1).floatValue();
     }
 
     /** SQL <code>ROUND</code> operator applied to double values. */


### PR DESCRIPTION
## What is the purpose of the change

`ROUND` SQL function accepts any numeric type as the first input argument. However when the first argument is of `TINYINT` / `SMALLINT` / `FLOAT` type the generated code fails to compile as we haven't implemented the round function for these types.

This PR fixes this issue.

## Brief change log

- Fix compile exception for ROUND function with some numeric input arguments

## Verifying this change

This change added tests and can be verified by running the added tests.

## Does this pull request potentially affect one of the following parts:

  - Dependencies (does it add or upgrade a dependency): no
  - The public API, i.e., is any changed class annotated with `@Public(Evolving)`: no
  - The serializers: no
  - The runtime per-record code paths (performance sensitive): no
  - Anything that affects deployment or recovery: JobManager (and its components), Checkpointing, Kubernetes/Yarn, ZooKeeper: no
  - The S3 file system connector: no

## Documentation

  - Does this pull request introduce a new feature? no
  - If yes, how is the feature documented? not applicable
