### PR TITLE
[FLINK-23941][python][docs] Add missing API in PyDocs

### DIFF
--- a/flink-python/docs/pyflink.datastream.rst
+++ b/flink-python/docs/pyflink.datastream.rst
@@ -26,3 +26,15 @@ Module contents
     :members:
     :undoc-members:
     :show-inheritance:
+
+pyflink.datastream.connectors module
+------------------------------------
+.. automodule:: pyflink.datastream.connectors
+    :members:
+    :undoc-members:
+
+pyflink.datastream.window module
+--------------------------------
+.. automodule:: pyflink.datastream.window
+    :members:
+    :undoc-members:

--- a/flink-python/docs/pyflink.table.rst
+++ b/flink-python/docs/pyflink.table.rst
@@ -50,3 +50,9 @@ pyflink.table.catalog module
 .. automodule:: pyflink.table.catalog
     :members:
     :undoc-members:
+
+pyflink.table.module module
+-------------------------------------
+.. automodule:: pyflink.table.module
+    :members:
+    :undoc-members:

--- a/flink-python/pyflink/common/__init__.py
+++ b/flink-python/pyflink/common/__init__.py
@@ -17,10 +17,32 @@
 ################################################################################
 
 """
-Important classes used by both Flink Streaming and Batch API:
+Common classes used by both Flink DataStream API and Table API:
 
+    - :class:`Configuration`:
+      Lightweight configuration object which stores key/value pairs.
     - :class:`ExecutionConfig`:
       A config to define the behavior of the program execution.
+    - :class:`ExecutionMode`:
+      Specifies how a batch program is executed in terms of data exchange: pipelining or batched.
+    - :class:`TypeInformation`:
+      TypeInformation is the core class of Flink's type system. FLink requires a type information
+      for all types that are used as input or return type of a user function.
+    - :class:`Types`:
+      Contains utilities to access the :class:`TypeInformation` of the most common types for which
+      Flink has provided built-in implementation.
+    - :class:`WatermarkStrategy`:
+      Defines how to generate Watermarks in the stream sources.
+    - :class:`Row`:
+      A row is a fixed-length, null-aware composite type for storing multiple values in a
+      deterministic field order.
+    - :class:`SerializationSchema`:
+      Base class to describes how to turn a data object into a different serialized representation.
+      Most data sinks (for example Apache Kafka) require the data to be handed to them in a specific
+      format (for example as byte strings). See :class:`JsonRowSerializationSchema`,
+      :class:`JsonRowDeserializationSchema`, :class:`CsvRowSerializationSchema`,
+      :class:`CsvRowDeserializationSchema`, :class:`AvroRowSerializationSchema`,
+      :class:`AvroRowDeserializationSchema` and :class:`SimpleStringSchema` for more details.
 """
 from pyflink.common.completable_future import CompletableFuture
 from pyflink.common.config_options import ConfigOption, ConfigOptions
@@ -33,17 +55,35 @@ from pyflink.common.job_execution_result import JobExecutionResult
 from pyflink.common.job_id import JobID
 from pyflink.common.job_status import JobStatus
 from pyflink.common.restart_strategy import RestartStrategies, RestartStrategyConfiguration
