### PR TITLE
[FLINK-23770][runtime][checkpoint] Retrieve the state with both uidHash and generated ID on checking finished state consistency

### DIFF
--- a/flink-runtime/src/main/java/org/apache/flink/runtime/checkpoint/VertexFinishedStateChecker.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/checkpoint/VertexFinishedStateChecker.java
@@ -196,7 +196,9 @@ public class VertexFinishedStateChecker {
         private VertexFinishedState checkOperatorFinishedStatus(
                 Map<OperatorID, OperatorState> operatorStates, OperatorIDPair idPair) {
             OperatorID operatorId =
-                    idPair.getUserDefinedOperatorID().orElse(idPair.getGeneratedOperatorID());
+                    idPair.getUserDefinedOperatorID()
+                            .filter(operatorStates::containsKey)
+                            .orElse(idPair.getGeneratedOperatorID());
             return Optional.ofNullable(operatorStates.get(operatorId))
                     .map(
                             operatorState -> {


### PR DESCRIPTION
## What is the purpose of the change

This PR fixes the issue that if uidHash is set, when checking finished state consistency the checker only retrieve state with the uidHash, but if the checkpoint is taking after the job started, the state would be keyed with the generated id.

## Brief change log

- da755cb1681130e773f6b57fb925f85854d159d7 fixes the issue by only retrieve the state with uidHash if uidHash is configured and there are state keyed with it.

## Verifying this change

This change is verified with the added UT.

## Does this pull request potentially affect one of the following parts:

  - Dependencies (does it add or upgrade a dependency): **no**
  - The public API, i.e., is any changed class annotated with `@Public(Evolving)`: **no**
  - The serializers: **no**
  - The runtime per-record code paths (performance sensitive): **no**
  - Anything that affects deployment or recovery: JobManager (and its components), Checkpointing, Kubernetes/Yarn, ZooKeeper: **yes**
  - The S3 file system connector: **no**

## Documentation

  - Does this pull request introduce a new feature? **no**
  - If yes, how is the feature documented? **not applicable**
