### PR TITLE
[FLINK-24086][checkpoint] Rebuilding the SharedStateRegistry only when the restore method is called for the first time.

### DIFF
--- a/flink-kubernetes/src/main/java/org/apache/flink/kubernetes/utils/KubernetesUtils.java
+++ b/flink-kubernetes/src/main/java/org/apache/flink/kubernetes/utils/KubernetesUtils.java
@@ -42,6 +42,7 @@ import org.apache.flink.runtime.jobmanager.NoOpJobGraphStoreWatcher;
 import org.apache.flink.runtime.leaderelection.LeaderInformation;
 import org.apache.flink.runtime.persistence.RetrievableStateStorageHelper;
 import org.apache.flink.runtime.persistence.filesystem.FileSystemStateStorageHelper;
+import org.apache.flink.runtime.state.SharedStateRegistry;
 import org.apache.flink.util.FlinkRuntimeException;
 import org.apache.flink.util.StringUtils;
 import org.apache.flink.util.function.FunctionUtils;
@@ -281,7 +282,8 @@ public class KubernetesUtils {
             Executor executor,
             String configMapName,
             String lockIdentity,
-            int maxNumberOfCheckpointsToRetain)
+            int maxNumberOfCheckpointsToRetain,
+            SharedStateRegistry sharedStateRegistry)
             throws Exception {
 
         final RetrievableStateStorageHelper<CompletedCheckpoint> stateStorage =
@@ -302,6 +304,7 @@ public class KubernetesUtils {
                 KubernetesCheckpointStoreUtil.INSTANCE,
                 DefaultCompletedCheckpointStoreUtils.retrieveCompletedCheckpoints(
                         stateHandleStore, KubernetesCheckpointStoreUtil.INSTANCE),
+                sharedStateRegistry,
                 executor);
     }
 

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/checkpoint/AbstractCompleteCheckpointStore.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/checkpoint/AbstractCompleteCheckpointStore.java
@@ -1,0 +1,41 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.flink.runtime.checkpoint;
+
+import org.apache.flink.runtime.jobgraph.OperatorID;
+import org.apache.flink.runtime.state.SharedStateRegistry;
+
+import java.util.Map;
+
+/**
+ * The abstract class of {@link CompletedCheckpointStore}, which holds the {@link
+ * SharedStateRegistry} and provides the registration of shared state.
+ */
+public abstract class AbstractCompleteCheckpointStore implements CompletedCheckpointStore {
+    private final SharedStateRegistry sharedStateRegistry;
+
+    public AbstractCompleteCheckpointStore(SharedStateRegistry sharedStateRegistry) {
+        this.sharedStateRegistry = sharedStateRegistry;
+    }
+
+    @Override
+    public void registerSharedState(Map<OperatorID, OperatorState> operatorStates) {
+        sharedStateRegistry.registerAll(operatorStates.values());
+    }
+}

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/checkpoint/AbstractCompleteCheckpointStore.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/checkpoint/AbstractCompleteCheckpointStore.java
@@ -18,10 +18,7 @@
 
 package org.apache.flink.runtime.checkpoint;
 
-import org.apache.flink.runtime.jobgraph.OperatorID;
 import org.apache.flink.runtime.state.SharedStateRegistry;
