### PR TITLE
Revert "[FLINK-22770][docs] Update usage of SET in docs to use quotes"

### DIFF
--- a/docs/content.zh/docs/dev/table/concepts/timezone.md
+++ b/docs/content.zh/docs/dev/table/concepts/timezone.md
@@ -49,7 +49,7 @@ Flink SQL> SELECT TIMESTAMP '1970-01-01 00:00:04.001';
 
  ```sql
 Flink SQL> CREATE VIEW T1 AS SELECT TO_TIMESTAMP_LTZ(4001, 3);
-Flink SQL> SET 'table.local-time-zone' = 'UTC';
+Flink SQL> SET table.local-time-zone=UTC;
 Flink SQL> SELECT * FROM T1;
 +---------------------------+
 | TO_TIMESTAMP_LTZ(4001, 3) |
@@ -57,7 +57,7 @@ Flink SQL> SELECT * FROM T1;
 |   1970-01-01 00:00:04.001 |
 +---------------------------+
 
-Flink SQL> SET 'table.local-time-zone' = 'Asia/Shanghai';
+Flink SQL> SET table.local-time-zone=Asia/Shanghai;
 Flink SQL> SELECT * FROM T1;
 +---------------------------+
 | TO_TIMESTAMP_LTZ(4001, 3) |
@@ -76,13 +76,13 @@ Flink SQL> SELECT * FROM T1;
 {{< tab "SQL Client" >}}
 ```sql
 -- 设置为 UTC 时区
-Flink SQL> SET 'table.local-time-zone' = 'UTC';
+Flink SQL> SET table.local-time-zone=UTC;
 
 -- 设置为上海时区
-Flink SQL> SET 'table.local-time-zone' = 'Asia/Shanghai';
+Flink SQL> SET table.local-time-zone=Asia/Shanghai;
 
 -- 设置为Los_Angeles时区
-Flink SQL> SET 'table.local-time-zone' = 'America/Los_Angeles';
+Flink SQL> SET table.local-time-zone=America/Los_Angeles;
 ```
 {{< /tab >}}
 {{< tab "Java" >}}
@@ -132,7 +132,7 @@ session （会话）中配置的时区会对以下函数生效。
 
 
 ```sql
-Flink SQL> SET 'sql-client.execution.result-mode' = 'tableau';
+Flink SQL> SET sql-client.execution.result-mode=tableau;
 Flink SQL> CREATE VIEW MyView1 AS SELECT LOCALTIME, LOCALTIMESTAMP, CURRENT_DATE, CURRENT_TIME, CURRENT_TIMESTAMP, CURRENT_ROW_TIMESTAMP(), NOW(), PROCTIME();
 Flink SQL> DESC MyView1;
 ```
@@ -153,7 +153,7 @@ Flink SQL> DESC MyView1;
 ```
 
 ```sql
-Flink SQL> SET 'table.local-time-zone' = 'UTC';
+Flink SQL> SET table.local-time-zone=UTC;
 Flink SQL> SELECT * FROM MyView1;
 ```
 
@@ -166,7 +166,7 @@ Flink SQL> SELECT * FROM MyView1;
 ```
 
 ```sql
-Flink SQL> SET 'table.local-time-zone' = 'Asia/Shanghai';
+Flink SQL> SET table.local-time-zone=Asia/Shanghai;
 Flink SQL> SELECT * FROM MyView1;
 ```
 
@@ -195,7 +195,7 @@ Flink SQL> DESC MyView2;
 ```
 
 ```sql
-Flink SQL> SET 'table.local-time-zone' = 'UTC';
+Flink SQL> SET table.local-time-zone=UTC;
 Flink SQL> SELECT * FROM MyView2;
 ```
 
@@ -208,7 +208,7 @@ Flink SQL> SELECT * FROM MyView2;
 ```
 
 ```sql
-Flink SQL> SET 'table.local-time-zone' = 'Asia/Shanghai';
+Flink SQL> SET table.local-time-zone=Asia/Shanghai;
 Flink SQL> SELECT * FROM MyView2;
 ```
 
@@ -264,7 +264,7 @@ Flink SQL 使用函数 `PROCTIME()` 来定义处理时间属性， 该函数返�
 `PROCTIME()` 返回的是本地时区的时间， 使用 `TIMESTAMP_LTZ` 类型也可以支持夏令时时间。
 
 ```sql
