### PR TITLE
[FLINK-22367][streaming] Reset syncSavepointId only if it is equal to…

### DIFF
--- a/flink-streaming-java/src/main/java/org/apache/flink/streaming/runtime/tasks/StreamTask.java
+++ b/flink-streaming-java/src/main/java/org/apache/flink/streaming/runtime/tasks/StreamTask.java
@@ -451,7 +451,7 @@ public abstract class StreamTask<OUT, OP extends StreamOperator<OUT>> extends Ab
             operatorChain.setIgnoreEndOfInput(false);
         }
 
-        if (syncSavepointId != null && syncSavepointId == id) {
+        if (syncSavepointId != null && syncSavepointId <= id) {
             syncSavepointId = null;
         }
     }

--- a/flink-streaming-java/src/main/java/org/apache/flink/streaming/runtime/tasks/StreamTask.java
+++ b/flink-streaming-java/src/main/java/org/apache/flink/streaming/runtime/tasks/StreamTask.java
@@ -450,7 +450,10 @@ public abstract class StreamTask<OUT, OP extends StreamOperator<OUT>> extends Ab
             activeSyncSavepointId = null;
             operatorChain.setIgnoreEndOfInput(false);
         }
-        syncSavepointId = null;
+
+        if (syncSavepointId != null && syncSavepointId == id) {
+            syncSavepointId = null;
+        }
     }
 
     private void setSynchronousSavepointId(long checkpointId, boolean ignoreEndOfInput) {

--- a/flink-streaming-java/src/test/java/org/apache/flink/streaming/runtime/tasks/StreamTaskTest.java
+++ b/flink-streaming-java/src/test/java/org/apache/flink/streaming/runtime/tasks/StreamTaskTest.java
@@ -1299,8 +1299,8 @@ public class StreamTaskTest extends TestLogger {
                                         CheckpointStorageLocationReference.getDefault()),
                                 new CheckpointMetricsBuilder()),
                 "test");
-        executor.execute(() -> harness.streamTask.notifyCheckpointAbortAsync(1), "test");
-        executor.execute(() -> harness.streamTask.notifyCheckpointCompleteAsync(2), "test");
+        harness.streamTask.notifyCheckpointAbortAsync(1);
+        harness.streamTask.notifyCheckpointCompleteAsync(2);
 
         harness.processAll();
 

--- a/flink-streaming-java/src/test/java/org/apache/flink/streaming/runtime/tasks/StreamTaskTest.java
+++ b/flink-streaming-java/src/test/java/org/apache/flink/streaming/runtime/tasks/StreamTaskTest.java
@@ -64,6 +64,7 @@ import org.apache.flink.runtime.shuffle.PartitionDescriptorBuilder;
 import org.apache.flink.runtime.shuffle.ShuffleEnvironment;
 import org.apache.flink.runtime.state.AbstractKeyedStateBackend;
 import org.apache.flink.runtime.state.AbstractStateBackend;
+import org.apache.flink.runtime.state.CheckpointStorageLocationReference;
 import org.apache.flink.runtime.state.CheckpointStreamFactory;
 import org.apache.flink.runtime.state.CheckpointableKeyedStateBackend;
 import org.apache.flink.runtime.state.DoneFuture;
@@ -1262,6 +1263,42 @@ public class StreamTaskTest extends TestLogger {
                 CheckpointOptions.forCheckpointWithDefaultLocation(),
                 new CheckpointMetricsBuilder());
         assertEquals(1, harness.getCheckpointResponder().getDeclineReports().size());
