### PR TITLE
[FLINK-23998][legal] Include flink-dist in NoticeFileChecker

### DIFF
--- a/flink-dist/src/main/resources/META-INF/NOTICE
+++ b/flink-dist/src/main/resources/META-INF/NOTICE
@@ -32,7 +32,6 @@ The following dependencies all share the same BSD license which you find under l
 - org.scala-lang:scala-compiler:2.11.12
 - org.scala-lang:scala-library:2.11.12
 - org.scala-lang:scala-reflect:2.11.12
-- org.scala-lang.modules:scala-java8-compat_2.11:0.7.0
 - org.scala-lang.modules:scala-parser-combinators_2.11:1.1.1
 - org.scala-lang.modules:scala-xml_2.11:1.0.5
 
@@ -40,6 +39,7 @@ This project bundles the following dependencies under the MIT/X11 license.
 See bundled license files for details.
 
 - org.slf4j:slf4j-api:1.7.15
+- com.github.scopt:scopt_2.11:3.5.0
 
 This project bundles the following dependencies under the CDDL 1.1 license.
 See bundled license files for details.

--- a/tools/ci/java-ci-tools/src/main/java/org/apache/flink/tools/ci/licensecheck/NoticeFileChecker.java
+++ b/tools/ci/java-ci-tools/src/main/java/org/apache/flink/tools/ci/licensecheck/NoticeFileChecker.java
@@ -51,7 +51,8 @@ public class NoticeFileChecker {
 
     // pattern for maven shade plugin
     private static final Pattern SHADE_NEXT_MODULE_PATTERN =
-            Pattern.compile(".*:shade \\((shade-flink|default)\\) @ ([^ _]+)(_[0-9.]+)? --.*");
+            Pattern.compile(
+                    ".*:shade \\((shade-flink|shade-dist|default)\\) @ ([^ _]+)(_[0-9.]+)? --.*");
     private static final Pattern SHADE_INCLUDE_MODULE_PATTERN =
             Pattern.compile(".*Including ([^:]+):([^:]+):jar:([^ ]+) in the shaded jar");
 


### PR DESCRIPTION
Fixes an issue in the NoticeFileChecker where flink-dist was not properly checked; this happened because the checker looks for specific execution names, and flink-dist uses a special one which was missed.

The checker noticed 2 issues in the NOTICE:
a) `scala-java8-compat_2.11` is listed but not actually bundled. This dependency is only required by flink-rpc-akka (which handles it appropriately)
b) `scopt` is not listed but actually bundled. This entry was mistakenly removed when we isolated Akka; it is still required by the scala-shell.