### PR TITLE
[BP-1.13][FLINK-23773][connector/kafka] Mark empty splits as finished to cleanup states in SplitFetcher

### DIFF
--- a/flink-connectors/flink-connector-base/src/main/java/org/apache/flink/connector/base/source/reader/SingleThreadMultiplexSourceReaderBase.java
+++ b/flink-connectors/flink-connector-base/src/main/java/org/apache/flink/connector/base/source/reader/SingleThreadMultiplexSourceReaderBase.java
@@ -26,7 +26,6 @@ import org.apache.flink.connector.base.source.reader.fetcher.SingleThreadFetcher
 import org.apache.flink.connector.base.source.reader.splitreader.SplitReader;
 import org.apache.flink.connector.base.source.reader.synchronization.FutureCompletingBlockingQueue;
 
-import java.util.Collection;
 import java.util.function.Supplier;
 
 /**
@@ -47,7 +46,7 @@ import java.util.function.Supplier;
  *   <li>The class must override the methods to convert back and forth between the immutable splits
  *       ({@code SplitT}) and the mutable split state representation ({@code SplitStateT}).
  *   <li>Finally, the reader must decide what to do when it starts ({@link #start()}) or when a
- *       split is finished ({@link #onSplitFinished(Collection)}).
+ *       split is finished ({@link #onSplitFinished(java.util.Map)}).
  * </ul>
  *
  * @param <E> The type of the records (the raw type that typically contains checkpointing

--- a/flink-connectors/flink-connector-base/src/main/java/org/apache/flink/connector/base/source/reader/fetcher/SingleThreadFetcherManager.java
+++ b/flink-connectors/flink-connector-base/src/main/java/org/apache/flink/connector/base/source/reader/fetcher/SingleThreadFetcherManager.java
@@ -18,13 +18,16 @@
 
 package org.apache.flink.connector.base.source.reader.fetcher;
 
+import org.apache.flink.annotation.VisibleForTesting;
 import org.apache.flink.api.connector.source.SourceSplit;
 import org.apache.flink.connector.base.source.reader.RecordsWithSplitIds;
 import org.apache.flink.connector.base.source.reader.SourceReaderBase;
 import org.apache.flink.connector.base.source.reader.splitreader.SplitReader;
 import org.apache.flink.connector.base.source.reader.synchronization.FutureCompletingBlockingQueue;
 
+import java.util.Collection;
 import java.util.List;
+import java.util.function.Consumer;
 import java.util.function.Supplier;
 
 /**
@@ -52,6 +55,24 @@ public class SingleThreadFetcherManager<E, SplitT extends SourceSplit>
             FutureCompletingBlockingQueue<RecordsWithSplitIds<E>> elementsQueue,
             Supplier<SplitReader<E, SplitT>> splitReaderSupplier) {
         super(elementsQueue, splitReaderSupplier);
+    }
+
+    /**
+     * Creates a new SplitFetcherManager with a single I/O threads.
+     *
+     * @param elementsQueue The queue that is used to hand over data from the I/O thread (the
+     *     fetchers) to the reader (which emits the records and book-keeps the state. This must be
+     *     the same queue instance that is also passed to the {@link SourceReaderBase}.
+     * @param splitReaderSupplier The factory for the split reader that connects to the source
+     *     system.
+     * @param splitFinishedHook Hook for handling finished splits in split fetchers
+     */
+    @VisibleForTesting
+    public SingleThreadFetcherManager(
+            FutureCompletingBlockingQueue<RecordsWithSplitIds<E>> elementsQueue,
+            Supplier<SplitReader<E, SplitT>> splitReaderSupplier,
+            Consumer<Collection<String>> splitFinishedHook) {
+        super(elementsQueue, splitReaderSupplier, splitFinishedHook);
     }
 
     @Override

--- a/flink-connectors/flink-connector-base/src/main/java/org/apache/flink/connector/base/source/reader/fetcher/SplitFetcher.java
+++ b/flink-connectors/flink-connector-base/src/main/java/org/apache/flink/connector/base/source/reader/fetcher/SplitFetcher.java
@@ -28,6 +28,7 @@ import org.slf4j.LoggerFactory;
 
 import javax.annotation.concurrent.GuardedBy;
 
