### PR TITLE
[FLINK-22601][table-planner] PushWatermarkIntoScan should produce digest created by Expression.

### DIFF
--- a/flink-table/flink-table-planner/src/main/java/org/apache/flink/table/planner/plan/rules/logical/PushWatermarkIntoTableSourceScanRuleBase.java
+++ b/flink-table/flink-table-planner/src/main/java/org/apache/flink/table/planner/plan/rules/logical/PushWatermarkIntoTableSourceScanRuleBase.java
@@ -86,7 +86,7 @@ public abstract class PushWatermarkIntoTableSourceScanRuleBase extends RelOptRul
             TableConfig tableConfig,
             boolean useWatermarkAssignerRowType) {
 
-        List<String> fieldNames = watermarkAssigner.getInput().getRowType().getFieldNames();
+        List<String> fieldNames = scan.getRowType().getFieldNames();
         String digest =
                 String.format(
                         "watermark=[%s]",

--- a/flink-table/flink-table-planner/src/test/resources/org/apache/flink/table/planner/plan/nodes/exec/stream/TableSourceJsonPlanTest_jsonplan/testWatermarkPushDown.out
+++ b/flink-table/flink-table-planner/src/test/resources/org/apache/flink/table/planner/plan/nodes/exec/stream/TableSourceJsonPlanTest_jsonplan/testWatermarkPushDown.out
@@ -92,7 +92,7 @@
         }
       } ]
     },
-    "description" : "TableSourceScan(table=[[default_catalog, default_database, WatermarkTable, watermark=[-($2, 5000:INTERVAL SECOND)]]], fields=[a, b, c])",
+    "description" : "TableSourceScan(table=[[default_catalog, default_database, WatermarkTable, watermark=[-(c, 5000:INTERVAL SECOND)]]], fields=[a, b, c])",
     "inputProperties" : [ ]
   }, {
     "class" : "org.apache.flink.table.planner.plan.nodes.exec.stream.StreamExecSink",

--- a/flink-table/flink-table-planner/src/test/resources/org/apache/flink/table/planner/plan/rules/logical/PushWatermarkIntoTableSourceScanRuleTest.xml
+++ b/flink-table/flink-table-planner/src/test/resources/org/apache/flink/table/planner/plan/rules/logical/PushWatermarkIntoTableSourceScanRuleTest.xml
@@ -112,7 +112,7 @@ LogicalProject(a=[$0], b=[$1], c=[$2], metadata=[$3], computed=[$4])
       <![CDATA[
 FlinkLogicalCalc(select=[a, b, c, metadata, computed])
 +- FlinkLogicalCalc(select=[a, b, Reinterpret(c) AS c, CAST(metadata_2) AS metadata, +(CAST(metadata_2), b) AS computed])
-   +- FlinkLogicalTableSourceScan(table=[[default_catalog, default_database, MyTable, watermark=[-(c, CAST(+(CAST(metadata), +(CAST(metadata), b))))]]], fields=[a, b, c, metadata_2])
+   +- FlinkLogicalTableSourceScan(table=[[default_catalog, default_database, MyTable, watermark=[-(c, CAST(+(CAST(metadata_2), +(CAST(metadata_2), b))))]]], fields=[a, b, c, metadata_2])
 ]]>
     </Resource>
   </TestCase>

--- a/flink-table/flink-table-planner/src/test/resources/org/apache/flink/table/planner/plan/rules/logical/PushWatermarkIntoTableSourceScanRuleTest.xml
+++ b/flink-table/flink-table-planner/src/test/resources/org/apache/flink/table/planner/plan/rules/logical/PushWatermarkIntoTableSourceScanRuleTest.xml
@@ -30,7 +30,7 @@ LogicalProject(a=[$0], c=[$2])
     <Resource name="optimized rel plan">
       <![CDATA[
 FlinkLogicalCalc(select=[a, c])
-+- FlinkLogicalTableSourceScan(table=[[default_catalog, default_database, MyTable, watermark=[-($2, 5000:INTERVAL SECOND)]]], fields=[a, b, c])
++- FlinkLogicalTableSourceScan(table=[[default_catalog, default_database, MyTable, watermark=[-(c, 5000:INTERVAL SECOND)]]], fields=[a, b, c])
 ]]>
     </Resource>
   </TestCase>
@@ -50,7 +50,7 @@ LogicalProject(a=[$0], b=[$1], c=[$2], d=[$3])
       <![CDATA[
 FlinkLogicalCalc(select=[a, b, c, d])
 +- FlinkLogicalCalc(select=[a, b, c, Reinterpret(+(c, 5000:INTERVAL SECOND)) AS d])
-   +- FlinkLogicalTableSourceScan(table=[[default_catalog, default_database, MyTable, watermark=[-(+($2, 5000:INTERVAL SECOND), 5000:INTERVAL SECOND)]]], fields=[a, b, c])
+   +- FlinkLogicalTableSourceScan(table=[[default_catalog, default_database, MyTable, watermark=[-(+(c, 5000:INTERVAL SECOND), 5000:INTERVAL SECOND)]]], fields=[a, b, c])
 ]]>
     </Resource>
   </TestCase>
@@ -72,7 +72,7 @@ LogicalProject(a=[$0], b=[$1])
 FlinkLogicalCalc(select=[a, b])
 +- FlinkLogicalCalc(select=[a, b, c, d], where=[>(d, TO_TIMESTAMP(_UTF-16LE'2020-10-09 12:12:12'))])
    +- FlinkLogicalCalc(select=[a, b, c, Reinterpret(+(c, 5000:INTERVAL SECOND)) AS d])
-      +- FlinkLogicalTableSourceScan(table=[[default_catalog, default_database, MyTable, watermark=[-(+($2, 5000:INTERVAL SECOND), 5000:INTERVAL SECOND)]]], fields=[a, b, c])
+      +- FlinkLogicalTableSourceScan(table=[[default_catalog, default_database, MyTable, watermark=[-(+(c, 5000:INTERVAL SECOND), 5000:INTERVAL SECOND)]]], fields=[a, b, c])
 ]]>
     </Resource>
   </TestCase>
