### PR TITLE
[FLINK-23381][state] Back-pressure on reaching state change to upload limit

### DIFF
--- a/flink-dstl/flink-dstl-dfs/src/main/java/org/apache/flink/changelog/fs/FsStateChangelogOptions.java
+++ b/flink-dstl/flink-dstl-dfs/src/main/java/org/apache/flink/changelog/fs/FsStateChangelogOptions.java
@@ -73,7 +73,8 @@ public class FsStateChangelogOptions {
                                     + ". Once reached, accumulated changes are persisted immediately. "
                                     + "This is different from "
                                     + PREEMPTIVE_PERSIST_THRESHOLD.key()
-                                    + " as it happens AFTER the checkpoint and potentially for state changes of multiple operators.");
+                                    + " as it happens AFTER the checkpoint and potentially for state changes of multiple operators. "
+                                    + "Must not exceed in-flight data limit (see below)");
 
     public static final ConfigOption<MemorySize> UPLOAD_BUFFER_SIZE =
             ConfigOptions.key("dstl.dfs.upload.buffer-size")
@@ -93,7 +94,14 @@ public class FsStateChangelogOptions {
                     .defaultValue(MemorySize.parse("100Mb"))
                     .withDescription(
                             "Max amount of data allowed to be in-flight. "
-                                    + "Upon reaching this limit the task will fail");
+                                    + "Upon reaching this limit the task will be back-pressured. "
+                                    + " I.e., snapshotting will block; normal processing will block if "
+                                    + PREEMPTIVE_PERSIST_THRESHOLD.key()
+                                    + " is set and reached. "
+                                    + "The limit is applied to the total size of in-flight changes if multiple "
+                                    + "operators/backends are using the same changelog storage. "
+                                    + "Must be greater than or equal to "
+                                    + PERSIST_SIZE_THRESHOLD.key());
 
     public static final ConfigOption<String> RETRY_POLICY =
             ConfigOptions.key("dstl.dfs.upload.retry-policy")

--- a/flink-dstl/flink-dstl-dfs/src/main/java/org/apache/flink/changelog/fs/FsStateChangelogStorage.java
+++ b/flink-dstl/flink-dstl-dfs/src/main/java/org/apache/flink/changelog/fs/FsStateChangelogStorage.java
@@ -21,6 +21,7 @@ import org.apache.flink.annotation.Experimental;
 import org.apache.flink.annotation.VisibleForTesting;
 import org.apache.flink.configuration.Configuration;
 import org.apache.flink.core.fs.Path;
+import org.apache.flink.runtime.io.AvailabilityProvider;
 import org.apache.flink.runtime.state.KeyGroupRange;
 import org.apache.flink.runtime.state.changelog.ChangelogStateHandleStreamImpl;
 import org.apache.flink.runtime.state.changelog.StateChangelogHandleReader;
@@ -91,5 +92,10 @@ public class FsStateChangelogStorage
     @Override
     public void close() throws Exception {
         uploader.close();
+    }
+
+    @Override
+    public AvailabilityProvider getAvailabilityProvider() {
+        return uploader.getAvailabilityProvider();
     }
 }

--- a/flink-dstl/flink-dstl-dfs/src/main/java/org/apache/flink/changelog/fs/StateChangeUploader.java
+++ b/flink-dstl/flink-dstl-dfs/src/main/java/org/apache/flink/changelog/fs/StateChangeUploader.java
@@ -19,6 +19,7 @@ package org.apache.flink.changelog.fs;
 
 import org.apache.flink.configuration.ReadableConfig;
 import org.apache.flink.core.fs.Path;
+import org.apache.flink.runtime.io.AvailabilityProvider;
 import org.apache.flink.runtime.state.changelog.SequenceNumber;
 
 import javax.annotation.concurrent.ThreadSafe;
@@ -87,6 +88,10 @@ interface StateChangeUploader extends AutoCloseable {
                         config.get(NUM_UPLOAD_THREADS),
                         config.get(IN_FLIGHT_DATA_LIMIT).getBytes());
         return batchingStore;
+    }
+
+    default AvailabilityProvider getAvailabilityProvider() {
+        return () -> AvailabilityProvider.AVAILABLE;
     }
 
     @ThreadSafe

--- a/flink-dstl/flink-dstl-dfs/src/main/java/org/apache/flink/changelog/fs/UploadThrottle.java
+++ b/flink-dstl/flink-dstl-dfs/src/main/java/org/apache/flink/changelog/fs/UploadThrottle.java
@@ -1,0 +1,61 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.flink.changelog.fs;
+
+import javax.annotation.concurrent.NotThreadSafe;
+
+import static org.apache.flink.util.Preconditions.checkState;
+
+/** Helper class to throttle upload requests when the in-flight data size limit is exceeded. */
+@NotThreadSafe
+class UploadThrottle {
+
+    private final long maxBytesInFlight;
+
+    private long inFlightBytesCounter = 0;
+
+    UploadThrottle(long maxBytesInFlight) {
+        this.maxBytesInFlight = maxBytesInFlight;
+    }
+
+    /**
+     * Seize <b>bytes</b> capacity. It is the caller responsibility to ensure at least some capacity
+     * {@link #hasCapacity() is available}. <strong>After</strong> this call, the caller is allowed
+     * to actually use the seized capacity. When the capacity is not needed anymore, the caller is
+     * required to {@link #releaseCapacity(long) release} it. Called by the Task thread.
+     *
+     * @throws IllegalStateException if capacity is unavailable.
+     */
+    public void seizeCapacity(long bytes) throws IllegalStateException {
+        checkState(hasCapacity());
+        inFlightBytesCounter += bytes;
+    }
+
+    /**
+     * Release previously {@link #seizeCapacity(long) seized} capacity. Called by {@link
+     * BatchingStateChangeUploader} (IO thread).
+     */
+    public void releaseCapacity(long bytes) {
+        inFlightBytesCounter -= bytes;
+    }
+
+    /** Test whether some capacity is available. */
+    public boolean hasCapacity() {
+        return inFlightBytesCounter < maxBytesInFlight;
+    }
+}

