### PR TITLE
[FLINK-24088][streaming] Log FlinkJobNotFoundException in debug instead of warn level in CollectResultFetcher for a cleaner log

### DIFF
--- a/flink-streaming-java/src/main/java/org/apache/flink/streaming/api/operators/collect/CollectResultFetcher.java
+++ b/flink-streaming-java/src/main/java/org/apache/flink/streaming/api/operators/collect/CollectResultFetcher.java
@@ -26,6 +26,7 @@ import org.apache.flink.api.java.tuple.Tuple2;
 import org.apache.flink.core.execution.JobClient;
 import org.apache.flink.runtime.dispatcher.UnavailableDispatcherOperationException;
 import org.apache.flink.runtime.jobgraph.OperatorID;
+import org.apache.flink.runtime.messages.FlinkJobNotFoundException;
 import org.apache.flink.runtime.operators.coordination.CoordinationRequestGateway;
 import org.apache.flink.util.ExceptionUtils;
 import org.apache.flink.util.Preconditions;
@@ -130,7 +131,13 @@ public class CollectResultFetcher<T> {
                     if (ExceptionUtils.findThrowable(
                                     e, UnavailableDispatcherOperationException.class)
                             .isPresent()) {
-                        LOG.debug("The job execution has not started yet; cannot fetch results.");
+                        LOG.debug(
+                                "The job execution has not started yet; cannot fetch results.", e);
+                    } else if (ExceptionUtils.findThrowable(e, FlinkJobNotFoundException.class)
+                            .isPresent()) {
+                        LOG.debug(
+                                "The job cannot be found. It is very likely that the job is not in a RUNNING state.",
+                                e);
                     } else {
                         LOG.warn("An exception occurred when fetching query results", e);
                     }


### PR DESCRIPTION
## What is the purpose of the change

Some users may encounter a warning message with `FlinkJobNotFoundException` when using `DataStream#collect` or `TableResult#collect`. This is because a collecting request is sent when the job is not running. See FLINK-24088 for more details.

These messages are actually harmless but for a cleaner log we change the logging level of this type of exception from warn to debug in this PR.

## Brief change log

 - Log FlinkJobNotFoundException in debug instead of warn level in CollectResultFetcher for a cleaner log

## Verifying this change

This change is a trivial rework / code cleanup without any test coverage.

## Does this pull request potentially affect one of the following parts:

  - Dependencies (does it add or upgrade a dependency): no
  - The public API, i.e., is any changed class annotated with `@Public(Evolving)`: no
  - The serializers: no
  - The runtime per-record code paths (performance sensitive): no
  - Anything that affects deployment or recovery: JobManager (and its components), Checkpointing, Kubernetes/Yarn, ZooKeeper: no
  - The S3 file system connector: no

## Documentation

  - Does this pull request introduce a new feature? no
  - If yes, how is the feature documented? not applicable