@@ -92,7 +92,7 @@ LogicalProject(a=[$0], b=[$1], c=[$2])
       <![CDATA[
 FlinkLogicalCalc(select=[a, b, c])
 +- FlinkLogicalCalc(select=[a, b, Reinterpret(TO_TIMESTAMP(a, b)) AS c])
-   +- FlinkLogicalTableSourceScan(table=[[default_catalog, default_database, MyTable, watermark=[-(TO_TIMESTAMP($0, $1), 5000:INTERVAL SECOND)]]], fields=[a, b])
+   +- FlinkLogicalTableSourceScan(table=[[default_catalog, default_database, MyTable, watermark=[-(TO_TIMESTAMP(a, b), 5000:INTERVAL SECOND)]]], fields=[a, b])
 ]]>
     </Resource>
   </TestCase>
@@ -112,7 +112,7 @@ LogicalProject(a=[$0], b=[$1], c=[$2], metadata=[$3], computed=[$4])
       <![CDATA[
 FlinkLogicalCalc(select=[a, b, c, metadata, computed])
 +- FlinkLogicalCalc(select=[a, b, Reinterpret(c) AS c, CAST(metadata_2) AS metadata, +(CAST(metadata_2), b) AS computed])
-   +- FlinkLogicalTableSourceScan(table=[[default_catalog, default_database, MyTable, watermark=[-($2, CAST(+(CAST($3):BIGINT, +(CAST($3):BIGINT, $1))):INTERVAL SECOND)]]], fields=[a, b, c, metadata_2])
+   +- FlinkLogicalTableSourceScan(table=[[default_catalog, default_database, MyTable, watermark=[-(c, CAST(+(CAST(metadata), +(CAST(metadata), b))))]]], fields=[a, b, c, metadata_2])
 ]]>
     </Resource>
   </TestCase>
