### PR TITLE
[FLINK-22971][tests] Bump testcontainers to 1.16.0

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -135,7 +135,7 @@ under the License.
 		<protoc.version>3.17.3</protoc.version>
 		<arrow.version>0.16.0</arrow.version>
 		<okhttp.version>3.14.9</okhttp.version>
-		<testcontainers.version>1.15.3</testcontainers.version>
+		<testcontainers.version>1.16.0</testcontainers.version>
 		<lz4.version>1.8.0</lz4.version>
 		<japicmp.skip>false</japicmp.skip>
 		<flink.convergence.phase>validate</flink.convergence.phase>


### PR DESCRIPTION
This version uses http5 as the default transport, which is not affected by the race condition we run into.

https://github.com/testcontainers/testcontainers-java/issues/3531