### PR TITLE
[hotfix][docs] Fix sentence by adding one word: 

### DIFF
--- a/flink-connectors/flink-connector-files/src/main/java/org/apache/flink/connector/file/src/reader/FileRecordFormat.java
+++ b/flink-connectors/flink-connector-files/src/main/java/org/apache/flink/connector/file/src/reader/FileRecordFormat.java
@@ -147,7 +147,7 @@ public interface FileRecordFormat<T> extends Serializable, ResultTypeQueryable<T
      *
      * <p>The number should be large enough so that the thread-to-thread handover overhead is
      * amortized across the records, but small enough so that the these records together do not
-     * consume too memory to be feasible.
+     * consume too much memory.
      */
     ConfigOption<Integer> RECORDS_PER_FETCH =
             ConfigOptions.key("source.file.records.fetch-size")


### PR DESCRIPTION
these records together do not consume too "much" memory.

## What is the purpose of the change

This pull request improves the java doc by fixing the sentence.


## Brief change log

  - *adding the missing word "much" for the java doc of FileRecordFormat#RECORDS_PER_FETCH*


## Verifying this change

This change is a trivial rework / java doc cleanup without any test coverage.
