### PR TITLE
[FLINK-21538][tests] Set default parallelism to 4 for Elasticsearch6DynamicSinkITCase.testWritingDocuments

### DIFF
--- a/flink-connectors/flink-connector-elasticsearch6/src/test/java/org/apache/flink/streaming/connectors/elasticsearch/table/Elasticsearch6DynamicSinkITCase.java
+++ b/flink-connectors/flink-connector-elasticsearch6/src/test/java/org/apache/flink/streaming/connectors/elasticsearch/table/Elasticsearch6DynamicSinkITCase.java
@@ -140,6 +140,8 @@ public class Elasticsearch6DynamicSinkITCase extends TestLogger {
         SinkFunction<RowData> sinkFunction = sinkRuntimeProvider.createSinkFunction();
         StreamExecutionEnvironment environment =
                 StreamExecutionEnvironment.getExecutionEnvironment();
+        environment.setParallelism(4);
+
         rowData.setRowKind(RowKind.UPDATE_AFTER);
         environment.<RowData>fromElements(rowData).addSink(sinkFunction);
         environment.execute();


### PR DESCRIPTION
This commit sets the default parallelism of Elasticsearch6DynamicSinkITCase.testWritingDocuments to 4 in order
to reduce the load for our CI infrastructure.
