### PR TITLE
[FLINK-23708][FLINK-23698][task] Re emit and pass watermarks in finished on restore tasks 

### DIFF
--- a/flink-runtime/src/test/java/org/apache/flink/runtime/io/network/api/writer/RecordOrEventCollectingResultPartitionWriter.java
+++ b/flink-runtime/src/test/java/org/apache/flink/runtime/io/network/api/writer/RecordOrEventCollectingResultPartitionWriter.java
@@ -20,6 +20,7 @@ package org.apache.flink.runtime.io.network.api.writer;
 
 import org.apache.flink.api.common.typeutils.TypeSerializer;
 import org.apache.flink.runtime.event.AbstractEvent;
+import org.apache.flink.runtime.io.network.api.EndOfData;
 import org.apache.flink.runtime.io.network.api.serialization.EventSerializer;
 import org.apache.flink.runtime.io.network.api.serialization.RecordDeserializer;
 import org.apache.flink.runtime.io.network.api.serialization.SpillingAdaptiveSpanningRecordDeserializer;
@@ -41,11 +42,18 @@ public class RecordOrEventCollectingResultPartitionWriter<T>
     private final RecordDeserializer<DeserializationDelegate<T>> deserializer =
             new SpillingAdaptiveSpanningRecordDeserializer<>(
                     new String[] {System.getProperty("java.io.tmpdir")});
+    private final boolean collectNetworkEvents;
 
     public RecordOrEventCollectingResultPartitionWriter(
             Collection<Object> output, TypeSerializer<T> serializer) {
+        this(output, serializer, false);
+    }
+
+    public RecordOrEventCollectingResultPartitionWriter(
+            Collection<Object> output, TypeSerializer<T> serializer, boolean collectNetworkEvents) {
         this.output = checkNotNull(output);
         this.delegate = new NonReusingDeserializationDelegate<>(checkNotNull(serializer));
+        this.collectNetworkEvents = collectNetworkEvents;
     }
 
     @Override
@@ -78,5 +86,12 @@ public class RecordOrEventCollectingResultPartitionWriter<T>
                 output.add(delegate.getInstance());
             }
         } while (!result.isBufferConsumed());
+    }
+
+    @Override
+    public void notifyEndOfData() throws IOException {
+        if (collectNetworkEvents) {
+            broadcastEvent(EndOfData.INSTANCE, false);
+        }
     }
 }

