### PR TITLE
[FLINK-23611][yarn-tests] Disables log message to enable watchdog functionality

### DIFF
--- a/flink-yarn-tests/src/test/java/org/apache/flink/yarn/YarnTestBase.java
+++ b/flink-yarn-tests/src/test/java/org/apache/flink/yarn/YarnTestBase.java
@@ -1216,7 +1216,7 @@ public abstract class YarnTestBase extends TestLogger {
         // to <flinkRoot>/target/flink-yarn-tests-*.
         // The files from there are picked up by the tools/ci/* scripts to upload them.
         if (isOnCI()) {
-            File target = new File("../target" + YARN_CONFIGURATION.get(TEST_CLUSTER_NAME_KEY));
+            File target = new File("../target/" + YARN_CONFIGURATION.get(TEST_CLUSTER_NAME_KEY));
             if (!target.mkdirs()) {
                 LOG.warn("Error creating dirs to {}", target);
             }

--- a/flink-yarn-tests/src/test/resources/log4j2-test.properties
+++ b/flink-yarn-tests/src/test/resources/log4j2-test.properties
@@ -25,7 +25,7 @@ appender.testlogger.name = TestLogger
 appender.testlogger.type = CONSOLE
 appender.testlogger.target = SYSTEM_ERR
 appender.testlogger.layout.type = PatternLayout
-appender.testlogger.layout.pattern = %-4r [%t] %-5p %c %x - %m%n
+appender.testlogger.layout.pattern = %d [%t] %-5p %c %x - %m%n
 
 logger.hadoop.name = org.apache.hadoop
 logger.hadoop.level = OFF

--- a/tools/ci/log4j.properties
+++ b/tools/ci/log4j.properties
@@ -59,3 +59,8 @@ logger.yarn1.appenderRef.out.ref = ConsoleAppender
 logger.yarn2.name = org.apache.flink.yarn.YARNSessionCapacitySchedulerITCase
 logger.yarn2.level = INFO
 logger.yarn2.appenderRef.out.ref = ConsoleAppender
+
+# YARN's cache cleanup is generating log output on a regular basis which prevents tools/ci/test_controller.sh's
+# watchdog mechanism to kick in in case of a timeout. Disabling this regular log message helps detecting timeouts.
+logger.yarn3.name = org.apache.hadoop.yarn.server.nodemanager.containermanager.localizer.ResourceLocalizationService
+logger.yarn3.level = WARN


### PR DESCRIPTION
## What is the purpose of the change

We struggled to investigate [FLINK-23611](https://issues.apache.org/jira/browse/FLINK-23611) due to missing Flink logs. It appears that something went wrong with the Flink cluster. The stop signal wasn't retrieved by the YARN Session Cluster thread for some reason which made the test wait forever for the thread to finish.

The tests are executed on AzureCI through `tools/ci/test_controller.sh` which implements a watchdog mechanism that checks the logs (`stdout` and `mvn-*.log`) for new content and kills the test if there's no output for a given amount of time (900s). YARN does produce regular logs, though, through the `org.apache.hadoop.yarn.server.nodemanager.containermanager.localizer.ResourceLocalizationService` logger. These log messages are generated every 10 minutes:
```
22:51:31,785 [AsyncDispatcher event handler] INFO  org.apache.hadoop.yarn.server.nodemanager.containermanager.localizer.ResourceLocalizationService [] - Cache Size Before Clean: 0, Total Deleted: 0, Public Deleted: 0, Private Deleted: 0
22:51:32,398 [AsyncDispatcher event handler] INFO  org.apache.hadoop.yarn.server.nodemanager.containermanager.localizer.ResourceLocalizationService [] - Cache Size Before Clean: 0, Total Deleted: 0, Public Deleted: 0, Private Deleted: 0
```

Hence, the test is not killed while waiting for the YARN cluster to finish. The Flink logs, as a consequence, are not copied over from the YARN application folder into the build artifact folder as part of the [tools/ci/test_controller.sh](https://github.com/apache/flink/blob/master/tools/ci/test_controller.sh#L128) execution.

## Brief change log

- Hotfix: Fixes bug in path creation
- Hotfix: Improves local log4j configuration for YARN tests
- Disables INFO logs for `org.apache.hadoop.yarn.server.nodemanager.containermanager.localizer.ResourceLocalizationService` in ci log4j configuration

## Verifying this change

This change is a trivial rework / code cleanup without any test coverage.

## Does this pull request potentially affect one of the following parts:

  - Dependencies (does it add or upgrade a dependency): no
  - The public API, i.e., is any changed class annotated with `@Public(Evolving)`: no
  - The serializers: no
  - The runtime per-record code paths (performance sensitive): no
  - Anything that affects deployment or recovery: JobManager (and its components), Checkpointing, Kubernetes/Yarn, ZooKeeper: no
  - The S3 file system connector: no

## Documentation

  - Does this pull request introduce a new feature? no
  - If yes, how is the feature documented? not applicable
