### PR TITLE
[FLINK-23289][table-common] Add null check in BinarySection's constructor and pointTo method

### DIFF
--- a/flink-table/flink-table-common/src/main/java/org/apache/flink/table/data/binary/BinarySection.java
+++ b/flink-table/flink-table-common/src/main/java/org/apache/flink/table/data/binary/BinarySection.java
@@ -19,6 +19,7 @@ package org.apache.flink.table.data.binary;
 
 import org.apache.flink.annotation.Internal;
 import org.apache.flink.core.memory.MemorySegment;
+import org.apache.flink.util.Preconditions;
 
 /** A basic implementation of {@link BinaryFormat} which describe a section of memory. */
 @Internal
@@ -31,6 +32,7 @@ public class BinarySection implements BinaryFormat {
     public BinarySection() {}
 
     public BinarySection(MemorySegment[] segments, int offset, int sizeInBytes) {
+        Preconditions.checkArgument(segments != null);
         this.segments = segments;
         this.offset = offset;
         this.sizeInBytes = sizeInBytes;
@@ -41,6 +43,7 @@ public class BinarySection implements BinaryFormat {
     }
 
     public void pointTo(MemorySegment[] segments, int offset, int sizeInBytes) {
+        Preconditions.checkArgument(segments != null);
         this.segments = segments;
         this.offset = offset;
         this.sizeInBytes = sizeInBytes;

--- a/flink-table/flink-table-common/src/main/java/org/apache/flink/table/data/binary/LazyBinaryFormat.java
+++ b/flink-table/flink-table-common/src/main/java/org/apache/flink/table/data/binary/LazyBinaryFormat.java
@@ -62,7 +62,7 @@ public abstract class LazyBinaryFormat<T> implements BinaryFormat {
     BinarySection binarySection;
 
     public LazyBinaryFormat() {
-        this(null, -1, -1, null);
+        this(null, null);
     }
 
     public LazyBinaryFormat(MemorySegment[] segments, int offset, int sizeInBytes, T javaObject) {


### PR DESCRIPTION
## What is the purpose of the change

`BinarySection` currently does not check if `MemorySegment[]` is null in its constructor. This might cause NullPointerException somewhere else and makes it harder to debug (as we don't know who sets the null value into `BinarySection`).

This PR added such null check.

## Brief change log

 - Add null check in BinarySection's constructor and pointTo method

## Verifying this change

This change is a trivial rework / code cleanup without any test coverage.

## Does this pull request potentially affect one of the following parts:

  - Dependencies (does it add or upgrade a dependency): no
  - The public API, i.e., is any changed class annotated with `@Public(Evolving)`: no
  - The serializers: no
  - The runtime per-record code paths (performance sensitive): **MAYBE**
  - Anything that affects deployment or recovery: JobManager (and its components), Checkpointing, Kubernetes/Yarn, ZooKeeper: no
  - The S3 file system connector: no

## Documentation

  - Does this pull request introduce a new feature? no
  - If yes, how is the feature documented? not applicable
