### PR TITLE
[FLINK-18840][table-api] Add StreamStatementSet.attachToDataStream()

### DIFF
--- a/docs/content/docs/dev/table/data_stream_api.md
+++ b/docs/content/docs/dev/table/data_stream_api.md
@@ -2148,6 +2148,136 @@ watermarks in a subsequent `ProcessFunction` in DataStream API.
 
 {{< top >}}
 
+Adding Table API Pipelines to DataStream API
+--------------------------------------------
+
+A single Flink job can consist of multiple disconnected pipelines that run next to each other.
+
+Source-to-sink pipelines defined in Table API can be attached *as a whole* to the `StreamExecutionEnvironment`
+and will be submitted when calling one of the `execute` methods in the DataStream API.
+
+However, a source does not necessarily have to be a table source but can also be another DataStream
+pipeline that was converted to Table API before. Thus, it is possible to use table sinks for DataStream API
+programs.
+
+The functionality is available through a specialized `StreamStatementSet` instance created with
+`StreamTableEnvironment.createStatementSet()`. By using a statement set, the planner can optimize all
+added statements together and come up with one or more end-to-end pipelines that are added to the
+`StreamExecutionEnvironment` when calling `StreamStatementSet.attachAsDataStream()`.
+
+The following example shows how to add table programs to a DataStream API program within one job.
+
+{{< tabs "de4cd538-4345-49ee-b86e-b308f002e069" >}}
+{{< tab "Java" >}}
+```java
+import org.apache.flink.streaming.api.datastream.DataStream;
+import org.apache.flink.streaming.api.environment.StreamExecutionEnvironment;
+import org.apache.flink.streaming.api.functions.sink.DiscardingSink;
+import org.apache.flink.table.api.*;
+import org.apache.flink.table.api.bridge.java.*;
+
+StreamExecutionEnvironment env = StreamExecutionEnvironment.getExecutionEnvironment();
+StreamTableEnvironment tableEnv = StreamTableEnvironment.create(env);
+
+StreamStatementSet statementSet = tableEnv.createStatementSet();
+
+// create some source
+TableDescriptor sourceDescriptor =
+    TableDescriptor.forConnector("datagen")
+        .option("number-of-rows", "3")
+        .schema(
+            Schema.newBuilder()
+                .column("myCol", DataTypes.INT())
+                .column("myOtherCol", DataTypes.BOOLEAN())
+                .build())
+        .build();
+
+// create some sink
+TableDescriptor sinkDescriptor = TableDescriptor.forConnector("print").build();
+
+// add a pure Table API pipeline
+Table tableFromSource = tableEnv.from(sourceDescriptor);
+statementSet.addInsert(sinkDescriptor, tableFromSource);
+
+// use table sinks for the DataStream API pipeline
+DataStream<Integer> dataStream = env.fromElements(1, 2, 3);
+Table tableFromStream = tableEnv.fromDataStream(dataStream);
+statementSet.addInsert(sinkDescriptor, tableFromStream);
+
+// attach both pipelines to StreamExecutionEnvironment
+// (the statement set will be cleared after calling this method)
+statementSet.attachAsDataStream();
+
+// define other DataStream API parts
+env.fromElements(4, 5, 6).addSink(new DiscardingSink<>());
+
+// use DataStream API to submit the pipelines
+env.execute();
+
+// prints similar to:
+// +I[1618440447, false]
+// +I[1259693645, true]
+// +I[158588930, false]
+// +I[1]
+// +I[2]
+// +I[3]
+```
+{{< /tab >}}
+{{< tab "Scala" >}}
+```scala
+import org.apache.flink.streaming.api.functions.sink.DiscardingSink
+import org.apache.flink.streaming.api.scala._
+import org.apache.flink.table.api._
+import org.apache.flink.table.api.bridge.scala.StreamTableEnvironment
+
+val env = StreamExecutionEnvironment.getExecutionEnvironment
+val tableEnv = StreamTableEnvironment.create(env)
+
+val statementSet = tableEnv.createStatementSet()
+
+// create some source
+val sourceDescriptor = TableDescriptor.forConnector("datagen")
+    .option("number-of-rows", "3")
+    .schema(Schema.newBuilder
+        .column("myCol", DataTypes.INT)
+        .column("myOtherCol", DataTypes.BOOLEAN).build)
+    .build
+
+// create some sink
+val sinkDescriptor = TableDescriptor.forConnector("print").build
+
+// add a pure Table API pipeline
+val tableFromSource = tableEnv.from(sourceDescriptor)
+statementSet.addInsert(sinkDescriptor, tableFromSource)
+
+// use table sinks for the DataStream API pipeline
+val dataStream = env.fromElements(1, 2, 3)
+val tableFromStream = tableEnv.fromDataStream(dataStream)
+statementSet.addInsert(sinkDescriptor, tableFromStream)
+
+// attach both pipelines to StreamExecutionEnvironment
+// (the statement set will be cleared calling this method)
+statementSet.attachAsDataStream()
+
+// define other DataStream API parts
+env.fromElements(4, 5, 6).addSink(new DiscardingSink[Int]())
+
+// now use DataStream API to submit the pipelines
+env.execute()
+
+// prints similar to:
+// +I[1618440447, false]
+// +I[1259693645, true]
+// +I[158588930, false]
+// +I[1]
+// +I[2]
+// +I[3]
+```
+{{< /tab >}}
+{{< /tabs >}}
+
+{{< top >}}
+
 Implicit Conversions in Scala
 -----------------------------
 
