### PR TITLE
[FLINK-24277][connector/kafka] And configuration for committing offset on checkpoint and disable it if group ID is not specified

### DIFF
--- a/docs/content/docs/connectors/datastream/kafka.md
+++ b/docs/content/docs/connectors/datastream/kafka.md
@@ -154,6 +154,7 @@ KafkaSource has following options for configuration:
   below for more details.
 - ```register.consumer.metrics``` specifies whether to register metrics of KafkaConsumer in Flink
 metric group
+- ```commit.offsets.on.checkpoint``` specifies whether to commit consuming offsets to Kafka brokers on checkpoint
 
 For configurations of KafkaConsumer, you can refer to
 <a href="http://kafka.apache.org/documentation/#consumerconfigs">Apache Kafka documentation</a>

--- a/flink-connectors/flink-connector-kafka/src/main/java/org/apache/flink/connector/kafka/source/KafkaSource.java
+++ b/flink-connectors/flink-connector-kafka/src/main/java/org/apache/flink/connector/kafka/source/KafkaSource.java
@@ -214,4 +214,9 @@ public class KafkaSource<OUT>
         props.stringPropertyNames().forEach(key -> config.setString(key, props.getProperty(key)));
         return config;
     }
+
+    @VisibleForTesting
+    Configuration getConfiguration() {
+        return toConfiguration(props);
+    }
 }

--- a/flink-connectors/flink-connector-kafka/src/main/java/org/apache/flink/connector/kafka/source/KafkaSourceBuilder.java
+++ b/flink-connectors/flink-connector-kafka/src/main/java/org/apache/flink/connector/kafka/source/KafkaSourceBuilder.java
@@ -22,6 +22,7 @@ import org.apache.flink.api.common.serialization.DeserializationSchema;
 import org.apache.flink.api.connector.source.Boundedness;
 import org.apache.flink.connector.kafka.source.enumerator.initializer.NoStoppingOffsetsInitializer;
 import org.apache.flink.connector.kafka.source.enumerator.initializer.OffsetsInitializer;
+import org.apache.flink.connector.kafka.source.enumerator.initializer.OffsetsInitializerValidator;
 import org.apache.flink.connector.kafka.source.enumerator.subscriber.KafkaSubscriber;
 import org.apache.flink.connector.kafka.source.reader.deserializer.KafkaRecordDeserializationSchema;
 
@@ -495,6 +496,13 @@ public class KafkaSourceBuilder<OUT> {
                 String.format(
                         "Property %s is required when offset commit is enabled",
                         ConsumerConfig.GROUP_ID_CONFIG));
