### PR TITLE
[FLINK-23595][formats / json] JSON format support deserialize non-numeric numbe fields

### DIFF
--- a/docs/content.zh/docs/connectors/table/formats/canal.md
+++ b/docs/content.zh/docs/connectors/table/formats/canal.md
@@ -284,6 +284,13 @@ Format 参数
       <td>String</td>
       <td>一个可选的正则表达式，通过正则匹配 Canal 记录中的 "table" 元字段，仅读取指定表的 changelog 记录。正则字符串与 Java 的 <a href="https://docs.oracle.com/javase/8/docs/api/java/util/regex/Pattern.html">Pattern</a> 兼容。</td>
     </tr>
+    <tr>
+      <td><h5>canal-json.allow-non-numeric-numbers</h5></td>
+      <td>可选</td>
+      <td style="word-wrap: break-word;">false</td>
+      <td>Boolean</td>
+      <td>是否支持当前解析字段为 non-numeric 数字（默认为 false，即抛出错误失败）。例如：<code>NaN</code>。</td>
+    </tr>
     </tbody>
 </table>
 

--- a/docs/content.zh/docs/connectors/table/formats/debezium.md
+++ b/docs/content.zh/docs/connectors/table/formats/debezium.md
@@ -417,6 +417,13 @@ Flink 提供了 `debezium-avro-confluent` 和 `debezium-json` 两种 format 来�
       <td>Boolean</td>
       <td>将所有 DECIMAL 类型的数据保持原状，不使用科学计数法表示。例：<code>0.000000027</code> 默认会表示为 <code>2.7E-8</code>。当此选项设为 true 时，则会表示为 <code>0.000000027</code>。</td>
     </tr>
+    <tr>
+      <td><h5>debezium-json.allow-non-numeric-numbers</h5></td>
+      <td>可选</td>
+      <td style="word-wrap: break-word;">false</td>
+      <td>Boolean</td>
+      <td>是否支持当前解析字段为 non-numeric 数字（默认为 false，即抛出错误失败）。例如：<code>NaN</code>。</td>
+    </tr>
     </tbody>
 </table>
 

--- a/docs/content.zh/docs/connectors/table/formats/json.md
+++ b/docs/content.zh/docs/connectors/table/formats/json.md
@@ -55,7 +55,8 @@ CREATE TABLE user_behavior (
  'properties.group.id' = 'testGroup',
  'format' = 'json',
  'json.fail-on-missing-field' = 'false',
- 'json.ignore-parse-errors' = 'true'
+ 'json.ignore-parse-errors' = 'true',
+ 'json.allow-non-numeric-numbers' = 'true'
 )
 ```
 
@@ -134,6 +135,13 @@ Format 参数
       <td style="word-wrap: break-word;">false</td>
       <td>Boolean</td>
       <td>将所有 DECIMAL 类型的数据保持原状，不使用科学计数法表示。例：<code>0.000000027</code> 默认会表示为 <code>2.7E-8</code>。当此选项设为 true 时，则会表示为 <code>0.000000027</code>。</td>
+    </tr>
+    <tr>
+      <td><h5>json.allow-non-numeric-numbers</h5></td>
+      <td>可选</td>
+      <td style="word-wrap: break-word;">false</td>
+      <td>Boolean</td>
+      <td>是否支持当前解析字段为 non-numeric 数字（默认为 false，即抛出错误失败）。例如：<code>NaN</code>。</td>
     </tr>
     </tbody>
 </table>

--- a/docs/content.zh/docs/connectors/table/formats/maxwell.md
+++ b/docs/content.zh/docs/connectors/table/formats/maxwell.md
@@ -251,6 +251,13 @@ Format Options
       <td>Boolean</td>
       <td>Encode all decimals as plain numbers instead of possible scientific notations. By default, decimals may be written using scientific notation. For example, <code>0.000000027</code> is encoded as <code>2.7E-8</code> by default, and will be written as <code>0.000000027</code> if set this option to true.</td>
     </tr>
+    <tr>
+      <td><h5>maxwell-json.allow-non-numeric-numbers</h5></td>
+      <td>optional</td>
+      <td style="word-wrap: break-word;">false</td>
+      <td>Boolean</td>
+      <td>Whether to fail if a field is non-numeric number or not. For example, <code>NaN</code></td>
+    </tr>
     </tbody>
 </table>
 

--- a/docs/content/docs/connectors/table/formats/canal.md
+++ b/docs/content/docs/connectors/table/formats/canal.md
@@ -288,6 +288,13 @@ Format Options
       <td>String</td>
       <td>An optional regular expression to only read the specific tables changelog rows by regular matching the "table" meta field in the Canal record. The pattern string is compatible with Java's <a href="https://docs.oracle.com/javase/8/docs/api/java/util/regex/Pattern.html">Pattern</a>.</td>
     </tr>
+    <tr>
+      <td><h5>canal-json.allow-non-numeric-numbers</h5></td>
+      <td>optional</td>
+      <td style="word-wrap: break-word;">false</td>
+      <td>Boolean</td>
+      <td>Whether to fail if a field is non-numeric number or not. For example, <code>NaN</code></td>
+    </tr>
     </tbody>
 </table>
 

--- a/docs/content/docs/connectors/table/formats/debezium.md
+++ b/docs/content/docs/connectors/table/formats/debezium.md
@@ -413,7 +413,14 @@ Use format `debezium-avro-confluent` to interpret Debezium Avro messages and for
       <td style="word-wrap: break-word;">false</td>
       <td>Boolean</td>
       <td>Encode all decimals as plain numbers instead of possible scientific notations. By default, decimals may be written using scientific notation. For example, <code>0.000000027</code> is encoded as <code>2.7E-8</code> by default, and will be written as <code>0.000000027</code> if set this option to true.</td>
-    </tr>   
+    </tr>
+    <tr>
+      <td><h5>debezium-json.allow-non-numeric-numbers</h5></td>
+      <td>optional</td>
+      <td style="word-wrap: break-word;">false</td>
+      <td>Boolean</td>
+      <td>Whether to fail if a field is non-numeric number or not. For example, <code>NaN</code></td>
+    </tr>
     </tbody>
 </table>
 

--- a/docs/content/docs/connectors/table/formats/json.md
+++ b/docs/content/docs/connectors/table/formats/json.md
@@ -55,7 +55,8 @@ CREATE TABLE user_behavior (
  'properties.group.id' = 'testGroup',
  'format' = 'json',
  'json.fail-on-missing-field' = 'false',
- 'json.ignore-parse-errors' = 'true'
+ 'json.ignore-parse-errors' = 'true',
+ 'json.allow-non-numeric-numbers' = 'true'
 )
 ```
 
