### PR TITLE
[FLINK-23707][streaming-java] Use consistent managed memory weights for StreamNode

### DIFF
--- a/flink-core/src/main/java/org/apache/flink/api/dag/Transformation.java
+++ b/flink-core/src/main/java/org/apache/flink/api/dag/Transformation.java
@@ -273,7 +273,8 @@ public abstract class Transformation<T> {
      * @param managedMemoryUseCase The use case that this transformation declares needing managed
      *     memory for.
      * @param weight Use-case-specific weights for this transformation. Used for sharing managed
-     *     memory across transformations for OPERATOR scope use cases.
+     *     memory across transformations for OPERATOR scope use cases. Check the individual {@link
+     *     ManagedMemoryUseCase} for the specific weight definition.
      * @return The previous weight, if exist.
      */
     public Optional<Integer> declareManagedMemoryUseCaseAtOperatorScope(
@@ -313,7 +314,8 @@ public abstract class Transformation<T> {
     /**
      * Get operator scope use cases that this transformation needs managed memory for, and the
      * use-case-specific weights for this transformation. The weights are used for sharing managed
-     * memory across transformations for the use cases.
+     * memory across transformations for the use cases. Check the individual {@link
+     * ManagedMemoryUseCase} for the specific weight definition.
      */
     public Map<ManagedMemoryUseCase, Integer> getManagedMemoryOperatorScopeUseCaseWeights() {
         return Collections.unmodifiableMap(managedMemoryOperatorScopeUseCaseWeights);

--- a/flink-core/src/main/java/org/apache/flink/configuration/ExecutionOptions.java
+++ b/flink-core/src/main/java/org/apache/flink/configuration/ExecutionOptions.java
@@ -99,7 +99,7 @@ public class ExecutionOptions {
                                     .build());
 
     @Documentation.ExcludeFromDocumentation(
-            "This is an expert option, that we do not want to expose in" + " the documentation")
+            "This is an expert option, that we do not want to expose in the documentation")
     public static final ConfigOption<Boolean> SORT_INPUTS =
             ConfigOptions.key("execution.sorted-inputs.enabled")
                     .booleanType()
@@ -109,7 +109,21 @@ public class ExecutionOptions {
                                     + "NOTE: It takes effect only in the BATCH runtime mode.");
 
     @Documentation.ExcludeFromDocumentation(
-            "This is an expert option, that we do not want to expose in" + " the documentation")
+            "This is an expert option, that we do not want to expose in the documentation")
+    public static final ConfigOption<MemorySize> SORTED_INPUTS_MEMORY =
+            ConfigOptions.key("execution.sorted-inputs.memory")
+                    .memoryType()
+                    // in sync with other weights from Table API and DataStream API
+                    .defaultValue(MemorySize.ofMebiBytes(128))
+                    .withDescription(
+                            "Sets the managed memory size for sorting inputs of keyed operators in "
+                                    + "BATCH runtime mode. The memory size is only a weight hint. "
+                                    + "Thus, it will affect the operator's memory weight within a "
+                                    + "task, but the actual memory used depends on the running "
+                                    + "environment.");
+
+    @Documentation.ExcludeFromDocumentation(
+            "This is an expert option, that we do not want to expose in the documentation")
     public static final ConfigOption<Boolean> USE_BATCH_STATE_BACKEND =
             ConfigOptions.key("execution.batch-state-backend.enabled")
                     .booleanType()

--- a/flink-core/src/main/java/org/apache/flink/core/memory/ManagedMemoryUseCase.java
+++ b/flink-core/src/main/java/org/apache/flink/core/memory/ManagedMemoryUseCase.java
@@ -24,8 +24,12 @@ import org.apache.flink.util.Preconditions;
 /** Use cases of managed memory. */
 @Internal
 public enum ManagedMemoryUseCase {
+
+    /** Currently, weights are defined as mebibyte values. */
     OPERATOR(Scope.OPERATOR),
+
     STATE_BACKEND(Scope.SLOT),
+
     PYTHON(Scope.SLOT);
 
     public final Scope scope;

--- a/flink-streaming-java/src/main/java/org/apache/flink/streaming/runtime/translators/BatchExecutionUtils.java
+++ b/flink-streaming-java/src/main/java/org/apache/flink/streaming/runtime/translators/BatchExecutionUtils.java
@@ -19,6 +19,7 @@
 package org.apache.flink.streaming.runtime.translators;
 
 import org.apache.flink.configuration.ExecutionOptions;
+import org.apache.flink.configuration.ReadableConfig;
 import org.apache.flink.core.memory.ManagedMemoryUseCase;
 import org.apache.flink.streaming.api.graph.StreamConfig;
 import org.apache.flink.streaming.api.graph.StreamNode;
@@ -61,10 +62,16 @@ class BatchExecutionUtils {
                 node.addInputRequirement(i, inputRequirements[i]);
             }
             Map<ManagedMemoryUseCase, Integer> operatorScopeUseCaseWeights = new HashMap<>();
-            operatorScopeUseCaseWeights.put(ManagedMemoryUseCase.OPERATOR, 1);
+            operatorScopeUseCaseWeights.put(
+                    ManagedMemoryUseCase.OPERATOR,
+                    deriveMemoryWeight(context.getGraphGeneratorConfig()));
             node.setManagedMemoryUseCaseWeights(
                     operatorScopeUseCaseWeights, Collections.emptySet());
         }
+    }
+
+    private static int deriveMemoryWeight(ReadableConfig configuration) {
+        return Math.max(1, configuration.get(ExecutionOptions.SORTED_INPUTS_MEMORY).getMebiBytes());
     }
 
     @SuppressWarnings("rawtypes")

--- a/flink-table/flink-table-api-java/src/main/java/org/apache/flink/table/api/config/ExecutionConfigOptions.java
+++ b/flink-table/flink-table-api-java/src/main/java/org/apache/flink/table/api/config/ExecutionConfigOptions.java
@@ -234,7 +234,8 @@ public class ExecutionConfigOptions {
     public static final ConfigOption<MemorySize> TABLE_EXEC_RESOURCE_HASH_JOIN_MEMORY =
             key("table.exec.resource.hash-join.memory")
                     .memoryType()
-                    .defaultValue(MemorySize.parse("128 mb"))
+                    // in sync with other weights from Table API and DataStream API
+                    .defaultValue(MemorySize.ofMebiBytes(128))
                     .withDescription(
                             "Sets the managed memory for hash join operator. It defines the lower"
                                     + " limit. Note: memory size is only a weight hint, it will affect the weight of"
@@ -247,7 +248,8 @@ public class ExecutionConfigOptions {
     public static final ConfigOption<MemorySize> TABLE_EXEC_RESOURCE_SORT_MEMORY =
             key("table.exec.resource.sort.memory")
                     .memoryType()
-                    .defaultValue(MemorySize.parse("128 mb"))
+                    // in sync with other weights from Table API and DataStream API
+                    .defaultValue(MemorySize.ofMebiBytes(128))
                     .withDescription(
                             "Sets the managed buffer memory size for sort operator. Note: memory"
                                     + " size is only a weight hint, it will affect the weight of memory that can be"

--- a/flink-table/flink-table-planner/src/main/java/org/apache/flink/table/planner/plan/nodes/exec/batch/BatchExecMultipleInput.java
+++ b/flink-table/flink-table-planner/src/main/java/org/apache/flink/table/planner/plan/nodes/exec/batch/BatchExecMultipleInput.java
@@ -118,8 +118,8 @@ public class BatchExecMultipleInput extends ExecNodeBase<RowData>
         // set resources
         multipleInputTransform.setResources(
                 generator.getMinResources(), generator.getPreferredResources());
-        long memoryKB = generator.getManagedMemoryWeight();
-        ExecNodeUtil.setManagedMemoryWeight(multipleInputTransform, memoryKB * 1024L);
+        final int memoryWeight = generator.getManagedMemoryWeight();
+        ExecNodeUtil.setManagedMemoryWeight(multipleInputTransform, memoryWeight);
 
         // set chaining strategy for source chaining
         multipleInputTransform.setChainingStrategy(ChainingStrategy.HEAD_WITH_SOURCES);

--- a/flink-table/flink-table-planner/src/main/java/org/apache/flink/table/planner/plan/nodes/exec/batch/BatchExecMultipleInput.java
+++ b/flink-table/flink-table-planner/src/main/java/org/apache/flink/table/planner/plan/nodes/exec/batch/BatchExecMultipleInput.java
@@ -119,7 +119,8 @@ public class BatchExecMultipleInput extends ExecNodeBase<RowData>
         multipleInputTransform.setResources(
                 generator.getMinResources(), generator.getPreferredResources());
         final int memoryWeight = generator.getManagedMemoryWeight();
-        ExecNodeUtil.setManagedMemoryWeight(multipleInputTransform, memoryWeight);
+        final long memoryBytes = (long) memoryWeight << 20;
+        ExecNodeUtil.setManagedMemoryWeight(multipleInputTransform, memoryBytes);
 
         // set chaining strategy for source chaining
         multipleInputTransform.setChainingStrategy(ChainingStrategy.HEAD_WITH_SOURCES);

--- a/flink-table/flink-table-runtime/src/main/java/org/apache/flink/table/runtime/operators/multipleinput/TableOperatorWrapperGenerator.java
+++ b/flink-table/flink-table-runtime/src/main/java/org/apache/flink/table/runtime/operators/multipleinput/TableOperatorWrapperGenerator.java
@@ -82,8 +82,9 @@ public class TableOperatorWrapperGenerator {
     private int maxParallelism;
     private ResourceSpec minResources;
     private ResourceSpec preferredResources;
-    /** managed memory weight for batch operator. */
-    private long managedMemoryWeight;
+
+    /** Managed memory weight for batch operator in mebibyte. */
+    private int managedMemoryWeight;
 
     public TableOperatorWrapperGenerator(
             List<Transformation<?>> inputTransforms, Transformation<?> tailTransform) {
@@ -139,7 +140,7 @@ public class TableOperatorWrapperGenerator {
         return preferredResources;
     }
 
-    public long getManagedMemoryWeight() {
+    public int getManagedMemoryWeight() {
         return managedMemoryWeight;
     }
 


### PR DESCRIPTION
## What is the purpose of the change

This synchronizes the weights between Table API and DataStream API for managed memory. Otherwise, keyed operators in DataStream API that are used in a unified pipeline would not get enough resources when using a weight of `1`. The weight is declared as a kibibyte value.

## Brief change log

- Use the same default value in keyed operators as for Table API sorting.
- Allow advanced users to change the default value via option `execution.sorted-inputs.memory`.

## Verifying this change

This change added tests and can be verified as follows: `StreamGraphGeneratorBatchExecutionTest`

## Does this pull request potentially affect one of the following parts:

  - Dependencies (does it add or upgrade a dependency): no
  - The public API, i.e., is any changed class annotated with `@Public(Evolving)`: yes
  - The serializers: no
  - The runtime per-record code paths (performance sensitive): no
  - Anything that affects deployment or recovery: JobManager (and its components), Checkpointing, Kubernetes/Yarn, ZooKeeper: no
  - The S3 file system connector: no

## Documentation

  - Does this pull request introduce a new feature? no
  - If yes, how is the feature documented? not applicable