-
-import java.util.Map;
 
 /**
  * The abstract class of {@link CompletedCheckpointStore}, which holds the {@link
@@ -35,7 +32,7 @@ public abstract class AbstractCompleteCheckpointStore implements CompletedCheckp
     }
 
     @Override
-    public void registerSharedState(Map<OperatorID, OperatorState> operatorStates) {
-        sharedStateRegistry.registerAll(operatorStates.values());
+    public SharedStateRegistry getSharedStateRegistry() {
+        return sharedStateRegistry;
     }
 }

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/checkpoint/CheckpointCoordinator.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/checkpoint/CheckpointCoordinator.java
@@ -41,6 +41,7 @@ import org.apache.flink.runtime.state.CheckpointStorage;
 import org.apache.flink.runtime.state.CheckpointStorageCoordinatorView;
 import org.apache.flink.runtime.state.CheckpointStorageLocation;
 import org.apache.flink.runtime.state.CompletedCheckpointStorageLocation;
+import org.apache.flink.runtime.state.SharedStateRegistry;
 import org.apache.flink.runtime.state.memory.ByteStreamStateHandle;
 import org.apache.flink.util.ExceptionUtils;
 import org.apache.flink.util.FlinkRuntimeException;
@@ -1208,7 +1209,8 @@ public class CheckpointCoordinator {
 
         // As a first step to complete the checkpoint, we register its state with the registry
         Map<OperatorID, OperatorState> operatorStates = pendingCheckpoint.getOperatorStates();
-        completedCheckpointStore.registerSharedState(operatorStates);
+        SharedStateRegistry sharedStateRegistry = completedCheckpointStore.getSharedStateRegistry();
+        sharedStateRegistry.registerAll(operatorStates.values());
 
         try {
             try {

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/checkpoint/CheckpointRecoveryFactory.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/checkpoint/CheckpointRecoveryFactory.java
@@ -19,6 +19,7 @@
 package org.apache.flink.runtime.checkpoint;
 
 import org.apache.flink.api.common.JobID;
+import org.apache.flink.runtime.state.SharedStateRegistry;
 
 /** A factory for per Job checkpoint recovery components. */
 public interface CheckpointRecoveryFactory {
@@ -31,10 +32,15 @@ public interface CheckpointRecoveryFactory {
      * @param jobId Job ID to recover checkpoints for
      * @param maxNumberOfCheckpointsToRetain Maximum number of checkpoints to retain
      * @param userClassLoader User code class loader of the job
+     * @param sharedStateRegistry Registry that tracks state which is shared across (incremental)
+     *     checkpoints
      * @return {@link CompletedCheckpointStore} instance for the job
      */
     CompletedCheckpointStore createRecoveredCompletedCheckpointStore(
-            JobID jobId, int maxNumberOfCheckpointsToRetain, ClassLoader userClassLoader)
+            JobID jobId,
+            int maxNumberOfCheckpointsToRetain,
+            ClassLoader userClassLoader,
+            SharedStateRegistry sharedStateRegistry)
             throws Exception;
 
     /**

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/checkpoint/CheckpointRecoveryFactory.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/checkpoint/CheckpointRecoveryFactory.java
@@ -20,6 +20,9 @@ package org.apache.flink.runtime.checkpoint;
 
 import org.apache.flink.api.common.JobID;
 import org.apache.flink.runtime.state.SharedStateRegistry;
+import org.apache.flink.runtime.state.SharedStateRegistryFactory;
+
+import java.util.concurrent.Executor;
 
 /** A factory for per Job checkpoint recovery components. */
 public interface CheckpointRecoveryFactory {
@@ -32,15 +35,17 @@ public interface CheckpointRecoveryFactory {
      * @param jobId Job ID to recover checkpoints for
      * @param maxNumberOfCheckpointsToRetain Maximum number of checkpoints to retain
      * @param userClassLoader User code class loader of the job
-     * @param sharedStateRegistry Registry that tracks state which is shared across (incremental)
-     *     checkpoints
+     * @param sharedStateRegistryFactory Simple factory to produce {@link SharedStateRegistry}
+     *     objects.
+     * @param ioExecutor Executor used to run (async) deletes.
      * @return {@link CompletedCheckpointStore} instance for the job
      */
     CompletedCheckpointStore createRecoveredCompletedCheckpointStore(
             JobID jobId,
             int maxNumberOfCheckpointsToRetain,
             ClassLoader userClassLoader,
-            SharedStateRegistry sharedStateRegistry)
+            SharedStateRegistryFactory sharedStateRegistryFactory,
+            Executor ioExecutor)
             throws Exception;
 
     /**

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/checkpoint/CompletedCheckpointStore.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/checkpoint/CompletedCheckpointStore.java
@@ -20,14 +20,12 @@ package org.apache.flink.runtime.checkpoint;
 
 import org.apache.flink.annotation.VisibleForTesting;
 import org.apache.flink.api.common.JobStatus;
-import org.apache.flink.runtime.jobgraph.OperatorID;
 import org.apache.flink.runtime.state.SharedStateRegistry;
 
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
 import java.util.List;
-import java.util.Map;
 
 /** A bounded LIFO-queue of {@link CompletedCheckpoint} instances. */
 public interface CompletedCheckpointStore {
@@ -108,7 +106,8 @@ public interface CompletedCheckpointStore {
      */
     boolean requiresExternalizedCheckpoints();
 
-    void registerSharedState(Map<OperatorID, OperatorState> operatorStates);
+    /** Returns the {@link SharedStateRegistry} used to register the shared state. */
+    SharedStateRegistry getSharedStateRegistry();
 
     @VisibleForTesting
     static CompletedCheckpointStore storeFor(

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/checkpoint/DeactivatedCheckpointCompletedCheckpointStore.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/checkpoint/DeactivatedCheckpointCompletedCheckpointStore.java
@@ -19,8 +19,10 @@
 package org.apache.flink.runtime.checkpoint;
 
 import org.apache.flink.api.common.JobStatus;
+import org.apache.flink.runtime.jobgraph.OperatorID;
 
 import java.util.List;
+import java.util.Map;
 
 /**
  * This class represents a {@link CompletedCheckpointStore} if checkpointing has been enabled.
@@ -60,6 +62,11 @@ public enum DeactivatedCheckpointCompletedCheckpointStore implements CompletedCh
 
     @Override
     public boolean requiresExternalizedCheckpoints() {
+        throw unsupportedOperationException();
+    }
+
+    @Override
+    public void registerSharedState(Map<OperatorID, OperatorState> operatorStates) {
         throw unsupportedOperationException();
     }
 

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/checkpoint/DeactivatedCheckpointCompletedCheckpointStore.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/checkpoint/DeactivatedCheckpointCompletedCheckpointStore.java
@@ -19,10 +19,9 @@
 package org.apache.flink.runtime.checkpoint;
 
 import org.apache.flink.api.common.JobStatus;
-import org.apache.flink.runtime.jobgraph.OperatorID;
+import org.apache.flink.runtime.state.SharedStateRegistry;
 
 import java.util.List;
-import java.util.Map;
 
 /**
  * This class represents a {@link CompletedCheckpointStore} if checkpointing has been enabled.
@@ -66,7 +65,7 @@ public enum DeactivatedCheckpointCompletedCheckpointStore implements CompletedCh
     }
 
     @Override
-    public void registerSharedState(Map<OperatorID, OperatorState> operatorStates) {
+    public SharedStateRegistry getSharedStateRegistry() {
         throw unsupportedOperationException();
     }
 

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/checkpoint/DefaultCompletedCheckpointStore.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/checkpoint/DefaultCompletedCheckpointStore.java
@@ -22,6 +22,7 @@ import org.apache.flink.api.common.JobStatus;
 import org.apache.flink.runtime.persistence.PossibleInconsistentStateException;
 import org.apache.flink.runtime.persistence.ResourceVersion;
 import org.apache.flink.runtime.persistence.StateHandleStore;
+import org.apache.flink.runtime.state.SharedStateRegistry;
 import org.apache.flink.util.Preconditions;
 
 import org.slf4j.Logger;
@@ -52,7 +53,7 @@ import static org.apache.flink.util.Preconditions.checkNotNull;
  * to circumvent those situations.
  */
 public class DefaultCompletedCheckpointStore<R extends ResourceVersion<R>>
-        implements CompletedCheckpointStore {
+        extends AbstractCompleteCheckpointStore {
 
     private static final Logger LOG =
             LoggerFactory.getLogger(DefaultCompletedCheckpointStore.class);
@@ -92,7 +93,9 @@ public class DefaultCompletedCheckpointStore<R extends ResourceVersion<R>>
             StateHandleStore<CompletedCheckpoint, R> stateHandleStore,
             CheckpointStoreUtil completedCheckpointStoreUtil,
             Collection<CompletedCheckpoint> completedCheckpoints,
+            SharedStateRegistry sharedStateRegistry,
             Executor executor) {
+        super(sharedStateRegistry);
         checkArgument(maxNumberOfCheckpointsToRetain >= 1, "Must retain at least one checkpoint.");
         this.maxNumberOfCheckpointsToRetain = maxNumberOfCheckpointsToRetain;
         this.checkpointStateHandleStore = checkNotNull(stateHandleStore);

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/checkpoint/EmbeddedCompletedCheckpointStore.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/checkpoint/EmbeddedCompletedCheckpointStore.java
@@ -74,7 +74,7 @@ public class EmbeddedCompletedCheckpointStore extends AbstractCompleteCheckpoint
         this.checkpoints.addAll(initialCheckpoints);
 
         for (CompletedCheckpoint completedCheckpoint : this.checkpoints) {
-            this.registerSharedState(completedCheckpoint.getOperatorStates());
+            getSharedStateRegistry().registerAll(completedCheckpoint.getOperatorStates().values());
         }
     }
 

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/checkpoint/PerJobCheckpointRecoveryFactory.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/checkpoint/PerJobCheckpointRecoveryFactory.java
@@ -20,10 +20,11 @@ package org.apache.flink.runtime.checkpoint;
 
 import org.apache.flink.annotation.VisibleForTesting;
 import org.apache.flink.api.common.JobID;
+import org.apache.flink.runtime.state.SharedStateRegistry;
+import org.apache.flink.util.function.TriFunction;
 
 import java.util.concurrent.ConcurrentHashMap;
 import java.util.concurrent.ConcurrentMap;
-import java.util.function.BiFunction;
 import java.util.function.IntFunction;
 import java.util.function.Supplier;
 
@@ -38,7 +39,7 @@ public class PerJobCheckpointRecoveryFactory<T extends CompletedCheckpointStore>
     public static <T extends CompletedCheckpointStore>
             CheckpointRecoveryFactory withoutCheckpointStoreRecovery(IntFunction<T> storeFn) {
         return new PerJobCheckpointRecoveryFactory<>(
-                (maxCheckpoints, previous) -> {
+                (maxCheckpoints, previous, sharedStateRegistry) -> {
                     if (previous != null) {
                         throw new UnsupportedOperationException(
                                 "Checkpoint store recovery is not supported.");
@@ -47,18 +48,19 @@ public class PerJobCheckpointRecoveryFactory<T extends CompletedCheckpointStore>
                 });
     }
 
-    private final BiFunction<Integer, T, T> completedCheckpointStorePerJobFactory;
+    private final TriFunction<Integer, T, SharedStateRegistry, T>
+            completedCheckpointStorePerJobFactory;
     private final Supplier<CheckpointIDCounter> checkpointIDCounterPerJobFactory;
     private final ConcurrentMap<JobID, T> store;
     private final ConcurrentMap<JobID, CheckpointIDCounter> counter;
 
     public PerJobCheckpointRecoveryFactory(
-            BiFunction<Integer, T, T> completedCheckpointStorePerJobFactory) {
+            TriFunction<Integer, T, SharedStateRegistry, T> completedCheckpointStorePerJobFactory) {
         this(completedCheckpointStorePerJobFactory, StandaloneCheckpointIDCounter::new);
     }
 
     public PerJobCheckpointRecoveryFactory(
-            BiFunction<Integer, T, T> completedCheckpointStorePerJobFactory,
+            TriFunction<Integer, T, SharedStateRegistry, T> completedCheckpointStorePerJobFactory,
             Supplier<CheckpointIDCounter> checkpointIDCounterPerJobFactory) {
         this.completedCheckpointStorePerJobFactory = completedCheckpointStorePerJobFactory;
         this.checkpointIDCounterPerJobFactory = checkpointIDCounterPerJobFactory;
@@ -68,12 +70,15 @@ public class PerJobCheckpointRecoveryFactory<T extends CompletedCheckpointStore>
 
     @Override
     public CompletedCheckpointStore createRecoveredCompletedCheckpointStore(
-            JobID jobId, int maxNumberOfCheckpointsToRetain, ClassLoader userClassLoader) {
+            JobID jobId,
+            int maxNumberOfCheckpointsToRetain,
+            ClassLoader userClassLoader,
+            SharedStateRegistry sharedStateRegistry) {
         return store.compute(
                 jobId,
                 (key, previous) ->
                         completedCheckpointStorePerJobFactory.apply(
-                                maxNumberOfCheckpointsToRetain, previous));
+                                maxNumberOfCheckpointsToRetain, previous, sharedStateRegistry));
     }
 
     @Override

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/checkpoint/PerJobCheckpointRecoveryFactory.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/checkpoint/PerJobCheckpointRecoveryFactory.java
@@ -21,10 +21,12 @@ package org.apache.flink.runtime.checkpoint;
 import org.apache.flink.annotation.VisibleForTesting;
 import org.apache.flink.api.common.JobID;
 import org.apache.flink.runtime.state.SharedStateRegistry;
+import org.apache.flink.runtime.state.SharedStateRegistryFactory;
 import org.apache.flink.util.function.TriFunction;
 
 import java.util.concurrent.ConcurrentHashMap;
 import java.util.concurrent.ConcurrentMap;
+import java.util.concurrent.Executor;
 import java.util.function.IntFunction;
 import java.util.function.Supplier;
 
@@ -73,12 +75,15 @@ public class PerJobCheckpointRecoveryFactory<T extends CompletedCheckpointStore>
             JobID jobId,
             int maxNumberOfCheckpointsToRetain,
             ClassLoader userClassLoader,
-            SharedStateRegistry sharedStateRegistry) {
+            SharedStateRegistryFactory sharedStateRegistryFactory,
+            Executor ioExecutor) {
         return store.compute(
                 jobId,
                 (key, previous) ->
                         completedCheckpointStorePerJobFactory.apply(
-                                maxNumberOfCheckpointsToRetain, previous, sharedStateRegistry));
+                                maxNumberOfCheckpointsToRetain,
+                                previous,
+                                sharedStateRegistryFactory.create(ioExecutor)));
     }
 
     @Override

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/checkpoint/StandaloneCompletedCheckpointStore.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/checkpoint/StandaloneCompletedCheckpointStore.java
@@ -18,8 +18,11 @@
 
 package org.apache.flink.runtime.checkpoint;
 
+import org.apache.flink.annotation.VisibleForTesting;
 import org.apache.flink.api.common.JobStatus;
 import org.apache.flink.runtime.jobmanager.HighAvailabilityMode;
+import org.apache.flink.runtime.state.SharedStateRegistry;
+import org.apache.flink.util.concurrent.Executors;
 
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
@@ -33,7 +36,7 @@ import static org.apache.flink.util.Preconditions.checkArgument;
 /**
  * {@link CompletedCheckpointStore} for JobManagers running in {@link HighAvailabilityMode#NONE}.
  */
-public class StandaloneCompletedCheckpointStore implements CompletedCheckpointStore {
+public class StandaloneCompletedCheckpointStore extends AbstractCompleteCheckpointStore {
 
     private static final Logger LOG =
             LoggerFactory.getLogger(StandaloneCompletedCheckpointStore.class);
@@ -44,13 +47,22 @@ public class StandaloneCompletedCheckpointStore implements CompletedCheckpointSt
     /** The completed checkpoints. */
     private final ArrayDeque<CompletedCheckpoint> checkpoints;
 
+    @VisibleForTesting
+    public StandaloneCompletedCheckpointStore(int maxNumberOfCheckpointsToRetain) {
+        this(
+                maxNumberOfCheckpointsToRetain,
+                SharedStateRegistry.DEFAULT_FACTORY.create(Executors.directExecutor()));
+    }
+
     /**
      * Creates {@link StandaloneCompletedCheckpointStore}.
      *
      * @param maxNumberOfCheckpointsToRetain The maximum number of checkpoints to retain (at least
      *     1). Adding more checkpoints than this results in older checkpoints being discarded.
      */
-    public StandaloneCompletedCheckpointStore(int maxNumberOfCheckpointsToRetain) {
+    public StandaloneCompletedCheckpointStore(
+            int maxNumberOfCheckpointsToRetain, SharedStateRegistry sharedStateRegistry) {
+        super(sharedStateRegistry);
         checkArgument(maxNumberOfCheckpointsToRetain >= 1, "Must retain at least one checkpoint.");
         this.maxNumberOfCheckpointsToRetain = maxNumberOfCheckpointsToRetain;
         this.checkpoints = new ArrayDeque<>(maxNumberOfCheckpointsToRetain + 1);

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/executiongraph/DefaultExecutionGraph.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/executiongraph/DefaultExecutionGraph.java
@@ -71,7 +71,6 @@ import org.apache.flink.runtime.scheduler.strategy.SchedulingResultPartition;
 import org.apache.flink.runtime.scheduler.strategy.SchedulingTopology;
 import org.apache.flink.runtime.shuffle.ShuffleMaster;
 import org.apache.flink.runtime.state.CheckpointStorage;
-import org.apache.flink.runtime.state.SharedStateRegistry;
 import org.apache.flink.runtime.state.StateBackend;
 import org.apache.flink.runtime.taskmanager.DispatcherThreadFactory;
 import org.apache.flink.types.Either;
@@ -445,7 +444,6 @@ public class DefaultExecutionGraph implements ExecutionGraph, InternalExecutionG
                         ioExecutor,
                         checkpointsCleaner,
                         new ScheduledExecutorServiceAdapter(checkpointCoordinatorTimer),
-                        SharedStateRegistry.DEFAULT_FACTORY,
                         failureManager,
                         createCheckpointPlanCalculator(
                                 chkConfig.isEnableCheckpointsAfterTasksFinish()),

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/highavailability/nonha/embedded/EmbeddedHaServicesWithLeadershipControl.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/highavailability/nonha/embedded/EmbeddedHaServicesWithLeadershipControl.java
@@ -23,6 +23,7 @@ import org.apache.flink.runtime.checkpoint.CheckpointRecoveryFactory;
 import org.apache.flink.runtime.checkpoint.EmbeddedCompletedCheckpointStore;
 import org.apache.flink.runtime.checkpoint.PerJobCheckpointRecoveryFactory;
 
+import java.util.Collections;
 import java.util.concurrent.CompletableFuture;
 import java.util.concurrent.Executor;
 
@@ -36,16 +37,19 @@ public class EmbeddedHaServicesWithLeadershipControl extends EmbeddedHaServices
         this(
                 executor,
                 new PerJobCheckpointRecoveryFactory<EmbeddedCompletedCheckpointStore>(
-                        (maxCheckpoints, previous) -> {
+                        (maxCheckpoints, previous, sharedStateRegistry) -> {
                             if (previous != null) {
                                 if (!previous.getShutdownStatus().isPresent()) {
                                     throw new IllegalStateException(
                                             "Completed checkpoint store from previous run has not yet shutdown.");
                                 }
                                 return new EmbeddedCompletedCheckpointStore(
-                                        maxCheckpoints, previous.getAllCheckpoints());
+                                        maxCheckpoints,
+                                        previous.getAllCheckpoints(),
+                                        sharedStateRegistry);
                             }
-                            return new EmbeddedCompletedCheckpointStore(maxCheckpoints);
+                            return new EmbeddedCompletedCheckpointStore(
+                                    maxCheckpoints, Collections.emptyList(), sharedStateRegistry);
                         }));
     }
 

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/scheduler/SchedulerBase.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/scheduler/SchedulerBase.java
@@ -81,6 +81,7 @@ import org.apache.flink.runtime.scheduler.strategy.SchedulingExecutionVertex;
 import org.apache.flink.runtime.scheduler.strategy.SchedulingTopology;
 import org.apache.flink.runtime.state.KeyGroupRange;
 import org.apache.flink.runtime.state.KeyGroupRangeAssignment;
+import org.apache.flink.runtime.state.SharedStateRegistry;
 import org.apache.flink.runtime.util.BoundedFIFOQueue;
 import org.apache.flink.runtime.util.IntArrayList;
 import org.apache.flink.util.ExceptionUtils;
@@ -180,6 +181,7 @@ public abstract class SchedulerBase implements SchedulerNG, CheckpointScheduling
                         jobMasterConfiguration,
                         userCodeLoader,
                         checkNotNull(checkpointRecoveryFactory),
+                        SharedStateRegistry.DEFAULT_FACTORY.create(ioExecutor),
                         log);
         this.checkpointIdCounter =
                 SchedulerUtils.createCheckpointIDCounterIfCheckpointingIsEnabled(

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/scheduler/SchedulerBase.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/scheduler/SchedulerBase.java
@@ -181,7 +181,8 @@ public abstract class SchedulerBase implements SchedulerNG, CheckpointScheduling
                         jobMasterConfiguration,
                         userCodeLoader,
                         checkNotNull(checkpointRecoveryFactory),
-                        SharedStateRegistry.DEFAULT_FACTORY.create(ioExecutor),
+                        SharedStateRegistry.DEFAULT_FACTORY,
+                        ioExecutor,
                         log);
         this.checkpointIdCounter =
                 SchedulerUtils.createCheckpointIDCounterIfCheckpointingIsEnabled(

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/scheduler/SchedulerUtils.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/scheduler/SchedulerUtils.java
@@ -30,6 +30,7 @@ import org.apache.flink.runtime.checkpoint.DeactivatedCheckpointIDCounter;
 import org.apache.flink.runtime.client.JobExecutionException;
 import org.apache.flink.runtime.executiongraph.DefaultExecutionGraphBuilder;
 import org.apache.flink.runtime.jobgraph.JobGraph;
+import org.apache.flink.runtime.state.SharedStateRegistry;
 
 import org.slf4j.Logger;
 
@@ -46,13 +47,19 @@ public final class SchedulerUtils {
             Configuration configuration,
             ClassLoader userCodeLoader,
             CheckpointRecoveryFactory checkpointRecoveryFactory,
+            SharedStateRegistry sharedStateRegistry,
             Logger log)
             throws JobExecutionException {
         final JobID jobId = jobGraph.getJobID();
         if (DefaultExecutionGraphBuilder.isCheckpointingEnabled(jobGraph)) {
             try {
                 return createCompletedCheckpointStore(
-                        configuration, userCodeLoader, checkpointRecoveryFactory, log, jobId);
+                        configuration,
+                        userCodeLoader,
+                        checkpointRecoveryFactory,
+                        sharedStateRegistry,
+                        log,
+                        jobId);
             } catch (Exception e) {
                 throw new JobExecutionException(
                         jobId,
@@ -69,6 +76,7 @@ public final class SchedulerUtils {
             Configuration jobManagerConfig,
             ClassLoader classLoader,
             CheckpointRecoveryFactory recoveryFactory,
+            SharedStateRegistry sharedStateRegistry,
             Logger log,
             JobID jobId)
             throws Exception {
@@ -89,7 +97,7 @@ public final class SchedulerUtils {
         }
 
         return recoveryFactory.createRecoveredCompletedCheckpointStore(
-                jobId, maxNumberOfCheckpointsToRetain, classLoader);
+                jobId, maxNumberOfCheckpointsToRetain, classLoader, sharedStateRegistry);
     }
 
     public static CheckpointIDCounter createCheckpointIDCounterIfCheckpointingIsEnabled(

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/scheduler/SchedulerUtils.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/scheduler/SchedulerUtils.java
@@ -30,9 +30,11 @@ import org.apache.flink.runtime.checkpoint.DeactivatedCheckpointIDCounter;
 import org.apache.flink.runtime.client.JobExecutionException;
 import org.apache.flink.runtime.executiongraph.DefaultExecutionGraphBuilder;
 import org.apache.flink.runtime.jobgraph.JobGraph;
-import org.apache.flink.runtime.state.SharedStateRegistry;
+import org.apache.flink.runtime.state.SharedStateRegistryFactory;
 
 import org.slf4j.Logger;
+
+import java.util.concurrent.Executor;
 
 /** Utils class for Flink's scheduler implementations. */
 public final class SchedulerUtils {
@@ -47,7 +49,8 @@ public final class SchedulerUtils {
             Configuration configuration,
             ClassLoader userCodeLoader,
             CheckpointRecoveryFactory checkpointRecoveryFactory,
-            SharedStateRegistry sharedStateRegistry,
+            SharedStateRegistryFactory sharedStateRegistryFactory,
+            Executor ioExecutor,
             Logger log)
             throws JobExecutionException {
         final JobID jobId = jobGraph.getJobID();
@@ -57,7 +60,8 @@ public final class SchedulerUtils {
                         configuration,
                         userCodeLoader,
                         checkpointRecoveryFactory,
-                        sharedStateRegistry,
+                        sharedStateRegistryFactory,
+                        ioExecutor,
                         log,
                         jobId);
             } catch (Exception e) {
@@ -76,7 +80,8 @@ public final class SchedulerUtils {
             Configuration jobManagerConfig,
             ClassLoader classLoader,
             CheckpointRecoveryFactory recoveryFactory,
-            SharedStateRegistry sharedStateRegistry,
+            SharedStateRegistryFactory sharedStateRegistryFactory,
+            Executor ioExecutor,
             Logger log,
             JobID jobId)
             throws Exception {
@@ -97,7 +102,11 @@ public final class SchedulerUtils {
         }
 
         return recoveryFactory.createRecoveredCompletedCheckpointStore(
-                jobId, maxNumberOfCheckpointsToRetain, classLoader, sharedStateRegistry);
+                jobId,
+                maxNumberOfCheckpointsToRetain,
+                classLoader,
+                sharedStateRegistryFactory,
+                ioExecutor);
     }
 
     public static CheckpointIDCounter createCheckpointIDCounterIfCheckpointingIsEnabled(

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/scheduler/adaptive/AdaptiveScheduler.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/scheduler/adaptive/AdaptiveScheduler.java
@@ -99,6 +99,7 @@ import org.apache.flink.runtime.scheduler.adaptive.allocator.VertexParallelism;
 import org.apache.flink.runtime.scheduler.adaptive.scalingpolicy.ReactiveScaleUpController;
 import org.apache.flink.runtime.scheduler.adaptive.scalingpolicy.ScaleUpController;
 import org.apache.flink.runtime.state.KeyGroupRange;
+import org.apache.flink.runtime.state.SharedStateRegistry;
 import org.apache.flink.runtime.util.ResourceCounter;
 import org.apache.flink.util.ExceptionUtils;
 import org.apache.flink.util.FlinkException;
@@ -244,6 +245,7 @@ public class AdaptiveScheduler
                         configuration,
                         userCodeClassLoader,
                         checkpointRecoveryFactory,
+                        SharedStateRegistry.DEFAULT_FACTORY.create(ioExecutor),
                         LOG);
         this.checkpointIdCounter =
                 SchedulerUtils.createCheckpointIDCounterIfCheckpointingIsEnabled(

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/scheduler/adaptive/AdaptiveScheduler.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/scheduler/adaptive/AdaptiveScheduler.java
@@ -245,7 +245,8 @@ public class AdaptiveScheduler
                         configuration,
                         userCodeClassLoader,
                         checkpointRecoveryFactory,
-                        SharedStateRegistry.DEFAULT_FACTORY.create(ioExecutor),
+                        SharedStateRegistry.DEFAULT_FACTORY,
+                        ioExecutor,
                         LOG);
         this.checkpointIdCounter =
                 SchedulerUtils.createCheckpointIDCounterIfCheckpointingIsEnabled(

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/util/ZooKeeperUtils.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/util/ZooKeeperUtils.java
@@ -50,6 +50,7 @@ import org.apache.flink.runtime.leaderretrieval.ZooKeeperLeaderRetrievalDriverFa
 import org.apache.flink.runtime.persistence.RetrievableStateStorageHelper;
 import org.apache.flink.runtime.persistence.filesystem.FileSystemStateStorageHelper;
 import org.apache.flink.runtime.rpc.FatalErrorHandler;
+import org.apache.flink.runtime.state.SharedStateRegistry;
 import org.apache.flink.runtime.zookeeper.ZooKeeperStateHandleStore;
 import org.apache.flink.util.concurrent.Executors;
 import org.apache.flink.util.function.RunnableWithException;
@@ -455,6 +456,7 @@ public class ZooKeeperUtils {
             CuratorFramework client,
             Configuration configuration,
             int maxNumberOfCheckpointsToRetain,
+            SharedStateRegistry sharedStateRegistry,
             Executor executor)
             throws Exception {
 
@@ -473,8 +475,8 @@ public class ZooKeeperUtils {
                         DefaultCompletedCheckpointStoreUtils.retrieveCompletedCheckpoints(
                                 completedCheckpointStateHandleStore,
                                 ZooKeeperCheckpointStoreUtil.INSTANCE),
+                        sharedStateRegistry,
                         executor);
-
         LOG.info(
                 "Initialized {} in '{}' with {}.",
                 DefaultCompletedCheckpointStore.class.getSimpleName(),

--- a/flink-runtime/src/test/java/org/apache/flink/runtime/checkpoint/CheckpointCoordinatorFailureTest.java
+++ b/flink-runtime/src/test/java/org/apache/flink/runtime/checkpoint/CheckpointCoordinatorFailureTest.java
@@ -35,9 +35,11 @@ import org.apache.flink.runtime.state.KeyedStateHandle;
 import org.apache.flink.runtime.state.OperatorStateHandle;
 import org.apache.flink.runtime.state.OperatorStreamStateHandle;
 import org.apache.flink.runtime.state.ResultSubpartitionStateHandle;
+import org.apache.flink.runtime.state.SharedStateRegistry;
 import org.apache.flink.runtime.state.StreamStateHandle;
 import org.apache.flink.util.FlinkRuntimeException;
 import org.apache.flink.util.TestLogger;
+import org.apache.flink.util.concurrent.Executors;
 
 import org.junit.Rule;
 import org.junit.Test;
@@ -246,11 +248,13 @@ public class CheckpointCoordinatorFailureTest extends TestLogger {
         assertThat(cleanupCallCount.get(), is(expectedCleanupCalls));
     }
 
-    private static final class FailingCompletedCheckpointStore implements CompletedCheckpointStore {
+    private static final class FailingCompletedCheckpointStore
+            extends AbstractCompleteCheckpointStore {
 
         private final Exception addCheckpointFailure;
 
         public FailingCompletedCheckpointStore(Exception addCheckpointFailure) {
+            super(SharedStateRegistry.DEFAULT_FACTORY.create(Executors.directExecutor()));
             this.addCheckpointFailure = addCheckpointFailure;
         }
 

--- a/flink-runtime/src/test/java/org/apache/flink/runtime/checkpoint/CheckpointCoordinatorMasterHooksTest.java
+++ b/flink-runtime/src/test/java/org/apache/flink/runtime/checkpoint/CheckpointCoordinatorMasterHooksTest.java
@@ -28,7 +28,6 @@ import org.apache.flink.runtime.jobgraph.JobVertexID;
 import org.apache.flink.runtime.jobgraph.OperatorID;
 import org.apache.flink.runtime.jobgraph.tasks.CheckpointCoordinatorConfiguration;
 import org.apache.flink.runtime.messages.checkpoint.AcknowledgeCheckpoint;
-import org.apache.flink.runtime.state.SharedStateRegistry;
 import org.apache.flink.runtime.state.memory.MemoryStateBackend;
 import org.apache.flink.runtime.state.testutils.TestCompletedCheckpointStorageLocation;
 import org.apache.flink.util.concurrent.Executors;
@@ -486,7 +485,6 @@ public class CheckpointCoordinatorMasterHooksTest {
                 executor,
                 new CheckpointsCleaner(),
                 testingScheduledExecutor,
-                SharedStateRegistry.DEFAULT_FACTORY,
                 new CheckpointFailureManager(0, NoOpFailJobCall.INSTANCE),
                 new DefaultCheckpointPlanCalculator(
                         graph.getJobID(),

--- a/flink-runtime/src/test/java/org/apache/flink/runtime/checkpoint/CheckpointCoordinatorRestoringTest.java
+++ b/flink-runtime/src/test/java/org/apache/flink/runtime/checkpoint/CheckpointCoordinatorRestoringTest.java
@@ -45,6 +45,7 @@ import org.apache.flink.runtime.testtasks.NoOpInvokable;
 import org.apache.flink.runtime.testutils.CommonTestUtils;
 import org.apache.flink.util.FlinkRuntimeException;
 import org.apache.flink.util.TestLogger;
+import org.apache.flink.util.concurrent.Executors;
 
 import org.apache.flink.shaded.guava30.com.google.common.collect.Iterables;
 
@@ -775,11 +776,14 @@ public class CheckpointCoordinatorRestoringTest extends TestLogger {
                         new TestCompletedCheckpointStorageLocation());
 
         // set up the coordinator and validate the initial state
+        SharedStateRegistry sharedStateRegistry =
+                SharedStateRegistry.DEFAULT_FACTORY.create(Executors.directExecutor());
         CheckpointCoordinator coord =
                 new CheckpointCoordinatorBuilder()
                         .setExecutionGraph(newGraph)
                         .setCompletedCheckpointStore(
-                                CompletedCheckpointStore.storeFor(() -> {}, completedCheckpoint))
+                                CompletedCheckpointStore.storeFor(
+                                        sharedStateRegistry, () -> {}, completedCheckpoint))
                         .setTimer(manuallyTriggeredScheduledExecutor)
                         .build();
 

--- a/flink-runtime/src/test/java/org/apache/flink/runtime/checkpoint/CheckpointCoordinatorTestingUtils.java
+++ b/flink-runtime/src/test/java/org/apache/flink/runtime/checkpoint/CheckpointCoordinatorTestingUtils.java
@@ -53,8 +53,6 @@ import org.apache.flink.runtime.state.KeyGroupsStateHandle;
 import org.apache.flink.runtime.state.KeyedStateHandle;
 import org.apache.flink.runtime.state.OperatorStateHandle;
 import org.apache.flink.runtime.state.OperatorStreamStateHandle;
-import org.apache.flink.runtime.state.SharedStateRegistry;
-import org.apache.flink.runtime.state.SharedStateRegistryFactory;
 import org.apache.flink.runtime.state.filesystem.FileStateHandle;
 import org.apache.flink.runtime.state.memory.ByteStreamStateHandle;
 import org.apache.flink.runtime.state.memory.MemoryStateBackend;
@@ -716,9 +714,6 @@ public class CheckpointCoordinatorTestingUtils {
 
         private ScheduledExecutor timer = new ManuallyTriggeredScheduledExecutor();
 
-        private SharedStateRegistryFactory sharedStateRegistryFactory =
-                SharedStateRegistry.DEFAULT_FACTORY;
-
         private CheckpointFailureManager failureManager =
                 new CheckpointFailureManager(0, NoOpFailJobCall.INSTANCE);
 
@@ -775,12 +770,6 @@ public class CheckpointCoordinatorTestingUtils {
             return this;
         }
 
-        public CheckpointCoordinatorBuilder setSharedStateRegistryFactory(
-                SharedStateRegistryFactory sharedStateRegistryFactory) {
-            this.sharedStateRegistryFactory = sharedStateRegistryFactory;
-            return this;
-        }
-
         public CheckpointCoordinatorBuilder setFailureManager(
                 CheckpointFailureManager failureManager) {
             this.failureManager = failureManager;
@@ -823,7 +812,6 @@ public class CheckpointCoordinatorTestingUtils {
                     ioExecutor,
                     checkpointsCleaner,
                     timer,
-                    sharedStateRegistryFactory,
                     failureManager,
                     checkpointPlanCalculator,
                     new ExecutionAttemptMappingProvider(executionGraph.getAllExecutionVertices()));

--- a/flink-runtime/src/test/java/org/apache/flink/runtime/checkpoint/DefaultCompletedCheckpointStoreTest.java
+++ b/flink-runtime/src/test/java/org/apache/flink/runtime/checkpoint/DefaultCompletedCheckpointStoreTest.java
@@ -364,6 +364,8 @@ public class DefaultCompletedCheckpointStoreTest extends TestLogger {
                 checkpointStoreUtil,
                 DefaultCompletedCheckpointStoreUtils.retrieveCompletedCheckpoints(
                         stateHandleStore, checkpointStoreUtil),
+                SharedStateRegistry.DEFAULT_FACTORY.create(
+                        org.apache.flink.util.concurrent.Executors.directExecutor()),
                 executorService);
     }
 

--- a/flink-runtime/src/test/java/org/apache/flink/runtime/checkpoint/FailoverStrategyCheckpointCoordinatorTest.java
+++ b/flink-runtime/src/test/java/org/apache/flink/runtime/checkpoint/FailoverStrategyCheckpointCoordinatorTest.java
@@ -24,7 +24,6 @@ import org.apache.flink.runtime.executiongraph.ExecutionGraph;
 import org.apache.flink.runtime.executiongraph.ExecutionGraphCheckpointPlanCalculatorContext;
 import org.apache.flink.runtime.jobgraph.JobVertexID;
 import org.apache.flink.runtime.jobgraph.tasks.CheckpointCoordinatorConfiguration;
-import org.apache.flink.runtime.state.SharedStateRegistry;
 import org.apache.flink.runtime.state.memory.MemoryStateBackend;
 import org.apache.flink.util.TestLogger;
 import org.apache.flink.util.concurrent.Executors;
@@ -82,7 +81,6 @@ public class FailoverStrategyCheckpointCoordinatorTest extends TestLogger {
                         Executors.directExecutor(),
                         new CheckpointsCleaner(),
                         manualThreadExecutor,
-                        SharedStateRegistry.DEFAULT_FACTORY,
                         mock(CheckpointFailureManager.class),
                         new DefaultCheckpointPlanCalculator(
                                 graph.getJobID(),

--- a/flink-runtime/src/test/java/org/apache/flink/runtime/checkpoint/PerJobCheckpointRecoveryTest.java
+++ b/flink-runtime/src/test/java/org/apache/flink/runtime/checkpoint/PerJobCheckpointRecoveryTest.java
@@ -19,7 +19,9 @@
 package org.apache.flink.runtime.checkpoint;
 
 import org.apache.flink.api.common.JobID;
+import org.apache.flink.runtime.state.SharedStateRegistry;
 import org.apache.flink.util.TestLogger;
+import org.apache.flink.util.concurrent.Executors;
 
 import org.junit.Test;
 
@@ -42,17 +44,38 @@ public class PerJobCheckpointRecoveryTest extends TestLogger {
 
         final JobID firstJobId = new JobID();
         assertSame(
-                store, factory.createRecoveredCompletedCheckpointStore(firstJobId, 1, classLoader));
+                store,
+                factory.createRecoveredCompletedCheckpointStore(
+                        firstJobId,
+                        1,
+                        classLoader,
+                        SharedStateRegistry.DEFAULT_FACTORY.create(Executors.directExecutor())));
         assertThrows(
                 UnsupportedOperationException.class,
-                () -> factory.createRecoveredCompletedCheckpointStore(firstJobId, 1, classLoader));
+                () ->
+                        factory.createRecoveredCompletedCheckpointStore(
+                                firstJobId,
+                                1,
+                                classLoader,
+                                SharedStateRegistry.DEFAULT_FACTORY.create(
+                                        Executors.directExecutor())));
 
         final JobID secondJobId = new JobID();
         assertSame(
                 store,
-                factory.createRecoveredCompletedCheckpointStore(secondJobId, 1, classLoader));
+                factory.createRecoveredCompletedCheckpointStore(
+                        secondJobId,
+                        1,
+                        classLoader,
+                        SharedStateRegistry.DEFAULT_FACTORY.create(Executors.directExecutor())));
         assertThrows(
                 UnsupportedOperationException.class,
-                () -> factory.createRecoveredCompletedCheckpointStore(secondJobId, 1, classLoader));
+                () ->
+                        factory.createRecoveredCompletedCheckpointStore(
+                                secondJobId,
+                                1,
+                                classLoader,
+                                SharedStateRegistry.DEFAULT_FACTORY.create(
+                                        Executors.directExecutor())));
     }
 }

--- a/flink-runtime/src/test/java/org/apache/flink/runtime/checkpoint/PerJobCheckpointRecoveryTest.java
+++ b/flink-runtime/src/test/java/org/apache/flink/runtime/checkpoint/PerJobCheckpointRecoveryTest.java
@@ -49,7 +49,8 @@ public class PerJobCheckpointRecoveryTest extends TestLogger {
                         firstJobId,
                         1,
                         classLoader,
-                        SharedStateRegistry.DEFAULT_FACTORY.create(Executors.directExecutor())));
+                        SharedStateRegistry.DEFAULT_FACTORY,
+                        Executors.directExecutor()));
         assertThrows(
                 UnsupportedOperationException.class,
                 () ->
@@ -57,8 +58,8 @@ public class PerJobCheckpointRecoveryTest extends TestLogger {
                                 firstJobId,
                                 1,
                                 classLoader,
-                                SharedStateRegistry.DEFAULT_FACTORY.create(
-                                        Executors.directExecutor())));
+                                SharedStateRegistry.DEFAULT_FACTORY,
+                                Executors.directExecutor()));
 
         final JobID secondJobId = new JobID();
         assertSame(
@@ -67,7 +68,8 @@ public class PerJobCheckpointRecoveryTest extends TestLogger {
                         secondJobId,
                         1,
                         classLoader,
-                        SharedStateRegistry.DEFAULT_FACTORY.create(Executors.directExecutor())));
+                        SharedStateRegistry.DEFAULT_FACTORY,
+                        Executors.directExecutor()));
         assertThrows(
                 UnsupportedOperationException.class,
                 () ->
@@ -75,7 +77,7 @@ public class PerJobCheckpointRecoveryTest extends TestLogger {
                                 secondJobId,
                                 1,
                                 classLoader,
-                                SharedStateRegistry.DEFAULT_FACTORY.create(
-                                        Executors.directExecutor())));
+                                SharedStateRegistry.DEFAULT_FACTORY,
+                                Executors.directExecutor()));
     }
 }

--- a/flink-runtime/src/test/java/org/apache/flink/runtime/checkpoint/TestingCheckpointRecoveryFactory.java
+++ b/flink-runtime/src/test/java/org/apache/flink/runtime/checkpoint/TestingCheckpointRecoveryFactory.java
@@ -18,6 +18,7 @@
 package org.apache.flink.runtime.checkpoint;
 
 import org.apache.flink.api.common.JobID;
+import org.apache.flink.runtime.state.SharedStateRegistry;
 
 /** A {@link CheckpointRecoveryFactory} that pre-defined checkpointing components. */
 public class TestingCheckpointRecoveryFactory implements CheckpointRecoveryFactory {
@@ -33,7 +34,10 @@ public class TestingCheckpointRecoveryFactory implements CheckpointRecoveryFacto
 
     @Override
     public CompletedCheckpointStore createRecoveredCompletedCheckpointStore(
-            JobID jobId, int maxNumberOfCheckpointsToRetain, ClassLoader userClassLoader) {
+            JobID jobId,
+            int maxNumberOfCheckpointsToRetain,
+            ClassLoader userClassLoader,
+            SharedStateRegistry sharedStateRegistry) {
         return store;
     }
 

--- a/flink-runtime/src/test/java/org/apache/flink/runtime/checkpoint/TestingCheckpointRecoveryFactory.java
+++ b/flink-runtime/src/test/java/org/apache/flink/runtime/checkpoint/TestingCheckpointRecoveryFactory.java
@@ -18,7 +18,9 @@
 package org.apache.flink.runtime.checkpoint;
 
 import org.apache.flink.api.common.JobID;
-import org.apache.flink.runtime.state.SharedStateRegistry;
+import org.apache.flink.runtime.state.SharedStateRegistryFactory;
+
+import java.util.concurrent.Executor;
 
 /** A {@link CheckpointRecoveryFactory} that pre-defined checkpointing components. */
 public class TestingCheckpointRecoveryFactory implements CheckpointRecoveryFactory {
@@ -37,7 +39,8 @@ public class TestingCheckpointRecoveryFactory implements CheckpointRecoveryFacto
             JobID jobId,
             int maxNumberOfCheckpointsToRetain,
             ClassLoader userClassLoader,
-            SharedStateRegistry sharedStateRegistry) {
+            SharedStateRegistryFactory sharedStateRegistryFactory,
+            Executor ioExecutor) {
         return store;
     }
 

--- a/flink-runtime/src/test/java/org/apache/flink/runtime/checkpoint/TestingCompletedCheckpointStore.java
+++ b/flink-runtime/src/test/java/org/apache/flink/runtime/checkpoint/TestingCompletedCheckpointStore.java
@@ -18,9 +18,11 @@
 package org.apache.flink.runtime.checkpoint;
 
 import org.apache.flink.api.common.JobStatus;
+import org.apache.flink.runtime.jobgraph.OperatorID;
 
 import java.util.Collections;
 import java.util.List;
+import java.util.Map;
 import java.util.concurrent.CompletableFuture;
 
 /** Test {@link CompletedCheckpointStore} implementation for testing the shutdown behavior. */
@@ -67,6 +69,11 @@ public final class TestingCompletedCheckpointStore implements CompletedCheckpoin
 
     @Override
     public boolean requiresExternalizedCheckpoints() {
+        throw new UnsupportedOperationException("Not implemented.");
+    }
+
+    @Override
+    public void registerSharedState(Map<OperatorID, OperatorState> operatorStates) {
         throw new UnsupportedOperationException("Not implemented.");
     }
 }

--- a/flink-runtime/src/test/java/org/apache/flink/runtime/checkpoint/TestingCompletedCheckpointStore.java
+++ b/flink-runtime/src/test/java/org/apache/flink/runtime/checkpoint/TestingCompletedCheckpointStore.java
@@ -18,11 +18,10 @@
 package org.apache.flink.runtime.checkpoint;
 
 import org.apache.flink.api.common.JobStatus;
-import org.apache.flink.runtime.jobgraph.OperatorID;
+import org.apache.flink.runtime.state.SharedStateRegistry;
 
 import java.util.Collections;
 import java.util.List;
-import java.util.Map;
 import java.util.concurrent.CompletableFuture;
 
 /** Test {@link CompletedCheckpointStore} implementation for testing the shutdown behavior. */
@@ -73,7 +72,7 @@ public final class TestingCompletedCheckpointStore implements CompletedCheckpoin
     }
 
     @Override
-    public void registerSharedState(Map<OperatorID, OperatorState> operatorStates) {
+    public SharedStateRegistry getSharedStateRegistry() {
         throw new UnsupportedOperationException("Not implemented.");
     }
 }

--- a/flink-runtime/src/test/java/org/apache/flink/runtime/checkpoint/ZooKeeperCompletedCheckpointStoreITCase.java
+++ b/flink-runtime/src/test/java/org/apache/flink/runtime/checkpoint/ZooKeeperCompletedCheckpointStoreITCase.java
@@ -29,6 +29,7 @@ import org.apache.flink.runtime.util.ZooKeeperUtils;
 import org.apache.flink.runtime.zookeeper.ZooKeeperStateHandleStore;
 import org.apache.flink.runtime.zookeeper.ZooKeeperTestEnvironment;
 import org.apache.flink.util.clock.ManualClock;
+import org.apache.flink.util.concurrent.Executors;
 
 import org.apache.flink.shaded.curator4.org.apache.curator.framework.CuratorFramework;
 import org.apache.flink.shaded.zookeeper3.org.apache.zookeeper.data.Stat;
@@ -88,6 +89,7 @@ public class ZooKeeperCompletedCheckpointStoreITCase extends CompletedCheckpoint
                 checkpointStoreUtil,
                 DefaultCompletedCheckpointStoreUtils.retrieveCompletedCheckpoints(
                         checkpointsInZooKeeper, checkpointStoreUtil),
+                SharedStateRegistry.DEFAULT_FACTORY.create(Executors.directExecutor()),
                 executor);
     }
 

--- a/flink-runtime/src/test/java/org/apache/flink/runtime/checkpoint/ZooKeeperCompletedCheckpointStoreTest.java
+++ b/flink-runtime/src/test/java/org/apache/flink/runtime/checkpoint/ZooKeeperCompletedCheckpointStoreTest.java
@@ -191,6 +191,7 @@ public class ZooKeeperCompletedCheckpointStoreTest extends TestLogger {
                 checkpointsInZooKeeper,
                 zooKeeperCheckpointStoreUtil,
                 Collections.emptyList(),
+                SharedStateRegistry.DEFAULT_FACTORY.create(Executors.directExecutor()),
                 Executors.directExecutor());
     }
 