-Flink SQL> SET 'table.local-time-zone' = 'UTC';
+Flink SQL> SET table.local-time-zone=UTC;
 Flink SQL> SELECT PROCTIME();
 ```
 ```
@@ -276,7 +276,7 @@ Flink SQL> SELECT PROCTIME();
 ```
 
 ```sql
-Flink SQL> SET 'table.local-time-zone' = 'Asia/Shanghai';
+Flink SQL> SET table.local-time-zone=Asia/Shanghai;
 Flink SQL> SELECT PROCTIME();
 ```
 ```
@@ -336,7 +336,7 @@ C,3.8
 ```
 
 ```sql
-Flink SQL> SET 'table.local-time-zone' = 'UTC';
+Flink SQL> SET table.local-time-zone=UTC;
 Flink SQL> SELECT * FROM MyView3;
 ```
 
@@ -351,7 +351,7 @@ Flink SQL> SELECT * FROM MyView3;
 ```
 
 ```sql
-Flink SQL> SET 'table.local-time-zone' = 'Asia/Shanghai';
+Flink SQL> SET table.local-time-zone=Asia/Shanghai;
 Flink SQL> SELECT * FROM MyView3;
 ```
 
@@ -426,7 +426,7 @@ C,3.8,2021-04-15 14:11:00
 ```
 
 ```sql
-Flink SQL> SET 'table.local-time-zone' = 'UTC'; 
+Flink SQL> SET table.local-time-zone=UTC; 
 Flink SQL> SELECT * FROM MyView4;
 ```
                
@@ -441,7 +441,7 @@ Flink SQL> SELECT * FROM MyView4;
 ```
 
 ```sql
-Flink SQL> SET 'table.local-time-zone' = 'Asia/Shanghai'; 
+Flink SQL> SET table.local-time-zone=Asia/Shanghai; 
 Flink SQL> SELECT * FROM MyView4;
 ```
 
@@ -508,7 +508,7 @@ C,3.8,1618495860000  # The corresponding utc timestamp is 2021-04-15 14:11:00
 ```    
 
 ```sql
-Flink SQL> SET 'table.local-time-zone' = 'UTC'; 
+Flink SQL> SET table.local-time-zone=UTC; 
 Flink SQL> SELECT * FROM MyView5;
 ```                         
                
@@ -523,7 +523,7 @@ Flink SQL> SELECT * FROM MyView5;
 ```
 
 ```sql
-Flink SQL> SET 'table.local-time-zone' = 'Asia/Shanghai'; 
+Flink SQL> SET table.local-time-zone=Asia/Shanghai; 
 Flink SQL> SELECT * FROM MyView5;
 ```
 

--- a/docs/content.zh/docs/dev/table/config.md
+++ b/docs/content.zh/docs/dev/table/config.md
@@ -84,9 +84,9 @@ configuration.set_string("table.exec.mini-batch.size", "5000")
 {{< /tab >}}
 {{< tab "SQL CLI" >}}
 ```
-Flink SQL> SET 'table.exec.mini-batch.enabled' = 'true';
-Flink SQL> SET 'table.exec.mini-batch.allow-latency' = '5s';
-Flink SQL> SET 'table.exec.mini-batch.size' = '5000';
+Flink SQL> SET table.exec.mini-batch.enabled = true;
+Flink SQL> SET table.exec.mini-batch.allow-latency = 5s;
+Flink SQL> SET table.exec.mini-batch.size = 5000;
 ```
 {{< /tab >}}
 {{< /tabs >}}

--- a/docs/content.zh/docs/dev/table/sql/reset.md
+++ b/docs/content.zh/docs/dev/table/sql/reset.md
@@ -43,7 +43,7 @@ The following examples show how to run a `RESET` statement in SQL CLI.
 {{< tabs "reset" >}}
 {{< tab "SQL CLI" >}}
 ```sql
-Flink SQL> RESET 'table.planner';
+Flink SQL> RESET table.planner;
 [INFO] Session property has been reset.
 
 Flink SQL> RESET;
@@ -55,7 +55,7 @@ Flink SQL> RESET;
 ## Syntax
 
 ```sql
