### PR TITLE
[FLINK-24023][runtime-web] The names of metrics are incomplete

### DIFF
--- a/flink-runtime-web/web-dashboard/src/app/pages/job/overview/chart/job-overview-drawer-chart.component.html
+++ b/flink-runtime-web/web-dashboard/src/app/pages/job/overview/chart/job-overview-drawer-chart.component.html
@@ -20,8 +20,12 @@
   <span *ngIf="listOfMetricName.length === 0; else elseTemplate;">No Available Metric</span>
   <ng-template #elseTemplate>
     Add Metric:
-    <nz-select nzSize="small" [ngModel]="null" nzShowSearch [nzPlaceHolder]="'Select Metric Name'" (ngModelChange)="updateMetric($event)">
-      <nz-option *ngFor="let name of listOfUnselectedMetric" [nzLabel]="name" [nzValue]="name"></nz-option>
+    <nz-select nzSize="small" [ngModel]="null" nzShowSearch [nzPlaceHolder]="'Select Metric Name'"
+               (ngModelChange)="updateMetric($event)">
+        <nz-option *ngFor="let name of listOfUnselectedMetric" [nzLabel]="name" [nzValue]="name"
+                   nzCustomContent>
+            <span [title]="name">{{name}}</span>
+        </nz-option>
     </nz-select>
   </ng-template>
 </div>


### PR DESCRIPTION
## What is the purpose of the change

Fixed the problem that the metrics are too long to display in the metrics select box by adding title for select box options.

## Brief change log

- flink-runtime-web/web-dashboard/src/app/pages/job/overview/chart/job-overview-drawer-chart.component.html

## Verifying this change

This change is a trivial rework / code cleanup without any test coverage.

## Does this pull request potentially affect one of the following parts:

  - Dependencies (does it add or upgrade a dependency): no
  - The public API, i.e., is any changed class annotated with `@Public(Evolving)`: no
  - The serializers: no
  - The runtime per-record code paths (performance sensitive): no
  - Anything that affects deployment or recovery: JobManager (and its components), Checkpointing, Kubernetes/Yarn, ZooKeeper: no
  - The S3 file system connector: no

## Documentation

  - Does this pull request introduce a new feature? no
