### PR TITLE
[FLINK-24148] Add bloom filter option in RocksDBConfiguredOptions

### DIFF
--- a/docs/layouts/shortcodes/generated/rocksdb_configurable_configuration.html
+++ b/docs/layouts/shortcodes/generated/rocksdb_configurable_configuration.html
@@ -27,6 +27,18 @@
             <td>Approximate size of partitioned metadata packed per block. Currently applied to indexes block when partitioned index/filters option is enabled. RocksDB has default metadata blocksize as '4KB'.</td>
         </tr>
         <tr>
+            <td><h5>state.backend.rocksdb.bloom-filter.bits-per-key</h5></td>
+            <td style="word-wrap: break-word;">10.0</td>
+            <td>Double</td>
+            <td>Bits per key that bloom filter will use, this only take effect when bloom filter is used.</td>
+        </tr>
+        <tr>
+            <td><h5>state.backend.rocksdb.bloom-filter.use-full-filter</h5></td>
+            <td style="word-wrap: break-word;">true</td>
+            <td>Boolean</td>
+            <td>If true, RocksDB will use full filter instead of block-based filter, this only take effect when bloom filter is used.</td>
+        </tr>
+        <tr>
             <td><h5>state.backend.rocksdb.compaction.level.max-size-level-base</h5></td>
             <td style="word-wrap: break-word;">(none)</td>
             <td>MemorySize</td>
@@ -85,6 +97,12 @@
             <td style="word-wrap: break-word;">(none)</td>
             <td>Integer</td>
             <td>The maximum number of concurrent background flush and compaction jobs (per stateful operator). RocksDB has default configuration as '1'.</td>
+        </tr>
+        <tr>
+            <td><h5>state.backend.rocksdb.use-bloom-filter</h5></td>
+            <td style="word-wrap: break-word;">false</td>
+            <td>Boolean</td>
+            <td>If true, every newly created SST file will contain a Bloom filter. RocksDB disables it by default.</td>
         </tr>
         <tr>
             <td><h5>state.backend.rocksdb.write-batch-size</h5></td>

--- a/docs/layouts/shortcodes/generated/rocksdb_configurable_configuration.html
+++ b/docs/layouts/shortcodes/generated/rocksdb_configurable_configuration.html
@@ -33,10 +33,10 @@
             <td>Bits per key that bloom filter will use, this only take effect when bloom filter is used.</td>
         </tr>
         <tr>
-            <td><h5>state.backend.rocksdb.bloom-filter.use-full-filter</h5></td>
-            <td style="word-wrap: break-word;">true</td>
+            <td><h5>state.backend.rocksdb.bloom-filter.block-based-mode</h5></td>
+            <td style="word-wrap: break-word;">false</td>
             <td>Boolean</td>
-            <td>If true, RocksDB will use full filter instead of block-based filter, this only take effect when bloom filter is used.</td>
+            <td>If true, RocksDB will use block-based filter instead of full filter, this only take effect when bloom filter is used.</td>
         </tr>
         <tr>
             <td><h5>state.backend.rocksdb.compaction.level.max-size-level-base</h5></td>

--- a/flink-state-backends/flink-statebackend-rocksdb/src/main/java/org/apache/flink/contrib/streaming/state/DefaultConfigurableOptionsFactory.java
+++ b/flink-state-backends/flink-statebackend-rocksdb/src/main/java/org/apache/flink/contrib/streaming/state/DefaultConfigurableOptionsFactory.java
@@ -44,7 +44,7 @@ import java.util.Set;
 import static org.apache.flink.contrib.streaming.state.RocksDBConfigurableOptions.BLOCK_CACHE_SIZE;
 import static org.apache.flink.contrib.streaming.state.RocksDBConfigurableOptions.BLOCK_SIZE;
 import static org.apache.flink.contrib.streaming.state.RocksDBConfigurableOptions.BLOOM_FILTER_BITS_PER_KEY;
-import static org.apache.flink.contrib.streaming.state.RocksDBConfigurableOptions.BLOOM_FILTER_USE_FULL_FILTER;
+import static org.apache.flink.contrib.streaming.state.RocksDBConfigurableOptions.BLOOM_FILTER_BLOCK_BASED_MODE;
 import static org.apache.flink.contrib.streaming.state.RocksDBConfigurableOptions.COMPACTION_STYLE;
 import static org.apache.flink.contrib.streaming.state.RocksDBConfigurableOptions.LOG_DIR;
 import static org.apache.flink.contrib.streaming.state.RocksDBConfigurableOptions.LOG_FILE_NUM;
