### PR TITLE
[FLINK-23719] [connectors/hbase] Support switch WAL in Flink SQL DDL options for HBase sink

### DIFF
--- a/docs/content.zh/docs/connectors/table/hbase.md
+++ b/docs/content.zh/docs/connectors/table/hbase.md
@@ -161,6 +161,12 @@ ON myTopic.key = hTable.rowkey;
       <td>为 HBase sink operator 定义并行度。默认情况下，并行度由框架决定，和链在一起的上游 operator 一样。</td>
     </tr>
     <tr>
+      <td><h5>sink.skip-wal</h5></td>
+      <td>可选</td>
+      <td style="word-wrap: break-word;">false</td>
+      <td>Boolean</td>
+      <td>写入的参数选项。指示是否禁用HBase WAL。它能提升写入 HBase 数据库的性能。但是，禁用 WAL 会使数据面临风险。唯一推荐使用的场景是 bulk loading。</td>
+    <tr>
       <td><h5>lookup.async</h5></td>
       <td>可选</td>
       <td style="word-wrap: break-word;">false</td>

--- a/docs/content/docs/connectors/table/hbase.md
+++ b/docs/content/docs/connectors/table/hbase.md
@@ -180,6 +180,15 @@ Connector Options
       <td>Defines the parallelism of the HBase sink operator. By default, the parallelism is determined by the framework using the same parallelism of the upstream chained operator.</td>
     </tr>
     <tr>
+      <td><h5>sink.skip-wal</h5></td>
+      <td>optional</td>
+      <td style="word-wrap: break-word;">false</td>
+      <td>Boolean</td>
+      <td>Writing option, indicates whether to disable HBase WAL. This can improve performance for writing data to HBase database. 
+      However, disabling the WAL puts the data at risk. The only situation where this is recommended is during a bulk loading.
+    </td>
+    </tr>
+    <tr>
       <td><h5>lookup.async</h5></td>
       <td>optional</td>
       <td>no</td>

--- a/flink-connectors/flink-connector-hbase-1.4/src/main/java/org/apache/flink/connector/hbase1/HBase1DynamicTableFactory.java
+++ b/flink-connectors/flink-connector-hbase-1.4/src/main/java/org/apache/flink/connector/hbase1/HBase1DynamicTableFactory.java
@@ -47,6 +47,7 @@ import static org.apache.flink.connector.hbase.table.HBaseConnectorOptions.SINK_
 import static org.apache.flink.connector.hbase.table.HBaseConnectorOptions.SINK_BUFFER_FLUSH_MAX_ROWS;
 import static org.apache.flink.connector.hbase.table.HBaseConnectorOptions.SINK_BUFFER_FLUSH_MAX_SIZE;
 import static org.apache.flink.connector.hbase.table.HBaseConnectorOptions.SINK_PARALLELISM;
+import static org.apache.flink.connector.hbase.table.HBaseConnectorOptions.SINK_SKIP_WAL;
 import static org.apache.flink.connector.hbase.table.HBaseConnectorOptions.TABLE_NAME;
 import static org.apache.flink.connector.hbase.table.HBaseConnectorOptions.ZOOKEEPER_QUORUM;
 import static org.apache.flink.connector.hbase.table.HBaseConnectorOptions.ZOOKEEPER_ZNODE_PARENT;
@@ -129,6 +130,7 @@ public class HBase1DynamicTableFactory
         set.add(SINK_BUFFER_FLUSH_MAX_ROWS);
         set.add(SINK_BUFFER_FLUSH_INTERVAL);
         set.add(SINK_PARALLELISM);
+        set.add(SINK_SKIP_WAL);
         set.add(LOOKUP_ASYNC);
         set.add(LOOKUP_CACHE_MAX_ROWS);
         set.add(LOOKUP_CACHE_TTL);
@@ -146,6 +148,7 @@ public class HBase1DynamicTableFactory
                         SINK_BUFFER_FLUSH_MAX_SIZE,
                         SINK_BUFFER_FLUSH_MAX_ROWS,
                         SINK_BUFFER_FLUSH_INTERVAL,
+                        SINK_SKIP_WAL,
                         LOOKUP_CACHE_MAX_ROWS,
                         LOOKUP_CACHE_TTL,
                         LOOKUP_MAX_RETRIES)

