### PR TITLE
[FLINK-24054][table-runtime] Let SinkUpsertMaterializer emit +U instead of only +I

### DIFF
--- a/flink-table/flink-table-planner-blink/src/test/java/org/apache/flink/table/planner/runtime/stream/sql/DataStreamJavaITCase.java
+++ b/flink-table/flink-table-planner-blink/src/test/java/org/apache/flink/table/planner/runtime/stream/sql/DataStreamJavaITCase.java
@@ -699,19 +699,17 @@ public class DataStreamJavaITCase extends AbstractTestBase {
                         final RowKind kind = row.getKind();
                         row.setKind(RowKind.INSERT);
                         switch (kind) {
-                            case UPDATE_BEFORE:
-                                materializedResult.remove(row);
-                                break;
-                            case INSERT: // temporary solution for FLINK-24054
                             case UPDATE_AFTER:
                                 final Object primaryKeyValue = row.getField(primaryKeyPos);
                                 assert primaryKeyValue != null;
                                 materializedResult.removeIf(
                                         r -> primaryKeyValue.equals(r.getField(primaryKeyPos)));
+                                // fall through
+                            case INSERT:
                                 materializedResult.add(row);
                                 break;
+                            case UPDATE_BEFORE:
                             case DELETE:
-                                row.setKind(RowKind.INSERT);
                                 materializedResult.remove(row);
                                 break;
                         }

--- a/flink-table/flink-table-runtime-blink/src/test/java/org/apache/flink/table/runtime/operators/sink/SinkUpsertMaterializerTest.java
+++ b/flink-table/flink-table-runtime-blink/src/test/java/org/apache/flink/table/runtime/operators/sink/SinkUpsertMaterializerTest.java
@@ -43,7 +43,7 @@ import java.util.List;
 
 import static org.apache.flink.table.runtime.util.StreamRecordUtils.deleteRecord;
 import static org.apache.flink.table.runtime.util.StreamRecordUtils.insertRecord;
-import static org.apache.flink.table.runtime.util.StreamRecordUtils.row;
+import static org.apache.flink.table.runtime.util.StreamRecordUtils.rowOfKind;
 import static org.junit.Assert.assertEquals;
 
 /** Test for {@link SinkUpsertMaterializer}. */
@@ -76,25 +76,25 @@ public class SinkUpsertMaterializerTest {
         testHarness.setStateTtlProcessingTime(1);
 
         testHarness.processElement(insertRecord(1, "a1"));
-        shouldEmit(testHarness, row(RowKind.INSERT, 1, "a1"));
+        shouldEmit(testHarness, rowOfKind(RowKind.INSERT, 1, "a1"));
 
         testHarness.processElement(insertRecord(1, "a2"));
-        shouldEmit(testHarness, row(RowKind.UPDATE_AFTER, 1, "a2"));
+        shouldEmit(testHarness, rowOfKind(RowKind.UPDATE_AFTER, 1, "a2"));
 
         testHarness.processElement(insertRecord(1, "a3"));
-        shouldEmit(testHarness, row(RowKind.UPDATE_AFTER, 1, "a3"));
+        shouldEmit(testHarness, rowOfKind(RowKind.UPDATE_AFTER, 1, "a3"));
 
         testHarness.processElement(deleteRecord(1, "a2"));
         shouldEmitNothing(testHarness);
 
         testHarness.processElement(deleteRecord(1, "a3"));
-        shouldEmit(testHarness, row(RowKind.UPDATE_AFTER, 1, "a1"));
+        shouldEmit(testHarness, rowOfKind(RowKind.UPDATE_AFTER, 1, "a1"));
 
         testHarness.processElement(deleteRecord(1, "a1"));
-        shouldEmit(testHarness, row(RowKind.DELETE, 1, "a1"));
+        shouldEmit(testHarness, rowOfKind(RowKind.DELETE, 1, "a1"));
 
         testHarness.processElement(insertRecord(1, "a4"));
-        shouldEmit(testHarness, row(RowKind.INSERT, 1, "a4"));
+        shouldEmit(testHarness, rowOfKind(RowKind.INSERT, 1, "a4"));
 
         testHarness.setStateTtlProcessingTime(1002);
 

--- a/flink-table/flink-table-runtime-blink/src/test/java/org/apache/flink/table/runtime/operators/sink/SinkUpsertMaterializerTest.java
+++ b/flink-table/flink-table-runtime-blink/src/test/java/org/apache/flink/table/runtime/operators/sink/SinkUpsertMaterializerTest.java
@@ -35,7 +35,6 @@ import org.apache.flink.table.types.logical.VarCharType;
 import org.apache.flink.table.utils.HandwrittenSelectorUtil;
 import org.apache.flink.types.RowKind;
 
-import org.junit.Assert;
 import org.junit.Test;
 
 import java.util.ArrayList;
@@ -45,6 +44,7 @@ import java.util.List;
 import static org.apache.flink.table.runtime.util.StreamRecordUtils.deleteRecord;
 import static org.apache.flink.table.runtime.util.StreamRecordUtils.insertRecord;
 import static org.apache.flink.table.runtime.util.StreamRecordUtils.row;
+import static org.junit.Assert.assertEquals;
 
 /** Test for {@link SinkUpsertMaterializer}. */
 public class SinkUpsertMaterializerTest {
@@ -76,52 +76,62 @@ public class SinkUpsertMaterializerTest {
         testHarness.setStateTtlProcessingTime(1);
 
         testHarness.processElement(insertRecord(1, "a1"));
-        Assert.assertEquals(Collections.singletonList(row(1, "a1")), toRows(testHarness));
+        shouldEmit(testHarness, row(RowKind.INSERT, 1, "a1"));
 
         testHarness.processElement(insertRecord(1, "a2"));
-        Assert.assertEquals(Collections.singletonList(row(1, "a2")), toRows(testHarness));
+        shouldEmit(testHarness, row(RowKind.UPDATE_AFTER, 1, "a2"));
 
         testHarness.processElement(insertRecord(1, "a3"));
-        Assert.assertEquals(Collections.singletonList(row(1, "a3")), toRows(testHarness));
+        shouldEmit(testHarness, row(RowKind.UPDATE_AFTER, 1, "a3"));
 
         testHarness.processElement(deleteRecord(1, "a2"));
-        Assert.assertEquals(Collections.emptyList(), toRows(testHarness));
+        shouldEmitNothing(testHarness);
 
         testHarness.processElement(deleteRecord(1, "a3"));
-        Assert.assertEquals(Collections.singletonList(row(1, "a1")), toRows(testHarness));
+        shouldEmit(testHarness, row(RowKind.UPDATE_AFTER, 1, "a1"));
 
         testHarness.processElement(deleteRecord(1, "a1"));
-        RowData deleteRow = row(1, "a1");
-        deleteRow.setRowKind(RowKind.DELETE);
-        Assert.assertEquals(Collections.singletonList(deleteRow), toRows(testHarness));
+        shouldEmit(testHarness, row(RowKind.DELETE, 1, "a1"));
 
         testHarness.processElement(insertRecord(1, "a4"));
-        Assert.assertEquals(Collections.singletonList(row(1, "a4")), toRows(testHarness));
+        shouldEmit(testHarness, row(RowKind.INSERT, 1, "a4"));
 
         testHarness.setStateTtlProcessingTime(1002);
 
         testHarness.processElement(deleteRecord(1, "a4"));
-        Assert.assertEquals(Collections.emptyList(), toRows(testHarness));
+        shouldEmitNothing(testHarness);
 
         testHarness.close();
     }
 
-    private List<RowData> toRows(OneInputStreamOperatorTestHarness<RowData, RowData> harness) {
+    private void shouldEmitNothing(OneInputStreamOperatorTestHarness<RowData, RowData> harness) {
+        assertEquals(Collections.emptyList(), getEmittedRows(harness));
+    }
+
+    private void shouldEmit(
+            OneInputStreamOperatorTestHarness<RowData, RowData> harness, RowData expected) {
+        assertEquals(Collections.singletonList(expected), getEmittedRows(harness));
+    }
+
+    private static List<RowData> getEmittedRows(
+            OneInputStreamOperatorTestHarness<RowData, RowData> harness) {
+        final List<RowData> rows = new ArrayList<>();
         Object o;
-        List<RowData> ret = new ArrayList<>();
         while ((o = harness.getOutput().poll()) != null) {
-            RowData value = (RowData) ((StreamRecord) o).getValue();
+            RowData value = (RowData) ((StreamRecord<?>) o).getValue();
             GenericRowData newRow = GenericRowData.of(value.getInt(0), value.getString(1));
             newRow.setRowKind(value.getRowKind());
-            ret.add(newRow);
+            rows.add(newRow);
         }
-        return ret;
+        return rows;
     }
 
     private static class TestRecordEqualiser implements RecordEqualiser {
         @Override
         public boolean equals(RowData row1, RowData row2) {
-            return row1.getInt(0) == row2.getInt(0) && row1.getString(1).equals(row2.getString(1));
+            return row1.getRowKind() == row2.getRowKind()
+                    && row1.getInt(0) == row2.getInt(0)
+                    && row1.getString(1).equals(row2.getString(1));
         }
     }
 }

--- a/flink-table/flink-table-runtime-blink/src/test/java/org/apache/flink/table/runtime/util/StreamRecordUtils.java
+++ b/flink-table/flink-table-runtime-blink/src/test/java/org/apache/flink/table/runtime/util/StreamRecordUtils.java
@@ -105,7 +105,7 @@ public class StreamRecordUtils {
     }
 
     /** Receives a object array, generates a RowData based on the array. */
-    public static RowData row(RowKind rowKind, Object... fields) {
+    public static RowData rowOfKind(RowKind rowKind, Object... fields) {
         Object[] objects = new Object[fields.length];
         for (int i = 0; i < fields.length; i++) {
             Object field = fields[i];
@@ -120,7 +120,7 @@ public class StreamRecordUtils {
 
     /** Receives a object array, generates a RowData based on the array. */
     public static RowData row(Object... fields) {
-        return row(RowKind.INSERT, fields);
+        return rowOfKind(RowKind.INSERT, fields);
     }
 
     /**

--- a/flink-table/flink-table-runtime-blink/src/test/java/org/apache/flink/table/runtime/util/StreamRecordUtils.java
+++ b/flink-table/flink-table-runtime-blink/src/test/java/org/apache/flink/table/runtime/util/StreamRecordUtils.java
@@ -104,13 +104,8 @@ public class StreamRecordUtils {
         return new StreamRecord<>(row);
     }
 
-    /**
-     * Receives a object array, generates a RowData based on the array.
-     *
-     * @param fields input object array
-     * @return generated RowData.
-     */
-    public static RowData row(Object... fields) {
+    /** Receives a object array, generates a RowData based on the array. */
+    public static RowData row(RowKind rowKind, Object... fields) {
         Object[] objects = new Object[fields.length];
         for (int i = 0; i < fields.length; i++) {
             Object field = fields[i];
@@ -120,7 +115,12 @@ public class StreamRecordUtils {
                 objects[i] = field;
             }
         }
-        return GenericRowData.of(objects);
+        return GenericRowData.ofKind(rowKind, objects);
+    }
+
+    /** Receives a object array, generates a RowData based on the array. */
+    public static RowData row(Object... fields) {
+        return row(RowKind.INSERT, fields);
     }
 
     /**


### PR DESCRIPTION
## What is the purpose of the change

This is a backport of FLINK-24054 and a follow up fix FLINK-24130 for the 1.13 release branch.

The SinkUpsertMaterializer will be introduced in 1.13.3 so this PR should not have side effects on backwards compatibility.

## Verifying this change

This change is already covered by existing tests, such as `DataStreamJavaITCase`

## Does this pull request potentially affect one of the following parts:

  - Dependencies (does it add or upgrade a dependency): no
  - The public API, i.e., is any changed class annotated with `@Public(Evolving)`: no
  - The serializers: no
  - The runtime per-record code paths (performance sensitive): yes
  - Anything that affects deployment or recovery: JobManager (and its components), Checkpointing, Kubernetes/Yarn, ZooKeeper: no
  - The S3 file system connector: no

## Documentation

  - Does this pull request introduce a new feature? no
  - If yes, how is the feature documented? not applicable
