### PR TITLE
[FLINK-16769][table] Use new type inference in Table.flatMap()

### DIFF
--- a/flink-table/flink-table-api-java/src/main/java/org/apache/flink/table/operations/utils/OperationTreeBuilder.java
+++ b/flink-table/flink-table-api-java/src/main/java/org/apache/flink/table/operations/utils/OperationTreeBuilder.java
@@ -43,7 +43,6 @@ import org.apache.flink.table.functions.AggregateFunctionDefinition;
 import org.apache.flink.table.functions.BuiltInFunctionDefinitions;
 import org.apache.flink.table.functions.FunctionDefinition;
 import org.apache.flink.table.functions.FunctionKind;
-import org.apache.flink.table.functions.TableFunctionDefinition;
 import org.apache.flink.table.operations.DistinctQueryOperation;
 import org.apache.flink.table.operations.FilterQueryOperation;
 import org.apache.flink.table.operations.JoinQueryOperation.JoinType;
@@ -70,6 +69,7 @@ import java.util.Optional;
 import java.util.Set;
 import java.util.stream.Collectors;
 
+import static org.apache.flink.table.expressions.ApiExpressionUtils.isFunctionOfKind;
 import static org.apache.flink.table.expressions.ApiExpressionUtils.localRef;
 import static org.apache.flink.table.expressions.ApiExpressionUtils.unresolvedCall;
 import static org.apache.flink.table.expressions.ApiExpressionUtils.unresolvedRef;
