### PR TITLE
[FLINK-23190][runtime] Make AdaptiveScheduler and DefaultScheduler allocate slot more evenly.

### DIFF
--- a/docs/layouts/shortcodes/generated/all_jobmanager_section.html
+++ b/docs/layouts/shortcodes/generated/all_jobmanager_section.html
@@ -86,5 +86,11 @@
             <td>Integer</td>
             <td>The maximum number of failures collected by the exception history per job.</td>
         </tr>
+        <tr>
+            <td><h5>jobmanager.scheduler.enable-slot-allocate-order-optimization</h5></td>
+            <td style="word-wrap: break-word;">false</td>
+            <td>Boolean</td>
+            <td>Flag indicating whether to enable the slot allocate optimization for DefaultScheduler and AdaptiveScheduler. It could distribute subtasks (belong to the same operator) across as many TaskManagers as possible.</td>
+        </tr>
     </tbody>
 </table>

--- a/docs/layouts/shortcodes/generated/expert_scheduling_section.html
+++ b/docs/layouts/shortcodes/generated/expert_scheduling_section.html
@@ -80,5 +80,11 @@
             <td>Integer</td>
             <td>Defines the maximum number of slots that the Flink cluster allocates. This configuration option is meant for limiting the resource consumption for batch workloads. It is not recommended to configure this option for streaming workloads, which may fail if there are not enough slots. Note that this configuration option does not take effect for standalone clusters, where how many slots are allocated is not controlled by Flink.</td>
         </tr>
+        <tr>
+            <td><h5>jobmanager.scheduler.enable-slot-allocate-order-optimization</h5></td>
+            <td style="word-wrap: break-word;">false</td>
+            <td>Boolean</td>
+            <td>Flag indicating whether to enable the slot allocate optimization for DefaultScheduler and AdaptiveScheduler. It could distribute subtasks (belong to the same operator) across as many TaskManagers as possible.</td>
+        </tr>
     </tbody>
 </table>

--- a/docs/layouts/shortcodes/generated/job_manager_configuration.html
+++ b/docs/layouts/shortcodes/generated/job_manager_configuration.html
@@ -164,5 +164,11 @@
             <td>Long</td>
             <td>The timeout in milliseconds for requesting a slot from Slot Pool.</td>
         </tr>
+        <tr>
+            <td><h5>jobmanager.scheduler.enable-slot-allocate-order-optimization</h5></td>
+            <td style="word-wrap: break-word;">false</td>
+            <td>Boolean</td>
+            <td>Flag indicating whether to enable the slot allocate optimization for DefaultScheduler and AdaptiveScheduler. It could distribute subtasks (belong to the same operator) across as many TaskManagers as possible.</td>
+        </tr>
     </tbody>
 </table>

