### PR TITLE
[FLINK-24081][table-planner] Fix StreamExecOverAggregate and StreamExecTemporalSort operator didn't support LocalZonedTimestampType

### DIFF
--- a/flink-table/flink-table-planner/src/main/java/org/apache/flink/table/planner/plan/nodes/exec/stream/StreamExecOverAggregate.java
+++ b/flink-table/flink-table-planner/src/main/java/org/apache/flink/table/planner/plan/nodes/exec/stream/StreamExecOverAggregate.java
@@ -51,11 +51,8 @@ import org.apache.flink.table.runtime.operators.over.RowTimeRowsBoundedPreceding
 import org.apache.flink.table.runtime.operators.over.RowTimeRowsUnboundedPrecedingFunction;
 import org.apache.flink.table.runtime.types.LogicalTypeDataTypeConverter;
 import org.apache.flink.table.runtime.typeutils.InternalTypeInfo;
-import org.apache.flink.table.types.logical.LocalZonedTimestampType;
 import org.apache.flink.table.types.logical.LogicalType;
 import org.apache.flink.table.types.logical.RowType;
-import org.apache.flink.table.types.logical.TimestampKind;
-import org.apache.flink.table.types.logical.TimestampType;
 
 import org.apache.flink.shaded.jackson2.com.fasterxml.jackson.annotation.JsonCreator;
 import org.apache.flink.shaded.jackson2.com.fasterxml.jackson.annotation.JsonIgnoreProperties;
@@ -74,6 +71,8 @@ import java.util.Collections;
 import java.util.List;
 import java.util.stream.IntStream;
 
+import static org.apache.flink.table.types.logical.utils.LogicalTypeChecks.isProctimeAttribute;
+import static org.apache.flink.table.types.logical.utils.LogicalTypeChecks.isRowtimeAttribute;
 import static org.apache.flink.util.Preconditions.checkArgument;
 import static org.apache.flink.util.Preconditions.checkNotNull;
 
@@ -149,11 +148,9 @@ public class StreamExecOverAggregate extends ExecNodeBase<RowData>
         final LogicalType orderKeyType = inputRowType.getFields().get(orderKey).getType();
         // check time field && identify window rowtime attribute
         final int rowTimeIdx;
