### PR TITLE
[FLINK-22944][state] Optimize writing state changelog

### DIFF
--- a/flink-state-backends/flink-statebackend-changelog/src/main/java/org/apache/flink/state/changelog/ChangelogKeyedStateBackend.java
+++ b/flink-state-backends/flink-statebackend-changelog/src/main/java/org/apache/flink/state/changelog/ChangelogKeyedStateBackend.java
@@ -60,6 +60,8 @@ import org.apache.flink.runtime.state.ttl.TtlTimeProvider;
 import org.apache.flink.state.changelog.restore.FunctionDelegationHelper;
 import org.apache.flink.util.FlinkRuntimeException;
 
+import org.apache.flink.shaded.guava30.com.google.common.io.Closer;
+
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
@@ -140,6 +142,7 @@ public class ChangelogKeyedStateBackend<K>
     private final TtlTimeProvider ttlTimeProvider;
 
     private final StateChangelogWriter<ChangelogStateHandle> stateChangelogWriter;
+    private final Closer closer = Closer.create();
 
     private long lastCheckpointId = -1L;
 
@@ -216,6 +219,7 @@ public class ChangelogKeyedStateBackend<K>
         this.mainMailboxExecutor = checkNotNull(mainMailboxExecutor);
         this.asyncOperationsThreadPool = checkNotNull(asyncOperationsThreadPool);
         this.completeRestore(initialState);
+        this.closer.register(keyedStateBackend);
     }
 
     // -------------------- CheckpointableKeyedStateBackend --------------------------------
@@ -226,7 +230,7 @@ public class ChangelogKeyedStateBackend<K>
 
     @Override
     public void close() throws IOException {
-        keyedStateBackend.close();
+        closer.close();
     }
 
     @Override
@@ -388,6 +392,7 @@ public class ChangelogKeyedStateBackend<K>
                             new RegisteredPriorityQueueStateBackendMetaInfo<>(
                                     stateName, byteOrderedElementSerializer),
                             ++lastCreatedStateId);
+            closer.register(priorityQueueStateChangeLogger);
             queue =
                     new ChangelogKeyGroupedPriorityQueue<>(
                             keyedStateBackend.create(stateName, byteOrderedElementSerializer),
@@ -516,6 +521,7 @@ public class ChangelogKeyedStateBackend<K>
                         stateDesc.getTtlConfig(),
                         stateDesc.getDefaultValue(),
                         ++lastCreatedStateId);
