### PR TITLE
[FLINK-24130][python] Fix RowDataSerializerTest after FLINK-24054

### DIFF
--- a/flink-table/flink-table-runtime/src/test/java/org/apache/flink/table/runtime/operators/sink/SinkUpsertMaterializerTest.java
+++ b/flink-table/flink-table-runtime/src/test/java/org/apache/flink/table/runtime/operators/sink/SinkUpsertMaterializerTest.java
@@ -43,7 +43,7 @@ import java.util.List;
 
 import static org.apache.flink.table.runtime.util.StreamRecordUtils.deleteRecord;
 import static org.apache.flink.table.runtime.util.StreamRecordUtils.insertRecord;
-import static org.apache.flink.table.runtime.util.StreamRecordUtils.row;
+import static org.apache.flink.table.runtime.util.StreamRecordUtils.rowOfKind;
 import static org.junit.Assert.assertEquals;
 
 /** Test for {@link SinkUpsertMaterializer}. */
@@ -76,25 +76,25 @@ public class SinkUpsertMaterializerTest {
         testHarness.setStateTtlProcessingTime(1);
 
         testHarness.processElement(insertRecord(1, "a1"));
-        shouldEmit(testHarness, row(RowKind.INSERT, 1, "a1"));
+        shouldEmit(testHarness, rowOfKind(RowKind.INSERT, 1, "a1"));
 
         testHarness.processElement(insertRecord(1, "a2"));
-        shouldEmit(testHarness, row(RowKind.UPDATE_AFTER, 1, "a2"));
+        shouldEmit(testHarness, rowOfKind(RowKind.UPDATE_AFTER, 1, "a2"));
 
         testHarness.processElement(insertRecord(1, "a3"));
-        shouldEmit(testHarness, row(RowKind.UPDATE_AFTER, 1, "a3"));
+        shouldEmit(testHarness, rowOfKind(RowKind.UPDATE_AFTER, 1, "a3"));
 
         testHarness.processElement(deleteRecord(1, "a2"));
         shouldEmitNothing(testHarness);
 
         testHarness.processElement(deleteRecord(1, "a3"));
-        shouldEmit(testHarness, row(RowKind.UPDATE_AFTER, 1, "a1"));
+        shouldEmit(testHarness, rowOfKind(RowKind.UPDATE_AFTER, 1, "a1"));
 
         testHarness.processElement(deleteRecord(1, "a1"));
-        shouldEmit(testHarness, row(RowKind.DELETE, 1, "a1"));
+        shouldEmit(testHarness, rowOfKind(RowKind.DELETE, 1, "a1"));
 
         testHarness.processElement(insertRecord(1, "a4"));
-        shouldEmit(testHarness, row(RowKind.INSERT, 1, "a4"));
+        shouldEmit(testHarness, rowOfKind(RowKind.INSERT, 1, "a4"));
 
         testHarness.setStateTtlProcessingTime(1002);
 

--- a/flink-table/flink-table-runtime/src/test/java/org/apache/flink/table/runtime/util/StreamRecordUtils.java
+++ b/flink-table/flink-table-runtime/src/test/java/org/apache/flink/table/runtime/util/StreamRecordUtils.java
@@ -105,7 +105,7 @@ public class StreamRecordUtils {
     }
 
     /** Receives a object array, generates a RowData based on the array. */
-    public static RowData row(RowKind rowKind, Object... fields) {
+    public static RowData rowOfKind(RowKind rowKind, Object... fields) {
         Object[] objects = new Object[fields.length];
         for (int i = 0; i < fields.length; i++) {
             Object field = fields[i];
@@ -120,7 +120,7 @@ public class StreamRecordUtils {
 
     /** Receives a object array, generates a RowData based on the array. */
     public static RowData row(Object... fields) {
-        return row(RowKind.INSERT, fields);
+        return rowOfKind(RowKind.INSERT, fields);
     }
 
     /**


### PR DESCRIPTION
## What is the purpose of the change

Fixes `RowDataSerializerTest` due to ambiguous method overloading in FLINK-24054.

## Verifying this change

This change is a trivial rework / code cleanup without any test coverage.

## Does this pull request potentially affect one of the following parts:

  - Dependencies (does it add or upgrade a dependency): no
  - The public API, i.e., is any changed class annotated with `@Public(Evolving)`: no
  - The serializers: no
  - The runtime per-record code paths (performance sensitive): no
  - Anything that affects deployment or recovery: JobManager (and its components), Checkpointing, Kubernetes/Yarn, ZooKeeper: no
  - The S3 file system connector: no

## Documentation

  - Does this pull request introduce a new feature? no
  - If yes, how is the feature documented? not applicable