--- a/flink-core/src/main/java/org/apache/flink/configuration/JobManagerOptions.java
+++ b/flink-core/src/main/java/org/apache/flink/configuration/JobManagerOptions.java
@@ -454,6 +454,18 @@ public class JobManagerOptions {
                     .withDescription(
                             "Controls whether partitions should already be released during the job execution.");
 
+    @Documentation.Section({
+        Documentation.Sections.EXPERT_SCHEDULING,
+        Documentation.Sections.ALL_JOB_MANAGER
+    })
+    public static final ConfigOption<Boolean> SLOT_ALLOCATE_ORDER_OPTIMIZATION =
+            key("jobmanager.scheduler.enable-slot-allocate-order-optimization")
+                    .booleanType()
+                    .defaultValue(false)
+                    .withDescription(
+                            "Flag indicating whether to enable the slot allocate optimization for DefaultScheduler and AdaptiveScheduler. "
+                                    + "It could distribute subtasks (belong to the same operator) across as many TaskManagers as possible.");
+
     // ---------------------------------------------------------------------------------------------
 
     private JobManagerOptions() {

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/scheduler/DefaultSchedulerComponents.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/scheduler/DefaultSchedulerComponents.java
@@ -23,6 +23,7 @@ import org.apache.flink.api.common.time.Time;
 import org.apache.flink.configuration.CheckpointingOptions;
 import org.apache.flink.configuration.ClusterOptions;
 import org.apache.flink.configuration.Configuration;
+import org.apache.flink.configuration.JobManagerOptions;
 import org.apache.flink.runtime.concurrent.ComponentMainThreadExecutor;
 import org.apache.flink.runtime.jobgraph.JobType;
 import org.apache.flink.runtime.jobmaster.slotpool.LocationPreferenceSlotSelectionStrategy;
@@ -100,12 +101,16 @@ public class DefaultSchedulerComponents {
                         slotPool, SystemClock.getInstance());
         final PhysicalSlotProvider physicalSlotProvider =
                 new PhysicalSlotProviderImpl(slotSelectionStrategy, slotPool);
+        final boolean enableSlotAllocateOrderOptimization =
+                jobMasterConfiguration.getBoolean(
+                        JobManagerOptions.SLOT_ALLOCATE_ORDER_OPTIMIZATION);
         final ExecutionSlotAllocatorFactory allocatorFactory =
                 new SlotSharingExecutionSlotAllocatorFactory(
                         physicalSlotProvider,
                         jobType == JobType.STREAMING,
                         bulkChecker,
-                        slotRequestTimeout);
+                        slotRequestTimeout,
+                        enableSlotAllocateOrderOptimization);
         return new DefaultSchedulerComponents(
                 new PipelinedRegionSchedulingStrategy.Factory(),
                 bulkChecker::start,

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/scheduler/EvenlySlotSharingGroupOrderStrategy.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/scheduler/EvenlySlotSharingGroupOrderStrategy.java
@@ -1,0 +1,50 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.flink.runtime.scheduler;
+
+import org.apache.flink.runtime.jobgraph.JobVertexID;
+import org.apache.flink.runtime.util.CircleIterator;
+
+import java.util.ArrayList;
+import java.util.Collection;
+import java.util.Comparator;
+import java.util.List;
+import java.util.Map;
+import java.util.Set;
+import java.util.stream.Collectors;
+
+/** A default implementation of {@link SlotSharingGroupOrderFunction}. */
+public class EvenlySlotSharingGroupOrderStrategy implements SlotSharingGroupOrderFunction {
+
+    @Override
+    public List<ExecutionSlotSharingGroup> determineOrder(
+            Collection<ExecutionSlotSharingGroup> groups) {
+        final Map<Set<JobVertexID>, List<ExecutionSlotSharingGroup>> slotSharingGroups =
+                groups.stream()
+                        .collect(Collectors.groupingBy(ExecutionSlotSharingGroup::getJobVertexIds));
+        final Comparator<Set<JobVertexID>> comparator = Comparator.comparingInt(Collection::size);
+
+        final CircleIterator<Set<JobVertexID>, ExecutionSlotSharingGroup> iterator =
+                new CircleIterator<>(slotSharingGroups, comparator.reversed());
+        List<ExecutionSlotSharingGroup> orders = new ArrayList<>();
+        while (iterator.hasNext()) {
+            orders.add(iterator.next());
+        }
+        return orders;
+    }
+}

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/scheduler/ExecutionSlotSharingGroup.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/scheduler/ExecutionSlotSharingGroup.java
@@ -19,12 +19,14 @@
 package org.apache.flink.runtime.scheduler;
 
 import org.apache.flink.runtime.clusterframework.types.ResourceProfile;
+import org.apache.flink.runtime.jobgraph.JobVertexID;
 import org.apache.flink.runtime.scheduler.strategy.ExecutionVertexID;
 import org.apache.flink.util.Preconditions;
 
 import java.util.Collections;
 import java.util.HashSet;
 import java.util.Set;
+import java.util.stream.Collectors;
 
 /** Represents execution vertices that will run the same shared slot. */
 class ExecutionSlotSharingGroup {
@@ -51,5 +53,11 @@ class ExecutionSlotSharingGroup {
 
     Set<ExecutionVertexID> getExecutionVertexIds() {
         return Collections.unmodifiableSet(executionVertexIds);
+    }
+
+    Set<JobVertexID> getJobVertexIds() {
+        return executionVertexIds.stream()
+                .map(ExecutionVertexID::getJobVertexId)
+                .collect(Collectors.toSet());
     }
 }

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/scheduler/SlotSharingGroupOrderFunction.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/scheduler/SlotSharingGroupOrderFunction.java
@@ -1,0 +1,33 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.flink.runtime.scheduler;
+
+import java.util.Collection;
+import java.util.List;
+
+/** A function for determining ExecutionSlotSharingGroup allocate orders. */
+@FunctionalInterface
+public interface SlotSharingGroupOrderFunction {
+    /**
+     * Sort the groups to control the allocate order.
+     *
+     * @param groups which need to be sorted
+     * @return sorted groups
+     */
+    List<ExecutionSlotSharingGroup> determineOrder(Collection<ExecutionSlotSharingGroup> groups);
+}

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/scheduler/adaptive/allocator/EvenlySlotSharingOrderStrategy.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/scheduler/adaptive/allocator/EvenlySlotSharingOrderStrategy.java
@@ -1,0 +1,50 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.flink.runtime.scheduler.adaptive.allocator;
+
+import org.apache.flink.runtime.jobmaster.SlotInfo;
+import org.apache.flink.runtime.taskmanager.TaskManagerLocation;
+import org.apache.flink.runtime.util.CircleIterator;
+
+import java.util.ArrayList;
+import java.util.Collection;
+import java.util.Comparator;
+import java.util.List;
+import java.util.Map;
+import java.util.stream.Collectors;
+
+/** A default implementation of {@link SlotOrderFunction}. */
+public class EvenlySlotSharingOrderStrategy implements SlotOrderFunction {
+
+    @Override
+    public List<? extends SlotInfo> determineOrder(Collection<? extends SlotInfo> slots) {
+        final Map<TaskManagerLocation, List<SlotInfo>> taskManagerSlots =
+                slots.stream().collect(Collectors.groupingBy(SlotInfo::getTaskManagerLocation));
+        final Comparator<TaskManagerLocation> comparator =
+                Comparator.comparingInt(taskManager -> taskManagerSlots.get(taskManager).size());
+
+        final CircleIterator<TaskManagerLocation, SlotInfo> iterator =
+                new CircleIterator<>(taskManagerSlots, comparator.reversed());
+        List<SlotInfo> orders = new ArrayList<>();
+        while (iterator.hasNext()) {
+            orders.add(iterator.next());
+        }
+
+        return orders;
+    }
+}

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/scheduler/adaptive/allocator/SlotOrderFunction.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/scheduler/adaptive/allocator/SlotOrderFunction.java
@@ -1,0 +1,35 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.flink.runtime.scheduler.adaptive.allocator;
+
+import org.apache.flink.runtime.jobmaster.SlotInfo;
+
+import java.util.Collection;
+import java.util.List;
+
+/** A function for determining slot allocate orders. */
+@FunctionalInterface
+public interface SlotOrderFunction {
+    /**
+     * Sort the slots to control the allocate order.
+     *
+     * @param slots which need to be sorted
+     * @return sorted slots
+     */
+    List<? extends SlotInfo> determineOrder(Collection<? extends SlotInfo> slots);
+}

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/scheduler/adaptive/allocator/SlotSharingSlotAllocator.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/scheduler/adaptive/allocator/SlotSharingSlotAllocator.java
@@ -49,22 +49,34 @@ public class SlotSharingSlotAllocator implements SlotAllocator {
     private final ReserveSlotFunction reserveSlotFunction;
     private final FreeSlotFunction freeSlotFunction;
     private final IsSlotAvailableAndFreeFunction isSlotAvailableAndFreeFunction;
+    private final SlotOrderFunction slotOrderFunction;
 
     private SlotSharingSlotAllocator(
             ReserveSlotFunction reserveSlot,
             FreeSlotFunction freeSlotFunction,
-            IsSlotAvailableAndFreeFunction isSlotAvailableAndFreeFunction) {
+            IsSlotAvailableAndFreeFunction isSlotAvailableAndFreeFunction,
+            SlotOrderFunction slotOrderFunction) {
         this.reserveSlotFunction = reserveSlot;
         this.freeSlotFunction = freeSlotFunction;
         this.isSlotAvailableAndFreeFunction = isSlotAvailableAndFreeFunction;
+        this.slotOrderFunction = slotOrderFunction;
     }
 
     public static SlotSharingSlotAllocator createSlotSharingSlotAllocator(
             ReserveSlotFunction reserveSlot,
             FreeSlotFunction freeSlotFunction,
             IsSlotAvailableAndFreeFunction isSlotAvailableAndFreeFunction) {
+        return createSlotSharingSlotAllocator(
+                reserveSlot, freeSlotFunction, isSlotAvailableAndFreeFunction, ArrayList::new);
+    }
+
+    public static SlotSharingSlotAllocator createSlotSharingSlotAllocator(
+            ReserveSlotFunction reserveSlot,
+            FreeSlotFunction freeSlotFunction,
+            IsSlotAvailableAndFreeFunction isSlotAvailableAndFreeFunction,
+            SlotOrderFunction slotOrderFunction) {
         return new SlotSharingSlotAllocator(
-                reserveSlot, freeSlotFunction, isSlotAvailableAndFreeFunction);
+                reserveSlot, freeSlotFunction, isSlotAvailableAndFreeFunction, slotOrderFunction);
     }
 
     @Override
@@ -103,7 +115,8 @@ public class SlotSharingSlotAllocator implements SlotAllocator {
             return Optional.empty();
         }
 
-        final Iterator<? extends SlotInfo> slotIterator = freeSlots.iterator();
+        final Iterator<? extends SlotInfo> slotIterator =
+                slotOrderFunction.determineOrder(freeSlots).iterator();
 
         final Collection<ExecutionSlotSharingGroupAndSlot> assignments = new ArrayList<>();
         final Map<JobVertexID, Integer> allVertexParallelism = new HashMap<>();

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/util/CircleIterator.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/util/CircleIterator.java
@@ -1,0 +1,67 @@
+package org.apache.flink.runtime.util;
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import org.apache.flink.util.Preconditions;
+
+import java.util.Comparator;
+import java.util.HashMap;
+import java.util.Iterator;
+import java.util.List;
+import java.util.Map;
+import java.util.NoSuchElementException;
+import java.util.stream.Collectors;
+
+public class CircleIterator<K, V> implements Iterator<V> {
+    private final Map<K, List<V>> values;
+    private final List<K> orders;
+    private int index;
+
+    public CircleIterator(Map<K, List<V>> values, Comparator<K> comparator) {
+        Preconditions.checkNotNull(values);
+        Preconditions.checkNotNull(comparator);
+        this.values = new HashMap<>(values);
+        this.orders = values.keySet().stream().sorted(comparator).collect(Collectors.toList());
+    }
+
+    @Override
+    public boolean hasNext() {
+        for (List<V> list : values.values()) {
+            if (!list.isEmpty()) {
+                return true;
+            }
+        }
+        return false;
+    }
+
+    @Override
+    public V next() {
+        for (int i = 0; i < orders.size(); ++i) {
+            List<V> candidate = nextCandidate();
+            if (candidate.isEmpty()) {
+                continue;
+            }
+            return candidate.remove(0);
+        }
+        throw new NoSuchElementException();
+    }
+
+    private List<V> nextCandidate() {
+        int i = (index++) % orders.size();
+        return values.get(orders.get(i));
+    }
+}

--- a/flink-runtime/src/test/java/org/apache/flink/runtime/jobmaster/slotpool/DeclarativeSlotPoolBridgeTest.java
+++ b/flink-runtime/src/test/java/org/apache/flink/runtime/jobmaster/slotpool/DeclarativeSlotPoolBridgeTest.java
@@ -20,6 +20,7 @@ package org.apache.flink.runtime.jobmaster.slotpool;
 
 import org.apache.flink.api.common.JobID;
 import org.apache.flink.api.common.time.Time;
+import org.apache.flink.configuration.JobManagerOptions;
 import org.apache.flink.core.testutils.FlinkMatchers;
 import org.apache.flink.runtime.clusterframework.types.AllocationID;
 import org.apache.flink.runtime.clusterframework.types.ResourceProfile;
@@ -43,15 +44,20 @@ import org.junit.Test;
 import javax.annotation.Nonnull;
 
 import java.time.Duration;
+import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.Collections;
+import java.util.LinkedHashMap;
 import java.util.List;
+import java.util.Map;
 import java.util.concurrent.CompletableFuture;
 import java.util.concurrent.ExecutionException;
+import java.util.concurrent.TimeUnit;
 import java.util.stream.Collectors;
 
 import static org.hamcrest.CoreMatchers.is;
 import static org.hamcrest.MatcherAssert.assertThat;
+import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.fail;
 
 /** Tests for the {@link DeclarativeSlotPoolBridge}. */
@@ -83,6 +89,53 @@ public class DeclarativeSlotPoolBridgeTest extends TestLogger {
             declarativeSlotPoolBridge.newSlotsAreAvailable(Collections.singleton(allocatedSlot));
 
             slotAllocationFuture.join();
+        }
+    }
+
+    /**
+     * This test guarantees the correctness of {@link
+     * JobManagerOptions#SLOT_ALLOCATE_ORDER_OPTIMIZATION}. The optimization only works under this
+     * assumption for DefaultScheduler.
+     */
+    @Test
+    public void testSlotAllocateOrder() throws Exception {
+        final TestingDeclarativeSlotPoolFactory declarativeSlotPoolFactory =
+                new TestingDeclarativeSlotPoolFactory(TestingDeclarativeSlotPool.builder());
+        try (DeclarativeSlotPoolBridge declarativeSlotPoolBridge =
+                createDeclarativeSlotPoolBridge(declarativeSlotPoolFactory)) {
+
+            declarativeSlotPoolBridge.start(jobMasterId, "localhost", mainThreadExecutor);
+
+            Map<SlotRequestId, PhysicalSlot> expectMapping = new LinkedHashMap<>();
+            List<PhysicalSlot> slots = new ArrayList<>();
+
+            for (int i = 0; i < 10; ++i) {
+                final AllocationID allocationId = new AllocationID();
+                final PhysicalSlot allocatedSlot = createAllocatedSlot(allocationId);
+                slots.add(allocatedSlot);
+
+                final SlotRequestId slotRequestId = new SlotRequestId();
+                expectMapping.put(slotRequestId, allocatedSlot);
+            }
+
+            Map<SlotRequestId, CompletableFuture<PhysicalSlot>> actualMapping =
+                    new LinkedHashMap<>();
+            for (SlotRequestId slotRequestId : expectMapping.keySet()) {
+                CompletableFuture<PhysicalSlot> slotAllocationFuture =
+                        declarativeSlotPoolBridge.requestNewAllocatedSlot(
+                                slotRequestId, ResourceProfile.UNKNOWN, null);
+                actualMapping.put(slotRequestId, slotAllocationFuture);
+            }
+
+            declarativeSlotPoolBridge.newSlotsAreAvailable(slots);
+
+            for (Map.Entry<SlotRequestId, CompletableFuture<PhysicalSlot>> entry :
+                    actualMapping.entrySet()) {
+                SlotRequestId slotRequestId = entry.getKey();
+                PhysicalSlot expectSlot = expectMapping.get(slotRequestId);
+                PhysicalSlot actualSlot = entry.getValue().get(10, TimeUnit.SECONDS);
+                assertEquals(expectSlot, actualSlot);
+            }
         }
     }
 

--- a/flink-runtime/src/test/java/org/apache/flink/runtime/scheduler/SchedulerTestingUtils.java
+++ b/flink-runtime/src/test/java/org/apache/flink/runtime/scheduler/SchedulerTestingUtils.java
@@ -382,7 +382,8 @@ public class SchedulerTestingUtils {
                 true,
                 new TestingPhysicalSlotRequestBulkChecker(),
                 allocationTimeout,
-                new LocalInputPreferredSlotSharingStrategy.Factory());
+                new LocalInputPreferredSlotSharingStrategy.Factory(),
+                false);
     }
 
     /** Builder for {@link DefaultScheduler}. */

