### PR TITLE
[FLINK-16204][table] Support JSON_ARRAY()

### DIFF
--- a/docs/data/sql_functions.yml
+++ b/docs/data/sql_functions.yml
@@ -739,6 +739,10 @@ json:
       This function returns a JSON string. The `ON NULL` behavior defines how to treat `NULL`
       values. If omitted, `NULL ON NULL` is assumed by default.
 
+      Values which are created from another JSON construction function call (`JSON_OBJECT`,
+      `JSON_ARRAY`) are inserted directly rather than as a string. This allows building nested JSON
+      structures.
+
       ```
       -- '{}'
       JSON_OBJECT()
@@ -761,6 +765,35 @@ json:
           VALUE 'V'
         )
       )
+      ```
+  - sql: JSON_ARRAY([value]* [ { NULL | ABSENT } ON NULL ])
+    table: jsonArray(JsonOnNull, values...)
+    description: |
+      Builds a JSON array string from a list of values.
+
+      This function returns a JSON string. The values can be arbitrary expressions. The `ON NULL`
+      behavior defines how to treat `NULL` values. If omitted, `ABSENT ON NULL` is assumed by
+      default.
+
+      Elements which are created from another JSON construction function call (`JSON_OBJECT`,
+      `JSON_ARRAY`) are inserted directly rather than as a string. This allows building nested JSON
+      structures.
+
+      ```
+      -- '[]'
+      JSON_ARRAY()
+      -- '[1,"2"]'
+      JSON_ARRAY(1, '2')
+
+      -- Expressions as values
+      JSON_ARRAY(orders.orderId)
+
+      -- ON NULL
+      JSON_ARRAY(CAST(NULL AS STRING) NULL ON NULL) -- '[null]'
+      JSON_ARRAY(CAST(NULL AS STRING) ABSENT ON NULL) -- '[]'
+
+      -- '[[1]]'
+      JSON_ARRAY(JSON_ARRAY(1))
       ```
 
 valueconstruction:

--- a/docs/data/sql_functions_zh.yml
+++ b/docs/data/sql_functions_zh.yml
@@ -857,6 +857,9 @@ json:
       This function returns a JSON string. The `ON NULL` behavior defines how to treat `NULL`
       values. If omitted, `NULL ON NULL` is assumed by default.
 
+      Values which are created from another JSON construction function call (`JSON_OBJECT`,
+      `JSON_ARRAY`) are inserted directly rather than as a string. This allows building nested JSON
+      structures.
 
       ```
       -- '{}'
@@ -880,6 +883,35 @@ json:
           VALUE 'V'
         )
       )
+      ```
+  - sql: JSON_ARRAY([value]* [ { NULL | ABSENT } ON NULL ])
+    table: jsonArray(JsonOnNull, values...)
+    description: |
+      Builds a JSON array string from a list of values.
+
+      This function returns a JSON string. The values can be arbitrary expressions. The `ON NULL`
+      behavior defines how to treat `NULL` values. If omitted, `ABSENT ON NULL` is assumed by
+      default.
+
+      Elements which are created from another JSON construction function call (`JSON_OBJECT`,
+      `JSON_ARRAY`) are inserted directly rather than as a string. This allows building nested JSON
+      structures.
+
+      ```
+      -- '[]'
+      JSON_ARRAY()
+      -- '[1,"2"]'
+      JSON_ARRAY(1, '2')
+
+      -- Expressions as values
+      JSON_ARRAY(orders.orderId)
+
+      -- ON NULL
+      JSON_ARRAY(CAST(NULL AS STRING) NULL ON NULL) -- '[null]'
+      JSON_ARRAY(CAST(NULL AS STRING) ABSENT ON NULL) -- '[]'
+
+      -- '[[1]]'
+      JSON_ARRAY(JSON_ARRAY(1))
       ```
 
 valueconstruction:

