### PR TITLE
[FLINK-24058][coordination][tests] Harden TaskSlotTableImplTest#runDeactivateSlotTimeoutTest

### DIFF
--- a/flink-runtime/src/main/java/org/apache/flink/runtime/taskexecutor/TaskManagerServices.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/taskexecutor/TaskManagerServices.java
@@ -36,6 +36,7 @@ import org.apache.flink.runtime.shuffle.ShuffleEnvironmentContext;
 import org.apache.flink.runtime.shuffle.ShuffleServiceLoader;
 import org.apache.flink.runtime.state.TaskExecutorLocalStateStoresManager;
 import org.apache.flink.runtime.state.TaskExecutorStateChangelogStoragesManager;
+import org.apache.flink.runtime.taskexecutor.slot.DefaultTimerService;
 import org.apache.flink.runtime.taskexecutor.slot.TaskSlotTable;
 import org.apache.flink.runtime.taskexecutor.slot.TaskSlotTableImpl;
 import org.apache.flink.runtime.taskexecutor.slot.TimerService;
@@ -377,7 +378,8 @@ public class TaskManagerServices {
             final int pageSize,
             final Executor memoryVerificationExecutor) {
         final TimerService<AllocationID> timerService =
-                new TimerService<>(new ScheduledThreadPoolExecutor(1), timerServiceShutdownTimeout);
+                new DefaultTimerService<>(
+                        new ScheduledThreadPoolExecutor(1), timerServiceShutdownTimeout);
         return new TaskSlotTableImpl<>(
                 numberOfSlots,
                 TaskExecutorResourceUtils.generateTotalAvailableResourceProfile(

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/taskexecutor/slot/DefaultTimerService.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/taskexecutor/slot/DefaultTimerService.java
@@ -18,6 +18,7 @@
 
 package org.apache.flink.runtime.taskexecutor.slot;
 
+import org.apache.flink.annotation.VisibleForTesting;
 import org.apache.flink.util.ExecutorUtils;
 import org.apache.flink.util.Preconditions;
 
@@ -120,6 +121,11 @@ public class DefaultTimerService<K> implements TimerService<K> {
         } else {
             return false;
         }
+    }
+
+    @VisibleForTesting
+    Map<K, Timeout<K>> getTimeouts() {
+        return timeouts;
     }
 
     // ---------------------------------------------------------------------

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/taskexecutor/slot/DefaultTimerService.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/taskexecutor/slot/DefaultTimerService.java
@@ -132,7 +132,8 @@ public class DefaultTimerService<K> implements TimerService<K> {
     // Static utility classes
     // ---------------------------------------------------------------------
 
-    private static final class Timeout<K> implements Runnable {
+    @VisibleForTesting
+    static final class Timeout<K> implements Runnable {
 
         private final TimeoutListener<K> timeoutListener;
         private final K key;

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/taskexecutor/slot/DefaultTimerService.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/taskexecutor/slot/DefaultTimerService.java
@@ -18,10 +18,8 @@
 
 package org.apache.flink.runtime.taskexecutor.slot;
 
+import org.apache.flink.util.ExecutorUtils;
 import org.apache.flink.util.Preconditions;
-
-import org.slf4j.Logger;
-import org.slf4j.LoggerFactory;
 
 import java.util.HashMap;
 import java.util.Map;
@@ -37,8 +35,6 @@ import java.util.concurrent.TimeUnit;
  * @param <K> Type of the key
  */
 public class DefaultTimerService<K> implements TimerService<K> {
-
-    private static final Logger LOG = LoggerFactory.getLogger(DefaultTimerService.class);
 
     /** Executor service for the scheduled timeouts. */
     private final ScheduledExecutorService scheduledExecutorService;
@@ -80,22 +76,8 @@ public class DefaultTimerService<K> implements TimerService<K> {
 
         timeoutListener = null;
 
-        scheduledExecutorService.shutdown();
-
-        try {
-            if (!scheduledExecutorService.awaitTermination(
-                    shutdownTimeout, TimeUnit.MILLISECONDS)) {
-                LOG.debug(
-                        "The scheduled executor service did not properly terminate. Shutting "
-                                + "it down now.");
-                scheduledExecutorService.shutdownNow();
-            }
-        } catch (InterruptedException e) {
-            LOG.debug(
-                    "Could not properly await the termination of the scheduled executor service.",
-                    e);
-            scheduledExecutorService.shutdownNow();
-        }
+        ExecutorUtils.gracefulShutdown(
+                shutdownTimeout, TimeUnit.MILLISECONDS, scheduledExecutorService);
     }
 
     @Override

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/taskexecutor/slot/DefaultTimerService.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/taskexecutor/slot/DefaultTimerService.java
@@ -1,0 +1,182 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.flink.runtime.taskexecutor.slot;
+
+import org.apache.flink.util.Preconditions;
+
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import java.util.HashMap;
+import java.util.Map;
+import java.util.UUID;
+import java.util.concurrent.ScheduledExecutorService;
+import java.util.concurrent.ScheduledFuture;
+import java.util.concurrent.TimeUnit;
+
+/**
+ * Service to register timeouts for a given key. The timeouts are identified by a ticket so that
+ * newly registered timeouts for the same key can be distinguished from older timeouts.
+ *
+ * @param <K> Type of the key
+ */
+public class DefaultTimerService<K> implements TimerService<K> {
+
+    private static final Logger LOG = LoggerFactory.getLogger(DefaultTimerService.class);
+
+    /** Executor service for the scheduled timeouts. */
+    private final ScheduledExecutorService scheduledExecutorService;
+
+    /** Timeout for the shutdown of the service. */
+    private final long shutdownTimeout;
+
+    /** Map of currently active timeouts. */
+    private final Map<K, Timeout<K>> timeouts;
+
+    /** Listener which is notified about occurring timeouts. */
+    private TimeoutListener<K> timeoutListener;
+
+    public DefaultTimerService(
+            final ScheduledExecutorService scheduledExecutorService, final long shutdownTimeout) {
+        this.scheduledExecutorService = Preconditions.checkNotNull(scheduledExecutorService);
+
+        Preconditions.checkArgument(
+                shutdownTimeout >= 0L,
+                "The shut down timeout must be larger than or equal than 0.");
+        this.shutdownTimeout = shutdownTimeout;
+
+        this.timeouts = new HashMap<>(16);
+        this.timeoutListener = null;
+    }
+
+    @Override
+    public void start(TimeoutListener<K> initialTimeoutListener) {
+        // sanity check; We only allow to assign a timeout listener once
+        Preconditions.checkState(!scheduledExecutorService.isShutdown());
+        Preconditions.checkState(timeoutListener == null);
+
+        this.timeoutListener = Preconditions.checkNotNull(initialTimeoutListener);
+    }
+
+    @Override
+    public void stop() {
+        unregisterAllTimeouts();
+
+        timeoutListener = null;
+
+        scheduledExecutorService.shutdown();
+
+        try {
+            if (!scheduledExecutorService.awaitTermination(
+                    shutdownTimeout, TimeUnit.MILLISECONDS)) {
+                LOG.debug(
+                        "The scheduled executor service did not properly terminate. Shutting "
+                                + "it down now.");
+                scheduledExecutorService.shutdownNow();
+            }
+        } catch (InterruptedException e) {
+            LOG.debug(
+                    "Could not properly await the termination of the scheduled executor service.",
+                    e);
+            scheduledExecutorService.shutdownNow();
+        }
+    }
+
+    @Override
+    public void registerTimeout(final K key, final long delay, final TimeUnit unit) {
+        Preconditions.checkState(
+                timeoutListener != null,
+                "The " + getClass().getSimpleName() + " has not been started.");
+
+        if (timeouts.containsKey(key)) {
+            unregisterTimeout(key);
+        }
+
+        timeouts.put(
+                key, new Timeout<>(timeoutListener, key, delay, unit, scheduledExecutorService));
+    }
+
+    @Override
+    public void unregisterTimeout(K key) {
+        Timeout<K> timeout = timeouts.remove(key);
+
+        if (timeout != null) {
+            timeout.cancel();
+        }
+    }
+
+    /** Unregister all timeouts. */
+    protected void unregisterAllTimeouts() {
+        for (Timeout<K> timeout : timeouts.values()) {
+            timeout.cancel();
+        }
+        timeouts.clear();
+    }
+
+    @Override
+    public boolean isValid(K key, UUID ticket) {
+        if (timeouts.containsKey(key)) {
+            Timeout<K> timeout = timeouts.get(key);
+
+            return timeout.getTicket().equals(ticket);
+        } else {
+            return false;
+        }
+    }
+
+    // ---------------------------------------------------------------------
+    // Static utility classes
+    // ---------------------------------------------------------------------
+
+    private static final class Timeout<K> implements Runnable {
+
+        private final TimeoutListener<K> timeoutListener;
+        private final K key;
+        private final ScheduledFuture<?> scheduledTimeout;
+        private final UUID ticket;
+
+        Timeout(
+                final TimeoutListener<K> timeoutListener,
+                final K key,
+                final long delay,
+                final TimeUnit unit,
+                final ScheduledExecutorService scheduledExecutorService) {
+
+            Preconditions.checkNotNull(scheduledExecutorService);
+
+            this.timeoutListener = Preconditions.checkNotNull(timeoutListener);
+            this.key = Preconditions.checkNotNull(key);
+            this.scheduledTimeout = scheduledExecutorService.schedule(this, delay, unit);
+            this.ticket = UUID.randomUUID();
+        }
+
+        UUID getTicket() {
+            return ticket;
+        }
+
+        void cancel() {
+            scheduledTimeout.cancel(true);
+        }
+
+        @Override
+        public void run() {
+            timeoutListener.notifyTimeout(key, ticket);
+        }
+    }
+}

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/taskexecutor/slot/TimerService.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/taskexecutor/slot/TimerService.java
@@ -1,13 +1,12 @@
 /*
- * Licensed to the Apache Software Foundation (ASF) under one
- * or more contributor license agreements.  See the NOTICE file
- * distributed with this work for additional information
- * regarding copyright ownership.  The ASF licenses this file
- * to you under the Apache License, Version 2.0 (the
- * "License"); you may not use this file except in compliance
- * with the License.  You may obtain a copy of the License at
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
  *
- *     http://www.apache.org/licenses/LICENSE-2.0
+ *    http://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,
@@ -18,16 +17,7 @@
 
 package org.apache.flink.runtime.taskexecutor.slot;
 
-import org.apache.flink.util.Preconditions;
-
-import org.slf4j.Logger;
-import org.slf4j.LoggerFactory;
-
-import java.util.HashMap;
-import java.util.Map;
 import java.util.UUID;
-import java.util.concurrent.ScheduledExecutorService;
-import java.util.concurrent.ScheduledFuture;
 import java.util.concurrent.TimeUnit;
 
 /**
@@ -36,65 +26,17 @@ import java.util.concurrent.TimeUnit;
  *
  * @param <K> Type of the key
  */
-public class TimerService<K> {
+public interface TimerService<K> {
 
-    private static final Logger LOG = LoggerFactory.getLogger(TimerService.class);
+    /**
+     * Starts this timer service.
+     *
+     * @param timeoutListener listener for timeouts that have fired
+     */
+    void start(TimeoutListener<K> timeoutListener);
 
-    /** Executor service for the scheduled timeouts. */
-    private final ScheduledExecutorService scheduledExecutorService;
-
-    /** Timeout for the shutdown of the service. */
-    private final long shutdownTimeout;
-
-    /** Map of currently active timeouts. */
-    private final Map<K, Timeout<K>> timeouts;
-
-    /** Listener which is notified about occurring timeouts. */
-    private TimeoutListener<K> timeoutListener;
-
-    public TimerService(
-            final ScheduledExecutorService scheduledExecutorService, final long shutdownTimeout) {
-        this.scheduledExecutorService = Preconditions.checkNotNull(scheduledExecutorService);
-
-        Preconditions.checkArgument(
-                shutdownTimeout >= 0L,
-                "The shut down timeout must be larger than or equal than 0.");
-        this.shutdownTimeout = shutdownTimeout;
-
-        this.timeouts = new HashMap<>(16);
-        this.timeoutListener = null;
-    }
-
-    public void start(TimeoutListener<K> initialTimeoutListener) {
-        // sanity check; We only allow to assign a timeout listener once
-        Preconditions.checkState(!scheduledExecutorService.isShutdown());
-        Preconditions.checkState(timeoutListener == null);
-
-        this.timeoutListener = Preconditions.checkNotNull(initialTimeoutListener);
-    }
-
-    public void stop() {
-        unregisterAllTimeouts();
-
-        timeoutListener = null;
-
-        scheduledExecutorService.shutdown();
-
-        try {
-            if (!scheduledExecutorService.awaitTermination(
-                    shutdownTimeout, TimeUnit.MILLISECONDS)) {
-                LOG.debug(
-                        "The scheduled executor service did not properly terminate. Shutting "
-                                + "it down now.");
-                scheduledExecutorService.shutdownNow();
-            }
-        } catch (InterruptedException e) {
-            LOG.debug(
-                    "Could not properly await the termination of the scheduled executor service.",
-                    e);
-            scheduledExecutorService.shutdownNow();
-        }
-    }
+    /** Stops this timer service. */
+    void stop();
 
     /**
      * Register a timeout for the given key which shall occur in the given delay.
@@ -103,39 +45,14 @@ public class TimerService<K> {
      * @param delay until the timeout
      * @param unit of the timeout delay
      */
-    public void registerTimeout(final K key, final long delay, final TimeUnit unit) {
-        Preconditions.checkState(
-                timeoutListener != null,
-                "The " + getClass().getSimpleName() + " has not been started.");
-
-        if (timeouts.containsKey(key)) {
-            unregisterTimeout(key);
-        }
-
-        timeouts.put(
-                key, new Timeout<>(timeoutListener, key, delay, unit, scheduledExecutorService));
-    }
+    void registerTimeout(K key, long delay, TimeUnit unit);
 
     /**
      * Unregister the timeout for the given key.
      *
      * @param key for which to unregister the timeout
      */
-    public void unregisterTimeout(K key) {
-        Timeout<K> timeout = timeouts.remove(key);
-
-        if (timeout != null) {
-            timeout.cancel();
-        }
-    }
-
-    /** Unregister all timeouts. */
-    protected void unregisterAllTimeouts() {
-        for (Timeout<K> timeout : timeouts.values()) {
-            timeout.cancel();
-        }
-        timeouts.clear();
-    }
+    void unregisterTimeout(K key);
 
     /**
      * Check whether the timeout for the given key and ticket is still valid (not yet unregistered
@@ -145,53 +62,5 @@ public class TimerService<K> {
      * @param ticket of the timeout
      * @return True if the timeout ticket is still valid; otherwise false
      */
-    public boolean isValid(K key, UUID ticket) {
-        if (timeouts.containsKey(key)) {
-            Timeout<K> timeout = timeouts.get(key);
-
-            return timeout.getTicket().equals(ticket);
-        } else {
-            return false;
-        }
-    }
-
-    // ---------------------------------------------------------------------
-    // Static utility classes
-    // ---------------------------------------------------------------------
-
-    private static final class Timeout<K> implements Runnable {
-
-        private final TimeoutListener<K> timeoutListener;
-        private final K key;
-        private final ScheduledFuture<?> scheduledTimeout;
-        private final UUID ticket;
-
-        Timeout(
-                final TimeoutListener<K> timeoutListener,
-                final K key,
-                final long delay,
-                final TimeUnit unit,
-                final ScheduledExecutorService scheduledExecutorService) {
-
-            Preconditions.checkNotNull(scheduledExecutorService);
-
-            this.timeoutListener = Preconditions.checkNotNull(timeoutListener);
-            this.key = Preconditions.checkNotNull(key);
-            this.scheduledTimeout = scheduledExecutorService.schedule(this, delay, unit);
-            this.ticket = UUID.randomUUID();
-        }
-
-        UUID getTicket() {
-            return ticket;
-        }
-
-        void cancel() {
-            scheduledTimeout.cancel(true);
-        }
-
-        @Override
-        public void run() {
-            timeoutListener.notifyTimeout(key, ticket);
-        }
-    }
+    boolean isValid(K key, UUID ticket);
 }

--- a/flink-runtime/src/test/java/org/apache/flink/runtime/taskexecutor/TaskSubmissionTestEnvironment.java
+++ b/flink-runtime/src/test/java/org/apache/flink/runtime/taskexecutor/TaskSubmissionTestEnvironment.java
@@ -47,6 +47,7 @@ import org.apache.flink.runtime.rpc.TestingRpcService;
 import org.apache.flink.runtime.shuffle.ShuffleEnvironment;
 import org.apache.flink.runtime.state.TaskExecutorLocalStateStoresManager;
 import org.apache.flink.runtime.taskexecutor.rpc.RpcResultPartitionConsumableNotifier;
+import org.apache.flink.runtime.taskexecutor.slot.DefaultTimerService;
 import org.apache.flink.runtime.taskexecutor.slot.TaskSlotTable;
 import org.apache.flink.runtime.taskexecutor.slot.TaskSlotUtils;
 import org.apache.flink.runtime.taskexecutor.slot.TestingTaskSlotTable;
@@ -89,7 +90,7 @@ class TaskSubmissionTestEnvironment implements AutoCloseable {
     private final TestingFatalErrorHandler testingFatalErrorHandler =
             new TestingFatalErrorHandler();
     private final TimerService<AllocationID> timerService =
-            new TimerService<>(TestingUtils.defaultExecutor(), timeout.toMilliseconds());
+            new DefaultTimerService<>(TestingUtils.defaultExecutor(), timeout.toMilliseconds());
 
     private final TestingHighAvailabilityServices haServices;
     private final TemporaryFolder temporaryFolder;

--- a/flink-runtime/src/test/java/org/apache/flink/runtime/taskexecutor/slot/DefaultTimerServiceTest.java
+++ b/flink-runtime/src/test/java/org/apache/flink/runtime/taskexecutor/slot/DefaultTimerServiceTest.java
@@ -29,7 +29,7 @@ import java.util.concurrent.ScheduledExecutorService;
 import java.util.concurrent.ScheduledFuture;
 import java.util.concurrent.TimeUnit;
 
-import static org.junit.Assert.*;
+import static org.junit.Assert.assertTrue;
 import static org.mockito.Matchers.any;
 import static org.mockito.Matchers.anyLong;
 import static org.mockito.Mockito.mock;
@@ -37,9 +37,10 @@ import static org.mockito.Mockito.times;
 import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
 
-public class TimerServiceTest extends TestLogger {
+/** Tests for the {@link DefaultTimerService}. */
+public class DefaultTimerServiceTest extends TestLogger {
     /**
-     * Test all timeouts registered can be unregistered
+     * Test all timeouts registered can be unregistered.
      *
      * @throws Exception
      */
@@ -51,8 +52,8 @@ public class TimerServiceTest extends TestLogger {
         ScheduledFuture scheduledFuture = mock(ScheduledFuture.class);
         when(scheduledExecutorService.schedule(any(Runnable.class), anyLong(), any(TimeUnit.class)))
                 .thenReturn(scheduledFuture);
-        TimerService<AllocationID> timerService =
-                new TimerService<>(scheduledExecutorService, 100L);
+        DefaultTimerService<AllocationID> timerService =
+                new DefaultTimerService<>(scheduledExecutorService, 100L);
         TimeoutListener<AllocationID> listener = mock(TimeoutListener.class);
 
         timerService.start(listener);

--- a/flink-runtime/src/test/java/org/apache/flink/runtime/taskexecutor/slot/TaskSlotTableImplTest.java
+++ b/flink-runtime/src/test/java/org/apache/flink/runtime/taskexecutor/slot/TaskSlotTableImplTest.java
@@ -41,15 +41,12 @@ import java.util.HashSet;
 import java.util.Iterator;
 import java.util.List;
 import java.util.concurrent.CompletableFuture;
-import java.util.concurrent.TimeUnit;
-import java.util.concurrent.TimeoutException;
 
 import static org.hamcrest.Matchers.containsInAnyOrder;
 import static org.hamcrest.Matchers.equalTo;
 import static org.hamcrest.Matchers.is;
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertThat;
-import static org.junit.Assert.fail;
 
 /** Tests for the {@link TaskSlotTable}. */
 public class TaskSlotTableImplTest extends TestLogger {
@@ -487,15 +484,15 @@ public class TaskSlotTableImplTest extends TestLogger {
                             SlotNotFoundException>
                     taskSlotTableAction)
             throws Exception {
-        final CompletableFuture<AllocationID> timeoutFuture = new CompletableFuture<>();
-        final TestingSlotActions testingSlotActions =
-                new TestingSlotActionsBuilder()
-                        .setTimeoutSlotConsumer(
-                                (allocationID, uuid) -> timeoutFuture.complete(allocationID))
-                        .build();
+        final CompletableFuture<AllocationID> timeoutCancellationFuture = new CompletableFuture<>();
+
+        final TimerService<AllocationID> testingTimerService =
+                new TestingTimerServiceBuilder<AllocationID>()
+                        .setUnregisterTimeoutConsumer(timeoutCancellationFuture::complete)
+                        .createTestingTimerService();
 
         try (final TaskSlotTableImpl<TaskSlotPayload> taskSlotTable =
-                createTaskSlotTableAndStart(1, testingSlotActions)) {
+                createTaskSlotTableAndStart(1, testingTimerService)) {
             final AllocationID allocationId = new AllocationID();
             final long timeout = 50L;
             final JobID jobId = new JobID();
@@ -504,11 +501,7 @@ public class TaskSlotTableImplTest extends TestLogger {
                     is(true));
             assertThat(taskSlotTableAction.apply(taskSlotTable, jobId, allocationId), is(true));
 
-            try {
-                timeoutFuture.get(timeout, TimeUnit.MILLISECONDS);
-                fail("The slot timeout should have been deactivated.");
-            } catch (TimeoutException expected) {
-            }
+            timeoutCancellationFuture.get();
         }
     }
 
@@ -546,6 +539,16 @@ public class TaskSlotTableImplTest extends TestLogger {
         final TaskSlotTableImpl<TaskSlotPayload> taskSlotTable =
                 TaskSlotUtils.createTaskSlotTable(numberOfSlots);
         taskSlotTable.start(slotActions, ComponentMainThreadExecutorServiceAdapter.forMainThread());
+        return taskSlotTable;
+    }
+
+    private static TaskSlotTableImpl<TaskSlotPayload> createTaskSlotTableAndStart(
+            final int numberOfSlots, TimerService<AllocationID> timerService) {
+        final TaskSlotTableImpl<TaskSlotPayload> taskSlotTable =
+                TaskSlotUtils.createTaskSlotTable(numberOfSlots, timerService);
+        taskSlotTable.start(
+                new TestingSlotActionsBuilder().build(),
+                ComponentMainThreadExecutorServiceAdapter.forMainThread());
         return taskSlotTable;
     }
 }

--- a/flink-runtime/src/test/java/org/apache/flink/runtime/taskexecutor/slot/TaskSlotUtils.java
+++ b/flink-runtime/src/test/java/org/apache/flink/runtime/taskexecutor/slot/TaskSlotUtils.java
@@ -52,7 +52,7 @@ public enum TaskSlotUtils {
                 numberOfSlots, createDefaultTimerService(timeout.toMilliseconds()));
     }
 
-    private static <T extends TaskSlotPayload> TaskSlotTableImpl<T> createTaskSlotTable(
+    public static <T extends TaskSlotPayload> TaskSlotTableImpl<T> createTaskSlotTable(
             int numberOfSlots, TimerService<AllocationID> timerService) {
         return new TaskSlotTableImpl<>(
                 numberOfSlots,

--- a/flink-runtime/src/test/java/org/apache/flink/runtime/taskexecutor/slot/TaskSlotUtils.java
+++ b/flink-runtime/src/test/java/org/apache/flink/runtime/taskexecutor/slot/TaskSlotUtils.java
@@ -76,6 +76,6 @@ public enum TaskSlotUtils {
     }
 
     public static TimerService<AllocationID> createDefaultTimerService(long shutdownTimeout) {
-        return new TimerService<>(TestingUtils.defaultExecutor(), shutdownTimeout);
+        return new DefaultTimerService<>(TestingUtils.defaultExecutor(), shutdownTimeout);
     }
 }

--- a/flink-runtime/src/test/java/org/apache/flink/runtime/taskexecutor/slot/TestingTimerService.java
+++ b/flink-runtime/src/test/java/org/apache/flink/runtime/taskexecutor/slot/TestingTimerService.java
@@ -1,0 +1,72 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.flink.runtime.taskexecutor.slot;
+
+import org.apache.flink.util.function.TriConsumer;
+
+import java.util.UUID;
+import java.util.concurrent.TimeUnit;
+import java.util.function.BiFunction;
+import java.util.function.Consumer;
+
+/** Testing {@link TimerService} implementation. */
+public class TestingTimerService<T> implements TimerService<T> {
+    private final Consumer<TimeoutListener<T>> startConsumer;
+    private final Runnable stopConsumer;
+    private final TriConsumer<T, Long, TimeUnit> registerTimeoutConsumer;
+    private final Consumer<T> unregisterTimeoutConsumer;
+    private final BiFunction<T, UUID, Boolean> isValidFunction;
+
+    public TestingTimerService(
+            Consumer<TimeoutListener<T>> startConsumer,
+            Runnable stopConsumer,
+            TriConsumer<T, Long, TimeUnit> registerTimeoutConsumer,
+            Consumer<T> unregisterTimeoutConsumer,
+            BiFunction<T, UUID, Boolean> isValidFunction) {
+        this.startConsumer = startConsumer;
+        this.stopConsumer = stopConsumer;
+        this.registerTimeoutConsumer = registerTimeoutConsumer;
+        this.unregisterTimeoutConsumer = unregisterTimeoutConsumer;
+        this.isValidFunction = isValidFunction;
+    }
+
+    @Override
+    public void start(TimeoutListener<T> timeoutListener) {
+        startConsumer.accept(timeoutListener);
+    }
+
+    @Override
+    public void stop() {
+        stopConsumer.run();
+    }
+
+    @Override
+    public void registerTimeout(T key, long delay, TimeUnit unit) {
+        registerTimeoutConsumer.accept(key, delay, unit);
+    }
+
+    @Override
+    public void unregisterTimeout(T key) {
+        unregisterTimeoutConsumer.accept(key);
+    }
+
+    @Override
+    public boolean isValid(T key, UUID ticket) {
+        return isValidFunction.apply(key, ticket);
+    }
+}

--- a/flink-runtime/src/test/java/org/apache/flink/runtime/taskexecutor/slot/TestingTimerServiceBuilder.java
+++ b/flink-runtime/src/test/java/org/apache/flink/runtime/taskexecutor/slot/TestingTimerServiceBuilder.java
@@ -1,0 +1,73 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.flink.runtime.taskexecutor.slot;
+
+import org.apache.flink.util.function.TriConsumer;
+
+import java.util.UUID;
+import java.util.concurrent.TimeUnit;
+import java.util.function.BiFunction;
+import java.util.function.Consumer;
+
+/** Builder for {@link TestingTimerService}. */
+public class TestingTimerServiceBuilder<T> {
+    private Consumer<TimeoutListener<T>> startConsumer = ignored -> {};
+    private Runnable stopConsumer = () -> {};
+    private TriConsumer<T, Long, TimeUnit> registerTimeoutConsumer =
+            (ignoredA, ignoredB, ignoredC) -> {};
+    private Consumer<T> unregisterTimeoutConsumer = ignored -> {};
+    private BiFunction<T, UUID, Boolean> isValidFunction = (ignoredA, ignoredB) -> true;
+
+    public TestingTimerServiceBuilder<T> setStartConsumer(
+            Consumer<TimeoutListener<T>> startConsumer) {
+        this.startConsumer = startConsumer;
+        return this;
+    }
+
+    public TestingTimerServiceBuilder<T> setStopConsumer(Runnable stopConsumer) {
+        this.stopConsumer = stopConsumer;
+        return this;
+    }
+
+    public TestingTimerServiceBuilder<T> setRegisterTimeoutConsumer(
+            TriConsumer<T, Long, TimeUnit> registerTimeoutConsumer) {
+        this.registerTimeoutConsumer = registerTimeoutConsumer;
+        return this;
+    }
+
+    public TestingTimerServiceBuilder<T> setUnregisterTimeoutConsumer(
+            Consumer<T> unregisterTimeoutConsumer) {
+        this.unregisterTimeoutConsumer = unregisterTimeoutConsumer;
+        return this;
+    }
+
+    public TestingTimerServiceBuilder<T> setIsValidFunction(
+            BiFunction<T, UUID, Boolean> isValidFunction) {
+        this.isValidFunction = isValidFunction;
+        return this;
+    }
+
+    public TestingTimerService<T> createTestingTimerService() {
+        return new TestingTimerService<T>(
+                startConsumer,
+                stopConsumer,
+                registerTimeoutConsumer,
+                unregisterTimeoutConsumer,
+                isValidFunction);
+    }
+}


### PR DESCRIPTION
`TaskSlotTableImplTest#runDeactivateSlotTimeoutTest` checks that the timeout is cancelled by asserting that a future is _not_ canceled in a given time-frame. These kind of assertions (of something _not_ happening) tend to be unstable because there is no good measure for how long you need to wait.
Instead the test was refactored to check that `TimerService#unregisterTimeout` is called instead. Several refactorings were made to make this possible, and existing tests for the TimerService were cleaned up and extended.