@@ -132,7 +132,7 @@ LogicalProject(a=[$0], b=[$1], c=[$2], g=[$3])
       <![CDATA[
 FlinkLogicalCalc(select=[a, b, c, g])
 +- FlinkLogicalCalc(select=[a, b, c, Reinterpret(c.d.f) AS g])
-   +- FlinkLogicalTableSourceScan(table=[[default_catalog, default_database, MyTable, watermark=[-($2.d.f, 5000:INTERVAL SECOND)]]], fields=[a, b, c])
+   +- FlinkLogicalTableSourceScan(table=[[default_catalog, default_database, MyTable, watermark=[-(c.d.f, 5000:INTERVAL SECOND)]]], fields=[a, b, c])
 ]]>
     </Resource>
   </TestCase>
@@ -152,7 +152,7 @@ LogicalProject(a=[$0], b=[$1], c=[$2], e=[$3])
       <![CDATA[
 FlinkLogicalCalc(select=[a, b, c, e])
 +- FlinkLogicalCalc(select=[a, b, c, Reinterpret(c.d) AS e])
-   +- FlinkLogicalTableSourceScan(table=[[default_catalog, default_database, MyTable, watermark=[-($2.d, 5000:INTERVAL SECOND)]]], fields=[a, b, c])
+   +- FlinkLogicalTableSourceScan(table=[[default_catalog, default_database, MyTable, watermark=[-(c.d, 5000:INTERVAL SECOND)]]], fields=[a, b, c])
 ]]>
     </Resource>
   </TestCase>
@@ -170,7 +170,7 @@ LogicalProject(a=[$0], c=[$2])
     <Resource name="optimized rel plan">
       <![CDATA[
 FlinkLogicalCalc(select=[a, c])
-+- FlinkLogicalTableSourceScan(table=[[default_catalog, default_database, MyTable, watermark=[-($2, 5000:INTERVAL SECOND)], idletimeout=[1000]]], fields=[a, b, c])
++- FlinkLogicalTableSourceScan(table=[[default_catalog, default_database, MyTable, watermark=[-(c, 5000:INTERVAL SECOND)], idletimeout=[1000]]], fields=[a, b, c])
 ]]>
     </Resource>
   </TestCase>
@@ -190,7 +190,7 @@ LogicalProject(a=[$0], b=[$1], c=[$2], d=[$3])
       <![CDATA[
 FlinkLogicalCalc(select=[a, b, c, d])
 +- FlinkLogicalCalc(select=[a, b, c, Reinterpret(func(c, a)) AS d])
-   +- FlinkLogicalTableSourceScan(table=[[default_catalog, default_database, MyTable, watermark=[func(func(func($2, $0), $0), $0)]]], fields=[a, b, c])
+   +- FlinkLogicalTableSourceScan(table=[[default_catalog, default_database, MyTable, watermark=[func(func(func(c, a), a), a)]]], fields=[a, b, c])
 ]]>
     </Resource>
   </TestCase>

--- a/flink-table/flink-table-planner/src/test/resources/org/apache/flink/table/planner/plan/stream/sql/FilterableSourceTest.xml
+++ b/flink-table/flink-table-planner/src/test/resources/org/apache/flink/table/planner/plan/stream/sql/FilterableSourceTest.xml
@@ -30,7 +30,7 @@ LogicalProject(a=[$0], b=[$1], c=[$2], d=[$3])
 		</Resource>
 		<Resource name="optimized exec plan">
 			<![CDATA[
-TableSourceScan(table=[[default_catalog, default_database, MyTable, watermark=[$2], filter=[equals(lower(d), 'hello')]]], fields=[a, b, c, d])
+TableSourceScan(table=[[default_catalog, default_database, MyTable, watermark=[c], filter=[equals(lower(d), 'hello')]]], fields=[a, b, c, d])
 ]]>
 		</Resource>
 	</TestCase>
