### PR TITLE
[WIP][FLINK-22790] HybridSource E2E tests 

### DIFF
--- a/flink-end-to-end-tests/flink-end-to-end-tests-common-kafka/pom.xml
+++ b/flink-end-to-end-tests/flink-end-to-end-tests-common-kafka/pom.xml
@@ -40,6 +40,12 @@ under the License.
 	<dependencies>
 		<dependency>
 			<groupId>org.apache.flink</groupId>
+			<artifactId>flink-connector-files</artifactId>
+			<version>${project.version}</version>
+		</dependency>
+
+		<dependency>
+			<groupId>org.apache.flink</groupId>
 			<artifactId>flink-end-to-end-tests-common</artifactId>
 			<version>${project.version}</version>
 		</dependency>

--- a/flink-end-to-end-tests/flink-end-to-end-tests-common-kafka/src/test/java/org/apache/flink/tests/util/kafka/KafkaSourceE2ECase.java
+++ b/flink-end-to-end-tests/flink-end-to-end-tests-common-kafka/src/test/java/org/apache/flink/tests/util/kafka/KafkaSourceE2ECase.java
@@ -27,6 +27,7 @@ import org.apache.flink.connectors.test.common.junit.annotations.TestEnv;
 import org.apache.flink.connectors.test.common.testsuites.SourceTestSuiteBase;
 import org.apache.flink.tests.util.TestUtils;
 import org.apache.flink.tests.util.flink.FlinkContainerTestEnvironment;
+import org.apache.flink.tests.util.flink.FlinkContainerTestEnvironment.EnvironmentBuilder;
 
 import org.testcontainers.containers.KafkaContainer;
 import org.testcontainers.utility.DockerImageName;
