### PR TITLE
[FLINK-24421][table-runtime] Fix conversion of strings to TIME

### DIFF
--- a/flink-table/flink-table-planner/src/test/java/org/apache/flink/table/planner/functions/CastFunctionITCase.java
+++ b/flink-table/flink-table-planner/src/test/java/org/apache/flink/table/planner/functions/CastFunctionITCase.java
@@ -577,7 +577,6 @@ public class CastFunctionITCase extends BuiltInFunctionTestBase {
                 CastTestSpecBuilder.testCastTo(DATE())
                         .fromCase(CHAR(3), "foo", null)
                         .fromCase(VARCHAR(5), "Flink", null)
-                        // https://issues.apache.org/jira/browse/FLINK-24421 Bug
                         .fromCase(STRING(), "123", LocalDate.of(123, 1, 1))
                         .fromCase(STRING(), "2021-09-27", LocalDate.of(2021, 9, 27))
                         .fromCase(
@@ -633,9 +632,10 @@ public class CastFunctionITCase extends BuiltInFunctionTestBase {
                 CastTestSpecBuilder.testCastTo(TIME())
                         .fromCase(CHAR(3), "foo", null)
                         .fromCase(VARCHAR(5), "Flink", null)
-                        // https://issues.apache.org/jira/browse/FLINK-24421 Bug
-                        .fromCase(STRING(), "123", LocalTime.of(23, 1, 1))
+                        .fromCase(STRING(), "123", LocalTime.of(23, 0, 0))
+                        .fromCase(STRING(), "123:45", LocalTime.of(23, 45, 0))
                         .fromCase(STRING(), "2021-09-27", null)
+                        .fromCase(STRING(), "2021-09-27 12:34:56", null)
                         // https://issues.apache.org/jira/browse/FLINK-17224 Fractional seconds are
                         // lost
                         .fromCase(STRING(), "12:34:56.123456789", LocalTime.of(12, 34, 56, 0))

--- a/flink-table/flink-table-runtime/src/main/java/org/apache/flink/table/runtime/functions/SqlDateTimeUtils.java
+++ b/flink-table/flink-table-runtime/src/main/java/org/apache/flink/table/runtime/functions/SqlDateTimeUtils.java
@@ -1465,8 +1465,8 @@ public class SqlDateTimeUtils {
                 return null;
             }
             hour = Integer.parseInt(v.substring(start, end).trim());
-            minute = 1;
-            second = 1;
+            minute = 0;
+            second = 0;
             milli = 0;
         } else {
             if (!isInteger(v.substring(start, colon1).trim())) {
@@ -1479,7 +1479,7 @@ public class SqlDateTimeUtils {
                     return null;
                 }
                 minute = Integer.parseInt(v.substring(colon1 + 1, end).trim());
-                second = 1;
+                second = 0;
                 milli = 0;
             } else {
                 if (!isInteger(v.substring(colon1 + 1, colon2).trim())) {


### PR DESCRIPTION
## What is the purpose of the change

Following calcite-avatica behaviour, fix the behaviour of parsing
string into unix time when the string is incomplete, missing 1 or
both `:` time units separator. Previously, minutes and seconds where
set to default value `1` instead of `0` when missing from the parsed
string. Issue was fixed in avatica with: https://github.com/apache/calcite-avatica/commit/cac2ffaaf97572d21cba195d7590d9ab0d32382e


## Brief change log

  - Apply the fix for parsing strings into time as in calcite-avatica


## Verifying this change

This change added tests and can be verified as follows:

  - Changed tests for CASTing string to TIME() which uses the method in question
  - Added more tests to demonstrate better the behaviour for such edge cases

## Does this pull request potentially affect one of the following parts:

  - Dependencies (does it add or upgrade a dependency): no
  - The public API, i.e., is any changed class annotated with `@Public(Evolving)`: no
  - The serializers: no
  - The runtime per-record code paths (performance sensitive): no
  - Anything that affects deployment or recovery: JobManager (and its components), Checkpointing, Kubernetes/Yarn, ZooKeeper: no
  - The S3 file system connector: no

## Documentation

  - Does this pull request introduce a new feature? no
  - If yes, how is the feature documented? not applicable
