### PR TITLE
[FLINK-23430][runtime][checkpoint] Allows taking snapshots for operator coordinators which all corresponding tasks finished

### DIFF
--- a/flink-runtime/src/main/java/org/apache/flink/runtime/checkpoint/DefaultCheckpointPlan.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/checkpoint/DefaultCheckpointPlan.java
@@ -233,8 +233,8 @@ public class DefaultCheckpointPlan implements CheckpointPlan {
                 OperatorState operatorState =
                         operatorStates.get(operatorID.getGeneratedOperatorID());
                 checkState(
-                        operatorState == null,
-                        "There should be no states reported for fully finished or finished on restore operators");
+                        operatorState == null || !operatorState.hasSubtaskStates(),
+                        "There should be no states or only coordinator state reported for fully finished operators");
 
                 operatorState =
                         new FullyFinishedOperatorState(

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/checkpoint/OperatorState.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/checkpoint/OperatorState.java
@@ -159,6 +159,10 @@ public class OperatorState implements CompositeStateHandle {
         }
     }
 
+    public boolean hasSubtaskStates() {
+        return operatorSubtaskStates.size() > 0;
+    }
+
     @Override
     public long getStateSize() {
         long result = coordinatorState == null ? 0L : coordinatorState.getStateSize();


### PR DESCRIPTION
## What is the purpose of the change

This PR fixes the issue that for the fully finished operator, if it has used the `OperatorCoordinator`, then when taking checkpoints, the `OperatorCoordinator` would report its state first and `PendingCheckpoint` would store an `OperatorState` for this operator. Then when we finally fulfill the `FullyFinishedOperatorState`, the current check that no `OperatorState` is stored would fail.

## Brief change log

We would relax the condition to allow if `OperatorState` is created, then it should not contains task state.

## Verifying this change

This change is tested via the added test.

## Does this pull request potentially affect one of the following parts:

  - Dependencies (does it add or upgrade a dependency): **no**
  - The public API, i.e., is any changed class annotated with `@Public(Evolving)`: **no**
  - The serializers: **no**
  - The runtime per-record code paths (performance sensitive): (yes / no / don't know)
  - Anything that affects deployment or recovery: JobManager (and its components), Checkpointing, Kubernetes/Yarn, ZooKeeper: **no**
  - The S3 file system connector: **no**

## Documentation

  - Does this pull request introduce a new feature? **no**
  - If yes, how is the feature documented? **not applicable**
