### PR TITLE
[FLINK-24010][connector/common] HybridSourceReader delegates checkpoint notifications

### DIFF
--- a/flink-connectors/flink-connector-base/src/main/java/org/apache/flink/connector/base/source/hybrid/HybridSourceReader.java
+++ b/flink-connectors/flink-connector-base/src/main/java/org/apache/flink/connector/base/source/hybrid/HybridSourceReader.java
@@ -121,6 +121,20 @@ public class HybridSourceReader<T> implements SourceReader<T, HybridSourceSplit>
     }
 
     @Override
+    public void notifyCheckpointComplete(long checkpointId) throws Exception {
+        if (currentReader != null) {
+            currentReader.notifyCheckpointComplete(checkpointId);
+        }
+    }
+
+    @Override
+    public void notifyCheckpointAborted(long checkpointId) throws Exception {
+        if (currentReader != null) {
+            currentReader.notifyCheckpointAborted(checkpointId);
+        }
+    }
+
+    @Override
     public CompletableFuture<Void> isAvailable() {
         return availabilityFuture;
     }

--- a/flink-connectors/flink-connector-base/src/main/java/org/apache/flink/connector/base/source/hybrid/HybridSourceSplitEnumerator.java
+++ b/flink-connectors/flink-connector-base/src/main/java/org/apache/flink/connector/base/source/hybrid/HybridSourceSplitEnumerator.java
@@ -176,6 +176,16 @@ public class HybridSourceSplitEnumerator
     }
 
     @Override
+    public void notifyCheckpointComplete(long checkpointId) throws Exception {
+        currentEnumerator.notifyCheckpointComplete(checkpointId);
+    }
+
+    @Override
+    public void notifyCheckpointAborted(long checkpointId) throws Exception {
+        currentEnumerator.notifyCheckpointAborted(checkpointId);
+    }
+
+    @Override
     public void handleSourceEvent(int subtaskId, SourceEvent sourceEvent) {
         LOG.debug(
                 "handleSourceEvent {} subtask={} pendingSplits={}",


### PR DESCRIPTION
## What is the purpose of the change

This change will ensure that the sources that are contained in `HybridSource` can receive `notifyCheckpointComplete` and `notifyCheckpointAborted`. Found this issue with `KafkaSouce` which would not commit offsets.

## Verifying this change

Added unit tests and verified with internal deployment.