### PR TITLE
[FLINK-24307][docs] Some lines in Scala code example end with unneces…

### DIFF
--- a/docs/content.zh/docs/dev/dataset/transformations.md
+++ b/docs/content.zh/docs/dev/dataset/transformations.md
@@ -1197,8 +1197,8 @@ public class PointWeighter
 }
 
 DataSet<Tuple2<String, Double>>
-            weightedRatings =
-            ratings.join(weights) // [...]
+        weightedRatings =
+        ratings.join(weights);
 ```
 
 {{< /tab >}}

--- a/docs/content.zh/docs/dev/datastream/event-time/generating_watermarks.md
+++ b/docs/content.zh/docs/dev/datastream/event-time/generating_watermarks.md
@@ -277,7 +277,7 @@ class BoundedOutOfOrdernessGenerator extends AssignerWithPeriodicWatermarks[MyEv
 
     override def onPeriodicEmit(): Unit = {
         // 发出的 watermark = 当前最大时间戳 - 最大乱序时间
-        output.emitWatermark(new Watermark(currentMaxTimestamp - maxOutOfOrderness - 1));
+        output.emitWatermark(new Watermark(currentMaxTimestamp - maxOutOfOrderness - 1))
     }
 }
 
@@ -293,7 +293,7 @@ class TimeLagWatermarkGenerator extends AssignerWithPeriodicWatermarks[MyEvent] 
     }
 
     override def onPeriodicEmit(): Unit = {
-        output.emitWatermark(new Watermark(System.currentTimeMillis() - maxTimeLag));
+        output.emitWatermark(new Watermark(System.currentTimeMillis() - maxTimeLag))
     }
 }
 ```

--- a/docs/content.zh/docs/dev/datastream/operators/joining.md
+++ b/docs/content.zh/docs/dev/datastream/operators/joining.md
@@ -81,8 +81,8 @@ orangeStream.join(greenStream)
 {{< tab "Scala" >}}
 
 ```scala
-import org.apache.flink.streaming.api.windowing.assigners.TumblingEventTimeWindows;
-import org.apache.flink.streaming.api.windowing.time.Time;
+import org.apache.flink.streaming.api.windowing.assigners.TumblingEventTimeWindows
+import org.apache.flink.streaming.api.windowing.time.Time
 
 ...
 
@@ -136,8 +136,8 @@ orangeStream.join(greenStream)
 {{< tab "Scala" >}}
 
 ```scala
-import org.apache.flink.streaming.api.windowing.assigners.SlidingEventTimeWindows;
-import org.apache.flink.streaming.api.windowing.time.Time;
+import org.apache.flink.streaming.api.windowing.assigners.SlidingEventTimeWindows
+import org.apache.flink.streaming.api.windowing.time.Time
 
 ...
 
@@ -189,9 +189,9 @@ orangeStream.join(greenStream)
 {{< tab "Scala" >}}
 
 ```scala
-import org.apache.flink.streaming.api.windowing.assigners.EventTimeSessionWindows;
-import org.apache.flink.streaming.api.windowing.time.Time;
- 
+import org.apache.flink.streaming.api.windowing.assigners.EventTimeSessionWindows
+import org.apache.flink.streaming.api.windowing.time.Time
+
 ...
 
 val orangeStream: DataStream[Integer] = ...
@@ -264,8 +264,8 @@ orangeStream
 {{< tab "Scala" >}}
 
 ```scala
-import org.apache.flink.streaming.api.functions.co.ProcessJoinFunction;
-import org.apache.flink.streaming.api.windowing.time.Time;
+import org.apache.flink.streaming.api.functions.co.ProcessJoinFunction
+import org.apache.flink.streaming.api.windowing.time.Time
 
 ...
 
@@ -278,10 +278,10 @@ orangeStream
     .between(Time.milliseconds(-2), Time.milliseconds(1))
     .process(new ProcessJoinFunction[Integer, Integer, String] {
         override def processElement(left: Integer, right: Integer, ctx: ProcessJoinFunction[Integer, Integer, String]#Context, out: Collector[String]): Unit = {
-         out.collect(left + "," + right); 
+            out.collect(left + "," + right)
         }
-      });
-    });
+    })
+
 ```
 
 {{< /tab >}}

--- a/docs/content.zh/docs/dev/datastream/operators/overview.md
+++ b/docs/content.zh/docs/dev/datastream/operators/overview.md
@@ -331,7 +331,7 @@ dataStream.union(otherStream1, otherStream2, ...);
 {{< /tab >}}
 {{< tab "Scala" >}}
 ```scala
