### PR TITLE
[FLINK-23626] [Runtime / Metrics] Migrate all TaskMG instantiations to factory method

### DIFF
--- a/flink-metrics/flink-metrics-prometheus/src/test/java/org/apache/flink/metrics/prometheus/PrometheusReporterTaskScopeTest.java
+++ b/flink-metrics/flink-metrics-prometheus/src/test/java/org/apache/flink/metrics/prometheus/PrometheusReporterTaskScopeTest.java
@@ -122,19 +122,11 @@ public class PrometheusReporterTaskScopeTest {
         TaskManagerJobMetricGroup tmJobMetricGroup =
                 new TaskManagerJobMetricGroup(registry, tmMetricGroup, jobId, JOB_NAME);
         taskMetricGroup1 =
-            tmJobMetricGroup.addTask(
-                        taskId1,
-                        taskAttemptId1,
-                        TASK_NAME,
-                        SUBTASK_INDEX_1,
-                        ATTEMPT_NUMBER);
+                tmJobMetricGroup.addTask(
+                        taskId1, taskAttemptId1, TASK_NAME, SUBTASK_INDEX_1, ATTEMPT_NUMBER);
         taskMetricGroup2 =
-            tmJobMetricGroup.addTask(
-                        taskId2,
-                        taskAttemptId2,
-                        TASK_NAME,
-                        SUBTASK_INDEX_2,
-                        ATTEMPT_NUMBER);
+                tmJobMetricGroup.addTask(
+                        taskId2, taskAttemptId2, TASK_NAME, SUBTASK_INDEX_2, ATTEMPT_NUMBER);
     }
 
     @After