@@ -135,6 +136,13 @@ Format Options
       <td style="word-wrap: break-word;">false</td>
       <td>Boolean</td>
       <td>Encode all decimals as plain numbers instead of possible scientific notations. By default, decimals may be written using scientific notation. For example, <code>0.000000027</code> is encoded as <code>2.7E-8</code> by default, and will be written as <code>0.000000027</code> if set this option to true.</td>
+    </tr>
+    <tr>
+      <td><h5>json.allow-non-numeric-numbers</h5></td>
+      <td>optional</td>
+      <td style="word-wrap: break-word;">false</td>
+      <td>Boolean</td>
+      <td>Whether to fail if a field is non-numeric number or not. For example, <code>NaN</code></td>
     </tr>
     </tbody>
 </table>

--- a/docs/content/docs/connectors/table/formats/maxwell.md
+++ b/docs/content/docs/connectors/table/formats/maxwell.md
@@ -251,6 +251,13 @@ Format Options
       <td>Boolean</td>
       <td>Encode all decimals as plain numbers instead of possible scientific notations. By default, decimals may be written using scientific notation. For example, <code>0.000000027</code> is encoded as <code>2.7E-8</code> by default, and will be written as <code>0.000000027</code> if set this option to true.</td>
     </tr>
+    <tr>
+      <td><h5>maxwell-json.allow-non-numeric-numbers</h5></td>
+      <td>optional</td>
+      <td style="word-wrap: break-word;">false</td>
+      <td>Boolean</td>
+      <td>Whether to fail if a field is non-numeric number or not. For example, <code>NaN</code></td>
+    </tr>
     </tbody>
 </table>
 

--- a/flink-formats/flink-json/src/main/java/org/apache/flink/formats/json/JsonFormatFactory.java
+++ b/flink-formats/flink-json/src/main/java/org/apache/flink/formats/json/JsonFormatFactory.java
@@ -42,6 +42,7 @@ import java.util.Collections;
 import java.util.HashSet;
 import java.util.Set;
 
+import static org.apache.flink.formats.json.JsonFormatOptions.ALLOW_NON_NUMERIC_NUMBERS;
 import static org.apache.flink.formats.json.JsonFormatOptions.ENCODE_DECIMAL_AS_PLAIN_NUMBER;
 import static org.apache.flink.formats.json.JsonFormatOptions.FAIL_ON_MISSING_FIELD;
 import static org.apache.flink.formats.json.JsonFormatOptions.IGNORE_PARSE_ERRORS;
@@ -66,6 +67,7 @@ public class JsonFormatFactory implements DeserializationFormatFactory, Serializ
 
         final boolean failOnMissingField = formatOptions.get(FAIL_ON_MISSING_FIELD);
         final boolean ignoreParseErrors = formatOptions.get(IGNORE_PARSE_ERRORS);
+        final boolean allowNonNumericNumbers = formatOptions.get(ALLOW_NON_NUMERIC_NUMBERS);
         TimestampFormat timestampOption = JsonFormatOptionsUtil.getTimestampFormat(formatOptions);
 
         return new DecodingFormat<DeserializationSchema<RowData>>() {
@@ -80,6 +82,7 @@ public class JsonFormatFactory implements DeserializationFormatFactory, Serializ
                         rowDataTypeInfo,
                         failOnMissingField,
                         ignoreParseErrors,
+                        allowNonNumericNumbers,
                         timestampOption);
             }
 
@@ -143,6 +146,7 @@ public class JsonFormatFactory implements DeserializationFormatFactory, Serializ
         options.add(MAP_NULL_KEY_MODE);
         options.add(MAP_NULL_KEY_LITERAL);
         options.add(ENCODE_DECIMAL_AS_PLAIN_NUMBER);
+        options.add(ALLOW_NON_NUMERIC_NUMBERS);
         return options;
     }
 }

