### PR TITLE
[24017] Setup Kryo to be usable without flink-scala

### DIFF
--- a/flink-core/src/main/java/org/apache/flink/api/java/typeutils/runtime/ValueSerializer.java
+++ b/flink-core/src/main/java/org/apache/flink/api/java/typeutils/runtime/ValueSerializer.java
@@ -145,7 +145,8 @@ public final class ValueSerializer<T extends Value> extends TypeSerializer<T> {
 
             this.kryo.setAsmEnabled(true);
 
-            KryoUtils.applyRegistrations(this.kryo, kryoRegistrations.values());
+            KryoUtils.applyRegistrations(
+                    this.kryo, kryoRegistrations.values(), this.kryo.getNextRegistrationId());
         }
     }
 

--- a/flink-core/src/main/java/org/apache/flink/api/java/typeutils/runtime/kryo/ChillSerializerRegistrar.java
+++ b/flink-core/src/main/java/org/apache/flink/api/java/typeutils/runtime/kryo/ChillSerializerRegistrar.java
@@ -1,0 +1,38 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.flink.api.java.typeutils.runtime.kryo;
+
+import com.esotericsoftware.kryo.Kryo;
+
+/** Interface for flink-core to interact with the FlinkChillPackageRegistrar in flink-java. */
+public interface ChillSerializerRegistrar {
+    /**
+     * Registers all serializers with the given {@link Kryo}. All serializers are registered with
+     * specific IDs as a continuous block.
+     *
+     * @param kryo Kryo to register serializers with
+     */
+    void registerSerializers(Kryo kryo);
+
+    /**
+     * Returns the registration ID that immediately follows the last registered serializer.
+     *
+     * @return registration ID that should be used for the next serializer registration
+     */
+    int getNextRegistrationId();
+}

--- a/flink-java/pom.xml
+++ b/flink-java/pom.xml
@@ -53,6 +53,12 @@ under the License.
 			<!-- managed version -->
 		</dependency>
 
+		<dependency>
+			<groupId>com.twitter</groupId>
+			<artifactId>chill-java</artifactId>
+			<version>${chill.version}</version>
+		</dependency>
+
 		<!-- test dependencies -->
 
 		<dependency>

--- a/flink-java/src/main/java/org/apache/flink/api/java/typeutils/runtime/kryo/FlinkChillPackageRegistrar.java
+++ b/flink-java/src/main/java/org/apache/flink/api/java/typeutils/runtime/kryo/FlinkChillPackageRegistrar.java
@@ -16,7 +16,7 @@
  * limitations under the License.
  */
 
-package org.apache.flink.runtime.types;
+package org.apache.flink.api.java.typeutils.runtime.kryo;
 
 import com.esotericsoftware.kryo.Kryo;
 import com.esotericsoftware.kryo.Serializer;

--- a/flink-java/src/main/java/org/apache/flink/api/java/typeutils/runtime/kryo/FlinkChillPackageRegistrar.java
+++ b/flink-java/src/main/java/org/apache/flink/api/java/typeutils/runtime/kryo/FlinkChillPackageRegistrar.java
@@ -51,11 +51,17 @@ import java.util.regex.Pattern;
  * <p>All registrations use a hard-coded ID which were determined at commit
  * 18f176ce86900fd4e932c73f3d138912355c6880.
  */
-public class FlinkChillPackageRegistrar {
+public class FlinkChillPackageRegistrar implements ChillSerializerRegistrar {
 
     private static final int FIRST_REGISTRATION_ID = 73;
 
-    public static void registerJavaTypes(Kryo kryo) {
+    @Override
+    public int getNextRegistrationId() {
+        return 85;
+    }
+
+    @Override
+    public void registerSerializers(Kryo kryo) {
         //noinspection ArraysAsListWithZeroOrOneArgument
         new RegistrationHelper(FIRST_REGISTRATION_ID, kryo)
                 .register(Arrays.asList("").getClass(), new ArraysAsListSerializer())

--- a/flink-java/src/main/java/org/apache/flink/api/java/typeutils/runtime/kryo/PriorityQueueSerializer.java
+++ b/flink-java/src/main/java/org/apache/flink/api/java/typeutils/runtime/kryo/PriorityQueueSerializer.java
@@ -16,7 +16,7 @@
  * limitations under the License.
  */
 
-package org.apache.flink.runtime.types;
+package org.apache.flink.api.java.typeutils.runtime.kryo;
 
 import com.esotericsoftware.kryo.Kryo;
 import com.esotericsoftware.kryo.Serializer;

--- a/flink-scala/src/main/scala/org/apache/flink/runtime/types/FlinkScalaKryoInstantiator.scala
+++ b/flink-scala/src/main/scala/org/apache/flink/runtime/types/FlinkScalaKryoInstantiator.scala
@@ -25,6 +25,7 @@ import _root_.java.io.Serializable
 
 import com.twitter.chill._
 
+import org.apache.flink.api.java.typeutils.runtime.kryo.FlinkChillPackageRegistrar
 
 import scala.collection.JavaConverters._
 
@@ -189,6 +190,6 @@ class AllScalaRegistrar extends IKryoRegistrar {
     // use the singleton serializer for boxed Unit
     val boxedUnit = scala.Unit.box(())
     k.register(boxedUnit.getClass, new SingletonSerializer(boxedUnit))
-    FlinkChillPackageRegistrar.registerJavaTypes(k)
+    new FlinkChillPackageRegistrar().registerSerializers(k)
   }
 }

--- a/flink-scala/src/main/scala/org/apache/flink/runtime/types/FlinkScalaKryoInstantiator.scala
+++ b/flink-scala/src/main/scala/org/apache/flink/runtime/types/FlinkScalaKryoInstantiator.scala
@@ -189,6 +189,6 @@ class AllScalaRegistrar extends IKryoRegistrar {
     // use the singleton serializer for boxed Unit
     val boxedUnit = scala.Unit.box(())
     k.register(boxedUnit.getClass, new SingletonSerializer(boxedUnit))
-    FlinkChillPackageRegistrar.all()(k)
+    FlinkChillPackageRegistrar.registerJavaTypes(k)
   }
 }


### PR DESCRIPTION
With this PR Kryo works in a backwards-compatible fashion even if flink-scala is not on the classpath.
To that end the java-related serializers were moved to flink-java to remain accessible in that scenario, and the registration IDs of the java serializers and custom user-defined serializers were pinned such that they remain identical.