-RESET ('key')?
+RESET (key)?
 ```
 
 If no key is specified, it reset all the properties to the default. Otherwise, reset the specified key to the default.

--- a/docs/content.zh/docs/dev/table/sql/set.md
+++ b/docs/content.zh/docs/dev/table/sql/set.md
@@ -43,7 +43,7 @@ The following examples show how to run a `SET` statement in SQL CLI.
 {{< tabs "set" >}}
 {{< tab "SQL CLI" >}}
 ```sql
-Flink SQL> SET 'table.planner' = 'blink';
+Flink SQL> SET table.planner = blink;
 [INFO] Session property has been set.
 
 Flink SQL> SET;
@@ -55,7 +55,7 @@ table.planner=blink;
 ## Syntax
 
 ```sql
-SET ('key' = 'value')?
+SET (key = value)?
 ```
 
 If no key and value are specified, it just print all the properties. Otherwise, set the key with specified value.

--- a/docs/content.zh/docs/dev/table/sqlClient.md
+++ b/docs/content.zh/docs/dev/table/sqlClient.md
@@ -74,20 +74,20 @@ CLI 为维护和可视化结果提供**三种模式**。
 **表格模式**（table mode）在内存中实体化结果，并将结果用规则的分页表格可视化展示出来。执行如下命令启用：
 
 ```text
-SET 'sql-client.execution.result-mode' = 'table';
+SET sql-client.execution.result-mode=table;
 ```
 
 **变更日志模式**（changelog mode）不会实体化和可视化结果，而是由插入（`+`）和撤销（`-`）组成的持续查询产生结果流。
 
 ```text
-SET 'sql-client.execution.result-mode' = 'changelog';
+SET sql-client.execution.result-mode=changelog;
 ```
 
 **Tableau模式**（tableau mode）更接近传统的数据库，会将执行的结果以制表的形式直接打在屏幕之上。具体显示的内容会取决于作业
 执行模式的不同(`execution.type`)：
 
 ```text
-SET 'sql-client.execution.result-mode' = 'tableau';
+SET sql-client.execution.result-mode=tableau;
 ```
 
 注意当你使用这个模式运行一个流式查询的时候，Flink 会将结果持续的打印在当前的屏幕之上。如果这个流式查询的输入是有限的数据集，
@@ -339,21 +339,21 @@ CREATE FUNCTION foo.bar.AggregateUDF AS myUDF;
 
 -- Properties that change the fundamental execution behavior of a table program.
 
-SET 'table.planner' = 'blink'; -- planner: either 'blink' (default) or 'old'
-SET 'execution.runtime-mode' = 'streaming'; -- execution mode either 'batch' or 'streaming'
-SET 'sql-client.execution.result-mode' = 'table'; -- available values: 'table', 'changelog' and 'tableau'
-SET 'sql-client.execution.max-table-result.rows' = '10000'; -- optional: maximum number of maintained rows
-SET 'parallelism.default' = '1'; -- optional: Flink's parallelism (1 by default)
-SET 'pipeline.auto-watermark-interval' = '200'; --optional: interval for periodic watermarks
-SET 'pipeline.max-parallelism' = '10'; -- optional: Flink's maximum parallelism
-SET 'table.exec.state.ttl' = '1000'; -- optional: table program's idle state time
-SET 'restart-strategy' = 'fixed-delay';
+SET table.planner = blink; -- planner: either 'blink' (default) or 'old'
+SET execution.runtime-mode = streaming; -- execution mode either 'batch' or 'streaming'
+SET sql-client.execution.result-mode = table; -- available values: 'table', 'changelog' and 'tableau'
+SET sql-client.execution.max-table-result.rows = 10000; -- optional: maximum number of maintained rows
+SET parallelism.default = 1; -- optional: Flink's parallelism (1 by default)
+SET pipeline.auto-watermark-interval = 200; --optional: interval for periodic watermarks
+SET pipeline.max-parallelism = 10; -- optional: Flink's maximum parallelism
+SET table.exec.state.ttl=1000; -- optional: table program's idle state time
+SET restart-strategy = fixed-delay;
 
 -- Configuration options for adjusting and tuning table programs.
 