--- a/flink-runtime/src/test/java/org/apache/flink/runtime/dispatcher/DispatcherFailoverITCase.java
+++ b/flink-runtime/src/test/java/org/apache/flink/runtime/dispatcher/DispatcherFailoverITCase.java
@@ -47,6 +47,7 @@ import org.junit.Test;
 import javax.annotation.Nullable;
 
 import java.util.ArrayList;
+import java.util.Collections;
 import java.util.List;
 import java.util.Objects;
 import java.util.Optional;
@@ -69,15 +70,18 @@ public class DispatcherFailoverITCase extends AbstractDispatcherTest {
         super.setUp();
         haServices.setCheckpointRecoveryFactory(
                 new PerJobCheckpointRecoveryFactory<EmbeddedCompletedCheckpointStore>(
-                        (maxCheckpoints, previous) -> {
+                        (maxCheckpoints, previous, sharedStateRegistry) -> {
                             if (previous != null) {
                                 // First job attempt failed before cleaning up the checkpoint store.
                                 assertFalse(previous.getShutdownStatus().isPresent());
                                 assertFalse(previous.getAllCheckpoints().isEmpty());
                                 return new EmbeddedCompletedCheckpointStore(
-                                        maxCheckpoints, previous.getAllCheckpoints());
+                                        maxCheckpoints,
+                                        previous.getAllCheckpoints(),
+                                        sharedStateRegistry);
                             }
-                            return new EmbeddedCompletedCheckpointStore(maxCheckpoints);
+                            return new EmbeddedCompletedCheckpointStore(
+                                    maxCheckpoints, Collections.emptyList(), sharedStateRegistry);
                         }));
     }
 

