### PR TITLE
[BP-1.14][FLINK-24117][HA]Remove unHandledErrorListener in ZooKeeperLeaderElectionDriver and ZooKeeperLeaderRetrievalDriver

### DIFF
--- a/flink-runtime/src/main/java/org/apache/flink/runtime/leaderretrieval/ZooKeeperLeaderRetrievalDriver.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/leaderretrieval/ZooKeeperLeaderRetrievalDriver.java
@@ -26,7 +26,6 @@ import org.apache.flink.runtime.util.ZooKeeperUtils;
 import org.apache.flink.util.ExceptionUtils;
 
 import org.apache.flink.shaded.curator4.org.apache.curator.framework.CuratorFramework;
-import org.apache.flink.shaded.curator4.org.apache.curator.framework.api.UnhandledErrorListener;
 import org.apache.flink.shaded.curator4.org.apache.curator.framework.recipes.cache.ChildData;
 import org.apache.flink.shaded.curator4.org.apache.curator.framework.recipes.cache.TreeCache;
 import org.apache.flink.shaded.curator4.org.apache.curator.framework.state.ConnectionState;
@@ -47,8 +46,7 @@ import static org.apache.flink.util.Preconditions.checkNotNull;
  * {@link ZooKeeperLeaderElectionDriver}. The leader address as well as the current leader session
  * ID is retrieved from ZooKeeper.
  */
-public class ZooKeeperLeaderRetrievalDriver
-        implements LeaderRetrievalDriver, UnhandledErrorListener {
+public class ZooKeeperLeaderRetrievalDriver implements LeaderRetrievalDriver {
     private static final Logger LOG = LoggerFactory.getLogger(ZooKeeperLeaderRetrievalDriver.class);
 
     /** Connection to the used ZooKeeper quorum. */
@@ -99,7 +97,6 @@ public class ZooKeeperLeaderRetrievalDriver
         this.leaderInformationClearancePolicy = leaderInformationClearancePolicy;
         this.fatalErrorHandler = checkNotNull(fatalErrorHandler);
 
-        client.getUnhandledErrorListenable().addListener(this);
         cache.start();
 
         client.getConnectionStateListenable().addListener(connectionStateListener);
@@ -117,7 +114,6 @@ public class ZooKeeperLeaderRetrievalDriver
 
         LOG.info("Closing {}.", this);
 
-        client.getUnhandledErrorListenable().removeListener(this);
         client.getConnectionStateListenable().removeListener(connectionStateListener);
 
         cache.close();
@@ -183,13 +179,6 @@ public class ZooKeeperLeaderRetrievalDriver
     private void onReconnectedConnectionState() {
         // check whether we find some new leader information in ZooKeeper
         retrieveLeaderInformationFromZooKeeper();
-    }
-
-    @Override
-    public void unhandledError(String s, Throwable throwable) {
-        fatalErrorHandler.onFatalError(
-                new LeaderRetrievalException(
-                        "Unhandled error in ZooKeeperLeaderRetrievalDriver:" + s, throwable));
     }
 
     @Override

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/util/ZooKeeperUtils.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/util/ZooKeeperUtils.java
@@ -241,7 +241,8 @@ public class ZooKeeperUtils {
      *     errors of {@link CuratorFramework}
      * @return {@link CuratorFramework} instance
      */
-    static CuratorFramework startCuratorFramework(
+    @VisibleForTesting
+    public static CuratorFramework startCuratorFramework(
             CuratorFrameworkFactory.Builder builder, FatalErrorHandler fatalErrorHandler) {
         CuratorFramework cf = builder.build();
         UnhandledErrorListener unhandledErrorListener =

--- a/flink-runtime/src/test/java/org/apache/flink/runtime/leaderretrieval/ZooKeeperLeaderRetrievalConnectionHandlingTest.java
+++ b/flink-runtime/src/test/java/org/apache/flink/runtime/leaderretrieval/ZooKeeperLeaderRetrievalConnectionHandlingTest.java
@@ -16,14 +16,12 @@
  * limitations under the License.
  */
 
-package org.apache.flink.runtime.leaderelection;
+package org.apache.flink.runtime.leaderretrieval;
 
 import org.apache.flink.api.common.time.Deadline;
 import org.apache.flink.configuration.Configuration;
 import org.apache.flink.configuration.HighAvailabilityOptions;
-import org.apache.flink.runtime.leaderretrieval.LeaderRetrievalDriver;
-import org.apache.flink.runtime.leaderretrieval.LeaderRetrievalEventHandler;
-import org.apache.flink.runtime.leaderretrieval.ZooKeeperLeaderRetrievalDriver;
+import org.apache.flink.runtime.leaderelection.LeaderInformation;
 import org.apache.flink.runtime.rest.util.NoOpFatalErrorHandler;
 import org.apache.flink.runtime.testutils.CommonTestUtils;
 import org.apache.flink.runtime.util.TestingFatalErrorHandlerResource;

--- a/flink-runtime/src/test/java/org/apache/flink/runtime/leaderretrieval/ZooKeeperLeaderRetrievalTest.java
+++ b/flink-runtime/src/test/java/org/apache/flink/runtime/leaderretrieval/ZooKeeperLeaderRetrievalTest.java
@@ -16,7 +16,7 @@
  * limitations under the License.
  */
 
-package org.apache.flink.runtime.leaderelection;
+package org.apache.flink.runtime.leaderretrieval;
 
 import org.apache.flink.configuration.Configuration;
 import org.apache.flink.configuration.HighAvailabilityOptions;
@@ -24,7 +24,8 @@ import org.apache.flink.runtime.blob.VoidBlobStore;
 import org.apache.flink.runtime.highavailability.HighAvailabilityServices;
 import org.apache.flink.runtime.highavailability.zookeeper.ZooKeeperHaServices;
 import org.apache.flink.runtime.jobmaster.JobMaster;
-import org.apache.flink.runtime.leaderretrieval.LeaderRetrievalService;
+import org.apache.flink.runtime.leaderelection.LeaderElectionService;
+import org.apache.flink.runtime.leaderelection.TestingContender;
 import org.apache.flink.runtime.rest.util.NoOpFatalErrorHandler;
 import org.apache.flink.runtime.rpc.AddressResolution;
 import org.apache.flink.runtime.rpc.RpcSystem;


### PR DESCRIPTION
Backport of #17150 to `release-1.14`.