### PR TITLE
[FLINK-24504][table-planner] Flink common expression elimination

### DIFF
--- a/flink-table/flink-table-planner/src/main/scala/org/apache/flink/table/planner/codegen/CodeGeneratorContext.scala
+++ b/flink-table/flink-table-planner/src/main/scala/org/apache/flink/table/planner/codegen/CodeGeneratorContext.scala
@@ -115,10 +115,16 @@ class CodeGeneratorContext(val tableConfig: TableConfig) {
   private val reusableExternalSerializers: mutable.Map[DataType, String] =
     mutable.Map[DataType,  String]()
 
-  // map of common expressions
+  // map of common code
   // string_code -> reused_term
-  private val reusableCommonExpression: mutable.Map[String, String] =
+  private val reusableCommonCode: mutable.Map[String, String] =
     mutable.Map[String, String]()
+
+  // map of common term
+  // term -> reused_term
+  private val reusableCommonTerm: mutable.Map[String, String] =
+    mutable.Map[String, String]()
+
 
   /**
     * The current method name for [[reusableLocalVariableStatements]]. You can start a new
@@ -166,8 +172,10 @@ class CodeGeneratorContext(val tableConfig: TableConfig) {
    * @param code the reusable expression code
    * @param term the reusable term
    */
-  def addReusableCommonExpression(code: String, term: String): Unit = {
-    reusableCommonExpression.put(code, term)
+  def addReusableCommonCode(code: String, term: String): Unit = {
+    if (!reusableCommonCode.contains(code)) {
+      reusableCommonCode.put(code, term)
+    }
   }
 
   /**
@@ -175,8 +183,28 @@ class CodeGeneratorContext(val tableConfig: TableConfig) {
    * @param code the generate code
    * @return the reusable term if not found return the code
    */
-  def getReusableCommonExpression(code: String) : String = {
-    reusableCommonExpression.getOrElse(code, code)
+  def getReusableCommonCode(code: String) : String = {
+    reusableCommonCode.getOrElse(code, code)
+  }
+
+  /**
+   * Add a reusable term and it's originalTerm term.
+   * @param newTerm the new term
+   * @param originalTerm the reusable term
+   */
+  def addReusableCommonTerm(newTerm: String, originalTerm: String): Unit = {
+    if (!reusableCommonTerm.contains(newTerm)) {
+      reusableCommonTerm.put(newTerm, originalTerm)
+    }
+  }
+
+  /**
+   * Get the reusable term by generate code.
+   * @param newTerm the generate code
+   * @return the reusable term if not found return the code
+   */
+  def getReusableCommonTerm(newTerm: String) : String = {
+    reusableCommonTerm.getOrElse(newTerm, newTerm)
   }
 
   /**

--- a/flink-table/flink-table-planner/src/test/scala/org/apache/flink/table/planner/runtime/stream/sql/CalcITCase.scala
+++ b/flink-table/flink-table-planner/src/test/scala/org/apache/flink/table/planner/runtime/stream/sql/CalcITCase.scala
@@ -551,11 +551,16 @@ class CalcITCase extends StreamingTestBase {
 
   @Test
   def testReusableCommonExpression(): Unit = {
-    val t = env.fromElements("aa_bb", "cc_dd", "ee_ff", "gg_hh")
+    val t = env.fromElements("aa_bb_oo", "cc_dd_pp", "ee_ff_qq", "gg_hh_rr")
       .toTable(tEnv).as("f1")
     tEnv.createTemporaryView("t1", t)
     tEnv.createTemporaryFunction("str_split", StringSplitFunc)
-    val stream = tEnv.sqlQuery("select str_split(f1, '_')[1], str_split(f1, '_')[2] from t1")
+    val sql = s"""
+                 | select str_split(f1, '_')[1],
+                 | str_split(f1, '_')[2],
+                 | str_split(f1, '_')[3],
+                 | str_split(f1, '_')[1] from t1""".stripMargin
+    val stream = tEnv.sqlQuery(sql)
       .toAppendStream[Row]
     stream.addSink(new TestingAppendSink)
     env.execute()


### PR DESCRIPTION
<!--
*Thank you very much for contributing to Apache Flink - we are happy that you want to help us improve Flink. To help the community review your contribution in the best possible way, please go through the checklist below, which will get the contribution into a shape in which it can be best reviewed.*

*Please understand that we do not do this to make contributions to Flink a hassle. In order to uphold a high standard of quality for code contributions, while at the same time managing a large number of contributions, we need contributors to prepare the contributions well, and give reviewers enough contextual information for the review. Please also understand that contributions that do not follow this guide will take longer to review and thus typically be picked up with lower priority by the community.*

## Contribution Checklist

  - Make sure that the pull request corresponds to a [JIRA issue](https://issues.apache.org/jira/projects/FLINK/issues). Exceptions are made for typos in JavaDoc or documentation files, which need no JIRA issue.
  
  - Name the pull request in the form "[FLINK-XXXX] [component] Title of the pull request", where *FLINK-XXXX* should be replaced by the actual issue number. Skip *component* if you are unsure about which is the best component.
  Typo fixes that have no associated JIRA issue should be named following this pattern: `[hotfix] [docs] Fix typo in event time introduction` or `[hotfix] [javadocs] Expand JavaDoc for PuncuatedWatermarkGenerator`.

  - Fill out the template below to describe the changes contributed by the pull request. That will give reviewers the context they need to do the review.
  
  - Make sure that the change passes the automated tests, i.e., `mvn clean verify` passes. You can set up Azure Pipelines CI to do that following [this guide](https://cwiki.apache.org/confluence/display/FLINK/Azure+Pipelines#AzurePipelines-Tutorial:SettingupAzurePipelinesforaforkoftheFlinkrepository).

  - Each pull request should address only one issue, not mix up code from multiple issues.
  
  - Each commit in the pull request has a meaningful commit message (including the JIRA id)

  - Once all items of the checklist are addressed, remove the above text and this checklist, leaving only the filled out template below.


**(The sections below can be removed for hotfixes of typos)**
-->

## What is the purpose of the change

*(For example: This pull request makes task deployment go through the blob server, rather than through RPC. That way we avoid re-transferring them on each deployment (during recovery).)*


## Brief change log

*(for example:)*
  - *The TaskInfo is stored in the blob store on job creation time as a persistent artifact*
  - *Deployments RPC transmits only the blob storage reference*
  - *TaskManagers retrieve the TaskInfo from the blob cache*


## Verifying this change

*(Please pick either of the following options)*

This change is a trivial rework / code cleanup without any test coverage.

*(or)*

This change is already covered by existing tests, such as *(please describe tests)*.

*(or)*

This change added tests and can be verified as follows:

*(example:)*
  - *Added integration tests for end-to-end deployment with large payloads (100MB)*
  - *Extended integration test for recovery after master (JobManager) failure*
  - *Added test that validates that TaskInfo is transferred only once across recoveries*
  - *Manually verified the change by running a 4 node cluser with 2 JobManagers and 4 TaskManagers, a stateful streaming program, and killing one JobManager and two TaskManagers during the execution, verifying that recovery happens correctly.*

## Does this pull request potentially affect one of the following parts:

  - Dependencies (does it add or upgrade a dependency): (yes / no)
  - The public API, i.e., is any changed class annotated with `@Public(Evolving)`: (yes / no)
  - The serializers: (yes / no / don't know)
  - The runtime per-record code paths (performance sensitive): (yes / no / don't know)
  - Anything that affects deployment or recovery: JobManager (and its components), Checkpointing, Kubernetes/Yarn, ZooKeeper: (yes / no / don't know)
  - The S3 file system connector: (yes / no / don't know)

## Documentation

  - Does this pull request introduce a new feature? (yes / no)
  - If yes, how is the feature documented? (not applicable / docs / JavaDocs / not documented)
