### PR TITLE
[FLINK-24476][docs] Rename Elasticsearch to remove CamelCase

### DIFF
--- a/docs/content.zh/docs/deployment/overview.md
+++ b/docs/content.zh/docs/deployment/overview.md
@@ -143,7 +143,7 @@ When deploying Flink, there are often multiple options available for each buildi
                 <ul>
                     <li>Apache Kafka</li>
                     <li>Amazon S3</li>
-                    <li>ElasticSearch</li>
+                    <li>Elasticsearch</li>
                     <li>Apache Cassandra</li>
                 </ul>
                 See <a href="{{< ref "docs/connectors/datastream/overview" >}}">Connectors</a> page.

--- a/docs/content.zh/release-notes/flink-1.6.md
+++ b/docs/content.zh/release-notes/flink-1.6.md
@@ -28,9 +28,9 @@ These release notes discuss important aspects, such as configuration, behavior, 
 
 The default value of the slot idle timeout `slot.idle.timeout` is set to the default value of the heartbeat timeout (`50 s`). 
 
-### Changed ElasticSearch 5.x Sink API
+### Changed Elasticsearch 5.x Sink API
 
-Previous APIs in the Flink ElasticSearch 5.x Sink's `RequestIndexer` interface have been deprecated in favor of new signatures. 
+Previous APIs in the Flink Elasticsearch 5.x Sink's `RequestIndexer` interface have been deprecated in favor of new signatures. 
 When adding requests to the `RequestIndexer`, the requests now must be of type `IndexRequest`, `DeleteRequest`, or `UpdateRequest`, instead of the base `ActionRequest`.
 
 <!-- Remove once FLINK-10712 has been fixed -->

--- a/docs/content/docs/connectors/table/hive/overview.md
+++ b/docs/content/docs/connectors/table/hive/overview.md
@@ -32,7 +32,7 @@ It serves as not only a SQL engine for big data analytics and ETL, but also a da
 Flink offers a two-fold integration with Hive.
 
 The first is to leverage Hive's Metastore as a persistent catalog with Flink's `HiveCatalog` for storing Flink specific metadata across sessions.
-For example, users can store their Kafka or ElasticSearch tables in Hive Metastore by using `HiveCatalog`, and reuse them later on in SQL queries.
+For example, users can store their Kafka or Elasticsearch tables in Hive Metastore by using `HiveCatalog`, and reuse them later on in SQL queries.
 
 The second is to offer Flink as an alternative engine for reading and writing Hive tables.
 

--- a/docs/content/docs/deployment/overview.md
+++ b/docs/content/docs/deployment/overview.md
@@ -143,7 +143,7 @@ When deploying Flink, there are often multiple options available for each buildi
                 <ul>
                     <li>Apache Kafka</li>
                     <li>Amazon S3</li>
-                    <li>ElasticSearch</li>
+                    <li>Elasticsearch</li>
                     <li>Apache Cassandra</li>
                 </ul>
                 See <a href="{{< ref "docs/connectors/datastream/overview" >}}">Connectors</a> page.

--- a/docs/content/release-notes/flink-1.6.md
+++ b/docs/content/release-notes/flink-1.6.md
@@ -28,9 +28,9 @@ These release notes discuss important aspects, such as configuration, behavior, 
 
 The default value of the slot idle timeout `slot.idle.timeout` is set to the default value of the heartbeat timeout (`50 s`). 
 
-### Changed ElasticSearch 5.x Sink API
+### Changed Elasticsearch 5.x Sink API
 
-Previous APIs in the Flink ElasticSearch 5.x Sink's `RequestIndexer` interface have been deprecated in favor of new signatures. 
+Previous APIs in the Flink Elasticsearch 5.x Sink's `RequestIndexer` interface have been deprecated in favor of new signatures. 
 When adding requests to the `RequestIndexer`, the requests now must be of type `IndexRequest`, `DeleteRequest`, or `UpdateRequest`, instead of the base `ActionRequest`.
 
 <!-- Remove once FLINK-10712 has been fixed -->


### PR DESCRIPTION
## What is the purpose of the change

FLINK-24476 This pull request renames all documentation and code instances of ElasticSearch to Elasticsearch to align with their brand guidelines.

## Brief change log

- There are no file names with an internal S
- All documentation, javadoc and private methods were renamed without an internal S.
- [This commit](https://github.com/RyanSkraba/flink/commit/55bbb7e7f747599b91a2926e47af4ea299a728e4) changes a class name that is technically exposed as API, but not `@Public` and clearly documented in comments for internal use only.

## Verifying this change

This change is a trivial rework / code cleanup without any test coverage.

`grep -r lasticSearch .` returns no results after this commit.

## Does this pull request potentially affect one of the following parts:

  - Dependencies (does it add or upgrade a dependency): no
  - The public API, i.e., is any changed class annotated with `@Public(Evolving)`: **yes**
  - The serializers: no
  - The runtime per-record code paths (performance sensitive): no
  - Anything that affects deployment or recovery: JobManager (and its components), Checkpointing, Kubernetes/Yarn, ZooKeeper: no
  - The S3 file system connector: no

## Documentation

  - Does this pull request introduce a new feature? no
  - If yes, how is the feature documented? not applicable
