### PR TITLE
[FLINK-24167][Runtime]Add default HeartbeatReceiver and HeartbeatSend…

### DIFF
--- a/flink-runtime/src/main/java/org/apache/flink/runtime/heartbeat/HeartbeatReceiver.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/heartbeat/HeartbeatReceiver.java
@@ -1,0 +1,40 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.flink.runtime.heartbeat;
+
+import org.apache.flink.runtime.clusterframework.types.ResourceID;
+import org.apache.flink.util.concurrent.FutureUtils;
+
+import java.util.concurrent.CompletableFuture;
+
+/**
+ * The receiver implementation of {@link HeartbeatTarget}, which mutes the {@link
+ * HeartbeatTarget#requestHeartbeat(ResourceID, I)}. The extender only has to care about the
+ * receiving logic.
+ *
+ * @param <I> Type of the payload which is received by the heartbeat target
+ */
+public abstract class HeartbeatReceiver<I> implements HeartbeatTarget<I> {
+
+    @Override
+    public final CompletableFuture<Void> requestHeartbeat(
+            ResourceID requestOrigin, I heartbeatPayload) {
+        return FutureUtils.unsupportedOperationFuture();
+    }
+}

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/heartbeat/HeartbeatSender.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/heartbeat/HeartbeatSender.java
@@ -1,0 +1,40 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.flink.runtime.heartbeat;
+
+import org.apache.flink.runtime.clusterframework.types.ResourceID;
+import org.apache.flink.util.concurrent.FutureUtils;
+
+import java.util.concurrent.CompletableFuture;
+
+/**
+ * The sender implementation of {@link HeartbeatTarget}, which mutes the {@link
+ * HeartbeatTarget#receiveHeartbeat(ResourceID, I)}. The extender only has to care about the sending
+ * logic.
+ *
+ * @param <I> Type of the payload which is sent to the heartbeat target
+ */
+public abstract class HeartbeatSender<I> implements HeartbeatTarget<I> {
+
+    @Override
+    public final CompletableFuture<Void> receiveHeartbeat(
+            ResourceID heartbeatOrigin, I heartbeatPayload) {
+        return FutureUtils.unsupportedOperationFuture();
+    }
+}

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/jobmaster/JobMaster.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/jobmaster/JobMaster.java
@@ -36,8 +36,9 @@ import org.apache.flink.runtime.executiongraph.ExecutionAttemptID;
 import org.apache.flink.runtime.executiongraph.JobStatusListener;
 import org.apache.flink.runtime.heartbeat.HeartbeatListener;
 import org.apache.flink.runtime.heartbeat.HeartbeatManager;
+import org.apache.flink.runtime.heartbeat.HeartbeatReceiver;
+import org.apache.flink.runtime.heartbeat.HeartbeatSender;
 import org.apache.flink.runtime.heartbeat.HeartbeatServices;
-import org.apache.flink.runtime.heartbeat.HeartbeatTarget;
 import org.apache.flink.runtime.heartbeat.NoOpHeartbeatManager;
 import org.apache.flink.runtime.highavailability.HighAvailabilityServices;
 import org.apache.flink.runtime.io.network.partition.JobMasterPartitionTracker;
@@ -736,7 +737,7 @@ public class JobMaster extends PermanentlyFencedRpcEndpoint<JobMasterId>
                                 // monitor the task manager as heartbeat target
                                 taskManagerHeartbeatManager.monitorTarget(
                                         taskManagerId,
-                                        new TaskExecutorHeartbeatTarget(taskExecutorGateway));
+                                        new TaskExecutorHeartbeatSender(taskExecutorGateway));
 
                                 return new JMTMRegistrationSuccess(resourceId);
                             },
