### PR TITLE
[FLINK-23916][python][docs] Expose in python and update the documentation how to set tolerable checkpoint failure number

### DIFF
--- a/flink-python/pyflink/datastream/checkpoint_config.py
+++ b/flink-python/pyflink/datastream/checkpoint_config.py
@@ -214,6 +214,35 @@ class CheckpointConfig(object):
         self._j_checkpoint_config.setFailOnCheckpointingErrors(fail_on_checkpointing_errors)
         return self
 
+    def get_tolerable_checkpoint_failure_number(self) -> int:
+        """
+        Get the defined number of consecutive checkpoint failures that will be tolerated, before the
+        whole job is failed over.
+
+        :return: The maximum number of tolerated checkpoint failures.
+        """
+        return self._j_checkpoint_config.getTolerableCheckpointFailureNumber()
+
+    def set_tolerable_checkpoint_failure_number(self,
+                                                tolerable_checkpoint_failure_number: int
+                                                ) -> 'CheckpointConfig':
+        """
+        This defines how many consecutive checkpoint failures will be tolerated, before the whole
+        job is failed over. The default value is `0`, which means no checkpoint failures will be
+        tolerated, and the job will fail on first reported checkpoint failure.
+
+        Example:
+        ::
+
+            >>> config.set_tolerable_checkpoint_failure_number(2)
+
+        :param tolerable_checkpoint_failure_number: The maximum number of tolerated checkpoint
+                                                    failures.
+        """
+        self._j_checkpoint_config.setTolerableCheckpointFailureNumber(
+            tolerable_checkpoint_failure_number)
+        return self
+
     def enable_externalized_checkpoints(
             self,
             cleanup_mode: 'ExternalizedCheckpointCleanup') -> 'CheckpointConfig':

--- a/flink-python/pyflink/datastream/tests/test_check_point_config.py
+++ b/flink-python/pyflink/datastream/tests/test_check_point_config.py
@@ -109,6 +109,14 @@ class CheckpointConfigTests(PyFlinkTestCase):
 
         self.assertFalse(self.checkpoint_config.is_fail_on_checkpointing_errors())
 
+    def test_get_set_tolerable_checkpoint_failure_number(self):
+
+        self.assertEqual(self.checkpoint_config.get_tolerable_checkpoint_failure_number(), 0)
+
+        self.checkpoint_config.set_tolerable_checkpoint_failure_number(2)
+
+        self.assertEqual(self.checkpoint_config.get_tolerable_checkpoint_failure_number(), 2)
+
     def test_get_set_externalized_checkpoints_cleanup(self):
 
         self.assertFalse(self.checkpoint_config.is_externalized_checkpoints_enabled())

--- a/flink-streaming-java/src/main/java/org/apache/flink/streaming/api/environment/CheckpointConfig.java
+++ b/flink-streaming-java/src/main/java/org/apache/flink/streaming/api/environment/CheckpointConfig.java
@@ -399,8 +399,8 @@ public class CheckpointConfig implements java.io.Serializable {
     }
 
     /**
-     * Get the tolerable checkpoint failure number which used by the checkpoint failure manager to
-     * determine when we need to fail the job.
+     * Get the defined number of consecutive checkpoint failures that will be tolerated, before the
+     * whole job is failed over.
      *
      * <p>If the {@link #tolerableCheckpointFailureNumber} has not been configured, this method
      * would return 0 which means the checkpoint failure manager would not tolerate any declined
@@ -414,8 +414,9 @@ public class CheckpointConfig implements java.io.Serializable {
     }
 
     /**
-     * Set the tolerable checkpoint failure number, the default value is 0 that means we do not
-     * tolerance any checkpoint failure.
+     * This defines how many consecutive checkpoint failures will be tolerated, before the whole job
+     * is failed over. The default value is `0`, which means no checkpoint failures will be
+     * tolerated, and the job will fail on first reported checkpoint failure.
      */
     public void setTolerableCheckpointFailureNumber(int tolerableCheckpointFailureNumber) {
         if (tolerableCheckpointFailureNumber < 0) {


### PR DESCRIPTION
This PR adds python API and updates the docs for setting the tolerable number of checkpoint failures.

## Does this pull request potentially affect one of the following parts:

  - Dependencies (does it add or upgrade a dependency): (yes / **no**)
  - The public API, i.e., is any changed class annotated with `@Public(Evolving)`: (**yes** / no)
  - The serializers: (yes / **no** / don't know)
  - The runtime per-record code paths (performance sensitive): (yes / **no** / don't know)
  - Anything that affects deployment or recovery: JobManager (and its components), Checkpointing, Kubernetes/Yarn, ZooKeeper: (yes / **no** / don't know)
  - The S3 file system connector: (yes / **no** / don't know)

## Documentation

  - Does this pull request introduce a new feature? (yes / **no**)
  - If yes, how is the feature documented? (not applicable / **docs** / **JavaDocs** / not documented)
