### PR TITLE
[FLINK-23812][rocksdb] support configuring RocksDB logging

### DIFF
--- a/docs/layouts/shortcodes/generated/rocksdb_configurable_configuration.html
+++ b/docs/layouts/shortcodes/generated/rocksdb_configurable_configuration.html
@@ -60,25 +60,25 @@
             <td><h5>state.backend.rocksdb.log.dir</h5></td>
             <td style="word-wrap: break-word;">(none)</td>
             <td>String</td>
-            <td>The directory for RocksDB's logging files. If empty (default RocksDB setting), log files will be in the same directory as data files. If non-empty, this directory will be used and the data directory's absolute path will be used as the prefix of the log file name.</td>
+            <td>The directory for RocksDB's information logging files. If empty (RocksDB default setting), log files will be in the same directory as data files. If non-empty, this directory will be used and the data directory's absolute path will be used as the prefix of the log file name.</td>
         </tr>
         <tr>
             <td><h5>state.backend.rocksdb.log.file-num</h5></td>
             <td style="word-wrap: break-word;">(none)</td>
             <td>Integer</td>
-            <td>The maximum number of files RocksDB should keep for logging (default RocksDB setting: 1000).</td>
+            <td>The maximum number of files RocksDB should keep for information logging (RocksDB default setting: 1000).</td>
         </tr>
         <tr>
             <td><h5>state.backend.rocksdb.log.level</h5></td>
             <td style="word-wrap: break-word;">(none)</td>
             <td><p>Enum</p></td>
-            <td>The specified log level for DB. Candidate log level is DEBUG_LEVEL, INFO_LEVEL, WARN_LEVEL, ERROR_LEVEL, FATAL_LEVEL, HEADER_LEVEL or NUM_INFO_LOG_LEVELS, and Flink choose 'HEADER_LEVEL' as default style. Note: RocksDB logs will not be output to TaskManager logs, and there is no rolling strategy. If the Flink task runs for a long time, it may lead to uncontrolled disk space usage. There is no need to modify the RocksDB log level, unless troubleshooting RocksDB.<br /><br />Possible values:<ul><li>"DEBUG_LEVEL"</li><li>"INFO_LEVEL"</li><li>"WARN_LEVEL"</li><li>"ERROR_LEVEL"</li><li>"FATAL_LEVEL"</li><li>"HEADER_LEVEL"</li><li>"NUM_INFO_LOG_LEVELS"</li></ul></td>
+            <td>The specified information logging level for RocksDB. If unset, Flink will use <code class="highlighter-rouge">HEADER_LEVEL</code>.<br />Note: RocksDB info logs will not be written to the TaskManager logs and there is no rolling strategy, unless you configure <code class="highlighter-rouge">state.backend.rocksdb.log.dir</code>, <code class="highlighter-rouge">state.backend.rocksdb.log.max-file-size</code>, and <code class="highlighter-rouge">state.backend.rocksdb.log.file-num</code> accordingly. Without a rolling strategy, long-running tasks may lead to uncontrolled disk space usage if configured with increased log levels!<br />There is no need to modify the RocksDB log level, unless for troubleshooting RocksDB.<br /><br />Possible values:<ul><li>"DEBUG_LEVEL"</li><li>"INFO_LEVEL"</li><li>"WARN_LEVEL"</li><li>"ERROR_LEVEL"</li><li>"FATAL_LEVEL"</li><li>"HEADER_LEVEL"</li><li>"NUM_INFO_LOG_LEVELS"</li></ul></td>
         </tr>
         <tr>
             <td><h5>state.backend.rocksdb.log.max-file-size</h5></td>
             <td style="word-wrap: break-word;">(none)</td>
             <td>MemorySize</td>
-            <td>The maximum size of RocksDB's file used for logging. If the log files becomes larger than this, a new file will be created.If 0 (default RocksDB setting), all logs will be written to one log file.</td>
+            <td>The maximum size of RocksDB's file used for information logging. If the log files becomes larger than this, a new file will be created. If 0 (RocksDB default setting), all logs will be written to one log file.</td>
         </tr>
         <tr>
             <td><h5>state.backend.rocksdb.thread.num</h5></td>

