### PR TITLE
[hotfix] Update frontend-maven-plugin

### DIFF
--- a/flink-runtime-web/pom.xml
+++ b/flink-runtime-web/pom.xml
@@ -253,7 +253,7 @@ under the License.
 			<plugin>
 				<groupId>com.github.eirslett</groupId>
 				<artifactId>frontend-maven-plugin</artifactId>
-				<version>1.6</version>
+				<version>1.9.1</version>
 				<executions>
 					<execution>
 						<id>install node and npm</id>


### PR DESCRIPTION
## What is the purpose of the change

This backports part of a commit to update the frontend-maven-plugin.
Doing so prevents Angular's compatibility compiler output to be logged
on ERROR level.

## Brief change log

Update frontend-maven-plugin from 1.6 to 1.9.1.

## Verifying this change

This change is a trivial rework / code cleanup without any test coverage.

## Does this pull request potentially affect one of the following parts:

  - Dependencies (does it add or upgrade a dependency): yes (build-only)
  - The public API, i.e., is any changed class annotated with `@Public(Evolving)`: no
  - The serializers: no
  - The runtime per-record code paths (performance sensitive): no
  - Anything that affects deployment or recovery: JobManager (and its components), Checkpointing, Kubernetes/Yarn, ZooKeeper: no
  - The S3 file system connector: no

## Documentation

  - Does this pull request introduce a new feature? no
  - If yes, how is the feature documented? not applicable
