### PR TITLE
[FLINK-23651][python] Support RabbitMQ in PyFlink

### DIFF
--- a/docs/content.zh/docs/connectors/datastream/rabbitmq.md
+++ b/docs/content.zh/docs/connectors/datastream/rabbitmq.md
@@ -108,6 +108,28 @@ val stream = env
     .setParallelism(1)               // non-parallel source is only required for exactly-once
 ```
 {{< /tab >}}
+{{< tab "Python" >}}
+```python
+env = StreamExecutionEnvironment.get_execution_environment()
+# checkpointing is required for exactly-once or at-least-once guarantees
+env.enable_checkpointing(...)
+
+connection_config = RMQConnectionConfig.Builder() \
+    .set_host("localhost") \
+    .set_port(5000) \
+    ...
+    .build()
+
+stream = env \
+    .add_source(RMQSource(
+        connection_config,
+        "queueName",
+        True,
+        SimpleStringSchema(),
+    )) \
+    .set_parallelism(1)
+```
+{{< /tab >}}
 {{< /tabs >}}
 
 #### 服务质量 (QoS) / 消费者预取(Consumer Prefetch)

--- a/docs/content/docs/connectors/datastream/rabbitmq.md
+++ b/docs/content/docs/connectors/datastream/rabbitmq.md
@@ -126,6 +126,28 @@ val stream = env
     .setParallelism(1)               // non-parallel source is only required for exactly-once
 ```
 {{< /tab >}}
+{{< tab "Python" >}}
+```python
+env = StreamExecutionEnvironment.get_execution_environment()
+# checkpointing is required for exactly-once or at-least-once guarantees
+env.enable_checkpointing(...)
+
+connection_config = RMQConnectionConfig.Builder() \
+    .set_host("localhost") \
+    .set_port(5000) \
+    ...
+    .build()
+
+stream = env \
+    .add_source(RMQSource(
+        connection_config,
+        "queueName",
+        True,
+        SimpleStringSchema(),
+    )) \
+    .set_parallelism(1)
+```
+{{< /tab >}}
 {{< /tabs >}}
 
 #### Quality of Service (QoS) / Consumer Prefetch

--- a/flink-connectors/flink-sql-connector-rabbitmq/pom.xml
+++ b/flink-connectors/flink-sql-connector-rabbitmq/pom.xml
@@ -1,0 +1,79 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!--
+Licensed to the Apache Software Foundation (ASF) under one
+or more contributor license agreements.  See the NOTICE file
+distributed with this work for additional information
+regarding copyright ownership.  The ASF licenses this file
+to you under the Apache License, Version 2.0 (the
+"License"); you may not use this file except in compliance
+with the License.  You may obtain a copy of the License at
+
+  http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing,
+software distributed under the License is distributed on an
+"AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+KIND, either express or implied.  See the License for the
+specific language governing permissions and limitations
+under the License.
+-->
+<project xmlns="http://maven.apache.org/POM/4.0.0"
+		 xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+		 xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+
+	<modelVersion>4.0.0</modelVersion>
+
+	<parent>
+		<artifactId>flink-connectors</artifactId>
+		<groupId>org.apache.flink</groupId>
+		<version>1.15-SNAPSHOT</version>
+		<relativePath>..</relativePath>
+	</parent>
+
+	<artifactId>flink-sql-connector-rabbitmq_${scala.binary.version}</artifactId>
+	<name>Flink : Connectors : SQL : RabbitMQ</name>
+
+	<packaging>jar</packaging>
+
+	<dependencies>
+		<dependency>
+			<groupId>org.apache.flink</groupId>
+			<artifactId>flink-connector-rabbitmq_${scala.binary.version}</artifactId>
+			<version>${project.version}</version>
+		</dependency>
+	</dependencies>
+
+	<build>
+		<plugins>
+			<plugin>
+				<groupId>org.apache.maven.plugins</groupId>
+				<artifactId>maven-shade-plugin</artifactId>
+				<executions>
+					<execution>
+						<id>shade-flink</id>
+						<phase>package</phase>
+						<goals>
+							<goal>shade</goal>
+						</goals>
+						<configuration>
+							<shadeTestJar>false</shadeTestJar>
+							<artifactSet>
+								<includes>
+									<include>com.rabbitmq:amqp-client</include>
+									<include>org.apache.flink:flink-connector-rabbitmq_${scala.binary.version}</include>
+								</includes>
+							</artifactSet>
+							<relocations>
+								<relocation>
+									<pattern>com.rabbitmq</pattern>
+									<shadedPattern>org.apache.flink.rabbitmq.shaded.com.rabbitmq</shadedPattern>
+								</relocation>
+							</relocations>
+						</configuration>
+					</execution>
+				</executions>
+			</plugin>
+		</plugins>
+	</build>
+
+</project>

