### PR TITLE
[FLINK-24161] Fix interplay of stop-with-savepoint w/o drain with final checkpoints

### DIFF
--- a/flink-streaming-java/src/test/java/org/apache/flink/streaming/runtime/tasks/StreamTaskFinalCheckpointsTest.java
+++ b/flink-streaming-java/src/test/java/org/apache/flink/streaming/runtime/tasks/StreamTaskFinalCheckpointsTest.java
@@ -599,8 +599,11 @@ public class StreamTaskFinalCheckpointsTest {
                     (e ->
                             e.getMessage()
                                     .equals(
-                                            "We run out of data to process while waiting for"
-                                                    + " a synchronous savepoint to be finished.")));
+                                            "We run out of data to process while waiting for a "
+                                                    + "synchronous savepoint to be finished. This "
+                                                    + "can lead to a deadlock waiting for a final "
+                                                    + "checkpoint after a synchronous savepoint, "
+                                                    + "which will never be triggered.")));
         }
     }
 

--- a/flink-streaming-java/src/test/java/org/apache/flink/streaming/runtime/tasks/StreamTaskFinalCheckpointsTest.java
+++ b/flink-streaming-java/src/test/java/org/apache/flink/streaming/runtime/tasks/StreamTaskFinalCheckpointsTest.java
@@ -23,6 +23,7 @@ import org.apache.flink.api.common.state.ListState;
 import org.apache.flink.api.common.state.ListStateDescriptor;
 import org.apache.flink.api.common.typeinfo.BasicTypeInfo;
 import org.apache.flink.api.common.typeutils.base.StringSerializer;
+import org.apache.flink.runtime.checkpoint.CheckpointException;
 import org.apache.flink.runtime.checkpoint.CheckpointMetaData;
 import org.apache.flink.runtime.checkpoint.CheckpointMetrics;
 import org.apache.flink.runtime.checkpoint.CheckpointMetricsBuilder;
@@ -61,6 +62,7 @@ import java.util.concurrent.Future;
 
 import static org.apache.flink.api.common.typeinfo.BasicTypeInfo.STRING_TYPE_INFO;
 import static org.apache.flink.runtime.state.CheckpointStorageLocationReference.getDefault;
+import static org.apache.flink.util.ExceptionUtils.assertThrowable;
 import static org.hamcrest.MatcherAssert.assertThat;
 import static org.hamcrest.Matchers.contains;
 import static org.junit.Assert.assertArrayEquals;
@@ -367,7 +369,7 @@ public class StreamTaskFinalCheckpointsTest {
 
                 // trigger the synchronous savepoint
                 CompletableFuture<Boolean> savepointFuture =
-                        triggerStopWithSavepoint(testHarness, syncSavepointId);
+                        triggerStopWithSavepointDrain(testHarness, syncSavepointId);
 
                 // The checkpoint 6 would be triggered successfully.
                 testHarness.finishProcessing();
@@ -466,7 +468,7 @@ public class StreamTaskFinalCheckpointsTest {
 
             // trigger the synchronous savepoint
             CompletableFuture<Boolean> savepointFuture =
-                    triggerStopWithSavepoint(testHarness, syncSavepointId);
+                    triggerStopWithSavepointDrain(testHarness, syncSavepointId);
 
             // The checkpoint 6 would be triggered successfully.
             testHarness.finishProcessing();
@@ -478,6 +480,127 @@ public class StreamTaskFinalCheckpointsTest {
             assertEquals(
                     syncSavepointId,
                     testHarness.getTaskStateManager().getNotifiedCompletedCheckpointId());
+        }
+    }
+
+    @Test
+    public void testTriggerStopWithSavepointNoDrainWhenWaitingForFinalCheckpointOnSourceTask()
+            throws Exception {
+        int finalCheckpointId = 6;
+        int syncSavepointId = 7;
+        CompletingCheckpointResponder checkpointResponder =
+                new CompletingCheckpointResponder() {
+
+                    private CheckpointMetrics metrics;
+                    private TaskStateSnapshot stateSnapshot;
+
+                    @Override
+                    public void acknowledgeCheckpoint(
+                            JobID jobID,
+                            ExecutionAttemptID executionAttemptID,
+                            long checkpointId,
+                            CheckpointMetrics checkpointMetrics,
+                            TaskStateSnapshot subtaskState) {
+                        // do not acknowledge any checkpoints straightaway
+                        if (checkpointId == finalCheckpointId) {
+                            metrics = checkpointMetrics;
+                            stateSnapshot = subtaskState;
+                        }
+                    }
+
+                    @Override
+                    public void declineCheckpoint(
+                            JobID jobID,
+                            ExecutionAttemptID executionAttemptID,
+                            long checkpointId,
+                            CheckpointException checkpointException) {
+                        // acknowledge the last pending checkpoint once the synchronous savepoint is
+                        // declined.
+                        if (syncSavepointId == checkpointId) {
+                            super.acknowledgeCheckpoint(
+                                    jobID,
+                                    executionAttemptID,
+                                    finalCheckpointId,
+                                    metrics,
+                                    stateSnapshot);
+                        }
+                    }
+                };
+
+        try (StreamTaskMailboxTestHarness<String> testHarness =
+                new StreamTaskMailboxTestHarnessBuilder<>(SourceStreamTask::new, STRING_TYPE_INFO)
+                        .modifyStreamConfig(
+                                config -> {
+                                    config.setCheckpointingEnabled(true);
+                                    config.getConfiguration()
+                                            .set(
+                                                    ExecutionCheckpointingOptions
+                                                            .ENABLE_CHECKPOINTS_AFTER_TASKS_FINISH,
+                                                    true);
+                                })
+                        .setCheckpointResponder(checkpointResponder)
+                        .setupOutputForSingletonOperatorChain(
+                                new StreamSource<>(new ImmediatelyFinishingSource()))
+                        .build()) {
+            checkpointResponder.setHandlers(
+                    testHarness.streamTask::notifyCheckpointCompleteAsync,
+                    testHarness.streamTask::notifyCheckpointAbortAsync);
+
+            // start task thread
+            testHarness.streamTask.runMailboxLoop();
+
+            // trigger the final checkpoint
+            CompletableFuture<Boolean> checkpointFuture =
+                    triggerCheckpoint(testHarness, finalCheckpointId);
+
+            // trigger the synchronous savepoint w/o drain, which should be declined
+            CompletableFuture<Boolean> savepointFuture =
+                    triggerStopWithSavepointNoDrain(testHarness, syncSavepointId);
+
+            // The checkpoint 6 would be triggered successfully.
+            testHarness.finishProcessing();
+            assertTrue(checkpointFuture.isDone());
+            assertTrue(savepointFuture.isDone());
+            assertFalse(savepointFuture.get());
+            testHarness.getTaskStateManager().getWaitForReportLatch().await();
+            assertEquals(
+                    finalCheckpointId, testHarness.getTaskStateManager().getReportedCheckpointId());
+            assertEquals(
+                    finalCheckpointId,
+                    testHarness.getTaskStateManager().getNotifiedCompletedCheckpointId());
+        }
+    }
+
+    @Test
+    public void testTriggerSourceFinishesWhileStoppingWithSavepointWithoutDrain() throws Exception {
+        try (StreamTaskMailboxTestHarness<String> testHarness =
+                new StreamTaskMailboxTestHarnessBuilder<>(SourceStreamTask::new, STRING_TYPE_INFO)
+                        .modifyStreamConfig(
+                                config -> {
+                                    config.setCheckpointingEnabled(true);
+                                    config.getConfiguration()
+                                            .set(
+                                                    ExecutionCheckpointingOptions
+                                                            .ENABLE_CHECKPOINTS_AFTER_TASKS_FINISH,
+                                                    true);
+                                })
+                        .setupOutputForSingletonOperatorChain(
+                                new StreamSource<>(new ImmediatelyFinishingSource()))
+                        .build()) {
+
+            // trigger the synchronous savepoint w/o drain
+            triggerStopWithSavepointNoDrain(testHarness, 1);
+
+            // start task thread
+            testHarness.streamTask.runMailboxLoop();
+        } catch (Exception ex) {
+            assertThrowable(
+                    ex,
+                    (e ->
+                            e.getMessage()
+                                    .equals(
+                                            "We run out of data to process while waiting for"
+                                                    + " a synchronous savepoint to be finished.")));
         }
     }
 
@@ -680,16 +803,29 @@ public class StreamTaskFinalCheckpointsTest {
                         checkpointOptions);
     }
 
