### PR TITLE
[FLINK-24245][python] Fix the problem caused by multiple jobs sharing the loopback mode address stored in the environment variable in PyFlink

### DIFF
--- a/flink-python/pyflink/datastream/tests/test_stream_execution_environment.py
+++ b/flink-python/pyflink/datastream/tests/test_stream_execution_environment.py
@@ -49,15 +49,11 @@ from pyflink.util.java_utils import get_j_env_configuration
 class StreamExecutionEnvironmentTests(PyFlinkTestCase):
 
     def setUp(self):
-        self.env = self.create_new_env()
+        os.environ['_python_worker_execution_mode'] = "loopback"
+        self.env = StreamExecutionEnvironment.get_execution_environment()
+        os.environ['_python_worker_execution_mode'] = "process"
+        self.env.set_parallelism(2)
         self.test_sink = DataStreamTestSinkFunction()
-
-    @staticmethod
-    def create_new_env(execution_mode='process'):
-        env = StreamExecutionEnvironment.get_execution_environment()
-        env.set_parallelism(2)
-        env._execution_mode = execution_mode
-        return env
 
     def test_get_config(self):
         execution_config = self.env.get_config()
@@ -358,7 +354,7 @@ class StreamExecutionEnvironmentTests(PyFlinkTestCase):
 
     def test_add_python_file(self):
         import uuid
-        env = self.create_new_env("loopback")
+        env = self.env
         python_file_dir = os.path.join(self.tempdir, "python_file_dir_" + str(uuid.uuid4()))
         os.mkdir(python_file_dir)
         python_file_path = os.path.join(python_file_dir, "test_dep1.py")
@@ -409,7 +405,7 @@ class StreamExecutionEnvironmentTests(PyFlinkTestCase):
 
     def test_add_python_file_2(self):
         import uuid
-        env = self.create_new_env("loopback")
+        env = self.env
         python_file_dir = os.path.join(self.tempdir, "python_file_dir_" + str(uuid.uuid4()))
         os.mkdir(python_file_dir)
         python_file_path = os.path.join(python_file_dir, "test_dep1.py")
@@ -477,7 +473,7 @@ class StreamExecutionEnvironmentTests(PyFlinkTestCase):
     def test_set_requirements_with_cached_directory(self):
         import uuid
         tmp_dir = self.tempdir
-        env = self.create_new_env("loopback")
+        env = self.env
         requirements_txt_path = os.path.join(tmp_dir, "requirements_txt_" + str(uuid.uuid4()))
         with open(requirements_txt_path, 'w') as f:
             f.write("python-package1==0.0.0")
@@ -523,7 +519,7 @@ class StreamExecutionEnvironmentTests(PyFlinkTestCase):
         import uuid
         import shutil
         tmp_dir = self.tempdir
-        env = self.create_new_env("loopback")
+        env = self.env
         archive_dir_path = os.path.join(tmp_dir, "archive_" + str(uuid.uuid4()))
         os.mkdir(archive_dir_path)
         with open(os.path.join(archive_dir_path, "data.txt"), 'w') as f:
@@ -550,7 +546,7 @@ class StreamExecutionEnvironmentTests(PyFlinkTestCase):
         import sys
         python_exec = sys.executable
         tmp_dir = self.tempdir
-        env = self.create_new_env("loopback")
+        env = self.env
         python_exec_link_path = os.path.join(tmp_dir, "py_exec")
         os.symlink(python_exec, python_exec_link_path)
         env.set_python_executable(python_exec_link_path)

--- a/flink-python/pyflink/table/tests/test_dependency.py
+++ b/flink-python/pyflink/table/tests/test_dependency.py
@@ -74,8 +74,9 @@ class StreamDependencyTests(DependencyTests, PyFlinkStreamTableTestCase):
 
     def setUp(self):
         super(StreamDependencyTests, self).setUp()
