### PR TITLE
[FLINK-24105][python] Fix the state ttl does not take effect in PyFlink

### DIFF
--- a/docs/content.zh/docs/dev/datastream/fault-tolerance/state.md
+++ b/docs/content.zh/docs/dev/datastream/fault-tolerance/state.md
@@ -367,10 +367,16 @@ TTL 的更新策略（默认是 `OnCreateAndWrite`）：
 
  - `StateTtlConfig.UpdateType.OnCreateAndWrite` - 仅在创建和写入时更新
  - `StateTtlConfig.UpdateType.OnReadAndWrite` - 读取时也更新
+
+    (**注意:** 如果你同时将状态的可见性配置为 `StateTtlConfig.StateVisibility.ReturnExpiredIfNotCleanedUp`，
+    那么在PyFlink作业中，状态的读缓存将会失效，这将导致一部分的性能损失)
  
 数据在过期但还未被清理时的可见性配置如下（默认为 `NeverReturnExpired`):
 
  - `StateTtlConfig.StateVisibility.NeverReturnExpired` - 不返回过期数据
+
+    (**注意:** 在PyFlink作业中，状态的读写缓存都将失效，这将导致一部分的性能损失)
+
  - `StateTtlConfig.StateVisibility.ReturnExpiredIfNotCleanedUp` - 会返回过期但未清理的数据
  
 `NeverReturnExpired` 情况下，过期数据就像不存在一样，不管是否被物理删除。这对于不能访问过期数据的场景下非常有用，比如敏感数据。

