### PR TITLE
[FLINK-23728][state-processor-api] State bootstrapping fails on new state backend factory stack

### DIFF
--- a/docs/content.zh/docs/libs/state_processor_api.md
+++ b/docs/content.zh/docs/libs/state_processor_api.md
@@ -78,7 +78,7 @@ The compatibility guarantees for restoring state are identical to those when res
 
 ```java
 ExecutionEnvironment bEnv   = ExecutionEnvironment.getExecutionEnvironment();
-ExistingSavepoint savepoint = Savepoint.load(bEnv, "hdfs://path/", new MemoryStateBackend());
+ExistingSavepoint savepoint = Savepoint.load(bEnv, "hdfs://path/", new HashMapStateBackend());
 ```
 
 
@@ -302,7 +302,7 @@ class ClickReader extends WindowReaderFunction<Integer, ClickState, String, Time
 }
 
 ExecutionEnvironment batchEnv = ExecutionEnvironment.getExecutionEnvironment();
-ExistingSavepoint savepoint = Savepoint.load(batchEnv, "hdfs://checkpoint-dir", new MemoryStateBackend());
+ExistingSavepoint savepoint = Savepoint.load(batchEnv, "hdfs://checkpoint-dir", new HashMapStateBackend());
 
 savepoint
     .window(TumblingEventTimeWindows.of(Time.minutes(1)))
@@ -329,7 +329,7 @@ a savepoint for the Scala DataStream API please manually pass in all type inform
 int maxParallelism = 128;
 
 Savepoint
-    .create(new MemoryStateBackend(), maxParallelism)
+    .create(new HashMapStateBackend(), maxParallelism)
     .withOperator("uid1", transformation1)
     .withOperator("uid2", transformation2)
     .write(savepointPath);
@@ -478,7 +478,7 @@ Besides creating a savepoint from scratch, you can base one off an existing save
 
 ```java
 Savepoint
-    .load(bEnv, new MemoryStateBackend(), oldPath)
+    .load(bEnv, new HashMapStateBackend(), oldPath)
     .withOperator("uid", transformation)
     .write(newPath);
 ```

--- a/docs/content/docs/libs/state_processor_api.md
+++ b/docs/content/docs/libs/state_processor_api.md
@@ -78,7 +78,7 @@ The compatibility guarantees for restoring state are identical to those when res
 
 ```java
 ExecutionEnvironment bEnv   = ExecutionEnvironment.getExecutionEnvironment();
-ExistingSavepoint savepoint = Savepoint.load(bEnv, "hdfs://path/", new MemoryStateBackend());
+ExistingSavepoint savepoint = Savepoint.load(bEnv, "hdfs://path/", new HashMapStateBackend());
 ```
 
 
@@ -302,7 +302,7 @@ class ClickReader extends WindowReaderFunction<Integer, ClickState, String, Time
 }
 
 ExecutionEnvironment batchEnv = ExecutionEnvironment.getExecutionEnvironment();
-ExistingSavepoint savepoint = Savepoint.load(batchEnv, "hdfs://checkpoint-dir", new MemoryStateBackend());
+ExistingSavepoint savepoint = Savepoint.load(batchEnv, "hdfs://checkpoint-dir", new HashMapStateBackend());
 
 savepoint
     .window(TumblingEventTimeWindows.of(Time.minutes(1)))
@@ -329,7 +329,7 @@ a savepoint for the Scala DataStream API please manually pass in all type inform
 int maxParallelism = 128;
 
 Savepoint
-    .create(new MemoryStateBackend(), maxParallelism)
+    .create(new HashMapStateBackend(), maxParallelism)
     .withOperator("uid1", transformation1)
     .withOperator("uid2", transformation2)
     .write(savepointPath);
@@ -478,7 +478,7 @@ Besides creating a savepoint from scratch, you can base one off an existing save
 
 ```java
 Savepoint
-    .load(bEnv, new MemoryStateBackend(), oldPath)
+    .load(bEnv, new HashMapStateBackend(), oldPath)
     .withOperator("uid", transformation)
     .write(newPath);
 ```

