### PR TITLE
[FLINK-24394][test] Refactor BuiltInFunctions IT Tests

### DIFF
--- a/flink-table/flink-table-planner/src/test/java/org/apache/flink/table/planner/functions/BuiltInFunctionTestBase.java
+++ b/flink-table/flink-table-planner/src/test/java/org/apache/flink/table/planner/functions/BuiltInFunctionTestBase.java
@@ -47,14 +47,16 @@ import javax.annotation.Nullable;
 import java.util.ArrayList;
 import java.util.Iterator;
 import java.util.List;
+import java.util.stream.Collectors;
 import java.util.stream.IntStream;
 
+import static java.util.Collections.singletonList;
 import static org.apache.flink.core.testutils.FlinkMatchers.containsCause;
 import static org.apache.flink.core.testutils.FlinkMatchers.containsMessage;
 import static org.hamcrest.CoreMatchers.containsString;
+import static org.hamcrest.MatcherAssert.assertThat;
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertFalse;
-import static org.junit.Assert.assertThat;
 import static org.junit.Assert.assertTrue;
 import static org.junit.Assert.fail;
 
@@ -101,18 +103,13 @@ public abstract class BuiltInFunctionTestBase {
 
         for (TestItem testItem : testSpec.testItems) {
             try {
-                if (testItem instanceof TableApiResultTestItem) {
-                    testTableApiResult(
-                            dataTypeFactory, inputTable, ((TableApiResultTestItem) testItem));
-                } else if (testItem instanceof TableApiErrorTestItem) {
-                    testTableApiError(inputTable, ((TableApiErrorTestItem) testItem));
-                } else if (testItem instanceof SqlResultTestItem) {
-                    testSqlResult(dataTypeFactory, env, inputTable, ((SqlResultTestItem) testItem));
-                } else if (testItem instanceof SqlErrorTestItem) {
-                    testSqlError(env, inputTable, ((SqlErrorTestItem) testItem));
+                if (testItem instanceof ResultTestItem<?>) {
+                    testResult(dataTypeFactory, env, inputTable, (ResultTestItem<?>) testItem);
+                } else if (testItem instanceof ErrorTestItem<?>) {
+                    testError(env, inputTable, (ErrorTestItem<?>) testItem);
                 }
             } catch (Throwable t) {
-                throw new AssertionError("Failing test item: " + testItem.toString(), t);
+                throw new AssertionError("Failing test item: " + testItem, t);
             }
         }
     }
@@ -120,73 +117,25 @@ public abstract class BuiltInFunctionTestBase {
     // --------------------------------------------------------------------------------------------
     // Test utilities
     // --------------------------------------------------------------------------------------------
-
-    private static void testTableApiResult(
-            DataTypeFactory dataTypeFactory, Table inputTable, TableApiResultTestItem testItem) {
-        testResult(dataTypeFactory, inputTable.select(testItem.expression), testItem);
-    }
-
-    private static void testTableApiError(Table inputTable, TableApiErrorTestItem testItem) {
-        try {
-            final TableResult tableResult = inputTable.select(testItem.expression).execute();
-            if (testItem.expectedDuringValidation) {
-                fail("Error expected: " + testItem.errorMessage);
-            }
-
-            try {
-                tableResult.await();
-                fail("Error expected: " + testItem.errorMessage);
-            } catch (AssertionError e) {
-                throw e;
-            } catch (Throwable t) {
-                assertThat(t, containsMessage(testItem.errorMessage));
-            }
-        } catch (AssertionError e) {
-            throw e;
-        } catch (Throwable t) {
-            assertThat(t, containsCause(new ValidationException(testItem.errorMessage)));
-        }
-    }
-
-    private static void testSqlResult(
+    private static void testResult(
             DataTypeFactory dataTypeFactory,
             TableEnvironment env,
             Table inputTable,
-            SqlResultTestItem testItem) {
-        testResult(
-                dataTypeFactory,
-                env.sqlQuery("SELECT " + testItem.expression + " FROM " + inputTable),
-                testItem);
-    }
+            ResultTestItem<?> testItem) {
 
-    private static void testSqlError(
-            TableEnvironment env, Table inputTable, SqlErrorTestItem testItem) {
-        try {
-            final TableResult tableResult =
-                    env.sqlQuery("SELECT " + testItem.expression + " FROM " + inputTable).execute();
-            if (testItem.expectedDuringValidation) {
-                fail("Error expected: " + testItem.errorMessage);
-            }
-
-            try {
-                tableResult.await();
-                fail("Error expected: " + testItem.errorMessage);
-            } catch (AssertionError e) {
-                throw e;
-            } catch (Throwable t) {
-                assertThat(t, containsMessage(testItem.errorMessage));
-            }
-        } catch (AssertionError e) {
-            throw e;
-        } catch (Throwable t) {
-            assertTrue(t instanceof ValidationException);
-            assertThat(t.getMessage(), containsString(testItem.errorMessage));
+        final Table resultTable;
+        if (testItem instanceof TableApiResultTestItem) {
+            resultTable =
+                    inputTable.select(
+                            ((TableApiResultTestItem) testItem)
+                                    .expression()
+                                    .toArray(new Expression[] {}));
+        } else {
+            resultTable = env.sqlQuery("SELECT " + testItem.expression() + " FROM " + inputTable);
         }
-    }
 
-    private static void testResult(
-            DataTypeFactory dataTypeFactory, Table resultTable, ResultTestItem testItem) {
-        final DataType expectedDataType = dataTypeFactory.createDataType(testItem.dataType);
+        final List<DataType> expectedDataTypes =
+                createDataTypes(dataTypeFactory, testItem.dataTypes);
         final TableResult result = resultTable.execute();
         final Iterator<Row> iterator = result.collect();
 
@@ -196,14 +145,55 @@ public abstract class BuiltInFunctionTestBase {
 
         assertFalse("No more rows expected.", iterator.hasNext());
 
-        assertEquals("Only 1 column expected.", 1, row.getArity());
+        for (int i = 0; i < row.getArity(); i++) {
+            assertEquals(
+                    "Logical type for spec [" + i + "] of test [" + testItem + "] doesn't match.",
+                    expectedDataTypes.get(i).getLogicalType(),
+                    result.getResolvedSchema().getColumnDataTypes().get(i).getLogicalType());
 
-        assertEquals(
-                "Logical type doesn't match.",
-                expectedDataType.getLogicalType(),
-                result.getResolvedSchema().getColumnDataTypes().get(0).getLogicalType());
+            assertEquals(
+                    "Result for spec [" + i + "] of test [" + testItem + "] doesn't match.",
+                    testItem.results.get(i),
+                    row.getField(i));
+        }
+    }
 
-        assertEquals("Result doesn't match.", testItem.result, row.getField(0));
+    private static void testError(
+            TableEnvironment env, Table inputTable, ErrorTestItem<?> testItem) {
+        try {
+            final TableResult tableResult;
+            if (testItem instanceof TableApiErrorTestItem) {
+                tableResult =
+                        inputTable
+                                .select(((TableApiErrorTestItem) testItem).expression())
+                                .execute();
+            } else {
+                tableResult =
+                        env.sqlQuery("SELECT " + testItem.expression() + " FROM " + inputTable)
+                                .execute();
+            }
+            if (testItem.expectedDuringValidation) {
+                fail("Error expected: " + testItem.errorMessage);
+            }
+
+            try {
+                tableResult.await();
+                fail("Error expected: " + testItem.errorMessage);
+            } catch (AssertionError e) {
+                throw e;
+            } catch (Throwable t) {
+                assertThat("Wrong error message", t, containsMessage(testItem.errorMessage));
+            }
+        } catch (AssertionError e) {
+            throw e;
+        } catch (Throwable t) {
+            if (testItem instanceof TableApiErrorTestItem) {
+                assertThat(t, containsCause(new ValidationException(testItem.errorMessage)));
+            } else {
+                assertTrue(t instanceof ValidationException);
+                assertThat(t.getMessage(), containsString(testItem.errorMessage));
+            }
+        }
     }
 
     /**
@@ -261,6 +251,14 @@ public abstract class BuiltInFunctionTestBase {
 
         TestSpec testTableApiResult(
                 Expression expression, Object result, AbstractDataType<?> dataType) {
+            return testTableApiResult(
+                    singletonList(expression), singletonList(result), singletonList(dataType));
+        }
+
+        TestSpec testTableApiResult(
+                List<Expression> expression,
+                List<Object> result,
+                List<AbstractDataType<?>> dataType) {
             testItems.add(new TableApiResultTestItem(expression, result, dataType));
             return this;
         }
@@ -276,6 +274,11 @@ public abstract class BuiltInFunctionTestBase {
         }
 
         TestSpec testSqlResult(String expression, Object result, AbstractDataType<?> dataType) {
+            return testSqlResult(expression, singletonList(result), singletonList(dataType));
+        }
+
+        TestSpec testSqlResult(
+                String expression, List<Object> result, List<AbstractDataType<?>> dataType) {
             testItems.add(new SqlResultTestItem(expression, result, dataType));
             return this;
         }
@@ -298,14 +301,51 @@ public abstract class BuiltInFunctionTestBase {
             return testResult(expression, sqlExpression, result, dataType, dataType);
         }
 
+        TestSpec testResult(ResultSpec... resultSpecs) {
+            final int cols = resultSpecs.length;
+            final List<Expression> expressions = new ArrayList<>(cols);
+            final List<String> sqlExpressions = new ArrayList<>(cols);
+            final List<Object> results = new ArrayList<>(cols);
+            final List<AbstractDataType<?>> tableApiDataTypes = new ArrayList<>(cols);
+            final List<AbstractDataType<?>> sqlDataTypes = new ArrayList<>(cols);
+
+            for (ResultSpec resultSpec : resultSpecs) {
+                expressions.add(resultSpec.tableApiExpression);
+                sqlExpressions.add(resultSpec.sqlExpression);
+                results.add(resultSpec.result);
+                tableApiDataTypes.add(resultSpec.tableApiDataType);
+                sqlDataTypes.add(resultSpec.sqlDataType);
+            }
+            return testResult(
+                    expressions, sqlExpressions, results, tableApiDataTypes, sqlDataTypes);
+        }
+
         TestSpec testResult(
                 Expression expression,
                 String sqlExpression,
                 Object result,
                 AbstractDataType<?> tableApiDataType,
                 AbstractDataType<?> sqlDataType) {
+            return testResult(
+                    singletonList(expression),
+                    singletonList(sqlExpression),
+                    singletonList(result),
+                    singletonList(tableApiDataType),
+                    singletonList(sqlDataType));
+        }
+
+        TestSpec testResult(
+                List<Expression> expression,
+                List<String> sqlExpression,
+                List<Object> result,
+                List<AbstractDataType<?>> tableApiDataType,
+                List<AbstractDataType<?>> sqlDataType) {
             testItems.add(new TableApiResultTestItem(expression, result, tableApiDataType));
-            testItems.add(new SqlResultTestItem(sqlExpression, result, sqlDataType));
+            testItems.add(
+                    new SqlResultTestItem(
+                            sqlExpression.stream().collect(Collectors.joining(",")),
+                            result,
+                            sqlDataType));
             return this;
         }
 
@@ -320,47 +360,67 @@ public abstract class BuiltInFunctionTestBase {
         // marker interface
     }
 
-    private static class ResultTestItem implements TestItem {
-        final Object result;
-        final AbstractDataType<?> dataType;
+    private abstract static class ResultTestItem<T> implements TestItem {
+        final T expression;
+        final List<Object> results;
+        final List<AbstractDataType<?>> dataTypes;
 
-        ResultTestItem(Object result, AbstractDataType<?> dataType) {
-            this.result = result;
-            this.dataType = dataType;
+        ResultTestItem(T expression, List<Object> results, List<AbstractDataType<?>> dataTypes) {
+            this.expression = expression;
+            this.results = results;
+            this.dataTypes = dataTypes;
         }
+
+        abstract T expression();
     }
 
-    private static class ErrorTestItem implements TestItem {
+    private abstract static class ErrorTestItem<T> implements TestItem {
+        final T expression;
         final String errorMessage;
-        boolean expectedDuringValidation;
+        final boolean expectedDuringValidation;
 
-        ErrorTestItem(String errorMessage, boolean expectedDuringValidation) {
+        ErrorTestItem(T expression, String errorMessage, boolean expectedDuringValidation) {
+            this.expression = expression;
             this.errorMessage = errorMessage;
             this.expectedDuringValidation = expectedDuringValidation;
         }
+
+        abstract T expression();
     }
 
-    private static class TableApiResultTestItem extends ResultTestItem {
-        final Expression expression;
+    private static class TableApiResultTestItem extends ResultTestItem<List<Expression>> {
 
-        TableApiResultTestItem(Expression expression, Object result, AbstractDataType<?> dataType) {
-            super(result, dataType);
-            this.expression = expression;
+        TableApiResultTestItem(
+                List<Expression> expressions,
+                List<Object> results,
+                List<AbstractDataType<?>> dataTypes) {
+            super(expressions, results, dataTypes);
+        }
+
+        @Override
+        List<Expression> expression() {
+            return expression;
         }
 
         @Override
         public String toString() {
-            return "[API] " + expression.asSummaryString();
+            return "[API] "
+                    + expression.stream()
+                            .map(Expression::asSummaryString)
+                            .collect(Collectors.joining());
         }
     }
 
-    private static class TableApiErrorTestItem extends ErrorTestItem {
-        final Expression expression;
+    private static class TableApiErrorTestItem extends ErrorTestItem<Expression> {
 
         TableApiErrorTestItem(
                 Expression expression, String errorMessage, boolean expectedDuringValidation) {
-            super(errorMessage, expectedDuringValidation);
-            this.expression = expression;
+            super(expression, errorMessage, expectedDuringValidation);
+        }
+
+        @Override
+        Expression expression() {
+            return expression;
         }
 
         @Override
@@ -369,12 +429,16 @@ public abstract class BuiltInFunctionTestBase {
         }
     }
 
-    private static class SqlResultTestItem extends ResultTestItem {
-        final String expression;
+    private static class SqlResultTestItem extends ResultTestItem<String> {
 
-        SqlResultTestItem(String expression, Object result, AbstractDataType<?> dataType) {
-            super(result, dataType);
-            this.expression = expression;
+        SqlResultTestItem(
+                String sqlExpression, List<Object> result, List<AbstractDataType<?>> dataType) {
+            super(sqlExpression, result, dataType);
+        }
+
+        @Override
+        String expression() {
+            return expression;
         }
 
         @Override
@@ -383,18 +447,67 @@ public abstract class BuiltInFunctionTestBase {
         }
     }
 
-    private static class SqlErrorTestItem extends ErrorTestItem {
-        final String expression;
+    private static class SqlErrorTestItem extends ErrorTestItem<String> {
 
         private SqlErrorTestItem(
                 String expression, String errorMessage, boolean expectedDuringValidation) {
-            super(errorMessage, expectedDuringValidation);
-            this.expression = expression;
+            super(expression, errorMessage, expectedDuringValidation);
+        }
+
+        @Override
+        String expression() {
+            return expression;
         }
 
         @Override
         public String toString() {
             return "[SQL] " + expression;
         }
+    }
+
+    private static List<DataType> createDataTypes(
+            DataTypeFactory dataTypeFactory, List<AbstractDataType<?>> dataTypes) {
+        return dataTypes.stream().map(dataTypeFactory::createDataType).collect(Collectors.toList());
+    }
+
+    /** Helper POJO to store test parameters. */
+    public static class ResultSpec {
+
+        final Expression tableApiExpression;
+        final String sqlExpression;
+        final Object result;
+        final AbstractDataType<?> tableApiDataType;
+        final AbstractDataType<?> sqlDataType;
+
+        private ResultSpec(
+                Expression tableApiExpression,
+                String sqlExpression,
+                Object result,
+                AbstractDataType<?> tableApiDataType,
+                AbstractDataType<?> sqlQueryDataType) {
+            this.tableApiExpression = tableApiExpression;
+            this.sqlExpression = sqlExpression;
+            this.result = result;
+            this.tableApiDataType = tableApiDataType;
+            this.sqlDataType = sqlQueryDataType;
+        }
+    }
+
+    public static ResultSpec resultSpec(
+            Expression tableApiExpression,
+            String sqlExpression,
+            Object result,
+            AbstractDataType<?> dataType) {
+        return resultSpec(tableApiExpression, sqlExpression, result, dataType, dataType);
+    }
+
+    public static ResultSpec resultSpec(
+            Expression tableApiExpression,
+            String sqlExpression,
+            Object result,
+            AbstractDataType<?> tableApiDataType,
+            AbstractDataType<?> sqlQueryDataType) {
+        return new ResultSpec(
+                tableApiExpression, sqlExpression, result, tableApiDataType, sqlQueryDataType);
     }
 }

--- a/flink-table/flink-table-planner/src/test/java/org/apache/flink/table/planner/functions/CoalesceFunctionITCase.java
+++ b/flink-table/flink-table-planner/src/test/java/org/apache/flink/table/planner/functions/CoalesceFunctionITCase.java
@@ -40,23 +40,28 @@ public class CoalesceFunctionITCase extends BuiltInFunctionTestBase {
                         .onFieldsWithData(null, null, 1)
                         .andDataTypes(BIGINT().nullable(), INT().nullable(), INT().notNull())
                         .testResult(
-                                coalesce($("f0"), $("f1")),
-                                "COALESCE(f0, f1)",
-                                null,
-                                BIGINT().nullable())
-                        .testResult(
-                                coalesce($("f0"), $("f2")),
-                                "COALESCE(f0, f2)",
-                                1L,
-                                BIGINT().notNull())
-                        .testResult(
-                                coalesce($("f1"), $("f2")), "COALESCE(f1, f2)", 1, INT().notNull())
-                        .testResult(
-                                coalesce($("f0"), 1),
-                                "COALESCE(f0, 1)",
-                                1L,
-                                // In this case, the return type is not null because we have a
-                                // constant in the function invocation
-                                BIGINT().notNull()));
+                                resultSpec(
+                                        coalesce($("f0"), $("f1")),
+                                        "COALESCE(f0, f1)",
+                                        null,
+                                        BIGINT().nullable()),
+                                resultSpec(
+                                        coalesce($("f0"), $("f2")),
+                                        "COALESCE(f0, f2)",
+                                        1L,
+                                        BIGINT().notNull()),
+                                resultSpec(
+                                        coalesce($("f1"), $("f2")),
+                                        "COALESCE(f1, f2)",
+                                        1,
+                                        INT().notNull()),
+                                resultSpec(
+                                        coalesce($("f0"), 1),
+                                        "COALESCE(f0, 1)",
+                                        1L,
+                                        // In this case, the return type is not null because we have
+                                        // a
+                                        // constant in the function invocation
+                                        BIGINT().notNull())));
     }
 }