--- a/flink-dstl/flink-dstl-dfs/src/test/java/org/apache/flink/changelog/fs/TestingStateChangeUploader.java
+++ b/flink-dstl/flink-dstl-dfs/src/test/java/org/apache/flink/changelog/fs/TestingStateChangeUploader.java
@@ -22,15 +22,15 @@ import org.apache.flink.runtime.state.changelog.StateChange;
 import org.apache.flink.runtime.state.memory.ByteStreamStateHandle;
 
 import java.io.IOException;
-import java.util.ArrayList;
 import java.util.Collection;
 import java.util.List;
+import java.util.concurrent.CopyOnWriteArrayList;
 
 import static java.util.stream.Collectors.toList;
 
 class TestingStateChangeUploader implements StateChangeUploader {
-    private final Collection<StateChangeSet> uploaded = new ArrayList<>();
-    private final List<UploadTask> tasks = new ArrayList<>();
+    private final Collection<StateChangeSet> uploaded = new CopyOnWriteArrayList<>();
+    private final List<UploadTask> tasks = new CopyOnWriteArrayList<>();
     private boolean closed;
 
     @Override

--- a/flink-libraries/flink-state-processing-api/src/main/java/org/apache/flink/state/api/runtime/SavepointTaskStateManager.java
+++ b/flink-libraries/flink-state-processing-api/src/main/java/org/apache/flink/state/api/runtime/SavepointTaskStateManager.java
@@ -103,7 +103,7 @@ final class SavepointTaskStateManager implements TaskStateManager {
     @Nullable
     @Override
     public StateChangelogStorage<?> getStateChangelogStorage() {
-        throw new UnsupportedOperationException(MSG);
+        return null;
     }
 
     @Override

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/state/changelog/StateChangelogStorage.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/state/changelog/StateChangelogStorage.java
@@ -19,6 +19,7 @@
 package org.apache.flink.runtime.state.changelog;
 
 import org.apache.flink.annotation.Internal;
+import org.apache.flink.runtime.io.AvailabilityProvider;
 import org.apache.flink.runtime.state.KeyGroupRange;
 
 /**
@@ -35,4 +36,8 @@ public interface StateChangelogStorage<Handle extends ChangelogStateHandle> exte
 
     @Override
     default void close() throws Exception {}
+
+    default AvailabilityProvider getAvailabilityProvider() {
+        return () -> AvailabilityProvider.AVAILABLE;
+    }
 }

--- a/flink-streaming-java/src/test/java/org/apache/flink/streaming/runtime/tasks/StreamTaskTest.java
+++ b/flink-streaming-java/src/test/java/org/apache/flink/streaming/runtime/tasks/StreamTaskTest.java
@@ -83,7 +83,7 @@ import org.apache.flink.runtime.state.StreamStateHandle;
 import org.apache.flink.runtime.state.TaskLocalStateStoreImpl;
 import org.apache.flink.runtime.state.TaskStateManager;
 import org.apache.flink.runtime.state.TaskStateManagerImpl;
-import org.apache.flink.runtime.state.changelog.StateChangelogStorage;
+import org.apache.flink.runtime.state.changelog.inmemory.InMemoryStateChangelogStorage;
 import org.apache.flink.runtime.state.memory.MemoryStateBackend;
 import org.apache.flink.runtime.taskmanager.AsynchronousException;
 import org.apache.flink.runtime.taskmanager.CheckpointResponder;
@@ -738,7 +738,7 @@ public class StreamTaskTest extends TestLogger {
                         new JobID(1L, 2L),
                         new ExecutionAttemptID(),
                         mock(TaskLocalStateStoreImpl.class),
-                        mock(StateChangelogStorage.class),
+                        new InMemoryStateChangelogStorage(),
                         null,
                         checkpointResponder);
 
@@ -931,7 +931,7 @@ public class StreamTaskTest extends TestLogger {
                         new JobID(1L, 2L),
                         new ExecutionAttemptID(),
                         mock(TaskLocalStateStoreImpl.class),
-                        mock(StateChangelogStorage.class),
+                        new InMemoryStateChangelogStorage(),
                         null,
                         checkpointResponder);
 


### PR DESCRIPTION
## What is the purpose of the change

Propagate back-pressure from changelog storage to (stream) task (record processing and checkpoionting).
The 1st commit replaces failing with blocking caller on reaching the limit.
The 2nd commit adds availability provider to StreamTask, so it shouldn't block in most cases. Checkpointing will still block.
The change wasn't benchmarked yet.

## Verifying this change
  - `BatchingStateChangeUploaderTest.testBackPressure`
  - `BatchingStateChangeUploaderTest.testInterruptedWhenBackPressured`

## Does this pull request potentially affect one of the following parts:

  - Dependencies (does it add or upgrade a dependency): no
  - The public API, i.e., is any changed class annotated with `@Public(Evolving)`: no
  - The serializers: no
  - The runtime per-record code paths (performance sensitive): yes
  - Anything that affects deployment or recovery: JobManager (and its components), Checkpointing, Kubernetes/Yarn/Mesos, ZooKeeper: no
  - The S3 file system connector: no

## Documentation

  - Does this pull request introduce a new feature? no
  - If yes, how is the feature documented? no