--- a/flink-formats/flink-json/src/main/java/org/apache/flink/formats/json/JsonFormatOptions.java
+++ b/flink-formats/flink-json/src/main/java/org/apache/flink/formats/json/JsonFormatOptions.java
@@ -73,6 +73,13 @@ public class JsonFormatOptions {
                     .withDescription(
                             "Optional flag to specify whether to encode all decimals as plain numbers instead of possible scientific notations, false by default.");
 
+    public static final ConfigOption<Boolean> ALLOW_NON_NUMERIC_NUMBERS =
+            ConfigOptions.key("allow-non-numeric-numbers")
+                    .booleanType()
+                    .defaultValue(false)
+                    .withDescription(
+                            "Optional flag to specify whether to deserialize non-numeric number instead of failing, false by default.");
+
     // --------------------------------------------------------------------------------------------
     // Enums
     // --------------------------------------------------------------------------------------------

--- a/flink-formats/flink-json/src/main/java/org/apache/flink/formats/json/JsonFormatOptions.java
+++ b/flink-formats/flink-json/src/main/java/org/apache/flink/formats/json/JsonFormatOptions.java
@@ -78,7 +78,7 @@ public class JsonFormatOptions {
                     .booleanType()
                     .defaultValue(false)
                     .withDescription(
-                            "Optional flag to specify whether to deserialize non-numeric number instead of failing, false by default.");
+                            "Flag to specify whether to deserialize non-numeric number instead of failing.");
 
     // --------------------------------------------------------------------------------------------
     // Enums

--- a/flink-formats/flink-json/src/main/java/org/apache/flink/formats/json/JsonRowDataDeserializationSchema.java
+++ b/flink-formats/flink-json/src/main/java/org/apache/flink/formats/json/JsonRowDataDeserializationSchema.java
@@ -57,6 +57,9 @@ public class JsonRowDataDeserializationSchema implements DeserializationSchema<R
     /** Flag indicating whether to ignore invalid fields/rows (default: throw an exception). */
     private final boolean ignoreParseErrors;
 
+    /** Flag indicating whether to parse non-numeric number fields (default: throw an exception). */
+    private final boolean allowNonNumericNumbers;
+
     /** TypeInformation of the produced {@link RowData}. */
     private final TypeInformation<RowData> resultTypeInfo;
 
@@ -77,6 +80,7 @@ public class JsonRowDataDeserializationSchema implements DeserializationSchema<R
             TypeInformation<RowData> resultTypeInfo,
             boolean failOnMissingField,
             boolean ignoreParseErrors,
+            boolean allowNonNumericNumbers,
             TimestampFormat timestampFormat) {
         if (ignoreParseErrors && failOnMissingField) {
             throw new IllegalArgumentException(
@@ -85,6 +89,7 @@ public class JsonRowDataDeserializationSchema implements DeserializationSchema<R
         this.resultTypeInfo = checkNotNull(resultTypeInfo);
         this.failOnMissingField = failOnMissingField;
         this.ignoreParseErrors = ignoreParseErrors;
+        this.allowNonNumericNumbers = allowNonNumericNumbers;
         this.runtimeConverter =
                 new JsonToRowDataConverters(failOnMissingField, ignoreParseErrors, timestampFormat)
                         .createConverter(checkNotNull(rowType));
@@ -95,6 +100,8 @@ public class JsonRowDataDeserializationSchema implements DeserializationSchema<R
             objectMapper.enable(DeserializationFeature.USE_BIG_DECIMAL_FOR_FLOATS);
         }
         objectMapper.configure(JsonReadFeature.ALLOW_UNESCAPED_CONTROL_CHARS.mappedFeature(), true);
+        objectMapper.configure(
+                JsonReadFeature.ALLOW_NON_NUMERIC_NUMBERS.mappedFeature(), allowNonNumericNumbers);
     }
 
     @Override
@@ -142,12 +149,18 @@ public class JsonRowDataDeserializationSchema implements DeserializationSchema<R
         JsonRowDataDeserializationSchema that = (JsonRowDataDeserializationSchema) o;
         return failOnMissingField == that.failOnMissingField
                 && ignoreParseErrors == that.ignoreParseErrors
+                && allowNonNumericNumbers == that.allowNonNumericNumbers
                 && resultTypeInfo.equals(that.resultTypeInfo)
                 && timestampFormat.equals(that.timestampFormat);
     }
 
     @Override
     public int hashCode() {
-        return Objects.hash(failOnMissingField, ignoreParseErrors, resultTypeInfo, timestampFormat);
+        return Objects.hash(
+                failOnMissingField,
+                ignoreParseErrors,
+                allowNonNumericNumbers,
+                resultTypeInfo,
+                timestampFormat);
     }
 }

--- a/flink-formats/flink-json/src/main/java/org/apache/flink/formats/json/canal/CanalJsonDecodingFormat.java
+++ b/flink-formats/flink-json/src/main/java/org/apache/flink/formats/json/canal/CanalJsonDecodingFormat.java
@@ -61,16 +61,20 @@ public class CanalJsonDecodingFormat implements DecodingFormat<DeserializationSc
 
     private final boolean ignoreParseErrors;
 
+    private final boolean allowNonNumericNumbers;
+
     private final TimestampFormat timestampFormat;
 
     public CanalJsonDecodingFormat(
             String database,
             String table,
             boolean ignoreParseErrors,
+            boolean allowNonNumericNumbers,
             TimestampFormat timestampFormat) {
         this.database = database;
         this.table = table;
         this.ignoreParseErrors = ignoreParseErrors;
+        this.allowNonNumericNumbers = allowNonNumericNumbers;
         this.timestampFormat = timestampFormat;
         this.metadataKeys = Collections.emptyList();
     }
@@ -100,6 +104,7 @@ public class CanalJsonDecodingFormat implements DecodingFormat<DeserializationSc
                 .setDatabase(database)
                 .setTable(table)
                 .setIgnoreParseErrors(ignoreParseErrors)
+                .setAllowNonNumericNumbers(allowNonNumericNumbers)
                 .setTimestampFormat(timestampFormat)
                 .build();
     }

--- a/flink-formats/flink-json/src/main/java/org/apache/flink/formats/json/canal/CanalJsonDeserializationSchema.java
+++ b/flink-formats/flink-json/src/main/java/org/apache/flink/formats/json/canal/CanalJsonDeserializationSchema.java
@@ -88,6 +88,9 @@ public final class CanalJsonDeserializationSchema implements DeserializationSche
     /** Flag indicating whether to ignore invalid fields/rows (default: throw an exception). */
     private final boolean ignoreParseErrors;
 
+    /** Flag indicating whether to parse non-numeric number fields (default: throw an exception). */
+    private final boolean allowNonNumericNumbers;
+
     /** Names of fields. */
     private final List<String> fieldNames;
 
@@ -107,6 +110,7 @@ public final class CanalJsonDeserializationSchema implements DeserializationSche
             @Nullable String database,
             @Nullable String table,
             boolean ignoreParseErrors,
+            boolean allowNonNumericNumbers,
             TimestampFormat timestampFormat) {
         final RowType jsonRowType = createJsonRowType(physicalDataType, requestedMetadata);
         this.jsonDeserializer =
@@ -118,6 +122,7 @@ public final class CanalJsonDeserializationSchema implements DeserializationSche
                         false, // ignoreParseErrors already contains the functionality of
                         // failOnMissingField
                         ignoreParseErrors,
+                        allowNonNumericNumbers,
                         timestampFormat);
         this.hasMetadata = requestedMetadata.size() > 0;
         this.metadataConverters = createMetadataConverters(jsonRowType, requestedMetadata);
@@ -125,6 +130,7 @@ public final class CanalJsonDeserializationSchema implements DeserializationSche
         this.database = database;
         this.table = table;
         this.ignoreParseErrors = ignoreParseErrors;
