### PR TITLE
[FLINK-23976] [Runtime / Metrics] Add additional availability timing metrics to Job lifecycle events

### DIFF
--- a/flink-runtime/src/main/java/org/apache/flink/runtime/executiongraph/DefaultExecutionGraphBuilder.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/executiongraph/DefaultExecutionGraphBuilder.java
@@ -38,8 +38,10 @@ import org.apache.flink.runtime.client.JobSubmissionException;
 import org.apache.flink.runtime.deployment.TaskDeploymentDescriptorFactory;
 import org.apache.flink.runtime.executiongraph.failover.flip1.partitionrelease.PartitionReleaseStrategy;
 import org.apache.flink.runtime.executiongraph.failover.flip1.partitionrelease.PartitionReleaseStrategyFactoryLoader;
+import org.apache.flink.runtime.executiongraph.metrics.CancellingTimeGauge;
 import org.apache.flink.runtime.executiongraph.metrics.DownTimeGauge;
 import org.apache.flink.runtime.executiongraph.metrics.RestartTimeGauge;
+import org.apache.flink.runtime.executiongraph.metrics.StartingTimeGauge;
 import org.apache.flink.runtime.executiongraph.metrics.UpTimeGauge;
 import org.apache.flink.runtime.io.network.partition.JobMasterPartitionTracker;
 import org.apache.flink.runtime.jobgraph.JobGraph;
@@ -328,6 +330,8 @@ public class DefaultExecutionGraphBuilder {
         metrics.gauge(RestartTimeGauge.METRIC_NAME, new RestartTimeGauge(executionGraph));
         metrics.gauge(DownTimeGauge.METRIC_NAME, new DownTimeGauge(executionGraph));
         metrics.gauge(UpTimeGauge.METRIC_NAME, new UpTimeGauge(executionGraph));
+        metrics.gauge(StartingTimeGauge.METRIC_NAME, new StartingTimeGauge(executionGraph));
+        metrics.gauge(CancellingTimeGauge.METRIC_NAME, new CancellingTimeGauge(executionGraph));
 
         return executionGraph;
     }

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/executiongraph/metrics/CancellingTimeGauge.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/executiongraph/metrics/CancellingTimeGauge.java
@@ -1,0 +1,62 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.flink.runtime.executiongraph.metrics;
+
+import org.apache.flink.api.common.JobStatus;
+import org.apache.flink.metrics.Gauge;
+import org.apache.flink.runtime.executiongraph.JobStatusProvider;
+
+import static org.apache.flink.util.Preconditions.checkNotNull;
+
+/** A gauge that returns (in milliseconds) how long a job spent in CANCELING state. */
+public class CancellingTimeGauge implements Gauge<Long> {
+
+    public static final String METRIC_NAME = "cancellingTime";
+
+    private static final long NOT_CANCELLING = 0L;
+
+    // ------------------------------------------------------------------------
+
+    private final JobStatusProvider jobStatusProvider;
+
+    public CancellingTimeGauge(JobStatusProvider jobStatusProvider) {
+        this.jobStatusProvider = checkNotNull(jobStatusProvider);
+    }
+
+    // ------------------------------------------------------------------------
+
+    @Override
+    public Long getValue() {
+        final JobStatus status = jobStatusProvider.getState();
+
+        final long cancellingTimestamp = jobStatusProvider.getStatusTimestamp(JobStatus.CANCELLING);
+        final long canceledTimestamp = jobStatusProvider.getStatusTimestamp(JobStatus.CANCELED);
+
+        if (cancellingTimestamp <= 0L) {
+            // Job is not in CANCELLING or CANCELED state
+            return NOT_CANCELLING;
+        } else if (canceledTimestamp <= 0L) {
+            // Job is in CANCELLING state but has not been canceled
+            return Math.max(System.currentTimeMillis() - cancellingTimestamp, 0L);
+        } else {
+            // Job has been canceled
+            return canceledTimestamp - cancellingTimestamp;
+        }
+    }
+}

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/executiongraph/metrics/StartingTimeGauge.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/executiongraph/metrics/StartingTimeGauge.java
@@ -1,0 +1,70 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.flink.runtime.executiongraph.metrics;
+
+import org.apache.flink.api.common.JobStatus;
+import org.apache.flink.metrics.Gauge;
+import org.apache.flink.runtime.executiongraph.JobStatusProvider;
+
+import static org.apache.flink.util.Preconditions.checkNotNull;
+
+/**
+ * A gauge that returns (in milliseconds) how long a job to get to running.
+ *
+ * <p>For jobs that are not running any more, it returns {@value NO_LONGER_RUNNING}.
+ */
+public class StartingTimeGauge implements Gauge<Long> {
+
+    public static final String METRIC_NAME = "startingTime";
+
+    private static final long NOT_RUNNING = 0L;
+
+    private static final long NO_LONGER_RUNNING = -1L;
+
+    // ------------------------------------------------------------------------
+
+    private final JobStatusProvider jobStatusProvider;
+
+    public StartingTimeGauge(JobStatusProvider jobStatusProvider) {
+        this.jobStatusProvider = checkNotNull(jobStatusProvider);
+    }
+
+    // ------------------------------------------------------------------------
+
+    @Override
+    public Long getValue() {
+        final JobStatus status = jobStatusProvider.getState();
+
+        // not running any more
+        if (status.isTerminalState()) {
+            return NO_LONGER_RUNNING;
+        }
+
+        final long createdTimestamp = jobStatusProvider.getStatusTimestamp(JobStatus.CREATED);
+        final long runningTimestamp = jobStatusProvider.getStatusTimestamp(JobStatus.RUNNING);
+
+        if (runningTimestamp <= createdTimestamp) {
+            // Job not running
+            return NOT_RUNNING;
+        } else {
+            // Job started, return the diff between RUNNING and CREATED
+            return runningTimestamp - createdTimestamp;
+        }
+    }
+}

