### PR TITLE
[FLINK-24186][table-planner] Allow multiple rowtime attributes for collect() and print()

### DIFF
--- a/flink-table/flink-table-planner/src/main/java/org/apache/flink/table/planner/connectors/CollectDynamicSink.java
+++ b/flink-table/flink-table-planner/src/main/java/org/apache/flink/table/planner/connectors/CollectDynamicSink.java
@@ -49,7 +49,7 @@ import java.util.function.Function;
 
 /** Table sink for {@link TableResult#collect()}. */
 @Internal
-final class CollectDynamicSink implements DynamicTableSink {
+public final class CollectDynamicSink implements DynamicTableSink {
 
     private final ObjectIdentifier tableIdentifier;
     private final DataType consumedDataType;

--- a/flink-table/flink-table-planner/src/main/java/org/apache/flink/table/planner/plan/nodes/exec/batch/BatchExecSink.java
+++ b/flink-table/flink-table-planner/src/main/java/org/apache/flink/table/planner/plan/nodes/exec/batch/BatchExecSink.java
@@ -56,6 +56,7 @@ public class BatchExecSink extends CommonExecSink implements BatchExecNode<Objec
     protected Transformation<Object> translateToPlanInternal(PlannerBase planner) {
         final Transformation<RowData> inputTransform =
                 (Transformation<RowData>) getInputEdges().get(0).translateToPlan(planner);
-        return createSinkTransformation(planner, inputTransform, -1, false);
+        final DynamicTableSink tableSink = tableSinkSpec.getTableSink(planner.getFlinkContext());
+        return createSinkTransformation(planner, inputTransform, tableSink, -1, false);
     }
 }

--- a/flink-table/flink-table-planner/src/main/java/org/apache/flink/table/planner/plan/nodes/exec/common/CommonExecSink.java
+++ b/flink-table/flink-table-planner/src/main/java/org/apache/flink/table/planner/plan/nodes/exec/common/CommonExecSink.java
@@ -117,9 +117,9 @@ public abstract class CommonExecSink extends ExecNodeBase<Object>
     protected Transformation<Object> createSinkTransformation(
             PlannerBase planner,
             Transformation<RowData> inputTransform,
+            DynamicTableSink tableSink,
             int rowtimeFieldIndex,
             boolean upsertMaterialize) {
-        final DynamicTableSink tableSink = tableSinkSpec.getTableSink(planner.getFlinkContext());
         final ResolvedSchema schema = tableSinkSpec.getCatalogTable().getResolvedSchema();
         final SinkRuntimeProvider runtimeProvider =
                 tableSink.getSinkRuntimeProvider(new SinkRuntimeProviderContext(isBounded));

--- a/flink-table/flink-table-planner/src/test/scala/org/apache/flink/table/api/TableITCase.scala
+++ b/flink-table/flink-table-planner/src/test/scala/org/apache/flink/table/api/TableITCase.scala
@@ -24,9 +24,12 @@ import org.apache.flink.table.api.bridge.java.StreamTableEnvironment
 import org.apache.flink.table.api.internal.TableEnvironmentImpl
 import org.apache.flink.table.catalog.{Column, ResolvedSchema}
 import org.apache.flink.table.planner.utils.TestTableSourceSinks
+import org.apache.flink.test.util.AbstractTestBase
 import org.apache.flink.types.{Row, RowKind}
 import org.apache.flink.util.{CollectionUtil, TestLogger}
 
+import org.hamcrest.MatcherAssert.assertThat
+import org.hamcrest.Matchers.containsInAnyOrder
 import org.junit.Assert.{assertEquals, assertNotEquals, assertTrue}
 import org.junit.rules.{ExpectedException, TemporaryFolder}
 import org.junit.runner.RunWith
@@ -35,9 +38,10 @@ import org.junit.{Before, Rule, Test}
 
 import _root_.java.lang.{Long => JLong}
 import _root_.java.util
+import java.time.Instant
 
 @RunWith(classOf[Parameterized])
-class TableITCase(tableEnvName: String, isStreaming: Boolean) extends TestLogger {
+class TableITCase(tableEnvName: String, isStreaming: Boolean) extends AbstractTestBase {
 
   // used for accurate exception information checking.
   val expectedException: ExpectedException = ExpectedException.none()
@@ -165,6 +169,35 @@ class TableITCase(tableEnvName: String, isStreaming: Boolean) extends TestLogger
     assertEquals(expected, actual)
   }
 
+  @Test
+  def testCollectWithMultiRowtime(): Unit = {
+    tEnv.executeSql(
+      """
+        |CREATE TABLE MyTableWithRowtime1 (
+        |  ts AS TO_TIMESTAMP_LTZ(id, 3),
+        |  WATERMARK FOR ts AS ts - INTERVAL '1' MINUTE)
+        |LIKE MyTable""".stripMargin)
+    tEnv.executeSql(
+      """
+        |CREATE TABLE MyTableWithRowtime2 (
+        |  ts AS TO_TIMESTAMP_LTZ(id, 3),
+        |  WATERMARK FOR ts AS ts - INTERVAL '1' MINUTE)
+        |LIKE MyTable""".stripMargin)
+
+    val tableResult = tEnv.executeSql(
+      """
+        |SELECT MyTableWithRowtime1.ts, MyTableWithRowtime2.ts
+        |FROM MyTableWithRowtime1, MyTableWithRowtime2
+        |WHERE
+        |  MyTableWithRowtime1.first = MyTableWithRowtime2.first AND
+        |  MyTableWithRowtime1.ts = MyTableWithRowtime2.ts""".stripMargin)
+
+    val expected = for (i <- 1 to 8) yield
+      Row.ofKind(RowKind.INSERT, Instant.ofEpochMilli(i), Instant.ofEpochMilli(i))
+
+    val actual = CollectionUtil.iteratorToList(tableResult.collect())
+    assertThat(actual, containsInAnyOrder(expected: _*))
+  }
 }
 
 object TableITCase {

--- a/flink-table/flink-table-planner/src/test/scala/org/apache/flink/table/planner/runtime/stream/table/TableSinkITCase.scala
+++ b/flink-table/flink-table-planner/src/test/scala/org/apache/flink/table/planner/runtime/stream/table/TableSinkITCase.scala
@@ -430,8 +430,9 @@ class TableSinkITCase extends StreamingTestBase {
       .select('num, 'w.rowtime as 'rowtime1, 'w.rowtime as 'rowtime2)
 
     thrown.expect(classOf[TableException])
-    thrown.expectMessage("Found more than one rowtime field: [rowtime1, rowtime2] " +
-      "in the query when insert into 'default_catalog.default_database.sink'")
+    thrown.expectMessage(
+      "The query contains more than one rowtime attribute column [rowtime1, rowtime2] for " +
+        "writing into table 'default_catalog.default_database.sink'.")
     table.executeInsert("sink")
   }
 


### PR DESCRIPTION
## What is the purpose of the change

Reduces friction by not throwing an exception for multi-rowtime queries for `collect()` and `print()`.

## Verifying this change

This change added tests and can be verified as follows: `TableITCase`.

## Does this pull request potentially affect one of the following parts:

  - Dependencies (does it add or upgrade a dependency): no
  - The public API, i.e., is any changed class annotated with `@Public(Evolving)`: no
  - The serializers: no
  - The runtime per-record code paths (performance sensitive): no
  - Anything that affects deployment or recovery: JobManager (and its components), Checkpointing, Kubernetes/Yarn, ZooKeeper: no
  - The S3 file system connector: no

## Documentation

  - Does this pull request introduce a new feature? no
  - If yes, how is the feature documented? not applicable