-    static CompletableFuture<Boolean> triggerStopWithSavepoint(
+    static CompletableFuture<Boolean> triggerStopWithSavepointDrain(
             StreamTaskMailboxTestHarness<String> testHarness, long checkpointId) {
+        return triggerStopWithSavepoint(
+                testHarness, checkpointId, CheckpointType.SAVEPOINT_TERMINATE);
+    }
+
+    static CompletableFuture<Boolean> triggerStopWithSavepointNoDrain(
+            StreamTaskMailboxTestHarness<String> testHarness, long checkpointId) {
+        return triggerStopWithSavepoint(
+                testHarness, checkpointId, CheckpointType.SAVEPOINT_SUSPEND);
+    }
+
+    static CompletableFuture<Boolean> triggerStopWithSavepoint(
+            StreamTaskMailboxTestHarness<String> testHarness,
+            long checkpointId,
+            CheckpointType checkpointType) {
         testHarness.getTaskStateManager().getWaitForReportLatch().reset();
         return testHarness
                 .getStreamTask()
                 .triggerCheckpointAsync(
                         new CheckpointMetaData(checkpointId, checkpointId * 1000),
                         CheckpointOptions.alignedNoTimeout(
-                                CheckpointType.SAVEPOINT_TERMINATE,
-                                CheckpointStorageLocationReference.getDefault()));
+                                checkpointType, CheckpointStorageLocationReference.getDefault()));
     }
 
     static void processMailTillCheckpointSucceeds(


### PR DESCRIPTION
## What is the purpose of the change
* In endData() if there is an pending savepoint without drain, we fail the task by throw an exception.
* When triggering stop-with-savepoint without drain, if endOfDataReceived = true , we then return false to reject the savepoint.

Both of the above 2 cases cause a failover. 

## Verifying this change
Added tests in StreamTaskFinalCheckpointsTest

## Does this pull request potentially affect one of the following parts:

  - Dependencies (does it add or upgrade a dependency): (yes / **no**)
  - The public API, i.e., is any changed class annotated with `@Public(Evolving)`: (yes / **no**)
  - The serializers: (yes / **no** / don't know)
  - The runtime per-record code paths (performance sensitive): (yes / no / don't know)
  - Anything that affects deployment or recovery: JobManager (and its components), Checkpointing, Kubernetes/Yarn, ZooKeeper: (**yes** / no / don't know)
  - The S3 file system connector: (yes / **no** / don't know)

## Documentation

  - Does this pull request introduce a new feature? (yes / **no**)
  - If yes, how is the feature documented? (**not applicable** / docs / JavaDocs / not documented)
