### PR TITLE
[FLINK-24087][connectors/kafka] Avoid importing table API class in DataStream API package

### DIFF
--- a/flink-connectors/flink-connector-kafka/src/main/java/org/apache/flink/streaming/connectors/kafka/config/StartupMode.java
+++ b/flink-connectors/flink-connector-kafka/src/main/java/org/apache/flink/streaming/connectors/kafka/config/StartupMode.java
@@ -19,8 +19,6 @@ package org.apache.flink.streaming.connectors.kafka.config;
 
 import org.apache.flink.annotation.Internal;
 import org.apache.flink.streaming.connectors.kafka.internals.KafkaTopicPartitionStateSentinel;
-import org.apache.flink.streaming.connectors.kafka.table.KafkaConnectorOptions.ScanStartupMode;
-import org.apache.flink.table.api.TableException;
 
 /** Startup modes for the Kafka Consumer. */
 @Internal
@@ -56,25 +54,6 @@ public enum StartupMode {
 
     StartupMode(long stateSentinel) {
         this.stateSentinel = stateSentinel;
-    }
-
-    public static StartupMode fromOption(ScanStartupMode scanStartupMode) {
-        switch (scanStartupMode) {
-            case EARLIEST_OFFSET:
-                return StartupMode.EARLIEST;
-            case LATEST_OFFSET:
-                return StartupMode.LATEST;
-            case GROUP_OFFSETS:
-                return StartupMode.GROUP_OFFSETS;
-            case SPECIFIC_OFFSETS:
-                return StartupMode.SPECIFIC_OFFSETS;
-            case TIMESTAMP:
-                return StartupMode.TIMESTAMP;
-
-            default:
-                throw new TableException(
-                        "Unsupported startup mode. Validator should have checked that.");
-        }
     }
 
     public long getStateSentinel() {

--- a/flink-connectors/flink-connector-kafka/src/main/java/org/apache/flink/streaming/connectors/kafka/table/KafkaConnectorOptionsUtil.java
+++ b/flink-connectors/flink-connector-kafka/src/main/java/org/apache/flink/streaming/connectors/kafka/table/KafkaConnectorOptionsUtil.java
@@ -224,7 +224,7 @@ class KafkaConnectorOptionsUtil {
         final StartupMode startupMode =
                 tableOptions
                         .getOptional(SCAN_STARTUP_MODE)
-                        .map(StartupMode::fromOption)
+                        .map(KafkaConnectorOptionsUtil::fromOption)
                         .orElse(StartupMode.GROUP_OFFSETS);
         if (startupMode == StartupMode.SPECIFIC_OFFSETS) {
             // It will be refactored after support specific offset for multiple topics in
@@ -255,6 +255,29 @@ class KafkaConnectorOptionsUtil {
                             new KafkaTopicPartition(topic, partition);
                     specificOffsets.put(topicPartition, offset);
                 });
+    }
+
+    /**
+     * Returns the {@link StartupMode} of Kafka Consumer by passed-in table-specific {@link
+     * ScanStartupMode}.
+     */
+    private static StartupMode fromOption(ScanStartupMode scanStartupMode) {
+        switch (scanStartupMode) {
+            case EARLIEST_OFFSET:
+                return StartupMode.EARLIEST;
+            case LATEST_OFFSET:
+                return StartupMode.LATEST;
+            case GROUP_OFFSETS:
+                return StartupMode.GROUP_OFFSETS;
+            case SPECIFIC_OFFSETS:
+                return StartupMode.SPECIFIC_OFFSETS;
+            case TIMESTAMP:
+                return StartupMode.TIMESTAMP;
+
+            default:
+                throw new TableException(
+                        "Unsupported startup mode. Validator should have checked that.");
+        }
     }
 
     public static Properties getKafkaProperties(Map<String, String> tableOptions) {


### PR DESCRIPTION
## What is the purpose of the change

* This pull request remove table API class from DataStream API package in Kafka connector

## Brief change log

  - Remove usage of table API class in `StartupMode.java` to `KafkaConnectorOptionsUtil`

## Verifying this change

This change is a trivial rework / code cleanup without any test coverage.

## Does this pull request potentially affect one of the following parts:

  - Dependencies (does it add or upgrade a dependency): (no)
  - The public API, i.e., is any changed class annotated with `@Public(Evolving)`: (no)
  - The serializers: (no)
  - The runtime per-record code paths (performance sensitive): ( no)
  - Anything that affects deployment or recovery: JobManager (and its components), Checkpointing, Yarn/Mesos, ZooKeeper: (no)
  - The S3 file system connector: (no)

## Documentation

  - Does this pull request introduce a new feature? (no)
  - If yes, how is the feature documented? (not applicable / docs / JavaDocs / not documented)
