### PR TITLE
[FLINK-24357][tests] Harden ZooKeeperLeaderElectionConnectionHandlingTest

### DIFF
--- a/flink-runtime/src/test/java/org/apache/flink/runtime/dispatcher/runner/ZooKeeperDefaultDispatcherRunnerTest.java
+++ b/flink-runtime/src/test/java/org/apache/flink/runtime/dispatcher/runner/ZooKeeperDefaultDispatcherRunnerTest.java
@@ -45,7 +45,6 @@ import org.apache.flink.runtime.jobmanager.JobGraphStoreFactory;
 import org.apache.flink.runtime.jobmaster.JobResult;
 import org.apache.flink.runtime.leaderelection.TestingLeaderElectionService;
 import org.apache.flink.runtime.metrics.groups.UnregisteredMetricGroups;
-import org.apache.flink.runtime.rest.util.NoOpFatalErrorHandler;
 import org.apache.flink.runtime.rpc.TestingRpcService;
 import org.apache.flink.runtime.rpc.TestingRpcServiceResource;
 import org.apache.flink.runtime.testtasks.NoOpInvokable;
@@ -144,7 +143,7 @@ public class ZooKeeperDefaultDispatcherRunnerTest extends TestLogger {
                 new TestingLeaderElectionService();
 
         final CuratorFramework client =
-                ZooKeeperUtils.startCuratorFramework(configuration, NoOpFatalErrorHandler.INSTANCE);
+                ZooKeeperUtils.startCuratorFramework(configuration, fatalErrorHandler);
         try (final TestingHighAvailabilityServices highAvailabilityServices =
                 new TestingHighAvailabilityServicesBuilder()
                         .setRunningJobsRegistry(

--- a/flink-runtime/src/test/java/org/apache/flink/runtime/highavailability/zookeeper/ZooKeeperHaServicesTest.java
+++ b/flink-runtime/src/test/java/org/apache/flink/runtime/highavailability/zookeeper/ZooKeeperHaServicesTest.java
@@ -27,8 +27,8 @@ import org.apache.flink.runtime.highavailability.RunningJobsRegistry;
 import org.apache.flink.runtime.leaderelection.LeaderElectionService;
 import org.apache.flink.runtime.leaderelection.TestingContender;
 import org.apache.flink.runtime.leaderretrieval.LeaderRetrievalService;
-import org.apache.flink.runtime.rest.util.NoOpFatalErrorHandler;
 import org.apache.flink.runtime.util.LeaderRetrievalUtils;
+import org.apache.flink.runtime.util.TestingFatalErrorHandlerResource;
 import org.apache.flink.runtime.util.ZooKeeperUtils;
 import org.apache.flink.runtime.zookeeper.ZooKeeperResource;
 import org.apache.flink.util.TestLogger;
@@ -43,6 +43,7 @@ import org.junit.AfterClass;
 import org.junit.Before;
 import org.junit.BeforeClass;
 import org.junit.ClassRule;
+import org.junit.Rule;
 import org.junit.Test;
 
 import javax.annotation.Nonnull;
@@ -64,6 +65,10 @@ import static org.junit.Assert.assertThat;
 public class ZooKeeperHaServicesTest extends TestLogger {
 
     @ClassRule public static final ZooKeeperResource ZOO_KEEPER_RESOURCE = new ZooKeeperResource();
+
+    @Rule
+    public final TestingFatalErrorHandlerResource testingFatalErrorHandlerResource =
+            new TestingFatalErrorHandlerResource();
 
     private static CuratorFramework client;
 
@@ -213,7 +218,8 @@ public class ZooKeeperHaServicesTest extends TestLogger {
         try (ZooKeeperHaServices zooKeeperHaServices =
                 new ZooKeeperHaServices(
                         ZooKeeperUtils.startCuratorFramework(
-                                configuration, NoOpFatalErrorHandler.INSTANCE),
+                                configuration,
+                                testingFatalErrorHandlerResource.getFatalErrorHandler()),
                         Executors.directExecutor(),
                         configuration,
                         blobStoreService)) {

--- a/flink-runtime/src/test/java/org/apache/flink/runtime/leaderelection/ZooKeeperLeaderElectionTest.java
+++ b/flink-runtime/src/test/java/org/apache/flink/runtime/leaderelection/ZooKeeperLeaderElectionTest.java
@@ -29,6 +29,7 @@ import org.apache.flink.runtime.leaderretrieval.ZooKeeperLeaderRetrievalDriver;
 import org.apache.flink.runtime.rest.util.NoOpFatalErrorHandler;
 import org.apache.flink.runtime.rpc.FatalErrorHandler;
 import org.apache.flink.runtime.util.TestingFatalErrorHandler;
+import org.apache.flink.runtime.util.TestingFatalErrorHandlerResource;
 import org.apache.flink.runtime.util.ZooKeeperUtils;
 import org.apache.flink.util.ExceptionUtils;
 import org.apache.flink.util.FlinkRuntimeException;
@@ -49,6 +50,7 @@ import org.apache.flink.shaded.zookeeper3.org.apache.zookeeper.data.ACL;
 import org.apache.curator.test.TestingServer;
 import org.junit.After;
 import org.junit.Before;
+import org.junit.Rule;
 import org.junit.Test;
 import org.mockito.Matchers;
 import org.mockito.Mockito;
@@ -106,6 +108,10 @@ public class ZooKeeperLeaderElectionTest extends TestLogger {
 
     private static final Logger LOG = LoggerFactory.getLogger(ZooKeeperLeaderElectionTest.class);
 
+    @Rule
+    public final TestingFatalErrorHandlerResource testingFatalErrorHandlerResource =
+            new TestingFatalErrorHandlerResource();
+
     @Before
     public void before() {
         try {
@@ -121,7 +127,8 @@ public class ZooKeeperLeaderElectionTest extends TestLogger {
         configuration.setString(HighAvailabilityOptions.HA_MODE, "zookeeper");
 
         client =
-                ZooKeeperUtils.startCuratorFramework(configuration, NoOpFatalErrorHandler.INSTANCE);
+                ZooKeeperUtils.startCuratorFramework(
+                        configuration, testingFatalErrorHandlerResource.getFatalErrorHandler());
     }
 
     @After
@@ -496,10 +503,10 @@ public class ZooKeeperLeaderElectionTest extends TestLogger {
         try {
             client =
                     ZooKeeperUtils.startCuratorFramework(
-                            configuration, NoOpFatalErrorHandler.INSTANCE);
+                            configuration, testingFatalErrorHandlerResource.getFatalErrorHandler());
             client2 =
                     ZooKeeperUtils.startCuratorFramework(
-                            configuration, NoOpFatalErrorHandler.INSTANCE);
+                            configuration, testingFatalErrorHandlerResource.getFatalErrorHandler());
 
             leaderElectionDriver = createAndInitLeaderElectionDriver(client, electionEventHandler);
             leaderRetrievalDriver =

--- a/flink-runtime/src/test/java/org/apache/flink/runtime/leaderretrieval/ZooKeeperLeaderRetrievalConnectionHandlingTest.java
+++ b/flink-runtime/src/test/java/org/apache/flink/runtime/leaderretrieval/ZooKeeperLeaderRetrievalConnectionHandlingTest.java
@@ -22,7 +22,6 @@ import org.apache.flink.api.common.time.Deadline;
 import org.apache.flink.configuration.Configuration;
 import org.apache.flink.configuration.HighAvailabilityOptions;
 import org.apache.flink.runtime.leaderelection.LeaderInformation;
-import org.apache.flink.runtime.rest.util.NoOpFatalErrorHandler;
 import org.apache.flink.runtime.testutils.CommonTestUtils;
 import org.apache.flink.runtime.util.TestingFatalErrorHandlerResource;
 import org.apache.flink.runtime.util.ZooKeeperUtils;
@@ -77,7 +76,8 @@ public class ZooKeeperLeaderRetrievalConnectionHandlingTest extends TestLogger {
                 HighAvailabilityOptions.HA_ZOOKEEPER_QUORUM, testingServer.getConnectString());
 
         zooKeeperClient =
-                ZooKeeperUtils.startCuratorFramework(config, NoOpFatalErrorHandler.INSTANCE);
+                ZooKeeperUtils.startCuratorFramework(
+                        config, fatalErrorHandlerResource.getFatalErrorHandler());
         zooKeeperClient.blockUntilConnected();
     }
 

--- a/flink-runtime/src/test/java/org/apache/flink/runtime/leaderretrieval/ZooKeeperLeaderRetrievalTest.java
+++ b/flink-runtime/src/test/java/org/apache/flink/runtime/leaderretrieval/ZooKeeperLeaderRetrievalTest.java
@@ -26,11 +26,11 @@ import org.apache.flink.runtime.highavailability.zookeeper.ZooKeeperHaServices;
 import org.apache.flink.runtime.jobmaster.JobMaster;
 import org.apache.flink.runtime.leaderelection.LeaderElectionService;
 import org.apache.flink.runtime.leaderelection.TestingContender;
-import org.apache.flink.runtime.rest.util.NoOpFatalErrorHandler;
 import org.apache.flink.runtime.rpc.AddressResolution;
 import org.apache.flink.runtime.rpc.RpcSystem;
 import org.apache.flink.runtime.testutils.TestingUtils;
 import org.apache.flink.runtime.util.LeaderRetrievalUtils;
+import org.apache.flink.runtime.util.TestingFatalErrorHandlerResource;
 import org.apache.flink.runtime.util.ZooKeeperUtils;
 import org.apache.flink.util.TestLogger;
 
@@ -39,6 +39,7 @@ import org.apache.flink.shaded.curator4.org.apache.curator.framework.CuratorFram
 import org.apache.curator.test.TestingServer;
 import org.junit.After;
 import org.junit.Before;
+import org.junit.Rule;
 import org.junit.Test;
 
 import java.io.IOException;
@@ -63,6 +64,10 @@ public class ZooKeeperLeaderRetrievalTest extends TestLogger {
 
     private HighAvailabilityServices highAvailabilityServices;
 
+    @Rule
+    public final TestingFatalErrorHandlerResource testingFatalErrorHandlerResource =
+            new TestingFatalErrorHandlerResource();
+
     @Before
     public void before() throws Exception {
         testingServer = new TestingServer();
@@ -73,7 +78,8 @@ public class ZooKeeperLeaderRetrievalTest extends TestLogger {
                 HighAvailabilityOptions.HA_ZOOKEEPER_QUORUM, testingServer.getConnectString());
 
         CuratorFramework client =
-                ZooKeeperUtils.startCuratorFramework(config, NoOpFatalErrorHandler.INSTANCE);
+                ZooKeeperUtils.startCuratorFramework(
+                        config, testingFatalErrorHandlerResource.getFatalErrorHandler());
 
         highAvailabilityServices =
                 new ZooKeeperHaServices(

--- a/flink-runtime/src/test/java/org/apache/flink/runtime/util/ExitJVMFatalErrorHandler.java
+++ b/flink-runtime/src/test/java/org/apache/flink/runtime/util/ExitJVMFatalErrorHandler.java
@@ -1,0 +1,32 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.flink.runtime.util;
+
+import org.apache.flink.runtime.rpc.FatalErrorHandler;
+import org.apache.flink.util.FatalExitExceptionHandler;
+
+/** Fatal error handler that exits the JVM. */
+public enum ExitJVMFatalErrorHandler implements FatalErrorHandler {
+    INSTANCE;
+
+    @Override
+    public void onFatalError(Throwable exception) {
+        FatalExitExceptionHandler.INSTANCE.uncaughtException(Thread.currentThread(), exception);
+    }
+}

--- a/flink-runtime/src/test/java/org/apache/flink/runtime/zookeeper/ZooKeeperTestEnvironment.java
+++ b/flink-runtime/src/test/java/org/apache/flink/runtime/zookeeper/ZooKeeperTestEnvironment.java
@@ -20,7 +20,7 @@ package org.apache.flink.runtime.zookeeper;
 
 import org.apache.flink.configuration.Configuration;
 import org.apache.flink.configuration.HighAvailabilityOptions;
-import org.apache.flink.runtime.rest.util.NoOpFatalErrorHandler;
+import org.apache.flink.runtime.util.ExitJVMFatalErrorHandler;
 import org.apache.flink.runtime.util.ZooKeeperUtils;
 
 import org.apache.flink.shaded.curator4.org.apache.curator.framework.CuratorFramework;
@@ -75,7 +75,7 @@ public class ZooKeeperTestEnvironment {
                         zooKeeperCluster.getConnectString());
             }
 
-            client = ZooKeeperUtils.startCuratorFramework(conf, NoOpFatalErrorHandler.INSTANCE);
+            client = ZooKeeperUtils.startCuratorFramework(conf, ExitJVMFatalErrorHandler.INSTANCE);
 
             client.newNamespaceAwareEnsurePath("/").ensure(client.getZookeeperClient());
         } catch (Exception e) {
@@ -128,7 +128,7 @@ public class ZooKeeperTestEnvironment {
     public CuratorFramework createClient() {
         Configuration config = new Configuration();
         config.setString(HighAvailabilityOptions.HA_ZOOKEEPER_QUORUM, getConnectString());
-        return ZooKeeperUtils.startCuratorFramework(config, NoOpFatalErrorHandler.INSTANCE);
+        return ZooKeeperUtils.startCuratorFramework(config, ExitJVMFatalErrorHandler.INSTANCE);
     }
 
     /**


### PR DESCRIPTION
This commit hardens ZooKeeperLeaderElectionConnectionHandlingTest.testLoseLeadershipOnLostConnectionIfTolerateSuspendedConnectionsIsEnabled
by allowing that exceptions can occur if the connection to ZooKeeper is lost. We do this by clearing the fatal error handler
at the end of the test.