### PR TITLE
[FLINK-23746][tests] Harden SuccessAfterNetworkBuffersFailureITCase.testSuccessfulProgramAfterFailure

### DIFF
--- a/flink-tests/src/test/java/org/apache/flink/test/misc/SuccessAfterNetworkBuffersFailureITCase.java
+++ b/flink-tests/src/test/java/org/apache/flink/test/misc/SuccessAfterNetworkBuffersFailureITCase.java
@@ -50,7 +50,7 @@ import static org.junit.Assert.fail;
  */
 public class SuccessAfterNetworkBuffersFailureITCase extends TestLogger {
 
-    private static final int PARALLELISM = 16;
+    private static final int PARALLELISM = 4;
 
     @ClassRule
     public static final MiniClusterWithClientResource MINI_CLUSTER_RESOURCE =
@@ -58,14 +58,14 @@ public class SuccessAfterNetworkBuffersFailureITCase extends TestLogger {
                     new MiniClusterResourceConfiguration.Builder()
                             .setConfiguration(getConfiguration())
                             .setNumberTaskManagers(2)
-                            .setNumberSlotsPerTaskManager(8)
+                            .setNumberSlotsPerTaskManager(2)
                             .build());
 
     private static Configuration getConfiguration() {
         Configuration config = new Configuration();
-        config.set(TaskManagerOptions.MANAGED_MEMORY_SIZE, MemorySize.parse("80m"));
-        config.set(TaskManagerOptions.NETWORK_MEMORY_MIN, MemorySize.ofMebiBytes(32L));
-        config.set(TaskManagerOptions.NETWORK_MEMORY_MAX, MemorySize.ofMebiBytes(32L));
+        config.set(TaskManagerOptions.MANAGED_MEMORY_SIZE, MemorySize.parse("20m"));
+        config.set(TaskManagerOptions.NETWORK_MEMORY_MIN, MemorySize.ofMebiBytes(3L));
+        config.set(TaskManagerOptions.NETWORK_MEMORY_MAX, MemorySize.ofMebiBytes(3L));
         return config;
     }
 


### PR DESCRIPTION
This commit decreases the parallelism used by the test job in order to reduce the time it takes to deploy
the whole job.