--- a/flink-runtime/src/test/java/org/apache/flink/runtime/scheduler/SlotSharingExecutionSlotAllocatorTest.java
+++ b/flink-runtime/src/test/java/org/apache/flink/runtime/scheduler/SlotSharingExecutionSlotAllocatorTest.java
@@ -22,6 +22,8 @@ import org.apache.flink.api.common.time.Time;
 import org.apache.flink.runtime.clusterframework.types.AllocationID;
 import org.apache.flink.runtime.clusterframework.types.ResourceProfile;
 import org.apache.flink.runtime.clusterframework.types.SlotProfile;
+import org.apache.flink.runtime.executiongraph.utils.SimpleAckingTaskManagerGateway;
+import org.apache.flink.runtime.jobgraph.JobVertexID;
 import org.apache.flink.runtime.jobmaster.LogicalSlot;
 import org.apache.flink.runtime.jobmaster.SlotRequestId;
 import org.apache.flink.runtime.jobmaster.TestingPayload;
@@ -31,6 +33,8 @@ import org.apache.flink.runtime.jobmaster.slotpool.PhysicalSlotRequestBulk;
 import org.apache.flink.runtime.jobmaster.slotpool.PhysicalSlotRequestBulkChecker;
 import org.apache.flink.runtime.scheduler.SharedSlotProfileRetriever.SharedSlotProfileRetrieverFactory;
 import org.apache.flink.runtime.scheduler.strategy.ExecutionVertexID;
