### PR TITLE
[FLINK-24206][connector/pulsar] Close the pulsar client properly

### DIFF
--- a/flink-connectors/flink-connector-pulsar/src/main/java/org/apache/flink/connector/pulsar/source/reader/source/PulsarSourceReaderBase.java
+++ b/flink-connectors/flink-connector-pulsar/src/main/java/org/apache/flink/connector/pulsar/source/reader/source/PulsarSourceReaderBase.java
@@ -79,10 +79,11 @@ abstract class PulsarSourceReaderBase<OUT>
 
     @Override
     public void close() throws Exception {
-        // Close shared pulsar resources.
-        pulsarClient.close();
-        pulsarAdmin.close();
-
+        // Close the all the consumers first.
         super.close();
+
+        // Close shared pulsar resources.
+        pulsarClient.shutdown();
+        pulsarAdmin.close();
     }
 }


### PR DESCRIPTION
## What is the purpose of the change

Pulsar Consumer would be closed in SplitReader if it reaches the end of the split. The registered Consumer would also be closed in PulsarClient if we call PulsarClient.close(). This would cause a race conditions. We have to use PulsarClient.shutdown() which doesn't close Consumer instead.

## Brief change log

  - Change the Reader close order.
  - Use `PulsarClient.shutdown()` instead of `PulsarClient.close()`

## Verifying this change

This change is already covered by existing tests, such as *PulsarSourceITCase*.

## Does this pull request potentially affect one of the following parts:

  - Dependencies (does it add or upgrade a dependency): (no)
  - The public API, i.e., is any changed class annotated with `@Public(Evolving)`: (no)
  - The serializers: (no)
  - The runtime per-record code paths (performance sensitive): (no)
  - Anything that affects deployment or recovery: JobManager (and its components), Checkpointing, Kubernetes/Yarn, ZooKeeper: (no)
  - The S3 file system connector: (no)

## Documentation

  - Does this pull request introduce a new feature? (no)
  - If yes, how is the feature documented? (not applicable)
