### PR TITLE
[FLINK-24159][docs][Runtime/Checkpointing] document of entropy injection may mislead users

### DIFF
--- a/docs/content.zh/docs/deployment/filesystems/s3.md
+++ b/docs/content.zh/docs/deployment/filesystems/s3.md
@@ -123,7 +123,7 @@ s3.path.style.access: true
 
 内置的 S3 文件系统 (`flink-s3-fs-presto` and `flink-s3-fs-hadoop`) 支持熵注入。熵注入是通过在关键字开头附近添加随机字符，以提高 AWS S3 bucket 可扩展性的技术。
 
-如果熵注入被启用，路径中配置好的字串将会被随机字符所替换。例如路径 `s3://my-bucket/checkpoints/_entropy_/dashboard-job/` 将会被替换成类似于 `s3://my-bucket/checkpoints/gf36ikvg/dashboard-job/` 的路径。
+如果熵注入被启用，路径中配置好的字串将会被随机字符所替换。例如路径 `s3://my-bucket/_entropy_/checkpoints/dashboard-job/` 将会被替换成类似于 `s3://my-bucket/gf36ikvg/checkpoints/dashboard-job/` 的路径。
 **这仅在使用熵注入选项创建文件时启用！**
 否则将完全删除文件路径中的 entropy key。更多细节请参见 [FileSystem.create(Path, WriteOption)](https://nightlies.apache.org/flink/flink-docs-release-1.6/api/java/org/apache/flink/core/fs/FileSystem.html#create-org.apache.flink.core.fs.Path-org.apache.flink.core.fs.FileSystem.WriteOptions-)。
 

--- a/docs/content/docs/deployment/filesystems/s3.md
+++ b/docs/content/docs/deployment/filesystems/s3.md
@@ -132,7 +132,7 @@ The bundled S3 file systems (`flink-s3-fs-presto` and `flink-s3-fs-hadoop`) supp
 a technique to improve the scalability of AWS S3 buckets through adding some random characters near the beginning of the key.
 
 If entropy injection is activated, a configured substring in the path is replaced with random characters. For example, path
-`s3://my-bucket/checkpoints/_entropy_/dashboard-job/` would be replaced by something like `s3://my-bucket/checkpoints/gf36ikvg/dashboard-job/`.
+`s3://my-bucket/_entropy_/checkpoints/dashboard-job/` would be replaced by something like `s3://my-bucket/gf36ikvg/checkpoints/dashboard-job/`.
 **This only happens when the file creation passes the option to inject entropy!**
 Otherwise, the file path removes the entropy key substring entirely. See [FileSystem.create(Path, WriteOption)](https://nightlies.apache.org/flink/flink-docs-release-1.6/api/java/org/apache/flink/core/fs/FileSystem.html#create-org.apache.flink.core.fs.Path-org.apache.flink.core.fs.FileSystem.WriteOptions-)
 for details.


### PR DESCRIPTION
## What is the purpose of the change

Document fix described in [FLINK-24159](https://issues.apache.org/jira/browse/FLINK-24159).


## Brief change log

alter the checkpoint directory in document of [entropy-injection-for-s3-file-systems](https://ci.apache.org/projects/flink/flink-docs-master/docs/deployment/filesystems/s3/#entropy-injection-for-s3-file-systems)  to "s3://my-bucket/_entropy_/checkpoints/dashboard-job/" (make entropy key at start of keys).


## Verifying this change

Not needed.

## Does this pull request potentially affect one of the following parts:

  - Dependencies (does it add or upgrade a dependency): no
  - The public API, i.e., is any changed class annotated with `@Public(Evolving)`: no
  - The serializers: no
  - The runtime per-record code paths (performance sensitive): no
  - Anything that affects deployment or recovery: JobManager (and its components), Checkpointing, Kubernetes/Yarn, ZooKeeper: no
  - The S3 file system connector: no

## Documentation

  - Does this pull request introduce a new feature? no
