### PR TITLE
[WIP]FLINK-23342] Introduce ShareableStateHandle

### DIFF
--- a/flink-runtime/src/main/java/org/apache/flink/runtime/state/DirectoryKeyedStateHandle.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/state/DirectoryKeyedStateHandle.java
@@ -65,8 +65,10 @@ public class DirectoryKeyedStateHandle implements KeyedStateHandle {
 
     @Override
     public KeyedStateHandle getIntersection(KeyGroupRange otherKeyGroupRange) {
-        return this.keyGroupRange.getIntersection(otherKeyGroupRange).getNumberOfKeyGroups() > 0
-                ? this
+        KeyGroupRange intersection = this.keyGroupRange.getIntersection(otherKeyGroupRange);
+        return intersection.getNumberOfKeyGroups() > 0
+                ? new DirectoryKeyedStateHandle(
+                        (DirectoryStateHandle) directoryStateHandle.asShared(), intersection)
                 : null;
     }
 

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/state/DirectoryStateHandle.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/state/DirectoryStateHandle.java
@@ -30,7 +30,7 @@ import java.nio.file.Paths;
  * This state handle represents a directory. This class is, for example, used to represent the
  * directory of RocksDB's native checkpoint directories for local recovery.
  */
-public class DirectoryStateHandle implements StateObject {
+public class DirectoryStateHandle implements StateObject, ShareableStateHandle {
 
     /** Serial version. */
     private static final long serialVersionUID = 1L;
@@ -41,9 +41,16 @@ public class DirectoryStateHandle implements StateObject {
     /** Transient path cache, to avoid re-parsing the string. */
     private transient Path directory;
 
+    private final boolean shared;
+
     public DirectoryStateHandle(@Nonnull Path directory) {
+        this(directory, false);
+    }
+
+    public DirectoryStateHandle(@Nonnull Path directory, boolean shared) {
         this.directory = directory;
         this.directoryString = directory.toString();
+        this.shared = shared;
     }
 
     @Override
@@ -93,5 +100,15 @@ public class DirectoryStateHandle implements StateObject {
     @Override
     public String toString() {
         return "DirectoryStateHandle{" + "directory=" + directoryString + '}';
+    }
+
+    @Override
+    public boolean isShared() {
+        return shared;
+    }
+
+    @Override
+    public StateObject asShared() {
+        return new DirectoryStateHandle(directory, true);
     }
 }

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/state/KeyGroupsSavepointStateHandle.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/state/KeyGroupsSavepointStateHandle.java
@@ -44,7 +44,8 @@ public class KeyGroupsSavepointStateHandle extends KeyGroupsStateHandle
         if (offsets.getKeyGroupRange().getNumberOfKeyGroups() <= 0) {
             return null;
         }
-        return new KeyGroupsSavepointStateHandle(offsets, getDelegateStateHandle());
+        return new KeyGroupsSavepointStateHandle(
+                offsets, (StreamStateHandle) getDelegateStateHandle().asShared());
     }
 
     @Override

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/state/KeyGroupsStateHandle.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/state/KeyGroupsStateHandle.java
@@ -150,4 +150,15 @@ public class KeyGroupsStateHandle implements StreamStateHandle, KeyedStateHandle
                 + stateHandle
                 + '}';
     }
+
+    @Override
+    public boolean isShared() {
+        return stateHandle.isShared();
+    }
+
+    @Override
+    public StateObject asShared() {
+        return new KeyGroupsStateHandle(
+                groupRangeOffsets, (StreamStateHandle) stateHandle.asShared());
+    }
 }

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/state/KeyGroupsStateHandle.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/state/KeyGroupsStateHandle.java
@@ -83,7 +83,7 @@ public class KeyGroupsStateHandle implements StreamStateHandle, KeyedStateHandle
         if (offsets.getKeyGroupRange().getNumberOfKeyGroups() <= 0) {
             return null;
         }
-        return new KeyGroupsStateHandle(offsets, stateHandle);
+        return new KeyGroupsStateHandle(offsets, (StreamStateHandle) stateHandle.asShared());
     }
 
     @Override

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/state/OperatorStreamStateHandle.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/state/OperatorStreamStateHandle.java
@@ -124,4 +124,15 @@ public class OperatorStreamStateHandle implements OperatorStateHandle {
                 + delegateStateHandle
                 + '}';
     }