-dataStream.union(otherStream1, otherStream2, ...);
+dataStream.union(otherStream1, otherStream2, ...)
 ```
 {{< /tab >}}
 {{< tab "Python" >}}

--- a/docs/content.zh/docs/dev/datastream/testing.md
+++ b/docs/content.zh/docs/dev/datastream/testing.md
@@ -220,23 +220,23 @@ class StatefulFlatMapFunctionTest extends FlatSpec with Matchers with BeforeAndA
     testHarness = new OneInputStreamOperatorTestHarness[Long, Long](new StreamFlatMap(statefulFlatMap))
 
     // optionally configured the execution environment
-    testHarness.getExecutionConfig().setAutoWatermarkInterval(50);
+    testHarness.getExecutionConfig().setAutoWatermarkInterval(50)
 
     // open the test harness (will also call open() on RichFunctions)
-    testHarness.open();
+    testHarness.open()
   }
 
   "StatefulFlatMap" should "do some fancy stuff with timers and state" in {
 
 
     //push (timestamped) elements into the operator (and hence user defined function)
-    testHarness.processElement(2, 100);
+    testHarness.processElement(2, 100)
 
     //trigger event time timers by advancing the event time of the operator with a watermark
-    testHarness.processWatermark(100);
+    testHarness.processWatermark(100)
 
     //trigger proccesign time timers by advancing the processing time of the operator directly
-    testHarness.setProcessingTime(100);
+    testHarness.setProcessingTime(100)
 
     //retrieve list of emitted records for assertions
     testHarness.getOutput should contain (3)
@@ -293,7 +293,7 @@ class StatefulFlatMapTest extends FlatSpec with Matchers with BeforeAndAfter {
     testHarness = new KeyedOneInputStreamOperatorTestHarness(new StreamFlatMap(statefulFlatMapFunction),new MyStringKeySelector(), Types.STRING())
 
     // open the test harness (will also call open() on RichFunctions)
-    testHarness.open();
+    testHarness.open()
   }
 
   //tests

--- a/docs/content.zh/docs/dev/datastream/user_defined_functions.md
+++ b/docs/content.zh/docs/dev/datastream/user_defined_functions.md
@@ -40,7 +40,7 @@ under the License.
 ```java
 class MyMapFunction implements MapFunction<String, Integer> {
   public Integer map(String value) { return Integer.parseInt(value); }
-};
+}
 data.map(new MyMapFunction());
 ```
 
@@ -78,7 +78,7 @@ data.reduce((i1,i2) -> i1 + i2);
 ```java
 class MyMapFunction implements MapFunction<String, Integer> {
   public Integer map(String value) { return Integer.parseInt(value); }
-};
+}
 ```
 
 替换成
@@ -86,7 +86,7 @@ class MyMapFunction implements MapFunction<String, Integer> {
 ```java
 class MyMapFunction extends RichMapFunction<String, Integer> {
   public Integer map(String value) { return Integer.parseInt(value); }
-};
+}
 ```
 
 并将 function 照常传递给 `map` transformation:
@@ -136,8 +136,8 @@ data.map { x => x.toInt }
 
 ```scala
 class MyMapFunction extends RichMapFunction[String, Int] {
-  def map(in: String):Int = { in.toInt }
-};
+  def map(in: String): Int = in.toInt
+}
 ```
 
 并将 function 传递给 `map` transformation:
@@ -149,7 +149,7 @@ data.map(new MyMapFunction())
 Rich functions 也可以定义成匿名类:
 ```scala
 data.map (new RichMapFunction[String, Int] {
-  def map(in: String):Int = { in.toInt }
+  def map(in: String): Int = in.toInt
 })
 ```
 {{< /tab >}}

--- a/docs/content.zh/docs/dev/table/common.md
+++ b/docs/content.zh/docs/dev/table/common.md
@@ -86,16 +86,16 @@ tableEnv.createTemporaryTable("SourceTable", TableDescriptor.forConnector("datag
   .build())
 
 // Create a sink table (using SQL DDL)
-tableEnv.executeSql("CREATE TEMPORARY TABLE SinkTable WITH ('connector' = 'blackhole') LIKE SourceTable");
+tableEnv.executeSql("CREATE TEMPORARY TABLE SinkTable WITH ('connector' = 'blackhole') LIKE SourceTable")
 
 // Create a Table object from a Table API query
-val table1 = tableEnv.from("SourceTable");
+val table1 = tableEnv.from("SourceTable")
 
 // Create a Table object from a SQL query
-val table2 = tableEnv.sqlQuery("SELECT * FROM SourceTable");
+val table2 = tableEnv.sqlQuery("SELECT * FROM SourceTable")
 
 // Emit a Table API result Table to a TableSink, same for SQL result
-val tableResult = table1.executeInsert("SinkTable");
+val tableResult = table1.executeInsert("SinkTable")
 ```
 {{< /tab >}}
 {{< tab "Python" >}}
