### PR TITLE
[FLINK-23950] Revert [FLINK-23738][state] to re-enable ChangelogBackend

### DIFF
--- a/docs/layouts/shortcodes/generated/checkpointing_configuration.html
+++ b/docs/layouts/shortcodes/generated/checkpointing_configuration.html
@@ -9,6 +9,18 @@
     </thead>
     <tbody>
         <tr>
+            <td><h5>state.backend.changelog.enabled</h5></td>
+            <td style="word-wrap: break-word;">false</td>
+            <td>Boolean</td>
+            <td>Whether to enable state backend to write state changes to StateChangelog. If this config is not set explicitly, it means no preference for enabling the change log, and the value in lower config level will take effect. The default value 'false' here means if no value set (job or cluster), the change log will not be enabled.</td>
+        </tr>
+        <tr>
+            <td><h5>state.backend.changelog.storage</h5></td>
+            <td style="word-wrap: break-word;">"memory"</td>
+            <td>String</td>
+            <td>The storage to be used to store state changelog.<br />The implementation can be specified via their shortcut name.<br />The list of recognized shortcut names currently includes 'memory' and 'filesystem'.</td>
+        </tr>
+        <tr>
             <td><h5>state.backend.incremental</h5></td>
             <td style="word-wrap: break-word;">false</td>
             <td>Boolean</td>

--- a/docs/layouts/shortcodes/generated/common_state_backends_section.html
+++ b/docs/layouts/shortcodes/generated/common_state_backends_section.html
@@ -33,6 +33,18 @@
             <td>The default directory for savepoints. Used by the state backends that write savepoints to file systems (HashMapStateBackend, EmbeddedRocksDBStateBackend).</td>
         </tr>
         <tr>
+            <td><h5>state.backend.changelog.enabled</h5></td>
+            <td style="word-wrap: break-word;">false</td>
+            <td>Boolean</td>
+            <td>Whether to enable state backend to write state changes to StateChangelog. If this config is not set explicitly, it means no preference for enabling the change log, and the value in lower config level will take effect. The default value 'false' here means if no value set (job or cluster), the change log will not be enabled.</td>
+        </tr>
+        <tr>
+            <td><h5>state.backend.changelog.storage</h5></td>
+            <td style="word-wrap: break-word;">"memory"</td>
+            <td>String</td>
+            <td>The storage to be used to store state changelog.<br />The implementation can be specified via their shortcut name.<br />The list of recognized shortcut names currently includes 'memory' and 'filesystem'.</td>
+        </tr>
+        <tr>
             <td><h5>state.backend.incremental</h5></td>
             <td style="word-wrap: break-word;">false</td>
             <td>Boolean</td>

