### PR TITLE
[FLINK-24443][table-runtime] Reenable IntervalJoinITCase.testRowTimeInnerJoinWithEquiTimeAttrs

### DIFF
--- a/flink-table/flink-table-planner/src/test/scala/org/apache/flink/table/planner/runtime/stream/sql/IntervalJoinITCase.scala
+++ b/flink-table/flink-table-planner/src/test/scala/org/apache/flink/table/planner/runtime/stream/sql/IntervalJoinITCase.scala
@@ -29,7 +29,7 @@ import org.apache.flink.types.Row
 import org.junit.Assert._
 import org.junit.runner.RunWith
 import org.junit.runners.Parameterized
-import org.junit.{Ignore, Test}
+import org.junit.Test
 
 import scala.collection.mutable
 
@@ -372,7 +372,6 @@ class IntervalJoinITCase(mode: StateBackendMode) extends StreamingWithStateTestB
   }
 
   /** test row time inner join with equi-times **/
-  @Ignore // see FLINK-24443
   @Test
   def testRowTimeInnerJoinWithEquiTimeAttrs(): Unit = {
 
@@ -390,10 +389,12 @@ class IntervalJoinITCase(mode: StateBackendMode) extends StreamingWithStateTestB
     data1.+=(("K1", 1000L, "L3"))
     data1.+=(("K2", 2000L, "L4"))
     data1.+=(("K1", 4000L, "L5"))
-    data1.+=(("K1", 1000L, "should-be-discarded"))
+    // See https://issues.apache.org/jira/browse/FLINK-24466
+    // data1.+=(("K1", 1000L, "should-be-discarded"))
     data1.+=(("K1", 6000L, "L7"))
     data1.+=(("K1", 5001L, "L8"))
-    data1.+=(("K2", 1000L, "should-be-discarded"))
+    // See https://issues.apache.org/jira/browse/FLINK-24466
+    // data1.+=(("K2", 1000L, "should-be-discarded"))
 
     val data2 = new mutable.MutableList[(String, Long, String)]
     data2.+=(("K1", 1000L, "R1"))


### PR DESCRIPTION
<!--
*Thank you very much for contributing to Apache Flink - we are happy that you want to help us improve Flink. To help the community review your contribution in the best possible way, please go through the checklist below, which will get the contribution into a shape in which it can be best reviewed.*

*Please understand that we do not do this to make contributions to Flink a hassle. In order to uphold a high standard of quality for code contributions, while at the same time managing a large number of contributions, we need contributors to prepare the contributions well, and give reviewers enough contextual information for the review. Please also understand that contributions that do not follow this guide will take longer to review and thus typically be picked up with lower priority by the community.*

## Contribution Checklist

  - Make sure that the pull request corresponds to a [JIRA issue](https://issues.apache.org/jira/projects/FLINK/issues). Exceptions are made for typos in JavaDoc or documentation files, which need no JIRA issue.
  
  - Name the pull request in the form "[FLINK-XXXX] [component] Title of the pull request", where *FLINK-XXXX* should be replaced by the actual issue number. Skip *component* if you are unsure about which is the best component.
  Typo fixes that have no associated JIRA issue should be named following this pattern: `[hotfix] [docs] Fix typo in event time introduction` or `[hotfix] [javadocs] Expand JavaDoc for PuncuatedWatermarkGenerator`.

  - Fill out the template below to describe the changes contributed by the pull request. That will give reviewers the context they need to do the review.
  
  - Make sure that the change passes the automated tests, i.e., `mvn clean verify` passes. You can set up Azure Pipelines CI to do that following [this guide](https://cwiki.apache.org/confluence/display/FLINK/Azure+Pipelines#AzurePipelines-Tutorial:SettingupAzurePipelinesforaforkoftheFlinkrepository).

  - Each pull request should address only one issue, not mix up code from multiple issues.
  
  - Each commit in the pull request has a meaningful commit message (including the JIRA id)

  - Once all items of the checklist are addressed, remove the above text and this checklist, leaving only the filled out template below.


**(The sections below can be removed for hotfixes of typos)**
-->

## What is the purpose of the change

Fixed and reenabled `IntervalJoinITCase.testRowTimeInnerJoinWithEquiTimeAttrs`

## Brief change log

- Fixed and reenabled `IntervalJoinITCase.testRowTimeInnerJoinWithEquiTimeAttrs`

## Verifying this change

This change is a trivial rework / code cleanup without any test coverage.

## Does this pull request potentially affect one of the following parts:

  - Dependencies (does it add or upgrade a dependency): no
  - The public API, i.e., is any changed class annotated with `@Public(Evolving)`: no
  - The serializers: no
  - The runtime per-record code paths (performance sensitive): no
  - Anything that affects deployment or recovery: JobManager (and its components), Checkpointing, Kubernetes/Yarn, ZooKeeper: no
  - The S3 file system connector: no

## Documentation

  - Does this pull request introduce a new feature? no
  - If yes, how is the feature documented? not applicable
