### PR TITLE
[FLINK-23579][table-runtime] Fix compile exception in hash functions with varbinary arguments

### DIFF
--- a/flink-table/flink-table-planner-blink/src/test/scala/org/apache/flink/table/planner/expressions/ScalarFunctionsTest.scala
+++ b/flink-table/flink-table-planner-blink/src/test/scala/org/apache/flink/table/planner/expressions/ScalarFunctionsTest.scala
@@ -3666,6 +3666,29 @@ class ScalarFunctionsTest extends ScalarTypesTestBase {
       "sha2('test', f44)",
       "SHA2('test', f44)",
       expectedSha256)
+
+    // bytes test
+    testSqlApi("MD5(cast('test' as varbinary))", expectedMd5)
+    testSqlApi("SHA1(cast('test' as varbinary))", expectedSha1)
+    testSqlApi("SHA224(cast('test' as varbinary))", expectedSha224)
+    testSqlApi("SHA2(cast('test' as varbinary), 224)", expectedSha224)
+    testSqlApi("SHA256(cast('test' as varbinary))", expectedSha256)
+    testSqlApi("SHA2(cast('test' as varbinary), 256)", expectedSha256)
+    testSqlApi("SHA384(cast('test' as varbinary))", expectedSha384)
+    testSqlApi("SHA2(cast('test' as varbinary), 384)", expectedSha384)
+    testSqlApi("SHA512(cast('test' as varbinary))", expectedSha512)
+    testSqlApi("SHA2(cast('test' as varbinary), 512)", expectedSha512)
+
+    testSqlApi("MD5(cast(null as varbinary))", "null")
+    testSqlApi("SHA1(cast(null as varbinary))", "null")
+    testSqlApi("SHA224(cast(null as varbinary))", "null")
+    testSqlApi("SHA2(cast(null as varbinary), 224)", "null")
+    testSqlApi("SHA256(cast(null as varbinary))", "null")
+    testSqlApi("SHA2(cast(null as varbinary), 256)", "null")
+    testSqlApi("SHA384(cast(null as varbinary))", "null")
+    testSqlApi("SHA2(cast(null as varbinary), 384)", "null")
+    testSqlApi("SHA512(cast(null as varbinary))", "null")
+    testSqlApi("SHA2(cast(null as varbinary), 512)", "null")
   }
 
   // ----------------------------------------------------------------------------------------------

--- a/flink-table/flink-table-runtime-blink/src/main/java/org/apache/flink/table/data/binary/BinaryStringDataUtil.java
+++ b/flink-table/flink-table-runtime-blink/src/main/java/org/apache/flink/table/data/binary/BinaryStringDataUtil.java
@@ -152,9 +152,14 @@ public class BinaryStringDataUtil {
                 : (FALSE_STRINGS.contains(lowerCase) ? Boolean.FALSE : null);
     }
 
+    /** Calculate the hash value of the given bytes use {@link MessageDigest}. */
+    public static BinaryStringData hash(byte[] bytes, MessageDigest md) {
+        return fromString(EncodingUtils.hex(md.digest(bytes)));
+    }
+
     /** Calculate the hash value of a given string use {@link MessageDigest}. */
     public static BinaryStringData hash(BinaryStringData str, MessageDigest md) {
-        return fromString(EncodingUtils.hex(md.digest(str.toBytes())));
+        return hash(str.toBytes(), md);
     }
 
     public static BinaryStringData hash(BinaryStringData str, String algorithm)


### PR DESCRIPTION
(This PR is cherry-picked from #16718)

## What is the purpose of the change

Currently hash functions like `MD5`, `SHA2`, etc. fails to compile if the argument is a varbinary value. This PR fixes this issue.

## Brief change log

 - Fix compile exception in hash functions with varbinary arguments

## Verifying this change

This change added tests and can be verified by running the added tests.

## Does this pull request potentially affect one of the following parts:

  - Dependencies (does it add or upgrade a dependency): no
  - The public API, i.e., is any changed class annotated with `@Public(Evolving)`: no
  - The serializers: no
  - The runtime per-record code paths (performance sensitive): no
  - Anything that affects deployment or recovery: JobManager (and its components), Checkpointing, Kubernetes/Yarn, ZooKeeper: no
  - The S3 file system connector: no

## Documentation

  - Does this pull request introduce a new feature? no
  - If yes, how is the feature documented? not applicable