--- a/flink-metrics/flink-metrics-prometheus/src/test/java/org/apache/flink/metrics/prometheus/PrometheusReporterTaskScopeTest.java
+++ b/flink-metrics/flink-metrics-prometheus/src/test/java/org/apache/flink/metrics/prometheus/PrometheusReporterTaskScopeTest.java
@@ -122,18 +122,14 @@ public class PrometheusReporterTaskScopeTest {
         TaskManagerJobMetricGroup tmJobMetricGroup =
                 new TaskManagerJobMetricGroup(registry, tmMetricGroup, jobId, JOB_NAME);
         taskMetricGroup1 =
-                new TaskMetricGroup(
-                        registry,
-                        tmJobMetricGroup,
+            tmJobMetricGroup.addTask(
                         taskId1,
                         taskAttemptId1,
                         TASK_NAME,
                         SUBTASK_INDEX_1,
                         ATTEMPT_NUMBER);
         taskMetricGroup2 =
-                new TaskMetricGroup(
-                        registry,
-                        tmJobMetricGroup,
+            tmJobMetricGroup.addTask(
                         taskId2,
                         taskAttemptId2,
                         TASK_NAME,

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/metrics/groups/TaskManagerJobMetricGroup.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/metrics/groups/TaskManagerJobMetricGroup.java
@@ -85,7 +85,7 @@ public class TaskManagerJobMetricGroup extends JobMetricGroup<TaskManagerMetricG
                     return prior;
                 } else {
                     TaskMetricGroup task =
-                            new TaskMetricGroup(
+                            TaskMetricGroup.createTaskMetricGroup(
                                     registry,
                                     this,
                                     jobVertexId,

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/metrics/groups/TaskManagerJobMetricGroup.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/metrics/groups/TaskManagerJobMetricGroup.java
@@ -85,7 +85,7 @@ public class TaskManagerJobMetricGroup extends JobMetricGroup<TaskManagerMetricG
                     return prior;
                 } else {
                     TaskMetricGroup task =
-                            TaskMetricGroup.createTaskMetricGroup(
+                            new TaskMetricGroup(
                                     registry,
                                     this,
                                     jobVertexId,

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/metrics/groups/TaskMetricGroup.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/metrics/groups/TaskMetricGroup.java
@@ -94,18 +94,6 @@ public class TaskMetricGroup extends ComponentMetricGroup<TaskManagerJobMetricGr
         this.ioMetrics = new TaskIOMetricGroup(this);
     }
 
-    public static TaskMetricGroup createTaskMetricGroup(
-            MetricRegistry registry,
-            TaskManagerJobMetricGroup parent,
-            JobVertexID vertexId,
-            ExecutionAttemptID executionId,
-            String taskName,
-            int subtaskIndex,
-            int attemptNumber) {
-        return new TaskMetricGroup(
-                registry, parent, vertexId, executionId, taskName, subtaskIndex, attemptNumber);
-    }
-
     // ------------------------------------------------------------------------
     //  properties
     // ------------------------------------------------------------------------

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/metrics/groups/TaskMetricGroup.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/metrics/groups/TaskMetricGroup.java
@@ -64,7 +64,7 @@ public class TaskMetricGroup extends ComponentMetricGroup<TaskManagerJobMetricGr
 
     // ------------------------------------------------------------------------
 
-    public TaskMetricGroup(
+    TaskMetricGroup(
             MetricRegistry registry,
             TaskManagerJobMetricGroup parent,
             JobVertexID vertexId,
@@ -92,6 +92,18 @@ public class TaskMetricGroup extends ComponentMetricGroup<TaskManagerJobMetricGr
         this.attemptNumber = attemptNumber;
 
         this.ioMetrics = new TaskIOMetricGroup(this);
+    }
+
+    public static TaskMetricGroup createTaskMetricGroup(
+            MetricRegistry registry,
+            TaskManagerJobMetricGroup parent,
+            JobVertexID vertexId,
+            ExecutionAttemptID executionId,
+            String taskName,
+            int subtaskIndex,
+            int attemptNumber) {
+        return new TaskMetricGroup(
+                registry, parent, vertexId, executionId, taskName, subtaskIndex, attemptNumber);
     }
 
     // ------------------------------------------------------------------------

--- a/flink-runtime/src/test/java/org/apache/flink/runtime/metrics/groups/MetricGroupTest.java
+++ b/flink-runtime/src/test/java/org/apache/flink/runtime/metrics/groups/MetricGroupTest.java
@@ -339,7 +339,8 @@ public class MetricGroupTest extends TestLogger {
         MetricRegistryImpl registry = new MetricRegistryImpl(defaultMetricRegistryConfiguration);
         TaskManagerMetricGroup tm = new TaskManagerMetricGroup(registry, "host", "id");
         TaskManagerJobMetricGroup job = new TaskManagerJobMetricGroup(registry, tm, jid, "jobname");
-        TaskMetricGroup task = new TaskMetricGroup(registry, job, vid, eid, "taskName", 4, 5);
+        TaskMetricGroup task =
+                TaskMetricGroup.createTaskMetricGroup(registry, job, vid, eid, "taskName", 4, 5);
         GenericMetricGroup userGroup1 = new GenericMetricGroup(registry, task, "hello");
         GenericMetricGroup userGroup2 = new GenericMetricGroup(registry, userGroup1, "world");
 

--- a/flink-runtime/src/test/java/org/apache/flink/runtime/metrics/groups/MetricGroupTest.java
+++ b/flink-runtime/src/test/java/org/apache/flink/runtime/metrics/groups/MetricGroupTest.java
@@ -339,8 +339,7 @@ public class MetricGroupTest extends TestLogger {
         MetricRegistryImpl registry = new MetricRegistryImpl(defaultMetricRegistryConfiguration);
         TaskManagerMetricGroup tm = new TaskManagerMetricGroup(registry, "host", "id");
         TaskManagerJobMetricGroup job = new TaskManagerJobMetricGroup(registry, tm, jid, "jobname");
-        TaskMetricGroup task =
-                TaskMetricGroup.createTaskMetricGroup(registry, job, vid, eid, "taskName", 4, 5);
+        TaskMetricGroup task = job.addTask(vid, eid, "taskName", 4, 5);
         GenericMetricGroup userGroup1 = new GenericMetricGroup(registry, task, "hello");
         GenericMetricGroup userGroup2 = new GenericMetricGroup(registry, userGroup1, "world");
 

--- a/flink-runtime/src/test/java/org/apache/flink/runtime/metrics/groups/OperatorGroupTest.java
+++ b/flink-runtime/src/test/java/org/apache/flink/runtime/metrics/groups/OperatorGroupTest.java
@@ -67,14 +67,7 @@ public class OperatorGroupTest extends TestLogger {
         TaskManagerJobMetricGroup jmGroup =
                 new TaskManagerJobMetricGroup(registry, tmGroup, new JobID(), "myJobName");
         TaskMetricGroup taskGroup =
-                TaskMetricGroup.createTaskMetricGroup(
-                        registry,
-                        jmGroup,
-                        new JobVertexID(),
-                        new ExecutionAttemptID(),
-                        "aTaskName",
-                        11,
-                        0);
+                jmGroup.addTask(new JobVertexID(), new ExecutionAttemptID(), "aTaskName", 11, 0);
         OperatorMetricGroup opGroup =
                 new OperatorMetricGroup(registry, taskGroup, new OperatorID(), "myOpName");
 
@@ -142,14 +135,7 @@ public class OperatorGroupTest extends TestLogger {
         TaskManagerJobMetricGroup jmGroup =
                 new TaskManagerJobMetricGroup(registry, tmGroup, new JobID(), "myJobName");
         TaskMetricGroup taskGroup =
-                TaskMetricGroup.createTaskMetricGroup(
-                        registry,
-                        jmGroup,
-                        new JobVertexID(),
-                        new ExecutionAttemptID(),
-                        "aTaskName",
-                        11,
-                        0);
+                jmGroup.addTask(new JobVertexID(), new ExecutionAttemptID(), "aTaskName", 11, 0);
         OperatorMetricGroup opGroup =
                 new OperatorMetricGroup(registry, taskGroup, new OperatorID(), "myOpName");
 
@@ -169,8 +155,7 @@ public class OperatorGroupTest extends TestLogger {
                 new TaskManagerMetricGroup(registry, "theHostName", "test-tm-id");
         TaskManagerJobMetricGroup jmGroup =
                 new TaskManagerJobMetricGroup(registry, tmGroup, jid, "myJobName");
-        TaskMetricGroup taskGroup =
-                TaskMetricGroup.createTaskMetricGroup(registry, jmGroup, tid, eid, "aTaskName", 11, 0);
+        TaskMetricGroup taskGroup = jmGroup.addTask(tid, eid, "aTaskName", 11, 0);
         OperatorMetricGroup opGroup = new OperatorMetricGroup(registry, taskGroup, oid, "myOpName");
 
         Map<String, String> variables = opGroup.getAllVariables();
@@ -203,8 +188,7 @@ public class OperatorGroupTest extends TestLogger {
         OperatorID oid = new OperatorID();
         TaskManagerMetricGroup tm = new TaskManagerMetricGroup(registry, "host", "id");
         TaskManagerJobMetricGroup job = new TaskManagerJobMetricGroup(registry, tm, jid, "jobname");
-        TaskMetricGroup task =
-                TaskMetricGroup.createTaskMetricGroup(registry, job, vid, eid, "taskName", 4, 5);
+        TaskMetricGroup task = job.addTask(vid, eid, "taskName", 4, 5);
         OperatorMetricGroup operator = new OperatorMetricGroup(registry, task, oid, "operator");
 
         QueryScopeInfo.OperatorQueryScopeInfo info =

--- a/flink-runtime/src/test/java/org/apache/flink/runtime/metrics/groups/OperatorGroupTest.java
+++ b/flink-runtime/src/test/java/org/apache/flink/runtime/metrics/groups/OperatorGroupTest.java
@@ -67,7 +67,7 @@ public class OperatorGroupTest extends TestLogger {
         TaskManagerJobMetricGroup jmGroup =
                 new TaskManagerJobMetricGroup(registry, tmGroup, new JobID(), "myJobName");
         TaskMetricGroup taskGroup =
-                new TaskMetricGroup(
+                TaskMetricGroup.createTaskMetricGroup(
                         registry,
                         jmGroup,
                         new JobVertexID(),
@@ -142,7 +142,7 @@ public class OperatorGroupTest extends TestLogger {
         TaskManagerJobMetricGroup jmGroup =
                 new TaskManagerJobMetricGroup(registry, tmGroup, new JobID(), "myJobName");
         TaskMetricGroup taskGroup =
-                new TaskMetricGroup(
+                TaskMetricGroup.createTaskMetricGroup(
                         registry,
                         jmGroup,
                         new JobVertexID(),
@@ -170,7 +170,7 @@ public class OperatorGroupTest extends TestLogger {
         TaskManagerJobMetricGroup jmGroup =
                 new TaskManagerJobMetricGroup(registry, tmGroup, jid, "myJobName");
         TaskMetricGroup taskGroup =
-                new TaskMetricGroup(registry, jmGroup, tid, eid, "aTaskName", 11, 0);
+                TaskMetricGroup.createTaskMetricGroup(registry, jmGroup, tid, eid, "aTaskName", 11, 0);
         OperatorMetricGroup opGroup = new OperatorMetricGroup(registry, taskGroup, oid, "myOpName");
 
         Map<String, String> variables = opGroup.getAllVariables();
@@ -203,7 +203,8 @@ public class OperatorGroupTest extends TestLogger {
         OperatorID oid = new OperatorID();
         TaskManagerMetricGroup tm = new TaskManagerMetricGroup(registry, "host", "id");
         TaskManagerJobMetricGroup job = new TaskManagerJobMetricGroup(registry, tm, jid, "jobname");
-        TaskMetricGroup task = new TaskMetricGroup(registry, job, vid, eid, "taskName", 4, 5);
+        TaskMetricGroup task =
+                TaskMetricGroup.createTaskMetricGroup(registry, job, vid, eid, "taskName", 4, 5);
         OperatorMetricGroup operator = new OperatorMetricGroup(registry, task, oid, "operator");
 
         QueryScopeInfo.OperatorQueryScopeInfo info =

--- a/flink-runtime/src/test/java/org/apache/flink/runtime/metrics/groups/TaskMetricGroupTest.java
+++ b/flink-runtime/src/test/java/org/apache/flink/runtime/metrics/groups/TaskMetricGroupTest.java
@@ -70,8 +70,7 @@ public class TaskMetricGroupTest extends TestLogger {
         TaskManagerJobMetricGroup jmGroup =
                 new TaskManagerJobMetricGroup(registry, tmGroup, new JobID(), "myJobName");
         TaskMetricGroup taskGroup =
-                TaskMetricGroup.createTaskMetricGroup(registry, jmGroup, new JobVertexID(), new ExecutionAttemptID(), 
-                    "aTaskName", 13, 2);
+                jmGroup.addTask(new JobVertexID(), new ExecutionAttemptID(), "aTaskName", 13, 2);
 
         assertArrayEquals(
                 new String[] {
@@ -102,8 +101,7 @@ public class TaskMetricGroupTest extends TestLogger {
                 new TaskManagerMetricGroup(registry, "theHostName", "test-tm-id");
         TaskManagerJobMetricGroup jmGroup =
                 new TaskManagerJobMetricGroup(registry, tmGroup, jid, "myJobName");
-        TaskMetricGroup taskGroup =
-                TaskMetricGroup.createTaskMetricGroup(registry, jmGroup, vertexId, executionId, "aTaskName", 13, 2);
+        TaskMetricGroup taskGroup = jmGroup.addTask(vertexId, executionId, "aTaskName", 13, 2);
 
         assertArrayEquals(
                 new String[] {
@@ -132,8 +130,7 @@ public class TaskMetricGroupTest extends TestLogger {
                 new TaskManagerJobMetricGroup(registry, tmGroup, new JobID(), "myJobName");
 
         TaskMetricGroup taskGroup =
-                TaskMetricGroup.createTaskMetricGroup(
-                        registry, jmGroup, new JobVertexID(), executionId, "aTaskName", 13, 1);
+                jmGroup.addTask(new JobVertexID(), executionId, "aTaskName", 13, 1);
 
         assertArrayEquals(
                 new String[] {
@@ -159,8 +156,7 @@ public class TaskMetricGroupTest extends TestLogger {
         ExecutionAttemptID eid = new ExecutionAttemptID();
         TaskManagerMetricGroup tm = new TaskManagerMetricGroup(registry, "host", "id");
         TaskManagerJobMetricGroup job = new TaskManagerJobMetricGroup(registry, tm, jid, "jobname");
-        TaskMetricGroup task =
-                TaskMetricGroup.createTaskMetricGroup(registry, job, vid, eid, "taskName", 4, 5);
+        TaskMetricGroup task = job.addTask(vid, eid, "taskName", 4, 5);
 
         QueryScopeInfo.TaskQueryScopeInfo info =
                 task.createQueryServiceMetricInfo(new DummyCharacterFilter());
@@ -178,14 +174,8 @@ public class TaskMetricGroupTest extends TestLogger {
         TaskManagerJobMetricGroup taskManagerJobMetricGroup =
                 new TaskManagerJobMetricGroup(registry, taskManagerMetricGroup, new JobID(), "job");
         TaskMetricGroup taskMetricGroup =
-                TaskMetricGroup.createTaskMetricGroup(
-                        registry,
-                        taskManagerJobMetricGroup,
-                        new JobVertexID(),
-                        new ExecutionAttemptID(),
-                        "task",
-                        0,
-                        0);
+                taskManagerJobMetricGroup.addTask(
+                        new JobVertexID(), new ExecutionAttemptID(), "task", 0, 0);
 
         // the io metric should have registered predefined metrics
         assertTrue(registry.getNumberRegisteredMetrics() > 0);
@@ -208,8 +198,7 @@ public class TaskMetricGroupTest extends TestLogger {
         TaskManagerJobMetricGroup job =
                 new TaskManagerJobMetricGroup(registry, tm, new JobID(), "jobname");
         TaskMetricGroup taskMetricGroup =
-                TaskMetricGroup.createTaskMetricGroup(
-                        registry, job, new JobVertexID(), new ExecutionAttemptID(), "task", 0, 0);
+                job.addTask(new JobVertexID(), new ExecutionAttemptID(), "task", 0, 0);
 
         String originalName = new String(new char[100]).replace("\0", "-");
         OperatorMetricGroup operatorMetricGroup = taskMetricGroup.getOrAddOperator(originalName);

--- a/flink-runtime/src/test/java/org/apache/flink/runtime/metrics/groups/TaskMetricGroupTest.java
+++ b/flink-runtime/src/test/java/org/apache/flink/runtime/metrics/groups/TaskMetricGroupTest.java
@@ -65,15 +65,13 @@ public class TaskMetricGroupTest extends TestLogger {
 
     @Test
     public void testGenerateScopeDefault() {
-        JobVertexID vertexId = new JobVertexID();
-        ExecutionAttemptID executionId = new ExecutionAttemptID();
-
         TaskManagerMetricGroup tmGroup =
                 new TaskManagerMetricGroup(registry, "theHostName", "test-tm-id");
         TaskManagerJobMetricGroup jmGroup =
                 new TaskManagerJobMetricGroup(registry, tmGroup, new JobID(), "myJobName");
         TaskMetricGroup taskGroup =
-                new TaskMetricGroup(registry, jmGroup, vertexId, executionId, "aTaskName", 13, 2);
+                TaskMetricGroup.createTaskMetricGroup(registry, jmGroup, new JobVertexID(), new ExecutionAttemptID(), 
+                    "aTaskName", 13, 2);
 
         assertArrayEquals(
                 new String[] {
@@ -105,7 +103,7 @@ public class TaskMetricGroupTest extends TestLogger {
         TaskManagerJobMetricGroup jmGroup =
                 new TaskManagerJobMetricGroup(registry, tmGroup, jid, "myJobName");
         TaskMetricGroup taskGroup =
-                new TaskMetricGroup(registry, jmGroup, vertexId, executionId, "aTaskName", 13, 2);
+                TaskMetricGroup.createTaskMetricGroup(registry, jmGroup, vertexId, executionId, "aTaskName", 13, 2);
 
         assertArrayEquals(
                 new String[] {
@@ -134,7 +132,7 @@ public class TaskMetricGroupTest extends TestLogger {
                 new TaskManagerJobMetricGroup(registry, tmGroup, new JobID(), "myJobName");
 
         TaskMetricGroup taskGroup =
-                new TaskMetricGroup(
+                TaskMetricGroup.createTaskMetricGroup(
                         registry, jmGroup, new JobVertexID(), executionId, "aTaskName", 13, 1);
 
         assertArrayEquals(
@@ -161,7 +159,8 @@ public class TaskMetricGroupTest extends TestLogger {
         ExecutionAttemptID eid = new ExecutionAttemptID();
         TaskManagerMetricGroup tm = new TaskManagerMetricGroup(registry, "host", "id");
         TaskManagerJobMetricGroup job = new TaskManagerJobMetricGroup(registry, tm, jid, "jobname");
-        TaskMetricGroup task = new TaskMetricGroup(registry, job, vid, eid, "taskName", 4, 5);
+        TaskMetricGroup task =
+                TaskMetricGroup.createTaskMetricGroup(registry, job, vid, eid, "taskName", 4, 5);
 
         QueryScopeInfo.TaskQueryScopeInfo info =
                 task.createQueryServiceMetricInfo(new DummyCharacterFilter());
@@ -179,7 +178,7 @@ public class TaskMetricGroupTest extends TestLogger {
         TaskManagerJobMetricGroup taskManagerJobMetricGroup =
                 new TaskManagerJobMetricGroup(registry, taskManagerMetricGroup, new JobID(), "job");
         TaskMetricGroup taskMetricGroup =
-                new TaskMetricGroup(
+                TaskMetricGroup.createTaskMetricGroup(
                         registry,
                         taskManagerJobMetricGroup,
                         new JobVertexID(),
@@ -209,7 +208,7 @@ public class TaskMetricGroupTest extends TestLogger {
         TaskManagerJobMetricGroup job =
                 new TaskManagerJobMetricGroup(registry, tm, new JobID(), "jobname");
         TaskMetricGroup taskMetricGroup =
-                new TaskMetricGroup(
+                TaskMetricGroup.createTaskMetricGroup(
                         registry, job, new JobVertexID(), new ExecutionAttemptID(), "task", 0, 0);
 
         String originalName = new String(new char[100]).replace("\0", "-");

--- a/flink-runtime/src/test/java/org/apache/flink/runtime/operators/chaining/ChainedOperatorsMetricTest.java
+++ b/flink-runtime/src/test/java/org/apache/flink/runtime/operators/chaining/ChainedOperatorsMetricTest.java
@@ -75,7 +75,7 @@ public class ChainedOperatorsMetricTest extends TaskTestBase {
                         .setInputSplitProvider(this.inputSplitProvider)
                         .setBufferSize(NETWORK_BUFFER_SIZE)
                         .setMetricGroup(
-                                new TaskMetricGroup(
+                                TaskMetricGroup.createTaskMetricGroup(
                                         NoOpMetricRegistry.INSTANCE,
                                         UnregisteredMetricGroups
                                                 .createUnregisteredTaskManagerJobMetricGroup(),

--- a/flink-runtime/src/test/java/org/apache/flink/runtime/operators/chaining/ChainedOperatorsMetricTest.java
+++ b/flink-runtime/src/test/java/org/apache/flink/runtime/operators/chaining/ChainedOperatorsMetricTest.java
@@ -18,6 +18,7 @@
 
 package org.apache.flink.runtime.operators.chaining;
 
+import org.apache.flink.api.common.JobID;
 import org.apache.flink.api.common.functions.FlatMapFunction;
 import org.apache.flink.api.common.functions.RichFlatMapFunction;
 import org.apache.flink.api.common.operators.util.UserCodeClassWrapper;
@@ -30,6 +31,7 @@ import org.apache.flink.runtime.metrics.NoOpMetricRegistry;
 import org.apache.flink.runtime.metrics.groups.OperatorIOMetricGroup;
 import org.apache.flink.runtime.metrics.groups.OperatorMetricGroup;
 import org.apache.flink.runtime.metrics.groups.TaskIOMetricGroup;
+import org.apache.flink.runtime.metrics.groups.TaskManagerJobMetricGroup;
 import org.apache.flink.runtime.metrics.groups.TaskMetricGroup;
 import org.apache.flink.runtime.metrics.groups.UnregisteredMetricGroups;
 import org.apache.flink.runtime.operators.BatchTask;
@@ -68,6 +70,7 @@ public class ChainedOperatorsMetricTest extends TaskTestBase {
     public void testOperatorIOMetricReuse() throws Exception {
         // environment
         initEnvironment(MEMORY_MANAGER_SIZE, NETWORK_BUFFER_SIZE);
+
         this.mockEnv =
                 new MockEnvironmentBuilder()
                         .setTaskName(HEAD_OPERATOR_NAME)
@@ -75,15 +78,18 @@ public class ChainedOperatorsMetricTest extends TaskTestBase {
                         .setInputSplitProvider(this.inputSplitProvider)
                         .setBufferSize(NETWORK_BUFFER_SIZE)
                         .setMetricGroup(
-                                TaskMetricGroup.createTaskMetricGroup(
-                                        NoOpMetricRegistry.INSTANCE,
-                                        UnregisteredMetricGroups
-                                                .createUnregisteredTaskManagerJobMetricGroup(),
-                                        new JobVertexID(),
-                                        new ExecutionAttemptID(),
-                                        "task",
-                                        0,
-                                        0))
+                                new TaskManagerJobMetricGroup(
+                                                NoOpMetricRegistry.INSTANCE,
+                                                UnregisteredMetricGroups
+                                                        .createUnregisteredTaskManagerMetricGroup(),
+                                                new JobID(0, 0),
+                                                "UnregisteredJob")
+                                        .addTask(
+                                                new JobVertexID(),
+                                                new ExecutionAttemptID(),
+                                                "task",
+                                                0,
+                                                0))
                         .build();
 
         final int keyCnt = 100;

--- a/flink-runtime/src/test/java/org/apache/flink/runtime/operators/chaining/ChainedOperatorsMetricTest.java
+++ b/flink-runtime/src/test/java/org/apache/flink/runtime/operators/chaining/ChainedOperatorsMetricTest.java
@@ -78,13 +78,13 @@ public class ChainedOperatorsMetricTest extends TaskTestBase {
                         .setInputSplitProvider(this.inputSplitProvider)
                         .setBufferSize(NETWORK_BUFFER_SIZE)
                         .setMetricGroup(
-                                new TaskManagerJobMetricGroup(
+                                MetricUtils.createTaskManagerMetricGroup(
                                                 NoOpMetricRegistry.INSTANCE,
-                                                UnregisteredMetricGroups
-                                                        .createUnregisteredTaskManagerMetricGroup(),
-                                                new JobID(0, 0),
-                                                "UnregisteredJob")
-                                        .addTask(
+                                                "host",
+                                                ResourceID.generate())
+                                        .addTaskForJob(
+                                                new JobID(),
+                                                "jobname",
                                                 new JobVertexID(),
                                                 new ExecutionAttemptID(),
                                                 "task",

--- a/flink-runtime/src/test/java/org/apache/flink/runtime/operators/chaining/ChainedOperatorsMetricTest.java
+++ b/flink-runtime/src/test/java/org/apache/flink/runtime/operators/chaining/ChainedOperatorsMetricTest.java
@@ -25,15 +25,15 @@ import org.apache.flink.api.common.operators.util.UserCodeClassWrapper;
 import org.apache.flink.api.common.typeutils.TypeSerializerFactory;
 import org.apache.flink.configuration.Configuration;
 import org.apache.flink.metrics.Counter;
+import org.apache.flink.runtime.clusterframework.types.ResourceID;
 import org.apache.flink.runtime.executiongraph.ExecutionAttemptID;
 import org.apache.flink.runtime.jobgraph.JobVertexID;
 import org.apache.flink.runtime.metrics.NoOpMetricRegistry;
 import org.apache.flink.runtime.metrics.groups.OperatorIOMetricGroup;
 import org.apache.flink.runtime.metrics.groups.OperatorMetricGroup;
 import org.apache.flink.runtime.metrics.groups.TaskIOMetricGroup;
-import org.apache.flink.runtime.metrics.groups.TaskManagerJobMetricGroup;
 import org.apache.flink.runtime.metrics.groups.TaskMetricGroup;
-import org.apache.flink.runtime.metrics.groups.UnregisteredMetricGroups;
+import org.apache.flink.runtime.metrics.util.MetricUtils;
 import org.apache.flink.runtime.operators.BatchTask;
 import org.apache.flink.runtime.operators.DriverStrategy;
 import org.apache.flink.runtime.operators.FlatMapDriver;
@@ -84,7 +84,7 @@ public class ChainedOperatorsMetricTest extends TaskTestBase {
                                                 ResourceID.generate())
                                         .addTaskForJob(
                                                 new JobID(),
-                                                "jobname",
+                                                "jobName",
                                                 new JobVertexID(),
                                                 new ExecutionAttemptID(),
                                                 "task",


### PR DESCRIPTION
## What is the purpose of the change

Modify all existing usages of the TaskMG constructor to use runtime Apis, for consistency and to make constructor changes easier.


## Brief change log



## Verifying this change

This change is already covered by existing tests, such as *(please describe tests)*.


## Does this pull request potentially affect one of the following parts:

  - Dependencies (does it add or upgrade a dependency): no
  - The public API, i.e., is any changed class annotated with `@Public(Evolving)`: no
  - The serializers: no
  - The runtime per-record code paths (performance sensitive): no
  - Anything that affects deployment or recovery: JobManager (and its components), Checkpointing, Kubernetes/Yarn, ZooKeeper: no
  - The S3 file system connector: no

## Documentation

  - Does this pull request introduce a new feature? no