### PR TITLE
[FLINK-24093] Supports setting the percentage of kubernetes Request resources

### DIFF
--- a/flink-kubernetes/src/main/java/org/apache/flink/kubernetes/configuration/KubernetesConfigOptions.java
+++ b/flink-kubernetes/src/main/java/org/apache/flink/kubernetes/configuration/KubernetesConfigOptions.java
@@ -149,6 +149,27 @@ public class KubernetesConfigOptions {
                             "The number of cpu used by task manager. By default, the cpu is set "
                                     + "to the number of slots per TaskManager");
 
+    public static final ConfigOption<Double> MEM_REQUEST_PERCENT =
+            key("kubernetes.mem.request.percent")
+                    .doubleType()
+                    .defaultValue(1.0)
+                    .withDescription(
+                            "For kubernetes Memory resource requests, you can set the request value to a certain ratio of limits value"
+                                    + " to start more jobs and increase the resource utilization of the cluster. "
+                                    + "And this value is greater than or equal to 0.0 and less than or equal to 1.0 ."
+                                    + "This applies to both TaskManager and JobManager  and JobManager");
+
+    public static final ConfigOption<Double> CPU_REQUEST_PERCENT =
+            key("kubernetes.cpu.request.percent")
+                    .doubleType()
+                    .defaultValue(1.0)
+                    .withDescription(
+                            "For kubernetes CPU resource requests, you can set the request value to a certain ratio of limits value"
+                                    + " to start more jobs and increase the resource utilization of the cluster. "
+                                    + "And this value is greater than or equal to 0.0 and less than or equal to 1.0 ."
+                                    + "This applies to both TaskManager and JobManager  and JobManager."
+                                    + "The value is reserved for one decimal place");
+
     public static final ConfigOption<ImagePullPolicy> CONTAINER_IMAGE_PULL_POLICY =
             key("kubernetes.container.image.pull-policy")
                     .enumType(ImagePullPolicy.class)

