### PR TITLE
[hotfix][state_processor_api][union_state][doc] Updated variable name…

### DIFF
--- a/docs/content.zh/docs/libs/state_processor_api.md
+++ b/docs/content.zh/docs/libs/state_processor_api.md
@@ -107,7 +107,7 @@ The state name and type information should match those used to define the `ListS
 The framework will return a _single_ copy of the state, equivalent to restoring a DataStream with parallelism 1.
 
 ```java
-DataSet<Integer> listState  = savepoint.readUnionState<>(
+DataSet<Integer> unionState  = savepoint.readUnionState<>(
     "my-uid",
     "union-state",
     Types.INT);

--- a/docs/content/docs/libs/state_processor_api.md
+++ b/docs/content/docs/libs/state_processor_api.md
@@ -107,7 +107,7 @@ The state name and type information should match those used to define the `ListS
 The framework will return a _single_ copy of the state, equivalent to restoring a DataStream with parallelism 1.
 
 ```java
-DataSet<Integer> listState  = savepoint.readUnionState<>(
+DataSet<Integer> unionState  = savepoint.readUnionState<>(
     "my-uid",
     "union-state",
     Types.INT);


### PR DESCRIPTION
## What is the purpose of the change

* Updated variable name to correspond to the method invocation

## Brief change log

* Changed variable name (listState) to match method invoked (readUnionState) 

## Verifying this change

This change is a trivial rework / code cleanup without any test coverage.

## Does this pull request potentially affect one of the following parts:

  - Dependencies (does it add or upgrade a dependency): no
  - The public API, i.e., is any changed class annotated with `@Public(Evolving)`: no
  - The serializers: no
  - The runtime per-record code paths (performance sensitive): no 
  - Anything that affects deployment or recovery: JobManager (and its components), Checkpointing, Kubernetes/Yarn, ZooKeeper:  no
  - The S3 file system connector: no

## Documentation

  - Does this pull request introduce a new feature? no
  - If yes, how is the feature documented? not applicable