--- a/flink-libraries/flink-state-processing-api/src/main/java/org/apache/flink/state/api/BootstrapTransformation.java
+++ b/flink-libraries/flink-state-processing-api/src/main/java/org/apache/flink/state/api/BootstrapTransformation.java
@@ -133,6 +133,7 @@ public class BootstrapTransformation<T> {
     /**
      * @param operatorID The operator id for the stream operator.
      * @param stateBackend The state backend for the job.
+     * @param config Additional configurations applied to the bootstrap stream tasks.
      * @param globalMaxParallelism Global max parallelism set for the savepoint.
      * @param savepointPath The path where the savepoint will be written.
      * @return The operator subtask states for this bootstrap transformation.
@@ -140,12 +141,13 @@ public class BootstrapTransformation<T> {
     DataSet<OperatorState> writeOperatorState(
             OperatorID operatorID,
             StateBackend stateBackend,
+            Configuration config,
             int globalMaxParallelism,
             Path savepointPath) {
         int localMaxParallelism = getMaxParallelism(globalMaxParallelism);
 
         return writeOperatorSubtaskStates(
-                        operatorID, stateBackend, savepointPath, localMaxParallelism)
+                        operatorID, stateBackend, config, savepointPath, localMaxParallelism)
                 .reduceGroup(new OperatorSubtaskStateReducer(operatorID, localMaxParallelism))
                 .name("reduce(OperatorSubtaskState)");
     }
@@ -154,6 +156,16 @@ public class BootstrapTransformation<T> {
     MapPartitionOperator<T, TaggedOperatorSubtaskState> writeOperatorSubtaskStates(
             OperatorID operatorID,
             StateBackend stateBackend,
+            Path savepointPath,
+            int localMaxParallelism) {
+        return writeOperatorSubtaskStates(
+                operatorID, stateBackend, new Configuration(), savepointPath, localMaxParallelism);
+    }
+
+    private MapPartitionOperator<T, TaggedOperatorSubtaskState> writeOperatorSubtaskStates(
+            OperatorID operatorID,
+            StateBackend stateBackend,
+            Configuration additionalConfig,
             Path savepointPath,
             int localMaxParallelism) {
 
@@ -169,7 +181,7 @@ public class BootstrapTransformation<T> {
 
         operator = dataSet.clean(operator);
 
-        final StreamConfig config = getConfig(operatorID, stateBackend, operator);
+        final StreamConfig config = getConfig(operatorID, stateBackend, additionalConfig, operator);
 
         BoundedOneInputStreamTaskRunner<T> operatorRunner =
                 new BoundedOneInputStreamTaskRunner<>(config, localMaxParallelism, timestamper);
@@ -192,12 +204,15 @@ public class BootstrapTransformation<T> {
     StreamConfig getConfig(
             OperatorID operatorID,
             StateBackend stateBackend,
+            Configuration additionalConfig,
             StreamOperator<TaggedOperatorSubtaskState> operator) {
         // Eagerly perform a deep copy of the configuration, otherwise it will result in undefined
         // behavior
         // when deploying with multiple bootstrap transformations.
         Configuration deepCopy =
                 new Configuration(dataSet.getExecutionEnvironment().getConfiguration());
+        deepCopy.addAll(additionalConfig);
+
         final StreamConfig config = new StreamConfig(deepCopy);
         config.setChainStart();
         config.setCheckpointingEnabled(true);

--- a/flink-libraries/flink-state-processing-api/src/main/java/org/apache/flink/state/api/WritableSavepoint.java
+++ b/flink-libraries/flink-state-processing-api/src/main/java/org/apache/flink/state/api/WritableSavepoint.java
@@ -19,6 +19,8 @@ package org.apache.flink.state.api;
 
 import org.apache.flink.annotation.PublicEvolving;
 import org.apache.flink.api.java.DataSet;
+import org.apache.flink.configuration.ConfigOption;
+import org.apache.flink.configuration.Configuration;
 import org.apache.flink.core.fs.Path;
 import org.apache.flink.runtime.checkpoint.OperatorState;
 import org.apache.flink.runtime.state.StateBackend;
@@ -53,11 +55,14 @@ public abstract class WritableSavepoint<F extends WritableSavepoint> {
     /** The state backend to use when writing this savepoint. */
     protected final StateBackend stateBackend;
 
+    private final Configuration configuration;
+
     WritableSavepoint(SavepointMetadata metadata, StateBackend stateBackend) {
         Preconditions.checkNotNull(metadata, "The savepoint metadata must not be null");
         Preconditions.checkNotNull(stateBackend, "The state backend must not be null");
         this.metadata = metadata;
         this.stateBackend = stateBackend;
+        this.configuration = new Configuration();
     }
 
     /**
@@ -86,6 +91,21 @@ public abstract class WritableSavepoint<F extends WritableSavepoint> {
     }
 
     /**
+     * Sets a configuration that will be applied to the stream operators used to bootstrap a new
+     * savepoint.
+     *
+     * @param option metadata information
+     * @param value value to be stored
+     * @param <T> type of the value to be stored
+     * @return The modified savepoint.
+     */
+    @SuppressWarnings("unchecked")
+    public <T> F withConfiguration(ConfigOption<T> option, T value) {
+        configuration.set(option, value);
+        return (F) this;
+    }
+
+    /**
      * Write out a new or updated savepoint.
      *
      * @param path The path to where the savepoint should be written.
@@ -96,7 +116,7 @@ public abstract class WritableSavepoint<F extends WritableSavepoint> {
         List<BootstrapTransformationWithID<?>> newOperatorTransformations =
                 metadata.getNewOperators();
         DataSet<OperatorState> newOperatorStates =
-                writeOperatorStates(newOperatorTransformations, savepointPath);
+                writeOperatorStates(newOperatorTransformations, configuration, savepointPath);
 
         List<OperatorState> existingOperators = metadata.getExistingOperators();
 
@@ -125,7 +145,9 @@ public abstract class WritableSavepoint<F extends WritableSavepoint> {
     }
 
     private DataSet<OperatorState> writeOperatorStates(
-            List<BootstrapTransformationWithID<?>> newOperatorStates, Path savepointWritePath) {
+            List<BootstrapTransformationWithID<?>> newOperatorStates,
+            Configuration config,
+            Path savepointWritePath) {
         return newOperatorStates.stream()
                 .map(
                         newOperatorState ->
@@ -134,6 +156,7 @@ public abstract class WritableSavepoint<F extends WritableSavepoint> {
                                         .writeOperatorState(
                                                 newOperatorState.getOperatorID(),
                                                 stateBackend,
+                                                config,
                                                 metadata.getMaxParallelism(),
                                                 savepointWritePath))
                 .reduce(DataSet::union)

--- a/flink-libraries/flink-state-processing-api/src/main/java/org/apache/flink/state/api/output/SnapshotUtils.java
+++ b/flink-libraries/flink-state-processing-api/src/main/java/org/apache/flink/state/api/output/SnapshotUtils.java
@@ -19,16 +19,23 @@
 package org.apache.flink.state.api.output;
 
 import org.apache.flink.annotation.Internal;
+import org.apache.flink.configuration.Configuration;
 import org.apache.flink.core.fs.Path;
 import org.apache.flink.runtime.checkpoint.CheckpointOptions;
 import org.apache.flink.runtime.checkpoint.CheckpointType;
 import org.apache.flink.runtime.checkpoint.OperatorSubtaskState;
-import org.apache.flink.runtime.state.CheckpointStorageWorkerView;
 import org.apache.flink.runtime.state.CheckpointStreamFactory;
 import org.apache.flink.runtime.state.filesystem.AbstractFsCheckpointStorageAccess;
+import org.apache.flink.runtime.state.filesystem.FsCheckpointStorageLocation;
 import org.apache.flink.streaming.api.operators.OperatorSnapshotFinalizer;
 import org.apache.flink.streaming.api.operators.OperatorSnapshotFutures;
 import org.apache.flink.streaming.api.operators.StreamOperator;
+import org.apache.flink.util.MathUtils;
+
+import java.io.IOException;
+
+import static org.apache.flink.configuration.CheckpointingOptions.FS_SMALL_FILE_THRESHOLD;
+import static org.apache.flink.configuration.CheckpointingOptions.FS_WRITE_BUFFER_SIZE;
 
 /** Takes a final snapshot of the state of an operator subtask. */
 @Internal
@@ -43,7 +50,7 @@ public final class SnapshotUtils {
             long timestamp,
             boolean isExactlyOnceMode,
             boolean isUnalignedCheckpoint,
-            CheckpointStorageWorkerView checkpointStorage,
+            Configuration configuration,
             Path savepointPath)
             throws Exception {
 
@@ -57,9 +64,7 @@ public final class SnapshotUtils {
 
         operator.prepareSnapshotPreBarrier(CHECKPOINT_ID);
 
-        CheckpointStreamFactory storage =
-                checkpointStorage.resolveCheckpointStorageLocation(
-                        CHECKPOINT_ID, options.getTargetLocation());
+        CheckpointStreamFactory storage = createStreamFactory(configuration, options);
 
         OperatorSnapshotFutures snapshotInProgress =
                 operator.snapshotState(CHECKPOINT_ID, timestamp, options, storage);
@@ -69,5 +74,21 @@ public final class SnapshotUtils {
 
         operator.notifyCheckpointComplete(CHECKPOINT_ID);
         return new TaggedOperatorSubtaskState(index, state);
+    }
+
+    private static CheckpointStreamFactory createStreamFactory(
+            Configuration configuration, CheckpointOptions options) throws IOException {
+        final Path path =
+                AbstractFsCheckpointStorageAccess.decodePathFromReference(
+                        options.getTargetLocation());
+
+        return new FsCheckpointStorageLocation(
+                path.getFileSystem(),
+                path,
+                path,
+                path,
+                options.getTargetLocation(),
+                MathUtils.checkedDownCast(configuration.get(FS_SMALL_FILE_THRESHOLD).getBytes()),
+                configuration.get(FS_WRITE_BUFFER_SIZE));
     }
 }

--- a/flink-libraries/flink-state-processing-api/src/main/java/org/apache/flink/state/api/output/operators/BroadcastStateBootstrapOperator.java
+++ b/flink-libraries/flink-state-processing-api/src/main/java/org/apache/flink/state/api/output/operators/BroadcastStateBootstrapOperator.java
@@ -78,7 +78,7 @@ public class BroadcastStateBootstrapOperator<IN>
                         timestamp,
                         getContainingTask().getConfiguration().isExactlyOnceCheckpointMode(),
                         getContainingTask().getConfiguration().isUnalignedCheckpointsEnabled(),
-                        getContainingTask().getCheckpointStorage(),
+                        getContainingTask().getConfiguration().getConfiguration(),
                         savepointPath);
 
         output.collect(new StreamRecord<>(state));

--- a/flink-libraries/flink-state-processing-api/src/main/java/org/apache/flink/state/api/output/operators/KeyedStateBootstrapOperator.java
+++ b/flink-libraries/flink-state-processing-api/src/main/java/org/apache/flink/state/api/output/operators/KeyedStateBootstrapOperator.java
@@ -93,7 +93,7 @@ public class KeyedStateBootstrapOperator<K, IN>
                         timestamp,
                         getContainingTask().getConfiguration().isExactlyOnceCheckpointMode(),
                         getContainingTask().getConfiguration().isUnalignedCheckpointsEnabled(),
-                        getContainingTask().getCheckpointStorage(),
+                        getContainingTask().getConfiguration().getConfiguration(),
                         savepointPath);
 
         output.collect(new StreamRecord<>(state));

