### PR TITLE
[FLINK-22198][connector/kafka] Disable log deletion on Kafka broker in Kafka table connector tests

### DIFF
--- a/flink-connectors/flink-connector-kafka/src/test/java/org/apache/flink/streaming/connectors/kafka/table/KafkaChangelogTableITCase.java
+++ b/flink-connectors/flink-connector-kafka/src/test/java/org/apache/flink/streaming/connectors/kafka/table/KafkaChangelogTableITCase.java
@@ -26,6 +26,7 @@ import org.apache.flink.streaming.api.datastream.DataStreamSource;
 import org.apache.flink.streaming.api.environment.StreamExecutionEnvironment;
 import org.apache.flink.streaming.connectors.kafka.FlinkKafkaProducerBase;
 import org.apache.flink.streaming.connectors.kafka.KafkaTestBaseWithFlink;
+import org.apache.flink.streaming.connectors.kafka.KafkaTestEnvironment;
 import org.apache.flink.streaming.connectors.kafka.partitioner.FlinkFixedPartitioner;
 import org.apache.flink.streaming.connectors.kafka.partitioner.FlinkKafkaPartitioner;
 import org.apache.flink.table.api.EnvironmentSettings;
@@ -34,6 +35,7 @@ import org.apache.flink.table.api.bridge.java.StreamTableEnvironment;
 import org.apache.flink.table.planner.factories.TestValuesTableFactory;
 
 import org.junit.Before;
+import org.junit.BeforeClass;
 import org.junit.Test;
 
 import java.time.Duration;
