### PR TITLE
[FLINK-10052][ha] Tolerate temporarily suspended ZooKeeper connections

### DIFF
--- a/docs/content.zh/docs/deployment/ha/zookeeper_ha.md
+++ b/docs/content.zh/docs/deployment/ha/zookeeper_ha.md
@@ -98,6 +98,19 @@ zookeeper.sasl.login-context-name: Client
 
 {{< top >}}
 
+## Advanced Configuration
+
+### Tolerating Suspended ZooKeeper Connections
+
+Per default, Flink's ZooKeeper client treats suspended ZooKeeper connections as an error.
+This means that Flink will invalidate all leaderships of its components and thereby triggering a failover if a connection is suspended.
+
+This behaviour might be too disruptive in some cases (e.g., unstable network environment).
+If you are willing to take a more aggressive approach, then you can tolerate suspended ZooKeeper connections and only treat lost connections as an error via [high-availability.zookeeper.client.tolerate-suspended-connections]({{< ref "docs/deployment/config" >}}#high-availability-zookeeper-client-tolerate-suspended-connection).
+Enabling this feature will make Flink more resilient against temporary connection problems but also increase the risk of running into ZooKeeper timing problems.
+
+For more information take a look at [Curator's error handling](https://curator.apache.org/errors.html).
+
 ## ZooKeeper 版本
 
 Flink 附带了 3.4 和 3.5 的单独的 ZooKeeper 客户端，其中 3.4 位于发行版的 `lib` 目录中，为默认使用版本，而 3.5 位于 opt 目录中。

--- a/docs/content/docs/deployment/ha/zookeeper_ha.md
+++ b/docs/content/docs/deployment/ha/zookeeper_ha.md
@@ -105,6 +105,19 @@ You can also find further details on [how Flink sets up Kerberos-based security 
 
 {{< top >}}
 
+## Advanced Configuration
+
+### Tolerating Suspended ZooKeeper Connections
+
+Per default, Flink's ZooKeeper client treats suspended ZooKeeper connections as an error.
+This means that Flink will invalidate all leaderships of its components and thereby triggering a failover if a connection is suspended.
+
+This behaviour might be too disruptive in some cases (e.g., unstable network environment).
+If you are willing to take a more aggressive approach, then you can tolerate suspended ZooKeeper connections and only treat lost connections as an error via [high-availability.zookeeper.client.tolerate-suspended-connections]({{< ref "docs/deployment/config" >}}#high-availability-zookeeper-client-tolerate-suspended-connection).
+Enabling this feature will make Flink more resilient against temporary connection problems but also increase the risk of running into ZooKeeper timing problems.
+
+For more information take a look at [Curator's error handling](https://curator.apache.org/errors.html).
+
 ## ZooKeeper Versions
 
 Flink ships with separate ZooKeeper clients for 3.4 and 3.5, with 3.4 being in the `lib` directory of the distribution

--- a/docs/layouts/shortcodes/generated/expert_high_availability_zk_section.html
+++ b/docs/layouts/shortcodes/generated/expert_high_availability_zk_section.html
@@ -39,6 +39,12 @@
             <td>Defines the session timeout for the ZooKeeper session in ms.</td>
         </tr>
         <tr>
+            <td><h5>high-availability.zookeeper.client.tolerate-suspended-connections</h5></td>
+            <td style="word-wrap: break-word;">false</td>
+            <td>Boolean</td>
+            <td>Defines whether a suspended ZooKeeper connection will be treated as an error that causes the leader information to be invalidated or not. In case you set this option to <code class="highlighter-rouge">true</code>, Flink will wait until a ZooKeeper connection is marked as lost before it revokes the leadership of components. This has the effect that Flink is more resilient against temporary connection instabilities at the cost of running more likely into timing issues with ZooKeeper.</td>
+        </tr>
+        <tr>
             <td><h5>high-availability.zookeeper.path.jobgraphs</h5></td>
             <td style="word-wrap: break-word;">"/jobgraphs"</td>
             <td>String</td>

--- a/docs/layouts/shortcodes/generated/high_availability_configuration.html
+++ b/docs/layouts/shortcodes/generated/high_availability_configuration.html
@@ -63,6 +63,12 @@
             <td>Defines the session timeout for the ZooKeeper session in ms.</td>
         </tr>
         <tr>
+            <td><h5>high-availability.zookeeper.client.tolerate-suspended-connections</h5></td>
+            <td style="word-wrap: break-word;">false</td>
+            <td>Boolean</td>
+            <td>Defines whether a suspended ZooKeeper connection will be treated as an error that causes the leader information to be invalidated or not. In case you set this option to <code class="highlighter-rouge">true</code>, Flink will wait until a ZooKeeper connection is marked as lost before it revokes the leadership of components. This has the effect that Flink is more resilient against temporary connection instabilities at the cost of running more likely into timing issues with ZooKeeper.</td>
+        </tr>
+        <tr>
             <td><h5>high-availability.zookeeper.path.jobgraphs</h5></td>
             <td style="word-wrap: break-word;">"/jobgraphs"</td>
             <td>String</td>

--- a/flink-core/src/main/java/org/apache/flink/configuration/HighAvailabilityOptions.java
+++ b/flink-core/src/main/java/org/apache/flink/configuration/HighAvailabilityOptions.java
@@ -19,6 +19,8 @@
 package org.apache.flink.configuration;
 
 import org.apache.flink.annotation.docs.Documentation;
+import org.apache.flink.configuration.description.Description;
+import org.apache.flink.configuration.description.TextElement;
 
 import static org.apache.flink.configuration.ConfigOptions.key;
 
@@ -168,6 +170,22 @@ public class HighAvailabilityOptions {
                             "Defines the ACL (open|creator) to be configured on ZK node. The configuration value can be"
                                     + " set to “creator” if the ZooKeeper server configuration has the “authProvider” property mapped to use"
                                     + " SASLAuthenticationProvider and the cluster is configured to run in secure mode (Kerberos).");
+
+    @Documentation.Section(Documentation.Sections.EXPERT_ZOOKEEPER_HIGH_AVAILABILITY)
+    public static final ConfigOption<Boolean> ZOOKEEPER_TOLERATE_SUSPENDED_CONNECTIONS =
+            key("high-availability.zookeeper.client.tolerate-suspended-connections")
+                    .booleanType()
+                    .defaultValue(false)
+                    .withDescription(
+                            Description.builder()
+                                    .text(
+                                            "Defines whether a suspended ZooKeeper connection will be treated as an error that causes the leader "
+                                                    + "information to be invalidated or not. In case you set this option to %s, Flink will wait until a "
+                                                    + "ZooKeeper connection is marked as lost before it revokes the leadership of components. This has the "
+                                                    + "effect that Flink is more resilient against temporary connection instabilities at the cost of running "
+                                                    + "more likely into timing issues with ZooKeeper.",
+                                            TextElement.code("true"))
+                                    .build());
 
     // ------------------------------------------------------------------------
     //  Deprecated options

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/highavailability/HighAvailabilityServicesUtils.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/highavailability/HighAvailabilityServicesUtils.java
@@ -145,7 +145,7 @@ public class HighAvailabilityServicesUtils {
                 return new StandaloneClientHAServices(webMonitorAddress);
             case ZOOKEEPER:
                 final CuratorFramework client = ZooKeeperUtils.startCuratorFramework(configuration);
-                return new ZooKeeperClientHAServices(client);
+                return new ZooKeeperClientHAServices(client, configuration);
             case FACTORY_CLASS:
                 return createCustomClientHAServices(configuration);
             default:

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/highavailability/zookeeper/ZooKeeperClientHAServices.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/highavailability/zookeeper/ZooKeeperClientHAServices.java
@@ -18,6 +18,7 @@
 
 package org.apache.flink.runtime.highavailability.zookeeper;
 
+import org.apache.flink.configuration.Configuration;
 import org.apache.flink.runtime.highavailability.ClientHighAvailabilityServices;
 import org.apache.flink.runtime.leaderretrieval.LeaderRetrievalService;
 import org.apache.flink.runtime.util.ZooKeeperUtils;
@@ -31,14 +32,18 @@ public class ZooKeeperClientHAServices implements ClientHighAvailabilityServices
 
     private final CuratorFramework client;
 
-    public ZooKeeperClientHAServices(@Nonnull CuratorFramework client) {
+    private final Configuration configuration;
+
+    public ZooKeeperClientHAServices(
+            @Nonnull CuratorFramework client, @Nonnull Configuration configuration) {
         this.client = client;
+        this.configuration = configuration;
     }
 
     @Override
     public LeaderRetrievalService getClusterRestEndpointLeaderRetriever() {
         return ZooKeeperUtils.createLeaderRetrievalService(
-                client, ZooKeeperUtils.getLeaderPathForRestServer());
+                client, ZooKeeperUtils.getLeaderPathForRestServer(), configuration);
     }
 
     @Override

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/highavailability/zookeeper/ZooKeeperHaServices.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/highavailability/zookeeper/ZooKeeperHaServices.java
@@ -137,7 +137,7 @@ public class ZooKeeperHaServices extends AbstractHaServices {
 
     @Override
     protected LeaderRetrievalService createLeaderRetrievalService(String leaderPath) {
-        return ZooKeeperUtils.createLeaderRetrievalService(client, leaderPath);
+        return ZooKeeperUtils.createLeaderRetrievalService(client, leaderPath, configuration);
     }
 
     @Override

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/leaderelection/ZooKeeperLeaderElectionDriver.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/leaderelection/ZooKeeperLeaderElectionDriver.java
@@ -271,10 +271,7 @@ public class ZooKeeperLeaderElectionDriver
                 LOG.debug("Connected to ZooKeeper quorum. Leader election can start.");
                 break;
             case SUSPENDED:
-                LOG.warn(
-                        "Connection to ZooKeeper suspended. The contender "
-                                + leaderContenderDescription
-                                + " no longer participates in the leader election.");
+                LOG.warn("Connection to ZooKeeper suspended, waiting for reconnection.");
                 break;
             case RECONNECTED:
                 LOG.info(

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/leaderretrieval/ZooKeeperLeaderRetrievalDriverFactory.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/leaderretrieval/ZooKeeperLeaderRetrievalDriverFactory.java
@@ -29,9 +29,17 @@ public class ZooKeeperLeaderRetrievalDriverFactory implements LeaderRetrievalDri
 
     private final String retrievalPath;
 
-    public ZooKeeperLeaderRetrievalDriverFactory(CuratorFramework client, String retrievalPath) {
+    private final ZooKeeperLeaderRetrievalDriver.LeaderInformationClearancePolicy
+            leaderInformationClearancePolicy;
+
+    public ZooKeeperLeaderRetrievalDriverFactory(
+            CuratorFramework client,
+            String retrievalPath,
+            ZooKeeperLeaderRetrievalDriver.LeaderInformationClearancePolicy
+                    leaderInformationClearancePolicy) {
         this.client = client;
         this.retrievalPath = retrievalPath;
+        this.leaderInformationClearancePolicy = leaderInformationClearancePolicy;
     }
 
     @Override
@@ -39,6 +47,10 @@ public class ZooKeeperLeaderRetrievalDriverFactory implements LeaderRetrievalDri
             LeaderRetrievalEventHandler leaderEventHandler, FatalErrorHandler fatalErrorHandler)
             throws Exception {
         return new ZooKeeperLeaderRetrievalDriver(
-                client, retrievalPath, leaderEventHandler, fatalErrorHandler);
+                client,
+                retrievalPath,
+                leaderEventHandler,
+                leaderInformationClearancePolicy,
+                fatalErrorHandler);
     }
 }

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/util/ZooKeeperUtils.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/util/ZooKeeperUtils.java
@@ -59,6 +59,7 @@ import org.apache.flink.shaded.curator4.org.apache.curator.framework.recipes.cac
 import org.apache.flink.shaded.curator4.org.apache.curator.framework.recipes.cache.TreeCache;
 import org.apache.flink.shaded.curator4.org.apache.curator.framework.recipes.cache.TreeCacheListener;
 import org.apache.flink.shaded.curator4.org.apache.curator.framework.recipes.cache.TreeCacheSelector;
+import org.apache.flink.shaded.curator4.org.apache.curator.framework.state.SessionConnectionStateErrorPolicy;
 import org.apache.flink.shaded.curator4.org.apache.curator.retry.ExponentialBackoffRetry;
 import org.apache.flink.shaded.zookeeper3.org.apache.zookeeper.ZooDefs;
 import org.apache.flink.shaded.zookeeper3.org.apache.zookeeper.data.ACL;
@@ -207,7 +208,7 @@ public class ZooKeeperUtils {
 
         LOG.info("Using '{}' as Zookeeper namespace.", rootWithNamespace);
 
-        CuratorFramework cf =
+        final CuratorFrameworkFactory.Builder curatorFrameworkBuilder =
                 CuratorFrameworkFactory.builder()
                         .connectString(zkQuorum)
                         .sessionTimeoutMs(sessionTimeout)
@@ -216,8 +217,14 @@ public class ZooKeeperUtils {
                         // Curator prepends a '/' manually and throws an Exception if the
                         // namespace starts with a '/'.
                         .namespace(trimStartingSlash(rootWithNamespace))
-                        .aclProvider(aclProvider)
-                        .build();
+                        .aclProvider(aclProvider);
+
+        if (configuration.get(HighAvailabilityOptions.ZOOKEEPER_TOLERATE_SUSPENDED_CONNECTIONS)) {
+            curatorFrameworkBuilder.connectionStateErrorPolicy(
+                    new SessionConnectionStateErrorPolicy());
+        }
+
+        CuratorFramework cf = curatorFrameworkBuilder.build();
 
         cf.start();
 
@@ -257,7 +264,7 @@ public class ZooKeeperUtils {
      */
     public static DefaultLeaderRetrievalService createLeaderRetrievalService(
             final CuratorFramework client) {
-        return createLeaderRetrievalService(client, "");
+        return createLeaderRetrievalService(client, "", new Configuration());
     }
 
     /**
@@ -266,11 +273,13 @@ public class ZooKeeperUtils {
      *
      * @param client The {@link CuratorFramework} ZooKeeper client to use
      * @param path The path for the leader retrieval
+     * @param configuration configuration for further config options
      * @return {@link DefaultLeaderRetrievalService} instance.
      */
     public static DefaultLeaderRetrievalService createLeaderRetrievalService(
-            final CuratorFramework client, final String path) {
-        return new DefaultLeaderRetrievalService(createLeaderRetrievalDriverFactory(client, path));
+            final CuratorFramework client, final String path, final Configuration configuration) {
+        return new DefaultLeaderRetrievalService(
+                createLeaderRetrievalDriverFactory(client, path, configuration));
     }
 
     /**
@@ -281,7 +290,7 @@ public class ZooKeeperUtils {
      */
     public static ZooKeeperLeaderRetrievalDriverFactory createLeaderRetrievalDriverFactory(
             final CuratorFramework client) {
-        return createLeaderRetrievalDriverFactory(client, "");
+        return createLeaderRetrievalDriverFactory(client, "", new Configuration());
     }
 
     /**
@@ -289,11 +298,26 @@ public class ZooKeeperUtils {
      *
      * @param client The {@link CuratorFramework} ZooKeeper client to use
      * @param path The path for the leader zNode
+     * @param configuration configuration for further config options
      * @return {@link LeaderRetrievalDriverFactory} instance.
      */
     public static ZooKeeperLeaderRetrievalDriverFactory createLeaderRetrievalDriverFactory(
-            final CuratorFramework client, final String path) {
-        return new ZooKeeperLeaderRetrievalDriverFactory(client, path);
+            final CuratorFramework client, final String path, final Configuration configuration) {
+        final ZooKeeperLeaderRetrievalDriver.LeaderInformationClearancePolicy
+                leaderInformationClearancePolicy;
+
+        if (configuration.get(HighAvailabilityOptions.ZOOKEEPER_TOLERATE_SUSPENDED_CONNECTIONS)) {
+            leaderInformationClearancePolicy =
+                    ZooKeeperLeaderRetrievalDriver.LeaderInformationClearancePolicy
+                            .ON_LOST_CONNECTION;
+        } else {
+            leaderInformationClearancePolicy =
+                    ZooKeeperLeaderRetrievalDriver.LeaderInformationClearancePolicy
+                            .ON_SUSPENDED_CONNECTION;
+        }
+
+        return new ZooKeeperLeaderRetrievalDriverFactory(
+                client, path, leaderInformationClearancePolicy);
     }
 
     /**

--- a/flink-runtime/src/test/java/org/apache/flink/runtime/leaderelection/ZooKeeperLeaderElectionConnectionHandlingTest.java
+++ b/flink-runtime/src/test/java/org/apache/flink/runtime/leaderelection/ZooKeeperLeaderElectionConnectionHandlingTest.java
@@ -1,0 +1,147 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.flink.runtime.leaderelection;
+
+import org.apache.flink.configuration.Configuration;
+import org.apache.flink.configuration.HighAvailabilityOptions;
+import org.apache.flink.core.testutils.OneShotLatch;
+import org.apache.flink.runtime.util.TestingFatalErrorHandlerResource;
+import org.apache.flink.runtime.util.ZooKeeperUtils;
+import org.apache.flink.runtime.zookeeper.ZooKeeperResource;
+import org.apache.flink.util.TestLogger;
+
+import org.apache.flink.shaded.curator4.org.apache.curator.framework.CuratorFramework;
+import org.apache.flink.shaded.curator4.org.apache.curator.framework.state.ConnectionState;
+import org.apache.flink.shaded.curator4.org.apache.curator.framework.state.ConnectionStateListener;
+
+import org.junit.Rule;
+import org.junit.Test;
+
+import java.util.UUID;
+
+import static org.junit.Assert.assertFalse;
+
+/**
+ * Test behaviors of {@link ZooKeeperLeaderElectionDriver} when losing the connection to ZooKeeper.
+ */
+public class ZooKeeperLeaderElectionConnectionHandlingTest extends TestLogger {
+
+    private static final String PATH = "/path";
+
+    @Rule public final ZooKeeperResource zooKeeperResource = new ZooKeeperResource();
+
+    @Rule
+    public final TestingFatalErrorHandlerResource fatalErrorHandlerResource =
+            new TestingFatalErrorHandlerResource();
+
+    @Test
+    public void testKeepLeadershipOnConnectionSuspended() throws Exception {
+        final Configuration configuration = new Configuration();
+        configuration.setString(
+                HighAvailabilityOptions.HA_ZOOKEEPER_QUORUM, zooKeeperResource.getConnectString());
+
+        CuratorFramework client = ZooKeeperUtils.startCuratorFramework(configuration);
+        LeaderElectionDriverFactory leaderElectionDriverFactory =
+                new ZooKeeperLeaderElectionDriverFactory(client, PATH);
+        DefaultLeaderElectionService leaderElectionService =
+                new DefaultLeaderElectionService(leaderElectionDriverFactory);
+
+        try {
+            final TestingConnectionStateListener connectionStateListener =
+                    new TestingConnectionStateListener();
+            client.getConnectionStateListenable().addListener(connectionStateListener);
+
+            final TestingContender contender = new TestingContender();
+            leaderElectionService.start(contender);
+
+            contender.awaitGrantLeadership();
+            zooKeeperResource.restart();
+            connectionStateListener.awaitSuspendedConnection();
+            connectionStateListener.awaitReconnectedConnection();
+            assertFalse(contender.hasRevokeLeadershipBeenTriggered());
+        } finally {
+            leaderElectionService.stop();
+            client.close();
+        }
+    }
+
+    private final class TestingContender implements LeaderContender {
+
+        private final OneShotLatch grantLeadershipLatch;
+        private final OneShotLatch revokeLeadershipLatch;
+
+        private TestingContender() {
+            this.grantLeadershipLatch = new OneShotLatch();
+            this.revokeLeadershipLatch = new OneShotLatch();
+        }
+
+        @Override
+        public void grantLeadership(UUID leaderSessionID) {
+            grantLeadershipLatch.trigger();
+        }
+
+        @Override
+        public void revokeLeadership() {
+            revokeLeadershipLatch.trigger();
+        }
+
+        @Override
+        public void handleError(Exception exception) {
+            fatalErrorHandlerResource.getFatalErrorHandler().onFatalError(exception);
+        }
+
+        public void awaitGrantLeadership() throws InterruptedException {
+            grantLeadershipLatch.await();
+        }
+
+        public boolean hasRevokeLeadershipBeenTriggered() {
+            return revokeLeadershipLatch.isTriggered();
+        }
+    }
+
+    private static final class TestingConnectionStateListener implements ConnectionStateListener {
+        private final OneShotLatch connectionSuspendedLatch;
+        private final OneShotLatch reconnectedLatch;
+
+        public TestingConnectionStateListener() {
+            this.connectionSuspendedLatch = new OneShotLatch();
+            this.reconnectedLatch = new OneShotLatch();
+        }
+
+        @Override
+        public void stateChanged(
+                CuratorFramework curatorFramework, ConnectionState connectionState) {
+            if (connectionState == ConnectionState.SUSPENDED) {
+                connectionSuspendedLatch.trigger();
+            }
+
+            if (connectionState == ConnectionState.RECONNECTED) {
+                reconnectedLatch.trigger();
+            }
+        }
+
+        public void awaitSuspendedConnection() throws InterruptedException {
+            connectionSuspendedLatch.await();
+        }
+
+        public void awaitReconnectedConnection() throws InterruptedException {
+            reconnectedLatch.await();
+        }
+    }
+}

--- a/flink-runtime/src/test/java/org/apache/flink/runtime/leaderelection/ZooKeeperLeaderRetrievalConnectionHandlingTest.java
+++ b/flink-runtime/src/test/java/org/apache/flink/runtime/leaderelection/ZooKeeperLeaderRetrievalConnectionHandlingTest.java
@@ -63,8 +63,6 @@ public class ZooKeeperLeaderRetrievalConnectionHandlingTest extends TestLogger {
 
     private TestingServer testingServer;
 
-    private Configuration config;
-
     private CuratorFramework zooKeeperClient;
 
     @Rule
@@ -75,8 +73,7 @@ public class ZooKeeperLeaderRetrievalConnectionHandlingTest extends TestLogger {
     public void before() throws Exception {
         testingServer = new TestingServer();
 
-        config = new Configuration();
-        config.setString(HighAvailabilityOptions.HA_MODE, "zookeeper");
+        final Configuration config = new Configuration();
         config.setString(
                 HighAvailabilityOptions.HA_ZOOKEEPER_QUORUM, testingServer.getConnectString());
 
@@ -115,7 +112,7 @@ public class ZooKeeperLeaderRetrievalConnectionHandlingTest extends TestLogger {
                     firstAddress,
                     is(nullValue()));
 
-            closeTestServer();
+            restartTestServer();
 
             // QueueLeaderElectionListener will be notified with an empty leader when ZK connection
             // is suspended
@@ -162,7 +159,7 @@ public class ZooKeeperLeaderRetrievalConnectionHandlingTest extends TestLogger {
                     firstAddress.get(),
                     is(leaderAddress));
 
-            closeTestServer();
+            restartTestServer();
 
             CompletableFuture<String> secondAddress = queueLeaderElectionListener.next();
             assertThat("The next result must not be missing.", secondAddress, is(notNullValue()));
@@ -208,7 +205,7 @@ public class ZooKeeperLeaderRetrievalConnectionHandlingTest extends TestLogger {
                     firstAddress.get(),
                     is(leaderAddress));
 
-            closeTestServer();
+            restartTestServer();
 
             // make sure that no new leader information is published
             assertThat(queueLeaderElectionListener.next(Duration.ofMillis(100L)), is(nullValue()));
@@ -350,6 +347,11 @@ public class ZooKeeperLeaderRetrievalConnectionHandlingTest extends TestLogger {
             testingServer.close();
             testingServer = null;
         }
+    }
+
+    private void restartTestServer() throws Exception {
+        Preconditions.checkNotNull(testingServer, "TestingServer needs to be initialized.")
+                .restart();
     }
 
     private static class QueueLeaderElectionListener implements LeaderRetrievalEventHandler {

--- a/flink-runtime/src/test/java/org/apache/flink/runtime/leaderelection/ZooKeeperLeaderRetrievalConnectionHandlingTest.java
+++ b/flink-runtime/src/test/java/org/apache/flink/runtime/leaderelection/ZooKeeperLeaderRetrievalConnectionHandlingTest.java
@@ -53,7 +53,7 @@ import java.util.concurrent.TimeUnit;
 import static org.hamcrest.CoreMatchers.is;
 import static org.hamcrest.CoreMatchers.notNullValue;
 import static org.hamcrest.CoreMatchers.nullValue;
-import static org.junit.Assert.assertThat;
+import static org.hamcrest.MatcherAssert.assertThat;
 
 /**
  * Tests for the error handling in case of a suspended connection to the ZooKeeper instance when

--- a/flink-runtime/src/test/java/org/apache/flink/runtime/zookeeper/ZooKeeperResource.java
+++ b/flink-runtime/src/test/java/org/apache/flink/runtime/zookeeper/ZooKeeperResource.java
@@ -71,4 +71,9 @@ public class ZooKeeperResource extends ExternalResource {
         Preconditions.checkNotNull(zooKeeperServer);
         zooKeeperServer.restart();
     }
+
+    public void stop() throws IOException {
+        Preconditions.checkNotNull(zooKeeperServer);
+        zooKeeperServer.stop();
+    }
 }


### PR DESCRIPTION
This is a revival of PR #15675. I added some more tests and fixed the problem in the `ZooKeeperLeaderRetrievalDriver` that we cleared the leader information on a `SUSPENDED` ZooKeeper connection.

cc @nicoweidner, @tisonkun, @mxm if you want to give it a pass.