--- a/flink-table/flink-table-planner/src/test/java/org/apache/flink/table/planner/functions/ConstructedAccessFunctionsITCase.java
+++ b/flink-table/flink-table-planner/src/test/java/org/apache/flink/table/planner/functions/ConstructedAccessFunctionsITCase.java
@@ -90,8 +90,16 @@ public class ConstructedAccessFunctionsITCase {
                                     ROW(FIELD("nested", BIGINT().notNull())).nullable(),
                                     ROW(FIELD("nested", BIGINT().notNull())).notNull())
                             .testResult(
-                                    $("f0").get("nested"), "f0.nested", null, BIGINT().nullable())
-                            .testResult($("f1").get("nested"), "f1.nested", 1L, BIGINT().notNull()),
+                                    resultSpec(
+                                            $("f0").get("nested"),
+                                            "f0.nested",
+                                            null,
+                                            BIGINT().nullable()),
+                                    resultSpec(
+                                            $("f1").get("nested"),
+                                            "f1.nested",
+                                            1L,
+                                            BIGINT().notNull())),
 
                     // In Calcite it maps to FlinkSqlOperatorTable.ITEM
                     TestSpec.forFunction(BuiltInFunctionDefinitions.AT)
@@ -112,15 +120,32 @@ public class ConstructedAccessFunctionsITCase {
                             // accessing elements of MAP or ARRAY is a runtime operations,
                             // we do not know about the size or contents during the inference
                             // therefore the results are always nullable
-                            .testSqlResult("f0[1]", null, BIGINT().nullable())
-                            .testSqlResult("f1[1]", 1L, BIGINT().nullable())
-                            .testSqlResult("f2['nested']", null, BIGINT().nullable())
-                            .testSqlResult("f3['nested']", 1L, BIGINT().nullable())
+                            .testResult(
+                                    resultSpec($("f0").at(1), "f0[1]", null, BIGINT().nullable()),
+                                    resultSpec($("f1").at(1), "f1[1]", 1L, BIGINT().nullable()),
+                                    resultSpec(
+                                            $("f2").at("nested"),
+                                            "f2['nested']",
+                                            null,
+                                            BIGINT().nullable()),
+                                    resultSpec(
+                                            $("f3").at("nested"),
+                                            "f3['nested']",
+                                            1L,
+                                            BIGINT().nullable()),
 
-                            // we know all the fields of a type up front, therefore we can
-                            // derive more accurate types during the inference
-                            .testSqlResult("f4['nested']", null, BIGINT().nullable())
-                            .testSqlResult("f5['nested']", 1L, BIGINT().notNull()));
+                                    // we know all the fields of a type up front, therefore we can
+                                    // derive more accurate types during the inference
+                                    resultSpec(
+                                            $("f4").get("nested"),
+                                            "f4['nested']",
+                                            null,
+                                            BIGINT().nullable()),
+                                    resultSpec(
+                                            $("f5").get("nested"),
+                                            "f5['nested']",
+                                            1L,
+                                            BIGINT().notNull())));
         }
     }
 

