### PR TITLE
[FLINK-24388][table] Modules can provide a table source/sink factory

### DIFF
--- a/flink-connectors/flink-connector-hive/src/main/java/org/apache/flink/connectors/hive/HiveDynamicTableFactory.java
+++ b/flink-connectors/flink-connector-hive/src/main/java/org/apache/flink/connectors/hive/HiveDynamicTableFactory.java
@@ -20,6 +20,7 @@ package org.apache.flink.connectors.hive;
 
 import org.apache.flink.configuration.ConfigOption;
 import org.apache.flink.configuration.Configuration;
+import org.apache.flink.configuration.ReadableConfig;
 import org.apache.flink.connectors.hive.util.JobConfUtils;
 import org.apache.flink.table.catalog.CatalogTable;
 import org.apache.flink.table.catalog.hive.HiveCatalog;
@@ -65,21 +66,10 @@ public class HiveDynamicTableFactory implements DynamicTableSourceFactory, Dynam
 
     @Override
     public DynamicTableSink createDynamicTableSink(Context context) {
-        boolean isHiveTable = HiveCatalog.isHiveTable(context.getCatalogTable().getOptions());
+        final boolean isHiveTable = HiveCatalog.isHiveTable(context.getCatalogTable().getOptions());
 
         // we don't support temporary hive tables yet
-        if (isHiveTable && !context.isTemporary()) {
-            Integer configuredParallelism =
-                    Configuration.fromMap(context.getCatalogTable().getOptions())
-                            .get(FileSystemConnectorOptions.SINK_PARALLELISM);
-            JobConf jobConf = JobConfUtils.createJobConfWithCredentials(hiveConf);
-            return new HiveTableSink(
-                    context.getConfiguration(),
-                    jobConf,
-                    context.getObjectIdentifier(),
-                    context.getCatalogTable(),
-                    configuredParallelism);
-        } else {
+        if (!isHiveTable || context.isTemporary()) {
             return FactoryUtil.createTableSink(
                     null, // we already in the factory of catalog
                     context.getObjectIdentifier(),
@@ -88,59 +78,60 @@ public class HiveDynamicTableFactory implements DynamicTableSourceFactory, Dynam
                     context.getClassLoader(),
                     context.isTemporary());
         }
+
+        final Integer configuredParallelism =
+                Configuration.fromMap(context.getCatalogTable().getOptions())
+                        .get(FileSystemConnectorOptions.SINK_PARALLELISM);
+        final JobConf jobConf = JobConfUtils.createJobConfWithCredentials(hiveConf);
+        return new HiveTableSink(
+                context.getConfiguration(),
+                jobConf,
+                context.getObjectIdentifier(),
+                context.getCatalogTable(),
+                configuredParallelism);
     }
 
     @Override
     public DynamicTableSource createDynamicTableSource(Context context) {
-        boolean isHiveTable = HiveCatalog.isHiveTable(context.getCatalogTable().getOptions());
+        final ReadableConfig configuration =
+                Configuration.fromMap(context.getCatalogTable().getOptions());
+
+        final boolean isHiveTable = HiveCatalog.isHiveTable(context.getCatalogTable().getOptions());
 
         // we don't support temporary hive tables yet
-        if (isHiveTable && !context.isTemporary()) {
-            CatalogTable catalogTable = Preconditions.checkNotNull(context.getCatalogTable());
-
-            boolean isStreamingSource =
-                    Boolean.parseBoolean(
-                            catalogTable
-                                    .getOptions()
-                                    .getOrDefault(
-                                            STREAMING_SOURCE_ENABLE.key(),
-                                            STREAMING_SOURCE_ENABLE.defaultValue().toString()));
-
-            boolean includeAllPartition =
-                    STREAMING_SOURCE_PARTITION_INCLUDE
-                            .defaultValue()
-                            .equals(
-                                    catalogTable
-                                            .getOptions()
-                                            .getOrDefault(
-                                                    STREAMING_SOURCE_PARTITION_INCLUDE.key(),
-                                                    STREAMING_SOURCE_PARTITION_INCLUDE
-                                                            .defaultValue()));
-            JobConf jobConf = JobConfUtils.createJobConfWithCredentials(hiveConf);
-            // hive table source that has not lookup ability
-            if (isStreamingSource && includeAllPartition) {
-                return new HiveTableSource(
-                        jobConf,
-                        context.getConfiguration(),
-                        context.getObjectIdentifier().toObjectPath(),
-                        catalogTable);
-            } else {
-                // hive table source that has scan and lookup ability
-                return new HiveLookupTableSource(
-                        jobConf,
-                        context.getConfiguration(),
-                        context.getObjectIdentifier().toObjectPath(),
-                        catalogTable);
-            }
-
-        } else {
-            return FactoryUtil.createTableSource(
-                    null, // we already in the factory of catalog
+        if (!isHiveTable || context.isTemporary()) {
+            return FactoryUtil.createDynamicTableSource(
+                    null,
                     context.getObjectIdentifier(),
                     context.getCatalogTable(),
                     context.getConfiguration(),
                     context.getClassLoader(),
                     context.isTemporary());
+        }
+
+        final CatalogTable catalogTable = Preconditions.checkNotNull(context.getCatalogTable());
+
+        final boolean isStreamingSource = configuration.get(STREAMING_SOURCE_ENABLE);
+        final boolean includeAllPartition =
+                STREAMING_SOURCE_PARTITION_INCLUDE
+                        .defaultValue()
+                        .equals(configuration.get(STREAMING_SOURCE_PARTITION_INCLUDE));
+        final JobConf jobConf = JobConfUtils.createJobConfWithCredentials(hiveConf);
+
+        // hive table source that has not lookup ability
+        if (isStreamingSource && includeAllPartition) {
+            return new HiveTableSource(
+                    jobConf,
+                    context.getConfiguration(),
+                    context.getObjectIdentifier().toObjectPath(),
+                    catalogTable);
+        } else {
+            // hive table source that has scan and lookup ability
+            return new HiveLookupTableSource(
+                    jobConf,
+                    context.getConfiguration(),
+                    context.getObjectIdentifier().toObjectPath(),
+                    catalogTable);
         }
     }
 }

--- a/flink-connectors/flink-connector-hive/src/main/java/org/apache/flink/connectors/hive/HiveDynamicTableFactory.java
+++ b/flink-connectors/flink-connector-hive/src/main/java/org/apache/flink/connectors/hive/HiveDynamicTableFactory.java
@@ -70,8 +70,8 @@ public class HiveDynamicTableFactory implements DynamicTableSourceFactory, Dynam
 
         // we don't support temporary hive tables yet
         if (!isHiveTable || context.isTemporary()) {
-            return FactoryUtil.createTableSink(
-                    null, // we already in the factory of catalog
+            return FactoryUtil.createDynamicTableSink(
+                    null,
                     context.getObjectIdentifier(),
                     context.getCatalogTable(),
                     context.getConfiguration(),

--- a/flink-connectors/flink-connector-hive/src/test/java/org/apache/flink/connectors/hive/HiveDynamicTableFactoryTest.java
+++ b/flink-connectors/flink-connector-hive/src/test/java/org/apache/flink/connectors/hive/HiveDynamicTableFactoryTest.java
@@ -29,6 +29,7 @@ import org.apache.flink.table.catalog.hive.HiveCatalog;
 import org.apache.flink.table.catalog.hive.HiveTestUtils;
 import org.apache.flink.table.connector.sink.DynamicTableSink;
 import org.apache.flink.table.connector.source.DynamicTableSource;
+import org.apache.flink.table.factories.DynamicTableSinkFactory;
 import org.apache.flink.table.factories.DynamicTableSourceFactory;
 import org.apache.flink.table.factories.FactoryUtil;
 import org.apache.flink.table.filesystem.FileSystemConnectorOptions.PartitionOrder;
@@ -299,8 +300,9 @@ public class HiveDynamicTableFactoryTest {
                 ObjectIdentifier.of(hiveCatalog.getName(), "default", tableName);
         CatalogTable catalogTable =
                 (CatalogTable) hiveCatalog.getTable(tableIdentifier.toObjectPath());
-        return FactoryUtil.createTableSink(
-                hiveCatalog,
+        return FactoryUtil.createDynamicTableSink(
+                (DynamicTableSinkFactory)
+                        hiveCatalog.getFactory().orElseThrow(IllegalStateException::new),
                 tableIdentifier,
                 tableEnvInternal.getCatalogManager().resolveCatalogTable(catalogTable),
                 tableEnv.getConfig().getConfiguration(),

--- a/flink-connectors/flink-connector-hive/src/test/java/org/apache/flink/connectors/hive/HiveDynamicTableFactoryTest.java
+++ b/flink-connectors/flink-connector-hive/src/test/java/org/apache/flink/connectors/hive/HiveDynamicTableFactoryTest.java
@@ -29,6 +29,7 @@ import org.apache.flink.table.catalog.hive.HiveCatalog;
 import org.apache.flink.table.catalog.hive.HiveTestUtils;
 import org.apache.flink.table.connector.sink.DynamicTableSink;
 import org.apache.flink.table.connector.source.DynamicTableSource;
+import org.apache.flink.table.factories.DynamicTableSourceFactory;
 import org.apache.flink.table.factories.FactoryUtil;
 import org.apache.flink.table.filesystem.FileSystemConnectorOptions.PartitionOrder;
 import org.apache.flink.table.filesystem.FileSystemLookupFunction;
@@ -282,8 +283,9 @@ public class HiveDynamicTableFactoryTest {
                 ObjectIdentifier.of(hiveCatalog.getName(), "default", tableName);
         CatalogTable catalogTable =
                 (CatalogTable) hiveCatalog.getTable(tableIdentifier.toObjectPath());
-        return FactoryUtil.createTableSource(
-                hiveCatalog,
+        return FactoryUtil.createDynamicTableSource(
+                (DynamicTableSourceFactory)
+                        hiveCatalog.getFactory().orElseThrow(IllegalStateException::new),
                 tableIdentifier,
                 tableEnvInternal.getCatalogManager().resolveCatalogTable(catalogTable),
                 tableEnv.getConfig().getConfiguration(),

--- a/flink-connectors/flink-connector-hive/src/test/java/org/apache/flink/connectors/hive/HiveLookupJoinITCase.java
+++ b/flink-connectors/flink-connector-hive/src/test/java/org/apache/flink/connectors/hive/HiveLookupJoinITCase.java
@@ -30,6 +30,7 @@ import org.apache.flink.table.catalog.hive.HiveCatalog;
 import org.apache.flink.table.catalog.hive.HiveTestUtils;
 import org.apache.flink.table.data.GenericRowData;
 import org.apache.flink.table.data.RowData;
+import org.apache.flink.table.factories.DynamicTableSourceFactory;
 import org.apache.flink.table.factories.FactoryUtil;
 import org.apache.flink.table.filesystem.FileSystemConnectorOptions;
 import org.apache.flink.table.filesystem.FileSystemLookupFunction;
@@ -360,8 +361,11 @@ public class HiveLookupJoinITCase {
                 (CatalogTable) hiveCatalog.getTable(tableIdentifier.toObjectPath());
         HiveLookupTableSource hiveTableSource =
                 (HiveLookupTableSource)
-                        FactoryUtil.createTableSource(
-                                hiveCatalog,
+                        FactoryUtil.createDynamicTableSource(
+                                (DynamicTableSourceFactory)
+                                        hiveCatalog
+                                                .getFactory()
+                                                .orElseThrow(IllegalStateException::new),
                                 tableIdentifier,
                                 tableEnvInternal
                                         .getCatalogManager()

--- a/flink-connectors/flink-connector-hive/src/test/java/org/apache/flink/connectors/hive/HiveTableFactoryTest.java
+++ b/flink-connectors/flink-connector-hive/src/test/java/org/apache/flink/connectors/hive/HiveTableFactoryTest.java
@@ -34,6 +34,7 @@ import org.apache.flink.table.catalog.hive.HiveCatalog;
 import org.apache.flink.table.catalog.hive.HiveTestUtils;
 import org.apache.flink.table.connector.sink.DynamicTableSink;
 import org.apache.flink.table.connector.source.DynamicTableSource;
+import org.apache.flink.table.factories.DynamicTableSinkFactory;
 import org.apache.flink.table.factories.DynamicTableSourceFactory;
 import org.apache.flink.table.factories.FactoryUtil;
 import org.apache.flink.table.factories.TableFactory;
@@ -137,8 +138,9 @@ public class HiveTableFactoryTest {
         assertTrue(tableSource instanceof HiveTableSource);
 
         final DynamicTableSink tableSink =
-                FactoryUtil.createTableSink(
-                        catalog,
+                FactoryUtil.createDynamicTableSink(
+                        (DynamicTableSinkFactory)
+                                catalog.getFactory().orElseThrow(IllegalStateException::new),
                         ObjectIdentifier.of("mycatalog", "mydb", "mytable"),
                         new ResolvedCatalogTable(table, schema),
                         new Configuration(),

--- a/flink-connectors/flink-connector-hive/src/test/java/org/apache/flink/connectors/hive/HiveTableFactoryTest.java
+++ b/flink-connectors/flink-connector-hive/src/test/java/org/apache/flink/connectors/hive/HiveTableFactoryTest.java
@@ -34,6 +34,7 @@ import org.apache.flink.table.catalog.hive.HiveCatalog;
 import org.apache.flink.table.catalog.hive.HiveTestUtils;
 import org.apache.flink.table.connector.sink.DynamicTableSink;
 import org.apache.flink.table.connector.source.DynamicTableSource;
+import org.apache.flink.table.factories.DynamicTableSourceFactory;
 import org.apache.flink.table.factories.FactoryUtil;
 import org.apache.flink.table.factories.TableFactory;
 import org.apache.flink.table.factories.TableSinkFactoryContextImpl;
@@ -47,6 +48,7 @@ import org.junit.AfterClass;
 import org.junit.BeforeClass;
 import org.junit.Test;
 
+import java.util.Collections;
 import java.util.HashMap;
 import java.util.Map;
 import java.util.Optional;
@@ -70,23 +72,24 @@ public class HiveTableFactoryTest {
 
     @Test
     public void testGenericTable() throws Exception {
-        TableSchema schema =
+        final TableSchema schema =
                 TableSchema.builder()
                         .field("name", DataTypes.STRING())
                         .field("age", DataTypes.INT())
                         .build();
 
-        Map<String, String> properties = new HashMap<>();
-        properties.put(FactoryUtil.CONNECTOR.key(), "COLLECTION");
-
         catalog.createDatabase("mydb", new CatalogDatabaseImpl(new HashMap<>(), ""), true);
-        ObjectPath path = new ObjectPath("mydb", "mytable");
-        CatalogTable table = new CatalogTableImpl(schema, properties, "csv table");
-        catalog.createTable(path, table, true);
-        Optional<TableFactory> opt = catalog.getTableFactory();
-        assertTrue(opt.isPresent());
-        HiveTableFactory tableFactory = (HiveTableFactory) opt.get();
-        TableSource tableSource =
+
+        final Map<String, String> options =
+                Collections.singletonMap(FactoryUtil.CONNECTOR.key(), "COLLECTION");
+        final CatalogTable table = new CatalogTableImpl(schema, options, "csv table");
+        catalog.createTable(new ObjectPath("mydb", "mytable"), table, true);
+
+        final Optional<TableFactory> tableFactoryOpt = catalog.getTableFactory();
+        assertTrue(tableFactoryOpt.isPresent());
+        final HiveTableFactory tableFactory = (HiveTableFactory) tableFactoryOpt.get();
+
+        final TableSource tableSource =
                 tableFactory.createTableSource(
                         new TableSourceFactoryContextImpl(
                                 ObjectIdentifier.of("mycatalog", "mydb", "mytable"),
@@ -94,7 +97,8 @@ public class HiveTableFactoryTest {
                                 new Configuration(),
                                 false));
         assertTrue(tableSource instanceof StreamTableSource);
-        TableSink tableSink =
+
+        final TableSink tableSink =
                 tableFactory.createTableSink(
                         new TableSinkFactoryContextImpl(
                                 ObjectIdentifier.of("mycatalog", "mydb", "mytable"),
@@ -107,24 +111,24 @@ public class HiveTableFactoryTest {
 
     @Test
     public void testHiveTable() throws Exception {
-        ResolvedSchema schema =
+        final ResolvedSchema schema =
                 ResolvedSchema.of(
                         Column.physical("name", DataTypes.STRING()),
                         Column.physical("age", DataTypes.INT()));
 
-        Map<String, String> properties = new HashMap<>();
-        properties.put(FactoryUtil.CONNECTOR.key(), SqlCreateHiveTable.IDENTIFIER);
-
         catalog.createDatabase("mydb", new CatalogDatabaseImpl(new HashMap<>(), ""), true);
-        ObjectPath path = new ObjectPath("mydb", "mytable");
-        CatalogTable table =
-                new CatalogTableImpl(
-                        TableSchema.fromResolvedSchema(schema), properties, "hive table");
-        catalog.createTable(path, table, true);
 
-        DynamicTableSource tableSource =
-                FactoryUtil.createTableSource(
-                        catalog,
+        final Map<String, String> options =
+                Collections.singletonMap(
+                        FactoryUtil.CONNECTOR.key(), SqlCreateHiveTable.IDENTIFIER);
+        final CatalogTable table =
+                new CatalogTableImpl(TableSchema.fromResolvedSchema(schema), options, "hive table");
+        catalog.createTable(new ObjectPath("mydb", "mytable"), table, true);
+
+        final DynamicTableSource tableSource =
+                FactoryUtil.createDynamicTableSource(
+                        (DynamicTableSourceFactory)
+                                catalog.getFactory().orElseThrow(IllegalStateException::new),
                         ObjectIdentifier.of("mycatalog", "mydb", "mytable"),
                         new ResolvedCatalogTable(table, schema),
                         new Configuration(),
@@ -132,7 +136,7 @@ public class HiveTableFactoryTest {
                         false);
         assertTrue(tableSource instanceof HiveTableSource);
 
-        DynamicTableSink tableSink =
+        final DynamicTableSink tableSink =
                 FactoryUtil.createTableSink(
                         catalog,
                         ObjectIdentifier.of("mycatalog", "mydb", "mytable"),

--- a/flink-core/src/main/java/org/apache/flink/util/OptionalUtils.java
+++ b/flink-core/src/main/java/org/apache/flink/util/OptionalUtils.java
@@ -1,0 +1,53 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.flink.util;
+
+import org.apache.flink.annotation.Internal;
+
+import java.util.Optional;
+import java.util.stream.Stream;
+
+/** Utilities for working with {@link Optional}. */
+@Internal
+public class OptionalUtils {
+
+    /**
+     * Converts the given {@link Optional} into a {@link Stream}.
+     *
+     * <p>This is akin to {@code Optional#stream} available in JDK9+.
+     */
+    @SuppressWarnings("OptionalUsedAsFieldOrParameterType")
+    public static <T> Stream<T> stream(Optional<T> opt) {
+        return opt.map(Stream::of).orElseGet(Stream::empty);
+    }
+
+    /** Returns the first {@link Optional} which is present. */
+    @SafeVarargs
+    public static <T> Optional<T> firstPresent(Optional<T>... opts) {
+        for (Optional<T> opt : opts) {
+            if (opt.isPresent()) {
+                return opt;
+            }
+        }
+
+        return Optional.empty();
+    }
+
+    private OptionalUtils() {}
+}

--- a/flink-table/flink-sql-client/src/main/java/org/apache/flink/table/client/gateway/context/ExecutionContext.java
+++ b/flink-table/flink-sql-client/src/main/java/org/apache/flink/table/client/gateway/context/ExecutionContext.java
@@ -135,7 +135,12 @@ public class ExecutionContext {
 
         final Planner planner =
                 PlannerFactoryUtil.createPlanner(
-                        settings.getPlanner(), executor, config, catalogManager, functionCatalog);
+                        settings.getPlanner(),
+                        executor,
+                        config,
+                        moduleManager,
+                        catalogManager,
+                        functionCatalog);
 
         return new StreamTableEnvironmentImpl(
                 catalogManager,

--- a/flink-table/flink-sql-client/src/test/java/org/apache/flink/table/client/SqlClientTest.java
+++ b/flink-table/flink-sql-client/src/test/java/org/apache/flink/table/client/SqlClientTest.java
@@ -144,7 +144,7 @@ public class SqlClientTest {
         String[] errorStack =
                 new String[] {
                     "at org.apache.flink.table.factories.FactoryUtil.discoverFactory",
-                    "at org.apache.flink.table.factories.FactoryUtil.createTableSource"
+                    "at org.apache.flink.table.factories.FactoryUtil.createSource"
                 };
         for (String stack : errorStack) {
             assertThat(output, not(containsString(stack)));
@@ -165,7 +165,7 @@ public class SqlClientTest {
                 new String[] {
                     "org.apache.flink.table.api.ValidationException: Could not find any factory for identifier 'invalid'",
                     "at org.apache.flink.table.factories.FactoryUtil.discoverFactory",
-                    "at org.apache.flink.table.factories.FactoryUtil.createTableSource"
+                    "at org.apache.flink.table.factories.FactoryUtil.createSource"
                 };
         for (String error : errors) {
             assertThat(output, containsString(error));

--- a/flink-table/flink-sql-client/src/test/java/org/apache/flink/table/client/SqlClientTest.java
+++ b/flink-table/flink-sql-client/src/test/java/org/apache/flink/table/client/SqlClientTest.java
@@ -144,7 +144,7 @@ public class SqlClientTest {
         String[] errorStack =
                 new String[] {
                     "at org.apache.flink.table.factories.FactoryUtil.discoverFactory",
-                    "at org.apache.flink.table.factories.FactoryUtil.createSource"
+                    "at org.apache.flink.table.factories.FactoryUtil.createDynamicTableSource"
                 };
         for (String stack : errorStack) {
             assertThat(output, not(containsString(stack)));
@@ -165,7 +165,7 @@ public class SqlClientTest {
                 new String[] {
                     "org.apache.flink.table.api.ValidationException: Could not find any factory for identifier 'invalid'",
                     "at org.apache.flink.table.factories.FactoryUtil.discoverFactory",
-                    "at org.apache.flink.table.factories.FactoryUtil.createSource"
+                    "at org.apache.flink.table.factories.FactoryUtil.createDynamicTableSource"
                 };
         for (String error : errors) {
             assertThat(output, containsString(error));

--- a/flink-table/flink-table-api-java-bridge/src/main/java/org/apache/flink/table/api/bridge/java/internal/StreamTableEnvironmentImpl.java
+++ b/flink-table/flink-table-api-java-bridge/src/main/java/org/apache/flink/table/api/bridge/java/internal/StreamTableEnvironmentImpl.java
@@ -152,6 +152,7 @@ public final class StreamTableEnvironmentImpl extends TableEnvironmentImpl
                         settings.getPlanner(),
                         executor,
                         tableConfig,
+                        moduleManager,
                         catalogManager,
                         functionCatalog);
 

--- a/flink-table/flink-table-api-java/src/main/java/org/apache/flink/table/api/internal/TableEnvironmentImpl.java
+++ b/flink-table/flink-table-api-java/src/main/java/org/apache/flink/table/api/internal/TableEnvironmentImpl.java
@@ -303,6 +303,7 @@ public class TableEnvironmentImpl implements TableEnvironmentInternal {
                         settings.getPlanner(),
                         executor,
                         tableConfig,
+                        moduleManager,
                         catalogManager,
                         functionCatalog);
 

--- a/flink-table/flink-table-api-java/src/main/java/org/apache/flink/table/delegation/PlannerFactory.java
+++ b/flink-table/flink-table-api-java/src/main/java/org/apache/flink/table/delegation/PlannerFactory.java
@@ -23,6 +23,7 @@ import org.apache.flink.table.api.TableConfig;
 import org.apache.flink.table.catalog.CatalogManager;
 import org.apache.flink.table.catalog.FunctionCatalog;
 import org.apache.flink.table.factories.Factory;
+import org.apache.flink.table.module.ModuleManager;
 
 /**
  * Factory that creates {@link Planner}.
@@ -50,6 +51,9 @@ public interface PlannerFactory extends Factory {
         /** The configuration of the planner to use. */
         TableConfig getTableConfig();
 
+        /** The module manager. */
+        ModuleManager getModuleManager();
+
         /** The catalog manager to look up tables and views. */
         CatalogManager getCatalogManager();
 
@@ -61,16 +65,19 @@ public interface PlannerFactory extends Factory {
     class DefaultPlannerContext implements Context {
         private final Executor executor;
         private final TableConfig tableConfig;
+        private final ModuleManager moduleManager;
         private final CatalogManager catalogManager;
         private final FunctionCatalog functionCatalog;
 
         public DefaultPlannerContext(
                 Executor executor,
                 TableConfig tableConfig,
+                ModuleManager moduleManager,
                 CatalogManager catalogManager,
                 FunctionCatalog functionCatalog) {
             this.executor = executor;
             this.tableConfig = tableConfig;
+            this.moduleManager = moduleManager;
             this.catalogManager = catalogManager;
             this.functionCatalog = functionCatalog;
         }
@@ -83,6 +90,11 @@ public interface PlannerFactory extends Factory {
         @Override
         public TableConfig getTableConfig() {
             return tableConfig;
+        }
+
+        @Override
+        public ModuleManager getModuleManager() {
+            return moduleManager;
         }
 
         @Override

--- a/flink-table/flink-table-api-java/src/main/java/org/apache/flink/table/factories/PlannerFactoryUtil.java
+++ b/flink-table/flink-table-api-java/src/main/java/org/apache/flink/table/factories/PlannerFactoryUtil.java
@@ -27,6 +27,7 @@ import org.apache.flink.table.delegation.Planner;
 import org.apache.flink.table.delegation.PlannerFactory;
 import org.apache.flink.table.delegation.PlannerFactory.Context;
 import org.apache.flink.table.delegation.PlannerFactory.DefaultPlannerContext;
+import org.apache.flink.table.module.ModuleManager;
 
 /** Utility for discovering and instantiating {@link PlannerFactory}. */
 @Internal
@@ -37,6 +38,7 @@ public class PlannerFactoryUtil {
             String plannerIdentifier,
             Executor executor,
             TableConfig tableConfig,
+            ModuleManager moduleManager,
             CatalogManager catalogManager,
             FunctionCatalog functionCatalog) {
         final PlannerFactory plannerFactory =
@@ -46,7 +48,8 @@ public class PlannerFactoryUtil {
                         plannerIdentifier);
 
         final Context context =
-                new DefaultPlannerContext(executor, tableConfig, catalogManager, functionCatalog);
+                new DefaultPlannerContext(
+                        executor, tableConfig, moduleManager, catalogManager, functionCatalog);
         return plannerFactory.create(context);
     }
 

--- a/flink-table/flink-table-api-java/src/main/java/org/apache/flink/table/module/ModuleManager.java
+++ b/flink-table/flink-table-api-java/src/main/java/org/apache/flink/table/module/ModuleManager.java
@@ -18,6 +18,7 @@
 
 package org.apache.flink.table.module;
 
+import org.apache.flink.annotation.Internal;
 import org.apache.flink.annotation.VisibleForTesting;
 import org.apache.flink.table.api.ValidationException;
 import org.apache.flink.table.functions.FunctionDefinition;
@@ -44,15 +45,16 @@ import static org.apache.flink.util.Preconditions.checkNotNull;
  * Responsible for loading/unloading modules, managing their life cycles, and resolving module
  * objects.
  */
+@Internal
 public class ModuleManager {
 
     private static final Logger LOG = LoggerFactory.getLogger(ModuleManager.class);
 
     /** To keep {@link #listFullModules()} deterministic. */
-    private LinkedHashMap<String, Module> loadedModules;
+    private final LinkedHashMap<String, Module> loadedModules;
 
     /** Keep tracking used modules with resolution order. */
-    private List<String> usedModules;
+    private final List<String> usedModules;
 
     public ModuleManager() {
         this.loadedModules = new LinkedHashMap<>();

--- a/flink-table/flink-table-api-java/src/main/java/org/apache/flink/table/module/ModuleManager.java
+++ b/flink-table/flink-table-api-java/src/main/java/org/apache/flink/table/module/ModuleManager.java
@@ -21,6 +21,7 @@ package org.apache.flink.table.module;
 import org.apache.flink.annotation.Internal;
 import org.apache.flink.annotation.VisibleForTesting;
 import org.apache.flink.table.api.ValidationException;
+import org.apache.flink.table.factories.Factory;
 import org.apache.flink.table.functions.FunctionDefinition;
 import org.apache.flink.util.StringUtils;
 
@@ -36,6 +37,7 @@ import java.util.List;
 import java.util.Map;
 import java.util.Optional;
 import java.util.Set;
+import java.util.function.Function;
 import java.util.stream.Collectors;
 
 import static org.apache.flink.util.Preconditions.checkArgument;
@@ -183,6 +185,25 @@ public class ModuleManager {
         }
 
         LOG.debug("Cannot find FunctionDefinition '{}' from any loaded modules.", name);
+        return Optional.empty();
+    }
+
+    /**
+     * Returns the first factory found in the loaded modules given a selector.
+     *
+     * <p>Modules are checked in the order in which they have been loaded. The first factory
+     * returned by a module will be used. If no loaded module provides a factory, {@link
+     * Optional#empty()} is returned.
+     */
+    @SuppressWarnings("unchecked")
+    public <T extends Factory> Optional<T> getFactory(Function<Module, Optional<T>> selector) {
+        for (final String moduleName : usedModules) {
+            final Optional<T> factory = selector.apply(loadedModules.get(moduleName));
+            if (factory.isPresent()) {
+                return factory;
+            }
+        }
+
         return Optional.empty();
     }
 

--- a/flink-table/flink-table-api-scala-bridge/src/main/scala/org/apache/flink/table/api/bridge/scala/internal/StreamTableEnvironmentImpl.scala
+++ b/flink-table/flink-table-api-scala-bridge/src/main/scala/org/apache/flink/table/api/bridge/scala/internal/StreamTableEnvironmentImpl.scala
@@ -492,7 +492,7 @@ object StreamTableEnvironmentImpl {
     val executor = lookupExecutor(classLoader, settings.getExecutor, executionEnvironment)
 
     val planner = PlannerFactoryUtil.createPlanner(settings.getPlanner, executor, tableConfig,
-      catalogManager, functionCatalog)
+      moduleManager, catalogManager, functionCatalog)
 
     new StreamTableEnvironmentImpl(
       catalogManager,

--- a/flink-table/flink-table-common/src/main/java/org/apache/flink/table/factories/FactoryUtil.java
+++ b/flink-table/flink-table-common/src/main/java/org/apache/flink/table/factories/FactoryUtil.java
@@ -127,10 +127,12 @@ public final class FactoryUtil {
     /**
      * Creates a {@link DynamicTableSource} from a {@link CatalogTable}.
      *
-     * <p>It considers {@link Catalog#getFactory()} if provided.
+     * <p>If {@param preferredFactory} is passed, the table source is created from that factory.
+     * Otherwise, an attempt is made to discover a matching factory using Java SPI (see {@link
+     * Factory} for details).
      */
-    public static DynamicTableSource createTableSource(
-            @Nullable Catalog catalog,
+    public static DynamicTableSource createDynamicTableSource(
+            @Nullable DynamicTableSourceFactory preferredFactory,
             ObjectIdentifier objectIdentifier,
             ResolvedCatalogTable catalogTable,
             ReadableConfig configuration,
@@ -141,7 +143,9 @@ public final class FactoryUtil {
                         objectIdentifier, catalogTable, configuration, classLoader, isTemporary);
         try {
             final DynamicTableSourceFactory factory =
-                    getDynamicTableFactory(DynamicTableSourceFactory.class, catalog, context);
+                    preferredFactory != null
+                            ? preferredFactory
+                            : discoverTableFactory(DynamicTableSourceFactory.class, context);
             return factory.createDynamicTableSource(context);
         } catch (Throwable t) {
             throw new ValidationException(
@@ -156,6 +160,35 @@ public final class FactoryUtil {
                                     .collect(Collectors.joining("\n"))),
                     t);
         }
+    }
+
+    /**
+     * Creates a {@link DynamicTableSource} from a {@link CatalogTable}.
+     *
+     * <p>It considers {@link Catalog#getFactory()} if provided.
+     *
+     * @deprecated Use {@link #createDynamicTableSource(DynamicTableSourceFactory, ObjectIdentifier,
+     *     ResolvedCatalogTable, ReadableConfig, ClassLoader, boolean)} instead.
+     */
+    @Deprecated
+    public static DynamicTableSource createTableSource(
+            @Nullable Catalog catalog,
+            ObjectIdentifier objectIdentifier,
+            ResolvedCatalogTable catalogTable,
+            ReadableConfig configuration,
+            ClassLoader classLoader,
+            boolean isTemporary) {
+        final DefaultDynamicTableContext context =
+                new DefaultDynamicTableContext(
+                        objectIdentifier, catalogTable, configuration, classLoader, isTemporary);
+
+        return createDynamicTableSource(
+                getDynamicTableFactory(DynamicTableSourceFactory.class, catalog, context),
+                objectIdentifier,
+                catalogTable,
+                configuration,
+                classLoader,
+                isTemporary);
     }
 
     /**
@@ -533,19 +566,24 @@ public final class FactoryUtil {
 
     @SuppressWarnings("unchecked")
     private static <T extends DynamicTableFactory> T getDynamicTableFactory(
-            Class<T> factoryClass, @Nullable Catalog catalog, DefaultDynamicTableContext context) {
-        // catalog factory has highest precedence
-        if (catalog != null) {
-            final Factory factory =
-                    catalog.getFactory()
-                            .filter(f -> factoryClass.isAssignableFrom(f.getClass()))
-                            .orElse(null);
-            if (factory != null) {
-                return (T) factory;
-            }
+            Class<T> factoryClass, @Nullable Catalog catalog, DynamicTableFactory.Context context) {
+        return getDynamicTableFactory(factoryClass, catalog)
+                .orElseGet(() -> discoverTableFactory(factoryClass, context));
+    }
+
+    @SuppressWarnings("unchecked")
+    private static <T extends DynamicTableFactory> Optional<T> getDynamicTableFactory(
+            Class<T> factoryClass, @Nullable Catalog catalog) {
+        if (catalog == null) {
+            return Optional.empty();
         }
 
-        // fallback to factory discovery
+        return catalog.getFactory()
+                .map(f -> factoryClass.isAssignableFrom(f.getClass()) ? (T) f : null);
+    }
+
+    private static <T extends DynamicTableFactory> T discoverTableFactory(
+            Class<T> factoryClass, DynamicTableFactory.Context context) {
         final String connectorOption = context.getCatalogTable().getOptions().get(CONNECTOR.key());
         if (connectorOption == null) {
             throw new ValidationException(
@@ -574,7 +612,7 @@ public final class FactoryUtil {
     }
 
     private static ValidationException enrichNoMatchingConnectorError(
-            Class<?> factoryClass, DefaultDynamicTableContext context, String connectorOption) {
+            Class<?> factoryClass, DynamicTableFactory.Context context, String connectorOption) {
         final DynamicTableFactory factory;
         try {
             factory =

--- a/flink-table/flink-table-common/src/main/java/org/apache/flink/table/module/Module.java
+++ b/flink-table/flink-table-common/src/main/java/org/apache/flink/table/module/Module.java
@@ -19,6 +19,7 @@
 package org.apache.flink.table.module;
 
 import org.apache.flink.annotation.PublicEvolving;
+import org.apache.flink.table.factories.DynamicTableSourceFactory;
 import org.apache.flink.table.functions.FunctionDefinition;
 
 import java.util.Collections;
@@ -49,6 +50,27 @@ public interface Module {
      * @return an optional function definition
      */
     default Optional<FunctionDefinition> getFunctionDefinition(String name) {
+        return Optional.empty();
+    }
+
+    /**
+     * Returns a {@link DynamicTableSourceFactory} for creating source tables.
+     *
+     * <p>A factory is determined with the following precedence rule:
+     *
+     * <ul>
+     *   <li>1. Factory provided by the corresponding catalog of a persisted table.
+     *   <li>2. Factory provided by a module.
+     *   <li>3. Factory discovered using Java SPI.
+     * </ul>
+     *
+     * <p>This will be called on loaded modules in the order in which they have been loaded. The
+     * first factory returned will be used.
+     *
+     * <p>This method can be useful to disable Java SPI completely or influence how temporary table
+     * sources should be created without a corresponding catalog.
+     */
+    default Optional<DynamicTableSourceFactory> getTableSourceFactory() {
         return Optional.empty();
     }
 

--- a/flink-table/flink-table-common/src/main/java/org/apache/flink/table/module/Module.java
+++ b/flink-table/flink-table-common/src/main/java/org/apache/flink/table/module/Module.java
@@ -19,6 +19,7 @@
 package org.apache.flink.table.module;
 
 import org.apache.flink.annotation.PublicEvolving;
+import org.apache.flink.table.factories.DynamicTableSinkFactory;
 import org.apache.flink.table.factories.DynamicTableSourceFactory;
 import org.apache.flink.table.functions.FunctionDefinition;
 
@@ -71,6 +72,27 @@ public interface Module {
      * sources should be created without a corresponding catalog.
      */
     default Optional<DynamicTableSourceFactory> getTableSourceFactory() {
+        return Optional.empty();
+    }
+
+    /**
+     * Returns a {@link DynamicTableSinkFactory} for creating sink tables.
+     *
+     * <p>A factory is determined with the following precedence rule:
+     *
+     * <ul>
+     *   <li>1. Factory provided by the corresponding catalog of a persisted table.
+     *   <li>2. Factory provided by a module.
+     *   <li>3. Factory discovered using Java SPI.
+     * </ul>
+     *
+     * <p>This will be called on loaded modules in the order in which they have been loaded. The
+     * first factory returned will be used.
+     *
+     * <p>This method can be useful to disable Java SPI completely or influence how temporary table
+     * sinks should be created without a corresponding catalog.
+     */
+    default Optional<DynamicTableSinkFactory> getTableSinkFactory() {
         return Optional.empty();
     }
 

--- a/flink-table/flink-table-common/src/test/java/org/apache/flink/table/factories/utils/FactoryMocks.java
+++ b/flink-table/flink-table-common/src/test/java/org/apache/flink/table/factories/utils/FactoryMocks.java
@@ -77,7 +77,7 @@ public final class FactoryMocks {
 
     public static DynamicTableSink createTableSink(
             ResolvedSchema schema, List<String> partitionKeys, Map<String, String> options) {
-        return FactoryUtil.createTableSink(
+        return FactoryUtil.createDynamicTableSink(
                 null,
                 IDENTIFIER,
                 new ResolvedCatalogTable(

--- a/flink-table/flink-table-common/src/test/java/org/apache/flink/table/factories/utils/FactoryMocks.java
+++ b/flink-table/flink-table-common/src/test/java/org/apache/flink/table/factories/utils/FactoryMocks.java
@@ -55,7 +55,7 @@ public final class FactoryMocks {
 
     public static DynamicTableSource createTableSource(
             ResolvedSchema schema, Map<String, String> options) {
-        return FactoryUtil.createTableSource(
+        return FactoryUtil.createDynamicTableSource(
                 null,
                 IDENTIFIER,
                 new ResolvedCatalogTable(

--- a/flink-table/flink-table-planner/src/main/java/org/apache/flink/table/planner/delegation/DefaultPlannerFactory.java
+++ b/flink-table/flink-table-planner/src/main/java/org/apache/flink/table/planner/delegation/DefaultPlannerFactory.java
@@ -57,12 +57,14 @@ public final class DefaultPlannerFactory implements PlannerFactory {
                 return new StreamPlanner(
                         context.getExecutor(),
                         context.getTableConfig(),
+                        context.getModuleManager(),
                         context.getFunctionCatalog(),
                         context.getCatalogManager());
             case BATCH:
                 return new BatchPlanner(
                         context.getExecutor(),
                         context.getTableConfig(),
+                        context.getModuleManager(),
                         context.getFunctionCatalog(),
                         context.getCatalogManager());
             default:

--- a/flink-table/flink-table-planner/src/main/java/org/apache/flink/table/planner/delegation/PlannerContext.java
+++ b/flink-table/flink-table-planner/src/main/java/org/apache/flink/table/planner/delegation/PlannerContext.java
@@ -25,6 +25,7 @@ import org.apache.flink.table.api.TableConfig;
 import org.apache.flink.table.api.TableException;
 import org.apache.flink.table.catalog.CatalogManager;
 import org.apache.flink.table.catalog.FunctionCatalog;
+import org.apache.flink.table.module.ModuleManager;
 import org.apache.flink.table.planner.calcite.CalciteConfig;
 import org.apache.flink.table.planner.calcite.CalciteConfig$;
 import org.apache.flink.table.planner.calcite.FlinkContext;
@@ -104,6 +105,7 @@ public class PlannerContext {
     public PlannerContext(
             boolean isBatchMode,
             TableConfig tableConfig,
+            ModuleManager moduleManager,
             FunctionCatalog functionCatalog,
             CatalogManager catalogManager,
             CalciteSchema rootSchema,
@@ -114,6 +116,7 @@ public class PlannerContext {
                 new FlinkContextImpl(
                         isBatchMode,
                         tableConfig,
+                        moduleManager,
                         functionCatalog,
                         catalogManager,
                         rexConverterFactory);

--- a/flink-table/flink-table-planner/src/main/java/org/apache/flink/table/planner/plan/abilities/source/SourceAbilityContext.java
+++ b/flink-table/flink-table-planner/src/main/java/org/apache/flink/table/planner/plan/abilities/source/SourceAbilityContext.java
@@ -22,6 +22,7 @@ import org.apache.flink.table.api.TableConfig;
 import org.apache.flink.table.catalog.CatalogManager;
 import org.apache.flink.table.catalog.FunctionCatalog;
 import org.apache.flink.table.connector.source.DynamicTableSource;
+import org.apache.flink.table.module.ModuleManager;
 import org.apache.flink.table.planner.calcite.FlinkContext;
 import org.apache.flink.table.planner.calcite.FlinkTypeFactory;
 import org.apache.flink.table.planner.calcite.SqlExprToRexConverterFactory;
@@ -69,6 +70,11 @@ public class SourceAbilityContext implements FlinkContext {
     @Override
     public CatalogManager getCatalogManager() {
         return context.getCatalogManager();
+    }
+
+    @Override
+    public ModuleManager getModuleManager() {
+        return context.getModuleManager();
     }
 
     @Override

--- a/flink-table/flink-table-planner/src/main/java/org/apache/flink/table/planner/plan/nodes/exec/batch/BatchExecSink.java
+++ b/flink-table/flink-table-planner/src/main/java/org/apache/flink/table/planner/plan/nodes/exec/batch/BatchExecSink.java
@@ -43,7 +43,7 @@ public class BatchExecSink extends CommonExecSink implements BatchExecNode<Objec
             String description) {
         super(
                 tableSinkSpec,
-                tableSinkSpec.getTableSink().getChangelogMode(ChangelogMode.insertOnly()),
+                ChangelogMode.insertOnly(),
                 true, // isBounded
                 getNewNodeId(),
                 Collections.singletonList(inputProperty),
@@ -56,7 +56,6 @@ public class BatchExecSink extends CommonExecSink implements BatchExecNode<Objec
     protected Transformation<Object> translateToPlanInternal(PlannerBase planner) {
         final Transformation<RowData> inputTransform =
                 (Transformation<RowData>) getInputEdges().get(0).translateToPlan(planner);
-        return createSinkTransformation(
-                planner.getExecEnv(), planner.getTableConfig(), inputTransform, -1, false);
+        return createSinkTransformation(planner, inputTransform, -1, false);
     }
 }

--- a/flink-table/flink-table-planner/src/main/java/org/apache/flink/table/planner/plan/nodes/exec/common/CommonExecSink.java
+++ b/flink-table/flink-table-planner/src/main/java/org/apache/flink/table/planner/plan/nodes/exec/common/CommonExecSink.java
@@ -48,6 +48,7 @@ import org.apache.flink.table.connector.sink.SinkProvider;
 import org.apache.flink.table.data.RowData;
 import org.apache.flink.table.planner.codegen.EqualiserCodeGenerator;
 import org.apache.flink.table.planner.connectors.TransformationSinkProvider;
+import org.apache.flink.table.planner.delegation.PlannerBase;
 import org.apache.flink.table.planner.plan.nodes.exec.ExecNode;
 import org.apache.flink.table.planner.plan.nodes.exec.ExecNodeBase;
 import org.apache.flink.table.planner.plan.nodes.exec.InputProperty;
@@ -109,12 +110,12 @@ public abstract class CommonExecSink extends ExecNodeBase<Object>
 
     @SuppressWarnings("unchecked")
     protected Transformation<Object> createSinkTransformation(
-            StreamExecutionEnvironment env,
-            TableConfig tableConfig,
+            PlannerBase planner,
             Transformation<RowData> inputTransform,
             int rowtimeFieldIndex,
             boolean upsertMaterialize) {
-        final DynamicTableSink tableSink = tableSinkSpec.getTableSink();
+        final DynamicTableSink tableSink = tableSinkSpec.getTableSink(planner);
+        final ChangelogMode inputChangelogMode = tableSink.getChangelogMode(changelogMode);
         final ResolvedSchema schema = tableSinkSpec.getCatalogTable().getResolvedSchema();
 
         final SinkRuntimeProvider runtimeProvider =
@@ -127,9 +128,15 @@ public abstract class CommonExecSink extends ExecNodeBase<Object>
         final int sinkParallelism = deriveSinkParallelism(inputTransform, runtimeProvider);
 
         Transformation<RowData> sinkTransform =
-                applyNotNullEnforcer(inputTransform, tableConfig, physicalRowType);
+                applyNotNullEnforcer(inputTransform, planner.getTableConfig(), physicalRowType);
 
-        sinkTransform = applyKeyBy(sinkTransform, primaryKeys, sinkParallelism, upsertMaterialize);
+        sinkTransform =
+                applyKeyBy(
+                        inputChangelogMode,
+                        sinkTransform,
+                        primaryKeys,
+                        sinkParallelism,
+                        upsertMaterialize);
 
         if (upsertMaterialize) {
             sinkTransform =
@@ -137,13 +144,17 @@ public abstract class CommonExecSink extends ExecNodeBase<Object>
                             sinkTransform,
                             primaryKeys,
                             sinkParallelism,
-                            tableConfig,
+                            planner.getTableConfig(),
                             physicalRowType);
         }
 
         return (Transformation<Object>)
                 applySinkProvider(
-                        sinkTransform, env, runtimeProvider, rowtimeFieldIndex, sinkParallelism);
+                        sinkTransform,
+                        planner.getExecEnv(),
+                        runtimeProvider,
+                        rowtimeFieldIndex,
+                        sinkParallelism);
     }
 
     /**
@@ -220,12 +231,13 @@ public abstract class CommonExecSink extends ExecNodeBase<Object>
      * messages.
      */
     private Transformation<RowData> applyKeyBy(
+            ChangelogMode inputChangelogMode,
             Transformation<RowData> inputTransform,
             int[] primaryKeys,
             int sinkParallelism,
             boolean upsertMaterialize) {
         final int inputParallelism = inputTransform.getParallelism();
-        if ((inputParallelism == sinkParallelism || changelogMode.containsOnly(RowKind.INSERT))
+        if ((inputParallelism == sinkParallelism || inputChangelogMode.containsOnly(RowKind.INSERT))
                 && !upsertMaterialize) {
             return inputTransform;
         }

--- a/flink-table/flink-table-planner/src/main/java/org/apache/flink/table/planner/plan/nodes/exec/spec/DynamicTableSinkSpec.java
+++ b/flink-table/flink-table-planner/src/main/java/org/apache/flink/table/planner/plan/nodes/exec/spec/DynamicTableSinkSpec.java
@@ -21,7 +21,10 @@ package org.apache.flink.table.planner.plan.nodes.exec.spec;
 import org.apache.flink.table.catalog.ObjectIdentifier;
 import org.apache.flink.table.catalog.ResolvedCatalogTable;
 import org.apache.flink.table.connector.sink.DynamicTableSink;
+import org.apache.flink.table.factories.DynamicTableSinkFactory;
 import org.apache.flink.table.factories.FactoryUtil;
+import org.apache.flink.table.module.Module;
+import org.apache.flink.table.planner.delegation.PlannerBase;
 import org.apache.flink.table.planner.plan.abilities.sink.SinkAbilitySpec;
 
 import org.apache.flink.shaded.jackson2.com.fasterxml.jackson.annotation.JsonCreator;
@@ -59,11 +62,17 @@ public class DynamicTableSinkSpec extends CatalogTableSpecBase {
         this.sinkAbilitySpecs = sinkAbilitySpecs;
     }
 
-    public DynamicTableSink getTableSink() {
+    public DynamicTableSink getTableSink(PlannerBase planner) {
         if (tableSink == null) {
+            final DynamicTableSinkFactory factory =
+                    planner.getFlinkContext()
+                            .getModuleManager()
+                            .getFactory(Module::getTableSinkFactory)
+                            .orElse(null);
+
             tableSink =
-                    FactoryUtil.createTableSink(
-                            null, // catalog, TODO support create Factory from catalog
+                    FactoryUtil.createDynamicTableSink(
+                            factory,
                             objectIdentifier,
                             catalogTable,
                             configuration,

--- a/flink-table/flink-table-planner/src/main/java/org/apache/flink/table/planner/plan/nodes/exec/spec/DynamicTableSourceSpec.java
+++ b/flink-table/flink-table-planner/src/main/java/org/apache/flink/table/planner/plan/nodes/exec/spec/DynamicTableSourceSpec.java
@@ -24,7 +24,9 @@ import org.apache.flink.table.catalog.ResolvedCatalogTable;
 import org.apache.flink.table.connector.source.DynamicTableSource;
 import org.apache.flink.table.connector.source.LookupTableSource;
 import org.apache.flink.table.connector.source.ScanTableSource;
+import org.apache.flink.table.factories.DynamicTableSourceFactory;
 import org.apache.flink.table.factories.FactoryUtil;
+import org.apache.flink.table.module.Module;
 import org.apache.flink.table.planner.delegation.PlannerBase;
 import org.apache.flink.table.planner.plan.abilities.source.SourceAbilityContext;
 import org.apache.flink.table.planner.plan.abilities.source.SourceAbilitySpec;
@@ -71,9 +73,16 @@ public class DynamicTableSourceSpec extends CatalogTableSpecBase {
     private DynamicTableSource getTableSource(PlannerBase planner) {
         checkNotNull(configuration);
         if (tableSource == null) {
+            final DynamicTableSourceFactory factory =
+                    planner.getFlinkContext()
+                            .getModuleManager()
+                            .getFactory(Module::getTableSourceFactory)
+                            .orElse(null);
+
             tableSource =
-                    FactoryUtil.createTableSource(
-                            null, // catalog, TODO support create Factory from catalog
+                    FactoryUtil.createDynamicTableSource(
+                            // TODO Support creating from a catalog
+                            factory,
                             objectIdentifier,
                             catalogTable,
                             configuration,

--- a/flink-table/flink-table-planner/src/main/java/org/apache/flink/table/planner/plan/nodes/exec/stream/StreamExecSink.java
+++ b/flink-table/flink-table-planner/src/main/java/org/apache/flink/table/planner/plan/nodes/exec/stream/StreamExecSink.java
@@ -75,7 +75,7 @@ public class StreamExecSink extends CommonExecSink implements StreamExecNode<Obj
             String description) {
         super(
                 tableSinkSpec,
-                tableSinkSpec.getTableSink().getChangelogMode(inputChangelogMode),
+                inputChangelogMode,
                 false, // isBounded
                 getNewNodeId(),
                 Collections.singletonList(inputProperty),
@@ -96,7 +96,7 @@ public class StreamExecSink extends CommonExecSink implements StreamExecNode<Obj
             @JsonProperty(FIELD_NAME_DESCRIPTION) String description) {
         super(
                 tableSinkSpec,
-                tableSinkSpec.getTableSink().getChangelogMode(inputChangelogMode),
+                inputChangelogMode,
                 false, // isBounded
                 id,
                 inputProperties,
@@ -138,10 +138,6 @@ public class StreamExecSink extends CommonExecSink implements StreamExecNode<Obj
         }
 
         return createSinkTransformation(
-                planner.getExecEnv(),
-                planner.getTableConfig(),
-                inputTransform,
-                rowtimeFieldIndex,
-                upsertMaterialize);
+                planner, inputTransform, rowtimeFieldIndex, upsertMaterialize);
     }
 }

--- a/flink-table/flink-table-planner/src/main/scala/org/apache/flink/table/planner/calcite/FlinkContext.scala
+++ b/flink-table/flink-table-planner/src/main/scala/org/apache/flink/table/planner/calcite/FlinkContext.scala
@@ -20,6 +20,7 @@ package org.apache.flink.table.planner.calcite
 
 import org.apache.flink.table.api.TableConfig
 import org.apache.flink.table.catalog.{CatalogManager, FunctionCatalog}
+import org.apache.flink.table.module.ModuleManager
 
 import org.apache.calcite.plan.Context
 
@@ -28,29 +29,22 @@ import org.apache.calcite.plan.Context
   */
 trait FlinkContext extends Context {
 
-  /**
-   * Returns whether the planner runs in batch mode.
-   */
+  /** Returns whether the planner is in batch mode. */
   def isBatchMode: Boolean
 
-  /**
-    * Gets [[TableConfig]] instance defined in [[org.apache.flink.table.api.TableEnvironment]].
-    */
+  /** Returns the [[TableConfig]] defined in [[org.apache.flink.table.api.TableEnvironment]]. */
   def getTableConfig: TableConfig
 
-  /**
-    * Gets [[FunctionCatalog]] instance defined in [[org.apache.flink.table.api.TableEnvironment]].
-    */
+  /** Returns the [[FunctionCatalog]] defined in [[org.apache.flink.table.api.TableEnvironment]]. */
   def getFunctionCatalog: FunctionCatalog
 
-  /**
-    * Gets [[CatalogManager]] instance defined in [[org.apache.flink.table.api.TableEnvironment]].
-    */
+  /** Returns the [[CatalogManager]] defined in [[org.apache.flink.table.api.TableEnvironment]]. */
   def getCatalogManager: CatalogManager
 
-  /**
-    * Gets [[SqlExprToRexConverterFactory]] instance to convert sql expression to rex node.
-    */
+  /** Returns the [[ModuleManager]] defined in [[org.apache.flink.table.api.TableEnvironment]]. */
+  def getModuleManager: ModuleManager
+
+  /** Returns the [[SqlExprToRexConverterFactory]] to convert SQL expressions to rex nodes. */
   def getSqlExprToRexConverterFactory: SqlExprToRexConverterFactory
 
   override def unwrap[C](clazz: Class[C]): C = {

--- a/flink-table/flink-table-planner/src/main/scala/org/apache/flink/table/planner/calcite/FlinkContextImpl.scala
+++ b/flink-table/flink-table-planner/src/main/scala/org/apache/flink/table/planner/calcite/FlinkContextImpl.scala
@@ -20,10 +20,12 @@ package org.apache.flink.table.planner.calcite
 
 import org.apache.flink.table.api.TableConfig
 import org.apache.flink.table.catalog.{CatalogManager, FunctionCatalog}
+import org.apache.flink.table.module.ModuleManager
 
 class FlinkContextImpl(
     inBatchMode: Boolean,
     tableConfig: TableConfig,
+    moduleManager: ModuleManager,
     functionCatalog: FunctionCatalog,
     catalogManager: CatalogManager,
     toRexFactory: SqlExprToRexConverterFactory)
@@ -32,6 +34,8 @@ class FlinkContextImpl(
   override def isBatchMode: Boolean = inBatchMode
 
   override def getTableConfig: TableConfig = tableConfig
+
+  override def getModuleManager: ModuleManager = moduleManager
 
   override def getFunctionCatalog: FunctionCatalog = functionCatalog
 

--- a/flink-table/flink-table-planner/src/main/scala/org/apache/flink/table/planner/delegation/BatchPlanner.scala
+++ b/flink-table/flink-table-planner/src/main/scala/org/apache/flink/table/planner/delegation/BatchPlanner.scala
@@ -26,6 +26,7 @@ import org.apache.flink.table.api.config.OptimizerConfigOptions
 import org.apache.flink.table.api.{ExplainDetail, TableConfig, TableException}
 import org.apache.flink.table.catalog.{CatalogManager, FunctionCatalog, ObjectIdentifier}
 import org.apache.flink.table.delegation.Executor
+import org.apache.flink.table.module.ModuleManager
 import org.apache.flink.table.operations.{CatalogSinkModifyOperation, ModifyOperation, Operation, QueryOperation}
 import org.apache.flink.table.planner.operations.PlannerQueryOperation
 import org.apache.flink.table.planner.plan.`trait`.FlinkRelDistributionTraitDef
@@ -49,9 +50,11 @@ import scala.collection.JavaConversions._
 class BatchPlanner(
     executor: Executor,
     config: TableConfig,
+    moduleManager: ModuleManager,
     functionCatalog: FunctionCatalog,
     catalogManager: CatalogManager)
-  extends PlannerBase(executor, config, functionCatalog, catalogManager, isStreamingMode = false) {
+  extends PlannerBase(executor, config, moduleManager, functionCatalog, catalogManager,
+    isStreamingMode = false) {
 
   override protected def getTraitDefs: Array[RelTraitDef[_ <: RelTrait]] = {
     Array(
@@ -158,7 +161,7 @@ class BatchPlanner(
   private def createDummyPlanner(): BatchPlanner = {
     val dummyExecEnv = new DummyStreamExecutionEnvironment(getExecEnv)
     val executor = new DefaultExecutor(dummyExecEnv)
-    new BatchPlanner(executor, config, functionCatalog, catalogManager)
+    new BatchPlanner(executor, config, moduleManager, functionCatalog, catalogManager)
   }
 
   override def explainJsonPlan(jsonPlan: String, extraDetails: ExplainDetail*): String = {

--- a/flink-table/flink-table-planner/src/main/scala/org/apache/flink/table/planner/delegation/PlannerBase.scala
+++ b/flink-table/flink-table-planner/src/main/scala/org/apache/flink/table/planner/delegation/PlannerBase.scala
@@ -29,6 +29,7 @@ import org.apache.flink.table.connector.sink.DynamicTableSink
 import org.apache.flink.table.delegation.{Executor, Parser, Planner}
 import org.apache.flink.table.descriptors.{ConnectorDescriptorValidator, DescriptorProperties}
 import org.apache.flink.table.factories.{FactoryUtil, TableFactoryUtil}
+import org.apache.flink.table.module.ModuleManager
 import org.apache.flink.table.operations.OutputConversionModifyOperation.UpdateMode
 import org.apache.flink.table.operations._
 import org.apache.flink.table.planner.JMap
@@ -75,6 +76,7 @@ import _root_.scala.collection.JavaConversions._
   *                        [[StreamExecutionEnvironment]] for
   *                        [[org.apache.flink.table.sources.StreamTableSource.getDataStream]]
   * @param config          mutable configuration passed from corresponding [[TableEnvironment]]
+  * @param moduleManager   manager for modules
   * @param functionCatalog catalog of functions
   * @param catalogManager  manager of catalog meta objects such as tables, views, databases etc.
   * @param isStreamingMode Determines if the planner should work in a batch (false}) or
@@ -83,6 +85,7 @@ import _root_.scala.collection.JavaConversions._
 abstract class PlannerBase(
     executor: Executor,
     config: TableConfig,
+    val moduleManager: ModuleManager,
     val functionCatalog: FunctionCatalog,
     val catalogManager: CatalogManager,
     isStreamingMode: Boolean)
@@ -103,6 +106,7 @@ abstract class PlannerBase(
     new PlannerContext(
       !isStreamingMode,
       config,
+      moduleManager,
       functionCatalog,
       catalogManager,
       asRootSchema(new CatalogManagerCalciteSchema(catalogManager, isStreamingMode)),

--- a/flink-table/flink-table-planner/src/main/scala/org/apache/flink/table/planner/delegation/StreamPlanner.scala
+++ b/flink-table/flink-table-planner/src/main/scala/org/apache/flink/table/planner/delegation/StreamPlanner.scala
@@ -25,6 +25,7 @@ import org.apache.flink.streaming.api.graph.StreamGraph
 import org.apache.flink.table.api.{ExplainDetail, TableConfig, TableException}
 import org.apache.flink.table.catalog.{CatalogManager, FunctionCatalog, ObjectIdentifier}
 import org.apache.flink.table.delegation.Executor
+import org.apache.flink.table.module.ModuleManager
 import org.apache.flink.table.operations.{CatalogSinkModifyOperation, ModifyOperation, Operation, QueryOperation}
 import org.apache.flink.table.planner.operations.PlannerQueryOperation
 import org.apache.flink.table.planner.plan.`trait`._
@@ -47,9 +48,11 @@ import _root_.scala.collection.JavaConversions._
 class StreamPlanner(
     executor: Executor,
     config: TableConfig,
+    moduleManager: ModuleManager,
     functionCatalog: FunctionCatalog,
     catalogManager: CatalogManager)
-  extends PlannerBase(executor, config, functionCatalog, catalogManager, isStreamingMode = true) {
+  extends PlannerBase(executor, config, moduleManager, functionCatalog, catalogManager,
+    isStreamingMode = true) {
 
   override protected def getTraitDefs: Array[RelTraitDef[_ <: RelTrait]] = {
     Array(
@@ -151,7 +154,7 @@ class StreamPlanner(
   private def createDummyPlanner(): StreamPlanner = {
     val dummyExecEnv = new DummyStreamExecutionEnvironment(getExecEnv)
     val executor = new DefaultExecutor(dummyExecEnv)
-    new StreamPlanner(executor, config, functionCatalog, catalogManager)
+    new StreamPlanner(executor, config, moduleManager, functionCatalog, catalogManager)
   }
 
   override def explainJsonPlan(jsonPlan: String, extraDetails: ExplainDetail*): String = {

--- a/flink-table/flink-table-planner/src/main/scala/org/apache/flink/table/planner/plan/optimize/BatchCommonSubGraphBasedOptimizer.scala
+++ b/flink-table/flink-table-planner/src/main/scala/org/apache/flink/table/planner/plan/optimize/BatchCommonSubGraphBasedOptimizer.scala
@@ -20,6 +20,7 @@ package org.apache.flink.table.planner.plan.optimize
 
 import org.apache.flink.table.api.TableConfig
 import org.apache.flink.table.catalog.{CatalogManager, FunctionCatalog}
+import org.apache.flink.table.module.ModuleManager
 import org.apache.flink.table.planner.calcite.{FlinkContext, SqlExprToRexConverterFactory}
 import org.apache.flink.table.planner.delegation.BatchPlanner
 import org.apache.flink.table.planner.plan.nodes.calcite.{LegacySink, Sink}
@@ -93,6 +94,8 @@ class BatchCommonSubGraphBasedOptimizer(planner: BatchPlanner)
       override def getFunctionCatalog: FunctionCatalog = planner.functionCatalog
 
       override def getCatalogManager: CatalogManager = planner.catalogManager
+
+      override def getModuleManager: ModuleManager = planner.moduleManager
 
       override def getSqlExprToRexConverterFactory: SqlExprToRexConverterFactory =
         context.getSqlExprToRexConverterFactory

--- a/flink-table/flink-table-planner/src/main/scala/org/apache/flink/table/planner/plan/optimize/StreamCommonSubGraphBasedOptimizer.scala
+++ b/flink-table/flink-table-planner/src/main/scala/org/apache/flink/table/planner/plan/optimize/StreamCommonSubGraphBasedOptimizer.scala
@@ -21,6 +21,7 @@ package org.apache.flink.table.planner.plan.optimize
 import org.apache.flink.table.api.TableConfig
 import org.apache.flink.table.api.config.ExecutionConfigOptions
 import org.apache.flink.table.catalog.{CatalogManager, FunctionCatalog}
+import org.apache.flink.table.module.ModuleManager
 import org.apache.flink.table.planner.calcite.{FlinkContext, SqlExprToRexConverterFactory}
 import org.apache.flink.table.planner.delegation.StreamPlanner
 import org.apache.flink.table.planner.plan.`trait`.{MiniBatchInterval, MiniBatchIntervalTrait, MiniBatchIntervalTraitDef, MiniBatchMode, ModifyKindSet, ModifyKindSetTraitDef, UpdateKind, UpdateKindTraitDef}
@@ -39,6 +40,7 @@ import org.apache.calcite.rex.RexBuilder
 
 import java.util
 import java.util.Collections
+
 import scala.collection.JavaConversions._
 
 /**
@@ -169,6 +171,8 @@ class StreamCommonSubGraphBasedOptimizer(planner: StreamPlanner)
       override def getFunctionCatalog: FunctionCatalog = planner.functionCatalog
 
       override def getCatalogManager: CatalogManager = planner.catalogManager
+
+      override def getModuleManager: ModuleManager = planner.moduleManager
 
       override def getSqlExprToRexConverterFactory: SqlExprToRexConverterFactory =
         context.getSqlExprToRexConverterFactory

--- a/flink-table/flink-table-planner/src/test/java/org/apache/flink/table/planner/delegation/ParserImplTest.java
+++ b/flink-table/flink-table-planner/src/test/java/org/apache/flink/table/planner/delegation/ParserImplTest.java
@@ -61,6 +61,7 @@ public class ParserImplTest {
             new PlannerContext(
                     !isStreamingMode,
                     tableConfig,
+                    moduleManager,
                     functionCatalog,
                     catalogManager,
                     asRootSchema(new CatalogManagerCalciteSchema(catalogManager, isStreamingMode)),

--- a/flink-table/flink-table-planner/src/test/java/org/apache/flink/table/planner/expressions/converter/ExpressionConverterTest.java
+++ b/flink-table/flink-table-planner/src/test/java/org/apache/flink/table/planner/expressions/converter/ExpressionConverterTest.java
@@ -60,11 +60,13 @@ public class ExpressionConverterTest {
 
     private final TableConfig tableConfig = new TableConfig();
     private final CatalogManager catalogManager = CatalogManagerMocks.createEmptyCatalogManager();
+    private final ModuleManager moduleManager = new ModuleManager();
     private final PlannerContext plannerContext =
             new PlannerContext(
                     false,
                     tableConfig,
-                    new FunctionCatalog(tableConfig, catalogManager, new ModuleManager()),
+                    moduleManager,
+                    new FunctionCatalog(tableConfig, catalogManager, moduleManager),
                     catalogManager,
                     CalciteSchema.from(MetadataTestUtil.initRootSchema()),
                     Arrays.asList(

--- a/flink-table/flink-table-planner/src/test/java/org/apache/flink/table/planner/operations/SqlToOperationConverterTest.java
+++ b/flink-table/flink-table-planner/src/test/java/org/apache/flink/table/planner/operations/SqlToOperationConverterTest.java
@@ -140,6 +140,7 @@ public class SqlToOperationConverterTest {
             new PlannerContext(
                     false,
                     tableConfig,
+                    moduleManager,
                     functionCatalog,
                     catalogManager,
                     asRootSchema(new CatalogManagerCalciteSchema(catalogManager, isStreamingMode)),

--- a/flink-table/flink-table-planner/src/test/java/org/apache/flink/table/planner/plan/nodes/exec/serde/DynamicTableSinkSpecSerdeTest.java
+++ b/flink-table/flink-table-planner/src/test/java/org/apache/flink/table/planner/plan/nodes/exec/serde/DynamicTableSinkSpecSerdeTest.java
@@ -26,6 +26,7 @@ import org.apache.flink.table.catalog.Column;
 import org.apache.flink.table.catalog.ObjectIdentifier;
 import org.apache.flink.table.catalog.ResolvedCatalogTable;
 import org.apache.flink.table.catalog.ResolvedSchema;
+import org.apache.flink.table.module.ModuleManager;
 import org.apache.flink.table.planner.calcite.FlinkContextImpl;
 import org.apache.flink.table.planner.calcite.FlinkTypeFactory;
 import org.apache.flink.table.planner.functions.sql.FlinkSqlOperatorTable;
@@ -71,6 +72,7 @@ public class DynamicTableSinkSpecSerdeTest {
                         new FlinkContextImpl(
                                 false,
                                 TableConfig.getDefault(),
+                                new ModuleManager(),
                                 null,
                                 CatalogManagerMocks.createEmptyCatalogManager(),
                                 null),

--- a/flink-table/flink-table-planner/src/test/java/org/apache/flink/table/planner/plan/nodes/exec/serde/DynamicTableSinkSpecSerdeTest.java
+++ b/flink-table/flink-table-planner/src/test/java/org/apache/flink/table/planner/plan/nodes/exec/serde/DynamicTableSinkSpecSerdeTest.java
@@ -20,7 +20,10 @@ package org.apache.flink.table.planner.plan.nodes.exec.serde;
 
 import org.apache.flink.configuration.Configuration;
 import org.apache.flink.table.api.DataTypes;
+import org.apache.flink.table.api.EnvironmentSettings;
 import org.apache.flink.table.api.TableConfig;
+import org.apache.flink.table.api.TableEnvironment;
+import org.apache.flink.table.api.internal.TableEnvironmentImpl;
 import org.apache.flink.table.catalog.CatalogTable;
 import org.apache.flink.table.catalog.Column;
 import org.apache.flink.table.catalog.ObjectIdentifier;
@@ -29,6 +32,7 @@ import org.apache.flink.table.catalog.ResolvedSchema;
 import org.apache.flink.table.module.ModuleManager;
 import org.apache.flink.table.planner.calcite.FlinkContextImpl;
 import org.apache.flink.table.planner.calcite.FlinkTypeFactory;
+import org.apache.flink.table.planner.delegation.PlannerBase;
 import org.apache.flink.table.planner.functions.sql.FlinkSqlOperatorTable;
 import org.apache.flink.table.planner.plan.abilities.sink.OverwriteSpec;
 import org.apache.flink.table.planner.plan.abilities.sink.PartitioningSpec;
@@ -91,7 +95,10 @@ public class DynamicTableSinkSpecSerdeTest {
         actual.setClassLoader(classLoader);
         assertNull(actual.getReadableConfig());
         actual.setReadableConfig(serdeCtx.getConfiguration());
-        assertNotNull(actual.getTableSink());
+        TableEnvironmentImpl tableEnv =
+                (TableEnvironmentImpl)
+                        TableEnvironment.create(EnvironmentSettings.inStreamingMode());
+        assertNotNull(actual.getTableSink((PlannerBase) tableEnv.getPlanner()));
     }
 
     @Parameterized.Parameters(name = "{0}")

--- a/flink-table/flink-table-planner/src/test/java/org/apache/flink/table/planner/plan/nodes/exec/serde/DynamicTableSourceSpecSerdeTest.java
+++ b/flink-table/flink-table-planner/src/test/java/org/apache/flink/table/planner/plan/nodes/exec/serde/DynamicTableSourceSpecSerdeTest.java
@@ -28,6 +28,7 @@ import org.apache.flink.table.catalog.Column;
 import org.apache.flink.table.catalog.ObjectIdentifier;
 import org.apache.flink.table.catalog.ResolvedCatalogTable;
 import org.apache.flink.table.catalog.ResolvedSchema;
+import org.apache.flink.table.module.ModuleManager;
 import org.apache.flink.table.planner.calcite.FlinkContextImpl;
 import org.apache.flink.table.planner.calcite.FlinkTypeFactory;
 import org.apache.flink.table.planner.delegation.PlannerBase;
@@ -91,6 +92,7 @@ public class DynamicTableSourceSpecSerdeTest {
                         new FlinkContextImpl(
                                 false,
                                 TableConfig.getDefault(),
+                                new ModuleManager(),
                                 null,
                                 CatalogManagerMocks.createEmptyCatalogManager(),
                                 null),

--- a/flink-table/flink-table-planner/src/test/java/org/apache/flink/table/planner/plan/nodes/exec/serde/LogicalTypeSerdeTest.java
+++ b/flink-table/flink-table-planner/src/test/java/org/apache/flink/table/planner/plan/nodes/exec/serde/LogicalTypeSerdeTest.java
@@ -26,6 +26,7 @@ import org.apache.flink.table.api.dataview.ListView;
 import org.apache.flink.table.api.dataview.MapView;
 import org.apache.flink.table.catalog.ObjectIdentifier;
 import org.apache.flink.table.expressions.TimeIntervalUnit;
+import org.apache.flink.table.module.ModuleManager;
 import org.apache.flink.table.planner.calcite.FlinkContextImpl;
 import org.apache.flink.table.planner.calcite.FlinkTypeFactory;
 import org.apache.flink.table.planner.functions.sql.FlinkSqlOperatorTable;
@@ -95,7 +96,13 @@ public class LogicalTypeSerdeTest {
     public void testLogicalTypeSerde() throws IOException {
         SerdeContext serdeCtx =
                 new SerdeContext(
-                        new FlinkContextImpl(false, TableConfig.getDefault(), null, null, null),
+                        new FlinkContextImpl(
+                                false,
+                                TableConfig.getDefault(),
+                                new ModuleManager(),
+                                null,
+                                null,
+                                null),
                         Thread.currentThread().getContextClassLoader(),
                         FlinkTypeFactory.INSTANCE(),
                         FlinkSqlOperatorTable.instance());

--- a/flink-table/flink-table-planner/src/test/java/org/apache/flink/table/planner/plan/nodes/exec/serde/LogicalWindowSerdeTest.java
+++ b/flink-table/flink-table-planner/src/test/java/org/apache/flink/table/planner/plan/nodes/exec/serde/LogicalWindowSerdeTest.java
@@ -21,6 +21,7 @@ package org.apache.flink.table.planner.plan.nodes.exec.serde;
 import org.apache.flink.table.api.TableConfig;
 import org.apache.flink.table.expressions.FieldReferenceExpression;
 import org.apache.flink.table.expressions.ValueLiteralExpression;
+import org.apache.flink.table.module.ModuleManager;
 import org.apache.flink.table.planner.calcite.FlinkContextImpl;
 import org.apache.flink.table.planner.calcite.FlinkTypeFactory;
 import org.apache.flink.table.planner.expressions.PlannerWindowReference;
@@ -115,7 +116,13 @@ public class LogicalWindowSerdeTest {
     public void testLogicalWindowSerde() throws JsonProcessingException {
         SerdeContext serdeCtx =
                 new SerdeContext(
-                        new FlinkContextImpl(false, TableConfig.getDefault(), null, null, null),
+                        new FlinkContextImpl(
+                                false,
+                                TableConfig.getDefault(),
+                                new ModuleManager(),
+                                null,
+                                null,
+                                null),
                         Thread.currentThread().getContextClassLoader(),
                         FlinkTypeFactory.INSTANCE(),
                         FlinkSqlOperatorTable.instance());

--- a/flink-table/flink-table-planner/src/test/java/org/apache/flink/table/planner/plan/nodes/exec/serde/LookupKeySerdeTest.java
+++ b/flink-table/flink-table-planner/src/test/java/org/apache/flink/table/planner/plan/nodes/exec/serde/LookupKeySerdeTest.java
@@ -48,6 +48,7 @@ public class LookupKeySerdeTest {
     @Test
     public void testLookupKey() throws JsonProcessingException {
         TableConfig tableConfig = TableConfig.getDefault();
+        ModuleManager moduleManager = new ModuleManager();
         CatalogManager catalogManager =
                 CatalogManager.newBuilder()
                         .classLoader(Thread.currentThread().getContextClassLoader())
@@ -58,7 +59,8 @@ public class LookupKeySerdeTest {
                 new FlinkContextImpl(
                         false,
                         tableConfig,
-                        new FunctionCatalog(tableConfig, catalogManager, new ModuleManager()),
+                        moduleManager,
+                        new FunctionCatalog(tableConfig, catalogManager, moduleManager),
                         catalogManager,
                         null);
         SerdeContext serdeCtx =

--- a/flink-table/flink-table-planner/src/test/java/org/apache/flink/table/planner/plan/nodes/exec/serde/RelDataTypeSerdeTest.java
+++ b/flink-table/flink-table-planner/src/test/java/org/apache/flink/table/planner/plan/nodes/exec/serde/RelDataTypeSerdeTest.java
@@ -22,6 +22,7 @@ import org.apache.flink.api.common.typeinfo.Types;
 import org.apache.flink.api.common.typeutils.base.VoidSerializer;
 import org.apache.flink.table.api.TableConfig;
 import org.apache.flink.table.catalog.ObjectIdentifier;
+import org.apache.flink.table.module.ModuleManager;
 import org.apache.flink.table.planner.calcite.FlinkContextImpl;
 import org.apache.flink.table.planner.calcite.FlinkTypeFactory;
 import org.apache.flink.table.planner.functions.sql.FlinkSqlOperatorTable;
@@ -259,7 +260,13 @@ public class RelDataTypeSerdeTest {
     public void testTypeSerde() throws Exception {
         SerdeContext serdeCtx =
                 new SerdeContext(
-                        new FlinkContextImpl(false, TableConfig.getDefault(), null, null, null),
+                        new FlinkContextImpl(
+                                false,
+                                TableConfig.getDefault(),
+                                new ModuleManager(),
+                                null,
+                                null,
+                                null),
                         Thread.currentThread().getContextClassLoader(),
                         FlinkTypeFactory.INSTANCE(),
                         FlinkSqlOperatorTable.instance());

--- a/flink-table/flink-table-planner/src/test/java/org/apache/flink/table/planner/plan/nodes/exec/serde/RexNodeSerdeTest.java
+++ b/flink-table/flink-table-planner/src/test/java/org/apache/flink/table/planner/plan/nodes/exec/serde/RexNodeSerdeTest.java
@@ -78,6 +78,7 @@ public class RexNodeSerdeTest {
     @Parameterized.Parameters(name = "{0}")
     public static Object[][] parameters() {
         TableConfig tableConfig = TableConfig.getDefault();
+        ModuleManager moduleManager = new ModuleManager();
         CatalogManager catalogManager =
                 CatalogManager.newBuilder()
                         .classLoader(Thread.currentThread().getContextClassLoader())
@@ -88,7 +89,8 @@ public class RexNodeSerdeTest {
                 new FlinkContextImpl(
                         false,
                         tableConfig,
-                        new FunctionCatalog(tableConfig, catalogManager, new ModuleManager()),
+                        moduleManager,
+                        new FunctionCatalog(tableConfig, catalogManager, moduleManager),
                         catalogManager,
                         null); // toRexFactory
         RexBuilder rexBuilder = new RexBuilder(FACTORY);

--- a/flink-table/flink-table-planner/src/test/java/org/apache/flink/table/planner/plan/nodes/exec/serde/RexWindowBoundSerdeTest.java
+++ b/flink-table/flink-table-planner/src/test/java/org/apache/flink/table/planner/plan/nodes/exec/serde/RexWindowBoundSerdeTest.java
@@ -19,6 +19,7 @@
 package org.apache.flink.table.planner.plan.nodes.exec.serde;
 
 import org.apache.flink.table.api.TableConfig;
+import org.apache.flink.table.module.ModuleManager;
 import org.apache.flink.table.planner.calcite.FlinkContextImpl;
 import org.apache.flink.table.planner.calcite.FlinkTypeFactory;
 import org.apache.flink.table.planner.functions.sql.FlinkSqlOperatorTable;
@@ -43,7 +44,13 @@ public class RexWindowBoundSerdeTest {
     public void testSerde() throws JsonProcessingException {
         SerdeContext serdeCtx =
                 new SerdeContext(
-                        new FlinkContextImpl(false, TableConfig.getDefault(), null, null, null),
+                        new FlinkContextImpl(
+                                false,
+                                TableConfig.getDefault(),
+                                new ModuleManager(),
+                                null,
+                                null,
+                                null),
                         Thread.currentThread().getContextClassLoader(),
                         FlinkTypeFactory.INSTANCE(),
                         FlinkSqlOperatorTable.instance());

--- a/flink-table/flink-table-planner/src/test/java/org/apache/flink/table/planner/plan/nodes/exec/serde/TemporalTableSourceSpecSerdeTest.java
+++ b/flink-table/flink-table-planner/src/test/java/org/apache/flink/table/planner/plan/nodes/exec/serde/TemporalTableSourceSpecSerdeTest.java
@@ -26,6 +26,7 @@ import org.apache.flink.table.catalog.ObjectIdentifier;
 import org.apache.flink.table.catalog.ResolvedCatalogTable;
 import org.apache.flink.table.catalog.ResolvedSchema;
 import org.apache.flink.table.connector.source.LookupTableSource;
+import org.apache.flink.table.module.ModuleManager;
 import org.apache.flink.table.planner.calcite.FlinkContext;
 import org.apache.flink.table.planner.calcite.FlinkContextImpl;
 import org.apache.flink.table.planner.calcite.FlinkTypeFactory;
@@ -64,6 +65,7 @@ public class TemporalTableSourceSpecSerdeTest {
             new FlinkContextImpl(
                     false,
                     TableConfig.getDefault(),
+                    new ModuleManager(),
                     null,
                     CatalogManagerMocks.createEmptyCatalogManager(),
                     null);

--- a/flink-table/flink-table-planner/src/test/java/org/apache/flink/table/planner/runtime/stream/module/ModuleITCase.java
+++ b/flink-table/flink-table-planner/src/test/java/org/apache/flink/table/planner/runtime/stream/module/ModuleITCase.java
@@ -1,0 +1,103 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.flink.table.planner.runtime.stream.module;
+
+import org.apache.flink.configuration.ConfigOption;
+import org.apache.flink.table.api.Schema;
+import org.apache.flink.table.api.Table;
+import org.apache.flink.table.connector.source.DynamicTableSource;
+import org.apache.flink.table.factories.DynamicTableSourceFactory;
+import org.apache.flink.table.factories.Factory;
+import org.apache.flink.table.module.Module;
+import org.apache.flink.table.planner.factories.TableFactoryHarness;
+import org.apache.flink.table.planner.runtime.utils.StreamingTestBase;
+
+import org.junit.Test;
+
+import java.util.Optional;
+import java.util.Set;
+
+import static org.apache.flink.core.testutils.CommonTestUtils.assertThrows;
+
+/** Tests for modules. */
+public class ModuleITCase extends StreamingTestBase {
+
+    @Test
+    public void testTableSourceFactory() {
+        tEnv().createTemporaryTable(
+                        "T",
+                        TableFactoryHarness.newBuilder()
+                                .schema(Schema.newBuilder().build())
+                                .source(
+                                        new TableFactoryHarness.ScanSourceBase() {
+                                            @Override
+                                            public ScanRuntimeProvider getScanRuntimeProvider(
+                                                    ScanContext runtimeProviderContext) {
+                                                throw new UnsupportedOperationException(
+                                                        "Discovered factory should not be used");
+                                            }
+                                        })
+                                .build());
+
+        final Table table = tEnv().from("T");
+
+        // Sanity check: without our module loaded, the factory discovery process is used.
+        assertThrows(
+                "Discovered factory should not be used",
+                UnsupportedOperationException.class,
+                table::explain);
+
+        // The module has precedence over factory discovery.
+        tEnv().loadModule("M", new SourceSinkFactoryOverwriteModule());
+        table.explain();
+    }
+
+    // ---------------------------------------------------------------------------------------------
+
+    private static class SourceSinkFactoryOverwriteModule implements Module {
+        @Override
+        public Optional<DynamicTableSourceFactory> getTableSourceFactory() {
+            return Optional.of(new SourceFactory());
+        }
+    }
+
+    private static class SourceFactory extends FactoryBase implements DynamicTableSourceFactory {
+        @Override
+        public DynamicTableSource createDynamicTableSource(Context context) {
+            return new TableFactoryHarness.ScanSourceBase() {};
+        }
+    }
+
+    private static class FactoryBase implements Factory {
+        @Override
+        public String factoryIdentifier() {
+            throw new UnsupportedOperationException();
+        }
+
+        @Override
+        public Set<ConfigOption<?>> requiredOptions() {
+            throw new UnsupportedOperationException();
+        }
+
+        @Override
+        public Set<ConfigOption<?>> optionalOptions() {
+            throw new UnsupportedOperationException();
+        }
+    }
+}

--- a/flink-table/flink-table-planner/src/test/java/org/apache/flink/table/planner/runtime/stream/module/ModuleITCase.java
+++ b/flink-table/flink-table-planner/src/test/java/org/apache/flink/table/planner/runtime/stream/module/ModuleITCase.java
@@ -19,9 +19,12 @@
 package org.apache.flink.table.planner.runtime.stream.module;
 
 import org.apache.flink.configuration.ConfigOption;
+import org.apache.flink.table.api.DataTypes;
 import org.apache.flink.table.api.Schema;
 import org.apache.flink.table.api.Table;
+import org.apache.flink.table.connector.sink.DynamicTableSink;
 import org.apache.flink.table.connector.source.DynamicTableSource;
+import org.apache.flink.table.factories.DynamicTableSinkFactory;
 import org.apache.flink.table.factories.DynamicTableSourceFactory;
 import org.apache.flink.table.factories.Factory;
 import org.apache.flink.table.module.Module;
@@ -68,6 +71,34 @@ public class ModuleITCase extends StreamingTestBase {
         table.explain();
     }
 
+    @Test
+    public void testTableSinkFactory() {
+        tEnv().createTemporaryTable(
+                        "T",
+                        TableFactoryHarness.newBuilder()
+                                .schema(Schema.newBuilder().column("f0", DataTypes.INT()).build())
+                                .sink(
+                                        new TableFactoryHarness.SinkBase() {
+                                            @Override
+                                            public SinkRuntimeProvider getSinkRuntimeProvider(
+                                                    Context context) {
+                                                throw new UnsupportedOperationException(
+                                                        "Discovered factory should not be used");
+                                            }
+                                        })
+                                .build());
+
+        // Sanity check: without our module loaded, the factory discovery process is used.
+        assertThrows(
+                "Discovered factory should not be used",
+                UnsupportedOperationException.class,
+                () -> tEnv().explainSql("INSERT INTO T SELECT 1"));
+
+        // The module has precedence over factory discovery.
+        tEnv().loadModule("M", new SourceSinkFactoryOverwriteModule());
+        tEnv().explainSql("INSERT INTO T SELECT 1");
+    }
+
     // ---------------------------------------------------------------------------------------------
 
     private static class SourceSinkFactoryOverwriteModule implements Module {
@@ -75,12 +106,24 @@ public class ModuleITCase extends StreamingTestBase {
         public Optional<DynamicTableSourceFactory> getTableSourceFactory() {
             return Optional.of(new SourceFactory());
         }
+
+        @Override
+        public Optional<DynamicTableSinkFactory> getTableSinkFactory() {
+            return Optional.of(new SinkFactory());
+        }
     }
 
     private static class SourceFactory extends FactoryBase implements DynamicTableSourceFactory {
         @Override
         public DynamicTableSource createDynamicTableSource(Context context) {
             return new TableFactoryHarness.ScanSourceBase() {};
+        }
+    }
+
+    private static class SinkFactory extends FactoryBase implements DynamicTableSinkFactory {
+        @Override
+        public DynamicTableSink createDynamicTableSink(Context context) {
+            return new TableFactoryHarness.SinkBase() {};
         }
     }
 

--- a/flink-table/flink-table-planner/src/test/java/org/apache/flink/table/planner/utils/PlannerMocks.java
+++ b/flink-table/flink-table-planner/src/test/java/org/apache/flink/table/planner/utils/PlannerMocks.java
@@ -46,6 +46,7 @@ public class PlannerMocks {
                 new PlannerContext(
                         false,
                         tableConfig,
+                        moduleManager,
                         functionCatalog,
                         catalogManager,
                         asRootSchema(new CatalogManagerCalciteSchema(catalogManager, true)),

--- a/flink-table/flink-table-planner/src/test/scala/org/apache/flink/table/planner/codegen/WatermarkGeneratorCodeGenTest.scala
+++ b/flink-table/flink-table-planner/src/test/scala/org/apache/flink/table/planner/codegen/WatermarkGeneratorCodeGenTest.scala
@@ -58,11 +58,13 @@ class WatermarkGeneratorCodeGenTest(useDefinedConstructor: Boolean) {
 
   // mock FlinkPlannerImpl to avoid discovering TableEnvironment and Executor.
   val config = new TableConfig
+  val moduleManager = new ModuleManager
   val catalogManager: CatalogManager = CatalogManagerMocks.createEmptyCatalogManager()
-  val functionCatalog = new FunctionCatalog(config, catalogManager, new ModuleManager)
+  val functionCatalog = new FunctionCatalog(config, catalogManager, moduleManager)
   val plannerContext = new PlannerContext(
     false,
     config,
+    moduleManager,
     functionCatalog,
     catalogManager,
     asRootSchema(new CatalogManagerCalciteSchema(catalogManager, false)),

--- a/flink-table/flink-table-planner/src/test/scala/org/apache/flink/table/planner/plan/metadata/AggCallSelectivityEstimatorTest.scala
+++ b/flink-table/flink-table-planner/src/test/scala/org/apache/flink/table/planner/plan/metadata/AggCallSelectivityEstimatorTest.scala
@@ -78,6 +78,7 @@ class AggCallSelectivityEstimatorTest {
   private def mockScan(
       statistic: FlinkStatistic = FlinkStatistic.UNKNOWN): TableScan = {
     val tableConfig = new TableConfig
+    val moduleManager = new ModuleManager
     val catalogManager = CatalogManagerMocks.createEmptyCatalogManager()
     val rootSchema = CalciteSchema.createRootSchema(true, false).plus()
     val table = new MockMetaTable(relDataType, statistic)
@@ -86,7 +87,8 @@ class AggCallSelectivityEstimatorTest {
       new PlannerContext(
         false,
         tableConfig,
-        new FunctionCatalog(tableConfig, catalogManager, new ModuleManager),
+        moduleManager,
+        new FunctionCatalog(tableConfig, catalogManager, moduleManager),
         catalogManager,
         CalciteSchema.from(rootSchema),
         util.Arrays.asList(

--- a/flink-table/flink-table-planner/src/test/scala/org/apache/flink/table/planner/plan/metadata/FlinkRelMdHandlerTestBase.scala
+++ b/flink-table/flink-table-planner/src/test/scala/org/apache/flink/table/planner/plan/metadata/FlinkRelMdHandlerTestBase.scala
@@ -90,6 +90,7 @@ class FlinkRelMdHandlerTestBase {
   new PlannerContext(
     false,
     tableConfig,
+    moduleManager,
     new FunctionCatalog(tableConfig, catalogManager, moduleManager),
     catalogManager,
     CalciteSchema.from(rootSchema),

--- a/flink-table/flink-table-planner/src/test/scala/org/apache/flink/table/planner/plan/metadata/MetadataTestUtil.scala
+++ b/flink-table/flink-table-planner/src/test/scala/org/apache/flink/table/planner/plan/metadata/MetadataTestUtil.scala
@@ -23,6 +23,7 @@ import org.apache.flink.table.api.{DataTypes, TableConfig, TableException, Table
 import org.apache.flink.table.catalog.{CatalogTable, Column, ObjectIdentifier, ResolvedCatalogTable, ResolvedSchema, UniqueConstraint}
 import org.apache.flink.table.connector.ChangelogMode
 import org.apache.flink.table.connector.source.{DynamicTableSource, ScanTableSource}
+import org.apache.flink.table.module.ModuleManager
 import org.apache.flink.table.plan.stats.{ColumnStats, TableStats}
 import org.apache.flink.table.planner.calcite.{FlinkContext, FlinkContextImpl, FlinkTypeFactory, FlinkTypeSystem}
 import org.apache.flink.table.planner.plan.schema.{FlinkPreparingTableBase, TableSourceTable}
@@ -251,6 +252,7 @@ object MetadataTestUtil {
   private val flinkContext = new FlinkContextImpl(
     false,
     TableConfig.getDefault,
+    new ModuleManager,
     null,
     CatalogManagerMocks.createEmptyCatalogManager,
     null)

--- a/flink-table/flink-table-planner/src/test/scala/org/apache/flink/table/planner/plan/metadata/SelectivityEstimatorTest.scala
+++ b/flink-table/flink-table-planner/src/test/scala/org/apache/flink/table/planner/plan/metadata/SelectivityEstimatorTest.scala
@@ -79,6 +79,7 @@ class SelectivityEstimatorTest {
   private def mockScan(
       statistic: FlinkStatistic = FlinkStatistic.UNKNOWN,
       tableConfig: TableConfig = TableConfig.getDefault): TableScan = {
+    val moduleManager = new ModuleManager
     val catalogManager = CatalogManagerMocks.createEmptyCatalogManager()
     val rootSchema = CalciteSchema.createRootSchema(true, false).plus()
     val table = new MockMetaTable(relDataType, statistic)
@@ -87,7 +88,8 @@ class SelectivityEstimatorTest {
       new PlannerContext(
         false,
         tableConfig,
-        new FunctionCatalog(tableConfig, catalogManager, new ModuleManager),
+        moduleManager,
+        new FunctionCatalog(tableConfig, catalogManager, moduleManager),
         catalogManager,
         CalciteSchema.from(rootSchema),
         util.Arrays.asList(

--- a/flink-table/flink-table-planner/src/test/scala/org/apache/flink/table/planner/plan/nodes/calcite/RelNodeTestBase.scala
+++ b/flink-table/flink-table-planner/src/test/scala/org/apache/flink/table/planner/plan/nodes/calcite/RelNodeTestBase.scala
@@ -53,6 +53,7 @@ class RelNodeTestBase {
   val plannerContext: PlannerContext = new PlannerContext(
     false,
     tableConfig,
+    moduleManager,
     new FunctionCatalog(tableConfig, catalogManager, moduleManager),
     catalogManager,
     CalciteSchema.from(rootSchema),

--- a/flink-table/flink-table-planner/src/test/scala/org/apache/flink/table/planner/utils/TableTestBase.scala
+++ b/flink-table/flink-table-planner/src/test/scala/org/apache/flink/table/planner/utils/TableTestBase.scala
@@ -1550,7 +1550,7 @@ object TestingTableEnvironment {
     val executor = executorFactory.create(tableConfig.getConfiguration)
 
     val planner = PlannerFactoryUtil.createPlanner(settings.getPlanner, executor, tableConfig,
-      catalogMgr, functionCatalog).asInstanceOf[PlannerBase]
+      moduleManager, catalogMgr, functionCatalog).asInstanceOf[PlannerBase]
 
     new TestingTableEnvironment(
       catalogMgr,


### PR DESCRIPTION
## What is the purpose of the change

This introduces `Module#getTableSourceFactory` and `Module#getTableSinkFactory`, which allow providing a corresponding factory when sources/sinks are created. The precedence is as follows:

1. Factory defined by the catalog
2. Factory defined by the module
3. Factory discovery

It may seem more appropriate to give modules the higher precedence, but in practice it's more useful to prefer the specificity of the catalog and have the module act as a fallback (that can override the discovery process fallback).

The changes in `FactoryUtil` have been kept backwards-compatible, but the old methods have been deprecated.

## Brief change log

* Provide `ModuleManager` in `FlinkContext`
* Introduce the new APIs.

## Verifying this change

*(Please pick either of the following options)*

Compatibility is covered through existing tests. A new `ModuleITCase` has been added to verify the new module APIs.

## Does this pull request potentially affect one of the following parts:

  - Dependencies (does it add or upgrade a dependency): no
  - The public API, i.e., is any changed class annotated with `@Public(Evolving)`: yes
  - The serializers: no
  - The runtime per-record code paths (performance sensitive): no
  - Anything that affects deployment or recovery: JobManager (and its components), Checkpointing, Kubernetes/Yarn, ZooKeeper: no
  - The S3 file system connector: no

## Documentation

  - Does this pull request introduce a new feature? yes
  - If yes, how is the feature documented? JavaDocs
