### PR TITLE
[FLINK-24034] Upgrade commons-compress to 1.21 and other apache.commons updates

### DIFF
--- a/flink-connectors/flink-connector-elasticsearch5/src/main/resources/META-INF/NOTICE
+++ b/flink-connectors/flink-connector-elasticsearch5/src/main/resources/META-INF/NOTICE
@@ -15,7 +15,7 @@ This project bundles the following dependencies under the Apache Software Licens
 - com.fasterxml.jackson.dataformat:jackson-dataformat-yaml:2.12.1
 - com.github.spullara.mustache.java:compiler:0.9.3
 - com.tdunning:t-digest:3.0
-- commons-codec:commons-codec:1.13
+- commons-codec:commons-codec:1.15
 - commons-logging:commons-logging:1.1.3
 - io.netty:netty:3.10.6.Final
 - io.netty:netty-buffer:4.1.46.Final

--- a/flink-connectors/flink-sql-connector-elasticsearch6/src/main/resources/META-INF/NOTICE
+++ b/flink-connectors/flink-sql-connector-elasticsearch6/src/main/resources/META-INF/NOTICE
@@ -12,7 +12,7 @@ This project bundles the following dependencies under the Apache Software Licens
 - com.fasterxml.jackson.dataformat:jackson-dataformat-cbor:2.12.1
 - com.fasterxml.jackson.dataformat:jackson-dataformat-smile:2.12.1
 - com.fasterxml.jackson.dataformat:jackson-dataformat-yaml:2.12.1
-- commons-codec:commons-codec:1.13
+- commons-codec:commons-codec:1.15
 - commons-logging:commons-logging:1.1.3
 - org.apache.httpcomponents:httpasyncclient:4.1.2
 - org.apache.httpcomponents:httpclient:4.5.13

--- a/flink-connectors/flink-sql-connector-elasticsearch7/src/main/resources/META-INF/NOTICE
+++ b/flink-connectors/flink-sql-connector-elasticsearch7/src/main/resources/META-INF/NOTICE
@@ -14,7 +14,7 @@ This project bundles the following dependencies under the Apache Software Licens
 - com.fasterxml.jackson.dataformat:jackson-dataformat-smile:2.12.1
 - com.fasterxml.jackson.dataformat:jackson-dataformat-yaml:2.12.1
 - com.github.spullara.mustache.java:compiler:0.9.6
-- commons-codec:commons-codec:1.13
+- commons-codec:commons-codec:1.15
 - commons-logging:commons-logging:1.1.3
 - org.apache.httpcomponents:httpasyncclient:4.1.4
 - org.apache.httpcomponents:httpclient:4.5.13

