### PR TITLE
[FLINK-23842][coordination] Add logging statements in SourceCoordinators for reader registration and split requests.

### DIFF
--- a/flink-runtime/src/main/java/org/apache/flink/runtime/source/coordinator/SourceCoordinator.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/source/coordinator/SourceCoordinator.java
@@ -161,13 +161,24 @@ public class SourceCoordinator<SplitT extends SourceSplit, EnumChkT>
                             operatorName,
                             event);
                     if (event instanceof RequestSplitEvent) {
+                        LOG.info(
+                                "Source {} received split request from parallel task {}",
+                                operatorName,
+                                subtask);
                         enumerator.handleSplitRequest(
                                 subtask, ((RequestSplitEvent) event).hostName());
                     } else if (event instanceof SourceEventWrapper) {
                         enumerator.handleSourceEvent(
                                 subtask, ((SourceEventWrapper) event).getSourceEvent());
                     } else if (event instanceof ReaderRegistrationEvent) {
-                        handleReaderRegistrationEvent((ReaderRegistrationEvent) event);
+                        final ReaderRegistrationEvent registrationEvent =
+                                (ReaderRegistrationEvent) event;
+                        LOG.info(
+                                "Source {} registering reader for parallel task {} @ {}",
+                                operatorName,
+                                subtask,
+                                registrationEvent.location());
+                        handleReaderRegistrationEvent(registrationEvent);
                     } else {
                         throw new FlinkException("Unrecognized Operator Event: " + event);
                     }


### PR DESCRIPTION
## What is the purpose of the change

Previously, there were no log statements when source enumerators get reader registration events, or when they receive split requests.

While some specific source implementations log this in their implementation, for the general case, this information were missing, even though it is super valuable when debugging and understanding the work assignment behavior.

This PR adds these log statements.

Main question to consider during the review: Would the log volume be too high?

  - For reader registration logging: Upon full failover in streaming, up to as many log lines as parallelism on recovery when readers register again.
  - For split request: For streaming, one line per initial split request, typically few requests after that. For batch, one line per each split request over time.