### PR TITLE
[FLINK-24432][rocksdb] RocksIteratorWrapper.seekToLast() logic typo

### DIFF
--- a/flink-state-backends/flink-statebackend-rocksdb/src/main/java/org/apache/flink/contrib/streaming/state/RocksIteratorWrapper.java
+++ b/flink-state-backends/flink-statebackend-rocksdb/src/main/java/org/apache/flink/contrib/streaming/state/RocksIteratorWrapper.java
@@ -59,7 +59,7 @@ public class RocksIteratorWrapper implements RocksIteratorInterface, Closeable {
 
     @Override
     public void seekToLast() {
-        iterator.seekToFirst();
+        iterator.seekToLast();
         status();
     }
 


### PR DESCRIPTION
## What is the purpose of the change

The RocksIteratorWrapper is a wrapper of RocksIterator to do additional status check for all the methods. However, there's a typo that RocksIteratorWrapper.seekToLast() method calls RocksIterator's seekToFirst(), which is obviously wrong. I guess this issue wasn't found before as it was only referenced in the RocksTransformingIteratorWrapper.seekToLast() method and nowhere else. 


## Brief change log

*(for example:)*
  - Replace the *iterator.seekToFirst()* to the *iterator.seekToLast()* in the seekToLast method;


## Verifying this change

This change is a trivial rework / code cleanup without any test coverage.


## Does this pull request potentially affect one of the following parts:

  - Dependencies (does it add or upgrade a dependency): (no)
  - The public API, i.e., is any changed class annotated with `@Public(Evolving)`: (no)
  - The serializers: (no)
  - The runtime per-record code paths (performance sensitive): (no)
  - Anything that affects deployment or recovery: JobManager (and its components), Checkpointing, Kubernetes/Yarn, ZooKeeper: (no)
  - The S3 file system connector: (no)

## Documentation

  - Does this pull request introduce a new feature? (no)
  - If yes, how is the feature documented? (not applicable / docs / JavaDocs / not documented)
