### PR TITLE
[FLINK-24021][HA]Handle curator framework start error by register UnhandledErrorListener before start zk client

### DIFF
--- a/flink-kubernetes/src/main/java/org/apache/flink/kubernetes/KubernetesClusterDescriptor.java
+++ b/flink-kubernetes/src/main/java/org/apache/flink/kubernetes/KubernetesClusterDescriptor.java
@@ -113,7 +113,9 @@ public class KubernetesClusterDescriptor implements ClusterDescriptor<String> {
                 return new RestClusterClient<>(
                         configuration,
                         clusterId,
-                        new StandaloneClientHAServices(getWebMonitorAddress(configuration)));
+                        (effectiveConfiguration, fatalErrorHandler) ->
+                                new StandaloneClientHAServices(
+                                        getWebMonitorAddress(effectiveConfiguration)));
             } catch (Exception e) {
                 throw new RuntimeException(
                         new ClusterRetrieveException("Could not create the RestClusterClient.", e));

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/entrypoint/ClusterEntrypoint.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/entrypoint/ClusterEntrypoint.java
@@ -359,7 +359,11 @@ public abstract class ClusterEntrypoint implements AutoCloseableAsync, FatalErro
             Configuration configuration, Executor executor, RpcSystemUtils rpcSystemUtils)
             throws Exception {
         return HighAvailabilityServicesUtils.createHighAvailabilityServices(
-                configuration, executor, AddressResolution.NO_ADDRESS_RESOLUTION, rpcSystemUtils);
+                configuration,
+                executor,
+                AddressResolution.NO_ADDRESS_RESOLUTION,
+                rpcSystemUtils,
+                this);
     }
 
     protected HeartbeatServices createHeartbeatServices(Configuration configuration) {

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/highavailability/ClientHighAvailabilityServicesFactory.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/highavailability/ClientHighAvailabilityServicesFactory.java
@@ -1,0 +1,38 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.flink.runtime.highavailability;
+
+import org.apache.flink.configuration.Configuration;
+import org.apache.flink.runtime.rpc.FatalErrorHandler;
+
+/** Factory interface for {@link ClientHighAvailabilityServices}. */
+public interface ClientHighAvailabilityServicesFactory {
+
+    /**
+     * Creates a {@link ClientHighAvailabilityServices} instance.
+     *
+     * @param configuration Flink configuration
+     * @param fatalErrorHandler {@link FatalErrorHandler} fatalErrorHandler to handle unexpected
+     *     errors
+     * @return instance of {@link ClientHighAvailabilityServices}
+     * @throws Exception when HA services can not be created.
+     */
+    ClientHighAvailabilityServices create(
+            Configuration configuration, FatalErrorHandler fatalErrorHandler) throws Exception;
+}

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/highavailability/DefaultClientHighAvailabilityServicesFactory.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/highavailability/DefaultClientHighAvailabilityServicesFactory.java
@@ -1,0 +1,38 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.flink.runtime.highavailability;
+
+import org.apache.flink.configuration.Configuration;
+import org.apache.flink.runtime.rpc.FatalErrorHandler;
+
+/** Default factory for creating client high availability services. */
+public class DefaultClientHighAvailabilityServicesFactory
+        implements ClientHighAvailabilityServicesFactory {
+
+    public static final DefaultClientHighAvailabilityServicesFactory INSTANCE =
+            new DefaultClientHighAvailabilityServicesFactory();
+
+    @Override
+    public ClientHighAvailabilityServices create(
+            Configuration configuration, FatalErrorHandler fatalErrorHandler) throws Exception {
+
+        return HighAvailabilityServicesUtils.createClientHAService(
+                configuration, fatalErrorHandler);
+    }
+}

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/minicluster/MiniCluster.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/minicluster/MiniCluster.java
@@ -503,7 +503,7 @@ public class MiniCluster implements AutoCloseableAsync {
                 return new EmbeddedHaServicesWithLeadershipControl(executor);
             case CONFIGURED:
                 return HighAvailabilityServicesUtils.createAvailableOrEmbeddedServices(
-                        configuration, executor);
+                        configuration, executor, new ShutDownFatalErrorHandler());
             default:
                 throw new IllegalConfigurationException("Unknown HA Services " + haServices);
         }

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/taskexecutor/TaskManagerRunner.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/taskexecutor/TaskManagerRunner.java
@@ -153,7 +153,8 @@ public class TaskManagerRunner implements FatalErrorHandler {
                         configuration,
                         executor,
                         AddressResolution.NO_ADDRESS_RESOLUTION,
-                        rpcSystem);
+                        rpcSystem,
+                        this);
 
         JMXService.startInstance(configuration.getString(JMXServerOptions.JMX_SERVER_PORT));
 

--- a/flink-runtime/src/test/java/org/apache/flink/runtime/checkpoint/ZKCheckpointIDCounterMultiServersTest.java
+++ b/flink-runtime/src/test/java/org/apache/flink/runtime/checkpoint/ZKCheckpointIDCounterMultiServersTest.java
@@ -21,6 +21,7 @@ package org.apache.flink.runtime.checkpoint;
 import org.apache.flink.configuration.Configuration;
 import org.apache.flink.configuration.HighAvailabilityOptions;
 import org.apache.flink.core.testutils.OneShotLatch;
