### PR TITLE
[FLINK-11250][runtime] Added method init for RecordWriter for initialization resources(OutputFlusher) outside of constructor

### DIFF
--- a/flink-runtime/src/test/java/org/apache/flink/runtime/taskmanager/TaskTest.java
+++ b/flink-runtime/src/test/java/org/apache/flink/runtime/taskmanager/TaskTest.java
@@ -153,6 +153,26 @@ public class TaskTest extends TestLogger {
     }
 
     @Test
+    public void testCleanupWhenSwitchToInitializationFails() throws Exception {
+        createTaskBuilder()
+                .setInvokable(TestInvokableCorrect.class)
+                .setTaskManagerActions(
+                        new NoOpTaskManagerActions() {
+                            @Override
+                            public void updateTaskExecutionState(
+                                    TaskExecutionState taskExecutionState) {
+                                if (taskExecutionState.getExecutionState()
+                                        == ExecutionState.INITIALIZING) {
+                                    throw new ExpectedTestException();
+                                }
+                            }
+                        })
+                .build()
+                .run();
+        assertTrue(wasCleanedUp);
+    }
+
+    @Test
     public void testRegularExecution() throws Exception {
         final QueuedNoOpTaskManagerActions taskManagerActions = new QueuedNoOpTaskManagerActions();
         final Task task =

--- a/flink-streaming-java/src/test/java/org/apache/flink/streaming/runtime/tasks/StreamConfigChainer.java
+++ b/flink-streaming-java/src/test/java/org/apache/flink/streaming/runtime/tasks/StreamConfigChainer.java
@@ -49,6 +49,7 @@ public class StreamConfigChainer<OWNER> {
     private final StreamConfig headConfig;
     private final Map<Integer, StreamConfig> chainedConfigs = new HashMap<>();
     private final int numberOfNonChainedOutputs;
+    private int bufferTimeout;
 
     private StreamConfig tailConfig;
     private int chainIndex = MAIN_NODE_ID;
@@ -127,26 +128,22 @@ public class StreamConfigChainer<OWNER> {
 
         chainIndex++;
 
-        tailConfig.setChainedOutputs(
-                Collections.singletonList(
-                        new StreamEdge(
-                                new StreamNode(
-                                        tailConfig.getChainIndex(),
-                                        null,
-                                        null,
-                                        (StreamOperator<?>) null,
-                                        null,
-                                        null),
-                                new StreamNode(
-                                        chainIndex,
-                                        null,
-                                        null,
-                                        (StreamOperator<?>) null,
-                                        null,
-                                        null),
-                                0,
+        StreamEdge streamEdge =
+                new StreamEdge(
+                        new StreamNode(
+                                tailConfig.getChainIndex(),
                                 null,
-                                null)));
+                                null,
+                                (StreamOperator<?>) null,
+                                null,
+                                null),
+                        new StreamNode(
+                                chainIndex, null, null, (StreamOperator<?>) null, null, null),
+                        0,
+                        null,
+                        null);
+        streamEdge.setBufferTimeout(bufferTimeout);
+        tailConfig.setChainedOutputs(Collections.singletonList(streamEdge));
         tailConfig = new StreamConfig(new Configuration());
         tailConfig.setStreamOperatorFactory(checkNotNull(operatorFactory));
         tailConfig.setOperatorID(checkNotNull(operatorID));
@@ -173,7 +170,7 @@ public class StreamConfigChainer<OWNER> {
         StreamNode sourceVertex =
                 new StreamNode(chainIndex, null, null, (StreamOperator<?>) null, null, null);
         for (int i = 0; i < numberOfNonChainedOutputs; ++i) {
-            outEdgesInOrder.add(
+            StreamEdge streamEdge =
                     new StreamEdge(
                             sourceVertex,
                             new StreamNode(
@@ -185,7 +182,9 @@ public class StreamConfigChainer<OWNER> {
                                     null),
                             0,
                             new BroadcastPartitioner<>(),
-                            null));
+                            null);
+            streamEdge.setBufferTimeout(1);
+            outEdgesInOrder.add(streamEdge);
         }
 
         tailConfig.setChainEnd();
@@ -249,5 +248,9 @@ public class StreamConfigChainer<OWNER> {
     public StreamConfigChainer<OWNER> name(String name) {
         tailConfig.setOperatorName(name);
         return this;
+    }
+
+    public void setBufferTimeout(int bufferTimeout) {
+        this.bufferTimeout = bufferTimeout;
     }
 }


### PR DESCRIPTION
<!--
*Thank you very much for contributing to Apache Flink - we are happy that you want to help us improve Flink. To help the community review your contribution in the best possible way, please go through the checklist below, which will get the contribution into a shape in which it can be best reviewed.*

*Please understand that we do not do this to make contributions to Flink a hassle. In order to uphold a high standard of quality for code contributions, while at the same time managing a large number of contributions, we need contributors to prepare the contributions well, and give reviewers enough contextual information for the review. Please also understand that contributions that do not follow this guide will take longer to review and thus typically be picked up with lower priority by the community.*

## Contribution Checklist

  - Make sure that the pull request corresponds to a [JIRA issue](https://issues.apache.org/jira/projects/FLINK/issues). Exceptions are made for typos in JavaDoc or documentation files, which need no JIRA issue.
  
  - Name the pull request in the form "[FLINK-XXXX] [component] Title of the pull request", where *FLINK-XXXX* should be replaced by the actual issue number. Skip *component* if you are unsure about which is the best component.
  Typo fixes that have no associated JIRA issue should be named following this pattern: `[hotfix] [docs] Fix typo in event time introduction` or `[hotfix] [javadocs] Expand JavaDoc for PuncuatedWatermarkGenerator`.

  - Fill out the template below to describe the changes contributed by the pull request. That will give reviewers the context they need to do the review.
  
  - Make sure that the change passes the automated tests, i.e., `mvn clean verify` passes. You can set up Azure Pipelines CI to do that following [this guide](https://cwiki.apache.org/confluence/display/FLINK/Azure+Pipelines#AzurePipelines-Tutorial:SettingupAzurePipelinesforaforkoftheFlinkrepository).

  - Each pull request should address only one issue, not mix up code from multiple issues.
  
  - Each commit in the pull request has a meaningful commit message (including the JIRA id)

  - Once all items of the checklist are addressed, remove the above text and this checklist, leaving only the filled out template below.


**(The sections below can be removed for hotfixes of typos)**
-->

## What is the purpose of the change

*This PR resolves the problem with closing the OutputFlusher when an exception happens before the task restore.*


## Brief change log
  - *New method `init` for RecordWriter created*
  - *Moved the INITIALIZING transition under cleanUp try-catch block*


## Verifying this change

This change added tests and can be verified as follows:

  - *Added tests for initialization of RecordWriter *
  - *Added test for check closing of OutputFlusher from Task*

## Does this pull request potentially affect one of the following parts:

  - Dependencies (does it add or upgrade a dependency): (yes / **no**)
  - The public API, i.e., is any changed class annotated with `@Public(Evolving)`: (yes / **no**)
  - The serializers: (yes / **no** / don't know)
  - The runtime per-record code paths (performance sensitive): (yes / **no** / don't know)
  - Anything that affects deployment or recovery: JobManager (and its components), Checkpointing, Kubernetes/Yarn, ZooKeeper: (yes / **no** / don't know)
  - The S3 file system connector: (yes / **no** / don't know)

## Documentation

  - Does this pull request introduce a new feature? (yes / **no**)
  - If yes, how is the feature documented? (not applicable / docs / JavaDocs / not documented)
