### PR TITLE
[FLINK-24303][coordination] Failure when creating a source enumerator leads to full failover, not JobManager failure.

### DIFF
--- a/flink-connectors/flink-connector-base/src/test/java/org/apache/flink/connector/base/source/reader/CoordinatedSourceITCase.java
+++ b/flink-connectors/flink-connector-base/src/test/java/org/apache/flink/connector/base/source/reader/CoordinatedSourceITCase.java
@@ -20,17 +20,26 @@ package org.apache.flink.connector.base.source.reader;
 
 import org.apache.flink.api.common.accumulators.ListAccumulator;
 import org.apache.flink.api.common.eventtime.WatermarkStrategy;
+import org.apache.flink.api.common.restartstrategy.RestartStrategies;
 import org.apache.flink.api.connector.source.Boundedness;
 import org.apache.flink.api.connector.source.Source;
+import org.apache.flink.api.connector.source.SplitEnumerator;
+import org.apache.flink.api.connector.source.SplitEnumeratorContext;
+import org.apache.flink.api.connector.source.mocks.MockSourceSplit;
 import org.apache.flink.configuration.Configuration;
 import org.apache.flink.connector.base.source.reader.mocks.MockBaseSource;
+import org.apache.flink.connector.base.source.reader.mocks.MockSplitEnumerator;
 import org.apache.flink.streaming.api.datastream.DataStream;
 import org.apache.flink.streaming.api.environment.StreamExecutionEnvironment;
 import org.apache.flink.streaming.api.functions.sink.RichSinkFunction;
 import org.apache.flink.test.util.AbstractTestBase;
+import org.apache.flink.util.FlinkRuntimeException;
 
 import org.junit.Test;
 
+import javax.annotation.Nullable;
+
+import java.io.IOException;
 import java.util.Collections;
 import java.util.List;
 
@@ -60,6 +69,34 @@ public class CoordinatedSourceITCase extends AbstractTestBase {
         executeAndVerify(env, stream1.union(stream2), 40);
     }
 
+    @Test
+    public void testEnumeratorCreationFails() throws Exception {
+        OnceFailingToCreateEnumeratorSource.reset();
+
+        final StreamExecutionEnvironment env = StreamExecutionEnvironment.getExecutionEnvironment();
+        env.setRestartStrategy(RestartStrategies.fixedDelayRestart(Integer.MAX_VALUE, 0L));
+        final Source<Integer, ?, ?> source =
+                new OnceFailingToCreateEnumeratorSource(2, 10, Boundedness.BOUNDED);
+        final DataStream<Integer> stream =
+                env.fromSource(source, WatermarkStrategy.noWatermarks(), "TestingSource");
+        executeAndVerify(env, stream, 20);
+    }
+
+    @Test
+    public void testEnumeratorRestoreFails() throws Exception {
+        OnceFailingToRestoreEnumeratorSource.reset();
+
+        final StreamExecutionEnvironment env = StreamExecutionEnvironment.getExecutionEnvironment();
+        env.setRestartStrategy(RestartStrategies.fixedDelayRestart(Integer.MAX_VALUE, 0L));
+        env.enableCheckpointing(10);
+
+        final Source<Integer, ?, ?> source =
+                new OnceFailingToRestoreEnumeratorSource(2, 10, Boundedness.BOUNDED);
+        final DataStream<Integer> stream =
+                env.fromSource(source, WatermarkStrategy.noWatermarks(), "TestingSource");
+        executeAndVerify(env, stream, 20);
+    }
+
     @SuppressWarnings("serial")
     private void executeAndVerify(
             StreamExecutionEnvironment env, DataStream<Integer> stream, int numRecords)