--- a/flink-table/flink-table-planner/src/test/java/org/apache/flink/table/planner/functions/GreatestLeastFunctionsITCase.java
+++ b/flink-table/flink-table-planner/src/test/java/org/apache/flink/table/planner/functions/GreatestLeastFunctionsITCase.java
@@ -60,24 +60,28 @@ public class GreatestLeastFunctionsITCase extends BuiltInFunctionTestBase {
                                 "GREATEST(f1, f4)",
                                 "SQL validation failed. Invalid function call:\n"
                                         + "GREATEST(INT NOT NULL, STRING NOT NULL)")
-                        .testSqlResult(
-                                "CAST(GREATEST(f1, f3, f2) AS DECIMAL(3, 2))",
-                                BigDecimal.valueOf(3.14),
-                                DataTypes.DECIMAL(3, 2).notNull())
                         .testResult(
-                                call("GREATEST", $("f0"), $("f1"), $("f2")),
-                                "GREATEST(f0, f1, f2)",
-                                null,
-                                DataTypes.INT())
-                        .testResult(
-                                call("GREATEST", $("f4"), $("f5")),
-                                "GREATEST(f4, f5)",
-                                "world",
-                                DataTypes.STRING().notNull())
-                        .testSqlResult(
-                                "GREATEST(f6, f7)",
-                                LocalDateTime.parse("1970-01-01T00:00:03.001"),
-                                DataTypes.TIMESTAMP(3).notNull())
+                                resultSpec(
+                                        call("GREATEST", $("f1"), $("f3"), $("f2"))
+                                                .cast(DataTypes.DECIMAL(3, 2)),
+                                        "CAST(GREATEST(f1, f3, f2) AS DECIMAL(3, 2))",
+                                        BigDecimal.valueOf(3.14),
+                                        DataTypes.DECIMAL(3, 2).notNull()),
+                                resultSpec(
+                                        call("GREATEST", $("f0"), $("f1"), $("f2")),
+                                        "GREATEST(f0, f1, f2)",
+                                        null,
+                                        DataTypes.INT()),
+                                resultSpec(
+                                        call("GREATEST", $("f4"), $("f5")),
+                                        "GREATEST(f4, f5)",
+                                        "world",
+                                        DataTypes.STRING().notNull()),
+                                resultSpec(
+                                        call("GREATEST", $("f6"), $("f7")),
+                                        "GREATEST(f6, f7)",
+                                        LocalDateTime.parse("1970-01-01T00:00:03.001"),
+                                        DataTypes.TIMESTAMP(3).notNull()))
                         .testSqlValidationError(
                                 "GREATEST(f5, f6)",
                                 "SQL validation failed. Invalid function call:\n"
@@ -95,24 +99,22 @@ public class GreatestLeastFunctionsITCase extends BuiltInFunctionTestBase {
                                 "LEAST(f1, f4)",
                                 "SQL validation failed. Invalid function call:\n"
                                         + "LEAST(INT NOT NULL, STRING NOT NULL)")
-                        .testSqlResult(
-                                "CAST(LEAST(f1, f3, f2) AS DECIMAL(3, 2))",
-                                BigDecimal.valueOf(100, 2),
-                                DataTypes.DECIMAL(3, 2).notNull())
-                        .testTableApiResult(
-                                call("LEAST", $("f1"), $("f3"), $("f2"))
-                                        .cast(DataTypes.DECIMAL(3, 2)),
-                                BigDecimal.valueOf(100, 2),
-                                DataTypes.DECIMAL(3, 2).notNull())
                         .testResult(
-                                call("LEAST", $("f0"), $("f1")),
-                                "LEAST(f0, f1)",
-                                null,
-                                DataTypes.INT())
-                        .testResult(
-                                call("LEAST", $("f4"), $("f5")),
-                                "LEAST(f4, f5)",
-                                "hello",
-                                DataTypes.STRING().notNull()));
+                                resultSpec(
+                                        call("LEAST", $("f1"), $("f3"), $("f2"))
+                                                .cast(DataTypes.DECIMAL(3, 2)),
+                                        "CAST(LEAST(f1, f3, f2) AS DECIMAL(3, 2))",
+                                        BigDecimal.valueOf(100, 2),
+                                        DataTypes.DECIMAL(3, 2).notNull()),
+                                resultSpec(
+                                        call("LEAST", $("f0"), $("f1")),
+                                        "LEAST(f0, f1)",
+                                        null,
+                                        DataTypes.INT()),
+                                resultSpec(
+                                        call("LEAST", $("f4"), $("f5")),
+                                        "LEAST(f4, f5)",
+                                        "hello",
+                                        DataTypes.STRING().notNull())));
     }
 }

