### PR TITLE
[FLINK-23699] Fixed RocksDBOptions attribute reference

### DIFF
--- a/flink-state-backends/flink-statebackend-rocksdb/src/main/java/org/apache/flink/contrib/streaming/state/RocksDBMemoryConfiguration.java
+++ b/flink-state-backends/flink-statebackend-rocksdb/src/main/java/org/apache/flink/contrib/streaming/state/RocksDBMemoryConfiguration.java
@@ -127,7 +127,7 @@ public final class RocksDBMemoryConfiguration implements Serializable {
     /**
      * Gets whether the state backend is configured to use a fixed amount of memory shared between
      * all RocksDB instances (in all tasks and operators) of a slot. See {@link
-     * RocksDBOptions#USE_MANAGED_MEMORY} for details.
+     * RocksDBOptions#FIX_PER_SLOT_MEMORY_SIZE} for details.
      */
     public boolean isUsingFixedMemoryPerSlot() {
         return fixedMemoryPerSlot != null;


### PR DESCRIPTION
## What is the purpose of the change

* Corrected RocksDBOptions reference in javadoc

## Brief change log

* Updated RocksDBOptions reference in javadoc to point to FIX_PER_SLOT_MEMORY_SIZE as mentioned in the Jira ticket.

## Verifying this change

This change is a trivial rework / code cleanup without any test coverage.

## Does this pull request potentially affect one of the following parts:

  - Dependencies (does it add or upgrade a dependency): no
  - The public API, i.e., is any changed class annotated with `@Public(Evolving)`:  no
  - The serializers: no 
  - The runtime per-record code paths (performance sensitive):  no 
  - Anything that affects deployment or recovery: JobManager (and its components), Checkpointing, Kubernetes/Yarn, ZooKeeper: no 
  - The S3 file system connector: no 

## Documentation

  - Does this pull request introduce a new feature?  no
  - If yes, how is the feature documented? not applicable 
