### PR TITLE
[FLINK-23615][docs] Fix the mistake in "systemfunctions"

### DIFF
--- a/docs/data/sql_functions.yml
+++ b/docs/data/sql_functions.yml
@@ -240,7 +240,7 @@ arithmetic:
     description: Returns a string representation of an integer NUMERIC value or a STRING in hex format. Returns NULL if the argument is NULL. E.g. a numeric 20 leads to "14", a numeric 100 leads to "64", a string "hello,world" leads to "68656C6C6F2C776F726C64".
   - sql: TRUNCATE(numeric1, integer2)
     table: numeric1.truncate(INTEGER2)
-    description: Returns a numeric of truncated to integer2 decimal places. Returns NULL if numeric1 or integer2 is NULL.If integer2 is 0,the result has no decimal point or fractional part.integer2 can be negative to cause integer2 digits left of the decimal point of the value to become zero.This function can also pass in only one numeric1 parameter and not set Integer2 to use.If Integer2 is not set, the function truncates as if Integer2 were 0. E.g. 42.324.truncate(2) to 42.32. and 42.324.truncate() to 42.0.
+    description: Returns a numeric of truncated to integer2 decimal places. Returns NULL if numeric1 or integer2 is NULL. If integer2 is 0, the result has no decimal point or fractional part. integer2 can be negative to cause integer2 digits left of the decimal point of the value to become zero. This function can also pass in only one numeric1 parameter and not set Integer2 to use. If Integer2 is not set, the function truncates as if Integer2 were 0. E.g. 42.324.truncate(2) to 42.32. and 42.324.truncate() to 42.0.
 
 string:
   - sql: string1 || string2
@@ -273,7 +273,7 @@ string:
     description: Returns a string that removes the left whitespaces from STRING. E.g., ' This is a test String.'.ltrim() returns "This is a test String.".
   - sql: RTRIM(string)
     table: STRING.rtrim()
-    description: Returns a string that removes the right whitespaces from STRING.E.g., 'This is a test String. '.rtrim() returns "This is a test String.".
+    description: Returns a string that removes the right whitespaces from STRING. E.g., 'This is a test String. '.rtrim() returns "This is a test String.".
   - sql: REPEAT(string, int)
     table: STRING.repeat(INT)
     description: Returns a string that repeats the base string integer times. E.g., REPEAT('This is a test String.', 2) returns "This is a test String.This is a test String.".
@@ -316,10 +316,10 @@ string:
     description: Returns a string that concatenates STRING2, STRING3, ... with a separator STRING1. The separator is added between the strings to be concatenated. Returns NULL If STRING1 is NULL. Compared with concat(), concat_ws() automatically skips NULL arguments. E.g., concat_ws('~', 'AA', Null(STRING), 'BB', '', 'CC') returns "AA~BB~~CC".
   - sql: LPAD(string1, integer, string2)
     table: STRING1.lpad(INT, STRING2)
-    description: Returns a new string from string1 left-padded with string2 to a length of integer characters. If the length of string1 is shorter than integer, returns string1 shortened to integer characters. E.g., LPAD('hi',4,'??') returns "??hi"; LPAD('hi',1,'??') returns "h".
+    description: Returns a new string from string1 left-padded with string2 to a length of integer characters. If the length of string1 is shorter than integer, returns string1 shortened to integer characters. E.g., LPAD('hi', 4, '??') returns "??hi"; LPAD('hi', 1, '??') returns "h".
   - sql: RPAD(string1, integer, string2)
     table: STRING1.rpad(INT, STRING2)
-    description: Returns a new string from string1 right-padded with string2 to a length of integer characters. If the length of string1 is shorter than integer, returns string1 shortened to integer characters. E.g., RPAD('hi',4,'??') returns "hi??", RPAD('hi',1,'??') returns "h". 
+    description: Returns a new string from string1 right-padded with string2 to a length of integer characters. If the length of string1 is shorter than integer, returns string1 shortened to integer characters. E.g., RPAD('hi', 4, '??') returns "hi??", RPAD('hi', 1, '??') returns "h".
   - sql: FROM_BASE64(string)
     table: STRING.fromBase64()
     description: Returns the base64-decoded result from string; returns NULL if string is NULL. E.g., FROM_BASE64('aGVsbG8gd29ybGQ=') returns "hello world".
