### PR TITLE
[FLINK-24081][table-blink-planner] Fix StreamExecOverAggregate and StreamExecTemporalSort operator didn't support LocalZonedTimestampType

### DIFF
--- a/flink-table/flink-table-planner-blink/src/main/java/org/apache/flink/table/planner/plan/nodes/exec/stream/StreamExecOverAggregate.java
+++ b/flink-table/flink-table-planner-blink/src/main/java/org/apache/flink/table/planner/plan/nodes/exec/stream/StreamExecOverAggregate.java
@@ -51,11 +51,8 @@ import org.apache.flink.table.runtime.operators.over.RowTimeRowsBoundedPreceding
 import org.apache.flink.table.runtime.operators.over.RowTimeRowsUnboundedPrecedingFunction;
 import org.apache.flink.table.runtime.types.LogicalTypeDataTypeConverter;
 import org.apache.flink.table.runtime.typeutils.InternalTypeInfo;
-import org.apache.flink.table.types.logical.LocalZonedTimestampType;
 import org.apache.flink.table.types.logical.LogicalType;
 import org.apache.flink.table.types.logical.RowType;
-import org.apache.flink.table.types.logical.TimestampKind;
-import org.apache.flink.table.types.logical.TimestampType;
 
 import org.apache.flink.shaded.jackson2.com.fasterxml.jackson.annotation.JsonCreator;
 import org.apache.flink.shaded.jackson2.com.fasterxml.jackson.annotation.JsonIgnoreProperties;
@@ -74,6 +71,8 @@ import java.util.Collections;
 import java.util.List;
 import java.util.stream.IntStream;
 
+import static org.apache.flink.table.types.logical.utils.LogicalTypeChecks.isProctimeAttribute;
+import static org.apache.flink.table.types.logical.utils.LogicalTypeChecks.isRowtimeAttribute;
 import static org.apache.flink.util.Preconditions.checkArgument;
 import static org.apache.flink.util.Preconditions.checkNotNull;
 
@@ -149,11 +148,9 @@ public class StreamExecOverAggregate extends ExecNodeBase<RowData>
         final LogicalType orderKeyType = inputRowType.getFields().get(orderKey).getType();
         // check time field && identify window rowtime attribute
         final int rowTimeIdx;