--- a/flink-kubernetes/src/main/java/org/apache/flink/kubernetes/kubeclient/decorators/InitJobManagerDecorator.java
+++ b/flink-kubernetes/src/main/java/org/apache/flink/kubernetes/kubeclient/decorators/InitJobManagerDecorator.java
@@ -125,10 +125,21 @@ public class InitJobManagerDecorator extends AbstractKubernetesStepDecorator {
                 container.getResources() == null
                         ? new ResourceRequirements()
                         : container.getResources();
+
         final ResourceRequirements requirements =
                 KubernetesUtils.getResourceRequirements(
                         requirementsInPodTemplate,
+                        KubernetesUtils.getRequestMem(
+                                kubernetesJobManagerParameters.getJobManagerMemoryMB(),
+                                kubernetesJobManagerParameters
+                                        .getFlinkConfiguration()
+                                        .getDouble(KubernetesConfigOptions.MEM_REQUEST_PERCENT)),
                         kubernetesJobManagerParameters.getJobManagerMemoryMB(),
+                        KubernetesUtils.getRequestCpu(
+                                kubernetesJobManagerParameters.getJobManagerCPU(),
+                                kubernetesJobManagerParameters
+                                        .getFlinkConfiguration()
+                                        .getDouble(KubernetesConfigOptions.CPU_REQUEST_PERCENT)),
                         kubernetesJobManagerParameters.getJobManagerCPU(),
                         Collections.emptyMap(),
                         Collections.emptyMap());

--- a/flink-kubernetes/src/main/java/org/apache/flink/kubernetes/kubeclient/decorators/InitTaskManagerDecorator.java
+++ b/flink-kubernetes/src/main/java/org/apache/flink/kubernetes/kubeclient/decorators/InitTaskManagerDecorator.java
@@ -109,13 +109,25 @@ public class InitTaskManagerDecorator extends AbstractKubernetesStepDecorator {
                 container.getResources() == null
                         ? new ResourceRequirements()
                         : container.getResources();
+
         final ResourceRequirements resourceRequirements =
                 KubernetesUtils.getResourceRequirements(
                         requirementsInPodTemplate,
+                        KubernetesUtils.getRequestMem(
+                                kubernetesTaskManagerParameters.getTaskManagerMemoryMB(),
+                                kubernetesTaskManagerParameters
+                                        .getFlinkConfiguration()
+                                        .getDouble(KubernetesConfigOptions.MEM_REQUEST_PERCENT)),
                         kubernetesTaskManagerParameters.getTaskManagerMemoryMB(),
+                        KubernetesUtils.getRequestCpu(
+                                kubernetesTaskManagerParameters.getTaskManagerCPU(),
+                                kubernetesTaskManagerParameters
+                                        .getFlinkConfiguration()
+                                        .getDouble(KubernetesConfigOptions.CPU_REQUEST_PERCENT)),
                         kubernetesTaskManagerParameters.getTaskManagerCPU(),
                         kubernetesTaskManagerParameters.getTaskManagerExternalResources(),
                         kubernetesTaskManagerParameters.getTaskManagerExternalResourceConfigKeys());
+
         final String image =
                 KubernetesUtils.resolveUserDefinedValue(
                         flinkConfig,

--- a/flink-kubernetes/src/test/java/org/apache/flink/kubernetes/KubernetesClusterDescriptorTest.java
+++ b/flink-kubernetes/src/test/java/org/apache/flink/kubernetes/KubernetesClusterDescriptorTest.java
@@ -34,6 +34,7 @@ import org.apache.flink.kubernetes.configuration.KubernetesConfigOptions;
 import org.apache.flink.kubernetes.configuration.KubernetesDeploymentTarget;
 import org.apache.flink.kubernetes.kubeclient.decorators.InternalServiceDecorator;
 import org.apache.flink.kubernetes.utils.Constants;
+import org.apache.flink.kubernetes.utils.KubernetesUtils;
 import org.apache.flink.runtime.jobmanager.HighAvailabilityMode;
 
 import io.fabric8.kubernetes.api.model.Container;
@@ -246,7 +247,11 @@ public class KubernetesClusterDescriptorTest extends KubernetesClientTestBase {
                 jmDeployment.getSpec().getTemplate().getSpec().getContainers().get(0);
 
         assertEquals(
-                String.valueOf(clusterSpecification.getMasterMemoryMB()),
+                String.valueOf(
+                        KubernetesUtils.getRequestMem(
+                                JOB_MANAGER_MEMORY,
+                                flinkConfig.getDouble(
+                                        KubernetesConfigOptions.MEM_REQUEST_PERCENT))),
                 jmContainer
                         .getResources()
                         .getRequests()

--- a/flink-kubernetes/src/test/java/org/apache/flink/kubernetes/KubernetesResourceManagerDriverTest.java
+++ b/flink-kubernetes/src/test/java/org/apache/flink/kubernetes/KubernetesResourceManagerDriverTest.java
@@ -29,6 +29,7 @@ import org.apache.flink.kubernetes.kubeclient.resources.KubernetesPod;
 import org.apache.flink.kubernetes.kubeclient.resources.KubernetesTooOldResourceVersionException;
 import org.apache.flink.kubernetes.kubeclient.resources.TestingKubernetesPod;
 import org.apache.flink.kubernetes.utils.Constants;
+import org.apache.flink.kubernetes.utils.KubernetesUtils;
 import org.apache.flink.runtime.clusterframework.TaskExecutorProcessSpec;
 import org.apache.flink.runtime.clusterframework.types.ResourceID;
 import org.apache.flink.runtime.resourcemanager.active.ResourceManagerDriver;
@@ -298,6 +299,7 @@ public class KubernetesResourceManagerDriverTest
             flinkConfig.setString(KubernetesConfigOptions.CLUSTER_ID, CLUSTER_ID);
             flinkConfig.setString(
                     TaskManagerOptions.RPC_PORT, String.valueOf(Constants.TASK_MANAGER_RPC_PORT));
+            flinkConfig.set(KubernetesConfigOptions.MEM_REQUEST_PERCENT, 0.8);
 
             flinkKubeClient = flinkKubeClientBuilder.build();
         }
@@ -357,9 +359,13 @@ public class KubernetesResourceManagerDriverTest
                             .getAmount(),
                     is(
                             String.valueOf(
-                                    taskExecutorProcessSpec
-                                            .getTotalProcessMemorySize()
-                                            .getMebiBytes())));
+                                    KubernetesUtils.getRequestMem(
+                                            taskExecutorProcessSpec
+                                                    .getTotalProcessMemorySize()
+                                                    .getMebiBytes(),
+                                            flinkConfig.getDouble(
+                                                    KubernetesConfigOptions
+                                                            .MEM_REQUEST_PERCENT)))));
             assertThat(
                     resourceRequirements.getRequests().get(Constants.RESOURCE_NAME_CPU).getAmount(),
                     is(

--- a/flink-kubernetes/src/test/java/org/apache/flink/kubernetes/KubernetesTestBase.java
+++ b/flink-kubernetes/src/test/java/org/apache/flink/kubernetes/KubernetesTestBase.java
@@ -58,7 +58,6 @@ public class KubernetesTestBase extends TestLogger {
     protected static final KubernetesConfigOptions.ImagePullPolicy CONTAINER_IMAGE_PULL_POLICY =
             KubernetesConfigOptions.ImagePullPolicy.IfNotPresent;
     protected static final int JOB_MANAGER_MEMORY = 768;
-
     @Rule public MixedKubernetesServer server = new MixedKubernetesServer(true, true);
 
     @Rule public TemporaryFolder temporaryFolder = new TemporaryFolder();
@@ -84,6 +83,8 @@ public class KubernetesTestBase extends TestLogger {
         flinkConfig.set(
                 JobManagerOptions.TOTAL_PROCESS_MEMORY, MemorySize.ofMebiBytes(JOB_MANAGER_MEMORY));
         flinkConfig.set(DeploymentOptionsInternal.CONF_DIR, flinkConfDir.toString());
+        flinkConfig.set(KubernetesConfigOptions.CPU_REQUEST_PERCENT, 0.6);
+        flinkConfig.set(KubernetesConfigOptions.MEM_REQUEST_PERCENT, 0.8);
     }
 
     protected void onSetup() throws Exception {}

--- a/flink-kubernetes/src/test/java/org/apache/flink/kubernetes/kubeclient/decorators/DecoratorWithPodTemplateTestBase.java
+++ b/flink-kubernetes/src/test/java/org/apache/flink/kubernetes/kubeclient/decorators/DecoratorWithPodTemplateTestBase.java
@@ -203,8 +203,22 @@ public abstract class DecoratorWithPodTemplateTestBase extends KubernetesPodTest
                 this.resultPod.getMainContainer().getResources();
 
         final Map<String, Quantity> requests = resourceRequirements.getRequests();
-        assertThat(requests.get("cpu").getAmount(), is(String.valueOf(RESOURCE_CPU)));
-        assertThat(requests.get("memory").getAmount(), is(String.valueOf(RESOURCE_MEMORY)));
+        assertThat(
+                requests.get("cpu").getAmount(),
+                is(
+                        Double.toString(
+                                KubernetesUtils.getRequestCpu(
+                                        RESOURCE_CPU,
+                                        flinkConfig.getDouble(
+                                                KubernetesConfigOptions.CPU_REQUEST_PERCENT)))));
+        assertThat(
+                requests.get("memory").getAmount(),
+                is(
+                        String.valueOf(
+                                KubernetesUtils.getRequestMem(
+                                        RESOURCE_MEMORY,
+                                        flinkConfig.getDouble(
+                                                KubernetesConfigOptions.MEM_REQUEST_PERCENT)))));
         assertThat(requests.get("ephemeral-storage").getAmount(), is("256"));
 
         final Map<String, Quantity> limits = resourceRequirements.getLimits();

--- a/flink-kubernetes/src/test/java/org/apache/flink/kubernetes/kubeclient/decorators/InitTaskManagerDecoratorTest.java
+++ b/flink-kubernetes/src/test/java/org/apache/flink/kubernetes/kubeclient/decorators/InitTaskManagerDecoratorTest.java
@@ -23,6 +23,7 @@ import org.apache.flink.kubernetes.configuration.KubernetesConfigOptions;
 import org.apache.flink.kubernetes.kubeclient.FlinkPod;
 import org.apache.flink.kubernetes.kubeclient.KubernetesTaskManagerTestBase;
 import org.apache.flink.kubernetes.utils.Constants;
+import org.apache.flink.kubernetes.utils.KubernetesUtils;
 
 import io.fabric8.kubernetes.api.model.Container;
 import io.fabric8.kubernetes.api.model.ContainerPort;
@@ -139,13 +140,28 @@ public class InitTaskManagerDecoratorTest extends KubernetesTaskManagerTestBase 
         final ResourceRequirements resourceRequirements = this.resultMainContainer.getResources();
 
         final Map<String, Quantity> requests = resourceRequirements.getRequests();
-        assertEquals(Double.toString(TASK_MANAGER_CPU), requests.get("cpu").getAmount());
-        assertEquals(String.valueOf(TOTAL_PROCESS_MEMORY), requests.get("memory").getAmount());
+        assertEquals(
+                Double.toString(
+                        KubernetesUtils.getRequestCpu(
+                                TASK_MANAGER_CPU,
+                                flinkConfig.getDouble(
+                                        KubernetesConfigOptions.CPU_REQUEST_PERCENT))),
+                requests.get("cpu").getAmount());
+        assertEquals(
+                String.valueOf(
+                        KubernetesUtils.getRequestMem(
+                                TOTAL_PROCESS_MEMORY,
+                                flinkConfig.getDouble(
+                                        KubernetesConfigOptions.MEM_REQUEST_PERCENT))),
+                requests.get("memory").getAmount());
 
         final Map<String, Quantity> limits = resourceRequirements.getLimits();
         assertEquals(Double.toString(TASK_MANAGER_CPU), limits.get("cpu").getAmount());
         assertEquals(String.valueOf(TOTAL_PROCESS_MEMORY), limits.get("memory").getAmount());
     }
+
+    @Test
+    public void testMainContainerResourceRequirementsByRequestPercent() {}
 
     @Test
     public void testExternalResourceInResourceRequirements() {

--- a/flink-kubernetes/src/test/java/org/apache/flink/kubernetes/utils/KubernetesUtilsTest.java
+++ b/flink-kubernetes/src/test/java/org/apache/flink/kubernetes/utils/KubernetesUtilsTest.java
@@ -226,4 +226,26 @@ public class KubernetesUtilsTest extends KubernetesTestBase {
                 Integer.valueOf(fallbackPort));
         assertEquals(expectedPort, cfg.get(HighAvailabilityOptions.HA_JOB_MANAGER_PORT_RANGE));
     }
+
+    @Test
+    public void testRequestMemory() {
+        final int limitMemory = 2048;
+        assertEquals(KubernetesUtils.getRequestMem(limitMemory, 1.0), 2048);
+        assertEquals(KubernetesUtils.getRequestMem(limitMemory, 0.8), 1638);
+        assertEquals(KubernetesUtils.getRequestMem(limitMemory, 0.811111), 1661);
+        assertEquals(KubernetesUtils.getRequestMem(limitMemory, 1.1), 2048);
+        assertEquals(KubernetesUtils.getRequestMem(limitMemory, 0.0), 0);
+        assertEquals(KubernetesUtils.getRequestMem(limitMemory, -1.0), 0);
+    }
+
+    @Test
+    public void testRequestCpu() {
+        final Double limitCpu = 1.0;
+        assertEquals(Double.toString(KubernetesUtils.getRequestCpu(limitCpu, 1.0)), "1.0");
+        assertEquals(Double.toString(KubernetesUtils.getRequestCpu(limitCpu, 0.8)), "0.8");
+        assertEquals(Double.toString(KubernetesUtils.getRequestCpu(limitCpu, 0.811111)), "0.8");
+        assertEquals(Double.toString(KubernetesUtils.getRequestCpu(limitCpu, 1.1)), "1.0");
+        assertEquals(Double.toString(KubernetesUtils.getRequestCpu(limitCpu, 0.0)), "0.0");
+        assertEquals(Double.toString(KubernetesUtils.getRequestCpu(limitCpu, -1.0)), "0.0");
+    }
 }


### PR DESCRIPTION
<!--
*Thank you very much for contributing to Apache Flink - we are happy that you want to help us improve Flink. To help the community review your contribution in the best possible way, please go through the checklist below, which will get the contribution into a shape in which it can be best reviewed.*

*Please understand that we do not do this to make contributions to Flink a hassle. In order to uphold a high standard of quality for code contributions, while at the same time managing a large number of contributions, we need contributors to prepare the contributions well, and give reviewers enough contextual information for the review. Please also understand that contributions that do not follow this guide will take longer to review and thus typically be picked up with lower priority by the community.*

## Contribution Checklist

  - Make sure that the pull request corresponds to a [JIRA issue](https://issues.apache.org/jira/projects/FLINK/issues). Exceptions are made for typos in JavaDoc or documentation files, which need no JIRA issue.
  
  - Name the pull request in the form "[FLINK-XXXX] [component] Title of the pull request", where *FLINK-XXXX* should be replaced by the actual issue number. Skip *component* if you are unsure about which is the best component.
  Typo fixes that have no associated JIRA issue should be named following this pattern: `[hotfix] [docs] Fix typo in event time introduction` or `[hotfix] [javadocs] Expand JavaDoc for PuncuatedWatermarkGenerator`.

  - Fill out the template below to describe the changes contributed by the pull request. That will give reviewers the context they need to do the review.
  
  - Make sure that the change passes the automated tests, i.e., `mvn clean verify` passes. You can set up Azure Pipelines CI to do that following [this guide](https://cwiki.apache.org/confluence/display/FLINK/Azure+Pipelines#AzurePipelines-Tutorial:SettingupAzurePipelinesforaforkoftheFlinkrepository).

  - Each pull request should address only one issue, not mix up code from multiple issues.
  
  - Each commit in the pull request has a meaningful commit message (including the JIRA id)

  - Once all items of the checklist are addressed, remove the above text and this checklist, leaving only the filled out template below.


**(The sections below can be removed for hotfixes of typos)**
-->

## What is the purpose of the change

For the current native Kubernetes, we start the job  to apply for resources (CPU,Memory) of the same **limit** and **request**, so as to achieve the best performance. However, in general, when the kubernetes cluster resources are used up by request allocation, In fact, there are still some physical resources left. If there is a way to reduce the number of requests per job, more jobs can be run and the resource utilization of the cluster can be improved.

Here are some simple configurations to scale down the value of request:

```
kubernetes.cpu.request.percent 
kubernetes.mem.request.percent
```

kubernetes.mem.request.percent： the default value is 1.0, the effective range of 0.0 to 1.0, the meaning of this value is: If the value is 0.5 and the total memory of taskmanager/jobmanager is 2048MB, the value of request is 2048MB*0.5=1024MB. That is, if the remaining memory of nodes is larger than 1024MB, pods can be allocated to run

kubernetes.cpu.request.percent:   the default value is 1.0, the effective range of 0.0 to 1.0, the meaning of this value is: If the value is 0.5 and the number of cpus requested by TaskManager/JobManager is 1, the value of request is 1 x 0.5=0.5, that is, the remaining CPU usage of Nodes is greater than 0.5 to allocate pods to run


## Brief change log

Supports setting the percentage of kubernetes Request resources

## Verifying this change

This change added tests and can be verified as follows:
org.apache.flink.kubernetes.utils.KubernetesUtilsTest#testRequestMemory
org.apache.flink.kubernetes.utils.KubernetesUtilsTest#testRequestCpu

## Does this pull request potentially affect one of the following parts:

  - Dependencies (does it add or upgrade a dependency): no
  - The public API, i.e., is any changed class annotated with `@Public(Evolving)`: no
  - The serializers: no
  - The runtime per-record code paths (performance sensitive): no
  - Anything that affects deployment or recovery: JobManager (and its components), Checkpointing, Kubernetes/Yarn, ZooKeeper: yes
  - The S3 file system connector: no

## Documentation

  - Does this pull request introduce a new feature? no 
  - If yes, how is the feature documented?  not documented
