### PR TITLE
[FLINK-23732][tests] Increase logger-startup-timeout to 50s

### DIFF
--- a/flink-rpc/flink-rpc-akka/src/main/java/org/apache/flink/runtime/rpc/akka/AkkaUtils.java
+++ b/flink-rpc/flink-rpc-akka/src/main/java/org/apache/flink/runtime/rpc/akka/AkkaUtils.java
@@ -83,7 +83,7 @@ class AkkaUtils {
                 .add("  loggers = [\"akka.event.slf4j.Slf4jLogger\"]")
                 .add("  logging-filter = \"akka.event.slf4j.Slf4jLoggingFilter\"")
                 .add("  log-config-on-start = off")
-                .add("  logger-startup-timeout = 30s")
+                .add("  logger-startup-timeout = 50s")
                 .add("  loglevel = " + getLogLevel())
                 .add("  stdout-loglevel = OFF")
                 .add("  log-dead-letters = " + logLifecycleEvents)

--- a/flink-tests/src/test/java/org/apache/flink/test/misc/SuccessAfterNetworkBuffersFailureITCase.java
+++ b/flink-tests/src/test/java/org/apache/flink/test/misc/SuccessAfterNetworkBuffersFailureITCase.java
@@ -50,7 +50,7 @@ import static org.junit.Assert.fail;
  */
 public class SuccessAfterNetworkBuffersFailureITCase extends TestLogger {
 
-    private static final int PARALLELISM = 16;
+    private static final int PARALLELISM = 4;
 
     @ClassRule
     public static final MiniClusterWithClientResource MINI_CLUSTER_RESOURCE =
@@ -58,14 +58,14 @@ public class SuccessAfterNetworkBuffersFailureITCase extends TestLogger {
                     new MiniClusterResourceConfiguration.Builder()
                             .setConfiguration(getConfiguration())
                             .setNumberTaskManagers(2)
-                            .setNumberSlotsPerTaskManager(8)
+                            .setNumberSlotsPerTaskManager(2)
                             .build());
 
     private static Configuration getConfiguration() {
         Configuration config = new Configuration();
-        config.set(TaskManagerOptions.MANAGED_MEMORY_SIZE, MemorySize.parse("80m"));
-        config.set(TaskManagerOptions.NETWORK_MEMORY_MIN, MemorySize.ofMebiBytes(32L));
-        config.set(TaskManagerOptions.NETWORK_MEMORY_MAX, MemorySize.ofMebiBytes(32L));
+        config.set(TaskManagerOptions.MANAGED_MEMORY_SIZE, MemorySize.parse("20m"));
+        config.set(TaskManagerOptions.NETWORK_MEMORY_MIN, MemorySize.ofMebiBytes(3L));
+        config.set(TaskManagerOptions.NETWORK_MEMORY_MAX, MemorySize.ofMebiBytes(3L));
         return config;
     }
 


### PR DESCRIPTION
In order to harden tests on slow CI, this commit increases the logger-startup-timeout from 30s to 50s.