### PR TITLE
[FLINK-24162][tests] Check MAX_WATERMARK per attempt in FLIP-147 tests

### DIFF
--- a/flink-tests/src/test/java/org/apache/flink/runtime/operators/lifecycle/PartiallyFinishedSourcesITCase.java
+++ b/flink-tests/src/test/java/org/apache/flink/runtime/operators/lifecycle/PartiallyFinishedSourcesITCase.java
@@ -17,6 +17,7 @@
 
 package org.apache.flink.runtime.operators.lifecycle;
 
+import org.apache.flink.configuration.Configuration;
 import org.apache.flink.runtime.OperatorIDPair;
 import org.apache.flink.runtime.jobgraph.JobVertexID;
 import org.apache.flink.runtime.operators.lifecycle.command.TestCommandDispatcher.TestCommandScope;
@@ -24,17 +25,26 @@ import org.apache.flink.runtime.operators.lifecycle.event.CheckpointCompletedEve
 import org.apache.flink.runtime.operators.lifecycle.graph.TestJobBuilders.TestingGraphBuilder;
 import org.apache.flink.runtime.operators.lifecycle.validation.DrainingValidator;
 import org.apache.flink.runtime.operators.lifecycle.validation.FinishingValidator;
-import org.apache.flink.test.util.AbstractTestBase;
+import org.apache.flink.runtime.testutils.MiniClusterResourceConfiguration;
+import org.apache.flink.test.util.MiniClusterWithClientResource;
 import org.apache.flink.testutils.junit.SharedObjects;
+import org.apache.flink.util.TestLogger;
 
+import org.junit.After;
+import org.junit.Before;
 import org.junit.Rule;
 import org.junit.Test;
 import org.junit.runner.RunWith;
 import org.junit.runners.Parameterized;
 import org.junit.runners.Parameterized.Parameter;
 
+import java.util.ArrayList;
+import java.util.List;
+
+import static java.util.Arrays.asList;
 import static java.util.stream.StreamSupport.stream;
 import static org.apache.flink.api.common.restartstrategy.RestartStrategies.fixedDelayRestart;
+import static org.apache.flink.configuration.JobManagerOptions.EXECUTION_FAILOVER_STRATEGY;
 import static org.apache.flink.runtime.operators.lifecycle.command.TestCommand.FINISH_SOURCES;
 import static org.apache.flink.runtime.operators.lifecycle.command.TestCommandDispatcher.TestCommandScope.ALL_SUBTASKS;
 import static org.apache.flink.runtime.operators.lifecycle.command.TestCommandDispatcher.TestCommandScope.SINGLE_SUBTASK;
@@ -54,9 +64,36 @@ import static org.apache.flink.streaming.api.environment.ExecutionCheckpointingO
  * the same.
  */
 @RunWith(Parameterized.class)