--- a/flink-table/flink-table-planner/src/test/java/org/apache/flink/table/planner/functions/MathFunctionsITCase.java
+++ b/flink-table/flink-table-planner/src/test/java/org/apache/flink/table/planner/functions/MathFunctionsITCase.java
@@ -38,91 +38,101 @@ public class MathFunctionsITCase extends BuiltInFunctionTestBase {
                 TestSpec.forFunction(BuiltInFunctionDefinitions.PLUS)
                         .onFieldsWithData(new BigDecimal("1514356320000"))
                         .andDataTypes(DataTypes.DECIMAL(19, 0).notNull())
-                        // DECIMAL(19, 0) + INT(10, 0) => DECIMAL(20, 0)
                         .testResult(
-                                $("f0").plus(6),
-                                "f0 + 6",
-                                new BigDecimal("1514356320006"),
-                                DataTypes.DECIMAL(20, 0).notNull())
-                        // DECIMAL(19, 0) + DECIMAL(19, 0) => DECIMAL(20, 0)
-                        .testResult(
-                                $("f0").plus($("f0")),
-                                "f0 + f0",
-                                new BigDecimal("3028712640000"),
-                                DataTypes.DECIMAL(20, 0).notNull()),
+                                // DECIMAL(19, 0) + INT(10, 0) => DECIMAL(20, 0)
+                                resultSpec(
+                                        $("f0").plus(6),
+                                        "f0 + 6",
+                                        new BigDecimal("1514356320006"),
+                                        DataTypes.DECIMAL(20, 0).notNull()),
+                                // DECIMAL(19, 0) + DECIMAL(19, 0) => DECIMAL(20, 0)
+                                resultSpec(
+                                        $("f0").plus($("f0")),
+                                        "f0 + f0",
+                                        new BigDecimal("3028712640000"),
+                                        DataTypes.DECIMAL(20, 0).notNull())),
                 TestSpec.forFunction(BuiltInFunctionDefinitions.MINUS)
                         .onFieldsWithData(new BigDecimal("1514356320000"))
                         .andDataTypes(DataTypes.DECIMAL(19, 0))
