### PR TITLE
[FLINK-23903][tests] Harden ZooKeeperLeaderRetrievalConnectionHandlingTest.testSuspendedConnectionDoesNotClearLeaderInformationIfClearanceOnLostConnection

### DIFF
--- a/flink-runtime/src/test/java/org/apache/flink/runtime/leaderelection/ZooKeeperLeaderRetrievalConnectionHandlingTest.java
+++ b/flink-runtime/src/test/java/org/apache/flink/runtime/leaderelection/ZooKeeperLeaderRetrievalConnectionHandlingTest.java
@@ -205,7 +205,7 @@ public class ZooKeeperLeaderRetrievalConnectionHandlingTest extends TestLogger {
                     firstAddress.get(),
                     is(leaderAddress));
 
-            restartTestServer();
+            closeTestServer();
 
             // make sure that no new leader information is published
             assertThat(queueLeaderElectionListener.next(Duration.ofMillis(100L)), is(nullValue()));


### PR DESCRIPTION
The problem was that the test restarted the ZooKeeper TestingServer. Due to this, it was possible
that the ZooKeeperLeaderRetrievalDriver could reconnect to the Zk server. In this case, the driver
resends the connection information which makes the test fail because it expects that no leader updates
will be sent. This commit fixes the problem by stopping the TestingServer instead of restarting it. That
way, it is no longer possible that the driver can reconnect.