### PR TITLE
[FLINK-24183][legal] Add aws-java-sdk-s3 to source NOTICE

### DIFF
--- a/NOTICE
+++ b/NOTICE
@@ -43,3 +43,22 @@ The Apache Flink project contains or reuses code that is licensed under the Apac
 - Google Cloud Client Library for Java (https://github.com/googleapis/google-cloud-java) Copyright 2017 Google LLC
 
   See: flink-end-to-end-tests/flink-connector-gcp-pubsub-emulator-tests/src/test/java/org/apache/flink/streaming/connectors/gcp/pubsub/emulator/PubsubHelper.java
+
+- aws-sdk-java-s3 (https://github.com/aws/aws-sdk-java)
+
+  See: flink/flink-filesystems/flink-s3-fs-base/src/main/java/com/amazonaws/services/s3/model/transform/XmlResponsesSaxParser.java
+
+AWS SDK for Java
+Copyright 2010-2014 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+
+This product includes software developed by
+Amazon Technologies, Inc (http://www.amazon.com/).
+
+**********************
+THIRD PARTY COMPONENTS
+**********************
+This software includes third party software subject to the following copyrights:
+- XML parsing and utility functions from JetS3t - Copyright 2006-2009 James Murty.
+- PKCS#1 PEM encoded private key parsing and utility functions from oauth.googlecode.com - Copyright 1998-2010 AOL Inc.
+
+


### PR DESCRIPTION
Adds the aws-java-sdk NOTICE to the source NOTICE, because we have copied classes from said project.