-public class PartiallyFinishedSourcesITCase extends AbstractTestBase {
+public class PartiallyFinishedSourcesITCase extends TestLogger {
 
     @Rule public final SharedObjects sharedObjects = SharedObjects.create();
+
+    private MiniClusterWithClientResource miniClusterResource;
+
+    @Before
+    public void init() throws Exception {
+        Configuration configuration = new Configuration();
+        // set failover strategy on the cluster level
+        // choose it from the parameter because it may affect the test
+        // - "region" is currently the default
+        // - "full" is enforced by Adaptive/Reactive scheduler (even when parameterized)
+        configuration.set(EXECUTION_FAILOVER_STRATEGY, failoverStrategy);
+        miniClusterResource =
+                new MiniClusterWithClientResource(
+                        new MiniClusterResourceConfiguration.Builder()
+                                .setConfiguration(configuration)
+                                .setNumberTaskManagers(1)
+                                .setNumberSlotsPerTaskManager(4)
+                                .build());
+        miniClusterResource.before();
+    }
+
+    @After
+    public void tearDown() {
+        if (miniClusterResource != null) {
+            miniClusterResource.after();
+        }
+    }
 
     @Parameter(0)
     public TestingGraphBuilder graphBuilder;
@@ -66,6 +103,9 @@ public class PartiallyFinishedSourcesITCase extends AbstractTestBase {
 
     @Parameter(2)
     public boolean failover;
+
+    @Parameter(3)
+    public String failoverStrategy;
 
     @Test
     public void test() throws Exception {
@@ -131,15 +171,25 @@ public class PartiallyFinishedSourcesITCase extends AbstractTestBase {
                 .equals(operatorID);
     }
 
-    @Parameterized.Parameters(name = "{0} {1}, failover: {2}")
-    public static Object[] parameters() {
-        return new Object[] {
-            new Object[] {SIMPLE_GRAPH_BUILDER, SINGLE_SUBTASK, true},
-            new Object[] {COMPLEX_GRAPH_BUILDER, SINGLE_SUBTASK, true},
-            new Object[] {COMPLEX_GRAPH_BUILDER, ALL_SUBTASKS, true},
-            new Object[] {SIMPLE_GRAPH_BUILDER, SINGLE_SUBTASK, false},
-            new Object[] {COMPLEX_GRAPH_BUILDER, SINGLE_SUBTASK, false},
-            new Object[] {COMPLEX_GRAPH_BUILDER, ALL_SUBTASKS, false},
-        };
+    @Parameterized.Parameters(name = "{0} {1}, failover: {2}, strategy: {3}")
+    public static List<Object[]> parameters() {
+        List<String> failoverStrategies = asList("full", "region");
+        List<List<Object>> rest =
+                asList(
+                        asList(SIMPLE_GRAPH_BUILDER, SINGLE_SUBTASK, true),
+                        asList(COMPLEX_GRAPH_BUILDER, SINGLE_SUBTASK, true),
+                        asList(COMPLEX_GRAPH_BUILDER, ALL_SUBTASKS, true),
+                        asList(SIMPLE_GRAPH_BUILDER, SINGLE_SUBTASK, false),
+                        asList(COMPLEX_GRAPH_BUILDER, SINGLE_SUBTASK, false),
+                        asList(COMPLEX_GRAPH_BUILDER, ALL_SUBTASKS, false));
+        List<Object[]> result = new ArrayList<>();
+        for (String failoverStrategy : failoverStrategies) {
+            for (List<Object> otherParams : rest) {
+                List<Object> fullList = new ArrayList<>(otherParams);
+                fullList.add(failoverStrategy);
+                result.add(fullList.toArray());
+            }
+        }
+        return result;
     }
 }

--- a/flink-tests/src/test/java/org/apache/flink/runtime/operators/lifecycle/event/CheckpointCompletedEvent.java
+++ b/flink-tests/src/test/java/org/apache/flink/runtime/operators/lifecycle/event/CheckpointCompletedEvent.java
@@ -30,8 +30,9 @@ import java.util.Objects;
 public class CheckpointCompletedEvent extends TestEvent {
     public final long checkpointID;
 
-    public CheckpointCompletedEvent(String operatorId, int subtaskIndex, long checkpointID) {
-        super(operatorId, subtaskIndex);
+    public CheckpointCompletedEvent(
+            String operatorId, int subtaskIndex, int attemptNumber, long checkpointID) {
+        super(operatorId, subtaskIndex, attemptNumber);
         this.checkpointID = checkpointID;
     }
 

--- a/flink-tests/src/test/java/org/apache/flink/runtime/operators/lifecycle/event/CheckpointStartedEvent.java
+++ b/flink-tests/src/test/java/org/apache/flink/runtime/operators/lifecycle/event/CheckpointStartedEvent.java
@@ -31,8 +31,9 @@ import java.util.Objects;
 public class CheckpointStartedEvent extends TestEvent {
     public final long checkpointID;
 
-    public CheckpointStartedEvent(String operatorId, int subtaskIndex, long checkpointID) {
-        super(operatorId, subtaskIndex);
+    public CheckpointStartedEvent(
+            String operatorId, int subtaskIndex, int attemptNumber, long checkpointID) {
+        super(operatorId, subtaskIndex, attemptNumber);
         this.checkpointID = checkpointID;
     }
 

--- a/flink-tests/src/test/java/org/apache/flink/runtime/operators/lifecycle/event/InputEndedEvent.java
+++ b/flink-tests/src/test/java/org/apache/flink/runtime/operators/lifecycle/event/InputEndedEvent.java
@@ -30,8 +30,8 @@ import java.util.Objects;
 public class InputEndedEvent extends TestEvent {
     public final int inputId;
 
-    public InputEndedEvent(String operatorId, int subtaskIndex, int inputId) {
-        super(operatorId, subtaskIndex);
+    public InputEndedEvent(String operatorId, int subtaskIndex, int attemptNumber, int inputId) {
+        super(operatorId, subtaskIndex, attemptNumber);
         this.inputId = inputId;
     }
 

--- a/flink-tests/src/test/java/org/apache/flink/runtime/operators/lifecycle/event/OperatorFinishedEvent.java
+++ b/flink-tests/src/test/java/org/apache/flink/runtime/operators/lifecycle/event/OperatorFinishedEvent.java
@@ -38,9 +38,10 @@ public class OperatorFinishedEvent extends TestEvent {
     public OperatorFinishedEvent(
             String operatorId,
             int subtaskIndex,
+            int attemptNumber,
             long lastSent,
             LastReceivedVertexDataInfo receiveInfo) {
-        super(operatorId, subtaskIndex);
+        super(operatorId, subtaskIndex, attemptNumber);
         this.receiveInfo = receiveInfo;
         this.lastSent = lastSent;
     }

--- a/flink-tests/src/test/java/org/apache/flink/runtime/operators/lifecycle/event/OperatorStartedEvent.java
+++ b/flink-tests/src/test/java/org/apache/flink/runtime/operators/lifecycle/event/OperatorStartedEvent.java
@@ -22,7 +22,7 @@ public class OperatorStartedEvent extends TestEvent {
     private final int attemptNumber;
 
     public OperatorStartedEvent(String operatorId, int subtaskIndex, int attemptNumber) {
-        super(operatorId, subtaskIndex);
+        super(operatorId, subtaskIndex, attemptNumber);
         this.attemptNumber = attemptNumber;
     }
 

--- a/flink-tests/src/test/java/org/apache/flink/runtime/operators/lifecycle/event/TestCommandAckEvent.java
+++ b/flink-tests/src/test/java/org/apache/flink/runtime/operators/lifecycle/event/TestCommandAckEvent.java
@@ -26,7 +26,7 @@ public class TestCommandAckEvent extends TestEvent {
 
     public TestCommandAckEvent(
             String operatorId, int subtaskIndex, int attemptNumber, TestCommand command) {
-        super(operatorId, subtaskIndex);
+        super(operatorId, subtaskIndex, attemptNumber);
         this.command = command;
         this.attemptNumber = attemptNumber;
     }

--- a/flink-tests/src/test/java/org/apache/flink/runtime/operators/lifecycle/event/TestEvent.java
+++ b/flink-tests/src/test/java/org/apache/flink/runtime/operators/lifecycle/event/TestEvent.java
@@ -30,11 +30,13 @@ import java.util.Objects;
 public abstract class TestEvent implements Serializable {
     public final String operatorId;
     public final int subtaskIndex;
+    public final int attemptNumber;
     private static final long serialVersionUID = 1L;
 
-    TestEvent(String operatorId, int subtaskIndex) {
+    TestEvent(String operatorId, int subtaskIndex, int attemptNumber) {
         this.operatorId = operatorId;
         this.subtaskIndex = subtaskIndex;
+        this.attemptNumber = attemptNumber;
     }
 
     @Override

--- a/flink-tests/src/test/java/org/apache/flink/runtime/operators/lifecycle/event/WatermarkReceivedEvent.java
+++ b/flink-tests/src/test/java/org/apache/flink/runtime/operators/lifecycle/event/WatermarkReceivedEvent.java
@@ -32,8 +32,9 @@ public class WatermarkReceivedEvent extends TestEvent {
     public final long ts;
     public final int inputId;
 
-    public WatermarkReceivedEvent(String operatorId, int subtaskIndex, long ts, int inputId) {
-        super(operatorId, subtaskIndex);
+    public WatermarkReceivedEvent(
+            String operatorId, int subtaskIndex, int attemptNumber, long ts, int inputId) {
+        super(operatorId, subtaskIndex, attemptNumber);
         this.ts = ts;
         this.inputId = inputId;
     }

--- a/flink-tests/src/test/java/org/apache/flink/runtime/operators/lifecycle/graph/OneInputTestStreamOperator.java
+++ b/flink-tests/src/test/java/org/apache/flink/runtime/operators/lifecycle/graph/OneInputTestStreamOperator.java
@@ -73,6 +73,7 @@ class OneInputTestStreamOperator extends AbstractStreamOperator<TestDataElement>
                 new CheckpointStartedEvent(
                         operatorID,
                         getRuntimeContext().getIndexOfThisSubtask(),
+                        getRuntimeContext().getAttemptNumber(),
                         context.getCheckpointId()));
         super.snapshotState(context);
     }
@@ -81,7 +82,10 @@ class OneInputTestStreamOperator extends AbstractStreamOperator<TestDataElement>
     public void notifyCheckpointComplete(long checkpointId) throws Exception {
         eventQueue.add(
                 new CheckpointCompletedEvent(
-                        operatorID, getRuntimeContext().getIndexOfThisSubtask(), checkpointId));
+                        operatorID,
+                        getRuntimeContext().getIndexOfThisSubtask(),
+                        getRuntimeContext().getAttemptNumber(),
+                        checkpointId));
         super.notifyCheckpointComplete(checkpointId);
     }
 
@@ -91,6 +95,7 @@ class OneInputTestStreamOperator extends AbstractStreamOperator<TestDataElement>
                 new OperatorFinishedEvent(
                         operatorID,
                         getRuntimeContext().getIndexOfThisSubtask(),
+                        getRuntimeContext().getAttemptNumber(),
                         lastDataSent,
                         new OperatorFinishedEvent.LastReceivedVertexDataInfo(lastDataReceived)));
         super.finish();
@@ -121,6 +126,7 @@ class OneInputTestStreamOperator extends AbstractStreamOperator<TestDataElement>
                 new WatermarkReceivedEvent(
                         operatorID,
                         getRuntimeContext().getIndexOfThisSubtask(),
+                        getRuntimeContext().getAttemptNumber(),
                         mark.getTimestamp(),
                         1));
         super.processWatermark(mark);
@@ -129,7 +135,11 @@ class OneInputTestStreamOperator extends AbstractStreamOperator<TestDataElement>
     @Override
     public void endInput() throws Exception {
         eventQueue.add(
-                new InputEndedEvent(operatorID, getRuntimeContext().getIndexOfThisSubtask(), 1));
+                new InputEndedEvent(
+                        operatorID,
+                        getRuntimeContext().getIndexOfThisSubtask(),
+                        getRuntimeContext().getAttemptNumber(),
+                        1));
     }
 
     @Override

--- a/flink-tests/src/test/java/org/apache/flink/runtime/operators/lifecycle/graph/TestEventSource.java
+++ b/flink-tests/src/test/java/org/apache/flink/runtime/operators/lifecycle/graph/TestEventSource.java
@@ -98,6 +98,7 @@ class TestEventSource extends RichSourceFunction<TestDataElement>
                     new OperatorFinishedEvent(
                             operatorID,
                             getRuntimeContext().getIndexOfThisSubtask(),
+                            getRuntimeContext().getAttemptNumber(),
                             lastSent,
                             new LastReceivedVertexDataInfo(emptyMap())));
         }

--- a/flink-tests/src/test/java/org/apache/flink/runtime/operators/lifecycle/graph/TwoInputTestStreamOperator.java
+++ b/flink-tests/src/test/java/org/apache/flink/runtime/operators/lifecycle/graph/TwoInputTestStreamOperator.java
@@ -74,6 +74,7 @@ class TwoInputTestStreamOperator extends AbstractStreamOperator<TestDataElement>
                 new CheckpointStartedEvent(
                         operatorID,
                         getRuntimeContext().getIndexOfThisSubtask(),
+                        getRuntimeContext().getAttemptNumber(),
                         context.getCheckpointId()));
         super.snapshotState(context);
     }
@@ -82,7 +83,10 @@ class TwoInputTestStreamOperator extends AbstractStreamOperator<TestDataElement>
     public void notifyCheckpointComplete(long checkpointId) throws Exception {
         collectEvent(
                 new CheckpointCompletedEvent(
-                        operatorID, getRuntimeContext().getIndexOfThisSubtask(), checkpointId));
+                        operatorID,
+                        getRuntimeContext().getIndexOfThisSubtask(),
+                        getRuntimeContext().getAttemptNumber(),
+                        checkpointId));
         super.notifyCheckpointComplete(checkpointId);
     }
 
@@ -92,6 +96,7 @@ class TwoInputTestStreamOperator extends AbstractStreamOperator<TestDataElement>
                 new OperatorFinishedEvent(
                         operatorID,
                         getRuntimeContext().getIndexOfThisSubtask(),
+                        getRuntimeContext().getAttemptNumber(),
                         lastDataSent,
                         new LastReceivedVertexDataInfo(lastDataReceived)));
         super.finish();
@@ -122,6 +127,7 @@ class TwoInputTestStreamOperator extends AbstractStreamOperator<TestDataElement>
                 new WatermarkReceivedEvent(
                         operatorID,
                         getRuntimeContext().getIndexOfThisSubtask(),
+                        getRuntimeContext().getAttemptNumber(),
                         mark.getTimestamp(),
                         1));
         super.processWatermark1(mark);
@@ -133,6 +139,7 @@ class TwoInputTestStreamOperator extends AbstractStreamOperator<TestDataElement>
                 new WatermarkReceivedEvent(
                         operatorID,
                         getRuntimeContext().getIndexOfThisSubtask(),
+                        getRuntimeContext().getAttemptNumber(),
                         mark.getTimestamp(),
                         2));
         super.processWatermark2(mark);
@@ -152,7 +159,10 @@ class TwoInputTestStreamOperator extends AbstractStreamOperator<TestDataElement>
     public void endInput(int inputId) throws Exception {
         collectEvent(
                 new InputEndedEvent(
-                        operatorID, getRuntimeContext().getIndexOfThisSubtask(), inputId));
+                        operatorID,
+                        getRuntimeContext().getIndexOfThisSubtask(),
+                        getRuntimeContext().getAttemptNumber(),
+                        inputId));
     }
 
     @Override

