### PR TITLE
[FLINK-23871][Runtime/Coordination]Dispatcher should handle finishing…

### DIFF
--- a/flink-runtime/src/main/java/org/apache/flink/runtime/jobmanager/OnCompletionActions.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/jobmanager/OnCompletionActions.java
@@ -31,9 +31,6 @@ public interface OnCompletionActions {
      */
     void jobReachedGloballyTerminalState(ExecutionGraphInfo executionGraphInfo);
 
-    /** Job was finished by another JobMaster. */
-    void jobFinishedByOther();
-
     /** The {@link JobMaster} failed while executing the job. */
     void jobMasterFailed(Throwable cause);
 }

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/jobmaster/DefaultJobMasterServiceProcess.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/jobmaster/DefaultJobMasterServiceProcess.java
@@ -215,15 +215,6 @@ public class DefaultJobMasterServiceProcess
     }
 
     @Override
-    public void jobFinishedByOther() {
-        LOG.debug(
-                "Job {} under leader id {} has been finished by another process.",
-                jobId,
-                leaderSessionId);
-        resultFuture.completeExceptionally(new JobNotFinishedException(jobId));
-    }
-
-    @Override
     public void jobMasterFailed(Throwable cause) {
         LOG.debug("Job {} under leader id {} failed.", jobId, leaderSessionId);
         resultFuture.completeExceptionally(cause);

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/jobmaster/JobAlreadyDoneException.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/jobmaster/JobAlreadyDoneException.java
@@ -1,0 +1,38 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.flink.runtime.jobmaster;
+
+import org.apache.flink.api.common.JobID;
+import org.apache.flink.runtime.JobException;
+
+/** Exception indicating that a Flink job failed in finishing phase. */
+class JobAlreadyDoneException extends JobException {
+    private static final long serialVersionUID = 5906282500322681417L;
+
+    JobAlreadyDoneException(JobID jobId) {
+        super(
+                "The job ("
+                        + jobId
+                        + ") has already terminated, but we cannot tell the final "
+                        + "state and also not serve the job result. This can happen if Flink "
+                        + "fails over shortly after finishing a job and before reporting "
+                        + "the result. Please check the output of your job to see whether the "
+                        + "execution was successful or not.");
+    }
+}

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/jobmaster/JobMasterServiceLeadershipRunner.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/jobmaster/JobMasterServiceLeadershipRunner.java
@@ -285,7 +285,12 @@ public class JobMasterServiceLeadershipRunner implements JobManagerRunner, Leade
     }
 
     private void jobAlreadyDone() {
-        resultFuture.completeExceptionally(new JobNotFinishedException(getJobID()));
+        resultFuture.complete(
+                JobManagerRunnerResult.forSuccess(
+                        new ExecutionGraphInfo(
+                                jobMasterServiceProcessFactory.createArchivedExecutionGraph(
+                                        JobStatus.FAILED,
+                                        new JobAlreadyDoneException(getJobID())))));
     }
 
     private RunningJobsRegistry.JobSchedulingStatus getJobSchedulingStatus() throws FlinkException {

--- a/flink-runtime/src/test/java/org/apache/flink/runtime/jobmaster/DefaultJobMasterServiceProcessTest.java
+++ b/flink-runtime/src/test/java/org/apache/flink/runtime/jobmaster/DefaultJobMasterServiceProcessTest.java
@@ -199,20 +199,6 @@ public class DefaultJobMasterServiceProcessTest extends TestLogger {
                 is(JobStatus.FINISHED));
     }
 
-    @Test
-    public void testJobFinishedByOther() {
-        final CompletableFuture<JobMasterService> jobMasterServiceFuture =
-                new CompletableFuture<>();
-        DefaultJobMasterServiceProcess serviceProcess = createTestInstance(jobMasterServiceFuture);
-        jobMasterServiceFuture.complete(new TestingJobMasterService());
-
-        serviceProcess.jobFinishedByOther();
-
-        assertThat(
-                serviceProcess.getResultFuture(),
-                futureWillCompleteExceptionally(JobNotFinishedException.class, TIMEOUT));
-    }
-
     private DefaultJobMasterServiceProcess createTestInstance(
             CompletableFuture<JobMasterService> jobMasterServiceFuture) {
 

--- a/flink-runtime/src/test/java/org/apache/flink/runtime/jobmaster/utils/JobMasterBuilder.java
+++ b/flink-runtime/src/test/java/org/apache/flink/runtime/jobmaster/utils/JobMasterBuilder.java
@@ -219,11 +219,6 @@ public class JobMasterBuilder {
         }
 
         @Override
-        public void jobFinishedByOther() {
-            jobFinishedByOtherFuture.complete(null);
-        }
-
-        @Override
         public void jobMasterFailed(Throwable cause) {
             jobMasterFailedFuture.complete(cause);
         }


### PR DESCRIPTION
… job exception when recover

## What is the purpose of the change

This pr is to harden the dispatcher to solve the case that master crashed at job finishing phase.


## Brief change log

Add a new exception to represent job have reached Done status, and handle this exception in jobManagerResultFuture.

## Verifying this change

This change added tests and can be verified as follows:

org.apache.flink.runtime.dispatcher.DispatcherTest#testNonFatalErrorWhenRecoveredJobFinishingException


