### PR TITLE
[FLINK-24134][python][docs] Update the documentation about how to install PyFlink in docker

### DIFF
--- a/docs/content.zh/docs/deployment/resource-providers/standalone/docker.md
+++ b/docs/content.zh/docs/deployment/resource-providers/standalone/docker.md
@@ -316,19 +316,44 @@ FROM flink:{{< version >}}
 FROM flink:latest
 {{< /unstable >}}
 
-# install python3 and pip3
+# install python3: it has updated Python to 3.9 in Debian 11 and so install Python 3.7 from source
+# it currently only supports Python 3.6, 3.7 and 3.8 in PyFlink officially.
+
+RUN apt-get update -y && \
+apt-get install -y build-essential libssl-dev zlib1g-dev libbz2-dev libffi-dev && \
+wget https://www.python.org/ftp/python/3.7.9/Python-3.7.9.tgz && \
+tar -xvf Python-3.7.9.tgz && \
+cd Python-3.7.9 && \
+./configure --without-tests --enable-shared && \
+make -j6 && \
+make install && \
+ldconfig /usr/local/lib && \
+cd .. && rm -f Python-3.7.9.tgz && rm -rf Python-3.7.9 && \
+ln -s /usr/local/bin/python3 /usr/local/bin/python && \
+apt-get clean && \
+rm -rf /var/lib/apt/lists/*
+
+# install PyFlink
+{{< stable >}}
+RUN pip3 install apache-flink=={{< version >}}
+{{< /stable >}}
+{{< unstable >}}
+COPY apache-flink*.tar.gz /
+RUN pip3 install /apache-flink-libraries*.tar.gz && pip3 install /apache-flink*.tar.gz
+{{< /unstable >}}
+```
+
+<span class="label label-info">Note</span> For Debian 10 and below, Python 3 could also be installed
+alternatively as following:
+```Dockerfile
 RUN apt-get update -y && \
 apt-get install -y python3.7 python3-pip python3.7-dev && rm -rf /var/lib/apt/lists/*
 RUN ln -s /usr/bin/python3 /usr/bin/python
-
-# install Python Flink
-{{< stable >}}
-RUN pip3 install apache-flink[=={{< version >}}]
-{{< /stable >}}
-{{< unstable >}}
-RUN pip3 install apache-flink
-{{< /unstable >}}
 ```
+
+{{< unstable >}}
+<span class="label label-info">Note</span> PyFlink packages could be built-in according to [development guide]({{< ref "docs/flinkDev/building" >}}#build-pyflink)
+{{< /unstable >}}
 
 Build the image named as **pyflink:latest**:
 

--- a/docs/content.zh/docs/flinkDev/building.md
+++ b/docs/content.zh/docs/flinkDev/building.md
@@ -95,22 +95,22 @@ mvn clean install -DskipTests -Dfast
 
 #### 安装
 
-进入 Flink 源码根目录，并执行以下命令，构建 apache-flink 和 apache-flink-libraries 的源码发布包和 wheel 包：
+进入 Flink 源码根目录，并执行以下命令，构建 `apache-flink` 和 `apache-flink-libraries` 的源码发布包和 wheel 包：
 
 ```bash
-cd flink-python; python setup.py sdist bdist_wheel; cd apache-flink-libraries; python setup.py sdist bdist_wheel; cd ..;
+cd flink-python; python setup.py sdist bdist_wheel; cd apache-flink-libraries; python setup.py sdist; cd ..;
 ```
 
-构建好的 apache-flink-libraries 的源码发布包和 wheel 包位于`./flink-python/apache-flink-libraries/dist/`目录下。它们均可使用 pip 安装，比如:
+构建好的 `apache-flink-libraries` 的源码发布包位于 `./flink-python/apache-flink-libraries/dist/` 目录下。可使用 pip 安装，比如:
 
 ```bash
 python -m pip install apache-flink-libraries/dist/*.tar.gz
 ```
 
-构建好的 apache-flink 的源码发布包和 wheel 包位于`./flink-python/dist/`目录下。它们均可使用 pip 安装，比如:
+构建好的 `apache-flink` 的源码发布包和 wheel 包位于 `./flink-python/dist/` 目录下。它们均可使用 pip 安装，比如:
 
 ```bash
-python -m pip install dist/*.tar.gz
+python -m pip install dist/*.whl
 ```
 
 ## 依赖屏蔽

--- a/docs/content/docs/deployment/resource-providers/standalone/docker.md
+++ b/docs/content/docs/deployment/resource-providers/standalone/docker.md
@@ -316,19 +316,44 @@ FROM flink:{{< version >}}
 FROM flink:latest
 {{< /unstable >}}
 
-# install python3 and pip3
+# install python3: it has updated Python to 3.9 in Debian 11 and so install Python 3.7 from source
+# it currently only supports Python 3.6, 3.7 and 3.8 in PyFlink officially.
+
+RUN apt-get update -y && \
+apt-get install -y build-essential libssl-dev zlib1g-dev libbz2-dev libffi-dev && \
+wget https://www.python.org/ftp/python/3.7.9/Python-3.7.9.tgz && \
+tar -xvf Python-3.7.9.tgz && \
+cd Python-3.7.9 && \
+./configure --without-tests --enable-shared && \
+make -j6 && \
+make install && \
+ldconfig /usr/local/lib && \
+cd .. && rm -f Python-3.7.9.tgz && rm -rf Python-3.7.9 && \
+ln -s /usr/local/bin/python3 /usr/local/bin/python && \
+apt-get clean && \
+rm -rf /var/lib/apt/lists/*
+
+# install PyFlink
+{{< stable >}}
+RUN pip3 install apache-flink=={{< version >}}
+{{< /stable >}}
+{{< unstable >}}
+COPY apache-flink*.tar.gz /
+RUN pip3 install /apache-flink-libraries*.tar.gz && pip3 install /apache-flink*.tar.gz
+{{< /unstable >}}
+```
+
+<span class="label label-info">Note</span> For Debian 10 and below, Python 3 could also be installed
+alternatively as following:
+```Dockerfile
 RUN apt-get update -y && \
 apt-get install -y python3.7 python3-pip python3.7-dev && rm -rf /var/lib/apt/lists/*
 RUN ln -s /usr/bin/python3 /usr/bin/python
-
-# install Python Flink
-{{< stable >}}
-RUN pip3 install apache-flink[=={{< version >}}]
-{{< /stable >}}
-{{< unstable >}}
-RUN pip3 install apache-flink
-{{< /unstable >}}
 ```
+
+{{< unstable >}}
+<span class="label label-info">Note</span> PyFlink packages could be built-in according to [development guide]({{< ref "docs/flinkDev/building" >}}#build-pyflink)
+{{< /unstable >}}
 
 Build the image named as **pyflink:latest**:
 

--- a/docs/content/docs/flinkDev/building.md
+++ b/docs/content/docs/flinkDev/building.md
@@ -89,22 +89,22 @@ mvn clean install -DskipTests -Dfast
 
 #### Installation
 
-Then go to the root directory of flink source code and run this command to build the sdist package and wheel package of apache-flink and apache-flink-libraries:
+Then go to the root directory of flink source code and run this command to build the sdist package and wheel package of `apache-flink` and `apache-flink-libraries`:
 
 ```bash
-cd flink-python; python setup.py sdist bdist_wheel; cd apache-flink-libraries; python setup.py sdist bdist_wheel; cd ..;
+cd flink-python; python setup.py sdist bdist_wheel; cd apache-flink-libraries; python setup.py sdist; cd ..;
 ```
 
-The sdist and wheel packages of will be found under `./flink-python/apache-flink-libraries/dist/`. Either of them could be used for pip installation, such as:
+The sdist package of `apache-flink-libraries` will be found under `./flink-python/apache-flink-libraries/dist/`. It could be installed as following:
 
 ```bash
 python -m pip install apache-flink-libraries/dist/*.tar.gz
 ```
 
-The sdist and wheel packages of will be found under `./flink-python/dist/`. Either of them could be used for pip installation, such as:
+The sdist and wheel packages of `apache-flink` will be found under `./flink-python/dist/`. Either of them could be used for installation, such as:
 
 ```bash
-python -m pip install dist/*.tar.gz
+python -m pip install dist/*.whl
 ```
 
 ## Dependency Shading


### PR DESCRIPTION

## What is the purpose of the change

*This pull request fixes the documentation about how to install PyFlink in docker as it has bumped the Python version from Python 3.7 to Python 3.9 in debian 11, however it doesn't support Python 3.9 officially in PyFlink. *


## Verifying this change

Tests the steps manually.

## Does this pull request potentially affect one of the following parts:

  - Dependencies (does it add or upgrade a dependency): (yes / no)
  - The public API, i.e., is any changed class annotated with `@Public(Evolving)`: (yes / no)
  - The serializers: (yes / no / don't know)
  - The runtime per-record code paths (performance sensitive): (yes / no / don't know)
  - Anything that affects deployment or recovery: JobManager (and its components), Checkpointing, Kubernetes/Yarn, ZooKeeper: (yes / no / don't know)
  - The S3 file system connector: (yes / no / don't know)

## Documentation

  - Does this pull request introduce a new feature? (yes / no)
  - If yes, how is the feature documented? (not applicable / docs / JavaDocs / not documented)
