### PR TITLE
[FLINK-22914][connector/kafka] Use FLIP-27 KafkaSource in Kafka table connector

### DIFF
--- a/flink-connectors/flink-connector-kafka/src/main/java/org/apache/flink/connector/kafka/source/enumerator/initializer/ReaderHandledOffsetsInitializer.java
+++ b/flink-connectors/flink-connector-kafka/src/main/java/org/apache/flink/connector/kafka/source/enumerator/initializer/ReaderHandledOffsetsInitializer.java
@@ -26,6 +26,7 @@ import org.apache.kafka.common.TopicPartition;
 import java.util.Collection;
 import java.util.HashMap;
 import java.util.Map;
+import java.util.Objects;
 
 /**
  * A initializer that initialize the partitions to the earliest / latest / last-committed offsets.
@@ -64,5 +65,18 @@ class ReaderHandledOffsetsInitializer implements OffsetsInitializer {
     @Override
     public OffsetResetStrategy getAutoOffsetResetStrategy() {
         return offsetResetStrategy;
+    }
+
+    @Override
+    public boolean equals(Object o) {
+        if (this == o) {
+            return true;
+        }
+        if (o == null || getClass() != o.getClass()) {
+            return false;
+        }
+        final ReaderHandledOffsetsInitializer that = (ReaderHandledOffsetsInitializer) o;
+        return Objects.equals(startingOffset, that.startingOffset)
+                && Objects.equals(offsetResetStrategy, that.offsetResetStrategy);
     }
 }

--- a/flink-connectors/flink-connector-kafka/src/main/java/org/apache/flink/connector/kafka/source/enumerator/initializer/SpecifiedOffsetsInitializer.java
+++ b/flink-connectors/flink-connector-kafka/src/main/java/org/apache/flink/connector/kafka/source/enumerator/initializer/SpecifiedOffsetsInitializer.java
@@ -27,6 +27,7 @@ import java.util.Collections;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
+import java.util.Objects;
 
 /**
  * An implementation of {@link OffsetsInitializer} which initializes the offsets of the partition
@@ -84,5 +85,18 @@ class SpecifiedOffsetsInitializer implements OffsetsInitializer {
     @Override
     public OffsetResetStrategy getAutoOffsetResetStrategy() {
         return offsetResetStrategy;
+    }
+
+    @Override
+    public boolean equals(Object o) {
+        if (this == o) {
+            return true;
+        }
+        if (o == null || getClass() != o.getClass()) {
+            return false;
+        }
+        final SpecifiedOffsetsInitializer that = (SpecifiedOffsetsInitializer) o;
+        return Objects.equals(initialOffsets, that.initialOffsets)
+                && Objects.equals(offsetResetStrategy, that.offsetResetStrategy);
     }
 }

--- a/flink-connectors/flink-connector-kafka/src/main/java/org/apache/flink/connector/kafka/source/enumerator/initializer/TimestampOffsetsInitializer.java
+++ b/flink-connectors/flink-connector-kafka/src/main/java/org/apache/flink/connector/kafka/source/enumerator/initializer/TimestampOffsetsInitializer.java
@@ -24,6 +24,7 @@ import org.apache.kafka.common.TopicPartition;
 import java.util.Collection;
 import java.util.HashMap;
 import java.util.Map;
+import java.util.Objects;
 
 /**
  * An implementation of {@link OffsetsInitializer} to initialize the offsets based on a timestamp.
@@ -71,5 +72,17 @@ class TimestampOffsetsInitializer implements OffsetsInitializer {
     @Override
     public OffsetResetStrategy getAutoOffsetResetStrategy() {
         return OffsetResetStrategy.NONE;
+    }
+
+    @Override
+    public boolean equals(Object o) {
+        if (this == o) {
+            return true;
+        }
+        if (o == null || getClass() != o.getClass()) {
+            return false;
+        }
+        final TimestampOffsetsInitializer that = (TimestampOffsetsInitializer) o;
+        return Objects.equals(startingTimestamp, that.startingTimestamp);
     }
 }

--- a/flink-connectors/flink-connector-kafka/src/main/java/org/apache/flink/connector/kafka/table/options/KafkaConnectorOptions.java
+++ b/flink-connectors/flink-connector-kafka/src/main/java/org/apache/flink/connector/kafka/table/options/KafkaConnectorOptions.java
@@ -16,9 +16,10 @@
  * limitations under the License.
  */
 
-package org.apache.flink.streaming.connectors.kafka.table;
+package org.apache.flink.connector.kafka.table.options;
 
 import org.apache.flink.annotation.PublicEvolving;
+import org.apache.flink.api.connector.source.Boundedness;
 import org.apache.flink.configuration.ConfigOption;
 import org.apache.flink.configuration.ConfigOptions;
 import org.apache.flink.configuration.DescribedEnum;