@@ -82,5 +119,132 @@ public class CoordinatedSourceITCase extends AbstractTestBase {
         assertEquals(numRecords, result.size());
         assertEquals(0, (int) result.get(0));
         assertEquals(numRecords - 1, (int) result.get(result.size() - 1));
+    }
+
+    // ------------------------------------------------------------------------
+
+    private static class OnceFailingToCreateEnumeratorSource extends MockBaseSource {
+
+        private static final long serialVersionUID = 1L;
+        private static boolean hasFailed;
+
+        OnceFailingToCreateEnumeratorSource(
+                int numSplits, int numRecordsPerSplit, Boundedness boundedness) {
+            super(numSplits, numRecordsPerSplit, boundedness);
+        }
+
+        @Override
+        public SplitEnumerator<MockSourceSplit, List<MockSourceSplit>> createEnumerator(
+                SplitEnumeratorContext<MockSourceSplit> enumContext) {
+            if (!hasFailed) {
+                hasFailed = true;
+                throw new FlinkRuntimeException("Test Failure");
+            }
+
+            return super.createEnumerator(enumContext);
+        }
+
+        static void reset() {
+            hasFailed = false;
+        }
+    }
+
+    /**
+     * A source with the following behavior:
+     *
+     * <ol>
+     *   <li>It initially creates an enumerator that does not assign work, waits until the first
+     *       checkpoint completes (which contains all work, because none is assigned, yet) and then
+     *       triggers a global failure.
+     *   <li>Upon restoring from the failure, the first attempt to restore the enumerator fails with
+     *       an exception.
+     *   <li>The next time to restore the enumerator succeeds and the enumerator works regularly.
+     * </ol>
+     */
+    private static class OnceFailingToRestoreEnumeratorSource extends MockBaseSource {
+
+        private static final long serialVersionUID = 1L;
+        private static boolean hasFailed;
+
+        OnceFailingToRestoreEnumeratorSource(
+                int numSplits, int numRecordsPerSplit, Boundedness boundedness) {
+            super(numSplits, numRecordsPerSplit, boundedness);
+        }
+
+        @Override
+        public SplitEnumerator<MockSourceSplit, List<MockSourceSplit>> createEnumerator(
+                SplitEnumeratorContext<MockSourceSplit> enumContext) {
+
+            final SplitEnumerator<MockSourceSplit, List<MockSourceSplit>> enumerator =
+                    super.createEnumerator(enumContext);
+
+            if (hasFailed) {
+                // after the failure happened, we proceed normally
+                return enumerator;
+            } else {
+                // before the failure, we go with
+                try {
+                    final List<MockSourceSplit> splits = enumerator.snapshotState(1L);
+                    return new NonAssigningEnumerator(splits, enumContext);
+                } catch (Exception e) {
+                    throw new FlinkRuntimeException(e.getMessage(), e);
+                }
+            }
+        }
+
+        @Override
+        public SplitEnumerator<MockSourceSplit, List<MockSourceSplit>> restoreEnumerator(
+                SplitEnumeratorContext<MockSourceSplit> enumContext,
+                List<MockSourceSplit> checkpoint)
+                throws IOException {
+            if (!hasFailed) {
+                hasFailed = true;
+                throw new FlinkRuntimeException("Test Failure");
+            }
+
+            return super.restoreEnumerator(enumContext, checkpoint);
+        }
+
+        static void reset() {
+            hasFailed = false;
+        }
+
+        /**
+         * This enumerator does not assign work, so all state is in the checkpoint. After the first
+         * checkpoint is complete, it triggers a global failure.
+         */
+        private static class NonAssigningEnumerator extends MockSplitEnumerator {
+
+            private final SplitEnumeratorContext<?> context;
+
+            NonAssigningEnumerator(
+                    List<MockSourceSplit> splits, SplitEnumeratorContext<MockSourceSplit> context) {
+                super(splits, context);
+                this.context = context;
+            }
+
+            @Override
+            public void addReader(int subtaskId) {
+                // we do nothing here to make sure there is no progress
+            }
+
+            @Override
+            public void handleSplitRequest(int subtaskId, @Nullable String requesterHostname) {
+                // we do nothing here to make sure there is no progress
+            }
+
+            @Override
+            public void notifyCheckpointComplete(long checkpointId) throws Exception {
+                // This is a bit of a clumsy way to trigger a global failover from a coordinator.
+                // This is safe, though, because per the contract, exceptions in the enumerator
+                // handlers trigger a global failover.
+                context.callAsync(
+                        () -> null,
+                        (success, failure) -> {
+                            throw new FlinkRuntimeException(
+                                    "Artificial trigger for Global Failover");
+                        });
+            }
+        }
     }
 }

