### PR TITLE
[FLINK-23729][sql-client] Make sql-client.sh work on Windows

### DIFF
--- a/flink-dist/src/main/flink-bin/bin/config.sh
+++ b/flink-dist/src/main/flink-bin/bin/config.sh
@@ -62,7 +62,7 @@ findFlinkDistJar() {
 # "cygpath" can do the conversion.
 manglePath() {
     UNAME=$(uname -s)
-    if [ "${UNAME:0:6}" == "CYGWIN" ]; then
+    if [ "${UNAME:0:6}" == "CYGWIN" ] || [ "$OSTYPE" = "msys" ]; then
         echo `cygpath -w "$1"`
     else
         echo $1
@@ -72,7 +72,7 @@ manglePath() {
 manglePathList() {
     UNAME=$(uname -s)
     # a path list, for example a java classpath
-    if [ "${UNAME:0:6}" == "CYGWIN" ]; then
+    if [ "${UNAME:0:6}" == "CYGWIN" ] || [ "$OSTYPE" = "msys" ]; then
         echo `cygpath -wp "$1"`
     else
         echo $1

--- a/flink-table/flink-sql-client/bin/sql-client.sh
+++ b/flink-table/flink-sql-client/bin/sql-client.sh
@@ -54,7 +54,7 @@ CC_CLASSPATH=`constructFlinkClassPath`
 ################################################################################
 
 log=$FLINK_LOG_DIR/flink-$FLINK_IDENT_STRING-sql-client-$HOSTNAME.log
-log_setting=(-Dlog.file="$log" -Dlog4j.configuration=file:"$FLINK_CONF_DIR"/log4j-cli.properties -Dlog4j.configurationFile=file:"$FLINK_CONF_DIR"/log4j-cli.properties -Dlogback.configurationFile=file:"$FLINK_CONF_DIR"/logback.xml)
+log_setting=(-Dlog.file="$log" -Dlog4j.configuration=file:"$FLINK_CONF_DIR"/log4j-cli.properties -Dlog4j.configurationFile=file://"$FLINK_CONF_DIR"/log4j-cli.properties -Dlogback.configurationFile=file:"$FLINK_CONF_DIR"/logback.xml)
 
 # get path of jar in /opt if it exist
 FLINK_SQL_CLIENT_JAR=$(find "$FLINK_OPT_DIR" -regex ".*flink-sql-client.*.jar")


### PR DESCRIPTION
## What is the purpose of the change

Allow sql-client.sh to work on Windows machines with "msys" bash.

https://issues.apache.org/jira/browse/FLINK-23729

## Brief change log

  - Make manglePath() and manglePathList() in config.sh aware of "msys" $OSTYPE
  - Make log4j.configurationFile system property an absolute `file:` scheme path instead of a relative path

## Verifying this change

This change is a trivial rework / code cleanup without any test coverage.

Changes to config.sh and sql-client.sh were manually tested on both Windows and Linux to find the appropriate minimal changes that would lead to identical behavior on both platforms.

## Does this pull request potentially affect one of the following parts:

  - Dependencies (does it add or upgrade a dependency): no
  - The public API, i.e., is any changed class annotated with `@Public(Evolving)`: no
  - The serializers: no
  - The runtime per-record code paths (performance sensitive): no
  - Anything that affects deployment or recovery: JobManager (and its components), Checkpointing, Kubernetes/Yarn, ZooKeeper: no
  - The S3 file system connector: no

## Documentation

  - Does this pull request introduce a new feature? no
