### PR TITLE
[BP-1.12][FLINK-23945][docs] Correct S3 URI in K8s ha documentation

### DIFF
--- a/docs/deployment/ha/kubernetes_ha.md
+++ b/docs/deployment/ha/kubernetes_ha.md
@@ -58,7 +58,7 @@ The `high-availability` option has to be set to `KubernetesHaServicesFactory`.
 - [high-availability.storageDir]({% link deployment/config.md %}#high-availability-storagedir) (required): 
 JobManager metadata is persisted in the file system `high-availability.storageDir` and only a pointer to this state is stored in Kubernetes.
 
-  <pre>high-availability.storageDir: s3:///flink/recovery</pre>
+  <pre>high-availability.storageDir: s3://flink/recovery</pre>
 
   The `storageDir` stores all metadata needed to recover a JobManager failure.
   

--- a/docs/deployment/ha/kubernetes_ha.zh.md
+++ b/docs/deployment/ha/kubernetes_ha.zh.md
@@ -51,7 +51,7 @@ The `high-availability` option has to be set to `KubernetesHaServicesFactory`.
 - [high-availability.storageDir]({% link deployment/config.zh.md %}#high-availability-storagedir) (required): 
 JobManager metadata is persisted in the file system `high-availability.storageDir` and only a pointer to this state is stored in Kubernetes.
 
-  <pre>high-availability.storageDir: s3:///flink/recovery</pre>
+  <pre>high-availability.storageDir: s3://flink/recovery</pre>
 
   The `storageDir` stores all metadata needed to recover a JobManager failure.
   


### PR DESCRIPTION
Backport of #17016 to `release-1.12`.