### PR TITLE
[FLINK-24168][table-planner] Update MATCH_ROWTIME function which could receive 0 argument or 1 argument

### DIFF
--- a/docs/content.zh/docs/dev/table/sql/queries/match_recognize.md
+++ b/docs/content.zh/docs/dev/table/sql/queries/match_recognize.md
@@ -930,11 +930,12 @@ FROM Ticker
   <tbody>
     <tr>
       <td>
-        <code>MATCH_ROWTIME()</code><br/>
+        <code>MATCH_ROWTIME([rowtime_field])</code><br/>
       </td>
       <td>
         <p>返回映射到给定模式的最后一行的时间戳。</p>
-        <p>结果属性是<a href="{{< ref "docs/dev/table/concepts/time_attributes" >}}">行时间属性</a>，可用于后续基于时间的操作，例如 <a href="{{< ref "docs/dev/table/sql/queries/joins" >}}#interval-joins">interval joins</a> 和 <a href="#aggregations">group window or over window aggregations</a>。</p>
+        <p>函数可以没有入参，这种情况下函数返回结果是 TIMESTAMP 类型且具有事件时间属性；也可以有一个入参，这个参数值必须是 TIMESTAMP 类型或者 TIMESTAMP_LTZ 类型，且必须有事件时间属性，这种情况下函数返回结果的数据类型和输入参数的一致，且必须有事件时间属性。</p>
+        <p>结果属性是<a href="{{< ref "docs/dev/table/concepts/time_attributes" >}}">事件时间属性</a>，可用于后续基于时间的操作，例如 <a href="{{< ref "docs/dev/table/sql/queries/joins" >}}#interval-joins">interval joins</a> 和 <a href="#aggregations">group window or over window aggregations</a>。</p>
       </td>
     </tr>
     <tr>

--- a/docs/content/docs/dev/table/sql/queries/match_recognize.md
+++ b/docs/content/docs/dev/table/sql/queries/match_recognize.md
@@ -1039,9 +1039,10 @@ use [time attributes]({{< ref "docs/dev/table/concepts/time_attributes" >}}). To
   <tbody>
     <tr>
       <td>
-        <code>MATCH_ROWTIME()</code><br/>
+        <code>MATCH_ROWTIME([rowtime_field])</code><br/>
       </td>
       <td><p>Returns the timestamp of the last row that was mapped to the given pattern.</p>
+      <p>The function accepts zero or one operand which is a field reference with rowtime attribute. If there is no operand, the function will return rowtime attribute with TIMESTAMP type. Otherwise, the return type will be same with the operand type.</p>
       <p>The resulting attribute is a <a href="{{< ref "docs/dev/table/concepts/time_attributes" >}}">rowtime attribute</a>
          that can be used in subsequent time-based operations such as
          <a href="{{< ref "docs/dev/table/sql/queries/joins" >}}#interval-joins">interval joins</a> and <a href="#aggregations">group window or over

--- a/flink-table/flink-table-planner/src/main/java/org/apache/flink/table/planner/calcite/RelTimeIndicatorConverter.java
+++ b/flink-table/flink-table-planner/src/main/java/org/apache/flink/table/planner/calcite/RelTimeIndicatorConverter.java
@@ -21,15 +21,7 @@ package org.apache.flink.table.planner.calcite;
 import org.apache.flink.api.java.tuple.Tuple2;
 import org.apache.flink.table.api.TableException;
 import org.apache.flink.table.api.ValidationException;
-import org.apache.flink.table.expressions.FieldReferenceExpression;
-import org.apache.flink.table.planner.expressions.PlannerNamedWindowProperty;
-import org.apache.flink.table.planner.expressions.PlannerRowtimeAttribute;
-import org.apache.flink.table.planner.expressions.PlannerWindowReference;
 import org.apache.flink.table.planner.functions.sql.FlinkSqlOperatorTable;
-import org.apache.flink.table.planner.plan.logical.LogicalWindow;
-import org.apache.flink.table.planner.plan.logical.SessionGroupWindow;
-import org.apache.flink.table.planner.plan.logical.SlidingGroupWindow;
-import org.apache.flink.table.planner.plan.logical.TumblingGroupWindow;
 import org.apache.flink.table.planner.plan.metadata.FlinkRelMetadataQuery;
 import org.apache.flink.table.planner.plan.nodes.logical.FlinkLogicalAggregate;
 import org.apache.flink.table.planner.plan.nodes.logical.FlinkLogicalCalc;
@@ -59,9 +51,7 @@ import org.apache.flink.table.planner.plan.utils.JoinUtil;
 import org.apache.flink.table.planner.plan.utils.TemporalJoinUtil;
 import org.apache.flink.table.types.logical.LocalZonedTimestampType;
 import org.apache.flink.table.types.logical.LogicalType;
-import org.apache.flink.table.types.logical.TimestampKind;
 import org.apache.flink.table.types.logical.TimestampType;
-import org.apache.flink.table.types.logical.utils.LogicalTypeChecks;
 import org.apache.flink.util.Preconditions;
 
 import org.apache.calcite.plan.RelOptUtil;
@@ -103,16 +93,11 @@ import java.util.function.Predicate;
 import java.util.stream.Collectors;
 import java.util.stream.IntStream;
 
-import scala.collection.JavaConverters;
-import scala.collection.Seq;
-
 import static org.apache.flink.table.planner.calcite.FlinkTypeFactory.isProctimeIndicatorType;
 import static org.apache.flink.table.planner.calcite.FlinkTypeFactory.isRowtimeIndicatorType;
 import static org.apache.flink.table.planner.calcite.FlinkTypeFactory.isTimeIndicatorType;
-import static org.apache.flink.table.planner.plan.utils.MatchUtil.isFinalOnRowTimeIndicator;
-import static org.apache.flink.table.planner.plan.utils.MatchUtil.isMatchRowTimeIndicator;
+import static org.apache.flink.table.planner.plan.utils.MatchUtil.isFinalOnMatchTimeIndicator;
 import static org.apache.flink.table.planner.plan.utils.WindowUtil.groupingContainsWindowStartEnd;
