### PR TITLE
[FLINK-24280] Support manual checkpoints triggering from a MiniCluster 

### DIFF
--- a/flink-core/src/test/java/org/apache/flink/api/connector/source/mocks/MockSourceReader.java
+++ b/flink-core/src/test/java/org/apache/flink/api/connector/source/mocks/MockSourceReader.java
@@ -40,7 +40,20 @@ public class MockSourceReader implements SourceReader<Integer, MockSourceSplit> 
     private int currentSplitIndex = 0;
     private boolean started;
     private int timesClosed;
-    private boolean waitingForMoreSplits;
+    private final WaitingForSplits waitingForSplitsBehaviour;
+    private SplitsAssignmentState splitsAssignmentState = SplitsAssignmentState.NO_SPLITS_ASSIGNED;
+
+    enum WaitingForSplits {
+        WAIT_FOR_INITIAL,
+        WAIT_UNTIL_ALL_SPLITS_ASSIGNED,
+        DO_NOT_WAIT_FOR_SPLITS
+    }
+
+    private enum SplitsAssignmentState {
+        NO_SPLITS_ASSIGNED,
+        INITIAL_SPLITS_ASSIGNED,
+        NO_MORE_SPLITS
+    }
 
     @GuardedBy("this")
     private CompletableFuture<Void> availableFuture;
@@ -50,10 +63,19 @@ public class MockSourceReader implements SourceReader<Integer, MockSourceSplit> 
     }
 
     public MockSourceReader(boolean waitingForMoreSplits, boolean markIdleOnNoSplits) {
+        this(
+                waitingForMoreSplits
+                        ? WaitingForSplits.WAIT_UNTIL_ALL_SPLITS_ASSIGNED
+                        : WaitingForSplits.DO_NOT_WAIT_FOR_SPLITS,
+                markIdleOnNoSplits);
+    }
+
+    public MockSourceReader(
+            WaitingForSplits waitingForSplitsBehaviour, boolean markIdleOnNoSplits) {
         this.started = false;
         this.timesClosed = 0;
         this.availableFuture = CompletableFuture.completedFuture(null);
-        this.waitingForMoreSplits = waitingForMoreSplits;
+        this.waitingForSplitsBehaviour = waitingForSplitsBehaviour;
         this.markIdleOnNoSplits = markIdleOnNoSplits;
     }
 
@@ -64,7 +86,16 @@ public class MockSourceReader implements SourceReader<Integer, MockSourceSplit> 
 
     @Override
     public InputStatus pollNext(ReaderOutput<Integer> sourceOutput) throws Exception {
-        boolean finished = !waitingForMoreSplits;
+
+        if (waitingForSplitsBehaviour == WaitingForSplits.WAIT_FOR_INITIAL
+                && splitsAssignmentState == SplitsAssignmentState.NO_SPLITS_ASSIGNED) {
+            markUnavailable();
+            return InputStatus.NOTHING_AVAILABLE;
+        }
+
+        boolean finished =
+                splitsAssignmentState == SplitsAssignmentState.NO_MORE_SPLITS
+                        || waitingForSplitsBehaviour == WaitingForSplits.DO_NOT_WAIT_FOR_SPLITS;
         currentSplitIndex = 0;
         // Find first splits with available records.
         while (currentSplitIndex < assignedSplits.size()
@@ -101,13 +132,16 @@ public class MockSourceReader implements SourceReader<Integer, MockSourceSplit> 
 
     @Override
     public void addSplits(List<MockSourceSplit> splits) {
+        if (splitsAssignmentState == SplitsAssignmentState.NO_SPLITS_ASSIGNED) {
+            splitsAssignmentState = SplitsAssignmentState.INITIAL_SPLITS_ASSIGNED;
+        }
         assignedSplits.addAll(splits);
         markAvailable();
     }
 
     @Override
     public void notifyNoMoreSplits() {
-        waitingForMoreSplits = false;
+        splitsAssignmentState = SplitsAssignmentState.NO_MORE_SPLITS;
         markAvailable();
     }
 

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/dispatcher/Dispatcher.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/dispatcher/Dispatcher.java
@@ -678,6 +678,12 @@ public abstract class Dispatcher extends PermanentlyFencedRpcEndpoint<Dispatcher
     }
 
     @Override
+    public CompletableFuture<String> triggerCheckpoint(JobID jobID, Time timeout) {
+        return performOperationOnJobMasterGateway(
+                jobID, gateway -> gateway.triggerCheckpoint(timeout));
+    }
+
+    @Override
     public CompletableFuture<String> triggerSavepoint(
             final JobID jobId,
             final String targetDirectory,

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/dispatcher/DispatcherGateway.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/dispatcher/DispatcherGateway.java
@@ -61,4 +61,8 @@ public interface DispatcherGateway extends FencedRpcGateway<DispatcherId>, Restf
     default CompletableFuture<Acknowledge> shutDownCluster(ApplicationStatus applicationStatus) {
         return shutDownCluster();
     }
+
+    default CompletableFuture<String> triggerCheckpoint(JobID jobID, @RpcTimeout Time timeout) {
+        throw new UnsupportedOperationException();
+    }
 }

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/jobmaster/JobMaster.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/jobmaster/JobMaster.java
@@ -792,6 +792,11 @@ public class JobMaster extends PermanentlyFencedRpcEndpoint<JobMasterId>
     }
 
     @Override
