### PR TITLE
[FLINK-24390][python] Limit the grpcio version <= 1.40.0 for Python 3.5 in dev/requirements.txt

### DIFF
--- a/flink-python/dev/dev-requirements.txt
+++ b/flink-python/dev/dev-requirements.txt
@@ -14,5 +14,6 @@
 # limitations under the License.
 setuptools>=18.0
 wheel
+grpcio<=1.40.0; python_version < "3.6"
 apache-beam==2.23.0
 cython==0.29.16


### PR DESCRIPTION

## What is the purpose of the change

*This pull request provides a quick fix to also updates the grpcio version <= 1.40.0 for Python 3.5 in dev/requirements.txt*


## Verifying this change

This change is a trivial rework without any test coverage.

## Does this pull request potentially affect one of the following parts:

  - Dependencies (does it add or upgrade a dependency): (no)
  - The public API, i.e., is any changed class annotated with `@Public(Evolving)`: (no)
  - The serializers: (no)
  - The runtime per-record code paths (performance sensitive): (no)
  - Anything that affects deployment or recovery: JobManager (and its components), Checkpointing, Kubernetes/Yarn, ZooKeeper: (no)
  - The S3 file system connector: (no)

## Documentation

  - Does this pull request introduce a new feature? (no)
  - If yes, how is the feature documented? (not applicable)