--- a/docs/content/docs/dev/datastream/fault-tolerance/state.md
+++ b/docs/content/docs/dev/datastream/fault-tolerance/state.md
@@ -397,14 +397,14 @@ The update type configures when the state TTL is refreshed (by default `OnCreate
  - `StateTtlConfig.UpdateType.OnReadAndWrite` - also on read access
 
     (**Notes:** If you set the state visibility to `StateTtlConfig.StateVisibility.ReturnExpiredIfNotCleanedUp`
-    at the same time, the state read cache will be disabled to cause some performance loss in PyFlink)
+    at the same time, the state read cache will be disabled, which will cause some performance loss in PyFlink)
  
 The state visibility configures whether the expired value is returned on read access 
 if it is not cleaned up yet (by default `NeverReturnExpired`):
 
  - `StateTtlConfig.StateVisibility.NeverReturnExpired` - expired value is never returned 
 
-    (**Notes:** The state read/write cache will be disabled to cause some performance loss in PyFlink)
+    (**Notes:** The state read/write cache will be disabled, which will cause some performance loss in PyFlink)
 
  - `StateTtlConfig.StateVisibility.ReturnExpiredIfNotCleanedUp` - returned if still available
  

--- a/docs/content/docs/dev/datastream/fault-tolerance/state.md
+++ b/docs/content/docs/dev/datastream/fault-tolerance/state.md
@@ -395,11 +395,17 @@ The update type configures when the state TTL is refreshed (by default `OnCreate
 
  - `StateTtlConfig.UpdateType.OnCreateAndWrite` - only on creation and write access
  - `StateTtlConfig.UpdateType.OnReadAndWrite` - also on read access
+
+    (**Notes:** If you set the state visibility to `StateTtlConfig.StateVisibility.ReturnExpiredIfNotCleanedUp`
+    at the same time, the state read cache will be disabled to cause some performance loss in PyFlink)
  
 The state visibility configures whether the expired value is returned on read access 
 if it is not cleaned up yet (by default `NeverReturnExpired`):
 
- - `StateTtlConfig.StateVisibility.NeverReturnExpired` - expired value is never returned
+ - `StateTtlConfig.StateVisibility.NeverReturnExpired` - expired value is never returned 
+
+    (**Notes:** The state read/write cache will be disabled to cause some performance loss in PyFlink)
+
  - `StateTtlConfig.StateVisibility.ReturnExpiredIfNotCleanedUp` - returned if still available
  
 In case of `NeverReturnExpired`, the expired state behaves as if it does not exist anymore, 

--- a/flink-python/pyflink/fn_execution/state_impl.py
+++ b/flink-python/pyflink/fn_execution/state_impl.py
@@ -99,6 +99,7 @@ class SynchronousKvRuntimeState(InternalKvState, ABC):
         self._internal_state = None
         self.namespace = None
         self._ttl_config = None
+        self._cache_type = SynchronousKvRuntimeState.CacheType.ENABLE_READ_WRITE_CACHE
 
     def set_current_namespace(self, namespace: N) -> None:
         if namespace == self.namespace:
@@ -111,10 +112,23 @@ class SynchronousKvRuntimeState(InternalKvState, ABC):
 
     def enable_time_to_live(self, ttl_config: StateTtlConfig):
         self._ttl_config = ttl_config
+        if ttl_config.get_state_visibility() == StateTtlConfig.StateVisibility.NeverReturnExpired:
+            self._cache_type = SynchronousKvRuntimeState.CacheType.DISABLE_CACHE
+        elif ttl_config.get_update_type() == StateTtlConfig.UpdateType.OnReadAndWrite:
+            self._cache_type = SynchronousKvRuntimeState.CacheType.ENABLE_WRITE_CACHE
+
+        if self._cache_type != SynchronousKvRuntimeState.CacheType.ENABLE_READ_WRITE_CACHE:
+            # disable read cache
+            self._remote_state_backend._state_handler._state_cache._cache._max_entries = 0
 
     @abstractmethod
     def get_internal_state(self):
         pass
+
+    class CacheType(Enum):
+        DISABLE_CACHE = 0
+        ENABLE_WRITE_CACHE = 1
+        ENABLE_READ_WRITE_CACHE = 2
 
 
 class SynchronousBagKvRuntimeState(SynchronousKvRuntimeState, ABC):
@@ -130,6 +144,11 @@ class SynchronousBagKvRuntimeState(SynchronousKvRuntimeState, ABC):
             self._internal_state = self._remote_state_backend._get_internal_bag_state(
                 self.name, self.namespace, self._value_coder, self._ttl_config)
         return self._internal_state
+
+    def _maybe_clear_write_cache(self):
+        if self._cache_type == SynchronousKvRuntimeState.CacheType.DISABLE_CACHE:
+            self._internal_state._cleared = True
+            self._internal_state.commit()
 
 
 class SynchronousValueRuntimeState(SynchronousBagKvRuntimeState, InternalValueState):
@@ -149,6 +168,7 @@ class SynchronousValueRuntimeState(SynchronousBagKvRuntimeState, InternalValueSt
         self.get_internal_state()
         self._internal_state.clear()
         self._internal_state.add(value)
+        self._maybe_clear_write_cache()
 
     def clear(self) -> None:
         self.get_internal_state().clear()
@@ -177,16 +197,19 @@ class SynchronousListRuntimeState(SynchronousMergingRuntimeState, InternalListSt
 
     def add(self, v):
         self.get_internal_state().add(v)
+        self._maybe_clear_write_cache()
 
     def get(self):
         return self.get_internal_state().read()
 
     def add_all(self, values):
         self.get_internal_state()._added_elements.extend(values)
+        self._maybe_clear_write_cache()
 
     def update(self, values):
         self.clear()
         self.add_all(values)
+        self._maybe_clear_write_cache()
 
     def clear(self):
         self.get_internal_state().clear()
@@ -213,6 +236,7 @@ class SynchronousReducingRuntimeState(SynchronousMergingRuntimeState, InternalRe
         else:
             self._internal_state.clear()
             self._internal_state.add(self._reduce_function.reduce(current_value, v))
+        self._maybe_clear_write_cache()
 
     def get(self):
         for i in self.get_internal_state().read():
@@ -247,6 +271,7 @@ class SynchronousAggregatingRuntimeState(SynchronousMergingRuntimeState, Interna
         accumulator = self._agg_function.add(v, accumulator)
         self._internal_state.clear()
         self._internal_state.add(accumulator)
+        self._maybe_clear_write_cache()
 
     def get(self):
         accumulator = self._get_accumulator()
@@ -877,7 +902,8 @@ class SynchronousMapRuntimeState(SynchronousKvRuntimeState, InternalMapState):
                 self.namespace,
                 self._map_key_coder,
                 self._map_value_coder,
-                self._ttl_config)
+                self._ttl_config,
+                self._cache_type)
         return self._internal_state
 
     def get(self, key):
@@ -1036,14 +1062,15 @@ class RemoteKeyedStateBackend(object):
         internal_state = self._create_bag_state(state_spec, encoded_namespace, ttl_config)
         return internal_state
 
-    def _get_internal_map_state(self, name, namespace, map_key_coder, map_value_coder, ttl_config):
+    def _get_internal_map_state(
+            self, name, namespace, map_key_coder, map_value_coder, ttl_config, cache_type):
         encoded_namespace = self._encode_namespace(namespace)
         cached_state = self._internal_state_cache.get(
             (name, self._encoded_current_key, encoded_namespace))
         if cached_state is not None:
             return cached_state
         internal_map_state = self._create_internal_map_state(
-            name, encoded_namespace, map_key_coder, map_value_coder, ttl_config)
+            name, encoded_namespace, map_key_coder, map_value_coder, ttl_config, cache_type)
         return internal_map_state
 
     def _create_bag_state(self, state_spec: userstate.StateSpec, encoded_namespace, ttl_config) \
@@ -1059,7 +1086,7 @@ class RemoteKeyedStateBackend(object):
             raise NotImplementedError(state_spec)
 
     def _create_internal_map_state(
-            self, name, encoded_namespace, map_key_coder, map_value_coder, ttl_config):
+            self, name, encoded_namespace, map_key_coder, map_value_coder, ttl_config, cache_type):
         # Currently the `beam_fn_api.proto` does not support MapState, so we use the
         # the `MultimapSideInput` message to mark the state as a MapState for now.
         from pyflink.fn_execution.flink_fn_execution_pb2 import StateDescriptor
@@ -1073,12 +1100,16 @@ class RemoteKeyedStateBackend(object):
                 window=encoded_namespace,
                 side_input_id=base64.b64encode(state_proto.SerializeToString()),
                 key=self._encoded_current_key))
