### PR TITLE
[FLINK-23054][table-blink] Correct upsert optimization by upsert keys

### DIFF
--- a/docs/layouts/shortcodes/generated/execution_config_configuration.html
+++ b/docs/layouts/shortcodes/generated/execution_config_configuration.html
@@ -65,6 +65,12 @@ By default no operator is disabled.</td>
             <td>The NOT NULL column constraint on a table enforces that null values can't be inserted into the table. Flink supports 'error' (default) and 'drop' enforcement behavior. By default, Flink will check values and throw runtime exception when null values writing into NOT NULL columns. Users can change the behavior to 'drop' to silently drop such records without throwing exception.</td>
         </tr>
         <tr>
+            <td><h5>table.exec.sink.upsert-materialize</h5><br> <span class="label label-primary">Streaming</span></td>
+            <td style="word-wrap: break-word;">AUTO</td>
+            <td><p>Enum</p>Possible values: [NONE, AUTO, FORCE]</td>
+            <td>Because of the disorder of ChangeLog data caused by Shuffle in distributed system, the data received by Sink may not be the order of global upsert. So add upsert materialize operator before upsert sink. It receives the upstream changelog records and generate an upsert view for the downstream.<br />By default, the materialize operator will be added when a distributed disorder occurs on unique keys. You can also choose no materialization(NONE) or force materialization(FORCE).</td>
+        </tr>
+        <tr>
             <td><h5>table.exec.sort.async-merge-enabled</h5><br> <span class="label label-primary">Batch</span></td>
             <td style="word-wrap: break-word;">true</td>
             <td>Boolean</td>

--- a/flink-table/flink-table-api-java/src/main/java/org/apache/flink/table/api/config/ExecutionConfigOptions.java
+++ b/flink-table/flink-table-api-java/src/main/java/org/apache/flink/table/api/config/ExecutionConfigOptions.java
@@ -122,6 +122,25 @@ public class ExecutionConfigOptions {
                                     + "into NOT NULL columns. Users can change the behavior to 'drop' to "
                                     + "silently drop such records without throwing exception.");
 
+    @Documentation.TableOption(execMode = Documentation.ExecMode.STREAMING)
+    public static final ConfigOption<UpsertMaterialize> TABLE_EXEC_SINK_UPSERT_MATERIALIZE =
+            key("table.exec.sink.upsert-materialize")
+                    .enumType(UpsertMaterialize.class)
+                    .defaultValue(UpsertMaterialize.AUTO)
+                    .withDescription(
+                            Description.builder()
+                                    .text(
+                                            "Because of the disorder of ChangeLog data caused by Shuffle in distributed system, "
+                                                    + "the data received by Sink may not be the order of global upsert. "
+                                                    + "So add upsert materialize operator before upsert sink. It receives the "
+                                                    + "upstream changelog records and generate an upsert view for the downstream.")
+                                    .linebreak()
+                                    .text(
+                                            "By default, the materialize operator will be added when a distributed disorder "
+                                                    + "occurs on unique keys. You can also choose no materialization(NONE) "
+                                                    + "or force materialization(FORCE).")
+                                    .build());
+
     // ------------------------------------------------------------------------
     //  Sort Options
     // ------------------------------------------------------------------------
@@ -364,5 +383,18 @@ public class ExecutionConfigOptions {
         ERROR,
         /** Drop records when writing null values into NOT NULL column. */
         DROP
+    }
+
+    /** Upsert materialize strategy before sink. */
+    public enum UpsertMaterialize {
+
+        /** In no case will materialize operator be added. */
+        NONE,
+
+        /** Add materialize operator when a distributed disorder occurs on unique keys. */
+        AUTO,
+
+        /** Add materialize operator in any case. */
+        FORCE
     }
 }

--- a/flink-table/flink-table-planner-blink/src/main/java/org/apache/flink/table/planner/plan/nodes/exec/batch/BatchExecSink.java
+++ b/flink-table/flink-table-planner-blink/src/main/java/org/apache/flink/table/planner/plan/nodes/exec/batch/BatchExecSink.java
@@ -57,6 +57,6 @@ public class BatchExecSink extends CommonExecSink implements BatchExecNode<Objec
         final Transformation<RowData> inputTransform =
                 (Transformation<RowData>) getInputEdges().get(0).translateToPlan(planner);
         return createSinkTransformation(
-                planner.getExecEnv(), planner.getTableConfig(), inputTransform, -1);
+                planner.getExecEnv(), planner.getTableConfig(), inputTransform, -1, false);
     }
 }

