### PR TITLE
[FLINK-23868][Client] JobExecutionResult printed when suppressSysout is on

### DIFF
--- a/flink-clients/src/main/java/org/apache/flink/client/program/ContextEnvironment.java
+++ b/flink-clients/src/main/java/org/apache/flink/client/program/ContextEnvironment.java
@@ -115,7 +115,9 @@ public class ContextEnvironment extends ExecutionEnvironment {
             }
 
             jobExecutionResult = jobExecutionResultFuture.get();
-            System.out.println(jobExecutionResult);
+            if (!suppressSysout) {
+                System.out.println(jobExecutionResult);
+            }
         } else {
             jobExecutionResult = new DetachedJobExecutionResult(jobClient.getJobID());
         }

--- a/flink-clients/src/main/java/org/apache/flink/client/program/StreamContextEnvironment.java
+++ b/flink-clients/src/main/java/org/apache/flink/client/program/StreamContextEnvironment.java
@@ -121,7 +121,9 @@ public class StreamContextEnvironment extends StreamExecutionEnvironment {
             }
 
             jobExecutionResult = jobExecutionResultFuture.get();
-            System.out.println(jobExecutionResult);
+            if (!suppressSysout) {
+                System.out.println(jobExecutionResult);
+            }
         } else {
             jobExecutionResult = new DetachedJobExecutionResult(jobClient.getJobID());
         }


### PR DESCRIPTION
## What is the purpose of the change

Environments prints job execution results to stdout by default and provides a flag `suppressSysout` to disable the behavior. This flag is useful when submitting jobs through REST API or other programmatic approaches. However, JobExecutionResult is still printed when this flag is on, which looks like a bug to me.

## Brief change log

Skip printing JobExecutionResult if suppressSysout is on.

## Verifying this change

This change is a trivial rework/code cleanup without any test coverage.

## Does this pull request potentially affect one of the following parts:

  - Dependencies (does it add or upgrade a dependency): no
  - The public API, i.e., is any changed class annotated with `@Public(Evolving)`: yes 
  - The serializers: no 
  - The runtime per-record code paths (performance sensitive): no
  - Anything that affects deployment or recovery: JobManager (and its components), Checkpointing, Kubernetes/Yarn, ZooKeeper: no
  - The S3 file system connector: no

## Documentation

  - Does this pull request introduces a new feature?  no
  - If yes, how is the feature documented? (not applicable / docs / JavaDocs / not documented)