+        if cache_type == SynchronousKvRuntimeState.CacheType.DISABLE_CACHE:
+            write_cache_size = 0
+        else:
+            write_cache_size = self._map_state_write_cache_size
         return InternalSynchronousMapRuntimeState(
             self._map_state_handler,
             state_key,
             map_key_coder,
             map_value_coder,
-            self._map_state_write_cache_size)
+            write_cache_size)
 
     def _encode_namespace(self, namespace):
         if namespace is not None:

--- a/flink-python/pyflink/fn_execution/state_impl.py
+++ b/flink-python/pyflink/fn_execution/state_impl.py
@@ -147,8 +147,9 @@ class SynchronousBagKvRuntimeState(SynchronousKvRuntimeState, ABC):
 
     def _maybe_clear_write_cache(self):
         if self._cache_type == SynchronousKvRuntimeState.CacheType.DISABLE_CACHE:
-            self._internal_state._cleared = True
             self._internal_state.commit()
+            self._internal_state._cleared = False
+            self._internal_state._added_elements = []
 
 
 class SynchronousValueRuntimeState(SynchronousBagKvRuntimeState, InternalValueState):


### PR DESCRIPTION
## What is the purpose of the change

*This pull request will fix the state ttl does not take effect in PyFlink*


## Brief change log

  - *Disable read/write cache according to ttl config*

## Verifying this change

This change added tests and can be verified as follows:

  - *IT `test_keyed_process_function_with_state` and `test_aggregating_state`*

## Does this pull request potentially affect one of the following parts:

  - Dependencies (does it add or upgrade a dependency): (no)
  - The public API, i.e., is any changed class annotated with `@Public(Evolving)`: (no)
  - The serializers: (no)
  - The runtime per-record code paths (performance sensitive): (no)
  - Anything that affects deployment or recovery: JobManager (and its components), Checkpointing, Kubernetes/Yarn, ZooKeeper: (no)
  - The S3 file system connector: (no)

## Documentation

  - Does this pull request introduce a new feature? (no)
  - If yes, how is the feature documented? (not applicable)
