### PR TITLE
[hotfix][docs] Remove the explicit requirement of flink-connector-base in pulsar connector document

### DIFF
--- a/docs/content.zh/docs/connectors/datastream/pulsar.md
+++ b/docs/content.zh/docs/connectors/datastream/pulsar.md
@@ -35,10 +35,6 @@ Flink 当前只提供 [Apache Pulsar](https://pulsar.apache.org) 数据源，用
 
 {{< artifact flink-connector-pulsar withScalaVersion >}}
 
-使用本连接器的同时，记得把 `flink-connector-base` 也加到项目的依赖里面：
-
-{{< artifact flink-connector-base >}}
-
 Flink 的流连接器并不会放到发行文件里面一同发布，阅读[此文档]({{< ref "docs/dev/datastream/project-configuration" >}})，了解如何将连接器添加到集群实例内。
 
 ## Pulsar 数据源

--- a/docs/content/docs/connectors/datastream/pulsar.md
+++ b/docs/content/docs/connectors/datastream/pulsar.md
@@ -35,10 +35,6 @@ For details on Pulsar compatibility, please refer to the [PIP-72](https://github
 
 {{< artifact flink-connector-pulsar withScalaVersion >}}
 
-If you are using Pulsar source, `flink-connector-base` is also required as dependency:
-
-{{< artifact flink-connector-base >}}
-
 Flink's streaming connectors are not currently part of the binary distribution.
 See how to link with them for cluster execution [here]({{< ref "docs/dev/datastream/project-configuration" >}}).
 
@@ -243,6 +239,10 @@ Built-in start cursors include:
   Include or exclude the start message by using the second boolean parameter.
   ```java
   StartCursor.fromMessageId(MessageId, boolean)
+  ```
+- Start from the specified message time by `Message<byte[]>.getEventTime()`.
+  ```java
+  StartCursor.fromMessageTime(long)
   ```
 
 {{< hint info >}}


### PR DESCRIPTION
## What is the purpose of the change

Correct the pulsar connector document.

## Brief change log

- Remove the explicit requirement of `flink-connector-base`
- Add the missing `StartCursor` in the English document.

## Verifying this change

This change is a trivial rework / code cleanup without any test coverage.

## Does this pull request potentially affect one of the following parts:

  - Dependencies (does it add or upgrade a dependency): (no)
  - The public API, i.e., is any changed class annotated with `@Public(Evolving)`: (no)
  - The serializers: (no)
  - The runtime per-record code paths (performance sensitive): (no)
  - Anything that affects deployment or recovery: JobManager (and its components), Checkpointing, Kubernetes/Yarn, ZooKeeper: (no)
  - The S3 file system connector: (no)

## Documentation

  - Does this pull request introduce a new feature? (no)
  - If yes, how is the feature documented? (not applicable)