-        if (orderKeyType instanceof TimestampType
-                && ((TimestampType) orderKeyType).getKind() == TimestampKind.ROWTIME) {
+        if (isRowtimeAttribute(orderKeyType)) {
             rowTimeIdx = orderKey;
-        } else if (orderKeyType instanceof LocalZonedTimestampType
-                && ((LocalZonedTimestampType) orderKeyType).getKind() == TimestampKind.PROCTIME) {
+        } else if (isProctimeAttribute(orderKeyType)) {
             rowTimeIdx = -1;
         } else {
             throw new TableException(

--- a/flink-table/flink-table-planner/src/main/java/org/apache/flink/table/planner/plan/nodes/exec/stream/StreamExecPythonOverAggregate.java
+++ b/flink-table/flink-table-planner/src/main/java/org/apache/flink/table/planner/plan/nodes/exec/stream/StreamExecPythonOverAggregate.java
@@ -40,11 +40,8 @@ import org.apache.flink.table.planner.plan.utils.KeySelectorUtil;
 import org.apache.flink.table.planner.plan.utils.OverAggregateUtil;
 import org.apache.flink.table.runtime.keyselector.RowDataKeySelector;
 import org.apache.flink.table.runtime.typeutils.InternalTypeInfo;
-import org.apache.flink.table.types.logical.LocalZonedTimestampType;
 import org.apache.flink.table.types.logical.LogicalType;
 import org.apache.flink.table.types.logical.RowType;
-import org.apache.flink.table.types.logical.TimestampKind;
-import org.apache.flink.table.types.logical.TimestampType;
 
 import org.apache.flink.shaded.jackson2.com.fasterxml.jackson.annotation.JsonCreator;
 import org.apache.flink.shaded.jackson2.com.fasterxml.jackson.annotation.JsonProperty;
@@ -59,6 +56,8 @@ import java.math.BigDecimal;
 import java.util.Collections;
 import java.util.List;
 
+import static org.apache.flink.table.types.logical.utils.LogicalTypeChecks.isProctimeAttribute;
+import static org.apache.flink.table.types.logical.utils.LogicalTypeChecks.isRowtimeAttribute;
 import static org.apache.flink.util.Preconditions.checkArgument;
 import static org.apache.flink.util.Preconditions.checkNotNull;
 
@@ -150,11 +149,9 @@ public class StreamExecPythonOverAggregate extends ExecNodeBase<RowData>
         final LogicalType orderKeyType = inputRowType.getFields().get(orderKey).getType();
         // check time field && identify window rowtime attribute
         final int rowTimeIdx;
-        if (orderKeyType instanceof TimestampType
-                && ((TimestampType) orderKeyType).getKind() == TimestampKind.ROWTIME) {
+        if (isRowtimeAttribute(orderKeyType)) {
             rowTimeIdx = orderKey;
-        } else if (orderKeyType instanceof LocalZonedTimestampType
-                && ((LocalZonedTimestampType) orderKeyType).getKind() == TimestampKind.PROCTIME) {
+        } else if (isProctimeAttribute(orderKeyType)) {
             rowTimeIdx = -1;
         } else {
             throw new TableException(

--- a/flink-table/flink-table-planner/src/main/java/org/apache/flink/table/planner/plan/nodes/exec/stream/StreamExecTemporalSort.java
+++ b/flink-table/flink-table-planner/src/main/java/org/apache/flink/table/planner/plan/nodes/exec/stream/StreamExecTemporalSort.java
@@ -35,11 +35,8 @@ import org.apache.flink.table.runtime.keyselector.EmptyRowDataKeySelector;
 import org.apache.flink.table.runtime.operators.sort.ProcTimeSortOperator;
 import org.apache.flink.table.runtime.operators.sort.RowTimeSortOperator;
 import org.apache.flink.table.runtime.typeutils.InternalTypeInfo;
-import org.apache.flink.table.types.logical.LocalZonedTimestampType;
 import org.apache.flink.table.types.logical.LogicalType;
 import org.apache.flink.table.types.logical.RowType;
-import org.apache.flink.table.types.logical.TimestampKind;
-import org.apache.flink.table.types.logical.TimestampType;
 
 import org.apache.flink.shaded.jackson2.com.fasterxml.jackson.annotation.JsonCreator;
 import org.apache.flink.shaded.jackson2.com.fasterxml.jackson.annotation.JsonProperty;
@@ -47,6 +44,8 @@ import org.apache.flink.shaded.jackson2.com.fasterxml.jackson.annotation.JsonPro
 import java.util.Collections;
 import java.util.List;
 
+import static org.apache.flink.table.types.logical.utils.LogicalTypeChecks.isProctimeAttribute;
+import static org.apache.flink.table.types.logical.utils.LogicalTypeChecks.isRowtimeAttribute;
 import static org.apache.flink.util.Preconditions.checkArgument;
 import static org.apache.flink.util.Preconditions.checkNotNull;
 
@@ -101,24 +100,17 @@ public class StreamExecTemporalSort extends ExecNodeBase<RowData>
         RowType inputType = (RowType) inputEdge.getOutputType();
         LogicalType timeType = inputType.getTypeAt(sortSpec.getFieldSpec(0).getFieldIndex());
         TableConfig config = planner.getTableConfig();
-        if (timeType instanceof TimestampType) {
-            TimestampType keyType = (TimestampType) timeType;
-            if (keyType.getKind() == TimestampKind.ROWTIME) {
-                return createSortRowTime(inputType, inputTransform, config);
-            }
+        if (isRowtimeAttribute(timeType)) {
+            return createSortRowTime(inputType, inputTransform, config);
+        } else if (isProctimeAttribute(timeType)) {
+            return createSortProcTime(inputType, inputTransform, config);
+        } else {
+            throw new TableException(
+                    String.format(
+                            "Sort: Internal Error\n"
+                                    + "First field in temporal sort is not a time attribute, %s is given.",
+                            timeType));
         }
-        if (timeType instanceof LocalZonedTimestampType) {
-            LocalZonedTimestampType keyType = (LocalZonedTimestampType) timeType;
-            if (keyType.getKind() == TimestampKind.PROCTIME) {
-                return createSortProcTime(inputType, inputTransform, config);
-            }
-        }
-
-        throw new TableException(
-                String.format(
-                        "Sort: Internal Error\n"
-                                + "First field in temporal sort is not a time attribute, %s is given.",
-                        timeType));
     }
 
     /** Create Sort logic based on processing time. */


### PR DESCRIPTION
## What is the purpose of the change

* Fix `StreamExecOverAggregate` and `StreamExecTemporalSort` operators didn't support LocalZonedTimestampType

## Brief change log
- Use `LogicalTypeChecks#isRowtimeAttribute()` utils to check the rowtime attribute


## Verifying this change

* Add ITCase to test the two operators.

## Does this pull request potentially affect one of the following parts:

  - Dependencies (does it add or upgrade a dependency): (no)
  - The public API, i.e., is any changed class annotated with `@Public(Evolving)`: (no)
  - The serializers: (no)
  - The runtime per-record code paths (performance sensitive): ( no)
  - Anything that affects deployment or recovery: JobManager (and its components), Checkpointing, Yarn/Mesos, ZooKeeper: (no)
  - The S3 file system connector: (no)

## Documentation

  - Does this pull request introduce a new feature? (no)
  - If yes, how is the feature documented? (not applicable / docs / JavaDocs / not documented)