### PR TITLE
[FLINK-23773][connector/kafka] Mark empty splits as finished to cleanup states in SplitFetcher

### DIFF
--- a/flink-connectors/flink-connector-base/src/main/java/org/apache/flink/connector/base/source/reader/SingleThreadMultiplexSourceReaderBase.java
+++ b/flink-connectors/flink-connector-base/src/main/java/org/apache/flink/connector/base/source/reader/SingleThreadMultiplexSourceReaderBase.java
@@ -26,7 +26,6 @@ import org.apache.flink.connector.base.source.reader.fetcher.SingleThreadFetcher
 import org.apache.flink.connector.base.source.reader.splitreader.SplitReader;
 import org.apache.flink.connector.base.source.reader.synchronization.FutureCompletingBlockingQueue;
 
-import java.util.Collection;
 import java.util.function.Supplier;
 
 /**
@@ -47,7 +46,7 @@ import java.util.function.Supplier;
  *   <li>The class must override the methods to convert back and forth between the immutable splits
  *       ({@code SplitT}) and the mutable split state representation ({@code SplitStateT}).
  *   <li>Finally, the reader must decide what to do when it starts ({@link #start()}) or when a
- *       split is finished ({@link #onSplitFinished(Collection)}).
+ *       split is finished ({@link #onSplitFinished(java.util.Map)}).
  * </ul>
  *
  * @param <E> The type of the records (the raw type that typically contains checkpointing

--- a/flink-connectors/flink-connector-base/src/main/java/org/apache/flink/connector/base/source/reader/fetcher/SingleThreadFetcherManager.java
+++ b/flink-connectors/flink-connector-base/src/main/java/org/apache/flink/connector/base/source/reader/fetcher/SingleThreadFetcherManager.java
@@ -18,13 +18,16 @@
 
 package org.apache.flink.connector.base.source.reader.fetcher;
 
+import org.apache.flink.annotation.VisibleForTesting;
 import org.apache.flink.api.connector.source.SourceSplit;
 import org.apache.flink.connector.base.source.reader.RecordsWithSplitIds;
 import org.apache.flink.connector.base.source.reader.SourceReaderBase;
 import org.apache.flink.connector.base.source.reader.splitreader.SplitReader;
 import org.apache.flink.connector.base.source.reader.synchronization.FutureCompletingBlockingQueue;
 
+import java.util.Collection;
 import java.util.List;
+import java.util.function.Consumer;
 import java.util.function.Supplier;
 
 /**
@@ -52,6 +55,24 @@ public class SingleThreadFetcherManager<E, SplitT extends SourceSplit>
             FutureCompletingBlockingQueue<RecordsWithSplitIds<E>> elementsQueue,
             Supplier<SplitReader<E, SplitT>> splitReaderSupplier) {
         super(elementsQueue, splitReaderSupplier);
+    }
+
+    /**
+     * Creates a new SplitFetcherManager with a single I/O threads.
+     *
+     * @param elementsQueue The queue that is used to hand over data from the I/O thread (the
+     *     fetchers) to the reader (which emits the records and book-keeps the state. This must be
+     *     the same queue instance that is also passed to the {@link SourceReaderBase}.
+     * @param splitReaderSupplier The factory for the split reader that connects to the source
+     *     system.
+     * @param splitFinishedHook Hook for handling finished splits in split fetchers
+     */
+    @VisibleForTesting
+    public SingleThreadFetcherManager(
+            FutureCompletingBlockingQueue<RecordsWithSplitIds<E>> elementsQueue,
+            Supplier<SplitReader<E, SplitT>> splitReaderSupplier,
+            Consumer<Collection<String>> splitFinishedHook) {
+        super(elementsQueue, splitReaderSupplier, splitFinishedHook);
     }
 
     @Override

--- a/flink-connectors/flink-connector-base/src/main/java/org/apache/flink/connector/base/source/reader/fetcher/SplitFetcher.java
+++ b/flink-connectors/flink-connector-base/src/main/java/org/apache/flink/connector/base/source/reader/fetcher/SplitFetcher.java
@@ -28,6 +28,7 @@ import org.slf4j.LoggerFactory;
 
 import javax.annotation.concurrent.GuardedBy;
 
