### PR TITLE
[FLINK-23994][python] Handle properly for null values in ArrayDataSerializer and MapDataSerializer

### DIFF
--- a/flink-python/src/main/java/org/apache/flink/table/runtime/typeutils/serializers/python/ArrayDataSerializer.java
+++ b/flink-python/src/main/java/org/apache/flink/table/runtime/typeutils/serializers/python/ArrayDataSerializer.java
@@ -54,12 +54,15 @@ public class ArrayDataSerializer
 
     private final int elementSize;
 
+    private final BinaryArrayWriter.NullSetter nullSetter;
+
     public ArrayDataSerializer(LogicalType eleType, TypeSerializer elementTypeSerializer) {
         super(eleType);
         this.elementType = eleType;
         this.elementTypeSerializer = elementTypeSerializer;
         this.elementSize = BinaryArrayData.calculateFixLengthPartSize(this.elementType);
         this.elementGetter = ArrayData.createElementGetter(elementType);
+        this.nullSetter = BinaryArrayWriter.createNullSetter(eleType);
     }
 
     @Override
@@ -99,7 +102,7 @@ public class ArrayDataSerializer
                 Object element = elementTypeSerializer.deserialize(source);
                 BinaryWriter.write(writer, i, element, elementType, elementTypeSerializer);
             } else {
-                writer.setNullAt(i);
+                nullSetter.setNull(writer, i);
             }
         }
         writer.complete();

--- a/flink-python/src/main/java/org/apache/flink/table/runtime/typeutils/serializers/python/MapDataSerializer.java
+++ b/flink-python/src/main/java/org/apache/flink/table/runtime/typeutils/serializers/python/MapDataSerializer.java
@@ -56,9 +56,15 @@ public class MapDataSerializer extends org.apache.flink.table.runtime.typeutils.
 
     private final TypeSerializer valueTypeSerializer;
 
+    private final BinaryWriter.ValueSetter keySetter;
+
+    private final BinaryWriter.ValueSetter valueSetter;
+
     private final ArrayData.ElementGetter keyGetter;
 
     private final ArrayData.ElementGetter valueGetter;
+
+    private final BinaryArrayWriter.NullSetter nullValueSetter;
 
     private final int keySize;
 
@@ -78,6 +84,9 @@ public class MapDataSerializer extends org.apache.flink.table.runtime.typeutils.
         this.valueSize = BinaryArrayData.calculateFixLengthPartSize(this.valueType);
         this.keyGetter = ArrayData.createElementGetter(keyType);
         this.valueGetter = ArrayData.createElementGetter(valueType);
+        this.nullValueSetter = BinaryArrayWriter.createNullSetter(valueType);
+        this.keySetter = BinaryWriter.createValueSetter(keyType);
+        this.valueSetter = BinaryWriter.createValueSetter(valueType);
     }
 
     @Override
@@ -127,13 +136,13 @@ public class MapDataSerializer extends org.apache.flink.table.runtime.typeutils.
         BinaryArrayWriter valueWriter = new BinaryArrayWriter(valueArray, size, valueSize);
         for (int i = 0; i < size; i++) {
             Object key = keyTypeSerializer.deserialize(source);
-            BinaryWriter.write(keyWriter, i, key, keyType, keyTypeSerializer);
+            keySetter.setValue(keyWriter, i, key);
             boolean isNull = source.readBoolean();
             if (isNull) {
-                valueWriter.setNullAt(i);
+                nullValueSetter.setNull(valueWriter, i);
             } else {
                 Object value = valueTypeSerializer.deserialize(source);
-                BinaryWriter.write(valueWriter, i, value, valueType, valueTypeSerializer);
+                valueSetter.setValue(valueWriter, i, value);
             }
         }
         keyWriter.complete();

--- a/flink-python/src/test/java/org/apache/flink/table/runtime/typeutils/serializers/python/ArrayDataSerializerTest.java
+++ b/flink-python/src/test/java/org/apache/flink/table/runtime/typeutils/serializers/python/ArrayDataSerializerTest.java
@@ -20,12 +20,14 @@ package org.apache.flink.table.runtime.typeutils.serializers.python;
 
 import org.apache.flink.api.common.typeutils.SerializerTestBase;
 import org.apache.flink.api.common.typeutils.TypeSerializer;
+import org.apache.flink.api.common.typeutils.base.IntSerializer;
 import org.apache.flink.api.common.typeutils.base.LongSerializer;
 import org.apache.flink.table.data.ArrayData;
 import org.apache.flink.table.data.binary.BinaryArrayData;
 import org.apache.flink.table.data.writer.BinaryArrayWriter;
 import org.apache.flink.table.types.logical.ArrayType;
 import org.apache.flink.table.types.logical.BigIntType;