-                        // DECIMAL(19, 0) - INT(10, 0) => DECIMAL(20, 0)
                         .testResult(
-                                $("f0").minus(6),
-                                "f0 - 6",
-                                new BigDecimal("1514356319994"),
-                                DataTypes.DECIMAL(20, 0))
-                        // DECIMAL(19, 0) - DECIMAL(19, 0) => DECIMAL(20, 0)
-                        .testResult(
-                                $("f0").minus($("f0")),
-                                "f0 - f0",
-                                new BigDecimal("0"),
-                                DataTypes.DECIMAL(20, 0)),
+                                // DECIMAL(19, 0) - INT(10, 0) => DECIMAL(20, 0)
+                                resultSpec(
+                                        $("f0").minus(6),
+                                        "f0 - 6",
+                                        new BigDecimal("1514356319994"),
+                                        DataTypes.DECIMAL(20, 0)),
+                                // DECIMAL(19, 0) - DECIMAL(19, 0) => DECIMAL(20, 0)
+                                resultSpec(
+                                        $("f0").minus($("f0")),
+                                        "f0 - f0",
+                                        new BigDecimal("0"),
+                                        DataTypes.DECIMAL(20, 0))),
                 TestSpec.forFunction(BuiltInFunctionDefinitions.DIVIDE)
                         .onFieldsWithData(new BigDecimal("1514356320000"))
                         .andDataTypes(DataTypes.DECIMAL(19, 0).notNull())
