### PR TITLE
[FLINK-22710][formats] Explicitly set the bucket assigner to avoid writing into two buckets in the tests

### DIFF
--- a/flink-connectors/flink-file-sink-common/pom.xml
+++ b/flink-connectors/flink-file-sink-common/pom.xml
@@ -41,4 +41,20 @@ under the License.
 			<version>${project.version}</version>
 		</dependency>
 	</dependencies>
+
+	<build>
+		<plugins>
+			<plugin>
+				<groupId>org.apache.maven.plugins</groupId>
+				<artifactId>maven-jar-plugin</artifactId>
+				<executions>
+					<execution>
+						<goals>
+							<goal>test-jar</goal>
+						</goals>
+					</execution>
+				</executions>
+			</plugin>
+		</plugins>
+	</build>
 </project>

--- a/flink-connectors/flink-file-sink-common/src/test/java/org/apache/flink/streaming/api/functions/sink/filesystem/bucketassigners/UniqueBucketAssigner.java
+++ b/flink-connectors/flink-file-sink-common/src/test/java/org/apache/flink/streaming/api/functions/sink/filesystem/bucketassigners/UniqueBucketAssigner.java
@@ -1,0 +1,42 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.flink.streaming.api.functions.sink.filesystem.bucketassigners;
+
+import org.apache.flink.core.io.SimpleVersionedSerializer;
+import org.apache.flink.streaming.api.functions.sink.filesystem.BucketAssigner;
+
+/** A {@link BucketAssigner} that assigns all the files into the unique bucket. */
+public class UniqueBucketAssigner<T> implements BucketAssigner<T, String> {
+
+    private final String bucketId;
+
+    public UniqueBucketAssigner(String bucketId) {
+        this.bucketId = bucketId;
+    }
+
+    @Override
+    public String getBucketId(T element, Context context) {
+        return bucketId;
+    }
+
+    @Override
+    public SimpleVersionedSerializer<String> getSerializer() {
+        return SimpleVersionedStringSerializer.INSTANCE;
+    }
+}

--- a/flink-formats/flink-avro/pom.xml
+++ b/flink-formats/flink-avro/pom.xml
@@ -146,6 +146,15 @@ under the License.
 			<scope>test</scope>
 		</dependency>
 
+		<!-- Required due to UniqueBucketAssigner -->
+		<dependency>
+			<groupId>org.apache.flink</groupId>
+			<artifactId>flink-file-sink-common</artifactId>
+			<version>${project.version}</version>
+			<scope>test</scope>
+			<type>test-jar</type>
+		</dependency>
+
 	</dependencies>
 
 	<build>

--- a/flink-formats/flink-avro/src/test/java/org/apache/flink/formats/avro/AvroStreamingFileSinkITCase.java
+++ b/flink-formats/flink-avro/src/test/java/org/apache/flink/formats/avro/AvroStreamingFileSinkITCase.java
@@ -25,6 +25,7 @@ import org.apache.flink.formats.avro.typeutils.GenericRecordAvroTypeInfo;
 import org.apache.flink.streaming.api.datastream.DataStream;
 import org.apache.flink.streaming.api.environment.StreamExecutionEnvironment;
 import org.apache.flink.streaming.api.functions.sink.filesystem.StreamingFileSink;
+import org.apache.flink.streaming.api.functions.sink.filesystem.bucketassigners.UniqueBucketAssigner;
 import org.apache.flink.streaming.util.FiniteTestSource;
 import org.apache.flink.test.util.AbstractTestBase;
 
