### PR TITLE
[FLINK-23907] Type Migration: introducing primitive functional interfaces

### DIFF
--- a/flink-runtime/src/main/java/org/apache/flink/runtime/io/network/partition/DataSetMetaInfo.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/io/network/partition/DataSetMetaInfo.java
@@ -20,7 +20,7 @@ package org.apache.flink.runtime.io.network.partition;
 import org.apache.flink.annotation.VisibleForTesting;
 import org.apache.flink.util.Preconditions;
 
-import java.util.Optional;
+import java.util.OptionalInt;
 
 /** Container for meta-data of a data set. */
 public final class DataSetMetaInfo {
@@ -34,10 +34,10 @@ public final class DataSetMetaInfo {
         this.numTotalPartitions = numTotalPartitions;
     }
 
-    public Optional<Integer> getNumRegisteredPartitions() {
+    public OptionalInt getNumRegisteredPartitions() {
         return numRegisteredPartitions == UNKNOWN
-                ? Optional.empty()
-                : Optional.of(numRegisteredPartitions);
+                ? OptionalInt.empty()
+                : OptionalInt.of(numRegisteredPartitions);
     }
 
     public int getNumTotalPartitions() {

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/io/network/partition/consumer/ChannelStatePersister.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/io/network/partition/consumer/ChannelStatePersister.java
@@ -36,7 +36,7 @@ import javax.annotation.concurrent.NotThreadSafe;
 
 import java.io.IOException;
 import java.util.List;
-import java.util.Optional;
+import java.util.OptionalLong;
 
 import static org.apache.flink.util.Preconditions.checkNotNull;
 
@@ -117,7 +117,7 @@ public final class ChannelStatePersister {
         }
     }
 
-    protected Optional<Long> checkForBarrier(Buffer buffer) throws IOException {
+    protected OptionalLong checkForBarrier(Buffer buffer) throws IOException {
         AbstractEvent event = parseEvent(buffer);
         if (event instanceof CheckpointBarrier) {
             long barrierId = ((CheckpointBarrier) event).getId();
@@ -129,7 +129,7 @@ public final class ChannelStatePersister {
                 logEvent("found barrier", barrierId);
                 checkpointStatus = CheckpointStatus.BARRIER_RECEIVED;
                 lastSeenBarrier = barrierId;
-                return Optional.of(lastSeenBarrier);
+                return OptionalLong.of(lastSeenBarrier);
             } else {
                 logEvent("ignoring barrier", barrierId);
             }
@@ -139,10 +139,10 @@ public final class ChannelStatePersister {
             if (announcement.getAnnouncedEvent() instanceof CheckpointBarrier) {
                 long barrierId = ((CheckpointBarrier) announcement.getAnnouncedEvent()).getId();
                 logEvent("found announcement for barrier", barrierId);
-                return Optional.of(barrierId);
+                return OptionalLong.of(barrierId);
             }
         }
-        return Optional.empty();
+        return OptionalLong.empty();
     }
 
     private void logEvent(String event, long barrierId) {

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/memory/MemoryManager.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/memory/MemoryManager.java
@@ -42,7 +42,7 @@ import java.util.NoSuchElementException;
 import java.util.Set;
 import java.util.concurrent.ConcurrentHashMap;
 import java.util.concurrent.atomic.AtomicReference;
-import java.util.function.Consumer;
+import java.util.function.LongConsumer;
 
 import static org.apache.flink.core.memory.MemorySegmentFactory.allocateOffHeapUnsafeMemory;
 
@@ -543,7 +543,7 @@ public class MemoryManager {
                     }
                 };
 
-        final Consumer<Long> releaser = (size) -> releaseMemory(type, size);
+        final LongConsumer releaser = (size) -> releaseMemory(type, size);
 
         // This object identifies the lease in this request. It is used only to identify the release
         // operation.

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/memory/SharedResources.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/memory/SharedResources.java
@@ -26,7 +26,7 @@ import javax.annotation.concurrent.GuardedBy;
 import java.util.HashMap;
 import java.util.HashSet;
 import java.util.concurrent.locks.ReentrantLock;
-import java.util.function.Consumer;
+import java.util.function.LongConsumer;
 
 import static org.apache.flink.util.Preconditions.checkState;
 
@@ -94,7 +94,7 @@ final class SharedResources {
      *
      * <p>This method takes an additional hook that is called when the resource is disposed.
      */
-    void release(String type, Object leaseHolder, Consumer<Long> releaser) throws Exception {
+    void release(String type, Object leaseHolder, LongConsumer releaser) throws Exception {
         lock.lock();
         try {
             final LeasedResource<?> resource = reservedResources.get(type);

--- a/flink-runtime/src/test/java/org/apache/flink/runtime/checkpoint/CheckpointRequestDeciderTest.java
+++ b/flink-runtime/src/test/java/org/apache/flink/runtime/checkpoint/CheckpointRequestDeciderTest.java
@@ -26,7 +26,7 @@ import java.util.List;
 import java.util.Optional;
 import java.util.concurrent.TimeUnit;
 import java.util.concurrent.atomic.AtomicInteger;
-import java.util.function.Consumer;
+import java.util.function.LongConsumer;
 
 import static java.util.concurrent.TimeUnit.MILLISECONDS;
 import static java.util.stream.Collectors.toList;
@@ -283,7 +283,7 @@ public class CheckpointRequestDeciderTest {
                 maxQueued);
     }
 
-    private static final Consumer<Long> NO_OP = unused -> {};
+    private static final LongConsumer NO_OP = unused -> {};
 
     static CheckpointTriggerRequest regularCheckpoint() {
         return checkpointRequest(true);

--- a/flink-runtime/src/test/java/org/apache/flink/runtime/memory/SharedResourcesTest.java
+++ b/flink-runtime/src/test/java/org/apache/flink/runtime/memory/SharedResourcesTest.java
@@ -20,7 +20,7 @@ package org.apache.flink.runtime.memory;
 
 import org.junit.Test;
 
-import java.util.function.Consumer;
+import java.util.function.LongConsumer;
 
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertFalse;
@@ -144,7 +144,7 @@ public class SharedResourcesTest {
 
     // ------------------------------------------------------------------------
 
-    private static final class TestReleaseHook implements Consumer<Long> {
+    private static final class TestReleaseHook implements LongConsumer {
 
         private final long expectedValue;
 
@@ -155,9 +155,9 @@ public class SharedResourcesTest {
         }
 
         @Override
-        public void accept(Long value) {
+        public void accept(long value) {
             wasCalled = true;
-            assertEquals(expectedValue, value.longValue());
+            assertEquals(expectedValue, value);
         }
     }
 }

--- a/flink-table/flink-sql-client/src/main/java/org/apache/flink/table/client/cli/CliInputView.java
+++ b/flink-table/flink-sql-client/src/main/java/org/apache/flink/table/client/cli/CliInputView.java
@@ -27,7 +27,7 @@ import org.jline.utils.InfoCmp.Capability;
 import java.util.ArrayList;
 import java.util.Collections;
 import java.util.List;
-import java.util.function.Function;
+import java.util.function.Predicate;
 import java.util.stream.IntStream;
 
 import static org.apache.flink.table.client.cli.CliInputView.InputOperation.BACKSPACE;
@@ -44,12 +44,12 @@ import static org.jline.keymap.KeyMap.key;
 public class CliInputView extends CliView<CliInputView.InputOperation, String> {
 
     private final String inputTitle;
-    private final Function<String, Boolean> validation;
+    private final Predicate<String> validation;
     private final StringBuilder currentInput;
     private int cursorPos;
     private boolean isError;
 
-    public CliInputView(CliClient client, String inputTitle, Function<String, Boolean> validation) {
+    public CliInputView(CliClient client, String inputTitle, Predicate<String> validation) {
         super(client);
 
         this.inputTitle = inputTitle;
@@ -222,7 +222,7 @@ public class CliInputView extends CliView<CliInputView.InputOperation, String> {
             close();
         }
         // validate and return
-        else if (validation.apply(s)) {
+        else if (validation.test(s)) {
             close(s);
         }
         // show error


### PR DESCRIPTION
<!--
*Thank you very much for contributing to Apache Flink - we are happy that you want to help us improve Flink. To help the community review your contribution in the best possible way, please go through the checklist below, which will get the contribution into a shape in which it can be best reviewed.*

*Please understand that we do not do this to make contributions to Flink a hassle. In order to uphold a high standard of quality for code contributions, while at the same time managing a large number of contributions, we need contributors to prepare the contributions well, and give reviewers enough contextual information for the review. Please also understand that contributions that do not follow this guide will take longer to review and thus typically be picked up with lower priority by the community.*

## Contribution Checklist

  - Make sure that the pull request corresponds to a [JIRA issue](https://issues.apache.org/jira/projects/FLINK/issues). Exceptions are made for typos in JavaDoc or documentation files, which need no JIRA issue.
  
  - Name the pull request in the form "[FLINK-XXXX] [component] Title of the pull request", where *FLINK-XXXX* should be replaced by the actual issue number. Skip *component* if you are unsure about which is the best component.
  Typo fixes that have no associated JIRA issue should be named following this pattern: `[hotfix] [docs] Fix typo in event time introduction` or `[hotfix] [javadocs] Expand JavaDoc for PuncuatedWatermarkGenerator`.

  - Fill out the template below to describe the changes contributed by the pull request. That will give reviewers the context they need to do the review.
  
  - Make sure that the change passes the automated tests, i.e., `mvn clean verify` passes. You can set up Azure Pipelines CI to do that following [this guide](https://cwiki.apache.org/confluence/display/FLINK/Azure+Pipelines#AzurePipelines-Tutorial:SettingupAzurePipelinesforaforkoftheFlinkrepository).

  - Each pull request should address only one issue, not mix up code from multiple issues.
  
  - Each commit in the pull request has a meaningful commit message (including the JIRA id)

  - Once all items of the checklist are addressed, remove the above text and this checklist, leaving only the filled out template below.


**(The sections below can be removed for hotfixes of typos)**
-->

## What is the purpose of the change

We are a collaborative group of researchers from JetBrains Research and Oregon State University, and we are testing our data-driven [plugin](https://github.com/JetBrains-Research/data-driven-type-migration), which is based on the IntelliJ's [Type Migration](https://www.jetbrains.com/help/idea/type-migration.html) framework and adjusts it using custom structural-replace templates that express the adaptations required to perform the type changes.

I want to apply several type changes using it and open the PR, thus introducing primitive functional interfaces in order to prevent unnecessary boxing (like `BooleanSupplier` instead of `Supplier<Boolean>`, `OptionalInt` instead of `Optional<Integer>`, `Predicate<T>` instead of `Function<T, Boolean>`, etc.), since it can affect the performance of the code (Effective Java, Items 44, 61). 

This patch is made automatically by the plugin, so it would help us a lot to evaluate the usefulness of our approach!

## Brief changelog

  - Introduce `LongConsumer` instead of `Consumer<Long>`
  - Introduce `IntSupplier` instead of `Supplier<Integer>`
  - Introduce `OptionalLong` instead of `Optional<Long>`
  - Introduce `Predicate<T>` instead of `Function<T, Boolean>`

## Verifying this change

This change is a trivial rework / code cleanup without any test coverage.

## Does this pull request potentially affect one of the following parts:

  - Dependencies (does it add or upgrade a dependency): no
  - The public API, i.e., is any changed class annotated with `@Public(Evolving)`: no
  - The serializers: don't know
  - The runtime per-record code paths (performance sensitive): should affect the performance in a positive way, but sure, not too much :)
  - Anything that affects deployment or recovery: JobManager (and its components), Checkpointing, Kubernetes/Yarn, ZooKeeper: no
  - The S3 file system connector: no

## Documentation

  - Does this pull request introduce a new feature: no
