### PR TITLE
[FLINK-23801][connector/kafka] Report numBytesIn and pendingRecords in KafkaSource

### DIFF
--- a/flink-connectors/flink-connector-kafka/src/main/java/org/apache/flink/connector/kafka/source/KafkaSource.java
+++ b/flink-connectors/flink-connector-kafka/src/main/java/org/apache/flink/connector/kafka/source/KafkaSource.java
@@ -142,7 +142,7 @@ public class KafkaSource<OUT>
                         new KafkaPartitionSplitReader<>(
                                 props,
                                 deserializationSchema,
-                                readerContext.getIndexOfSubtask(),
+                                readerContext,
                                 kafkaSourceReaderMetrics);
         KafkaRecordEmitter<OUT> recordEmitter = new KafkaRecordEmitter<>();
 

--- a/flink-connectors/flink-connector-kafka/src/test/java/org/apache/flink/connector/kafka/source/metrics/KafkaSourceReaderMetricsTest.java
+++ b/flink-connectors/flink-connector-kafka/src/test/java/org/apache/flink/connector/kafka/source/metrics/KafkaSourceReaderMetricsTest.java
@@ -18,16 +18,20 @@
 
 package org.apache.flink.connector.kafka.source.metrics;
 
+import org.apache.flink.metrics.Counter;
 import org.apache.flink.metrics.Gauge;
 import org.apache.flink.metrics.testutils.MetricListener;
 
 import org.apache.kafka.common.TopicPartition;
 import org.junit.Test;
 
