### PR TITLE
[hotfix][FileSource] internal refactoring to remove duplicated code without API change

### DIFF
--- a/flink-connectors/flink-connector-files/src/main/java/org/apache/flink/connector/file/src/FileSource.java
+++ b/flink-connectors/flink-connector-files/src/main/java/org/apache/flink/connector/file/src/FileSource.java
@@ -161,13 +161,8 @@ public final class FileSource<T> extends AbstractFileSource<T, FileSourceSplit> 
      * (GZip).
      */
     public static <T> FileSourceBuilder<T> forRecordStreamFormat(
-            final StreamFormat<T> reader, final Path... paths) {
-        checkNotNull(reader, "reader");
-        checkNotNull(paths, "paths");
-        checkArgument(paths.length > 0, "paths must not be empty");
-
-        final BulkFormat<T, FileSourceSplit> bulkFormat = new StreamFormatAdapter<>(reader);
-        return new FileSourceBuilder<>(paths, bulkFormat);
+            final StreamFormat<T> streamFormat, final Path... paths) {
+        return forBulkFileFormat(new StreamFormatAdapter<>(streamFormat), paths);
     }
 
     /**
@@ -177,12 +172,12 @@ public final class FileSource<T> extends AbstractFileSource<T, FileSourceSplit> 
      * <p>Examples for bulk readers are compressed and vectorized formats such as ORC or Parquet.
      */
     public static <T> FileSourceBuilder<T> forBulkFileFormat(
-            final BulkFormat<T, FileSourceSplit> reader, final Path... paths) {
-        checkNotNull(reader, "reader");
+            final BulkFormat<T, FileSourceSplit> bulkFormat, final Path... paths) {
+        checkNotNull(bulkFormat, "reader");
         checkNotNull(paths, "paths");
         checkArgument(paths.length > 0, "paths must not be empty");
 
-        return new FileSourceBuilder<>(paths, reader);
+        return new FileSourceBuilder<>(paths, bulkFormat);
     }
 
     /**
@@ -193,13 +188,8 @@ public final class FileSource<T> extends AbstractFileSource<T, FileSourceSplit> 
      * requires often more careful parametrization.
      */
     public static <T> FileSourceBuilder<T> forRecordFileFormat(
-            final FileRecordFormat<T> reader, final Path... paths) {
-        checkNotNull(reader, "reader");
-        checkNotNull(paths, "paths");
-        checkArgument(paths.length > 0, "paths must not be empty");
-
-        final BulkFormat<T, FileSourceSplit> bulkFormat = new FileRecordFormatAdapter<>(reader);
-        return new FileSourceBuilder<>(paths, bulkFormat);
+            final FileRecordFormat<T> recordFormat, final Path... paths) {
+        return forBulkFileFormat(new FileRecordFormatAdapter<>(recordFormat), paths);
     }
 
     // ------------------------------------------------------------------------


### PR DESCRIPTION
## What is the purpose of the change

This pull request removes the duplicated code for arguments check.

## Brief change log

  - Consolidate the arguments check in the forBulkFileFormat(...) method that will be called by other method for different Format i.e. forRecordStreamFormat(...) and forRecordFileFormat(...). Duplicated code is therefore removed.
  - Rename method argument names from "reader" to ***Format to improve the code readability.


## Verifying this change

This change is already covered by existing tests, such as *FileSourceTextLinesITCase* and *FileSourceHeavyThroughputTest*.

## Does this pull request potentially affect one of the following parts:

  - Dependencies (does it add or upgrade a dependency): (yes / **no**)
  - The public API, i.e., is any changed class annotated with `@Public(Evolving)`: (**yes** / no)
  - The serializers: (yes / **no** / don't know)
  - The runtime per-record code paths (performance sensitive): (yes / **no** / don't know)
  - Anything that affects deployment or recovery: JobManager (and its components), Checkpointing, Kubernetes/Yarn, ZooKeeper: (yes / **no** / don't know)
  - The S3 file system connector: (yes / **no** / don't know)

## Documentation

  - Does this pull request introduce a new feature? (yes / **no**)
  - If yes, how is the feature documented? (**not applicable** / docs / JavaDocs / not documented)
