### PR TITLE
[FLINK-22871][python] Support to specify python client interpreter used to compile jobs

### DIFF
--- a/docs/content.zh/docs/deployment/cli.md
+++ b/docs/content.zh/docs/deployment/cli.md
@@ -480,6 +480,14 @@ related options. Here's an overview of all the Python related options for the ac
             </td>
         </tr>
         <tr>
+            <td><code class="highlighter-rouge">-pyclientexec,--pyClientExecutable</code></td>
+            <td>
+                The path of the Python interpreter used to launch the Python process when submitting
+                the Python jobs via \"flink run\" or compiling the Java/Scala jobs containing
+                Python UDFs.
+            </td>
+        </tr>
+        <tr>
             <td><code class="highlighter-rouge">-pyexec,--pyExecutable</code></td>
             <td>
                 Specify the path of the python interpreter used to execute the python UDF worker

--- a/docs/content.zh/docs/deployment/cli.md
+++ b/docs/content.zh/docs/deployment/cli.md
@@ -485,6 +485,7 @@ related options. Here's an overview of all the Python related options for the ac
                 The path of the Python interpreter used to launch the Python process when submitting
                 the Python jobs via \"flink run\" or compiling the Java/Scala jobs containing
                 Python UDFs.
+                (e.g., --pyArchives file:///tmp/py37.zip --pyClientExecutable py37.zip/py37/python)
             </td>
         </tr>
         <tr>

--- a/docs/content/docs/deployment/cli.md
+++ b/docs/content/docs/deployment/cli.md
@@ -483,6 +483,7 @@ related options. Here's an overview of all the Python related options for the ac
                 The path of the Python interpreter used to launch the Python process when submitting
                 the Python jobs via \"flink run\" or compiling the Java/Scala jobs containing
                 Python UDFs.
+                (e.g., --pyArchives file:///tmp/py37.zip --pyClientExecutable py37.zip/py37/python)
             </td>
         </tr>
         <tr>

--- a/docs/content/docs/deployment/cli.md
+++ b/docs/content/docs/deployment/cli.md
@@ -478,6 +478,14 @@ related options. Here's an overview of all the Python related options for the ac
             </td>
         </tr>
         <tr>
+            <td><code class="highlighter-rouge">-pyclientexec,--pyClientExecutable</code></td>
+            <td>
+                The path of the Python interpreter used to launch the Python process when submitting
+                the Python jobs via \"flink run\" or compiling the Java/Scala jobs containing
+                Python UDFs.
+            </td>
+        </tr>
+        <tr>
             <td><code class="highlighter-rouge">-pyexec,--pyExecutable</code></td>
             <td>
                 Specify the path of the python interpreter used to execute the python UDF worker

--- a/docs/layouts/shortcodes/generated/python_configuration.html
+++ b/docs/layouts/shortcodes/generated/python_configuration.html
@@ -18,7 +18,7 @@
             <td><h5>python.client.executable</h5></td>
             <td style="word-wrap: break-word;">"python"</td>
             <td>String</td>
-            <td>The path of the Python interpreter used to launch the Python process when submitting the Python jobs via "flink run" or compiling the Java/Scala jobs containing Python UDFs. Equivalent to the environment variable PYFLINK_CLIENT_EXECUTABLE. The priority is as following: <br />1. the configuration 'python.client.executable' defined in the source code;<br />2. the environment variable PYFLINK_CLIENT_EXECUTABLE;<br />3. the configuration 'python.client.executable' defined in flink-conf.yaml</td>
+            <td>The path of the Python interpreter used to launch the Python process when submitting the Python jobs via "flink run" or compiling the Java/Scala jobs containing Python UDFs. Equivalent to the command line option "-pyclientexec" or the environment variable PYFLINK_CLIENT_EXECUTABLE. The priority is as following: <br />1. the command line option "-pyclientexec";<br />2. the environment variable PYFLINK_CLIENT_EXECUTABLE;<br />3. the configuration 'python.client.executable' defined in flink-conf.yaml</td>
         </tr>
         <tr>
             <td><h5>python.executable</h5></td>

--- a/flink-clients/src/main/java/org/apache/flink/client/cli/CliFrontendParser.java
+++ b/flink-clients/src/main/java/org/apache/flink/client/cli/CliFrontendParser.java
@@ -244,6 +244,15 @@ public class CliFrontendParser {
                             + "Pip (version >= 7.1.0) and SetupTools (version >= 37.0.0). "
                             + "Please ensure that the specified environment meets the above requirements.");
 
+    public static final Option PYCLIENTEXEC_OPTION =
+            new Option(
+                    "pyclientexec",
+                    "pyClientExecutable",
+                    true,
+                    "The path of the Python interpreter used to launch the Python "
+                            + "process when submitting the Python jobs via \"flink run\" or compiling "
+                            + "the Java/Scala jobs containing Python UDFs.");
+
     static {
         HELP_OPTION.setRequired(false);
 
@@ -305,6 +314,8 @@ public class CliFrontendParser {
         PYARCHIVE_OPTION.setRequired(false);
 
         PYEXEC_OPTION.setRequired(false);
+
+        PYCLIENTEXEC_OPTION.setRequired(false);
     }
 
     static final Options RUN_OPTIONS = getRunCommandOptions();
@@ -331,6 +342,7 @@ public class CliFrontendParser {
         options.addOption(PYREQUIREMENTS_OPTION);
         options.addOption(PYARCHIVE_OPTION);
         options.addOption(PYEXEC_OPTION);
+        options.addOption(PYCLIENTEXEC_OPTION);
         return options;
     }
 
@@ -346,6 +358,7 @@ public class CliFrontendParser {
         options.addOption(PYREQUIREMENTS_OPTION);
         options.addOption(PYARCHIVE_OPTION);
         options.addOption(PYEXEC_OPTION);
+        options.addOption(PYCLIENTEXEC_OPTION);
         return options;
     }
 

--- a/flink-clients/src/main/java/org/apache/flink/client/cli/ProgramOptionsUtils.java
+++ b/flink-clients/src/main/java/org/apache/flink/client/cli/ProgramOptionsUtils.java
@@ -36,6 +36,7 @@ import java.net.URLClassLoader;
 
 import static org.apache.flink.client.cli.CliFrontendParser.CLASS_OPTION;
 import static org.apache.flink.client.cli.CliFrontendParser.PYARCHIVE_OPTION;
+import static org.apache.flink.client.cli.CliFrontendParser.PYCLIENTEXEC_OPTION;
 import static org.apache.flink.client.cli.CliFrontendParser.PYEXEC_OPTION;
 import static org.apache.flink.client.cli.CliFrontendParser.PYFILES_OPTION;
 import static org.apache.flink.client.cli.CliFrontendParser.PYMODULE_OPTION;
@@ -67,7 +68,8 @@ public enum ProgramOptionsUtils {
         return line.hasOption(PYFILES_OPTION.getOpt())
                 || line.hasOption(PYREQUIREMENTS_OPTION.getOpt())
                 || line.hasOption(PYARCHIVE_OPTION.getOpt())
-                || line.hasOption(PYEXEC_OPTION.getOpt());
+                || line.hasOption(PYEXEC_OPTION.getOpt())
+                || line.hasOption(PYCLIENTEXEC_OPTION.getOpt());
     }
 
     public static ProgramOptions createPythonProgramOptions(CommandLine line)

--- a/flink-python/src/main/java/org/apache/flink/python/PythonOptions.java
+++ b/flink-python/src/main/java/org/apache/flink/python/PythonOptions.java
@@ -148,7 +148,7 @@ public class PythonOptions {
                                                     + "Equivalent to the command line option \"-pyclientexec\" or the environment variable PYFLINK_CLIENT_EXECUTABLE. "
                                                     + "The priority is as following: ")
                                     .linebreak()
-                                    .text("1. the command line option \"-pyclientexec\"")
+                                    .text("1. the command line option \"-pyclientexec\";")
                                     .linebreak()
                                     .text("2. the environment variable PYFLINK_CLIENT_EXECUTABLE;")
                                     .linebreak()

--- a/flink-python/src/main/java/org/apache/flink/python/PythonOptions.java
+++ b/flink-python/src/main/java/org/apache/flink/python/PythonOptions.java
@@ -145,11 +145,10 @@ public class PythonOptions {
                                     .text(
                                             "The path of the Python interpreter used to launch the Python process when submitting the "
                                                     + "Python jobs via \"flink run\" or compiling the Java/Scala jobs containing Python UDFs. "
-                                                    + "Equivalent to the environment variable PYFLINK_CLIENT_EXECUTABLE. "
+                                                    + "Equivalent to the command line option \"-pyclientexec\" or the environment variable PYFLINK_CLIENT_EXECUTABLE. "
                                                     + "The priority is as following: ")
                                     .linebreak()
-                                    .text(
-                                            "1. the configuration 'python.client.executable' defined in the source code;")
+                                    .text("1. the command line option \"-pyclientexec\"")
                                     .linebreak()
                                     .text("2. the environment variable PYFLINK_CLIENT_EXECUTABLE;")
                                     .linebreak()

--- a/flink-python/src/main/java/org/apache/flink/python/util/PythonDependencyUtils.java
+++ b/flink-python/src/main/java/org/apache/flink/python/util/PythonDependencyUtils.java
@@ -43,6 +43,7 @@ import java.util.Map;
 import java.util.stream.Collectors;
 
 import static org.apache.flink.client.cli.CliFrontendParser.PYARCHIVE_OPTION;
+import static org.apache.flink.client.cli.CliFrontendParser.PYCLIENTEXEC_OPTION;
 import static org.apache.flink.client.cli.CliFrontendParser.PYEXEC_OPTION;
 import static org.apache.flink.client.cli.CliFrontendParser.PYFILES_OPTION;
 import static org.apache.flink.client.cli.CliFrontendParser.PYREQUIREMENTS_OPTION;
@@ -111,6 +112,12 @@ public class PythonDependencyUtils {
                     PythonOptions.PYTHON_EXECUTABLE,
                     commandLine.getOptionValue(PYEXEC_OPTION.getOpt()));
         }
+        if (commandLine.hasOption(PYCLIENTEXEC_OPTION.getOpt())) {
+            config.set(
+                    PythonOptions.PYTHON_CLIENT_EXECUTABLE,
+                    commandLine.getOptionValue(PYCLIENTEXEC_OPTION.getOpt()));
+        }
+
         return config;
     }
 

--- a/flink-table/flink-sql-client/src/main/java/org/apache/flink/table/client/cli/CliOptionsParser.java
+++ b/flink-table/flink-sql-client/src/main/java/org/apache/flink/table/client/cli/CliOptionsParser.java
@@ -38,6 +38,7 @@ import java.util.List;
 import java.util.stream.Collectors;
 
 import static org.apache.flink.client.cli.CliFrontendParser.PYARCHIVE_OPTION;
+import static org.apache.flink.client.cli.CliFrontendParser.PYCLIENTEXEC_OPTION;
 import static org.apache.flink.client.cli.CliFrontendParser.PYEXEC_OPTION;
 import static org.apache.flink.client.cli.CliFrontendParser.PYFILES_OPTION;
 import static org.apache.flink.client.cli.CliFrontendParser.PYREQUIREMENTS_OPTION;
@@ -160,6 +161,7 @@ public class CliOptionsParser {
         options.addOption(PYREQUIREMENTS_OPTION);
         options.addOption(PYARCHIVE_OPTION);
         options.addOption(PYEXEC_OPTION);
+        options.addOption(PYCLIENTEXEC_OPTION);
         return options;
     }
 
@@ -172,6 +174,7 @@ public class CliOptionsParser {
         options.addOption(PYREQUIREMENTS_OPTION);
         options.addOption(PYARCHIVE_OPTION);
         options.addOption(PYEXEC_OPTION);
+        options.addOption(PYCLIENTEXEC_OPTION);
         return options;
     }
 
@@ -183,6 +186,7 @@ public class CliOptionsParser {
         options.addOption(PYREQUIREMENTS_OPTION);
         options.addOption(PYARCHIVE_OPTION);
         options.addOption(PYEXEC_OPTION);
+        options.addOption(PYCLIENTEXEC_OPTION);
         return options;
     }
 


### PR DESCRIPTION
## What is the purpose of the change

*This pull request will support to specify python client interpreter used to compile jobs*


## Brief change log

  - *Support to specify python client interpreter used to compile jobs*

## Verifying this change

This change added tests and can be verified as follows:

  - *UT in `PythonEnvUtilsTest.java`*

## Does this pull request potentially affect one of the following parts:

  - Dependencies (does it add or upgrade a dependency): (no)
  - The public API, i.e., is any changed class annotated with `@Public(Evolving)`: (no)
  - The serializers: (no)
  - The runtime per-record code paths (performance sensitive): (no)
  - Anything that affects deployment or recovery: JobManager (and its components), Checkpointing, Kubernetes/Yarn, ZooKeeper: (no)
  - The S3 file system connector: (no)

## Documentation

  - Does this pull request introduce a new feature? (no)
  - If yes, how is the feature documented? (not applicable)
