### PR TITLE
[FLINK-24027][filesystems] Remove excessive dependencies from NOTICE files

### DIFF
--- a/flink-filesystems/flink-azure-fs-hadoop/src/main/resources/META-INF/NOTICE
+++ b/flink-filesystems/flink-azure-fs-hadoop/src/main/resources/META-INF/NOTICE
@@ -6,9 +6,7 @@ The Apache Software Foundation (http://www.apache.org/).
 
 This project bundles the following dependencies under the Apache Software License 2.0 (http://www.apache.org/licenses/LICENSE-2.0.txt)
 
-- com.fasterxml.jackson.core:jackson-annotations:2.12.1
 - com.fasterxml.jackson.core:jackson-core:2.12.1
-- com.fasterxml.jackson.core:jackson-databind:2.12.1
 - com.google.errorprone:error_prone_annotations:2.2.0
 - com.google.guava:failureaccess:1.0
 - com.google.guava:guava:27.0-jre

--- a/flink-filesystems/flink-fs-hadoop-shaded/src/main/resources/META-INF/NOTICE
+++ b/flink-filesystems/flink-fs-hadoop-shaded/src/main/resources/META-INF/NOTICE
@@ -13,7 +13,6 @@ This project bundles the following dependencies under the Apache Software Licens
 - org.apache.commons:commons-configuration2:2.1.1
 - org.apache.commons:commons-lang3:3.3.2
 - org.apache.commons:commons-text:1.4
-- commons-lang:commons-lang:2.6
 - commons-collections:commons-collections:3.2.2
 - commons-io:commons-io:2.8.0
 - commons-logging:commons-logging:1.1.3

--- a/flink-filesystems/flink-s3-fs-hadoop/src/main/resources/META-INF/NOTICE
+++ b/flink-filesystems/flink-s3-fs-hadoop/src/main/resources/META-INF/NOTICE
@@ -23,7 +23,6 @@ This project bundles the following dependencies under the Apache Software Licens
 - commons-codec:commons-codec:1.13
 - commons-collections:commons-collections:3.2.2
 - commons-io:commons-io:2.8.0
-- commons-lang:commons-lang:2.6
 - commons-logging:commons-logging:1.1.3
 - joda-time:joda-time:2.5
 - org.apache.commons:commons-configuration2:2.1.1
@@ -33,12 +32,9 @@ This project bundles the following dependencies under the Apache Software Licens
 - org.apache.hadoop:hadoop-annotations:3.2.2
 - org.apache.hadoop:hadoop-aws:3.2.2
 - org.apache.hadoop:hadoop-common:3.2.2
-- org.apache.hadoop.thirdparty:hadoop-shaded-guava:1.1.1
-- org.apache.hadoop.thirdparty:hadoop-shaded-protobuf_3_7:1.1.1
 - org.apache.htrace:htrace-core4:4.1.0-incubating
 - org.apache.httpcomponents:httpclient:4.5.13
 - org.apache.httpcomponents:httpcore:4.4.14
-- org.wildfly.openssl:wildfly-openssl:1.0.7.Final
 - software.amazon.ion:ion-java:1.0.2
 
 This project bundles the following dependencies under BSD-2 License (https://opensource.org/licenses/BSD-2-Clause).

--- a/flink-filesystems/flink-s3-fs-presto/src/main/resources/META-INF/NOTICE
+++ b/flink-filesystems/flink-s3-fs-presto/src/main/resources/META-INF/NOTICE
@@ -10,7 +10,6 @@ This project bundles the following dependencies under the Apache Software Licens
 - commons-codec:commons-codec:1.13
 - commons-collections:commons-collections:3.2.2
 - commons-io:commons-io:2.8.0
-- commons-lang:commons-lang:2.6
 - commons-logging:commons-logging:1.1.3
 - com.amazonaws:aws-java-sdk-core:1.11.951
 - com.amazonaws:aws-java-sdk-dynamodb:1.11.951
@@ -44,13 +43,10 @@ This project bundles the following dependencies under the Apache Software Licens
 - org.apache.hadoop:hadoop-aws:3.2.2
 - org.apache.hadoop:hadoop-auth:3.2.2
 - org.apache.hadoop:hadoop-common:3.2.2
-- org.apache.hadoop.thirdparty:hadoop-shaded-guava:1.1.1
-- org.apache.hadoop.thirdparty:hadoop-shaded-protobuf_3_7:1.1.1
 - org.apache.htrace:htrace-core4:4.1.0-incubating
 - org.apache.httpcomponents:httpclient:4.5.13
 - org.apache.httpcomponents:httpcore:4.4.14
 - org.weakref:jmxutils:1.19
-- org.wildfly.openssl:wildfly-openssl:1.0.7.Final
 - software.amazon.ion:ion-java:1.0.2
 
 This project bundles the following dependencies under BSD-2 License (https://opensource.org/licenses/BSD-2-Clause).


### PR DESCRIPTION
## What is the purpose of the change

This removes some entries from NOTICE files which are no longer included.

## Verifying this change

This change is a trivial rework / code cleanup without any test coverage.

## Does this pull request potentially affect one of the following parts:

  - Dependencies (does it add or upgrade a dependency): no
  - The public API, i.e., is any changed class annotated with `@Public(Evolving)`: no
  - The serializers: no
  - The runtime per-record code paths (performance sensitive): no
  - Anything that affects deployment or recovery: JobManager (and its components), Checkpointing, Kubernetes/Yarn, ZooKeeper: no
  - The S3 file system connector: no

## Documentation

  - Does this pull request introduce a new feature? no
  - If yes, how is the feature documented? not applicable
