### PR TITLE
[hotfix] Fixed Savepoint Documentation Typo

### DIFF
--- a/docs/content.zh/docs/ops/state/savepoints.md
+++ b/docs/content.zh/docs/ops/state/savepoints.md
@@ -107,7 +107,7 @@ mapper-id   | State of StatefulMapper
 
 {{< hint warning >}}
 在如下两种情况中不支持 savepoint 目录的移动：1）如果启用了 *<a href="{{< ref "docs/deployment/filesystems/s3" >}}#entropy-injection-for-s3-file-systems">entropy injection</a>* ：这种情况下，savepoint 目录不包含所有的数据文件，因为注入的路径会分散在各个路径中。
-由于缺乏一个共同的根目录，因此 savepoint 将包含绝对路径，从而导致无法支持 savepoint 目录的迁移。2）作业包含了 task-owned state（比如 `GenericWriteAhreadLog` sink）。
+由于缺乏一个共同的根目录，因此 savepoint 将包含绝对路径，从而导致无法支持 savepoint 目录的迁移。2）作业包含了 task-owned state（比如 `GenericWriteAheadLog` sink）。
 {{< /hint >}}
 
 {{< hint warning >}}

--- a/docs/content/docs/ops/state/savepoints.md
+++ b/docs/content/docs/ops/state/savepoints.md
@@ -123,7 +123,7 @@ There are two exceptions:
 1) if [*entropy injection*]({{< ref "docs/deployment/filesystems/s3" >}}#entropy-injection-for-s3-file-systems) is activated: In that case the savepoint directory will not contain all savepoint data files,
 because the injected path entropy spreads the files over many directories. Lacking a common savepoint root directory, the savepoints will contain absolute path references, which prevent moving the directory.
 
-2) The job contains task-owned state, such as `GenericWriteAhreadLog` sink.
+2) The job contains task-owned state, such as `GenericWriteAheadLog` sink.
 {{< /hint >}}
 
 Unlike savepoints, checkpoints cannot generally be moved to a different location, because checkpoints may include some absolute path references.


### PR DESCRIPTION
## What is the purpose of the change

Fixed a minor typo within the Savepoints documentation to avoid referencing a class/object that doesn't exist due to a typo.

## Brief change log

Updated both Savepoint-related doc pages (context/context.zh) to reflect the change.

## Verifying this change

This change is a trivial rework / code cleanup without any test coverage.

## Does this pull request potentially affect one of the following parts:

  - Dependencies (does it add or upgrade a dependency): no
  - The public API, i.e., is any changed class annotated with `@Public(Evolving)`: no
  - The serializers: no
  - The runtime per-record code paths (performance sensitive): no
  - Anything that affects deployment or recovery: JobManager (and its components), Checkpointing, Kubernetes/Yarn, ZooKeeper: no
  - The S3 file system connector: no

## Documentation

  - Does this pull request introduce a new feature? no
  - If yes, how is the feature documented? not applicable
