### PR TITLE
[FLINK-23954][tests] Fix e2e test test_queryable_state_restart_tm.sh 

### DIFF
--- a/flink-queryable-state/flink-queryable-state-client-java/src/main/java/org/apache/flink/queryablestate/client/state/serialization/KvStateSerializer.java
+++ b/flink-queryable-state/flink-queryable-state-client-java/src/main/java/org/apache/flink/queryablestate/client/state/serialization/KvStateSerializer.java
@@ -23,9 +23,6 @@ import org.apache.flink.api.java.tuple.Tuple2;
 import org.apache.flink.core.memory.DataInputDeserializer;
 import org.apache.flink.core.memory.DataOutputSerializer;
 
-import org.slf4j.Logger;
-import org.slf4j.LoggerFactory;
-
 import java.io.IOException;
 import java.nio.ByteBuffer;
 import java.util.ArrayList;
@@ -35,7 +32,6 @@ import java.util.Map;
 
 /** Serialization and deserialization the different state types and namespaces. */
 public final class KvStateSerializer {
-    private static final Logger LOG = LoggerFactory.getLogger(KvStateSerializer.class);
 
     // The magic number is as a flag between key and namespace.
     private static final int MAGIC_NUMBER = 42;
@@ -229,7 +225,6 @@ public final class KvStateSerializer {
             // Serialize
             DataOutputSerializer dos = new DataOutputSerializer(32);
 
-            int size = 0;
             for (Map.Entry<UK, UV> entry : entries) {
                 keySerializer.serialize(entry.getKey(), dos);
 
@@ -239,11 +234,7 @@ public final class KvStateSerializer {
                     dos.writeBoolean(false);
                     valueSerializer.serialize(entry.getValue(), dos);
                 }
-
-                size++;
             }
-
-            LOG.debug("Serialized map has {} entries.", size);
 
             return dos.getCopyOfBuffer();
         } else {

--- a/tools/ci/log4j.properties
+++ b/tools/ci/log4j.properties
@@ -59,7 +59,3 @@ logger.yarn1.appenderRef.out.ref = ConsoleAppender
 logger.yarn2.name = org.apache.flink.yarn.YARNSessionCapacitySchedulerITCase
 logger.yarn2.level = INFO
 logger.yarn2.appenderRef.out.ref = ConsoleAppender
-
-# debug information for queryable state
-logger.qs.name = org.apache.flink.queryablestate.client.state.serialization.KvStateSerializer
-logger.qs.level = DEBUG


### PR DESCRIPTION
The problem was that we output the number of state entries at the time when the checkpoint
is confirmed. However, at this point in time we might have already added more elements to
the map. Hence, we risk reporting more elements than are actually contained in the checkpoint.
The solution is to remember what the element count was when creating the checkpoint.