--- a/flink-streaming-java/src/main/java/org/apache/flink/streaming/runtime/io/StreamMultipleInputProcessorFactory.java
+++ b/flink-streaming-java/src/main/java/org/apache/flink/streaming/runtime/io/StreamMultipleInputProcessorFactory.java
@@ -199,7 +199,8 @@ public class StreamMultipleInputProcessorFactory {
             if (configuredInput instanceof StreamConfig.NetworkInputConfig) {
                 StreamTaskNetworkOutput dataOutput =
                         new StreamTaskNetworkOutput<>(
-                                operatorInputs.get(i),
+                                operatorChain.getFinishedOnRestoreInputOrDefault(
+                                        operatorInputs.get(i)),
                                 inputWatermarkGauges[i],
                                 mainOperatorRecordsIn,
                                 networkRecordsIn);
@@ -289,7 +290,7 @@ public class StreamMultipleInputProcessorFactory {
         }
 
         @Override
-        public void emitStreamStatus(StreamStatus streamStatus) throws Exception {
+        public void emitStreamStatus(StreamStatus streamStatus) {
             chainedOutput.emitStreamStatus(streamStatus);
         }
     }

--- a/flink-streaming-java/src/main/java/org/apache/flink/streaming/runtime/tasks/FinishedOnRestoreInput.java
+++ b/flink-streaming-java/src/main/java/org/apache/flink/streaming/runtime/tasks/FinishedOnRestoreInput.java
@@ -1,0 +1,73 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.flink.streaming.runtime.tasks;
+
+import org.apache.flink.streaming.api.operators.Input;
+import org.apache.flink.streaming.api.watermark.Watermark;
+import org.apache.flink.streaming.runtime.io.RecordWriterOutput;
+import org.apache.flink.streaming.runtime.streamrecord.LatencyMarker;
+import org.apache.flink.streaming.runtime.streamrecord.StreamRecord;
+import org.apache.flink.streaming.runtime.streamstatus.StreamStatus;
+
+/** A fake {@link Input} for finished on restore tasks. */
+public class FinishedOnRestoreInput<IN> implements Input<IN> {
+    private final RecordWriterOutput<?>[] streamOutputs;
+    private final int inputCount;
+
+    private int watermarksSeen = 0;
+
+    public FinishedOnRestoreInput(RecordWriterOutput<?>[] streamOutputs, int inputCount) {
+        this.streamOutputs = streamOutputs;
+        this.inputCount = inputCount;
+    }
+
+    @Override
+    public void processElement(StreamRecord<IN> element) throws Exception {
+        throw new IllegalStateException();
+    }
+
+    @Override
+    public void processWatermark(Watermark watermark) {
+        if (watermark.getTimestamp() != Watermark.MAX_WATERMARK.getTimestamp()) {
+            throw new IllegalStateException(
+                    String.format(
+                            "We should not receive any watermarks [%s] other than the MAX_WATERMARK if finished on restore",
+                            watermark));
+        }
+        if (++watermarksSeen == inputCount) {
+            for (RecordWriterOutput<?> streamOutput : streamOutputs) {
+                streamOutput.emitWatermark(watermark);
+            }
+        }
+    }
+
+    @Override
+    public void processStreamStatus(StreamStatus streamStatus) throws Exception {
+        throw new IllegalStateException();
+    }
+
+    @Override
+    public void processLatencyMarker(LatencyMarker latencyMarker) throws Exception {
+        throw new IllegalStateException();
+    }
+
+    @Override
+    public void setKeyContextElement(StreamRecord<IN> record) throws Exception {
+        throw new IllegalStateException();
+    }
+}

--- a/flink-streaming-java/src/main/java/org/apache/flink/streaming/runtime/tasks/FinishedOperatorChain.java
+++ b/flink-streaming-java/src/main/java/org/apache/flink/streaming/runtime/tasks/FinishedOperatorChain.java
@@ -64,11 +64,7 @@ public class FinishedOperatorChain<OUT, OP extends StreamOperator<OUT>>
     public void prepareSnapshotPreBarrier(long checkpointId) {}
 
     @Override
-    public void endInput(int inputId) throws Exception {
-        if (mainOperatorWrapper != null) {
-            mainOperatorWrapper.endOperatorInput(inputId);
-        }
-    }
+    public void endInput(int inputId) throws Exception {}
 
     @Override
     public void initializeStateAndOpenOperators(

--- a/flink-streaming-java/src/main/java/org/apache/flink/streaming/runtime/tasks/FinishedOperatorChain.java
+++ b/flink-streaming-java/src/main/java/org/apache/flink/streaming/runtime/tasks/FinishedOperatorChain.java
@@ -1,0 +1,100 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.flink.streaming.runtime.tasks;
+
+import org.apache.flink.annotation.Internal;
+import org.apache.flink.runtime.checkpoint.CheckpointMetaData;
+import org.apache.flink.runtime.checkpoint.CheckpointOptions;
+import org.apache.flink.runtime.checkpoint.channel.ChannelStateWriter;
+import org.apache.flink.runtime.io.network.api.writer.RecordWriterDelegate;
+import org.apache.flink.runtime.jobgraph.OperatorID;
+import org.apache.flink.runtime.operators.coordination.OperatorEvent;
+import org.apache.flink.runtime.plugable.SerializationDelegate;
+import org.apache.flink.runtime.state.CheckpointStreamFactory;
+import org.apache.flink.runtime.state.TaskStateManager;
+import org.apache.flink.streaming.api.operators.OperatorSnapshotFutures;
+import org.apache.flink.streaming.api.operators.StreamOperator;
+import org.apache.flink.streaming.api.operators.StreamTaskStateInitializer;
+import org.apache.flink.streaming.runtime.streamrecord.StreamRecord;
+import org.apache.flink.util.SerializedValue;
+
+import java.util.Map;
+import java.util.function.Supplier;
+
+/**
+ * The {@link OperatorChain} that is used for restoring tasks that are {@link
+ * TaskStateManager#isFinishedOnRestore()}.
+ */
+@Internal
+public class FinishedOperatorChain<OUT, OP extends StreamOperator<OUT>>
+        extends OperatorChain<OUT, OP> {
+
+    public FinishedOperatorChain(
+            StreamTask<OUT, OP> containingTask,
+            RecordWriterDelegate<SerializationDelegate<StreamRecord<OUT>>> recordWriterDelegate) {
+        super(containingTask, recordWriterDelegate);
+    }
+
+    @Override
+    public boolean isFinishedOnRestore() {
+        return true;
+    }
+
+    @Override
+    public void dispatchOperatorEvent(OperatorID operator, SerializedValue<OperatorEvent> event) {
+        throw new UnsupportedOperationException();
+    }
+
+    @Override
+    public void prepareSnapshotPreBarrier(long checkpointId) {}
+
+    @Override
+    public void endInput(int inputId) throws Exception {
+        if (mainOperatorWrapper != null) {
+            mainOperatorWrapper.endOperatorInput(inputId);
+        }
+    }
+
+    @Override
+    public void initializeStateAndOpenOperators(
+            StreamTaskStateInitializer streamTaskStateInitializer) {}
+
+    @Override
+    public void finishOperators(StreamTaskActionExecutor actionExecutor) throws Exception {}
+
+    @Override
+    public void notifyCheckpointComplete(long checkpointId) throws Exception {}
+
+    @Override
+    public void notifyCheckpointAborted(long checkpointId) throws Exception {}
+
+    @Override
+    public boolean isClosed() {
+        return isClosed;
+    }
+
+    @Override
+    public void snapshotState(
+            Map<OperatorID, OperatorSnapshotFutures> operatorSnapshotsInProgress,
+            CheckpointMetaData checkpointMetaData,
+            CheckpointOptions checkpointOptions,
+            Supplier<Boolean> isRunning,
+            ChannelStateWriter.ChannelStateWriteResult channelStateWriteResult,
+            CheckpointStreamFactory storage)
+            throws Exception {}
+}

--- a/flink-streaming-java/src/main/java/org/apache/flink/streaming/runtime/tasks/OperatorChain.java
+++ b/flink-streaming-java/src/main/java/org/apache/flink/streaming/runtime/tasks/OperatorChain.java
@@ -1,12 +1,13 @@
 /*
- * Licensed to the Apache Software Foundation (ASF) under one or more
- * contributor license agreements.  See the NOTICE file distributed with
- * this work for additional information regarding copyright ownership.
- * The ASF licenses this file to You under the Apache License, Version 2.0
- * (the "License"); you may not use this file except in compliance with
- * the License.  You may obtain a copy of the License at
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
  *
- *    http://www.apache.org/licenses/LICENSE-2.0
+ *     http://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,
@@ -17,10 +18,12 @@
 
 package org.apache.flink.streaming.runtime.tasks;
 
-import org.apache.flink.annotation.Internal;
 import org.apache.flink.annotation.VisibleForTesting;
 import org.apache.flink.api.common.typeutils.TypeSerializer;
 import org.apache.flink.api.java.tuple.Tuple2;
+import org.apache.flink.runtime.checkpoint.CheckpointMetaData;
+import org.apache.flink.runtime.checkpoint.CheckpointOptions;
+import org.apache.flink.runtime.checkpoint.channel.ChannelStateWriter;
 import org.apache.flink.runtime.event.AbstractEvent;
 import org.apache.flink.runtime.execution.Environment;
 import org.apache.flink.runtime.io.network.api.writer.RecordWriter;
@@ -32,14 +35,14 @@ import org.apache.flink.runtime.metrics.groups.OperatorMetricGroup;
 import org.apache.flink.runtime.operators.coordination.OperatorEvent;
 import org.apache.flink.runtime.operators.coordination.OperatorEventDispatcher;
 import org.apache.flink.runtime.plugable.SerializationDelegate;
+import org.apache.flink.runtime.state.CheckpointStreamFactory;
 import org.apache.flink.streaming.api.graph.StreamConfig;
-import org.apache.flink.streaming.api.graph.StreamConfig.InputConfig;
-import org.apache.flink.streaming.api.graph.StreamConfig.SourceInputConfig;
 import org.apache.flink.streaming.api.graph.StreamEdge;
 import org.apache.flink.streaming.api.operators.BoundedMultiInput;
 import org.apache.flink.streaming.api.operators.Input;
 import org.apache.flink.streaming.api.operators.MultipleInputStreamOperator;
 import org.apache.flink.streaming.api.operators.OneInputStreamOperator;
+import org.apache.flink.streaming.api.operators.OperatorSnapshotFutures;
 import org.apache.flink.streaming.api.operators.Output;
 import org.apache.flink.streaming.api.operators.SourceOperator;
 import org.apache.flink.streaming.api.operators.StreamOperator;
@@ -70,9 +73,9 @@ import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
 import java.util.Optional;
+import java.util.function.Supplier;
 import java.util.stream.Collectors;
 
-import static org.apache.flink.util.ExceptionUtils.firstOrSuppressed;
 import static org.apache.flink.util.Preconditions.checkArgument;
 import static org.apache.flink.util.Preconditions.checkNotNull;
 import static org.apache.flink.util.Preconditions.checkState;
@@ -88,17 +91,14 @@ import static org.apache.flink.util.Preconditions.checkState;
  * @param <OUT> The type of elements accepted by the chain, i.e., the input type of the chain's main
  *     operator.
  */
-@Internal
-public class OperatorChain<OUT, OP extends StreamOperator<OUT>>
+public abstract class OperatorChain<OUT, OP extends StreamOperator<OUT>>
         implements BoundedMultiInput, Closeable {
 
     private static final Logger LOG = LoggerFactory.getLogger(OperatorChain.class);
 
-    private final RecordWriterOutput<?>[] streamOutputs;
+    protected final RecordWriterOutput<?>[] streamOutputs;
 
-    private final WatermarkGaugeExposingOutput<StreamRecord<OUT>> mainOperatorOutput;
-
-    private final boolean finishedOnRestore;
+    protected final WatermarkGaugeExposingOutput<StreamRecord<OUT>> mainOperatorOutput;
 
     /**
      * For iteration, {@link StreamIterationHead} and {@link StreamIterationTail} used for executing
@@ -122,23 +122,24 @@ public class OperatorChain<OUT, OP extends StreamOperator<OUT>>
      * traversed: first, second, main, ..., tail or in reversed order: tail, ..., main, second,
      * first
      */
-    @Nullable private final StreamOperatorWrapper<OUT, OP> mainOperatorWrapper;
+    @Nullable protected final StreamOperatorWrapper<OUT, OP> mainOperatorWrapper;
 
-    @Nullable private final StreamOperatorWrapper<?, ?> firstOperatorWrapper;
-    @Nullable private final StreamOperatorWrapper<?, ?> tailOperatorWrapper;
+    @Nullable protected final StreamOperatorWrapper<?, ?> firstOperatorWrapper;
+    @Nullable protected final StreamOperatorWrapper<?, ?> tailOperatorWrapper;
 
-    private final Map<SourceInputConfig, ChainedSource> chainedSources;
+    protected final Map<StreamConfig.SourceInputConfig, ChainedSource> chainedSources;
 
-    private final int numOperators;
+    protected final int numOperators;
 
-    private final OperatorEventDispatcherImpl operatorEventDispatcher;
+    protected final OperatorEventDispatcherImpl operatorEventDispatcher;
 
-    private final Closer closer = Closer.create();
+    protected final Closer closer = Closer.create();
+
+    protected boolean isClosed;
 
     public OperatorChain(
             StreamTask<OUT, OP> containingTask,
-            RecordWriterDelegate<SerializationDelegate<StreamRecord<OUT>>> recordWriterDelegate,
-            boolean finishedOnRestore) {
+            RecordWriterDelegate<SerializationDelegate<StreamRecord<OUT>>> recordWriterDelegate) {
 
         this.operatorEventDispatcher =
                 new OperatorEventDispatcherImpl(
@@ -161,7 +162,6 @@ public class OperatorChain<OUT, OP extends StreamOperator<OUT>>
         Map<StreamEdge, RecordWriterOutput<?>> streamOutputMap =
                 new HashMap<>(outEdgesInOrder.size());
         this.streamOutputs = new RecordWriterOutput<?>[outEdgesInOrder.size()];
-        this.finishedOnRestore = finishedOnRestore;
 
         // from here on, we need to make sure that the output writers are shut down again on failure
         boolean success = false;
@@ -236,10 +236,11 @@ public class OperatorChain<OUT, OP extends StreamOperator<OUT>>
             // make sure we clean up after ourselves in case of a failure after acquiring
             // the first resources
             if (!success) {
-                for (RecordWriterOutput<?> output : this.streamOutputs) {
-                    if (output != null) {
-                        output.close();
+                for (int i = 0; i < streamOutputs.length; i++) {
+                    if (streamOutputs[i] != null) {
+                        streamOutputs[i].close();
                     }
+                    streamOutputs[i] = null;
                 }
             }
         }
@@ -251,8 +252,7 @@ public class OperatorChain<OUT, OP extends StreamOperator<OUT>>
             RecordWriterOutput<?>[] streamOutputs,
             WatermarkGaugeExposingOutput<StreamRecord<OUT>> mainOperatorOutput,
             StreamOperatorWrapper<OUT, OP> mainOperatorWrapper) {
-
-        this.streamOutputs = checkNotNull(streamOutputs);
+        this.streamOutputs = streamOutputs;
         this.mainOperatorOutput = checkNotNull(mainOperatorOutput);
         this.operatorEventDispatcher = null;
 
@@ -263,133 +263,52 @@ public class OperatorChain<OUT, OP extends StreamOperator<OUT>>
         this.chainedSources = Collections.emptyMap();
 
         firstOperatorWrapper = linkOperatorWrappers(allOperatorWrappers);
-        finishedOnRestore = false;
     }
 
-    private void createChainOutputs(
-            List<StreamEdge> outEdgesInOrder,
-            RecordWriterDelegate<SerializationDelegate<StreamRecord<OUT>>> recordWriterDelegate,
-            Map<Integer, StreamConfig> chainedConfigs,
-            StreamTask<OUT, OP> containingTask,
-            Map<StreamEdge, RecordWriterOutput<?>> streamOutputMap) {
-        for (int i = 0; i < outEdgesInOrder.size(); i++) {
-            StreamEdge outEdge = outEdgesInOrder.get(i);
+    public abstract boolean isFinishedOnRestore();
 
-            RecordWriterOutput<?> streamOutput =
-                    createStreamOutput(
-                            recordWriterDelegate.getRecordWriter(i),
-                            outEdge,
-                            chainedConfigs.get(outEdge.getSourceId()),
-                            containingTask.getEnvironment());
+    public abstract void dispatchOperatorEvent(
+            OperatorID operator, SerializedValue<OperatorEvent> event) throws FlinkException;
 
-            this.streamOutputs[i] = streamOutput;
-            streamOutputMap.put(outEdge, streamOutput);
-        }
-    }
+    public abstract void prepareSnapshotPreBarrier(long checkpointId) throws Exception;
 
-    @SuppressWarnings("rawtypes")
-    private Map<SourceInputConfig, ChainedSource> createChainedSources(
-            StreamTask<OUT, OP> containingTask,
-            InputConfig[] configuredInputs,
-            Map<Integer, StreamConfig> chainedConfigs,
-            ClassLoader userCodeClassloader,
-            List<StreamOperatorWrapper<?, ?>> allOpWrappers) {
-        if (Arrays.stream(configuredInputs)
-                .noneMatch(input -> input instanceof SourceInputConfig)) {
-            return Collections.emptyMap();
-        }
-        checkState(
-                mainOperatorWrapper.getStreamOperator() instanceof MultipleInputStreamOperator,
-                "Creating chained input is only supported with MultipleInputStreamOperator and MultipleInputStreamTask");
-        Map<SourceInputConfig, ChainedSource> chainedSourceInputs = new HashMap<>();
-        MultipleInputStreamOperator<?> multipleInputOperator =
-                (MultipleInputStreamOperator<?>) mainOperatorWrapper.getStreamOperator();
-        List<Input> operatorInputs = multipleInputOperator.getInputs();
+    /**
+     * Ends the main operator input specified by {@code inputId}).
+     *
+     * @param inputId the input ID starts from 1 which indicates the first input.
+     */
+    public abstract void endInput(int inputId) throws Exception;
 
-        int sourceInputGateIndex =
-                Arrays.stream(containingTask.getEnvironment().getAllInputGates())
-                                .mapToInt(IndexedInputGate::getInputGateIndex)
-                                .max()
-                                .orElse(-1)
-                        + 1;
+    /**
+     * Initialize state and open all operators in the chain from <b>tail to heads</b>, contrary to
+     * {@link StreamOperator#close()} which happens <b>heads to tail</b> (see {@link
+     * #finishOperators(StreamTaskActionExecutor)}).
+     */
+    public abstract void initializeStateAndOpenOperators(
+            StreamTaskStateInitializer streamTaskStateInitializer) throws Exception;
 
-        for (int inputId = 0; inputId < configuredInputs.length; inputId++) {
-            if (!(configuredInputs[inputId] instanceof SourceInputConfig)) {
-                continue;
-            }
-            SourceInputConfig sourceInput = (SourceInputConfig) configuredInputs[inputId];
-            int sourceEdgeId = sourceInput.getInputEdge().getSourceId();
-            StreamConfig sourceInputConfig = chainedConfigs.get(sourceEdgeId);
-            OutputTag outputTag = sourceInput.getInputEdge().getOutputTag();
+    /**
+     * Closes all operators in a chain effect way. Closing happens from <b>heads to tail</b>
+     * operator in the chain, contrary to {@link StreamOperator#open()} which happens <b>tail to
+     * heads</b> (see {@link #initializeStateAndOpenOperators(StreamTaskStateInitializer)}).
+     */
+    public abstract void finishOperators(StreamTaskActionExecutor actionExecutor) throws Exception;
 
-            WatermarkGaugeExposingOutput chainedSourceOutput =
-                    createChainedSourceOutput(
-                            containingTask,
-                            sourceInputConfig,
-                            userCodeClassloader,
-                            operatorInputs.get(inputId),
-                            (OperatorMetricGroup) multipleInputOperator.getMetricGroup(),
-                            outputTag);
+    public abstract void notifyCheckpointComplete(long checkpointId) throws Exception;
 
-            SourceOperator<?, ?> sourceOperator =
-                    (SourceOperator<?, ?>)
-                            createOperator(
-                                    containingTask,
-                                    sourceInputConfig,
-                                    userCodeClassloader,
-                                    (WatermarkGaugeExposingOutput<StreamRecord<OUT>>)
-                                            chainedSourceOutput,
-                                    allOpWrappers,
-                                    true);
-            chainedSourceInputs.put(
-                    sourceInput,
-                    new ChainedSource(
-                            chainedSourceOutput,
-                            finishedOnRestore
-                                    ? new StreamTaskFinishedOnRestoreSourceInput<>(
-                                            sourceOperator, sourceInputGateIndex++, inputId)
-                                    : new StreamTaskSourceInput<>(
-                                            sourceOperator, sourceInputGateIndex++, inputId)));
-        }
-        return chainedSourceInputs;
-    }
+    public abstract void notifyCheckpointAborted(long checkpointId) throws Exception;
 
-    @SuppressWarnings({"rawtypes", "unchecked"})
-    private WatermarkGaugeExposingOutput<StreamRecord> createChainedSourceOutput(
-            StreamTask<?, OP> containingTask,
-            StreamConfig sourceInputConfig,
-            ClassLoader userCodeClassloader,
-            Input input,
-            OperatorMetricGroup metricGroup,
-            OutputTag outputTag) {
-
-        WatermarkGaugeExposingOutput<StreamRecord> chainedSourceOutput;
-        if (containingTask.getExecutionConfig().isObjectReuseEnabled()) {
-            chainedSourceOutput = new ChainingOutput(input, metricGroup, outputTag);
-        } else {
-            TypeSerializer<?> inSerializer =
-                    sourceInputConfig.getTypeSerializerOut(userCodeClassloader);
-            chainedSourceOutput =
-                    new CopyingChainingOutput(input, inSerializer, metricGroup, outputTag);
-        }
-        /**
-         * Chained sources are closed when {@link
-         * org.apache.flink.streaming.runtime.io.StreamTaskSourceInput} are being closed.
-         */
-        return closer.register(chainedSourceOutput);
-    }
-
-    public boolean isFinishedOnRestore() {
-        return finishedOnRestore;
-    }
+    public abstract void snapshotState(
+            Map<OperatorID, OperatorSnapshotFutures> operatorSnapshotsInProgress,
+            CheckpointMetaData checkpointMetaData,
+            CheckpointOptions checkpointOptions,
+            Supplier<Boolean> isRunning,
+            ChannelStateWriter.ChannelStateWriteResult channelStateWriteResult,
+            CheckpointStreamFactory storage)
+            throws Exception;
 
     public OperatorEventDispatcher getOperatorEventDispatcher() {
         return operatorEventDispatcher;
-    }
-
-    public void dispatchOperatorEvent(OperatorID operator, SerializedValue<OperatorEvent> event)
-            throws FlinkException {
-        operatorEventDispatcher.dispatchEventToHandlers(operator, event);
     }
 
     public void broadcastEvent(AbstractEvent event) throws IOException {
@@ -402,85 +321,12 @@ public class OperatorChain<OUT, OP extends StreamOperator<OUT>>
         }
     }
 
-    public void prepareSnapshotPreBarrier(long checkpointId) throws Exception {
-        if (finishedOnRestore) {
-            return;
-        }
-
-        // go forward through the operator chain and tell each operator
-        // to prepare the checkpoint
-        for (StreamOperatorWrapper<?, ?> operatorWrapper : getAllOperators()) {
-            if (!operatorWrapper.isClosed()) {
-                operatorWrapper.getStreamOperator().prepareSnapshotPreBarrier(checkpointId);
-            }
-        }
-    }
-
-    /**
-     * Ends the main operator input specified by {@code inputId}).
-     *
-     * @param inputId the input ID starts from 1 which indicates the first input.
-     */
-    @Override
-    public void endInput(int inputId) throws Exception {
-        if (mainOperatorWrapper != null) {
-            mainOperatorWrapper.endOperatorInput(inputId);
-        }
-    }
-
-    /**
-     * Initialize state and open all operators in the chain from <b>tail to heads</b>, contrary to
-     * {@link StreamOperator#close()} which happens <b>heads to tail</b> (see {@link
-     * #finishOperators(StreamTaskActionExecutor)}).
-     */
-    protected void initializeStateAndOpenOperators(
-            StreamTaskStateInitializer streamTaskStateInitializer) throws Exception {
-        if (finishedOnRestore) {
-            return;
-        }
-
-        for (StreamOperatorWrapper<?, ?> operatorWrapper : getAllOperators(true)) {
-            StreamOperator<?> operator = operatorWrapper.getStreamOperator();
-            operator.initializeState(streamTaskStateInitializer);
-            operator.open();
-        }
-    }
-
-    /**
-     * Closes all operators in a chain effect way. Closing happens from <b>heads to tail</b>
-     * operator in the chain, contrary to {@link StreamOperator#open()} which happens <b>tail to
-     * heads</b> (see {@link #initializeStateAndOpenOperators(StreamTaskStateInitializer)}).
-     */
-    protected void finishOperators(StreamTaskActionExecutor actionExecutor) throws Exception {
-        if (finishedOnRestore) {
-            return;
-        }
-
-        if (firstOperatorWrapper != null) {
-            firstOperatorWrapper.finish(actionExecutor);
-        }
-    }
-
     /**
      * Execute {@link StreamOperator#close()} of each operator in the chain of this {@link
      * StreamTask}. Closing happens from <b>tail to head</b> operator in the chain.
      */
-    protected void closeAllOperators() throws Exception {
-        if (finishedOnRestore) {
-            return;
-        }
-
-        Exception closingException = null;
-        for (StreamOperatorWrapper<?, ?> operatorWrapper : getAllOperators(true)) {
-            try {
-                operatorWrapper.close();
-            } catch (Exception e) {
-                closingException = firstOrSuppressed(e, closingException);
-            }
-        }
-        if (closingException != null) {
-            throw closingException;
-        }
+    public void closeAllOperators() throws Exception {
+        isClosed = true;
     }
 
     public RecordWriterOutput<?>[] getStreamOutputs() {
@@ -488,6 +334,7 @@ public class OperatorChain<OUT, OP extends StreamOperator<OUT>>
     }
 
     /** Returns an {@link Iterable} which traverses all operators in forward topological order. */
+    @VisibleForTesting
     public Iterable<StreamOperatorWrapper<?, ?>> getAllOperators() {
         return getAllOperators(false);
     }
@@ -496,7 +343,7 @@ public class OperatorChain<OUT, OP extends StreamOperator<OUT>>
      * Returns an {@link Iterable} which traverses all operators in forward or reverse topological
      * order.
      */
-    public Iterable<StreamOperatorWrapper<?, ?>> getAllOperators(boolean reverse) {
+    protected Iterable<StreamOperatorWrapper<?, ?>> getAllOperators(boolean reverse) {
         return reverse
                 ? new StreamOperatorWrapper.ReadIterator(tailOperatorWrapper, true)
                 : new StreamOperatorWrapper.ReadIterator(mainOperatorWrapper, false);
@@ -511,7 +358,7 @@ public class OperatorChain<OUT, OP extends StreamOperator<OUT>>
     }
 
     public WatermarkGaugeExposingOutput<StreamRecord<?>> getChainedSourceOutput(
-            SourceInputConfig sourceInput) {
+            StreamConfig.SourceInputConfig sourceInput) {
         checkArgument(
                 chainedSources.containsKey(sourceInput),
                 "Chained source with sourcedId = [%s] was not found",
@@ -525,7 +372,7 @@ public class OperatorChain<OUT, OP extends StreamOperator<OUT>>
                 .collect(Collectors.toList());
     }
 
-    public StreamTaskSourceInput<?> getSourceTaskInput(SourceInputConfig sourceInput) {
+    public StreamTaskSourceInput<?> getSourceTaskInput(StreamConfig.SourceInputConfig sourceInput) {
         checkArgument(
                 chainedSources.containsKey(sourceInput),
                 "Chained source with sourcedId = [%s] was not found",
@@ -567,9 +414,178 @@ public class OperatorChain<OUT, OP extends StreamOperator<OUT>>
         return (mainOperatorWrapper == null) ? null : mainOperatorWrapper.getStreamOperator();
     }
 
+    public boolean isClosed() {
+        return isClosed;
+    }
+
+    /** Wrapper class to access the chained sources and their's outputs. */
+    public static class ChainedSource {
+        private final WatermarkGaugeExposingOutput<StreamRecord<?>> chainedSourceOutput;
+        private final StreamTaskSourceInput<?> sourceTaskInput;
+
+        public ChainedSource(
+                WatermarkGaugeExposingOutput<StreamRecord<?>> chainedSourceOutput,
+                StreamTaskSourceInput<?> sourceTaskInput) {
+            this.chainedSourceOutput = chainedSourceOutput;
+            this.sourceTaskInput = sourceTaskInput;
+        }
+
+        public WatermarkGaugeExposingOutput<StreamRecord<?>> getSourceOutput() {
+            return chainedSourceOutput;
+        }
+
+        public StreamTaskSourceInput<?> getSourceTaskInput() {
+            return sourceTaskInput;
+        }
+    }
+
     // ------------------------------------------------------------------------
     //  initialization utilities
     // ------------------------------------------------------------------------
+
+    private void createChainOutputs(
+            List<StreamEdge> outEdgesInOrder,
+            RecordWriterDelegate<SerializationDelegate<StreamRecord<OUT>>> recordWriterDelegate,
+            Map<Integer, StreamConfig> chainedConfigs,
+            StreamTask<OUT, OP> containingTask,
+            Map<StreamEdge, RecordWriterOutput<?>> streamOutputMap) {
+        for (int i = 0; i < outEdgesInOrder.size(); i++) {
+            StreamEdge outEdge = outEdgesInOrder.get(i);
+
+            RecordWriterOutput<?> streamOutput =
+                    createStreamOutput(
+                            recordWriterDelegate.getRecordWriter(i),
+                            outEdge,
+                            chainedConfigs.get(outEdge.getSourceId()),
+                            containingTask.getEnvironment());
+
+            this.streamOutputs[i] = streamOutput;
+            streamOutputMap.put(outEdge, streamOutput);
+        }
+    }
+
+    private RecordWriterOutput<OUT> createStreamOutput(
+            RecordWriter<SerializationDelegate<StreamRecord<OUT>>> recordWriter,
+            StreamEdge edge,
+            StreamConfig upStreamConfig,
+            Environment taskEnvironment) {
+        OutputTag sideOutputTag = edge.getOutputTag(); // OutputTag, return null if not sideOutput
+
+        TypeSerializer outSerializer;
+
+        if (edge.getOutputTag() != null) {
+            // side output
+            outSerializer =
+                    upStreamConfig.getTypeSerializerSideOut(
+                            edge.getOutputTag(),
+                            taskEnvironment.getUserCodeClassLoader().asClassLoader());
+        } else {
+            // main output
+            outSerializer =
+                    upStreamConfig.getTypeSerializerOut(
+                            taskEnvironment.getUserCodeClassLoader().asClassLoader());
+        }
+
+        return closer.register(
+                new RecordWriterOutput<OUT>(
+                        recordWriter,
+                        outSerializer,
+                        sideOutputTag,
+                        edge.supportsUnalignedCheckpoints()));
+    }
+
+    @SuppressWarnings("rawtypes")
+    private Map<StreamConfig.SourceInputConfig, ChainedSource> createChainedSources(
+            StreamTask<OUT, OP> containingTask,
+            StreamConfig.InputConfig[] configuredInputs,
+            Map<Integer, StreamConfig> chainedConfigs,
+            ClassLoader userCodeClassloader,
+            List<StreamOperatorWrapper<?, ?>> allOpWrappers) {
+        if (Arrays.stream(configuredInputs)
+                .noneMatch(input -> input instanceof StreamConfig.SourceInputConfig)) {
+            return Collections.emptyMap();
+        }
+        checkState(
+                mainOperatorWrapper.getStreamOperator() instanceof MultipleInputStreamOperator,
+                "Creating chained input is only supported with MultipleInputStreamOperator and MultipleInputStreamTask");
+        Map<StreamConfig.SourceInputConfig, ChainedSource> chainedSourceInputs = new HashMap<>();
+        MultipleInputStreamOperator<?> multipleInputOperator =
+                (MultipleInputStreamOperator<?>) mainOperatorWrapper.getStreamOperator();
+        List<Input> operatorInputs = multipleInputOperator.getInputs();
+
+        int sourceInputGateIndex =
+                Arrays.stream(containingTask.getEnvironment().getAllInputGates())
+                                .mapToInt(IndexedInputGate::getInputGateIndex)
+                                .max()
+                                .orElse(-1)
+                        + 1;
+
+        for (int inputId = 0; inputId < configuredInputs.length; inputId++) {
+            if (!(configuredInputs[inputId] instanceof StreamConfig.SourceInputConfig)) {
+                continue;
+            }
+            StreamConfig.SourceInputConfig sourceInput =
+                    (StreamConfig.SourceInputConfig) configuredInputs[inputId];
+            int sourceEdgeId = sourceInput.getInputEdge().getSourceId();
+            StreamConfig sourceInputConfig = chainedConfigs.get(sourceEdgeId);
+            OutputTag outputTag = sourceInput.getInputEdge().getOutputTag();
+
+            WatermarkGaugeExposingOutput chainedSourceOutput =
+                    createChainedSourceOutput(
+                            containingTask,
+                            sourceInputConfig,
+                            userCodeClassloader,
+                            operatorInputs.get(inputId),
+                            (OperatorMetricGroup) multipleInputOperator.getMetricGroup(),
+                            outputTag);
+
+            SourceOperator<?, ?> sourceOperator =
+                    (SourceOperator<?, ?>)
+                            createOperator(
+                                    containingTask,
+                                    sourceInputConfig,
+                                    userCodeClassloader,
+                                    (WatermarkGaugeExposingOutput<StreamRecord<OUT>>)
+                                            chainedSourceOutput,
+                                    allOpWrappers,
+                                    true);
+            chainedSourceInputs.put(
+                    sourceInput,
+                    new ChainedSource(
+                            chainedSourceOutput,
+                            this.isFinishedOnRestore()
+                                    ? new StreamTaskFinishedOnRestoreSourceInput<>(
+                                            sourceOperator, sourceInputGateIndex++, inputId)
+                                    : new StreamTaskSourceInput<>(
+                                            sourceOperator, sourceInputGateIndex++, inputId)));
+        }
+        return chainedSourceInputs;
+    }
+
+    @SuppressWarnings({"rawtypes", "unchecked"})
+    private WatermarkGaugeExposingOutput<StreamRecord> createChainedSourceOutput(
+            StreamTask<?, OP> containingTask,
+            StreamConfig sourceInputConfig,
+            ClassLoader userCodeClassloader,
+            Input input,
+            OperatorMetricGroup metricGroup,
+            OutputTag outputTag) {
+
+        WatermarkGaugeExposingOutput<StreamRecord> chainedSourceOutput;
+        if (containingTask.getExecutionConfig().isObjectReuseEnabled()) {
+            chainedSourceOutput = new ChainingOutput(input, metricGroup, outputTag);
+        } else {
+            TypeSerializer<?> inSerializer =
+                    sourceInputConfig.getTypeSerializerOut(userCodeClassloader);
+            chainedSourceOutput =
+                    new CopyingChainingOutput(input, inSerializer, metricGroup, outputTag);
+        }
+        /**
+         * Chained sources are closed when {@link
+         * org.apache.flink.streaming.runtime.io.StreamTaskSourceInput} are being closed.
+         */
+        return closer.register(chainedSourceOutput);
+    }
 
     private <T> WatermarkGaugeExposingOutput<StreamRecord<T>> createOutputCollector(
             StreamTask<?, ?> containingTask,
@@ -731,36 +747,6 @@ public class OperatorChain<OUT, OP extends StreamOperator<OUT>>
         return closer.register(currentOperatorOutput);
     }
 
-    private RecordWriterOutput<OUT> createStreamOutput(
-            RecordWriter<SerializationDelegate<StreamRecord<OUT>>> recordWriter,
-            StreamEdge edge,
-            StreamConfig upStreamConfig,
-            Environment taskEnvironment) {
-        OutputTag sideOutputTag = edge.getOutputTag(); // OutputTag, return null if not sideOutput
-
-        TypeSerializer outSerializer;
-
-        if (edge.getOutputTag() != null) {
-            // side output
-            outSerializer =
-                    upStreamConfig.getTypeSerializerSideOut(
-                            edge.getOutputTag(),
-                            taskEnvironment.getUserCodeClassLoader().asClassLoader());
-        } else {
-            // main output
-            outSerializer =
-                    upStreamConfig.getTypeSerializerOut(
-                            taskEnvironment.getUserCodeClassLoader().asClassLoader());
-        }
-
-        return closer.register(
-                new RecordWriterOutput<OUT>(
-                        recordWriter,
-                        outSerializer,
-                        sideOutputTag,
-                        edge.supportsUnalignedCheckpoints()));
-    }
-
     /**
      * Links operator wrappers in forward topological order.
      *
@@ -792,31 +778,5 @@ public class OperatorChain<OUT, OP extends StreamOperator<OUT>>
                         .getMailboxExecutorFactory()
                         .createExecutor(operatorConfig.getChainIndex()),
                 isHead);
-    }
-
-    @Nullable
-    StreamOperator<?> getTailOperator() {
-        return (tailOperatorWrapper == null) ? null : tailOperatorWrapper.getStreamOperator();
-    }
-
-    /** Wrapper class to access the chained sources and their's outputs. */
-    public static class ChainedSource {
-        private final WatermarkGaugeExposingOutput<StreamRecord<?>> chainedSourceOutput;
-        private final StreamTaskSourceInput<?> sourceTaskInput;
-
-        public ChainedSource(
-                WatermarkGaugeExposingOutput<StreamRecord<?>> chainedSourceOutput,
-                StreamTaskSourceInput<?> sourceTaskInput) {
-            this.chainedSourceOutput = chainedSourceOutput;
-            this.sourceTaskInput = sourceTaskInput;
-        }
-
-        public WatermarkGaugeExposingOutput<StreamRecord<?>> getSourceOutput() {
-            return chainedSourceOutput;
-        }
-
-        public StreamTaskSourceInput<?> getSourceTaskInput() {
-            return sourceTaskInput;
-        }
     }
 }

--- a/flink-streaming-java/src/main/java/org/apache/flink/streaming/runtime/tasks/RegularOperatorChain.java
+++ b/flink-streaming-java/src/main/java/org/apache/flink/streaming/runtime/tasks/RegularOperatorChain.java
@@ -1,0 +1,245 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.flink.streaming.runtime.tasks;
+
+import org.apache.flink.annotation.Internal;
+import org.apache.flink.annotation.VisibleForTesting;
+import org.apache.flink.runtime.checkpoint.CheckpointMetaData;
+import org.apache.flink.runtime.checkpoint.CheckpointOptions;
+import org.apache.flink.runtime.checkpoint.StateObjectCollection;
+import org.apache.flink.runtime.checkpoint.channel.ChannelStateWriter;
+import org.apache.flink.runtime.io.network.api.writer.RecordWriterDelegate;
+import org.apache.flink.runtime.jobgraph.OperatorID;
+import org.apache.flink.runtime.operators.coordination.OperatorEvent;
+import org.apache.flink.runtime.plugable.SerializationDelegate;
+import org.apache.flink.runtime.state.CheckpointStreamFactory;
+import org.apache.flink.runtime.state.SnapshotResult;
+import org.apache.flink.streaming.api.operators.OperatorSnapshotFutures;
+import org.apache.flink.streaming.api.operators.StreamOperator;
+import org.apache.flink.streaming.api.operators.StreamTaskStateInitializer;
+import org.apache.flink.streaming.runtime.io.RecordWriterOutput;
+import org.apache.flink.streaming.runtime.streamrecord.StreamRecord;
+import org.apache.flink.util.ExceptionUtils;
+import org.apache.flink.util.FlinkException;
+import org.apache.flink.util.SerializedValue;
+
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import javax.annotation.Nullable;
+
+import java.io.IOException;
+import java.util.List;
+import java.util.Map;
+import java.util.function.Supplier;
+
+import static org.apache.flink.util.ExceptionUtils.firstOrSuppressed;
+
+/** A regular non finished on restore {@link OperatorChain}. */
+@Internal
+public class RegularOperatorChain<OUT, OP extends StreamOperator<OUT>>
+        extends OperatorChain<OUT, OP> {
+
+    private static final Logger LOG = LoggerFactory.getLogger(RegularOperatorChain.class);
+
+    public RegularOperatorChain(
+            StreamTask<OUT, OP> containingTask,
+            RecordWriterDelegate<SerializationDelegate<StreamRecord<OUT>>> recordWriterDelegate) {
+        super(containingTask, recordWriterDelegate);
+    }
+
+    @VisibleForTesting
+    RegularOperatorChain(
+            List<StreamOperatorWrapper<?, ?>> allOperatorWrappers,
+            RecordWriterOutput<?>[] streamOutputs,
+            WatermarkGaugeExposingOutput<StreamRecord<OUT>> mainOperatorOutput,
+            StreamOperatorWrapper<OUT, OP> mainOperatorWrapper) {
+        super(allOperatorWrappers, streamOutputs, mainOperatorOutput, mainOperatorWrapper);
+    }
+
+    @Override
+    public boolean isFinishedOnRestore() {
+        return false;
+    }
+
+    @Override
+    public void dispatchOperatorEvent(OperatorID operator, SerializedValue<OperatorEvent> event)
+            throws FlinkException {
+        operatorEventDispatcher.dispatchEventToHandlers(operator, event);
+    }
+
+    @Override
+    public void prepareSnapshotPreBarrier(long checkpointId) throws Exception {
+        // go forward through the operator chain and tell each operator
+        // to prepare the checkpoint
+        for (StreamOperatorWrapper<?, ?> operatorWrapper : getAllOperators()) {
+            if (!operatorWrapper.isClosed()) {
+                operatorWrapper.getStreamOperator().prepareSnapshotPreBarrier(checkpointId);
+            }
+        }
+    }
+
+    @Override
+    public void endInput(int inputId) throws Exception {
+        if (mainOperatorWrapper != null) {
+            mainOperatorWrapper.endOperatorInput(inputId);
+        }
+    }
+
+    @Override
+    public void initializeStateAndOpenOperators(
+            StreamTaskStateInitializer streamTaskStateInitializer) throws Exception {
+        for (StreamOperatorWrapper<?, ?> operatorWrapper : getAllOperators(true)) {
+            StreamOperator<?> operator = operatorWrapper.getStreamOperator();
+            operator.initializeState(streamTaskStateInitializer);
+            operator.open();
+        }
+    }
+
+    @Override
+    public void finishOperators(StreamTaskActionExecutor actionExecutor) throws Exception {
+        if (firstOperatorWrapper != null) {
+            firstOperatorWrapper.finish(actionExecutor);
+        }
+    }
+
+    @Override
+    public void closeAllOperators() throws Exception {
+        super.closeAllOperators();
+        Exception closingException = null;
+        for (StreamOperatorWrapper<?, ?> operatorWrapper : getAllOperators(true)) {
+            try {
+                operatorWrapper.close();
+            } catch (Exception e) {
+                closingException = firstOrSuppressed(e, closingException);
+            }
+        }
+        if (closingException != null) {
+            throw closingException;
+        }
+    }
+
+    @Override
+    public void close() throws IOException {
+        super.close();
+    }
+
+    @Nullable
+    StreamOperator<?> getTailOperator() {
+        return (tailOperatorWrapper == null) ? null : tailOperatorWrapper.getStreamOperator();
+    }
+
+    @Override
+    public void notifyCheckpointComplete(long checkpointId) throws Exception {
+        Exception previousException = null;
+        for (StreamOperatorWrapper<?, ?> operatorWrapper : getAllOperators(true)) {
+            try {
+                operatorWrapper.notifyCheckpointComplete(checkpointId);
+            } catch (Exception e) {
+                previousException = ExceptionUtils.firstOrSuppressed(e, previousException);
+            }
+        }
+        ExceptionUtils.tryRethrowException(previousException);
+    }
+
+    @Override
+    public void notifyCheckpointAborted(long checkpointId) throws Exception {
+        Exception previousException = null;
+        for (StreamOperatorWrapper<?, ?> operatorWrapper : getAllOperators(true)) {
+            try {
+                operatorWrapper.getStreamOperator().notifyCheckpointAborted(checkpointId);
+            } catch (Exception e) {
+                previousException = ExceptionUtils.firstOrSuppressed(e, previousException);
+            }
+        }
+        ExceptionUtils.tryRethrowException(previousException);
+    }
+
+    @Override
+    public void snapshotState(
+            Map<OperatorID, OperatorSnapshotFutures> operatorSnapshotsInProgress,
+            CheckpointMetaData checkpointMetaData,
+            CheckpointOptions checkpointOptions,
+            Supplier<Boolean> isRunning,
+            ChannelStateWriter.ChannelStateWriteResult channelStateWriteResult,
+            CheckpointStreamFactory storage)
+            throws Exception {
+        for (StreamOperatorWrapper<?, ?> operatorWrapper : getAllOperators(true)) {
+            if (!operatorWrapper.isClosed()) {
+                operatorSnapshotsInProgress.put(
+                        operatorWrapper.getStreamOperator().getOperatorID(),
+                        buildOperatorSnapshotFutures(
+                                checkpointMetaData,
+                                checkpointOptions,
+                                operatorWrapper.getStreamOperator(),
+                                isRunning,
+                                channelStateWriteResult,
+                                storage));
+            }
+        }
+    }
+
+    private OperatorSnapshotFutures buildOperatorSnapshotFutures(
+            CheckpointMetaData checkpointMetaData,
+            CheckpointOptions checkpointOptions,
+            StreamOperator<?> op,
+            Supplier<Boolean> isRunning,
+            ChannelStateWriter.ChannelStateWriteResult channelStateWriteResult,
+            CheckpointStreamFactory storage)
+            throws Exception {
+        OperatorSnapshotFutures snapshotInProgress =
+                checkpointStreamOperator(
+                        op, checkpointMetaData, checkpointOptions, storage, isRunning);
+        if (op == getMainOperator()) {
+            snapshotInProgress.setInputChannelStateFuture(
+                    channelStateWriteResult
+                            .getInputChannelStateHandles()
+                            .thenApply(StateObjectCollection::new)
+                            .thenApply(SnapshotResult::of));
+        }
+        if (op == getTailOperator()) {
+            snapshotInProgress.setResultSubpartitionStateFuture(
+                    channelStateWriteResult
+                            .getResultSubpartitionStateHandles()
+                            .thenApply(StateObjectCollection::new)
+                            .thenApply(SnapshotResult::of));
+        }
+        return snapshotInProgress;
+    }
+
+    private static OperatorSnapshotFutures checkpointStreamOperator(
+            StreamOperator<?> op,
+            CheckpointMetaData checkpointMetaData,
+            CheckpointOptions checkpointOptions,
+            CheckpointStreamFactory storageLocation,
+            Supplier<Boolean> isRunning)
+            throws Exception {
+        try {
+            return op.snapshotState(
+                    checkpointMetaData.getCheckpointId(),
+                    checkpointMetaData.getTimestamp(),
+                    checkpointOptions,
+                    storageLocation);
+        } catch (Exception ex) {
+            if (isRunning.get()) {
+                LOG.info(ex.getMessage(), ex);
+            }
+            throw ex;
+        }
+    }
+}

--- a/flink-streaming-java/src/main/java/org/apache/flink/streaming/runtime/tasks/SourceOperatorStreamTask.java
+++ b/flink-streaming-java/src/main/java/org/apache/flink/streaming/runtime/tasks/SourceOperatorStreamTask.java
@@ -71,6 +71,7 @@ public class SourceOperatorStreamTask<T> extends StreamTask<T, SourceOperator<T,
         final SourceReader<T, ?> sourceReader = sourceOperator.getSourceReader();
         final StreamTaskInput<T> input;
 
+        // TODO: should the input be constructed inside the `OperatorChain` class?
         if (operatorChain.isFinishedOnRestore()) {
             input = new StreamTaskFinishedOnRestoreSourceInput<>(sourceOperator, 0, 0);
         } else if (sourceReader instanceof ExternallyInducedSourceReader) {

--- a/flink-streaming-java/src/main/java/org/apache/flink/streaming/runtime/tasks/StreamTask.java
+++ b/flink-streaming-java/src/main/java/org/apache/flink/streaming/runtime/tasks/StreamTask.java
@@ -648,10 +648,9 @@ public abstract class StreamTask<OUT, OP extends StreamOperator<OUT>> extends Ab
         LOG.debug("Initializing {}.", getName());
 
         operatorChain =
-                new OperatorChain<>(
-                        this,
-                        recordWriter,
-                        getEnvironment().getTaskStateManager().isFinishedOnRestore());
+                getEnvironment().getTaskStateManager().isFinishedOnRestore()
+                        ? new FinishedOperatorChain<>(this, recordWriter)
+                        : new RegularOperatorChain<>(this, recordWriter);
         mainOperator = operatorChain.getMainOperator();
 
         // task specific initialization

--- a/flink-streaming-java/src/main/java/org/apache/flink/streaming/runtime/tasks/SubtaskCheckpointCoordinatorImpl.java
+++ b/flink-streaming-java/src/main/java/org/apache/flink/streaming/runtime/tasks/SubtaskCheckpointCoordinatorImpl.java
@@ -24,7 +24,6 @@ import org.apache.flink.runtime.checkpoint.CheckpointFailureReason;
 import org.apache.flink.runtime.checkpoint.CheckpointMetaData;
 import org.apache.flink.runtime.checkpoint.CheckpointMetricsBuilder;
 import org.apache.flink.runtime.checkpoint.CheckpointOptions;
-import org.apache.flink.runtime.checkpoint.StateObjectCollection;
 import org.apache.flink.runtime.checkpoint.channel.ChannelStateWriter;
 import org.apache.flink.runtime.checkpoint.channel.ChannelStateWriter.ChannelStateWriteResult;
 import org.apache.flink.runtime.checkpoint.channel.ChannelStateWriterImpl;
@@ -35,10 +34,7 @@ import org.apache.flink.runtime.jobgraph.OperatorID;
 import org.apache.flink.runtime.state.CheckpointStorageLocationReference;
 import org.apache.flink.runtime.state.CheckpointStorageWorkerView;
 import org.apache.flink.runtime.state.CheckpointStreamFactory;
-import org.apache.flink.runtime.state.SnapshotResult;
 import org.apache.flink.streaming.api.operators.OperatorSnapshotFutures;
-import org.apache.flink.streaming.api.operators.StreamOperator;
-import org.apache.flink.util.ExceptionUtils;
 import org.apache.flink.util.FlinkRuntimeException;
 import org.apache.flink.util.IOUtils;
 import org.apache.flink.util.function.BiFunctionWithException;
@@ -339,32 +335,22 @@ class SubtaskCheckpointCoordinatorImpl implements SubtaskCheckpointCoordinator {
     public void notifyCheckpointComplete(
             long checkpointId, OperatorChain<?, ?> operatorChain, Supplier<Boolean> isRunning)
             throws Exception {
-        Exception previousException = null;
-        if (!isRunning.get()) {
-            LOG.debug(
-                    "Ignoring notification of complete checkpoint {} for not-running task {}",
-                    checkpointId,
-                    taskName);
-        } else if (operatorChain.isFinishedOnRestore()) {
-            LOG.debug(
-                    "Ignoring notification of complete checkpoint {} for finished on restore task {}",
-                    checkpointId,
-                    taskName);
-        } else {
-            LOG.debug(
-                    "Notification of completed checkpoint {} for task {}", checkpointId, taskName);
-
-            for (StreamOperatorWrapper<?, ?> operatorWrapper :
-                    operatorChain.getAllOperators(true)) {
-                try {
-                    operatorWrapper.notifyCheckpointComplete(checkpointId);
-                } catch (Exception e) {
-                    previousException = ExceptionUtils.firstOrSuppressed(e, previousException);
-                }
+        try {
+            if (!isRunning.get()) {
+                LOG.debug(
+                        "Ignoring notification of complete checkpoint {} for not-running task {}",
+                        checkpointId,
+                        taskName);
+            } else {
+                LOG.debug(
+                        "Notification of completed checkpoint {} for task {}",
+                        checkpointId,
+                        taskName);
+                operatorChain.notifyCheckpointComplete(checkpointId);
             }
+        } finally {
+            env.getTaskStateManager().notifyCheckpointComplete(checkpointId);
         }
-        env.getTaskStateManager().notifyCheckpointComplete(checkpointId);
-        ExceptionUtils.tryRethrowException(previousException);
     }
 
     @Override
@@ -372,46 +358,37 @@ class SubtaskCheckpointCoordinatorImpl implements SubtaskCheckpointCoordinator {
             long checkpointId, OperatorChain<?, ?> operatorChain, Supplier<Boolean> isRunning)
             throws Exception {
 
-        Exception previousException = null;
-        if (!isRunning.get()) {
-            LOG.debug(
-                    "Ignoring notification of aborted checkpoint {} for not-running task {}",
-                    checkpointId,
-                    taskName);
-        } else if (operatorChain.isFinishedOnRestore()) {
-            LOG.debug(
-                    "Ignoring notification of aborted checkpoint {} for finished on restore task {}",
-                    checkpointId,
-                    taskName);
-        } else {
-            LOG.debug("Notification of aborted checkpoint {} for task {}", checkpointId, taskName);
+        try {
+            if (!isRunning.get()) {
+                LOG.debug(
+                        "Ignoring notification of aborted checkpoint {} for not-running task {}",
+                        checkpointId,
+                        taskName);
+            } else {
+                LOG.debug(
+                        "Notification of aborted checkpoint {} for task {}",
+                        checkpointId,
+                        taskName);
 
-            boolean canceled = cancelAsyncCheckpointRunnable(checkpointId);
+                boolean canceled = cancelAsyncCheckpointRunnable(checkpointId);
 
-            if (!canceled) {
-                if (checkpointId > lastCheckpointId) {
-                    // only record checkpoints that have not triggered on task side.
-                    abortedCheckpointIds.add(checkpointId);
+                if (!canceled) {
+                    if (checkpointId > lastCheckpointId) {
+                        // only record checkpoints that have not triggered on task side.
+                        abortedCheckpointIds.add(checkpointId);
+                    }
                 }
-            }
 
-            channelStateWriter.abort(
-                    checkpointId,
-                    new CancellationException("checkpoint aborted via notification"),
-                    false);
+                channelStateWriter.abort(
+                        checkpointId,
+                        new CancellationException("checkpoint aborted via notification"),
+                        false);
 
-            for (StreamOperatorWrapper<?, ?> operatorWrapper :
-                    operatorChain.getAllOperators(true)) {
-                try {
-                    operatorWrapper.getStreamOperator().notifyCheckpointAborted(checkpointId);
-                } catch (Exception e) {
-                    previousException = ExceptionUtils.firstOrSuppressed(e, previousException);
-                }
+                operatorChain.notifyCheckpointAborted(checkpointId);
             }
+        } finally {
+            env.getTaskStateManager().notifyCheckpointAborted(checkpointId);
         }
-
-        env.getTaskStateManager().notifyCheckpointAborted(checkpointId);
-        ExceptionUtils.tryRethrowException(previousException);
     }
 
     @Override
@@ -609,16 +586,13 @@ class SubtaskCheckpointCoordinatorImpl implements SubtaskCheckpointCoordinator {
             Supplier<Boolean> isRunning)
             throws Exception {
 
-        for (final StreamOperatorWrapper<?, ?> operatorWrapper :
-                operatorChain.getAllOperators(true)) {
-            if (!enableCheckpointAfterTasksFinished && operatorWrapper.isClosed()) {
-                env.declineCheckpoint(
-                        checkpointMetaData.getCheckpointId(),
-                        new CheckpointException(
-                                "Task Name" + taskName,
-                                CheckpointFailureReason.CHECKPOINT_DECLINED_TASK_CLOSING));
-                return false;
-            }
+        if (!enableCheckpointAfterTasksFinished && operatorChain.isClosed()) {
+            env.declineCheckpoint(
+                    checkpointMetaData.getCheckpointId(),
+                    new CheckpointException(
+                            "Task Name" + taskName,
+                            CheckpointFailureReason.CHECKPOINT_DECLINED_TASK_CLOSING));
+            return false;
         }
 
         long checkpointId = checkpointMetaData.getCheckpointId();
@@ -634,23 +608,14 @@ class SubtaskCheckpointCoordinatorImpl implements SubtaskCheckpointCoordinator {
                         checkpointId, checkpointOptions.getTargetLocation());
 
         try {
-            if (!operatorChain.isFinishedOnRestore()) {
-                for (StreamOperatorWrapper<?, ?> operatorWrapper :
-                        operatorChain.getAllOperators(true)) {
-                    if (!operatorWrapper.isClosed()) {
-                        operatorSnapshotsInProgress.put(
-                                operatorWrapper.getStreamOperator().getOperatorID(),
-                                buildOperatorSnapshotFutures(
-                                        checkpointMetaData,
-                                        checkpointOptions,
-                                        operatorChain,
-                                        operatorWrapper.getStreamOperator(),
-                                        isRunning,
-                                        channelStateWriteResult,
-                                        storage));
-                    }
-                }
-            }
+            operatorChain.snapshotState(
+                    operatorSnapshotsInProgress,
+                    checkpointMetaData,
+                    checkpointOptions,
+                    isRunning,
+                    channelStateWriteResult,
+                    storage);
+
         } finally {
             checkpointStorage.clearCacheFor(checkpointId);
         }
@@ -666,35 +631,6 @@ class SubtaskCheckpointCoordinatorImpl implements SubtaskCheckpointCoordinator {
         checkpointMetrics.setSyncDurationMillis((System.nanoTime() - started) / 1_000_000);
         checkpointMetrics.setUnalignedCheckpoint(checkpointOptions.isUnalignedCheckpoint());
         return true;
-    }
-
-    private OperatorSnapshotFutures buildOperatorSnapshotFutures(
-            CheckpointMetaData checkpointMetaData,
-            CheckpointOptions checkpointOptions,
-            OperatorChain<?, ?> operatorChain,
-            StreamOperator<?> op,
-            Supplier<Boolean> isRunning,
-            ChannelStateWriteResult channelStateWriteResult,
-            CheckpointStreamFactory storage)
-            throws Exception {
-        OperatorSnapshotFutures snapshotInProgress =
-                checkpointStreamOperator(
-                        op, checkpointMetaData, checkpointOptions, storage, isRunning);
-        if (op == operatorChain.getMainOperator()) {
-            snapshotInProgress.setInputChannelStateFuture(
-                    channelStateWriteResult
-                            .getInputChannelStateHandles()
-                            .thenApply(StateObjectCollection::new)
-                            .thenApply(SnapshotResult::of));
-        }
-        if (op == operatorChain.getTailOperator()) {
-            snapshotInProgress.setResultSubpartitionStateFuture(
-                    channelStateWriteResult
-                            .getResultSubpartitionStateHandles()
-                            .thenApply(StateObjectCollection::new)
-                            .thenApply(SnapshotResult::of));
-        }
-        return snapshotInProgress;
     }
 
     private Set<Long> createAbortedCheckpointSetWithLimitSize(int maxRecordAbortedCheckpoints) {
@@ -746,27 +682,6 @@ class SubtaskCheckpointCoordinatorImpl implements SubtaskCheckpointCoordinator {
         public CheckpointStreamFactory.CheckpointStateOutputStream createTaskOwnedStateStream()
                 throws IOException {
             return delegate.createTaskOwnedStateStream();
-        }
-    }
-
-    private static OperatorSnapshotFutures checkpointStreamOperator(
-            StreamOperator<?> op,
-            CheckpointMetaData checkpointMetaData,
-            CheckpointOptions checkpointOptions,
-            CheckpointStreamFactory storageLocation,
-            Supplier<Boolean> isRunning)
-            throws Exception {
-        try {
-            return op.snapshotState(
-                    checkpointMetaData.getCheckpointId(),
-                    checkpointMetaData.getTimestamp(),
-                    checkpointOptions,
-                    storageLocation);
-        } catch (Exception ex) {
-            if (isRunning.get()) {
-                LOG.info(ex.getMessage(), ex);
-            }
-            throw ex;
         }
     }
 

--- a/flink-streaming-java/src/main/java/org/apache/flink/streaming/runtime/tasks/SubtaskCheckpointCoordinatorImpl.java
+++ b/flink-streaming-java/src/main/java/org/apache/flink/streaming/runtime/tasks/SubtaskCheckpointCoordinatorImpl.java
@@ -20,7 +20,6 @@ package org.apache.flink.streaming.runtime.tasks;
 import org.apache.flink.annotation.VisibleForTesting;
 import org.apache.flink.core.fs.CloseableRegistry;
 import org.apache.flink.runtime.checkpoint.CheckpointException;
-import org.apache.flink.runtime.checkpoint.CheckpointFailureReason;
 import org.apache.flink.runtime.checkpoint.CheckpointMetaData;
 import org.apache.flink.runtime.checkpoint.CheckpointMetricsBuilder;
 import org.apache.flink.runtime.checkpoint.CheckpointOptions;
@@ -586,14 +585,9 @@ class SubtaskCheckpointCoordinatorImpl implements SubtaskCheckpointCoordinator {
             Supplier<Boolean> isRunning)
             throws Exception {
 
-        if (!enableCheckpointAfterTasksFinished && operatorChain.isClosed()) {
-            env.declineCheckpoint(
-                    checkpointMetaData.getCheckpointId(),
-                    new CheckpointException(
-                            "Task Name" + taskName,
-                            CheckpointFailureReason.CHECKPOINT_DECLINED_TASK_CLOSING));
-            return false;
-        }
+        checkState(
+                !operatorChain.isClosed(),
+                "OperatorChain and Task should never be closed at this point");
 
         long checkpointId = checkpointMetaData.getCheckpointId();
         long started = System.nanoTime();

--- a/flink-streaming-java/src/test/java/org/apache/flink/streaming/runtime/operators/StreamOperatorChainingTest.java
+++ b/flink-streaming-java/src/test/java/org/apache/flink/streaming/runtime/operators/StreamOperatorChainingTest.java
@@ -21,11 +21,13 @@ package org.apache.flink.streaming.runtime.operators;
 import org.apache.flink.api.common.ExecutionConfig;
 import org.apache.flink.configuration.Configuration;
 import org.apache.flink.runtime.execution.Environment;
+import org.apache.flink.runtime.io.network.api.writer.RecordWriterDelegate;
 import org.apache.flink.runtime.jobgraph.JobGraph;
 import org.apache.flink.runtime.jobgraph.JobVertex;
 import org.apache.flink.runtime.operators.testutils.MockEnvironment;
 import org.apache.flink.runtime.operators.testutils.MockEnvironmentBuilder;
 import org.apache.flink.runtime.operators.testutils.MockInputSplitProvider;
+import org.apache.flink.runtime.plugable.SerializationDelegate;
 import org.apache.flink.streaming.api.datastream.DataStream;
 import org.apache.flink.streaming.api.datastream.SingleOutputStreamOperator;
 import org.apache.flink.streaming.api.environment.StreamExecutionEnvironment;
@@ -34,8 +36,10 @@ import org.apache.flink.streaming.api.functions.sink.SinkFunction;
 import org.apache.flink.streaming.api.graph.StreamConfig;
 import org.apache.flink.streaming.api.operators.StreamMap;
 import org.apache.flink.streaming.api.operators.StreamOperator;
+import org.apache.flink.streaming.api.operators.StreamTaskStateInitializer;
 import org.apache.flink.streaming.runtime.streamrecord.StreamRecord;
 import org.apache.flink.streaming.runtime.tasks.OperatorChain;
+import org.apache.flink.streaming.runtime.tasks.RegularOperatorChain;
 import org.apache.flink.streaming.runtime.tasks.StreamOperatorWrapper;
 import org.apache.flink.streaming.runtime.tasks.StreamTask;
 import org.apache.flink.streaming.util.MockStreamTaskBuilder;
@@ -133,10 +137,7 @@ public class StreamOperatorChainingTest {
 
             headOperator.setup(mockTask, streamConfig, operatorChain.getMainOperatorOutput());
 
-            for (StreamOperatorWrapper<?, ?> operatorWrapper :
-                    operatorChain.getAllOperators(true)) {
-                operatorWrapper.getStreamOperator().open();
-            }
+            operatorChain.initializeStateAndOpenOperators(null);
 
             headOperator.processElement(new StreamRecord<>(1));
             headOperator.processElement(new StreamRecord<>(2));
@@ -262,10 +263,7 @@ public class StreamOperatorChainingTest {
 
             headOperator.setup(mockTask, streamConfig, operatorChain.getMainOperatorOutput());
 
-            for (StreamOperatorWrapper<?, ?> operatorWrapper :
-                    operatorChain.getAllOperators(true)) {
-                operatorWrapper.getStreamOperator().open();
-            }
+            operatorChain.initializeStateAndOpenOperators(null);
 
             headOperator.processElement(new StreamRecord<>(1));
             headOperator.processElement(new StreamRecord<>(2));
@@ -279,8 +277,8 @@ public class StreamOperatorChainingTest {
 
     private <IN, OT extends StreamOperator<IN>> OperatorChain<IN, OT> createOperatorChain(
             StreamConfig streamConfig, Environment environment, StreamTask<IN, OT> task) {
-        return new OperatorChain<>(
-                task, StreamTask.createRecordWriterDelegate(streamConfig, environment), false);
+        return new TestOperatorChain<>(
+                task, StreamTask.createRecordWriterDelegate(streamConfig, environment));
     }
 
     private <IN, OT extends StreamOperator<IN>> StreamTask<IN, OT> createMockTask(
@@ -291,5 +289,24 @@ public class StreamOperatorChainingTest {
                 .setConfig(streamConfig)
                 .setExecutionConfig(new ExecutionConfig().enableObjectReuse())
                 .build();
+    }
+
+    private static class TestOperatorChain<IN, OUT extends StreamOperator<IN>>
+            extends RegularOperatorChain<IN, OUT> {
+        public TestOperatorChain(
+                StreamTask<IN, OUT> task,
+                RecordWriterDelegate<SerializationDelegate<StreamRecord<IN>>>
+                        recordWriterDelegate) {
+            super(task, recordWriterDelegate);
+        }
+
+        @Override
+        public void initializeStateAndOpenOperators(
+                StreamTaskStateInitializer streamTaskStateInitializer) throws Exception {
+            for (StreamOperatorWrapper<?, ?> operatorWrapper : getAllOperators(true)) {
+                StreamOperator<?> operator = operatorWrapper.getStreamOperator();
+                operator.open();
+            }
+        }
     }
 }

--- a/flink-streaming-java/src/test/java/org/apache/flink/streaming/runtime/operators/StreamSourceOperatorLatencyMetricsTest.java
+++ b/flink-streaming-java/src/test/java/org/apache/flink/streaming/runtime/operators/StreamSourceOperatorLatencyMetricsTest.java
@@ -35,6 +35,7 @@ import org.apache.flink.streaming.api.operators.StreamSource;
 import org.apache.flink.streaming.runtime.streamrecord.StreamElement;
 import org.apache.flink.streaming.runtime.streamrecord.StreamRecord;
 import org.apache.flink.streaming.runtime.tasks.OperatorChain;
+import org.apache.flink.streaming.runtime.tasks.RegularOperatorChain;
 import org.apache.flink.streaming.runtime.tasks.StreamTask;
 import org.apache.flink.streaming.runtime.tasks.TestProcessingTimeService;
 import org.apache.flink.streaming.runtime.tasks.TimerService;
@@ -183,11 +184,11 @@ public class StreamSourceOperatorLatencyMetricsTest extends TestLogger {
 
         // run and wait to be stopped
         OperatorChain<?, ?> operatorChain =
-                new OperatorChain<>(
+                new RegularOperatorChain<>(
                         operator.getContainingTask(),
                         StreamTask.createRecordWriterDelegate(
-                                operator.getOperatorConfig(), new MockEnvironmentBuilder().build()),
-                        false);
+                                operator.getOperatorConfig(),
+                                new MockEnvironmentBuilder().build()));
         try {
             operator.run(new Object(), new CollectorOutput<>(output), operatorChain);
             operator.finish();

--- a/flink-streaming-java/src/test/java/org/apache/flink/streaming/runtime/tasks/MultipleInputStreamTaskChainedSourcesCheckpointingTest.java
+++ b/flink-streaming-java/src/test/java/org/apache/flink/streaming/runtime/tasks/MultipleInputStreamTaskChainedSourcesCheckpointingTest.java
@@ -58,7 +58,6 @@ import org.apache.flink.streaming.runtime.tasks.LifeCycleMonitor.LifeCyclePhase;
 import org.apache.flink.streaming.runtime.tasks.MultipleInputStreamTaskTest.MapToStringMultipleInputOperatorFactory;
 import org.apache.flink.streaming.util.CompletingCheckpointResponder;
 
-import org.junit.Ignore;
 import org.junit.Test;
 import org.junit.runner.RunWith;
 import org.junit.runners.Parameterized;
@@ -454,7 +453,6 @@ public class MultipleInputStreamTaskChainedSourcesCheckpointingTest {
         }
     }
 
-    @Ignore("Enable after fixing emitting watermarks in FLINK-23698")
     @Test
     public void testSkipExecutionsIfFinishedOnRestoreWithSourceChained() throws Exception {
         OperatorID firstSourceOperatorId = new OperatorID();

--- a/flink-streaming-java/src/test/java/org/apache/flink/streaming/runtime/tasks/MultipleInputStreamTaskChainedSourcesCheckpointingTest.java
+++ b/flink-streaming-java/src/test/java/org/apache/flink/streaming/runtime/tasks/MultipleInputStreamTaskChainedSourcesCheckpointingTest.java
@@ -39,22 +39,26 @@ import org.apache.flink.runtime.io.network.partition.ResultPartition;
 import org.apache.flink.runtime.io.network.partition.ResultPartitionType;
 import org.apache.flink.runtime.jobgraph.OperatorID;
 import org.apache.flink.runtime.state.CheckpointStorageLocationReference;
-import org.apache.flink.runtime.state.StateInitializationContext;
 import org.apache.flink.streaming.api.environment.ExecutionCheckpointingOptions;
 import org.apache.flink.streaming.api.graph.StreamConfig;
 import org.apache.flink.streaming.api.operators.AbstractStreamOperatorFactory;
+import org.apache.flink.streaming.api.operators.Input;
+import org.apache.flink.streaming.api.operators.MultipleInputStreamOperator;
 import org.apache.flink.streaming.api.operators.SourceOperator;
 import org.apache.flink.streaming.api.operators.SourceOperatorFactory;
 import org.apache.flink.streaming.api.operators.StreamOperator;
 import org.apache.flink.streaming.api.operators.StreamOperatorParameters;
 import org.apache.flink.streaming.api.watermark.Watermark;
+import org.apache.flink.streaming.runtime.streamrecord.LatencyMarker;
 import org.apache.flink.streaming.runtime.streamrecord.StreamElement;
 import org.apache.flink.streaming.runtime.streamrecord.StreamElementSerializer;
 import org.apache.flink.streaming.runtime.streamrecord.StreamRecord;
+import org.apache.flink.streaming.runtime.streamstatus.StreamStatus;
 import org.apache.flink.streaming.runtime.tasks.LifeCycleMonitor.LifeCyclePhase;
 import org.apache.flink.streaming.runtime.tasks.MultipleInputStreamTaskTest.MapToStringMultipleInputOperatorFactory;
 import org.apache.flink.streaming.util.CompletingCheckpointResponder;
 
+import org.junit.Ignore;
 import org.junit.Test;
 import org.junit.runner.RunWith;
 import org.junit.runners.Parameterized;
@@ -77,7 +81,9 @@ import static org.apache.flink.util.Preconditions.checkState;
 import static org.hamcrest.MatcherAssert.assertThat;
 import static org.hamcrest.Matchers.contains;
 import static org.hamcrest.Matchers.containsInAnyOrder;
+import static org.hamcrest.Matchers.empty;
 import static org.hamcrest.Matchers.equalTo;
+import static org.hamcrest.Matchers.is;
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertFalse;
 import static org.junit.Assert.assertTrue;
@@ -448,6 +454,7 @@ public class MultipleInputStreamTaskChainedSourcesCheckpointingTest {
         }
     }
 
+    @Ignore("Enable after fixing emitting watermarks in FLINK-23698")
     @Test
     public void testSkipExecutionsIfFinishedOnRestoreWithSourceChained() throws Exception {
         OperatorID firstSourceOperatorId = new OperatorID();
@@ -491,11 +498,9 @@ public class MultipleInputStreamTaskChainedSourcesCheckpointingTest {
                         .finishForSingletonOperatorChain(StringSerializer.INSTANCE)
                         .build()) {
 
-            testHarness.processElement(Watermark.MAX_WATERMARK, 0, 0);
-            testHarness.processEvent(EndOfData.INSTANCE, 0, 0);
-            testHarness.processEvent(EndOfPartitionEvent.INSTANCE, 0, 0);
-
-            testHarness.processAll();
+            testHarness.processElement(Watermark.MAX_WATERMARK);
+            assertThat(output, is(empty()));
+            testHarness.waitForTaskCompletion();
             assertThat(output, contains(Watermark.MAX_WATERMARK, EndOfData.INSTANCE));
 
             for (StreamOperatorWrapper<?, ?> wrapper :
@@ -506,12 +511,8 @@ public class MultipleInputStreamTaskChainedSourcesCheckpointingTest {
                                     ((SourceOperator<?, ?>) wrapper.getStreamOperator())
                                             .getSourceReader();
                     sourceReader.getLifeCycleMonitor().assertCallTimes(0, LifeCyclePhase.values());
-                } else if (wrapper.getStreamOperator()
-                        instanceof LifeCycleMonitorMultipleInputOperator) {
-                    ((LifeCycleMonitorMultipleInputOperator) wrapper.getStreamOperator())
-                            .getLifeCycleMonitor()
-                            .assertCallTimes(0, LifeCyclePhase.values());
-                } else {
+                } else if (!(wrapper.getStreamOperator()
+                        instanceof LifeCycleMonitorMultipleInputOperator)) {
                     fail("Unexpected operator type for " + wrapper.getStreamOperator());
                 }
             }
@@ -579,41 +580,45 @@ public class MultipleInputStreamTaskChainedSourcesCheckpointingTest {
         assertTrue(condition.get());
     }
 
-    static class LifeCycleMonitorMultipleInputOperator
-            extends MultipleInputStreamTaskTest.MapToStringMultipleInputOperator {
+    static class LifeCycleMonitorMultipleInputOperator extends TestFinishedOnRestoreStreamOperator
+            implements MultipleInputStreamOperator<String> {
 
-        private final LifeCycleMonitor lifeCycleMonitor = new LifeCycleMonitor();
-
-        public LifeCycleMonitorMultipleInputOperator(StreamOperatorParameters<String> parameters) {
-            super(parameters, 3);
-        }
+        public LifeCycleMonitorMultipleInputOperator() {}
 
         @Override
-        public void open() throws Exception {
-            super.open();
-            lifeCycleMonitor.incrementCallTime(LifeCyclePhase.OPEN);
+        public List<Input> getInputs() {
+            ArrayList<Input> inputs = new ArrayList<>();
+            inputs.add(new TestFinishedOnRestoreInput());
+            inputs.add(new TestFinishedOnRestoreInput());
+            inputs.add(new TestFinishedOnRestoreInput());
+            return inputs;
         }
 
-        @Override
-        public void initializeState(StateInitializationContext context) throws Exception {
-            super.initializeState(context);
-            lifeCycleMonitor.incrementCallTime(LifeCyclePhase.INITIALIZE_STATE);
-        }
+        private static class TestFinishedOnRestoreInput implements Input {
+            @Override
+            public void processElement(StreamRecord element) throws Exception {
+                throw new IllegalStateException(MESSAGE);
+            }
 
-        @Override
-        public void finish() throws Exception {
-            super.finish();
-            lifeCycleMonitor.incrementCallTime(LifeCyclePhase.FINISH);
-        }
+            @Override
+            public void processWatermark(Watermark mark) throws Exception {
+                throw new IllegalStateException(MESSAGE);
+            }
 
-        @Override
-        public void close() throws Exception {
-            super.close();
-            lifeCycleMonitor.incrementCallTime(LifeCyclePhase.CLOSE);
-        }
+            @Override
+            public void processStreamStatus(StreamStatus streamStatus) throws Exception {
+                throw new IllegalStateException(MESSAGE);
+            }
 
-        public LifeCycleMonitor getLifeCycleMonitor() {
-            return lifeCycleMonitor;
+            @Override
+            public void processLatencyMarker(LatencyMarker latencyMarker) throws Exception {
+                throw new IllegalStateException(MESSAGE);
+            }
+
+            @Override
+            public void setKeyContextElement(StreamRecord record) throws Exception {
+                throw new IllegalStateException(MESSAGE);
+            }
         }
     }
 
@@ -622,7 +627,7 @@ public class MultipleInputStreamTaskChainedSourcesCheckpointingTest {
         @Override
         public <T extends StreamOperator<String>> T createStreamOperator(
                 StreamOperatorParameters<String> parameters) {
-            return (T) new LifeCycleMonitorMultipleInputOperator(parameters);
+            return (T) new LifeCycleMonitorMultipleInputOperator();
         }
 
         @Override

--- a/flink-streaming-java/src/test/java/org/apache/flink/streaming/runtime/tasks/MultipleInputStreamTaskChainedSourcesCheckpointingTest.java
+++ b/flink-streaming-java/src/test/java/org/apache/flink/streaming/runtime/tasks/MultipleInputStreamTaskChainedSourcesCheckpointingTest.java
@@ -255,6 +255,7 @@ public class MultipleInputStreamTaskChainedSourcesCheckpointingTest {
         try (StreamTaskMailboxTestHarness<String> testHarness =
                 new StreamTaskMailboxTestHarnessBuilder<>(
                                 MultipleInputStreamTask::new, BasicTypeInfo.STRING_TYPE_INFO)
+                        .setCollectNetworkEvents()
                         .modifyExecutionConfig(applyObjectReuse(objectReuse))
                         .modifyStreamConfig(config -> config.setCheckpointingEnabled(true))
                         .addInput(BasicTypeInfo.STRING_TYPE_INFO)
@@ -306,8 +307,8 @@ public class MultipleInputStreamTaskChainedSourcesCheckpointingTest {
                     actualOutput.subList(0, expectedOutput.size()),
                     containsInAnyOrder(expectedOutput.toArray()));
             assertThat(
-                    actualOutput.subList(actualOutput.size() - 2, actualOutput.size()),
-                    contains(new StreamRecord<>("FINISH"), barrier));
+                    actualOutput.subList(actualOutput.size() - 3, actualOutput.size()),
+                    contains(new StreamRecord<>("FINISH"), EndOfData.INSTANCE, barrier));
         }
     }
 

--- a/flink-streaming-java/src/test/java/org/apache/flink/streaming/runtime/tasks/MultipleInputStreamTaskTest.java
+++ b/flink-streaming-java/src/test/java/org/apache/flink/streaming/runtime/tasks/MultipleInputStreamTaskTest.java
@@ -1024,8 +1024,12 @@ public class MultipleInputStreamTaskTest {
                         .finishForSingletonOperatorChain(StringSerializer.INSTANCE)
                         .build()) {
 
+            testHarness.processElement(Watermark.MAX_WATERMARK, 0);
+            testHarness.processElement(Watermark.MAX_WATERMARK, 1);
+            testHarness.processElement(Watermark.MAX_WATERMARK, 2);
             testHarness.waitForTaskCompletion();
-            assertThat(testHarness.getOutput(), contains(EndOfData.INSTANCE));
+            assertThat(
+                    testHarness.getOutput(), contains(Watermark.MAX_WATERMARK, EndOfData.INSTANCE));
         }
     }
 

--- a/flink-streaming-java/src/test/java/org/apache/flink/streaming/runtime/tasks/OneInputStreamTaskTest.java
+++ b/flink-streaming-java/src/test/java/org/apache/flink/streaming/runtime/tasks/OneInputStreamTaskTest.java
@@ -67,6 +67,7 @@ import org.hamcrest.collection.IsMapContaining;
 import org.junit.Assert;
 import org.junit.Test;
 
+import java.util.ArrayDeque;
 import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.Collections;
@@ -83,7 +84,7 @@ import scala.concurrent.duration.Deadline;
 import scala.concurrent.duration.FiniteDuration;
 
 import static org.hamcrest.MatcherAssert.assertThat;
-import static org.junit.Assert.assertArrayEquals;
+import static org.hamcrest.Matchers.containsInAnyOrder;
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertTrue;
 import static org.junit.Assert.fail;
@@ -705,7 +706,7 @@ public class OneInputStreamTaskTest extends TestLogger {
 
         testHarness.waitForTaskCompletion();
 
-        ArrayList<StreamRecord<String>> expected = new ArrayList<>();
+        ArrayDeque<Object> expected = new ArrayDeque<>();
         Collections.addAll(
                 expected,
                 new StreamRecord<>("Hello"),
@@ -716,8 +717,7 @@ public class OneInputStreamTaskTest extends TestLogger {
                 new StreamRecord<>("[Operator1]: Bye"),
                 new StreamRecord<>("[Operator0]: Bye"));
 
-        final Object[] output = testHarness.getOutput().toArray();
-        assertArrayEquals("Output was not correct.", expected.toArray(), output);
+        assertThat(testHarness.getOutput(), containsInAnyOrder(expected.toArray()));
     }
 
     private static class TestOperator extends AbstractStreamOperator<String>

--- a/flink-streaming-java/src/test/java/org/apache/flink/streaming/runtime/tasks/OperatorChainTest.java
+++ b/flink-streaming-java/src/test/java/org/apache/flink/streaming/runtime/tasks/OperatorChainTest.java
@@ -115,7 +115,7 @@ public class OperatorChainTest {
                     (StreamOperatorWrapper<T, OP>)
                             operatorWrappers.get(operatorWrappers.size() - 1);
 
-            return new OperatorChain<>(
+            return new RegularOperatorChain<>(
                     operatorWrappers,
                     new RecordWriterOutput<?>[0],
                     lastWriter,

--- a/flink-streaming-java/src/test/java/org/apache/flink/streaming/runtime/tasks/SourceOperatorStreamTaskTest.java
+++ b/flink-streaming-java/src/test/java/org/apache/flink/streaming/runtime/tasks/SourceOperatorStreamTaskTest.java
@@ -122,6 +122,7 @@ public class SourceOperatorStreamTaskTest extends SourceStreamTaskTestBase {
 
             Queue<Object> expectedOutput = new LinkedList<>();
             expectedOutput.add(Watermark.MAX_WATERMARK);
+            expectedOutput.add(EndOfData.INSTANCE);
             expectedOutput.add(
                     new CheckpointBarrier(checkpointId, checkpointId, checkpointOptions));
 
@@ -135,7 +136,9 @@ public class SourceOperatorStreamTaskTest extends SourceStreamTaskTestBase {
             testHarness.processAll();
             testHarness.finishProcessing();
 
-            List<Object> expectedOutput = Collections.singletonList(Watermark.MAX_WATERMARK);
+            Queue<Object> expectedOutput = new LinkedList<>();
+            expectedOutput.add(Watermark.MAX_WATERMARK);
+            expectedOutput.add(EndOfData.INSTANCE);
             assertThat(testHarness.getOutput().toArray(), equalTo(expectedOutput.toArray()));
         }
     }
@@ -301,7 +304,8 @@ public class SourceOperatorStreamTaskTest extends SourceStreamTaskTestBase {
             // Set initial snapshot if needed.
             builder.setTaskStateSnapshot(checkpointId, snapshot);
         }
-        return builder.setupOutputForSingletonOperatorChain(sourceOperatorFactory, OPERATOR_ID)
+        return builder.setCollectNetworkEvents()
+                .setupOutputForSingletonOperatorChain(sourceOperatorFactory, OPERATOR_ID)
                 .build();
     }
 

--- a/flink-streaming-java/src/test/java/org/apache/flink/streaming/runtime/tasks/SourceStreamTaskTest.java
+++ b/flink-streaming-java/src/test/java/org/apache/flink/streaming/runtime/tasks/SourceStreamTaskTest.java
@@ -278,7 +278,7 @@ public class SourceStreamTaskTest extends SourceStreamTaskTestBase {
         testHarness.invoke();
         testHarness.waitForTaskCompletion();
 
-        ArrayList<StreamElement> expected = new ArrayList<>();
+        ArrayList<Object> expected = new ArrayList<>();
         Collections.addAll(
                 expected,
                 new StreamRecord<>("Hello"),

--- a/flink-streaming-java/src/test/java/org/apache/flink/streaming/runtime/tasks/SourceTaskTerminationTest.java
+++ b/flink-streaming-java/src/test/java/org/apache/flink/streaming/runtime/tasks/SourceTaskTerminationTest.java
@@ -28,18 +28,15 @@ import org.apache.flink.runtime.io.network.api.CheckpointBarrier;
 import org.apache.flink.runtime.jobgraph.OperatorID;
 import org.apache.flink.runtime.state.CheckpointStorageLocationReference;
 import org.apache.flink.streaming.api.functions.source.SourceFunction;
-import org.apache.flink.streaming.api.graph.StreamConfig;
 import org.apache.flink.streaming.api.operators.StreamSource;
 import org.apache.flink.streaming.api.watermark.Watermark;
 import org.apache.flink.streaming.runtime.streamrecord.StreamRecord;
 import org.apache.flink.util.TestLogger;
 
 import org.junit.Before;
-import org.junit.Rule;
 import org.junit.Test;
-import org.junit.rules.Timeout;
 
-import java.util.concurrent.BlockingQueue;
+import java.util.Queue;
 
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertFalse;
@@ -54,8 +51,6 @@ public class SourceTaskTerminationTest extends TestLogger {
     private static OneShotLatch ready;
     private static MultiShotLatch runLoopStart;
     private static MultiShotLatch runLoopEnd;
-
-    @Rule public final Timeout timeoutPerTest = Timeout.seconds(20);
 
     @Before
     public void initialize() {
@@ -78,33 +73,34 @@ public class SourceTaskTerminationTest extends TestLogger {
             throws Exception {
         final long syncSavepointId = 34L;
 
-        final StreamTaskTestHarness<Long> srcTaskTestHarness = getSourceStreamTaskTestHarness();
-        final Thread executionThread = srcTaskTestHarness.invoke();
-        final StreamTask<Long, ?> srcTask = srcTaskTestHarness.getTask();
+        try (StreamTaskMailboxTestHarness<Long> srcTaskTestHarness =
+                getSourceStreamTaskTestHarness()) {
+            final StreamTask<Long, ?> srcTask = srcTaskTestHarness.getStreamTask();
+            srcTaskTestHarness.processAll();
 
-        ready.await();
+            // step by step let the source thread emit elements
+            emitAndVerifyWatermarkAndElement(srcTaskTestHarness, 1L);
+            emitAndVerifyWatermarkAndElement(srcTaskTestHarness, 2L);
 
-        // step by step let the source thread emit elements
-        emitAndVerifyWatermarkAndElement(srcTaskTestHarness, 1L);
-        emitAndVerifyWatermarkAndElement(srcTaskTestHarness, 2L);
+            srcTaskTestHarness.processUntil(
+                    srcTask.triggerCheckpointAsync(
+                                    new CheckpointMetaData(31L, 900),
+                                    CheckpointOptions.forCheckpointWithDefaultLocation())
+                            ::isDone);
 
-        srcTask.triggerCheckpointAsync(
-                        new CheckpointMetaData(31L, 900),
-                        CheckpointOptions.forCheckpointWithDefaultLocation())
-                .get();
+            verifyCheckpointBarrier(srcTaskTestHarness.getOutput(), 31L);
 
-        verifyCheckpointBarrier(srcTaskTestHarness.getOutput(), 31L);
+            emitAndVerifyWatermarkAndElement(srcTaskTestHarness, 3L);
 
-        emitAndVerifyWatermarkAndElement(srcTaskTestHarness, 3L);
-
-        srcTask.triggerCheckpointAsync(
-                        new CheckpointMetaData(syncSavepointId, 900),
-                        new CheckpointOptions(
-                                shouldTerminate
-                                        ? CheckpointType.SAVEPOINT_TERMINATE
-                                        : CheckpointType.SAVEPOINT_SUSPEND,
-                                CheckpointStorageLocationReference.getDefault()))
-                .get();
+            srcTaskTestHarness.processUntil(
+                    srcTask.triggerCheckpointAsync(
+                                    new CheckpointMetaData(syncSavepointId, 900),
+                                    new CheckpointOptions(
+                                            shouldTerminate
+                                                    ? CheckpointType.SAVEPOINT_TERMINATE
+                                                    : CheckpointType.SAVEPOINT_SUSPEND,
+                                            CheckpointStorageLocationReference.getDefault()))
+                            ::isDone);
 
         if (shouldTerminate) {
             // if we are in TERMINATE mode, we expect the source task
@@ -112,33 +108,30 @@ public class SourceTaskTerminationTest extends TestLogger {
             verifyWatermark(srcTaskTestHarness.getOutput(), Watermark.MAX_WATERMARK);
         }
 
-        verifyCheckpointBarrier(srcTaskTestHarness.getOutput(), syncSavepointId);
+            verifyCheckpointBarrier(srcTaskTestHarness.getOutput(), syncSavepointId);
 
-        waitForSynchronousSavepointIdToBeSet(srcTask);
+            waitForSynchronousSavepointIdToBeSet(srcTask);
 
-        assertTrue(srcTask.getSynchronousSavepointId().isPresent());
+            assertTrue(srcTask.getSynchronousSavepointId().isPresent());
 
-        srcTask.notifyCheckpointCompleteAsync(syncSavepointId).get();
-        if (!shouldTerminate) {
-            assertFalse(srcTask.getSynchronousSavepointId().isPresent());
+            srcTaskTestHarness.processUntil(
+                    srcTask.notifyCheckpointCompleteAsync(syncSavepointId)::isDone);
+            if (!shouldTerminate) {
+                assertFalse(srcTask.getSynchronousSavepointId().isPresent());
+            }
+
+            srcTaskTestHarness.waitForTaskCompletion();
         }
-
-        executionThread.join();
     }
 
-    private StreamTaskTestHarness<Long> getSourceStreamTaskTestHarness() {
-        final StreamTaskTestHarness<Long> testHarness =
-                new StreamTaskTestHarness<>(SourceStreamTask::new, BasicTypeInfo.LONG_TYPE_INFO);
-
-        final LockStepSourceWithOneWmPerElement source = new LockStepSourceWithOneWmPerElement();
-
-        testHarness.setupOutputForSingletonOperatorChain();
-        testHarness.getExecutionConfig().setLatencyTrackingInterval(-1);
-
-        StreamConfig streamConfig = testHarness.getStreamConfig();
-        StreamSource<Long, ?> sourceOperator = new StreamSource<>(source);
-        streamConfig.setStreamOperator(sourceOperator);
-        streamConfig.setOperatorID(new OperatorID());
+    private StreamTaskMailboxTestHarness<Long> getSourceStreamTaskTestHarness() throws Exception {
+        StreamTaskMailboxTestHarness<Long> testHarness =
+                new StreamTaskMailboxTestHarnessBuilder<>(
+                                SourceStreamTask::new, BasicTypeInfo.LONG_TYPE_INFO)
+                        .modifyExecutionConfig((config) -> config.setLatencyTrackingInterval(-1))
+                        .setupOutputForSingletonOperatorChain(
+                                new StreamSource<>(new LockStepSourceWithOneWmPerElement()))
+                        .build();
         return testHarness;
     }
 
@@ -150,33 +143,31 @@ public class SourceTaskTerminationTest extends TestLogger {
     }
 
     private void emitAndVerifyWatermarkAndElement(
-            final StreamTaskTestHarness<Long> srcTaskTestHarness, final long expectedElement)
-            throws InterruptedException {
+            final StreamTaskMailboxTestHarness<Long> srcTaskTestHarness, final long expectedElement)
+            throws Exception {
 
         runLoopStart.trigger();
+        runLoopEnd.await();
+        srcTaskTestHarness.processAll();
         verifyWatermark(srcTaskTestHarness.getOutput(), new Watermark(expectedElement));
         verifyNextElement(srcTaskTestHarness.getOutput(), expectedElement);
-        runLoopEnd.await();
     }
 
-    private void verifyNextElement(BlockingQueue<Object> output, long expectedElement)
-            throws InterruptedException {
-        Object next = output.take();
+    private void verifyNextElement(Queue<Object> output, long expectedElement) {
+        Object next = output.remove();
         assertTrue("next element is not an event", next instanceof StreamRecord);
         assertEquals(
                 "wrong event", expectedElement, ((StreamRecord<Long>) next).getValue().longValue());
     }
 
-    private void verifyWatermark(BlockingQueue<Object> output, Watermark expectedWatermark)
-            throws InterruptedException {
-        Object next = output.take();
+    private void verifyWatermark(Queue<Object> output, Watermark expectedWatermark) {
+        Object next = output.remove();
         assertTrue("next element is not a watermark", next instanceof Watermark);
         assertEquals("wrong watermark", expectedWatermark, next);
     }
 
-    private void verifyCheckpointBarrier(BlockingQueue<Object> output, long checkpointId)
-            throws InterruptedException {
-        Object next = output.take();
+    private void verifyCheckpointBarrier(Queue<Object> output, long checkpointId) {
+        Object next = output.remove();
         assertTrue("next element is not a checkpoint barrier", next instanceof CheckpointBarrier);
         assertEquals("wrong checkpoint id", checkpointId, ((CheckpointBarrier) next).getId());
     }

--- a/flink-streaming-java/src/test/java/org/apache/flink/streaming/runtime/tasks/StreamMockEnvironment.java
+++ b/flink-streaming-java/src/test/java/org/apache/flink/streaming/runtime/tasks/StreamMockEnvironment.java
@@ -116,6 +116,8 @@ public class StreamMockEnvironment implements Environment {
     private final UserCodeClassLoader userCodeClassLoader =
             TestingUserCodeClassLoader.newBuilder().build();
 
+    private final boolean collectNetworkEvents;
+
     @Nullable private Consumer<Throwable> externalExceptionHandler;
 
     private TaskEventDispatcher taskEventDispatcher = mock(TaskEventDispatcher.class);
@@ -147,7 +149,8 @@ public class StreamMockEnvironment implements Environment {
                 inputSplitProvider,
                 bufferSize,
                 taskStateManager,
-                new ThroughputCalculator(SystemClock.getInstance(), 10));
+                new ThroughputCalculator(SystemClock.getInstance(), 10),
+                false);
     }
 
     public StreamMockEnvironment(
@@ -160,7 +163,8 @@ public class StreamMockEnvironment implements Environment {
             MockInputSplitProvider inputSplitProvider,
             int bufferSize,
             TaskStateManager taskStateManager,
-            ThroughputCalculator throughputCalculator) {
+            ThroughputCalculator throughputCalculator,
+            boolean collectNetworkEvents) {
 
         this.jobID = jobID;
         this.executionAttemptID = executionAttemptID;
@@ -191,6 +195,7 @@ public class StreamMockEnvironment implements Environment {
         KvStateRegistry registry = new KvStateRegistry();
         this.kvStateRegistry = registry.createTaskRegistry(jobID, getJobVertexId());
         this.throughputCalculator = throughputCalculator;
+        this.collectNetworkEvents = collectNetworkEvents;
     }
 
     public StreamMockEnvironment(
@@ -217,7 +222,9 @@ public class StreamMockEnvironment implements Environment {
 
     public <T> void addOutput(
             final Collection<Object> outputList, final TypeSerializer<T> serializer) {
-        addOutput(new RecordOrEventCollectingResultPartitionWriter<T>(outputList, serializer));
+        addOutput(
+                new RecordOrEventCollectingResultPartitionWriter<T>(
+                        outputList, serializer, collectNetworkEvents));
     }
 
     public void addOutput(ResultPartitionWriter resultPartitionWriter) {

--- a/flink-streaming-java/src/test/java/org/apache/flink/streaming/runtime/tasks/StreamTaskExecutionDecorationTest.java
+++ b/flink-streaming-java/src/test/java/org/apache/flink/streaming/runtime/tasks/StreamTaskExecutionDecorationTest.java
@@ -116,7 +116,7 @@ public class StreamTaskExecutionDecorationTest {
                     @Override
                     protected void processInput(MailboxDefaultAction.Controller controller) {}
                 };
-        task.operatorChain = new OperatorChain<>(task, new NonRecordWriter<>(), false);
+        task.operatorChain = new RegularOperatorChain<>(task, new NonRecordWriter<>());
     }
 
     @After

--- a/flink-streaming-java/src/test/java/org/apache/flink/streaming/runtime/tasks/StreamTaskFinalCheckpointsTest.java
+++ b/flink-streaming-java/src/test/java/org/apache/flink/streaming/runtime/tasks/StreamTaskFinalCheckpointsTest.java
@@ -711,6 +711,7 @@ public class StreamTaskFinalCheckpointsTest {
                 new StreamTaskMailboxTestHarnessBuilder<>(
                                 OneInputStreamTask::new, BasicTypeInfo.STRING_TYPE_INFO)
                         .addInput(BasicTypeInfo.STRING_TYPE_INFO, 3)
+                        .setCollectNetworkEvents()
                         .setTaskStateSnapshot(1, TaskStateSnapshot.FINISHED_ON_RESTORE)
                         .setupOutputForSingletonOperatorChain(
                                 new TestFinishedOnRestoreStreamOperator())

--- a/flink-streaming-java/src/test/java/org/apache/flink/streaming/runtime/tasks/StreamTaskFinalCheckpointsTest.java
+++ b/flink-streaming-java/src/test/java/org/apache/flink/streaming/runtime/tasks/StreamTaskFinalCheckpointsTest.java
@@ -45,6 +45,7 @@ import org.apache.flink.streaming.api.functions.source.SourceFunction;
 import org.apache.flink.streaming.api.operators.AbstractStreamOperator;
 import org.apache.flink.streaming.api.operators.OneInputStreamOperator;
 import org.apache.flink.streaming.api.operators.StreamSource;
+import org.apache.flink.streaming.api.watermark.Watermark;
 import org.apache.flink.streaming.runtime.streamrecord.StreamRecord;
 import org.apache.flink.streaming.util.CompletingCheckpointResponder;
 import org.apache.flink.util.FlinkRuntimeException;
@@ -742,6 +743,9 @@ public class StreamTaskFinalCheckpointsTest {
             harness.processAll();
 
             // Finish & close operators.
+            harness.processElement(Watermark.MAX_WATERMARK, 0, 0);
+            harness.processElement(Watermark.MAX_WATERMARK, 0, 1);
+            harness.processElement(Watermark.MAX_WATERMARK, 0, 2);
             harness.waitForTaskCompletion();
             harness.finishProcessing();
 
@@ -752,6 +756,7 @@ public class StreamTaskFinalCheckpointsTest {
                                     checkpointMetaData.getCheckpointId(),
                                     checkpointMetaData.getTimestamp(),
                                     checkpointOptions),
+                            Watermark.MAX_WATERMARK,
                             EndOfData.INSTANCE));
         }
     }

--- a/flink-streaming-java/src/test/java/org/apache/flink/streaming/runtime/tasks/StreamTaskMailboxTestHarness.java
+++ b/flink-streaming-java/src/test/java/org/apache/flink/streaming/runtime/tasks/StreamTaskMailboxTestHarness.java
@@ -26,6 +26,7 @@ import org.apache.flink.runtime.state.TestTaskStateManager;
 import org.apache.flink.runtime.taskmanager.TestCheckpointResponder;
 
 import java.util.Queue;
+import java.util.function.Supplier;
 
 import static org.apache.flink.util.Preconditions.checkNotNull;
 import static org.junit.Assert.assertTrue;
@@ -113,6 +114,13 @@ public class StreamTaskMailboxTestHarness<OUT> implements AutoCloseable {
 
     private void maybeProcess() throws Exception {
         if (autoProcess) {
+            processAll();
+        }
+    }
+
+    /** Process until {@code condition} is met. */
+    public void processUntil(Supplier<Boolean> condition) throws Exception {
+        while (!condition.get()) {
             processAll();
         }
     }

--- a/flink-streaming-java/src/test/java/org/apache/flink/streaming/runtime/tasks/StreamTaskMailboxTestHarnessBuilder.java
+++ b/flink-streaming-java/src/test/java/org/apache/flink/streaming/runtime/tasks/StreamTaskMailboxTestHarnessBuilder.java
@@ -91,6 +91,7 @@ public class StreamTaskMailboxTestHarnessBuilder<OUT> {
             UnregisteredMetricGroups.createUnregisteredTaskMetricGroup();
     protected Map<Long, TaskStateSnapshot> taskStateSnapshots;
     protected CheckpointResponder checkpointResponder = new TestCheckpointResponder();
+    protected boolean collectNetworkEvents;
 
     protected final ArrayList<InputConfig> inputs = new ArrayList<>();
     protected final ArrayList<Integer> inputChannelsPerGate = new ArrayList<>();
@@ -139,6 +140,11 @@ public class StreamTaskMailboxTestHarnessBuilder<OUT> {
     public <T> StreamTaskMailboxTestHarnessBuilder<OUT> setTaskManagerRuntimeInfo(
             TaskManagerRuntimeInfo taskManagerRuntimeInfo) {
         this.taskManagerRuntimeInfo = taskManagerRuntimeInfo;
+        return this;
+    }
+
+    public <T> StreamTaskMailboxTestHarnessBuilder<OUT> setCollectNetworkEvents() {
+        this.collectNetworkEvents = true;
         return this;
     }
 
@@ -223,7 +229,8 @@ public class StreamTaskMailboxTestHarnessBuilder<OUT> {
                         new MockInputSplitProvider(),
                         bufferSize,
                         taskStateManager,
-                        throughputCalculator);
+                        throughputCalculator,
+                        collectNetworkEvents);
 
         streamMockEnvironment.setCheckpointResponder(taskStateManager.getCheckpointResponder());
         initializeInputs(streamMockEnvironment);

--- a/flink-streaming-java/src/test/java/org/apache/flink/streaming/runtime/tasks/StreamTaskSelectiveReadingTest.java
+++ b/flink-streaming-java/src/test/java/org/apache/flink/streaming/runtime/tasks/StreamTaskSelectiveReadingTest.java
@@ -46,6 +46,12 @@ import static org.junit.Assert.fail;
 /** Test selective reading. */
 public class StreamTaskSelectiveReadingTest {
 
+    private static String elementToString(Object record) {
+        return record instanceof StreamRecord
+                ? ((StreamRecord) record).getValue().toString()
+                : record.toString();
+    }
+
     @Test
     public void testAnyOrderedReading() throws Exception {
         ConcurrentLinkedQueue<Object> expectedOutput = new ConcurrentLinkedQueue<>();
@@ -180,13 +186,13 @@ public class StreamTaskSelectiveReadingTest {
         } else {
             String[] expectedResult =
                     expectedOutput.stream()
-                            .map(record -> ((StreamRecord) record).getValue().toString())
+                            .map(StreamTaskSelectiveReadingTest::elementToString)
                             .toArray(String[]::new);
             Arrays.sort(expectedResult);
 
             String[] result =
                     output.stream()
-                            .map(record -> ((StreamRecord) record).getValue().toString())
+                            .map(StreamTaskSelectiveReadingTest::elementToString)
                             .toArray(String[]::new);
             Arrays.sort(result);
 

--- a/flink-streaming-java/src/test/java/org/apache/flink/streaming/runtime/tasks/SubtaskCheckpointCoordinatorTest.java
+++ b/flink-streaming-java/src/test/java/org/apache/flink/streaming/runtime/tasks/SubtaskCheckpointCoordinatorTest.java
@@ -158,10 +158,9 @@ public class SubtaskCheckpointCoordinatorTest {
                         .build()) {
             AtomicReference<Boolean> broadcastedPriorityEvent = new AtomicReference<>(null);
             final OperatorChain<?, ?> operatorChain =
-                    new OperatorChain(
+                    new RegularOperatorChain(
                             new MockStreamTaskBuilder(mockEnvironment).build(),
-                            new NonRecordWriter<>(),
-                            false) {
+                            new NonRecordWriter<>()) {
                         @Override
                         public void broadcastEvent(AbstractEvent event, boolean isPriorityEvent)
                                 throws IOException {
@@ -196,10 +195,9 @@ public class SubtaskCheckpointCoordinatorTest {
 
             AtomicReference<Boolean> broadcastedPriorityEvent = new AtomicReference<>(null);
             final OperatorChain<?, ?> operatorChain =
-                    new OperatorChain(
+                    new RegularOperatorChain(
                             new MockStreamTaskBuilder(mockEnvironment).build(),
-                            new NonRecordWriter<>(),
-                            false) {
+                            new NonRecordWriter<>()) {
                         @Override
                         public void broadcastEvent(AbstractEvent event, boolean isPriorityEvent)
                                 throws IOException {
@@ -247,10 +245,8 @@ public class SubtaskCheckpointCoordinatorTest {
                     new CheckpointOptions(
                             SAVEPOINT, CheckpointStorageLocationReference.getDefault()),
                     new CheckpointMetricsBuilder(),
-                    new OperatorChain<>(
-                            new NoOpStreamTask<>(new DummyEnvironment()),
-                            new NonRecordWriter<>(),
-                            false),
+                    new RegularOperatorChain<>(
+                            new NoOpStreamTask<>(new DummyEnvironment()), new NonRecordWriter<>()),
                     false,
                     () -> true);
         }
@@ -353,10 +349,9 @@ public class SubtaskCheckpointCoordinatorTest {
 
             OneInputStreamTask<String, String> task = testHarness.getTask();
             OperatorChain<String, OneInputStreamOperator<String, String>> operatorChain =
-                    new OperatorChain<>(
+                    new RegularOperatorChain<>(
                             task,
-                            StreamTask.createRecordWriterDelegate(streamConfig, mockEnvironment),
-                            false);
+                            StreamTask.createRecordWriterDelegate(streamConfig, mockEnvironment));
             long checkpointId = 42L;
             // notify checkpoint aborted before execution.
             subtaskCheckpointCoordinator.notifyCheckpointAborted(
@@ -465,8 +460,8 @@ public class SubtaskCheckpointCoordinatorTest {
     }
 
     private OperatorChain<?, ?> getOperatorChain(MockEnvironment mockEnvironment) throws Exception {
-        return new OperatorChain<>(
-                new MockStreamTaskBuilder(mockEnvironment).build(), new NonRecordWriter<>(), false);
+        return new RegularOperatorChain<>(
+                new MockStreamTaskBuilder(mockEnvironment).build(), new NonRecordWriter<>());
     }
 
     private <T> OperatorChain<T, AbstractStreamOperator<T>> operatorChain(

--- a/flink-streaming-java/src/test/java/org/apache/flink/streaming/runtime/tasks/TestFinishedOnRestoreStreamOperator.java
+++ b/flink-streaming-java/src/test/java/org/apache/flink/streaming/runtime/tasks/TestFinishedOnRestoreStreamOperator.java
@@ -19,25 +19,31 @@
 package org.apache.flink.streaming.runtime.tasks;
 
 import org.apache.flink.metrics.MetricGroup;
-import org.apache.flink.metrics.groups.UnregisteredMetricsGroup;
 import org.apache.flink.runtime.checkpoint.CheckpointOptions;
 import org.apache.flink.runtime.jobgraph.OperatorID;
 import org.apache.flink.runtime.state.CheckpointStreamFactory;
+import org.apache.flink.streaming.api.operators.BoundedMultiInput;
 import org.apache.flink.streaming.api.operators.BoundedOneInput;
 import org.apache.flink.streaming.api.operators.OneInputStreamOperator;
 import org.apache.flink.streaming.api.operators.OperatorSnapshotFutures;
 import org.apache.flink.streaming.api.operators.StreamTaskStateInitializer;
+import org.apache.flink.streaming.api.operators.TwoInputStreamOperator;
 import org.apache.flink.streaming.api.watermark.Watermark;
 import org.apache.flink.streaming.runtime.streamrecord.LatencyMarker;
 import org.apache.flink.streaming.runtime.streamrecord.StreamRecord;
 import org.apache.flink.streaming.runtime.streamstatus.StreamStatus;
 
-/** A bounded one-input stream operator for test. */
+import static org.apache.flink.runtime.metrics.groups.UnregisteredMetricGroups.createUnregisteredOperatorMetricGroup;
+
+/** A bounded one-input or two-input stream operator for test. */
 public class TestFinishedOnRestoreStreamOperator
-        implements OneInputStreamOperator<String, String>, BoundedOneInput {
+        implements OneInputStreamOperator<String, String>,
+                TwoInputStreamOperator<String, String, String>,
+                BoundedOneInput,
+                BoundedMultiInput {
     private static final long serialVersionUID = 1L;
 
-    private static final String MESSAGE = "This should never be called";
+    protected static final String MESSAGE = "This should never be called";
 
     @Override
     public void open() {
@@ -111,7 +117,7 @@ public class TestFinishedOnRestoreStreamOperator
     @Override
     public MetricGroup getMetricGroup() {
         // TODO: Should this be allowed to access for finished tasks?
-        return new UnregisteredMetricsGroup();
+        return createUnregisteredOperatorMetricGroup();
     }
 
     @Override
@@ -131,6 +137,51 @@ public class TestFinishedOnRestoreStreamOperator
 
     @Override
     public Object getCurrentKey() {
+        throw new IllegalStateException(MESSAGE);
+    }
+
+    @Override
+    public void endInput(int inputId) throws Exception {
+        throw new IllegalStateException(MESSAGE);
+    }
+
+    @Override
+    public void processElement1(StreamRecord<String> element) throws Exception {
+        throw new IllegalStateException(MESSAGE);
+    }
+
+    @Override
+    public void processElement2(StreamRecord<String> element) throws Exception {
+        throw new IllegalStateException(MESSAGE);
+    }
+
+    @Override
+    public void processWatermark1(Watermark mark) throws Exception {
+        throw new IllegalStateException(MESSAGE);
+    }
+
+    @Override
+    public void processWatermark2(Watermark mark) throws Exception {
+        throw new IllegalStateException(MESSAGE);
+    }
+
+    @Override
+    public void processLatencyMarker1(LatencyMarker latencyMarker) throws Exception {
+        throw new IllegalStateException(MESSAGE);
+    }
+
+    @Override
+    public void processLatencyMarker2(LatencyMarker latencyMarker) throws Exception {
+        throw new IllegalStateException(MESSAGE);
+    }
+
+    @Override
+    public void processStreamStatus1(StreamStatus streamStatus) throws Exception {
+        throw new IllegalStateException(MESSAGE);
+    }
+
+    @Override
+    public void processStreamStatus2(StreamStatus streamStatus) throws Exception {
         throw new IllegalStateException(MESSAGE);
     }
 }

--- a/flink-streaming-java/src/test/java/org/apache/flink/streaming/runtime/tasks/TestFinishedOnRestoreStreamOperator.java
+++ b/flink-streaming-java/src/test/java/org/apache/flink/streaming/runtime/tasks/TestFinishedOnRestoreStreamOperator.java
@@ -1,0 +1,136 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.flink.streaming.runtime.tasks;
+
+import org.apache.flink.metrics.MetricGroup;
+import org.apache.flink.metrics.groups.UnregisteredMetricsGroup;
+import org.apache.flink.runtime.checkpoint.CheckpointOptions;
+import org.apache.flink.runtime.jobgraph.OperatorID;
+import org.apache.flink.runtime.state.CheckpointStreamFactory;
+import org.apache.flink.streaming.api.operators.BoundedOneInput;
+import org.apache.flink.streaming.api.operators.OneInputStreamOperator;
+import org.apache.flink.streaming.api.operators.OperatorSnapshotFutures;
+import org.apache.flink.streaming.api.operators.StreamTaskStateInitializer;
+import org.apache.flink.streaming.api.watermark.Watermark;
+import org.apache.flink.streaming.runtime.streamrecord.LatencyMarker;
+import org.apache.flink.streaming.runtime.streamrecord.StreamRecord;
+import org.apache.flink.streaming.runtime.streamstatus.StreamStatus;
+
+/** A bounded one-input stream operator for test. */
+public class TestFinishedOnRestoreStreamOperator
+        implements OneInputStreamOperator<String, String>, BoundedOneInput {
+    private static final long serialVersionUID = 1L;
+
+    private static final String MESSAGE = "This should never be called";
+
+    @Override
+    public void open() {
+        throw new IllegalStateException(MESSAGE);
+    }
+
+    @Override
+    public void processElement(StreamRecord<String> element) {
+        throw new IllegalStateException(MESSAGE);
+    }
+
+    @Override
+    public void processWatermark(Watermark mark) {
+        throw new IllegalStateException(MESSAGE);
+    }
+
+    @Override
+    public void processStreamStatus(StreamStatus streamStatus) {
+        throw new IllegalStateException(MESSAGE);
+    }
+
+    @Override
+    public void processLatencyMarker(LatencyMarker latencyMarker) {
+        throw new IllegalStateException(MESSAGE);
+    }
+
+    @Override
+    public void endInput() {
+        throw new IllegalStateException(MESSAGE);
+    }
+
+    @Override
+    public void finish() {
+        throw new IllegalStateException(MESSAGE);
+    }
+
+    @Override
+    public void close() {
+        throw new IllegalStateException(MESSAGE);
+    }
+
+    @Override
+    public void prepareSnapshotPreBarrier(long checkpointId) {
+        throw new IllegalStateException(MESSAGE);
+    }
+
+    @Override
+    public OperatorSnapshotFutures snapshotState(
+            long checkpointId,
+            long timestamp,
+            CheckpointOptions checkpointOptions,
+            CheckpointStreamFactory storageLocation) {
+        throw new IllegalStateException(MESSAGE);
+    }
+
+    @Override
+    public void initializeState(StreamTaskStateInitializer streamTaskStateManager) {
+        throw new IllegalStateException(MESSAGE);
+    }
+
+    @Override
+    public void setKeyContextElement1(StreamRecord<?> record) {
+        throw new IllegalStateException(MESSAGE);
+    }
+
+    @Override
+    public void setKeyContextElement2(StreamRecord<?> record) {
+        throw new IllegalStateException(MESSAGE);
+    }
+
+    @Override
+    public MetricGroup getMetricGroup() {
+        // TODO: Should this be allowed to access for finished tasks?
+        return new UnregisteredMetricsGroup();
+    }
+
+    @Override
+    public OperatorID getOperatorID() {
+        throw new IllegalStateException(MESSAGE);
+    }
+
+    @Override
+    public void notifyCheckpointComplete(long checkpointId) {
+        throw new IllegalStateException(MESSAGE);
+    }
+
+    @Override
+    public void setCurrentKey(Object key) {
+        throw new IllegalStateException(MESSAGE);
+    }
+
+    @Override
+    public Object getCurrentKey() {
+        throw new IllegalStateException(MESSAGE);
+    }
+}

--- a/flink-streaming-java/src/test/java/org/apache/flink/streaming/runtime/tasks/TwoInputStreamTaskTest.java
+++ b/flink-streaming-java/src/test/java/org/apache/flink/streaming/runtime/tasks/TwoInputStreamTaskTest.java
@@ -27,6 +27,7 @@ import org.apache.flink.metrics.Metric;
 import org.apache.flink.runtime.checkpoint.CheckpointOptions;
 import org.apache.flink.runtime.io.network.api.CancelCheckpointMarker;
 import org.apache.flink.runtime.io.network.api.CheckpointBarrier;
+import org.apache.flink.runtime.io.network.api.EndOfData;
 import org.apache.flink.runtime.jobgraph.OperatorID;
 import org.apache.flink.runtime.metrics.MetricNames;
 import org.apache.flink.runtime.metrics.NoOpMetricRegistry;
@@ -701,7 +702,7 @@ public class TwoInputStreamTaskTest {
 
         testHarness.waitForTaskCompletion();
 
-        ArrayList<StreamRecord<String>> expected = new ArrayList<>();
+        ArrayList<Object> expected = new ArrayList<>();
         Collections.addAll(
                 expected,
                 new StreamRecord<>("[Operator0-1]: Hello-1"),

--- a/flink-streaming-java/src/test/java/org/apache/flink/streaming/runtime/tasks/TwoInputStreamTaskTest.java
+++ b/flink-streaming-java/src/test/java/org/apache/flink/streaming/runtime/tasks/TwoInputStreamTaskTest.java
@@ -20,11 +20,13 @@ package org.apache.flink.streaming.runtime.tasks;
 
 import org.apache.flink.api.common.ExecutionConfig;
 import org.apache.flink.api.common.typeinfo.BasicTypeInfo;
+import org.apache.flink.api.common.typeutils.base.StringSerializer;
 import org.apache.flink.configuration.Configuration;
 import org.apache.flink.metrics.Counter;
 import org.apache.flink.metrics.Gauge;
 import org.apache.flink.metrics.Metric;
 import org.apache.flink.runtime.checkpoint.CheckpointOptions;
+import org.apache.flink.runtime.checkpoint.TaskStateSnapshot;
 import org.apache.flink.runtime.io.network.api.CancelCheckpointMarker;
 import org.apache.flink.runtime.io.network.api.CheckpointBarrier;
 import org.apache.flink.runtime.io.network.api.EndOfData;
@@ -66,6 +68,7 @@ import java.util.concurrent.ConcurrentHashMap;
 import java.util.concurrent.ConcurrentLinkedQueue;
 
 import static org.hamcrest.MatcherAssert.assertThat;
+import static org.hamcrest.Matchers.contains;
 import static org.junit.Assert.assertArrayEquals;
 import static org.junit.Assert.assertEquals;
 
@@ -516,6 +519,28 @@ public class TwoInputStreamTaskTest {
 
         testHarness.endInput();
         testHarness.waitForTaskCompletion();
+    }
+
+    @Test
+    public void testSkipExecutionsIfFinishedOnRestore() throws Exception {
+        OperatorID nonSourceOperatorId = new OperatorID();
+
+        try (StreamTaskMailboxTestHarness<String> testHarness =
+                new StreamTaskMailboxTestHarnessBuilder<>(
+                                TwoInputStreamTask::new, BasicTypeInfo.STRING_TYPE_INFO)
+                        .setCollectNetworkEvents()
+                        .modifyStreamConfig(config -> config.setCheckpointingEnabled(true))
+                        .addInput(BasicTypeInfo.INT_TYPE_INFO)
+                        .addInput(BasicTypeInfo.INT_TYPE_INFO)
+                        .setTaskStateSnapshot(1, TaskStateSnapshot.FINISHED_ON_RESTORE)
+                        .setupOperatorChain(
+                                nonSourceOperatorId, new TestFinishedOnRestoreStreamOperator())
+                        .finishForSingletonOperatorChain(StringSerializer.INSTANCE)
+                        .build()) {
+
+            testHarness.waitForTaskCompletion();
+            assertThat(testHarness.getOutput(), contains(EndOfData.INSTANCE));
+        }
     }
 
     static class DuplicatingOperator extends AbstractStreamOperator<String>

--- a/flink-streaming-java/src/test/java/org/apache/flink/streaming/runtime/tasks/TwoInputStreamTaskTest.java
+++ b/flink-streaming-java/src/test/java/org/apache/flink/streaming/runtime/tasks/TwoInputStreamTaskTest.java
@@ -538,8 +538,11 @@ public class TwoInputStreamTaskTest {
                         .finishForSingletonOperatorChain(StringSerializer.INSTANCE)
                         .build()) {
 
+            testHarness.processElement(Watermark.MAX_WATERMARK, 0);
+            testHarness.processElement(Watermark.MAX_WATERMARK, 1);
             testHarness.waitForTaskCompletion();
-            assertThat(testHarness.getOutput(), contains(EndOfData.INSTANCE));
+            assertThat(
+                    testHarness.getOutput(), contains(Watermark.MAX_WATERMARK, EndOfData.INSTANCE));
         }
     }
 


### PR DESCRIPTION
This PR provides a bug fixes for two bugs: FLINK-23708 and FLINK-23698

## Verifying this change

Add a various unit tests for missing test coverage

## Does this pull request potentially affect one of the following parts:

  - Dependencies (does it add or upgrade a dependency): (yes / **no**)
  - The public API, i.e., is any changed class annotated with `@Public(Evolving)`: (yes / **no**)
  - The serializers: (yes / **no** / don't know)
  - The runtime per-record code paths (performance sensitive): (**yes** / no / don't know)
  - Anything that affects deployment or recovery: JobManager (and its components), Checkpointing, Kubernetes/Yarn, ZooKeeper: (yes / **no** / don't know)
  - The S3 file system connector: (yes / no ****/ don't know)

## Documentation

  - Does this pull request introduce a new feature? (yes / **no**)
  - If yes, how is the feature documented? (**not applicable** / docs / JavaDocs / not documented)
