### PR TITLE
 [FLINK-24374] Retry querying for checkpoint stats 

### DIFF
--- a/flink-runtime/src/main/java/org/apache/flink/runtime/checkpoint/PendingCheckpoint.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/checkpoint/PendingCheckpoint.java
@@ -338,7 +338,6 @@ public class PendingCheckpoint implements Checkpoint {
 
                 onCompletionPromise.complete(completed);
 
-                // to prevent null-pointers from concurrent modification, copy reference onto stack
                 if (statsCallback != null) {
                     LOG.trace(
                             "Checkpoint {} size: {}Kb, duration: {}ms",


### PR DESCRIPTION

## What is the purpose of the change

The checkpoint stats are updated after the corresponding future for a
checkpoint is completed. Therefore we might retrieve the old stats that
do not reflect the just completed checkpoint yet. In this commit we do
retry until we reach the desired number of checkpoints.

## Does this pull request potentially affect one of the following parts:

  - Dependencies (does it add or upgrade a dependency): (yes / **no**)
  - The public API, i.e., is any changed class annotated with `@Public(Evolving)`: (yes / **no**)
  - The serializers: (yes / **no** / don't know)
  - The runtime per-record code paths (performance sensitive): (yes / **no** / don't know)
  - Anything that affects deployment or recovery: JobManager (and its components), Checkpointing, Kubernetes/Yarn, ZooKeeper: (yes / **no** / don't know)
  - The S3 file system connector: (yes / **no** / don't know)

## Documentation

  - Does this pull request introduce a new feature? (yes / **no**)
  - If yes, how is the feature documented? (**not applicable** / docs / JavaDocs / not documented)