+import org.apache.flink.runtime.taskmanager.LocalTaskManagerLocation;
+import org.apache.flink.runtime.taskmanager.TaskManagerLocation;
 import org.apache.flink.util.FlinkException;
 import org.apache.flink.util.TestLogger;
 import org.apache.flink.util.function.BiConsumerWithException;
@@ -43,6 +47,7 @@ import java.util.Collection;
 import java.util.Collections;
 import java.util.HashMap;
 import java.util.HashSet;
+import java.util.LinkedList;
 import java.util.List;
 import java.util.Map;
 import java.util.Optional;
@@ -50,6 +55,7 @@ import java.util.Set;
 import java.util.concurrent.CancellationException;
 import java.util.concurrent.CompletableFuture;
 import java.util.concurrent.ExecutionException;
+import java.util.concurrent.TimeUnit;
 import java.util.stream.Collectors;
 
 import static org.apache.flink.runtime.executiongraph.ExecutionGraphTestUtils.createRandomExecutionVertexId;
@@ -59,6 +65,7 @@ import static org.hamcrest.Matchers.empty;
 import static org.hamcrest.Matchers.hasSize;
 import static org.hamcrest.Matchers.instanceOf;
 import static org.hamcrest.Matchers.notNullValue;
+import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertThat;
 import static org.junit.Assert.assertTrue;
 import static org.junit.Assert.fail;
