### PR TITLE
[FLINK-23776][datastream] Optimize source metric calculation

### DIFF
--- a/flink-connectors/flink-connector-base/src/test/java/org/apache/flink/connector/base/source/reader/SourceMetricsITCase.java
+++ b/flink-connectors/flink-connector-base/src/test/java/org/apache/flink/connector/base/source/reader/SourceMetricsITCase.java
@@ -32,6 +32,7 @@ import org.apache.flink.metrics.Gauge;
 import org.apache.flink.metrics.Metric;
 import org.apache.flink.metrics.groups.OperatorMetricGroup;
 import org.apache.flink.runtime.metrics.MetricNames;
+import org.apache.flink.runtime.metrics.groups.InternalSourceReaderMetricGroup;
 import org.apache.flink.runtime.testutils.InMemoryReporter;
 import org.apache.flink.runtime.testutils.MiniClusterResourceConfiguration;
 import org.apache.flink.streaming.api.datastream.DataStream;
@@ -184,7 +185,9 @@ public class SourceMetricsITCase extends TestLogger {
             // there are only 2 splits assigned; so two groups will not update metrics
             if (group.getIOMetricGroup().getNumRecordsInCounter().getCount() == 0) {
                 // assert that optional metrics are not initialized when no split assigned
-                assertThat(metrics.get(MetricNames.CURRENT_EMIT_EVENT_TIME_LAG), nullValue());
+                assertThat(
+                        metrics.get(MetricNames.CURRENT_EMIT_EVENT_TIME_LAG),
+                        isGauge(equalTo(InternalSourceReaderMetricGroup.UNDEFINED)));
                 assertThat(metrics.get(MetricNames.WATERMARK_LAG), nullValue());
                 continue;
             }
@@ -224,7 +227,9 @@ public class SourceMetricsITCase extends TestLogger {
                 assertThat(watermarkLag, isCloseTo(WATERMARK_LAG, WATERMARK_EPSILON));
             } else {
                 // assert that optional metrics are not initialized when no timestamp assigned
-                assertThat(metrics.get(MetricNames.CURRENT_EMIT_EVENT_TIME_LAG), nullValue());
+                assertThat(
+                        metrics.get(MetricNames.CURRENT_EMIT_EVENT_TIME_LAG),
+                        isGauge(equalTo(InternalSourceReaderMetricGroup.UNDEFINED)));
                 assertThat(metrics.get(MetricNames.WATERMARK_LAG), nullValue());
             }
 

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/metrics/groups/InternalSourceReaderMetricGroup.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/metrics/groups/InternalSourceReaderMetricGroup.java
@@ -20,6 +20,8 @@ package org.apache.flink.runtime.metrics.groups;
 
 import org.apache.flink.annotation.Internal;
 import org.apache.flink.annotation.VisibleForTesting;
+import org.apache.flink.api.common.eventtime.TimestampAssigner;
+import org.apache.flink.api.common.eventtime.Watermark;
 import org.apache.flink.metrics.Counter;
 import org.apache.flink.metrics.Gauge;
 import org.apache.flink.metrics.MetricGroup;
@@ -35,17 +37,17 @@ import org.apache.flink.util.clock.SystemClock;
 @Internal
 public class InternalSourceReaderMetricGroup extends ProxyMetricGroup<MetricGroup>
         implements SourceReaderMetricGroup {
-
-    public static final long ACTIVE = Long.MAX_VALUE;
+    public static final long UNDEFINED = -1L;
+    private static final long ACTIVE = Long.MAX_VALUE;
+    private static final long MAX_WATERMARK_TIMESTAMP = Watermark.MAX_WATERMARK.getTimestamp();
 
     private final OperatorIOMetricGroup operatorIOMetricGroup;
-    private final Clock clock;
     private final Counter numRecordsInErrors;
-    private boolean watermarkLagRegistered;
-    private boolean eventTimeLagRegistered;
+    private final Clock clock;
     private long lastWatermark;
-    private long lastEventTime;
+    private long lastEventTime = TimestampAssigner.NO_TIMESTAMP;
     private long idleStartTime = ACTIVE;
+    private boolean firstWatermark = true;
 
     private InternalSourceReaderMetricGroup(
             MetricGroup parentMetricGroup,
@@ -55,9 +57,8 @@ public class InternalSourceReaderMetricGroup extends ProxyMetricGroup<MetricGrou
         numRecordsInErrors = parentMetricGroup.counter(MetricNames.NUM_RECORDS_IN_ERRORS);
         this.operatorIOMetricGroup = operatorIOMetricGroup;
         this.clock = clock;
-        parentMetricGroup.gauge(
-                MetricNames.SOURCE_IDLE_TIME,
-                () -> isIdling() ? this.clock.absoluteTimeMillis() - idleStartTime : 0);
+        parentMetricGroup.gauge(MetricNames.SOURCE_IDLE_TIME, this::getIdleTime);
+        parentMetricGroup.gauge(MetricNames.CURRENT_EMIT_EVENT_TIME_LAG, this::getEmitTimeLag);
     }
 
     public static InternalSourceReaderMetricGroup wrap(OperatorMetricGroup operatorMetricGroup) {
@@ -75,52 +76,9 @@ public class InternalSourceReaderMetricGroup extends ProxyMetricGroup<MetricGrou
                 SystemClock.getInstance());
     }
 
-    private boolean isIdling() {
-        return idleStartTime != ACTIVE;
-    }
-
-    public void idlingStarted() {
-        if (!isIdling()) {
-            idleStartTime = clock.absoluteTimeMillis();
-        }
-    }
-
-    public void recordEmitted() {
-        idleStartTime = ACTIVE;
-    }
-
     @Override
     public Counter getNumRecordsInErrorsCounter() {
         return numRecordsInErrors;
-    }
-
-    public void watermarkEmitted(long watermark) {
-        lastWatermark = watermark;
-        // iff a respective source emits a watermark, Flink can provide the watermark lag
-        if (!watermarkLagRegistered) {
-            parentMetricGroup.gauge(
-                    MetricNames.WATERMARK_LAG, () -> clock.absoluteTimeMillis() - lastWatermark);
-            watermarkLagRegistered = true;
-        }
-    }
-
-    public void eventTimeEmitted(long timestamp) {
-        lastEventTime = timestamp;
-        // iff a respective source emits a timestamp, Flink can provide the event lag
-        if (!eventTimeLagRegistered) {
-            parentMetricGroup.gauge(
-                    MetricNames.CURRENT_EMIT_EVENT_TIME_LAG,
-                    () -> getLastEmitTime() - lastEventTime);
-            eventTimeLagRegistered = true;
-        }
-    }
-
-    /**
-     * This is a rough approximation. If the source is busy, we assume that <code>emit time == now()
-     * </code>. If it's idling, we just take the time it started idling as the last emit time.
-     */
-    private long getLastEmitTime() {
-        return isIdling() ? idleStartTime : clock.absoluteTimeMillis();
     }
 
     @Override
@@ -136,5 +94,67 @@ public class InternalSourceReaderMetricGroup extends ProxyMetricGroup<MetricGrou
     @Override
     public OperatorIOMetricGroup getIOMetricGroup() {
         return operatorIOMetricGroup;
+    }
+
+    /**
+     * Called when a new record was emitted with the given timestamp. {@link
+     * TimestampAssigner#NO_TIMESTAMP} should be indicated that the record did not have a timestamp.
+     *
+     * <p>Note this function should be called before the actual record is emitted such that chained
+     * processing does not influence the statistics.
+     */
+    public void recordEmitted(long timestamp) {
+        idleStartTime = ACTIVE;
+        lastEventTime = timestamp;
+    }
+
+    public void idlingStarted() {
+        if (!isIdling()) {
+            idleStartTime = clock.absoluteTimeMillis();
+        }
+    }
+
+    /**
+     * Called when a watermark was emitted.
+     *
+     * <p>Note this function should be called before the actual watermark is emitted such that
+     * chained processing does not influence the statistics.
+     */
+    public void watermarkEmitted(long watermark) {
+        if (watermark == MAX_WATERMARK_TIMESTAMP) {
+            return;
+        }
+        lastWatermark = watermark;
+        if (firstWatermark) {
+            parentMetricGroup.gauge(MetricNames.WATERMARK_LAG, this::getWatermarkLag);
+            firstWatermark = false;
+        }
+    }
+
+    boolean isIdling() {
+        return idleStartTime != ACTIVE;
+    }
+
+    long getIdleTime() {
+        return isIdling() ? this.clock.absoluteTimeMillis() - idleStartTime : 0;
+    }
+
+    /**
+     * This is a rough approximation. If the source is busy, we assume that <code>
+     * emit time == now()
+     * </code>. If it's idling, we just take the time it started idling as the last emit time.
+     */
+    private long getLastEmitTime() {
+        return isIdling() ? idleStartTime : clock.absoluteTimeMillis();
+    }
+
+    long getEmitTimeLag() {
+        return lastEventTime != TimestampAssigner.NO_TIMESTAMP
+                ? getLastEmitTime() - lastEventTime
+                : UNDEFINED;
+    }
+
+    long getWatermarkLag() {
+        return getLastEmitTime() - lastWatermark;
     }
 }

