### PR TITLE
[hotfix]Refactor the registerJobManager to registerJobMaster

### DIFF
--- a/flink-runtime/src/main/java/org/apache/flink/runtime/jobmaster/JobMaster.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/jobmaster/JobMaster.java
@@ -1274,7 +1274,7 @@ public class JobMaster extends PermanentlyFencedRpcEndpoint<JobMasterId>
                         long timeoutMillis) {
                     Time timeout = Time.milliseconds(timeoutMillis);
 
-                    return gateway.registerJobManager(
+                    return gateway.registerJobMaster(
                             jobMasterId,
                             jobManagerResourceID,
                             jobManagerRpcAddress,

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/resourcemanager/ResourceManager.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/resourcemanager/ResourceManager.java
@@ -99,8 +99,8 @@ import static org.apache.flink.util.Preconditions.checkNotNull;
  * <p>It offers the following methods as part of its rpc interface to interact with him remotely:
  *
  * <ul>
- *   <li>{@link #registerJobManager(JobMasterId, ResourceID, String, JobID, Time)} registers a
- *       {@link JobMaster} at the resource manager
+ *   <li>{@link #registerJobMaster(JobMasterId, ResourceID, String, JobID, Time)} registers a {@link
+ *       JobMaster} at the resource manager
  * </ul>
  */
 public abstract class ResourceManager<WorkerType extends ResourceIDRetrievable>
@@ -311,7 +311,7 @@ public abstract class ResourceManager<WorkerType extends ResourceIDRetrievable>
     // ------------------------------------------------------------------------
 
     @Override
-    public CompletableFuture<RegistrationResponse> registerJobManager(
+    public CompletableFuture<RegistrationResponse> registerJobMaster(
             final JobMasterId jobMasterId,
             final ResourceID jobManagerResourceId,
             final String jobManagerAddress,

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/resourcemanager/ResourceManagerGateway.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/resourcemanager/ResourceManagerGateway.java
@@ -67,7 +67,7 @@ public interface ResourceManagerGateway
      * @param timeout Timeout for the future to complete
      * @return Future registration response
      */
-    CompletableFuture<RegistrationResponse> registerJobManager(
+    CompletableFuture<RegistrationResponse> registerJobMaster(
             JobMasterId jobMasterId,
             ResourceID jobMasterResourceId,
             String jobMasterAddress,

--- a/flink-runtime/src/test/java/org/apache/flink/runtime/resourcemanager/ResourceManagerJobMasterTest.java
+++ b/flink-runtime/src/test/java/org/apache/flink/runtime/resourcemanager/ResourceManagerJobMasterTest.java
@@ -145,7 +145,7 @@ public class ResourceManagerJobMasterTest extends TestLogger {
     public void testRegisterJobMaster() throws Exception {
         // test response successful
         CompletableFuture<RegistrationResponse> successfulFuture =
-                resourceManagerGateway.registerJobManager(
+                resourceManagerGateway.registerJobMaster(
                         jobMasterGateway.getFencingToken(),
                         jobMasterResourceId,
                         jobMasterGateway.getAddress(),
@@ -170,7 +170,7 @@ public class ResourceManagerJobMasterTest extends TestLogger {
         // test throw exception when receive a registration from job master which takes unmatched
         // leaderSessionId
         CompletableFuture<RegistrationResponse> unMatchedLeaderFuture =
-                wronglyFencedGateway.registerJobManager(
+                wronglyFencedGateway.registerJobMaster(
                         jobMasterGateway.getFencingToken(),
                         jobMasterResourceId,
                         jobMasterGateway.getAddress(),
@@ -192,7 +192,7 @@ public class ResourceManagerJobMasterTest extends TestLogger {
         // leaderSessionId
         JobMasterId differentJobMasterId = JobMasterId.generate();
         CompletableFuture<RegistrationResponse> unMatchedLeaderFuture =
-                resourceManagerGateway.registerJobManager(
+                resourceManagerGateway.registerJobMaster(
                         differentJobMasterId,
                         jobMasterResourceId,
                         jobMasterGateway.getAddress(),
@@ -208,7 +208,7 @@ public class ResourceManagerJobMasterTest extends TestLogger {
         // address
         String invalidAddress = "/jobMasterAddress2";
         CompletableFuture<RegistrationResponse> invalidAddressFuture =
-                resourceManagerGateway.registerJobManager(
+                resourceManagerGateway.registerJobMaster(
                         new JobMasterId(HighAvailabilityServices.DEFAULT_LEADER_ID),
                         jobMasterResourceId,
                         invalidAddress,
@@ -229,7 +229,7 @@ public class ResourceManagerJobMasterTest extends TestLogger {
 
         // this should fail because we try to register a job leader listener for an unknown job id
         CompletableFuture<RegistrationResponse> registrationFuture =
-                resourceManagerGateway.registerJobManager(
+                resourceManagerGateway.registerJobMaster(
                         jobMasterGateway.getFencingToken(),
                         jobMasterResourceId,
                         jobMasterGateway.getAddress(),

--- a/flink-runtime/src/test/java/org/apache/flink/runtime/resourcemanager/ResourceManagerTest.java
+++ b/flink-runtime/src/test/java/org/apache/flink/runtime/resourcemanager/ResourceManagerTest.java
@@ -272,7 +272,7 @@ public class ResourceManagerTest extends TestLogger {
         final ResourceManagerGateway resourceManagerGateway =
                 resourceManager.getSelfGateway(ResourceManagerGateway.class);
         resourceManagerGateway
-                .registerJobManager(
+                .registerJobMaster(
                         jobMasterGateway.getFencingToken(),
                         ResourceID.generate(),
                         jobMasterGateway.getAddress(),
@@ -327,7 +327,7 @@ public class ResourceManagerTest extends TestLogger {
                 (ignore) -> {},
                 resourceManagerGateway -> {
                     final CompletableFuture<RegistrationResponse> registrationFuture =
-                            resourceManagerGateway.registerJobManager(
+                            resourceManagerGateway.registerJobMaster(
                                     jobMasterGateway.getFencingToken(),
                                     jobMasterResourceId,
                                     jobMasterGateway.getAddress(),
@@ -383,7 +383,7 @@ public class ResourceManagerTest extends TestLogger {
                 (ignore) -> {},
                 resourceManagerGateway -> {
                     final CompletableFuture<RegistrationResponse> registrationFuture =
-                            resourceManagerGateway.registerJobManager(
+                            resourceManagerGateway.registerJobMaster(
                                     jobMasterGateway.getFencingToken(),
                                     jobMasterResourceId,
                                     jobMasterGateway.getAddress(),
@@ -541,7 +541,7 @@ public class ResourceManagerTest extends TestLogger {
         final JobID jobId = JobID.generate();
         final ResourceManagerGateway resourceManagerGateway =
                 resourceManager.getSelfGateway(ResourceManagerGateway.class);
-        resourceManagerGateway.registerJobManager(
+        resourceManagerGateway.registerJobMaster(
                 jobMasterGateway.getFencingToken(),
                 ResourceID.generate(),
                 jobMasterGateway.getAddress(),

--- a/flink-runtime/src/test/java/org/apache/flink/runtime/resourcemanager/utils/TestingResourceManagerGateway.java
+++ b/flink-runtime/src/test/java/org/apache/flink/runtime/resourcemanager/utils/TestingResourceManagerGateway.java
@@ -236,7 +236,7 @@ public class TestingResourceManagerGateway implements ResourceManagerGateway {
     }
 
     @Override
-    public CompletableFuture<RegistrationResponse> registerJobManager(
+    public CompletableFuture<RegistrationResponse> registerJobMaster(
             JobMasterId jobMasterId,
             ResourceID jobMasterResourceId,
             String jobMasterAddress,


### PR DESCRIPTION
This pr refactor the outdated method naming `registerJobManager` to `registerJobMaster`, 