### PR TITLE
[BP-1.13][FLINK-22002][tests] Let taskmanager.slot.timeout fall back to akka.ask.timeout

### DIFF
--- a/docs/layouts/shortcodes/generated/all_taskmanager_section.html
+++ b/docs/layouts/shortcodes/generated/all_taskmanager_section.html
@@ -103,7 +103,7 @@
             <td><h5>taskmanager.slot.timeout</h5></td>
             <td style="word-wrap: break-word;">10 s</td>
             <td>Duration</td>
-            <td>Timeout used for identifying inactive slots. The TaskManager will free the slot if it does not become active within the given amount of time. Inactive slots can be caused by an out-dated slot request.</td>
+            <td>Timeout used for identifying inactive slots. The TaskManager will free the slot if it does not become active within the given amount of time. Inactive slots can be caused by an out-dated slot request. If no value is configured, then it will fall back to <code class="highlighter-rouge">akka.ask.timeout</code>.</td>
         </tr>
     </tbody>
 </table>

--- a/docs/layouts/shortcodes/generated/task_manager_configuration.html
+++ b/docs/layouts/shortcodes/generated/task_manager_configuration.html
@@ -97,7 +97,7 @@
             <td><h5>taskmanager.slot.timeout</h5></td>
             <td style="word-wrap: break-word;">10 s</td>
             <td>Duration</td>
-            <td>Timeout used for identifying inactive slots. The TaskManager will free the slot if it does not become active within the given amount of time. Inactive slots can be caused by an out-dated slot request.</td>
+            <td>Timeout used for identifying inactive slots. The TaskManager will free the slot if it does not become active within the given amount of time. Inactive slots can be caused by an out-dated slot request. If no value is configured, then it will fall back to <code class="highlighter-rouge">akka.ask.timeout</code>.</td>
         </tr>
     </tbody>
 </table>

--- a/flink-core/src/main/java/org/apache/flink/configuration/TaskManagerOptions.java
+++ b/flink-core/src/main/java/org/apache/flink/configuration/TaskManagerOptions.java
@@ -30,6 +30,7 @@ import java.util.HashMap;
 import java.util.Map;
 
 import static org.apache.flink.configuration.ConfigOptions.key;
+import static org.apache.flink.configuration.description.TextElement.code;
 import static org.apache.flink.configuration.description.TextElement.text;
 
 /** The set of configuration options relating to TaskManager and Task settings. */
@@ -239,12 +240,17 @@ public class TaskManagerOptions {
     /** Timeout for identifying inactive slots. */
     @Documentation.Section(Documentation.Sections.ALL_TASK_MANAGER)
     public static final ConfigOption<Duration> SLOT_TIMEOUT =
-            ConfigOptions.key("taskmanager.slot.timeout")
+            key("taskmanager.slot.timeout")
                     .durationType()
-                    .defaultValue(TimeUtils.parseDuration("10 s"))
+                    .defaultValue(TimeUtils.parseDuration(AkkaOptions.ASK_TIMEOUT.defaultValue()))
                     .withDescription(
-                            "Timeout used for identifying inactive slots. The TaskManager will free the slot if it does not become active "
-                                    + "within the given amount of time. Inactive slots can be caused by an out-dated slot request.");
+                            Description.builder()
+                                    .text(
+                                            "Timeout used for identifying inactive slots. The TaskManager will free the slot if it does not become active "
+                                                    + "within the given amount of time. Inactive slots can be caused by an out-dated slot request. If no "
+                                                    + "value is configured, then it will fall back to %s.",
+                                            code(AkkaOptions.ASK_TIMEOUT.key()))
+                                    .build());
 
     @Documentation.Section(Documentation.Sections.ALL_TASK_MANAGER)
     public static final ConfigOption<Boolean> DEBUG_MEMORY_LOG =

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/taskexecutor/TaskManagerConfiguration.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/taskexecutor/TaskManagerConfiguration.java
@@ -198,8 +198,13 @@ public class TaskManagerConfiguration implements TaskManagerRuntimeInfo {
 
         LOG.debug("Messages have a max timeout of " + rpcTimeout);
 
-        final Time slotTimeout =
-                Time.milliseconds(configuration.get(TaskManagerOptions.SLOT_TIMEOUT).toMillis());
+        // Fall back to AkkaOptions.ASK_TIMEOUT if TaskManagerOptions.SLOT_TIMEOUT is not
+        // configured. This has to happen manually because the two options have different types.
+        final Duration slotTimeoutDuration =
+                configuration
+                        .getOptional(TaskManagerOptions.SLOT_TIMEOUT)
+                        .orElseGet(() -> AkkaUtils.getTimeout(configuration));
+        final Time slotTimeout = Time.milliseconds(slotTimeoutDuration.toMillis());
 
         Time finiteRegistrationDuration;
         try {


### PR DESCRIPTION
Backport of #16995 to `release-1.13`.