@@ -379,11 +379,11 @@ tableEnv.createTemporaryView("other_catalog.other_database.exampleView", table);
 {{< tab "Scala" >}}
 ```scala
 // get a TableEnvironment
-val tEnv: TableEnvironment = ...;
+val tEnv: TableEnvironment = ...
 tEnv.useCatalog("custom_catalog")
 tEnv.useDatabase("custom_database")
 
-val table: Table = ...;
+val table: Table = ...
 
 // register the view named 'exampleView' in the catalog named 'custom_catalog'
 // in the database named 'custom_database' 

--- a/docs/content.zh/docs/dev/table/data_stream_api.md
+++ b/docs/content.zh/docs/dev/table/data_stream_api.md
@@ -789,7 +789,7 @@ val table =
                     .column("uid", DataTypes.TINYINT())
                     .column("payload", DataTypes.STRING())
                     .build())
-            .build());
+            .build())
 
 // convert the Table to a DataStream and further transform the pipeline
 tableEnv.toDataStream(table)
@@ -1153,7 +1153,7 @@ table.printSchema();
 {{< tab "Scala" >}}
 ```scala
 import org.apache.flink.api.scala._
-import java.time.Instant;
+import java.time.Instant
 
 // some example case class
 case class User(name: String, score: java.lang.Integer, event_time: java.time.Instant)
@@ -2864,7 +2864,7 @@ val table: Table = tableEnv.fromValues(
         DataTypes.FIELD("name", DataTypes.STRING()),
         DataTypes.FIELD("age", DataTypes.INT()),
     row("john", 35),
-    row("sarah", 32));
+    row("sarah", 32))
 
 // Convert the Table into an append DataStream of Row by specifying the class
 val dsRow: DataStream[Row] = tableEnv.toAppendStream[Row](table)

--- a/docs/content.zh/docs/dev/table/sql/alter.md
+++ b/docs/content.zh/docs/dev/table/sql/alter.md
@@ -91,7 +91,7 @@ String[] tables = tableEnv.listTables();
 val tableEnv = TableEnvironment.create(...)
 
 // 注册名为 “Orders” 的表
-tableEnv.executeSql("CREATE TABLE Orders (`user` BIGINT, product STRING, amount INT) WITH (...)");
+tableEnv.executeSql("CREATE TABLE Orders (`user` BIGINT, product STRING, amount INT) WITH (...)")
 
 // 字符串数组： ["Orders"]
 val tables = tableEnv.listTables()

--- a/docs/content.zh/docs/dev/table/sql/create.md
+++ b/docs/content.zh/docs/dev/table/sql/create.md
@@ -96,14 +96,14 @@ val tableEnv = TableEnvironment.create(...)
 
 // 对已注册的表进行 SQL 查询
 // 注册名为 “Orders” 的表
-tableEnv.executeSql("CREATE TABLE Orders (`user` BIGINT, product STRING, amount INT) WITH (...)");
+tableEnv.executeSql("CREATE TABLE Orders (`user` BIGINT, product STRING, amount INT) WITH (...)")
 // 在表上执行 SQL 查询，并把得到的结果作为一个新的表
 val result = tableEnv.sqlQuery(
-  "SELECT product, amount FROM Orders WHERE product LIKE '%Rubber%'");
+  "SELECT product, amount FROM Orders WHERE product LIKE '%Rubber%'")
 
 // 对已注册的表进行 INSERT 操作
 // 注册 TableSink
-tableEnv.executeSql("CREATE TABLE RubberOrders(product STRING, amount INT) WITH ('connector.path'='/path/to/file' ...)");
+tableEnv.executeSql("CREATE TABLE RubberOrders(product STRING, amount INT) WITH ('connector.path'='/path/to/file' ...)")
 // 在表上执行 INSERT 语句并向 TableSink 发出结果
 tableEnv.executeSql(
   "INSERT INTO RubberOrders SELECT product, amount FROM Orders WHERE product LIKE '%Rubber%'")

--- a/docs/content.zh/docs/dev/table/tableApi.md
+++ b/docs/content.zh/docs/dev/table/tableApi.md
@@ -89,9 +89,9 @@ import org.apache.flink.table.api.bridge.scala._
 val settings = EnvironmentSettings
     .newInstance()
     .inStreamingMode()
-    .build();
+    .build()
 
-val tEnv = TableEnvironment.create(settings);
+val tEnv = TableEnvironment.create(settings)
 
 // 在表环境中注册 Orders 表
 // ...
@@ -363,7 +363,7 @@ Table result = orders.select($("a"), $("c").as("d"));
 {{< tab "Scala" >}}
 ```scala
 val orders = tableEnv.from("Orders")
-Table result = orders.select($"a", $"c" as "d");
+Table result = orders.select($"a", $"c" as "d")
 ```
 {{< /tab >}}
 {{< tab "Python" >}}
@@ -495,7 +495,7 @@ Table result = orders.addColumns(concat($("c"), "sunny"));
 {{< /tab >}}
 {{< tab "Scala" >}}
 ```scala
-val orders = tableEnv.from("Orders");
+val orders = tableEnv.from("Orders")
 val result = orders.addColumns(concat($"c", "Sunny"))
 ```
 {{< /tab >}}
@@ -526,7 +526,7 @@ Table result = orders.addOrReplaceColumns(concat($("c"), "sunny").as("desc"));
 {{< /tab >}}
 {{< tab "Scala" >}}
 ```scala
-val orders = tableEnv.from("Orders");
+val orders = tableEnv.from("Orders")
 val result = orders.addOrReplaceColumns(concat($"c", "Sunny") as "desc")
 ```
 {{< /tab >}}
