### PR TITLE
[hotfix][test] Clearly mark old TestHarness classes as deprecated

### DIFF
--- a/flink-streaming-java/src/test/java/org/apache/flink/streaming/runtime/tasks/OneInputStreamTaskTestHarness.java
+++ b/flink-streaming-java/src/test/java/org/apache/flink/streaming/runtime/tasks/OneInputStreamTaskTestHarness.java
@@ -49,7 +49,11 @@ import java.io.File;
  * the Task notifyNonEmpty from this queue. Use {@link #waitForInputProcessing()} to wait until all
  * queues are empty. This must be used after entering some elements before checking the desired
  * output.
+ *
+ * @deprecated Please use {@link StreamTaskMailboxTestHarness} and {@link
+ *     StreamTaskMailboxTestHarnessBuilder}. Do not add new code using this test harness.
  */
+@Deprecated
 public class OneInputStreamTaskTestHarness<IN, OUT> extends StreamTaskTestHarness<OUT> {
 
     private TypeInformation<IN> inputType;

--- a/flink-streaming-java/src/test/java/org/apache/flink/streaming/runtime/tasks/StreamTaskTestHarness.java
+++ b/flink-streaming-java/src/test/java/org/apache/flink/streaming/runtime/tasks/StreamTaskTestHarness.java
@@ -94,8 +94,8 @@ import static org.apache.flink.util.Preconditions.checkState;
  * new Thread to execute the Task. Use {@link #waitForTaskCompletion()} to wait for the Task thread
  * to finish.
  *
- * <p>This class id deprecated because of it's threading model. Please use {@link
- * StreamTaskMailboxTestHarness}
+ * @deprecated Please use {@link StreamTaskMailboxTestHarness} and {@link
+ *     StreamTaskMailboxTestHarnessBuilder}. Do not add new code using this test harness.
  */
 @Deprecated
 public class StreamTaskTestHarness<OUT> {

--- a/flink-streaming-java/src/test/java/org/apache/flink/streaming/runtime/tasks/TwoInputStreamTaskTestHarness.java
+++ b/flink-streaming-java/src/test/java/org/apache/flink/streaming/runtime/tasks/TwoInputStreamTaskTestHarness.java
@@ -49,7 +49,11 @@ import java.util.List;
  * <p>When Elements or Events are offered to the Task they are put into a queue. The input gates of
  * the Task read from this queue. Use {@link #waitForInputProcessing()} to wait until all queues are
  * empty. This must be used after entering some elements before checking the desired output.
+ *
+ * @deprecated Please use {@link StreamTaskMailboxTestHarness} and {@link
+ *     StreamTaskMailboxTestHarnessBuilder}. Do not add new code using this test harness.
  */
+@Deprecated
 public class TwoInputStreamTaskTestHarness<IN1, IN2, OUT> extends StreamTaskTestHarness<OUT> {
 
     private TypeSerializer<IN1> inputSerializer1;


### PR DESCRIPTION
Old test harness should no longer be used and any new code should be using StreamTaskMailboxTestHarness

## Verifying this change

This is change in tests.

## Does this pull request potentially affect one of the following parts:

  - Dependencies (does it add or upgrade a dependency): (yes / **no**)
  - The public API, i.e., is any changed class annotated with `@Public(Evolving)`: (yes / **no**)
  - The serializers: (yes / **no** / don't know)
  - The runtime per-record code paths (performance sensitive): (yes / **no** / don't know)
  - Anything that affects deployment or recovery: JobManager (and its components), Checkpointing, Kubernetes/Yarn, ZooKeeper: (yes / **no** / don't know)
  - The S3 file system connector: (yes / **no** / don't know)

## Documentation

  - Does this pull request introduce a new feature? (yes / **no**)
  - If yes, how is the feature documented? (**not applicable /** docs / JavaDocs / not documented)