-SET 'table.optimizer.join-reorder-enabled' = 'true';
-SET 'table.exec.spill-compression.enabled' = 'true';
-SET 'table.exec.spill-compression.block-size' = '128kb';
+SET table.optimizer.join-reorder-enabled = true;
+SET table.exec.spill-compression.enabled = true;
+SET table.exec.spill-compression.block-size = 128kb;
 ```
 
 This configuration:
@@ -403,7 +403,7 @@ In interactive Command Line, the SQL Client reads user inputs and executes the s
 
 SQL Client will print success message if the statement is executed successfully. When getting errors, SQL Client will also print error messages.
 By default, the error message only contains the error cause. In order to print the full exception stack for debugging, please set the
-`sql-client.verbose` to true through command `SET 'sql-client.verbose' = 'true';`.
+`sql-client.verbose` to true through command `SET sql-client.verbose = true;`.
 
 ### Execute SQL Files
 
@@ -429,19 +429,19 @@ CREATE TEMPORARY TABLE users (
 );
 
 -- set sync mode
-SET 'table.dml-sync' = 'true';
+SET table.dml-sync=true;
 
 -- set the job name
-SET 'pipeline.name' = 'SqlJob';
+SET pipeline.name=SqlJob;
 
 -- set the queue that the job submit to
-SET 'yarn.application.queue' = 'root';
+SET yarn.application.queue=root;
 
 -- set the job parallism
-SET 'parallism.default' = '100';
+SET parallism.default=100;
 
 -- restore from the specific savepoint path
-SET 'execution.savepoint.path' = '/tmp/flink-savepoints/savepoint-cca7bc-bb1e257f0dab';
+SET execution.savepoint.path=/tmp/flink-savepoints/savepoint-cca7bc-bb1e257f0dab;
 
 INSERT INTO pageviews_enriched
 SELECT *
@@ -609,7 +609,7 @@ previous DML statement finishes. In order to execute DML statements synchronousl
 `table.dml-sync` option true in SQL Client.
 
 ```sql
-Flink SQL> SET 'table.dml-sync' = 'true';
+Flink SQL> SET table.dml-sync = true;
 [INFO] Session property has been set.
 
 Flink SQL> INSERT INTO MyTableSink SELECT * FROM MyTableSource;
@@ -625,7 +625,7 @@ Flink SQL> INSERT INTO MyTableSink SELECT * FROM MyTableSource;
 Flink supports to start the job with specified savepoint. In SQL Client, it's allowed to use `SET` command to specify the path of the savepoint.
 
 ```sql
-Flink SQL> SET 'execution.savepoint.path' = '/tmp/flink-savepoints/savepoint-cca7bc-bb1e257f0dab';
+Flink SQL> SET execution.savepoint.path=/tmp/flink-savepoints/savepoint-cca7bc-bb1e257f0dab;
 [INFO] Session property has been set.
 
 -- all the following DML statements will be restroed from the specified savepoint path
@@ -648,7 +648,7 @@ For more details about creating and managing savepoints, please refer to [Job Li
 SQL Client supports to define job name for queries and DML statements through `SET` command.
 
 ```sql
-Flink SQL> SET 'pipeline.name' = 'kafka-to-hive';
+Flink SQL> SET pipeline.name= 'kafka-to-hive' ;
 [INFO] Session property has been set.
 
 -- all the following DML statements will use the specified job name.
@@ -673,7 +673,7 @@ To be compatible with before, SQL Client still supports to initialize with envir
 When set the key defined in YAML file, the SQL Client will print the warning messages to inform.
 
 ```sql
-Flink SQL> SET 'execution.type' = 'batch';
+Flink SQL> SET execution.type = batch;
 [WARNING] The specified key 'execution.type' is deprecated. Please use 'execution.runtime-mode' instead.
 [INFO] Session property has been set.
 

--- a/docs/content/docs/dev/table/concepts/timezone.md
+++ b/docs/content/docs/dev/table/concepts/timezone.md
@@ -49,7 +49,7 @@ Flink SQL> SELECT TIMESTAMP '1970-01-01 00:00:04.001';
 
  ```sql
 Flink SQL> CREATE VIEW T1 AS SELECT TO_TIMESTAMP_LTZ(4001, 3);