@@ -553,7 +553,7 @@ Table result = orders.dropColumns($("b"), $("c"));
 {{< /tab >}}
 {{< tab "Scala" >}}
 ```scala
-val orders = tableEnv.from("Orders");
+val orders = tableEnv.from("Orders")
 val result = orders.dropColumns($"b", $"c")
 ```
 {{< /tab >}}
@@ -581,7 +581,7 @@ Table result = orders.renameColumns($("b").as("b2"), $("c").as("c2"));
 {{< /tab >}}
 {{< tab "Scala" >}}
 ```scala
-val orders = tableEnv.from("Orders");
+val orders = tableEnv.from("Orders")
 val result = orders.renameColumns($"b" as "b2", $"c" as "c2")
 ```
 {{< /tab >}}
@@ -773,7 +773,7 @@ Table result = orders
 {{< /tab >}}
 {{< tab "Scala" >}}
 ```scala
-val orders: Table = tableEnv.from("Orders");
+val orders: Table = tableEnv.from("Orders")
 // 按属性分组后的的互异（互不相同、去重）聚合
 val groupByDistinctResult = orders
     .groupBy($"a")
@@ -833,11 +833,11 @@ orders.groupBy("users")
 {{< /tab >}}
 {{< tab "Scala" >}}
 ```scala
-val orders: Table = tEnv.from("Orders");
+val orders: Table = tEnv.from("Orders")
 
 // 对 user-defined aggregate functions 使用互异（互不相同、去重）聚合
-val myUdagg = new MyUdagg();
-orders.groupBy($"users").select($"users", myUdagg.distinct($"points") as "myDistinctResult");
+val myUdagg = new MyUdagg()
+orders.groupBy($"users").select($"users", myUdagg.distinct($"points") as "myDistinctResult")
 ```
 {{< /tab >}}
 {{< tab "Python" >}}
@@ -1360,7 +1360,7 @@ Table result = left.select($("a"), $("b"), $("c")).where($("a").in(right));
 {{< tab "Scala" >}}
 ```scala
 val left = tableEnv.from("Orders1")
-val right = tableEnv.from("Orders2");
+val right = tableEnv.from("Orders2")
 
 val result = left.select($"a", $"b", $"c").where($"a".in(right))
 ```

--- a/docs/content.zh/docs/dev/table/types.md
+++ b/docs/content.zh/docs/dev/table/types.md
@@ -87,7 +87,7 @@ It is recommended to add a star import to your table programs for having a fluen
 ```scala
 import org.apache.flink.table.api.DataTypes._
 
-val t: DataType = INTERVAL(DAY(), SECOND(3));
+val t: DataType = INTERVAL(DAY(), SECOND(3))
 ```
 {{< /tab >}}
 {{< tab "Python" >}}
@@ -129,11 +129,11 @@ DataType t = DataTypes.ARRAY(DataTypes.INT().notNull()).bridgedTo(int[].class);
 ```scala
 // tell the runtime to not produce or consume java.time.LocalDateTime instances
 // but java.sql.Timestamp
-val t: DataType = DataTypes.TIMESTAMP(3).bridgedTo(classOf[java.sql.Timestamp]);
+val t: DataType = DataTypes.TIMESTAMP(3).bridgedTo(classOf[java.sql.Timestamp])
 
 // tell the runtime to not produce or consume boxed integer arrays
 // but primitive int arrays
-val t: DataType = DataTypes.ARRAY(DataTypes.INT().notNull()).bridgedTo(classOf[Array[Int]]);
+val t: DataType = DataTypes.ARRAY(DataTypes.INT().notNull()).bridgedTo(classOf[Array[Int]])
 ```
 {{< /tab >}}
 {{< /tabs >}}
@@ -1577,7 +1577,7 @@ class User {
 ```
 {{< /tab >}}
 {{< tab "Scala" >}}
-```java
+```scala
 import org.apache.flink.table.annotation.DataTypeHint
 
 class User {

--- a/docs/content/docs/dev/dataset/transformations.md
+++ b/docs/content/docs/dev/dataset/transformations.md
@@ -1195,8 +1195,8 @@ public class PointWeighter
 }
 
 DataSet<Tuple2<String, Double>>
-            weightedRatings =
-            ratings.join(weights) // [...]
+        weightedRatings =
+        ratings.join(weights);
 ```
 
 {{< /tab >}}

--- a/docs/content/docs/dev/datastream/event-time/generating_watermarks.md
+++ b/docs/content/docs/dev/datastream/event-time/generating_watermarks.md
@@ -331,7 +331,7 @@ class BoundedOutOfOrdernessGenerator extends WatermarkGenerator[MyEvent] {
 
     override def onPeriodicEmit(output: WatermarkOutput): Unit = {
         // emit the watermark as current highest timestamp minus the out-of-orderness bound
-        output.emitWatermark(new Watermark(currentMaxTimestamp - maxOutOfOrderness - 1));
+        output.emitWatermark(new Watermark(currentMaxTimestamp - maxOutOfOrderness - 1))
     }
 }
 
@@ -349,7 +349,7 @@ class TimeLagWatermarkGenerator extends WatermarkGenerator[MyEvent] {
     }
 
     override def onPeriodicEmit(output: WatermarkOutput): Unit = {
-        output.emitWatermark(new Watermark(System.currentTimeMillis() - maxTimeLag));
+        output.emitWatermark(new Watermark(System.currentTimeMillis() - maxTimeLag))
     }
 }
 ```

