### PR TITLE
[FLINK-23811][tests] Handle finished subtasks in CommonTestUtils.waitForAllTaskRunning

### DIFF
--- a/flink-connectors/flink-connector-files/src/test/java/org/apache/flink/connector/file/sink/writer/FileSinkMigrationITCase.java
+++ b/flink-connectors/flink-connector-files/src/test/java/org/apache/flink/connector/file/sink/writer/FileSinkMigrationITCase.java
@@ -185,7 +185,7 @@ public class FileSinkMigrationITCase extends TestLogger {
                     miniCluster.submitJob(jobGraph);
             JobID jobId = jobSubmissionResultFuture.get().getJobID();
 
-            waitForAllTaskRunning(miniCluster, jobId);
+            waitForAllTaskRunning(miniCluster, jobId, false);
 
             CompletableFuture<String> savepointResultFuture =
                     miniCluster.triggerSavepoint(jobId, savepointBasePath, true);

--- a/flink-runtime/src/test/java/org/apache/flink/runtime/testutils/CommonTestUtils.java
+++ b/flink-runtime/src/test/java/org/apache/flink/runtime/testutils/CommonTestUtils.java
@@ -26,6 +26,7 @@ import org.apache.flink.runtime.execution.ExecutionState;
 import org.apache.flink.runtime.executiongraph.AccessExecutionGraph;
 import org.apache.flink.runtime.minicluster.MiniCluster;
 import org.apache.flink.util.FileUtils;
+import org.apache.flink.util.Preconditions;
 import org.apache.flink.util.function.SupplierWithException;
 
 import java.io.BufferedInputStream;
@@ -176,6 +177,10 @@ public class CommonTestUtils {
         waitUntilCondition(
                 () -> {
                     final AccessExecutionGraph graph = executionGraphSupplier.get();
+                    Preconditions.checkState(
+                            !graph.getState().isGloballyTerminalState(),
+                            "Graph is in globally terminal state (%s)",
+                            graph.getState());
                     return graph.getState() == JobStatus.RUNNING
                             && graph.getAllVertices().values().stream()
                                     .allMatch(

--- a/flink-tests/src/test/java/org/apache/flink/runtime/jobmaster/JobMasterStopWithSavepointITCase.java
+++ b/flink-tests/src/test/java/org/apache/flink/runtime/jobmaster/JobMasterStopWithSavepointITCase.java
@@ -315,7 +315,8 @@ public class JobMasterStopWithSavepointITCase extends AbstractTestBase {
                                 .getMiniCluster()
                                 .getExecutionGraph(jobID)
                                 .get(60, TimeUnit.SECONDS),
-                deadline);
+                deadline,
+                false);
     }
 
     /**

--- a/flink-tests/src/test/java/org/apache/flink/test/checkpointing/RescalingITCase.java
+++ b/flink-tests/src/test/java/org/apache/flink/test/checkpointing/RescalingITCase.java
@@ -238,7 +238,7 @@ public class RescalingITCase extends TestLogger {
             // clear the CollectionSink set for the restarted job
             CollectionSink.clearElementsSet();
 
-            waitForAllTaskRunning(cluster.getMiniCluster(), jobGraph.getJobID());
+            waitForAllTaskRunning(cluster.getMiniCluster(), jobGraph.getJobID(), false);
             CompletableFuture<String> savepointPathFuture = client.triggerSavepoint(jobID, null);
 
             final String savepointPath =
@@ -317,7 +317,7 @@ public class RescalingITCase extends TestLogger {
             client.submitJob(jobGraph).get();
 
             // wait until the operator is started
-            waitForAllTaskRunning(cluster.getMiniCluster(), jobGraph.getJobID());
+            waitForAllTaskRunning(cluster.getMiniCluster(), jobGraph.getJobID(), false);
             // wait until the operator handles some data
             StateSourceBase.workStartedLatch.await();
 
@@ -418,7 +418,7 @@ public class RescalingITCase extends TestLogger {
             // clear the CollectionSink set for the restarted job
             CollectionSink.clearElementsSet();
 
-            waitForAllTaskRunning(cluster.getMiniCluster(), jobGraph.getJobID());
+            waitForAllTaskRunning(cluster.getMiniCluster(), jobGraph.getJobID(), false);
             CompletableFuture<String> savepointPathFuture = client.triggerSavepoint(jobID, null);
 
             final String savepointPath =
@@ -542,7 +542,7 @@ public class RescalingITCase extends TestLogger {
             client.submitJob(jobGraph).get();
 
             // wait until the operator is started
-            waitForAllTaskRunning(cluster.getMiniCluster(), jobGraph.getJobID());
+            waitForAllTaskRunning(cluster.getMiniCluster(), jobGraph.getJobID(), false);
             // wait until the operator handles some data
             StateSourceBase.workStartedLatch.await();
 

--- a/flink-tests/src/test/java/org/apache/flink/test/checkpointing/SavepointITCase.java
+++ b/flink-tests/src/test/java/org/apache/flink/test/checkpointing/SavepointITCase.java
@@ -370,7 +370,7 @@ public class SavepointITCase extends TestLogger {
         try {
             client.submitJob(jobGraph).get();
 
-            waitForAllTaskRunning(cluster.getMiniCluster(), jobId);
+            waitForAllTaskRunning(cluster.getMiniCluster(), jobId, false);
             StatefulCounter.getProgressLatch().await();
 
             return client.cancelWithSavepoint(jobId, null).get();
@@ -502,7 +502,7 @@ public class SavepointITCase extends TestLogger {
         try {
             client.submitJob(graph).get();
             // triggerSavepoint is only available after all tasks are running
-            waitForAllTaskRunning(cluster.getMiniCluster(), graph.getJobID());
+            waitForAllTaskRunning(cluster.getMiniCluster(), graph.getJobID(), false);
 
             client.triggerSavepoint(graph.getJobID(), null).get();
 
@@ -993,7 +993,7 @@ public class SavepointITCase extends TestLogger {
             JobID jobID = client.submitJob(originalJobGraph).get();
 
             // wait for the Tasks to be ready
-            waitForAllTaskRunning(cluster.getMiniCluster(), jobID);
+            waitForAllTaskRunning(cluster.getMiniCluster(), jobID, false);
             assertTrue(
                     StatefulCounter.getProgressLatch()
                             .await(deadline.timeLeft().toMillis(), TimeUnit.MILLISECONDS));
@@ -1334,7 +1334,7 @@ public class SavepointITCase extends TestLogger {
         try {
             client.submitJob(jobGraph).get();
 
-            waitForAllTaskRunning(cluster.getMiniCluster(), jobGraph.getJobID());
+            waitForAllTaskRunning(cluster.getMiniCluster(), jobGraph.getJobID(), false);
 
             for (OneShotLatch latch : iterTestSnapshotWait) {
                 latch.await();

--- a/flink-tests/src/test/java/org/apache/flink/test/checkpointing/TimersSavepointITCase.java
+++ b/flink-tests/src/test/java/org/apache/flink/test/checkpointing/TimersSavepointITCase.java
@@ -120,7 +120,7 @@ public class TimersSavepointITCase {
     private void takeSavepoint(String savepointPath, ClusterClient<?> client) throws Exception {
         JobGraph jobGraph = getJobGraph(EmbeddedRocksDBStateBackend.PriorityQueueStateType.ROCKSDB);
         client.submitJob(jobGraph).get();
-        waitForAllTaskRunning(miniClusterResource.getMiniCluster(), jobGraph.getJobID());
+        waitForAllTaskRunning(miniClusterResource.getMiniCluster(), jobGraph.getJobID(), false);
         CompletableFuture<String> savepointPathFuture =
                 client.triggerSavepoint(jobGraph.getJobID(), null);
 

--- a/flink-tests/src/test/java/org/apache/flink/test/checkpointing/UnalignedCheckpointCompatibilityITCase.java
+++ b/flink-tests/src/test/java/org/apache/flink/test/checkpointing/UnalignedCheckpointCompatibilityITCase.java
@@ -146,7 +146,8 @@ public class UnalignedCheckpointCompatibilityITCase extends TestLogger {
     private Tuple2<String, Map<String, Object>> runAndTakeSavepoint() throws Exception {
         JobClient jobClient = submitJobInitially(env(startAligned, 0));
         waitForAllTaskRunning(
-                () -> miniCluster.getMiniCluster().getExecutionGraph(jobClient.getJobID()).get());
+                () -> miniCluster.getMiniCluster().getExecutionGraph(jobClient.getJobID()).get(),
+                false);
         Thread.sleep(FIRST_RUN_BACKPRESSURE_MS); // wait for some backpressure from sink
 
         Future<Map<String, Object>> accFuture =


### PR DESCRIPTION
```
CommonTestUtils.waitForAllTaskRunning returns when all the subtasks are running AND
the job is running and not finished. However, with FLIP-147, subtasks may finish and
the job will still be running. So the method won't return and instead timeout.

This commit adds a flag to indicate whether to fail or proceed
when a finished sub-task is encountered.
```

[original discussion](https://github.com/apache/flink/pull/16773#discussion_r688532348)
