### PR TITLE
[FLINK-9465][Runtime/Checkpointing] Specify a separate savepoint timeout option via CLI and REST API

### DIFF
--- a/docs/content.zh/docs/deployment/cli.md
+++ b/docs/content.zh/docs/deployment/cli.md
@@ -110,7 +110,8 @@ in. All that's needed is the JobID:
 ```bash
 $ ./bin/flink savepoint \
       $JOB_ID \ 
-      /tmp/flink-savepoints
+      /tmp/flink-savepoints \
+      --savepointTimeout 300000
 ```
 ```
 Triggering savepoint for job cca7bc1061d61cf15238e92312c2fc20.
@@ -120,6 +121,8 @@ You can resume your program from this savepoint with the run command.
 ```
 The savepoint folder is optional and needs to be specified if 
 [state.savepoints.dir]({{< ref "docs/deployment/config" >}}#state-savepoints-dir) isn't set.
+
+The savepoint timeout is optional and checkpoint timeout will take effect if isn't set.
 
 The path to the savepoint can be used later on to [restart the Flink job](#starting-a-job-from-a-savepoint).
 
@@ -163,6 +166,7 @@ completion of that savepoint, they will finish by calling their `cancel()` metho
 ```bash
 $ ./bin/flink stop \
       --savepointPath /tmp/flink-savepoints \
+      --savepointTimeout 300000 \
       $JOB_ID
 ```
 ```
@@ -171,6 +175,8 @@ Savepoint completed. Path: file:/tmp/flink-savepoints/savepoint-cca7bc-bb1e257f0
 ```
 We have to use `--savepointPath` to specify the savepoint folder if 
 [state.savepoints.dir]({{< ref "docs/deployment/config" >}}#state-savepoints-dir) isn't set.
+
+The savepoint timeout is optional and checkpoint timeout will take effect if isn't set.
 
 If the `--drain` flag is specified, then a `MAX_WATERMARK` will be emitted before the last checkpoint 
 barrier. This will make all registered event-time timers fire, thus flushing out any state that 

--- a/docs/content/docs/deployment/cli.md
+++ b/docs/content/docs/deployment/cli.md
@@ -108,7 +108,8 @@ in. All that's needed is the JobID:
 ```bash
 $ ./bin/flink savepoint \
       $JOB_ID \ 
-      /tmp/flink-savepoints
+      /tmp/flink-savepoints \
+      --savepointTimeout 300000
 ```
 ```
 Triggering savepoint for job cca7bc1061d61cf15238e92312c2fc20.
@@ -118,6 +119,8 @@ You can resume your program from this savepoint with the run command.
 ```
 The savepoint folder is optional and needs to be specified if 
 [state.savepoints.dir]({{< ref "docs/deployment/config" >}}#state-savepoints-dir) isn't set.
+
+The savepoint timeout is optional and checkpoint timeout will take effect if isn't set.
 
 The path to the savepoint can be used later on to [restart the Flink job](#starting-a-job-from-a-savepoint).
 
@@ -161,6 +164,7 @@ completion of that savepoint, they will finish by calling their `cancel()` metho
 ```bash
 $ ./bin/flink stop \
       --savepointPath /tmp/flink-savepoints \
+      --savepointTimeout 300000 \
       $JOB_ID
 ```
 ```
@@ -169,6 +173,8 @@ Savepoint completed. Path: file:/tmp/flink-savepoints/savepoint-cca7bc-bb1e257f0
 ```
 We have to use `--savepointPath` to specify the savepoint folder if 
 [state.savepoints.dir]({{< ref "docs/deployment/config" >}}#state-savepoints-dir) isn't set.
+
+The savepoint timeout is optional and checkpoint timeout will take effect if isn't set.
 
 If the `--drain` flag is specified, then a `MAX_WATERMARK` will be emitted before the last checkpoint 
 barrier. This will make all registered event-time timers fire, thus flushing out any state that 

--- a/flink-clients/src/main/java/org/apache/flink/client/cli/CliFrontendParser.java
+++ b/flink-clients/src/main/java/org/apache/flink/client/cli/CliFrontendParser.java
@@ -132,6 +132,9 @@ public class CliFrontendParser {
     static final Option SAVEPOINT_DISPOSE_OPTION =
             new Option("d", "dispose", true, "Path of savepoint to dispose.");
 
+    static final Option SAVEPOINT_TIMEOUT_OPTION =
+            new Option("st", "savepointTimeout", true, "timeout of savepoint.");
+
     // list specific options
     static final Option RUNNING_OPTION =
             new Option("r", "running", false, "Show only running programs and their JobIDs");
@@ -389,12 +392,14 @@ public class CliFrontendParser {
     static Options getStopCommandOptions() {
         return buildGeneralOptions(new Options())
                 .addOption(STOP_WITH_SAVEPOINT_PATH)
-                .addOption(STOP_AND_DRAIN);
+                .addOption(STOP_AND_DRAIN)
+                .addOption(SAVEPOINT_TIMEOUT_OPTION);
     }
 
     static Options getSavepointCommandOptions() {
         Options options = buildGeneralOptions(new Options());
         options.addOption(SAVEPOINT_DISPOSE_OPTION);
+        options.addOption(SAVEPOINT_TIMEOUT_OPTION);
         return options.addOption(JAR_OPTION);
     }
 

--- a/flink-clients/src/main/java/org/apache/flink/client/cli/SavepointOptions.java
+++ b/flink-clients/src/main/java/org/apache/flink/client/cli/SavepointOptions.java
@@ -22,6 +22,7 @@ import org.apache.commons.cli.CommandLine;
 
 import static org.apache.flink.client.cli.CliFrontendParser.JAR_OPTION;
 import static org.apache.flink.client.cli.CliFrontendParser.SAVEPOINT_DISPOSE_OPTION;
+import static org.apache.flink.client.cli.CliFrontendParser.SAVEPOINT_TIMEOUT_OPTION;
 
 /** Command line options for the SAVEPOINT command. */
 public class SavepointOptions extends CommandLineOptions {
@@ -30,6 +31,7 @@ public class SavepointOptions extends CommandLineOptions {
     private boolean dispose;
     private String disposeSavepointPath;
     private String jarFile;
+    private long savepointTimeout;
 
     public SavepointOptions(CommandLine line) {
         super(line);
@@ -37,6 +39,10 @@ public class SavepointOptions extends CommandLineOptions {
         dispose = line.hasOption(SAVEPOINT_DISPOSE_OPTION.getOpt());
         disposeSavepointPath = line.getOptionValue(SAVEPOINT_DISPOSE_OPTION.getOpt());
         jarFile = line.getOptionValue(JAR_OPTION.getOpt());
+        savepointTimeout =
+                line.hasOption(SAVEPOINT_TIMEOUT_OPTION.getOpt())
+                        ? Long.valueOf(line.getOptionValue(SAVEPOINT_TIMEOUT_OPTION.getOpt()))
+                        : 0;
     }
 
     public String[] getArgs() {
@@ -53,5 +59,9 @@ public class SavepointOptions extends CommandLineOptions {
 
     public String getJarFilePath() {
         return jarFile;
+    }
+
+    public long getSavepointTimeout() {
+        return savepointTimeout;
     }
 }

--- a/flink-clients/src/main/java/org/apache/flink/client/cli/StopOptions.java
+++ b/flink-clients/src/main/java/org/apache/flink/client/cli/StopOptions.java
@@ -20,6 +20,7 @@ package org.apache.flink.client.cli;
 
 import org.apache.commons.cli.CommandLine;
 
+import static org.apache.flink.client.cli.CliFrontendParser.SAVEPOINT_TIMEOUT_OPTION;
 import static org.apache.flink.client.cli.CliFrontendParser.STOP_AND_DRAIN;
 import static org.apache.flink.client.cli.CliFrontendParser.STOP_WITH_SAVEPOINT_PATH;
 
@@ -33,6 +34,8 @@ class StopOptions extends CommandLineOptions {
     /** Optional target directory for the savepoint. Overwrites cluster default. */
     private final String targetDirectory;
 
+    private final long savepointTimeout;
+
     private final boolean advanceToEndOfEventTime;
 
     StopOptions(CommandLine line) {
@@ -41,6 +44,10 @@ class StopOptions extends CommandLineOptions {
 
         this.savepointFlag = line.hasOption(STOP_WITH_SAVEPOINT_PATH.getOpt());
         this.targetDirectory = line.getOptionValue(STOP_WITH_SAVEPOINT_PATH.getOpt());
+        this.savepointTimeout =
+                line.hasOption(SAVEPOINT_TIMEOUT_OPTION.getOpt())
+                        ? Long.valueOf(line.getOptionValue(SAVEPOINT_TIMEOUT_OPTION.getOpt()))
+                        : 0;
 
         this.advanceToEndOfEventTime = line.hasOption(STOP_AND_DRAIN.getOpt());
     }
@@ -55,6 +62,10 @@ class StopOptions extends CommandLineOptions {
 
     String getTargetDirectory() {
         return targetDirectory;
+    }
+
+    long getSavepointTimeout() {
+        return savepointTimeout;
     }
 
     boolean shouldAdvanceToEndOfEventTime() {

--- a/flink-clients/src/main/java/org/apache/flink/client/program/ClusterClient.java
+++ b/flink-clients/src/main/java/org/apache/flink/client/program/ClusterClient.java
@@ -157,6 +157,26 @@ public interface ClusterClient<T> extends AutoCloseable {
             @Nullable final String savepointDirectory);
 
     /**
+     * Stops a program on Flink cluster whose job-manager is configured in this client's
+     * configuration. Stopping works only for streaming programs. Be aware, that the program might
+     * continue to run for a while after sending the stop command, because after sources stopped to
+     * emit data all operators need to finish processing.
+     *
+     * @param jobId the job ID of the streaming program to stop
+     * @param advanceToEndOfEventTime flag indicating if the source should inject a {@code
+     *     MAX_WATERMARK} in the pipeline
+     * @param savepointDirectory directory the savepoint should be written to
+     * @param savepointTimeout Timeout for the savepoint. If it <= 0, checkpoint timeout will take
+     *     effect.
+     * @return a {@link CompletableFuture} containing the path where the savepoint is located
+     */
+    CompletableFuture<String> stopWithSavepoint(
+            final JobID jobId,
+            final boolean advanceToEndOfEventTime,
+            @Nullable final String savepointDirectory,
+            final long savepointTimeout);
+
+    /**
      * Triggers a savepoint for the job identified by the job id. The savepoint will be written to
      * the given savepoint directory, or {@link
      * org.apache.flink.configuration.CheckpointingOptions#SAVEPOINT_DIRECTORY} if it is null.
@@ -166,6 +186,20 @@ public interface ClusterClient<T> extends AutoCloseable {
      * @return path future where the savepoint is located
      */
     CompletableFuture<String> triggerSavepoint(JobID jobId, @Nullable String savepointDirectory);
+
+    /**
+     * Triggers a savepoint for the job identified by the job id. The savepoint will be written to
+     * the given savepoint directory, or {@link
+     * org.apache.flink.configuration.CheckpointingOptions#SAVEPOINT_DIRECTORY} if it is null.
+     *
+     * @param jobId job id
+     * @param savepointDirectory directory the savepoint should be written to
+     * @param savepointTimeout Timeout for the savepoint. If it <= 0, checkpoint timeout will take
+     *     effect.
+     * @return path future where the savepoint is located
+     */
+    CompletableFuture<String> triggerSavepoint(
+            JobID jobId, @Nullable String savepointDirectory, long savepointTimeout);
 
     /**
      * Sends out a request to a specified coordinator and return the response.

--- a/flink-clients/src/main/java/org/apache/flink/client/program/MiniClusterClient.java
+++ b/flink-clients/src/main/java/org/apache/flink/client/program/MiniClusterClient.java
@@ -96,9 +96,25 @@ public class MiniClusterClient implements ClusterClient<MiniClusterClient.MiniCl
     }
 
     @Override
+    public CompletableFuture<String> stopWithSavepoint(
+            JobID jobId,
+            boolean advanceToEndOfEventTime,
+            @Nullable String savepointDirector,
+            long savepointTimeout) {
+        return miniCluster.stopWithSavepoint(
+                jobId, savepointDirector, savepointTimeout, advanceToEndOfEventTime);
+    }
+
+    @Override
     public CompletableFuture<String> triggerSavepoint(
             JobID jobId, @Nullable String savepointDirectory) {
         return miniCluster.triggerSavepoint(jobId, savepointDirectory, false);
+    }
+
+    @Override
+    public CompletableFuture<String> triggerSavepoint(
+            JobID jobId, @Nullable String savepointDirectory, long savepointTimeout) {
+        return miniCluster.triggerSavepoint(jobId, savepointDirectory, savepointTimeout, false);
     }
 
     @Override

--- a/flink-clients/src/test/java/org/apache/flink/client/program/TestingClusterClient.java
+++ b/flink-clients/src/test/java/org/apache/flink/client/program/TestingClusterClient.java
@@ -141,9 +141,24 @@ public class TestingClusterClient<T> implements ClusterClient<T> {
     }
 
     @Override
+    public CompletableFuture<String> stopWithSavepoint(
+            JobID jobId,
+            boolean advanceToEndOfEventTime,
+            @Nullable String savepointDirectory,
+            long savepointTimeout) {
+        return stopWithSavepointFunction.apply(jobId, advanceToEndOfEventTime, savepointDirectory);
+    }
+
+    @Override
     public CompletableFuture<String> triggerSavepoint(
             JobID jobId, @Nullable String savepointDirectory) {
         return triggerSavepointFunction.apply(jobId, savepointDirectory);
+    }
+
+    @Override
+    public CompletableFuture<String> triggerSavepoint(
+            JobID jobId, @Nullable String savepointDirectory, long savepointTimeout) {
+        throw new UnsupportedOperationException();
     }
 
     @Override

--- a/flink-runtime-web/src/test/resources/rest_api_v1.snapshot
+++ b/flink-runtime-web/src/test/resources/rest_api_v1.snapshot
@@ -1869,6 +1869,9 @@
         "target-directory" : {
           "type" : "string"
         },
+        "savepointTimeout" : {
+          "type" : "integer"
+        },
         "cancel-job" : {
           "type" : "boolean"
         }
@@ -1940,6 +1943,9 @@
       "properties" : {
         "targetDirectory" : {
           "type" : "string"
+        },
+        "savepointTimeout" : {
+          "type" : "integer"
         },
         "drain" : {
           "type" : "boolean"

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/dispatcher/Dispatcher.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/dispatcher/Dispatcher.java
@@ -707,6 +707,21 @@ public abstract class Dispatcher extends PermanentlyFencedRpcEndpoint<Dispatcher
     }
 
     @Override
+    public CompletableFuture<String> triggerSavepoint(
+            JobID jobId,
+            String targetDirectory,
+            long savepointTimeout,
+            boolean cancelJob,
+            Time timeout) {
+
+        return performOperationOnJobMasterGateway(
+                jobId,
+                gateway ->
+                        gateway.triggerSavepoint(
+                                targetDirectory, savepointTimeout, cancelJob, timeout));
+    }
+
+    @Override
     public CompletableFuture<String> stopWithSavepoint(
             final JobID jobId,
             final String targetDirectory,
@@ -714,6 +729,20 @@ public abstract class Dispatcher extends PermanentlyFencedRpcEndpoint<Dispatcher
             final Time timeout) {
         return performOperationOnJobMasterGateway(
                 jobId, gateway -> gateway.stopWithSavepoint(targetDirectory, terminate, timeout));
+    }
+
+    @Override
+    public CompletableFuture<String> stopWithSavepoint(
+            final JobID jobId,
+            final String targetDirectory,
+            final long savepointTimeout,
+            final boolean terminate,
+            final Time timeout) {
+        return performOperationOnJobMasterGateway(
+                jobId,
+                gateway ->
+                        gateway.stopWithSavepoint(
+                                targetDirectory, savepointTimeout, terminate, timeout));
     }
 
     @Override

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/jobmaster/JobMaster.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/jobmaster/JobMaster.java
@@ -788,7 +788,16 @@ public class JobMaster extends PermanentlyFencedRpcEndpoint<JobMasterId>
     public CompletableFuture<String> triggerSavepoint(
             @Nullable final String targetDirectory, final boolean cancelJob, final Time timeout) {
 
-        return schedulerNG.triggerSavepoint(targetDirectory, cancelJob);
+        return triggerSavepoint(targetDirectory, 0, cancelJob, timeout);
+    }
+
+    @Override
+    public CompletableFuture<String> triggerSavepoint(
+            @Nullable String targetDirectory,
+            long savepointTimeout,
+            boolean cancelJob,
+            Time timeout) {
+        return schedulerNG.triggerSavepoint(targetDirectory, savepointTimeout, cancelJob);
     }
 
     @Override
@@ -800,7 +809,17 @@ public class JobMaster extends PermanentlyFencedRpcEndpoint<JobMasterId>
     public CompletableFuture<String> stopWithSavepoint(
             @Nullable final String targetDirectory, final boolean terminate, final Time timeout) {
 
-        return schedulerNG.stopWithSavepoint(targetDirectory, terminate);
+        return stopWithSavepoint(targetDirectory, 0, terminate, timeout);
+    }
+
+    @Override
+    public CompletableFuture<String> stopWithSavepoint(
+            @Nullable final String targetDirectory,
+            final long savepointTimeout,
+            final boolean terminate,
+            final Time timeout) {
+
+        return schedulerNG.stopWithSavepoint(targetDirectory, savepointTimeout, terminate);
     }
 
     @Override

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/jobmaster/JobMasterGateway.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/jobmaster/JobMasterGateway.java
@@ -235,6 +235,22 @@ public interface JobMasterGateway
             @RpcTimeout final Time timeout);
 
     /**
+     * Triggers taking a savepoint of the executed job.
+     *
+     * @param targetDirectory to which to write the savepoint data or null if the default savepoint
+     *     directory should be used
+     * @param savepointTimeout Timeout for the savepoint. If it <= 0, checkpoint timeout will take
+     *     effect.
+     * @param timeout for the rpc call
+     * @return Future which is completed with the savepoint path once completed
+     */
+    CompletableFuture<String> triggerSavepoint(
+            @Nullable final String targetDirectory,
+            final long savepointTimeout,
+            final boolean cancelJob,
+            @RpcTimeout final Time timeout);
+
+    /**
      * Triggers taking a checkpoint of the executed job.
      *
      * @param timeout for the rpc call
@@ -253,6 +269,23 @@ public interface JobMasterGateway
      */
     CompletableFuture<String> stopWithSavepoint(
             @Nullable final String targetDirectory,
+            final boolean terminate,
+            @RpcTimeout final Time timeout);
+
+    /**
+     * Stops the job with a savepoint.
+     *
+     * @param targetDirectory to which to write the savepoint data or null if the default savepoint
+     *     directory should be used
+     * @param savepointTimeout Timeout for the savepoint. If it <= 0, checkpoint timeout will take
+     *     effect.
+     * @param terminate flag indicating if the job should terminate or just suspend
+     * @param timeout for the rpc call
+     * @return Future which is completed with the savepoint path once completed
+     */
+    CompletableFuture<String> stopWithSavepoint(
+            @Nullable final String targetDirectory,
+            final long savepointTimeout,
             final boolean terminate,
             @RpcTimeout final Time timeout);
 

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/minicluster/MiniCluster.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/minicluster/MiniCluster.java
@@ -744,6 +744,14 @@ public class MiniCluster implements AutoCloseableAsync {
                                 jobId, targetDirectory, cancelJob, rpcTimeout));
     }
 
+    public CompletableFuture<String> triggerSavepoint(
+            JobID jobId, String targetDirectory, long savepointTimeout, boolean cancelJob) {
+        return runDispatcherCommand(
+                dispatcherGateway ->
+                        dispatcherGateway.triggerSavepoint(
+                                jobId, targetDirectory, savepointTimeout, cancelJob, rpcTimeout));
+    }
+
     public CompletableFuture<String> triggerCheckpoint(JobID jobID) {
         return runDispatcherCommand(
                 dispatcherGateway -> dispatcherGateway.triggerCheckpoint(jobID, rpcTimeout));
@@ -755,6 +763,14 @@ public class MiniCluster implements AutoCloseableAsync {
                 dispatcherGateway ->
                         dispatcherGateway.stopWithSavepoint(
                                 jobId, targetDirectory, terminate, rpcTimeout));
+    }
+
+    public CompletableFuture<String> stopWithSavepoint(
+            JobID jobId, String targetDirectory, long savepointTimeout, boolean terminate) {
+        return runDispatcherCommand(
+                dispatcherGateway ->
+                        dispatcherGateway.stopWithSavepoint(
+                                jobId, targetDirectory, savepointTimeout, terminate, rpcTimeout));
     }
 
     public CompletableFuture<Acknowledge> disposeSavepoint(String savepointPath) {

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/rest/handler/job/savepoints/SavepointHandlers.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/rest/handler/job/savepoints/SavepointHandlers.java
@@ -154,6 +154,7 @@ public class SavepointHandlers
 
             final JobID jobId = request.getPathParameter(JobIDPathParameter.class);
             final String requestedTargetDirectory = request.getRequestBody().getTargetDirectory();
+            final long savepointTimeout = request.getRequestBody().getSavepointTimeout();
 
             if (requestedTargetDirectory == null && defaultSavepointDir == null) {
                 throw new RestHandlerException(
@@ -170,7 +171,7 @@ public class SavepointHandlers
                             ? requestedTargetDirectory
                             : defaultSavepointDir;
             return gateway.stopWithSavepoint(
-                    jobId, targetDirectory, shouldDrain, RpcUtils.INF_TIMEOUT);
+                    jobId, targetDirectory, savepointTimeout, shouldDrain, RpcUtils.INF_TIMEOUT);
         }
     }
 
@@ -190,6 +191,7 @@ public class SavepointHandlers
                 throws RestHandlerException {
             final JobID jobId = request.getPathParameter(JobIDPathParameter.class);
             final String requestedTargetDirectory = request.getRequestBody().getTargetDirectory();
+            final long savepointTimeout = request.getRequestBody().getSavepointTimeout();
 
             if (requestedTargetDirectory == null && defaultSavepointDir == null) {
                 throw new RestHandlerException(
@@ -206,7 +208,7 @@ public class SavepointHandlers
                             ? requestedTargetDirectory
                             : defaultSavepointDir;
             return gateway.triggerSavepoint(
-                    jobId, targetDirectory, cancelJob, RpcUtils.INF_TIMEOUT);
+                    jobId, targetDirectory, savepointTimeout, cancelJob, RpcUtils.INF_TIMEOUT);
         }
     }
 

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/rest/messages/job/savepoints/SavepointTriggerRequestBody.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/rest/messages/job/savepoints/SavepointTriggerRequestBody.java
@@ -30,26 +30,41 @@ public class SavepointTriggerRequestBody implements RequestBody {
 
     public static final String FIELD_NAME_TARGET_DIRECTORY = "target-directory";
 
+    public static final String FIELD_NAME_SAVEPOINT_TIMEOUT = "savepointTimeout";
+
     private static final String FIELD_NAME_CANCEL_JOB = "cancel-job";
 
     @JsonProperty(FIELD_NAME_TARGET_DIRECTORY)
     @Nullable
     private final String targetDirectory;
 
+    @JsonProperty(FIELD_NAME_SAVEPOINT_TIMEOUT)
+    private final long savepointTimeout;
+
     @JsonProperty(FIELD_NAME_CANCEL_JOB)
     private final boolean cancelJob;
+
+    public SavepointTriggerRequestBody(final String targetDirectory, final Boolean cancelJob) {
+        this(targetDirectory, null, cancelJob);
+    }
 
     @JsonCreator
     public SavepointTriggerRequestBody(
             @Nullable @JsonProperty(FIELD_NAME_TARGET_DIRECTORY) final String targetDirectory,
+            @Nullable @JsonProperty(FIELD_NAME_SAVEPOINT_TIMEOUT) final Long savepointTimeout,
             @Nullable @JsonProperty(FIELD_NAME_CANCEL_JOB) final Boolean cancelJob) {
         this.targetDirectory = targetDirectory;
+        this.savepointTimeout = savepointTimeout != null ? savepointTimeout : 0;
         this.cancelJob = cancelJob != null ? cancelJob : false;
     }
 
     @Nullable
     public String getTargetDirectory() {
         return targetDirectory;
+    }
+
+    public long getSavepointTimeout() {
+        return savepointTimeout;
     }
 
     public boolean isCancelJob() {

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/rest/messages/job/savepoints/stop/StopWithSavepointRequestBody.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/rest/messages/job/savepoints/stop/StopWithSavepointRequestBody.java
@@ -30,26 +30,41 @@ public class StopWithSavepointRequestBody implements RequestBody {
 
     public static final String FIELD_NAME_TARGET_DIRECTORY = "targetDirectory";
 
+    public static final String FIELD_NAME_SAVEPOINT_TIMEOUT = "savepointTimeout";
+
     private static final String FIELD_NAME_DRAIN = "drain";
 
     @JsonProperty(FIELD_NAME_TARGET_DIRECTORY)
     @Nullable
     private final String targetDirectory;
 
+    @JsonProperty(FIELD_NAME_SAVEPOINT_TIMEOUT)
+    private final long savepointTimeout;
+
     @JsonProperty(FIELD_NAME_DRAIN)
     private final boolean drain;
+
+    public StopWithSavepointRequestBody(final String targetDirectory, final boolean drain) {
+        this(targetDirectory, null, drain);
+    }
 
     @JsonCreator
     public StopWithSavepointRequestBody(
             @Nullable @JsonProperty(FIELD_NAME_TARGET_DIRECTORY) final String targetDirectory,
+            @Nullable @JsonProperty(FIELD_NAME_SAVEPOINT_TIMEOUT) final Long savepointTimeout,
             @Nullable @JsonProperty(FIELD_NAME_DRAIN) final Boolean drain) {
         this.targetDirectory = targetDirectory;
+        this.savepointTimeout = savepointTimeout != null ? savepointTimeout : 0;
         this.drain = drain != null ? drain : false;
     }
 
     @Nullable
     public String getTargetDirectory() {
         return targetDirectory;
+    }
+
+    public long getSavepointTimeout() {
+        return savepointTimeout;
     }
 
     public boolean shouldDrain() {

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/scheduler/SchedulerNG.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/scheduler/SchedulerNG.java
@@ -127,6 +127,9 @@ public interface SchedulerNG extends AutoCloseableAsync {
 
     CompletableFuture<String> triggerSavepoint(@Nullable String targetDirectory, boolean cancelJob);
 
+    CompletableFuture<String> triggerSavepoint(
+            @Nullable String targetDirectory, long savepointTimeout, boolean cancelJob);
+
     CompletableFuture<String> triggerCheckpoint();
 
     void acknowledgeCheckpoint(
@@ -145,6 +148,9 @@ public interface SchedulerNG extends AutoCloseableAsync {
     void declineCheckpoint(DeclineCheckpoint decline);
 
     CompletableFuture<String> stopWithSavepoint(String targetDirectory, boolean terminate);
+
+    CompletableFuture<String> stopWithSavepoint(
+            String targetDirectory, long savepointTimeout, boolean terminate);
 
     // ------------------------------------------------------------------------
     //  Operator Coordinator related methods

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/scheduler/adaptive/AdaptiveScheduler.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/scheduler/adaptive/AdaptiveScheduler.java
@@ -587,11 +587,17 @@ public class AdaptiveScheduler
     @Override
     public CompletableFuture<String> triggerSavepoint(
             @Nullable String targetDirectory, boolean cancelJob) {
+        return triggerSavepoint(targetDirectory, 0, cancelJob);
+    }
+
+    @Override
+    public CompletableFuture<String> triggerSavepoint(
+            @Nullable String targetDirectory, long savepointTimeout, boolean cancelJob) {
         return state.tryCall(
                         StateWithExecutionGraph.class,
                         stateWithExecutionGraph ->
                                 stateWithExecutionGraph.triggerSavepoint(
-                                        targetDirectory, cancelJob),
+                                        targetDirectory, savepointTimeout, cancelJob),
                         "triggerSavepoint")
                 .orElse(
                         FutureUtils.completedExceptionally(
@@ -655,11 +661,18 @@ public class AdaptiveScheduler
     }
 
     @Override
+    public CompletableFuture<String> stopWithSavepoint(String targetDirectory, boolean terminate) {
+        return stopWithSavepoint(targetDirectory, 0, terminate);
+    }
+
+    @Override
     public CompletableFuture<String> stopWithSavepoint(
-            @Nullable String targetDirectory, boolean terminate) {
+            @Nullable String targetDirectory, long savepointTimeout, boolean terminate) {
         return state.tryCall(
                         Executing.class,
-                        executing -> executing.stopWithSavepoint(targetDirectory, terminate),
+                        executing ->
+                                executing.stopWithSavepoint(
+                                        targetDirectory, savepointTimeout, terminate),
                         "stopWithSavepoint")
                 .orElse(
                         FutureUtils.completedExceptionally(

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/scheduler/adaptive/Executing.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/scheduler/adaptive/Executing.java
@@ -165,6 +165,13 @@ class Executing extends StateWithExecutionGraph implements ResourceConsumer {
 
     CompletableFuture<String> stopWithSavepoint(
             @Nullable final String targetDirectory, boolean terminate) {
+        return stopWithSavepoint(targetDirectory, 0, terminate);
+    }
+
+    CompletableFuture<String> stopWithSavepoint(
+            @Nullable final String targetDirectory,
+            final long savepointTimeout,
+            boolean terminate) {
         final ExecutionGraph executionGraph = getExecutionGraph();
 
         StopWithSavepointTerminationManager.checkSavepointActionPreconditions(
@@ -182,7 +189,7 @@ class Executing extends StateWithExecutionGraph implements ResourceConsumer {
         final CompletableFuture<String> savepointFuture =
                 executionGraph
                         .getCheckpointCoordinator()
-                        .triggerSynchronousSavepoint(terminate, targetDirectory)
+                        .triggerSynchronousSavepoint(terminate, targetDirectory, savepointTimeout)
                         .thenApply(CompletedCheckpoint::getExternalPointer);
         return context.goToStopWithSavepoint(
                 executionGraph,

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/scheduler/adaptive/StateWithExecutionGraph.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/scheduler/adaptive/StateWithExecutionGraph.java
@@ -221,7 +221,8 @@ abstract class StateWithExecutionGraph implements State {
                 jobId, jobVertexId, keyGroupRange, registrationName);
     }
 
-    CompletableFuture<String> triggerSavepoint(String targetDirectory, boolean cancelJob) {
+    CompletableFuture<String> triggerSavepoint(
+            String targetDirectory, long savepointTimeout, boolean cancelJob) {
         final CheckpointCoordinator checkpointCoordinator =
                 executionGraph.getCheckpointCoordinator();
         StopWithSavepointTerminationManager.checkSavepointActionPreconditions(
@@ -237,7 +238,7 @@ abstract class StateWithExecutionGraph implements State {
         }
 
         return checkpointCoordinator
-                .triggerSavepoint(targetDirectory)
+                .triggerSavepoint(targetDirectory, savepointTimeout)
                 .thenApply(CompletedCheckpoint::getExternalPointer)
                 .handleAsync(
                         (path, throwable) -> {

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/webmonitor/RestfulGateway.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/webmonitor/RestfulGateway.java
@@ -146,6 +146,26 @@ public interface RestfulGateway extends RpcGateway {
     }
 
     /**
+     * Triggers a savepoint with the given savepoint directory as a target.
+     *
+     * @param jobId ID of the job for which the savepoint should be triggered.
+     * @param targetDirectory Target directory for the savepoint.
+     * @param savepointTimeout Timeout for the savepoint. If it <= 0, checkpoint timeout will take
+     *     effect.
+     * @param timeout Timeout for the asynchronous operation
+     * @return A future to the {@link CompletedCheckpoint#getExternalPointer() external pointer} of
+     *     the savepoint.
+     */
+    default CompletableFuture<String> triggerSavepoint(
+            JobID jobId,
+            String targetDirectory,
+            long savepointTimeout,
+            boolean cancelJob,
+            @RpcTimeout Time timeout) {
+        throw new UnsupportedOperationException();
+    }
+
+    /**
      * Stops the job with a savepoint.
      *
      * @param jobId ID of the job for which the savepoint should be triggered.
@@ -158,6 +178,27 @@ public interface RestfulGateway extends RpcGateway {
     default CompletableFuture<String> stopWithSavepoint(
             final JobID jobId,
             final String targetDirectory,
+            final boolean terminate,
+            @RpcTimeout final Time timeout) {
+        throw new UnsupportedOperationException();
+    }
+
+    /**
+     * Stops the job with a savepoint.
+     *
+     * @param jobId ID of the job for which the savepoint should be triggered.
+     * @param targetDirectory to which to write the savepoint data or null if the default savepoint
+     *     directory should be used
+     * @param savepointTimeout Timeout for the savepoint. If it <= 0, checkpoint timeout will take
+     *     effect.
+     * @param terminate flag indicating if the job should terminate or just suspend
+     * @param timeout for the rpc call
+     * @return Future which is completed with the savepoint path once completed
+     */
+    default CompletableFuture<String> stopWithSavepoint(
+            final JobID jobId,
+            final String targetDirectory,
+            final long savepointTimeout,
             final boolean terminate,
             @RpcTimeout final Time timeout) {
         throw new UnsupportedOperationException();

--- a/flink-runtime/src/test/java/org/apache/flink/runtime/jobmaster/utils/TestingJobMasterGateway.java
+++ b/flink-runtime/src/test/java/org/apache/flink/runtime/jobmaster/utils/TestingJobMasterGateway.java
@@ -413,6 +413,15 @@ public class TestingJobMasterGateway implements JobMasterGateway {
     }
 
     @Override
+    public CompletableFuture<String> triggerSavepoint(
+            @Nullable String targetDirectory,
+            long savepointTimeout,
+            boolean cancelJob,
+            Time timeout) {
+        throw new UnsupportedOperationException("This operation is not supported.");
+    }
+
+    @Override
     public CompletableFuture<String> triggerCheckpoint(Time timeout) {
         return triggerCheckpointFunction.get();
     }
@@ -421,6 +430,15 @@ public class TestingJobMasterGateway implements JobMasterGateway {
     public CompletableFuture<String> stopWithSavepoint(
             @Nullable final String targetDirectory, final boolean terminate, final Time timeout) {
         return stopWithSavepointFunction.apply(targetDirectory, terminate);
+    }
+
+    @Override
+    public CompletableFuture<String> stopWithSavepoint(
+            @Nullable String targetDirectory,
+            long savepointTimeout,
+            boolean terminate,
+            Time timeout) {
+        throw new UnsupportedOperationException("This operation is not supported.");
     }
 
     @Override

--- a/flink-runtime/src/test/java/org/apache/flink/runtime/scheduler/TestingSchedulerNG.java
+++ b/flink-runtime/src/test/java/org/apache/flink/runtime/scheduler/TestingSchedulerNG.java
@@ -183,6 +183,12 @@ public class TestingSchedulerNG implements SchedulerNG {
     }
 
     @Override
+    public CompletableFuture<String> triggerSavepoint(
+            @Nullable String targetDirectory, long savepointTimeout, boolean cancelJob) {
+        return triggerSavepointFunction.apply(targetDirectory, cancelJob);
+    }
+
+    @Override
     public CompletableFuture<String> triggerCheckpoint() {
         return triggerCheckpointFunction.get();
     }
@@ -204,6 +210,13 @@ public class TestingSchedulerNG implements SchedulerNG {
 
     @Override
     public CompletableFuture<String> stopWithSavepoint(String targetDirectory, boolean terminate) {
+        failOperation();
+        return null;
+    }
+
+    @Override
+    public CompletableFuture<String> stopWithSavepoint(
+            String targetDirectory, long savepointTimeout, boolean terminate) {
         failOperation();
         return null;
     }

--- a/flink-runtime/src/test/java/org/apache/flink/runtime/webmonitor/TestingRestfulGateway.java
+++ b/flink-runtime/src/test/java/org/apache/flink/runtime/webmonitor/TestingRestfulGateway.java
@@ -261,8 +261,28 @@ public class TestingRestfulGateway implements RestfulGateway {
     }
 
     @Override
+    public CompletableFuture<String> triggerSavepoint(
+            JobID jobId,
+            String targetDirectory,
+            long savepointTimeout,
+            boolean cancelJob,
+            Time timeout) {
+        return triggerSavepointFunction.apply(jobId, targetDirectory);
+    }
+
+    @Override
     public CompletableFuture<String> stopWithSavepoint(
             JobID jobId, String targetDirectory, boolean terminate, Time timeout) {
+        return stopWithSavepointFunction.apply(jobId, targetDirectory);
+    }
+
+    @Override
+    public CompletableFuture<String> stopWithSavepoint(
+            JobID jobId,
+            String targetDirectory,
+            long savepointTimeout,
+            boolean terminate,
+            Time timeout) {
         return stopWithSavepointFunction.apply(jobId, targetDirectory);
     }
 

--- a/flink-tests/src/test/java/org/apache/flink/test/streaming/api/environment/RemoteStreamEnvironmentTest.java
+++ b/flink-tests/src/test/java/org/apache/flink/test/streaming/api/environment/RemoteStreamEnvironmentTest.java
@@ -265,8 +265,23 @@ public class RemoteStreamEnvironmentTest extends TestLogger {
         }
 
         @Override
+        public CompletableFuture<String> stopWithSavepoint(
+                JobID jobId,
+                boolean advanceToEndOfEventTime,
+                @Nullable String savepointDirectory,
+                long savepointTimeout) {
+            return null;
+        }
+
+        @Override
         public CompletableFuture<String> triggerSavepoint(
                 JobID jobId, @Nullable String savepointDirectory) {
+            return null;
+        }
+
+        @Override
+        public CompletableFuture<String> triggerSavepoint(
+                JobID jobId, @Nullable String savepointDirectory, long savepointTimeout) {
             return null;
         }
 


### PR DESCRIPTION
## What is the purpose of the change

This pull request support specify a separate savepoint timeout option via REST API and CLI, which is decribed in [FLINK-9465](https://issues.apache.org/jira/browse/FLINK-9465).


## Brief change log

  - *CheckpointCoordinator.CheckpointTriggerRequest* add savepointTimeout field,
  - *CheckpointCoordinator#createPendingCheckpoint()* add a "timeout" parameter, and use it as canceller trigger delay if it > 0,
  - *CheckpointCoordinator, RestfulGateway, JobMasterGateway,SchedulerNG,ClusterClient* add triggerSavepoint/stopWithSavepoint method with parameter "savepointTimeout"
  - *CliFrontend#savepoint(), CliFrontend#stop(), SavepointTriggerHandler, StopWithSavepointHandler* migrate to method with "savepointTimeout"

## Verifying this change

This change is already covered by existing tests, such as *(please describe tests)*.

## Does this pull request potentially affect one of the following parts:

  - Dependencies (does it add or upgrade a dependency): no
  - The public API, i.e., is any changed class annotated with `@Public(Evolving)`: yes
  - The serializers: no
  - The runtime per-record code paths (performance sensitive): no
  - Anything that affects deployment or recovery: JobManager (and its components), Checkpointing, Kubernetes/Yarn, ZooKeeper: yes
  - The S3 file system connector: no

## Documentation

  - Does this pull request introduce a new feature? no