### PR TITLE
[FLINK-24371][datastream] Call preCommit on SinkWriter although no committer is available

### DIFF
--- a/flink-core/src/main/java/org/apache/flink/api/connector/sink/SinkWriter.java
+++ b/flink-core/src/main/java/org/apache/flink/api/connector/sink/SinkWriter.java
@@ -63,6 +63,9 @@ public interface SinkWriter<InputT, CommT, WriterStateT> extends AutoCloseable {
      *
      * <p>This will be called before we checkpoint the Writer's state in Streaming execution mode.
      *
+     * <p>In case the sink has no explicit committer, this method is still called to allow the
+     * writer to implement a 1-phase commit protocol.
+     *
      * @param flush Whether flushing the un-staged data or not
      * @return The data is ready to commit.
      * @throws IOException if fail to prepare for a commit.

--- a/flink-streaming-java/src/main/java/org/apache/flink/streaming/runtime/operators/sink/AbstractCommitterHandler.java
+++ b/flink-streaming-java/src/main/java/org/apache/flink/streaming/runtime/operators/sink/AbstractCommitterHandler.java
@@ -17,8 +17,6 @@
 
 package org.apache.flink.streaming.runtime.operators.sink;
 
-import org.apache.flink.util.function.SupplierWithException;
-
 import java.io.IOException;
 import java.util.ArrayDeque;
 import java.util.ArrayList;
@@ -72,9 +70,8 @@ abstract class AbstractCommitterHandler<InputT, OutputT, RecoverT>
             throws IOException, InterruptedException;
 
     @Override
-    public List<OutputT> processCommittables(
-            SupplierWithException<List<InputT>, Exception> committableSupplier) throws Exception {
-        this.committables.addAll(committableSupplier.get());
+    public List<OutputT> processCommittables(List<InputT> committables) {
+        this.committables.addAll(committables);
         return Collections.emptyList();
     }
 

--- a/flink-streaming-java/src/main/java/org/apache/flink/streaming/runtime/operators/sink/BatchCommitterHandler.java
+++ b/flink-streaming-java/src/main/java/org/apache/flink/streaming/runtime/operators/sink/BatchCommitterHandler.java
@@ -19,7 +19,6 @@
 package org.apache.flink.streaming.runtime.operators.sink;
 
 import org.apache.flink.api.connector.sink.Committer;
-import org.apache.flink.util.function.SupplierWithException;
 
 import java.io.IOException;
 import java.util.List;
@@ -51,11 +50,9 @@ final class BatchCommitterHandler<InputT, OutputT>
     }
 
     @Override
-    public List<OutputT> processCommittables(
-            SupplierWithException<List<InputT>, Exception> committableSupplier) throws Exception {
-        List<InputT> committables = committableSupplier.get();
-        super.processCommittables(() -> committables);
-        return chainedHandler.processCommittables(() -> committables);
+    public List<OutputT> processCommittables(List<InputT> committables) {
+        super.processCommittables(committables);
+        return chainedHandler.processCommittables(committables);
     }
 
     @Override

--- a/flink-streaming-java/src/main/java/org/apache/flink/streaming/runtime/operators/sink/CommitterHandler.java
+++ b/flink-streaming-java/src/main/java/org/apache/flink/streaming/runtime/operators/sink/CommitterHandler.java
@@ -19,7 +19,6 @@ package org.apache.flink.streaming.runtime.operators.sink;
 
 import org.apache.flink.runtime.state.StateInitializationContext;
 import org.apache.flink.runtime.state.StateSnapshotContext;
-import org.apache.flink.util.function.SupplierWithException;
 
 import java.io.IOException;
 import java.io.Serializable;
@@ -44,16 +43,15 @@ interface CommitterHandler<InputT, OutputT> extends AutoCloseable, Serializable 
 
     /**
      * Processes the committables by either directly transforming them or by adding them to the
-     * internal state of this handler. The supplier should only be queried once.
+     * internal state of this handler.
      *
      * @return a list of output committables that is send downstream.
      */
-    List<OutputT> processCommittables(
-            SupplierWithException<List<InputT>, Exception> committableSupplier) throws Exception;
+    List<OutputT> processCommittables(List<InputT> committables);
 
     /**
      * Called when no more committables are going to be added through {@link
-     * #processCommittables(SupplierWithException)}.
+     * #processCommittables(List)}.
      *
      * @return a list of output committables that is send downstream.
      */

--- a/flink-streaming-java/src/main/java/org/apache/flink/streaming/runtime/operators/sink/CommitterOperator.java
+++ b/flink-streaming-java/src/main/java/org/apache/flink/streaming/runtime/operators/sink/CommitterOperator.java
@@ -99,10 +99,9 @@ class CommitterOperator<InputT, OutputT> extends AbstractStreamOperator<byte[]>
     @Override
     public void processElement(StreamRecord<byte[]> element) throws Exception {
         committerHandler.processCommittables(
-                () ->
-                        Collections.singletonList(
-                                SimpleVersionedSerialization.readVersionAndDeSerialize(
-                                        inputSerializer, element.getValue())));
+                Collections.singletonList(
+                        SimpleVersionedSerialization.readVersionAndDeSerialize(
+                                inputSerializer, element.getValue())));
     }
 
     @Override

--- a/flink-streaming-java/src/main/java/org/apache/flink/streaming/runtime/operators/sink/ForwardCommittingHandler.java
+++ b/flink-streaming-java/src/main/java/org/apache/flink/streaming/runtime/operators/sink/ForwardCommittingHandler.java
@@ -17,8 +17,6 @@
 
 package org.apache.flink.streaming.runtime.operators.sink;
 
-import org.apache.flink.util.function.SupplierWithException;
-
 import java.io.IOException;
 import java.util.List;
 
@@ -31,9 +29,8 @@ class ForwardCommittingHandler<CommT> extends AbstractCommitterHandler<CommT, Co
     ForwardCommittingHandler() {}
 
     @Override
-    public List<CommT> processCommittables(
-            SupplierWithException<List<CommT>, Exception> committableSupplier) throws Exception {
-        return committableSupplier.get();
+    public List<CommT> processCommittables(List<CommT> committables) {
+        return committables;
     }
 
     @Override

--- a/flink-streaming-java/src/main/java/org/apache/flink/streaming/runtime/operators/sink/NoopCommitterHandler.java
+++ b/flink-streaming-java/src/main/java/org/apache/flink/streaming/runtime/operators/sink/NoopCommitterHandler.java
@@ -17,8 +17,6 @@
 
 package org.apache.flink.streaming.runtime.operators.sink;
 
-import org.apache.flink.util.function.SupplierWithException;
-
 import java.io.IOException;
 import java.util.Collections;
 import java.util.List;
@@ -33,8 +31,7 @@ enum NoopCommitterHandler implements CommitterHandler<Object, Object> {
     }
 
     @Override
-    public List<Object> processCommittables(
-            SupplierWithException<List<Object>, Exception> committableSupplier) {
+    public List<Object> processCommittables(List<Object> committables) {
         return Collections.emptyList();
     }
 

--- a/flink-streaming-java/src/main/java/org/apache/flink/streaming/runtime/operators/sink/SinkOperator.java
+++ b/flink-streaming-java/src/main/java/org/apache/flink/streaming/runtime/operators/sink/SinkOperator.java
@@ -171,8 +171,7 @@ class SinkOperator<InputT, CommT, WriterStateT> extends AbstractStreamOperator<b
     public void prepareSnapshotPreBarrier(long checkpointId) throws Exception {
         super.prepareSnapshotPreBarrier(checkpointId);
         if (!endOfInput) {
-            emitCommittables(
-                    committerHandler.processCommittables(() -> sinkWriter.prepareCommit(false)));
+            emitCommittables(committerHandler.processCommittables(sinkWriter.prepareCommit(false)));
         }
     }
 
@@ -194,8 +193,7 @@ class SinkOperator<InputT, CommT, WriterStateT> extends AbstractStreamOperator<b
     @Override
     public void endInput() throws Exception {
         endOfInput = true;
-        emitCommittables(
-                committerHandler.processCommittables(() -> sinkWriter.prepareCommit(true)));
+        emitCommittables(committerHandler.processCommittables(sinkWriter.prepareCommit(true)));
         emitCommittables(committerHandler.endOfInput());
         commitRetrier.retryIndefinitely();
     }

--- a/flink-streaming-java/src/test/java/org/apache/flink/streaming/runtime/operators/sink/SinkWriterOperatorTest.java
+++ b/flink-streaming-java/src/test/java/org/apache/flink/streaming/runtime/operators/sink/SinkWriterOperatorTest.java
@@ -319,7 +319,7 @@ public class SinkWriterOperatorTest extends TestLogger {
     }
 
     /** A {@link SinkWriter} buffers elements and snapshots them when asked. */
-    static class SnapshottingBufferingSinkWriter extends BufferingSinkWriter {
+    private static class SnapshottingBufferingSinkWriter extends BufferingSinkWriter {
         public static final int NOT_SNAPSHOTTED = -1;
         long lastCheckpointId = NOT_SNAPSHOTTED;
 
@@ -335,7 +335,7 @@ public class SinkWriterOperatorTest extends TestLogger {
         }
     }
 
-    static class DummySinkOperator extends AbstractStreamOperator<String>
+    private static class DummySinkOperator extends AbstractStreamOperator<String>
             implements OneInputStreamOperator<String, String> {
 
         static final String DUMMY_SINK_STATE_NAME = "dummy_sink_state";
@@ -375,7 +375,7 @@ public class SinkWriterOperatorTest extends TestLogger {
      * A {@link SinkWriter} that only returns committables from {@link #prepareCommit(boolean)} when
      * {@code flush} is {@code true}.
      */
-    static class BufferingSinkWriter extends TestSink.DefaultSinkWriter<Integer> {
+    private static class BufferingSinkWriter extends TestSink.DefaultSinkWriter<Integer> {
         @Override
         public List<String> prepareCommit(boolean flush) {
             if (!flush) {
@@ -391,7 +391,7 @@ public class SinkWriterOperatorTest extends TestLogger {
      * A {@link SinkWriter} that buffers the committables and send the cached committables per
      * second.
      */
-    static class TimeBasedBufferingSinkWriter extends TestSink.DefaultSinkWriter<Integer>
+    private static class TimeBasedBufferingSinkWriter extends TestSink.DefaultSinkWriter<Integer>
             implements Sink.ProcessingTimeService.ProcessingTimeCallback {
 
         private final List<String> cachedCommittables = new ArrayList<>();

--- a/flink-streaming-java/src/test/java/org/apache/flink/streaming/runtime/operators/sink/SinkWriterOperatorTest.java
+++ b/flink-streaming-java/src/test/java/org/apache/flink/streaming/runtime/operators/sink/SinkWriterOperatorTest.java
@@ -54,6 +54,7 @@ import static org.hamcrest.MatcherAssert.assertThat;
 import static org.hamcrest.Matchers.contains;
 import static org.hamcrest.Matchers.containsInAnyOrder;
 import static org.hamcrest.Matchers.equalTo;
+import static org.junit.jupiter.api.Assertions.assertTrue;
 
 /** Test stateful and stateless {@link SinkWriterStateHandler} in {@link SinkOperator}. */
 @RunWith(Parameterized.class)
@@ -318,6 +319,58 @@ public class SinkWriterOperatorTest extends TestLogger {
                 containsInAnyOrder(expectedOutput2.toArray()));
     }
 
+    @Test
+    public void receivePreCommitWithoutCommitter() throws Exception {
+        final long initialTime = 0;
+
+        PreBarrierSinkWriter writer = new PreBarrierSinkWriter();
+        final OneInputStreamOperatorTestHarness<Integer, byte[]> testHarness =
+                createTestHarness(writer, false);
+        testHarness.open();
+
+        testHarness.processWatermark(initialTime);
+        testHarness.processElement(1, initialTime + 1);
+        testHarness.processElement(2, initialTime + 2);
+
+        testHarness.prepareSnapshotPreBarrier(1L);
+        // Expect that preCommit was called
+        assertTrue(writer.hasReceivedPreCommit());
+        testHarness.snapshot(1L, 1L);
+
+        assertThat(
+                writer.getElements(),
+                contains(
+                        Tuple3.of(1, initialTime + 1, initialTime).toString(),
+                        Tuple3.of(2, initialTime + 2, initialTime).toString()));
+
+        assertThat(
+                writer.getWatermarks(),
+                contains(new org.apache.flink.api.common.eventtime.Watermark(initialTime)));
+    }
+
+    private static class PreBarrierSinkWriter extends TestSink.DefaultSinkWriter<Integer> {
+
+        private boolean receivedPreCommit = false;
+
+        @Override
+        public List<String> prepareCommit(boolean flush) {
+            receivedPreCommit = true;
+            return Collections.emptyList();
+        }
+
+        public boolean hasReceivedPreCommit() {
+            return receivedPreCommit;
+        }
+
+        public List<org.apache.flink.api.common.eventtime.Watermark> getWatermarks() {
+            return watermarks;
+        }
+
+        public List<String> getElements() {
+            return elements;
+        }
+    }
+
     /** A {@link SinkWriter} buffers elements and snapshots them when asked. */
     private static class SnapshottingBufferingSinkWriter extends BufferingSinkWriter {
         public static final int NOT_SNAPSHOTTED = -1;
@@ -417,8 +470,13 @@ public class SinkWriterOperatorTest extends TestLogger {
 
     private OneInputStreamOperatorTestHarness<Integer, byte[]> createTestHarness(
             TestSink.DefaultSinkWriter<Integer> writer) throws Exception {
+        return createTestHarness(writer, true);
+    }
+
+    private OneInputStreamOperatorTestHarness<Integer, byte[]> createTestHarness(
+            TestSink.DefaultSinkWriter<Integer> writer, boolean withCommitter) throws Exception {
         return new OneInputStreamOperatorTestHarness<>(
-                new SinkOperatorFactory<>(getBuilder(writer).build(), false, true),
+                new SinkOperatorFactory<>(getBuilder(writer).build(), false, withCommitter),
                 IntSerializer.INSTANCE);
     }
 


### PR DESCRIPTION
<!--
*Thank you very much for contributing to Apache Flink - we are happy that you want to help us improve Flink. To help the community review your contribution in the best possible way, please go through the checklist below, which will get the contribution into a shape in which it can be best reviewed.*

*Please understand that we do not do this to make contributions to Flink a hassle. In order to uphold a high standard of quality for code contributions, while at the same time managing a large number of contributions, we need contributors to prepare the contributions well, and give reviewers enough contextual information for the review. Please also understand that contributions that do not follow this guide will take longer to review and thus typically be picked up with lower priority by the community.*

## Contribution Checklist

  - Make sure that the pull request corresponds to a [JIRA issue](https://issues.apache.org/jira/projects/FLINK/issues). Exceptions are made for typos in JavaDoc or documentation files, which need no JIRA issue.
  
  - Name the pull request in the form "[FLINK-XXXX] [component] Title of the pull request", where *FLINK-XXXX* should be replaced by the actual issue number. Skip *component* if you are unsure about which is the best component.
  Typo fixes that have no associated JIRA issue should be named following this pattern: `[hotfix] [docs] Fix typo in event time introduction` or `[hotfix] [javadocs] Expand JavaDoc for PuncuatedWatermarkGenerator`.

  - Fill out the template below to describe the changes contributed by the pull request. That will give reviewers the context they need to do the review.
  
  - Make sure that the change passes the automated tests, i.e., `mvn clean verify` passes. You can set up Azure Pipelines CI to do that following [this guide](https://cwiki.apache.org/confluence/display/FLINK/Azure+Pipelines#AzurePipelines-Tutorial:SettingupAzurePipelinesforaforkoftheFlinkrepository).

  - Each pull request should address only one issue, not mix up code from multiple issues.
  
  - Each commit in the pull request has a meaningful commit message (including the JIRA id)

  - Once all items of the checklist are addressed, remove the above text and this checklist, leaving only the filled out template below.


**(The sections below can be removed for hotfixes of typos)**
-->

## What is the purpose of the change

 Before this change, if no committer was after the SinkWriter in the pipeline preCommit was never called. With this change, preCommit is now called as well but the return values are discarded as before.


## Brief change log

  - Call the passed lambda in NoopCommitHandler 


## Verifying this change

- Added a test to ensure that preCommit is called if the Sink is configured without a commiter

## Does this pull request potentially affect one of the following parts:

  - Dependencies (does it add or upgrade a dependency): (yes / **no**)
  - The public API, i.e., is any changed class annotated with `@Public(Evolving)`: (yes / **no**)
  - The serializers: (yes / **no** / don't know)
  - The runtime per-record code paths (performance sensitive): (yes / **no** / don't know)
  - Anything that affects deployment or recovery: JobManager (and its components), Checkpointing, Kubernetes/Yarn, ZooKeeper: (yes / **no** / don't know)
  - The S3 file system connector: (yes / **no** / don't know)

## Documentation

  - Does this pull request introduce a new feature? (yes / **no**)
  - If yes, how is the feature documented? (**not applicable** / docs / JavaDocs / not documented)
