### PR TITLE
[FLINK-24035][network] Guarantee that the LocalBufferPool is initialized with one buffer

### DIFF
--- a/flink-runtime/src/main/java/org/apache/flink/runtime/io/network/buffer/NetworkBufferPool.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/io/network/buffer/NetworkBufferPool.java
@@ -156,6 +156,10 @@ public class NetworkBufferPool
         }
     }
 
+    public MemorySegment requestMemorySegmentBlocking() throws IOException {
+        return internalRequestMemorySegments(1).get(0);
+    }
+
     public void recycle(MemorySegment segment) {
         // Adds the segment back to the queue, which does not immediately free the memory
         // however, since this happens when references to the global pool are also released,
@@ -182,6 +186,11 @@ public class NetworkBufferPool
             tryRedistributeBuffers(numberOfSegmentsToRequest);
         }
 
+        return internalRequestMemorySegments(numberOfSegmentsToRequest);
+    }
+
+    private List<MemorySegment> internalRequestMemorySegments(int numberOfSegmentsToRequest)
+            throws IOException {
         final List<MemorySegment> segments = new ArrayList<>(numberOfSegmentsToRequest);
         try {
             final Deadline deadline = Deadline.fromNow(requestSegmentsTimeout);

--- a/flink-runtime/src/test/java/org/apache/flink/runtime/io/network/buffer/LocalBufferPoolDestroyTest.java
+++ b/flink-runtime/src/test/java/org/apache/flink/runtime/io/network/buffer/LocalBufferPoolDestroyTest.java
@@ -41,7 +41,7 @@ public class LocalBufferPoolDestroyTest {
      * and we check whether the request Thread threw the expected Exception.
      */
     @Test
-    public void testDestroyWhileBlockingRequest() throws InterruptedException {
+    public void testDestroyWhileBlockingRequest() throws Exception {
         AtomicReference<Exception> asyncException = new AtomicReference<>();
 
         NetworkBufferPool networkBufferPool = null;


### PR DESCRIPTION
## What is the purpose of the change

Previously, The buffer listeners are not notified when the the local buffer pool receives available notification from the global pool. This may cause potential deadlock issue:
    
    1. A LocalBufferPool is created but there is no available buffers in the global NetworkBufferPool.
    2. The LocalBufferPool registers an available buffer listener to the global NetworkBufferPool.
    3. The BufferManager requests buffers from the LocalBufferPool but no buffer is available. As a result, it registers an available buffer listener to the LocalBufferPool.
    4. A buffer is recycled to the global NetworkBufferPool and the LocalBufferPool is notified about the available buffer.
    5. The LocalBufferPool requests the available buffer from the global NetworkBufferPool but the registered available buffer listener of BufferManager is not notified and it can never get a chance to be notified so deadlock occurs.
    
    This patch fixes this issue by guaranteeing that the LocalBufferPool is initialized with one buffer. With this piece of guaranteed buffer, the LocalBufferPool will be in the healthy buffer request and recycle loop. Note: We are not fixing this issue by notifying the buffer listeners when the local buffer pool receives available notification from the global pool because of the potential deadlock.


## Brief change log

  - Guarantee that the LocalBufferPool is initialized with one buffer.

## Verifying this change

This change added tests.

## Does this pull request potentially affect one of the following parts:

  - Dependencies (does it add or upgrade a dependency): (yes / **no**)
  - The public API, i.e., is any changed class annotated with `@Public(Evolving)`: (yes / **no**)
  - The serializers: (yes / **no** / don't know)
  - The runtime per-record code paths (performance sensitive): (yes / **no** / don't know)
  - Anything that affects deployment or recovery: JobManager (and its components), Checkpointing, Kubernetes/Yarn, ZooKeeper: (yes / **no** / don't know)
  - The S3 file system connector: (yes / **no** / don't know)

## Documentation

  - Does this pull request introduce a new feature? (yes / **no**)
  - If yes, how is the feature documented? (**not applicable** / docs / JavaDocs / not documented)
