### PR TITLE
[FLINK-23705][connectors/kinesis] Unregistering metric reporting for closed shards

### DIFF
--- a/flink-connectors/flink-connector-kinesis/src/main/java/org/apache/flink/streaming/connectors/kinesis/internals/ShardConsumer.java
+++ b/flink-connectors/flink-connector-kinesis/src/main/java/org/apache/flink/streaming/connectors/kinesis/internals/ShardConsumer.java
@@ -158,6 +158,8 @@ public class ShardConsumer<T> implements Runnable {
             }
         } catch (Throwable t) {
             fetcherRef.stopWithError(t);
+        } finally {
+            this.shardConsumerMetricsReporter.unregister();
         }
     }
 

--- a/flink-connectors/flink-connector-kinesis/src/main/java/org/apache/flink/streaming/connectors/kinesis/metrics/ShardConsumerMetricsReporter.java
+++ b/flink-connectors/flink-connector-kinesis/src/main/java/org/apache/flink/streaming/connectors/kinesis/metrics/ShardConsumerMetricsReporter.java
@@ -20,11 +20,14 @@ package org.apache.flink.streaming.connectors.kinesis.metrics;
 
 import org.apache.flink.annotation.Internal;
 import org.apache.flink.metrics.MetricGroup;
+import org.apache.flink.runtime.metrics.groups.AbstractMetricGroup;
 import org.apache.flink.streaming.connectors.kinesis.internals.ShardConsumer;
 
 /** A container for {@link ShardConsumer}s to report metric values. */
 @Internal
 public class ShardConsumerMetricsReporter {
+
+    private final MetricGroup metricGroup;
 
     private volatile long millisBehindLatest = -1;
     private volatile long averageRecordSizeBytes = 0L;
@@ -32,6 +35,7 @@ public class ShardConsumerMetricsReporter {
     private volatile int numberOfDeaggregatedRecords = 0;
 
     public ShardConsumerMetricsReporter(final MetricGroup metricGroup) {
+        this.metricGroup = metricGroup;
         metricGroup.gauge(
                 KinesisConsumerMetricConstants.MILLIS_BEHIND_LATEST_GAUGE,
                 this::getMillisBehindLatest);
@@ -76,5 +80,11 @@ public class ShardConsumerMetricsReporter {
 
     public void setNumberOfDeaggregatedRecords(int numberOfDeaggregatedRecords) {
         this.numberOfDeaggregatedRecords = numberOfDeaggregatedRecords;
+    }
+
+    public void unregister() {
+        if (this.metricGroup instanceof AbstractMetricGroup) {
+            ((AbstractMetricGroup) this.metricGroup).close();
+        }
     }
 }

--- a/flink-connectors/flink-connector-kinesis/src/test/java/org/apache/flink/streaming/connectors/kinesis/internals/DynamoDBStreamsDataFetcherTest.java
+++ b/flink-connectors/flink-connector-kinesis/src/test/java/org/apache/flink/streaming/connectors/kinesis/internals/DynamoDBStreamsDataFetcherTest.java
@@ -19,6 +19,7 @@ package org.apache.flink.streaming.connectors.kinesis.internals;
 
 import org.apache.flink.api.common.functions.RuntimeContext;
 import org.apache.flink.api.common.serialization.SimpleStringSchema;
+import org.apache.flink.runtime.metrics.groups.OperatorMetricGroup;
 import org.apache.flink.streaming.connectors.kinesis.model.StreamShardHandle;
 import org.apache.flink.streaming.connectors.kinesis.proxy.KinesisProxyInterface;
 import org.apache.flink.streaming.connectors.kinesis.serialization.KinesisDeserializationSchemaWrapper;
@@ -32,6 +33,7 @@ import java.util.Properties;
 import static com.amazonaws.services.kinesis.model.ShardIteratorType.LATEST;
 import static java.util.Collections.singletonList;
 import static org.apache.flink.streaming.connectors.kinesis.internals.KinesisDataFetcher.DEFAULT_SHARD_ASSIGNER;
+import static org.apache.flink.streaming.connectors.kinesis.internals.ShardConsumerTestUtils.createFakeShardConsumerMetricGroup;
 import static org.apache.flink.streaming.connectors.kinesis.model.SentinelSequenceNumber.SENTINEL_LATEST_SEQUENCE_NUM;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.verify;
@@ -60,7 +62,8 @@ public class DynamoDBStreamsDataFetcherTest {
         fetcher.createRecordPublisher(
                 SENTINEL_LATEST_SEQUENCE_NUM.get(),
                 new Properties(),
-                runtimeContext.getMetricGroup(),
+                createFakeShardConsumerMetricGroup(
+                        (OperatorMetricGroup) runtimeContext.getMetricGroup()),
                 dummyStreamShardHandle);
 
         verify(kinesis).getShardIterator(dummyStreamShardHandle, LATEST.toString(), null);

--- a/flink-connectors/flink-connector-kinesis/src/test/java/org/apache/flink/streaming/connectors/kinesis/internals/ShardConsumerTestUtils.java
+++ b/flink-connectors/flink-connector-kinesis/src/test/java/org/apache/flink/streaming/connectors/kinesis/internals/ShardConsumerTestUtils.java
@@ -18,9 +18,12 @@
 package org.apache.flink.streaming.connectors.kinesis.internals;
 
 import org.apache.flink.api.common.serialization.SimpleStringSchema;
-import org.apache.flink.metrics.MetricGroup;
+import org.apache.flink.runtime.metrics.groups.AbstractMetricGroup;
+import org.apache.flink.runtime.metrics.groups.OperatorMetricGroup;
+import org.apache.flink.runtime.metrics.groups.UnregisteredMetricGroups;
 import org.apache.flink.streaming.connectors.kinesis.internals.publisher.RecordPublisher;
 import org.apache.flink.streaming.connectors.kinesis.internals.publisher.RecordPublisherFactory;
+import org.apache.flink.streaming.connectors.kinesis.metrics.KinesisConsumerMetricConstants;
 import org.apache.flink.streaming.connectors.kinesis.metrics.ShardConsumerMetricsReporter;
 import org.apache.flink.streaming.connectors.kinesis.model.KinesisStreamShardState;
 import org.apache.flink.streaming.connectors.kinesis.model.SequenceNumber;
@@ -47,12 +50,11 @@ import java.util.concurrent.atomic.AtomicReference;
 
 import static org.apache.flink.streaming.connectors.kinesis.model.SentinelSequenceNumber.SENTINEL_SHARD_ENDING_SEQUENCE_NUM;
 import static org.junit.Assert.assertEquals;
-import static org.mockito.Mockito.mock;
 
 /** Tests for the {@link ShardConsumer}. */
 public class ShardConsumerTestUtils {
 
-    public static <T> ShardConsumerMetricsReporter assertNumberOfMessagesReceivedFromKinesis(
+    public static ShardConsumerMetricsReporter assertNumberOfMessagesReceivedFromKinesis(
             final int expectedNumberOfMessages,
             final RecordPublisherFactory recordPublisherFactory,
             final SequenceNumber startingSequenceNumber,
@@ -66,15 +68,32 @@ public class ShardConsumerTestUtils {
                 SENTINEL_SHARD_ENDING_SEQUENCE_NUM.get());
     }
 
-    public static <T> ShardConsumerMetricsReporter assertNumberOfMessagesReceivedFromKinesis(
+    public static ShardConsumerMetricsReporter assertNumberOfMessagesReceivedFromKinesis(
             final int expectedNumberOfMessages,
             final RecordPublisherFactory recordPublisherFactory,
             final SequenceNumber startingSequenceNumber,
             final Properties consumerProperties,
-            final SequenceNumber expectedLastProcessedSequenceNum)
+            final AbstractMetricGroup metricGroup)
+            throws InterruptedException {
+        return assertNumberOfMessagesReceivedFromKinesis(
+                expectedNumberOfMessages,
+                recordPublisherFactory,
+                startingSequenceNumber,
+                consumerProperties,
+                SENTINEL_SHARD_ENDING_SEQUENCE_NUM.get(),
+                metricGroup);
+    }
+
+    public static ShardConsumerMetricsReporter assertNumberOfMessagesReceivedFromKinesis(
+            final int expectedNumberOfMessages,
+            final RecordPublisherFactory recordPublisherFactory,
+            final SequenceNumber startingSequenceNumber,
+            final Properties consumerProperties,
+            final SequenceNumber expectedLastProcessedSequenceNum,
+            final AbstractMetricGroup metricGroup)
             throws InterruptedException {
         ShardConsumerMetricsReporter shardMetricsReporter =
-                new ShardConsumerMetricsReporter(mock(MetricGroup.class));
+                new ShardConsumerMetricsReporter(metricGroup);
 
         StreamShardHandle fakeToBeConsumedShard = getMockStreamShard("fakeStream", 0);
 
@@ -116,7 +135,7 @@ public class ShardConsumerTestUtils {
                 recordPublisherFactory.create(
                         startingPosition,
                         fetcher.getConsumerConfiguration(),
-                        mock(MetricGroup.class),
+                        metricGroup,
                         shardHandle);
 
         int shardIndex =
@@ -139,6 +158,22 @@ public class ShardConsumerTestUtils {
         return shardMetricsReporter;
     }
 
+    public static ShardConsumerMetricsReporter assertNumberOfMessagesReceivedFromKinesis(
+            final int expectedNumberOfMessages,
+            final RecordPublisherFactory recordPublisherFactory,
+            final SequenceNumber startingSequenceNumber,
+            final Properties consumerProperties,
+            final SequenceNumber expectedLastProcessedSequenceNum)
+            throws InterruptedException {
+        return assertNumberOfMessagesReceivedFromKinesis(
+                expectedNumberOfMessages,
+                recordPublisherFactory,
+                startingSequenceNumber,
+                consumerProperties,
+                expectedLastProcessedSequenceNum,
+                createFakeShardConsumerMetricGroup());
+    }
+
     public static StreamShardHandle getMockStreamShard(String streamName, int shardId) {
         return new StreamShardHandle(
                 streamName,
@@ -154,5 +189,20 @@ public class ShardConsumerTestUtils {
 
     public static SequenceNumber fakeSequenceNumber() {
         return new SequenceNumber("fakeStartingState");
+    }
+
+    public static AbstractMetricGroup createFakeShardConsumerMetricGroup(
+            OperatorMetricGroup metricGroup) {
+        return (AbstractMetricGroup)
+                metricGroup
+                        .addGroup(KinesisConsumerMetricConstants.STREAM_METRICS_GROUP, "fakeStream")
+                        .addGroup(
+                                KinesisConsumerMetricConstants.SHARD_METRICS_GROUP,
+                                "shardId-000000000000");
+    }
+
+    public static AbstractMetricGroup createFakeShardConsumerMetricGroup() {
+        return createFakeShardConsumerMetricGroup(
+                UnregisteredMetricGroups.createUnregisteredOperatorMetricGroup());
     }
 }

--- a/flink-connectors/flink-connector-kinesis/src/test/java/org/apache/flink/streaming/connectors/kinesis/internals/publisher/polling/PollingRecordPublisherFactoryTest.java
+++ b/flink-connectors/flink-connector-kinesis/src/test/java/org/apache/flink/streaming/connectors/kinesis/internals/publisher/polling/PollingRecordPublisherFactoryTest.java
@@ -17,7 +17,6 @@
 
 package org.apache.flink.streaming.connectors.kinesis.internals.publisher.polling;
 
-import org.apache.flink.metrics.MetricGroup;
 import org.apache.flink.streaming.connectors.kinesis.internals.publisher.RecordPublisher;
 import org.apache.flink.streaming.connectors.kinesis.model.StartingPosition;
 import org.apache.flink.streaming.connectors.kinesis.model.StreamShardHandle;
@@ -28,6 +27,7 @@ import org.junit.Test;
 import java.util.Properties;
 
 import static org.apache.flink.streaming.connectors.kinesis.config.ConsumerConfigConstants.SHARD_USE_ADAPTIVE_READS;
+import static org.apache.flink.streaming.connectors.kinesis.internals.ShardConsumerTestUtils.createFakeShardConsumerMetricGroup;
 import static org.apache.flink.streaming.connectors.kinesis.model.SentinelSequenceNumber.SENTINEL_LATEST_SEQUENCE_NUM;
 import static org.junit.Assert.assertFalse;
 import static org.junit.Assert.assertTrue;
@@ -46,7 +46,7 @@ public class PollingRecordPublisherFactoryTest {
                         StartingPosition.restartFromSequenceNumber(
                                 SENTINEL_LATEST_SEQUENCE_NUM.get()),
                         new Properties(),
-                        mock(MetricGroup.class),
+                        createFakeShardConsumerMetricGroup(),
                         mock(StreamShardHandle.class));
 
         assertTrue(recordPublisher instanceof PollingRecordPublisher);
@@ -63,7 +63,7 @@ public class PollingRecordPublisherFactoryTest {
                         StartingPosition.restartFromSequenceNumber(
                                 SENTINEL_LATEST_SEQUENCE_NUM.get()),
                         properties,
-                        mock(MetricGroup.class),
+                        createFakeShardConsumerMetricGroup(),
                         mock(StreamShardHandle.class));
 
         assertTrue(recordPublisher instanceof PollingRecordPublisher);

--- a/flink-connectors/flink-connector-kinesis/src/test/java/org/apache/flink/streaming/connectors/kinesis/internals/publisher/polling/PollingRecordPublisherTest.java
+++ b/flink-connectors/flink-connector-kinesis/src/test/java/org/apache/flink/streaming/connectors/kinesis/internals/publisher/polling/PollingRecordPublisherTest.java
@@ -17,7 +17,6 @@
 
 package org.apache.flink.streaming.connectors.kinesis.internals.publisher.polling;
 
-import org.apache.flink.metrics.MetricGroup;
 import org.apache.flink.streaming.connectors.kinesis.metrics.PollingRecordPublisherMetricsReporter;
 import org.apache.flink.streaming.connectors.kinesis.model.StartingPosition;
 import org.apache.flink.streaming.connectors.kinesis.proxy.KinesisProxyInterface;
@@ -29,6 +28,7 @@ import org.junit.Rule;
 import org.junit.Test;
 import org.junit.rules.ExpectedException;
 
+import static org.apache.flink.streaming.connectors.kinesis.internals.ShardConsumerTestUtils.createFakeShardConsumerMetricGroup;
 import static org.apache.flink.streaming.connectors.kinesis.internals.publisher.RecordPublisher.RecordPublisherRunResult.COMPLETE;
 import static org.apache.flink.streaming.connectors.kinesis.internals.publisher.RecordPublisher.RecordPublisherRunResult.INCOMPLETE;
 import static org.apache.flink.streaming.connectors.kinesis.model.SentinelSequenceNumber.SENTINEL_EARLIEST_SEQUENCE_NUM;
@@ -64,7 +64,9 @@ public class PollingRecordPublisherTest {
     @Test
     public void testRunEmitsRunLoopTimeNanos() throws Exception {
         PollingRecordPublisherMetricsReporter metricsReporter =
-                spy(new PollingRecordPublisherMetricsReporter(mock(MetricGroup.class)));
+                spy(
+                        new PollingRecordPublisherMetricsReporter(
+                                createFakeShardConsumerMetricGroup()));
 
         KinesisProxyInterface fakeKinesis = totalNumOfRecordsAfterNumOfGetRecordsCalls(5, 5, 100);
         PollingRecordPublisher recordPublisher =
@@ -152,7 +154,7 @@ public class PollingRecordPublisherTest {
     PollingRecordPublisher createPollingRecordPublisher(final KinesisProxyInterface kinesis)
             throws Exception {
         PollingRecordPublisherMetricsReporter metricsReporter =
-                new PollingRecordPublisherMetricsReporter(mock(MetricGroup.class));
+                new PollingRecordPublisherMetricsReporter(createFakeShardConsumerMetricGroup());
 
         return createPollingRecordPublisher(kinesis, metricsReporter);
     }

--- a/flink-connectors/flink-connector-kinesis/src/test/java/org/apache/flink/streaming/connectors/kinesis/metrics/ShardConsumerMetricsReporterTest.java
+++ b/flink-connectors/flink-connector-kinesis/src/test/java/org/apache/flink/streaming/connectors/kinesis/metrics/ShardConsumerMetricsReporterTest.java
@@ -18,6 +18,8 @@
 package org.apache.flink.streaming.connectors.kinesis.metrics;
 
 import org.apache.flink.metrics.MetricGroup;
+import org.apache.flink.runtime.metrics.groups.AbstractMetricGroup;
+import org.apache.flink.streaming.connectors.kinesis.internals.ShardConsumerTestUtils;
 
 import org.junit.Before;
 import org.junit.Test;
@@ -26,6 +28,7 @@ import org.mockito.Mock;
 import org.mockito.MockitoAnnotations;
 
 import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertTrue;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.ArgumentMatchers.eq;
 import static org.mockito.Mockito.verify;
@@ -66,5 +69,17 @@ public class ShardConsumerMetricsReporterTest {
         assertEquals(2, metricsReporter.getMillisBehindLatest());
         assertEquals(3, metricsReporter.getNumberOfAggregatedRecords());
         assertEquals(4, metricsReporter.getNumberOfDeaggregatedRecords());
+    }
+
+    @Test
+    public void testUnregister() {
+        AbstractMetricGroup metricGroup =
+                ShardConsumerTestUtils.createFakeShardConsumerMetricGroup();
+        ShardConsumerMetricsReporter metricsReporter =
+                new ShardConsumerMetricsReporter(metricGroup);
+
+        metricsReporter.unregister();
+
+        assertTrue(metricGroup.isClosed());
     }
 }

--- a/flink-connectors/flink-connector-kinesis/src/test/java/org/apache/flink/streaming/connectors/kinesis/testutils/TestUtils.java
+++ b/flink-connectors/flink-connector-kinesis/src/test/java/org/apache/flink/streaming/connectors/kinesis/testutils/TestUtils.java
@@ -19,7 +19,6 @@ package org.apache.flink.streaming.connectors.kinesis.testutils;
 
 import org.apache.flink.api.common.functions.RuntimeContext;
 import org.apache.flink.configuration.ConfigConstants;
-import org.apache.flink.metrics.groups.UnregisteredMetricsGroup;
 import org.apache.flink.streaming.connectors.kinesis.config.AWSConfigConstants;
 import org.apache.flink.streaming.connectors.kinesis.internals.publisher.RecordBatch;
 import org.apache.flink.streaming.connectors.kinesis.internals.publisher.RecordPublisher;
@@ -46,6 +45,7 @@ import java.util.Properties;
 import java.util.UUID;
 import java.util.concurrent.atomic.AtomicInteger;
 
+import static org.apache.flink.runtime.metrics.groups.UnregisteredMetricGroups.createUnregisteredOperatorMetricGroup;
 import static org.apache.flink.streaming.connectors.kinesis.config.ConsumerConfigConstants.EFORegistrationType.NONE;
 import static org.apache.flink.streaming.connectors.kinesis.config.ConsumerConfigConstants.EFO_CONSUMER_ARN_PREFIX;
 import static org.apache.flink.streaming.connectors.kinesis.config.ConsumerConfigConstants.EFO_REGISTRATION_TYPE;
@@ -164,7 +164,7 @@ public class TestUtils {
                 .thenReturn(Thread.currentThread().getContextClassLoader());
 
         Mockito.when(mockedRuntimeContext.getMetricGroup())
-                .thenReturn(new UnregisteredMetricsGroup());
+                .thenReturn(createUnregisteredOperatorMetricGroup());
 
         return mockedRuntimeContext;
     }


### PR DESCRIPTION
## What is the purpose of the change

This pull request unregisters metrics reporting for closed shards in the Kinesis connector. This avoids confusing and incorrect aggregated metrics after resharding.

## Brief change log

  - ShardConsumerMetricsReporter has an unregister method
  - ShardConsumer unregisters ShardConsumerMetricsReporter after consuming shard

## Verifying this change

This change added tests and can be verified as follows:

  - Added unit test that checks that the registered MetricGroup is closed after a shard completes.
  - Manually verified the change by running a Kinesis Data Analytics app reading from a Kinesis stream with 1 shard then increasing the number of shards to 2, verifying that the metrics for the closed shard are zeroed in the Flink dashboard

## Does this pull request potentially affect one of the following parts:

  - Dependencies (does it add or upgrade a dependency): (no)
  - The public API, i.e., is any changed class annotated with `@Public(Evolving)`: (no)
  - The serializers: (no)
  - The runtime per-record code paths (performance sensitive): (no)
  - Anything that affects deployment or recovery: JobManager (and its components), Checkpointing, Kubernetes/Yarn, ZooKeeper: (no)
  - The S3 file system connector: (no)

## Documentation

  - Does this pull request introduce a new feature? (no)
  - If yes, how is the feature documented? (not applicable)