+    public CompletableFuture<String> triggerCheckpoint(Time timeout) {
+        return schedulerNG.triggerCheckpoint();
+    }
+
+    @Override
     public CompletableFuture<String> stopWithSavepoint(
             @Nullable final String targetDirectory, final boolean terminate, final Time timeout) {
 

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/jobmaster/JobMasterGateway.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/jobmaster/JobMasterGateway.java
@@ -235,6 +235,14 @@ public interface JobMasterGateway
             @RpcTimeout final Time timeout);
 
     /**
+     * Triggers taking a checkpoint of the executed job.
+     *
+     * @param timeout for the rpc call
+     * @return Future which is completed with the checkpoint path once completed
+     */
+    CompletableFuture<String> triggerCheckpoint(@RpcTimeout final Time timeout);
+
+    /**
      * Stops the job with a savepoint.
      *
      * @param targetDirectory to which to write the savepoint data or null if the default savepoint

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/minicluster/MiniCluster.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/minicluster/MiniCluster.java
@@ -744,6 +744,11 @@ public class MiniCluster implements AutoCloseableAsync {
                                 jobId, targetDirectory, cancelJob, rpcTimeout));
     }
 
+    public CompletableFuture<String> triggerCheckpoint(JobID jobID) {
+        return runDispatcherCommand(
+                dispatcherGateway -> dispatcherGateway.triggerCheckpoint(jobID, rpcTimeout));
+    }
+
     public CompletableFuture<String> stopWithSavepoint(
             JobID jobId, String targetDirectory, boolean terminate) {
         return runDispatcherCommand(

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/scheduler/SchedulerNG.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/scheduler/SchedulerNG.java
@@ -127,6 +127,8 @@ public interface SchedulerNG extends AutoCloseableAsync {
 
     CompletableFuture<String> triggerSavepoint(@Nullable String targetDirectory, boolean cancelJob);
 
+    CompletableFuture<String> triggerCheckpoint();
+
     void acknowledgeCheckpoint(
             JobID jobID,
             ExecutionAttemptID executionAttemptID,

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/scheduler/adaptive/AdaptiveScheduler.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/scheduler/adaptive/AdaptiveScheduler.java
@@ -601,6 +601,19 @@ public class AdaptiveScheduler
     }
 
     @Override
+    public CompletableFuture<String> triggerCheckpoint() {
+        return state.tryCall(
+                        StateWithExecutionGraph.class,
+                        StateWithExecutionGraph::triggerCheckpoint,
+                        "triggerCheckpoint")
+                .orElse(
+                        FutureUtils.completedExceptionally(
+                                new CheckpointException(
+                                        "The Flink job is currently not executing.",
+                                        CheckpointFailureReason.TRIGGER_CHECKPOINT_FAILURE)));
+    }
+
+    @Override
     public void acknowledgeCheckpoint(
             JobID jobID,
             ExecutionAttemptID executionAttemptID,

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/state/filesystem/FsCheckpointStorageAccess.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/state/filesystem/FsCheckpointStorageAccess.java
@@ -112,15 +112,12 @@ public class FsCheckpointStorageAccess extends AbstractFsCheckpointStorageAccess
     public void initializeBaseLocationsForCheckpoint() throws IOException {
         fileSystem.mkdirs(sharedStateDirectory);
         fileSystem.mkdirs(taskOwnedStateDirectory);
-        baseLocationsInitialized = true;
     }
 
     @Override
     public CheckpointStorageLocation initializeLocationForCheckpoint(long checkpointId)
             throws IOException {
         checkArgument(checkpointId >= 0, "Illegal negative checkpoint id: %s.", checkpointId);
-        checkArgument(
-                baseLocationsInitialized, "The base checkpoint location has not been initialized.");
 
         // prepare all the paths needed for the checkpoints
         final Path checkpointDir = createCheckpointDirectory(checkpointsDirectory, checkpointId);

--- a/flink-runtime/src/test/java/org/apache/flink/runtime/jobmaster/utils/TestingJobMasterGateway.java
+++ b/flink-runtime/src/test/java/org/apache/flink/runtime/jobmaster/utils/TestingJobMasterGateway.java
@@ -133,6 +133,8 @@ public class TestingJobMasterGateway implements JobMasterGateway {
     @Nonnull
     private final BiFunction<String, Boolean, CompletableFuture<String>> triggerSavepointFunction;
 
+    @Nonnull private final Supplier<CompletableFuture<String>> triggerCheckpointFunction;
+
     @Nonnull
     private final BiFunction<String, Boolean, CompletableFuture<String>> stopWithSavepointFunction;
 
@@ -233,6 +235,7 @@ public class TestingJobMasterGateway implements JobMasterGateway {
             @Nonnull Supplier<CompletableFuture<ExecutionGraphInfo>> requestJobSupplier,
             @Nonnull
                     BiFunction<String, Boolean, CompletableFuture<String>> triggerSavepointFunction,
+            @Nonnull Supplier<CompletableFuture<String>> triggerCheckpointFunction,
             @Nonnull
                     BiFunction<String, Boolean, CompletableFuture<String>>
                             stopWithSavepointFunction,
@@ -301,6 +304,7 @@ public class TestingJobMasterGateway implements JobMasterGateway {
         this.requestJobDetailsSupplier = requestJobDetailsSupplier;
         this.requestJobSupplier = requestJobSupplier;
         this.triggerSavepointFunction = triggerSavepointFunction;
+        this.triggerCheckpointFunction = triggerCheckpointFunction;
         this.stopWithSavepointFunction = stopWithSavepointFunction;
         this.notifyAllocationFailureConsumer = notifyAllocationFailureConsumer;
         this.acknowledgeCheckpointConsumer = acknowledgeCheckpointConsumer;
@@ -406,6 +410,11 @@ public class TestingJobMasterGateway implements JobMasterGateway {
     public CompletableFuture<String> triggerSavepoint(
             @Nullable final String targetDirectory, final boolean cancelJob, final Time timeout) {
         return triggerSavepointFunction.apply(targetDirectory, cancelJob);
+    }
+
+    @Override
+    public CompletableFuture<String> triggerCheckpoint(Time timeout) {
+        return triggerCheckpointFunction.get();
     }
 
     @Override

--- a/flink-runtime/src/test/java/org/apache/flink/runtime/jobmaster/utils/TestingJobMasterGatewayBuilder.java
+++ b/flink-runtime/src/test/java/org/apache/flink/runtime/jobmaster/utils/TestingJobMasterGatewayBuilder.java
@@ -126,6 +126,8 @@ public class TestingJobMasterGatewayBuilder {
                             targetDirectory != null
                                     ? targetDirectory
                                     : UUID.randomUUID().toString());
+    private Supplier<CompletableFuture<String>> triggerCheckpointFunction =
+            () -> CompletableFuture.completedFuture(UUID.randomUUID().toString());
     private BiFunction<String, Boolean, CompletableFuture<String>> stopWithSavepointFunction =
             (targetDirectory, ignoredB) ->
                     CompletableFuture.completedFuture(
@@ -285,6 +287,12 @@ public class TestingJobMasterGatewayBuilder {
         return this;
     }
 
+    public TestingJobMasterGatewayBuilder setTriggerCheckpointFunction(
+            Supplier<CompletableFuture<String>> triggerCheckpointFunction) {
+        this.triggerCheckpointFunction = triggerCheckpointFunction;
+        return this;
+    }
+
     public TestingJobMasterGatewayBuilder setStopWithSavepointSupplier(
             BiFunction<String, Boolean, CompletableFuture<String>> stopWithSavepointFunction) {
         this.stopWithSavepointFunction = stopWithSavepointFunction;
@@ -400,6 +408,7 @@ public class TestingJobMasterGatewayBuilder {
                 requestJobDetailsSupplier,
                 requestJobSupplier,
                 triggerSavepointFunction,
+                triggerCheckpointFunction,
                 stopWithSavepointFunction,
                 notifyAllocationFailureConsumer,
                 acknowledgeCheckpointConsumer,

--- a/flink-runtime/src/test/java/org/apache/flink/runtime/scheduler/TestingSchedulerNG.java
+++ b/flink-runtime/src/test/java/org/apache/flink/runtime/scheduler/TestingSchedulerNG.java
@@ -57,6 +57,7 @@ public class TestingSchedulerNG implements SchedulerNG {
     private final Runnable startSchedulingRunnable;
     private final Supplier<CompletableFuture<Void>> closeAsyncSupplier;
     private final BiFunction<String, Boolean, CompletableFuture<String>> triggerSavepointFunction;
+    private final Supplier<CompletableFuture<String>> triggerCheckpointFunction;
     private final Consumer<Throwable> handleGlobalFailureConsumer;
 
     private TestingSchedulerNG(
@@ -64,11 +65,13 @@ public class TestingSchedulerNG implements SchedulerNG {
             Runnable startSchedulingRunnable,
             Supplier<CompletableFuture<Void>> closeAsyncSupplier,
             BiFunction<String, Boolean, CompletableFuture<String>> triggerSavepointFunction,
+            Supplier<CompletableFuture<String>> triggerCheckpointFunction,
             Consumer<Throwable> handleGlobalFailureConsumer) {
         this.jobTerminationFuture = jobTerminationFuture;
         this.startSchedulingRunnable = startSchedulingRunnable;
         this.closeAsyncSupplier = closeAsyncSupplier;
         this.triggerSavepointFunction = triggerSavepointFunction;
+        this.triggerCheckpointFunction = triggerCheckpointFunction;
         this.handleGlobalFailureConsumer = handleGlobalFailureConsumer;
     }
 
@@ -180,6 +183,11 @@ public class TestingSchedulerNG implements SchedulerNG {
     }
 
     @Override
+    public CompletableFuture<String> triggerCheckpoint() {
+        return triggerCheckpointFunction.get();
+    }
+
+    @Override
     public void acknowledgeCheckpoint(
             JobID jobID,
             ExecutionAttemptID executionAttemptID,
@@ -232,6 +240,8 @@ public class TestingSchedulerNG implements SchedulerNG {
                 FutureUtils::completedVoidFuture;
         private BiFunction<String, Boolean, CompletableFuture<String>> triggerSavepointFunction =
                 (ignoredA, ignoredB) -> new CompletableFuture<>();
+        private Supplier<CompletableFuture<String>> triggerCheckpointFunction =
+                CompletableFuture::new;
         private Consumer<Throwable> handleGlobalFailureConsumer = (ignored) -> {};
 
         public Builder setJobTerminationFuture(CompletableFuture<JobStatus> jobTerminationFuture) {
@@ -255,6 +265,12 @@ public class TestingSchedulerNG implements SchedulerNG {
             return this;
         }
 
+        public Builder setTriggerCheckpointFunction(
+                Supplier<CompletableFuture<String>> triggerCheckpointFunction) {
+            this.triggerCheckpointFunction = triggerCheckpointFunction;
+            return this;
+        }
+
         public Builder setHandleGlobalFailureConsumer(
                 Consumer<Throwable> handleGlobalFailureConsumer) {
             this.handleGlobalFailureConsumer = handleGlobalFailureConsumer;
@@ -267,6 +283,7 @@ public class TestingSchedulerNG implements SchedulerNG {
                     startSchedulingRunnable,
                     closeAsyncSupplier,
                     triggerSavepointFunction,
+                    triggerCheckpointFunction,
                     handleGlobalFailureConsumer);
         }
     }

--- a/flink-tests/src/test/java/org/apache/flink/test/checkpointing/ManualCheckpointITCase.java
+++ b/flink-tests/src/test/java/org/apache/flink/test/checkpointing/ManualCheckpointITCase.java
@@ -1,0 +1,180 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.flink.test.checkpointing;
+
+import org.apache.flink.api.common.JobID;
+import org.apache.flink.api.common.JobStatus;
+import org.apache.flink.api.common.eventtime.WatermarkStrategy;
+import org.apache.flink.api.common.functions.RichFlatMapFunction;
+import org.apache.flink.api.common.state.ValueState;
+import org.apache.flink.api.common.state.ValueStateDescriptor;
+import org.apache.flink.api.common.time.Deadline;
+import org.apache.flink.api.common.typeinfo.BasicTypeInfo;
+import org.apache.flink.api.connector.source.mocks.MockSource;
+import org.apache.flink.configuration.Configuration;
+import org.apache.flink.core.execution.JobClient;
+import org.apache.flink.runtime.minicluster.MiniCluster;
+import org.apache.flink.runtime.state.CheckpointStorage;
+import org.apache.flink.runtime.state.storage.FileSystemCheckpointStorage;
+import org.apache.flink.runtime.state.storage.JobManagerCheckpointStorage;
+import org.apache.flink.runtime.testutils.CommonTestUtils;
+import org.apache.flink.streaming.api.environment.StreamExecutionEnvironment;
+import org.apache.flink.streaming.api.functions.sink.DiscardingSink;
+import org.apache.flink.test.util.AbstractTestBase;
+import org.apache.flink.util.Collector;
+
+import org.junit.Rule;
+import org.junit.Test;
+import org.junit.rules.TemporaryFolder;
+import org.junit.runner.RunWith;
+import org.junit.runners.Parameterized;
+
+import java.io.IOException;
+import java.time.Duration;
+import java.util.Collections;
+import java.util.Optional;
+import java.util.function.Function;
+
+import static org.hamcrest.CoreMatchers.equalTo;
+import static org.hamcrest.MatcherAssert.assertThat;
+import static org.hamcrest.Matchers.greaterThanOrEqualTo;
+
+/** Tests for manually triggering checkpoints. */
+@RunWith(Parameterized.class)
+public class ManualCheckpointITCase extends AbstractTestBase {
+
+    @Parameterized.Parameter public StorageSupplier storageSupplier;
+
+    @Rule public TemporaryFolder temporaryFolder = new TemporaryFolder();
+
+    private interface StorageSupplier extends Function<String, CheckpointStorage> {}
+
+    @Parameterized.Parameters
+    public static StorageSupplier[] parameters() throws IOException {
+        return new StorageSupplier[] {
+            path -> new JobManagerCheckpointStorage(), FileSystemCheckpointStorage::new
+        };
+    }
+
+    @Test
+    public void testTriggeringWhenPeriodicDisabled() throws Exception {
+        int parallelism = miniClusterResource.getNumberSlots();
+        final StreamExecutionEnvironment env = StreamExecutionEnvironment.getExecutionEnvironment();
+        env.setParallelism(parallelism);
+        env.getCheckpointConfig()
+                .setCheckpointStorage(
+                        storageSupplier.apply(temporaryFolder.newFolder().toURI().toString()));
+
+        env.fromSource(
+                        MockSource.continuous(parallelism).build(),
+                        WatermarkStrategy.noWatermarks(),
+                        "generator")
+                .keyBy(key -> key % parallelism)
+                .flatMap(new StatefulMapper())
+                .addSink(new DiscardingSink<>());
+
+        final JobClient jobClient = env.executeAsync();
+        final JobID jobID = jobClient.getJobID();
+        final MiniCluster miniCluster = miniClusterResource.getMiniCluster();
+
+        CommonTestUtils.waitForJobStatus(
+                jobClient,
+                Collections.singletonList(JobStatus.RUNNING),
+                Deadline.fromNow(Duration.ofSeconds(30)));
+        CommonTestUtils.waitForAllTaskRunning(miniCluster, jobID, false);
+
+        // wait for the checkpoint to be taken
+        miniCluster.triggerCheckpoint(jobID).get();
+        miniCluster.cancelJob(jobID).get();
+        final long numberOfCompletedCheckpoints = queryCompletedCheckpoints(miniCluster, jobID);
+        assertThat(numberOfCompletedCheckpoints, equalTo(1L));
+    }
+
+    @Test
+    public void testTriggeringWhenPeriodicEnabled() throws Exception {
+        int parallelism = miniClusterResource.getNumberSlots();
+        final int checkpointingInterval = 500;
+        final StreamExecutionEnvironment env = StreamExecutionEnvironment.getExecutionEnvironment();
+        env.setParallelism(parallelism);
+        env.enableCheckpointing(checkpointingInterval);
+        env.getCheckpointConfig()
+                .setCheckpointStorage(
+                        storageSupplier.apply(temporaryFolder.newFolder().toURI().toString()));
+
+        env.fromSource(
+                        MockSource.continuous(parallelism).build(),
+                        WatermarkStrategy.noWatermarks(),
+                        "generator")
+                .keyBy(key -> key % parallelism)
+                .flatMap(new StatefulMapper())
+                .addSink(new DiscardingSink<>());
+
+        final JobClient jobClient = env.executeAsync();
+        final JobID jobID = jobClient.getJobID();
+        final MiniCluster miniCluster = miniClusterResource.getMiniCluster();
+
+        CommonTestUtils.waitForJobStatus(
+                jobClient,
+                Collections.singletonList(JobStatus.RUNNING),
+                Deadline.fromNow(Duration.ofSeconds(30)));
+        CommonTestUtils.waitForAllTaskRunning(miniCluster, jobID, false);
+        CommonTestUtils.waitUntilCondition(
+                () -> queryCompletedCheckpoints(miniCluster, jobID) > 0L,
+                Deadline.fromNow(Duration.ofSeconds(30)),
+                checkpointingInterval / 2);
+
+        final long numberOfPeriodicCheckpoints = queryCompletedCheckpoints(miniCluster, jobID);
+        // wait for the checkpoint to be taken
+        miniCluster.triggerCheckpoint(jobID).get();
+        miniCluster.cancelJob(jobID).get();
+        final long numberOfCompletedCheckpoints = queryCompletedCheckpoints(miniCluster, jobID);
+        assertThat(
+                numberOfCompletedCheckpoints,
+                greaterThanOrEqualTo(numberOfPeriodicCheckpoints + 1));
+    }
+
+    private long queryCompletedCheckpoints(MiniCluster miniCluster, JobID jobID) throws Exception {
+        return miniCluster
+                .getArchivedExecutionGraph(jobID)
+                .get()
+                .getCheckpointStatsSnapshot()
+                .getCounts()
+                .getNumberOfCompletedCheckpoints();
+    }
+
+    private static final class StatefulMapper extends RichFlatMapFunction<Integer, Long> {
+        private ValueState<Long> count;
+
+        @Override
+        public void open(Configuration parameters) throws Exception {
+            count =
+                    getRuntimeContext()
+                            .getState(
+                                    new ValueStateDescriptor<>(
+                                            "count", BasicTypeInfo.LONG_TYPE_INFO));
+        }
+
+        @Override
+        public void flatMap(Integer value, Collector<Long> out) throws Exception {
+            final long sum = Optional.ofNullable(count.value()).orElse(0L) + value;
+            count.update(sum);
+            out.collect(sum);
+        }
+    }
+}