-                        // DECIMAL(19, 0) / INT(10, 0) => DECIMAL(30, 11)
                         .testResult(
-                                $("f0").dividedBy(6),
-                                "f0 / 6",
-                                new BigDecimal("252392720000.00000000000"),
-                                DataTypes.DECIMAL(30, 11).notNull())
-                        // DECIMAL(19, 0) / DECIMAL(19, 0) => DECIMAL(39, 20) => DECIMAL(38, 19)
-                        .testResult(
-                                $("f0").dividedBy($("f0")),
-                                "f0 / f0",
-                                new BigDecimal("1.0000000000000000000"),
-                                DataTypes.DECIMAL(38, 19).notNull()),
+                                // DECIMAL(19, 0) / INT(10, 0) => DECIMAL(30, 11)
+                                resultSpec(
+                                        $("f0").dividedBy(6),
+                                        "f0 / 6",
+                                        new BigDecimal("252392720000.00000000000"),
+                                        DataTypes.DECIMAL(30, 11).notNull()),
+                                // DECIMAL(19, 0) / DECIMAL(19, 0) => DECIMAL(39, 20) => DECIMAL(38,
+                                // 19)
+                                resultSpec(
+                                        $("f0").dividedBy($("f0")),
+                                        "f0 / f0",
+                                        new BigDecimal("1.0000000000000000000"),
+                                        DataTypes.DECIMAL(38, 19).notNull())),
                 TestSpec.forFunction(BuiltInFunctionDefinitions.TIMES)
                         .onFieldsWithData(new BigDecimal("1514356320000"))
                         .andDataTypes(DataTypes.DECIMAL(19, 0))
