### PR TITLE
[hotfix][datastream] Add missing Internal annotations for OperatorCoordinator class

### DIFF
--- a/flink-runtime/src/main/java/org/apache/flink/runtime/operators/coordination/OperatorCoordinator.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/operators/coordination/OperatorCoordinator.java
@@ -18,6 +18,7 @@
 
 package org.apache.flink.runtime.operators.coordination;
 
+import org.apache.flink.annotation.Internal;
 import org.apache.flink.api.common.state.CheckpointListener;
 import org.apache.flink.runtime.executiongraph.ExecutionAttemptID;
 import org.apache.flink.runtime.jobgraph.OperatorID;
@@ -70,6 +71,7 @@ import java.util.concurrent.CompletableFuture;
  *       methods, the task are scheduled and deployed.
  * </ol>
  */
+@Internal
 public interface OperatorCoordinator extends CheckpointListener, AutoCloseable {
 
     /**

--- a/flink-streaming-java/src/main/java/org/apache/flink/streaming/api/operators/CoordinatedOperatorFactory.java
+++ b/flink-streaming-java/src/main/java/org/apache/flink/streaming/api/operators/CoordinatedOperatorFactory.java
@@ -18,6 +18,7 @@ limitations under the License.
 
 package org.apache.flink.streaming.api.operators;
 
+import org.apache.flink.annotation.Internal;
 import org.apache.flink.runtime.jobgraph.OperatorID;
 import org.apache.flink.runtime.operators.coordination.OperatorCoordinator;
 
@@ -25,6 +26,7 @@ import org.apache.flink.runtime.operators.coordination.OperatorCoordinator;
  * A factory class for the {@link StreamOperator}s implementing {@link
  * org.apache.flink.runtime.operators.coordination.OperatorEventHandler}.
  */
+@Internal
 public interface CoordinatedOperatorFactory<OUT> extends StreamOperatorFactory<OUT> {
 
     /**


### PR DESCRIPTION
For now we don't want to expose the coordinators, just things that use a coordinator, like the SourceEnumerator.

## Verifying this change

N/A

## Documentation

N/A
