### PR TITLE
[FLINK-24260][python] Limit requests to 2.26.0 or above only for python 3.6+

### DIFF
--- a/flink-python/setup.py
+++ b/flink-python/setup.py
@@ -319,7 +319,7 @@ run sdist.
                           'pandas>=0.24.2,<1; python_full_version < "3.5.3"',
                           'pandas>=0.25.2,<1; python_full_version >= "3.5.3"',
                           'pyarrow>=0.15.1,<0.18.0', 'pytz>=2018.3', 'numpy>=1.14.3,<1.20',
-                          'requests>=2.26.0'],
+                          'requests>=2.26.0; python_version >= "3.6"'],
         cmdclass={'build_ext': build_ext},
         tests_require=['pytest==4.4.1'],
         description='Apache Flink Python API',


### PR DESCRIPTION
## What is the purpose of the change

*This pull request limits requests to 2.26.0 or above only for python 3.6+ as it's only available for Python 3.6+*


## Verifying this change

This change is a trivial rework without any test coverage.

## Does this pull request potentially affect one of the following parts:

  - Dependencies (does it add or upgrade a dependency): (yes / no)
  - The public API, i.e., is any changed class annotated with `@Public(Evolving)`: (yes / no)
  - The serializers: (yes / no / don't know)
  - The runtime per-record code paths (performance sensitive): (yes / no / don't know)
  - Anything that affects deployment or recovery: JobManager (and its components), Checkpointing, Kubernetes/Yarn, ZooKeeper: (yes / no / don't know)
  - The S3 file system connector: (yes / no / don't know)

## Documentation

  - Does this pull request introduce a new feature? (yes / no)
  - If yes, how is the feature documented? (not applicable / docs / JavaDocs / not documented)