+import java.util.Optional;
+
 import static org.apache.flink.connector.kafka.source.metrics.KafkaSourceReaderMetrics.PARTITION_GROUP;
 import static org.apache.flink.connector.kafka.source.metrics.KafkaSourceReaderMetrics.TOPIC_GROUP;
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertThrows;
+import static org.junit.Assert.assertTrue;
 
 /** Unit test for {@link KafkaSourceReaderMetrics}. */
 public class KafkaSourceReaderMetricsTest {
@@ -82,23 +86,16 @@ public class KafkaSourceReaderMetricsTest {
         assertCommittedOffset(BAR_0, 18613L, metricListener);
         assertCommittedOffset(BAR_1, 15513L, metricListener);
 
-        assertEquals(
-                0L,
-                metricListener
-                        .getCounter(
-                                KafkaSourceReaderMetrics.KAFKA_SOURCE_READER_METRIC_GROUP,
-                                KafkaSourceReaderMetrics.COMMITS_SUCCEEDED_METRIC_COUNTER)
-                        .getCount());
+        final Optional<Counter> commitsSucceededCounter =
+                metricListener.getCounter(
+                        KafkaSourceReaderMetrics.KAFKA_SOURCE_READER_METRIC_GROUP,
+                        KafkaSourceReaderMetrics.COMMITS_SUCCEEDED_METRIC_COUNTER);
+        assertTrue(commitsSucceededCounter.isPresent());
+        assertEquals(0L, commitsSucceededCounter.get().getCount());
 
         kafkaSourceReaderMetrics.recordSucceededCommit();
 
-        assertEquals(
-                1L,
-                metricListener
-                        .getCounter(
-                                KafkaSourceReaderMetrics.KAFKA_SOURCE_READER_METRIC_GROUP,
-                                KafkaSourceReaderMetrics.COMMITS_SUCCEEDED_METRIC_COUNTER)
-                        .getCount());
+        assertEquals(1L, commitsSucceededCounter.get().getCount());
     }
 
     @Test
@@ -120,47 +117,41 @@ public class KafkaSourceReaderMetricsTest {
         final KafkaSourceReaderMetrics kafkaSourceReaderMetrics =
                 new KafkaSourceReaderMetrics(metricListener.getMetricGroup());
         kafkaSourceReaderMetrics.recordFailedCommit();
-        assertEquals(
-                1L,
-                metricListener
-                        .getCounter(
-                                KafkaSourceReaderMetrics.KAFKA_SOURCE_READER_METRIC_GROUP,
-                                KafkaSourceReaderMetrics.COMMITS_FAILED_METRIC_COUNTER)
-                        .getCount());
+        final Optional<Counter> commitsFailedCounter =
+                metricListener.getCounter(
+                        KafkaSourceReaderMetrics.KAFKA_SOURCE_READER_METRIC_GROUP,
+                        KafkaSourceReaderMetrics.COMMITS_FAILED_METRIC_COUNTER);
+        assertTrue(commitsFailedCounter.isPresent());
+        assertEquals(1L, commitsFailedCounter.get().getCount());
     }
 
     // ----------- Assertions --------------
 
     private void assertCurrentOffset(
             TopicPartition tp, long expectedOffset, MetricListener metricListener) {
-        assertGaugeValueEquals(
-                expectedOffset,
+        final Optional<Gauge<Long>> currentOffsetGauge =
                 metricListener.getGauge(
                         KafkaSourceReaderMetrics.KAFKA_SOURCE_READER_METRIC_GROUP,
                         TOPIC_GROUP,
                         tp.topic(),
                         PARTITION_GROUP,
                         String.valueOf(tp.partition()),
-                        KafkaSourceReaderMetrics.CURRENT_OFFSET_METRIC_GAUGE),
-                Long.class);
+                        KafkaSourceReaderMetrics.CURRENT_OFFSET_METRIC_GAUGE);
+        assertTrue(currentOffsetGauge.isPresent());
+        assertEquals(expectedOffset, (long) currentOffsetGauge.get().getValue());
     }
 
     private void assertCommittedOffset(
             TopicPartition tp, long expectedOffset, MetricListener metricListener) {
-        assertGaugeValueEquals(
-                expectedOffset,
+        final Optional<Gauge<Long>> committedOffsetGauge =
                 metricListener.getGauge(
                         KafkaSourceReaderMetrics.KAFKA_SOURCE_READER_METRIC_GROUP,
                         TOPIC_GROUP,
                         tp.topic(),
                         PARTITION_GROUP,
                         String.valueOf(tp.partition()),
-                        KafkaSourceReaderMetrics.COMMITTED_OFFSET_METRIC_GAUGE),
-                Long.class);
-    }
-
-    private <T> void assertGaugeValueEquals(T expected, Gauge<?> gauge, Class<T> type) {
-        final T actual = type.cast(gauge.getValue());
-        assertEquals(expected, actual);
+                        KafkaSourceReaderMetrics.COMMITTED_OFFSET_METRIC_GAUGE);
+        assertTrue(committedOffsetGauge.isPresent());
+        assertEquals(expectedOffset, (long) committedOffsetGauge.get().getValue());
     }
 }

--- a/flink-connectors/flink-connector-kafka/src/test/java/org/apache/flink/connector/kafka/source/metrics/KafkaSourceReaderMetricsTest.java
+++ b/flink-connectors/flink-connector-kafka/src/test/java/org/apache/flink/connector/kafka/source/metrics/KafkaSourceReaderMetricsTest.java
@@ -21,6 +21,7 @@ package org.apache.flink.connector.kafka.source.metrics;
 import org.apache.flink.metrics.Counter;
 import org.apache.flink.metrics.Gauge;
 import org.apache.flink.metrics.testutils.MetricListener;
+import org.apache.flink.runtime.metrics.groups.InternalSourceReaderMetricGroup;
 
 import org.apache.kafka.common.TopicPartition;
 import org.junit.Test;
