### PR TITLE
[FLINK-23556][tests] Make SQLClientSchemaRegistryITCase more stable

### DIFF
--- a/flink-end-to-end-tests/flink-end-to-end-tests-common-kafka/src/main/java/org/apache/flink/tests/util/kafka/KafkaContainerClient.java
+++ b/flink-end-to-end-tests/flink-end-to-end-tests-common-kafka/src/main/java/org/apache/flink/tests/util/kafka/KafkaContainerClient.java
@@ -106,7 +106,7 @@ public class KafkaContainerClient {
                         "Waiting for messages. Received {}/{}.",
                         messages.size(),
                         expectedNumMessages);
-                ConsumerRecords<Bytes, T> records = consumer.poll(Duration.ofMillis(100));
+                ConsumerRecords<Bytes, T> records = consumer.poll(Duration.ofMillis(1000));
                 for (ConsumerRecord<Bytes, T> record : records) {
                     messages.add(record.value());
                 }

--- a/flink-end-to-end-tests/flink-end-to-end-tests-common-kafka/src/test/java/org/apache/flink/tests/util/kafka/SQLClientSchemaRegistryITCase.java
+++ b/flink-end-to-end-tests/flink-end-to-end-tests-common-kafka/src/test/java/org/apache/flink/tests/util/kafka/SQLClientSchemaRegistryITCase.java
@@ -37,13 +37,15 @@ import org.apache.avro.generic.GenericRecordBuilder;
 import org.apache.kafka.common.serialization.StringDeserializer;
 import org.junit.Before;
 import org.junit.ClassRule;
-import org.junit.Ignore;
 import org.junit.Rule;
 import org.junit.Test;
 import org.junit.experimental.categories.Category;
 import org.junit.rules.Timeout;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 import org.testcontainers.containers.KafkaContainer;
 import org.testcontainers.containers.Network;
+import org.testcontainers.containers.output.Slf4jLogConsumer;
 import org.testcontainers.utility.DockerImageName;
 
 import java.nio.file.Path;