@@ -81,6 +82,7 @@ public class AvroStreamingFileSinkITCase extends AbstractTestBase {
                 env.addSource(new FiniteTestSource<>(data), TypeInformation.of(Address.class));
         stream.addSink(
                 StreamingFileSink.forBulkFormat(Path.fromLocalFile(folder), avroWriterFactory)
+                        .withBucketAssigner(new UniqueBucketAssigner<>("test"))
                         .build());
         env.execute();
 
@@ -103,6 +105,7 @@ public class AvroStreamingFileSinkITCase extends AbstractTestBase {
                 env.addSource(new FiniteTestSource<>(data), new GenericRecordAvroTypeInfo(schema));
         stream.addSink(
                 StreamingFileSink.forBulkFormat(Path.fromLocalFile(folder), avroWriterFactory)
+                        .withBucketAssigner(new UniqueBucketAssigner<>("test"))
                         .build());
         env.execute();
 
@@ -124,6 +127,7 @@ public class AvroStreamingFileSinkITCase extends AbstractTestBase {
                 env.addSource(new FiniteTestSource<>(data), TypeInformation.of(Datum.class));
         stream.addSink(
                 StreamingFileSink.forBulkFormat(Path.fromLocalFile(folder), avroWriterFactory)
+                        .withBucketAssigner(new UniqueBucketAssigner<>("test"))
                         .build());
         env.execute();
 

--- a/flink-formats/flink-compress/pom.xml
+++ b/flink-formats/flink-compress/pom.xml
@@ -79,6 +79,14 @@ under the License.
 			<type>test-jar</type>
 		</dependency>
 
+		<!-- Required due to UniqueBucketAssigner -->
+		<dependency>
+			<groupId>org.apache.flink</groupId>
+			<artifactId>flink-file-sink-common</artifactId>
+			<version>${project.version}</version>
+			<scope>test</scope>
+			<type>test-jar</type>
+		</dependency>
 	</dependencies>
 
 	<build>

--- a/flink-formats/flink-compress/src/test/java/org/apache/flink/formats/compress/CompressWriterFactoryTest.java
+++ b/flink-formats/flink-compress/src/test/java/org/apache/flink/formats/compress/CompressWriterFactoryTest.java
@@ -19,11 +19,9 @@
 package org.apache.flink.formats.compress;
 
 import org.apache.flink.core.fs.Path;
-import org.apache.flink.core.io.SimpleVersionedSerializer;
 import org.apache.flink.formats.compress.extractor.DefaultExtractor;
-import org.apache.flink.streaming.api.functions.sink.filesystem.BucketAssigner;
 import org.apache.flink.streaming.api.functions.sink.filesystem.StreamingFileSink;
-import org.apache.flink.streaming.api.functions.sink.filesystem.bucketassigners.SimpleVersionedStringSerializer;
+import org.apache.flink.streaming.api.functions.sink.filesystem.bucketassigners.UniqueBucketAssigner;
 import org.apache.flink.streaming.api.operators.StreamSink;
 import org.apache.flink.streaming.runtime.streamrecord.StreamRecord;
 import org.apache.flink.streaming.util.OneInputStreamOperatorTestHarness;
@@ -144,22 +142,9 @@ public class CompressWriterFactoryTest extends TestLogger {
             throws Exception {
         final File outDir = TEMPORARY_FOLDER.newFolder();
 
-        final BucketAssigner<String, String> assigner =
-                new BucketAssigner<String, String>() {
-                    @Override
-                    public String getBucketId(String element, BucketAssigner.Context context) {
-                        return "bucket";
-                    }
-
-                    @Override
-                    public SimpleVersionedSerializer<String> getSerializer() {
-                        return SimpleVersionedStringSerializer.INSTANCE;
-                    }
-                };
-
         StreamingFileSink<String> sink =
                 StreamingFileSink.forBulkFormat(new Path(outDir.toURI()), writer)
-                        .withBucketAssigner(assigner)
+                        .withBucketAssigner(new UniqueBucketAssigner<>("test"))
                         .build();
 
         try (OneInputStreamOperatorTestHarness<String, Object> testHarness =

--- a/flink-formats/flink-compress/src/test/java/org/apache/flink/formats/compress/CompressionFactoryITCase.java
+++ b/flink-formats/flink-compress/src/test/java/org/apache/flink/formats/compress/CompressionFactoryITCase.java
@@ -24,6 +24,7 @@ import org.apache.flink.formats.compress.extractor.DefaultExtractor;
 import org.apache.flink.streaming.api.datastream.DataStream;
 import org.apache.flink.streaming.api.environment.StreamExecutionEnvironment;
 import org.apache.flink.streaming.api.functions.sink.filesystem.StreamingFileSink;
+import org.apache.flink.streaming.api.functions.sink.filesystem.bucketassigners.UniqueBucketAssigner;
 import org.apache.flink.streaming.util.FiniteTestSource;
 import org.apache.flink.test.util.AbstractTestBase;
 
@@ -78,6 +79,7 @@ public class CompressionFactoryITCase extends AbstractTestBase {
                                         testPath,
                                         CompressWriters.forExtractor(new DefaultExtractor<String>())
                                                 .withHadoopCompression(TEST_CODEC_NAME))
+                                .withBucketAssigner(new UniqueBucketAssigner<>("test"))
                                 .build());
 
         env.execute();

--- a/flink-formats/flink-orc/pom.xml
+++ b/flink-formats/flink-orc/pom.xml
@@ -138,6 +138,15 @@ under the License.
 			<type>test-jar</type>
 		</dependency>
 
+		<!-- Required due to UniqueBucketAssigner -->
+		<dependency>
+			<groupId>org.apache.flink</groupId>
+			<artifactId>flink-file-sink-common</artifactId>
+			<version>${project.version}</version>
+			<scope>test</scope>
+			<type>test-jar</type>
+		</dependency>
+
 	</dependencies>
 
 	<profiles>

--- a/flink-formats/flink-orc/src/test/java/org/apache/flink/orc/writer/OrcBulkRowDataWriterTest.java
+++ b/flink-formats/flink-orc/src/test/java/org/apache/flink/orc/writer/OrcBulkRowDataWriterTest.java
@@ -21,6 +21,7 @@ package org.apache.flink.orc.writer;
 import org.apache.flink.core.fs.Path;
 import org.apache.flink.orc.vector.RowDataVectorizer;
 import org.apache.flink.streaming.api.functions.sink.filesystem.StreamingFileSink;
+import org.apache.flink.streaming.api.functions.sink.filesystem.bucketassigners.UniqueBucketAssigner;
 import org.apache.flink.streaming.api.operators.StreamSink;
 import org.apache.flink.streaming.util.OneInputStreamOperatorTestHarness;
 import org.apache.flink.table.data.ArrayData;
@@ -100,6 +101,7 @@ public class OrcBulkRowDataWriterTest {
 
         StreamingFileSink<RowData> sink =
                 StreamingFileSink.forBulkFormat(new Path(outDir.toURI()), writer)
+                        .withBucketAssigner(new UniqueBucketAssigner<>("test"))
                         .withBucketCheckInterval(10000)
                         .build();
 

--- a/flink-formats/flink-orc/src/test/java/org/apache/flink/orc/writer/OrcBulkWriterITCase.java
+++ b/flink-formats/flink-orc/src/test/java/org/apache/flink/orc/writer/OrcBulkWriterITCase.java
@@ -26,6 +26,7 @@ import org.apache.flink.orc.vector.RecordVectorizer;
 import org.apache.flink.streaming.api.datastream.DataStream;
 import org.apache.flink.streaming.api.environment.StreamExecutionEnvironment;
 import org.apache.flink.streaming.api.functions.sink.filesystem.StreamingFileSink;
+import org.apache.flink.streaming.api.functions.sink.filesystem.bucketassigners.UniqueBucketAssigner;
 import org.apache.flink.streaming.util.FiniteTestSource;
 import org.apache.flink.util.TestLogger;
 
@@ -66,7 +67,9 @@ public class OrcBulkWriterITCase extends TestLogger {
                 env.addSource(new FiniteTestSource<>(testData), TypeInformation.of(Record.class));
         stream.map(str -> str)
                 .addSink(
-                        StreamingFileSink.forBulkFormat(new Path(outDir.toURI()), factory).build());
+                        StreamingFileSink.forBulkFormat(new Path(outDir.toURI()), factory)
+                                .withBucketAssigner(new UniqueBucketAssigner<>("test"))
+                                .build());
 
         env.execute();
 

--- a/flink-formats/flink-orc/src/test/java/org/apache/flink/orc/writer/OrcBulkWriterTest.java
+++ b/flink-formats/flink-orc/src/test/java/org/apache/flink/orc/writer/OrcBulkWriterTest.java
@@ -23,6 +23,7 @@ import org.apache.flink.orc.data.Record;
 import org.apache.flink.orc.util.OrcBulkWriterTestUtil;
 import org.apache.flink.orc.vector.RecordVectorizer;
 import org.apache.flink.streaming.api.functions.sink.filesystem.StreamingFileSink;
+import org.apache.flink.streaming.api.functions.sink.filesystem.bucketassigners.UniqueBucketAssigner;
 import org.apache.flink.streaming.api.operators.StreamSink;
 import org.apache.flink.streaming.util.OneInputStreamOperatorTestHarness;
 
@@ -57,6 +58,7 @@ public class OrcBulkWriterTest {
 
         StreamingFileSink<Record> sink =
                 StreamingFileSink.forBulkFormat(new Path(outDir.toURI()), writer)
+                        .withBucketAssigner(new UniqueBucketAssigner<>("test"))
                         .withBucketCheckInterval(10000)
                         .build();
 

--- a/flink-formats/flink-parquet/pom.xml
+++ b/flink-formats/flink-parquet/pom.xml
@@ -187,6 +187,14 @@ under the License.
 			<scope>test</scope>
 		</dependency>
 
+		<!-- Required due to UniqueBucketAssigner -->
+		<dependency>
+			<groupId>org.apache.flink</groupId>
+			<artifactId>flink-file-sink-common</artifactId>
+			<version>${project.version}</version>
+			<scope>test</scope>
+			<type>test-jar</type>
+		</dependency>
 	</dependencies>
 
 	<build>

--- a/flink-formats/flink-parquet/src/test/java/org/apache/flink/formats/parquet/avro/ParquetAvroStreamingFileSinkITCase.java
+++ b/flink-formats/flink-parquet/src/test/java/org/apache/flink/formats/parquet/avro/ParquetAvroStreamingFileSinkITCase.java
@@ -25,6 +25,7 @@ import org.apache.flink.formats.parquet.generated.Address;
 import org.apache.flink.streaming.api.datastream.DataStream;
 import org.apache.flink.streaming.api.environment.StreamExecutionEnvironment;
 import org.apache.flink.streaming.api.functions.sink.filesystem.StreamingFileSink;
+import org.apache.flink.streaming.api.functions.sink.filesystem.bucketassigners.UniqueBucketAssigner;
 import org.apache.flink.streaming.util.FiniteTestSource;
 import org.apache.flink.test.util.AbstractTestBase;
 
@@ -87,6 +88,7 @@ public class ParquetAvroStreamingFileSinkITCase extends AbstractTestBase {
                 StreamingFileSink.forBulkFormat(
                                 Path.fromLocalFile(folder),
                                 ParquetAvroWriters.forSpecificRecord(Address.class))
+                        .withBucketAssigner(new UniqueBucketAssigner<>("test"))
                         .build());
 
         env.execute();
@@ -114,6 +116,7 @@ public class ParquetAvroStreamingFileSinkITCase extends AbstractTestBase {
                 StreamingFileSink.forBulkFormat(
                                 Path.fromLocalFile(folder),
                                 ParquetAvroWriters.forGenericRecord(schema))
+                        .withBucketAssigner(new UniqueBucketAssigner<>("test"))
                         .build());
 
         env.execute();
@@ -145,6 +148,7 @@ public class ParquetAvroStreamingFileSinkITCase extends AbstractTestBase {
                 StreamingFileSink.forBulkFormat(
                                 Path.fromLocalFile(folder),
                                 ParquetAvroWriters.forReflectRecord(Datum.class))
+                        .withBucketAssigner(new UniqueBucketAssigner<>("test"))
                         .build());
 
         env.execute();

--- a/flink-formats/flink-parquet/src/test/java/org/apache/flink/formats/parquet/protobuf/ParquetProtoStreamingFileSinkITCase.java
+++ b/flink-formats/flink-parquet/src/test/java/org/apache/flink/formats/parquet/protobuf/ParquetProtoStreamingFileSinkITCase.java
@@ -23,6 +23,7 @@ import org.apache.flink.core.fs.Path;
 import org.apache.flink.streaming.api.datastream.DataStream;
 import org.apache.flink.streaming.api.environment.StreamExecutionEnvironment;
 import org.apache.flink.streaming.api.functions.sink.filesystem.StreamingFileSink;
+import org.apache.flink.streaming.api.functions.sink.filesystem.bucketassigners.UniqueBucketAssigner;
 import org.apache.flink.streaming.util.FiniteTestSource;
 import org.apache.flink.test.util.AbstractTestBase;
 
@@ -76,6 +77,7 @@ public class ParquetProtoStreamingFileSinkITCase extends AbstractTestBase {
                 StreamingFileSink.forBulkFormat(
                                 Path.fromLocalFile(folder),
                                 ParquetProtoWriters.forType(SimpleProtoRecord.class))
+                        .withBucketAssigner(new UniqueBucketAssigner<>("test"))
                         .build());
 
         env.execute();

--- a/flink-formats/flink-sequence-file/pom.xml
+++ b/flink-formats/flink-sequence-file/pom.xml
@@ -85,6 +85,14 @@ under the License.
 			<scope>test</scope>
 		</dependency>
 
+        <!-- Required due to UniqueBucketAssigner -->
+        <dependency>
+            <groupId>org.apache.flink</groupId>
+            <artifactId>flink-file-sink-common</artifactId>
+            <version>${project.version}</version>
+            <scope>test</scope>
+            <type>test-jar</type>
+        </dependency>
 	</dependencies>
 
 

--- a/flink-formats/flink-sequence-file/src/test/java/org/apache/flink/formats/sequencefile/SequenceStreamingFileSinkITCase.java
+++ b/flink-formats/flink-sequence-file/src/test/java/org/apache/flink/formats/sequencefile/SequenceStreamingFileSinkITCase.java
@@ -26,6 +26,7 @@ import org.apache.flink.core.fs.Path;
 import org.apache.flink.streaming.api.datastream.DataStream;
 import org.apache.flink.streaming.api.environment.StreamExecutionEnvironment;
 import org.apache.flink.streaming.api.functions.sink.filesystem.StreamingFileSink;
+import org.apache.flink.streaming.api.functions.sink.filesystem.bucketassigners.UniqueBucketAssigner;
 import org.apache.flink.streaming.util.FiniteTestSource;
 import org.apache.flink.test.util.AbstractTestBase;
 
@@ -90,6 +91,7 @@ public class SequenceStreamingFileSinkITCase extends AbstractTestBase {
                                                 LongWritable.class,
                                                 Text.class,
                                                 "BZip2"))
+                                .withBucketAssigner(new UniqueBucketAssigner<>("test"))
                                 .build());
 
         env.execute();


### PR DESCRIPTION
## What is the purpose of the change

This PR fixes that some tests use the default DateTimeBucketAssigner which partitions the data into buckets according to the hour, if the test are executed at the boundary of an hour, the data might be write into two buckets, but the tests will validate that there is only one bucket.


## Brief change log

- 4ecced5f26139215ae8555cc358291c46e9c7bfb adds a default `UniqueBucketAssigner` and configure the bucket assigner explicitly.


## Verifying this change


This change is already covered by existing tests.


## Does this pull request potentially affect one of the following parts:

  - Dependencies (does it add or upgrade a dependency): **no**
  - The public API, i.e., is any changed class annotated with `@Public(Evolving)`: **no**
  - The serializers: **no**
  - The runtime per-record code paths (performance sensitive): **no**
  - Anything that affects deployment or recovery: JobManager (and its components), Checkpointing, Kubernetes/Yarn, ZooKeeper: **no**
  - The S3 file system connector: **no**

## Documentation

  - Does this pull request introduce a new feature? **no**
  - If yes, how is the feature documented? **not applicable**
