### PR TITLE
[FLINK-24480][table-planner] Do not discard exception in test

### DIFF
--- a/flink-table/flink-table-planner/src/test/java/org/apache/flink/table/planner/codegen/EqualiserCodeGeneratorTest.java
+++ b/flink-table/flink-table-planner/src/test/java/org/apache/flink/table/planner/codegen/EqualiserCodeGeneratorTest.java
@@ -92,18 +92,10 @@ public class EqualiserCodeGeneratorTest {
                         .mapToObj(i -> new VarCharType())
                         .toArray(LogicalType[]::new);
 
-        RecordEqualiser equaliser;
-        try {
-            equaliser =
-                    new EqualiserCodeGenerator(fieldTypes)
-                            .generateRecordEqualiser("ManyFields")
-                            .newInstance(Thread.currentThread().getContextClassLoader());
-        } catch (Exception e) {
-            Assert.fail("Expected compilation to succeed");
-
-            // Unreachable
-            throw e;
-        }
+        final RecordEqualiser equaliser =
+                new EqualiserCodeGenerator(fieldTypes)
+                        .generateRecordEqualiser("ManyFields")
+                        .newInstance(Thread.currentThread().getContextClassLoader());
 
         final StringData[] fields =
                 IntStream.range(0, 999)


### PR DESCRIPTION
## What is the purpose of the change

This does _not_ fix FLINK-24480, but instead hopefully will help investigating why the test sometimes fails. Currently, the actual exception is unfortunately discarded.

## Verifying this change

This change is a trivial rework / code cleanup without any test coverage.

## Does this pull request potentially affect one of the following parts:

  - Dependencies (does it add or upgrade a dependency): no
  - The public API, i.e., is any changed class annotated with `@Public(Evolving)`: no
  - The serializers: no
  - The runtime per-record code paths (performance sensitive): no
  - Anything that affects deployment or recovery: JobManager (and its components), Checkpointing, Kubernetes/Yarn, ZooKeeper: no
  - The S3 file system connector: no

## Documentation

  - Does this pull request introduce a new feature? no
  - If yes, how is the feature documented? not applicable
