### PR TITLE
[FLINK-24305][python] Limit the protobuf version<3.18

### DIFF
--- a/flink-python/setup.py
+++ b/flink-python/setup.py
@@ -312,7 +312,7 @@ try:
                           'cloudpickle==1.2.2', 'avro-python3>=1.8.1,!=1.9.2,<1.10.0',
                           'pandas>=1.0,<1.2.0', 'pyarrow>=0.15.1,<3.0.0',
                           'pytz>=2018.3', 'numpy>=1.14.3,<1.20', 'fastavro>=0.21.4,<0.24',
-                          'requests>=2.26.0',
+                          'requests>=2.26.0', 'protobuf<3.18',
                           apache_flink_libraries_dependency],
         cmdclass={'build_ext': build_ext},
         tests_require=['pytest==4.4.1'],


### PR DESCRIPTION
## What is the purpose of the change

*This pull request will Limit the protobuf version<3.18, protobuf 3.18.0 has some compatibility problem.*


## Brief change log

  - *Limit the protobuf version<3.18*

## Verifying this change

 - *original tests*

## Does this pull request potentially affect one of the following parts:

  - Dependencies (does it add or upgrade a dependency): (no)
  - The public API, i.e., is any changed class annotated with `@Public(Evolving)`: (no)
  - The serializers: (no)
  - The runtime per-record code paths (performance sensitive): (no)
  - Anything that affects deployment or recovery: JobManager (and its components), Checkpointing, Kubernetes/Yarn, ZooKeeper: (no)
  - The S3 file system connector: (no)

## Documentation

  - Does this pull request introduce a new feature? (no)
  - If yes, how is the feature documented? (not applicable)
