### PR TITLE
[FLINK-22246]when use HiveCatalog create table , can't set Table owne…

### DIFF
--- a/flink-connectors/flink-connector-hive/src/main/java/org/apache/flink/table/catalog/hive/HiveCatalog.java
+++ b/flink-connectors/flink-connector-hive/src/main/java/org/apache/flink/table/catalog/hive/HiveCatalog.java
@@ -150,6 +150,7 @@ public class HiveCatalog extends AbstractCatalog {
 
     private static final Logger LOG = LoggerFactory.getLogger(HiveCatalog.class);
     public static final String HIVE_SITE_FILE = "hive-site.xml";
+    private static final String HIVE_AUTHORIZATION_ENABLED = "hive.security.authorization.enabled";
 
     // Prefix used to distinguish scala/python functions
     private static final String FLINK_SCALA_FUNCTION_PREFIX = "flink:scala:";
@@ -311,10 +312,12 @@ public class HiveCatalog extends AbstractCatalog {
         }
 
         try {
-            if (UserGroupInformation.isSecurityEnabled()) {
-                userName = UserGroupInformation.getCurrentUser().getShortUserName();
-            } else {
-                userName = hiveConf.get("user.name", "").trim();
+            if (hiveConf.getBoolean(HIVE_AUTHORIZATION_ENABLED, false)) {
+                if (UserGroupInformation.isSecurityEnabled()) {
+                    userName = UserGroupInformation.getCurrentUser().getShortUserName();
+                } else {
+                    userName = hiveConf.get("user.name", "").trim();
+                }
             }
         } catch (IOException e) {
             throw new CatalogException("Failed to get userName", e);

--- a/flink-connectors/flink-connector-hive/src/main/java/org/apache/flink/table/catalog/hive/HiveCatalog.java
+++ b/flink-connectors/flink-connector-hive/src/main/java/org/apache/flink/table/catalog/hive/HiveCatalog.java
@@ -313,11 +313,7 @@ public class HiveCatalog extends AbstractCatalog {
 
         try {
             if (hiveConf.getBoolean(HIVE_AUTHORIZATION_ENABLED, false)) {
-                if (UserGroupInformation.isSecurityEnabled()) {
-                    userName = UserGroupInformation.getCurrentUser().getShortUserName();
-                } else {
-                    userName = hiveConf.get("user.name", "").trim();
-                }
+                userName = UserGroupInformation.getCurrentUser().getShortUserName();
             }
         } catch (IOException e) {
             throw new CatalogException("Failed to get userName", e);

--- a/flink-connectors/flink-connector-hive/src/main/java/org/apache/flink/table/catalog/hive/util/HiveTableUtil.java
+++ b/flink-connectors/flink-connector-hive/src/main/java/org/apache/flink/table/catalog/hive/util/HiveTableUtil.java
@@ -28,7 +28,6 @@ import org.apache.flink.table.catalog.CatalogBaseTable;
 import org.apache.flink.table.catalog.CatalogTable;
 import org.apache.flink.table.catalog.CatalogView;
 import org.apache.flink.table.catalog.ObjectPath;
-import org.apache.flink.table.catalog.exceptions.CatalogException;
 import org.apache.flink.table.catalog.hive.HiveCatalog;
 import org.apache.flink.table.catalog.hive.HiveCatalogConfig;
 import org.apache.flink.table.catalog.hive.client.HiveShim;
@@ -47,8 +46,6 @@ import org.apache.flink.table.types.DataType;
 import org.apache.flink.table.types.logical.LogicalTypeFamily;
 import org.apache.flink.table.types.logical.LogicalTypeRoot;
 
-import org.apache.flink.shaded.guava30.com.google.common.base.Strings;
-
 import org.apache.hadoop.conf.Configuration;
 import org.apache.hadoop.fs.Path;
 import org.apache.hadoop.hive.conf.HiveConf;
@@ -62,10 +59,8 @@ import org.apache.hadoop.hive.ql.io.StorageFormatDescriptor;
 import org.apache.hadoop.hive.ql.io.StorageFormatFactory;
 import org.apache.hadoop.hive.serde.serdeConstants;
 import org.apache.hadoop.hive.serde2.typeinfo.TypeInfoUtils;
-import org.apache.hadoop.security.UserGroupInformation;
 
 import java.io.File;
-import java.io.IOException;
 import java.util.ArrayList;
 import java.util.HashMap;
 import java.util.List;
@@ -347,24 +342,6 @@ public class HiveTableUtil {
             newHiveTable.setOwner(oldHiveTable.getOwner());
         }
         return newHiveTable;
-    }
-
-    public static void setTableOwner(Table hiveTable, CatalogBaseTable table, HiveConf hiveConf) {
-        try {
-            if (UserGroupInformation.isSecurityEnabled()) {
-                hiveTable.setOwner(UserGroupInformation.getCurrentUser().getShortUserName());
-                return;
-            }
-        } catch (IOException e) {
-            throw new CatalogException(
-                    String.format("Failed to setOwner for table %s", hiveTable.getTableName()), e);
-        }
-
-        String userName = hiveConf.get("user.name", "").trim();
-        if (!Strings.isNullOrEmpty(userName)) {
-            hiveTable.setOwner(userName);
-            return;
-        }
     }
 
     public static Table instantiateHiveTable(

--- a/flink-connectors/flink-connector-hive/src/test/java/org/apache/flink/table/catalog/hive/HiveCatalogHiveMetadataTest.java
+++ b/flink-connectors/flink-connector-hive/src/test/java/org/apache/flink/table/catalog/hive/HiveCatalogHiveMetadataTest.java
@@ -91,6 +91,17 @@ public class HiveCatalogHiveMetadataTest extends HiveCatalogMetadataTestBase {
     public void testCreateTable_Streaming() throws Exception {}
 
     @Test
+    public void testCreateTable_SetOwner() throws Exception {
+        catalog.createDatabase(db1, createDb(), false);
+        CatalogTable table = createTable();
+        table.getOptions().put("properties.hive.user.name", "test");
+        catalog.createTable(path1, table, false);
+
+        Table hiveTable = ((HiveCatalog) catalog).getHiveTable(path1);
+        assertEquals("test", hiveTable.getOwner());
+    }
+
+    @Test
     // verifies that input/output formats and SerDe are set for Hive tables
     public void testCreateTable_StorageFormatSet() throws Exception {
         catalog.createDatabase(db1, createDb(), false);

--- a/flink-connectors/flink-connector-hive/src/test/java/org/apache/flink/table/catalog/hive/HiveCatalogHiveMetadataTest.java
+++ b/flink-connectors/flink-connector-hive/src/test/java/org/apache/flink/table/catalog/hive/HiveCatalogHiveMetadataTest.java
@@ -73,6 +73,7 @@ import static org.apache.flink.sql.parser.hive.ddl.SqlCreateHiveTable.IDENTIFIER
 import static org.apache.flink.table.factories.FactoryUtil.CONNECTOR;
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertFalse;
+import static org.junit.Assert.assertNotNull;
 import static org.junit.Assert.assertNull;
 import static org.junit.Assert.assertTrue;
 
@@ -82,7 +83,7 @@ public class HiveCatalogHiveMetadataTest extends HiveCatalogMetadataTestBase {
     @BeforeClass
     public static void init() {
         HiveConf conf = HiveTestUtils.createHiveConf();
-        conf.set("user.name", "test");
+        conf.setBoolean("hive.security.authorization.enabled", true);
         catalog = HiveTestUtils.createHiveCatalog(conf);
         catalog.open();
     }
@@ -100,7 +101,7 @@ public class HiveCatalogHiveMetadataTest extends HiveCatalogMetadataTestBase {
         catalog.createTable(path1, table, false);
 
         Table hiveTable = ((HiveCatalog) catalog).getHiveTable(path1);
-        assertEquals("test", hiveTable.getOwner());
+        assertNotNull(hiveTable.getOwner());
     }
 
     @Test

--- a/flink-connectors/flink-connector-hive/src/test/java/org/apache/flink/table/catalog/hive/HiveCatalogHiveMetadataTest.java
+++ b/flink-connectors/flink-connector-hive/src/test/java/org/apache/flink/table/catalog/hive/HiveCatalogHiveMetadataTest.java
@@ -53,6 +53,7 @@ import org.apache.flink.table.types.DataType;
 import org.apache.flink.util.StringUtils;
 
 import org.apache.hadoop.hive.common.StatsSetupConst;
+import org.apache.hadoop.hive.conf.HiveConf;
 import org.apache.hadoop.hive.metastore.TableType;
 import org.apache.hadoop.hive.metastore.api.FieldSchema;
 import org.apache.hadoop.hive.metastore.api.Table;
@@ -80,7 +81,9 @@ public class HiveCatalogHiveMetadataTest extends HiveCatalogMetadataTestBase {
 
     @BeforeClass
     public static void init() {
-        catalog = HiveTestUtils.createHiveCatalog();
+        HiveConf conf = HiveTestUtils.createHiveConf();
+        conf.set("user.name", "test");
+        catalog = HiveTestUtils.createHiveCatalog(conf);
         catalog.open();
     }
 
@@ -94,7 +97,6 @@ public class HiveCatalogHiveMetadataTest extends HiveCatalogMetadataTestBase {
     public void testCreateTable_SetOwner() throws Exception {
         catalog.createDatabase(db1, createDb(), false);
         CatalogTable table = createTable();
-        table.getOptions().put("properties.hive.user.name", "test");
         catalog.createTable(path1, table, false);
 
         Table hiveTable = ((HiveCatalog) catalog).getHiveTable(path1);


### PR DESCRIPTION
…r property correctly

<!--
*Thank you very much for contributing to Apache Flink - we are happy that you want to help us improve Flink. To help the community review your contribution in the best possible way, please go through the checklist below, which will get the contribution into a shape in which it can be best reviewed.*

*Please understand that we do not do this to make contributions to Flink a hassle. In order to uphold a high standard of quality for code contributions, while at the same time managing a large number of contributions, we need contributors to prepare the contributions well, and give reviewers enough contextual information for the review. Please also understand that contributions that do not follow this guide will take longer to review and thus typically be picked up with lower priority by the community.*

## Contribution Checklist

  - Make sure that the pull request corresponds to a [JIRA issue](https://issues.apache.org/jira/projects/FLINK/issues). Exceptions are made for typos in JavaDoc or documentation files, which need no JIRA issue.
  
  - Name the pull request in the form "[FLINK-XXXX] [component] Title of the pull request", where *FLINK-XXXX* should be replaced by the actual issue number. Skip *component* if you are unsure about which is the best component.
  Typo fixes that have no associated JIRA issue should be named following this pattern: `[hotfix] [docs] Fix typo in event time introduction` or `[hotfix] [javadocs] Expand JavaDoc for PuncuatedWatermarkGenerator`.

  - Fill out the template below to describe the changes contributed by the pull request. That will give reviewers the context they need to do the review.
  
  - Make sure that the change passes the automated tests, i.e., `mvn clean verify` passes. You can set up Azure Pipelines CI to do that following [this guide](https://cwiki.apache.org/confluence/display/FLINK/Azure+Pipelines#AzurePipelines-Tutorial:SettingupAzurePipelinesforaforkoftheFlinkrepository).

  - Each pull request should address only one issue, not mix up code from multiple issues.
  
  - Each commit in the pull request has a meaningful commit message (including the JIRA id)

  - Once all items of the checklist are addressed, remove the above text and this checklist, leaving only the filled out template below.


**(The sections below can be removed for hotfixes of typos)**
-->

## What is the purpose of the change

*(For example: This pull request makes task deployment go through the blob server, rather than through RPC. That way we avoid re-transferring them on each deployment (during recovery).)*


## Brief change log

*(for example:)*
  - *The TaskInfo is stored in the blob store on job creation time as a persistent artifact*
  - *Deployments RPC transmits only the blob storage reference*
  - *TaskManagers retrieve the TaskInfo from the blob cache*


## Verifying this change

*(Please pick either of the following options)*

This change is a trivial rework / code cleanup without any test coverage.

*(or)*

This change is already covered by existing tests, such as *(please describe tests)*.

*(or)*

This change added tests and can be verified as follows:

*(example:)*
  - *Added integration tests for end-to-end deployment with large payloads (100MB)*
  - *Extended integration test for recovery after master (JobManager) failure*
  - *Added test that validates that TaskInfo is transferred only once across recoveries*
  - *Manually verified the change by running a 4 node cluser with 2 JobManagers and 4 TaskManagers, a stateful streaming program, and killing one JobManager and two TaskManagers during the execution, verifying that recovery happens correctly.*

## Does this pull request potentially affect one of the following parts:

  - Dependencies (does it add or upgrade a dependency): (yes / no)
  - The public API, i.e., is any changed class annotated with `@Public(Evolving)`: (yes / no)
  - The serializers: (yes / no / don't know)
  - The runtime per-record code paths (performance sensitive): (yes / no / don't know)
  - Anything that affects deployment or recovery: JobManager (and its components), Checkpointing, Kubernetes/Yarn, ZooKeeper: (yes / no / don't know)
  - The S3 file system connector: (yes / no / don't know)

## Documentation

  - Does this pull request introduce a new feature? (yes / no)
  - If yes, how is the feature documented? (not applicable / docs / JavaDocs / not documented)