+import java.util.Collection;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
@@ -69,8 +70,8 @@ public class SplitFetcher<E, SplitT extends SourceSplit> implements Runnable {
             FutureCompletingBlockingQueue<RecordsWithSplitIds<E>> elementsQueue,
             SplitReader<E, SplitT> splitReader,
             Consumer<Throwable> errorHandler,
-            Runnable shutdownHook) {
-
+            Runnable shutdownHook,
+            Consumer<Collection<String>> splitFinishedHook) {
         this.id = id;
         this.taskQueue = new LinkedBlockingDeque<>();
         this.elementsQueue = elementsQueue;
@@ -88,6 +89,7 @@ public class SplitFetcher<E, SplitT extends SourceSplit> implements Runnable {
                         elementsQueue,
                         ids -> {
                             ids.forEach(assignedSplits::remove);
+                            splitFinishedHook.accept(ids);
                             LOG.info("Finished reading from splits {}", ids);
                         },
                         id);

--- a/flink-connectors/flink-connector-base/src/test/java/org/apache/flink/connector/base/source/reader/fetcher/SplitFetcherTest.java
+++ b/flink-connectors/flink-connector-base/src/test/java/org/apache/flink/connector/base/source/reader/fetcher/SplitFetcherTest.java
@@ -179,7 +179,8 @@ public class SplitFetcherTest {
                         elementQueue,
                         new MockSplitReader(2, true),
                         ExceptionUtils::rethrow,
-                        () -> {});
+                        () -> {},
+                        (ignore) -> {});
 
         // Prepare the splits.
         List<MockSourceSplit> splits = new ArrayList<>();
