### PR TITLE
[FLINK-24091][tests] Harden TaskManagerProcessFailureBatchRecoveryITCase 

### DIFF
--- a/flink-runtime/src/main/java/org/apache/flink/runtime/executiongraph/Execution.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/executiongraph/Execution.java
@@ -593,7 +593,10 @@ public class Execution
                                 if (failure == null) {
                                     vertex.notifyCompletedDeployment(this);
                                 } else {
-                                    if (failure instanceof TimeoutException) {
+                                    final Throwable actualFailure =
+                                            ExceptionUtils.stripCompletionException(failure);
+
+                                    if (actualFailure instanceof TimeoutException) {
                                         String taskname =
                                                 vertex.getTaskNameWithSubtaskIndex()
                                                         + " ("
@@ -608,9 +611,9 @@ public class Execution
                                                                 + getAssignedResourceLocation()
                                                                 + ") not responding after a rpcTimeout of "
                                                                 + rpcTimeout,
-                                                        failure));
+                                                        actualFailure));
                                     } else {
-                                        markFailed(failure);
+                                        markFailed(actualFailure);
                                     }
                                 }
                             },

--- a/flink-tests/src/test/java/org/apache/flink/test/recovery/AbstractTaskManagerProcessFailureRecoveryTest.java
+++ b/flink-tests/src/test/java/org/apache/flink/test/recovery/AbstractTaskManagerProcessFailureRecoveryTest.java
@@ -92,8 +92,9 @@ public abstract class AbstractTaskManagerProcessFailureRecoveryTest extends Test
         Configuration config = new Configuration();
         config.setString(JobManagerOptions.ADDRESS, "localhost");
         config.setString(RestOptions.BIND_PORT, "0");
-        config.setLong(HeartbeatManagerOptions.HEARTBEAT_INTERVAL, 500L);
+        config.setLong(HeartbeatManagerOptions.HEARTBEAT_INTERVAL, 200L);
         config.setLong(HeartbeatManagerOptions.HEARTBEAT_TIMEOUT, 10000L);
+        config.set(HeartbeatManagerOptions.HEARTBEAT_RPC_FAILURE_THRESHOLD, 1);
         config.setString(HighAvailabilityOptions.HA_MODE, "zookeeper");
         config.setString(
                 HighAvailabilityOptions.HA_ZOOKEEPER_QUORUM, zooKeeperResource.getConnectString());

--- a/flink-tests/src/test/java/org/apache/flink/test/recovery/TaskManagerProcessFailureBatchRecoveryITCase.java
+++ b/flink-tests/src/test/java/org/apache/flink/test/recovery/TaskManagerProcessFailureBatchRecoveryITCase.java
@@ -67,7 +67,7 @@ public class TaskManagerProcessFailureBatchRecoveryITCase
         ExecutionEnvironment env =
                 ExecutionEnvironment.createRemoteEnvironment("localhost", 1337, configuration);
         env.setParallelism(PARALLELISM);
-        env.setRestartStrategy(RestartStrategies.fixedDelayRestart(1, 1000L));
+        env.setRestartStrategy(RestartStrategies.fixedDelayRestart(1, 1500L));
         env.getConfig().setExecutionMode(executionMode);
 
         final long numElements = 100000L;


### PR DESCRIPTION
This commit hardens the TaskManagerProcessFailureBatchRecoveryITCase.testTaskManagerProcessFailure by decreasing
the heartbeat interval and the number of failed heartbeat RPCs. Moreover, it increases the delay between job restarts
so that there is enough time for the heartbeat rpc to fail.