### PR TITLE
[FLINK-24410] Upgrade Confluent Platform OSS version in end-to-end tests

### DIFF
--- a/flink-end-to-end-tests/test-scripts/kafka-common.sh
+++ b/flink-end-to-end-tests/test-scripts/kafka-common.sh
@@ -52,7 +52,11 @@ function setup_kafka_dist {
 function setup_confluent_dist {
   # download confluent
   mkdir -p $TEST_DATA_DIR
-  CONFLUENT_URL="http://packages.confluent.io/archive/$CONFLUENT_MAJOR_VERSION/confluent-oss-$CONFLUENT_VERSION-2.11.tar.gz"
+  if [[ $CONFLUENT_MAJOR_VERSION =~ ^[6] ]]; then
+    CONFLUENT_URL="http://packages.confluent.io/archive/$CONFLUENT_MAJOR_VERSION/confluent-community-$CONFLUENT_VERSION.tar.gz"
+  else
+    CONFLUENT_URL="http://packages.confluent.io/archive/$CONFLUENT_MAJOR_VERSION/confluent-community-$CONFLUENT_VERSION-2.12.tar.gz"
+  fi
   echo "Downloading confluent from $CONFLUENT_URL"
   cache_path=$(get_artifact $CONFLUENT_URL)
   ln "$cache_path" "${TEST_DATA_DIR}/confluent.tgz"

--- a/flink-end-to-end-tests/test-scripts/test_confluent_schema_registry.sh
+++ b/flink-end-to-end-tests/test-scripts/test_confluent_schema_registry.sh
@@ -19,8 +19,18 @@
 
 set -Eeuo pipefail
 
+KAFKA_VERSION="2.6.0"
+CONFLUENT_VERSION="6.0.4"
+CONFLUENT_MAJOR_VERSION="6.0"
+# Check the Confluent Platform <> Apache Kafka compatibility matrix when updating KAFKA_VERSION
+KAFKA_SQL_VERSION="universal"
+
 source "$(dirname "$0")"/common.sh
-source "$(dirname "$0")"/kafka-common.sh 2.6.0 5.0.0 5.0
+source "$(dirname "$0")"/kafka_sql_common.sh \
+  $KAFKA_VERSION \
+  $CONFLUENT_VERSION \
+  $CONFLUENT_MAJOR_VERSION \
+  $KAFKA_SQL_VERSION
 
 function verify_output {
   local expected=$(printf $1)

--- a/flink-end-to-end-tests/test-scripts/test_pyflink.sh
+++ b/flink-end-to-end-tests/test-scripts/test_pyflink.sh
@@ -20,8 +20,9 @@
 set -Eeuo pipefail
 
 KAFKA_VERSION="2.2.0"
-CONFLUENT_VERSION="5.0.0"
-CONFLUENT_MAJOR_VERSION="5.0"
+CONFLUENT_VERSION="5.2.6"
+CONFLUENT_MAJOR_VERSION="5.2"
+# Check the Confluent Platform <> Apache Kafka compatibility matrix when updating KAFKA_VERSION
 KAFKA_SQL_VERSION="universal"
 SQL_JARS_DIR=${END_TO_END_DIR}/flink-sql-client-test/target/sql-jars
 KAFKA_SQL_JAR=$(find "$SQL_JARS_DIR" | grep "kafka_" )

--- a/flink-end-to-end-tests/test-scripts/test_sql_client.sh
+++ b/flink-end-to-end-tests/test-scripts/test_sql_client.sh
@@ -20,8 +20,9 @@
 set -Eeuo pipefail
 
 KAFKA_VERSION="2.2.2"
-CONFLUENT_VERSION="5.0.0"
-CONFLUENT_MAJOR_VERSION="5.0"
+CONFLUENT_VERSION="5.2.6"
+CONFLUENT_MAJOR_VERSION="5.2"
+# Check the Confluent Platform <> Apache Kafka compatibility matrix when updating KAFKA_VERSION
 KAFKA_SQL_VERSION="universal"
 ELASTICSEARCH_VERSION=7
 # we use the smallest version possible


### PR DESCRIPTION
## What is the purpose of the change

* Upgrade the used Confluent Platform OSS version in the Bash end-to-end tests to remove Scala 2.11 reference and match with used Kafka version in the tests according to https://docs.confluent.io/platform/current/installation/versions-interoperability.html

## Brief change log

* Bumped Confluent Platform OSS version to match with the Kafka version that's used by the test
* Using Scala 2.12 version instead of Scala 2.11 version, which now matches with Kafka (which already uses 2.12), unless the needed Confluent Platform OSS version is 6.x: then it will use the available version (there are no separate Scala versions as of version 6)
* Since Confluent Platform was renamed from `oss` to `community`, also updated the URL

## Verifying this change

This change is a trivial rework / code cleanup without any test coverage.

## Does this pull request potentially affect one of the following parts:

  - Dependencies (does it add or upgrade a dependency): (yes / **no**)
  - The public API, i.e., is any changed class annotated with `@Public(Evolving)`: (yes / **no**)
  - The serializers: (yes / **no** / don't know)
  - The runtime per-record code paths (performance sensitive): (yes / **no** / don't know)
  - Anything that affects deployment or recovery: JobManager (and its components), Checkpointing, Kubernetes/Yarn, ZooKeeper: (yes / **no** / don't know)
  - The S3 file system connector: (yes / **no** / don't know)

## Documentation

  - Does this pull request introduce a new feature? (yes / **no**)
  - If yes, how is the feature documented? (**not applicable** / docs / JavaDocs / not documented)