--- a/docs/content/docs/dev/datastream/operators/joining.md
+++ b/docs/content/docs/dev/datastream/operators/joining.md
@@ -83,8 +83,8 @@ orangeStream.join(greenStream)
 {{< tab "Scala" >}}
 
 ```scala
-import org.apache.flink.streaming.api.windowing.assigners.TumblingEventTimeWindows;
-import org.apache.flink.streaming.api.windowing.time.Time;
+import org.apache.flink.streaming.api.windowing.assigners.TumblingEventTimeWindows
+import org.apache.flink.streaming.api.windowing.time.Time
 
 ...
 
@@ -137,8 +137,8 @@ orangeStream.join(greenStream)
 {{< tab "Scala" >}}
 
 ```scala
-import org.apache.flink.streaming.api.windowing.assigners.SlidingEventTimeWindows;
-import org.apache.flink.streaming.api.windowing.time.Time;
+import org.apache.flink.streaming.api.windowing.assigners.SlidingEventTimeWindows
+import org.apache.flink.streaming.api.windowing.time.Time
 
 ...
 
@@ -190,9 +190,9 @@ orangeStream.join(greenStream)
 {{< tab "Scala" >}}
 
 ```scala
-import org.apache.flink.streaming.api.windowing.assigners.EventTimeSessionWindows;
-import org.apache.flink.streaming.api.windowing.time.Time;
- 
+import org.apache.flink.streaming.api.windowing.assigners.EventTimeSessionWindows
+import org.apache.flink.streaming.api.windowing.time.Time
+
 ...
 
 val orangeStream: DataStream[Integer] = ...
@@ -264,8 +264,8 @@ orangeStream
 {{< tab "Scala" >}}
 
 ```scala
-import org.apache.flink.streaming.api.functions.co.ProcessJoinFunction;
-import org.apache.flink.streaming.api.windowing.time.Time;
+import org.apache.flink.streaming.api.functions.co.ProcessJoinFunction
+import org.apache.flink.streaming.api.windowing.time.Time
 
 ...
 
@@ -278,10 +278,10 @@ orangeStream
     .between(Time.milliseconds(-2), Time.milliseconds(1))
     .process(new ProcessJoinFunction[Integer, Integer, String] {
         override def processElement(left: Integer, right: Integer, ctx: ProcessJoinFunction[Integer, Integer, String]#Context, out: Collector[String]): Unit = {
-         out.collect(left + "," + right); 
+            out.collect(left + "," + right)
         }
-      });
-    });
+    })
+
 ```
 
 {{< /tab >}}

--- a/docs/content/docs/dev/datastream/operators/overview.md
+++ b/docs/content/docs/dev/datastream/operators/overview.md
@@ -334,7 +334,7 @@ dataStream.union(otherStream1, otherStream2, ...);
 {{< /tab >}}
 {{< tab "Scala" >}}
 ```scala
