### PR TITLE
[FLINK-23189][checkpoint] Count and fail the task in case of IOExceptions in CheckpointCoordinator

### DIFF
--- a/flink-runtime/src/main/java/org/apache/flink/runtime/checkpoint/CheckpointCoordinator.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/checkpoint/CheckpointCoordinator.java
@@ -2132,10 +2132,16 @@ public class CheckpointCoordinator {
     private static CheckpointException getCheckpointException(
             CheckpointFailureReason defaultReason, Throwable throwable) {
 
-        final Optional<CheckpointException> checkpointExceptionOptional =
-                findThrowable(throwable, CheckpointException.class);
-        return checkpointExceptionOptional.orElseGet(
-                () -> new CheckpointException(defaultReason, throwable));
+        final Optional<IOException> ioExceptionOptional =
+                findThrowable(throwable, IOException.class);
+        if (ioExceptionOptional.isPresent()) {
+            return new CheckpointException(CheckpointFailureReason.IO_EXCEPTION, throwable);
+        } else {
+            final Optional<CheckpointException> checkpointExceptionOptional =
+                    findThrowable(throwable, CheckpointException.class);
+            return checkpointExceptionOptional.orElseGet(
+                    () -> new CheckpointException(defaultReason, throwable));
+        }
     }
 
     private static class CheckpointIdAndStorageLocation {

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/checkpoint/CheckpointFailureManager.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/checkpoint/CheckpointFailureManager.java
@@ -127,7 +127,6 @@ public class CheckpointFailureManager {
             case CHECKPOINT_DECLINED_SUBSUMED:
             case CHECKPOINT_DECLINED_INPUT_END_OF_STREAM:
 
-            case EXCEPTION:
             case TASK_FAILURE:
             case TASK_CHECKPOINT_FAILURE:
             case UNKNOWN_TASK_CHECKPOINT_NOTIFICATION_FAILURE:

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/checkpoint/CheckpointFailureManager.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/checkpoint/CheckpointFailureManager.java
@@ -136,6 +136,7 @@ public class CheckpointFailureManager {
                 // ignore
                 break;
 
+            case IO_EXCEPTION:
             case CHECKPOINT_ASYNC_EXCEPTION:
             case CHECKPOINT_DECLINED:
             case CHECKPOINT_EXPIRED:

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/checkpoint/CheckpointFailureReason.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/checkpoint/CheckpointFailureReason.java
@@ -81,7 +81,10 @@ public enum CheckpointFailureReason {
 
     FINALIZE_CHECKPOINT_FAILURE(false, "Failure to finalize checkpoint."),
 
-    TRIGGER_CHECKPOINT_FAILURE(false, "Trigger checkpoint failure.");
+    TRIGGER_CHECKPOINT_FAILURE(false, "Trigger checkpoint failure."),
+
+    IO_EXCEPTION(
+            false, "An Exception occurred while triggering the checkpoint. IO-problem detected.");
 
     // ------------------------------------------------------------------------
 

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/checkpoint/CheckpointFailureReason.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/checkpoint/CheckpointFailureReason.java
@@ -34,7 +34,8 @@ public enum CheckpointFailureReason {
 
     NOT_ALL_REQUIRED_TASKS_RUNNING(true, "Not all required tasks are currently running."),
 
-    EXCEPTION(true, "An Exception occurred while triggering the checkpoint."),
+    IO_EXCEPTION(
+            true, "An Exception occurred while triggering the checkpoint. IO-problem detected."),
 
     CHECKPOINT_ASYNC_EXCEPTION(false, "Asynchronous task checkpoint failed."),
 
@@ -81,10 +82,7 @@ public enum CheckpointFailureReason {
 
     FINALIZE_CHECKPOINT_FAILURE(false, "Failure to finalize checkpoint."),
 
-    TRIGGER_CHECKPOINT_FAILURE(false, "Trigger checkpoint failure."),
-
-    IO_EXCEPTION(
-            false, "An Exception occurred while triggering the checkpoint. IO-problem detected.");
+    TRIGGER_CHECKPOINT_FAILURE(false, "Trigger checkpoint failure.");
 
     // ------------------------------------------------------------------------
 

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/checkpoint/OperatorCoordinatorCheckpoints.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/checkpoint/OperatorCoordinatorCheckpoints.java
@@ -21,10 +21,13 @@ package org.apache.flink.runtime.checkpoint;
 import org.apache.flink.runtime.operators.coordination.OperatorCoordinator;
 import org.apache.flink.runtime.operators.coordination.OperatorInfo;
 import org.apache.flink.runtime.state.memory.ByteStreamStateHandle;
+import org.apache.flink.util.ExceptionUtils;
 import org.apache.flink.util.concurrent.FutureUtils;
 
+import java.io.IOException;
 import java.util.ArrayList;
 import java.util.Collection;
+import java.util.Optional;
 import java.util.concurrent.CompletableFuture;
 import java.util.concurrent.CompletionException;
 import java.util.concurrent.Executor;
@@ -121,14 +124,17 @@ final class OperatorCoordinatorCheckpoints {
                 final Throwable error =
                         checkpoint.isDisposed() ? checkpoint.getFailureCause() : null;
 
+                CheckpointFailureReason reason = CheckpointFailureReason.TRIGGER_CHECKPOINT_FAILURE;
                 if (error != null) {
-                    throw new CheckpointException(
-                            errorMessage,
-                            CheckpointFailureReason.TRIGGER_CHECKPOINT_FAILURE,
-                            error);
+                    final Optional<IOException> ioExceptionOptional =
+                            ExceptionUtils.findThrowable(error, IOException.class);
+                    if (ioExceptionOptional.isPresent()) {
+                        reason = CheckpointFailureReason.IO_EXCEPTION;
+                    }
+
+                    throw new CheckpointException(errorMessage, reason, error);
                 } else {
-                    throw new CheckpointException(
-                            errorMessage, CheckpointFailureReason.TRIGGER_CHECKPOINT_FAILURE);
+                    throw new CheckpointException(errorMessage, reason);
                 }
             }
         }

--- a/flink-runtime/src/test/java/org/apache/flink/runtime/checkpoint/CheckpointCoordinatorTest.java
+++ b/flink-runtime/src/test/java/org/apache/flink/runtime/checkpoint/CheckpointCoordinatorTest.java
@@ -111,6 +111,7 @@ import static org.apache.flink.runtime.checkpoint.CheckpointFailureReason.CHECKP
 import static org.apache.flink.runtime.checkpoint.CheckpointFailureReason.CHECKPOINT_DECLINED;
 import static org.apache.flink.runtime.checkpoint.CheckpointFailureReason.CHECKPOINT_EXPIRED;
 import static org.apache.flink.runtime.checkpoint.CheckpointFailureReason.IO_EXCEPTION;
+import static org.apache.flink.runtime.checkpoint.CheckpointFailureReason.PERIODIC_SCHEDULER_SHUTDOWN;
 import static org.apache.flink.util.Preconditions.checkNotNull;
 import static org.apache.flink.util.Preconditions.checkState;
 import static org.junit.Assert.assertEquals;
@@ -346,74 +347,64 @@ public class CheckpointCoordinatorTest extends TestLogger {
     }
 
     @Test
-    public void testCheckpointAbortsIfTriggerTasksAreNotExecuted() {
-        try {
-            // set up the coordinator and validate the initial state
-            ExecutionGraph graph =
-                    new CheckpointCoordinatorTestingUtils.CheckpointExecutionGraphBuilder()
-                            .addJobVertex(new JobVertexID())
-                            .addJobVertex(new JobVertexID(), false)
-                            .setTransitToRunning(false)
-                            .build();
+    public void testCheckpointAbortsIfTriggerTasksAreNotExecuted() throws Exception {
+        // set up the coordinator and validate the initial state
+        ExecutionGraph graph =
+                new CheckpointCoordinatorTestingUtils.CheckpointExecutionGraphBuilder()
+                        .addJobVertex(new JobVertexID())
+                        .addJobVertex(new JobVertexID(), false)
+                        .setTransitToRunning(false)
+                        .build();
 
-            CheckpointCoordinator checkpointCoordinator = getCheckpointCoordinator(graph);
+        CheckpointCoordinator checkpointCoordinator = getCheckpointCoordinator(graph);
 
-            // nothing should be happening
-            assertEquals(0, checkpointCoordinator.getNumberOfPendingCheckpoints());
-            assertEquals(0, checkpointCoordinator.getNumberOfRetainedSuccessfulCheckpoints());
+        // nothing should be happening
+        assertEquals(0, checkpointCoordinator.getNumberOfPendingCheckpoints());
+        assertEquals(0, checkpointCoordinator.getNumberOfRetainedSuccessfulCheckpoints());
 
-            // trigger the first checkpoint. this should not succeed
-            final CompletableFuture<CompletedCheckpoint> checkpointFuture =
-                    checkpointCoordinator.triggerCheckpoint(false);
-            manuallyTriggeredScheduledExecutor.triggerAll();
-            assertTrue(checkpointFuture.isCompletedExceptionally());
+        // trigger the first checkpoint. this should not succeed
+        final CompletableFuture<CompletedCheckpoint> checkpointFuture =
+                checkpointCoordinator.triggerCheckpoint(false);
+        manuallyTriggeredScheduledExecutor.triggerAll();
+        assertTrue(checkpointFuture.isCompletedExceptionally());
 
-            // still, nothing should be happening
-            assertEquals(0, checkpointCoordinator.getNumberOfPendingCheckpoints());
-            assertEquals(0, checkpointCoordinator.getNumberOfRetainedSuccessfulCheckpoints());
+        // still, nothing should be happening
+        assertEquals(0, checkpointCoordinator.getNumberOfPendingCheckpoints());
+        assertEquals(0, checkpointCoordinator.getNumberOfRetainedSuccessfulCheckpoints());
 
-            checkpointCoordinator.shutdown();
-        } catch (Exception e) {
-            e.printStackTrace();
-            fail(e.getMessage());
-        }
+        checkpointCoordinator.shutdown();
     }
 
     @Test
-    public void testCheckpointAbortsIfTriggerTasksAreFinished() {
-        try {
-            JobVertexID jobVertexID1 = new JobVertexID();
-            JobVertexID jobVertexID2 = new JobVertexID();
+    public void testCheckpointAbortsIfTriggerTasksAreFinished() throws Exception {
+        JobVertexID jobVertexID1 = new JobVertexID();
+        JobVertexID jobVertexID2 = new JobVertexID();
 
-            ExecutionGraph graph =
-                    new CheckpointCoordinatorTestingUtils.CheckpointExecutionGraphBuilder()
-                            .addJobVertex(jobVertexID1)
-                            .addJobVertex(jobVertexID2, false)
-                            .build();
+        ExecutionGraph graph =
+                new CheckpointCoordinatorTestingUtils.CheckpointExecutionGraphBuilder()
+                        .addJobVertex(jobVertexID1)
+                        .addJobVertex(jobVertexID2, false)
+                        .build();
 
-            CheckpointCoordinator checkpointCoordinator = getCheckpointCoordinator(graph);
-            Arrays.stream(graph.getJobVertex(jobVertexID1).getTaskVertices())
-                    .forEach(task -> task.getCurrentExecutionAttempt().markFinished());
+        CheckpointCoordinator checkpointCoordinator = getCheckpointCoordinator(graph);
+        Arrays.stream(graph.getJobVertex(jobVertexID1).getTaskVertices())
+                .forEach(task -> task.getCurrentExecutionAttempt().markFinished());
 
-            // nothing should be happening
-            assertEquals(0, checkpointCoordinator.getNumberOfPendingCheckpoints());
-            assertEquals(0, checkpointCoordinator.getNumberOfRetainedSuccessfulCheckpoints());
+        // nothing should be happening
+        assertEquals(0, checkpointCoordinator.getNumberOfPendingCheckpoints());
+        assertEquals(0, checkpointCoordinator.getNumberOfRetainedSuccessfulCheckpoints());
 
-            // trigger the first checkpoint. this should not succeed
-            final CompletableFuture<CompletedCheckpoint> checkpointFuture =
-                    checkpointCoordinator.triggerCheckpoint(false);
-            manuallyTriggeredScheduledExecutor.triggerAll();
-            assertTrue(checkpointFuture.isCompletedExceptionally());
+        // trigger the first checkpoint. this should not succeed
+        final CompletableFuture<CompletedCheckpoint> checkpointFuture =
+                checkpointCoordinator.triggerCheckpoint(false);
+        manuallyTriggeredScheduledExecutor.triggerAll();
+        assertTrue(checkpointFuture.isCompletedExceptionally());
 
-            // still, nothing should be happening
-            assertEquals(0, checkpointCoordinator.getNumberOfPendingCheckpoints());
-            assertEquals(0, checkpointCoordinator.getNumberOfRetainedSuccessfulCheckpoints());
+        // still, nothing should be happening
+        assertEquals(0, checkpointCoordinator.getNumberOfPendingCheckpoints());
+        assertEquals(0, checkpointCoordinator.getNumberOfRetainedSuccessfulCheckpoints());
 
-            checkpointCoordinator.shutdown();
-        } catch (Exception e) {
-            e.printStackTrace();
-            fail(e.getMessage());
-        }
+        checkpointCoordinator.shutdown();
     }
 
     @Test
@@ -614,16 +605,9 @@ public class CheckpointCoordinatorTest extends TestLogger {
 
             fail("Test failed.");
         } catch (Exception e) {
-            // expected
-            assertTrue(e instanceof RuntimeException);
-            assertEquals(errorMsg, e.getMessage());
+            ExceptionUtils.assertThrowableWithMessage(e, errorMsg);
         } finally {
-            try {
-                checkpointCoordinator.shutdown();
-            } catch (Exception e) {
-                e.printStackTrace();
-                fail(e.getMessage());
-            }
+            checkpointCoordinator.shutdown();
         }
     }
 
@@ -838,21 +822,19 @@ public class CheckpointCoordinatorTest extends TestLogger {
 
             fail("Test failed.");
         } catch (Exception e) {
-            // expected
-            assertTrue(e instanceof RuntimeException);
-            assertEquals(errorMsg, e.getMessage());
+            ExceptionUtils.assertThrowableWithMessage(e, errorMsg);
         } finally {
             checkpointCoordinator.shutdown();
         }
     }
 
     @Test
-    public void testTriggerAndDeclineSyncCheckpointFailureSimple() {
+    public void testTriggerAndDeclineSyncCheckpointFailureSimple() throws Exception {
         testTriggerAndDeclineCheckpointSimple(CHECKPOINT_DECLINED);
     }
 
     @Test
-    public void testTriggerAndDeclineAsyncCheckpointFailureSimple() {
+    public void testTriggerAndDeclineAsyncCheckpointFailureSimple() throws Exception {
         testTriggerAndDeclineCheckpointSimple(CHECKPOINT_ASYNC_EXCEPTION);
     }
 
@@ -862,141 +844,131 @@ public class CheckpointCoordinatorTest extends TestLogger {
      * triggered.
      */
     private void testTriggerAndDeclineCheckpointSimple(
-            CheckpointFailureReason checkpointFailureReason) {
-        try {
-            final CheckpointException checkpointException =
-                    new CheckpointException(checkpointFailureReason);
+            CheckpointFailureReason checkpointFailureReason) throws Exception {
+        final CheckpointException checkpointException =
+                new CheckpointException(checkpointFailureReason);
 
-            JobVertexID jobVertexID1 = new JobVertexID();
-            JobVertexID jobVertexID2 = new JobVertexID();
+        JobVertexID jobVertexID1 = new JobVertexID();
+        JobVertexID jobVertexID2 = new JobVertexID();
 
-            CheckpointCoordinatorTestingUtils.CheckpointRecorderTaskManagerGateway gateway =
-                    new CheckpointCoordinatorTestingUtils.CheckpointRecorderTaskManagerGateway();
+        CheckpointCoordinatorTestingUtils.CheckpointRecorderTaskManagerGateway gateway =
+                new CheckpointCoordinatorTestingUtils.CheckpointRecorderTaskManagerGateway();
 
-            ExecutionGraph graph =
-                    new CheckpointCoordinatorTestingUtils.CheckpointExecutionGraphBuilder()
-                            .addJobVertex(jobVertexID1)
-                            .addJobVertex(jobVertexID2)
-                            .setTaskManagerGateway(gateway)
-                            .build();
+        ExecutionGraph graph =
+                new CheckpointCoordinatorTestingUtils.CheckpointExecutionGraphBuilder()
+                        .addJobVertex(jobVertexID1)
+                        .addJobVertex(jobVertexID2)
+                        .setTaskManagerGateway(gateway)
+                        .build();
 
-            ExecutionVertex vertex1 = graph.getJobVertex(jobVertexID1).getTaskVertices()[0];
-            ExecutionVertex vertex2 = graph.getJobVertex(jobVertexID2).getTaskVertices()[0];
+        ExecutionVertex vertex1 = graph.getJobVertex(jobVertexID1).getTaskVertices()[0];
+        ExecutionVertex vertex2 = graph.getJobVertex(jobVertexID2).getTaskVertices()[0];
 
-            ExecutionAttemptID attemptID1 = vertex1.getCurrentExecutionAttempt().getAttemptId();
-            ExecutionAttemptID attemptID2 = vertex2.getCurrentExecutionAttempt().getAttemptId();
+        ExecutionAttemptID attemptID1 = vertex1.getCurrentExecutionAttempt().getAttemptId();
+        ExecutionAttemptID attemptID2 = vertex2.getCurrentExecutionAttempt().getAttemptId();
 
-            TestFailJobCallback failJobCallback = new TestFailJobCallback();
-            // set up the coordinator and validate the initial state
-            CheckpointCoordinator checkpointCoordinator =
-                    new CheckpointCoordinatorBuilder()
-                            .setExecutionGraph(graph)
-                            .setCheckpointCoordinatorConfiguration(
-                                    CheckpointCoordinatorConfiguration.builder()
-                                            .setAlignedCheckpointTimeout(Long.MAX_VALUE)
-                                            .setMaxConcurrentCheckpoints(Integer.MAX_VALUE)
-                                            .build())
-                            .setTimer(manuallyTriggeredScheduledExecutor)
-                            .setCheckpointFailureManager(
-                                    new CheckpointFailureManager(0, failJobCallback))
-                            .build();
+        TestFailJobCallback failJobCallback = new TestFailJobCallback();
+        // set up the coordinator and validate the initial state
+        CheckpointCoordinator checkpointCoordinator =
+                new CheckpointCoordinatorBuilder()
+                        .setExecutionGraph(graph)
+                        .setCheckpointCoordinatorConfiguration(
+                                CheckpointCoordinatorConfiguration.builder()
+                                        .setAlignedCheckpointTimeout(Long.MAX_VALUE)
+                                        .setMaxConcurrentCheckpoints(Integer.MAX_VALUE)
+                                        .build())
+                        .setTimer(manuallyTriggeredScheduledExecutor)
+                        .setCheckpointFailureManager(
+                                new CheckpointFailureManager(0, failJobCallback))
+                        .build();
 
-            assertEquals(0, checkpointCoordinator.getNumberOfPendingCheckpoints());
-            assertEquals(0, checkpointCoordinator.getNumberOfRetainedSuccessfulCheckpoints());
+        assertEquals(0, checkpointCoordinator.getNumberOfPendingCheckpoints());
+        assertEquals(0, checkpointCoordinator.getNumberOfRetainedSuccessfulCheckpoints());
 
-            // trigger the first checkpoint. this should succeed
-            final CompletableFuture<CompletedCheckpoint> checkpointFuture =
-                    checkpointCoordinator.triggerCheckpoint(false);
-            manuallyTriggeredScheduledExecutor.triggerAll();
-            FutureUtils.throwIfCompletedExceptionally(checkpointFuture);
+        // trigger the first checkpoint. this should succeed
+        final CompletableFuture<CompletedCheckpoint> checkpointFuture =
+                checkpointCoordinator.triggerCheckpoint(false);
+        manuallyTriggeredScheduledExecutor.triggerAll();
+        FutureUtils.throwIfCompletedExceptionally(checkpointFuture);
 
-            // validate that we have a pending checkpoint
-            assertEquals(1, checkpointCoordinator.getNumberOfPendingCheckpoints());
-            assertEquals(0, checkpointCoordinator.getNumberOfRetainedSuccessfulCheckpoints());
+        // validate that we have a pending checkpoint
+        assertEquals(1, checkpointCoordinator.getNumberOfPendingCheckpoints());
+        assertEquals(0, checkpointCoordinator.getNumberOfRetainedSuccessfulCheckpoints());
 
-            // we have one task scheduled that will cancel after timeout
-            assertEquals(1, manuallyTriggeredScheduledExecutor.getActiveScheduledTasks().size());
+        // we have one task scheduled that will cancel after timeout
+        assertEquals(1, manuallyTriggeredScheduledExecutor.getActiveScheduledTasks().size());
 
-            long checkpointId =
-                    checkpointCoordinator
-                            .getPendingCheckpoints()
-                            .entrySet()
-                            .iterator()
-                            .next()
-                            .getKey();
-            PendingCheckpoint checkpoint =
-                    checkpointCoordinator.getPendingCheckpoints().get(checkpointId);
+        long checkpointId =
+                checkpointCoordinator.getPendingCheckpoints().entrySet().iterator().next().getKey();
+        PendingCheckpoint checkpoint =
+                checkpointCoordinator.getPendingCheckpoints().get(checkpointId);
 
-            assertNotNull(checkpoint);
-            assertEquals(checkpointId, checkpoint.getCheckpointId());
-            assertEquals(graph.getJobID(), checkpoint.getJobId());
-            assertEquals(2, checkpoint.getNumberOfNonAcknowledgedTasks());
-            assertEquals(0, checkpoint.getNumberOfAcknowledgedTasks());
-            assertEquals(0, checkpoint.getOperatorStates().size());
-            assertFalse(checkpoint.isDisposed());
-            assertFalse(checkpoint.areTasksFullyAcknowledged());
+        assertNotNull(checkpoint);
+        assertEquals(checkpointId, checkpoint.getCheckpointId());
+        assertEquals(graph.getJobID(), checkpoint.getJobId());
+        assertEquals(2, checkpoint.getNumberOfNonAcknowledgedTasks());
+        assertEquals(0, checkpoint.getNumberOfAcknowledgedTasks());
+        assertEquals(0, checkpoint.getOperatorStates().size());
+        assertFalse(checkpoint.isDisposed());
+        assertFalse(checkpoint.areTasksFullyAcknowledged());
 
-            // check that the vertices received the trigger checkpoint message
-            for (ExecutionVertex vertex : Arrays.asList(vertex1, vertex2)) {
-                CheckpointCoordinatorTestingUtils.TriggeredCheckpoint triggeredCheckpoint =
-                        gateway.getOnlyTriggeredCheckpoint(
-                                vertex.getCurrentExecutionAttempt().getAttemptId());
-                assertEquals(checkpointId, triggeredCheckpoint.checkpointId);
-                assertEquals(checkpoint.getCheckpointTimestamp(), triggeredCheckpoint.timestamp);
-                assertEquals(
-                        CheckpointOptions.forCheckpointWithDefaultLocation(),
-                        triggeredCheckpoint.checkpointOptions);
-            }
-
-            // acknowledge from one of the tasks
-            checkpointCoordinator.receiveAcknowledgeMessage(
-                    new AcknowledgeCheckpoint(graph.getJobID(), attemptID2, checkpointId),
-                    "Unknown location");
-            assertEquals(1, checkpoint.getNumberOfAcknowledgedTasks());
-            assertEquals(1, checkpoint.getNumberOfNonAcknowledgedTasks());
-            assertFalse(checkpoint.isDisposed());
-            assertFalse(checkpoint.areTasksFullyAcknowledged());
-
-            // acknowledge the same task again (should not matter)
-            checkpointCoordinator.receiveAcknowledgeMessage(
-                    new AcknowledgeCheckpoint(graph.getJobID(), attemptID2, checkpointId),
-                    "Unknown location");
-            assertFalse(checkpoint.isDisposed());
-            assertFalse(checkpoint.areTasksFullyAcknowledged());
-
-            // decline checkpoint from the other task, this should cancel the checkpoint
-            // and trigger a new one
-            checkpointCoordinator.receiveDeclineMessage(
-                    new DeclineCheckpoint(
-                            graph.getJobID(), attemptID1, checkpointId, checkpointException),
-                    TASK_MANAGER_LOCATION_INFO);
-            assertTrue(checkpoint.isDisposed());
-
-            // the canceler is also removed
-            assertEquals(0, manuallyTriggeredScheduledExecutor.getActiveScheduledTasks().size());
-
-            // validate that we have no new pending checkpoint
-            assertEquals(0, checkpointCoordinator.getNumberOfPendingCheckpoints());
-            assertEquals(0, checkpointCoordinator.getNumberOfRetainedSuccessfulCheckpoints());
-
-            // decline again, nothing should happen
-            // decline from the other task, nothing should happen
-            checkpointCoordinator.receiveDeclineMessage(
-                    new DeclineCheckpoint(
-                            graph.getJobID(), attemptID1, checkpointId, checkpointException),
-                    TASK_MANAGER_LOCATION_INFO);
-            checkpointCoordinator.receiveDeclineMessage(
-                    new DeclineCheckpoint(
-                            graph.getJobID(), attemptID2, checkpointId, checkpointException),
-                    TASK_MANAGER_LOCATION_INFO);
-            assertTrue(checkpoint.isDisposed());
-            assertEquals(1, failJobCallback.getInvokeCounter());
-
-            checkpointCoordinator.shutdown();
-        } catch (Exception e) {
-            e.printStackTrace();
-            fail(e.getMessage());
+        // check that the vertices received the trigger checkpoint message
+        for (ExecutionVertex vertex : Arrays.asList(vertex1, vertex2)) {
+            CheckpointCoordinatorTestingUtils.TriggeredCheckpoint triggeredCheckpoint =
+                    gateway.getOnlyTriggeredCheckpoint(
+                            vertex.getCurrentExecutionAttempt().getAttemptId());
+            assertEquals(checkpointId, triggeredCheckpoint.checkpointId);
+            assertEquals(checkpoint.getCheckpointTimestamp(), triggeredCheckpoint.timestamp);
+            assertEquals(
+                    CheckpointOptions.forCheckpointWithDefaultLocation(),
+                    triggeredCheckpoint.checkpointOptions);
         }
+
+        // acknowledge from one of the tasks
+        checkpointCoordinator.receiveAcknowledgeMessage(
+                new AcknowledgeCheckpoint(graph.getJobID(), attemptID2, checkpointId),
+                "Unknown location");
+        assertEquals(1, checkpoint.getNumberOfAcknowledgedTasks());
+        assertEquals(1, checkpoint.getNumberOfNonAcknowledgedTasks());
+        assertFalse(checkpoint.isDisposed());
+        assertFalse(checkpoint.areTasksFullyAcknowledged());
+
+        // acknowledge the same task again (should not matter)
+        checkpointCoordinator.receiveAcknowledgeMessage(
+                new AcknowledgeCheckpoint(graph.getJobID(), attemptID2, checkpointId),
+                "Unknown location");
+        assertFalse(checkpoint.isDisposed());
+        assertFalse(checkpoint.areTasksFullyAcknowledged());
+
+        // decline checkpoint from the other task, this should cancel the checkpoint
+        // and trigger a new one
+        checkpointCoordinator.receiveDeclineMessage(
+                new DeclineCheckpoint(
+                        graph.getJobID(), attemptID1, checkpointId, checkpointException),
+                TASK_MANAGER_LOCATION_INFO);
+        assertTrue(checkpoint.isDisposed());
+
+        // the canceler is also removed
+        assertEquals(0, manuallyTriggeredScheduledExecutor.getActiveScheduledTasks().size());
+
+        // validate that we have no new pending checkpoint
+        assertEquals(0, checkpointCoordinator.getNumberOfPendingCheckpoints());
+        assertEquals(0, checkpointCoordinator.getNumberOfRetainedSuccessfulCheckpoints());
+
+        // decline again, nothing should happen
+        // decline from the other task, nothing should happen
+        checkpointCoordinator.receiveDeclineMessage(
+                new DeclineCheckpoint(
+                        graph.getJobID(), attemptID1, checkpointId, checkpointException),
+                TASK_MANAGER_LOCATION_INFO);
+        checkpointCoordinator.receiveDeclineMessage(
+                new DeclineCheckpoint(
+                        graph.getJobID(), attemptID2, checkpointId, checkpointException),
+                TASK_MANAGER_LOCATION_INFO);
+        assertTrue(checkpoint.isDisposed());
+        assertEquals(1, failJobCallback.getInvokeCounter());
+
+        checkpointCoordinator.shutdown();
     }
 
     /**
@@ -1005,888 +977,825 @@ public class CheckpointCoordinatorTest extends TestLogger {
      * checkpoint because a later checkpoint is already in progress.
      */
     @Test
-    public void testTriggerAndDeclineCheckpointComplex() {
-        try {
-            JobVertexID jobVertexID1 = new JobVertexID();
-            JobVertexID jobVertexID2 = new JobVertexID();
+    public void testTriggerAndDeclineCheckpointComplex() throws Exception {
+        JobVertexID jobVertexID1 = new JobVertexID();
+        JobVertexID jobVertexID2 = new JobVertexID();
 
-            CheckpointCoordinatorTestingUtils.CheckpointRecorderTaskManagerGateway gateway =
-                    new CheckpointCoordinatorTestingUtils.CheckpointRecorderTaskManagerGateway();
+        CheckpointCoordinatorTestingUtils.CheckpointRecorderTaskManagerGateway gateway =
+                new CheckpointCoordinatorTestingUtils.CheckpointRecorderTaskManagerGateway();
 
-            ExecutionGraph graph =
-                    new CheckpointCoordinatorTestingUtils.CheckpointExecutionGraphBuilder()
-                            .addJobVertex(jobVertexID1)
-                            .addJobVertex(jobVertexID2)
-                            .setTaskManagerGateway(gateway)
-                            .build();
+        ExecutionGraph graph =
+                new CheckpointCoordinatorTestingUtils.CheckpointExecutionGraphBuilder()
+                        .addJobVertex(jobVertexID1)
+                        .addJobVertex(jobVertexID2)
+                        .setTaskManagerGateway(gateway)
+                        .build();
 
-            ExecutionVertex vertex1 = graph.getJobVertex(jobVertexID1).getTaskVertices()[0];
-            ExecutionVertex vertex2 = graph.getJobVertex(jobVertexID2).getTaskVertices()[0];
+        ExecutionVertex vertex1 = graph.getJobVertex(jobVertexID1).getTaskVertices()[0];
+        ExecutionVertex vertex2 = graph.getJobVertex(jobVertexID2).getTaskVertices()[0];
 
-            ExecutionAttemptID attemptID1 = vertex1.getCurrentExecutionAttempt().getAttemptId();
-            ExecutionAttemptID attemptID2 = vertex2.getCurrentExecutionAttempt().getAttemptId();
-            CheckpointCoordinator checkpointCoordinator = getCheckpointCoordinator(graph);
+        ExecutionAttemptID attemptID1 = vertex1.getCurrentExecutionAttempt().getAttemptId();
+        ExecutionAttemptID attemptID2 = vertex2.getCurrentExecutionAttempt().getAttemptId();
+        CheckpointCoordinator checkpointCoordinator = getCheckpointCoordinator(graph);
 
-            assertEquals(0, checkpointCoordinator.getNumberOfPendingCheckpoints());
-            assertEquals(0, checkpointCoordinator.getNumberOfRetainedSuccessfulCheckpoints());
-            assertEquals(0, manuallyTriggeredScheduledExecutor.getActiveScheduledTasks().size());
+        assertEquals(0, checkpointCoordinator.getNumberOfPendingCheckpoints());
+        assertEquals(0, checkpointCoordinator.getNumberOfRetainedSuccessfulCheckpoints());
+        assertEquals(0, manuallyTriggeredScheduledExecutor.getActiveScheduledTasks().size());
 
-            // trigger the first checkpoint. this should succeed
-            final CompletableFuture<CompletedCheckpoint> checkpointFuture1 =
-                    checkpointCoordinator.triggerCheckpoint(false);
-            manuallyTriggeredScheduledExecutor.triggerAll();
-            FutureUtils.throwIfCompletedExceptionally(checkpointFuture1);
+        // trigger the first checkpoint. this should succeed
+        final CompletableFuture<CompletedCheckpoint> checkpointFuture1 =
+                checkpointCoordinator.triggerCheckpoint(false);
+        manuallyTriggeredScheduledExecutor.triggerAll();
+        FutureUtils.throwIfCompletedExceptionally(checkpointFuture1);
 
-            // trigger second checkpoint, should also succeed
-            final CompletableFuture<CompletedCheckpoint> checkpointFuture2 =
-                    checkpointCoordinator.triggerCheckpoint(false);
-            manuallyTriggeredScheduledExecutor.triggerAll();
-            FutureUtils.throwIfCompletedExceptionally(checkpointFuture2);
+        // trigger second checkpoint, should also succeed
+        final CompletableFuture<CompletedCheckpoint> checkpointFuture2 =
+                checkpointCoordinator.triggerCheckpoint(false);
+        manuallyTriggeredScheduledExecutor.triggerAll();
+        FutureUtils.throwIfCompletedExceptionally(checkpointFuture2);
 
-            // validate that we have a pending checkpoint
-            assertEquals(2, checkpointCoordinator.getNumberOfPendingCheckpoints());
-            assertEquals(0, checkpointCoordinator.getNumberOfRetainedSuccessfulCheckpoints());
-            assertEquals(2, manuallyTriggeredScheduledExecutor.getActiveScheduledTasks().size());
+        // validate that we have a pending checkpoint
+        assertEquals(2, checkpointCoordinator.getNumberOfPendingCheckpoints());
+        assertEquals(0, checkpointCoordinator.getNumberOfRetainedSuccessfulCheckpoints());
+        assertEquals(2, manuallyTriggeredScheduledExecutor.getActiveScheduledTasks().size());
 
-            Iterator<Map.Entry<Long, PendingCheckpoint>> it =
-                    checkpointCoordinator.getPendingCheckpoints().entrySet().iterator();
-            long checkpoint1Id = it.next().getKey();
-            long checkpoint2Id = it.next().getKey();
-            PendingCheckpoint checkpoint1 =
-                    checkpointCoordinator.getPendingCheckpoints().get(checkpoint1Id);
-            PendingCheckpoint checkpoint2 =
-                    checkpointCoordinator.getPendingCheckpoints().get(checkpoint2Id);
+        Iterator<Map.Entry<Long, PendingCheckpoint>> it =
+                checkpointCoordinator.getPendingCheckpoints().entrySet().iterator();
+        long checkpoint1Id = it.next().getKey();
+        long checkpoint2Id = it.next().getKey();
+        PendingCheckpoint checkpoint1 =
+                checkpointCoordinator.getPendingCheckpoints().get(checkpoint1Id);
+        PendingCheckpoint checkpoint2 =
+                checkpointCoordinator.getPendingCheckpoints().get(checkpoint2Id);
 
-            assertNotNull(checkpoint1);
-            assertEquals(checkpoint1Id, checkpoint1.getCheckpointId());
-            assertEquals(graph.getJobID(), checkpoint1.getJobId());
-            assertEquals(2, checkpoint1.getNumberOfNonAcknowledgedTasks());
-            assertEquals(0, checkpoint1.getNumberOfAcknowledgedTasks());
-            assertEquals(0, checkpoint1.getOperatorStates().size());
-            assertFalse(checkpoint1.isDisposed());
-            assertFalse(checkpoint1.areTasksFullyAcknowledged());
+        assertNotNull(checkpoint1);
+        assertEquals(checkpoint1Id, checkpoint1.getCheckpointId());
+        assertEquals(graph.getJobID(), checkpoint1.getJobId());
+        assertEquals(2, checkpoint1.getNumberOfNonAcknowledgedTasks());
+        assertEquals(0, checkpoint1.getNumberOfAcknowledgedTasks());
+        assertEquals(0, checkpoint1.getOperatorStates().size());
+        assertFalse(checkpoint1.isDisposed());
+        assertFalse(checkpoint1.areTasksFullyAcknowledged());
 
-            assertNotNull(checkpoint2);
-            assertEquals(checkpoint2Id, checkpoint2.getCheckpointId());
-            assertEquals(graph.getJobID(), checkpoint2.getJobId());
-            assertEquals(2, checkpoint2.getNumberOfNonAcknowledgedTasks());
-            assertEquals(0, checkpoint2.getNumberOfAcknowledgedTasks());
-            assertEquals(0, checkpoint2.getOperatorStates().size());
-            assertFalse(checkpoint2.isDisposed());
-            assertFalse(checkpoint2.areTasksFullyAcknowledged());
+        assertNotNull(checkpoint2);
+        assertEquals(checkpoint2Id, checkpoint2.getCheckpointId());
+        assertEquals(graph.getJobID(), checkpoint2.getJobId());
+        assertEquals(2, checkpoint2.getNumberOfNonAcknowledgedTasks());
+        assertEquals(0, checkpoint2.getNumberOfAcknowledgedTasks());
+        assertEquals(0, checkpoint2.getOperatorStates().size());
+        assertFalse(checkpoint2.isDisposed());
+        assertFalse(checkpoint2.areTasksFullyAcknowledged());
 
-            // check that the vertices received the trigger checkpoint message
-            for (ExecutionVertex vertex : Arrays.asList(vertex1, vertex2)) {
-                List<CheckpointCoordinatorTestingUtils.TriggeredCheckpoint> triggeredCheckpoints =
-                        gateway.getTriggeredCheckpoints(
-                                vertex.getCurrentExecutionAttempt().getAttemptId());
-                assertEquals(2, triggeredCheckpoints.size());
-                assertEquals(checkpoint1Id, triggeredCheckpoints.get(0).checkpointId);
-                assertEquals(checkpoint2Id, triggeredCheckpoints.get(1).checkpointId);
-            }
+        // check that the vertices received the trigger checkpoint message
+        for (ExecutionVertex vertex : Arrays.asList(vertex1, vertex2)) {
+            List<CheckpointCoordinatorTestingUtils.TriggeredCheckpoint> triggeredCheckpoints =
+                    gateway.getTriggeredCheckpoints(
+                            vertex.getCurrentExecutionAttempt().getAttemptId());
+            assertEquals(2, triggeredCheckpoints.size());
+            assertEquals(checkpoint1Id, triggeredCheckpoints.get(0).checkpointId);
+            assertEquals(checkpoint2Id, triggeredCheckpoints.get(1).checkpointId);
+        }
 
-            // decline checkpoint from one of the tasks, this should cancel the checkpoint
-            checkpointCoordinator.receiveDeclineMessage(
-                    new DeclineCheckpoint(
-                            graph.getJobID(),
-                            attemptID1,
-                            checkpoint1Id,
-                            new CheckpointException(CHECKPOINT_DECLINED)),
-                    TASK_MANAGER_LOCATION_INFO);
-            for (ExecutionVertex vertex : Arrays.asList(vertex1, vertex2)) {
-                assertEquals(
+        // decline checkpoint from one of the tasks, this should cancel the checkpoint
+        checkpointCoordinator.receiveDeclineMessage(
+                new DeclineCheckpoint(
+                        graph.getJobID(),
+                        attemptID1,
                         checkpoint1Id,
-                        gateway.getOnlyNotifiedAbortedCheckpoint(
-                                        vertex.getCurrentExecutionAttempt().getAttemptId())
-                                .checkpointId);
-            }
-
-            assertTrue(checkpoint1.isDisposed());
-
-            // validate that we have only one pending checkpoint left
-            assertEquals(1, checkpointCoordinator.getNumberOfPendingCheckpoints());
-            assertEquals(0, checkpointCoordinator.getNumberOfRetainedSuccessfulCheckpoints());
-            assertEquals(1, manuallyTriggeredScheduledExecutor.getActiveScheduledTasks().size());
-
-            // validate that it is the same second checkpoint from earlier
-            long checkpointIdNew =
-                    checkpointCoordinator
-                            .getPendingCheckpoints()
-                            .entrySet()
-                            .iterator()
-                            .next()
-                            .getKey();
-            PendingCheckpoint checkpointNew =
-                    checkpointCoordinator.getPendingCheckpoints().get(checkpointIdNew);
-            assertEquals(checkpoint2Id, checkpointIdNew);
-
-            assertNotNull(checkpointNew);
-            assertEquals(checkpointIdNew, checkpointNew.getCheckpointId());
-            assertEquals(graph.getJobID(), checkpointNew.getJobId());
-            assertEquals(2, checkpointNew.getNumberOfNonAcknowledgedTasks());
-            assertEquals(0, checkpointNew.getNumberOfAcknowledgedTasks());
-            assertEquals(0, checkpointNew.getOperatorStates().size());
-            assertFalse(checkpointNew.isDisposed());
-            assertFalse(checkpointNew.areTasksFullyAcknowledged());
-            assertNotEquals(checkpoint1.getCheckpointId(), checkpointNew.getCheckpointId());
-
-            // decline again, nothing should happen
-            // decline from the other task, nothing should happen
-            checkpointCoordinator.receiveDeclineMessage(
-                    new DeclineCheckpoint(
-                            graph.getJobID(),
-                            attemptID1,
-                            checkpoint1Id,
-                            new CheckpointException(CHECKPOINT_DECLINED)),
-                    TASK_MANAGER_LOCATION_INFO);
-            checkpointCoordinator.receiveDeclineMessage(
-                    new DeclineCheckpoint(
-                            graph.getJobID(),
-                            attemptID2,
-                            checkpoint1Id,
-                            new CheckpointException(CHECKPOINT_DECLINED)),
-                    TASK_MANAGER_LOCATION_INFO);
-            assertTrue(checkpoint1.isDisposed());
-
-            // will not notify abort message again
-            for (ExecutionVertex vertex : Arrays.asList(vertex1, vertex2)) {
-                assertEquals(
-                        1,
-                        gateway.getNotifiedAbortedCheckpoints(
-                                        vertex.getCurrentExecutionAttempt().getAttemptId())
-                                .size());
-            }
-
-            checkpointCoordinator.shutdown();
-        } catch (Exception e) {
-            e.printStackTrace();
-            fail(e.getMessage());
+                        new CheckpointException(CHECKPOINT_DECLINED)),
+                TASK_MANAGER_LOCATION_INFO);
+        for (ExecutionVertex vertex : Arrays.asList(vertex1, vertex2)) {
+            assertEquals(
+                    checkpoint1Id,
+                    gateway.getOnlyNotifiedAbortedCheckpoint(
+                                    vertex.getCurrentExecutionAttempt().getAttemptId())
+                            .checkpointId);
         }
+
+        assertTrue(checkpoint1.isDisposed());
+
+        // validate that we have only one pending checkpoint left
+        assertEquals(1, checkpointCoordinator.getNumberOfPendingCheckpoints());
+        assertEquals(0, checkpointCoordinator.getNumberOfRetainedSuccessfulCheckpoints());
+        assertEquals(1, manuallyTriggeredScheduledExecutor.getActiveScheduledTasks().size());
+
+        // validate that it is the same second checkpoint from earlier
+        long checkpointIdNew =
+                checkpointCoordinator.getPendingCheckpoints().entrySet().iterator().next().getKey();
+        PendingCheckpoint checkpointNew =
+                checkpointCoordinator.getPendingCheckpoints().get(checkpointIdNew);
+        assertEquals(checkpoint2Id, checkpointIdNew);
+
+        assertNotNull(checkpointNew);
+        assertEquals(checkpointIdNew, checkpointNew.getCheckpointId());
+        assertEquals(graph.getJobID(), checkpointNew.getJobId());
+        assertEquals(2, checkpointNew.getNumberOfNonAcknowledgedTasks());
+        assertEquals(0, checkpointNew.getNumberOfAcknowledgedTasks());
+        assertEquals(0, checkpointNew.getOperatorStates().size());
+        assertFalse(checkpointNew.isDisposed());
+        assertFalse(checkpointNew.areTasksFullyAcknowledged());
+        assertNotEquals(checkpoint1.getCheckpointId(), checkpointNew.getCheckpointId());
+
+        // decline again, nothing should happen
+        // decline from the other task, nothing should happen
+        checkpointCoordinator.receiveDeclineMessage(
+                new DeclineCheckpoint(
+                        graph.getJobID(),
+                        attemptID1,
+                        checkpoint1Id,
+                        new CheckpointException(CHECKPOINT_DECLINED)),
+                TASK_MANAGER_LOCATION_INFO);
+        checkpointCoordinator.receiveDeclineMessage(
+                new DeclineCheckpoint(
+                        graph.getJobID(),
+                        attemptID2,
+                        checkpoint1Id,
+                        new CheckpointException(CHECKPOINT_DECLINED)),
+                TASK_MANAGER_LOCATION_INFO);
+        assertTrue(checkpoint1.isDisposed());
+
+        // will not notify abort message again
+        for (ExecutionVertex vertex : Arrays.asList(vertex1, vertex2)) {
+            assertEquals(
+                    1,
+                    gateway.getNotifiedAbortedCheckpoints(
+                                    vertex.getCurrentExecutionAttempt().getAttemptId())
+                            .size());
+        }
+
+        checkpointCoordinator.shutdown();
     }
 
     @Test
-    public void testTriggerAndConfirmSimpleCheckpoint() {
-        try {
-            JobVertexID jobVertexID1 = new JobVertexID();
-            JobVertexID jobVertexID2 = new JobVertexID();
+    public void testTriggerAndConfirmSimpleCheckpoint() throws Exception {
+        JobVertexID jobVertexID1 = new JobVertexID();
+        JobVertexID jobVertexID2 = new JobVertexID();
 
-            CheckpointCoordinatorTestingUtils.CheckpointRecorderTaskManagerGateway gateway =
-                    new CheckpointCoordinatorTestingUtils.CheckpointRecorderTaskManagerGateway();
+        CheckpointCoordinatorTestingUtils.CheckpointRecorderTaskManagerGateway gateway =
+                new CheckpointCoordinatorTestingUtils.CheckpointRecorderTaskManagerGateway();
 
-            ExecutionGraph graph =
-                    new CheckpointCoordinatorTestingUtils.CheckpointExecutionGraphBuilder()
-                            .addJobVertex(jobVertexID1)
-                            .addJobVertex(jobVertexID2)
-                            .setTaskManagerGateway(gateway)
-                            .build();
+        ExecutionGraph graph =
+                new CheckpointCoordinatorTestingUtils.CheckpointExecutionGraphBuilder()
+                        .addJobVertex(jobVertexID1)
+                        .addJobVertex(jobVertexID2)
+                        .setTaskManagerGateway(gateway)
+                        .build();
 
-            ExecutionVertex vertex1 = graph.getJobVertex(jobVertexID1).getTaskVertices()[0];
-            ExecutionVertex vertex2 = graph.getJobVertex(jobVertexID2).getTaskVertices()[0];
+        ExecutionVertex vertex1 = graph.getJobVertex(jobVertexID1).getTaskVertices()[0];
+        ExecutionVertex vertex2 = graph.getJobVertex(jobVertexID2).getTaskVertices()[0];
 
-            ExecutionAttemptID attemptID1 = vertex1.getCurrentExecutionAttempt().getAttemptId();
-            ExecutionAttemptID attemptID2 = vertex2.getCurrentExecutionAttempt().getAttemptId();
-            CheckpointCoordinator checkpointCoordinator = getCheckpointCoordinator(graph);
+        ExecutionAttemptID attemptID1 = vertex1.getCurrentExecutionAttempt().getAttemptId();
+        ExecutionAttemptID attemptID2 = vertex2.getCurrentExecutionAttempt().getAttemptId();
+        CheckpointCoordinator checkpointCoordinator = getCheckpointCoordinator(graph);
 
-            assertEquals(0, checkpointCoordinator.getNumberOfPendingCheckpoints());
-            assertEquals(0, checkpointCoordinator.getNumberOfRetainedSuccessfulCheckpoints());
-            assertEquals(0, manuallyTriggeredScheduledExecutor.getActiveScheduledTasks().size());
+        assertEquals(0, checkpointCoordinator.getNumberOfPendingCheckpoints());
+        assertEquals(0, checkpointCoordinator.getNumberOfRetainedSuccessfulCheckpoints());
+        assertEquals(0, manuallyTriggeredScheduledExecutor.getActiveScheduledTasks().size());
 
-            // trigger the first checkpoint. this should succeed
-            final CompletableFuture<CompletedCheckpoint> checkpointFuture =
-                    checkpointCoordinator.triggerCheckpoint(false);
-            manuallyTriggeredScheduledExecutor.triggerAll();
-            FutureUtils.throwIfCompletedExceptionally(checkpointFuture);
+        // trigger the first checkpoint. this should succeed
+        final CompletableFuture<CompletedCheckpoint> checkpointFuture =
+                checkpointCoordinator.triggerCheckpoint(false);
+        manuallyTriggeredScheduledExecutor.triggerAll();
+        FutureUtils.throwIfCompletedExceptionally(checkpointFuture);
 
-            // validate that we have a pending checkpoint
-            assertEquals(1, checkpointCoordinator.getNumberOfPendingCheckpoints());
-            assertEquals(0, checkpointCoordinator.getNumberOfRetainedSuccessfulCheckpoints());
-            assertEquals(1, manuallyTriggeredScheduledExecutor.getActiveScheduledTasks().size());
+        // validate that we have a pending checkpoint
+        assertEquals(1, checkpointCoordinator.getNumberOfPendingCheckpoints());
+        assertEquals(0, checkpointCoordinator.getNumberOfRetainedSuccessfulCheckpoints());
+        assertEquals(1, manuallyTriggeredScheduledExecutor.getActiveScheduledTasks().size());
 
-            long checkpointId =
-                    checkpointCoordinator
-                            .getPendingCheckpoints()
-                            .entrySet()
-                            .iterator()
-                            .next()
-                            .getKey();
-            PendingCheckpoint checkpoint =
-                    checkpointCoordinator.getPendingCheckpoints().get(checkpointId);
+        long checkpointId =
+                checkpointCoordinator.getPendingCheckpoints().entrySet().iterator().next().getKey();
+        PendingCheckpoint checkpoint =
+                checkpointCoordinator.getPendingCheckpoints().get(checkpointId);
 
-            assertNotNull(checkpoint);
-            assertEquals(checkpointId, checkpoint.getCheckpointId());
-            assertEquals(graph.getJobID(), checkpoint.getJobId());
-            assertEquals(2, checkpoint.getNumberOfNonAcknowledgedTasks());
-            assertEquals(0, checkpoint.getNumberOfAcknowledgedTasks());
-            assertEquals(0, checkpoint.getOperatorStates().size());
-            assertFalse(checkpoint.isDisposed());
-            assertFalse(checkpoint.areTasksFullyAcknowledged());
+        assertNotNull(checkpoint);
+        assertEquals(checkpointId, checkpoint.getCheckpointId());
+        assertEquals(graph.getJobID(), checkpoint.getJobId());
+        assertEquals(2, checkpoint.getNumberOfNonAcknowledgedTasks());
+        assertEquals(0, checkpoint.getNumberOfAcknowledgedTasks());
+        assertEquals(0, checkpoint.getOperatorStates().size());
+        assertFalse(checkpoint.isDisposed());
+        assertFalse(checkpoint.areTasksFullyAcknowledged());
 
-            // check that the vertices received the trigger checkpoint message
-            for (ExecutionVertex vertex : Arrays.asList(vertex1, vertex2)) {
-                ExecutionAttemptID attemptId = vertex.getCurrentExecutionAttempt().getAttemptId();
-                assertEquals(
-                        checkpointId, gateway.getOnlyTriggeredCheckpoint(attemptId).checkpointId);
-            }
+        // check that the vertices received the trigger checkpoint message
+        for (ExecutionVertex vertex : Arrays.asList(vertex1, vertex2)) {
+            ExecutionAttemptID attemptId = vertex.getCurrentExecutionAttempt().getAttemptId();
+            assertEquals(checkpointId, gateway.getOnlyTriggeredCheckpoint(attemptId).checkpointId);
+        }
 
-            OperatorID opID1 =
-                    vertex1.getJobVertex().getOperatorIDs().get(0).getGeneratedOperatorID();
-            OperatorID opID2 =
-                    vertex2.getJobVertex().getOperatorIDs().get(0).getGeneratedOperatorID();
-            TaskStateSnapshot taskOperatorSubtaskStates1 = mock(TaskStateSnapshot.class);
-            TaskStateSnapshot taskOperatorSubtaskStates2 = mock(TaskStateSnapshot.class);
-            OperatorSubtaskState subtaskState1 = mock(OperatorSubtaskState.class);
-            OperatorSubtaskState subtaskState2 = mock(OperatorSubtaskState.class);
-            when(taskOperatorSubtaskStates1.getSubtaskStateByOperatorID(opID1))
-                    .thenReturn(subtaskState1);
-            when(taskOperatorSubtaskStates2.getSubtaskStateByOperatorID(opID2))
-                    .thenReturn(subtaskState2);
+        OperatorID opID1 = vertex1.getJobVertex().getOperatorIDs().get(0).getGeneratedOperatorID();
+        OperatorID opID2 = vertex2.getJobVertex().getOperatorIDs().get(0).getGeneratedOperatorID();
+        TaskStateSnapshot taskOperatorSubtaskStates1 = mock(TaskStateSnapshot.class);
+        TaskStateSnapshot taskOperatorSubtaskStates2 = mock(TaskStateSnapshot.class);
+        OperatorSubtaskState subtaskState1 = mock(OperatorSubtaskState.class);
+        OperatorSubtaskState subtaskState2 = mock(OperatorSubtaskState.class);
+        when(taskOperatorSubtaskStates1.getSubtaskStateByOperatorID(opID1))
+                .thenReturn(subtaskState1);
+        when(taskOperatorSubtaskStates2.getSubtaskStateByOperatorID(opID2))
+                .thenReturn(subtaskState2);
 
-            // acknowledge from one of the tasks
-            AcknowledgeCheckpoint acknowledgeCheckpoint1 =
-                    new AcknowledgeCheckpoint(
-                            graph.getJobID(),
-                            attemptID2,
-                            checkpointId,
-                            new CheckpointMetrics(),
-                            taskOperatorSubtaskStates2);
-            checkpointCoordinator.receiveAcknowledgeMessage(
-                    acknowledgeCheckpoint1, TASK_MANAGER_LOCATION_INFO);
-            assertEquals(1, checkpoint.getNumberOfAcknowledgedTasks());
-            assertEquals(1, checkpoint.getNumberOfNonAcknowledgedTasks());
-            assertFalse(checkpoint.isDisposed());
-            assertFalse(checkpoint.areTasksFullyAcknowledged());
-            verify(taskOperatorSubtaskStates2, never())
-                    .registerSharedStates(any(SharedStateRegistry.class));
-
-            // acknowledge the same task again (should not matter)
-            checkpointCoordinator.receiveAcknowledgeMessage(
-                    acknowledgeCheckpoint1, TASK_MANAGER_LOCATION_INFO);
-            assertFalse(checkpoint.isDisposed());
-            assertFalse(checkpoint.areTasksFullyAcknowledged());
-            verify(subtaskState2, never()).registerSharedStates(any(SharedStateRegistry.class));
-
-            // acknowledge the other task.
-            checkpointCoordinator.receiveAcknowledgeMessage(
-                    new AcknowledgeCheckpoint(
-                            graph.getJobID(),
-                            attemptID1,
-                            checkpointId,
-                            new CheckpointMetrics(),
-                            taskOperatorSubtaskStates1),
-                    TASK_MANAGER_LOCATION_INFO);
-
-            // the checkpoint is internally converted to a successful checkpoint and the
-            // pending checkpoint object is disposed
-            assertTrue(checkpoint.isDisposed());
-
-            // the now we should have a completed checkpoint
-            assertEquals(1, checkpointCoordinator.getNumberOfRetainedSuccessfulCheckpoints());
-            assertEquals(0, checkpointCoordinator.getNumberOfPendingCheckpoints());
-
-            // the canceler should be removed now
-            assertEquals(0, manuallyTriggeredScheduledExecutor.getActiveScheduledTasks().size());
-
-            // validate that the subtasks states have registered their shared states.
-            {
-                verify(subtaskState1, times(1))
-                        .registerSharedStates(any(SharedStateRegistry.class));
-                verify(subtaskState2, times(1))
-                        .registerSharedStates(any(SharedStateRegistry.class));
-            }
-
-            // validate that the relevant tasks got a confirmation message
-            for (ExecutionVertex vertex : Arrays.asList(vertex1, vertex2)) {
-                ExecutionAttemptID attemptId = vertex.getCurrentExecutionAttempt().getAttemptId();
-                assertEquals(
+        // acknowledge from one of the tasks
+        AcknowledgeCheckpoint acknowledgeCheckpoint1 =
+                new AcknowledgeCheckpoint(
+                        graph.getJobID(),
+                        attemptID2,
                         checkpointId,
-                        gateway.getOnlyNotifiedCompletedCheckpoint(attemptId).checkpointId);
-            }
+                        new CheckpointMetrics(),
+                        taskOperatorSubtaskStates2);
+        checkpointCoordinator.receiveAcknowledgeMessage(
+                acknowledgeCheckpoint1, TASK_MANAGER_LOCATION_INFO);
+        assertEquals(1, checkpoint.getNumberOfAcknowledgedTasks());
+        assertEquals(1, checkpoint.getNumberOfNonAcknowledgedTasks());
+        assertFalse(checkpoint.isDisposed());
+        assertFalse(checkpoint.areTasksFullyAcknowledged());
+        verify(taskOperatorSubtaskStates2, never())
+                .registerSharedStates(any(SharedStateRegistry.class));
 
-            CompletedCheckpoint success = checkpointCoordinator.getSuccessfulCheckpoints().get(0);
-            assertEquals(graph.getJobID(), success.getJobId());
-            assertEquals(checkpoint.getCheckpointId(), success.getCheckpointID());
-            assertEquals(2, success.getOperatorStates().size());
+        // acknowledge the same task again (should not matter)
+        checkpointCoordinator.receiveAcknowledgeMessage(
+                acknowledgeCheckpoint1, TASK_MANAGER_LOCATION_INFO);
+        assertFalse(checkpoint.isDisposed());
+        assertFalse(checkpoint.areTasksFullyAcknowledged());
+        verify(subtaskState2, never()).registerSharedStates(any(SharedStateRegistry.class));
 
-            // ---------------
-            // trigger another checkpoint and see that this one replaces the other checkpoint
-            // ---------------
-            gateway.resetCount();
-            checkpointCoordinator.triggerCheckpoint(false);
-            manuallyTriggeredScheduledExecutor.triggerAll();
+        // acknowledge the other task.
+        checkpointCoordinator.receiveAcknowledgeMessage(
+                new AcknowledgeCheckpoint(
+                        graph.getJobID(),
+                        attemptID1,
+                        checkpointId,
+                        new CheckpointMetrics(),
+                        taskOperatorSubtaskStates1),
+                TASK_MANAGER_LOCATION_INFO);
 
-            long checkpointIdNew =
-                    checkpointCoordinator
-                            .getPendingCheckpoints()
-                            .entrySet()
-                            .iterator()
-                            .next()
-                            .getKey();
-            checkpointCoordinator.receiveAcknowledgeMessage(
-                    new AcknowledgeCheckpoint(graph.getJobID(), attemptID1, checkpointIdNew),
-                    TASK_MANAGER_LOCATION_INFO);
-            checkpointCoordinator.receiveAcknowledgeMessage(
-                    new AcknowledgeCheckpoint(graph.getJobID(), attemptID2, checkpointIdNew),
-                    TASK_MANAGER_LOCATION_INFO);
+        // the checkpoint is internally converted to a successful checkpoint and the
+        // pending checkpoint object is disposed
+        assertTrue(checkpoint.isDisposed());
 
-            assertEquals(0, checkpointCoordinator.getNumberOfPendingCheckpoints());
-            assertEquals(1, checkpointCoordinator.getNumberOfRetainedSuccessfulCheckpoints());
-            assertEquals(0, manuallyTriggeredScheduledExecutor.getActiveScheduledTasks().size());
+        // the now we should have a completed checkpoint
+        assertEquals(1, checkpointCoordinator.getNumberOfRetainedSuccessfulCheckpoints());
+        assertEquals(0, checkpointCoordinator.getNumberOfPendingCheckpoints());
 
-            CompletedCheckpoint successNew =
-                    checkpointCoordinator.getSuccessfulCheckpoints().get(0);
-            assertEquals(graph.getJobID(), successNew.getJobId());
-            assertEquals(checkpointIdNew, successNew.getCheckpointID());
-            assertEquals(2, successNew.getOperatorStates().size());
-            assertTrue(
-                    successNew.getOperatorStates().values().stream().allMatch(this::hasNoSubState));
+        // the canceler should be removed now
+        assertEquals(0, manuallyTriggeredScheduledExecutor.getActiveScheduledTasks().size());
 
-            // validate that the relevant tasks got a confirmation message
-            for (ExecutionVertex vertex : Arrays.asList(vertex1, vertex2)) {
-                ExecutionAttemptID attemptId = vertex.getCurrentExecutionAttempt().getAttemptId();
-                assertEquals(
-                        checkpointIdNew,
-                        gateway.getOnlyTriggeredCheckpoint(attemptId).checkpointId);
-                assertEquals(
-                        checkpointIdNew,
-                        gateway.getOnlyNotifiedCompletedCheckpoint(attemptId).checkpointId);
-            }
-
-            checkpointCoordinator.shutdown();
-        } catch (Exception e) {
-            e.printStackTrace();
-            fail(e.getMessage());
+        // validate that the subtasks states have registered their shared states.
+        {
+            verify(subtaskState1, times(1)).registerSharedStates(any(SharedStateRegistry.class));
+            verify(subtaskState2, times(1)).registerSharedStates(any(SharedStateRegistry.class));
         }
+
+        // validate that the relevant tasks got a confirmation message
+        for (ExecutionVertex vertex : Arrays.asList(vertex1, vertex2)) {
+            ExecutionAttemptID attemptId = vertex.getCurrentExecutionAttempt().getAttemptId();
+            assertEquals(
+                    checkpointId,
+                    gateway.getOnlyNotifiedCompletedCheckpoint(attemptId).checkpointId);
+        }
+
+        CompletedCheckpoint success = checkpointCoordinator.getSuccessfulCheckpoints().get(0);
+        assertEquals(graph.getJobID(), success.getJobId());
+        assertEquals(checkpoint.getCheckpointId(), success.getCheckpointID());
+        assertEquals(2, success.getOperatorStates().size());
+
+        // ---------------
+        // trigger another checkpoint and see that this one replaces the other checkpoint
+        // ---------------
+        gateway.resetCount();
+        checkpointCoordinator.triggerCheckpoint(false);
+        manuallyTriggeredScheduledExecutor.triggerAll();
+
+        long checkpointIdNew =
+                checkpointCoordinator.getPendingCheckpoints().entrySet().iterator().next().getKey();
+        checkpointCoordinator.receiveAcknowledgeMessage(
+                new AcknowledgeCheckpoint(graph.getJobID(), attemptID1, checkpointIdNew),
+                TASK_MANAGER_LOCATION_INFO);
+        checkpointCoordinator.receiveAcknowledgeMessage(
+                new AcknowledgeCheckpoint(graph.getJobID(), attemptID2, checkpointIdNew),
+                TASK_MANAGER_LOCATION_INFO);
+
+        assertEquals(0, checkpointCoordinator.getNumberOfPendingCheckpoints());
+        assertEquals(1, checkpointCoordinator.getNumberOfRetainedSuccessfulCheckpoints());
+        assertEquals(0, manuallyTriggeredScheduledExecutor.getActiveScheduledTasks().size());
+
+        CompletedCheckpoint successNew = checkpointCoordinator.getSuccessfulCheckpoints().get(0);
+        assertEquals(graph.getJobID(), successNew.getJobId());
+        assertEquals(checkpointIdNew, successNew.getCheckpointID());
+        assertEquals(2, successNew.getOperatorStates().size());
+        assertTrue(successNew.getOperatorStates().values().stream().allMatch(this::hasNoSubState));
+
+        // validate that the relevant tasks got a confirmation message
+        for (ExecutionVertex vertex : Arrays.asList(vertex1, vertex2)) {
+            ExecutionAttemptID attemptId = vertex.getCurrentExecutionAttempt().getAttemptId();
+            assertEquals(
+                    checkpointIdNew, gateway.getOnlyTriggeredCheckpoint(attemptId).checkpointId);
+            assertEquals(
+                    checkpointIdNew,
+                    gateway.getOnlyNotifiedCompletedCheckpoint(attemptId).checkpointId);
+        }
+
+        checkpointCoordinator.shutdown();
     }
 
     @Test
-    public void testMultipleConcurrentCheckpoints() {
-        try {
-            JobVertexID jobVertexID1 = new JobVertexID();
-            JobVertexID jobVertexID2 = new JobVertexID();
-            JobVertexID jobVertexID3 = new JobVertexID();
+    public void testMultipleConcurrentCheckpoints() throws Exception {
+        JobVertexID jobVertexID1 = new JobVertexID();
+        JobVertexID jobVertexID2 = new JobVertexID();
+        JobVertexID jobVertexID3 = new JobVertexID();
 
-            CheckpointCoordinatorTestingUtils.CheckpointRecorderTaskManagerGateway gateway =
-                    new CheckpointCoordinatorTestingUtils.CheckpointRecorderTaskManagerGateway();
+        CheckpointCoordinatorTestingUtils.CheckpointRecorderTaskManagerGateway gateway =
+                new CheckpointCoordinatorTestingUtils.CheckpointRecorderTaskManagerGateway();
 
-            ExecutionGraph graph =
-                    new CheckpointCoordinatorTestingUtils.CheckpointExecutionGraphBuilder()
-                            .addJobVertex(jobVertexID1)
-                            .addJobVertex(jobVertexID2)
-                            .addJobVertex(jobVertexID3, false)
-                            .setTaskManagerGateway(gateway)
-                            .build();
+        ExecutionGraph graph =
+                new CheckpointCoordinatorTestingUtils.CheckpointExecutionGraphBuilder()
+                        .addJobVertex(jobVertexID1)
+                        .addJobVertex(jobVertexID2)
+                        .addJobVertex(jobVertexID3, false)
+                        .setTaskManagerGateway(gateway)
+                        .build();
 
-            ExecutionVertex vertex1 = graph.getJobVertex(jobVertexID1).getTaskVertices()[0];
-            ExecutionVertex vertex2 = graph.getJobVertex(jobVertexID2).getTaskVertices()[0];
-            ExecutionVertex vertex3 = graph.getJobVertex(jobVertexID3).getTaskVertices()[0];
+        ExecutionVertex vertex1 = graph.getJobVertex(jobVertexID1).getTaskVertices()[0];
+        ExecutionVertex vertex2 = graph.getJobVertex(jobVertexID2).getTaskVertices()[0];
+        ExecutionVertex vertex3 = graph.getJobVertex(jobVertexID3).getTaskVertices()[0];
 
-            ExecutionAttemptID attemptID1 = vertex1.getCurrentExecutionAttempt().getAttemptId();
-            ExecutionAttemptID attemptID2 = vertex2.getCurrentExecutionAttempt().getAttemptId();
-            ExecutionAttemptID attemptID3 = vertex3.getCurrentExecutionAttempt().getAttemptId();
+        ExecutionAttemptID attemptID1 = vertex1.getCurrentExecutionAttempt().getAttemptId();
+        ExecutionAttemptID attemptID2 = vertex2.getCurrentExecutionAttempt().getAttemptId();
+        ExecutionAttemptID attemptID3 = vertex3.getCurrentExecutionAttempt().getAttemptId();
 
-            // set up the coordinator and validate the initial state
-            CheckpointCoordinator checkpointCoordinator =
-                    new CheckpointCoordinatorBuilder()
-                            .setExecutionGraph(graph)
-                            .setCheckpointCoordinatorConfiguration(
-                                    CheckpointCoordinatorConfiguration.builder()
-                                            .setMaxConcurrentCheckpoints(Integer.MAX_VALUE)
-                                            .build())
-                            .setCompletedCheckpointStore(new StandaloneCompletedCheckpointStore(2))
-                            .setTimer(manuallyTriggeredScheduledExecutor)
-                            .build();
+        // set up the coordinator and validate the initial state
+        CheckpointCoordinator checkpointCoordinator =
+                new CheckpointCoordinatorBuilder()
+                        .setExecutionGraph(graph)
+                        .setCheckpointCoordinatorConfiguration(
+                                CheckpointCoordinatorConfiguration.builder()
+                                        .setMaxConcurrentCheckpoints(Integer.MAX_VALUE)
+                                        .build())
+                        .setCompletedCheckpointStore(new StandaloneCompletedCheckpointStore(2))
+                        .setTimer(manuallyTriggeredScheduledExecutor)
+                        .build();
 
-            assertEquals(0, checkpointCoordinator.getNumberOfPendingCheckpoints());
-            assertEquals(0, checkpointCoordinator.getNumberOfRetainedSuccessfulCheckpoints());
+        assertEquals(0, checkpointCoordinator.getNumberOfPendingCheckpoints());
+        assertEquals(0, checkpointCoordinator.getNumberOfRetainedSuccessfulCheckpoints());
 
-            // trigger the first checkpoint. this should succeed
-            final CompletableFuture<CompletedCheckpoint> checkpointFuture1 =
-                    checkpointCoordinator.triggerCheckpoint(false);
-            manuallyTriggeredScheduledExecutor.triggerAll();
-            FutureUtils.throwIfCompletedExceptionally(checkpointFuture1);
+        // trigger the first checkpoint. this should succeed
+        final CompletableFuture<CompletedCheckpoint> checkpointFuture1 =
+                checkpointCoordinator.triggerCheckpoint(false);
+        manuallyTriggeredScheduledExecutor.triggerAll();
+        FutureUtils.throwIfCompletedExceptionally(checkpointFuture1);
 
-            assertEquals(1, checkpointCoordinator.getNumberOfPendingCheckpoints());
-            assertEquals(0, checkpointCoordinator.getNumberOfRetainedSuccessfulCheckpoints());
+        assertEquals(1, checkpointCoordinator.getNumberOfPendingCheckpoints());
+        assertEquals(0, checkpointCoordinator.getNumberOfRetainedSuccessfulCheckpoints());
 
-            PendingCheckpoint pending1 =
-                    checkpointCoordinator.getPendingCheckpoints().values().iterator().next();
-            long checkpointId1 = pending1.getCheckpointId();
+        PendingCheckpoint pending1 =
+                checkpointCoordinator.getPendingCheckpoints().values().iterator().next();
+        long checkpointId1 = pending1.getCheckpointId();
 
-            // trigger messages should have been sent
-            for (ExecutionVertex vertex : Arrays.asList(vertex1, vertex2)) {
-                ExecutionAttemptID attemptId = vertex.getCurrentExecutionAttempt().getAttemptId();
-                assertEquals(
-                        checkpointId1, gateway.getOnlyTriggeredCheckpoint(attemptId).checkpointId);
-            }
+        // trigger messages should have been sent
+        for (ExecutionVertex vertex : Arrays.asList(vertex1, vertex2)) {
+            ExecutionAttemptID attemptId = vertex.getCurrentExecutionAttempt().getAttemptId();
+            assertEquals(checkpointId1, gateway.getOnlyTriggeredCheckpoint(attemptId).checkpointId);
+        }
 
-            // acknowledge one of the three tasks
-            checkpointCoordinator.receiveAcknowledgeMessage(
-                    new AcknowledgeCheckpoint(graph.getJobID(), attemptID2, checkpointId1),
-                    TASK_MANAGER_LOCATION_INFO);
+        // acknowledge one of the three tasks
+        checkpointCoordinator.receiveAcknowledgeMessage(
+                new AcknowledgeCheckpoint(graph.getJobID(), attemptID2, checkpointId1),
+                TASK_MANAGER_LOCATION_INFO);
 
-            // start the second checkpoint
-            // trigger the first checkpoint. this should succeed
-            gateway.resetCount();
-            final CompletableFuture<CompletedCheckpoint> checkpointFuture2 =
-                    checkpointCoordinator.triggerCheckpoint(false);
-            manuallyTriggeredScheduledExecutor.triggerAll();
-            FutureUtils.throwIfCompletedExceptionally(checkpointFuture2);
+        // start the second checkpoint
+        // trigger the first checkpoint. this should succeed
+        gateway.resetCount();
+        final CompletableFuture<CompletedCheckpoint> checkpointFuture2 =
+                checkpointCoordinator.triggerCheckpoint(false);
+        manuallyTriggeredScheduledExecutor.triggerAll();
+        FutureUtils.throwIfCompletedExceptionally(checkpointFuture2);
 
-            assertEquals(2, checkpointCoordinator.getNumberOfPendingCheckpoints());
-            assertEquals(0, checkpointCoordinator.getNumberOfRetainedSuccessfulCheckpoints());
+        assertEquals(2, checkpointCoordinator.getNumberOfPendingCheckpoints());
+        assertEquals(0, checkpointCoordinator.getNumberOfRetainedSuccessfulCheckpoints());
 
-            PendingCheckpoint pending2;
-            {
-                Iterator<PendingCheckpoint> all =
-                        checkpointCoordinator.getPendingCheckpoints().values().iterator();
-                PendingCheckpoint cc1 = all.next();
-                PendingCheckpoint cc2 = all.next();
-                pending2 = pending1 == cc1 ? cc2 : cc1;
-            }
-            long checkpointId2 = pending2.getCheckpointId();
+        PendingCheckpoint pending2;
+        {
+            Iterator<PendingCheckpoint> all =
+                    checkpointCoordinator.getPendingCheckpoints().values().iterator();
+            PendingCheckpoint cc1 = all.next();
+            PendingCheckpoint cc2 = all.next();
+            pending2 = pending1 == cc1 ? cc2 : cc1;
+        }
+        long checkpointId2 = pending2.getCheckpointId();
 
-            // trigger messages should have been sent
-            for (ExecutionVertex vertex : Arrays.asList(vertex1, vertex2)) {
-                ExecutionAttemptID attemptId = vertex.getCurrentExecutionAttempt().getAttemptId();
-                assertEquals(
-                        checkpointId2, gateway.getOnlyTriggeredCheckpoint(attemptId).checkpointId);
-            }
+        // trigger messages should have been sent
+        for (ExecutionVertex vertex : Arrays.asList(vertex1, vertex2)) {
+            ExecutionAttemptID attemptId = vertex.getCurrentExecutionAttempt().getAttemptId();
+            assertEquals(checkpointId2, gateway.getOnlyTriggeredCheckpoint(attemptId).checkpointId);
+        }
 
-            // we acknowledge the remaining two tasks from the first
-            // checkpoint and two tasks from the second checkpoint
-            checkpointCoordinator.receiveAcknowledgeMessage(
-                    new AcknowledgeCheckpoint(graph.getJobID(), attemptID3, checkpointId1),
-                    TASK_MANAGER_LOCATION_INFO);
-            checkpointCoordinator.receiveAcknowledgeMessage(
-                    new AcknowledgeCheckpoint(graph.getJobID(), attemptID1, checkpointId2),
-                    TASK_MANAGER_LOCATION_INFO);
-            checkpointCoordinator.receiveAcknowledgeMessage(
-                    new AcknowledgeCheckpoint(graph.getJobID(), attemptID1, checkpointId1),
-                    TASK_MANAGER_LOCATION_INFO);
-            checkpointCoordinator.receiveAcknowledgeMessage(
-                    new AcknowledgeCheckpoint(graph.getJobID(), attemptID2, checkpointId2),
-                    TASK_MANAGER_LOCATION_INFO);
+        // we acknowledge the remaining two tasks from the first
+        // checkpoint and two tasks from the second checkpoint
+        checkpointCoordinator.receiveAcknowledgeMessage(
+                new AcknowledgeCheckpoint(graph.getJobID(), attemptID3, checkpointId1),
+                TASK_MANAGER_LOCATION_INFO);
+        checkpointCoordinator.receiveAcknowledgeMessage(
+                new AcknowledgeCheckpoint(graph.getJobID(), attemptID1, checkpointId2),
+                TASK_MANAGER_LOCATION_INFO);
+        checkpointCoordinator.receiveAcknowledgeMessage(
+                new AcknowledgeCheckpoint(graph.getJobID(), attemptID1, checkpointId1),
+                TASK_MANAGER_LOCATION_INFO);
+        checkpointCoordinator.receiveAcknowledgeMessage(
+                new AcknowledgeCheckpoint(graph.getJobID(), attemptID2, checkpointId2),
+                TASK_MANAGER_LOCATION_INFO);
 
-            // now, the first checkpoint should be confirmed
-            assertEquals(1, checkpointCoordinator.getNumberOfPendingCheckpoints());
-            assertEquals(1, checkpointCoordinator.getNumberOfRetainedSuccessfulCheckpoints());
-            assertTrue(pending1.isDisposed());
+        // now, the first checkpoint should be confirmed
+        assertEquals(1, checkpointCoordinator.getNumberOfPendingCheckpoints());
+        assertEquals(1, checkpointCoordinator.getNumberOfRetainedSuccessfulCheckpoints());
+        assertTrue(pending1.isDisposed());
 
-            // the first confirm message should be out
-            for (ExecutionVertex vertex : Arrays.asList(vertex1, vertex2, vertex3)) {
-                ExecutionAttemptID attemptId = vertex.getCurrentExecutionAttempt().getAttemptId();
-                assertEquals(
+        // the first confirm message should be out
+        for (ExecutionVertex vertex : Arrays.asList(vertex1, vertex2, vertex3)) {
+            ExecutionAttemptID attemptId = vertex.getCurrentExecutionAttempt().getAttemptId();
+            assertEquals(
+                    checkpointId1,
+                    gateway.getOnlyNotifiedCompletedCheckpoint(attemptId).checkpointId);
+        }
+
+        // send the last remaining ack for the second checkpoint
+        gateway.resetCount();
+        checkpointCoordinator.receiveAcknowledgeMessage(
+                new AcknowledgeCheckpoint(graph.getJobID(), attemptID3, checkpointId2),
+                TASK_MANAGER_LOCATION_INFO);
+
+        // now, the second checkpoint should be confirmed
+        assertEquals(0, checkpointCoordinator.getNumberOfPendingCheckpoints());
+        assertEquals(2, checkpointCoordinator.getNumberOfRetainedSuccessfulCheckpoints());
+        assertTrue(pending2.isDisposed());
+
+        // the second commit message should be out
+        for (ExecutionVertex vertex : Arrays.asList(vertex1, vertex2, vertex3)) {
+            ExecutionAttemptID attemptId = vertex.getCurrentExecutionAttempt().getAttemptId();
+            assertEquals(
+                    checkpointId2,
+                    gateway.getOnlyNotifiedCompletedCheckpoint(attemptId).checkpointId);
+        }
+
+        // validate the committed checkpoints
+        List<CompletedCheckpoint> scs = checkpointCoordinator.getSuccessfulCheckpoints();
+
+        CompletedCheckpoint sc1 = scs.get(0);
+        assertEquals(checkpointId1, sc1.getCheckpointID());
+        assertEquals(graph.getJobID(), sc1.getJobId());
+        assertEquals(3, sc1.getOperatorStates().size());
+        assertTrue(sc1.getOperatorStates().values().stream().allMatch(this::hasNoSubState));
+
+        CompletedCheckpoint sc2 = scs.get(1);
+        assertEquals(checkpointId2, sc2.getCheckpointID());
+        assertEquals(graph.getJobID(), sc2.getJobId());
+        assertEquals(3, sc2.getOperatorStates().size());
+        assertTrue(sc2.getOperatorStates().values().stream().allMatch(this::hasNoSubState));
+
+        checkpointCoordinator.shutdown();
+    }
+
+    @Test
+    public void testSuccessfulCheckpointSubsumesUnsuccessful() throws Exception {
+        JobVertexID jobVertexID1 = new JobVertexID();
+        JobVertexID jobVertexID2 = new JobVertexID();
+        JobVertexID jobVertexID3 = new JobVertexID();
+
+        CheckpointCoordinatorTestingUtils.CheckpointRecorderTaskManagerGateway gateway =
+                new CheckpointCoordinatorTestingUtils.CheckpointRecorderTaskManagerGateway();
+
+        ExecutionGraph graph =
+                new CheckpointCoordinatorTestingUtils.CheckpointExecutionGraphBuilder()
+                        .addJobVertex(jobVertexID1)
+                        .addJobVertex(jobVertexID2)
+                        .addJobVertex(jobVertexID3, false)
+                        .setTaskManagerGateway(gateway)
+                        .build();
+
+        ExecutionVertex vertex1 = graph.getJobVertex(jobVertexID1).getTaskVertices()[0];
+        ExecutionVertex vertex2 = graph.getJobVertex(jobVertexID2).getTaskVertices()[0];
+        ExecutionVertex vertex3 = graph.getJobVertex(jobVertexID3).getTaskVertices()[0];
+
+        ExecutionAttemptID attemptID1 = vertex1.getCurrentExecutionAttempt().getAttemptId();
+        ExecutionAttemptID attemptID2 = vertex2.getCurrentExecutionAttempt().getAttemptId();
+        ExecutionAttemptID attemptID3 = vertex3.getCurrentExecutionAttempt().getAttemptId();
+
+        // set up the coordinator and validate the initial state
+        final StandaloneCompletedCheckpointStore completedCheckpointStore =
+                new StandaloneCompletedCheckpointStore(10);
+        CheckpointCoordinator checkpointCoordinator =
+                new CheckpointCoordinatorBuilder()
+                        .setExecutionGraph(graph)
+                        .setCheckpointCoordinatorConfiguration(
+                                CheckpointCoordinatorConfiguration.builder()
+                                        .setMaxConcurrentCheckpoints(Integer.MAX_VALUE)
+                                        .build())
+                        .setCompletedCheckpointStore(completedCheckpointStore)
+                        .setTimer(manuallyTriggeredScheduledExecutor)
+                        .build();
+
+        assertEquals(0, checkpointCoordinator.getNumberOfPendingCheckpoints());
+        assertEquals(0, checkpointCoordinator.getNumberOfRetainedSuccessfulCheckpoints());
+
+        // trigger the first checkpoint. this should succeed
+        final CompletableFuture<CompletedCheckpoint> checkpointFuture1 =
+                checkpointCoordinator.triggerCheckpoint(false);
+        manuallyTriggeredScheduledExecutor.triggerAll();
+        FutureUtils.throwIfCompletedExceptionally(checkpointFuture1);
+
+        assertEquals(1, checkpointCoordinator.getNumberOfPendingCheckpoints());
+        assertEquals(0, checkpointCoordinator.getNumberOfRetainedSuccessfulCheckpoints());
+
+        PendingCheckpoint pending1 =
+                checkpointCoordinator.getPendingCheckpoints().values().iterator().next();
+        long checkpointId1 = pending1.getCheckpointId();
+
+        // trigger messages should have been sent
+        for (ExecutionVertex vertex : Arrays.asList(vertex1, vertex2)) {
+            ExecutionAttemptID attemptId = vertex.getCurrentExecutionAttempt().getAttemptId();
+            assertEquals(checkpointId1, gateway.getOnlyTriggeredCheckpoint(attemptId).checkpointId);
+        }
+
+        OperatorID opID1 = vertex1.getJobVertex().getOperatorIDs().get(0).getGeneratedOperatorID();
+        OperatorID opID2 = vertex2.getJobVertex().getOperatorIDs().get(0).getGeneratedOperatorID();
+        OperatorID opID3 = vertex3.getJobVertex().getOperatorIDs().get(0).getGeneratedOperatorID();
+
+        TaskStateSnapshot taskOperatorSubtaskStates11 = spy(new TaskStateSnapshot());
+        TaskStateSnapshot taskOperatorSubtaskStates12 = spy(new TaskStateSnapshot());
+        TaskStateSnapshot taskOperatorSubtaskStates13 = spy(new TaskStateSnapshot());
+
+        OperatorSubtaskState subtaskState11 = mock(OperatorSubtaskState.class);
+        OperatorSubtaskState subtaskState12 = mock(OperatorSubtaskState.class);
+        OperatorSubtaskState subtaskState13 = mock(OperatorSubtaskState.class);
+        taskOperatorSubtaskStates11.putSubtaskStateByOperatorID(opID1, subtaskState11);
+        taskOperatorSubtaskStates12.putSubtaskStateByOperatorID(opID2, subtaskState12);
+        taskOperatorSubtaskStates13.putSubtaskStateByOperatorID(opID3, subtaskState13);
+
+        // acknowledge one of the three tasks
+        checkpointCoordinator.receiveAcknowledgeMessage(
+                new AcknowledgeCheckpoint(
+                        graph.getJobID(),
+                        attemptID2,
                         checkpointId1,
-                        gateway.getOnlyNotifiedCompletedCheckpoint(attemptId).checkpointId);
-            }
+                        new CheckpointMetrics(),
+                        taskOperatorSubtaskStates12),
+                TASK_MANAGER_LOCATION_INFO);
 
-            // send the last remaining ack for the second checkpoint
-            gateway.resetCount();
-            checkpointCoordinator.receiveAcknowledgeMessage(
-                    new AcknowledgeCheckpoint(graph.getJobID(), attemptID3, checkpointId2),
-                    TASK_MANAGER_LOCATION_INFO);
+        // start the second checkpoint
+        gateway.resetCount();
+        final CompletableFuture<CompletedCheckpoint> checkpointFuture2 =
+                checkpointCoordinator.triggerCheckpoint(false);
+        manuallyTriggeredScheduledExecutor.triggerAll();
+        FutureUtils.throwIfCompletedExceptionally(checkpointFuture2);
 
-            // now, the second checkpoint should be confirmed
-            assertEquals(0, checkpointCoordinator.getNumberOfPendingCheckpoints());
-            assertEquals(2, checkpointCoordinator.getNumberOfRetainedSuccessfulCheckpoints());
-            assertTrue(pending2.isDisposed());
+        assertEquals(2, checkpointCoordinator.getNumberOfPendingCheckpoints());
+        assertEquals(0, checkpointCoordinator.getNumberOfRetainedSuccessfulCheckpoints());
 
-            // the second commit message should be out
-            for (ExecutionVertex vertex : Arrays.asList(vertex1, vertex2, vertex3)) {
-                ExecutionAttemptID attemptId = vertex.getCurrentExecutionAttempt().getAttemptId();
-                assertEquals(
+        PendingCheckpoint pending2;
+        {
+            Iterator<PendingCheckpoint> all =
+                    checkpointCoordinator.getPendingCheckpoints().values().iterator();
+            PendingCheckpoint cc1 = all.next();
+            PendingCheckpoint cc2 = all.next();
+            pending2 = pending1 == cc1 ? cc2 : cc1;
+        }
+        long checkpointId2 = pending2.getCheckpointId();
+
+        TaskStateSnapshot taskOperatorSubtaskStates21 = spy(new TaskStateSnapshot());
+        TaskStateSnapshot taskOperatorSubtaskStates22 = spy(new TaskStateSnapshot());
+        TaskStateSnapshot taskOperatorSubtaskStates23 = spy(new TaskStateSnapshot());
+
+        OperatorSubtaskState subtaskState21 = mock(OperatorSubtaskState.class);
+        OperatorSubtaskState subtaskState22 = mock(OperatorSubtaskState.class);
+        OperatorSubtaskState subtaskState23 = mock(OperatorSubtaskState.class);
+
+        taskOperatorSubtaskStates21.putSubtaskStateByOperatorID(opID1, subtaskState21);
+        taskOperatorSubtaskStates22.putSubtaskStateByOperatorID(opID2, subtaskState22);
+        taskOperatorSubtaskStates23.putSubtaskStateByOperatorID(opID3, subtaskState23);
+
+        // trigger messages should have been sent
+        for (ExecutionVertex vertex : Arrays.asList(vertex1, vertex2)) {
+            ExecutionAttemptID attemptId = vertex.getCurrentExecutionAttempt().getAttemptId();
+            assertEquals(checkpointId2, gateway.getOnlyTriggeredCheckpoint(attemptId).checkpointId);
+        }
+
+        // we acknowledge one more task from the first checkpoint and the second
+        // checkpoint completely. The second checkpoint should then subsume the first checkpoint
+
+        checkpointCoordinator.receiveAcknowledgeMessage(
+                new AcknowledgeCheckpoint(
+                        graph.getJobID(),
+                        attemptID3,
                         checkpointId2,
-                        gateway.getOnlyNotifiedCompletedCheckpoint(attemptId).checkpointId);
-            }
+                        new CheckpointMetrics(),
+                        taskOperatorSubtaskStates23),
+                TASK_MANAGER_LOCATION_INFO);
 
-            // validate the committed checkpoints
-            List<CompletedCheckpoint> scs = checkpointCoordinator.getSuccessfulCheckpoints();
-
-            CompletedCheckpoint sc1 = scs.get(0);
-            assertEquals(checkpointId1, sc1.getCheckpointID());
-            assertEquals(graph.getJobID(), sc1.getJobId());
-            assertEquals(3, sc1.getOperatorStates().size());
-            assertTrue(sc1.getOperatorStates().values().stream().allMatch(this::hasNoSubState));
-
-            CompletedCheckpoint sc2 = scs.get(1);
-            assertEquals(checkpointId2, sc2.getCheckpointID());
-            assertEquals(graph.getJobID(), sc2.getJobId());
-            assertEquals(3, sc2.getOperatorStates().size());
-            assertTrue(sc2.getOperatorStates().values().stream().allMatch(this::hasNoSubState));
-
-            checkpointCoordinator.shutdown();
-        } catch (Exception e) {
-            e.printStackTrace();
-            fail(e.getMessage());
-        }
-    }
-
-    @Test
-    public void testSuccessfulCheckpointSubsumesUnsuccessful() {
-        try {
-            JobVertexID jobVertexID1 = new JobVertexID();
-            JobVertexID jobVertexID2 = new JobVertexID();
-            JobVertexID jobVertexID3 = new JobVertexID();
-
-            CheckpointCoordinatorTestingUtils.CheckpointRecorderTaskManagerGateway gateway =
-                    new CheckpointCoordinatorTestingUtils.CheckpointRecorderTaskManagerGateway();
-
-            ExecutionGraph graph =
-                    new CheckpointCoordinatorTestingUtils.CheckpointExecutionGraphBuilder()
-                            .addJobVertex(jobVertexID1)
-                            .addJobVertex(jobVertexID2)
-                            .addJobVertex(jobVertexID3, false)
-                            .setTaskManagerGateway(gateway)
-                            .build();
-
-            ExecutionVertex vertex1 = graph.getJobVertex(jobVertexID1).getTaskVertices()[0];
-            ExecutionVertex vertex2 = graph.getJobVertex(jobVertexID2).getTaskVertices()[0];
-            ExecutionVertex vertex3 = graph.getJobVertex(jobVertexID3).getTaskVertices()[0];
-
-            ExecutionAttemptID attemptID1 = vertex1.getCurrentExecutionAttempt().getAttemptId();
-            ExecutionAttemptID attemptID2 = vertex2.getCurrentExecutionAttempt().getAttemptId();
-            ExecutionAttemptID attemptID3 = vertex3.getCurrentExecutionAttempt().getAttemptId();
-
-            // set up the coordinator and validate the initial state
-            final StandaloneCompletedCheckpointStore completedCheckpointStore =
-                    new StandaloneCompletedCheckpointStore(10);
-            CheckpointCoordinator checkpointCoordinator =
-                    new CheckpointCoordinatorBuilder()
-                            .setExecutionGraph(graph)
-                            .setCheckpointCoordinatorConfiguration(
-                                    CheckpointCoordinatorConfiguration.builder()
-                                            .setMaxConcurrentCheckpoints(Integer.MAX_VALUE)
-                                            .build())
-                            .setCompletedCheckpointStore(completedCheckpointStore)
-                            .setTimer(manuallyTriggeredScheduledExecutor)
-                            .build();
-
-            assertEquals(0, checkpointCoordinator.getNumberOfPendingCheckpoints());
-            assertEquals(0, checkpointCoordinator.getNumberOfRetainedSuccessfulCheckpoints());
-
-            // trigger the first checkpoint. this should succeed
-            final CompletableFuture<CompletedCheckpoint> checkpointFuture1 =
-                    checkpointCoordinator.triggerCheckpoint(false);
-            manuallyTriggeredScheduledExecutor.triggerAll();
-            FutureUtils.throwIfCompletedExceptionally(checkpointFuture1);
-
-            assertEquals(1, checkpointCoordinator.getNumberOfPendingCheckpoints());
-            assertEquals(0, checkpointCoordinator.getNumberOfRetainedSuccessfulCheckpoints());
-
-            PendingCheckpoint pending1 =
-                    checkpointCoordinator.getPendingCheckpoints().values().iterator().next();
-            long checkpointId1 = pending1.getCheckpointId();
-
-            // trigger messages should have been sent
-            for (ExecutionVertex vertex : Arrays.asList(vertex1, vertex2)) {
-                ExecutionAttemptID attemptId = vertex.getCurrentExecutionAttempt().getAttemptId();
-                assertEquals(
-                        checkpointId1, gateway.getOnlyTriggeredCheckpoint(attemptId).checkpointId);
-            }
-
-            OperatorID opID1 =
-                    vertex1.getJobVertex().getOperatorIDs().get(0).getGeneratedOperatorID();
-            OperatorID opID2 =
-                    vertex2.getJobVertex().getOperatorIDs().get(0).getGeneratedOperatorID();
-            OperatorID opID3 =
-                    vertex3.getJobVertex().getOperatorIDs().get(0).getGeneratedOperatorID();
-
-            TaskStateSnapshot taskOperatorSubtaskStates11 = spy(new TaskStateSnapshot());
-            TaskStateSnapshot taskOperatorSubtaskStates12 = spy(new TaskStateSnapshot());
-            TaskStateSnapshot taskOperatorSubtaskStates13 = spy(new TaskStateSnapshot());
-
-            OperatorSubtaskState subtaskState11 = mock(OperatorSubtaskState.class);
-            OperatorSubtaskState subtaskState12 = mock(OperatorSubtaskState.class);
-            OperatorSubtaskState subtaskState13 = mock(OperatorSubtaskState.class);
-            taskOperatorSubtaskStates11.putSubtaskStateByOperatorID(opID1, subtaskState11);
-            taskOperatorSubtaskStates12.putSubtaskStateByOperatorID(opID2, subtaskState12);
-            taskOperatorSubtaskStates13.putSubtaskStateByOperatorID(opID3, subtaskState13);
-
-            // acknowledge one of the three tasks
-            checkpointCoordinator.receiveAcknowledgeMessage(
-                    new AcknowledgeCheckpoint(
-                            graph.getJobID(),
-                            attemptID2,
-                            checkpointId1,
-                            new CheckpointMetrics(),
-                            taskOperatorSubtaskStates12),
-                    TASK_MANAGER_LOCATION_INFO);
-
-            // start the second checkpoint
-            gateway.resetCount();
-            final CompletableFuture<CompletedCheckpoint> checkpointFuture2 =
-                    checkpointCoordinator.triggerCheckpoint(false);
-            manuallyTriggeredScheduledExecutor.triggerAll();
-            FutureUtils.throwIfCompletedExceptionally(checkpointFuture2);
-
-            assertEquals(2, checkpointCoordinator.getNumberOfPendingCheckpoints());
-            assertEquals(0, checkpointCoordinator.getNumberOfRetainedSuccessfulCheckpoints());
-
-            PendingCheckpoint pending2;
-            {
-                Iterator<PendingCheckpoint> all =
-                        checkpointCoordinator.getPendingCheckpoints().values().iterator();
-                PendingCheckpoint cc1 = all.next();
-                PendingCheckpoint cc2 = all.next();
-                pending2 = pending1 == cc1 ? cc2 : cc1;
-            }
-            long checkpointId2 = pending2.getCheckpointId();
-
-            TaskStateSnapshot taskOperatorSubtaskStates21 = spy(new TaskStateSnapshot());
-            TaskStateSnapshot taskOperatorSubtaskStates22 = spy(new TaskStateSnapshot());
-            TaskStateSnapshot taskOperatorSubtaskStates23 = spy(new TaskStateSnapshot());
-
-            OperatorSubtaskState subtaskState21 = mock(OperatorSubtaskState.class);
-            OperatorSubtaskState subtaskState22 = mock(OperatorSubtaskState.class);
-            OperatorSubtaskState subtaskState23 = mock(OperatorSubtaskState.class);
-
-            taskOperatorSubtaskStates21.putSubtaskStateByOperatorID(opID1, subtaskState21);
-            taskOperatorSubtaskStates22.putSubtaskStateByOperatorID(opID2, subtaskState22);
-            taskOperatorSubtaskStates23.putSubtaskStateByOperatorID(opID3, subtaskState23);
-
-            // trigger messages should have been sent
-            for (ExecutionVertex vertex : Arrays.asList(vertex1, vertex2)) {
-                ExecutionAttemptID attemptId = vertex.getCurrentExecutionAttempt().getAttemptId();
-                assertEquals(
-                        checkpointId2, gateway.getOnlyTriggeredCheckpoint(attemptId).checkpointId);
-            }
-
-            // we acknowledge one more task from the first checkpoint and the second
-            // checkpoint completely. The second checkpoint should then subsume the first checkpoint
-
-            checkpointCoordinator.receiveAcknowledgeMessage(
-                    new AcknowledgeCheckpoint(
-                            graph.getJobID(),
-                            attemptID3,
-                            checkpointId2,
-                            new CheckpointMetrics(),
-                            taskOperatorSubtaskStates23),
-                    TASK_MANAGER_LOCATION_INFO);
-
-            checkpointCoordinator.receiveAcknowledgeMessage(
-                    new AcknowledgeCheckpoint(
-                            graph.getJobID(),
-                            attemptID1,
-                            checkpointId2,
-                            new CheckpointMetrics(),
-                            taskOperatorSubtaskStates21),
-                    TASK_MANAGER_LOCATION_INFO);
-
-            checkpointCoordinator.receiveAcknowledgeMessage(
-                    new AcknowledgeCheckpoint(
-                            graph.getJobID(),
-                            attemptID1,
-                            checkpointId1,
-                            new CheckpointMetrics(),
-                            taskOperatorSubtaskStates11),
-                    TASK_MANAGER_LOCATION_INFO);
-
-            checkpointCoordinator.receiveAcknowledgeMessage(
-                    new AcknowledgeCheckpoint(
-                            graph.getJobID(),
-                            attemptID2,
-                            checkpointId2,
-                            new CheckpointMetrics(),
-                            taskOperatorSubtaskStates22),
-                    TASK_MANAGER_LOCATION_INFO);
-
-            // now, the second checkpoint should be confirmed, and the first discarded
-            // actually both pending checkpoints are discarded, and the second has been transformed
-            // into a successful checkpoint
-            assertTrue(pending1.isDisposed());
-            assertTrue(pending2.isDisposed());
-
-            assertEquals(0, checkpointCoordinator.getNumberOfPendingCheckpoints());
-            assertEquals(1, checkpointCoordinator.getNumberOfRetainedSuccessfulCheckpoints());
-
-            // validate that all received subtask states in the first checkpoint have been discarded
-            verify(subtaskState11, times(1)).discardState();
-            verify(subtaskState12, times(1)).discardState();
-
-            // validate that all subtask states in the second checkpoint are not discarded
-            verify(subtaskState21, never()).discardState();
-            verify(subtaskState22, never()).discardState();
-            verify(subtaskState23, never()).discardState();
-
-            // validate the committed checkpoints
-            List<CompletedCheckpoint> scs = checkpointCoordinator.getSuccessfulCheckpoints();
-            CompletedCheckpoint success = scs.get(0);
-            assertEquals(checkpointId2, success.getCheckpointID());
-            assertEquals(graph.getJobID(), success.getJobId());
-            assertEquals(3, success.getOperatorStates().size());
-
-            // the first confirm message should be out
-            for (ExecutionVertex vertex : Arrays.asList(vertex1, vertex2, vertex3)) {
-                ExecutionAttemptID attemptId = vertex.getCurrentExecutionAttempt().getAttemptId();
-                assertEquals(
+        checkpointCoordinator.receiveAcknowledgeMessage(
+                new AcknowledgeCheckpoint(
+                        graph.getJobID(),
+                        attemptID1,
                         checkpointId2,
-                        gateway.getOnlyNotifiedCompletedCheckpoint(attemptId).checkpointId);
-            }
+                        new CheckpointMetrics(),
+                        taskOperatorSubtaskStates21),
+                TASK_MANAGER_LOCATION_INFO);
 
-            // send the last remaining ack for the first checkpoint. This should not do anything
-            checkpointCoordinator.receiveAcknowledgeMessage(
-                    new AcknowledgeCheckpoint(
-                            graph.getJobID(),
-                            attemptID3,
-                            checkpointId1,
-                            new CheckpointMetrics(),
-                            taskOperatorSubtaskStates13),
-                    TASK_MANAGER_LOCATION_INFO);
-            verify(subtaskState13, times(1)).discardState();
+        checkpointCoordinator.receiveAcknowledgeMessage(
+                new AcknowledgeCheckpoint(
+                        graph.getJobID(),
+                        attemptID1,
+                        checkpointId1,
+                        new CheckpointMetrics(),
+                        taskOperatorSubtaskStates11),
+                TASK_MANAGER_LOCATION_INFO);
 
-            checkpointCoordinator.shutdown();
-            completedCheckpointStore.shutdown(JobStatus.FINISHED, new CheckpointsCleaner());
+        checkpointCoordinator.receiveAcknowledgeMessage(
+                new AcknowledgeCheckpoint(
+                        graph.getJobID(),
+                        attemptID2,
+                        checkpointId2,
+                        new CheckpointMetrics(),
+                        taskOperatorSubtaskStates22),
+                TASK_MANAGER_LOCATION_INFO);
 
-            // validate that the states in the second checkpoint have been discarded
-            verify(subtaskState21, times(1)).discardState();
-            verify(subtaskState22, times(1)).discardState();
-            verify(subtaskState23, times(1)).discardState();
+        // now, the second checkpoint should be confirmed, and the first discarded
+        // actually both pending checkpoints are discarded, and the second has been transformed
+        // into a successful checkpoint
+        assertTrue(pending1.isDisposed());
+        assertTrue(pending2.isDisposed());
 
-        } catch (Exception e) {
-            e.printStackTrace();
-            fail(e.getMessage());
+        assertEquals(0, checkpointCoordinator.getNumberOfPendingCheckpoints());
+        assertEquals(1, checkpointCoordinator.getNumberOfRetainedSuccessfulCheckpoints());
+
+        // validate that all received subtask states in the first checkpoint have been discarded
+        verify(subtaskState11, times(1)).discardState();
+        verify(subtaskState12, times(1)).discardState();
+
+        // validate that all subtask states in the second checkpoint are not discarded
+        verify(subtaskState21, never()).discardState();
+        verify(subtaskState22, never()).discardState();
+        verify(subtaskState23, never()).discardState();
+
+        // validate the committed checkpoints
+        List<CompletedCheckpoint> scs = checkpointCoordinator.getSuccessfulCheckpoints();
+        CompletedCheckpoint success = scs.get(0);
+        assertEquals(checkpointId2, success.getCheckpointID());
+        assertEquals(graph.getJobID(), success.getJobId());
+        assertEquals(3, success.getOperatorStates().size());
+
+        // the first confirm message should be out
+        for (ExecutionVertex vertex : Arrays.asList(vertex1, vertex2, vertex3)) {
+            ExecutionAttemptID attemptId = vertex.getCurrentExecutionAttempt().getAttemptId();
+            assertEquals(
+                    checkpointId2,
+                    gateway.getOnlyNotifiedCompletedCheckpoint(attemptId).checkpointId);
         }
+
+        // send the last remaining ack for the first checkpoint. This should not do anything
+        checkpointCoordinator.receiveAcknowledgeMessage(
+                new AcknowledgeCheckpoint(
+                        graph.getJobID(),
+                        attemptID3,
+                        checkpointId1,
+                        new CheckpointMetrics(),
+                        taskOperatorSubtaskStates13),
+                TASK_MANAGER_LOCATION_INFO);
+        verify(subtaskState13, times(1)).discardState();
+
+        checkpointCoordinator.shutdown();
+        completedCheckpointStore.shutdown(JobStatus.FINISHED, new CheckpointsCleaner());
+
+        // validate that the states in the second checkpoint have been discarded
+        verify(subtaskState21, times(1)).discardState();
+        verify(subtaskState22, times(1)).discardState();
+        verify(subtaskState23, times(1)).discardState();
     }
 
     @Test
-    public void testCheckpointTimeoutIsolated() {
-        try {
-            JobVertexID jobVertexID1 = new JobVertexID();
-            JobVertexID jobVertexID2 = new JobVertexID();
+    public void testCheckpointTimeoutIsolated() throws Exception {
+        JobVertexID jobVertexID1 = new JobVertexID();
+        JobVertexID jobVertexID2 = new JobVertexID();
 
-            CheckpointCoordinatorTestingUtils.CheckpointRecorderTaskManagerGateway gateway =
-                    new CheckpointCoordinatorTestingUtils.CheckpointRecorderTaskManagerGateway();
+        CheckpointCoordinatorTestingUtils.CheckpointRecorderTaskManagerGateway gateway =
+                new CheckpointCoordinatorTestingUtils.CheckpointRecorderTaskManagerGateway();
 
-            ExecutionGraph graph =
-                    new CheckpointCoordinatorTestingUtils.CheckpointExecutionGraphBuilder()
-                            .addJobVertex(jobVertexID1)
-                            .addJobVertex(jobVertexID2, false)
-                            .setTaskManagerGateway(gateway)
-                            .build();
+        ExecutionGraph graph =
+                new CheckpointCoordinatorTestingUtils.CheckpointExecutionGraphBuilder()
+                        .addJobVertex(jobVertexID1)
+                        .addJobVertex(jobVertexID2, false)
+                        .setTaskManagerGateway(gateway)
+                        .build();
 
-            ExecutionVertex vertex1 = graph.getJobVertex(jobVertexID1).getTaskVertices()[0];
-            ExecutionVertex vertex2 = graph.getJobVertex(jobVertexID2).getTaskVertices()[0];
+        ExecutionVertex vertex1 = graph.getJobVertex(jobVertexID1).getTaskVertices()[0];
+        ExecutionVertex vertex2 = graph.getJobVertex(jobVertexID2).getTaskVertices()[0];
 
-            ExecutionAttemptID attemptID1 = vertex1.getCurrentExecutionAttempt().getAttemptId();
+        ExecutionAttemptID attemptID1 = vertex1.getCurrentExecutionAttempt().getAttemptId();
 
-            // set up the coordinator
-            CheckpointCoordinator checkpointCoordinator =
-                    new CheckpointCoordinatorBuilder()
-                            .setExecutionGraph(graph)
-                            .setCompletedCheckpointStore(new StandaloneCompletedCheckpointStore(2))
-                            .setTimer(manuallyTriggeredScheduledExecutor)
-                            .build();
+        // set up the coordinator
+        CheckpointCoordinator checkpointCoordinator =
+                new CheckpointCoordinatorBuilder()
+                        .setExecutionGraph(graph)
+                        .setCompletedCheckpointStore(new StandaloneCompletedCheckpointStore(2))
+                        .setTimer(manuallyTriggeredScheduledExecutor)
+                        .build();
 
-            // trigger a checkpoint, partially acknowledged
-            final CompletableFuture<CompletedCheckpoint> checkpointFuture =
-                    checkpointCoordinator.triggerCheckpoint(false);
-            manuallyTriggeredScheduledExecutor.triggerAll();
-            FutureUtils.throwIfCompletedExceptionally(checkpointFuture);
-            assertEquals(1, checkpointCoordinator.getNumberOfPendingCheckpoints());
+        // trigger a checkpoint, partially acknowledged
+        final CompletableFuture<CompletedCheckpoint> checkpointFuture =
+                checkpointCoordinator.triggerCheckpoint(false);
+        manuallyTriggeredScheduledExecutor.triggerAll();
+        FutureUtils.throwIfCompletedExceptionally(checkpointFuture);
+        assertEquals(1, checkpointCoordinator.getNumberOfPendingCheckpoints());
 
-            PendingCheckpoint checkpoint =
-                    checkpointCoordinator.getPendingCheckpoints().values().iterator().next();
-            assertFalse(checkpoint.isDisposed());
+        PendingCheckpoint checkpoint =
+                checkpointCoordinator.getPendingCheckpoints().values().iterator().next();
+        assertFalse(checkpoint.isDisposed());
 
-            OperatorID opID1 =
-                    vertex1.getJobVertex().getOperatorIDs().get(0).getGeneratedOperatorID();
+        OperatorID opID1 = vertex1.getJobVertex().getOperatorIDs().get(0).getGeneratedOperatorID();
 
-            TaskStateSnapshot taskOperatorSubtaskStates1 = spy(new TaskStateSnapshot());
-            OperatorSubtaskState subtaskState1 = mock(OperatorSubtaskState.class);
-            taskOperatorSubtaskStates1.putSubtaskStateByOperatorID(opID1, subtaskState1);
+        TaskStateSnapshot taskOperatorSubtaskStates1 = spy(new TaskStateSnapshot());
+        OperatorSubtaskState subtaskState1 = mock(OperatorSubtaskState.class);
+        taskOperatorSubtaskStates1.putSubtaskStateByOperatorID(opID1, subtaskState1);
 
-            checkpointCoordinator.receiveAcknowledgeMessage(
-                    new AcknowledgeCheckpoint(
-                            graph.getJobID(),
-                            attemptID1,
-                            checkpoint.getCheckpointId(),
-                            new CheckpointMetrics(),
-                            taskOperatorSubtaskStates1),
-                    TASK_MANAGER_LOCATION_INFO);
+        checkpointCoordinator.receiveAcknowledgeMessage(
+                new AcknowledgeCheckpoint(
+                        graph.getJobID(),
+                        attemptID1,
+                        checkpoint.getCheckpointId(),
+                        new CheckpointMetrics(),
+                        taskOperatorSubtaskStates1),
+                TASK_MANAGER_LOCATION_INFO);
 
-            // triggers cancelling
-            manuallyTriggeredScheduledExecutor.triggerScheduledTasks();
-            assertTrue("Checkpoint was not canceled by the timeout", checkpoint.isDisposed());
-            assertEquals(0, checkpointCoordinator.getNumberOfPendingCheckpoints());
-            assertEquals(0, checkpointCoordinator.getNumberOfRetainedSuccessfulCheckpoints());
+        // triggers cancelling
+        manuallyTriggeredScheduledExecutor.triggerScheduledTasks();
+        assertTrue("Checkpoint was not canceled by the timeout", checkpoint.isDisposed());
+        assertEquals(0, checkpointCoordinator.getNumberOfPendingCheckpoints());
+        assertEquals(0, checkpointCoordinator.getNumberOfRetainedSuccessfulCheckpoints());
 
-            // validate that the received states have been discarded
-            verify(subtaskState1, times(1)).discardState();
+        // validate that the received states have been discarded
+        verify(subtaskState1, times(1)).discardState();
 
-            // no confirm message must have been sent
-            for (ExecutionVertex vertex : Arrays.asList(vertex1, vertex2)) {
-                ExecutionAttemptID attemptId = vertex.getCurrentExecutionAttempt().getAttemptId();
-                assertEquals(0, gateway.getNotifiedCompletedCheckpoints(attemptId).size());
-            }
-
-            checkpointCoordinator.shutdown();
-        } catch (Exception e) {
-            e.printStackTrace();
-            fail(e.getMessage());
+        // no confirm message must have been sent
+        for (ExecutionVertex vertex : Arrays.asList(vertex1, vertex2)) {
+            ExecutionAttemptID attemptId = vertex.getCurrentExecutionAttempt().getAttemptId();
+            assertEquals(0, gateway.getNotifiedCompletedCheckpoints(attemptId).size());
         }
+
+        checkpointCoordinator.shutdown();
     }
 
     @Test
-    public void testHandleMessagesForNonExistingCheckpoints() {
-        try {
-            // create some mock execution vertices and trigger some checkpoint
-            JobVertexID jobVertexID1 = new JobVertexID();
-            JobVertexID jobVertexID2 = new JobVertexID();
+    public void testHandleMessagesForNonExistingCheckpoints() throws Exception {
+        // create some mock execution vertices and trigger some checkpoint
+        JobVertexID jobVertexID1 = new JobVertexID();
+        JobVertexID jobVertexID2 = new JobVertexID();
 
-            CheckpointCoordinatorTestingUtils.CheckpointRecorderTaskManagerGateway gateway =
-                    new CheckpointCoordinatorTestingUtils.CheckpointRecorderTaskManagerGateway();
+        CheckpointCoordinatorTestingUtils.CheckpointRecorderTaskManagerGateway gateway =
+                new CheckpointCoordinatorTestingUtils.CheckpointRecorderTaskManagerGateway();
 
-            ExecutionGraph graph =
-                    new CheckpointCoordinatorTestingUtils.CheckpointExecutionGraphBuilder()
-                            .addJobVertex(jobVertexID1)
-                            .addJobVertex(jobVertexID2, false)
-                            .setTaskManagerGateway(gateway)
-                            .build();
+        ExecutionGraph graph =
+                new CheckpointCoordinatorTestingUtils.CheckpointExecutionGraphBuilder()
+                        .addJobVertex(jobVertexID1)
+                        .addJobVertex(jobVertexID2, false)
+                        .setTaskManagerGateway(gateway)
+                        .build();
 
-            ExecutionVertex vertex1 = graph.getJobVertex(jobVertexID1).getTaskVertices()[0];
+        ExecutionVertex vertex1 = graph.getJobVertex(jobVertexID1).getTaskVertices()[0];
 
-            ExecutionAttemptID attemptID1 = vertex1.getCurrentExecutionAttempt().getAttemptId();
+        ExecutionAttemptID attemptID1 = vertex1.getCurrentExecutionAttempt().getAttemptId();
 
-            CheckpointCoordinator checkpointCoordinator =
-                    new CheckpointCoordinatorBuilder()
-                            .setExecutionGraph(graph)
-                            .setCompletedCheckpointStore(new StandaloneCompletedCheckpointStore(2))
-                            .setTimer(manuallyTriggeredScheduledExecutor)
-                            .build();
+        CheckpointCoordinator checkpointCoordinator =
+                new CheckpointCoordinatorBuilder()
+                        .setExecutionGraph(graph)
+                        .setCompletedCheckpointStore(new StandaloneCompletedCheckpointStore(2))
+                        .setTimer(manuallyTriggeredScheduledExecutor)
+                        .build();
 
-            final CompletableFuture<CompletedCheckpoint> checkpointFuture =
-                    checkpointCoordinator.triggerCheckpoint(false);
-            manuallyTriggeredScheduledExecutor.triggerAll();
-            FutureUtils.throwIfCompletedExceptionally(checkpointFuture);
+        final CompletableFuture<CompletedCheckpoint> checkpointFuture =
+                checkpointCoordinator.triggerCheckpoint(false);
+        manuallyTriggeredScheduledExecutor.triggerAll();
+        FutureUtils.throwIfCompletedExceptionally(checkpointFuture);
 
-            long checkpointId =
-                    checkpointCoordinator.getPendingCheckpoints().keySet().iterator().next();
+        long checkpointId =
+                checkpointCoordinator.getPendingCheckpoints().keySet().iterator().next();
 
-            // send some messages that do not belong to either the job or the any
-            // of the vertices that need to be acknowledged.
-            // non of the messages should throw an exception
+        // send some messages that do not belong to either the job or the any
+        // of the vertices that need to be acknowledged.
+        // non of the messages should throw an exception
 
-            // wrong job id
-            checkpointCoordinator.receiveAcknowledgeMessage(
-                    new AcknowledgeCheckpoint(new JobID(), attemptID1, checkpointId),
-                    TASK_MANAGER_LOCATION_INFO);
+        // wrong job id
+        checkpointCoordinator.receiveAcknowledgeMessage(
+                new AcknowledgeCheckpoint(new JobID(), attemptID1, checkpointId),
+                TASK_MANAGER_LOCATION_INFO);
 
-            // unknown checkpoint
-            checkpointCoordinator.receiveAcknowledgeMessage(
-                    new AcknowledgeCheckpoint(graph.getJobID(), attemptID1, 1L),
-                    TASK_MANAGER_LOCATION_INFO);
+        // unknown checkpoint
+        checkpointCoordinator.receiveAcknowledgeMessage(
+                new AcknowledgeCheckpoint(graph.getJobID(), attemptID1, 1L),
+                TASK_MANAGER_LOCATION_INFO);
 
-            // unknown ack vertex
-            checkpointCoordinator.receiveAcknowledgeMessage(
-                    new AcknowledgeCheckpoint(
-                            graph.getJobID(), new ExecutionAttemptID(), checkpointId),
-                    TASK_MANAGER_LOCATION_INFO);
+        // unknown ack vertex
+        checkpointCoordinator.receiveAcknowledgeMessage(
+                new AcknowledgeCheckpoint(graph.getJobID(), new ExecutionAttemptID(), checkpointId),
+                TASK_MANAGER_LOCATION_INFO);
 
-            checkpointCoordinator.shutdown();
-        } catch (Exception e) {
-            e.printStackTrace();
-            fail(e.getMessage());
-        }
+        checkpointCoordinator.shutdown();
     }
 
     /**
@@ -2436,123 +2345,109 @@ public class CheckpointCoordinatorTest extends TestLogger {
     }
 
     @Test
-    public void testMaxConcurrentAttempsWithSubsumption() {
-        try {
-            final int maxConcurrentAttempts = 2;
-            JobVertexID jobVertexID1 = new JobVertexID();
+    public void testMaxConcurrentAttempsWithSubsumption() throws Exception {
+        final int maxConcurrentAttempts = 2;
+        JobVertexID jobVertexID1 = new JobVertexID();
 
-            ExecutionGraph graph =
-                    new CheckpointCoordinatorTestingUtils.CheckpointExecutionGraphBuilder()
-                            .addJobVertex(jobVertexID1)
-                            .build();
+        ExecutionGraph graph =
+                new CheckpointCoordinatorTestingUtils.CheckpointExecutionGraphBuilder()
+                        .addJobVertex(jobVertexID1)
+                        .build();
 
-            ExecutionVertex vertex1 = graph.getJobVertex(jobVertexID1).getTaskVertices()[0];
+        ExecutionVertex vertex1 = graph.getJobVertex(jobVertexID1).getTaskVertices()[0];
 
-            ExecutionAttemptID attemptID1 = vertex1.getCurrentExecutionAttempt().getAttemptId();
+        ExecutionAttemptID attemptID1 = vertex1.getCurrentExecutionAttempt().getAttemptId();
 
-            CheckpointCoordinatorConfiguration chkConfig =
-                    new CheckpointCoordinatorConfiguration
-                                    .CheckpointCoordinatorConfigurationBuilder()
-                            .setCheckpointInterval(10) // periodic interval is 10 ms
-                            .setCheckpointTimeout(200000) // timeout is very long (200 s)
-                            .setMinPauseBetweenCheckpoints(0L) // no extra delay
-                            .setMaxConcurrentCheckpoints(maxConcurrentAttempts)
-                            .build();
-            CheckpointCoordinator checkpointCoordinator =
-                    new CheckpointCoordinatorBuilder()
-                            .setExecutionGraph(graph)
-                            .setCheckpointCoordinatorConfiguration(chkConfig)
-                            .setCompletedCheckpointStore(new StandaloneCompletedCheckpointStore(2))
-                            .setTimer(manuallyTriggeredScheduledExecutor)
-                            .build();
+        CheckpointCoordinatorConfiguration chkConfig =
+                new CheckpointCoordinatorConfiguration.CheckpointCoordinatorConfigurationBuilder()
+                        .setCheckpointInterval(10) // periodic interval is 10 ms
+                        .setCheckpointTimeout(200000) // timeout is very long (200 s)
+                        .setMinPauseBetweenCheckpoints(0L) // no extra delay
+                        .setMaxConcurrentCheckpoints(maxConcurrentAttempts)
+                        .build();
+        CheckpointCoordinator checkpointCoordinator =
+                new CheckpointCoordinatorBuilder()
+                        .setExecutionGraph(graph)
+                        .setCheckpointCoordinatorConfiguration(chkConfig)
+                        .setCompletedCheckpointStore(new StandaloneCompletedCheckpointStore(2))
+                        .setTimer(manuallyTriggeredScheduledExecutor)
+                        .build();
 
-            checkpointCoordinator.startCheckpointScheduler();
+        checkpointCoordinator.startCheckpointScheduler();
 
-            do {
-                manuallyTriggeredScheduledExecutor.triggerPeriodicScheduledTasks();
-                manuallyTriggeredScheduledExecutor.triggerAll();
-            } while (checkpointCoordinator.getNumberOfPendingCheckpoints() < maxConcurrentAttempts);
+        do {
+            manuallyTriggeredScheduledExecutor.triggerPeriodicScheduledTasks();
+            manuallyTriggeredScheduledExecutor.triggerAll();
+        } while (checkpointCoordinator.getNumberOfPendingCheckpoints() < maxConcurrentAttempts);
 
-            // validate that the pending checkpoints are there
-            assertEquals(
-                    maxConcurrentAttempts, checkpointCoordinator.getNumberOfPendingCheckpoints());
-            assertNotNull(checkpointCoordinator.getPendingCheckpoints().get(1L));
-            assertNotNull(checkpointCoordinator.getPendingCheckpoints().get(2L));
+        // validate that the pending checkpoints are there
+        assertEquals(maxConcurrentAttempts, checkpointCoordinator.getNumberOfPendingCheckpoints());
+        assertNotNull(checkpointCoordinator.getPendingCheckpoints().get(1L));
+        assertNotNull(checkpointCoordinator.getPendingCheckpoints().get(2L));
 
-            // now we acknowledge the second checkpoint, which should subsume the first checkpoint
-            // and allow two more checkpoints to be triggered
-            // now, once we acknowledge one checkpoint, it should trigger the next one
-            checkpointCoordinator.receiveAcknowledgeMessage(
-                    new AcknowledgeCheckpoint(graph.getJobID(), attemptID1, 2L),
-                    TASK_MANAGER_LOCATION_INFO);
+        // now we acknowledge the second checkpoint, which should subsume the first checkpoint
+        // and allow two more checkpoints to be triggered
+        // now, once we acknowledge one checkpoint, it should trigger the next one
+        checkpointCoordinator.receiveAcknowledgeMessage(
+                new AcknowledgeCheckpoint(graph.getJobID(), attemptID1, 2L),
+                TASK_MANAGER_LOCATION_INFO);
 
-            // after a while, there should be the new checkpoints
-            do {
-                manuallyTriggeredScheduledExecutor.triggerPeriodicScheduledTasks();
-                manuallyTriggeredScheduledExecutor.triggerAll();
-            } while (checkpointCoordinator.getNumberOfPendingCheckpoints() < maxConcurrentAttempts);
+        // after a while, there should be the new checkpoints
+        do {
+            manuallyTriggeredScheduledExecutor.triggerPeriodicScheduledTasks();
+            manuallyTriggeredScheduledExecutor.triggerAll();
+        } while (checkpointCoordinator.getNumberOfPendingCheckpoints() < maxConcurrentAttempts);
 
-            // do the final check
-            assertEquals(
-                    maxConcurrentAttempts, checkpointCoordinator.getNumberOfPendingCheckpoints());
-            assertNotNull(checkpointCoordinator.getPendingCheckpoints().get(3L));
-            assertNotNull(checkpointCoordinator.getPendingCheckpoints().get(4L));
+        // do the final check
+        assertEquals(maxConcurrentAttempts, checkpointCoordinator.getNumberOfPendingCheckpoints());
+        assertNotNull(checkpointCoordinator.getPendingCheckpoints().get(3L));
+        assertNotNull(checkpointCoordinator.getPendingCheckpoints().get(4L));
 
-            checkpointCoordinator.shutdown();
-        } catch (Exception e) {
-            e.printStackTrace();
-            fail(e.getMessage());
-        }
+        checkpointCoordinator.shutdown();
     }
 
     @Test
-    public void testPeriodicSchedulingWithInactiveTasks() {
-        try {
-            JobVertexID jobVertexID1 = new JobVertexID();
+    public void testPeriodicSchedulingWithInactiveTasks() throws Exception {
+        JobVertexID jobVertexID1 = new JobVertexID();
 
-            ExecutionGraph graph =
-                    new CheckpointCoordinatorTestingUtils.CheckpointExecutionGraphBuilder()
-                            .addJobVertex(jobVertexID1)
-                            .setTransitToRunning(false)
-                            .build();
+        ExecutionGraph graph =
+                new CheckpointCoordinatorTestingUtils.CheckpointExecutionGraphBuilder()
+                        .addJobVertex(jobVertexID1)
+                        .setTransitToRunning(false)
+                        .build();
 
-            ExecutionVertex vertex1 = graph.getJobVertex(jobVertexID1).getTaskVertices()[0];
+        ExecutionVertex vertex1 = graph.getJobVertex(jobVertexID1).getTaskVertices()[0];
 
-            CheckpointCoordinatorConfiguration chkConfig =
-                    new CheckpointCoordinatorConfiguration
-                                    .CheckpointCoordinatorConfigurationBuilder()
-                            .setCheckpointInterval(10) // periodic interval is 10 ms
-                            .setCheckpointTimeout(200000) // timeout is very long (200 s)
-                            .setMinPauseBetweenCheckpoints(0) // no extra delay
-                            .setMaxConcurrentCheckpoints(2) // max two concurrent checkpoints
-                            .build();
-            CheckpointCoordinator checkpointCoordinator =
-                    new CheckpointCoordinatorBuilder()
-                            .setExecutionGraph(graph)
-                            .setCheckpointCoordinatorConfiguration(chkConfig)
-                            .setCompletedCheckpointStore(new StandaloneCompletedCheckpointStore(2))
-                            .setTimer(manuallyTriggeredScheduledExecutor)
-                            .build();
+        CheckpointCoordinatorConfiguration chkConfig =
+                new CheckpointCoordinatorConfiguration.CheckpointCoordinatorConfigurationBuilder()
+                        .setCheckpointInterval(10) // periodic interval is 10 ms
+                        .setCheckpointTimeout(200000) // timeout is very long (200 s)
+                        .setMinPauseBetweenCheckpoints(0) // no extra delay
+                        .setMaxConcurrentCheckpoints(2) // max two concurrent checkpoints
+                        .build();
+        CheckpointCoordinator checkpointCoordinator =
+                new CheckpointCoordinatorBuilder()
+                        .setExecutionGraph(graph)
+                        .setCheckpointCoordinatorConfiguration(chkConfig)
+                        .setCompletedCheckpointStore(new StandaloneCompletedCheckpointStore(2))
+                        .setTimer(manuallyTriggeredScheduledExecutor)
+                        .build();
 
-            checkpointCoordinator.startCheckpointScheduler();
+        checkpointCoordinator.startCheckpointScheduler();
 
-            manuallyTriggeredScheduledExecutor.triggerPeriodicScheduledTasks();
-            manuallyTriggeredScheduledExecutor.triggerAll();
-            // no checkpoint should have started so far
-            assertEquals(0, checkpointCoordinator.getNumberOfPendingCheckpoints());
+        manuallyTriggeredScheduledExecutor.triggerPeriodicScheduledTasks();
+        manuallyTriggeredScheduledExecutor.triggerAll();
+        // no checkpoint should have started so far
+        assertEquals(0, checkpointCoordinator.getNumberOfPendingCheckpoints());
 
-            // now move the state to RUNNING
-            vertex1.getCurrentExecutionAttempt().transitionState(ExecutionState.RUNNING);
+        // now move the state to RUNNING
+        vertex1.getCurrentExecutionAttempt().transitionState(ExecutionState.RUNNING);
 
-            // the coordinator should start checkpointing now
-            manuallyTriggeredScheduledExecutor.triggerPeriodicScheduledTasks();
-            manuallyTriggeredScheduledExecutor.triggerAll();
+        // the coordinator should start checkpointing now
+        manuallyTriggeredScheduledExecutor.triggerPeriodicScheduledTasks();
+        manuallyTriggeredScheduledExecutor.triggerAll();
 
-            assertTrue(checkpointCoordinator.getNumberOfPendingCheckpoints() > 0);
-        } catch (Exception e) {
-            e.printStackTrace();
-            fail(e.getMessage());
-        }
+        assertTrue(checkpointCoordinator.getNumberOfPendingCheckpoints() > 0);
     }
 
     /** Tests that the savepoints can be triggered concurrently. */
@@ -2647,48 +2542,39 @@ public class CheckpointCoordinatorTest extends TestLogger {
     /** Tests that the externalized checkpoint configuration is respected. */
     @Test
     public void testExternalizedCheckpoints() throws Exception {
-        try {
+        ExecutionGraph graph =
+                new CheckpointCoordinatorTestingUtils.CheckpointExecutionGraphBuilder()
+                        .addJobVertex(new JobVertexID())
+                        .build();
 
-            ExecutionGraph graph =
-                    new CheckpointCoordinatorTestingUtils.CheckpointExecutionGraphBuilder()
-                            .addJobVertex(new JobVertexID())
-                            .build();
+        // set up the coordinator and validate the initial state
+        CheckpointCoordinatorConfiguration chkConfig =
+                new CheckpointCoordinatorConfiguration.CheckpointCoordinatorConfigurationBuilder()
+                        .setCheckpointRetentionPolicy(CheckpointRetentionPolicy.RETAIN_ON_FAILURE)
+                        .build();
+        CheckpointCoordinator checkpointCoordinator =
+                new CheckpointCoordinatorBuilder()
+                        .setExecutionGraph(graph)
+                        .setCheckpointCoordinatorConfiguration(chkConfig)
+                        .setTimer(manuallyTriggeredScheduledExecutor)
+                        .build();
 
-            // set up the coordinator and validate the initial state
-            CheckpointCoordinatorConfiguration chkConfig =
-                    new CheckpointCoordinatorConfiguration
-                                    .CheckpointCoordinatorConfigurationBuilder()
-                            .setCheckpointRetentionPolicy(
-                                    CheckpointRetentionPolicy.RETAIN_ON_FAILURE)
-                            .build();
-            CheckpointCoordinator checkpointCoordinator =
-                    new CheckpointCoordinatorBuilder()
-                            .setExecutionGraph(graph)
-                            .setCheckpointCoordinatorConfiguration(chkConfig)
-                            .setTimer(manuallyTriggeredScheduledExecutor)
-                            .build();
+        CompletableFuture<CompletedCheckpoint> checkpointFuture =
+                checkpointCoordinator.triggerCheckpoint(false);
+        manuallyTriggeredScheduledExecutor.triggerAll();
+        FutureUtils.throwIfCompletedExceptionally(checkpointFuture);
 
-            CompletableFuture<CompletedCheckpoint> checkpointFuture =
-                    checkpointCoordinator.triggerCheckpoint(false);
-            manuallyTriggeredScheduledExecutor.triggerAll();
-            FutureUtils.throwIfCompletedExceptionally(checkpointFuture);
+        for (PendingCheckpoint checkpoint :
+                checkpointCoordinator.getPendingCheckpoints().values()) {
+            CheckpointProperties props = checkpoint.getProps();
+            CheckpointProperties expected =
+                    CheckpointProperties.forCheckpoint(CheckpointRetentionPolicy.RETAIN_ON_FAILURE);
 
-            for (PendingCheckpoint checkpoint :
-                    checkpointCoordinator.getPendingCheckpoints().values()) {
-                CheckpointProperties props = checkpoint.getProps();
-                CheckpointProperties expected =
-                        CheckpointProperties.forCheckpoint(
-                                CheckpointRetentionPolicy.RETAIN_ON_FAILURE);
-
-                assertEquals(expected, props);
-            }
-
-            // the now we should have a completed checkpoint
-            checkpointCoordinator.shutdown();
-        } catch (Exception e) {
-            e.printStackTrace();
-            fail(e.getMessage());
+            assertEquals(expected, props);
         }
+
+        // the now we should have a completed checkpoint
+        checkpointCoordinator.shutdown();
     }
 
     @Test
@@ -3236,10 +3122,11 @@ public class CheckpointCoordinatorTest extends TestLogger {
             } catch (ExecutionException e) {
                 final Optional<CheckpointException> checkpointExceptionOptional =
                         ExceptionUtils.findThrowable(e, CheckpointException.class);
-                assertTrue(checkpointExceptionOptional.isPresent());
-                assertEquals(
-                        CheckpointFailureReason.PERIODIC_SCHEDULER_SHUTDOWN,
-                        checkpointExceptionOptional.get().getCheckpointFailureReason());
+                if (!checkpointExceptionOptional.isPresent()
+                        || checkpointExceptionOptional.get().getCheckpointFailureReason()
+                                != PERIODIC_SCHEDULER_SHUTDOWN) {
+                    throw e;
+                }
             }
         } finally {
             checkpointCoordinator.shutdown();

--- a/flink-runtime/src/test/java/org/apache/flink/runtime/checkpoint/CheckpointFailureManagerTest.java
+++ b/flink-runtime/src/test/java/org/apache/flink/runtime/checkpoint/CheckpointFailureManagerTest.java
@@ -71,7 +71,7 @@ public class CheckpointFailureManagerTest extends TestLogger {
         CheckpointFailureManager failureManager = new CheckpointFailureManager(2, callback);
 
         failureManager.handleJobLevelCheckpointException(
-                new CheckpointException(CheckpointFailureReason.EXCEPTION), 1);
+                new CheckpointException(CheckpointFailureReason.IO_EXCEPTION), 1);
         failureManager.handleJobLevelCheckpointException(
                 new CheckpointException(CheckpointFailureReason.CHECKPOINT_DECLINED), 2);
 

--- a/flink-runtime/src/test/java/org/apache/flink/runtime/checkpoint/CheckpointFailureManagerTest.java
+++ b/flink-runtime/src/test/java/org/apache/flink/runtime/checkpoint/CheckpointFailureManagerTest.java
@@ -95,8 +95,8 @@ public class CheckpointFailureManagerTest extends TestLogger {
             failureManager.handleJobLevelCheckpointException(new CheckpointException(reason), -1);
         }
 
-        // CHECKPOINT_DECLINED, CHECKPOINT_EXPIRED and CHECKPOINT_ASYNC_EXCEPTION
-        assertEquals(3, callback.getInvokeCounter());
+        // IO_EXCEPTION, CHECKPOINT_DECLINED, CHECKPOINT_EXPIRED and CHECKPOINT_ASYNC_EXCEPTION
+        assertEquals(4, callback.getInvokeCounter());
     }
 
     @Test

--- a/flink-streaming-java/src/main/java/org/apache/flink/streaming/runtime/io/StreamTaskNetworkInput.java
+++ b/flink-streaming-java/src/main/java/org/apache/flink/streaming/runtime/io/StreamTaskNetworkInput.java
@@ -106,7 +106,7 @@ public final class StreamTaskNetworkInput<T>
                         ChannelStateWriter.SEQUENCE_NUMBER_UNKNOWN,
                         e.getValue().getUnconsumedBuffer());
             } catch (IOException ioException) {
-                throw new CheckpointException(CheckpointFailureReason.EXCEPTION, ioException);
+                throw new CheckpointException(CheckpointFailureReason.IO_EXCEPTION, ioException);
             }
         }
         return checkpointedInputGate.getAllBarriersReceivedFuture(checkpointId);

--- a/flink-tests/src/test/java/org/apache/flink/runtime/jobmaster/JobMasterStopWithSavepointITCase.java
+++ b/flink-tests/src/test/java/org/apache/flink/runtime/jobmaster/JobMasterStopWithSavepointITCase.java
@@ -226,8 +226,7 @@ public class JobMasterStopWithSavepointITCase extends AbstractTestBase {
             String exceptionMessage = checkpointExceptionOptional.get().getMessage();
             assertTrue(
                     "Stop with savepoint failed because of another cause " + exceptionMessage,
-                    exceptionMessage.contains(
-                            CheckpointFailureReason.TRIGGER_CHECKPOINT_FAILURE.message()));
+                    exceptionMessage.contains(CheckpointFailureReason.IO_EXCEPTION.message()));
         }
 
         final JobStatus jobStatus =


### PR DESCRIPTION
This PR supersedes https://github.com/apache/flink/pull/16637. It's adding a two commits on top of the original one.

## What is the purpose of the change

This pull request make some kinds of failures be checked against CheckpointFailureManager and be deciding whether these errors should be just logged or checked against the number of tolerable failures and maybe fail the job. So it separate IO_EXCEPTION from TRIGGER_CHECKPOINT_FAILURE enum and add IO_EXCEPTION to the reason which will checked against the number of tolerable failures. With this we can let users perceived some unrecoverable error faster. Also it Migrate from EXCEPTION enum to IO_EXCEPTION because according to the code it is exactly IO_EXCEPTION.


## Brief change log

  - *Separate IO_EXCEPTION from TRIGGER_CHECKPOINT_FAILURE enum*
  - *Add IO_EXCEPTION to identify the disk error and increase the number of failure count*
  - *Add a unit test case for IO_EXCEPTION scene*
  - *Migrate from EXCEPTION enum to IO_EXCEPTION*


## Verifying this change

  - *Added IO_EXCEPTION scene to CheckpointCoordinatorTest and modify the number of CheckpointFailureManagerTest*
  - *Add unit test case in CheckpointCoordinatorTest for IO_EXCEPTION scene*
  - *Modify JobMasterStopWithSavepointITCase for IO_EXCEPTION scene*

## Does this pull request potentially affect one of the following parts:

  - Dependencies (does it add or upgrade a dependency): (no)
  - The public API, i.e., is any changed class annotated with `@Public(Evolving)`: (no)
  - The serializers: (no)
  - The runtime per-record code paths (performance sensitive): (no)
  - Anything that affects deployment or recovery: JobManager (and its components), Checkpointing, Kubernetes/Yarn, ZooKeeper: (yes)
  - The S3 file system connector: (no)

## Documentation

  - Does this pull request introduce a new feature? (no)
  - If yes, how is the feature documented? (not applicable)