--- a/flink-connectors/flink-sql-connector-rabbitmq/src/main/resources/META-INF/NOTICE
+++ b/flink-connectors/flink-sql-connector-rabbitmq/src/main/resources/META-INF/NOTICE
@@ -1,0 +1,9 @@
+flink-sql-connector-rabbitmq
+Copyright 2014-2021 The Apache Software Foundation
+
+This product includes software developed at
+The Apache Software Foundation (http://www.apache.org/).
+
+This project bundles the following dependencies under the Apache Software License 2.0 (http://www.apache.org/licenses/LICENSE-2.0.txt)
+
+- com.rabbitmq:amqp-client:5.9.0

--- a/flink-connectors/pom.xml
+++ b/flink-connectors/pom.xml
@@ -104,6 +104,7 @@ under the License.
 				<module>flink-sql-connector-hive-3.1.2</module>
 				<module>flink-sql-connector-kafka</module>
 				<module>flink-sql-connector-kinesis</module>
+				<module>flink-sql-connector-rabbitmq</module>
 			</modules>
 		</profile>
 	</profiles>

--- a/flink-python/pyflink/datastream/connectors.py
+++ b/flink-python/pyflink/datastream/connectors.py
@@ -41,6 +41,9 @@ __all__ = [
     'JdbcExecutionOptions',
     'NumberSequenceSource',
     'OutputFileConfig',
+    'RMQConnectionConfig',
+    'RMQSource',
+    'RMQSink',
     'RollingPolicy',
     'Sink',
     'Source',
@@ -1074,3 +1077,179 @@ class FileSink(Sink):
 
         return FileSink.RowFormatBuilder(
             JFileSink.forRowFormat(JPath(base_path), encoder._j_encoder))
+
+
+class RMQConnectionConfig(object):
+    """
+    Connection Configuration for RMQ.
+    """
+
+    def __init__(self, j_rmq_connection_config):
+        self._j_rmq_connection_config = j_rmq_connection_config
+
+    def get_host(self) -> str:
+        return self._j_rmq_connection_config.getHost()
+
+    def get_port(self) -> int:
+        return self._j_rmq_connection_config.getPort()
+
+    def get_virtual_host(self) -> str:
+        return self._j_rmq_connection_config.getVirtualHost()
+
+    def get_user_name(self) -> str:
+        return self._j_rmq_connection_config.getUsername()
+
+    def get_password(self) -> str:
+        return self._j_rmq_connection_config.getPassword()
+
+    def get_uri(self) -> str:
+        return self._j_rmq_connection_config.getUri()
+
+    def get_network_recovery_interval(self) -> int:
+        return self._j_rmq_connection_config.getNetworkRecoveryInterval()
+
+    def is_automatic_recovery(self) -> bool:
+        return self._j_rmq_connection_config.isAutomaticRecovery()
+
+    def is_topology_recovery(self) -> bool:
+        return self._j_rmq_connection_config.isTopologyRecovery()
+
+    def get_connection_timeout(self) -> int:
+        return self._j_rmq_connection_config.getConnectionTimeout()
+
+    def get_requested_channel_max(self) -> int:
+        return self._j_rmq_connection_config.getRequestedChannelMax()
+
+    def get_requested_frame_max(self) -> int:
+        return self._j_rmq_connection_config.getRequestedFrameMax()
+
+    def get_requested_heartbeat(self) -> int:
+        return self._j_rmq_connection_config.getRequestedHeartbeat()
+
+    class Builder(object):
+        """
+        Builder for RMQConnectionConfig.
+        """
+
+        def __init__(self):
+            self._j_options_builder = get_gateway().jvm.org.apache.flink.streaming.connectors\
+                .rabbitmq.common.RMQConnectionConfig.Builder()
+
+        def set_port(self, port: int) -> 'RMQConnectionConfig.Builder':
+            self._j_options_builder.setPort(port)
+            return self
+
+        def set_host(self, host: str) -> 'RMQConnectionConfig.Builder':
+            self._j_options_builder.setHost(host)
+            return self
+
+        def set_virtual_host(self, vhost: str) -> 'RMQConnectionConfig.Builder':
+            self._j_options_builder.setVirtualHost(vhost)
+            return self
+
+        def set_user_name(self, user_name: str) -> 'RMQConnectionConfig.Builder':
+            self._j_options_builder.setUserName(user_name)
+            return self
+
+        def set_password(self, password: str) -> 'RMQConnectionConfig.Builder':
+            self._j_options_builder.setPassword(password)
+            return self
+
+        def set_uri(self, uri: str) -> 'RMQConnectionConfig.Builder':
+            self._j_options_builder.setUri(uri)
+            return self
+
+        def set_topology_recovery_enabled(
+                self, topology_recovery_enabled: bool) -> 'RMQConnectionConfig.Builder':
+            self._j_options_builder.setTopologyRecoveryEnabled(topology_recovery_enabled)
+            return self
+
+        def set_requested_heartbeat(
+                self, requested_heartbeat: int) -> 'RMQConnectionConfig.Builder':
+            self._j_options_builder.setRequestedHeartbeat(requested_heartbeat)
+            return self
+
+        def set_requested_frame_max(
+                self, requested_frame_max: int) -> 'RMQConnectionConfig.Builder':
+            self._j_options_builder.setRequestedFrameMax(requested_frame_max)
+            return self
+
+        def set_requested_channel_max(
+                self, requested_channel_max: int) -> 'RMQConnectionConfig.Builder':
+            self._j_options_builder.setRequestedChannelMax(requested_channel_max)
+            return self
+
+        def set_network_recovery_interval(
+                self, network_recovery_interval: int) -> 'RMQConnectionConfig.Builder':
+            self._j_options_builder.setNetworkRecoveryInterval(network_recovery_interval)
+            return self
+
+        def set_connection_timeout(self, connection_timeout: int) -> 'RMQConnectionConfig.Builder':
+            self._j_options_builder.setConnectionTimeout(connection_timeout)
+            return self
+
+        def set_automatic_recovery(self, automatic_recovery: bool) -> 'RMQConnectionConfig.Builder':
+            self._j_options_builder.setAutomaticRecovery(automatic_recovery)
+            return self
+
+        def set_prefetch_count(self, prefetch_count: int) -> 'RMQConnectionConfig.Builder':
+            self._j_options_builder.setPrefetchCount(prefetch_count)
+            return self
+
+        def build(self) -> 'RMQConnectionConfig':
+            return RMQConnectionConfig(self._j_options_builder.build())
+
+
+class RMQSource(SourceFunction):
+    def __init__(self,
+                 connection_config: 'RMQConnectionConfig',
+                 queue_name: str,
+                 use_correlation_id: bool,
+                 deserialization_schema: DeserializationSchema
+                 ):
+        """
+        Creates a new RabbitMQ source.
+
+        For exactly-once, you must set the correlation ids of messages at the producer.
+        The correlation id must be unique. Otherwise the behavior of the source is undefined.
+
+        If in doubt, set use_correlation_id to False.
+
+        When correlation ids are not used, this source has at-least-once processing semantics
+        when checkpointing is enabled.
+
+        :param connection_config: The RabbiMQ connection configuration.
+        :param queue_name: The queue to receive messages from.
+        :param use_correlation_id: Whether the messages received are supplied with a unique id
+                                   to deduplicate messages (in case of failed acknowledgments).
+                                   Only used when checkpointing is enabled.
+        :param deserialization_schema: A deserializer used to convert between RabbitMQ's
+                                       messages and Flink's objects.
+        """
+        JRMQSource = get_gateway().jvm.org.apache.flink.streaming.connectors.rabbitmq.RMQSource
+        j_rmq_source = JRMQSource(
+            connection_config._j_rmq_connection_config,
+            queue_name,
+            use_correlation_id,
+            deserialization_schema._j_deserialization_schema
+        )
+        super(RMQSource, self).__init__(source_func=j_rmq_source)
+
+
+class RMQSink(SinkFunction):
+    def __init__(self, connection_config: 'RMQConnectionConfig',
+                 queue_name: str, serialization_schema: SerializationSchema):
+        """
+        Creates a new RabbitMQ sink.
+
+        :param connection_config: The RabbiMQ connection configuration.
+        :param queue_name: The queue to publish messages to.
+        :param serialization_schema: A serializer used to convert Flink objects to bytes.
+        """
+        JRMQSink = get_gateway().jvm.org.apache.flink.streaming.connectors.rabbitmq.RMQSink
+        j_rmq_sink = JRMQSink(
+            connection_config._j_rmq_connection_config,
+            queue_name,
+            serialization_schema._j_serialization_schema,
+        )
+        super(RMQSink, self).__init__(sink_func=j_rmq_sink)


### PR DESCRIPTION
<!--
*Thank you very much for contributing to Apache Flink - we are happy that you want to help us improve Flink. To help the community review your contribution in the best possible way, please go through the checklist below, which will get the contribution into a shape in which it can be best reviewed.*

*Please understand that we do not do this to make contributions to Flink a hassle. In order to uphold a high standard of quality for code contributions, while at the same time managing a large number of contributions, we need contributors to prepare the contributions well, and give reviewers enough contextual information for the review. Please also understand that contributions that do not follow this guide will take longer to review and thus typically be picked up with lower priority by the community.*

## Contribution Checklist

  - Make sure that the pull request corresponds to a [JIRA issue](https://issues.apache.org/jira/projects/FLINK/issues). Exceptions are made for typos in JavaDoc or documentation files, which need no JIRA issue.
  
  - Name the pull request in the form "[FLINK-XXXX] [component] Title of the pull request", where *FLINK-XXXX* should be replaced by the actual issue number. Skip *component* if you are unsure about which is the best component.
  Typo fixes that have no associated JIRA issue should be named following this pattern: `[hotfix] [docs] Fix typo in event time introduction` or `[hotfix] [javadocs] Expand JavaDoc for PuncuatedWatermarkGenerator`.

  - Fill out the template below to describe the changes contributed by the pull request. That will give reviewers the context they need to do the review.
  
  - Make sure that the change passes the automated tests, i.e., `mvn clean verify` passes. You can set up Azure Pipelines CI to do that following [this guide](https://cwiki.apache.org/confluence/display/FLINK/Azure+Pipelines#AzurePipelines-Tutorial:SettingupAzurePipelinesforaforkoftheFlinkrepository).

  - Each pull request should address only one issue, not mix up code from multiple issues.
  
  - Each commit in the pull request has a meaningful commit message (including the JIRA id)

  - Once all items of the checklist are addressed, remove the above text and this checklist, leaving only the filled out template below.


**(The sections below can be removed for hotfixes of typos)**
-->

## What is the purpose of the change

Add support for RabbitMQ data connectors in the Python datastream API

## Brief change log


* Add RMQSink
* Add RMQSource
* Add RMQConnectionConfig
* Update `RabbitMQ` connector document

## Verifying this change

This change is a simple wrapper over the RMQ data connectors for the Java API.

Change was manually verified by creating a simple Flink cluster and RabbitMQ instance with docker-compose. The process is described below:

File structure:
```txt
sample-app/
├─ Dockerfile
├─ app.py
├─ docker-compose.yml
├─ pom.xml
```

`docker-compose.yml`
```yml
version: "3.3"

services:
  rabbitmq:
    image: rabbitmq:3.8.14-management-alpine
    ports:
      - "5672:5672"
      - "15672:15672"

  flink-jobmanager:
    build: .
    ports:
      - "8081:8081"
    command: jobmanager
    depends_on:
      - rabbitmq
    environment:
      - |
        FLINK_PROPERTIES=
        jobmanager.rpc.address: flink-jobmanager

  flink-taskmanager:
    build: .
    depends_on:
      - flink-jobmanager
    command: taskmanager
    environment:
      - |
        FLINK_PROPERTIES=
        jobmanager.rpc.address: flink-jobmanager
        taskmanager.numberOfTaskSlots: 2
```

`Dockerfile` (for the above jobmanager and taskmanager)
```Dockerfile
FROM flink:1.13.0 as base

RUN apt update -y 
RUN apt install -y git build-essential zlib1g-dev libncurses5-dev libgdbm-dev libnss3-dev libssl-dev libsqlite3-dev libreadline-dev libffi-dev wget curl libbz2-dev maven liblzma-dev
RUN curl -O https://www.python.org/ftp/python/3.8.2/Python-3.8.2.tar.xz
RUN tar -xf Python-3.8.2.tar.xz
RUN cd Python-3.8.2 && ./configure --enable-optimizations && make -j 1 && make altinstall
RUN ln -sf /usr/local/bin/python3.8 /usr/local/bin/python


COPY pom.xml pom.xml
RUN mvn dependency:copy-dependencies -DoutputDirectory="/opt/flink/lib/"


FROM base as pyflink

WORKDIR /flink

RUN python -m pip install --upgrade pip
RUN pip install apache-flink

COPY . .

ENTRYPOINT [ "/docker-entrypoint.sh" ]
```

`pom.xml` (for managing dependencies)
```xml
<?xml version="1.0" encoding="UTF-8"?>
<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
    <modelVersion>4.0.0</modelVersion>
    <version>0.1</version>
	
    <groupId>com.example</groupId>
    <artifactId>dependencies</artifactId>

    <dependencies>
        <dependency>
            <groupId>org.apache.flink</groupId>
            <artifactId>flink-connector-rabbitmq_2.12</artifactId>
            <version>1.13.0</version>
        </dependency>
    </dependencies>

</project>
```


`app.py`
```python
from pyflink.common.serialization import SimpleStringSchema
from pyflink.common.typeinfo import BasicTypeInfo
from pyflink.datastream.stream_execution_environment import StreamExecutionEnvironment
# Change import so that it works with your setup
from pyflink.datastream.connectors import RMQSink, RMQSource, RMQConnectionConfig


if __name__ == "__main__":
    env = StreamExecutionEnvironment.get_execution_environment()

    connection_config = RMQConnectionConfig.Builder() \
        .set_host("rabbitmq") \
        .set_port(5672) \
        .set_virtual_host("/") \
        .set_user_name("guest") \
        .set_password("guest") \
        .build()

    source = RMQSource(
        connection_config,
        "source-queue",
        False,
        SimpleStringSchema(),
    )

    sink = RMQSink(
        connection_config,
        "sink-queue",
        SimpleStringSchema()
    )

    env \
        .add_source(source) \
        .map(lambda x: f"PROCESSED: {x}", output_type=BasicTypeInfo.STRING_TYPE_INFO()) \
        .add_sink(sink)

    env.execute("test")
```


Putting it all together
```bash
$ docker-compose up --build -d flink-jobmanager flink-taskmanager rabbitmq  # start containers
$ docker exec -it $(docker ps -q -f "name=jobmanager") /opt/flink/bin/flink run -py app.py  # submit job (app.py)
```

Eg. RabbitMQ management panel (http://localhost:15672/) may be used for publishing and consuming messages


## Does this pull request potentially affect one of the following parts:

  - Dependencies (does it add or upgrade a dependency): (**no**)
  - The public API, i.e., is any changed class annotated with `@Public(Evolving)`: (**no**)
  - The serializers: (**no**)
  - The runtime per-record code paths (performance sensitive): (**no**)
  - Anything that affects deployment or recovery: JobManager (and its components), Checkpointing, Kubernetes/Yarn, ZooKeeper: (**no**)
  - The S3 file system connector: (**no**)

## Documentation

  - Does this pull request introduce a new feature? (**yes**)
  - If yes, how is the feature documented? (**docs**)
