### PR TITLE
[FLINK-24337] fix WEB UI build failure on windows

### DIFF
--- a/flink-runtime-web/web-dashboard/.eslintrc.js
+++ b/flink-runtime-web/web-dashboard/.eslintrc.js
@@ -136,7 +136,8 @@ module.exports = {
         'prettier/prettier': [
           'error',
           {
-            parser: 'angular'
+            parser: 'angular',
+            endOfLine: 'auto'
           }
         ]
       }

--- a/flink-runtime-web/web-dashboard/.prettierrc
+++ b/flink-runtime-web/web-dashboard/.prettierrc
@@ -9,6 +9,7 @@
   "bracketSpacing": true,
   "proseWrap": "preserve",
   "trailingComma": "none",
+  "endOfLine": "auto",
   "overrides": [
     {
       "files": ".prettierrc",


### PR DESCRIPTION
## What is the purpose of the change

Make the building process of module _**flink-runtime-web**_ doesn't throw error on Windows.
Git will transform all the source code's line seperator to CRLF(for developers working on windows) include the js and ts files in _flink webdashboard_, and that makes eslint throw errors like Delete \`␍\` eslint(prettier/prettier).

But if I set git autocrlf to false, the spotless-check will throw error because of the line seperator of java source file is not CRLF.

## Brief change log

After changing the .eslintrc.js file(add an endOfLine setting), the building process succeed.

```
'prettier/prettier': [
  'error',
  {
    parser: 'angular',
    endOfLine: 'auto'
  }
```


## Verifying this change

This change can be verified as follows:
use `mvn clean package` command to build module _**flink-runtime-web**_