### PR TITLE
[FLINK-23616][python] Support to chain the Python DataStream operators when mixing use of Python Table API and Python DataStream API

### DIFF
--- a/flink-python/pyflink/datastream/tests/test_connectors.py
+++ b/flink-python/pyflink/datastream/tests/test_connectors.py
@@ -28,8 +28,8 @@ from pyflink.datastream.connectors import FlinkKafkaConsumer, FlinkKafkaProducer
 from pyflink.datastream.tests.test_util import DataStreamTestSinkFunction
 from pyflink.java_gateway import get_gateway
 from pyflink.testing.test_case_utils import PyFlinkTestCase, _load_specific_flink_module_jars, \
-    get_private_field, invoke_java_object_method
-from pyflink.util.java_utils import load_java_class
+    invoke_java_object_method
+from pyflink.util.java_utils import load_java_class, get_field_value
 
 
 class FlinkKafkaTest(PyFlinkTestCase):
@@ -61,22 +61,22 @@ class FlinkKafkaTest(PyFlinkTestCase):
         flink_kafka_consumer.set_start_from_earliest()
         flink_kafka_consumer.set_commit_offsets_on_checkpoints(True)
 
-        j_properties = get_private_field(flink_kafka_consumer.get_java_function(), 'properties')
+        j_properties = get_field_value(flink_kafka_consumer.get_java_function(), 'properties')
         self.assertEqual('localhost:9092', j_properties.getProperty('bootstrap.servers'))
         self.assertEqual('test_group', j_properties.getProperty('group.id'))
-        self.assertTrue(get_private_field(flink_kafka_consumer.get_java_function(),
-                                          'enableCommitOnCheckpoints'))
-        j_start_up_mode = get_private_field(flink_kafka_consumer.get_java_function(), 'startupMode')
+        self.assertTrue(get_field_value(flink_kafka_consumer.get_java_function(),
+                                        'enableCommitOnCheckpoints'))
+        j_start_up_mode = get_field_value(flink_kafka_consumer.get_java_function(), 'startupMode')
 
-        j_deserializer = get_private_field(flink_kafka_consumer.get_java_function(), 'deserializer')
+        j_deserializer = get_field_value(flink_kafka_consumer.get_java_function(), 'deserializer')
         j_deserialize_type_info = invoke_java_object_method(j_deserializer, "getProducedType")
         deserialize_type_info = typeinfo._from_java_type(j_deserialize_type_info)
         self.assertTrue(deserialize_type_info == type_info)
         self.assertTrue(j_start_up_mode.equals(get_gateway().jvm
                                                .org.apache.flink.streaming.connectors
                                                .kafka.config.StartupMode.EARLIEST))
-        j_topic_desc = get_private_field(flink_kafka_consumer.get_java_function(),
-                                         'topicsDescriptor')
+        j_topic_desc = get_field_value(flink_kafka_consumer.get_java_function(),
+                                       'topicsDescriptor')
         j_topics = invoke_java_object_method(j_topic_desc, 'getFixedTopics')
         self.assertEqual(['test_source_topic'], list(j_topics))
 
@@ -86,12 +86,12 @@ class FlinkKafkaTest(PyFlinkTestCase):
         flink_kafka_producer = flink_kafka_producer_clz(sink_topic, serialization_schema, props)
         flink_kafka_producer.set_write_timestamp_to_kafka(False)
 
-        j_producer_config = get_private_field(flink_kafka_producer.get_java_function(),
-                                              'producerConfig')
+        j_producer_config = get_field_value(flink_kafka_producer.get_java_function(),
+                                            'producerConfig')
         self.assertEqual('localhost:9092', j_producer_config.getProperty('bootstrap.servers'))
         self.assertEqual('test_group', j_producer_config.getProperty('group.id'))
-        self.assertFalse(get_private_field(flink_kafka_producer.get_java_function(),
-                                           'writeTimestampToKafka'))
+        self.assertFalse(get_field_value(flink_kafka_producer.get_java_function(),
+                                         'writeTimestampToKafka'))
 
     def tearDown(self):
         # Change the ClassLoader back to the cached ContextClassLoader after the test case finished.
@@ -123,11 +123,11 @@ class FlinkJdbcSinkTest(PyFlinkTestCase):
         ds.add_sink(jdbc_sink).name('jdbc sink')
         plan = eval(self.env.get_execution_plan())
         self.assertEqual('Sink: jdbc sink', plan['nodes'][1]['type'])
-        j_output_format = get_private_field(jdbc_sink.get_java_function(), 'outputFormat')
+        j_output_format = get_field_value(jdbc_sink.get_java_function(), 'outputFormat')
 
         connection_options = JdbcConnectionOptions(
-            get_private_field(get_private_field(j_output_format, 'connectionProvider'),
-                              'jdbcOptions'))
+            get_field_value(get_field_value(j_output_format, 'connectionProvider'),
+                            'jdbcOptions'))
         self.assertEqual(jdbc_connection_options.get_db_url(), connection_options.get_db_url())
         self.assertEqual(jdbc_connection_options.get_driver_name(),
                          connection_options.get_driver_name())
@@ -135,7 +135,7 @@ class FlinkJdbcSinkTest(PyFlinkTestCase):
         self.assertEqual(jdbc_connection_options.get_user_name(),
                          connection_options.get_user_name())
 
