### PR TITLE
[FLINK-23769][DOC]Delete the superfluous Chinese text for the English…

### DIFF
--- a/docs/content/docs/deployment/resource-providers/yarn.md
+++ b/docs/content/docs/deployment/resource-providers/yarn.md
@@ -38,7 +38,6 @@ Flink services are submitted to YARN's ResourceManager, which spawns containers 
 
 Flink can dynamically allocate and de-allocate TaskManager resources depending on the number of processing slots required by the job(s) running on the JobManager.
 
- [测试]({{< downloads >}}) 
 
 ### Preparation
 


### PR DESCRIPTION
https://ci.apache.org/projects/flink/flink-docs-master/docs/deployment/resource-providers/yarn/

The following line is added to the English page,For this page, this line  is redundant.
```
 [测试]({{< downloads >}}) 
```
 
This issue was introduced during a previous fix for download links(https://issues.apache.org/jira/browse/FLINK-23581)
 