-        if (orderKeyType instanceof TimestampType
-                && ((TimestampType) orderKeyType).getKind() == TimestampKind.ROWTIME) {
+        if (isRowtimeAttribute(orderKeyType)) {
             rowTimeIdx = orderKey;
-        } else if (orderKeyType instanceof LocalZonedTimestampType
-                && ((LocalZonedTimestampType) orderKeyType).getKind() == TimestampKind.PROCTIME) {
+        } else if (isProctimeAttribute(orderKeyType)) {
             rowTimeIdx = -1;
         } else {
             throw new TableException(

--- a/flink-table/flink-table-planner-blink/src/main/java/org/apache/flink/table/planner/plan/nodes/exec/stream/StreamExecTemporalSort.java
+++ b/flink-table/flink-table-planner-blink/src/main/java/org/apache/flink/table/planner/plan/nodes/exec/stream/StreamExecTemporalSort.java
@@ -35,11 +35,8 @@ import org.apache.flink.table.runtime.keyselector.EmptyRowDataKeySelector;
 import org.apache.flink.table.runtime.operators.sort.ProcTimeSortOperator;
 import org.apache.flink.table.runtime.operators.sort.RowTimeSortOperator;
 import org.apache.flink.table.runtime.typeutils.InternalTypeInfo;
-import org.apache.flink.table.types.logical.LocalZonedTimestampType;
 import org.apache.flink.table.types.logical.LogicalType;
 import org.apache.flink.table.types.logical.RowType;
-import org.apache.flink.table.types.logical.TimestampKind;
-import org.apache.flink.table.types.logical.TimestampType;
 
 import org.apache.flink.shaded.jackson2.com.fasterxml.jackson.annotation.JsonCreator;
 import org.apache.flink.shaded.jackson2.com.fasterxml.jackson.annotation.JsonProperty;
@@ -47,6 +44,8 @@ import org.apache.flink.shaded.jackson2.com.fasterxml.jackson.annotation.JsonPro
 import java.util.Collections;
 import java.util.List;
 
+import static org.apache.flink.table.types.logical.utils.LogicalTypeChecks.isProctimeAttribute;
+import static org.apache.flink.table.types.logical.utils.LogicalTypeChecks.isRowtimeAttribute;
 import static org.apache.flink.util.Preconditions.checkArgument;
 import static org.apache.flink.util.Preconditions.checkNotNull;
 
@@ -101,24 +100,17 @@ public class StreamExecTemporalSort extends ExecNodeBase<RowData>
         RowType inputType = (RowType) inputEdge.getOutputType();
         LogicalType timeType = inputType.getTypeAt(sortSpec.getFieldSpec(0).getFieldIndex());
         TableConfig config = planner.getTableConfig();
-        if (timeType instanceof TimestampType) {
-            TimestampType keyType = (TimestampType) timeType;
-            if (keyType.getKind() == TimestampKind.ROWTIME) {
-                return createSortRowTime(inputType, inputTransform, config);
-            }
+        if (isRowtimeAttribute(timeType)) {
+            return createSortRowTime(inputType, inputTransform, config);
+        } else if (isProctimeAttribute(timeType)) {
+            return createSortProcTime(inputType, inputTransform, config);
+        } else {
+            throw new TableException(
+                    String.format(
+                            "Sort: Internal Error\n"
+                                    + "First field in temporal sort is not a time attribute, %s is given.",
+                            timeType));
         }
-        if (timeType instanceof LocalZonedTimestampType) {
-            LocalZonedTimestampType keyType = (LocalZonedTimestampType) timeType;
-            if (keyType.getKind() == TimestampKind.PROCTIME) {
-                return createSortProcTime(inputType, inputTransform, config);
-            }
-        }
-
-        throw new TableException(
-                String.format(
-                        "Sort: Internal Error\n"
-                                + "First field in temporal sort is not a time attribute, %s is given.",
-                        timeType));
     }
 
     /** Create Sort logic based on processing time. */

--- a/flink-table/flink-table-planner-blink/src/test/scala/org/apache/flink/table/planner/runtime/stream/sql/OverAggregateITCase.scala
+++ b/flink-table/flink-table-planner-blink/src/test/scala/org/apache/flink/table/planner/runtime/stream/sql/OverAggregateITCase.scala
@@ -1008,16 +1008,16 @@ class OverAggregateITCase(mode: StateBackendMode) extends StreamingWithStateTest
   @Test
   def testTimestampRowTimeDistinctUnboundedPartitionedRangeOverWithNullValues(): Unit = {
     val rows = Seq(
-      row(LocalDateTime.parse("1970-01-01T00:00:01"), 1, null),
-      row(LocalDateTime.parse("1970-01-01T00:00:02"), 1, null),
-      row(LocalDateTime.parse("1970-01-01T00:00:03"), 2, null),
-      row(LocalDateTime.parse("1970-01-01T00:00:04"), 1, "Hello"),
-      row(LocalDateTime.parse("1970-01-01T00:00:05"), 1, "Hello"),
-      row(LocalDateTime.parse("1970-01-01T00:00:06"), 2, "Hello"),
-      row(LocalDateTime.parse("1970-01-01T00:00:07"), 1, "Hello World"),
-      row(LocalDateTime.parse("1970-01-01T00:00:08"), 2, "Hello World"),
-      row(LocalDateTime.parse("1970-01-01T00:00:09"), 2, "Hello World"),
-      row(LocalDateTime.parse("1970-01-01T00:00:10"), 1, null))
+      rowOf(LocalDateTime.parse("1970-01-01T00:00:01"), 1, null),
+      rowOf(LocalDateTime.parse("1970-01-01T00:00:02"), 1, null),
+      rowOf(LocalDateTime.parse("1970-01-01T00:00:03"), 2, null),
+      rowOf(LocalDateTime.parse("1970-01-01T00:00:04"), 1, "Hello"),
+      rowOf(LocalDateTime.parse("1970-01-01T00:00:05"), 1, "Hello"),
+      rowOf(LocalDateTime.parse("1970-01-01T00:00:06"), 2, "Hello"),
+      rowOf(LocalDateTime.parse("1970-01-01T00:00:07"), 1, "Hello World"),
+      rowOf(LocalDateTime.parse("1970-01-01T00:00:08"), 2, "Hello World"),
+      rowOf(LocalDateTime.parse("1970-01-01T00:00:09"), 2, "Hello World"),
+      rowOf(LocalDateTime.parse("1970-01-01T00:00:10"), 1, null))
 
     val tableId = TestValuesTableFactory.registerData(rows)
 
@@ -1064,16 +1064,16 @@ class OverAggregateITCase(mode: StateBackendMode) extends StreamingWithStateTest
   @Test
   def testTimestampLtzRowTimeDistinctUnboundedPartitionedRangeOverWithNullValues(): Unit = {
     val rows = Seq(
-      row(Instant.ofEpochSecond(1L), 1, null),
-      row(Instant.ofEpochSecond(2L), 1, null),
-      row(Instant.ofEpochSecond(3L), 2, null),
-      row(Instant.ofEpochSecond(4L), 1, "Hello"),
-      row(Instant.ofEpochSecond(5L), 1, "Hello"),
-      row(Instant.ofEpochSecond(6L), 2, "Hello"),
-      row(Instant.ofEpochSecond(7L), 1, "Hello World"),
-      row(Instant.ofEpochSecond(8L), 2, "Hello World"),
-      row(Instant.ofEpochSecond(9L), 2, "Hello World"),
-      row(Instant.ofEpochSecond(10L), 1, null))
+      rowOf(Instant.ofEpochSecond(1L), 1, null),
+      rowOf(Instant.ofEpochSecond(2L), 1, null),
+      rowOf(Instant.ofEpochSecond(3L), 2, null),
+      rowOf(Instant.ofEpochSecond(4L), 1, "Hello"),
+      rowOf(Instant.ofEpochSecond(5L), 1, "Hello"),
+      rowOf(Instant.ofEpochSecond(6L), 2, "Hello"),
+      rowOf(Instant.ofEpochSecond(7L), 1, "Hello World"),
+      rowOf(Instant.ofEpochSecond(8L), 2, "Hello World"),
+      rowOf(Instant.ofEpochSecond(9L), 2, "Hello World"),
+      rowOf(Instant.ofEpochSecond(10L), 1, null))
 
     val tableId = TestValuesTableFactory.registerData(rows)
 

--- a/flink-table/flink-table-planner-blink/src/test/scala/org/apache/flink/table/planner/runtime/stream/sql/OverAggregateITCase.scala
+++ b/flink-table/flink-table-planner-blink/src/test/scala/org/apache/flink/table/planner/runtime/stream/sql/OverAggregateITCase.scala
@@ -21,6 +21,7 @@ package org.apache.flink.table.planner.runtime.stream.sql
 import org.apache.flink.api.scala._
 import org.apache.flink.table.api._
 import org.apache.flink.table.api.bridge.scala._
+import org.apache.flink.table.planner.factories.TestValuesTableFactory
 import org.apache.flink.table.planner.runtime.utils.StreamingWithStateTestBase.StateBackendMode
 import org.apache.flink.table.planner.runtime.utils.TimeTestUtil.EventTimeProcessOperator
 import org.apache.flink.table.planner.runtime.utils.UserDefinedFunctionTestUtils.{CountNullNonNull, CountPairs, LargerThanCount}
@@ -32,7 +33,9 @@ import org.junit._
 import org.junit.runner.RunWith
 import org.junit.runners.Parameterized
 
-import scala.collection.mutable
+import java.time.{Instant, LocalDateTime}
+
+import scala.collection.{Seq, mutable}
 
 @RunWith(classOf[Parameterized])
 class OverAggregateITCase(mode: StateBackendMode) extends StreamingWithStateTestBase(mode) {
@@ -1003,28 +1006,94 @@ class OverAggregateITCase(mode: StateBackendMode) extends StreamingWithStateTest
   }
 
   @Test
-  def testRowTimeDistinctUnboundedPartitionedRangeOverWithNullValues(): Unit = {
-    val data = List(
-      (1L, 1, null),
-      (2L, 1, null),
-      (3L, 2, null),
-      (4L, 1, "Hello"),
-      (5L, 1, "Hello"),
-      (6L, 2, "Hello"),
-      (7L, 1, "Hello World"),
-      (8L, 2, "Hello World"),
-      (9L, 2, "Hello World"),
-      (10L, 1, null))
+  def testTimestampRowTimeDistinctUnboundedPartitionedRangeOverWithNullValues(): Unit = {
+    val rows = Seq(
+      row(LocalDateTime.parse("1970-01-01T00:00:01"), 1, null),
+      row(LocalDateTime.parse("1970-01-01T00:00:02"), 1, null),
+      row(LocalDateTime.parse("1970-01-01T00:00:03"), 2, null),
+      row(LocalDateTime.parse("1970-01-01T00:00:04"), 1, "Hello"),
+      row(LocalDateTime.parse("1970-01-01T00:00:05"), 1, "Hello"),
+      row(LocalDateTime.parse("1970-01-01T00:00:06"), 2, "Hello"),
+      row(LocalDateTime.parse("1970-01-01T00:00:07"), 1, "Hello World"),
+      row(LocalDateTime.parse("1970-01-01T00:00:08"), 2, "Hello World"),
+      row(LocalDateTime.parse("1970-01-01T00:00:09"), 2, "Hello World"),
+      row(LocalDateTime.parse("1970-01-01T00:00:10"), 1, null))
+
+    val tableId = TestValuesTableFactory.registerData(rows)
 
     // for sum aggregation ensure that every time the order of each element is consistent
     env.setParallelism(1)
+    tEnv.executeSql(
+      s"""
+         |CREATE TABLE MyTable (
+         |  rowtime TIMESTAMP(3),
+         |  b INT,
+         |  c STRING,
+         |  WATERMARK FOR rowtime AS rowtime
+         |) WITH (
+         |  'connector' = 'values',
+         |  'data-id' = '$tableId',
+         |  'bounded' = 'true'
+         |)
+         |""".stripMargin)
 
-    val table = failingDataSource(data)
-      .assignAscendingTimestamps(_._1)
-      .toTable(tEnv, 'a, 'b, 'c, 'rowtime.rowtime)
+    tEnv.createTemporaryFunction("CntNullNonNull", new CountNullNonNull)
 
-    tEnv.registerTable("MyTable", table)
-    tEnv.registerFunction("CntNullNonNull", new CountNullNonNull)
+    val sqlQuery = "SELECT " +
+      "  c, " +
+      "  b, " +
+      "  COUNT(DISTINCT c) " +
+      "    OVER (PARTITION BY b ORDER BY rowtime RANGE UNBOUNDED preceding), " +
+      "  CntNullNonNull(DISTINCT c) " +
+      "    OVER (PARTITION BY b ORDER BY rowtime RANGE UNBOUNDED preceding)" +
+      "FROM " +
+      "  MyTable"
+
+    val result = tEnv.sqlQuery(sqlQuery).toAppendStream[Row]
+    val sink = new TestingAppendSink
+    result.addSink(sink)
+    env.execute()
+
+    val expected = List(
+      "null,1,0,0|1", "null,1,0,0|1", "null,2,0,0|1", "null,1,2,2|1",
+      "Hello,1,1,1|1", "Hello,1,1,1|1", "Hello,2,1,1|1",
+      "Hello World,1,2,2|1", "Hello World,2,2,2|1", "Hello World,2,2,2|1")
+    assertEquals(expected.sorted, sink.getAppendResults.sorted)
+  }
+
+  @Test
+  def testTimestampLtzRowTimeDistinctUnboundedPartitionedRangeOverWithNullValues(): Unit = {
+    val rows = Seq(
+      row(Instant.ofEpochSecond(1L), 1, null),
+      row(Instant.ofEpochSecond(2L), 1, null),
+      row(Instant.ofEpochSecond(3L), 2, null),
+      row(Instant.ofEpochSecond(4L), 1, "Hello"),
+      row(Instant.ofEpochSecond(5L), 1, "Hello"),
+      row(Instant.ofEpochSecond(6L), 2, "Hello"),
+      row(Instant.ofEpochSecond(7L), 1, "Hello World"),
+      row(Instant.ofEpochSecond(8L), 2, "Hello World"),
+      row(Instant.ofEpochSecond(9L), 2, "Hello World"),
+      row(Instant.ofEpochSecond(10L), 1, null))
+
+    val tableId = TestValuesTableFactory.registerData(rows)
+
+    // for sum aggregation ensure that every time the order of each element is consistent
+    env.setParallelism(1)
+    tEnv.executeSql(
+      s"""
+         |CREATE TABLE MyTable (
+         |  rowtime TIMESTAMP_LTZ(3),
+         |  b INT,
+         |  c STRING,
+         |  WATERMARK FOR rowtime AS rowtime
+         |) WITH (
+         |  'connector' = 'values',
+         |  'data-id' = '$tableId',
+         |  'bounded' = 'true'
+         |)
+         |""".stripMargin)
+
+    tEnv.createTemporaryFunction("CntNullNonNull", new CountNullNonNull)
 
     val sqlQuery = "SELECT " +
       "  c, " +

--- a/flink-table/flink-table-planner-blink/src/test/scala/org/apache/flink/table/planner/runtime/stream/sql/TemporalSortITCase.scala
+++ b/flink-table/flink-table-planner-blink/src/test/scala/org/apache/flink/table/planner/runtime/stream/sql/TemporalSortITCase.scala
@@ -130,17 +130,17 @@ class TemporalSortITCase(mode: StateBackendMode) extends StreamingWithStateTestB
   @Test
   def testTimestampEventTimeAndOtherFieldOrderBy(): Unit = {
     val rows = Seq(
-      row(LocalDateTime.parse("1970-01-01T00:00:03"), 2L, "Hello world", 3),
-      row(LocalDateTime.parse("1970-01-01T00:00:02"), 2L, "Hello", 2),
-      row(LocalDateTime.parse("1970-01-01T00:00:06"), 3L, "Luke Skywalker", 6),
-      row(LocalDateTime.parse("1970-01-01T00:00:05"), 3L, "I am fine.", 5),
-      row(LocalDateTime.parse("1970-01-01T00:00:07"), 4L, "Comment#1", 7),
-      row(LocalDateTime.parse("1970-01-01T00:00:09"), 4L, "Comment#3", 9),
-      row(LocalDateTime.parse("1970-01-01T00:00:10"), 4L, "Comment#4", 10),
-      row(LocalDateTime.parse("1970-01-01T00:00:08"), 4L, "Comment#2", 8),
-      row(LocalDateTime.parse("1970-01-01T00:00:01"), 1L, "Hi", 2),
-      row(LocalDateTime.parse("1970-01-01T00:00:01"), 1L, "Hi", 1),
-      row(LocalDateTime.parse("1970-01-01T00:00:04"), 3L, "Helloworld, how are you?", 4))
+      rowOf(LocalDateTime.parse("1970-01-01T00:00:03"), 2L, "Hello world", 3),
+      rowOf(LocalDateTime.parse("1970-01-01T00:00:02"), 2L, "Hello", 2),
+      rowOf(LocalDateTime.parse("1970-01-01T00:00:06"), 3L, "Luke Skywalker", 6),
+      rowOf(LocalDateTime.parse("1970-01-01T00:00:05"), 3L, "I am fine.", 5),
+      rowOf(LocalDateTime.parse("1970-01-01T00:00:07"), 4L, "Comment#1", 7),
+      rowOf(LocalDateTime.parse("1970-01-01T00:00:09"), 4L, "Comment#3", 9),
+      rowOf(LocalDateTime.parse("1970-01-01T00:00:10"), 4L, "Comment#4", 10),
+      rowOf(LocalDateTime.parse("1970-01-01T00:00:08"), 4L, "Comment#2", 8),
+      rowOf(LocalDateTime.parse("1970-01-01T00:00:01"), 1L, "Hi", 2),
+      rowOf(LocalDateTime.parse("1970-01-01T00:00:01"), 1L, "Hi", 1),
+      rowOf(LocalDateTime.parse("1970-01-01T00:00:04"), 3L, "Helloworld, how are you?", 4))
 
     val tableId = TestValuesTableFactory.registerData(rows)
     tEnv.executeSql(
@@ -184,17 +184,17 @@ class TemporalSortITCase(mode: StateBackendMode) extends StreamingWithStateTestB
   @Test
   def testTimestampLtzEventTimeAndOtherFieldOrderBy(): Unit = {
     val rows = Seq(
-      row(Instant.ofEpochSecond(3L), 2L, "Hello world", 3),
-      row(Instant.ofEpochSecond(2L), 2L, "Hello", 2),
-      row(Instant.ofEpochSecond(6L), 3L, "Luke Skywalker", 6),
-      row(Instant.ofEpochSecond(5L), 3L, "I am fine.", 5),
-      row(Instant.ofEpochSecond(7L), 4L, "Comment#1", 7),
-      row(Instant.ofEpochSecond(9L), 4L, "Comment#3", 9),
-      row(Instant.ofEpochSecond(10L), 4L, "Comment#4", 10),
-      row(Instant.ofEpochSecond(8L), 4L, "Comment#2", 8),
-      row(Instant.ofEpochSecond(1L), 1L, "Hi", 2),
-      row(Instant.ofEpochSecond(1L), 1L, "Hi", 1),
-      row(Instant.ofEpochSecond(4L), 3L, "Helloworld, how are you?", 4))
+      rowOf(Instant.ofEpochSecond(3L), 2L, "Hello world", 3),
+      rowOf(Instant.ofEpochSecond(2L), 2L, "Hello", 2),
+      rowOf(Instant.ofEpochSecond(6L), 3L, "Luke Skywalker", 6),
+      rowOf(Instant.ofEpochSecond(5L), 3L, "I am fine.", 5),
+      rowOf(Instant.ofEpochSecond(7L), 4L, "Comment#1", 7),
+      rowOf(Instant.ofEpochSecond(9L), 4L, "Comment#3", 9),
+      rowOf(Instant.ofEpochSecond(10L), 4L, "Comment#4", 10),
+      rowOf(Instant.ofEpochSecond(8L), 4L, "Comment#2", 8),
+      rowOf(Instant.ofEpochSecond(1L), 1L, "Hi", 2),
+      rowOf(Instant.ofEpochSecond(1L), 1L, "Hi", 1),
+      rowOf(Instant.ofEpochSecond(4L), 3L, "Helloworld, how are you?", 4))
 
     val tableId = TestValuesTableFactory.registerData(rows)
     tEnv.executeSql(


### PR DESCRIPTION
## What is the purpose of the change

* Fix `StreamExecOverAggregate` and `StreamExecTemporalSort` operators didn't support LocalZonedTimestampType

## Brief change log
- Use `LogicalTypeChecks#isRowtimeAttribute()` utils to check the rowtime attribute


## Verifying this change

* Add ITCase to test the two operators.

## Does this pull request potentially affect one of the following parts:

  - Dependencies (does it add or upgrade a dependency): (no)
  - The public API, i.e., is any changed class annotated with `@Public(Evolving)`: (no)
  - The serializers: (no)
  - The runtime per-record code paths (performance sensitive): ( no)
  - Anything that affects deployment or recovery: JobManager (and its components), Checkpointing, Yarn/Mesos, ZooKeeper: (no)
  - The S3 file system connector: (no)

## Documentation

  - Does this pull request introduce a new feature? (no)
  - If yes, how is the feature documented? (not applicable / docs / JavaDocs / not documented)