### PR TITLE
[FLINK-23977][elasticsearch] Added DynamicElasticsearchSink for Dynamic ES Cluster Routing

### DIFF
--- a/flink-connectors/flink-connector-elasticsearch-base/src/main/java/org/apache/flink/streaming/connectors/elasticsearch/DynamicElasticsearchSink.java
+++ b/flink-connectors/flink-connector-elasticsearch-base/src/main/java/org/apache/flink/streaming/connectors/elasticsearch/DynamicElasticsearchSink.java
@@ -1,0 +1,75 @@
+package org.apache.flink.streaming.connectors.elasticsearch;
+
+import org.apache.flink.configuration.Configuration;
+import org.apache.flink.runtime.state.FunctionInitializationContext;
+import org.apache.flink.runtime.state.FunctionSnapshotContext;
+import org.apache.flink.streaming.api.checkpoint.CheckpointedFunction;
+import org.apache.flink.streaming.api.functions.sink.RichSinkFunction;
+
+import java.util.HashMap;
+import java.util.Map;
+
+/**
+ * Creates a dynamic wrapper for the Elasticsearch API that supports routing {@link ElementT}
+ * elements to corresponding {@link SinkT} instances based on the logic defined within a
+ * {@link ElasticsearchSinkRouter}.
+ *
+ * @param <ElementT> The type of element being routed
+ * @param <RouteT> The type of deterministic identifier used to associate an element to a sink
+ * @param <SinkT> The sink that the element will be written to
+ */
+public class DynamicElasticsearchSink<
+        ElementT,
+        RouteT,
+        SinkT extends ElasticsearchSinkBase<ElementT, ? extends AutoCloseable>>
+        extends RichSinkFunction<ElementT> implements CheckpointedFunction {
+
+    private final ElasticsearchSinkRouter<ElementT, RouteT, SinkT> sinkRouter;
+    private final Map<RouteT, SinkT> sinkRoutes = new HashMap<>();
+
+    private transient Configuration configuration;
+
+    public DynamicElasticsearchSink(ElasticsearchSinkRouter<ElementT, RouteT, SinkT> sinkRouter) {
+        this.sinkRouter = sinkRouter;
+    }
+
+    @Override
+    public void open(Configuration parameters) throws Exception {
+        this.configuration = parameters;
+    }
+
+    @Override
+    public void invoke(ElementT value, Context context) throws Exception {
+        final RouteT route = sinkRouter.getRoute(value);
+        SinkT sink = sinkRoutes.get(route);
+        if (sink == null) {
+            // If a route wasn't found for the existing element, create a new sink according
+            // to the router definition and cache it
+            sink = sinkRouter.createSink(route, value);
+            sink.setRuntimeContext(getRuntimeContext());
+            sink.open(configuration);
+            sinkRoutes.put(route, sink);
+        }
+
+        sink.invoke(value, context);
+    }
+
+    @Override
+    public void initializeState(FunctionInitializationContext context) throws Exception {
+        // No-op.
+    }
+
+    @Override
+    public void snapshotState(FunctionSnapshotContext context) throws Exception {
+        for (SinkT sink : sinkRoutes.values()) {
+            sink.snapshotState(context);
+        }
+    }
+
+    @Override
+    public void close() throws Exception {
+        for (SinkT sink : sinkRoutes.values()) {
+            sink.close();
+        }
+    }
+}

--- a/flink-connectors/flink-connector-elasticsearch-base/src/main/java/org/apache/flink/streaming/connectors/elasticsearch/DynamicElasticsearchSink.java
+++ b/flink-connectors/flink-connector-elasticsearch-base/src/main/java/org/apache/flink/streaming/connectors/elasticsearch/DynamicElasticsearchSink.java
@@ -36,7 +36,7 @@ public class DynamicElasticsearchSink<
      * A key-value cache of all of the previously seen route-sink combinations to reduce the
      * overhead of creating a new sink each time for routes that have already been established.
      *
