### PR TITLE
[FLINK-23693][tests] Add principal creation possibilities to SecureTestEnvironment

### DIFF
--- a/flink-runtime/src/main/java/org/apache/flink/runtime/security/KerberosUtils.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/security/KerberosUtils.java
@@ -45,6 +45,8 @@ public class KerberosUtils {
 
     private static final boolean IBM_JAVA;
 
+    private static final String DEFAULT_KERBEROS_INIT_APP_ENTRY_NAME;
+
     private static final Map<String, String> debugOptions = new HashMap<>();
 
     private static final Map<String, String> kerberosCacheOptions = new HashMap<>();
@@ -58,8 +60,18 @@ public class KerberosUtils {
                 : "com.sun.security.auth.module.Krb5LoginModule";
     }
 
+    public static String getDefaultKerberosInitAppEntryName() {
+        return DEFAULT_KERBEROS_INIT_APP_ENTRY_NAME;
+    }
+
     static {
         IBM_JAVA = JAVA_VENDOR_NAME.contains("IBM");
+
+        if (IBM_JAVA) {
+            DEFAULT_KERBEROS_INIT_APP_ENTRY_NAME = "com.ibm.security.jgss.krb5.initiate";
+        } else {
+            DEFAULT_KERBEROS_INIT_APP_ENTRY_NAME = "com.sun.security.jgss.krb5.initiate";
+        }
 
         if (LOG.isDebugEnabled()) {
             debugOptions.put("debug", "true");

--- a/flink-test-utils-parent/flink-test-utils/src/main/java/org/apache/flink/test/util/SecureTestEnvironment.java
+++ b/flink-test-utils-parent/flink-test-utils/src/main/java/org/apache/flink/test/util/SecureTestEnvironment.java
@@ -21,6 +21,7 @@ package org.apache.flink.test.util;
 import org.apache.flink.configuration.Configuration;
 import org.apache.flink.configuration.GlobalConfiguration;
 import org.apache.flink.configuration.SecurityOptions;
+import org.apache.flink.runtime.security.KerberosUtils;
 import org.apache.flink.runtime.security.SecurityConfiguration;
 
 import org.apache.commons.lang3.ArrayUtils;
@@ -154,7 +155,9 @@ public class SecureTestEnvironment {
             flinkConfig.setString(SecurityOptions.KERBEROS_LOGIN_KEYTAB, testKeytab);
             flinkConfig.setBoolean(SecurityOptions.KERBEROS_LOGIN_USETICKETCACHE, false);
             flinkConfig.setString(SecurityOptions.KERBEROS_LOGIN_PRINCIPAL, testPrincipal);
-            flinkConfig.setString(SecurityOptions.KERBEROS_LOGIN_CONTEXTS, "Client,KafkaClient");
+            flinkConfig.setString(
+                    SecurityOptions.KERBEROS_LOGIN_CONTEXTS,
+                    "Client,KafkaClient," + KerberosUtils.getDefaultKerberosInitAppEntryName());
             SecurityConfiguration ctx = new SecurityConfiguration(flinkConfig);
             TestingSecurityContext.install(ctx, getClientSecurityConfigurationMap());
 


### PR DESCRIPTION
## What is the purpose of the change

There are use-cases where this is needed. A good example is Kerberos authentication handler which is intended to be added as external project in FLINK-23274.

## Brief change log

* Fixed some forgotten reference bugs
* Minor re-ordering to see easily what's de-referenced and what's not
* Added `additionalPrincipals` parameter to `SecureTestEnvironment.prepare`
* Added default kerberos init app entry to contexts in `SecureTestEnvironment.prepare`

## Verifying this change

* Existing unit tests
* New unit tests with local build in the mentioned Kerberos authentication handler (intended to be published soon)

## Does this pull request potentially affect one of the following parts:

  - Dependencies (does it add or upgrade a dependency): no
  - The public API, i.e., is any changed class annotated with `@Public(Evolving)`: no
  - The serializers: no
  - The runtime per-record code paths (performance sensitive): no
  - Anything that affects deployment or recovery: JobManager (and its components), Checkpointing, Kubernetes/Yarn, ZooKeeper: no
  - The S3 file system connector: no

## Documentation

  - Does this pull request introduce a new feature? no
  - If yes, how is the feature documented? not applicable