+        this.allowNonNumericNumbers = allowNonNumericNumbers;
         final RowType physicalRowType = ((RowType) physicalDataType.getLogicalType());
         this.fieldNames = physicalRowType.getFieldNames();
         this.fieldCount = physicalRowType.getFieldCount();
@@ -153,6 +159,7 @@ public final class CanalJsonDeserializationSchema implements DeserializationSche
         private String database = null;
         private String table = null;
         private boolean ignoreParseErrors = false;
+        private boolean allowNonNumericNumbers = false;
         private TimestampFormat timestampFormat = TimestampFormat.SQL;
 
         private Builder(
@@ -179,6 +186,11 @@ public final class CanalJsonDeserializationSchema implements DeserializationSche
             return this;
         }
 
+        public Builder setAllowNonNumericNumbers(boolean allowNonNumericNumbers) {
+            this.allowNonNumericNumbers = allowNonNumericNumbers;
+            return this;
+        }
+
         public Builder setTimestampFormat(TimestampFormat timestampFormat) {
             this.timestampFormat = timestampFormat;
             return this;
@@ -192,6 +204,7 @@ public final class CanalJsonDeserializationSchema implements DeserializationSche
                     database,
                     table,
                     ignoreParseErrors,
+                    allowNonNumericNumbers,
                     timestampFormat);
         }
     }
@@ -333,6 +346,7 @@ public final class CanalJsonDeserializationSchema implements DeserializationSche
                 && Objects.equals(database, that.database)
                 && Objects.equals(table, that.table)
                 && ignoreParseErrors == that.ignoreParseErrors
+                && allowNonNumericNumbers == that.allowNonNumericNumbers
                 && fieldCount == that.fieldCount;
     }
 
@@ -345,6 +359,7 @@ public final class CanalJsonDeserializationSchema implements DeserializationSche
                 database,
                 table,
                 ignoreParseErrors,
+                allowNonNumericNumbers,
                 fieldCount);
     }
 

--- a/flink-formats/flink-json/src/main/java/org/apache/flink/formats/json/canal/CanalJsonFormatFactory.java
+++ b/flink-formats/flink-json/src/main/java/org/apache/flink/formats/json/canal/CanalJsonFormatFactory.java
@@ -44,6 +44,7 @@ import java.util.HashSet;
 import java.util.Set;
 
 import static org.apache.flink.formats.json.JsonFormatOptions.ENCODE_DECIMAL_AS_PLAIN_NUMBER;
+import static org.apache.flink.formats.json.canal.CanalJsonFormatOptions.ALLOW_NON_NUMERIC_NUMBERS;
 import static org.apache.flink.formats.json.canal.CanalJsonFormatOptions.DATABASE_INCLUDE;
 import static org.apache.flink.formats.json.canal.CanalJsonFormatOptions.IGNORE_PARSE_ERRORS;
 import static org.apache.flink.formats.json.canal.CanalJsonFormatOptions.JSON_MAP_NULL_KEY_LITERAL;
@@ -70,10 +71,12 @@ public class CanalJsonFormatFactory
         final String database = formatOptions.getOptional(DATABASE_INCLUDE).orElse(null);
         final String table = formatOptions.getOptional(TABLE_INCLUDE).orElse(null);
         final boolean ignoreParseErrors = formatOptions.get(IGNORE_PARSE_ERRORS);
+        final boolean allowNonNumericNumbers = formatOptions.get(ALLOW_NON_NUMERIC_NUMBERS);
         final TimestampFormat timestampFormat =
                 JsonFormatOptionsUtil.getTimestampFormat(formatOptions);
 
-        return new CanalJsonDecodingFormat(database, table, ignoreParseErrors, timestampFormat);
+        return new CanalJsonDecodingFormat(
+                database, table, ignoreParseErrors, allowNonNumericNumbers, timestampFormat);
     }
 
     @Override
@@ -136,6 +139,7 @@ public class CanalJsonFormatFactory
         options.add(JSON_MAP_NULL_KEY_MODE);
         options.add(JSON_MAP_NULL_KEY_LITERAL);
         options.add(ENCODE_DECIMAL_AS_PLAIN_NUMBER);
+        options.add(ALLOW_NON_NUMERIC_NUMBERS);
         return options;
     }
 

--- a/flink-formats/flink-json/src/main/java/org/apache/flink/formats/json/canal/CanalJsonFormatOptions.java
+++ b/flink-formats/flink-json/src/main/java/org/apache/flink/formats/json/canal/CanalJsonFormatOptions.java
@@ -54,5 +54,8 @@ public class CanalJsonFormatOptions {
                             "An optional regular expression to only read the specific tables changelog rows by regular matching the \"table\" meta field in the Canal record."
                                     + "The pattern string is compatible with Java's Pattern.");
 
+    public static final ConfigOption<Boolean> ALLOW_NON_NUMERIC_NUMBERS =
+            JsonFormatOptions.ALLOW_NON_NUMERIC_NUMBERS;
+
     private CanalJsonFormatOptions() {}
 }

--- a/flink-formats/flink-json/src/main/java/org/apache/flink/formats/json/debezium/DebeziumJsonDecodingFormat.java
+++ b/flink-formats/flink-json/src/main/java/org/apache/flink/formats/json/debezium/DebeziumJsonDecodingFormat.java
@@ -59,12 +59,18 @@ public class DebeziumJsonDecodingFormat implements DecodingFormat<Deserializatio
 
     private final boolean ignoreParseErrors;
 
+    private final boolean allowNonNumericNumbers;
+
     private final TimestampFormat timestampFormat;
 
     public DebeziumJsonDecodingFormat(
-            boolean schemaInclude, boolean ignoreParseErrors, TimestampFormat timestampFormat) {
+            boolean schemaInclude,
+            boolean ignoreParseErrors,
+            boolean allowNonNumericNumbers,
+            TimestampFormat timestampFormat) {
         this.schemaInclude = schemaInclude;
         this.ignoreParseErrors = ignoreParseErrors;
+        this.allowNonNumericNumbers = allowNonNumericNumbers;
         this.timestampFormat = timestampFormat;
         this.metadataKeys = Collections.emptyList();
     }
