### PR TITLE
[FLINK-24126][connector/kafka] Use increment of bytes consumed/produced for updating numBytesIn/Out in Kafka connector

### DIFF
--- a/flink-connectors/flink-connector-kafka/src/main/java/org/apache/flink/connector/kafka/sink/KafkaWriter.java
+++ b/flink-connectors/flink-connector-kafka/src/main/java/org/apache/flink/connector/kafka/sink/KafkaWriter.java
@@ -85,6 +85,8 @@ class KafkaWriter<IN> implements SinkWriter<IN, KafkaCommittable, KafkaWriterSta
     private final Sink.ProcessingTimeService timeService;
     private final boolean disabledMetrics;
 
+    // Number of outgoing bytes at the latest metric sync
+    private long latestOutgoingByteTotal;
     private Metric byteOutMetric;
     private FlinkKafkaInternalProducer<byte[], byte[]> currentProducer;
     private final KafkaWriterState kafkaWriterState;
@@ -378,7 +380,11 @@ class KafkaWriter<IN> implements SinkWriter<IN, KafkaCommittable, KafkaWriterSta
                     if (closed) {
                         return;
                     }
-                    MetricUtil.sync(byteOutMetric, numBytesOutCounter);
+                    long outgoingBytesUntilNow = ((Number) byteOutMetric.metricValue()).longValue();
+                    long outgoingBytesSinceLastUpdate =
+                            outgoingBytesUntilNow - latestOutgoingByteTotal;
+                    numBytesOutCounter.inc(outgoingBytesSinceLastUpdate);
+                    latestOutgoingByteTotal = outgoingBytesUntilNow;
                     lastSync = time;
                     registerMetricSync();
                 });

--- a/flink-connectors/flink-connector-kafka/src/main/java/org/apache/flink/connector/kafka/source/metrics/KafkaSourceReaderMetrics.java
+++ b/flink-connectors/flink-connector-kafka/src/main/java/org/apache/flink/connector/kafka/source/metrics/KafkaSourceReaderMetrics.java
@@ -22,8 +22,10 @@ import org.apache.flink.connector.kafka.MetricUtil;
 import org.apache.flink.connector.kafka.source.reader.KafkaSourceReader;
 import org.apache.flink.metrics.Counter;
 import org.apache.flink.metrics.MetricGroup;
+import org.apache.flink.metrics.groups.OperatorIOMetricGroup;
 import org.apache.flink.metrics.groups.SourceReaderMetricGroup;
 import org.apache.flink.runtime.metrics.MetricNames;
+import org.apache.flink.runtime.metrics.groups.TaskIOMetricGroup;
 
 import org.apache.kafka.clients.consumer.KafkaConsumer;
 import org.apache.kafka.common.Metric;
@@ -99,6 +101,9 @@ public class KafkaSourceReaderMetrics {
 
     // Kafka raw metric for bytes consumed total
     @Nullable private Metric bytesConsumedTotalMetric;
+
+    /** Number of bytes consumed total at the latest {@link #updateNumBytesInCounter()}. */
+    private long latestBytesConsumedTotal;
 
     public KafkaSourceReaderMetrics(SourceReaderMetricGroup sourceReaderMetricGroup) {
         this.sourceReaderMetricGroup = sourceReaderMetricGroup;
@@ -235,12 +240,24 @@ public class KafkaSourceReaderMetrics {
         }
     }
 
-    /** Update {@link org.apache.flink.runtime.metrics.MetricNames#IO_NUM_BYTES_IN}. */
+    /**
+     * Update {@link org.apache.flink.runtime.metrics.MetricNames#IO_NUM_BYTES_IN}.
+     *
+     * <p>Instead of simply setting {@link OperatorIOMetricGroup#getNumBytesInCounter()} to the same
+     * value as bytes-consumed-total from Kafka consumer, which will screw {@link
+     * TaskIOMetricGroup#getNumBytesInCounter()} if chained sources exist, we track the increment of
+     * bytes-consumed-total and count it towards the counter.
+     */
     public void updateNumBytesInCounter() {
         if (this.bytesConsumedTotalMetric != null) {
-            MetricUtil.sync(
-                    this.bytesConsumedTotalMetric,
-                    this.sourceReaderMetricGroup.getIOMetricGroup().getNumBytesInCounter());
+            long bytesConsumedUntilNow =
+                    ((Number) this.bytesConsumedTotalMetric.metricValue()).longValue();
+            long bytesConsumedSinceLastUpdate = bytesConsumedUntilNow - latestBytesConsumedTotal;
+            this.sourceReaderMetricGroup
+                    .getIOMetricGroup()
+                    .getNumBytesInCounter()
+                    .inc(bytesConsumedSinceLastUpdate);
+            latestBytesConsumedTotal = bytesConsumedUntilNow;
         }
     }
 


### PR DESCRIPTION
## What is the purpose of the change

This pull request changes the implementation of updating ```numBytesIn/Out``` metric in Kafka connector to handle the counter correctly in chained operator scenario.


## Brief change log
 - Use increment of bytes consumed/produced for updating numBytesIn/Out in Kafka connector

## Verifying this change

This change is a trivial rework / code cleanup without any test coverage.

## Does this pull request potentially affect one of the following parts:

  - Dependencies (does it add or upgrade a dependency): (no)
  - The public API, i.e., is any changed class annotated with `@Public(Evolving)`: (no)
  - The serializers: (no)
  - The runtime per-record code paths (performance sensitive): (no)
  - Anything that affects deployment or recovery: JobManager (and its components), Checkpointing, Kubernetes/Yarn, ZooKeeper: (no)
  - The S3 file system connector: (no)

## Documentation

  - Does this pull request introduce a new feature? (no)
  - If yes, how is the feature documented? (not applicable)