-Flink SQL> SET 'table.local-time-zone' = 'UTC';
+Flink SQL> SET table.local-time-zone=UTC;
 Flink SQL> SELECT * FROM T1;
 +---------------------------+
 | TO_TIMESTAMP_LTZ(4001, 3) |
@@ -57,7 +57,7 @@ Flink SQL> SELECT * FROM T1;
 |   1970-01-01 00:00:04.001 |
 +---------------------------+
 
-Flink SQL> SET 'table.local-time-zone' = 'Asia/Shanghai';
+Flink SQL> SET table.local-time-zone=Asia/Shanghai;
 Flink SQL> SELECT * FROM T1;
 +---------------------------+
 | TO_TIMESTAMP_LTZ(4001, 3) |
@@ -76,13 +76,13 @@ The local time zone defines current session time zone id. You can config the tim
 {{< tab "SQL Client" >}}
 ```sql
 -- set to UTC time zone
-Flink SQL> SET 'table.local-time-zone' = 'UTC';
+Flink SQL> SET table.local-time-zone=UTC;
 
 -- set to Shanghai time zone
-Flink SQL> SET 'table.local-time-zone' = 'Asia/Shanghai';
+Flink SQL> SET table.local-time-zone=Asia/Shanghai;
 
 -- set to Los_Angeles time zone
-Flink SQL> SET 'table.local-time-zone' = 'America/Los_Angeles';
+Flink SQL> SET table.local-time-zone=America/Los_Angeles;
 ```
 {{< /tab >}}
 {{< tab "Java" >}}
@@ -132,7 +132,7 @@ The following time functions is influenced by the configured time zone.
 
 
 ```sql
-Flink SQL> SET 'sql-client.execution.result-mode' = 'tableau';
+Flink SQL> SET sql-client.execution.result-mode=tableau;
 Flink SQL> CREATE VIEW MyView1 AS SELECT LOCALTIME, LOCALTIMESTAMP, CURRENT_DATE, CURRENT_TIME, CURRENT_TIMESTAMP, CURRENT_ROW_TIMESTAMP(), NOW(), PROCTIME();
 Flink SQL> DESC MyView1;
 ```
@@ -153,7 +153,7 @@ Flink SQL> DESC MyView1;
 ```
 
 ```sql
-Flink SQL> SET 'table.local-time-zone' = 'UTC';
+Flink SQL> SET table.local-time-zone=UTC;
 Flink SQL> SELECT * FROM MyView1;
 ```
 
@@ -166,7 +166,7 @@ Flink SQL> SELECT * FROM MyView1;
 ```
 
 ```sql
-Flink SQL> SET 'table.local-time-zone' = 'Asia/Shanghai';
+Flink SQL> SET table.local-time-zone=Asia/Shanghai;
 Flink SQL> SELECT * FROM MyView1;
 ```
 
@@ -195,7 +195,7 @@ Flink SQL> DESC MyView2;
 ```
 
 ```sql
-Flink SQL> SET 'table.local-time-zone' = 'UTC';
+Flink SQL> SET table.local-time-zone=UTC;
 Flink SQL> SELECT * FROM MyView2;
 ```
 
@@ -208,7 +208,7 @@ Flink SQL> SELECT * FROM MyView2;
 ```
 
 ```sql
-Flink SQL> SET 'table.local-time-zone' = 'Asia/Shanghai';
+Flink SQL> SET table.local-time-zone=Asia/Shanghai;
 Flink SQL> SELECT * FROM MyView2;
 ```
 
@@ -265,7 +265,7 @@ Flink 1.13 fixes this issue and uses `TIMESTAMP_LTZ` type as return type of `PRO
 The PROCTIME() always represents your local timestamp value, using TIMESTAMP_LTZ type can also support DayLight Saving Time well.
 
 ```sql
-Flink SQL> SET 'table.local-time-zone' = 'UTC';
+Flink SQL> SET table.local-time-zone=UTC;
 Flink SQL> SELECT PROCTIME();
 ```
 ```