@@ -49,7 +49,7 @@ LogicalProject(a=[$0], b=[$1], c=[$2], d=[$3])
 		<Resource name="optimized exec plan">
 			<![CDATA[
 Calc(select=[a, b, c, d], where=[d IS NOT NULL])
-+- TableSourceScan(table=[[default_catalog, default_database, MyTable, watermark=[$2], filter=[equals(lower(d), 'h')]]], fields=[a, b, c, d])
++- TableSourceScan(table=[[default_catalog, default_database, MyTable, watermark=[c], filter=[equals(lower(d), 'h')]]], fields=[a, b, c, d])
 ]]>
 		</Resource>
 	</TestCase>
@@ -87,7 +87,7 @@ LogicalProject(a=[$0], b=[$1], c=[$2], d=[$3])
 		<Resource name="optimized exec plan">
 			<![CDATA[
 Calc(select=[a, b, c, d], where=[(b > 5)])
-+- TableSourceScan(table=[[default_catalog, default_database, MyTable, watermark=[$2], filter=[]]], fields=[a, b, c, d])
++- TableSourceScan(table=[[default_catalog, default_database, MyTable, watermark=[c], filter=[]]], fields=[a, b, c, d])
 ]]>
 		</Resource>
 	</TestCase>
@@ -107,7 +107,7 @@ LogicalProject(event_time=[$0], name=[$1], lowercase_name=[$2])
 		<Resource name="optimized exec plan">
 			<![CDATA[
 Calc(select=[Reinterpret(event_time) AS event_time, name, CAST(_UTF-16LE'foo':VARCHAR(2147483647) CHARACTER SET "UTF-16LE") AS lowercase_name])
-+- TableSourceScan(table=[[default_catalog, default_database, WithWatermark, watermark=[$0], filter=[equals(lower(name), 'foo')]]], fields=[event_time, name])
++- TableSourceScan(table=[[default_catalog, default_database, WithWatermark, watermark=[event_time], filter=[equals(lower(name), 'foo')]]], fields=[event_time, name])
 ]]>
 		</Resource>
 	</TestCase>
@@ -144,7 +144,7 @@ LogicalProject(a=[$0], b=[$1], c=[$2], d=[$3], f=[$4])
 		<Resource name="optimized exec plan">
 			<![CDATA[
 Calc(select=[a, b, Reinterpret(c) AS c, func(c, a) AS d, f])
-+- TableSourceScan(table=[[default_catalog, default_database, UdfTable, watermark=[func(func(func($2, $0), $0), $0)], filter=[equals(upper(f), 'welcome')]]], fields=[a, b, c, f])
++- TableSourceScan(table=[[default_catalog, default_database, UdfTable, watermark=[func(func(func(c, a), a), a)], filter=[equals(upper(f), 'welcome')]]], fields=[a, b, c, f])
 ]]>
 		</Resource>
 	</TestCase>
@@ -164,7 +164,7 @@ LogicalProject(a=[$0], b=[$1], c=[$2], d=[$3], f=[$4])
 		<Resource name="optimized exec plan">
 			<![CDATA[
 Calc(select=[a, b, Reinterpret(c) AS c, func(c, a) AS d, f])
-+- TableSourceScan(table=[[default_catalog, default_database, UdfTable, watermark=[func(func(func($2, $0), $0), $0)], filter=[equals(upper(f), 'welcome')]]], fields=[a, b, c, f])
++- TableSourceScan(table=[[default_catalog, default_database, UdfTable, watermark=[func(func(func(c, a), a), a)], filter=[equals(upper(f), 'welcome')]]], fields=[a, b, c, f])
 ]]>
 		</Resource>
 	</TestCase>

