### PR TITLE
[FLINK-24035][network] Notify the buffer listeners when the local buffer pool receives available notification from the global pool

### DIFF
--- a/flink-runtime/src/main/java/org/apache/flink/runtime/io/network/buffer/BufferListener.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/io/network/buffer/BufferListener.java
@@ -24,27 +24,6 @@ package org.apache.flink.runtime.io.network.buffer;
  */
 public interface BufferListener {
 
-    /** Status of the notification result from the buffer listener. */
-    enum NotificationResult {
-        BUFFER_NOT_USED(false),
-        BUFFER_USED(true);
-
-        private final boolean isBufferUsed;
-
-        NotificationResult(boolean isBufferUsed) {
-            this.isBufferUsed = isBufferUsed;
-        }
-
-        /**
-         * Whether the notified buffer is accepted to use by the listener.
-         *
-         * @return <tt>true</tt> if the notified buffer is accepted.
-         */
-        boolean isBufferUsed() {
-            return isBufferUsed;
-        }
-    }
-
     /**
      * Notification callback if a buffer is recycled and becomes available in buffer pool.
      *
@@ -59,9 +38,9 @@ public interface BufferListener {
      * stack!
      *
      * @param buffer buffer that becomes available in buffer pool.
-     * @return NotificationResult if the listener wants to be notified next time.
+     * @return true if the buffer is accepted by the listener.
      */
-    NotificationResult notifyBufferAvailable(Buffer buffer);
+    boolean notifyBufferAvailable(Buffer buffer);
 
     /** Notification callback if the buffer provider is destroyed. */
     void notifyBufferDestroyed();

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/io/network/buffer/BufferListener.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/io/network/buffer/BufferListener.java
@@ -26,16 +26,13 @@ public interface BufferListener {
 
     /** Status of the notification result from the buffer listener. */
     enum NotificationResult {
-        BUFFER_NOT_USED(false, false),
-        BUFFER_USED_NO_NEED_MORE(true, false),
-        BUFFER_USED_NEED_MORE(true, true);
+        BUFFER_NOT_USED(false),
+        BUFFER_USED(true);
 
         private final boolean isBufferUsed;
-        private final boolean needsMoreBuffers;
 
-        NotificationResult(boolean isBufferUsed, boolean needsMoreBuffers) {
+        NotificationResult(boolean isBufferUsed) {
             this.isBufferUsed = isBufferUsed;
-            this.needsMoreBuffers = needsMoreBuffers;
         }
 
         /**
@@ -46,22 +43,14 @@ public interface BufferListener {
         boolean isBufferUsed() {
             return isBufferUsed;
         }
-
-        /**
-         * Whether the listener still needs more buffers to be notified.
-         *
-         * @return <tt>true</tt> if the listener is still waiting for more buffers.
-         */
-        boolean needsMoreBuffers() {
-            return needsMoreBuffers;
-        }
     }
 
     /**
      * Notification callback if a buffer is recycled and becomes available in buffer pool.
      *
-     * <p>Note: responsibility on recycling the given buffer is transferred to this implementation,
-     * including any errors that lead to exceptions being thrown!
+     * <p>Note: 1) Responsibility on recycling the given buffer is transferred to this
+     * implementation, including any errors that lead to exceptions being thrown! 2) The listener
+     * must register itself again if it needs still need more buffers.
      *
      * <p><strong>BEWARE:</strong> since this may be called from outside the thread that relies on
      * the listener's logic, any exception that occurs with this handler should be forwarded to the

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/io/network/buffer/LocalBufferPool.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/io/network/buffer/LocalBufferPool.java
@@ -19,7 +19,6 @@
 package org.apache.flink.runtime.io.network.buffer;
 
 import org.apache.flink.core.memory.MemorySegment;
-import org.apache.flink.runtime.io.network.buffer.BufferListener.NotificationResult;
 import org.apache.flink.util.ExceptionUtils;
 
 import org.slf4j.Logger;
@@ -495,12 +494,12 @@ class LocalBufferPool implements BufferPool {
 
                 checkConsistentAvailability();
             }
-        } while (!fireBufferAvailableNotification(listener, segment).isBufferUsed());
+        } while (!fireBufferAvailableNotification(listener, segment));
 
         mayNotifyAvailable(toNotify);
     }
 
-    private NotificationResult fireBufferAvailableNotification(
+    private boolean fireBufferAvailableNotification(
             BufferListener listener, MemorySegment segment) {
         // We do not know which locks have been acquired before the recycle() or are needed in the
         // notification and which other threads also access them.

--- a/flink-runtime/src/test/java/org/apache/flink/runtime/io/network/buffer/LocalBufferPoolTest.java
+++ b/flink-runtime/src/test/java/org/apache/flink/runtime/io/network/buffer/LocalBufferPoolTest.java
@@ -537,10 +537,10 @@ public class LocalBufferPoolTest extends TestLogger {
         private final AtomicInteger times = new AtomicInteger(0);
 
         @Override
-        public NotificationResult notifyBufferAvailable(Buffer buffer) {
+        public boolean notifyBufferAvailable(Buffer buffer) {
             times.incrementAndGet();
             buffer.recycleBuffer();
-            return NotificationResult.BUFFER_USED;
+            return true;
         }
 
         @Override

--- a/flink-runtime/src/test/java/org/apache/flink/runtime/io/network/partition/consumer/RemoteInputChannelTest.java
+++ b/flink-runtime/src/test/java/org/apache/flink/runtime/io/network/partition/consumer/RemoteInputChannelTest.java
@@ -584,8 +584,8 @@ public class RemoteInputChannelTest {
 
             // Assign the floating buffer to the listener and the channel is still waiting for more
             // floating buffers
-            verify(bufferPool, times(15)).requestBuffer();
-            verify(bufferPool, times(1)).addBufferListener(inputChannel.getBufferManager());
+            verify(bufferPool, times(16)).requestBuffer();
+            verify(bufferPool, times(2)).addBufferListener(inputChannel.getBufferManager());
             assertEquals(
                     "There should be 15 buffers available in the channel",
                     15,
@@ -604,8 +604,8 @@ public class RemoteInputChannelTest {
             inputChannel.onSenderBacklog(13);
 
             // Only the number of required buffers is changed by (backlog + numExclusiveBuffers)
-            verify(bufferPool, times(15)).requestBuffer();
-            verify(bufferPool, times(1)).addBufferListener(inputChannel.getBufferManager());
+            verify(bufferPool, times(16)).requestBuffer();
+            verify(bufferPool, times(2)).addBufferListener(inputChannel.getBufferManager());
             assertEquals(
                     "There should be 15 buffers available in the channel",
                     15,
@@ -625,8 +625,8 @@ public class RemoteInputChannelTest {
 
             // Return the floating buffer to the buffer pool and the channel is not waiting for more
             // floating buffers
-            verify(bufferPool, times(15)).requestBuffer();
-            verify(bufferPool, times(1)).addBufferListener(inputChannel.getBufferManager());
+            verify(bufferPool, times(16)).requestBuffer();
+            verify(bufferPool, times(2)).addBufferListener(inputChannel.getBufferManager());
             assertEquals(
                     "There should be 15 buffers available in the channel",
                     15,
@@ -646,8 +646,8 @@ public class RemoteInputChannelTest {
 
             // The floating buffer is requested from the buffer pool and the channel is registered
             // as listener again.
-            verify(bufferPool, times(17)).requestBuffer();
-            verify(bufferPool, times(2)).addBufferListener(inputChannel.getBufferManager());
+            verify(bufferPool, times(18)).requestBuffer();
+            verify(bufferPool, times(3)).addBufferListener(inputChannel.getBufferManager());
             assertEquals(
                     "There should be 16 buffers available in the channel",
                     16,

--- a/flink-tests/src/test/java/org/apache/flink/test/checkpointing/UnalignedCheckpointTestBase.java
+++ b/flink-tests/src/test/java/org/apache/flink/test/checkpointing/UnalignedCheckpointTestBase.java
@@ -75,6 +75,7 @@ import org.junit.Rule;
 import org.junit.experimental.categories.Category;
 import org.junit.rules.ErrorCollector;
 import org.junit.rules.TemporaryFolder;
+import org.junit.rules.TestName;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
@@ -120,6 +121,8 @@ public abstract class UnalignedCheckpointTestBase extends TestLogger {
 
     @Rule public ErrorCollector collector = new ErrorCollector();
 
+    @Rule public TestName name = new TestName();
+
     @Nullable
     protected File execute(UnalignedSettings settings) throws Exception {
         final File checkpointDir = temp.newFolder();
@@ -150,6 +153,9 @@ public abstract class UnalignedCheckpointTestBase extends TestLogger {
                 StreamExecutionEnvironment.getExecutionEnvironment(conf);
         settings.configure(env);
         try {
+            // print the test parameters to help debugging when the case is stuck
+            System.out.println(
+                    "Starting " + getClass().getCanonicalName() + "#" + name.getMethodName() + ".");
             waitForCleanShutdown();
             final CompletableFuture<JobSubmissionResult> result =
                     miniCluster.getMiniCluster().submitJob(streamGraph.getJobGraph());
@@ -160,6 +166,8 @@ public abstract class UnalignedCheckpointTestBase extends TestLogger {
                             .requestJobResult(result.get().getJobID())
                             .get()
                             .toJobExecutionResult(getClass().getClassLoader()));
+            System.out.println(
+                    "Finished " + getClass().getCanonicalName() + "#" + name.getMethodName() + ".");
         } catch (Exception e) {
             if (!ExceptionUtils.findThrowable(e, TestException.class).isPresent()) {
                 throw e;


### PR DESCRIPTION
## What is the purpose of the change
    
    Previously, The buffer listeners are not notified when the the local buffer pool receives available notification from the global pool. This may cause potential deadlock issue:
    
    1. A LocalBufferPool is created but there is no available buffers in the global NetworkBufferPool.
    2. The LocalBufferPool registers an available buffer listener to the global NetworkBufferPool.
    3. The BufferManager requests buffers from the LocalBufferPool but no buffer is available. As a result, it registers an available buffer listener to the LocalBufferPool.
    4. A buffer is recycled to the global NetworkBufferPool and the LocalBufferPool is notified about the available buffer.
    5. The LocalBufferPool requests the available buffer from the global NetworkBufferPool but the registered available buffer listener of BufferManager is not notified and it can never get a chance to be notified so deadlock occurs.
    
    This patch fixes this issue by notifying the buffer listeners when the local buffer pool receives available notification from the global pool.


## Brief change log

  - Notify the buffer listeners when the local buffer pool receives available notification from the global pool.


## Verifying this change

This change added tests.

## Does this pull request potentially affect one of the following parts:

  - Dependencies (does it add or upgrade a dependency): (yes / **no**)
  - The public API, i.e., is any changed class annotated with `@Public(Evolving)`: (yes / **no**)
  - The serializers: (yes / **no** / don't know)
  - The runtime per-record code paths (performance sensitive): (yes / **no** / don't know)
  - Anything that affects deployment or recovery: JobManager (and its components), Checkpointing, Kubernetes/Yarn, ZooKeeper: (yes / **no** / don't know)
  - The S3 file system connector: (yes / **no** / don't know)

## Documentation

  - Does this pull request introduce a new feature? (yes / **no**)
  - If yes, how is the feature documented? (**not applicable** / docs / JavaDocs / not documented)