--- a/flink-runtime/src/test/java/org/apache/flink/runtime/scheduler/SchedulerUtilsTest.java
+++ b/flink-runtime/src/test/java/org/apache/flink/runtime/scheduler/SchedulerUtilsTest.java
@@ -23,7 +23,9 @@ import org.apache.flink.configuration.CheckpointingOptions;
 import org.apache.flink.configuration.Configuration;
 import org.apache.flink.runtime.checkpoint.CompletedCheckpointStore;
 import org.apache.flink.runtime.checkpoint.StandaloneCheckpointRecoveryFactory;
+import org.apache.flink.runtime.state.SharedStateRegistry;
 import org.apache.flink.util.TestLogger;
+import org.apache.flink.util.concurrent.Executors;
 
 import org.junit.Test;
 
@@ -45,6 +47,7 @@ public class SchedulerUtilsTest extends TestLogger {
                         jobManagerConfig,
                         getClass().getClassLoader(),
                         new StandaloneCheckpointRecoveryFactory(),
+                        SharedStateRegistry.DEFAULT_FACTORY.create(Executors.directExecutor()),
                         log,
                         new JobID());
 

--- a/flink-runtime/src/test/java/org/apache/flink/runtime/scheduler/SchedulerUtilsTest.java
+++ b/flink-runtime/src/test/java/org/apache/flink/runtime/scheduler/SchedulerUtilsTest.java
@@ -47,7 +47,8 @@ public class SchedulerUtilsTest extends TestLogger {
                         jobManagerConfig,
                         getClass().getClassLoader(),
                         new StandaloneCheckpointRecoveryFactory(),
-                        SharedStateRegistry.DEFAULT_FACTORY.create(Executors.directExecutor()),
+                        SharedStateRegistry.DEFAULT_FACTORY,
+                        Executors.directExecutor(),
                         log,
                         new JobID());
 