+
+    @Override
+    public boolean isShared() {
+        return delegateStateHandle.isShared();
+    }
+
+    @Override
+    public StateObject asShared() {
+        return new OperatorStreamStateHandle(
+                stateNameToPartitionOffsets, (StreamStateHandle) delegateStateHandle.asShared());
+    }
 }

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/state/PlaceholderStreamStateHandle.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/state/PlaceholderStreamStateHandle.java
@@ -29,11 +29,19 @@ import java.util.Optional;
  * ByteStreamStateHandle}. This class is used in the referenced states of {@link
  * IncrementalRemoteKeyedStateHandle}.
  */
-public class PlaceholderStreamStateHandle implements StreamStateHandle {
+public class PlaceholderStreamStateHandle implements StreamStateHandle, ShareableStateHandle {
 
     private static final long serialVersionUID = 1L;
 
-    public PlaceholderStreamStateHandle() {}
+    private final boolean shared;
+
+    public PlaceholderStreamStateHandle() {
+        this.shared = false;
+    }
+
+    public PlaceholderStreamStateHandle(boolean shared) {
+        this.shared = shared;
+    }
 
     @Override
     public FSDataInputStream openInputStream() {
@@ -45,6 +53,16 @@ public class PlaceholderStreamStateHandle implements StreamStateHandle {
     public Optional<byte[]> asBytesIfInMemory() {
         throw new UnsupportedOperationException(
                 "This is only a placeholder to be replaced by a real StreamStateHandle in the checkpoint coordinator.");
+    }
+
+    @Override
+    public boolean isShared() {
+        return shared;
+    }
+
+    @Override
+    public StateObject asShared() {
+        return new PlaceholderStreamStateHandle(true);
     }
 
     @Override

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/state/RetrievableStreamStateHandle.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/state/RetrievableStreamStateHandle.java
@@ -85,4 +85,15 @@ public class RetrievableStreamStateHandle<T extends Serializable>
     public void close() throws IOException {
         //		wrappedStreamStateHandle.close();
     }
+
+    @Override
+    public boolean isShared() {
+        return wrappedStreamStateHandle.isShared();
+    }
+
+    @Override
+    public StateObject asShared() {
+        return new RetrievableStreamStateHandle<>(
+                (StreamStateHandle) wrappedStreamStateHandle.asShared());
+    }
 }

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/state/ShareableStateHandle.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/state/ShareableStateHandle.java
@@ -1,0 +1,36 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.flink.runtime.state;
+
+import org.apache.flink.annotation.Internal;
+
+/**
+ * A handle to a state shared across multiple execution units, such as Subtasks or Operators. It is
+ * not supposed to be extended by {@link CompositeStateHandle}.
+ */
+@Internal
+public interface ShareableStateHandle extends StateObject {
+
+    /** @return true if the referenced state is actually shared. */
+    boolean isShared();
+
+    /**
+     * @return a new state handle pointing to the same state object but explicitly marked as shared,
+     *     i.e. it will return true from {@link #isShared()}.
+     */
+    StateObject asShared();
+}

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/state/StreamStateHandle.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/state/StreamStateHandle.java
@@ -27,7 +27,7 @@ import java.util.Optional;
  * A {@link StateObject} that represents state that was written to a stream. The data can be read
  * back via {@link #openInputStream()}.
  */
-public interface StreamStateHandle extends StateObject {
+public interface StreamStateHandle extends ShareableStateHandle {
 
     /**
      * Returns an {@link FSDataInputStream} that can be used to read back the data that was

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/state/filesystem/FileStateHandle.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/state/filesystem/FileStateHandle.java
@@ -21,6 +21,8 @@ package org.apache.flink.runtime.state.filesystem;
 import org.apache.flink.core.fs.FSDataInputStream;
 import org.apache.flink.core.fs.FileSystem;
 import org.apache.flink.core.fs.Path;
+import org.apache.flink.runtime.state.ShareableStateHandle;
+import org.apache.flink.runtime.state.StateObject;
 import org.apache.flink.runtime.state.StreamStateHandle;
 
 import java.io.IOException;
@@ -33,7 +35,7 @@ import static org.apache.flink.util.Preconditions.checkNotNull;
  * {@link StreamStateHandle} for state that was written to a file stream. The written data is
  * identified by the file path. The state can be read again by calling {@link #openInputStream()}.
  */
-public class FileStateHandle implements StreamStateHandle {
+public class FileStateHandle implements StreamStateHandle, ShareableStateHandle {
 
     private static final long serialVersionUID = 350284443258002355L;
 
@@ -43,15 +45,28 @@ public class FileStateHandle implements StreamStateHandle {
     /** The size of the state in the file. */
     private final long stateSize;
 
+    private final boolean shared;
+
     /**
      * Creates a new file state for the given file path.
      *
      * @param filePath The path to the file that stores the state.
      */
     public FileStateHandle(Path filePath, long stateSize) {
+        this(filePath, stateSize, false);
+    }
+
+    /**
+     * Creates a new file state for the given file path.
+     *
+     * @param filePath The path to the file that stores the state.
+     * @param shared whether the file is shared
+     */
+    public FileStateHandle(Path filePath, long stateSize, boolean shared) {
         checkArgument(stateSize >= -1);
         this.filePath = checkNotNull(filePath);
         this.stateSize = stateSize;
+        this.shared = shared;
     }
 
     /**
@@ -71,6 +86,16 @@ public class FileStateHandle implements StreamStateHandle {
     @Override
     public Optional<byte[]> asBytesIfInMemory() {
         return Optional.empty();
+    }
+
+    @Override
+    public boolean isShared() {
+        return shared;
+    }
+
+    @Override
+    public StateObject asShared() {
+        return new FileStateHandle(filePath, stateSize, true);
     }
 
     /**

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/state/filesystem/RelativeFileStateHandle.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/state/filesystem/RelativeFileStateHandle.java
@@ -19,6 +19,7 @@
 package org.apache.flink.runtime.state.filesystem;
 
 import org.apache.flink.core.fs.Path;
+import org.apache.flink.runtime.state.StateObject;
 import org.apache.flink.runtime.state.StreamStateHandle;
 
 /**
@@ -32,7 +33,11 @@ public class RelativeFileStateHandle extends FileStateHandle {
     private final String relativePath;
 
     public RelativeFileStateHandle(Path path, String relativePath, long stateSize) {
-        super(path, stateSize);
+        this(path, relativePath, stateSize, false);
+    }
+
+    public RelativeFileStateHandle(Path path, String relativePath, long stateSize, boolean shared) {
+        super(path, stateSize, shared);
         this.relativePath = relativePath;
     }
 
@@ -66,5 +71,10 @@ public class RelativeFileStateHandle extends FileStateHandle {
         return String.format(
                 "RelativeFileStateHandle State: %s, %s [%d bytes]",
                 getFilePath(), relativePath, getStateSize());
+    }
+
+    @Override
+    public StateObject asShared() {
+        return new RelativeFileStateHandle(getFilePath(), relativePath, getStateSize(), true);
     }
 }

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/state/memory/ByteStreamStateHandle.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/state/memory/ByteStreamStateHandle.java
@@ -19,14 +19,19 @@
 package org.apache.flink.runtime.state.memory;
 
 import org.apache.flink.core.fs.FSDataInputStream;
+import org.apache.flink.runtime.state.ShareableStateHandle;
+import org.apache.flink.runtime.state.StateObject;
 import org.apache.flink.runtime.state.StreamStateHandle;
 import org.apache.flink.util.Preconditions;
 
 import java.io.IOException;
 import java.util.Optional;
 
-/** A state handle that contains stream state in a byte array. */
-public class ByteStreamStateHandle implements StreamStateHandle {
+/**
+ * A state handle that contains stream state in a byte array. Can be {@link ShareableStateHandle
+ * shared} if snapshots of multiple state backends were multiplexed over a single byte stream.
+ */
+public class ByteStreamStateHandle implements StreamStateHandle, ShareableStateHandle {
 
     private static final long serialVersionUID = -5280226231202517594L;
 
@@ -40,10 +45,17 @@ public class ByteStreamStateHandle implements StreamStateHandle {
      */
     private final String handleName;
 
+    private final boolean shared;
+
     /** Creates a new ByteStreamStateHandle containing the given data. */
     public ByteStreamStateHandle(String handleName, byte[] data) {
+        this(handleName, data, false);
+    }
+
+    public ByteStreamStateHandle(String handleName, byte[] data, boolean shared) {
         this.handleName = Preconditions.checkNotNull(handleName);
         this.data = Preconditions.checkNotNull(data);
+        this.shared = shared;
     }
 
     @Override
@@ -54,6 +66,16 @@ public class ByteStreamStateHandle implements StreamStateHandle {
     @Override
     public Optional<byte[]> asBytesIfInMemory() {
         return Optional.of(getData());
+    }
+
+    @Override
+    public boolean isShared() {
+        return shared;
+    }
+
+    @Override
+    public StateObject asShared() {
+        return new ByteStreamStateHandle(handleName, data, true);
     }
 
     public byte[] getData() {

--- a/flink-runtime/src/test/java/org/apache/flink/runtime/checkpoint/metadata/CheckpointTestUtils.java
+++ b/flink-runtime/src/test/java/org/apache/flink/runtime/checkpoint/metadata/CheckpointTestUtils.java
@@ -290,8 +290,8 @@ public class CheckpointTestUtils {
         if (!isSavepoint(basePath)) {
             return new ByteStreamStateHandle(
                     String.valueOf(createRandomUUID(rnd)),
-                    String.valueOf(createRandomUUID(rnd))
-                            .getBytes(ConfigConstants.DEFAULT_CHARSET));
+                    String.valueOf(createRandomUUID(rnd)).getBytes(ConfigConstants.DEFAULT_CHARSET),
+                    true);
         } else {
             long stateSize = rnd.nextLong();
             if (stateSize <= 0) {
@@ -299,7 +299,7 @@ public class CheckpointTestUtils {
             }
             String relativePath = String.valueOf(createRandomUUID(rnd));
             Path statePath = new Path(basePath, relativePath);
-            return new RelativeFileStateHandle(statePath, relativePath, stateSize);
+            return new RelativeFileStateHandle(statePath, relativePath, stateSize, true);
         }
     }
 

--- a/flink-runtime/src/test/java/org/apache/flink/runtime/messages/CheckpointMessagesTest.java
+++ b/flink-runtime/src/test/java/org/apache/flink/runtime/messages/CheckpointMessagesTest.java
@@ -29,6 +29,7 @@ import org.apache.flink.runtime.jobgraph.JobVertexID;
 import org.apache.flink.runtime.jobgraph.OperatorID;
 import org.apache.flink.runtime.messages.checkpoint.AcknowledgeCheckpoint;
 import org.apache.flink.runtime.state.KeyGroupRange;
+import org.apache.flink.runtime.state.StateObject;
 import org.apache.flink.runtime.state.StreamStateHandle;
 
 import org.junit.Test;
@@ -135,6 +136,16 @@ public class CheckpointMessagesTest {
         @Override
         public Optional<byte[]> asBytesIfInMemory() {
             return Optional.empty();
+        }
+
+        @Override
+        public boolean isShared() {
+            return false;
+        }
+
+        @Override
+        public StateObject asShared() {
+            return this;
         }
     }
 }

--- a/flink-runtime/src/test/java/org/apache/flink/runtime/state/SharedStateRegistryTest.java
+++ b/flink-runtime/src/test/java/org/apache/flink/runtime/state/SharedStateRegistryTest.java
@@ -98,11 +98,18 @@ public class SharedStateRegistryTest {
 
         private SharedStateRegistryKey key;
 
+        private final boolean shared;
+
         private boolean discarded;
 
         TestSharedState(String key) {
-            this.key = new SharedStateRegistryKey(key);
+            this(new SharedStateRegistryKey(key), false);
+        }
+
+        TestSharedState(SharedStateRegistryKey key, boolean shared) {
+            this.key = key;
             this.discarded = false;
+            this.shared = shared;
         }
 
         public SharedStateRegistryKey getRegistrationKey() {
@@ -136,6 +143,16 @@ public class SharedStateRegistryTest {
 
         public boolean isDiscarded() {
             return discarded;
+        }
+
+        @Override
+        public boolean isShared() {
+            return shared;
+        }
+
+        @Override
+        public StateObject asShared() {
+            return new TestSharedState(key, shared);
         }
     }
 }

--- a/flink-runtime/src/test/java/org/apache/flink/runtime/state/testutils/EmptyStreamStateHandle.java
+++ b/flink-runtime/src/test/java/org/apache/flink/runtime/state/testutils/EmptyStreamStateHandle.java
@@ -19,6 +19,7 @@
 package org.apache.flink.runtime.state.testutils;
 
 import org.apache.flink.core.fs.FSDataInputStream;
+import org.apache.flink.runtime.state.StateObject;
 import org.apache.flink.runtime.state.StreamStateHandle;
 
 import java.io.IOException;
@@ -75,5 +76,15 @@ public class EmptyStreamStateHandle implements StreamStateHandle {
     @Override
     public long getStateSize() {
         return 0;
+    }
+
+    @Override
+    public boolean isShared() {
+        return false;
+    }
+
+    @Override
+    public StateObject asShared() {
+        return this;
     }
 }

--- a/flink-state-backends/flink-statebackend-rocksdb/src/test/java/org/apache/flink/contrib/streaming/state/RocksDBStateDownloaderTest.java
+++ b/flink-state-backends/flink-statebackend-rocksdb/src/test/java/org/apache/flink/contrib/streaming/state/RocksDBStateDownloaderTest.java
@@ -23,6 +23,7 @@ import org.apache.flink.core.fs.FSDataInputStream;
 import org.apache.flink.runtime.state.IncrementalRemoteKeyedStateHandle;
 import org.apache.flink.runtime.state.KeyGroupRange;
 import org.apache.flink.runtime.state.StateHandleID;
+import org.apache.flink.runtime.state.StateObject;
 import org.apache.flink.runtime.state.StreamStateHandle;
 import org.apache.flink.runtime.state.memory.ByteStreamStateHandle;
 import org.apache.flink.util.TestLogger;
@@ -58,6 +59,16 @@ public class RocksDBStateDownloaderTest extends TestLogger {
                 new SpecifiedException("throw exception while multi thread restore.");
         StreamStateHandle stateHandle =
                 new StreamStateHandle() {
+                    @Override
+                    public boolean isShared() {
+                        return false;
+                    }
+
+                    @Override
+                    public StateObject asShared() {
+                        return this;
+                    }
+
                     @Override
                     public FSDataInputStream openInputStream() throws IOException {
                         throw expectedException;

--- a/flink-streaming-java/src/test/java/org/apache/flink/streaming/runtime/tasks/InterruptSensitiveRestoreTest.java
+++ b/flink-streaming-java/src/test/java/org/apache/flink/streaming/runtime/tasks/InterruptSensitiveRestoreTest.java
@@ -61,6 +61,7 @@ import org.apache.flink.runtime.state.KeyedStateHandle;
 import org.apache.flink.runtime.state.OperatorStateHandle;
 import org.apache.flink.runtime.state.OperatorStreamStateHandle;
 import org.apache.flink.runtime.state.StateInitializationContext;
+import org.apache.flink.runtime.state.StateObject;
 import org.apache.flink.runtime.state.StreamStateHandle;
 import org.apache.flink.runtime.state.TestTaskStateManager;
 import org.apache.flink.runtime.taskexecutor.KvStateService;
@@ -369,6 +370,16 @@ public class InterruptSensitiveRestoreTest {
         @Override
         public long getStateSize() {
             return 0;
+        }
+
+        @Override
+        public boolean isShared() {
+            return false;
+        }
+
+        @Override
+        public StateObject asShared() {
+            return this;
         }
     }
 

--- a/flink-streaming-java/src/test/java/org/apache/flink/streaming/runtime/tasks/StreamTaskTest.java
+++ b/flink-streaming-java/src/test/java/org/apache/flink/streaming/runtime/tasks/StreamTaskTest.java
@@ -82,6 +82,7 @@ import org.apache.flink.runtime.state.SharedStateRegistry;
 import org.apache.flink.runtime.state.SnapshotResult;
 import org.apache.flink.runtime.state.StateBackendFactory;
 import org.apache.flink.runtime.state.StateInitializationContext;
+import org.apache.flink.runtime.state.StateObject;
 import org.apache.flink.runtime.state.StatePartitionStreamProvider;
 import org.apache.flink.runtime.state.StreamStateHandle;
 import org.apache.flink.runtime.state.TaskLocalStateStoreImpl;
@@ -2536,6 +2537,16 @@ public class StreamTaskTest extends TestLogger {
         @Override
         public long getStateSize() {
             return 0L;
+        }
+
+        @Override
+        public boolean isShared() {
+            return false;
+        }
+
+        @Override
+        public StateObject asShared() {
+            throw new UnsupportedOperationException("Not implemented.");
         }
     }
 


### PR DESCRIPTION
This is a protottype to evalueate the use of `ShareableStateHandle` in `KeyedStateHandle.getIntersection`.

First, it introduces `ShareableStateHandle` that can be marked as shared (e.g. `FileStateHandle`) or checked whether it is shared.
Second, it marks such states in case of key group range intersection on rescaling.

This allows to discard private and shared state differently, which is helpful when TM partially owns the state.

It doesn't address the case when the state is shared across different operators (i.e. changelog files), 
which is the main functional difference from #17258

`SharedStateRegistry` not affected.