### PR DESCRIPTION
## What is the purpose of the change

We want to have a way to trigger a checkpoint at a well defined point in time. The feature is intended to be used purely in tests and benchmarks

## Brief change log

  - 3ac77bd - changes the `MockSourceReader` so that it can wait for the initial splits. Without the change it could've finished before any splits were assigned to it, even though there were `AddSplitsEvent(s)` "on the wire" 
  - e7af45a - exposes an already available method `CheckpointCoordinator#triggerCheckpoint(boolean periodic)` through REST APIs of (Dispatcher/JobManager/...)


## Verifying this change
Added tests in `ManualCheckpointITCase`

## Does this pull request potentially affect one of the following parts:

  - Dependencies (does it add or upgrade a dependency): (yes / **no**)
  - The public API, i.e., is any changed class annotated with `@Public(Evolving)`: (yes / **no**)
  - The serializers: (yes / **no** / don't know)
  - The runtime per-record code paths (performance sensitive): (yes / **no** / don't know)
  - Anything that affects deployment or recovery: JobManager (and its components), Checkpointing, Kubernetes/Yarn, ZooKeeper: (**yes** / no / don't know)
  - The S3 file system connector: (yes / **no** / don't know)

## Documentation

  - Does this pull request introduce a new feature? (yes / **no**)
  - If yes, how is the feature documented? (**not applicable** / docs / JavaDocs / not documented)
