### PR TITLE
[FLINK-23663][table-planner] Reduce state size of ChangelogNormalize

### DIFF
--- a/flink-table/flink-table-api-java/src/main/java/org/apache/flink/table/api/TableDescriptor.java
+++ b/flink-table/flink-table-api-java/src/main/java/org/apache/flink/table/api/TableDescriptor.java
@@ -51,14 +51,14 @@ import java.util.stream.Collectors;
  * TableEnvironment#createTemporaryTable(String, TableDescriptor)}.
  */
 @PublicEvolving
-public final class TableDescriptor {
+public class TableDescriptor {
 
     private final @Nullable Schema schema;
     private final Map<String, String> options;
     private final List<String> partitionKeys;
     private final @Nullable String comment;
 
-    private TableDescriptor(
+    protected TableDescriptor(
             @Nullable Schema schema,
             Map<String, String> options,
             List<String> partitionKeys,
@@ -100,6 +100,21 @@ public final class TableDescriptor {
     }
 
     // ---------------------------------------------------------------------------------------------
+
+    /** Converts this descriptor into a {@link CatalogTable}. */
+    public CatalogTable toCatalogTable() {
+        final Schema schema =
+                getSchema()
+                        .orElseThrow(
+                                () ->
+                                        new ValidationException(
+                                                "Missing schema in TableDescriptor. "
+                                                        + "A schema is typically required. "
+                                                        + "It can only be omitted at certain "
+                                                        + "documented locations."));
+
+        return CatalogTable.of(schema, getComment().orElse(null), getPartitionKeys(), getOptions());
+    }
 
     /** Converts this immutable instance into a mutable {@link Builder}. */
     public Builder toBuilder() {

--- a/flink-table/flink-table-api-java/src/main/java/org/apache/flink/table/api/internal/TableEnvironmentImpl.java
+++ b/flink-table/flink-table-api-java/src/main/java/org/apache/flink/table/api/internal/TableEnvironmentImpl.java
@@ -29,7 +29,6 @@ import org.apache.flink.table.api.DataTypes;
 import org.apache.flink.table.api.EnvironmentSettings;
 import org.apache.flink.table.api.ExplainDetail;
 import org.apache.flink.table.api.ResultKind;
-import org.apache.flink.table.api.Schema;
 import org.apache.flink.table.api.SqlParserException;
 import org.apache.flink.table.api.StatementSet;
 import org.apache.flink.table.api.Table;
@@ -470,8 +469,7 @@ public class TableEnvironmentImpl implements TableEnvironmentInternal {
     private void createTemporaryTableInternal(
             UnresolvedIdentifier path, TableDescriptor descriptor) {
         final ObjectIdentifier tableIdentifier = catalogManager.qualifyIdentifier(path);
-        final CatalogTable catalogTable = convertTableDescriptor(descriptor);
-        catalogManager.createTemporaryTable(catalogTable, tableIdentifier, false);
+        catalogManager.createTemporaryTable(descriptor.toCatalogTable(), tableIdentifier, false);
     }
 
     @Override
@@ -481,27 +479,7 @@ public class TableEnvironmentImpl implements TableEnvironmentInternal {
 
         final ObjectIdentifier tableIdentifier =
                 catalogManager.qualifyIdentifier(getParser().parseIdentifier(path));
-        final CatalogTable catalogTable = convertTableDescriptor(descriptor);
-        catalogManager.createTable(catalogTable, tableIdentifier, false);
-    }
-
-    private CatalogTable convertTableDescriptor(TableDescriptor descriptor) {
-        final Schema schema =
-                descriptor
-                        .getSchema()
-                        .orElseThrow(
-                                () ->
-                                        new ValidationException(
-                                                "Missing schema in TableDescriptor. "
-                                                        + "A schema is typically required. "
-                                                        + "It can only be omitted at certain "
-                                                        + "documented locations."));
-
-        return CatalogTable.of(
-                schema,
-                descriptor.getComment().orElse(null),
-                descriptor.getPartitionKeys(),
-                descriptor.getOptions());
+        catalogManager.createTable(descriptor.toCatalogTable(), tableIdentifier, false);
     }
 
     @Override

--- a/flink-table/flink-table-common/src/main/java/org/apache/flink/table/catalog/DefaultCatalogTable.java
+++ b/flink-table/flink-table-common/src/main/java/org/apache/flink/table/catalog/DefaultCatalogTable.java
@@ -33,14 +33,14 @@ import static org.apache.flink.util.Preconditions.checkNotNull;
 
 /** Default implementation of a {@link CatalogTable}. */
 @Internal
-class DefaultCatalogTable implements CatalogTable {
+public class DefaultCatalogTable implements CatalogTable {
 
     private final Schema schema;
     private final @Nullable String comment;
     private final List<String> partitionKeys;
     private final Map<String, String> options;
 
-    DefaultCatalogTable(
+    protected DefaultCatalogTable(
             Schema schema,
             @Nullable String comment,
             List<String> partitionKeys,

--- a/flink-table/flink-table-planner/src/main/java/org/apache/flink/table/planner/plan/rules/physical/stream/PushFilterPastChangelogNormalizeRule.java
+++ b/flink-table/flink-table-planner/src/main/java/org/apache/flink/table/planner/plan/rules/physical/stream/PushFilterPastChangelogNormalizeRule.java
@@ -1,0 +1,240 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.flink.table.planner.plan.rules.physical.stream;
+
+import org.apache.flink.annotation.Internal;
+import org.apache.flink.table.planner.plan.nodes.physical.stream.StreamPhysicalCalc;
+import org.apache.flink.table.planner.plan.nodes.physical.stream.StreamPhysicalChangelogNormalize;
+
+import org.apache.calcite.plan.RelOptRule;
+import org.apache.calcite.plan.RelOptRuleCall;
+import org.apache.calcite.plan.RelOptUtil;
+import org.apache.calcite.plan.RelRule;
+import org.apache.calcite.rel.RelNode;
+import org.apache.calcite.rex.RexLocalRef;
+import org.apache.calcite.rex.RexNode;
+import org.apache.calcite.rex.RexProgram;
+import org.apache.calcite.rex.RexProgramBuilder;
+import org.apache.calcite.rex.RexUtil;
+import org.apache.calcite.tools.RelBuilder;
+import org.apache.calcite.util.Pair;
+
+import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.Collections;
+import java.util.List;
+import java.util.Set;
+import java.util.stream.Collectors;
+import java.util.stream.IntStream;
+
+import static org.apache.flink.table.planner.plan.utils.RexNodeExtractor.extractRefInputFields;
+
+/**
+ * Pushes primary key filters through a {@link StreamPhysicalChangelogNormalize ChangelogNormalize}
+ * operator to reduce its state size.
+ *
+ * <p>This rule looks for Calc → ChangelogNormalize where the {@link StreamPhysicalCalc Calc}
+ * contains a filter condition. The condition is transformed into CNF and then each conjunction is
+ * tested for whether it affects only primary key columns. If such conditions exist, they are moved
+ * into a new, separate Calc and pushed through the ChangelogNormalize operator. ChangelogNormalize
+ * keeps state for every unique key it encounters, thus pushing filters on the primary key in front
+ * of it helps reduce the size of its state.
+ *
+ * <p>Note that pushing primary key filters is safe to do, but pushing any other filters would lead
+ * to incorrect results.
+ */
+@Internal
+public class PushFilterPastChangelogNormalizeRule
+        extends RelRule<PushFilterPastChangelogNormalizeRule.Config> {
+
+    public static final RelOptRule INSTANCE =
+            Config.EMPTY.as(Config.class).onFilterWithChangelogNormalize().toRule();
+
+    public PushFilterPastChangelogNormalizeRule(Config config) {
+        super(config);
+    }
+
+    @Override
+    public void onMatch(RelOptRuleCall call) {
+        final StreamPhysicalCalc calc = call.rel(0);
+        final StreamPhysicalChangelogNormalize changelogNormalize = call.rel(1);
+
+        final RexProgram program = calc.getProgram();
+        final RexNode condition =
+                RexUtil.toCnf(
+                        call.builder().getRexBuilder(),
+                        program.expandLocalRef(program.getCondition()));
+
+        final Set<Integer> primaryKeyIndices =
+                IntStream.of(changelogNormalize.uniqueKeys()).boxed().collect(Collectors.toSet());
+
+        // Determine which filters can be pushed (= involve only primary key columns)
+        final List<RexNode> primaryKeyPredicates = new ArrayList<>();
+        final List<RexNode> otherPredicates = new ArrayList<>();
+        partitionPrimaryKeyPredicates(
+                RelOptUtil.conjunctions(condition),
+                primaryKeyIndices,
+                primaryKeyPredicates,
+                otherPredicates);
+
+        // Construct a new ChangelogNormalize which has primary key filters pushed into it
+        final StreamPhysicalChangelogNormalize newChangelogNormalize =
+                pushFiltersThroughChangeNormalize(call, primaryKeyPredicates);
+
+        // Retain only filters which haven't been pushed
+        transformWithRemainingPredicates(call, newChangelogNormalize, otherPredicates);
+    }
+
+    /**
+     * Separates the given {@param predicates} into filters which affect only the primary key and
+     * anything else.
+     */
+    private void partitionPrimaryKeyPredicates(
+            List<RexNode> predicates,
+            Set<Integer> primaryKeyIndices,
+            List<RexNode> primaryKeyPredicates,
+            List<RexNode> remainingPredicates) {
+        for (RexNode predicate : predicates) {
+            int[] inputRefs = extractRefInputFields(Collections.singletonList(predicate));
+            if (Arrays.stream(inputRefs).allMatch(primaryKeyIndices::contains)) {
+                primaryKeyPredicates.add(predicate);
+            } else {
+                remainingPredicates.add(predicate);
+            }
+        }
+    }
+
+    /** Pushes {@param primaryKeyPredicates} into the {@link StreamPhysicalChangelogNormalize}. */
+    private StreamPhysicalChangelogNormalize pushFiltersThroughChangeNormalize(
+            RelOptRuleCall call, List<RexNode> primaryKeyPredicates) {
+        final StreamPhysicalChangelogNormalize changelogNormalize = call.rel(1);
+
+        if (primaryKeyPredicates.isEmpty()) {
+            // There are no filters which can be pushed, so just return the existing node.
+            return changelogNormalize;
+        }
+
+        final StreamPhysicalCalc pushedFiltersCalc =
+                projectIdentityWithConditions(
+                        call.builder(), changelogNormalize.getInput(), primaryKeyPredicates);
+
+        return (StreamPhysicalChangelogNormalize)
+                changelogNormalize.copy(
+                        changelogNormalize.getTraitSet(),
+                        Collections.singletonList(pushedFiltersCalc));
+    }
+
+    /**
+     * Returns a {@link StreamPhysicalCalc} with the given {@param conditions} and an identity
+     * projection.
+     */
+    private StreamPhysicalCalc projectIdentityWithConditions(
+            RelBuilder relBuilder, RelNode newInput, List<RexNode> conditions) {
+
+        final RexProgramBuilder programBuilder =
+                new RexProgramBuilder(newInput.getRowType(), relBuilder.getRexBuilder());
+        programBuilder.addIdentity();
+
+        final RexNode condition = relBuilder.and(conditions);
+        if (!condition.isAlwaysTrue()) {
+            programBuilder.addCondition(condition);
+        }
+
+        final RexProgram newProgram = programBuilder.getProgram();
+        return new StreamPhysicalCalc(
+                newInput.getCluster(),
+                newInput.getTraitSet(),
+                newInput,
+                newProgram,
+                newProgram.getOutputRowType());
+    }
+
+    /**
+     * Returns a {@link StreamPhysicalCalc} which is a copy of {@param calc}, but with the
+     * projections applied from {@param projectFromCalc}.
+     */
+    private StreamPhysicalCalc projectWith(
+            RelBuilder relBuilder, StreamPhysicalCalc projectFromCalc, StreamPhysicalCalc calc) {
+        final RexProgramBuilder programBuilder =
+                new RexProgramBuilder(calc.getRowType(), relBuilder.getRexBuilder());
+        if (calc.getProgram().getCondition() != null) {
+            programBuilder.addCondition(
+                    calc.getProgram().expandLocalRef(calc.getProgram().getCondition()));
+        }
+
+        for (Pair<RexLocalRef, String> projectRef :
+                projectFromCalc.getProgram().getNamedProjects()) {
+            final RexNode project = projectFromCalc.getProgram().expandLocalRef(projectRef.left);
+            programBuilder.addProject(project, projectRef.right);
+        }
+
+        final RexProgram newProgram = programBuilder.getProgram();
+        return (StreamPhysicalCalc) calc.copy(calc.getTraitSet(), calc.getInput(), newProgram);
+    }
+
+    /**
+     * Transforms the {@link RelOptRuleCall} to use {@param changelogNormalize} as the new input to
+     * a {@link StreamPhysicalCalc} which uses {@param predicates} for the condition.
+     */
+    private void transformWithRemainingPredicates(
+            RelOptRuleCall call,
+            StreamPhysicalChangelogNormalize changelogNormalize,
+            List<RexNode> predicates) {
+        final StreamPhysicalCalc calc = call.rel(0);
+        final RelBuilder relBuilder = call.builder();
+
+        final StreamPhysicalCalc newCalc =
+                projectIdentityWithConditions(relBuilder, changelogNormalize, predicates);
+        final StreamPhysicalCalc newProjectedCalc = projectWith(relBuilder, calc, newCalc);
+
+        if (newProjectedCalc.getProgram().isTrivial()) {
+            call.transformTo(changelogNormalize);
+        } else {
+            call.transformTo(newProjectedCalc);
+        }
+    }
+
+    // ---------------------------------------------------------------------------------------------
+
+    /** Configuration for {@link PushFilterPastChangelogNormalizeRule}. */
+    public interface Config extends RelRule.Config {
+
+        @Override
+        default RelOptRule toRule() {
+            return new PushFilterPastChangelogNormalizeRule(this);
+        }
+
+        default Config onFilterWithChangelogNormalize() {
+            final RelRule.OperandTransform changelogNormalizeTransform =
+                    operandBuilder ->
+                            operandBuilder
+                                    .operand(StreamPhysicalChangelogNormalize.class)
+                                    .anyInputs();
+
+            final RelRule.OperandTransform calcTransform =
+                    operandBuilder ->
+                            operandBuilder
+                                    .operand(StreamPhysicalCalc.class)
+                                    .predicate(calc -> calc.getProgram().getCondition() != null)
+                                    .oneInput(changelogNormalizeTransform);
+
+            return withOperandSupplier(calcTransform).as(Config.class);
+        }
+    }
+}

--- a/flink-table/flink-table-planner/src/main/java/org/apache/flink/table/planner/plan/rules/physical/stream/PushFilterPastChangelogNormalizeRule.java
+++ b/flink-table/flink-table-planner/src/main/java/org/apache/flink/table/planner/plan/rules/physical/stream/PushFilterPastChangelogNormalizeRule.java
@@ -56,8 +56,8 @@ import static org.apache.flink.table.planner.plan.utils.RexNodeExtractor.extract
  * keeps state for every unique key it encounters, thus pushing filters on the primary key in front
  * of it helps reduce the size of its state.
  *
- * <p>Note that pushing primary key filters is safe to do, but pushing any other filters would lead
- * to incorrect results.
+ * <p>Note that pushing primary key filters is safe to do, but pushing any other filters can lead to
+ * incorrect results.
  */
 @Internal
 public class PushFilterPastChangelogNormalizeRule
@@ -95,7 +95,7 @@ public class PushFilterPastChangelogNormalizeRule
 
         // Construct a new ChangelogNormalize which has primary key filters pushed into it
         final StreamPhysicalChangelogNormalize newChangelogNormalize =
-                pushFiltersThroughChangeNormalize(call, primaryKeyPredicates);
+                pushFiltersThroughChangelogNormalize(call, primaryKeyPredicates);
 
         // Retain only filters which haven't been pushed
         transformWithRemainingPredicates(call, newChangelogNormalize, otherPredicates);
@@ -121,7 +121,7 @@ public class PushFilterPastChangelogNormalizeRule
     }
 
     /** Pushes {@param primaryKeyPredicates} into the {@link StreamPhysicalChangelogNormalize}. */
-    private StreamPhysicalChangelogNormalize pushFiltersThroughChangeNormalize(
+    private StreamPhysicalChangelogNormalize pushFiltersThroughChangelogNormalize(
             RelOptRuleCall call, List<RexNode> primaryKeyPredicates) {
         final StreamPhysicalChangelogNormalize changelogNormalize = call.rel(1);
 

--- a/flink-table/flink-table-planner/src/main/scala/org/apache/flink/table/planner/plan/rules/FlinkStreamRuleSets.scala
+++ b/flink-table/flink-table-planner/src/main/scala/org/apache/flink/table/planner/plan/rules/FlinkStreamRuleSets.scala
@@ -495,6 +495,9 @@ object FlinkStreamRuleSets {
     SimplifyWindowTableFunctionRules.WITH_LEFT_RIGHT_CALC_WINDOW_JOIN,
     SimplifyWindowTableFunctionRules.WITH_LEFT_CALC_WINDOW_JOIN,
     SimplifyWindowTableFunctionRules.WITH_RIGHT_CALC_WINDOW_JOIN,
-    SimplifyWindowTableFunctionRules.WITH_WINDOW_JOIN)
+    SimplifyWindowTableFunctionRules.WITH_WINDOW_JOIN,
+    // optimize ChangelogNormalize
+    PushFilterPastChangelogNormalizeRule.INSTANCE
+  )
 
 }

--- a/flink-table/flink-table-planner/src/test/java/org/apache/flink/table/planner/factories/TableFactoryHarness.java
+++ b/flink-table/flink-table-planner/src/test/java/org/apache/flink/table/planner/factories/TableFactoryHarness.java
@@ -1,0 +1,361 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.flink.table.planner.factories;
+
+import org.apache.flink.configuration.ConfigOption;
+import org.apache.flink.configuration.ConfigOptions;
+import org.apache.flink.configuration.ReadableConfig;
+import org.apache.flink.streaming.api.functions.sink.SinkFunction;
+import org.apache.flink.streaming.api.functions.source.SourceFunction;
+import org.apache.flink.table.api.Schema;
+import org.apache.flink.table.api.TableDescriptor;
+import org.apache.flink.table.api.ValidationException;
+import org.apache.flink.table.catalog.CatalogTable;
+import org.apache.flink.table.connector.ChangelogMode;
+import org.apache.flink.table.connector.sink.DynamicTableSink;
+import org.apache.flink.table.connector.sink.DynamicTableSink.SinkRuntimeProvider;
+import org.apache.flink.table.connector.sink.SinkFunctionProvider;
+import org.apache.flink.table.connector.source.DynamicTableSource;
+import org.apache.flink.table.connector.source.LookupTableSource;
+import org.apache.flink.table.connector.source.ScanTableSource;
+import org.apache.flink.table.connector.source.ScanTableSource.ScanRuntimeProvider;
+import org.apache.flink.table.connector.source.SourceFunctionProvider;
+import org.apache.flink.table.connector.source.TableFunctionProvider;
+import org.apache.flink.table.data.RowData;
+import org.apache.flink.table.factories.DynamicTableFactory;
+import org.apache.flink.table.factories.DynamicTableSinkFactory;
+import org.apache.flink.table.factories.DynamicTableSourceFactory;
+import org.apache.flink.table.factories.FactoryUtil;
+import org.apache.flink.table.functions.TableFunction;
+import org.apache.flink.testutils.junit.SharedObjects;
+import org.apache.flink.util.InstantiationUtil;
+
+import java.io.IOException;
+import java.io.Serializable;
+import java.util.Base64;
+import java.util.HashSet;
+import java.util.Set;
+
+/**
+ * Provides a flexible testing harness for table factories.
+ *
+ * <p>This testing harness allows writing custom sources and sinks which can be directly
+ * instantiated from the test. This avoids having to implement a factory, and enables using the
+ * {@link SharedObjects} rule to get direct access to the underlying source/sink from the test.
+ *
+ * <p>Note that the underlying source/sink must be {@link Serializable}. It is recommended to extend
+ * from {@link ScanSourceBase}, {@link LookupSourceBase}, or {@link SinkBase} which provide default
+ * implementations for most methods as well as some convenience methods.
+ *
+ * <p>The harness provides a {@link Factory}. You can register a source / sink through configuration
+ * by passing a base64-encoded serialization. The harness provides convenience methods to make this
+ * process as simple as possible.
+ *
+ * <p>Example:
+ *
+ * <pre>{@code
+ * public class CustomSourceTest {
+ *     {@literal @}Rule public SharedObjects sharedObjects = SharedObjects.create();
+ *
+ *     {@literal @}Test
+ *     public void test() {
+ *         SharedReference<List<Long>> appliedLimits = sharedObjects.add(new ArrayList<>());
+ *
+ *         Schema schema = Schema.newBuilder().build();
+ *         TableDescriptor sourceDescriptor = TableFactoryHarness.forSource(schema,
+ *             new CustomSource(appliedLimits));
+ *
+ *         tEnv.createTable("T", sourceDescriptor);
+ *         tEnv.explainSql("SELECT * FROM T LIMIT 42");
+ *
+ *         assertEquals(1, appliedLimits.get().size());
+ *         assertEquals((Long) 42L, appliedLimits.get().get(0));
+ *     }
+ *
+ *     private static class CustomSource extends ScanSourceBase implements SupportsLimitPushDown {
+ *         private final SharedReference<List<Long>> appliedLimits;
+ *
+ *         CustomSource(SharedReference<List<Long>> appliedLimits) {
+ *             this.appliedLimits = appliedLimits;
+ *         }
+ *
+ *         {@literal @}Override
+ *         public void applyLimit(long limit) {
+ *             appliedLimits.get().add(limit);
+ *         }
+ *     }
+ * }
+ * }</pre>
+ */
+public class TableFactoryHarness {
+
+    /** Factory identifier for {@link Factory}. */
+    public static final String IDENTIFIER = "harness";
+
+    public static final ConfigOption<String> SOURCE =
+            ConfigOptions.key("source")
+                    .stringType()
+                    .noDefaultValue()
+                    .withDescription("Serialized instance of DynamicTableSource (Base64-encoded)");
+
+    public static final ConfigOption<String> SINK =
+            ConfigOptions.key("sink")
+                    .stringType()
+                    .noDefaultValue()
+                    .withDescription("Serialized instance of DynamicTableSink (Base64-encoded)");
+
+    // ---------------------------------------------------------------------------------------------
+
+    /** Creates a {@link TableDescriptor} for the given {@param schema} and {@param source}. */
+    public static TableDescriptor forSource(Schema schema, SourceBase source) {
+        return TableDescriptor.forConnector(IDENTIFIER)
+                .schema(schema)
+                .option(SOURCE, source.serialize())
+                .build();
+    }
+
+    /** Creates a {@link TableDescriptor} for the given {@param schema} and {@param sink}. */
+    public static TableDescriptor forSink(Schema schema, SinkBase sink) {
+        return TableDescriptor.forConnector(IDENTIFIER)
+                .schema(schema)
+                .option(SINK, sink.serialize())
+                .build();
+    }
+
+    // ---------------------------------------------------------------------------------------------
+
+    /** Harness factory for creating sources / sinks from base64-encoded serialized strings. */
+    public static class Factory implements DynamicTableSourceFactory, DynamicTableSinkFactory {
+
+        @Override
+        public String factoryIdentifier() {
+            return IDENTIFIER;
+        }
+
+        @Override
+        public Set<ConfigOption<?>> requiredOptions() {
+            return new HashSet<>();
+        }
+
+        @Override
+        public Set<ConfigOption<?>> optionalOptions() {
+            Set<ConfigOption<?>> options = new HashSet<>();
+            options.add(SOURCE);
+            options.add(SINK);
+            return options;
+        }
+
+        @Override
+        public DynamicTableSource createDynamicTableSource(Context context) {
+            final FactoryUtil.TableFactoryHelper factoryHelper =
+                    FactoryUtil.createTableFactoryHelper(this, context);
+            factoryHelper.validate();
+
+            final DynamicTableSource source =
+                    deserializeSourceSink(factoryHelper.getOptions(), SOURCE);
+            if (source instanceof SourceBase) {
+                ((SourceBase) source).factoryContext = context;
+            }
+
+            return source;
+        }
+
+        @Override
+        public DynamicTableSink createDynamicTableSink(Context context) {
+            final FactoryUtil.TableFactoryHelper factoryHelper =
+                    FactoryUtil.createTableFactoryHelper(this, context);
+            factoryHelper.validate();
+
+            final DynamicTableSink sink = deserializeSourceSink(factoryHelper.getOptions(), SINK);
+            if (sink instanceof SinkBase) {
+                ((SinkBase) sink).factoryContext = context;
+            }
+
+            return sink;
+        }
+
+        private <T> T deserializeSourceSink(
+                ReadableConfig options, ConfigOption<String> configOption) {
+            final String serializedValue =
+                    options.getOptional(configOption)
+                            .orElseThrow(
+                                    () ->
+                                            new ValidationException(
+                                                    String.format(
+                                                            "Missing option '%s'.",
+                                                            configOption.key())));
+
+            try {
+                return InstantiationUtil.deserializeObject(
+                        Base64.getDecoder().decode(serializedValue),
+                        Thread.currentThread().getContextClassLoader());
+            } catch (ClassNotFoundException | IOException e) {
+                throw new ValidationException(
+                        "Serialized source/sink could not be deserialized.", e);
+            }
+        }
+    }
+
+    // ---------------------------------------------------------------------------------------------
+
+    /**
+     * Serializes a source / sink into a base64-encoded string which can be used by {@link Factory}.
+     *
+     * <p>If your source / sink extends from {@link ScanSourceBase}, {@link LookupSourceBase}, or
+     * {@link SinkBase}, you can use {@link SourceBase#serialize()} / {@link SinkBase#serialize()}
+     * instead, or use {@link #forSource(Schema, SourceBase)} / {@link #forSink(Schema, SinkBase)}.
+     */
+    public static String serializeImplementation(Object obj) {
+        try {
+            return Base64.getEncoder().encodeToString(InstantiationUtil.serializeObject(obj));
+        } catch (IOException e) {
+            throw new RuntimeException(e.getMessage(), e);
+        }
+    }
+
+    /** Creates a {@link ScanRuntimeProvider} which produces nothing. */
+    public static ScanRuntimeProvider createEmptyScanProvider() {
+        return SourceFunctionProvider.of(
+                new SourceFunction<RowData>() {
+                    @Override
+                    public void run(SourceContext<RowData> ctx) {}
+
+                    @Override
+                    public void cancel() {}
+                },
+                true);
+    }
+
+    /** Creates a {@link SinkRuntimeProvider} which discards all records. */
+    public static SinkRuntimeProvider createEmptySinkProvider() {
+        return SinkFunctionProvider.of(
+                new SinkFunction<RowData>() {
+                    @Override
+                    public void invoke(RowData value, Context context) {}
+                });
+    }
+
+    // ---------------------------------------------------------------------------------------------
+
+    /**
+     * Serializable base class for custom sources which implement {@link ScanTableSource}.
+     *
+     * <p>Most interface methods are default-implemented for convenience, but can be overridden when
+     * necessary. By default, a {@link ScanRuntimeProvider} is used which doesn't produce anything.
+     *
+     * <p>Sources derived from this base class will also be provided the {@link
+     * DynamicTableFactory.Context} of the factory which gives access to e.g. the {@link
+     * CatalogTable}.
+     */
+    public abstract static class ScanSourceBase extends SourceBase implements ScanTableSource {
+        @Override
+        public ChangelogMode getChangelogMode() {
+            return ChangelogMode.insertOnly();
+        }
+
+        @Override
+        public ScanRuntimeProvider getScanRuntimeProvider(ScanContext runtimeProviderContext) {
+            return createEmptyScanProvider();
+        }
+    }
+
+    /**
+     * Serializable base class for custom sources which implement {@link LookupTableSource}.
+     *
+     * <p>Most interface methods are default-implemented for convenience, but can be overridden when
+     * necessary. By default, a {@link LookupRuntimeProvider} is used which doesn't produce
+     * anything.
+     *
+     * <p>Sources derived from this base class will also be provided the {@link
+     * DynamicTableFactory.Context} of the factory which gives access to e.g. the {@link
+     * CatalogTable}.
+     */
+    public abstract static class LookupSourceBase extends SourceBase implements LookupTableSource {
+        @Override
+        public LookupRuntimeProvider getLookupRuntimeProvider(LookupContext context) {
+            return TableFunctionProvider.of(new TableFunction<RowData>() {});
+        }
+    }
+
+    /**
+     * Serializable base class for custom sinks.
+     *
+     * <p>Most interface methods are default-implemented for convenience, but can be overridden when
+     * necessary. By default, a {@link SinkRuntimeProvider} is used which does nothing.
+     *
+     * <p>Sinks derived from this base class will also be provided the {@link
+     * DynamicTableFactory.Context} of the factory which gives access to e.g. the {@link
+     * CatalogTable}.
+     */
+    public abstract static class SinkBase implements Serializable, DynamicTableSink {
+
+        private DynamicTableFactory.Context factoryContext;
+
+        @Override
+        public ChangelogMode getChangelogMode(ChangelogMode requestedMode) {
+            return ChangelogMode.all();
+        }
+
+        @Override
+        public SinkRuntimeProvider getSinkRuntimeProvider(Context context) {
+            return createEmptySinkProvider();
+        }
+
+        @Override
+        public DynamicTableSink copy() {
+            return this;
+        }
+
+        @Override
+        public String asSummaryString() {
+            return "Unspecified Testing Sink";
+        }
+
+        public DynamicTableFactory.Context getFactoryContext() {
+            return factoryContext;
+        }
+
+        public String serialize() {
+            return serializeImplementation(this);
+        }
+    }
+
+    /** Base class for {@link ScanSourceBase} and {{@link LookupSourceBase}}. */
+    private abstract static class SourceBase implements Serializable, DynamicTableSource {
+        private DynamicTableFactory.Context factoryContext;
+
+        @Override
+        public DynamicTableSource copy() {
+            return this;
+        }
+
+        @Override
+        public String asSummaryString() {
+            return "Unspecified Testing Source";
+        }
+
+        public DynamicTableFactory.Context getFactoryContext() {
+            return factoryContext;
+        }
+
+        public String serialize() {
+            return serializeImplementation(this);
+        }
+    }
+}

--- a/flink-table/flink-table-planner/src/test/java/org/apache/flink/table/planner/plan/rules/logical/PushProjectIntoTableSourceScanRuleTest.java
+++ b/flink-table/flink-table-planner/src/test/java/org/apache/flink/table/planner/plan/rules/logical/PushProjectIntoTableSourceScanRuleTest.java
@@ -18,40 +18,31 @@
 
 package org.apache.flink.table.planner.plan.rules.logical;
 
-import org.apache.flink.configuration.ConfigOption;
-import org.apache.flink.configuration.ConfigOptions;
-import org.apache.flink.configuration.ReadableConfig;
-import org.apache.flink.streaming.api.functions.source.SourceFunction;
 import org.apache.flink.table.api.Schema;
-import org.apache.flink.table.api.TableDescriptor;
-import org.apache.flink.table.connector.ChangelogMode;
-import org.apache.flink.table.connector.source.DynamicTableSource;
-import org.apache.flink.table.connector.source.ScanTableSource;
-import org.apache.flink.table.connector.source.SourceFunctionProvider;
+import org.apache.flink.table.connector.source.abilities.SupportsProjectionPushDown;
 import org.apache.flink.table.connector.source.abilities.SupportsReadingMetadata;
-import org.apache.flink.table.data.RowData;
-import org.apache.flink.table.factories.DynamicTableSourceFactory;
-import org.apache.flink.table.factories.FactoryUtil;
 import org.apache.flink.table.planner.calcite.CalciteConfig;
+import org.apache.flink.table.planner.factories.TableFactoryHarness;
 import org.apache.flink.table.planner.plan.optimize.program.BatchOptimizeContext;
 import org.apache.flink.table.planner.plan.optimize.program.FlinkBatchProgram;
 import org.apache.flink.table.planner.plan.optimize.program.FlinkHepRuleSetProgramBuilder;
 import org.apache.flink.table.planner.plan.optimize.program.HEP_RULES_EXECUTION_TYPE;
 import org.apache.flink.table.planner.utils.TableConfigUtils;
 import org.apache.flink.table.types.DataType;
+import org.apache.flink.testutils.junit.SharedObjects;
+import org.apache.flink.testutils.junit.SharedReference;
 
 import org.apache.calcite.plan.hep.HepMatchOrder;
 import org.apache.calcite.tools.RuleSets;
+import org.junit.Rule;
 import org.junit.Test;
 
-import java.util.Collections;
+import java.util.ArrayList;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
-import java.util.Set;
 
 import static org.apache.flink.table.api.DataTypes.STRING;
-import static org.apache.flink.table.planner.plan.rules.logical.PushProjectIntoTableSourceScanRuleTest.MetadataNoProjectionPushDownTableFactory.SUPPORTS_METADATA_PROJECTION;
 import static org.hamcrest.MatcherAssert.assertThat;
 import static org.hamcrest.Matchers.contains;
 import static org.hamcrest.Matchers.hasSize;
@@ -59,6 +50,8 @@ import static org.hamcrest.Matchers.hasSize;
 /** Test for {@link PushProjectIntoTableSourceScanRule}. */
 public class PushProjectIntoTableSourceScanRuleTest
         extends PushProjectIntoLegacyTableSourceScanRuleTest {
+
+    @Rule public final SharedObjects sharedObjects = SharedObjects.create();
 
     @Override
     public void setup() {
@@ -273,121 +266,73 @@ public class PushProjectIntoTableSourceScanRuleTest
 
     @Test
     public void testMetadataProjectionWithoutProjectionPushDownWhenSupported() {
-        createMetadataTableWithoutProjectionPushDown("T1", true);
+        final SharedReference<List<String>> appliedKeys = sharedObjects.add(new ArrayList<>());
+        final NoPushDownSource source = new NoPushDownSource(true, appliedKeys);
+
+        util().tableEnv()
+                .createTable("T1", TableFactoryHarness.forSource(NoPushDownSource.SCHEMA, source));
 
         util().verifyRelPlan("SELECT m1, metadata FROM T1");
-        assertThat(
-                MetadataNoProjectionPushDownTableFactory.appliedMetadataKeys.get(),
-                contains("m1", "m2"));
+        assertThat(appliedKeys.get(), contains("m1", "m2"));
     }
 
     @Test
     public void testMetadataProjectionWithoutProjectionPushDownWhenNotSupported() {
-        createMetadataTableWithoutProjectionPushDown("T2", false);
+        final SharedReference<List<String>> appliedKeys = sharedObjects.add(new ArrayList<>());
+        final NoPushDownSource source = new NoPushDownSource(false, appliedKeys);
+
+        util().tableEnv()
+                .createTable("T2", TableFactoryHarness.forSource(NoPushDownSource.SCHEMA, source));
 
         util().verifyRelPlan("SELECT m1, metadata FROM T2");
-        assertThat(
-                MetadataNoProjectionPushDownTableFactory.appliedMetadataKeys.get(),
-                contains("m1", "m2", "m3"));
+        assertThat(appliedKeys.get(), contains("m1", "m2", "m3"));
     }
 
     @Test
     public void testMetadataProjectionWithoutProjectionPushDownWhenSupportedAndNoneSelected() {
-        createMetadataTableWithoutProjectionPushDown("T3", true);
+        final SharedReference<List<String>> appliedKeys = sharedObjects.add(new ArrayList<>());
+        final NoPushDownSource source = new NoPushDownSource(true, appliedKeys);
+
+        util().tableEnv()
+                .createTable("T3", TableFactoryHarness.forSource(NoPushDownSource.SCHEMA, source));
 
         util().verifyRelPlan("SELECT 1 FROM T3");
-        assertThat(MetadataNoProjectionPushDownTableFactory.appliedMetadataKeys.get(), hasSize(0));
+        assertThat(appliedKeys.get(), hasSize(0));
     }
 
     @Test
     public void testMetadataProjectionWithoutProjectionPushDownWhenNotSupportedAndNoneSelected() {
-        createMetadataTableWithoutProjectionPushDown("T4", false);
+        final SharedReference<List<String>> appliedKeys = sharedObjects.add(new ArrayList<>());
+        final NoPushDownSource source = new NoPushDownSource(false, appliedKeys);
+
+        util().tableEnv()
+                .createTable("T4", TableFactoryHarness.forSource(NoPushDownSource.SCHEMA, source));
 
         util().verifyRelPlan("SELECT 1 FROM T4");
-        assertThat(
-                MetadataNoProjectionPushDownTableFactory.appliedMetadataKeys.get(),
-                contains("m1", "m2", "m3"));
+        assertThat(appliedKeys.get(), contains("m1", "m2", "m3"));
     }
 
     // ---------------------------------------------------------------------------------------------
 
-    private void createMetadataTableWithoutProjectionPushDown(
-            String name, boolean supportsMetadataProjection) {
-        util().tableEnv()
-                .createTable(
-                        name,
-                        TableDescriptor.forConnector(
-                                        MetadataNoProjectionPushDownTableFactory.IDENTIFIER)
-                                .schema(
-                                        Schema.newBuilder()
-                                                .columnByMetadata("m1", STRING())
-                                                .columnByMetadata("metadata", STRING(), "m2")
-                                                .columnByMetadata("m3", STRING())
-                                                .build())
-                                .option(SUPPORTS_METADATA_PROJECTION, supportsMetadataProjection)
-                                .build());
-    }
+    /** Source which supports metadata but not {@link SupportsProjectionPushDown}. */
+    private static class NoPushDownSource extends TableFactoryHarness.ScanSourceBase
+            implements SupportsReadingMetadata {
 
-    // ---------------------------------------------------------------------------------------------
+        public static final Schema SCHEMA =
+                Schema.newBuilder()
+                        .columnByMetadata("m1", STRING())
+                        .columnByMetadata("metadata", STRING(), "m2")
+                        .columnByMetadata("m3", STRING())
+                        .build();
 
-    /** Factory for {@link Source}. */
-    public static class MetadataNoProjectionPushDownTableFactory
-            implements DynamicTableSourceFactory {
-        public static final String IDENTIFIER = "metadataNoProjectionPushDown";
+        private final boolean supportsMetadataProjection;
+        private final SharedReference<List<String>> appliedMetadataKeys;
 
-        public static final ConfigOption<Boolean> SUPPORTS_METADATA_PROJECTION =
-                ConfigOptions.key("supports-metadata-projection").booleanType().defaultValue(true);
-
-        public static ThreadLocal<List<String>> appliedMetadataKeys = new ThreadLocal<>();
-
-        @Override
-        public String factoryIdentifier() {
-            return IDENTIFIER;
-        }
-
-        @Override
-        public Set<ConfigOption<?>> requiredOptions() {
-            return Collections.emptySet();
-        }
-
-        @Override
-        public Set<ConfigOption<?>> optionalOptions() {
-            return Collections.singleton(SUPPORTS_METADATA_PROJECTION);
-        }
-
-        @Override
-        public DynamicTableSource createDynamicTableSource(Context context) {
-            FactoryUtil.TableFactoryHelper helper =
-                    FactoryUtil.createTableFactoryHelper(this, context);
-            return new Source(helper.getOptions());
-        }
-    }
-
-    private static class Source implements ScanTableSource, SupportsReadingMetadata {
-
-        private final ReadableConfig options;
-
-        public Source(ReadableConfig options) {
-            this.options = options;
-            MetadataNoProjectionPushDownTableFactory.appliedMetadataKeys.remove();
-        }
-
-        @Override
-        public ChangelogMode getChangelogMode() {
-            return ChangelogMode.insertOnly();
-        }
-
-        @Override
-        public ScanRuntimeProvider getScanRuntimeProvider(ScanContext runtimeProviderContext) {
-            return SourceFunctionProvider.of(
-                    new SourceFunction<RowData>() {
-                        @Override
-                        public void run(SourceContext<RowData> ctx) {}
-
-                        @Override
-                        public void cancel() {}
-                    },
-                    true);
+        public NoPushDownSource(
+                boolean supportsMetadataProjection,
+                SharedReference<List<String>> appliedMetadataKeys) {
+            this.supportsMetadataProjection = supportsMetadataProjection;
+            this.appliedMetadataKeys = appliedMetadataKeys;
         }
 
         @Override
@@ -401,22 +346,13 @@ public class PushProjectIntoTableSourceScanRuleTest
 
         @Override
         public void applyReadableMetadata(List<String> metadataKeys, DataType producedDataType) {
-            MetadataNoProjectionPushDownTableFactory.appliedMetadataKeys.set(metadataKeys);
+            appliedMetadataKeys.get().clear();
+            appliedMetadataKeys.get().addAll(metadataKeys);
         }
 
         @Override
         public boolean supportsMetadataProjection() {
-            return options.get(SUPPORTS_METADATA_PROJECTION);
-        }
-
-        @Override
-        public DynamicTableSource copy() {
-            return new Source(options);
-        }
-
-        @Override
-        public String asSummaryString() {
-            return getClass().getName();
+            return supportsMetadataProjection;
         }
     }
 }

--- a/flink-table/flink-table-planner/src/test/java/org/apache/flink/table/planner/plan/rules/logical/PushProjectIntoTableSourceScanRuleTest.java
+++ b/flink-table/flink-table-planner/src/test/java/org/apache/flink/table/planner/plan/rules/logical/PushProjectIntoTableSourceScanRuleTest.java
@@ -19,6 +19,7 @@
 package org.apache.flink.table.planner.plan.rules.logical;
 
 import org.apache.flink.table.api.Schema;
+import org.apache.flink.table.api.TableDescriptor;
 import org.apache.flink.table.connector.source.abilities.SupportsProjectionPushDown;
 import org.apache.flink.table.connector.source.abilities.SupportsReadingMetadata;
 import org.apache.flink.table.planner.calcite.CalciteConfig;
@@ -267,10 +268,12 @@ public class PushProjectIntoTableSourceScanRuleTest
     @Test
     public void testMetadataProjectionWithoutProjectionPushDownWhenSupported() {
         final SharedReference<List<String>> appliedKeys = sharedObjects.add(new ArrayList<>());
-        final NoPushDownSource source = new NoPushDownSource(true, appliedKeys);
-
-        util().tableEnv()
-                .createTable("T1", TableFactoryHarness.forSource(NoPushDownSource.SCHEMA, source));
+        final TableDescriptor sourceDescriptor =
+                TableFactoryHarness.newBuilder()
+                        .schema(NoPushDownSource.SCHEMA)
+                        .source(new NoPushDownSource(true, appliedKeys))
+                        .build();
+        util().tableEnv().createTable("T1", sourceDescriptor);
 
         util().verifyRelPlan("SELECT m1, metadata FROM T1");
         assertThat(appliedKeys.get(), contains("m1", "m2"));
@@ -279,10 +282,12 @@ public class PushProjectIntoTableSourceScanRuleTest
     @Test
     public void testMetadataProjectionWithoutProjectionPushDownWhenNotSupported() {
         final SharedReference<List<String>> appliedKeys = sharedObjects.add(new ArrayList<>());
-        final NoPushDownSource source = new NoPushDownSource(false, appliedKeys);
-
-        util().tableEnv()
-                .createTable("T2", TableFactoryHarness.forSource(NoPushDownSource.SCHEMA, source));
+        final TableDescriptor sourceDescriptor =
+                TableFactoryHarness.newBuilder()
+                        .schema(NoPushDownSource.SCHEMA)
+                        .source(new NoPushDownSource(false, appliedKeys))
+                        .build();
+        util().tableEnv().createTable("T2", sourceDescriptor);
 
         util().verifyRelPlan("SELECT m1, metadata FROM T2");
         assertThat(appliedKeys.get(), contains("m1", "m2", "m3"));
@@ -291,10 +296,12 @@ public class PushProjectIntoTableSourceScanRuleTest
     @Test
     public void testMetadataProjectionWithoutProjectionPushDownWhenSupportedAndNoneSelected() {
         final SharedReference<List<String>> appliedKeys = sharedObjects.add(new ArrayList<>());
-        final NoPushDownSource source = new NoPushDownSource(true, appliedKeys);
-
-        util().tableEnv()
-                .createTable("T3", TableFactoryHarness.forSource(NoPushDownSource.SCHEMA, source));
+        final TableDescriptor sourceDescriptor =
+                TableFactoryHarness.newBuilder()
+                        .schema(NoPushDownSource.SCHEMA)
+                        .source(new NoPushDownSource(true, appliedKeys))
+                        .build();
+        util().tableEnv().createTable("T3", sourceDescriptor);
 
         util().verifyRelPlan("SELECT 1 FROM T3");
         assertThat(appliedKeys.get(), hasSize(0));
@@ -303,10 +310,12 @@ public class PushProjectIntoTableSourceScanRuleTest
     @Test
     public void testMetadataProjectionWithoutProjectionPushDownWhenNotSupportedAndNoneSelected() {
         final SharedReference<List<String>> appliedKeys = sharedObjects.add(new ArrayList<>());
-        final NoPushDownSource source = new NoPushDownSource(false, appliedKeys);
-
-        util().tableEnv()
-                .createTable("T4", TableFactoryHarness.forSource(NoPushDownSource.SCHEMA, source));
+        final TableDescriptor sourceDescriptor =
+                TableFactoryHarness.newBuilder()
+                        .schema(NoPushDownSource.SCHEMA)
+                        .source(new NoPushDownSource(false, appliedKeys))
+                        .build();
+        util().tableEnv().createTable("T4", sourceDescriptor);
 
         util().verifyRelPlan("SELECT 1 FROM T4");
         assertThat(appliedKeys.get(), contains("m1", "m2", "m3"));

--- a/flink-table/flink-table-planner/src/test/java/org/apache/flink/table/planner/plan/rules/physical/stream/PushFilterPastChangelogNormalizeRuleTest.java
+++ b/flink-table/flink-table-planner/src/test/java/org/apache/flink/table/planner/plan/rules/physical/stream/PushFilterPastChangelogNormalizeRuleTest.java
@@ -1,0 +1,104 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.flink.table.planner.plan.rules.physical.stream;
+
+import org.apache.flink.table.api.Schema;
+import org.apache.flink.table.api.TableConfig;
+import org.apache.flink.table.api.TableDescriptor;
+import org.apache.flink.table.connector.ChangelogMode;
+import org.apache.flink.table.planner.factories.TableFactoryHarness;
+import org.apache.flink.table.planner.utils.StreamTableTestUtil;
+import org.apache.flink.table.planner.utils.TableTestBase;
+
+import org.junit.Before;
+import org.junit.Test;
+
+import static org.apache.flink.table.api.DataTypes.BIGINT;
+import static org.apache.flink.table.api.DataTypes.INT;
+import static org.apache.flink.table.api.DataTypes.STRING;
+
+/** Tests for {@link PushFilterPastChangelogNormalizeRule}. */
+public class PushFilterPastChangelogNormalizeRuleTest extends TableTestBase {
+
+    private StreamTableTestUtil util;
+
+    @Before
+    public void before() {
+        util = streamTestUtil(TableConfig.getDefault());
+    }
+
+    @Test
+    public void testWithSinglePrimaryKeyFilter() {
+        final TableDescriptor sourceDescriptor =
+                TableFactoryHarness.forSource(
+                        Schema.newBuilder()
+                                .column("f0", STRING())
+                                .column("f1", INT().notNull())
+                                .primaryKey("f1")
+                                .build(),
+                        new NoFilterPushDownUpsertSource());
+
+        util.tableEnv().createTable("T", sourceDescriptor);
+        util.verifyRelPlan("SELECT * FROM T WHERE f1 < 1");
+    }
+
+    @Test
+    public void testWithMultipleFilters() {
+        final TableDescriptor sourceDescriptor =
+                TableFactoryHarness.forSource(
+                        Schema.newBuilder()
+                                .column("f0", STRING())
+                                .column("f1", INT().notNull())
+                                .column("f2", STRING())
+                                .primaryKey("f1")
+                                .build(),
+                        new NoFilterPushDownUpsertSource());
+
+        util.tableEnv().createTable("T", sourceDescriptor);
+
+        // Only the first filter (f1 < 10) can be pushed
+        util.verifyRelPlan(
+                "SELECT f1, SUM(f1) AS `sum` FROM T WHERE f1 < 10 AND (f1 > 3 OR f2 IS NULL) GROUP BY f1");
+    }
+
+    @Test
+    public void testWithMultiplePrimaryKeyColumns() {
+        final TableDescriptor sourceDescriptor =
+                TableFactoryHarness.forSource(
+                        Schema.newBuilder()
+                                .column("f0", STRING())
+                                .column("f1", INT().notNull())
+                                .column("f2", BIGINT().notNull())
+                                .primaryKey("f1", "f2")
+                                .build(),
+                        new NoFilterPushDownUpsertSource());
+
+        util.tableEnv().createTable("T", sourceDescriptor);
+        util.verifyRelPlan("SELECT f0, f1 FROM T WHERE (f1 < 1 OR f2 > 10) AND f0 IS NOT NULL");
+    }
+
+    // ---------------------------------------------------------------------------------------------
+
+    private static class NoFilterPushDownUpsertSource extends TableFactoryHarness.ScanSourceBase {
+        @Override
+        public ChangelogMode getChangelogMode() {
+            return ChangelogMode.upsert();
+        }
+    }
+}

--- a/flink-table/flink-table-planner/src/test/java/org/apache/flink/table/planner/plan/rules/physical/stream/PushFilterPastChangelogNormalizeRuleTest.java
+++ b/flink-table/flink-table-planner/src/test/java/org/apache/flink/table/planner/plan/rules/physical/stream/PushFilterPastChangelogNormalizeRuleTest.java
@@ -53,7 +53,7 @@ public class PushFilterPastChangelogNormalizeRuleTest extends TableTestBase {
                                         .column("f1", INT().notNull())
                                         .primaryKey("f1")
                                         .build())
-                        .source(new NoFilterPushDownUpsertSource())
+                        .unboundedScanSource(ChangelogMode.upsert())
                         .build();
 
         util.tableEnv().createTable("T", sourceDescriptor);
@@ -71,7 +71,7 @@ public class PushFilterPastChangelogNormalizeRuleTest extends TableTestBase {
                                         .column("f2", STRING())
                                         .primaryKey("f1")
                                         .build())
-                        .source(new NoFilterPushDownUpsertSource())
+                        .unboundedScanSource(ChangelogMode.upsert())
                         .build();
 
         util.tableEnv().createTable("T", sourceDescriptor);
@@ -92,19 +92,10 @@ public class PushFilterPastChangelogNormalizeRuleTest extends TableTestBase {
                                         .column("f2", BIGINT().notNull())
                                         .primaryKey("f1", "f2")
                                         .build())
-                        .source(new NoFilterPushDownUpsertSource())
+                        .unboundedScanSource(ChangelogMode.upsert())
                         .build();
 
         util.tableEnv().createTable("T", sourceDescriptor);
         util.verifyRelPlan("SELECT f0, f1 FROM T WHERE (f1 < 1 OR f2 > 10) AND f0 IS NOT NULL");
-    }
-
-    // ---------------------------------------------------------------------------------------------
-
-    private static class NoFilterPushDownUpsertSource extends TableFactoryHarness.ScanSourceBase {
-        @Override
-        public ChangelogMode getChangelogMode() {
-            return ChangelogMode.upsert();
-        }
     }
 }

--- a/flink-table/flink-table-planner/src/test/java/org/apache/flink/table/planner/plan/rules/physical/stream/PushFilterPastChangelogNormalizeRuleTest.java
+++ b/flink-table/flink-table-planner/src/test/java/org/apache/flink/table/planner/plan/rules/physical/stream/PushFilterPastChangelogNormalizeRuleTest.java
@@ -46,13 +46,15 @@ public class PushFilterPastChangelogNormalizeRuleTest extends TableTestBase {
     @Test
     public void testWithSinglePrimaryKeyFilter() {
         final TableDescriptor sourceDescriptor =
-                TableFactoryHarness.forSource(
-                        Schema.newBuilder()
-                                .column("f0", STRING())
-                                .column("f1", INT().notNull())
-                                .primaryKey("f1")
-                                .build(),
-                        new NoFilterPushDownUpsertSource());
+                TableFactoryHarness.newBuilder()
+                        .schema(
+                                Schema.newBuilder()
+                                        .column("f0", STRING())
+                                        .column("f1", INT().notNull())
+                                        .primaryKey("f1")
+                                        .build())
+                        .source(new NoFilterPushDownUpsertSource())
+                        .build();
 
         util.tableEnv().createTable("T", sourceDescriptor);
         util.verifyRelPlan("SELECT * FROM T WHERE f1 < 1");
@@ -61,14 +63,16 @@ public class PushFilterPastChangelogNormalizeRuleTest extends TableTestBase {
     @Test
     public void testWithMultipleFilters() {
         final TableDescriptor sourceDescriptor =
-                TableFactoryHarness.forSource(
-                        Schema.newBuilder()
-                                .column("f0", STRING())
-                                .column("f1", INT().notNull())
-                                .column("f2", STRING())
-                                .primaryKey("f1")
-                                .build(),
-                        new NoFilterPushDownUpsertSource());
+                TableFactoryHarness.newBuilder()
+                        .schema(
+                                Schema.newBuilder()
+                                        .column("f0", STRING())
+                                        .column("f1", INT().notNull())
+                                        .column("f2", STRING())
+                                        .primaryKey("f1")
+                                        .build())
+                        .source(new NoFilterPushDownUpsertSource())
+                        .build();
 
         util.tableEnv().createTable("T", sourceDescriptor);
 
@@ -80,14 +84,16 @@ public class PushFilterPastChangelogNormalizeRuleTest extends TableTestBase {
     @Test
     public void testWithMultiplePrimaryKeyColumns() {
         final TableDescriptor sourceDescriptor =
-                TableFactoryHarness.forSource(
-                        Schema.newBuilder()
-                                .column("f0", STRING())
-                                .column("f1", INT().notNull())
-                                .column("f2", BIGINT().notNull())
-                                .primaryKey("f1", "f2")
-                                .build(),
-                        new NoFilterPushDownUpsertSource());
+                TableFactoryHarness.newBuilder()
+                        .schema(
+                                Schema.newBuilder()
+                                        .column("f0", STRING())
+                                        .column("f1", INT().notNull())
+                                        .column("f2", BIGINT().notNull())
+                                        .primaryKey("f1", "f2")
+                                        .build())
+                        .source(new NoFilterPushDownUpsertSource())
+                        .build();
 
         util.tableEnv().createTable("T", sourceDescriptor);
         util.verifyRelPlan("SELECT f0, f1 FROM T WHERE (f1 < 1 OR f2 > 10) AND f0 IS NOT NULL");

--- a/flink-table/flink-table-planner/src/test/resources/META-INF/services/org.apache.flink.table.factories.Factory
+++ b/flink-table/flink-table-planner/src/test/resources/META-INF/services/org.apache.flink.table.factories.Factory
@@ -16,3 +16,4 @@
 org.apache.flink.table.planner.factories.TestValuesTableFactory
 org.apache.flink.table.planner.factories.TestFileFactory
 org.apache.flink.table.planner.plan.rules.logical.PushProjectIntoTableSourceScanRuleTest$MetadataNoProjectionPushDownTableFactory
+org.apache.flink.table.planner.factories.TableFactoryHarness$Factory

--- a/flink-table/flink-table-planner/src/test/resources/META-INF/services/org.apache.flink.table.factories.Factory
+++ b/flink-table/flink-table-planner/src/test/resources/META-INF/services/org.apache.flink.table.factories.Factory
@@ -15,5 +15,4 @@
 
 org.apache.flink.table.planner.factories.TestValuesTableFactory
 org.apache.flink.table.planner.factories.TestFileFactory
-org.apache.flink.table.planner.plan.rules.logical.PushProjectIntoTableSourceScanRuleTest$MetadataNoProjectionPushDownTableFactory
 org.apache.flink.table.planner.factories.TableFactoryHarness$Factory

--- a/flink-table/flink-table-planner/src/test/resources/org/apache/flink/table/planner/plan/rules/physical/stream/PushFilterPastChangelogNormalizeRuleTest.xml
+++ b/flink-table/flink-table-planner/src/test/resources/org/apache/flink/table/planner/plan/rules/physical/stream/PushFilterPastChangelogNormalizeRuleTest.xml
@@ -32,8 +32,8 @@ LogicalAggregate(group=[{0}], sum=[SUM($0)])
       <![CDATA[
 Calc(select=[f1, f1 AS sum], where=[OR(>(f1, 3), IS NULL(f2))])
 +- ChangelogNormalize(key=[f1])
-   +- Calc(select=[f0, f1, f2], where=[<(f1, 10)])
-      +- Exchange(distribution=[hash[f1]])
+   +- Exchange(distribution=[hash[f1]])
+      +- Calc(select=[f0, f1, f2], where=[<(f1, 10)])
          +- TableSourceScan(table=[[default_catalog, default_database, T]], fields=[f0, f1, f2])
 ]]>
     </Resource>
@@ -53,8 +53,8 @@ LogicalProject(f0=[$0], f1=[$1])
       <![CDATA[
 Calc(select=[f0, f1], where=[IS NOT NULL(f0)])
 +- ChangelogNormalize(key=[f1, f2])
-   +- Calc(select=[f0, f1, f2], where=[OR(<(f1, 1), >(f2, 10))])
-      +- Exchange(distribution=[hash[f1, f2]])
+   +- Exchange(distribution=[hash[f1, f2]])
+      +- Calc(select=[f0, f1, f2], where=[OR(<(f1, 1), >(f2, 10))])
          +- TableSourceScan(table=[[default_catalog, default_database, T]], fields=[f0, f1, f2])
 ]]>
     </Resource>
@@ -73,8 +73,8 @@ LogicalProject(f0=[$0], f1=[$1])
     <Resource name="optimized rel plan">
       <![CDATA[
 ChangelogNormalize(key=[f1])
-+- Calc(select=[f0, f1], where=[<(f1, 1)])
-   +- Exchange(distribution=[hash[f1]])
++- Exchange(distribution=[hash[f1]])
+   +- Calc(select=[f0, f1], where=[<(f1, 1)])
       +- TableSourceScan(table=[[default_catalog, default_database, T]], fields=[f0, f1])
 ]]>
     </Resource>

--- a/flink-table/flink-table-planner/src/test/resources/org/apache/flink/table/planner/plan/rules/physical/stream/PushFilterPastChangelogNormalizeRuleTest.xml
+++ b/flink-table/flink-table-planner/src/test/resources/org/apache/flink/table/planner/plan/rules/physical/stream/PushFilterPastChangelogNormalizeRuleTest.xml
@@ -1,0 +1,82 @@
+<?xml version="1.0" ?>
+<!--
+Licensed to the Apache Software Foundation (ASF) under one or more
+contributor license agreements.  See the NOTICE file distributed with
+this work for additional information regarding copyright ownership.
+The ASF licenses this file to you under the Apache License, Version 2.0
+(the "License"); you may not use this file except in compliance with
+the License.  You may obtain a copy of the License at
+
+http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+-->
+<Root>
+  <TestCase name="testWithMultipleFilters">
+    <Resource name="sql">
+      <![CDATA[SELECT f1, SUM(f1) AS `sum` FROM T WHERE f1 < 10 AND (f1 > 3 OR f2 IS NULL) GROUP BY f1]]>
+    </Resource>
+    <Resource name="ast">
+      <![CDATA[
+LogicalAggregate(group=[{0}], sum=[SUM($0)])
++- LogicalProject(f1=[$1])
+   +- LogicalFilter(condition=[AND(<($1, 10), OR(>($1, 3), IS NULL($2)))])
+      +- LogicalTableScan(table=[[default_catalog, default_database, T]])
+]]>
+    </Resource>
+    <Resource name="optimized rel plan">
+      <![CDATA[
+Calc(select=[f1, f1 AS sum], where=[OR(>(f1, 3), IS NULL(f2))])
++- ChangelogNormalize(key=[f1])
+   +- Calc(select=[f0, f1, f2], where=[<(f1, 10)])
+      +- Exchange(distribution=[hash[f1]])
+         +- TableSourceScan(table=[[default_catalog, default_database, T]], fields=[f0, f1, f2])
+]]>
+    </Resource>
+  </TestCase>
+  <TestCase name="testWithMultiplePrimaryKeyColumns">
+    <Resource name="sql">
+      <![CDATA[SELECT f0, f1 FROM T WHERE (f1 < 1 OR f2 > 10) AND f0 IS NOT NULL]]>
+    </Resource>
+    <Resource name="ast">
+      <![CDATA[
+LogicalProject(f0=[$0], f1=[$1])
++- LogicalFilter(condition=[AND(OR(<($1, 1), >($2, 10)), IS NOT NULL($0))])
+   +- LogicalTableScan(table=[[default_catalog, default_database, T]])
+]]>
+    </Resource>
+    <Resource name="optimized rel plan">
+      <![CDATA[
+Calc(select=[f0, f1], where=[IS NOT NULL(f0)])
++- ChangelogNormalize(key=[f1, f2])
+   +- Calc(select=[f0, f1, f2], where=[OR(<(f1, 1), >(f2, 10))])
+      +- Exchange(distribution=[hash[f1, f2]])
+         +- TableSourceScan(table=[[default_catalog, default_database, T]], fields=[f0, f1, f2])
+]]>
+    </Resource>
+  </TestCase>
+  <TestCase name="testWithSinglePrimaryKeyFilter">
+    <Resource name="sql">
+      <![CDATA[SELECT * FROM T WHERE f1 < 1]]>
+    </Resource>
+    <Resource name="ast">
+      <![CDATA[
+LogicalProject(f0=[$0], f1=[$1])
++- LogicalFilter(condition=[<($1, 1)])
+   +- LogicalTableScan(table=[[default_catalog, default_database, T]])
+]]>
+    </Resource>
+    <Resource name="optimized rel plan">
+      <![CDATA[
+ChangelogNormalize(key=[f1])
++- Calc(select=[f0, f1], where=[<(f1, 1)])
+   +- Exchange(distribution=[hash[f1]])
+      +- TableSourceScan(table=[[default_catalog, default_database, T]], fields=[f0, f1])
+]]>
+    </Resource>
+  </TestCase>
+</Root>


### PR DESCRIPTION
## What is the purpose of the change

`ChangelogNormalize` keeps state for each unique key, which is quite expensive. In general it isn't safe to push filters through this operator, but we _can_ allow filters which only filter on the key space to go past it. This allows for a significant reduction in the footprint of the operator if the key space is reduced.

This PR implements a new optimization rule which pushes such primary key filters past the `ChangelogNormalize` operator to allow its state to be reduced. The tests have first been run without the rule and the changes made by the rule are pushed as a second fixup commit for a more pleasant review experience. :-)

Note that sources which implement `SupportsFilterPushDown` currently always have all filters pushed past `ChangelogNormalize` into the source, see FLINK-24014.

~This PR is currently in draft mode as we want to implement FLINK-24004 here to improve the test infrastructure.~

## Verifying this change

This change added tests and can be verified as follows:

* `PushFilterPastChangelogNormalizeRuleTest`

## Does this pull request potentially affect one of the following parts:

  - Dependencies (does it add or upgrade a dependency): no
  - The public API, i.e., is any changed class annotated with `@Public(Evolving)`: no
  - The serializers: no
  - The runtime per-record code paths (performance sensitive): no
  - Anything that affects deployment or recovery: JobManager (and its components), Checkpointing, Kubernetes/Yarn, ZooKeeper: no
  - The S3 file system connector: no

## Documentation

  - Does this pull request introduce a new feature? no
  - If yes, how is the feature documented? JavaDocs