--- a/flink-connectors/flink-connector-hbase-1.4/src/main/java/org/apache/flink/connector/hbase1/sink/HBaseDynamicTableSink.java
+++ b/flink-connectors/flink-connector-hbase-1.4/src/main/java/org/apache/flink/connector/hbase1/sink/HBaseDynamicTableSink.java
@@ -64,7 +64,8 @@ public class HBaseDynamicTableSink implements DynamicTableSink {
                         new RowDataToMutationConverter(hbaseTableSchema, nullStringLiteral),
                         writeOptions.getBufferFlushMaxSizeInBytes(),
                         writeOptions.getBufferFlushMaxRows(),
-                        writeOptions.getBufferFlushIntervalMillis());
+                        writeOptions.getBufferFlushIntervalMillis(),
+                        writeOptions.getSkipWal());
         return SinkFunctionProvider.of(sinkFunction, writeOptions.getParallelism());
     }
 

--- a/flink-connectors/flink-connector-hbase-1.4/src/test/java/org/apache/flink/connector/hbase1/HBaseDynamicTableFactoryTest.java
+++ b/flink-connectors/flink-connector-hbase-1.4/src/test/java/org/apache/flink/connector/hbase1/HBaseDynamicTableFactoryTest.java
@@ -246,6 +246,19 @@ public class HBaseDynamicTableFactoryTest {
     }
 
     @Test
+    public void testSkipWalOptions() {
+        Map<String, String> options = getAllOptions();
+        options.put("sink.skip-wal", "true");
+
+        ResolvedSchema schema = ResolvedSchema.of(Column.physical(ROWKEY, STRING()));
+
+        DynamicTableSink sink = createTableSink(schema, options);
+        assertTrue(sink instanceof HBaseDynamicTableSink);
+        HBaseDynamicTableSink hbaseSink = (HBaseDynamicTableSink) sink;
+        assertTrue(hbaseSink.getWriteOptions().getSkipWal());
+    }
+
+    @Test
     public void testLookupOptions() {
         Map<String, String> options = getAllOptions();
         options.put("lookup.cache.max-rows", "1000");

--- a/flink-connectors/flink-connector-hbase-2.2/src/main/java/org/apache/flink/connector/hbase2/HBase2DynamicTableFactory.java
+++ b/flink-connectors/flink-connector-hbase-2.2/src/main/java/org/apache/flink/connector/hbase2/HBase2DynamicTableFactory.java
@@ -48,6 +48,7 @@ import static org.apache.flink.connector.hbase.table.HBaseConnectorOptions.SINK_
 import static org.apache.flink.connector.hbase.table.HBaseConnectorOptions.SINK_BUFFER_FLUSH_MAX_ROWS;
 import static org.apache.flink.connector.hbase.table.HBaseConnectorOptions.SINK_BUFFER_FLUSH_MAX_SIZE;
 import static org.apache.flink.connector.hbase.table.HBaseConnectorOptions.SINK_PARALLELISM;
+import static org.apache.flink.connector.hbase.table.HBaseConnectorOptions.SINK_SKIP_WAL;
 import static org.apache.flink.connector.hbase.table.HBaseConnectorOptions.TABLE_NAME;
 import static org.apache.flink.connector.hbase.table.HBaseConnectorOptions.ZOOKEEPER_QUORUM;
 import static org.apache.flink.connector.hbase.table.HBaseConnectorOptions.ZOOKEEPER_ZNODE_PARENT;
@@ -127,6 +128,7 @@ public class HBase2DynamicTableFactory
         set.add(SINK_BUFFER_FLUSH_MAX_ROWS);
         set.add(SINK_BUFFER_FLUSH_INTERVAL);
         set.add(SINK_PARALLELISM);
+        set.add(SINK_SKIP_WAL);
         set.add(LOOKUP_ASYNC);
         set.add(LOOKUP_CACHE_MAX_ROWS);
         set.add(LOOKUP_CACHE_TTL);
@@ -146,7 +148,8 @@ public class HBase2DynamicTableFactory
                         LOOKUP_MAX_RETRIES,
                         SINK_BUFFER_FLUSH_MAX_SIZE,
                         SINK_BUFFER_FLUSH_MAX_ROWS,
-                        SINK_BUFFER_FLUSH_INTERVAL)
+                        SINK_BUFFER_FLUSH_INTERVAL,
+                        SINK_SKIP_WAL)
                 .collect(Collectors.toSet());
     }
 }

