### PR TITLE
[FLINK-18592][Connectors/FileSystem] StreamingFileSink fails due to truncating HDFS file failure

### DIFF
--- a/flink-filesystems/flink-hadoop-fs/src/main/java/org/apache/flink/runtime/fs/hdfs/HadoopRecoverableFsDataOutputStream.java
+++ b/flink-filesystems/flink-hadoop-fs/src/main/java/org/apache/flink/runtime/fs/hdfs/HadoopRecoverableFsDataOutputStream.java
@@ -56,7 +56,7 @@ import static org.apache.flink.util.Preconditions.checkNotNull;
 @Internal
 class HadoopRecoverableFsDataOutputStream extends RecoverableFsDataOutputStream {
 
-    private static final long LEASE_RECOVERY_TIMEOUT_MS = 9_000_000L;
+    private static final long LEASE_RECOVERY_TIMEOUT_MS = 900_000L;
 
     private static final long BLOCK_RECOVERY_TIMEOUT_MS = 300_000L;
 

--- a/flink-filesystems/flink-hadoop-fs/src/main/java/org/apache/flink/runtime/fs/hdfs/HadoopRecoverableFsDataOutputStream.java
+++ b/flink-filesystems/flink-hadoop-fs/src/main/java/org/apache/flink/runtime/fs/hdfs/HadoopRecoverableFsDataOutputStream.java
@@ -163,9 +163,7 @@ class HadoopRecoverableFsDataOutputStream extends RecoverableFsDataOutputStream 
     // ------------------------------------------------------------------------
 
     private static void safelyTruncateFile(
-            final FileSystem fileSystem,
-            final Path path,
-            final HadoopFsRecoverable recoverable)
+            final FileSystem fileSystem, final Path path, final HadoopFsRecoverable recoverable)
             throws IOException {
 
         ensureTruncateInitialized();
@@ -178,7 +176,7 @@ class HadoopRecoverableFsDataOutputStream extends RecoverableFsDataOutputStream 
                 isLeaseReleased,
                 "Failed to release lease on file `%s` in %d ms.",
                 path.toString(),
-            LEASE_RECOVERY_TIMEOUT_MS);
+                LEASE_RECOVERY_TIMEOUT_MS);
         long leaseRecoveredTime = System.currentTimeMillis();
         LOG.debug("Lease recovery for file {} take {} ms.", path, leaseRecoveredTime - start);
 

--- a/flink-filesystems/flink-hadoop-fs/src/main/java/org/apache/flink/runtime/fs/hdfs/HadoopRecoverableFsDataOutputStream.java
+++ b/flink-filesystems/flink-hadoop-fs/src/main/java/org/apache/flink/runtime/fs/hdfs/HadoopRecoverableFsDataOutputStream.java
@@ -37,7 +37,6 @@ import org.apache.hadoop.fs.viewfs.ViewFileSystem;
 import org.apache.hadoop.hdfs.DistributedFileSystem;
 import org.apache.hadoop.hdfs.protocol.LocatedBlocks;
 import org.apache.hadoop.util.VersionInfo;
-
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 

--- a/flink-filesystems/flink-hadoop-fs/src/main/java/org/apache/flink/runtime/fs/hdfs/HadoopRecoverableFsDataOutputStream.java
+++ b/flink-filesystems/flink-hadoop-fs/src/main/java/org/apache/flink/runtime/fs/hdfs/HadoopRecoverableFsDataOutputStream.java
@@ -407,8 +407,9 @@ class HadoopRecoverableFsDataOutputStream extends RecoverableFsDataOutputStream 
 
         boolean success = false;
         while (deadline.hasTimeLeft()) {
+            String absolutePath = Path.getPathWithoutSchemeAndAuthority(path).toString();
             LocatedBlocks blocks =
-                    dfs.getClient().getLocatedBlocks(path.toString(), 0, Long.MAX_VALUE);
+                    dfs.getClient().getLocatedBlocks(absolutePath, 0, Long.MAX_VALUE);
             boolean noLastBlock = blocks.getLastLocatedBlock() == null;
             if (!blocks.isUnderConstruction() && (noLastBlock || blocks.isLastBlockComplete())) {
                 success = true;


### PR DESCRIPTION
## What is the purpose of the change

In the case of HDFS, upon job recovery, StreamingFileSink would not wait for lease recoveries to complete before truncating a file (now it would try to truncate the file after a timeout, no matter if the lease is revoked or not). This may lead to an IOException because the file length could be behind the actual length and the checkpointed length. What's worse, the job may fall into an endless restart loop, because a new invoke of #recoverLease will interrupt the previous one (see [HBase's RecoverLeaseFSUtils](https://github.com/apache/hbase/blob/a9a1b9524daa9e33541c655620b9c07d5a93d533/hbase-asyncfs/src/main/java/org/apache/hadoop/hbase/util/RecoverLeaseFSUtils.java#L68)).

Moreover, we should wait for block recoveries which may be triggered by truncate calls (as mentioned in [Hadoop FileSystem Javadoc](https://hadoop.apache.org/docs/current/api/org/apache/hadoop/fs/FileSystem.html#truncate)), before appending to the recovered files.

This PR fixes the problem, but with two hard-coded timeout thresholds since it requires interfaces changes to make these timeouts configurable. If the lease recovery of the block recovery fails, an IOException would be thrown, which triggers a restart of the job.

## Brief change log

- Wait for lease recoveries to complete before truncating in-progress files.
- Wait for possible block recoveries to complete before appending to recovered files.

## Verifying this change

I simply tested it on an HDFS cluster with 3 nodes, but it may require further tests.

This change added tests and can be verified as follows:

1. Start a Flink job writing recoverable HDFS files.
2. Manually kill a DateNode which StreamingFileSink is writing to (to trigger lease recovery and block recovery).
3. Restart the job from the latest successful checkpoint. The files should be properly recovered.

## Does this pull request potentially affect one of the following parts:

  - Dependencies (does it add or upgrade a dependency): no
  - The public API, i.e., is any changed class annotated with `@Public(Evolving)`: no
  - The serializers: no
  - The runtime per-record code paths (performance sensitive): no
  - Anything that affects deployment or recovery: JobManager (and its components), Checkpointing, Kubernetes/Yarn, ZooKeeper: no
  - The S3 file system connector: no

## Documentation

  - Does this pull request introduce a new feature? no
  - If yes, how is the feature documented? (not applicable / docs / JavaDocs / not documented)
