### PR TITLE
[FLINK-24409][connectors] Fix metrics errors with topics names with periods

### DIFF
--- a/flink-connectors/flink-connector-kafka/src/main/java/org/apache/flink/connector/kafka/source/metrics/KafkaSourceReaderMetrics.java
+++ b/flink-connectors/flink-connector-kafka/src/main/java/org/apache/flink/connector/kafka/source/metrics/KafkaSourceReaderMetrics.java
@@ -289,6 +289,8 @@ public class KafkaSourceReaderMetrics {
     private @Nullable Metric getRecordsLagMetric(
             Map<MetricName, ? extends Metric> metrics, TopicPartition tp) {
         try {
+            final String resolvedTopic = tp.topic().replace('.', '_');
+            final String resolvedPartition = String.valueOf(tp.partition());
             Predicate<Map.Entry<MetricName, ? extends Metric>> filter =
                     entry -> {
                         final MetricName metricName = entry.getKey();
@@ -297,9 +299,9 @@ public class KafkaSourceReaderMetrics {
                         return metricName.group().equals(CONSUMER_FETCH_MANAGER_GROUP)
                                 && metricName.name().equals(RECORDS_LAG)
                                 && tags.containsKey("topic")
-                                && tags.get("topic").equals(tp.topic())
+                                && tags.get("topic").equals(resolvedTopic)
                                 && tags.containsKey("partition")
-                                && tags.get("partition").equals(String.valueOf(tp.partition()));
+                                && tags.get("partition").equals(resolvedPartition);
                     };
             return MetricUtil.getKafkaMetric(metrics, filter);
         } catch (IllegalStateException e) {


### PR DESCRIPTION
## What is the purpose of the change

* Fix the errors generated by the metrics code when reading from a Kafka topic that includes periods in the names. The filter for the metric tries to compare the topic name against the corresponding metric `topic` tag, but the metric tags execute a transform on the topic name that replaces any periods with underscores, so if you try to find the records-lag metric in via the changed function, it logs a WARN level log with an exception stack trace.

## Brief change log

  - Execute the required transformation in the `getRecordsLagMetric` function

## Verifying this change

This change is a trivial rework / code cleanup without any test coverage.

Unfortunately while some of the tests in `KafkaSourceReaderTest` cover this code and changing the topic name in that class to `"Kafka.Source.Reader.Test"` even causes the issue, it doesn't actually cause the tests to fail.  Further, the `KafkaSourceReaderMetricsTest` doesn't have any coverage of the `getRecordsLagMetric` function at all, which is disappointing.   I tried to add some coverage but I wasn't successful.  


## Does this pull request potentially affect one of the following parts:

  - Dependencies (does it add or upgrade a dependency): no
  - The public API, i.e., is any changed class annotated with `@Public(Evolving)`: no
  - The serializers: no
  - The runtime per-record code paths (performance sensitive): no
  - Anything that affects deployment or recovery: no
  - The S3 file system connector: no

## Documentation

  - Does this pull request introduce a new feature? no
  - If yes, how is the feature documented? not applicable
