### PR TITLE
[FLINK-23791] Enable RocksDB info log by default

### DIFF
--- a/docs/layouts/shortcodes/generated/rocksdb_configurable_configuration.html
+++ b/docs/layouts/shortcodes/generated/rocksdb_configurable_configuration.html
@@ -76,21 +76,21 @@
         </tr>
         <tr>
             <td><h5>state.backend.rocksdb.log.file-num</h5></td>
-            <td style="word-wrap: break-word;">1000</td>
+            <td style="word-wrap: break-word;">4</td>
             <td>Integer</td>
-            <td>The maximum number of files RocksDB should keep for information logging (Default setting: 1000).</td>
+            <td>The maximum number of files RocksDB should keep for information logging (Default setting: 4).</td>
         </tr>
         <tr>
             <td><h5>state.backend.rocksdb.log.level</h5></td>
-            <td style="word-wrap: break-word;">HEADER_LEVEL</td>
+            <td style="word-wrap: break-word;">INFO_LEVEL</td>
             <td><p>Enum</p></td>
-            <td>The specified information logging level for RocksDB. If unset, Flink will use <code class="highlighter-rouge">HEADER_LEVEL</code>.<br />Note: RocksDB info logs will not be written to the TaskManager logs and there is no rolling strategy, unless you configure <code class="highlighter-rouge">state.backend.rocksdb.log.dir</code>, <code class="highlighter-rouge">state.backend.rocksdb.log.max-file-size</code>, and <code class="highlighter-rouge">state.backend.rocksdb.log.file-num</code> accordingly. Without a rolling strategy, long-running tasks may lead to uncontrolled disk space usage if configured with increased log levels!<br />There is no need to modify the RocksDB log level, unless for troubleshooting RocksDB.<br /><br />Possible values:<ul><li>"DEBUG_LEVEL"</li><li>"INFO_LEVEL"</li><li>"WARN_LEVEL"</li><li>"ERROR_LEVEL"</li><li>"FATAL_LEVEL"</li><li>"HEADER_LEVEL"</li><li>"NUM_INFO_LOG_LEVELS"</li></ul></td>
+            <td>The specified information logging level for RocksDB. If unset, Flink will use <code class="highlighter-rouge">INFO_LEVEL</code>.<br />Note: RocksDB info logs will not be written to the TaskManager logs and there is no rolling strategy, unless you configure <code class="highlighter-rouge">state.backend.rocksdb.log.dir</code>, <code class="highlighter-rouge">state.backend.rocksdb.log.max-file-size</code>, and <code class="highlighter-rouge">state.backend.rocksdb.log.file-num</code> accordingly. Without a rolling strategy, long-running tasks may lead to uncontrolled disk space usage if configured with increased log levels!<br />There is no need to modify the RocksDB log level, unless for troubleshooting RocksDB.<br /><br />Possible values:<ul><li>"DEBUG_LEVEL"</li><li>"INFO_LEVEL"</li><li>"WARN_LEVEL"</li><li>"ERROR_LEVEL"</li><li>"FATAL_LEVEL"</li><li>"HEADER_LEVEL"</li><li>"NUM_INFO_LOG_LEVELS"</li></ul></td>
         </tr>
         <tr>
             <td><h5>state.backend.rocksdb.log.max-file-size</h5></td>
-            <td style="word-wrap: break-word;">0 bytes</td>
+            <td style="word-wrap: break-word;">25 mb</td>
             <td>MemorySize</td>
-            <td>The maximum size of RocksDB's file used for information logging. If the log files becomes larger than this, a new file will be created. If 0 (Flink default setting), all logs will be written to one log file.</td>
+            <td>The maximum size of RocksDB's file used for information logging. If the log files becomes larger than this, a new file will be created. If 0, all logs will be written to one log file. The default maximum file size is '25MB'. </td>
         </tr>
         <tr>
             <td><h5>state.backend.rocksdb.thread.num</h5></td>

--- a/flink-state-backends/flink-statebackend-rocksdb/src/main/java/org/apache/flink/contrib/streaming/state/RocksDBConfigurableOptions.java
+++ b/flink-state-backends/flink-statebackend-rocksdb/src/main/java/org/apache/flink/contrib/streaming/state/RocksDBConfigurableOptions.java
@@ -39,7 +39,7 @@ import static org.rocksdb.CompactionStyle.FIFO;
 import static org.rocksdb.CompactionStyle.LEVEL;
 import static org.rocksdb.CompactionStyle.NONE;
 import static org.rocksdb.CompactionStyle.UNIVERSAL;
-import static org.rocksdb.InfoLogLevel.HEADER_LEVEL;
+import static org.rocksdb.InfoLogLevel.INFO_LEVEL;
 
 /**
  * This class contains the configuration options for the {@link EmbeddedRocksDBStateBackend}.
@@ -73,18 +73,19 @@ public class RocksDBConfigurableOptions implements Serializable {
     public static final ConfigOption<MemorySize> LOG_MAX_FILE_SIZE =
             key("state.backend.rocksdb.log.max-file-size")
                     .memoryType()
-                    .defaultValue(MemorySize.ZERO)
+                    .defaultValue(MemorySize.parse("25mb"))
                     .withDescription(
                             "The maximum size of RocksDB's file used for information logging. "
                                     + "If the log files becomes larger than this, a new file will be created. "
-                                    + "If 0 (Flink default setting), all logs will be written to one log file.");
+                                    + "If 0, all logs will be written to one log file. "
+                                    + "The default maximum file size is '25MB'. ");
 
     public static final ConfigOption<Integer> LOG_FILE_NUM =
             key("state.backend.rocksdb.log.file-num")
                     .intType()
-                    .defaultValue(1000)
+                    .defaultValue(4)
                     .withDescription(
-                            "The maximum number of files RocksDB should keep for information logging (Default setting: 1000).");
+                            "The maximum number of files RocksDB should keep for information logging (Default setting: 4).");
 
     public static final ConfigOption<String> LOG_DIR =
             key("state.backend.rocksdb.log.dir")
@@ -98,13 +99,13 @@ public class RocksDBConfigurableOptions implements Serializable {
     public static final ConfigOption<InfoLogLevel> LOG_LEVEL =
             key("state.backend.rocksdb.log.level")
                     .enumType(InfoLogLevel.class)
-                    .defaultValue(HEADER_LEVEL)
+                    .defaultValue(INFO_LEVEL)
                     .withDescription(
                             Description.builder()
                                     .text(
                                             "The specified information logging level for RocksDB. "
                                                     + "If unset, Flink will use %s.",
-                                            code(HEADER_LEVEL.name()))
+                                            code(INFO_LEVEL.name()))
                                     .linebreak()
                                     .text(
                                             "Note: RocksDB info logs will not be written to the TaskManager logs and there "


### PR DESCRIPTION
## What is the purpose of the change

FLINK-15068 disabled the RocksDB's local LOG due to previous RocksDB cannot limit the local log files.
After we upgraded to newer RocksDB version, we can then enable RocksDB log again.


## Brief change log

Change every predefined options for RocksDB, setting log level to INFO and limiting the log file size.

## Verifying this change

This change is a trivial rework without any test coverage.

## Does this pull request potentially affect one of the following parts:

  - Dependencies (does it add or upgrade a dependency): no
  - The public API, i.e., is any changed class annotated with `@Public(Evolving)`: no
  - The serializers: no
  - The runtime per-record code paths (performance sensitive): no
  - Anything that affects deployment or recovery: JobManager (and its components), Checkpointing, Kubernetes/Yarn, ZooKeeper: no
  - The S3 file system connector: no

## Documentation

  - Does this pull request introduce a new feature? no
