### PR TITLE
[FLINK-24184][task] Introduce lock to guard against race conditions around shouldInterruptOnCancel

### DIFF
--- a/flink-runtime/src/main/java/org/apache/flink/runtime/jobgraph/tasks/AbstractInvokable.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/jobgraph/tasks/AbstractInvokable.java
@@ -27,6 +27,7 @@ import org.apache.flink.runtime.checkpoint.CheckpointOptions;
 import org.apache.flink.runtime.execution.Environment;
 import org.apache.flink.runtime.jobgraph.OperatorID;
 import org.apache.flink.runtime.operators.coordination.OperatorEvent;
+import org.apache.flink.runtime.taskmanager.Task;
 import org.apache.flink.util.FlinkException;
 import org.apache.flink.util.SerializedValue;
 
@@ -82,8 +83,13 @@ public abstract class AbstractInvokable
     public void cleanUp(@Nullable Throwable throwable) throws Exception {}
 
     @Override
-    public boolean shouldInterruptOnCancel() {
-        return true;
+    public void maybeInterruptOnCancel(
+            Thread toInterrupt, @Nullable String taskName, @Nullable Long timeout) {
+        if (taskName != null && timeout != null) {
+            Task.logTaskThreadStackTrace(toInterrupt, taskName, timeout, "interrupting");
+        }
+
+        toInterrupt.interrupt();
     }
 
     // ------------------------------------------------------------------------

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/jobgraph/tasks/TaskInvokable.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/jobgraph/tasks/TaskInvokable.java
@@ -95,9 +95,13 @@ public interface TaskInvokable {
     boolean isUsingNonBlockingInput();
 
     /**
-     * Checks whether the task should be interrupted during cancellation. This method is check both
-     * for the initial interrupt, as well as for the repeated interrupt. If this method returns true
-     * then no further interrupts will happen.
+     * Checks whether the task should be interrupted during cancellation and if so, execute the
+     * specified {@code Runnable interruptAction}.
+     *
+     * @param toInterrupt
+     * @param taskName optional taskName to log stack trace
+     * @param timeout optional timeout to log stack trace
      */
-    boolean shouldInterruptOnCancel();
+    void maybeInterruptOnCancel(
+            Thread toInterrupt, @Nullable String taskName, @Nullable Long timeout);
 }

--- a/flink-streaming-java/src/main/java/org/apache/flink/streaming/runtime/tasks/StreamTask.java
+++ b/flink-streaming-java/src/main/java/org/apache/flink/streaming/runtime/tasks/StreamTask.java
@@ -65,6 +65,7 @@ import org.apache.flink.runtime.state.StateBackend;
 import org.apache.flink.runtime.state.StateBackendLoader;
 import org.apache.flink.runtime.state.ttl.TtlTimeProvider;
 import org.apache.flink.runtime.taskmanager.DispatcherThreadFactory;
+import org.apache.flink.runtime.taskmanager.Task;
 import org.apache.flink.runtime.throughput.ThroughputCalculator;
 import org.apache.flink.streaming.api.TimeCharacteristic;
 import org.apache.flink.streaming.api.environment.ExecutionCheckpointingOptions;
@@ -111,6 +112,7 @@ import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
 import javax.annotation.Nullable;
+import javax.annotation.concurrent.GuardedBy;
 
 import java.io.IOException;
 import java.util.ArrayList;
@@ -295,7 +297,10 @@ public abstract class StreamTask<OUT, OP extends StreamOperator<OUT>>
 
     private final Environment environment;
 
-    private volatile boolean shouldInterruptOnCancel = true;
+    private final Object shouldInterruptOnCancelLock = new Object();
+
+    @GuardedBy("shouldInterruptOnCancelLock")
+    private boolean shouldInterruptOnCancel = true;
 
     // ------------------------------------------------------------------------
 
@@ -892,7 +897,7 @@ public abstract class StreamTask<OUT, OP extends StreamOperator<OUT>>
         // that block and stall shutdown.
         // Additionally, the cancellation watch dog will issue a hard-cancel (kill the TaskManager
         // process) as a backup in case some shutdown procedure blocks outside our control.
-        shouldInterruptOnCancel = false;
+        disableInterruptOnCancel();
 
         // clear any previously issued interrupt for a more graceful shutdown
         Thread.interrupted();
@@ -1728,9 +1733,24 @@ public abstract class StreamTask<OUT, OP extends StreamOperator<OUT>>
         return true;
     }
 
+    private void disableInterruptOnCancel() {
+        synchronized (shouldInterruptOnCancelLock) {
+            shouldInterruptOnCancel = false;
+        }
+    }
+
     @Override
-    public boolean shouldInterruptOnCancel() {
-        return shouldInterruptOnCancel;
+    public void maybeInterruptOnCancel(
+            Thread toInterrupt, @Nullable String taskName, @Nullable Long timeout) {
+        synchronized (shouldInterruptOnCancelLock) {
+            if (shouldInterruptOnCancel) {
+                if (taskName != null && timeout != null) {
+                    Task.logTaskThreadStackTrace(toInterrupt, taskName, timeout, "interrupting");
+                }
+
+                toInterrupt.interrupt();
+            }
+        }
     }
 
     @Override


### PR DESCRIPTION
Previously there was a potential race condition in disabling interrupts while closing resources.
It used be guarded by a volatile variable, but there might have been a race condition when:
1. interrupter thread first checked the shouldInterruptOnCancel flag
2. shouldInterruptOnCancel flag switched to false as Task/StreamTask entered cleaning up phase
3. interrupter issued an interrupt while Task/StreamTask are closing/releasing resources, potentially causing a memory leak

## Verifying this change

It would be very difficult to provide a test coverage for this bug.

## Does this pull request potentially affect one of the following parts:

  - Dependencies (does it add or upgrade a dependency): (yes / **no**)
  - The public API, i.e., is any changed class annotated with `@Public(Evolving)`: (yes / **no**)
  - The serializers: (yes / **no** / don't know)
  - The runtime per-record code paths (performance sensitive): (yes / **no** / don't know)
  - Anything that affects deployment or recovery: JobManager (and its components), Checkpointing, Kubernetes/Yarn, ZooKeeper: (yes / **no** / don't know)
  - The S3 file system connector: (yes / **no** / don't know)

## Documentation

  - Does this pull request introduce a new feature? (yes / **no**)
  - If yes, how is the feature documented? (**not applicable** / docs / JavaDocs / not documented)
