### PR TITLE
[FLINK-24177][runtime/network] Add epoll available check exception

### DIFF
--- a/flink-runtime/src/main/java/org/apache/flink/runtime/io/network/netty/NettyServer.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/io/network/netty/NettyServer.java
@@ -198,6 +198,10 @@ class NettyServer {
         // multiple servers running on the same host.
         String name = NettyConfig.SERVER_THREAD_GROUP_NAME + " (" + config.getServerPort() + ")";
 
+        if (!Epoll.isAvailable()) {
+            throw new IllegalStateException("epoll is not available", Epoll.unavailabilityCause());
+        }
+
         EpollEventLoopGroup epollGroup =
                 new EpollEventLoopGroup(config.getServerNumThreads(), getNamedThreadFactory(name));
         bootstrap.group(epollGroup).channel(EpollServerSocketChannel.class);

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/io/network/netty/NettyServer.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/io/network/netty/NettyServer.java
@@ -103,6 +103,9 @@ class NettyServer {
                     initNioBootstrap();
                     LOG.info("Transport type 'auto': using NIO.");
                 }
+
+            default:
+                throw new IllegalStateException();
         }
 
         // --------------------------------------------------------------------

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/io/network/netty/NettyServer.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/io/network/netty/NettyServer.java
@@ -103,6 +103,7 @@ class NettyServer {
                     initNioBootstrap();
                     LOG.info("Transport type 'auto': using NIO.");
                 }
+                break;
 
             default:
                 throw new IllegalStateException();


### PR DESCRIPTION
## What is the purpose of the change

There is no exception check in `NettyServer`  when using epoll, and exception check is required when using epoll, thanks


## Brief change log
Add epoll available check exception


