### PR TITLE
[FLINK-24259] - Check for empty, blank or null topic names in KafkaTopicsDescriptor and provide appropriate message

### DIFF
--- a/flink-connectors/flink-connector-kafka/src/main/java/org/apache/flink/streaming/connectors/kafka/internals/KafkaTopicsDescriptor.java
+++ b/flink-connectors/flink-connector-kafka/src/main/java/org/apache/flink/streaming/connectors/kafka/internals/KafkaTopicsDescriptor.java
@@ -20,11 +20,14 @@ package org.apache.flink.streaming.connectors.kafka.internals;
 
 import org.apache.flink.annotation.Internal;
 
+import org.apache.commons.lang3.StringUtils;
+
 import javax.annotation.Nullable;
 
 import java.io.Serializable;
 import java.util.List;
 import java.util.regex.Pattern;
+import java.util.stream.Collectors;
 
 import static org.apache.flink.util.Preconditions.checkArgument;
 
@@ -49,8 +52,12 @@ public class KafkaTopicsDescriptor implements Serializable {
 
         if (fixedTopics != null) {
             checkArgument(
-                    !fixedTopics.isEmpty(),
-                    "If subscribing to a fixed topics list, the supplied list cannot be empty.");
+                    !fixedTopics.isEmpty()
+                            && fixedTopics.stream()
+                                    .filter(s -> StringUtils.isBlank(s))
+                                    .collect(Collectors.toList())
+                                    .isEmpty(),
+                    "If subscribing to a fixed topics list, the supplied list cannot be empty or contain blanks.");
         }
 
         this.fixedTopics = fixedTopics;


### PR DESCRIPTION

## What is the purpose of the change

* Exception thrown when Kafka topic is null for FlinkKafkaConsumer with message Error computing size for field 'topics' : Error computing size for field 'name': Missing value for field 'name' which has no default value.


## Brief change log

* Added check for topic names in FlinkKafkaDescriptor and provide more informative message

## Verifying this change

This change added tests and can be verified as follows:

* Added unit tests to FlinkKafkaDescriptorTest suite

## Does this pull request potentially affect one of the following parts:

  - Dependencies (does it add or upgrade a dependency): no
  - The public API, i.e., is any changed class annotated with `@Public(Evolving)`: no
  - The serializers: no 
  - The runtime per-record code paths (performance sensitive): no
  - Anything that affects deployment or recovery: JobManager (and its components), Checkpointing, Kubernetes/Yarn, ZooKeeper: no 
  - The S3 file system connector:  no

## Documentation

  - Does this pull request introduce a new feature?  no
  - If yes, how is the feature documented? not applicable
