### PR TITLE
[FLINK-24540] : fix resource leak due to Files.list

### DIFF
--- a/flink-core/src/main/java/org/apache/flink/core/plugin/DirectoryBasedPluginFinder.java
+++ b/flink-core/src/main/java/org/apache/flink/core/plugin/DirectoryBasedPluginFinder.java
@@ -75,7 +75,7 @@ public class DirectoryBasedPluginFinder implements PluginFinder {
                     "Plugins root directory [" + pluginsRootDir + "] does not exist!");
         }
         try (Stream<Path> stream = Files.list(pluginsRootDir)) {
-            stream.filter((Path path) -> Files.isDirectory(path))
+            return stream.filter((Path path) -> Files.isDirectory(path))
                     .map(
                             FunctionUtils.uncheckedFunction(
                                     this::createPluginDescriptorForSubDirectory))


### PR DESCRIPTION
Files.list will open dir and we should close it

see jdk:

the

{@code try}-with-resources construct should be used to ensure that the
stream's {@link Stream#close close} method is invoked after the stream
operations are completed.