### PR TITLE
[FLINK-24047][tests] Retry if leader election is in progress

### DIFF
--- a/flink-tests/src/test/java/org/apache/flink/test/checkpointing/SavepointITCase.java
+++ b/flink-tests/src/test/java/org/apache/flink/test/checkpointing/SavepointITCase.java
@@ -31,6 +31,7 @@ import org.apache.flink.api.common.time.Time;
 import org.apache.flink.api.common.typeinfo.BasicTypeInfo;
 import org.apache.flink.api.java.functions.KeySelector;
 import org.apache.flink.client.program.ClusterClient;
+import org.apache.flink.client.program.rest.RestClusterClient;
 import org.apache.flink.configuration.CheckpointingOptions;
 import org.apache.flink.configuration.ClusterOptions;
 import org.apache.flink.configuration.Configuration;
@@ -38,7 +39,6 @@ import org.apache.flink.configuration.HighAvailabilityOptions;
 import org.apache.flink.configuration.MemorySize;
 import org.apache.flink.configuration.StateBackendOptions;
 import org.apache.flink.configuration.TaskManagerOptions;
-import org.apache.flink.configuration.UnmodifiableConfiguration;
 import org.apache.flink.core.testutils.OneShotLatch;
 import org.apache.flink.runtime.checkpoint.CheckpointException;
 import org.apache.flink.runtime.checkpoint.CheckpointRecoveryFactory;
@@ -57,11 +57,9 @@ import org.apache.flink.runtime.jobgraph.JobVertex;
 import org.apache.flink.runtime.jobgraph.SavepointRestoreSettings;
 import org.apache.flink.runtime.messages.FlinkJobNotFoundException;
 import org.apache.flink.runtime.operators.testutils.ExpectedTestException;
-import org.apache.flink.runtime.rest.RestClient;
 import org.apache.flink.runtime.rest.messages.EmptyRequestBody;
 import org.apache.flink.runtime.rest.messages.JobMessageParameters;
 import org.apache.flink.runtime.rest.messages.job.JobDetailsHeaders;
-import org.apache.flink.runtime.rest.messages.job.JobDetailsInfo;
 import org.apache.flink.runtime.state.FunctionInitializationContext;
 import org.apache.flink.runtime.state.FunctionSnapshotContext;
 import org.apache.flink.runtime.state.StateSnapshotContext;
@@ -243,7 +241,7 @@ public class SavepointITCase extends TestLogger {
         try {
             ClusterClient<?> client = cluster.getClusterClient();
             client.submitJob(jobGraph).get();
-            waitUntilAllTasksAreRunning(cluster.getRestAddres(), jobGraph.getJobID());
+            waitUntilAllTasksAreRunning(cluster.getRestClusterClient(), jobGraph.getJobID());
 
             client.stopWithSavepoint(jobGraph.getJobID(), true, savepointDir.getAbsolutePath())
                     .get();
@@ -725,7 +723,7 @@ public class SavepointITCase extends TestLogger {
         try {
             ClusterClient<?> client = cluster.getClusterClient();
             client.submitJob(jobGraph).get();
-            waitUntilAllTasksAreRunning(cluster.getRestAddres(), jobGraph.getJobID());
+            waitUntilAllTasksAreRunning(cluster.getRestClusterClient(), jobGraph.getJobID());
 
             try {
                 client.stopWithSavepoint(jobGraph.getJobID(), true, savepointDir.getAbsolutePath())
@@ -736,7 +734,7 @@ public class SavepointITCase extends TestLogger {
             }
 
             // make sure that we restart all tasks after the savepoint failure
-            waitUntilAllTasksAreRunning(cluster.getRestAddres(), jobGraph.getJobID());
+            waitUntilAllTasksAreRunning(cluster.getRestClusterClient(), jobGraph.getJobID());
         } finally {
             cluster.after();
         }
@@ -888,38 +886,30 @@ public class SavepointITCase extends TestLogger {
                 assertThrowable(e, ex -> exceptionAssertion.apply(jobGraph.getJobID(), e));
             }
 
-            waitUntilAllTasksAreRunning(cluster.getRestAddres(), jobGraph.getJobID());
+            waitUntilAllTasksAreRunning(cluster.getRestClusterClient(), jobGraph.getJobID());
         } finally {
             cluster.after();
         }
     }
 
-    public static void waitUntilAllTasksAreRunning(URI restAddress, JobID jobId) throws Exception {
+    public static void waitUntilAllTasksAreRunning(
+            RestClusterClient<?> restClusterClient, JobID jobId) throws Exception {
         // access the REST endpoint of the cluster to determine the state of each
         // ExecutionVertex
-        final RestClient restClient =
-                new RestClient(
-                        new UnmodifiableConfiguration(new Configuration()),
-                        TestingUtils.defaultExecutor());
 
         final JobDetailsHeaders detailsHeaders = JobDetailsHeaders.getInstance();
         final JobMessageParameters params = detailsHeaders.getUnresolvedMessageParameters();
         params.jobPathParameter.resolve(jobId);
 
         CommonTestUtils.waitUntilCondition(
-                () -> {
-                    JobDetailsInfo detailsInfo =
-                            restClient
-                                    .sendRequest(
-                                            restAddress.getHost(),
-                                            restAddress.getPort(),
-                                            detailsHeaders,
-                                            params,
-                                            EmptyRequestBody.getInstance())
-                                    .get();
-
-                    return allVerticesRunning(detailsInfo.getJobVerticesPerState());
-                },
+                () ->
+                        restClusterClient
+                                .sendRequest(detailsHeaders, params, EmptyRequestBody.getInstance())
+                                .thenApply(
+                                        detailsInfo ->
+                                                allVerticesRunning(
+                                                        detailsInfo.getJobVerticesPerState()))
+                                .get(),
                 Deadline.fromNow(Duration.ofSeconds(10)));
     }
 

--- a/flink-tests/src/test/java/org/apache/flink/test/streaming/runtime/TimestampITCase.java
+++ b/flink-tests/src/test/java/org/apache/flink/test/streaming/runtime/TimestampITCase.java
@@ -202,7 +202,7 @@ public class TimestampITCase extends TestLogger {
 
                             JobID id = running.get(0);
 
-                            waitUntilAllTasksAreRunning(CLUSTER.getRestAddres(), id);
+                            waitUntilAllTasksAreRunning(CLUSTER.getRestClusterClient(), id);
                             // send stop until the job is stopped
                             do {
                                 try {


### PR DESCRIPTION
SavepointITCase#waitUntilAllTasksAreRunning is querying the REST API, but did not account for the possibility of requests failing due to leader elections being in progress. If the startup of the cluster was slow the test ended up failing.

We now use the RestClusterClient to submit these requests which automatically retries in this case.

