### PR TITLE
[hotfix][tests] Azure tests fail prematurely because timeout watchdog fails to sleep

### DIFF
--- a/tools/azure-pipelines/uploading_watchdog.sh
+++ b/tools/azure-pipelines/uploading_watchdog.sh
@@ -57,7 +57,7 @@ function timeout_watchdog() {
   if [[ $secondsToKill -lt 0 ]]; then
     secondsToKill=0
   fi
-  sleep $(secondsToKill)
+  sleep ${secondsToKill}
   print_stacktraces | tee "$DEBUG_FILES_OUTPUT_DIR/jps-traces.1"
 
   echo "============================="


### PR DESCRIPTION
## What is the purpose of the change

The `secondsToKill` variable is executed as a command by mistake thus not effective, which makes the tests fail prematurely when the build takes 95% of the build time.

## Brief change log

- Reference `secondsToKill` as a varialble.

## Verifying this change

This change is a trivial rework / code cleanup without any test coverage.

## Does this pull request potentially affect one of the following parts:

  - Dependencies (does it add or upgrade a dependency): no
  - The public API, i.e., is any changed class annotated with `@Public(Evolving)`:  no
  - The serializers: no 
  - The runtime per-record code paths (performance sensitive): no
  - Anything that affects deployment or recovery: JobManager (and its components), Checkpointing, Kubernetes/Yarn, ZooKeeper: no
  - The S3 file system connector: no 

## Documentation

  - Does this pull request introduce a new feature?  no
  - If yes, how is the feature documented? (not applicable / docs / JavaDocs / not documented)