+        // Check offsets initializers
+        if (startingOffsetsInitializer instanceof OffsetsInitializerValidator) {
+            ((OffsetsInitializerValidator) startingOffsetsInitializer).validate(props);
+        }
+        if (stoppingOffsetsInitializer instanceof OffsetsInitializerValidator) {
+            ((OffsetsInitializerValidator) stoppingOffsetsInitializer).validate(props);
+        }
     }
 
     private boolean offsetCommitEnabledManually() {

--- a/flink-connectors/flink-connector-kafka/src/main/java/org/apache/flink/connector/kafka/source/KafkaSourceOptions.java
+++ b/flink-connectors/flink-connector-kafka/src/main/java/org/apache/flink/connector/kafka/source/KafkaSourceOptions.java
@@ -48,6 +48,12 @@ public class KafkaSourceOptions {
                     .withDescription(
                             "Whether to register metrics of KafkaConsumer into Flink metric group");
 
+    public static final ConfigOption<Boolean> COMMIT_OFFSETS_ON_CHECKPOINT =
+            ConfigOptions.key("commit.offsets.on.checkpoint")
+                    .booleanType()
+                    .defaultValue(true)
+                    .withDescription("Whether to commit consuming offset on checkpoint.");
+
     @SuppressWarnings("unchecked")
     public static <T> T getOption(
             Properties props, ConfigOption<?> configOption, Function<String, T> parser) {

--- a/flink-connectors/flink-connector-kafka/src/main/java/org/apache/flink/connector/kafka/source/enumerator/initializer/OffsetsInitializerValidator.java
+++ b/flink-connectors/flink-connector-kafka/src/main/java/org/apache/flink/connector/kafka/source/enumerator/initializer/OffsetsInitializerValidator.java
@@ -1,0 +1,39 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.flink.connector.kafka.source.enumerator.initializer;
+
+import org.apache.flink.annotation.Internal;
+
+import java.util.Properties;
+
+/**
+ * Interface for validating {@link OffsetsInitializer} with properties from {@link
+ * org.apache.flink.connector.kafka.source.KafkaSource}.
+ */
+@Internal
+public interface OffsetsInitializerValidator {
+
+    /**
+     * Validate offsets initializer with properties of Kafka source.
+     *
+     * @param kafkaSourceProperties Properties of Kafka source
+     * @throws IllegalStateException if validation fails
+     */
+    void validate(Properties kafkaSourceProperties) throws IllegalStateException;
+}

--- a/flink-connectors/flink-connector-kafka/src/main/java/org/apache/flink/connector/kafka/source/enumerator/initializer/ReaderHandledOffsetsInitializer.java
+++ b/flink-connectors/flink-connector-kafka/src/main/java/org/apache/flink/connector/kafka/source/enumerator/initializer/ReaderHandledOffsetsInitializer.java
@@ -20,12 +20,16 @@ package org.apache.flink.connector.kafka.source.enumerator.initializer;
 
 import org.apache.flink.connector.kafka.source.split.KafkaPartitionSplit;
 
+import org.apache.kafka.clients.consumer.ConsumerConfig;
 import org.apache.kafka.clients.consumer.OffsetResetStrategy;
 import org.apache.kafka.common.TopicPartition;
 
 import java.util.Collection;
 import java.util.HashMap;
 import java.util.Map;
+import java.util.Properties;
+
+import static org.apache.flink.util.Preconditions.checkState;
 
 /**
  * A initializer that initialize the partitions to the earliest / latest / last-committed offsets.
@@ -34,7 +38,7 @@ import java.util.Map;
  *
  * <p>Package private and should be instantiated via {@link OffsetsInitializer}.
  */
-class ReaderHandledOffsetsInitializer implements OffsetsInitializer {
+class ReaderHandledOffsetsInitializer implements OffsetsInitializer, OffsetsInitializerValidator {
     private static final long serialVersionUID = 172938052008787981L;
     private final long startingOffset;
     private final OffsetResetStrategy offsetResetStrategy;
@@ -64,5 +68,16 @@ class ReaderHandledOffsetsInitializer implements OffsetsInitializer {
     @Override
     public OffsetResetStrategy getAutoOffsetResetStrategy() {
         return offsetResetStrategy;
+    }
+
+    @Override
+    public void validate(Properties kafkaSourceProperties) {
+        if (startingOffset == KafkaPartitionSplit.COMMITTED_OFFSET) {
+            checkState(
+                    kafkaSourceProperties.containsKey(ConsumerConfig.GROUP_ID_CONFIG),
+                    String.format(
+                            "Property %s is required when using committed offset for offsets initializer",
+                            ConsumerConfig.GROUP_ID_CONFIG));
+        }
     }
 }

--- a/flink-connectors/flink-connector-kafka/src/main/java/org/apache/flink/connector/kafka/source/reader/KafkaPartitionSplitReader.java
+++ b/flink-connectors/flink-connector-kafka/src/main/java/org/apache/flink/connector/kafka/source/reader/KafkaPartitionSplitReader.java
@@ -353,17 +353,19 @@ public class KafkaPartitionSplitReader<T>
             Set<TopicPartition> partitionsStoppingAtCommitted) {
         Map<TopicPartition, Long> endOffset = consumer.endOffsets(partitionsStoppingAtLatest);
         stoppingOffsets.putAll(endOffset);
-        consumer.committed(partitionsStoppingAtCommitted)
-                .forEach(
-                        (tp, offsetAndMetadata) -> {
-                            Preconditions.checkNotNull(
-                                    offsetAndMetadata,
-                                    String.format(
-                                            "Partition %s should stop at committed offset. "
-                                                    + "But there is no committed offset of this partition for group %s",
-                                            tp, groupId));
-                            stoppingOffsets.put(tp, offsetAndMetadata.offset());
-                        });
+        if (!partitionsStoppingAtCommitted.isEmpty()) {
+            consumer.committed(partitionsStoppingAtCommitted)
+                    .forEach(
+                            (tp, offsetAndMetadata) -> {
+                                Preconditions.checkNotNull(
+                                        offsetAndMetadata,
+                                        String.format(
+                                                "Partition %s should stop at committed offset. "
+                                                        + "But there is no committed offset of this partition for group %s",
+                                                tp, groupId));
+                                stoppingOffsets.put(tp, offsetAndMetadata.offset());
+                            });
+        }
     }
 
     private void removeEmptySplits() {

--- a/flink-connectors/flink-connector-kafka/src/main/java/org/apache/flink/connector/kafka/source/reader/KafkaSourceReader.java
+++ b/flink-connectors/flink-connector-kafka/src/main/java/org/apache/flink/connector/kafka/source/reader/KafkaSourceReader.java
@@ -26,6 +26,7 @@ import org.apache.flink.connector.base.source.reader.RecordEmitter;
 import org.apache.flink.connector.base.source.reader.RecordsWithSplitIds;
 import org.apache.flink.connector.base.source.reader.SingleThreadMultiplexSourceReaderBase;
 import org.apache.flink.connector.base.source.reader.synchronization.FutureCompletingBlockingQueue;
+import org.apache.flink.connector.kafka.source.KafkaSourceOptions;
 import org.apache.flink.connector.kafka.source.metrics.KafkaSourceReaderMetrics;
 import org.apache.flink.connector.kafka.source.reader.fetcher.KafkaSourceFetcherManager;
 import org.apache.flink.connector.kafka.source.split.KafkaPartitionSplit;
@@ -55,6 +56,7 @@ public class KafkaSourceReader<T>
     private final SortedMap<Long, Map<TopicPartition, OffsetAndMetadata>> offsetsToCommit;
     private final ConcurrentMap<TopicPartition, OffsetAndMetadata> offsetsOfFinishedSplits;
     private final KafkaSourceReaderMetrics kafkaSourceReaderMetrics;
+    private final boolean commitOffsetsOnCheckpoint;
 
     public KafkaSourceReader(
             FutureCompletingBlockingQueue<RecordsWithSplitIds<Tuple3<T, Long, Long>>> elementsQueue,
@@ -67,6 +69,13 @@ public class KafkaSourceReader<T>
         this.offsetsToCommit = Collections.synchronizedSortedMap(new TreeMap<>());
         this.offsetsOfFinishedSplits = new ConcurrentHashMap<>();
         this.kafkaSourceReaderMetrics = kafkaSourceReaderMetrics;
+        this.commitOffsetsOnCheckpoint =
+                config.get(KafkaSourceOptions.COMMIT_OFFSETS_ON_CHECKPOINT);
+        if (!commitOffsetsOnCheckpoint) {
+            LOG.warn(
+                    "Offset commit on checkpoint is disabled. "
+                            + "Consuming offset will not be reported back to Kafka cluster.");
+        }
     }
 
     @Override
@@ -84,6 +93,10 @@ public class KafkaSourceReader<T>
     @Override
     public List<KafkaPartitionSplit> snapshotState(long checkpointId) {
         List<KafkaPartitionSplit> splits = super.snapshotState(checkpointId);
+        if (!commitOffsetsOnCheckpoint) {
+            return splits;
+        }
+
         if (splits.isEmpty() && offsetsOfFinishedSplits.isEmpty()) {
             offsetsToCommit.put(checkpointId, Collections.emptyMap());
         } else {
@@ -108,6 +121,10 @@ public class KafkaSourceReader<T>
     @Override
     public void notifyCheckpointComplete(long checkpointId) throws Exception {
         LOG.debug("Committing offsets for checkpoint {}", checkpointId);
+        if (!commitOffsetsOnCheckpoint) {
+            return;
+        }
+
         ((KafkaSourceFetcherManager<T>) splitFetcherManager)
                 .commitOffsets(
                         offsetsToCommit.get(checkpointId),

--- a/flink-connectors/flink-connector-kafka/src/main/java/org/apache/flink/streaming/connectors/kafka/table/KafkaDynamicSource.java
+++ b/flink-connectors/flink-connector-kafka/src/main/java/org/apache/flink/streaming/connectors/kafka/table/KafkaDynamicSource.java
@@ -49,12 +49,9 @@ import org.apache.flink.table.types.DataType;
 import org.apache.flink.table.types.utils.DataTypeUtils;
 import org.apache.flink.util.Preconditions;
 
-import org.apache.kafka.clients.consumer.ConsumerConfig;
 import org.apache.kafka.clients.consumer.ConsumerRecord;
 import org.apache.kafka.common.TopicPartition;
 import org.apache.kafka.common.header.Header;
-import org.slf4j.Logger;
-import org.slf4j.LoggerFactory;
 
 import javax.annotation.Nullable;
 
@@ -76,8 +73,6 @@ import java.util.stream.Stream;
 @Internal
 public class KafkaDynamicSource
         implements ScanTableSource, SupportsReadingMetadata, SupportsWatermarkPushDown {
-
-    private static final Logger LOG = LoggerFactory.getLogger(KafkaDynamicSource.class);
 
     // --------------------------------------------------------------------------------------------
     // Mutable attributes
@@ -387,17 +382,6 @@ public class KafkaDynamicSource
             kafkaSourceBuilder.setTopics(topics);
         } else {
             kafkaSourceBuilder.setTopicPattern(topicPattern);
-        }
-
-        // For compatibility with legacy source that is not validating group id
-        if (!properties.containsKey(ConsumerConfig.GROUP_ID_CONFIG)) {
-            String generatedGroupId = "KafkaSource-" + tableIdentifier;
-            LOG.warn(
-                    "Property \"{}\" is required for offset commit but not set in table options. "
-                            + "Assigning \"{}\" as consumer group id",
-                    ConsumerConfig.GROUP_ID_CONFIG,
-                    generatedGroupId);
-            kafkaSourceBuilder.setGroupId(generatedGroupId);
         }
 
         switch (startupMode) {

--- a/flink-connectors/flink-connector-kafka/src/test/java/org/apache/flink/connector/kafka/source/KafkaSourceBuilderTest.java
+++ b/flink-connectors/flink-connector-kafka/src/test/java/org/apache/flink/connector/kafka/source/KafkaSourceBuilderTest.java
@@ -17,22 +17,103 @@
 
 package org.apache.flink.connector.kafka.source;
 
+import org.apache.flink.configuration.ConfigOptions;
 import org.apache.flink.connector.kafka.source.reader.deserializer.KafkaRecordDeserializationSchema;
 import org.apache.flink.util.TestLogger;
 
+import org.apache.kafka.clients.consumer.ConsumerConfig;
 import org.apache.kafka.common.serialization.StringDeserializer;
+import org.hamcrest.CoreMatchers;
+import org.hamcrest.MatcherAssert;
+import org.junit.Assert;
+import org.junit.jupiter.api.Assertions;
 import org.junit.jupiter.api.Test;
 
 /** Tests for {@link KafkaSourceBuilder}. */
 public class KafkaSourceBuilderTest extends TestLogger {
 
     @Test
+    public void testBuildSourceWithGroupId() {
+        final KafkaSource<String> kafkaSource = getBasicBuilder().setGroupId("groupId").build();
+        // Commit on checkpoint should be enabled by default
+        Assertions.assertTrue(
+                kafkaSource
+                        .getConfiguration()
+                        .get(KafkaSourceOptions.COMMIT_OFFSETS_ON_CHECKPOINT));
+        // Auto commit should be disabled by default
+        Assertions.assertFalse(
+                kafkaSource
+                        .getConfiguration()
+                        .get(
+                                ConfigOptions.key(ConsumerConfig.ENABLE_AUTO_COMMIT_CONFIG)
+                                        .booleanType()
+                                        .noDefaultValue()));
+    }
+
+    @Test
     public void testBuildSourceWithoutGroupId() {
-        new KafkaSourceBuilder<String>()
+        final KafkaSource<String> kafkaSource = getBasicBuilder().build();
+        // Commit on checkpoint and auto commit should be disabled because group.id is not specified
+        Assertions.assertFalse(
+                kafkaSource
+                        .getConfiguration()
+                        .get(KafkaSourceOptions.COMMIT_OFFSETS_ON_CHECKPOINT));
+        Assertions.assertFalse(
+                kafkaSource
+                        .getConfiguration()
+                        .get(
+                                ConfigOptions.key(ConsumerConfig.ENABLE_AUTO_COMMIT_CONFIG)
+                                        .booleanType()
+                                        .noDefaultValue()));
+    }
+
+    @Test
+    public void testEnableCommitOnCheckpointWithoutGroupId() {
+        final IllegalStateException exception =
+                Assert.assertThrows(
+                        IllegalStateException.class,
+                        () ->
+                                getBasicBuilder()
+                                        .setProperty(
+                                                KafkaSourceOptions.COMMIT_OFFSETS_ON_CHECKPOINT
+                                                        .key(),
+                                                "true")
+                                        .build());
+        MatcherAssert.assertThat(
+                exception.getMessage(),
+                CoreMatchers.containsString(
+                        "Property group.id is required when offset commit is enabled"));
+    }
+
+    @Test
+    public void testEnableAutoCommitWithoutGroupId() {
+        final IllegalStateException exception =
+                Assert.assertThrows(
+                        IllegalStateException.class,
+                        () ->
+                                getBasicBuilder()
+                                        .setProperty(
+                                                ConsumerConfig.ENABLE_AUTO_COMMIT_CONFIG, "true")
+                                        .build());
+        MatcherAssert.assertThat(
+                exception.getMessage(),
+                CoreMatchers.containsString(
+                        "Property group.id is required when offset commit is enabled"));
+    }
+
+    @Test
+    public void testDisableOffsetCommitWithoutGroupId() {
+        getBasicBuilder()
+                .setProperty(KafkaSourceOptions.COMMIT_OFFSETS_ON_CHECKPOINT.key(), "false")
+                .build();
+        getBasicBuilder().setProperty(ConsumerConfig.ENABLE_AUTO_COMMIT_CONFIG, "false").build();
+    }
+
+    private KafkaSourceBuilder<String> getBasicBuilder() {
+        return new KafkaSourceBuilder<String>()
                 .setBootstrapServers("testServer")
                 .setTopics("topic")
                 .setDeserializer(
-                        KafkaRecordDeserializationSchema.valueOnly(StringDeserializer.class))
-                .build();
+                        KafkaRecordDeserializationSchema.valueOnly(StringDeserializer.class));
     }
 }

--- a/flink-connectors/flink-connector-kafka/src/test/java/org/apache/flink/connector/kafka/source/KafkaSourceBuilderTest.java
+++ b/flink-connectors/flink-connector-kafka/src/test/java/org/apache/flink/connector/kafka/source/KafkaSourceBuilderTest.java
@@ -18,16 +18,22 @@
 package org.apache.flink.connector.kafka.source;
 
 import org.apache.flink.configuration.ConfigOptions;
+import org.apache.flink.connector.kafka.source.enumerator.initializer.OffsetsInitializer;
 import org.apache.flink.connector.kafka.source.reader.deserializer.KafkaRecordDeserializationSchema;
+import org.apache.flink.connector.kafka.source.split.KafkaPartitionSplit;
 import org.apache.flink.util.TestLogger;
 
 import org.apache.kafka.clients.consumer.ConsumerConfig;
+import org.apache.kafka.common.TopicPartition;
 import org.apache.kafka.common.serialization.StringDeserializer;
 import org.hamcrest.CoreMatchers;
 import org.hamcrest.MatcherAssert;
 import org.junit.Assert;
 import org.junit.jupiter.api.Assertions;
 import org.junit.jupiter.api.Test;
+
+import java.util.HashMap;
+import java.util.Map;
 
 /** Tests for {@link KafkaSourceBuilder}. */
 public class KafkaSourceBuilderTest extends TestLogger {
@@ -88,7 +94,7 @@ public class KafkaSourceBuilderTest extends TestLogger {
     @Test
     public void testEnableAutoCommitWithoutGroupId() {
         final IllegalStateException exception =
-                Assert.assertThrows(
+                Assertions.assertThrows(
                         IllegalStateException.class,
                         () ->
                                 getBasicBuilder()
@@ -107,6 +113,53 @@ public class KafkaSourceBuilderTest extends TestLogger {
                 .setProperty(KafkaSourceOptions.COMMIT_OFFSETS_ON_CHECKPOINT.key(), "false")
                 .build();
         getBasicBuilder().setProperty(ConsumerConfig.ENABLE_AUTO_COMMIT_CONFIG, "false").build();
+    }
+
+    @Test
+    public void testUsingCommittedOffsetsInitializerWithoutGroupId() {
+        // Using OffsetsInitializer#committedOffsets as starting offsets
+        final IllegalStateException startingOffsetException =
+                Assertions.assertThrows(
+                        IllegalStateException.class,
+                        () ->
+                                getBasicBuilder()
+                                        .setStartingOffsets(OffsetsInitializer.committedOffsets())
+                                        .build());
+        MatcherAssert.assertThat(
+                startingOffsetException.getMessage(),
+                CoreMatchers.containsString(
+                        "Property group.id is required when using committed offset for offsets initializer"));
+
+        // Using OffsetsInitializer#committedOffsets as stopping offsets
+        final IllegalStateException stoppingOffsetException =
+                Assertions.assertThrows(
+                        IllegalStateException.class,
+                        () ->
+                                getBasicBuilder()
+                                        .setBounded(OffsetsInitializer.committedOffsets())
+                                        .build());
+        MatcherAssert.assertThat(
+                stoppingOffsetException.getMessage(),
+                CoreMatchers.containsString(
+                        "Property group.id is required when using committed offset for offsets initializer"));
+
+        // Using OffsetsInitializer#offsets to manually specify committed offset as starting offset
+        final IllegalStateException specificStartingOffsetException =
+                Assertions.assertThrows(
+                        IllegalStateException.class,
+                        () -> {
+                            final Map<TopicPartition, Long> offsetMap = new HashMap<>();
+                            offsetMap.put(
+                                    new TopicPartition("topic", 0),
+                                    KafkaPartitionSplit.COMMITTED_OFFSET);
+                            getBasicBuilder()
+                                    .setStartingOffsets(OffsetsInitializer.offsets(offsetMap))
+                                    .build();
+                        });
+        MatcherAssert.assertThat(
+                specificStartingOffsetException.getMessage(),
+                CoreMatchers.containsString(
+                        "Property group.id is required because partition topic-0 is initialized with committed offset"));
     }
 
     private KafkaSourceBuilder<String> getBasicBuilder() {

--- a/flink-connectors/flink-connector-kafka/src/test/java/org/apache/flink/connector/kafka/source/KafkaSourceITCase.java
+++ b/flink-connectors/flink-connector-kafka/src/test/java/org/apache/flink/connector/kafka/source/KafkaSourceITCase.java
@@ -219,6 +219,27 @@ public class KafkaSourceITCase {
                             source, WatermarkStrategy.noWatermarks(), "testRedundantParallelism");
             executeAndVerify(env, stream);
         }
+
+        @Test
+        public void testBasicReadWithoutGroupId() throws Exception {
+            KafkaSource<PartitionAndValue> source =
+                    KafkaSource.<PartitionAndValue>builder()
+                            .setBootstrapServers(KafkaSourceTestEnv.brokerConnectionStrings)
+                            .setTopics(Arrays.asList(TOPIC1, TOPIC2))
+                            .setDeserializer(new TestingKafkaRecordDeserializationSchema())
+                            .setStartingOffsets(OffsetsInitializer.earliest())
+                            .setBounded(OffsetsInitializer.latest())
+                            .build();
+
+            StreamExecutionEnvironment env = StreamExecutionEnvironment.getExecutionEnvironment();
+            env.setParallelism(1);
+            DataStream<PartitionAndValue> stream =
+                    env.fromSource(
+                            source,
+                            WatermarkStrategy.noWatermarks(),
+                            "testBasicReadWithoutGroupId");
+            executeAndVerify(env, stream);
+        }
     }
 
     /** Integration test based on connector testing framework. */

--- a/flink-connectors/flink-connector-kafka/src/test/java/org/apache/flink/connector/kafka/source/KafkaSourceTestUtils.java
+++ b/flink-connectors/flink-connector-kafka/src/test/java/org/apache/flink/connector/kafka/source/KafkaSourceTestUtils.java
@@ -19,6 +19,7 @@
 package org.apache.flink.connector.kafka.source;
 
 import org.apache.flink.api.connector.source.SourceReaderContext;
+import org.apache.flink.configuration.Configuration;
 import org.apache.flink.connector.kafka.source.reader.KafkaSourceReader;
 
 import java.util.Collection;
@@ -43,5 +44,10 @@ public class KafkaSourceTestUtils {
             throws Exception {
         return ((KafkaSourceReader<T>)
                 kafkaSource.createReader(sourceReaderContext, splitFinishedHook));
+    }
+
+    /** Get configuration of KafkaSource. */
+    public static Configuration getKafkaSourceConfiguration(KafkaSource<?> kafkaSource) {
+        return kafkaSource.getConfiguration();
     }
 }

--- a/flink-connectors/flink-connector-kafka/src/test/java/org/apache/flink/streaming/connectors/kafka/table/KafkaDynamicTableFactoryTest.java
+++ b/flink-connectors/flink-connector-kafka/src/test/java/org/apache/flink/streaming/connectors/kafka/table/KafkaDynamicTableFactoryTest.java
@@ -22,9 +22,13 @@ import org.apache.flink.api.common.serialization.DeserializationSchema;
 import org.apache.flink.api.common.serialization.SerializationSchema;
 import org.apache.flink.api.connector.sink.Sink;
 import org.apache.flink.api.dag.Transformation;
+import org.apache.flink.configuration.ConfigOptions;
+import org.apache.flink.configuration.Configuration;
 import org.apache.flink.connector.base.DeliveryGuarantee;
 import org.apache.flink.connector.kafka.sink.KafkaSink;
 import org.apache.flink.connector.kafka.source.KafkaSource;
+import org.apache.flink.connector.kafka.source.KafkaSourceOptions;
+import org.apache.flink.connector.kafka.source.KafkaSourceTestUtils;
 import org.apache.flink.connector.kafka.source.enumerator.KafkaSourceEnumState;
 import org.apache.flink.connector.kafka.source.split.KafkaPartitionSplit;
 import org.apache.flink.formats.avro.AvroRowDataSerializationSchema;
@@ -68,6 +72,7 @@ import org.apache.flink.util.TestLogger;
 
 import org.apache.flink.shaded.guava30.com.google.common.collect.ImmutableList;
 
+import org.apache.kafka.clients.consumer.ConsumerConfig;
 import org.junit.Rule;
 import org.junit.Test;
 import org.junit.rules.ExpectedException;
@@ -93,6 +98,7 @@ import static org.apache.flink.table.factories.utils.FactoryMocks.createTableSou
 import static org.hamcrest.CoreMatchers.instanceOf;
 import static org.hamcrest.MatcherAssert.assertThat;
 import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertFalse;
 import static org.junit.Assert.assertTrue;
 import static org.junit.Assert.fail;
 
@@ -347,6 +353,31 @@ public class KafkaDynamicTableFactoryTest extends TestLogger {
         expectedKafkaSource.metadataKeys = Collections.singletonList("timestamp");
 
         assertEquals(actualSource, expectedKafkaSource);
+    }
+
+    @Test
+    public void testTableSourceCommitOnCheckpointDisabled() {
+        final Map<String, String> modifiedOptions =
+                getModifiedOptions(
+                        getBasicSourceOptions(), options -> options.remove("properties.group.id"));
+        final DynamicTableSource tableSource = createTableSource(SCHEMA, modifiedOptions);
+
+        assertThat(tableSource, instanceOf(KafkaDynamicSource.class));
+        ScanTableSource.ScanRuntimeProvider providerWithoutGroupId =
+                ((KafkaDynamicSource) tableSource)
+                        .getScanRuntimeProvider(ScanRuntimeProviderContext.INSTANCE);
+        assertThat(providerWithoutGroupId, instanceOf(DataStreamScanProvider.class));
+        final KafkaSource<?> kafkaSource = assertKafkaSource(providerWithoutGroupId);
+        final Configuration configuration =
+                KafkaSourceTestUtils.getKafkaSourceConfiguration(kafkaSource);
+
+        // Test offset commit on checkpoint should be disabled when do not set consumer group.
+        assertFalse(configuration.get(KafkaSourceOptions.COMMIT_OFFSETS_ON_CHECKPOINT));
+        assertFalse(
+                configuration.get(
+                        ConfigOptions.key(ConsumerConfig.ENABLE_AUTO_COMMIT_CONFIG)
+                                .booleanType()
+                                .noDefaultValue()));
     }
 
     @Test
@@ -997,7 +1028,7 @@ public class KafkaDynamicTableFactoryTest extends TestLogger {
         return tableOptions;
     }
 
-    private void assertKafkaSource(ScanTableSource.ScanRuntimeProvider provider) {
+    private KafkaSource<?> assertKafkaSource(ScanTableSource.ScanRuntimeProvider provider) {
         assertThat(provider, instanceOf(DataStreamScanProvider.class));
         final DataStreamScanProvider dataStreamScanProvider = (DataStreamScanProvider) provider;
         final Transformation<RowData> transformation =
@@ -1010,5 +1041,6 @@ public class KafkaDynamicTableFactoryTest extends TestLogger {
                         (SourceTransformation<RowData, KafkaPartitionSplit, KafkaSourceEnumState>)
                                 transformation;
         assertThat(sourceTransformation.getSource(), instanceOf(KafkaSource.class));
+        return (KafkaSource<?>) sourceTransformation.getSource();
     }
 }


### PR DESCRIPTION

## What is the purpose of the change
This pull request adds a configuration for KafkaSource for disabling offset commit on checkpoint, and add sanity checks on `group.id`


## Brief change log
- Add config for disabling offset commit on checkpoint
- Add sanity checks on `group.id`. If `group.id` is not specified, offset commit on checkpoint will be disabled
- Remove auto-generated group id in Kafka table source


## Verifying this change

This change added tests and can be verified as follows:

  - Added integration tests for using Kafka source without group ID
  - Added test validating KafkaSourceBuilder capturing corrupted configurations (enabled offset commit manually but missing group id)
  - Added test in Kafka table source for validating offset commit is disabled without group id

## Does this pull request potentially affect one of the following parts:

  - Dependencies (does it add or upgrade a dependency): (no)
  - The public API, i.e., is any changed class annotated with `@Public(Evolving)`: (no)
  - The serializers: (no)
  - The runtime per-record code paths (performance sensitive): (no)
  - Anything that affects deployment or recovery: JobManager (and its components), Checkpointing, Kubernetes/Yarn, ZooKeeper: (no)
  - The S3 file system connector: (no)

## Documentation

  - Does this pull request introduce a new feature? (no)
  - If yes, how is the feature documented? (docs)
