### PR TITLE
[FLINK-23316][Table SQL/Ecosystem] Add tests for custom PartitionCommitPolicy

### DIFF
--- a/flink-connectors/flink-connector-hive/src/test/java/org/apache/flink/connectors/hive/CustomCommitPolicy.java
+++ b/flink-connectors/flink-connector-hive/src/test/java/org/apache/flink/connectors/hive/CustomCommitPolicy.java
@@ -1,0 +1,41 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.flink.connectors.hive;
+
+import org.apache.flink.table.filesystem.PartitionCommitPolicy;
+
+import java.util.HashSet;
+import java.util.Set;
+
+/** A custom PartitionCommitPolicy for test. */
+public class CustomCommitPolicy implements PartitionCommitPolicy {
+
+    private static Set<String> committedPartitionPaths = new HashSet<>();
+
+    @Override
+    public void commit(PartitionCommitPolicy.Context context) throws Exception {
+        CustomCommitPolicy.committedPartitionPaths.add(context.partitionPath().getPath());
+    }
+
+    static Set<String> getCommittedPartitionPathsAndReset() {
+        Set<String> paths = CustomCommitPolicy.committedPartitionPaths;
+        CustomCommitPolicy.committedPartitionPaths = new HashSet<>();
+        return paths;
+    }
+}

--- a/flink-connectors/flink-connector-hive/src/test/java/org/apache/flink/connectors/hive/HiveTableSinkITCase.java
+++ b/flink-connectors/flink-connector-hive/src/test/java/org/apache/flink/connectors/hive/HiveTableSinkITCase.java
@@ -514,9 +514,6 @@ public class HiveTableSinkITCase {
                             + " stored as textfile"
                             + " TBLPROPERTIES ("
                             + "'"
-                            + PARTITION_TIME_EXTRACTOR_TIMESTAMP_PATTERN.key()
-                            + "'='$d $e:00:00',"
-                            + "'"
                             + SINK_PARTITION_COMMIT_DELAY.key()
                             + "'='1h',"
                             + "'"
@@ -549,11 +546,13 @@ public class HiveTableSinkITCase {
                         String partitionPath =
                                 new Path(new Path(base, "d=2020-05-03"), partitionKV).toString();
                         Assert.assertTrue(
-                                String.join("", committedPaths),
+                                "Partition(d=2020-05-03, "
+                                        + partitionKV
+                                        + ") is not committed successfully",
                                 committedPaths.contains(partitionPath));
                     });
         } finally {
-            tEnv.executeSql("drop database db1 cascade");
+            tEnv.executeSql("drop database if exists db1 cascade");
         }
     }
 

--- a/flink-connectors/flink-connector-hive/src/test/java/org/apache/flink/connectors/hive/TestCustomCommitPolicy.java
+++ b/flink-connectors/flink-connector-hive/src/test/java/org/apache/flink/connectors/hive/TestCustomCommitPolicy.java
@@ -24,18 +24,18 @@ import java.util.HashSet;
 import java.util.Set;
 
 /** A custom PartitionCommitPolicy for test. */
-public class CustomCommitPolicy implements PartitionCommitPolicy {
+public class TestCustomCommitPolicy implements PartitionCommitPolicy {
 
     private static Set<String> committedPartitionPaths = new HashSet<>();
 
     @Override
     public void commit(PartitionCommitPolicy.Context context) throws Exception {
-        CustomCommitPolicy.committedPartitionPaths.add(context.partitionPath().getPath());
+        TestCustomCommitPolicy.committedPartitionPaths.add(context.partitionPath().getPath());
     }
 
     static Set<String> getCommittedPartitionPathsAndReset() {
-        Set<String> paths = CustomCommitPolicy.committedPartitionPaths;
-        CustomCommitPolicy.committedPartitionPaths = new HashSet<>();
+        Set<String> paths = TestCustomCommitPolicy.committedPartitionPaths;
+        TestCustomCommitPolicy.committedPartitionPaths = new HashSet<>();
         return paths;
     }
 }

--- a/flink-table/flink-table-runtime/src/main/java/org/apache/flink/table/filesystem/PartitionCommitPolicy.java
+++ b/flink-table/flink-table-runtime/src/main/java/org/apache/flink/table/filesystem/PartitionCommitPolicy.java
@@ -111,7 +111,7 @@ public interface PartitionCommitPolicy {
                                             | IllegalAccessException
                                             | InstantiationException e) {
                                         throw new RuntimeException(
-                                                "Can not new instance for custom class from "
+                                                "Can not create new instance for custom class from "
                                                         + customClass,
                                                 e);
                                     }


### PR DESCRIPTION
## What is the purpose of the change

This pull request add tests for cutom PartitionCommitPolicy.


## Brief change log
No changes, only add new tests

## Verifying this change
This change added tests and can be verified as follows:

*(example:)*
  - *New test case: HiveTableSinkITCase#testCustomPartitionCommitPolicyNotFound()*
  - *Extend existed test cases in HiveTableSink to cover custom PartitionCommitPolicy*
  - 
## Does this pull request potentially affect one of the following parts:

  - Dependencies (does it add or upgrade a dependency): no
  - The public API, i.e., is any changed class annotated with `@Public(Evolving)`: no
  - The serializers: no
  - The runtime per-record code paths (performance sensitive): no
  - Anything that affects deployment or recovery: JobManager (and its components), Checkpointing, Kubernetes/Yarn, ZooKeeper:  no
  - The S3 file system connector: no

## Documentation

  - Does this pull request introduce a new feature? no
  - If yes, how is the feature documented? not applicable
