### PR TITLE
[FLINK-24251][table-common] Make default constructor of BinaryStringData construct an empty binary string again

### DIFF
--- a/flink-table/flink-table-common/src/main/java/org/apache/flink/table/data/binary/BinaryStringData.java
+++ b/flink-table/flink-table-common/src/main/java/org/apache/flink/table/data/binary/BinaryStringData.java
@@ -45,7 +45,9 @@ public final class BinaryStringData extends LazyBinaryFormat<String> implements 
     public static final BinaryStringData EMPTY_UTF8 =
             BinaryStringData.fromBytes(StringUtf8Utils.encodeUTF8(""));
 
-    public BinaryStringData() {}
+    public BinaryStringData() {
+        super(new MemorySegment[] {MemorySegmentFactory.wrap(new byte[0])}, 0, 0);
+    }
 
     public BinaryStringData(String javaObject) {
         super(javaObject);

--- a/flink-table/flink-table-runtime/src/test/java/org/apache/flink/table/data/BinaryStringDataTest.java
+++ b/flink-table/flink-table-runtime/src/test/java/org/apache/flink/table/data/BinaryStringDataTest.java
@@ -830,4 +830,9 @@ public class BinaryStringDataTest {
         // check reference same.
         assertSame(str.toString(), javaStr);
     }
+
+    @Test
+    public void testDefaultConstructor() {
+        assertEquals(BinaryStringData.blankString(0), new BinaryStringData());
+    }
 }


### PR DESCRIPTION
## What is the purpose of the change

In FLINK-23289 we add a not null checking for BinarySection. After the change the default constructor of BinaryStringData will now construct a BinaryStringData with null Java object and null BinarySection. This is different from the behavior before where the default constructor constructs an empty binary string.

Although BinaryStringData is an internal class, it might confuse some developers (actually I myself have been confused) if they build their programs around this class. So we should make the default constructor construct an empty binary string again without breaking the not null checking.

## Brief change log

 - Make default constructor of BinaryStringData construct an empty binary string again

## Verifying this change

This change added tests and can be verified by running the added tests.

## Does this pull request potentially affect one of the following parts:

  - Dependencies (does it add or upgrade a dependency): no
  - The public API, i.e., is any changed class annotated with `@Public(Evolving)`: no
  - The serializers: no
  - The runtime per-record code paths (performance sensitive): no
  - Anything that affects deployment or recovery: JobManager (and its components), Checkpointing, Kubernetes/Yarn, ZooKeeper: no
  - The S3 file system connector: no

## Documentation

  - Does this pull request introduce a new feature? no
  - If yes, how is the feature documented? not applicable