### PR TITLE
[FLINK-22198][connector/kafka] Disable log deletion on Kafka broker in KafkaTableTestBase

### DIFF
--- a/flink-connectors/flink-connector-kafka/src/test/java/org/apache/flink/streaming/connectors/kafka/table/KafkaTableTestBase.java
+++ b/flink-connectors/flink-connector-kafka/src/test/java/org/apache/flink/streaming/connectors/kafka/table/KafkaTableTestBase.java
@@ -75,7 +75,9 @@ public abstract class KafkaTableTestBase extends AbstractTestBase {
                 }
             }.withEmbeddedZookeeper()
                     .withNetwork(NETWORK)
-                    .withNetworkAliases(INTER_CONTAINER_KAFKA_ALIAS);
+                    .withNetworkAliases(INTER_CONTAINER_KAFKA_ALIAS)
+                    // Disable log deletion to prevent records from being deleted during test run
+                    .withEnv("KAFKA_LOG_RETENTION_MS", "-1");
 
     protected StreamExecutionEnvironment env;
     protected StreamTableEnvironment tEnv;


### PR DESCRIPTION
## What is the purpose of the change

This pull request set Kafka broker configuration ```log.retention.ms``` to -1 in ```KafkaTableTestBase``` to prevent deleting records with explicitly assigned timestamp.

## Brief change log

- Add environment variable ```KAFKA_LOG_RETENTION_MS=-1``` to KafkaContainer to set broker config ```log.retention.ms``` to -1


## Verifying this change

This change is a trivial rework / code cleanup without any test coverage.

## Does this pull request potentially affect one of the following parts:

  - Dependencies (does it add or upgrade a dependency): (no)
  - The public API, i.e., is any changed class annotated with `@Public(Evolving)`: (no)
  - The serializers: (no)
  - The runtime per-record code paths (performance sensitive): (no)
  - Anything that affects deployment or recovery: JobManager (and its components), Checkpointing, Kubernetes/Yarn, ZooKeeper: (no)
  - The S3 file system connector: (no)

## Documentation

  - Does this pull request introduce a new feature? (no)
  - If yes, how is the feature documented? (not applicable)