@@ -167,12 +167,12 @@ public class DefaultConfigurableOptionsFactory implements ConfigurableRocksDBOpt
                         isOptionConfigured(BLOOM_FILTER_BITS_PER_KEY)
                                 ? Double.parseDouble(getInternal(BLOOM_FILTER_BITS_PER_KEY.key()))
                                 : BLOOM_FILTER_BITS_PER_KEY.defaultValue();
-                final boolean useFullFilter =
-                        isOptionConfigured(BLOOM_FILTER_USE_FULL_FILTER)
+                final boolean blockBasedMode =
+                        isOptionConfigured(BLOOM_FILTER_BLOCK_BASED_MODE)
                                 ? Boolean.parseBoolean(
-                                        getInternal(BLOOM_FILTER_USE_FULL_FILTER.key()))
-                                : BLOOM_FILTER_USE_FULL_FILTER.defaultValue();
-                BloomFilter bloomFilter = new BloomFilter(bitsPerKey, useFullFilter);
+                                        getInternal(BLOOM_FILTER_BLOCK_BASED_MODE.key()))
+                                : BLOOM_FILTER_BLOCK_BASED_MODE.defaultValue();
+                BloomFilter bloomFilter = new BloomFilter(bitsPerKey, blockBasedMode);
                 handlesToClose.add(bloomFilter);
                 blockBasedTableConfig.setFilterPolicy(bloomFilter);
             }
@@ -473,12 +473,12 @@ public class DefaultConfigurableOptionsFactory implements ConfigurableRocksDBOpt
         return this;
     }
 
-    private boolean getBloomFilterUseFullFilter() {
-        return Boolean.parseBoolean(getInternal(BLOOM_FILTER_USE_FULL_FILTER.key()));
+    private boolean getBloomFilterBlockBasedMode() {
+        return Boolean.parseBoolean(getInternal(BLOOM_FILTER_BLOCK_BASED_MODE.key()));
     }
 
-    public DefaultConfigurableOptionsFactory setBloomFilterUseFullFilter(boolean useFullFilter) {
-        setInternal(BLOOM_FILTER_USE_FULL_FILTER.key(), String.valueOf(useFullFilter));
+    public DefaultConfigurableOptionsFactory setBloomFilterBlockBasedMode(boolean blockBasedMode) {
+        setInternal(BLOOM_FILTER_BLOCK_BASED_MODE.key(), String.valueOf(blockBasedMode));
         return this;
     }
 
@@ -505,7 +505,7 @@ public class DefaultConfigurableOptionsFactory implements ConfigurableRocksDBOpt
                 BLOCK_CACHE_SIZE,
                 USE_BLOOM_FILTER,
                 BLOOM_FILTER_BITS_PER_KEY,
-                BLOOM_FILTER_USE_FULL_FILTER
+                BLOOM_FILTER_BLOCK_BASED_MODE
             };
 
     private static final Set<ConfigOption<?>> POSITIVE_INT_CONFIG_SET =

--- a/flink-state-backends/flink-statebackend-rocksdb/src/main/java/org/apache/flink/contrib/streaming/state/RocksDBConfigurableOptions.java
+++ b/flink-state-backends/flink-statebackend-rocksdb/src/main/java/org/apache/flink/contrib/streaming/state/RocksDBConfigurableOptions.java
@@ -241,4 +241,11 @@ public class RocksDBConfigurableOptions implements Serializable {
                     .defaultValue(10.0)
                     .withDescription(
                             "Bits per key that bloom filter will use, this only take effect when bloom filter is used.");
+
+    public static final ConfigOption<Boolean> BLOOM_FILTER_USE_FULL_FILTER =
+            key("state.backend.rocksdb.bloom-filter.use-full-filter")
+                    .booleanType()
+                    .defaultValue(true)
+                    .withDescription(
+                            "If true, RocksDB will use full filter instead of block-based filter, this only take effect when bloom filter is used.");
 }

--- a/flink-state-backends/flink-statebackend-rocksdb/src/main/java/org/apache/flink/contrib/streaming/state/RocksDBConfigurableOptions.java
+++ b/flink-state-backends/flink-statebackend-rocksdb/src/main/java/org/apache/flink/contrib/streaming/state/RocksDBConfigurableOptions.java
@@ -227,4 +227,18 @@ public class RocksDBConfigurableOptions implements Serializable {
                     .withDescription(
                             "The max size of the consumed memory for RocksDB batch write, "
                                     + "will flush just based on item count if this config set to 0.");
+
+    public static final ConfigOption<Boolean> USE_BLOOM_FILTER =
+            key("state.backend.rocksdb.use-bloom-filter")
+                    .booleanType()
+                    .defaultValue(false)
+                    .withDescription(
+                            "If true, every newly created SST file will contain a Bloom filter. RocksDB disables it by default.");
+
+    public static final ConfigOption<Double> BLOOM_FILTER_BITS_PER_KEY =
+            key("state.backend.rocksdb.bloom-filter.bits-per-key")
+                    .doubleType()
+                    .defaultValue(10.0)
+                    .withDescription(
+                            "Bits per key that bloom filter will use, this only take effect when bloom filter is used.");
 }

--- a/flink-state-backends/flink-statebackend-rocksdb/src/main/java/org/apache/flink/contrib/streaming/state/RocksDBConfigurableOptions.java
+++ b/flink-state-backends/flink-statebackend-rocksdb/src/main/java/org/apache/flink/contrib/streaming/state/RocksDBConfigurableOptions.java
@@ -242,10 +242,10 @@ public class RocksDBConfigurableOptions implements Serializable {
                     .withDescription(
                             "Bits per key that bloom filter will use, this only take effect when bloom filter is used.");
 
-    public static final ConfigOption<Boolean> BLOOM_FILTER_USE_FULL_FILTER =
-            key("state.backend.rocksdb.bloom-filter.use-full-filter")
+    public static final ConfigOption<Boolean> BLOOM_FILTER_BLOCK_BASED_MODE =
+            key("state.backend.rocksdb.bloom-filter.block-based-mode")
                     .booleanType()
-                    .defaultValue(true)
+                    .defaultValue(false)
                     .withDescription(
-                            "If true, RocksDB will use full filter instead of block-based filter, this only take effect when bloom filter is used.");
+                            "If true, RocksDB will use block-based filter instead of full filter, this only take effect when bloom filter is used.");
 }

