### PR TITLE
[FLINK-24445][build] Copy rpc-akka jar in package phase

### DIFF
--- a/flink-rpc/flink-rpc-akka-loader/pom.xml
+++ b/flink-rpc/flink-rpc-akka-loader/pom.xml
@@ -78,7 +78,7 @@ under the License.
 				<executions>
 					<execution>
 						<id>copy-rpc-akka-jars</id>
-						<phase>process-resources</phase>
+						<phase>package</phase>
 						<goals>
 							<goal>copy</goal>
 						</goals>


### PR DESCRIPTION
We now copy the rpc-akka jar in package phase. This allows developers to run `mvn clean compile/test` (and anything in-between) as we no longer require the jar to be present.