### PR TITLE
[FLINK-24212][kerbernets] fix the problem that kerberos krb5.conf file is mounted as empty directory, not a expected file

### DIFF
--- a/flink-kubernetes/src/main/java/org/apache/flink/kubernetes/kubeclient/decorators/KerberosMountDecorator.java
+++ b/flink-kubernetes/src/main/java/org/apache/flink/kubernetes/kubeclient/decorators/KerberosMountDecorator.java
@@ -43,6 +43,7 @@ import java.util.ArrayList;
 import java.util.Base64;
 import java.util.List;
 
+import static org.apache.flink.kubernetes.utils.Constants.KERBEROS_KRB5CONF_FILE;
 import static org.apache.flink.util.Preconditions.checkNotNull;
 
 /** Mount the custom Kerberos Configuration and Credential to the JobManager(s)/TaskManagers. */
@@ -107,7 +108,7 @@ public class KerberosMountDecorator extends AbstractKubernetesStepDecorator {
                             .withItems(
                                     new KeyToPathBuilder()
                                             .withKey(krb5Conf.getName())
-                                            .withPath(krb5Conf.getName())
+                                            .withPath(KERBEROS_KRB5CONF_FILE)
                                             .build())
                             .endConfigMap()
                             .endVolume()
@@ -117,8 +118,11 @@ public class KerberosMountDecorator extends AbstractKubernetesStepDecorator {
                     containerBuilder
                             .addNewVolumeMount()
                             .withName(Constants.KERBEROS_KRB5CONF_VOLUME)
-                            .withMountPath(Constants.KERBEROS_KRB5CONF_MOUNT_DIR + "/krb5.conf")
-                            .withSubPath("krb5.conf")
+                            .withMountPath(
+                                    Constants.KERBEROS_KRB5CONF_MOUNT_DIR
+                                            + "/"
+                                            + KERBEROS_KRB5CONF_FILE)
+                            .withSubPath(KERBEROS_KRB5CONF_FILE)
                             .endVolumeMount();
         }
 

--- a/flink-kubernetes/src/main/java/org/apache/flink/kubernetes/utils/Constants.java
+++ b/flink-kubernetes/src/main/java/org/apache/flink/kubernetes/utils/Constants.java
@@ -45,6 +45,7 @@ public class Constants {
     public static final String KERBEROS_KRB5CONF_VOLUME = "kerberos-krb5conf-volume";
     public static final String KERBEROS_KRB5CONF_CONFIG_MAP_PREFIX = "kerberos-krb5conf-";
     public static final String KERBEROS_KRB5CONF_MOUNT_DIR = "/etc";
+    public static final String KERBEROS_KRB5CONF_FILE = "krb5.conf";
 
     public static final String FLINK_REST_SERVICE_SUFFIX = "-rest";
 

--- a/flink-kubernetes/src/test/java/org/apache/flink/kubernetes/kubeclient/decorators/KerberosMountDecoratorTest.java
+++ b/flink-kubernetes/src/test/java/org/apache/flink/kubernetes/kubeclient/decorators/KerberosMountDecoratorTest.java
@@ -19,16 +19,19 @@
 package org.apache.flink.kubernetes.kubeclient.decorators;
 
 import org.apache.flink.configuration.SecurityOptions;
+import org.apache.flink.kubernetes.KubernetesTestUtils;
 import org.apache.flink.kubernetes.kubeclient.FlinkPod;
 import org.apache.flink.kubernetes.kubeclient.KubernetesPodTestBase;
 import org.apache.flink.kubernetes.kubeclient.parameters.AbstractKubernetesParametersTest;
 import org.apache.flink.kubernetes.utils.Constants;
 
 import io.fabric8.kubernetes.api.model.Container;
+import io.fabric8.kubernetes.api.model.Volume;
 import io.fabric8.kubernetes.api.model.VolumeMount;
 import org.junit.Test;
 
 import java.io.IOException;
+import java.util.List;
 import java.util.stream.Collectors;
 
 import static org.junit.Assert.assertEquals;
@@ -43,6 +46,8 @@ public class KerberosMountDecoratorTest extends KubernetesPodTestBase {
     private AbstractKubernetesParametersTest.TestingKubernetesParameters
             testingKubernetesParameters;
 
+    private static final String MY_KRB5_CONF_FILE = "mykrb5.conf";
+
     @Override
     protected void setupFlinkConfig() {
         super.setupFlinkConfig();
@@ -51,7 +56,14 @@ public class KerberosMountDecoratorTest extends KubernetesPodTestBase {
                 SecurityOptions.KERBEROS_LOGIN_KEYTAB, kerberosDir.toString() + "/" + KEYTAB_FILE);
         flinkConfig.set(SecurityOptions.KERBEROS_LOGIN_PRINCIPAL, "test");
         flinkConfig.set(
-                SecurityOptions.KERBEROS_KRB5_PATH, kerberosDir.toString() + "/" + KRB5_CONF_FILE);
+                SecurityOptions.KERBEROS_KRB5_PATH,
+                kerberosDir.toString() + "/" + MY_KRB5_CONF_FILE);
+    }
+
+    @Override
+    protected void generateKerberosFileItems() throws IOException {
+        KubernetesTestUtils.createTemporyFile("some keytab", kerberosDir, KEYTAB_FILE);
+        KubernetesTestUtils.createTemporyFile("some conf", kerberosDir, MY_KRB5_CONF_FILE);
     }
 
     @Override
@@ -107,5 +119,37 @@ public class KerberosMountDecoratorTest extends KubernetesPodTestBase {
         assertEquals(
                 Constants.KERBEROS_KRB5CONF_MOUNT_DIR + "/krb5.conf",
                 krb5ConfVolumeMount.getMountPath());
+    }
+
+    @Test
+    public void testDecoratedFlinkPodVolumes() {
+        final FlinkPod resultFlinkPod = kerberosMountDecorator.decorateFlinkPod(baseFlinkPod);
+        List<Volume> volumes = resultFlinkPod.getPodWithoutMainContainer().getSpec().getVolumes();
+        assertEquals(2, volumes.size());
+
+        final Volume keytabVolume =
+                volumes.stream()
+                        .filter(x -> x.getName().equals(Constants.KERBEROS_KEYTAB_VOLUME))
+                        .collect(Collectors.toList())
+                        .get(0);
+        final Volume krb5ConfVolume =
+                volumes.stream()
+                        .filter(x -> x.getName().equals(Constants.KERBEROS_KRB5CONF_VOLUME))
+                        .collect(Collectors.toList())
+                        .get(0);
+        assertNotNull(keytabVolume.getSecret());
+        assertEquals(
+                KerberosMountDecorator.getKerberosKeytabSecretName(
+                        testingKubernetesParameters.getClusterId()),
+                keytabVolume.getSecret().getSecretName());
+
+        assertNotNull(krb5ConfVolume.getConfigMap());
+        assertEquals(
+                KerberosMountDecorator.getKerberosKrb5confConfigMapName(
+                        testingKubernetesParameters.getClusterId()),
+                krb5ConfVolume.getConfigMap().getName());
+        assertEquals(1, krb5ConfVolume.getConfigMap().getItems().size());
+        assertEquals(MY_KRB5_CONF_FILE, krb5ConfVolume.getConfigMap().getItems().get(0).getKey());
+        assertEquals(KRB5_CONF_FILE, krb5ConfVolume.getConfigMap().getItems().get(0).getPath());
     }
 }


### PR DESCRIPTION
## What is the purpose of the change

If the user-provided krb5 conf file is not named krb5.conf (e.g named mykrb5.conf)，the mount path /etc/krb5.conf in pod will be an empty directory, not a file that we expect.

## Brief change log

- KerberosMountDecorator#decorateFlinkPod

## Verifying this change

This change is a trivial rework / code cleanup without any test coverage.

## Does this pull request potentially affect one of the following parts:

  - Dependencies (does it add or upgrade a dependency):  no
  - The public API, i.e., is any changed class annotated with `@Public(Evolving)`: no
  - The serializers: no
  - The runtime per-record code paths (performance sensitive):  no
  - Anything that affects deployment or recovery: JobManager (and its components), Checkpointing, Kubernetes/Yarn, ZooKeeper: Kubernetes deployment
  - The S3 file system connector: no

## Documentation

  - Does this pull request introduce a new feature? no
  - If yes, how is the feature documented? not documented