--- a/flink-streaming-java/src/main/java/org/apache/flink/streaming/runtime/io/StreamMultipleInputProcessorFactory.java
+++ b/flink-streaming-java/src/main/java/org/apache/flink/streaming/runtime/io/StreamMultipleInputProcessorFactory.java
@@ -31,6 +31,7 @@ import org.apache.flink.runtime.checkpoint.InflightDataRescalingDescriptor;
 import org.apache.flink.runtime.io.disk.iomanager.IOManager;
 import org.apache.flink.runtime.jobgraph.tasks.TaskInvokable;
 import org.apache.flink.runtime.memory.MemoryManager;
+import org.apache.flink.runtime.metrics.groups.InternalSourceReaderMetricGroup;
 import org.apache.flink.runtime.metrics.groups.TaskIOMetricGroup;
 import org.apache.flink.streaming.api.graph.StreamConfig;
 import org.apache.flink.streaming.api.operators.Input;
@@ -211,14 +212,19 @@ public class StreamMultipleInputProcessorFactory {
             } else if (configuredInput instanceof StreamConfig.SourceInputConfig) {
                 StreamConfig.SourceInputConfig sourceInput =
                         (StreamConfig.SourceInputConfig) configuredInput;
-                WatermarkGaugeExposingOutput<StreamRecord<?>> chainedSourceOutput =
-                        operatorChain.getChainedSourceOutput(sourceInput);
+                OperatorChain.ChainedSource chainedSource =
+                        operatorChain.getChainedSource(sourceInput);
 
                 inputProcessors[i] =
                         new StreamOneInputProcessor(
                                 inputs[i],
                                 new StreamTaskSourceOutput(
-                                        chainedSourceOutput, inputWatermarkGauges[i]),
+                                        chainedSource.getSourceOutput(),
+                                        inputWatermarkGauges[i],
+                                        chainedSource
+                                                .getSourceTaskInput()
+                                                .getOperator()
+                                                .getSourceMetricGroup()),
                                 operatorChain);
             } else {
                 throw new UnsupportedOperationException("Unknown input type: " + configuredInput);
@@ -285,8 +291,9 @@ public class StreamMultipleInputProcessorFactory {
 
         public StreamTaskSourceOutput(
                 WatermarkGaugeExposingOutput<StreamRecord<?>> chainedSourceOutput,
-                WatermarkGauge inputWatermarkGauge) {
-            super(chainedSourceOutput, new SimpleCounter(), inputWatermarkGauge);
+                WatermarkGauge inputWatermarkGauge,
+                InternalSourceReaderMetricGroup metricGroup) {
+            super(chainedSourceOutput, metricGroup, inputWatermarkGauge);
             this.chainedOutput = chainedSourceOutput;
         }
 

--- a/flink-streaming-java/src/main/java/org/apache/flink/streaming/runtime/tasks/OperatorChain.java
+++ b/flink-streaming-java/src/main/java/org/apache/flink/streaming/runtime/tasks/OperatorChain.java
@@ -369,13 +369,12 @@ public abstract class OperatorChain<OUT, OP extends StreamOperator<OUT>>
         return mainOperatorOutput;
     }
 
-    public WatermarkGaugeExposingOutput<StreamRecord<?>> getChainedSourceOutput(
-            StreamConfig.SourceInputConfig sourceInput) {
+    public ChainedSource getChainedSource(StreamConfig.SourceInputConfig sourceInput) {
         checkArgument(
                 chainedSources.containsKey(sourceInput),
                 "Chained source with sourcedId = [%s] was not found",
                 sourceInput);
-        return chainedSources.get(sourceInput).getSourceOutput();
+        return chainedSources.get(sourceInput);
     }
 
     public List<Output<StreamRecord<?>>> getChainedSourceOutputs() {

--- a/flink-streaming-java/src/test/java/org/apache/flink/streaming/api/operators/source/TestingSourceOperator.java
+++ b/flink-streaming-java/src/test/java/org/apache/flink/streaming/api/operators/source/TestingSourceOperator.java
@@ -95,6 +95,7 @@ public class TestingSourceOperator<T> extends SourceOperator<T, MockSourceSplit>
         this.subtaskIndex = subtaskIndex;
         this.parallelism = parallelism;
         this.metrics = UnregisteredMetricGroups.createUnregisteredOperatorMetricGroup();
+        initSourceMetricGroup();
 
         // unchecked wrapping is okay to keep tests simpler
         try {


### PR DESCRIPTION

<!--
*Thank you very much for contributing to Apache Flink - we are happy that you want to help us improve Flink. To help the community review your contribution in the best possible way, please go through the checklist below, which will get the contribution into a shape in which it can be best reviewed.*

*Please understand that we do not do this to make contributions to Flink a hassle. In order to uphold a high standard of quality for code contributions, while at the same time managing a large number of contributions, we need contributors to prepare the contributions well, and give reviewers enough contextual information for the review. Please also understand that contributions that do not follow this guide will take longer to review and thus typically be picked up with lower priority by the community.*

## Contribution Checklist

  - Make sure that the pull request corresponds to a [JIRA issue](https://issues.apache.org/jira/projects/FLINK/issues). Exceptions are made for typos in JavaDoc or documentation files, which need no JIRA issue.
  
  - Name the pull request in the form "[FLINK-XXXX] [component] Title of the pull request", where *FLINK-XXXX* should be replaced by the actual issue number. Skip *component* if you are unsure about which is the best component.
  Typo fixes that have no associated JIRA issue should be named following this pattern: `[hotfix] [docs] Fix typo in event time introduction` or `[hotfix] [javadocs] Expand JavaDoc for PuncuatedWatermarkGenerator`.

  - Fill out the template below to describe the changes contributed by the pull request. That will give reviewers the context they need to do the review.
  
  - Make sure that the change passes the automated tests, i.e., `mvn clean verify` passes. You can set up Azure Pipelines CI to do that following [this guide](https://cwiki.apache.org/confluence/display/FLINK/Azure+Pipelines#AzurePipelines-Tutorial:SettingupAzurePipelinesforaforkoftheFlinkrepository).

  - Each pull request should address only one issue, not mix up code from multiple issues.
  
  - Each commit in the pull request has a meaningful commit message (including the JIRA id)

  - Once all items of the checklist are addressed, remove the above text and this checklist, leaving only the filled out template below.


**(The sections below can be removed for hotfixes of typos)**
-->

## What is the purpose of the change

There is a performance regression of 15% on new sources in InputBenchmark. 

## Brief change log

A couple of issues are fixed with this commit:
- MetricTrackingOutput in SourceOperator adds 1 virtual calls per record. This accounts for ~5% of the regression. The solution is to move the functionality inside SourceOutput. The newly added SourceListener abstracts from the InternalSourceReaderMetricGroup and can be used inside the SourceOutput right before record/watermark emission.
- Lazy registration of CURRENT_EMIT_EVENT_TIME_LAG gauge. This adds ~2% overhead as it checks for each record whether the metric has been registered already. The solution is to always add the metric and just return some UNDEFINED value when there is no record.
- Check of NO_TIMESTAMP. This adds ~3% overhead as it's a long comparison for each record. The solution is to lazily check the timestamp in the gauge. This solution depends on the prior solution.
- Fusion of recordEmitted() and eventTimeEmitted(). This removes 2% overhead and is possible after the previous optimizations.

A bit of regression may remain after this commit. Future work may further improve the situation. However, it may also be the price to be paid for the additional metrics. In real sources with I/O, the remaining regression will not be as noticeable. For example, the micro benchmarks imply that the new source is 2x faster than the old sources but we do not see any difference in actual sources.

## Verifying this change

Functionality covered by test. Performance tested with benchmark-requested.

## Does this pull request potentially affect one of the following parts:

  - Dependencies (does it add or upgrade a dependency): (yes / **no**)
  - The public API, i.e., is any changed class annotated with `@Public(Evolving)`: (yes / **no**)
  - The serializers: (yes / **no** / don't know)
  - The runtime per-record code paths (performance sensitive): (**yes** / no / don't know)
  - Anything that affects deployment or recovery: JobManager (and its components), Checkpointing, Kubernetes/Yarn, ZooKeeper: (yes / **no** / don't know)
  - The S3 file system connector: (yes / **no** / don't know)

## Documentation

  - Does this pull request introduce a new feature? (yes / **no**)
  - If yes, how is the feature documented? (**not applicable** / docs / JavaDocs / not documented)
