### PR TITLE
[FLINK-24222] Migrate ReporterSetupTest to ContextClassLoaderExtension 

### DIFF
--- a/flink-runtime/src/test/java/org/apache/flink/runtime/metrics/ReporterSetupTest.java
+++ b/flink-runtime/src/test/java/org/apache/flink/runtime/metrics/ReporterSetupTest.java
@@ -62,7 +62,11 @@ class ReporterSetupTest {
                             TestReporter2.class.getName(),
                             TestReporter11.class.getName(),
                             TestReporter12.class.getName(),
-                            TestReporter13.class.getName())
+                            TestReporter13.class.getName(),
+                            TestReporterFactory.class.getName(),
+                            FailingFactory.class.getName(),
+                            InstantiationTypeTrackingTestReporterFactory.class.getName(),
+                            ConfigExposingReporterFactory.class.getName())
                     .build();
 
     /** TestReporter1 class only for type differentiation. */

--- a/flink-runtime/src/test/resources/META-INF/services/org.apache.flink.metrics.reporter.MetricReporterFactory
+++ b/flink-runtime/src/test/resources/META-INF/services/org.apache.flink.metrics.reporter.MetricReporterFactory
@@ -13,8 +13,4 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-org.apache.flink.runtime.metrics.ReporterSetupTest$TestReporterFactory
-org.apache.flink.runtime.metrics.ReporterSetupTest$FailingFactory
-org.apache.flink.runtime.metrics.ReporterSetupTest$InstantiationTypeTrackingTestReporterFactory
-org.apache.flink.runtime.metrics.ReporterSetupTest$ConfigExposingReporterFactory
 org.apache.flink.runtime.testutils.InMemoryReporter$Factory


### PR DESCRIPTION
This reduces noise in other tests/modules that use reporters.