### PR TITLE
[FLINK-23527][core] Clarify semantics of "SourceFunction.cancel()" with respect to thread interruptions

### DIFF
--- a/flink-streaming-java/src/main/java/org/apache/flink/streaming/api/functions/source/SourceFunction.java
+++ b/flink-streaming-java/src/main/java/org/apache/flink/streaming/api/functions/source/SourceFunction.java
@@ -75,7 +75,7 @@ import java.io.Serializable;
  *
  *          if (context.isRestored()) {
  *              for (Long count : this.checkpointedCount.get()) {
- *                  this.count = count;
+ *                  this.count += count;
  *              }
  *          }
  *      }


### PR DESCRIPTION
## What is the purpose of the change

This PR updates the JavaDocs of `SourceFunctions`. Primarily, this fixes the docs for the `cancel()` method, pointing out the dual use during graceful shutdown (stop with savepoint) and ungraceful shutdown (cancellation), as well as mentioning that no thread interruptions may happen during graceful shutdown.

As a preparation, additional hotfix commits clean up the general state of JavaDocs in that file.