@@ -100,6 +106,7 @@ public class DebeziumJsonDecodingFormat implements DecodingFormat<Deserializatio
                 producedTypeInfo,
                 schemaInclude,
                 ignoreParseErrors,
+                allowNonNumericNumbers,
                 timestampFormat);
     }
 

--- a/flink-formats/flink-json/src/main/java/org/apache/flink/formats/json/debezium/DebeziumJsonDeserializationSchema.java
+++ b/flink-formats/flink-json/src/main/java/org/apache/flink/formats/json/debezium/DebeziumJsonDeserializationSchema.java
@@ -88,12 +88,16 @@ public final class DebeziumJsonDeserializationSchema implements DeserializationS
     /** Flag indicating whether to ignore invalid fields/rows (default: throw an exception). */
     private final boolean ignoreParseErrors;
 
+    /** Flag indicating whether to parse non-numeric number fields (default: throw an exception). */
+    private final boolean allowNonNumericNumbers;
+
     public DebeziumJsonDeserializationSchema(
             DataType physicalDataType,
             List<ReadableMetadata> requestedMetadata,
             TypeInformation<RowData> producedTypeInfo,
             boolean schemaInclude,
             boolean ignoreParseErrors,
+            boolean allowNonNumericNumbers,
             TimestampFormat timestampFormat) {
         final RowType jsonRowType =
                 createJsonRowType(physicalDataType, requestedMetadata, schemaInclude);
@@ -106,6 +110,7 @@ public final class DebeziumJsonDeserializationSchema implements DeserializationS
                         false, // ignoreParseErrors already contains the functionality of
                         // failOnMissingField
                         ignoreParseErrors,
+                        allowNonNumericNumbers,
                         timestampFormat);
         this.hasMetadata = requestedMetadata.size() > 0;
         this.metadataConverters =
@@ -113,6 +118,7 @@ public final class DebeziumJsonDeserializationSchema implements DeserializationS
         this.producedTypeInfo = producedTypeInfo;
         this.schemaInclude = schemaInclude;
         this.ignoreParseErrors = ignoreParseErrors;
+        this.allowNonNumericNumbers = allowNonNumericNumbers;
     }
 
     @Override
@@ -224,13 +230,19 @@ public final class DebeziumJsonDeserializationSchema implements DeserializationS
                 && hasMetadata == that.hasMetadata
                 && Objects.equals(producedTypeInfo, that.producedTypeInfo)
                 && schemaInclude == that.schemaInclude
-                && ignoreParseErrors == that.ignoreParseErrors;
+                && ignoreParseErrors == that.ignoreParseErrors
+                && allowNonNumericNumbers == that.allowNonNumericNumbers;
     }
 
     @Override
     public int hashCode() {
         return Objects.hash(
-                jsonDeserializer, hasMetadata, producedTypeInfo, schemaInclude, ignoreParseErrors);
+                jsonDeserializer,
+                hasMetadata,
+                producedTypeInfo,
+                schemaInclude,
+                ignoreParseErrors,
+                allowNonNumericNumbers);
     }
 
     // --------------------------------------------------------------------------------------------

--- a/flink-formats/flink-json/src/main/java/org/apache/flink/formats/json/debezium/DebeziumJsonFormatFactory.java
+++ b/flink-formats/flink-json/src/main/java/org/apache/flink/formats/json/debezium/DebeziumJsonFormatFactory.java
@@ -45,6 +45,7 @@ import java.util.HashSet;
 import java.util.Set;
 
 import static org.apache.flink.formats.json.JsonFormatOptions.ENCODE_DECIMAL_AS_PLAIN_NUMBER;
+import static org.apache.flink.formats.json.debezium.DebeziumJsonFormatOptions.ALLOW_NON_NUMERIC_NUMBERS;
 import static org.apache.flink.formats.json.debezium.DebeziumJsonFormatOptions.IGNORE_PARSE_ERRORS;
 import static org.apache.flink.formats.json.debezium.DebeziumJsonFormatOptions.JSON_MAP_NULL_KEY_LITERAL;
 import static org.apache.flink.formats.json.debezium.DebeziumJsonFormatOptions.JSON_MAP_NULL_KEY_MODE;
@@ -72,10 +73,13 @@ public class DebeziumJsonFormatFactory
 
         final boolean ignoreParseErrors = formatOptions.get(IGNORE_PARSE_ERRORS);
 
+        final boolean allowNonNumericNumbers = formatOptions.get(ALLOW_NON_NUMERIC_NUMBERS);
+
         final TimestampFormat timestampFormat =
                 JsonFormatOptionsUtil.getTimestampFormat(formatOptions);
 
-        return new DebeziumJsonDecodingFormat(schemaInclude, ignoreParseErrors, timestampFormat);
+        return new DebeziumJsonDecodingFormat(
+                schemaInclude, ignoreParseErrors, allowNonNumericNumbers, timestampFormat);
     }
 
     @Override
@@ -138,6 +142,7 @@ public class DebeziumJsonFormatFactory
         options.add(JSON_MAP_NULL_KEY_MODE);
         options.add(JSON_MAP_NULL_KEY_LITERAL);
         options.add(ENCODE_DECIMAL_AS_PLAIN_NUMBER);
+        options.add(ALLOW_NON_NUMERIC_NUMBERS);
         return options;
     }
 

--- a/flink-formats/flink-json/src/main/java/org/apache/flink/formats/json/debezium/DebeziumJsonFormatOptions.java
+++ b/flink-formats/flink-json/src/main/java/org/apache/flink/formats/json/debezium/DebeziumJsonFormatOptions.java
@@ -48,5 +48,8 @@ public class DebeziumJsonFormatOptions {
     public static final ConfigOption<String> JSON_MAP_NULL_KEY_LITERAL =
             JsonFormatOptions.MAP_NULL_KEY_LITERAL;
 
+    public static final ConfigOption<Boolean> ALLOW_NON_NUMERIC_NUMBERS =
+            JsonFormatOptions.ALLOW_NON_NUMERIC_NUMBERS;
+
     private DebeziumJsonFormatOptions() {}
 }

