### PR TITLE
[FLINK-24065][connector] Upgrade the state of TwoPhaseCommitSink to support empty transaction after finished

### DIFF
--- a/flink-streaming-java/src/test/java/org/apache/flink/streaming/api/functions/sink/TwoPhaseCommitSinkFunctionTest.java
+++ b/flink-streaming-java/src/test/java/org/apache/flink/streaming/api/functions/sink/TwoPhaseCommitSinkFunctionTest.java
@@ -150,6 +150,22 @@ public class TwoPhaseCommitSinkFunctionTest {
     }
 
     @Test
+    public void testRecoverFromStateAfterFinished() throws Exception {
+        harness.open();
+        harness.processElement("42", 0);
+        sinkFunction.finish();
+
+        OperatorSubtaskState operatorSubtaskState = harness.snapshot(2, 5);
+
+        closeTestHarness();
+        setUpTestHarness();
+
+        harness.initializeState(operatorSubtaskState);
+        harness.open();
+        assertEquals(0, sinkFunction.abortedTransactions.size());
+    }
+
+    @Test
     public void testNotifyOfCompletedCheckpoint() throws Exception {
         harness.open();
         harness.processElement("42", 0);
@@ -300,12 +316,10 @@ public class TwoPhaseCommitSinkFunctionTest {
 
     private class ContentDumpSinkFunction
             extends TwoPhaseCommitSinkFunction<String, ContentTransaction, Void> {
+        final List<ContentTransaction> abortedTransactions = new ArrayList<>();
 
         public ContentDumpSinkFunction() {
-            super(
-                    new KryoSerializer<>(ContentTransaction.class, new ExecutionConfig()),
-                    VoidSerializer.INSTANCE,
-                    clock);
+            super(new ContentTransactionSerializer(), VoidSerializer.INSTANCE, clock);
         }
 
         @Override
@@ -336,6 +350,7 @@ public class TwoPhaseCommitSinkFunctionTest {
 
         @Override
         protected void abort(ContentTransaction transaction) {
+            abortedTransactions.add(transaction);
             transaction.tmpContentWriter.close();
             tmpDirectory.delete(transaction.tmpContentWriter.getName());
         }
@@ -351,6 +366,23 @@ public class TwoPhaseCommitSinkFunctionTest {
         @Override
         public String toString() {
             return String.format("ContentTransaction[%s]", tmpContentWriter.getName());
+        }
+    }
+
+    private static class ContentTransactionSerializer extends KryoSerializer<ContentTransaction> {
+
+        public ContentTransactionSerializer() {
+            super(ContentTransaction.class, new ExecutionConfig());
+        }
+
+        @Override
+        public KryoSerializer<ContentTransaction> duplicate() {
+            return this;
+        }
+
+        @Override
+        public String toString() {
+            return "ContentTransactionSerializer";
         }
     }
 

--- a/flink-streaming-java/src/test/java/org/apache/flink/streaming/api/functions/sink/TwoPhaseCommitSinkStateSerializerUpgradeTest.java
+++ b/flink-streaming-java/src/test/java/org/apache/flink/streaming/api/functions/sink/TwoPhaseCommitSinkStateSerializerUpgradeTest.java
@@ -130,7 +130,11 @@ public class TwoPhaseCommitSinkStateSerializerUpgradeTest
                         TypeSerializerSchemaCompatibility<
                                 TwoPhaseCommitSinkFunction.State<Integer, String>>>
                 schemaCompatibilityMatcher(MigrationVersion version) {
-            return TypeSerializerMatchers.isCompatibleAsIs();
+            if (version.isNewerVersionThan(MigrationVersion.v1_13)) {
+                return TypeSerializerMatchers.isCompatibleAsIs();
+            } else {
+                return TypeSerializerMatchers.isCompatibleAfterMigration();
+            }
         }
     }
 }


### PR DESCRIPTION
## What is the purpose of the change

This PR fixes the problems that
1. Currently if the sink is finished, then after that the sink would have empty pending transaction for each checkpoint. However, the current state serializer does not support the null pending transactions.
2. Remove the not-null check for the pending transaction when restoring state. 


## Brief change log

- f1b39f2 upgrades the state version to solve the above issue.

## Verifying this change

This PR is verified via the added ut, the existing state migration test and ci tests with checkpoints after tasks finished enabled. 

## Does this pull request potentially affect one of the following parts:

  - Dependencies (does it add or upgrade a dependency): **no**
  - The public API, i.e., is any changed class annotated with `@Public(Evolving)`: **no**
  - The serializers: **no**
  - The runtime per-record code paths (performance sensitive): **no**
  - Anything that affects deployment or recovery: JobManager (and its components), Checkpointing, Kubernetes/Yarn, ZooKeeper: **no**
  - The S3 file system connector: **no**

## Documentation

  - Does this pull request introduce a new feature? **no**
  - If yes, how is the feature documented? **not applicable**