+import org.apache.flink.runtime.rest.util.NoOpFatalErrorHandler;
 import org.apache.flink.runtime.util.ZooKeeperUtils;
 import org.apache.flink.runtime.zookeeper.ZooKeeperResource;
 import org.apache.flink.util.TestLogger;
@@ -53,7 +54,8 @@ public final class ZKCheckpointIDCounterMultiServersTest extends TestLogger {
         final Configuration configuration = new Configuration();
         configuration.setString(
                 HighAvailabilityOptions.HA_ZOOKEEPER_QUORUM, zooKeeperResource.getConnectString());
-        final CuratorFramework client = ZooKeeperUtils.startCuratorFramework(configuration);
+        final CuratorFramework client =
+                ZooKeeperUtils.startCuratorFramework(configuration, NoOpFatalErrorHandler.INSTANCE);
 
         try {
             OneShotLatch connectionLossLatch = new OneShotLatch();

--- a/flink-runtime/src/test/java/org/apache/flink/runtime/checkpoint/ZooKeeperCompletedCheckpointStoreTest.java
+++ b/flink-runtime/src/test/java/org/apache/flink/runtime/checkpoint/ZooKeeperCompletedCheckpointStoreTest.java
@@ -25,6 +25,7 @@ import org.apache.flink.configuration.Configuration;
 import org.apache.flink.configuration.HighAvailabilityOptions;
 import org.apache.flink.core.testutils.FlinkMatchers;
 import org.apache.flink.runtime.operators.testutils.ExpectedTestException;
+import org.apache.flink.runtime.rest.util.NoOpFatalErrorHandler;
 import org.apache.flink.runtime.state.RetrievableStateHandle;
 import org.apache.flink.runtime.state.SharedStateRegistry;
 import org.apache.flink.runtime.state.testutils.TestCompletedCheckpointStorageLocation;
@@ -79,7 +80,8 @@ public class ZooKeeperCompletedCheckpointStoreTest extends TestLogger {
                 new ArrayList<>();
         final ZooKeeperStateHandleStore<CompletedCheckpoint> checkpointsInZooKeeper =
                 new ZooKeeperStateHandleStore<CompletedCheckpoint>(
-                        ZooKeeperUtils.startCuratorFramework(configuration),
+                        ZooKeeperUtils.startCuratorFramework(
+                                configuration, NoOpFatalErrorHandler.INSTANCE),
                         new TestingRetrievableStateStorageHelper<>()) {
                     @Override
                     public List<Tuple2<RetrievableStateHandle<CompletedCheckpoint>, String>>
@@ -118,7 +120,8 @@ public class ZooKeeperCompletedCheckpointStoreTest extends TestLogger {
         configuration.setString(
                 HighAvailabilityOptions.HA_ZOOKEEPER_QUORUM, zooKeeperResource.getConnectString());
 
-        final CuratorFramework client = ZooKeeperUtils.startCuratorFramework(configuration);
+        final CuratorFramework client =
+                ZooKeeperUtils.startCuratorFramework(configuration, NoOpFatalErrorHandler.INSTANCE);
         final CompletedCheckpointStore checkpointStore = createZooKeeperCheckpointStore(client);
 
         try {
@@ -153,7 +156,8 @@ public class ZooKeeperCompletedCheckpointStoreTest extends TestLogger {
         configuration.setString(
                 HighAvailabilityOptions.HA_ZOOKEEPER_QUORUM, zooKeeperResource.getConnectString());
 
-        final CuratorFramework client = ZooKeeperUtils.startCuratorFramework(configuration);
+        final CuratorFramework client =
+                ZooKeeperUtils.startCuratorFramework(configuration, NoOpFatalErrorHandler.INSTANCE);
         final CompletedCheckpointStore checkpointStore = createZooKeeperCheckpointStore(client);
 
         try {
@@ -223,7 +227,8 @@ public class ZooKeeperCompletedCheckpointStoreTest extends TestLogger {
         configuration.setString(
                 HighAvailabilityOptions.HA_ZOOKEEPER_QUORUM, zooKeeperResource.getConnectString());
 
-        final CuratorFramework client = ZooKeeperUtils.startCuratorFramework(configuration);
+        final CuratorFramework client =
+                ZooKeeperUtils.startCuratorFramework(configuration, NoOpFatalErrorHandler.INSTANCE);
         final CompletedCheckpointStore store = createZooKeeperCheckpointStore(client);
 
         CountDownLatch discardAttempted = new CountDownLatch(1);

--- a/flink-runtime/src/test/java/org/apache/flink/runtime/dispatcher/runner/ZooKeeperDefaultDispatcherRunnerTest.java
+++ b/flink-runtime/src/test/java/org/apache/flink/runtime/dispatcher/runner/ZooKeeperDefaultDispatcherRunnerTest.java
@@ -45,6 +45,7 @@ import org.apache.flink.runtime.jobmanager.JobGraphStoreFactory;
 import org.apache.flink.runtime.jobmaster.JobResult;
 import org.apache.flink.runtime.leaderelection.TestingLeaderElectionService;
 import org.apache.flink.runtime.metrics.groups.UnregisteredMetricGroups;
+import org.apache.flink.runtime.rest.util.NoOpFatalErrorHandler;
 import org.apache.flink.runtime.rpc.TestingRpcService;
 import org.apache.flink.runtime.rpc.TestingRpcServiceResource;
 import org.apache.flink.runtime.testtasks.NoOpInvokable;
@@ -142,7 +143,8 @@ public class ZooKeeperDefaultDispatcherRunnerTest extends TestLogger {
         final TestingLeaderElectionService dispatcherLeaderElectionService =
                 new TestingLeaderElectionService();
 
-        final CuratorFramework client = ZooKeeperUtils.startCuratorFramework(configuration);
+        final CuratorFramework client =
+                ZooKeeperUtils.startCuratorFramework(configuration, NoOpFatalErrorHandler.INSTANCE);
         try (final TestingHighAvailabilityServices highAvailabilityServices =
                 new TestingHighAvailabilityServicesBuilder()
                         .setRunningJobsRegistry(

--- a/flink-runtime/src/test/java/org/apache/flink/runtime/highavailability/HighAvailabilityServicesUtilsTest.java
+++ b/flink-runtime/src/test/java/org/apache/flink/runtime/highavailability/HighAvailabilityServicesUtilsTest.java
@@ -22,6 +22,7 @@ import org.apache.flink.configuration.Configuration;
 import org.apache.flink.configuration.HighAvailabilityOptions;
 import org.apache.flink.core.fs.Path;
 import org.apache.flink.runtime.jobmanager.HighAvailabilityMode;
+import org.apache.flink.runtime.rest.util.NoOpFatalErrorHandler;
 import org.apache.flink.runtime.rpc.AddressResolution;
 import org.apache.flink.runtime.rpc.RpcSystem;
 import org.apache.flink.util.TestLogger;
@@ -57,7 +58,8 @@ public class HighAvailabilityServicesUtilsTest extends TestLogger {
 
         // when
         HighAvailabilityServices actualHaServices =
-                HighAvailabilityServicesUtils.createAvailableOrEmbeddedServices(config, executor);
+                HighAvailabilityServicesUtils.createAvailableOrEmbeddedServices(
+                        config, executor, NoOpFatalErrorHandler.INSTANCE);
 
         // then
         assertSame(haServices, actualHaServices);
@@ -68,7 +70,8 @@ public class HighAvailabilityServicesUtilsTest extends TestLogger {
                         config,
                         executor,
                         AddressResolution.NO_ADDRESS_RESOLUTION,
-                        RpcSystem.load());
+                        RpcSystem.load(),
+                        NoOpFatalErrorHandler.INSTANCE);
 
         // then
         assertSame(haServices, actualHaServices);
@@ -86,7 +89,8 @@ public class HighAvailabilityServicesUtilsTest extends TestLogger {
 
         // when
         ClientHighAvailabilityServices actualClientHAServices =
-                HighAvailabilityServicesUtils.createClientHAService(config);
+                HighAvailabilityServicesUtils.createClientHAService(
+                        config, NoOpFatalErrorHandler.INSTANCE);
 
         // then
         assertSame(clientHAServices, actualClientHAServices);
@@ -103,7 +107,8 @@ public class HighAvailabilityServicesUtilsTest extends TestLogger {
                 HighAvailabilityMode.FACTORY_CLASS.name().toLowerCase());
 
         // expect
-        HighAvailabilityServicesUtils.createAvailableOrEmbeddedServices(config, executor);
+        HighAvailabilityServicesUtils.createAvailableOrEmbeddedServices(
+                config, executor, NoOpFatalErrorHandler.INSTANCE);
     }
 
     @Test

--- a/flink-runtime/src/test/java/org/apache/flink/runtime/highavailability/zookeeper/ZooKeeperHaServicesTest.java
+++ b/flink-runtime/src/test/java/org/apache/flink/runtime/highavailability/zookeeper/ZooKeeperHaServicesTest.java
@@ -27,6 +27,7 @@ import org.apache.flink.runtime.highavailability.RunningJobsRegistry;
 import org.apache.flink.runtime.leaderelection.LeaderElectionService;
 import org.apache.flink.runtime.leaderelection.TestingContender;
 import org.apache.flink.runtime.leaderretrieval.LeaderRetrievalService;
+import org.apache.flink.runtime.rest.util.NoOpFatalErrorHandler;
 import org.apache.flink.runtime.util.LeaderRetrievalUtils;
 import org.apache.flink.runtime.util.ZooKeeperUtils;
 import org.apache.flink.runtime.zookeeper.ZooKeeperResource;
@@ -211,7 +212,8 @@ public class ZooKeeperHaServicesTest extends TestLogger {
             throws Exception {
         try (ZooKeeperHaServices zooKeeperHaServices =
                 new ZooKeeperHaServices(
-                        ZooKeeperUtils.startCuratorFramework(configuration),
+                        ZooKeeperUtils.startCuratorFramework(
+                                configuration, NoOpFatalErrorHandler.INSTANCE),
                         Executors.directExecutor(),
                         configuration,
                         blobStoreService)) {

--- a/flink-runtime/src/test/java/org/apache/flink/runtime/highavailability/zookeeper/ZooKeeperRegistryTest.java
+++ b/flink-runtime/src/test/java/org/apache/flink/runtime/highavailability/zookeeper/ZooKeeperRegistryTest.java
@@ -25,6 +25,7 @@ import org.apache.flink.runtime.blob.VoidBlobStore;
 import org.apache.flink.runtime.highavailability.HighAvailabilityServices;
 import org.apache.flink.runtime.highavailability.RunningJobsRegistry;
 import org.apache.flink.runtime.highavailability.RunningJobsRegistry.JobSchedulingStatus;
+import org.apache.flink.runtime.rest.util.NoOpFatalErrorHandler;
 import org.apache.flink.runtime.util.ZooKeeperUtils;
 import org.apache.flink.util.TestLogger;
 import org.apache.flink.util.concurrent.Executors;
@@ -64,7 +65,8 @@ public class ZooKeeperRegistryTest extends TestLogger {
                 HighAvailabilityOptions.HA_ZOOKEEPER_QUORUM, testingServer.getConnectString());
         configuration.setString(HighAvailabilityOptions.HA_MODE, "zookeeper");
 
-        final CuratorFramework zkClient = ZooKeeperUtils.startCuratorFramework(configuration);
+        final CuratorFramework zkClient =
+                ZooKeeperUtils.startCuratorFramework(configuration, NoOpFatalErrorHandler.INSTANCE);
 
         final HighAvailabilityServices zkHaService =
                 new ZooKeeperHaServices(

--- a/flink-runtime/src/test/java/org/apache/flink/runtime/jobmanager/ZooKeeperJobGraphStoreWatcherTest.java
+++ b/flink-runtime/src/test/java/org/apache/flink/runtime/jobmanager/ZooKeeperJobGraphStoreWatcherTest.java
@@ -25,6 +25,7 @@ import org.apache.flink.configuration.HighAvailabilityOptions;
 import org.apache.flink.runtime.jobgraph.JobGraph;
 import org.apache.flink.runtime.jobgraph.JobGraphTestUtils;
 import org.apache.flink.runtime.persistence.RetrievableStateStorageHelper;
+import org.apache.flink.runtime.rest.util.NoOpFatalErrorHandler;
 import org.apache.flink.runtime.testutils.CommonTestUtils;
 import org.apache.flink.runtime.util.ZooKeeperUtils;
 import org.apache.flink.runtime.zookeeper.ZooKeeperResource;
@@ -70,7 +71,9 @@ public class ZooKeeperJobGraphStoreWatcherTest extends TestLogger {
 
     @Test
     public void testJobGraphAddedAndRemovedShouldNotifyGraphStoreListener() throws Exception {
-        try (final CuratorFramework client = ZooKeeperUtils.startCuratorFramework(configuration)) {
+        try (final CuratorFramework client =
+                ZooKeeperUtils.startCuratorFramework(
+                        configuration, NoOpFatalErrorHandler.INSTANCE)) {
             final JobGraphStoreWatcher jobGraphStoreWatcher =
                     createAndStartJobGraphStoreWatcher(client);
 

--- a/flink-runtime/src/test/java/org/apache/flink/runtime/leaderelection/LeaderElectionTest.java
+++ b/flink-runtime/src/test/java/org/apache/flink/runtime/leaderelection/LeaderElectionTest.java
@@ -21,6 +21,7 @@ package org.apache.flink.runtime.leaderelection;
 import org.apache.flink.configuration.Configuration;
 import org.apache.flink.configuration.HighAvailabilityOptions;
 import org.apache.flink.runtime.highavailability.nonha.embedded.EmbeddedLeaderService;
+import org.apache.flink.runtime.rest.util.NoOpFatalErrorHandler;
 import org.apache.flink.runtime.testutils.TestingUtils;
 import org.apache.flink.runtime.util.ZooKeeperUtils;
 import org.apache.flink.util.TestLogger;
@@ -183,7 +184,9 @@ public class LeaderElectionTest extends TestLogger {
                     HighAvailabilityOptions.HA_ZOOKEEPER_QUORUM, testingServer.getConnectString());
             configuration.setString(HighAvailabilityOptions.HA_MODE, "zookeeper");
 
-            client = ZooKeeperUtils.startCuratorFramework(configuration);
+            client =
+                    ZooKeeperUtils.startCuratorFramework(
+                            configuration, NoOpFatalErrorHandler.INSTANCE);
         }
 
         @Override

--- a/flink-runtime/src/test/java/org/apache/flink/runtime/leaderelection/ZooKeeperLeaderElectionConnectionHandlingTest.java
+++ b/flink-runtime/src/test/java/org/apache/flink/runtime/leaderelection/ZooKeeperLeaderElectionConnectionHandlingTest.java
@@ -21,6 +21,7 @@ package org.apache.flink.runtime.leaderelection;
 import org.apache.flink.configuration.Configuration;
 import org.apache.flink.configuration.HighAvailabilityOptions;
 import org.apache.flink.core.testutils.OneShotLatch;
+import org.apache.flink.runtime.rest.util.NoOpFatalErrorHandler;
 import org.apache.flink.runtime.util.TestingFatalErrorHandlerResource;
 import org.apache.flink.runtime.util.ZooKeeperUtils;
 import org.apache.flink.runtime.zookeeper.ZooKeeperResource;
@@ -129,7 +130,8 @@ public class ZooKeeperLeaderElectionConnectionHandlingTest extends TestLogger {
                     validationLogic,
             Problem problem)
             throws Exception {
-        CuratorFramework client = ZooKeeperUtils.startCuratorFramework(configuration);
+        CuratorFramework client =
+                ZooKeeperUtils.startCuratorFramework(configuration, NoOpFatalErrorHandler.INSTANCE);
         LeaderElectionDriverFactory leaderElectionDriverFactory =
                 new ZooKeeperLeaderElectionDriverFactory(client, PATH);
         DefaultLeaderElectionService leaderElectionService =

--- a/flink-runtime/src/test/java/org/apache/flink/runtime/leaderelection/ZooKeeperLeaderElectionTest.java
+++ b/flink-runtime/src/test/java/org/apache/flink/runtime/leaderelection/ZooKeeperLeaderElectionTest.java
@@ -25,6 +25,7 @@ import org.apache.flink.runtime.leaderretrieval.DefaultLeaderRetrievalService;
 import org.apache.flink.runtime.leaderretrieval.LeaderRetrievalDriver;
 import org.apache.flink.runtime.leaderretrieval.TestingLeaderRetrievalEventHandler;
 import org.apache.flink.runtime.leaderretrieval.ZooKeeperLeaderRetrievalDriver;
+import org.apache.flink.runtime.rest.util.NoOpFatalErrorHandler;
 import org.apache.flink.runtime.util.ZooKeeperUtils;
 import org.apache.flink.util.ExceptionUtils;
 import org.apache.flink.util.TestLogger;
@@ -110,7 +111,8 @@ public class ZooKeeperLeaderElectionTest extends TestLogger {
                 HighAvailabilityOptions.HA_ZOOKEEPER_QUORUM, testingServer.getConnectString());
         configuration.setString(HighAvailabilityOptions.HA_MODE, "zookeeper");
 
-        client = ZooKeeperUtils.startCuratorFramework(configuration);
+        client =
+                ZooKeeperUtils.startCuratorFramework(configuration, NoOpFatalErrorHandler.INSTANCE);
     }
 
     @After
@@ -355,7 +357,9 @@ public class ZooKeeperLeaderElectionTest extends TestLogger {
             electionEventHandler.waitForLeader(timeout);
             assertThat(electionEventHandler.getConfirmedLeaderInformation(), is(TEST_LEADER));
 
-            anotherClient = ZooKeeperUtils.startCuratorFramework(configuration);
+            anotherClient =
+                    ZooKeeperUtils.startCuratorFramework(
+                            configuration, NoOpFatalErrorHandler.INSTANCE);
 
             ByteArrayOutputStream baos = new ByteArrayOutputStream();
             ObjectOutputStream oos = new ObjectOutputStream(baos);
@@ -428,7 +432,10 @@ public class ZooKeeperLeaderElectionTest extends TestLogger {
         final Exception testException = new Exception(exMsg);
 
         try {
-            client = spy(ZooKeeperUtils.startCuratorFramework(configuration));
+            client =
+                    spy(
+                            ZooKeeperUtils.startCuratorFramework(
+                                    configuration, NoOpFatalErrorHandler.INSTANCE));
 
             doAnswer(invocation -> mockCreateBuilder).when(client).create();
 
@@ -478,8 +485,12 @@ public class ZooKeeperLeaderElectionTest extends TestLogger {
         NodeCache cache = null;
 
         try {
-            client = ZooKeeperUtils.startCuratorFramework(configuration);
-            client2 = ZooKeeperUtils.startCuratorFramework(configuration);
+            client =
+                    ZooKeeperUtils.startCuratorFramework(
+                            configuration, NoOpFatalErrorHandler.INSTANCE);
+            client2 =
+                    ZooKeeperUtils.startCuratorFramework(
+                            configuration, NoOpFatalErrorHandler.INSTANCE);
 
             leaderElectionDriver = createAndInitLeaderElectionDriver(client, electionEventHandler);
             leaderRetrievalDriver =

--- a/flink-runtime/src/test/java/org/apache/flink/runtime/leaderelection/ZooKeeperLeaderRetrievalConnectionHandlingTest.java
+++ b/flink-runtime/src/test/java/org/apache/flink/runtime/leaderelection/ZooKeeperLeaderRetrievalConnectionHandlingTest.java
@@ -24,6 +24,7 @@ import org.apache.flink.configuration.HighAvailabilityOptions;
 import org.apache.flink.runtime.leaderretrieval.LeaderRetrievalDriver;
 import org.apache.flink.runtime.leaderretrieval.LeaderRetrievalEventHandler;
 import org.apache.flink.runtime.leaderretrieval.ZooKeeperLeaderRetrievalDriver;
+import org.apache.flink.runtime.rest.util.NoOpFatalErrorHandler;
 import org.apache.flink.runtime.testutils.CommonTestUtils;
 import org.apache.flink.runtime.util.TestingFatalErrorHandlerResource;
 import org.apache.flink.runtime.util.ZooKeeperUtils;
@@ -77,7 +78,8 @@ public class ZooKeeperLeaderRetrievalConnectionHandlingTest extends TestLogger {
         config.setString(
                 HighAvailabilityOptions.HA_ZOOKEEPER_QUORUM, testingServer.getConnectString());
 
-        zooKeeperClient = ZooKeeperUtils.startCuratorFramework(config);
+        zooKeeperClient =
+                ZooKeeperUtils.startCuratorFramework(config, NoOpFatalErrorHandler.INSTANCE);
         zooKeeperClient.blockUntilConnected();
     }
 

--- a/flink-runtime/src/test/java/org/apache/flink/runtime/leaderelection/ZooKeeperLeaderRetrievalTest.java
+++ b/flink-runtime/src/test/java/org/apache/flink/runtime/leaderelection/ZooKeeperLeaderRetrievalTest.java
@@ -25,6 +25,7 @@ import org.apache.flink.runtime.highavailability.HighAvailabilityServices;
 import org.apache.flink.runtime.highavailability.zookeeper.ZooKeeperHaServices;
 import org.apache.flink.runtime.jobmaster.JobMaster;
 import org.apache.flink.runtime.leaderretrieval.LeaderRetrievalService;
+import org.apache.flink.runtime.rest.util.NoOpFatalErrorHandler;
 import org.apache.flink.runtime.rpc.AddressResolution;
 import org.apache.flink.runtime.rpc.RpcSystem;
 import org.apache.flink.runtime.testutils.TestingUtils;
@@ -70,7 +71,8 @@ public class ZooKeeperLeaderRetrievalTest extends TestLogger {
         config.setString(
                 HighAvailabilityOptions.HA_ZOOKEEPER_QUORUM, testingServer.getConnectString());
 
-        CuratorFramework client = ZooKeeperUtils.startCuratorFramework(config);
+        CuratorFramework client =
+                ZooKeeperUtils.startCuratorFramework(config, NoOpFatalErrorHandler.INSTANCE);
 
         highAvailabilityServices =
                 new ZooKeeperHaServices(

--- a/flink-runtime/src/test/java/org/apache/flink/runtime/rest/util/DocumentingDispatcherRestEndpoint.java
+++ b/flink-runtime/src/test/java/org/apache/flink/runtime/rest/util/DocumentingDispatcherRestEndpoint.java
@@ -32,7 +32,6 @@ import org.apache.flink.runtime.rest.handler.RestHandlerConfiguration;
 import org.apache.flink.runtime.rest.handler.RestHandlerSpecification;
 import org.apache.flink.runtime.rest.handler.legacy.metrics.VoidMetricFetcher;
 import org.apache.flink.runtime.rest.messages.MessageHeaders;
-import org.apache.flink.runtime.rpc.FatalErrorHandler;
 import org.apache.flink.runtime.webmonitor.retriever.GatewayRetriever;
 import org.apache.flink.util.ConfigurationException;
 
@@ -105,12 +104,5 @@ public class DocumentingDispatcherRestEndpoint extends DispatcherRestEndpoint
         public boolean hasLeadership(@Nonnull UUID leaderSessionId) {
             return false;
         }
-    }
-
-    private enum NoOpFatalErrorHandler implements FatalErrorHandler {
-        INSTANCE;
-
-        @Override
-        public void onFatalError(final Throwable exception) {}
     }
 }

--- a/flink-runtime/src/test/java/org/apache/flink/runtime/rest/util/NoOpFatalErrorHandler.java
+++ b/flink-runtime/src/test/java/org/apache/flink/runtime/rest/util/NoOpFatalErrorHandler.java
@@ -1,0 +1,29 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.flink.runtime.rest.util;
+
+import org.apache.flink.runtime.rpc.FatalErrorHandler;
+
+/** {@link FatalErrorHandler} which does nothing. */
+public enum NoOpFatalErrorHandler implements FatalErrorHandler {
+    INSTANCE;
+
+    @Override
+    public void onFatalError(final Throwable exception) {}
+}

--- a/flink-runtime/src/test/java/org/apache/flink/runtime/taskexecutor/TaskManagerRunnerConfigurationTest.java
+++ b/flink-runtime/src/test/java/org/apache/flink/runtime/taskexecutor/TaskManagerRunnerConfigurationTest.java
@@ -29,6 +29,7 @@ import org.apache.flink.core.fs.FileSystem;
 import org.apache.flink.runtime.entrypoint.FlinkParseException;
 import org.apache.flink.runtime.highavailability.HighAvailabilityServices;
 import org.apache.flink.runtime.highavailability.HighAvailabilityServicesUtils;
+import org.apache.flink.runtime.rest.util.NoOpFatalErrorHandler;
 import org.apache.flink.runtime.rpc.AddressResolution;
 import org.apache.flink.runtime.rpc.RpcService;
 import org.apache.flink.runtime.rpc.RpcSystem;
@@ -246,7 +247,8 @@ public class TaskManagerRunnerConfigurationTest extends TestLogger {
                 config,
                 Executors.directExecutor(),
                 AddressResolution.NO_ADDRESS_RESOLUTION,
-                RpcSystem.load());
+                RpcSystem.load(),
+                NoOpFatalErrorHandler.INSTANCE);
     }
 
     private static ServerSocket openServerSocket() {

--- a/flink-runtime/src/test/java/org/apache/flink/runtime/util/ZooKeeperUtilsTreeCacheTest.java
+++ b/flink-runtime/src/test/java/org/apache/flink/runtime/util/ZooKeeperUtilsTreeCacheTest.java
@@ -21,6 +21,7 @@ package org.apache.flink.runtime.util;
 import org.apache.flink.configuration.Configuration;
 import org.apache.flink.configuration.HighAvailabilityOptions;
 import org.apache.flink.core.testutils.FlinkMatchers;
+import org.apache.flink.runtime.rest.util.NoOpFatalErrorHandler;
 import org.apache.flink.util.TestLogger;
 
 import org.apache.flink.shaded.curator4.org.apache.curator.framework.CuratorFramework;
@@ -64,8 +65,14 @@ public class ZooKeeperUtilsTreeCacheTest extends TestLogger {
         configuration.set(
                 HighAvailabilityOptions.HA_ZOOKEEPER_QUORUM, testingServer.getConnectString());
 
-        client = closer.register(ZooKeeperUtils.startCuratorFramework(configuration));
-        client = closer.register(ZooKeeperUtils.startCuratorFramework(configuration));
+        client =
+                closer.register(
+                        ZooKeeperUtils.startCuratorFramework(
+                                configuration, NoOpFatalErrorHandler.INSTANCE));
+        client =
+                closer.register(
+                        ZooKeeperUtils.startCuratorFramework(
+                                configuration, NoOpFatalErrorHandler.INSTANCE));
         final TreeCache cache =
                 closer.register(
                         ZooKeeperUtils.createTreeCache(

--- a/flink-runtime/src/test/java/org/apache/flink/runtime/zookeeper/ZooKeeperStateHandleStoreTest.java
+++ b/flink-runtime/src/test/java/org/apache/flink/runtime/zookeeper/ZooKeeperStateHandleStoreTest.java
@@ -26,6 +26,7 @@ import org.apache.flink.runtime.persistence.PossibleInconsistentStateException;
 import org.apache.flink.runtime.persistence.RetrievableStateStorageHelper;
 import org.apache.flink.runtime.persistence.StateHandleStore;
 import org.apache.flink.runtime.persistence.TestingLongStateHandleHelper;
+import org.apache.flink.runtime.rest.util.NoOpFatalErrorHandler;
 import org.apache.flink.runtime.state.RetrievableStateHandle;
 import org.apache.flink.runtime.util.ZooKeeperUtils;
 import org.apache.flink.util.InstantiationUtil;
@@ -782,8 +783,12 @@ public class ZooKeeperStateHandleStoreTest extends TestLogger {
         configuration.setInteger(HighAvailabilityOptions.ZOOKEEPER_SESSION_TIMEOUT, 100);
         configuration.setString(HighAvailabilityOptions.HA_ZOOKEEPER_ROOT, "timeout");
 
-        try (CuratorFramework client = ZooKeeperUtils.startCuratorFramework(configuration);
-                CuratorFramework client2 = ZooKeeperUtils.startCuratorFramework(configuration)) {
+        try (CuratorFramework client =
+                        ZooKeeperUtils.startCuratorFramework(
+                                configuration, NoOpFatalErrorHandler.INSTANCE);
+                CuratorFramework client2 =
+                        ZooKeeperUtils.startCuratorFramework(
+                                configuration, NoOpFatalErrorHandler.INSTANCE)) {
 
             ZooKeeperStateHandleStore<TestingLongStateHandleHelper.LongStateHandle> zkStore =
                     new ZooKeeperStateHandleStore<>(client, longStateStorage);

--- a/flink-runtime/src/test/java/org/apache/flink/runtime/zookeeper/ZooKeeperTestEnvironment.java
+++ b/flink-runtime/src/test/java/org/apache/flink/runtime/zookeeper/ZooKeeperTestEnvironment.java
@@ -20,6 +20,7 @@ package org.apache.flink.runtime.zookeeper;
 
 import org.apache.flink.configuration.Configuration;
 import org.apache.flink.configuration.HighAvailabilityOptions;
+import org.apache.flink.runtime.rest.util.NoOpFatalErrorHandler;
 import org.apache.flink.runtime.util.ZooKeeperUtils;
 
 import org.apache.flink.shaded.curator4.org.apache.curator.framework.CuratorFramework;
@@ -74,7 +75,7 @@ public class ZooKeeperTestEnvironment {
                         zooKeeperCluster.getConnectString());
             }
 
-            client = ZooKeeperUtils.startCuratorFramework(conf);
+            client = ZooKeeperUtils.startCuratorFramework(conf, NoOpFatalErrorHandler.INSTANCE);
 
             client.newNamespaceAwareEnsurePath("/").ensure(client.getZookeeperClient());
         } catch (Exception e) {
@@ -127,7 +128,7 @@ public class ZooKeeperTestEnvironment {
     public CuratorFramework createClient() {
         Configuration config = new Configuration();
         config.setString(HighAvailabilityOptions.HA_ZOOKEEPER_QUORUM, getConnectString());
-        return ZooKeeperUtils.startCuratorFramework(config);
+        return ZooKeeperUtils.startCuratorFramework(config, NoOpFatalErrorHandler.INSTANCE);
     }
 
     /**

--- a/flink-tests/src/test/java/org/apache/flink/test/recovery/JobManagerHAProcessFailureRecoveryITCase.java
+++ b/flink-tests/src/test/java/org/apache/flink/test/recovery/JobManagerHAProcessFailureRecoveryITCase.java
@@ -40,6 +40,7 @@ import org.apache.flink.runtime.highavailability.HighAvailabilityServices;
 import org.apache.flink.runtime.highavailability.HighAvailabilityServicesUtils;
 import org.apache.flink.runtime.leaderelection.TestingListener;
 import org.apache.flink.runtime.leaderretrieval.LeaderRetrievalService;
+import org.apache.flink.runtime.rest.util.NoOpFatalErrorHandler;
 import org.apache.flink.runtime.rpc.RpcService;
 import org.apache.flink.runtime.rpc.RpcSystem;
 import org.apache.flink.runtime.rpc.RpcUtils;
@@ -286,7 +287,7 @@ public class JobManagerHAProcessFailureRecoveryITCase extends TestLogger {
 
             highAvailabilityServices =
                     HighAvailabilityServicesUtils.createAvailableOrEmbeddedServices(
-                            config, TestingUtils.defaultExecutor());
+                            config, TestingUtils.defaultExecutor(), NoOpFatalErrorHandler.INSTANCE);
 
             final PluginManager pluginManager =
                     PluginUtils.createPluginManagerFromRootFolder(config);

--- a/flink-tests/src/test/java/org/apache/flink/test/recovery/ProcessFailureCancelingITCase.java
+++ b/flink-tests/src/test/java/org/apache/flink/test/recovery/ProcessFailureCancelingITCase.java
@@ -42,6 +42,7 @@ import org.apache.flink.runtime.highavailability.HighAvailabilityServices;
 import org.apache.flink.runtime.highavailability.HighAvailabilityServicesUtils;
 import org.apache.flink.runtime.metrics.NoOpMetricRegistry;
 import org.apache.flink.runtime.resourcemanager.StandaloneResourceManagerFactory;
+import org.apache.flink.runtime.rest.util.NoOpFatalErrorHandler;
 import org.apache.flink.runtime.rpc.AddressResolution;
 import org.apache.flink.runtime.rpc.RpcService;
 import org.apache.flink.runtime.rpc.RpcSystem;
@@ -130,7 +131,8 @@ public class ProcessFailureCancelingITCase extends TestLogger {
                         config,
                         ioExecutor,
                         AddressResolution.NO_ADDRESS_RESOLUTION,
-                        RpcSystem.load());
+                        RpcSystem.load(),
+                        NoOpFatalErrorHandler.INSTANCE);
 
         final AtomicReference<Throwable> programException = new AtomicReference<>();
 


### PR DESCRIPTION
## What is the purpose of the change

As described in issue , this PR is meant to fix the potential job unrecoverable due to network failure . This is done by add an unhandledErrorListener before start curator client

Tests:
ZookeeperUtilsTest#testStartCuratorFrameworkFailed

## Does this pull request potentially affect one of the following parts:

  - Dependencies (does it add or upgrade a dependency): (no)
  - The public API, i.e., is any changed class annotated with `@Public(Evolving)`: (no)
  - The serializers: (no)
  - The runtime per-record code paths (performance sensitive): (no)
  - Anything that affects deployment or recovery: JobManager (and its components), Checkpointing, Kubernetes/Yarn, ZooKeeper: (yes)
  - The S3 file system connector: (no)
