### PR TITLE
[FLINK-24469][runtime] Allowed to have zero number of buffers in use …

### DIFF
--- a/flink-runtime/src/main/java/org/apache/flink/runtime/io/network/partition/consumer/SingleInputGate.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/io/network/partition/consumer/SingleInputGate.java
@@ -378,7 +378,7 @@ public class SingleInputGate extends IndexedInputGate {
     public int getBuffersInUseCount() {
         int total = 0;
         for (InputChannel channel : channels) {
-            total += Math.max(1, channel.getBuffersInUseCount());
+            total += channel.getBuffersInUseCount();
         }
         return total;
     }

--- a/flink-runtime/src/test/java/org/apache/flink/runtime/io/network/partition/consumer/SingleInputGateTest.java
+++ b/flink-runtime/src/test/java/org/apache/flink/runtime/io/network/partition/consumer/SingleInputGateTest.java
@@ -938,6 +938,32 @@ public class SingleInputGateTest extends InputGateTestBase {
         assertEquals(Collections.emptyList(), inputGate.getUnfinishedChannels());
     }
 
+    @Test
+    public void testBufferInUseCount() throws Exception {
+        // Setup
+        final SingleInputGate inputGate = createInputGate();
+
+        final TestInputChannel[] inputChannels =
+                new TestInputChannel[] {
+                    new TestInputChannel(inputGate, 0), new TestInputChannel(inputGate, 1)
+                };
+
+        inputGate.setInputChannels(inputChannels);
+
+        // It should be no buffers when all channels are empty.
+        assertThat(inputGate.getBuffersInUseCount(), is(0));
+
+        // Add buffers into channels.
+        inputChannels[0].readBuffer();
+        assertThat(inputGate.getBuffersInUseCount(), is(1));
+
+        inputChannels[0].readBuffer();
+        assertThat(inputGate.getBuffersInUseCount(), is(2));
+
+        inputChannels[1].readBuffer();
+        assertThat(inputGate.getBuffersInUseCount(), is(3));
+    }
+
     // ---------------------------------------------------------------------------------------------
 
     private static Map<InputGateID, SingleInputGate> createInputGateWithLocalChannels(


### PR DESCRIPTION
…for channels in order to avoid miscalculation in case of channel data skew

<!--
*Thank you very much for contributing to Apache Flink - we are happy that you want to help us improve Flink. To help the community review your contribution in the best possible way, please go through the checklist below, which will get the contribution into a shape in which it can be best reviewed.*

*Please understand that we do not do this to make contributions to Flink a hassle. In order to uphold a high standard of quality for code contributions, while at the same time managing a large number of contributions, we need contributors to prepare the contributions well, and give reviewers enough contextual information for the review. Please also understand that contributions that do not follow this guide will take longer to review and thus typically be picked up with lower priority by the community.*

## Contribution Checklist

  - Make sure that the pull request corresponds to a [JIRA issue](https://issues.apache.org/jira/projects/FLINK/issues). Exceptions are made for typos in JavaDoc or documentation files, which need no JIRA issue.
  
  - Name the pull request in the form "[FLINK-XXXX] [component] Title of the pull request", where *FLINK-XXXX* should be replaced by the actual issue number. Skip *component* if you are unsure about which is the best component.
  Typo fixes that have no associated JIRA issue should be named following this pattern: `[hotfix] [docs] Fix typo in event time introduction` or `[hotfix] [javadocs] Expand JavaDoc for PuncuatedWatermarkGenerator`.

  - Fill out the template below to describe the changes contributed by the pull request. That will give reviewers the context they need to do the review.
  
  - Make sure that the change passes the automated tests, i.e., `mvn clean verify` passes. You can set up Azure Pipelines CI to do that following [this guide](https://cwiki.apache.org/confluence/display/FLINK/Azure+Pipelines#AzurePipelines-Tutorial:SettingupAzurePipelinesforaforkoftheFlinkrepository).

  - Each pull request should address only one issue, not mix up code from multiple issues.
  
  - Each commit in the pull request has a meaningful commit message (including the JIRA id)

  - Once all items of the checklist are addressed, remove the above text and this checklist, leaving only the filled out template below.


**(The sections below can be removed for hotfixes of typos)**
-->

## What is the purpose of the change

*This PR removes the limitation of 1 buffer in use per channel*


## Brief change log

  - *SingleInputGate#getBuffersInUseCount can return zero buffers if there are no buffers in channels*


## Verifying this change

This change added tests and can be verified as follows:

  - *Added new test to SingleInputGateTest*

## Does this pull request potentially affect one of the following parts:

  - Dependencies (does it add or upgrade a dependency): (yes / **no**)
  - The public API, i.e., is any changed class annotated with `@Public(Evolving)`: (yes / **no**)
  - The serializers: (yes / **no** / don't know)
  - The runtime per-record code paths (performance sensitive): (yes / **no** / don't know)
  - Anything that affects deployment or recovery: JobManager (and its components), Checkpointing, Kubernetes/Yarn, ZooKeeper: (yes / **no** / don't know)
  - The S3 file system connector: (yes / **no** / don't know)

## Documentation

  - Does this pull request introduce a new feature? (yes / **no**)
  - If yes, how is the feature documented? (not applicable / docs / JavaDocs / not documented)
