### PR TITLE
[FLINK-15532][rocksdb] Enable strict capacity limit for memory usage for RocksDB

### DIFF
--- a/flink-state-backends/flink-statebackend-rocksdb/src/main/java/org/apache/flink/contrib/streaming/state/RocksDBMemoryControllerUtils.java
+++ b/flink-state-backends/flink-statebackend-rocksdb/src/main/java/org/apache/flink/contrib/streaming/state/RocksDBMemoryControllerUtils.java
@@ -103,8 +103,7 @@ public class RocksDBMemoryControllerUtils {
 
     @VisibleForTesting
     static Cache createCache(long cacheCapacity, double highPriorityPoolRatio) {
-        // TODO use strict capacity limit until FLINK-15532 resolved
-        return new LRUCache(cacheCapacity, -1, false, highPriorityPoolRatio);
+        return new LRUCache(cacheCapacity, -1, true, highPriorityPoolRatio);
     }
 
     @VisibleForTesting


### PR DESCRIPTION
## What is the purpose of the change

Enable strict capacity limit for memory usage for RocksDB.


## Brief change log

Change the constructor of `LRUCache` to strict mode.


## Verifying this change

This change is a trivial rework / code cleanup without any test coverage.


## Does this pull request potentially affect one of the following parts:

  - Dependencies (does it add or upgrade a dependency): no
  - The public API, i.e., is any changed class annotated with `@Public(Evolving)`: no
  - The serializers: no
  - The runtime per-record code paths (performance sensitive): no
  - Anything that affects deployment or recovery: JobManager (and its components), Checkpointing, Kubernetes/Yarn, ZooKeeper: no
  - The S3 file system connector: no

## Documentation

  - Does this pull request introduce a new feature? no
  - If yes, how is the feature documented? not applicable