### PR TITLE
[hotfix][flink-avro] Use local actual schema variable

### DIFF
--- a/flink-formats/flink-avro/src/main/java/org/apache/flink/formats/avro/AvroRowDeserializationSchema.java
+++ b/flink-formats/flink-avro/src/main/java/org/apache/flink/formats/avro/AvroRowDeserializationSchema.java
@@ -243,7 +243,6 @@ public class AvroRowDeserializationSchema extends AbstractDeserializationSchema<
             case UNION:
                 final List<Schema> types = schema.getTypes();
                 final int size = types.size();
-                final Schema actualSchema;
                 if (size == 2 && types.get(0).getType() == Schema.Type.NULL) {
                     return convertAvroType(types.get(1), info, object);
                 } else if (size == 2 && types.get(1).getType() == Schema.Type.NULL) {

--- a/flink-formats/flink-avro/src/main/java/org/apache/flink/formats/avro/AvroRowDeserializationSchema.java
+++ b/flink-formats/flink-avro/src/main/java/org/apache/flink/formats/avro/AvroRowDeserializationSchema.java
@@ -243,16 +243,18 @@ public class AvroRowDeserializationSchema extends AbstractDeserializationSchema<
             case UNION:
                 final List<Schema> types = schema.getTypes();
                 final int size = types.size();
+                final Schema actualSchema;
                 if (size == 2 && types.get(0).getType() == Schema.Type.NULL) {
-                    return convertAvroType(types.get(1), info, object);
+                    actualSchema = types.get(1);
                 } else if (size == 2 && types.get(1).getType() == Schema.Type.NULL) {
-                    return convertAvroType(types.get(0), info, object);
+                    actualSchema = types.get(0);
                 } else if (size == 1) {
-                    return convertAvroType(types.get(0), info, object);
+                    actualSchema = types.get(0);
                 } else {
                     // generic type
                     return object;
                 }
+                return convertAvroType(actualSchema, info, object);
             case FIXED:
                 final byte[] fixedBytes = ((GenericFixed) object).bytes();
                 if (info == Types.BIG_DEC) {


### PR DESCRIPTION
## What is the purpose of the change

* The variable actualSchema is declared but not used.

## Brief change log

* Removed unused variable.

## Verifying this change

This change is a trivial rework / code cleanup without any test coverage.

## Does this pull request potentially affect one of the following parts:

  - Dependencies (does it add or upgrade a dependency): no
  - The public API, i.e., is any changed class annotated with `@Public(Evolving)`: no
  - The serializers: no
  - The runtime per-record code paths (performance sensitive): no
  - Anything that affects deployment or recovery: JobManager (and its components), Checkpointing, Kubernetes/Yarn, ZooKeeper: no
  - The S3 file system connector: no

## Documentation

  - Does this pull request introduce a new feature? no
  - If yes, how is the feature documented? not applicable