@@ -277,7 +277,7 @@ Flink SQL> SELECT PROCTIME();
 ```
 
 ```sql
-Flink SQL> SET 'table.local-time-zone' = 'Asia/Shanghai';
+Flink SQL> SET table.local-time-zone=Asia/Shanghai;
 Flink SQL> SELECT PROCTIME();
 ```
 ```
@@ -337,7 +337,7 @@ C,3.8
 ```
 
 ```sql
-Flink SQL> SET 'table.local-time-zone' = 'UTC';
+Flink SQL> SET table.local-time-zone=UTC;
 Flink SQL> SELECT * FROM MyView3;
 ```
 
@@ -352,7 +352,7 @@ Flink SQL> SELECT * FROM MyView3;
 ```
 
 ```sql
-Flink SQL> SET 'table.local-time-zone' = 'Asia/Shanghai';
+Flink SQL> SET table.local-time-zone=Asia/Shanghai;
 Flink SQL> SELECT * FROM MyView3;
 ```
 
@@ -427,7 +427,7 @@ C,3.8,2021-04-15 14:11:00
 ```
 
 ```sql
-Flink SQL> SET 'table.local-time-zone' = 'UTC';
+Flink SQL> SET table.local-time-zone=UTC;
 Flink SQL> SELECT * FROM MyView4;
 ```
 
@@ -442,7 +442,7 @@ Flink SQL> SELECT * FROM MyView4;
 ```
 
 ```sql
-Flink SQL> SET 'table.local-time-zone' = 'Asia/Shanghai';
+Flink SQL> SET table.local-time-zone=Asia/Shanghai;
 Flink SQL> SELECT * FROM MyView4;
 ```
 
@@ -509,7 +509,7 @@ C,3.8,1618495860000  # The corresponding utc timestamp is 2021-04-15 14:11:00
 ```
 
 ```sql
-Flink SQL> SET 'table.local-time-zone' = 'UTC';
+Flink SQL> SET table.local-time-zone=UTC;
 Flink SQL> SELECT * FROM MyView5;
 ```
 
@@ -524,7 +524,7 @@ Flink SQL> SELECT * FROM MyView5;
 ```
 
 ```sql
-Flink SQL> SET 'table.local-time-zone' = 'Asia/Shanghai';
+Flink SQL> SET table.local-time-zone=Asia/Shanghai;
 Flink SQL> SELECT * FROM MyView5;
 ```
 

--- a/docs/content/docs/dev/table/config.md
+++ b/docs/content/docs/dev/table/config.md
@@ -91,9 +91,9 @@ configuration.set_string("table.exec.mini-batch.size", "5000")
 {{< /tab >}}
 {{< tab "SQL CLI" >}}
 ```
-Flink SQL> SET 'table.exec.mini-batch.enabled' = 'true';
-Flink SQL> SET 'table.exec.mini-batch.allow-latency' = '5s';
-Flink SQL> SET 'table.exec.mini-batch.size' = '5000';
+Flink SQL> SET table.exec.mini-batch.enabled = true;
+Flink SQL> SET table.exec.mini-batch.allow-latency = 5s;
+Flink SQL> SET table.exec.mini-batch.size = 5000;
 ```
 {{< /tab >}}
 {{< /tabs >}}

--- a/docs/content/docs/dev/table/sql/reset.md
+++ b/docs/content/docs/dev/table/sql/reset.md
@@ -43,7 +43,7 @@ The following examples show how to run a `RESET` statement in SQL CLI.
 {{< tabs "reset" >}}
 {{< tab "SQL CLI" >}}
 ```sql
-Flink SQL> RESET 'table.planner';
+Flink SQL> RESET table.planner;
 [INFO] Session property has been reset.
 
 Flink SQL> RESET;
@@ -55,7 +55,7 @@ Flink SQL> RESET;
 ## Syntax
 
 ```sql
-RESET ('key')?
+RESET (key)?
 ```
 
 If no key is specified, it reset all the properties to the default. Otherwise, reset the specified key to the default.

--- a/docs/content/docs/dev/table/sql/set.md
+++ b/docs/content/docs/dev/table/sql/set.md
@@ -43,7 +43,7 @@ The following examples show how to run a `SET` statement in SQL CLI.
 {{< tabs "set" >}}
 {{< tab "SQL CLI" >}}
 ```sql
