### PR TITLE
[BP-1.14][FLINK-24292][connectors/kafka] Use KafkaSink in examples instead of FlinkKafkaProducer

### DIFF
--- a/flink-examples/flink-examples-streaming/src/main/java/org/apache/flink/streaming/examples/statemachine/KafkaEventsGeneratorJob.java
+++ b/flink-examples/flink-examples-streaming/src/main/java/org/apache/flink/streaming/examples/statemachine/KafkaEventsGeneratorJob.java
@@ -24,7 +24,7 @@ import org.apache.flink.connector.kafka.sink.KafkaSink;
 import org.apache.flink.streaming.api.environment.StreamExecutionEnvironment;
 import org.apache.flink.streaming.examples.statemachine.event.Event;
 import org.apache.flink.streaming.examples.statemachine.generator.EventsGeneratorSource;
-import org.apache.flink.streaming.examples.statemachine.kafka.EventDeSerializer;
+import org.apache.flink.streaming.examples.statemachine.kafka.EventDeSerializationSchema;
 
 /**
  * Job to generate input events that are written to Kafka, for the {@link StateMachineExample} job.
@@ -55,7 +55,7 @@ public class KafkaEventsGeneratorJob {
                                 .setRecordSerializer(
                                         KafkaRecordSerializationSchema.builder()
                                                 .setValueSerializationSchema(
-                                                        new EventDeSerializer())
+                                                        new EventDeSerializationSchema())
                                                 .setTopic(kafkaTopic)
                                                 .build())
                                 .build());

--- a/flink-examples/flink-examples-streaming/src/main/java/org/apache/flink/streaming/examples/statemachine/KafkaEventsGeneratorJob.java
+++ b/flink-examples/flink-examples-streaming/src/main/java/org/apache/flink/streaming/examples/statemachine/KafkaEventsGeneratorJob.java
@@ -19,8 +19,10 @@
 package org.apache.flink.streaming.examples.statemachine;
 
 import org.apache.flink.api.java.utils.ParameterTool;
+import org.apache.flink.connector.kafka.sink.KafkaRecordSerializationSchema;
+import org.apache.flink.connector.kafka.sink.KafkaSink;
 import org.apache.flink.streaming.api.environment.StreamExecutionEnvironment;
-import org.apache.flink.streaming.connectors.kafka.FlinkKafkaProducer;
+import org.apache.flink.streaming.examples.statemachine.event.Event;
 import org.apache.flink.streaming.examples.statemachine.generator.EventsGeneratorSource;
 import org.apache.flink.streaming.examples.statemachine.kafka.EventDeSerializer;
 
@@ -47,7 +49,16 @@ public class KafkaEventsGeneratorJob {
         final StreamExecutionEnvironment env = StreamExecutionEnvironment.getExecutionEnvironment();
 
         env.addSource(new EventsGeneratorSource(errorRate, sleep))
-                .addSink(new FlinkKafkaProducer<>(brokers, kafkaTopic, new EventDeSerializer()));
+                .sinkTo(
+                        KafkaSink.<Event>builder()
+                                .setBootstrapServers(brokers)
+                                .setRecordSerializer(
+                                        KafkaRecordSerializationSchema.builder()
+                                                .setValueSerializationSchema(
+                                                        new EventDeSerializer())
+                                                .setTopic(kafkaTopic)
+                                                .build())
+                                .build());
 
         // trigger program execution
         env.execute("State machine example Kafka events generator job");

--- a/flink-examples/flink-examples-streaming/src/main/java/org/apache/flink/streaming/examples/statemachine/StateMachineExample.java
+++ b/flink-examples/flink-examples-streaming/src/main/java/org/apache/flink/streaming/examples/statemachine/StateMachineExample.java
@@ -36,7 +36,7 @@ import org.apache.flink.streaming.examples.statemachine.dfa.State;
 import org.apache.flink.streaming.examples.statemachine.event.Alert;
 import org.apache.flink.streaming.examples.statemachine.event.Event;
 import org.apache.flink.streaming.examples.statemachine.generator.EventsGeneratorSource;
-import org.apache.flink.streaming.examples.statemachine.kafka.EventDeSerializer;
+import org.apache.flink.streaming.examples.statemachine.kafka.EventDeSerializationSchema;
 import org.apache.flink.util.Collector;
 
 /**
@@ -102,7 +102,7 @@ public class StateMachineExample {
                             .setTopics(kafkaTopic)
                             .setDeserializer(
                                     KafkaRecordDeserializationSchema.valueOnly(
-                                            new EventDeSerializer()))
+                                            new EventDeSerializationSchema()))
                             .setStartingOffsets(OffsetsInitializer.latest())
                             .build();
             events =

--- a/flink-examples/flink-examples-streaming/src/main/java/org/apache/flink/streaming/examples/statemachine/kafka/EventDeSerializationSchema.java
+++ b/flink-examples/flink-examples-streaming/src/main/java/org/apache/flink/streaming/examples/statemachine/kafka/EventDeSerializationSchema.java
@@ -29,7 +29,8 @@ import java.nio.ByteBuffer;
 import java.nio.ByteOrder;
 
 /** A serializer and deserializer for the {@link Event} type. */
-public class EventDeSerializer implements DeserializationSchema<Event>, SerializationSchema<Event> {
+public class EventDeSerializationSchema
+        implements DeserializationSchema<Event>, SerializationSchema<Event> {
 
     private static final long serialVersionUID = 1L;
 

--- a/flink-examples/flink-examples-streaming/src/main/java/org/apache/flink/streaming/examples/statemachine/kafka/KafkaStandaloneGenerator.java
+++ b/flink-examples/flink-examples-streaming/src/main/java/org/apache/flink/streaming/examples/statemachine/kafka/KafkaStandaloneGenerator.java
@@ -59,7 +59,7 @@ public class KafkaStandaloneGenerator extends StandaloneThreadedGenerator {
 
         private final KafkaProducer<Object, byte[]> producer;
 
-        private final EventDeSerializer serializer;
+        private final EventDeSerializationSchema serializer;
 
         private final String topic;
 
@@ -68,7 +68,7 @@ public class KafkaStandaloneGenerator extends StandaloneThreadedGenerator {
         KafkaCollector(String brokerAddress, String topic, int partition) {
             this.topic = checkNotNull(topic);
             this.partition = partition;
-            this.serializer = new EventDeSerializer();
+            this.serializer = new EventDeSerializationSchema();
 
             // create Kafka producer
             Properties properties = new Properties();


### PR DESCRIPTION
Unchanged backport of #17288 