+    }
+
+    @Test
+    public void testAbortPreviousCheckpointBeforeCompleteTerminateSavepoint() throws Throwable {
+        // given: Marker that the task is finished.
+        AtomicBoolean finishTask = new AtomicBoolean();
+        StreamTaskMailboxTestHarnessBuilder<Integer> builder =
+                new StreamTaskMailboxTestHarnessBuilder<>(
+                                (env) ->
+                                        new OneInputStreamTask<Integer, Integer>(env) {
+                                            @Override
+                                            protected void finishTask() throws Exception {
+                                                super.finishTask();
+                                                finishTask.set(true);
+                                            }
+                                        },
+                                BasicTypeInfo.INT_TYPE_INFO)
+                        .addInput(BasicTypeInfo.INT_TYPE_INFO);
+        StreamTaskMailboxTestHarness<Integer> harness =
+                builder.setupOutputForSingletonOperatorChain(
+                                new TestBoundedOneInputStreamOperator())
+                        .build();
+
+        // when: Receiving the abort notification of the previous checkpoint before the complete
+        // notification of the savepoint terminate.
+        harness.streamTask.notifyCheckpointAbortAsync(1);
+        harness.streamTask.notifyCheckpointCompleteAsync(2);
+        harness.streamTask.triggerCheckpointOnBarrier(
+                new CheckpointMetaData(2, 0),
+                new CheckpointOptions(
+                        CheckpointType.SAVEPOINT_TERMINATE,
+                        CheckpointStorageLocationReference.getDefault()),
+                new CheckpointMetricsBuilder());
+
+        // then: The task should be finished.
+        assertEquals(true, finishTask.get());
     }
 
     @Test


### PR DESCRIPTION
… checkpoint id from event

<!--
*Thank you very much for contributing to Apache Flink - we are happy that you want to help us improve Flink. To help the community review your contribution in the best possible way, please go through the checklist below, which will get the contribution into a shape in which it can be best reviewed.*

*Please understand that we do not do this to make contributions to Flink a hassle. In order to uphold a high standard of quality for code contributions, while at the same time managing a large number of contributions, we need contributors to prepare the contributions well, and give reviewers enough contextual information for the review. Please also understand that contributions that do not follow this guide will take longer to review and thus typically be picked up with lower priority by the community.*

## Contribution Checklist

  - Make sure that the pull request corresponds to a [JIRA issue](https://issues.apache.org/jira/projects/FLINK/issues). Exceptions are made for typos in JavaDoc or documentation files, which need no JIRA issue.
  
  - Name the pull request in the form "[FLINK-XXXX] [component] Title of the pull request", where *FLINK-XXXX* should be replaced by the actual issue number. Skip *component* if you are unsure about which is the best component.
  Typo fixes that have no associated JIRA issue should be named following this pattern: `[hotfix] [docs] Fix typo in event time introduction` or `[hotfix] [javadocs] Expand JavaDoc for PuncuatedWatermarkGenerator`.

  - Fill out the template below to describe the changes contributed by the pull request. That will give reviewers the context they need to do the review.
  
  - Make sure that the change passes the automated tests, i.e., `mvn clean verify` passes. You can set up Azure Pipelines CI to do that following [this guide](https://cwiki.apache.org/confluence/display/FLINK/Azure+Pipelines#AzurePipelines-Tutorial:SettingupAzurePipelinesforaforkoftheFlinkrepository).

  - Each pull request should address only one issue, not mix up code from multiple issues.
  
  - Each commit in the pull request has a meaningful commit message (including the JIRA id)

  - Once all items of the checklist are addressed, remove the above text and this checklist, leaving only the filled out template below.


**(The sections below can be removed for hotfixes of typos)**
-->

## What is the purpose of the change

*PR fixes the bug with resetting syncSavepointId at the wrong time which led to problem with terminateWithSavepointWithoutComplicationsShouldSucceedAndLeadJobToFinished*


## Brief change log

  - *Right now, syncSavepointId can be reset only if it is equal to the checkpoint id from event *


## Verifying this change
This change added tests and can be verified as follows:


  - *Added new test which checks that the abort before completing checkpoint  doesn't lead to the problem with finishing task. *

## Does this pull request potentially affect one of the following parts:

  - Dependencies (does it add or upgrade a dependency): (yes / **no**)
  - The public API, i.e., is any changed class annotated with `@Public(Evolving)`: (yes / **no**)
  - The serializers: (yes / **no** / don't know)
  - The runtime per-record code paths (performance sensitive): (yes / **no** / don't know)
  - Anything that affects deployment or recovery: JobManager (and its components), Checkpointing, Kubernetes/Yarn, ZooKeeper: (yes / **no** / don't know)
  - The S3 file system connector: (yes / **no** / don't know)

## Documentation

  - Does this pull request introduce a new feature? (yes / **no**)
  - If yes, how is the feature documented? (not applicable / docs / JavaDocs / not documented)
