### PR TITLE
[FLINK-24120] Add docs for using environment variable MALLOC_ARENA_MA…

### DIFF
--- a/docs/content.zh/docs/deployment/memory/mem_trouble.md
+++ b/docs/content.zh/docs/deployment/memory/mem_trouble.md
@@ -72,7 +72,10 @@ under the License.
 
 对于 *JobManager* 进程，你还可以尝试启用 *JVM 直接内存限制*（[`jobmanager.memory.enable-jvm-direct-memory-limit`]({{< ref "docs/deployment/config" >}}#jobmanager-memory-enable-jvm-direct-memory-limit)），以排除 *JVM 直接内存泄漏*的可能性。
 
-如果使用了 [RocksDBStateBackend]({{< ref "docs/ops/state/state_backends" >}}#rocksdbstatebackend) 且没有开启内存控制，也可以尝试增大 TaskManager 的[托管内存]({{< ref "docs/deployment/memory/mem_setup" >}}#managed-memory)。
+If [RocksDBStateBackend]({{< ref "docs/ops/state/state_backends" >}}#the-rocksdbstatebackend) is used：
+* and memory controlling is disabled: You can try to increase the TaskManager's [managed memory]({{< ref "docs/deployment/memory/mem_setup" >}}#managed-memory).
+* and memory controlling is enabled and non-heap memory increases during savepoint or full checkpoints: This may happen due to the `glibc` memory allocator (see [glibc bug](https://sourceware.org/bugzilla/show_bug.cgi?id=15321)).
+  You can try to add the [environment variable]({{< ref "docs/deployment/config" >}}#forwarding-environment-variables) `MALLOC_ARENA_MAX=1` for TaskManagers.
 
 此外，还可以尝试增大 [JVM 开销]({{< ref "docs/deployment/memory/mem_setup" >}}#capped-fractionated-components)。
 

--- a/docs/content.zh/docs/deployment/resource-providers/standalone/docker.md
+++ b/docs/content.zh/docs/deployment/resource-providers/standalone/docker.md
@@ -349,6 +349,15 @@ You could switch back to use `glibc` as the memory allocator to restore the old 
       flink:{{< stable >}}{{< version >}}-scala{{< scala_version >}}{{< /stable >}}{{< unstable >}}latest{{< /unstable >}} <jobmanager|standalone-job|taskmanager>
 ```
 
+For users that are still using `glibc` memory allocator, the [glibc bug](https://sourceware.org/bugzilla/show_bug.cgi?id=15321) can easily be reproduced, especially while savepoints or full checkpoints with RocksDBStateBackend are created. 
+Setting the environment variable `MALLOC_ARENA_MAX` can avoid unlimited memory growth:
+
+```sh
+    $ docker run \
+      --env MALLOC_ARENA_MAX=1 \
+      flink:{{< stable >}}{{< version >}}-scala{{< scala_version >}}{{< /stable >}}{{< unstable >}}latest{{< /unstable >}} <jobmanager|standalone-job|taskmanager>
+```
+
 ### Advanced customization
 
 There are several ways in which you can further customize the Flink image:

--- a/docs/content/docs/deployment/memory/mem_trouble.md
+++ b/docs/content/docs/deployment/memory/mem_trouble.md
@@ -80,8 +80,10 @@ If you encounter this problem in the *JobManager* process, you can also enable t
 [`jobmanager.memory.enable-jvm-direct-memory-limit`]({{< ref "docs/deployment/config" >}}#jobmanager-memory-enable-jvm-direct-memory-limit) option
 to exclude possible *JVM Direct Memory* leak.
 
-If [RocksDBStateBackend]({{< ref "docs/ops/state/state_backends" >}}#the-rocksdbstatebackend) is used, and the memory controlling is disabled,
-you can try to increase the TaskManager's [managed memory]({{< ref "docs/deployment/memory/mem_setup" >}}#managed-memory).
+If [RocksDBStateBackend]({{< ref "docs/ops/state/state_backends" >}}#the-rocksdbstatebackend) is used：
+* and memory controlling is disabled: You can try to increase the TaskManager's [managed memory]({{< ref "docs/deployment/memory/mem_setup" >}}#managed-memory).
+* and memory controlling is enabled and non-heap memory increases during savepoint or full checkpoints: This may happen due to the `glibc` memory allocator (see [glibc bug](https://sourceware.org/bugzilla/show_bug.cgi?id=15321)).
+You can try to add the [environment variable]({{< ref "docs/deployment/config" >}}#forwarding-environment-variables) `MALLOC_ARENA_MAX=1` for TaskManagers.
 
 Alternatively, you can increase the [JVM Overhead]({{< ref "docs/deployment/memory/mem_setup" >}}#capped-fractionated-components).
 

--- a/docs/content/docs/deployment/resource-providers/standalone/docker.md
+++ b/docs/content/docs/deployment/resource-providers/standalone/docker.md
@@ -349,6 +349,15 @@ You could switch back to use `glibc` as the memory allocator to restore the old 
       flink:{{< stable >}}{{< version >}}-scala{{< scala_version >}}{{< /stable >}}{{< unstable >}}latest{{< /unstable >}} <jobmanager|standalone-job|taskmanager>
 ```
 
+For users that are still using `glibc` memory allocator, the [glibc bug](https://sourceware.org/bugzilla/show_bug.cgi?id=15321) can easily be reproduced, especially while savepoints or full checkpoints with RocksDBStateBackend are created. 
+Setting the environment variable `MALLOC_ARENA_MAX` can avoid unlimited memory growth:
+
+```sh
+    $ docker run \
+      --env MALLOC_ARENA_MAX=1 \
+      flink:{{< stable >}}{{< version >}}-scala{{< scala_version >}}{{< /stable >}}{{< unstable >}}latest{{< /unstable >}} <jobmanager|standalone-job|taskmanager>
+```
+
 ### Advanced customization
 
 There are several ways in which you can further customize the Flink image:


### PR DESCRIPTION
## What is the purpose of the change

For users that uses `glibc` memory allocator and enables memory controlling, it's very easy to trigger the [glibc bug](https://sourceware.org/bugzilla/show_bug.cgi?id=15321), we add a few tips on the document to guide uses to use environment variable `MALLOC_ARENA_MAX ` to avoid unlimited memory increasing. 

## Brief change log

* Add docs on docker document.
* Add docs on trouble shooting document.

## Verifying this change

Not needed.

## Does this pull request potentially affect one of the following parts:

  - Dependencies (does it add or upgrade a dependency): no
  - The public API, i.e., is any changed class annotated with `@Public(Evolving)`: no
  - The serializers: no
  - The runtime per-record code paths (performance sensitive): no
  - Anything that affects deployment or recovery: JobManager (and its components), Checkpointing, Kubernetes/Yarn, ZooKeeper: no
  - The S3 file system connector: no

## Documentation

This is a document change.
