### PR TITLE
[FLINK-24488][connectors/kafka] KafkaRecordSerializationSchemaBuilder does not forward timestamp

### DIFF
--- a/flink-connectors/flink-connector-kafka/src/main/java/org/apache/flink/connector/kafka/sink/KafkaRecordSerializationSchemaBuilder.java
+++ b/flink-connectors/flink-connector-kafka/src/main/java/org/apache/flink/connector/kafka/sink/KafkaRecordSerializationSchemaBuilder.java
@@ -326,7 +326,11 @@ public class KafkaRecordSerializationSchemaBuilder<IN> {
                             : OptionalInt.empty();
 
             return new ProducerRecord<>(
-                    targetTopic, partition.isPresent() ? partition.getAsInt() : null, key, value);
+                    targetTopic,
+                    partition.isPresent() ? partition.getAsInt() : null,
+                    timestamp == null || timestamp < 0L ? null : timestamp,
+                    key,
+                    value);
         }
     }
 }

--- a/flink-connectors/flink-connector-kafka/src/test/java/org/apache/flink/connector/kafka/sink/KafkaRecordSerializationSchemaBuilderTest.java
+++ b/flink-connectors/flink-connector-kafka/src/test/java/org/apache/flink/connector/kafka/sink/KafkaRecordSerializationSchemaBuilderTest.java
@@ -197,6 +197,32 @@ public class KafkaRecordSerializationSchemaBuilderTest extends TestLogger {
         assertEquals("a", deserializer.deserialize(DEFAULT_TOPIC, record.value()));
     }
 
+    @Test
+    public void testSerializeRecordWithTimestamp() {
+        final SerializationSchema<String> serializationSchema = new SimpleStringSchema();
+        final KafkaRecordSerializationSchema<String> schema =
+                KafkaRecordSerializationSchema.builder()
+                        .setTopic(DEFAULT_TOPIC)
+                        .setValueSerializationSchema(serializationSchema)
+                        .setKeySerializationSchema(serializationSchema)
+                        .build();
+        final ProducerRecord<byte[], byte[]> recordWithTimestamp =
+                schema.serialize("a", null, 100L);
+        assertEquals(100L, (long) recordWithTimestamp.timestamp());
+
+        final ProducerRecord<byte[], byte[]> recordWithTimestampZero =
+                schema.serialize("a", null, 0L);
+        assertEquals(0L, (long) recordWithTimestampZero.timestamp());
+
+        final ProducerRecord<byte[], byte[]> recordWithoutTimestamp =
+                schema.serialize("a", null, null);
+        assertNull(recordWithoutTimestamp.timestamp());
+
+        final ProducerRecord<byte[], byte[]> recordWithInvalidTimestamp =
+                schema.serialize("a", null, -100L);
+        assertNull(recordWithInvalidTimestamp.timestamp());
+    }
+
     private static void assertOnlyOneSerializerAllowed(
             List<
                             Function<


### PR DESCRIPTION

<!--
*Thank you very much for contributing to Apache Flink - we are happy that you want to help us improve Flink. To help the community review your contribution in the best possible way, please go through the checklist below, which will get the contribution into a shape in which it can be best reviewed.*

*Please understand that we do not do this to make contributions to Flink a hassle. In order to uphold a high standard of quality for code contributions, while at the same time managing a large number of contributions, we need contributors to prepare the contributions well, and give reviewers enough contextual information for the review. Please also understand that contributions that do not follow this guide will take longer to review and thus typically be picked up with lower priority by the community.*

## Contribution Checklist

  - Make sure that the pull request corresponds to a [JIRA issue](https://issues.apache.org/jira/projects/FLINK/issues). Exceptions are made for typos in JavaDoc or documentation files, which need no JIRA issue.
  
  - Name the pull request in the form "[FLINK-XXXX] [component] Title of the pull request", where *FLINK-XXXX* should be replaced by the actual issue number. Skip *component* if you are unsure about which is the best component.
  Typo fixes that have no associated JIRA issue should be named following this pattern: `[hotfix] [docs] Fix typo in event time introduction` or `[hotfix] [javadocs] Expand JavaDoc for PuncuatedWatermarkGenerator`.

  - Fill out the template below to describe the changes contributed by the pull request. That will give reviewers the context they need to do the review.
  
  - Make sure that the change passes the automated tests, i.e., `mvn clean verify` passes. You can set up Azure Pipelines CI to do that following [this guide](https://cwiki.apache.org/confluence/display/FLINK/Azure+Pipelines#AzurePipelines-Tutorial:SettingupAzurePipelinesforaforkoftheFlinkrepository).

  - Each pull request should address only one issue, not mix up code from multiple issues.
  
  - Each commit in the pull request has a meaningful commit message (including the JIRA id)

  - Once all items of the checklist are addressed, remove the above text and this checklist, leaving only the filled out template below.


**(The sections below can be removed for hotfixes of typos)**
-->

## What is the purpose of the change

*Fix KafkaRecordSerializationSchemaBuilder does not forward timestamp issue*


## Brief change log

  - *Correct KafkaRecordSerializationSchemaWrapper.serialize to use a with timestamp ProducerRecord construct*
  - *Add a unit test*


## Verifying this change

This change added tests and can be verified as follows:

  - *Use KafkaRecordSerializationSchemaBuilderTest.testSerializeRecordWithTimestamp to test it*
 
## Does this pull request potentially affect one of the following parts:

  - Dependencies (does it add or upgrade a dependency): (no)
  - The public API, i.e., is any changed class annotated with `@Public(Evolving)`: (no)
  - The serializers: (no)
  - The runtime per-record code paths (performance sensitive): (no)
  - Anything that affects deployment or recovery: JobManager (and its components), Checkpointing, Kubernetes/Yarn, ZooKeeper: (no)
  - The S3 file system connector: (no)

## Documentation

  - Does this pull request introduce a new feature? (no)
  - If yes, how is the feature documented? (not documented)
