### PR TITLE
[FLINK-23896][streaming] Implement retrying for failed committables for Sinks

### DIFF
--- a/flink-connectors/flink-connector-kafka/src/test/java/org/apache/flink/connector/kafka/sink/KafkaCommitterTest.java
+++ b/flink-connectors/flink-connector-kafka/src/test/java/org/apache/flink/connector/kafka/sink/KafkaCommitterTest.java
@@ -1,0 +1,40 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.flink.connector.kafka.sink;
+
+import org.junit.Test;
+
+import java.io.IOException;
+import java.util.Collections;
+import java.util.List;
+import java.util.Properties;
+
+import static org.junit.Assert.assertEquals;
+
+/** Tests for {@link KafkaCommitter}. */
+public class KafkaCommitterTest {
+
+    @Test
+    public void testRetryCommittableOnFailure() throws IOException {
+        final KafkaCommitter committer = new KafkaCommitter(new Properties());
+        final short epoch = 0;
+        final List<KafkaCommittable> committables =
+                Collections.singletonList(new KafkaCommittable(0, epoch, "transactionalId"));
+        assertEquals(committables, committer.commit(committables));
+    }
+}

--- a/flink-streaming-java/src/main/java/org/apache/flink/streaming/runtime/operators/sink/AbstractStreamingCommitterHandler.java
+++ b/flink-streaming-java/src/main/java/org/apache/flink/streaming/runtime/operators/sink/AbstractStreamingCommitterHandler.java
@@ -138,7 +138,10 @@ abstract class AbstractStreamingCommitterHandler<InputT, CommT>
         LOG.info("Committing the state for checkpoint {}", checkpointId);
         final List<CommT> neededToRetryCommittables = commit(readyCommittables);
         if (!neededToRetryCommittables.isEmpty()) {
-            throw new UnsupportedOperationException("Currently does not support the re-commit!");
+            LOG.warn(
+                    "{} committables were not committed successfully, retrying.",
+                    neededToRetryCommittables.size());
+            recoveredCommittables(neededToRetryCommittables);
         }
         return readyCommittables;
     }

--- a/flink-streaming-java/src/main/java/org/apache/flink/streaming/runtime/operators/sink/GlobalBatchCommitterHandler.java
+++ b/flink-streaming-java/src/main/java/org/apache/flink/streaming/runtime/operators/sink/GlobalBatchCommitterHandler.java
@@ -20,6 +20,9 @@ package org.apache.flink.streaming.runtime.operators.sink;
 
 import org.apache.flink.api.connector.sink.GlobalCommitter;
 
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
 import java.io.IOException;
 import java.util.Collections;
 import java.util.List;
