### PR TITLE
[FLINK-24049][python] Handle properly for field types need conversion in TupleTypeInfo

### DIFF
--- a/flink-python/pyflink/datastream/tests/test_data_stream.py
+++ b/flink-python/pyflink/datastream/tests/test_data_stream.py
@@ -62,11 +62,12 @@ class DataStreamTests(object):
         self.assertEqual(expected, actual)
 
     def test_basic_operations(self):
-        ds = self.env.from_collection([('ab', decimal.Decimal(1)),
-                                       ('bdc', decimal.Decimal(2)),
-                                       ('cfgs', decimal.Decimal(3)),
-                                       ('deeefg', decimal.Decimal(4))],
-                                      type_info=Types.ROW([Types.STRING(), Types.BIG_DEC()]))
+        ds = self.env.from_collection(
+            [('ab', Row('a', decimal.Decimal(1))),
+             ('bdc', Row('b', decimal.Decimal(2))),
+             ('cfgs', Row('c', decimal.Decimal(3))),
+             ('deeefg', Row('d', decimal.Decimal(4)))],
+            type_info=Types.TUPLE([Types.STRING(), Types.ROW([Types.STRING(), Types.BIG_DEC()])]))
 
         class MyMapFunction(MapFunction):
             def map(self, value):
@@ -81,7 +82,7 @@ class DataStreamTests(object):
             def filter(self, value):
                 return value[1] > 2
 
-        (ds.map(lambda i: (i[0], len(i[0]), i[1]),
+        (ds.map(lambda i: (i[0], len(i[0]), i[1][1]),
                 output_type=Types.TUPLE([Types.STRING(), Types.INT(), Types.BIG_DEC()]))
            .flat_map(MyFlatMapFunction(),
                      output_type=Types.TUPLE([Types.STRING(), Types.INT(), Types.BIG_DEC()]))


### PR DESCRIPTION

## What is the purpose of the change

*This pull request fixes TupleTypeInfo to handle properly for field types need conversion.*


## Verifying this change

This change updated tests and can be verified as follows:

  - *Updated tests test_basic_operations in test_data_stream.py*

## Does this pull request potentially affect one of the following parts:

  - Dependencies (does it add or upgrade a dependency): (no)
  - The public API, i.e., is any changed class annotated with `@Public(Evolving)`: (no)
  - The serializers: (no)
  - The runtime per-record code paths (performance sensitive): (no)
  - Anything that affects deployment or recovery: JobManager (and its components), Checkpointing, Kubernetes/Yarn, ZooKeeper: (no)
  - The S3 file system connector: (no)

## Documentation

  - Does this pull request introduce a new feature? (no)
  - If yes, how is the feature documented? (not applicable)
