### PR TITLE
[FLINK-24319][Tests] Fix invalid surefire work directory for flink-tests

### DIFF
--- a/flink-tests/pom.xml
+++ b/flink-tests/pom.xml
@@ -410,6 +410,7 @@ under the License.
 					<systemPropertyVariables>
 						<log.level>WARN</log.level>
 					</systemPropertyVariables>
+					<workingDirectory>${project.build.directory}</workingDirectory>
 					<excludes>
 						<exclude>**/*TestBase*.class</exclude>
 					</excludes>


### PR DESCRIPTION
## What is the purpose of the change

Commit https://github.com/apache/flink/commit/7aa510c9e5dad2f0d2bcdcf1abc6b4f9e0374470#diff-9c5fb3d1b7e3b0f54bc5c4182965c4fe1f9023d449017cece3005d3f90e8e4d8 changed the working dir of surefire plugin to project base dir, which leads to jar not found exception in ClassLoaderITCase, because it locates jar files via relative paths.


## Brief change log

- Make flink-tests run in the project build directory.

## Verifying this change

This change is a trivial rework / code cleanup without any test coverage.

## Does this pull request potentially affect one of the following parts:

  - Dependencies (does it add or upgrade a dependency): no
  - The public API, i.e., is any changed class annotated with `@Public(Evolving)`: no
  - The serializers: no
  - The runtime per-record code paths (performance sensitive): no
  - Anything that affects deployment or recovery: JobManager (and its components), Checkpointing, Kubernetes/Yarn, ZooKeeper: no 
  - The S3 file system connector: no

## Documentation

  - Does this pull request introduce a new feature? no
  - If yes, how is the feature documented? (not applicable / docs / JavaDocs / not documented)