--- a/flink-core/src/main/java/org/apache/flink/configuration/CheckpointingOptions.java
+++ b/flink-core/src/main/java/org/apache/flink/configuration/CheckpointingOptions.java
@@ -102,7 +102,6 @@ public class CheckpointingOptions {
 
     /** Whether to enable state change log. */
     @Documentation.Section(value = Documentation.Sections.COMMON_STATE_BACKENDS)
-    @Documentation.ExcludeFromDocumentation("ChangelogBackend is under development")
     public static final ConfigOption<Boolean> ENABLE_STATE_CHANGE_LOG =
             ConfigOptions.key("state.backend.changelog.enabled")
                     .booleanType()
@@ -122,7 +121,6 @@ public class CheckpointingOptions {
      * InMemoryStateChangelogStorageFactory.getIdentifier()}, which is also the default value.
      */
     @Documentation.Section(value = Documentation.Sections.COMMON_STATE_BACKENDS)
-    @Documentation.ExcludeFromDocumentation("ChangelogBackend is under development")
     public static final ConfigOption<String> STATE_CHANGE_LOG_STORAGE =
             ConfigOptions.key("state.backend.changelog.storage")
                     .stringType()

--- a/flink-dstl/flink-dstl-dfs/src/main/java/org/apache/flink/changelog/fs/FsStateChangelogOptions.java
+++ b/flink-dstl/flink-dstl-dfs/src/main/java/org/apache/flink/changelog/fs/FsStateChangelogOptions.java
@@ -18,7 +18,6 @@
 package org.apache.flink.changelog.fs;
 
 import org.apache.flink.annotation.Experimental;
-import org.apache.flink.annotation.docs.Documentation;
 import org.apache.flink.configuration.ConfigOption;
 import org.apache.flink.configuration.ConfigOptions;
 import org.apache.flink.configuration.MemorySize;
@@ -29,7 +28,6 @@ import static org.apache.flink.streaming.api.environment.ExecutionCheckpointingO
 
 /** {@link ConfigOptions} for {@link FsStateChangelogStorage}. */
 @Experimental
-@Documentation.ExcludeFromDocumentation("ChangelogBackend is under development")
 public class FsStateChangelogOptions {
 
     public static final ConfigOption<String> BASE_PATH =

--- a/flink-python/pyflink/datastream/tests/test_stream_execution_environment.py
+++ b/flink-python/pyflink/datastream/tests/test_stream_execution_environment.py
@@ -180,6 +180,19 @@ class StreamExecutionEnvironmentTests(PyFlinkTestCase):
         self.assertEqual(output_backend._j_memory_state_backend,
                          input_backend._j_memory_state_backend)
 
+    def test_is_changelog_state_backend_enabled(self):
+        self.assertIsNone(self.env.is_changelog_state_backend_enabled())
+
+    def test_enable_changelog_state_backend(self):
+
+        self.env.enable_changelog_state_backend(True)
+
+        self.assertTrue(self.env.is_changelog_state_backend_enabled())
+
+        self.env.enable_changelog_state_backend(False)
+
+        self.assertFalse(self.env.is_changelog_state_backend_enabled())
+
     def test_get_set_stream_time_characteristic(self):
         default_time_characteristic = self.env.get_stream_time_characteristic()
 

--- a/flink-streaming-java/src/test/java/org/apache/flink/streaming/api/environment/StreamExecutionEnvironmentComplexConfigurationTest.java
+++ b/flink-streaming-java/src/test/java/org/apache/flink/streaming/api/environment/StreamExecutionEnvironmentComplexConfigurationTest.java
@@ -31,6 +31,7 @@ import org.apache.flink.core.execution.JobClient;
 import org.apache.flink.core.execution.JobListener;
 import org.apache.flink.runtime.state.StateBackend;
 import org.apache.flink.runtime.state.memory.MemoryStateBackend;
+import org.apache.flink.util.TernaryBoolean;
 
 import com.esotericsoftware.kryo.Kryo;
 import com.esotericsoftware.kryo.Serializer;
@@ -45,6 +46,7 @@ import java.util.Arrays;
 import java.util.LinkedHashMap;
 import java.util.List;
 
+import static org.apache.flink.configuration.CheckpointingOptions.ENABLE_STATE_CHANGE_LOG;
 import static org.hamcrest.CoreMatchers.equalTo;
 import static org.hamcrest.CoreMatchers.instanceOf;
 import static org.junit.Assert.assertEquals;
@@ -137,6 +139,29 @@ public class StreamExecutionEnvironmentComplexConfigurationTest {
 
         StateBackend actualStateBackend = envFromConfiguration.getStateBackend();
         assertThat(actualStateBackend, instanceOf(MemoryStateBackend.class));
+    }
+
+    @Test
+    public void testOverridingChangelogStateBackendWithFromConfigurationWhenSet() {
+        StreamExecutionEnvironment envFromConfiguration =
+                StreamExecutionEnvironment.getExecutionEnvironment();
+        assertEquals(
+                TernaryBoolean.UNDEFINED, envFromConfiguration.isChangelogStateBackendEnabled());
+
+        Configuration configuration = new Configuration();
+        configuration.setBoolean(ENABLE_STATE_CHANGE_LOG, true);
+        envFromConfiguration.configure(
+                configuration, Thread.currentThread().getContextClassLoader());
+        assertEquals(TernaryBoolean.TRUE, envFromConfiguration.isChangelogStateBackendEnabled());
+
+        envFromConfiguration.configure(
+                configuration, Thread.currentThread().getContextClassLoader());
+        assertEquals(TernaryBoolean.TRUE, envFromConfiguration.isChangelogStateBackendEnabled());
+
+        configuration.setBoolean(ENABLE_STATE_CHANGE_LOG, false);
+        envFromConfiguration.configure(
+                configuration, Thread.currentThread().getContextClassLoader());
+        assertEquals(TernaryBoolean.FALSE, envFromConfiguration.isChangelogStateBackendEnabled());
     }
 
     @Test

--- a/flink-streaming-scala/src/main/scala/org/apache/flink/streaming/api/scala/StreamExecutionEnvironment.scala
+++ b/flink-streaming-scala/src/main/scala/org/apache/flink/streaming/api/scala/StreamExecutionEnvironment.scala
@@ -315,6 +315,51 @@ class StreamExecutionEnvironment(javaEnv: JavaEnv) {
   def getStateBackend: StateBackend = javaEnv.getStateBackend()
 
   /**
+   * Enable the change log for current state backend. This change log allows operators to persist
+   * state changes in a very fine-grained manner. Currently, the change log only applies to keyed
+   * state, so non-keyed operator state and channel state are persisted as usual. The 'state' here
+   * refers to 'keyed state'. Details are as follows:
+   *
+   * Stateful operators write the state changes to that log (logging the state), in addition to
+   * applying them to the state tables in RocksDB or the in-mem Hashtable.
+   *
+   * An operator can acknowledge a checkpoint as soon as the changes in the log have reached
+   * the durable checkpoint storage.
+   *
+   * The state tables are persisted periodically, independent of the checkpoints. We call this
+   * the materialization of the state on the checkpoint storage.
+   *
+   * Once the state is materialized on checkpoint storage, the state changelog can be truncated
+   * to the corresponding point.
+   *
+   * It establish a way to drastically reduce the checkpoint interval for streaming
+   * applications across state backends. For more details please check the FLIP-158.
+   *
+   * If this method is not called explicitly, it means no preference for enabling the change log.
+   * Configs for change log enabling will override in different config levels (job/local/cluster).
+   *
+   * @param enabled true if enable the change log for state backend explicitly, otherwise disable
+   *                the change log.
+   * @return This StreamExecutionEnvironment itself, to allow chaining of function calls.
+   * @see #isChangelogStateBackendEnabled()
+   */
+  @PublicEvolving
+  def enableChangelogStateBackend(enabled: Boolean): StreamExecutionEnvironment = {
+    javaEnv.enableChangelogStateBackend(enabled)
+    this
+  }
+
+  /**
+   * Gets the enable status of change log for state backend.
+   *
+   * @return a [[TernaryBoolean]] for the enable status of change log for state backend. Could
+   *         be [[TernaryBoolean#UNDEFINED]] if user never specify this by calling
+   *         [[enableChangelogStateBackend(boolean)]].
+   */
+  @PublicEvolving
+  def isChangelogStateBackendEnabled: TernaryBoolean = javaEnv.isChangelogStateBackendEnabled
+
+  /**
    * Sets the default savepoint directory, where savepoints will be written to
    * if no is explicitly provided when triggered.
    *

--- a/pom.xml
+++ b/pom.xml
@@ -1558,8 +1558,7 @@ under the License.
 							random: enable it randomly, unless explicitly set
 							unset: don't alter the configuration
 						-->
-                        <!-- disable temporarily for 1.14 release -->
-						<checkpointing.changelog>unset</checkpointing.changelog>
+						<checkpointing.changelog>random</checkpointing.changelog>
 						<project.basedir>${project.basedir}</project.basedir>
 						<!--suppress MavenModelInspection -->
 						<test.randomization.seed>${test.randomization.seed}</test.randomization.seed>


### PR DESCRIPTION
## What is the purpose of the change

This reverts commits:
- d6bccd13190f0dbb2505b4512a38ae71b3d78195
- b4c385e41832f16e39d5cbe4fb69ead9bbe077b2
- 67dd4932133d74d88666433d4d8aa4a6cbc94c78

## Verifying this change

This change is a trivial rework without any test coverage.

## Does this pull request potentially affect one of the following parts:

  - Dependencies (does it add or upgrade a dependency): no
  - The public API, i.e., is any changed class annotated with `@Public(Evolving)`: no
  - The serializers: no
  - The runtime per-record code paths (performance sensitive): no
  - Anything that affects deployment or recovery: JobManager (and its components), Checkpointing, Kubernetes/Yarn/Mesos, ZooKeeper: no
  - The S3 file system connector: no

## Documentation

  - Does this pull request introduce a new feature? no
  - If yes, how is the feature documented? no