@@ -2188,7 +2318,6 @@ val dataStreamAgain1: DataStream[Row] = table
 // call toChangelogStream() implicitly on the Table object
 val dataStreamAgain2: DataStream[Row] = table.toChangelogStream
 ```
-
 {{< top >}}
 
 Mapping between TypeInformation and DataType

--- a/flink-table/flink-table-api-java-bridge/src/main/java/org/apache/flink/table/api/bridge/java/StreamStatementSet.java
+++ b/flink-table/flink-table-api-java-bridge/src/main/java/org/apache/flink/table/api/bridge/java/StreamStatementSet.java
@@ -1,0 +1,65 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.flink.table.api.bridge.java;
+
+import org.apache.flink.annotation.PublicEvolving;
+import org.apache.flink.streaming.api.datastream.DataStream;
+import org.apache.flink.streaming.api.environment.StreamExecutionEnvironment;
+import org.apache.flink.table.api.StatementSet;
+import org.apache.flink.table.api.Table;
+import org.apache.flink.table.api.TableDescriptor;
+
+/**
+ * A {@link StatementSet} that integrates with the Java-specific {@link DataStream} API.
+ *
+ * <p>It accepts pipelines defined by DML statements or {@link Table} objects. The planner can
+ * optimize all added statements together and then either submit them as one job or attach them to
+ * the underlying {@link StreamExecutionEnvironment}.
+ *
+ * <p>The added statements will be cleared when calling the {@link #execute()} or {@link
+ * #attachAsDataStream()} method.
+ */
+@PublicEvolving
+public interface StreamStatementSet extends StatementSet {
+
+    @Override
+    StreamStatementSet addInsertSql(String statement);
+
+    @Override
+    StreamStatementSet addInsert(String targetPath, Table table);
+
+    @Override
+    StreamStatementSet addInsert(String targetPath, Table table, boolean overwrite);
+
+    @Override
+    StreamStatementSet addInsert(TableDescriptor targetDescriptor, Table table);
+
+    @Override
+    StreamStatementSet addInsert(TableDescriptor targetDescriptor, Table table, boolean overwrite);
+
+    /**
+     * Optimizes all statements as one entity and adds them as transformations to the underlying
+     * {@link StreamExecutionEnvironment}.
+     *
+     * <p>Use {@link StreamExecutionEnvironment#execute()} to execute them.
+     *
+     * <p>The added statements will be cleared after calling this method.
+     */
+    void attachAsDataStream();
+}

--- a/flink-table/flink-table-api-java-bridge/src/main/java/org/apache/flink/table/api/bridge/java/StreamTableEnvironment.java
+++ b/flink-table/flink-table-api-java-bridge/src/main/java/org/apache/flink/table/api/bridge/java/StreamTableEnvironment.java
@@ -30,6 +30,7 @@ import org.apache.flink.streaming.api.environment.StreamExecutionEnvironment;
 import org.apache.flink.table.api.DataTypes;
 import org.apache.flink.table.api.EnvironmentSettings;
 import org.apache.flink.table.api.Schema;
+import org.apache.flink.table.api.StatementSet;
 import org.apache.flink.table.api.Table;
 import org.apache.flink.table.api.TableConfig;
 import org.apache.flink.table.api.TableEnvironment;
@@ -720,6 +721,17 @@ public interface StreamTableEnvironment extends TableEnvironment {
      */
     DataStream<Row> toChangelogStream(
             Table table, Schema targetSchema, ChangelogMode changelogMode);
+
+    /**
+     * Returns a {@link StatementSet} that integrates with the Java-specific {@link DataStream} API.
+     *
+     * <p>It accepts pipelines defined by DML statements or {@link Table} objects. The planner can
+     * optimize all added statements together and then either submit them as one job or attach them
+     * to the underlying {@link StreamExecutionEnvironment}.
+     *
+     * @return statement set builder for the Java-specific {@link DataStream} API
+     */
+    StreamStatementSet createStatementSet();
 
     /**
      * Converts the given {@link DataStream} into a {@link Table} with specified field names.

--- a/flink-table/flink-table-api-java-bridge/src/main/java/org/apache/flink/table/api/bridge/java/internal/StreamStatementSetImpl.java
+++ b/flink-table/flink-table-api-java-bridge/src/main/java/org/apache/flink/table/api/bridge/java/internal/StreamStatementSetImpl.java
@@ -1,0 +1,70 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.flink.table.api.bridge.java.internal;
+
+import org.apache.flink.annotation.Internal;
+import org.apache.flink.table.api.Table;
+import org.apache.flink.table.api.TableDescriptor;
+import org.apache.flink.table.api.bridge.java.StreamStatementSet;
+import org.apache.flink.table.api.internal.StatementSetImpl;
+
+/** Implementation for {@link StreamStatementSet}. */
+@Internal
+public class StreamStatementSetImpl extends StatementSetImpl<StreamTableEnvironmentImpl>
+        implements StreamStatementSet {
+
+    protected StreamStatementSetImpl(StreamTableEnvironmentImpl tableEnvironment) {
+        super(tableEnvironment);
+    }
+
+    @Override
+    public StreamStatementSet addInsertSql(String statement) {
+        return (StreamStatementSet) super.addInsertSql(statement);
+    }
+
+    @Override
+    public StreamStatementSet addInsert(String targetPath, Table table) {
+        return (StreamStatementSet) super.addInsert(targetPath, table);
+    }
+
+    @Override
+    public StreamStatementSet addInsert(String targetPath, Table table, boolean overwrite) {
+        return (StreamStatementSet) super.addInsert(targetPath, table, overwrite);
+    }
+
+    @Override
+    public StreamStatementSet addInsert(TableDescriptor targetDescriptor, Table table) {
+        return (StreamStatementSet) super.addInsert(targetDescriptor, table);
+    }
+
+    @Override
+    public StreamStatementSet addInsert(
+            TableDescriptor targetDescriptor, Table table, boolean overwrite) {
+        return (StreamStatementSet) super.addInsert(targetDescriptor, table, overwrite);
+    }
+
+    @Override
+    public void attachAsDataStream() {
+        try {
+            tableEnvironment.attachAsDataStream(operations);
+        } finally {
+            operations.clear();
+        }
+    }
+}

--- a/flink-table/flink-table-api-java-bridge/src/main/java/org/apache/flink/table/api/bridge/java/internal/StreamTableEnvironmentImpl.java
+++ b/flink-table/flink-table-api-java-bridge/src/main/java/org/apache/flink/table/api/bridge/java/internal/StreamTableEnvironmentImpl.java
@@ -35,6 +35,7 @@ import org.apache.flink.table.api.TableConfig;
 import org.apache.flink.table.api.TableException;
 import org.apache.flink.table.api.Types;
 import org.apache.flink.table.api.ValidationException;
+import org.apache.flink.table.api.bridge.java.StreamStatementSet;
 import org.apache.flink.table.api.bridge.java.StreamTableEnvironment;
 import org.apache.flink.table.api.internal.TableEnvironmentImpl;
 import org.apache.flink.table.catalog.CatalogManager;
@@ -446,6 +447,16 @@ public final class StreamTableEnvironmentImpl extends TableEnvironmentImpl
         executionEnvironment.configure(tableConfig.getConfiguration());
 
         return new DataStream<>(executionEnvironment, transformation);
+    }
+
+    @Override
+    public StreamStatementSet createStatementSet() {
+        return new StreamStatementSetImpl(this);
+    }
+
+    void attachAsDataStream(List<ModifyOperation> modifyOperations) {
+        final List<Transformation<?>> transformations = translate(modifyOperations);
+        transformations.forEach(executionEnvironment::addOperator);
     }
 
     @Override

--- a/flink-table/flink-table-api-java/src/main/java/org/apache/flink/table/api/StatementSet.java
+++ b/flink-table/flink-table-api-java/src/main/java/org/apache/flink/table/api/StatementSet.java
@@ -147,9 +147,9 @@ public interface StatementSet {
     String explain(ExplainDetail... extraDetails);
 
     /**
-     * Executes all statements as a batch.
+     * Executes all statements as one job.
      *
-     * <p>The added statements will be cleared when executing this method.
+     * <p>The added statements will be cleared after calling this method.
      *
      * <p>By default, all DML operations are executed asynchronously. Use {@link
      * TableResult#await()} or {@link TableResult#getJobClient()} to monitor the execution. Set

--- a/flink-table/flink-table-api-java/src/main/java/org/apache/flink/table/api/TableEnvironment.java
+++ b/flink-table/flink-table-api-java/src/main/java/org/apache/flink/table/api/TableEnvironment.java
@@ -1248,8 +1248,9 @@ public interface TableEnvironment {
     JobExecutionResult execute(String jobName) throws Exception;
 
     /**
-     * Create a {@link StatementSet} instance which accepts DML statements or Tables, the planner
-     * can optimize all added statements and Tables together and then submit as one job.
+     * Returns a {@link StatementSet} that accepts pipelines defined by DML statements or {@link
+     * Table} objects. The planner can optimize all added statements together and then submit them
+     * as one job.
      */
     StatementSet createStatementSet();
 }

--- a/flink-table/flink-table-api-java/src/main/java/org/apache/flink/table/api/internal/StatementSetImpl.java
+++ b/flink-table/flink-table-api-java/src/main/java/org/apache/flink/table/api/internal/StatementSetImpl.java
@@ -40,11 +40,11 @@ import java.util.stream.Collectors;
 
 /** Implementation for {@link StatementSet}. */
 @Internal
-class StatementSetImpl implements StatementSet {
-    private final TableEnvironmentInternal tableEnvironment;
-    private final List<ModifyOperation> operations = new ArrayList<>();
+public class StatementSetImpl<E extends TableEnvironmentInternal> implements StatementSet {
+    protected final E tableEnvironment;
+    protected final List<ModifyOperation> operations = new ArrayList<>();
 
-    protected StatementSetImpl(TableEnvironmentInternal tableEnvironment) {
+    protected StatementSetImpl(E tableEnvironment) {
         this.tableEnvironment = tableEnvironment;
     }
 

--- a/flink-table/flink-table-api-java/src/main/java/org/apache/flink/table/api/internal/TableEnvironmentImpl.java
+++ b/flink-table/flink-table-api-java/src/main/java/org/apache/flink/table/api/internal/TableEnvironmentImpl.java
@@ -1695,7 +1695,7 @@ public class TableEnvironmentImpl implements TableEnvironmentInternal {
         return transformations;
     }
 
-    private List<Transformation<?>> translate(List<ModifyOperation> modifyOperations) {
+    protected List<Transformation<?>> translate(List<ModifyOperation> modifyOperations) {
         return planner.translate(modifyOperations);
     }
 

--- a/flink-table/flink-table-api-scala-bridge/src/main/scala/org/apache/flink/table/api/bridge/scala/StreamStatementSet.scala
+++ b/flink-table/flink-table-api-scala-bridge/src/main/scala/org/apache/flink/table/api/bridge/scala/StreamStatementSet.scala
@@ -1,0 +1,61 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.flink.table.api.bridge.scala
+
+import org.apache.flink.annotation.PublicEvolving
+import org.apache.flink.streaming.api.scala.{DataStream, StreamExecutionEnvironment}
+import org.apache.flink.table.api.{StatementSet, Table, TableDescriptor}
+
+/**
+ * A [[StatementSet]] that integrates with the Scala-specific [[DataStream]] API.
+ *
+ * It accepts pipelines defined by DML statements or [[Table]] objects. The planner can optimize all
+ * added statements together and then either submit them as one job or attach them to the underlying
+ * [[StreamExecutionEnvironment]].
+ *
+ * The added statements will be cleared when calling the `execute()` or `attachAsDataStream()`
+ * method.
+ */
+@PublicEvolving
+trait StreamStatementSet extends StatementSet {
+
+  override def addInsertSql(statement: String): StreamStatementSet
+
+  override def addInsert(targetPath: String, table: Table): StreamStatementSet
+
+  override def addInsert(targetPath: String, table: Table, overwrite: Boolean): StreamStatementSet
+
+  override def addInsert(targetDescriptor: TableDescriptor, table: Table): StreamStatementSet
+
+  override def addInsert(
+      targetDescriptor: TableDescriptor,
+      table: Table,
+      overwrite: Boolean)
+    : StreamStatementSet
+
+  /**
+   * Optimizes all statements as one entity and adds them as transformations to the underlying
+   * [[StreamExecutionEnvironment]].
+   *
+   * Use [[StreamExecutionEnvironment.execute()]] to execute them.
+   *
+   * The added statements will be cleared after calling this method.
+   */
+  def attachAsDataStream(): Unit
+}

--- a/flink-table/flink-table-api-scala-bridge/src/main/scala/org/apache/flink/table/api/bridge/scala/StreamTableEnvironment.scala
+++ b/flink-table/flink-table-api-scala-bridge/src/main/scala/org/apache/flink/table/api/bridge/scala/StreamTableEnvironment.scala
@@ -584,6 +584,17 @@ trait StreamTableEnvironment extends TableEnvironment {
         table: Table, targetSchema: Schema, changelogMode: ChangelogMode): DataStream[Row]
 
   /**
+   * Returns a [[StatementSet]] that integrates with the Scala-specific [[DataStream]] API.
+   *
+   * It accepts pipelines defined by DML statements or [[Table]] objects. The planner can
+   * optimize all added statements together and then either submit them as one job or attach them
+   * to the underlying [[StreamExecutionEnvironment]].
+   *
+   * @return statement set builder for the Scala-specific [[DataStream]] API
+   */
+  def createStatementSet(): StreamStatementSet
+
+  /**
     * Converts the given [[DataStream]] into a [[Table]] with specified field names.
     *
     * There are two modes for mapping original fields to the fields of the [[Table]]:

--- a/flink-table/flink-table-api-scala-bridge/src/main/scala/org/apache/flink/table/api/bridge/scala/internal/StreamStatementSetImpl.scala
+++ b/flink-table/flink-table-api-scala-bridge/src/main/scala/org/apache/flink/table/api/bridge/scala/internal/StreamStatementSetImpl.scala
@@ -1,0 +1,68 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.flink.table.api.bridge.scala.internal
+
+import org.apache.flink.annotation.Internal
+import org.apache.flink.table.api.bridge.scala.StreamStatementSet
+import org.apache.flink.table.api.internal.StatementSetImpl
+import org.apache.flink.table.api.{Table, TableDescriptor}
+
+/** Implementation for [[StreamStatementSet]]. */
+@Internal
+class StreamStatementSetImpl(tableEnvironment: StreamTableEnvironmentImpl)
+    extends StatementSetImpl[StreamTableEnvironmentImpl](tableEnvironment)
+    with StreamStatementSet {
+
+  override def addInsertSql(statement: String): StreamStatementSet = {
+    super.addInsertSql(statement).asInstanceOf[StreamStatementSet]
+  }
+
+  override def addInsert(targetPath: String, table: Table): StreamStatementSet = {
+    super.addInsert(targetPath, table).asInstanceOf[StreamStatementSet]
+  }
+
+  override def addInsert(
+      targetPath: String,
+      table: Table,
+      overwrite: Boolean)
+    : StreamStatementSet = {
+    super.addInsert(targetPath, table, overwrite).asInstanceOf[StreamStatementSet]
+  }
+
+  override def addInsert(targetDescriptor: TableDescriptor, table: Table): StreamStatementSet = {
+    super.addInsert(targetDescriptor, table).asInstanceOf[StreamStatementSet]
+  }
+
+  override def addInsert(
+      targetDescriptor: TableDescriptor,
+      table: Table,
+      overwrite: Boolean)
+    : StreamStatementSet = {
+    super.addInsert(targetDescriptor, table, overwrite).asInstanceOf[StreamStatementSet]
+  }
+
+  override def attachAsDataStream(): Unit = {
+    try {
+      tableEnvironment.attachAsDataStream(operations)
+    }
+    finally {
+      operations.clear()
+    }
+  }
+}

--- a/flink-table/flink-table-api-scala-bridge/src/main/scala/org/apache/flink/table/api/bridge/scala/internal/StreamTableEnvironmentImpl.scala
+++ b/flink-table/flink-table-api-scala-bridge/src/main/scala/org/apache/flink/table/api/bridge/scala/internal/StreamTableEnvironmentImpl.scala
@@ -19,7 +19,6 @@ package org.apache.flink.table.api.bridge.scala.internal
 
 import java.util
 import java.util.{Collections, List => JList}
-
 import javax.annotation.Nullable
 import org.apache.flink.annotation.Internal
 import org.apache.flink.api.common.typeinfo.TypeInformation
@@ -30,6 +29,7 @@ import org.apache.flink.streaming.api.datastream.{DataStream => JDataStream}
 import org.apache.flink.streaming.api.environment.{StreamExecutionEnvironment => JStreamExecutionEnvironment}
 import org.apache.flink.streaming.api.scala.{DataStream, StreamExecutionEnvironment}
 import org.apache.flink.table.api._
+import org.apache.flink.table.api.bridge.scala.StreamStatementSet
 import org.apache.flink.table.api.internal.TableEnvironmentImpl
 import org.apache.flink.table.catalog.SchemaTranslator.ProducingResult
 import org.apache.flink.table.catalog._
@@ -302,6 +302,16 @@ class StreamTableEnvironmentImpl (
     javaExecutionEnvironment.configure(tableConfig.getConfiguration)
 
     new DataStream[T](new JDataStream[T](javaExecutionEnvironment, streamTransformation))
+  }
+
+  override def createStatementSet(): StreamStatementSet = {
+    new StreamStatementSetImpl(this)
+  }
+
+  private[internal] def attachAsDataStream(modifyOperations: JList[ModifyOperation]) {
+    val javaEnv = scalaExecutionEnvironment.getJavaEnv
+    val transformations = translate(modifyOperations).asScala
+    transformations.foreach(javaEnv.addOperator)
   }
 
   override def fromDataStream[T](dataStream: DataStream[T], fields: Expression*): Table = {


### PR DESCRIPTION
## What is the purpose of the change

This adds `StreamStatementSet.attachToDataStream()` as mentioned in FLIP-136.

## Brief change log

`StreamTableEnvironment.createStatementSet` return `StreamStatementSet` in Java and Scala.

## Verifying this change

This change added tests and can be verified as follows: `DataStreamJavaITCase`

## Does this pull request potentially affect one of the following parts:

  - Dependencies (does it add or upgrade a dependency): no
  - The public API, i.e., is any changed class annotated with `@Public(Evolving)`: yes
  - The serializers: no
  - The runtime per-record code paths (performance sensitive): no
  - Anything that affects deployment or recovery: JobManager (and its components), Checkpointing, Kubernetes/Yarn, ZooKeeper: no
  - The S3 file system connector: no

## Documentation

  - Does this pull request introduce a new feature? yes
  - If yes, how is the feature documented? docs
