### PR TITLE
[FLINK-23727][core] Skip null values in SimpleStringSchema#deserialize

### DIFF
--- a/flink-core/src/main/java/org/apache/flink/api/common/serialization/SimpleStringSchema.java
+++ b/flink-core/src/main/java/org/apache/flink/api/common/serialization/SimpleStringSchema.java
@@ -75,6 +75,9 @@ public class SimpleStringSchema
 
     @Override
     public String deserialize(byte[] message) {
+        if (message == null) {
+            return null;
+        }
         return new String(message, charset);
     }
 
@@ -85,6 +88,9 @@ public class SimpleStringSchema
 
     @Override
     public byte[] serialize(String element) {
+        if (element == null) {
+            return new byte[0];
+        }
         return element.getBytes(charset);
     }
 


### PR DESCRIPTION
## What is the purpose of the change

Fixe the issue that the resulting scale of TRUNCATE(DECIMAL, ...) is not correct.


## Brief change log

- flink-core/src/main/java/org/apache/flink/api/common/serialization/SimpleStringSchema.java
- flink-core/src/test/java/org/apache/flink/api/common/serialization/SimpleStringSchemaTest.java

## Verifying this change

This change added tests and can be verified as follows:

- Added more test cases in flink-core/src/test/java/org/apache/flink/api/common/serialization/SimpleStringSchemaTest.java


## Does this pull request potentially affect one of the following parts:

  - Dependencies (does it add or upgrade a dependency): no
  - The public API, i.e., is any changed class annotated with `@Public(Evolving)`: no
  - The serializers: no
  - The runtime per-record code paths (performance sensitive): no
  - Anything that affects deployment or recovery: JobManager (and its components), Checkpointing, Kubernetes/Yarn, ZooKeeper: no
  - The S3 file system connector: no

## Documentation

  - Does this pull request introduce a new feature? no
