### PR TITLE
[FLINK-24084][docs] Correct the examples in SQL JOIN docs

### DIFF
--- a/docs/content.zh/docs/dev/table/sql/queries/joins.md
+++ b/docs/content.zh/docs/dev/table/sql/queries/joins.md
@@ -150,10 +150,12 @@ CREATE TABLE orders (
 CREATE TABLE currency_rates (
     currency STRING,
     conversion_rate DECIMAL(32, 2),
-    update_time TIMESTAMP(3) METADATA FROM `values.source.timestamp` VIRTUAL
-    WATERMARK FOR update_time AS update_time
+    update_time TIMESTAMP(3) METADATA FROM `values.source.timestamp` VIRTUAL,
+    WATERMARK FOR update_time AS update_time,
+    PRIMARY KEY(currency) NOT ENFORCED
 ) WITH (
-   'connector' = 'upsert-kafka',
+    'connector' = 'kafka',
+    'value.format' = 'debezium-json',
    /* ... */
 );
 
@@ -164,13 +166,13 @@ SELECT
      conversion_rate,
      order_time,
 FROM orders
-LEFT JOIN currency_rates FOR SYSTEM TIME AS OF orders.order_time
-ON orders.currency = currency_rates.currency
+LEFT JOIN currency_rates FOR SYSTEM_TIME AS OF orders.order_time
+ON orders.currency = currency_rates.currency;
 
-order_id price currency conversion_rate  order_time
-====== ==== ======  ============  ========
-o_001    11.11  EUR        1.14                    12:00:00
-o_002    12.51  EUR        1.10                    12:06:00
+order_id  price  currency  conversion_rate  order_time
+========  =====  ========  ===============  =========
+o_001     11.11  EUR       1.14             12:00:00
+o_002     12.51  EUR       1.10             12:06:00
 
 ```
 

--- a/docs/content/docs/dev/table/sql/queries/joins.md
+++ b/docs/content/docs/dev/table/sql/queries/joins.md
@@ -150,10 +150,12 @@ CREATE TABLE orders (
 CREATE TABLE currency_rates (
     currency STRING,
     conversion_rate DECIMAL(32, 2),
-    update_time TIMESTAMP(3) METADATA FROM `values.source.timestamp` VIRTUAL
-    WATERMARK FOR update_time AS update_time
+    update_time TIMESTAMP(3) METADATA FROM `values.source.timestamp` VIRTUAL,
+    WATERMARK FOR update_time AS update_time,
+    PRIMARY KEY(currency) NOT ENFORCED
 ) WITH (
-   'connector' = 'upsert-kafka',
+   'connector' = 'kafka',
+   'value.format' = 'debezium-json',
    /* ... */
 );
 
@@ -164,13 +166,13 @@ SELECT
      conversion_rate,
      order_time,
 FROM orders
-LEFT JOIN currency_rates FOR SYSTEM TIME AS OF orders.order_time
-ON orders.currency = currency_rates.currency
+LEFT JOIN currency_rates FOR SYSTEM_TIME AS OF orders.order_time
+ON orders.currency = currency_rates.currency;
 
-order_id price currency conversion_rate  order_time
-====== ==== ======  ============  ========
-o_001    11.11  EUR        1.14                    12:00:00
-o_002    12.51  EUR        1.10                    12:06:00
+order_id  price  currency  conversion_rate  order_time
+========  =====  ========  ===============  =========
+o_001     11.11  EUR       1.14             12:00:00
+o_002     12.51  EUR       1.10             12:06:00
 
 ```
 


### PR DESCRIPTION
## What is the purpose of the change

* This pull request Fix  the examples in SQL JOIN docs

## Brief change log

  -  The metadata key `values.source.timestamp` only supports in debezium json
  - The primary key is missed
  - Add the Missed `,` after `VIRTUAL`
  - `SYSTEM TIME` -> `SYSTEM_TIME`
  - minor format improvement


## Verifying this change

This change is a trivial rework / code cleanup without any test coverage.

## Does this pull request potentially affect one of the following parts:

  - Dependencies (does it add or upgrade a dependency): (no)
  - The public API, i.e., is any changed class annotated with `@Public(Evolving)`: (no)
  - The serializers: (no)
  - The runtime per-record code paths (performance sensitive): ( no)
  - Anything that affects deployment or recovery: JobManager (and its components), Checkpointing, Yarn/Mesos, ZooKeeper: (no)
  - The S3 file system connector: (no)

## Documentation

  - Does this pull request introduce a new feature? (no)
  - If yes, how is the feature documented? (not applicable / docs / JavaDocs / not documented)
