### PR TITLE
[FLINK-23688][hadoop] Make JaasModule.getAppConfigurationEntries public

### DIFF
--- a/flink-runtime/src/main/java/org/apache/flink/runtime/security/modules/JaasModule.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/security/modules/JaasModule.java
@@ -125,7 +125,7 @@ public class JaasModule implements SecurityModule {
         return currentConfig;
     }
 
-    private static AppConfigurationEntry[] getAppConfigurationEntries(
+    public static AppConfigurationEntry[] getAppConfigurationEntries(
             SecurityConfiguration securityConfig) {
 
         AppConfigurationEntry userKerberosAce = null;


### PR DESCRIPTION
## What is the purpose of the change

There are use-cases where this information is needed. A good example is Kerberos authentication handler which is intended to be added as external project in FLINK-23274.

## Brief change log

Simply made `JaasModule.getAppConfigurationEntries` public.

## Verifying this change

Since this change is just visibility change no tests executed.

## Does this pull request potentially affect one of the following parts:

  - Dependencies (does it add or upgrade a dependency): no
  - The public API, i.e., is any changed class annotated with `@Public(Evolving)`: yes
  - The serializers: no
  - The runtime per-record code paths (performance sensitive): no
  - Anything that affects deployment or recovery: JobManager (and its components), Checkpointing, Kubernetes/Yarn, ZooKeeper: no
  - The S3 file system connector: no

## Documentation

  - Does this pull request introduce a new feature? no
  - If yes, how is the feature documented? not applicable
