### PR TITLE
[FLINK-24413] Casting to a CHAR() and VARCHAR() doesn't trim the stri…

### DIFF
--- a/flink-table/flink-table-planner/src/test/java/org/apache/flink/table/planner/functions/CastFunctionITCase.java
+++ b/flink-table/flink-table-planner/src/test/java/org/apache/flink/table/planner/functions/CastFunctionITCase.java
@@ -80,26 +80,30 @@ public class CastFunctionITCase extends BuiltInFunctionTestBase {
         return Arrays.asList(
                 CastTestSpecBuilder.testCastTo(CHAR(3))
                         .fromCase(CHAR(3), "foo", "foo")
-                        .fromCase(CHAR(4), "foo", "foo ")
-                        .fromCase(CHAR(4), "foo ", "foo ")
+                        .fromCase(CHAR(4), "foo", "foo")
+                        .fromCase(CHAR(4), "foo ", "foo")
                         .fromCase(VARCHAR(3), "foo", "foo")
                         .fromCase(VARCHAR(5), "foo", "foo")
-                        .fromCase(VARCHAR(5), "foo ", "foo ")
+                        .fromCase(VARCHAR(5), "foo ", "foo")
                         // https://issues.apache.org/jira/browse/FLINK-24413 - Trim to precision
                         // in this case down to 3 chars
-                        .fromCase(STRING(), "abcdef", "abcdef") // "abc"
-                        .fromCase(DATE(), LocalDate.parse("2021-09-30"), "2021-09-30") // "202"
+                        .fromCase(STRING(), "abcdef", "abc") // "abc"
+                        .fromCase(CHAR(5), "abcdef", "abc")
+                        .fromCase(VARCHAR(5), "abcdef", "abc")
+                        .fromCase(CHAR(2), "ab", "ab ")
+                        .fromCase(VARCHAR(2), "ab", "ab ")
+                        .fromCase(DATE(), LocalDate.parse("2021-09-30"), "202") // "202"
                         .build(),
                 CastTestSpecBuilder.testCastTo(VARCHAR(3))
                         .fromCase(CHAR(3), "foo", "foo")
-                        .fromCase(CHAR(4), "foo", "foo ")
-                        .fromCase(CHAR(4), "foo ", "foo ")
+                        .fromCase(CHAR(4), "foo", "foo")
+                        .fromCase(CHAR(4), "foo ", "foo")
                         .fromCase(VARCHAR(3), "foo", "foo")
                         .fromCase(VARCHAR(5), "foo", "foo")
-                        .fromCase(VARCHAR(5), "foo ", "foo ")
+                        .fromCase(VARCHAR(5), "foo ", "foo")
                         // https://issues.apache.org/jira/browse/FLINK-24413 - Trim to precision
                         // in this case down to 3 chars
-                        .fromCase(STRING(), "abcdef", "abcdef")
+                        .fromCase(STRING(), "abcdef", "abc")
                         .build(),
                 CastTestSpecBuilder.testCastTo(STRING())
                         .fromCase(STRING(), null, null)

--- a/flink-table/flink-table-planner/src/test/scala/org/apache/flink/table/planner/expressions/DecimalCastTest.scala
+++ b/flink-table/flink-table-planner/src/test/scala/org/apache/flink/table/planner/expressions/DecimalCastTest.scala
@@ -164,16 +164,17 @@ class DecimalCastTest extends ExpressionTestBase {
 
   @Test
   def testCastToString(): Unit = {
-    def test(t: String): Unit = {
-      testSqlApi(s"CAST(${decimal_38_2(null)} AS $t)", "null")
-      testSqlApi(s"CAST(${decimal_38_2(0)} AS $t)", "0.00")
-      testSqlApi(s"CAST(${decimal_38_2(12.2)} AS $t)", "12.20")
-      testSqlApi(s"CAST(${decimal_38_2(-12.2)} AS $t)", "-12.20")
-      testSqlApi(s"CAST(${decimal_38_2(5.26)} AS $t)", "5.26")
-    }
+    testSqlApi(s"CAST(${decimal_38_2(null)} AS VARCHAR)", "null")
+    testSqlApi(s"CAST(${decimal_38_2(0)} AS VARCHAR)", "0.00")
+    testSqlApi(s"CAST(${decimal_38_2(12.2)} AS VARCHAR)", "12.20")
+    testSqlApi(s"CAST(${decimal_38_2(-12.2)} AS VARCHAR)", "-12.20")
+    testSqlApi(s"CAST(${decimal_38_2(5.26)} AS VARCHAR)", "5.26")
 
-    test("VARCHAR")
-    test("CHAR") // current CHAR is same to VARCHAR
+    testSqlApi(s"CAST(${decimal_38_2(null)} AS CHAR(4))", "null")
+    testSqlApi(s"CAST(${decimal_38_2(0)} AS CHAR(4))", "0.00")
+    testSqlApi(s"CAST(${decimal_38_2(12.2)} AS CHAR(5))", "12.20")
+    testSqlApi(s"CAST(${decimal_38_2(-12.2)} AS CHAR(6))", "-12.20")
+    testSqlApi(s"CAST(${decimal_38_2(5.26)} AS CHAR(4))", "5.26")
   }
 
   @Test


### PR DESCRIPTION
Casting to a CHAR() and VARCHAR() doesn't trim the string to the specified precision

## What is the purpose of the change

```
CAST('abcdfe' AS CHAR(3)) should trim the string to 3 chars but currently returns the whole string 'abcdfe'.

PostgreSQL and Oracle for example behave as such:

postgres=# select '123456afas'::char(4);
bpchar
--------
1234
(1 row)

postgres=# select '123456afas'::varchar(5);
varchar
---------
12345
(1 row)
```

## Brief change log

## Verifying this change

This change is already covered by existing tests `CastFunctionITCase`.

## Does this pull request potentially affect one of the following parts:

  - Dependencies (does it add or upgrade a dependency): (no)
  - The public API, i.e., is any changed class annotated with `@Public(Evolving)`: (no)
  - The serializers: (no)
  - The runtime per-record code paths (performance sensitive): (no)
  - Anything that affects deployment or recovery: JobManager (and its components), Checkpointing, Kubernetes/Yarn, ZooKeeper: (no)
  - The S3 file system connector: (no)

## Documentation

  - Does this pull request introduce a new feature? (no)
  - If yes, how is the feature documented? (docs)