--- a/flink-libraries/flink-state-processing-api/src/main/java/org/apache/flink/state/api/output/operators/StateBootstrapOperator.java
+++ b/flink-libraries/flink-state-processing-api/src/main/java/org/apache/flink/state/api/output/operators/StateBootstrapOperator.java
@@ -74,7 +74,7 @@ public class StateBootstrapOperator<IN>
                         timestamp,
                         getContainingTask().getConfiguration().isExactlyOnceCheckpointMode(),
                         getContainingTask().getConfiguration().isUnalignedCheckpointsEnabled(),
-                        getContainingTask().getCheckpointStorage(),
+                        getContainingTask().getConfiguration().getConfiguration(),
                         savepointPath);
 
         output.collect(new StreamRecord<>(state));

--- a/flink-libraries/flink-state-processing-api/src/main/java/org/apache/flink/state/api/output/operators/StateBootstrapWrapperOperator.java
+++ b/flink-libraries/flink-state-processing-api/src/main/java/org/apache/flink/state/api/output/operators/StateBootstrapWrapperOperator.java
@@ -196,7 +196,7 @@ public final class StateBootstrapWrapperOperator<
                         operator.getContainingTask()
                                 .getConfiguration()
                                 .isUnalignedCheckpointsEnabled(),
-                        operator.getContainingTask().getCheckpointStorage(),
+                        operator.getContainingTask().getConfiguration().getConfiguration(),
                         savepointPath);
 
         output.collect(new StreamRecord<>(state));

