### PR TITLE
[FLINK-23759][runtime][checkpoint] Ignore the restored checkpoints when reporting latest completed id with abortion message

### DIFF
--- a/flink-runtime/src/main/java/org/apache/flink/runtime/checkpoint/CheckpointCoordinator.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/checkpoint/CheckpointCoordinator.java
@@ -1371,43 +1371,6 @@ public class CheckpointCoordinator {
     // --------------------------------------------------------------------------------------------
 
     /**
-     * Restores the latest checkpointed state.
-     *
-     * @param tasks Map of job vertices to restore. State for these vertices is restored via {@link
-     *     Execution#setInitialState(JobManagerTaskRestore)}.
-     * @param errorIfNoCheckpoint Fail if no completed checkpoint is available to restore from.
-     * @param allowNonRestoredState Allow checkpoint state that cannot be mapped to any job vertex
-     *     in tasks.
-     * @return <code>true</code> if state was restored, <code>false</code> otherwise.
-     * @throws IllegalStateException If the CheckpointCoordinator is shut down.
-     * @throws IllegalStateException If no completed checkpoint is available and the <code>
-     *     failIfNoCheckpoint</code> flag has been set.
-     * @throws IllegalStateException If the checkpoint contains state that cannot be mapped to any
-     *     job vertex in <code>tasks</code> and the <code>allowNonRestoredState</code> flag has not
-     *     been set.
-     * @throws IllegalStateException If the max parallelism changed for an operator that restores
-     *     state from this checkpoint.
-     * @throws IllegalStateException If the parallelism changed for an operator that restores
-     *     <i>non-partitioned</i> state from this checkpoint.
-     */
-    @Deprecated
-    public boolean restoreLatestCheckpointedState(
-            Map<JobVertexID, ExecutionJobVertex> tasks,
-            boolean errorIfNoCheckpoint,
-            boolean allowNonRestoredState)
-            throws Exception {
-
-        final OptionalLong restoredCheckpointId =
-                restoreLatestCheckpointedStateInternal(
-                        new HashSet<>(tasks.values()),
-                        OperatorCoordinatorRestoreBehavior.RESTORE_OR_RESET,
-                        errorIfNoCheckpoint,
-                        allowNonRestoredState);
-
-        return restoredCheckpointId.isPresent();
-    }
-
-    /**
      * Restores the latest checkpointed state to a set of subtasks. This method represents a "local"
      * or "regional" failover and does restore states to coordinators. Note that a regional failover
      * might still include all tasks.

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/checkpoint/CompletedCheckpointStore.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/checkpoint/CompletedCheckpointStore.java
@@ -77,21 +77,6 @@ public interface CompletedCheckpointStore {
         return lastCompleted;
     }
 
-    /** Returns the id of the latest completed checkpoints. */
-    default long getLatestCheckpointId() {
-        try {
-            List<CompletedCheckpoint> allCheckpoints = getAllCheckpoints();
-            if (allCheckpoints.isEmpty()) {
-                return 0;
-            }
-
-            return allCheckpoints.get(allCheckpoints.size() - 1).getCheckpointID();
-        } catch (Throwable throwable) {
-            LOG.warn("Get the latest completed checkpoints failed", throwable);
-            return 0;
-        }
-    }
-
     /**
      * Shuts down the store.
      *

--- a/flink-runtime/src/test/java/org/apache/flink/runtime/checkpoint/CheckpointCoordinatorTest.java
+++ b/flink-runtime/src/test/java/org/apache/flink/runtime/checkpoint/CheckpointCoordinatorTest.java
@@ -3607,6 +3607,80 @@ public class CheckpointCoordinatorTest extends TestLogger {
         assertEquals(completedCheckpointId, reportedCheckpointId.get());
     }
 
+    @Test
+    public void testNotReportRestoredCompletedCheckpointIdWithAbort() throws Exception {
+        JobVertexID jobVertexID = new JobVertexID();
+        ExecutionGraph graph =
+                new CheckpointCoordinatorTestingUtils.CheckpointExecutionGraphBuilder()
+                        .addJobVertex(jobVertexID)
+                        .setTransitToRunning(false)
+                        .build();
+
+        ExecutionVertex task = graph.getJobVertex(jobVertexID).getTaskVertices()[0];
+        AtomicLong reportedCheckpointId = new AtomicLong(Long.MIN_VALUE);
+        LogicalSlot slot =
+                new TestingLogicalSlotBuilder()
+                        .setTaskManagerGateway(
+                                new SimpleAckingTaskManagerGateway() {
+                                    @Override
+                                    public void notifyCheckpointAborted(
+                                            ExecutionAttemptID executionAttemptID,
+                                            JobID jobId,
+                                            long checkpointId,
+                                            long latestCompletedCheckpointId,
+                                            long timestamp) {
+                                        reportedCheckpointId.set(latestCompletedCheckpointId);
+                                    }
+                                })
+                        .createTestingLogicalSlot();
+        ExecutionGraphTestUtils.setVertexResource(task, slot);
+        task.getCurrentExecutionAttempt().transitionState(ExecutionState.RUNNING);
+
+        CompletedCheckpoint restoredCheckpoint =
+                new CompletedCheckpoint(
+                        graph.getJobID(),
+                        5,
+                        5,
+                        5,
+                        Collections.emptyMap(),
+                        null,
+                        CheckpointProperties.forCheckpoint(
+                                CheckpointRetentionPolicy.NEVER_RETAIN_AFTER_TERMINATION),
+                        new TestCompletedCheckpointStorageLocation());
+        CompletedCheckpointStore completedCheckpointStore =
+                new StandaloneCompletedCheckpointStore(10);
+        completedCheckpointStore.addCheckpoint(
+                restoredCheckpoint, new CheckpointsCleaner(), () -> {});
+        StandaloneCheckpointIDCounter checkpointIDCounter = new StandaloneCheckpointIDCounter();
+        checkpointIDCounter.setCount(6);
+
+        CheckpointCoordinator checkpointCoordinator =
+                new CheckpointCoordinatorBuilder()
+                        .setExecutionGraph(graph)
+                        .setTimer(manuallyTriggeredScheduledExecutor)
+                        .setCompletedCheckpointStore(completedCheckpointStore)
+                        .setCheckpointIDCounter(checkpointIDCounter)
+                        .setAllowCheckpointsAfterTasksFinished(true)
+                        .build();
+        checkpointCoordinator.restoreLatestCheckpointedStateToSubtasks(
+                new HashSet<>(graph.getAllVertices().values()));
+
+        CompletableFuture<?> result = checkpointCoordinator.triggerCheckpoint(false);
+        manuallyTriggeredScheduledExecutor.triggerAll();
+        long abortedCheckpointId =
+                checkpointCoordinator.getPendingCheckpoints().entrySet().iterator().next().getKey();
+        checkpointCoordinator.receiveDeclineMessage(
+                new DeclineCheckpoint(
+                        graph.getJobID(),
+                        task.getCurrentExecutionAttempt().getAttemptId(),
+                        abortedCheckpointId,
+                        new CheckpointException(CHECKPOINT_EXPIRED)),
+                "localhost");
+        assertTrue(result.isCompletedExceptionally());
+
+        assertEquals(0, reportedCheckpointId.get());
+    }
+
     private CheckpointCoordinator getCheckpointCoordinator(ExecutionGraph graph) throws Exception {
         return new CheckpointCoordinatorBuilder()
                 .setExecutionGraph(graph)

--- a/flink-runtime/src/test/java/org/apache/flink/runtime/checkpoint/CompletedCheckpointStoreTest.java
+++ b/flink-runtime/src/test/java/org/apache/flink/runtime/checkpoint/CompletedCheckpointStoreTest.java
@@ -198,21 +198,6 @@ public abstract class CompletedCheckpointStoreTest extends TestLogger {
         }
     }
 
-    @Test
-    public void testAcquireLatestCompletedCheckpointId() throws Exception {
-        SharedStateRegistry sharedStateRegistry = new SharedStateRegistry();
-        CompletedCheckpointStore checkpoints = createRecoveredCompletedCheckpointStore(1);
-        assertEquals(0, checkpoints.getLatestCheckpointId());
-
-        checkpoints.addCheckpoint(
-                createCheckpoint(2, sharedStateRegistry), new CheckpointsCleaner(), () -> {});
-        assertEquals(2, checkpoints.getLatestCheckpointId());
-
-        checkpoints.addCheckpoint(
-                createCheckpoint(4, sharedStateRegistry), new CheckpointsCleaner(), () -> {});
-        assertEquals(4, checkpoints.getLatestCheckpointId());
-    }
-
     // ---------------------------------------------------------------------------------------------
 
     public static TestCompletedCheckpoint createCheckpoint(


### PR DESCRIPTION
## What is the purpose of the change

This PR fixes the problem that when reporting the latest completed id with the abortion message, the restored checkpoints should be ignored, otherwise some operator would be failed due to report completed of a checkpoint without snapshotting.

## Brief change log

- 3049e0b3134673e9245bd5d27e9dbeb8a641baf0 now keeps the completed id directly without taking it from the completed checkpoint store.

## Verifying this change

This change is verified via the added UT.

## Does this pull request potentially affect one of the following parts:

  - Dependencies (does it add or upgrade a dependency): **no**
  - The public API, i.e., is any changed class annotated with `@Public(Evolving)`: **no**
  - The serializers: **no**
  - The runtime per-record code paths (performance sensitive):**no**
  - Anything that affects deployment or recovery: JobManager (and its components), Checkpointing, Kubernetes/Yarn, ZooKeeper: **yes**
  - The S3 file system connector: (yes / no / don't know)**no**

## Documentation

  - Does this pull request introduce a new feature?  **no** 
  - If yes, how is the feature documented? **not applicable**