--- a/flink-formats/flink-json/src/main/java/org/apache/flink/formats/json/maxwell/MaxwellJsonDecodingFormat.java
+++ b/flink-formats/flink-json/src/main/java/org/apache/flink/formats/json/maxwell/MaxwellJsonDecodingFormat.java
@@ -52,10 +52,16 @@ public class MaxwellJsonDecodingFormat implements DecodingFormat<Deserialization
 
     private final boolean ignoreParseErrors;
 
+    private final boolean allowNonNumericNumbers;
+
     private final TimestampFormat timestampFormat;
 
-    public MaxwellJsonDecodingFormat(boolean ignoreParseErrors, TimestampFormat timestampFormat) {
+    public MaxwellJsonDecodingFormat(
+            boolean ignoreParseErrors,
+            boolean allowNonNumericNumbers,
+            TimestampFormat timestampFormat) {
         this.ignoreParseErrors = ignoreParseErrors;
+        this.allowNonNumericNumbers = allowNonNumericNumbers;
         this.timestampFormat = timestampFormat;
         this.metadataKeys = Collections.emptyList();
     }
@@ -90,6 +96,7 @@ public class MaxwellJsonDecodingFormat implements DecodingFormat<Deserialization
                 readableMetadata,
                 producedTypeInfo,
                 ignoreParseErrors,
+                allowNonNumericNumbers,
                 timestampFormat);
     }
 

--- a/flink-formats/flink-json/src/main/java/org/apache/flink/formats/json/maxwell/MaxwellJsonDeserializationSchema.java
+++ b/flink-formats/flink-json/src/main/java/org/apache/flink/formats/json/maxwell/MaxwellJsonDeserializationSchema.java
@@ -76,6 +76,9 @@ public class MaxwellJsonDeserializationSchema implements DeserializationSchema<R
     /** Flag indicating whether to ignore invalid fields/rows (default: throw an exception). */
     private final boolean ignoreParseErrors;
 
+    /** Flag indicating whether to parse non-numeric number fields (default: throw an exception). */
+    private final boolean allowNonNumericNumbers;
+
     /** Names of physical fields. */
     private final List<String> fieldNames;
 
@@ -87,6 +90,7 @@ public class MaxwellJsonDeserializationSchema implements DeserializationSchema<R
             List<ReadableMetadata> requestedMetadata,
             TypeInformation<RowData> producedTypeInfo,
             boolean ignoreParseErrors,
+            boolean allowNonNumericNumbers,
             TimestampFormat timestampFormat) {
         final RowType jsonRowType = createJsonRowType(physicalDataType, requestedMetadata);
         this.jsonDeserializer =
@@ -99,11 +103,13 @@ public class MaxwellJsonDeserializationSchema implements DeserializationSchema<R
                         // failOnMissingField
                         false,
                         ignoreParseErrors,
+                        allowNonNumericNumbers,
                         timestampFormat);
         this.hasMetadata = requestedMetadata.size() > 0;
         this.metadataConverters = createMetadataConverters(jsonRowType, requestedMetadata);
         this.producedTypeInfo = producedTypeInfo;
         this.ignoreParseErrors = ignoreParseErrors;
+        this.allowNonNumericNumbers = allowNonNumericNumbers;
         final RowType physicalRowType = ((RowType) physicalDataType.getLogicalType());
         this.fieldNames = physicalRowType.getFieldNames();
         this.fieldCount = physicalRowType.getFieldCount();
@@ -213,13 +219,19 @@ public class MaxwellJsonDeserializationSchema implements DeserializationSchema<R
                 && hasMetadata == that.hasMetadata
                 && Objects.equals(producedTypeInfo, that.producedTypeInfo)
                 && ignoreParseErrors == that.ignoreParseErrors
+                && allowNonNumericNumbers == that.allowNonNumericNumbers
                 && fieldCount == that.fieldCount;
     }
 
     @Override
     public int hashCode() {
         return Objects.hash(
-                jsonDeserializer, hasMetadata, producedTypeInfo, ignoreParseErrors, fieldCount);
+                jsonDeserializer,
+                hasMetadata,
+                producedTypeInfo,
+                ignoreParseErrors,
+                allowNonNumericNumbers,
+                fieldCount);
     }
 
     // --------------------------------------------------------------------------------------------

--- a/flink-formats/flink-json/src/main/java/org/apache/flink/formats/json/maxwell/MaxwellJsonFormatFactory.java
+++ b/flink-formats/flink-json/src/main/java/org/apache/flink/formats/json/maxwell/MaxwellJsonFormatFactory.java
@@ -44,6 +44,7 @@ import java.util.HashSet;
 import java.util.Set;
 
 import static org.apache.flink.formats.json.JsonFormatOptions.ENCODE_DECIMAL_AS_PLAIN_NUMBER;
+import static org.apache.flink.formats.json.maxwell.MaxwellJsonFormatOptions.ALLOW_NON_NUMERIC_NUMBERS;
 import static org.apache.flink.formats.json.maxwell.MaxwellJsonFormatOptions.IGNORE_PARSE_ERRORS;
 import static org.apache.flink.formats.json.maxwell.MaxwellJsonFormatOptions.JSON_MAP_NULL_KEY_LITERAL;
 import static org.apache.flink.formats.json.maxwell.MaxwellJsonFormatOptions.JSON_MAP_NULL_KEY_MODE;
@@ -66,10 +67,12 @@ public class MaxwellJsonFormatFactory
         validateDecodingFormatOptions(formatOptions);
 
         final boolean ignoreParseErrors = formatOptions.get(IGNORE_PARSE_ERRORS);
+        final boolean allowNonNumericNumbers = formatOptions.get(ALLOW_NON_NUMERIC_NUMBERS);
         final TimestampFormat timestampFormat =
                 JsonFormatOptionsUtil.getTimestampFormat(formatOptions);
 
-        return new MaxwellJsonDecodingFormat(ignoreParseErrors, timestampFormat);
+        return new MaxwellJsonDecodingFormat(
+                ignoreParseErrors, allowNonNumericNumbers, timestampFormat);
     }
 
     @Override
@@ -130,6 +133,7 @@ public class MaxwellJsonFormatFactory
         options.add(JSON_MAP_NULL_KEY_MODE);
         options.add(JSON_MAP_NULL_KEY_LITERAL);
         options.add(ENCODE_DECIMAL_AS_PLAIN_NUMBER);
