### PR TITLE
[FLINK-24510][Deployment/Scripts]Fix the duplicate log output of libraries/connectors，when logback is used

### DIFF
--- a/flink-dist/src/main/flink-bin/conf/logback.xml
+++ b/flink-dist/src/main/flink-bin/conf/logback.xml
@@ -38,21 +38,11 @@
     <!-- The following lines keep the log level of common libraries/connectors on
          log level INFO. The root logger does not override this. You have to manually
          change the log levels here. -->
-    <logger name="akka" level="INFO">
-        <appender-ref ref="file"/>
-    </logger>
-    <logger name="org.apache.kafka" level="INFO">
-        <appender-ref ref="file"/>
-    </logger>
-    <logger name="org.apache.hadoop" level="INFO">
-        <appender-ref ref="file"/>
-    </logger>
-    <logger name="org.apache.zookeeper" level="INFO">
-        <appender-ref ref="file"/>
-    </logger>
+    <logger name="akka" level="INFO"/>
+    <logger name="org.apache.kafka" level="INFO"/>
+    <logger name="org.apache.hadoop" level="INFO"/>
+    <logger name="org.apache.zookeeper" level="INFO"/>
 
     <!-- Suppress the irrelevant (wrong) warnings from the Netty channel handler -->
-    <logger name="org.jboss.netty.channel.DefaultChannelPipeline" level="ERROR">
-        <appender-ref ref="file"/>
-    </logger>
+    <logger name="org.jboss.netty.channel.DefaultChannelPipeline" level="ERROR"/>
 </configuration>


### PR DESCRIPTION
## Fix the duplicate log output of libraries/connectors，when logback is used
When logback is used, the logs of libraries / connectors are output repeatedly.

By default, appenders are cumulative: a logger will log to the appenders attached to itself (if any) as well as all the appenders attached to its ancestors. Thus, attaching the same appender to multiple loggers will cause logging output to be duplicated.

http://logback.qos.ch/manual/configuration.html#cumulative


## Verifying this change
This change is a trivial rework / code cleanup without any test coverage.

## Does this pull request potentially affect one of the following parts:

  - Dependencies (does it add or upgrade a dependency): (yes / **no**)
  - The public API, i.e., is any changed class annotated with `@Public(Evolving)`: (yes / **no**)
  - The serializers: (yes / **no** / don't know)
  - The runtime per-record code paths (performance sensitive): (yes / **no** / don't know)
  - Anything that affects deployment or recovery: JobManager (and its components), Checkpointing, Kubernetes/Yarn, ZooKeeper: (yes / **no** / don't know)
  - The S3 file system connector: (yes / **no** / don't know)

## Documentation

  - Does this pull request introduce a new feature? (yes / **no**)
  - If yes, how is the feature documented? (**not applicable** / docs / JavaDocs / not documented)