+        closer.register(kvStateChangeLogger);
         IS is =
                 stateFactory.create(
                         state,

--- a/flink-state-backends/flink-statebackend-changelog/src/main/java/org/apache/flink/state/changelog/ChangelogKeyedStateBackend.java
+++ b/flink-state-backends/flink-statebackend-changelog/src/main/java/org/apache/flink/state/changelog/ChangelogKeyedStateBackend.java
@@ -190,6 +190,13 @@ public class ChangelogKeyedStateBackend<K>
 
     private final ExecutorService asyncOperationsThreadPool;
 
+    /**
+     * Provides a unique ID for each state created by this backend instance. A mapping from this ID
+     * to state name is written once along with metadata; afterwards, only ID is written with each
+     * state change for efficiency.
+     */
+    private short lastCreatedStateId = -1;
+
     public ChangelogKeyedStateBackend(
             AbstractKeyedStateBackend<K> keyedStateBackend,
             ExecutionConfig executionConfig,
@@ -379,7 +386,8 @@ public class ChangelogKeyedStateBackend<K>
                             keyedStateBackend.getKeyContext(),
                             stateChangelogWriter,
                             new RegisteredPriorityQueueStateBackendMetaInfo<>(
-                                    stateName, byteOrderedElementSerializer));
+                                    stateName, byteOrderedElementSerializer),
+                            ++lastCreatedStateId);
             queue =
                     new ChangelogKeyGroupedPriorityQueue<>(
                             keyedStateBackend.create(stateName, byteOrderedElementSerializer),
@@ -506,7 +514,8 @@ public class ChangelogKeyedStateBackend<K>
                         stateChangelogWriter,
                         meta,
                         stateDesc.getTtlConfig(),
-                        stateDesc.getDefaultValue());
+                        stateDesc.getDefaultValue(),
+                        ++lastCreatedStateId);
         IS is =
                 stateFactory.create(
                         state,

--- a/flink-state-backends/flink-statebackend-changelog/src/main/java/org/apache/flink/state/changelog/KvStateChangeLoggerImpl.java
+++ b/flink-state-backends/flink-statebackend-changelog/src/main/java/org/apache/flink/state/changelog/KvStateChangeLoggerImpl.java
@@ -52,8 +52,9 @@ class KvStateChangeLoggerImpl<Key, Value, Ns> extends AbstractStateChangeLogger<
             StateChangelogWriter<?> stateChangelogWriter,
             RegisteredStateMetaInfoBase metaInfo,
             StateTtlConfig ttlConfig,
-            @Nullable Value defaultValue) {
-        super(stateChangelogWriter, keyContext, metaInfo);
+            @Nullable Value defaultValue,
+            short stateId) {
+        super(stateChangelogWriter, keyContext, metaInfo, stateId);
         this.keySerializer = checkNotNull(keySerializer);
         this.valueSerializer = checkNotNull(valueSerializer);
         this.namespaceSerializer = checkNotNull(namespaceSerializer);

--- a/flink-state-backends/flink-statebackend-changelog/src/main/java/org/apache/flink/state/changelog/PriorityQueueStateChangeLoggerImpl.java
+++ b/flink-state-backends/flink-statebackend-changelog/src/main/java/org/apache/flink/state/changelog/PriorityQueueStateChangeLoggerImpl.java
@@ -35,8 +35,9 @@ class PriorityQueueStateChangeLoggerImpl<K, T> extends AbstractStateChangeLogger
             TypeSerializer<T> serializer,
             InternalKeyContext<K> keyContext,
             StateChangelogWriter<?> stateChangelogWriter,
-            RegisteredPriorityQueueStateBackendMetaInfo<T> meta) {
-        super(stateChangelogWriter, keyContext, meta);
+            RegisteredPriorityQueueStateBackendMetaInfo<T> meta,
+            short stateId) {
+        super(stateChangelogWriter, keyContext, meta, stateId);
         this.serializer = checkNotNull(serializer);
     }
 

--- a/flink-state-backends/flink-statebackend-changelog/src/main/java/org/apache/flink/state/changelog/StateChangeLogger.java
+++ b/flink-state-backends/flink-statebackend-changelog/src/main/java/org/apache/flink/state/changelog/StateChangeLogger.java
@@ -21,6 +21,7 @@ import org.apache.flink.api.common.state.ListState;
 import org.apache.flink.core.memory.DataOutputViewStreamWrapper;
 import org.apache.flink.util.function.ThrowingConsumer;
 
+import java.io.Closeable;
 import java.io.IOException;
 
 /**
@@ -41,7 +42,7 @@ import java.io.IOException;
  * @param <Value> type of state (value)
  * @param <Namespace> type of namespace
  */
