### PR TITLE
[FLINK-23405][tests] Use free ports for Zookeeper

### DIFF
--- a/flink-connectors/flink-connector-kafka/src/test/java/org/apache/flink/streaming/connectors/kafka/KafkaTestEnvironmentImpl.java
+++ b/flink-connectors/flink-connector-kafka/src/test/java/org/apache/flink/streaming/connectors/kafka/KafkaTestEnvironmentImpl.java
@@ -35,6 +35,7 @@ import kafka.server.KafkaConfig;
 import kafka.server.KafkaServer;
 import org.apache.commons.collections.list.UnmodifiableList;
 import org.apache.commons.io.FileUtils;
+import org.apache.curator.test.InstanceSpec;
 import org.apache.curator.test.TestingServer;
 import org.apache.kafka.clients.admin.AdminClient;
 import org.apache.kafka.clients.admin.NewTopic;
@@ -125,7 +126,7 @@ public class KafkaTestEnvironmentImpl extends KafkaTestEnvironment {
         zookeeper = null;
         brokers.clear();
 
-        zookeeper = new TestingServer(-1, tmpZkDir);
+        zookeeper = new TestingServer(new InstanceSpec(tmpZkDir, 0, 0, 0, true, -1), true);
         zookeeperConnectionString = zookeeper.getConnectString();
         LOG.info(
                 "Starting Zookeeper with zookeeperConnectionString: {}", zookeeperConnectionString);


### PR DESCRIPTION
With this PR Zookeeper uses `0` for all ports instead of `-1`.
When `-1` is used then ZK searches for a port that is _currently_ free and tries to re-use it later, which can obviously fail.