+import java.util.Collection;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
@@ -69,8 +70,8 @@ public class SplitFetcher<E, SplitT extends SourceSplit> implements Runnable {
             FutureCompletingBlockingQueue<RecordsWithSplitIds<E>> elementsQueue,
             SplitReader<E, SplitT> splitReader,
             Consumer<Throwable> errorHandler,
-            Runnable shutdownHook) {
-
+            Runnable shutdownHook,
+            Consumer<Collection<String>> splitFinishedHook) {
         this.id = id;
         this.taskQueue = new LinkedBlockingDeque<>();
         this.elementsQueue = elementsQueue;
@@ -88,6 +89,7 @@ public class SplitFetcher<E, SplitT extends SourceSplit> implements Runnable {
                         elementsQueue,
                         ids -> {
                             ids.forEach(assignedSplits::remove);
+                            splitFinishedHook.accept(ids);
                             LOG.info("Finished reading from splits {}", ids);
                         },
                         id);

--- a/flink-connectors/flink-connector-base/src/test/java/org/apache/flink/connector/base/source/reader/fetcher/SplitFetcherTest.java
+++ b/flink-connectors/flink-connector-base/src/test/java/org/apache/flink/connector/base/source/reader/fetcher/SplitFetcherTest.java
@@ -182,7 +182,8 @@ public class SplitFetcherTest {
                                 .setBlockingFetch(true)
                                 .build(),
                         ExceptionUtils::rethrow,
-                        () -> {});
+                        () -> {},
+                        (ignore) -> {});
 
         // Prepare the splits.
         List<MockSourceSplit> splits = new ArrayList<>();