@@ -60,6 +62,9 @@ import static org.junit.Assert.assertThat;
 /** End-to-end test for SQL client using Avro Confluent Registry format. */
 @Category(value = {TravisGroup1.class})
 public class SQLClientSchemaRegistryITCase {
+    private static final Logger LOG = LoggerFactory.getLogger(SQLClientSchemaRegistryITCase.class);
+    private static final Slf4jLogConsumer LOG_CONSUMER = new Slf4jLogConsumer(LOG);
+
     public static final String INTER_CONTAINER_KAFKA_ALIAS = "kafka";
     public static final String INTER_CONTAINER_REGISTRY_ALIAS = "registry";
     private static final Path sqlAvroJar = TestUtils.getResource(".*avro.jar");
@@ -67,18 +72,22 @@ public class SQLClientSchemaRegistryITCase {
     private static final Path sqlToolBoxJar = TestUtils.getResource(".*SqlToolbox.jar");
     private final Path sqlConnectorKafkaJar = TestUtils.getResource(".*kafka.jar");
 
-    public final Network network = Network.newNetwork();
+    @ClassRule private static final Network network = Network.newNetwork();
 
     @ClassRule public static final Timeout TIMEOUT = new Timeout(10, TimeUnit.MINUTES);
 
-    @Rule
-    public final KafkaContainer kafka =
-            new KafkaContainer(DockerImageName.parse(DockerImageVersions.KAFKA))
-                    .withNetwork(network)
-                    .withNetworkAliases(INTER_CONTAINER_KAFKA_ALIAS);
+    @ClassRule
+    private static final KafkaContainer kafka =
+            new KafkaContainer(DockerImageName.parse(DockerImageVersions.KAFKA)) {
+                @Override
+                protected void doStart() {
+                    super.doStart();
+                    this.followOutput(LOG_CONSUMER);
+                }
+            }.withNetwork(network).withNetworkAliases(INTER_CONTAINER_KAFKA_ALIAS);
 
-    @Rule
-    public final SchemaRegistryContainer registry =
+    @ClassRule
+    private static final SchemaRegistryContainer registry =
             new SchemaRegistryContainer("5.5.2")
                     .withKafka(INTER_CONTAINER_KAFKA_ALIAS + ":9092")
                     .withNetwork(network)
@@ -89,16 +98,16 @@ public class SQLClientSchemaRegistryITCase {
     public final FlinkContainer flink =
             FlinkContainer.builder().build().withNetwork(network).dependsOn(kafka);
 
-    private final KafkaContainerClient kafkaClient = new KafkaContainerClient(kafka);
+    private KafkaContainerClient kafkaClient;
     private CachedSchemaRegistryClient registryClient;
 
     @Before
     public void setUp() {
+        kafkaClient = new KafkaContainerClient(kafka);
         registryClient = new CachedSchemaRegistryClient(registry.getSchemaRegistryUrl(), 10);
     }
 
-    @Ignore("FLINK-23556")
-    @Test(timeout = 120_000)
+    @Test
     public void testReading() throws Exception {
         String testCategoryTopic = "test-category-" + UUID.randomUUID().toString();
         String testResultsTopic = "test-results-" + UUID.randomUUID().toString();
@@ -133,6 +142,7 @@ public class SQLClientSchemaRegistryITCase {
                                 + ":9092',",
                         " 'topic' = '" + testCategoryTopic + "',",
                         " 'scan.startup.mode' = 'earliest-offset',",
+                        " 'properties.group.id' = 'test-group',",
                         " 'format' = 'avro-confluent',",
                         " 'avro-confluent.url' = 'http://"
                                 + INTER_CONTAINER_REGISTRY_ALIAS
@@ -148,6 +158,7 @@ public class SQLClientSchemaRegistryITCase {
                         " 'properties.bootstrap.servers' = '"
                                 + INTER_CONTAINER_KAFKA_ALIAS
                                 + ":9092',",
+                        " 'properties.group.id' = 'test-group',",
                         " 'topic' = '" + testResultsTopic + "',",
                         " 'format' = 'csv',",
                         " 'csv.null-literal' = 'null'",
@@ -162,8 +173,7 @@ public class SQLClientSchemaRegistryITCase {
         assertThat(categories, equalTo(Collections.singletonList("1,electronics,null")));
     }
 
-    @Ignore("FLINK-23556")
-    @Test(timeout = 120_000)
+    @Test
     public void testWriting() throws Exception {
         String testUserBehaviorTopic = "test-user-behavior-" + UUID.randomUUID().toString();
         // Create topic test-avro
@@ -204,11 +214,9 @@ public class SQLClientSchemaRegistryITCase {
                         testUserBehaviorTopic,
                         new KafkaAvroDeserializer(registryClient));
 
-        Schema userBehaviorSchema =
-                (Schema)
-                        registryClient
-                                .getSchemaBySubjectAndId(behaviourSubject, versions.get(0))
-                                .rawSchema();
+        String schemaString =
+                registryClient.getByVersion(behaviourSubject, versions.get(0), false).getSchema();
+        Schema userBehaviorSchema = new Schema.Parser().parse(schemaString);
         GenericRecordBuilder recordBuilder = new GenericRecordBuilder(userBehaviorSchema);
         assertThat(
                 userBehaviors,
@@ -224,7 +232,7 @@ public class SQLClientSchemaRegistryITCase {
     }
 
     private List<Integer> getAllVersions(String behaviourSubject) throws Exception {
-        Deadline deadline = Deadline.fromNow(Duration.ofSeconds(30));
+        Deadline deadline = Deadline.fromNow(Duration.ofSeconds(120));
         Exception ex =
                 new IllegalStateException(
                         "Could not query schema registry. Negative deadline provided.");

--- a/flink-end-to-end-tests/flink-end-to-end-tests-common-kafka/src/test/java/org/apache/flink/tests/util/kafka/SQLClientSchemaRegistryITCase.java
+++ b/flink-end-to-end-tests/flink-end-to-end-tests-common-kafka/src/test/java/org/apache/flink/tests/util/kafka/SQLClientSchemaRegistryITCase.java
@@ -78,13 +78,10 @@ public class SQLClientSchemaRegistryITCase {
 
     @ClassRule
     private static final KafkaContainer kafka =
-            new KafkaContainer(DockerImageName.parse(DockerImageVersions.KAFKA)) {
-                @Override
-                protected void doStart() {
-                    super.doStart();
-                    this.followOutput(LOG_CONSUMER);
-                }
-            }.withNetwork(network).withNetworkAliases(INTER_CONTAINER_KAFKA_ALIAS);
+            new KafkaContainer(DockerImageName.parse(DockerImageVersions.KAFKA))
+                    .withNetwork(network)
+                    .withNetworkAliases(INTER_CONTAINER_KAFKA_ALIAS)
+                    .withLogConsumer(LOG_CONSUMER);
 
     @ClassRule
     private static final SchemaRegistryContainer registry =


### PR DESCRIPTION
<!--
*Thank you very much for contributing to Apache Flink - we are happy that you want to help us improve Flink. To help the community review your contribution in the best possible way, please go through the checklist below, which will get the contribution into a shape in which it can be best reviewed.*

*Please understand that we do not do this to make contributions to Flink a hassle. In order to uphold a high standard of quality for code contributions, while at the same time managing a large number of contributions, we need contributors to prepare the contributions well, and give reviewers enough contextual information for the review. Please also understand that contributions that do not follow this guide will take longer to review and thus typically be picked up with lower priority by the community.*

## Contribution Checklist

  - Make sure that the pull request corresponds to a [JIRA issue](https://issues.apache.org/jira/projects/FLINK/issues). Exceptions are made for typos in JavaDoc or documentation files, which need no JIRA issue.
  
  - Name the pull request in the form "[FLINK-XXXX] [component] Title of the pull request", where *FLINK-XXXX* should be replaced by the actual issue number. Skip *component* if you are unsure about which is the best component.
  Typo fixes that have no associated JIRA issue should be named following this pattern: `[hotfix] [docs] Fix typo in event time introduction` or `[hotfix] [javadocs] Expand JavaDoc for PuncuatedWatermarkGenerator`.

  - Fill out the template below to describe the changes contributed by the pull request. That will give reviewers the context they need to do the review.
  
  - Make sure that the change passes the automated tests, i.e., `mvn clean verify` passes. You can set up Azure Pipelines CI to do that following [this guide](https://cwiki.apache.org/confluence/display/FLINK/Azure+Pipelines#AzurePipelines-Tutorial:SettingupAzurePipelinesforaforkoftheFlinkrepository).

  - Each pull request should address only one issue, not mix up code from multiple issues.
  
  - Each commit in the pull request has a meaningful commit message (including the JIRA id)

  - Once all items of the checklist are addressed, remove the above text and this checklist, leaving only the filled out template below.


**(The sections below can be removed for hotfixes of typos)**
-->

## What is the purpose of the change

This PR aims at improving the pass rate of SQLClientSchemaRegistryITCase(an unstable e2e test case).


## Brief change log

  - Remove 120 seconds limitation of the test. Due to the complexity of this e2e case, the old time limitation will make the case fail easily. Besides, after removing the limit, if this test fails, we can get its meaningful logs instead of a single timeout error.
  - Use ClassRule instead of Rule to reuse created containers which will save resources and time.
  - Increate max waiting time of some functions to make it easier to success.


## Verifying this change
- This change is already covered by existing tests, such as SQLClientSchemaRegistryITCase.



## Does this pull request potentially affect one of the following parts:

  - Dependencies (does it add or upgrade a dependency): no
  - The public API, i.e., is any changed class annotated with `@Public(Evolving)`: no
  - The serializers:  no
  - The runtime per-record code paths (performance sensitive): no
  - Anything that affects deployment or recovery: JobManager (and its components), Checkpointing, Kubernetes/Yarn, ZooKeeper:  no
  - The S3 file system connector: no

## Documentation

  - Does this pull request introduce a new feature? no
  - If yes, how is the feature documented? not applicable