+        os.environ['_python_worker_execution_mode'] = "loopback"
         self.st_env = TableEnvironment.create(EnvironmentSettings.in_streaming_mode())
-        self.st_env._execution_mode = "loopback"
+        os.environ['_python_worker_execution_mode'] = "process"
 
     def test_set_requirements_without_cached_directory(self):
         requirements_txt_path = os.path.join(self.tempdir, str(uuid.uuid4()))

--- a/flink-python/pyflink/testing/test_case_utils.py
+++ b/flink-python/pyflink/testing/test_case_utils.py
@@ -83,6 +83,7 @@ class PyFlinkTestCase(unittest.TestCase):
         cls.tempdir = tempfile.mkdtemp()
 
         os.environ["FLINK_TESTING"] = "1"
+        os.environ['_python_worker_execution_mode'] = "process"
         _find_flink_home()
 
         logging.info("Using %s as FLINK_HOME...", os.environ["FLINK_HOME"])
@@ -90,6 +91,7 @@ class PyFlinkTestCase(unittest.TestCase):
     @classmethod
     def tearDownClass(cls):
         shutil.rmtree(cls.tempdir, ignore_errors=True)
+        os.environ['_python_worker_execution_mode'] = ""
 
     @classmethod
     def assert_equals(cls, actual, expected):
@@ -136,7 +138,6 @@ class PyFlinkStreamTableTestCase(PyFlinkTestCase):
         self.t_env.get_config().get_configuration().set_string("parallelism.default", "2")
         self.t_env.get_config().get_configuration().set_string(
             "python.fn-execution.bundle.size", "1")
-        self.t_env._execution_mode = "process"
 
 
 class PyFlinkBatchTableTestCase(PyFlinkTestCase):
@@ -150,7 +151,6 @@ class PyFlinkBatchTableTestCase(PyFlinkTestCase):
         self.t_env.get_config().get_configuration().set_string("parallelism.default", "2")
         self.t_env.get_config().get_configuration().set_string(
             "python.fn-execution.bundle.size", "1")
-        self.t_env._execution_mode = "process"
 
 
 class PyFlinkStreamingTestCase(PyFlinkTestCase):
@@ -163,7 +163,6 @@ class PyFlinkStreamingTestCase(PyFlinkTestCase):
         self.env = StreamExecutionEnvironment.get_execution_environment()
         self.env.set_parallelism(2)
         self.env.set_runtime_mode(RuntimeExecutionMode.STREAMING)
-        self.env._execution_mode = "process"
 
 
 class PyFlinkBatchTestCase(PyFlinkTestCase):
@@ -176,7 +175,6 @@ class PyFlinkBatchTestCase(PyFlinkTestCase):
         self.env = StreamExecutionEnvironment.get_execution_environment()
         self.env.set_parallelism(2)
         self.env.set_runtime_mode(RuntimeExecutionMode.BATCH)
-        self.env._execution_mode = "process"
 
 
 class PythonAPICompletenessTestCase(object):


### PR DESCRIPTION
## What is the purpose of the change

*This pull request will fix the problem caused by multiple jobs sharing the loopback mode address stored in the environment variable in PyFlink*


## Brief change log

  - *set loopback address in config*

## Verifying this change

This change added tests and can be verified as follows:

- *`test_dependency.py` and `test_stream_execution_environment.py`*

## Does this pull request potentially affect one of the following parts:

  - Dependencies (does it add or upgrade a dependency): (no)
  - The public API, i.e., is any changed class annotated with `@Public(Evolving)`: (no)
  - The serializers: (no)
  - The runtime per-record code paths (performance sensitive): (no)
  - Anything that affects deployment or recovery: JobManager (and its components), Checkpointing, Kubernetes/Yarn, ZooKeeper: (no)
  - The S3 file system connector: (no)

## Documentation

  - Does this pull request introduce a new feature? (no)
  - If yes, how is the feature documented? (not applicable)