--- a/flink-table/flink-table-planner-blink/src/main/scala/org/apache/flink/table/planner/plan/rules/logical/TemporalJoinRewriteWithUniqueKeyRule.scala
+++ b/flink-table/flink-table-planner-blink/src/main/scala/org/apache/flink/table/planner/plan/rules/logical/TemporalJoinRewriteWithUniqueKeyRule.scala
@@ -161,21 +161,21 @@ class TemporalJoinRewriteWithUniqueKeyRule extends RelOptRule(
     val rightFields = snapshot.getRowType.getFieldList
     val fmq = FlinkRelMetadataQuery.reuseOrCreate(snapshot.getCluster.getMetadataQuery)
 
-    val uniqueKeySet = fmq.getUniqueKeys(snapshot.getInput())
+    val upsertKeySet = fmq.getUpsertKeys(snapshot.getInput())
     val fields = snapshot.getRowType.getFieldList
 
-    if (uniqueKeySet != null && uniqueKeySet.size() > 0) {
+    if (upsertKeySet != null && upsertKeySet.size() > 0) {
       val leftFieldCnt = leftInput.getRowType.getFieldCount
-      val uniqueKeySetInputRefs = uniqueKeySet.filter(_.nonEmpty)
+      val upsertKeySetInputRefs = upsertKeySet.filter(_.nonEmpty)
         .map(_.toArray
           .map(fields)
-          // build InputRef of unique key in snapshot
+          // build InputRef of upsert key in snapshot
           .map(f => rexBuilder.makeInputRef(
             f.getType,
             leftFieldCnt + rightFields.indexOf(f)))
           .toSeq)
-      // select shortest unique key as primary key
-      uniqueKeySetInputRefs
+      // select shortest upsert key as primary key
+      upsertKeySetInputRefs
         .toArray
         .sortBy(_.length)
         .headOption

--- a/flink-table/flink-table-planner-blink/src/test/resources/org/apache/flink/table/planner/plan/stream/sql/TableSinkTest.xml
+++ b/flink-table/flink-table-planner-blink/src/test/resources/org/apache/flink/table/planner/plan/stream/sql/TableSinkTest.xml
@@ -105,11 +105,6 @@ Sink(table=[default_catalog.default_database.upsertSink], fields=[a, total_min],
 ]]>
     </Resource>
   </TestCase>
-  <TestCase name="testInsertMismatchTypeForEmptyChar">
-    <Resource name="sql">
-      <![CDATA[INSERT INTO my_sink SELECT a, '', '' FROM MyTable]]>
-    </Resource>
-  </TestCase>
   <TestCase name="testMetadataColumn">
     <Resource name="ast">
       <![CDATA[
@@ -240,6 +235,41 @@ Sink(table=[default_catalog.default_database.retractSink], fields=[cnt, a], chan
 ]]>
     </Resource>
   </TestCase>
+  <TestCase name="testSinkDisorderChangeLogWithRank">
+    <Resource name="sql">
+      <![CDATA[
+INSERT INTO SinkRankChangeLog
+SELECT person, sum_votes FROM
+ (SELECT person, sum_votes,
+   ROW_NUMBER() OVER (PARTITION BY vote_section ORDER BY sum_votes DESC) AS rank_number
+   FROM (SELECT person, SUM(votes) AS sum_votes, SUM(votes) / 2 AS vote_section FROM src
+      GROUP BY person))
+   WHERE rank_number < 10
+]]>
+    </Resource>
+    <Resource name="ast">
+      <![CDATA[
+LogicalSink(table=[default_catalog.default_database.SinkRankChangeLog], fields=[person, sum_votes])
++- LogicalProject(person=[$0], sum_votes=[$1])
+   +- LogicalFilter(condition=[<($2, 10)])
+      +- LogicalProject(person=[$0], sum_votes=[$1], rank_number=[ROW_NUMBER() OVER (PARTITION BY /($1, 2) ORDER BY $1 DESC NULLS LAST)])
+         +- LogicalAggregate(group=[{0}], sum_votes=[SUM($1)])
+            +- LogicalTableScan(table=[[default_catalog, default_database, src]])
+]]>
+    </Resource>
+    <Resource name="optimized exec plan">
+      <![CDATA[
+Sink(table=[default_catalog.default_database.SinkRankChangeLog], fields=[person, sum_votes], upsertMaterialize=[true])
++- Calc(select=[person, sum_votes])
+   +- Rank(strategy=[RetractStrategy], rankType=[ROW_NUMBER], rankRange=[rankStart=1, rankEnd=9], partitionBy=[$2], orderBy=[sum_votes DESC], select=[person, sum_votes, $2])
+      +- Exchange(distribution=[hash[$2]])
+         +- Calc(select=[person, sum_votes, (sum_votes / 2) AS $2])
+            +- GroupAggregate(groupBy=[person], select=[person, SUM(votes) AS sum_votes])
+               +- Exchange(distribution=[hash[person]])
+                  +- TableSourceScan(table=[[default_catalog, default_database, src]], fields=[person, votes])
+]]>
+    </Resource>
+  </TestCase>
   <TestCase name="testUpsertSinkWithFilter">
     <Resource name="ast">
       <![CDATA[
@@ -259,6 +289,40 @@ Sink(table=[default_catalog.default_database.upsertSink], fields=[a, cnt], chang
       +- Exchange(distribution=[hash[a]], changelogMode=[I])
          +- Calc(select=[a], changelogMode=[I])
             +- DataStreamScan(table=[[default_catalog, default_database, MyTable]], fields=[a, b, c], changelogMode=[I])
+]]>
+    </Resource>
+  </TestCase>
+  <TestCase name="testSinkDisorderChangeLogWithJoin">
+    <Resource name="sql">
+      <![CDATA[
+INSERT INTO SinkJoinChangeLog
+SELECT T.person, T.sum_votes, award.prize FROM
+   (SELECT person, SUM(votes) AS sum_votes FROM src GROUP BY person) T, award
+   WHERE T.sum_votes = award.votes
+]]>
+    </Resource>
+    <Resource name="ast">
+      <![CDATA[
+LogicalSink(table=[default_catalog.default_database.SinkJoinChangeLog], fields=[person, sum_votes, prize])
++- LogicalProject(person=[$0], sum_votes=[$1], prize=[$3])
+   +- LogicalFilter(condition=[=($1, $2)])
+      +- LogicalJoin(condition=[true], joinType=[inner])
+         :- LogicalAggregate(group=[{0}], sum_votes=[SUM($1)])
+         :  +- LogicalTableScan(table=[[default_catalog, default_database, src]])
+         +- LogicalTableScan(table=[[default_catalog, default_database, award]])
+]]>
+    </Resource>
+    <Resource name="optimized exec plan">
+      <![CDATA[
+Sink(table=[default_catalog.default_database.SinkJoinChangeLog], fields=[person, sum_votes, prize], upsertMaterialize=[true])
++- Calc(select=[person, sum_votes, prize])
+   +- Join(joinType=[InnerJoin], where=[(sum_votes = votes)], select=[person, sum_votes, votes, prize], leftInputSpec=[HasUniqueKey], rightInputSpec=[JoinKeyContainsUniqueKey])
+      :- Exchange(distribution=[hash[sum_votes]])
+      :  +- GroupAggregate(groupBy=[person], select=[person, SUM(votes) AS sum_votes])
+      :     +- Exchange(distribution=[hash[person]])
+      :        +- TableSourceScan(table=[[default_catalog, default_database, src]], fields=[person, votes])
+      +- Exchange(distribution=[hash[votes]])
+         +- TableSourceScan(table=[[default_catalog, default_database, award]], fields=[votes, prize])
 ]]>
     </Resource>
   </TestCase>

--- a/flink-table/flink-table-planner-blink/src/test/resources/org/apache/flink/table/planner/plan/stream/sql/join/JoinTest.xml
+++ b/flink-table/flink-table-planner-blink/src/test/resources/org/apache/flink/table/planner/plan/stream/sql/join/JoinTest.xml
@@ -423,6 +423,49 @@ Calc(select=[a1])
 ]]>
     </Resource>
   </TestCase>
+  <TestCase name="testJoinDisorderChangeLog">
+    <Resource name="sql">
+      <![CDATA[
+SELECT T1.person, T1.sum_votes, T1.prize, T2.age FROM
+ (SELECT T.person, T.sum_votes, award.prize FROM
+   (SELECT person, SUM(votes) AS sum_votes FROM src GROUP BY person) T,
+   award
+   WHERE T.sum_votes = award.votes) T1, people T2
+ WHERE T1.person = T2.person
+]]>
+    </Resource>
+    <Resource name="ast">
+      <![CDATA[
+LogicalProject(person=[$0], sum_votes=[$1], prize=[$2], age=[$4])
++- LogicalFilter(condition=[=($0, $3)])
+   +- LogicalJoin(condition=[true], joinType=[inner])
+      :- LogicalProject(person=[$0], sum_votes=[$1], prize=[$3])
+      :  +- LogicalFilter(condition=[=($1, $2)])
+      :     +- LogicalJoin(condition=[true], joinType=[inner])
+      :        :- LogicalAggregate(group=[{0}], sum_votes=[SUM($1)])
+      :        :  +- LogicalTableScan(table=[[default_catalog, default_database, src]])
+      :        +- LogicalTableScan(table=[[default_catalog, default_database, award]])
+      +- LogicalTableScan(table=[[default_catalog, default_database, people]])
+]]>
+    </Resource>
+    <Resource name="optimized exec plan">
+      <![CDATA[
+Calc(select=[person, sum_votes, prize, age])
++- Join(joinType=[InnerJoin], where=[(person = person0)], select=[person, sum_votes, prize, person0, age], leftInputSpec=[NoUniqueKey], rightInputSpec=[JoinKeyContainsUniqueKey])
+   :- Exchange(distribution=[hash[person]])
+   :  +- Calc(select=[person, sum_votes, prize])
+   :     +- Join(joinType=[InnerJoin], where=[(sum_votes = votes)], select=[person, sum_votes, votes, prize], leftInputSpec=[HasUniqueKey], rightInputSpec=[JoinKeyContainsUniqueKey])
+   :        :- Exchange(distribution=[hash[sum_votes]])
+   :        :  +- GroupAggregate(groupBy=[person], select=[person, SUM(votes) AS sum_votes])
+   :        :     +- Exchange(distribution=[hash[person]])
+   :        :        +- TableSourceScan(table=[[default_catalog, default_database, src]], fields=[person, votes])
+   :        +- Exchange(distribution=[hash[votes]])
+   :           +- TableSourceScan(table=[[default_catalog, default_database, award]], fields=[votes, prize])
+   +- Exchange(distribution=[hash[person]])
+      +- TableSourceScan(table=[[default_catalog, default_database, people]], fields=[person, age])
+]]>
+    </Resource>
+  </TestCase>
   <TestCase name="testJoinWithSort">
     <Resource name="sql">
       <![CDATA[

--- a/flink-table/flink-table-planner-blink/src/test/scala/org/apache/flink/table/planner/plan/stream/sql/join/JoinTest.scala
+++ b/flink-table/flink-table-planner-blink/src/test/scala/org/apache/flink/table/planner/plan/stream/sql/join/JoinTest.scala
@@ -299,4 +299,38 @@ class JoinTest extends TableTestBase {
         |""".stripMargin)
     util.verifyExecPlan("SELECT A.a1 FROM A LEFT JOIN tableWithCompositePk T ON A.a1 = T.pk1")
   }
+
+  @Test
+  def testJoinDisorderChangeLog(): Unit = {
+    util.tableEnv.executeSql(
+      """
+        |CREATE TABLE src (person String, votes BIGINT) WITH(
+        |  'connector' = 'values'
+        |)
+        |""".stripMargin)
+
+    util.tableEnv.executeSql(
+      """
+        |CREATE TABLE award (votes BIGINT, prize DOUBLE, PRIMARY KEY(votes) NOT ENFORCED) WITH(
+        |  'connector' = 'values'
+        |)
+        |""".stripMargin)
+
+    util.tableEnv.executeSql(
+      """
+        |CREATE TABLE people (person STRING, age INT, PRIMARY KEY(person) NOT ENFORCED) WITH(
+        |  'connector' = 'values'
+        |)
+        |""".stripMargin)
+
+    util.verifyExecPlan(
+      """
+        |SELECT T1.person, T1.sum_votes, T1.prize, T2.age FROM
+        | (SELECT T.person, T.sum_votes, award.prize FROM
+        |   (SELECT person, SUM(votes) AS sum_votes FROM src GROUP BY person) T,
+        |   award
+        |   WHERE T.sum_votes = award.votes) T1, people T2
+        | WHERE T1.person = T2.person
+        |""".stripMargin)
+  }
 }

--- a/flink-table/flink-table-planner-blink/src/test/scala/org/apache/flink/table/planner/runtime/stream/sql/TableSinkITCase.scala
+++ b/flink-table/flink-table-planner-blink/src/test/scala/org/apache/flink/table/planner/runtime/stream/sql/TableSinkITCase.scala
@@ -1,0 +1,157 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.flink.table.planner.runtime.stream.sql
+
+import org.apache.flink.table.planner.factories.TestValuesTableFactory
+import org.apache.flink.table.planner.runtime.utils.BatchTestBase.row
+import org.apache.flink.table.planner.runtime.utils.StreamingWithStateTestBase.StateBackendMode
+import org.apache.flink.table.planner.runtime.utils._
+
+import org.junit.Assert.assertEquals
+import org.junit.Test
+import org.junit.runner.RunWith
+import org.junit.runners.Parameterized
+
+import scala.collection.JavaConversions._
+
+@RunWith(classOf[Parameterized])
+class TableSinkITCase(mode: StateBackendMode) extends StreamingWithStateTestBase(mode) {
+
+  override def before(): Unit = {
+    super.before()
+
+    val srcDataId = TestValuesTableFactory.registerData(Seq(
+      row("jason", 1L),
+      row("jason", 1L),
+      row("jason", 1L),
+      row("jason", 1L)
+    ))
+    tEnv.executeSql(
+      s"""
+        |CREATE TABLE src (person String, votes BIGINT) WITH(
+        |  'connector' = 'values',
+        |  'data-id' = '$srcDataId'
+        |)
+        |""".stripMargin)
+
+    val awardDataId = TestValuesTableFactory.registerData(Seq(
+      row(1L, 5.2D),
+      row(2L, 12.1D),
+      row(3L, 18.3D),
+      row(4L, 22.5D)
+    ))
+    tEnv.executeSql(
+      s"""
+        |CREATE TABLE award (votes BIGINT, prize DOUBLE, PRIMARY KEY(votes) NOT ENFORCED) WITH(
+        |  'connector' = 'values',
+        |  'data-id' = '$awardDataId'
+        |)
+        |""".stripMargin)
+
+    val peopleDataId = TestValuesTableFactory.registerData(Seq(row("jason", 22)))
+    tEnv.executeSql(
+      s"""
+        |CREATE TABLE people (person STRING, age INT, PRIMARY KEY(person) NOT ENFORCED) WITH(
+        |  'connector' = 'values',
+        |  'data-id' = '$peopleDataId'
+        |)
+        |""".stripMargin)
+  }
+
+  @Test
+  def testJoinDisorderChangeLog(): Unit = {
+    tEnv.executeSql(
+      """
+        |CREATE TABLE JoinDisorderChangeLog (
+        |  person STRING, votes BIGINT, prize DOUBLE, age INT,
+        |  PRIMARY KEY(person) NOT ENFORCED) WITH(
+        |  'connector' = 'values',
+        |  'sink-insert-only' = 'false'
+        |)
+        |""".stripMargin)
+
+    tEnv.executeSql(
+      """
+        |INSERT INTO JoinDisorderChangeLog
+        |SELECT T1.person, T1.sum_votes, T1.prize, T2.age FROM
+        | (SELECT T.person, T.sum_votes, award.prize FROM
+        |   (SELECT person, SUM(votes) AS sum_votes FROM src GROUP BY person) T,
+        |   award
+        |   WHERE T.sum_votes = award.votes) T1, people T2
+        | WHERE T1.person = T2.person
+        |""".stripMargin).await()
+
+    val result = TestValuesTableFactory.getResults("JoinDisorderChangeLog")
+    val expected = List("+I[jason, 4, 22.5, 22]")
+    assertEquals(expected.sorted, result.sorted)
+  }
+
+  @Test
+  def testSinkDisorderChangeLog(): Unit = {
+    tEnv.executeSql(
+      """
+        |CREATE TABLE SinkDisorderChangeLog (
+        |  person STRING, votes BIGINT, prize DOUBLE,
+        |  PRIMARY KEY(person) NOT ENFORCED) WITH(
+        |  'connector' = 'values',
+        |  'sink-insert-only' = 'false'
+        |)
+        |""".stripMargin)
+
+    tEnv.executeSql(
+      """
+        |INSERT INTO SinkDisorderChangeLog
+        |SELECT T.person, T.sum_votes, award.prize FROM
+        |   (SELECT person, SUM(votes) AS sum_votes FROM src GROUP BY person) T, award
+        |   WHERE T.sum_votes = award.votes
+        |""".stripMargin).await()
+
+    val result = TestValuesTableFactory.getResults("SinkDisorderChangeLog")
+    val expected = List("+I[jason, 4, 22.5]")
+    assertEquals(expected.sorted, result.sorted)
+  }
+
+  @Test
+  def testSinkDisorderChangeLogWithRank(): Unit = {
+    tEnv.executeSql(
+      """
+        |CREATE TABLE SinkRankChangeLog (
+        |  person STRING, votes BIGINT,
+        |  PRIMARY KEY(person) NOT ENFORCED) WITH(
+        |  'connector' = 'values',
+        |  'sink-insert-only' = 'false'
+        |)
+        |""".stripMargin)
+
+    tEnv.executeSql(
+      """
+        |INSERT INTO SinkRankChangeLog
+        |SELECT person, sum_votes FROM
+        | (SELECT person, sum_votes,
+        |   ROW_NUMBER() OVER (PARTITION BY vote_section ORDER BY sum_votes DESC) AS rank_number
+        |   FROM (SELECT person, SUM(votes) AS sum_votes, SUM(votes) / 2 AS vote_section FROM src
+        |      GROUP BY person))
+        |   WHERE rank_number < 10
+        |""".stripMargin).await()
+
+    val result = TestValuesTableFactory.getResults("SinkRankChangeLog")
+    val expected = List("+I[jason, 4]")
+    assertEquals(expected.sorted, result.sorted)
+  }
+}

--- a/flink-table/flink-table-runtime-blink/src/main/java/org/apache/flink/table/runtime/operators/sink/SinkUpsertMaterializer.java
+++ b/flink-table/flink-table-runtime-blink/src/main/java/org/apache/flink/table/runtime/operators/sink/SinkUpsertMaterializer.java
@@ -1,0 +1,151 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.flink.table.runtime.operators.sink;
+
+import org.apache.flink.api.common.state.StateTtlConfig;
+import org.apache.flink.api.common.state.ValueState;
+import org.apache.flink.api.common.state.ValueStateDescriptor;
+import org.apache.flink.api.common.typeutils.TypeSerializer;
+import org.apache.flink.api.common.typeutils.base.ListSerializer;
+import org.apache.flink.streaming.api.operators.OneInputStreamOperator;
+import org.apache.flink.streaming.api.operators.TimestampedCollector;
+import org.apache.flink.streaming.runtime.streamrecord.StreamRecord;
+import org.apache.flink.table.data.RowData;
+import org.apache.flink.table.runtime.generated.GeneratedRecordEqualiser;
+import org.apache.flink.table.runtime.generated.RecordEqualiser;
+import org.apache.flink.table.runtime.operators.TableStreamOperator;
+
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import java.util.ArrayList;
+import java.util.Iterator;
+import java.util.List;
+
+import static org.apache.flink.types.RowKind.DELETE;
+import static org.apache.flink.types.RowKind.INSERT;
+import static org.apache.flink.types.RowKind.UPDATE_AFTER;
+
+/**
+ * A operator that maintains the records corresponding to the upsert keys in the state, it receives
+ * the upstream changelog records and generate an upsert view for the downstream.
+ *
+ * <ul>
+ *   <li>For insert record, append the state and collect current record.
+ *   <li>For delete record, delete in the state, collect delete record when the state is empty.
+ *   <li>For delete record, delete in the state, collect the last one when the state is not empty.
+ * </ul>
+ */
+public class SinkUpsertMaterializer extends TableStreamOperator<RowData>
+        implements OneInputStreamOperator<RowData, RowData> {
+
+    private static final long serialVersionUID = 1L;
+
+    private static final Logger LOG = LoggerFactory.getLogger(SinkUpsertMaterializer.class);
+
+    private static final String STATE_CLEARED_WARN_MSG =
+            "The state is cleared because of state ttl. This will result in incorrect result. "
+                    + "You can increase the state ttl to avoid this.";
+
+    private final StateTtlConfig ttlConfig;
+    private final TypeSerializer<RowData> serializer;
+    private final GeneratedRecordEqualiser generatedEqualiser;
+
+    private transient RecordEqualiser equaliser;
+    private transient ValueState<List<RowData>> state;
+    private transient TimestampedCollector<RowData> collector;
+
+    public SinkUpsertMaterializer(
+            StateTtlConfig ttlConfig,
+            TypeSerializer<RowData> serializer,
+            GeneratedRecordEqualiser generatedEqualiser) {
+        this.ttlConfig = ttlConfig;
+        this.serializer = serializer;
+        this.generatedEqualiser = generatedEqualiser;
+    }
+
+    @Override
+    public void open() throws Exception {
+        super.open();
+        this.equaliser =
+                generatedEqualiser.newInstance(getRuntimeContext().getUserCodeClassLoader());
+        ValueStateDescriptor<List<RowData>> descriptor =
+                new ValueStateDescriptor<>("values", new ListSerializer<>(serializer));
+        if (ttlConfig.isEnabled()) {
+            descriptor.enableTimeToLive(ttlConfig);
+        }
+        this.state = getRuntimeContext().getState(descriptor);
+        this.collector = new TimestampedCollector<>(output);
+    }
+
+    @Override
+    public void processElement(StreamRecord<RowData> element) throws Exception {
+        RowData row = element.getValue();
+        boolean isInsertOp = row.getRowKind() == INSERT || row.getRowKind() == UPDATE_AFTER;
+        // Always set the RowKind to INSERT, so that we can compare rows correctly (RowKind will
+        // be ignored)
+        row.setRowKind(INSERT);
+        List<RowData> values = state.value();
+        if (values == null) {
+            values = new ArrayList<>(2);
+        }
+
+        if (isInsertOp) {
+            values.add(row);
+            // Update to this new one
+            collector.collect(row);
+        } else {
+            int lastIndex = values.size() - 1;
+            int index = removeFirst(values, row);
+            if (index == -1) {
+                LOG.info(STATE_CLEARED_WARN_MSG);
+                return;
+            }
+            if (values.isEmpty()) {
+                // Delete this row
+                row.setRowKind(DELETE);
+                collector.collect(row);
+            } else if (index == lastIndex) {
+                // Last one removed
+                // Update to newer
+                collector.collect(values.get(values.size() - 1));
+            }
+        }
+
+        if (values.isEmpty()) {
+            state.clear();
+        } else {
+            state.update(values);
+        }
+    }
+
+    private int removeFirst(List<RowData> values, RowData remove) {
+        Iterator<RowData> iterator = values.iterator();
+        int i = 0;
+        while (iterator.hasNext()) {
+            RowData row = iterator.next();
+            if (equaliser.equals(row, remove)) {
+                iterator.remove();
+                return i;
+            }
+            i++;
+        }
+        return -1;
+    }
+}

--- a/flink-table/flink-table-runtime-blink/src/test/java/org/apache/flink/table/runtime/operators/sink/SinkUpsertMaterializerTest.java
+++ b/flink-table/flink-table-runtime-blink/src/test/java/org/apache/flink/table/runtime/operators/sink/SinkUpsertMaterializerTest.java
@@ -1,0 +1,127 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.flink.table.runtime.operators.sink;
+
+import org.apache.flink.api.common.state.StateTtlConfig;
+import org.apache.flink.streaming.runtime.streamrecord.StreamRecord;
+import org.apache.flink.streaming.util.KeyedOneInputStreamOperatorTestHarness;
+import org.apache.flink.streaming.util.OneInputStreamOperatorTestHarness;
+import org.apache.flink.table.data.GenericRowData;
+import org.apache.flink.table.data.RowData;
+import org.apache.flink.table.runtime.generated.GeneratedRecordEqualiser;
+import org.apache.flink.table.runtime.generated.RecordEqualiser;
+import org.apache.flink.table.runtime.keyselector.RowDataKeySelector;
+import org.apache.flink.table.runtime.typeutils.RowDataSerializer;
+import org.apache.flink.table.runtime.util.StateConfigUtil;
+import org.apache.flink.table.types.logical.IntType;
+import org.apache.flink.table.types.logical.LogicalType;
+import org.apache.flink.table.types.logical.VarCharType;
+import org.apache.flink.table.utils.HandwrittenSelectorUtil;
+import org.apache.flink.types.RowKind;
+
+import org.junit.Assert;
+import org.junit.Test;
+
+import java.util.ArrayList;
+import java.util.Collections;
+import java.util.List;
+
+import static org.apache.flink.table.runtime.util.StreamRecordUtils.deleteRecord;
+import static org.apache.flink.table.runtime.util.StreamRecordUtils.insertRecord;
+import static org.apache.flink.table.runtime.util.StreamRecordUtils.row;
+
+/** Test for {@link SinkUpsertMaterializer}. */
+public class SinkUpsertMaterializerTest {
+
+    private final StateTtlConfig ttlConfig = StateConfigUtil.createTtlConfig(1000);
+    private final LogicalType[] types = new LogicalType[] {new IntType(), new VarCharType()};
+    private final RowDataSerializer serializer = new RowDataSerializer(types);
+    private final RowDataKeySelector keySelector =
+            HandwrittenSelectorUtil.getRowDataSelector(new int[0], types);
+    private final GeneratedRecordEqualiser equaliser =
+            new GeneratedRecordEqualiser("", "", new Object[0]) {
+
+                @Override
+                public RecordEqualiser newInstance(ClassLoader classLoader) {
+                    return new TestRecordEqualiser();
+                }
+            };
+
+    @Test
+    public void test() throws Exception {
+        SinkUpsertMaterializer materializer =
+                new SinkUpsertMaterializer(ttlConfig, serializer, equaliser);
+        KeyedOneInputStreamOperatorTestHarness<RowData, RowData, RowData> testHarness =
+                new KeyedOneInputStreamOperatorTestHarness<>(
+                        materializer, keySelector, keySelector.getProducedType());
+
+        testHarness.open();
+
+        testHarness.setStateTtlProcessingTime(1);
+
+        testHarness.processElement(insertRecord(1, "a1"));
+        Assert.assertEquals(Collections.singletonList(row(1, "a1")), toRows(testHarness));
+
+        testHarness.processElement(insertRecord(1, "a2"));
+        Assert.assertEquals(Collections.singletonList(row(1, "a2")), toRows(testHarness));
+
+        testHarness.processElement(insertRecord(1, "a3"));
+        Assert.assertEquals(Collections.singletonList(row(1, "a3")), toRows(testHarness));
+
+        testHarness.processElement(deleteRecord(1, "a2"));
+        Assert.assertEquals(Collections.emptyList(), toRows(testHarness));
+
+        testHarness.processElement(deleteRecord(1, "a3"));
+        Assert.assertEquals(Collections.singletonList(row(1, "a1")), toRows(testHarness));
+
+        testHarness.processElement(deleteRecord(1, "a1"));
+        RowData deleteRow = row(1, "a1");
+        deleteRow.setRowKind(RowKind.DELETE);
+        Assert.assertEquals(Collections.singletonList(deleteRow), toRows(testHarness));
+
+        testHarness.processElement(insertRecord(1, "a4"));
+        Assert.assertEquals(Collections.singletonList(row(1, "a4")), toRows(testHarness));
+
+        testHarness.setStateTtlProcessingTime(1002);
+
+        testHarness.processElement(deleteRecord(1, "a4"));
+        Assert.assertEquals(Collections.emptyList(), toRows(testHarness));
+
+        testHarness.close();
+    }
+
+    private List<RowData> toRows(OneInputStreamOperatorTestHarness<RowData, RowData> harness) {
+        Object o;
+        List<RowData> ret = new ArrayList<>();
+        while ((o = harness.getOutput().poll()) != null) {
+            RowData value = (RowData) ((StreamRecord) o).getValue();
+            GenericRowData newRow = GenericRowData.of(value.getInt(0), value.getString(1));
+            newRow.setRowKind(value.getRowKind());
+            ret.add(newRow);
+        }
+        return ret;
+    }
+
+    private static class TestRecordEqualiser implements RecordEqualiser {
+        @Override
+        public boolean equals(RowData row1, RowData row2) {
+            return row1.getInt(0) == row2.getInt(0) && row1.getString(1).equals(row2.getString(1));
+        }
+    }
+}


### PR DESCRIPTION
Cherry-pick #16239

## What is the purpose of the change

After FLINK-22901.

We can use upsert keys to fix upsert join, upsert rank, and upsert sink.

- For join and rank: if input has no upsert keys, do not use upsert optimization.
- For upsert sink: if input has unique keys but no upsert keys, we need add a materialize operator to produce upsert records.

## Brief change log

- Join should use upsert keys instead of unique keys to do upsert
- Rank should use upsert keys instead of unique keys to do upsert
- TemporalJoin should use upsert keys instead of unique keys to do upsert
- Introduce materialize operator to produce upsert records before sink.

## Verifying this change

- UpsertTest
- UpsertITCase

## Does this pull request potentially affect one of the following parts:

  - Dependencies (does it add or upgrade a dependency): (yes / no) no
  - The public API, i.e., is any changed class annotated with `@Public(Evolving)`: (yes / no) no
  - The serializers: (yes / no / don't know) no
  - The runtime per-record code paths (performance sensitive): (yes / no / don't know) no
  - Anything that affects deployment or recovery: JobManager (and its components), Checkpointing, Kubernetes/Yarn/Mesos, ZooKeeper: (yes / no / don't know) no
  - The S3 file system connector: (yes / no / don't know) no

## Documentation

  - Does this pull request introduce a new feature? (yes / no) no