@@ -49,6 +51,22 @@ public class KafkaChangelogTableITCase extends KafkaTestBaseWithFlink {
 
     protected StreamExecutionEnvironment env;
     protected StreamTableEnvironment tEnv;
+
+    @BeforeClass
+    public static void prepare() throws Exception {
+        LOG.info("-------------------------------------------------------------------------");
+        LOG.info("    Starting KafkaChangelogTableITCase ");
+        LOG.info("-------------------------------------------------------------------------");
+
+        Properties serverProperties = new Properties();
+        serverProperties.put("log.retention.ms", Integer.toString(-1));
+        startClusters(
+                KafkaTestEnvironment.createConfig()
+                        .setKafkaServersNumber(NUMBER_OF_KAFKA_SERVERS)
+                        .setSecureMode(false)
+                        .setHideKafkaBehindProxy(false)
+                        .setKafkaServerProperties(serverProperties));
+    }
 
     @Before
     public void setup() {

--- a/flink-connectors/flink-connector-kafka/src/test/java/org/apache/flink/streaming/connectors/kafka/table/KafkaTableITCase.java
+++ b/flink-connectors/flink-connector-kafka/src/test/java/org/apache/flink/streaming/connectors/kafka/table/KafkaTableITCase.java
@@ -25,6 +25,7 @@ import org.apache.flink.streaming.api.environment.StreamExecutionEnvironment;
 import org.apache.flink.streaming.api.functions.sink.SinkFunction;
 import org.apache.flink.streaming.connectors.kafka.KafkaTestBase;
 import org.apache.flink.streaming.connectors.kafka.KafkaTestBaseWithFlink;
+import org.apache.flink.streaming.connectors.kafka.KafkaTestEnvironment;
 import org.apache.flink.streaming.connectors.kafka.partitioner.FlinkKafkaPartitioner;
 import org.apache.flink.table.api.EnvironmentSettings;
 import org.apache.flink.table.api.TableResult;
@@ -35,6 +36,7 @@ import org.apache.flink.test.util.SuccessException;
 import org.apache.flink.types.Row;
 
 import org.junit.Before;
+import org.junit.BeforeClass;
 import org.junit.Test;
 import org.junit.runner.RunWith;
 import org.junit.runners.Parameterized;
@@ -48,6 +50,7 @@ import java.util.Comparator;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
+import java.util.Properties;
 import java.util.stream.Collectors;
 import java.util.stream.IntStream;
 
@@ -87,6 +90,22 @@ public class KafkaTableITCase extends KafkaTestBaseWithFlink {
 
     protected StreamExecutionEnvironment env;
     protected StreamTableEnvironment tEnv;
+
+    @BeforeClass
+    public static void prepare() throws Exception {
+        LOG.info("-------------------------------------------------------------------------");
+        LOG.info("    Starting KafkaTableITCase ");
+        LOG.info("-------------------------------------------------------------------------");
+
+        Properties serverProperties = new Properties();
+        serverProperties.put("log.retention.ms", Integer.toString(-1));
+        startClusters(
+                KafkaTestEnvironment.createConfig()
+                        .setKafkaServersNumber(NUMBER_OF_KAFKA_SERVERS)
+                        .setSecureMode(false)
+                        .setHideKafkaBehindProxy(false)
+                        .setKafkaServerProperties(serverProperties));
+    }
 
     @Before
     public void setup() {

--- a/flink-connectors/flink-connector-kafka/src/test/java/org/apache/flink/streaming/connectors/kafka/table/UpsertKafkaTableITCase.java
+++ b/flink-connectors/flink-connector-kafka/src/test/java/org/apache/flink/streaming/connectors/kafka/table/UpsertKafkaTableITCase.java
@@ -21,6 +21,7 @@ package org.apache.flink.streaming.connectors.kafka.table;
 import org.apache.flink.api.common.restartstrategy.RestartStrategies;
 import org.apache.flink.streaming.api.environment.StreamExecutionEnvironment;
 import org.apache.flink.streaming.connectors.kafka.KafkaTestBaseWithFlink;
+import org.apache.flink.streaming.connectors.kafka.KafkaTestEnvironment;
 import org.apache.flink.table.api.EnvironmentSettings;
 import org.apache.flink.table.api.TableResult;
 import org.apache.flink.table.api.bridge.java.StreamTableEnvironment;
@@ -28,6 +29,7 @@ import org.apache.flink.table.planner.factories.TestValuesTableFactory;
 import org.apache.flink.types.Row;
 
 import org.junit.Before;
+import org.junit.BeforeClass;
 import org.junit.Test;
 import org.junit.runner.RunWith;
 import org.junit.runners.Parameterized;
@@ -39,6 +41,7 @@ import java.util.Collections;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
+import java.util.Properties;
 import java.util.stream.Collectors;
 
 import static org.apache.flink.streaming.connectors.kafka.table.KafkaTableTestUtils.collectRows;
@@ -68,6 +71,22 @@ public class UpsertKafkaTableITCase extends KafkaTestBaseWithFlink {
 
     private static final String USERS_TOPIC = "users";
     private static final String WORD_COUNT_TOPIC = "word_count";
+
+    @BeforeClass
+    public static void prepare() throws Exception {
+        LOG.info("-------------------------------------------------------------------------");
+        LOG.info("    Starting UpsertKafkaTableITCase ");
+        LOG.info("-------------------------------------------------------------------------");
+
+        Properties serverProperties = new Properties();
+        serverProperties.put("log.retention.ms", Integer.toString(-1));
+        startClusters(
+                KafkaTestEnvironment.createConfig()
+                        .setKafkaServersNumber(NUMBER_OF_KAFKA_SERVERS)
+                        .setSecureMode(false)
+                        .setHideKafkaBehindProxy(false)
+                        .setKafkaServerProperties(serverProperties));
+    }
 
     @Before
     public void setup() {


### PR DESCRIPTION
## What is the purpose of the change

This pull request set Kafka broker configuration log.retention.ms to -1 in KafkaTableTestBase to prevent deleting records with explicitly assigned timestamp.


## Brief change log

*(for example:)*
  - Add additional property "log.retention.ms = -1" to KafkaServer config


## Verifying this change

This change is a trivial rework / code cleanup without any test coverage.

## Does this pull request potentially affect one of the following parts:

  - Dependencies (does it add or upgrade a dependency): (no)
  - The public API, i.e., is any changed class annotated with `@Public(Evolving)`: (no)
  - The serializers: (no)
  - The runtime per-record code paths (performance sensitive): (no)
  - Anything that affects deployment or recovery: JobManager (and its components), Checkpointing, Kubernetes/Yarn, ZooKeeper: (no)
  - The S3 file system connector: (no)

## Documentation

  - Does this pull request introduce a new feature? (no)
  - If yes, how is the feature documented? (not applicable)