-        exec_options = JdbcExecutionOptions(get_private_field(j_output_format, 'executionOptions'))
+        exec_options = JdbcExecutionOptions(get_field_value(j_output_format, 'executionOptions'))
         self.assertEqual(jdbc_execution_options.get_batch_interval_ms(),
                          exec_options.get_batch_interval_ms())
         self.assertEqual(jdbc_execution_options.get_batch_size(),

--- a/flink-python/pyflink/table/tests/test_environment_settings.py
+++ b/flink-python/pyflink/table/tests/test_environment_settings.py
@@ -19,7 +19,8 @@ from pyflink.java_gateway import get_gateway
 
 from pyflink.common import Configuration
 from pyflink.table import EnvironmentSettings
-from pyflink.testing.test_case_utils import PyFlinkTestCase, get_private_field
+from pyflink.testing.test_case_utils import PyFlinkTestCase
+from pyflink.util.java_utils import get_field_value
 
 
 class EnvironmentSettingsTests(PyFlinkTestCase):
@@ -120,7 +121,7 @@ class EnvironmentSettingsTests(PyFlinkTestCase):
         CLASS_NAME = gateway.jvm.EnvironmentSettings.CLASS_NAME
 
         builder = EnvironmentSettings.new_instance()
-        BLINK_PLANNER_FACTORY = get_private_field(builder._j_builder, "BLINK_PLANNER_FACTORY")
+        BLINK_PLANNER_FACTORY = get_field_value(builder._j_builder, "BLINK_PLANNER_FACTORY")
 
         self.assertEqual(
             settings._j_environment_settings.toPlannerProperties()[CLASS_NAME],

--- a/flink-python/pyflink/table/tests/test_table_environment_api.py
+++ b/flink-python/pyflink/table/tests/test_table_environment_api.py
@@ -295,7 +295,8 @@ class DataStreamConversionTestCases(PyFlinkTestCase):
         expected = ['+I[1, Hi, Hello]', '+I[2, Hello, Hi]']
         self.assert_equals(result, expected)
 
-        ds = ds.map(lambda x: x, Types.ROW([Types.INT(), Types.STRING(), Types.STRING()]))
+        ds = ds.map(lambda x: x, Types.ROW([Types.INT(), Types.STRING(), Types.STRING()])) \
+               .map(lambda x: x, Types.ROW([Types.INT(), Types.STRING(), Types.STRING()]))
         table = t_env.from_data_stream(ds, col('a'), col('b'), col('c'))
         t_env.register_table_sink("ExprSink",
                                   source_sink_utils.TestAppendSink(field_names, field_types))

--- a/flink-python/pyflink/testing/test_case_utils.py
+++ b/flink-python/pyflink/testing/test_case_utils.py
@@ -26,7 +26,6 @@ import unittest
 from abc import abstractmethod
 
 from py4j.java_gateway import JavaObject
-from py4j.protocol import Py4JJavaError
 
 from pyflink.common import JobExecutionResult
 from pyflink.datastream.execution_mode import RuntimeExecutionMode
@@ -44,23 +43,6 @@ else:
     log_level = logging.INFO
 logging.basicConfig(stream=sys.stdout, level=log_level,
                     format="%(asctime)s - %(name)s - %(levelname)s - %(message)s")
-
-
-def get_private_field(java_obj, field_name):
-    try:
-        field = java_obj.getClass().getDeclaredField(field_name)
-        field.setAccessible(True)
-        return field.get(java_obj)
-    except Py4JJavaError:
-        cls = java_obj.getClass()
-        while cls.getSuperclass() is not None:
-            cls = cls.getSuperclass()
-            try:
-                field = cls.getDeclaredField(field_name)
-                field.setAccessible(True)
-                return field.get(java_obj)
-            except Py4JJavaError:
-                pass
 
 
 def exec_insert_table(table, table_path) -> JobExecutionResult:

--- a/flink-python/pyflink/util/java_utils.py
+++ b/flink-python/pyflink/util/java_utils.py
@@ -19,6 +19,7 @@
 from datetime import timedelta
 
 from py4j.java_gateway import JavaClass, get_java_class, JavaObject
+from py4j.protocol import Py4JJavaError
 
 from pyflink.java_gateway import get_gateway
 
@@ -89,6 +90,27 @@ def get_j_env_configuration(j_env):
         field = env_clazz.getDeclaredField("configuration")
         field.setAccessible(True)
         return field.get(j_env)
+
+
+def get_field_value(java_obj, field_name):
+    field = get_field(java_obj.getClass(), field_name)
+    return field.get(java_obj)
+
+
+def get_field(cls, field_name):
+    try:
+        field = cls.getDeclaredField(field_name)
+        field.setAccessible(True)
+        return field
+    except Py4JJavaError:
+        while cls.getSuperclass() is not None:
+            cls = cls.getSuperclass()
+            try:
+                field = cls.getDeclaredField(field_name)
+                field.setAccessible(True)
+                return field
+            except Py4JJavaError:
+                pass
 
 
 def invoke_method(obj, object_type, method_name, args=None, arg_types=None):

--- a/flink-python/src/main/java/org/apache/flink/python/util/PythonConfigUtil.java
+++ b/flink-python/src/main/java/org/apache/flink/python/util/PythonConfigUtil.java
@@ -25,13 +25,11 @@ import org.apache.flink.configuration.Configuration;
 import org.apache.flink.core.memory.ManagedMemoryUseCase;
 import org.apache.flink.python.PythonConfig;
 import org.apache.flink.streaming.api.environment.StreamExecutionEnvironment;
-import org.apache.flink.streaming.api.graph.StreamGraph;
 import org.apache.flink.streaming.api.operators.SimpleOperatorFactory;
 import org.apache.flink.streaming.api.operators.StreamOperatorFactory;
 import org.apache.flink.streaming.api.operators.python.AbstractDataStreamPythonFunctionOperator;
 import org.apache.flink.streaming.api.operators.python.AbstractOneInputPythonFunctionOperator;
 import org.apache.flink.streaming.api.operators.python.AbstractPythonFunctionOperator;
-import org.apache.flink.streaming.api.operators.python.PythonProcessOperator;
 import org.apache.flink.streaming.api.transformations.AbstractMultipleInputTransformation;
 import org.apache.flink.streaming.api.transformations.OneInputTransformation;
 import org.apache.flink.streaming.api.transformations.PartitionTransformation;
@@ -40,9 +38,15 @@ import org.apache.flink.streaming.runtime.partitioner.ForwardPartitioner;
 import org.apache.flink.table.api.TableConfig;
 import org.apache.flink.table.api.TableException;
 
+import org.apache.flink.shaded.guava30.com.google.common.collect.Queues;
+import org.apache.flink.shaded.guava30.com.google.common.collect.Sets;
+
 import java.lang.reflect.Field;
 import java.lang.reflect.InvocationTargetException;
 import java.util.List;
+import java.util.Optional;
+import java.util.Queue;
+import java.util.Set;
 
 /**
  * A Util class to get the {@link StreamExecutionEnvironment} configuration and merged configuration
@@ -90,21 +94,6 @@ public class PythonConfigUtil {
         return (Configuration) configurationField.get(env);
     }
 
-    /**
-     * Generate a {@link StreamGraph} for transformations maintained by current {@link
-     * StreamExecutionEnvironment}, and reset the merged env configurations with dependencies to
-     * every {@link AbstractOneInputPythonFunctionOperator}. It is an idempotent operation that can
-     * be call multiple times. Remember that only when need to execute the StreamGraph can we set
-     * the clearTransformations to be True.
-     */
-    public static StreamGraph generateStreamGraphWithDependencies(
-            StreamExecutionEnvironment env, boolean clearTransformations)
-            throws IllegalAccessException, InvocationTargetException, NoSuchFieldException {
-        configPythonOperator(env);
-
-        return env.getStreamGraph(clearTransformations);
-    }
-
     @SuppressWarnings("unchecked")
     public static void configPythonOperator(StreamExecutionEnvironment env)
             throws IllegalAccessException, InvocationTargetException, NoSuchFieldException {
@@ -132,8 +121,6 @@ public class PythonConfigUtil {
                 }
             }
         }
-
-        setPartitionCustomOperatorNumPartitions(transformations);
     }
 
     public static Configuration getMergedConfig(
@@ -175,6 +162,9 @@ public class PythonConfigUtil {
     private static void alignTransformation(Transformation<?> transformation)
             throws NoSuchFieldException, IllegalAccessException {
         String transformName = transformation.getName();
+        if (transformation.getInputs().isEmpty()) {
+            return;
+        }
         Transformation<?> inputTransformation = transformation.getInputs().get(0);
         String inputTransformName = inputTransformation.getName();
         if (inputTransformName.equals(KEYED_STREAM_VALUE_OPERATOR_NAME)) {
@@ -288,22 +278,53 @@ public class PythonConfigUtil {
         return new PythonConfig(mergedConfig);
     }
 
-    private static void setPartitionCustomOperatorNumPartitions(
+    public static void setPartitionCustomOperatorNumPartitions(
             List<Transformation<?>> transformations) {
         // Update the numPartitions of PartitionCustomOperator after aligned all operators.
-        for (Transformation<?> transformation : transformations) {
-            Transformation<?> firstInputTransformation = transformation.getInputs().get(0);
-            if (firstInputTransformation instanceof PartitionTransformation) {
-                firstInputTransformation = firstInputTransformation.getInputs().get(0);
-            }
-            AbstractPythonFunctionOperator<?> pythonFunctionOperator =
-                    getPythonOperator(firstInputTransformation);
-            if (pythonFunctionOperator instanceof PythonProcessOperator) {
-                PythonProcessOperator<?, ?> partitionCustomFunctionOperator =
-                        (PythonProcessOperator<?, ?>) pythonFunctionOperator;
+        final Set<Transformation<?>> alreadyTransformed = Sets.newIdentityHashSet();
+        final Queue<Transformation<?>> toTransformQueue = Queues.newArrayDeque(transformations);
+        while (!toTransformQueue.isEmpty()) {
+            final Transformation<?> transformation = toTransformQueue.poll();
+            if (!alreadyTransformed.contains(transformation)
+                    && !(transformation instanceof PartitionTransformation)) {
+                alreadyTransformed.add(transformation);
 
-                partitionCustomFunctionOperator.setNumPartitions(transformation.getParallelism());
+                getNonPartitionTransformationInput(transformation)
+                        .ifPresent(
+                                input -> {
+                                    AbstractPythonFunctionOperator<?> pythonFunctionOperator =
+                                            getPythonOperator(input);
+                                    if (pythonFunctionOperator
+                                            instanceof AbstractDataStreamPythonFunctionOperator) {
+                                        AbstractDataStreamPythonFunctionOperator<?>
+                                                pythonDataStreamFunctionOperator =
+                                                        (AbstractDataStreamPythonFunctionOperator<
+                                                                        ?>)
+                                                                pythonFunctionOperator;
+                                        if (pythonDataStreamFunctionOperator
+                                                .containsPartitionCustom()) {
+                                            pythonDataStreamFunctionOperator.setNumPartitions(
+                                                    transformation.getParallelism());
+                                        }
+                                    }
+                                });
+
+                toTransformQueue.addAll(transformation.getInputs());
             }
+        }
+    }
+
+    private static Optional<Transformation<?>> getNonPartitionTransformationInput(
+            Transformation<?> transformation) {
+        if (transformation.getInputs().size() != 1) {
+            return Optional.empty();
+        }
+
+        final Transformation<?> inputTransformation = transformation.getInputs().get(0);
+        if (inputTransformation instanceof PartitionTransformation) {
+            return getNonPartitionTransformationInput(inputTransformation);
+        } else {
+            return Optional.of(inputTransformation);
         }
     }
 }

--- a/flink-python/src/main/java/org/apache/flink/streaming/api/functions/python/DataStreamPythonFunctionInfo.java
+++ b/flink-python/src/main/java/org/apache/flink/streaming/api/functions/python/DataStreamPythonFunctionInfo.java
@@ -44,4 +44,15 @@ public class DataStreamPythonFunctionInfo extends PythonFunctionInfo {
     public int getFunctionType() {
         return this.functionType;
     }
+
+    public DataStreamPythonFunctionInfo copy() {
+        if (getInputs().length == 0) {
+            return new DataStreamPythonFunctionInfo(getPythonFunction(), this.functionType);
+        } else {
+            return new DataStreamPythonFunctionInfo(
+                    getPythonFunction(),
+                    ((DataStreamPythonFunctionInfo) getInputs()[0]).copy(),
+                    this.functionType);
+        }
+    }
 }

--- a/flink-python/src/main/java/org/apache/flink/streaming/api/operators/python/AbstractDataStreamPythonFunctionOperator.java
+++ b/flink-python/src/main/java/org/apache/flink/streaming/api/operators/python/AbstractDataStreamPythonFunctionOperator.java
@@ -26,12 +26,28 @@ import org.apache.flink.streaming.api.functions.python.DataStreamPythonFunctionI
 import org.apache.flink.table.functions.python.PythonEnv;
 import org.apache.flink.util.Preconditions;
 
+import javax.annotation.Nullable;
+
+import java.util.HashMap;
+import java.util.Map;
+
 /** Base class for all Python DataStream operators. */
 @Internal
 public abstract class AbstractDataStreamPythonFunctionOperator<OUT>
         extends AbstractPythonFunctionOperator<OUT> implements ResultTypeQueryable<OUT> {
 
     private static final long serialVersionUID = 1L;
+
+    private static final String NUM_PARTITIONS = "NUM_PARTITIONS";
+
+    /** The number of partitions for the partition custom function. */
+    @Nullable private Integer numPartitions = null;
+
+    /**
+     * Whether it contains partition custom function. If true, the variable numPartitions should be
+     * set and the value should be set to the parallelism of the downstream operator.
+     */
+    private boolean containsPartitionCustom;
 
     /** The serialized python function to be executed. */
     private final DataStreamPythonFunctionInfo pythonFunctionInfo;
@@ -60,6 +76,26 @@ public abstract class AbstractDataStreamPythonFunctionOperator<OUT>
 
     public abstract <T> AbstractDataStreamPythonFunctionOperator<T> copy(
             DataStreamPythonFunctionInfo pythonFunctionInfo, TypeInformation<T> outputTypeInfo);
+
+    public Map<String, String> getInternalParameters() {
+        Map<String, String> internalParameters = new HashMap<>();
+        if (numPartitions != null) {
+            internalParameters.put(NUM_PARTITIONS, String.valueOf(numPartitions));
+        }
+        return internalParameters;
+    }
+
+    public void setNumPartitions(int numPartitions) {
+        this.numPartitions = numPartitions;
+    }
+
+    public void setContainsPartitionCustom(boolean containsPartitionCustom) {
+        this.containsPartitionCustom = containsPartitionCustom;
+    }
+
+    public boolean containsPartitionCustom() {
+        return this.containsPartitionCustom;
+    }
 
     // ----------------------------------------------------------------------
     // Getters

--- a/flink-python/src/main/java/org/apache/flink/streaming/api/operators/python/AbstractOneInputPythonFunctionOperator.java
+++ b/flink-python/src/main/java/org/apache/flink/streaming/api/operators/python/AbstractOneInputPythonFunctionOperator.java
@@ -38,7 +38,6 @@ import org.apache.flink.streaming.api.utils.PythonTypeUtils;
 import org.apache.flink.types.Row;
 import org.apache.flink.util.Preconditions;
 
-import java.util.Collections;
 import java.util.Map;
 
 import static org.apache.flink.streaming.api.utils.ProtoUtils.createRawTypeCoderInfoDescriptorProto;
@@ -145,10 +144,6 @@ public abstract class AbstractOneInputPythonFunctionOperator<IN, OUT>
         elementCount++;
         checkInvokeFinishBundleByCount();
         emitResults();
-    }
-
-    public Map<String, String> getInternalParameters() {
-        return Collections.emptyMap();
     }
 
     public FlinkFnApi.CoderInfoDescriptor createInputCoderInfoDescriptor() {

--- a/flink-python/src/main/java/org/apache/flink/streaming/api/operators/python/PythonCoProcessOperator.java
+++ b/flink-python/src/main/java/org/apache/flink/streaming/api/operators/python/PythonCoProcessOperator.java
@@ -29,8 +29,6 @@ import org.apache.flink.streaming.api.utils.ProtoUtils;
 import org.apache.flink.streaming.api.watermark.Watermark;
 import org.apache.flink.streaming.runtime.streamrecord.StreamRecord;
 
-import java.util.Collections;
-
 import static org.apache.flink.python.Constants.STATELESS_FUNCTION_URN;
 import static org.apache.flink.streaming.api.utils.PythonOperatorUtils.inBatchExecutionMode;
 
@@ -45,7 +43,7 @@ import static org.apache.flink.streaming.api.utils.PythonOperatorUtils.inBatchEx
 public class PythonCoProcessOperator<IN1, IN2, OUT>
         extends AbstractTwoInputPythonFunctionOperator<IN1, IN2, OUT> {
 
-    private static final long serialVersionUID = 1L;
+    private static final long serialVersionUID = 2L;
 
     /** We listen to this ourselves because we don't have an {@link InternalTimerService}. */
     private transient long currentWatermark;
@@ -74,7 +72,7 @@ public class PythonCoProcessOperator<IN1, IN2, OUT>
                 ProtoUtils.createUserDefinedDataStreamFunctionProtos(
                         getPythonFunctionInfo(),
                         getRuntimeContext(),
-                        Collections.emptyMap(),
+                        getInternalParameters(),
                         inBatchExecutionMode(getKeyedStateBackend())),
                 getJobOptions(),
                 getFlinkMetricContainer(),

--- a/flink-python/src/main/java/org/apache/flink/streaming/api/operators/python/PythonKeyedCoProcessOperator.java
+++ b/flink-python/src/main/java/org/apache/flink/streaming/api/operators/python/PythonKeyedCoProcessOperator.java
@@ -40,8 +40,6 @@ import org.apache.flink.streaming.api.utils.PythonTypeUtils;
 import org.apache.flink.streaming.runtime.streamrecord.StreamRecord;
 import org.apache.flink.types.Row;
 
-import java.util.Collections;
-
 import static org.apache.flink.python.Constants.STATEFUL_FUNCTION_URN;
 import static org.apache.flink.streaming.api.operators.python.timer.TimerUtils.createTimerDataCoderInfoDescriptorProto;
 import static org.apache.flink.streaming.api.operators.python.timer.TimerUtils.createTimerDataTypeInfo;
@@ -53,7 +51,7 @@ public class PythonKeyedCoProcessOperator<OUT>
         extends AbstractTwoInputPythonFunctionOperator<Row, Row, OUT>
         implements Triggerable<Row, VoidNamespace> {
 
-    private static final long serialVersionUID = 1L;
+    private static final long serialVersionUID = 2L;
 
     /** TimerService for current operator to register or fire timer. */
     private transient InternalTimerService<VoidNamespace> internalTimerService;
@@ -112,7 +110,7 @@ public class PythonKeyedCoProcessOperator<OUT>
                 ProtoUtils.createUserDefinedDataStreamStatefulFunctionProtos(
                         getPythonFunctionInfo(),
                         getRuntimeContext(),
-                        Collections.emptyMap(),
+                        getInternalParameters(),
                         keyTypeInfo,
                         inBatchExecutionMode(getKeyedStateBackend())),
                 getJobOptions(),

--- a/flink-python/src/main/java/org/apache/flink/streaming/api/operators/python/PythonKeyedProcessOperator.java
+++ b/flink-python/src/main/java/org/apache/flink/streaming/api/operators/python/PythonKeyedProcessOperator.java
@@ -40,8 +40,6 @@ import org.apache.flink.streaming.api.utils.PythonTypeUtils;
 import org.apache.flink.streaming.runtime.streamrecord.StreamRecord;
 import org.apache.flink.types.Row;
 
-import java.util.Collections;
-
 import static org.apache.flink.python.Constants.STATEFUL_FUNCTION_URN;
 import static org.apache.flink.streaming.api.operators.python.timer.TimerUtils.createTimerDataCoderInfoDescriptorProto;
 import static org.apache.flink.streaming.api.operators.python.timer.TimerUtils.createTimerDataTypeInfo;
@@ -57,7 +55,7 @@ public class PythonKeyedProcessOperator<OUT>
         extends AbstractOneInputPythonFunctionOperator<Row, OUT>
         implements Triggerable<Row, Object> {
 
-    private static final long serialVersionUID = 1L;
+    private static final long serialVersionUID = 2L;
 
     /** The TypeSerializer of the namespace. */
     private final TypeSerializer namespaceSerializer;
@@ -142,7 +140,7 @@ public class PythonKeyedProcessOperator<OUT>
                 ProtoUtils.createUserDefinedDataStreamStatefulFunctionProtos(
                         getPythonFunctionInfo(),
                         getRuntimeContext(),
-                        Collections.emptyMap(),
+                        getInternalParameters(),
                         keyTypeInfo,
                         inBatchExecutionMode(getKeyedStateBackend())),
                 getJobOptions(),

--- a/flink-python/src/main/java/org/apache/flink/streaming/api/operators/python/PythonProcessOperator.java
+++ b/flink-python/src/main/java/org/apache/flink/streaming/api/operators/python/PythonProcessOperator.java
@@ -30,11 +30,6 @@ import org.apache.flink.streaming.api.utils.ProtoUtils;
 import org.apache.flink.streaming.api.watermark.Watermark;
 import org.apache.flink.streaming.runtime.streamrecord.StreamRecord;
 
-import javax.annotation.Nullable;
-
-import java.util.HashMap;
-import java.util.Map;
-
 import static org.apache.flink.python.Constants.STATELESS_FUNCTION_URN;
 import static org.apache.flink.streaming.api.utils.PythonOperatorUtils.inBatchExecutionMode;
 
@@ -46,11 +41,7 @@ import static org.apache.flink.streaming.api.utils.PythonOperatorUtils.inBatchEx
 public class PythonProcessOperator<IN, OUT>
         extends AbstractOneInputPythonFunctionOperator<IN, OUT> {
 
-    private static final long serialVersionUID = 1L;
-
-    private static final String NUM_PARTITIONS = "NUM_PARTITIONS";
-
-    @Nullable private Integer numPartitions = null;
+    private static final long serialVersionUID = 2L;
 
     /** We listen to this ourselves because we don't have an {@link InternalTimerService}. */
     private transient long currentWatermark;
@@ -112,20 +103,6 @@ public class PythonProcessOperator<IN, OUT>
     public void processWatermark(Watermark mark) throws Exception {
         super.processWatermark(mark);
         currentWatermark = mark.getTimestamp();
-    }
-
-    @Override
-    public Map<String, String> getInternalParameters() {
-        Map<String, String> internalParameters = super.getInternalParameters();
-        if (numPartitions != null) {
-            internalParameters = new HashMap<>(internalParameters);
-            internalParameters.put(NUM_PARTITIONS, String.valueOf(numPartitions));
-        }
-        return internalParameters;
-    }
-
-    public void setNumPartitions(int numPartitions) {
-        this.numPartitions = numPartitions;
     }
 
     @Override

--- a/flink-python/src/main/java/org/apache/flink/table/executor/python/ChainingOptimizingExecutor.java
+++ b/flink-python/src/main/java/org/apache/flink/table/executor/python/ChainingOptimizingExecutor.java
@@ -1,0 +1,75 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.flink.table.executor.python;
+
+import org.apache.flink.annotation.Internal;
+import org.apache.flink.api.common.JobExecutionResult;
+import org.apache.flink.api.dag.Pipeline;
+import org.apache.flink.api.dag.Transformation;
+import org.apache.flink.configuration.ReadableConfig;
+import org.apache.flink.core.execution.JobClient;
+import org.apache.flink.python.PythonOptions;
+import org.apache.flink.python.chain.PythonOperatorChainingOptimizer;
+import org.apache.flink.python.util.PythonConfigUtil;
+import org.apache.flink.table.delegation.Executor;
+import org.apache.flink.util.Preconditions;
+
+import java.util.List;
+
+/** {@link Executor} which will perform chaining optimization before generating the StreamGraph. */
+@Internal
+public class ChainingOptimizingExecutor implements Executor {
+
+    private final Executor executor;
+
+    public ChainingOptimizingExecutor(Executor executor) {
+        this.executor = Preconditions.checkNotNull(executor);
+    }
+
+    @Override
+    public ReadableConfig getConfiguration() {
+        return executor.getConfiguration();
+    }
+
+    @Override
+    public Pipeline createPipeline(
+            List<Transformation<?>> transformations,
+            ReadableConfig configuration,
+            String defaultJobName) {
+        List<Transformation<?>> chainedTransformations = transformations;
+        if (configuration
+                .getOptional(PythonOptions.PYTHON_OPERATOR_CHAINING_ENABLED)
+                .orElse(getConfiguration().get(PythonOptions.PYTHON_OPERATOR_CHAINING_ENABLED))) {
+            chainedTransformations = PythonOperatorChainingOptimizer.optimize(transformations);
+        }
+
+        PythonConfigUtil.setPartitionCustomOperatorNumPartitions(chainedTransformations);
+        return executor.createPipeline(chainedTransformations, configuration, defaultJobName);
+    }
+
+    @Override
+    public JobExecutionResult execute(Pipeline pipeline) throws Exception {
+        return executor.execute(pipeline);
+    }
+
+    @Override
+    public JobClient executeAsync(Pipeline pipeline) throws Exception {
+        return executor.executeAsync(pipeline);
+    }
+}

--- a/flink-python/src/test/java/org/apache/flink/python/chain/PythonOperatorChainingOptimizerTest.java
+++ b/flink-python/src/test/java/org/apache/flink/python/chain/PythonOperatorChainingOptimizerTest.java
@@ -51,7 +51,7 @@ import static org.mockito.Mockito.mock;
 public class PythonOperatorChainingOptimizerTest {
 
     @Test
-    public void testChainedTransformationPropertiesCorrectlySet() throws Exception {
+    public void testChainedTransformationPropertiesCorrectlySet() {
         PythonKeyedProcessOperator<?> keyedProcessOperator =
                 createKeyedProcessOperator(
                         "f1", new RowTypeInfo(Types.INT(), Types.INT()), Types.STRING());
@@ -97,9 +97,8 @@ public class PythonOperatorChainingOptimizerTest {
         transformations.add(keyedProcessTransformation);
         transformations.add(processTransformation);
 
-        PythonOperatorChainingOptimizer optimizer =
-                new PythonOperatorChainingOptimizer(transformations, true);
-        List<Transformation<?>> optimized = optimizer.optimize();
+        List<Transformation<?>> optimized =
+                PythonOperatorChainingOptimizer.optimize(transformations);
         assertEquals(2, optimized.size());
 
         OneInputTransformation<?, ?> chainedTransformation =
@@ -139,7 +138,7 @@ public class PythonOperatorChainingOptimizerTest {
     }
 
     @Test
-    public void testChainingMultipleOperators() throws Exception {
+    public void testChainingMultipleOperators() {
         PythonKeyedProcessOperator<?> keyedProcessOperator =
                 createKeyedProcessOperator(
                         "f1", new RowTypeInfo(Types.INT(), Types.INT()), Types.STRING());
@@ -177,9 +176,8 @@ public class PythonOperatorChainingOptimizerTest {
         transformations.add(processTransformation1);
         transformations.add(processTransformation2);
 
-        PythonOperatorChainingOptimizer optimizer =
-                new PythonOperatorChainingOptimizer(transformations, true);
-        List<Transformation<?>> optimized = optimizer.optimize();
+        List<Transformation<?>> optimized =
+                PythonOperatorChainingOptimizer.optimize(transformations);
         assertEquals(2, optimized.size());
 
         OneInputTransformation<?, ?> chainedTransformation =
@@ -197,7 +195,7 @@ public class PythonOperatorChainingOptimizerTest {
     }
 
     @Test
-    public void testChainingNonKeyedOperators() throws Exception {
+    public void testChainingNonKeyedOperators() {
         PythonProcessOperator<?, ?> processOperator1 =
                 createProcessOperator(
                         "f1", new RowTypeInfo(Types.INT(), Types.INT()), Types.STRING());
@@ -225,9 +223,8 @@ public class PythonOperatorChainingOptimizerTest {
         transformations.add(processTransformation1);
         transformations.add(processTransformation2);
 
-        PythonOperatorChainingOptimizer optimizer =
-                new PythonOperatorChainingOptimizer(transformations, true);
-        List<Transformation<?>> optimized = optimizer.optimize();
+        List<Transformation<?>> optimized =
+                PythonOperatorChainingOptimizer.optimize(transformations);
         assertEquals(2, optimized.size());
 
         OneInputTransformation<?, ?> chainedTransformation =
@@ -244,7 +241,7 @@ public class PythonOperatorChainingOptimizerTest {
     }
 
     @Test
-    public void testContinuousKeyedOperators() throws Exception {
+    public void testContinuousKeyedOperators() {
         PythonKeyedProcessOperator<?> keyedProcessOperator1 =
                 createKeyedProcessOperator(
                         "f1",
@@ -275,9 +272,8 @@ public class PythonOperatorChainingOptimizerTest {
         transformations.add(processTransformation1);
         transformations.add(processTransformation2);
 
-        PythonOperatorChainingOptimizer optimizer =
-                new PythonOperatorChainingOptimizer(transformations, true);
-        List<Transformation<?>> optimized = optimizer.optimize();
+        List<Transformation<?>> optimized =
+                PythonOperatorChainingOptimizer.optimize(transformations);
         assertEquals(3, optimized.size());
 
         assertEquals(processTransformation1, optimized.get(1));
@@ -285,7 +281,7 @@ public class PythonOperatorChainingOptimizerTest {
     }
 
     @Test
-    public void testMultipleChainedOperators() throws Exception {
+    public void testMultipleChainedOperators() {
         PythonKeyedProcessOperator<?> keyedProcessOperator1 =
                 createKeyedProcessOperator(
                         "f1", new RowTypeInfo(Types.INT(), Types.INT()), Types.STRING());
@@ -349,9 +345,8 @@ public class PythonOperatorChainingOptimizerTest {
         transformations.add(keyedProcessTransformation2);
         transformations.add(processTransformation3);
 
-        PythonOperatorChainingOptimizer optimizer =
-                new PythonOperatorChainingOptimizer(transformations, true);
-        List<Transformation<?>> optimized = optimizer.optimize();
+        List<Transformation<?>> optimized =
+                PythonOperatorChainingOptimizer.optimize(transformations);
         assertEquals(3, optimized.size());
 
         OneInputTransformation<?, ?> chainedTransformation1 =
@@ -381,7 +376,7 @@ public class PythonOperatorChainingOptimizerTest {
     }
 
     @Test
-    public void testChainingTwoInputOperators() throws Exception {
+    public void testChainingTwoInputOperators() {
         PythonKeyedCoProcessOperator<?> keyedCoProcessOperator1 =
                 createCoKeyedProcessOperator(
                         "f1",
@@ -451,9 +446,8 @@ public class PythonOperatorChainingOptimizerTest {
         transformations.add(keyedProcessTransformation);
         transformations.add(processTransformation3);
 
-        PythonOperatorChainingOptimizer optimizer =
-                new PythonOperatorChainingOptimizer(transformations, true);
-        List<Transformation<?>> optimized = optimizer.optimize();
+        List<Transformation<?>> optimized =
+                PythonOperatorChainingOptimizer.optimize(transformations);
         assertEquals(4, optimized.size());
 
         TwoInputTransformation<?, ?, ?> chainedTransformation1 =
@@ -481,6 +475,63 @@ public class PythonOperatorChainingOptimizerTest {
                 ((PythonKeyedProcessOperator<?>) chainedOperator2).getPythonFunctionInfo(),
                 "f5",
                 "f4");
+    }
+
+    @Test
+    public void testChainingUnorderedTransformations() {
+        PythonKeyedProcessOperator<?> keyedProcessOperator =
+                createKeyedProcessOperator(
+                        "f1", new RowTypeInfo(Types.INT(), Types.INT()), Types.STRING());
+        PythonProcessOperator<?, ?> processOperator1 =
+                createProcessOperator("f2", Types.STRING(), Types.LONG());
+        PythonProcessOperator<?, ?> processOperator2 =
+                createProcessOperator("f3", Types.LONG(), Types.INT());
+
+        Transformation<?> sourceTransformation = mock(SourceTransformation.class);
+        OneInputTransformation<?, ?> keyedProcessTransformation =
+                new OneInputTransformation(
+                        sourceTransformation,
+                        "keyedProcess",
+                        keyedProcessOperator,
+                        keyedProcessOperator.getProducedType(),
+                        2);
+        Transformation<?> processTransformation1 =
+                new OneInputTransformation(
+                        keyedProcessTransformation,
+                        "process",
+                        processOperator1,
+                        processOperator1.getProducedType(),
+                        2);
+        Transformation<?> processTransformation2 =
+                new OneInputTransformation(
+                        processTransformation1,
+                        "process",
+                        processOperator2,
+                        processOperator2.getProducedType(),
+                        2);
+
+        List<Transformation<?>> transformations = new ArrayList<>();
+        transformations.add(sourceTransformation);
+        transformations.add(processTransformation2);
+        transformations.add(processTransformation1);
+        transformations.add(keyedProcessTransformation);
+
+        List<Transformation<?>> optimized =
+                PythonOperatorChainingOptimizer.optimize(transformations);
+        assertEquals(2, optimized.size());
+
+        OneInputTransformation<?, ?> chainedTransformation =
+                (OneInputTransformation<?, ?>) optimized.get(1);
+        assertEquals(sourceTransformation.getOutputType(), chainedTransformation.getInputType());
+        assertEquals(processOperator2.getProducedType(), chainedTransformation.getOutputType());
+
+        OneInputStreamOperator<?, ?> chainedOperator = chainedTransformation.getOperator();
+        assertTrue(chainedOperator instanceof PythonKeyedProcessOperator);
+        validateChainedPythonFunctions(
+                ((PythonKeyedProcessOperator<?>) chainedOperator).getPythonFunctionInfo(),
+                "f3",
+                "f2",
+                "f1");
     }
 
     // ----------------------- Utility Methods -----------------------

--- a/flink-python/src/test/java/org/apache/flink/python/util/PythonConfigUtilTest.java
+++ b/flink-python/src/test/java/org/apache/flink/python/util/PythonConfigUtilTest.java
@@ -45,15 +45,14 @@ public class PythonConfigUtilTest {
     }
 
     @Test
-    public void testJobName()
-            throws IllegalAccessException, InvocationTargetException, NoSuchFieldException {
+    public void testJobName() {
         String jobName = "MyTestJob";
         Configuration config = new Configuration();
         config.set(PipelineOptions.NAME, jobName);
         StreamExecutionEnvironment env = StreamExecutionEnvironment.getExecutionEnvironment(config);
 
         env.fromCollection(Collections.singletonList("test")).addSink(new DiscardingSink<>());
-        StreamGraph streamGraph = PythonConfigUtil.generateStreamGraphWithDependencies(env, true);
+        StreamGraph streamGraph = env.getStreamGraph(true);
         assertEquals(jobName, streamGraph.getJobName());
     }
 }

--- a/flink-table/flink-table-common/src/main/java/org/apache/flink/table/functions/python/PythonFunctionInfo.java
+++ b/flink-table/flink-table-common/src/main/java/org/apache/flink/table/functions/python/PythonFunctionInfo.java
@@ -39,7 +39,7 @@ public class PythonFunctionInfo implements Serializable {
      * The input arguments, it could be an input offset of the input row or the execution result of
      * another python function described as PythonFunctionInfo.
      */
-    private final Object[] inputs;
+    private Object[] inputs;
 
     public PythonFunctionInfo(PythonFunction pythonFunction, Object[] inputs) {
         this.pythonFunction = Preconditions.checkNotNull(pythonFunction);
@@ -52,5 +52,10 @@ public class PythonFunctionInfo implements Serializable {
 
     public Object[] getInputs() {
         return this.inputs;
+    }
+
+    public void setInputs(Object[] inputs) {
+        Preconditions.checkNotNull(inputs);
+        this.inputs = inputs;
     }
 }


### PR DESCRIPTION
## What is the purpose of the change

*This pull request support to chain the Python DataStream operators when mixing use of Python Table API and Python DataStream API*

It's based on the PR #16804

## Verifying this change

This change is covered in test case test_from_data_stream*.

## Does this pull request potentially affect one of the following parts:

  - Dependencies (does it add or upgrade a dependency): (no)
  - The public API, i.e., is any changed class annotated with `@Public(Evolving)`: (no)
  - The serializers: (no)
  - The runtime per-record code paths (performance sensitive): (no)
  - Anything that affects deployment or recovery: JobManager (and its components), Checkpointing, Kubernetes/Yarn, ZooKeeper: (no)
  - The S3 file system connector: (no)

## Documentation

  - Does this pull request introduce a new feature? (no)
  - If yes, how is the feature documented? (not applicable)
