### PR TITLE
[FLINK-22198][connector/kafka] Redirect KafkaContainer output to log4j and print debug log if test hangs

### DIFF
--- a/flink-connectors/flink-connector-kafka/src/test/java/org/apache/flink/streaming/connectors/kafka/table/KafkaTableTestBase.java
+++ b/flink-connectors/flink-connector-kafka/src/test/java/org/apache/flink/streaming/connectors/kafka/table/KafkaTableTestBase.java
@@ -145,7 +145,7 @@ public abstract class KafkaTableTestBase extends AbstractTestBase {
 
     // ------------------------ For Debug Logging Purpose ----------------------------------
 
-    protected void scheduleTimeoutLogger(Duration period, Runnable loggingAction) {
+    private void scheduleTimeoutLogger(Duration period, Runnable loggingAction) {
         TimerTask timeoutLoggerTask =
                 new TimerTask() {
                     @Override
@@ -160,11 +160,11 @@ public abstract class KafkaTableTestBase extends AbstractTestBase {
         loggingTimer.schedule(timeoutLoggerTask, 0L, period.toMillis());
     }
 
-    protected void cancelTimeoutLogger() {
+    private void cancelTimeoutLogger() {
         loggingTimer.cancel();
     }
 
-    protected Map<String, TopicDescription> describeExternalTopics() {
+    private Map<String, TopicDescription> describeExternalTopics() {
         final AdminClient adminClient = AdminClient.create(getStandardProps());
         try {
             final List<String> topics =
@@ -179,7 +179,7 @@ public abstract class KafkaTableTestBase extends AbstractTestBase {
         }
     }
 
-    protected void logTopicPartitionStatus(Map<String, TopicDescription> topicDescriptions) {
+    private void logTopicPartitionStatus(Map<String, TopicDescription> topicDescriptions) {
         final Properties properties = getStandardProps();
         properties.setProperty(ConsumerConfig.GROUP_ID_CONFIG, "flink-tests-debugging");
         properties.setProperty(

--- a/flink-connectors/flink-connector-kafka/src/test/java/org/apache/flink/streaming/connectors/kafka/table/KafkaTableTestBase.java
+++ b/flink-connectors/flink-connector-kafka/src/test/java/org/apache/flink/streaming/connectors/kafka/table/KafkaTableTestBase.java
@@ -27,19 +27,37 @@ import org.apache.flink.util.DockerImageVersions;
 import org.apache.kafka.clients.CommonClientConfigs;
 import org.apache.kafka.clients.admin.AdminClient;
 import org.apache.kafka.clients.admin.NewTopic;
+import org.apache.kafka.clients.admin.TopicDescription;
+import org.apache.kafka.clients.admin.TopicListing;
+import org.apache.kafka.clients.consumer.ConsumerConfig;
+import org.apache.kafka.clients.consumer.KafkaConsumer;
+import org.apache.kafka.common.TopicPartition;
+import org.apache.kafka.common.serialization.StringDeserializer;
+import org.junit.After;
 import org.junit.Before;
 import org.junit.ClassRule;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 import org.testcontainers.containers.KafkaContainer;
 import org.testcontainers.containers.Network;
+import org.testcontainers.containers.output.Slf4jLogConsumer;
 import org.testcontainers.utility.DockerImageName;
 
+import java.time.Duration;
+import java.util.ArrayList;
 import java.util.Collections;
 import java.util.HashMap;
+import java.util.List;
 import java.util.Map;
 import java.util.Properties;
+import java.util.Timer;
+import java.util.TimerTask;
+import java.util.stream.Collectors;
 
 /** Base class for Kafka Table IT Cases. */
 public abstract class KafkaTableTestBase extends AbstractTestBase {
+
+    private static final Logger LOG = LoggerFactory.getLogger(KafkaTableTestBase.class);
 
     private static final String INTER_CONTAINER_KAFKA_ALIAS = "kafka";
     private static final Network NETWORK = Network.newNetwork();
@@ -47,19 +65,48 @@ public abstract class KafkaTableTestBase extends AbstractTestBase {
 
     @ClassRule
     public static final KafkaContainer KAFKA_CONTAINER =
-            new KafkaContainer(DockerImageName.parse(DockerImageVersions.KAFKA))
-                    .withEmbeddedZookeeper()
+            new KafkaContainer(DockerImageName.parse(DockerImageVersions.KAFKA)) {
+                @Override
+                protected void doStart() {
+                    super.doStart();
+                    if (LOG.isInfoEnabled()) {
+                        this.followOutput(new Slf4jLogConsumer(LOG));
+                    }
+                }
+            }.withEmbeddedZookeeper()
                     .withNetwork(NETWORK)
                     .withNetworkAliases(INTER_CONTAINER_KAFKA_ALIAS);
 
     protected StreamExecutionEnvironment env;
     protected StreamTableEnvironment tEnv;
 
+    // Timer for scheduling logging task if the test hangs
+    private final Timer loggingTimer = new Timer("Debug Logging Timer");
+
     @Before
     public void setup() {
         env = StreamExecutionEnvironment.getExecutionEnvironment();
         tEnv = StreamTableEnvironment.create(env);
         env.getConfig().setRestartStrategy(RestartStrategies.noRestart());
+
+        // Probe Kafka broker status per 30 seconds
+        scheduleTimeoutLogger(
+                Duration.ofSeconds(30),
+                () -> {
+                    // List all non-internal topics
+                    final Map<String, TopicDescription> topicDescriptions =
+                            describeExternalTopics();
+                    LOG.info("Current existing topics: {}", topicDescriptions.keySet());
+
+                    // Log status of topics
+                    logTopicPartitionStatus(topicDescriptions);
+                });
+    }
+
+    @After
+    public void after() {
+        // Cancel timer for debug logging
+        cancelTimeoutLogger();
     }
 
     public Properties getStandardProps() {
@@ -94,5 +141,72 @@ public abstract class KafkaTableTestBase extends AbstractTestBase {
         try (AdminClient admin = AdminClient.create(properties)) {
             admin.deleteTopics(Collections.singletonList(topic));
         }
+    }
+
+    // ------------------------ For Debug Logging Purpose ----------------------------------
+
+    protected void scheduleTimeoutLogger(Duration period, Runnable loggingAction) {
+        TimerTask timeoutLoggerTask =
+                new TimerTask() {
+                    @Override
+                    public void run() {
+                        try {
+                            loggingAction.run();
+                        } catch (Exception e) {
+                            throw new RuntimeException("Failed to execute logging action", e);
+                        }
+                    }
+                };
+        loggingTimer.schedule(timeoutLoggerTask, 0L, period.toMillis());
+    }
+
+    protected void cancelTimeoutLogger() {
+        loggingTimer.cancel();
+    }
+
+    protected Map<String, TopicDescription> describeExternalTopics() {
+        final AdminClient adminClient = AdminClient.create(getStandardProps());
+        try {
+            final List<String> topics =
+                    adminClient.listTopics().listings().get().stream()
+                            .filter(listing -> !listing.isInternal())
+                            .map(TopicListing::name)
+                            .collect(Collectors.toList());
+
+            return adminClient.describeTopics(topics).all().get();
+        } catch (Exception e) {
+            throw new RuntimeException("Failed to list Kafka topics", e);
+        }
+    }
+
+    protected void logTopicPartitionStatus(Map<String, TopicDescription> topicDescriptions) {
+        final Properties properties = getStandardProps();
+        properties.setProperty(ConsumerConfig.GROUP_ID_CONFIG, "flink-tests-debugging");
+        properties.setProperty(
+                ConsumerConfig.KEY_DESERIALIZER_CLASS_CONFIG,
+                StringDeserializer.class.getCanonicalName());
+        properties.setProperty(
+                ConsumerConfig.VALUE_DESERIALIZER_CLASS_CONFIG,
+                StringDeserializer.class.getCanonicalName());
+        final KafkaConsumer<?, ?> consumer = new KafkaConsumer<String, String>(properties);
+        List<TopicPartition> partitions = new ArrayList<>();
+        topicDescriptions.forEach(
+                (topic, description) ->
+                        description
+                                .partitions()
+                                .forEach(
+                                        tpInfo ->
+                                                partitions.add(
+                                                        new TopicPartition(
+                                                                topic, tpInfo.partition()))));
+        final Map<TopicPartition, Long> beginningOffsets = consumer.beginningOffsets(partitions);
+        final Map<TopicPartition, Long> endOffsets = consumer.endOffsets(partitions);
+        partitions.forEach(
+                partition ->
+                        LOG.info(
+                                "TopicPartition \"{}\": starting offset: {}, stopping offset: {}",
+                                partition,
+                                beginningOffsets.get(partition),
+                                endOffsets.get(partition)));
     }
 }


### PR DESCRIPTION
## What is the purpose of the change

This pull request adds more logging utils for ```KafkaTableTestBase``` in order to reveal more information if test hangs.

## Brief change log
- Redirect KafkaContainer's STDOUT and STDERR to log4j
- Add debugging log if the test hangs for 5 minutes

## Verifying this change
This change is a trivial rework / code cleanup without any test coverage.

## Does this pull request potentially affect one of the following parts:

  - Dependencies (does it add or upgrade a dependency): (no)
  - The public API, i.e., is any changed class annotated with `@Public(Evolving)`: (no)
  - The serializers: (no)
  - The runtime per-record code paths (performance sensitive): (no)
  - Anything that affects deployment or recovery: JobManager (and its components), Checkpointing, Kubernetes/Yarn, ZooKeeper: (no)
  - The S3 file system connector: (no)

## Documentation

  - Does this pull request introduce a new feature? (no)
  - If yes, how is the feature documented? (not applicable)
