### PR TITLE
[FLINK-23724][network] Fix the network buffer leak when ResultPartition is released (cherry-pick)

### DIFF
--- a/flink-runtime/src/main/java/org/apache/flink/runtime/io/network/partition/ResultPartition.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/io/network/partition/ResultPartition.java
@@ -230,15 +230,21 @@ public abstract class ResultPartition implements ResultPartitionWriter {
     /** Releases all produced data including both those stored in memory and persisted on disk. */
     protected abstract void releaseInternal();
 
-    @Override
-    public void close() {
+    private void closeBufferPool() {
         if (bufferPool != null) {
             bufferPool.lazyDestroy();
         }
     }
 
     @Override
+    public void close() {
+        closeBufferPool();
+    }
+
+    @Override
     public void fail(@Nullable Throwable throwable) {
+        // the task canceler thread will call this method to early release the output buffer pool
+        closeBufferPool();
         partitionManager.releasePartition(partitionId, throwable);
     }
 

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/taskmanager/Task.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/taskmanager/Task.java
@@ -965,12 +965,15 @@ public class Task
 
         for (ResultPartitionWriter partitionWriter : consumableNotifyingPartitionWriters) {
             taskEventDispatcher.unregisterPartition(partitionWriter.getPartitionId());
-            if (isCanceledOrFailed()) {
-                partitionWriter.fail(getFailureCause());
-            }
         }
 
-        closeNetworkResources();
+        // close network resources
+        if (isCanceledOrFailed()) {
+            failAllResultPartitions();
+        }
+        closeAllResultPartitions();
+        closeAllInputGates();
+
         try {
             taskStateManager.close();
         } catch (Exception e) {
@@ -978,11 +981,13 @@ public class Task
         }
     }
 
-    /**
-     * There are two scenarios to close the network resources. One is from {@link TaskCanceler} to
-     * early release partitions and gates. Another is from task thread during task exiting.
-     */
-    private void closeNetworkResources() {
+    private void failAllResultPartitions() {
+        for (ResultPartitionWriter partitionWriter : consumableNotifyingPartitionWriters) {
+            partitionWriter.fail(getFailureCause());
+        }
+    }
+
+    private void closeAllResultPartitions() {
         for (ResultPartitionWriter partitionWriter : consumableNotifyingPartitionWriters) {
             try {
                 partitionWriter.close();
@@ -992,14 +997,14 @@ public class Task
                         "Failed to release result partition for task {}.", taskNameWithSubtask, t);
             }
         }
+    }
 
+    private void closeAllInputGates() {
         AbstractInvokable invokable = this.invokable;
         if (invokable == null || !invokable.isUsingNonBlockingInput()) {
-            // Cleanup resources instead of invokable if it is null,
-            // or prevent it from being blocked on input,
-            // or interrupt if it is already blocked.
-            // Not needed for StreamTask (which does NOT use blocking input); for which this could
-            // cause race conditions
+            // Cleanup resources instead of invokable if it is null, or prevent it from being
+            // blocked on input, or interrupt if it is already blocked. Not needed for StreamTask
+            // (which does NOT use blocking input); for which this could cause race conditions
             for (InputGate inputGate : inputGates) {
                 try {
                     inputGate.close();
@@ -1175,7 +1180,6 @@ public class Task
                         Runnable canceler =
                                 new TaskCanceler(
                                         LOG,
-                                        this::closeNetworkResources,
                                         taskCancellationTimeout > 0
                                                 ? taskCancellationTimeout
                                                 : TaskManagerOptions.TASK_CANCELLATION_TIMEOUT
@@ -1555,10 +1559,9 @@ public class Task
      * This runner calls cancel() on the invokable, closes input-/output resources, and initially
      * interrupts the task thread.
      */
-    private static class TaskCanceler implements Runnable {
+    private class TaskCanceler implements Runnable {
 
         private final Logger logger;
-        private final Runnable networkResourcesCloser;
         /** Time to wait after cancellation and interruption before releasing network resources. */
         private final long taskCancellationTimeout;
 
@@ -1568,13 +1571,11 @@ public class Task
 
         TaskCanceler(
                 Logger logger,
-                Runnable networkResourcesCloser,
                 long taskCancellationTimeout,
                 AbstractInvokable invokable,
                 Thread executer,
                 String taskName) {
             this.logger = logger;
-            this.networkResourcesCloser = networkResourcesCloser;
             this.taskCancellationTimeout = taskCancellationTimeout;
             this.invokable = invokable;
             this.executer = executer;
@@ -1607,7 +1608,12 @@ public class Task
                 // in order to unblock async Threads, which produce/consume the
                 // intermediate streams outside of the main Task Thread (like
                 // the Kafka consumer).
-                networkResourcesCloser.run();
+                // Notes: 1) This does not mean to release all network resources,
+                // the task thread itself will release them; 2) We can not close
+                // ResultPartitions here because of possible race conditions with
+                // Task thread so we just call the fail here.
+                failAllResultPartitions();
+                closeAllInputGates();
 
             } catch (Throwable t) {
                 ExceptionUtils.rethrowIfFatalError(t);

--- a/flink-runtime/src/test/java/org/apache/flink/runtime/io/network/partition/ResultPartitionTest.java
+++ b/flink-runtime/src/test/java/org/apache/flink/runtime/io/network/partition/ResultPartitionTest.java
@@ -340,50 +340,37 @@ public class ResultPartitionTest {
         }
     }
 
+    /**
+     * Tests {@link ResultPartition#close()} and {@link ResultPartition#release()} on a working
+     * pipelined partition.
+     */
     @Test
     public void testReleaseMemoryOnPipelinedPartition() throws Exception {
-        testReleaseMemory(ResultPartitionType.PIPELINED);
-    }
-
-    /**
-     * Tests {@link ResultPartition#releaseMemory(int)} on a working partition.
-     *
-     * @param resultPartitionType the result partition type to set up
-     */
-    private void testReleaseMemory(final ResultPartitionType resultPartitionType) throws Exception {
         final int numAllBuffers = 10;
         final NettyShuffleEnvironment network =
                 new NettyShuffleEnvironmentBuilder()
                         .setNumNetworkBuffers(numAllBuffers)
                         .setBufferSize(bufferSize)
                         .build();
-        final ResultPartition resultPartition = createPartition(network, resultPartitionType, 1);
+        final ResultPartition resultPartition =
+                createPartition(network, ResultPartitionType.PIPELINED, 1);
         try {
             resultPartition.setup();
 
             // take all buffers (more than the minimum required)
             for (int i = 0; i < numAllBuffers; ++i) {
-                resultPartition.emitRecord(ByteBuffer.allocate(bufferSize), 0);
+                resultPartition.emitRecord(ByteBuffer.allocate(bufferSize - 1), 0);
             }
-            resultPartition.finish();
-
             assertEquals(0, resultPartition.getBufferPool().getNumberOfAvailableMemorySegments());
 
-            // reset the pool size less than the number of requested buffers
-            final int numLocalBuffers = 4;
-            resultPartition.getBufferPool().setNumBuffers(numLocalBuffers);
+            resultPartition.close();
+            assertTrue(resultPartition.getBufferPool().isDestroyed());
+            assertEquals(
+                    numAllBuffers, network.getNetworkBufferPool().getNumberOfUsedMemorySegments());
 
-            // partition with blocking type should release excess buffers
-            if (!resultPartitionType.hasBackPressure()) {
-                assertEquals(
-                        numLocalBuffers,
-                        resultPartition.getBufferPool().getNumberOfAvailableMemorySegments());
-            } else {
-                assertEquals(
-                        0, resultPartition.getBufferPool().getNumberOfAvailableMemorySegments());
-            }
-        } finally {
             resultPartition.release();
+            assertEquals(0, network.getNetworkBufferPool().getNumberOfUsedMemorySegments());
+        } finally {
             network.close();
         }
     }


### PR DESCRIPTION
## What is the purpose of the change

This patch fixes the network buffer leak when ResultPartition is released by closing all BufferBuilders.

cherry-pick from https://github.com/apache/flink/pull/16844.

## Brief change log

  - All BufferBuilders are closed in the BufferWritingResultPartition#close method;
  - The TaskCanceler call the ResultPartition#fail method instead of the ResultPartition#close method because the close method can incur concurrency issue.


## Verifying this change

An existing test is modified to cover the scenario.

## Does this pull request potentially affect one of the following parts:

  - Dependencies (does it add or upgrade a dependency): (yes / **no**)
  - The public API, i.e., is any changed class annotated with `@Public(Evolving)`: (yes / **no**)
  - The serializers: (yes / **no** / don't know)
  - The runtime per-record code paths (performance sensitive): (yes / **no** / don't know)
  - Anything that affects deployment or recovery: JobManager (and its components), Checkpointing, Kubernetes/Yarn, ZooKeeper: (yes / **no** / don't know)
  - The S3 file system connector: (yes / **no** / don't know)

## Documentation

  - Does this pull request introduce a new feature? (yes / **no**)
  - If yes, how is the feature documented? (**not applicable** / docs / JavaDocs / not documented)
