### PR TITLE
[FLINK-23242][docs-zh] Translate the page of "Handling Application Parameters" into Chinese

### DIFF
--- a/docs/content.zh/docs/dev/datastream/application_parameters.md
+++ b/docs/content.zh/docs/dev/datastream/application_parameters.md
@@ -3,7 +3,7 @@ title: "Handling Application Parameters"
 weight: 51
 type: docs
 aliases:
-  - /zh/dev/application_parameters.html
+- /zh/dev/application_parameters.html
 ---
 <!--
 Licensed to the Apache Software Foundation (ASF) under one
@@ -24,28 +24,23 @@ specific language governing permissions and limitations
 under the License.
 -->
 
-# Handling Application Parameters
+# 应用程序参数处理
 
-
-
-Handling Application Parameters
+应用程序参数处理
 -------------------------------
-Almost all Flink applications, both batch and streaming, rely on external configuration parameters.
-They are used to specify input and output sources (like paths or addresses), system parameters (parallelism, runtime configuration), and application specific parameters (typically used within user functions).
+几乎所有的批和流的 Flink 应用程序，都依赖于外部配置参数。这些配置参数可以用于指定输入和输出源（如路径或地址）、系统参数（并行度，运行时配置）和特定的应用程序参数（通常使用在用户自定义函数）。
 