+from pyflink.common.serialization import SerializationSchema, DeserializationSchema, \
+    SimpleStringSchema, JsonRowSerializationSchema, JsonRowDeserializationSchema, \
+    CsvRowSerializationSchema, CsvRowDeserializationSchema, AvroRowSerializationSchema, \
+    AvroRowDeserializationSchema, Encoder
+from pyflink.common.serializer import TypeSerializer
 from pyflink.common.typeinfo import Types, TypeInformation
 from pyflink.common.types import Row, RowKind
 from pyflink.common.time import Duration, Instant, Time
 from pyflink.common.watermark_strategy import WatermarkStrategy
 
 __all__ = [
-    'CompletableFuture',
     'Configuration',
     'ConfigOption',
     'ConfigOptions',
     'ExecutionConfig',
+    "TypeInformation",
+    "TypeSerializer",
+    "Types",
+    'SerializationSchema',
+    'DeserializationSchema',
+    'SimpleStringSchema',
+    'JsonRowSerializationSchema',
+    'JsonRowDeserializationSchema',
+    'CsvRowSerializationSchema',
+    'CsvRowDeserializationSchema',
+    'AvroRowSerializationSchema',
+    'AvroRowDeserializationSchema',
+    'Encoder',
+    'CompletableFuture',
     'ExecutionMode',
     'InputDependencyConstraint',
     'JobClient',
@@ -54,10 +94,8 @@ __all__ = [
     'RestartStrategyConfiguration',
     "Row",
     "RowKind",
-    "Duration",
     "WatermarkStrategy",
-    "Types",
-    "TypeInformation",
+    "Duration",
     "Instant",
     "Time"
 ]

--- a/flink-python/pyflink/common/serialization.py
+++ b/flink-python/pyflink/common/serialization.py
@@ -23,6 +23,11 @@ from pyflink.util.java_utils import load_java_class
 
 from pyflink.java_gateway import get_gateway
 
+__all__ = ['SerializationSchema', 'DeserializationSchema', 'SimpleStringSchema',
+           'JsonRowSerializationSchema', 'JsonRowDeserializationSchema',
+           'CsvRowSerializationSchema', 'CsvRowDeserializationSchema',
+           'AvroRowSerializationSchema', 'AvroRowDeserializationSchema', 'Encoder']
+
 
 class SerializationSchema(object):
     """

--- a/flink-python/pyflink/common/serializer.py
+++ b/flink-python/pyflink/common/serializer.py
@@ -22,6 +22,8 @@ from typing import TypeVar, Generic
 
 T = TypeVar('T')
 
+__all__ = ['TypeSerializer']
+
 
 class TypeSerializer(ABC, Generic[T]):
     """

--- a/flink-python/pyflink/datastream/__init__.py
+++ b/flink-python/pyflink/datastream/__init__.py
@@ -17,65 +17,184 @@
 ################################################################################
 
 """
-Important classes of Flink Streaming API:
+Entry point classes of Flink DataStream API:
 
     - :class:`StreamExecutionEnvironment`:
       The context in which a streaming program is executed.
-    - :class:`CheckpointConfig`:
-      Configuration that captures all checkpointing related settings.
-    - :class:`CheckpointingMode`:
-      Defines what consistency guarantees the system gives in the presence of failures.
-    - :class:`CoMapFunction`:
-      Implements a map transformation over two connected streams.
-    - :class:`CoFlatMapFunction`:
-      Implements a flat-map transformation over two connected streams.
     - :class:`DataStream`:
       Represents a stream of elements of the same type. A DataStream can be transformed
-      into another DataStream by applying a transformation
+      into another DataStream by applying a transformation.
+    - :class:`KeyedStream`:
+      Represents a :class:`DataStream` where elements are partitioned by key using a
+      provided KeySelector.
+    - :class:`WindowedStream`:
+      Represents a data stream where elements are grouped by key, and for each
+      key, the stream of elements is split into windows based on a WindowAssigner. Window emission
+      is triggered based on a Trigger.
+    - :class:`ConnectedStreams`:
+      Represent two connected streams of (possibly) different data types. Connected
+      streams are useful for cases where operations on one stream directly affect the operations on
+      the other stream, usually via shared state between the streams.
+
+Functions used to transform a :class:`DataStream` into another :class:`DataStream`:
+
+    - :class:`MapFunction`:
+      Performs a map transformation of a :class:`DataStream` at element wise.
+    - :class:`CoMapFunction`:
+      Performs a map transformation over two connected streams.
     - :class:`FlatMapFunction`:
-      FlatMap functions take elements and transform them, into zero, one, or more elements.
+      Performs a flatmap transformation of a :class:`DataStream` which produces zero, one, or more
+      elements for each input element.
+    - :class:`CoFlatMapFunction`:
+      Performs a flatmap transformation over two connected streams.
     - :class:`FilterFunction`:
       A filter function is a predicate applied individually to each record.
+    - :class:`ReduceFunction`:
+      Combines groups of elements to a single value.
+    - :class:`ProcessFunction`:
+      Similar to :class:`FlatMapFunction`, except that it could access the current timestamp and
+      watermark in :class:`ProcessFunction`.
+    - :class:`KeyedProcessFunction`:
+      Similar to :class:`ProcessFunction`, except that it was applied to a :class:`KeyedStream` and
+      could register event-time and processing-time timers.
+    - :class:`CoProcessFunction`:
+      Similar to :class:`CoFlatMapFunction`, except that it could access the current timestamp and
+      watermark in :class:`CoProcessFunction`.
+    - :class:`KeyedCoProcessFunction`:
+      Similar to :class:`CoProcessFunction`, except that it was applied to a keyed
+      :class:`ConnectedStreams` and could register event-time and processing-time timers.
+    - :class:`KeyedCoProcessFunction`:
+      Similar to :class:`CoProcessFunction`, except that it was applied to a keyed
+      :class:`ConnectedStreams` and could register event-time and processing-time timers.
+    - :class:`WindowFunction`:
+      Base interface for functions that are evaluated over keyed (grouped) windows.
+    - :class:`ProcessWindowFunction`:
+      Similar to :class:`WindowFunction`, except that it could access a context for retrieving extra
+      information such as the current timestamp, the watermark, etc.
+    - :class:`AggregateFunction`:
+      Base class for a user-defined aggregate function.
+    - :class:`RuntimeContext`:
+      Contains information about the context in which functions are executed. Each
+      parallel instance of the function will have a context through which it can access static
+      contextual information (such as the current parallelism), etc.
+
+Classes to define window:
+
+    - :class:`Window`:
+      A grouping of elements into finite buckets.
+    - :class:`TimeWindow`:
+      A grouping of elements according to a time interval from start (inclusive) to end (exclusive).
+    - :class:`CountWindow`:
+      A grouping of elements according to element count from start (inclusive) to end (exclusive).
+    - :class:`WindowAssigner`:
+      Assigns zero or more :class:`Window` to an element.
+    - :class:`MergingWindowAssigner`:
+      A :class:`WindowAssigner` that can merge windows.
+    - :class:`TriggerResult`:
+      Result type for trigger methods. This determines what happens with the window, for example
+      whether the window function should be called, or the window should be discarded.
+    - :class:`Trigger`:
+      Determines when a pane of a window should be evaluated to emit the results for that
+      part of the window.
+
+Classes to define the behavior of checkpoint and state backend:
+
+    - :class:`CheckpointingMode`:
+      Defines what consistency guarantees the system gives in the presence of failures.
+    - :class:`CheckpointConfig`:
+      Configuration that captures all checkpointing related settings.
+    - :class:`StateBackend`:
+      Base class of the state backends which define how the state of a streaming application is
+      stored locally within the cluster. Different state backends store their state in different
+      fashions, and use different data structures to hold the state of a running application.
+    - :class:`HashMapStateBackend`:
+      Holds the working state in the memory (JVM heap) of the TaskManagers and
+      checkpoints based on the configured :class:`CheckpointStorage`.
+    - :class:`EmbeddedRocksDBStateBackend`:
+      Stores its state in an embedded `RocksDB` instance. This state backend can store very large
+      state that exceeds memory and spills to local disk.
+    - :class:`CustomStateBackend`:
+      A wrapper of customized java state backend.
+    - :class:`JobManagerCheckpointStorage`:
+      Checkpoints state directly to the JobManager's memory (hence the name), but savepoints will
+      be persisted to a file system.
+    - :class:`FileSystemCheckpointStorage`:
+      Checkpoints state as files to a file system. Each checkpoint individually will store all its
+      files in a subdirectory that includes the checkpoint number, such as
+      `hdfs://namenode:port/flink-checkpoints/chk-17/`.
+    - :class:`CustomCheckpointStorage`:
+      A wrapper of customized java checkpoint storage.
+
+Classes for state operations:
+
+    - :class:`state.ValueState`:
+      Interface for partitioned single-value state. The value can be retrieved or updated.
+    - :class:`state.ListState`:
+      Interface for partitioned list state in Operations. The state is accessed and modified by
+      user functions, and checkpointed consistently by the system as part of the distributed
+      snapshots.
+    - :class:`state.MapState`:
+      Interface for partitioned key-value state. The key-value pair can be added, updated and
+      retrieved.
+    - :class:`state.ReducingState`:
+      Interface for reducing state. Elements can be added to the state, they will be combined using
+      a :class:`ReduceFunction`. The current state can be inspected.
+    - :class:`state.AggregatingState`:
+      Interface for aggregating state, based on an :class:`AggregateFunction`. Elements that are
+      added to this type of state will be eagerly pre-aggregated using a given AggregateFunction.
+    - :class:`state.StateTtlConfig`:
+      Configuration of state TTL logic.
+
+Classes to define source & sink:
+
+    - :class:`connectors.FlinkKafkaConsumer`:
+      A streaming data source that pulls a parallel data stream from Apache Kafka.
+    - :class:`connectors.FlinkKafkaProducer`:
+      A streaming data sink to produce data into a Kafka topic.
+    - :class:`connectors.FileSource`:
+      A unified data source that reads files - both in batch and in streaming mode.
+      This source supports all (distributed) file systems and object stores that can be accessed via
+      the Flink's FileSystem class.
+    - :class:`connectors.FileSink`:
+      A unified sink that emits its input elements to FileSystem files within buckets. This
+      sink achieves exactly-once semantics for both BATCH and STREAMING.
+    - :class:`connectors.NumberSequenceSource`:
+      A data source that produces a sequence of numbers (longs). This source is useful for testing
+      and for cases that just need a stream of N events of any kind.
+    - :class:`connectors.JdbcSink`:
+      A data sink to produce data into an external storage using JDBC.
+    - :class:`connectors.StreamingFileSink`:
+      Sink that emits its input elements to files within buckets. This is integrated with the
+      checkpointing mechanism to provide exactly once semantics.
+
+Other important classes:
+
+    - :class:`TimeCharacteristic`:
+      Defines how the system determines time for time-dependent order and operations that depend
+      on time (such as time windows).
+    - :class:`TimeDomain`:
+      Specifies whether a firing timer is based on event time or processing time.
     - :class:`KeySelector`:
       The extractor takes an object and returns the deterministic key for that object.
     - :class:`Partitioner`:
       Function to implement a custom partition assignment for keys.
-    - :class:`ReduceFunction`:
-      Reduce functions combine groups of elements to a single value.
     - :class:`SinkFunction`:
       Interface for implementing user defined sink functionality.
     - :class:`SourceFunction`:
       Interface for implementing user defined source functionality.
-    - :class:`StateBackend`:
-      Defines how the state of a streaming application is stored and checkpointed.
-    - :class:`MapFunction`:
-      Map functions take elements and transform them, element wise.
-    - :class:`MemoryStateBackend`:
-      This state backend holds the working state in the memory (JVM heap) of the TaskManagers.
-    - :class:`FsStateBackend`:
-      The state backend checkpoints state as files to a file system.
-    - :class:`RocksDBStateBackend`:
-      A State Backend that stores its state in `RocksDB`.
-    - :class:`CustomStateBackend`:
-      A wrapper of customized java state backend created from the provided `StateBackendFactory`.
-    - :class:`PredefinedOptions`:
-      Configuration settings for the `RocksDBStateBackend`.
-    - :class:`ExternalizedCheckpointCleanup`:
-      Cleanup behaviour for externalized checkpoints when the job is cancelled.
-    - :class:`TimeCharacteristic`:
-      The time characteristic defines how the system determines time for time-dependent
-      order and operations that depend on time (such as time windows).
 """
 from pyflink.datastream.checkpoint_config import CheckpointConfig, ExternalizedCheckpointCleanup
 from pyflink.datastream.checkpointing_mode import CheckpointingMode
-from pyflink.datastream.data_stream import DataStream
+from pyflink.datastream.data_stream import DataStream, KeyedStream, WindowedStream, \
+    ConnectedStreams, DataStreamSink
+from pyflink.datastream.execution_mode import RuntimeExecutionMode
 from pyflink.datastream.functions import (MapFunction, CoMapFunction, FlatMapFunction,
                                           CoFlatMapFunction, ReduceFunction, RuntimeContext,
                                           KeySelector, FilterFunction, Partitioner, SourceFunction,
                                           SinkFunction, CoProcessFunction, KeyedProcessFunction,
                                           KeyedCoProcessFunction, AggregateFunction, WindowFunction,
                                           ProcessWindowFunction)
-from pyflink.datastream.slot_sharing_group import SlotSharingGroup
+from pyflink.datastream.slot_sharing_group import SlotSharingGroup, MemorySize
 from pyflink.datastream.state_backend import (StateBackend, MemoryStateBackend, FsStateBackend,
                                               RocksDBStateBackend, CustomStateBackend,
                                               PredefinedOptions, HashMapStateBackend,
@@ -93,43 +212,42 @@ from pyflink.datastream.window import Window, TimeWindow, CountWindow, WindowAss
 
 __all__ = [
     'StreamExecutionEnvironment',
-    'CheckpointConfig',
-    'CheckpointingMode',
     'DataStream',
-    'KeySelector',
-    'Partitioner',
+    'KeyedStream',
+    'WindowedStream',
+    'ConnectedStreams',
+    'DataStreamSink',
+    'MapFunction',
+    'CoMapFunction',
+    'FlatMapFunction',
+    'CoFlatMapFunction',
+    'ReduceFunction',
+    'FilterFunction',
+    'ProcessFunction',
+    'KeyedProcessFunction',
+    'CoProcessFunction',
+    'KeyedCoProcessFunction',
+    'WindowFunction',
+    'ProcessWindowFunction',
+    'AggregateFunction',
     'RuntimeContext',
-    'SourceFunction',
-    'SinkFunction',
+    'TimerService',
+    'CheckpointingMode',
+    'CheckpointConfig',
+    'ExternalizedCheckpointCleanup',
     'StateBackend',
     'HashMapStateBackend',
     'EmbeddedRocksDBStateBackend',
-    'MemoryStateBackend',
-    'FsStateBackend',
-    'RocksDBStateBackend',
     'CustomStateBackend',
+    'MemoryStateBackend',
+    'RocksDBStateBackend',
+    'FsStateBackend',
     'PredefinedOptions',
     'CheckpointStorage',
     'JobManagerCheckpointStorage',
     'FileSystemCheckpointStorage',
     'CustomCheckpointStorage',
-    'ExternalizedCheckpointCleanup',
-    'TimeCharacteristic',
-    'TimeDomain',
-    'MapFunction',
-    'FlatMapFunction',
-    'ReduceFunction',
-    'FilterFunction',
-    'ProcessFunction',
-    'KeyedProcessFunction',
-    'AggregateFunction',
-    'WindowFunction',
-    'ProcessWindowFunction',
-    'CoMapFunction',
-    'CoFlatMapFunction',
-    'CoProcessFunction',
-    'KeyedCoProcessFunction',
-    'TimerService',
+    'RuntimeExecutionMode',
     'Window',
     'TimeWindow',
     'CountWindow',
@@ -137,5 +255,12 @@ __all__ = [
     'MergingWindowAssigner',
     'TriggerResult',
     'Trigger',
-    'SlotSharingGroup'
+    'TimeCharacteristic',
+    'TimeDomain',
+    'KeySelector',
+    'Partitioner',
+    'SourceFunction',
+    'SinkFunction',
+    'SlotSharingGroup',
+    'MemorySize'
 ]

--- a/flink-python/pyflink/datastream/checkpoint_storage.py
+++ b/flink-python/pyflink/datastream/checkpoint_storage.py
@@ -356,7 +356,7 @@ class FileSystemCheckpointStorage(CheckpointStorage):
 
 class CustomCheckpointStorage(CheckpointStorage):
     """
-    A wrapper of customized java checkpoint storage created from the provided `StateBackendFactory`.
+    A wrapper of customized java checkpoint storage.
     """
 
     def __init__(self, j_custom_checkpoint_storage):

--- a/flink-python/pyflink/datastream/connectors.py
+++ b/flink-python/pyflink/datastream/connectors.py
@@ -151,7 +151,7 @@ class FlinkKafkaConsumerBase(SourceFunction, abc.ABC):
 class FlinkKafkaConsumer(FlinkKafkaConsumerBase):
     """
     The Flink Kafka Consumer is a streaming data source that pulls a parallel data stream from
-    Apache Kafka 0.10.x. The consumer can run in multiple parallel instances, each of which will
+    Apache Kafka. The consumer can run in multiple parallel instances, each of which will
     pull data from one or more Kafka partitions.
 
     The Flink Kafka Consumer participates in checkpointing and guarantees that no data is lost
@@ -276,8 +276,8 @@ class Semantic(Enum):
 
 class FlinkKafkaProducer(FlinkKafkaProducerBase):
     """
-    Flink Sink to produce data into a Kafka topic. This producer is compatible with Kafka 0.11.x. By
-    default producer will use AT_LEAST_ONCE sematic. Before using EXACTLY_ONCE please refer to
+    Flink Sink to produce data into a Kafka topic. By
+    default producer will use AT_LEAST_ONCE semantic. Before using EXACTLY_ONCE please refer to
     Flink's Kafka connector documentation.
     """
 

--- a/flink-python/pyflink/datastream/data_stream.py
+++ b/flink-python/pyflink/datastream/data_stream.py
@@ -40,7 +40,8 @@ from pyflink.datastream.utils import convert_to_python_obj
 from pyflink.java_gateway import get_gateway
 
 
-__all__ = ['CloseableIterator', 'DataStream']
+__all__ = ['CloseableIterator', 'DataStream', 'KeyedStream', 'ConnectedStreams', 'WindowedStream',
+           'DataStreamSink', 'CloseableIterator']
 
 
 class DataStream(object):
@@ -1036,6 +1037,7 @@ class KeyedStream(DataStream):
 
         Example:
         ::
+
             >>> ds = env.from_collection([(1, 'a'), (2, 'a'), (3, 'a'), (4, 'b'])
             >>> ds.key_by(lambda x: x[1]).reduce(lambda a, b: a[0] + b[0], b[1])
 

--- a/flink-python/pyflink/datastream/state_backend.py
+++ b/flink-python/pyflink/datastream/state_backend.py
@@ -1051,7 +1051,7 @@ class PredefinedOptions(Enum):
 
 class CustomStateBackend(StateBackend):
     """
-    A wrapper of customized java state backend created from the provided `StateBackendFactory`.
+    A wrapper of customized java state backend.
     """
 
     def __init__(self, j_custom_state_backend):

--- a/flink-python/pyflink/table/__init__.py
+++ b/flink-python/pyflink/table/__init__.py
@@ -17,54 +17,96 @@
 ################################################################################
 
 """
-Important classes of Flink Table API:
+Entry point classes of Flink Table API:
 
-    - :class:`pyflink.table.TableEnvironment`
-      Main entry point for :class:`Table` and SQL functionality
-    - :class:`pyflink.table.Table`
-      The core component of the Table API.
-      Use the methods of :class:`Table` to transform data.
-    - :class:`pyflink.table.TableConfig`
+    - :class:`TableEnvironment` and :class:`StreamTableEnvironment`
+      Main entry point for Flink Table API & SQL functionality. :class:`TableEnvironment` is used
+      in pure Table API & SQL jobs. Meanwhile, :class:`StreamTableEnvironment` needs to be used when
+      mixing use of Table API and DataStream API.
+    - :class:`Table`
+      The core component of the Table API. Use the methods of :class:`Table` to transform data.
+    - :class:`StatementSet`
+      The core component of the Table API. It's used to create jobs with multiple sinks.
+    - :class:`EnvironmentSettings`
+      Defines all the parameters used to initialize a :class:`TableEnvironment`.
+    - :class:`TableConfig`
       A config to define the runtime behavior of the Table API.
-      It is necessary when creating :class:`TableEnvironment`.
-    - :class:`pyflink.table.EnvironmentSettings`
-      Defines all parameters that initialize a table environment.
-    - :class:`pyflink.table.TableSource`
-      Defines an external data source as a table.
-    - :class:`pyflink.table.TableSink`
-      Specifies how to emit a table to an external system or location.
-    - :class:`pyflink.table.DataTypes`
-      Defines a list of data types available.
-    - :class:`pyflink.table.Row`
-      A row in a :class:`Table`.
-    - :class:`pyflink.table.Expression`
-      A column expression in a :class:`Table`.
-    - :class:`pyflink.table.window`
-      Helper classes for working with :class:`pyflink.table.window.GroupWindow`
-      (:class:`pyflink.table.window.Tumble`, :class:`pyflink.table.window.Session`,
-      :class:`pyflink.table.window.Slide`) and :class:`pyflink.table.window.OverWindow` window
-      (:class:`pyflink.table.window.Over`).
-    - :class:`pyflink.table.descriptors`
-      Helper classes that describes DDL information, such as how to connect to another system,
-      the format of data, the schema of table, the event time attribute in the schema, etc.
-    - :class:`pyflink.table.catalog`
-      Responsible for reading and writing metadata such as database/table/views/UDFs
-      from a registered :class:`pyflink.table.catalog.Catalog`.
-    - :class:`pyflink.table.TableSchema`
-      Represents a table's structure with field names and data types.
-    - :class:`pyflink.table.FunctionContext`
+      It is used together with :class:`pyflink.datastream.StreamExecutionEnvironment` to create
+      :class:`StreamTableEnvironment`.
+
+Classes to define user-defined functions:
+
+    - :class:`ScalarFunction`
+      Base interface for user-defined scalar function.
+    - :class:`TableFunction`
+      Base interface for user-defined table function.
+    - :class:`AggregateFunction`
+      Base interface for user-defined aggregate function.
+    - :class:`TableAggregateFunction`
+      Base interface for user-defined table aggregate function.
+    - :class:`FunctionContext`
       Used to obtain global runtime information about the context in which the
       user-defined function is executed, such as the metric group, and global job parameters, etc.
-    - :class:`pyflink.table.ScalarFunction`
-      Base interface for user-defined scalar function.
-    - :class:`pyflink.table.TableFunction`
-      Base interface for user-defined table function.
-    - :class:`pyflink.table.AggregateFunction`
-      Base interface for user-defined aggregate function.
-    - :class:`pyflink.table.TableAggregateFunction`
-      Base interface for user-defined table aggregate function.
-    - :class:`pyflink.table.StatementSet`
-      Base interface accepts DML statements or Tables.
+
+Classes to define window:
+
+    - :class:`window.GroupWindow`
+      Group windows group rows based on time or row-count intervals. See :class:`window.Tumble`,
+      :class:`window.Session` and :class:`window.Slide` for more details on how to create a tumble
+      window, session window, hop window separately.
+    - :class:`window.OverWindow`
+      Over window aggregates compute an aggregate for each input row over a range
+      of its neighboring rows. See :class:`window.Over` for more details on how to create an over
+      window.
+
+Classes for catalog:
+
+    - :class:`catalog.Catalog`
+      Responsible for reading and writing metadata such as database/table/views/UDFs
+      from and to a catalog.
+    - :class:`catalog.HiveCatalog`
+      Responsible for reading and writing metadata stored in Hive.
+
+Classes to define source & sink:
+
+    - :class:`TableDescriptor`
+      TableDescriptor is a template for creating a CatalogTable instance. It closely resembles the
+      "CREATE TABLE" SQL DDL statement, containing schema, connector options, and other
+      characteristics. Since tables in Flink are typically backed by external systems, the
+      descriptor describes how a connector (and possibly its format) are configured.
+    - :class:`FormatDescriptor`
+      Describes a format and its options for use with :class:`TableDescriptor`.
+    - :class:`Schema`
+      Describes the schema for use with :class:`TableDescriptor`. It represents the schema part of a
+      `CREATE TABLE (schema) WITH (options)` DDL statement in SQL. It defines columns of
+      different kind, constraints, time attributes, and watermark strategies. It is possible to
+      reference objects (such as functions or types) across different catalogs.
+
+Classes for module:
+
+    - :class:`Module`
+      Defines a set of metadata, including functions, user defined types, operators, rules,
+      etc. Metadata from modules are regarded as built-in or system metadata that users can take
+      advantages of.
+    - :class:`module.HiveModule`
+      Implementation of :class:`Module` to provide Hive built-in metadata.
+
+Other important classes:
+
+    - :class:`DataTypes`
+      Defines a list of data types available in Table API.
+    - :class:`Expression`
+      Represents a logical tree for producing a computation result for a column in a :class:`Table`.
+      Might be literal values, function calls, or field references.
+    - :class:`TableSchema`
+      Represents a table's structure with field names and data types.
+    - :class:`SqlDialect`
+      Enumeration of valid SQL compatibility modes.
+    - :class:`ChangelogMode`
+      The set of changes contained in a changelog.
+    - :class:`ExplainDetail`
+      Defines the types of details for explain result.
+
 """
 from __future__ import absolute_import
 
@@ -83,6 +125,7 @@ from pyflink.table.statement_set import StatementSet
 from pyflink.table.table import GroupWindowedTable, GroupedTable, OverWindowedTable, Table, \
     WindowGroupedTable
 from pyflink.table.table_config import TableConfig
+from pyflink.table.table_descriptor import TableDescriptor, FormatDescriptor
 from pyflink.table.table_environment import (TableEnvironment, StreamTableEnvironment)
 from pyflink.table.table_result import TableResult
 from pyflink.table.table_schema import TableSchema
@@ -91,41 +134,43 @@ from pyflink.table.udf import FunctionContext, ScalarFunction, TableFunction, Ag
     TableAggregateFunction
 
 __all__ = [
-    'AggregateFunction',
-    'CsvTableSink',
-    'CsvTableSource',
-    'DataTypes',
-    'DataView',
-    'EnvironmentSettings',
-    'ExplainDetail',
-    'Expression',
-    'FunctionContext',
-    'GroupWindowedTable',
-    'GroupedTable',
-    'ListView',
-    'MapView',
-    'Module',
-    'ModuleEntry',
-    'OverWindowedTable',
-    'ResultKind',
-    'Row',
-    'RowKind',
-    'ScalarFunction',
-    'Schema',
-    'SqlDialect',
-    'StatementSet',
+    'TableEnvironment',
     'StreamTableEnvironment',
     'Table',
+    'StatementSet',
+    'EnvironmentSettings',
     'TableConfig',
-    'TableEnvironment',
-    'TableFunction',
-    'TableResult',
-    'TableSchema',
-    'TableSink',
-    'TableSource',
-    'TableAggregateFunction',
-    'UserDefinedType',
+    'GroupedTable',
+    'GroupWindowedTable',
+    'OverWindowedTable',
     'WindowGroupedTable',
+    'ScalarFunction',
+    'TableFunction',
+    'AggregateFunction',
+    'TableAggregateFunction',
+    'FunctionContext',
+    'DataView',
+    'ListView',
+    'MapView',
+    'TableDescriptor',
+    'FormatDescriptor',
+    'Schema',
+    'Module',
+    'ModuleEntry',
+    'SqlDialect',
+    'DataTypes',
+    'UserDefinedType',
+    'Expression',
+    'TableSchema',
+    'TableResult',
+    'Row',
+    'RowKind',
+    'ChangelogMode',
+    'ExplainDetail',
+    'TableSource',
+    'TableSink',
+    'CsvTableSource',
+    'CsvTableSink',
     'WriteMode',
-    'ChangelogMode'
+    'ResultKind'
 ]

--- a/flink-python/pyflink/table/table_descriptor.py
+++ b/flink-python/pyflink/table/table_descriptor.py
@@ -29,7 +29,7 @@ class TableDescriptor(object):
     """
     Describes a CatalogTable representing a source or sink.
 
-    TableDescriptor is a template for creating a CatalogTable} instance. It closely resembles the
+    TableDescriptor is a template for creating a CatalogTable instance. It closely resembles the
     "CREATE TABLE" SQL DDL statement, containing schema, connector options, and other
     characteristics. Since tables in Flink are typically backed by external systems, the
     descriptor describes how a connector (and possibly its format) are configured.

--- a/flink-python/pyflink/table/table_environment.py
+++ b/flink-python/pyflink/table/table_environment.py
@@ -631,6 +631,8 @@ class TableEnvironment(object):
         trigger an execution.
 
         :return: The Table object describing the pipeline for further transformations.
+
+        .. versionadded:: 1.14.0
         """
         return Table(get_method(self._j_tenv, "from")(descriptor._j_table_descriptor), self)
 


### PR DESCRIPTION

## What is the purpose of the change

*This pull request fixes the PyDocs by adding documentation for some missing API. It also refactors the PyDocs a bit by grouping APIs with similar functionalities together to make the doc more readable.*

## Verifying this change

This change is a documentation work without any test coverage.

## Does this pull request potentially affect one of the following parts:

  - Dependencies (does it add or upgrade a dependency): (no)
  - The public API, i.e., is any changed class annotated with `@Public(Evolving)`: (no)
  - The serializers: (no)
  - The runtime per-record code paths (performance sensitive): (no)
  - Anything that affects deployment or recovery: JobManager (and its components), Checkpointing, Kubernetes/Yarn, ZooKeeper: (no)
  - The S3 file system connector: (no)

## Documentation

  - Does this pull request introduce a new feature? (no)
  - If yes, how is the feature documented? (not applicable)