@@ -1094,7 +1095,7 @@ public class JobMaster extends PermanentlyFencedRpcEndpoint<JobMasterId>
 
             resourceManagerHeartbeatManager.monitorTarget(
                     resourceManagerResourceId,
-                    new ResourceManagerHeartbeatTarget(resourceManagerGateway));
+                    new ResourceManagerHeartbeatReceiver(resourceManagerGateway));
         } else {
             log.debug(
                     "Ignoring resource manager connection to {} because it's duplicated or outdated.",
@@ -1155,20 +1156,12 @@ public class JobMaster extends PermanentlyFencedRpcEndpoint<JobMasterId>
     // Utility classes
     // ----------------------------------------------------------------------------------------------
 
-    private static final class TaskExecutorHeartbeatTarget
-            implements HeartbeatTarget<AllocatedSlotReport> {
+    private static final class TaskExecutorHeartbeatSender
+            extends HeartbeatSender<AllocatedSlotReport> {
         private final TaskExecutorGateway taskExecutorGateway;
 
-        private TaskExecutorHeartbeatTarget(TaskExecutorGateway taskExecutorGateway) {
+        private TaskExecutorHeartbeatSender(TaskExecutorGateway taskExecutorGateway) {
             this.taskExecutorGateway = taskExecutorGateway;
-        }
-
-        @Override
-        public CompletableFuture<Void> receiveHeartbeat(
-                ResourceID resourceID, AllocatedSlotReport payload) {
-            // the task manager will not request heartbeat, so
-            // this method will never be called currently
-            return FutureUtils.unsupportedOperationFuture();
         }
 
         @Override
@@ -1178,22 +1171,16 @@ public class JobMaster extends PermanentlyFencedRpcEndpoint<JobMasterId>
         }
     }
 
-    private static final class ResourceManagerHeartbeatTarget implements HeartbeatTarget<Void> {
+    private static final class ResourceManagerHeartbeatReceiver extends HeartbeatReceiver<Void> {
         private final ResourceManagerGateway resourceManagerGateway;
 
-        private ResourceManagerHeartbeatTarget(ResourceManagerGateway resourceManagerGateway) {
+        private ResourceManagerHeartbeatReceiver(ResourceManagerGateway resourceManagerGateway) {
             this.resourceManagerGateway = resourceManagerGateway;
         }
 
         @Override
         public CompletableFuture<Void> receiveHeartbeat(ResourceID resourceID, Void payload) {
             return resourceManagerGateway.heartbeatFromJobManager(resourceID);
-        }
-
-        @Override
-        public CompletableFuture<Void> requestHeartbeat(ResourceID resourceID, Void payload) {
-            // request heartbeat will never be called on the job manager side
-            return FutureUtils.unsupportedOperationFuture();
         }
     }
 

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/resourcemanager/ResourceManager.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/resourcemanager/ResourceManager.java
@@ -33,8 +33,8 @@ import org.apache.flink.runtime.clusterframework.types.SlotID;
 import org.apache.flink.runtime.entrypoint.ClusterInformation;
 import org.apache.flink.runtime.heartbeat.HeartbeatListener;
 import org.apache.flink.runtime.heartbeat.HeartbeatManager;
+import org.apache.flink.runtime.heartbeat.HeartbeatSender;
 import org.apache.flink.runtime.heartbeat.HeartbeatServices;
-import org.apache.flink.runtime.heartbeat.HeartbeatTarget;
 import org.apache.flink.runtime.heartbeat.NoOpHeartbeatManager;
 import org.apache.flink.runtime.instance.InstanceID;
 import org.apache.flink.runtime.io.network.partition.DataSetMetaInfo;
@@ -854,7 +854,7 @@ public abstract class ResourceManager<WorkerType extends ResourceIDRetrievable>
                 jobId);
 
         jobManagerHeartbeatManager.monitorTarget(
-                jobManagerResourceId, new JobMasterHeartbeatTarget(jobMasterGateway));
+                jobManagerResourceId, new JobMasterHeartbeatSender(jobMasterGateway));
 
         return new JobMasterRegistrationSuccess(getFencingToken(), resourceId);
     }
@@ -916,7 +916,7 @@ public abstract class ResourceManager<WorkerType extends ResourceIDRetrievable>
             taskExecutors.put(taskExecutorResourceId, registration);
 
             taskManagerHeartbeatManager.monitorTarget(
-                    taskExecutorResourceId, new TaskExecutorHeartbeatTarget(taskExecutorGateway));
+                    taskExecutorResourceId, new TaskExecutorHeartbeatSender(taskExecutorGateway));
 
             return new TaskExecutorRegistrationSuccess(
                     registration.getInstanceID(), resourceId, clusterInformation);
@@ -1197,17 +1197,11 @@ public abstract class ResourceManager<WorkerType extends ResourceIDRetrievable>
     //  Static utility classes
     // ------------------------------------------------------------------------
 
-    private static final class JobMasterHeartbeatTarget implements HeartbeatTarget<Void> {
+    private static final class JobMasterHeartbeatSender extends HeartbeatSender<Void> {
         private final JobMasterGateway jobMasterGateway;
 
-        private JobMasterHeartbeatTarget(JobMasterGateway jobMasterGateway) {
+        private JobMasterHeartbeatSender(JobMasterGateway jobMasterGateway) {
             this.jobMasterGateway = jobMasterGateway;
-        }
-
-        @Override
-        public CompletableFuture<Void> receiveHeartbeat(ResourceID resourceID, Void payload) {
-            // the ResourceManager will always send heartbeat requests to the JobManager
-            return FutureUtils.unsupportedOperationFuture();
         }
 
         @Override
@@ -1216,18 +1210,11 @@ public abstract class ResourceManager<WorkerType extends ResourceIDRetrievable>
         }
     }
 
-    private static final class TaskExecutorHeartbeatTarget implements HeartbeatTarget<Void> {
+    private static final class TaskExecutorHeartbeatSender extends HeartbeatSender<Void> {
         private final TaskExecutorGateway taskExecutorGateway;
 
-        private TaskExecutorHeartbeatTarget(TaskExecutorGateway taskExecutorGateway) {
+        private TaskExecutorHeartbeatSender(TaskExecutorGateway taskExecutorGateway) {
             this.taskExecutorGateway = taskExecutorGateway;
-        }
-
-        @Override
-        public CompletableFuture<Void> receiveHeartbeat(ResourceID resourceID, Void payload) {
-            // the ResourceManager will always send heartbeat requests to the
-            // TaskManager
-            return FutureUtils.unsupportedOperationFuture();
         }
 
         @Override


### PR DESCRIPTION
…er to simplify the usage of HeartbeatTarget

## What is the purpose of the change

Add default HeartbeatReceiver and HeartbeatSender to simplify the usage of HeartbeatTarget


## Brief change log

Let most heartbeat listeners extend from `HeartbeatReceiver` or `HeartbeatSender`, instead of using `HeartbeatTarget` directly.

## Verifying this change

This change is already covered by existing tests