-dataStream.union(otherStream1, otherStream2, ...);
+dataStream.union(otherStream1, otherStream2, ...)
 ```
 {{< /tab >}}
 {{< tab "Python" >}}

--- a/docs/content/docs/dev/datastream/testing.md
+++ b/docs/content/docs/dev/datastream/testing.md
@@ -218,23 +218,23 @@ class StatefulFlatMapFunctionTest extends FlatSpec with Matchers with BeforeAndA
     testHarness = new OneInputStreamOperatorTestHarness[Long, Long](new StreamFlatMap(statefulFlatMap))
 
     // optionally configured the execution environment
-    testHarness.getExecutionConfig().setAutoWatermarkInterval(50);
+    testHarness.getExecutionConfig().setAutoWatermarkInterval(50)
 
     // open the test harness (will also call open() on RichFunctions)
-    testHarness.open();
+    testHarness.open()
   }
 
   "StatefulFlatMap" should "do some fancy stuff with timers and state" in {
 
 
     //push (timestamped) elements into the operator (and hence user defined function)
-    testHarness.processElement(2, 100);
+    testHarness.processElement(2, 100)
 
     //trigger event time timers by advancing the event time of the operator with a watermark
-    testHarness.processWatermark(100);
+    testHarness.processWatermark(100)
 
     //trigger proccesign time timers by advancing the processing time of the operator directly
-    testHarness.setProcessingTime(100);
+    testHarness.setProcessingTime(100)
 
     //retrieve list of emitted records for assertions
     testHarness.getOutput should contain (3)
@@ -291,7 +291,7 @@ class StatefulFlatMapTest extends FlatSpec with Matchers with BeforeAndAfter {
     testHarness = new KeyedOneInputStreamOperatorTestHarness(new StreamFlatMap(statefulFlatMapFunction),new MyStringKeySelector(), Types.STRING())
 
     // open the test harness (will also call open() on RichFunctions)
-    testHarness.open();
+    testHarness.open()
   }
 
   //tests

--- a/docs/content/docs/dev/datastream/user_defined_functions.md
+++ b/docs/content/docs/dev/datastream/user_defined_functions.md
@@ -40,7 +40,7 @@ The most basic way is to implement one of the provided interfaces:
 ```java
 class MyMapFunction implements MapFunction<String, Integer> {
   public Integer map(String value) { return Integer.parseInt(value); }
-};
+}
 data.map(new MyMapFunction());
 ```
 
@@ -73,7 +73,7 @@ instead take as argument a *rich* function. For example, instead of
 ```java
 class MyMapFunction implements MapFunction<String, Integer> {
   public Integer map(String value) { return Integer.parseInt(value); }
-};
+}
 ```
 
 you can write
@@ -81,7 +81,7 @@ you can write
 ```java
 class MyMapFunction extends RichMapFunction<String, Integer> {
   public Integer map(String value) { return Integer.parseInt(value); }
-};
+}
 ```
 
 and pass the function as usual to a `map` transformation:
@@ -129,8 +129,8 @@ you can write
 
 ```scala
 class MyMapFunction extends RichMapFunction[String, Int] {
-  def map(in: String):Int = { in.toInt }
-};
+  def map(in: String): Int = in.toInt
+}
 ```
 
 and pass the function to a `map` transformation:
@@ -142,7 +142,7 @@ data.map(new MyMapFunction())
 Rich functions can also be defined as an anonymous class:
 ```scala
 data.map (new RichMapFunction[String, Int] {
-  def map(in: String):Int = { in.toInt }
+  def map(in: String): Int = in.toInt
 })
 ```
 {{< /tab >}}

--- a/docs/content/docs/dev/table/common.md
+++ b/docs/content/docs/dev/table/common.md
@@ -84,16 +84,16 @@ tableEnv.createTemporaryTable("SourceTable", TableDescriptor.forConnector("datag
   .build())
 
 // Create a sink table (using SQL DDL)
-tableEnv.executeSql("CREATE TEMPORARY TABLE SinkTable WITH ('connector' = 'blackhole') LIKE SourceTable");
+tableEnv.executeSql("CREATE TEMPORARY TABLE SinkTable WITH ('connector' = 'blackhole') LIKE SourceTable")
 
 // Create a Table object from a Table API query
-val table1 = tableEnv.from("SourceTable");
+val table1 = tableEnv.from("SourceTable")
 
 // Create a Table object from a SQL query
-val table2 = tableEnv.sqlQuery("SELECT * FROM SourceTable");
+val table2 = tableEnv.sqlQuery("SELECT * FROM SourceTable")
 
 // Emit a Table API result Table to a TableSink, same for SQL result
-val tableResult = table1.executeInsert("SinkTable");
+val tableResult = table1.executeInsert("SinkTable")
 ```
 {{< /tab >}}
 {{< tab "Python" >}}
@@ -388,11 +388,11 @@ tableEnv.createTemporaryView("other_catalog.other_database.exampleView", table);
 {{< tab "Scala" >}}
 ```scala
 // get a TableEnvironment
-val tEnv: TableEnvironment = ...;
+val tEnv: TableEnvironment = ...
 tEnv.useCatalog("custom_catalog")
 tEnv.useDatabase("custom_database")
 
-val table: Table = ...;
+val table: Table = ...
 
 // register the view named 'exampleView' in the catalog named 'custom_catalog'
 // in the database named 'custom_database' 

--- a/docs/content/docs/dev/table/data_stream_api.md
+++ b/docs/content/docs/dev/table/data_stream_api.md
@@ -789,7 +789,7 @@ val table =
                     .column("uid", DataTypes.TINYINT())
                     .column("payload", DataTypes.STRING())
                     .build())
-            .build());
+            .build())
 
 // convert the Table to a DataStream and further transform the pipeline
 tableEnv.toDataStream(table)
@@ -1153,7 +1153,7 @@ table.printSchema();
 {{< tab "Scala" >}}
 ```scala
 import org.apache.flink.api.scala._
-import java.time.Instant;
+import java.time.Instant
 
 // some example case class
 case class User(name: String, score: java.lang.Integer, event_time: java.time.Instant)
@@ -2856,7 +2856,7 @@ val table: Table = tableEnv.fromValues(
         DataTypes.FIELD("name", DataTypes.STRING()),
         DataTypes.FIELD("age", DataTypes.INT()),
     row("john", 35),
-    row("sarah", 32));
+    row("sarah", 32))
 
 // Convert the Table into an append DataStream of Row by specifying the class
 val dsRow: DataStream[Row] = tableEnv.toAppendStream[Row](table)

