### PR TITLE
[hotfix][docs] Move out the time zone page from streaming concepts section

### DIFF
--- a/docs/content.zh/docs/dev/table/timezone.md
+++ b/docs/content.zh/docs/dev/table/timezone.md
@@ -1,6 +1,6 @@
 ---
 title: "时区"
-weight: 4
+weight: 86
 type: docs
 ---
 <!--

--- a/docs/content.zh/docs/dev/table/timezone.md
+++ b/docs/content.zh/docs/dev/table/timezone.md
@@ -1,6 +1,6 @@
 ---
 title: "时区"
-weight: 86
+weight: 22
 type: docs
 ---
 <!--

--- a/docs/content/docs/dev/table/timezone.md
+++ b/docs/content/docs/dev/table/timezone.md
@@ -1,6 +1,6 @@
 ---
 title: "Time Zone"
-weight: 4
+weight: 86
 type: docs
 ---
 <!--

--- a/docs/content/docs/dev/table/timezone.md
+++ b/docs/content/docs/dev/table/timezone.md
@@ -1,6 +1,6 @@
 ---
 title: "Time Zone"
-weight: 86
+weight: 22
 type: docs
 ---
 <!--


### PR DESCRIPTION
## What is the purpose of the change

* This pull request move out the time zone page from streaming concepts section

## Brief change log

  -  move out the timezone page as it is not streaming specific


## Verifying this change

This change is a doc hotfix without any test coverage.

## Does this pull request potentially affect one of the following parts:

  - Dependencies (does it add or upgrade a dependency): (no)
  - The public API, i.e., is any changed class annotated with `@Public(Evolving)`: (no)
  - The serializers: (no)
  - The runtime per-record code paths (performance sensitive): ( no)
  - Anything that affects deployment or recovery: JobManager (and its components), Checkpointing, Yarn/Mesos, ZooKeeper: (no)
  - The S3 file system connector: (no)

## Documentation

  - Does this pull request introduce a new feature? (no)
  - If yes, how is the feature documented? (not applicable / docs / JavaDocs / not documented)
