### PR TITLE
[FLINK-21853][e2e] Harden common_ha.sh#ha_tm_watchdog 

### DIFF
--- a/flink-end-to-end-tests/test-scripts/test_ha_datastream.sh
+++ b/flink-end-to-end-tests/test-scripts/test_ha_datastream.sh
@@ -36,7 +36,7 @@ function run_ha_test() {
     local INCREM=$4
     local ZOOKEEPER_VERSION=$5
 
-    local JM_KILLS=3
+    local JM_KILLS=2
     local CHECKPOINT_DIR="${TEST_DATA_DIR}/checkpoints/"
 
     CLEARED=0

--- a/flink-end-to-end-tests/test-scripts/test_ha_per_job_cluster_datastream.sh
+++ b/flink-end-to-end-tests/test-scripts/test_ha_per_job_cluster_datastream.sh
@@ -100,7 +100,7 @@ function run_ha_test() {
     local INCREM=$4
     local ZOOKEEPER_VERSION=$5
 
-    local JM_KILLS=3
+    local JM_KILLS=2
 
     CLEARED=0
 


### PR DESCRIPTION
0bd99f5:
This commit hardens the common_ha.sh#ha_tm_watchdog function by always starting
the expected number of TaskManagers. This will ensure that the e2e tests that are
using this function also pass if a TaskManager dies accidentally.

c8c132c:
This commit reduces the number of JM kills in test_ha_per_job_cluster_datastream.sh and test_ha_datastream.sh because on
CI killing the JM 3 times can take more than the current timeout (15 minutes) (2 minutes per successful checkpoint, 8
successful checkpoints required to pass).