### PR TITLE
[FLINK-24236] Migrate tests to factory approach

### DIFF
--- a/flink-connectors/flink-connector-kafka/src/test/java/org/apache/flink/streaming/connectors/kafka/KafkaTestBase.java
+++ b/flink-connectors/flink-connector-kafka/src/test/java/org/apache/flink/streaming/connectors/kafka/KafkaTestBase.java
@@ -23,7 +23,7 @@ import org.apache.flink.configuration.Configuration;
 import org.apache.flink.configuration.MemorySize;
 import org.apache.flink.configuration.MetricOptions;
 import org.apache.flink.configuration.TaskManagerOptions;
-import org.apache.flink.metrics.jmx.JMXReporter;
+import org.apache.flink.metrics.jmx.JMXReporterFactory;
 import org.apache.flink.runtime.client.JobExecutionException;
 import org.apache.flink.streaming.api.environment.StreamExecutionEnvironment;
 import org.apache.flink.streaming.util.TestStreamEnvironment;
@@ -134,8 +134,8 @@ public abstract class KafkaTestBase extends TestLogger {
         flinkConfig.setString(
                 ConfigConstants.METRICS_REPORTER_PREFIX
                         + "my_reporter."
-                        + MetricOptions.REPORTER_CLASS.key(),
-                JMXReporter.class.getName());
+                        + MetricOptions.REPORTER_FACTORY_CLASS.key(),
+                JMXReporterFactory.class.getName());
         return flinkConfig;
     }
 

--- a/flink-metrics/flink-metrics-jmx/src/test/java/org/apache/flink/runtime/jobmanager/JMXJobManagerMetricTest.java
+++ b/flink-metrics/flink-metrics-jmx/src/test/java/org/apache/flink/runtime/jobmanager/JMXJobManagerMetricTest.java
@@ -26,7 +26,7 @@ import org.apache.flink.configuration.ConfigConstants;
 import org.apache.flink.configuration.Configuration;
 import org.apache.flink.configuration.MetricOptions;
 import org.apache.flink.core.testutils.OneShotLatch;
-import org.apache.flink.metrics.jmx.JMXReporter;
+import org.apache.flink.metrics.jmx.JMXReporterFactory;
 import org.apache.flink.runtime.checkpoint.CheckpointRetentionPolicy;
 import org.apache.flink.runtime.execution.Environment;
 import org.apache.flink.runtime.jobgraph.JobGraph;
@@ -79,8 +79,8 @@ class JMXJobManagerMetricTest {
         flinkConfiguration.setString(
                 ConfigConstants.METRICS_REPORTER_PREFIX
                         + "test."
-                        + MetricOptions.REPORTER_CLASS.key(),
-                JMXReporter.class.getName());
+                        + MetricOptions.REPORTER_FACTORY_CLASS.key(),
+                JMXReporterFactory.class.getName());
         flinkConfiguration.setString(MetricOptions.SCOPE_NAMING_JM_JOB, "jobmanager.<job_name>");
 
         return flinkConfiguration;

--- a/flink-runtime/src/test/java/org/apache/flink/runtime/metrics/ReporterSetupTest.java
+++ b/flink-runtime/src/test/java/org/apache/flink/runtime/metrics/ReporterSetupTest.java
@@ -29,10 +29,11 @@ import org.apache.flink.metrics.reporter.MetricReporter;
 import org.apache.flink.metrics.reporter.MetricReporterFactory;
 import org.apache.flink.runtime.metrics.scope.ScopeFormat;
 import org.apache.flink.runtime.metrics.util.TestReporter;
-import org.apache.flink.util.TestLogger;
+import org.apache.flink.util.TestLoggerExtension;
 
 import org.junit.Assert;
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
 
 import java.util.Collections;
 import java.util.List;
@@ -47,7 +48,8 @@ import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertTrue;
 
 /** Tests for the {@link ReporterSetup}. */