--- a/flink-runtime/src/test/java/org/apache/flink/runtime/executiongraph/metrics/CancellingTimeGaugeTest.java
+++ b/flink-runtime/src/test/java/org/apache/flink/runtime/executiongraph/metrics/CancellingTimeGaugeTest.java
@@ -1,0 +1,73 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.flink.runtime.executiongraph.metrics;
+
+import org.apache.flink.api.common.JobStatus;
+import org.apache.flink.runtime.executiongraph.TestingJobStatusProvider;
+import org.apache.flink.util.TestLogger;
+
+import org.junit.Test;
+
+import java.util.HashMap;
+import java.util.Map;
+
+import static org.hamcrest.MatcherAssert.assertThat;
+import static org.hamcrest.Matchers.greaterThan;
+import static org.hamcrest.Matchers.is;
+
+/** Tests for {@link CancellingTimeGauge}. */
+public class CancellingTimeGaugeTest extends TestLogger {
+
+    @Test
+    public void testNotCanceling() {
+        final CancellingTimeGauge gauge =
+                new CancellingTimeGauge(new TestingJobStatusProvider(JobStatus.RUNNING, 0L));
+        assertThat(gauge.getValue(), is(0L));
+    }
+
+    @Test
+    public void testCancellingNotCancelled() {
+        final Map<JobStatus, Long> statusTimestampMap = new HashMap<>();
+        statusTimestampMap.put(JobStatus.CANCELLING, 123L);
+
+        final long before = System.currentTimeMillis();
+
+        final CancellingTimeGauge gauge =
+                new CancellingTimeGauge(
+                        new TestingJobStatusProvider(
+                                JobStatus.CANCELLING,
+                                status -> statusTimestampMap.getOrDefault(status, 0L)));
+
+        assertThat(gauge.getValue(), greaterThan(before - 123L));
+    }
+
+    @Test
+    public void testCancelled() {
+        final Map<JobStatus, Long> statusTimestampMap = new HashMap<>();
+        statusTimestampMap.put(JobStatus.CANCELLING, 123L);
+        statusTimestampMap.put(JobStatus.CANCELED, 234L);
+
+        final CancellingTimeGauge gauge =
+                new CancellingTimeGauge(
+                        new TestingJobStatusProvider(
+                                JobStatus.CANCELED,
+                                status -> statusTimestampMap.getOrDefault(status, 0L)));
+        assertThat(gauge.getValue(), is(111L));
+    }
+}