--- a/flink-table/flink-table-api-scala/src/main/scala/org/apache/flink/table/api/ImplicitExpressionConversions.scala
+++ b/flink-table/flink-table-api-scala/src/main/scala/org/apache/flink/table/api/ImplicitExpressionConversions.scala
@@ -875,7 +875,7 @@ trait ImplicitExpressionConversions {
    *
    * @see #jsonObject
    */
-  def jsonArray(onNull: JsonOnNull, values: Any*): Expression = {
+  def jsonArray(onNull: JsonOnNull, values: Expression*): Expression = {
     Expressions.jsonArray(onNull, values)
   }
 }

--- a/flink-table/flink-table-api-scala/src/main/scala/org/apache/flink/table/api/ImplicitExpressionConversions.scala
+++ b/flink-table/flink-table-api-scala/src/main/scala/org/apache/flink/table/api/ImplicitExpressionConversions.scala
@@ -834,7 +834,7 @@ trait ImplicitExpressionConversions {
    * jsonObject(JsonOnNull.NULL, "K1", jsonObject(JsonOnNull.NULL, "K2", "V"))
    * }}}
    */
-  def jsonObject(onNull: JsonOnNull, keyValues: Any*): Expression = {
+  def jsonObject(onNull: JsonOnNull, keyValues: Expression*): Expression = {
     Expressions.jsonObject(onNull, keyValues)
   }
 }

--- a/flink-table/flink-table-api-scala/src/main/scala/org/apache/flink/table/api/ImplicitExpressionConversions.scala
+++ b/flink-table/flink-table-api-scala/src/main/scala/org/apache/flink/table/api/ImplicitExpressionConversions.scala
@@ -810,11 +810,15 @@ trait ImplicitExpressionConversions {
   /**
    * Builds a JSON object string from a list of key-value pairs.
    *
-   * <code>keyValues</code> is an even-numbered list of alternating key/value pairs. Note that keys
-   * must be string literals, values may be arbitrary expressions.
+   * `keyValues` is an even-numbered list of alternating key/value pairs. Note that keys must be
+   * string literals, values may be arbitrary expressions.
    *
    * This function returns a JSON string. The [[JsonOnNull onNull]] behavior defines how to treat
-   * <code>NULL</code> values.
+   * `NULL` values.
+   *
+   * Values which are created from another JSON construction function call
+   * (`jsonObject`, `jsonArray`) are inserted directly rather than as a string. This allows
+   * building nested JSON structures.
    *
    * Examples:
    * {{{
@@ -833,8 +837,45 @@ trait ImplicitExpressionConversions {
    * // {"K1":{"K2":"V"}}
    * jsonObject(JsonOnNull.NULL, "K1", jsonObject(JsonOnNull.NULL, "K2", "V"))
    * }}}
+   *
+   * @see #jsonObject
    */
   def jsonObject(onNull: JsonOnNull, keyValues: Expression*): Expression = {
     Expressions.jsonObject(onNull, keyValues)
+  }
+
+  /**
+   * Builds a JSON array string from a list of values.
+   *
+   * This function returns a JSON string. The values can be arbitrary expressions. The
+   * [[JsonOnNull onNull]] behavior defines how to treat `NULL` values.
+   *
+   * Elements which are created from another JSON construction function call
+   * (`jsonObject`, `jsonArray`) are inserted directly rather than as a string. This allows
+   * building nested JSON structures.
+   *
+   * Examples:
+   *
+   * {{{
+   * // "[]"
+   * jsonArray(JsonOnNull.NULL)
+   * // "[1,\"2\"]"
+   * jsonArray(JsonOnNull.NULL, 1, "2")
+   *
+   * // Expressions as values
+   * jsonArray(JsonOnNull.NULL, $("orderId"))
+   *
+   * // ON NULL
+   * jsonArray(JsonOnNull.NULL, nullOf(DataTypes.STRING()))   // "[null]"
+   * jsonArray(JsonOnNull.ABSENT, nullOf(DataTypes.STRING())) // "[]"
+   *
+   * // "[[1]]"
+   * jsonArray(JsonOnNull.NULL, jsonArray(JsonOnNull.NULL, 1))
+   * }}}
+   *
+   * @see #jsonObject
+   */
+  def jsonArray(onNull: JsonOnNull, values: Any*): Expression = {
+    Expressions.jsonArray(onNull, values)
   }
 }

