### PR TITLE
[FLINK-23686][connector/kafka] Increase counter "commitsSucceeded" per commit instead of per partition

### DIFF
--- a/flink-connectors/flink-connector-kafka/src/main/java/org/apache/flink/connector/kafka/source/metrics/KafkaSourceReaderMetrics.java
+++ b/flink-connectors/flink-connector-kafka/src/main/java/org/apache/flink/connector/kafka/source/metrics/KafkaSourceReaderMetrics.java
@@ -137,8 +137,12 @@ public class KafkaSourceReaderMetrics {
      */
     public void recordCommittedOffset(TopicPartition tp, long offset) {
         checkTopicPartitionTracked(tp);
-        commitsSucceeded.inc();
         offsets.get(tp).committedOffset = offset;
+    }
+
+    /** Mark a successful commit. */
+    public void recordSucceededCommit() {
+        commitsSucceeded.inc();
     }
 
     /** Mark a failure commit. */

--- a/flink-connectors/flink-connector-kafka/src/main/java/org/apache/flink/connector/kafka/source/reader/KafkaSourceReader.java
+++ b/flink-connectors/flink-connector-kafka/src/main/java/org/apache/flink/connector/kafka/source/reader/KafkaSourceReader.java
@@ -130,6 +130,7 @@ public class KafkaSourceReader<T>
                                 LOG.debug(
                                         "Successfully committed offsets for checkpoint {}",
                                         checkpointId);
+                                kafkaSourceReaderMetrics.recordSucceededCommit();
                                 // If the finished topic partition has been committed, we remove it
                                 // from the offsets of the finished splits map.
                                 Map<TopicPartition, OffsetAndMetadata> committedPartitions =

--- a/flink-connectors/flink-connector-kafka/src/test/java/org/apache/flink/connector/kafka/source/metrics/KafkaSourceReaderMetricsTest.java
+++ b/flink-connectors/flink-connector-kafka/src/test/java/org/apache/flink/connector/kafka/source/metrics/KafkaSourceReaderMetricsTest.java
@@ -83,7 +83,17 @@ public class KafkaSourceReaderMetricsTest {
         assertCommittedOffset(BAR_1, 15513L, metricListener);
 
         assertEquals(
-                4L,
+                0L,
+                metricListener
+                        .getCounter(
+                                KafkaSourceReaderMetrics.KAFKA_SOURCE_READER_METRIC_GROUP,
+                                KafkaSourceReaderMetrics.COMMITS_SUCCEEDED_METRIC_COUNTER)
+                        .getCount());
+
+        kafkaSourceReaderMetrics.recordSucceededCommit();
+
+        assertEquals(
+                1L,
                 metricListener
                         .getCounter(
                                 KafkaSourceReaderMetrics.KAFKA_SOURCE_READER_METRIC_GROUP,

--- a/flink-connectors/flink-connector-kafka/src/test/java/org/apache/flink/connector/kafka/source/reader/KafkaSourceReaderTest.java
+++ b/flink-connectors/flink-connector-kafka/src/test/java/org/apache/flink/connector/kafka/source/reader/KafkaSourceReaderTest.java
@@ -51,6 +51,7 @@ import org.junit.Test;
 
 import java.time.Duration;
 import java.util.ArrayList;
+import java.util.Arrays;
 import java.util.Collections;
 import java.util.List;
 import java.util.Map;
@@ -237,7 +238,8 @@ public class KafkaSourceReaderTest extends SourceReaderTestBase<KafkaPartitionSp
     public void testKafkaSourceMetrics() throws Exception {
         final MetricListener metricListener = new MetricListener();
         final String groupId = "testKafkaSourceMetrics";
-        final TopicPartition tp = new TopicPartition(TOPIC, 0);
+        final TopicPartition tp0 = new TopicPartition(TOPIC, 0);
+        final TopicPartition tp1 = new TopicPartition(TOPIC, 1);
 
         try (KafkaSourceReader<Integer> reader =
                 (KafkaSourceReader<Integer>)
@@ -246,28 +248,32 @@ public class KafkaSourceReaderTest extends SourceReaderTestBase<KafkaPartitionSp
                                 groupId,
                                 metricListener.getMetricGroup())) {
 
-            KafkaPartitionSplit split =
-                    new KafkaPartitionSplit(tp, KafkaPartitionSplit.EARLIEST_OFFSET);
-            reader.addSplits(Collections.singletonList(split));
+            KafkaPartitionSplit split0 =
+                    new KafkaPartitionSplit(tp0, KafkaPartitionSplit.EARLIEST_OFFSET);
+            KafkaPartitionSplit split1 =
+                    new KafkaPartitionSplit(tp1, KafkaPartitionSplit.EARLIEST_OFFSET);
+            reader.addSplits(Arrays.asList(split0, split1));
 
             TestingReaderOutput<Integer> output = new TestingReaderOutput<>();
             pollUntil(
                     reader,
                     output,
-                    () -> output.getEmittedRecords().size() == NUM_RECORDS_PER_SPLIT,
+                    () -> output.getEmittedRecords().size() == NUM_RECORDS_PER_SPLIT * 2,
                     String.format(
-                            "Failed to poll %d records until timeout", NUM_RECORDS_PER_SPLIT));
+                            "Failed to poll %d records until timeout", NUM_RECORDS_PER_SPLIT * 2));
 
             // Metric "records-consumed-total" of KafkaConsumer should be NUM_RECORDS_PER_SPLIT
             assertEquals(
-                    NUM_RECORDS_PER_SPLIT,
+                    NUM_RECORDS_PER_SPLIT * 2,
                     getKafkaConsumerMetric("records-consumed-total", metricListener));
 
             // Current consuming offset should be NUM_RECORD_PER_SPLIT - 1
-            assertEquals(NUM_RECORDS_PER_SPLIT - 1, getCurrentOffsetMetric(tp, metricListener));
+            assertEquals(NUM_RECORDS_PER_SPLIT - 1, getCurrentOffsetMetric(tp0, metricListener));
+            assertEquals(NUM_RECORDS_PER_SPLIT - 1, getCurrentOffsetMetric(tp1, metricListener));
 
             // No offset is committed till now
-            assertEquals(INITIAL_OFFSET, getCommittedOffsetMetric(tp, metricListener));
+            assertEquals(INITIAL_OFFSET, getCommittedOffsetMetric(tp0, metricListener));
+            assertEquals(INITIAL_OFFSET, getCommittedOffsetMetric(tp1, metricListener));
 
             // Trigger offset commit
             reader.snapshotState(15213L);
@@ -283,7 +289,8 @@ public class KafkaSourceReaderTest extends SourceReaderTestBase<KafkaPartitionSp
             assertEquals(1, getKafkaConsumerMetric("commit-total", metricListener));
 
             // Committed offset should be NUM_RECORD_PER_SPLIT
-            assertEquals(NUM_RECORDS_PER_SPLIT, getCommittedOffsetMetric(tp, metricListener));
+            assertEquals(NUM_RECORDS_PER_SPLIT, getCommittedOffsetMetric(tp0, metricListener));
+            assertEquals(NUM_RECORDS_PER_SPLIT, getCommittedOffsetMetric(tp1, metricListener));
 
             // Number of successful commits should be 1
             assertEquals(


### PR DESCRIPTION
## What is the purpose of the change

This pull request fixes a bug that counter "commitsSucceeded" is increased per partition instead of per commit.


## Brief change log
- Extract ```recordSucceededCommit``` as an individual method in ```KafkaSourceReaderMetrics```
- Invoke ```recordSucceededCommit``` in Kafka consumer commit callback

## Verifying this change

This change added tests and can be verified as follows:
- Subscribe to two partitions in ```KafkaSourceReader```
- Commit offset only once, and "commitsSucceeded" should be 1 instead of 2

## Does this pull request potentially affect one of the following parts:

  - Dependencies (does it add or upgrade a dependency): (no)
  - The public API, i.e., is any changed class annotated with `@Public(Evolving)`: (no)
  - The serializers: (no)
  - The runtime per-record code paths (performance sensitive): (no)
  - Anything that affects deployment or recovery: JobManager (and its components), Checkpointing, Kubernetes/Yarn, ZooKeeper: (no)
  - The S3 file system connector: (no)

## Documentation

  - Does this pull request introduce a new feature? (no)
  - If yes, how is the feature documented? (not applicable)
