### PR TITLE
[FLINK-24243][python] Cleanup code to use latest API to avoid warnings

### DIFF
--- a/flink-python/pyflink/datastream/tests/test_stream_execution_environment.py
+++ b/flink-python/pyflink/datastream/tests/test_stream_execution_environment.py
@@ -446,7 +446,7 @@ class StreamExecutionEnvironmentTests(PyFlinkTestCase):
         from pyflink.table.expressions import col
         add_three = udf(plus_three, result_type=DataTypes.BIGINT())
 
-        tab = t_env.from_data_stream(ds, 'a') \
+        tab = t_env.from_data_stream(ds, col('a')) \
                    .select(add_three(col('a')))
         result = [i[0] for i in tab.execute().collect()]
         expected = [6, 7, 8, 9, 10]

--- a/flink-python/pyflink/fn_execution/state_impl.py
+++ b/flink-python/pyflink/fn_execution/state_impl.py
@@ -22,6 +22,11 @@ from enum import Enum
 from functools import partial
 from io import BytesIO
 
+try:
+    collectionsAbc = collections.abc
+except AttributeError:
+    collectionsAbc = collections
+
 from apache_beam.coders import coder_impl
 from apache_beam.portability.api import beam_fn_api_pb2
 from apache_beam.runners.worker.bundle_processor import SynchronousBagRuntimeState
@@ -674,7 +679,7 @@ class CachingMapStateHandler(object):
         return state_key.SerializeToString()
 
 
-class RemovableConcatIterator(collections.Iterator):
+class RemovableConcatIterator(collectionsAbc.Iterator):
 
     def __init__(self, internal_map_state, first, second):
         self._first = first

--- a/flink-python/pyflink/fn_execution/state_impl.py
+++ b/flink-python/pyflink/fn_execution/state_impl.py
@@ -23,9 +23,9 @@ from functools import partial
 from io import BytesIO
 
 try:
-    collectionsAbc = collections.abc
-except AttributeError:
-    collectionsAbc = collections
+    import collections.abc as collections_abc
+except:
+    import collections as collections_abc  # type: ignore
 
 from apache_beam.coders import coder_impl
 from apache_beam.portability.api import beam_fn_api_pb2
@@ -679,7 +679,7 @@ class CachingMapStateHandler(object):
         return state_key.SerializeToString()
 
 
-class RemovableConcatIterator(collectionsAbc.Iterator):
+class RemovableConcatIterator(collections_abc.Iterator):
 
     def __init__(self, internal_map_state, first, second):
         self._first = first

--- a/flink-python/pyflink/fn_execution/state_impl.py
+++ b/flink-python/pyflink/fn_execution/state_impl.py
@@ -22,11 +22,6 @@ from enum import Enum
 from functools import partial
 from io import BytesIO
 
-try:
-    import collections.abc as collections_abc
-except:
-    import collections as collections_abc  # type: ignore
-
 from apache_beam.coders import coder_impl
 from apache_beam.portability.api import beam_fn_api_pb2
 from apache_beam.runners.worker.bundle_processor import SynchronousBagRuntimeState
@@ -679,7 +674,7 @@ class CachingMapStateHandler(object):
         return state_key.SerializeToString()
 
 
-class RemovableConcatIterator(collections_abc.Iterator):
+class RemovableConcatIterator(collections.abc.Iterator):
 
     def __init__(self, internal_map_state, first, second):
         self._first = first

--- a/flink-python/pyflink/fn_execution/utils/operation_utils.py
+++ b/flink-python/pyflink/fn_execution/utils/operation_utils.py
@@ -16,11 +16,7 @@
 # limitations under the License.
 ################################################################################
 import datetime
-
-try:
-    from collections.abc import Generator
-except AttributeError:
-    from collections import Generator
+from collections.abc import Generator
 
 from functools import partial
 

--- a/flink-python/pyflink/fn_execution/utils/operation_utils.py
+++ b/flink-python/pyflink/fn_execution/utils/operation_utils.py
@@ -16,7 +16,12 @@
 # limitations under the License.
 ################################################################################
 import datetime
-from collections import Generator
+
+try:
+    from collections.abc import Generator
+except AttributeError:
+    from collections import Generator
+
 from functools import partial
 
 from typing import Any, Tuple, Dict, List

--- a/flink-python/pyflink/table/tests/test_expression.py
+++ b/flink-python/pyflink/table/tests/test_expression.py
@@ -234,7 +234,7 @@ class PyFlinkBatchExpressionTests(PyFlinkTestCase):
         self.assertEqual('currentTimestamp()', str(current_timestamp()))
         self.assertEqual('localTime()', str(local_time()))
         self.assertEqual('localTimestamp()', str(local_timestamp()))
