### PR TITLE
[FLINK-24005][coordination] Only return fulfilled requirements for reserved slots

### DIFF
--- a/flink-runtime/src/main/java/org/apache/flink/runtime/jobmaster/slotpool/AllocatedSlotPool.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/jobmaster/slotpool/AllocatedSlotPool.java
@@ -50,9 +50,9 @@ public interface AllocatedSlotPool {
      * Removes all slots belonging to the owning TaskExecutor identified by owner.
      *
      * @param owner owner identifies the TaskExecutor whose slots shall be removed
-     * @return the collection of removed slots
+     * @return the collection of removed slots and for each slot whether it was currently free
      */
-    Collection<AllocatedSlot> removeSlots(ResourceID owner);
+    AllocatedSlotsAndReservationStatus removeSlots(ResourceID owner);
 
     /**
      * Checks whether the slot pool contains at least one slot belonging to the specified owner.
@@ -130,5 +130,12 @@ public interface AllocatedSlotPool {
         default AllocationID getAllocationId() {
             return asSlotInfo().getAllocationId();
         }
+    }
+
+    /** A collection of {@link AllocatedSlot AllocatedSlots} and their reservation status. */
+    interface AllocatedSlotsAndReservationStatus {
+        boolean wasFree(AllocatedSlot allocatedSlot);
+
+        Collection<AllocatedSlot> getAllocatedSlots();
     }
 }

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/jobmaster/slotpool/AllocatedSlotPool.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/jobmaster/slotpool/AllocatedSlotPool.java
@@ -134,7 +134,7 @@ public interface AllocatedSlotPool {
 
     /** A collection of {@link AllocatedSlot AllocatedSlots} and their reservation status. */
     interface AllocatedSlotsAndReservationStatus {
-        boolean wasFree(AllocatedSlot allocatedSlot);
+        boolean wasFree(AllocationID allocatedSlot);
 
         Collection<AllocatedSlot> getAllocatedSlots();
     }

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/jobmaster/slotpool/DeclarativeSlotPool.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/jobmaster/slotpool/DeclarativeSlotPool.java
@@ -132,7 +132,7 @@ public interface DeclarativeSlotPool {
      * @param allocationId allocationId identifying the slot to release
      * @param cause cause for releasing the slot; can be {@code null}
      * @param currentTime currentTime when the slot was released
-     * @return resource information about freed slot
+     * @return the resource requirements that the slot was fulfilling
      */
     ResourceCounter freeReservedSlot(
             AllocationID allocationId, @Nullable Throwable cause, long currentTime);
@@ -142,7 +142,8 @@ public interface DeclarativeSlotPool {
      *
      * @param owner owner identifying the owning TaskExecutor
      * @param cause cause for failing the slots
-     * @return resource information about released slots
+     * @return the resource requirements that all slots were fulfilling; empty if all slots were
+     *     currently free
      */
     ResourceCounter releaseSlots(ResourceID owner, Exception cause);
 
@@ -151,7 +152,8 @@ public interface DeclarativeSlotPool {
      *
      * @param allocationId allocationId identifying the slot to fail
      * @param cause cause for failing the slot
-     * @return resource information about released slot
+     * @return the resource requirements that the slot was fulfilling; empty if the slot was
+     *     currently free
      */
     ResourceCounter releaseSlot(AllocationID allocationId, Exception cause);
 

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/jobmaster/slotpool/DefaultDeclarativeSlotPool.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/jobmaster/slotpool/DefaultDeclarativeSlotPool.java
@@ -374,7 +374,7 @@ public class DefaultDeclarativeSlotPool implements DeclarativeSlotPool {
 
         final Collection<AllocatedSlot> slotsToFree = new ArrayList<>();
         for (AllocatedSlot removedSlot : removedSlots.getAllocatedSlots()) {
-            if (!removedSlots.wasFree(removedSlot)) {
+            if (!removedSlots.wasFree(removedSlot.getAllocationId())) {
                 slotsToFree.add(removedSlot);
             }
         }

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/jobmaster/slotpool/DefaultDeclarativeSlotPool.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/jobmaster/slotpool/DefaultDeclarativeSlotPool.java
@@ -65,6 +65,21 @@ import java.util.stream.Collectors;
  *
  * <p>The slot pool will call {@link #newSlotsListener} whenever newly offered slots are accepted or
  * if an allocated slot should become free after it is being {@link #freeReservedSlot freed}.
+ *
+ * <p>This class expects 1 of 2 access patterns for changing requirements, which should not be
+ * mixed:
+ *
+ * <p>1) the legacy approach (used by the DefaultScheduler) tightly couples requirements to reserved
+ * slots. When a slot is requested it increases the requirements, when the slot is freed they are
+ * decreased again. In the general case what happens is that requirements are increased, a free slot
+ * is reserved, (the slot is used for a bit,) the slot is freed, the requirements are reduced. To
+ * this end {@link #freeReservedSlot}, {@link #releaseSlot} and {@link #releaseSlots} return a
+ * {@link ResourceCounter} describing which requirement the slot(s) were fulfilling, with the
+ * expectation that the scheduler will subsequently decrease the requirements by that amount.
+ *
+ * <p>2) The declarative approach (used by the AdaptiveScheduler) in contrast derives requirements
+ * exclusively based on what a given job currently requires. It may repeatedly reserve/free slots
+ * without any modifications to the requirements.
  */
 public class DefaultDeclarativeSlotPool implements DeclarativeSlotPool {
 
@@ -354,30 +369,49 @@ public class DefaultDeclarativeSlotPool implements DeclarativeSlotPool {
 
     @Override
     public ResourceCounter releaseSlots(ResourceID owner, Exception cause) {
-        final Collection<AllocatedSlot> removedSlots = slotPool.removeSlots(owner);
+        final AllocatedSlotPool.AllocatedSlotsAndReservationStatus removedSlots =
+                slotPool.removeSlots(owner);
 
-        ResourceCounter previouslyFulfilledRequirements = getFulfilledRequirements(removedSlots);
+        final Collection<AllocatedSlot> slotsToFree = new ArrayList<>();
+        for (AllocatedSlot removedSlot : removedSlots.getAllocatedSlots()) {
+            if (!removedSlots.wasFree(removedSlot)) {
+                slotsToFree.add(removedSlot);
+            }
+        }
 
-        releasePayload(removedSlots, cause);
-        releaseSlots(removedSlots, cause);
-
-        return previouslyFulfilledRequirements;
+        return freeAndReleaseSlots(slotsToFree, removedSlots.getAllocatedSlots(), cause);
     }
 
     @Override
     public ResourceCounter releaseSlot(AllocationID allocationId, Exception cause) {
+        final boolean wasSlotFree = slotPool.containsFreeSlot(allocationId);
         final Optional<AllocatedSlot> removedSlot = slotPool.removeSlot(allocationId);
 
-        Optional<ResourceCounter> previouslyFulfilledRequirement =
-                removedSlot.map(Collections::singleton).map(this::getFulfilledRequirements);
+        if (removedSlot.isPresent()) {
+            final AllocatedSlot slot = removedSlot.get();
 
-        removedSlot.ifPresent(
-                allocatedSlot -> {
-                    releasePayload(Collections.singleton(allocatedSlot), cause);
-                    releaseSlots(Collections.singleton(allocatedSlot), cause);
-                });
+            final Collection<AllocatedSlot> slotAsCollection = Collections.singleton(slot);
+            return freeAndReleaseSlots(
+                    wasSlotFree ? Collections.emptySet() : slotAsCollection,
+                    slotAsCollection,
+                    cause);
+        } else {
+            return ResourceCounter.empty();
+        }
+    }
 
-        return previouslyFulfilledRequirement.orElseGet(ResourceCounter::empty);
+    private ResourceCounter freeAndReleaseSlots(
+            Collection<AllocatedSlot> currentlyReservedSlots,
+            Collection<AllocatedSlot> slots,
+            Exception cause) {
+
+        ResourceCounter previouslyFulfilledRequirements =
+                getFulfilledRequirements(currentlyReservedSlots);
+
+        releasePayload(currentlyReservedSlots, cause);
+        releaseSlots(slots, cause);
+
+        return previouslyFulfilledRequirements;
     }
 
     private void releasePayload(Iterable<? extends AllocatedSlot> allocatedSlots, Throwable cause) {

--- a/flink-runtime/src/test/java/org/apache/flink/runtime/jobmaster/slotpool/DefaultAllocatedSlotPoolTest.java
+++ b/flink-runtime/src/test/java/org/apache/flink/runtime/jobmaster/slotpool/DefaultAllocatedSlotPoolTest.java
@@ -121,8 +121,8 @@ public class DefaultAllocatedSlotPoolTest extends TestLogger {
                 allocatedSlotsAndReservationStatus = slotPool.removeSlots(owner);
 
         assertThat(allocatedSlotsAndReservationStatus.getAllocatedSlots(), hasItems(slot1, slot2));
-        assertThat(allocatedSlotsAndReservationStatus.wasFree(slot1), is(false));
-        assertThat(allocatedSlotsAndReservationStatus.wasFree(slot2), is(true));
+        assertThat(allocatedSlotsAndReservationStatus.wasFree(slot1.getAllocationId()), is(false));
+        assertThat(allocatedSlotsAndReservationStatus.wasFree(slot2.getAllocationId()), is(true));
     }
 
     @Test

--- a/flink-runtime/src/test/java/org/apache/flink/runtime/jobmaster/slotpool/DefaultAllocatedSlotPoolTest.java
+++ b/flink-runtime/src/test/java/org/apache/flink/runtime/jobmaster/slotpool/DefaultAllocatedSlotPoolTest.java
@@ -49,6 +49,7 @@ import java.util.Map;
 import java.util.function.Function;
 import java.util.stream.Collectors;
 
+import static org.hamcrest.CoreMatchers.hasItems;
 import static org.hamcrest.CoreMatchers.is;
 import static org.hamcrest.Matchers.closeTo;
 import static org.hamcrest.Matchers.hasSize;
@@ -103,6 +104,25 @@ public class DefaultAllocatedSlotPoolTest extends TestLogger {
         slotPool.removeSlots(owner);
 
         assertSlotPoolContainsSlots(slotPool, Collections.singleton(otherSlot));
+    }
+
+    @Test
+    public void testRemoveSlotsReturnValue() {
+        final DefaultAllocatedSlotPool slotPool = new DefaultAllocatedSlotPool();
+
+        final ResourceID owner = ResourceID.generate();
+        final AllocatedSlot slot1 = createAllocatedSlot(owner);
+        final AllocatedSlot slot2 = createAllocatedSlot(owner);
+
+        slotPool.addSlots(Arrays.asList(slot1, slot2), 0);
+        slotPool.reserveFreeSlot(slot1.getAllocationId());
+
+        final AllocatedSlotPool.AllocatedSlotsAndReservationStatus
+                allocatedSlotsAndReservationStatus = slotPool.removeSlots(owner);
+
+        assertThat(allocatedSlotsAndReservationStatus.getAllocatedSlots(), hasItems(slot1, slot2));
+        assertThat(allocatedSlotsAndReservationStatus.wasFree(slot1), is(false));
+        assertThat(allocatedSlotsAndReservationStatus.wasFree(slot2), is(true));
     }
 
     @Test

--- a/flink-runtime/src/test/java/org/apache/flink/runtime/jobmaster/slotpool/DefaultDeclarativeSlotPoolTest.java
+++ b/flink-runtime/src/test/java/org/apache/flink/runtime/jobmaster/slotpool/DefaultDeclarativeSlotPoolTest.java
@@ -285,7 +285,7 @@ public class DefaultDeclarativeSlotPoolTest extends TestLogger {
                     slotPool.reserveFreeSlot(
                                     slotToReserve.getAllocationId(),
                                     slotToReserve.getResourceProfile())
-                            .tryAssignPayload(new TestPhysicalSlotPayload());
+                            .tryAssignPayload(new TestingPhysicalSlotPayload());
 
                     final ResourceCounter fulfilledRequirements =
                             slotPool.releaseSlots(
@@ -309,7 +309,7 @@ public class DefaultDeclarativeSlotPoolTest extends TestLogger {
                     slotPool.reserveFreeSlot(
                                     slotToReserve.getAllocationId(),
                                     slotToReserve.getResourceProfile())
-                            .tryAssignPayload(new TestPhysicalSlotPayload());
+                            .tryAssignPayload(new TestingPhysicalSlotPayload());
 
                     final ResourceCounter fulfilledRequirementsOfFreeSlot =
                             slotPool.releaseSlot(
@@ -819,17 +819,6 @@ public class DefaultDeclarativeSlotPoolTest extends TestLogger {
             freedSlots.drainTo(result);
 
             return result;
-        }
-    }
-
-    private static class TestPhysicalSlotPayload implements PhysicalSlot.Payload {
-
-        @Override
-        public void release(Throwable cause) {}
-
-        @Override
-        public boolean willOccupySlotIndefinitely() {
-            return false;
         }
     }
 }

--- a/flink-runtime/src/test/java/org/apache/flink/runtime/jobmaster/slotpool/DefaultDeclarativeSlotPoolTest.java
+++ b/flink-runtime/src/test/java/org/apache/flink/runtime/jobmaster/slotpool/DefaultDeclarativeSlotPoolTest.java
@@ -28,9 +28,11 @@ import org.apache.flink.runtime.taskexecutor.TestingTaskExecutorGateway;
 import org.apache.flink.runtime.taskexecutor.TestingTaskExecutorGatewayBuilder;
 import org.apache.flink.runtime.taskexecutor.slot.SlotOffer;
 import org.apache.flink.runtime.taskmanager.LocalTaskManagerLocation;
+import org.apache.flink.runtime.taskmanager.TaskManagerLocation;
 import org.apache.flink.runtime.util.ResourceCounter;
 import org.apache.flink.util.FlinkException;
 import org.apache.flink.util.TestLogger;
+import org.apache.flink.util.function.QuadConsumer;
 
 import org.apache.flink.shaded.guava30.com.google.common.collect.Iterables;
 
@@ -44,6 +46,7 @@ import javax.annotation.Nullable;
 import java.util.ArrayList;
 import java.util.Collection;
 import java.util.HashMap;
+import java.util.Iterator;
 import java.util.Map;
 import java.util.concurrent.ArrayBlockingQueue;
 import java.util.concurrent.BlockingQueue;
@@ -273,6 +276,85 @@ public class DefaultDeclarativeSlotPoolTest extends TestLogger {
         assertThat(
                 freedSlots,
                 containsInAnyOrder(slotOffers.stream().map(SlotOffer::getAllocationId).toArray()));
+    }
+
+    @Test
+    public void testReleaseSlotsOnlyReturnsFulfilledRequirementsOfReservedSlots() {
+        withSlotPoolContainingOneTaskManagerWithTwoSlotsWithUniqueResourceProfiles(
+                (slotPool, freeSlot, slotToReserve, taskManagerLocation) -> {
+                    slotPool.reserveFreeSlot(
+                                    slotToReserve.getAllocationId(),
+                                    slotToReserve.getResourceProfile())
+                            .tryAssignPayload(new TestPhysicalSlotPayload());
+
+                    final ResourceCounter fulfilledRequirements =
+                            slotPool.releaseSlots(
+                                    taskManagerLocation.getResourceID(),
+                                    new FlinkException("Test failure"));
+
+                    assertThat(
+                            fulfilledRequirements.getResourceCount(freeSlot.getResourceProfile()),
+                            is(0));
+                    assertThat(
+                            fulfilledRequirements.getResourceCount(
+                                    slotToReserve.getResourceProfile()),
+                            is(1));
+                });
+    }
+
+    @Test
+    public void testReleaseSlotOnlyReturnsFulfilledRequirementsOfReservedSlots() {
+        withSlotPoolContainingOneTaskManagerWithTwoSlotsWithUniqueResourceProfiles(
+                (slotPool, freeSlot, slotToReserve, ignored) -> {
+                    slotPool.reserveFreeSlot(
+                                    slotToReserve.getAllocationId(),
+                                    slotToReserve.getResourceProfile())
+                            .tryAssignPayload(new TestPhysicalSlotPayload());
+
+                    final ResourceCounter fulfilledRequirementsOfFreeSlot =
+                            slotPool.releaseSlot(
+                                    freeSlot.getAllocationId(), new FlinkException("Test failure"));
+                    final ResourceCounter fulfilledRequirementsOfReservedSlot =
+                            slotPool.releaseSlot(
+                                    slotToReserve.getAllocationId(),
+                                    new FlinkException("Test failure"));
+
+                    assertThat(fulfilledRequirementsOfFreeSlot.getResources(), is(empty()));
+                    assertThat(
+                            fulfilledRequirementsOfReservedSlot.getResourceCount(
+                                    slotToReserve.getResourceProfile()),
+                            is(1));
+                });
+    }
+
+    private static void withSlotPoolContainingOneTaskManagerWithTwoSlotsWithUniqueResourceProfiles(
+            QuadConsumer<DefaultDeclarativeSlotPool, SlotOffer, SlotOffer, TaskManagerLocation>
+                    test) {
+        final DefaultDeclarativeSlotPool slotPool =
+                DefaultDeclarativeSlotPoolBuilder.builder().build();
+
+        final ResourceCounter resourceRequirements =
+                ResourceCounter.withResource(RESOURCE_PROFILE_1, 1).add(RESOURCE_PROFILE_2, 1);
+
+        final LocalTaskManagerLocation taskManagerLocation = new LocalTaskManagerLocation();
+        final FreeSlotConsumer freeSlotConsumer = new FreeSlotConsumer();
+        final TestingTaskExecutorGateway testingTaskExecutorGateway =
+                new TestingTaskExecutorGatewayBuilder()
+                        .setFreeSlotFunction(freeSlotConsumer)
+                        .createTestingTaskExecutorGateway();
+
+        final Iterator<SlotOffer> slotOffers =
+                increaseRequirementsAndOfferSlotsToSlotPool(
+                                slotPool,
+                                resourceRequirements,
+                                taskManagerLocation,
+                                testingTaskExecutorGateway)
+                        .iterator();
+
+        final SlotOffer slot1 = slotOffers.next();
+        final SlotOffer slot2 = slotOffers.next();
+
+        test.accept(slotPool, slot1, slot2, taskManagerLocation);
     }
 
     @Test
@@ -737,6 +819,17 @@ public class DefaultDeclarativeSlotPoolTest extends TestLogger {
             freedSlots.drainTo(result);
 
             return result;
+        }
+    }
+
+    private static class TestPhysicalSlotPayload implements PhysicalSlot.Payload {
+
+        @Override
+        public void release(Throwable cause) {}
+
+        @Override
+        public boolean willOccupySlotIndefinitely() {
+            return false;
         }
     }
 }

--- a/flink-runtime/src/test/java/org/apache/flink/runtime/jobmaster/slotpool/TestingPhysicalSlotPayload.java
+++ b/flink-runtime/src/test/java/org/apache/flink/runtime/jobmaster/slotpool/TestingPhysicalSlotPayload.java
@@ -1,0 +1,30 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.flink.runtime.jobmaster.slotpool;
+
+/** Dummy payload. */
+public class TestingPhysicalSlotPayload implements PhysicalSlot.Payload {
+
+    @Override
+    public void release(Throwable cause) {}
+
+    @Override
+    public boolean willOccupySlotIndefinitely() {
+        return false;
+    }
+}

--- a/flink-runtime/src/test/java/org/apache/flink/runtime/scheduler/adaptive/allocator/SharedSlotTest.java
+++ b/flink-runtime/src/test/java/org/apache/flink/runtime/scheduler/adaptive/allocator/SharedSlotTest.java
@@ -21,7 +21,7 @@ import org.apache.flink.runtime.jobmanager.scheduler.Locality;
 import org.apache.flink.runtime.jobmaster.LogicalSlot;
 import org.apache.flink.runtime.jobmaster.SlotRequestId;
 import org.apache.flink.runtime.jobmaster.TestingLogicalSlotBuilder;
-import org.apache.flink.runtime.jobmaster.slotpool.PhysicalSlot;
+import org.apache.flink.runtime.jobmaster.slotpool.TestingPhysicalSlotPayload;
 import org.apache.flink.runtime.scheduler.TestingPhysicalSlot;
 import org.apache.flink.util.TestLogger;
 
@@ -53,7 +53,7 @@ public class SharedSlotTest extends TestLogger {
     @Test(expected = IllegalStateException.class)
     public void testConstructorFailsIfSlotAlreadyHasAssignedPayload() {
         final TestingPhysicalSlot physicalSlot = TestingPhysicalSlot.builder().build();
-        physicalSlot.tryAssignPayload(new TestPhysicalSlotPayload());
+        physicalSlot.tryAssignPayload(new TestingPhysicalSlotPayload());
 
         new SharedSlot(new SlotRequestId(), physicalSlot, false, () -> {});
     }
@@ -219,17 +219,6 @@ public class SharedSlotTest extends TestLogger {
                 new TestLogicalSlotPayload(ignored -> sharedSlot.allocateLogicalSlot()));
 
         sharedSlot.release(new Exception("test"));
-    }
-
-    private static class TestPhysicalSlotPayload implements PhysicalSlot.Payload {
-
-        @Override
-        public void release(Throwable cause) {}
-
-        @Override
-        public boolean willOccupySlotIndefinitely() {
-            return false;
-        }
     }
 
     private static class TestLogicalSlotPayload implements LogicalSlot.Payload {


### PR DESCRIPTION
When a slot is released in the `DefaultDeclarativeSlotPool` then the pool returns a `ResourceCounter` describing which requirements said slots were fulfilling, such that the `DeclarativeSlotPoolBridge` can then reduce the requirements accordingly.

The pool however did not take into account that the released slot may already be free; in that case the requirements were already reduced previously (at the time the slot was freed); according to the returned `ResourceCounter` the slot was nevertheless still fulfilling the previous requirement, which lead to a requirement reduction being applied twice.

The pool now checks for all slots that are released whether they are currently reserved or not, and only determines the fulfilled requirements for the reserved ones.

To determine whether a slot was reserved or not `AllocatedSlotPool#removeSlots` was modified to also return the reservation status.

With this change the behavior of `#releaseSlot(s)` and `#freeReservedSlot` are much more aligned