### PR TITLE
[hotfix][docs] Add Analytics GA4 implementation to be prepared for migration

### DIFF
--- a/docs/layouts/_default/baseof.html
+++ b/docs/layouts/_default/baseof.html
@@ -23,6 +23,15 @@ under the License.
   {{ hugo.Generator }}
   {{ partial "docs/html-head" . }}
   {{ partial "docs/inject/head" . }}
+    <!-- Global site tag (gtag.js) - Google Analytics GA4 -->
+    <script async src="https://www.googletagmanager.com/gtag/js?id=G-8ML5TM8Q0M"></script>
+    <script>
+      window.dataLayer = window.dataLayer || [];
+      function gtag(){dataLayer.push(arguments);}
+      gtag('js', new Date());
+
+      gtag('config', 'G-8ML5TM8Q0M');
+    </script>
 </head>
 
 <body dir={{ .Site.Language.LanguageDirection }}>
@@ -66,7 +75,7 @@ under the License.
 
   {{ partial "docs/inject/body" . }}
 
-  <!-- Google Analytics -->
+  <!-- Google Analytics UA -->
   <script>
     (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
     (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),

--- a/docs/layouts/_default/baseof.html
+++ b/docs/layouts/_default/baseof.html
@@ -83,6 +83,7 @@ under the License.
     })(window,document,'script','//www.google-analytics.com/analytics.js','ga');
 
     ga('create', 'UA-52545728-1', 'auto');
+    ga('set', 'anonymizeIp', true);
     ga('send', 'pageview');
   </script>
 </body>


### PR DESCRIPTION
Google has a new implementation to track website behaviour, called GA4. This will replace the existing UA implementations and is not compatible with the current version of tracking behaviour.

This PR implements the GA4 tracking next to the UA tracking, so that at a later stage the UA tracking can be removed.

See also https://github.com/apache/flink-web/pull/475 and https://support.google.com/analytics/answer/10089681?hl=en

Commit 7b874ea41cfe88a039144067fd74f6840eeeb38e makes sure that the old implementation anonymises IP addresses by default. The new implementation already does this by default. See https://support.google.com/analytics/answer/2763052?hl=en