--- a/flink-tests/src/test/java/org/apache/flink/runtime/operators/lifecycle/validation/DrainingValidator.java
+++ b/flink-tests/src/test/java/org/apache/flink/runtime/operators/lifecycle/validation/DrainingValidator.java
@@ -21,14 +21,21 @@ import org.apache.flink.runtime.OperatorIDPair;
 import org.apache.flink.runtime.jobgraph.JobVertex;
 import org.apache.flink.runtime.jobgraph.OperatorID;
 import org.apache.flink.runtime.operators.lifecycle.TestJobWithDescription;
+import org.apache.flink.runtime.operators.lifecycle.command.TestCommand;
 import org.apache.flink.runtime.operators.lifecycle.event.InputEndedEvent;
+import org.apache.flink.runtime.operators.lifecycle.event.TestCommandAckEvent;
 import org.apache.flink.runtime.operators.lifecycle.event.TestEvent;
 import org.apache.flink.runtime.operators.lifecycle.event.WatermarkReceivedEvent;
 import org.apache.flink.streaming.api.watermark.Watermark;
 
+import java.util.ArrayList;
 import java.util.BitSet;
+import java.util.HashMap;
+import java.util.HashSet;
 import java.util.List;
+import java.util.Map;
 import java.util.NoSuchElementException;
