### PR TITLE
[FLINK-24197] Guard against CLRF being split across chunks

### DIFF
--- a/flink-runtime/src/test/java/org/apache/flink/runtime/rest/MultipartUploadResource.java
+++ b/flink-runtime/src/test/java/org/apache/flink/runtime/rest/MultipartUploadResource.java
@@ -135,7 +135,10 @@ public class MultipartUploadResource extends ExternalResource {
                 (request, restfulGateway) -> {
                     // the default verifier checks for identiy (i.e. same name and content) of all
                     // uploaded files
-                    List<Path> expectedFiles = Arrays.asList(file1.toPath(), file2.toPath());
+                    List<Path> expectedFiles =
+                            getFilesToUpload().stream()
+                                    .map(File::toPath)
+                                    .collect(Collectors.toList());
                     List<Path> uploadedFiles =
                             request.getUploadedFiles().stream()
                                     .map(File::toPath)

--- a/flink-runtime/src/test/java/org/apache/flink/runtime/rest/MultipartUploadResource.java
+++ b/flink-runtime/src/test/java/org/apache/flink/runtime/rest/MultipartUploadResource.java
@@ -62,7 +62,6 @@ import java.util.Collections;
 import java.util.Comparator;
 import java.util.List;
 import java.util.Objects;
-import java.util.Random;
 import java.util.concurrent.CompletableFuture;
 import java.util.stream.Collectors;
 import java.util.stream.Stream;
@@ -112,7 +111,8 @@ public class MultipartUploadResource extends ExternalResource {
 
         file1 = temporaryFolder.newFile();
         try (RandomAccessFile rw = new RandomAccessFile(file1, "rw")) {
-            rw.setLength(1024 * 1024 * 64);
+            // magic value that reliably reproduced https://github.com/netty/netty/issues/11668
+            rw.setLength(5043444);
         }
         file2 = temporaryFolder.newFile();
         Files.write(file2.toPath(), "world".getBytes(ConfigConstants.DEFAULT_CHARSET));
@@ -455,13 +455,13 @@ public class MultipartUploadResource extends ExternalResource {
     /** Simple test {@link RequestBody}. */
     protected static final class TestRequestBody implements RequestBody {
         private static final String FIELD_NAME_INDEX = "index";
-        private static final Random RANDOM = new Random();
 
         @JsonProperty(FIELD_NAME_INDEX)
         private final int index;
 
         TestRequestBody() {
-            this(RANDOM.nextInt());
+            // magic value that reliably reproduced https://github.com/netty/netty/issues/11668
+            this(-766974635);
         }
 
         @JsonCreator


### PR DESCRIPTION
This PR adds a defense mechanism against https://github.com/netty/netty/issues/11668.
If the CRLF prefix of a multipart delimiter is split across 2 chunks an exception is thrown because Netty incorrectly treats CR as data.
If CR is the last byte of the current chunk, then we pessimistically assume that this case occurred.
We exclude the trailing CR from the current chunk, and add it to the front of the next received chunk.