### PR TITLE
[FLINK-23692] Clarify text on Cancel Job confirmation buttons

### DIFF
--- a/flink-runtime-web/web-dashboard/src/app/pages/job/status/job-status.component.html
+++ b/flink-runtime-web/web-dashboard/src/app/pages/job/status/job-status.component.html
@@ -51,7 +51,7 @@
   <div class="operate">
     <span *ngIf="statusTips">{{ statusTips }}</span>
     <ng-container *ngIf="!statusTips">
-      <a nz-popconfirm nzTitle="Cancel Job?" (nzOnConfirm)="cancelJob()" *ngIf="webCancelEnabled && (jobDetail.state=='RUNNING' || jobDetail.state=='CREATED' || jobDetail.state=='RESTARTING')">Cancel Job</a>
+        <a nz-popconfirm nzTitle="Cancel Job?" nzOkText="Yes" nzCancelText="No" (nzOnConfirm)="cancelJob()" *ngIf="jobDetail.state=='RUNNING' || jobDetail.state=='CREATED' || jobDetail.state=='RESTARTING'">Cancel Job</a>
     </ng-container>
   </div>
 </div>

--- a/flink-runtime-web/web-dashboard/src/app/pages/job/status/job-status.component.html
+++ b/flink-runtime-web/web-dashboard/src/app/pages/job/status/job-status.component.html
@@ -51,7 +51,7 @@
   <div class="operate">
     <span *ngIf="statusTips">{{ statusTips }}</span>
     <ng-container *ngIf="!statusTips">
-        <a nz-popconfirm nzTitle="Cancel Job?" nzOkText="Yes" nzCancelText="No" (nzOnConfirm)="cancelJob()" *ngIf="jobDetail.state=='RUNNING' || jobDetail.state=='CREATED' || jobDetail.state=='RESTARTING'">Cancel Job</a>
+        <a nz-popconfirm nzTitle="Cancel Job?" nzOkText="Yes" nzCancelText="No" (nzOnConfirm)="cancelJob()" *ngIf="webCancelEnabled && (jobDetail.state=='RUNNING' || jobDetail.state=='CREATED' || jobDetail.state=='RESTARTING')">Cancel Job</a>
     </ng-container>
   </div>
 </div>

--- a/flink-runtime-web/web-dashboard/src/app/pages/job/status/job-status.component.html
+++ b/flink-runtime-web/web-dashboard/src/app/pages/job/status/job-status.component.html
@@ -51,7 +51,7 @@
   <div class="operate">
     <span *ngIf="statusTips">{{ statusTips }}</span>
     <ng-container *ngIf="!statusTips">
-        <a nz-popconfirm nzTitle="Cancel Job?" nzOkText="Yes" nzCancelText="No" (nzOnConfirm)="cancelJob()" *ngIf="webCancelEnabled && (jobDetail.state=='RUNNING' || jobDetail.state=='CREATED' || jobDetail.state=='RESTARTING')">Cancel Job</a>
+      <a nz-popconfirm nzTitle="Cancel Job?" nzOkText="Yes" nzCancelText="No" (nzOnConfirm)="cancelJob()" *ngIf="webCancelEnabled && (jobDetail.state=='RUNNING' || jobDetail.state=='CREATED' || jobDetail.state=='RESTARTING')">Cancel Job</a>
     </ng-container>
   </div>
 </div>


### PR DESCRIPTION
## What is the purpose of the change

*When prompting a user to confirm a job cancellation currently we present a popup with text: "Calncel Job?" and decision options: Cancel or OK. These decision options were the default in the html layer, and it had been changed with this PR to "Yes" or "No"*


## Brief change log
  - *Added nzOkText="Yes" nzCancelText="No" to the html layer*


## Verifying this change

This change is a trivial rework / code cleanup without any test coverage.


## Does this pull request potentially affect one of the following parts:

  - Dependencies (does it add or upgrade a dependency): NO
  - The public API, i.e., is any changed class annotated with `@Public(Evolving)`: NO
  - The serializers: don't know
  - The runtime per-record code paths (performance sensitive): NO
  - Anything that affects deployment or recovery: NO
  - The S3 file system connector: NO


## Documentation

  - Does this pull request introduce a new feature? NO
