### PR TITLE
[BP-1.14][FLINK-24129][connectors-pulsar] Harden TopicRangeTest.rangeCreationHaveALimitedScope.

### DIFF
--- a/flink-connectors/flink-connector-pulsar/src/test/java/org/apache/flink/connector/pulsar/source/enumerator/topic/TopicRangeTest.java
+++ b/flink-connectors/flink-connector-pulsar/src/test/java/org/apache/flink/connector/pulsar/source/enumerator/topic/TopicRangeTest.java
@@ -20,10 +20,7 @@ package org.apache.flink.connector.pulsar.source.enumerator.topic;
 
 import org.apache.flink.util.InstantiationUtil;
 
-import org.junit.jupiter.api.RepeatedTest;
 import org.junit.jupiter.api.Test;
-
-import java.util.Random;
 
 import static org.apache.flink.connector.pulsar.source.enumerator.topic.TopicRange.MAX_RANGE;
 import static org.junit.jupiter.api.Assertions.assertDoesNotThrow;
@@ -33,26 +30,30 @@ import static org.junit.jupiter.api.Assertions.assertThrows;
 /** Unit tests for {@link TopicRange}. */
 class TopicRangeTest {
 
-    private final Random random = new Random(System.currentTimeMillis());
-
-    @RepeatedTest(10)
-    @SuppressWarnings("java:S5778")
-    void rangeCreationHaveALimitedScope() {
-        assertThrows(
-                IllegalArgumentException.class,
-                () -> new TopicRange(-1, random.nextInt(MAX_RANGE)));
-        assertThrows(
-                IllegalArgumentException.class,
-                () -> new TopicRange(1, MAX_RANGE + random.nextInt(10000)));
-
-        assertDoesNotThrow(() -> new TopicRange(1, random.nextInt(MAX_RANGE)));
+    @Test
+    void topicRangeIsSerializable() throws Exception {
+        final TopicRange range = new TopicRange(1, 5);
+        final TopicRange cloneRange = InstantiationUtil.clone(range);
+        assertEquals(range, cloneRange);
     }
 
     @Test
-    void topicRangeIsSerializable() throws Exception {
-        TopicRange range = new TopicRange(10, random.nextInt(MAX_RANGE));
-        TopicRange cloneRange = InstantiationUtil.clone(range);
+    void negativeStart() {
+        assertThrows(IllegalArgumentException.class, () -> new TopicRange(-1, 1));
+    }
 
-        assertEquals(range, cloneRange);
+    @Test
+    void endBelowTheMaximum() {
+        assertDoesNotThrow(() -> new TopicRange(1, MAX_RANGE - 1));
+    }
+
+    @Test
+    void endOnTheMaximum() {
+        assertDoesNotThrow(() -> new TopicRange(1, MAX_RANGE));
+    }
+
+    @Test
+    void endAboveTheMaximum() {
+        assertThrows(IllegalArgumentException.class, () -> new TopicRange(1, MAX_RANGE + 1));
     }
 }


### PR DESCRIPTION
## What is the purpose of the change

Backport of #17159

## Brief change log

* The randomizer was removed from the test

## Verifying this change

This change is a trivial rework / code cleanup without any test coverage.

## Does this pull request potentially affect one of the following parts:

  - Dependencies (does it add or upgrade a dependency): no
  - The public API, i.e., is any changed class annotated with `@Public(Evolving)`: no
  - The serializers: no
  - The runtime per-record code paths (performance sensitive): no
  - Anything that affects deployment or recovery: JobManager (and its components), Checkpointing, Kubernetes/Yarn, ZooKeeper: no
  - The S3 file system connector: no

## Documentation

  - Does this pull request introduce a new feature? no
  - If yes, how is the feature documented? not applicable