--- a/flink-state-backends/flink-statebackend-rocksdb/src/test/java/org/apache/flink/contrib/streaming/state/RocksDBStateBackendConfigTest.java
+++ b/flink-state-backends/flink-statebackend-rocksdb/src/test/java/org/apache/flink/contrib/streaming/state/RocksDBStateBackendConfigTest.java
@@ -485,7 +485,7 @@ public class RocksDBStateBackendConfigTest {
                         .setBlockCacheSize("512mb")
                         .setUseBloomFilter(true)
                         .setBloomFilterBitsPerKey(12.0)
-                        .setBloomFilterUseFullFilter(false);
+                        .setBloomFilterBlockBasedMode(false);
 
         try (RocksDBResourceContainer optionsContainer =
                 new RocksDBResourceContainer(PredefinedOptions.DEFAULT, customizedOptions)) {
@@ -546,7 +546,7 @@ public class RocksDBStateBackendConfigTest {
 
             verifyIllegalArgument(RocksDBConfigurableOptions.COMPACTION_STYLE, "LEV");
             verifyIllegalArgument(RocksDBConfigurableOptions.USE_BLOOM_FILTER, "NO");
-            verifyIllegalArgument(RocksDBConfigurableOptions.BLOOM_FILTER_USE_FULL_FILTER, "YES");
+            verifyIllegalArgument(RocksDBConfigurableOptions.BLOOM_FILTER_BLOCK_BASED_MODE, "YES");
         }
 
         // verify legal configuration

--- a/flink-state-backends/flink-statebackend-rocksdb/src/test/java/org/apache/flink/contrib/streaming/state/RocksDBStateBackendConfigTest.java
+++ b/flink-state-backends/flink-statebackend-rocksdb/src/test/java/org/apache/flink/contrib/streaming/state/RocksDBStateBackendConfigTest.java
@@ -51,6 +51,7 @@ import org.junit.Rule;
 import org.junit.Test;
 import org.junit.rules.TemporaryFolder;
 import org.rocksdb.BlockBasedTableConfig;
+import org.rocksdb.BloomFilter;
 import org.rocksdb.ColumnFamilyOptions;
 import org.rocksdb.CompactionStyle;
 import org.rocksdb.DBOptions;
@@ -481,7 +482,9 @@ public class RocksDBStateBackendConfigTest {
                         .setMinWriteBufferNumberToMerge(3)
                         .setBlockSize("64KB")
                         .setMetadataBlockSize("16KB")
-                        .setBlockCacheSize("512mb");
+                        .setBlockCacheSize("512mb")
+                        .setUseBloomFilter(true)
+                        .setBloomFilterBitsPerKey(12.0);
 
         try (RocksDBResourceContainer optionsContainer =
                 new RocksDBResourceContainer(PredefinedOptions.DEFAULT, customizedOptions)) {
@@ -507,6 +510,7 @@ public class RocksDBStateBackendConfigTest {
             assertEquals(64 * SizeUnit.KB, tableConfig.blockSize());
             assertEquals(16 * SizeUnit.KB, tableConfig.metadataBlockSize());
             assertEquals(512 * SizeUnit.MB, tableConfig.blockCacheSize());
+            assertTrue(tableConfig.filterPolicy() instanceof BloomFilter);
         }
     }
 
@@ -540,6 +544,7 @@ public class RocksDBStateBackendConfigTest {
             verifyIllegalArgument(RocksDBConfigurableOptions.USE_DYNAMIC_LEVEL_SIZE, "1");
 
             verifyIllegalArgument(RocksDBConfigurableOptions.COMPACTION_STYLE, "LEV");
+            verifyIllegalArgument(RocksDBConfigurableOptions.USE_BLOOM_FILTER, "NO");
         }
 
         // verify legal configuration
@@ -561,6 +566,7 @@ public class RocksDBStateBackendConfigTest {
             configuration.setString(RocksDBConfigurableOptions.BLOCK_SIZE.key(), "4 kb");
             configuration.setString(RocksDBConfigurableOptions.METADATA_BLOCK_SIZE.key(), "8 kb");
             configuration.setString(RocksDBConfigurableOptions.BLOCK_CACHE_SIZE.key(), "512 mb");
+            configuration.setString(RocksDBConfigurableOptions.USE_BLOOM_FILTER.key(), "TRUE");
 
             DefaultConfigurableOptionsFactory optionsFactory =
                     new DefaultConfigurableOptionsFactory();
@@ -590,6 +596,7 @@ public class RocksDBStateBackendConfigTest {
                 assertEquals(4 * SizeUnit.KB, tableConfig.blockSize());
                 assertEquals(8 * SizeUnit.KB, tableConfig.metadataBlockSize());
                 assertEquals(512 * SizeUnit.MB, tableConfig.blockCacheSize());
+                assertTrue(tableConfig.filterPolicy() instanceof BloomFilter);
             }
         }
     }

--- a/flink-state-backends/flink-statebackend-rocksdb/src/test/java/org/apache/flink/contrib/streaming/state/RocksDBStateBackendConfigTest.java
+++ b/flink-state-backends/flink-statebackend-rocksdb/src/test/java/org/apache/flink/contrib/streaming/state/RocksDBStateBackendConfigTest.java
@@ -484,7 +484,8 @@ public class RocksDBStateBackendConfigTest {
                         .setMetadataBlockSize("16KB")
                         .setBlockCacheSize("512mb")
                         .setUseBloomFilter(true)
-                        .setBloomFilterBitsPerKey(12.0);
+                        .setBloomFilterBitsPerKey(12.0)
+                        .setBloomFilterUseFullFilter(false);
 
         try (RocksDBResourceContainer optionsContainer =
                 new RocksDBResourceContainer(PredefinedOptions.DEFAULT, customizedOptions)) {
@@ -545,6 +546,7 @@ public class RocksDBStateBackendConfigTest {
 
             verifyIllegalArgument(RocksDBConfigurableOptions.COMPACTION_STYLE, "LEV");
             verifyIllegalArgument(RocksDBConfigurableOptions.USE_BLOOM_FILTER, "NO");
+            verifyIllegalArgument(RocksDBConfigurableOptions.BLOOM_FILTER_USE_FULL_FILTER, "YES");
         }
 
         // verify legal configuration


### PR DESCRIPTION
## What is the purpose of the change

This change provides bloom filter option in `RocksDBConfigurableOptions`. (more details see https://github.com/facebook/rocksdb/wiki/RocksDB-Bloom-Filter)

## Brief change log

* Add a bloom filter option in `RocksDBConfigurableOptions`.

## Verifying this change

`RocksDBStateBackendConfigTest` help to verify the legality. 

## Does this pull request potentially affect one of the following parts:

  - Dependencies (does it add or upgrade a dependency): no
  - The public API, i.e., is any changed class annotated with `@Public(Evolving)`: no
  - The serializers: no
  - The runtime per-record code paths (performance sensitive): no
  - Anything that affects deployment or recovery: JobManager (and its components), Checkpointing, Kubernetes/Yarn, ZooKeeper: no
  - The S3 file system connector: no

## Documentation

  - Does this pull request introduce a new feature? yes
  - If yes, how is the feature documented? docs