-import static org.apache.flink.table.runtime.types.LogicalTypeDataTypeConverter.fromLogicalTypeToDataType;
 
 /**
  * Traverses a {@link RelNode} tree and converts fields with {@link TimeIndicatorRelDataType} type.
@@ -225,15 +210,9 @@ public final class RelTimeIndicatorConverter extends RelHomogeneousShuttle {
                     }
                 };
 
-        // decide the MATCH_ROWTIME() return type is TIMESTAMP or TIMESTAMP_LTZ, if it is
-        // TIMESTAMP_LTZ, we need to materialize the output type of LogicalMatch node to
-        // TIMESTAMP_LTZ too.
-        boolean isTimestampLtz =
-                newMeasures.values().stream().anyMatch(node -> isTimestampLtzType(node.getType()));
         // materialize all output types
         RelDataType newOutputType =
-                getRowTypeWithoutTimeIndicator(
-                        match.getRowType(), isTimestampLtz, isNoLongerTimeIndicator);
+                getRowTypeWithoutTimeIndicator(match.getRowType(), isNoLongerTimeIndicator);
         return new FlinkLogicalMatch(
                 match.getCluster(),
                 match.getTraitSet(),
@@ -481,8 +460,7 @@ public final class RelTimeIndicatorConverter extends RelHomogeneousShuttle {
                 .collect(Collectors.toList());
     }
 
-    private RelNode visitTableAggregate(FlinkLogicalTableAggregate node) {
-        FlinkLogicalTableAggregate tableAgg = node;
+    private RelNode visitTableAggregate(FlinkLogicalTableAggregate tableAgg) {
         FlinkLogicalAggregate correspondingAgg =
                 FlinkLogicalAggregate.create(
                         tableAgg.getInput(),
@@ -502,92 +480,17 @@ public final class RelTimeIndicatorConverter extends RelHomogeneousShuttle {
     private FlinkLogicalWindowAggregate visitWindowAggregate(FlinkLogicalWindowAggregate agg) {
         RelNode newInput = convertAggInput(agg);
         List<AggregateCall> updatedAggCalls = convertAggregateCalls(agg);
-        LogicalWindow oldWindow = agg.getWindow();
-        Seq<PlannerNamedWindowProperty> oldNamedProperties = agg.getNamedProperties();
-        FieldReferenceExpression oldTimeAttribute = agg.getWindow().timeAttribute();
-        LogicalType oldTimeAttributeType = oldTimeAttribute.getOutputDataType().getLogicalType();
-        boolean isRowtimeIndicator = LogicalTypeChecks.isRowtimeAttribute(oldTimeAttributeType);
-        boolean convertedToRowtimeTimestampLtz;
-        if (!isRowtimeIndicator) {
-            convertedToRowtimeTimestampLtz = false;
-        } else {
-            int timeIndicatorIdx = oldTimeAttribute.getFieldIndex();
-            RelDataType oldType =
-                    agg.getInput().getRowType().getFieldList().get(timeIndicatorIdx).getType();
-            RelDataType newType =
-                    newInput.getRowType().getFieldList().get(timeIndicatorIdx).getType();
-            convertedToRowtimeTimestampLtz =
-                    isTimestampLtzType(newType) && !isTimestampLtzType(oldType);
-        }
-        LogicalWindow newWindow;
-        Seq<PlannerNamedWindowProperty> newNamedProperties;
-        if (convertedToRowtimeTimestampLtz) {
-            // MATCH_ROWTIME may be converted from rowtime attribute to timestamp_ltz rowtime
-            // attribute, if time indicator of current window aggregate depends on input
-            // MATCH_ROWTIME, we should rewrite logicalWindow and namedProperties.
-            LogicalType newTimestampLtzType =
-                    new LocalZonedTimestampType(
-                            oldTimeAttributeType.isNullable(), TimestampKind.ROWTIME, 3);
-            FieldReferenceExpression newFieldRef =
-                    new FieldReferenceExpression(
-                            oldTimeAttribute.getName(),
-                            fromLogicalTypeToDataType(newTimestampLtzType),
-                            oldTimeAttribute.getInputIndex(),
-                            oldTimeAttribute.getFieldIndex());
-            PlannerWindowReference newAlias =
-                    new PlannerWindowReference(
-                            oldWindow.aliasAttribute().getName(), newTimestampLtzType);
-            if (oldWindow instanceof TumblingGroupWindow) {
-                TumblingGroupWindow window = (TumblingGroupWindow) oldWindow;
-                newWindow = new TumblingGroupWindow(newAlias, newFieldRef, window.size());
-            } else if (oldWindow instanceof SlidingGroupWindow) {
-                SlidingGroupWindow window = (SlidingGroupWindow) oldWindow;
-                newWindow =
-                        new SlidingGroupWindow(
-                                newAlias, newFieldRef, window.size(), window.slide());
-            } else if (oldWindow instanceof SessionGroupWindow) {
-                SessionGroupWindow window = (SessionGroupWindow) oldWindow;
-                newWindow = new SessionGroupWindow(newAlias, newFieldRef, window.gap());
-            } else {
-                throw new TableException(
-                        String.format(
-                                "This is a bug and should not happen. Please file an issue. Invalid window %s.",
-                                oldWindow.getClass().getSimpleName()));
-            }
-            List<PlannerNamedWindowProperty> newNamedPropertiesList =
-                    JavaConverters.seqAsJavaListConverter(oldNamedProperties).asJava().stream()
-                            .map(
-                                    namedProperty -> {
-                                        if (namedProperty.getProperty()
-                                                instanceof PlannerRowtimeAttribute) {
-                                            return new PlannerNamedWindowProperty(
-                                                    namedProperty.getName(),
-                                                    new PlannerRowtimeAttribute(newAlias));
-                                        } else {
-                                            return namedProperty;
-                                        }
-                                    })
-                            .collect(Collectors.toList());
-            newNamedProperties =
-                    JavaConverters.iterableAsScalaIterableConverter(newNamedPropertiesList)
-                            .asScala()
-                            .toSeq();
-        } else {
-            newWindow = oldWindow;
-            newNamedProperties = oldNamedProperties;
-        }
         return new FlinkLogicalWindowAggregate(
                 agg.getCluster(),
                 agg.getTraitSet(),
                 newInput,
                 agg.getGroupSet(),
                 updatedAggCalls,
-                newWindow,
-                newNamedProperties);
+                agg.getWindow(),
+                agg.getNamedProperties());
     }
 
-    private RelNode visitWindowTableAggregate(FlinkLogicalWindowTableAggregate node) {
-        FlinkLogicalWindowTableAggregate tableAgg = node;
+    private RelNode visitWindowTableAggregate(FlinkLogicalWindowTableAggregate tableAgg) {
         FlinkLogicalWindowAggregate correspondingAgg =
                 new FlinkLogicalWindowAggregate(
                         tableAgg.getCluster(),
@@ -716,11 +619,7 @@ public final class RelTimeIndicatorConverter extends RelHomogeneousShuttle {
         if (isTimeIndicatorType(l) && isTimeIndicatorType(r)) {
             boolean leftIsEventTime = ((TimeIndicatorRelDataType) l).isEventTime();
             boolean rightIsEventTime = ((TimeIndicatorRelDataType) r).isEventTime();
-            if (leftIsEventTime && rightIsEventTime) {
-                isValid = isTimestampLtzType(l) == isTimestampLtzType(r);
-            } else {
-                isValid = leftIsEventTime == rightIsEventTime;
-            }
+            isValid = leftIsEventTime == rightIsEventTime;
         } else {
             isValid = !isTimeIndicatorType(l) && !isTimeIndicatorType(r);
         }
@@ -733,28 +632,18 @@ public final class RelTimeIndicatorConverter extends RelHomogeneousShuttle {
     }
 
     private RelDataType getRowTypeWithoutTimeIndicator(
-            RelDataType relType, boolean isTimestampLtzType, Predicate<String> shouldMaterialize) {
+            RelDataType relType, Predicate<String> shouldMaterialize) {
         Map<String, RelDataType> convertedFields =
                 relType.getFieldList().stream()
                         .map(
                                 field -> {
                                     RelDataType fieldType = field.getType();
-                                    if (isTimeIndicatorType(fieldType)) {
-                                        if (isTimestampLtzType) {
-                                            fieldType =
-                                                    ((FlinkTypeFactory) rexBuilder.getTypeFactory())
-                                                            .createFieldTypeFromLogicalType(
-                                                                    new LocalZonedTimestampType(
-                                                                            fieldType.isNullable(),
-                                                                            TimestampKind.ROWTIME,
-                                                                            3));
-                                        }
-                                        if (shouldMaterialize.test(field.getName())) {
-                                            fieldType =
-                                                    timestamp(
-                                                            fieldType.isNullable(),
-                                                            isTimestampLtzType(fieldType));
-                                        }
+                                    if (isTimeIndicatorType(fieldType)
+                                            && shouldMaterialize.test(field.getName())) {
+                                        fieldType =
+                                                timestamp(
+                                                        fieldType.isNullable(),
+                                                        isTimestampLtzType(fieldType));
                                     }
                                     return Tuple2.of(field.getName(), fieldType);
                                 })
@@ -830,30 +719,11 @@ public final class RelTimeIndicatorConverter extends RelHomogeneousShuttle {
                                 .collect(Collectors.toList());
             }
 
-            if (isFinalOnRowTimeIndicator(call)) {
-                // All calls in MEASURES and DEFINE are wrapped with FINAL/RUNNING, therefore
-                // we should treat FINAL(MATCH_ROWTIME) and FINAL(MATCH_PROCTIME) as a time
-                // attribute extraction.
-                // The type of FINAL(MATCH_ROWTIME) is inferred by first operand's type,
-                // the initial type of MATCH_ROWTIME is TIMESTAMP(3) *ROWTIME*, it may be rewrote.
-                RelDataType rowTimeType = updatedCall.getOperands().get(0).getType();
-                return rexBuilder.makeCall(
-                        rowTimeType, updatedCall.getOperator(), updatedCall.getOperands());
-            } else if (isMatchRowTimeIndicator(updatedCall)) {
-                // MATCH_ROWTIME() is a no-args function, it can own two kind of return types based
-                // on the rowTime attribute type of its input, we rewrite the return type here
-                RelDataType firstRowTypeType =
-                        inputFieldTypes.stream()
-                                .filter(FlinkTypeFactory::isTimeIndicatorType)
-                                .findFirst()
-                                .get();
-                return rexBuilder.makeCall(
-                        ((FlinkTypeFactory) rexBuilder.getTypeFactory())
-                                .createRowtimeIndicatorType(
-                                        updatedCall.getType().isNullable(),
-                                        isTimestampLtzType(firstRowTypeType)),
-                        updatedCall.getOperator(),
-                        materializedOperands);
+            // All calls in MEASURES and DEFINE are wrapped with FINAL/RUNNING, therefore
+            // we should treat FINAL(MATCH_ROWTIME) and FINAL(MATCH_PROCTIME) as a time attribute
+            // extraction
+            if (isFinalOnMatchTimeIndicator(call)) {
+                return updatedCall;
             } else if (isTimeIndicatorType(updatedCall.getType())) {
                 // do not modify window time attributes and some special operators
                 if (updatedCallOp == FlinkSqlOperatorTable.TUMBLE_ROWTIME
@@ -862,6 +732,7 @@ public final class RelTimeIndicatorConverter extends RelHomogeneousShuttle {
                         || updatedCallOp == FlinkSqlOperatorTable.HOP_PROCTIME
                         || updatedCallOp == FlinkSqlOperatorTable.SESSION_ROWTIME
                         || updatedCallOp == FlinkSqlOperatorTable.SESSION_PROCTIME
+                        || updatedCallOp == FlinkSqlOperatorTable.MATCH_ROWTIME
                         || updatedCallOp == FlinkSqlOperatorTable.MATCH_PROCTIME
                         || updatedCallOp == FlinkSqlOperatorTable.PROCTIME
                         || updatedCallOp == SqlStdOperatorTable.AS
@@ -887,10 +758,7 @@ public final class RelTimeIndicatorConverter extends RelHomogeneousShuttle {
             RelDataType oldType = inputRef.getType();
             if (isTimeIndicatorType(oldType)) {
                 RelDataType resolvedRefType = inputFieldTypes.get(inputRef.getIndex());
-                if (isTimestampLtzType(resolvedRefType) && !isTimestampLtzType(oldType)) {
-                    // input has been converted from TIMESTAMP to TIMESTAMP_LTZ type
-                    return rexBuilder.makeInputRef(resolvedRefType, inputRef.getIndex());
-                } else if (!isTimeIndicatorType(resolvedRefType)) {
+                if (!isTimeIndicatorType(resolvedRefType)) {
                     // input has been materialized
                     return new RexInputRef(inputRef.getIndex(), resolvedRefType);
                 }
@@ -903,11 +771,7 @@ public final class RelTimeIndicatorConverter extends RelHomogeneousShuttle {
             RelDataType oldType = fieldRef.getType();
             if (isTimeIndicatorType(oldType)) {
                 RelDataType resolvedRefType = inputFieldTypes.get(fieldRef.getIndex());
-                if (isTimestampLtzType(resolvedRefType) && !isTimestampLtzType(oldType)) {
-                    // input has been converted from TIMESTAMP to TIMESTAMP_LTZ type
-                    return rexBuilder.makePatternFieldRef(
-                            fieldRef.getAlpha(), resolvedRefType, fieldRef.getIndex());
-                } else if (!isTimeIndicatorType(resolvedRefType)) {
+                if (!isTimeIndicatorType(resolvedRefType)) {
                     // input has been materialized
                     return new RexPatternFieldRef(
                             fieldRef.getAlpha(), fieldRef.getIndex(), resolvedRefType);

--- a/flink-table/flink-table-planner/src/main/java/org/apache/flink/table/planner/functions/sql/FlinkSqlOperatorTable.java
+++ b/flink-table/flink-table-planner/src/main/java/org/apache/flink/table/planner/functions/sql/FlinkSqlOperatorTable.java
@@ -72,23 +72,9 @@ public class FlinkSqlOperatorTable extends ReflectiveSqlOperatorTable {
         return instance;
     }
 
-    private static final SqlReturnTypeInference ROWTIME_TYPE_INFERENCE =
-            createTimeIndicatorReturnType(true, false);
     private static final SqlReturnTypeInference PROCTIME_TYPE_INFERENCE =
-            createTimeIndicatorReturnType(false, true);
-
-    private static SqlReturnTypeInference createTimeIndicatorReturnType(
-            boolean isRowTime, boolean isTimestampLtz) {
-        return ReturnTypes.explicit(
-                factory -> {
-                    if (isRowTime) {
-                        return ((FlinkTypeFactory) factory)
-                                .createRowtimeIndicatorType(false, isTimestampLtz);
-                    } else {
-                        return ((FlinkTypeFactory) factory).createProctimeIndicatorType(false);
-                    }
-                });
-    }
+            ReturnTypes.explicit(
+                    factory -> ((FlinkTypeFactory) factory).createProctimeIndicatorType(false));
 
     @Override
     public void lookupOperatorOverloads(
@@ -121,18 +107,9 @@ public class FlinkSqlOperatorTable extends ReflectiveSqlOperatorTable {
 
     /**
      * Function used to access a event time attribute with TIMESTAMP or TIMESTAMP_LTZ type from
-     * MATCH_RECOGNIZE, for TIMESTAMP_LTZ type, we rewrite the return type in
-     * [org.apache.flink.table.planner.calcite.RelTimeIndicatorConverter].
+     * MATCH_RECOGNIZE.
      */
