### PR TITLE
[FLINK-22603][table-planner]The digest can be produced by SourceAbilitySpec.

### DIFF
--- a/flink-table/flink-table-planner/src/main/java/org/apache/flink/table/planner/connectors/DynamicSourceUtils.java
+++ b/flink-table/flink-table-planner/src/main/java/org/apache/flink/table/planner/connectors/DynamicSourceUtils.java
@@ -43,6 +43,7 @@ import org.apache.flink.table.planner.expressions.converter.ExpressionConverter;
 import org.apache.flink.table.planner.plan.abilities.source.SourceAbilitySpec;
 import org.apache.flink.table.planner.plan.schema.TableSourceTable;
 import org.apache.flink.table.planner.plan.stats.FlinkStatistic;
+import org.apache.flink.table.planner.utils.ShortcutUtils;
 import org.apache.flink.table.runtime.connector.source.ScanRuntimeProviderContext;
 import org.apache.flink.table.types.DataType;
 import org.apache.flink.table.types.logical.LogicalType;
@@ -343,7 +344,7 @@ public final class DynamicSourceUtils {
                         tableSource,
                         !isBatchMode,
                         catalogTable,
-                        new String[0],
+                        ShortcutUtils.unwrapContext(relBuilder),
                         new SourceAbilitySpec[0]);
 
         final LogicalTableScan scan =

--- a/flink-table/flink-table-planner/src/main/java/org/apache/flink/table/planner/plan/abilities/source/FilterPushDownSpec.java
+++ b/flink-table/flink-table-planner/src/main/java/org/apache/flink/table/planner/plan/abilities/source/FilterPushDownSpec.java
@@ -25,7 +25,10 @@ import org.apache.flink.table.expressions.Expression;
 import org.apache.flink.table.expressions.ResolvedExpression;
 import org.apache.flink.table.expressions.resolver.ExpressionResolver;
 import org.apache.flink.table.planner.calcite.FlinkTypeFactory;
+import org.apache.flink.table.planner.plan.utils.FlinkRexUtil;
 import org.apache.flink.table.planner.plan.utils.RexNodeToExpressionConverter;
+import org.apache.flink.table.planner.utils.JavaScalaConversionUtil;
+import org.apache.flink.table.types.logical.RowType;
 
 import org.apache.flink.shaded.jackson2.com.fasterxml.jackson.annotation.JsonCreator;
 import org.apache.flink.shaded.jackson2.com.fasterxml.jackson.annotation.JsonProperty;
@@ -118,5 +121,23 @@ public class FilterPushDownSpec extends SourceAbilitySpecBase {
                             "%s does not support SupportsFilterPushDown.",
                             tableSource.getClass().getName()));
         }
+    }
+
+    @Override
+    public String getDigests(SourceAbilityContext context) {
+        final List<String> expressionStrs = new ArrayList<>();
+        final RowType souorceRowType = context.getSourceRowType();
+        for (RexNode rexNode : predicates) {
+            expressionStrs.add(
+                    FlinkRexUtil.getExpressionString(
+                            rexNode,
+                            JavaScalaConversionUtil.toScala(souorceRowType.getFieldNames())));
+        }
+
+        return String.format(
+                "filter=[%s]",
+                expressionStrs.stream()
+                        .reduce((l, r) -> String.format("and(%s, %s)", l, r))
+                        .orElse(""));
     }
 }

--- a/flink-table/flink-table-planner/src/main/java/org/apache/flink/table/planner/plan/abilities/source/FilterPushDownSpec.java
+++ b/flink-table/flink-table-planner/src/main/java/org/apache/flink/table/planner/plan/abilities/source/FilterPushDownSpec.java
@@ -126,12 +126,12 @@ public class FilterPushDownSpec extends SourceAbilitySpecBase {
     @Override
     public String getDigests(SourceAbilityContext context) {
         final List<String> expressionStrs = new ArrayList<>();
-        final RowType souorceRowType = context.getSourceRowType();
+        final RowType sourceRowType = context.getSourceRowType();
         for (RexNode rexNode : predicates) {
             expressionStrs.add(
                     FlinkRexUtil.getExpressionString(
                             rexNode,
-                            JavaScalaConversionUtil.toScala(souorceRowType.getFieldNames())));
+                            JavaScalaConversionUtil.toScala(sourceRowType.getFieldNames())));
         }
 
         return String.format(

--- a/flink-table/flink-table-planner/src/main/java/org/apache/flink/table/planner/plan/abilities/source/LimitPushDownSpec.java
+++ b/flink-table/flink-table-planner/src/main/java/org/apache/flink/table/planner/plan/abilities/source/LimitPushDownSpec.java
@@ -53,4 +53,9 @@ public class LimitPushDownSpec extends SourceAbilitySpecBase {
                             tableSource.getClass().getName()));
         }
     }
+
+    @Override
+    public String getDigests(SourceAbilityContext context) {
+        return "limit=[" + this.limit + "]";
+    }
 }

--- a/flink-table/flink-table-planner/src/main/java/org/apache/flink/table/planner/plan/abilities/source/PartitionPushDownSpec.java
+++ b/flink-table/flink-table-planner/src/main/java/org/apache/flink/table/planner/plan/abilities/source/PartitionPushDownSpec.java
@@ -60,4 +60,12 @@ public class PartitionPushDownSpec extends SourceAbilitySpecBase {
                             tableSource.getClass().getName()));
         }
     }
+
+    @Override
+    public String getDigests(SourceAbilityContext context) {
+        return "partitions=["
+                + String.join(
+                        ", ", this.partitions.stream().map(Object::toString).toArray(String[]::new))
+                + "]";
+    }
 }

--- a/flink-table/flink-table-planner/src/main/java/org/apache/flink/table/planner/plan/abilities/source/PartitionPushDownSpec.java
+++ b/flink-table/flink-table-planner/src/main/java/org/apache/flink/table/planner/plan/abilities/source/PartitionPushDownSpec.java
@@ -29,6 +29,7 @@ import org.apache.flink.shaded.jackson2.com.fasterxml.jackson.annotation.JsonTyp
 import java.util.ArrayList;
 import java.util.List;
 import java.util.Map;
+import java.util.stream.Collectors;
 
 import static org.apache.flink.util.Preconditions.checkNotNull;
 
@@ -64,8 +65,7 @@ public class PartitionPushDownSpec extends SourceAbilitySpecBase {
     @Override
     public String getDigests(SourceAbilityContext context) {
         return "partitions=["
-                + String.join(
-                        ", ", this.partitions.stream().map(Object::toString).toArray(String[]::new))
+                + this.partitions.stream().map(Object::toString).collect(Collectors.joining(", "))
                 + "]";
     }
 }

--- a/flink-table/flink-table-planner/src/main/java/org/apache/flink/table/planner/plan/abilities/source/ProjectPushDownSpec.java
+++ b/flink-table/flink-table-planner/src/main/java/org/apache/flink/table/planner/plan/abilities/source/ProjectPushDownSpec.java
@@ -27,6 +27,8 @@ import org.apache.flink.shaded.jackson2.com.fasterxml.jackson.annotation.JsonCre
 import org.apache.flink.shaded.jackson2.com.fasterxml.jackson.annotation.JsonProperty;
 import org.apache.flink.shaded.jackson2.com.fasterxml.jackson.annotation.JsonTypeName;
 
+import java.util.List;
+
 import static org.apache.flink.util.Preconditions.checkNotNull;
 
 /**
@@ -58,5 +60,15 @@ public class ProjectPushDownSpec extends SourceAbilitySpecBase {
                             "%s does not support SupportsProjectionPushDown.",
                             tableSource.getClass().getName()));
         }
+    }
+
+    @Override
+    public String getDigests(SourceAbilityContext context) {
+        final List<String> fieldNames =
+                this.getProducedType()
+                        .orElseThrow(() -> new TableException("Produced data type is not present."))
+                        .getFieldNames();
+
+        return String.format("project=[%s]", String.join(", ", fieldNames));
     }
 }

--- a/flink-table/flink-table-planner/src/main/java/org/apache/flink/table/planner/plan/abilities/source/ReadingMetadataSpec.java
+++ b/flink-table/flink-table-planner/src/main/java/org/apache/flink/table/planner/plan/abilities/source/ReadingMetadataSpec.java
@@ -74,4 +74,9 @@ public class ReadingMetadataSpec extends SourceAbilitySpecBase {
                             tableSource.getClass().getName()));
         }
     }
+
+    @Override
+    public String getDigests(SourceAbilityContext context) {
+        return String.format("metadata=[%s]", String.join(", ", this.metadataKeys));
+    }
 }

--- a/flink-table/flink-table-planner/src/main/java/org/apache/flink/table/planner/plan/abilities/source/SourceAbilitySpec.java
+++ b/flink-table/flink-table-planner/src/main/java/org/apache/flink/table/planner/plan/abilities/source/SourceAbilitySpec.java
@@ -56,4 +56,11 @@ public interface SourceAbilitySpec {
      */
     @JsonIgnore
     Optional<RowType> getProducedType();
+
+    /**
+     * Additional digests to generate when this spec is applied to the source.
+     *
+     * @param context The context about the source.
+     */
+    String getDigests(SourceAbilityContext context);
 }

--- a/flink-table/flink-table-planner/src/main/java/org/apache/flink/table/planner/plan/abilities/source/SourceWatermarkSpec.java
+++ b/flink-table/flink-table-planner/src/main/java/org/apache/flink/table/planner/plan/abilities/source/SourceWatermarkSpec.java
@@ -60,4 +60,9 @@ public class SourceWatermarkSpec extends SourceAbilitySpecBase {
                             tableSource.getClass().getName()));
         }
     }
+
+    @Override
+    public String getDigests(SourceAbilityContext context) {
+        return "watermark=[SOURCE_WATERMARK()]";
+    }
 }

--- a/flink-table/flink-table-planner/src/main/java/org/apache/flink/table/planner/plan/abilities/source/WatermarkPushDownSpec.java
+++ b/flink-table/flink-table-planner/src/main/java/org/apache/flink/table/planner/plan/abilities/source/WatermarkPushDownSpec.java
@@ -103,6 +103,20 @@ public class WatermarkPushDownSpec extends SourceAbilitySpecBase {
         }
     }
 