--- a/docs/content/docs/dev/table/sql/alter.md
+++ b/docs/content/docs/dev/table/sql/alter.md
@@ -92,7 +92,7 @@ String[] tables = tableEnv.listTables();
 val tableEnv = TableEnvironment.create(...)
 
 // register a table named "Orders"
-tableEnv.executeSql("CREATE TABLE Orders (`user` BIGINT, product STRING, amount INT) WITH (...)");
+tableEnv.executeSql("CREATE TABLE Orders (`user` BIGINT, product STRING, amount INT) WITH (...)")
 
 // a string array: ["Orders"]
 val tables = tableEnv.listTables()

--- a/docs/content/docs/dev/table/sql/create.md
+++ b/docs/content/docs/dev/table/sql/create.md
@@ -92,14 +92,14 @@ val tableEnv = TableEnvironment.create(...)
 
 // SQL query with a registered table
 // register a table named "Orders"
-tableEnv.executeSql("CREATE TABLE Orders (`user` BIGINT, product STRING, amount INT) WITH (...)");
+tableEnv.executeSql("CREATE TABLE Orders (`user` BIGINT, product STRING, amount INT) WITH (...)")
 // run a SQL query on the Table and retrieve the result as a new Table
 val result = tableEnv.sqlQuery(
-  "SELECT product, amount FROM Orders WHERE product LIKE '%Rubber%'");
+  "SELECT product, amount FROM Orders WHERE product LIKE '%Rubber%'")
 
 // Execute insert SQL with a registered table
 // register a TableSink
-tableEnv.executeSql("CREATE TABLE RubberOrders(product STRING, amount INT) WITH ('connector.path'='/path/to/file' ...)");
+tableEnv.executeSql("CREATE TABLE RubberOrders(product STRING, amount INT) WITH ('connector.path'='/path/to/file' ...)")
 // run an insert SQL on the Table and emit the result to the TableSink
 tableEnv.executeSql(
   "INSERT INTO RubberOrders SELECT product, amount FROM Orders WHERE product LIKE '%Rubber%'")

--- a/docs/content/docs/dev/table/tableApi.md
+++ b/docs/content/docs/dev/table/tableApi.md
@@ -90,9 +90,9 @@ import org.apache.flink.table.api.bridge.scala._
 val settings = EnvironmentSettings
     .newInstance()
     .inStreamingMode()
-    .build();
+    .build()
 
-val tEnv = TableEnvironment.create(settings);
+val tEnv = TableEnvironment.create(settings)
 
 // register Orders table in table environment
 // ...
@@ -364,7 +364,7 @@ Table result = orders.select($("a"), $("c").as("d"));
 {{< tab "Scala" >}}
 ```scala
 val orders = tableEnv.from("Orders")
-Table result = orders.select($"a", $"c" as "d");
+Table result = orders.select($"a", $"c" as "d")
 ```
 {{< /tab >}}
 {{< tab "Python" >}}
@@ -493,7 +493,7 @@ Table result = orders.addColumns(concat($("c"), "sunny"));
 {{< /tab >}}
 {{< tab "Scala" >}}
 ```scala
-val orders = tableEnv.from("Orders");
+val orders = tableEnv.from("Orders")
 val result = orders.addColumns(concat($"c", "Sunny"))
 ```
 {{< /tab >}}
@@ -524,7 +524,7 @@ Table result = orders.addOrReplaceColumns(concat($("c"), "sunny").as("desc"));
 {{< /tab >}}
 {{< tab "Scala" >}}
 ```scala
-val orders = tableEnv.from("Orders");
+val orders = tableEnv.from("Orders")
 val result = orders.addOrReplaceColumns(concat($"c", "Sunny") as "desc")
 ```
 {{< /tab >}}
@@ -551,7 +551,7 @@ Table result = orders.dropColumns($("b"), $("c"));
 {{< /tab >}}
 {{< tab "Scala" >}}
 ```scala
-val orders = tableEnv.from("Orders");
+val orders = tableEnv.from("Orders")
 val result = orders.dropColumns($"b", $"c")
 ```
 {{< /tab >}}
@@ -579,7 +579,7 @@ Table result = orders.renameColumns($("b").as("b2"), $("c").as("c2"));
 {{< /tab >}}
 {{< tab "Scala" >}}
 ```scala
-val orders = tableEnv.from("Orders");
+val orders = tableEnv.from("Orders")
 val result = orders.renameColumns($"b" as "b2", $"c" as "c2")
 ```
 {{< /tab >}}
@@ -772,7 +772,7 @@ Table result = orders
 {{< /tab >}}
 {{< tab "Scala" >}}
 ```scala
-val orders: Table = tableEnv.from("Orders");
+val orders: Table = tableEnv.from("Orders")
 // Distinct aggregation on group by
 val groupByDistinctResult = orders
     .groupBy($"a")
@@ -832,11 +832,11 @@ orders.groupBy("users")
 {{< /tab >}}
 {{< tab "Scala" >}}
 ```scala
