### PR TITLE
[FLINK-24163][test] Increase the checkpoint timeout for PartiallyFinishedSourcesITCase

### DIFF
--- a/flink-tests/src/test/java/org/apache/flink/runtime/operators/lifecycle/PartiallyFinishedSourcesITCase.java
+++ b/flink-tests/src/test/java/org/apache/flink/runtime/operators/lifecycle/PartiallyFinishedSourcesITCase.java
@@ -103,7 +103,7 @@ public class PartiallyFinishedSourcesITCase extends AbstractTestBase {
                     env.setRestartStrategy(fixedDelayRestart(1, 0));
                     // checkpoints can hang (because of not yet fixed bugs and triggering
                     // checkpoint while the source finishes), so let them timeout quickly
-                    env.getCheckpointConfig().setCheckpointTimeout(5000);
+                    env.getCheckpointConfig().setCheckpointTimeout(30000);
                     // but don't fail the job
                     env.getCheckpointConfig()
                             .setTolerableCheckpointFailureNumber(Integer.MAX_VALUE);


### PR DESCRIPTION
## What is the purpose of the change

This PR increases the checkpoint timeout for PartiallyFinishedITCase since it seems that it might use more than 5s. 

## Brief change log

- 640612cea5e28872110368b62edfc53a350f7a8c increases the timeout to 30s

## Verifying this change


This change is a trivial rework / code cleanup without any test coverage.

## Does this pull request potentially affect one of the following parts:

  - Dependencies (does it add or upgrade a dependency):  **no**
  - The public API, i.e., is any changed class annotated with `@Public(Evolving)`: **no**
  - The serializers: **no**
  - The runtime per-record code paths (performance sensitive): **no**
  - Anything that affects deployment or recovery: JobManager (and its components), Checkpointing, Kubernetes/Yarn, ZooKeeper: **no**
  - The S3 file system connector: **no**

## Documentation

  - Does this pull request introduce a new feature? **no**
  - If yes, how is the feature documented? **not applicable**