--- a/flink-libraries/flink-state-processing-api/src/test/java/org/apache/flink/state/api/BootstrapTransformationTest.java
+++ b/flink-libraries/flink-state-processing-api/src/test/java/org/apache/flink/state/api/BootstrapTransformationTest.java
@@ -24,6 +24,7 @@ import org.apache.flink.api.java.ExecutionEnvironment;
 import org.apache.flink.api.java.functions.KeySelector;
 import org.apache.flink.api.java.operators.DataSource;
 import org.apache.flink.api.java.operators.Operator;
+import org.apache.flink.configuration.Configuration;
 import org.apache.flink.core.fs.Path;
 import org.apache.flink.runtime.state.FunctionInitializationContext;
 import org.apache.flink.runtime.state.FunctionSnapshotContext;
@@ -156,7 +157,10 @@ public class BootstrapTransformationTest extends AbstractTestBase {
 
         StreamConfig config =
                 transformation.getConfig(
-                        OperatorIDGenerator.fromUid("uid"), new MemoryStateBackend(), null);
+                        OperatorIDGenerator.fromUid("uid"),
+                        new MemoryStateBackend(),
+                        new Configuration(),
+                        null);
         KeySelector selector =
                 config.getStatePartitioner(0, Thread.currentThread().getContextClassLoader());
 

