### PR TITLE
[FLINK-24398][connectors/kafka] KafkaSourceFetcherManager should re-use an existing SplitFetcher to commit offset if possible

### DIFF
--- a/flink-connectors/flink-connector-kafka/src/main/java/org/apache/flink/connector/kafka/source/reader/fetcher/KafkaSourceFetcherManager.java
+++ b/flink-connectors/flink-connector-kafka/src/main/java/org/apache/flink/connector/kafka/source/reader/fetcher/KafkaSourceFetcherManager.java
@@ -73,7 +73,7 @@ public class KafkaSourceFetcherManager<T>
         if (offsetsToCommit.isEmpty()) {
             return;
         }
-        SplitFetcher<Tuple3<T, Long, Long>, KafkaPartitionSplit> splitFetcher = fetchers.get(0);
+        SplitFetcher<Tuple3<T, Long, Long>, KafkaPartitionSplit> splitFetcher = getRunningFetcher();
         if (splitFetcher != null) {
             // The fetcher thread is still running. This should be the majority of the cases.
             enqueueOffsetsCommitTask(splitFetcher, offsetsToCommit, callback);


### PR DESCRIPTION
## What is the purpose of the change

The purpose of this PR is to improve the performance of `KafkaSourceFetcherManager::commitOffsets(...)`.

## Brief change log

This PR updated KafkaSourceFetcherManager::commitOffsets(...) to re-use an existing SplitFetcher to commit offset, if there is any SplitFetcher in the `fetchers`.

## Verifying this change

No extra unit test is needed since this PR does not fix any bug. 

All unit tests have passed.

## Does this pull request potentially affect one of the following parts:

- Dependencies (does it add or upgrade a dependency): (no)
- The public API, i.e., is any changed class annotated with `@Public(Evolving)`: (no)
- The serializers: (no)
- The runtime per-record code paths (performance sensitive): (no)
- Anything that affects deployment or recovery: JobManager (and its components), Checkpointing, Kubernetes/Yarn/Mesos, ZooKeeper: (no)
- The S3 file system connector: (no)

## Documentation

- Does this pull request introduce a new feature? (no)
- If yes, how is the feature documented? (no)