### PR TITLE
FLINK-24540 : Fix Resocue leak due to Files.list

### DIFF
--- a/flink-core/src/main/java/org/apache/flink/core/plugin/DirectoryBasedPluginFinder.java
+++ b/flink-core/src/main/java/org/apache/flink/core/plugin/DirectoryBasedPluginFinder.java
@@ -29,13 +29,16 @@ import java.util.Arrays;
 import java.util.Collection;
 import java.util.Comparator;
 import java.util.stream.Collectors;
+import java.util.stream.Stream;
 
 /**
- * This class is used to create a collection of {@link PluginDescriptor} based on directory structure for a given plugin
- * root folder.
+ * This class is used to create a collection of {@link PluginDescriptor} based on directory
+ * structure for a given plugin root folder.
  *
- * <p>The expected structure is as follows: the given plugins root folder, containing the plugins folder. One plugin folder
- * contains all resources (jar files) belonging to a plugin. The name of the plugin folder becomes the plugin id.
+ * <p>The expected structure is as follows: the given plugins root folder, containing the plugins
+ * folder. One plugin folder contains all resources (jar files) belonging to a plugin. The name of
+ * the plugin folder becomes the plugin id.
+ *
  * <pre>
  * plugins-root-folder/
  *            |------------plugin-a/ (folder of plugin a)
@@ -50,54 +53,58 @@ import java.util.stream.Collectors;
  */
 public class DirectoryBasedPluginFinder implements PluginFinder {
 
-	/** Pattern to match jar files in a directory. */
-	private static final String JAR_MATCHER_PATTERN = "glob:**.jar";
+    /** Pattern to match jar files in a directory. */
+    private static final String JAR_MATCHER_PATTERN = "glob:**.jar";
 
-	/** Root directory to the plugin folders. */
-	private final Path pluginsRootDir;
+    /** Root directory to the plugin folders. */
+    private final Path pluginsRootDir;
 
-	/** Matcher for jar files in the filesystem of the root folder. */
-	private final PathMatcher jarFileMatcher;
+    /** Matcher for jar files in the filesystem of the root folder. */
+    private final PathMatcher jarFileMatcher;
 
-	public DirectoryBasedPluginFinder(Path pluginsRootDir) {
-		this.pluginsRootDir = pluginsRootDir;
-		this.jarFileMatcher = pluginsRootDir.getFileSystem().getPathMatcher(JAR_MATCHER_PATTERN);
+    public DirectoryBasedPluginFinder(Path pluginsRootDir) {
+        this.pluginsRootDir = pluginsRootDir;
+        this.jarFileMatcher = pluginsRootDir.getFileSystem().getPathMatcher(JAR_MATCHER_PATTERN);
+    }
+
+    @Override
+    public Collection<PluginDescriptor> findPlugins() throws IOException {
+
+        if (!Files.isDirectory(pluginsRootDir)) {
+            throw new IOException(
+                    "Plugins root directory [" + pluginsRootDir + "] does not exist!");
+        }
+        try (Stream<Path> stream = Files.list(pluginsRootDir)) {
+            stream.filter((Path path) -> Files.isDirectory(path))
+                .map(FunctionUtils.uncheckedFunction(this::createPluginDescriptorForSubDirectory))
+                .collect(Collectors.toList());
 	}
+    }
 
-	@Override
-	public Collection<PluginDescriptor> findPlugins() throws IOException {
+    private PluginDescriptor createPluginDescriptorForSubDirectory(Path subDirectory)
+            throws IOException {
+        URL[] urls = createJarURLsFromDirectory(subDirectory);
+        Arrays.sort(urls, Comparator.comparing(URL::toString));
+        // TODO: This class could be extended to parse exclude-pattern from a optional text files in
+        // the plugin directories.
+        return new PluginDescriptor(subDirectory.getFileName().toString(), urls, new String[0]);
+    }
 
-		if (!Files.isDirectory(pluginsRootDir)) {
-			throw new IOException("Plugins root directory [" + pluginsRootDir + "] does not exist!");
-		}
+    private URL[] createJarURLsFromDirectory(Path subDirectory) throws IOException {
+        try (Stream<Path> stream = Files.list(subDirectory)) {
+            URL[] urls =
+                  stream.filter((Path p) -> Files.isRegularFile(p) && jarFileMatcher.matches(p))
+                        .map(FunctionUtils.uncheckedFunction((Path p) -> p.toUri().toURL()))
+                        .toArray(URL[]::new);
 
-		return Files.list(pluginsRootDir)
-			.filter((Path path) -> Files.isDirectory(path))
-			.map(FunctionUtils.uncheckedFunction(this::createPluginDescriptorForSubDirectory))
-			.collect(Collectors.toList());
-	}
+            if (urls.length < 1) {
+               throw new IOException(
+                   "Cannot find any jar files for plugin in directory ["
+                   + subDirectory
+                   + "]."
+                   + " Please provide the jar files for the plugin or delete the directory.");
+            }
 
-	private PluginDescriptor createPluginDescriptorForSubDirectory(Path subDirectory) throws IOException {
-		URL[] urls = createJarURLsFromDirectory(subDirectory);
-		Arrays.sort(urls, Comparator.comparing(URL::toString));
-		//TODO: This class could be extended to parse exclude-pattern from a optional text files in the plugin directories.
-		return new PluginDescriptor(
-				subDirectory.getFileName().toString(),
-				urls,
-				new String[0]);
-	}
-
-	private URL[] createJarURLsFromDirectory(Path subDirectory) throws IOException {
-		URL[] urls = Files.list(subDirectory)
-			.filter((Path p) -> Files.isRegularFile(p) && jarFileMatcher.matches(p))
-			.map(FunctionUtils.uncheckedFunction((Path p) -> p.toUri().toURL()))
-			.toArray(URL[]::new);
-
-		if (urls.length < 1) {
-			throw new IOException("Cannot find any jar files for plugin in directory [" + subDirectory + "]." +
-				" Please provide the jar files for the plugin or delete the directory.");
-		}
-
-		return urls;
-	}
+            return urls;
+    }
 }


### PR DESCRIPTION
Files.list will open dir and we should close it


see jdk:

the

{@code try}-with-resources construct should be used to ensure that the
stream's {@link Stream#close close} method is invoked after the stream
operations are completed.