### PR TITLE
[hotfix] Fix a typo in 'estimatedTimeToConsume(r)BuffersMs'

### DIFF
--- a/docs/content.zh/docs/ops/metrics.md
+++ b/docs/content.zh/docs/ops/metrics.md
@@ -1276,7 +1276,7 @@ Certain RocksDB native metrics are available but disabled by default, you can fi
     </tr>
     <tr>
       <td rowspan="2"><strong>Task (only if buffer debloating is enabled and in non-source tasks)</strong></td>
-      <td>estimatedTimeToConsumerBuffersMs</td>
+      <td>estimatedTimeToConsumeBuffersMs</td>
       <td>The estimated time (in milliseconds) by the buffer debloater to consume all of the buffered data in the network exchange preceding this task. This value is calculated by approximated amount of the in-flight data and calculated throughput.</td>
       <td>Gauge</td>
     </tr>

--- a/docs/content/docs/deployment/memory/network_mem_tuning.md
+++ b/docs/content/docs/deployment/memory/network_mem_tuning.md
@@ -67,7 +67,7 @@ firing windowed aggregations or joins), you might need to adjust the following s
 Consult the [configuration]({{< ref "docs/deployment/config" >}}#full-taskmanageroptions) documentation for more details and additional parameters.
 
 Here are [metrics]({{< ref "docs/ops/metrics" >}}#io) you can use to monitor the current buffer size:
-* `estimatedTimeToConsumerBuffersMs` - total time to consume data from all input channels
+* `estimatedTimeToConsumeBuffersMs` - total time to consume data from all input channels
 * `debloatedBufferSize` - current buffer size
 
 ### Limitations

--- a/docs/content/docs/ops/metrics.md
+++ b/docs/content/docs/ops/metrics.md
@@ -1275,7 +1275,7 @@ Certain RocksDB native metrics are available but disabled by default, you can fi
     </tr>
     <tr>
       <td rowspan="2"><strong>Task (only if buffer debloating is enabled and in non-source tasks)</strong></td>
-      <td>estimatedTimeToConsumerBuffersMs</td>
+      <td>estimatedTimeToConsumeBuffersMs</td>
       <td>The estimated time (in milliseconds) by the buffer debloater to consume all of the buffered data in the network exchange preceding this task. This value is calculated by approximated amount of the in-flight data and calculated throughput.</td>
       <td>Gauge</td>
     </tr>

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/metrics/MetricNames.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/metrics/MetricNames.java
@@ -73,7 +73,7 @@ public class MetricNames {
     public static final String TASK_BACK_PRESSURED_TIME = "backPressuredTimeMs" + SUFFIX_RATE;
 
     public static final String ESTIMATED_TIME_TO_CONSUME_BUFFERS =
-            "estimatedTimeToConsumerBuffersMs";
+            "estimatedTimeToConsumeBuffersMs";
     public static final String DEBLOATED_BUFFER_SIZE = "debloatedBufferSize";
 
     // FLIP-33 sink


### PR DESCRIPTION
Backport of #17295