--- a/flink-runtime/src/test/java/org/apache/flink/runtime/executiongraph/metrics/StartingTimeGaugeTest.java
+++ b/flink-runtime/src/test/java/org/apache/flink/runtime/executiongraph/metrics/StartingTimeGaugeTest.java
@@ -1,0 +1,56 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.flink.runtime.executiongraph.metrics;
+
+import org.apache.flink.api.common.JobStatus;
+import org.apache.flink.runtime.executiongraph.TestingJobStatusProvider;
+import org.apache.flink.util.TestLogger;
+
+import org.junit.Test;
+
+import java.util.HashMap;
+import java.util.Map;
+
+import static org.hamcrest.MatcherAssert.assertThat;
+import static org.hamcrest.Matchers.is;
+
+/** Tests for {@link StartingTimeGauge}. */
+public class StartingTimeGaugeTest extends TestLogger {
+
+    @Test
+    public void testNotStarted() {
+        final StartingTimeGauge gauge =
+                new StartingTimeGauge(new TestingJobStatusProvider(JobStatus.INITIALIZING, 0L));
+        assertThat(gauge.getValue(), is(0L));
+    }
+
+    @Test
+    public void testRunningAfterStarting() {
+        final Map<JobStatus, Long> statusTimestampMap = new HashMap<>();
+        statusTimestampMap.put(JobStatus.CREATED, 123L);
+        statusTimestampMap.put(JobStatus.RUNNING, 234L);
+
+        final StartingTimeGauge gauge =
+                new StartingTimeGauge(
+                        new TestingJobStatusProvider(
+                                JobStatus.RUNNING,
+                                status -> statusTimestampMap.getOrDefault(status, 0L)));
+        assertThat(gauge.getValue(), is(111L));
+    }
+}


### PR DESCRIPTION
<!--
*Thank you very much for contributing to Apache Flink - we are happy that you want to help us improve Flink. To help the community review your contribution in the best possible way, please go through the checklist below, which will get the contribution into a shape in which it can be best reviewed.*

*Please understand that we do not do this to make contributions to Flink a hassle. In order to uphold a high standard of quality for code contributions, while at the same time managing a large number of contributions, we need contributors to prepare the contributions well, and give reviewers enough contextual information for the review. Please also understand that contributions that do not follow this guide will take longer to review and thus typically be picked up with lower priority by the community.*

## Contribution Checklist

  - Make sure that the pull request corresponds to a [JIRA issue](https://issues.apache.org/jira/projects/FLINK/issues). Exceptions are made for typos in JavaDoc or documentation files, which need no JIRA issue.
  
  - Name the pull request in the form "[FLINK-XXXX] [component] Title of the pull request", where *FLINK-XXXX* should be replaced by the actual issue number. Skip *component* if you are unsure about which is the best component.
  Typo fixes that have no associated JIRA issue should be named following this pattern: `[hotfix] [docs] Fix typo in event time introduction` or `[hotfix] [javadocs] Expand JavaDoc for PuncuatedWatermarkGenerator`.

  - Fill out the template below to describe the changes contributed by the pull request. That will give reviewers the context they need to do the review.
  
  - Make sure that the change passes the automated tests, i.e., `mvn clean verify` passes. You can set up Azure Pipelines CI to do that following [this guide](https://cwiki.apache.org/confluence/display/FLINK/Azure+Pipelines#AzurePipelines-Tutorial:SettingupAzurePipelinesforaforkoftheFlinkrepository).

  - Each pull request should address only one issue, not mix up code from multiple issues.
  
  - Each commit in the pull request has a meaningful commit message (including the JIRA id)

  - Once all items of the checklist are addressed, remove the above text and this checklist, leaving only the filled out template below.


**(The sections below can be removed for hotfixes of typos)**
-->

## What is the purpose of the change

[FLINK-23976](https://issues.apache.org/jira/browse/FLINK-23976) Add additional availability timing metrics to Job lifecycle events

This PR adds two additional metrics; startingTime, and cancellingTime
- startingTime is the time it takes a job to get to running
- cancellingTime is the time spent in status CANCELLING 


## Brief change log

  - *Added class `CancellingTimeGauge.java`*
  - *Added class `StartingTimeGauge.java`*
  - *Register these metrics in `DefaultExecutionGraphBuilder.java`*
  - *Added unit tests*


## Verifying this change

This change added tests and can be verified as follows:

  - *Added unit tests for `CancellingTimeGauge.java`*
  - *Added unit tests for `StartingTimeGauge.java`*
## Does this pull request potentially affect one of the following parts:

  - Dependencies (does it add or upgrade a dependency): (no)
  - The public API, i.e., is any changed class annotated with `@Public(Evolving)`: (no)
  - The serializers: (no)
  - The runtime per-record code paths (performance sensitive): (no)
  - Anything that affects deployment or recovery: JobManager (and its components), Checkpointing, Kubernetes/Yarn, ZooKeeper: (no)
  - The S3 file system connector: (no)

## Documentation

  - Does this pull request introduce a new feature? (no)