### PR TITLE
[FLINK-23457][network] The upstream sends the buffer of the right size for broadcast case

### DIFF
--- a/flink-runtime/src/main/java/org/apache/flink/runtime/io/network/partition/BufferWritingResultPartition.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/io/network/partition/BufferWritingResultPartition.java
@@ -332,7 +332,6 @@ public abstract class BufferWritingResultPartition extends ResultPartition {
         try (final BufferConsumer consumer = buffer.createBufferConsumerFromBeginning()) {
             int desirableBufferSize = Integer.MAX_VALUE;
             for (ResultSubpartition subpartition : subpartitions) {
-                subpartition.add(consumer.copy(), partialRecordBytes);
                 int subPartitionBufferSize = subpartition.add(consumer.copy(), partialRecordBytes);
                 desirableBufferSize =
                         subPartitionBufferSize > 0

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/io/network/partition/BufferWritingResultPartition.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/io/network/partition/BufferWritingResultPartition.java
@@ -330,9 +330,16 @@ public abstract class BufferWritingResultPartition extends ResultPartition {
     private void createBroadcastBufferConsumers(BufferBuilder buffer, int partialRecordBytes)
             throws IOException {
         try (final BufferConsumer consumer = buffer.createBufferConsumerFromBeginning()) {
+            int desirableBufferSize = Integer.MAX_VALUE;
             for (ResultSubpartition subpartition : subpartitions) {
                 subpartition.add(consumer.copy(), partialRecordBytes);
+                int subPartitionBufferSize = subpartition.add(consumer.copy(), partialRecordBytes);
+                desirableBufferSize =
+                        subPartitionBufferSize > 0
+                                ? Math.min(desirableBufferSize, subPartitionBufferSize)
+                                : desirableBufferSize;
             }
+            buffer.trim(desirableBufferSize);
         }
     }
 


### PR DESCRIPTION
## What is the purpose of the change

*This PR fit NewBufferSize in broadcast case*


## Brief change log
  - *Support create  broadcast buffer consumers with desirable size*


## Verifying this change

- *Added unit tests for each classes which behaviour was changed*

## Does this pull request potentially affect one of the following parts:

  - Dependencies (does it add or upgrade a dependency): ( no)
  - The public API, i.e., is any changed class annotated with `@Public(Evolving)`: (no)
  - The serializers: (no)
  - The runtime per-record code paths (performance sensitive): (no)
  - Anything that affects deployment or recovery: JobManager (and its components), Checkpointing, Kubernetes/Yarn, ZooKeeper: (no)
  - The S3 file system connector: (no)

## Documentation

  - Does this pull request introduce a new feature? (no)
  - If yes, how is the feature documented? (not applicable / docs / JavaDocs / not documented)