@@ -631,7 +631,7 @@ hashfunctions:
     description: Returns the hash using the SHA-2 family of hash functions (SHA-224, SHA-256, SHA-384, or SHA-512). The first argument string is the string to be hashed and the second argument hashLength is the bit length of the result (224, 256, 384, or 512). Returns NULL if string or hashLength is NULL. 
 
 auxilary:
-  - table:  callSql(STRING)
+  - table: callSql(STRING)
     description: |
       A call to a SQL expression.
 

--- a/docs/data/sql_functions.yml
+++ b/docs/data/sql_functions.yml
@@ -240,7 +240,7 @@ arithmetic:
     description: Returns a string representation of an integer NUMERIC value or a STRING in hex format. Returns NULL if the argument is NULL. E.g. a numeric 20 leads to "14", a numeric 100 leads to "64", a string "hello,world" leads to "68656C6C6F2C776F726C64".
   - sql: TRUNCATE(numeric1, integer2)
     table: numeric1.truncate(INTEGER2)
-    description: Returns a numeric of truncated to integer2 decimal places. Returns NULL if numeric1 or integer2 is NULL.If integer2 is 0,the result has no decimal point or fractional part.integer2 can be negative to cause integer2 digits left of the decimal point of the value to become zero.This function can also pass in only one numeric1 parameter and not set Integer2 to use.If Integer2 is not set, the function truncates as if Integer2 were 0. E.g. 42.324.truncate(2) to 42.34. and 42.324.truncate() to 42.0.
+    description: Returns a numeric of truncated to integer2 decimal places. Returns NULL if numeric1 or integer2 is NULL.If integer2 is 0,the result has no decimal point or fractional part.integer2 can be negative to cause integer2 digits left of the decimal point of the value to become zero.This function can also pass in only one numeric1 parameter and not set Integer2 to use.If Integer2 is not set, the function truncates as if Integer2 were 0. E.g. 42.324.truncate(2) to 42.32. and 42.324.truncate() to 42.0.
 
 string:
   - sql: string1 || string2

--- a/docs/data/sql_functions_zh.yml
+++ b/docs/data/sql_functions_zh.yml
@@ -302,7 +302,7 @@ arithmetic:
       返回截取 integer2 位小数的数字。如果 numeric1 或 integer2 为 `NULL`，则返回 `NULL`。
       如果 integer2 为 0，则结果没有小数点或小数部分。integer2 可以为负数，使值的小数点左边的 integer2 位变为零。
       此函数也可以传入只有一个 numeric1 参数且不设置 Integer2 以使用。如果未设置 Integer2 则 Integer2 为 0。
-      例如 42.324.truncate(2) 为 42.34，42.324.truncate() 为 42.0。
+      例如 42.324.truncate(2) 为 42.32，42.324.truncate() 为 42.0。
 
 string:
   - sql: string1 || string2
@@ -519,7 +519,7 @@ temporal:
   - sql: CURRENT_TIMESTAMP
     table: currentTimestamp()
     description: |
-      返回本地时区的当前 SQL 时间戳，返回类型为TIMESTAMP_LTZ(3)。在流模式下为每条记录进行取值。
+      返回本地时区的当前 SQL 时间戳，返回类型为 TIMESTAMP_LTZ(3)。在流模式下为每条记录进行取值。
       但在批处理模式下，它在查询开始时计算一次，并对每一行使用相同的结果。
   - sql: NOW()
     description: 返回本地时区的当前 SQL 时间戳，这是 CURRENT_TIMESTAMP 的同义词。
@@ -593,13 +593,13 @@ temporal:
   - sql: CONVERT_TZ(string1, string2, string3)
     description: |
       将日期时间 string1（具有默认 ISO 时间戳格式 'yyyy-MM-dd HH:mm:ss'）从时区 string2 转换为时区 string3 的值。
-      时区的格式应该是缩写如“PST”，全名如“America/Los_Angeles”，或自定义ID如“GMT-08:00”。例如
+      时区的格式应该是缩写如“PST”，全名如“America/Los_Angeles”，或自定义 ID 如“GMT-08:00”。例如
       `CONVERT_TZ('1970-01-01 00:00:00', 'UTC', 'America/Los_Angeles')` 返回 `'1969-12-31 16:00:00`'。
   - sql: FROM_UNIXTIME(numeric[, string])
     description: |
       以字符串格式 string 返回数字参数 numberic 的表示形式（默认为 'yyyy-MM-dd HH:mm:ss'）。numeric 是一个内部
       时间戳值，表示自'1970-01-01 00:00:00' UTC 以来的秒数，由 UNIX_TIMESTAMP() 函数生成。返回值以会话时区表示