--- a/flink-libraries/flink-state-processing-api/src/test/java/org/apache/flink/state/api/EmbeddedRocksDBStateBackendReaderKeyedStateITCase.java
+++ b/flink-libraries/flink-state-processing-api/src/test/java/org/apache/flink/state/api/EmbeddedRocksDBStateBackendReaderKeyedStateITCase.java
@@ -1,0 +1,31 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.flink.state.api;
+
+import org.apache.flink.contrib.streaming.state.EmbeddedRocksDBStateBackend;
+
+/** IT Case for reading state from a RocksDB keyed state backend. */
+public class EmbeddedRocksDBStateBackendReaderKeyedStateITCase
+        extends SavepointReaderKeyedStateITCase<EmbeddedRocksDBStateBackend> {
+
+    @Override
+    protected EmbeddedRocksDBStateBackend getStateBackend() {
+        return new EmbeddedRocksDBStateBackend();
+    }
+}

--- a/flink-libraries/flink-state-processing-api/src/test/java/org/apache/flink/state/api/EmbeddedRocksDBStateBackendWindowITCase.java
+++ b/flink-libraries/flink-state-processing-api/src/test/java/org/apache/flink/state/api/EmbeddedRocksDBStateBackendWindowITCase.java
@@ -1,0 +1,31 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.flink.state.api;
+
+import org.apache.flink.contrib.streaming.state.EmbeddedRocksDBStateBackend;
+
+/** IT Case for reading window state with the memory state backend. */
+public class EmbeddedRocksDBStateBackendWindowITCase
+        extends SavepointWindowReaderITCase<EmbeddedRocksDBStateBackend> {
+
+    @Override
+    protected EmbeddedRocksDBStateBackend getStateBackend() {
+        return new EmbeddedRocksDBStateBackend();
+    }
+}