-Flink SQL> SET 'table.planner' = 'blink';
+Flink SQL> SET table.planner = blink;
 [INFO] Session property has been set.
 
 Flink SQL> SET;
@@ -55,7 +55,7 @@ table.planner=blink;
 ## Syntax
 
 ```sql
-SET ('key' = 'value')?
+SET (key = value)?
 ```
 
 If no key and value are specified, it just print all the properties. Otherwise, set the key with specified value.

--- a/docs/content/docs/dev/table/sqlClient.md
+++ b/docs/content/docs/dev/table/sqlClient.md
@@ -78,21 +78,21 @@ The **table mode** materializes results in memory and visualizes them in a regul
 It can be enabled by executing the following command in the CLI:
 
 ```text
-SET 'sql-client.execution.result-mode' = 'table';
+SET sql-client.execution.result-mode=table;
 ```
 
 The **changelog mode** does not materialize results and visualizes the result stream that is produced
 by a [continuous query]({{< ref "docs/dev/table/concepts/dynamic_tables" >}}#continuous-queries) consisting of insertions (`+`) and retractions (`-`).
 
 ```text
-SET 'sql-client.execution.result-mode' = 'changelog';
+SET sql-client.execution.result-mode=changelog;
 ```
 
 The **tableau mode** is more like a traditional way which will display the results in the screen directly with a tableau format.
 The displaying content will be influenced by the query execution type(`execution.type`).
 
 ```text
-SET 'sql-client.execution.result-mode' = 'tableau';
+SET sql-client.execution.result-mode=tableau;
 ```
 
 Note that when you use this mode with streaming query, the result will be continuously printed on the console. If the input data of
@@ -345,21 +345,21 @@ CREATE FUNCTION foo.bar.AggregateUDF AS myUDF;
 
 -- Properties that change the fundamental execution behavior of a table program.
 
-SET 'table.planner' = 'blink'; -- planner: either 'blink' (default) or 'old'
-SET 'execution.runtime-mode' = 'streaming'; -- execution mode either 'batch' or 'streaming'
-SET 'sql-client.execution.result-mode' = 'table'; -- available values: 'table', 'changelog' and 'tableau'
-SET 'sql-client.execution.max-table-result.rows' = '10000'; -- optional: maximum number of maintained rows
-SET 'parallelism.default' = '1'; -- optional: Flink's parallelism (1 by default)
-SET 'pipeline.auto-watermark-interval' = '200'; --optional: interval for periodic watermarks
-SET 'pipeline.max-parallelism' = '10'; -- optional: Flink's maximum parallelism
-SET 'table.exec.state.ttl' = '1000'; -- optional: table program's idle state time
-SET 'restart-strategy' = 'fixed-delay';
+SET table.planner = blink; -- planner: either 'blink' (default) or 'old'
+SET execution.runtime-mode = streaming; -- execution mode either 'batch' or 'streaming'
+SET sql-client.execution.result-mode = table; -- available values: 'table', 'changelog' and 'tableau'
+SET sql-client.execution.max-table-result.rows = 10000; -- optional: maximum number of maintained rows
+SET parallelism.default = 1; -- optional: Flink's parallelism (1 by default)
+SET pipeline.auto-watermark-interval = 200; --optional: interval for periodic watermarks
+SET pipeline.max-parallelism = 10; -- optional: Flink's maximum parallelism
+SET table.exec.state.ttl=1000; -- optional: table program's idle state time
+SET restart-strategy = fixed-delay;
 
 -- Configuration options for adjusting and tuning table programs.
 
-SET 'table.optimizer.join-reorder-enabled' = 'true';
-SET 'table.exec.spill-compression.enabled' = 'true';
-SET 'table.exec.spill-compression.block-size' = '128kb';
+SET table.optimizer.join-reorder-enabled = true;
+SET table.exec.spill-compression.enabled = true;
+SET table.exec.spill-compression.block-size = 128kb;
 ```
 
 This configuration:
@@ -409,7 +409,7 @@ In interactive Command Line, the SQL Client reads user inputs and executes the s
 
 SQL Client will print success message if the statement is executed successfully. When getting errors, SQL Client will also print error messages.
 By default, the error message only contains the error cause. In order to print the full exception stack for debugging, please set the
-`sql-client.verbose` to true through command `SET 'sql-client.verbose' = 'true';`.
+`sql-client.verbose` to true through command `SET sql-client.verbose = true;`.
 
 ### Execute SQL Files
 
@@ -435,19 +435,19 @@ CREATE TEMPORARY TABLE users (
 );
 
 -- set sync mode
-SET 'table.dml-sync' = 'true';
+SET table.dml-sync=true;
 
 -- set the job name
-SET 'pipeline.name' = 'SqlJob';
+SET pipeline.name=SqlJob;
 
 -- set the queue that the job submit to
-SET 'yarn.application.queue' = 'root';
+SET yarn.application.queue=root;
 
 -- set the job parallism
-SET 'parallism.default' = '100';
+SET parallism.default=100;
 
 -- restore from the specific savepoint path
-SET 'execution.savepoint.path' = '/tmp/flink-savepoints/savepoint-cca7bc-bb1e257f0dab';
+SET execution.savepoint.path=/tmp/flink-savepoints/savepoint-cca7bc-bb1e257f0dab;
 
 INSERT INTO pageviews_enriched
 SELECT *
@@ -615,7 +615,7 @@ previous DML statement finishes. In order to execute DML statements synchronousl
 `table.dml-sync` option true in SQL Client.
 
 ```sql
-Flink SQL> SET 'table.dml-sync' = 'true';
+Flink SQL> SET table.dml-sync = true;
 [INFO] Session property has been set.
 
 Flink SQL> INSERT INTO MyTableSink SELECT * FROM MyTableSource;
@@ -631,7 +631,7 @@ Flink SQL> INSERT INTO MyTableSink SELECT * FROM MyTableSource;
 Flink supports to start the job with specified savepoint. In SQL Client, it's allowed to use `SET` command to specify the path of the savepoint.
 
 ```sql
-Flink SQL> SET 'execution.savepoint.path' = '/tmp/flink-savepoints/savepoint-cca7bc-bb1e257f0dab';
+Flink SQL> SET execution.savepoint.path=/tmp/flink-savepoints/savepoint-cca7bc-bb1e257f0dab;
 [INFO] Session property has been set.
 
 -- all the following DML statements will be restroed from the specified savepoint path
@@ -654,7 +654,7 @@ For more details about creating and managing savepoints, please refer to [Job Li
 SQL Client supports to define job name for queries and DML statements through `SET` command.
 
 ```sql
-Flink SQL> SET 'pipeline.name' = 'kafka-to-hive';
+Flink SQL> SET pipeline.name= 'kafka-to-hive' ;
 [INFO] Session property has been set.
 
 -- all the following DML statements will use the specified job name.
@@ -679,7 +679,7 @@ To be compatible with before, SQL Client still supports to initialize with envir
 When set the key defined in YAML file, the SQL Client will print the warning messages to inform.
 
 ```sql
-Flink SQL> SET 'execution.type' = 'batch';
+Flink SQL> SET execution.type = batch;
 [WARNING] The specified key 'execution.type' is deprecated. Please use 'execution.runtime-mode' instead.
 [INFO] Session property has been set.
 


### PR DESCRIPTION
## What is the purpose of the change

This reverts commit 320ed880513377acc622daf7764a9be70e7704f0.

Changing the syntax in the current patch version caused confusion for
users of lower patch versions.

## Verifying this change

This change is a trivial rework / code cleanup without any test coverage.

## Does this pull request potentially affect one of the following parts:

  - Dependencies (does it add or upgrade a dependency): no
  - The public API, i.e., is any changed class annotated with `@Public(Evolving)`: no
  - The serializers: no
  - The runtime per-record code paths (performance sensitive): no
  - Anything that affects deployment or recovery: JobManager (and its components), Checkpointing, Kubernetes/Yarn, ZooKeeper: no
  - The S3 file system connector: no

## Documentation

  - Does this pull request introduce a new feature? no
  - If yes, how is the feature documented? not applicable
