### PR TITLE
[FLINK-23953] In the AvroSerializerSnapshot set the serializer compatibility to 'AS IS' in case when underlying Avro schemas are compatible

### DIFF
--- a/flink-formats/flink-avro/src/main/java/org/apache/flink/formats/avro/typeutils/AvroSerializerSnapshot.java
+++ b/flink-formats/flink-avro/src/main/java/org/apache/flink/formats/avro/typeutils/AvroSerializerSnapshot.java
@@ -191,7 +191,7 @@ public class AvroSerializerSnapshot<T> implements TypeSerializerSnapshot<T> {
                     // The new serializer would be able to read data persisted with *this*
                     // serializer, therefore no migration
                     // is required.
-                    return TypeSerializerSchemaCompatibility.compatibleAfterMigration();
+                    return TypeSerializerSchemaCompatibility.compatibleAsIs();
                 }
             case INCOMPATIBLE:
                 {

--- a/flink-formats/flink-avro/src/test/java/org/apache/flink/formats/avro/typeutils/AvroSerializerSnapshotTest.java
+++ b/flink-formats/flink-avro/src/test/java/org/apache/flink/formats/avro/typeutils/AvroSerializerSnapshotTest.java
@@ -87,7 +87,7 @@ public class AvroSerializerSnapshotTest {
         assertThat(
                 AvroSerializerSnapshot.resolveSchemaCompatibility(
                         FIRST_REQUIRED_LAST_OPTIONAL, FIRST_NAME),
-                isCompatibleAfterMigration());
+                isCompatibleAsIs());
     }
 
     @Test
@@ -95,7 +95,7 @@ public class AvroSerializerSnapshotTest {
         assertThat(
                 AvroSerializerSnapshot.resolveSchemaCompatibility(
                         FIRST_NAME, FIRST_REQUIRED_LAST_OPTIONAL),
-                isCompatibleAfterMigration());
+                isCompatibleAsIs());
     }
 
     @Test
@@ -192,7 +192,7 @@ public class AvroSerializerSnapshotTest {
     }
 
     @Test
-    public void validSchemaEvaluationShouldResultInCRequiresMigration() {
+    public void validSchemaEvaluationShouldResultInCAsIs() {
         final AvroSerializer<GenericRecord> originalSerializer =
                 new AvroSerializer<>(GenericRecord.class, FIRST_NAME);
         final AvroSerializer<GenericRecord> newSerializer =
@@ -203,7 +203,7 @@ public class AvroSerializerSnapshotTest {
 
         assertThat(
                 originalSnapshot.resolveSchemaCompatibility(newSerializer),
-                isCompatibleAfterMigration());
+                isCompatibleAsIs());
     }
 
     @Test

--- a/flink-formats/flink-avro/src/test/java/org/apache/flink/formats/avro/typeutils/AvroSerializerSnapshotTest.java
+++ b/flink-formats/flink-avro/src/test/java/org/apache/flink/formats/avro/typeutils/AvroSerializerSnapshotTest.java
@@ -41,7 +41,6 @@ import java.nio.file.Path;
 import java.nio.file.Paths;
 import java.util.Random;
 
-import static org.apache.flink.api.common.typeutils.TypeSerializerMatchers.isCompatibleAfterMigration;
 import static org.apache.flink.api.common.typeutils.TypeSerializerMatchers.isCompatibleAsIs;
 import static org.apache.flink.api.common.typeutils.TypeSerializerMatchers.isIncompatible;
 import static org.hamcrest.CoreMatchers.is;

--- a/flink-formats/flink-avro/src/test/java/org/apache/flink/formats/avro/typeutils/AvroSerializerSnapshotTest.java
+++ b/flink-formats/flink-avro/src/test/java/org/apache/flink/formats/avro/typeutils/AvroSerializerSnapshotTest.java
@@ -200,9 +200,7 @@ public class AvroSerializerSnapshotTest {
         TypeSerializerSnapshot<GenericRecord> originalSnapshot =
                 originalSerializer.snapshotConfiguration();
 
-        assertThat(
-                originalSnapshot.resolveSchemaCompatibility(newSerializer),
-                isCompatibleAsIs());
+        assertThat(originalSnapshot.resolveSchemaCompatibility(newSerializer), isCompatibleAsIs());
     }
 
     @Test


### PR DESCRIPTION

## What is the purpose of the change
To fix schema evolution for Avro records by eliminating the state migration in the scenario when the old and the new Avro schemas are compatible.


## Brief change log

- Resolve the schema compatibility status to "AS IS" in case when the old and the new Avro schemas are compatible.


## Verifying this change


## Does this pull request potentially affect one of the following parts:

  - Dependencies (does it add or upgrade a dependency): no
  - The public API, i.e., is any changed class annotated with `@Public(Evolving)`: no
  - The serializers: yes
  - The runtime per-record code paths (performance sensitive): no
  - Anything that affects deployment or recovery: JobManager (and its components), Checkpointing, Kubernetes/Yarn, ZooKeeper: yes
  - The S3 file system connector: no

## Documentation

  - Does this pull request introduce a new feature? no
  - If yes, how is the feature documented? not applicable