### PR TITLE
[FLINK-17495][metrics] Add additional variables config for metric reporters

### DIFF
--- a/docs/content.zh/docs/deployment/metric_reporters.md
+++ b/docs/content.zh/docs/deployment/metric_reporters.md
@@ -42,6 +42,7 @@ reporters will be instantiated on each job and task manager when they are starte
 - `metrics.reporter.<name>.scope.delimiter`: The delimiter to use for the identifier (default value use `metrics.scope.delimiter`) for the reporter named `<name>`.
 - `metrics.reporter.<name>.scope.variables.excludes`: (optional) A semi-colon (;) separate list of variables that should be ignored by tag-based reporters (e.g., Prometheus, InfluxDB). 
 - `metrics.reporters`: (optional) A comma-separated include list of reporter names. By default all configured reporters will be used.
+- `metrics.reporter.<name>.scope.variables.additional`: (optional) A comma separated map of variables and their values, which are separated by a colon (:). These mappings are added to the variable map by tag-based reporters (e.g. Prometheux, InfluxDB).
 
 All reporters must at least have either the `class` or `factory.class` property. Which property may/should be used depends on the reporter implementation. See the individual reporter configuration sections for more information.
 Some reporters (referred to as `Scheduled`) allow specifying a reporting `interval`.
@@ -55,6 +56,7 @@ metrics.reporters: my_jmx_reporter,my_other_reporter
 metrics.reporter.my_jmx_reporter.factory.class: org.apache.flink.metrics.jmx.JMXReporterFactory
 metrics.reporter.my_jmx_reporter.port: 9020-9040
 metrics.reporter.my_jmx_reporter.scope.variables.excludes:job_id;task_attempt_num
+metrics.reporter.my_jmx_reporter.scope.variables.additional: cluster_name:my_test_cluster,tag_name:tag_value
 
 metrics.reporter.my_other_reporter.class: org.apache.flink.metrics.graphite.GraphiteReporter
 metrics.reporter.my_other_reporter.host: 192.168.1.1

--- a/docs/content/docs/deployment/metric_reporters.md
+++ b/docs/content/docs/deployment/metric_reporters.md
@@ -41,6 +41,7 @@ reporters will be instantiated on each job and task manager when they are starte
 - `metrics.reporter.<name>.interval`: The reporter interval to use for the reporter named `<name>`.
 - `metrics.reporter.<name>.scope.delimiter`: The delimiter to use for the identifier (default value use `metrics.scope.delimiter`) for the reporter named `<name>`.
 - `metrics.reporter.<name>.scope.variables.excludes`: (optional) A semi-colon (;) separate list of variables that should be ignored by tag-based reporters (e.g., Prometheus, InfluxDB). 
+- `metrics.reporter.<name>.scope.variables.additional`: (optional) A comma separated map of variables and their values, which are separated by a colon (:). These mappings are added to the variable map by tag-based reporters (e.g. Prometheux, InfluxDB). 
 - `metrics.reporters`: (optional) A comma-separated include list of reporter names. By default all configured reporters will be used.
 
 All reporters must at least have either the `class` or `factory.class` property. Which property may/should be used depends on the reporter implementation. See the individual reporter configuration sections for more information.
@@ -55,6 +56,7 @@ metrics.reporters: my_jmx_reporter,my_other_reporter
 metrics.reporter.my_jmx_reporter.factory.class: org.apache.flink.metrics.jmx.JMXReporterFactory
 metrics.reporter.my_jmx_reporter.port: 9020-9040
 metrics.reporter.my_jmx_reporter.scope.variables.excludes:job_id;task_attempt_num
+metrics.reporter.my_jmx_reporter.scope.variables.additional: cluster_name:my_test_cluster,tag_name:tag_value
 
 metrics.reporter.my_other_reporter.class: org.apache.flink.metrics.graphite.GraphiteReporter
 metrics.reporter.my_other_reporter.host: 192.168.1.1