-        self.assertEquals('toTimestampLtz(123, 0)', str(to_timestamp_ltz(123, 0)))
+        self.assertEqual('toTimestampLtz(123, 0)', str(to_timestamp_ltz(123, 0)))
         self.assertEqual("temporalOverlaps(cast('2:55:00', TIME(0)), 3600000, "
                          "cast('3:30:00', TIME(0)), 7200000)",
                          str(temporal_overlaps(

--- a/flink-python/pyflink/table/tests/test_pandas_conversion.py
+++ b/flink-python/pyflink/table/tests/test_pandas_conversion.py
@@ -18,7 +18,7 @@
 import datetime
 import decimal
 
-from pandas.util.testing import assert_frame_equal
+from pandas.testing import assert_frame_equal
 
 from pyflink.common import Row
 from pyflink.table.types import DataTypes

--- a/flink-python/pyflink/table/tests/test_pandas_udf.py
+++ b/flink-python/pyflink/table/tests/test_pandas_udf.py
@@ -284,11 +284,11 @@ class PandasUDFITTests(object):
 
     def test_invalid_pandas_udf(self):
 
-        @udf(result_type=DataTypes.INT(), udf_type="pandas")
+        @udf(result_type=DataTypes.INT(), func_type="pandas")
         def length_mismatch(i):
             return i[1:]
 
-        @udf(result_type=DataTypes.INT(), udf_type="pandas")
+        @udf(result_type=DataTypes.INT(), func_type="pandas")
         def result_type_not_series(i):
             return i.iloc[0]
 

--- a/flink-python/pyflink/table/udf.py
+++ b/flink-python/pyflink/table/udf.py
@@ -21,6 +21,11 @@ import functools
 import inspect
 from typing import Union, List, Type, Callable, TypeVar, Generic, Iterable
 
+try:
+    collectionsAbc = collections.abc
+except AttributeError:
+    collectionsAbc = collections
+
 from pyflink.java_gateway import get_gateway
 from pyflink.metrics import MetricGroup
 from pyflink.table import Expression
@@ -323,7 +328,7 @@ class UserDefinedFunctionWrapper(object):
 
         if input_types is not None:
             from pyflink.table.types import RowType
-            if not isinstance(input_types, collections.Iterable) \
+            if not isinstance(input_types, collectionsAbc.Iterable) \
                     or isinstance(input_types, RowType):
                 input_types = [input_types]
 
@@ -444,7 +449,7 @@ class UserDefinedTableFunctionWrapper(UserDefinedFunctionWrapper):
             func, input_types, "general", deterministic, name)
 
         from pyflink.table.types import RowType
-        if not isinstance(result_types, collections.Iterable) \
+        if not isinstance(result_types, collectionsAbc.Iterable) \
                 or isinstance(result_types, RowType):
             result_types = [result_types]
 

--- a/flink-python/pyflink/table/udf.py
+++ b/flink-python/pyflink/table/udf.py
@@ -16,14 +16,10 @@
 # limitations under the License.
 ################################################################################
 import abc
+import collections
 import functools
 import inspect
 from typing import Union, List, Type, Callable, TypeVar, Generic, Iterable
-
-try:
-    import collections.abc as collections_abc
-except:
-    import collections as collections_abc  # type: ignore
 
 from pyflink.java_gateway import get_gateway
 from pyflink.metrics import MetricGroup
@@ -327,7 +323,7 @@ class UserDefinedFunctionWrapper(object):
 
         if input_types is not None:
             from pyflink.table.types import RowType
-            if not isinstance(input_types, collections_abc.Iterable) \
+            if not isinstance(input_types, collections.abc.Iterable) \
                     or isinstance(input_types, RowType):
                 input_types = [input_types]
 
@@ -448,7 +444,7 @@ class UserDefinedTableFunctionWrapper(UserDefinedFunctionWrapper):
             func, input_types, "general", deterministic, name)
 
         from pyflink.table.types import RowType
-        if not isinstance(result_types, collections_abc.Iterable) \
+        if not isinstance(result_types, collections.abc.Iterable) \
                 or isinstance(result_types, RowType):
             result_types = [result_types]
 

--- a/flink-python/pyflink/table/udf.py
+++ b/flink-python/pyflink/table/udf.py
@@ -16,15 +16,14 @@
 # limitations under the License.
 ################################################################################
 import abc
-import collections
 import functools
 import inspect
 from typing import Union, List, Type, Callable, TypeVar, Generic, Iterable
 
 try:
-    collectionsAbc = collections.abc
-except AttributeError:
-    collectionsAbc = collections
+    import collections.abc as collections_abc
+except:
+    import collections as collections_abc  # type: ignore
 
 from pyflink.java_gateway import get_gateway
 from pyflink.metrics import MetricGroup
@@ -328,7 +327,7 @@ class UserDefinedFunctionWrapper(object):
 
         if input_types is not None:
             from pyflink.table.types import RowType
-            if not isinstance(input_types, collectionsAbc.Iterable) \
+            if not isinstance(input_types, collections_abc.Iterable) \
                     or isinstance(input_types, RowType):
                 input_types = [input_types]
 
@@ -449,7 +448,7 @@ class UserDefinedTableFunctionWrapper(UserDefinedFunctionWrapper):
             func, input_types, "general", deterministic, name)
 
         from pyflink.table.types import RowType
-        if not isinstance(result_types, collectionsAbc.Iterable) \
+        if not isinstance(result_types, collections_abc.Iterable) \
                 or isinstance(result_types, RowType):
             result_types = [result_types]
 


### PR DESCRIPTION

## What is the purpose of the change

*This pull request cleanup code by using latest API to avoid unnecessary warnings*


## Verifying this change

This change is a trivial rework without any test coverage.

## Does this pull request potentially affect one of the following parts:

  - Dependencies (does it add or upgrade a dependency): (no)
  - The public API, i.e., is any changed class annotated with `@Public(Evolving)`: (no)
  - The serializers: (yes / no / don't know)
  - The runtime per-record code paths (performance sensitive): (yes / no / don't know)
  - Anything that affects deployment or recovery: JobManager (and its components), Checkpointing, Kubernetes/Yarn, ZooKeeper: (yes / no / don't know)
  - The S3 file system connector: (yes / no / don't know)

## Documentation

  - Does this pull request introduce a new feature? (yes / no)
  - If yes, how is the feature documented? (not applicable / docs / JavaDocs / not documented)
