### PR TITLE
[BP-1.14][FLINK-24315][k8s] Throw exception in failing watching pods

### DIFF
--- a/flink-kubernetes/src/main/java/org/apache/flink/kubernetes/KubernetesResourceManagerDriver.java
+++ b/flink-kubernetes/src/main/java/org/apache/flink/kubernetes/KubernetesResourceManagerDriver.java
@@ -326,7 +326,7 @@ public class KubernetesResourceManagerDriver
                         });
     }
 
-    private Optional<KubernetesWatch> watchTaskManagerPods() {
+    private Optional<KubernetesWatch> watchTaskManagerPods() throws Exception {
         return Optional.of(
                 flinkKubeClient.watchPodsAndDoCallback(
                         KubernetesUtils.getTaskManagerLabels(clusterId),
@@ -368,7 +368,11 @@ public class KubernetesResourceManagerDriver
                                     if (running) {
                                         podsWatchOpt.ifPresent(KubernetesWatch::close);
                                         log.info("Creating a new watch on TaskManager pods.");
-                                        podsWatchOpt = watchTaskManagerPods();
+                                        try {
+                                            podsWatchOpt = watchTaskManagerPods();
+                                        } catch (Exception e) {
+                                            getResourceEventHandler().onError(e);
+                                        }
                                     }
                                 });
             } else {

--- a/flink-kubernetes/src/main/java/org/apache/flink/kubernetes/kubeclient/Fabric8FlinkKubeClient.java
+++ b/flink-kubernetes/src/main/java/org/apache/flink/kubernetes/kubeclient/Fabric8FlinkKubeClient.java
@@ -229,12 +229,26 @@ public class Fabric8FlinkKubeClient implements FlinkKubeClient {
 
     @Override
     public KubernetesWatch watchPodsAndDoCallback(
-            Map<String, String> labels, WatchCallbackHandler<KubernetesPod> podCallbackHandler) {
-        return new KubernetesWatch(
-                this.internalClient
-                        .pods()
-                        .withLabels(labels)
-                        .watch(new KubernetesPodsWatcher(podCallbackHandler)));
+            Map<String, String> labels, WatchCallbackHandler<KubernetesPod> podCallbackHandler)
+            throws Exception {
+        return FutureUtils.retry(
+                        () ->
+                                CompletableFuture.supplyAsync(
+                                        () ->
+                                                new KubernetesWatch(
+                                                        this.internalClient
+                                                                .pods()
+                                                                .withLabels(labels)
+                                                                .watch(
+                                                                        new KubernetesPodsWatcher(
+                                                                                podCallbackHandler))),
+                                        kubeClientExecutorService),
+                        maxRetryAttempts,
+                        t ->
+                                ExceptionUtils.findThrowable(t, KubernetesClientException.class)
+                                        .isPresent(),
+                        kubeClientExecutorService)
+                .get();
     }
 
     @Override

--- a/flink-kubernetes/src/main/java/org/apache/flink/kubernetes/kubeclient/FlinkKubeClient.java
+++ b/flink-kubernetes/src/main/java/org/apache/flink/kubernetes/kubeclient/FlinkKubeClient.java
@@ -106,7 +106,8 @@ public interface FlinkKubeClient extends AutoCloseable {
      * @return Return a watch for pods. It needs to be closed after use.
      */
     KubernetesWatch watchPodsAndDoCallback(
-            Map<String, String> labels, WatchCallbackHandler<KubernetesPod> podCallbackHandler);
+            Map<String, String> labels, WatchCallbackHandler<KubernetesPod> podCallbackHandler)
+            throws Exception;
 
     /**
      * Create a leader elector service based on Kubernetes api.

--- a/flink-kubernetes/src/test/java/org/apache/flink/kubernetes/KubernetesResourceManagerDriverTest.java
+++ b/flink-kubernetes/src/test/java/org/apache/flink/kubernetes/KubernetesResourceManagerDriverTest.java
@@ -31,6 +31,7 @@ import org.apache.flink.kubernetes.kubeclient.resources.TestingKubernetesPod;
 import org.apache.flink.kubernetes.utils.Constants;
 import org.apache.flink.runtime.clusterframework.TaskExecutorProcessSpec;
 import org.apache.flink.runtime.clusterframework.types.ResourceID;
+import org.apache.flink.runtime.operators.testutils.ExpectedTestException;
 import org.apache.flink.runtime.resourcemanager.active.ResourceManagerDriver;
 import org.apache.flink.runtime.resourcemanager.active.ResourceManagerDriverTestBase;
 import org.apache.flink.runtime.testutils.CommonTestUtils;
@@ -223,6 +224,48 @@ public class KubernetesResourceManagerDriverTest
         };
     }
 
+    @Test(expected = ExpectedTestException.class)
+    public void testThrowExceptionWhenWatchPodsFailInInitializing() throws Exception {
+        new Context() {
+            {
+                flinkKubeClientBuilder.setWatchPodsAndDoCallbackFunction(
+                        (ignore1, ignore2) -> {
+                            throw new ExpectedTestException();
+                        });
+                runTest(() -> {});
+            }
+        };
+    }
+
+    @Test
+    public void testThrowExceptionWhenWatchPodsFailInHandlingError() throws Exception {
+        new Context() {
+            {
+                final CompletableFuture<Throwable> onErrorFuture = new CompletableFuture<>();
+                resourceEventHandlerBuilder.setOnErrorConsumer(onErrorFuture::complete);
+                final CompletableFuture<Void> initWatchFuture = new CompletableFuture<>();
+                final ExpectedTestException testingError = new ExpectedTestException();
+                flinkKubeClientBuilder.setWatchPodsAndDoCallbackFunction(
+                        (ignore, handler) -> {
+                            if (initWatchFuture.isDone()) {
+                                throw testingError;
+                            } else {
+                                initWatchFuture.complete(null);
+                                getSetWatchPodsAndDoCallbackFuture().complete(handler);
+                                return new TestingFlinkKubeClient.MockKubernetesWatch();
+                            }
+                        });
+                runTest(
+                        () -> {
+                            getPodCallbackHandler().handleError(testingError);
+                            assertThat(
+                                    onErrorFuture.get(TIMEOUT_SEC, TimeUnit.SECONDS),
+                                    is(testingError));
+                        });
+            }
+        };
+    }
+
     @Override
     protected ResourceManagerDriverTestBase<KubernetesWorkerNode>.Context createContext() {
         return new Context();
@@ -291,6 +334,11 @@ public class KubernetesResourceManagerDriverTest
 
         List<TestingFlinkKubeClient.MockKubernetesWatch> getPodsWatches() {
             return podsWatches;
+        }
+
+        CompletableFuture<WatchCallbackHandler<KubernetesPod>>
+                getSetWatchPodsAndDoCallbackFuture() {
+            return setWatchPodsAndDoCallbackFuture;
         }
 
         @Override


### PR DESCRIPTION
<!--
*Thank you very much for contributing to Apache Flink - we are happy that you want to help us improve Flink. To help the community review your contribution in the best possible way, please go through the checklist below, which will get the contribution into a shape in which it can be best reviewed.*

*Please understand that we do not do this to make contributions to Flink a hassle. In order to uphold a high standard of quality for code contributions, while at the same time managing a large number of contributions, we need contributors to prepare the contributions well, and give reviewers enough contextual information for the review. Please also understand that contributions that do not follow this guide will take longer to review and thus typically be picked up with lower priority by the community.*

## Contribution Checklist

  - Make sure that the pull request corresponds to a [JIRA issue](https://issues.apache.org/jira/projects/FLINK/issues). Exceptions are made for typos in JavaDoc or documentation files, which need no JIRA issue.
  
  - Name the pull request in the form "[FLINK-XXXX] [component] Title of the pull request", where *FLINK-XXXX* should be replaced by the actual issue number. Skip *component* if you are unsure about which is the best component.
  Typo fixes that have no associated JIRA issue should be named following this pattern: `[hotfix] [docs] Fix typo in event time introduction` or `[hotfix] [javadocs] Expand JavaDoc for PuncuatedWatermarkGenerator`.

  - Fill out the template below to describe the changes contributed by the pull request. That will give reviewers the context they need to do the review.
  
  - Make sure that the change passes the automated tests, i.e., `mvn clean verify` passes. You can set up Azure Pipelines CI to do that following [this guide](https://cwiki.apache.org/confluence/display/FLINK/Azure+Pipelines#AzurePipelines-Tutorial:SettingupAzurePipelinesforaforkoftheFlinkrepository).

  - Each pull request should address only one issue, not mix up code from multiple issues.
  
  - Each commit in the pull request has a meaningful commit message (including the JIRA id)

  - Once all items of the checklist are addressed, remove the above text and this checklist, leaving only the filled out template below.


**(The sections below can be removed for hotfixes of typos)**
-->

## What is the purpose of the change

*(For example: This pull request makes task deployment go through the blob server, rather than through RPC. That way we avoid re-transferring them on each deployment (during recovery).)*


## Brief change log

*(for example:)*
  - *The TaskInfo is stored in the blob store on job creation time as a persistent artifact*
  - *Deployments RPC transmits only the blob storage reference*
  - *TaskManagers retrieve the TaskInfo from the blob cache*


## Verifying this change

*(Please pick either of the following options)*

This change is a trivial rework / code cleanup without any test coverage.

*(or)*

This change is already covered by existing tests, such as *(please describe tests)*.

*(or)*

This change added tests and can be verified as follows:

*(example:)*
  - *Added integration tests for end-to-end deployment with large payloads (100MB)*
  - *Extended integration test for recovery after master (JobManager) failure*
  - *Added test that validates that TaskInfo is transferred only once across recoveries*
  - *Manually verified the change by running a 4 node cluser with 2 JobManagers and 4 TaskManagers, a stateful streaming program, and killing one JobManager and two TaskManagers during the execution, verifying that recovery happens correctly.*

## Does this pull request potentially affect one of the following parts:

  - Dependencies (does it add or upgrade a dependency): (yes / no)
  - The public API, i.e., is any changed class annotated with `@Public(Evolving)`: (yes / no)
  - The serializers: (yes / no / don't know)
  - The runtime per-record code paths (performance sensitive): (yes / no / don't know)
  - Anything that affects deployment or recovery: JobManager (and its components), Checkpointing, Kubernetes/Yarn, ZooKeeper: (yes / no / don't know)
  - The S3 file system connector: (yes / no / don't know)

## Documentation

  - Does this pull request introduce a new feature? (yes / no)
  - If yes, how is the feature documented? (not applicable / docs / JavaDocs / not documented)