--- a/flink-runtime/src/test/java/org/apache/flink/runtime/source/coordinator/SourceCoordinatorTest.java
+++ b/flink-runtime/src/test/java/org/apache/flink/runtime/source/coordinator/SourceCoordinatorTest.java
@@ -256,6 +256,26 @@ public class SourceCoordinatorTest extends SourceCoordinatorTestBase {
     }
 
     @Test
+    public void testFailJobWhenExceptionThrownFromEnumeratorCreation() throws Exception {
+        final RuntimeException failureReason = new RuntimeException("Artificial Exception");
+
+        final SourceCoordinator<?, ?> coordinator =
+                new SourceCoordinator<>(
+                        OPERATOR_NAME,
+                        coordinatorExecutor,
+                        new EnumeratorCreatingSource<>(
+                                () -> {
+                                    throw failureReason;
+                                }),
+                        context);
+
+        coordinator.start();
+
+        assertTrue(operatorCoordinatorContext.isJobFailed());
+        assertEquals(failureReason, operatorCoordinatorContext.getJobFailureReason());
+    }
+
+    @Test
     public void testErrorThrownFromSplitEnumerator() throws Exception {
         final Error error = new Error("Test Error");
         try (final MockSplitEnumeratorContext<MockSourceSplit> enumeratorContext =


### PR DESCRIPTION
## What is the purpose of the change

Exceptions during the creation of a `SplitEnumerator` in the `SourceCoordinator` now lead to full failover, not JobManager failure (JobManager crash / HA failover).

Instead of letting exceptions during the creation of the `SplitEnumerator` bubble up (and ultimately fail the JobManager / Scheduler creation), we now catch those exceptions and trigger a full (global) failover for that case.

## Design Rationale

Why not fix it for all `OperatorCoordinators` on the generic level? Meaning, trigger failover when the start method of OperatorCoordinator produces an exception?

I was looking to do that initially, but the scheduler is not prepared to handle global failures in cases where the starting procedure wasn't completed. A failover during that phase results in `IllegalStateException: BUG: trying to schedule a region which is not in CREATED state`.
This can be mitigated by not triggering the global failure synchronously, but enqueuing a failure trigger in the scheduler's main thread executor.
The solution here felt more "controlled" to me, minimal impact, given that this is a sensitive fix on a stable branch.

In the longer term, I would like to change the Source Coordinator code such that all enumerator creation and restore happens actually in the enumerator thread. That makes the failure handling cleaner (no exceptions can happen during the startup phase) and also solves the issue what we move expensive enumerator initialization out of the JobManager startup phase

## Verifying this change

This patch adds
 - a Unit Test in `SourceCoordinatorTest`
 - To Integration Tests for both creating and restoring of the `SplitEnumerator` in `CoordinatedSourceITCase`

## Does this pull request potentially affect one of the following parts:

  - Dependencies (does it add or upgrade a dependency): **no**
  - The public API, i.e., is any changed class annotated with `@Public(Evolving)`: **no**
  - The serializers: **no**
  - The runtime per-record code paths (performance sensitive): **no**
  - Anything that affects deployment or recovery: JobManager (and its components), Checkpointing, Kubernetes/Yarn, ZooKeeper: **yes**
  - The S3 file system connector: **no**

## Documentation

  - Does this pull request introduce a new feature? **no**
  - If yes, how is the feature documented? **not applicable**
