### PR TITLE
[FLINK-23910][streaming] Updated message to correspond to the counter type

### DIFF
--- a/flink-streaming-java/src/main/java/org/apache/flink/streaming/api/functions/async/RichAsyncFunction.java
+++ b/flink-streaming-java/src/main/java/org/apache/flink/streaming/api/functions/async/RichAsyncFunction.java
@@ -236,7 +236,7 @@ public abstract class RichAsyncFunction<IN, OUT> extends AbstractRichFunction
         @Override
         public DoubleCounter getDoubleCounter(String name) {
             throw new UnsupportedOperationException(
-                    "Long counters are not supported in rich async functions.");
+                    "Double counters are not supported in rich async functions.");
         }
 
         @Override


### PR DESCRIPTION

## What is the purpose of the change

* RichAsyncFunction does not support double counters but the message indicates "Long counters..."

## Brief change log

* Corrected message to correspond to the counter type


## Verifying this change

This change is a trivial rework / code cleanup without any test coverage.

## Does this pull request potentially affect one of the following parts:

  - Dependencies (does it add or upgrade a dependency): no
  - The public API, i.e., is any changed class annotated with `@Public(Evolving)`: no
  - The serializers:  no
  - The runtime per-record code paths (performance sensitive): no 
  - Anything that affects deployment or recovery: JobManager (and its components), Checkpointing, Kubernetes/Yarn, ZooKeeper: no 
  - The S3 file system connector: no 

## Documentation

  - Does this pull request introduce a new feature? no
  - If yes, how is the feature documented? not applicable 
