### PR TITLE
[FLINK-23170] Write metadata after materialization

### DIFF
--- a/flink-state-backends/flink-statebackend-changelog/src/main/java/org/apache/flink/state/changelog/AbstractChangelogState.java
+++ b/flink-state-backends/flink-statebackend-changelog/src/main/java/org/apache/flink/state/changelog/AbstractChangelogState.java
@@ -90,6 +90,11 @@ abstract class AbstractChangelogState<K, N, V, S extends InternalKvState<K, N, V
         return delegatedState.getStateIncrementalVisitor(recommendedMaxNumberOfReturnedRecords);
     }
 
+    @Override
+    public void resetWritingMetaFlag() {
+        changeLogger.resetWritingMetaFlag();
+    }
+
     protected N getCurrentNamespace() throws NullPointerException {
         return checkNotNull(currentNamespace);
     }

--- a/flink-state-backends/flink-statebackend-changelog/src/main/java/org/apache/flink/state/changelog/AbstractStateChangeLogger.java
+++ b/flink-state-backends/flink-statebackend-changelog/src/main/java/org/apache/flink/state/changelog/AbstractStateChangeLogger.java
@@ -130,6 +130,11 @@ abstract class AbstractStateChangeLogger<Key, Value, Ns>
         log(REMOVE_ELEMENT, dataSerializer, ns);
     }
 
+    @Override
+    public void resetWritingMetaFlag() {
+        metaDataWritten = false;
+    }
+
     protected void log(StateChangeOperation op, Ns ns) throws IOException {
         logMetaIfNeeded();
         stateChangelogWriter.append(keyContext.getCurrentKeyGroupIndex(), serialize(op, ns, null));

--- a/flink-state-backends/flink-statebackend-changelog/src/main/java/org/apache/flink/state/changelog/ChangelogKeyGroupedPriorityQueue.java
+++ b/flink-state-backends/flink-statebackend-changelog/src/main/java/org/apache/flink/state/changelog/ChangelogKeyGroupedPriorityQueue.java
@@ -137,4 +137,9 @@ public class ChangelogKeyGroupedPriorityQueue<T>
     public StateChangeApplier getChangeApplier(ChangelogApplierFactory factory) {
         return factory.forPriorityQueue(delegatedPriorityQueue, serializer);
     }
+
+    @Override
+    public void resetWritingMetaFlag() {
+        logger.resetWritingMetaFlag();
+    }
 }

--- a/flink-state-backends/flink-statebackend-changelog/src/main/java/org/apache/flink/state/changelog/ChangelogKeyedStateBackend.java
+++ b/flink-state-backends/flink-statebackend-changelog/src/main/java/org/apache/flink/state/changelog/ChangelogKeyedStateBackend.java
@@ -92,6 +92,7 @@ import static java.util.Collections.singletonList;
 import static java.util.Collections.unmodifiableList;
 import static org.apache.flink.state.changelog.PeriodicMaterializationManager.MaterializationRunnable;
 import static org.apache.flink.util.Preconditions.checkNotNull;
+import static org.apache.flink.util.Preconditions.checkState;
 
 /**
  * A {@link KeyedStateBackend} that keeps state on the underlying delegated keyed state backend as
@@ -587,7 +588,7 @@ public class ChangelogKeyedStateBackend<K>
 
             LOG.info("Starting materialization from {} : {}", lastMaterializedTo, upTo);
 
-            return Optional.of(
+            MaterializationRunnable materializationRunnable =
                     new MaterializationRunnable(
                             keyedStateBackend.snapshot(
                                     // This ID is not needed for materialization;
@@ -600,8 +601,20 @@ public class ChangelogKeyedStateBackend<K>
                                     System.currentTimeMillis(),
                                     streamFactory,
                                     CHECKPOINT_OPTIONS),
-                            // TODO: add metadata to log FLINK-23170.
-                            upTo));
+                            upTo);
+
+            // log metadata after materialization is triggered
+            for (InternalKvState<K, ?, ?> changelogState : keyValueStatesByName.values()) {
+                checkState(changelogState instanceof ChangelogState);
+                ((ChangelogState) changelogState).resetWritingMetaFlag();
+            }
+
+            for (ChangelogKeyGroupedPriorityQueue<?> priorityQueueState :
+                    priorityQueueStatesByName.values()) {
+                priorityQueueState.resetWritingMetaFlag();
+            }
+
+            return Optional.of(materializationRunnable);
         } else {
             LOG.debug(
                     "Skip materialization, last materialized to {} : last log to {}",

--- a/flink-state-backends/flink-statebackend-changelog/src/main/java/org/apache/flink/state/changelog/ChangelogKeyedStateBackend.java
+++ b/flink-state-backends/flink-statebackend-changelog/src/main/java/org/apache/flink/state/changelog/ChangelogKeyedStateBackend.java
@@ -625,12 +625,6 @@ public class ChangelogKeyedStateBackend<K>
         }
     }
 
-    /** Not thread safe. */
-    @VisibleForTesting
-    boolean hasNonMaterializedChanges() {
-        return getLastAppendedTo().compareTo(changelogSnapshotState.lastMaterializedTo()) > 0;
-    }
-
     // TODO: Remove after fix FLINK-24436
     //  FsStateChangelogWriter#lastAppendedSequenceNumber returns different seq number
     //  the first time called vs called after the first time.

