### PR TITLE
[FLINK-24513][tests] Make AkkaRpcSystemLoaderTest an ITCase

### DIFF
--- a/flink-rpc/flink-rpc-akka-loader/src/test/java/org/apache/flink/runtime/rpc/akka/AkkaRpcSystemLoaderITCase.java
+++ b/flink-rpc/flink-rpc-akka-loader/src/test/java/org/apache/flink/runtime/rpc/akka/AkkaRpcSystemLoaderITCase.java
@@ -32,7 +32,12 @@ import static org.hamcrest.CoreMatchers.not;
 import static org.hamcrest.CoreMatchers.nullValue;
 import static org.hamcrest.MatcherAssert.assertThat;
 
-/** Tests for the {@link AkkaRpcSystemLoader}. */
+/**
+ * Tests for the {@link AkkaRpcSystemLoader}.
+ *
+ * <p>This must be an ITCase so that it runs after the 'package' phase of maven. Otherwise the
+ * flink-rpc-akka jar will not be available.
+ */
 public class AkkaRpcSystemLoaderITCase extends TestLogger {
 
     private static final AkkaRpcSystemLoader LOADER = new AkkaRpcSystemLoader();


### PR DESCRIPTION
Since the tests specifically tests the AkkaRpcSystemLoader, which relies on the flink-rpc-akka jar to be available (which runs in the package phase since FLINK-24445), it needs to be an ITCase.