### PR TITLE
[FLINK-24024][table-planner] Fix syntax mistake in session Window TVF

### DIFF
--- a/flink-table/flink-table-planner/src/main/java/org/apache/flink/table/planner/plan/logical/CumulativeWindowSpec.java
+++ b/flink-table/flink-table-planner/src/main/java/org/apache/flink/table/planner/plan/logical/CumulativeWindowSpec.java
@@ -60,7 +60,7 @@ public class CumulativeWindowSpec implements WindowSpec {
     }
 
     @Override
-    public String toSummaryString(String windowing) {
+    public String toSummaryString(String windowing, String[] inputFieldNames) {
         if (offset == null) {
             return String.format(
                     "CUMULATE(%s, max_size=[%s], step=[%s])",

--- a/flink-table/flink-table-planner/src/main/java/org/apache/flink/table/planner/plan/logical/HoppingWindowSpec.java
+++ b/flink-table/flink-table-planner/src/main/java/org/apache/flink/table/planner/plan/logical/HoppingWindowSpec.java
@@ -60,7 +60,7 @@ public class HoppingWindowSpec implements WindowSpec {
     }
 
     @Override
-    public String toSummaryString(String windowing) {
+    public String toSummaryString(String windowing, String[] inputFieldNames) {
         if (offset == null) {
             return String.format(
                     "HOP(%s, size=[%s], slide=[%s])",

--- a/flink-table/flink-table-planner/src/main/java/org/apache/flink/table/planner/plan/logical/SliceAttachedWindowingStrategy.java
+++ b/flink-table/flink-table-planner/src/main/java/org/apache/flink/table/planner/plan/logical/SliceAttachedWindowingStrategy.java
@@ -54,7 +54,7 @@ public class SliceAttachedWindowingStrategy extends WindowingStrategy {
     public String toSummaryString(String[] inputFieldNames) {
         checkArgument(sliceEnd < inputFieldNames.length);
         String windowing = String.format("slice_end=[%s]", inputFieldNames[sliceEnd]);
-        return window.toSummaryString(windowing);
+        return window.toSummaryString(windowing, inputFieldNames);
     }
 
     public int getSliceEnd() {

--- a/flink-table/flink-table-planner/src/main/java/org/apache/flink/table/planner/plan/logical/TimeAttributeWindowingStrategy.java
+++ b/flink-table/flink-table-planner/src/main/java/org/apache/flink/table/planner/plan/logical/TimeAttributeWindowingStrategy.java
@@ -47,7 +47,7 @@ public class TimeAttributeWindowingStrategy extends WindowingStrategy {
     public String toSummaryString(String[] inputFieldNames) {
         checkArgument(timeAttributeIndex >= 0 && timeAttributeIndex < inputFieldNames.length);
         String windowing = String.format("time_col=[%s]", inputFieldNames[timeAttributeIndex]);
-        return window.toSummaryString(windowing);
+        return window.toSummaryString(windowing, inputFieldNames);
     }
 
     public int getTimeAttributeIndex() {

--- a/flink-table/flink-table-planner/src/main/java/org/apache/flink/table/planner/plan/logical/TumblingWindowSpec.java
+++ b/flink-table/flink-table-planner/src/main/java/org/apache/flink/table/planner/plan/logical/TumblingWindowSpec.java
@@ -54,7 +54,7 @@ public class TumblingWindowSpec implements WindowSpec {
     }
 
     @Override
-    public String toSummaryString(String windowing) {
+    public String toSummaryString(String windowing, String[] inputFieldNames) {
         if (offset == null) {
             return String.format("TUMBLE(%s, size=[%s])", windowing, formatWithHighestUnit(size));
         } else {

--- a/flink-table/flink-table-planner/src/main/java/org/apache/flink/table/planner/plan/logical/WindowAttachedWindowingStrategy.java
+++ b/flink-table/flink-table-planner/src/main/java/org/apache/flink/table/planner/plan/logical/WindowAttachedWindowingStrategy.java
@@ -77,7 +77,7 @@ public class WindowAttachedWindowingStrategy extends WindowingStrategy {
                             "win_start=[%s], win_end=[%s]",
                             inputFieldNames[windowStart], inputFieldNames[windowEnd]);
         }
-        return window.toSummaryString(windowing);
+        return window.toSummaryString(windowing, inputFieldNames);
     }
 
     public int getWindowStart() {

--- a/flink-table/flink-table-planner/src/main/java/org/apache/flink/table/planner/plan/logical/WindowSpec.java
+++ b/flink-table/flink-table-planner/src/main/java/org/apache/flink/table/planner/plan/logical/WindowSpec.java
@@ -31,5 +31,5 @@ import org.apache.flink.shaded.jackson2.com.fasterxml.jackson.annotation.JsonTyp
 })
 public interface WindowSpec {
 
-    String toSummaryString(String windowing);
+    String toSummaryString(String windowing, String[] inputFieldNames);
 }

--- a/flink-table/flink-table-planner/src/main/java/org/apache/flink/table/planner/plan/rules/logical/ProjectWindowTableFunctionTransposeRule.java
+++ b/flink-table/flink-table-planner/src/main/java/org/apache/flink/table/planner/plan/rules/logical/ProjectWindowTableFunctionTransposeRule.java
@@ -20,6 +20,7 @@ package org.apache.flink.table.planner.plan.rules.logical;
 
 import org.apache.flink.table.planner.calcite.FlinkTypeFactory;
 import org.apache.flink.table.planner.functions.sql.SqlWindowTableFunction;
+import org.apache.flink.table.planner.plan.logical.SessionWindowSpec;
 import org.apache.flink.table.planner.plan.logical.TimeAttributeWindowingStrategy;
 import org.apache.flink.table.planner.plan.utils.WindowUtil;
 import org.apache.flink.table.types.logical.LogicalType;
@@ -86,6 +87,13 @@ public class ProjectWindowTableFunctionTransposeRule extends RelOptRule {
                 ImmutableBitSet.range(0, scanInputFieldCount)
                         .intersect(projectFields)
                         .set(windowingStrategy.getTimeAttributeIndex());
+        if (windowingStrategy.getWindow() instanceof SessionWindowSpec) {
+            SessionWindowSpec sessionWindowSpec = (SessionWindowSpec) windowingStrategy.getWindow();
+            int[] partitionKeyIndices = sessionWindowSpec.getPartitionKeyIndices();
+            for (int partitionKeyIndex : partitionKeyIndices) {
+                toPushFields = toPushFields.set(partitionKeyIndex);
+            }
+        }
         if (toPushFields.cardinality() == scanInputFieldCount) {
             return;
         }

--- a/flink-table/flink-table-planner/src/main/scala/org/apache/flink/table/planner/plan/rules/physical/stream/ExpandWindowTableFunctionTransposeRule.scala
+++ b/flink-table/flink-table-planner/src/main/scala/org/apache/flink/table/planner/plan/rules/physical/stream/ExpandWindowTableFunctionTransposeRule.scala
@@ -129,7 +129,7 @@ class ExpandWindowTableFunctionTransposeRule
     //  1. transpose Calc and WindowTVF, build the new Calc node (the top node)
     // -------------------------------------------------------------------------
     val windowColumns = fmq.getRelWindowProperties(windowTVF).getWindowColumns
-    val (newProgram, fieldShifting, newTimeField, timeFieldAdded) =
+    val (newProgram, fieldShifting, newTimeField, timeFieldAdded, _, _) =
       buildNewProgramWithoutWindowColumns(
         cluster.getRexBuilder,
         calc.getProgram,

--- a/flink-table/flink-table-planner/src/test/resources/org/apache/flink/table/planner/plan/stream/sql/WindowRankTest.xml
+++ b/flink-table/flink-table-planner/src/test/resources/org/apache/flink/table/planner/plan/stream/sql/WindowRankTest.xml
@@ -146,7 +146,12 @@ FROM (
     max(d) filter (where b > 1000) as max_d,
     weightedAvg(b, e) AS wAvg,
     count(distinct c) AS uv
-  FROM TABLE(SESSION(TABLE MyTable, DESCRIPTOR(rowtime), INTERVAL '15' MINUTE))
+  FROM TABLE(
+    SESSION(
+      TABLE MyTable,
+      DESCRIPTOR(rowtime),
+      DESCRIPTOR(a),
+      INTERVAL '15' MINUTE))
   GROUP BY a, window_start, window_end, window_time
   )
 )
@@ -160,7 +165,7 @@ LogicalProject(window_start=[$1], window_end=[$2], window_time=[$3], a=[$0], cnt
    +- LogicalProject(a=[$0], window_start=[$1], window_end=[$2], window_time=[$3], cnt=[$4], sum_d=[$5], max_d=[$6], wAvg=[$7], uv=[$8], rownum=[ROW_NUMBER() OVER (PARTITION BY $1, $2 ORDER BY $4 DESC NULLS LAST)])
       +- LogicalAggregate(group=[{0, 1, 2, 3}], cnt=[COUNT()], sum_d=[SUM($4)], max_d=[MAX($4) FILTER $5], wAvg=[weightedAvg($6, $7)], uv=[COUNT(DISTINCT $8)])
          +- LogicalProject(a=[$0], window_start=[$7], window_end=[$8], window_time=[$9], d=[$3], $f5=[IS TRUE(>($1, 1000))], b=[$1], e=[$4], c=[$2])
-            +- LogicalTableFunctionScan(invocation=[SESSION($6, DESCRIPTOR($5), 900000:INTERVAL MINUTE)], rowType=[RecordType(INTEGER a, BIGINT b, VARCHAR(2147483647) c, DECIMAL(10, 3) d, BIGINT e, TIMESTAMP(3) *ROWTIME* rowtime, TIMESTAMP_LTZ(3) *PROCTIME* proctime, TIMESTAMP(3) window_start, TIMESTAMP(3) window_end, TIMESTAMP(3) *ROWTIME* window_time)])
+            +- LogicalTableFunctionScan(invocation=[SESSION($6, DESCRIPTOR($5), DESCRIPTOR($0), 900000:INTERVAL MINUTE)], rowType=[RecordType(INTEGER a, BIGINT b, VARCHAR(2147483647) c, DECIMAL(10, 3) d, BIGINT e, TIMESTAMP(3) *ROWTIME* rowtime, TIMESTAMP_LTZ(3) *PROCTIME* proctime, TIMESTAMP(3) window_start, TIMESTAMP(3) window_end, TIMESTAMP(3) *ROWTIME* window_time)])
                +- LogicalProject(a=[$0], b=[$1], c=[$2], d=[$3], e=[$4], rowtime=[$5], proctime=[$6])
                   +- LogicalWatermarkAssigner(rowtime=[rowtime], watermark=[-($5, 1000:INTERVAL SECOND)])
                      +- LogicalProject(a=[$0], b=[$1], c=[$2], d=[$3], e=[$4], rowtime=[$5], proctime=[PROCTIME()])
@@ -170,10 +175,10 @@ LogicalProject(window_start=[$1], window_end=[$2], window_time=[$3], a=[$0], cnt
     <Resource name="optimized rel plan">
       <![CDATA[
 Calc(select=[window_start, window_end, window_time, a, cnt, sum_d, max_d, wAvg, uv])
-+- WindowRank(window=[SESSION(win_start=[window_start], win_end=[window_end], gap=[15 min])], rankType=[ROW_NUMBER], rankRange=[rankStart=1, rankEnd=3], partitionBy=[], orderBy=[cnt DESC], select=[a, window_start, window_end, window_time, cnt, sum_d, max_d, wAvg, uv])
++- WindowRank(window=[SESSION(win_start=[window_start], win_end=[window_end], gap=[15 min], partition keys=[a])], rankType=[ROW_NUMBER], rankRange=[rankStart=1, rankEnd=3], partitionBy=[], orderBy=[cnt DESC], select=[a, window_start, window_end, window_time, cnt, sum_d, max_d, wAvg, uv])
    +- Exchange(distribution=[single])
       +- Calc(select=[a, window_start, window_end, window_time, cnt, sum_d, max_d, wAvg, uv])
-         +- WindowAggregate(groupBy=[a], window=[SESSION(time_col=[rowtime], gap=[15 min])], select=[a, COUNT(*) AS cnt, SUM(d) AS sum_d, MAX(d) FILTER $f5 AS max_d, weightedAvg(b, e) AS wAvg, COUNT(DISTINCT c) AS uv, start('w$) AS window_start, end('w$) AS window_end, rowtime('w$) AS window_time])
+         +- WindowAggregate(groupBy=[a], window=[SESSION(time_col=[rowtime], gap=[15 min], partition keys=[a])], select=[a, COUNT(*) AS cnt, SUM(d) AS sum_d, MAX(d) FILTER $f5 AS max_d, weightedAvg(b, e) AS wAvg, COUNT(DISTINCT c) AS uv, start('w$) AS window_start, end('w$) AS window_end, rowtime('w$) AS window_time])
             +- Exchange(distribution=[hash[a]])
                +- Calc(select=[a, d, IS TRUE(>(b, 1000)) AS $f5, b, e, c, rowtime])
                   +- WatermarkAssigner(rowtime=[rowtime], watermark=[-(rowtime, 1000:INTERVAL SECOND)])

--- a/flink-table/flink-table-planner/src/test/resources/org/apache/flink/table/planner/plan/stream/sql/agg/WindowAggregateTest.xml
+++ b/flink-table/flink-table-planner/src/test/resources/org/apache/flink/table/planner/plan/stream/sql/agg/WindowAggregateTest.xml
@@ -1595,7 +1595,11 @@ SELECT
    max(d) filter (where b > 1000),
    count(distinct c) AS uv
 FROM TABLE(
-  SESSION(TABLE MyTable, DESCRIPTOR(proctime), INTERVAL '5' MINUTE))
+  SESSION(
+    TABLE MyTable,
+    DESCRIPTOR(proctime),
+    DESCRIPTOR(a),
+    INTERVAL '5' MINUTE))
 GROUP BY a, window_start, window_end
       ]]>
     </Resource>
@@ -1603,7 +1607,7 @@ GROUP BY a, window_start, window_end
       <![CDATA[
 LogicalAggregate(group=[{0, 1, 2}], EXPR$3=[COUNT()], EXPR$4=[SUM($3)], EXPR$5=[MAX($3) FILTER $4], uv=[COUNT(DISTINCT $5)])
 +- LogicalProject(a=[$0], window_start=[$7], window_end=[$8], d=[$3], $f4=[IS TRUE(>($1, 1000))], c=[$2])
-   +- LogicalTableFunctionScan(invocation=[SESSION($6, DESCRIPTOR($6), 300000:INTERVAL MINUTE)], rowType=[RecordType(INTEGER a, BIGINT b, VARCHAR(2147483647) c, DECIMAL(10, 3) d, BIGINT e, TIMESTAMP(3) *ROWTIME* rowtime, TIMESTAMP_LTZ(3) *PROCTIME* proctime, TIMESTAMP(3) window_start, TIMESTAMP(3) window_end, TIMESTAMP_LTZ(3) *PROCTIME* window_time)])
+   +- LogicalTableFunctionScan(invocation=[SESSION($6, DESCRIPTOR($6), DESCRIPTOR($0), 300000:INTERVAL MINUTE)], rowType=[RecordType(INTEGER a, BIGINT b, VARCHAR(2147483647) c, DECIMAL(10, 3) d, BIGINT e, TIMESTAMP(3) *ROWTIME* rowtime, TIMESTAMP_LTZ(3) *PROCTIME* proctime, TIMESTAMP(3) window_start, TIMESTAMP(3) window_end, TIMESTAMP_LTZ(3) *PROCTIME* window_time)])
       +- LogicalProject(a=[$0], b=[$1], c=[$2], d=[$3], e=[$4], rowtime=[$5], proctime=[$6])
          +- LogicalWatermarkAssigner(rowtime=[rowtime], watermark=[-($5, 1000:INTERVAL SECOND)])
             +- LogicalProject(a=[$0], b=[$1], c=[$2], d=[$3], e=[$4], rowtime=[$5], proctime=[PROCTIME()])
@@ -1613,7 +1617,7 @@ LogicalAggregate(group=[{0, 1, 2}], EXPR$3=[COUNT()], EXPR$4=[SUM($3)], EXPR$5=[
     <Resource name="optimized rel plan">
       <![CDATA[
 Calc(select=[a, window_start, window_end, EXPR$3, EXPR$4, EXPR$5, uv])
-+- WindowAggregate(groupBy=[a], window=[SESSION(time_col=[proctime], gap=[5 min])], select=[a, COUNT(*) AS EXPR$3, SUM(d) AS EXPR$4, MAX(d) FILTER $f4 AS EXPR$5, COUNT(DISTINCT c) AS uv, start('w$) AS window_start, end('w$) AS window_end])
++- WindowAggregate(groupBy=[a], window=[SESSION(time_col=[proctime], gap=[5 min], partition keys=[a])], select=[a, COUNT(*) AS EXPR$3, SUM(d) AS EXPR$4, MAX(d) FILTER $f4 AS EXPR$5, COUNT(DISTINCT c) AS uv, start('w$) AS window_start, end('w$) AS window_end])
    +- Exchange(distribution=[hash[a]])
       +- Calc(select=[a, d, IS TRUE(>(b, 1000)) AS $f4, c, proctime])
          +- WatermarkAssigner(rowtime=[rowtime], watermark=[-(rowtime, 1000:INTERVAL SECOND)])
@@ -1634,7 +1638,11 @@ SELECT
    max(d) filter (where b > 1000),
    count(distinct c) AS uv
 FROM TABLE(
-  SESSION(TABLE MyTable, DESCRIPTOR(proctime), INTERVAL '5' MINUTE))
+  SESSION(
+    TABLE MyTable,
+    DESCRIPTOR(proctime),
+    DESCRIPTOR(a),
+    INTERVAL '5' MINUTE))
 GROUP BY a, window_start, window_end
       ]]>
     </Resource>
@@ -1642,7 +1650,7 @@ GROUP BY a, window_start, window_end
       <![CDATA[
 LogicalAggregate(group=[{0, 1, 2}], EXPR$3=[COUNT()], EXPR$4=[SUM($3)], EXPR$5=[MAX($3) FILTER $4], uv=[COUNT(DISTINCT $5)])
 +- LogicalProject(a=[$0], window_start=[$7], window_end=[$8], d=[$3], $f4=[IS TRUE(>($1, 1000))], c=[$2])
-   +- LogicalTableFunctionScan(invocation=[SESSION($6, DESCRIPTOR($6), 300000:INTERVAL MINUTE)], rowType=[RecordType(INTEGER a, BIGINT b, VARCHAR(2147483647) c, DECIMAL(10, 3) d, BIGINT e, TIMESTAMP(3) *ROWTIME* rowtime, TIMESTAMP_LTZ(3) *PROCTIME* proctime, TIMESTAMP(3) window_start, TIMESTAMP(3) window_end, TIMESTAMP_LTZ(3) *PROCTIME* window_time)])
+   +- LogicalTableFunctionScan(invocation=[SESSION($6, DESCRIPTOR($6), DESCRIPTOR($0), 300000:INTERVAL MINUTE)], rowType=[RecordType(INTEGER a, BIGINT b, VARCHAR(2147483647) c, DECIMAL(10, 3) d, BIGINT e, TIMESTAMP(3) *ROWTIME* rowtime, TIMESTAMP_LTZ(3) *PROCTIME* proctime, TIMESTAMP(3) window_start, TIMESTAMP(3) window_end, TIMESTAMP_LTZ(3) *PROCTIME* window_time)])
       +- LogicalProject(a=[$0], b=[$1], c=[$2], d=[$3], e=[$4], rowtime=[$5], proctime=[$6])
          +- LogicalWatermarkAssigner(rowtime=[rowtime], watermark=[-($5, 1000:INTERVAL SECOND)])
             +- LogicalProject(a=[$0], b=[$1], c=[$2], d=[$3], e=[$4], rowtime=[$5], proctime=[PROCTIME()])
@@ -1652,7 +1660,7 @@ LogicalAggregate(group=[{0, 1, 2}], EXPR$3=[COUNT()], EXPR$4=[SUM($3)], EXPR$5=[
     <Resource name="optimized rel plan">
       <![CDATA[
 Calc(select=[a, window_start, window_end, EXPR$3, EXPR$4, EXPR$5, uv])
-+- WindowAggregate(groupBy=[a], window=[SESSION(time_col=[proctime], gap=[5 min])], select=[a, COUNT(*) AS EXPR$3, SUM(d) AS EXPR$4, MAX(d) FILTER $f4 AS EXPR$5, COUNT(DISTINCT c) AS uv, start('w$) AS window_start, end('w$) AS window_end])
++- WindowAggregate(groupBy=[a], window=[SESSION(time_col=[proctime], gap=[5 min], partition keys=[a])], select=[a, COUNT(*) AS EXPR$3, SUM(d) AS EXPR$4, MAX(d) FILTER $f4 AS EXPR$5, COUNT(DISTINCT c) AS uv, start('w$) AS window_start, end('w$) AS window_end])
    +- Exchange(distribution=[hash[a]])
       +- Calc(select=[a, d, IS TRUE(>(b, 1000)) AS $f4, c, proctime])
          +- WatermarkAssigner(rowtime=[rowtime], watermark=[-(rowtime, 1000:INTERVAL SECOND)])
@@ -1674,7 +1682,11 @@ SELECT
    weightedAvg(b, e) AS wAvg,
    count(distinct c) AS uv
 FROM TABLE(
-  SESSION(TABLE MyTable, DESCRIPTOR(proctime), INTERVAL '5' MINUTE))
+  SESSION(
+    TABLE MyTable,
+    DESCRIPTOR(proctime),
+    DESCRIPTOR(a),
+    INTERVAL '5' MINUTE))
 GROUP BY a, window_start, window_end
       ]]>
     </Resource>
@@ -1682,7 +1694,7 @@ GROUP BY a, window_start, window_end
       <![CDATA[
 LogicalAggregate(group=[{0, 1, 2}], EXPR$3=[COUNT()], EXPR$4=[SUM($3)], EXPR$5=[MAX($3) FILTER $4], wAvg=[weightedAvg($5, $6)], uv=[COUNT(DISTINCT $7)])
 +- LogicalProject(a=[$0], window_start=[$7], window_end=[$8], d=[$3], $f4=[IS TRUE(>($1, 1000))], b=[$1], e=[$4], c=[$2])
-   +- LogicalTableFunctionScan(invocation=[SESSION($6, DESCRIPTOR($6), 300000:INTERVAL MINUTE)], rowType=[RecordType(INTEGER a, BIGINT b, VARCHAR(2147483647) c, DECIMAL(10, 3) d, BIGINT e, TIMESTAMP(3) *ROWTIME* rowtime, TIMESTAMP_LTZ(3) *PROCTIME* proctime, TIMESTAMP(3) window_start, TIMESTAMP(3) window_end, TIMESTAMP_LTZ(3) *PROCTIME* window_time)])
+   +- LogicalTableFunctionScan(invocation=[SESSION($6, DESCRIPTOR($6), DESCRIPTOR($0), 300000:INTERVAL MINUTE)], rowType=[RecordType(INTEGER a, BIGINT b, VARCHAR(2147483647) c, DECIMAL(10, 3) d, BIGINT e, TIMESTAMP(3) *ROWTIME* rowtime, TIMESTAMP_LTZ(3) *PROCTIME* proctime, TIMESTAMP(3) window_start, TIMESTAMP(3) window_end, TIMESTAMP_LTZ(3) *PROCTIME* window_time)])
       +- LogicalProject(a=[$0], b=[$1], c=[$2], d=[$3], e=[$4], rowtime=[$5], proctime=[$6])
          +- LogicalWatermarkAssigner(rowtime=[rowtime], watermark=[-($5, 1000:INTERVAL SECOND)])
             +- LogicalProject(a=[$0], b=[$1], c=[$2], d=[$3], e=[$4], rowtime=[$5], proctime=[PROCTIME()])
@@ -1692,7 +1704,7 @@ LogicalAggregate(group=[{0, 1, 2}], EXPR$3=[COUNT()], EXPR$4=[SUM($3)], EXPR$5=[
     <Resource name="optimized rel plan">
       <![CDATA[
 Calc(select=[a, window_start, window_end, EXPR$3, EXPR$4, EXPR$5, wAvg, uv])
-+- WindowAggregate(groupBy=[a], window=[SESSION(time_col=[proctime], gap=[5 min])], select=[a, COUNT(*) AS EXPR$3, SUM(d) AS EXPR$4, MAX(d) FILTER $f4 AS EXPR$5, weightedAvg(b, e) AS wAvg, COUNT(DISTINCT c) AS uv, start('w$) AS window_start, end('w$) AS window_end])
++- WindowAggregate(groupBy=[a], window=[SESSION(time_col=[proctime], gap=[5 min], partition keys=[a])], select=[a, COUNT(*) AS EXPR$3, SUM(d) AS EXPR$4, MAX(d) FILTER $f4 AS EXPR$5, weightedAvg(b, e) AS wAvg, COUNT(DISTINCT c) AS uv, start('w$) AS window_start, end('w$) AS window_end])
    +- Exchange(distribution=[hash[a]])
       +- Calc(select=[a, d, IS TRUE(>(b, 1000)) AS $f4, b, e, c, proctime])
          +- WatermarkAssigner(rowtime=[rowtime], watermark=[-(rowtime, 1000:INTERVAL SECOND)])
@@ -1714,7 +1726,11 @@ SELECT
    weightedAvg(b, e) AS wAvg,
    count(distinct c) AS uv
 FROM TABLE(
-  SESSION(TABLE MyTable, DESCRIPTOR(proctime), INTERVAL '5' MINUTE))
+  SESSION(
+    TABLE MyTable,
+    DESCRIPTOR(proctime),
+    DESCRIPTOR(a),
+    INTERVAL '5' MINUTE))
 GROUP BY a, window_start, window_end
       ]]>
     </Resource>
@@ -1722,7 +1738,7 @@ GROUP BY a, window_start, window_end
       <![CDATA[
 LogicalAggregate(group=[{0, 1, 2}], EXPR$3=[COUNT()], EXPR$4=[SUM($3)], EXPR$5=[MAX($3) FILTER $4], wAvg=[weightedAvg($5, $6)], uv=[COUNT(DISTINCT $7)])
 +- LogicalProject(a=[$0], window_start=[$7], window_end=[$8], d=[$3], $f4=[IS TRUE(>($1, 1000))], b=[$1], e=[$4], c=[$2])
-   +- LogicalTableFunctionScan(invocation=[SESSION($6, DESCRIPTOR($6), 300000:INTERVAL MINUTE)], rowType=[RecordType(INTEGER a, BIGINT b, VARCHAR(2147483647) c, DECIMAL(10, 3) d, BIGINT e, TIMESTAMP(3) *ROWTIME* rowtime, TIMESTAMP_LTZ(3) *PROCTIME* proctime, TIMESTAMP(3) window_start, TIMESTAMP(3) window_end, TIMESTAMP_LTZ(3) *PROCTIME* window_time)])
+   +- LogicalTableFunctionScan(invocation=[SESSION($6, DESCRIPTOR($6), DESCRIPTOR($0), 300000:INTERVAL MINUTE)], rowType=[RecordType(INTEGER a, BIGINT b, VARCHAR(2147483647) c, DECIMAL(10, 3) d, BIGINT e, TIMESTAMP(3) *ROWTIME* rowtime, TIMESTAMP_LTZ(3) *PROCTIME* proctime, TIMESTAMP(3) window_start, TIMESTAMP(3) window_end, TIMESTAMP_LTZ(3) *PROCTIME* window_time)])
       +- LogicalProject(a=[$0], b=[$1], c=[$2], d=[$3], e=[$4], rowtime=[$5], proctime=[$6])
          +- LogicalWatermarkAssigner(rowtime=[rowtime], watermark=[-($5, 1000:INTERVAL SECOND)])
             +- LogicalProject(a=[$0], b=[$1], c=[$2], d=[$3], e=[$4], rowtime=[$5], proctime=[PROCTIME()])
@@ -1732,7 +1748,7 @@ LogicalAggregate(group=[{0, 1, 2}], EXPR$3=[COUNT()], EXPR$4=[SUM($3)], EXPR$5=[
     <Resource name="optimized rel plan">
       <![CDATA[
 Calc(select=[a, window_start, window_end, EXPR$3, EXPR$4, EXPR$5, wAvg, uv])
-+- WindowAggregate(groupBy=[a], window=[SESSION(time_col=[proctime], gap=[5 min])], select=[a, COUNT(*) AS EXPR$3, SUM(d) AS EXPR$4, MAX(d) FILTER $f4 AS EXPR$5, weightedAvg(b, e) AS wAvg, COUNT(DISTINCT c) AS uv, start('w$) AS window_start, end('w$) AS window_end])
++- WindowAggregate(groupBy=[a], window=[SESSION(time_col=[proctime], gap=[5 min], partition keys=[a])], select=[a, COUNT(*) AS EXPR$3, SUM(d) AS EXPR$4, MAX(d) FILTER $f4 AS EXPR$5, weightedAvg(b, e) AS wAvg, COUNT(DISTINCT c) AS uv, start('w$) AS window_start, end('w$) AS window_end])
    +- Exchange(distribution=[hash[a]])
       +- Calc(select=[a, d, IS TRUE(>(b, 1000)) AS $f4, b, e, c, proctime])
          +- WatermarkAssigner(rowtime=[rowtime], watermark=[-(rowtime, 1000:INTERVAL SECOND)])
@@ -1742,79 +1758,59 @@ Calc(select=[a, window_start, window_end, EXPR$3, EXPR$4, EXPR$5, wAvg, uv])
     </Resource>
   </TestCase>
   <TestCase name="testSession_OnRowtime[aggPhaseEnforcer=ONE_PHASE]">
-    <Resource name="sql">
-      <![CDATA[
-SELECT
-   a,
-   window_start,
-   window_end,
-   count(*),
-   sum(d),
-   max(d) filter (where b > 1000),
-   weightedAvg(b, e) AS wAvg,
-   count(distinct c) AS uv
-FROM TABLE(
-  SESSION(TABLE MyTable, DESCRIPTOR(rowtime), INTERVAL '5' MINUTE))
-GROUP BY a, window_start, window_end
-      ]]>
-    </Resource>
-    <Resource name="ast">
-      <![CDATA[
+    <Resource name="explain">
+      <![CDATA[== Abstract Syntax Tree ==
 LogicalAggregate(group=[{0, 1, 2}], EXPR$3=[COUNT()], EXPR$4=[SUM($3)], EXPR$5=[MAX($3) FILTER $4], wAvg=[weightedAvg($5, $6)], uv=[COUNT(DISTINCT $7)])
 +- LogicalProject(a=[$0], window_start=[$7], window_end=[$8], d=[$3], $f4=[IS TRUE(>($1, 1000))], b=[$1], e=[$4], c=[$2])
-   +- LogicalTableFunctionScan(invocation=[SESSION($6, DESCRIPTOR($5), 300000:INTERVAL MINUTE)], rowType=[RecordType(INTEGER a, BIGINT b, VARCHAR(2147483647) c, DECIMAL(10, 3) d, BIGINT e, TIMESTAMP(3) *ROWTIME* rowtime, TIMESTAMP_LTZ(3) *PROCTIME* proctime, TIMESTAMP(3) window_start, TIMESTAMP(3) window_end, TIMESTAMP(3) *ROWTIME* window_time)])
+   +- LogicalTableFunctionScan(invocation=[SESSION($6, DESCRIPTOR($5), DESCRIPTOR($0), 300000:INTERVAL MINUTE)], rowType=[RecordType(INTEGER a, BIGINT b, VARCHAR(2147483647) c, DECIMAL(10, 3) d, BIGINT e, TIMESTAMP(3) *ROWTIME* rowtime, TIMESTAMP_LTZ(3) *PROCTIME* proctime, TIMESTAMP(3) window_start, TIMESTAMP(3) window_end, TIMESTAMP(3) *ROWTIME* window_time)])
       +- LogicalProject(a=[$0], b=[$1], c=[$2], d=[$3], e=[$4], rowtime=[$5], proctime=[$6])
          +- LogicalWatermarkAssigner(rowtime=[rowtime], watermark=[-($5, 1000:INTERVAL SECOND)])
             +- LogicalProject(a=[$0], b=[$1], c=[$2], d=[$3], e=[$4], rowtime=[$5], proctime=[PROCTIME()])
                +- LogicalTableScan(table=[[default_catalog, default_database, MyTable]])
-]]>
-    </Resource>
-    <Resource name="optimized rel plan">
-      <![CDATA[
+
+== Optimized Physical Plan ==
 Calc(select=[a, window_start, window_end, EXPR$3, EXPR$4, EXPR$5, wAvg, uv])
-+- WindowAggregate(groupBy=[a], window=[SESSION(time_col=[rowtime], gap=[5 min])], select=[a, COUNT(*) AS EXPR$3, SUM(d) AS EXPR$4, MAX(d) FILTER $f4 AS EXPR$5, weightedAvg(b, e) AS wAvg, COUNT(DISTINCT c) AS uv, start('w$) AS window_start, end('w$) AS window_end])
++- WindowAggregate(groupBy=[a], window=[SESSION(time_col=[rowtime], gap=[5 min], partition keys=[a])], select=[a, COUNT(*) AS EXPR$3, SUM(d) AS EXPR$4, MAX(d) FILTER $f4 AS EXPR$5, weightedAvg(b, e) AS wAvg, COUNT(DISTINCT c) AS uv, start('w$) AS window_start, end('w$) AS window_end])
    +- Exchange(distribution=[hash[a]])
       +- Calc(select=[a, d, IS TRUE(>(b, 1000)) AS $f4, b, e, c, rowtime])
          +- WatermarkAssigner(rowtime=[rowtime], watermark=[-(rowtime, 1000:INTERVAL SECOND)])
+            +- TableSourceScan(table=[[default_catalog, default_database, MyTable]], fields=[a, b, c, d, e, rowtime])
+
+== Optimized Execution Plan ==
+Calc(select=[a, window_start, window_end, EXPR$3, EXPR$4, EXPR$5, wAvg, uv])
++- WindowAggregate(groupBy=[a], window=[SESSION(time_col=[rowtime], gap=[5 min], partition keys=[a])], select=[a, COUNT(*) AS EXPR$3, SUM(d) AS EXPR$4, MAX(d) FILTER $f4 AS EXPR$5, weightedAvg(b, e) AS wAvg, COUNT(DISTINCT c) AS uv, start('w$) AS window_start, end('w$) AS window_end])
+   +- Exchange(distribution=[hash[a]])
+      +- Calc(select=[a, d, (b > 1000) IS TRUE AS $f4, b, e, c, rowtime])
+         +- WatermarkAssigner(rowtime=[rowtime], watermark=[(rowtime - 1000:INTERVAL SECOND)])
             +- TableSourceScan(table=[[default_catalog, default_database, MyTable]], fields=[a, b, c, d, e, rowtime])
 ]]>
     </Resource>
   </TestCase>
   <TestCase name="testSession_OnRowtime[aggPhaseEnforcer=TWO_PHASE]">
-    <Resource name="sql">
-      <![CDATA[
-SELECT
-   a,
-   window_start,
-   window_end,
-   count(*),
-   sum(d),
-   max(d) filter (where b > 1000),
-   weightedAvg(b, e) AS wAvg,
-   count(distinct c) AS uv
-FROM TABLE(
-  SESSION(TABLE MyTable, DESCRIPTOR(rowtime), INTERVAL '5' MINUTE))
-GROUP BY a, window_start, window_end
-      ]]>
-    </Resource>
-    <Resource name="ast">
-      <![CDATA[
+    <Resource name="explain">
+      <![CDATA[== Abstract Syntax Tree ==
 LogicalAggregate(group=[{0, 1, 2}], EXPR$3=[COUNT()], EXPR$4=[SUM($3)], EXPR$5=[MAX($3) FILTER $4], wAvg=[weightedAvg($5, $6)], uv=[COUNT(DISTINCT $7)])
 +- LogicalProject(a=[$0], window_start=[$7], window_end=[$8], d=[$3], $f4=[IS TRUE(>($1, 1000))], b=[$1], e=[$4], c=[$2])
-   +- LogicalTableFunctionScan(invocation=[SESSION($6, DESCRIPTOR($5), 300000:INTERVAL MINUTE)], rowType=[RecordType(INTEGER a, BIGINT b, VARCHAR(2147483647) c, DECIMAL(10, 3) d, BIGINT e, TIMESTAMP(3) *ROWTIME* rowtime, TIMESTAMP_LTZ(3) *PROCTIME* proctime, TIMESTAMP(3) window_start, TIMESTAMP(3) window_end, TIMESTAMP(3) *ROWTIME* window_time)])
+   +- LogicalTableFunctionScan(invocation=[SESSION($6, DESCRIPTOR($5), DESCRIPTOR($0), 300000:INTERVAL MINUTE)], rowType=[RecordType(INTEGER a, BIGINT b, VARCHAR(2147483647) c, DECIMAL(10, 3) d, BIGINT e, TIMESTAMP(3) *ROWTIME* rowtime, TIMESTAMP_LTZ(3) *PROCTIME* proctime, TIMESTAMP(3) window_start, TIMESTAMP(3) window_end, TIMESTAMP(3) *ROWTIME* window_time)])
       +- LogicalProject(a=[$0], b=[$1], c=[$2], d=[$3], e=[$4], rowtime=[$5], proctime=[$6])
          +- LogicalWatermarkAssigner(rowtime=[rowtime], watermark=[-($5, 1000:INTERVAL SECOND)])
             +- LogicalProject(a=[$0], b=[$1], c=[$2], d=[$3], e=[$4], rowtime=[$5], proctime=[PROCTIME()])
                +- LogicalTableScan(table=[[default_catalog, default_database, MyTable]])
-]]>
-    </Resource>
-    <Resource name="optimized rel plan">
-      <![CDATA[
+
+== Optimized Physical Plan ==
 Calc(select=[a, window_start, window_end, EXPR$3, EXPR$4, EXPR$5, wAvg, uv])
-+- WindowAggregate(groupBy=[a], window=[SESSION(time_col=[rowtime], gap=[5 min])], select=[a, COUNT(*) AS EXPR$3, SUM(d) AS EXPR$4, MAX(d) FILTER $f4 AS EXPR$5, weightedAvg(b, e) AS wAvg, COUNT(DISTINCT c) AS uv, start('w$) AS window_start, end('w$) AS window_end])
++- WindowAggregate(groupBy=[a], window=[SESSION(time_col=[rowtime], gap=[5 min], partition keys=[a])], select=[a, COUNT(*) AS EXPR$3, SUM(d) AS EXPR$4, MAX(d) FILTER $f4 AS EXPR$5, weightedAvg(b, e) AS wAvg, COUNT(DISTINCT c) AS uv, start('w$) AS window_start, end('w$) AS window_end])
    +- Exchange(distribution=[hash[a]])
       +- Calc(select=[a, d, IS TRUE(>(b, 1000)) AS $f4, b, e, c, rowtime])
          +- WatermarkAssigner(rowtime=[rowtime], watermark=[-(rowtime, 1000:INTERVAL SECOND)])
+            +- TableSourceScan(table=[[default_catalog, default_database, MyTable]], fields=[a, b, c, d, e, rowtime])
+
+== Optimized Execution Plan ==
+Calc(select=[a, window_start, window_end, EXPR$3, EXPR$4, EXPR$5, wAvg, uv])
++- WindowAggregate(groupBy=[a], window=[SESSION(time_col=[rowtime], gap=[5 min], partition keys=[a])], select=[a, COUNT(*) AS EXPR$3, SUM(d) AS EXPR$4, MAX(d) FILTER $f4 AS EXPR$5, weightedAvg(b, e) AS wAvg, COUNT(DISTINCT c) AS uv, start('w$) AS window_start, end('w$) AS window_end])
+   +- Exchange(distribution=[hash[a]])
+      +- Calc(select=[a, d, (b > 1000) IS TRUE AS $f4, b, e, c, rowtime])
+         +- WatermarkAssigner(rowtime=[rowtime], watermark=[(rowtime - 1000:INTERVAL SECOND)])
             +- TableSourceScan(table=[[default_catalog, default_database, MyTable]], fields=[a, b, c, d, e, rowtime])
 ]]>
     </Resource>

--- a/flink-table/flink-table-planner/src/test/resources/org/apache/flink/table/planner/plan/stream/sql/join/WindowJoinTest.xml
+++ b/flink-table/flink-table-planner/src/test/resources/org/apache/flink/table/planner/plan/stream/sql/join/WindowJoinTest.xml
@@ -1175,7 +1175,12 @@ FROM (
     window_time,
     count(*) as cnt,
     count(distinct c) AS uv
-  FROM TABLE(SESSION(TABLE MyTable, DESCRIPTOR(rowtime), INTERVAL '15' MINUTE))
+  FROM TABLE(
+    SESSION(
+      TABLE MyTable,
+      DESCRIPTOR(rowtime),
+      DESCRIPTOR(a),
+      INTERVAL '15' MINUTE))
   GROUP BY a, window_start, window_end, window_time
 ) L
 JOIN (
@@ -1186,7 +1191,12 @@ JOIN (
     window_time,
     count(*) as cnt,
     count(distinct c) AS uv
-  FROM TABLE(SESSION(TABLE MyTable2, DESCRIPTOR(rowtime), INTERVAL '15' MINUTE))
+  FROM TABLE(
+    SESSION(
+      TABLE MyTable2,
+      DESCRIPTOR(rowtime),
+      DESCRIPTOR(a),
+      INTERVAL '15' MINUTE))
   GROUP BY a, window_start, window_end, window_time
 ) R
 ON L.window_start = R.window_start AND L.window_end = R.window_end AND L.a = R.a
@@ -1198,14 +1208,14 @@ LogicalProject(a=[$0], window_start=[$1], window_end=[$2], window_time=[$3], cnt
 +- LogicalJoin(condition=[AND(=($1, $7), =($2, $8), =($0, $6))], joinType=[inner])
    :- LogicalAggregate(group=[{0, 1, 2, 3}], cnt=[COUNT()], uv=[COUNT(DISTINCT $4)])
    :  +- LogicalProject(a=[$0], window_start=[$5], window_end=[$6], window_time=[$7], c=[$2])
-   :     +- LogicalTableFunctionScan(invocation=[SESSION($4, DESCRIPTOR($3), 900000:INTERVAL MINUTE)], rowType=[RecordType(INTEGER a, VARCHAR(2147483647) b, BIGINT c, TIMESTAMP(3) *ROWTIME* rowtime, TIMESTAMP_LTZ(3) *PROCTIME* proctime, TIMESTAMP(3) window_start, TIMESTAMP(3) window_end, TIMESTAMP(3) *ROWTIME* window_time)])
+   :     +- LogicalTableFunctionScan(invocation=[SESSION($4, DESCRIPTOR($3), DESCRIPTOR($0), 900000:INTERVAL MINUTE)], rowType=[RecordType(INTEGER a, VARCHAR(2147483647) b, BIGINT c, TIMESTAMP(3) *ROWTIME* rowtime, TIMESTAMP_LTZ(3) *PROCTIME* proctime, TIMESTAMP(3) window_start, TIMESTAMP(3) window_end, TIMESTAMP(3) *ROWTIME* window_time)])
    :        +- LogicalProject(a=[$0], b=[$1], c=[$2], rowtime=[$3], proctime=[$4])
    :           +- LogicalWatermarkAssigner(rowtime=[rowtime], watermark=[-($3, 1000:INTERVAL SECOND)])
    :              +- LogicalProject(a=[$0], b=[$1], c=[$2], rowtime=[$3], proctime=[PROCTIME()])
    :                 +- LogicalTableScan(table=[[default_catalog, default_database, MyTable]])
    +- LogicalAggregate(group=[{0, 1, 2, 3}], cnt=[COUNT()], uv=[COUNT(DISTINCT $4)])
       +- LogicalProject(a=[$0], window_start=[$5], window_end=[$6], window_time=[$7], c=[$2])
-         +- LogicalTableFunctionScan(invocation=[SESSION($4, DESCRIPTOR($3), 900000:INTERVAL MINUTE)], rowType=[RecordType(INTEGER a, VARCHAR(2147483647) b, BIGINT c, TIMESTAMP(3) *ROWTIME* rowtime, TIMESTAMP_LTZ(3) *PROCTIME* proctime, TIMESTAMP(3) window_start, TIMESTAMP(3) window_end, TIMESTAMP(3) *ROWTIME* window_time)])
+         +- LogicalTableFunctionScan(invocation=[SESSION($4, DESCRIPTOR($3), DESCRIPTOR($0), 900000:INTERVAL MINUTE)], rowType=[RecordType(INTEGER a, VARCHAR(2147483647) b, BIGINT c, TIMESTAMP(3) *ROWTIME* rowtime, TIMESTAMP_LTZ(3) *PROCTIME* proctime, TIMESTAMP(3) window_start, TIMESTAMP(3) window_end, TIMESTAMP(3) *ROWTIME* window_time)])
             +- LogicalProject(a=[$0], b=[$1], c=[$2], rowtime=[$3], proctime=[$4])
                +- LogicalWatermarkAssigner(rowtime=[rowtime], watermark=[-($3, 1000:INTERVAL SECOND)])
                   +- LogicalProject(a=[$0], b=[$1], c=[$2], rowtime=[$3], proctime=[PROCTIME()])
@@ -1214,16 +1224,16 @@ LogicalProject(a=[$0], window_start=[$1], window_end=[$2], window_time=[$3], cnt
     </Resource>
     <Resource name="optimized rel plan">
       <![CDATA[
-WindowJoin(leftWindow=[SESSION(win_start=[window_start], win_end=[window_end], gap=[15 min])], rightWindow=[SESSION(win_start=[window_start], win_end=[window_end], gap=[15 min])], joinType=[InnerJoin], where=[=(a, a0)], select=[a, window_start, window_end, window_time, cnt, uv, a0, window_start0, window_end0, window_time0, cnt0, uv0])
+WindowJoin(leftWindow=[SESSION(win_start=[window_start], win_end=[window_end], gap=[15 min], partition keys=[a])], rightWindow=[SESSION(win_start=[window_start], win_end=[window_end], gap=[15 min], partition keys=[a])], joinType=[InnerJoin], where=[=(a, a0)], select=[a, window_start, window_end, window_time, cnt, uv, a0, window_start0, window_end0, window_time0, cnt0, uv0])
 :- Exchange(distribution=[hash[a]])
 :  +- Calc(select=[a, window_start, window_end, window_time, cnt, uv])
-:     +- WindowAggregate(groupBy=[a], window=[SESSION(time_col=[rowtime], gap=[15 min])], select=[a, COUNT(*) AS cnt, COUNT(DISTINCT c) AS uv, start('w$) AS window_start, end('w$) AS window_end, rowtime('w$) AS window_time])
+:     +- WindowAggregate(groupBy=[a], window=[SESSION(time_col=[rowtime], gap=[15 min], partition keys=[a])], select=[a, COUNT(*) AS cnt, COUNT(DISTINCT c) AS uv, start('w$) AS window_start, end('w$) AS window_end, rowtime('w$) AS window_time])
 :        +- Exchange(distribution=[hash[a]])
 :           +- WatermarkAssigner(rowtime=[rowtime], watermark=[-(rowtime, 1000:INTERVAL SECOND)])
 :              +- TableSourceScan(table=[[default_catalog, default_database, MyTable, project=[a, c, rowtime], metadata=[]]], fields=[a, c, rowtime])
 +- Exchange(distribution=[hash[a]])
    +- Calc(select=[a, window_start, window_end, window_time, cnt, uv])
-      +- WindowAggregate(groupBy=[a], window=[SESSION(time_col=[rowtime], gap=[15 min])], select=[a, COUNT(*) AS cnt, COUNT(DISTINCT c) AS uv, start('w$) AS window_start, end('w$) AS window_end, rowtime('w$) AS window_time])
+      +- WindowAggregate(groupBy=[a], window=[SESSION(time_col=[rowtime], gap=[15 min], partition keys=[a])], select=[a, COUNT(*) AS cnt, COUNT(DISTINCT c) AS uv, start('w$) AS window_start, end('w$) AS window_end, rowtime('w$) AS window_time])
          +- Exchange(distribution=[hash[a]])
             +- WatermarkAssigner(rowtime=[rowtime], watermark=[-(rowtime, 1000:INTERVAL SECOND)])
                +- TableSourceScan(table=[[default_catalog, default_database, MyTable2, project=[a, c, rowtime], metadata=[]]], fields=[a, c, rowtime])
@@ -1242,7 +1252,12 @@ FROM (
     window_time,
     count(*) as cnt,
     count(distinct c) AS uv
-  FROM TABLE(SESSION(TABLE MyTable, DESCRIPTOR(proctime), INTERVAL '15' MINUTE))
+  FROM TABLE(
+    SESSION(
+      TABLE MyTable,
+      DESCRIPTOR(proctime),
+      DESCRIPTOR(a),
+      INTERVAL '15' MINUTE))
   GROUP BY a, window_start, window_end, window_time
 ) L
 JOIN (
@@ -1253,7 +1268,12 @@ JOIN (
     window_time,
     count(*) as cnt,
     count(distinct c) AS uv
-  FROM TABLE(SESSION(TABLE MyTable2, DESCRIPTOR(proctime), INTERVAL '15' MINUTE))
+  FROM TABLE(
+    SESSION(
+      TABLE MyTable2,
+      DESCRIPTOR(proctime),
+      DESCRIPTOR(a),
+      INTERVAL '15' MINUTE))
   GROUP BY a, window_start, window_end, window_time
 ) R
 ON L.window_start = R.window_start AND L.window_end = R.window_end AND L.a = R.a
@@ -1265,14 +1285,14 @@ LogicalProject(a=[$0], window_start=[$1], window_end=[$2], window_time=[$3], cnt
 +- LogicalJoin(condition=[AND(=($1, $7), =($2, $8), =($0, $6))], joinType=[inner])
    :- LogicalAggregate(group=[{0, 1, 2, 3}], cnt=[COUNT()], uv=[COUNT(DISTINCT $4)])
    :  +- LogicalProject(a=[$0], window_start=[$5], window_end=[$6], window_time=[$7], c=[$2])
-   :     +- LogicalTableFunctionScan(invocation=[SESSION($4, DESCRIPTOR($4), 900000:INTERVAL MINUTE)], rowType=[RecordType(INTEGER a, VARCHAR(2147483647) b, BIGINT c, TIMESTAMP(3) *ROWTIME* rowtime, TIMESTAMP_LTZ(3) *PROCTIME* proctime, TIMESTAMP(3) window_start, TIMESTAMP(3) window_end, TIMESTAMP_LTZ(3) *PROCTIME* window_time)])
+   :     +- LogicalTableFunctionScan(invocation=[SESSION($4, DESCRIPTOR($4), DESCRIPTOR($0), 900000:INTERVAL MINUTE)], rowType=[RecordType(INTEGER a, VARCHAR(2147483647) b, BIGINT c, TIMESTAMP(3) *ROWTIME* rowtime, TIMESTAMP_LTZ(3) *PROCTIME* proctime, TIMESTAMP(3) window_start, TIMESTAMP(3) window_end, TIMESTAMP_LTZ(3) *PROCTIME* window_time)])
    :        +- LogicalProject(a=[$0], b=[$1], c=[$2], rowtime=[$3], proctime=[$4])
    :           +- LogicalWatermarkAssigner(rowtime=[rowtime], watermark=[-($3, 1000:INTERVAL SECOND)])
    :              +- LogicalProject(a=[$0], b=[$1], c=[$2], rowtime=[$3], proctime=[PROCTIME()])
    :                 +- LogicalTableScan(table=[[default_catalog, default_database, MyTable]])
    +- LogicalAggregate(group=[{0, 1, 2, 3}], cnt=[COUNT()], uv=[COUNT(DISTINCT $4)])
       +- LogicalProject(a=[$0], window_start=[$5], window_end=[$6], window_time=[$7], c=[$2])
-         +- LogicalTableFunctionScan(invocation=[SESSION($4, DESCRIPTOR($4), 900000:INTERVAL MINUTE)], rowType=[RecordType(INTEGER a, VARCHAR(2147483647) b, BIGINT c, TIMESTAMP(3) *ROWTIME* rowtime, TIMESTAMP_LTZ(3) *PROCTIME* proctime, TIMESTAMP(3) window_start, TIMESTAMP(3) window_end, TIMESTAMP_LTZ(3) *PROCTIME* window_time)])
+         +- LogicalTableFunctionScan(invocation=[SESSION($4, DESCRIPTOR($4), DESCRIPTOR($0), 900000:INTERVAL MINUTE)], rowType=[RecordType(INTEGER a, VARCHAR(2147483647) b, BIGINT c, TIMESTAMP(3) *ROWTIME* rowtime, TIMESTAMP_LTZ(3) *PROCTIME* proctime, TIMESTAMP(3) window_start, TIMESTAMP(3) window_end, TIMESTAMP_LTZ(3) *PROCTIME* window_time)])
             +- LogicalProject(a=[$0], b=[$1], c=[$2], rowtime=[$3], proctime=[$4])
                +- LogicalWatermarkAssigner(rowtime=[rowtime], watermark=[-($3, 1000:INTERVAL SECOND)])
                   +- LogicalProject(a=[$0], b=[$1], c=[$2], rowtime=[$3], proctime=[PROCTIME()])
@@ -1282,10 +1302,10 @@ LogicalProject(a=[$0], window_start=[$1], window_end=[$2], window_time=[$3], cnt
     <Resource name="optimized rel plan">
       <![CDATA[
 Calc(select=[a, window_start, window_end, PROCTIME_MATERIALIZE(window_time) AS window_time, cnt, uv, a0, window_start0, window_end0, PROCTIME_MATERIALIZE(window_time0) AS window_time0, cnt0, uv0])
-+- WindowJoin(leftWindow=[SESSION(win_start=[window_start], win_end=[window_end], gap=[15 min])], rightWindow=[SESSION(win_start=[window_start], win_end=[window_end], gap=[15 min])], joinType=[InnerJoin], where=[=(a, a0)], select=[a, window_start, window_end, window_time, cnt, uv, a0, window_start0, window_end0, window_time0, cnt0, uv0])
++- WindowJoin(leftWindow=[SESSION(win_start=[window_start], win_end=[window_end], gap=[15 min], partition keys=[a])], rightWindow=[SESSION(win_start=[window_start], win_end=[window_end], gap=[15 min], partition keys=[a])], joinType=[InnerJoin], where=[=(a, a0)], select=[a, window_start, window_end, window_time, cnt, uv, a0, window_start0, window_end0, window_time0, cnt0, uv0])
    :- Exchange(distribution=[hash[a]])
    :  +- Calc(select=[a, window_start, window_end, window_time, cnt, uv])
-   :     +- WindowAggregate(groupBy=[a], window=[SESSION(time_col=[proctime], gap=[15 min])], select=[a, COUNT(*) AS cnt, COUNT(DISTINCT c) AS uv, start('w$) AS window_start, end('w$) AS window_end, proctime('w$) AS window_time])
+   :     +- WindowAggregate(groupBy=[a], window=[SESSION(time_col=[proctime], gap=[15 min], partition keys=[a])], select=[a, COUNT(*) AS cnt, COUNT(DISTINCT c) AS uv, start('w$) AS window_start, end('w$) AS window_end, proctime('w$) AS window_time])
    :        +- Exchange(distribution=[hash[a]])
    :           +- Calc(select=[a, c, proctime])
    :              +- WatermarkAssigner(rowtime=[rowtime], watermark=[-(rowtime, 1000:INTERVAL SECOND)])
@@ -1293,7 +1313,7 @@ Calc(select=[a, window_start, window_end, PROCTIME_MATERIALIZE(window_time) AS w
    :                    +- TableSourceScan(table=[[default_catalog, default_database, MyTable, project=[a, c, rowtime], metadata=[]]], fields=[a, c, rowtime])
    +- Exchange(distribution=[hash[a]])
       +- Calc(select=[a, window_start, window_end, window_time, cnt, uv])
-         +- WindowAggregate(groupBy=[a], window=[SESSION(time_col=[proctime], gap=[15 min])], select=[a, COUNT(*) AS cnt, COUNT(DISTINCT c) AS uv, start('w$) AS window_start, end('w$) AS window_end, proctime('w$) AS window_time])
+         +- WindowAggregate(groupBy=[a], window=[SESSION(time_col=[proctime], gap=[15 min], partition keys=[a])], select=[a, COUNT(*) AS cnt, COUNT(DISTINCT c) AS uv, start('w$) AS window_start, end('w$) AS window_end, proctime('w$) AS window_time])
             +- Exchange(distribution=[hash[a]])
                +- Calc(select=[a, c, proctime])
                   +- WatermarkAssigner(rowtime=[rowtime], watermark=[-(rowtime, 1000:INTERVAL SECOND)])

--- a/flink-table/flink-table-planner/src/test/scala/org/apache/flink/table/planner/plan/stream/sql/WindowRankTest.scala
+++ b/flink-table/flink-table-planner/src/test/scala/org/apache/flink/table/planner/plan/stream/sql/WindowRankTest.scala
@@ -427,7 +427,12 @@ class WindowRankTest extends TableTestBase {
         |    max(d) filter (where b > 1000) as max_d,
         |    weightedAvg(b, e) AS wAvg,
         |    count(distinct c) AS uv
-        |  FROM TABLE(SESSION(TABLE MyTable, DESCRIPTOR(rowtime), INTERVAL '15' MINUTE))
+        |  FROM TABLE(
+        |    SESSION(
+        |      TABLE MyTable,
+        |      DESCRIPTOR(rowtime),
+        |      DESCRIPTOR(a),
+        |      INTERVAL '15' MINUTE))
         |  GROUP BY a, window_start, window_end, window_time
         |  )
         |)
@@ -455,7 +460,12 @@ class WindowRankTest extends TableTestBase {
         |    max(d) filter (where b > 1000) as max_d,
         |    weightedAvg(b, e) AS wAvg,
         |    count(distinct c) AS uv
-        |  FROM TABLE(SESSION(TABLE MyTable, DESCRIPTOR(proctime), INTERVAL '15' MINUTE))
+        |  FROM TABLE(
+        |    SESSION(
+        |      TABLE MyTable,
+        |      DESCRIPTOR(proctime),
+        |      DESCRIPTOR(a),
+        |      INTERVAL '15' MINUTE))
         |  GROUP BY a, window_start, window_end, window_time
         |  )
         |)

--- a/flink-table/flink-table-planner/src/test/scala/org/apache/flink/table/planner/plan/stream/sql/join/WindowJoinTest.scala
+++ b/flink-table/flink-table-planner/src/test/scala/org/apache/flink/table/planner/plan/stream/sql/join/WindowJoinTest.scala
@@ -957,7 +957,12 @@ class WindowJoinTest extends TableTestBase {
         |    window_time,
         |    count(*) as cnt,
         |    count(distinct c) AS uv
-        |  FROM TABLE(SESSION(TABLE MyTable, DESCRIPTOR(rowtime), INTERVAL '15' MINUTE))
+        |  FROM TABLE(
+        |    SESSION(
+        |      TABLE MyTable,
+        |      DESCRIPTOR(rowtime),
+        |      DESCRIPTOR(a),
+        |      INTERVAL '15' MINUTE))
         |  GROUP BY a, window_start, window_end, window_time
         |) L
         |JOIN (
@@ -968,7 +973,12 @@ class WindowJoinTest extends TableTestBase {
         |    window_time,
         |    count(*) as cnt,
         |    count(distinct c) AS uv
-        |  FROM TABLE(SESSION(TABLE MyTable2, DESCRIPTOR(rowtime), INTERVAL '15' MINUTE))
+        |  FROM TABLE(
+        |    SESSION(
+        |      TABLE MyTable2,
+        |      DESCRIPTOR(rowtime),
+        |      DESCRIPTOR(a),
+        |      INTERVAL '15' MINUTE))
         |  GROUP BY a, window_start, window_end, window_time
         |) R
         |ON L.window_start = R.window_start AND L.window_end = R.window_end AND L.a = R.a
@@ -989,7 +999,12 @@ class WindowJoinTest extends TableTestBase {
         |    window_time,
         |    count(*) as cnt,
         |    count(distinct c) AS uv
-        |  FROM TABLE(SESSION(TABLE MyTable, DESCRIPTOR(proctime), INTERVAL '15' MINUTE))
+        |  FROM TABLE(
+        |    SESSION(
+        |      TABLE MyTable,
+        |      DESCRIPTOR(proctime),
+        |      DESCRIPTOR(a),
+        |      INTERVAL '15' MINUTE))
         |  GROUP BY a, window_start, window_end, window_time
         |) L
         |JOIN (
@@ -1000,7 +1015,12 @@ class WindowJoinTest extends TableTestBase {
         |    window_time,
         |    count(*) as cnt,
         |    count(distinct c) AS uv
-        |  FROM TABLE(SESSION(TABLE MyTable2, DESCRIPTOR(proctime), INTERVAL '15' MINUTE))
+        |  FROM TABLE(
+        |    SESSION(
+        |      TABLE MyTable2,
+        |      DESCRIPTOR(proctime),
+        |      DESCRIPTOR(a),
+        |      INTERVAL '15' MINUTE))
         |  GROUP BY a, window_start, window_end, window_time
         |) R
         |ON L.window_start = R.window_start AND L.window_end = R.window_end AND L.a = R.a

--- a/flink-table/flink-table-planner/src/test/scala/org/apache/flink/table/planner/runtime/stream/sql/WindowAggregateITCase.scala
+++ b/flink-table/flink-table-planner/src/test/scala/org/apache/flink/table/planner/runtime/stream/sql/WindowAggregateITCase.scala
@@ -934,7 +934,11 @@ class WindowAggregateITCase(
         |  SUM(`int`),
         |  COUNT(DISTINCT name)
         |FROM TABLE(
-        |  SESSION(TABLE T, DESCRIPTOR(rowtime), INTERVAL '0.005' SECOND))
+        |  SESSION(
+        |    TABLE T,
+        |    DESCRIPTOR(rowtime),
+        |    DESCRIPTOR(`string`),
+        |    INTERVAL '0.005' SECOND))
         |GROUP BY `string`, window_start, window_end, window_time
       """.stripMargin
 
@@ -972,7 +976,11 @@ class WindowAggregateITCase(
         |   COUNT(DISTINCT b),
         |   window_end
         |FROM TABLE(
-        |  SESSION(TABLE MyTable, DESCRIPTOR(rowtime), INTERVAL '0.005' SECOND))
+        |  SESSION(
+        |    TABLE MyTable,
+        |    DESCRIPTOR(rowtime),
+        |    DESCRIPTOR(c),
+        |    INTERVAL '0.005' SECOND))
         |GROUP BY c, window_start, window_end
       """.stripMargin
     val sink = new TestingAppendSink


### PR DESCRIPTION
## What is the purpose of the change

There is a syntax mistake in session Window TVF in FLINK-23543.

For example, the following SQL has syntax mistake.

 

"""
  |SELECT
  |   a,
  |   window_start,
  |   window_end,
  |   count(*),
  |   sum(d),
  |   max(d) filter (where b > 1000),
  |   count(distinct c) AS uv
  |FROM TABLE(
  |  SESSION(
  |    TABLE MyTable, 
  |    DESCRIPTOR(proctime), 
  |    INTERVAL '5' MINUTE))
  |GROUP BY a, window_start, window_end
""".stripMargin
 

It should updated to the following SQL, while partition key (a) should be moved into SESSION

Window TVF based on Calcite SESSION window TVF.

 

val sql =
  """
    |SELECT
    |   a,
    |   window_start,
    |   window_end,
    |   count(*),
    |   sum(d),
    |   max(d) filter (where b > 1000),
    |   count(distinct c) AS uv
    |FROM TABLE(
    |  SESSION(
    |    TABLE MyTable,
    |    DESCRIPTOR(proctime),
    |    DESCRIPTOR(a)
    |    INTERVAL '5' MINUTE))
    |GROUP BY a, window_start, window_end
  """.stripMargin
 

To fix the bug, we only need update Session Window TVF syntax, we don't need update the operator part.

Besides, we should check group keys of window aggregate should only contain window_start, window_end, partition_key. group keys could not contain other fields. 


## Brief change log

* Update `SqlSessionTableFunction` to add partition key parameter and add check logical for new added parameter
* Update `SessionWindowSpec` to add partition key indices
* Update `WindowSpec#toSummaryString` to add second parameter inputFieldNames  in order to make session window spec  string more friendly to read. and update it's related classes.
* Update `ProjectWindowTableFunctionTransposeRule`, `ExpandWindowTableFunctionTransposeRule`, `PullUpWindowTableFunctionIntoWindowAggregateRule` to adjust session window partition key indices.

## Verifying this change

  - Add test in `WindowAggregateTest` to test group key of window aggregate should contain and only contain window_start, window_end and partition keys of session window.
  - Add test in `WindowAggregateJsonITCase`
  - Update test in `WindowAggregateITCase`

## Does this pull request potentially affect one of the following parts:

  - Dependencies (does it add or upgrade a dependency): (no)
  - The public API, i.e., is any changed class annotated with `@Public(Evolving)`: (no)
  - The serializers: (no)
  - The runtime per-record code paths (performance sensitive): (no)
  - Anything that affects deployment or recovery: JobManager (and its components), Checkpointing, Kubernetes/Yarn, ZooKeeper: (no)
  - The S3 file system connector: (no)

## Documentation

  - Does this pull request introduce a new feature? (no)
  - If yes, how is the feature documented? (not applicable)