--- a/flink-state-backends/flink-statebackend-changelog/src/main/java/org/apache/flink/state/changelog/ChangelogState.java
+++ b/flink-state-backends/flink-statebackend-changelog/src/main/java/org/apache/flink/state/changelog/ChangelogState.java
@@ -27,4 +27,7 @@ import org.apache.flink.state.changelog.restore.StateChangeApplier;
 @Internal
 public interface ChangelogState {
     StateChangeApplier getChangeApplier(ChangelogApplierFactory factory);
+
+    /** Enable logging meta data before next writes. */
+    void resetWritingMetaFlag();
 }

--- a/flink-state-backends/flink-statebackend-changelog/src/main/java/org/apache/flink/state/changelog/StateChangeLogger.java
+++ b/flink-state-backends/flink-statebackend-changelog/src/main/java/org/apache/flink/state/changelog/StateChangeLogger.java
@@ -70,4 +70,7 @@ interface StateChangeLogger<Value, Namespace> extends Closeable {
     void valueElementRemoved(
             ThrowingConsumer<DataOutputViewStreamWrapper, IOException> dataSerializer, Namespace ns)
             throws IOException;
+
+    /** Enable logging meta data before next writes. */
+    void resetWritingMetaFlag();
 }

--- a/flink-state-backends/flink-statebackend-changelog/src/test/java/org/apache/flink/state/changelog/ChangelogDelegateEmbeddedRocksDBStateBackendTest.java
+++ b/flink-state-backends/flink-statebackend-changelog/src/test/java/org/apache/flink/state/changelog/ChangelogDelegateEmbeddedRocksDBStateBackendTest.java
@@ -93,4 +93,12 @@ public class ChangelogDelegateEmbeddedRocksDBStateBackendTest
         ChangelogStateBackendTestUtils.testMaterializedRestore(
                 getStateBackend(), env, streamFactory);
     }
+
+    @Test
+    public void testMaterializedRestorePriorityQueue() throws Exception {
+        CheckpointStreamFactory streamFactory = createStreamFactory();
+
+        ChangelogStateBackendTestUtils.testMaterializedRestoreForPriorityQueue(
+                getStateBackend(), env, streamFactory);
+    }
 }

--- a/flink-state-backends/flink-statebackend-changelog/src/test/java/org/apache/flink/state/changelog/ChangelogDelegateFileStateBackendTest.java
+++ b/flink-state-backends/flink-statebackend-changelog/src/test/java/org/apache/flink/state/changelog/ChangelogDelegateFileStateBackendTest.java
@@ -89,4 +89,12 @@ public class ChangelogDelegateFileStateBackendTest extends FileStateBackendTest 
         ChangelogStateBackendTestUtils.testMaterializedRestore(
                 getStateBackend(), env, streamFactory);
     }
+
+    @Test
+    public void testMaterializedRestorePriorityQueue() throws Exception {
+        CheckpointStreamFactory streamFactory = createStreamFactory();
+
+        ChangelogStateBackendTestUtils.testMaterializedRestoreForPriorityQueue(
+                getStateBackend(), env, streamFactory);
+    }
 }

