### PR TITLE
[HOTFIX][docs] fix sentence to make the description more clear.

### DIFF
--- a/flink-core/src/main/java/org/apache/flink/core/fs/FSDataInputStream.java
+++ b/flink-core/src/main/java/org/apache/flink/core/fs/FSDataInputStream.java
@@ -33,8 +33,8 @@ import java.io.InputStream;
 public abstract class FSDataInputStream extends InputStream {
 
     /**
-     * Seek to the given offset from the start of the file. The next read() will be from that
-     * location. Can't seek past the end of the stream.
+     * Seeks to the given offset from the start of the file. The next read() will be from that
+     * location. Can't seek to the position past the end of the stream.
      *
      * @param desired the desired offset
      * @throws IOException Thrown if an error occurred while seeking inside the input stream.


### PR DESCRIPTION

## What is the purpose of the change

This pull request improves the java doc of the seek() method in the @public abstract class FSDataInputStream by fixing the sentence.


## Brief change log

  - *Replace "seek" with "seeks" based on the convention*
  - *Add "to the position" before "past the end of the stream" to improve the expression* 


## Verifying this change

This change is a trivial rework / java doc cleanup without any test coverage.

