### PR TITLE
[FLINK-20928] Fix flaky test by retrying notifyCheckpointComplete until either commit success or timeout

### DIFF
--- a/flink-test-utils-parent/flink-test-utils-junit/src/main/java/org/apache/flink/core/testutils/CommonTestUtils.java
+++ b/flink-test-utils-parent/flink-test-utils-junit/src/main/java/org/apache/flink/core/testutils/CommonTestUtils.java
@@ -190,13 +190,15 @@ public class CommonTestUtils {
      *
      * @param condition the condition to wait for.
      * @param timeout the maximum time to wait for the condition to become true.
+     * @param pause delay between condition checks.
      * @param errorMsg the error message to include in the <code>TimeoutException</code> if the
      *     condition was not met before timeout.
      * @throws TimeoutException if the condition is not met before timeout.
      * @throws InterruptedException if the thread is interrupted.
      */
     @SuppressWarnings("BusyWait")
-    public static void waitUtil(Supplier<Boolean> condition, Duration timeout, String errorMsg)
+    public static void waitUtil(
+            Supplier<Boolean> condition, Duration timeout, Duration pause, String errorMsg)
             throws TimeoutException, InterruptedException {
         long timeoutMs = timeout.toMillis();
         if (timeoutMs <= 0) {
@@ -206,10 +208,25 @@ public class CommonTestUtils {
         boolean conditionResult = condition.get();
         while (!conditionResult && System.currentTimeMillis() - startingTime < timeoutMs) {
             conditionResult = condition.get();
-            Thread.sleep(1);
+            Thread.sleep(pause.toMillis());
         }
         if (!conditionResult) {
             throw new TimeoutException(errorMsg);
         }
+    }
+
+    /**
+     * Wait util the given condition is met or timeout.
+     *
+     * @param condition the condition to wait for.
+     * @param timeout the maximum time to wait for the condition to become true.
+     * @param errorMsg the error message to include in the <code>TimeoutException</code> if the
+     *     condition was not met before timeout.
+     * @throws TimeoutException if the condition is not met before timeout.
+     * @throws InterruptedException if the thread is interrupted.
+     */
+    public static void waitUtil(Supplier<Boolean> condition, Duration timeout, String errorMsg)
+            throws TimeoutException, InterruptedException {
+        waitUtil(condition, timeout, Duration.ofMillis(1), errorMsg);
     }
 }


### PR DESCRIPTION
## What is the purpose of the change

The test `KafkaSourceReaderTest.testOffsetCommitOnCheckpointComplete` is flaky according to the test failure history in [FLINK-20928](https://issues.apache.org/jira/browse/FLINK-20928). This PR attempts to fix this flaky test.

## Brief change log

Here are the problems with the existing code that could explain why the test is flaky:

1) The test calls `KafkaSourceReader.notifyCheckpointComplete(...)` once and expects the offset commit to be successful. 
2) However, `KafkaSourceReader.notifyCheckpointComplete(...)` does not guarantee the offset commit to be successfully. This is because it calls `KafkaConsumer.commitAsync(...)` just once and won't retry even if the commit fails with an retriable exception.
3) During in the test, if the coordinator is temporarily unavailable due to e.g. coordinator movement or network disconnection, the test will fail due to TimeoutException.

This PR made the following changes to address the issues described above:

1) Updated `KafkaSourceReader.notifyCheckpointComplete` so that it can be called multiple times with the same `checkpointId`.
2) Updated `CommonTestUtils.waitUtil(...)` to support user-specified sleep time. Previously `waitUtil(...)` hardcodes the sleep time to be 1 ms.
3) Updated `KafkaSourceReaderTest.testOffsetCommitOnCheckpointComplete` to retry `KafkaSourceReader.notifyCheckpointComplete` once per second until either the offset commit has completed or the max wait time has been reached.

## Verifying this change

The test `KafkaSourceReaderTest#testOffsetCommitOnCheckpointComplete` could consistently pass across 200 runs.

## Does this pull request potentially affect one of the following parts:

- Dependencies (does it add or upgrade a dependency): (no)
- The public API, i.e., is any changed class annotated with `@Public(Evolving)`: (no)
- The serializers: (no)
- The runtime per-record code paths (performance sensitive): (no)
- Anything that affects deployment or recovery: JobManager (and its components), Checkpointing, Kubernetes/Yarn/Mesos, ZooKeeper: (no)
- The S3 file system connector: (no)

## Documentation

- Does this pull request introduce a new feature? (no)
- If yes, how is the feature documented? (no)