-                        // DECIMAL(19, 0) * INT(10, 0) => DECIMAL(29, 0)
                         .testResult(
-                                $("f0").times(6),
-                                "f0 * 6",
-                                new BigDecimal("9086137920000"),
-                                DataTypes.DECIMAL(30, 0))
-                        // DECIMAL(19, 0) * DECIMAL(19, 0) => DECIMAL(38, 0)
-                        .testResult(
-                                $("f0").times($("f0")),
-                                "f0 * f0",
-                                new BigDecimal("2293275063923942400000000"),
-                                DataTypes.DECIMAL(38, 0)),
+                                // DECIMAL(19, 0) * INT(10, 0) => DECIMAL(29, 0)
+                                resultSpec(
+                                        $("f0").times(6),
+                                        "f0 * 6",
+                                        new BigDecimal("9086137920000"),
+                                        DataTypes.DECIMAL(30, 0)),
+                                // DECIMAL(19, 0) * DECIMAL(19, 0) => DECIMAL(38, 0)
+                                resultSpec(
+                                        $("f0").times($("f0")),
+                                        "f0 * f0",
+                                        new BigDecimal("2293275063923942400000000"),
+                                        DataTypes.DECIMAL(38, 0))),
                 TestSpec.forFunction(BuiltInFunctionDefinitions.MOD)
                         .onFieldsWithData(new BigDecimal("1514356320000"), 44L, 3)
                         .andDataTypes(DataTypes.DECIMAL(19, 0), DataTypes.BIGINT(), DataTypes.INT())
-                        // DECIMAL(19, 0) % DECIMAL(19, 0) => DECIMAL(19, 0)
                         .testResult(
-                                $("f0").mod($("f0")),
-                                "MOD(f0, f0)",
-                                new BigDecimal(0),
-                                DataTypes.DECIMAL(19, 0))
-                        // DECIMAL(19, 0) % INT(10, 0) => INT(10, 0)
-                        .testResult($("f0").mod(6), "MOD(f0, 6)", 0, DataTypes.INT())
-                        // BIGINT(19, 0) % INT(10, 0) => INT(10, 0)
-                        .testResult($("f1").mod($("f2")), "MOD(f1, f2)", 2, DataTypes.INT()),
+                                // DECIMAL(19, 0) % DECIMAL(19, 0) => DECIMAL(19, 0)
+                                resultSpec(
+                                        $("f0").mod($("f0")),
+                                        "MOD(f0, f0)",
+                                        new BigDecimal(0),
+                                        DataTypes.DECIMAL(19, 0)),
+
+                                // DECIMAL(19, 0) % INT(10, 0) => INT(10, 0)
+                                resultSpec($("f0").mod(6), "MOD(f0, 6)", 0, DataTypes.INT()),
+                                // BIGINT(19, 0) % INT(10, 0) => INT(10, 0)
+                                resultSpec(
+                                        $("f1").mod($("f2")), "MOD(f1, f2)", 2, DataTypes.INT())),
                 TestSpec.forFunction(BuiltInFunctionDefinitions.ROUND)
                         .onFieldsWithData(new BigDecimal("12345.12345"))
-                        // ROUND(DECIMAL(10, 5) NOT NULL, 2) => DECIMAL(8, 2) NOT NULL
                         .testResult(
-                                $("f0").round(2),
-                                "ROUND(f0, 2)",
-                                new BigDecimal("12345.12"),
-                                DataTypes.DECIMAL(8, 2).notNull()),
+                                // ROUND(DECIMAL(10, 5) NOT NULL, 2) => DECIMAL(8, 2) NOT NULL
+                                resultSpec(
+                                        $("f0").round(2),
+                                        "ROUND(f0, 2)",
+                                        new BigDecimal("12345.12"),
+                                        DataTypes.DECIMAL(8, 2).notNull())),
                 TestSpec.forFunction(BuiltInFunctionDefinitions.TRUNCATE)
                         .onFieldsWithData(new BigDecimal("123.456"))