--- a/docs/layouts/shortcodes/generated/rocksdb_configurable_configuration.html
+++ b/docs/layouts/shortcodes/generated/rocksdb_configurable_configuration.html
@@ -57,10 +57,28 @@
             <td>The maximum number of open files (per stateful operator) that can be used by the DB, '-1' means no limit. RocksDB has default configuration as '-1'.</td>
         </tr>
         <tr>
+            <td><h5>state.backend.rocksdb.log.dir</h5></td>
+            <td style="word-wrap: break-word;">(none)</td>
+            <td>String</td>
+            <td>The directory for RocksDB's logging files. If empty (default RocksDB setting), log files will be in the same directory as data files. If non-empty, this directory will be used and the data directory's absolute path will be used as the prefix of the log file name.</td>
+        </tr>
+        <tr>
+            <td><h5>state.backend.rocksdb.log.file-num</h5></td>
+            <td style="word-wrap: break-word;">(none)</td>
+            <td>Integer</td>
+            <td>The maximum number of files RocksDB should keep for logging (default RocksDB setting: 1000).</td>
+        </tr>
+        <tr>
             <td><h5>state.backend.rocksdb.log.level</h5></td>
             <td style="word-wrap: break-word;">(none)</td>
             <td><p>Enum</p></td>
             <td>The specified log level for DB. Candidate log level is DEBUG_LEVEL, INFO_LEVEL, WARN_LEVEL, ERROR_LEVEL, FATAL_LEVEL, HEADER_LEVEL or NUM_INFO_LOG_LEVELS, and Flink choose 'HEADER_LEVEL' as default style. Note: RocksDB logs will not be output to TaskManager logs, and there is no rolling strategy. If the Flink task runs for a long time, it may lead to uncontrolled disk space usage. There is no need to modify the RocksDB log level, unless troubleshooting RocksDB.<br /><br />Possible values:<ul><li>"DEBUG_LEVEL"</li><li>"INFO_LEVEL"</li><li>"WARN_LEVEL"</li><li>"ERROR_LEVEL"</li><li>"FATAL_LEVEL"</li><li>"HEADER_LEVEL"</li><li>"NUM_INFO_LOG_LEVELS"</li></ul></td>
+        </tr>
+        <tr>
+            <td><h5>state.backend.rocksdb.log.max-file-size</h5></td>
+            <td style="word-wrap: break-word;">(none)</td>
+            <td>MemorySize</td>
+            <td>The maximum size of RocksDB's file used for logging. If the log files becomes larger than this, a new file will be created.If 0 (default RocksDB setting), all logs will be written to one log file.</td>
         </tr>
         <tr>
             <td><h5>state.backend.rocksdb.thread.num</h5></td>

--- a/flink-state-backends/flink-statebackend-rocksdb/src/main/java/org/apache/flink/contrib/streaming/state/RocksDBConfigurableOptions.java
+++ b/flink-state-backends/flink-statebackend-rocksdb/src/main/java/org/apache/flink/contrib/streaming/state/RocksDBConfigurableOptions.java
@@ -93,6 +93,31 @@ public class RocksDBConfigurableOptions implements Serializable {
                                     NUM_INFO_LOG_LEVELS.name(),
                                     HEADER_LEVEL.name()));
 
+    public static final ConfigOption<MemorySize> LOG_MAX_FILE_SIZE =
+            key("state.backend.rocksdb.log.max-file-size")
+                    .memoryType()
+                    .noDefaultValue()
+                    .withDescription(
+                            "The maximum size of RocksDB's file used for logging. "
+                                    + "If the log files becomes larger than this, a new file will be created."
+                                    + "If 0 (default RocksDB setting), all logs will be written to one log file.");
+
+    public static final ConfigOption<Integer> LOG_FILE_NUM =
+            key("state.backend.rocksdb.log.file-num")
+                    .intType()
+                    .noDefaultValue()
+                    .withDescription(
+                            "The maximum number of files RocksDB should keep for logging (default RocksDB setting: 1000).");
+
+    public static final ConfigOption<String> LOG_DIR =
+            key("state.backend.rocksdb.log.dir")
+                    .stringType()
+                    .noDefaultValue()
+                    .withDescription(
+                            "The directory for RocksDB's logging files. "
+                                    + "If empty (default RocksDB setting), log files will be in the same directory as data files. "
+                                    + "If non-empty, this directory will be used and the data directory's absolute path will be used as the prefix of the log file name.");
+
     // --------------------------------------------------------------------------
     // Provided configurable ColumnFamilyOptions within Flink
     // --------------------------------------------------------------------------

