### PR TITLE
[FLINK-23876][docs] Update JDBC XA Sink docs

### DIFF
--- a/docs/content/docs/connectors/datastream/jdbc.md
+++ b/docs/content/docs/connectors/datastream/jdbc.md
@@ -182,9 +182,31 @@ env.execute();
 ```
 Postgres XADataSource Example:
 ```java
-PGXADataSource pgxaDataSource = new PGXADataSource();
-pgxaDataSource.setUrl(
-"jdbc:postgresql://localhost:5432/postgres");
+
+### `XADataSource` examples
+PostgreSQL `XADataSource` example:
+```java
+PGXADataSource xaDataSource = new org.postgresql.xa.PGXADataSource();
+xaDataSource.setUrl("jdbc:postgresql://localhost:5432/postgres");
+xaDataSource.setUser(username);
+xaDataSource.setPassword(password);
 ```
+
+MySQL `XADataSource` example:
+```java
+MysqlXADataSource xaDataSource = new com.mysql.cj.jdbc.MysqlXADataSource();
+xaDataSource.setUrl("jdbc:mysql://localhost:3306/");
+xaDataSource.setUser(username);
+xaDataSource.setPassword(password);
+```
+
+Oracle `XADataSource` example:
+```java
+OracleXADataSource xaDataSource = new oracle.jdbc.xa.OracleXADataSource();
+xaDataSource.setURL("jdbc:oracle:oci8:@");
+xaDataSource.setUser("scott");
+xaDataSource.setPassword("tiger");
+```
+Please also take Oracle connection pooling into account.
 
 Please refer to the `JdbcXaSinkFunction` documentation for more details.

--- a/docs/content/docs/connectors/datastream/jdbc.md
+++ b/docs/content/docs/connectors/datastream/jdbc.md
@@ -32,15 +32,8 @@ To use it, add the following dependency to your project (along with your JDBC dr
 
 {{< artifact flink-connector-jdbc withScalaVersion >}}
 
-A driver dependency is also required to connect to a specified database. Here are drivers currently supported:
-
-| Driver      |      Group Id      |      Artifact Id       |      JAR         |
-| :-----------| :------------------| :----------------------| :----------------|
-| MySQL       |       `mysql`      | `mysql-connector-java` | [Download](https://repo.maven.apache.org/maven2/mysql/mysql-connector-java/) |
-| PostgreSQL  |  `org.postgresql`  |      `postgresql`      | [Download](https://jdbc.postgresql.org/download.html) |
-| Derby       | `org.apache.derby` |        `derby`         | [Download](http://db.apache.org/derby/derby_downloads.html) |
-
 Note that the streaming connectors are currently __NOT__ part of the binary distribution. See how to link with them for cluster execution [here]({{< ref "docs/dev/datastream/project-configuration" >}}).
+A driver dependency is also required to connect to a specified database. Please consult your database documentation on how to add the corresponding driver.
 
 ## `JdbcSink.sink`
 

--- a/docs/content/docs/connectors/datastream/jdbc.md
+++ b/docs/content/docs/connectors/datastream/jdbc.md
@@ -145,15 +145,14 @@ public class JdbcSinkExample {
 Since 1.13, Flink JDBC sink supports exactly-once mode. 
 The implementation relies on the JDBC driver support of XA 
 [standard](https://pubs.opengroup.org/onlinepubs/009680699/toc.pdf).
+Most drivers support XA if the database also supports XA (so the driver is usually the same).
 
 To use it, create a sink using `exactlyOnceSink()` method as above and additionally provide:
 - {{< javadoc name="exactly-once options" file="org/apache/flink/connector/jdbc/JdbcExactlyOnceOptions.html" >}}
 - {{< javadoc name="execution options" file="org/apache/flink/connector/jdbc/JdbcExecutionOptions.html" >}}
 - [XA DataSource](https://docs.oracle.com/javase/8/docs/api/javax/sql/XADataSource.html) Supplier
 
-**ATTENTION!** Currently `JdbcSink.exactlyOnceSink` can ensure exactly once semantics
-with `JdbcExecutionOptions.maxRetries == 0`; otherwise, duplicated results maybe produced.
-
+For example:
 ```java
 StreamExecutionEnvironment env = StreamExecutionEnvironment.getExecutionEnvironment();
 env
@@ -180,8 +179,22 @@ env
                 });
 env.execute();
 ```
-Postgres XADataSource Example:
+**NOTE:** Some databases only allow a single XA transaction per connection (e.g. PostgreSQL, MySQL).
+In such cases, please use the following API to construct `JdbcExactlyOnceOptions`:
 ```java
+JdbcExactlyOnceOptions.builder()
+.withTransactionPerConnection(true)
+.build()
+```
+This will make Flink use a separate connection for every XA transaction. This may require adjusting connection limits.
+For PostgreSQL and MySQL, this can be done by increasing `max_connections`.
+
+Furthermore, XA needs to be enabled and/or configured in some databases.
+For PostgreSQL, you should set `max_prepared_transactions` to some value greater than zero.
+For MySQL v8+, you should grant `XA_RECOVER_ADMIN` to Flink DB user.
+
+**ATTENTION:** Currently, `JdbcSink.exactlyOnceSink` can ensure exactly once semantics
+with `JdbcExecutionOptions.maxRetries == 0`; otherwise, duplicated results maybe produced.
 
 ### `XADataSource` examples
 PostgreSQL `XADataSource` example:

--- a/flink-connectors/flink-connector-jdbc/src/main/java/org/apache/flink/connector/jdbc/xa/JdbcXaSinkFunction.java
+++ b/flink-connectors/flink-connector-jdbc/src/main/java/org/apache/flink/connector/jdbc/xa/JdbcXaSinkFunction.java
@@ -124,10 +124,6 @@ import static org.apache.flink.connector.jdbc.xa.JdbcXaSinkFunctionState.of;
  * </tbody>
  * </table>
  *
- * <p>Attention: JdbcXaSinkFunction does not support exactly-once mode with MySQL or other databases
- * that do not support multiple XA transaction per connection. We will improve the support in
- * FLINK-22239.
- *
  * @since 1.13
  */
 @Internal


### PR DESCRIPTION
## What is the purpose of the change

Update JDBC exactly once sink docs (see also commits):
- remove explicit list of JDBC drivers as dialects are only used in Table API
- add more datasource building examlpes
- clarify withTransactionPerConnection usage and some DB-specific settings

**note** Chinese version not updated (significantly outdated).