### PR TITLE
[FLINK-24149][runtime][checkpoint] Make checkpoint relocatable

### DIFF
--- a/flink-runtime/src/main/java/org/apache/flink/runtime/state/filesystem/FsCheckpointStorageAccess.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/state/filesystem/FsCheckpointStorageAccess.java
@@ -176,7 +176,11 @@ public class FsCheckpointStorageAccess extends AbstractFsCheckpointStorageAccess
         // change into shared state,
         // so we use CheckpointedStateScope.SHARED here.
         return new FsCheckpointStateOutputStream(
-                taskOwnedStateDirectory, fileSystem, writeBufferSize, fileSizeThreshold);
+                checkpointsDirectory,
+                taskOwnedStateDirectory,
+                fileSystem,
+                writeBufferSize,
+                fileSizeThreshold);
     }
 
     @Override

--- a/flink-runtime/src/test/java/org/apache/flink/runtime/state/filesystem/FsCheckpointStreamFactoryTest.java
+++ b/flink-runtime/src/test/java/org/apache/flink/runtime/state/filesystem/FsCheckpointStreamFactoryTest.java
@@ -88,7 +88,7 @@ public class FsCheckpointStreamFactoryTest {
     }
 
     @Test
-    public void testSharedStateHasAbsolutePathHandles() throws IOException {
+    public void testSharedStateHasRelativePathHandles() throws IOException {
         final FsCheckpointStreamFactory factory = createFactory(FileSystem.getLocalFileSystem(), 0);
 
         final FsCheckpointStreamFactory.FsCheckpointStateOutputStream stream =
@@ -96,8 +96,7 @@ public class FsCheckpointStreamFactoryTest {
         stream.write(0);
         final StreamStateHandle handle = stream.closeAndGetHandle();
 
-        assertThat(handle, instanceOf(FileStateHandle.class));
-        assertThat(handle, not(instanceOf(RelativeFileStateHandle.class)));
+        assertThat(handle, instanceOf(RelativeFileStateHandle.class));
         assertPathsEqual(sharedStateDir, ((FileStateHandle) handle).getFilePath().getParent());
     }
 
@@ -114,6 +113,21 @@ public class FsCheckpointStreamFactoryTest {
         assertThat(handle, instanceOf(FileStateHandle.class));
         assertThat(handle, not(instanceOf(RelativeFileStateHandle.class)));
         assertPathsEqual(exclusiveStateDir, ((FileStateHandle) handle).getFilePath().getParent());
+    }
+
+    @Test
+    public void testEntropyMakesSharedStateAbsolutePaths() throws IOException {
+        final FsCheckpointStreamFactory factory =
+                createFactory(new FsStateBackendEntropyTest.TestEntropyAwareFs(), 0);
+
+        final FsCheckpointStreamFactory.FsCheckpointStateOutputStream stream =
+                factory.createCheckpointStateOutputStream(CheckpointedStateScope.SHARED);
+        stream.write(0);
+        final StreamStateHandle handle = stream.closeAndGetHandle();
+
+        assertThat(handle, instanceOf(FileStateHandle.class));
+        assertThat(handle, not(instanceOf(RelativeFileStateHandle.class)));
+        assertPathsEqual(sharedStateDir, ((FileStateHandle) handle).getFilePath().getParent());
     }
 
     @Test


### PR DESCRIPTION
## What is the purpose of the change

This PR include changes described in [FLINK-24149](https://issues.apache.org/jira/browse/FLINK-24149)

## Brief change log
**changes to FsCheckpointStateOutputStream :**
  - introduce ***checkpointDirectory*** field, and remove ***allowRelativePaths*** field
  - introduce ***entropyInjecting*** field
  - ***closeAndGetHandle()*** return ***RelativeFileStateHandle*** with relative path base on ***checkpointDirectory*** (except entropy injecting file system)


## Verifying this change

This change is already covered by existing tests, such as *FsCheckpointStateOutputStreamTest*. We just need to make some adjustments:

  - Added *getFileSystemForTest()* to create FileSystem for test
  - Verifying StreamStateHandle is a RelativeFileStateHandle when not in entropyInjectingFileSystem


## Does this pull request potentially affect one of the following parts:

  - Dependencies (does it add or upgrade a dependency): no
  - The public API, i.e., is any changed class annotated with `@Public(Evolving)`: no
  - The serializers: no
  - The runtime per-record code paths (performance sensitive): no
  - Anything that affects deployment or recovery: JobManager (and its components), Checkpointing, Kubernetes/Yarn, ZooKeeper: yes
  - The S3 file system connector: (yes / no / don't know)

## Documentation

  - Does this pull request introduce a new feature? no