### PR TITLE
[FLINK-22914][connector/kafka] Use FLIP-27 KafkaSource in table connector

### DIFF
--- a/docs/content.zh/docs/connectors/table/kafka.md
+++ b/docs/content.zh/docs/connectors/table/kafka.md
@@ -212,11 +212,10 @@ CREATE TABLE KafkaTable (
     </tr>
     <tr>
       <td><h5>properties.group.id</h5></td>
-      <td>required by source</td>
+      <td>对 source 可选，不适用于 sink</td>
       <td style="word-wrap: break-word;">（无）</td>
       <td>String</td>
-      <td>The id of the consumer group for Kafka source, optional for Kafka sink.</td>
-      <td>Kafka source 的 consumer 组 id，对于 Kafka sink 可选填。</td>
+      <td>Kafka source 的消费组 id。如果未指定消费组 ID，则会使用自动生成的 "KafkaSource-{tableIdentifier}" 作为消费组 ID。</td>
     </tr>
     <tr>
       <td><h5>properties.*</h5></td>

--- a/docs/content/docs/connectors/table/kafka.md
+++ b/docs/content/docs/connectors/table/kafka.md
@@ -1,3 +1,4 @@
+
 ---
 title: Kafka
 weight: 3
@@ -214,10 +215,10 @@ Connector Options
     </tr>
     <tr>
       <td><h5>properties.group.id</h5></td>
-      <td>required by source</td>
+      <td>optional for source, not applicable for sink</td>
       <td style="word-wrap: break-word;">(none)</td>
       <td>String</td>
-      <td>The id of the consumer group for Kafka source, optional for Kafka sink.</td>
+      <td>The id of the consumer group for Kafka source. If group ID is not specified, an automatically generated id "KafkaSource-{tableIdentifier}" will be used.</td>
     </tr>
     <tr>
       <td><h5>properties.*</h5></td>

--- a/flink-connectors/flink-connector-kafka/src/main/java/org/apache/flink/streaming/connectors/kafka/table/UpsertKafkaDynamicTableFactory.java
+++ b/flink-connectors/flink-connector-kafka/src/main/java/org/apache/flink/streaming/connectors/kafka/table/UpsertKafkaDynamicTableFactory.java
@@ -138,7 +138,8 @@ public class UpsertKafkaDynamicTableFactory
                 earliest,
                 Collections.emptyMap(),
                 0,
-                true);
+                true,
+                context.getObjectIdentifier().asSummaryString());
     }
 
     @Override


### PR DESCRIPTION
## What is the purpose of the change

This pull request introduces FLIP-27 KafkaSource in the Kafka table connector, and migrate legacy table source using FlinkKafkaConsumer to another identifier "kafka-legacy"

## Brief change log

- Replace the runtime provider of KafkaDynamicTableSource to KafkaSource
- Move legacy table source using FlinkKafkaConsumer to identifier "kafka-legacy" and "upsert-kafka-legacy"


## Verifying this change

This change is already covered by existing tests for Kafka table connectors

## Does this pull request potentially affect one of the following parts:

  - Dependencies (does it add or upgrade a dependency): (no)
  - The public API, i.e., is any changed class annotated with `@Public(Evolving)`: (no)
  - The serializers: (no)
  - The runtime per-record code paths (performance sensitive): (no)
  - Anything that affects deployment or recovery: JobManager (and its components), Checkpointing, Kubernetes/Yarn, ZooKeeper: (no)
  - The S3 file system connector: (no)

## Documentation

  - Does this pull request introduce a new feature? (no)
  - If yes, how is the feature documented? (not applicable)