--- a/flink-connectors/flink-connector-hbase-2.2/src/main/java/org/apache/flink/connector/hbase2/sink/HBaseDynamicTableSink.java
+++ b/flink-connectors/flink-connector-hbase-2.2/src/main/java/org/apache/flink/connector/hbase2/sink/HBaseDynamicTableSink.java
@@ -65,7 +65,8 @@ public class HBaseDynamicTableSink implements DynamicTableSink {
                         new RowDataToMutationConverter(hbaseTableSchema, nullStringLiteral),
                         writeOptions.getBufferFlushMaxSizeInBytes(),
                         writeOptions.getBufferFlushMaxRows(),
-                        writeOptions.getBufferFlushIntervalMillis());
+                        writeOptions.getBufferFlushIntervalMillis(),
+                        writeOptions.getSkipWal());
         return SinkFunctionProvider.of(sinkFunction, writeOptions.getParallelism());
     }
 

--- a/flink-connectors/flink-connector-hbase-2.2/src/test/java/org/apache/flink/connector/hbase2/HBaseDynamicTableFactoryTest.java
+++ b/flink-connectors/flink-connector-hbase-2.2/src/test/java/org/apache/flink/connector/hbase2/HBaseDynamicTableFactoryTest.java
@@ -249,6 +249,19 @@ public class HBaseDynamicTableFactoryTest {
     }
 
     @Test
+    public void testSkipWalOptions() {
+        Map<String, String> options = getAllOptions();
+        options.put("sink.skip-wal", "true");
+
+        ResolvedSchema schema = ResolvedSchema.of(Column.physical(ROWKEY, STRING()));
+
+        DynamicTableSink sink = createTableSink(schema, options);
+        assertTrue(sink instanceof HBaseDynamicTableSink);
+        HBaseDynamicTableSink hbaseSink = (HBaseDynamicTableSink) sink;
+        assertTrue(hbaseSink.getWriteOptions().getSkipWal());
+    }
+
+    @Test
     public void testLookupOptions() {
         Map<String, String> options = getAllOptions();
         options.put("lookup.cache.max-rows", "1000");

--- a/flink-connectors/flink-connector-hbase-base/src/main/java/org/apache/flink/connector/hbase/options/HBaseWriteOptions.java
+++ b/flink-connectors/flink-connector-hbase-base/src/main/java/org/apache/flink/connector/hbase/options/HBaseWriteOptions.java
@@ -35,16 +35,19 @@ public class HBaseWriteOptions implements Serializable {
     private final long bufferFlushMaxRows;
     private final long bufferFlushIntervalMillis;
     private final Integer parallelism;
+    private final boolean skipWal;
 
     private HBaseWriteOptions(
             long bufferFlushMaxSizeInBytes,
             long bufferFlushMaxMutations,
             long bufferFlushIntervalMillis,
-            Integer parallelism) {
+            Integer parallelism,
+            boolean skipWal) {
         this.bufferFlushMaxSizeInBytes = bufferFlushMaxSizeInBytes;
         this.bufferFlushMaxRows = bufferFlushMaxMutations;
         this.bufferFlushIntervalMillis = bufferFlushIntervalMillis;
         this.parallelism = parallelism;
+        this.skipWal = skipWal;
     }
 
     public long getBufferFlushMaxSizeInBytes() {
@@ -63,6 +66,10 @@ public class HBaseWriteOptions implements Serializable {
         return parallelism;
     }
 
+    public boolean getSkipWal() {
+        return skipWal;
+    }
+
     @Override
     public String toString() {
         return "HBaseWriteOptions{"
@@ -74,6 +81,8 @@ public class HBaseWriteOptions implements Serializable {
                 + bufferFlushIntervalMillis
                 + ", parallelism="
                 + parallelism
+                + ", skipWal="
+                + skipWal
                 + '}';
     }
 
@@ -89,7 +98,8 @@ public class HBaseWriteOptions implements Serializable {
         return bufferFlushMaxSizeInBytes == that.bufferFlushMaxSizeInBytes
                 && bufferFlushMaxRows == that.bufferFlushMaxRows
                 && bufferFlushIntervalMillis == that.bufferFlushIntervalMillis
-                && parallelism == that.parallelism;
+                && parallelism == that.parallelism
+                && skipWal == that.skipWal;
     }
 
     @Override
@@ -98,7 +108,8 @@ public class HBaseWriteOptions implements Serializable {
                 bufferFlushMaxSizeInBytes,
                 bufferFlushMaxRows,
                 bufferFlushIntervalMillis,
-                parallelism);
+                parallelism,
+                skipWal);
     }
 
     /** Creates a builder for {@link HBaseWriteOptions}. */
@@ -113,6 +124,7 @@ public class HBaseWriteOptions implements Serializable {
         private long bufferFlushMaxRows = 0;
         private long bufferFlushIntervalMillis = 0;
         private Integer parallelism;
+        private boolean skipWal;
 
         /**
          * Optional. Sets when to flush a buffered request based on the memory size of rows
@@ -151,13 +163,23 @@ public class HBaseWriteOptions implements Serializable {
             return this;
         }
 
+        /**
+         * Optional. Indicates whether to skip HBase Write Ahead Log (WAL) when write records.
+         * Default to <code>false</code>, i.e. don't skip WAL.
+         */
+        public Builder setSkipWal(boolean skipWal) {
+            this.skipWal = skipWal;
+            return this;
+        }
+
         /** Creates a new instance of {@link HBaseWriteOptions}. */
         public HBaseWriteOptions build() {
             return new HBaseWriteOptions(
                     bufferFlushMaxSizeInBytes,
                     bufferFlushMaxRows,
                     bufferFlushIntervalMillis,
-                    parallelism);
+                    parallelism,
+                    skipWal);
         }
     }
 }