-                        // TRUNCATE(DECIMAL(6, 3) NOT NULL, 2) => DECIMAL(6, 2) NOT NULL
                         .testResult(
-                                $("f0").truncate(2),
-                                "TRUNCATE(f0, 2)",
-                                new BigDecimal("123.45"),
-                                DataTypes.DECIMAL(6, 2).notNull()));
+                                // TRUNCATE(DECIMAL(6, 3) NOT NULL, 2) => DECIMAL(6, 2) NOT NULL
+                                resultSpec(
+                                        $("f0").truncate(2),
+                                        "TRUNCATE(f0, 2)",
+                                        new BigDecimal("123.45"),
+                                        DataTypes.DECIMAL(6, 2).notNull())));
     }
 }

--- a/flink-table/flink-table-planner/src/test/java/org/apache/flink/table/planner/functions/MiscFunctionsITCase.java
+++ b/flink-table/flink-table-planner/src/test/java/org/apache/flink/table/planner/functions/MiscFunctionsITCase.java
@@ -60,20 +60,21 @@ public class MiscFunctionsITCase extends BuiltInFunctionTestBase {
                         .andDataTypes(DataTypes.INT().nullable(), DataTypes.DECIMAL(5, 2).notNull())
                         .withFunction(TakesNotNull.class)
                         .testResult(
-                                $("f0").ifNull($("f0")),
-                                "IFNULL(f0, f0)",
-                                null,
-                                DataTypes.INT().nullable())
-                        .testResult(
-                                $("f0").ifNull($("f1")),
-                                "IFNULL(f0, f1)",
-                                new BigDecimal("123.45"),
-                                DataTypes.DECIMAL(12, 2).notNull())
-                        .testResult(
-                                $("f1").ifNull($("f0")),
-                                "IFNULL(f1, f0)",
-                                new BigDecimal("123.45"),
-                                DataTypes.DECIMAL(12, 2).notNull())
+                                resultSpec(
+                                        $("f0").ifNull($("f0")),
+                                        "IFNULL(f0, f0)",
+                                        null,
+                                        DataTypes.INT().nullable()),
+                                resultSpec(
+                                        $("f0").ifNull($("f1")),
+                                        "IFNULL(f0, f1)",
+                                        new BigDecimal("123.45"),
+                                        DataTypes.DECIMAL(12, 2).notNull()),
+                                resultSpec(
+                                        $("f1").ifNull($("f0")),
+                                        "IFNULL(f1, f0)",
+                                        new BigDecimal("123.45"),
+                                        DataTypes.DECIMAL(12, 2).notNull()))
                         .testSqlValidationError(
                                 "IFNULL(SUBSTR(''), f0)",
                                 "Invalid number of arguments to function 'SUBSTR'.")

--- a/flink-table/flink-table-planner/src/test/java/org/apache/flink/table/planner/functions/StringFunctionsITCase.java
+++ b/flink-table/flink-table-planner/src/test/java/org/apache/flink/table/planner/functions/StringFunctionsITCase.java
@@ -38,14 +38,15 @@ public class StringFunctionsITCase extends BuiltInFunctionTestBase {
                 TestSpec.forFunction(BuiltInFunctionDefinitions.REGEXP_EXTRACT, "Check return type")
                         .onFieldsWithData("22", "ABC")
                         .testResult(
-                                call("regexpExtract", $("f0"), "[A-Z]+"),
-                                "REGEXP_EXTRACT(f0,'[A-Z]+')",
-                                null,
-                                DataTypes.STRING().nullable())
-                        .testResult(
-                                call("regexpExtract", $("f1"), "[A-Z]+"),
-                                "REGEXP_EXTRACT(f1, '[A-Z]+')",
-                                "ABC",
-                                DataTypes.STRING().nullable()));
+                                resultSpec(
+                                        call("regexpExtract", $("f0"), "[A-Z]+"),
+                                        "REGEXP_EXTRACT(f0,'[A-Z]+')",
+                                        null,
+                                        DataTypes.STRING().nullable()),
+                                resultSpec(
+                                        call("regexpExtract", $("f1"), "[A-Z]+"),
+                                        "REGEXP_EXTRACT(f1, '[A-Z]+')",
+                                        "ABC",
+                                        DataTypes.STRING().nullable())));
     }
 }


### PR DESCRIPTION
Add the possibility to tests multiple TableApi expressions
and/or SQL expressions as multiple table columns using just one
execution of the pipeline to speed up the total test execution time.

Refactor existing tests of BuiltInFunctions to use the new approach
wherever possible.

## What is the purpose of the change

Refactor `BuiltInFunctionTestBase` to allow testing of multiple expressions at once.


## Brief change log

  - Add the possibility to test multiple TableApi and SQL expressions within on execution, by converting them into multiple table columns. This allows for faster overall test execution.
  - Refactor existing builtin function tests to use this new approach
  - Change some of the existing tests so that both Table API and SQL paths are verified.


## Verifying this change

This change is a trivial rework / code cleanup without any test coverage.


## Does this pull request potentially affect one of the following parts:

  - Dependencies (does it add or upgrade a dependency): no
  - The public API, i.e., is any changed class annotated with `@Public(Evolving)`: no
  - The serializers: no
  - The runtime per-record code paths (performance sensitive): no
  - Anything that affects deployment or recovery: JobManager (and its components), Checkpointing, Kubernetes/Yarn, ZooKeeper: no
  - The S3 file system connector: no

## Documentation

  - Does this pull request introduce a new feature? no
  - If yes, how is the feature documented? not applicable
