### PR TITLE
[FLINK-15648][flink-kubernetes] Support to configure limit for CPU & memory

### DIFF
--- a/docs/layouts/shortcodes/generated/kubernetes_config_configuration.html
+++ b/docs/layouts/shortcodes/generated/kubernetes_config_configuration.html
@@ -99,10 +99,22 @@
             <td>The number of cpu used by job manager</td>
         </tr>
         <tr>
+            <td><h5>kubernetes.jobmanager.cpu.limit-factor</h5></td>
+            <td style="word-wrap: break-word;">1.0</td>
+            <td>Double</td>
+            <td>The limit factor of cpu used by job manager. The resources limit cpu will be set to cpu * limit-factor.</td>
+        </tr>
+        <tr>
             <td><h5>kubernetes.jobmanager.labels</h5></td>
             <td style="word-wrap: break-word;">(none)</td>
             <td>Map</td>
             <td>The labels to be set for JobManager pod. Specified as key:value pairs separated by commas. For example, version:alphav1,deploy:test.</td>
+        </tr>
+        <tr>
+            <td><h5>kubernetes.jobmanager.memory.limit-factor</h5></td>
+            <td style="word-wrap: break-word;">1.0</td>
+            <td>Double</td>
+            <td>The limit factor of memory used by job manager. The resources limit memory will be set to memory * limit-factor.</td>
         </tr>
         <tr>
             <td><h5>kubernetes.jobmanager.node-selector</h5></td>
@@ -201,10 +213,22 @@
             <td>The number of cpu used by task manager. By default, the cpu is set to the number of slots per TaskManager</td>
         </tr>
         <tr>
+            <td><h5>kubernetes.taskmanager.cpu.limit-factor</h5></td>
+            <td style="word-wrap: break-word;">1.0</td>
+            <td>Double</td>
+            <td>The limit factor of cpu used by task manager. The resources limit cpu will be set to cpu * limit-factor.</td>
+        </tr>
+        <tr>
             <td><h5>kubernetes.taskmanager.labels</h5></td>
             <td style="word-wrap: break-word;">(none)</td>
             <td>Map</td>
             <td>The labels to be set for TaskManager pods. Specified as key:value pairs separated by commas. For example, version:alphav1,deploy:test.</td>
+        </tr>
+        <tr>
+            <td><h5>kubernetes.taskmanager.memory.limit-factor</h5></td>
+            <td style="word-wrap: break-word;">1.0</td>
+            <td>Double</td>
+            <td>The limit factor of memory used by task manager. The resources limit memory will be set to memory * limit-factor.</td>
         </tr>
         <tr>
             <td><h5>kubernetes.taskmanager.node-selector</h5></td>

