### PR TITLE
[FLINK-23208] let late processing timers fired immediately

### DIFF
--- a/flink-streaming-java/src/main/java/org/apache/flink/streaming/runtime/tasks/ProcessingTimeServiceUtil.java
+++ b/flink-streaming-java/src/main/java/org/apache/flink/streaming/runtime/tasks/ProcessingTimeServiceUtil.java
@@ -34,9 +34,19 @@ public class ProcessingTimeServiceUtil {
      */
     public static long getProcessingTimeDelay(long processingTimestamp, long currentTimestamp) {
 
-        // delay the firing of the timer by 1 ms to align the semantics with watermark. A watermark
-        // T says we won't see elements in the future with a timestamp smaller or equal to T.
-        // With processing time, we therefore need to delay firing the timer by one ms.
-        return Math.max(processingTimestamp - currentTimestamp, 0) + 1;
+        // Two cases of timers here:
+        // (1) future/now timers(processingTimestamp >= currentTimestamp): delay the firing of the
+        //   timer by 1 ms to align the semantics with watermark. A watermark T says we won't see
+        //   elements in the future with a timestamp smaller or equal to T. With processing time, we
+        //   therefore need to delay firing the timer by one ms.
+        // (2) past timers(processingTimestamp < currentTimestamp): do not need to delay the firing
+        //   because currentTimestamp is larger than processingTimestamp pluses the 1ms offset.
+        // TODO. The processing timers' performance can be further improved.
+        //   see FLINK-23690 and https://github.com/apache/flink/pull/16744
+        if (processingTimestamp >= currentTimestamp) {
+            return processingTimestamp - currentTimestamp + 1;
+        } else {
+            return 0;
+        }
     }
 }


### PR DESCRIPTION
## What is the purpose of the change

Currently late timers need to wait 1ms at least to be fired which may decrease the whole job's throughput. (see benchmarks in https://github.com/apache/flink-benchmarks/pull/25)

## Brief change log

* In `InternalTimerServiceImpl.onProcessingTime(long)`, we fire all late timers(timer's timestamp < now() - 1ms) directly.

## Verifying this change

The benchmark uses [ProcessingTimerBenchmark.java](https://github.com/apache/flink-benchmarks/blob/master/src/main/java/org/apache/flink/benchmark/ProcessingTimerBenchmark.java).

Before the change:

```
Result "org.apache.flink.benchmark.ProcessingTimerBenchmark.fireProcessingTimers":
  0.683 ±(99.9%) 0.010 ops/ms [Average]
  (min, avg, max) = (0.659, 0.683, 0.730), stdev = 0.015
  CI (99.9%): [0.673, 0.692] (assumes normal distribution)


# Run complete. Total time: 00:01:37

Benchmark                                       Mode  Cnt  Score   Error   Units
ProcessingTimerBenchmark.fireProcessingTimers  thrpt   30  0.683 ± 0.010  ops/ms

Benchmark result is saved to jmh-result.csv
```

After the change:
```

Result "org.apache.flink.benchmark.ProcessingTimerBenchmark.fireProcessingTimers":
  8.427 ±(99.9%) 0.104 ops/ms [Average]
  (min, avg, max) = (7.912, 8.427, 8.726), stdev = 0.156
  CI (99.9%): [8.323, 8.532] (assumes normal distribution)


# Run complete. Total time: 00:01:15

Benchmark                                       Mode  Cnt  Score   Error   Units
ProcessingTimerBenchmark.fireProcessingTimers  thrpt   30  8.427 ± 0.104  ops/ms

Benchmark result is saved to jmh-result.csv
```

## Does this pull request potentially affect one of the following parts:

  - Dependencies (does it add or upgrade a dependency): no
  - The public API, i.e., is any changed class annotated with `@Public(Evolving)`: no
  - The serializers: no
  - The runtime per-record code paths (performance sensitive): yes
  - Anything that affects deployment or recovery: JobManager (and its components), Checkpointing, Kubernetes/Yarn, ZooKeeper: no
  - The S3 file system connector: no

## Documentation

  - Does this pull request introduce a new feature? no
  - If yes, how is the feature documented? not applicable