-public class ReporterSetupTest extends TestLogger {
+@ExtendWith(TestLoggerExtension.class)
+class ReporterSetupTest {
 
     /** TestReporter1 class only for type differentiation. */
     static class TestReporter1 extends TestReporter {}
@@ -57,7 +59,7 @@ public class ReporterSetupTest extends TestLogger {
 
     /** Verifies that a reporter can be configured with all it's arguments being forwarded. */
     @Test
-    public void testReporterArgumentForwarding() {
+    void testReporterArgumentForwarding() {
         final Configuration config = new Configuration();
 
         configureReporter1(config);
@@ -74,7 +76,7 @@ public class ReporterSetupTest extends TestLogger {
      * Verifies that multiple reporters can be configured with all their arguments being forwarded.
      */
     @Test
-    public void testSeveralReportersWithArgumentForwarding() {
+    void testSeveralReportersWithArgumentForwarding() {
         final Configuration config = new Configuration();
 
         configureReporter1(config);
@@ -102,7 +104,7 @@ public class ReporterSetupTest extends TestLogger {
      * reporters.
      */
     @Test
-    public void testActivateOneReporterAmongTwoDeclared() {
+    void testActivateOneReporterAmongTwoDeclared() {
         final Configuration config = new Configuration();
 
         configureReporter1(config);
@@ -119,7 +121,7 @@ public class ReporterSetupTest extends TestLogger {
     }
 
     @Test
-    public void testReporterSetupSupplier() throws Exception {
+    void testReporterSetupSupplier() throws Exception {
         final Configuration config = new Configuration();
 
         config.setString(
@@ -139,7 +141,7 @@ public class ReporterSetupTest extends TestLogger {
 
     /** Verifies that multiple reporters are instantiated correctly. */
     @Test
-    public void testMultipleReporterInstantiation() throws Exception {
+    void testMultipleReporterInstantiation() throws Exception {
         Configuration config = new Configuration();
 
         config.setString(
@@ -235,7 +237,7 @@ public class ReporterSetupTest extends TestLogger {
     }
 
     @Test
-    public void testVariableExclusionParsing() throws Exception {
+    void testVariableExclusionParsing() throws Exception {
         final String excludedVariable1 = "foo";
         final String excludedVariable2 = "foo";
         final Configuration config = new Configuration();
@@ -265,7 +267,7 @@ public class ReporterSetupTest extends TestLogger {
 
     /** Verifies that a factory configuration is correctly parsed. */
     @Test
-    public void testFactoryParsing() throws Exception {
+    void testFactoryParsing() throws Exception {
         final Configuration config = new Configuration();
         config.setString(
                 ConfigConstants.METRICS_REPORTER_PREFIX
@@ -287,7 +289,7 @@ public class ReporterSetupTest extends TestLogger {
      * are configured.
      */
     @Test
-    public void testFactoryPrioritization() throws Exception {
+    void testFactoryPrioritization() throws Exception {
         final Configuration config = new Configuration();
         config.setString(
                 ConfigConstants.METRICS_REPORTER_PREFIX
@@ -313,7 +315,7 @@ public class ReporterSetupTest extends TestLogger {
 
     /** Verifies that an error thrown by a factory does not affect the setup of other reporters. */
     @Test
-    public void testFactoryFailureIsolation() throws Exception {
+    void testFactoryFailureIsolation() throws Exception {
         final Configuration config = new Configuration();
         config.setString(
                 ConfigConstants.METRICS_REPORTER_PREFIX
@@ -333,7 +335,7 @@ public class ReporterSetupTest extends TestLogger {
 
     /** Verifies that factory/reflection approaches can be mixed freely. */
     @Test
-    public void testMixedSetupsFactoryParsing() throws Exception {
+    void testMixedSetupsFactoryParsing() throws Exception {
         final Configuration config = new Configuration();
         config.setString(
                 ConfigConstants.METRICS_REPORTER_PREFIX
@@ -362,7 +364,7 @@ public class ReporterSetupTest extends TestLogger {
     }
 
     @Test
-    public void testFactoryArgumentForwarding() throws Exception {
+    void testFactoryArgumentForwarding() throws Exception {
         final Configuration config = new Configuration();
         config.setString(
                 ConfigConstants.METRICS_REPORTER_PREFIX
@@ -382,7 +384,7 @@ public class ReporterSetupTest extends TestLogger {
      * InstantiateViaFactory}.
      */
     @Test
-    public void testFactoryAnnotation() {
+    void testFactoryAnnotation() {
         final Configuration config = new Configuration();
         config.setString(
                 ConfigConstants.METRICS_REPORTER_PREFIX
@@ -406,7 +408,7 @@ public class ReporterSetupTest extends TestLogger {
      * org.apache.flink.metrics.reporter.InterceptInstantiationViaReflection}.
      */
     @Test
-    public void testReflectionInterception() {
+    void testReflectionInterception() {
         final Configuration config = new Configuration();
         config.setString(
                 ConfigConstants.METRICS_REPORTER_PREFIX
@@ -434,7 +436,7 @@ public class ReporterSetupTest extends TestLogger {
     }
 
     @Test
-    public void testAdditionalVariablesParsing() {
+    void testAdditionalVariablesParsing() {
         final String tag1 = "foo";
         final String tagValue1 = "bar";
         final String tag2 = "fizz";

--- a/flink-runtime/src/test/java/org/apache/flink/runtime/metrics/groups/AbstractMetricGroupTest.java
+++ b/flink-runtime/src/test/java/org/apache/flink/runtime/metrics/groups/AbstractMetricGroupTest.java
@@ -160,18 +160,8 @@ public class AbstractMetricGroupTest extends TestLogger {
         config.setString(
                 ConfigConstants.METRICS_REPORTER_PREFIX
                         + "test1."
-                        + MetricOptions.REPORTER_CLASS.key(),
-                CollectingMetricsReporter.class.getName());
-        config.setString(
-                ConfigConstants.METRICS_REPORTER_PREFIX
-                        + "test1."
                         + MetricOptions.REPORTER_SCOPE_DELIMITER.key(),
                 "-");
-        config.setString(
-                ConfigConstants.METRICS_REPORTER_PREFIX
-                        + "test2."
-                        + MetricOptions.REPORTER_CLASS.key(),
-                CollectingMetricsReporter.class.getName());
         config.setString(
                 ConfigConstants.METRICS_REPORTER_PREFIX
                         + "test2."

--- a/flink-runtime/src/test/java/org/apache/flink/runtime/metrics/groups/MetricGroupTest.java
+++ b/flink-runtime/src/test/java/org/apache/flink/runtime/metrics/groups/MetricGroupTest.java
@@ -19,9 +19,7 @@
 package org.apache.flink.runtime.metrics.groups;
 
 import org.apache.flink.api.common.JobID;
-import org.apache.flink.configuration.ConfigConstants;
 import org.apache.flink.configuration.Configuration;
-import org.apache.flink.configuration.MetricOptions;
 import org.apache.flink.metrics.CharacterFilter;
 import org.apache.flink.metrics.Gauge;
 import org.apache.flink.metrics.Metric;
@@ -34,6 +32,7 @@ import org.apache.flink.runtime.metrics.MetricRegistryConfiguration;
 import org.apache.flink.runtime.metrics.MetricRegistryImpl;
 import org.apache.flink.runtime.metrics.MetricRegistryTestUtils;
 import org.apache.flink.runtime.metrics.NoOpMetricRegistry;
+import org.apache.flink.runtime.metrics.ReporterSetup;
 import org.apache.flink.runtime.metrics.dump.QueryScopeInfo;
 import org.apache.flink.runtime.metrics.scope.ScopeFormat;
 import org.apache.flink.runtime.metrics.util.DummyCharacterFilter;
@@ -43,6 +42,8 @@ import org.apache.flink.util.TestLogger;
 import org.junit.After;
 import org.junit.Before;
 import org.junit.Test;
+
+import java.util.Arrays;
 
 import static org.hamcrest.Matchers.containsString;
 import static org.hamcrest.Matchers.not;
@@ -241,14 +242,11 @@ public class MetricGroupTest extends TestLogger {
     @Test
     public void testLogicalScopeShouldIgnoreValueGroupName() throws Exception {
         Configuration config = new Configuration();
-        config.setString(
-                ConfigConstants.METRICS_REPORTER_PREFIX
-                        + "test."
-                        + MetricOptions.REPORTER_CLASS.key(),
-                TestReporter.class.getName());
 
         MetricRegistryImpl registry =
-                new MetricRegistryImpl(MetricRegistryTestUtils.fromConfiguration(config));
+                new MetricRegistryImpl(
+                        MetricRegistryTestUtils.defaultMetricRegistryConfiguration(),
+                        Arrays.asList(ReporterSetup.forReporter("test", new TestReporter())));
         try {
             GenericMetricGroup root =
                     new GenericMetricGroup(

--- a/flink-runtime/src/test/java/org/apache/flink/runtime/metrics/util/TestReporter.java
+++ b/flink-runtime/src/test/java/org/apache/flink/runtime/metrics/util/TestReporter.java
@@ -22,9 +22,13 @@ import org.apache.flink.metrics.Metric;
 import org.apache.flink.metrics.MetricConfig;
 import org.apache.flink.metrics.MetricGroup;
 import org.apache.flink.metrics.reporter.AbstractReporter;
+import org.apache.flink.metrics.reporter.MetricReporter;
+import org.apache.flink.metrics.reporter.MetricReporterFactory;
+
+import java.util.Properties;
 
 /** No-op reporter implementation. */
-public class TestReporter extends AbstractReporter {
+public class TestReporter extends AbstractReporter implements MetricReporterFactory {
 
     @Override
     public void open(MetricConfig config) {}
@@ -41,5 +45,10 @@ public class TestReporter extends AbstractReporter {
     @Override
     public String filterCharacters(String input) {
         return input;
+    }
+
+    @Override
+    public MetricReporter createMetricReporter(Properties properties) {
+        return this;
     }
 }


### PR DESCRIPTION
Configuring the reporter factory class is the recommended way to configure a reporter.