### PR TITLE
[BP-1.13][FLINK-23813][connectors/jdbc] Update delete executor in TableJdbcUpsertOutputFormat

### DIFF
--- a/flink-connectors/flink-connector-jdbc/src/main/java/org/apache/flink/connector/jdbc/internal/TableJdbcUpsertOutputFormat.java
+++ b/flink-connectors/flink-connector-jdbc/src/main/java/org/apache/flink/connector/jdbc/internal/TableJdbcUpsertOutputFormat.java
@@ -17,6 +17,7 @@
 
 package org.apache.flink.connector.jdbc.internal;
 
+import org.apache.flink.annotation.VisibleForTesting;
 import org.apache.flink.api.common.functions.RuntimeContext;
 import org.apache.flink.api.java.tuple.Tuple2;
 import org.apache.flink.connector.jdbc.JdbcExecutionOptions;
@@ -46,24 +47,35 @@ class TableJdbcUpsertOutputFormat
     private static final Logger LOG = LoggerFactory.getLogger(TableJdbcUpsertOutputFormat.class);
 
     private JdbcBatchStatementExecutor<Row> deleteExecutor;
-    private final JdbcDmlOptions dmlOptions;
+    private final StatementExecutorFactory<JdbcBatchStatementExecutor<Row>>
+            deleteStatementExecutorFactory;
 
     TableJdbcUpsertOutputFormat(
             JdbcConnectionProvider connectionProvider,
             JdbcDmlOptions dmlOptions,
             JdbcExecutionOptions batchOptions) {
-        super(
+        this(
                 connectionProvider,
                 batchOptions,
                 ctx -> createUpsertRowExecutor(dmlOptions, ctx),
-                tuple2 -> tuple2.f1);
-        this.dmlOptions = dmlOptions;
+                ctx -> createDeleteExecutor(dmlOptions, ctx));
+    }
+
+    @VisibleForTesting
+    TableJdbcUpsertOutputFormat(
+            JdbcConnectionProvider connectionProvider,
+            JdbcExecutionOptions batchOptions,
+            StatementExecutorFactory<JdbcBatchStatementExecutor<Row>> statementExecutorFactory,
+            StatementExecutorFactory<JdbcBatchStatementExecutor<Row>>
+                    deleteStatementExecutorFactory) {
+        super(connectionProvider, batchOptions, statementExecutorFactory, tuple2 -> tuple2.f1);
+        this.deleteStatementExecutorFactory = deleteStatementExecutorFactory;
     }
 
     @Override
     public void open(int taskNumber, int numTasks) throws IOException {
         super.open(taskNumber, numTasks);
-        deleteExecutor = createDeleteExecutor();
+        deleteExecutor = deleteStatementExecutorFactory.apply(getRuntimeContext());
         try {
             deleteExecutor.prepareStatements(connectionProvider.getConnection());
         } catch (SQLException e) {
@@ -71,7 +83,8 @@ class TableJdbcUpsertOutputFormat
         }
     }
 