--- a/flink-connectors/flink-connector-hbase-base/src/main/java/org/apache/flink/connector/hbase/table/HBaseConnectorOptions.java
+++ b/flink-connectors/flink-connector-hbase-base/src/main/java/org/apache/flink/connector/hbase/table/HBaseConnectorOptions.java
@@ -87,6 +87,16 @@ public class HBaseConnectorOptions {
                                     + "Can be set to '0' to disable it. Note, both 'sink.buffer-flush.max-size' and 'sink.buffer-flush.max-rows' "
                                     + "can be set to '0' with the flush interval set allowing for complete async processing of buffered actions.");
 
+    public static final ConfigOption<Boolean> SINK_SKIP_WAL =
+            ConfigOptions.key("sink.skip-wal")
+                    .booleanType()
+                    .defaultValue(false)
+                    .withDescription(
+                            "Writing option, indicates whether to disable HBase WAL. "
+                                    + "This can improve performance for writing data to HBase database. "
+                                    + "However, disabling the WAL puts the data at risk. "
+                                    + "The only situation where this is recommended is during a bulk loading.");
+
     public static final ConfigOption<Boolean> LOOKUP_ASYNC =
             ConfigOptions.key("lookup.async")
                     .booleanType()

--- a/flink-connectors/flink-connector-hbase-base/src/main/java/org/apache/flink/connector/hbase/table/HBaseConnectorOptionsUtil.java
+++ b/flink-connectors/flink-connector-hbase-base/src/main/java/org/apache/flink/connector/hbase/table/HBaseConnectorOptionsUtil.java
@@ -37,6 +37,7 @@ import static org.apache.flink.connector.hbase.table.HBaseConnectorOptions.SINK_
 import static org.apache.flink.connector.hbase.table.HBaseConnectorOptions.SINK_BUFFER_FLUSH_MAX_ROWS;
 import static org.apache.flink.connector.hbase.table.HBaseConnectorOptions.SINK_BUFFER_FLUSH_MAX_SIZE;
 import static org.apache.flink.connector.hbase.table.HBaseConnectorOptions.SINK_PARALLELISM;
+import static org.apache.flink.connector.hbase.table.HBaseConnectorOptions.SINK_SKIP_WAL;
 import static org.apache.flink.connector.hbase.table.HBaseConnectorOptions.ZOOKEEPER_QUORUM;
 import static org.apache.flink.connector.hbase.table.HBaseConnectorOptions.ZOOKEEPER_ZNODE_PARENT;
 
