### PR TITLE
[FLINK-24172][tableapi][docs] - Fixed missing quote for join examples

### DIFF
--- a/docs/content.zh/docs/dev/table/tableApi.md
+++ b/docs/content.zh/docs/dev/table/tableApi.md
@@ -891,8 +891,8 @@ result = orders.distinct()
 {{< tabs "innerjoin" >}}
 {{< tab "Java" >}}
 ```java
-Table left = tableEnv.from("MyTable).select($("a"), $("b"), $("c"));
-Table right = tableEnv.from("MyTable).select($("d"), $("e"), $("f"));
+Table left = tableEnv.from("MyTable").select($("a"), $("b"), $("c"));
+Table right = tableEnv.from("MyTable").select($("d"), $("e"), $("f"));
 Table result = left.join(right)
     .where($("a").isEqual($("d")))
     .select($("a"), $("b"), $("e"));
@@ -929,8 +929,8 @@ result = left.join(right).where(left.a == right.d).select(left.a, left.b, right.
 {{< tabs "outerjoin" >}}
 {{< tab "Java" >}}
 ```java
-Table left = tableEnv.from("MyTable).select($("a"), $("b"), $("c"));
-Table right = tableEnv.from("MyTable).select($("d"), $("e"), $("f"));
+Table left = tableEnv.from("MyTable").select($("a"), $("b"), $("c"));
+Table right = tableEnv.from("MyTable").select($("d"), $("e"), $("f"));
 
 Table leftOuterResult = left.leftOuterJoin(right, $("a").isEqual($("d")))
                             .select($("a"), $("b"), $("e"));
@@ -977,8 +977,8 @@ Interval join 至少需要一个 equi-join 谓词和一个限制双方时间界�
 {{< tabs "intervaljoin" >}}
 {{< tab "Java" >}}
 ```java
-Table left = tableEnv.from("MyTable).select($("a"), $("b"), $("c"), $("ltime"));
-Table right = tableEnv.from("MyTable).select($("d"), $("e"), $("f"), $("rtime"));
+Table left = tableEnv.from("MyTable").select($("a"), $("b"), $("c"), $("ltime"));
+Table right = tableEnv.from("MyTable").select($("d"), $("e"), $("f"), $("rtime"));
 
 Table result = left.join(right)
   .where(

--- a/docs/content/docs/dev/table/tableApi.md
+++ b/docs/content/docs/dev/table/tableApi.md
@@ -890,8 +890,8 @@ Similar to a SQL JOIN clause. Joins two tables. Both tables must have distinct f
 {{< tabs "innerjoin" >}}
 {{< tab "Java" >}}
 ```java
-Table left = tableEnv.from("MyTable).select($("a"), $("b"), $("c"));
-Table right = tableEnv.from("MyTable).select($("d"), $("e"), $("f"));
+Table left = tableEnv.from("MyTable").select($("a"), $("b"), $("c"));
+Table right = tableEnv.from("MyTable").select($("d"), $("e"), $("f"));
 Table result = left.join(right)
     .where($("a").isEqual($("d")))
     .select($("a"), $("b"), $("e"));
@@ -928,8 +928,8 @@ Both tables must have distinct field names and at least one equality join predic
 {{< tabs "outerjoin" >}}
 {{< tab "Java" >}}
 ```java
-Table left = tableEnv.from("MyTable).select($("a"), $("b"), $("c"));
-Table right = tableEnv.from("MyTable).select($("d"), $("e"), $("f"));
+Table left = tableEnv.from("MyTable").select($("a"), $("b"), $("c"));
+Table right = tableEnv.from("MyTable").select($("d"), $("e"), $("f"));
 
 Table leftOuterResult = left.leftOuterJoin(right, $("a").isEqual($("d")))
                             .select($("a"), $("b"), $("e"));
@@ -976,8 +976,8 @@ An interval join requires at least one equi-join predicate and a join condition 
 {{< tabs "intervaljoin" >}}
 {{< tab "Java" >}}
 ```java
-Table left = tableEnv.from("MyTable).select($("a"), $("b"), $("c"), $("ltime"));
-Table right = tableEnv.from("MyTable).select($("d"), $("e"), $("f"), $("rtime"));
+Table left = tableEnv.from("MyTable").select($("a"), $("b"), $("c"), $("ltime"));
+Table right = tableEnv.from("MyTable").select($("d"), $("e"), $("f"), $("rtime"));
 
 Table result = left.join(right)
   .where(


### PR DESCRIPTION

## What is the purpose of the change

* Table API join documentation for Java has missing end quote after table name

## Brief change log

* Fixed missing quote 

## Verifying this change

This change is a trivial rework / code cleanup without any test coverage.

## Does this pull request potentially affect one of the following parts:

  - Dependencies (does it add or upgrade a dependency): no
  - The public API, i.e., is any changed class annotated with `@Public(Evolving)`: no
  - The serializers: no
  - The runtime per-record code paths (performance sensitive): no
  - Anything that affects deployment or recovery: JobManager (and its components), Checkpointing, Kubernetes/Yarn, ZooKeeper: no
  - The S3 file system connector: no

## Documentation

  - Does this pull request introduce a new feature? no
  - If yes, how is the feature documented? not applicable
