### PR TITLE
[FLINK-24042] Corrected the description of stderr in DataStream java doc

### DIFF
--- a/flink-streaming-java/src/main/java/org/apache/flink/streaming/api/datastream/DataStream.java
+++ b/flink-streaming-java/src/main/java/org/apache/flink/streaming/api/datastream/DataStream.java
@@ -938,7 +938,7 @@ public class DataStream<T> {
     }
 
     /**
-     * Writes a DataStream to the standard output stream (stderr).
+     * Writes a DataStream to the standard error stream (stderr).
      *
      * <p>For each element of the DataStream the result of {@link Object#toString()} is written.
      *
@@ -971,7 +971,7 @@ public class DataStream<T> {
     }
 
     /**
-     * Writes a DataStream to the standard output stream (stderr).
+     * Writes a DataStream to the standard error stream (stderr).
      *
      * <p>For each element of the DataStream the result of {@link Object#toString()} is written.
      *

--- a/flink-streaming-scala/src/main/scala/org/apache/flink/streaming/api/scala/DataStream.scala
+++ b/flink-streaming-scala/src/main/scala/org/apache/flink/streaming/api/scala/DataStream.scala
@@ -956,7 +956,7 @@ class DataStream[T](stream: JavaStream[T]) {
   def print(): DataStreamSink[T] = stream.print()
 
   /**
-   * Writes a DataStream to the standard output stream (stderr).
+   * Writes a DataStream to the standard error stream (stderr).
    *
    * For each element of the DataStream the result of
    * [[AnyRef.toString()]] is written.
@@ -978,7 +978,7 @@ class DataStream[T](stream: JavaStream[T]) {
   def print(sinkIdentifier: String): DataStreamSink[T] = stream.print(sinkIdentifier)
 
   /**
-    * Writes a DataStream to the standard output stream (stderr).
+    * Writes a DataStream to the standard error stream (stderr).
     *
     * For each element of the DataStream the result of
     * [[AnyRef.toString()]] is written.


### PR DESCRIPTION

## What is the purpose of the change

* The printToErr methods doc indicates it writes to standard output stream

## Brief change log

* Corrected javadoc to indicate that printToErr writes to standard error stream

## Verifying this change

This change is a trivial rework / code cleanup without any test coverage.

## Does this pull request potentially affect one of the following parts:

  - Dependencies (does it add or upgrade a dependency): no
  - The public API, i.e., is any changed class annotated with `@Public(Evolving)`: no
  - The serializers: no
  - The runtime per-record code paths (performance sensitive): no
  - Anything that affects deployment or recovery: JobManager (and its components), Checkpointing, Kubernetes/Yarn, ZooKeeper: no
  - The S3 file system connector: no

## Documentation

  - Does this pull request introduce a new feature? no
  - If yes, how is the feature documented? not applicable