@@ -268,7 +269,8 @@ public class SplitFetcherTest {
     private static <E> SplitFetcher<E, TestingSourceSplit> createFetcher(
             final SplitReader<E, TestingSourceSplit> reader,
             final FutureCompletingBlockingQueue<RecordsWithSplitIds<E>> queue) {
-        return new SplitFetcher<>(0, queue, reader, ExceptionUtils::rethrow, () -> {});
+        return new SplitFetcher<>(
+                0, queue, reader, ExceptionUtils::rethrow, () -> {}, (ignore) -> {});
     }
 
     private static <E> SplitFetcher<E, TestingSourceSplit> createFetcherWithSplit(

--- a/flink-connectors/flink-connector-kafka/src/main/java/org/apache/flink/connector/kafka/source/reader/KafkaPartitionSplitReader.java
+++ b/flink-connectors/flink-connector-kafka/src/main/java/org/apache/flink/connector/kafka/source/reader/KafkaPartitionSplitReader.java
@@ -56,6 +56,7 @@ import java.util.Map;
 import java.util.Properties;
 import java.util.Set;
 import java.util.StringJoiner;
+import java.util.stream.Collectors;
 
 /**
  * A {@link SplitReader} implementation that reads records from Kafka partitions.
@@ -76,6 +77,9 @@ public class KafkaPartitionSplitReader<T>
     private final String groupId;
     private final int subtaskId;
     private final KafkaSourceReaderMetrics kafkaSourceReaderMetrics;
+
+    // Tracking empty splits that has not been added to finished splits in fetch()
+    private final Set<String> emptySplits = new HashSet<>();
 
     public KafkaPartitionSplitReader(
             Properties props,
@@ -174,6 +178,14 @@ public class KafkaPartitionSplitReader<T>
                         tp, recordsFromPartition.get(recordsFromPartition.size() - 1).offset());
             }
         }
+
+        // Some splits are discovered as empty when handling split additions. These splits should be
+        // added to finished splits to clean up states in split fetcher and source reader.
+        if (!emptySplits.isEmpty()) {
+            recordsBySplits.finishedSplits.addAll(emptySplits);
+            emptySplits.clear();
+        }
+
         // Unassign the partitions that has finished.
         if (!finishedPartitions.isEmpty()) {
             unassignPartitions(finishedPartitions);
@@ -342,15 +354,24 @@ public class KafkaPartitionSplitReader<T>
     }
 
     private void removeEmptySplits() {
-        List<TopicPartition> emptySplits = new ArrayList<>();
+        List<TopicPartition> emptyPartitions = new ArrayList<>();
         // If none of the partitions have any records,
         for (TopicPartition tp : consumer.assignment()) {
             if (consumer.position(tp) >= getStoppingOffset(tp)) {
-                emptySplits.add(tp);
+                emptyPartitions.add(tp);
             }
         }
-        if (!emptySplits.isEmpty()) {
-            unassignPartitions(emptySplits);
+        if (!emptyPartitions.isEmpty()) {
+            LOG.debug(
+                    "These assigning splits are empty and will be marked as finished in later fetch: {}",
+                    emptyPartitions);
+            // Add empty partitions to empty split set for later cleanup in fetch()
+            emptySplits.addAll(
+                    emptyPartitions.stream()
+                            .map(KafkaPartitionSplit::toSplitId)
+                            .collect(Collectors.toSet()));
+            // Un-assign partitions from Kafka consumer
+            unassignPartitions(emptyPartitions);
         }
     }
 
@@ -366,7 +387,7 @@ public class KafkaPartitionSplitReader<T>
                                 "[%s, start:%d, stop: %d]",
                                 split.getTopicPartition(), startingOffset, stoppingOffset));
             }
-            LOG.debug("SplitsChange handling result: {}", splitsInfo.toString());
+            LOG.debug("SplitsChange handling result: {}", splitsInfo);
         }
     }
 

--- a/flink-connectors/flink-connector-kafka/src/main/java/org/apache/flink/connector/kafka/source/reader/KafkaSourceReader.java
+++ b/flink-connectors/flink-connector-kafka/src/main/java/org/apache/flink/connector/kafka/source/reader/KafkaSourceReader.java
@@ -44,7 +44,6 @@ import java.util.SortedMap;
 import java.util.TreeMap;
 import java.util.concurrent.ConcurrentHashMap;
 import java.util.concurrent.ConcurrentMap;
-import java.util.function.Supplier;
 
 /** The source reader for Kafka partitions. */
 public class KafkaSourceReader<T>
@@ -59,17 +58,12 @@ public class KafkaSourceReader<T>
 
     public KafkaSourceReader(
             FutureCompletingBlockingQueue<RecordsWithSplitIds<Tuple3<T, Long, Long>>> elementsQueue,
-            Supplier<KafkaPartitionSplitReader<T>> splitReaderSupplier,
+            KafkaSourceFetcherManager<T> kafkaSourceFetcherManager,
             RecordEmitter<Tuple3<T, Long, Long>, T, KafkaPartitionSplitState> recordEmitter,
             Configuration config,
             SourceReaderContext context,
             KafkaSourceReaderMetrics kafkaSourceReaderMetrics) {
-        super(
-                elementsQueue,
-                new KafkaSourceFetcherManager<>(elementsQueue, splitReaderSupplier::get),
-                recordEmitter,
-                config,
-                context);
+        super(elementsQueue, kafkaSourceFetcherManager, recordEmitter, config, context);
         this.offsetsToCommit = Collections.synchronizedSortedMap(new TreeMap<>());
         this.offsetsOfFinishedSplits = new ConcurrentHashMap<>();
         this.kafkaSourceReaderMetrics = kafkaSourceReaderMetrics;

--- a/flink-connectors/flink-connector-kafka/src/main/java/org/apache/flink/connector/kafka/source/reader/fetcher/KafkaSourceFetcherManager.java
+++ b/flink-connectors/flink-connector-kafka/src/main/java/org/apache/flink/connector/kafka/source/reader/fetcher/KafkaSourceFetcherManager.java
@@ -36,7 +36,9 @@ import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
 import java.io.IOException;
+import java.util.Collection;
 import java.util.Map;
+import java.util.function.Consumer;
 import java.util.function.Supplier;
 
 /**
@@ -56,11 +58,13 @@ public class KafkaSourceFetcherManager<T>
      *     the same queue instance that is also passed to the {@link SourceReaderBase}.
      * @param splitReaderSupplier The factory for the split reader that connects to the source
      *     system.
+     * @param splitFinishedHook Hook for handling finished splits in split fetchers.
      */
     public KafkaSourceFetcherManager(
             FutureCompletingBlockingQueue<RecordsWithSplitIds<Tuple3<T, Long, Long>>> elementsQueue,
-            Supplier<SplitReader<Tuple3<T, Long, Long>, KafkaPartitionSplit>> splitReaderSupplier) {
-        super(elementsQueue, splitReaderSupplier);
+            Supplier<SplitReader<Tuple3<T, Long, Long>, KafkaPartitionSplit>> splitReaderSupplier,
+            Consumer<Collection<String>> splitFinishedHook) {
+        super(elementsQueue, splitReaderSupplier, splitFinishedHook);
     }
 
     public void commitOffsets(

--- a/flink-connectors/flink-connector-kafka/src/test/java/org/apache/flink/connector/kafka/source/KafkaSourceTestUtils.java
+++ b/flink-connectors/flink-connector-kafka/src/test/java/org/apache/flink/connector/kafka/source/KafkaSourceTestUtils.java
@@ -1,0 +1,47 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.flink.connector.kafka.source;
+
+import org.apache.flink.api.connector.source.SourceReaderContext;
+import org.apache.flink.connector.kafka.source.reader.KafkaSourceReader;
+
+import java.util.Collection;
+import java.util.function.Consumer;
+
+/** Utility class for testing {@link KafkaSource}. */
+public class KafkaSourceTestUtils {
+
+    /**
+     * Create {@link KafkaSourceReader} with a custom hook handling IDs of finished {@link
+     * org.apache.flink.connector.kafka.source.split.KafkaPartitionSplit}.
+     *
+     * @param kafkaSource Kafka source
+     * @param sourceReaderContext Context for SourceReader
+     * @param splitFinishedHook Hook for handling finished splits
+     * @param <T> Type of emitting records
+     */
+    public static <T> KafkaSourceReader<T> createReaderWithFinishedSplitHook(
+            KafkaSource<T> kafkaSource,
+            SourceReaderContext sourceReaderContext,
+            Consumer<Collection<String>> splitFinishedHook)
+            throws Exception {
+        return ((KafkaSourceReader<T>)
+                kafkaSource.createReader(sourceReaderContext, splitFinishedHook));
+    }
+}

--- a/flink-connectors/flink-connector-kafka/src/test/java/org/apache/flink/connector/kafka/source/reader/KafkaSourceReaderTest.java
+++ b/flink-connectors/flink-connector-kafka/src/test/java/org/apache/flink/connector/kafka/source/reader/KafkaSourceReaderTest.java
@@ -26,6 +26,7 @@ import org.apache.flink.configuration.Configuration;
 import org.apache.flink.connector.kafka.source.KafkaSource;
 import org.apache.flink.connector.kafka.source.KafkaSourceBuilder;
 import org.apache.flink.connector.kafka.source.KafkaSourceTestEnv;
+import org.apache.flink.connector.kafka.source.KafkaSourceTestUtils;
 import org.apache.flink.connector.kafka.source.enumerator.initializer.OffsetsInitializer;
 import org.apache.flink.connector.kafka.source.reader.deserializer.KafkaRecordDeserializationSchema;
 import org.apache.flink.connector.kafka.source.split.KafkaPartitionSplit;
@@ -52,9 +53,11 @@ import org.junit.Test;
 import java.time.Duration;
 import java.util.ArrayList;
 import java.util.Arrays;
+import java.util.Collection;
 import java.util.Collections;
 import java.util.List;
 import java.util.Map;
+import java.util.function.Consumer;
 import java.util.function.Supplier;
 
 import static org.apache.flink.connector.kafka.source.metrics.KafkaSourceReaderMetrics.COMMITS_SUCCEEDED_METRIC_COUNTER;
@@ -68,7 +71,6 @@ import static org.apache.flink.connector.kafka.source.metrics.KafkaSourceReaderM
 import static org.apache.flink.core.testutils.CommonTestUtils.waitUtil;
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertTrue;
-import static org.junit.Assert.fail;
 
 /** Unit tests for {@link KafkaSourceReader}. */
 public class KafkaSourceReaderTest extends SourceReaderTestBase<KafkaPartitionSplit> {
@@ -338,17 +340,24 @@ public class KafkaSourceReaderTest extends SourceReaderTestBase<KafkaPartitionSp
 
     private SourceReader<Integer, KafkaPartitionSplit> createReader(
             Boundedness boundedness, String groupId) throws Exception {
-        return createReader(boundedness, groupId, new TestingReaderContext());
+        return createReader(boundedness, groupId, new TestingReaderContext(), (ignore) -> {});
     }
 
     private SourceReader<Integer, KafkaPartitionSplit> createReader(
             Boundedness boundedness, String groupId, MetricGroup metricGroup) throws Exception {
         return createReader(
-                boundedness, groupId, new TestingReaderContext(new Configuration(), metricGroup));
+                boundedness,
+                groupId,
+                new TestingReaderContext(new Configuration(), metricGroup),
+                (ignore) -> {});
     }
 
     private SourceReader<Integer, KafkaPartitionSplit> createReader(
-            Boundedness boundedness, String groupId, SourceReaderContext context) throws Exception {
+            Boundedness boundedness,
+            String groupId,
+            SourceReaderContext context,
+            Consumer<Collection<String>> splitFinishedHook)
+            throws Exception {
         KafkaSourceBuilder<Integer> builder =
                 KafkaSource.<Integer>builder()
                         .setClientIdPrefix("KafkaSourceReaderTest")
@@ -366,7 +375,8 @@ public class KafkaSourceReaderTest extends SourceReaderTestBase<KafkaPartitionSp
             builder.setBounded(OffsetsInitializer.latest());
         }
 
-        return builder.build().createReader(context);
+        return KafkaSourceTestUtils.createReaderWithFinishedSplitHook(
+                builder.build(), context, splitFinishedHook);
     }
 
     private void pollUntil(
@@ -380,10 +390,9 @@ public class KafkaSourceReaderTest extends SourceReaderTestBase<KafkaPartitionSp
                     try {
                         reader.pollNext(output);
                     } catch (Exception exception) {
-                        fail(
-                                String.format(
-                                        "Caught unexpected exception %s when polling from the reader.",
-                                        exception));
+                        throw new RuntimeException(
+                                "Caught unexpected exception when polling from the reader",
+                                exception);
                     }
                     return condition.get();
                 },


### PR DESCRIPTION
Unchanged backport of #16870 on release-1.13