--- a/flink-connectors/flink-sql-connector-hbase-1.4/src/main/resources/META-INF/NOTICE
+++ b/flink-connectors/flink-sql-connector-hbase-1.4/src/main/resources/META-INF/NOTICE
@@ -7,7 +7,7 @@ The Apache Software Foundation (http://www.apache.org/).
 This project bundles the following dependencies under the Apache Software License 2.0. (http://www.apache.org/licenses/LICENSE-2.0.txt)
 - com.google.guava:guava:12.0.1
 - com.yammer.metrics:metrics-core:2.2.0
-- commons-codec:commons-codec:1.13
+- commons-codec:commons-codec:1.15
 - commons-lang:commons-lang:2.6
 - commons-logging:commons-logging:1.1.3
 - io.netty:netty-all:4.1.46.Final

--- a/flink-connectors/flink-sql-connector-hbase-2.2/src/main/resources/META-INF/NOTICE
+++ b/flink-connectors/flink-sql-connector-hbase-2.2/src/main/resources/META-INF/NOTICE
@@ -6,7 +6,7 @@ The Apache Software Foundation (http://www.apache.org/).
 
 This project bundles the following dependencies under the Apache Software License 2.0. (http://www.apache.org/licenses/LICENSE-2.0.txt)
 
- - commons-codec:commons-codec:1.13
+ - commons-codec:commons-codec:1.15
  - io.netty:netty-all:4.1.46.Final
  - io.dropwizard.metrics:metrics-core:3.2.6
  - org.apache.commons:commons-crypto:1.0.0

--- a/flink-connectors/flink-sql-connector-kinesis/src/main/resources/META-INF/NOTICE
+++ b/flink-connectors/flink-sql-connector-kinesis/src/main/resources/META-INF/NOTICE
@@ -7,10 +7,10 @@ The Apache Software Foundation (http://www.apache.org/).
 This project bundles the following dependencies under the Apache Software License 2.0. (http://www.apache.org/licenses/LICENSE-2.0.txt)
 
 - joda-time:joda-time:2.5
-- commons-io:commons-io:2.8.0
+- commons-io:commons-io:2.11.0
 - commons-lang:commons-lang:2.6
 - commons-logging:commons-logging:1.1.3
-- commons-codec:commons-codec:1.13
+- commons-codec:commons-codec:1.15
 - org.apache.commons:commons-lang3:3.3.2
 - com.google.guava:guava:29.0-jre
 - com.google.guava:failureaccess:1.0.1

--- a/flink-dist/src/main/resources/META-INF/NOTICE
+++ b/flink-dist/src/main/resources/META-INF/NOTICE
@@ -10,12 +10,12 @@ This project bundles the following dependencies under the Apache Software Licens
 - com.google.code.findbugs:jsr305:1.3.9
 - com.twitter:chill-java:0.7.6
 - com.twitter:chill_2.11:0.7.6
-- commons-cli:commons-cli:1.3.1
+- commons-cli:commons-cli:1.4
 - commons-collections:commons-collections:3.2.2
-- commons-io:commons-io:2.8.0
+- commons-io:commons-io:2.11.0
 - org.apache.commons:commons-compress:1.21
 - org.apache.commons:commons-lang3:3.3.2
-- org.apache.commons:commons-math3:3.5
+- org.apache.commons:commons-math3:3.6.1
 - org.javassist:javassist:3.24.0-GA
 - org.lz4:lz4-java:1.8.0
 - org.objenesis:objenesis:2.1

--- a/flink-dist/src/main/resources/META-INF/NOTICE
+++ b/flink-dist/src/main/resources/META-INF/NOTICE
@@ -13,7 +13,7 @@ This project bundles the following dependencies under the Apache Software Licens
 - commons-cli:commons-cli:1.3.1
 - commons-collections:commons-collections:3.2.2
 - commons-io:commons-io:2.8.0
-- org.apache.commons:commons-compress:1.20
+- org.apache.commons:commons-compress:1.21
 - org.apache.commons:commons-lang3:3.3.2
 - org.apache.commons:commons-math3:3.5
 - org.javassist:javassist:3.24.0-GA

--- a/flink-filesystems/flink-azure-fs-hadoop/src/main/resources/META-INF/NOTICE
+++ b/flink-filesystems/flink-azure-fs-hadoop/src/main/resources/META-INF/NOTICE
@@ -12,7 +12,7 @@ This project bundles the following dependencies under the Apache Software Licens
 - com.google.guava:guava:27.0-jre
 - com.google.guava:listenablefuture:9999.0-empty-to-avoid-conflict-with-guava
 - com.google.j2objc:j2objc-annotations:1.1
-- commons-codec:commons-codec:1.13
+- commons-codec:commons-codec:1.15
 - commons-logging:commons-logging:1.1.3
 - org.apache.hadoop:hadoop-azure:3.2.2
 - org.apache.httpcomponents:httpclient:4.5.13

--- a/flink-filesystems/flink-fs-hadoop-shaded/src/main/resources/META-INF/NOTICE
+++ b/flink-filesystems/flink-fs-hadoop-shaded/src/main/resources/META-INF/NOTICE
@@ -14,7 +14,7 @@ This project bundles the following dependencies under the Apache Software Licens
 - org.apache.commons:commons-lang3:3.3.2
 - org.apache.commons:commons-text:1.4
 - commons-collections:commons-collections:3.2.2
-- commons-io:commons-io:2.8.0
+- commons-io:commons-io:2.11.0
 - commons-logging:commons-logging:1.1.3
 - commons-beanutils:commons-beanutils:1.9.4
 - com.google.errorprone:error_prone_annotations:2.2.0

--- a/flink-filesystems/flink-oss-fs-hadoop/src/main/resources/META-INF/NOTICE
+++ b/flink-filesystems/flink-oss-fs-hadoop/src/main/resources/META-INF/NOTICE
@@ -11,7 +11,7 @@ This project bundles the following dependencies under the Apache Software Licens
 - com.aliyun:aliyun-java-sdk-ecs:4.2.0
 - com.aliyun:aliyun-java-sdk-ram:3.0.0
 - com.aliyun:aliyun-java-sdk-sts:3.0.0
-- commons-codec:commons-codec:1.13
+- commons-codec:commons-codec:1.15
 - commons-logging:commons-logging:1.1.3
 - org.apache.hadoop:hadoop-aliyun:3.2.2
 - org.apache.httpcomponents:httpclient:4.5.13

--- a/flink-filesystems/flink-s3-fs-hadoop/src/main/resources/META-INF/NOTICE
+++ b/flink-filesystems/flink-s3-fs-hadoop/src/main/resources/META-INF/NOTICE
@@ -20,9 +20,9 @@ This project bundles the following dependencies under the Apache Software Licens
 - com.google.guava:listenablefuture:9999.0-empty-to-avoid-conflict-with-guava
 - com.google.j2objc:j2objc-annotations:1.1
 - commons-beanutils:commons-beanutils:1.9.4
-- commons-codec:commons-codec:1.13
+- commons-codec:commons-codec:1.15
 - commons-collections:commons-collections:3.2.2
-- commons-io:commons-io:2.8.0
+- commons-io:commons-io:2.11.0
 - commons-logging:commons-logging:1.1.3
 - joda-time:joda-time:2.5
 - org.apache.commons:commons-configuration2:2.1.1

--- a/flink-filesystems/flink-s3-fs-presto/src/main/resources/META-INF/NOTICE
+++ b/flink-filesystems/flink-s3-fs-presto/src/main/resources/META-INF/NOTICE
@@ -7,9 +7,9 @@ The Apache Software Foundation (http://www.apache.org/).
 This project bundles the following dependencies under the Apache Software License 2.0 (http://www.apache.org/licenses/LICENSE-2.0.txt)
 
 - commons-beanutils:commons-beanutils:1.9.4
-- commons-codec:commons-codec:1.13
+- commons-codec:commons-codec:1.15
 - commons-collections:commons-collections:3.2.2
-- commons-io:commons-io:2.8.0
+- commons-io:commons-io:2.11.0
 - commons-logging:commons-logging:1.1.3
 - com.amazonaws:aws-java-sdk-core:1.11.951
 - com.amazonaws:aws-java-sdk-dynamodb:1.11.951

--- a/flink-formats/flink-sql-avro-confluent-registry/src/main/resources/META-INF/NOTICE
+++ b/flink-formats/flink-sql-avro-confluent-registry/src/main/resources/META-INF/NOTICE
@@ -10,7 +10,7 @@ This project bundles the following dependencies under the Apache Software Licens
 - com.fasterxml.jackson.core:jackson-core:2.12.1
 - com.fasterxml.jackson.core:jackson-databind:2.12.1
 - com.fasterxml.jackson.core:jackson-annotations:2.12.1
-- org.apache.commons:commons-compress:1.20
+- org.apache.commons:commons-compress:1.21
 - io.confluent:kafka-schema-registry-client:5.5.2
 - org.apache.kafka:kafka-clients:5.5.2-ccs
 - io.confluent:common-config:5.5.2

--- a/flink-formats/flink-sql-avro/src/main/resources/META-INF/NOTICE
+++ b/flink-formats/flink-sql-avro/src/main/resources/META-INF/NOTICE
@@ -10,4 +10,4 @@ This project bundles the following dependencies under the Apache Software Licens
 - com.fasterxml.jackson.core:jackson-core:2.12.1
 - com.fasterxml.jackson.core:jackson-databind:2.12.1
 - com.fasterxml.jackson.core:jackson-annotations:2.12.1
-- org.apache.commons:commons-compress:1.20
+- org.apache.commons:commons-compress:1.21

--- a/flink-streaming-java/pom.xml
+++ b/flink-streaming-java/pom.xml
@@ -77,7 +77,7 @@ under the License.
 		<dependency>
 			<groupId>org.apache.commons</groupId>
 			<artifactId>commons-math3</artifactId>
-			<version>3.5</version>
+			<version>3.6.1</version>
 		</dependency>
 
 		<!-- test dependencies -->

--- a/flink-table/flink-table-planner/src/main/resources/META-INF/NOTICE
+++ b/flink-table/flink-table-planner/src/main/resources/META-INF/NOTICE
@@ -17,8 +17,8 @@ This project bundles the following dependencies under the Apache Software Licens
 - org.apache.calcite:calcite-linq4j:1.26.0
 - org.apache.calcite.avatica:avatica-core:1.17.0
 - org.scala-lang.modules:scala-parser-combinators_2.11:1.1.1
-- commons-codec:commons-codec:1.13
-- commons-io:commons-io:2.8.0
+- commons-codec:commons-codec:1.15
+- commons-io:commons-io:2.11.0
 
 This project bundles the following dependencies under the BSD license.
 See bundled license files for details

--- a/pom.xml
+++ b/pom.xml
@@ -583,13 +583,13 @@ under the License.
 			<dependency>
 				<groupId>commons-cli</groupId>
 				<artifactId>commons-cli</artifactId>
-				<version>1.3.1</version>
+				<version>1.4</version>
 			</dependency>
 
 			<dependency>
 				<groupId>commons-io</groupId>
 				<artifactId>commons-io</artifactId>
-				<version>2.8.0</version>
+				<version>2.11.0</version>
 			</dependency>
 
 			<!-- commons collections needs to be pinned to this critical security fix version -->
@@ -616,13 +616,13 @@ under the License.
 			<dependency>
 				<groupId>commons-codec</groupId>
 				<artifactId>commons-codec</artifactId>
-				<version>1.13</version>
+				<version>1.15</version>
 			</dependency>
 
 			<dependency>
 				<groupId>org.apache.commons</groupId>
 				<artifactId>commons-math3</artifactId>
-				<version>3.5</version>
+				<version>3.6.1</version>
 			</dependency>
 
 			<dependency>

--- a/pom.xml
+++ b/pom.xml
@@ -628,7 +628,7 @@ under the License.
 			<dependency>
 				<groupId>org.apache.commons</groupId>
 				<artifactId>commons-compress</artifactId>
-				<version>1.20</version>
+				<version>1.21</version>
 			</dependency>
 
 			<!-- Managed dependency required for HBase in flink-connector-hbase -->


### PR DESCRIPTION
## What is the purpose of the change

* Update commons-compress to 1.21 due to CVE-2021-35517
* Updated other apache.commons dependencies to latest version

## Brief change log

* Separate commits for addressing the commons-compress update and the other apache.commons updates

## Verifying this change

This change is a trivial rework / code cleanup without any test coverage.

## Does this pull request potentially affect one of the following parts:

  - Dependencies (does it add or upgrade a dependency): (**yes** / no)
  - The public API, i.e., is any changed class annotated with `@Public(Evolving)`: (yes / **no**)
  - The serializers: (yes / **no** / don't know)
  - The runtime per-record code paths (performance sensitive): (yes / **no** / don't know)
  - Anything that affects deployment or recovery: JobManager (and its components), Checkpointing, Kubernetes/Yarn, ZooKeeper: (yes / **no** / don't know)
  - The S3 file system connector: (yes / **no** / don't know)

## Documentation

  - Does this pull request introduce a new feature? (yes / **no**)
  - If yes, how is the feature documented? (**not applicable** / docs / JavaDocs / not documented)
