### PR TITLE
[FLINK-23180] Do not initialize checkpoint base locations when checkp…

### DIFF
--- a/flink-runtime/src/main/java/org/apache/flink/runtime/checkpoint/CheckpointCoordinator.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/checkpoint/CheckpointCoordinator.java
@@ -325,7 +325,7 @@ public class CheckpointCoordinator {
             this.checkpointStorageView = checkpointStorage.createCheckpointStorage(job);
 
             if (isPeriodicCheckpointingConfigured()) {
-                checkpointStorageView.initializeBaseLocations();
+                checkpointStorageView.initializeBaseLocationsForCheckpoint();
             }
         } catch (IOException e) {
             throw new FlinkRuntimeException(

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/checkpoint/CheckpointCoordinator.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/checkpoint/CheckpointCoordinator.java
@@ -323,7 +323,10 @@ public class CheckpointCoordinator {
 
         try {
             this.checkpointStorageView = checkpointStorage.createCheckpointStorage(job);
-            checkpointStorageView.initializeBaseLocations();
+
+            if (isPeriodicCheckpointingConfigured()) {
+                checkpointStorageView.initializeBaseLocations();
+            }
         } catch (IOException e) {
             throw new FlinkRuntimeException(
                     "Failed to create checkpoint storage at checkpoint coordinator side.", e);

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/state/CheckpointStorageCoordinatorView.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/state/CheckpointStorageCoordinatorView.java
@@ -57,12 +57,11 @@ public interface CheckpointStorageCoordinatorView {
     CompletedCheckpointStorageLocation resolveCheckpoint(String externalPointer) throws IOException;
 
     /**
-     * Initializes the necessary prerequisites for storage locations of checkpoints/savepoints.
+     * Initializes the necessary prerequisites for storage locations of checkpoints.
      *
      * <p>For file-based checkpoint storage, this method would initialize essential base checkpoint
      * directories on checkpoint coordinator side and should be executed before calling {@link
-     * #initializeLocationForCheckpoint(long)} and {@link #initializeLocationForSavepoint(long,
-     * String)}.
+     * #initializeLocationForCheckpoint(long)}.
      *
      * @throws IOException Thrown, if these base storage locations cannot be initialized due to an
      *     I/O exception.

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/state/CheckpointStorageCoordinatorView.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/state/CheckpointStorageCoordinatorView.java
@@ -66,7 +66,7 @@ public interface CheckpointStorageCoordinatorView {
      * @throws IOException Thrown, if these base storage locations cannot be initialized due to an
      *     I/O exception.
      */
-    void initializeBaseLocations() throws IOException;
+    void initializeBaseLocationsForCheckpoint() throws IOException;
 
     /**
      * Initializes a storage location for new checkpoint with the given ID.

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/state/filesystem/FsCheckpointStorageAccess.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/state/filesystem/FsCheckpointStorageAccess.java
@@ -109,7 +109,7 @@ public class FsCheckpointStorageAccess extends AbstractFsCheckpointStorageAccess
     }
 
     @Override
-    public void initializeBaseLocations() throws IOException {
+    public void initializeBaseLocationsForCheckpoint() throws IOException {
         fileSystem.mkdirs(sharedStateDirectory);
         fileSystem.mkdirs(taskOwnedStateDirectory);
         baseLocationsInitialized = true;

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/state/memory/MemoryBackendCheckpointStorageAccess.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/state/memory/MemoryBackendCheckpointStorageAccess.java
@@ -112,7 +112,7 @@ public class MemoryBackendCheckpointStorageAccess extends AbstractFsCheckpointSt
     }
 
     @Override
-    public void initializeBaseLocations() {
+    public void initializeBaseLocationsForCheckpoint() {
         // since 'checkpointDir' which under 'checkpointsDirectory' would be created when calling
         // #initializeLocationForCheckpoint, we could also avoid to call mkdirs for the
         // 'checkpointsDirectory' here.

--- a/flink-runtime/src/test/java/org/apache/flink/runtime/state/StateBackendMigrationTestBase.java
+++ b/flink-runtime/src/test/java/org/apache/flink/runtime/state/StateBackendMigrationTestBase.java
@@ -1258,7 +1258,7 @@ public abstract class StateBackendMigrationTestBase<B extends AbstractStateBacke
         if (checkpointStorageLocation == null) {
             CheckpointStorageAccess checkpointStorageAccess =
                     getCheckpointStorage().createCheckpointStorage(new JobID());
-            checkpointStorageAccess.initializeBaseLocations();
+            checkpointStorageAccess.initializeBaseLocationsForCheckpoint();
             checkpointStorageLocation = checkpointStorageAccess.initializeLocationForCheckpoint(1L);
         }
         return checkpointStorageLocation;

--- a/flink-runtime/src/test/java/org/apache/flink/runtime/state/TestingCheckpointStorageAccessCoordinatorView.java
+++ b/flink-runtime/src/test/java/org/apache/flink/runtime/state/TestingCheckpointStorageAccessCoordinatorView.java
@@ -72,7 +72,7 @@ public class TestingCheckpointStorageAccessCoordinatorView
     }
 
     @Override
-    public void initializeBaseLocations() throws IOException {}
+    public void initializeBaseLocationsForCheckpoint() throws IOException {}
 
     @Override
     public CheckpointStorageLocation initializeLocationForCheckpoint(long checkpointId)

--- a/flink-runtime/src/test/java/org/apache/flink/runtime/state/filesystem/AbstractFileCheckpointStorageAccessTestBase.java
+++ b/flink-runtime/src/test/java/org/apache/flink/runtime/state/filesystem/AbstractFileCheckpointStorageAccessTestBase.java
@@ -165,9 +165,9 @@ public abstract class AbstractFileCheckpointStorageAccessTestBase {
         final long checkpointId = 177;
 
         final CheckpointStorageAccess storage1 = createCheckpointStorage(checkpointDir);
-        storage1.initializeBaseLocations();
+        storage1.initializeBaseLocationsForCheckpoint();
         final CheckpointStorageAccess storage2 = createCheckpointStorage(checkpointDir);
-        storage2.initializeBaseLocations();
+        storage2.initializeBaseLocationsForCheckpoint();
 
         final CheckpointStorageLocation loc1 =
                 storage1.initializeLocationForCheckpoint(checkpointId);
@@ -221,7 +221,7 @@ public abstract class AbstractFileCheckpointStorageAccessTestBase {
         final long checkpointId = 177;
 
         final CheckpointStorageAccess storage = createCheckpointStorage(randomTempPath());
-        storage.initializeBaseLocations();
+        storage.initializeBaseLocationsForCheckpoint();
         final CheckpointStorageLocation loc = storage.initializeLocationForCheckpoint(checkpointId);
 
         // write to the metadata file for the checkpoint

--- a/flink-runtime/src/test/java/org/apache/flink/runtime/state/filesystem/FsCheckpointStorageAccessTest.java
+++ b/flink-runtime/src/test/java/org/apache/flink/runtime/state/filesystem/FsCheckpointStorageAccessTest.java
@@ -230,7 +230,7 @@ public class FsCheckpointStorageAccessTest extends AbstractFileCheckpointStorage
         assertFalse(baseDir.exists());
 
         // mkdirs would only be called when initializeBaseLocations
-        storage.initializeBaseLocations();
+        storage.initializeBaseLocationsForCheckpoint();
         assertTrue(baseDir.exists());
 
         // mkdir would not be called when resolveCheckpointStorageLocation

--- a/flink-runtime/src/test/java/org/apache/flink/runtime/state/filesystem/FsStateBackendEntropyTest.java
+++ b/flink-runtime/src/test/java/org/apache/flink/runtime/state/filesystem/FsStateBackendEntropyTest.java
@@ -61,7 +61,7 @@ public class FsStateBackendEntropyTest {
         final FsCheckpointStorageAccess storage =
                 new FsCheckpointStorageAccess(
                         fs, checkpointDir, null, new JobID(), fileSizeThreshold, 4096);
-        storage.initializeBaseLocations();
+        storage.initializeBaseLocationsForCheckpoint();
 
         final FsCheckpointStorageLocation location =
                 (FsCheckpointStorageLocation) storage.initializeLocationForCheckpoint(96562);

--- a/flink-runtime/src/test/java/org/apache/flink/runtime/state/testutils/BackendForTestStream.java
+++ b/flink-runtime/src/test/java/org/apache/flink/runtime/state/testutils/BackendForTestStream.java
@@ -89,7 +89,7 @@ public class BackendForTestStream extends MemoryStateBackend {
         }
 
         @Override
-        public void initializeBaseLocations() {
+        public void initializeBaseLocationsForCheckpoint() {
             throw new UnsupportedOperationException();
         }
 

--- a/flink-runtime/src/test/java/org/apache/flink/runtime/state/ttl/mock/MockCheckpointStorage.java
+++ b/flink-runtime/src/test/java/org/apache/flink/runtime/state/ttl/mock/MockCheckpointStorage.java
@@ -55,7 +55,7 @@ public class MockCheckpointStorage implements CheckpointStorage {
             }
 
             @Override
-            public void initializeBaseLocations() {}
+            public void initializeBaseLocationsForCheckpoint() {}
 
             @Override
             public CheckpointStorageLocation initializeLocationForCheckpoint(long checkpointId) {

--- a/flink-streaming-java/src/main/java/org/apache/flink/streaming/api/operators/sorted/state/NonCheckpointingStorageAccess.java
+++ b/flink-streaming-java/src/main/java/org/apache/flink/streaming/api/operators/sorted/state/NonCheckpointingStorageAccess.java
@@ -45,7 +45,7 @@ class NonCheckpointingStorageAccess implements CheckpointStorageAccess {
     }
 
     @Override
-    public void initializeBaseLocations() {}
+    public void initializeBaseLocationsForCheckpoint() {}
 
     @Override
     public CheckpointStorageLocation initializeLocationForCheckpoint(long checkpointId) {

--- a/flink-tests/src/test/java/org/apache/flink/test/checkpointing/SavepointITCase.java
+++ b/flink-tests/src/test/java/org/apache/flink/test/checkpointing/SavepointITCase.java
@@ -115,6 +115,7 @@ import java.util.Collection;
 import java.util.Collections;
 import java.util.List;
 import java.util.Map;
+import java.util.Objects;
 import java.util.Optional;
 import java.util.Random;
 import java.util.concurrent.CompletableFuture;
@@ -511,6 +512,48 @@ public class SavepointITCase extends TestLogger {
             assertThrowableWithMessage(e, graph.getJobID().toString());
             assertThrowableWithMessage(e, "is not a streaming job");
         } finally {
+            cluster.after();
+        }
+    }
+
+    @Test
+    public void testTriggerSavepointWithoutCheckpointBaseLocations() throws Exception {
+        StreamExecutionEnvironment env = StreamExecutionEnvironment.getExecutionEnvironment();
+        env.getCheckpointConfig().disableCheckpointing();
+        env.setParallelism(1);
+
+        env.addSource(new IntegerStreamSource()).addSink(new DiscardingSink<>());
+
+        JobGraph jobGraph = env.getStreamGraph().getJobGraph();
+
+        Configuration config = getFileBasedCheckpointsConfig();
+        config.addAll(jobGraph.getJobConfiguration());
+
+        MiniClusterWithClientResource cluster =
+                new MiniClusterWithClientResource(
+                        new MiniClusterResourceConfiguration.Builder()
+                                .setConfiguration(config)
+                                .setNumberTaskManagers(1)
+                                .setNumberSlotsPerTaskManager(1)
+                                .build());
+        cluster.before();
+        ClusterClient<?> client = cluster.getClusterClient();
+
+        String savepointPath = null;
+        try {
+            client.submitJob(jobGraph).get();
+
+            waitForAllTaskRunning(cluster.getMiniCluster(), jobGraph.getJobID(), false);
+
+            savepointPath = client.triggerSavepoint(jobGraph.getJobID(), null).get();
+
+            client.cancel(jobGraph.getJobID()).get();
+            // checkpoint directory should not be initialized
+            assertEquals(0, Objects.requireNonNull(checkpointDir.listFiles()).length);
+        } finally {
+            if (null != savepointPath) {
+                client.disposeSavepoint(savepointPath);
+            }
             cluster.after();
         }
     }

--- a/flink-tests/src/test/java/org/apache/flink/test/checkpointing/SavepointITCase.java
+++ b/flink-tests/src/test/java/org/apache/flink/test/checkpointing/SavepointITCase.java
@@ -136,6 +136,7 @@ import static org.apache.flink.util.ExceptionUtils.assertThrowableWithMessage;
 import static org.apache.flink.util.ExceptionUtils.findThrowable;
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertFalse;
+import static org.junit.Assert.assertNotNull;
 import static org.junit.Assert.assertThat;
 import static org.junit.Assert.assertTrue;
 import static org.junit.Assert.fail;
@@ -546,6 +547,8 @@ public class SavepointITCase extends TestLogger {
             waitForAllTaskRunning(cluster.getMiniCluster(), jobGraph.getJobID(), false);
 
             savepointPath = client.triggerSavepoint(jobGraph.getJobID(), null).get();
+
+            assertNotNull(savepointPath);
 
             client.cancel(jobGraph.getJobID()).get();
             // checkpoint directory should not be initialized


### PR DESCRIPTION
## What is the purpose of the change

Currently batch jobs will initialize checkpoint location eagerly when CheckpointCoordinator is created, which will create lots of useless directories on distributed filesystem. The change initializes checkpoint base locations only when checkpointing is enabled. 

## Brief change log

* Check whether checkpoint is enabled before initializing base locations.


## Verifying this change

* #CheckpointCoordinatorTest#testBaseLocationsInitialized: Check that base locations will not be initialized when checkpointing is disabled.

## Does this pull request potentially affect one of the following parts:

  - Dependencies (does it add or upgrade a dependency): no
  - The public API, i.e., is any changed class annotated with `@Public(Evolving)`: no
  - The serializers: no
  - The runtime per-record code paths (performance sensitive): no
  - Anything that affects deployment or recovery: JobManager (and its components), Checkpointing, Kubernetes/Yarn, ZooKeeper: Checkpointing
  - The S3 file system connector: no

## Documentation

  - Does this pull request introduce a new feature? no
  - If yes, how is the feature documented? not applicable
