### PR TITLE
[FLINK-23765][python] Fix the NPE in Python UDTF

### DIFF
--- a/flink-python/src/test/java/org/apache/flink/table/runtime/operators/python/table/PythonTableFunctionOperatorTest.java
+++ b/flink-python/src/test/java/org/apache/flink/table/runtime/operators/python/table/PythonTableFunctionOperatorTest.java
@@ -32,7 +32,6 @@ import org.apache.flink.table.types.logical.RowType;
 import org.apache.flink.types.RowKind;
 
 import org.apache.calcite.rel.core.JoinRelType;
-import org.junit.Ignore;
 
 import java.util.Collection;
 import java.util.HashMap;
@@ -40,7 +39,6 @@ import java.util.HashMap;
 import static org.apache.flink.table.runtime.util.StreamRecordUtils.row;
 
 /** Tests for {@link PythonTableFunctionOperator}. */
-@Ignore
 public class PythonTableFunctionOperatorTest
         extends PythonTableFunctionOperatorTestBase<RowData, RowData> {
 


### PR DESCRIPTION
## What is the purpose of the change

*This pull request will fix the NPE in Python UDTF*


## Brief change log

  - *Change the logic of emitResult in Python Table Function Operator for facing parts of results have been received*

## Verifying this change

This change added tests and can be verified as follows:

  - *Original Java UT and python IT*

## Does this pull request potentially affect one of the following parts:

  - Dependencies (does it add or upgrade a dependency): (no)
  - The public API, i.e., is any changed class annotated with `@Public(Evolving)`: (no)
  - The serializers: (no)
  - The runtime per-record code paths (performance sensitive): (no)
  - Anything that affects deployment or recovery: JobManager (and its components), Checkpointing, Kubernetes/Yarn, ZooKeeper: (no)
  - The S3 file system connector: (no)

## Documentation

  - Does this pull request introduce a new feature? (no)
  - If yes, how is the feature documented? (not applicable)