-val orders: Table = tEnv.from("Orders");
+val orders: Table = tEnv.from("Orders")
 
 // Use distinct aggregation for user-defined aggregate functions
-val myUdagg = new MyUdagg();
-orders.groupBy($"users").select($"users", myUdagg.distinct($"points") as "myDistinctResult");
+val myUdagg = new MyUdagg()
+orders.groupBy($"users").select($"users", myUdagg.distinct($"points") as "myDistinctResult")
 ```
 {{< /tab >}}
 {{< tab "Python" >}}
@@ -1359,7 +1359,7 @@ Table result = left.select($("a"), $("b"), $("c")).where($("a").in(right));
 {{< tab "Scala" >}}
 ```scala
 val left = tableEnv.from("Orders1")
-val right = tableEnv.from("Orders2");
+val right = tableEnv.from("Orders2")
 
 val result = left.select($"a", $"b", $"c").where($"a".in(right))
 ```

--- a/docs/content/docs/dev/table/types.md
+++ b/docs/content/docs/dev/table/types.md
@@ -87,7 +87,7 @@ It is recommended to add a star import to your table programs for having a fluen
 ```scala
 import org.apache.flink.table.api.DataTypes._
 
-val t: DataType = INTERVAL(DAY(), SECOND(3));
+val t: DataType = INTERVAL(DAY(), SECOND(3))
 ```
 {{< /tab >}}
 {{< tab "Python" >}}
@@ -129,11 +129,11 @@ DataType t = DataTypes.ARRAY(DataTypes.INT().notNull()).bridgedTo(int[].class);
 ```scala
 // tell the runtime to not produce or consume java.time.LocalDateTime instances
 // but java.sql.Timestamp
-val t: DataType = DataTypes.TIMESTAMP(3).bridgedTo(classOf[java.sql.Timestamp]);
+val t: DataType = DataTypes.TIMESTAMP(3).bridgedTo(classOf[java.sql.Timestamp])
 
 // tell the runtime to not produce or consume boxed integer arrays
 // but primitive int arrays
-val t: DataType = DataTypes.ARRAY(DataTypes.INT().notNull()).bridgedTo(classOf[Array[Int]]);
+val t: DataType = DataTypes.ARRAY(DataTypes.INT().notNull()).bridgedTo(classOf[Array[Int]])
 ```
 {{< /tab >}}
 {{< /tabs >}}
@@ -1577,7 +1577,7 @@ class User {
 ```
 {{< /tab >}}
 {{< tab "Scala" >}}
-```java
+```scala
 import org.apache.flink.table.annotation.DataTypeHint
 
 class User {


### PR DESCRIPTION
…sary semicolons. Also some Scala code blocks are wrongly typed with Java blocks

## What is the purpose of the change

Some lines in Scala code example end with unnecessary semicolons. Also some Scala code blocks are wrongly typed with Java blocks.

## Brief change log

- docs/content/docs/dev/dataset/transformations.md
- docs/content/docs/dev/datastream/event-time/generating_watermarks.md
- docs/content/docs/dev/datastream/operators/joining.md
- docs/content/docs/dev/datastream/operators/overview.md
- docs/content/docs/dev/datastream/testing.md
- docs/content/docs/dev/datastream/user_defined_functions.md
- docs/content/docs/dev/table/sql/alter.md
- docs/content/docs/dev/table/sql/create.md
- docs/content/docs/dev/table/common.md
- docs/content/docs/dev/table/data_stream_api.md
- docs/content/docs/dev/table/tableApi.md
- docs/content/docs/dev/table/types.md
- docs/content.zh/docs/dev/dataset/transformations.md
- docs/content.zh/docs/dev/datastream/event-time/generating_watermarks.md
- docs/content.zh/docs/dev/datastream/operators/joining.md
- docs/content.zh/docs/dev/datastream/operators/overview.md
- docs/content.zh/docs/dev/datastream/testing.md
- docs/content.zh/docs/dev/datastream/user_defined_functions.md
- docs/content.zh/docs/dev/table/sql/alter.md
- docs/content.zh/docs/dev/table/sql/create.md
- docs/content.zh/docs/dev/table/common.md
- docs/content.zh/docs/dev/table/data_stream_api.md
- docs/content.zh/docs/dev/table/tableApi.md
- docs/content.zh/docs/dev/table/types.md

## Verifying this change

This change is a trivial rework / code cleanup without any test coverage.

## Does this pull request potentially affect one of the following parts:

  - Dependencies (does it add or upgrade a dependency): no
  - The public API, i.e., is any changed class annotated with `@Public(Evolving)`: no
  - The serializers: no
  - The runtime per-record code paths (performance sensitive): no
  - Anything that affects deployment or recovery: JobManager (and its components), Checkpointing, Kubernetes/Yarn, ZooKeeper: no
  - The S3 file system connector: no

## Documentation

  - Does this pull request introduce a new feature? no
