### PR TITLE
[FLINK-23937][Documentation] Fix PQ comment in KeyGroupPartitionedPriorityQueue

### DIFF
--- a/flink-runtime/src/main/java/org/apache/flink/runtime/state/heap/KeyGroupPartitionedPriorityQueue.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/state/heap/KeyGroupPartitionedPriorityQueue.java
@@ -44,7 +44,7 @@ import static org.apache.flink.util.Preconditions.checkArgument;
  * elements if the sub-queues have set semantics.
  *
  * @param <T> the type of elements in the queue.
- * @param <PQ> type type of sub-queue used for each key-group partition.
+ * @param <PQ> the type of sub-queue used for each key-group partition.
  */
 public class KeyGroupPartitionedPriorityQueue<
                 T, PQ extends InternalPriorityQueue<T> & HeapPriorityQueueElement>


### PR DESCRIPTION
## What is the purpose of the change

*The comment "@param <PQ> type type of sub-queue used for each key-group partition." should be "@param <PQ> the type of sub-queue used for each key-group partition." in KeyGroupPartitionedPriorityQueue.  Fix the small word error.*


## Brief change log

  - *Change the word 'type' to the word 'the'*


## Verifying this change

This change is a trivial rework / code cleanup without any test coverage.


## Does this pull request potentially affect one of the following parts:

  - Dependencies (does it add or upgrade a dependency): (no)
  - The public API, i.e., is any changed class annotated with `@Public(Evolving)`: (no)
  - The serializers: (no)
  - The runtime per-record code paths (performance sensitive): (no)
  - Anything that affects deployment or recovery: JobManager (and its components), Checkpointing, Kubernetes/Yarn, ZooKeeper: (no)
  - The S3 file system connector: (no)


## Documentation

  - Does this pull request introduce a new feature? (no) 