### PR TITLE
[FLINK-24431][kinesis][efo] Stop consumer deregistration when EAGER EFO configured into 1.12.x

### DIFF
--- a/docs/dev/connectors/kinesis.md
+++ b/docs/dev/connectors/kinesis.md
@@ -510,8 +510,7 @@ Retry and backoff parameters can be configured using the
 this is called during stream consumer registration and deregistration. For each stream this service will be invoked 
 periodically until the stream consumer is reported `ACTIVE`/`not found` for registration/deregistration. By default,
 the `LAZY` registration strategy will scale the number of calls by the job parallelism. `EAGER` will call the service 
-once per stream for registration, and scale the number of calls by the job parallelism for deregistration. 
-`NONE` will not invoke this service. Retry and backoff parameters can be configured using the 
+once per stream for registration only. `NONE` will not invoke this service. Retry and backoff parameters can be configured using the 
 `ConsumerConfigConstants.DESCRIBE_STREAM_CONSUMER_*` keys.  
 
 - *[RegisterStreamConsumer](https://docs.aws.amazon.com/kinesis/latest/APIReference/API_RegisterStreamConsumer.html)*: 
@@ -519,7 +518,7 @@ this is called once per stream during stream consumer registration, unless the `
 Retry and backoff parameters can be configured using the `ConsumerConfigConstants.REGISTER_STREAM_*` keys.
 
 - *[DeregisterStreamConsumer](https://docs.aws.amazon.com/kinesis/latest/APIReference/API_DeregisterStreamConsumer.html)*: 
-this is called once per stream during stream consumer deregistration, unless the `NONE` registration strategy is configured.
+this is called once per stream during stream consumer deregistration, unless the `NONE` or `EAGER` registration strategy is configured.
 Retry and backoff parameters can be configured using the `ConsumerConfigConstants.DEREGISTER_STREAM_*` keys.  
 
 ## Kinesis Producer

--- a/docs/dev/connectors/kinesis.zh.md
+++ b/docs/dev/connectors/kinesis.zh.md
@@ -510,8 +510,7 @@ Retry and backoff parameters can be configured using the
 this is called during stream consumer registration and deregistration. For each stream this service will be invoked 
 periodically until the stream consumer is reported `ACTIVE`/`not found` for registration/deregistration. By default,
 the `LAZY` registration strategy will scale the number of calls by the job parallelism. `EAGER` will call the service 
-once per stream for registration, and scale the number of calls by the job parallelism for deregistration. 
-`NONE` will not invoke this service. Retry and backoff parameters can be configured using the 
+once per stream for registration only. `NONE` will not invoke this service. Retry and backoff parameters can be configured using the 
 `ConsumerConfigConstants.DESCRIBE_STREAM_CONSUMER_*` keys.  
 
 - *[RegisterStreamConsumer](https://docs.aws.amazon.com/kinesis/latest/APIReference/API_RegisterStreamConsumer.html)*: 
@@ -519,7 +518,7 @@ this is called once per stream during stream consumer registration, unless the `
 Retry and backoff parameters can be configured using the `ConsumerConfigConstants.REGISTER_STREAM_*` keys.
 
 - *[DeregisterStreamConsumer](https://docs.aws.amazon.com/kinesis/latest/APIReference/API_DeregisterStreamConsumer.html)*: 
-this is called once per stream during stream consumer deregistration, unless the `NONE` registration strategy is configured.
+this is called once per stream during stream consumer deregistration, unless the `NONE` or `EAGER` registration strategy is configured.
 Retry and backoff parameters can be configured using the `ConsumerConfigConstants.DEREGISTER_STREAM_*` keys.  
 
 ## Kinesis Producer

--- a/docs/dev/table/connectors/kinesis.md
+++ b/docs/dev/table/connectors/kinesis.md
@@ -736,10 +736,10 @@ You can enable and configure EFO with the following properties:
 However, consumer names do not have to be unique across data streams.
 Reusing a consumer name will result in existing subscriptions being terminated.
 
-<span class="label label-info">Note</span> With the `LAZY` and `EAGER` strategies, stream consumers are de-registered when the job is shutdown gracefully.
+<span class="label label-info">Note</span> With the `LAZY` strategy, stream consumers are de-registered when the job is shutdown gracefully.
 In the event that a job terminates within executing the shutdown hooks, stream consumers will remain active.
 In this situation the stream consumers will be gracefully reused when the application restarts.
-With the `NONE` strategy, stream consumer de-registration is not performed by `FlinkKinesisConsumer`.
+With the `NONE` and `EAGER` strategies, stream consumer de-registration is not performed by `FlinkKinesisConsumer`.
 
 Data Type Mapping
 ----------------

--- a/docs/dev/table/connectors/kinesis.zh.md
+++ b/docs/dev/table/connectors/kinesis.zh.md
@@ -736,10 +736,10 @@ You can enable and configure EFO with the following properties:
 However, consumer names do not have to be unique across data streams.
 Reusing a consumer name will result in existing subscriptions being terminated.
 
-<span class="label label-info">Note</span> With the `LAZY` and `EAGER` strategies, stream consumers are de-registered when the job is shutdown gracefully.
+<span class="label label-info">Note</span> With the `LAZY` strategy, stream consumers are de-registered when the job is shutdown gracefully.
 In the event that a job terminates within executing the shutdown hooks, stream consumers will remain active.
 In this situation the stream consumers will be gracefully reused when the application restarts.
-With the `NONE` strategy, stream consumer de-registration is not performed by `FlinkKinesisConsumer`.
+With the `NONE` and `EAGER` strategies, stream consumer de-registration is not performed by `FlinkKinesisConsumer`.
 
 Data Type Mapping
 ----------------

--- a/flink-connectors/flink-connector-kinesis/src/main/java/org/apache/flink/streaming/connectors/kinesis/util/StreamConsumerRegistrarUtil.java
+++ b/flink-connectors/flink-connector-kinesis/src/main/java/org/apache/flink/streaming/connectors/kinesis/util/StreamConsumerRegistrarUtil.java
@@ -34,7 +34,6 @@ import static org.apache.flink.streaming.connectors.kinesis.config.ConsumerConfi
 import static org.apache.flink.streaming.connectors.kinesis.config.ConsumerConfigConstants.efoConsumerArn;
 import static org.apache.flink.streaming.connectors.kinesis.util.AwsV2Util.isEagerEfoRegistrationType;
 import static org.apache.flink.streaming.connectors.kinesis.util.AwsV2Util.isLazyEfoRegistrationType;
-import static org.apache.flink.streaming.connectors.kinesis.util.AwsV2Util.isNoneEfoRegistrationType;
 import static org.apache.flink.streaming.connectors.kinesis.util.AwsV2Util.isUsingEfoRecordPublisher;
 
 /**
@@ -85,17 +84,18 @@ public class StreamConsumerRegistrarUtil {
      */
     public static void deregisterStreamConsumers(
             final Properties configProps, final List<String> streams) {
-        if (!isUsingEfoRecordPublisher(configProps) || isNoneEfoRegistrationType(configProps)) {
-            return;
+        if (isConsumerDeregistrationRequired(configProps)) {
+            StreamConsumerRegistrar registrar = createStreamConsumerRegistrar(configProps, streams);
+            try {
+                deregisterStreamConsumers(registrar, configProps, streams);
+            } finally {
+                registrar.close();
+            }
         }
+    }
 
-        StreamConsumerRegistrar registrar = createStreamConsumerRegistrar(configProps, streams);
-
-        try {
-            deregisterStreamConsumers(registrar, configProps, streams);
-        } finally {
-            registrar.close();
-        }
+    private static boolean isConsumerDeregistrationRequired(final Properties configProps) {
+        return isUsingEfoRecordPublisher(configProps) && isLazyEfoRegistrationType(configProps);
     }
 
     private static void registerStreamConsumers(
@@ -137,20 +137,18 @@ public class StreamConsumerRegistrarUtil {
             final StreamConsumerRegistrar registrar,
             final Properties configProps,
             final List<String> streams) {
-        if (!isUsingEfoRecordPublisher(configProps) || isNoneEfoRegistrationType(configProps)) {
-            return;
-        }
-
-        for (String stream : streams) {
-            try {
-                registrar.deregisterStreamConsumer(stream);
-            } catch (ExecutionException ex) {
-                throw new FlinkKinesisStreamConsumerRegistrarException(
-                        "Error deregistering stream: " + stream, ex);
-            } catch (InterruptedException ex) {
-                Thread.currentThread().interrupt();
-                throw new FlinkKinesisStreamConsumerRegistrarException(
-                        "Error registering stream: " + stream, ex);
+        if (isConsumerDeregistrationRequired(configProps)) {
+            for (String stream : streams) {
+                try {
+                    registrar.deregisterStreamConsumer(stream);
+                } catch (ExecutionException ex) {
+                    throw new FlinkKinesisStreamConsumerRegistrarException(
+                            "Error deregistering stream: " + stream, ex);
+                } catch (InterruptedException ex) {
+                    Thread.currentThread().interrupt();
+                    throw new FlinkKinesisStreamConsumerRegistrarException(
+                            "Error registering stream: " + stream, ex);
+                }
             }
         }
     }


### PR DESCRIPTION
## What is the purpose of the change

This is a fix being pulled back into 1.12, please see #17417 for the original PR. The following is just the original text from the previous pull request; 

The EFO Kinesis connector will register and de-register stream consumers based on the [configured registration strategy](https://ci.apache.org/projects/flink/flink-docs-release-1.13/docs/connectors/datastream/kinesis/#efo-stream-consumer-registrationderegistration). When EAGER is used, the client (usually job manager) will register the consumer and then the task managers will de-register the consumer when job stops/fails. If the job is configured to restart on fail, then the consumer will not exist and the job will continuously fail over.

After this change the connector will not trigger consumer deregistration in EFO if using the EAGER registration strategy. This will allow EAGER EFO configured connector applications to use restart policies without continuously failing. The documentation is updated accordingly.

## Brief change log

  - *Add dedicated utility function for determining whether consumer deregistration is required.*
  - *Ensure consumer deregistration now only occurs when EFO is configured using the LAZY registration strategy.*
  - *Update the documentation to reflect the changes.* 


## Verifying this change

Parts of this change are already covered by existing tests in `org.apache.flink.streaming.connectors.kinesis.util.StreamConsumerRegistrarUtilTest`. 

This change added tests and can be verified as follows:
  - *Added unit test to verify deregistration criteria i.e. `org.apache.flink.streaming.connectors.kinesis.util.StreamConsumerRegistrarUtilTest#testDeregisterStreamConsumersOnlyDeregistersEFOLazilyInitializedConsumers`*
  - *Manually verified the change by running a Flink application with a fixed delay restart strategy and a FlinkKinesisConsumer with EAGER EFO configured.* 

## Does this pull request potentially affect one of the following parts:

  - Dependencies (does it add or upgrade a dependency): **No**
  - The public API, i.e., is any changed class annotated with `@Public(Evolving)`: **No**
  - The serializers: **No**
  - The runtime per-record code paths (performance sensitive): **No**
  - Anything that affects deployment or recovery: JobManager (and its components), Checkpointing, Kubernetes/Yarn, ZooKeeper: **_Yes_**
  - The S3 file system connector: **No**

## Documentation

  - References to the EAGER EFO deregistration policy have been updated in `datastream/kinesis.md` and `table/kinesis.md`.