@@ -128,6 +129,13 @@ public class KafkaConnectorOptions {
                     .withDescription(
                             "Optional topic pattern from which the table is read for source. Either 'topic' or 'topic-pattern' must be set.");
 
+    public static final ConfigOption<List<String>> PARTITIONS =
+            ConfigOptions.key("partitions")
+                    .stringType()
+                    .asList()
+                    .noDefaultValue()
+                    .withDescription("Set of partitions from which the table is reading from.");
+
     public static final ConfigOption<String> PROPS_BOOTSTRAP_SERVERS =
             ConfigOptions.key("properties.bootstrap.servers")
                     .stringType()
@@ -145,10 +153,10 @@ public class KafkaConnectorOptions {
     // Scan specific options
     // --------------------------------------------------------------------------------------------
 
-    public static final ConfigOption<ScanStartupMode> SCAN_STARTUP_MODE =
+    public static final ConfigOption<OffsetMode> SCAN_STARTUP_MODE =
             ConfigOptions.key("scan.startup.mode")
-                    .enumType(ScanStartupMode.class)
-                    .defaultValue(ScanStartupMode.GROUP_OFFSETS)
+                    .enumType(OffsetMode.class)
+                    .defaultValue(OffsetMode.GROUP_OFFSETS)
                     .withDescription("Startup mode for Kafka consumer.");
 
     public static final ConfigOption<String> SCAN_STARTUP_SPECIFIC_OFFSETS =
@@ -164,6 +172,32 @@ public class KafkaConnectorOptions {
                     .noDefaultValue()
                     .withDescription(
                             "Optional timestamp used in case of \"timestamp\" startup mode");
+
+    public static final ConfigOption<OffsetMode> SCAN_STOP_MODE =
+            ConfigOptions.key("scan.stop.mode")
+                    .enumType(OffsetMode.class)
+                    .noDefaultValue()
+                    .withDescription("Stop mode for Kafka consumer");
+
+    public static final ConfigOption<String> SCAN_STOP_SPECIFIC_OFFSETS =
+            ConfigOptions.key("scan.stop.specific-offsets")
+                    .stringType()
+                    .noDefaultValue()
+                    .withDescription(
+                            "Optional offsets used in case of \"specific-offsets\" stop mode");
+
+    public static final ConfigOption<Long> SCAN_STOP_TIMESTAMP_MILLIS =
+            ConfigOptions.key("scan.stop.timestamp-millis")
+                    .longType()
+                    .noDefaultValue()
+                    .withDescription("Optional timestamp used in case of \"timestamp\" stop mode");
+
+    public static final ConfigOption<Boundedness> BOUNDEDNESS =
+            ConfigOptions.key("boundedness")
+                    .enumType(Boundedness.class)
+                    .noDefaultValue()
+                    .withDescription(
+                            "Specify whether Kafka source runs in unbounded or bounded mode");
 
     public static final ConfigOption<Duration> SCAN_TOPIC_PARTITION_DISCOVERY =
             ConfigOptions.key("scan.topic-partition-discovery.interval")
@@ -251,7 +285,7 @@ public class KafkaConnectorOptions {
     }
 
     /** Startup mode for the Kafka consumer, see {@link #SCAN_STARTUP_MODE}. */
-    public enum ScanStartupMode implements DescribedEnum {
+    public enum OffsetMode implements DescribedEnum {
         EARLIEST_OFFSET("earliest-offset", text("Start from the earliest offset possible.")),
         LATEST_OFFSET("latest-offset", text("Start from the latest offset.")),
         GROUP_OFFSETS(
@@ -266,7 +300,7 @@ public class KafkaConnectorOptions {
         private final String value;
         private final InlineElement description;
 
-        ScanStartupMode(String value, InlineElement description) {
+        OffsetMode(String value, InlineElement description) {
             this.value = value;
             this.description = description;
         }
@@ -316,7 +350,7 @@ public class KafkaConnectorOptions {
             return value;
         }
 
-        FlinkKafkaProducer.Semantic getSemantic() {
+        public FlinkKafkaProducer.Semantic getSemantic() {
             return semantic;
         }
 

--- a/flink-connectors/flink-connector-kafka/src/main/java/org/apache/flink/connector/kafka/table/serde/DynamicKafkaDeserializationSchema.java
+++ b/flink-connectors/flink-connector-kafka/src/main/java/org/apache/flink/connector/kafka/table/serde/DynamicKafkaDeserializationSchema.java
@@ -16,10 +16,11 @@
  * limitations under the License.
  */
 
-package org.apache.flink.streaming.connectors.kafka.table;
+package org.apache.flink.connector.kafka.table.serde;
 
 import org.apache.flink.api.common.serialization.DeserializationSchema;
 import org.apache.flink.api.common.typeinfo.TypeInformation;
+import org.apache.flink.connector.kafka.table.source.KafkaDynamicTableSource;
 import org.apache.flink.streaming.connectors.kafka.KafkaDeserializationSchema;
 import org.apache.flink.streaming.connectors.kafka.KafkaSerializationSchema;
 import org.apache.flink.table.data.GenericRowData;
@@ -37,8 +38,8 @@ import java.io.Serializable;
 import java.util.ArrayList;
 import java.util.List;
 
-/** A specific {@link KafkaSerializationSchema} for {@link KafkaDynamicSource}. */
-class DynamicKafkaDeserializationSchema implements KafkaDeserializationSchema<RowData> {
+/** A specific {@link KafkaSerializationSchema} for {@link KafkaDynamicTableSource}. */
+public class DynamicKafkaDeserializationSchema implements KafkaDeserializationSchema<RowData> {
 
     private static final long serialVersionUID = 1L;
 
@@ -56,7 +57,7 @@ class DynamicKafkaDeserializationSchema implements KafkaDeserializationSchema<Ro
 
     private final boolean upsertMode;
 
-    DynamicKafkaDeserializationSchema(
+    public DynamicKafkaDeserializationSchema(
             int physicalArity,
             @Nullable DeserializationSchema<RowData> keyDeserialization,
             int[] keyProjection,
@@ -139,7 +140,8 @@ class DynamicKafkaDeserializationSchema implements KafkaDeserializationSchema<Ro
 
     // --------------------------------------------------------------------------------------------
 
-    interface MetadataConverter extends Serializable {
+    /** Metadata converter. */
+    public interface MetadataConverter extends Serializable {
         Object read(ConsumerRecord<?, ?> record);
     }
 

--- a/flink-connectors/flink-connector-kafka/src/main/java/org/apache/flink/connector/kafka/table/serde/DynamicKafkaSerializationSchema.java
+++ b/flink-connectors/flink-connector-kafka/src/main/java/org/apache/flink/connector/kafka/table/serde/DynamicKafkaSerializationSchema.java
@@ -16,9 +16,10 @@
  * limitations under the License.
  */
 
-package org.apache.flink.streaming.connectors.kafka.table;
+package org.apache.flink.connector.kafka.table.serde;
 
 import org.apache.flink.api.common.serialization.SerializationSchema;
+import org.apache.flink.connector.kafka.table.sink.KafkaDynamicSink;
 import org.apache.flink.streaming.connectors.kafka.KafkaContextAware;
 import org.apache.flink.streaming.connectors.kafka.KafkaSerializationSchema;
 import org.apache.flink.streaming.connectors.kafka.partitioner.FlinkKafkaPartitioner;
@@ -34,7 +35,7 @@ import javax.annotation.Nullable;
 import java.io.Serializable;
 
 /** A specific {@link KafkaSerializationSchema} for {@link KafkaDynamicSink}. */
-class DynamicKafkaSerializationSchema
+public class DynamicKafkaSerializationSchema
         implements KafkaSerializationSchema<RowData>, KafkaContextAware<RowData> {
 
     private static final long serialVersionUID = 1L;
@@ -67,7 +68,7 @@ class DynamicKafkaSerializationSchema
 
     private int numParallelInstances;
 
-    DynamicKafkaSerializationSchema(
+    public DynamicKafkaSerializationSchema(
             String topic,
             @Nullable FlinkKafkaPartitioner<RowData> partitioner,
             @Nullable SerializationSchema<RowData> keySerialization,
@@ -187,7 +188,7 @@ class DynamicKafkaSerializationSchema
         return null;
     }
 
-    static RowData createProjectedRow(
+    public static RowData createProjectedRow(
             RowData consumedRow, RowKind kind, RowData.FieldGetter[] fieldGetters) {
         final int arity = fieldGetters.length;
         final GenericRowData genericRowData = new GenericRowData(kind, arity);
@@ -199,7 +200,8 @@ class DynamicKafkaSerializationSchema
 
     // --------------------------------------------------------------------------------------------
 
-    interface MetadataConverter extends Serializable {
+    /** Metadata converter. */
+    public interface MetadataConverter extends Serializable {
         Object read(RowData consumedRow, int pos);
     }
 }

--- a/flink-connectors/flink-connector-kafka/src/main/java/org/apache/flink/connector/kafka/table/source/KafkaDynamicTableSource.java
+++ b/flink-connectors/flink-connector-kafka/src/main/java/org/apache/flink/connector/kafka/table/source/KafkaDynamicTableSource.java
@@ -1,0 +1,639 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.flink.connector.kafka.table.source;
+
+import org.apache.flink.annotation.Internal;
+import org.apache.flink.annotation.VisibleForTesting;
+import org.apache.flink.api.common.eventtime.WatermarkStrategy;
+import org.apache.flink.api.common.serialization.DeserializationSchema;
+import org.apache.flink.api.common.typeinfo.TypeInformation;
+import org.apache.flink.api.connector.source.Boundedness;
+import org.apache.flink.connector.kafka.source.KafkaSource;
+import org.apache.flink.connector.kafka.source.KafkaSourceBuilder;
+import org.apache.flink.connector.kafka.source.enumerator.initializer.OffsetsInitializer;
+import org.apache.flink.connector.kafka.source.reader.deserializer.KafkaRecordDeserializationSchema;
+import org.apache.flink.connector.kafka.table.serde.DynamicKafkaDeserializationSchema;
+import org.apache.flink.connector.kafka.table.serde.DynamicKafkaDeserializationSchema.MetadataConverter;
+import org.apache.flink.streaming.api.datastream.DataStream;
+import org.apache.flink.streaming.api.environment.StreamExecutionEnvironment;
+import org.apache.flink.table.api.DataTypes;
+import org.apache.flink.table.catalog.ObjectPath;
+import org.apache.flink.table.connector.ChangelogMode;
+import org.apache.flink.table.connector.format.DecodingFormat;
+import org.apache.flink.table.connector.source.DataStreamScanProvider;
+import org.apache.flink.table.connector.source.DynamicTableSource;
+import org.apache.flink.table.connector.source.ScanTableSource;
+import org.apache.flink.table.connector.source.abilities.SupportsReadingMetadata;
+import org.apache.flink.table.connector.source.abilities.SupportsWatermarkPushDown;
+import org.apache.flink.table.data.GenericMapData;
+import org.apache.flink.table.data.RowData;
+import org.apache.flink.table.data.StringData;
+import org.apache.flink.table.data.TimestampData;
+import org.apache.flink.table.types.DataType;
+import org.apache.flink.table.types.utils.DataTypeUtils;
+
+import org.apache.kafka.clients.consumer.ConsumerRecord;
+import org.apache.kafka.common.TopicPartition;
+import org.apache.kafka.common.header.Header;
+
+import javax.annotation.Nullable;
+
+import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.Collections;
+import java.util.HashMap;
+import java.util.LinkedHashMap;
+import java.util.List;
+import java.util.Map;
+import java.util.Objects;
+import java.util.Properties;
+import java.util.Set;
+import java.util.regex.Pattern;
+import java.util.stream.Collectors;
+import java.util.stream.IntStream;
+import java.util.stream.Stream;
+
+import static org.apache.flink.util.Preconditions.checkNotNull;
+
+/** A version-agnostic Kafka {@link ScanTableSource}. */
+@Internal
+public class KafkaDynamicTableSource
+        implements ScanTableSource, SupportsReadingMetadata, SupportsWatermarkPushDown {
+
+    // --------------------------------------------------------------------------------------------
+    // Mutable attributes
+    // --------------------------------------------------------------------------------------------
+
+    /** Data type that describes the final output of the source. */
+    protected DataType producedDataType;
+
+    /** Metadata that is appended at the end of a physical source row. */
+    protected List<String> metadataKeys;
+
+    /** Watermark strategy that is used to generate per-partition watermark. */
+    protected @Nullable WatermarkStrategy<RowData> watermarkStrategy;
+
+    // --------------------------------------------------------------------------------------------
+    // Format attributes
+    // --------------------------------------------------------------------------------------------
+
+    private static final String VALUE_METADATA_PREFIX = "value.";
+
+    /** Data type to configure the formats. */
+    protected final DataType physicalDataType;
+
+    /** Optional format for decoding keys from Kafka. */
+    protected final @Nullable DecodingFormat<DeserializationSchema<RowData>> keyDecodingFormat;
+
+    /** Format for decoding values from Kafka. */
+    protected final DecodingFormat<DeserializationSchema<RowData>> valueDecodingFormat;
+
+    /** Indices that determine the key fields and the target position in the produced row. */
+    protected final int[] keyProjection;
+
+    /** Indices that determine the value fields and the target position in the produced row. */
+    protected final int[] valueProjection;
+
+    /** Prefix that needs to be removed from fields when constructing the physical data type. */
+    protected final @Nullable String keyPrefix;
+
+    // --------------------------------------------------------------------------------------------
+    // Kafka-specific attributes
+    // --------------------------------------------------------------------------------------------
+
+    protected final TopicPartitionSubscription topicPartitionSubscription;
+
+    protected final OffsetsInitializer startingOffsetsInitializer;
+
+    protected final OffsetsInitializer stoppingOffsetsInitializer;
+
+    protected final Boundedness boundedness;
+
+    /** Properties for the Kafka consumer. */
+    protected final Properties properties;
+
+    protected final ObjectPath objectPath;
+
+    /** Flag to determine source mode. In upsert mode, it will keep the tombstone message. * */
+    protected final boolean upsertMode;
+
+    public KafkaDynamicTableSource(
+            DataType physicalDataType,
+            @Nullable DecodingFormat<DeserializationSchema<RowData>> keyDecodingFormat,
+            DecodingFormat<DeserializationSchema<RowData>> valueDecodingFormat,
+            int[] keyProjection,
+            int[] valueProjection,
+            @Nullable String keyPrefix,
+            TopicPartitionSubscription topicPartitionSubscription,
+            OffsetsInitializer startingOffsetsInitializer,
+            @Nullable OffsetsInitializer stoppingOffsetsInitializer,
+            Boundedness boundedness,
+            Properties properties,
+            ObjectPath objectPath,
+            boolean upsertMode) {
+        // Format attributes
+        this.physicalDataType =
+                checkNotNull(physicalDataType, "Physical data type must not be null.");
+        this.keyDecodingFormat = keyDecodingFormat;
+        this.valueDecodingFormat =
+                checkNotNull(valueDecodingFormat, "Value decoding format must not be null.");
+        this.keyProjection = checkNotNull(keyProjection, "Key projection must not be null.");
+        this.valueProjection = checkNotNull(valueProjection, "Value projection must not be null.");
+        this.keyPrefix = keyPrefix;
+        // Mutable attributes
+        this.producedDataType = physicalDataType;
+        this.metadataKeys = Collections.emptyList();
+        this.watermarkStrategy = WatermarkStrategy.noWatermarks();
+        // Kafka-specific attributes
+        this.topicPartitionSubscription = topicPartitionSubscription;
+        this.startingOffsetsInitializer = startingOffsetsInitializer;
+        this.stoppingOffsetsInitializer = stoppingOffsetsInitializer;
+        this.boundedness = boundedness;
+        this.properties = checkNotNull(properties, "Properties must not be null.");
+        this.objectPath = objectPath;
+        this.upsertMode = upsertMode;
+    }
+
+    @Override
+    public ChangelogMode getChangelogMode() {
+        return valueDecodingFormat.getChangelogMode();
+    }
+
+    @Override
+    public ScanRuntimeProvider getScanRuntimeProvider(ScanContext context) {
+        final KafkaRecordDeserializationSchema<RowData> deserializer = createDeserializer(context);
+        final KafkaSource<RowData> kafkaSource =
+                createKafkaSource(
+                        this.topicPartitionSubscription,
+                        this.startingOffsetsInitializer,
+                        this.stoppingOffsetsInitializer,
+                        this.boundedness,
+                        deserializer,
+                        this.properties);
+
+        return new DataStreamScanProvider() {
+            @Override
+            public DataStream<RowData> produceDataStream(StreamExecutionEnvironment execEnv) {
+                return execEnv.fromSource(
+                        kafkaSource, watermarkStrategy, "KafkaSource-" + objectPath.getFullName());
+            }
+
+            @Override
+            public boolean isBounded() {
+                return kafkaSource.getBoundedness() == Boundedness.BOUNDED;
+            }
+        };
+    }
+
+    @Override
+    public Map<String, DataType> listReadableMetadata() {
+        final Map<String, DataType> metadataMap = new LinkedHashMap<>();
+
+        // according to convention, the order of the final row must be
+        // PHYSICAL + FORMAT METADATA + CONNECTOR METADATA
+        // where the format metadata has highest precedence
+
+        // add value format metadata with prefix
+        valueDecodingFormat
+                .listReadableMetadata()
+                .forEach((key, value) -> metadataMap.put(VALUE_METADATA_PREFIX + key, value));
+
+        // add connector metadata
+        Stream.of(ReadableMetadata.values())
+                .forEachOrdered(m -> metadataMap.putIfAbsent(m.key, m.dataType));
+
+        return metadataMap;
+    }
+
+    @Override
+    public void applyReadableMetadata(List<String> metadataKeys, DataType producedDataType) {
+        // separate connector and format metadata
+        final List<String> formatMetadataKeys =
+                metadataKeys.stream()
+                        .filter(k -> k.startsWith(VALUE_METADATA_PREFIX))
+                        .collect(Collectors.toList());
+        final List<String> connectorMetadataKeys = new ArrayList<>(metadataKeys);
+        connectorMetadataKeys.removeAll(formatMetadataKeys);
+
+        // push down format metadata
+        final Map<String, DataType> formatMetadata = valueDecodingFormat.listReadableMetadata();
+        if (formatMetadata.size() > 0) {
+            final List<String> requestedFormatMetadataKeys =
+                    formatMetadataKeys.stream()
+                            .map(k -> k.substring(VALUE_METADATA_PREFIX.length()))
+                            .collect(Collectors.toList());
+            valueDecodingFormat.applyReadableMetadata(requestedFormatMetadataKeys);
+        }
+
+        this.metadataKeys = connectorMetadataKeys;
+        this.producedDataType = producedDataType;
+    }
+
+    @Override
+    public void applyWatermark(WatermarkStrategy<RowData> watermarkStrategy) {
+        this.watermarkStrategy = watermarkStrategy;
+    }
+
+    @Override
+    public DynamicTableSource copy() {
+        final KafkaDynamicTableSource copy =
+                new KafkaDynamicTableSource(
+                        physicalDataType,
+                        keyDecodingFormat,
+                        valueDecodingFormat,
+                        keyProjection,
+                        valueProjection,
+                        keyPrefix,
+                        topicPartitionSubscription,
+                        startingOffsetsInitializer,
+                        stoppingOffsetsInitializer,
+                        boundedness,
+                        properties,
+                        objectPath,
+                        upsertMode);
+        copy.producedDataType = producedDataType;
+        copy.metadataKeys = metadataKeys;
+        copy.watermarkStrategy = watermarkStrategy;
+        return copy;
+    }
+
+    @Override
+    public String asSummaryString() {
+        return "Kafka table source";
+    }
+
+    @Override
+    public boolean equals(Object o) {
+        if (this == o) {
+            return true;
+        }
+        if (o == null || getClass() != o.getClass()) {
+            return false;
+        }
+        final KafkaDynamicTableSource that = (KafkaDynamicTableSource) o;
+        return Objects.equals(producedDataType, that.producedDataType)
+                && Objects.equals(metadataKeys, that.metadataKeys)
+                && Objects.equals(physicalDataType, that.physicalDataType)
+                && Objects.equals(keyDecodingFormat, that.keyDecodingFormat)
+                && Objects.equals(valueDecodingFormat, that.valueDecodingFormat)
+                && Arrays.equals(keyProjection, that.keyProjection)
+                && Arrays.equals(valueProjection, that.valueProjection)
+                && Objects.equals(keyPrefix, that.keyPrefix)
+                && Objects.equals(topicPartitionSubscription, that.topicPartitionSubscription)
+                && Objects.equals(startingOffsetsInitializer, that.startingOffsetsInitializer)
+                && Objects.equals(stoppingOffsetsInitializer, that.stoppingOffsetsInitializer)
+                && Objects.equals(boundedness, that.boundedness)
+                && Objects.equals(properties, that.properties)
+                && Objects.equals(objectPath, that.objectPath)
+                && Objects.equals(upsertMode, that.upsertMode)
+                && Objects.equals(watermarkStrategy, that.watermarkStrategy);
+    }
+
+    @Override
+    public int hashCode() {
+        return Objects.hash(
+                producedDataType,
+                metadataKeys,
+                physicalDataType,
+                keyDecodingFormat,
+                valueDecodingFormat,
+                Arrays.hashCode(keyProjection),
+                Arrays.hashCode(valueProjection),
+                keyPrefix,
+                topicPartitionSubscription,
+                startingOffsetsInitializer,
+                stoppingOffsetsInitializer,
+                boundedness,
+                properties,
+                upsertMode);
+    }
+
+    // --------------------------------------------------------------------------------------------
+
+    protected KafkaRecordDeserializationSchema<RowData> createDeserializer(ScanContext context) {
+        final DeserializationSchema<RowData> keyDeserialization =
+                createDeserialization(context, keyDecodingFormat, keyProjection, keyPrefix);
+
+        final DeserializationSchema<RowData> valueDeserialization =
+                createDeserialization(context, valueDecodingFormat, valueProjection, null);
+
+        final TypeInformation<RowData> producedTypeInfo =
+                context.createTypeInformation(producedDataType);
+
+        final MetadataConverter[] metadataConverters =
+                metadataKeys.stream()
+                        .map(
+                                k ->
+                                        Stream.of(ReadableMetadata.values())
+                                                .filter(rm -> rm.key.equals(k))
+                                                .findFirst()
+                                                .orElseThrow(IllegalStateException::new))
+                        .map(m -> m.converter)
+                        .toArray(MetadataConverter[]::new);
+
+        // check if connector metadata is used at all
+        final boolean hasMetadata = metadataKeys.size() > 0;
+
+        // adjust physical arity with value format's metadata
+        final int adjustedPhysicalArity =
+                producedDataType.getChildren().size() - metadataKeys.size();
+
+        // adjust value format projection to include value format's metadata columns at the end
+        final int[] adjustedValueProjection =
+                IntStream.concat(
+                                IntStream.of(valueProjection),
+                                IntStream.range(
+                                        keyProjection.length + valueProjection.length,
+                                        adjustedPhysicalArity))
+                        .toArray();
+
+        final DynamicKafkaDeserializationSchema dynamicKafkaDeserializationSchema =
+                new DynamicKafkaDeserializationSchema(
+                        adjustedPhysicalArity,
+                        keyDeserialization,
+                        keyProjection,
+                        valueDeserialization,
+                        adjustedValueProjection,
+                        hasMetadata,
+                        metadataConverters,
+                        producedTypeInfo,
+                        upsertMode);
+
+        return KafkaRecordDeserializationSchema.of(dynamicKafkaDeserializationSchema);
+    }
+
+    protected KafkaSource<RowData> createKafkaSource(
+            TopicPartitionSubscription topicPartitionSubscription,
+            OffsetsInitializer startingOffsetsInitializer,
+            @Nullable OffsetsInitializer stoppingOffsetsInitializer,
+            Boundedness boundedness,
+            KafkaRecordDeserializationSchema<RowData> deserializer,
+            Properties properties) {
+
+        // Initialize Kafka source builder
+        final KafkaSourceBuilder<RowData> builder =
+                KafkaSource.<RowData>builder()
+                        .setDeserializer(deserializer)
+                        .setStartingOffsets(startingOffsetsInitializer)
+                        .setProperties(properties);
+
+        // Subscribe to topic partitions
+        switch (topicPartitionSubscription.getSubscriptionType()) {
+            case TOPICS:
+                builder.setTopics(topicPartitionSubscription.getTopics());
+                break;
+            case TOPIC_PATTERN:
+                builder.setTopicPattern(topicPartitionSubscription.getTopicPattern());
+                break;
+            case PARTITIONS:
+                builder.setPartitions(topicPartitionSubscription.getPartitions());
+                break;
+            default:
+                throw new IllegalStateException("Unknown topic partition subscription type");
+        }
+
+        // Boundedness
+        if (boundedness == Boundedness.BOUNDED) {
+            // Bounded mode
+            checkNotNull(
+                    stoppingOffsetsInitializer,
+                    "Stopping offset must be specified in bounded mode");
+            builder.setBounded(stoppingOffsetsInitializer);
+        } else {
+            if (stoppingOffsetsInitializer != null) {
+                // Unbounded mode with stopping offset
+                builder.setUnbounded(stoppingOffsetsInitializer);
+            }
+        }
+
+        // Additional properties
+        builder.setProperties(properties);
+
+        // Build Kafka source
+        return builder.build();
+    }
+
+    private @Nullable DeserializationSchema<RowData> createDeserialization(
+            Context context,
+            @Nullable DecodingFormat<DeserializationSchema<RowData>> format,
+            int[] projection,
+            @Nullable String prefix) {
+        if (format == null) {
+            return null;
+        }
+        DataType physicalFormatDataType =
+                DataTypeUtils.projectRow(this.physicalDataType, projection);
+        if (prefix != null) {
+            physicalFormatDataType = DataTypeUtils.stripRowPrefix(physicalFormatDataType, prefix);
+        }
+        return format.createRuntimeDecoder(context, physicalFormatDataType);
+    }
+
+    // --------------------------------------------------------------------------------------------
+    // Metadata handling
+    // --------------------------------------------------------------------------------------------
+
+    enum ReadableMetadata {
+        TOPIC(
+                "topic",
+                DataTypes.STRING().notNull(),
+                new MetadataConverter() {
+                    private static final long serialVersionUID = 1L;
+
+                    @Override
+                    public Object read(ConsumerRecord<?, ?> record) {
+                        return StringData.fromString(record.topic());
+                    }
+                }),
+
+        PARTITION(
+                "partition",
+                DataTypes.INT().notNull(),
+                new MetadataConverter() {
+                    private static final long serialVersionUID = 1L;
+
+                    @Override
+                    public Object read(ConsumerRecord<?, ?> record) {
+                        return record.partition();
+                    }
+                }),
+
+        HEADERS(
+                "headers",
+                // key and value of the map are nullable to make handling easier in queries
+                DataTypes.MAP(DataTypes.STRING().nullable(), DataTypes.BYTES().nullable())
+                        .notNull(),
+                new MetadataConverter() {
+                    private static final long serialVersionUID = 1L;
+
+                    @Override
+                    public Object read(ConsumerRecord<?, ?> record) {
+                        final Map<StringData, byte[]> map = new HashMap<>();
+                        for (Header header : record.headers()) {
+                            map.put(StringData.fromString(header.key()), header.value());
+                        }
+                        return new GenericMapData(map);
+                    }
+                }),
+
+        LEADER_EPOCH(
+                "leader-epoch",
+                DataTypes.INT().nullable(),
+                new MetadataConverter() {
+                    private static final long serialVersionUID = 1L;
+
+                    @Override
+                    public Object read(ConsumerRecord<?, ?> record) {
+                        return record.leaderEpoch().orElse(null);
+                    }
+                }),
+
+        OFFSET(
+                "offset",
+                DataTypes.BIGINT().notNull(),
+                new MetadataConverter() {
+                    private static final long serialVersionUID = 1L;
+
+                    @Override
+                    public Object read(ConsumerRecord<?, ?> record) {
+                        return record.offset();
+                    }
+                }),
+
+        TIMESTAMP(
+                "timestamp",
+                DataTypes.TIMESTAMP_WITH_LOCAL_TIME_ZONE(3).notNull(),
+                new MetadataConverter() {
+                    private static final long serialVersionUID = 1L;
+
+                    @Override
+                    public Object read(ConsumerRecord<?, ?> record) {
+                        return TimestampData.fromEpochMillis(record.timestamp());
+                    }
+                }),
+
+        TIMESTAMP_TYPE(
+                "timestamp-type",
+                DataTypes.STRING().notNull(),
+                new MetadataConverter() {
+                    private static final long serialVersionUID = 1L;
+
+                    @Override
+                    public Object read(ConsumerRecord<?, ?> record) {
+                        return StringData.fromString(record.timestampType().toString());
+                    }
+                });
+
+        final String key;
+
+        final DataType dataType;
+
+        final MetadataConverter converter;
+
+        ReadableMetadata(String key, DataType dataType, MetadataConverter converter) {
+            this.key = key;
+            this.dataType = dataType;
+            this.converter = converter;
+        }
+    }
+
+    /** Helper class for subscribing to Kafka topics and partitions. */
+    public static class TopicPartitionSubscription {
+
+        private final SubscriptionType subscriptionType;
+
+        private final List<String> topics;
+        private final Pattern topicPattern;
+        private final Set<TopicPartition> partitions;
+
+        private TopicPartitionSubscription(
+                SubscriptionType subscriptionType,
+                List<String> topics,
+                Pattern topicPattern,
+                Set<TopicPartition> partitions) {
+            this.subscriptionType = subscriptionType;
+            this.topics = topics;
+            this.topicPattern = topicPattern;
+            this.partitions = partitions;
+        }
+
+        public static TopicPartitionSubscription topics(List<String> topics) {
+            return new TopicPartitionSubscription(SubscriptionType.TOPICS, topics, null, null);
+        }
+
+        public static TopicPartitionSubscription topicPattern(Pattern topicPattern) {
+            return new TopicPartitionSubscription(
+                    SubscriptionType.TOPIC_PATTERN, null, topicPattern, null);
+        }
+
+        public static TopicPartitionSubscription partitions(Set<TopicPartition> partitions) {
+            return new TopicPartitionSubscription(
+                    SubscriptionType.PARTITIONS, null, null, partitions);
+        }
+
+        public SubscriptionType getSubscriptionType() {
+            return subscriptionType;
+        }
+
+        public List<String> getTopics() {
+            return topics;
+        }
+
+        public Pattern getTopicPattern() {
+            return topicPattern;
+        }
+
+        public Set<TopicPartition> getPartitions() {
+            return partitions;
+        }
+
+        /** Topic / Partition subscription type. */
+        public enum SubscriptionType {
+            TOPICS,
+            TOPIC_PATTERN,
+            PARTITIONS
+        }
+
+        @Override
+        public boolean equals(Object o) {
+            if (this == o) {
+                return true;
+            }
+            if (o == null || getClass() != o.getClass()) {
+                return false;
+            }
+            final TopicPartitionSubscription that = (TopicPartitionSubscription) o;
+            return Objects.equals(subscriptionType, that.subscriptionType)
+                    && Objects.equals(topics, that.topics)
+                    && Objects.equals(
+                            String.valueOf(topicPattern), String.valueOf(that.topicPattern))
+                    && Objects.equals(partitions, that.partitions);
+        }
+    }
+
+    @VisibleForTesting
+    public void setProducedDataType(DataType producedDataType) {
+        this.producedDataType = producedDataType;
+    }
+
+    @VisibleForTesting
+    public void setMetadataKeys(List<String> metadataKeys) {
+        this.metadataKeys = metadataKeys;
+    }
+}

--- a/flink-connectors/flink-connector-kafka/src/main/java/org/apache/flink/connector/kafka/table/utils/BufferedUpsertSinkFunction.java
+++ b/flink-connectors/flink-connector-kafka/src/main/java/org/apache/flink/connector/kafka/table/utils/BufferedUpsertSinkFunction.java
@@ -16,7 +16,7 @@
  * limitations under the License.
  */
 
-package org.apache.flink.streaming.connectors.kafka.table;
+package org.apache.flink.connector.kafka.table.utils;
 
 import org.apache.flink.api.common.functions.RuntimeContext;
 import org.apache.flink.api.common.state.CheckpointListener;
@@ -47,7 +47,7 @@ import java.util.concurrent.ScheduledFuture;
 import java.util.concurrent.TimeUnit;
 import java.util.function.Function;
 
-import static org.apache.flink.streaming.connectors.kafka.table.DynamicKafkaSerializationSchema.createProjectedRow;
+import static org.apache.flink.connector.kafka.table.serde.DynamicKafkaSerializationSchema.createProjectedRow;
 import static org.apache.flink.types.RowKind.DELETE;
 import static org.apache.flink.types.RowKind.UPDATE_AFTER;
 import static org.apache.flink.util.Preconditions.checkArgument;

--- a/flink-connectors/flink-connector-kafka/src/main/java/org/apache/flink/connector/kafka/table/utils/SinkBufferFlushMode.java
+++ b/flink-connectors/flink-connector-kafka/src/main/java/org/apache/flink/connector/kafka/table/utils/SinkBufferFlushMode.java
@@ -16,7 +16,7 @@
  * limitations under the License.
  */
 
-package org.apache.flink.streaming.connectors.kafka.table;
+package org.apache.flink.connector.kafka.table.utils;
 
 import java.util.Objects;
 

--- a/flink-connectors/flink-connector-kafka/src/main/java/org/apache/flink/streaming/connectors/kafka/config/StartupMode.java
+++ b/flink-connectors/flink-connector-kafka/src/main/java/org/apache/flink/streaming/connectors/kafka/config/StartupMode.java
@@ -18,8 +18,8 @@
 package org.apache.flink.streaming.connectors.kafka.config;
 
 import org.apache.flink.annotation.Internal;
+import org.apache.flink.connector.kafka.table.options.KafkaConnectorOptions.OffsetMode;
 import org.apache.flink.streaming.connectors.kafka.internals.KafkaTopicPartitionStateSentinel;
-import org.apache.flink.streaming.connectors.kafka.table.KafkaConnectorOptions.ScanStartupMode;
 import org.apache.flink.table.api.TableException;
 
 /** Startup modes for the Kafka Consumer. */
@@ -58,7 +58,7 @@ public enum StartupMode {
         this.stateSentinel = stateSentinel;
     }
 
-    public static StartupMode fromOption(ScanStartupMode scanStartupMode) {
+    public static StartupMode fromOption(OffsetMode scanStartupMode) {
         switch (scanStartupMode) {
             case EARLIEST_OFFSET:
                 return StartupMode.EARLIEST;

--- a/flink-connectors/flink-connector-kafka/src/main/java/org/apache/flink/streaming/connectors/kafka/table/KafkaLegacyDynamicTableFactory.java
+++ b/flink-connectors/flink-connector-kafka/src/main/java/org/apache/flink/streaming/connectors/kafka/table/KafkaLegacyDynamicTableFactory.java
@@ -1,0 +1,354 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.flink.streaming.connectors.kafka.table;
+
+import org.apache.flink.annotation.Internal;
+import org.apache.flink.api.common.serialization.DeserializationSchema;
+import org.apache.flink.api.common.serialization.SerializationSchema;
+import org.apache.flink.configuration.ConfigOption;
+import org.apache.flink.configuration.ReadableConfig;
+import org.apache.flink.connector.kafka.table.options.KafkaConnectorOptions.SinkSemantic;
+import org.apache.flink.connector.kafka.table.sink.KafkaDynamicSink;
+import org.apache.flink.connector.kafka.table.source.KafkaDynamicTableSource;
+import org.apache.flink.connector.kafka.table.utils.SinkBufferFlushMode;
+import org.apache.flink.streaming.connectors.kafka.FlinkKafkaConsumerBase;
+import org.apache.flink.streaming.connectors.kafka.config.StartupMode;
+import org.apache.flink.streaming.connectors.kafka.internals.KafkaTopicPartition;
+import org.apache.flink.streaming.connectors.kafka.partitioner.FlinkKafkaPartitioner;
+import org.apache.flink.table.api.ValidationException;
+import org.apache.flink.table.connector.format.DecodingFormat;
+import org.apache.flink.table.connector.format.EncodingFormat;
+import org.apache.flink.table.connector.sink.DynamicTableSink;
+import org.apache.flink.table.connector.source.DynamicTableSource;
+import org.apache.flink.table.data.RowData;
+import org.apache.flink.table.factories.DeserializationFormatFactory;
+import org.apache.flink.table.factories.DynamicTableSinkFactory;
+import org.apache.flink.table.factories.DynamicTableSourceFactory;
+import org.apache.flink.table.factories.FactoryUtil;
+import org.apache.flink.table.factories.FactoryUtil.TableFactoryHelper;
+import org.apache.flink.table.factories.SerializationFormatFactory;
+import org.apache.flink.table.types.DataType;
+import org.apache.flink.types.RowKind;
+
+import javax.annotation.Nullable;
+
+import java.time.Duration;
+import java.util.HashSet;
+import java.util.List;
+import java.util.Map;
+import java.util.Optional;
+import java.util.Properties;
+import java.util.Set;
+import java.util.regex.Pattern;
+
+import static org.apache.flink.connector.kafka.table.options.KafkaConnectorOptions.KEY_FIELDS;
+import static org.apache.flink.connector.kafka.table.options.KafkaConnectorOptions.KEY_FIELDS_PREFIX;
+import static org.apache.flink.connector.kafka.table.options.KafkaConnectorOptions.KEY_FORMAT;
+import static org.apache.flink.connector.kafka.table.options.KafkaConnectorOptions.PROPS_BOOTSTRAP_SERVERS;
+import static org.apache.flink.connector.kafka.table.options.KafkaConnectorOptions.PROPS_GROUP_ID;
+import static org.apache.flink.connector.kafka.table.options.KafkaConnectorOptions.SCAN_STARTUP_MODE;
+import static org.apache.flink.connector.kafka.table.options.KafkaConnectorOptions.SCAN_STARTUP_SPECIFIC_OFFSETS;
+import static org.apache.flink.connector.kafka.table.options.KafkaConnectorOptions.SCAN_STARTUP_TIMESTAMP_MILLIS;
+import static org.apache.flink.connector.kafka.table.options.KafkaConnectorOptions.SCAN_TOPIC_PARTITION_DISCOVERY;
+import static org.apache.flink.connector.kafka.table.options.KafkaConnectorOptions.SINK_PARALLELISM;
+import static org.apache.flink.connector.kafka.table.options.KafkaConnectorOptions.SINK_PARTITIONER;
+import static org.apache.flink.connector.kafka.table.options.KafkaConnectorOptions.SINK_SEMANTIC;
+import static org.apache.flink.connector.kafka.table.options.KafkaConnectorOptions.TOPIC;
+import static org.apache.flink.connector.kafka.table.options.KafkaConnectorOptions.TOPIC_PATTERN;
+import static org.apache.flink.connector.kafka.table.options.KafkaConnectorOptions.VALUE_FIELDS_INCLUDE;
+import static org.apache.flink.connector.kafka.table.options.KafkaConnectorOptions.VALUE_FORMAT;
+import static org.apache.flink.connector.kafka.table.options.KafkaConnectorOptionsUtil.PROPERTIES_PREFIX;
+import static org.apache.flink.connector.kafka.table.options.KafkaConnectorOptionsUtil.StartupOptions;
+import static org.apache.flink.connector.kafka.table.options.KafkaConnectorOptionsUtil.autoCompleteSchemaRegistrySubject;
+import static org.apache.flink.connector.kafka.table.options.KafkaConnectorOptionsUtil.createKeyFormatProjection;
+import static org.apache.flink.connector.kafka.table.options.KafkaConnectorOptionsUtil.createValueFormatProjection;
+import static org.apache.flink.connector.kafka.table.options.KafkaConnectorOptionsUtil.getFlinkKafkaPartitioner;
+import static org.apache.flink.connector.kafka.table.options.KafkaConnectorOptionsUtil.getKafkaProperties;
+import static org.apache.flink.connector.kafka.table.options.KafkaConnectorOptionsUtil.getSourceTopicPattern;
+import static org.apache.flink.connector.kafka.table.options.KafkaConnectorOptionsUtil.getSourceTopics;
+import static org.apache.flink.connector.kafka.table.options.KafkaConnectorOptionsUtil.getStartupOptions;
+import static org.apache.flink.connector.kafka.table.options.KafkaConnectorOptionsUtil.validateLegacyTableSourceOptions;
+import static org.apache.flink.connector.kafka.table.options.KafkaConnectorOptionsUtil.validatePKConstraints;
+import static org.apache.flink.connector.kafka.table.options.KafkaConnectorOptionsUtil.validateTableSinkOptions;
+
+/**
+ * Factory for creating configured instances of {@link KafkaDynamicTableSource} and {@link
+ * KafkaDynamicSink}.
+ */
+@Internal
+public class KafkaLegacyDynamicTableFactory
+        implements DynamicTableSourceFactory, DynamicTableSinkFactory {
+
+    public static final String IDENTIFIER = "kafka-legacy";
+
+    @Override
+    public String factoryIdentifier() {
+        return IDENTIFIER;
+    }
+
+    @Override
+    public Set<ConfigOption<?>> requiredOptions() {
+        final Set<ConfigOption<?>> options = new HashSet<>();
+        options.add(PROPS_BOOTSTRAP_SERVERS);
+        return options;
+    }
+
+    @Override
+    public Set<ConfigOption<?>> optionalOptions() {
+        final Set<ConfigOption<?>> options = new HashSet<>();
+        options.add(FactoryUtil.FORMAT);
+        options.add(KEY_FORMAT);
+        options.add(KEY_FIELDS);
+        options.add(KEY_FIELDS_PREFIX);
+        options.add(VALUE_FORMAT);
+        options.add(VALUE_FIELDS_INCLUDE);
+        options.add(TOPIC);
+        options.add(TOPIC_PATTERN);
+        options.add(PROPS_GROUP_ID);
+        options.add(SCAN_STARTUP_MODE);
+        options.add(SCAN_STARTUP_SPECIFIC_OFFSETS);
+        options.add(SCAN_TOPIC_PARTITION_DISCOVERY);
+        options.add(SCAN_STARTUP_TIMESTAMP_MILLIS);
+        options.add(SINK_PARTITIONER);
+        options.add(SINK_SEMANTIC);
+        options.add(SINK_PARALLELISM);
+        return options;
+    }
+
+    @Override
+    public DynamicTableSource createDynamicTableSource(Context context) {
+        final TableFactoryHelper helper = FactoryUtil.createTableFactoryHelper(this, context);
+
+        final ReadableConfig tableOptions = helper.getOptions();
+
+        final Optional<DecodingFormat<DeserializationSchema<RowData>>> keyDecodingFormat =
+                getKeyDecodingFormat(helper);
+
+        final DecodingFormat<DeserializationSchema<RowData>> valueDecodingFormat =
+                getValueDecodingFormat(helper);
+
+        helper.validateExcept(PROPERTIES_PREFIX);
+
+        validateLegacyTableSourceOptions(tableOptions);
+
+        validatePKConstraints(
+                context.getObjectIdentifier(), context.getCatalogTable(), valueDecodingFormat);
+
+        final StartupOptions startupOptions = getStartupOptions(tableOptions);
+
+        final Properties properties = getKafkaProperties(context.getCatalogTable().getOptions());
+
+        // add topic-partition discovery
+        properties.setProperty(
+                FlinkKafkaConsumerBase.KEY_PARTITION_DISCOVERY_INTERVAL_MILLIS,
+                String.valueOf(
+                        tableOptions
+                                .getOptional(SCAN_TOPIC_PARTITION_DISCOVERY)
+                                .map(Duration::toMillis)
+                                .orElse(FlinkKafkaConsumerBase.PARTITION_DISCOVERY_DISABLED)));
+
+        final DataType physicalDataType =
+                context.getCatalogTable().getSchema().toPhysicalRowDataType();
+
+        final int[] keyProjection = createKeyFormatProjection(tableOptions, physicalDataType);
+
+        final int[] valueProjection = createValueFormatProjection(tableOptions, physicalDataType);
+
+        final String keyPrefix = tableOptions.getOptional(KEY_FIELDS_PREFIX).orElse(null);
+
+        return createKafkaTableSource(
+                physicalDataType,
+                keyDecodingFormat.orElse(null),
+                valueDecodingFormat,
+                keyProjection,
+                valueProjection,
+                keyPrefix,
+                getSourceTopics(tableOptions),
+                getSourceTopicPattern(tableOptions),
+                properties,
+                startupOptions.startupMode,
+                startupOptions.specificOffsets,
+                startupOptions.startupTimestampMillis);
+    }
+
+    @Override
+    public DynamicTableSink createDynamicTableSink(Context context) {
+        final TableFactoryHelper helper =
+                FactoryUtil.createTableFactoryHelper(
+                        this, autoCompleteSchemaRegistrySubject(context));
+
+        final ReadableConfig tableOptions = helper.getOptions();
+
+        final Optional<EncodingFormat<SerializationSchema<RowData>>> keyEncodingFormat =
+                getKeyEncodingFormat(helper);
+
+        final EncodingFormat<SerializationSchema<RowData>> valueEncodingFormat =
+                getValueEncodingFormat(helper);
+
+        helper.validateExcept(PROPERTIES_PREFIX);
+
+        validateTableSinkOptions(tableOptions);
+
+        validatePKConstraints(
+                context.getObjectIdentifier(), context.getCatalogTable(), valueEncodingFormat);
+
+        final DataType physicalDataType =
+                context.getCatalogTable().getSchema().toPhysicalRowDataType();
+
+        final int[] keyProjection = createKeyFormatProjection(tableOptions, physicalDataType);
+
+        final int[] valueProjection = createValueFormatProjection(tableOptions, physicalDataType);
+
+        final String keyPrefix = tableOptions.getOptional(KEY_FIELDS_PREFIX).orElse(null);
+
+        final Integer parallelism = tableOptions.getOptional(SINK_PARALLELISM).orElse(null);
+
+        return createKafkaTableSink(
+                physicalDataType,
+                keyEncodingFormat.orElse(null),
+                valueEncodingFormat,
+                keyProjection,
+                valueProjection,
+                keyPrefix,
+                tableOptions.get(TOPIC).get(0),
+                getKafkaProperties(context.getCatalogTable().getOptions()),
+                getFlinkKafkaPartitioner(tableOptions, context.getClassLoader()).orElse(null),
+                tableOptions.get(SINK_SEMANTIC),
+                parallelism);
+    }
+
+    // --------------------------------------------------------------------------------------------
+
+    private static Optional<DecodingFormat<DeserializationSchema<RowData>>> getKeyDecodingFormat(
+            TableFactoryHelper helper) {
+        final Optional<DecodingFormat<DeserializationSchema<RowData>>> keyDecodingFormat =
+                helper.discoverOptionalDecodingFormat(
+                        DeserializationFormatFactory.class, KEY_FORMAT);
+        keyDecodingFormat.ifPresent(
+                format -> {
+                    if (!format.getChangelogMode().containsOnly(RowKind.INSERT)) {
+                        throw new ValidationException(
+                                String.format(
+                                        "A key format should only deal with INSERT-only records. "
+                                                + "But %s has a changelog mode of %s.",
+                                        helper.getOptions().get(KEY_FORMAT),
+                                        format.getChangelogMode()));
+                    }
+                });
+        return keyDecodingFormat;
+    }
+
+    private static Optional<EncodingFormat<SerializationSchema<RowData>>> getKeyEncodingFormat(
+            TableFactoryHelper helper) {
+        final Optional<EncodingFormat<SerializationSchema<RowData>>> keyEncodingFormat =
+                helper.discoverOptionalEncodingFormat(SerializationFormatFactory.class, KEY_FORMAT);
+        keyEncodingFormat.ifPresent(
+                format -> {
+                    if (!format.getChangelogMode().containsOnly(RowKind.INSERT)) {
+                        throw new ValidationException(
+                                String.format(
+                                        "A key format should only deal with INSERT-only records. "
+                                                + "But %s has a changelog mode of %s.",
+                                        helper.getOptions().get(KEY_FORMAT),
+                                        format.getChangelogMode()));
+                    }
+                });
+        return keyEncodingFormat;
+    }
+
+    private static DecodingFormat<DeserializationSchema<RowData>> getValueDecodingFormat(
+            TableFactoryHelper helper) {
+        return helper.discoverOptionalDecodingFormat(
+                        DeserializationFormatFactory.class, FactoryUtil.FORMAT)
+                .orElseGet(
+                        () ->
+                                helper.discoverDecodingFormat(
+                                        DeserializationFormatFactory.class, VALUE_FORMAT));
+    }
+
+    private static EncodingFormat<SerializationSchema<RowData>> getValueEncodingFormat(
+            TableFactoryHelper helper) {
+        return helper.discoverOptionalEncodingFormat(
+                        SerializationFormatFactory.class, FactoryUtil.FORMAT)
+                .orElseGet(
+                        () ->
+                                helper.discoverEncodingFormat(
+                                        SerializationFormatFactory.class, VALUE_FORMAT));
+    }
+
+    // --------------------------------------------------------------------------------------------
+
+    protected KafkaLegacyDynamicSource createKafkaTableSource(
+            DataType physicalDataType,
+            @Nullable DecodingFormat<DeserializationSchema<RowData>> keyDecodingFormat,
+            DecodingFormat<DeserializationSchema<RowData>> valueDecodingFormat,
+            int[] keyProjection,
+            int[] valueProjection,
+            @Nullable String keyPrefix,
+            @Nullable List<String> topics,
+            @Nullable Pattern topicPattern,
+            Properties properties,
+            StartupMode startupMode,
+            Map<KafkaTopicPartition, Long> specificStartupOffsets,
+            long startupTimestampMillis) {
+        return new KafkaLegacyDynamicSource(
+                physicalDataType,
+                keyDecodingFormat,
+                valueDecodingFormat,
+                keyProjection,
+                valueProjection,
+                keyPrefix,
+                topics,
+                topicPattern,
+                properties,
+                startupMode,
+                specificStartupOffsets,
+                startupTimestampMillis,
+                false);
+    }
+
+    protected KafkaDynamicSink createKafkaTableSink(
+            DataType physicalDataType,
+            @Nullable EncodingFormat<SerializationSchema<RowData>> keyEncodingFormat,
+            EncodingFormat<SerializationSchema<RowData>> valueEncodingFormat,
+            int[] keyProjection,
+            int[] valueProjection,
+            @Nullable String keyPrefix,
+            String topic,
+            Properties properties,
+            FlinkKafkaPartitioner<RowData> partitioner,
+            SinkSemantic semantic,
+            Integer parallelism) {
+        return new KafkaDynamicSink(
+                physicalDataType,
+                physicalDataType,
+                keyEncodingFormat,
+                valueEncodingFormat,
+                keyProjection,
+                valueProjection,
+                keyPrefix,
+                topic,
+                properties,
+                partitioner,
+                semantic,
+                false,
+                SinkBufferFlushMode.DISABLED,
+                parallelism);
+    }
+}

--- a/flink-connectors/flink-connector-kafka/src/main/java/org/apache/flink/streaming/connectors/kafka/table/UpsertKafkaLegacyDynamicTableFactory.java
+++ b/flink-connectors/flink-connector-kafka/src/main/java/org/apache/flink/streaming/connectors/kafka/table/UpsertKafkaLegacyDynamicTableFactory.java
@@ -1,0 +1,389 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.flink.streaming.connectors.kafka.table;
+
+import org.apache.flink.api.common.serialization.DeserializationSchema;
+import org.apache.flink.api.common.serialization.SerializationSchema;
+import org.apache.flink.api.java.tuple.Tuple2;
+import org.apache.flink.configuration.ConfigOption;
+import org.apache.flink.configuration.Configuration;
+import org.apache.flink.configuration.ReadableConfig;
+import org.apache.flink.connector.kafka.table.options.KafkaConnectorOptions.SinkSemantic;
+import org.apache.flink.connector.kafka.table.sink.KafkaDynamicSink;
+import org.apache.flink.connector.kafka.table.utils.SinkBufferFlushMode;
+import org.apache.flink.streaming.connectors.kafka.config.StartupMode;
+import org.apache.flink.table.api.TableSchema;
+import org.apache.flink.table.api.ValidationException;
+import org.apache.flink.table.catalog.CatalogTable;
+import org.apache.flink.table.connector.ChangelogMode;
+import org.apache.flink.table.connector.format.DecodingFormat;
+import org.apache.flink.table.connector.format.EncodingFormat;
+import org.apache.flink.table.connector.format.Format;
+import org.apache.flink.table.connector.sink.DynamicTableSink;
+import org.apache.flink.table.connector.source.DynamicTableSource;
+import org.apache.flink.table.data.RowData;
+import org.apache.flink.table.factories.DeserializationFormatFactory;
+import org.apache.flink.table.factories.DynamicTableSinkFactory;
+import org.apache.flink.table.factories.DynamicTableSourceFactory;
+import org.apache.flink.table.factories.FactoryUtil;
+import org.apache.flink.table.factories.SerializationFormatFactory;
+import org.apache.flink.table.types.DataType;
+import org.apache.flink.types.RowKind;
+
+import java.time.Duration;
+import java.util.Collections;
+import java.util.HashSet;
+import java.util.List;
+import java.util.Objects;
+import java.util.Properties;
+import java.util.Set;
+
+import static org.apache.flink.connector.kafka.table.options.KafkaConnectorOptions.KEY_FIELDS;
+import static org.apache.flink.connector.kafka.table.options.KafkaConnectorOptions.KEY_FIELDS_PREFIX;
+import static org.apache.flink.connector.kafka.table.options.KafkaConnectorOptions.KEY_FORMAT;
+import static org.apache.flink.connector.kafka.table.options.KafkaConnectorOptions.PROPS_BOOTSTRAP_SERVERS;
+import static org.apache.flink.connector.kafka.table.options.KafkaConnectorOptions.SINK_BUFFER_FLUSH_INTERVAL;
+import static org.apache.flink.connector.kafka.table.options.KafkaConnectorOptions.SINK_BUFFER_FLUSH_MAX_ROWS;
+import static org.apache.flink.connector.kafka.table.options.KafkaConnectorOptions.SINK_PARALLELISM;
+import static org.apache.flink.connector.kafka.table.options.KafkaConnectorOptions.TOPIC;
+import static org.apache.flink.connector.kafka.table.options.KafkaConnectorOptions.VALUE_FIELDS_INCLUDE;
+import static org.apache.flink.connector.kafka.table.options.KafkaConnectorOptions.VALUE_FORMAT;
+import static org.apache.flink.connector.kafka.table.options.KafkaConnectorOptionsUtil.PROPERTIES_PREFIX;
+import static org.apache.flink.connector.kafka.table.options.KafkaConnectorOptionsUtil.autoCompleteSchemaRegistrySubject;
+import static org.apache.flink.connector.kafka.table.options.KafkaConnectorOptionsUtil.createKeyFormatProjection;
+import static org.apache.flink.connector.kafka.table.options.KafkaConnectorOptionsUtil.createValueFormatProjection;
+import static org.apache.flink.connector.kafka.table.options.KafkaConnectorOptionsUtil.getKafkaProperties;
+import static org.apache.flink.connector.kafka.table.options.KafkaConnectorOptionsUtil.getSourceTopicPattern;
+import static org.apache.flink.connector.kafka.table.options.KafkaConnectorOptionsUtil.getSourceTopics;
+
+/** Upsert-Kafka factory. */
+public class UpsertKafkaLegacyDynamicTableFactory
+        implements DynamicTableSourceFactory, DynamicTableSinkFactory {
+
+    public static final String IDENTIFIER = "upsert-kafka-legacy";
+
+    @Override
+    public String factoryIdentifier() {
+        return IDENTIFIER;
+    }
+
+    @Override
+    public Set<ConfigOption<?>> requiredOptions() {
+        final Set<ConfigOption<?>> options = new HashSet<>();
+        options.add(PROPS_BOOTSTRAP_SERVERS);
+        options.add(TOPIC);
+        options.add(KEY_FORMAT);
+        options.add(VALUE_FORMAT);
+        return options;
+    }
+
+    @Override
+    public Set<ConfigOption<?>> optionalOptions() {
+        final Set<ConfigOption<?>> options = new HashSet<>();
+        options.add(KEY_FIELDS_PREFIX);
+        options.add(VALUE_FIELDS_INCLUDE);
+        options.add(SINK_PARALLELISM);
+        options.add(SINK_BUFFER_FLUSH_INTERVAL);
+        options.add(SINK_BUFFER_FLUSH_MAX_ROWS);
+        return options;
+    }
+
+    @Override
+    public DynamicTableSource createDynamicTableSource(Context context) {
+        FactoryUtil.TableFactoryHelper helper = FactoryUtil.createTableFactoryHelper(this, context);
+
+        ReadableConfig tableOptions = helper.getOptions();
+        DecodingFormat<DeserializationSchema<RowData>> keyDecodingFormat =
+                helper.discoverDecodingFormat(DeserializationFormatFactory.class, KEY_FORMAT);
+        DecodingFormat<DeserializationSchema<RowData>> valueDecodingFormat =
+                helper.discoverDecodingFormat(DeserializationFormatFactory.class, VALUE_FORMAT);
+
+        // Validate the option data type.
+        helper.validateExcept(PROPERTIES_PREFIX);
+        TableSchema schema = context.getCatalogTable().getSchema();
+        validateSource(tableOptions, keyDecodingFormat, valueDecodingFormat, schema);
+
+        Tuple2<int[], int[]> keyValueProjections =
+                createKeyValueProjections(context.getCatalogTable());
+        String keyPrefix = tableOptions.getOptional(KEY_FIELDS_PREFIX).orElse(null);
+        Properties properties = getKafkaProperties(context.getCatalogTable().getOptions());
+        // always use earliest to keep data integrity
+        StartupMode earliest = StartupMode.EARLIEST;
+
+        return new KafkaLegacyDynamicSource(
+                schema.toPhysicalRowDataType(),
+                keyDecodingFormat,
+                new DecodingFormatWrapper(valueDecodingFormat),
+                keyValueProjections.f0,
+                keyValueProjections.f1,
+                keyPrefix,
+                getSourceTopics(tableOptions),
+                getSourceTopicPattern(tableOptions),
+                properties,
+                earliest,
+                Collections.emptyMap(),
+                0,
+                true);
+    }
+
+    @Override
+    public DynamicTableSink createDynamicTableSink(Context context) {
+        FactoryUtil.TableFactoryHelper helper =
+                FactoryUtil.createTableFactoryHelper(
+                        this, autoCompleteSchemaRegistrySubject(context));
+
+        final ReadableConfig tableOptions = helper.getOptions();
+
+        EncodingFormat<SerializationSchema<RowData>> keyEncodingFormat =
+                helper.discoverEncodingFormat(SerializationFormatFactory.class, KEY_FORMAT);
+        EncodingFormat<SerializationSchema<RowData>> valueEncodingFormat =
+                helper.discoverEncodingFormat(SerializationFormatFactory.class, VALUE_FORMAT);
+
+        // Validate the option data type.
+        helper.validateExcept(PROPERTIES_PREFIX);
+        TableSchema schema = context.getCatalogTable().getSchema();
+        validateSink(tableOptions, keyEncodingFormat, valueEncodingFormat, schema);
+
+        Tuple2<int[], int[]> keyValueProjections =
+                createKeyValueProjections(context.getCatalogTable());
+        final String keyPrefix = tableOptions.getOptional(KEY_FIELDS_PREFIX).orElse(null);
+        final Properties properties = getKafkaProperties(context.getCatalogTable().getOptions());
+
+        Integer parallelism = tableOptions.get(SINK_PARALLELISM);
+
+        int batchSize = tableOptions.get(SINK_BUFFER_FLUSH_MAX_ROWS);
+        Duration batchInterval = tableOptions.get(SINK_BUFFER_FLUSH_INTERVAL);
+        SinkBufferFlushMode flushMode =
+                new SinkBufferFlushMode(batchSize, batchInterval.toMillis());
+
+        // use {@link org.apache.kafka.clients.producer.internals.DefaultPartitioner}.
+        // it will use hash partition if key is set else in round-robin behaviour.
+        return new KafkaDynamicSink(
+                schema.toPhysicalRowDataType(),
+                schema.toPhysicalRowDataType(),
+                keyEncodingFormat,
+                new EncodingFormatWrapper(valueEncodingFormat),
+                keyValueProjections.f0,
+                keyValueProjections.f1,
+                keyPrefix,
+                tableOptions.get(TOPIC).get(0),
+                properties,
+                null,
+                SinkSemantic.AT_LEAST_ONCE,
+                true,
+                flushMode,
+                parallelism);
+    }
+
+    private Tuple2<int[], int[]> createKeyValueProjections(CatalogTable catalogTable) {
+        TableSchema schema = catalogTable.getSchema();
+        // primary key should validated earlier
+        List<String> keyFields = schema.getPrimaryKey().get().getColumns();
+        DataType physicalDataType = schema.toPhysicalRowDataType();
+
+        Configuration tableOptions = Configuration.fromMap(catalogTable.getOptions());
+        // upsert-kafka will set key.fields to primary key fields by default
+        tableOptions.set(KEY_FIELDS, keyFields);
+
+        int[] keyProjection = createKeyFormatProjection(tableOptions, physicalDataType);
+        int[] valueProjection = createValueFormatProjection(tableOptions, physicalDataType);
+
+        return Tuple2.of(keyProjection, valueProjection);
+    }
+
+    // --------------------------------------------------------------------------------------------
+    // Validation
+    // --------------------------------------------------------------------------------------------
+
+    private static void validateSource(
+            ReadableConfig tableOptions, Format keyFormat, Format valueFormat, TableSchema schema) {
+        validateTopic(tableOptions);
+        validateFormat(keyFormat, valueFormat, tableOptions);
+        validatePKConstraints(schema);
+    }
+
+    private static void validateSink(
+            ReadableConfig tableOptions, Format keyFormat, Format valueFormat, TableSchema schema) {
+        validateTopic(tableOptions);
+        validateFormat(keyFormat, valueFormat, tableOptions);
+        validatePKConstraints(schema);
+        validateSinkBufferFlush(tableOptions);
+    }
+
+    private static void validateTopic(ReadableConfig tableOptions) {
+        List<String> topic = tableOptions.get(TOPIC);
+        if (topic.size() > 1) {
+            throw new ValidationException(
+                    "The 'upsert-kafka' connector doesn't support topic list now. "
+                            + "Please use single topic as the value of the parameter 'topic'.");
+        }
+    }
+
+    private static void validateFormat(
+            Format keyFormat, Format valueFormat, ReadableConfig tableOptions) {
+        if (!keyFormat.getChangelogMode().containsOnly(RowKind.INSERT)) {
+            String identifier = tableOptions.get(KEY_FORMAT);
+            throw new ValidationException(
+                    String.format(
+                            "'upsert-kafka' connector doesn't support '%s' as key format, "
+                                    + "because '%s' is not in insert-only mode.",
+                            identifier, identifier));
+        }
+        if (!valueFormat.getChangelogMode().containsOnly(RowKind.INSERT)) {
+            String identifier = tableOptions.get(VALUE_FORMAT);
+            throw new ValidationException(
+                    String.format(
+                            "'upsert-kafka' connector doesn't support '%s' as value format, "
+                                    + "because '%s' is not in insert-only mode.",
+                            identifier, identifier));
+        }
+    }
+
+    private static void validatePKConstraints(TableSchema schema) {
+        if (!schema.getPrimaryKey().isPresent()) {
+            throw new ValidationException(
+                    "'upsert-kafka' tables require to define a PRIMARY KEY constraint. "
+                            + "The PRIMARY KEY specifies which columns should be read from or write to the Kafka message key. "
+                            + "The PRIMARY KEY also defines records in the 'upsert-kafka' table should update or delete on which keys.");
+        }
+    }
+
+    private static void validateSinkBufferFlush(ReadableConfig tableOptions) {
+        int flushMaxRows = tableOptions.get(SINK_BUFFER_FLUSH_MAX_ROWS);
+        long flushIntervalMs = tableOptions.get(SINK_BUFFER_FLUSH_INTERVAL).toMillis();
+        if (flushMaxRows > 0 && flushIntervalMs > 0) {
+            // flush is enabled
+            return;
+        }
+        if (flushMaxRows <= 0 && flushIntervalMs <= 0) {
+            // flush is disabled
+            return;
+        }
+        // one of them is set which is not allowed
+        throw new ValidationException(
+                String.format(
+                        "'%s' and '%s' must be set to be greater than zero together to enable sink buffer flushing.",
+                        SINK_BUFFER_FLUSH_MAX_ROWS.key(), SINK_BUFFER_FLUSH_INTERVAL.key()));
+    }
+
+    // --------------------------------------------------------------------------------------------
+    // Format wrapper
+    // --------------------------------------------------------------------------------------------
+
+    /**
+     * It is used to wrap the decoding format and expose the desired changelog mode. It's only works
+     * for insert-only format.
+     */
+    public static class DecodingFormatWrapper
+            implements DecodingFormat<DeserializationSchema<RowData>> {
+        private final DecodingFormat<DeserializationSchema<RowData>> innerDecodingFormat;
+
+        private static final ChangelogMode SOURCE_CHANGELOG_MODE =
+                ChangelogMode.newBuilder()
+                        .addContainedKind(RowKind.UPDATE_AFTER)
+                        .addContainedKind(RowKind.DELETE)
+                        .build();
+
+        public DecodingFormatWrapper(
+                DecodingFormat<DeserializationSchema<RowData>> innerDecodingFormat) {
+            this.innerDecodingFormat = innerDecodingFormat;
+        }
+
+        @Override
+        public DeserializationSchema<RowData> createRuntimeDecoder(
+                DynamicTableSource.Context context, DataType producedDataType) {
+            return innerDecodingFormat.createRuntimeDecoder(context, producedDataType);
+        }
+
+        @Override
+        public ChangelogMode getChangelogMode() {
+            return SOURCE_CHANGELOG_MODE;
+        }
+
+        @Override
+        public boolean equals(Object obj) {
+            if (obj == this) {
+                return true;
+            }
+
+            if (obj == null || getClass() != obj.getClass()) {
+                return false;
+            }
+
+            DecodingFormatWrapper that = (DecodingFormatWrapper) obj;
+            return Objects.equals(innerDecodingFormat, that.innerDecodingFormat);
+        }
+
+        @Override
+        public int hashCode() {
+            return Objects.hash(innerDecodingFormat);
+        }
+    }
+
+    /**
+     * It is used to wrap the encoding format and expose the desired changelog mode. It's only works
+     * for insert-only format.
+     */
+    protected static class EncodingFormatWrapper
+            implements EncodingFormat<SerializationSchema<RowData>> {
+        private final EncodingFormat<SerializationSchema<RowData>> innerEncodingFormat;
+
+        public static final ChangelogMode SINK_CHANGELOG_MODE =
+                ChangelogMode.newBuilder()
+                        .addContainedKind(RowKind.INSERT)
+                        .addContainedKind(RowKind.UPDATE_AFTER)
+                        .addContainedKind(RowKind.DELETE)
+                        .build();
+
+        public EncodingFormatWrapper(
+                EncodingFormat<SerializationSchema<RowData>> innerEncodingFormat) {
+            this.innerEncodingFormat = innerEncodingFormat;
+        }
+
+        @Override
+        public SerializationSchema<RowData> createRuntimeEncoder(
+                DynamicTableSink.Context context, DataType consumedDataType) {
+            return innerEncodingFormat.createRuntimeEncoder(context, consumedDataType);
+        }
+
+        @Override
+        public ChangelogMode getChangelogMode() {
+            return SINK_CHANGELOG_MODE;
+        }
+
+        @Override
+        public boolean equals(Object obj) {
+            if (obj == this) {
+                return true;
+            }
+
+            if (obj == null || getClass() != obj.getClass()) {
+                return false;
+            }
+
+            EncodingFormatWrapper that = (EncodingFormatWrapper) obj;
+            return Objects.equals(innerEncodingFormat, that.innerEncodingFormat);
+        }
+
+        @Override
+        public int hashCode() {
+            return Objects.hash(innerEncodingFormat);
+        }
+    }
+}

--- a/flink-connectors/flink-connector-kafka/src/main/resources/META-INF/services/org.apache.flink.table.factories.Factory
+++ b/flink-connectors/flink-connector-kafka/src/main/resources/META-INF/services/org.apache.flink.table.factories.Factory
@@ -13,5 +13,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-org.apache.flink.streaming.connectors.kafka.table.KafkaDynamicTableFactory
-org.apache.flink.streaming.connectors.kafka.table.UpsertKafkaDynamicTableFactory
+org.apache.flink.connector.kafka.table.factories.KafkaDynamicTableFactory
+org.apache.flink.streaming.connectors.kafka.table.KafkaLegacyDynamicTableFactory
+org.apache.flink.connector.kafka.table.factories.UpsertKafkaDynamicTableFactory
+org.apache.flink.streaming.connectors.kafka.table.UpsertKafkaLegacyDynamicTableFactory

--- a/flink-connectors/flink-connector-kafka/src/test/java/org/apache/flink/connector/kafka/table/KafkaTableTestBase.java
+++ b/flink-connectors/flink-connector-kafka/src/test/java/org/apache/flink/connector/kafka/table/KafkaTableTestBase.java
@@ -16,7 +16,7 @@
  * limitations under the License.
  */
 
-package org.apache.flink.streaming.connectors.kafka.table;
+package org.apache.flink.connector.kafka.table;
 
 import org.apache.flink.api.common.restartstrategy.RestartStrategies;
 import org.apache.flink.streaming.api.environment.StreamExecutionEnvironment;
@@ -44,6 +44,10 @@ public abstract class KafkaTableTestBase extends AbstractTestBase {
     private static final String INTER_CONTAINER_KAFKA_ALIAS = "kafka";
     private static final Network NETWORK = Network.newNetwork();
     private static final int zkTimeoutMills = 30000;
+
+    protected boolean isLegacySource() {
+        return false;
+    }
 
     @ClassRule
     public static final KafkaContainer KAFKA_CONTAINER =

--- a/flink-connectors/flink-connector-kafka/src/test/java/org/apache/flink/connector/kafka/table/KafkaTableTestUtils.java
+++ b/flink-connectors/flink-connector-kafka/src/test/java/org/apache/flink/connector/kafka/table/KafkaTableTestUtils.java
@@ -16,7 +16,7 @@
  * limitations under the License.
  */
 
-package org.apache.flink.streaming.connectors.kafka.table;
+package org.apache.flink.connector.kafka.table;
 
 import org.apache.flink.table.api.Table;
 import org.apache.flink.table.api.TableResult;

--- a/flink-connectors/flink-connector-kafka/src/test/java/org/apache/flink/connector/kafka/table/options/KafkaConnectorOptionsUtilTest.java
+++ b/flink-connectors/flink-connector-kafka/src/test/java/org/apache/flink/connector/kafka/table/options/KafkaConnectorOptionsUtilTest.java
@@ -16,7 +16,7 @@
  * limitations under the License.
  */
 
-package org.apache.flink.streaming.connectors.kafka.table;
+package org.apache.flink.connector.kafka.table.options;
 
 import org.apache.flink.configuration.Configuration;
 import org.apache.flink.table.api.DataTypes;
@@ -30,8 +30,8 @@ import org.junit.Test;
 import java.util.HashMap;
 import java.util.Map;
 
-import static org.apache.flink.streaming.connectors.kafka.table.KafkaConnectorOptionsUtil.createKeyFormatProjection;
-import static org.apache.flink.streaming.connectors.kafka.table.KafkaConnectorOptionsUtil.createValueFormatProjection;
+import static org.apache.flink.connector.kafka.table.options.KafkaConnectorOptionsUtil.createKeyFormatProjection;
+import static org.apache.flink.connector.kafka.table.options.KafkaConnectorOptionsUtil.createValueFormatProjection;
 import static org.hamcrest.CoreMatchers.equalTo;
 import static org.junit.Assert.assertArrayEquals;
 import static org.junit.Assert.assertThat;

--- a/flink-connectors/flink-connector-kafka/src/test/java/org/apache/flink/connector/kafka/table/utils/BufferedUpsertSinkFunctionTest.java
+++ b/flink-connectors/flink-connector-kafka/src/test/java/org/apache/flink/connector/kafka/table/utils/BufferedUpsertSinkFunctionTest.java
@@ -16,7 +16,7 @@
  * limitations under the License.
  */
 
-package org.apache.flink.streaming.connectors.kafka.table;
+package org.apache.flink.connector.kafka.table.utils;
 
 import org.apache.flink.api.common.functions.RuntimeContext;
 import org.apache.flink.api.common.state.CheckpointListener;

--- a/flink-connectors/flink-connector-kafka/src/test/java/org/apache/flink/streaming/connectors/kafka/table/KafkaLegacyChangelogTableITCase.java
+++ b/flink-connectors/flink-connector-kafka/src/test/java/org/apache/flink/streaming/connectors/kafka/table/KafkaLegacyChangelogTableITCase.java
@@ -1,0 +1,29 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.flink.streaming.connectors.kafka.table;
+
+import org.apache.flink.connector.kafka.table.KafkaChangelogTableITCase;
+
+/** Integration test for Kafka changelog table with legacy dynamic table source. */
+public class KafkaLegacyChangelogTableITCase extends KafkaChangelogTableITCase {
+    @Override
+    protected boolean isLegacySource() {
+        return true;
+    }
+}

--- a/flink-connectors/flink-connector-kafka/src/test/java/org/apache/flink/streaming/connectors/kafka/table/KafkaLegacyDynamicTableFactoryTest.java
+++ b/flink-connectors/flink-connector-kafka/src/test/java/org/apache/flink/streaming/connectors/kafka/table/KafkaLegacyDynamicTableFactoryTest.java
@@ -1,0 +1,29 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.flink.streaming.connectors.kafka.table;
+
+import org.apache.flink.connector.kafka.table.factories.KafkaDynamicTableFactoryTest;
+
+/** Test for {@link KafkaLegacyDynamicTableFactory}. */
+public class KafkaLegacyDynamicTableFactoryTest extends KafkaDynamicTableFactoryTest {
+    @Override
+    protected boolean isLegacySource() {
+        return true;
+    }
+}

--- a/flink-connectors/flink-connector-kafka/src/test/java/org/apache/flink/streaming/connectors/kafka/table/KafkaLegacyTableITCase.java
+++ b/flink-connectors/flink-connector-kafka/src/test/java/org/apache/flink/streaming/connectors/kafka/table/KafkaLegacyTableITCase.java
@@ -1,0 +1,29 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.flink.streaming.connectors.kafka.table;
+
+import org.apache.flink.connector.kafka.table.KafkaTableITCase;
+
+/** IT case for Kafka legacy table. */
+public class KafkaLegacyTableITCase extends KafkaTableITCase {
+    @Override
+    protected boolean isLegacySource() {
+        return true;
+    }
+}

--- a/flink-connectors/flink-connector-kafka/src/test/java/org/apache/flink/streaming/connectors/kafka/table/UpsertKafkaLegacyDynamicTableFactoryTest.java
+++ b/flink-connectors/flink-connector-kafka/src/test/java/org/apache/flink/streaming/connectors/kafka/table/UpsertKafkaLegacyDynamicTableFactoryTest.java
@@ -1,0 +1,29 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.flink.streaming.connectors.kafka.table;
+
+import org.apache.flink.connector.kafka.table.factories.UpsertKafkaDynamicTableFactoryTest;
+
+/** Test for {@link UpsertKafkaLegacyDynamicTableFactory}. */
+public class UpsertKafkaLegacyDynamicTableFactoryTest extends UpsertKafkaDynamicTableFactoryTest {
+    @Override
+    protected boolean isLegacySource() {
+        return true;
+    }
+}

--- a/flink-connectors/flink-connector-kafka/src/test/java/org/apache/flink/streaming/connectors/kafka/table/UpsertKafkaLegacyTableITCase.java
+++ b/flink-connectors/flink-connector-kafka/src/test/java/org/apache/flink/streaming/connectors/kafka/table/UpsertKafkaLegacyTableITCase.java
@@ -1,0 +1,29 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.flink.streaming.connectors.kafka.table;
+
+import org.apache.flink.connector.kafka.table.UpsertKafkaTableITCase;
+
+/** Integration test for legacy upsert-kafka table connector. */
+public class UpsertKafkaLegacyTableITCase extends UpsertKafkaTableITCase {
+    @Override
+    protected boolean isLegacySource() {
+        return true;
+    }
+}


### PR DESCRIPTION
## What is the purpose of the change

This pull request introduces FLIP-27 ```KafkaSource``` in the Kafka table connector, and migrate legacy table source using ```FlinkKafkaConsumer``` to another identifier "kafka-legacy"

## Brief change log
- Replace the runtime provider of ```KafkaDynamicTableSource``` to ```KafkaSource```
- Add new table option "scan.stop.mode" to support bounded mode in Kafka table source
- Move legacy table source using ```FlinkKafkaConsumer``` to identifier "kafka-legacy" and "upsert-kafka-legacy"

## Verifying this change
This change is already covered by existing tests for Kafka table source, also adds tests to cover the new bounded mode.


## Does this pull request potentially affect one of the following parts:

  - Dependencies (does it add or upgrade a dependency): (no)
  - The public API, i.e., is any changed class annotated with `@Public(Evolving)`: (no)
  - The serializers: (no)
  - The runtime per-record code paths (performance sensitive): (no)
  - Anything that affects deployment or recovery: JobManager (and its components), Checkpointing, Kubernetes/Yarn, ZooKeeper: (no)
  - The S3 file system connector: no)

## Documentation

  - Does this pull request introduce a new feature? (yes)
  - If yes, how is the feature documented? (docs)