@@ -34,6 +37,8 @@ import static org.apache.flink.util.Preconditions.checkNotNull;
  */
 final class GlobalBatchCommitterHandler<CommT, GlobalCommT>
         extends AbstractCommitterHandler<CommT, GlobalCommT> {
+
+    private static final Logger LOG = LoggerFactory.getLogger(GlobalBatchCommitterHandler.class);
 
     /**
      * Aggregate committables to global committables and commit the global committables to the
@@ -50,11 +55,13 @@ final class GlobalBatchCommitterHandler<CommT, GlobalCommT>
         List<CommT> allCommittables = pollCommittables();
         if (!allCommittables.isEmpty()) {
             final GlobalCommT globalCommittable = globalCommitter.combine(allCommittables);
-            final List<GlobalCommT> neededRetryCommittables =
+            List<GlobalCommT> neededRetryCommittables =
                     globalCommitter.commit(Collections.singletonList(globalCommittable));
-            if (!neededRetryCommittables.isEmpty()) {
-                throw new UnsupportedOperationException(
-                        "Currently does not support the re-commit!");
+            while (!neededRetryCommittables.isEmpty()) {
+                LOG.warn(
+                        "{} committables were not committed successfully, retrying.",
+                        neededRetryCommittables.size());
+                neededRetryCommittables = globalCommitter.commit(neededRetryCommittables);
             }
         }
         globalCommitter.endOfInput();

--- a/flink-streaming-java/src/test/java/org/apache/flink/streaming/runtime/operators/sink/TestSink.java
+++ b/flink-streaming-java/src/test/java/org/apache/flink/streaming/runtime/operators/sink/TestSink.java
@@ -35,9 +35,11 @@ import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.Collection;
 import java.util.Collections;
+import java.util.LinkedHashSet;
 import java.util.List;
 import java.util.Optional;
 import java.util.Queue;
+import java.util.Set;
 import java.util.concurrent.ConcurrentLinkedQueue;
 import java.util.function.Function;
 import java.util.function.Supplier;
@@ -275,7 +277,7 @@ public class TestSink<T> implements Sink<T, String, String, String> {
     /** Base class for testing {@link Committer} and {@link GlobalCommitter}. */
     static class DefaultCommitter implements Committer<String>, Serializable {
 
-        @Nullable private Queue<String> committedData;
+        @Nullable protected Queue<String> committedData;
 
         private boolean isClosed;
 
@@ -321,11 +323,22 @@ public class TestSink<T> implements Sink<T, String, String, String> {
     }
 
     /** A {@link Committer} that always re-commits the committables data it received. */
-    static class AlwaysRetryCommitter extends DefaultCommitter implements Committer<String> {
+    static class RetryOnceCommitter extends DefaultCommitter implements Committer<String> {
+
+        private final Set<String> seen = new LinkedHashSet<>();
 
         @Override
         public List<String> commit(List<String> committables) {
-            return committables;
+            committables.forEach(
+                    c -> {
+                        if (seen.remove(c)) {
+                            checkNotNull(committedData);
+                            committedData.add(c);
+                        } else {
+                            seen.add(c);
+                        }
+                    });
+            return new ArrayList<>(seen);
         }
     }
 
@@ -380,11 +393,13 @@ public class TestSink<T> implements Sink<T, String, String, String> {
     }
 
     /** A {@link GlobalCommitter} that always re-commits global committables it received. */
-    static class AlwaysRetryGlobalCommitter extends DefaultGlobalCommitter {
+    static class RetryOnceGlobalCommitter extends DefaultGlobalCommitter {
+
+        private final Set<String> seen = new LinkedHashSet<>();
 
         @Override
         public List<String> filterRecoveredCommittables(List<String> globalCommittables) {
-            return Collections.emptyList();
+            return globalCommittables;
         }
 
         @Override
@@ -397,7 +412,16 @@ public class TestSink<T> implements Sink<T, String, String, String> {
 
         @Override
         public List<String> commit(List<String> committables) {
-            return committables;
+            committables.forEach(
+                    c -> {
+                        if (seen.remove(c)) {
+                            checkNotNull(committedData);
+                            committedData.add(c);
+                        } else {
+                            seen.add(c);
+                        }
+                    });
+            return new ArrayList<>(seen);
         }
     }
 


### PR DESCRIPTION
<!--
*Thank you very much for contributing to Apache Flink - we are happy that you want to help us improve Flink. To help the community review your contribution in the best possible way, please go through the checklist below, which will get the contribution into a shape in which it can be best reviewed.*

*Please understand that we do not do this to make contributions to Flink a hassle. In order to uphold a high standard of quality for code contributions, while at the same time managing a large number of contributions, we need contributors to prepare the contributions well, and give reviewers enough contextual information for the review. Please also understand that contributions that do not follow this guide will take longer to review and thus typically be picked up with lower priority by the community.*

## Contribution Checklist

  - Make sure that the pull request corresponds to a [JIRA issue](https://issues.apache.org/jira/projects/FLINK/issues). Exceptions are made for typos in JavaDoc or documentation files, which need no JIRA issue.
  
  - Name the pull request in the form "[FLINK-XXXX] [component] Title of the pull request", where *FLINK-XXXX* should be replaced by the actual issue number. Skip *component* if you are unsure about which is the best component.
  Typo fixes that have no associated JIRA issue should be named following this pattern: `[hotfix] [docs] Fix typo in event time introduction` or `[hotfix] [javadocs] Expand JavaDoc for PuncuatedWatermarkGenerator`.

  - Fill out the template below to describe the changes contributed by the pull request. That will give reviewers the context they need to do the review.
  
  - Make sure that the change passes the automated tests, i.e., `mvn clean verify` passes. You can set up Azure Pipelines CI to do that following [this guide](https://cwiki.apache.org/confluence/display/FLINK/Azure+Pipelines#AzurePipelines-Tutorial:SettingupAzurePipelinesforaforkoftheFlinkrepository).

  - Each pull request should address only one issue, not mix up code from multiple issues.
  
  - Each commit in the pull request has a meaningful commit message (including the JIRA id)

  - Once all items of the checklist are addressed, remove the above text and this checklist, leaving only the filled out template below.


**(The sections below can be removed for hotfixes of typos)**
-->

## What is the purpose of the change

This PR implements that Sink committers can re-commit committables on transient failures.
The functionality was planned for FLIP-143 https://cwiki.apache.org/confluence/display/FLINK/FLIP-143%3A+Unified+Sink+API but never implemented and a missing final piece to guarantee no data loss.

Furthermore, the KafkaSink is now also retrying to commit transactions on non-fatal errors.


## Brief change log

  - Allow Sink committer operators to retry failed committables
  - KafkaCommitter retries failed transactions

## Verifying this change

  - Enabled retry tests for Sink committer operators
  - Added test to assert that KafkaCommitter returns committable on failure

## Does this pull request potentially affect one of the following parts:

  - Dependencies (does it add or upgrade a dependency): (yes / **no**)
  - The public API, i.e., is any changed class annotated with `@Public(Evolving)`: (yes / **no**)
  - The serializers: (yes / **no** / don't know)
  - The runtime per-record code paths (performance sensitive): (yes / **no** / don't know)
  - Anything that affects deployment or recovery: JobManager (and its components), Checkpointing, Kubernetes/Yarn, ZooKeeper: (yes / **no** / don't know)
  - The S3 file system connector: (yes / **no** / don't know)

## Documentation

  - Does this pull request introduce a new feature? (yes / **no**)
  - If yes, how is the feature documented? (**not applicable** / docs / JavaDocs / not documented)