@@ -39,11 +40,13 @@ public class KafkaSourceE2ECase extends SourceTestSuiteBase<String> {
     // Defines TestEnvironment
     @TestEnv
     FlinkContainerTestEnvironment flink =
-            new FlinkContainerTestEnvironment(
-                    1,
-                    6,
-                    TestUtils.getResource("kafka-connector.jar").toAbsolutePath().toString(),
-                    TestUtils.getResource("kafka-clients.jar").toAbsolutePath().toString());
+            new EnvironmentBuilder(1, 6)
+                    .withJarPath(
+                            TestUtils.getResource("kafka-connector.jar")
+                                    .toAbsolutePath()
+                                    .toString(),
+                            TestUtils.getResource("kafka-clients.jar").toAbsolutePath().toString())
+                    .build();
 
     // Defines ConnectorExternalSystem
     @ExternalSystem

--- a/flink-end-to-end-tests/flink-end-to-end-tests-common-kafka/src/test/java/org/apache/flink/tests/util/kafka/hybrid/FileDataWriter.java
+++ b/flink-end-to-end-tests/flink-end-to-end-tests-common-kafka/src/test/java/org/apache/flink/tests/util/kafka/hybrid/FileDataWriter.java
@@ -1,0 +1,69 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.flink.tests.util.kafka.hybrid;
+
+import org.apache.flink.connectors.test.common.external.SourceSplitDataWriter;
+
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import java.io.BufferedWriter;
+import java.io.IOException;
+import java.nio.charset.StandardCharsets;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.util.Collection;
+
+import static org.apache.flink.util.Preconditions.checkNotNull;
+
+public class FileDataWriter implements SourceSplitDataWriter<String> {
+
+    private static final Logger LOG = LoggerFactory.getLogger(FileDataWriter.class);
+
+    private final BufferedWriter fileWriter;
+
+    public FileDataWriter(Path outputFile) {
+        checkNotNull(outputFile);
+        try {
+            this.fileWriter = Files.newBufferedWriter(outputFile, StandardCharsets.UTF_8);
+        } catch (IOException e) {
+            LOG.error("Cannot initialize BufferedWriter for {}", outputFile.toAbsolutePath());
+            throw new IllegalStateException(e);
+        }
+    }
+
+    @Override
+    public void writeRecords(Collection<String> records) {
+        try {
+            for (String record : records) {
+                fileWriter.write(record);
+                fileWriter.newLine();
+            }
+            fileWriter.flush();
+        } catch (IOException e) {
+            LOG.error("Cannot write records");
+            throw new IllegalStateException(e);
+        }
+    }
+
+    @Override
+    public void close() throws IOException {
+        fileWriter.close();
+    }
+}

--- a/flink-end-to-end-tests/flink-end-to-end-tests-common-kafka/src/test/java/org/apache/flink/tests/util/kafka/hybrid/FileNonSplittableExternalContext.java
+++ b/flink-end-to-end-tests/flink-end-to-end-tests-common-kafka/src/test/java/org/apache/flink/tests/util/kafka/hybrid/FileNonSplittableExternalContext.java
@@ -1,0 +1,126 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.flink.tests.util.kafka.hybrid;
+
+import org.apache.flink.api.connector.source.Boundedness;
+import org.apache.flink.api.connector.source.Source;
+import org.apache.flink.connector.file.src.FileSource;
+import org.apache.flink.connector.file.src.reader.TextLineFormat;
+import org.apache.flink.connectors.test.common.external.ExternalContext;
+import org.apache.flink.connectors.test.common.external.SourceSplitDataWriter;
+
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import java.nio.file.Path;
+import java.util.ArrayList;
+import java.util.Collection;
+import java.util.List;
+import java.util.Random;
+import java.util.UUID;
+
+public class FileNonSplittableExternalContext implements ExternalContext<String> {
+
+    private static final Logger LOG =
+            LoggerFactory.getLogger(FileNonSplittableExternalContext.class);
+
+    private static final int NUM_RECORDS_UPPER_BOUND = 500;
+    private static final int NUM_RECORDS_LOWER_BOUND = 100;
+
+    private final Collection<SourceSplitDataWriter<String>> fileWriters = new ArrayList<>();
+
+    private final Path fileSourceDir;
+
+    public FileNonSplittableExternalContext(Path fileSourceDir) {
+        this.fileSourceDir = fileSourceDir;
+    }
+
+    @Override
+    public Source<String, ?, ?> createSource(Boundedness boundedness) {
+        return FileSource.forRecordStreamFormat(
+                        new TextLineFormat(),
+                        org.apache.flink.core.fs.Path.fromLocalFile(fileSourceDir.toFile()))
+                .build();
+    }
+
+    @Override
+    public SourceSplitDataWriter<String> createSourceSplitDataWriter() {
+        FileDataWriter fileDataWriter =
+                new FileDataWriter(fileSourceDir.resolve(UUID.randomUUID().toString()));
+        fileWriters.add(fileDataWriter);
+        return fileDataWriter;
+    }
+
+    @Override
+    public Collection<String> generateTestData(int splitIndex, long seed) {
+        Random random = new Random(seed);
+        List<String> randomStringRecords = new ArrayList<>();
+        int recordNum =
+                random.nextInt(NUM_RECORDS_UPPER_BOUND - NUM_RECORDS_LOWER_BOUND)
+                        + NUM_RECORDS_LOWER_BOUND;
+        for (int i = 0; i < recordNum; i++) {
+            int stringLength = random.nextInt(50) + 1;
+            randomStringRecords.add(generateRandomString(stringLength, random));
+        }
+        return randomStringRecords;
+    }
+
+    private String generateRandomString(int length, Random random) {
+        String alphaNumericString =
+                "ABCDEFGHIJKLMNOPQRSTUVWXYZ" + "abcdefghijklmnopqrstuvwxyz" + "0123456789";
+        StringBuilder sb = new StringBuilder();
+        for (int i = 0; i < length; ++i) {
+            sb.append(alphaNumericString.charAt(random.nextInt(alphaNumericString.length())));
+        }
+        return sb.toString();
+    }
+
+    @Override
+    public void close() {
+        fileWriters.forEach(
+                writer -> {
+                    try {
+                        writer.close();
+                    } catch (Exception e) {
+                        throw new RuntimeException("Cannot close file writer", e);
+                    }
+                });
+        fileWriters.clear();
+    }
+
+    @Override
+    public String toString() {
+        return "Non-splittable File context";
+    }
+
+    /** Factory of {@link FileNonSplittableExternalContext}. */
+    public static class Factory implements ExternalContext.Factory<String> {
+
+        private final Path fileSourceDir;
+
+        public Factory(Path fileSourceDir) {
+            this.fileSourceDir = fileSourceDir;
+        }
+
+        @Override
+        public ExternalContext<String> createExternalContext() {
+            return new FileNonSplittableExternalContext(fileSourceDir);
+        }
+    }
+}

--- a/flink-end-to-end-tests/flink-end-to-end-tests-common-kafka/src/test/java/org/apache/flink/tests/util/kafka/hybrid/HybridDataWriter.java
+++ b/flink-end-to-end-tests/flink-end-to-end-tests-common-kafka/src/test/java/org/apache/flink/tests/util/kafka/hybrid/HybridDataWriter.java
@@ -1,0 +1,63 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.flink.tests.util.kafka.hybrid;
+
+import org.apache.flink.connectors.test.common.external.SourceSplitDataWriter;
+
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import java.util.Collection;
+import java.util.List;
+
+import static org.apache.flink.tests.util.kafka.hybrid.TestDataUtils.divide;
+import static org.apache.flink.util.Preconditions.checkNotNull;
+
+public class HybridDataWriter implements SourceSplitDataWriter<String> {
+
+    private static final Logger LOG = LoggerFactory.getLogger(HybridDataWriter.class);
+    public static final double defaultDivideFraction = 0.5;
+
+    private final SourceSplitDataWriter<String> fileDataWriter;
+    private final SourceSplitDataWriter<String> kafkaDataWriter;
+
+    public HybridDataWriter(
+            SourceSplitDataWriter<String> fileDataWriter,
+            SourceSplitDataWriter<String> kafkaDataWriter) {
+        checkNotNull(fileDataWriter);
+        checkNotNull(kafkaDataWriter);
+
+        this.fileDataWriter = fileDataWriter;
+        this.kafkaDataWriter = kafkaDataWriter;
+    }
+
+    @Override
+    public void writeRecords(Collection<String> records) {
+        // Implicitly split the records between the two sources.
+        List<Collection<String>> parts = divide(records, defaultDivideFraction);
+        fileDataWriter.writeRecords(parts.get(0));
+        kafkaDataWriter.writeRecords(parts.get(1));
+    }
+
+    @Override
+    public void close() throws Exception {
+        fileDataWriter.close();
+        kafkaDataWriter.close();
+    }
+}

--- a/flink-end-to-end-tests/flink-end-to-end-tests-common-kafka/src/test/java/org/apache/flink/tests/util/kafka/hybrid/HybridKafkaAndFileExternalContext.java
+++ b/flink-end-to-end-tests/flink-end-to-end-tests-common-kafka/src/test/java/org/apache/flink/tests/util/kafka/hybrid/HybridKafkaAndFileExternalContext.java
@@ -1,0 +1,110 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.flink.tests.util.kafka.hybrid;
+
+import org.apache.flink.api.connector.source.Boundedness;
+import org.apache.flink.api.connector.source.Source;
+import org.apache.flink.connector.base.source.hybrid.HybridSource;
+import org.apache.flink.connector.kafka.source.testutils.KafkaSingleTopicExternalContext;
+import org.apache.flink.connectors.test.common.external.ExternalContext;
+import org.apache.flink.connectors.test.common.external.SourceSplitDataWriter;
+
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+import org.testcontainers.containers.KafkaContainer;
+
+import java.nio.file.Path;
+import java.util.Collection;
+import java.util.stream.Collectors;
+
+public class HybridKafkaAndFileExternalContext implements ExternalContext<String> {
+
+    private static final Logger LOG =
+            LoggerFactory.getLogger(HybridKafkaAndFileExternalContext.class);
+
+    private final ExternalContext<String> kafkaContext;
+    private final ExternalContext<String> fileContext;
+
+    public HybridKafkaAndFileExternalContext(
+            ExternalContext<String> kafkaContext, ExternalContext<String> fileContext) {
+        this.kafkaContext = kafkaContext;
+        this.fileContext = fileContext;
+    }
+
+    @Override
+    public Source<String, ?, ?> createSource(Boundedness boundedness) {
+        Source<String, ?, ?> fileSource = fileContext.createSource(Boundedness.BOUNDED);
+        Source<String, ?, ?> kafkaSource = kafkaContext.createSource(boundedness);
+        return HybridSource.builder(fileSource).addSource(kafkaSource).build();
+    }
+
+    @Override
+    public SourceSplitDataWriter<String> createSourceSplitDataWriter() {
+        return new HybridDataWriter(
+                fileContext.createSourceSplitDataWriter(),
+                kafkaContext.createSourceSplitDataWriter());
+    }
+
+    @Override
+    public Collection<String> generateTestData(int splitIndex, long seed) {
+        return fileContext.generateTestData(splitIndex, seed);
+    }
+
+    @Override
+    public void close() throws Exception {
+        kafkaContext.close();
+        fileContext.close();
+    }
+
+    @Override
+    public String toString() {
+        return "Hybrid Kafka+File context";
+    }
+
+    public enum Destination {
+        KAFKA,
+        FILE;
+    }
+
+    public static class Factory implements ExternalContext.Factory<String> {
+
+        private final KafkaContainer kafkaContainer;
+        private final Path fileSourceDir;
+
+        public Factory(KafkaContainer kafkaContainer, Path fileSourceDir) {
+            this.kafkaContainer = kafkaContainer;
+            this.fileSourceDir = fileSourceDir;
+        }
+
+        @Override
+        public ExternalContext<String> createExternalContext() {
+            return new HybridKafkaAndFileExternalContext(
+                    new KafkaSingleTopicExternalContext(getBootstrapServer()),
+                    new FileNonSplittableExternalContext(fileSourceDir));
+        }
+
+        private String getBootstrapServer() {
+            final String internalEndpoints =
+                    kafkaContainer.getNetworkAliases().stream()
+                            .map(host -> String.join(":", host, Integer.toString(9092)))
+                            .collect(Collectors.joining(","));
+            return String.join(",", kafkaContainer.getBootstrapServers(), internalEndpoints);
+        }
+    }
+}

--- a/flink-end-to-end-tests/flink-end-to-end-tests-common-kafka/src/test/java/org/apache/flink/tests/util/kafka/hybrid/HybridSourceE2ETest.java
+++ b/flink-end-to-end-tests/flink-end-to-end-tests-common-kafka/src/test/java/org/apache/flink/tests/util/kafka/hybrid/HybridSourceE2ETest.java
@@ -1,0 +1,310 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.flink.tests.util.kafka.hybrid;
+
+import org.apache.flink.api.common.JobStatus;
+import org.apache.flink.api.common.eventtime.WatermarkStrategy;
+import org.apache.flink.api.common.time.Deadline;
+import org.apache.flink.api.common.typeutils.TypeSerializer;
+import org.apache.flink.api.connector.source.Boundedness;
+import org.apache.flink.connectors.test.common.environment.ClusterControllable;
+import org.apache.flink.connectors.test.common.environment.TestEnvironment;
+import org.apache.flink.connectors.test.common.external.DefaultContainerizedExternalSystem;
+import org.apache.flink.connectors.test.common.external.ExternalContext;
+import org.apache.flink.connectors.test.common.junit.annotations.ExternalContextFactory;
+import org.apache.flink.connectors.test.common.junit.annotations.ExternalSystem;
+import org.apache.flink.connectors.test.common.junit.annotations.TestEnv;
+import org.apache.flink.connectors.test.common.junit.extensions.ConnectorTestingExtension;
+import org.apache.flink.connectors.test.common.junit.extensions.TestCaseInvocationContextProvider;
+import org.apache.flink.connectors.test.common.junit.extensions.TestLoggerExtension;
+import org.apache.flink.core.execution.JobClient;
+import org.apache.flink.runtime.testutils.CommonTestUtils;
+import org.apache.flink.streaming.api.datastream.DataStreamSource;
+import org.apache.flink.streaming.api.environment.StreamExecutionEnvironment;
+import org.apache.flink.streaming.api.operators.collect.CollectResultIterator;
+import org.apache.flink.streaming.api.operators.collect.CollectSinkOperator;
+import org.apache.flink.streaming.api.operators.collect.CollectSinkOperatorFactory;
+import org.apache.flink.streaming.api.operators.collect.CollectStreamSink;
+import org.apache.flink.tests.util.TestUtils;
+import org.apache.flink.tests.util.flink.FlinkContainerTestEnvironment;
+import org.apache.flink.tests.util.flink.FlinkContainerTestEnvironment.EnvironmentBuilder;
+import org.apache.flink.tests.util.flink.Mount;
+import org.apache.flink.util.CloseableIterator;
+
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.TestInstance;
+import org.junit.jupiter.api.TestTemplate;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+import org.testcontainers.containers.KafkaContainer;
+import org.testcontainers.utility.DockerImageName;
+
+import java.io.File;
+import java.io.IOException;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.time.Duration;
+import java.util.Collection;
+import java.util.Collections;
+import java.util.List;
+import java.util.UUID;
+import java.util.concurrent.ThreadLocalRandom;
+
+import static org.apache.flink.connectors.test.common.utils.TestDataMatchers.matchesSplitTestData;
+import static org.apache.flink.tests.util.kafka.hybrid.TestDataUtils.divideIndex;
+import static org.apache.flink.tests.util.kafka.hybrid.TestDataUtils.slice;
+import static org.hamcrest.MatcherAssert.assertThat;
+
+@ExtendWith({
+    ConnectorTestingExtension.class,
+    TestLoggerExtension.class,
+    TestCaseInvocationContextProvider.class
+})
+@TestInstance(TestInstance.Lifecycle.PER_CLASS)
+public class HybridSourceE2ETest {
+
+    private static final Logger LOG = LoggerFactory.getLogger(HybridSourceE2ETest.class);
+
+    Path tmpDir = Files.createTempDirectory("file_source_test_");
+
+    public HybridSourceE2ETest() throws IOException {}
+
+    @TestEnv
+    //    MiniClusterTestEnvironment flink = new MiniClusterTestEnvironment();
+    FlinkContainerTestEnvironment flink =
+            new EnvironmentBuilder(1, 6)
+                    .withJarPath(
+                            TestUtils.getResource("kafka-connector.jar")
+                                    .toAbsolutePath()
+                                    .toString(),
+                            TestUtils.getResource("kafka-clients.jar").toAbsolutePath().toString())
+                    .withMount(Mount.of(tmpDir.toString(), tmpDir.toString()))
+                    // Use for speedup during local development
+                    //                    .deleteOnExit(false)
+                    .build();
+
+    // Defines ConnectorExternalSystem
+    private static final String KAFKA_HOSTNAME = "kafka";
+    private static final String KAFKA_IMAGE_NAME = "confluentinc/cp-kafka:5.5.2";
+
+    // Defines ConnectorExternalSystem
+    @ExternalSystem
+    DefaultContainerizedExternalSystem<KafkaContainer> kafka =
+            DefaultContainerizedExternalSystem.builder()
+                    .fromContainer(
+                            new KafkaContainer(DockerImageName.parse(KAFKA_IMAGE_NAME))
+                                    .withNetworkAliases(KAFKA_HOSTNAME))
+                    .bindWithFlinkContainer(flink.getFlinkContainer())
+                    .build();
+
+    @SuppressWarnings("unused")
+    @ExternalContextFactory
+    HybridKafkaAndFileExternalContext.Factory singleTopic =
+            new HybridKafkaAndFileExternalContext.Factory(kafka.getContainer(), tmpDir);
+
+    // ----------------------------- Basic test cases ---------------------------------
+
+    @TestTemplate
+    @DisplayName("Test HybridSource")
+    public void testSourceSingleSplit(
+            TestEnvironment testEnv, ExternalContext<String> externalContext) throws Exception {
+
+        // Write test data to external system
+        final Collection<String> testRecords = generateAndWriteTestData(0, externalContext, 0.5);
+
+        // Build and execute Flink job
+        StreamExecutionEnvironment execEnv = testEnv.createExecutionEnvironment();
+
+        try (CloseableIterator<String> resultIterator =
+                execEnv.fromSource(
+                                externalContext.createSource(Boundedness.BOUNDED),
+                                WatermarkStrategy.noWatermarks(),
+                                "Tested Source")
+                        .returns(String.class)
+                        .setParallelism(1)
+                        .executeAndCollect("Source Single Split Test")) {
+            // Check test result
+            assertThat(resultIterator, matchesSplitTestData(testRecords));
+        }
+    }
+
+    @TestTemplate
+    @DisplayName("Test HybridSource with TaskManager failover pre-switch")
+    public void testTaskManagerFailurePreSwitch(
+            TestEnvironment testEnv,
+            ExternalContext<String> externalContext,
+            ClusterControllable controller)
+            throws Exception {
+        double divideFraction = 0.5; // test data split proportion between two sources
+        int failurePositionShift = +1; // fail post-switch
+        testFailover(testEnv, externalContext, controller, divideFraction, failurePositionShift);
+    }
+
+    @TestTemplate
+    @DisplayName("Test HybridSource with TaskManager failover pre-switch")
+    public void testTaskManagerFailurePostSwitch(
+            TestEnvironment testEnv,
+            ExternalContext<String> externalContext,
+            ClusterControllable controller)
+            throws Exception {
+
+        double divideFraction = 0.5; // test data split proportion between two sources
+        int failurePositionShift = -1; // fail pre-switch
+        testFailover(testEnv, externalContext, controller, divideFraction, failurePositionShift);
+    }
+
+    private void testFailover(
+            TestEnvironment testEnv,
+            ExternalContext<String> externalContext,
+            ClusterControllable controller,
+            double divideFraction,
+            int failurePositionShift)
+            throws Exception {
+        TestExecutionContext<String> testContext = setup(testEnv, externalContext, divideFraction);
+        int divideIndex = divideIndex(testContext.testRecords, divideFraction);
+
+        List<Collection<String>> failureSlices =
+                slice(testContext.testRecords, divideIndex + failurePositionShift);
+        Collection<String> slicePreFailure = failureSlices.get(0);
+
+        assertThat(
+                testContext.iterator,
+                matchesSplitTestData(slicePreFailure, slicePreFailure.size()));
+
+        Collection<String> slicePostFailure = failureSlices.get(1);
+
+        controller.triggerTaskManagerFailover(testContext.jobClient, () -> {});
+        assertThat(
+                testContext.iterator,
+                matchesSplitTestData(slicePostFailure, slicePostFailure.size()));
+
+        cleanUp(testContext);
+    }
+
+    private void cleanUp(TestExecutionContext<String> testContext) throws Exception {
+        // TODO: Fix. Immediate cleanup sometimes causes a job-not-found exception.
+        Thread.sleep(5000);
+
+        testContext.iterator.close();
+        CommonTestUtils.terminateJob(testContext.jobClient, Duration.ofSeconds(30));
+        CommonTestUtils.waitForJobStatus(
+                testContext.jobClient,
+                Collections.singletonList(JobStatus.CANCELED),
+                Deadline.fromNow(Duration.ofSeconds(30)));
+
+        for (File file : tmpDir.toFile().listFiles()) {
+            if (!file.isDirectory()) {
+                file.delete();
+            }
+        }
+    }
+
+    private TestExecutionContext<String> setup(
+            TestEnvironment testEnv, ExternalContext<String> externalContext, double divideFraction)
+            throws Exception {
+        int splitIndex = 0;
+        final Collection<String> testRecords =
+                generateAndWriteTestData(splitIndex, externalContext, divideFraction);
+
+        final StreamExecutionEnvironment env = testEnv.createExecutionEnvironment();
+
+        env.enableCheckpointing(50);
+
+        // CONTINUOUS_UNBOUNDED has to be used, otherwise even when not all data was yet read from
+        // the File source, the job is in FINISHED state when failover is triggered.
+        final DataStreamSource<String> dataStreamSource =
+                (DataStreamSource<String>)
+                        env.fromSource(
+                                        externalContext.createSource(
+                                                Boundedness.CONTINUOUS_UNBOUNDED),
+                                        WatermarkStrategy.noWatermarks(),
+                                        "Tested Source")
+                                .returns(String.class)
+                                .setParallelism(1);
+
+        final CollectResultIterator<String> iterator = getResultsIterator(env, dataStreamSource);
+        final JobClient jobClient = env.executeAsync("TaskManager Failover Test");
+        iterator.setJobClient(jobClient);
+
+        return new TestExecutionContext<>(testRecords, jobClient, iterator);
+    }
+
+    private static class TestExecutionContext<T> {
+        final Collection<T> testRecords;
+        final JobClient jobClient;
+        final CollectResultIterator<T> iterator;
+
+        public TestExecutionContext(
+                Collection<T> testRecords, JobClient jobClient, CollectResultIterator<T> iterator) {
+            this.testRecords = testRecords;
+            this.jobClient = jobClient;
+            this.iterator = iterator;
+        }
+    }
+
+    // ----------------------------- Helper Functions ---------------------------------
+
+    /**
+     * Generate a set of test records and write it to the given split writer.
+     *
+     * @param externalContext External context
+     * @param fraction Determines how to divide test data between the FileSource and KafkaSource
+     *     parts of the HybridSource under test
+     * @return Collection of generated test records
+     */
+    private static Collection<String> generateAndWriteTestData(
+            int splitIndex, ExternalContext<String> externalContext, double fraction) {
+        final Collection<String> testRecordCollection =
+                externalContext.generateTestData(
+                        splitIndex, ThreadLocalRandom.current().nextLong());
+        LOG.debug("Writing {} records to external system", testRecordCollection.size());
+
+        externalContext.createSourceSplitDataWriter().writeRecords(testRecordCollection);
+
+        return testRecordCollection;
+    }
+
+    // This approach is used since DataStream API doesn't expose job client for executeAndCollect()
+    private CollectResultIterator<String> getResultsIterator(
+            StreamExecutionEnvironment env, DataStreamSource<String> dataStreamSource) {
+
+        TypeSerializer<String> serializer =
+                dataStreamSource.getType().createSerializer(env.getConfig());
+
+        String accumulatorName = "dataStreamCollect_" + UUID.randomUUID();
+
+        CollectSinkOperatorFactory<String> factory =
+                new CollectSinkOperatorFactory<>(serializer, accumulatorName);
+
+        CollectSinkOperator<String> operator = (CollectSinkOperator<String>) factory.getOperator();
+
+        CollectResultIterator<String> iterator =
+                new CollectResultIterator<>(
+                        operator.getOperatorIdFuture(),
+                        serializer,
+                        accumulatorName,
+                        env.getCheckpointConfig());
+
+        CollectStreamSink<String> sink = new CollectStreamSink<>(dataStreamSource, factory);
+
+        sink.name("Data stream collect sink");
+        env.addOperator(sink.getTransformation());
+        return iterator;
+    }
+}

--- a/flink-end-to-end-tests/flink-end-to-end-tests-common-kafka/src/test/java/org/apache/flink/tests/util/kafka/hybrid/TestDataUtils.java
+++ b/flink-end-to-end-tests/flink-end-to-end-tests-common-kafka/src/test/java/org/apache/flink/tests/util/kafka/hybrid/TestDataUtils.java
@@ -1,0 +1,85 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.flink.tests.util.kafka.hybrid;
+
+import java.util.ArrayList;
+import java.util.Collection;
+import java.util.List;
+import java.util.Map;
+import java.util.concurrent.atomic.AtomicInteger;
+import java.util.stream.Collectors;
+
+public class TestDataUtils {
+
+    /**
+     * Divides the collection into two parts based on the proportion between the part's sizes.
+     *
+     * @param input collection to be divided.
+     * @param fraction indicating which portion of the input elements should be placed into the
+     *     first part of the division. The second part will be assigned the remaining elements (1 -
+     *     {@code fraction}).
+     * @param <T> type of the collection.
+     * @return resulting parts of the division stored separately at index 0 and 1 of the returned
+     *     list.
+     */
+    public static <T> List<Collection<T>> divide(Collection<T> input, double fraction) {
+        int divideIndex = divideIndex(input, fraction);
+        return slice(input, divideIndex);
+    }
+
+    /**
+     * Calculates the index of an element in the {@code input} collection that denotes the division
+     * according to the specified {@code fraction} relation between the parts.
+     *
+     * @param input collection to be divided.
+     * @param fraction indicating which portion of the input elements should be placed into the
+     *     first part of the division. The second part will be assigned the remaining elements
+     *     {@code (1 - fraction)}.
+     * @param <T> type of the collection.
+     * @return the index of the first element in the {@code input} collection that belongs to the
+     *     second part of the division.
+     */
+    public static <T> int divideIndex(Collection<T> input, double fraction) {
+        return (int) (input.size() * fraction);
+    }
+
+    /**
+     * Divides the collection into two parts with the first part containing {@code numRecords}.
+     *
+     * @param input collection to be divided.
+     * @param numRecords indicating how many elements the first part of the division has to contain.
+     *     If {@code numRecords} is larger than the size of the input collection, the second part is
+     *     going to be empty.
+     * @param <T> type of the collection.
+     * @return resulting parts of the division stored separately at index 0 and 1 of the returned
+     *     list.
+     */
+    public static <T> List<Collection<T>> slice(Collection<T> input, int numRecords) {
+        final List<T> list = new ArrayList<>(input);
+        final AtomicInteger counter = new AtomicInteger();
+
+        Map<Boolean, List<T>> map =
+                list.stream()
+                        .collect(
+                                Collectors.partitioningBy(
+                                        e -> counter.incrementAndGet() > numRecords));
+
+        return new ArrayList<>(map.values());
+    }
+}

--- a/flink-end-to-end-tests/flink-end-to-end-tests-common/src/main/java/org/apache/flink/tests/util/flink/FlinkContainerTestEnvironment.java
+++ b/flink-end-to-end-tests/flink-end-to-end-tests-common/src/main/java/org/apache/flink/tests/util/flink/FlinkContainerTestEnvironment.java
@@ -26,6 +26,8 @@ import org.apache.flink.core.execution.JobClient;
 import org.apache.flink.runtime.testutils.CommonTestUtils;
 import org.apache.flink.streaming.api.environment.StreamExecutionEnvironment;
 
+import javax.annotation.Nullable;
+
 import java.time.Duration;
 
 import static org.apache.flink.configuration.HeartbeatManagerOptions.HEARTBEAT_INTERVAL;
@@ -40,7 +42,11 @@ public class FlinkContainerTestEnvironment implements TestEnvironment, ClusterCo
     private final String[] jarPath;
 
     public FlinkContainerTestEnvironment(
-            int numTaskManagers, int numSlotsPerTaskManager, String... jarPath) {
+            int numTaskManagers,
+            int numSlotsPerTaskManager,
+            @Nullable Mount mount,
+            boolean deleteOnExit,
+            String... jarPath) {
 
         Configuration flinkConfiguration = flinkConfiguration();
         flinkConfiguration.set(NUM_TASK_SLOTS, numSlotsPerTaskManager);
@@ -49,7 +55,10 @@ public class FlinkContainerTestEnvironment implements TestEnvironment, ClusterCo
                 FlinkContainer.builder()
                         .numTaskManagers(numTaskManagers)
                         .withFlinkConfiguration(flinkConfiguration)
+                        .withMount(mount)
+                        .deleteOnExit(deleteOnExit)
                         .build();
+
         this.jarPath = jarPath;
     }
 
@@ -118,5 +127,38 @@ public class FlinkContainerTestEnvironment implements TestEnvironment, ClusterCo
         flinkConfiguration.set(SLOT_REQUEST_TIMEOUT, 10000L);
 
         return flinkConfiguration;
+    }
+
+    public static class EnvironmentBuilder {
+        private final int numTaskManagers;
+        private final int numSlotsPerTaskManager;
+        private Mount mount;
+        private boolean deleteOnExit = true;
+        private String[] jarPath;
+
+        public EnvironmentBuilder(int numTaskManagers, int numSlotsPerTaskManager) {
+            this.numTaskManagers = numTaskManagers;
+            this.numSlotsPerTaskManager = numSlotsPerTaskManager;
+        }
+
+        public EnvironmentBuilder withJarPath(String... jarPath) {
+            this.jarPath = jarPath;
+            return this;
+        }
+
+        public EnvironmentBuilder withMount(Mount mount) {
+            this.mount = mount;
+            return this;
+        }
+
+        public EnvironmentBuilder deleteOnExit(boolean deleteOnExit) {
+            this.deleteOnExit = deleteOnExit;
+            return this;
+        }
+
+        public FlinkContainerTestEnvironment build() {
+            return new FlinkContainerTestEnvironment(
+                    numTaskManagers, numSlotsPerTaskManager, mount, deleteOnExit, jarPath);
+        }
     }
 }

--- a/flink-end-to-end-tests/flink-end-to-end-tests-common/src/main/java/org/apache/flink/tests/util/flink/Mount.java
+++ b/flink-end-to-end-tests/flink-end-to-end-tests-common/src/main/java/org/apache/flink/tests/util/flink/Mount.java
@@ -1,0 +1,43 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.flink.tests.util.flink;
+
+/** Represents a mount of a file or a directory from the local file system into a test container. */
+public class Mount {
+
+    private final String from;
+    private final String to;
+
+    private Mount(String from, String to) {
+        this.from = from;
+        this.to = to;
+    }
+
+    public static Mount of(String from, String to) {
+        return new Mount(from, to);
+    }
+
+    public String from() {
+        return from;
+    }
+
+    public String to() {
+        return to;
+    }
+}


### PR DESCRIPTION
Same as https://github.com/apache/flink/pull/17215, but rebased.
In comparison to the original PR, tests do not terminate because of the changes in `FlinkContainerTestEnvironment`'s triggerJobManagerFailover.

In addition, removes the changes to the `ExternalContext` interface by introducing a `HybridDataWriter` which always splits data in half between the two underlying sources.