### PR TITLE
[FLINK-23809][checkpoint] Respect the finished flag when extracting operator states due to skip in-flight data

### DIFF
--- a/flink-runtime/src/main/java/org/apache/flink/runtime/checkpoint/CheckpointCoordinator.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/checkpoint/CheckpointCoordinator.java
@@ -1601,10 +1601,15 @@ public class CheckpointCoordinator {
         // Create the new operator states without in-flight data.
         for (OperatorState originalOperatorState : originalOperatorStates.values()) {
             OperatorState newState =
-                    new OperatorState(
-                            originalOperatorState.getOperatorID(),
-                            originalOperatorState.getParallelism(),
-                            originalOperatorState.getMaxParallelism());
+                    originalOperatorState.isFullyFinished()
+                            ? new FullyFinishedOperatorState(
+                                    originalOperatorState.getOperatorID(),
+                                    originalOperatorState.getParallelism(),
+                                    originalOperatorState.getMaxParallelism())
+                            : new OperatorState(
+                                    originalOperatorState.getOperatorID(),
+                                    originalOperatorState.getParallelism(),
+                                    originalOperatorState.getMaxParallelism());
 
             newStates.put(newState.getOperatorID(), newState);
 


### PR DESCRIPTION
## What is the purpose of the change

This PR fixes that when enabled skipping in-flight data, the checkpoint coordinator would create new `OperatorState` but discard the in-flight data, but it does not consider the finished flag for now. 

## Brief change log

- 2b37118c0194dcc7d0171ff0f155d22364d86703 fixes the issue by considering the finished flag.

## Verifying this change

This change is verified by the added UT.

## Does this pull request potentially affect one of the following parts:

  - Dependencies (does it add or upgrade a dependency): **no**
  - The public API, i.e., is any changed class annotated with `@Public(Evolving)`: **no**
  - The serializers: **no**
  - The runtime per-record code paths (performance sensitive): **no**
  - Anything that affects deployment or recovery: JobManager (and its components), Checkpointing, Kubernetes/Yarn, ZooKeeper: **yes**
  - The S3 file system connector: **no**

## Documentation

  - Does this pull request introduce a new feature? **no**
  - If yes, how is the feature documented? **not applicable**