@@ -271,7 +272,8 @@ public class SplitFetcherTest {
     private static <E> SplitFetcher<E, TestingSourceSplit> createFetcher(
             final SplitReader<E, TestingSourceSplit> reader,
             final FutureCompletingBlockingQueue<RecordsWithSplitIds<E>> queue) {
-        return new SplitFetcher<>(0, queue, reader, ExceptionUtils::rethrow, () -> {});
+        return new SplitFetcher<>(
+                0, queue, reader, ExceptionUtils::rethrow, () -> {}, (ignore) -> {});
     }
 
     private static <E> SplitFetcher<E, TestingSourceSplit> createFetcherWithSplit(

--- a/flink-connectors/flink-connector-kafka/src/main/java/org/apache/flink/connector/kafka/source/reader/KafkaPartitionSplitReader.java
+++ b/flink-connectors/flink-connector-kafka/src/main/java/org/apache/flink/connector/kafka/source/reader/KafkaPartitionSplitReader.java
@@ -57,6 +57,7 @@ import java.util.Map;
 import java.util.Properties;
 import java.util.Set;
 import java.util.StringJoiner;
+import java.util.stream.Collectors;
 
 /**
  * A {@link SplitReader} implementation that reads records from Kafka partitions.
@@ -78,6 +79,9 @@ public class KafkaPartitionSplitReader<T>
     private final int subtaskId;
 
     private final KafkaSourceReaderMetrics kafkaSourceReaderMetrics;
+
+    // Tracking empty splits that has not been added to finished splits in fetch()
+    private final Set<String> emptySplits = new HashSet<>();
 
     public KafkaPartitionSplitReader(
             Properties props,
@@ -182,6 +186,14 @@ public class KafkaPartitionSplitReader<T>
             // Track this partition's record lag if it never appears before
             kafkaSourceReaderMetrics.maybeAddRecordsLagMetric(consumer, tp);
         }
+
+        // Some splits are discovered as empty when handling split additions. These splits should be
+        // added to finished splits to clean up states in split fetcher and source reader.
+        if (!emptySplits.isEmpty()) {
+            recordsBySplits.finishedSplits.addAll(emptySplits);
+            emptySplits.clear();
+        }
+
         // Unassign the partitions that has finished.
         if (!finishedPartitions.isEmpty()) {
             finishedPartitions.forEach(kafkaSourceReaderMetrics::removeRecordsLagMetric);
@@ -355,15 +367,24 @@ public class KafkaPartitionSplitReader<T>
     }
 
     private void removeEmptySplits() {
-        List<TopicPartition> emptySplits = new ArrayList<>();
+        List<TopicPartition> emptyPartitions = new ArrayList<>();
         // If none of the partitions have any records,
         for (TopicPartition tp : consumer.assignment()) {
             if (consumer.position(tp) >= getStoppingOffset(tp)) {
-                emptySplits.add(tp);
+                emptyPartitions.add(tp);
             }
         }
-        if (!emptySplits.isEmpty()) {
-            unassignPartitions(emptySplits);
+        if (!emptyPartitions.isEmpty()) {
+            LOG.debug(
+                    "These assigning splits are empty and will be marked as finished in later fetch: {}",
+                    emptyPartitions);
+            // Add empty partitions to empty split set for later cleanup in fetch()
+            emptySplits.addAll(
+                    emptyPartitions.stream()
+                            .map(KafkaPartitionSplit::toSplitId)
+                            .collect(Collectors.toSet()));
+            // Un-assign partitions from Kafka consumer
+            unassignPartitions(emptyPartitions);
         }
     }
 
@@ -379,7 +400,7 @@ public class KafkaPartitionSplitReader<T>
                                 "[%s, start:%d, stop: %d]",
                                 split.getTopicPartition(), startingOffset, stoppingOffset));
             }
-            LOG.debug("SplitsChange handling result: {}", splitsInfo.toString());
+            LOG.debug("SplitsChange handling result: {}", splitsInfo);
         }
     }
 

--- a/flink-connectors/flink-connector-kafka/src/main/java/org/apache/flink/connector/kafka/source/reader/KafkaSourceReader.java
+++ b/flink-connectors/flink-connector-kafka/src/main/java/org/apache/flink/connector/kafka/source/reader/KafkaSourceReader.java
@@ -44,7 +44,6 @@ import java.util.SortedMap;
 import java.util.TreeMap;
 import java.util.concurrent.ConcurrentHashMap;
 import java.util.concurrent.ConcurrentMap;
-import java.util.function.Supplier;
 
 /** The source reader for Kafka partitions. */
 public class KafkaSourceReader<T>
@@ -59,17 +58,12 @@ public class KafkaSourceReader<T>
 
     public KafkaSourceReader(
             FutureCompletingBlockingQueue<RecordsWithSplitIds<Tuple3<T, Long, Long>>> elementsQueue,
-            Supplier<KafkaPartitionSplitReader<T>> splitReaderSupplier,
+            KafkaSourceFetcherManager<T> kafkaSourceFetcherManager,
             RecordEmitter<Tuple3<T, Long, Long>, T, KafkaPartitionSplitState> recordEmitter,
             Configuration config,
             SourceReaderContext context,
             KafkaSourceReaderMetrics kafkaSourceReaderMetrics) {
-        super(
-                elementsQueue,
-                new KafkaSourceFetcherManager<>(elementsQueue, splitReaderSupplier::get),
-                recordEmitter,
-                config,
-                context);
+        super(elementsQueue, kafkaSourceFetcherManager, recordEmitter, config, context);
         this.offsetsToCommit = Collections.synchronizedSortedMap(new TreeMap<>());
         this.offsetsOfFinishedSplits = new ConcurrentHashMap<>();
         this.kafkaSourceReaderMetrics = kafkaSourceReaderMetrics;

--- a/flink-connectors/flink-connector-kafka/src/main/java/org/apache/flink/connector/kafka/source/reader/fetcher/KafkaSourceFetcherManager.java
+++ b/flink-connectors/flink-connector-kafka/src/main/java/org/apache/flink/connector/kafka/source/reader/fetcher/KafkaSourceFetcherManager.java
@@ -36,7 +36,9 @@ import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
 import java.io.IOException;
+import java.util.Collection;
 import java.util.Map;
+import java.util.function.Consumer;
 import java.util.function.Supplier;
 
 /**
@@ -56,11 +58,13 @@ public class KafkaSourceFetcherManager<T>
      *     the same queue instance that is also passed to the {@link SourceReaderBase}.
      * @param splitReaderSupplier The factory for the split reader that connects to the source
      *     system.
+     * @param splitFinishedHook Hook for handling finished splits in split fetchers.
      */
     public KafkaSourceFetcherManager(
             FutureCompletingBlockingQueue<RecordsWithSplitIds<Tuple3<T, Long, Long>>> elementsQueue,
-            Supplier<SplitReader<Tuple3<T, Long, Long>, KafkaPartitionSplit>> splitReaderSupplier) {
-        super(elementsQueue, splitReaderSupplier);
+            Supplier<SplitReader<Tuple3<T, Long, Long>, KafkaPartitionSplit>> splitReaderSupplier,
+            Consumer<Collection<String>> splitFinishedHook) {
+        super(elementsQueue, splitReaderSupplier, splitFinishedHook);
     }
 
     public void commitOffsets(

--- a/flink-connectors/flink-connector-kafka/src/test/java/org/apache/flink/connector/kafka/source/KafkaSourceTestUtils.java
+++ b/flink-connectors/flink-connector-kafka/src/test/java/org/apache/flink/connector/kafka/source/KafkaSourceTestUtils.java
@@ -1,0 +1,47 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.flink.connector.kafka.source;
+
+import org.apache.flink.api.connector.source.SourceReaderContext;
+import org.apache.flink.connector.kafka.source.reader.KafkaSourceReader;
+
+import java.util.Collection;
+import java.util.function.Consumer;
+
+/** Utility class for testing {@link KafkaSource}. */
+public class KafkaSourceTestUtils {
+
+    /**
+     * Create {@link KafkaSourceReader} with a custom hook handling IDs of finished {@link
+     * org.apache.flink.connector.kafka.source.split.KafkaPartitionSplit}.
+     *
+     * @param kafkaSource Kafka source
+     * @param sourceReaderContext Context for SourceReader
+     * @param splitFinishedHook Hook for handling finished splits
+     * @param <T> Type of emitting records
+     */
+    public static <T> KafkaSourceReader<T> createReaderWithFinishedSplitHook(
+            KafkaSource<T> kafkaSource,
+            SourceReaderContext sourceReaderContext,
+            Consumer<Collection<String>> splitFinishedHook)
+            throws Exception {
+        return ((KafkaSourceReader<T>)
+                kafkaSource.createReader(sourceReaderContext, splitFinishedHook));
+    }
+}

--- a/flink-connectors/flink-connector-kafka/src/test/java/org/apache/flink/connector/kafka/source/reader/KafkaSourceReaderTest.java
+++ b/flink-connectors/flink-connector-kafka/src/test/java/org/apache/flink/connector/kafka/source/reader/KafkaSourceReaderTest.java
@@ -49,6 +49,8 @@ import org.apache.kafka.common.TopicPartition;
 import org.apache.kafka.common.serialization.IntegerDeserializer;
 import org.apache.kafka.common.serialization.IntegerSerializer;
 import org.apache.kafka.common.serialization.StringSerializer;
+import org.hamcrest.MatcherAssert;
+import org.hamcrest.Matchers;
 import org.junit.AfterClass;
 import org.junit.BeforeClass;
 import org.junit.Test;
@@ -58,9 +60,11 @@ import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.Collection;
 import java.util.Collections;
+import java.util.HashSet;
 import java.util.List;
 import java.util.Map;
 import java.util.Optional;
+import java.util.Set;
 import java.util.function.Consumer;
 import java.util.function.Supplier;
 
@@ -304,6 +308,41 @@ public class KafkaSourceReaderTest extends SourceReaderTestBase<KafkaPartitionSp
                             KAFKA_SOURCE_READER_METRIC_GROUP, COMMITS_SUCCEEDED_METRIC_COUNTER);
             assertTrue(commitsSucceeded.isPresent());
             assertEquals(1L, commitsSucceeded.get().getCount());
+        }
+    }
+
+    @Test
+    public void testAssigningEmptySplits() throws Exception {
+        // Normal split with NUM_RECORDS_PER_SPLIT records
+        final KafkaPartitionSplit normalSplit =
+                new KafkaPartitionSplit(
+                        new TopicPartition(TOPIC, 0), 0, KafkaPartitionSplit.LATEST_OFFSET);
+        // Empty split with no record
+        final KafkaPartitionSplit emptySplit =
+                new KafkaPartitionSplit(
+                        new TopicPartition(TOPIC, 1), NUM_RECORDS_PER_SPLIT, NUM_RECORDS_PER_SPLIT);
+        // Split finished hook for listening finished splits
+        final Set<String> finishedSplits = new HashSet<>();
+        final Consumer<Collection<String>> splitFinishedHook = finishedSplits::addAll;
+
+        try (final KafkaSourceReader<Integer> reader =
+                (KafkaSourceReader<Integer>)
+                        createReader(
+                                Boundedness.BOUNDED,
+                                "KafkaSourceReaderTestGroup",
+                                new TestingReaderContext(),
+                                splitFinishedHook)) {
+            reader.addSplits(Arrays.asList(normalSplit, emptySplit));
+            pollUntil(
+                    reader,
+                    new TestingReaderOutput<>(),
+                    () -> reader.getNumAliveFetchers() == 0,
+                    "The split fetcher did not exit before timeout.");
+            MatcherAssert.assertThat(
+                    finishedSplits,
+                    Matchers.containsInAnyOrder(
+                            KafkaPartitionSplit.toSplitId(normalSplit.getTopicPartition()),
+                            KafkaPartitionSplit.toSplitId(emptySplit.getTopicPartition())));
         }
     }
 


### PR DESCRIPTION
## What is the purpose of the change

This pull request fixes a bug that empty split is only unassigned from KafkaConsumer but not be cleaned up in SplitFetcher.


## Brief change log

- Add a set for tracking splits discovered empty at ```KafkaPartitionSplitReader#handleSplitsChanges```
- Mark empty splits in the set above as finished in ```KafkaPartitionSplitReader#fetch```


## Verifying this change
This change added tests and can be verified as follows:
- Assign an empty split to ```KafkaPartitionSplitReader``` 
- Make a fetch and check if the empty split is added to finished split in the returning ```RecordsWithSplitIds```

## Does this pull request potentially affect one of the following parts:

  - Dependencies (does it add or upgrade a dependency): (no)
  - The public API, i.e., is any changed class annotated with `@Public(Evolving)`: (no)
  - The serializers: (no)
  - The runtime per-record code paths (performance sensitive): (no)
  - Anything that affects deployment or recovery: JobManager (and its components), Checkpointing, Kubernetes/Yarn, ZooKeeper: (no)
  - The S3 file system connector: (no)

## Documentation

  - Does this pull request introduce a new feature? (no)
  - If yes, how is the feature documented? (not applicable)