@@ -471,6 +478,85 @@ public class SlotSharingExecutionSlotAllocatorTest extends TestLogger {
                 containsInAnyOrder(resourceProfile1, resourceProfile2));
     }
 
+    @Test
+    public void testAllocatePhysicalSlotEnableOrderOptimization() throws Exception {
+        AllocationContext.Builder build =
+                AllocationContext.newBuilder()
+                        .withSlotSharingGroupOrderFunction(
+                                new EvenlySlotSharingGroupOrderStrategy());
+
+        JobVertexID operatorA = new JobVertexID();
+        JobVertexID operatorB = new JobVertexID();
+
+        // Specify operatorA parallelism 4
+        // Specify operatorB parallelism 8
+        List<ExecutionVertexID> executionVertexIds = new ArrayList<>();
+        for (int i = 0; i < 4; ++i) {
+            ExecutionVertexID executionVertexId1 = new ExecutionVertexID(operatorA, i);
+            ExecutionVertexID executionVertexId2 = new ExecutionVertexID(operatorB, i);
+            build.addGroup(executionVertexId1, executionVertexId2);
+            executionVertexIds.add(executionVertexId1);
+            executionVertexIds.add(executionVertexId2);
+        }
+
+        for (int i = 4; i < 8; ++i) {
+            ExecutionVertexID executionVertexId = new ExecutionVertexID(operatorB, i);
+            build.addGroup(executionVertexId);
+            executionVertexIds.add(executionVertexId);
+        }
+
+        // Create 4 TaskMangers with 2 slots.
+        final int taskManagers = 4;
+        final int ys = 2;
+        final List<TestingPhysicalSlot> physicalSlots = new LinkedList<>();
+        for (int i = 0; i < taskManagers; ++i) {
+            TaskManagerLocation taskManager = new LocalTaskManagerLocation();
+            SimpleAckingTaskManagerGateway gateway = new SimpleAckingTaskManagerGateway();
+            for (int j = 0; j < ys; ++j) {
+                TestingPhysicalSlot physicalSlot =
+                        new TestingPhysicalSlot(
+                                new AllocationID(), taskManager, gateway, ResourceProfile.UNKNOWN);
+                physicalSlots.add(physicalSlot);
+            }
+        }
+
+        TestingPhysicalSlotProvider physicalSlotProvider =
+                TestingPhysicalSlotProvider.create(
+                        (resourceProfile) ->
+                                CompletableFuture.completedFuture(physicalSlots.remove(0)));
+
+        build.withPhysicalSlotProvider(physicalSlotProvider);
+        AllocationContext context = build.build();
+
+        List<SlotExecutionVertexAssignment> assignments =
+                context.allocateSlotsFor(executionVertexIds.toArray(new ExecutionVertexID[0]));
+
+        Map<TaskManagerLocation, List<ExecutionVertexID>> distribution = new HashMap<>();
+        for (SlotExecutionVertexAssignment assignment : assignments) {
+            LogicalSlot slot = assignment.getLogicalSlotFuture().get(10, TimeUnit.SECONDS);
+            TaskManagerLocation taskManager = slot.getTaskManagerLocation();
+            distribution
+                    .computeIfAbsent(taskManager, (key) -> new ArrayList<>())
+                    .add(assignment.getExecutionVertexId());
+        }
+
+        for (Map.Entry<TaskManagerLocation, List<ExecutionVertexID>> entry :
+                distribution.entrySet()) {
+            List<ExecutionVertexID> vertexIds = entry.getValue();
+            long parallelismA =
+                    vertexIds.stream()
+                            .filter(vertex -> vertex.getJobVertexId().equals(operatorA))
+                            .count();
+            long parallelismB =
+                    vertexIds.stream()
+                            .filter(vertex -> vertex.getJobVertexId().equals(operatorB))
+                            .count();
+            // Every TaskManager contains 1 operatorA and 2 operatorB.
+            assertEquals(1, parallelismA);
+            assertEquals(2, parallelismB);
+        }
+    }
+
     private static List<ExecutionVertexID> getAssignIds(
             Collection<SlotExecutionVertexAssignment> assignments) {
         return assignments.stream()
@@ -552,6 +638,8 @@ public class SlotSharingExecutionSlotAllocatorTest extends TestLogger {
             private TestingPhysicalSlotProvider physicalSlotProvider =
                     TestingPhysicalSlotProvider.createWithInfiniteSlotCreation();
 
+            private SlotSharingGroupOrderFunction slotSharingGroupOrderFunction = ArrayList::new;
+
             private Builder addGroup(ExecutionVertexID... group) {
                 groups.put(group, ResourceProfile.UNKNOWN);
                 return this;
@@ -580,6 +668,12 @@ public class SlotSharingExecutionSlotAllocatorTest extends TestLogger {
                 return this;
             }
 
+            private Builder withSlotSharingGroupOrderFunction(
+                    SlotSharingGroupOrderFunction slotSharingGroupOrderFunction) {
+                this.slotSharingGroupOrderFunction = slotSharingGroupOrderFunction;
+                return this;
+            }
+
             private AllocationContext build() {
                 TestingSharedSlotProfileRetrieverFactory sharedSlotProfileRetrieverFactory =
                         new TestingSharedSlotProfileRetrieverFactory();
@@ -593,7 +687,8 @@ public class SlotSharingExecutionSlotAllocatorTest extends TestLogger {
                                 sharedSlotProfileRetrieverFactory,
                                 bulkChecker,
                                 ALLOCATION_TIMEOUT,
-                                executionVertexID -> RESOURCE_PROFILE);
+                                executionVertexID -> RESOURCE_PROFILE,
+                                slotSharingGroupOrderFunction);
                 return new AllocationContext(
                         physicalSlotProvider,
                         slotSharingStrategy,

--- a/flink-runtime/src/test/java/org/apache/flink/runtime/scheduler/adaptive/AdaptiveSchedulerBuilder.java
+++ b/flink-runtime/src/test/java/org/apache/flink/runtime/scheduler/adaptive/AdaptiveSchedulerBuilder.java
@@ -204,7 +204,7 @@ public class AdaptiveSchedulerBuilder {
                 declarativeSlotPool,
                 slotAllocator == null
                         ? AdaptiveSchedulerFactory.createSlotSharingSlotAllocator(
-                                declarativeSlotPool)
+                                declarativeSlotPool, jobMasterConfiguration)
                         : slotAllocator,
                 ioExecutor,
                 userCodeLoader,

--- a/flink-runtime/src/test/java/org/apache/flink/runtime/scheduler/adaptive/allocator/TestSlotInfo.java
+++ b/flink-runtime/src/test/java/org/apache/flink/runtime/scheduler/adaptive/allocator/TestSlotInfo.java
@@ -27,6 +27,15 @@ import org.apache.flink.runtime.taskmanager.TaskManagerLocation;
 class TestSlotInfo implements SlotInfo {
 
     private final AllocationID allocationId = new AllocationID();
+    private final TaskManagerLocation taskManagerLocation;
+
+    public TestSlotInfo() {
+        this(new LocalTaskManagerLocation());
+    }
+
+    public TestSlotInfo(TaskManagerLocation taskManagerLocation) {
+        this.taskManagerLocation = taskManagerLocation;
+    }
 
     @Override
     public AllocationID getAllocationId() {
@@ -35,7 +44,7 @@ class TestSlotInfo implements SlotInfo {
 
     @Override
     public TaskManagerLocation getTaskManagerLocation() {
-        return new LocalTaskManagerLocation();
+        return taskManagerLocation;
     }
 
     @Override


### PR DESCRIPTION
<!--
*Thank you very much for contributing to Apache Flink - we are happy that you want to help us improve Flink. To help the community review your contribution in the best possible way, please go through the checklist below, which will get the contribution into a shape in which it can be best reviewed.*

*Please understand that we do not do this to make contributions to Flink a hassle. In order to uphold a high standard of quality for code contributions, while at the same time managing a large number of contributions, we need contributors to prepare the contributions well, and give reviewers enough contextual information for the review. Please also understand that contributions that do not follow this guide will take longer to review and thus typically be picked up with lower priority by the community.*

## Contribution Checklist

  - Make sure that the pull request corresponds to a [JIRA issue](https://issues.apache.org/jira/projects/FLINK/issues). Exceptions are made for typos in JavaDoc or documentation files, which need no JIRA issue.
  
  - Name the pull request in the form "[FLINK-XXXX] [component] Title of the pull request", where *FLINK-XXXX* should be replaced by the actual issue number. Skip *component* if you are unsure about which is the best component.
  Typo fixes that have no associated JIRA issue should be named following this pattern: `[hotfix] [docs] Fix typo in event time introduction` or `[hotfix] [javadocs] Expand JavaDoc for PuncuatedWatermarkGenerator`.

  - Fill out the template below to describe the changes contributed by the pull request. That will give reviewers the context they need to do the review.
  
  - Make sure that the change passes the automated tests, i.e., `mvn clean verify` passes. You can set up Azure Pipelines CI to do that following [this guide](https://cwiki.apache.org/confluence/display/FLINK/Azure+Pipelines#AzurePipelines-Tutorial:SettingupAzurePipelinesforaforkoftheFlinkrepository).

  - Each pull request should address only one issue, not mix up code from multiple issues.
  
  - Each commit in the pull request has a meaningful commit message (including the JIRA id)

  - Once all items of the checklist are addressed, remove the above text and this checklist, leaving only the filled out template below.


**(The sections below can be removed for hotfixes of typos)**
-->

## What is the purpose of the change

*This pull request improves AdaptiveScheduler and DefaultScheduler slot allocation, and try to distribute subtasks (belong to the same operator) across as many TaskManagers as possible.*

Discussion in FLINK-23190


## Brief change log

  - *Add jobmanager options to enable the optimization, off by default.*

## Verifying this change

*(Please pick either of the following options)*

This change is a trivial rework / code cleanup without any test coverage.

**no**

This change is already covered by existing tests, such as *(please describe tests)*.

**no**

This change added tests and can be verified as follows:

-  add test in **DeclarativeSlotPoolBridgeTest** to guard the correctness of  DefaultScheduler
-  add test in **SlotSharingSlotAllocatorTest**
-  add test in **SlotSharingExecutionSlotAllocatorTest**
## Does this pull request potentially affect one of the following parts:

  - Dependencies (does it add or upgrade a dependency): (**no**)
  - The public API, i.e., is any changed class annotated with `@Public(Evolving)`: (**yes**)
  - The serializers: (**no**)
  - The runtime per-record code paths (performance sensitive): (**no**)
  - Anything that affects deployment or recovery: JobManager (and its components), Checkpointing, Kubernetes/Yarn, ZooKeeper: (**yes**)
  - The S3 file system connector: (**no**)

## Documentation

  - Does this pull request introduce a new feature? (**yes**)
  - If yes, how is the feature documented? (**docs**)
