### PR TITLE
[FLINK-23929][python] Operator with multiple outputs should not chain with one of the outputs

### DIFF
--- a/flink-python/src/main/java/org/apache/flink/python/chain/PythonOperatorChainingOptimizer.java
+++ b/flink-python/src/main/java/org/apache/flink/python/chain/PythonOperatorChainingOptimizer.java
@@ -235,7 +235,7 @@ public class PythonOperatorChainingOptimizer {
                 }
             }
 
-            if (isChainable(input, transform)) {
+            if (isChainable(input, transform, outputMap)) {
                 Transformation<?> chainedTransformation =
                         createChainedTransformation(input, transform);
                 Set<Transformation<?>> outputTransformations = outputMap.get(transform);
@@ -243,6 +243,7 @@ public class PythonOperatorChainingOptimizer {
                     for (Transformation<?> output : outputTransformations) {
                         replaceInput(output, transform, chainedTransformation);
                     }
+                    outputMap.put(chainedTransformation, outputTransformations);
                 }
                 chainInfo = ChainInfo.of(chainedTransformation, Arrays.asList(input, transform));
             }
@@ -368,11 +369,14 @@ public class PythonOperatorChainingOptimizer {
     }
 
     private static boolean isChainable(
-            Transformation<?> upTransform, Transformation<?> downTransform) {
+            Transformation<?> upTransform,
+            Transformation<?> downTransform,
+            Map<Transformation<?>, Set<Transformation<?>>> outputMap) {
         return upTransform.getParallelism() == downTransform.getParallelism()
                 && upTransform.getMaxParallelism() == downTransform.getMaxParallelism()
                 && upTransform.getSlotSharingGroup().equals(downTransform.getSlotSharingGroup())
-                && areOperatorsChainable(upTransform, downTransform);
+                && areOperatorsChainable(upTransform, downTransform)
+                && outputMap.get(upTransform).size() == 1;
     }
 
     private static boolean areOperatorsChainable(


### PR DESCRIPTION

## What is the purpose of the change

*This pull request ensures that operator with multiple outputs should not chain with one of the outputs*


## Verifying this change


This change added tests and can be verified as follows:

  - *Added test case: testTransformationWithMultipleOutputs*

## Does this pull request potentially affect one of the following parts:

  - Dependencies (does it add or upgrade a dependency): (no)
  - The public API, i.e., is any changed class annotated with `@Public(Evolving)`: (no)
  - The serializers: (no)
  - The runtime per-record code paths (performance sensitive): (no)
  - Anything that affects deployment or recovery: JobManager (and its components), Checkpointing, Kubernetes/Yarn, ZooKeeper: (no)
  - The S3 file system connector: (no)

## Documentation

  - Does this pull request introduce a new feature? (no)
  - If yes, how is the feature documented? (not applicable)
