### PR TITLE
[hotfix][docs] fix link from upsert-kafka to kafka Table(!) connector

### DIFF
--- a/docs/content.zh/docs/connectors/table/upsert-kafka.md
+++ b/docs/content.zh/docs/connectors/table/upsert-kafka.md
@@ -88,7 +88,7 @@ GROUP BY user_region;
 Available Metadata
 ------------------
 
-See the [regular Kafka connector]({{< ref "docs/connectors/datastream/kafka" >}}#available-metadata) for a list
+See the [regular Kafka connector]({{< ref "docs/connectors/table/kafka" >}}#available-metadata) for a list
 of all available metadata fields.
 
 连接器参数

--- a/docs/content/docs/connectors/table/upsert-kafka.md
+++ b/docs/content/docs/connectors/table/upsert-kafka.md
@@ -97,7 +97,7 @@ GROUP BY user_region;
 Available Metadata
 ------------------
 
-See the [regular Kafka connector]({{< ref "docs/connectors/datastream/kafka" >}}#available-metadata) for a list
+See the [regular Kafka connector]({{< ref "docs/connectors/table/kafka" >}}#available-metadata) for a list
 of all available metadata fields.
 
 Connector Options


### PR DESCRIPTION
## What is the purpose of the change

The current Table API upsert-kafka docs page wrongly links to the DataStream kafka connector for available metadata, however, it should link to the Table API kafka connector instead.


## Brief change log

  - fix links in the English and Chinese docs pages