+    @Override
+    public String getDigests(SourceAbilityContext context) {
+        final String expressionStr =
+                FlinkRexUtil.getExpressionString(
+                        watermarkExpr,
+                        JavaScalaConversionUtil.toScala(
+                                context.getSourceRowType().getFieldNames()));
+        if (idleTimeoutMillis > 0) {
+            return String.format(
+                    "watermark=[%s], idletimeout=[%d]", expressionStr, idleTimeoutMillis);
+        }
+        return String.format("watermark=[%s]", expressionStr);
+    }
+
     /**
      * Wrapper of the {@link GeneratedWatermarkGenerator} that is used to create {@link
      * WatermarkGenerator}. The {@link DefaultWatermarkGeneratorSupplier} uses the {@link
@@ -184,26 +198,5 @@ public class WatermarkPushDownSpec extends SourceAbilitySpecBase {
                 output.emitWatermark(new Watermark(currentWatermark));
             }
         }
-    }
-
-    @Override
-    public String getDigests(SourceAbilityContext context) {
-        final String expressionStr =
-                FlinkRexUtil.getExpressionString(
-                        watermarkExpr,
-                        JavaScalaConversionUtil.toScala(
-                                context.getSourceRowType().getFieldNames()));
-
-        //        final String expressionStr =
-        //                FlinkRexUtil.getExpressionString(
-        //                        watermarkExpr,
-        //
-        // JavaScalaConversionUtil.toScala(getProducedType().get().getFieldNames()));
-
-        if (idleTimeoutMillis == -1L) {
-            return String.format("watermark=[%s]", expressionStr);
-        }
-
-        return String.format("watermark=[%s], idletimeout=[%d]", expressionStr, idleTimeoutMillis);
     }
 }

--- a/flink-table/flink-table-planner/src/main/java/org/apache/flink/table/planner/plan/abilities/source/WatermarkPushDownSpec.java
+++ b/flink-table/flink-table-planner/src/main/java/org/apache/flink/table/planner/plan/abilities/source/WatermarkPushDownSpec.java
@@ -29,6 +29,8 @@ import org.apache.flink.table.connector.source.DynamicTableSource;
 import org.apache.flink.table.connector.source.abilities.SupportsWatermarkPushDown;
 import org.apache.flink.table.data.RowData;
 import org.apache.flink.table.planner.codegen.WatermarkGeneratorCodeGenerator;
+import org.apache.flink.table.planner.plan.utils.FlinkRexUtil;
+import org.apache.flink.table.planner.utils.JavaScalaConversionUtil;
 import org.apache.flink.table.runtime.generated.GeneratedWatermarkGenerator;
 import org.apache.flink.table.types.logical.RowType;
 
@@ -182,5 +184,26 @@ public class WatermarkPushDownSpec extends SourceAbilitySpecBase {
                 output.emitWatermark(new Watermark(currentWatermark));
             }
         }
+    }
+
+    @Override
+    public String getDigests(SourceAbilityContext context) {
+        final String expressionStr =
+                FlinkRexUtil.getExpressionString(
+                        watermarkExpr,
+                        JavaScalaConversionUtil.toScala(
+                                context.getSourceRowType().getFieldNames()));
+
+        //        final String expressionStr =
+        //                FlinkRexUtil.getExpressionString(
+        //                        watermarkExpr,
+        //
+        // JavaScalaConversionUtil.toScala(getProducedType().get().getFieldNames()));
+
+        if (idleTimeoutMillis == -1L) {
+            return String.format("watermark=[%s]", expressionStr);
+        }
+
+        return String.format("watermark=[%s], idletimeout=[%d]", expressionStr, idleTimeoutMillis);
     }
 }

--- a/flink-table/flink-table-planner/src/main/java/org/apache/flink/table/planner/plan/nodes/exec/spec/TemporalTableSourceSpec.java
+++ b/flink-table/flink-table-planner/src/main/java/org/apache/flink/table/planner/plan/nodes/exec/spec/TemporalTableSourceSpec.java
@@ -106,7 +106,7 @@ public class TemporalTableSourceSpec {
                     lookupTableSource,
                     true,
                     catalogTable,
-                    new String[] {},
+                    planner.getFlinkContext(),
                     sourceAbilitySpecs);
         }
         throw new TableException("Can not obtain temporalTable correctly!");

--- a/flink-table/flink-table-planner/src/main/java/org/apache/flink/table/planner/plan/rules/logical/PushLimitIntoTableSourceScanRule.java
+++ b/flink-table/flink-table-planner/src/main/java/org/apache/flink/table/planner/plan/rules/logical/PushLimitIntoTableSourceScanRule.java
@@ -109,9 +109,6 @@ public class PushLimitIntoTableSourceScanRule extends RelOptRule {
                 FlinkStatistic.builder().statistic(statistic).tableStats(newTableStats).build();
 
         return oldTableSourceTable.copy(
-                newTableSource,
-                newStatistic,
-                new String[] {"limit=[" + limit + "]"},
-                new SourceAbilitySpec[] {limitPushDownSpec});
+                newTableSource, newStatistic, new SourceAbilitySpec[] {limitPushDownSpec});
     }
 }

--- a/flink-table/flink-table-planner/src/main/java/org/apache/flink/table/planner/plan/rules/logical/PushPartitionIntoTableSourceScanRule.java
+++ b/flink-table/flink-table-planner/src/main/java/org/apache/flink/table/planner/plan/rules/logical/PushPartitionIntoTableSourceScanRule.java
@@ -209,19 +209,10 @@ public class PushPartitionIntoTableSourceScanRule extends RelOptRule {
                         .tableStats(newTableStat)
                         .build();
 
-        String extraDigest =
-                "partitions=["
-                        + String.join(
-                                ", ",
-                                remainingPartitions.stream()
-                                        .map(Object::toString)
-                                        .toArray(String[]::new))
-                        + "]";
         TableSourceTable newTableSourceTable =
                 tableSourceTable.copy(
                         dynamicTableSource,
                         newStatistic,
-                        new String[] {extraDigest},
                         new SourceAbilitySpec[] {partitionPushDownSpec});
         LogicalTableScan newScan =
                 LogicalTableScan.create(scan.getCluster(), newTableSourceTable, scan.getHints());

--- a/flink-table/flink-table-planner/src/main/java/org/apache/flink/table/planner/plan/rules/logical/PushProjectIntoTableSourceScanRule.java
+++ b/flink-table/flink-table-planner/src/main/java/org/apache/flink/table/planner/plan/rules/logical/PushProjectIntoTableSourceScanRule.java
@@ -159,10 +159,7 @@ public class PushProjectIntoTableSourceScanRule
         final RelDataType newRowType = typeFactory.buildRelNodeRowType(newProducedType);
         final TableSourceTable newSource =
                 sourceTable.copy(
-                        newTableSource,
-                        newRowType,
-                        getExtraDigests(abilitySpecs),
-                        abilitySpecs.toArray(new SourceAbilitySpec[0]));
+                        newTableSource, newRowType, abilitySpecs.toArray(new SourceAbilitySpec[0]));
         final LogicalTableScan newScan =
                 new LogicalTableScan(
                         scan.getCluster(), scan.getTraitSet(), scan.getHints(), newSource);
@@ -327,33 +324,6 @@ public class PushProjectIntoTableSourceScanRule
         } else {
             return project.getProjects();
         }
-    }
-
-    private static String[] getExtraDigests(List<SourceAbilitySpec> abilitySpecs) {
-        final List<String> digests = new ArrayList<>();
-        for (SourceAbilitySpec abilitySpec : abilitySpecs) {
-            if (abilitySpec instanceof ProjectPushDownSpec) {
-                digests.add(formatPushDownDigest((ProjectPushDownSpec) abilitySpec));
-            } else if (abilitySpec instanceof ReadingMetadataSpec) {
-                digests.add(formatMetadataDigest((ReadingMetadataSpec) abilitySpec));
-            }
-        }
-
-        return digests.toArray(new String[0]);
-    }
-
-    private static String formatPushDownDigest(ProjectPushDownSpec pushDownSpec) {
-        final List<String> fieldNames =
-                pushDownSpec
-                        .getProducedType()
-                        .orElseThrow(() -> new TableException("Produced data type is not present."))
-                        .getFieldNames();
-
-        return String.format("project=[%s]", String.join(", ", fieldNames));
-    }
-
-    private static String formatMetadataDigest(ReadingMetadataSpec metadataSpec) {
-        return String.format("metadata=[%s]", String.join(", ", metadataSpec.getMetadataKeys()));
     }
 
     // ---------------------------------------------------------------------------------------------

--- a/flink-table/flink-table-planner/src/main/java/org/apache/flink/table/planner/plan/rules/logical/PushWatermarkIntoTableSourceScanRuleBase.java
+++ b/flink-table/flink-table-planner/src/main/java/org/apache/flink/table/planner/plan/rules/logical/PushWatermarkIntoTableSourceScanRuleBase.java
@@ -82,8 +82,6 @@ public abstract class PushWatermarkIntoTableSourceScanRuleBase extends RelOptRul
             FlinkLogicalTableSourceScan scan,
             TableConfig tableConfig,
             boolean useWatermarkAssignerRowType) {
-        String digest = String.format("watermark=[%s]", watermarkExpr);
-
         final TableSourceTable tableSourceTable = scan.getTable().unwrap(TableSourceTable.class);
         final DynamicTableSource newDynamicTableSource = tableSourceTable.tableSource().copy();
 
@@ -117,7 +115,6 @@ public abstract class PushWatermarkIntoTableSourceScanRuleBase extends RelOptRul
             final long idleTimeoutMillis;
             if (!idleTimeout.isZero() && !idleTimeout.isNegative()) {
                 idleTimeoutMillis = idleTimeout.toMillis();
-                digest = String.format("%s, idletimeout=[%s]", digest, idleTimeoutMillis);
             } else {
                 idleTimeoutMillis = -1L;
             }
@@ -130,10 +127,7 @@ public abstract class PushWatermarkIntoTableSourceScanRuleBase extends RelOptRul
 
         TableSourceTable newTableSourceTable =
                 tableSourceTable.copy(
-                        newDynamicTableSource,
-                        newType,
-                        new String[] {digest},
-                        new SourceAbilitySpec[] {abilitySpec});
+                        newDynamicTableSource, newType, new SourceAbilitySpec[] {abilitySpec});
         return FlinkLogicalTableSourceScan.create(
                 scan.getCluster(), scan.getHints(), newTableSourceTable);
     }

--- a/flink-table/flink-table-planner/src/main/scala/org/apache/flink/table/planner/plan/nodes/FlinkRelNode.scala
+++ b/flink-table/flink-table-planner/src/main/scala/org/apache/flink/table/planner/plan/nodes/FlinkRelNode.scala
@@ -18,12 +18,13 @@
 
 package org.apache.flink.table.planner.plan.nodes
 
+import org.apache.flink.table.planner.plan.utils.ExpressionFormat.ExpressionFormat
 import org.apache.flink.table.planner.plan.utils.{ExpressionFormat, FlinkRexUtil, RelDescriptionWriterImpl}
+
 import org.apache.calcite.rel.RelNode
 import org.apache.calcite.rex._
-import java.io.{PrintWriter, StringWriter}
 
-import org.apache.flink.table.planner.plan.utils.ExpressionFormat.ExpressionFormat
+import java.io.{PrintWriter, StringWriter}
 
 /**
   * Base class for flink relational expression.

--- a/flink-table/flink-table-planner/src/main/scala/org/apache/flink/table/planner/plan/nodes/FlinkRelNode.scala
+++ b/flink-table/flink-table-planner/src/main/scala/org/apache/flink/table/planner/plan/nodes/FlinkRelNode.scala
@@ -18,17 +18,12 @@
 
 package org.apache.flink.table.planner.plan.nodes
 
-import org.apache.flink.table.planner.plan.nodes.ExpressionFormat.ExpressionFormat
-import org.apache.flink.table.planner.plan.utils.RelDescriptionWriterImpl
-
+import org.apache.flink.table.planner.plan.utils.{ExpressionFormat, FlinkRexUtil, RelDescriptionWriterImpl}
 import org.apache.calcite.rel.RelNode
 import org.apache.calcite.rex._
-import org.apache.calcite.sql.SqlAsOperator
-import org.apache.calcite.sql.SqlKind._
-
 import java.io.{PrintWriter, StringWriter}
 
-import scala.collection.JavaConversions._
+import org.apache.flink.table.planner.plan.utils.ExpressionFormat.ExpressionFormat
 
 /**
   * Base class for flink relational expression.
@@ -63,89 +58,9 @@ trait FlinkRelNode extends RelNode {
       inFields: List[String],
       localExprsTable: Option[List[RexNode]],
       expressionFormat: ExpressionFormat): String = {
-
-    expr match {
-      case pr: RexPatternFieldRef =>
-        val alpha = pr.getAlpha
-        val field = inFields.get(pr.getIndex)
-        s"$alpha.$field"
-
-      case i: RexInputRef =>
-        inFields.get(i.getIndex)
-
-      case l: RexLiteral =>
-        l.toString
-
-      case l: RexLocalRef if localExprsTable.isEmpty =>
-        throw new IllegalArgumentException("Encountered RexLocalRef without " +
-          "local expression table")
-
-      case l: RexLocalRef =>
-        val lExpr = localExprsTable.get(l.getIndex)
-        getExpressionString(lExpr, inFields, localExprsTable, expressionFormat)
-
-      case c: RexCall =>
-        val op = c.getOperator.toString
-        val ops = c.getOperands.map(
-          getExpressionString(_, inFields, localExprsTable, expressionFormat))
-        c.getOperator match {
-          case _: SqlAsOperator => ops.head
-          case _ =>
-            if (ops.size() == 1) {
-              val operand = ops.head
-              expressionFormat match {
-                case ExpressionFormat.Infix =>
-                  c.getKind match {
-                    case IS_FALSE | IS_NOT_FALSE | IS_TRUE | IS_NOT_TRUE | IS_UNKNOWN
-                         | IS_NULL | IS_NOT_NULL => s"$operand $op"
-                    case _ => s"$op($operand)"
-                  }
-                case ExpressionFormat.PostFix => s"$operand $op"
-                case ExpressionFormat.Prefix => s"$op($operand)"
-              }
-            } else {
-              c.getKind match {
-                case TIMES | DIVIDE | PLUS | MINUS
-                     | LESS_THAN | LESS_THAN_OR_EQUAL
-                     | GREATER_THAN | GREATER_THAN_OR_EQUAL
-                     | EQUALS | NOT_EQUALS
-                     | OR | AND =>
-                  expressionFormat match {
-                    case ExpressionFormat.Infix => s"(${ops.mkString(s" $op ")})"
-                    case ExpressionFormat.PostFix => s"(${ops.mkString(", ")})$op"
-                    case ExpressionFormat.Prefix => s"$op(${ops.mkString(", ")})"
-                  }
-                case _ => s"$op(${ops.mkString(", ")})"
-              }
-            }
-        }
-
-      case fa: RexFieldAccess =>
-        val referenceExpr = getExpressionString(
-          fa.getReferenceExpr,
-          inFields,
-          localExprsTable,
-          expressionFormat)
-        val field = fa.getField.getName
-        s"$referenceExpr.$field"
-      case cv: RexCorrelVariable =>
-        cv.toString
-      case _ =>
-        throw new IllegalArgumentException(s"Unknown expression type '${expr.getClass}': $expr")
-    }
+    FlinkRexUtil.getExpressionString(expr, inFields, localExprsTable, expressionFormat)
   }
 }
 
-/**
-  * Infix, Postfix and Prefix notations are three different but equivalent ways of writing
-  * expressions. It is easiest to demonstrate the differences by looking at examples of operators
-  * that take two operands.
-  * Infix notation: (X + Y)
-  * Postfix notation: (X Y) +
-  * Prefix notation: + (X Y)
-  */
-object ExpressionFormat extends Enumeration {
-  type ExpressionFormat = Value
-  val Infix, PostFix, Prefix = Value
-}
+
 

--- a/flink-table/flink-table-planner/src/main/scala/org/apache/flink/table/planner/plan/nodes/common/CommonCalc.scala
+++ b/flink-table/flink-table-planner/src/main/scala/org/apache/flink/table/planner/plan/nodes/common/CommonCalc.scala
@@ -19,17 +19,18 @@
 package org.apache.flink.table.planner.plan.nodes.common
 
 import org.apache.flink.table.planner.plan.nodes.FlinkRelNode
+import org.apache.flink.table.planner.plan.utils.ExpressionFormat.ExpressionFormat
 import org.apache.flink.table.planner.plan.utils.RelExplainUtil.{conditionToString, preferExpressionFormat}
+import org.apache.flink.table.planner.plan.utils.{ExpressionFormat, FlinkRexUtil}
+
 import org.apache.calcite.plan.{RelOptCluster, RelOptCost, RelOptPlanner, RelTraitSet}
 import org.apache.calcite.rel.core.Calc
 import org.apache.calcite.rel.hint.RelHint
 import org.apache.calcite.rel.metadata.RelMetadataQuery
 import org.apache.calcite.rel.{RelNode, RelWriter}
 import org.apache.calcite.rex.{RexCall, RexInputRef, RexLiteral, RexProgram}
-import java.util.Collections
 
-import org.apache.flink.table.planner.plan.utils.ExpressionFormat.ExpressionFormat
-import org.apache.flink.table.planner.plan.utils.{ExpressionFormat, FlinkRexUtil}
+import java.util.Collections
 
 import scala.collection.JavaConversions._
 

--- a/flink-table/flink-table-planner/src/main/scala/org/apache/flink/table/planner/plan/nodes/physical/common/CommonPhysicalJoin.scala
+++ b/flink-table/flink-table-planner/src/main/scala/org/apache/flink/table/planner/plan/nodes/physical/common/CommonPhysicalJoin.scala
@@ -21,14 +21,16 @@ package org.apache.flink.table.planner.plan.nodes.physical.common
 import org.apache.flink.table.api.TableException
 import org.apache.flink.table.planner.plan.nodes.exec.spec.JoinSpec
 import org.apache.flink.table.planner.plan.nodes.physical.FlinkPhysicalRel
-import org.apache.flink.table.planner.plan.utils.{FlinkRexUtil, JoinUtil}
 import org.apache.flink.table.planner.plan.utils.PythonUtil.containsPythonCall
 import org.apache.flink.table.planner.plan.utils.RelExplainUtil.preferExpressionFormat
+import org.apache.flink.table.planner.plan.utils.{FlinkRexUtil, JoinUtil}
+
 import org.apache.calcite.plan.{RelOptCluster, RelTraitSet}
 import org.apache.calcite.rel.`type`.RelDataType
 import org.apache.calcite.rel.core.{CorrelationId, Join, JoinRelType}
 import org.apache.calcite.rel.{RelNode, RelWriter}
 import org.apache.calcite.rex.RexNode
+
 import java.util.Collections
 
 import scala.collection.JavaConversions._

--- a/flink-table/flink-table-planner/src/main/scala/org/apache/flink/table/planner/plan/nodes/physical/common/CommonPhysicalJoin.scala
+++ b/flink-table/flink-table-planner/src/main/scala/org/apache/flink/table/planner/plan/nodes/physical/common/CommonPhysicalJoin.scala
@@ -21,16 +21,14 @@ package org.apache.flink.table.planner.plan.nodes.physical.common
 import org.apache.flink.table.api.TableException
 import org.apache.flink.table.planner.plan.nodes.exec.spec.JoinSpec
 import org.apache.flink.table.planner.plan.nodes.physical.FlinkPhysicalRel
-import org.apache.flink.table.planner.plan.utils.JoinUtil
+import org.apache.flink.table.planner.plan.utils.{FlinkRexUtil, JoinUtil}
 import org.apache.flink.table.planner.plan.utils.PythonUtil.containsPythonCall
 import org.apache.flink.table.planner.plan.utils.RelExplainUtil.preferExpressionFormat
-
 import org.apache.calcite.plan.{RelOptCluster, RelTraitSet}
 import org.apache.calcite.rel.`type`.RelDataType
 import org.apache.calcite.rel.core.{CorrelationId, Join, JoinRelType}
 import org.apache.calcite.rel.{RelNode, RelWriter}
 import org.apache.calcite.rex.RexNode