--- a/flink-table/flink-table-planner/src/test/resources/org/apache/flink/table/planner/plan/stream/sql/SourceWatermarkTest.xml
+++ b/flink-table/flink-table-planner/src/test/resources/org/apache/flink/table/planner/plan/stream/sql/SourceWatermarkTest.xml
@@ -31,7 +31,7 @@ LogicalProject(EXPR$0=[-($0, $1)])
     <Resource name="optimized exec plan">
       <![CDATA[
 Calc(select=[(a - b) AS EXPR$0])
-+- TableSourceScan(table=[[default_catalog, default_database, UdfTable, watermark=[func(func(func($2, $0), $0), $0)]]], fields=[a, b, c])
++- TableSourceScan(table=[[default_catalog, default_database, UdfTable, watermark=[func(func(func(c, a), a), a)]]], fields=[a, b, c])
 ]]>
     </Resource>
   </TestCase>
@@ -49,7 +49,7 @@ LogicalProject(a=[$0], b=[$1], ts=[$5])
     </Resource>
     <Resource name="optimized exec plan">
       <![CDATA[
-TableSourceScan(table=[[default_catalog, default_database, t1, project=[a, b, t], metadata=[], watermark=[-($2, 10000:INTERVAL SECOND)]]], fields=[a, b, t])
+TableSourceScan(table=[[default_catalog, default_database, t1, project=[a, b, t], metadata=[], watermark=[-(t, 10000:INTERVAL SECOND)]]], fields=[a, b, t])
 ]]>
     </Resource>
   </TestCase>
@@ -67,7 +67,7 @@ LogicalProject(a=[$0], b=[$1], c=[$2])
     </Resource>
     <Resource name="optimized exec plan">
       <![CDATA[
-TableSourceScan(table=[[default_catalog, default_database, VirtualTable, watermark=[-(+($2, 5000:INTERVAL SECOND), 5000:INTERVAL SECOND)]]], fields=[a, b, c])
+TableSourceScan(table=[[default_catalog, default_database, VirtualTable, watermark=[-(+(c, 5000:INTERVAL SECOND), 5000:INTERVAL SECOND)]]], fields=[a, b, c])
 ]]>
     </Resource>
   </TestCase>
@@ -87,7 +87,7 @@ LogicalProject(a=[$0], b=[$1])
     <Resource name="optimized exec plan">
       <![CDATA[
 Calc(select=[a, b], where=[(b > 10)])
-+- TableSourceScan(table=[[default_catalog, default_database, VirtualTable, watermark=[-(+($2, 5000:INTERVAL SECOND), 5000:INTERVAL SECOND)], filter=[]]], fields=[a, b, c])
++- TableSourceScan(table=[[default_catalog, default_database, VirtualTable, watermark=[-(+(c, 5000:INTERVAL SECOND), 5000:INTERVAL SECOND)], filter=[]]], fields=[a, b, c])
 ]]>
     </Resource>
   </TestCase>
@@ -106,7 +106,7 @@ LogicalProject(a=[$0], b=[$1], rowtime=[$2])
     <Resource name="optimized exec plan">
       <![CDATA[
 Calc(select=[a, b, Reinterpret(TO_TIMESTAMP_LTZ(b, 0)) AS rowtime])
-+- TableSourceScan(table=[[default_catalog, default_database, timeTestTable, watermark=[TO_TIMESTAMP_LTZ($1, 0)]]], fields=[a, b])
++- TableSourceScan(table=[[default_catalog, default_database, timeTestTable, watermark=[TO_TIMESTAMP_LTZ(b, 0)]]], fields=[a, b])
 ]]>
     </Resource>
   </TestCase>
@@ -125,7 +125,7 @@ LogicalProject(e=[$2.d.e], d=[$2.d])
     <Resource name="optimized exec plan">
       <![CDATA[
 Calc(select=[c.d.e AS e, c.d AS d])
-+- TableSourceScan(table=[[default_catalog, default_database, NestedTable, project=[c], metadata=[], watermark=[-($0.d.f, 5000:INTERVAL SECOND)]]], fields=[c])
++- TableSourceScan(table=[[default_catalog, default_database, NestedTable, project=[c], metadata=[], watermark=[-(c.d.f, 5000:INTERVAL SECOND)]]], fields=[c])
 ]]>
     </Resource>
   </TestCase>
