### PR TITLE
[FLINK-23765][python] Fix the NPE in Python UDTF

### DIFF
--- a/flink-python/src/main/java/org/apache/flink/table/runtime/operators/python/table/PythonTableFunctionOperator.java
+++ b/flink-python/src/main/java/org/apache/flink/table/runtime/operators/python/table/PythonTableFunctionOperator.java
@@ -56,6 +56,15 @@ public class PythonTableFunctionOperator
     /** The TypeSerializer for udtf input elements. */
     private transient TypeSerializer<Row> udtfInputTypeSerializer;
 
+    /** The current input element which has not been received all python udtf results. */
+    private transient CRow input;
+
+    /** Whether the current input element has joined parts of python udtf results. */
+    private transient boolean hasJoined;
+
+    /** Whether the current received data is the finished result of the current input element. */
+    private transient boolean isFinishResult;
+
     public PythonTableFunctionOperator(
             Configuration config,
             PythonFunctionInfo tableFunction,
@@ -87,17 +96,21 @@ public class PythonTableFunctionOperator
                 PythonTypeUtils.toFlinkTypeSerializer(userDefinedFunctionOutputType);
         udtfInputTypeSerializer =
                 PythonTypeUtils.toFlinkTypeSerializer(userDefinedFunctionInputType);
+        input = null;
+        hasJoined = false;
+        isFinishResult = true;
     }
 
     @Override
     @SuppressWarnings("ConstantConditions")
     public void emitResult(Tuple2<byte[], Integer> resultTuple) throws Exception {
-        CRow input = forwardedInputQueue.poll();
         byte[] rawUdtfResult;
         int length;
-        boolean isFinishResult;
-        boolean hasJoined = false;
         Row udtfResult;
+        if (isFinishResult) {
+            input = forwardedInputQueue.poll();
+            hasJoined = false;
+        }
         do {
             rawUdtfResult = resultTuple.f0;
             length = resultTuple.f1;
@@ -117,7 +130,7 @@ public class PythonTableFunctionOperator
                 cRowWrapper.setChange(input.change());
                 cRowWrapper.collect(Row.join(input.row(), udtfResult));
             }
-        } while (!isFinishResult);
+        } while (!isFinishResult && resultTuple != null);
     }
 
     @Override

--- a/flink-python/src/main/java/org/apache/flink/table/runtime/operators/python/table/RowDataPythonTableFunctionOperator.java
+++ b/flink-python/src/main/java/org/apache/flink/table/runtime/operators/python/table/RowDataPythonTableFunctionOperator.java
@@ -64,6 +64,15 @@ public class RowDataPythonTableFunctionOperator
     /** The type serializer for the forwarded fields. */
     private transient RowDataSerializer forwardedInputSerializer;
 
+    /** The current input element which has not been received all python udtf results. */
+    private transient RowData input;
+
+    /** Whether the current input element has joined parts of python udtf results. */
+    private transient boolean hasJoined;
+
+    /** Whether the current received data is the finished result of the current input element. */
+    private transient boolean isFinishResult;
+
     public RowDataPythonTableFunctionOperator(
             Configuration config,
             PythonFunctionInfo tableFunction,
@@ -87,6 +96,9 @@ public class RowDataPythonTableFunctionOperator
                 PythonTypeUtils.toBlinkTypeSerializer(userDefinedFunctionInputType);
         udtfOutputTypeSerializer =
                 PythonTypeUtils.toBlinkTypeSerializer(userDefinedFunctionOutputType);
+        input = null;
+        hasJoined = false;
+        isFinishResult = true;
     }
 
     @Override
@@ -124,11 +136,12 @@ public class RowDataPythonTableFunctionOperator
     @Override
     @SuppressWarnings("ConstantConditions")
     public void emitResult(Tuple2<byte[], Integer> resultTuple) throws Exception {
-        RowData input = forwardedInputQueue.poll();
         byte[] rawUdtfResult;
         int length;
-        boolean isFinishResult;
-        boolean hasJoined = false;
+        if (isFinishResult) {
+            input = forwardedInputQueue.poll();
+            hasJoined = false;
+        }
         do {
             rawUdtfResult = resultTuple.f0;
             length = resultTuple.f1;
@@ -148,6 +161,6 @@ public class RowDataPythonTableFunctionOperator
                 }
                 rowDataWrapper.collect(reuseJoinedRow.replace(input, udtfResult));
             }
-        } while (!isFinishResult);
+        } while (!isFinishResult && resultTuple != null);
     }
 }


### PR DESCRIPTION
## What is the purpose of the change

*This pull request will fix the NPE in Python UDTF*


## Brief change log

  - *Change the logic of emitResult in Python Table Function Operator for facing parts of results have been received*

## Verifying this change

This change added tests and can be verified as follows:

  - *Original Java UT and python IT*

## Does this pull request potentially affect one of the following parts:

  - Dependencies (does it add or upgrade a dependency): (no)
  - The public API, i.e., is any changed class annotated with `@Public(Evolving)`: (no)
  - The serializers: (no)
  - The runtime per-record code paths (performance sensitive): (no)
  - Anything that affects deployment or recovery: JobManager (and its components), Checkpointing, Kubernetes/Yarn, ZooKeeper: (no)
  - The S3 file system connector: (no)

## Documentation

  - Does this pull request introduce a new feature? (no)
  - If yes, how is the feature documented? (not applicable)