@@ -92,6 +93,7 @@ public class HBaseConnectorOptionsUtil {
         builder.setBufferFlushMaxSizeInBytes(
                 tableOptions.get(SINK_BUFFER_FLUSH_MAX_SIZE).getBytes());
         builder.setParallelism(tableOptions.getOptional(SINK_PARALLELISM).orElse(null));
+        builder.setSkipWal(tableOptions.getOptional(SINK_SKIP_WAL).orElse(false));
         return builder.build();
     }
 


### PR DESCRIPTION
<!--
*Thank you very much for contributing to Apache Flink - we are happy that you want to help us improve Flink. To help the community review your contribution in the best possible way, please go through the checklist below, which will get the contribution into a shape in which it can be best reviewed.*

*Please understand that we do not do this to make contributions to Flink a hassle. In order to uphold a high standard of quality for code contributions, while at the same time managing a large number of contributions, we need contributors to prepare the contributions well, and give reviewers enough contextual information for the review. Please also understand that contributions that do not follow this guide will take longer to review and thus typically be picked up with lower priority by the community.*

## Contribution Checklist

  - Make sure that the pull request corresponds to a [JIRA issue](https://issues.apache.org/jira/projects/FLINK/issues). Exceptions are made for typos in JavaDoc or documentation files, which need no JIRA issue.
  
  - Name the pull request in the form "[FLINK-XXXX] [component] Title of the pull request", where *FLINK-XXXX* should be replaced by the actual issue number. Skip *component* if you are unsure about which is the best component.
  Typo fixes that have no associated JIRA issue should be named following this pattern: `[hotfix] [docs] Fix typo in event time introduction` or `[hotfix] [javadocs] Expand JavaDoc for PuncuatedWatermarkGenerator`.

  - Fill out the template below to describe the changes contributed by the pull request. That will give reviewers the context they need to do the review.
  
  - Make sure that the change passes the automated tests, i.e., `mvn clean verify` passes. You can set up Azure Pipelines CI to do that following [this guide](https://cwiki.apache.org/confluence/display/FLINK/Azure+Pipelines#AzurePipelines-Tutorial:SettingupAzurePipelinesforaforkoftheFlinkrepository).

  - Each pull request should address only one issue, not mix up code from multiple issues.
  
  - Each commit in the pull request has a meaningful commit message (including the JIRA id)

  - Once all items of the checklist are addressed, remove the above text and this checklist, leaving only the filled out template below.


**(The sections below can be removed for hotfixes of typos)**
-->

## What is the purpose of the change

It is possible to disable the HBase WAL, to improve performance in certain specific situations. The WAL is disabled by calling the HBase client field `Mutation.writeToWAL(false)`. Use the `Mutation.setDurability(Durability.SKIP_WAL)` and `Mutation.getDurability()` methods to set and get the field’s value. 

But HBase can only use API to skip WAL, and cannot use `properties.*` configuration items. So we need to add an additional sink option.

## Brief change log

- Add a sink option `sink.skip-wal` in `HBaseConnectorOptions`
- Modify the `HBaseSinkFunction` to use the `sink.skip-wal`
- Add `sink.skip-wal` in document and Chinese translation.


## Verifying this change

This change added tests and can be verified as follows:

- Add unit test in `HBaseDynamicTableFactoryTest` both for module `flink-connector-hbase-1.4` and `flink-connector-hbase-2.2`
- End-to-end testing can be done by adding `sink.skip-wal` to the DDL statement and monitoring HBase WAL 

## Does this pull request potentially affect one of the following parts:

  - Dependencies (does it add or upgrade a dependency): no
  - The public API, i.e., is any changed class annotated with `@Public(Evolving)`: yes
  - The serializers: no
  - The runtime per-record code paths (performance sensitive): no
  - Anything that affects deployment or recovery: JobManager (and its components), Checkpointing, Kubernetes/Yarn, ZooKeeper: no
  - The S3 file system connector: no

## Documentation

  - Does this pull request introduce a new feature? yes
  - If yes, how is the feature documented? docs
