### PR TITLE
[FLINK-24460][rocksdb] Rocksdb Iterator Error Handling Improvement

### DIFF
--- a/flink-state-backends/flink-statebackend-rocksdb/src/main/java/org/apache/flink/contrib/streaming/state/RocksIteratorWrapper.java
+++ b/flink-state-backends/flink-statebackend-rocksdb/src/main/java/org/apache/flink/contrib/streaming/state/RocksIteratorWrapper.java
@@ -30,11 +30,17 @@ import java.io.Closeable;
 import java.nio.ByteBuffer;
 
 /**
- * This is a wrapper around {@link RocksIterator} to check the iterator status for all the methods
- * mentioned to require this check in the wiki documentation: seek, next, seekToFirst, seekToLast,
- * seekForPrev, and prev. This is required because the iterator may pass the blocks or files it had
- * difficulties in reading (because of IO error, data corruption or other issues) and continue with
- * the next available keys. The status flag may not be OK, even if the iterator is valid. More
+ * This class was originally a wrapper around {@link RocksIterator} to check the iterator status for
+ * all the methods mentioned to require this check in the wiki documentation: seek, next,
+ * seekToFirst, seekToLast, seekForPrev, and prev. At that time, this was required because the
+ * iterator may pass the blocks or files it had difficulties in reading (because of IO errors, data
+ * corruptions or other issues) and continue with the next available keys. The status flag may not
+ * be OK, even if the iterator is valid.
+ *
+ * <p>However, after <a href="https://github.com/facebook/rocksdb/pull/3810">3810</a> was merged,
+ * the behaviour had changed. If the iterator is valid, the status() is guaranteed to be OK; If the
+ * iterator is not valid, there are two possibilities: 1) We have reached the end of the data. And
+ * in this case, status() is OK; 2) There is an error. In this case, status() is not OK; More
  * information can be found <a
  * href="https://github.com/facebook/rocksdb/wiki/Iterator#error-handling">here</a>.
  */
@@ -48,55 +54,52 @@ public class RocksIteratorWrapper implements RocksIteratorInterface, Closeable {
 
     @Override
     public boolean isValid() {
-        return this.iterator.isValid();
+        boolean isValid = this.iterator.isValid();
+        if (!isValid) {
+            status();
+        }
+
+        return isValid;
     }
 
     @Override
     public void seekToFirst() {
         iterator.seekToFirst();
-        status();
     }
 
     @Override
     public void seekToLast() {
         iterator.seekToFirst();
-        status();
     }
 
     @Override
     public void seek(byte[] target) {
         iterator.seek(target);
-        status();
     }
 
     @Override
     public void seekForPrev(byte[] target) {
         iterator.seekForPrev(target);
-        status();
     }
 
     @Override
     public void seek(ByteBuffer target) {
         iterator.seek(target);
-        status();
     }
 
     @Override
     public void seekForPrev(ByteBuffer target) {
         iterator.seekForPrev(target);
-        status();
     }
 
     @Override
     public void next() {
         iterator.next();
-        status();
     }
 
     @Override
     public void prev() {
         iterator.prev();
-        status();
     }
 
     @Override
@@ -111,7 +114,6 @@ public class RocksIteratorWrapper implements RocksIteratorInterface, Closeable {
     @Override
     public void refresh() throws RocksDBException {
         iterator.refresh();
-        status();
     }
 
     public byte[] key() {


### PR DESCRIPTION
## What is the purpose of the change

In FLINK-9373, we introduced RocksIteratorWrapper which was a wrapper around RocksIterator to check the iterator status for all the methods. At that time, it was required because the iterator may pass the blocks or files it had difficulties in reading (because of IO errors, data corruptions, or other issues) and continue with the next available keys. The status flag may not be OK, even if the iterator is valid.

However, the above behaviour changed after 3810 was merged on May 17, 2018:
 - If the iterator is valid, the status() is guaranteed to be OK;
 - If the iterator is not valid, there are two possibilities:
    1) We have reached the end of the data. And in this case, status() is OK;
    2) There is an error. In this case, status() is not OK;

More information can be found here: https://github.com/facebook/rocksdb/wiki/Iterator#error-handling


## Brief change log

  - *Remove all the status() calls from existing methods*
  - *Add status() check when the iterator is invalid (as per the best practice in the rocksdb wiki above)*
  - *Update the comments of RocksIteratorWrapper for this change*


## Verifying this change

This change is a trivial rework / code cleanup without any test coverage.


## Does this pull request potentially affect one of the following parts:

  - Dependencies (does it add or upgrade a dependency): (no)
  - The public API, i.e., is any changed class annotated with `@Public(Evolving)`: (no)
  - The serializers: (no)
  - The runtime per-record code paths (performance sensitive): (no)
  - Anything that affects deployment or recovery: JobManager (and its components), Checkpointing, Kubernetes/Yarn, ZooKeeper: (no)
  - The S3 file system connector: (no)

## Documentation

  - Does this pull request introduce a new feature? (no)
  - If yes, how is the feature documented? (not applicable)
