### PR TITLE
[FLINK-24031] Extend vcs.xml

### DIFF
--- a/.idea/vcs.xml
+++ b/.idea/vcs.xml
@@ -1,20 +1,4 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<!--
-  ~ Licensed to the Apache Software Foundation (ASF) under one or more
-  ~ contributor license agreements.  See the NOTICE file distributed with
-  ~ this work for additional information regarding copyright ownership.
-  ~ The ASF licenses this file to You under the Apache License, Version 2.0
-  ~ (the "License"); you may not use this file except in compliance with
-  ~ the License.  You may obtain a copy of the License at
-  ~
-  ~    http://www.apache.org/licenses/LICENSE-2.0
-  ~
-  ~ Unless required by applicable law or agreed to in writing, software
-  ~ distributed under the License is distributed on an "AS IS" BASIS,
-  ~ WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
-  ~ See the License for the specific language governing permissions and
-  ~ limitations under the License.
--->
 <project version="4">
   <component name="IssueNavigationConfiguration">
     <option name="links">
@@ -27,7 +11,7 @@
           <option name="issueRegexp" value="FLIP\-\d+" />
           <option name="linkRegexp" value="https://cwiki.apache.org/confluence/display/FLINK/$0" />
         </IssueNavigationLink>
-          <IssueNavigationLink>
+        <IssueNavigationLink>
           <option name="issueRegexp" value="#(\d+)" />
           <option name="linkRegexp" value="https://github.com/apache/flink/pull/$1" />
         </IssueNavigationLink>
@@ -36,5 +20,6 @@
   </component>
   <component name="VcsDirectoryMappings">
     <mapping directory="$PROJECT_DIR$" vcs="Git" />
+    <mapping directory="$PROJECT_DIR$/docs/themes/book" vcs="Git" />
   </component>
 </project>


### PR DESCRIPTION
This PR modifies the vcs.xml to include any changes that _my_ IDE makes automatically. It fixes a formatting issues, removes the license (which is unnecessary because it's not part of the source release), and it adds the git subdirectory for the documentation.