-
 import java.util.Collections
 
 import scala.collection.JavaConversions._
@@ -62,7 +60,7 @@ abstract class CommonPhysicalJoin(
   override def explainTerms(pw: RelWriter): RelWriter = {
     pw.input("left", getLeft).input("right", getRight)
       .item("joinType", joinSpec.getJoinType.toString)
-      .item("where", getExpressionString(
+      .item("where", FlinkRexUtil.getExpressionString(
         getCondition, inputRowType.getFieldNames.toList, None, preferExpressionFormat(pw)))
       .item("select", getRowType.getFieldNames.mkString(", "))
   }

--- a/flink-table/flink-table-planner/src/main/scala/org/apache/flink/table/planner/plan/nodes/physical/common/CommonPhysicalLookupJoin.scala
+++ b/flink-table/flink-table-planner/src/main/scala/org/apache/flink/table/planner/plan/nodes/physical/common/CommonPhysicalLookupJoin.scala
@@ -23,11 +23,13 @@ import org.apache.flink.table.functions.{AsyncTableFunction, TableFunction, User
 import org.apache.flink.table.planner.calcite.FlinkTypeFactory
 import org.apache.flink.table.planner.plan.nodes.FlinkRelNode
 import org.apache.flink.table.planner.plan.schema.{LegacyTableSourceTable, TableSourceTable}
+import org.apache.flink.table.planner.plan.utils.ExpressionFormat.ExpressionFormat
 import org.apache.flink.table.planner.plan.utils.LookupJoinUtil._
 import org.apache.flink.table.planner.plan.utils.PythonUtil.containsPythonCall
 import org.apache.flink.table.planner.plan.utils.RelExplainUtil.preferExpressionFormat
 import org.apache.flink.table.planner.plan.utils.{ExpressionFormat, FlinkRexUtil, JoinTypeUtil, LookupJoinUtil, RelExplainUtil}
 import org.apache.flink.table.runtime.types.PlannerTypeUtils
+
 import org.apache.calcite.plan.{RelOptCluster, RelOptTable, RelTraitSet}
 import org.apache.calcite.rel.`type`.{RelDataType, RelDataTypeField}
 import org.apache.calcite.rel.core.{JoinInfo, JoinRelType}
@@ -37,9 +39,8 @@ import org.apache.calcite.sql.SqlKind
 import org.apache.calcite.sql.fun.SqlStdOperatorTable
 import org.apache.calcite.sql.validate.SqlValidatorUtil
 import org.apache.calcite.util.mapping.IntPair
-import java.util.Collections
 
-import org.apache.flink.table.planner.plan.utils.ExpressionFormat.ExpressionFormat
+import java.util.Collections
 
 import scala.collection.JavaConverters._
 import scala.collection.mutable

--- a/flink-table/flink-table-planner/src/main/scala/org/apache/flink/table/planner/plan/nodes/physical/common/CommonPhysicalLookupJoin.scala
+++ b/flink-table/flink-table-planner/src/main/scala/org/apache/flink/table/planner/plan/nodes/physical/common/CommonPhysicalLookupJoin.scala
@@ -21,15 +21,13 @@ import org.apache.flink.table.api.TableException
 import org.apache.flink.table.catalog.ObjectIdentifier
 import org.apache.flink.table.functions.{AsyncTableFunction, TableFunction, UserDefinedFunction}
 import org.apache.flink.table.planner.calcite.FlinkTypeFactory
-import org.apache.flink.table.planner.plan.nodes.ExpressionFormat.ExpressionFormat
-import org.apache.flink.table.planner.plan.nodes.{ExpressionFormat, FlinkRelNode}
+import org.apache.flink.table.planner.plan.nodes.FlinkRelNode
 import org.apache.flink.table.planner.plan.schema.{LegacyTableSourceTable, TableSourceTable}
 import org.apache.flink.table.planner.plan.utils.LookupJoinUtil._
 import org.apache.flink.table.planner.plan.utils.PythonUtil.containsPythonCall
 import org.apache.flink.table.planner.plan.utils.RelExplainUtil.preferExpressionFormat
-import org.apache.flink.table.planner.plan.utils.{JoinTypeUtil, LookupJoinUtil, RelExplainUtil}
+import org.apache.flink.table.planner.plan.utils.{ExpressionFormat, FlinkRexUtil, JoinTypeUtil, LookupJoinUtil, RelExplainUtil}
 import org.apache.flink.table.runtime.types.PlannerTypeUtils
-
 import org.apache.calcite.plan.{RelOptCluster, RelOptTable, RelTraitSet}
 import org.apache.calcite.rel.`type`.{RelDataType, RelDataTypeField}
 import org.apache.calcite.rel.core.{JoinInfo, JoinRelType}
@@ -39,8 +37,9 @@ import org.apache.calcite.sql.SqlKind
 import org.apache.calcite.sql.fun.SqlStdOperatorTable
 import org.apache.calcite.sql.validate.SqlValidatorUtil
 import org.apache.calcite.util.mapping.IntPair
-
 import java.util.Collections
+
+import org.apache.flink.table.planner.plan.utils.ExpressionFormat.ExpressionFormat
 
 import scala.collection.JavaConverters._
 import scala.collection.mutable
@@ -141,7 +140,10 @@ abstract class CommonPhysicalLookupJoin(
     val resultFieldNames = getRowType.getFieldNames.asScala.toArray
     val whereString = calcOnTemporalTable match {
       case Some(calc) =>
-        RelExplainUtil.conditionToString(calc, getExpressionString, preferExpressionFormat(pw))
+        RelExplainUtil.conditionToString(
+          calc,
+          FlinkRexUtil.getExpressionString,
+          preferExpressionFormat(pw))
       case None => ""
     }
     val lookupKeys = allLookupKeys.map {
@@ -154,7 +156,7 @@ abstract class CommonPhysicalLookupJoin(
       case Some(calc) =>
         val rightSelect = RelExplainUtil.selectionToString(
           calc,
-          getExpressionString,
+          FlinkRexUtil.getExpressionString,
           preferExpressionFormat(pw))
         inputFieldNames.mkString(", ") + ", " + rightSelect
       case None =>
@@ -346,7 +348,11 @@ abstract class CommonPhysicalLookupJoin(
       joinCondition: Option[RexNode],
       expressionFormat: ExpressionFormat = ExpressionFormat.Prefix): String = joinCondition match {
     case Some(condition) =>
-      getExpressionString(condition, resultFieldNames.toList, None, expressionFormat)
+      FlinkRexUtil.getExpressionString(
+        condition,
+        resultFieldNames.toList,
+        None,
+        expressionFormat)
     case None => "N/A"
   }
 }

--- a/flink-table/flink-table-planner/src/main/scala/org/apache/flink/table/planner/plan/nodes/physical/stream/StreamPhysicalIntervalJoin.scala
+++ b/flink-table/flink-table-planner/src/main/scala/org/apache/flink/table/planner/plan/nodes/physical/stream/StreamPhysicalIntervalJoin.scala
@@ -25,13 +25,14 @@ import org.apache.flink.table.planner.plan.nodes.exec.spec.IntervalJoinSpec.Wind
 import org.apache.flink.table.planner.plan.nodes.exec.stream.StreamExecIntervalJoin
 import org.apache.flink.table.planner.plan.nodes.exec.{ExecNode, InputProperty}
 import org.apache.flink.table.planner.plan.nodes.physical.common.CommonPhysicalJoin
+import org.apache.flink.table.planner.plan.utils.FlinkRexUtil
 import org.apache.flink.table.planner.plan.utils.PythonUtil.containsPythonCall
 import org.apache.flink.table.planner.plan.utils.RelExplainUtil.preferExpressionFormat
+
 import org.apache.calcite.plan._
 import org.apache.calcite.rel.core.{Join, JoinRelType}
 import org.apache.calcite.rel.{RelNode, RelWriter}
 import org.apache.calcite.rex.RexNode
-import org.apache.flink.table.planner.plan.utils.FlinkRexUtil
 
 import scala.collection.JavaConversions._
 

--- a/flink-table/flink-table-planner/src/main/scala/org/apache/flink/table/planner/plan/nodes/physical/stream/StreamPhysicalIntervalJoin.scala
+++ b/flink-table/flink-table-planner/src/main/scala/org/apache/flink/table/planner/plan/nodes/physical/stream/StreamPhysicalIntervalJoin.scala
@@ -27,11 +27,11 @@ import org.apache.flink.table.planner.plan.nodes.exec.{ExecNode, InputProperty}
 import org.apache.flink.table.planner.plan.nodes.physical.common.CommonPhysicalJoin
 import org.apache.flink.table.planner.plan.utils.PythonUtil.containsPythonCall
 import org.apache.flink.table.planner.plan.utils.RelExplainUtil.preferExpressionFormat
-
 import org.apache.calcite.plan._
 import org.apache.calcite.rel.core.{Join, JoinRelType}
 import org.apache.calcite.rel.{RelNode, RelWriter}
 import org.apache.calcite.rex.RexNode
+import org.apache.flink.table.planner.plan.utils.FlinkRexUtil
 
 import scala.collection.JavaConversions._
 
@@ -81,7 +81,7 @@ class StreamPhysicalIntervalJoin(
       .input("right", right)
       .item("joinType", joinSpec.getJoinType)
       .item("windowBounds", windowBoundsDesc)
-      .item("where", getExpressionString(
+      .item("where", FlinkRexUtil.getExpressionString(
           originalCondition, getRowType.getFieldNames.toList, None, preferExpressionFormat(pw)))
       .item("select", getRowType.getFieldNames.mkString(", "))
   }

--- a/flink-table/flink-table-planner/src/main/scala/org/apache/flink/table/planner/plan/nodes/physical/stream/StreamPhysicalWatermarkAssigner.scala
+++ b/flink-table/flink-table-planner/src/main/scala/org/apache/flink/table/planner/plan/nodes/physical/stream/StreamPhysicalWatermarkAssigner.scala
@@ -22,11 +22,12 @@ import org.apache.flink.table.planner.calcite.FlinkTypeFactory
 import org.apache.flink.table.planner.plan.nodes.calcite.WatermarkAssigner
 import org.apache.flink.table.planner.plan.nodes.exec.stream.StreamExecWatermarkAssigner
 import org.apache.flink.table.planner.plan.nodes.exec.{ExecNode, InputProperty}
+import org.apache.flink.table.planner.plan.utils.FlinkRexUtil
 import org.apache.flink.table.planner.plan.utils.RelExplainUtil.preferExpressionFormat
+
 import org.apache.calcite.plan.{RelOptCluster, RelTraitSet}
 import org.apache.calcite.rel.{RelNode, RelWriter}
 import org.apache.calcite.rex.RexNode
-import org.apache.flink.table.planner.plan.utils.FlinkRexUtil
 
 import scala.collection.JavaConversions._
 

--- a/flink-table/flink-table-planner/src/main/scala/org/apache/flink/table/planner/plan/nodes/physical/stream/StreamPhysicalWatermarkAssigner.scala
+++ b/flink-table/flink-table-planner/src/main/scala/org/apache/flink/table/planner/plan/nodes/physical/stream/StreamPhysicalWatermarkAssigner.scala
@@ -21,12 +21,12 @@ package org.apache.flink.table.planner.plan.nodes.physical.stream
 import org.apache.flink.table.planner.calcite.FlinkTypeFactory
 import org.apache.flink.table.planner.plan.nodes.calcite.WatermarkAssigner
 import org.apache.flink.table.planner.plan.nodes.exec.stream.StreamExecWatermarkAssigner
-import org.apache.flink.table.planner.plan.nodes.exec.{InputProperty, ExecNode}
+import org.apache.flink.table.planner.plan.nodes.exec.{ExecNode, InputProperty}
 import org.apache.flink.table.planner.plan.utils.RelExplainUtil.preferExpressionFormat
-
 import org.apache.calcite.plan.{RelOptCluster, RelTraitSet}
 import org.apache.calcite.rel.{RelNode, RelWriter}
 import org.apache.calcite.rex.RexNode
+import org.apache.flink.table.planner.plan.utils.FlinkRexUtil
 
 import scala.collection.JavaConversions._
 
@@ -60,7 +60,7 @@ class StreamPhysicalWatermarkAssigner(
     val rowtimeFieldName = inFieldNames(rowtimeFieldIndex)
     pw.input("input", getInput())
       .item("rowtime", rowtimeFieldName)
-      .item("watermark", getExpressionString(
+      .item("watermark", FlinkRexUtil.getExpressionString(
         watermarkExpr,
         inFieldNames,
         None,

--- a/flink-table/flink-table-planner/src/main/scala/org/apache/flink/table/planner/plan/nodes/physical/stream/StreamPhysicalWindowJoin.scala
+++ b/flink-table/flink-table-planner/src/main/scala/org/apache/flink/table/planner/plan/nodes/physical/stream/StreamPhysicalWindowJoin.scala
@@ -20,17 +20,18 @@ package org.apache.flink.table.planner.plan.nodes.physical.stream
 import org.apache.flink.table.api.TableException
 import org.apache.flink.table.planner.calcite.FlinkTypeFactory
 import org.apache.flink.table.planner.plan.logical.WindowingStrategy
-import org.apache.flink.table.planner.plan.nodes.exec.{ExecNode, InputProperty}
 import org.apache.flink.table.planner.plan.nodes.exec.stream.StreamExecWindowJoin
+import org.apache.flink.table.planner.plan.nodes.exec.{ExecNode, InputProperty}
 import org.apache.flink.table.planner.plan.nodes.physical.common.CommonPhysicalJoin
+import org.apache.flink.table.planner.plan.utils.FlinkRexUtil
 import org.apache.flink.table.planner.plan.utils.PythonUtil.containsPythonCall
 import org.apache.flink.table.planner.plan.utils.RelExplainUtil.preferExpressionFormat
+
 import org.apache.calcite.plan.{RelOptCluster, RelTraitSet}
 import org.apache.calcite.rel._
 import org.apache.calcite.rel.core.{Join, JoinRelType}
 import org.apache.calcite.rex.RexNode
 import org.apache.calcite.util.Litmus
-import org.apache.flink.table.planner.plan.utils.FlinkRexUtil
 
 import scala.collection.JavaConversions._
 import scala.collection.JavaConverters._

--- a/flink-table/flink-table-planner/src/main/scala/org/apache/flink/table/planner/plan/nodes/physical/stream/StreamPhysicalWindowJoin.scala
+++ b/flink-table/flink-table-planner/src/main/scala/org/apache/flink/table/planner/plan/nodes/physical/stream/StreamPhysicalWindowJoin.scala
@@ -25,12 +25,12 @@ import org.apache.flink.table.planner.plan.nodes.exec.stream.StreamExecWindowJoi
 import org.apache.flink.table.planner.plan.nodes.physical.common.CommonPhysicalJoin
 import org.apache.flink.table.planner.plan.utils.PythonUtil.containsPythonCall
 import org.apache.flink.table.planner.plan.utils.RelExplainUtil.preferExpressionFormat
-
 import org.apache.calcite.plan.{RelOptCluster, RelTraitSet}
 import org.apache.calcite.rel._
 import org.apache.calcite.rel.core.{Join, JoinRelType}
 import org.apache.calcite.rex.RexNode
 import org.apache.calcite.util.Litmus
+import org.apache.flink.table.planner.plan.utils.FlinkRexUtil
 
 import scala.collection.JavaConversions._
 import scala.collection.JavaConverters._
@@ -99,7 +99,7 @@ class StreamPhysicalWindowJoin(
       .item("rightWindow", rightWindowing.toSummaryString(rightInputFieldNames))
       .item("joinType", joinSpec.getJoinType)
       .item("where",
-        getExpressionString(
+        FlinkRexUtil.getExpressionString(
           remainingCondition, inputRowType.getFieldNames.toList, None, preferExpressionFormat(pw)))
       .item("select", getRowType.getFieldNames.mkString(", "))
   }

--- a/flink-table/flink-table-planner/src/main/scala/org/apache/flink/table/planner/plan/schema/TableSourceTable.scala
+++ b/flink-table/flink-table-planner/src/main/scala/org/apache/flink/table/planner/plan/schema/TableSourceTable.scala
@@ -43,7 +43,8 @@ import java.util
  * @param tableSource The [[DynamicTableSource]] for which is converted to a Calcite Table
  * @param isStreamingMode A flag that tells if the current table is in stream mode
  * @param catalogTable Resolved catalog table where this table source table comes from
- * @param flinkContext The flink context abilitySpecs use to generate corresponding digests
+ * @param flinkContext The flink context which is used to generate extra digests based on
+ *                     abilitySpecs
  * @param abilitySpecs The abilitySpecs applied to the source
  */
 class TableSourceTable(

--- a/flink-table/flink-table-planner/src/main/scala/org/apache/flink/table/planner/plan/schema/TableSourceTable.scala
+++ b/flink-table/flink-table-planner/src/main/scala/org/apache/flink/table/planner/plan/schema/TableSourceTable.scala
@@ -20,14 +20,17 @@ package org.apache.flink.table.planner.plan.schema
 
 import org.apache.flink.table.catalog.{ObjectIdentifier, ResolvedCatalogTable}
 import org.apache.flink.table.connector.source.DynamicTableSource
-import org.apache.flink.table.planner.plan.abilities.source.SourceAbilitySpec
+import org.apache.flink.table.planner.plan.abilities.source.{SourceAbilityContext, SourceAbilitySpec}
 import org.apache.flink.table.planner.plan.stats.FlinkStatistic
-
 import com.google.common.collect.ImmutableList
 import org.apache.calcite.plan.RelOptSchema
 import org.apache.calcite.rel.`type`.RelDataType
-
 import java.util
+
+import org.apache.flink.table.planner.calcite.{FlinkContext, FlinkTypeFactory}
+import org.apache.flink.table.planner.connectors.DynamicSourceUtils
+import org.apache.flink.table.planner.utils.ShortcutUtils
+import org.apache.flink.table.types.logical.RowType
 
 /**
  * A [[FlinkPreparingTableBase]] implementation which defines the context variables
@@ -41,8 +44,8 @@ import java.util
  * @param tableSource The [[DynamicTableSource]] for which is converted to a Calcite Table
  * @param isStreamingMode A flag that tells if the current table is in stream mode
  * @param catalogTable Resolved catalog table where this table source table comes from
- * @param extraDigests The extra digests which will be added into `getQualifiedName`
- *                     as a part of table digest
+ * @param flinkContext The flink context
+ * @param abilitySpecs The abilitySpec applied to the source
  */
 class TableSourceTable(
     relOptSchema: RelOptSchema,
@@ -52,7 +55,7 @@ class TableSourceTable(
     val tableSource: DynamicTableSource,
     val isStreamingMode: Boolean,
     val catalogTable: ResolvedCatalogTable,
-    val extraDigests: Array[String] = Array.empty,
+    val flinkContext: FlinkContext,
     val abilitySpecs: Array[SourceAbilitySpec] = Array.empty)
   extends FlinkPreparingTableBase(
     relOptSchema,
@@ -65,8 +68,28 @@ class TableSourceTable(
 
   override def getQualifiedName: util.List[String] = {
     val builder = ImmutableList.builder[String]()
-        .addAll(super.getQualifiedName)
-    extraDigests.foreach(builder.add)
+      .addAll(super.getQualifiedName)
+
+    if(abilitySpecs != null && abilitySpecs.length != 0){
+//      var newProducedType = catalogTable
+//        .getResolvedSchema
+//        .toSourceRowDataType
+//        .getLogicalType
+//        .asInstanceOf[RowType]
+
+      var newProducedType = DynamicSourceUtils.createProducedType(
+        catalogTable.getResolvedSchema,
+        tableSource)
+
+      for (spec <- abilitySpecs) {
+        val sourceAbilityContext = new SourceAbilityContext(flinkContext, newProducedType)
+
+        builder.add(spec.getDigests(sourceAbilityContext))
+        if (spec.getProducedType.isPresent) {
+          newProducedType = spec.getProducedType.get
+        }
+      }
+    }
     builder.build()
   }
 
@@ -80,7 +103,6 @@ class TableSourceTable(
   def copy(
       newTableSource: DynamicTableSource,
       newRowType: RelDataType,
-      newExtraDigests: Array[String],
       newAbilitySpecs: Array[SourceAbilitySpec]): TableSourceTable = {
     new TableSourceTable(
       relOptSchema,
@@ -90,7 +112,7 @@ class TableSourceTable(
       newTableSource,
       isStreamingMode,
       catalogTable,
-      extraDigests ++ newExtraDigests,
+      flinkContext,
       abilitySpecs ++ newAbilitySpecs
     )
   }
@@ -105,7 +127,6 @@ class TableSourceTable(
   def copy(
       newTableSource: DynamicTableSource,
       newStatistic: FlinkStatistic,
-      newExtraDigests: Array[String],
       newAbilitySpecs: Array[SourceAbilitySpec]): TableSourceTable = {
     new TableSourceTable(
       relOptSchema,
@@ -115,7 +136,7 @@ class TableSourceTable(
       newTableSource,
       isStreamingMode,
       catalogTable,
-      extraDigests ++ newExtraDigests,
+      flinkContext,
       abilitySpecs ++ newAbilitySpecs)
   }
 }

--- a/flink-table/flink-table-planner/src/main/scala/org/apache/flink/table/planner/plan/utils/FlinkRexUtil.scala
+++ b/flink-table/flink-table-planner/src/main/scala/org/apache/flink/table/planner/plan/utils/FlinkRexUtil.scala
@@ -21,19 +21,19 @@ import org.apache.flink.annotation.Experimental
 import org.apache.flink.configuration.ConfigOption
 import org.apache.flink.configuration.ConfigOptions.key
 import org.apache.flink.table.planner.JList
-
 import com.google.common.base.Function
 import com.google.common.collect.{ImmutableList, Lists}
 import org.apache.calcite.plan.{RelOptPredicateList, RelOptUtil}
 import org.apache.calcite.rel.`type`.RelDataType
 import org.apache.calcite.rex._
-import org.apache.calcite.sql.SqlKind
+import org.apache.calcite.sql.{SqlAsOperator, SqlKind}
 import org.apache.calcite.sql.fun.SqlStdOperatorTable
 import org.apache.calcite.sql.fun.SqlStdOperatorTable._
 import org.apache.calcite.util.{ControlFlowException, ImmutableBitSet, Sarg, Util}
-
 import java.lang.Iterable
 import java.util
+
+import org.apache.flink.table.planner.plan.utils.ExpressionFormat.ExpressionFormat
 
 import scala.collection.JavaConversions._
 import scala.collection.mutable
@@ -451,4 +451,100 @@ object FlinkRexUtil {
     }
   }
 
+  def getExpressionString(
+        expr: RexNode,
+        inFields: Seq[String]): String = {
+    getExpressionString(expr, inFields, Option.empty[List[RexNode]], ExpressionFormat.Prefix)
+  }
+
+  def getExpressionString(
+        expr: RexNode,
+        inFields: Seq[String],
+        localExprsTable: Option[List[RexNode]],
+        expressionFormat: ExpressionFormat): String = {
+
+    expr match {
+      case pr: RexPatternFieldRef =>
+        val alpha = pr.getAlpha
+        val field = inFields(pr.getIndex)
+        s"$alpha.$field"
+
+      case i: RexInputRef =>
+        inFields(i.getIndex)
+
+      case l: RexLiteral =>
+        l.toString
+
+      case l: RexLocalRef if localExprsTable.isEmpty =>
+        throw new IllegalArgumentException("Encountered RexLocalRef without " +
+          "local expression table")
+
+      case l: RexLocalRef =>
+        val lExpr = localExprsTable.get(l.getIndex)
+        getExpressionString(lExpr, inFields, localExprsTable, expressionFormat)
+
+      case c: RexCall =>
+        val op = c.getOperator.toString
+        val ops = c.getOperands.map(
+          getExpressionString(_, inFields, localExprsTable, expressionFormat))
+        c.getOperator match {
+          case _: SqlAsOperator => ops.head
+          case _ =>
+            if (ops.size() == 1) {
+              val operand = ops.head
+              expressionFormat match {
+                case ExpressionFormat.Infix =>
+                  c.getKind match {
+                    case SqlKind.IS_FALSE | SqlKind.IS_NOT_FALSE | SqlKind.IS_TRUE
+                         | SqlKind.IS_NOT_TRUE | SqlKind.IS_UNKNOWN
+                         | SqlKind.IS_NULL | SqlKind.IS_NOT_NULL => s"$operand $op"
+                    case _ => s"$op($operand)"
+                  }
+                case ExpressionFormat.PostFix => s"$operand $op"
+                case ExpressionFormat.Prefix => s"$op($operand)"
+              }
+            } else {
+              c.getKind match {
+                case SqlKind.TIMES | SqlKind.DIVIDE | SqlKind.PLUS | SqlKind.MINUS
+                     | SqlKind.LESS_THAN | SqlKind.LESS_THAN_OR_EQUAL
+                     | SqlKind.GREATER_THAN | SqlKind.GREATER_THAN_OR_EQUAL
+                     | SqlKind.EQUALS | SqlKind.NOT_EQUALS
+                     | SqlKind.OR | SqlKind.AND =>
+                  expressionFormat match {
+                    case ExpressionFormat.Infix => s"(${ops.mkString(s" $op ")})"
+                    case ExpressionFormat.PostFix => s"(${ops.mkString(", ")})$op"
+                    case ExpressionFormat.Prefix => s"$op(${ops.mkString(", ")})"
+                  }
+                case _ => s"$op(${ops.mkString(", ")})"
+              }
+            }
+        }
+
+      case fa: RexFieldAccess =>
+        val referenceExpr = getExpressionString(
+          fa.getReferenceExpr,
+          inFields,
+          localExprsTable,
+          expressionFormat)
+        val field = fa.getField.getName
+        s"$referenceExpr.$field"
+      case cv: RexCorrelVariable =>
+        cv.toString
+      case _ =>
+        throw new IllegalArgumentException(s"Unknown expression type '${expr.getClass}': $expr")
+    }
+  }
+}
+
+/**
+ * Infix, Postfix and Prefix notations are three different but equivalent ways of writing
+ * expressions. It is easiest to demonstrate the differences by looking at examples of operators
+ * that take two operands.
+ * Infix notation: (X + Y)
+ * Postfix notation: (X Y) +
+ * Prefix notation: + (X Y)
+ */
+object ExpressionFormat extends Enumeration {
+  type ExpressionFormat = Value
+  val Infix, PostFix, Prefix = Value
 }

--- a/flink-table/flink-table-planner/src/main/scala/org/apache/flink/table/planner/plan/utils/FlinkRexUtil.scala
+++ b/flink-table/flink-table-planner/src/main/scala/org/apache/flink/table/planner/plan/utils/FlinkRexUtil.scala
@@ -21,19 +21,20 @@ import org.apache.flink.annotation.Experimental
 import org.apache.flink.configuration.ConfigOption
 import org.apache.flink.configuration.ConfigOptions.key
 import org.apache.flink.table.planner.JList
+import org.apache.flink.table.planner.plan.utils.ExpressionFormat.ExpressionFormat
+
 import com.google.common.base.Function
 import com.google.common.collect.{ImmutableList, Lists}
 import org.apache.calcite.plan.{RelOptPredicateList, RelOptUtil}
 import org.apache.calcite.rel.`type`.RelDataType
 import org.apache.calcite.rex._
-import org.apache.calcite.sql.{SqlAsOperator, SqlKind}
 import org.apache.calcite.sql.fun.SqlStdOperatorTable
 import org.apache.calcite.sql.fun.SqlStdOperatorTable._
+import org.apache.calcite.sql.{SqlAsOperator, SqlKind}
 import org.apache.calcite.util.{ControlFlowException, ImmutableBitSet, Sarg, Util}
-import java.lang.Iterable
-import java.util
 
-import org.apache.flink.table.planner.plan.utils.ExpressionFormat.ExpressionFormat
+import java.lang.{Iterable => JIterable}
+import java.util
 
 import scala.collection.JavaConversions._
 import scala.collection.mutable
@@ -189,10 +190,10 @@ object FlinkRexUtil {
       }
     }
 
-    private def and(nodes: Iterable[_ <: RexNode]): RexNode =
+    private def and(nodes: JIterable[_ <: RexNode]): RexNode =
       RexUtil.composeConjunction(rexBuilder, nodes, false)
 
-    private def or(nodes: Iterable[_ <: RexNode]): RexNode =
+    private def or(nodes: JIterable[_ <: RexNode]): RexNode =
       RexUtil.composeDisjunction(rexBuilder, nodes)
   }
 

--- a/flink-table/flink-table-planner/src/main/scala/org/apache/flink/table/planner/plan/utils/RelExplainUtil.scala
+++ b/flink-table/flink-table-planner/src/main/scala/org/apache/flink/table/planner/plan/utils/RelExplainUtil.scala
@@ -22,7 +22,9 @@ import org.apache.flink.table.functions.{AggregateFunction, UserDefinedFunction}
 import org.apache.flink.table.planner.CalcitePair
 import org.apache.flink.table.planner.expressions.PlannerNamedWindowProperty
 import org.apache.flink.table.planner.functions.aggfunctions.DeclarativeAggregateFunction
-import com.google.common.collect.{ImmutableList, ImmutableMap}
+import org.apache.flink.table.planner.plan.utils.ExpressionFormat.ExpressionFormat
+
+import com.google.common.collect.ImmutableMap
 import org.apache.calcite.rel.`type`.RelDataType
 import org.apache.calcite.rel.core.Window.Group
 import org.apache.calcite.rel.core.{AggregateCall, Window}
@@ -31,10 +33,9 @@ import org.apache.calcite.rel.{RelCollation, RelWriter}
 import org.apache.calcite.rex._
 import org.apache.calcite.sql.SqlKind
 import org.apache.calcite.sql.SqlMatchRecognize.AfterOption
+
 import java.util
 import java.util.{SortedSet => JSortedSet}
-
-import org.apache.flink.table.planner.plan.utils.ExpressionFormat.ExpressionFormat
 
 import scala.collection.JavaConversions._
 import scala.collection.mutable

--- a/flink-table/flink-table-planner/src/main/scala/org/apache/flink/table/planner/plan/utils/RelExplainUtil.scala
+++ b/flink-table/flink-table-planner/src/main/scala/org/apache/flink/table/planner/plan/utils/RelExplainUtil.scala
@@ -22,9 +22,6 @@ import org.apache.flink.table.functions.{AggregateFunction, UserDefinedFunction}
 import org.apache.flink.table.planner.CalcitePair
 import org.apache.flink.table.planner.expressions.PlannerNamedWindowProperty
 import org.apache.flink.table.planner.functions.aggfunctions.DeclarativeAggregateFunction
-import org.apache.flink.table.planner.plan.nodes.ExpressionFormat
-import org.apache.flink.table.planner.plan.nodes.ExpressionFormat.ExpressionFormat
-
 import com.google.common.collect.{ImmutableList, ImmutableMap}
 import org.apache.calcite.rel.`type`.RelDataType
 import org.apache.calcite.rel.core.Window.Group
@@ -34,9 +31,10 @@ import org.apache.calcite.rel.{RelCollation, RelWriter}
 import org.apache.calcite.rex._
 import org.apache.calcite.sql.SqlKind
 import org.apache.calcite.sql.SqlMatchRecognize.AfterOption
-
 import java.util
 import java.util.{SortedSet => JSortedSet}
+
+import org.apache.flink.table.planner.plan.utils.ExpressionFormat.ExpressionFormat
 
 import scala.collection.JavaConversions._
 import scala.collection.mutable

--- a/flink-table/flink-table-planner/src/main/scala/org/apache/flink/table/planner/plan/utils/WindowJoinUtil.scala
+++ b/flink-table/flink-table-planner/src/main/scala/org/apache/flink/table/planner/plan/utils/WindowJoinUtil.scala
@@ -18,9 +18,9 @@
 
 package org.apache.flink.table.planner.plan.utils
 
+import org.apache.flink.table.planner.plan.`trait`.RelWindowProperties
 import org.apache.flink.table.planner.plan.metadata.FlinkRelMetadataQuery
 import org.apache.flink.table.planner.plan.nodes.logical.FlinkLogicalJoin
-import org.apache.flink.table.planner.plan.`trait`.RelWindowProperties
 import org.apache.flink.table.planner.utils.Logging
 
 import org.apache.calcite.rex.{RexInputRef, RexNode, RexUtil}

--- a/flink-table/flink-table-planner/src/main/scala/org/apache/flink/table/planner/plan/utils/WindowJoinUtil.scala
+++ b/flink-table/flink-table-planner/src/main/scala/org/apache/flink/table/planner/plan/utils/WindowJoinUtil.scala
@@ -19,7 +19,6 @@
 package org.apache.flink.table.planner.plan.utils
 
 import org.apache.flink.table.planner.plan.metadata.FlinkRelMetadataQuery
-import org.apache.flink.table.planner.plan.nodes.ExpressionFormat
 import org.apache.flink.table.planner.plan.nodes.logical.FlinkLogicalJoin
 import org.apache.flink.table.planner.plan.`trait`.RelWindowProperties
 import org.apache.flink.table.planner.utils.Logging

--- a/flink-table/flink-table-planner/src/test/java/org/apache/flink/table/planner/plan/nodes/exec/serde/TemporalTableSourceSpecSerdeTest.java
+++ b/flink-table/flink-table-planner/src/test/java/org/apache/flink/table/planner/plan/nodes/exec/serde/TemporalTableSourceSpecSerdeTest.java
@@ -26,6 +26,7 @@ import org.apache.flink.table.catalog.ObjectIdentifier;
 import org.apache.flink.table.catalog.ResolvedCatalogTable;
 import org.apache.flink.table.catalog.ResolvedSchema;
 import org.apache.flink.table.connector.source.LookupTableSource;
+import org.apache.flink.table.planner.calcite.FlinkContext;
 import org.apache.flink.table.planner.calcite.FlinkContextImpl;
 import org.apache.flink.table.planner.calcite.FlinkTypeFactory;
 import org.apache.flink.table.planner.factories.TestValuesTableFactory;
@@ -59,17 +60,23 @@ import static org.junit.Assert.assertEquals;
 public class TemporalTableSourceSpecSerdeTest {
     private static final FlinkTypeFactory FACTORY = FlinkTypeFactory.INSTANCE();
 
+    private static final FlinkContext flinkContext = createFlinkContext();
+
+    private static FlinkContext createFlinkContext() {
+        return new FlinkContextImpl(
+                false,
+                TableConfig.getDefault(),
+                null,
+                CatalogManagerMocks.createEmptyCatalogManager(),
+                null);
+    }
+
     @Test
     public void testTemporalTableSourceSpecSerde() throws IOException {
         ClassLoader classLoader = Thread.currentThread().getContextClassLoader();
         SerdeContext serdeCtx =
                 new SerdeContext(
-                        new FlinkContextImpl(
-                                false,
-                                TableConfig.getDefault(),
-                                null,
-                                CatalogManagerMocks.createEmptyCatalogManager(),
-                                null),
+                        flinkContext,
                         classLoader,
                         FlinkTypeFactory.INSTANCE(),
                         FlinkSqlOperatorTable.instance());
@@ -123,12 +130,7 @@ public class TemporalTableSourceSpecSerdeTest {
                         lookupTableSource,
                         true,
                         resolvedCatalogTable,
-                        new FlinkContextImpl(
-                                false,
-                                TableConfig.getDefault(),
-                                null,
-                                CatalogManagerMocks.createEmptyCatalogManager(),
-                                null),
+                        flinkContext,
                         new SourceAbilitySpec[] {});
         TemporalTableSourceSpec temporalTableSourceSpec1 =
                 new TemporalTableSourceSpec(tableSourceTable1, new TableConfig());

--- a/flink-table/flink-table-planner/src/test/java/org/apache/flink/table/planner/plan/nodes/exec/serde/TemporalTableSourceSpecSerdeTest.java
+++ b/flink-table/flink-table-planner/src/test/java/org/apache/flink/table/planner/plan/nodes/exec/serde/TemporalTableSourceSpecSerdeTest.java
@@ -60,23 +60,20 @@ import static org.junit.Assert.assertEquals;
 public class TemporalTableSourceSpecSerdeTest {
     private static final FlinkTypeFactory FACTORY = FlinkTypeFactory.INSTANCE();
 
-    private static final FlinkContext flinkContext = createFlinkContext();
-
-    private static FlinkContext createFlinkContext() {
-        return new FlinkContextImpl(
-                false,
-                TableConfig.getDefault(),
-                null,
-                CatalogManagerMocks.createEmptyCatalogManager(),
-                null);
-    }
+    private static final FlinkContext FLINK_CONTEXT =
+            new FlinkContextImpl(
+                    false,
+                    TableConfig.getDefault(),
+                    null,
+                    CatalogManagerMocks.createEmptyCatalogManager(),
+                    null);
 
     @Test
     public void testTemporalTableSourceSpecSerde() throws IOException {
         ClassLoader classLoader = Thread.currentThread().getContextClassLoader();
         SerdeContext serdeCtx =
                 new SerdeContext(
-                        flinkContext,
+                        FLINK_CONTEXT,
                         classLoader,
                         FlinkTypeFactory.INSTANCE(),
                         FlinkSqlOperatorTable.instance());
@@ -130,7 +127,7 @@ public class TemporalTableSourceSpecSerdeTest {
                         lookupTableSource,
                         true,
                         resolvedCatalogTable,
-                        flinkContext,
+                        FLINK_CONTEXT,
                         new SourceAbilitySpec[] {});
         TemporalTableSourceSpec temporalTableSourceSpec1 =
                 new TemporalTableSourceSpec(tableSourceTable1, new TableConfig());

--- a/flink-table/flink-table-planner/src/test/java/org/apache/flink/table/planner/plan/nodes/exec/serde/TemporalTableSourceSpecSerdeTest.java
+++ b/flink-table/flink-table-planner/src/test/java/org/apache/flink/table/planner/plan/nodes/exec/serde/TemporalTableSourceSpecSerdeTest.java
@@ -123,7 +123,12 @@ public class TemporalTableSourceSpecSerdeTest {
                         lookupTableSource,
                         true,
                         resolvedCatalogTable,
-                        new String[] {},
+                        new FlinkContextImpl(
+                                false,
+                                TableConfig.getDefault(),
+                                null,
+                                CatalogManagerMocks.createEmptyCatalogManager(),
+                                null),
                         new SourceAbilitySpec[] {});
         TemporalTableSourceSpec temporalTableSourceSpec1 =
                 new TemporalTableSourceSpec(tableSourceTable1, new TableConfig());

--- a/flink-table/flink-table-planner/src/test/java/org/apache/flink/table/planner/plan/rules/logical/PushFilterIntoTableSourceScanRuleTestBase.java
+++ b/flink-table/flink-table-planner/src/test/java/org/apache/flink/table/planner/plan/rules/logical/PushFilterIntoTableSourceScanRuleTestBase.java
@@ -35,6 +35,11 @@ public abstract class PushFilterIntoTableSourceScanRuleTestBase extends TableTes
     }
 
     @Test
+    public void testCanPushDownWithCastConstant() {
+        util.verifyRelPlan("SELECT * FROM MyTable WHERE amount > cast(1.1 as int)");
+    }
+
+    @Test
     public void testCanPushDownWithVirtualColumn() {
         util.verifyRelPlan("SELECT * FROM VirtualTable WHERE amount > 2");
     }
@@ -43,6 +48,12 @@ public abstract class PushFilterIntoTableSourceScanRuleTestBase extends TableTes
     public void testCannotPushDown() {
         // TestFilterableTableSource only accept predicates with `amount`
         util.verifyRelPlan("SELECT * FROM MyTable WHERE price > 10");
+    }
+
+    @Test
+    public void testCannotPushDownWithCastConstant() {
+        // TestFilterableTableSource only accept predicates with `amount`
+        util.verifyRelPlan("SELECT * FROM MyTable WHERE price > cast(10.1 as int)");
     }
 
     @Test

--- a/flink-table/flink-table-planner/src/test/resources/org/apache/flink/table/filesystem/FileSystemTableSourceTest.xml
+++ b/flink-table/flink-table-planner/src/test/resources/org/apache/flink/table/filesystem/FileSystemTableSourceTest.xml
@@ -32,7 +32,7 @@ LogicalSink(table=[default_catalog.default_database.MySink], fields=[a, b, c])
       <![CDATA[
 Sink(table=[default_catalog.default_database.MySink], fields=[a, b, c])
 +- Calc(select=[a, b, c], where=[>(a, 10)])
-   +- TableSourceScan(table=[[default_catalog, default_database, MyTable, filter=[greaterThan(a, 10)]]], fields=[a, b, c])
+   +- TableSourceScan(table=[[default_catalog, default_database, MyTable, filter=[>(a, 10)]]], fields=[a, b, c])
 ]]>
     </Resource>
   </TestCase>

--- a/flink-table/flink-table-planner/src/test/resources/org/apache/flink/table/planner/plan/nodes/exec/stream/TableSourceJsonPlanTest_jsonplan/testFilterPushDown.out
+++ b/flink-table/flink-table-planner/src/test/resources/org/apache/flink/table/planner/plan/nodes/exec/stream/TableSourceJsonPlanTest_jsonplan/testFilterPushDown.out
@@ -62,7 +62,7 @@
         "c" : "VARCHAR(2147483647)"
       } ]
     },
-    "description" : "TableSourceScan(table=[[default_catalog, default_database, src, filter=[greaterThan(a, 0)]]], fields=[a, b, c])",
+    "description" : "TableSourceScan(table=[[default_catalog, default_database, src, filter=[>(a, 0)]]], fields=[a, b, c])",
     "inputProperties" : [ ]
   }, {
     "class" : "org.apache.flink.table.planner.plan.nodes.exec.stream.StreamExecSink",

--- a/flink-table/flink-table-planner/src/test/resources/org/apache/flink/table/planner/plan/nodes/exec/stream/TableSourceJsonPlanTest_jsonplan/testWatermarkPushDown.out
+++ b/flink-table/flink-table-planner/src/test/resources/org/apache/flink/table/planner/plan/nodes/exec/stream/TableSourceJsonPlanTest_jsonplan/testWatermarkPushDown.out
@@ -92,7 +92,7 @@
         }
       } ]
     },
-    "description" : "TableSourceScan(table=[[default_catalog, default_database, WatermarkTable, watermark=[-($2, 5000:INTERVAL SECOND)]]], fields=[a, b, c])",
+    "description" : "TableSourceScan(table=[[default_catalog, default_database, WatermarkTable, watermark=[-(c, 5000:INTERVAL SECOND)]]], fields=[a, b, c])",
     "inputProperties" : [ ]
   }, {
     "class" : "org.apache.flink.table.planner.plan.nodes.exec.stream.StreamExecSink",

--- a/flink-table/flink-table-planner/src/test/resources/org/apache/flink/table/planner/plan/rules/logical/PushFilterInCalcIntoTableSourceRuleTest.xml
+++ b/flink-table/flink-table-planner/src/test/resources/org/apache/flink/table/planner/plan/rules/logical/PushFilterInCalcIntoTableSourceRuleTest.xml
@@ -89,6 +89,24 @@ FlinkLogicalCalc(select=[name, id, amount, price], where=[SEARCH(name, Sarg[_UTF
 ]]>
     </Resource>
   </TestCase>
+  <TestCase name="testCannotPushDownWithCastConstant">
+    <Resource name="sql">
+      <![CDATA[SELECT * FROM MyTable WHERE price > cast(10.1 as int)]]>
+    </Resource>
+    <Resource name="ast">
+      <![CDATA[
+LogicalProject(name=[$0], id=[$1], amount=[$2], price=[$3])
++- LogicalFilter(condition=[>($3, 10.1)])
+   +- LogicalTableScan(table=[[default_catalog, default_database, MyTable]])
+]]>
+    </Resource>
+    <Resource name="optimized rel plan">
+      <![CDATA[
+FlinkLogicalCalc(select=[name, id, amount, price], where=[>(price, 10)])
++- FlinkLogicalTableSourceScan(table=[[default_catalog, default_database, MyTable, filter=[]]], fields=[name, id, amount, price])
+]]>
+    </Resource>
+  </TestCase>
   <TestCase name="testCannotPushDownWithVirtualColumn">
     <Resource name="sql">
       <![CDATA[SELECT * FROM VirtualTable WHERE price > 10]]>
@@ -121,7 +139,24 @@ LogicalProject(name=[$0], id=[$1], amount=[$2], price=[$3])
     </Resource>
     <Resource name="optimized rel plan">
       <![CDATA[
-FlinkLogicalTableSourceScan(table=[[default_catalog, default_database, MyTable, filter=[greaterThan(amount, 2)]]], fields=[name, id, amount, price])
+FlinkLogicalTableSourceScan(table=[[default_catalog, default_database, MyTable, filter=[>(amount, 2)]]], fields=[name, id, amount, price])
+]]>
+    </Resource>
+  </TestCase>
+  <TestCase name="testCanPushDownWithCastConstant">
+    <Resource name="sql">
+      <![CDATA[SELECT * FROM MyTable WHERE amount > cast(1.1 as int)]]>
+    </Resource>
+    <Resource name="ast">
+      <![CDATA[
+LogicalProject(name=[$0], id=[$1], amount=[$2], price=[$3])
++- LogicalFilter(condition=[>($2, 1.1)])
+   +- LogicalTableScan(table=[[default_catalog, default_database, MyTable]])
+]]>
+    </Resource>
+    <Resource name="optimized rel plan">
+      <![CDATA[
+FlinkLogicalTableSourceScan(table=[[default_catalog, default_database, MyTable, filter=[>(amount, 1)]]], fields=[name, id, amount, price])
 ]]>
     </Resource>
   </TestCase>
@@ -140,7 +175,7 @@ LogicalProject(name=[$0], id=[$1], amount=[$2], virtualField=[$3], price=[$4])
     <Resource name="optimized rel plan">
       <![CDATA[
 FlinkLogicalCalc(select=[name, id, amount, +(amount, 1) AS virtualField, price])
-+- FlinkLogicalTableSourceScan(table=[[default_catalog, default_database, VirtualTable, filter=[greaterThan(amount, 2)]]], fields=[name, id, amount, price])
++- FlinkLogicalTableSourceScan(table=[[default_catalog, default_database, VirtualTable, filter=[>(amount, 2)]]], fields=[name, id, amount, price])
 ]]>
     </Resource>
   </TestCase>
@@ -177,7 +212,7 @@ LogicalProject(name=[$0], id=[$1], amount=[$2], price=[$3])
     </Resource>
     <Resource name="optimized rel plan">
       <![CDATA[
-FlinkLogicalTableSourceScan(table=[[default_catalog, default_database, MyTable, filter=[and(greaterThan(amount, 2), lessThan(amount, 10))]]], fields=[name, id, amount, price])
+FlinkLogicalTableSourceScan(table=[[default_catalog, default_database, MyTable, filter=[and(>(amount, 2), <(amount, 10))]]], fields=[name, id, amount, price])
 ]]>
     </Resource>
   </TestCase>
@@ -196,7 +231,7 @@ LogicalProject(name=[$0], id=[$1], amount=[$2], virtualField=[$3], price=[$4])
     <Resource name="optimized rel plan">
       <![CDATA[
 FlinkLogicalCalc(select=[name, id, amount, +(amount, 1) AS virtualField, price])
-+- FlinkLogicalTableSourceScan(table=[[default_catalog, default_database, VirtualTable, filter=[and(greaterThan(amount, 2), lessThan(amount, 10))]]], fields=[name, id, amount, price])
++- FlinkLogicalTableSourceScan(table=[[default_catalog, default_database, VirtualTable, filter=[and(>(amount, 2), <(amount, 10))]]], fields=[name, id, amount, price])
 ]]>
     </Resource>
   </TestCase>
@@ -213,7 +248,7 @@ LogicalProject(a=[$0], b=[$1])
     </Resource>
     <Resource name="optimized rel plan">
       <![CDATA[
-FlinkLogicalTableSourceScan(table=[[default_catalog, default_database, MTable, filter=[and(equals(lower(a), 'foo'), equals(upper(b), 'bar'))]]], fields=[a, b])
+FlinkLogicalTableSourceScan(table=[[default_catalog, default_database, MTable, filter=[and(=(LOWER(a), _UTF-16LE'foo':VARCHAR(2147483647) CHARACTER SET "UTF-16LE"), =(UPPER(b), _UTF-16LE'bar':VARCHAR(2147483647) CHARACTER SET "UTF-16LE"))]]], fields=[a, b])
 ]]>
     </Resource>
   </TestCase>
@@ -231,7 +266,7 @@ LogicalProject(name=[$0], id=[$1], amount=[$2], price=[$3])
     <Resource name="optimized rel plan">
       <![CDATA[
 FlinkLogicalCalc(select=[name, id, amount, price], where=[>(price, 10)])
-+- FlinkLogicalTableSourceScan(table=[[default_catalog, default_database, MyTable, filter=[greaterThan(amount, 2)]]], fields=[name, id, amount, price])
++- FlinkLogicalTableSourceScan(table=[[default_catalog, default_database, MyTable, filter=[>(amount, 2)]]], fields=[name, id, amount, price])
 ]]>
     </Resource>
   </TestCase>
@@ -289,7 +324,7 @@ LogicalProject(name=[$0], id=[$1], amount=[$2], virtualField=[$3], price=[$4])
     <Resource name="optimized rel plan">
       <![CDATA[
 FlinkLogicalCalc(select=[name, id, amount, +(amount, 1) AS virtualField, price], where=[>(price, 10)])
-+- FlinkLogicalTableSourceScan(table=[[default_catalog, default_database, VirtualTable, filter=[greaterThan(amount, 2)]]], fields=[name, id, amount, price])
++- FlinkLogicalTableSourceScan(table=[[default_catalog, default_database, VirtualTable, filter=[>(amount, 2)]]], fields=[name, id, amount, price])
 ]]>
     </Resource>
   </TestCase>
@@ -308,7 +343,7 @@ LogicalProject(name=[$0], id=[$1], amount=[$2], price=[$3])
     <Resource name="optimized rel plan">
       <![CDATA[
 FlinkLogicalCalc(select=[name, id, amount, price], where=[AND(<(id, 100), >(CAST(amount), 10))])
-+- FlinkLogicalTableSourceScan(table=[[default_catalog, default_database, MyTable, filter=[greaterThan(amount, 2)]]], fields=[name, id, amount, price])
++- FlinkLogicalTableSourceScan(table=[[default_catalog, default_database, MyTable, filter=[>(amount, 2)]]], fields=[name, id, amount, price])
 ]]>
     </Resource>
   </TestCase>
@@ -345,7 +380,7 @@ LogicalProject(name=[$0], id=[$1], amount=[$2], price=[$3])
     <Resource name="optimized rel plan">
       <![CDATA[
 FlinkLogicalCalc(select=[name, id, amount, price], where=[<(myUdf(amount), 32)])
-+- FlinkLogicalTableSourceScan(table=[[default_catalog, default_database, MyTable, filter=[greaterThan(amount, 2)]]], fields=[name, id, amount, price])
++- FlinkLogicalTableSourceScan(table=[[default_catalog, default_database, MyTable, filter=[>(amount, 2)]]], fields=[name, id, amount, price])
 ]]>
     </Resource>
   </TestCase>

--- a/flink-table/flink-table-planner/src/test/resources/org/apache/flink/table/planner/plan/rules/logical/PushFilterIntoLegacyTableSourceScanRuleTest.xml
+++ b/flink-table/flink-table-planner/src/test/resources/org/apache/flink/table/planner/plan/rules/logical/PushFilterIntoLegacyTableSourceScanRuleTest.xml
@@ -94,6 +94,25 @@ LogicalProject(name=[$0], id=[$1], amount=[$2], price=[$3])
 ]]>
     </Resource>
   </TestCase>
+  <TestCase name="testCannotPushDownWithCastConstant">
+    <Resource name="sql">
+      <![CDATA[SELECT * FROM MyTable WHERE price > cast(10.1 as int)]]>
+    </Resource>
+    <Resource name="ast">
+      <![CDATA[
+LogicalProject(name=[$0], id=[$1], amount=[$2], price=[$3])
++- LogicalFilter(condition=[>($3, 10.1)])
+   +- LogicalTableScan(table=[[default_catalog, default_database, MyTable, source: [filterPushedDown=[false], filter=[]]]])
+]]>
+    </Resource>
+    <Resource name="optimized rel plan">
+      <![CDATA[
+LogicalProject(name=[$0], id=[$1], amount=[$2], price=[$3])
++- LogicalFilter(condition=[>($3, 10)])
+   +- LogicalTableScan(table=[[default_catalog, default_database, MyTable, source: [filterPushedDown=[true], filter=[]]]])
+]]>
+    </Resource>
+  </TestCase>
   <TestCase name="testCannotPushDownWithVirtualColumn">
     <Resource name="sql">
       <![CDATA[SELECT * FROM VirtualTable WHERE price > 10]]>
@@ -130,6 +149,24 @@ LogicalProject(name=[$0], id=[$1], amount=[$2], price=[$3])
       <![CDATA[
 LogicalProject(name=[$0], id=[$1], amount=[$2], price=[$3])
 +- LogicalTableScan(table=[[default_catalog, default_database, MyTable, source: [filterPushedDown=[true], filter=[greaterThan(amount, 2)]]]])
+]]>
+    </Resource>
+  </TestCase>
+  <TestCase name="testCanPushDownWithCastConstant">
+    <Resource name="sql">
+      <![CDATA[SELECT * FROM MyTable WHERE amount > cast(1.1 as int)]]>
+    </Resource>
+    <Resource name="ast">
+      <![CDATA[
+LogicalProject(name=[$0], id=[$1], amount=[$2], price=[$3])
++- LogicalFilter(condition=[>($2, 1.1)])
+   +- LogicalTableScan(table=[[default_catalog, default_database, MyTable, source: [filterPushedDown=[false], filter=[]]]])
+]]>
+    </Resource>
+    <Resource name="optimized rel plan">
+      <![CDATA[
+LogicalProject(name=[$0], id=[$1], amount=[$2], price=[$3])
++- LogicalTableScan(table=[[default_catalog, default_database, MyTable, source: [filterPushedDown=[true], filter=[greaterThan(amount, 1)]]]])
 ]]>
     </Resource>
   </TestCase>

--- a/flink-table/flink-table-planner/src/test/resources/org/apache/flink/table/planner/plan/rules/logical/PushFilterIntoTableSourceScanRuleTest.xml
+++ b/flink-table/flink-table-planner/src/test/resources/org/apache/flink/table/planner/plan/rules/logical/PushFilterIntoTableSourceScanRuleTest.xml
@@ -94,6 +94,25 @@ LogicalProject(name=[$0], id=[$1], amount=[$2], price=[$3])
 ]]>
     </Resource>
   </TestCase>
+  <TestCase name="testCannotPushDownWithCastConstant">
+    <Resource name="sql">
+      <![CDATA[SELECT * FROM MyTable WHERE price > cast(10.1 as int)]]>
+    </Resource>
+    <Resource name="ast">
+      <![CDATA[
+LogicalProject(name=[$0], id=[$1], amount=[$2], price=[$3])
++- LogicalFilter(condition=[>($3, 10.1)])
+   +- LogicalTableScan(table=[[default_catalog, default_database, MyTable]])
+]]>
+    </Resource>
+    <Resource name="optimized rel plan">
+      <![CDATA[
+LogicalProject(name=[$0], id=[$1], amount=[$2], price=[$3])
++- LogicalFilter(condition=[>($3, 10)])
+   +- LogicalTableScan(table=[[default_catalog, default_database, MyTable, filter=[]]])
+]]>
+    </Resource>
+  </TestCase>
   <TestCase name="testCannotPushDownWithVirtualColumn">
     <Resource name="sql">
       <![CDATA[SELECT * FROM VirtualTable WHERE price > 10]]>
@@ -129,7 +148,25 @@ LogicalProject(name=[$0], id=[$1], amount=[$2], price=[$3])
     <Resource name="optimized rel plan">
       <![CDATA[
 LogicalProject(name=[$0], id=[$1], amount=[$2], price=[$3])
-+- LogicalTableScan(table=[[default_catalog, default_database, MyTable, filter=[greaterThan(amount, 2)]]])
++- LogicalTableScan(table=[[default_catalog, default_database, MyTable, filter=[>(amount, 2)]]])
+]]>
+    </Resource>
+  </TestCase>
+  <TestCase name="testCanPushDownWithCastConstant">
+    <Resource name="sql">
+      <![CDATA[SELECT * FROM MyTable WHERE amount > cast(1.1 as int)]]>
+    </Resource>
+    <Resource name="ast">
+      <![CDATA[
+LogicalProject(name=[$0], id=[$1], amount=[$2], price=[$3])
++- LogicalFilter(condition=[>($2, 1.1)])
+   +- LogicalTableScan(table=[[default_catalog, default_database, MyTable]])
+]]>
+    </Resource>
+    <Resource name="optimized rel plan">
+      <![CDATA[
+LogicalProject(name=[$0], id=[$1], amount=[$2], price=[$3])
++- LogicalTableScan(table=[[default_catalog, default_database, MyTable, filter=[>(amount, 1)]]])
 ]]>
     </Resource>
   </TestCase>
@@ -149,7 +186,7 @@ LogicalProject(name=[$0], id=[$1], amount=[$2], virtualField=[$3], price=[$4])
       <![CDATA[
 LogicalProject(name=[$0], id=[$1], amount=[$2], virtualField=[$3], price=[$4])
 +- LogicalProject(name=[$0], id=[$1], amount=[$2], virtualField=[+($2, 1)], price=[$3])
-   +- LogicalTableScan(table=[[default_catalog, default_database, VirtualTable, filter=[greaterThan(amount, 2)]]])
+   +- LogicalTableScan(table=[[default_catalog, default_database, VirtualTable, filter=[>(amount, 2)]]])
 ]]>
     </Resource>
   </TestCase>
@@ -167,7 +204,7 @@ LogicalProject(name=[$0], id=[$1], amount=[$2], price=[$3])
     <Resource name="optimized rel plan">
       <![CDATA[
 LogicalProject(name=[$0], id=[$1], amount=[$2], price=[$3])
-+- LogicalTableScan(table=[[default_catalog, default_database, MyTable, filter=[and(greaterThan(amount, 2), lessThan(amount, 10))]]])
++- LogicalTableScan(table=[[default_catalog, default_database, MyTable, filter=[and(>(amount, 2), <(amount, 10))]]])
 ]]>
     </Resource>
   </TestCase>
@@ -187,7 +224,7 @@ LogicalProject(name=[$0], id=[$1], amount=[$2], virtualField=[$3], price=[$4])
       <![CDATA[
 LogicalProject(name=[$0], id=[$1], amount=[$2], virtualField=[$3], price=[$4])
 +- LogicalProject(name=[$0], id=[$1], amount=[$2], virtualField=[+($2, 1)], price=[$3])
-   +- LogicalTableScan(table=[[default_catalog, default_database, VirtualTable, filter=[and(greaterThan(amount, 2), lessThan(amount, 10))]]])
+   +- LogicalTableScan(table=[[default_catalog, default_database, VirtualTable, filter=[and(>(amount, 2), <(amount, 10))]]])
 ]]>
     </Resource>
   </TestCase>
@@ -205,7 +242,7 @@ LogicalProject(a=[$0], b=[$1])
     <Resource name="optimized rel plan">
       <![CDATA[
 LogicalProject(a=[$0], b=[$1])
-+- LogicalTableScan(table=[[default_catalog, default_database, MTable, filter=[and(equals(lower(a), 'foo'), equals(upper(b), 'bar'))]]])
++- LogicalTableScan(table=[[default_catalog, default_database, MTable, filter=[and(=(LOWER(a), _UTF-16LE'foo':VARCHAR(2147483647) CHARACTER SET "UTF-16LE"), =(UPPER(b), _UTF-16LE'bar':VARCHAR(2147483647) CHARACTER SET "UTF-16LE"))]]])
 ]]>
     </Resource>
   </TestCase>
@@ -224,7 +261,7 @@ LogicalProject(name=[$0], id=[$1], amount=[$2], price=[$3])
       <![CDATA[
 LogicalProject(name=[$0], id=[$1], amount=[$2], price=[$3])
 +- LogicalFilter(condition=[>($3, 10)])
-   +- LogicalTableScan(table=[[default_catalog, default_database, MyTable, filter=[greaterThan(amount, 2)]]])
+   +- LogicalTableScan(table=[[default_catalog, default_database, MyTable, filter=[>(amount, 2)]]])
 ]]>
     </Resource>
   </TestCase>
@@ -286,7 +323,7 @@ LogicalProject(name=[$0], id=[$1], amount=[$2], virtualField=[$3], price=[$4])
 LogicalProject(name=[$0], id=[$1], amount=[$2], virtualField=[$3], price=[$4])
 +- LogicalProject(name=[$0], id=[$1], amount=[$2], virtualField=[+($2, 1)], price=[$3])
    +- LogicalFilter(condition=[>($3, 10)])
-      +- LogicalTableScan(table=[[default_catalog, default_database, VirtualTable, filter=[greaterThan(amount, 2)]]])
+      +- LogicalTableScan(table=[[default_catalog, default_database, VirtualTable, filter=[>(amount, 2)]]])
 ]]>
     </Resource>
   </TestCase>
@@ -306,7 +343,7 @@ LogicalProject(name=[$0], id=[$1], amount=[$2], price=[$3])
       <![CDATA[
 LogicalProject(name=[$0], id=[$1], amount=[$2], price=[$3])
 +- LogicalFilter(condition=[AND(<($1, 100), >(CAST($2):BIGINT, 10))])
-   +- LogicalTableScan(table=[[default_catalog, default_database, MyTable, filter=[greaterThan(amount, 2)]]])
+   +- LogicalTableScan(table=[[default_catalog, default_database, MyTable, filter=[>(amount, 2)]]])
 ]]>
     </Resource>
   </TestCase>
@@ -346,7 +383,7 @@ LogicalProject(name=[$0], id=[$1], amount=[$2], price=[$3])
       <![CDATA[
 LogicalProject(name=[$0], id=[$1], amount=[$2], price=[$3])
 +- LogicalFilter(condition=[<(myUdf($2), 32)])
-   +- LogicalTableScan(table=[[default_catalog, default_database, MyTable, filter=[greaterThan(amount, 2)]]])
+   +- LogicalTableScan(table=[[default_catalog, default_database, MyTable, filter=[>(amount, 2)]]])
 ]]>
     </Resource>
   </TestCase>

--- a/flink-table/flink-table-planner/src/test/resources/org/apache/flink/table/planner/plan/rules/logical/PushWatermarkIntoTableSourceScanRuleTest.xml
+++ b/flink-table/flink-table-planner/src/test/resources/org/apache/flink/table/planner/plan/rules/logical/PushWatermarkIntoTableSourceScanRuleTest.xml
@@ -30,7 +30,7 @@ LogicalProject(a=[$0], c=[$2])
     <Resource name="optimized rel plan">
       <![CDATA[
 FlinkLogicalCalc(select=[a, c])
-+- FlinkLogicalTableSourceScan(table=[[default_catalog, default_database, MyTable, watermark=[-($2, 5000:INTERVAL SECOND)]]], fields=[a, b, c])
++- FlinkLogicalTableSourceScan(table=[[default_catalog, default_database, MyTable, watermark=[-(c, 5000:INTERVAL SECOND)]]], fields=[a, b, c])
 ]]>
     </Resource>
   </TestCase>
@@ -50,7 +50,7 @@ LogicalProject(a=[$0], b=[$1], c=[$2], d=[$3])
       <![CDATA[
 FlinkLogicalCalc(select=[a, b, c, d])
 +- FlinkLogicalCalc(select=[a, b, c, Reinterpret(+(c, 5000:INTERVAL SECOND)) AS d])
-   +- FlinkLogicalTableSourceScan(table=[[default_catalog, default_database, MyTable, watermark=[-(+($2, 5000:INTERVAL SECOND), 5000:INTERVAL SECOND)]]], fields=[a, b, c])
+   +- FlinkLogicalTableSourceScan(table=[[default_catalog, default_database, MyTable, watermark=[-(+(c, 5000:INTERVAL SECOND), 5000:INTERVAL SECOND)]]], fields=[a, b, c])
 ]]>
     </Resource>
   </TestCase>
@@ -72,7 +72,7 @@ LogicalProject(a=[$0], b=[$1])
 FlinkLogicalCalc(select=[a, b])
 +- FlinkLogicalCalc(select=[a, b, c, d], where=[>(d, TO_TIMESTAMP(_UTF-16LE'2020-10-09 12:12:12'))])
    +- FlinkLogicalCalc(select=[a, b, c, Reinterpret(+(c, 5000:INTERVAL SECOND)) AS d])
-      +- FlinkLogicalTableSourceScan(table=[[default_catalog, default_database, MyTable, watermark=[-(+($2, 5000:INTERVAL SECOND), 5000:INTERVAL SECOND)]]], fields=[a, b, c])
+      +- FlinkLogicalTableSourceScan(table=[[default_catalog, default_database, MyTable, watermark=[-(+(c, 5000:INTERVAL SECOND), 5000:INTERVAL SECOND)]]], fields=[a, b, c])
 ]]>
     </Resource>
   </TestCase>
@@ -92,7 +92,7 @@ LogicalProject(a=[$0], b=[$1], c=[$2])
       <![CDATA[
 FlinkLogicalCalc(select=[a, b, c])
 +- FlinkLogicalCalc(select=[a, b, Reinterpret(TO_TIMESTAMP(a, b)) AS c])
-   +- FlinkLogicalTableSourceScan(table=[[default_catalog, default_database, MyTable, watermark=[-(TO_TIMESTAMP($0, $1), 5000:INTERVAL SECOND)]]], fields=[a, b])
+   +- FlinkLogicalTableSourceScan(table=[[default_catalog, default_database, MyTable, watermark=[-(TO_TIMESTAMP(a, b), 5000:INTERVAL SECOND)]]], fields=[a, b])
 ]]>
     </Resource>
   </TestCase>
@@ -112,7 +112,7 @@ LogicalProject(a=[$0], b=[$1], c=[$2], metadata=[$3], computed=[$4])
       <![CDATA[
 FlinkLogicalCalc(select=[a, b, c, metadata, computed])
 +- FlinkLogicalCalc(select=[a, b, Reinterpret(c) AS c, CAST(metadata_2) AS metadata, +(CAST(metadata_2), b) AS computed])
-   +- FlinkLogicalTableSourceScan(table=[[default_catalog, default_database, MyTable, watermark=[-($2, CAST(+(CAST($3):BIGINT, +(CAST($3):BIGINT, $1))):INTERVAL SECOND)]]], fields=[a, b, c, metadata_2])
+   +- FlinkLogicalTableSourceScan(table=[[default_catalog, default_database, MyTable, watermark=[-(c, CAST(+(CAST(metadata_2), +(CAST(metadata_2), b))))]]], fields=[a, b, c, metadata_2])
 ]]>
     </Resource>
   </TestCase>
@@ -132,7 +132,7 @@ LogicalProject(a=[$0], b=[$1], c=[$2], g=[$3])
       <![CDATA[
 FlinkLogicalCalc(select=[a, b, c, g])
 +- FlinkLogicalCalc(select=[a, b, c, Reinterpret(c.d.f) AS g])
-   +- FlinkLogicalTableSourceScan(table=[[default_catalog, default_database, MyTable, watermark=[-($2.d.f, 5000:INTERVAL SECOND)]]], fields=[a, b, c])
+   +- FlinkLogicalTableSourceScan(table=[[default_catalog, default_database, MyTable, watermark=[-(c.d.f, 5000:INTERVAL SECOND)]]], fields=[a, b, c])
 ]]>
     </Resource>
   </TestCase>
@@ -152,7 +152,7 @@ LogicalProject(a=[$0], b=[$1], c=[$2], e=[$3])
       <![CDATA[
 FlinkLogicalCalc(select=[a, b, c, e])
 +- FlinkLogicalCalc(select=[a, b, c, Reinterpret(c.d) AS e])
-   +- FlinkLogicalTableSourceScan(table=[[default_catalog, default_database, MyTable, watermark=[-($2.d, 5000:INTERVAL SECOND)]]], fields=[a, b, c])
+   +- FlinkLogicalTableSourceScan(table=[[default_catalog, default_database, MyTable, watermark=[-(c.d, 5000:INTERVAL SECOND)]]], fields=[a, b, c])
 ]]>
     </Resource>
   </TestCase>
@@ -170,7 +170,7 @@ LogicalProject(a=[$0], c=[$2])
     <Resource name="optimized rel plan">
       <![CDATA[
 FlinkLogicalCalc(select=[a, c])
-+- FlinkLogicalTableSourceScan(table=[[default_catalog, default_database, MyTable, watermark=[-($2, 5000:INTERVAL SECOND)], idletimeout=[1000]]], fields=[a, b, c])
++- FlinkLogicalTableSourceScan(table=[[default_catalog, default_database, MyTable, watermark=[-(c, 5000:INTERVAL SECOND)], idletimeout=[1000]]], fields=[a, b, c])
 ]]>
     </Resource>
   </TestCase>
@@ -190,7 +190,7 @@ LogicalProject(a=[$0], b=[$1], c=[$2], d=[$3])
       <![CDATA[
 FlinkLogicalCalc(select=[a, b, c, d])
 +- FlinkLogicalCalc(select=[a, b, c, Reinterpret(func(c, a)) AS d])
-   +- FlinkLogicalTableSourceScan(table=[[default_catalog, default_database, MyTable, watermark=[func(func(func($2, $0), $0), $0)]]], fields=[a, b, c])
+   +- FlinkLogicalTableSourceScan(table=[[default_catalog, default_database, MyTable, watermark=[func(func(func(c, a), a), a)]]], fields=[a, b, c])
 ]]>
     </Resource>
   </TestCase>

--- a/flink-table/flink-table-planner/src/test/resources/org/apache/flink/table/planner/plan/stream/sql/FilterableSourceTest.xml
+++ b/flink-table/flink-table-planner/src/test/resources/org/apache/flink/table/planner/plan/stream/sql/FilterableSourceTest.xml
@@ -30,7 +30,7 @@ LogicalProject(a=[$0], b=[$1], c=[$2], d=[$3])
 		</Resource>
 		<Resource name="optimized exec plan">
 			<![CDATA[
-TableSourceScan(table=[[default_catalog, default_database, MyTable, watermark=[$2], filter=[equals(lower(d), 'hello')]]], fields=[a, b, c, d])
+TableSourceScan(table=[[default_catalog, default_database, MyTable, watermark=[c], filter=[=(LOWER(d), _UTF-16LE'hello':VARCHAR(2147483647) CHARACTER SET "UTF-16LE")]]], fields=[a, b, c, d])
 ]]>
 		</Resource>
 	</TestCase>
@@ -49,7 +49,7 @@ LogicalProject(a=[$0], b=[$1], c=[$2], d=[$3])
 		<Resource name="optimized exec plan">
 			<![CDATA[
 Calc(select=[a, b, c, d], where=[d IS NOT NULL])
-+- TableSourceScan(table=[[default_catalog, default_database, MyTable, watermark=[$2], filter=[equals(lower(d), 'h')]]], fields=[a, b, c, d])
++- TableSourceScan(table=[[default_catalog, default_database, MyTable, watermark=[c], filter=[=(LOWER(d), _UTF-16LE'h':VARCHAR(2147483647) CHARACTER SET "UTF-16LE")]]], fields=[a, b, c, d])
 ]]>
 		</Resource>
 	</TestCase>
@@ -68,7 +68,7 @@ LogicalProject(a=[$0], b=[$1], c=[$2], d=[$3])
 		<Resource name="optimized exec plan">
 			<![CDATA[
 Calc(select=[a, b, c, d], where=[d IS NOT NULL])
-+- TableSourceScan(table=[[default_catalog, default_database, MyTable, watermark=[$2], filter=[equals(lower(d), 'h')]]], fields=[a, b, c, d])
++- TableSourceScan(table=[[default_catalog, default_database, MyTable, watermark=[$2], filter=[equals(LOWER(d), 'h')]]], fields=[a, b, c, d])
 ]]>
 		</Resource>
 	</TestCase>
@@ -107,7 +107,7 @@ LogicalProject(event_time=[$0], name=[$1], lowercase_name=[$2])
 		<Resource name="optimized exec plan">
 			<![CDATA[
 Calc(select=[Reinterpret(event_time) AS event_time, name, CAST(_UTF-16LE'foo':VARCHAR(2147483647) CHARACTER SET "UTF-16LE") AS lowercase_name])
-+- TableSourceScan(table=[[default_catalog, default_database, WithWatermark, watermark=[$0], filter=[equals(lower(name), 'foo')]]], fields=[event_time, name])
++- TableSourceScan(table=[[default_catalog, default_database, WithWatermark, watermark=[event_time], filter=[=(LOWER(name), _UTF-16LE'foo':VARCHAR(2147483647) CHARACTER SET "UTF-16LE")]]], fields=[event_time, name])
 ]]>
 		</Resource>
 	</TestCase>
@@ -124,7 +124,7 @@ LogicalProject(name=[$0], event_time=[$1])
 		</Resource>
 		<Resource name="optimized exec plan">
 			<![CDATA[
-TableSourceScan(table=[[default_catalog, default_database, NoWatermark, filter=[and(equals(lower(name), 'foo'), equals(upper(name), 'FOO'))]]], fields=[name, event_time])
+TableSourceScan(table=[[default_catalog, default_database, NoWatermark, filter=[and(=(LOWER(name), _UTF-16LE'foo':VARCHAR(2147483647) CHARACTER SET "UTF-16LE"), =(UPPER(name), _UTF-16LE'FOO':VARCHAR(2147483647) CHARACTER SET "UTF-16LE"))]]], fields=[name, event_time])
 ]]>
 		</Resource>
 	</TestCase>
@@ -144,7 +144,7 @@ LogicalProject(a=[$0], b=[$1], c=[$2], d=[$3], f=[$4])
 		<Resource name="optimized exec plan">
 			<![CDATA[
 Calc(select=[a, b, Reinterpret(c) AS c, func(c, a) AS d, f])
-+- TableSourceScan(table=[[default_catalog, default_database, UdfTable, watermark=[func(func(func($2, $0), $0), $0)], filter=[equals(upper(f), 'welcome')]]], fields=[a, b, c, f])
++- TableSourceScan(table=[[default_catalog, default_database, UdfTable, watermark=[func(func(func(c, a), a), a)], filter=[=(UPPER(f), _UTF-16LE'welcome':VARCHAR(2147483647) CHARACTER SET "UTF-16LE")]]], fields=[a, b, c, f])
 ]]>
 		</Resource>
 	</TestCase>
@@ -164,7 +164,7 @@ LogicalProject(a=[$0], b=[$1], c=[$2], d=[$3], f=[$4])
 		<Resource name="optimized exec plan">
 			<![CDATA[
 Calc(select=[a, b, Reinterpret(c) AS c, func(c, a) AS d, f])
-+- TableSourceScan(table=[[default_catalog, default_database, UdfTable, watermark=[func(func(func($2, $0), $0), $0)], filter=[equals(upper(f), 'welcome')]]], fields=[a, b, c, f])
++- TableSourceScan(table=[[default_catalog, default_database, UdfTable, watermark=[func(func(func(c, a), a), a)], filter=[=(UPPER(f), _UTF-16LE'welcome':VARCHAR(2147483647) CHARACTER SET "UTF-16LE")]]], fields=[a, b, c, f])
 ]]>
 		</Resource>
 	</TestCase>
@@ -182,7 +182,7 @@ LogicalProject(name=[$0], event_time=[$1])
 		<Resource name="optimized exec plan">
 			<![CDATA[
 Calc(select=[name, event_time], where=[name IS NOT NULL])
-+- TableSourceScan(table=[[default_catalog, default_database, NoWatermark, filter=[equals(lower(name), 'foo')]]], fields=[name, event_time])
++- TableSourceScan(table=[[default_catalog, default_database, NoWatermark, filter=[=(LOWER(name), _UTF-16LE'foo':VARCHAR(2147483647) CHARACTER SET "UTF-16LE")]]], fields=[name, event_time])
 ]]>
 		</Resource>
 	</TestCase>

--- a/flink-table/flink-table-planner/src/test/resources/org/apache/flink/table/planner/plan/stream/sql/FilterableSourceTest.xml
+++ b/flink-table/flink-table-planner/src/test/resources/org/apache/flink/table/planner/plan/stream/sql/FilterableSourceTest.xml
@@ -87,7 +87,7 @@ LogicalProject(a=[$0], b=[$1], c=[$2], d=[$3])
 		<Resource name="optimized exec plan">
 			<![CDATA[
 Calc(select=[a, b, c, d], where=[(b > 5)])
-+- TableSourceScan(table=[[default_catalog, default_database, MyTable, watermark=[$2], filter=[]]], fields=[a, b, c, d])
++- TableSourceScan(table=[[default_catalog, default_database, MyTable, watermark=[c], filter=[]]], fields=[a, b, c, d])
 ]]>
 		</Resource>
 	</TestCase>

--- a/flink-table/flink-table-planner/src/test/resources/org/apache/flink/table/planner/plan/stream/sql/SourceWatermarkTest.xml
+++ b/flink-table/flink-table-planner/src/test/resources/org/apache/flink/table/planner/plan/stream/sql/SourceWatermarkTest.xml
@@ -31,7 +31,7 @@ LogicalProject(EXPR$0=[-($0, $1)])
     <Resource name="optimized exec plan">
       <![CDATA[
 Calc(select=[(a - b) AS EXPR$0])
-+- TableSourceScan(table=[[default_catalog, default_database, UdfTable, watermark=[func(func(func($2, $0), $0), $0)]]], fields=[a, b, c])
++- TableSourceScan(table=[[default_catalog, default_database, UdfTable, watermark=[func(func(func(c, a), a), a)]]], fields=[a, b, c])
 ]]>
     </Resource>
   </TestCase>
@@ -49,7 +49,7 @@ LogicalProject(a=[$0], b=[$1], ts=[$5])
     </Resource>
     <Resource name="optimized exec plan">
       <![CDATA[
-TableSourceScan(table=[[default_catalog, default_database, t1, project=[a, b, t], metadata=[], watermark=[-($2, 10000:INTERVAL SECOND)]]], fields=[a, b, t])
+TableSourceScan(table=[[default_catalog, default_database, t1, project=[a, b, t], metadata=[], watermark=[-(t, 10000:INTERVAL SECOND)]]], fields=[a, b, t])
 ]]>
     </Resource>
   </TestCase>
@@ -67,7 +67,7 @@ LogicalProject(a=[$0], b=[$1], c=[$2])
     </Resource>
     <Resource name="optimized exec plan">
       <![CDATA[
-TableSourceScan(table=[[default_catalog, default_database, VirtualTable, watermark=[-(+($2, 5000:INTERVAL SECOND), 5000:INTERVAL SECOND)]]], fields=[a, b, c])
+TableSourceScan(table=[[default_catalog, default_database, VirtualTable, watermark=[-(+(c, 5000:INTERVAL SECOND), 5000:INTERVAL SECOND)]]], fields=[a, b, c])
 ]]>
     </Resource>
   </TestCase>
@@ -87,7 +87,7 @@ LogicalProject(a=[$0], b=[$1])
     <Resource name="optimized exec plan">
       <![CDATA[
 Calc(select=[a, b], where=[(b > 10)])
-+- TableSourceScan(table=[[default_catalog, default_database, VirtualTable, watermark=[-(+($2, 5000:INTERVAL SECOND), 5000:INTERVAL SECOND)], filter=[]]], fields=[a, b, c])
++- TableSourceScan(table=[[default_catalog, default_database, VirtualTable, watermark=[-(+(c, 5000:INTERVAL SECOND), 5000:INTERVAL SECOND)], filter=[]]], fields=[a, b, c])
 ]]>
     </Resource>
   </TestCase>
@@ -106,7 +106,7 @@ LogicalProject(a=[$0], b=[$1], rowtime=[$2])
     <Resource name="optimized exec plan">
       <![CDATA[
 Calc(select=[a, b, Reinterpret(TO_TIMESTAMP_LTZ(b, 0)) AS rowtime])
-+- TableSourceScan(table=[[default_catalog, default_database, timeTestTable, watermark=[TO_TIMESTAMP_LTZ($1, 0)]]], fields=[a, b])
++- TableSourceScan(table=[[default_catalog, default_database, timeTestTable, watermark=[TO_TIMESTAMP_LTZ(b, 0)]]], fields=[a, b])
 ]]>
     </Resource>
   </TestCase>
@@ -125,7 +125,7 @@ LogicalProject(e=[$2.d.e], d=[$2.d])
     <Resource name="optimized exec plan">
       <![CDATA[
 Calc(select=[c.d.e AS e, c.d AS d])
-+- TableSourceScan(table=[[default_catalog, default_database, NestedTable, project=[c], metadata=[], watermark=[-($0.d.f, 5000:INTERVAL SECOND)]]], fields=[c])
++- TableSourceScan(table=[[default_catalog, default_database, NestedTable, project=[c], metadata=[], watermark=[-(c.d.f, 5000:INTERVAL SECOND)]]], fields=[c])
 ]]>
     </Resource>
   </TestCase>
@@ -144,7 +144,7 @@ LogicalProject(a=[$0], b=[$1])
     <Resource name="optimized exec plan">
       <![CDATA[
 Calc(select=[a, b])
-+- TableSourceScan(table=[[default_catalog, default_database, MyLtzTable, project=[a, b, originTime], metadata=[originTime], watermark=[TO_TIMESTAMP_LTZ($2, 3)]]], fields=[a, b, originTime])
++- TableSourceScan(table=[[default_catalog, default_database, MyLtzTable, project=[a, b, originTime], metadata=[originTime], watermark=[TO_TIMESTAMP_LTZ(originTime, 3)]]], fields=[a, b, originTime])
 ]]>
     </Resource>
   </TestCase>
@@ -163,7 +163,7 @@ LogicalProject(a=[$0], b=[$1], EXPR$2=[EXTRACT(FLAG(SECOND), $3)])
     <Resource name="optimized exec plan">
       <![CDATA[
 Calc(select=[a, b, EXTRACT(FLAG(SECOND), CAST(Reinterpret((c + 5000:INTERVAL SECOND)))) AS EXPR$2])
-+- TableSourceScan(table=[[default_catalog, default_database, VirtualTable, watermark=[-(+($2, 5000:INTERVAL SECOND), 5000:INTERVAL SECOND)]]], fields=[a, b, c])
++- TableSourceScan(table=[[default_catalog, default_database, VirtualTable, watermark=[-(+(c, 5000:INTERVAL SECOND), 5000:INTERVAL SECOND)]]], fields=[a, b, c])
 ]]>
     </Resource>
   </TestCase>
@@ -182,7 +182,7 @@ LogicalProject(a=[$0], b=[$1])
     <Resource name="optimized exec plan">
       <![CDATA[
 Calc(select=[a, b])
-+- TableSourceScan(table=[[default_catalog, default_database, MyTable, project=[a, b, originTime], metadata=[originTime], watermark=[TO_TIMESTAMP(FROM_UNIXTIME(/($2, 1000)), _UTF-16LE'yyyy-MM-dd HH:mm:ss')]]], fields=[a, b, originTime])
++- TableSourceScan(table=[[default_catalog, default_database, MyTable, project=[a, b, originTime], metadata=[originTime], watermark=[TO_TIMESTAMP(FROM_UNIXTIME(/(originTime, 1000)), _UTF-16LE'yyyy-MM-dd HH:mm:ss')]]], fields=[a, b, originTime])
 ]]>
     </Resource>
   </TestCase>

--- a/flink-table/flink-table-planner/src/test/resources/org/apache/flink/table/planner/plan/stream/sql/TableScanTest.xml
+++ b/flink-table/flink-table-planner/src/test/resources/org/apache/flink/table/planner/plan/stream/sql/TableScanTest.xml
@@ -638,7 +638,7 @@ LogicalProject(id=[$0], ts=[$4])
 Calc(select=[id, Reinterpret(TO_TIMESTAMP(c)) AS ts], changelogMode=[I,UA,D])
 +- ChangelogNormalize(key=[id], changelogMode=[I,UA,D])
    +- Exchange(distribution=[hash[id]], changelogMode=[UA,D])
-      +- TableSourceScan(table=[[default_catalog, default_database, src, project=[id, c], metadata=[], watermark=[-(TO_TIMESTAMP($1), 1000:INTERVAL SECOND)]]], fields=[id, c], changelogMode=[UA,D])
+      +- TableSourceScan(table=[[default_catalog, default_database, src, project=[id, c], metadata=[], watermark=[-(TO_TIMESTAMP(c), 1000:INTERVAL SECOND)]]], fields=[id, c], changelogMode=[UA,D])
 ]]>
     </Resource>
   </TestCase>

--- a/flink-table/flink-table-planner/src/test/scala/org/apache/flink/table/planner/plan/metadata/MetadataTestUtil.scala
+++ b/flink-table/flink-table-planner/src/test/scala/org/apache/flink/table/planner/plan/metadata/MetadataTestUtil.scala
@@ -248,17 +248,12 @@ object MetadataTestUtil {
     getMetadataTable(fieldNames, fieldTypes, new FlinkStatistic(tableStats))
   }
 
-
-  private val flinkContext = createFlinkContext
-
-  private def createFlinkContext(): FlinkContext = {
-    new FlinkContextImpl(
-      false,
-      TableConfig.getDefault,
-      null,
-      CatalogManagerMocks.createEmptyCatalogManager,
-      null)
-  }
+  private val flinkContext = new FlinkContextImpl(
+    false,
+    TableConfig.getDefault,
+    null,
+    CatalogManagerMocks.createEmptyCatalogManager,
+    null)
 
   private def createProjectedTableSourceTable(): Table = {
     val catalogTable = CatalogTable.fromProperties(

--- a/flink-table/flink-table-planner/src/test/scala/org/apache/flink/table/planner/plan/metadata/MetadataTestUtil.scala
+++ b/flink-table/flink-table-planner/src/test/scala/org/apache/flink/table/planner/plan/metadata/MetadataTestUtil.scala
@@ -29,16 +29,17 @@ import org.apache.flink.table.planner.plan.schema.{FlinkPreparingTableBase, Tabl
 import org.apache.flink.table.planner.plan.stats.FlinkStatistic
 import org.apache.flink.table.runtime.types.TypeInfoLogicalTypeConverter.fromTypeInfoToLogicalType
 import org.apache.flink.table.types.logical.{BigIntType, DoubleType, IntType, LocalZonedTimestampType, LogicalType, TimestampKind, TimestampType, VarCharType}
+import org.apache.flink.table.utils.CatalogManagerMocks
+
 import org.apache.calcite.config.CalciteConnectionConfig
 import org.apache.calcite.jdbc.CalciteSchema
 import org.apache.calcite.rel.`type`.{RelDataType, RelDataTypeFactory}
 import org.apache.calcite.schema.Schema.TableType
 import org.apache.calcite.schema.{Schema, SchemaPlus, Table}
 import org.apache.calcite.sql.{SqlCall, SqlNode}
+
 import java.util
 import java.util.Collections
-
-import org.apache.flink.table.utils.CatalogManagerMocks
 
 import scala.collection.JavaConversions._
 import scala.collection.JavaConverters._
@@ -247,6 +248,18 @@ object MetadataTestUtil {
     getMetadataTable(fieldNames, fieldTypes, new FlinkStatistic(tableStats))
   }
 
+
+  private val flinkContext = createFlinkContext
+
+  private def createFlinkContext(): FlinkContext = {
+    new FlinkContextImpl(
+      false,
+      TableConfig.getDefault,
+      null,
+      CatalogManagerMocks.createEmptyCatalogManager,
+      null)
+  }
+
   private def createProjectedTableSourceTable(): Table = {
     val catalogTable = CatalogTable.fromProperties(
       Map(
@@ -284,12 +297,8 @@ object MetadataTestUtil {
       new TestTableSource(),
       true,
       new ResolvedCatalogTable(catalogTable, resolvedSchema),
-      new FlinkContextImpl(
-        false,
-        TableConfig.getDefault,
-        null,
-        CatalogManagerMocks.createEmptyCatalogManager,
-        null))
+      flinkContext
+      )
   }
 
   private def createProjectedTableSourceTableWithPartialCompositePrimaryKey(): Table = {
@@ -326,12 +335,7 @@ object MetadataTestUtil {
       new TestTableSource(),
       true,
       new ResolvedCatalogTable(catalogTable, resolvedSchema),
-      new FlinkContextImpl(
-        false,
-        TableConfig.getDefault,
-        null,
-        CatalogManagerMocks.createEmptyCatalogManager,
-        null))
+      flinkContext)
   }
 
   private def getMetadataTable(


### PR DESCRIPTION
## What is the purpose of the change

- In PushWatermarkIntoTableSourceScanRuleBase, the digest is created by RexNode instead of Expression, RexNode rely on field index but Expression rely on field name. The digest is adjusted from field index to field name.

- In the current situation, the extra digests of SourceAbilitySpec is directly written by the corresponding rules. However, a good design is that the extra digests are produced by SourceAbilitySpec by a common interface method. We should not separate SourceAbilitySpec and digests, which may lead to the risk of consistency.

## Brief change log

  - *add a interface method named _getExtraDigests _into SourceAbilitySpec*
  - *class FilterPushDownSpec/LimitPushDownSpec/PartitionPushDownSpec/ProjectPushDownSpec/ReadingMetadataSpec/WatermarkPushDownSpec/SourceWatermarkSpec all implement the interface method*
  - *change the generation of extra digests in all corresponding rules*


## Verifying this change

Existing tests can cover this change.

## Does this pull request potentially affect one of the following parts:

  - Dependencies (does it add or upgrade a dependency): no
  - The public API, i.e., is any changed class annotated with `@Public(Evolving)`: no
  - The serializers: no
  - The runtime per-record code paths (performance sensitive): no
  - Anything that affects deployment or recovery: JobManager (and its components), Checkpointing, Kubernetes/Yarn, ZooKeeper: no
  - The S3 file system connector: no

## Documentation

  - Does this pull request introduce a new feature? no
  - If yes, how is the feature documented? 