+        options.add(ALLOW_NON_NUMERIC_NUMBERS);
         return options;
     }
 

--- a/flink-formats/flink-json/src/main/java/org/apache/flink/formats/json/maxwell/MaxwellJsonFormatOptions.java
+++ b/flink-formats/flink-json/src/main/java/org/apache/flink/formats/json/maxwell/MaxwellJsonFormatOptions.java
@@ -37,5 +37,8 @@ public class MaxwellJsonFormatOptions {
     public static final ConfigOption<String> JSON_MAP_NULL_KEY_LITERAL =
             JsonFormatOptions.MAP_NULL_KEY_LITERAL;
 
+    public static final ConfigOption<Boolean> ALLOW_NON_NUMERIC_NUMBERS =
+            JsonFormatOptions.ALLOW_NON_NUMERIC_NUMBERS;
+
     private MaxwellJsonFormatOptions() {}
 }

--- a/flink-formats/flink-json/src/test/java/org/apache/flink/formats/json/JsonFormatFactoryTest.java
+++ b/flink-formats/flink-json/src/test/java/org/apache/flink/formats/json/JsonFormatFactoryTest.java
@@ -134,6 +134,19 @@ public class JsonFormatFactoryTest extends TestLogger {
         testSchemaDeserializationSchema(tableOptions);
     }
 
+    @Test
+    public void testInvalidOptionForAllowNonNumericNumbers() {
+        final Map<String, String> tableOptions =
+                getModifyOptions(options -> options.put("json.allow-non-numeric-numbers", "abc"));
+
+        thrown.expect(ValidationException.class);
+        thrown.expect(
+                containsCause(
+                        new IllegalArgumentException(
+                                "Unrecognized option for boolean: abc. Expected either true or false(case insensitive)")));
+        testSchemaDeserializationSchema(tableOptions);
+    }
+
     // ------------------------------------------------------------------------
     //  Utilities
     // ------------------------------------------------------------------------
@@ -144,6 +157,7 @@ public class JsonFormatFactoryTest extends TestLogger {
                         PHYSICAL_TYPE,
                         InternalTypeInfo.of(PHYSICAL_TYPE),
                         false,
+                        true,
                         true,
                         TimestampFormat.ISO_8601);
 
@@ -204,6 +218,7 @@ public class JsonFormatFactoryTest extends TestLogger {
         options.put("json.map-null-key.mode", "LITERAL");
         options.put("json.map-null-key.literal", "null");
         options.put("json.encode.decimal-as-plain-number", "true");
+        options.put("json.allow-non-numeric-numbers", "true");
         return options;
     }
 }

--- a/flink-formats/flink-json/src/test/java/org/apache/flink/formats/json/canal/CanalJsonFormatFactoryTest.java
+++ b/flink-formats/flink-json/src/test/java/org/apache/flink/formats/json/canal/CanalJsonFormatFactoryTest.java
@@ -65,6 +65,7 @@ public class CanalJsonFormatFactoryTest extends TestLogger {
                 CanalJsonDeserializationSchema.builder(
                                 PHYSICAL_DATA_TYPE, Collections.emptyList(), ROW_TYPE_INFO)
                         .setIgnoreParseErrors(false)
+                        .setAllowNonNumericNumbers(false)
                         .setTimestampFormat(TimestampFormat.SQL)
                         .build();
         DeserializationSchema<RowData> actualDeser = createDeserializationSchema(options);
@@ -155,6 +156,19 @@ public class CanalJsonFormatFactoryTest extends TestLogger {
                         new ValidationException(
                                 "Unsupported value 'invalid' for option map-null-key.mode. Supported values are [LITERAL, FAIL, DROP].")));
         createSerializationSchema(tableOptions);
+    }
+
+    @Test
+    public void testInvalidOptionForAllowNonNumericNumbers() {
+        thrown.expect(
+                containsCause(
+                        new IllegalArgumentException(
+                                "Unrecognized option for boolean: abc. Expected either true or false(case insensitive)")));
+
+        final Map<String, String> options =
+                getModifiedOptions(opts -> opts.put("canal-json.allow-non-numeric-numbers", "abc"));
+
+        createDeserializationSchema(options);
     }
 
     // ------------------------------------------------------------------------

--- a/flink-formats/flink-json/src/test/java/org/apache/flink/formats/json/debezium/DebeziumJsonFormatFactoryTest.java
+++ b/flink-formats/flink-json/src/test/java/org/apache/flink/formats/json/debezium/DebeziumJsonFormatFactoryTest.java
@@ -64,6 +64,7 @@ public class DebeziumJsonFormatFactoryTest extends TestLogger {
                         InternalTypeInfo.of(PHYSICAL_TYPE),
                         false,
                         true,
+                        false,
                         TimestampFormat.ISO_8601);
 
         final Map<String, String> options = getAllOptions();
@@ -124,6 +125,7 @@ public class DebeziumJsonFormatFactoryTest extends TestLogger {
                         InternalTypeInfo.of(PHYSICAL_DATA_TYPE.getLogicalType()),
                         true,
                         true,
+                        false,
                         TimestampFormat.ISO_8601);
         final DynamicTableSource actualSource = createTableSource(SCHEMA, options);
         TestDynamicTableFactory.DynamicTableSourceMock scanSourceMock =
@@ -176,6 +178,20 @@ public class DebeziumJsonFormatFactoryTest extends TestLogger {
         createTableSink(SCHEMA, tableOptions);
     }
 
+    @Test
+    public void testInvalidOptionForAllowNonNumericNumbers() {
+        thrown.expect(
+                containsCause(
+                        new IllegalArgumentException(
+                                "Unrecognized option for boolean: abc. Expected either true or false(case insensitive)")));
+
+        final Map<String, String> options =
+                getModifiedOptions(
+                        opts -> opts.put("debezium-json.allow-non-numeric-numbers", "abc"));
+
+        createTableSource(SCHEMA, options);
+    }
+
     // ------------------------------------------------------------------------
     //  Utilities
     // ------------------------------------------------------------------------