+import org.apache.flink.table.types.logical.IntType;
 
 /** Test for {@link ArrayDataSerializer}. */
 public class ArrayDataSerializerTest {
@@ -81,6 +83,37 @@ public class ArrayDataSerializerTest {
             BinaryArrayData array = new BinaryArrayData();
             BinaryArrayWriter writer = new BinaryArrayWriter(array, 1, 8);
             writer.writeArray(0, elementArray, elementTypeSerializer);
+            writer.complete();
+            return new BinaryArrayData[] {array};
+        }
+    }
+
+    /** Test for ArrayData with ArrayData data type. */
+    public static class BaseArrayWithNullTest extends SerializerTestBase<ArrayData> {
+
+        @Override
+        protected TypeSerializer<ArrayData> createSerializer() {
+            return new ArrayDataSerializer(new IntType(), IntSerializer.INSTANCE);
+        }
+
+        @Override
+        protected int getLength() {
+            return -1;
+        }
+
+        @Override
+        protected Class<ArrayData> getTypeClass() {
+            return ArrayData.class;
+        }
+
+        @Override
+        protected ArrayData[] getTestData() {
+            BinaryArrayData array = new BinaryArrayData();
+            BinaryArrayWriter writer = new BinaryArrayWriter(array, 2, 4);
+            BinaryArrayWriter.NullSetter nullSetter =
+                    BinaryArrayWriter.createNullSetter(new IntType());
+            nullSetter.setNull(writer, 0);
+            nullSetter.setNull(writer, 1);
             writer.complete();
             return new BinaryArrayData[] {array};
         }

--- a/flink-python/src/test/java/org/apache/flink/table/runtime/typeutils/serializers/python/MapDataSerializerTest.java
+++ b/flink-python/src/test/java/org/apache/flink/table/runtime/typeutils/serializers/python/MapDataSerializerTest.java
@@ -27,8 +27,7 @@ import org.apache.flink.table.data.GenericMapData;
 import org.apache.flink.table.data.MapData;
 import org.apache.flink.table.data.binary.BinaryArrayData;
 import org.apache.flink.table.data.binary.BinaryMapData;
-import org.apache.flink.table.types.logical.BigIntType;
-import org.apache.flink.table.types.logical.FloatType;
+import org.apache.flink.table.data.writer.BinaryArrayWriter;
 import org.apache.flink.table.types.logical.LogicalType;
 import org.apache.flink.testutils.DeeplyEqualsChecker;
 
@@ -69,10 +68,7 @@ public class MapDataSerializerTest extends SerializerTestBase<MapData> {
     @Override
     protected TypeSerializer<MapData> createSerializer() {
         return new MapDataSerializer(
-                new BigIntType(),
-                new FloatType(),
-                LongSerializer.INSTANCE,
-                FloatSerializer.INSTANCE);
+                BIGINT, FLOAT, LongSerializer.INSTANCE, FloatSerializer.INSTANCE);
     }
 
     @Override
@@ -89,8 +85,13 @@ public class MapDataSerializerTest extends SerializerTestBase<MapData> {
     protected MapData[] getTestData() {
         Map<Object, Object> first = new HashMap<>();
         first.put(1L, -100.1F);
-        BinaryArrayData keyBinary = BinaryArrayData.fromPrimitiveArray(new long[] {10L});
-        BinaryArrayData valueBinary = BinaryArrayData.fromPrimitiveArray(new float[] {10.2F});
+        BinaryArrayData keyBinary = BinaryArrayData.fromPrimitiveArray(new long[] {10L, 20L});
+        BinaryArrayData valueBinary = new BinaryArrayData();
+        BinaryArrayWriter writer = new BinaryArrayWriter(valueBinary, 2, 4);
+        BinaryArrayWriter.NullSetter nullSetter = BinaryArrayWriter.createNullSetter(FLOAT);
+        writer.writeFloat(0, 10.2F);
+        nullSetter.setNull(writer, 1);
+        writer.complete();
         return new MapData[] {
             new GenericMapData(first), BinaryMapData.valueOf(keyBinary, valueBinary)
         };


### PR DESCRIPTION

## What is the purpose of the change

*This pull request fixes ArrayDataSerializer and MapDataSerializer and null data handling*


## Verifying this change

  - *Added tests in ArrayDataSerializerTest and MapDataSerializerTest*

## Does this pull request potentially affect one of the following parts:

  - Dependencies (does it add or upgrade a dependency): (no)
  - The public API, i.e., is any changed class annotated with `@Public(Evolving)`: (no)
  - The serializers: (no)
  - The runtime per-record code paths (performance sensitive): (no)
  - Anything that affects deployment or recovery: JobManager (and its components), Checkpointing, Kubernetes/Yarn, ZooKeeper: (no)
  - The S3 file system connector: (no)

## Documentation

  - Does this pull request introduce a new feature? (no)
  - If yes, how is the feature documented? (not applicable)
