### PR TITLE
[FLINK-24373][docs] Remove BETA Tag from FLIP-27 Source Docs

### DIFF
--- a/docs/content.zh/docs/dev/datastream/sources.md
+++ b/docs/content.zh/docs/dev/datastream/sources.md
@@ -26,14 +26,6 @@ under the License.
 
 # 数据源
 
-
-{{< hint warning >}}
-**注意**: 当前文档所描述的为新的数据源 API，在 Flink 1.11 中作为 [FLIP-27]("https://cwiki.apache.org/confluence/display/FLINK/FLIP-27%3A+Refactor+Source+Interface") 中的一部分引入。
-该新 API 仍处于 **BETA** 阶段。
-
-（从 Flink 1.11 开始）大多数现有的 source 连接器尚未使用此新 API 实现，仍旧使用之前的 API，也就是基于 [SourceFunction]("https://github.com/apache/flink/blob/master/flink-streaming-java/src/main/java/org/apache/flink/streaming/api/functions/source/SourceFunction.java") 的实现的 API。
-{{< /hint >}}
-
 当前页面所描述的是 Flink 的 Data Source API 及其背后的概念和架构。
 **如果您对 Flink 中的 Data Source 如何工作感兴趣，或者您想实现一个新的数据 source，请阅读本文。**
 

--- a/docs/content/docs/dev/datastream/sources.md
+++ b/docs/content/docs/dev/datastream/sources.md
@@ -26,20 +26,10 @@ under the License.
 
 # Data Sources
 
-
-{{< hint warning >}}
-**Note**: This describes the new Data Source API, introduced in Flink 1.11 as part of [FLIP-27]("https://cwiki.apache.org/confluence/display/FLINK/FLIP-27%3A+Refactor+Source+Interface").
-This new API is currently in **BETA**  status.
-
- Most of the existing source connectors are not yet (as of Flink 1.11) implemented using this new API,
- but using the previous API, based on [SourceFunction]("https://github.com/apache/flink/blob/master/flink-streaming-java/src/main/java/org/apache/flink/streaming/api/functions/source/SourceFunction.java").
-{{< /hint >}}
-
 This page describes Flink's Data Source API and the concepts and architecture behind it.
 **Read this, if you are interested in how data sources in Flink work, or if you want to implement a new Data Source.**
 
 If you are looking for pre-defined source connectors, please check the [Connector Docs]({{< ref "docs/connectors/datastream/overview" >}}).
-
 
 ## Data Source Concepts
 


### PR DESCRIPTION
## What is the purpose of the change

Remove BETA Tag from FLIP-27 Source Docs. We will backport this to 1.14 release branch. 

## Does this pull request potentially affect one of the following parts:

Not Relevant

## Documentation

  - Does this pull request introduce a new feature? (yes / **no**)
  - If yes, how is the feature documented? (not applicable / **docs** / JavaDocs / not documented)
