### PR TITLE
[FLINK-22932][tests] Harden RocksDBStateBackendWindowITCase by using RpcUtils.INF_TIMEOUT for MiniCluster RPC timeout

### DIFF
--- a/flink-runtime/src/main/java/org/apache/flink/runtime/minicluster/MiniCluster.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/minicluster/MiniCluster.java
@@ -220,7 +220,9 @@ public class MiniCluster implements AutoCloseableAsync {
                                         .getNumTaskManagers()); // common + JM + RM + TMs
         this.dispatcherResourceManagerComponents = new ArrayList<>(1);
 
-        this.rpcTimeout = miniClusterConfiguration.getRpcTimeout();
+        // There shouldn't be any lost messages between the MiniCluster and the Flink components
+        // since they all run in the same process.
+        this.rpcTimeout = RpcUtils.INF_TIMEOUT;
         this.terminationFuture = CompletableFuture.completedFuture(null);
         running = false;
 

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/minicluster/MiniClusterConfiguration.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/minicluster/MiniClusterConfiguration.java
@@ -31,6 +31,8 @@ import org.apache.flink.util.Preconditions;
 
 import javax.annotation.Nullable;
 
+import java.time.Duration;
+
 import static org.apache.flink.runtime.minicluster.RpcServiceSharing.SHARED;
 
 /** Configuration object for the {@link MiniCluster}. */
@@ -73,6 +75,11 @@ public class MiniClusterConfiguration {
         // set default io pool size.
         if (!modifiedConfig.contains(ClusterOptions.CLUSTER_IO_EXECUTOR_POOL_SIZE)) {
             modifiedConfig.set(ClusterOptions.CLUSTER_IO_EXECUTOR_POOL_SIZE, DEFAULT_IO_POOL_SIZE);
+        }
+
+        // increase the akka.ask.timeout if not set in order to harden tests on slow CI
+        if (!modifiedConfig.contains(AkkaOptions.ASK_TIMEOUT_DURATION)) {
+            modifiedConfig.set(AkkaOptions.ASK_TIMEOUT_DURATION, Duration.ofMinutes(5L));
         }
 
         return new UnmodifiableConfiguration(modifiedConfig);

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/minicluster/MiniClusterConfiguration.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/minicluster/MiniClusterConfiguration.java
@@ -18,8 +18,6 @@
 
 package org.apache.flink.runtime.minicluster;
 
-import org.apache.flink.api.common.time.Time;
-import org.apache.flink.configuration.AkkaOptions;
 import org.apache.flink.configuration.ClusterOptions;
 import org.apache.flink.configuration.Configuration;
 import org.apache.flink.configuration.JobManagerOptions;
@@ -127,10 +125,6 @@ public class MiniClusterConfiguration {
         return commonBindAddress != null
                 ? commonBindAddress
                 : configuration.getString(TaskManagerOptions.BIND_HOST, "localhost");
-    }
-
-    public Time getRpcTimeout() {
-        return Time.fromDuration(configuration.get(AkkaOptions.ASK_TIMEOUT_DURATION));
     }
 
     public UnmodifiableConfiguration getConfiguration() {


### PR DESCRIPTION
This commit sets the default rpc timeout for the MiniCluster to `RpcUtils.INF_TIMEOUT`. This should be ok since
in a local execution the communication between the different components should be reliable.