+import java.util.Set;
 
 import static java.lang.String.format;
 import static org.junit.Assert.assertEquals;
@@ -47,21 +54,55 @@ public class DrainingValidator implements TestOperatorLifecycleValidator {
             String operatorId,
             int subtaskIndex,
             List<TestEvent> operatorEvents) {
+
+        Map<Integer, List<TestEvent>> byAttempt = new HashMap<>();
+        Set<Integer> normallyFinishedAttempts = new HashSet<>();
+        int lastAttempt = Integer.MIN_VALUE;
+        for (TestEvent e : operatorEvents) {
+            byAttempt.computeIfAbsent(e.attemptNumber, ign -> new ArrayList<>()).add(e);
+            if (isFinishAck(e)) {
+                normallyFinishedAttempts.add(e.attemptNumber);
+            }
+            lastAttempt = Math.max(lastAttempt, e.attemptNumber);
+        }
+
+        for (Map.Entry<Integer, List<TestEvent>> entry : byAttempt.entrySet()) {
+            // Validate if:
+            // - finished normally, last attempt
+            // - finished normally, recovered, finished - both attempts must emit MAX_WATERMARK and
+            // end input
+            // Skip if this or other task from this attempt failed.
+            if (lastAttempt == entry.getKey()
+                    || normallyFinishedAttempts.contains(entry.getKey())) {
+                validateSubtaskAttempt(job, operatorId, subtaskIndex, entry.getValue());
+            }
+        }
+    }
+
+    private void validateSubtaskAttempt(
+            TestJobWithDescription job,
+            String operatorId,
+            int subtaskIndex,
+            List<TestEvent> operatorEvents) {
         BitSet endedInputs = new BitSet();
         BitSet inputsWithMaxWatermark = new BitSet();
         for (TestEvent ev : operatorEvents) {
             if (ev instanceof WatermarkReceivedEvent) {
                 WatermarkReceivedEvent w = (WatermarkReceivedEvent) ev;
                 if (w.ts == Watermark.MAX_WATERMARK.getTimestamp()) {
-                    assertFalse(inputsWithMaxWatermark.get(w.inputId));
+                    assertFalse(
+                            String.format(
+                                    "Max Watermark received twice by %s/%d/%d",
+                                    w.operatorId, w.subtaskIndex, w.inputId),
+                            inputsWithMaxWatermark.get(w.inputId));
                     inputsWithMaxWatermark.set(w.inputId);
                 }
             } else if (ev instanceof InputEndedEvent) {
                 InputEndedEvent w = (InputEndedEvent) ev;
                 assertTrue(
                         format(
-                                "Input %d ended before receiving max watermark by %s[%d]",
-                                w.inputId, operatorId, subtaskIndex),
+                                "Input %d ended before receiving max watermark by %s[%d]#%d",
+                                w.inputId, operatorId, subtaskIndex, w.attemptNumber),
                         inputsWithMaxWatermark.get(w.inputId));
                 assertFalse(endedInputs.get(w.inputId));
                 endedInputs.set(w.inputId);
@@ -71,6 +112,11 @@ public class DrainingValidator implements TestOperatorLifecycleValidator {
                 format("Incorrect number of ended inputs for %s[%d]", operatorId, subtaskIndex),
                 getNumInputs(job, operatorId),
                 endedInputs.cardinality());
+    }
+
+    private boolean isFinishAck(TestEvent ev) {
+        return ev instanceof TestCommandAckEvent
+                && ((TestCommandAckEvent) ev).getCommand() == TestCommand.FINISH_SOURCES;
     }
 
     private static int getNumInputs(TestJobWithDescription testJob, String operator) {


### PR DESCRIPTION
## What is the purpose of the change

Fix test stability issue FLINK-24162 by
checking MAX_WATERMARK per attempt in FLIP-147 tests.
```
Adjust DrainingValidator to validate subtask events if:
- finished normally, last attempt
- finished normally, recovered, finished - both attempts must emit MAX_WATERMARK and end input

Skip if task wasn't finished and the attempt failed (by any subtask).
```

In addition, parameterize to test with full and region failover strategy
(currently depends on scheduler).

## Does this pull request potentially affect one of the following parts:

  - Dependencies (does it add or upgrade a dependency): no
  - The public API, i.e., is any changed class annotated with `@Public(Evolving)`: no
  - The serializers: no
  - The runtime per-record code paths (performance sensitive): no
  - Anything that affects deployment or recovery: JobManager (and its components), Checkpointing, Kubernetes/Yarn/Mesos, ZooKeeper: no
  - The S3 file system connector: no

## Documentation

  - Does this pull request introduce a new feature? no
  - If yes, how is the feature documented? no
