### PR TITLE
[FLINK-20928] Fix flaky test by retrying notifyCheckpointComplete until either commit success or timeout

### DIFF
--- a/flink-test-utils-parent/flink-test-utils-junit/src/main/java/org/apache/flink/core/testutils/CommonTestUtils.java
+++ b/flink-test-utils-parent/flink-test-utils-junit/src/main/java/org/apache/flink/core/testutils/CommonTestUtils.java
@@ -190,13 +190,15 @@ public class CommonTestUtils {
      *
      * @param condition the condition to wait for.
      * @param timeout the maximum time to wait for the condition to become true.
+     * @param pause delay between condition checks.
      * @param errorMsg the error message to include in the <code>TimeoutException</code> if the
      *     condition was not met before timeout.
      * @throws TimeoutException if the condition is not met before timeout.
      * @throws InterruptedException if the thread is interrupted.
      */
     @SuppressWarnings("BusyWait")
-    public static void waitUtil(Supplier<Boolean> condition, Duration timeout, String errorMsg)
+    public static void waitUtil(
+            Supplier<Boolean> condition, Duration timeout, Duration pause, String errorMsg)
             throws TimeoutException, InterruptedException {
         long timeoutMs = timeout.toMillis();
         if (timeoutMs <= 0) {
@@ -206,10 +208,25 @@ public class CommonTestUtils {
         boolean conditionResult = condition.get();
         while (!conditionResult && System.currentTimeMillis() - startingTime < timeoutMs) {
             conditionResult = condition.get();
-            Thread.sleep(1);
+            Thread.sleep(pause.toMillis());
         }
         if (!conditionResult) {
             throw new TimeoutException(errorMsg);
         }
+    }
+
+    /**
+     * Wait util the given condition is met or timeout.
+     *
+     * @param condition the condition to wait for.
+     * @param timeout the maximum time to wait for the condition to become true.
+     * @param errorMsg the error message to include in the <code>TimeoutException</code> if the
+     *     condition was not met before timeout.
+     * @throws TimeoutException if the condition is not met before timeout.
+     * @throws InterruptedException if the thread is interrupted.
+     */
+    public static void waitUtil(Supplier<Boolean> condition, Duration timeout, String errorMsg)
+            throws TimeoutException, InterruptedException {
+        waitUtil(condition, timeout, Duration.ofMillis(1), errorMsg);
     }
 }


### PR DESCRIPTION
This PR cherry-picks the PR from https://github.com/apache/flink/pull/17342 to the release-1.14 branch.