--- a/flink-state-backends/flink-statebackend-rocksdb/src/main/java/org/apache/flink/contrib/streaming/state/RocksDBConfigurableOptions.java
+++ b/flink-state-backends/flink-statebackend-rocksdb/src/main/java/org/apache/flink/contrib/streaming/state/RocksDBConfigurableOptions.java
@@ -29,17 +29,12 @@ import java.io.Serializable;
 
 import static org.apache.flink.configuration.ConfigOptions.key;
 import static org.apache.flink.configuration.description.LinkElement.link;
+import static org.apache.flink.configuration.description.TextElement.code;
 import static org.rocksdb.CompactionStyle.FIFO;
 import static org.rocksdb.CompactionStyle.LEVEL;
 import static org.rocksdb.CompactionStyle.NONE;
 import static org.rocksdb.CompactionStyle.UNIVERSAL;
-import static org.rocksdb.InfoLogLevel.DEBUG_LEVEL;
-import static org.rocksdb.InfoLogLevel.ERROR_LEVEL;
-import static org.rocksdb.InfoLogLevel.FATAL_LEVEL;
 import static org.rocksdb.InfoLogLevel.HEADER_LEVEL;
-import static org.rocksdb.InfoLogLevel.INFO_LEVEL;
-import static org.rocksdb.InfoLogLevel.NUM_INFO_LOG_LEVELS;
-import static org.rocksdb.InfoLogLevel.WARN_LEVEL;
 
 /**
  * This class contains the configuration options for the {@link DefaultConfigurableOptionsFactory}.
@@ -73,50 +68,54 @@ public class RocksDBConfigurableOptions implements Serializable {
                             "The maximum number of open files (per stateful operator) that can be used by the DB, '-1' means no limit. "
                                     + "RocksDB has default configuration as '-1'.");
 
-    public static final ConfigOption<InfoLogLevel> LOG_LEVEL =
-            key("state.backend.rocksdb.log.level")
-                    .enumType(InfoLogLevel.class)
-                    .noDefaultValue()
-                    .withDescription(
-                            String.format(
-                                    "The specified log level for DB. Candidate log level is %s, %s, %s, %s, %s, %s or %s, "
-                                            + "and Flink choose '%s' as default style. "
-                                            + "Note: RocksDB logs will not be output to TaskManager logs, and there is no rolling strategy. "
-                                            + "If the Flink task runs for a long time, it may lead to uncontrolled disk space usage. "
-                                            + "There is no need to modify the RocksDB log level, unless troubleshooting RocksDB.",
-                                    DEBUG_LEVEL.name(),
-                                    INFO_LEVEL.name(),
-                                    WARN_LEVEL.name(),
-                                    ERROR_LEVEL.name(),
-                                    FATAL_LEVEL.name(),
-                                    HEADER_LEVEL.name(),
-                                    NUM_INFO_LOG_LEVELS.name(),
-                                    HEADER_LEVEL.name()));
-
     public static final ConfigOption<MemorySize> LOG_MAX_FILE_SIZE =
             key("state.backend.rocksdb.log.max-file-size")
                     .memoryType()
                     .noDefaultValue()
                     .withDescription(
-                            "The maximum size of RocksDB's file used for logging. "
-                                    + "If the log files becomes larger than this, a new file will be created."
-                                    + "If 0 (default RocksDB setting), all logs will be written to one log file.");
+                            "The maximum size of RocksDB's file used for information logging. "
+                                    + "If the log files becomes larger than this, a new file will be created. "
+                                    + "If 0 (RocksDB default setting), all logs will be written to one log file.");
 
     public static final ConfigOption<Integer> LOG_FILE_NUM =
             key("state.backend.rocksdb.log.file-num")
                     .intType()
                     .noDefaultValue()
                     .withDescription(
-                            "The maximum number of files RocksDB should keep for logging (default RocksDB setting: 1000).");
+                            "The maximum number of files RocksDB should keep for information logging (RocksDB default setting: 1000).");
 
     public static final ConfigOption<String> LOG_DIR =
             key("state.backend.rocksdb.log.dir")
                     .stringType()
                     .noDefaultValue()
                     .withDescription(
-                            "The directory for RocksDB's logging files. "
-                                    + "If empty (default RocksDB setting), log files will be in the same directory as data files. "
+                            "The directory for RocksDB's information logging files. "
+                                    + "If empty (RocksDB default setting), log files will be in the same directory as data files. "
                                     + "If non-empty, this directory will be used and the data directory's absolute path will be used as the prefix of the log file name.");
+
+    public static final ConfigOption<InfoLogLevel> LOG_LEVEL =
+            key("state.backend.rocksdb.log.level")
+                    .enumType(InfoLogLevel.class)
+                    .noDefaultValue()
+                    .withDescription(
+                            Description.builder()
+                                    .text(
+                                            "The specified information logging level for RocksDB. "
+                                                    + "If unset, Flink will use %s.",
+                                            code(HEADER_LEVEL.name()))
+                                    .linebreak()
+                                    .text(
+                                            "Note: RocksDB info logs will not be written to the TaskManager logs and there "
+                                                    + "is no rolling strategy, unless you configure %s, %s, and %s accordingly. "
+                                                    + "Without a rolling strategy, long-running tasks may lead to uncontrolled "
+                                                    + "disk space usage if configured with increased log levels!",
+                                            code(LOG_DIR.key()),
+                                            code(LOG_MAX_FILE_SIZE.key()),
+                                            code(LOG_FILE_NUM.key()))
+                                    .linebreak()
+                                    .text(
+                                            "There is no need to modify the RocksDB log level, unless for troubleshooting RocksDB.")
+                                    .build());
 
     // --------------------------------------------------------------------------
     // Provided configurable ColumnFamilyOptions within Flink

--- a/flink-state-backends/flink-statebackend-rocksdb/src/test/java/org/apache/flink/contrib/streaming/state/RocksDBStateBackendConfigTest.java
+++ b/flink-state-backends/flink-statebackend-rocksdb/src/test/java/org/apache/flink/contrib/streaming/state/RocksDBStateBackendConfigTest.java
@@ -469,6 +469,9 @@ public class RocksDBStateBackendConfigTest {
                         .setMaxBackgroundThreads(4)
                         .setMaxOpenFiles(-1)
                         .setLogLevel(InfoLogLevel.DEBUG_LEVEL)
+                        .setLogDir("/tmp/rocksdb-logs/")
+                        .setLogFileNum(10)
+                        .setMaxLogFileSize("2MB")
                         .setCompactionStyle(CompactionStyle.LEVEL)
                         .setUseDynamicLevelSize(true)
                         .setTargetFileSizeBase("4MB")
@@ -485,7 +488,11 @@ public class RocksDBStateBackendConfigTest {
 
             DBOptions dbOptions = optionsContainer.getDbOptions();
             assertEquals(-1, dbOptions.maxOpenFiles());
+
             assertEquals(InfoLogLevel.DEBUG_LEVEL, dbOptions.infoLogLevel());
+            assertEquals("/tmp/rocksdb-logs/", dbOptions.dbLogDir());
+            assertEquals(10, dbOptions.keepLogFileNum());
+            assertEquals(2 * SizeUnit.MB, dbOptions.maxLogFileSize());
 
             ColumnFamilyOptions columnOptions = optionsContainer.getColumnOptions();
             assertEquals(CompactionStyle.LEVEL, columnOptions.compactionStyle());
@@ -514,6 +521,11 @@ public class RocksDBStateBackendConfigTest {
         {
             verifyIllegalArgument(RocksDBConfigurableOptions.MAX_BACKGROUND_THREADS, "-1");
             verifyIllegalArgument(RocksDBConfigurableOptions.LOG_LEVEL, "DEBUG");
+            verifyIllegalArgument(RocksDBConfigurableOptions.LOG_DIR, "tmp/rocksdb-logs/");
+            verifyIllegalArgument(RocksDBConfigurableOptions.LOG_DIR, "");
+            verifyIllegalArgument(RocksDBConfigurableOptions.LOG_FILE_NUM, "0");
+            verifyIllegalArgument(RocksDBConfigurableOptions.LOG_FILE_NUM, "-1");
+            verifyIllegalArgument(RocksDBConfigurableOptions.LOG_MAX_FILE_SIZE, "-1KB");
             verifyIllegalArgument(RocksDBConfigurableOptions.MAX_WRITE_BUFFER_NUMBER, "-1");
             verifyIllegalArgument(
                     RocksDBConfigurableOptions.MIN_WRITE_BUFFER_NUMBER_TO_MERGE, "-1");
@@ -533,6 +545,9 @@ public class RocksDBStateBackendConfigTest {
         // verify legal configuration
         {
             configuration.setString(RocksDBConfigurableOptions.LOG_LEVEL.key(), "DEBUG_LEVEL");
+            configuration.setString(RocksDBConfigurableOptions.LOG_DIR.key(), "/tmp/rocksdb-logs/");
+            configuration.setString(RocksDBConfigurableOptions.LOG_FILE_NUM.key(), "10");
+            configuration.setString(RocksDBConfigurableOptions.LOG_MAX_FILE_SIZE.key(), "2MB");
             configuration.setString(RocksDBConfigurableOptions.COMPACTION_STYLE.key(), "level");
             configuration.setString(
                     RocksDBConfigurableOptions.USE_DYNAMIC_LEVEL_SIZE.key(), "TRUE");
@@ -557,6 +572,9 @@ public class RocksDBStateBackendConfigTest {
                 DBOptions dbOptions = optionsContainer.getDbOptions();
                 assertEquals(-1, dbOptions.maxOpenFiles());
                 assertEquals(InfoLogLevel.DEBUG_LEVEL, dbOptions.infoLogLevel());
+                assertEquals("/tmp/rocksdb-logs/", dbOptions.dbLogDir());
+                assertEquals(10, dbOptions.keepLogFileNum());
+                assertEquals(2 * SizeUnit.MB, dbOptions.maxLogFileSize());
 
                 ColumnFamilyOptions columnOptions = optionsContainer.getColumnOptions();
                 assertEquals(CompactionStyle.LEVEL, columnOptions.compactionStyle());


### PR DESCRIPTION
## What is the purpose of the change

This allows further tuning RocksDB's logger with the following three new parameters:
- `state.backend.rocksdb.log.max-file-size` sets the max log file size
- `state.backend.rocksdb.log.file-num` configures the number of logging files to keep
- `state.backend.rocksdb.log.dir` sets the directory of the logging files, e.g. to put these logs onto a (separate) volume that may not be local and is retained after container shutdown for debugging purposes

## Brief change log
  - add the options above to `RocksDBConfigurableOptions` with no default values (not changing the current behaviour and instead relying on RocksDB's defaults)
  - extend `DefaultConfigurableOptionsFactory` to deal with the new option settings from configuration and via getters/setters
  - extend `RocksDBStateBackendConfigTest` to verify valid and invalid settings.

## Verifying this change

This change added tests and can be verified as follows:

- Running the `RocksDBStateBackendConfigTest` test
- Tested by running a test Flink job in a cluster with the following config:
```
state.backend: rocksdb
state.backend.rocksdb.log.level: DEBUG_LEVEL
state.backend.rocksdb.log.max-file-size: 50KB
state.backend.rocksdb.log.file-num: 2
state.backend.rocksdb.log.dir: /tmp/flink/log/
```

## Does this pull request potentially affect one of the following parts:

  - Dependencies (does it add or upgrade a dependency): **no**
  - The public API, i.e., is any changed class annotated with `@Public(Evolving)`: **no** (adds 3 new config options though)
  - The serializers: **no**
  - The runtime per-record code paths (performance sensitive): **no**
  - Anything that affects deployment or recovery: JobManager (and its components), Checkpointing, Kubernetes/Yarn, ZooKeeper:  **no**
  - The S3 file system connector: **no**

## Documentation

  - Does this pull request introduce a new feature? **yes**
  - If yes, how is the feature documented? docs + JavaDocs