@@ -203,6 +219,7 @@ public class DebeziumJsonFormatFactoryTest extends TestLogger {
         options.put("debezium-json.map-null-key.mode", "LITERAL");
         options.put("debezium-json.map-null-key.literal", "null");
         options.put("debezium-json.encode.decimal-as-plain-number", "true");
+        options.put("debezium-json.allow-non-numeric-numbers", "false");
         return options;
     }
 }

--- a/flink-formats/flink-json/src/test/java/org/apache/flink/formats/json/maxwell/MaxwellJsonFormatFactoryTest.java
+++ b/flink-formats/flink-json/src/test/java/org/apache/flink/formats/json/maxwell/MaxwellJsonFormatFactoryTest.java
@@ -64,6 +64,7 @@ public class MaxwellJsonFormatFactoryTest extends TestLogger {
                         Collections.emptyList(),
                         ROW_TYPE_INFO,
                         true,
+                        false,
                         TimestampFormat.ISO_8601);
 
         final MaxwellJsonSerializationSchema expectedSer =
@@ -139,6 +140,20 @@ public class MaxwellJsonFormatFactoryTest extends TestLogger {
         createTableSink(SCHEMA, tableOptions);
     }
 
+    @Test
+    public void testInvalidOptionForAllowNonNumericNumbers() {
+        thrown.expect(
+                containsCause(
+                        new IllegalArgumentException(
+                                "Unrecognized option for boolean: abc. Expected either true or false(case insensitive)")));
+
+        final Map<String, String> options =
+                getModifiedOptions(
+                        opts -> opts.put("maxwell-json.allow-non-numeric-numbers", "abc"));
+
+        createTableSource(SCHEMA, options);
+    }
+
     // ------------------------------------------------------------------------
     //  Utilities
     // ------------------------------------------------------------------------
@@ -166,6 +181,7 @@ public class MaxwellJsonFormatFactoryTest extends TestLogger {
         options.put("maxwell-json.map-null-key.mode", "LITERAL");
         options.put("maxwell-json.map-null-key.literal", "null");
         options.put("maxwell-json.encode.decimal-as-plain-number", "true");
+        options.put("maxwell-json.allow-non-numeric-numbers", "false");
         return options;
     }
 }


### PR DESCRIPTION
<!--
*Thank you very much for contributing to Apache Flink - we are happy that you want to help us improve Flink. To help the community review your contribution in the best possible way, please go through the checklist below, which will get the contribution into a shape in which it can be best reviewed.*

*Please understand that we do not do this to make contributions to Flink a hassle. In order to uphold a high standard of quality for code contributions, while at the same time managing a large number of contributions, we need contributors to prepare the contributions well, and give reviewers enough contextual information for the review. Please also understand that contributions that do not follow this guide will take longer to review and thus typically be picked up with lower priority by the community.*

## Contribution Checklist

  - Make sure that the pull request corresponds to a [JIRA issue](https://issues.apache.org/jira/projects/FLINK/issues). Exceptions are made for typos in JavaDoc or documentation files, which need no JIRA issue.
  
  - Name the pull request in the form "[FLINK-XXXX] [component] Title of the pull request", where *FLINK-XXXX* should be replaced by the actual issue number. Skip *component* if you are unsure about which is the best component.
  Typo fixes that have no associated JIRA issue should be named following this pattern: `[hotfix] [docs] Fix typo in event time introduction` or `[hotfix] [javadocs] Expand JavaDoc for PuncuatedWatermarkGenerator`.

  - Fill out the template below to describe the changes contributed by the pull request. That will give reviewers the context they need to do the review.
  
  - Make sure that the change passes the automated tests, i.e., `mvn clean verify` passes. You can set up Azure Pipelines CI to do that following [this guide](https://cwiki.apache.org/confluence/display/FLINK/Azure+Pipelines#AzurePipelines-Tutorial:SettingupAzurePipelinesforaforkoftheFlinkrepository).

  - Each pull request should address only one issue, not mix up code from multiple issues.
  
  - Each commit in the pull request has a meaningful commit message (including the JIRA id)

  - Once all items of the checklist are addressed, remove the above text and this checklist, leaving only the filled out template below.


**(The sections below can be removed for hotfixes of typos)**
-->

## What is the purpose of the change

*This pull request makes json format support deserialize **non-numeric number** fields (default: throw an exception). For example, **NaN**、   **Infinity**  or  **-Infinity**.*

FLINK-23595

## Brief change log

Add new JsonFormatOptions:  **allow-non-numeric-numbers**

*Involved implemention:*
  - *json*
  - *maxwell-json*
  - *canal-json*
  - *debezium-json*
 

## Verifying this change

*(Please pick either of the following options)*

This change is a trivial rework / code cleanup without any test coverage.

**no**

This change is already covered by existing tests.

- Add test in **JsonFormatFactoryTest**  to cover parse options cases.
- Add test in **CanalJsonFormatFactoryTest** to cover parse options cases.
- Add test in **DebeziumJsonFormatFactoryTest**  to cover parse options cases.
- Add test in **MaxwellJsonFormatFactoryTest** to cover parse options cases.
- Add test in **JsonRowDataSerDeSchemaTest** to cover deserialize non-numeric number cases.
- Add test in **CanalJsonSerDeSchemaTest** to cover deserialize non-numeric number cases.
- Add test in **DebeziumJsonSerDeSchemaTest** to cover deserialize non-numeric number cases.
- Add test in **MaxwellJsonSerDerTest** to cover deserialize non-numeric number cases.


## Does this pull request potentially affect one of the following parts:

  - Dependencies (does it add or upgrade a dependency): (**no**)
  - The public API, i.e., is any changed class annotated with `@Public(Evolving)`: (**yes**)
  - The serializers: (**no**)
  - The runtime per-record code paths (performance sensitive): (**no**)
  - Anything that affects deployment or recovery: JobManager (and its components), Checkpointing, Kubernetes/Yarn, ZooKeeper: (**no**)
  - The S3 file system connector: (**no**)

## Documentation

  - Does this pull request introduce a new feature? (**yes**)
  - If yes, how is the feature documented? (**docs**)
  
