### PR TITLE
[hotfix] WIP: Remove redundant scala suffix

### DIFF
--- a/flink-clients/pom.xml
+++ b/flink-clients/pom.xml
@@ -30,7 +30,7 @@ under the License.
 		<relativePath>..</relativePath>
 	</parent>
 
-	<artifactId>flink-clients_${scala.binary.version}</artifactId>
+	<artifactId>flink-clients</artifactId>
 	<name>Flink : Clients</name>
 
 	<packaging>jar</packaging>
@@ -85,7 +85,7 @@ under the License.
 
 		<dependency>
 			<groupId>org.apache.flink</groupId>
-			<artifactId>flink-streaming-java_${scala.binary.version}</artifactId>
+			<artifactId>flink-streaming-java</artifactId>
 			<version>${project.version}</version>
 		</dependency>
 

--- a/flink-kubernetes/pom.xml
+++ b/flink-kubernetes/pom.xml
@@ -27,7 +27,7 @@ under the License.
 		<relativePath>..</relativePath>
 	</parent>
 
-	<artifactId>flink-kubernetes_${scala.binary.version}</artifactId>
+	<artifactId>flink-kubernetes</artifactId>
 	<name>Flink : Kubernetes</name>
 	<packaging>jar</packaging>
 
@@ -41,7 +41,7 @@ under the License.
 
 		<dependency>
 			<groupId>org.apache.flink</groupId>
-			<artifactId>flink-clients_${scala.binary.version}</artifactId>
+			<artifactId>flink-clients</artifactId>
 			<version>${project.version}</version>
 			<scope>provided</scope>
 		</dependency>
@@ -90,7 +90,7 @@ under the License.
 
 		<dependency>
 			<groupId>org.apache.flink</groupId>
-			<artifactId>flink-clients_${scala.binary.version}</artifactId>
+			<artifactId>flink-clients</artifactId>
 			<version>${project.version}</version>
 			<type>test-jar</type>
 			<scope>test</scope>
@@ -98,7 +98,7 @@ under the License.
 
 		<dependency>
 			<groupId>org.apache.flink</groupId>
-			<artifactId>flink-test-utils_${scala.binary.version}</artifactId>
+			<artifactId>flink-test-utils</artifactId>
 			<version>${project.version}</version>
 			<scope>test</scope>
 		</dependency>

--- a/flink-streaming-java/pom.xml
+++ b/flink-streaming-java/pom.xml
@@ -29,7 +29,7 @@ under the License.
 		<relativePath>..</relativePath>
 	</parent>
 
-	<artifactId>flink-streaming-java_${scala.binary.version}</artifactId>
+	<artifactId>flink-streaming-java</artifactId>
 	<name>Flink : Streaming Java</name>
 
 	<packaging>jar</packaging>
@@ -53,13 +53,6 @@ under the License.
 		<dependency>
 			<groupId>org.apache.flink</groupId>
 			<artifactId>flink-runtime</artifactId>
-			<version>${project.version}</version>
-		</dependency>
-
-		<dependency>
-			<!-- Provides the kryo serializer -->
-			<groupId>org.apache.flink</groupId>
-			<artifactId>flink-scala_${scala.binary.version}</artifactId>
 			<version>${project.version}</version>
 		</dependency>
 

--- a/flink-streaming-java/src/main/java/org/apache/flink/streaming/util/typeutils/FieldAccessor.java
+++ b/flink-streaming-java/src/main/java/org/apache/flink/streaming/util/typeutils/FieldAccessor.java
@@ -99,7 +99,6 @@ public abstract class FieldAccessor<T, F> implements Serializable {
      * Gets the value of the field (specified in the constructor) of the given record.
      *
      * @param record The record on which the field will be accessed
-     *
      * @return The value of the field.
      */
     public abstract F get(T record);
@@ -112,9 +111,8 @@ public abstract class FieldAccessor<T, F> implements Serializable {
      *
      * @param record The record to modify
      * @param fieldValue The new value of the field
-     *
      * @return A record that has the given field value. (this might be a new instance or the
-     *         original)
+     *     original)
      */
     public abstract T set(T record, F fieldValue);
 
@@ -288,7 +286,8 @@ public abstract class FieldAccessor<T, F> implements Serializable {
         @Override
         public F get(T pojo) {
             try {
-                @SuppressWarnings("unchecked") final R inner = (R) field.get(pojo);
+                @SuppressWarnings("unchecked")
+                final R inner = (R) field.get(pojo);
                 return innerAccessor.get(inner);
             } catch (IllegalAccessException iaex) {
                 // The Field class is transient and when deserializing its value we also make it
@@ -305,7 +304,8 @@ public abstract class FieldAccessor<T, F> implements Serializable {
         @Override
         public T set(T pojo, F valueToSet) {
             try {
-                @SuppressWarnings("unchecked") final R inner = (R) field.get(pojo);
+                @SuppressWarnings("unchecked")
+                final R inner = (R) field.get(pojo);
                 field.set(pojo, innerAccessor.set(inner, valueToSet));
                 return pojo;
             } catch (IllegalAccessException iaex) {

--- a/flink-test-utils-parent/flink-test-utils/pom.xml
+++ b/flink-test-utils-parent/flink-test-utils/pom.xml
@@ -29,7 +29,7 @@ under the License.
 		<relativePath>..</relativePath>
 	</parent>
 
-	<artifactId>flink-test-utils_${scala.binary.version}</artifactId>
+	<artifactId>flink-test-utils</artifactId>
 	<name>Flink : Test utils : Utils</name>
 
 	<packaging>jar</packaging>
@@ -59,14 +59,14 @@ under the License.
 
 		<dependency>
 			<groupId>org.apache.flink</groupId>
-			<artifactId>flink-clients_${scala.binary.version}</artifactId>
+			<artifactId>flink-clients</artifactId>
 			<version>${project.version}</version>
 			<scope>compile</scope>
 		</dependency>
 
 		<dependency>
 			<groupId>org.apache.flink</groupId>
-			<artifactId>flink-streaming-java_${scala.binary.version}</artifactId>
+			<artifactId>flink-streaming-java</artifactId>
 			<version>${project.version}</version>
 			<scope>compile</scope>
 		</dependency>


### PR DESCRIPTION
## What is the purpose of the change

After flink-runtime becomes scala free. It seems several other modules can get rid of scala suffix. Trying to verify it.

## Brief change log

* Remove flink-scala dep from flink-streaming-java which seems not into use.
* Remove scala suffix for
  * flink-streaming-java
  * flink-client
  * flink-test-util
  * flink-kubernetes

## Verifying this change

If and only if codebase compiled and all existing tests passed.

## Does this pull request potentially affect one of the following parts:

  - Dependencies (does it add or upgrade a dependency): (yes)
  - The public API, i.e., is any changed class annotated with `@Public(Evolving)`: (no)
  - The serializers: (no)
  - The runtime per-record code paths (performance sensitive): (no)
  - Anything that affects deployment or recovery: JobManager (and its components), Checkpointing, Kubernetes/Yarn, ZooKeeper: (no)
  - The S3 file system connector: (no)

## Documentation

  - Does this pull request introduce a new feature? (no)
  - If yes, how is the feature documented? (not applicable)
