### PR TITLE
[FLINK-24015] Log failure cause of failed jobs on the Dispatcher

### DIFF
--- a/flink-runtime/src/main/java/org/apache/flink/runtime/dispatcher/Dispatcher.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/dispatcher/Dispatcher.java
@@ -849,10 +849,18 @@ public abstract class Dispatcher extends PermanentlyFencedRpcEndpoint<Dispatcher
                 archivedExecutionGraph.getJobID(),
                 archivedExecutionGraph.getState());
 
-        log.info(
-                "Job {} reached terminal state {}.",
-                archivedExecutionGraph.getJobID(),
-                archivedExecutionGraph.getState());
+        if (archivedExecutionGraph.getFailureInfo() != null) {
+            log.info(
+                    "Job {} reached terminal state {}.\n{}",
+                    archivedExecutionGraph.getJobID(),
+                    archivedExecutionGraph.getState(),
+                    archivedExecutionGraph.getFailureInfo().getExceptionAsString().trim());
+        } else {
+            log.info(
+                    "Job {} reached terminal state {}.",
+                    archivedExecutionGraph.getJobID(),
+                    archivedExecutionGraph.getState());
+        }
 
         archiveExecutionGraph(executionGraphInfo);
 


### PR DESCRIPTION
In order to avoid that we don't log failure causes of failed jobs (e.g. initialization errors),
this commit lets the Dispatcher log the failure cause when archiving the job. This will ensure
that there will be always a record of what happened in the logs of the Dispatcher.