-      （在 TableConfig中指定）。例如，如果在 UTC 时区，FROM_UNIXTIME(44) 返回 '1970-01-01 00:00:44'，如果在
+      （在 TableConfig 中指定）。例如，如果在 UTC 时区，FROM_UNIXTIME(44) 返回 '1970-01-01 00:00:44'，如果在
       'Asia/Tokyo' 时区，则返回 '1970-01-01 09:00:44'。
   - sql: UNIX_TIMESTAMP()
     description: 以秒为单位获取当前的 Unix 时间戳。此函数不是确定性的，这意味着将为每个记录重新计算该值。

--- a/docs/data/sql_functions_zh.yml
+++ b/docs/data/sql_functions_zh.yml
@@ -89,12 +89,12 @@ comparison:
   - sql: value1 IN (value2 [, value3]* )
     table: value1.in(valu2)
     description: |
-      在给定列表(value2,value3, ...)中存在 value1 返回 `TRUE`。当列表包含 `NULL`，如果可以找到 value1 则返回
+      在给定列表 (value2, value3, ...) 中存在 value1 返回 `TRUE`。当列表包含 `NULL`，如果可以找到 value1 则返回
       `TRUE`，否则返回 `UNKNOWN`。如果 value1 为 `NULL` 则始终返回 `UNKNOWN`。例如 `4 IN (1, 2, 3)` 返回
       `FALSE`；`1 IN (1, 2, NULL)` 返回 `TRUE`；`4 IN (1, 2, NULL)` 返回 `UNKNOWN`。
   - sql: value1 NOT IN (value2 [, value3]* )
     description: |
-      在给定列表(value2,value3, ...)中不存在 value1 返回 `TRUE`。当列表包含 `NULL`，如果可以找到 value1 则
+      在给定列表 (value2, value3, ...) 中不存在 value1 返回 `TRUE`。当列表包含 `NULL`，如果可以找到 value1 则
       返回 `FALSE`，否则返回 `UNKNOWN`。如果 value1 为 `NULL`，则始终返回 `UNKNOWN`。例如 `4 NOT IN (1, 2, 3)`
       返回 `TRUE`；`1 NOT IN (1, 2, NULL)` 返回 `FALSE`；`4 NOT IN (1, 2, NULL)` 返回 `UNKNOWN`。
   - sql: EXISTS (sub-query)
@@ -446,7 +446,7 @@ string:
       如果有任一参数为 `NULL`，则返回 `NULL`。例如
       `parse_url(' http://facebook.com/path1/p.php?k1=v1&k2=v2#Ref1', 'HOST')` 返回 `'facebook.com'`。
       还可以通过提供关键词 string3 作为第三个参数来提取 QUERY 中特定键的值。例如
-      `parse_url('http://facebook.com/path1/p.php?k1=v1&k2=v2#Ref1', 'QUERY','k1')` 返回 `'v1'`。
+      `parse_url('http://facebook.com/path1/p.php?k1=v1&k2=v2#Ref1', 'QUERY', 'k1')` 返回 `'v1'`。
   - sql: REGEXP(string1, string2)
     description: |
       如果 string1 的任何（可能为空）子字符串与 Java 正则表达式 string2 匹配，则返回 TRUE，否则返回 FALSE。


### PR DESCRIPTION
## What is the purpose of the change
Fix the mistake in "systemfunctions".

The documentation of the TRUNCATE SQL function states that "E.g. 42.324.truncate(2) to 42.34", which should be "42.32".
Some period in the document also lacks trailing spaces.

## Brief change log

  - The description of TRUNCATE SQL function has been modified in docs/data/sql_functions.yml and docs/data/sql_functions_zh.yml
  - Add spaces  in docs/data/sql_functions_zh.yml where the specification requires 


## Verifying this change

This change is a trivial rework / code cleanup without any test coverage.

## Does this pull request potentially affect one of the following parts:

  - Dependencies (does it add or upgrade a dependency): ( no )
  - The public API, i.e., is any changed class annotated with `@Public(Evolving)`: ( no )
  - The serializers: ( no )
  - The runtime per-record code paths (performance sensitive): ( no )
  - Anything that affects deployment or recovery: JobManager (and its components), Checkpointing, Kubernetes/Yarn, ZooKeeper: ( no )
  - The S3 file system connector: ( no )

## Documentation

  - Does this pull request introduce a new feature? ( no )
  - If yes, how is the feature documented? ( no )