--- a/flink-core/src/main/java/org/apache/flink/configuration/ConfigConstants.java
+++ b/flink-core/src/main/java/org/apache/flink/configuration/ConfigConstants.java
@@ -1134,6 +1134,9 @@ public final class ConfigConstants {
     /** The set of variables that should be excluded. */
     public static final String METRICS_REPORTER_EXCLUDED_VARIABLES = "scope.variables.excludes";
 
+    /** The map of additional variables that should be included. */
+    public static final String METRICS_REPORTER_ADDITIONAL_VARIABLES = "scope.variables.additional";
+
     /** @deprecated Use {@link MetricOptions#SCOPE_DELIMITER} instead. */
     @Deprecated public static final String METRICS_SCOPE_DELIMITER = "metrics.scope.delimiter";
 

--- a/flink-metrics/flink-metrics-prometheus/src/test/java/org/apache/flink/metrics/prometheus/PrometheusReporterTest.java
+++ b/flink-metrics/flink-metrics-prometheus/src/test/java/org/apache/flink/metrics/prometheus/PrometheusReporterTest.java
@@ -414,6 +414,6 @@ public class PrometheusReporterTest extends TestLogger {
     }
 
     private static ReporterScopedSettings createReporterScopedSettings() {
-        return new ReporterScopedSettings(0, ',', Collections.emptySet());
+        return new ReporterScopedSettings(0, ',', Collections.emptySet(), Collections.emptyMap());
     }
 }

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/metrics/MetricRegistryImpl.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/metrics/MetricRegistryImpl.java
@@ -171,7 +171,7 @@ public class MetricRegistryImpl implements MetricRegistry {
                                             reporters.size(),
                                             delimiterForReporter.charAt(0),
                                             reporterSetup.getExcludedVariables(),
-                                            reporterSetup.tryGetAdditionalVariables())));
+                                            reporterSetup.getAdditionalVariables())));
                 } catch (Throwable t) {
                     LOG.error(
                             "Could not instantiate metrics reporter {}. Metrics might not be exposed/reported.",

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/metrics/MetricRegistryImpl.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/metrics/MetricRegistryImpl.java
@@ -170,7 +170,8 @@ public class MetricRegistryImpl implements MetricRegistry {
                                     new ReporterScopedSettings(
                                             reporters.size(),
                                             delimiterForReporter.charAt(0),
-                                            reporterSetup.getExcludedVariables())));
+                                            reporterSetup.getExcludedVariables(),
+                                            reporterSetup.tryGetAdditionalVariables())));
                 } catch (Throwable t) {
                     LOG.error(
                             "Could not instantiate metrics reporter {}. Metrics might not be exposed/reported.",

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/metrics/ReporterSetup.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/metrics/ReporterSetup.java
@@ -48,6 +48,7 @@ import java.util.HashSet;
 import java.util.Iterator;
 import java.util.List;
 import java.util.Map;
+import java.util.Map.Entry;
 import java.util.Optional;
 import java.util.ServiceConfigurationError;
 import java.util.ServiceLoader;
@@ -305,7 +306,13 @@ public final class ReporterSetup {
                 Optional<MetricReporter> metricReporterOptional =
                         loadReporter(reporterName, reporterConfig, reporterFactories);
 
-                Map<String, String> additionalVariables = reporterConfig.get(ADDITIONAL_VARIABLES);
+                // massage user variables keys into scope format for parity to variable exclusion
+                Map<String, String> additionalVariables =
+                        reporterConfig.get(ADDITIONAL_VARIABLES).entrySet().stream()
+                                .collect(
+                                        Collectors.toMap(
+                                                e -> ScopeFormat.asVariable(e.getKey()),
+                                                Entry::getValue));
 
                 metricReporterOptional.ifPresent(
                         reporter -> {

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/metrics/groups/FrontMetricGroup.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/metrics/groups/FrontMetricGroup.java
@@ -23,6 +23,8 @@ import org.apache.flink.metrics.CharacterFilter;
 import org.apache.flink.metrics.LogicalScopeProvider;
 import org.apache.flink.metrics.MetricGroup;
 
+import org.apache.commons.collections.map.CompositeMap;
+
 import java.util.Map;
 
 /**
@@ -76,11 +78,11 @@ public class FrontMetricGroup<P extends AbstractMetricGroup<?>> extends ProxyMet
                 parentMetricGroup.getAllVariables(
                         this.settings.getReporterIndex(), this.settings.getExcludedVariables());
 
-        for (Map.Entry<String, String> entry : this.settings.getAdditionalVariables().entrySet()) {
-            allVariables.putIfAbsent(entry.getKey(), entry.getValue());
+        if (this.settings.getAdditionalVariables().isEmpty()) {
+            return allVariables;
         }
 
-        return allVariables;
+        return new CompositeMap(allVariables, this.settings.getAdditionalVariables());
     }
 
     /** @deprecated work against the LogicalScopeProvider interface instead. */

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/metrics/groups/FrontMetricGroup.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/metrics/groups/FrontMetricGroup.java
@@ -72,8 +72,15 @@ public class FrontMetricGroup<P extends AbstractMetricGroup<?>> extends ProxyMet
 
     @Override
     public Map<String, String> getAllVariables() {
-        return parentMetricGroup.getAllVariables(
-                this.settings.getReporterIndex(), this.settings.getExcludedVariables());
+        Map<String, String> allVariables =
+                parentMetricGroup.getAllVariables(
+                        this.settings.getReporterIndex(), this.settings.getExcludedVariables());
+
+        for (Map.Entry<String, String> entry : this.settings.getAdditionalVariables().entrySet()) {
+            allVariables.putIfAbsent(entry.getKey(), entry.getValue());
+        }
+
+        return allVariables;
     }
 
     /** @deprecated work against the LogicalScopeProvider interface instead. */

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/metrics/groups/FrontMetricGroup.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/metrics/groups/FrontMetricGroup.java
@@ -25,6 +25,7 @@ import org.apache.flink.metrics.MetricGroup;
 
 import org.apache.commons.collections.map.CompositeMap;
 
+import java.util.Collections;
 import java.util.Map;
 
 /**
@@ -78,11 +79,11 @@ public class FrontMetricGroup<P extends AbstractMetricGroup<?>> extends ProxyMet
                 parentMetricGroup.getAllVariables(
                         this.settings.getReporterIndex(), this.settings.getExcludedVariables());
 
-        if (this.settings.getAdditionalVariables().isEmpty()) {
-            return allVariables;
+        if (!this.settings.getAdditionalVariables().isEmpty()) {
+            allVariables = new CompositeMap(allVariables, this.settings.getAdditionalVariables());
         }
 
-        return new CompositeMap(allVariables, this.settings.getAdditionalVariables());
+        return Collections.unmodifiableMap(allVariables);
     }
 
     /** @deprecated work against the LogicalScopeProvider interface instead. */

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/metrics/groups/ReporterScopedSettings.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/metrics/groups/ReporterScopedSettings.java
@@ -19,6 +19,7 @@ package org.apache.flink.runtime.metrics.groups;
 
 import org.apache.flink.util.Preconditions;
 
+import java.util.Map;
 import java.util.Set;
 
 /** Encapsulates all settings that are defined per reporter. */
@@ -28,14 +29,20 @@ public class ReporterScopedSettings {
 
     private final char delimiter;
 
-    private Set<String> excludedVariables;
+    private final Set<String> excludedVariables;
+
+    private final Map<String, String> additionalVariables;
 
     public ReporterScopedSettings(
-            int reporterIndex, char delimiter, Set<String> excludedVariables) {
+            int reporterIndex,
+            char delimiter,
+            Set<String> excludedVariables,
+            Map<String, String> additionalVariables) {
         this.excludedVariables = excludedVariables;
         Preconditions.checkArgument(reporterIndex >= 0);
         this.reporterIndex = reporterIndex;
         this.delimiter = delimiter;
+        this.additionalVariables = additionalVariables;
     }
 
     public int getReporterIndex() {
@@ -48,5 +55,9 @@ public class ReporterScopedSettings {
 
     public Set<String> getExcludedVariables() {
         return excludedVariables;
+    }
+
+    public Map<String, String> getAdditionalVariables() {
+        return additionalVariables;
     }
 }

--- a/flink-runtime/src/test/java/org/apache/flink/runtime/metrics/ReporterSetupTest.java
+++ b/flink-runtime/src/test/java/org/apache/flink/runtime/metrics/ReporterSetupTest.java
@@ -458,11 +458,11 @@ public class ReporterSetupTest extends TestLogger {
         final ReporterSetup reporterSetup = reporterSetups.get(0);
 
         assertThat(
-                reporterSetup.tryGetAdditionalVariables(),
+                reporterSetup.getAdditionalVariables(),
                 hasEntry(ScopeFormat.asVariable(tag1), tagValue1));
 
         assertThat(
-                reporterSetup.tryGetAdditionalVariables(),
+                reporterSetup.getAdditionalVariables(),
                 hasEntry(ScopeFormat.asVariable(tag2), tagValue2));
     }
 

--- a/flink-runtime/src/test/java/org/apache/flink/runtime/metrics/ReporterSetupTest.java
+++ b/flink-runtime/src/test/java/org/apache/flink/runtime/metrics/ReporterSetupTest.java
@@ -40,6 +40,7 @@ import java.util.Optional;
 import java.util.Properties;
 
 import static org.hamcrest.MatcherAssert.assertThat;
+import static org.hamcrest.collection.IsMapContaining.hasEntry;
 import static org.hamcrest.core.IsCollectionContaining.hasItems;
 import static org.hamcrest.core.IsInstanceOf.instanceOf;
 import static org.junit.Assert.assertEquals;
@@ -430,6 +431,39 @@ public class ReporterSetupTest extends TestLogger {
                 (InstantiationTypeTrackingTestReporter) reporterSetup.getReporter();
 
         assertTrue(metricReporter.createdByFactory);
+    }
+
+    @Test
+    public void testAdditionalVariablesParsing() {
+        final String tag1 = "foo";
+        final String tagValue1 = "bar";
+        final String tag2 = "fizz";
+        final String tagValue2 = "buzz";
+        final Configuration config = new Configuration();
+        config.setString(
+                ConfigConstants.METRICS_REPORTER_PREFIX
+                        + "test."
+                        + ConfigConstants.METRICS_REPORTER_FACTORY_CLASS_SUFFIX,
+                TestReporterFactory.class.getName());
+        config.setString(
+                ConfigConstants.METRICS_REPORTER_PREFIX
+                        + "test."
+                        + ConfigConstants.METRICS_REPORTER_ADDITIONAL_VARIABLES,
+                String.join(",", tag1 + ":" + tagValue1, tag2 + ":" + tagValue2));
+
+        final List<ReporterSetup> reporterSetups = ReporterSetup.fromConfiguration(config, null);
+
+        assertEquals(1, reporterSetups.size());
+
+        final ReporterSetup reporterSetup = reporterSetups.get(0);
+
+        assertThat(
+                reporterSetup.tryGetAdditionalVariables(),
+                hasEntry(ScopeFormat.asVariable(tag1), tagValue1));
+
+        assertThat(
+                reporterSetup.tryGetAdditionalVariables(),
+                hasEntry(ScopeFormat.asVariable(tag2), tagValue2));
     }
 
     /** Factory that exposed the last provided metric config. */

--- a/flink-runtime/src/test/java/org/apache/flink/runtime/metrics/groups/FrontMetricGroupTest.java
+++ b/flink-runtime/src/test/java/org/apache/flink/runtime/metrics/groups/FrontMetricGroupTest.java
@@ -105,9 +105,13 @@ public class FrontMetricGroupTest {
         final FrontMetricGroup<?> frontMetricGroup =
                 new FrontMetricGroup<>(
                         new ReporterScopedSettings(
-                                0, '.', Collections.emptySet(), ImmutableMap.of("foo", "bar")),
+                                0,
+                                '.',
+                                Collections.emptySet(),
+                                ImmutableMap.of(ScopeFormat.asVariable("foo"), "bar")),
                         new ProcessMetricGroup(TestingMetricRegistry.builder().build(), "host"));
 
-        assertThat(frontMetricGroup.getAllVariables(), hasEntry("foo", "bar"));
+        assertThat(
+                frontMetricGroup.getAllVariables(), hasEntry(ScopeFormat.asVariable("foo"), "bar"));
     }
 }

--- a/flink-runtime/src/test/java/org/apache/flink/runtime/metrics/groups/FrontMetricGroupTest.java
+++ b/flink-runtime/src/test/java/org/apache/flink/runtime/metrics/groups/FrontMetricGroupTest.java
@@ -23,6 +23,8 @@ import org.apache.flink.runtime.metrics.scope.ScopeFormat;
 import org.apache.flink.runtime.metrics.scope.ScopeFormats;
 import org.apache.flink.runtime.metrics.util.TestingMetricRegistry;
 
+import org.apache.flink.shaded.guava30.com.google.common.collect.ImmutableMap;
+
 import org.junit.Test;
 
 import java.util.Collections;
@@ -45,7 +47,8 @@ public class FrontMetricGroupTest {
 
         final FrontMetricGroup<?> frontMetricGroup =
                 new FrontMetricGroup<>(
-                        new ReporterScopedSettings(0, delimiter, Collections.emptySet()),
+                        new ReporterScopedSettings(
+                                0, delimiter, Collections.emptySet(), Collections.emptyMap()),
                         new ProcessMetricGroup(
                                 TestingMetricRegistry.builder()
                                         .setScopeFormats(ScopeFormats.fromConfig(config))
@@ -75,7 +78,8 @@ public class FrontMetricGroupTest {
 
         final FrontMetricGroup<?> frontMetricGroup =
                 new FrontMetricGroup<>(
-                        new ReporterScopedSettings(0, delimiter, Collections.emptySet()),
+                        new ReporterScopedSettings(
+                                0, delimiter, Collections.emptySet(), Collections.emptyMap()),
                         new ProcessMetricGroup(
                                 TestingMetricRegistry.builder()
                                         .setScopeFormats(ScopeFormats.fromConfig(config))
@@ -94,5 +98,16 @@ public class FrontMetricGroupTest {
         // delimiters in variables should not be filtered, because they are usually not used in a
         // context where the delimiter matters
         assertThat(frontMetricGroup.getAllVariables(), hasEntry(ScopeFormat.SCOPE_HOST, hostName));
+    }
+
+    @Test
+    public void testGetAllVariablesWithAdditionalVariables() {
+        final FrontMetricGroup<?> frontMetricGroup =
+                new FrontMetricGroup<>(
+                        new ReporterScopedSettings(
+                                0, '.', Collections.emptySet(), ImmutableMap.of("foo", "bar")),
+                        new ProcessMetricGroup(TestingMetricRegistry.builder().build(), "host"));
+
+        assertThat(frontMetricGroup.getAllVariables(), hasEntry("foo", "bar"));
     }
 }


### PR DESCRIPTION
## What is the purpose of the change

To add a configuration for additional variables reported by the metric reporters, in a generic fashion.

## Brief change log

* ReporterSetup and FrontMetricGroup have enhanced logic to parse and apply the configuration, respectively.

## Verifying this change

Functionality verification is covered by unit tests.

## Does this pull request potentially affect one of the following parts:

  - Dependencies (does it add or upgrade a dependency): (yes / **no**)
  - The public API, i.e., is any changed class annotated with `@Public(Evolving)`: (yes / **no**)
  - The serializers: (yes / **no** / don't know)
  - The runtime per-record code paths (performance sensitive): (yes / **no** / don't know)
  - Anything that affects deployment or recovery: JobManager (and its components), Checkpointing, Kubernetes/Yarn, ZooKeeper: (yes / **no** / don't know)
  - The S3 file system connector: (yes / **no** / don't know)

## Documentation

  - Does this pull request introduce a new feature? (yes / **no**)
  - If yes, how is the feature documented? (**not applicable** / docs / JavaDocs / not documented)