--- a/flink-table/flink-table-common/src/main/java/org/apache/flink/table/api/JsonOnNull.java
+++ b/flink-table/flink-table-common/src/main/java/org/apache/flink/table/api/JsonOnNull.java
@@ -22,7 +22,10 @@ import org.apache.flink.annotation.PublicEvolving;
 import org.apache.flink.table.expressions.TableSymbol;
 import org.apache.flink.table.functions.BuiltInFunctionDefinitions;
 
-/** Behavior for entries with a null value for {@link BuiltInFunctionDefinitions#JSON_OBJECT}. */
+/**
+ * Behavior for entries with a null value for {@link BuiltInFunctionDefinitions#JSON_OBJECT} and
+ * {@link BuiltInFunctionDefinitions#JSON_ARRAY}.
+ */
 @PublicEvolving
 public enum JsonOnNull implements TableSymbol {
     /** Use a JSON {@code null} value. */

--- a/flink-table/flink-table-common/src/main/java/org/apache/flink/table/functions/BuiltInFunctionDefinitions.java
+++ b/flink-table/flink-table-common/src/main/java/org/apache/flink/table/functions/BuiltInFunctionDefinitions.java
@@ -1578,6 +1578,15 @@ public final class BuiltInFunctionDefinitions {
                     .runtimeDeferred()
                     .build();
 
+    public static final BuiltInFunctionDefinition JSON_ARRAY =
+            BuiltInFunctionDefinition.newBuilder()
+                    .name("JSON_ARRAY")
+                    .kind(SCALAR)
+                    .inputTypeStrategy(SpecificInputTypeStrategies.JSON_ARRAY)
+                    .outputTypeStrategy(explicit(DataTypes.STRING().notNull()))
+                    .runtimeDeferred()
+                    .build();
+
     // --------------------------------------------------------------------------------------------
     // Other functions
     // --------------------------------------------------------------------------------------------

--- a/flink-table/flink-table-common/src/main/java/org/apache/flink/table/types/inference/strategies/SpecificInputTypeStrategies.java
+++ b/flink-table/flink-table-common/src/main/java/org/apache/flink/table/types/inference/strategies/SpecificInputTypeStrategies.java
@@ -36,6 +36,7 @@ import static org.apache.flink.table.types.inference.InputTypeStrategies.logical
 import static org.apache.flink.table.types.inference.InputTypeStrategies.or;
 import static org.apache.flink.table.types.inference.InputTypeStrategies.repeatingSequence;
 import static org.apache.flink.table.types.inference.InputTypeStrategies.symbol;
+import static org.apache.flink.table.types.inference.InputTypeStrategies.varyingSequence;
 
 /**
  * Entry point for specific input type strategies not covered in {@link InputTypeStrategies}.
@@ -75,6 +76,18 @@ public final class SpecificInputTypeStrategies {
                                             logical(LogicalTypeFamily.CONSTRUCTED),
                                             logical(LogicalTypeRoot.BOOLEAN),
                                             logical(LogicalTypeFamily.NUMERIC))));
+
+    /** Input strategy for {@link BuiltInFunctionDefinitions#JSON_ARRAY}. */
+    public static final InputTypeStrategy JSON_ARRAY =
+            varyingSequence(
+                    symbol(JsonOnNull.class),
+                    or(
+                            logical(LogicalTypeFamily.CHARACTER_STRING),
+                            logical(LogicalTypeFamily.BINARY_STRING),
+                            logical(LogicalTypeFamily.TIMESTAMP),
+                            logical(LogicalTypeFamily.CONSTRUCTED),
+                            logical(LogicalTypeRoot.BOOLEAN),
+                            logical(LogicalTypeFamily.NUMERIC)));
 
     // --------------------------------------------------------------------------------------------
     // Strategies composed of other strategies

--- a/flink-table/flink-table-planner/src/main/java/org/apache/flink/table/planner/expressions/converter/converters/CustomizedConverters.java
+++ b/flink-table/flink-table-planner/src/main/java/org/apache/flink/table/planner/expressions/converter/converters/CustomizedConverters.java
@@ -57,6 +57,7 @@ public class CustomizedConverters {
         CONVERTERS.put(BuiltInFunctionDefinitions.JSON_VALUE, new JsonValueConverter());
         CONVERTERS.put(BuiltInFunctionDefinitions.JSON_QUERY, new JsonQueryConverter());
         CONVERTERS.put(BuiltInFunctionDefinitions.JSON_OBJECT, new JsonObjectConverter());
+        CONVERTERS.put(BuiltInFunctionDefinitions.JSON_ARRAY, new JsonArrayConverter());
         CONVERTERS.put(InternalFunctionDefinitions.THROW_EXCEPTION, new ThrowExceptionConverter());
     }
 

--- a/flink-table/flink-table-planner/src/main/java/org/apache/flink/table/planner/expressions/converter/converters/JsonConverterUtil.java
+++ b/flink-table/flink-table-planner/src/main/java/org/apache/flink/table/planner/expressions/converter/converters/JsonConverterUtil.java
@@ -1,0 +1,52 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.flink.table.planner.expressions.converter.converters;
+
+import org.apache.flink.annotation.Internal;
+import org.apache.flink.table.api.JsonOnNull;
+import org.apache.flink.table.api.TableException;
+import org.apache.flink.table.expressions.CallExpression;
+import org.apache.flink.table.expressions.ValueLiteralExpression;
+
+import org.apache.calcite.sql.SqlJsonConstructorNullClause;
+
+/** Utilities for JSON function converters. */
+@Internal
+class JsonConverterUtil {
+    public static SqlJsonConstructorNullClause getOnNullArgument(
+            CallExpression call, int argumentIdx) {
+        return ((ValueLiteralExpression) call.getChildren().get(argumentIdx))
+                .getValueAs(JsonOnNull.class)
+                .map(JsonConverterUtil::convertOnNull)
+                .orElseThrow(() -> new TableException("Missing argument for ON NULL."));
+    }
+
+    private static SqlJsonConstructorNullClause convertOnNull(JsonOnNull onNull) {
+        switch (onNull) {
+            case NULL:
+                return SqlJsonConstructorNullClause.NULL_ON_NULL;
+            case ABSENT:
+                return SqlJsonConstructorNullClause.ABSENT_ON_NULL;
+            default:
+                throw new TableException("Unknown ON NULL behavior: " + onNull);
+        }
+    }
+
+    private JsonConverterUtil() {}
+}

--- a/flink-table/flink-table-planner/src/main/java/org/apache/flink/table/planner/functions/sql/FlinkSqlOperatorTable.java
+++ b/flink-table/flink-table-planner/src/main/java/org/apache/flink/table/planner/functions/sql/FlinkSqlOperatorTable.java
@@ -1146,6 +1146,7 @@ public class FlinkSqlOperatorTable extends ReflectiveSqlOperatorTable {
     public static final SqlFunction JSON_VALUE = SqlStdOperatorTable.JSON_VALUE;
     public static final SqlFunction JSON_QUERY = SqlStdOperatorTable.JSON_QUERY;
     public static final SqlFunction JSON_OBJECT = new SqlJsonObjectFunction();
+    public static final SqlFunction JSON_ARRAY = SqlStdOperatorTable.JSON_ARRAY;
     public static final SqlPostfixOperator IS_JSON_VALUE = SqlStdOperatorTable.IS_JSON_VALUE;
     public static final SqlPostfixOperator IS_JSON_OBJECT = SqlStdOperatorTable.IS_JSON_OBJECT;
     public static final SqlPostfixOperator IS_JSON_ARRAY = SqlStdOperatorTable.IS_JSON_ARRAY;

--- a/flink-table/flink-table-planner/src/main/scala/org/apache/flink/table/planner/codegen/ExprCodeGenerator.scala
+++ b/flink-table/flink-table-planner/src/main/scala/org/apache/flink/table/planner/codegen/ExprCodeGenerator.scala
@@ -784,6 +784,8 @@ class ExprCodeGenerator(ctx: CodeGeneratorContext, nullableInput: Boolean)
 
       case JSON_OBJECT => new JsonObjectCallGen(call).generate(ctx, operands, resultType)
 
+      case JSON_ARRAY => new JsonArrayCallGen(call).generate(ctx, operands, resultType)
+
       case _: SqlThrowExceptionFunction =>
         val nullValue = generateNullLiteral(resultType, nullCheck = true)
         val code =

--- a/flink-table/flink-table-planner/src/main/scala/org/apache/flink/table/planner/codegen/JsonGenerateUtils.scala
+++ b/flink-table/flink-table-planner/src/main/scala/org/apache/flink/table/planner/codegen/JsonGenerateUtils.scala
@@ -38,8 +38,8 @@ import java.time.format.DateTimeFormatter
 /** Utility for generating JSON function calls. */
 object JsonGenerateUtils {
 
-  /** Returns a term which wraps the given <code>expression</code> into a [[JsonNode]]. If the
-   * operand represents another JSON construction function, a raw node is used instead. */
+  /** Returns a term which wraps the given `expression` into a [[JsonNode]]. If the operand
+   * represents another JSON construction function, a raw node is used instead. */
   def createNodeTerm(
       ctx: CodeGeneratorContext,
       containerNodeTerm: String,
@@ -53,8 +53,7 @@ object JsonGenerateUtils {
   }
 
   /**
-   * Returns a term which wraps the given <code>valueExpr</code> into a [[JsonNode]] of the
-   * appropriate type.
+   * Returns a term which wraps the given `valueExpr` into a [[JsonNode]] of the appropriate type.
    */
   def createNodeTerm(
       ctx: CodeGeneratorContext,
@@ -115,7 +114,7 @@ object JsonGenerateUtils {
   }
 
   /**
-   * Returns a term which wraps the given <code>valueExpr</code> as a raw [[JsonNode]].
+   * Returns a term which wraps the given `valueExpr` as a raw [[JsonNode]].
    *
    * @param containerNodeTerm Name of the [[ContainerNode]] from which to create the raw node.
    * @param valueExpr Generated expression of the value which should be wrapped.

--- a/flink-table/flink-table-planner/src/main/scala/org/apache/flink/table/planner/codegen/calls/BuiltInMethods.scala
+++ b/flink-table/flink-table-planner/src/main/scala/org/apache/flink/table/planner/codegen/calls/BuiltInMethods.scala
@@ -513,7 +513,4 @@ object BuiltInMethods {
   val JSON_QUERY = Types.lookupMethod(classOf[JsonFunctions], "jsonQuery",
     classOf[String], classOf[String], classOf[SqlJsonQueryWrapperBehavior],
     classOf[SqlJsonQueryEmptyOrErrorBehavior], classOf[SqlJsonQueryEmptyOrErrorBehavior])
-
-  val JSON_OBJECT = Types.lookupMethod(classOf[JsonFunctions], "jsonObject",
-    classOf[SqlJsonConstructorNullClause], classOf[Array[Any]])
 }

--- a/flink-table/flink-table-planner/src/main/scala/org/apache/flink/table/planner/codegen/calls/JsonArrayCallGen.scala
+++ b/flink-table/flink-table-planner/src/main/scala/org/apache/flink/table/planner/codegen/calls/JsonArrayCallGen.scala
@@ -17,29 +17,20 @@
  */
 
 package org.apache.flink.table.planner.codegen.calls
-import org.apache.flink.table.planner.codegen.CodeGenUtils._
+
+import org.apache.flink.table.planner.codegen.CodeGenUtils.{BINARY_STRING, className, newName, primitiveTypeTermForType}
 import org.apache.flink.table.planner.codegen.JsonGenerateUtils.{createNodeTerm, getOnNullBehavior}
 import org.apache.flink.table.planner.codegen.{CodeGeneratorContext, GeneratedExpression}
 import org.apache.flink.table.runtime.functions.SqlJsonUtils
 import org.apache.flink.table.types.logical.LogicalType
 
-import org.apache.flink.shaded.jackson2.com.fasterxml.jackson.databind.node.{NullNode, ObjectNode}
+import org.apache.flink.shaded.jackson2.com.fasterxml.jackson.databind.node.{ArrayNode, NullNode}
 
 import org.apache.calcite.rex.RexCall
 import org.apache.calcite.sql.SqlJsonConstructorNullClause.{ABSENT_ON_NULL, NULL_ON_NULL}
 
-/**
- * [[CallGenerator]] for `JSON_OBJECT`.
- *
- * `JSON_OBJECT` returns a character string. However, this creates an issue when nesting calls to
- * this function with the intention of creating a nested JSON structure. Instead of a nested JSON
- * object, a JSON string would be inserted, i.e.
- * `JSON_OBJECT(KEY 'K' VALUE JSON_OBJECT(KEY 'A' VALUE 'B'))` would result in
- * `{"K":"{\"A\":\"B\"}"}` instead of the intended `{"K":{"A":"B"}}`. We remedy this by treating
- * nested calls to this function differently and inserting the value as a raw node instead of as a
- * string node.
- */
-class JsonObjectCallGen(call: RexCall) extends CallGenerator {
+/** [[CallGenerator]] for `JSON_ARRAY`. */
+class JsonArrayCallGen(call: RexCall) extends CallGenerator {
   private def jsonUtils = className[SqlJsonUtils]
 
   override def generate(
@@ -48,29 +39,29 @@ class JsonObjectCallGen(call: RexCall) extends CallGenerator {
       returnType: LogicalType): GeneratedExpression = {
 
     val nodeTerm = newName("node")
-    ctx.addReusableMember(s"${className[ObjectNode]} $nodeTerm = $jsonUtils.createObjectNode();")
+    ctx.addReusableMember(s"${className[ArrayNode]} $nodeTerm = $jsonUtils.createArrayNode();")
 
     val nullNodeTerm = newName("nullNode")
     ctx.addReusableMember(s"${className[NullNode]} $nullNodeTerm = $nodeTerm.nullNode();")
 
     val onNull = getOnNullBehavior(operands.head)
-    val populateNodeCode = operands.zipWithIndex.drop(1).grouped(2).map {
-      case Seq((keyExpr, _), (valueExpr, valueIdx)) =>
-        val valueTerm = createNodeTerm(ctx, nodeTerm, valueExpr, call.operands.get(valueIdx))
+    val populateNodeCode = operands.zipWithIndex.drop(1).map {
+      case (elementExpr, elementIdx) =>
+        val elementTerm = createNodeTerm(ctx, nodeTerm, elementExpr, call.operands.get(elementIdx))
 
         onNull match {
           case NULL_ON_NULL =>
             s"""
-               |if (${valueExpr.nullTerm}) {
-               |    $nodeTerm.set(${keyExpr.resultTerm}.toString(), $nullNodeTerm);
+               |if (${elementExpr.nullTerm}) {
+               |    $nodeTerm.add($nullNodeTerm);
                |} else {
-               |    $nodeTerm.set(${keyExpr.resultTerm}.toString(), $valueTerm);
+               |    $nodeTerm.add($elementTerm);
                |}
                |""".stripMargin
           case ABSENT_ON_NULL =>
             s"""
-               |if (!${valueExpr.nullTerm}) {
-               |    $nodeTerm.set(${keyExpr.resultTerm}.toString(), $valueTerm);
+               |if (!${elementExpr.nullTerm}) {
+               |    $nodeTerm.add($elementTerm);
                |}
                |""".stripMargin
         }
@@ -78,15 +69,16 @@ class JsonObjectCallGen(call: RexCall) extends CallGenerator {
 
     val resultTerm = newName("result")
     val resultTermType = primitiveTypeTermForType(returnType)
-    val resultCode = s"""
-       |${operands.map(_.code).mkString}
-       |
-       |$nodeTerm.removeAll();
-       |$populateNodeCode
-       |
-       |$resultTermType $resultTerm =
-       |    $BINARY_STRING.fromString($jsonUtils.serializeJson($nodeTerm));
-       |""".stripMargin
+    val resultCode =
+      s"""
+         |${operands.map(_.code).mkString}
+         |
+         |$nodeTerm.removeAll();
+         |$populateNodeCode
+         |
+         |$resultTermType $resultTerm =
+         |    $BINARY_STRING.fromString($jsonUtils.serializeJson($nodeTerm));
+         |""".stripMargin
 
     GeneratedExpression(resultTerm, "false", resultCode, returnType)
   }

--- a/flink-table/flink-table-runtime/src/main/java/org/apache/flink/table/runtime/functions/SqlJsonUtils.java
+++ b/flink-table/flink-table-runtime/src/main/java/org/apache/flink/table/runtime/functions/SqlJsonUtils.java
@@ -25,6 +25,7 @@ import org.apache.flink.shaded.jackson2.com.fasterxml.jackson.core.JsonFactory;
 import org.apache.flink.shaded.jackson2.com.fasterxml.jackson.core.JsonProcessingException;
 import org.apache.flink.shaded.jackson2.com.fasterxml.jackson.databind.JsonNode;
 import org.apache.flink.shaded.jackson2.com.fasterxml.jackson.databind.ObjectMapper;
+import org.apache.flink.shaded.jackson2.com.fasterxml.jackson.databind.node.ArrayNode;
 import org.apache.flink.shaded.jackson2.com.fasterxml.jackson.databind.node.ObjectNode;
 
 /**
@@ -41,6 +42,11 @@ public class SqlJsonUtils {
     /** Returns a new {@link ObjectNode}. */
     public static ObjectNode createObjectNode() {
         return MAPPER.createObjectNode();
+    }
+
+    /** Returns a new {@link ArrayNode}. */
+    public static ArrayNode createArrayNode() {
+        return MAPPER.createArrayNode();
     }
 
     /** Serializes the given {@link JsonNode} to a JSON string. */


### PR DESCRIPTION
## What is the purpose of the change

This introduces support for `JSON_ARRAY` in Table API, SQL, and PyFlink. The implementation is akin to `JSON_OBJECT`.

supersedes #11282

## Verifying this change

This change added tests and can be verified as follows:

* `JsonFunctionsITCase`: added tests for all supported data types, `ON NULL` behaviors as well as nesting scenarios across different JSON construction functions

## Does this pull request potentially affect one of the following parts:

  - Dependencies (does it add or upgrade a dependency): no
  - The public API, i.e., is any changed class annotated with `@Public(Evolving)`: yes
  - The serializers: no
  - The runtime per-record code paths (performance sensitive): no
  - Anything that affects deployment or recovery: JobManager (and its components), Checkpointing, Kubernetes/Yarn, ZooKeeper: no
  - The S3 file system connector: no

## Documentation

  - Does this pull request introduce a new feature? yes
  - If yes, how is the feature documented? docs + JavaDocs
