### PR TITLE
[FLINK-24020][web] Aggregate HTTP requests before custom netty handers are getting the data

### DIFF
--- a/flink-runtime-web/src/main/java/org/apache/flink/runtime/webmonitor/HttpRequestHandler.java
+++ b/flink-runtime-web/src/main/java/org/apache/flink/runtime/webmonitor/HttpRequestHandler.java
@@ -51,6 +51,7 @@ import org.apache.flink.shaded.netty4.io.netty.handler.codec.http.multipart.Http
 import org.apache.flink.shaded.netty4.io.netty.handler.codec.http.multipart.HttpPostRequestDecoder.EndOfDataDecoderException;
 import org.apache.flink.shaded.netty4.io.netty.handler.codec.http.multipart.InterfaceHttpData;
 import org.apache.flink.shaded.netty4.io.netty.handler.codec.http.multipart.InterfaceHttpData.HttpDataType;
+import org.apache.flink.shaded.netty4.io.netty.util.ReferenceCountUtil;
 
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
@@ -169,6 +170,8 @@ public class HttpRequestHandler extends SimpleChannelInboundHandler<HttpObject> 
                     // fire next channel handler
                     ctx.fireChannelRead(request);
                 }
+            } else {
+                ctx.fireChannelRead(ReferenceCountUtil.retain(msg));
             }
         } catch (Throwable t) {
             currentRequest = null;

--- a/flink-runtime-web/src/main/java/org/apache/flink/runtime/webmonitor/utils/WebFrontendBootstrap.java
+++ b/flink-runtime-web/src/main/java/org/apache/flink/runtime/webmonitor/utils/WebFrontendBootstrap.java
@@ -23,6 +23,7 @@ import org.apache.flink.configuration.Configuration;
 import org.apache.flink.configuration.JobManagerOptions;
 import org.apache.flink.runtime.io.network.netty.InboundChannelHandlerFactory;
 import org.apache.flink.runtime.io.network.netty.SSLHandlerFactory;
+import org.apache.flink.runtime.rest.FlinkHttpObjectAggregator;
 import org.apache.flink.runtime.rest.handler.router.Router;
 import org.apache.flink.runtime.rest.handler.router.RouterHandler;
 import org.apache.flink.runtime.webmonitor.HttpRequestHandler;
@@ -58,6 +59,8 @@ import java.util.Map;
 import java.util.Optional;
 import java.util.ServiceLoader;
 
+import static org.apache.flink.configuration.RestOptions.SERVER_MAX_CONTENT_LENGTH;
+
 /** This classes encapsulates the boot-strapping of netty for the web-frontend. */
 public class WebFrontendBootstrap {
     private final Router router;
@@ -66,6 +69,7 @@ public class WebFrontendBootstrap {
     private final ServerBootstrap bootstrap;
     private final Channel serverChannel;
     private final String restAddress;
+    private final int maxContentLength;
     private final Map<String, String> responseHeaders;
     @VisibleForTesting List<InboundChannelHandlerFactory> inboundChannelHandlerFactories;
 
@@ -82,6 +86,7 @@ public class WebFrontendBootstrap {
         this.router = Preconditions.checkNotNull(router);
         this.log = Preconditions.checkNotNull(log);
         this.uploadDir = directory;
+        this.maxContentLength = config.get(SERVER_MAX_CONTENT_LENGTH);
         this.responseHeaders = new HashMap<>();
         inboundChannelHandlerFactories = new ArrayList<>();
         ServiceLoader<InboundChannelHandlerFactory> loader =
@@ -119,7 +124,12 @@ public class WebFrontendBootstrap {
                                             serverSSLFactory.createNettySSLHandler(ch.alloc()));
                         }
 
-                        ch.pipeline().addLast(new HttpServerCodec());
+                        ch.pipeline()
+                                .addLast(new HttpServerCodec())
+                                .addLast(new HttpRequestHandler(uploadDir))
+                                .addLast(
+                                        new FlinkHttpObjectAggregator(
+                                                maxContentLength, responseHeaders));
 
                         for (InboundChannelHandlerFactory factory :
                                 inboundChannelHandlerFactories) {
@@ -132,7 +142,6 @@ public class WebFrontendBootstrap {
 
                         ch.pipeline()
                                 .addLast(new ChunkedWriteHandler())
-                                .addLast(new HttpRequestHandler(uploadDir))
                                 .addLast(handler.getName(), handler)
                                 .addLast(new PipelineErrorHandler(WebFrontendBootstrap.this.log));
                     }

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/rest/RestServerEndpoint.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/rest/RestServerEndpoint.java
@@ -207,7 +207,12 @@ public abstract class RestServerEndpoint implements AutoCloseableAsync {
                                                         sslHandlerFactory));
                             }
 
-                            ch.pipeline().addLast(new HttpServerCodec());
+                            ch.pipeline()
+                                    .addLast(new HttpServerCodec())
+                                    .addLast(new FileUploadHandler(uploadDir))
+                                    .addLast(
+                                            new FlinkHttpObjectAggregator(
+                                                    maxContentLength, responseHeaders));
 
                             for (InboundChannelHandlerFactory factory :
                                     inboundChannelHandlerFactories) {
@@ -219,10 +224,6 @@ public abstract class RestServerEndpoint implements AutoCloseableAsync {
                             }
 
                             ch.pipeline()
-                                    .addLast(new FileUploadHandler(uploadDir))
-                                    .addLast(
-                                            new FlinkHttpObjectAggregator(
-                                                    maxContentLength, responseHeaders))
                                     .addLast(new ChunkedWriteHandler())
                                     .addLast(handler.getName(), handler)
                                     .addLast(new PipelineErrorHandler(log, responseHeaders));


### PR DESCRIPTION
## What is the purpose of the change

Custom netty handlers can do authentication (amongst other possibilities).
This requires that the handlers are getting the whole HttpRequest content and not just partial data.
At the moment it's not implemented this way which ends-up in flaky behaviour.
Namely sometimes for example History server responds properly (when the request fits into one netty chunk) but sometimes authentication fails (when the request split into multiple netty chunks).

In this PR I've moved/added `FlinkHttpObjectAggregator` before custom netty handlers.

## Brief change log

* Added `FlinkHttpObjectAggregator` in `WebFrontendBootstrap` before custom netty handlers.
* Moved `FlinkHttpObjectAggregator` in `RestServerEndpoint` before custom netty handlers.

Important note that upload handlers are streaming the uploadable content so they must be before `FlinkHttpObjectAggregator`.

## Verifying this change

* Existing unit tests.
* Endurance test on cluster.

## Does this pull request potentially affect one of the following parts:

  - Dependencies (does it add or upgrade a dependency): no
  - The public API, i.e., is any changed class annotated with `@Public(Evolving)`: no
  - The serializers: no
  - The runtime per-record code paths (performance sensitive): no
  - Anything that affects deployment or recovery: JobManager (and its components), Checkpointing, Kubernetes/Yarn, ZooKeeper: no
  - The S3 file system connector: no

## Documentation

  - Does this pull request introduce a new feature? no
  - If yes, how is the feature documented? not applicable
