### PR TITLE
[FLINK-24142]Fix Document DataStream Connectors File Sink ORC Format …

### DIFF
--- a/docs/content.zh/docs/connectors/datastream/file_sink.md
+++ b/docs/content.zh/docs/connectors/datastream/file_sink.md
@@ -379,8 +379,10 @@ class PersonVectorizer(schema: String) extends Vectorizer[Person](schema) {
   override def vectorize(element: Person, batch: VectorizedRowBatch): Unit = {
     val nameColVector = batch.cols(0).asInstanceOf[BytesColumnVector]
     val ageColVector = batch.cols(1).asInstanceOf[LongColumnVector]
-    nameColVector.setVal(batch.size + 1, element.getName.getBytes(StandardCharsets.UTF_8))
-    ageColVector.vector(batch.size + 1) = element.getAge
+    val row = batch.size 
+    nameColVector.setVal(row, element.getName.getBytes(StandardCharsets.UTF_8))
+    ageColVector.vector(row) = element.getAge
+    batch.size += 1
   }
 
 }

--- a/docs/content/docs/connectors/datastream/file_sink.md
+++ b/docs/content/docs/connectors/datastream/file_sink.md
@@ -406,8 +406,10 @@ class PersonVectorizer(schema: String) extends Vectorizer[Person](schema) {
   override def vectorize(element: Person, batch: VectorizedRowBatch): Unit = {
     val nameColVector = batch.cols(0).asInstanceOf[BytesColumnVector]
     val ageColVector = batch.cols(1).asInstanceOf[LongColumnVector]
-    nameColVector.setVal(batch.size + 1, element.getName.getBytes(StandardCharsets.UTF_8))
-    ageColVector.vector(batch.size + 1) = element.getAge
+    val row = batch.size 
+    nameColVector.setVal(row, element.getName.getBytes(StandardCharsets.UTF_8))
+    ageColVector.vector(row) = element.getAge
+    batch.size += 1
   }
 
 }


### PR DESCRIPTION
## What is the purpose of the change

Compared with the Java sample, batch.size in the implementation of vectorizer in scala cannot be increased. As a result, the generated Orc file has no data. 


## Brief change log

  - *fix content and content.zh*


## Verifying this change

Not needed.

## Does this pull request potentially affect one of the following parts:

  - Dependencies (does it add or upgrade a dependency): no
  - The public API, i.e., is any changed class annotated with `@Public(Evolving)`: no
  - The serializers: no
  - The runtime per-record code paths (performance sensitive): no
  - Anything that affects deployment or recovery: JobManager (and its components), Checkpointing, Kubernetes/Yarn, ZooKeeper: no
  - The S3 file system connector: no

## Documentation

  - This is a document change.