--- a/flink-kubernetes/src/main/java/org/apache/flink/kubernetes/configuration/KubernetesConfigOptions.java
+++ b/flink-kubernetes/src/main/java/org/apache/flink/kubernetes/configuration/KubernetesConfigOptions.java
@@ -141,6 +141,22 @@ public class KubernetesConfigOptions {
                     .defaultValue(1.0)
                     .withDescription("The number of cpu used by job manager");
 
+    public static final ConfigOption<Double> JOB_MANAGER_CPU_LIMIT_FACTOR =
+            key("kubernetes.jobmanager.cpu.limit-factor")
+                    .doubleType()
+                    .defaultValue(1.0)
+                    .withDescription(
+                            "The limit factor of cpu used by job manager. "
+                                    + "The resources limit cpu will be set to cpu * limit-factor.");
+
+    public static final ConfigOption<Double> JOB_MANAGER_MEMORY_LIMIT_FACTOR =
+            key("kubernetes.jobmanager.memory.limit-factor")
+                    .doubleType()
+                    .defaultValue(1.0)
+                    .withDescription(
+                            "The limit factor of memory used by job manager. "
+                                    + "The resources limit memory will be set to memory * limit-factor.");
+
     public static final ConfigOption<Double> TASK_MANAGER_CPU =
             key("kubernetes.taskmanager.cpu")
                     .doubleType()
@@ -148,6 +164,22 @@ public class KubernetesConfigOptions {
                     .withDescription(
                             "The number of cpu used by task manager. By default, the cpu is set "
                                     + "to the number of slots per TaskManager");
+
+    public static final ConfigOption<Double> TASK_MANAGER_CPU_LIMIT_FACTOR =
+            key("kubernetes.taskmanager.cpu.limit-factor")
+                    .doubleType()
+                    .defaultValue(1.0)
+                    .withDescription(
+                            "The limit factor of cpu used by task manager. "
+                                    + "The resources limit cpu will be set to cpu * limit-factor.");
+
+    public static final ConfigOption<Double> TASK_MANAGER_MEMORY_LIMIT_FACTOR =
+            key("kubernetes.taskmanager.memory.limit-factor")
+                    .doubleType()
+                    .defaultValue(1.0)
+                    .withDescription(
+                            "The limit factor of memory used by task manager. "
+                                    + "The resources limit memory will be set to memory * limit-factor.");
 
     public static final ConfigOption<ImagePullPolicy> CONTAINER_IMAGE_PULL_POLICY =
             key("kubernetes.container.image.pull-policy")

--- a/flink-kubernetes/src/main/java/org/apache/flink/kubernetes/kubeclient/decorators/InitJobManagerDecorator.java
+++ b/flink-kubernetes/src/main/java/org/apache/flink/kubernetes/kubeclient/decorators/InitJobManagerDecorator.java
@@ -129,7 +129,9 @@ public class InitJobManagerDecorator extends AbstractKubernetesStepDecorator {
                 KubernetesUtils.getResourceRequirements(
                         requirementsInPodTemplate,
                         kubernetesJobManagerParameters.getJobManagerMemoryMB(),
+                        kubernetesJobManagerParameters.getJobManagerMemoryLimitFactor(),
                         kubernetesJobManagerParameters.getJobManagerCPU(),
+                        kubernetesJobManagerParameters.getJobManagerCPULimitFactor(),
                         Collections.emptyMap(),
                         Collections.emptyMap());
         mainContainerBuilder

--- a/flink-kubernetes/src/main/java/org/apache/flink/kubernetes/kubeclient/decorators/InitTaskManagerDecorator.java
+++ b/flink-kubernetes/src/main/java/org/apache/flink/kubernetes/kubeclient/decorators/InitTaskManagerDecorator.java
@@ -113,7 +113,9 @@ public class InitTaskManagerDecorator extends AbstractKubernetesStepDecorator {
                 KubernetesUtils.getResourceRequirements(
                         requirementsInPodTemplate,
                         kubernetesTaskManagerParameters.getTaskManagerMemoryMB(),
+                        kubernetesTaskManagerParameters.getTaskManagerMemoryLimitFactor(),
                         kubernetesTaskManagerParameters.getTaskManagerCPU(),
+                        kubernetesTaskManagerParameters.getTaskManagerCPULimitFactor(),
                         kubernetesTaskManagerParameters.getTaskManagerExternalResources(),
                         kubernetesTaskManagerParameters.getTaskManagerExternalResourceConfigKeys());
         final String image =

--- a/flink-kubernetes/src/main/java/org/apache/flink/kubernetes/kubeclient/parameters/KubernetesJobManagerParameters.java
+++ b/flink-kubernetes/src/main/java/org/apache/flink/kubernetes/kubeclient/parameters/KubernetesJobManagerParameters.java
@@ -125,6 +125,26 @@ public class KubernetesJobManagerParameters extends AbstractKubernetesParameters
         return flinkConfig.getDouble(KubernetesConfigOptions.JOB_MANAGER_CPU);
     }
 
+    public double getJobManagerCPULimitFactor() {
+        final double limitFactor =
+                flinkConfig.getDouble(KubernetesConfigOptions.JOB_MANAGER_CPU_LIMIT_FACTOR);
+        checkArgument(
+                limitFactor >= 1,
+                "%s should be greater or equal to 1.",
+                KubernetesConfigOptions.JOB_MANAGER_CPU_LIMIT_FACTOR.key());
+        return limitFactor;
+    }
+
+    public double getJobManagerMemoryLimitFactor() {
+        final double limitFactor =
+                flinkConfig.getDouble(KubernetesConfigOptions.JOB_MANAGER_MEMORY_LIMIT_FACTOR);
+        checkArgument(
+                limitFactor >= 1,
+                "%s should be greater or equal to 1.",
+                KubernetesConfigOptions.JOB_MANAGER_MEMORY_LIMIT_FACTOR.key());
+        return limitFactor;
+    }
+
     public int getRestPort() {
         return flinkConfig.getInteger(RestOptions.PORT);
     }

--- a/flink-kubernetes/src/main/java/org/apache/flink/kubernetes/kubeclient/parameters/KubernetesTaskManagerParameters.java
+++ b/flink-kubernetes/src/main/java/org/apache/flink/kubernetes/kubeclient/parameters/KubernetesTaskManagerParameters.java
@@ -127,6 +127,26 @@ public class KubernetesTaskManagerParameters extends AbstractKubernetesParameter
                 .doubleValue();
     }
 
+    public double getTaskManagerCPULimitFactor() {
+        final double limitFactor =
+                flinkConfig.getDouble(KubernetesConfigOptions.TASK_MANAGER_CPU_LIMIT_FACTOR);
+        checkArgument(
+                limitFactor >= 1,
+                "%s should be greater or equal to 1.",
+                KubernetesConfigOptions.TASK_MANAGER_CPU_LIMIT_FACTOR.key());
+        return limitFactor;
+    }
+
+    public double getTaskManagerMemoryLimitFactor() {
+        final double limitFactor =
+                flinkConfig.getDouble(KubernetesConfigOptions.TASK_MANAGER_MEMORY_LIMIT_FACTOR);
+        checkArgument(
+                limitFactor >= 1,
+                "%s should be greater or equal to 1.",
+                KubernetesConfigOptions.TASK_MANAGER_MEMORY_LIMIT_FACTOR.key());
+        return limitFactor;
+    }
+
     public Map<String, ExternalResource> getTaskManagerExternalResources() {
         return containeredTaskManagerParameters.getTaskExecutorProcessSpec().getExtendedResources();
     }

--- a/flink-kubernetes/src/main/java/org/apache/flink/kubernetes/utils/KubernetesUtils.java
+++ b/flink-kubernetes/src/main/java/org/apache/flink/kubernetes/utils/KubernetesUtils.java
@@ -329,7 +329,9 @@ public class KubernetesUtils {
      *
      * @param resourceRequirements resource requirements in pod template
      * @param mem Memory in mb.
+     * @param memoryLimitFactor limit factor for the memory, used to set the limit resources.
      * @param cpu cpu.
+     * @param cpuLimitFactor limit factor for the cpu, used to set the limit resources.
      * @param externalResources external resources
      * @param externalResourceConfigKeys config keys of external resources
      * @return KubernetesResource requirements.
@@ -337,18 +339,23 @@ public class KubernetesUtils {
     public static ResourceRequirements getResourceRequirements(
             ResourceRequirements resourceRequirements,
             int mem,
+            double memoryLimitFactor,
             double cpu,
+            double cpuLimitFactor,
             Map<String, ExternalResource> externalResources,
             Map<String, String> externalResourceConfigKeys) {
         final Quantity cpuQuantity = new Quantity(String.valueOf(cpu));
+        final Quantity cpuLimitQuantity = new Quantity(String.valueOf(cpu * cpuLimitFactor));
         final Quantity memQuantity = new Quantity(mem + Constants.RESOURCE_UNIT_MB);
+        final Quantity memQuantityLimit =
+                new Quantity(((int) (mem * memoryLimitFactor)) + Constants.RESOURCE_UNIT_MB);
 
         ResourceRequirementsBuilder resourceRequirementsBuilder =
                 new ResourceRequirementsBuilder(resourceRequirements)
                         .addToRequests(Constants.RESOURCE_NAME_MEMORY, memQuantity)
                         .addToRequests(Constants.RESOURCE_NAME_CPU, cpuQuantity)
-                        .addToLimits(Constants.RESOURCE_NAME_MEMORY, memQuantity)
-                        .addToLimits(Constants.RESOURCE_NAME_CPU, cpuQuantity);
+                        .addToLimits(Constants.RESOURCE_NAME_MEMORY, memQuantityLimit)
+                        .addToLimits(Constants.RESOURCE_NAME_CPU, cpuLimitQuantity);
 
         // Add the external resources to resource requirement.
         for (Map.Entry<String, ExternalResource> externalResource : externalResources.entrySet()) {

--- a/flink-kubernetes/src/test/java/org/apache/flink/kubernetes/entrypoint/KubernetesWorkerResourceSpecFactoryTest.java
+++ b/flink-kubernetes/src/test/java/org/apache/flink/kubernetes/entrypoint/KubernetesWorkerResourceSpecFactoryTest.java
@@ -37,6 +37,7 @@ public class KubernetesWorkerResourceSpecFactoryTest extends TestLogger {
         final Configuration configuration = new Configuration();
         configuration.setDouble(TaskManagerOptions.CPU_CORES, 1.0);
         configuration.setDouble(KubernetesConfigOptions.TASK_MANAGER_CPU, 2.0);
+        configuration.setDouble(KubernetesConfigOptions.TASK_MANAGER_CPU_LIMIT_FACTOR, 1.5);
         configuration.setInteger(TaskManagerOptions.NUM_TASK_SLOTS, 3);
 
         assertThat(
@@ -48,6 +49,7 @@ public class KubernetesWorkerResourceSpecFactoryTest extends TestLogger {
     public void testGetCpuCoresKubernetesOption() {
         final Configuration configuration = new Configuration();
         configuration.setDouble(KubernetesConfigOptions.TASK_MANAGER_CPU, 2.0);
+        configuration.setDouble(KubernetesConfigOptions.TASK_MANAGER_CPU_LIMIT_FACTOR, 1.5);
         configuration.setInteger(TaskManagerOptions.NUM_TASK_SLOTS, 3);
 
         assertThat(

--- a/flink-kubernetes/src/test/java/org/apache/flink/kubernetes/kubeclient/KubernetesJobManagerTestBase.java
+++ b/flink-kubernetes/src/test/java/org/apache/flink/kubernetes/kubeclient/KubernetesJobManagerTestBase.java
@@ -31,7 +31,9 @@ import org.apache.flink.kubernetes.kubeclient.parameters.KubernetesJobManagerPar
 public class KubernetesJobManagerTestBase extends KubernetesPodTestBase {
 
     protected static final double JOB_MANAGER_CPU = 2.0;
+    protected static final double JOB_MANAGER_CPU_LIMIT_FACTOR = 1.5;
     protected static final int JOB_MANAGER_MEMORY = 768;
+    protected static final double JOB_MANAGER_MEMORY_LIMIT_FACTOR = 2;
 
     protected static final int REST_PORT = 9081;
     protected static final String REST_BIND_PORT = "9082";
@@ -49,6 +51,11 @@ public class KubernetesJobManagerTestBase extends KubernetesPodTestBase {
         this.flinkConfig.set(JobManagerOptions.PORT, RPC_PORT);
         this.flinkConfig.set(BlobServerOptions.PORT, Integer.toString(BLOB_SERVER_PORT));
         this.flinkConfig.set(KubernetesConfigOptions.JOB_MANAGER_CPU, JOB_MANAGER_CPU);
+        this.flinkConfig.set(
+                KubernetesConfigOptions.JOB_MANAGER_CPU_LIMIT_FACTOR, JOB_MANAGER_CPU_LIMIT_FACTOR);
+        this.flinkConfig.set(
+                KubernetesConfigOptions.JOB_MANAGER_MEMORY_LIMIT_FACTOR,
+                JOB_MANAGER_MEMORY_LIMIT_FACTOR);
         this.customizedEnvs.forEach(
                 (k, v) ->
                         this.flinkConfig.setString(

--- a/flink-kubernetes/src/test/java/org/apache/flink/kubernetes/kubeclient/KubernetesTaskManagerTestBase.java
+++ b/flink-kubernetes/src/test/java/org/apache/flink/kubernetes/kubeclient/KubernetesTaskManagerTestBase.java
@@ -39,6 +39,8 @@ public class KubernetesTaskManagerTestBase extends KubernetesPodTestBase {
 
     protected static final int TOTAL_PROCESS_MEMORY = 1184;
     protected static final double TASK_MANAGER_CPU = 2.0;
+    protected static final double TASK_MANAGER_CPU_LIMIT_FACTOR = 1.5;
+    protected static final double TASK_MANAGER_MEMORY_LIMIT_FACTOR = 2.0;
 
     protected TaskExecutorProcessSpec taskExecutorProcessSpec;
 
@@ -60,8 +62,14 @@ public class KubernetesTaskManagerTestBase extends KubernetesPodTestBase {
                         flinkConfig.setString(
                                 ResourceManagerOptions.CONTAINERIZED_TASK_MANAGER_ENV_PREFIX + k,
                                 v));
-        this.flinkConfig.set(KubernetesConfigOptions.TASK_MANAGER_LABELS, userLabels);
-        this.flinkConfig.set(KubernetesConfigOptions.TASK_MANAGER_NODE_SELECTOR, nodeSelector);
+        flinkConfig.set(KubernetesConfigOptions.TASK_MANAGER_LABELS, userLabels);
+        flinkConfig.set(KubernetesConfigOptions.TASK_MANAGER_NODE_SELECTOR, nodeSelector);
+        flinkConfig.set(
+                KubernetesConfigOptions.TASK_MANAGER_CPU_LIMIT_FACTOR,
+                TASK_MANAGER_CPU_LIMIT_FACTOR);
+        flinkConfig.set(
+                KubernetesConfigOptions.TASK_MANAGER_MEMORY_LIMIT_FACTOR,
+                TASK_MANAGER_MEMORY_LIMIT_FACTOR);
     }
 
     @Override

--- a/flink-kubernetes/src/test/java/org/apache/flink/kubernetes/kubeclient/decorators/InitJobManagerDecoratorTest.java
+++ b/flink-kubernetes/src/test/java/org/apache/flink/kubernetes/kubeclient/decorators/InitJobManagerDecoratorTest.java
@@ -121,8 +121,12 @@ public class InitJobManagerDecoratorTest extends KubernetesJobManagerTestBase {
         assertEquals(String.valueOf(JOB_MANAGER_MEMORY), requests.get("memory").getAmount());
 
         final Map<String, Quantity> limits = resourceRequirements.getLimits();
-        assertEquals(Double.toString(JOB_MANAGER_CPU), limits.get("cpu").getAmount());
-        assertEquals(String.valueOf(JOB_MANAGER_MEMORY), limits.get("memory").getAmount());
+        assertEquals(
+                Double.toString(JOB_MANAGER_CPU * JOB_MANAGER_CPU_LIMIT_FACTOR),
+                limits.get("cpu").getAmount());
+        assertEquals(
+                Integer.toString((int) (JOB_MANAGER_MEMORY * JOB_MANAGER_MEMORY_LIMIT_FACTOR)),
+                limits.get("memory").getAmount());
     }
 
     @Test

--- a/flink-kubernetes/src/test/java/org/apache/flink/kubernetes/kubeclient/decorators/InitTaskManagerDecoratorTest.java
+++ b/flink-kubernetes/src/test/java/org/apache/flink/kubernetes/kubeclient/decorators/InitTaskManagerDecoratorTest.java
@@ -143,8 +143,12 @@ public class InitTaskManagerDecoratorTest extends KubernetesTaskManagerTestBase 
         assertEquals(String.valueOf(TOTAL_PROCESS_MEMORY), requests.get("memory").getAmount());
 
         final Map<String, Quantity> limits = resourceRequirements.getLimits();
-        assertEquals(Double.toString(TASK_MANAGER_CPU), limits.get("cpu").getAmount());
-        assertEquals(String.valueOf(TOTAL_PROCESS_MEMORY), limits.get("memory").getAmount());
+        assertEquals(
+                Double.toString(TASK_MANAGER_CPU * TASK_MANAGER_CPU_LIMIT_FACTOR),
+                limits.get("cpu").getAmount());
+        assertEquals(
+                Integer.toString((int) (TOTAL_PROCESS_MEMORY * TASK_MANAGER_MEMORY_LIMIT_FACTOR)),
+                limits.get("memory").getAmount());
     }
 
     @Test

--- a/flink-kubernetes/src/test/java/org/apache/flink/kubernetes/kubeclient/parameters/KubernetesJobManagerParametersTest.java
+++ b/flink-kubernetes/src/test/java/org/apache/flink/kubernetes/kubeclient/parameters/KubernetesJobManagerParametersTest.java
@@ -49,6 +49,8 @@ import static org.junit.Assert.fail;
 public class KubernetesJobManagerParametersTest extends KubernetesTestBase {
 
     private static final double JOB_MANAGER_CPU = 2.0;
+    private static final double JOB_MANAGER_CPU_LIMIT_FACTOR = 2.5;
+    private static final double JOB_MANAGER_MEMORY_LIMIT_FACTOR = 2.0;
 
     private final ClusterSpecification clusterSpecification =
             new ClusterSpecification.ClusterSpecificationBuilder()
@@ -119,6 +121,27 @@ public class KubernetesJobManagerParametersTest extends KubernetesTestBase {
     public void testGetJobManagerCPU() {
         flinkConfig.set(KubernetesConfigOptions.JOB_MANAGER_CPU, JOB_MANAGER_CPU);
         assertEquals(JOB_MANAGER_CPU, kubernetesJobManagerParameters.getJobManagerCPU(), 0.00001);
+    }
+
+    @Test
+    public void testGetJobManagerCPULimitFactor() {
+        flinkConfig.set(
+                KubernetesConfigOptions.JOB_MANAGER_CPU_LIMIT_FACTOR, JOB_MANAGER_CPU_LIMIT_FACTOR);
+        assertEquals(
+                JOB_MANAGER_CPU_LIMIT_FACTOR,
+                kubernetesJobManagerParameters.getJobManagerCPULimitFactor(),
+                0.00001);
+    }
+
+    @Test
+    public void testGetJobManagerMemoryLimitFactor() {
+        flinkConfig.set(
+                KubernetesConfigOptions.JOB_MANAGER_MEMORY_LIMIT_FACTOR,
+                JOB_MANAGER_MEMORY_LIMIT_FACTOR);
+        assertEquals(
+                JOB_MANAGER_MEMORY_LIMIT_FACTOR,
+                kubernetesJobManagerParameters.getJobManagerMemoryLimitFactor(),
+                0.00001);
     }
 
     @Test

--- a/flink-kubernetes/src/test/java/org/apache/flink/kubernetes/kubeclient/parameters/KubernetesTaskManagerParametersTest.java
+++ b/flink-kubernetes/src/test/java/org/apache/flink/kubernetes/kubeclient/parameters/KubernetesTaskManagerParametersTest.java
@@ -45,6 +45,8 @@ public class KubernetesTaskManagerParametersTest extends KubernetesTestBase {
 
     private static final int TASK_MANAGER_MEMORY = 1024;
     private static final double TASK_MANAGER_CPU = 1.2;
+    private static final double TASK_MANAGER_CPU_LIMIT_FACTOR = 2.0;
+    private static final double TASK_MANAGER_MEMORY_LIMIT_FACTOR = 2.0;
     private static final int RPC_PORT = 13001;
 
     private static final String POD_NAME = "task-manager-pod-1";
@@ -70,6 +72,12 @@ public class KubernetesTaskManagerParametersTest extends KubernetesTestBase {
                 TaskManagerOptions.TOTAL_PROCESS_MEMORY,
                 MemorySize.parse(TASK_MANAGER_MEMORY + "m"));
         flinkConfig.set(TaskManagerOptions.RPC_PORT, String.valueOf(RPC_PORT));
+        flinkConfig.set(
+                KubernetesConfigOptions.TASK_MANAGER_CPU_LIMIT_FACTOR,
+                TASK_MANAGER_CPU_LIMIT_FACTOR);
+        flinkConfig.set(
+                KubernetesConfigOptions.TASK_MANAGER_MEMORY_LIMIT_FACTOR,
+                TASK_MANAGER_MEMORY_LIMIT_FACTOR);
 
         customizedEnvs.forEach(
                 (k, v) ->
@@ -134,9 +142,23 @@ public class KubernetesTaskManagerParametersTest extends KubernetesTestBase {
     @Test
     public void testGetTaskManagerCPU() {
         assertEquals(
-                TASK_MANAGER_CPU,
-                kubernetesTaskManagerParameters.getTaskManagerCPU(),
-                0.000000000001);
+                TASK_MANAGER_CPU, kubernetesTaskManagerParameters.getTaskManagerCPU(), 0.00001);
+    }
+
+    @Test
+    public void testGetTaskManagerCPULimitFactor() {
+        assertEquals(
+                TASK_MANAGER_CPU_LIMIT_FACTOR,
+                kubernetesTaskManagerParameters.getTaskManagerCPULimitFactor(),
+                0.00001);
+    }
+
+    @Test
+    public void testGetTaskManagerMemoryLimitFactor() {
+        assertEquals(
+                TASK_MANAGER_MEMORY_LIMIT_FACTOR,
+                kubernetesTaskManagerParameters.getTaskManagerMemoryLimitFactor(),
+                0.00001);
     }
 
     @Test


### PR DESCRIPTION
## What is the purpose of the change

The purpose of this PR is to allow the user to configure the Taskmanager's and Jobmanager's CPU and Memory limits when deploying Flink using the Kubernetes Resource provider.

The "kubernetes.jobmanager.cpu.limit-factor" will calculate the CPU limit of the Jobmanager using the following formula: jobmanager cpu * limit-factor. The "kubernetes.taskmanager.cpu.limit-factor" will do the same for the Taskmanager.

The same logic applies to "kubernetes.taskmanager.memory.limit-factor" and "kubernetes.jobmanager.memory.limit-factor" 

## Brief change log

- Added the "kubernetes.jobmanager.cpu.limit-factor" config option to configure the Jobmanager's limit CPU when using the Kubernetes resource provider.
- Added the "kubernetes.taskmanager.cpu.limit-factor" config option to configure the Taskmanager's limit CPU when using the Kubernetes resource provider.
- Added the "kubernetes.jobmanager.memory.limit-factor" config option to configure the Jobmanager's limit memory when using the Kubernetes resource provider.
- Added the "kubernetes.taskmanager.memory.limit-factor" config option to configure the Taskmanager's limit memory when using the Kubernetes resource provider.

## Verifying this change

This change added tests and can be verified as follows:

  - *Added getter tests in KubernetesJobManagerParametersTest.java and KubernetesTaskManagerParametersTest.java.*
  - *Ensured the resource CPU limits are set correctly for the Jobmanager by modifying the InitJobManagerDecoratorTest.java test*
  -  *Ensured the resource CPU limits are set correctly for the Taskmanager by modifying the InitTaskManagerDecoratorTest.java test*

## Does this pull request potentially affect one of the following parts:

  - Dependencies (does it add or upgrade a dependency): no
  - The public API, i.e., is any changed class annotated with `@Public(Evolving)`:  no
  - The serializers:  no
  - The runtime per-record code paths (performance sensitive): don't know)
  - Anything that affects deployment or recovery: JobManager (and its components), Checkpointing, Kubernetes/Yarn, ZooKeeper: yes
  - The S3 file system connector: no

## Documentation

  - Does this pull request introduce a new feature? yes 
  - If yes, how is the feature documented? JavaDocs
