### PR TITLE
[FLINK-23944][connector/pulsar] Enable PulsarSourceITCase.testTaskManagerFailure

### DIFF
--- a/flink-connectors/flink-connector-pulsar/src/test/java/org/apache/flink/connector/pulsar/source/PulsarSourceITCase.java
+++ b/flink-connectors/flink-connector-pulsar/src/test/java/org/apache/flink/connector/pulsar/source/PulsarSourceITCase.java
@@ -23,16 +23,11 @@ import org.apache.flink.connector.pulsar.testutils.PulsarTestEnvironment;
 import org.apache.flink.connector.pulsar.testutils.cases.MultipleTopicConsumingContext;
 import org.apache.flink.connector.pulsar.testutils.cases.SingleTopicConsumingContext;
 import org.apache.flink.connector.pulsar.testutils.runtime.PulsarRuntime;
-import org.apache.flink.connectors.test.common.environment.ClusterControllable;
 import org.apache.flink.connectors.test.common.environment.MiniClusterTestEnvironment;
-import org.apache.flink.connectors.test.common.environment.TestEnvironment;
-import org.apache.flink.connectors.test.common.external.ExternalContext;
 import org.apache.flink.connectors.test.common.junit.annotations.ExternalContextFactory;
 import org.apache.flink.connectors.test.common.junit.annotations.ExternalSystem;
 import org.apache.flink.connectors.test.common.junit.annotations.TestEnv;
 import org.apache.flink.connectors.test.common.testsuites.SourceTestSuiteBase;
-
-import org.junit.jupiter.api.Disabled;
 
 /** Unite test class for {@link PulsarSource}. */
 @SuppressWarnings("unused")
@@ -53,14 +48,4 @@ class PulsarSourceITCase extends SourceTestSuiteBase<String> {
     @ExternalContextFactory
     PulsarTestContextFactory<String, MultipleTopicConsumingContext> multipleTopic =
             new PulsarTestContextFactory<>(pulsar, MultipleTopicConsumingContext::new);
-
-    @Disabled
-    @Override
-    public void testTaskManagerFailure(
-            TestEnvironment testEnv,
-            ExternalContext<String> externalContext,
-            ClusterControllable controller)
-            throws Exception {
-        super.testTaskManagerFailure(testEnv, externalContext, controller);
-    }
 }


### PR DESCRIPTION
## What is the purpose of the change

This pull request enables the test method `testTaskManagerFailure` on `PulsarSourceITCase`.

## Brief change log

  - Enable `PulsarSourceITCase.testTaskManagerFailure`

## Verifying this change

This change is a trivial rework / code cleanup without any test coverage.

## Does this pull request potentially affect one of the following parts:

  - Dependencies (does it add or upgrade a dependency): (no)
  - The public API, i.e., is any changed class annotated with `@Public(Evolving)`: (no)
  - The serializers: (no)
  - The runtime per-record code paths (performance sensitive): (no)
  - Anything that affects deployment or recovery: JobManager (and its components), Checkpointing, Kubernetes/Yarn, ZooKeeper: (no)
  - The S3 file system connector: (no)

## Documentation

  - Does this pull request introduce a new feature? (no)
  - If yes, how is the feature documented? (not applicable)
