### PR TITLE
[FLINK-24255][tests] Test environments respect configuration when being instantiated

### DIFF
--- a/flink-test-utils-parent/flink-test-utils/src/main/java/org/apache/flink/streaming/util/TestStreamEnvironment.java
+++ b/flink-test-utils-parent/flink-test-utils/src/main/java/org/apache/flink/streaming/util/TestStreamEnvironment.java
@@ -50,19 +50,26 @@ public class TestStreamEnvironment extends StreamExecutionEnvironment {
 
     public TestStreamEnvironment(
             MiniCluster miniCluster,
+            Configuration config,
             int parallelism,
             Collection<Path> jarFiles,
             Collection<URL> classPaths) {
         super(
                 new MiniClusterPipelineExecutorServiceLoader(miniCluster),
-                MiniClusterPipelineExecutorServiceLoader.createConfiguration(jarFiles, classPaths),
+                MiniClusterPipelineExecutorServiceLoader.createConfiguration(
+                        config, jarFiles, classPaths),
                 null);
 
         setParallelism(parallelism);
     }
 
     public TestStreamEnvironment(MiniCluster miniCluster, int parallelism) {
-        this(miniCluster, parallelism, Collections.emptyList(), Collections.emptyList());
+        this(
+                miniCluster,
+                new Configuration(),
+                parallelism,
+                Collections.emptyList(),
+                Collections.emptyList());
     }
 
     /**
@@ -85,7 +92,7 @@ public class TestStreamEnvironment extends StreamExecutionEnvironment {
                 conf -> {
                     TestStreamEnvironment env =
                             new TestStreamEnvironment(
-                                    miniCluster, parallelism, jarFiles, classpaths);
+                                    miniCluster, conf, parallelism, jarFiles, classpaths);
                     if (RANDOMIZE_CHECKPOINTING_CONFIG) {
                         randomize(
                                 conf, ExecutionCheckpointingOptions.ENABLE_UNALIGNED, true, false);

--- a/flink-test-utils-parent/flink-test-utils/src/main/java/org/apache/flink/test/util/MiniClusterPipelineExecutorServiceLoader.java
+++ b/flink-test-utils-parent/flink-test-utils/src/main/java/org/apache/flink/test/util/MiniClusterPipelineExecutorServiceLoader.java
@@ -61,8 +61,7 @@ public class MiniClusterPipelineExecutorServiceLoader implements PipelineExecuto
      * MiniClusterPipelineExecutorServiceLoader}.
      */
     public static Configuration createConfiguration(
-            Collection<Path> jarFiles, Collection<URL> classPaths) {
-        Configuration config = new Configuration();
+            Configuration config, Collection<Path> jarFiles, Collection<URL> classPaths) {
         ConfigUtils.encodeCollectionToConfig(
                 config,
                 PipelineOptions.JARS,

--- a/flink-test-utils-parent/flink-test-utils/src/main/java/org/apache/flink/test/util/TestEnvironment.java
+++ b/flink-test-utils-parent/flink-test-utils/src/main/java/org/apache/flink/test/util/TestEnvironment.java
@@ -21,6 +21,7 @@ package org.apache.flink.test.util;
 import org.apache.flink.api.common.JobExecutionResult;
 import org.apache.flink.api.java.ExecutionEnvironment;
 import org.apache.flink.api.java.ExecutionEnvironmentFactory;
+import org.apache.flink.configuration.Configuration;
 import org.apache.flink.core.fs.Path;
 import org.apache.flink.runtime.minicluster.MiniCluster;
 import org.apache.flink.util.Preconditions;
@@ -46,7 +47,8 @@ public class TestEnvironment extends ExecutionEnvironment {
             Collection<URL> classPaths) {
         super(
                 new MiniClusterPipelineExecutorServiceLoader(miniCluster),
-                MiniClusterPipelineExecutorServiceLoader.createConfiguration(jarFiles, classPaths),
+                MiniClusterPipelineExecutorServiceLoader.createConfiguration(
+                        new Configuration(), jarFiles, classPaths),
                 null);
 
         this.miniCluster = Preconditions.checkNotNull(miniCluster);


### PR DESCRIPTION
## What is the purpose of the change

Ensure that the `Configuration` passed to `StreamExecutionEnvironment getExecutionEnvironment(Configuration)` is also respected when instantiating local mini cluster execution via the `MiniClusterWithClientRule`.

When using `StreamExecutionEnvironment getExecutionEnvironment(Configuration)`, the config should determine the characteristics of the execution. The config is for example passed to the local environment in the local execution case, and used during the instantiation of the MiniCluster.

But before this patch, when using the `TestStreamEnvironment` and the `MiniClusterWithClientRule`, the config is ignored.
The issue is that the `StreamExecutionEnvironmentFactory` in `TestStreamEnvironment` ignores the config that is passed to it.

This PR primarily just passes the configuration on, properly.

## Verifying this change

This change is a minor rework of existing tests and test infrastructure.

## Does this pull request potentially affect one of the following parts:

  - Dependencies (does it add or upgrade a dependency): **no**
  - The public API, i.e., is any changed class annotated with `@Public(Evolving)`: **no**
  - The serializers: **no**
  - The runtime per-record code paths (performance sensitive): **no**
  - Anything that affects deployment or recovery: JobManager (and its components), Checkpointing, Kubernetes/Yarn, ZooKeeper: **no**
  - The S3 file system connector: **no**

## Documentation

  - Does this pull request introduce a new feature? **no**
  - If yes, how is the feature documented? **not applicable**