-    public static final SqlFunction MATCH_ROWTIME =
-            new CalciteSqlFunction(
-                    "MATCH_ROWTIME",
-                    SqlKind.OTHER_FUNCTION,
-                    ROWTIME_TYPE_INFERENCE,
-                    null,
-                    OperandTypes.NILADIC,
-                    SqlFunctionCategory.MATCH_RECOGNIZE,
-                    true);
+    public static final SqlFunction MATCH_ROWTIME = new MatchRowTimeFunction();
 
     /** Function used to access a processing time attribute from MATCH_RECOGNIZE. */
     public static final SqlFunction MATCH_PROCTIME =

--- a/flink-table/flink-table-planner/src/main/java/org/apache/flink/table/planner/functions/sql/FlinkSqlOperatorTable.java
+++ b/flink-table/flink-table-planner/src/main/java/org/apache/flink/table/planner/functions/sql/FlinkSqlOperatorTable.java
@@ -106,7 +106,7 @@ public class FlinkSqlOperatorTable extends ReflectiveSqlOperatorTable {
                     false);
 
     /**
-     * Function used to access a event time attribute with TIMESTAMP or TIMESTAMP_LTZ type from
+     * Function used to access an event time attribute with TIMESTAMP or TIMESTAMP_LTZ type from
      * MATCH_RECOGNIZE.
      */
     public static final SqlFunction MATCH_ROWTIME = new MatchRowTimeFunction();

--- a/flink-table/flink-table-planner/src/main/java/org/apache/flink/table/planner/functions/sql/MatchRowTimeFunction.java
+++ b/flink-table/flink-table-planner/src/main/java/org/apache/flink/table/planner/functions/sql/MatchRowTimeFunction.java
@@ -1,0 +1,129 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to you under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.flink.table.planner.functions.sql;
+
+import org.apache.flink.table.api.ValidationException;
+import org.apache.flink.table.planner.calcite.FlinkTypeFactory;
+
+import org.apache.calcite.rel.type.RelDataType;
+import org.apache.calcite.sql.SqlCallBinding;
+import org.apache.calcite.sql.SqlFunction;
+import org.apache.calcite.sql.SqlFunctionCategory;
+import org.apache.calcite.sql.SqlKind;
+import org.apache.calcite.sql.SqlNode;
+import org.apache.calcite.sql.SqlOperandCountRange;
+import org.apache.calcite.sql.SqlOperatorBinding;
+import org.apache.calcite.sql.type.SqlOperandCountRanges;
+
+import java.util.List;
+
+/**
+ * Function used to access an row time attribute with TIMESTAMP or TIMESTAMP_LTZ type from
+ * MATCH_RECOGNIZE. The function could receive no operand or one operand which is a field reference
+ * with row time attribute. If there is no operand, the function returns row time attribute with
+ * TIMESTAMP. Else, return type is same with operand type.
+ */
+public class MatchRowTimeFunction extends SqlFunction {
+
+    /** Creates a window table function with a given name. */
+    public MatchRowTimeFunction() {
+        super(
+                "MATCH_ROWTIME",
+                SqlKind.OTHER_FUNCTION,
+                null,
+                null,
+                null,
+                SqlFunctionCategory.MATCH_RECOGNIZE);
+    }
+
+    @Override
+    public String getAllowedSignatures(String opNameToUse) {
+        return "MATCH_ROWTIME([time attribute field])";
+    }
+
+    @Override
+    public SqlOperandCountRange getOperandCountRange() {
+        return SqlOperandCountRanges.between(0, 1);
+    }
+
+    public String getSignatureTemplate(final int operandsCount) {
+        switch (operandsCount) {
+            case 0:
+                return "{}";
+            case 1:
+                return "{0})";
+            default:
+                throw new AssertionError();
+        }
+    }
+
+    @Override
+    public boolean checkOperandTypes(SqlCallBinding callBinding, boolean throwOnFailure) {
+        List<SqlNode> operands = callBinding.operands();
+        int n = operands.size();
+        assert n == 0 || n == 1;
+        if (n == 0) {
+            return true;
+        } else {
+            SqlNode operand = callBinding.operand(0);
+            if (operand.getKind() != SqlKind.IDENTIFIER) {
+                if (throwOnFailure) {
+                    ValidationException exception =
+                            new ValidationException(
+                                    String.format(
+                                            "The function %s requires argument to be a field reference, but is '%s'.",
+                                            callBinding.getOperator().getName(),
+                                            operand.getKind()));
+                    throw exception;
+                } else {
+                    return false;
+                }
+            }
+            RelDataType operandType = callBinding.getOperandType(0);
+            if (FlinkTypeFactory.isRowtimeIndicatorType(operandType)) {
+                return true;
+            } else {
+                if (throwOnFailure) {
+                    ValidationException exception =
+                            new ValidationException(
+                                    String.format(
+                                            "The function %s requires argument to be a row time attribute type, but is '%s'.",
+                                            callBinding.getOperator().getName(), operandType));
+                    throw exception;
+                } else {
+                    return false;
+                }
+            }
+        }
+    }
+
+    @Override
+    public RelDataType inferReturnType(SqlOperatorBinding opBinding) {
+        // Returns RowTime if there is no argument
+        if (opBinding.getOperandCount() == 0) {
+            final FlinkTypeFactory typeFactory = (FlinkTypeFactory) opBinding.getTypeFactory();
+            return typeFactory.createRowtimeIndicatorType(false, false);
+        }
+        return opBinding.getOperandType(0);
+    }
+
+    @Override
+    public boolean isDeterministic() {
+        return true;
+    }
+}