--- a/flink-state-backends/flink-statebackend-changelog/src/test/java/org/apache/flink/state/changelog/ChangelogDelegateHashMapTest.java
+++ b/flink-state-backends/flink-statebackend-changelog/src/test/java/org/apache/flink/state/changelog/ChangelogDelegateHashMapTest.java
@@ -80,4 +80,12 @@ public class ChangelogDelegateHashMapTest extends HashMapStateBackendTest {
         ChangelogStateBackendTestUtils.testMaterializedRestore(
                 getStateBackend(), env, streamFactory);
     }
+
+    @Test
+    public void testMaterializedRestorePriorityQueue() throws Exception {
+        CheckpointStreamFactory streamFactory = createStreamFactory();
+
+        ChangelogStateBackendTestUtils.testMaterializedRestoreForPriorityQueue(
+                getStateBackend(), env, streamFactory);
+    }
 }

--- a/flink-state-backends/flink-statebackend-changelog/src/test/java/org/apache/flink/state/changelog/ChangelogDelegateMemoryStateBackendTest.java
+++ b/flink-state-backends/flink-statebackend-changelog/src/test/java/org/apache/flink/state/changelog/ChangelogDelegateMemoryStateBackendTest.java
@@ -89,4 +89,12 @@ public class ChangelogDelegateMemoryStateBackendTest extends MemoryStateBackendT
         ChangelogStateBackendTestUtils.testMaterializedRestore(
                 getStateBackend(), env, streamFactory);
     }
+
+    @Test
+    public void testMaterializedRestorePriorityQueue() throws Exception {
+        CheckpointStreamFactory streamFactory = createStreamFactory();
+
+        ChangelogStateBackendTestUtils.testMaterializedRestoreForPriorityQueue(
+                getStateBackend(), env, streamFactory);
+    }
 }

--- a/flink-state-backends/flink-statebackend-changelog/src/test/java/org/apache/flink/state/changelog/ChangelogPqStateTest.java
+++ b/flink-state-backends/flink-statebackend-changelog/src/test/java/org/apache/flink/state/changelog/ChangelogPqStateTest.java
@@ -166,6 +166,9 @@ public class ChangelogPqStateTest {
             stateElementRemoved = true;
         }
 
+        @Override
+        public void resetWritingMetaFlag() {}
+
         public boolean anythingChanged() {
             return stateElementChanged || stateElementRemoved || stateCleared;
         }

--- a/flink-state-backends/flink-statebackend-changelog/src/test/java/org/apache/flink/state/changelog/ChangelogStateBackendTestUtils.java
+++ b/flink-state-backends/flink-statebackend-changelog/src/test/java/org/apache/flink/state/changelog/ChangelogStateBackendTestUtils.java
@@ -173,8 +173,6 @@ public class ChangelogStateBackendTestUtils {
             keyedBackend.setCurrentKey(3);
             state.update(new StateBackendTestBase.TestPojo("u3", 3));
 
-            awaitMaterialization(keyedBackend, env.getMainMailboxExecutor());
-
             KeyedStateHandle snapshot =
                     runSnapshot(
                             keyedBackend.snapshot(
@@ -184,9 +182,9 @@ public class ChangelogStateBackendTestUtils {
                                     CheckpointOptions.forCheckpointWithDefaultLocation()),
                             sharedStateRegistry);
 
+            periodicMaterializationManager.close();
             IOUtils.closeQuietly(keyedBackend);
             keyedBackend.dispose();
-            periodicMaterializationManager.close();
 
             // make sure the asycn phase completes successfully
             if (asyncComplete.isCompletedExceptionally()) {

--- a/flink-state-backends/flink-statebackend-changelog/src/test/java/org/apache/flink/state/changelog/TestChangeLoggerKv.java
+++ b/flink-state-backends/flink-statebackend-changelog/src/test/java/org/apache/flink/state/changelog/TestChangeLoggerKv.java
@@ -118,6 +118,9 @@ class TestChangeLoggerKv<State> implements KvStateChangeLogger<State, String> {
     }
 
     @Override
+    public void resetWritingMetaFlag() {}
+
+    @Override
     public void namespacesMerged(String target, Collection<String> sources) {
         stateMerged = true;
     }


### PR DESCRIPTION
## What is the purpose of the change

After materialization is added in FLINK-21357, a snapshot is composed of 
"the materialized part" + "the changelog part", where the changelog part relies on metadata to replay the log during recovery. So we need to add metadata after materialization.

FLINK-23170 includes discussions of where and when should such metadata be added. Here we add metadata right after materialization is triggered each time.

## Verifying this change

Unit tests.
