### PR TITLE
[FLINK-23560][runtime] Calculate absoluteTimeMillis only once for idle metric and throughput calculation.

### DIFF
--- a/flink-runtime/src/main/java/org/apache/flink/runtime/metrics/TimerGauge.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/metrics/TimerGauge.java
@@ -47,14 +47,38 @@ public class TimerGauge implements Gauge<Long>, View {
     }
 
     public synchronized void markStart() {
-        if (currentMeasurementStart == 0) {
-            currentMeasurementStart = clock.absoluteTimeMillis();
-        }
+        markStartUnsafe(clock.absoluteTimeMillis());
     }
 
     public synchronized void markEnd() {
+        markEndUnsafe(clock.absoluteTimeMillis());
+    }
+
+    /**
+     * Duplicate of {@link #markStart()} with ability passing the time from outside for possible
+     * optimization on calling {@link Clock#absoluteTimeMillis()}.
+     */
+    public synchronized void markStart(long absoluteTimeMillis) {
+        markStartUnsafe(absoluteTimeMillis);
+    }
+
+    /**
+     * Duplicate of {@link #markEnd()} with ability passing the time from outside for possible
+     * optimization on calling {@link Clock#absoluteTimeMillis()}.
+     */
+    public synchronized void markEnd(long absoluteTimeMillis) {
+        markEndUnsafe(absoluteTimeMillis);
+    }
+
+    private void markStartUnsafe(long absoluteTimeMillis) {
+        if (currentMeasurementStart == 0) {
+            currentMeasurementStart = absoluteTimeMillis;
+        }
+    }
+
+    private void markEndUnsafe(long absoluteTimeMillis) {
         if (currentMeasurementStart != 0) {
-            currentCount += clock.absoluteTimeMillis() - currentMeasurementStart;
+            currentCount += absoluteTimeMillis - currentMeasurementStart;
             currentMeasurementStart = 0;
         }
     }

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/throughput/ThroughputCalculator.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/throughput/ThroughputCalculator.java
@@ -71,14 +71,15 @@ public class ThroughputCalculator {
     /** @return Calculated throughput based on the collected data for the last period. */
     public long calculateThroughput() {
         if (measurementStartTime != NOT_TRACKED) {
-            currentMeasurementTime += clock.absoluteTimeMillis() - measurementStartTime;
+            long absoluteTimeMillis = clock.absoluteTimeMillis();
+            currentMeasurementTime += absoluteTimeMillis - measurementStartTime;
+            measurementStartTime = absoluteTimeMillis;
         }
 
         long throughput =
                 throughputEMA.calculateThroughput(
                         currentAccumulatedDataSize, currentMeasurementTime);
 
-        measurementStartTime = clock.absoluteTimeMillis();
         currentAccumulatedDataSize = currentMeasurementTime = 0;
 
         return throughput;

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/throughput/ThroughputCalculator.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/throughput/ThroughputCalculator.java
@@ -36,36 +36,49 @@ public class ThroughputCalculator {
     }
 
     public void incomingDataSize(long receivedDataSize) {
-        resumeMeasurement();
+        // Force resuming measurement.
+        if (measurementStartTime == NOT_TRACKED) {
+            measurementStartTime = clock.absoluteTimeMillis();
+        }
         currentAccumulatedDataSize += receivedDataSize;
     }
 
-    /** Mark when the time should not be taken into account. */
-    public void pauseMeasurement() {
+    /**
+     * Mark when the time should not be taken into account.
+     *
+     * @param absoluteTimeMillis Current absolute time received outside to avoid performance drop on
+     *     calling {@link Clock#absoluteTimeMillis()} inside of the method.
+     */
+    public void pauseMeasurement(long absoluteTimeMillis) {
         if (measurementStartTime != NOT_TRACKED) {
-            currentMeasurementTime += clock.relativeTimeMillis() - measurementStartTime;
+            currentMeasurementTime += absoluteTimeMillis - measurementStartTime;
         }
         measurementStartTime = NOT_TRACKED;
     }
 
-    /** Mark when the time should be included to the throughput calculation. */
-    public void resumeMeasurement() {
+    /**
+     * Mark when the time should be included to the throughput calculation.
+     *
+     * @param absoluteTimeMillis Current absolute time received outside to avoid performance drop on
+     *     calling {@link Clock#absoluteTimeMillis()} inside of the method.
+     */
+    public void resumeMeasurement(long absoluteTimeMillis) {
         if (measurementStartTime == NOT_TRACKED) {
-            measurementStartTime = clock.relativeTimeMillis();
+            measurementStartTime = absoluteTimeMillis;
         }
     }
 
     /** @return Calculated throughput based on the collected data for the last period. */
     public long calculateThroughput() {
         if (measurementStartTime != NOT_TRACKED) {
-            currentMeasurementTime += clock.relativeTimeMillis() - measurementStartTime;
+            currentMeasurementTime += clock.absoluteTimeMillis() - measurementStartTime;
         }
 
         long throughput =
                 throughputEMA.calculateThroughput(
                         currentAccumulatedDataSize, currentMeasurementTime);
 
-        measurementStartTime = clock.relativeTimeMillis();
+        measurementStartTime = clock.absoluteTimeMillis();
         currentAccumulatedDataSize = currentMeasurementTime = 0;
 
         return throughput;

--- a/flink-runtime/src/test/java/org/apache/flink/runtime/throughput/ThroughputCalculatorTest.java
+++ b/flink-runtime/src/test/java/org/apache/flink/runtime/throughput/ThroughputCalculatorTest.java
@@ -35,8 +35,6 @@ public class ThroughputCalculatorTest extends TestCase {
     public void testCorrectThroughputCalculation() {
         ManualClock clock = new ManualClock();
         ThroughputCalculator throughputCalculator = new ThroughputCalculator(clock, 10);
-        // Start throughput time.
-        throughputCalculator.calculateThroughput();
 
         throughputCalculator.incomingDataSize(6666);
         clock.advanceTime(Duration.ofMillis(1));
@@ -52,8 +50,6 @@ public class ThroughputCalculatorTest extends TestCase {
     public void testResetValueAfterCalculation() {
         ManualClock clock = new ManualClock();
         ThroughputCalculator throughputCalculator = new ThroughputCalculator(clock, 10);
-        // Start throughput time.
-        throughputCalculator.calculateThroughput();
 
         throughputCalculator.incomingDataSize(666);
         clock.advanceTime(Duration.ofMillis(100));
@@ -70,8 +66,6 @@ public class ThroughputCalculatorTest extends TestCase {
     public void testIgnoringIdleTime() {
         ManualClock clock = new ManualClock();
         ThroughputCalculator throughputCalculator = new ThroughputCalculator(clock, 10);
-        // Start throughput time.
-        throughputCalculator.calculateThroughput();
 
         throughputCalculator.incomingDataSize(7);
         clock.advanceTime(Duration.ofMillis(1));
@@ -89,8 +83,6 @@ public class ThroughputCalculatorTest extends TestCase {
     public void testCalculationDuringIdleTime() {
         ManualClock clock = new ManualClock();
         ThroughputCalculator throughputCalculator = new ThroughputCalculator(clock, 10);
-        // Start throughput time.
-        throughputCalculator.calculateThroughput();
 
         throughputCalculator.incomingDataSize(10);
         clock.advanceTime(Duration.ofMillis(1));
@@ -105,9 +97,6 @@ public class ThroughputCalculatorTest extends TestCase {
     public void testMultiplyIdleEnd() {
         ManualClock clock = new ManualClock();
         ThroughputCalculator throughputCalculator = new ThroughputCalculator(clock, 10);
-
-        // Start throughput time.
-        throughputCalculator.calculateThroughput();
 
         throughputCalculator.incomingDataSize(10);
         // It won't be ignored.
@@ -124,5 +113,25 @@ public class ThroughputCalculatorTest extends TestCase {
 
         // resumeMeasurement should not reset the time because pauseMeasurement was not called.
         assertThat(throughputCalculator.calculateThroughput(), is(1_000L));
+    }
+
+    @Test
+    public void testNotRestartTimerOnCalculationDuringIdleTime() {
+        ManualClock clock = new ManualClock();
+        ThroughputCalculator throughputCalculator = new ThroughputCalculator(clock, 10);
+
+        throughputCalculator.pauseMeasurement(clock.absoluteTimeMillis());
+
+        // Should not resume measurement.
+        throughputCalculator.calculateThroughput();
+
+        // This will be ignored because it is still in idle.
+        clock.advanceTime(Duration.ofMillis(9));
+
+        // Resume measurement.
+        throughputCalculator.incomingDataSize(10);
+        clock.advanceTime(Duration.ofMillis(1));
+
+        assertThat(throughputCalculator.calculateThroughput(), is(10L * 1_000));
     }
 }

--- a/flink-runtime/src/test/java/org/apache/flink/runtime/throughput/ThroughputCalculatorTest.java
+++ b/flink-runtime/src/test/java/org/apache/flink/runtime/throughput/ThroughputCalculatorTest.java
@@ -75,7 +75,7 @@ public class ThroughputCalculatorTest extends TestCase {
 
         throughputCalculator.incomingDataSize(7);
         clock.advanceTime(Duration.ofMillis(1));
-        throughputCalculator.pauseMeasurement();
+        throughputCalculator.pauseMeasurement(clock.absoluteTimeMillis());
         // This will be ignored because it is in idle now.
         clock.advanceTime(Duration.ofMillis(9));
         // This should resume the measurement time.
@@ -94,7 +94,7 @@ public class ThroughputCalculatorTest extends TestCase {
 
         throughputCalculator.incomingDataSize(10);
         clock.advanceTime(Duration.ofMillis(1));
-        throughputCalculator.pauseMeasurement();
+        throughputCalculator.pauseMeasurement(clock.absoluteTimeMillis());
         // This will be ignored because it is in idle now.
         clock.advanceTime(Duration.ofMillis(9));
 
@@ -112,13 +112,13 @@ public class ThroughputCalculatorTest extends TestCase {
         throughputCalculator.incomingDataSize(10);
         // It won't be ignored.
         clock.advanceTime(Duration.ofMillis(3));
-        throughputCalculator.resumeMeasurement();
+        throughputCalculator.resumeMeasurement(clock.absoluteTimeMillis());
         // It won't be ignored.
         clock.advanceTime(Duration.ofMillis(3));
-        throughputCalculator.resumeMeasurement();
+        throughputCalculator.resumeMeasurement(clock.absoluteTimeMillis());
         // It won't be ignored.
         clock.advanceTime(Duration.ofMillis(3));
-        throughputCalculator.resumeMeasurement();
+        throughputCalculator.resumeMeasurement(clock.absoluteTimeMillis());
 
         clock.advanceTime(Duration.ofMillis(1));
 

--- a/flink-streaming-java/src/test/java/org/apache/flink/streaming/runtime/tasks/StreamTaskTest.java
+++ b/flink-streaming-java/src/test/java/org/apache/flink/streaming/runtime/tasks/StreamTaskTest.java
@@ -1536,11 +1536,11 @@ public class StreamTaskTest extends TestLogger {
 
             SystemClock clock = SystemClock.getInstance();
 
-            long startTs = clock.relativeTimeMillis();
+            long startTs = clock.absoluteTimeMillis();
             throughputCalculator.incomingDataSize(incomingDataSize);
             task.invoke();
             long resultThroughput = throughputCalculator.calculateThroughput();
-            long totalDuration = clock.relativeTimeMillis() - startTs;
+            long totalDuration = clock.absoluteTimeMillis() - startTs;
 
             assertThat(
                     resultThroughput,


### PR DESCRIPTION
<!--
*Thank you very much for contributing to Apache Flink - we are happy that you want to help us improve Flink. To help the community review your contribution in the best possible way, please go through the checklist below, which will get the contribution into a shape in which it can be best reviewed.*

*Please understand that we do not do this to make contributions to Flink a hassle. In order to uphold a high standard of quality for code contributions, while at the same time managing a large number of contributions, we need contributors to prepare the contributions well, and give reviewers enough contextual information for the review. Please also understand that contributions that do not follow this guide will take longer to review and thus typically be picked up with lower priority by the community.*

## Contribution Checklist

  - Make sure that the pull request corresponds to a [JIRA issue](https://issues.apache.org/jira/projects/FLINK/issues). Exceptions are made for typos in JavaDoc or documentation files, which need no JIRA issue.
  
  - Name the pull request in the form "[FLINK-XXXX] [component] Title of the pull request", where *FLINK-XXXX* should be replaced by the actual issue number. Skip *component* if you are unsure about which is the best component.
  Typo fixes that have no associated JIRA issue should be named following this pattern: `[hotfix] [docs] Fix typo in event time introduction` or `[hotfix] [javadocs] Expand JavaDoc for PuncuatedWatermarkGenerator`.

  - Fill out the template below to describe the changes contributed by the pull request. That will give reviewers the context they need to do the review.
  
  - Make sure that the change passes the automated tests, i.e., `mvn clean verify` passes. You can set up Azure Pipelines CI to do that following [this guide](https://cwiki.apache.org/confluence/display/FLINK/Azure+Pipelines#AzurePipelines-Tutorial:SettingupAzurePipelinesforaforkoftheFlinkrepository).

  - Each pull request should address only one issue, not mix up code from multiple issues.
  
  - Each commit in the pull request has a meaningful commit message (including the JIRA id)

  - Once all items of the checklist are addressed, remove the above text and this checklist, leaving only the filled out template below.


**(The sections below can be removed for hotfixes of typos)**
-->

## What is the purpose of the change

*PR should fix the performance drop after FLINK-23452 but the result is complicated. When I apply these changes right after the problematic commit I defenetelly see the improvement:

- http://codespeed.dak8s.net:8080/job/flink-benchmark-request/424/
- http://codespeed.dak8s.net:8080/job/flink-benchmark-request/425/
- http://codespeed.dak8s.net:8080/job/flink-benchmark-request/427/
But when I apply these changes on the last master(current branch). The improvement is not so obvious:

- http://codespeed.dak8s.net:8080/job/flink-benchmark-request/422/
- http://codespeed.dak8s.net:8080/job/flink-benchmark-request/423/
- http://codespeed.dak8s.net:8080/job/flink-benchmark-request/426/

I still think that this PR makes sense but perhaps we should continue our investigation at least for the sortedMultiInput
*


## Brief change log
  - *TimerGauge can receive the current absolute time millis from outside rather than calculate it by itself*
  - *ThroughputCalculator can receive the current absolute time millis from outside rather than calculate it by itself*


## Verifying this change

There are refactoring only.

## Does this pull request potentially affect one of the following parts:

  - Dependencies (does it add or upgrade a dependency): (yes / **no**)
  - The public API, i.e., is any changed class annotated with `@Public(Evolving)`: (yes / **no**)
  - The serializers: (yes / **no** / don't know)
  - The runtime per-record code paths (performance sensitive): (yes / **no** / don't know)
  - Anything that affects deployment or recovery: JobManager (and its components), Checkpointing, Kubernetes/Yarn, ZooKeeper: (yes / **no** / don't know)
  - The S3 file system connector: (yes / **no** / don't know)

## Documentation

  - Does this pull request introduce a new feature? (yes / **no**)
  - If yes, how is the feature documented? (not applicable / docs / JavaDocs / not documented)
