### PR TITLE
[FLINK-24509][docs] Add kafka serializer to producer examples

### DIFF
--- a/docs/content/docs/connectors/datastream/kafka.md
+++ b/docs/content/docs/connectors/datastream/kafka.md
@@ -624,10 +624,19 @@ DataStream<String> stream = ...
 Properties properties = new Properties();
 properties.setProperty("bootstrap.servers", "localhost:9092");
 
+KafkaSerializationSchema<String> serializationSchema = new KafkaSerializationSchema<String>() {
+        @Override
+        public ProducerRecord<byte[], byte[]> serialize(String element, @Nullable Long timestamp) {
+            return new ProducerRecord<>(
+                    "my-topic", // target topic
+                    element.getBytes(StandardCharsets.UTF_8)); // record contents
+            }
+        };
+
 FlinkKafkaProducer<String> myProducer = new FlinkKafkaProducer<>(
-        "my-topic",                  // target topic
-        new SimpleStringSchema(),    // serialization schema
-        properties,                  // producer config
+        "my-topic",             // target topic
+        serializationSchema,    // serialization schema
+        properties,             // producer config
         FlinkKafkaProducer.Semantic.EXACTLY_ONCE); // fault-tolerance
 
 stream.addSink(myProducer);
@@ -640,9 +649,17 @@ val stream: DataStream[String] = ...
 val properties = new Properties
 properties.setProperty("bootstrap.servers", "localhost:9092")
 
+val serializationSchema = new KafkaSerializationSchema[String] {
+        override def serialize(element: String,
+                               timestamp: lang.Long): ProducerRecord[Array[Byte], Array[Byte]] =
+            new ProducerRecord[Array[Byte], Array[Byte]](
+                    "my-topic",      // target topic
+                    element.getBytes(StandardCharsets.UTF_8)) // record contents
+        }
+
 val myProducer = new FlinkKafkaProducer[String](
         "my-topic",                  // target topic
-        new SimpleStringSchema(),    // serialization schema
+        serializationSchema,         // serialization schema
         properties,                  // producer config
         FlinkKafkaProducer.Semantic.EXACTLY_ONCE) // fault-tolerance
 


### PR DESCRIPTION
## What is the purpose of the change

This pull request fixes documentation examples for the kafka producer by replacing the SimpleStringSchema with KafkaSerializationSchema

## Brief change log

  - A new KafkaSerializationSchema is created with basic topic and record content filling
  - A newly created KafkaSerializationSchema is passed as the serialization schema to the FlinkKafkaProducer constructor

## Verifying this change

This change does not affect any tests since it is an update to the documentation.

## Does this pull request potentially affect one of the following parts:

  - Dependencies (does it add or upgrade a dependency): (no)
  - The public API, i.e., is any changed class annotated with `@Public(Evolving)`: (no)
  - The serializers: (no)
  - The runtime per-record code paths (performance sensitive): (no)
  - Anything that affects deployment or recovery: JobManager (and its components), Checkpointing, Kubernetes/Yarn, ZooKeeper: (no)
  - The S3 file system connector: (no)

## Documentation

  - Does this pull request introduce a new feature? (no)
  - If yes, how is the feature documented? (not applicable)