-     * NOTE: Since individual sink instances will be stored in memory, it is important that any
+     * <p>NOTE: Since individual sink instances will be stored in memory, it is important that any
      * usage of this should properly allocate adequate memory if use-cases might result in the
      * creation of a large number of separate sinks.
      */
@@ -90,14 +90,14 @@ public class DynamicElasticsearchSink<
 
     @Override
     public void finish() throws Exception {
-        for (SinkT sink : sinkRoutes.values()){
+        for (SinkT sink : sinkRoutes.values()) {
             sink.finish();
         }
     }
 
     @Override
     public void writeWatermark(Watermark watermark) throws Exception {
-        for (SinkT sink : sinkRoutes.values()){
+        for (SinkT sink : sinkRoutes.values()) {
             sink.writeWatermark(watermark);
         }
     }

--- a/flink-connectors/flink-connector-elasticsearch-base/src/main/java/org/apache/flink/streaming/connectors/elasticsearch/DynamicElasticsearchSink.java
+++ b/flink-connectors/flink-connector-elasticsearch-base/src/main/java/org/apache/flink/streaming/connectors/elasticsearch/DynamicElasticsearchSink.java
@@ -11,21 +11,21 @@ import java.util.Map;
 
 /**
  * Creates a dynamic wrapper for the Elasticsearch API that supports routing {@link ElementT}
- * elements to corresponding {@link SinkT} instances based on the logic defined within a
- * {@link ElasticsearchSinkRouter}.
+ * elements to corresponding {@link SinkT} instances based on the logic defined within a {@link
+ * ElasticsearchSinkRouter}.
  *
  * @param <ElementT> The type of element being routed
  * @param <RouteT> The type of deterministic identifier used to associate an element to a sink
  * @param <SinkT> The sink that the element will be written to
  */
 public class DynamicElasticsearchSink<
-        ElementT,
-        RouteT,
-        SinkT extends ElasticsearchSinkBase<ElementT, ? extends AutoCloseable>>
+                ElementT,
+                RouteT,
+                SinkT extends ElasticsearchSinkBase<ElementT, ? extends AutoCloseable>>
         extends RichSinkFunction<ElementT> implements CheckpointedFunction {
 
     private final ElasticsearchSinkRouter<ElementT, RouteT, SinkT> sinkRouter;
-    private final Map<RouteT, SinkT> sinkRoutes = new HashMap<>();
+    protected final Map<RouteT, SinkT> sinkRoutes = new HashMap<>();
 
     private transient Configuration configuration;
 
@@ -70,6 +70,13 @@ public class DynamicElasticsearchSink<
     public void close() throws Exception {
         for (SinkT sink : sinkRoutes.values()) {
             sink.close();
+        }
+    }
+
+    @Override
+    public void finish() throws Exception {
+        for (SinkT sink : sinkRoutes.values()){
+            sink.finish();
         }
     }
 }

--- a/flink-connectors/flink-connector-elasticsearch-base/src/main/java/org/apache/flink/streaming/connectors/elasticsearch/ElasticsearchSinkRouter.java
+++ b/flink-connectors/flink-connector-elasticsearch-base/src/main/java/org/apache/flink/streaming/connectors/elasticsearch/ElasticsearchSinkRouter.java
@@ -5,15 +5,16 @@ package org.apache.flink.streaming.connectors.elasticsearch;
  * be consumed by an {@link DynamicElasticsearchSink} instance.
  */
 public interface ElasticsearchSinkRouter<
-            ElementT, RouteT, SinkT extends ElasticsearchSinkBase<ElementT, ?>> {
+        ElementT, RouteT, SinkT extends ElasticsearchSinkBase<ElementT, ?>> {
     /**
-     * Generate a deterministically unique identifier from an {@link ElementT} instance, which
-     * is used to initialize and cache the {@link SinkT} defined in the router.
-     * */
+     * Generate a deterministically unique identifier from an {@link ElementT} instance, which is
+     * used to initialize and cache the {@link SinkT} defined in the router.
+     */
     RouteT getRoute(ElementT element);
+
     /**
      * Generate a {@link SinkT} instance from an {@link ElementT} instance that will associate all
      * Elasticsearch requests for the {@link RouteT} defined in the router.
-     * */
+     */
     SinkT createSink(RouteT cacheKey, ElementT element);
 }

--- a/flink-connectors/flink-connector-elasticsearch-base/src/main/java/org/apache/flink/streaming/connectors/elasticsearch/ElasticsearchSinkRouter.java
+++ b/flink-connectors/flink-connector-elasticsearch-base/src/main/java/org/apache/flink/streaming/connectors/elasticsearch/ElasticsearchSinkRouter.java
@@ -1,0 +1,19 @@
+package org.apache.flink.streaming.connectors.elasticsearch;
+
+/**
+ * This interface is responsible for defining routing and sink creation from an {@link ElementT} to
+ * be consumed by an {@link DynamicElasticsearchSink} instance.
+ */
+public interface ElasticsearchSinkRouter<
+            ElementT, RouteT, SinkT extends ElasticsearchSinkBase<ElementT, ?>> {
+    /**
+     * Generate a deterministically unique identifier from an {@link ElementT} instance, which
+     * is used to initialize and cache the {@link SinkT} defined in the router.
+     * */
+    RouteT getRoute(ElementT element);
+    /**
+     * Generate a {@link SinkT} instance from an {@link ElementT} instance that will associate all
+     * Elasticsearch requests for the {@link RouteT} defined in the router.
+     * */
+    SinkT createSink(RouteT cacheKey, ElementT element);
+}

--- a/flink-connectors/flink-connector-elasticsearch-base/src/test/java/org/apache/flink/streaming/connectors/elasticsearch/DynamicElasticsearchSinkTest.java
+++ b/flink-connectors/flink-connector-elasticsearch-base/src/test/java/org/apache/flink/streaming/connectors/elasticsearch/DynamicElasticsearchSinkTest.java
@@ -1,6 +1,136 @@
 package org.apache.flink.streaming.connectors.elasticsearch;
 
+import org.apache.flink.api.common.functions.RuntimeContext;
+import org.apache.flink.api.java.tuple.Tuple2;
+import org.apache.flink.configuration.Configuration;
+import org.apache.flink.streaming.api.operators.StreamSink;
+import org.apache.flink.streaming.connectors.elasticsearch.ElasticsearchSinkBaseTest.DummyElasticsearchSink;
+import org.apache.flink.streaming.connectors.elasticsearch.util.NoOpFailureHandler;
+import org.apache.flink.streaming.runtime.streamrecord.StreamRecord;
+import org.apache.flink.streaming.util.OneInputStreamOperatorTestHarness;
+
+import org.elasticsearch.client.Requests;
+import org.junit.Test;
+
+import java.util.HashMap;
+import java.util.Map;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+
 /** Suite of tests for {@link DynamicElasticsearchSink}. */
 public class DynamicElasticsearchSinkTest {
-    /* TODO: Write a few tests */
+
+    /**
+     * Tests that multiple elements that resolve to different routes via the router are each
+     * queued to be sent by their respective underlying sink
+     */
+    @Test
+    public void testItemsWithDifferentRoutesAreRoutedToRespectiveSinks() throws Exception {
+        final DummyDynamicElasticsearchSink sink = new DummyDynamicElasticsearchSink(
+                new DummyElasticsearchSinkRouter()
+        );
+
+        final OneInputStreamOperatorTestHarness<Tuple2<String, String>, Object> testHarness =
+                new OneInputStreamOperatorTestHarness<>(new StreamSink<>(sink));
+
+        testHarness.open();
+        testHarness.processElement(new StreamRecord<>(Tuple2.of("sink-a", "1")));
+        testHarness.processElement(new StreamRecord<>(Tuple2.of("sink-b", "a")));
+
+        assertEquals(1, sink.sinkRoutes.get("sink-a").getNumPendingRequests());
+        assertEquals(1, sink.sinkRoutes.get("sink-b").getNumPendingRequests());
+    }
+
+    /**
+     * Tests that for any items that resolve to the same route, that only a single sink for that
+     * route is created (and cached) by the dynamic sink
+     */
+    @Test
+    public void testItemsWithSameRouteReuseSameSink() throws Exception {
+        final DummyDynamicElasticsearchSink sink = new DummyDynamicElasticsearchSink(
+                new DummyElasticsearchSinkRouter()
+        );
+
+        final OneInputStreamOperatorTestHarness<Tuple2<String, String>, Object> testHarness =
+                new OneInputStreamOperatorTestHarness<>(new StreamSink<>(sink));
+
+        testHarness.open();
+        testHarness.processElement(new StreamRecord<>(Tuple2.of("sink-a", "1")));
+        testHarness.processElement(new StreamRecord<>(Tuple2.of("sink-a", "2")));
+
+        assertEquals(1, sink.sinkRoutes.size());
+    }
+
+    /**
+     * Tests that for any items that resolve to different sinks that a unique one is created for
+     * each route and will be reused for subsequent items that match known routes
+     */
+    @Test
+    public void testItemsWithUniqueRoutesCreateSeparateSinks() throws Exception {
+        final DummyDynamicElasticsearchSink sink = new DummyDynamicElasticsearchSink(
+            new DummyElasticsearchSinkRouter()
+        );
+
+        final OneInputStreamOperatorTestHarness<Tuple2<String, String>, Object> testHarness =
+                new OneInputStreamOperatorTestHarness<>(new StreamSink<>(sink));
+
+        testHarness.open();
+        testHarness.processElement(new StreamRecord<>(Tuple2.of("sink-a", "1")));
+        testHarness.processElement(new StreamRecord<>(Tuple2.of("sink-b", "1")));
+        testHarness.processElement(new StreamRecord<>(Tuple2.of("sink-a", "2")));
+        testHarness.processElement(new StreamRecord<>(Tuple2.of("sink-b", "2")));
+
+        assertEquals(2, sink.sinkRoutes.size());
+    }
+
+    private static class DummyDynamicElasticsearchSink extends DynamicElasticsearchSink<Tuple2<String, String>, String, DummyElasticsearchSink<Tuple2<String, String>>> {
+        public DummyDynamicElasticsearchSink(
+                ElasticsearchSinkRouter<Tuple2<String, String>, String, DummyElasticsearchSink<Tuple2<String, String>>> sinkRouter) {
+            super(sinkRouter);
+        }
+
+        @Override
+        public void open(Configuration parameters) throws Exception {
+            super.open(parameters);
+        }
+
+        @Override
+        public void invoke(Tuple2<String, String> value, Context context) throws Exception {
+            super.invoke(value, context);
+        }
+    }
+
+    private static class DummyElasticsearchSinkRouter implements ElasticsearchSinkRouter<Tuple2<String, String>, String, DummyElasticsearchSink<Tuple2<String, String>>> {
+
+        @Override
+        public String getRoute(Tuple2<String, String> element) {
+            return element.f0;
+        }
+
+        @Override
+        public DummyElasticsearchSink<Tuple2<String, String>> createSink(
+                String cacheKey,
+                Tuple2<String, String> element) {
+
+            return new DummyElasticsearchSink<>(
+                    new HashMap<>(),
+                    new DummySinkFunction(),
+                    new NoOpFailureHandler()
+            );
+        }
+    }
+
+    private static class DummySinkFunction implements ElasticsearchSinkFunction<Tuple2<String, String>> {
+        @Override
+        public void process(
+                Tuple2<String, String> element,
+                RuntimeContext ctx,
+                RequestIndexer indexer) {
+
+            Map<java.lang.String, Object> json = new HashMap<>();
+            json.put("data", element);
+
+            indexer.add(Requests.indexRequest().index("index").type("type").id("id").source(json));
+        }
+    }
 }

--- a/flink-connectors/flink-connector-elasticsearch-base/src/test/java/org/apache/flink/streaming/connectors/elasticsearch/DynamicElasticsearchSinkTest.java
+++ b/flink-connectors/flink-connector-elasticsearch-base/src/test/java/org/apache/flink/streaming/connectors/elasticsearch/DynamicElasticsearchSinkTest.java
@@ -1,0 +1,6 @@
+package org.apache.flink.streaming.connectors.elasticsearch;
+
+/** Suite of tests for {@link DynamicElasticsearchSink}. */
+public class DynamicElasticsearchSinkTest {
+    /* TODO: Write a few tests */
+}

--- a/flink-connectors/flink-connector-elasticsearch-base/src/test/java/org/apache/flink/streaming/connectors/elasticsearch/DynamicElasticsearchSinkTest.java
+++ b/flink-connectors/flink-connector-elasticsearch-base/src/test/java/org/apache/flink/streaming/connectors/elasticsearch/DynamicElasticsearchSinkTest.java
@@ -21,14 +21,13 @@ import static org.junit.jupiter.api.Assertions.assertEquals;
 public class DynamicElasticsearchSinkTest {
 
     /**
-     * Tests that multiple elements that resolve to different routes via the router are each
-     * queued to be sent by their respective underlying sink
+     * Tests that multiple elements that resolve to different routes via the router are each queued
+     * to be sent by their respective underlying sink
      */
     @Test
     public void testItemsWithDifferentRoutesAreRoutedToRespectiveSinks() throws Exception {
-        final DummyDynamicElasticsearchSink sink = new DummyDynamicElasticsearchSink(
-                new DummyElasticsearchSinkRouter()
-        );
+        final DummyDynamicElasticsearchSink sink =
+                new DummyDynamicElasticsearchSink(new DummyElasticsearchSinkRouter());
 
         final OneInputStreamOperatorTestHarness<Tuple2<String, String>, Object> testHarness =
                 new OneInputStreamOperatorTestHarness<>(new StreamSink<>(sink));
@@ -47,9 +46,8 @@ public class DynamicElasticsearchSinkTest {
      */
     @Test
     public void testItemsWithSameRouteReuseSameSink() throws Exception {
-        final DummyDynamicElasticsearchSink sink = new DummyDynamicElasticsearchSink(
-                new DummyElasticsearchSinkRouter()
-        );
+        final DummyDynamicElasticsearchSink sink =
+                new DummyDynamicElasticsearchSink(new DummyElasticsearchSinkRouter());
 
         final OneInputStreamOperatorTestHarness<Tuple2<String, String>, Object> testHarness =
                 new OneInputStreamOperatorTestHarness<>(new StreamSink<>(sink));
@@ -67,9 +65,8 @@ public class DynamicElasticsearchSinkTest {
      */
     @Test
     public void testItemsWithUniqueRoutesCreateSeparateSinks() throws Exception {
-        final DummyDynamicElasticsearchSink sink = new DummyDynamicElasticsearchSink(
-            new DummyElasticsearchSinkRouter()
-        );
+        final DummyDynamicElasticsearchSink sink =
+                new DummyDynamicElasticsearchSink(new DummyElasticsearchSinkRouter());
 
         final OneInputStreamOperatorTestHarness<Tuple2<String, String>, Object> testHarness =
                 new OneInputStreamOperatorTestHarness<>(new StreamSink<>(sink));
@@ -83,9 +80,17 @@ public class DynamicElasticsearchSinkTest {
         assertEquals(2, sink.sinkRoutes.size());
     }
 
-    private static class DummyDynamicElasticsearchSink extends DynamicElasticsearchSink<Tuple2<String, String>, String, DummyElasticsearchSink<Tuple2<String, String>>> {
+    private static class DummyDynamicElasticsearchSink
+            extends DynamicElasticsearchSink<
+                    Tuple2<String, String>,
+                    String,
+                    DummyElasticsearchSink<Tuple2<String, String>>> {
         public DummyDynamicElasticsearchSink(
-                ElasticsearchSinkRouter<Tuple2<String, String>, String, DummyElasticsearchSink<Tuple2<String, String>>> sinkRouter) {
+                ElasticsearchSinkRouter<
+                                Tuple2<String, String>,
+                                String,
+                                DummyElasticsearchSink<Tuple2<String, String>>>
+                        sinkRouter) {
             super(sinkRouter);
         }
 
@@ -100,7 +105,11 @@ public class DynamicElasticsearchSinkTest {
         }
     }
 
-    private static class DummyElasticsearchSinkRouter implements ElasticsearchSinkRouter<Tuple2<String, String>, String, DummyElasticsearchSink<Tuple2<String, String>>> {
+    private static class DummyElasticsearchSinkRouter
+            implements ElasticsearchSinkRouter<
+                    Tuple2<String, String>,
+                    String,
+                    DummyElasticsearchSink<Tuple2<String, String>>> {
 
         @Override
         public String getRoute(Tuple2<String, String> element) {
@@ -109,23 +118,18 @@ public class DynamicElasticsearchSinkTest {
 
         @Override
         public DummyElasticsearchSink<Tuple2<String, String>> createSink(
-                String cacheKey,
-                Tuple2<String, String> element) {
+                String cacheKey, Tuple2<String, String> element) {
 
             return new DummyElasticsearchSink<>(
-                    new HashMap<>(),
-                    new DummySinkFunction(),
-                    new NoOpFailureHandler()
-            );
+                    new HashMap<>(), new DummySinkFunction(), new NoOpFailureHandler());
         }
     }
 
-    private static class DummySinkFunction implements ElasticsearchSinkFunction<Tuple2<String, String>> {
+    private static class DummySinkFunction
+            implements ElasticsearchSinkFunction<Tuple2<String, String>> {
         @Override
         public void process(
-                Tuple2<String, String> element,
-                RuntimeContext ctx,
-                RequestIndexer indexer) {
+                Tuple2<String, String> element, RuntimeContext ctx, RequestIndexer indexer) {
 
             Map<java.lang.String, Object> json = new HashMap<>();
             json.put("data", element);

--- a/flink-connectors/flink-connector-elasticsearch-base/src/test/java/org/apache/flink/streaming/connectors/elasticsearch/ElasticsearchSinkBaseTest.java
+++ b/flink-connectors/flink-connector-elasticsearch-base/src/test/java/org/apache/flink/streaming/connectors/elasticsearch/ElasticsearchSinkBaseTest.java
@@ -485,7 +485,7 @@ public class ElasticsearchSinkBaseTest {
         Assert.assertTrue(sinkFunction.closeCalled);
     }
 
-    private static class DummyElasticsearchSink<T> extends ElasticsearchSinkBase<T, Client> {
+    static class DummyElasticsearchSink<T> extends ElasticsearchSinkBase<T, Client> {
 
         private static final long serialVersionUID = 5051907841570096991L;
 


### PR DESCRIPTION
## What is the purpose of the change

Currently, the existing `ElasticsearchSink` implementation supports dynamic, index-based routing at runtime however any additional routing to separate ES clusters would require the sinks to be known when the job was started up, which may not always be the available.

This pull request implements a `DynamicElasticsearchSink` that supports an `ElasticsearchSinkRouter` interface which handles resolving a unique route and sink from an incoming element, which in turn **allows elements to not only be routed to dynamic indices but also dynamic Elasticsearch sinks at runtime**. 

The sink itself functions as a wrapper with an in-memory cache that contains the route (i.e. key) and its corresponding sink. When a previously unseen route is encountered, a new sink will be created and cached, otherwise the original sink for that route will be used.

### Example Usage

An example usage might look something like this:

```
env
    .fromElements(
            // Define a series of Tuples where the first element represents the ES
            // host being targeted and the second is the message payload
            Tuple2.of(HttpHost.create(".../sink-a"), "message-a-1"),
            Tuple2.of(HttpHost.create(".../sink-b"), "message-b-1"),
            Tuple2.of(HttpHost.create(".../sink-a"), "message-a-2")
    )
    .addSink(
        new DynamicElasticsearchSink<>(
            new ElasticsearchSinkRouter<
                    // Element-type
                    Tuple2<HttpHost, String>,
                    // Route-type (used to seed the hashmap / cache sinks)
                    String,
                    // Sink implementation for this route
                    ElasticsearchSink<Tuple2<HttpHost, String>>>() {

                @Override
                public String getRoute(Tuple2<HttpHost, String> element) {
                    // Construct a deterministic unique caching key to associate
                    // a given "route" to a corresponding sink
                    return element.f0.toHostString();
                }

                @Override
                public ElasticsearchSink<Tuple2<HttpHost, String>> createSink(
                        String cacheKey, Tuple2<HttpHost, String> element) {

                    // Construct a new sink based on the configuration information for
                    // this element
                    ElasticsearchSink.Builder<Tuple2<HttpHost, String>> builder =
                            ElasticsearchSink.Builder(
                                List.of(element.f0),
                                (ElasticsearchSinkFunction<Tuple2<HttpHost, String>>)
                                    (el, ctx, indexer) -> {
                                        // Construct index request.
                                        indexer.add(...);
                                    });

                    builder.setRestClientFactory(restClientBuilder -> {
                        // Apply any authentication here if that information was available
                        // within your routing / element
                    });

                    return builder.build();
                }
            }
        )
    );
```

This example takes a series of `Tuple2<HttpHost, String>` elements (where the HttpHost represents the host of a given Elasticsearch cluster and the String is the data), these are passed to an `ElasticsearchSinkRouter` instance that can do the following given an instance:

- Resolve the route identifier `RouteT` that is used to associate a specific route to a given Sink (generally you will want these to be something that is deterministically unique).
- Create a sink from a given element that corresponds to the route identifier mentioned previously. The example below simply uses an `HttpHost` instance for simplicity sake, but you could easily construct a more robust object to store additional metadata about your sink (e.g. authentication information, specific configuration, etc.) that would be passed to the sink during construction.

Next when the dynamic sink is invoked, it would check the cache to see if the route had previously been seen, if so, it would use the sink for that route, otherwise it would create and configure the route (according to the `ElasticsearchSinkRouter.createSink()` function), store it within the cache, and subsequently invoke the new sink.

I’d appreciate any feedback, suggestions, and more especially from anyone familiar with the ES connector implementations. 

## Brief change log

- *Added `DynamicElasticsearchSink` and related `ElasticsearchSinkRouter` interface to support dynamic sink creation and routing at runtime.*
- *Added a series of tests that leverage some of the existing functionality found within the `ElasticsearchSinkBaseTest` test suite*

## Verifying this change

This change added tests and can be verified as follows:

- *Added test that verifies unique routes from incoming elements "registers" a new Elasticsearch sink instance for each unique route.*
- *Added test that verifies existing sinks are cached based on the route key (e.g. two incoming elements that resolve to the same route will be sent to the same sink*
- *Added test to verify that a series of incoming elements are routed to two separate sinks based on their routes and each underlying sink contains the elements ready to be evicted as pending requests*
- *Added a series of static helper classes to assist with further testing (e.g. `DummyDynamicElasticsearchSink`, `DummyElasticsearchSinkRouter` etc.)*
- *Locally tested via integration tests (Elasticsearch TestContainers) for specific use-cases against multiple clusters*
- *Tested using production-like data within cloud-based test environments running against Elasticsearch clusters for specific business use cases*

## Does this pull request potentially affect one of the following parts:

  - Dependencies (does it add or upgrade a dependency): **No**
  - The public API, i.e., is any changed class annotated with `@Public(Evolving)`: **No**
  - The serializers: **No**
  - The runtime per-record code paths (performance sensitive): **No**
  - Anything that affects deployment or recovery: JobManager (and its components), Checkpointing, Kubernetes/Yarn, ZooKeeper: No
  - The S3 file system connector: **No**
  
## Documentation

  - Does this pull request introduce a new feature? **Yes**
  - If yes, how is the feature documented? **Javadocs**