### PR DESCRIPTION
 [FLINK-24086][checkpoint] Rebuilding the SharedStateRegistry only when the restore method is called for the first time.
 
From FLINK-22483, the CompletedCheckpointStore will not change during task failover, so we only need to rebuild the SharedStateRegistry once, which can reduce the recovery time during failover.


<!--
*Thank you very much for contributing to Apache Flink - we are happy that you want to help us improve Flink. To help the community review your contribution in the best possible way, please go through the checklist below, which will get the contribution into a shape in which it can be best reviewed.*

*Please understand that we do not do this to make contributions to Flink a hassle. In order to uphold a high standard of quality for code contributions, while at the same time managing a large number of contributions, we need contributors to prepare the contributions well, and give reviewers enough contextual information for the review. Please also understand that contributions that do not follow this guide will take longer to review and thus typically be picked up with lower priority by the community.*

## Contribution Checklist

  - Make sure that the pull request corresponds to a [JIRA issue](https://issues.apache.org/jira/projects/FLINK/issues). Exceptions are made for typos in JavaDoc or documentation files, which need no JIRA issue.
  
  - Name the pull request in the form "[FLINK-XXXX] [component] Title of the pull request", where *FLINK-XXXX* should be replaced by the actual issue number. Skip *component* if you are unsure about which is the best component.
  Typo fixes that have no associated JIRA issue should be named following this pattern: `[hotfix] [docs] Fix typo in event time introduction` or `[hotfix] [javadocs] Expand JavaDoc for PuncuatedWatermarkGenerator`.

  - Fill out the template below to describe the changes contributed by the pull request. That will give reviewers the context they need to do the review.
  
  - Make sure that the change passes the automated tests, i.e., `mvn clean verify` passes. You can set up Azure Pipelines CI to do that following [this guide](https://cwiki.apache.org/confluence/display/FLINK/Azure+Pipelines#AzurePipelines-Tutorial:SettingupAzurePipelinesforaforkoftheFlinkrepository).

  - Each pull request should address only one issue, not mix up code from multiple issues.
  
  - Each commit in the pull request has a meaningful commit message (including the JIRA id)

  - Once all items of the checklist are addressed, remove the above text and this checklist, leaving only the filled out template below.


**(The sections below can be removed for hotfixes of typos)**
-->

## What is the purpose of the change

Move `SharedStateRigistry` to `CompleteCheckpointStore` to make the life cycle of them consistent, so that we only need to re-register the shared state once when the `CompleteCheckpointStore` is restored, which can reduce the time of task failover.

## Brief change log

1. Add `SharedStateRegistry` to the `createRecoveredCompletedCheckpointStore` method of `CheckpointRecoveryFactory`, and let `CompletedCheckpointStore` manage `SharedStateRegistry` by itself. `CheckpointCoordinator` no longer manages `SharedStateRegistry`.
2. When the `CompletedCheckpointStore` is recovering, it will also register the shared state of the recovered `CompletedCheckpoint`.
3. `CompletedCheckpointStore` adds the `registerSharedState` method, which is used to provide an interface for the `CheckpointCoordinator` to register the shared state.

## Verifying this change

This change added tests and can be verified as follows:
  - *Added a test to verify that the shared state reference is correct and can be deleted correctly when the SharedStateRegistry is not rebuilt during failover.*
>  org.apache.flink.runtime.checkpoint.CheckpointCoordinatorTest#testSharedStateRegistrationWithoutRebuildSharedStateRegistry

## Does this pull request potentially affect one of the following parts:

  - Dependencies (does it add or upgrade a dependency): (yes / **no**)
  - The public API, i.e., is any changed class annotated with `@Public(Evolving)`: (yes / **no**)
  - The serializers: (yes / **no** / don't know)
  - The runtime per-record code paths (performance sensitive): (yes / **no** / don't know)
  - Anything that affects deployment or recovery: JobManager (and its components), Checkpointing, Kubernetes/Yarn, ZooKeeper: (**yes** / no / don't know)
  - The S3 file system connector: (yes / **no** / don't know)

## Documentation

  - Does this pull request introduce a new feature? (yes / **no**)
  - If yes, how is the feature documented? (not applicable / docs / JavaDocs / not documented)