@@ -144,7 +144,7 @@ LogicalProject(a=[$0], b=[$1])
     <Resource name="optimized exec plan">
       <![CDATA[
 Calc(select=[a, b])
-+- TableSourceScan(table=[[default_catalog, default_database, MyLtzTable, project=[a, b, originTime], metadata=[originTime], watermark=[TO_TIMESTAMP_LTZ($2, 3)]]], fields=[a, b, originTime])
++- TableSourceScan(table=[[default_catalog, default_database, MyLtzTable, project=[a, b, originTime], metadata=[originTime], watermark=[TO_TIMESTAMP_LTZ(rowtime, 3)]]], fields=[a, b, originTime])
 ]]>
     </Resource>
   </TestCase>
@@ -163,7 +163,7 @@ LogicalProject(a=[$0], b=[$1], EXPR$2=[EXTRACT(FLAG(SECOND), $3)])
     <Resource name="optimized exec plan">
       <![CDATA[
 Calc(select=[a, b, EXTRACT(FLAG(SECOND), CAST(Reinterpret((c + 5000:INTERVAL SECOND)))) AS EXPR$2])
-+- TableSourceScan(table=[[default_catalog, default_database, VirtualTable, watermark=[-(+($2, 5000:INTERVAL SECOND), 5000:INTERVAL SECOND)]]], fields=[a, b, c])
++- TableSourceScan(table=[[default_catalog, default_database, VirtualTable, watermark=[-(+(c, 5000:INTERVAL SECOND), 5000:INTERVAL SECOND)]]], fields=[a, b, c])
 ]]>
     </Resource>
   </TestCase>
@@ -182,7 +182,7 @@ LogicalProject(a=[$0], b=[$1])
     <Resource name="optimized exec plan">
       <![CDATA[
 Calc(select=[a, b])
-+- TableSourceScan(table=[[default_catalog, default_database, MyTable, project=[a, b, originTime], metadata=[originTime], watermark=[TO_TIMESTAMP(FROM_UNIXTIME(/($2, 1000)), _UTF-16LE'yyyy-MM-dd HH:mm:ss')]]], fields=[a, b, originTime])
++- TableSourceScan(table=[[default_catalog, default_database, MyTable, project=[a, b, originTime], metadata=[originTime], watermark=[TO_TIMESTAMP(FROM_UNIXTIME(/(rowtime, 1000)), _UTF-16LE'yyyy-MM-dd HH:mm:ss')]]], fields=[a, b, originTime])
 ]]>
     </Resource>
   </TestCase>

--- a/flink-table/flink-table-planner/src/test/resources/org/apache/flink/table/planner/plan/stream/sql/SourceWatermarkTest.xml
+++ b/flink-table/flink-table-planner/src/test/resources/org/apache/flink/table/planner/plan/stream/sql/SourceWatermarkTest.xml
@@ -144,7 +144,7 @@ LogicalProject(a=[$0], b=[$1])
     <Resource name="optimized exec plan">
       <![CDATA[
 Calc(select=[a, b])
-+- TableSourceScan(table=[[default_catalog, default_database, MyLtzTable, project=[a, b, originTime], metadata=[originTime], watermark=[TO_TIMESTAMP_LTZ(rowtime, 3)]]], fields=[a, b, originTime])
++- TableSourceScan(table=[[default_catalog, default_database, MyLtzTable, project=[a, b, originTime], metadata=[originTime], watermark=[TO_TIMESTAMP_LTZ(originTime, 3)]]], fields=[a, b, originTime])
 ]]>
     </Resource>
   </TestCase>