--- a/flink-table/flink-table-planner/src/main/java/org/apache/flink/table/planner/functions/sql/MatchRowTimeFunction.java
+++ b/flink-table/flink-table-planner/src/main/java/org/apache/flink/table/planner/functions/sql/MatchRowTimeFunction.java
@@ -33,14 +33,13 @@ import org.apache.calcite.sql.type.SqlOperandCountRanges;
 import java.util.List;
 
 /**
- * Function used to access an row time attribute with TIMESTAMP or TIMESTAMP_LTZ type from
- * MATCH_RECOGNIZE. The function could receive no operand or one operand which is a field reference
- * with row time attribute. If there is no operand, the function returns row time attribute with
- * TIMESTAMP. Else, return type is same with operand type.
+ * The function used to access a rowtime attribute with TIMESTAMP or TIMESTAMP_LTZ type from
+ * MATCH_RECOGNIZE clause. The function accepts zero or one operand which is a field reference with
+ * rowtime attribute. If there is no operand, the function will return rowtime attribute with
+ * TIMESTAMP type. Otherwise, the return type will be same with the operand type.
  */
 public class MatchRowTimeFunction extends SqlFunction {
 
-    /** Creates a window table function with a given name. */
     public MatchRowTimeFunction() {
         super(
                 "MATCH_ROWTIME",
@@ -53,7 +52,7 @@ public class MatchRowTimeFunction extends SqlFunction {
 
     @Override
     public String getAllowedSignatures(String opNameToUse) {
-        return "MATCH_ROWTIME([time attribute field])";
+        return "MATCH_ROWTIME([rowtime_field])";
     }
 
     @Override
@@ -86,7 +85,7 @@ public class MatchRowTimeFunction extends SqlFunction {
                     ValidationException exception =
                             new ValidationException(
                                     String.format(
-                                            "The function %s requires argument to be a field reference, but is '%s'.",
+                                            "The function %s requires a field reference as argument, but actual argument is '%s'.",
                                             callBinding.getOperator().getName(),
                                             operand.getKind()));
                     throw exception;
@@ -114,7 +113,7 @@ public class MatchRowTimeFunction extends SqlFunction {
 
     @Override
     public RelDataType inferReturnType(SqlOperatorBinding opBinding) {
-        // Returns RowTime if there is no argument
+        // Returns rowtime if there is no argument
         if (opBinding.getOperandCount() == 0) {
             final FlinkTypeFactory typeFactory = (FlinkTypeFactory) opBinding.getTypeFactory();
             return typeFactory.createRowtimeIndicatorType(false, false);

--- a/flink-table/flink-table-planner/src/main/java/org/apache/flink/table/planner/functions/sql/MatchRowTimeFunction.java
+++ b/flink-table/flink-table-planner/src/main/java/org/apache/flink/table/planner/functions/sql/MatchRowTimeFunction.java
@@ -82,13 +82,10 @@ public class MatchRowTimeFunction extends SqlFunction {
             SqlNode operand = callBinding.operand(0);
             if (operand.getKind() != SqlKind.IDENTIFIER) {
                 if (throwOnFailure) {
-                    ValidationException exception =
-                            new ValidationException(
-                                    String.format(
-                                            "The function %s requires a field reference as argument, but actual argument is '%s'.",
-                                            callBinding.getOperator().getName(),
-                                            operand.getKind()));
-                    throw exception;
+                    throw new ValidationException(
+                            String.format(
+                                    "The function %s requires a field reference as argument, but actual argument is not a simple field reference.",
+                                    callBinding.getOperator().getName()));
                 } else {
                     return false;
                 }
@@ -98,12 +95,10 @@ public class MatchRowTimeFunction extends SqlFunction {
                 return true;
             } else {
                 if (throwOnFailure) {
-                    ValidationException exception =
-                            new ValidationException(
-                                    String.format(
-                                            "The function %s requires argument to be a row time attribute type, but is '%s'.",
-                                            callBinding.getOperator().getName(), operandType));
-                    throw exception;
+                    throw new ValidationException(
+                            String.format(
+                                    "The function %s requires argument to be a row time attribute type, but is '%s'.",
+                                    callBinding.getOperator().getName(), operandType));
                 } else {
                     return false;
                 }

--- a/flink-table/flink-table-planner/src/main/scala/org/apache/flink/table/planner/plan/nodes/logical/FlinkLogicalMatch.scala
+++ b/flink-table/flink-table-planner/src/main/scala/org/apache/flink/table/planner/plan/nodes/logical/FlinkLogicalMatch.scala
@@ -18,7 +18,9 @@
 
 package org.apache.flink.table.planner.plan.nodes.logical
 
+import org.apache.flink.table.planner.calcite.FlinkTypeFactory.isRowtimeIndicatorType
 import org.apache.flink.table.planner.plan.nodes.FlinkConventions
+import org.apache.flink.table.planner.plan.utils.MatchUtil
 
 import org.apache.calcite.plan._
 import org.apache.calcite.rel.`type`.RelDataType
@@ -27,9 +29,12 @@ import org.apache.calcite.rel.core.Match
 import org.apache.calcite.rel.logical.LogicalMatch
 import org.apache.calcite.rel.{RelCollation, RelNode}
 import org.apache.calcite.rex.RexNode
-import org.apache.calcite.util.ImmutableBitSet
+import org.apache.calcite.sql.`type`.SqlTypeName
+import org.apache.calcite.util.{ImmutableBitSet, Litmus}
 
 import java.util
+
+import scala.collection.JavaConversions._
 
 class FlinkLogicalMatch(
     cluster: RelOptCluster,
@@ -64,6 +69,28 @@ class FlinkLogicalMatch(
     orderKeys,
     interval)
   with FlinkLogicalRel {
+
+  override def isValid(litmus: Litmus, context: RelNode.Context): Boolean = {
+    val inputContainsRowTimeLtz = input.getRowType.getFieldList.exists { field =>
+      isRowtimeIndicatorType(field.getType) &&
+        field.getType.getSqlTypeName == SqlTypeName.TIMESTAMP_WITH_LOCAL_TIME_ZONE
+    }
+    if (inputContainsRowTimeLtz) {
+      val containMatchRowTimeWithoutArgs = getMeasures.values().exists(
+        MatchUtil.isFinalOnMatchRowTimeWithoutArgs)
+      if (containMatchRowTimeWithoutArgs) {
+        litmus.fail(
+          "MATCH_ROWTIME() could only be used when input stream does not contain " +
+            "row time attribute with TIMESTAMP_LTZ type.\n" +
+            "Please pass rowtime attribute field as input argument of MATCH_ROWTIME function.")
+      } else {
+        litmus.succeed()
+      }
+    } else {
+      litmus.succeed()
+    }
+  }
+
 
   override def copy(traitSet: RelTraitSet, inputs: util.List[RelNode]): RelNode = {
     new FlinkLogicalMatch(

--- a/flink-table/flink-table-planner/src/test/resources/org/apache/flink/table/planner/plan/stream/sql/MatchRecognizeTest.xml
+++ b/flink-table/flink-table-planner/src/test/resources/org/apache/flink/table/planner/plan/stream/sql/MatchRecognizeTest.xml
@@ -16,53 +16,6 @@ See the License for the specific language governing permissions and
 limitations under the License.
 -->
 <Root>
-  <TestCase name="testMatchRecognizeOnRowtimeLTZ">
-    <Resource name="sql">
-      <![CDATA[
-SELECT
-  symbol,
-  SUM(price) as price,
-  TUMBLE_ROWTIME(matchRowtime, interval '3' second) as rowTime,
-  TUMBLE_START(matchRowtime, interval '3' second) as startTime
-FROM Ticker
-MATCH_RECOGNIZE (
-  PARTITION BY symbol
-  ORDER BY ts_ltz
-  MEASURES
-    A.price as price,
-    A.tax as tax,
-    MATCH_ROWTIME() as matchRowtime
-  ONE ROW PER MATCH
-  PATTERN (A)
-  DEFINE
-    A AS A.price > 0
-) AS T
-GROUP BY symbol, TUMBLE(matchRowtime, interval '3' second)
-]]>
-    </Resource>
-    <Resource name="ast">
-      <![CDATA[
-LogicalProject(symbol=[$0], price=[$2], rowTime=[TUMBLE_ROWTIME($1)], startTime=[TUMBLE_START($1)])
-+- LogicalAggregate(group=[{0, 1}], price=[SUM($2)])
-   +- LogicalProject(symbol=[$0], $f1=[$TUMBLE($3, 3000:INTERVAL SECOND)], price=[$1])
-      +- LogicalMatch(partition=[[0]], order=[[1 ASC-nulls-first]], outputFields=[[symbol, price, tax, matchRowtime]], allRows=[false], after=[FLAG(SKIP TO NEXT ROW)], pattern=[_UTF-16LE'A'], isStrictStarts=[false], isStrictEnds=[false], subsets=[[]], patternDefinitions=[[>(PREV(A.$2, 0), 0)]], inputFields=[[symbol, ts_ltz, price, tax]])
-         +- LogicalWatermarkAssigner(rowtime=[ts_ltz], watermark=[-($1, 1000:INTERVAL SECOND)])
-            +- LogicalTableScan(table=[[default_catalog, default_database, Ticker]])
-]]>
-    </Resource>
-    <Resource name="optimized rel plan">
-      <![CDATA[
-Calc(select=[symbol, price, CAST(w$rowtime) AS rowTime, w$start AS startTime])
-+- GroupWindowAggregate(groupBy=[symbol], window=[TumblingGroupWindow('w$, matchRowtime, 3000)], properties=[w$start, w$end, w$rowtime, w$proctime], select=[symbol, SUM(price) AS price, start('w$) AS w$start, end('w$) AS w$end, rowtime('w$) AS w$rowtime, proctime('w$) AS w$proctime])
-   +- Exchange(distribution=[hash[symbol]])
-      +- Calc(select=[symbol, matchRowtime, price])
-         +- Match(partitionBy=[symbol], orderBy=[ts_ltz ASC], measures=[FINAL(A.price) AS price, FINAL(A.tax) AS tax, FINAL(MATCH_ROWTIME()) AS matchRowtime], rowsPerMatch=[ONE ROW PER MATCH], after=[SKIP TO NEXT ROW], pattern=[_UTF-16LE'A'], define=[{A=>(PREV(A.$2, 0), 0)}])
-            +- Exchange(distribution=[hash[symbol]])
-               +- WatermarkAssigner(rowtime=[ts_ltz], watermark=[-(ts_ltz, 1000:INTERVAL SECOND)])
-                  +- TableSourceScan(table=[[default_catalog, default_database, Ticker]], fields=[symbol, ts_ltz, price, tax])
-]]>
-    </Resource>
-  </TestCase>
   <TestCase name="testCascadeMatch">
     <Resource name="sql">
       <![CDATA[
@@ -80,7 +33,7 @@ FROM (
   MEASURES
     A.price as price,
     A.tax as tax,
-    MATCH_ROWTIME() as matchRowtime
+    MATCH_ROWTIME(ts_ltz) as matchRowtime
   ONE ROW PER MATCH
   PATTERN (A)
   DEFINE
@@ -120,10 +73,137 @@ Match(partitionBy=[symbol], orderBy=[matchRowtime ASC], measures=[FINAL(A.price)
       +- GroupWindowAggregate(groupBy=[symbol, price, matchRowtime], window=[TumblingGroupWindow('w$, matchRowtime0, 3000)], properties=[w$start, w$end, w$rowtime, w$proctime], select=[symbol, price, matchRowtime, start('w$) AS w$start, end('w$) AS w$end, rowtime('w$) AS w$rowtime, proctime('w$) AS w$proctime])
          +- Exchange(distribution=[hash[symbol, price, matchRowtime]])
             +- Calc(select=[symbol, price, tax, CAST(matchRowtime) AS matchRowtime])
-               +- Match(partitionBy=[symbol], orderBy=[ts_ltz ASC], measures=[FINAL(A.price) AS price, FINAL(A.tax) AS tax, FINAL(MATCH_ROWTIME()) AS matchRowtime], rowsPerMatch=[ONE ROW PER MATCH], after=[SKIP TO NEXT ROW], pattern=[_UTF-16LE'A'], define=[{A=>(PREV(A.$2, 0), 0)}])
+               +- Match(partitionBy=[symbol], orderBy=[ts_ltz ASC], measures=[FINAL(A.price) AS price, FINAL(A.tax) AS tax, FINAL(MATCH_ROWTIME(*.ts_ltz)) AS matchRowtime], rowsPerMatch=[ONE ROW PER MATCH], after=[SKIP TO NEXT ROW], pattern=[_UTF-16LE'A'], define=[{A=>(PREV(A.$2, 0), 0)}])
                   +- Exchange(distribution=[hash[symbol]])
                      +- WatermarkAssigner(rowtime=[ts_ltz], watermark=[-(ts_ltz, 1000:INTERVAL SECOND)])
                         +- TableSourceScan(table=[[default_catalog, default_database, Ticker]], fields=[symbol, ts_ltz, price, tax])
+]]>
+    </Resource>
+  </TestCase>
+  <TestCase name="testMatchRecognizeOnRowtime">
+    <Resource name="sql">
+      <![CDATA[
+SELECT
+  symbol,
+  SUM(price) as price,
+  TUMBLE_ROWTIME(matchRowtime, interval '3' second) as rowTime,
+  TUMBLE_START(matchRowtime, interval '3' second) as startTime
+FROM Ticker1
+MATCH_RECOGNIZE (
+  PARTITION BY symbol
+  ORDER BY ts_ltz
+  MEASURES
+    A.price as price,
+    A.tax as tax,
+    MATCH_ROWTIME() as matchRowtime
+  ONE ROW PER MATCH
+  PATTERN (A)
+  DEFINE
+    A AS A.price > 0
+) AS T
+GROUP BY symbol, TUMBLE(matchRowtime, interval '3' second)
+]]>
+    </Resource>
+    <Resource name="ast">
+      <![CDATA[
+LogicalProject(symbol=[$0], price=[$2], rowTime=[TUMBLE_ROWTIME($1)], startTime=[TUMBLE_START($1)])
++- LogicalAggregate(group=[{0, 1}], price=[SUM($2)])
+   +- LogicalProject(symbol=[$0], $f1=[$TUMBLE($3, 3000:INTERVAL SECOND)], price=[$1])
+      +- LogicalMatch(partition=[[0]], order=[[1 ASC-nulls-first]], outputFields=[[symbol, price, tax, matchRowtime]], allRows=[false], after=[FLAG(SKIP TO NEXT ROW)], pattern=[_UTF-16LE'A'], isStrictStarts=[false], isStrictEnds=[false], subsets=[[]], patternDefinitions=[[>(PREV(A.$2, 0), 0)]], inputFields=[[symbol, ts_ltz, price, tax]])
+         +- LogicalWatermarkAssigner(rowtime=[ts_ltz], watermark=[-($1, 1000:INTERVAL SECOND)])
+            +- LogicalTableScan(table=[[default_catalog, default_database, Ticker1]])
+]]>
+    </Resource>
+    <Resource name="optimized rel plan">
+      <![CDATA[
+Calc(select=[symbol, price, CAST(w$rowtime) AS rowTime, w$start AS startTime])
++- GroupWindowAggregate(groupBy=[symbol], window=[TumblingGroupWindow('w$, matchRowtime, 3000)], properties=[w$start, w$end, w$rowtime, w$proctime], select=[symbol, SUM(price) AS price, start('w$) AS w$start, end('w$) AS w$end, rowtime('w$) AS w$rowtime, proctime('w$) AS w$proctime])
+   +- Exchange(distribution=[hash[symbol]])
+      +- Calc(select=[symbol, matchRowtime, price])
+         +- Match(partitionBy=[symbol], orderBy=[ts_ltz ASC], measures=[FINAL(A.price) AS price, FINAL(A.tax) AS tax, FINAL(MATCH_ROWTIME()) AS matchRowtime], rowsPerMatch=[ONE ROW PER MATCH], after=[SKIP TO NEXT ROW], pattern=[_UTF-16LE'A'], define=[{A=>(PREV(A.$2, 0), 0)}])
+            +- Exchange(distribution=[hash[symbol]])
+               +- WatermarkAssigner(rowtime=[ts_ltz], watermark=[-(ts_ltz, 1000:INTERVAL SECOND)])
+                  +- TableSourceScan(table=[[default_catalog, default_database, Ticker1]], fields=[symbol, ts_ltz, price, tax])
+]]>
+    </Resource>
+  </TestCase>
+  <TestCase name="testOverWindowOnMatchRecognizeOnRowtimeLTZ">
+    <Resource name="sql">
+      <![CDATA[
+SELECT
+  symbol,
+  price,
+  tax,
+  matchRowtime,
+  SUM(price) OVER (
+    PARTITION BY symbol ORDER BY matchRowtime RANGE UNBOUNDED PRECEDING) as price_sum
+FROM T
+    ]]>
+    </Resource>
+    <Resource name="ast">
+      <![CDATA[
+LogicalProject(symbol=[$0], price=[$1], tax=[$2], matchRowtime=[$3], price_sum=[CASE(>(COUNT($1) OVER (PARTITION BY $0 ORDER BY $3 NULLS FIRST), 0), $SUM0($1) OVER (PARTITION BY $0 ORDER BY $3 NULLS FIRST), null:INTEGER)]), rowType=[RecordType(VARCHAR(2147483647) symbol, INTEGER price, INTEGER tax, TIMESTAMP_LTZ(3) *ROWTIME* matchRowtime, INTEGER price_sum)]
++- LogicalMatch(partition=[[0]], order=[[1 ASC-nulls-first]], outputFields=[[symbol, price, tax, matchRowtime]], allRows=[false], after=[FLAG(SKIP TO NEXT ROW)], pattern=[_UTF-16LE'A'], isStrictStarts=[false], isStrictEnds=[false], subsets=[[]], patternDefinitions=[[>(PREV(A.$2, 0), 0)]], inputFields=[[symbol, ts_ltz, price, tax]]), rowType=[RecordType(VARCHAR(2147483647) symbol, INTEGER price, INTEGER tax, TIMESTAMP_LTZ(3) *ROWTIME* matchRowtime)]
+   +- LogicalWatermarkAssigner(rowtime=[ts_ltz], watermark=[-($1, 1000:INTERVAL SECOND)]), rowType=[RecordType(VARCHAR(2147483647) symbol, TIMESTAMP_LTZ(3) *ROWTIME* ts_ltz, INTEGER price, INTEGER tax)]
+      +- LogicalTableScan(table=[[default_catalog, default_database, Ticker]]), rowType=[RecordType(VARCHAR(2147483647) symbol, TIMESTAMP_WITH_LOCAL_TIME_ZONE(3) ts_ltz, INTEGER price, INTEGER tax)]
+]]>
+    </Resource>
+    <Resource name="optimized rel plan">
+      <![CDATA[
+Calc(select=[symbol, price, tax, matchRowtime, CASE(>(w0$o0, 0:BIGINT), w0$o1, null:INTEGER) AS price_sum]), rowType=[RecordType(VARCHAR(2147483647) symbol, INTEGER price, INTEGER tax, TIMESTAMP_LTZ(3) *ROWTIME* matchRowtime, INTEGER price_sum)]
++- OverAggregate(partitionBy=[symbol], orderBy=[matchRowtime ASC], window=[ RANG BETWEEN UNBOUNDED PRECEDING AND CURRENT ROW], select=[symbol, price, tax, matchRowtime, COUNT(price) AS w0$o0, $SUM0(price) AS w0$o1]), rowType=[RecordType(VARCHAR(2147483647) symbol, INTEGER price, INTEGER tax, TIMESTAMP_LTZ(3) *ROWTIME* matchRowtime, BIGINT w0$o0, INTEGER w0$o1)]
+   +- Exchange(distribution=[hash[symbol]]), rowType=[RecordType(VARCHAR(2147483647) symbol, INTEGER price, INTEGER tax, TIMESTAMP_LTZ(3) *ROWTIME* matchRowtime)]
+      +- Match(partitionBy=[symbol], orderBy=[ts_ltz ASC], measures=[FINAL(A.price) AS price, FINAL(A.tax) AS tax, FINAL(MATCH_ROWTIME(*.ts_ltz)) AS matchRowtime], rowsPerMatch=[ONE ROW PER MATCH], after=[SKIP TO NEXT ROW], pattern=[_UTF-16LE'A'], define=[{A=>(PREV(A.$2, 0), 0)}]), rowType=[RecordType(VARCHAR(2147483647) symbol, INTEGER price, INTEGER tax, TIMESTAMP_LTZ(3) *ROWTIME* matchRowtime)]
+         +- Exchange(distribution=[hash[symbol]]), rowType=[RecordType(VARCHAR(2147483647) symbol, TIMESTAMP_LTZ(3) *ROWTIME* ts_ltz, INTEGER price, INTEGER tax)]
+            +- WatermarkAssigner(rowtime=[ts_ltz], watermark=[-(ts_ltz, 1000:INTERVAL SECOND)]), rowType=[RecordType(VARCHAR(2147483647) symbol, TIMESTAMP_LTZ(3) *ROWTIME* ts_ltz, INTEGER price, INTEGER tax)]
+               +- TableSourceScan(table=[[default_catalog, default_database, Ticker]], fields=[symbol, ts_ltz, price, tax]), rowType=[RecordType(VARCHAR(2147483647) symbol, TIMESTAMP_WITH_LOCAL_TIME_ZONE(3) ts_ltz, INTEGER price, INTEGER tax)]
+]]>
+    </Resource>
+  </TestCase>
+  <TestCase name="testMatchRecognizeOnRowtimeLTZ">
+    <Resource name="sql">
+      <![CDATA[
+SELECT
+  symbol,
+  SUM(price) as price,
+  TUMBLE_ROWTIME(matchRowtime, interval '3' second) as rowTime,
+  TUMBLE_START(matchRowtime, interval '3' second) as startTime
+FROM Ticker
+MATCH_RECOGNIZE (
+  PARTITION BY symbol
+  ORDER BY ts_ltz
+  MEASURES
+    A.price as price,
+    A.tax as tax,
+    MATCH_ROWTIME(ts_ltz) as matchRowtime
+  ONE ROW PER MATCH
+  PATTERN (A)
+  DEFINE
+    A AS A.price > 0
+) AS T
+GROUP BY symbol, TUMBLE(matchRowtime, interval '3' second)
+]]>
+    </Resource>
+    <Resource name="ast">
+      <![CDATA[
+LogicalProject(symbol=[$0], price=[$2], rowTime=[TUMBLE_ROWTIME($1)], startTime=[TUMBLE_START($1)])
++- LogicalAggregate(group=[{0, 1}], price=[SUM($2)])
+   +- LogicalProject(symbol=[$0], $f1=[$TUMBLE($3, 3000:INTERVAL SECOND)], price=[$1])
+      +- LogicalMatch(partition=[[0]], order=[[1 ASC-nulls-first]], outputFields=[[symbol, price, tax, matchRowtime]], allRows=[false], after=[FLAG(SKIP TO NEXT ROW)], pattern=[_UTF-16LE'A'], isStrictStarts=[false], isStrictEnds=[false], subsets=[[]], patternDefinitions=[[>(PREV(A.$2, 0), 0)]], inputFields=[[symbol, ts_ltz, price, tax]])
+         +- LogicalWatermarkAssigner(rowtime=[ts_ltz], watermark=[-($1, 1000:INTERVAL SECOND)])
+            +- LogicalTableScan(table=[[default_catalog, default_database, Ticker]])
+]]>
+    </Resource>
+    <Resource name="optimized rel plan">
+      <![CDATA[
+Calc(select=[symbol, price, w$rowtime AS rowTime, w$start AS startTime])
++- GroupWindowAggregate(groupBy=[symbol], window=[TumblingGroupWindow('w$, matchRowtime, 3000)], properties=[w$start, w$end, w$rowtime, w$proctime], select=[symbol, SUM(price) AS price, start('w$) AS w$start, end('w$) AS w$end, rowtime('w$) AS w$rowtime, proctime('w$) AS w$proctime])
+   +- Exchange(distribution=[hash[symbol]])
+      +- Calc(select=[symbol, matchRowtime, price])
+         +- Match(partitionBy=[symbol], orderBy=[ts_ltz ASC], measures=[FINAL(A.price) AS price, FINAL(A.tax) AS tax, FINAL(MATCH_ROWTIME(*.ts_ltz)) AS matchRowtime], rowsPerMatch=[ONE ROW PER MATCH], after=[SKIP TO NEXT ROW], pattern=[_UTF-16LE'A'], define=[{A=>(PREV(A.$2, 0), 0)}])
+            +- Exchange(distribution=[hash[symbol]])
+               +- WatermarkAssigner(rowtime=[ts_ltz], watermark=[-(ts_ltz, 1000:INTERVAL SECOND)])
+                  +- TableSourceScan(table=[[default_catalog, default_database, Ticker]], fields=[symbol, ts_ltz, price, tax])
 ]]>
     </Resource>
   </TestCase>

--- a/flink-table/flink-table-planner/src/test/resources/org/apache/flink/table/planner/plan/stream/sql/MatchRecognizeTest.xml
+++ b/flink-table/flink-table-planner/src/test/resources/org/apache/flink/table/planner/plan/stream/sql/MatchRecognizeTest.xml
@@ -207,4 +207,31 @@ Calc(select=[symbol, price, w$rowtime AS rowTime, w$start AS startTime])
 ]]>
     </Resource>
   </TestCase>
+  <TestCase name="testWindowTVFOnMatchRecognizeOnRowtimeLTZ">
+    <Resource name="sql">
+      <![CDATA[
+SELECT *
+FROM TABLE(TUMBLE(TABLE T, DESCRIPTOR(matchRowtime), INTERVAL '3' second))
+]]>
+    </Resource>
+    <Resource name="ast">
+      <![CDATA[
+LogicalProject(symbol=[$0], price=[$1], tax=[$2], matchRowtime=[$3], window_start=[$4], window_end=[$5], window_time=[$6]), rowType=[RecordType(VARCHAR(2147483647) symbol, INTEGER price, INTEGER tax, TIMESTAMP_LTZ(3) *ROWTIME* matchRowtime, TIMESTAMP(3) window_start, TIMESTAMP(3) window_end, TIMESTAMP_LTZ(3) *ROWTIME* window_time)]
++- LogicalTableFunctionScan(invocation=[TUMBLE($3, DESCRIPTOR($3), 3000:INTERVAL SECOND)], rowType=[RecordType(VARCHAR(2147483647) symbol, INTEGER price, INTEGER tax, TIMESTAMP_LTZ(3) *ROWTIME* matchRowtime, TIMESTAMP(3) window_start, TIMESTAMP(3) window_end, TIMESTAMP_LTZ(3) *ROWTIME* window_time)]), rowType=[RecordType(VARCHAR(2147483647) symbol, INTEGER price, INTEGER tax, TIMESTAMP_LTZ(3) *ROWTIME* matchRowtime, TIMESTAMP(3) window_start, TIMESTAMP(3) window_end, TIMESTAMP_LTZ(3) *ROWTIME* window_time)]
+   +- LogicalProject(symbol=[$0], price=[$1], tax=[$2], matchRowtime=[$3]), rowType=[RecordType(VARCHAR(2147483647) symbol, INTEGER price, INTEGER tax, TIMESTAMP_LTZ(3) *ROWTIME* matchRowtime)]
+      +- LogicalMatch(partition=[[0]], order=[[1 ASC-nulls-first]], outputFields=[[symbol, price, tax, matchRowtime]], allRows=[false], after=[FLAG(SKIP TO NEXT ROW)], pattern=[_UTF-16LE'A'], isStrictStarts=[false], isStrictEnds=[false], subsets=[[]], patternDefinitions=[[>(PREV(A.$2, 0), 0)]], inputFields=[[symbol, ts_ltz, price, tax]]), rowType=[RecordType(VARCHAR(2147483647) symbol, INTEGER price, INTEGER tax, TIMESTAMP_LTZ(3) *ROWTIME* matchRowtime)]
+         +- LogicalWatermarkAssigner(rowtime=[ts_ltz], watermark=[-($1, 1000:INTERVAL SECOND)]), rowType=[RecordType(VARCHAR(2147483647) symbol, TIMESTAMP_LTZ(3) *ROWTIME* ts_ltz, INTEGER price, INTEGER tax)]
+            +- LogicalTableScan(table=[[default_catalog, default_database, Ticker]]), rowType=[RecordType(VARCHAR(2147483647) symbol, TIMESTAMP_WITH_LOCAL_TIME_ZONE(3) ts_ltz, INTEGER price, INTEGER tax)]
+]]>
+    </Resource>
+    <Resource name="optimized rel plan">
+      <![CDATA[
+WindowTableFunction(window=[TUMBLE(time_col=[matchRowtime], size=[3 s])]), rowType=[RecordType(VARCHAR(2147483647) symbol, INTEGER price, INTEGER tax, TIMESTAMP_LTZ(3) *ROWTIME* matchRowtime, TIMESTAMP(3) window_start, TIMESTAMP(3) window_end, TIMESTAMP_LTZ(3) *ROWTIME* window_time)]
++- Match(partitionBy=[symbol], orderBy=[ts_ltz ASC], measures=[FINAL(A.price) AS price, FINAL(A.tax) AS tax, FINAL(MATCH_ROWTIME(*.ts_ltz)) AS matchRowtime], rowsPerMatch=[ONE ROW PER MATCH], after=[SKIP TO NEXT ROW], pattern=[_UTF-16LE'A'], define=[{A=>(PREV(A.$2, 0), 0)}]), rowType=[RecordType(VARCHAR(2147483647) symbol, INTEGER price, INTEGER tax, TIMESTAMP_LTZ(3) *ROWTIME* matchRowtime)]
+   +- Exchange(distribution=[hash[symbol]]), rowType=[RecordType(VARCHAR(2147483647) symbol, TIMESTAMP_LTZ(3) *ROWTIME* ts_ltz, INTEGER price, INTEGER tax)]
+      +- WatermarkAssigner(rowtime=[ts_ltz], watermark=[-(ts_ltz, 1000:INTERVAL SECOND)]), rowType=[RecordType(VARCHAR(2147483647) symbol, TIMESTAMP_LTZ(3) *ROWTIME* ts_ltz, INTEGER price, INTEGER tax)]
+         +- TableSourceScan(table=[[default_catalog, default_database, Ticker]], fields=[symbol, ts_ltz, price, tax]), rowType=[RecordType(VARCHAR(2147483647) symbol, TIMESTAMP_WITH_LOCAL_TIME_ZONE(3) ts_ltz, INTEGER price, INTEGER tax)]
+]]>
+    </Resource>
+  </TestCase>
 </Root>

--- a/flink-table/flink-table-planner/src/test/resources/org/apache/flink/table/planner/plan/stream/sql/MatchRecognizeTest.xml
+++ b/flink-table/flink-table-planner/src/test/resources/org/apache/flink/table/planner/plan/stream/sql/MatchRecognizeTest.xml
@@ -91,7 +91,7 @@ SELECT
 FROM Ticker1
 MATCH_RECOGNIZE (
   PARTITION BY symbol
-  ORDER BY ts_ltz
+  ORDER BY ts
   MEASURES
     A.price as price,
     A.tax as tax,
@@ -109,8 +109,8 @@ GROUP BY symbol, TUMBLE(matchRowtime, interval '3' second)
 LogicalProject(symbol=[$0], price=[$2], rowTime=[TUMBLE_ROWTIME($1)], startTime=[TUMBLE_START($1)])
 +- LogicalAggregate(group=[{0, 1}], price=[SUM($2)])
    +- LogicalProject(symbol=[$0], $f1=[$TUMBLE($3, 3000:INTERVAL SECOND)], price=[$1])
-      +- LogicalMatch(partition=[[0]], order=[[1 ASC-nulls-first]], outputFields=[[symbol, price, tax, matchRowtime]], allRows=[false], after=[FLAG(SKIP TO NEXT ROW)], pattern=[_UTF-16LE'A'], isStrictStarts=[false], isStrictEnds=[false], subsets=[[]], patternDefinitions=[[>(PREV(A.$2, 0), 0)]], inputFields=[[symbol, ts_ltz, price, tax]])
-         +- LogicalWatermarkAssigner(rowtime=[ts_ltz], watermark=[-($1, 1000:INTERVAL SECOND)])
+      +- LogicalMatch(partition=[[0]], order=[[1 ASC-nulls-first]], outputFields=[[symbol, price, tax, matchRowtime]], allRows=[false], after=[FLAG(SKIP TO NEXT ROW)], pattern=[_UTF-16LE'A'], isStrictStarts=[false], isStrictEnds=[false], subsets=[[]], patternDefinitions=[[>(PREV(A.$2, 0), 0)]], inputFields=[[symbol, ts, price, tax]])
+         +- LogicalWatermarkAssigner(rowtime=[ts], watermark=[-($1, 1000:INTERVAL SECOND)])
             +- LogicalTableScan(table=[[default_catalog, default_database, Ticker1]])
 ]]>
     </Resource>
@@ -120,10 +120,10 @@ Calc(select=[symbol, price, CAST(w$rowtime) AS rowTime, w$start AS startTime])
 +- GroupWindowAggregate(groupBy=[symbol], window=[TumblingGroupWindow('w$, matchRowtime, 3000)], properties=[w$start, w$end, w$rowtime, w$proctime], select=[symbol, SUM(price) AS price, start('w$) AS w$start, end('w$) AS w$end, rowtime('w$) AS w$rowtime, proctime('w$) AS w$proctime])
    +- Exchange(distribution=[hash[symbol]])
       +- Calc(select=[symbol, matchRowtime, price])
-         +- Match(partitionBy=[symbol], orderBy=[ts_ltz ASC], measures=[FINAL(A.price) AS price, FINAL(A.tax) AS tax, FINAL(MATCH_ROWTIME()) AS matchRowtime], rowsPerMatch=[ONE ROW PER MATCH], after=[SKIP TO NEXT ROW], pattern=[_UTF-16LE'A'], define=[{A=>(PREV(A.$2, 0), 0)}])
+         +- Match(partitionBy=[symbol], orderBy=[ts ASC], measures=[FINAL(A.price) AS price, FINAL(A.tax) AS tax, FINAL(MATCH_ROWTIME()) AS matchRowtime], rowsPerMatch=[ONE ROW PER MATCH], after=[SKIP TO NEXT ROW], pattern=[_UTF-16LE'A'], define=[{A=>(PREV(A.$2, 0), 0)}])
             +- Exchange(distribution=[hash[symbol]])
-               +- WatermarkAssigner(rowtime=[ts_ltz], watermark=[-(ts_ltz, 1000:INTERVAL SECOND)])
-                  +- TableSourceScan(table=[[default_catalog, default_database, Ticker1]], fields=[symbol, ts_ltz, price, tax])
+               +- WatermarkAssigner(rowtime=[ts], watermark=[-(ts, 1000:INTERVAL SECOND)])
+                  +- TableSourceScan(table=[[default_catalog, default_database, Ticker1]], fields=[symbol, ts, price, tax])
 ]]>
     </Resource>
   </TestCase>

--- a/flink-table/flink-table-planner/src/test/scala/org/apache/flink/table/planner/plan/stream/sql/MatchRecognizeTest.scala
+++ b/flink-table/flink-table-planner/src/test/scala/org/apache/flink/table/planner/plan/stream/sql/MatchRecognizeTest.scala
@@ -50,10 +50,10 @@ class MatchRecognizeTest extends TableTestBase {
       """
         |CREATE TABLE Ticker1 (
         | `symbol` STRING,
-        | `ts_ltz` TIMESTAMP(3),
+        | `ts` TIMESTAMP(3),
         | `price` INT,
         | `tax` INT,
-        | WATERMARK FOR `ts_ltz` AS `ts_ltz` - INTERVAL '1' SECOND
+        | WATERMARK FOR `ts` AS `ts` - INTERVAL '1' SECOND
         |) WITH (
         | 'connector' = 'values'
         |)
@@ -70,7 +70,7 @@ class MatchRecognizeTest extends TableTestBase {
          |FROM Ticker1
          |MATCH_RECOGNIZE (
          |  PARTITION BY symbol
-         |  ORDER BY ts_ltz
+         |  ORDER BY ts
          |  MEASURES
          |    A.price as price,
          |    A.tax as tax,
@@ -224,9 +224,10 @@ class MatchRecognizeTest extends TableTestBase {
   @Test
   def testMatchRowtimeWithoutArgumentOnRowtimeLTZ(): Unit = {
     thrown.expectMessage(
-      "MATCH_ROWTIME() could only be used when input stream does not contain " +
-        "row time attribute with TIMESTAMP_LTZ type.\n" +
-        "Please pass rowtime attribute field as input argument of MATCH_ROWTIME function.")
+      "MATCH_ROWTIME(rowtimeField) should be used when input stream " +
+        "contains rowtime attribute with TIMESTAMP_LTZ type.\n" +
+        "Please pass rowtime attribute field as input argument of " +
+        "MATCH_ROWTIME(rowtimeField) function.")
     thrown.expect(classOf[AssertionError])
 
     val sqlQuery =
@@ -319,7 +320,8 @@ class MatchRecognizeTest extends TableTestBase {
   @Test
   def testMatchRowtimeWithRexCallAsArg(): Unit = {
     thrown.expectMessage(
-      "The function MATCH_ROWTIME requires argument to be a field reference, but is 'PLUS'.")
+      "The function MATCH_ROWTIME requires a field reference as argument, " +
+        "but actual argument is 'PLUS'.")
     thrown.expect(classOf[ValidationException])
 
     val sqlQuery =

--- a/flink-table/flink-table-planner/src/test/scala/org/apache/flink/table/planner/plan/stream/sql/MatchRecognizeTest.scala
+++ b/flink-table/flink-table-planner/src/test/scala/org/apache/flink/table/planner/plan/stream/sql/MatchRecognizeTest.scala
@@ -112,6 +112,7 @@ class MatchRecognizeTest extends TableTestBase {
     util.verifyRelPlan(sqlQuery)
   }
 
+  @Test
   def testWindowTVFOnMatchRecognizeOnRowtimeLTZ(): Unit = {
     val sqlQuery =
       s"""
@@ -321,7 +322,7 @@ class MatchRecognizeTest extends TableTestBase {
   def testMatchRowtimeWithRexCallAsArg(): Unit = {
     thrown.expectMessage(
       "The function MATCH_ROWTIME requires a field reference as argument, " +
-        "but actual argument is 'PLUS'.")
+        "but actual argument is not a simple field reference.")
     thrown.expect(classOf[ValidationException])
 
     val sqlQuery =

--- a/flink-table/flink-table-planner/src/test/scala/org/apache/flink/table/planner/runtime/stream/sql/MatchRecognizeITCase.scala
+++ b/flink-table/flink-table-planner/src/test/scala/org/apache/flink/table/planner/runtime/stream/sql/MatchRecognizeITCase.scala
@@ -409,7 +409,7 @@ class MatchRecognizeITCase(backend: StateBackendMode) extends StreamingWithState
          |  MEASURES
          |    A.price as price,
          |    A.tax as tax,
-         |    MATCH_ROWTIME() as matchRowtime
+         |    MATCH_ROWTIME(ts_ltz) as matchRowtime
          |  ONE ROW PER MATCH
          |  PATTERN (A)
          |  DEFINE
@@ -424,8 +424,8 @@ class MatchRecognizeITCase(backend: StateBackendMode) extends StreamingWithState
     env.execute()
 
     val expected = List(
-      "ACME,3,1970-01-01T08:00:02.999,1970-01-01T08:00",
-      "ACME,2,1970-01-01T08:00:05.999,1970-01-01T08:00:03")
+      "ACME,3,1970-01-01T00:00:02.999Z,1970-01-01T08:00",
+      "ACME,2,1970-01-01T00:00:05.999Z,1970-01-01T08:00:03")
     assertEquals(expected.sorted, sink.getAppendResults.sorted)
   }
 


### PR DESCRIPTION
## What is the purpose of the change

This pr aims to update `MATCH_ROWTIME` function. After update, `MATCH_ROWTIME` function could receive no operand or one operand which is a field reference with row time attribute. If there is no operand, the function returns row time attribute with TIMESTAMP. Else, return type is same with operand type.

## Brief change log

  - Add `MatchRowTimeFunction` class to do operand checker and return type inference.
  - Update `FlinkSqlOperatorTable` to use `MatchRowTimeFunction`
  - Add validate in `FlinkLogicalMatch` to check `MATCH_ROWTIME()` could only be used when input stream does not contain row time attribute with TIMESTAMP_LTZ type.
  - Simplify `RelTimeIndicatorConverter` because it does not need to take `MATCH_ROWTIME()` type infer and propagation into consideration.

## Verifying this change

  - Add UT in `MatchRecognizeTest`
  - Fix wrong results of ITCase: `MatchRecognizeITCase#testWindowedGroupingAppliedToMatchRecognizeOnLtzRowtime` 

## Does this pull request potentially affect one of the following parts:

  - Dependencies (does it add or upgrade a dependency): (no)
  - The public API, i.e., is any changed class annotated with `@Public(Evolving)`: (no)
  - The serializers: (no)
  - The runtime per-record code paths (performance sensitive): (no)
  - Anything that affects deployment or recovery: JobManager (and its components), Checkpointing, Kubernetes/Yarn, ZooKeeper: (no)
  - The S3 file system connector: (no )

## Documentation

  - Does this pull request introduce a new feature? (no)
  - If yes, how is the feature documented? (not applicable)
