### PR TITLE
[FLINK-23895][table] Upsert materializer is not inserted for all sink providers

### DIFF
--- a/flink-table/flink-table-api-java-bridge/src/main/java/org/apache/flink/table/connector/sink/DataStreamSinkProvider.java
+++ b/flink-table/flink-table-api-java-bridge/src/main/java/org/apache/flink/table/connector/sink/DataStreamSinkProvider.java
@@ -28,8 +28,9 @@ import org.apache.flink.table.data.RowData;
  * DynamicTableSink}.
  *
  * <p>Note: This provider is only meant for advanced connector developers. Usually, a sink should
- * consist of a single entity expressed via {@link OutputFormatProvider} or {@link
- * SinkFunctionProvider}, or {@link SinkProvider}.
+ * consist of a single entity expressed via {@link SinkProvider}, {@link SinkFunctionProvider}, or
+ * {@link OutputFormatProvider}. When using a {@link DataStream} an implementer needs to pay
+ * attention to how changes are shuffled to not mess up the changelog per parallel subtask.
  */
 @PublicEvolving
 public interface DataStreamSinkProvider extends DynamicTableSink.SinkRuntimeProvider {

--- a/flink-table/flink-table-api-java-bridge/src/main/java/org/apache/flink/table/connector/sink/DataStreamSinkProvider.java
+++ b/flink-table/flink-table-api-java-bridge/src/main/java/org/apache/flink/table/connector/sink/DataStreamSinkProvider.java
@@ -21,7 +21,10 @@ package org.apache.flink.table.connector.sink;
 import org.apache.flink.annotation.PublicEvolving;
 import org.apache.flink.streaming.api.datastream.DataStream;
 import org.apache.flink.streaming.api.datastream.DataStreamSink;
+import org.apache.flink.table.connector.ParallelismProvider;
 import org.apache.flink.table.data.RowData;
+
+import java.util.Optional;
 
 /**
  * Provider that consumes a Java {@link DataStream} as a runtime implementation for {@link
@@ -33,11 +36,24 @@ import org.apache.flink.table.data.RowData;
  * attention to how changes are shuffled to not mess up the changelog per parallel subtask.
  */
 @PublicEvolving
-public interface DataStreamSinkProvider extends DynamicTableSink.SinkRuntimeProvider {
+public interface DataStreamSinkProvider
+        extends DynamicTableSink.SinkRuntimeProvider, ParallelismProvider {
 
     /**
      * Consumes the given Java {@link DataStream} and returns the sink transformation {@link
      * DataStreamSink}.
      */
     DataStreamSink<?> consumeDataStream(DataStream<RowData> dataStream);
+
+    /**
+     * {@inheritDoc}
+     *
+     * <p>Note: If a custom parallelism is returned and {@link #consumeDataStream(DataStream)}
+     * applies multiple transformations, make sure to set the same custom parallelism to each
+     * operator to not mess up the changelog.
+     */
+    @Override
+    default Optional<Integer> getParallelism() {
+        return Optional.empty();
+    }
 }

--- a/flink-table/flink-table-api-java-bridge/src/main/java/org/apache/flink/table/connector/sink/SinkFunctionProvider.java
+++ b/flink-table/flink-table-api-java-bridge/src/main/java/org/apache/flink/table/connector/sink/SinkFunctionProvider.java
@@ -23,6 +23,8 @@ import org.apache.flink.streaming.api.functions.sink.SinkFunction;
 import org.apache.flink.table.connector.ParallelismProvider;
 import org.apache.flink.table.data.RowData;
 
+import javax.annotation.Nullable;
+
 import java.util.Optional;
 
 /**
@@ -39,7 +41,8 @@ public interface SinkFunctionProvider
     }
 
     /** Helper method for creating a SinkFunction provider with a provided sink parallelism. */
-    static SinkFunctionProvider of(SinkFunction<RowData> sinkFunction, Integer sinkParallelism) {
+    static SinkFunctionProvider of(
+            SinkFunction<RowData> sinkFunction, @Nullable Integer sinkParallelism) {
         return new SinkFunctionProvider() {
 
             @Override

--- a/flink-table/flink-table-api-java-bridge/src/main/java/org/apache/flink/table/connector/source/DataStreamScanProvider.java
+++ b/flink-table/flink-table-api-java-bridge/src/main/java/org/apache/flink/table/connector/source/DataStreamScanProvider.java
@@ -28,8 +28,8 @@ import org.apache.flink.table.data.RowData;
  * ScanTableSource}.
  *
  * <p>Note: This provider is only meant for advanced connector developers. Usually, a source should
- * consist of a single entity expressed via {@link InputFormatProvider}, {@link
- * SourceFunctionProvider}, or {@link SourceProvider}.
+ * consist of a single entity expressed via {@link SourceProvider}, {@link SourceFunctionProvider},
+ * or {@link InputFormatProvider}.
  */
 @PublicEvolving
 public interface DataStreamScanProvider extends ScanTableSource.ScanRuntimeProvider {

--- a/flink-table/flink-table-common/src/main/java/org/apache/flink/table/connector/ParallelismProvider.java
+++ b/flink-table/flink-table-common/src/main/java/org/apache/flink/table/connector/ParallelismProvider.java
@@ -19,7 +19,7 @@
 package org.apache.flink.table.connector;
 
 import org.apache.flink.annotation.PublicEvolving;
-import org.apache.flink.table.connector.sink.OutputFormatProvider;
+import org.apache.flink.table.connector.sink.DynamicTableSink.SinkRuntimeProvider;
 
 import java.util.Optional;
 
@@ -27,9 +27,7 @@ import java.util.Optional;
  * Parallelism provider for other connector providers. It allows to express a custom parallelism for
  * the connector runtime implementation. Otherwise the parallelism is determined by the planner.
  *
- * <p>Note: Currently, this interface can only work with {@code
- * org.apache.flink.table.connector.sink.SinkFunctionProvider} in {@code
- * flink-table-api-java-bridge} module and {@link OutputFormatProvider}.
+ * <p>Note: Currently, this interface only works with {@link SinkRuntimeProvider}.
  */
 @PublicEvolving
 public interface ParallelismProvider {
@@ -39,6 +37,10 @@ public interface ParallelismProvider {
      *
      * <p>The parallelism denotes how many parallel instances of a source or sink will be spawned
      * during the execution.
+     *
+     * <p>Enforcing a different parallelism for sinks might mess up the changelog if the input is
+     * not {@link ChangelogMode#insertOnly()}. Therefore, a primary key is required by which the
+     * input will be shuffled before records enter the {@link SinkRuntimeProvider} implementation.
      *
      * @return empty if the connector does not provide a custom parallelism, then the planner will
      *     decide the number of parallel instances by itself.

--- a/flink-table/flink-table-common/src/main/java/org/apache/flink/table/connector/sink/DynamicTableSink.java
+++ b/flink-table/flink-table-common/src/main/java/org/apache/flink/table/connector/sink/DynamicTableSink.java
@@ -22,7 +22,6 @@ import org.apache.flink.annotation.PublicEvolving;
 import org.apache.flink.api.common.typeinfo.TypeInformation;
 import org.apache.flink.table.catalog.ResolvedSchema;
 import org.apache.flink.table.connector.ChangelogMode;
-import org.apache.flink.table.connector.ParallelismProvider;
 import org.apache.flink.table.connector.RuntimeConverter;
 import org.apache.flink.table.connector.sink.abilities.SupportsOverwrite;
 import org.apache.flink.table.connector.sink.abilities.SupportsPartitioning;
@@ -101,10 +100,11 @@ public interface DynamicTableSink {
      * <p>The given {@link Context} offers utilities by the planner for creating runtime
      * implementation with minimal dependencies to internal data structures.
      *
-     * <p>See {@code org.apache.flink.table.connector.sink.SinkFunctionProvider} in {@code
-     * flink-table-api-java-bridge}.
+     * <p>{@link SinkProvider} is the recommended core interface. {@code SinkFunctionProvider} in
+     * {@code flink-table-api-java-bridge} and {@link OutputFormatProvider} are available for
+     * backwards compatibility.
      *
-     * @see ParallelismProvider
+     * @see SinkProvider
      */
     SinkRuntimeProvider getSinkRuntimeProvider(Context context);
 
@@ -186,8 +186,11 @@ public interface DynamicTableSink {
      * SinkRuntimeProvider} serves as the base interface. Concrete {@link SinkRuntimeProvider}
      * interfaces might be located in other Flink modules.
      *
-     * <p>See {@code org.apache.flink.table.connector.sink.SinkFunctionProvider} in {@code
-     * flink-table-api-java-bridge}.
+     * <p>{@link SinkProvider} is the recommended core interface. {@code SinkFunctionProvider} in
+     * {@code flink-table-api-java-bridge} and {@link OutputFormatProvider} are available for
+     * backwards compatibility.
+     *
+     * @see SinkProvider
      */
     interface SinkRuntimeProvider {
         // marker interface

--- a/flink-table/flink-table-common/src/main/java/org/apache/flink/table/connector/sink/SinkProvider.java
+++ b/flink-table/flink-table-common/src/main/java/org/apache/flink/table/connector/sink/SinkProvider.java
@@ -23,9 +23,16 @@ import org.apache.flink.api.connector.sink.Sink;
 import org.apache.flink.table.connector.ParallelismProvider;
 import org.apache.flink.table.data.RowData;
 
+import javax.annotation.Nullable;
+
 import java.util.Optional;
 
-/** Provider of a {@link Sink} instance as a runtime implementation for {@link DynamicTableSink}. */
+/**
+ * Provider of a {@link Sink} instance as a runtime implementation for {@link DynamicTableSink}.
+ *
+ * <p>{@code DataStreamSinkProvider} in {@code flink-table-api-java-bridge} is available for
+ * advanced connector developers.
+ */
 @PublicEvolving
 public interface SinkProvider extends DynamicTableSink.SinkRuntimeProvider, ParallelismProvider {
 
@@ -35,7 +42,7 @@ public interface SinkProvider extends DynamicTableSink.SinkRuntimeProvider, Para
     }
 
     /** Helper method for creating a Sink provider with a provided sink parallelism. */
-    static SinkProvider of(Sink<RowData, ?, ?, ?> sink, Integer sinkParallelism) {
+    static SinkProvider of(Sink<RowData, ?, ?, ?> sink, @Nullable Integer sinkParallelism) {
         return new SinkProvider() {
 
             @Override

--- a/flink-table/flink-table-common/src/main/java/org/apache/flink/table/connector/source/ScanTableSource.java
+++ b/flink-table/flink-table-common/src/main/java/org/apache/flink/table/connector/source/ScanTableSource.java
@@ -85,8 +85,11 @@ public interface ScanTableSource extends DynamicTableSource {
      * <p>The given {@link ScanContext} offers utilities by the planner for creating runtime
      * implementation with minimal dependencies to internal data structures.
      *
-     * <p>See {@code org.apache.flink.table.connector.source.SourceFunctionProvider} in {@code
-     * flink-table-api-java-bridge}.
+     * <p>{@link SourceProvider} is the recommended core interface. {@code SourceFunctionProvider}
+     * in {@code flink-table-api-java-bridge} and {@link InputFormatProvider} are available for
+     * backwards compatibility.
+     *
+     * @see SourceProvider
      */
     ScanRuntimeProvider getScanRuntimeProvider(ScanContext runtimeProviderContext);
 
@@ -115,8 +118,9 @@ public interface ScanTableSource extends DynamicTableSource {
      * ScanRuntimeProvider} serves as the base interface. Concrete {@link ScanRuntimeProvider}
      * interfaces might be located in other Flink modules.
      *
-     * <p>See {@code org.apache.flink.table.connector.source.SourceFunctionProvider} in {@code
-     * flink-table-api-java-bridge}.
+     * <p>{@link SourceProvider} is the recommended core interface. {@code SourceFunctionProvider}
+     * in {@code flink-table-api-java-bridge} and {@link InputFormatProvider} are available for
+     * backwards compatibility.
      */
     interface ScanRuntimeProvider {
 

--- a/flink-table/flink-table-common/src/main/java/org/apache/flink/table/connector/source/SourceProvider.java
+++ b/flink-table/flink-table-common/src/main/java/org/apache/flink/table/connector/source/SourceProvider.java
@@ -25,6 +25,9 @@ import org.apache.flink.table.data.RowData;
 
 /**
  * Provider of a {@link Source} instance as a runtime implementation for {@link ScanTableSource}.
+ *
+ * <p>{@code DataStreamScanProvider} in {@code flink-table-api-java-bridge} is available for
+ * advanced connector developers.
  */
 @PublicEvolving
 public interface SourceProvider extends ScanTableSource.ScanRuntimeProvider {

--- a/flink-table/flink-table-common/src/main/java/org/apache/flink/table/connector/source/abilities/SupportsReadingMetadata.java
+++ b/flink-table/flink-table-common/src/main/java/org/apache/flink/table/connector/source/abilities/SupportsReadingMetadata.java
@@ -20,7 +20,7 @@ package org.apache.flink.table.connector.source.abilities;
 
 import org.apache.flink.annotation.PublicEvolving;
 import org.apache.flink.api.common.typeinfo.TypeInformation;
-import org.apache.flink.table.api.TableSchema;
+import org.apache.flink.table.catalog.ResolvedSchema;
 import org.apache.flink.table.connector.format.DecodingFormat;
 import org.apache.flink.table.connector.source.ScanTableSource;
 import org.apache.flink.table.data.RowData;
@@ -120,10 +120,10 @@ public interface SupportsReadingMetadata {
      * <p>Implementations of this method must be idempotent. The planner might call this method
      * multiple times.
      *
-     * <p>Note: Use the passed data type instead of {@link TableSchema#toPhysicalRowDataType()} for
-     * describing the final output data type when creating {@link TypeInformation}. If the source
-     * implements {@link SupportsProjectionPushDown}, the projection is already considered in the
-     * given output data type.
+     * <p>Note: Use the passed data type instead of {@link ResolvedSchema#toPhysicalRowDataType()}
+     * for describing the final output data type when creating {@link TypeInformation}. If the
+     * source implements {@link SupportsProjectionPushDown}, the projection is already considered in
+     * the given output data type.
      *
      * @param metadataKeys a subset of the keys returned by {@link #listReadableMetadata()}, ordered
      *     by the iteration order of returned map

--- a/flink-table/flink-table-planner/src/test/java/org/apache/flink/table/planner/factories/TestValuesRuntimeFunctions.java
+++ b/flink-table/flink-table-planner/src/test/java/org/apache/flink/table/planner/factories/TestValuesRuntimeFunctions.java
@@ -34,12 +34,8 @@ import org.apache.flink.core.memory.DataOutputViewStreamWrapper;
 import org.apache.flink.runtime.state.FunctionInitializationContext;
 import org.apache.flink.runtime.state.FunctionSnapshotContext;
 import org.apache.flink.streaming.api.checkpoint.CheckpointedFunction;
-import org.apache.flink.streaming.api.datastream.DataStream;
-import org.apache.flink.streaming.api.datastream.DataStreamSink;
 import org.apache.flink.streaming.api.functions.sink.RichSinkFunction;
 import org.apache.flink.streaming.api.functions.source.SourceFunction;
-import org.apache.flink.table.connector.ParallelismProvider;
-import org.apache.flink.table.connector.sink.DataStreamSinkProvider;
 import org.apache.flink.table.connector.sink.DynamicTableSink.DataStructureConverter;
 import org.apache.flink.table.data.RowData;
 import org.apache.flink.table.data.TimestampData;
@@ -62,7 +58,6 @@ import java.util.HashMap;
 import java.util.LinkedList;
 import java.util.List;
 import java.util.Map;
-import java.util.Optional;
 import java.util.concurrent.CompletableFuture;
 import java.util.concurrent.ExecutorService;
 import java.util.concurrent.Executors;
@@ -146,29 +141,6 @@ final class TestValuesRuntimeFunctions {
             globalUpsertResult.clear();
             globalRetractResult.clear();
             watermarkHistory.clear();
-        }
-    }
-
-    // ------------------------------------------------------------------------------------------
-    // Specialized test provider implementations
-    // ------------------------------------------------------------------------------------------
-    static class InternalDataStreamSinkProviderWithParallelism
-            implements DataStreamSinkProvider, ParallelismProvider {
-
-        private final Integer parallelism;
-
-        public InternalDataStreamSinkProviderWithParallelism(Integer parallelism) {
-            this.parallelism = parallelism;
-        }
-
-        @Override
-        public DataStreamSink<?> consumeDataStream(DataStream<RowData> dataStream) {
-            throw new UnsupportedOperationException("should not be called");
-        }
-
-        @Override
-        public Optional<Integer> getParallelism() {
-            return Optional.ofNullable(parallelism);
         }
     }
 

--- a/flink-table/flink-table-planner/src/test/java/org/apache/flink/table/planner/runtime/stream/sql/DataStreamJavaITCase.java
+++ b/flink-table/flink-table-planner/src/test/java/org/apache/flink/table/planner/runtime/stream/sql/DataStreamJavaITCase.java
@@ -71,6 +71,7 @@ import java.time.DayOfWeek;
 import java.time.LocalDateTime;
 import java.time.ZoneId;
 import java.time.ZoneOffset;
+import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.Collections;
 import java.util.List;
@@ -638,6 +639,80 @@ public class DataStreamJavaITCase extends AbstractTestBase {
                 containsInAnyOrder("+I[1]", "+I[2]", "+I[3]"));
     }
 
+    @Test
+    public void testMultiChangelogStreamUpsert() throws Exception {
+        final StreamTableEnvironment tableEnv = StreamTableEnvironment.create(env);
+
+        createTableFromElements(
+                tableEnv,
+                "T1",
+                ChangelogMode.insertOnly(),
+                Schema.newBuilder()
+                        .column("pk", "INT NOT NULL")
+                        .column("x", "STRING NOT NULL")
+                        .primaryKey("pk")
+                        .build(),
+                Arrays.asList(Types.INT, Types.STRING),
+                Row.ofKind(RowKind.INSERT, 1, "1"),
+                Row.ofKind(RowKind.INSERT, 2, "2"));
+
+        createTableFromElements(
+                tableEnv,
+                "T2",
+                ChangelogMode.upsert(),
+                Schema.newBuilder()
+                        .column("pk", "INT NOT NULL")
+                        .column("y", "STRING NOT NULL")
+                        .column("some_value", "DOUBLE NOT NULL")
+                        .primaryKey("pk")
+                        .build(),
+                Arrays.asList(Types.INT, Types.STRING, Types.DOUBLE),
+                Row.ofKind(RowKind.INSERT, 1, "A", 1.0),
+                Row.ofKind(RowKind.INSERT, 2, "B", 2.0),
+                Row.ofKind(RowKind.UPDATE_AFTER, 1, "A", 1.1),
+                Row.ofKind(RowKind.UPDATE_AFTER, 2, "B", 2.1));
+
+        createTableFromElements(
+                tableEnv,
+                "T3",
+                ChangelogMode.insertOnly(),
+                Schema.newBuilder()
+                        .column("pk1", "STRING NOT NULL")
+                        .column("pk2", "STRING NOT NULL")
+                        .column("some_other_value", "DOUBLE NOT NULL")
+                        .primaryKey("pk1", "pk2")
+                        .build(),
+                Arrays.asList(Types.STRING, Types.STRING, Types.DOUBLE),
+                Row.ofKind(RowKind.INSERT, "1", "A", 10.0),
+                Row.ofKind(RowKind.INSERT, "1", "B", 11.0));
+
+        final Table resultTable =
+                tableEnv.sqlQuery(
+                        "SELECT\n"
+                                + "T1.pk,\n"
+                                + "T2.some_value * T3.some_other_value,\n"
+                                + "T3.pk1,\n"
+                                + "T3.pk2\n"
+                                + "FROM T1\n"
+                                + "LEFT JOIN T2 on T1.pk = T2.pk\n"
+                                + "LEFT JOIN T3 ON T1.x = T3.pk1 AND T2.y = T3.pk2");
+
+        final DataStream<Row> resultStream =
+                tableEnv.toChangelogStream(
+                        resultTable,
+                        Schema.newBuilder()
+                                .column("pk", "INT NOT NULL")
+                                .column("some_calculated_value", "DOUBLE")
+                                .column("pk1", "STRING")
+                                .column("pk2", "STRING")
+                                .primaryKey("pk")
+                                .build(),
+                        ChangelogMode.upsert());
+
+        testMaterializedResult(
+                resultStream, 0, Row.of(2, null, null, null), Row.of(1, 11.0, "1", "A"));
+    }
+
     // --------------------------------------------------------------------------------------------
     // Helper methods
     // --------------------------------------------------------------------------------------------
@@ -731,6 +806,24 @@ public class DataStreamJavaITCase extends AbstractTestBase {
                 .toArray(Row[]::new);
     }
 
+    private void createTableFromElements(
+            StreamTableEnvironment tableEnv,
+            String name,
+            ChangelogMode changelogMode,
+            Schema schema,
+            List<TypeInformation<?>> fieldTypeInfo,
+            Row... elements) {
+        final String[] fieldNames =
+                schema.getColumns().stream()
+                        .map(Schema.UnresolvedColumn::getName)
+                        .toArray(String[]::new);
+        final TypeInformation<?>[] fieldTypes = fieldTypeInfo.toArray(new TypeInformation[0]);
+        final DataStream<Row> dataStream =
+                env.fromElements(elements).returns(Types.ROW_NAMED(fieldNames, fieldTypes));
+        final Table table = tableEnv.fromChangelogStream(dataStream, schema, changelogMode);
+        tableEnv.createTemporaryView(name, table);
+    }
+
     private static void testSchema(Table table, Column... expectedColumns) {
         assertEquals(ResolvedSchema.of(expectedColumns), table.getResolvedSchema());
     }
@@ -754,6 +847,36 @@ public class DataStreamJavaITCase extends AbstractTestBase {
         try (CloseableIterator<T> iterator = dataStream.executeAndCollect()) {
             final List<T> list = CollectionUtil.iteratorToList(iterator);
             assertThat(list, containsInAnyOrder(expectedResult));
+        }
+    }
+
+    private static void testMaterializedResult(
+            DataStream<Row> dataStream, int primaryKeyPos, Row... expectedResult) throws Exception {
+        try (CloseableIterator<Row> iterator = dataStream.executeAndCollect()) {
+            final List<Row> materializedResult = new ArrayList<>();
+            iterator.forEachRemaining(
+                    row -> {
+                        final RowKind kind = row.getKind();
+                        row.setKind(RowKind.INSERT);
+                        switch (kind) {
+                            case UPDATE_BEFORE:
+                                materializedResult.remove(row);
+                                break;
+                            case INSERT: // temporary solution for FLINK-24054
+                            case UPDATE_AFTER:
+                                final Object primaryKeyValue = row.getField(primaryKeyPos);
+                                assert primaryKeyValue != null;
+                                materializedResult.removeIf(
+                                        r -> primaryKeyValue.equals(r.getField(primaryKeyPos)));
+                                materializedResult.add(row);
+                                break;
+                            case DELETE:
+                                row.setKind(RowKind.INSERT);
+                                materializedResult.remove(row);
+                                break;
+                        }
+                    });
+            assertThat(materializedResult, containsInAnyOrder(expectedResult));
         }
     }
 

--- a/flink-table/flink-table-planner/src/test/scala/org/apache/flink/table/planner/runtime/stream/table/TableSinkITCase.scala
+++ b/flink-table/flink-table-planner/src/test/scala/org/apache/flink/table/planner/runtime/stream/table/TableSinkITCase.scala
@@ -680,24 +680,6 @@ class TableSinkITCase extends StreamingTestBase {
     assertEquals(expected.sorted, result.sorted)
   }
 
-
-  @Test
-  def testParallelismWithDataStream(): Unit = {
-    Try(innerTestSetParallelism(
-      "DataStreamWithParallelism",
-      1,
-      index = 1)) match {
-      case Success(_) => fail("this should not happen")
-      case Failure(t) => {
-        val exception = ExceptionUtils.findThrowableWithMessage(
-          t,
-          "`DataStreamSinkProvider` is not allowed to work with `ParallelismProvider`," +
-            " please see document of `ParallelismProvider`")
-        assertTrue(exception.isPresent)
-      }
-    }
-  }
-
   @Test
   def testParallelismWithSinkFunction(): Unit = {
     val negativeParallelism = -1
@@ -710,45 +692,17 @@ class TableSinkITCase extends StreamingTestBase {
       index = index.getAndIncrement))
     match {
       case Success(_) => fail("this should not happen")
-      case Failure(t) => {
+      case Failure(t) =>
         val exception = ExceptionUtils.findThrowableWithMessage(
           t,
-          s"should not be less than zero or equal to zero")
+          s"Invalid configured parallelism")
         assertTrue(exception.isPresent)
-      }
     }
 
     assertTrue(Try(innerTestSetParallelism(
       "SinkFunction",
       validParallelism,
       index = index.getAndIncrement)).isSuccess)
-  }
-
-  @Test
-  def testParallelismWithOutputFormat(): Unit = {
-    val negativeParallelism = -1
-    val validParallelism = 1
-    val index = new AtomicInteger(1)
-
-    Try(innerTestSetParallelism(
-      "OutputFormat",
-      negativeParallelism,
-      index = index.getAndIncrement))
-    match {
-      case Success(_) => fail("this should not happen")
-      case Failure(t) => {
-        val exception = ExceptionUtils.findThrowableWithMessage(
-          t,
-          s"should not be less than zero or equal to zero")
-        assertTrue(exception.isPresent)
-      }
-    }
-
-    assertTrue(Try(innerTestSetParallelism(
-      "SinkFunction",
-      validParallelism,
-      index = index.getAndIncrement))
-      .isSuccess)
   }
 
   @Test
@@ -791,7 +745,7 @@ class TableSinkITCase extends StreamingTestBase {
         val exception = ExceptionUtils
           .findThrowableWithMessage(
             e,
-            "primary key is required but no primary key is found")
+            "a primary key is required")
         assertTrue(exception.isPresent)
     }
 


### PR DESCRIPTION
## What is the purpose of the change

Ensures that all sink providers will receive the same preprocessing transformations (i.e. `SinkUpsertMaterializer`, `keyBy`).

## Brief change log

- Clean up code base
- Unify sink provider preprocessing pipelines

## Verifying this change

This change added tests and can be verified as follows: `testMultiChangelogStreamUpsert`

## Does this pull request potentially affect one of the following parts:

  - Dependencies (does it add or upgrade a dependency): no
  - The public API, i.e., is any changed class annotated with `@Public(Evolving)`: yes
  - The serializers: no
  - The runtime per-record code paths (performance sensitive): no
  - Anything that affects deployment or recovery: JobManager (and its components), Checkpointing, Kubernetes/Yarn, ZooKeeper: no
  - The S3 file system connector: no

## Documentation

  - Does this pull request introduce a new feature? no
  - If yes, how is the feature documented? JavaDocs