--- a/flink-libraries/flink-state-processing-api/src/test/java/org/apache/flink/state/api/HashMapStateBackendReaderKeyedStateITCase.java
+++ b/flink-libraries/flink-state-processing-api/src/test/java/org/apache/flink/state/api/HashMapStateBackendReaderKeyedStateITCase.java
@@ -1,0 +1,31 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.flink.state.api;
+
+import org.apache.flink.runtime.state.hashmap.HashMapStateBackend;
+
+/** IT Case for reading keyed state from a memory state backend. */
+public class HashMapStateBackendReaderKeyedStateITCase
+        extends SavepointReaderKeyedStateITCase<HashMapStateBackend> {
+
+    @Override
+    protected HashMapStateBackend getStateBackend() {
+        return new HashMapStateBackend();
+    }
+}

--- a/flink-libraries/flink-state-processing-api/src/test/java/org/apache/flink/state/api/HashMapStateBackendWindowITCase.java
+++ b/flink-libraries/flink-state-processing-api/src/test/java/org/apache/flink/state/api/HashMapStateBackendWindowITCase.java
@@ -1,0 +1,31 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.flink.state.api;
+
+import org.apache.flink.runtime.state.hashmap.HashMapStateBackend;
+
+/** IT Case for reading window state with the memory state backend. */
+public class HashMapStateBackendWindowITCase
+        extends SavepointWindowReaderITCase<HashMapStateBackend> {
+
+    @Override
+    protected HashMapStateBackend getStateBackend() {
+        return new HashMapStateBackend();
+    }
+}

--- a/flink-libraries/flink-state-processing-api/src/test/java/org/apache/flink/state/api/SavepointWriterITCase.java
+++ b/flink-libraries/flink-state-processing-api/src/test/java/org/apache/flink/state/api/SavepointWriterITCase.java
@@ -30,6 +30,7 @@ import org.apache.flink.api.java.DataSet;
 import org.apache.flink.api.java.ExecutionEnvironment;
 import org.apache.flink.client.program.ClusterClient;
 import org.apache.flink.configuration.Configuration;
+import org.apache.flink.contrib.streaming.state.EmbeddedRocksDBStateBackend;
 import org.apache.flink.contrib.streaming.state.RocksDBStateBackend;
 import org.apache.flink.runtime.jobgraph.JobGraph;
 import org.apache.flink.runtime.jobgraph.SavepointRestoreSettings;
@@ -37,6 +38,7 @@ import org.apache.flink.runtime.state.FunctionInitializationContext;
 import org.apache.flink.runtime.state.FunctionSnapshotContext;
 import org.apache.flink.runtime.state.StateBackend;
 import org.apache.flink.runtime.state.filesystem.FsStateBackend;
+import org.apache.flink.runtime.state.hashmap.HashMapStateBackend;
 import org.apache.flink.state.api.functions.BroadcastStateBootstrapFunction;
 import org.apache.flink.state.api.functions.KeyedStateBootstrapFunction;
 import org.apache.flink.state.api.functions.StateBootstrapFunction;
@@ -97,6 +99,17 @@ public class SavepointWriterITCase extends AbstractTestBase {
         StateBackend backend =
                 new RocksDBStateBackend(
                         new FsStateBackend(TEMPORARY_FOLDER.newFolder().toURI(), FILE_STATE_SIZE));
+        testStateBootstrapAndModification(backend);
+    }
+
+    @Test
+    public void testHashMapStateBackend() throws Exception {
+        testStateBootstrapAndModification(new HashMapStateBackend());
+    }
+
+    @Test
+    public void testEmbeddedRocksDBStateBackend() throws Exception {
+        StateBackend backend = new EmbeddedRocksDBStateBackend();
         testStateBootstrapAndModification(backend);
     }
 

--- a/flink-libraries/flink-state-processing-api/src/test/java/org/apache/flink/state/api/SavepointWriterWindowITCase.java
+++ b/flink-libraries/flink-state-processing-api/src/test/java/org/apache/flink/state/api/SavepointWriterWindowITCase.java
@@ -28,10 +28,12 @@ import org.apache.flink.api.java.ExecutionEnvironment;
 import org.apache.flink.api.java.tuple.Tuple2;
 import org.apache.flink.api.java.tuple.Tuple3;
 import org.apache.flink.client.program.ClusterClient;
