### PR TITLE
[FLINK-23991][yarn] Specifying yarn.staging-dir fail when staging scheme is…

### DIFF
--- a/flink-yarn/src/main/java/org/apache/flink/yarn/YarnClusterDescriptor.java
+++ b/flink-yarn/src/main/java/org/apache/flink/yarn/YarnClusterDescriptor.java
@@ -800,10 +800,12 @@ public class YarnClusterDescriptor implements ClusterDescriptor<ApplicationId> {
         final List<Path> providedLibDirs =
                 Utils.getQualifiedRemoteSharedPaths(configuration, yarnConfiguration);
 
+        Path stagingDirPath = getStagingDir(fs);
+        FileSystem stagingDirFs = stagingDirPath.getFileSystem(yarnConfiguration);
         final YarnApplicationFileUploader fileUploader =
                 YarnApplicationFileUploader.from(
-                        fs,
-                        getStagingDir(fs),
+                        stagingDirFs,
+                        stagingDirPath,
                         providedLibDirs,
                         appContext.getApplicationId(),
                         getFileReplication());
@@ -1250,15 +1252,19 @@ public class YarnClusterDescriptor implements ClusterDescriptor<ApplicationId> {
      * Returns the configured remote target home directory if set, otherwise returns the default
      * home directory.
      *
-     * @param fileSystem file system used
+     * @param defaultFileSystem default file system used
      * @return the remote target home directory
      */
-    private Path getStagingDir(FileSystem fileSystem) {
+    @VisibleForTesting
+    Path getStagingDir(FileSystem defaultFileSystem) throws IOException {
         final String configuredStagingDir =
                 flinkConfiguration.getString(YarnConfigOptions.STAGING_DIRECTORY);
-        return configuredStagingDir != null
-                ? fileSystem.makeQualified(new Path(configuredStagingDir))
-                : fileSystem.getHomeDirectory();
+        if (configuredStagingDir == null) {
+            return defaultFileSystem.getHomeDirectory();
+        }
+        FileSystem stagingDirFs =
+                new Path(configuredStagingDir).getFileSystem(defaultFileSystem.getConf());
+        return stagingDirFs.makeQualified(new Path(configuredStagingDir));
     }
 
     private int getFileReplication() {


### PR DESCRIPTION
… different from default fs scheme

### Why
When the yarn.staging-dir path scheme is different from the default fs scheme, the client will fail fast. Example as follows
```
core-site.xml
<property>
  <name>fs.defaultFS</name>
  <value>qbfs://test01</value>
  <description>The name of the default file system</description>
</property>
```
Besides qbfs is our internal filesystem implemented HCFS interface.

But when i specify the `yarn.staging-dir=hdfs://rbf-alwl/system/flink`, the job will fail. The exception as follows:
![aaaa](https://user-images.githubusercontent.com/8609142/132184468-22631425-4224-4b49-b5b5-53c831e9b356.png)


This PR has been applied on our production env and runs well.
