### PR TITLE
[FLINK-23757][python] Support json_exists and json_value

### DIFF
--- a/flink-python/pyflink/table/tests/test_expression.py
+++ b/flink-python/pyflink/table/tests/test_expression.py
@@ -18,7 +18,8 @@
 import unittest
 
 from pyflink.table import DataTypes
-from pyflink.table.expression import TimeIntervalUnit, TimePointUnit
+from pyflink.table.expression import TimeIntervalUnit, TimePointUnit, JsonExistsOnError, \
+    JsonValueOnEmptyOrError
 from pyflink.table.expressions import (col, lit, range_, and_, or_, current_date,
                                        current_time, current_timestamp, local_time,
                                        local_timestamp, temporal_overlaps, date_format,
@@ -190,6 +191,18 @@ class PyFlinkBatchExpressionTests(PyFlinkTestCase):
         self.assertEqual('sha384(a)', str(expr1.sha384))
         self.assertEqual('sha512(a)', str(expr1.sha512))
         self.assertEqual('sha2(a, 224)', str(expr1.sha2(224)))
+
+        # json functions
+        self.assertEqual("JSON_EXISTS('{}', '$.x')", str(lit('{}').json_exists('$.x')))
+        self.assertEqual("JSON_EXISTS('{}', '$.x', FALSE)",
+                         str(lit('{}').json_exists('$.x', JsonExistsOnError.FALSE)))
+
+        self.assertEqual("JSON_VALUE('{}', '$.x', STRING, NULL, null, NULL, null)",
+                         str(lit('{}').json_value('$.x')))
+        self.assertEqual("JSON_VALUE('{}', '$.x', INT, DEFAULT, 42, ERROR, null)",
+                         str(lit('{}').json_value('$.x', DataTypes.INT(),
+                                                  JsonValueOnEmptyOrError.DEFAULT, 42,
+                                                  JsonValueOnEmptyOrError.ERROR, None)))
 
     def test_expressions(self):
         expr1 = col('a')

--- a/flink-python/pyflink/table/tests/test_expression_completeness.py
+++ b/flink-python/pyflink/table/tests/test_expression_completeness.py
@@ -41,10 +41,6 @@ class ExpressionCompletenessTests(PythonAPICompletenessTestCase, PyFlinkTestCase
             'toExpr',
             'getChildren',
 
-            # The following methods need to be implemented still
-            'jsonExists',
-            'jsonValue',
-
             # The following methods have been replaced with the built-in methods in Python,
             # such as __and__ for and to be more Pythonic.
             'and',


### PR DESCRIPTION
## What is the purpose of the change

This supports `JSON_EXISTS` and `JSON_VALUE` for PyFlink.

## Verifying this change

This change added tests and can be verified as follows:

* `test_expression.py`
* `test_expression_completeness.py`

## Does this pull request potentially affect one of the following parts:

  - Dependencies (does it add or upgrade a dependency): no
  - The public API, i.e., is any changed class annotated with `@Public(Evolving)`: no (?)
  - The serializers: no
  - The runtime per-record code paths (performance sensitive): no
  - Anything that affects deployment or recovery: JobManager (and its components), Checkpointing, Kubernetes/Yarn, ZooKeeper: no
  - The S3 file system connector: no

## Documentation

  - Does this pull request introduce a new feature? "yes" (only exposure of an existing feature in PyFlink)
  - If yes, how is the feature documented? PyDocs
