### PR TITLE
[BP-1.13][FLINK-23945][docs] Correct s3 URI in K8s ha documentation

### DIFF
--- a/docs/content.zh/docs/deployment/ha/kubernetes_ha.md
+++ b/docs/content.zh/docs/deployment/ha/kubernetes_ha.md
@@ -55,7 +55,7 @@ high-availability: org.apache.flink.kubernetes.highavailability.KubernetesHaServ
 JobManager metadata is persisted in the file system `high-availability.storageDir` and only a pointer to this state is stored in Kubernetes.
 
 ```yaml
-high-availability.storageDir: s3:///flink/recovery
+high-availability.storageDir: s3://flink/recovery
 ```
 
 The `storageDir` stores all metadata needed to recover a JobManager failure.

--- a/docs/content/docs/deployment/ha/kubernetes_ha.md
+++ b/docs/content/docs/deployment/ha/kubernetes_ha.md
@@ -55,7 +55,7 @@ high-availability: org.apache.flink.kubernetes.highavailability.KubernetesHaServ
 JobManager metadata is persisted in the file system `high-availability.storageDir` and only a pointer to this state is stored in Kubernetes.
 
 ```yaml
-high-availability.storageDir: s3:///flink/recovery
+high-availability.storageDir: s3://flink/recovery
 ```
 
 The `storageDir` stores all metadata needed to recover a JobManager failure.


### PR DESCRIPTION
Backport of #17016 to `release-1.13`.