### PR TITLE
[FLINK-23920][table-common] Keep primary key when inferring schema with SchemaTranslator

### DIFF
--- a/flink-table/flink-table-api-java/src/main/java/org/apache/flink/table/catalog/SchemaTranslator.java
+++ b/flink-table/flink-table-api-java/src/main/java/org/apache/flink/table/catalog/SchemaTranslator.java
@@ -66,7 +66,8 @@ public final class SchemaTranslator {
      *
      * <ul>
      *   <li>1. Derive physical columns from the input schema.
-     *   <li>2. Derive physical columns from the input schema but enrich with metadata column.
+     *   <li>2. Derive physical columns from the input schema but enrich with metadata column and
+     *       primary key.
      *   <li>3. Entirely use declared schema.
      * </ul>
      */
@@ -85,7 +86,7 @@ public final class SchemaTranslator {
         final List<UnresolvedColumn> declaredColumns = declaredSchema.getColumns();
 
         // the declared schema does not contain physical information,
-        // thus, it only replaces physical columns with metadata rowtime
+        // thus, it only replaces physical columns with metadata rowtime or adds a primary key
         if (declaredColumns.stream().noneMatch(SchemaTranslator::isPhysical)) {
             // go through data type to erase time attributes
             final DataType sourceDataType = inputSchema.toSourceRowDataType();
@@ -93,7 +94,7 @@ public final class SchemaTranslator {
                     patchDataTypeWithoutMetadataRowtime(sourceDataType, declaredColumns);
             final Schema.Builder builder = Schema.newBuilder();
             builder.fromRowDataType(physicalDataType);
-            builder.fromColumns(declaredColumns);
+            builder.fromSchema(declaredSchema);
             return new ProducingResult(null, builder.build(), null);
         }
 

--- a/flink-table/flink-table-api-java/src/test/java/org/apache/flink/table/catalog/SchemaTranslatorTest.java
+++ b/flink-table/flink-table-api-java/src/test/java/org/apache/flink/table/catalog/SchemaTranslatorTest.java
@@ -312,6 +312,30 @@ public class SchemaTranslatorTest {
     }
 
     @Test
+    public void testOutputToEmptySchema() {
+        final ResolvedSchema tableSchema =
+                ResolvedSchema.of(
+                        Column.physical("id", DataTypes.BIGINT()),
+                        Column.metadata("rowtime", DataTypes.TIMESTAMP_LTZ(3), null, false),
+                        Column.physical("name", DataTypes.STRING()));
+
+        final ProducingResult result =
+                SchemaTranslator.createProducingResult(tableSchema, Schema.derived());
+
+        assertEquals(Optional.empty(), result.getProjections());
+
+        assertEquals(
+                Schema.newBuilder()
+                        .column("id", DataTypes.BIGINT())
+                        .column("rowtime", DataTypes.TIMESTAMP_LTZ(3)) // becomes physical
+                        .column("name", DataTypes.STRING())
+                        .build(),
+                result.getSchema());
+
+        assertEquals(Optional.empty(), result.getPhysicalDataType());
+    }
+
+    @Test
     public void testOutputToMetadataSchema() {
         final ResolvedSchema tableSchema =
                 ResolvedSchema.of(

--- a/flink-table/flink-table-api-java/src/test/java/org/apache/flink/table/catalog/SchemaTranslatorTest.java
+++ b/flink-table/flink-table-api-java/src/test/java/org/apache/flink/table/catalog/SchemaTranslatorTest.java
@@ -336,10 +336,10 @@ public class SchemaTranslatorTest {
     }
 
     @Test
-    public void testOutputToMetadataSchema() {
+    public void testOutputToPartialSchema() {
         final ResolvedSchema tableSchema =
                 ResolvedSchema.of(
-                        Column.physical("id", DataTypes.BIGINT()),
+                        Column.physical("id", DataTypes.BIGINT().notNull()),
                         Column.physical("name", DataTypes.STRING()),
                         Column.metadata("rowtime", DataTypes.TIMESTAMP_LTZ(3), null, false));
 
@@ -349,14 +349,16 @@ public class SchemaTranslatorTest {
                         Schema.newBuilder()
                                 .columnByExpression("computed", "f1 + 42")
                                 .columnByMetadata("rowtime", DataTypes.TIMESTAMP_LTZ(3))
+                                .primaryKey("id")
                                 .build());
 
         assertEquals(
                 Schema.newBuilder()
-                        .column("id", DataTypes.BIGINT())
+                        .column("id", DataTypes.BIGINT().notNull())
                         .column("name", DataTypes.STRING())
                         .columnByExpression("computed", "f1 + 42")
                         .columnByMetadata("rowtime", DataTypes.TIMESTAMP_LTZ(3)) // becomes metadata
+                        .primaryKey("id")
                         .build(),
                 result.getSchema());
     }

--- a/flink-table/flink-table-common/src/main/java/org/apache/flink/table/api/Schema.java
+++ b/flink-table/flink-table-common/src/main/java/org/apache/flink/table/api/Schema.java
@@ -71,6 +71,8 @@ import static org.apache.flink.table.types.logical.utils.LogicalTypeChecks.hasRo
 @PublicEvolving
 public final class Schema {
 
+    private static final Schema EMPTY = Schema.newBuilder().build();
+
     private final List<UnresolvedColumn> columns;
 
     private final List<UnresolvedWatermarkSpec> watermarkSpecs;
@@ -89,6 +91,19 @@ public final class Schema {
     /** Builder for configuring and creating instances of {@link Schema}. */
     public static Schema.Builder newBuilder() {
         return new Builder();
+    }
+
+    /**
+     * Convenience method for stating explicitly that a schema is empty and should be fully derived
+     * by the framework.
+     *
+     * <p>The semantics are equivalent to calling {@code Schema.newBuilder().build()}.
+     *
+     * <p>Note that derivation depends on the context. Usually, the method that accepts a {@link
+     * Schema} instance will mention whether schema derivation is supported or not.
+     */
+    public static Schema derived() {
+        return EMPTY;
     }
 
     public List<UnresolvedColumn> getColumns() {

--- a/flink-table/flink-table-common/src/main/java/org/apache/flink/table/api/Schema.java
+++ b/flink-table/flink-table-common/src/main/java/org/apache/flink/table/api/Schema.java
@@ -221,18 +221,6 @@ public final class Schema {
             return this;
         }
 
-        /** Apply comment to the previous column. */
-        public Builder withComment(@Nullable String comment) {
-            if (columns.size() > 0) {
-                columns.set(
-                        columns.size() - 1, columns.get(columns.size() - 1).withComment(comment));
-            } else {
-                throw new IllegalArgumentException(
-                        "Method \"withComment\" must be followed by a column definition, but there is no preceding column defined.");
-            }
-            return this;
-        }
-
         /**
          * Declares a physical column that is appended to this schema.
          *
@@ -462,6 +450,19 @@ public final class Schema {
                 boolean isVirtual) {
             return columnByMetadata(
                     columnName, DataTypes.of(serializableTypeString), metadataKey, isVirtual);
+        }
+
+        /** Apply comment to the previous column. */
+        public Builder withComment(@Nullable String comment) {
+            if (columns.size() > 0) {
+                columns.set(
+                        columns.size() - 1, columns.get(columns.size() - 1).withComment(comment));
+            } else {
+                throw new IllegalArgumentException(
+                        "Method 'withComment(...)' must be called after a column definition, "
+                                + "but there is no preceding column defined.");
+            }
+            return this;
         }
 
         /**


### PR DESCRIPTION
## What is the purpose of the change

Fixes a couple of shortcomings with the `Schema` and `SchemaTranslator`.

## Brief change log

See commit messages.

## Verifying this change

This change added tests and can be verified as follows: `SchemaTranslatorTest`

## Does this pull request potentially affect one of the following parts:

  - Dependencies (does it add or upgrade a dependency): no
  - The public API, i.e., is any changed class annotated with `@Public(Evolving)`: yes
  - The serializers: no
  - The runtime per-record code paths (performance sensitive): no
  - Anything that affects deployment or recovery: JobManager (and its components), Checkpointing, Kubernetes/Yarn, ZooKeeper: no
  - The S3 file system connector: no

## Documentation

  - Does this pull request introduce a new feature? no
  - If yes, how is the feature documented? JavaDocs
