### PR TITLE
[BP-1.13][FLINK-23906][tests] Increase the default akka.ask.timeout for the MiniCluster to 5 minutes

### DIFF
--- a/flink-runtime/src/main/java/org/apache/flink/runtime/minicluster/MiniClusterConfiguration.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/minicluster/MiniClusterConfiguration.java
@@ -19,6 +19,7 @@
 package org.apache.flink.runtime.minicluster;
 
 import org.apache.flink.api.common.time.Time;
+import org.apache.flink.configuration.AkkaOptions;
 import org.apache.flink.configuration.Configuration;
 import org.apache.flink.configuration.JobManagerOptions;
 import org.apache.flink.configuration.RestOptions;
@@ -66,6 +67,11 @@ public class MiniClusterConfiguration {
         final Configuration modifiedConfig = new Configuration(configuration);
 
         TaskExecutorResourceUtils.adjustForLocalExecution(modifiedConfig);
+
+        // increase the akka.ask.timeout if not set in order to harden tests on slow CI
+        if (!modifiedConfig.contains(AkkaOptions.ASK_TIMEOUT)) {
+            modifiedConfig.set(AkkaOptions.ASK_TIMEOUT, "5 min");
+        }
 
         return new UnmodifiableConfiguration(modifiedConfig);
     }


### PR DESCRIPTION
Backport of #16921 to `release-1.13`.