@@ -470,7 +470,7 @@ public final class OperationTreeBuilder {
 
         Expression resolvedMapFunction = mapFunction.accept(lookupResolver);
 
-        if (!ApiExpressionUtils.isFunctionOfKind(resolvedMapFunction, FunctionKind.SCALAR)) {
+        if (!isFunctionOfKind(resolvedMapFunction, FunctionKind.SCALAR)) {
             throw new ValidationException(
                     "Only a scalar function can be used in the map operator.");
         }
@@ -480,25 +480,18 @@ public final class OperationTreeBuilder {
         return project(Collections.singletonList(expandedFields), child, false);
     }
 
-    public QueryOperation flatMap(Expression tableFunction, QueryOperation child) {
+    public QueryOperation flatMap(Expression tableFunctionCall, QueryOperation child) {
+        final ExpressionResolver resolver = getResolverBuilder(child).build();
+        final ResolvedExpression resolvedCall =
+                resolveSingleExpression(tableFunctionCall, resolver);
 
-        Expression resolvedTableFunction = tableFunction.accept(lookupResolver);
-
-        if (!ApiExpressionUtils.isFunctionOfKind(resolvedTableFunction, FunctionKind.TABLE)) {
+        if (!isFunctionOfKind(resolvedCall, FunctionKind.TABLE)) {
             throw new ValidationException(
                     "Only a table function can be used in the flatMap operator.");
         }
 
-        FunctionDefinition functionDefinition =
-                ((UnresolvedCallExpression) resolvedTableFunction).getFunctionDefinition();
-        if (!(functionDefinition instanceof TableFunctionDefinition)) {
-            throw new ValidationException(
-                    "The new type inference for functions is not supported in the flatMap yet.");
-        }
-
-        TypeInformation<?> resultType =
-                ((TableFunctionDefinition) functionDefinition).getResultType();
-        List<String> originFieldNames = Arrays.asList(FieldInfoUtils.getFieldNames(resultType));
+        final List<String> originFieldNames =
+                DataTypeUtils.flattenToNames(resolvedCall.getOutputDataType());
 
         List<String> childFields = child.getResolvedSchema().getColumnNames();
         Set<String> usedFieldNames = new HashSet<>(childFields);
@@ -510,7 +503,7 @@ public final class OperationTreeBuilder {
             args.add(valueLiteral(resultName));
         }
 
-        args.add(0, resolvedTableFunction);
+        args.add(0, tableFunctionCall);
         Expression renamedTableFunction =
                 unresolvedCall(BuiltInFunctionDefinitions.AS, args.toArray(new Expression[0]));
         QueryOperation joinNode =
@@ -670,7 +663,7 @@ public final class OperationTreeBuilder {
         private Optional<AggregateWithAlias> getAggregate(
                 UnresolvedCallExpression unresolvedCall, List<String> aliases) {
             FunctionDefinition functionDefinition = unresolvedCall.getFunctionDefinition();
-            if (ApiExpressionUtils.isFunctionOfKind(unresolvedCall, FunctionKind.AGGREGATE)) {
+            if (isFunctionOfKind(unresolvedCall, FunctionKind.AGGREGATE)) {
                 final List<String> fieldNames;
                 if (aliases.isEmpty()) {
                     if (functionDefinition instanceof AggregateFunctionDefinition) {
@@ -914,7 +907,7 @@ public final class OperationTreeBuilder {
 
         @Override
         public Void visit(UnresolvedCallExpression call) {
-            if (ApiExpressionUtils.isFunctionOfKind(call, FunctionKind.AGGREGATE)) {
+            if (isFunctionOfKind(call, FunctionKind.AGGREGATE)) {
                 throw new ValidationException(exceptionMessage);
             }
             call.getChildren().forEach(expr -> expr.accept(this));

--- a/flink-table/flink-table-planner/src/test/resources/org/apache/flink/table/planner/plan/stream/table/CorrelateTest.xml
+++ b/flink-table/flink-table-planner/src/test/resources/org/apache/flink/table/planner/plan/stream/table/CorrelateTest.xml
@@ -185,13 +185,14 @@ Correlate(invocation=[org$apache$flink$table$planner$utils$HierarchyTableFunctio
 LogicalProject(f0=[AS($3, _UTF-16LE'f0')], f1=[AS($4, _UTF-16LE'f1')])
 +- LogicalCorrelate(correlation=[$cor0], joinType=[inner], requiredColumns=[{}])
    :- LogicalTableScan(table=[[default_catalog, default_database, MyTable, source: [TestTableSource(f1, f2, f3)]]])
-   +- LogicalTableFunctionScan(invocation=[org$apache$flink$table$planner$utils$TableFunc2$e9d8fd0c1a1f8cddfbbd46c86e136247($2)], rowType=[RecordType(VARCHAR(2147483647) f0, INTEGER f1_0)], elementType=[class [Ljava.lang.Object;])
+   +- LogicalProject(f0=[$0], f1_0=[$1])
+      +- LogicalTableFunctionScan(invocation=[org$apache$flink$table$planner$utils$TableFunc2$e9d8fd0c1a1f8cddfbbd46c86e136247($2)], rowType=[RecordType:peek_no_expand(VARCHAR(2147483647) f0, INTEGER f1)])
 ]]>
     </Resource>
     <Resource name="optimized exec plan">
       <![CDATA[
-Calc(select=[f0, f1_0 AS f1])
-+- Correlate(invocation=[org$apache$flink$table$planner$utils$TableFunc2$e9d8fd0c1a1f8cddfbbd46c86e136247($2)], correlate=[table(TableFunc2(f3))], select=[f1,f2,f3,f0,f1_0], rowType=[RecordType(INTEGER f1, BIGINT f2, VARCHAR(2147483647) f3, VARCHAR(2147483647) f0, INTEGER f1_0)], joinType=[INNER])
+Calc(select=[f0, f10 AS f1])
++- Correlate(invocation=[org$apache$flink$table$planner$utils$TableFunc2$e9d8fd0c1a1f8cddfbbd46c86e136247($2)], correlate=[table(org$apache$flink$table$planner$utils$TableFunc2$e9d8fd0c1a1f8cddfbbd46c86e136247(f3))], select=[f1,f2,f3,f0,f10], rowType=[RecordType(INTEGER f1, BIGINT f2, VARCHAR(2147483647) f3, VARCHAR(2147483647) f0, INTEGER f10)], joinType=[INNER])
    +- LegacyTableSourceScan(table=[[default_catalog, default_database, MyTable, source: [TestTableSource(f1, f2, f3)]]], fields=[f1, f2, f3])
 ]]>
     </Resource>

--- a/flink-table/flink-table-planner/src/test/scala/org/apache/flink/table/planner/plan/stream/table/CorrelateTest.scala
+++ b/flink-table/flink-table-planner/src/test/scala/org/apache/flink/table/planner/plan/stream/table/CorrelateTest.scala
@@ -172,11 +172,8 @@ class CorrelateTest extends TableTestBase {
   @Test
   def testFlatMap(): Unit = {
     val util = streamTestUtil()
-
-    val func2 = new TableFunc2
     val sourceTable = util.addTableSource[(Int, Long, String)]("MyTable", 'f1, 'f2, 'f3)
-    val resultTable = sourceTable
-      .flatMap(func2('f3))
+    val resultTable = sourceTable.flatMap(call(classOf[TableFunc2], 'f3))
     util.verifyExecPlan(resultTable)
   }
 

--- a/flink-table/flink-table-planner/src/test/scala/org/apache/flink/table/planner/runtime/stream/table/CorrelateITCase.scala
+++ b/flink-table/flink-table-planner/src/test/scala/org/apache/flink/table/planner/runtime/stream/table/CorrelateITCase.scala
@@ -340,13 +340,12 @@ class CorrelateITCase(mode: StateBackendMode) extends StreamingWithStateTestBase
 
   @Test
   def testFlatMap(): Unit = {
-    val func2 = new TableFunc2
     val ds = testData(env).toTable(tEnv, 'a, 'b, 'c)
       // test non alias
-      .flatMap(func2('c))
+      .flatMap(call(classOf[TableFunc2], 'c))
       .select('f0, 'f1)
       // test the output field name of flatMap is the same as the field name of the input table
-      .flatMap(func2(concat('f0, "#")))
+      .flatMap(call(classOf[TableFunc2], concat('f0, "#")))
       .as ("f0", "f1")
       .select('f0, 'f1)
 

--- a/flink-table/flink-table-planner/src/test/scala/org/apache/flink/table/planner/utils/UserDefinedTableFunctions.scala
+++ b/flink-table/flink-table-planner/src/test/scala/org/apache/flink/table/planner/utils/UserDefinedTableFunctions.scala
@@ -63,6 +63,7 @@ class TableFunc1 extends TableFunction[String] {
 }
 
 @SerialVersionUID(1L)
+@DataTypeHint("ROW<f0 STRING, f1 INT>")
 class TableFunc2 extends TableFunction[Row] {
   def eval(str: String): Unit = {
     if (str.contains("#")) {


### PR DESCRIPTION
## What is the purpose of the change

This updates `flatMap()` to the new type system and new type inference.

## Brief change log

Support both new and old inference.

## Verifying this change

This change is already covered by existing tests, such as `CorrelateITCase`.

## Does this pull request potentially affect one of the following parts:

  - Dependencies (does it add or upgrade a dependency): no
  - The public API, i.e., is any changed class annotated with `@Public(Evolving)`: no
  - The serializers: no
  - The runtime per-record code paths (performance sensitive): no
  - Anything that affects deployment or recovery: JobManager (and its components), Checkpointing, Kubernetes/Yarn, ZooKeeper: no
  - The S3 file system connector: no

## Documentation

  - Does this pull request introduce a new feature? no
  - If yes, how is the feature documented? not applicable