-Flink provides a simple utility called `ParameterTool` to provide some basic tooling for solving these problems.
-Please note that you don't have to use the `ParameterTool` described here. Other frameworks such as [Commons CLI](https://commons.apache.org/proper/commons-cli/) and
-[argparse4j](http://argparse4j.sourceforge.net/) also work well with Flink.
+为解决以上问题，Flink 提供一个名为 `Parametertool` 的简单公共类，其中包含了一些基本的工具。请注意，这里说的 `Parametertool` 并不是必须使用的。[Commons CLI](https://commons.apache.org/proper/commons-cli/) 和 [argparse4j](http://argparse4j.sourceforge.net/) 等其他框架也可以非常好地兼容 Flink。
 
+### `ParameterTool` 读取配置值
 
-### Getting your configuration values into the `ParameterTool`
-
-The `ParameterTool` provides a set of predefined static methods for reading the configuration. The tool is internally expecting a `Map<String, String>`, so it's very easy to integrate it with your own configuration style.
+`ParameterTool` 已经定义好了一组静态方法，用于读取配置信息。该工具类内部使用了 `Map<string，string>` 类型，这样使得它可以很容易地与你的配置集成在一起。
 
 
-#### From `.properties` files
+#### 配置值来自 `.properties` 文件
 
-The following method will read a [Properties](https://docs.oracle.com/javase/tutorial/essential/environment/properties.html) file and provide the key/value pairs:
+以下方法可以读取 [Properties](https://docs.oracle.com/javase/tutorial/essential/environment/properties.html) 文件并解析出键/值对：
+
 ```java
 String propertiesFilePath = "/home/sam/flink/myjob.properties";
 ParameterTool parameter = ParameterTool.fromPropertiesFile(propertiesFilePath);
@@ -57,10 +52,10 @@ InputStream propertiesFileInputStream = new FileInputStream(file);
 ParameterTool parameter = ParameterTool.fromPropertiesFile(propertiesFileInputStream);
 ```
 
+#### 配置值来自命令行
 
-#### From the command line arguments
+以下方法可以从命令行中获取参数，如 `--input hdfs:///mydata --elements 42`。
 
-This allows getting arguments like `--input hdfs:///mydata --elements 42` from the command line.
 ```java
 public static void main(String[] args) {
     ParameterTool parameter = ParameterTool.fromArgs(args);
@@ -68,22 +63,22 @@ public static void main(String[] args) {
 ```
 
 
-#### From system properties
+#### 配置值来自系统属性
 
-When starting a JVM, you can pass system properties to it: `-Dinput=hdfs:///mydata`. You can also initialize the `ParameterTool` from these system properties:
+启动 JVM 时，可以将系统属性传递给 JVM：`-Dinput=hdfs:///mydata`。你也可以从这些系统属性初始化 `ParameterTool`：
 
 ```java
 ParameterTool parameter = ParameterTool.fromSystemProperties();
 ```
 
+### 在 Flink 程序中使用参数
 
-### Using the parameters in your Flink program
+现在我们已经从某处获取了参数（见上文），可以以各种不同的方式使用它们。
 
-Now that we've got the parameters from somewhere (see above) we can use them in various ways.
+**直接从 `ParameterTool` 获取**
 
-**Directly from the `ParameterTool`**
+`ParameterTool` 本身具有访问配置值的方法。
 
-The `ParameterTool` itself has methods for accessing the values.
 ```java
 ParameterTool parameters = // ...
 parameter.getRequired("input");
@@ -93,8 +88,7 @@ parameter.getNumberOfParameters()
 // .. there are more methods available.
 ```
 
-You can use the return values of these methods directly in the `main()` method of the client submitting the application.
-For example, you could set the parallelism of a operator like this:
+你可以在提交应用程序时直接在客户端的 `main()` 方法中使用这些方法的返回值。例如，你可以这样设置算子的并行度：
 
 ```java
 ParameterTool parameters = ParameterTool.fromArgs(args);
@@ -102,20 +96,20 @@ int parallelism = parameters.get("mapParallelism", 2);
 DataStream<Tuple2<String, Integer>> counts = text.flatMap(new Tokenizer()).setParallelism(parallelism);
 ```
 
-Since the `ParameterTool` is serializable, you can pass it to the functions itself:
+由于 `ParameterTool` 是序列化的，你可以将其传递给函数本身：
 
 ```java
 ParameterTool parameters = ParameterTool.fromArgs(args);
 DataStream<Tuple2<String, Integer>> counts = text.flatMap(new Tokenizer(parameters));
 ```
 
-and then use it inside the function for getting values from the command line.
+然后在函数内使用它以获取命令行的传递的参数。
 
-#### Register the parameters globally
+#### 全局注册参数
 
-Parameters registered as global job parameters in the `ExecutionConfig` can be accessed as configuration values from the JobManager web interface and in all functions defined by the user.
+从 JobManager web 界面和用户定义的所有函数中可以以配置值的方式访问在 `ExecutionConfig` 中注册的全局作业参数。
 
-Register the parameters globally:
+在全局注册参数：
 
 ```java
 ParameterTool parameters = ParameterTool.fromArgs(args);
@@ -124,18 +118,17 @@ ParameterTool parameters = ParameterTool.fromArgs(args);
 final ExecutionEnvironment env = ExecutionEnvironment.getExecutionEnvironment();
 env.getConfig().setGlobalJobParameters(parameters);
 ```
-
-Access them in any rich user function:
+在任意富函数中访问参数：
 
 ```java
 public static final class Tokenizer extends RichFlatMapFunction<String, Tuple2<String, Integer>> {
 
     @Override
     public void flatMap(String value, Collector<Tuple2<String, Integer>> out) {
-	ParameterTool parameters = (ParameterTool)
-	    getRuntimeContext().getExecutionConfig().getGlobalJobParameters();
-	parameters.getRequired("input");
-	// .. do more ..
+        ParameterTool parameters = (ParameterTool)
+                getRuntimeContext().getExecutionConfig().getGlobalJobParameters();
+        parameters.getRequired("input");
+        // .. do more ..
 ```
 
 {{< top >}}

--- a/docs/content.zh/docs/dev/datastream/application_parameters.md
+++ b/docs/content.zh/docs/dev/datastream/application_parameters.md
@@ -34,7 +34,7 @@ under the License.
 
 ### `ParameterTool` 读取配置值
 
-`ParameterTool` 已经定义好了一组静态方法，用于读取配置信息。该工具类内部使用了 `Map<string，string>` 类型，这样使得它可以很容易地与你的配置集成在一起。
+`ParameterTool` 定义了一组静态方法，用于读取配置信息。该工具类内部使用了 `Map<string，string>` 类型，这样使得它可以很容易地与你的配置集成在一起。
 
 
 #### 配置值来自 `.properties` 文件
@@ -105,11 +105,11 @@ DataStream<Tuple2<String, Integer>> counts = text.flatMap(new Tokenizer(paramete
 
 然后在函数内使用它以获取命令行的传递的参数。
 
-#### 全局注册参数
+#### 注册全局参数
 
 从 JobManager web 界面和用户定义的所有函数中可以以配置值的方式访问在 `ExecutionConfig` 中注册的全局作业参数。
 
-在全局注册参数：
+注册全局参数：
 
 ```java
 ParameterTool parameters = ParameterTool.fromArgs(args);

--- a/docs/content.zh/docs/dev/datastream/application_parameters.md
+++ b/docs/content.zh/docs/dev/datastream/application_parameters.md
@@ -32,7 +32,7 @@ under the License.
 
 为解决以上问题，Flink 提供一个名为 `Parametertool` 的简单公共类，其中包含了一些基本的工具。请注意，这里说的 `Parametertool` 并不是必须使用的。[Commons CLI](https://commons.apache.org/proper/commons-cli/) 和 [argparse4j](http://argparse4j.sourceforge.net/) 等其他框架也可以非常好地兼容 Flink。
 
-### `ParameterTool` 读取配置值
+### 用 `ParameterTool` 读取配置值
 
 `ParameterTool` 定义了一组静态方法，用于读取配置信息。该工具类内部使用了 `Map<string，string>` 类型，这样使得它可以很容易地与你的配置集成在一起。
 


### PR DESCRIPTION
What is the purpose of the change
Translate the page of "Handling Application Parameters " into Chinese

The page url of "Handling Application Parameters" is https://ci.apache.org/projects/flink/flink-docs-release-1.13/zh/docs/dev/datastream/application_parameters/.

The markdown file can be found in flink/docs/content.zh/docs/dev/datastream/application_parameters.md in English.

Brief change log
Translate 'flink/docs/content.zh/docs/dev/datastream/application_parameters.md'.
Verifying this change
This change is a trivial rework / code cleanup without any test coverage.

Does this pull request potentially affect one of the following parts:
Dependencies (does it add or upgrade a dependency): no
The public API, i.e., is any changed class annotated with @public(Evolving): no
The serializers: no
The runtime per-record code paths (performance sensitive): no
Anything that affects deployment or recovery: JobManager (and its components), Checkpointing, Kubernetes/Yarn, ZooKeeper: no
The S3 file system connector: no
Documentation
Does this pull request introduce a new feature? no
If yes, how is the feature documented? not documented