### PR TITLE
[FLINK-23789][rocksdb] Remove unnecessary setTotalOrderForSeek for Rocks iterator

### DIFF
--- a/flink-state-backends/flink-statebackend-rocksdb/src/main/java/org/apache/flink/contrib/streaming/state/RocksDBIncrementalCheckpointUtils.java
+++ b/flink-state-backends/flink-statebackend-rocksdb/src/main/java/org/apache/flink/contrib/streaming/state/RocksDBIncrementalCheckpointUtils.java
@@ -127,7 +127,7 @@ public class RocksDBIncrementalCheckpointUtils {
             throws RocksDBException {
 
         for (ColumnFamilyHandle columnFamilyHandle : columnFamilyHandles) {
-            try (ReadOptions readOptions = RocksDBOperationUtils.createTotalOrderSeekReadOptions();
+            try (ReadOptions readOptions = new ReadOptions();
                     RocksIteratorWrapper iteratorWrapper =
                             RocksDBOperationUtils.getRocksIterator(
                                     db, columnFamilyHandle, readOptions);

--- a/flink-state-backends/flink-statebackend-rocksdb/src/main/java/org/apache/flink/contrib/streaming/state/RocksDBOperationUtils.java
+++ b/flink-state-backends/flink-statebackend-rocksdb/src/main/java/org/apache/flink/contrib/streaming/state/RocksDBOperationUtils.java
@@ -104,16 +104,6 @@ public class RocksDBOperationUtils {
         return new RocksIteratorWrapper(db.newIterator(columnFamilyHandle, readOptions));
     }
 
-    /**
-     * Create a total order read option to avoid user misuse, see FLINK-17800 for more details.
-     *
-     * <p>Note, remember to close the generated {@link ReadOptions} when dispose.
-     */
-    // TODO We would remove this method once we bump RocksDB version larger than 6.2.2.
-    public static ReadOptions createTotalOrderSeekReadOptions() {
-        return new ReadOptions().setTotalOrderSeek(true);
-    }
-
     public static void registerKvStateInformation(
             Map<String, RocksDBKeyedStateBackend.RocksDbKvStateInfo> kvStateInformation,
             RocksDBNativeMetricMonitor nativeMetricMonitor,

--- a/flink-state-backends/flink-statebackend-rocksdb/src/main/java/org/apache/flink/contrib/streaming/state/RocksDBResourceContainer.java
+++ b/flink-state-backends/flink-statebackend-rocksdb/src/main/java/org/apache/flink/contrib/streaming/state/RocksDBResourceContainer.java
@@ -183,9 +183,7 @@ public final class RocksDBResourceContainer implements AutoCloseable {
 
     /** Gets the RocksDB {@link ReadOptions} to be used for read operations. */
     public ReadOptions getReadOptions() {
-        // We ensure total order seek by default to prevent user misuse, see FLINK-17800 for more
-        // details
-        ReadOptions opt = RocksDBOperationUtils.createTotalOrderSeekReadOptions();
+        ReadOptions opt = new ReadOptions();
         handlesToClose.add(opt);
 
         // add user-defined options factory, if specified

--- a/flink-state-backends/flink-statebackend-rocksdb/src/main/java/org/apache/flink/contrib/streaming/state/restore/RocksDBIncrementalRestoreOperation.java
+++ b/flink-state-backends/flink-statebackend-rocksdb/src/main/java/org/apache/flink/contrib/streaming/state/restore/RocksDBIncrementalRestoreOperation.java
@@ -422,7 +422,7 @@ public class RocksDBIncrementalRestoreOperation<K> implements RocksDBRestoreOper
             this.columnFamilyHandles = columnFamilyHandles;
             this.columnFamilyDescriptors = columnFamilyDescriptors;
             this.stateMetaInfoSnapshots = stateMetaInfoSnapshots;
-            this.readOptions = RocksDBOperationUtils.createTotalOrderSeekReadOptions();
+            this.readOptions = new ReadOptions();
         }
 
         @Override

--- a/flink-state-backends/flink-statebackend-rocksdb/src/test/java/org/apache/flink/contrib/streaming/state/RocksDBResource.java
+++ b/flink-state-backends/flink-statebackend-rocksdb/src/test/java/org/apache/flink/contrib/streaming/state/RocksDBResource.java
@@ -165,7 +165,7 @@ public class RocksDBResource extends ExternalResource {
                         handlesToClose);
         this.writeOptions = new WriteOptions();
         this.writeOptions.disableWAL();
-        this.readOptions = RocksDBOperationUtils.createTotalOrderSeekReadOptions();
+        this.readOptions = new ReadOptions();
         this.columnFamilyHandles = new ArrayList<>(1);
         this.rocksDB =
                 RocksDB.open(

--- a/flink-state-backends/flink-statebackend-rocksdb/src/test/java/org/apache/flink/contrib/streaming/state/RocksDBStateOptionTest.java
+++ b/flink-state-backends/flink-statebackend-rocksdb/src/test/java/org/apache/flink/contrib/streaming/state/RocksDBStateOptionTest.java
@@ -52,31 +52,29 @@ import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertTrue;
 
 /**
- * Tests to cover cases that even user misuse some options, RocksDB state-backend could still work
- * as expected or give explicit feedback.
+ * Tests to cover cases that if user choose options previously prone to misuse, embedded RocksDB
+ * state-backend could still work as expected or give explicit feedback.
  *
  * <p>RocksDB state-backend has some internal operations based on RocksDB's APIs which is
  * transparent for users. However, user could still configure options via {@link
  * RocksDBOptionsFactory}, and might lead some operations could not get expected result, e.g.
  * FLINK-17800
  */
-public class RocksDBStateMisuseOptionTest {
+public class RocksDBStateOptionTest {
 
     @Rule public final TemporaryFolder tempFolder = new TemporaryFolder();
 
     /**
-     * Tests to cover case when user misuse optimizeForPointLookup with iterator interfaces on map
+     * Tests to cover case when user choose optimizeForPointLookup with iterator interfaces on map
      * state.
-     *
-     * <p>The option {@link ColumnFamilyOptions#optimizeForPointLookup(long)} would lead to
-     * iterator.seek with prefix bytes invalid.
      */
     @Test
     public void testMisuseOptimizePointLookupWithMapState() throws Exception {
-        RocksDBStateBackend rocksDBStateBackend = createStateBackendWithOptimizePointLookup();
+        EmbeddedRocksDBStateBackend rocksDBStateBackend =
+                createStateBackendWithOptimizePointLookup();
         RocksDBKeyedStateBackend<Integer> keyedStateBackend =
                 createKeyedStateBackend(
-                        rocksDBStateBackend.getEmbeddedRocksDBStateBackend(),
+                        rocksDBStateBackend,
                         new MockEnvironmentBuilder().build(),
                         IntSerializer.INSTANCE);
         try {
@@ -111,18 +109,16 @@ public class RocksDBStateMisuseOptionTest {
     }
 
     /**
-     * Tests to cover case when user misuse optimizeForPointLookup with peek operations on priority
+     * Tests to cover case when user choose optimizeForPointLookup with peek operations on priority
      * queue.
-     *
-     * <p>The option {@link ColumnFamilyOptions#optimizeForPointLookup(long)} would lead to
-     * iterator.seek with prefix bytes invalid.
      */
     @Test
     public void testMisuseOptimizePointLookupWithPriorityQueue() throws IOException {
-        RocksDBStateBackend rocksDBStateBackend = createStateBackendWithOptimizePointLookup();
+        EmbeddedRocksDBStateBackend rocksDBStateBackend =
+                createStateBackendWithOptimizePointLookup();
         RocksDBKeyedStateBackend<Integer> keyedStateBackend =
                 createKeyedStateBackend(
-                        rocksDBStateBackend.getEmbeddedRocksDBStateBackend(),
+                        rocksDBStateBackend,
                         new MockEnvironmentBuilder().build(),
                         IntSerializer.INSTANCE);
         try {
@@ -159,11 +155,10 @@ public class RocksDBStateMisuseOptionTest {
         }
     }
 
-    private RocksDBStateBackend createStateBackendWithOptimizePointLookup() throws IOException {
-        RocksDBStateBackend rocksDBStateBackend =
-                new RocksDBStateBackend(tempFolder.newFolder().toURI(), true);
+    private EmbeddedRocksDBStateBackend createStateBackendWithOptimizePointLookup() {
+        EmbeddedRocksDBStateBackend rocksDBStateBackend = new EmbeddedRocksDBStateBackend(true);
         rocksDBStateBackend.setPriorityQueueStateType(
-                RocksDBStateBackend.PriorityQueueStateType.ROCKSDB);
+                EmbeddedRocksDBStateBackend.PriorityQueueStateType.ROCKSDB);
         rocksDBStateBackend.setRocksDBOptions(
                 new RocksDBOptionsFactory() {
 

--- a/flink-state-backends/flink-statebackend-rocksdb/src/test/java/org/apache/flink/contrib/streaming/state/RocksDBStateOptionTest.java
+++ b/flink-state-backends/flink-statebackend-rocksdb/src/test/java/org/apache/flink/contrib/streaming/state/RocksDBStateOptionTest.java
@@ -112,7 +112,7 @@ public class RocksDBStateOptionTest {
      * queue.
      */
     @Test
-    public void testMisuseOptimizePointLookupWithPriorityQueue() throws IOException {
+    public void testUseOptimizePointLookupWithPriorityQueue() throws IOException {
         RocksDBStateBackend rocksDBStateBackend = createStateBackendWithOptimizePointLookup();
         RocksDBKeyedStateBackend<Integer> keyedStateBackend =
                 createKeyedStateBackend(

--- a/flink-state-backends/flink-statebackend-rocksdb/src/test/java/org/apache/flink/contrib/streaming/state/RocksDBStateOptionTest.java
+++ b/flink-state-backends/flink-statebackend-rocksdb/src/test/java/org/apache/flink/contrib/streaming/state/RocksDBStateOptionTest.java
@@ -69,12 +69,11 @@ public class RocksDBStateOptionTest {
      * state.
      */
     @Test
-    public void testMisuseOptimizePointLookupWithMapState() throws Exception {
-        EmbeddedRocksDBStateBackend rocksDBStateBackend =
-                createStateBackendWithOptimizePointLookup();
+    public void testUseOptimizePointLookupWithMapState() throws Exception {
+        RocksDBStateBackend rocksDBStateBackend = createStateBackendWithOptimizePointLookup();
         RocksDBKeyedStateBackend<Integer> keyedStateBackend =
                 createKeyedStateBackend(
-                        rocksDBStateBackend,
+                        rocksDBStateBackend.getEmbeddedRocksDBStateBackend(),
                         new MockEnvironmentBuilder().build(),
                         IntSerializer.INSTANCE);
         try {
@@ -114,11 +113,10 @@ public class RocksDBStateOptionTest {
      */
     @Test
     public void testMisuseOptimizePointLookupWithPriorityQueue() throws IOException {
-        EmbeddedRocksDBStateBackend rocksDBStateBackend =
-                createStateBackendWithOptimizePointLookup();
+        RocksDBStateBackend rocksDBStateBackend = createStateBackendWithOptimizePointLookup();
         RocksDBKeyedStateBackend<Integer> keyedStateBackend =
                 createKeyedStateBackend(
-                        rocksDBStateBackend,
+                        rocksDBStateBackend.getEmbeddedRocksDBStateBackend(),
                         new MockEnvironmentBuilder().build(),
                         IntSerializer.INSTANCE);
         try {
@@ -155,10 +153,11 @@ public class RocksDBStateOptionTest {
         }
     }
 
-    private EmbeddedRocksDBStateBackend createStateBackendWithOptimizePointLookup() {
-        EmbeddedRocksDBStateBackend rocksDBStateBackend = new EmbeddedRocksDBStateBackend(true);
+    private RocksDBStateBackend createStateBackendWithOptimizePointLookup() throws IOException {
+        RocksDBStateBackend rocksDBStateBackend =
+                new RocksDBStateBackend(tempFolder.newFolder().toURI(), true);
         rocksDBStateBackend.setPriorityQueueStateType(
-                EmbeddedRocksDBStateBackend.PriorityQueueStateType.ROCKSDB);
+                RocksDBStateBackend.PriorityQueueStateType.ROCKSDB);
         rocksDBStateBackend.setRocksDBOptions(
                 new RocksDBOptionsFactory() {
 


### PR DESCRIPTION
## What is the purpose of the change

Remove unnecessary setTotalOrderForSeek for Rocks iterator

## Brief change log

Remove unnecessary setTotalOrderForSeek for Rocks iterator and modify related tests.

## Verifying this change


This change is already covered by existing tests, such as `RocksDBStateOptionTest.java`.

## Does this pull request potentially affect one of the following parts:

  - Dependencies (does it add or upgrade a dependency): no
  - The public API, i.e., is any changed class annotated with `@Public(Evolving)`: no
  - The serializers: no
  - The runtime per-record code paths (performance sensitive): no
  - Anything that affects deployment or recovery: JobManager (and its components), Checkpointing, Kubernetes/Yarn, ZooKeeper: no
  - The S3 file system connector: no

## Documentation

  - Does this pull request introduce a new feature? no
  - If yes, how is the feature documented? not applicable