@@ -46,7 +47,8 @@ public class KafkaSourceReaderMetricsTest {
         MetricListener metricListener = new MetricListener();
 
         final KafkaSourceReaderMetrics kafkaSourceReaderMetrics =
-                new KafkaSourceReaderMetrics(metricListener.getMetricGroup());
+                new KafkaSourceReaderMetrics(
+                        InternalSourceReaderMetricGroup.mock(metricListener.getMetricGroup()));
 
         kafkaSourceReaderMetrics.registerTopicPartition(FOO_0);
         kafkaSourceReaderMetrics.registerTopicPartition(FOO_1);
@@ -69,7 +71,8 @@ public class KafkaSourceReaderMetricsTest {
         MetricListener metricListener = new MetricListener();
 
         final KafkaSourceReaderMetrics kafkaSourceReaderMetrics =
-                new KafkaSourceReaderMetrics(metricListener.getMetricGroup());
+                new KafkaSourceReaderMetrics(
+                        InternalSourceReaderMetricGroup.mock(metricListener.getMetricGroup()));
 
         kafkaSourceReaderMetrics.registerTopicPartition(FOO_0);
         kafkaSourceReaderMetrics.registerTopicPartition(FOO_1);
@@ -102,7 +105,8 @@ public class KafkaSourceReaderMetricsTest {
     public void testNonTrackingTopicPartition() {
         MetricListener metricListener = new MetricListener();
         final KafkaSourceReaderMetrics kafkaSourceReaderMetrics =
-                new KafkaSourceReaderMetrics(metricListener.getMetricGroup());
+                new KafkaSourceReaderMetrics(
+                        InternalSourceReaderMetricGroup.mock(metricListener.getMetricGroup()));
         assertThrows(
                 IllegalArgumentException.class,
                 () -> kafkaSourceReaderMetrics.recordCurrentOffset(FOO_0, 15213L));
@@ -115,7 +119,8 @@ public class KafkaSourceReaderMetricsTest {
     public void testFailedCommit() {
         MetricListener metricListener = new MetricListener();
         final KafkaSourceReaderMetrics kafkaSourceReaderMetrics =
-                new KafkaSourceReaderMetrics(metricListener.getMetricGroup());
+                new KafkaSourceReaderMetrics(
+                        InternalSourceReaderMetricGroup.mock(metricListener.getMetricGroup()));
         kafkaSourceReaderMetrics.recordFailedCommit();
         final Optional<Counter> commitsFailedCounter =
                 metricListener.getCounter(

--- a/flink-test-utils-parent/flink-test-utils-junit/src/main/java/org/apache/flink/core/testutils/CommonTestUtils.java
+++ b/flink-test-utils-parent/flink-test-utils-junit/src/main/java/org/apache/flink/core/testutils/CommonTestUtils.java
@@ -203,10 +203,12 @@ public class CommonTestUtils {
             throw new IllegalArgumentException("The timeout must be positive.");
         }
         long startingTime = System.currentTimeMillis();
-        while (!condition.get() && System.currentTimeMillis() - startingTime < timeoutMs) {
+        boolean conditionResult = condition.get();
+        while (!conditionResult && System.currentTimeMillis() - startingTime < timeoutMs) {
+            conditionResult = condition.get();
             Thread.sleep(1);
         }
-        if (!condition.get()) {
+        if (!conditionResult) {
             throw new TimeoutException(errorMsg);
         }
     }

--- a/flink-test-utils-parent/flink-test-utils/src/test/java/org/apache/flink/metric/testutils/MetricListenerTest.java
+++ b/flink-test-utils-parent/flink-test-utils/src/test/java/org/apache/flink/metric/testutils/MetricListenerTest.java
@@ -28,7 +28,10 @@ import org.apache.flink.metrics.testutils.MetricListener;
 
 import org.junit.Test;
 
+import java.util.Optional;
+
 import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertTrue;
 
 /** Test for {@link MetricListener}. */
 public class MetricListenerTest {
@@ -51,13 +54,15 @@ public class MetricListenerTest {
         // Counter
         final Counter counter = metricGroup.counter(COUNTER_NAME);
         counter.inc(15213);
-        final Counter registeredCounter = metricListener.getCounter(COUNTER_NAME);
-        assertEquals(15213L, registeredCounter.getCount());
+        final Optional<Counter> registeredCounter = metricListener.getCounter(COUNTER_NAME);
+        assertTrue(registeredCounter.isPresent());
+        assertEquals(15213L, registeredCounter.get().getCount());
 
         // Gauge
         metricGroup.gauge(GAUGE_NAME, () -> 15213);
-        final Gauge<Integer> registeredGauge = metricListener.getGauge(GAUGE_NAME);
-        assertEquals(Integer.valueOf(15213), registeredGauge.getValue());
+        final Optional<Gauge<Integer>> registeredGauge = metricListener.getGauge(GAUGE_NAME);
+        assertTrue(registeredGauge.isPresent());
+        assertEquals(Integer.valueOf(15213), registeredGauge.get().getValue());
 
         // Meter
         metricGroup.meter(
@@ -79,9 +84,10 @@ public class MetricListenerTest {
                         return 18213L;
                     }
                 });
-        final Meter registeredMeter = metricListener.getMeter(METER_NAME);
-        assertEquals(15213.0, registeredMeter.getRate(), 0.1);
-        assertEquals(18213L, registeredMeter.getCount());
+        final Optional<Meter> registeredMeter = metricListener.getMeter(METER_NAME);
+        assertTrue(registeredMeter.isPresent());
+        assertEquals(15213.0, registeredMeter.get().getRate(), 0.1);
+        assertEquals(18213L, registeredMeter.get().getCount());
 
         // Histogram
         metricGroup.histogram(
@@ -100,8 +106,9 @@ public class MetricListenerTest {
                         return null;
                     }
                 });
-        final Histogram registeredHistogram = metricListener.getHistogram(HISTOGRAM_NAME);
-        assertEquals(15213L, registeredHistogram.getCount());
+        final Optional<Histogram> registeredHistogram = metricListener.getHistogram(HISTOGRAM_NAME);
+        assertTrue(registeredHistogram.isPresent());
+        assertEquals(15213L, registeredHistogram.get().getCount());
     }
 
     @Test
@@ -118,14 +125,20 @@ public class MetricListenerTest {
         groupB2.counter(COUNTER_NAME).inc(15513L);
 
         // groupA.groupA_1.testCounter
-        assertEquals(
-                18213L, metricListener.getCounter(GROUP_A, GROUP_A_1, COUNTER_NAME).getCount());
+        final Optional<Counter> counterA =
+                metricListener.getCounter(GROUP_A, GROUP_A_1, COUNTER_NAME);
+        assertTrue(counterA.isPresent());
+        assertEquals(18213L, counterA.get().getCount());
 
         // groupB.groupB_1.testGauge
-        assertEquals(15213L, metricListener.getGauge(GROUP_B, GROUP_B_1, GAUGE_NAME).getValue());
+        final Optional<Gauge<Long>> gauge = metricListener.getGauge(GROUP_B, GROUP_B_1, GAUGE_NAME);
+        assertTrue(gauge.isPresent());
+        assertEquals(15213L, (long) gauge.get().getValue());
 
         // groupB.groupB_2.testCounter
-        assertEquals(
-                15513L, metricListener.getCounter(GROUP_B, GROUP_B_2, COUNTER_NAME).getCount());
+        final Optional<Counter> counterB =
+                metricListener.getCounter(GROUP_B, GROUP_B_2, COUNTER_NAME);
+        assertTrue(counterB.isPresent());
+        assertEquals(15513L, counterB.get().getCount());
     }
 }


### PR DESCRIPTION
## What is the purpose of the change

This pull requests add metric "numBytesIn" and "pendingRecords" for KafkaSource

## Brief change log
- Register "numBytesIn" and "pendingRecords" for KafkaSource

## Verifying this change
This change added tests and can be verified as follows:
- Create ```KafkaPartitionSplitReader``` and assign splits
- Fetch records and check if metrics work s expected

## Does this pull request potentially affect one of the following parts:

  - Dependencies (does it add or upgrade a dependency): (no)
  - The public API, i.e., is any changed class annotated with `@Public(Evolving)`: (no)
  - The serializers: (no)
  - The runtime per-record code paths (performance sensitive): (no)
  - Anything that affects deployment or recovery: JobManager (and its components), Checkpointing, Kubernetes/Yarn, ZooKeeper: (no)
  - The S3 file system connector: (no)

## Documentation

  - Does this pull request introduce a new feature? (no)
  - If yes, how is the feature documented? (not applicable)
