### PR TITLE
[BP-1.14][FLINK-22889][tests] Increase timeouts in JdbcExactlyOnceSinkE2eTest

### DIFF
--- a/flink-connectors/flink-connector-jdbc/src/test/java/org/apache/flink/connector/jdbc/xa/JdbcExactlyOnceSinkE2eTest.java
+++ b/flink-connectors/flink-connector-jdbc/src/test/java/org/apache/flink/connector/jdbc/xa/JdbcExactlyOnceSinkE2eTest.java
@@ -98,8 +98,8 @@ public class JdbcExactlyOnceSinkE2eTest extends JdbcTestBase {
 
     private static final Logger LOG = LoggerFactory.getLogger(JdbcExactlyOnceSinkE2eTest.class);
 
-    private static final long CHECKPOINT_TIMEOUT_MS = 2000L;
-    private static final long TASK_CANCELLATION_TIMEOUT_MS = 2000L;
+    private static final long CHECKPOINT_TIMEOUT_MS = 20_000L;
+    private static final long TASK_CANCELLATION_TIMEOUT_MS = 20_000L;
 
     // todo: remove after fixing FLINK-22889
     @ClassRule


### PR DESCRIPTION
Backport of #17167 to 1.14