### PR TITLE
[FLINK-23330][table-api-java-bridge] Deprecate old fromDataStream, toAppendStream, toRetractStream

### DIFF
--- a/flink-table/flink-table-api-java-bridge/src/main/java/org/apache/flink/table/api/bridge/java/StreamTableEnvironment.java
+++ b/flink-table/flink-table-api-java-bridge/src/main/java/org/apache/flink/table/api/bridge/java/StreamTableEnvironment.java
@@ -826,7 +826,12 @@ public interface StreamTableEnvironment extends TableEnvironment {
      *     of the {@code Table}.
      * @param <T> The type of the {@link DataStream}.
      * @return The converted {@link Table}.
+     * @deprecated Use {@link #fromDataStream(DataStream, Schema)} instead. In most cases, {@link
+     *     #fromDataStream(DataStream)} should already be sufficient. It integrates with the new
+     *     type system and supports all kinds of {@link DataTypes} that the table runtime can
+     *     consume. The semantics might be slightly different for raw and structured types.
      */
+    @Deprecated
     <T> Table fromDataStream(DataStream<T> dataStream, Expression... fields);
 
     /**
@@ -1010,7 +1015,13 @@ public interface StreamTableEnvironment extends TableEnvironment {
      * @param fields The fields expressions to map original fields of the DataStream to the fields
      *     of the View.
      * @param <T> The type of the {@link DataStream}.
+     * @deprecated Use {@link #createTemporaryView(String, DataStream, Schema)} instead. In most
+     *     cases, {@link #createTemporaryView(String, DataStream)} should already be sufficient. It
+     *     integrates with the new type system and supports all kinds of {@link DataTypes} that the
+     *     table runtime can consume. The semantics might be slightly different for raw and
+     *     structured types.
      */
+    @Deprecated
     <T> void createTemporaryView(String path, DataStream<T> dataStream, Expression... fields);
 
     /**
@@ -1031,7 +1042,13 @@ public interface StreamTableEnvironment extends TableEnvironment {
      * @param clazz The class of the type of the resulting {@link DataStream}.
      * @param <T> The type of the resulting {@link DataStream}.
      * @return The converted {@link DataStream}.
+     * @deprecated Use {@link #toDataStream(Table, Class)} instead. It integrates with the new type
+     *     system and supports all kinds of {@link DataTypes} that the table runtime can produce.
+     *     The semantics might be slightly different for raw and structured types. Use {@code
+     *     toDataStream(DataTypes.of(TypeInformation.of(Class)))} if {@link TypeInformation} should
+     *     be used as source of truth.
      */
+    @Deprecated
     <T> DataStream<T> toAppendStream(Table table, Class<T> clazz);
 
     /**
@@ -1053,7 +1070,13 @@ public interface StreamTableEnvironment extends TableEnvironment {
      *     DataStream}.
      * @param <T> The type of the resulting {@link DataStream}.
      * @return The converted {@link DataStream}.
+     * @deprecated Use {@link #toDataStream(Table, Class)} instead. It integrates with the new type
+     *     system and supports all kinds of {@link DataTypes} that the table runtime can produce.
+     *     The semantics might be slightly different for raw and structured types. Use {@code
+     *     toDataStream(DataTypes.of(TypeInformation.of(Class)))} if {@link TypeInformation} should
+     *     be used as source of truth.
      */
+    @Deprecated
     <T> DataStream<T> toAppendStream(Table table, TypeInformation<T> typeInfo);
 
     /**
@@ -1076,7 +1099,11 @@ public interface StreamTableEnvironment extends TableEnvironment {
      * @param clazz The class of the requested record type.
      * @param <T> The type of the requested record type.
      * @return The converted {@link DataStream}.
+     * @deprecated Use {@link #toChangelogStream(Table, Schema)} instead. It integrates with the new
+     *     type system and supports all kinds of {@link DataTypes} and every {@link ChangelogMode}
+     *     that the table runtime can produce.
      */
+    @Deprecated
     <T> DataStream<Tuple2<Boolean, T>> toRetractStream(Table table, Class<T> clazz);
 
     /**
@@ -1099,7 +1126,11 @@ public interface StreamTableEnvironment extends TableEnvironment {
      * @param typeInfo The {@link TypeInformation} of the requested record type.
      * @param <T> The type of the requested record type.
      * @return The converted {@link DataStream}.
+     * @deprecated Use {@link #toChangelogStream(Table, Schema)} instead. It integrates with the new
+     *     type system and supports all kinds of {@link DataTypes} and every {@link ChangelogMode}
+     *     that the table runtime can produce.
      */
+    @Deprecated
     <T> DataStream<Tuple2<Boolean, T>> toRetractStream(Table table, TypeInformation<T> typeInfo);
 
     /**

--- a/flink-table/flink-table-api-scala-bridge/src/main/scala/org/apache/flink/table/api/bridge/scala/StreamTableEnvironment.scala
+++ b/flink-table/flink-table-api-scala-bridge/src/main/scala/org/apache/flink/table/api/bridge/scala/StreamTableEnvironment.scala
@@ -619,7 +619,7 @@ trait StreamTableEnvironment extends TableEnvironment {
     *   )
     * }}}
     *
-    * <p>2. Reference input fields by position:
+    * 2. Reference input fields by position:
     * In this mode, fields are simply renamed. Event-time attributes can
     * replace the field on their position in the input data (if it is of correct type) or be
     * appended at the end. Proctime attributes must be appended at the end. This mode can only be
@@ -644,7 +644,13 @@ trait StreamTableEnvironment extends TableEnvironment {
     *               the [[Table]].
     * @tparam T The type of the [[DataStream]].
     * @return The converted [[Table]].
+    * @deprecated Use [[fromDataStream(DataStream, Schema)]] instead. In most cases,
+    *             [[fromDataStream(DataStream)]] should already be sufficient. It integrates with
+    *             the new type system and supports all kinds of [[DataTypes]] that the table runtime
+    *             can consume. The semantics might be slightly different for raw and structured
+    *             types.
     */
+  @deprecated
   def fromDataStream[T](dataStream: DataStream[T], fields: Expression*): Table
 
   /**
@@ -790,7 +796,13 @@ trait StreamTableEnvironment extends TableEnvironment {
     * @param fields The fields expressions to map original fields of the DataStream to the fields of
     *               the View.
     * @tparam T The type of the [[DataStream]].
+    * @deprecated Use [[createTemporaryView(String, DataStream, Schema)]] instead. In most cases,
+    *             [[createTemporaryView(String, DataStream)]] should already be sufficient. It
+    *             integrates with the new type system and supports all kinds of [[DataTypes]] that
+    *             the table runtime can consume. The semantics might be slightly different for raw
+    *             and structured types.
     */
+  @deprecated
   def createTemporaryView[T](path: String, dataStream: DataStream[T], fields: Expression*): Unit
 
   /**
@@ -807,7 +819,13 @@ trait StreamTableEnvironment extends TableEnvironment {
     * @param table The [[Table]] to convert.
     * @tparam T The type of the resulting [[DataStream]].
     * @return The converted [[DataStream]].
+    * @deprecated Use [[toDataStream(Table, Class)]] instead. It integrates with the new type
+    *             system and supports all kinds of [[DataTypes]] that the table runtime can produce.
+    *             The semantics might be slightly different for raw and structured types. Use
+    *             `toDataStream(DataTypes.of(Types.of[Class]))` if [[TypeInformation]]
+    *             should be used as source of truth.
     */
+  @deprecated
   def toAppendStream[T: TypeInformation](table: Table): DataStream[T]
 
   /**
@@ -820,7 +838,11 @@ trait StreamTableEnvironment extends TableEnvironment {
     * @param table The [[Table]] to convert.
     * @tparam T The type of the requested data type.
     * @return The converted [[DataStream]].
+    * @deprecated Use [[toChangelogStream(Table, Schema)]] instead. It integrates with the new
+    *             type system and supports all kinds of [[DataTypes]] and every [[ChangelogMode]]
+    *             that the table runtime can produce.
     */
+  @deprecated
   def toRetractStream[T: TypeInformation](table: Table): DataStream[(Boolean, T)]
 
   /**


### PR DESCRIPTION
## What is the purpose of the change

After stabilizing the new `(from|to)(Data|Changelog)Stream` method in 1.13. We can mark the old methods as deprecated in 1.14 and avoid confusing.

## Brief change log

- Deprecate affected methods
- Update documentation

## Verifying this change

This change is a trivial rework / code cleanup without any test coverage.

## Does this pull request potentially affect one of the following parts:

  - Dependencies (does it add or upgrade a dependency): no
  - The public API, i.e., is any changed class annotated with `@Public(Evolving)`: yes
  - The serializers: no
  - The runtime per-record code paths (performance sensitive): no
  - Anything that affects deployment or recovery: JobManager (and its components), Checkpointing, Kubernetes/Yarn, ZooKeeper: no
  - The S3 file system connector: no

## Documentation

  - Does this pull request introduce a new feature? no
  - If yes, how is the feature documented? not applicable