-    private JdbcBatchStatementExecutor<Row> createDeleteExecutor() {
+    private static JdbcBatchStatementExecutor<Row> createDeleteExecutor(
+            JdbcDmlOptions dmlOptions, RuntimeContext ctx) {
         int[] pkFields =
                 Arrays.stream(dmlOptions.getFieldNames())
                         .mapToInt(Arrays.asList(dmlOptions.getFieldNames())::indexOf)
@@ -118,6 +131,13 @@ class TableJdbcUpsertOutputFormat
     protected void attemptFlush() throws SQLException {
         super.attemptFlush();
         deleteExecutor.executeBatch();
+    }
+
+    @Override
+    public void updateExecutor(boolean reconnect) throws SQLException, ClassNotFoundException {
+        super.updateExecutor(reconnect);
+        deleteExecutor.closeStatements();
+        deleteExecutor.prepareStatements(connectionProvider.getConnection());
     }
 
     private static JdbcBatchStatementExecutor<Row> createKeyedRowExecutor(

--- a/flink-connectors/flink-connector-jdbc/src/test/java/org/apache/flink/connector/jdbc/internal/JdbcTableOutputFormatTest.java
+++ b/flink-connectors/flink-connector-jdbc/src/test/java/org/apache/flink/connector/jdbc/internal/JdbcTableOutputFormatTest.java
@@ -24,6 +24,7 @@ import org.apache.flink.api.java.tuple.Tuple2;
 import org.apache.flink.connector.jdbc.JdbcDataTestBase;
 import org.apache.flink.connector.jdbc.JdbcExecutionOptions;
 import org.apache.flink.connector.jdbc.internal.connection.SimpleJdbcConnectionProvider;
+import org.apache.flink.connector.jdbc.internal.executor.JdbcBatchStatementExecutor;
 import org.apache.flink.connector.jdbc.internal.options.JdbcDmlOptions;
 import org.apache.flink.connector.jdbc.internal.options.JdbcOptions;
 import org.apache.flink.types.Row;
@@ -47,6 +48,7 @@ import static org.apache.flink.connector.jdbc.JdbcTestFixture.OUTPUT_TABLE;
 import static org.apache.flink.connector.jdbc.JdbcTestFixture.TEST_DATA;
 import static org.apache.flink.connector.jdbc.JdbcTestFixture.TestEntry;
 import static org.junit.Assert.assertArrayEquals;
+import static org.junit.Assert.assertTrue;
 import static org.mockito.Mockito.doReturn;
 
 /** Tests for the {@link JdbcBatchingOutputFormat}. */
@@ -83,6 +85,90 @@ public class JdbcTableOutputFormatTest extends JdbcDataTestBase {
                         JdbcExecutionOptions.defaults());
         // FLINK-17544: There should be no NPE thrown from this method
         format.close();
+    }
+
+    /**
+     * Test that the delete executor in {@link TableJdbcUpsertOutputFormat} is updated when {@link
+     * JdbcBatchingOutputFormat#attemptFlush()} fails.
+     */
+    @Test
+    public void testDeleteExecutorUpdatedOnReconnect() throws Exception {
+        // first fail flush from the main executor
+        boolean[] exceptionThrown = {false};
+        // then record whether the delete executor was updated
+        // and check it on the next flush attempt
+        boolean[] deleteExecutorPrepared = {false};
+        boolean[] deleteExecuted = {false};
+        format =
+                new TableJdbcUpsertOutputFormat(
+                        new SimpleJdbcConnectionProvider(
+                                JdbcOptions.builder()
+                                        .setDBUrl(getDbMetadata().getUrl())
+                                        .setTableName(OUTPUT_TABLE)
+                                        .build()) {
+                            @Override
+                            public boolean isConnectionValid() throws SQLException {
+                                return false; // trigger reconnect and re-prepare on flush failure
+                            }
+                        },
+                        JdbcExecutionOptions.builder()
+                                .withMaxRetries(1)
+                                .withBatchIntervalMs(Long.MAX_VALUE) // disable periodic flush
+                                .build(),
+                        ctx ->
+                                new JdbcBatchStatementExecutor<Row>() {
+
+                                    @Override
+                                    public void executeBatch() throws SQLException {
+                                        if (!exceptionThrown[0]) {
+                                            exceptionThrown[0] = true;
+                                            throw new SQLException();
+                                        }
+                                    }
+
+                                    @Override
+                                    public void prepareStatements(Connection connection) {}
+
+                                    @Override
+                                    public void addToBatch(Row record) {}
+
+                                    @Override
+                                    public void closeStatements() {}
+                                },
+                        ctx ->
+                                new JdbcBatchStatementExecutor<Row>() {
+                                    @Override
+                                    public void prepareStatements(Connection connection) {
+                                        if (exceptionThrown[0]) {
+                                            deleteExecutorPrepared[0] = true;
+                                        }
+                                    }
+
+                                    @Override
+                                    public void addToBatch(Row record) {}
+
+                                    @Override
+                                    public void executeBatch() {
+                                        deleteExecuted[0] = true;
+                                    }
+
+                                    @Override
+                                    public void closeStatements() {}
+                                });
+        RuntimeContext context = Mockito.mock(RuntimeContext.class);
+        ExecutionConfig config = Mockito.mock(ExecutionConfig.class);
+        doReturn(config).when(context).getExecutionConfig();
+        doReturn(true).when(config).isObjectReuseEnabled();
+        format.setRuntimeContext(context);
+        format.open(0, 1);
+
+        format.writeRecord(Tuple2.of(false /* false = delete*/, toRow(TEST_DATA[0])));
+        format.flush();
+
+        assertTrue("Delete should be executed", deleteExecuted[0]);
+        assertTrue(
+                "Delete executor should be prepared" + exceptionThrown[0],
+                deleteExecutorPrepared[0]);
     }
 
     @Test


### PR DESCRIPTION
Backport of #16895 to 1.13

## What is the purpose of the change

```
...so that it is properly initializated after reconnection
```

## Verifying this change

- Added `JdbcTableOutputFormatTest.testDeleteExecutorUpdatedOnReconnect`

## Does this pull request potentially affect one of the following parts:

  - Dependencies (does it add or upgrade a dependency): no
  - The public API, i.e., is any changed class annotated with `@Public(Evolving)`: no
  - The serializers: no
  - The runtime per-record code paths (performance sensitive): no
  - Anything that affects deployment or recovery: JobManager (and its components), Checkpointing, Kubernetes/Yarn/Mesos, ZooKeeper: no
  - The S3 file system connector: no

## Documentation

  - Does this pull request introduce a new feature? no
  - If yes, how is the feature documented? no
