### PR TITLE
[hotfix][docs] Fix Blob Server configuration doc

### DIFF
--- a/docs/content.zh/docs/deployment/config.md
+++ b/docs/content.zh/docs/deployment/config.md
@@ -398,7 +398,7 @@ With the introduction of `state.backend.rocksdb.memory.managed` and `state.backe
 
 **Blob Server**
 
-The Blob Server is a component in the JobManager. It is used for distribution of objects that are too large to be attached to a RPC message and that benefit from caching (like Jar files or large serialized code objects).
+The Blob Server is a component in the JobManager and the TaskManager. It is used for distribution of objects that are too large to be attached to an RPC message and that benefit from caching (like Jar files or large serialized code objects).
 
 {{< generated/blob_server_configuration >}}
 

--- a/docs/content/docs/deployment/config.md
+++ b/docs/content/docs/deployment/config.md
@@ -400,7 +400,7 @@ With the introduction of `state.backend.rocksdb.memory.managed` and `state.backe
 
 **Blob Server**
 
-The Blob Server is a component in the JobManager. It is used for distribution of objects that are too large to be attached to a RPC message and that benefit from caching (like Jar files or large serialized code objects).
+The Blob Server is a component in the JobManager and the TaskManager. It is used for distribution of objects that are too large to be attached to an RPC message and that benefit from caching (like Jar files or large serialized code objects).
 
 {{< generated/blob_server_configuration >}}
 


### PR DESCRIPTION
Both TaskManager and JobManager use Blob Server. So fart, the configuration documentation says only JobManager uses it.

## What is the purpose of the change

Change the docs to reflect how things really work, i.e. that also the TaskManager uses Blob Server.

Also, fix a grammar issue "a RPC message" -> "an RPC message".