@@ -182,7 +182,7 @@ LogicalProject(a=[$0], b=[$1])
     <Resource name="optimized exec plan">
       <![CDATA[
 Calc(select=[a, b])
-+- TableSourceScan(table=[[default_catalog, default_database, MyTable, project=[a, b, originTime], metadata=[originTime], watermark=[TO_TIMESTAMP(FROM_UNIXTIME(/(rowtime, 1000)), _UTF-16LE'yyyy-MM-dd HH:mm:ss')]]], fields=[a, b, originTime])
++- TableSourceScan(table=[[default_catalog, default_database, MyTable, project=[a, b, originTime], metadata=[originTime], watermark=[TO_TIMESTAMP(FROM_UNIXTIME(/(originTime, 1000)), _UTF-16LE'yyyy-MM-dd HH:mm:ss')]]], fields=[a, b, originTime])
 ]]>
     </Resource>
   </TestCase>

--- a/flink-table/flink-table-planner/src/test/resources/org/apache/flink/table/planner/plan/stream/sql/TableScanTest.xml
+++ b/flink-table/flink-table-planner/src/test/resources/org/apache/flink/table/planner/plan/stream/sql/TableScanTest.xml
@@ -638,7 +638,7 @@ LogicalProject(id=[$0], ts=[$4])
 Calc(select=[id, Reinterpret(TO_TIMESTAMP(c)) AS ts], changelogMode=[I,UA,D])
 +- ChangelogNormalize(key=[id], changelogMode=[I,UA,D])
    +- Exchange(distribution=[hash[id]], changelogMode=[UA,D])
-      +- TableSourceScan(table=[[default_catalog, default_database, src, project=[id, c], metadata=[], watermark=[-(TO_TIMESTAMP($1), 1000:INTERVAL SECOND)]]], fields=[id, c], changelogMode=[UA,D])
+      +- TableSourceScan(table=[[default_catalog, default_database, src, project=[id, c], metadata=[], watermark=[-(TO_TIMESTAMP(ts), 1000:INTERVAL SECOND)]]], fields=[id, c], changelogMode=[UA,D])
 ]]>
     </Resource>
   </TestCase>

--- a/flink-table/flink-table-planner/src/test/resources/org/apache/flink/table/planner/plan/stream/sql/TableScanTest.xml
+++ b/flink-table/flink-table-planner/src/test/resources/org/apache/flink/table/planner/plan/stream/sql/TableScanTest.xml
@@ -638,7 +638,7 @@ LogicalProject(id=[$0], ts=[$4])
 Calc(select=[id, Reinterpret(TO_TIMESTAMP(c)) AS ts], changelogMode=[I,UA,D])
 +- ChangelogNormalize(key=[id], changelogMode=[I,UA,D])
    +- Exchange(distribution=[hash[id]], changelogMode=[UA,D])
-      +- TableSourceScan(table=[[default_catalog, default_database, src, project=[id, c], metadata=[], watermark=[-(TO_TIMESTAMP(ts), 1000:INTERVAL SECOND)]]], fields=[id, c], changelogMode=[UA,D])
+      +- TableSourceScan(table=[[default_catalog, default_database, src, project=[id, c], metadata=[], watermark=[-(TO_TIMESTAMP(c), 1000:INTERVAL SECOND)]]], fields=[id, c], changelogMode=[UA,D])
 ]]>
     </Resource>
   </TestCase>


### PR DESCRIPTION
### What is the purpose of the change
---
"In PushWatermarkIntoTableSourceScanRuleBase, the digest is created by RexNode instead of Expression, RexNode rely on field index but Expression rely on field name.

What this change does is adjusting the digest from field index to field name.

### Brief change log
---
- Changed the args of the function named String.format in PushWatermarkIntoTableSourceScanRuleBase.

### Verifying this change
---
Existing tests can cover this change.

### Does this pull request potentially affect one of the following parts:
---
Dependencies (does it add or upgrade a dependency): no
The public API, i.e., is any changed class annotated with @Public(Evolving): no
The serializers: no
The runtime per-record code paths (performance sensitive): no
Anything that affects deployment or recovery: JobManager (and its components), Checkpointing, Kubernetes/Yarn, ZooKeeper: no
The S3 file system connector: no

### Documentation
---
Does this pull request introduce a new feature? no
If yes, how is the feature documented?