### PR TITLE
[FLINK-23895][table] Upsert materializer is not inserted for all sink providers

### DIFF
--- a/flink-table/flink-table-common/src/main/java/org/apache/flink/table/connector/ParallelismProvider.java
+++ b/flink-table/flink-table-common/src/main/java/org/apache/flink/table/connector/ParallelismProvider.java
@@ -19,7 +19,7 @@
 package org.apache.flink.table.connector;
 
 import org.apache.flink.annotation.PublicEvolving;
-import org.apache.flink.table.connector.sink.OutputFormatProvider;
+import org.apache.flink.table.connector.sink.DynamicTableSink.SinkRuntimeProvider;
 
 import java.util.Optional;
 
@@ -27,9 +27,7 @@ import java.util.Optional;
  * Parallelism provider for other connector providers. It allows to express a custom parallelism for
  * the connector runtime implementation. Otherwise the parallelism is determined by the planner.
  *
- * <p>Note: Currently, this interface can only work with {@code
- * org.apache.flink.table.connector.sink.SinkFunctionProvider} in {@code
- * flink-table-api-java-bridge} module and {@link OutputFormatProvider}.
+ * <p>Note: Currently, this interface only works with {@link SinkRuntimeProvider}.
  */
 @PublicEvolving
 public interface ParallelismProvider {
@@ -39,6 +37,10 @@ public interface ParallelismProvider {
      *
      * <p>The parallelism denotes how many parallel instances of a source or sink will be spawned
      * during the execution.
+     *
+     * <p>Enforcing a different parallelism for sinks might mess up the changelog if the input is
+     * not {@link ChangelogMode#insertOnly()}. Therefore, a primary key is required by which the
+     * input will be shuffled before records enter the {@link SinkRuntimeProvider} implementation.
      *
      * @return empty if the connector does not provide a custom parallelism, then the planner will
      *     decide the number of parallel instances by itself.

--- a/flink-table/flink-table-planner-blink/src/test/java/org/apache/flink/table/planner/factories/TestValuesRuntimeFunctions.java
+++ b/flink-table/flink-table-planner-blink/src/test/java/org/apache/flink/table/planner/factories/TestValuesRuntimeFunctions.java
@@ -34,12 +34,8 @@ import org.apache.flink.core.memory.DataOutputViewStreamWrapper;
 import org.apache.flink.runtime.state.FunctionInitializationContext;
 import org.apache.flink.runtime.state.FunctionSnapshotContext;
 import org.apache.flink.streaming.api.checkpoint.CheckpointedFunction;
-import org.apache.flink.streaming.api.datastream.DataStream;
-import org.apache.flink.streaming.api.datastream.DataStreamSink;
 import org.apache.flink.streaming.api.functions.sink.RichSinkFunction;
 import org.apache.flink.streaming.api.functions.source.SourceFunction;
-import org.apache.flink.table.connector.ParallelismProvider;
-import org.apache.flink.table.connector.sink.DataStreamSinkProvider;
 import org.apache.flink.table.connector.sink.DynamicTableSink.DataStructureConverter;
 import org.apache.flink.table.data.RowData;
 import org.apache.flink.table.data.TimestampData;
@@ -62,7 +58,6 @@ import java.util.HashMap;
 import java.util.LinkedList;
 import java.util.List;
 import java.util.Map;
-import java.util.Optional;
 import java.util.concurrent.CompletableFuture;
 import java.util.concurrent.ExecutorService;
 import java.util.concurrent.Executors;
@@ -131,29 +126,6 @@ final class TestValuesRuntimeFunctions {
             globalUpsertResult.clear();
             globalRetractResult.clear();
             watermarkHistory.clear();
-        }
-    }
-
-    // ------------------------------------------------------------------------------------------
-    // Specialized test provider implementations
-    // ------------------------------------------------------------------------------------------
-    static class InternalDataStreamSinkProviderWithParallelism
-            implements DataStreamSinkProvider, ParallelismProvider {
-
-        private final Integer parallelism;
-
-        public InternalDataStreamSinkProviderWithParallelism(Integer parallelism) {
-            this.parallelism = parallelism;
-        }
-
-        @Override
-        public DataStreamSink<?> consumeDataStream(DataStream<RowData> dataStream) {
-            throw new UnsupportedOperationException("should not be called");
-        }
-
-        @Override
-        public Optional<Integer> getParallelism() {
-            return Optional.ofNullable(parallelism);
         }
     }
 

--- a/flink-table/flink-table-planner-blink/src/test/java/org/apache/flink/table/planner/factories/TestValuesTableFactory.java
+++ b/flink-table/flink-table-planner-blink/src/test/java/org/apache/flink/table/planner/factories/TestValuesTableFactory.java
@@ -1354,9 +1354,6 @@ public final class TestValuesTableFactory
                                         dataStream.addSink(
                                                 new AppendingSinkFunction(
                                                         tableName, converter, rowtimeIndex));
-                    case "DataStreamWithParallelism":
-                        return new TestValuesRuntimeFunctions
-                                .InternalDataStreamSinkProviderWithParallelism(1);
                     default:
                         throw new IllegalArgumentException(
                                 "Unsupported runtime sink class: " + runtimeSink);

--- a/flink-table/flink-table-planner-blink/src/test/java/org/apache/flink/table/planner/runtime/stream/sql/DataStreamJavaITCase.java
+++ b/flink-table/flink-table-planner-blink/src/test/java/org/apache/flink/table/planner/runtime/stream/sql/DataStreamJavaITCase.java
@@ -63,6 +63,7 @@ import java.time.DayOfWeek;
 import java.time.LocalDateTime;
 import java.time.ZoneId;
 import java.time.ZoneOffset;
+import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.Collections;
 import java.util.List;
@@ -533,6 +534,80 @@ public class DataStreamJavaITCase extends AbstractTestBase {
         config.setLocalTimeZone(originalZone);
     }
 
+    @Test
+    public void testMultiChangelogStreamUpsert() throws Exception {
+        final StreamTableEnvironment tableEnv = StreamTableEnvironment.create(env);
+
+        createTableFromElements(
+                tableEnv,
+                "T1",
+                ChangelogMode.insertOnly(),
+                Schema.newBuilder()
+                        .column("pk", "INT NOT NULL")
+                        .column("x", "STRING NOT NULL")
+                        .primaryKey("pk")
+                        .build(),
+                Arrays.asList(Types.INT, Types.STRING),
+                Row.ofKind(RowKind.INSERT, 1, "1"),
+                Row.ofKind(RowKind.INSERT, 2, "2"));
+
+        createTableFromElements(
+                tableEnv,
+                "T2",
+                ChangelogMode.upsert(),
+                Schema.newBuilder()
+                        .column("pk", "INT NOT NULL")
+                        .column("y", "STRING NOT NULL")
+                        .column("some_value", "DOUBLE NOT NULL")
+                        .primaryKey("pk")
+                        .build(),
+                Arrays.asList(Types.INT, Types.STRING, Types.DOUBLE),
+                Row.ofKind(RowKind.INSERT, 1, "A", 1.0),
+                Row.ofKind(RowKind.INSERT, 2, "B", 2.0),
+                Row.ofKind(RowKind.UPDATE_AFTER, 1, "A", 1.1),
+                Row.ofKind(RowKind.UPDATE_AFTER, 2, "B", 2.1));
+
+        createTableFromElements(
+                tableEnv,
+                "T3",
+                ChangelogMode.insertOnly(),
+                Schema.newBuilder()
+                        .column("pk1", "STRING NOT NULL")
+                        .column("pk2", "STRING NOT NULL")
+                        .column("some_other_value", "DOUBLE NOT NULL")
+                        .primaryKey("pk1", "pk2")
+                        .build(),
+                Arrays.asList(Types.STRING, Types.STRING, Types.DOUBLE),
+                Row.ofKind(RowKind.INSERT, "1", "A", 10.0),
+                Row.ofKind(RowKind.INSERT, "1", "B", 11.0));
+
+        final Table resultTable =
+                tableEnv.sqlQuery(
+                        "SELECT\n"
+                                + "T1.pk,\n"
+                                + "T2.some_value * T3.some_other_value,\n"
+                                + "T3.pk1,\n"
+                                + "T3.pk2\n"
+                                + "FROM T1\n"
+                                + "LEFT JOIN T2 on T1.pk = T2.pk\n"
+                                + "LEFT JOIN T3 ON T1.x = T3.pk1 AND T2.y = T3.pk2");
+
+        final DataStream<Row> resultStream =
+                tableEnv.toChangelogStream(
+                        resultTable,
+                        Schema.newBuilder()
+                                .column("pk", "INT NOT NULL")
+                                .column("some_calculated_value", "DOUBLE")
+                                .column("pk1", "STRING")
+                                .column("pk2", "STRING")
+                                .primaryKey("pk")
+                                .build(),
+                        ChangelogMode.upsert());
+
+        testMaterializedResult(
+                resultStream, 0, Row.of(2, null, null, null), Row.of(1, 11.0, "1", "A"));
+    }
+
     // --------------------------------------------------------------------------------------------
     // Helper methods
     // --------------------------------------------------------------------------------------------
@@ -571,6 +646,24 @@ public class DataStreamJavaITCase extends AbstractTestBase {
                 .toArray(Row[]::new);
     }
 
+    private void createTableFromElements(
+            StreamTableEnvironment tableEnv,
+            String name,
+            ChangelogMode changelogMode,
+            Schema schema,
+            List<TypeInformation<?>> fieldTypeInfo,
+            Row... elements) {
+        final String[] fieldNames =
+                schema.getColumns().stream()
+                        .map(Schema.UnresolvedColumn::getName)
+                        .toArray(String[]::new);
+        final TypeInformation<?>[] fieldTypes = fieldTypeInfo.toArray(new TypeInformation[0]);
+        final DataStream<Row> dataStream =
+                env.fromElements(elements).returns(Types.ROW_NAMED(fieldNames, fieldTypes));
+        final Table table = tableEnv.fromChangelogStream(dataStream, schema, changelogMode);
+        tableEnv.createTemporaryView(name, table);
+    }
+
     private static void testSchema(Table table, Column... expectedColumns) {
         assertEquals(ResolvedSchema.of(expectedColumns), table.getResolvedSchema());
     }
@@ -594,6 +687,36 @@ public class DataStreamJavaITCase extends AbstractTestBase {
         try (CloseableIterator<T> iterator = dataStream.executeAndCollect()) {
             final List<T> list = CollectionUtil.iteratorToList(iterator);
             assertThat(list, containsInAnyOrder(expectedResult));
+        }
+    }
+
+    private static void testMaterializedResult(
+            DataStream<Row> dataStream, int primaryKeyPos, Row... expectedResult) throws Exception {
+        try (CloseableIterator<Row> iterator = dataStream.executeAndCollect()) {
+            final List<Row> materializedResult = new ArrayList<>();
+            iterator.forEachRemaining(
+                    row -> {
+                        final RowKind kind = row.getKind();
+                        row.setKind(RowKind.INSERT);
+                        switch (kind) {
+                            case UPDATE_BEFORE:
+                                materializedResult.remove(row);
+                                break;
+                            case INSERT: // temporary solution for FLINK-24054
+                            case UPDATE_AFTER:
+                                final Object primaryKeyValue = row.getField(primaryKeyPos);
+                                assert primaryKeyValue != null;
+                                materializedResult.removeIf(
+                                        r -> primaryKeyValue.equals(r.getField(primaryKeyPos)));
+                                materializedResult.add(row);
+                                break;
+                            case DELETE:
+                                row.setKind(RowKind.INSERT);
+                                materializedResult.remove(row);
+                                break;
+                        }
+                    });
+            assertThat(materializedResult, containsInAnyOrder(expectedResult));
         }
     }
 

--- a/flink-table/flink-table-planner-blink/src/test/scala/org/apache/flink/table/planner/runtime/stream/table/TableSinkITCase.scala
+++ b/flink-table/flink-table-planner-blink/src/test/scala/org/apache/flink/table/planner/runtime/stream/table/TableSinkITCase.scala
@@ -680,24 +680,6 @@ class TableSinkITCase extends StreamingTestBase {
     assertEquals(expected.sorted, result.sorted)
   }
 
-
-  @Test
-  def testParallelismWithDataStream(): Unit = {
-    Try(innerTestSetParallelism(
-      "DataStreamWithParallelism",
-      1,
-      index = 1)) match {
-      case Success(_) => fail("this should not happen")
-      case Failure(t) => {
-        val exception = ExceptionUtils.findThrowableWithMessage(
-          t,
-          "`DataStreamSinkProvider` is not allowed to work with `ParallelismProvider`," +
-            " please see document of `ParallelismProvider`")
-        assertTrue(exception.isPresent)
-      }
-    }
-  }
-
   @Test
   def testParallelismWithSinkFunction(): Unit = {
     val negativeParallelism = -1
@@ -710,45 +692,17 @@ class TableSinkITCase extends StreamingTestBase {
       index = index.getAndIncrement))
     match {
       case Success(_) => fail("this should not happen")
-      case Failure(t) => {
+      case Failure(t) =>
         val exception = ExceptionUtils.findThrowableWithMessage(
           t,
-          s"should not be less than zero or equal to zero")
+          s"Invalid configured parallelism")
         assertTrue(exception.isPresent)
-      }
     }
 
     assertTrue(Try(innerTestSetParallelism(
       "SinkFunction",
       validParallelism,
       index = index.getAndIncrement)).isSuccess)
-  }
-
-  @Test
-  def testParallelismWithOutputFormat(): Unit = {
-    val negativeParallelism = -1
-    val validParallelism = 1
-    val index = new AtomicInteger(1)
-
-    Try(innerTestSetParallelism(
-      "OutputFormat",
-      negativeParallelism,
-      index = index.getAndIncrement))
-    match {
-      case Success(_) => fail("this should not happen")
-      case Failure(t) => {
-        val exception = ExceptionUtils.findThrowableWithMessage(
-          t,
-          s"should not be less than zero or equal to zero")
-        assertTrue(exception.isPresent)
-      }
-    }
-
-    assertTrue(Try(innerTestSetParallelism(
-      "SinkFunction",
-      validParallelism,
-      index = index.getAndIncrement))
-      .isSuccess)
   }
 
   @Test
@@ -791,7 +745,7 @@ class TableSinkITCase extends StreamingTestBase {
         val exception = ExceptionUtils
           .findThrowableWithMessage(
             e,
-            "primary key is required but no primary key is found")
+            "a primary key is required")
         assertTrue(exception.isPresent)
     }
 


### PR DESCRIPTION
## What is the purpose of the change

This is a backport of FLINK-23895 / #17060 for the 1.13 branch.

We aim to fully support primary keys in a bugfix release. The changes should not lead to side effects for existing correct pipelines.

## Verifying this change

This change added tests and can be verified as follows: `DataStreamJavaITCase`

## Does this pull request potentially affect one of the following parts:

  - Dependencies (does it add or upgrade a dependency): no
  - The public API, i.e., is any changed class annotated with `@Public(Evolving)`: no
  - The serializers: no
  - The runtime per-record code paths (performance sensitive): yes
  - Anything that affects deployment or recovery: JobManager (and its components), Checkpointing, Kubernetes/Yarn, ZooKeeper: no
  - The S3 file system connector: no

## Documentation

  - Does this pull request introduce a new feature? no
  - If yes, how is the feature documented? not applicable