+import org.apache.flink.contrib.streaming.state.EmbeddedRocksDBStateBackend;
 import org.apache.flink.contrib.streaming.state.RocksDBStateBackend;
 import org.apache.flink.runtime.jobgraph.JobGraph;
 import org.apache.flink.runtime.jobgraph.SavepointRestoreSettings;
 import org.apache.flink.runtime.state.StateBackend;
+import org.apache.flink.runtime.state.hashmap.HashMapStateBackend;
 import org.apache.flink.runtime.state.memory.MemoryStateBackend;
 import org.apache.flink.state.api.utils.MaxWatermarkSource;
 import org.apache.flink.streaming.api.datastream.DataStream;
@@ -111,7 +113,9 @@ public class SavepointWriterWindowITCase extends AbstractTestBase {
 
     private static final List<Tuple2<String, StateBackend>> STATE_BACKENDS =
             Arrays.asList(
-                    Tuple2.of("MemoryStateBackend", new MemoryStateBackend()),
+                    Tuple2.of("HashMap", new HashMapStateBackend()),
+                    Tuple2.of("EmbeddedRocksDB", new EmbeddedRocksDBStateBackend()),
+                    Tuple2.of("Memory", new MemoryStateBackend()),
                     Tuple2.of(
                             "RocksDB",
                             new RocksDBStateBackend((StateBackend) new MemoryStateBackend())));

--- a/flink-libraries/flink-state-processing-api/src/test/java/org/apache/flink/state/api/output/SnapshotUtilsTest.java
+++ b/flink-libraries/flink-state-processing-api/src/test/java/org/apache/flink/state/api/output/SnapshotUtilsTest.java
@@ -18,14 +18,12 @@
 
 package org.apache.flink.state.api.output;
 
-import org.apache.flink.api.common.JobID;
+import org.apache.flink.configuration.Configuration;
 import org.apache.flink.core.fs.Path;
 import org.apache.flink.metrics.groups.OperatorMetricGroup;
 import org.apache.flink.runtime.checkpoint.CheckpointOptions;
 import org.apache.flink.runtime.jobgraph.OperatorID;
-import org.apache.flink.runtime.state.CheckpointStorageWorkerView;
 import org.apache.flink.runtime.state.CheckpointStreamFactory;
-import org.apache.flink.runtime.state.ttl.mock.MockCheckpointStorage;
 import org.apache.flink.streaming.api.operators.OperatorSnapshotFutures;
 import org.apache.flink.streaming.api.operators.StreamOperator;
 import org.apache.flink.streaming.api.operators.StreamTaskStateInitializer;
@@ -55,12 +53,9 @@ public class SnapshotUtilsTest {
     @Test
     public void testSnapshotUtilsLifecycle() throws Exception {
         StreamOperator<Void> operator = new LifecycleOperator();
-        CheckpointStorageWorkerView storage =
-                new MockCheckpointStorage().createCheckpointStorage(new JobID());
-
         Path path = new Path(folder.newFolder().getAbsolutePath());
 
-        SnapshotUtils.snapshot(operator, 0, 0L, true, false, storage, path);
+        SnapshotUtils.snapshot(operator, 0, 0L, true, false, new Configuration(), path);
 
         Assert.assertEquals(EXPECTED_CALL_OPERATOR_SNAPSHOT, ACTUAL_ORDER_TRACKING);
     }


### PR DESCRIPTION
## What is the purpose of the change

Support the new state backend interfaces in the state processor api by forcing checkpoint storage to always use FileSystemCheckpointStorage.

## Brief change log

See above


## Verifying this change

Added new state backends to the test suite. 

## Does this pull request potentially affect one of the following parts:

  - Dependencies (does it add or upgrade a dependency): (yes / **no**)
  - The public API, i.e., is any changed class annotated with `@Public(Evolving)`: (yes / **no**)
  - The serializers: (yes / no / don't know)
  - The runtime per-record code paths (performance sensitive): (yes / **no** / don't know)
  - Anything that affects deployment or recovery: JobManager (and its components), Checkpointing, Kubernetes/Yarn, ZooKeeper: (yes / **no** / don't know)
  - The S3 file system connector: (yes / **no** / don't know)

## Documentation

  - Does this pull request introduce a new feature? (yes / **no**)
  - If yes, how is the feature documented? (not applicable / **docs** / JavaDocs / not documented)