-interface StateChangeLogger<Value, Namespace> {
+interface StateChangeLogger<Value, Namespace> extends Closeable {
 
     /** State updated, such as by {@link ListState#update}. */
     void valueUpdated(Value newValue, Namespace ns) throws IOException;

--- a/flink-state-backends/flink-statebackend-changelog/src/main/java/org/apache/flink/state/changelog/restore/ChangelogBackendRestoreOperation.java
+++ b/flink-state-backends/flink-statebackend-changelog/src/main/java/org/apache/flink/state/changelog/restore/ChangelogBackendRestoreOperation.java
@@ -31,6 +31,8 @@ import org.apache.flink.util.function.BiFunctionWithException;
 import org.apache.flink.util.function.FunctionWithException;
 
 import java.util.Collection;
+import java.util.HashMap;
+import java.util.Map;
 import java.util.Objects;
 import java.util.stream.Collectors;
 
@@ -82,12 +84,14 @@ public class ChangelogBackendRestoreOperation {
             StateChangelogHandleReader<T> changelogHandleReader,
             ClassLoader classLoader)
             throws Exception {
+        Map<Short, StateID> stateIds = new HashMap<>();
         for (ChangelogStateHandle changelogHandle :
                 backendHandle.getNonMaterializedStateHandles()) {
             try (CloseableIterator<StateChange> changes =
                     changelogHandleReader.getChanges((T) changelogHandle)) {
                 while (changes.hasNext()) {
-                    ChangelogBackendLogApplier.apply(changes.next(), backend, classLoader);
+                    ChangelogBackendLogApplier.apply(
+                            changes.next(), backend, classLoader, stateIds);
                 }
             }
         }

--- a/flink-state-backends/flink-statebackend-changelog/src/main/java/org/apache/flink/state/changelog/restore/StateID.java
+++ b/flink-state-backends/flink-statebackend-changelog/src/main/java/org/apache/flink/state/changelog/restore/StateID.java
@@ -1,0 +1,31 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.flink.state.changelog.restore;
+
+import org.apache.flink.runtime.state.metainfo.StateMetaInfoSnapshot;
+
+/** Identifies a state during recovery. */
+final class StateID {
+    final StateMetaInfoSnapshot.BackendStateType stateType;
+    final String stateName;
+
+    StateID(String stateName, StateMetaInfoSnapshot.BackendStateType stateType) {
+        this.stateType = stateType;
+        this.stateName = stateName;
+    }
+}

--- a/flink-state-backends/flink-statebackend-changelog/src/test/java/org/apache/flink/state/changelog/ChangelogPqStateTest.java
+++ b/flink-state-backends/flink-statebackend-changelog/src/test/java/org/apache/flink/state/changelog/ChangelogPqStateTest.java
@@ -169,6 +169,9 @@ public class ChangelogPqStateTest {
         public boolean anythingChanged() {
             return stateElementChanged || stateElementRemoved || stateCleared;
         }
+
+        @Override
+        public void close() {}
     }
 
     private static class TestingInternalQueueState

--- a/flink-state-backends/flink-statebackend-changelog/src/test/java/org/apache/flink/state/changelog/KvStateChangeLoggerImplTest.java
+++ b/flink-state-backends/flink-statebackend-changelog/src/test/java/org/apache/flink/state/changelog/KvStateChangeLoggerImplTest.java
@@ -50,7 +50,8 @@ public class KvStateChangeLoggerImplTest extends StateChangeLoggerTestBase<Strin
                 writer,
                 metaInfo,
                 StateTtlConfig.DISABLED,
-                "default");
+                "default",
+                Short.MIN_VALUE);
     }
 
     @Override

--- a/flink-state-backends/flink-statebackend-changelog/src/test/java/org/apache/flink/state/changelog/PriorityQueueStateChangeLoggerImplTest.java
+++ b/flink-state-backends/flink-statebackend-changelog/src/test/java/org/apache/flink/state/changelog/PriorityQueueStateChangeLoggerImplTest.java
@@ -37,7 +37,7 @@ public class PriorityQueueStateChangeLoggerImplTest extends StateChangeLoggerTes
         RegisteredPriorityQueueStateBackendMetaInfo<String> metaInfo =
                 new RegisteredPriorityQueueStateBackendMetaInfo<>("test", valueSerializer);
         return new PriorityQueueStateChangeLoggerImpl<>(
-                valueSerializer, keyContext, writer, metaInfo);
+                valueSerializer, keyContext, writer, metaInfo, Short.MIN_VALUE);
     }
 
     @Override

