### PR TITLE
[history] Add support to do clean in history server

### DIFF
--- a/docs/layouts/shortcodes/generated/history_server_configuration.html
+++ b/docs/layouts/shortcodes/generated/history_server_configuration.html
@@ -33,6 +33,12 @@
             <td>The maximum number of jobs to retain in each archive directory defined by `historyserver.archive.fs.dir`. If set to `-1`(default), there is no limit to the number of archives. If set to `0` or less than `-1` HistoryServer will throw an <code class="highlighter-rouge">IllegalConfigurationException</code>. </td>
         </tr>
         <tr>
+            <td><h5>historyserver.archive.retained-time</h5></td>
+            <td style="word-wrap: break-word;">-1</td>
+            <td>Long</td>
+            <td>The maximum time of jobs to retain in each archive directory defined by `historyserver.archive.fs.dir`. If set to `-1`(default), there is no limit to the time of archives. If set to `0` or less than `-1` HistoryServer will throw an <code class="highlighter-rouge">IllegalConfigurationException</code>. </td>
+        </tr>
+        <tr>
             <td><h5>historyserver.web.address</h5></td>
             <td style="word-wrap: break-word;">(none)</td>
             <td>String</td>

--- a/flink-core/src/main/java/org/apache/flink/configuration/HistoryServerOptions.java
+++ b/flink-core/src/main/java/org/apache/flink/configuration/HistoryServerOptions.java
@@ -112,5 +112,22 @@ public class HistoryServerOptions {
                                             code("IllegalConfigurationException"))
                                     .build());
 
+    public static final ConfigOption<Long> HISTORY_SERVER_RETAINED_TIME =
+            key("historyserver.archive.retained-time")
+                    .longType()
+                    .defaultValue(-1L)
+                    .withDescription(
+                            Description.builder()
+                                    .text(
+                                            String.format(
+                                                    "The maximum time of jobs to retain in each archive directory defined by `%s`. ",
+                                                    HISTORY_SERVER_ARCHIVE_DIRS.key()))
+                                    .text(
+                                            "If set to `-1`(default), there is no limit to the time of archives. ")
+                                    .text(
+                                            "If set to `0` or less than `-1` HistoryServer will throw an %s. ",
+                                            code("IllegalConfigurationException"))
+                                    .build());
+
     private HistoryServerOptions() {}
 }

--- a/flink-runtime-web/src/main/java/org/apache/flink/runtime/webmonitor/history/HistoryServer.java
+++ b/flink-runtime-web/src/main/java/org/apache/flink/runtime/webmonitor/history/HistoryServer.java
@@ -239,13 +239,20 @@ public class HistoryServer {
                     "Cannot set %s to 0 or less than -1",
                     HistoryServerOptions.HISTORY_SERVER_RETAINED_JOBS.key());
         }
+        long maxRetainedTime = config.getLong(HistoryServerOptions.HISTORY_SERVER_RETAINED_TIME);
+        if (maxRetainedTime == 0 || maxRetainedTime < -1) {
+            throw new IllegalConfigurationException(
+                    "Cannot set %s to 0 or less than -1",
+                    HistoryServerOptions.HISTORY_SERVER_RETAINED_TIME.key());
+        }
         archiveFetcher =
                 new HistoryServerArchiveFetcher(
                         refreshDirs,
                         webDir,
                         jobArchiveEventListener,
                         cleanupExpiredArchives,
-                        maxHistorySize);
+                        maxHistorySize,
+                        maxRetainedTime);
 
         this.shutdownHook =
                 ShutdownHookUtil.addShutdownHook(


### PR DESCRIPTION
## What is the purpose of the change

* Enable to specify the retention time for history server jobs


## Brief change log

  - *Add a config named: historyserver.archive.retained-time and default value is -1, means no limit*
  - *In JovArchiveFetcherTask, periodicly check whether the jobArchive is beyound the max retained time, and if the answer is yes, then clean this jobArchive*


## Verifying this change

This change added tests and can be verified as follows:

  - *Added integration tests for end-to-end deployment with large payloads (100MB)*

## Does this pull request potentially affect one of the following parts:

  - Dependencies (does it add or upgrade a dependency): (no)
  - The public API, i.e., is any changed class annotated with `@Public(Evolving)`: (no)
  - The serializers: (no)
  - The runtime per-record code paths (performance sensitive): (no)
  - Anything that affects deployment or recovery: JobManager (and its components), Checkpointing, Kubernetes/Yarn, ZooKeeper: (no)
  - The S3 file system connector: (no)

## Documentation

  - Does this pull request introduce a new feature? (yes)
  - If yes, how is the feature documented? (docs)
