### PR TITLE
[FLINK-14482][rocksdb] Bump FRocksDB version to 6.20.3

### DIFF
--- a/docs/layouts/shortcodes/generated/rocksdb_configurable_configuration.html
+++ b/docs/layouts/shortcodes/generated/rocksdb_configurable_configuration.html
@@ -48,7 +48,7 @@
             <td><h5>state.backend.rocksdb.compaction.style</h5></td>
             <td style="word-wrap: break-word;">(none)</td>
             <td><p>Enum</p></td>
-            <td>The specified compaction style for DB. Candidate compaction style is LEVEL, FIFO or UNIVERSAL, and RocksDB choose 'LEVEL' as default style.<br /><br />Possible values:<ul><li>"LEVEL"</li><li>"UNIVERSAL"</li><li>"FIFO"</li></ul></td>
+            <td>The specified compaction style for DB. Candidate compaction style is LEVEL, FIFO, UNIVERSAL or NONE, and RocksDB choose 'LEVEL' as default style.<br /><br />Possible values:<ul><li>"LEVEL"</li><li>"UNIVERSAL"</li><li>"FIFO"</li><li>"NONE"</li></ul></td>
         </tr>
         <tr>
             <td><h5>state.backend.rocksdb.files.open</h5></td>

--- a/flink-dist/src/main/resources/META-INF/NOTICE
+++ b/flink-dist/src/main/resources/META-INF/NOTICE
@@ -6,7 +6,7 @@ The Apache Software Foundation (http://www.apache.org/).
 
 This project bundles the following dependencies under the Apache Software License 2.0 (http://www.apache.org/licenses/LICENSE-2.0.txt)
 
-- com.data-artisans:frocksdbjni:5.17.2-artisans-2.0
+- com.ververica:frocksdbjni:6.20.3-ververica-1.0
 - com.google.code.findbugs:jsr305:1.3.9
 - com.twitter:chill-java:0.7.6
 - com.twitter:chill_2.11:0.7.6

--- a/flink-state-backends/flink-statebackend-rocksdb/pom.xml
+++ b/flink-state-backends/flink-statebackend-rocksdb/pom.xml
@@ -57,7 +57,7 @@ under the License.
 		<dependency>
 			<groupId>com.ververica</groupId>
 			<artifactId>frocksdbjni</artifactId>
-			<version>5.17.2-ververica-2.1</version>
+			<version>6.20.3-ververica-1.0</version>
 		</dependency>
 
 		<!-- test dependencies -->

--- a/flink-state-backends/flink-statebackend-rocksdb/src/main/java/org/apache/flink/contrib/streaming/state/RocksDBConfigurableOptions.java
+++ b/flink-state-backends/flink-statebackend-rocksdb/src/main/java/org/apache/flink/contrib/streaming/state/RocksDBConfigurableOptions.java
@@ -31,6 +31,7 @@ import static org.apache.flink.configuration.ConfigOptions.key;
 import static org.apache.flink.configuration.description.LinkElement.link;
 import static org.rocksdb.CompactionStyle.FIFO;
 import static org.rocksdb.CompactionStyle.LEVEL;
+import static org.rocksdb.CompactionStyle.NONE;
 import static org.rocksdb.CompactionStyle.UNIVERSAL;
 import static org.rocksdb.InfoLogLevel.DEBUG_LEVEL;
 import static org.rocksdb.InfoLogLevel.ERROR_LEVEL;
@@ -102,9 +103,13 @@ public class RocksDBConfigurableOptions implements Serializable {
                     .noDefaultValue()
                     .withDescription(
                             String.format(
-                                    "The specified compaction style for DB. Candidate compaction style is %s, %s or %s, "
+                                    "The specified compaction style for DB. Candidate compaction style is %s, %s, %s or %s, "
                                             + "and RocksDB choose '%s' as default style.",
-                                    LEVEL.name(), FIFO.name(), UNIVERSAL.name(), LEVEL.name()));
+                                    LEVEL.name(),
+                                    FIFO.name(),
+                                    UNIVERSAL.name(),
+                                    NONE.name(),
+                                    LEVEL.name()));
 
     public static final ConfigOption<Boolean> USE_DYNAMIC_LEVEL_SIZE =
             key("state.backend.rocksdb.compaction.level.use-dynamic-size")

--- a/flink-state-backends/flink-statebackend-rocksdb/src/main/java/org/apache/flink/contrib/streaming/state/RocksDBResourceContainer.java
+++ b/flink-state-backends/flink-statebackend-rocksdb/src/main/java/org/apache/flink/contrib/streaming/state/RocksDBResourceContainer.java
@@ -250,7 +250,7 @@ public final class RocksDBResourceContainer implements AutoCloseable {
     @VisibleForTesting
     static Filter getFilterFromBlockBasedTableConfig(BlockBasedTableConfig blockBasedTableConfig)
             throws NoSuchFieldException, IllegalAccessException {
-        Field filterField = blockBasedTableConfig.getClass().getDeclaredField("filter_");
+        Field filterField = blockBasedTableConfig.getClass().getDeclaredField("filterPolicy");
         filterField.setAccessible(true);
         Object filter = filterField.get(blockBasedTableConfig);
         filterField.setAccessible(false);

--- a/flink-state-backends/flink-statebackend-rocksdb/src/main/java/org/apache/flink/contrib/streaming/state/RocksIteratorWrapper.java
+++ b/flink-state-backends/flink-statebackend-rocksdb/src/main/java/org/apache/flink/contrib/streaming/state/RocksIteratorWrapper.java
@@ -27,6 +27,7 @@ import org.rocksdb.RocksIteratorInterface;
 import javax.annotation.Nonnull;
 
 import java.io.Closeable;
+import java.nio.ByteBuffer;
 
 /**
  * This is a wrapper around {@link RocksIterator} to check the iterator status for all the methods
@@ -75,6 +76,18 @@ public class RocksIteratorWrapper implements RocksIteratorInterface, Closeable {
     }
 
     @Override
+    public void seek(ByteBuffer target) {
+        iterator.seek(target);
+        status();
+    }
+
+    @Override
+    public void seekForPrev(ByteBuffer target) {
+        iterator.seekForPrev(target);
+        status();
+    }
+
+    @Override
     public void next() {
         iterator.next();
         status();
@@ -93,6 +106,12 @@ public class RocksIteratorWrapper implements RocksIteratorInterface, Closeable {
         } catch (RocksDBException ex) {
             throw new FlinkRuntimeException("Internal exception found in RocksDB", ex);
         }
+    }
+
+    @Override
+    public void refresh() throws RocksDBException {
+        iterator.refresh();
+        status();
     }
 
     public byte[] key() {

--- a/flink-state-backends/flink-statebackend-rocksdb/src/test/java/org/apache/flink/contrib/streaming/state/RocksDBInitTest.java
+++ b/flink-state-backends/flink-statebackend-rocksdb/src/test/java/org/apache/flink/contrib/streaming/state/RocksDBInitTest.java
@@ -28,7 +28,7 @@ import org.junit.runner.RunWith;
 import org.powermock.api.mockito.PowerMockito;
 import org.powermock.core.classloader.annotations.PrepareForTest;
 import org.powermock.modules.junit4.PowerMockRunner;
-import org.rocksdb.RocksDB;
+import org.rocksdb.NativeLibraryLoader;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
@@ -39,7 +39,7 @@ import static org.junit.Assert.fail;
 
 /** Tests for {@link EmbeddedRocksDBStateBackend} on initialization. */
 @RunWith(PowerMockRunner.class)
-@PrepareForTest({RocksDB.class})
+@PrepareForTest({NativeLibraryLoader.class})
 public class RocksDBInitTest {
 
     private static final Logger LOG = LoggerFactory.getLogger(RocksDBInitTest.class);
@@ -57,8 +57,9 @@ public class RocksDBInitTest {
 
     @Test
     public void testTempLibFolderDeletedOnFail() throws Exception {
-        PowerMockito.spy(RocksDB.class);
-        PowerMockito.when(RocksDB.class, "loadLibrary").thenThrow(new ExpectedTestException());
+        PowerMockito.spy(NativeLibraryLoader.class);
+        PowerMockito.when(NativeLibraryLoader.class, "getInstance")
+                .thenThrow(new ExpectedTestException());
 
         File tempFolder = temporaryFolder.newFolder();
         try {

--- a/flink-state-backends/flink-statebackend-rocksdb/src/test/java/org/apache/flink/contrib/streaming/state/RocksDBResourceContainerTest.java
+++ b/flink-state-backends/flink-statebackend-rocksdb/src/test/java/org/apache/flink/contrib/streaming/state/RocksDBResourceContainerTest.java
@@ -173,15 +173,15 @@ public class RocksDBResourceContainerTest {
         }
         Field cacheField = null;
         try {
-            cacheField = BlockBasedTableConfig.class.getDeclaredField("blockCache_");
+            cacheField = BlockBasedTableConfig.class.getDeclaredField("blockCache");
         } catch (NoSuchFieldException e) {
-            fail("blockCache_ is not defined");
+            fail("blockCache is not defined");
         }
         cacheField.setAccessible(true);
         try {
             return (Cache) cacheField.get(blockBasedTableConfig);
         } catch (IllegalAccessException e) {
-            fail("Cannot access blockCache_ field.");
+            fail("Cannot access blockCache field.");
             return null;
         }
     }


### PR DESCRIPTION
## What is the purpose of the change

The purpose of this change is to bump the version of the FRocksDB state backend from `5.17.2-ververica-2.1` to `6.20.3-ververica-1.0`.

The tests will fail for now as the artifact is no longer on the staging repo, but has not been synced to maven yet. The tests ran against the staging repo here: https://dev.azure.com/apache-flink/apache-flink/_build/results?buildId=22046&view=results

## Brief change log

  - *FRocksDB state backend version has been bumped to 6.20.3-ververica-1.0*

## Verifying this change

This change is already covered by existing tests

## Does this pull request potentially affect one of the following parts:

  - Dependencies (does it add or upgrade a dependency): (yes)
  - The serializers: (don't know)
  - The runtime per-record code paths (performance sensitive): (don't know)
  - Anything that affects deployment or recovery: JobManager (and its components), Checkpointing, Kubernetes/Yarn, ZooKeeper: (yes, I think)
  - The S3 file system connector: (no)

## Documentation

  - Does this pull request introduce a new feature? (no)
  - If yes, how is the feature documented? (not applicable)