--- a/flink-state-backends/flink-statebackend-changelog/src/test/java/org/apache/flink/state/changelog/StateChangeLoggerTestBase.java
+++ b/flink-state-backends/flink-statebackend-changelog/src/test/java/org/apache/flink/state/changelog/StateChangeLoggerTestBase.java
@@ -42,19 +42,21 @@ abstract class StateChangeLoggerTestBase<Namespace> {
         TestingStateChangelogWriter writer = new TestingStateChangelogWriter();
         InternalKeyContextImpl<String> keyContext =
                 new InternalKeyContextImpl<>(KeyGroupRange.of(1, 1000), 1000);
-        StateChangeLogger<String, Namespace> logger = getLogger(writer, keyContext);
 
-        List<Tuple2<Integer, StateChangeOperation>> expectedAppends = new ArrayList<>();
-        expectedAppends.add(Tuple2.of(COMMON_KEY_GROUP, METADATA));
+        try (StateChangeLogger<String, Namespace> logger = getLogger(writer, keyContext)) {
+            List<Tuple2<Integer, StateChangeOperation>> expectedAppends = new ArrayList<>();
+            expectedAppends.add(Tuple2.of(COMMON_KEY_GROUP, METADATA));
 
-        // log every applicable operations, several times each
-        int numOpTypes = StateChangeOperation.values().length;
-        for (int i = 0; i < numOpTypes * 7; i++) {
-            String element = Integer.toString(i);
-            StateChangeOperation operation = StateChangeOperation.byCode((byte) (i % numOpTypes));
-            log(operation, element, logger, keyContext).ifPresent(expectedAppends::add);
+            // log every applicable operations, several times each
+            int numOpTypes = StateChangeOperation.values().length;
+            for (int i = 0; i < numOpTypes * 7; i++) {
+                String element = Integer.toString(i);
+                StateChangeOperation operation =
+                        StateChangeOperation.byCode((byte) (i % numOpTypes));
+                log(operation, element, logger, keyContext).ifPresent(expectedAppends::add);
+            }
+            assertEquals(expectedAppends, writer.appends);
         }
-        assertEquals(expectedAppends, writer.appends);
     }
 
     protected abstract StateChangeLogger<String, Namespace> getLogger(

--- a/flink-state-backends/flink-statebackend-changelog/src/test/java/org/apache/flink/state/changelog/TestChangeLoggerKv.java
+++ b/flink-state-backends/flink-statebackend-changelog/src/test/java/org/apache/flink/state/changelog/TestChangeLoggerKv.java
@@ -131,4 +131,7 @@ class TestChangeLoggerKv<State> implements KvStateChangeLogger<State, String> {
                 || stateElementRemoved
                 || stateMerged;
     }
+
+    @Override
+    public void close() {}
 }


### PR DESCRIPTION
## What is the purpose of the change

This PR optimizes writing of state changes in `ChangelogKeyedStateBackend`.
Currently, state name and type are written with every change.
With this change, only a short ID of state is written every time; the mapping from this ID to name and type is written before the first write.

The change is split into three commits to ease reviewing. They could be squashed together upon merging.

An alternative approach would be to sort changes in each write batch and write common part once.
That would minimize writing of keys and namespaces.
However, it has some drawbacks:
 - writing again in every batch
 - more complex writer interface - it must be aware of ns/keys as well as serializers (they differ per call because different state of of the same backend have different serializers)
 - more complex format and read/write logic
 - harder to re-use writer for non-backend purposes
 - harder to re-use sorting code in other writer implementations

Because of the above drawbacks the mapping approach was chosen.

## Verifying this change

Correctness is covered by the existing changelog backend tests.
Optimization is not covered.

## Does this pull request potentially affect one of the following parts:

  - Dependencies (does it add or upgrade a dependency): no
  - The public API, i.e., is any changed class annotated with `@Public(Evolving)`: no
  - The serializers: no
  - The runtime per-record code paths (performance sensitive): no
  - Anything that affects deployment or recovery: JobManager (and its components), Checkpointing, Kubernetes/Yarn/Mesos, ZooKeeper: no
  - The S3 file system connector: no

## Documentation

  - Does this pull request introduce a new feature? no
  - If yes, how is the feature documented? no
