### PR TITLE
[FLINK-24064][connector/common] HybridSource restore from savepoint

### DIFF
--- a/flink-connectors/flink-connector-base/src/main/java/org/apache/flink/connector/base/source/hybrid/HybridSourceEnumeratorState.java
+++ b/flink-connectors/flink-connector-base/src/main/java/org/apache/flink/connector/base/source/hybrid/HybridSourceEnumeratorState.java
@@ -21,18 +21,25 @@ package org.apache.flink.connector.base.source.hybrid;
 /** The state of hybrid source enumerator. */
 public class HybridSourceEnumeratorState {
     private final int currentSourceIndex;
-    private final Object wrappedState;
+    private byte[] wrappedStateBytes;
+    private final int wrappedStateSerializerVersion;
 
-    HybridSourceEnumeratorState(int currentSourceIndex, Object wrappedState) {
+    HybridSourceEnumeratorState(
+            int currentSourceIndex, byte[] wrappedStateBytes, int serializerVersion) {
         this.currentSourceIndex = currentSourceIndex;
-        this.wrappedState = wrappedState;
+        this.wrappedStateBytes = wrappedStateBytes;
+        this.wrappedStateSerializerVersion = serializerVersion;
     }
 
     public int getCurrentSourceIndex() {
         return this.currentSourceIndex;
     }
 
-    public Object getWrappedState() {
-        return wrappedState;
+    public byte[] getWrappedState() {
+        return wrappedStateBytes;
+    }
+
+    public int getWrappedStateSerializerVersion() {
+        return wrappedStateSerializerVersion;
     }
 }

--- a/flink-connectors/flink-connector-base/src/main/java/org/apache/flink/connector/base/source/hybrid/HybridSourceReader.java
+++ b/flink-connectors/flink-connector-base/src/main/java/org/apache/flink/connector/base/source/hybrid/HybridSourceReader.java
@@ -34,7 +34,6 @@ import java.util.ArrayList;
 import java.util.Collections;
 import java.util.Iterator;
 import java.util.List;
-import java.util.Map;
 import java.util.concurrent.CompletableFuture;
 
 /**
@@ -55,17 +54,15 @@ import java.util.concurrent.CompletableFuture;
 public class HybridSourceReader<T> implements SourceReader<T, HybridSourceSplit> {
     private static final Logger LOG = LoggerFactory.getLogger(HybridSourceReader.class);
     private final SourceReaderContext readerContext;
-    private final Map<Integer, Source> switchedSources;
+    private final SwitchedSources switchedSources = new SwitchedSources();
     private int currentSourceIndex = -1;
     private boolean isFinalSource;
     private SourceReader<T, ? extends SourceSplit> currentReader;
     private CompletableFuture<Void> availabilityFuture = new CompletableFuture<>();
     private List<HybridSourceSplit> restoredSplits = new ArrayList<>();
 
-    public HybridSourceReader(
-            SourceReaderContext readerContext, Map<Integer, Source> switchedSources) {
+    public HybridSourceReader(SourceReaderContext readerContext) {
         this.readerContext = readerContext;
-        this.switchedSources = switchedSources;
     }
 
     @Override
@@ -117,7 +114,7 @@ public class HybridSourceReader<T> implements SourceReader<T, HybridSourceSplit>
                 currentReader != null
                         ? currentReader.snapshotState(checkpointId)
                         : Collections.emptyList();
-        return HybridSourceSplit.wrapSplits(currentSourceIndex, state);
+        return HybridSourceSplit.wrapSplits(state, currentSourceIndex, switchedSources);
     }
 
     @Override
@@ -158,7 +155,7 @@ public class HybridSourceReader<T> implements SourceReader<T, HybridSourceSplit>
                         "Split %s while current source is %s",
                         split,
                         currentSourceIndex);
-                realSplits.add(split.getWrappedSplit());
+                realSplits.add(HybridSourceSplit.unwrapSplit(split, switchedSources));
             }
             currentReader.addSplits((List) realSplits);
         }
@@ -224,9 +221,7 @@ public class HybridSourceReader<T> implements SourceReader<T, HybridSourceSplit>
                     currentReader);
         }
         // TODO: track previous readers splits till checkpoint
-        Source source =
-                Preconditions.checkNotNull(
-                        switchedSources.get(index), "Source for index=%s not available", index);
+        Source source = switchedSources.sourceOf(index);
         SourceReader<T, ?> reader;
         try {
             reader = source.createReader(readerContext);

--- a/flink-connectors/flink-connector-base/src/main/java/org/apache/flink/connector/base/source/hybrid/HybridSourceSplitEnumerator.java
+++ b/flink-connectors/flink-connector-base/src/main/java/org/apache/flink/connector/base/source/hybrid/HybridSourceSplitEnumerator.java
@@ -25,6 +25,7 @@ import org.apache.flink.api.connector.source.SourceSplit;
 import org.apache.flink.api.connector.source.SplitEnumerator;
 import org.apache.flink.api.connector.source.SplitEnumeratorContext;
 import org.apache.flink.api.connector.source.SplitsAssignment;
+import org.apache.flink.core.io.SimpleVersionedSerializer;
 import org.apache.flink.metrics.groups.SplitEnumeratorMetricGroup;
 import org.apache.flink.util.Preconditions;
 
@@ -68,21 +69,21 @@ public class HybridSourceSplitEnumerator
 
     private final SplitEnumeratorContext<HybridSourceSplit> context;
     private final List<HybridSource.SourceListEntry> sources;
-    private final Map<Integer, Source> switchedSources;
+    private final SwitchedSources switchedSources = new SwitchedSources();
     // Splits that have been returned due to subtask reset
     private final Map<Integer, TreeMap<Integer, List<HybridSourceSplit>>> pendingSplits;
     private final Set<Integer> finishedReaders;
     private final Map<Integer, Integer> readerSourceIndex;
     private int currentSourceIndex;
-    private Object restoredEnumeratorState;
+    private HybridSourceEnumeratorState restoredEnumeratorState;
     private SplitEnumerator<SourceSplit, Object> currentEnumerator;
+    private SimpleVersionedSerializer<Object> currentEnumeratorCheckpointSerializer;
 
     public HybridSourceSplitEnumerator(
             SplitEnumeratorContext<HybridSourceSplit> context,
             List<HybridSource.SourceListEntry> sources,
             int initialSourceIndex,
-            Map<Integer, Source> switchedSources,
-            Object restoredEnumeratorState) {
+            HybridSourceEnumeratorState restoredEnumeratorState) {
         Preconditions.checkArgument(initialSourceIndex < sources.size());
         this.context = context;
         this.sources = sources;
@@ -90,7 +91,6 @@ public class HybridSourceSplitEnumerator
         this.pendingSplits = new HashMap<>();
         this.finishedReaders = new HashSet<>();
         this.readerSourceIndex = new HashMap<>();
-        this.switchedSources = switchedSources;
         this.restoredEnumeratorState = restoredEnumeratorState;
     }
 
@@ -127,7 +127,8 @@ public class HybridSourceSplitEnumerator
                 (k, splitsPerSource) -> {
                     if (k == currentSourceIndex) {
                         currentEnumerator.addSplitsBack(
-                                HybridSourceSplit.unwrapSplits(splitsPerSource), subtaskId);
+                                HybridSourceSplit.unwrapSplits(splitsPerSource, switchedSources),
+                                subtaskId);
                     } else {
                         pendingSplits
                                 .computeIfAbsent(subtaskId, sourceIndex -> new TreeMap<>())
@@ -144,7 +145,7 @@ public class HybridSourceSplitEnumerator
 
     private void sendSwitchSourceEvent(int subtaskId, int sourceIndex) {
         readerSourceIndex.put(subtaskId, sourceIndex);
-        Source source = Preconditions.checkNotNull(switchedSources.get(sourceIndex));
+        Source source = switchedSources.sourceOf(sourceIndex);
         context.sendEventToSourceReader(
                 subtaskId,
                 new SwitchSourceEvent(sourceIndex, source, sourceIndex >= (sources.size() - 1)));
@@ -172,7 +173,11 @@ public class HybridSourceSplitEnumerator
     @Override
     public HybridSourceEnumeratorState snapshotState(long checkpointId) throws Exception {
         Object enumState = currentEnumerator.snapshotState(checkpointId);
-        return new HybridSourceEnumeratorState(currentSourceIndex, enumState);
+        byte[] enumStateBytes = currentEnumeratorCheckpointSerializer.serialize(enumState);
+        return new HybridSourceEnumeratorState(
+                currentSourceIndex,
+                enumStateBytes,
+                currentEnumeratorCheckpointSerializer.getVersion());
     }
 
     @Override
@@ -262,21 +267,22 @@ public class HybridSourceSplitEnumerator
                 };
 
         Source<?, ? extends SourceSplit, Object> source =
-                switchedSources.computeIfAbsent(
-                        currentSourceIndex,
-                        k -> {
-                            return sources.get(currentSourceIndex).factory.create(switchContext);
-                        });
+                sources.get(currentSourceIndex).factory.create(switchContext);
         switchedSources.put(currentSourceIndex, source);
+        currentEnumeratorCheckpointSerializer = source.getEnumeratorCheckpointSerializer();
         SplitEnumeratorContextProxy delegatingContext =
-                new SplitEnumeratorContextProxy(currentSourceIndex, context, readerSourceIndex);
+                new SplitEnumeratorContextProxy(
+                        currentSourceIndex, context, readerSourceIndex, switchedSources);
         try {
             if (restoredEnumeratorState == null) {
                 currentEnumerator = source.createEnumerator(delegatingContext);
             } else {
                 LOG.info("Restoring enumerator for sourceIndex={}", currentSourceIndex);
-                currentEnumerator =
-                        source.restoreEnumerator(delegatingContext, restoredEnumeratorState);
+                Object nestedEnumState =
+                        currentEnumeratorCheckpointSerializer.deserialize(
+                                restoredEnumeratorState.getWrappedStateSerializerVersion(),
+                                restoredEnumeratorState.getWrappedState());
+                currentEnumerator = source.restoreEnumerator(delegatingContext, nestedEnumState);
                 restoredEnumeratorState = null;
             }
         } catch (Exception e) {
@@ -301,14 +307,17 @@ public class HybridSourceSplitEnumerator
         private final SplitEnumeratorContext<HybridSourceSplit> realContext;
         private final int sourceIndex;
         private final Map<Integer, Integer> readerSourceIndex;
+        private final SwitchedSources switchedSources;
 
         private SplitEnumeratorContextProxy(
                 int sourceIndex,
                 SplitEnumeratorContext<HybridSourceSplit> realContext,
-                Map<Integer, Integer> readerSourceIndex) {
+                Map<Integer, Integer> readerSourceIndex,
+                SwitchedSources switchedSources) {
             this.realContext = realContext;
             this.sourceIndex = sourceIndex;
             this.readerSourceIndex = readerSourceIndex;
+            this.switchedSources = switchedSources;
         }
 
         @Override
@@ -358,7 +367,7 @@ public class HybridSourceSplitEnumerator
             Map<Integer, List<HybridSourceSplit>> wrappedAssignmentMap = new HashMap<>();
             for (Map.Entry<Integer, List<SplitT>> e : newSplitAssignments.assignment().entrySet()) {
                 List<HybridSourceSplit> splits =
-                        HybridSourceSplit.wrapSplits(sourceIndex, e.getValue());
+                        HybridSourceSplit.wrapSplits(e.getValue(), sourceIndex, switchedSources);
                 wrappedAssignmentMap.put(e.getKey(), splits);
             }
             SplitsAssignment<HybridSourceSplit> wrappedAssignments =
@@ -369,7 +378,8 @@ public class HybridSourceSplitEnumerator
 
         @Override
         public void assignSplit(SplitT split, int subtask) {
-            HybridSourceSplit wrappedSplit = new HybridSourceSplit(sourceIndex, split);
+            HybridSourceSplit wrappedSplit =
+                    HybridSourceSplit.wrapSplit(split, sourceIndex, switchedSources);
             realContext.assignSplit(wrappedSplit, subtask);
         }
 

--- a/flink-connectors/flink-connector-base/src/main/java/org/apache/flink/connector/base/source/hybrid/HybridSourceSplitSerializer.java
+++ b/flink-connectors/flink-connector-base/src/main/java/org/apache/flink/connector/base/source/hybrid/HybridSourceSplitSerializer.java
@@ -18,29 +18,18 @@
 
 package org.apache.flink.connector.base.source.hybrid;
 
-import org.apache.flink.api.connector.source.Source;
-import org.apache.flink.api.connector.source.SourceSplit;
 import org.apache.flink.core.io.SimpleVersionedSerializer;
-import org.apache.flink.util.Preconditions;
 
 import java.io.ByteArrayInputStream;
 import java.io.ByteArrayOutputStream;
 import java.io.DataInputStream;
 import java.io.DataOutputStream;
 import java.io.IOException;
-import java.util.HashMap;
-import java.util.Map;
 
 /** Serializes splits by delegating to the source-indexed underlying split serializer. */
 public class HybridSourceSplitSerializer implements SimpleVersionedSerializer<HybridSourceSplit> {
 
-    final Map<Integer, SimpleVersionedSerializer<SourceSplit>> cachedSerializers;
-    final Map<Integer, Source> switchedSources;
-
-    public HybridSourceSplitSerializer(Map<Integer, Source> switchedSources) {
-        this.cachedSerializers = new HashMap<>();
-        this.switchedSources = switchedSources;
-    }
+    public HybridSourceSplitSerializer() {}
 
     @Override
     public int getVersion() {
@@ -52,11 +41,10 @@ public class HybridSourceSplitSerializer implements SimpleVersionedSerializer<Hy
         try (ByteArrayOutputStream baos = new ByteArrayOutputStream();
                 DataOutputStream out = new DataOutputStream(baos)) {
             out.writeInt(split.sourceIndex());
-            out.writeInt(serializerOf(split.sourceIndex()).getVersion());
-            byte[] serializedSplit =
-                    serializerOf(split.sourceIndex()).serialize(split.getWrappedSplit());
-            out.writeInt(serializedSplit.length);
-            out.write(serializedSplit);
+            out.writeUTF(split.splitId());
+            out.writeInt(split.wrappedSplitSerializerVersion());
+            out.writeInt(split.wrappedSplitBytes().length);
+            out.write(split.wrappedSplitBytes());
             out.flush();
             return baos.toByteArray();
         }
@@ -74,25 +62,12 @@ public class HybridSourceSplitSerializer implements SimpleVersionedSerializer<Hy
         try (ByteArrayInputStream bais = new ByteArrayInputStream(serialized);
                 DataInputStream in = new DataInputStream(bais)) {
             int sourceIndex = in.readInt();
+            String splitId = in.readUTF();
             int nestedVersion = in.readInt();
             int length = in.readInt();
             byte[] splitBytes = new byte[length];
             in.readFully(splitBytes);
-            SourceSplit split = serializerOf(sourceIndex).deserialize(nestedVersion, splitBytes);
-            return new HybridSourceSplit(sourceIndex, split);
+            return new HybridSourceSplit(sourceIndex, splitBytes, nestedVersion, splitId);
         }
-    }
-
-    private SimpleVersionedSerializer<SourceSplit> serializerOf(int sourceIndex) {
-        return cachedSerializers.computeIfAbsent(
-                sourceIndex,
-                (k -> {
-                    Source source =
-                            Preconditions.checkNotNull(
-                                    switchedSources.get(k),
-                                    "Source for index=%s not available",
-                                    sourceIndex);
-                    return source.getSplitSerializer();
-                }));
     }
 }

--- a/flink-connectors/flink-connector-base/src/main/java/org/apache/flink/connector/base/source/hybrid/SwitchedSources.java
+++ b/flink-connectors/flink-connector-base/src/main/java/org/apache/flink/connector/base/source/hybrid/SwitchedSources.java
@@ -1,0 +1,48 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.flink.connector.base.source.hybrid;
+
+import org.apache.flink.api.connector.source.Source;
+import org.apache.flink.api.connector.source.SourceSplit;
+import org.apache.flink.core.io.SimpleVersionedSerializer;
+import org.apache.flink.util.Preconditions;
+
+import java.util.HashMap;
+import java.util.Map;
+
+/** Sources that participated in switching with cached serializers. */
+class SwitchedSources {
+    private final Map<Integer, Source> sources = new HashMap<>();
+    private final Map<Integer, SimpleVersionedSerializer<SourceSplit>> cachedSerializers =
+            new HashMap<>();
+
+    public Source sourceOf(int sourceIndex) {
+        return Preconditions.checkNotNull(
+                sources.get(sourceIndex), "Source for index=%s not available", sourceIndex);
+    }
+
+    public SimpleVersionedSerializer<SourceSplit> serializerOf(int sourceIndex) {
+        return cachedSerializers.computeIfAbsent(
+                sourceIndex, (k -> sourceOf(k).getSplitSerializer()));
+    }
+
+    public void put(int sourceIndex, Source source) {
+        sources.put(sourceIndex, Preconditions.checkNotNull(source));
+    }
+}

--- a/flink-connectors/flink-connector-base/src/test/java/org/apache/flink/connector/base/source/hybrid/HybridSourceSplitSerializerTest.java
+++ b/flink-connectors/flink-connector-base/src/test/java/org/apache/flink/connector/base/source/hybrid/HybridSourceSplitSerializerTest.java
@@ -20,7 +20,6 @@ package org.apache.flink.connector.base.source.hybrid;
 
 import org.apache.flink.api.connector.source.Source;
 import org.apache.flink.api.connector.source.mocks.MockSource;
-import org.apache.flink.api.connector.source.mocks.MockSourceSplit;
 
 import org.junit.Assert;
 import org.junit.Test;
@@ -36,8 +35,9 @@ public class HybridSourceSplitSerializerTest {
     public void testSerialization() throws Exception {
         Map<Integer, Source> switchedSources = new HashMap<>();
         switchedSources.put(0, new MockSource(null, 0));
-        HybridSourceSplitSerializer serializer = new HybridSourceSplitSerializer(switchedSources);
-        HybridSourceSplit split = new HybridSourceSplit(0, new MockSourceSplit(1));
+        byte[] splitBytes = {1, 2, 3};
+        HybridSourceSplitSerializer serializer = new HybridSourceSplitSerializer();
+        HybridSourceSplit split = new HybridSourceSplit(0, splitBytes, 0, "splitId");
         byte[] serialized = serializer.serialize(split);
         HybridSourceSplit clonedSplit = serializer.deserialize(0, serialized);
         Assert.assertEquals(split, clonedSplit);

--- a/flink-connectors/flink-connector-base/src/test/java/org/apache/flink/connector/base/source/reader/mocks/MockBaseSource.java
+++ b/flink-connectors/flink-connector-base/src/test/java/org/apache/flink/connector/base/source/reader/mocks/MockBaseSource.java
@@ -117,7 +117,8 @@ public class MockBaseSource implements Source<Integer, MockSourceSplit, List<Moc
 
             @Override
             public byte[] serialize(List<MockSourceSplit> obj) throws IOException {
-                return InstantiationUtil.serializeObject(obj.toArray());
+                return InstantiationUtil.serializeObject(
+                        obj.toArray(new MockSourceSplit[obj.size()]));
             }
 
             @Override


### PR DESCRIPTION
## What is the purpose of the change

Restore from savepoint fails due to deserialization of underlying splits before the underlying enumerator has been restored (details in JIRA). With this change deserialization will be deferred and be explicit in the HybridSource enumerator/reader.

## Verifying this change

Existing tests don't cover restore from savepoint (ITCase performs recovery from initial state). Deserialization of HybridSplit and enumerator checkpoint covered by unit test. Changes verified with internal deployment. Planning to add unit test that just deserializes HybridSourceSplit before merging. 
