### PR TITLE
[FLINK-24068][checkpoint] Also check for alignment start when received EndOfPartition from pending channels

### DIFF
--- a/flink-streaming-java/src/main/java/org/apache/flink/streaming/runtime/io/checkpointing/CheckpointBarrierHandler.java
+++ b/flink-streaming-java/src/main/java/org/apache/flink/streaming/runtime/io/checkpointing/CheckpointBarrierHandler.java
@@ -18,6 +18,7 @@
 
 package org.apache.flink.streaming.runtime.io.checkpointing;
 
+import org.apache.flink.annotation.VisibleForTesting;
 import org.apache.flink.runtime.checkpoint.CheckpointException;
 import org.apache.flink.runtime.checkpoint.CheckpointFailureReason;
 import org.apache.flink.runtime.checkpoint.CheckpointMetaData;
@@ -203,7 +204,8 @@ public abstract class CheckpointBarrierHandler implements Closeable {
         }
     }
 
-    private boolean isDuringAlignment() {
+    @VisibleForTesting
+    boolean isDuringAlignment() {
         return startOfAlignmentTimestamp > OUTSIDE_OF_ALIGNMENT;
     }
 


### PR DESCRIPTION
## What is the purpose of the change

This PR fixed that in a special case described in https://issues.apache.org/jira/browse/FLINK-24068, the `markAlignmentStart` method is skipped wrongly. 

## Brief change log

- 7d6995d8f94fe01c45ea479de175f51ff4a64ac5 fixes this issue by also checking if it is the first channel aligned when received `EndOfPartitionEvent`.


## Verifying this change

This change is verified by the added UT.

## Does this pull request potentially affect one of the following parts:

  - Dependencies (does it add or upgrade a dependency): **no**
  - The public API, i.e., is any changed class annotated with `@Public(Evolving)`: **no**
  - The serializers: **no**
  - The runtime per-record code paths (performance sensitive): **no**
  - Anything that affects deployment or recovery: JobManager (and its components), Checkpointing, Kubernetes/Yarn, ZooKeeper: **no**
  - The S3 file system connector: **no**

## Documentation

  - Does this pull request introduce a new feature? **no**
  - If yes, how is the feature documented? **not applicable**
