### PR TITLE
[FLINK-23627] [Runtime / Metrics] Migrate all OperatorMG instantiations to factory method

### DIFF
--- a/flink-runtime/src/main/java/org/apache/flink/runtime/metrics/groups/InternalOperatorMetricGroup.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/metrics/groups/InternalOperatorMetricGroup.java
@@ -41,7 +41,7 @@ public class InternalOperatorMetricGroup extends ComponentMetricGroup<TaskMetric
 
     private final InternalOperatorIOMetricGroup ioMetrics;
 
-    public InternalOperatorMetricGroup(
+    InternalOperatorMetricGroup(
             MetricRegistry registry,
             TaskMetricGroup parent,
             OperatorID operatorID,

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/metrics/groups/UnregisteredMetricGroups.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/metrics/groups/UnregisteredMetricGroups.java
@@ -65,6 +65,11 @@ public class UnregisteredMetricGroups {
         return new UnregisteredOperatorMetricGroup();
     }
 
+    private static InternalOperatorMetricGroup createUnregisteredOperatorMetricGroup(
+            TaskMetricGroup parent) {
+        return new UnregisteredOperatorMetricGroup(parent);
+    }
+
     /** A safe drop-in replacement for {@link ProcessMetricGroup ProcessMetricGroups}. */
     public static class UnregisteredProcessMetricGroup extends ProcessMetricGroup {
         private static final String UNREGISTERED_HOST = "UnregisteredHost";
@@ -188,7 +193,7 @@ public class UnregisteredMetricGroups {
 
         @Override
         public InternalOperatorMetricGroup getOrAddOperator(OperatorID operatorID, String name) {
-            return createUnregisteredOperatorMetricGroup();
+            return createUnregisteredOperatorMetricGroup(this);
         }
     }
 
@@ -198,11 +203,11 @@ public class UnregisteredMetricGroups {
         private static final String DEFAULT_OPERATOR_NAME = "UnregisteredOperator";
 
         protected UnregisteredOperatorMetricGroup() {
-            super(
-                    NoOpMetricRegistry.INSTANCE,
-                    new UnregisteredTaskMetricGroup(),
-                    DEFAULT_OPERATOR_ID,
-                    DEFAULT_OPERATOR_NAME);
+            this(new UnregisteredTaskMetricGroup());
+        }
+
+        UnregisteredOperatorMetricGroup(TaskMetricGroup parent) {
+            super(NoOpMetricRegistry.INSTANCE, parent, DEFAULT_OPERATOR_ID, DEFAULT_OPERATOR_NAME);
         }
     }
 }

--- a/flink-runtime/src/test/java/org/apache/flink/runtime/metrics/groups/InternalOperatorGroupTest.java
+++ b/flink-runtime/src/test/java/org/apache/flink/runtime/metrics/groups/InternalOperatorGroupTest.java
@@ -71,7 +71,7 @@ public class InternalOperatorGroupTest extends TestLogger {
         TaskMetricGroup taskGroup =
                 jmGroup.addTask(new JobVertexID(), new ExecutionAttemptID(), "aTaskName", 11, 0);
         InternalOperatorMetricGroup opGroup =
-                new InternalOperatorMetricGroup(registry, taskGroup, new OperatorID(), "myOpName");
+                taskGroup.getOrAddOperator(new OperatorID(), "myOpName");
 
         assertArrayEquals(
                 new String[] {
@@ -141,7 +141,7 @@ public class InternalOperatorGroupTest extends TestLogger {
         TaskMetricGroup taskGroup =
                 jmGroup.addTask(new JobVertexID(), new ExecutionAttemptID(), "aTaskName", 11, 0);
         InternalOperatorMetricGroup opGroup =
-                new InternalOperatorMetricGroup(registry, taskGroup, new OperatorID(), "myOpName");
+                taskGroup.getOrAddOperator(new OperatorID(), "myOpName");
 
         assertNotNull(opGroup.getIOMetricGroup());
         assertNotNull(opGroup.getIOMetricGroup().getNumRecordsInCounter());
@@ -161,8 +161,7 @@ public class InternalOperatorGroupTest extends TestLogger {
         TaskManagerJobMetricGroup jmGroup =
                 new TaskManagerJobMetricGroup(registry, tmGroup, jid, "myJobName");
         TaskMetricGroup taskGroup = jmGroup.addTask(tid, eid, "aTaskName", 11, 0);
-        InternalOperatorMetricGroup opGroup =
-                new InternalOperatorMetricGroup(registry, taskGroup, oid, "myOpName");
+        InternalOperatorMetricGroup opGroup = taskGroup.getOrAddOperator(oid, "myOpName");
 
         Map<String, String> variables = opGroup.getAllVariables();
 
@@ -197,8 +196,7 @@ public class InternalOperatorGroupTest extends TestLogger {
                         registry, "host", new ResourceID("id"));
         TaskManagerJobMetricGroup job = new TaskManagerJobMetricGroup(registry, tm, jid, "jobname");
         TaskMetricGroup task = job.addTask(vid, eid, "taskName", 4, 5);
-        InternalOperatorMetricGroup operator =
-                new InternalOperatorMetricGroup(registry, task, oid, "operator");
+        InternalOperatorMetricGroup operator = task.getOrAddOperator(oid, "operator");
 
         QueryScopeInfo.OperatorQueryScopeInfo info =
                 operator.createQueryServiceMetricInfo(new DummyCharacterFilter());

--- a/flink-streaming-java/src/test/java/org/apache/flink/streaming/runtime/tasks/MultipleInputStreamTaskTest.java
+++ b/flink-streaming-java/src/test/java/org/apache/flink/streaming/runtime/tasks/MultipleInputStreamTaskTest.java
@@ -53,7 +53,6 @@ import org.apache.flink.runtime.io.network.partition.ResultPartition;
 import org.apache.flink.runtime.io.network.partition.ResultPartitionType;
 import org.apache.flink.runtime.jobgraph.OperatorID;
 import org.apache.flink.runtime.metrics.MetricNames;
-import org.apache.flink.runtime.metrics.NoOpMetricRegistry;
 import org.apache.flink.runtime.metrics.groups.InternalOperatorMetricGroup;
 import org.apache.flink.runtime.metrics.groups.TaskIOMetricGroup;
 import org.apache.flink.runtime.metrics.groups.TaskMetricGroup;
@@ -402,8 +401,7 @@ public class MultipleInputStreamTaskTest {
                     public InternalOperatorMetricGroup getOrAddOperator(
                             OperatorID operatorID, String name) {
                         InternalOperatorMetricGroup operatorMetricGroup =
-                                new InternalOperatorMetricGroup(
-                                        NoOpMetricRegistry.INSTANCE, this, operatorID, name);
+                                super.getOrAddOperator(operatorID, name);
                         operatorMetrics.put(name, operatorMetricGroup);
                         return operatorMetricGroup;
                     }

--- a/flink-streaming-java/src/test/java/org/apache/flink/streaming/runtime/tasks/OneInputStreamTaskTest.java
+++ b/flink-streaming-java/src/test/java/org/apache/flink/streaming/runtime/tasks/OneInputStreamTaskTest.java
@@ -19,6 +19,7 @@
 package org.apache.flink.streaming.runtime.tasks;
 
 import org.apache.flink.api.common.ExecutionConfig;
+import org.apache.flink.api.common.JobID;
 import org.apache.flink.api.common.functions.MapFunction;
 import org.apache.flink.api.common.functions.RichMapFunction;
 import org.apache.flink.api.common.state.ListState;
@@ -34,15 +35,18 @@ import org.apache.flink.metrics.Metric;
 import org.apache.flink.runtime.checkpoint.CheckpointMetaData;
 import org.apache.flink.runtime.checkpoint.CheckpointOptions;
 import org.apache.flink.runtime.checkpoint.TaskStateSnapshot;
+import org.apache.flink.runtime.clusterframework.types.ResourceID;
+import org.apache.flink.runtime.executiongraph.ExecutionAttemptID;
 import org.apache.flink.runtime.io.network.api.CancelCheckpointMarker;
 import org.apache.flink.runtime.io.network.api.CheckpointBarrier;
+import org.apache.flink.runtime.jobgraph.JobVertexID;
 import org.apache.flink.runtime.jobgraph.OperatorID;
 import org.apache.flink.runtime.metrics.MetricNames;
 import org.apache.flink.runtime.metrics.NoOpMetricRegistry;
 import org.apache.flink.runtime.metrics.groups.InternalOperatorMetricGroup;
 import org.apache.flink.runtime.metrics.groups.TaskIOMetricGroup;
+import org.apache.flink.runtime.metrics.groups.TaskManagerMetricGroup;
 import org.apache.flink.runtime.metrics.groups.TaskMetricGroup;
-import org.apache.flink.runtime.metrics.groups.UnregisteredMetricGroups;
 import org.apache.flink.runtime.metrics.util.InterceptingOperatorMetricGroup;
 import org.apache.flink.runtime.metrics.util.InterceptingTaskMetricGroup;
 import org.apache.flink.runtime.operators.testutils.MockInputSplitProvider;
@@ -762,14 +766,16 @@ public class OneInputStreamTaskTest extends TestLogger {
                 .finish();
 
         final TaskMetricGroup taskMetricGroup =
-                new UnregisteredMetricGroups.UnregisteredTaskMetricGroup() {
-                    @Override
-                    public InternalOperatorMetricGroup getOrAddOperator(
-                            OperatorID operatorID, String name) {
-                        return new InternalOperatorMetricGroup(
-                                NoOpMetricRegistry.INSTANCE, this, operatorID, name);
-                    }
-                };
+                TaskManagerMetricGroup.createTaskManagerMetricGroup(
+                                NoOpMetricRegistry.INSTANCE, "host", ResourceID.generate())
+                        .addTaskForJob(
+                                new JobID(),
+                                "jobname",
+                                new JobVertexID(),
+                                new ExecutionAttemptID(),
+                                "task",
+                                0,
+                                0);
 
         final StreamMockEnvironment env =
                 new StreamMockEnvironment(


### PR DESCRIPTION
<!--
*Thank you very much for contributing to Apache Flink - we are happy that you want to help us improve Flink. To help the community review your contribution in the best possible way, please go through the checklist below, which will get the contribution into a shape in which it can be best reviewed.*

*Please understand that we do not do this to make contributions to Flink a hassle. In order to uphold a high standard of quality for code contributions, while at the same time managing a large number of contributions, we need contributors to prepare the contributions well, and give reviewers enough contextual information for the review. Please also understand that contributions that do not follow this guide will take longer to review and thus typically be picked up with lower priority by the community.*

## Contribution Checklist

  - Make sure that the pull request corresponds to a [JIRA issue](https://issues.apache.org/jira/projects/FLINK/issues). Exceptions are made for typos in JavaDoc or documentation files, which need no JIRA issue.
  
  - Name the pull request in the form "[FLINK-XXXX] [component] Title of the pull request", where *FLINK-XXXX* should be replaced by the actual issue number. Skip *component* if you are unsure about which is the best component.
  Typo fixes that have no associated JIRA issue should be named following this pattern: `[hotfix] [docs] Fix typo in event time introduction` or `[hotfix] [javadocs] Expand JavaDoc for PuncuatedWatermarkGenerator`.

  - Fill out the template below to describe the changes contributed by the pull request. That will give reviewers the context they need to do the review.
  
  - Make sure that the change passes the automated tests, i.e., `mvn clean verify` passes. You can set up Azure Pipelines CI to do that following [this guide](https://cwiki.apache.org/confluence/display/FLINK/Azure+Pipelines#AzurePipelines-Tutorial:SettingupAzurePipelinesforaforkoftheFlinkrepository).

  - Each pull request should address only one issue, not mix up code from multiple issues.
  
  - Each commit in the pull request has a meaningful commit message (including the JIRA id)

  - Once all items of the checklist are addressed, remove the above text and this checklist, leaving only the filled out template below.


**(The sections below can be removed for hotfixes of typos)**
-->

## What is the purpose of the change

Modify all existing usages of the OperatorMG constructor to use runtime Apis, for consistency and to make constructor changes easier.


## Brief change log

*(for example:)*
  - *The TaskInfo is stored in the blob store on job creation time as a persistent artifact*
  - *Deployments RPC transmits only the blob storage reference*
  - *TaskManagers retrieve the TaskInfo from the blob cache*


## Verifying this change

*(Please pick either of the following options)*

This change is a trivial rework / code cleanup without any test coverage.

*(or)*

This change is already covered by existing tests, such as *(please describe tests)*.

*(or)*

This change added tests and can be verified as follows:

*(example:)*
  - *Added integration tests for end-to-end deployment with large payloads (100MB)*
  - *Extended integration test for recovery after master (JobManager) failure*
  - *Added test that validates that TaskInfo is transferred only once across recoveries*
  - *Manually verified the change by running a 4 node cluser with 2 JobManagers and 4 TaskManagers, a stateful streaming program, and killing one JobManager and two TaskManagers during the execution, verifying that recovery happens correctly.*

## Does this pull request potentially affect one of the following parts:

  - Dependencies (does it add or upgrade a dependency): (no)
  - The public API, i.e., is any changed class annotated with `@Public(Evolving)`: (no)
  - The serializers: (no)
  - The runtime per-record code paths (performance sensitive): (no)
  - Anything that affects deployment or recovery: JobManager (and its components), Checkpointing, Kubernetes/Yarn, ZooKeeper: (no)
  - The S3 file system connector: (no)

## Documentation

  - Does this pull request introduce a new feature? (no)
