### PR TITLE
[FLINK-24038] Add support for single leader election per JobManager process

### DIFF
--- a/docs/layouts/shortcodes/generated/expert_high_availability_section.html
+++ b/docs/layouts/shortcodes/generated/expert_high_availability_section.html
@@ -14,5 +14,11 @@
             <td>String</td>
             <td>The port (range) used by the Flink Master for its RPC connections in highly-available setups. In highly-available setups, this value is used instead of 'jobmanager.rpc.port'.A value of '0' means that a random free port is chosen. TaskManagers discover this port through the high-availability services (leader election), so a random port or a port range works without requiring any additional means of service discovery.</td>
         </tr>
+        <tr>
+            <td><h5>high-availability.use-old-ha-services</h5></td>
+            <td style="word-wrap: break-word;">false</td>
+            <td>Boolean</td>
+            <td>Use this option to disable the new HA service implementations for ZooKeeper and K8s. This is a safety hatch in case that the new ha services are buggy.</td>
+        </tr>
     </tbody>
 </table>

--- a/docs/layouts/shortcodes/generated/high_availability_configuration.html
+++ b/docs/layouts/shortcodes/generated/high_availability_configuration.html
@@ -33,6 +33,12 @@
             <td>File system path (URI) where Flink persists metadata in high-availability setups.</td>
         </tr>
         <tr>
+            <td><h5>high-availability.use-old-ha-services</h5></td>
+            <td style="word-wrap: break-word;">false</td>
+            <td>Boolean</td>
+            <td>Use this option to disable the new HA service implementations for ZooKeeper and K8s. This is a safety hatch in case that the new ha services are buggy.</td>
+        </tr>
+        <tr>
             <td><h5>high-availability.zookeeper.client.acl</h5></td>
             <td style="word-wrap: break-word;">"open"</td>
             <td>String</td>

--- a/flink-core/src/main/java/org/apache/flink/configuration/HighAvailabilityOptions.java
+++ b/flink-core/src/main/java/org/apache/flink/configuration/HighAvailabilityOptions.java
@@ -204,6 +204,25 @@ public class HighAvailabilityOptions {
                     .withDescription(
                             "The time before a JobManager after a fail over recovers the current jobs.");
 
+    /**
+     * Safety hatch to fallback to the old ha services implementations.
+     *
+     * <p>Ideally, we can remove this option together with the old implementations in the next
+     * release.
+     *
+     * @see <a href="https://issues.apache.org/jira/browse/FLINK-25806">FLINK-25806</a>
+     */
+    @Documentation.Section(Documentation.Sections.EXPERT_HIGH_AVAILABILITY)
+    public static final ConfigOption<Boolean> USE_OLD_HA_SERVICES =
+            key("high-availability.use-old-ha-services")
+                    .booleanType()
+                    .defaultValue(false)
+                    .withDescription(
+                            Description.builder()
+                                    .text(
+                                            "Use this option to disable the new HA service implementations for ZooKeeper and K8s. This is a safety hatch in case that the new ha services are buggy.")
+                                    .build());
+
     // ------------------------------------------------------------------------
 
     /** Not intended to be instantiated. */

--- a/flink-kubernetes/src/main/java/org/apache/flink/kubernetes/highavailability/KubernetesCheckpointRecoveryFactory.java
+++ b/flink-kubernetes/src/main/java/org/apache/flink/kubernetes/highavailability/KubernetesCheckpointRecoveryFactory.java
@@ -27,6 +27,8 @@ import org.apache.flink.runtime.checkpoint.CheckpointRecoveryFactory;
 import org.apache.flink.runtime.checkpoint.CompletedCheckpointStore;
 import org.apache.flink.runtime.state.SharedStateRegistryFactory;
 
+import javax.annotation.Nullable;
+
 import java.util.concurrent.Executor;
 import java.util.function.Function;
 
@@ -45,7 +47,9 @@ public class KubernetesCheckpointRecoveryFactory implements CheckpointRecoveryFa
 
     private final Configuration configuration;
 
-    private final String lockIdentity;
+    @Nullable private final String lockIdentity;
+
+    private final String clusterId;
 
     /**
      * Create a KubernetesCheckpointRecoveryFactory.
@@ -56,18 +60,20 @@ public class KubernetesCheckpointRecoveryFactory implements CheckpointRecoveryFa
      * @param function Function to get the ConfigMap name for checkpoint.
      * @param lockIdentity Lock identity of current HA service
      */
-    public KubernetesCheckpointRecoveryFactory(
+    private KubernetesCheckpointRecoveryFactory(
             FlinkKubeClient kubeClient,
             Configuration configuration,
             Executor executor,
             Function<JobID, String> function,
-            String lockIdentity) {
+            String clusterId,
+            @Nullable String lockIdentity) {
 
         this.kubeClient = checkNotNull(kubeClient);
         this.configuration = checkNotNull(configuration);
         this.executor = checkNotNull(executor);
         this.getConfigMapNameFunction = checkNotNull(function);
-        this.lockIdentity = checkNotNull(lockIdentity);
+        this.lockIdentity = lockIdentity;
+        this.clusterId = clusterId;
     }
 
     @Override
@@ -78,12 +84,14 @@ public class KubernetesCheckpointRecoveryFactory implements CheckpointRecoveryFa
             SharedStateRegistryFactory sharedStateRegistryFactory,
             Executor ioExecutor)
             throws Exception {
+        final String configMapName = getConfigMapNameFunction.apply(jobID);
+        KubernetesUtils.createConfigMapIfItDoesNotExist(kubeClient, configMapName, clusterId);
 
         return KubernetesUtils.createCompletedCheckpointStore(
                 configuration,
                 kubeClient,
                 executor,
-                getConfigMapNameFunction.apply(jobID),
+                configMapName,
                 lockIdentity,
                 maxNumberOfCheckpointsToRetain,
                 sharedStateRegistryFactory,
@@ -91,8 +99,31 @@ public class KubernetesCheckpointRecoveryFactory implements CheckpointRecoveryFa
     }
 
     @Override
-    public CheckpointIDCounter createCheckpointIDCounter(JobID jobID) {
-        return new KubernetesCheckpointIDCounter(
-                kubeClient, getConfigMapNameFunction.apply(jobID), lockIdentity);
+    public CheckpointIDCounter createCheckpointIDCounter(JobID jobID) throws Exception {
+        final String configMapName = getConfigMapNameFunction.apply(jobID);
+        KubernetesUtils.createConfigMapIfItDoesNotExist(kubeClient, configMapName, clusterId);
+
+        return new KubernetesCheckpointIDCounter(kubeClient, configMapName, lockIdentity);
+    }
+
+    public static KubernetesCheckpointRecoveryFactory withLeadershipValidation(
+            FlinkKubeClient kubeClient,
+            Configuration configuration,
+            Executor executor,
+            String clusterId,
+            Function<JobID, String> function,
+            String lockIdentity) {
+        return new KubernetesCheckpointRecoveryFactory(
+                kubeClient, configuration, executor, function, clusterId, lockIdentity);
+    }
+
+    public static KubernetesCheckpointRecoveryFactory withoutLeadershipValidation(
+            FlinkKubeClient kubeClient,
+            Configuration configuration,
+            Executor executor,
+            String clusterId,
+            Function<JobID, String> function) {
+        return new KubernetesCheckpointRecoveryFactory(
+                kubeClient, configuration, executor, function, clusterId, null);
     }
 }

--- a/flink-kubernetes/src/main/java/org/apache/flink/kubernetes/highavailability/KubernetesHaServices.java
+++ b/flink-kubernetes/src/main/java/org/apache/flink/kubernetes/highavailability/KubernetesHaServices.java
@@ -130,10 +130,11 @@ public class KubernetesHaServices extends AbstractHaServices {
 
     @Override
     public CheckpointRecoveryFactory createCheckpointRecoveryFactory() {
-        return new KubernetesCheckpointRecoveryFactory(
+        return KubernetesCheckpointRecoveryFactory.withLeadershipValidation(
                 kubeClient,
                 configuration,
                 ioExecutor,
+                clusterId,
                 this::getLeaderPathForJobManager,
                 lockIdentity);
     }

--- a/flink-kubernetes/src/main/java/org/apache/flink/kubernetes/highavailability/KubernetesHaServices.java
+++ b/flink-kubernetes/src/main/java/org/apache/flink/kubernetes/highavailability/KubernetesHaServices.java
@@ -61,7 +61,10 @@ import static org.apache.flink.util.Preconditions.checkNotNull;
  * k8s-ha-app1-00000000000000000000000000000000-jobmanager-leader
  *
  * <p>Note that underline("_") is not allowed in Kubernetes ConfigMap name.
+ *
+ * @deprecated in favour of {@link KubernetesMultipleComponentLeaderElectionHaServices}
  */
+@Deprecated
 public class KubernetesHaServices extends AbstractHaServices {
 
     private final String clusterId;

--- a/flink-kubernetes/src/main/java/org/apache/flink/kubernetes/highavailability/KubernetesLeaderElectionDriver.java
+++ b/flink-kubernetes/src/main/java/org/apache/flink/kubernetes/highavailability/KubernetesLeaderElectionDriver.java
@@ -192,7 +192,7 @@ public class KubernetesLeaderElectionDriver implements LeaderElectionDriver {
 
         @Override
         public void isLeader() {
-            leaderElectionEventHandler.onGrantLeadership();
+            leaderElectionEventHandler.onGrantLeadership(UUID.randomUUID());
         }
 
         @Override

--- a/flink-kubernetes/src/main/java/org/apache/flink/kubernetes/highavailability/KubernetesLeaderElectionDriver.java
+++ b/flink-kubernetes/src/main/java/org/apache/flink/kubernetes/highavailability/KubernetesLeaderElectionDriver.java
@@ -54,7 +54,10 @@ import static org.apache.flink.util.Preconditions.checkNotNull;
  * Kubernetes ConfigMap. Note that the contending lock and leader storage are using the same
  * ConfigMap. And every component(e.g. ResourceManager, Dispatcher, RestEndpoint, JobManager for
  * each job) will have a separate ConfigMap.
+ *
+ * @deprecated in favour of {@link KubernetesMultipleComponentLeaderElectionDriver}
  */
+@Deprecated
 public class KubernetesLeaderElectionDriver implements LeaderElectionDriver {
 
     private static final Logger LOG = LoggerFactory.getLogger(KubernetesLeaderElectionDriver.class);

--- a/flink-kubernetes/src/main/java/org/apache/flink/kubernetes/highavailability/KubernetesLeaderElectionDriverFactory.java
+++ b/flink-kubernetes/src/main/java/org/apache/flink/kubernetes/highavailability/KubernetesLeaderElectionDriverFactory.java
@@ -27,7 +27,11 @@ import org.apache.flink.runtime.rpc.FatalErrorHandler;
 
 import java.util.concurrent.ExecutorService;
 
-/** {@link LeaderElectionDriverFactory} implementation for Kubernetes. */
+/**
+ * {@link LeaderElectionDriverFactory} implementation for Kubernetes.
+ *
+ * @deprecated in favour of {@link KubernetesMultipleComponentLeaderElectionDriverFactory}
+ */
 public class KubernetesLeaderElectionDriverFactory implements LeaderElectionDriverFactory {
 
     private final FlinkKubeClient kubeClient;

--- a/flink-kubernetes/src/main/java/org/apache/flink/kubernetes/highavailability/KubernetesLeaderRetrievalDriver.java
+++ b/flink-kubernetes/src/main/java/org/apache/flink/kubernetes/highavailability/KubernetesLeaderRetrievalDriver.java
@@ -31,7 +31,7 @@ import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
 import java.util.List;
-import java.util.concurrent.ExecutorService;
+import java.util.concurrent.Executor;
 
 import static org.apache.flink.kubernetes.utils.KubernetesUtils.checkConfigMaps;
 import static org.apache.flink.kubernetes.utils.KubernetesUtils.getLeaderInformationFromConfigMap;
@@ -63,7 +63,7 @@ public class KubernetesLeaderRetrievalDriver implements LeaderRetrievalDriver {
     public KubernetesLeaderRetrievalDriver(
             FlinkKubeClient kubeClient,
             KubernetesConfigMapSharedWatcher configMapSharedWatcher,
-            ExecutorService watchExecutorService,
+            Executor watchExecutor,
             String configMapName,
             LeaderRetrievalEventHandler leaderRetrievalEventHandler,
             FatalErrorHandler fatalErrorHandler) {
@@ -75,10 +75,7 @@ public class KubernetesLeaderRetrievalDriver implements LeaderRetrievalDriver {
 
         kubernetesWatch =
                 checkNotNull(configMapSharedWatcher, "ConfigMap Shared Informer")
-                        .watch(
-                                configMapName,
-                                new ConfigMapCallbackHandlerImpl(),
-                                watchExecutorService);
+                        .watch(configMapName, new ConfigMapCallbackHandlerImpl(), watchExecutor);
 
         running = true;
     }

--- a/flink-kubernetes/src/main/java/org/apache/flink/kubernetes/highavailability/KubernetesLeaderRetrievalDriver.java
+++ b/flink-kubernetes/src/main/java/org/apache/flink/kubernetes/highavailability/KubernetesLeaderRetrievalDriver.java
@@ -22,6 +22,7 @@ import org.apache.flink.kubernetes.kubeclient.FlinkKubeClient;
 import org.apache.flink.kubernetes.kubeclient.KubernetesConfigMapSharedWatcher;
 import org.apache.flink.kubernetes.kubeclient.KubernetesSharedWatcher.Watch;
 import org.apache.flink.kubernetes.kubeclient.resources.KubernetesConfigMap;
+import org.apache.flink.runtime.leaderelection.LeaderInformation;
 import org.apache.flink.runtime.leaderretrieval.LeaderRetrievalDriver;
 import org.apache.flink.runtime.leaderretrieval.LeaderRetrievalEventHandler;
 import org.apache.flink.runtime.leaderretrieval.LeaderRetrievalException;
@@ -32,9 +33,9 @@ import org.slf4j.LoggerFactory;
 
 import java.util.List;
 import java.util.concurrent.Executor;
+import java.util.function.Function;
 
 import static org.apache.flink.kubernetes.utils.KubernetesUtils.checkConfigMaps;
-import static org.apache.flink.kubernetes.utils.KubernetesUtils.getLeaderInformationFromConfigMap;
 import static org.apache.flink.util.Preconditions.checkNotNull;
 
 /**
@@ -60,18 +61,22 @@ public class KubernetesLeaderRetrievalDriver implements LeaderRetrievalDriver {
 
     private final Watch kubernetesWatch;
 
+    private final Function<KubernetesConfigMap, LeaderInformation> leaderInformationExtractor;
+
     public KubernetesLeaderRetrievalDriver(
             FlinkKubeClient kubeClient,
             KubernetesConfigMapSharedWatcher configMapSharedWatcher,
             Executor watchExecutor,
             String configMapName,
             LeaderRetrievalEventHandler leaderRetrievalEventHandler,
+            Function<KubernetesConfigMap, LeaderInformation> leaderInformationExtractor,
             FatalErrorHandler fatalErrorHandler) {
         this.kubeClient = checkNotNull(kubeClient, "Kubernetes client");
         this.configMapName = checkNotNull(configMapName, "ConfigMap name");
         this.leaderRetrievalEventHandler =
                 checkNotNull(leaderRetrievalEventHandler, "LeaderRetrievalEventHandler");
         this.fatalErrorHandler = checkNotNull(fatalErrorHandler);
+        this.leaderInformationExtractor = leaderInformationExtractor;
 
         kubernetesWatch =
                 checkNotNull(configMapSharedWatcher, "ConfigMap Shared Informer")
@@ -106,7 +111,7 @@ public class KubernetesLeaderRetrievalDriver implements LeaderRetrievalDriver {
         public void onModified(List<KubernetesConfigMap> configMaps) {
             final KubernetesConfigMap configMap = checkConfigMaps(configMaps, configMapName);
             leaderRetrievalEventHandler.notifyLeaderAddress(
-                    getLeaderInformationFromConfigMap(configMap));
+                    leaderInformationExtractor.apply(configMap));
         }
 
         @Override

--- a/flink-kubernetes/src/main/java/org/apache/flink/kubernetes/highavailability/KubernetesLeaderRetrievalDriverFactory.java
+++ b/flink-kubernetes/src/main/java/org/apache/flink/kubernetes/highavailability/KubernetesLeaderRetrievalDriverFactory.java
@@ -27,7 +27,12 @@ import org.apache.flink.runtime.rpc.FatalErrorHandler;
 
 import java.util.concurrent.Executor;
 
-/** {@link LeaderRetrievalDriverFactory} implementation for Kubernetes. */
+/**
+ * {@link LeaderRetrievalDriverFactory} implementation for Kubernetes.
+ *
+ * @deprecated in favour of {@link KubernetesMultipleComponentLeaderRetrievalDriverFactory}
+ */
+@Deprecated
 public class KubernetesLeaderRetrievalDriverFactory implements LeaderRetrievalDriverFactory {
 
     private final FlinkKubeClient kubeClient;

--- a/flink-kubernetes/src/main/java/org/apache/flink/kubernetes/highavailability/KubernetesLeaderRetrievalDriverFactory.java
+++ b/flink-kubernetes/src/main/java/org/apache/flink/kubernetes/highavailability/KubernetesLeaderRetrievalDriverFactory.java
@@ -24,7 +24,7 @@ import org.apache.flink.runtime.leaderretrieval.LeaderRetrievalDriverFactory;
 import org.apache.flink.runtime.leaderretrieval.LeaderRetrievalEventHandler;
 import org.apache.flink.runtime.rpc.FatalErrorHandler;
 
-import java.util.concurrent.ExecutorService;
+import java.util.concurrent.Executor;
 
 /** {@link LeaderRetrievalDriverFactory} implementation for Kubernetes. */
 public class KubernetesLeaderRetrievalDriverFactory implements LeaderRetrievalDriverFactory {
@@ -32,18 +32,18 @@ public class KubernetesLeaderRetrievalDriverFactory implements LeaderRetrievalDr
     private final FlinkKubeClient kubeClient;
 
     private final KubernetesConfigMapSharedWatcher configMapSharedWatcher;
-    private final ExecutorService watchExecutorService;
+    private final Executor watchExecutor;
 
     private final String configMapName;
 
     public KubernetesLeaderRetrievalDriverFactory(
             FlinkKubeClient kubeClient,
             KubernetesConfigMapSharedWatcher configMapSharedWatcher,
-            ExecutorService watchExecutorService,
+            Executor watchExecutor,
             String configMapName) {
         this.kubeClient = kubeClient;
         this.configMapSharedWatcher = configMapSharedWatcher;
-        this.watchExecutorService = watchExecutorService;
+        this.watchExecutor = watchExecutor;
         this.configMapName = configMapName;
     }
 
@@ -53,7 +53,7 @@ public class KubernetesLeaderRetrievalDriverFactory implements LeaderRetrievalDr
         return new KubernetesLeaderRetrievalDriver(
                 kubeClient,
                 configMapSharedWatcher,
-                watchExecutorService,
+                watchExecutor,
                 configMapName,
                 leaderEventHandler,
                 fatalErrorHandler);

--- a/flink-kubernetes/src/main/java/org/apache/flink/kubernetes/highavailability/KubernetesMultipleComponentLeaderElectionDriver.java
+++ b/flink-kubernetes/src/main/java/org/apache/flink/kubernetes/highavailability/KubernetesMultipleComponentLeaderElectionDriver.java
@@ -1,0 +1,272 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.flink.kubernetes.highavailability;
+
+import org.apache.flink.kubernetes.configuration.KubernetesLeaderElectionConfiguration;
+import org.apache.flink.kubernetes.kubeclient.FlinkKubeClient;
+import org.apache.flink.kubernetes.kubeclient.KubernetesConfigMapSharedWatcher;
+import org.apache.flink.kubernetes.kubeclient.KubernetesSharedWatcher;
+import org.apache.flink.kubernetes.kubeclient.resources.KubernetesConfigMap;
+import org.apache.flink.kubernetes.kubeclient.resources.KubernetesException;
+import org.apache.flink.kubernetes.kubeclient.resources.KubernetesLeaderElector;
+import org.apache.flink.kubernetes.utils.KubernetesUtils;
+import org.apache.flink.runtime.leaderelection.LeaderElectionException;
+import org.apache.flink.runtime.leaderelection.LeaderInformation;
+import org.apache.flink.runtime.leaderelection.LeaderInformationWithComponentId;
+import org.apache.flink.runtime.leaderelection.MultipleComponentLeaderElectionDriver;
+import org.apache.flink.runtime.rpc.FatalErrorHandler;
+import org.apache.flink.util.Preconditions;
+
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import java.util.ArrayList;
+import java.util.Collection;
+import java.util.List;
+import java.util.Map;
+import java.util.Optional;
+import java.util.concurrent.Executor;
+import java.util.concurrent.atomic.AtomicBoolean;
+import java.util.function.Function;
+
+import static org.apache.flink.kubernetes.utils.Constants.LABEL_CONFIGMAP_TYPE_HIGH_AVAILABILITY;
+import static org.apache.flink.kubernetes.utils.KubernetesUtils.checkConfigMaps;
+
+/** {@link MultipleComponentLeaderElectionDriver} for Kubernetes. */
+public class KubernetesMultipleComponentLeaderElectionDriver
+        implements MultipleComponentLeaderElectionDriver {
+
+    private static final Logger LOG =
+            LoggerFactory.getLogger(KubernetesMultipleComponentLeaderElectionDriver.class);
+
+    private final FlinkKubeClient kubeClient;
+
+    private final String configMapName;
+
+    private final String lockIdentity;
+
+    private final MultipleComponentLeaderElectionDriver.Listener leaderElectionListener;
+
+    private final KubernetesLeaderElector leaderElector;
+
+    // Labels will be used to clean up the ha related ConfigMaps.
+    private final Map<String, String> configMapLabels;
+
+    private final FatalErrorHandler fatalErrorHandler;
+
+    private final KubernetesSharedWatcher.Watch kubernetesWatch;
+
+    private final AtomicBoolean running = new AtomicBoolean(true);
+
+    public KubernetesMultipleComponentLeaderElectionDriver(
+            KubernetesLeaderElectionConfiguration leaderElectionConfiguration,
+            FlinkKubeClient kubeClient,
+            Listener leaderElectionListener,
+            KubernetesConfigMapSharedWatcher configMapSharedWatcher,
+            Executor watchExecutor,
+            FatalErrorHandler fatalErrorHandler) {
+        Preconditions.checkNotNull(leaderElectionConfiguration);
+        this.kubeClient = Preconditions.checkNotNull(kubeClient);
+        this.leaderElectionListener = Preconditions.checkNotNull(leaderElectionListener);
+        this.fatalErrorHandler = Preconditions.checkNotNull(fatalErrorHandler);
+        Preconditions.checkNotNull(configMapSharedWatcher);
+        Preconditions.checkNotNull(watchExecutor);
+
+        this.configMapName = leaderElectionConfiguration.getConfigMapName();
+        this.lockIdentity = leaderElectionConfiguration.getLockIdentity();
+
+        this.leaderElector =
+                kubeClient.createLeaderElector(
+                        leaderElectionConfiguration, new LeaderCallbackHandlerImpl());
+
+        this.configMapLabels =
+                KubernetesUtils.getConfigMapLabels(
+                        leaderElectionConfiguration.getClusterId(),
+                        LABEL_CONFIGMAP_TYPE_HIGH_AVAILABILITY);
+
+        kubernetesWatch =
+                configMapSharedWatcher.watch(
+                        configMapName, new ConfigMapCallbackHandlerImpl(), watchExecutor);
+
+        leaderElector.run();
+    }
+
+    @Override
+    public void close() throws Exception {
+        if (running.compareAndSet(true, false)) {
+            LOG.info("Closing {}.", this);
+
+            leaderElector.stop();
+            kubernetesWatch.close();
+        }
+    }
+
+    @Override
+    public boolean hasLeadership() {
+        Preconditions.checkState(running.get());
+        final Optional<KubernetesConfigMap> optionalConfigMap =
+                kubeClient.getConfigMap(configMapName);
+
+        if (optionalConfigMap.isPresent()) {
+            return KubernetesLeaderElector.hasLeadership(optionalConfigMap.get(), lockIdentity);
+        } else {
+            fatalErrorHandler.onFatalError(
+                    new KubernetesException(
+                            String.format(
+                                    "ConfigMap %s does not exist. This indicates that somebody has interfered with Flink's operation.",
+                                    configMapName)));
+            return false;
+        }
+    }
+
+    @Override
+    public void publishLeaderInformation(String componentId, LeaderInformation leaderInformation)
+            throws Exception {
+        Preconditions.checkState(running.get());
+
+        kubeClient
+                .checkAndUpdateConfigMap(
+                        configMapName,
+                        updateConfigMapWithLeaderInformation(componentId, leaderInformation))
+                .get();
+
+        LOG.debug(
+                "Successfully wrote leader information {} for leader {} into the config map {}.",
+                leaderInformation,
+                componentId,
+                configMapName);
+    }
+
+    @Override
+    public void deleteLeaderInformation(String componentId) throws Exception {
+        publishLeaderInformation(componentId, LeaderInformation.empty());
+    }
+
+    private Function<KubernetesConfigMap, Optional<KubernetesConfigMap>>
+            updateConfigMapWithLeaderInformation(
+                    String leaderName, LeaderInformation leaderInformation) {
+        final String configMapDataKey = KubernetesUtils.createSingleLeaderKey(leaderName);
+
+        return kubernetesConfigMap -> {
+            if (KubernetesLeaderElector.hasLeadership(kubernetesConfigMap, lockIdentity)) {
+                final Map<String, String> data = kubernetesConfigMap.getData();
+
+                if (leaderInformation.isEmpty()) {
+                    data.remove(configMapDataKey);
+                } else {
+                    data.put(
+                            configMapDataKey,
+                            KubernetesUtils.encodeLeaderInformation(leaderInformation));
+                }
+
+                kubernetesConfigMap.getLabels().putAll(configMapLabels);
+                return Optional.of(kubernetesConfigMap);
+            }
+
+            return Optional.empty();
+        };
+    }
+
+    private static Collection<LeaderInformationWithComponentId> extractLeaderInformation(
+            KubernetesConfigMap configMap) {
+        final Map<String, String> data = configMap.getData();
+
+        final Collection<LeaderInformationWithComponentId> leaderInformationWithLeaderNames =
+                new ArrayList<>();
+
+        for (Map.Entry<String, String> keyValuePair : data.entrySet()) {
+            final String key = keyValuePair.getKey();
+            if (KubernetesUtils.isSingleLeaderKey(key)) {
+                final String leaderName = KubernetesUtils.extractLeaderName(key);
+                final LeaderInformation leaderInformation =
+                        KubernetesUtils.parseLeaderInformationSafely(keyValuePair.getValue())
+                                .orElse(LeaderInformation.empty());
+                leaderInformationWithLeaderNames.add(
+                        LeaderInformationWithComponentId.create(leaderName, leaderInformation));
+            }
+        }
+
+        return leaderInformationWithLeaderNames;
+    }
+
+    private class LeaderCallbackHandlerImpl extends KubernetesLeaderElector.LeaderCallbackHandler {
+        @Override
+        public void isLeader() {
+            leaderElectionListener.isLeader();
+        }
+
+        @Override
+        public void notLeader() {
+            leaderElectionListener.notLeader();
+            leaderElector.run();
+        }
+    }
+
+    private class ConfigMapCallbackHandlerImpl
+            implements FlinkKubeClient.WatchCallbackHandler<KubernetesConfigMap> {
+        @Override
+        public void onAdded(List<KubernetesConfigMap> resources) {
+            // nothing to do
+        }
+
+        @Override
+        public void onModified(List<KubernetesConfigMap> configMaps) {
+            final KubernetesConfigMap configMap = checkConfigMaps(configMaps, configMapName);
+
+            if (KubernetesLeaderElector.hasLeadership(configMap, lockIdentity)) {
+                Collection<LeaderInformationWithComponentId> leaderInformationWithLeaderNames =
+                        extractLeaderInformation(configMap);
+
+                leaderElectionListener.notifyAllKnownLeaderInformation(
+                        leaderInformationWithLeaderNames);
+            }
+        }
+
+        @Override
+        public void onDeleted(List<KubernetesConfigMap> configMaps) {
+            final KubernetesConfigMap configMap = checkConfigMaps(configMaps, configMapName);
+            if (KubernetesLeaderElector.hasLeadership(configMap, lockIdentity)) {
+                fatalErrorHandler.onFatalError(
+                        new LeaderElectionException(
+                                String.format(
+                                        "ConfigMap %s has been deleted externally.",
+                                        configMapName)));
+            }
+        }
+
+        @Override
+        public void onError(List<KubernetesConfigMap> configMaps) {
+            final KubernetesConfigMap configMap = checkConfigMaps(configMaps, configMapName);
+            if (KubernetesLeaderElector.hasLeadership(configMap, lockIdentity)) {
+                fatalErrorHandler.onFatalError(
+                        new LeaderElectionException(
+                                String.format(
+                                        "Error while watching the ConfigMap %s.", configMapName)));
+            }
+        }
+
+        @Override
+        public void handleError(Throwable throwable) {
+            fatalErrorHandler.onFatalError(
+                    new LeaderElectionException(
+                            String.format("Error while watching the ConfigMap %s.", configMapName),
+                            throwable));
+        }
+    }
+}

--- a/flink-kubernetes/src/main/java/org/apache/flink/kubernetes/highavailability/KubernetesMultipleComponentLeaderElectionDriverFactory.java
+++ b/flink-kubernetes/src/main/java/org/apache/flink/kubernetes/highavailability/KubernetesMultipleComponentLeaderElectionDriverFactory.java
@@ -1,0 +1,70 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.flink.kubernetes.highavailability;
+
+import org.apache.flink.kubernetes.configuration.KubernetesLeaderElectionConfiguration;
+import org.apache.flink.kubernetes.kubeclient.FlinkKubeClient;
+import org.apache.flink.kubernetes.kubeclient.KubernetesConfigMapSharedWatcher;
+import org.apache.flink.runtime.leaderelection.MultipleComponentLeaderElectionDriver;
+import org.apache.flink.runtime.leaderelection.MultipleComponentLeaderElectionDriverFactory;
+import org.apache.flink.runtime.rpc.FatalErrorHandler;
+import org.apache.flink.util.Preconditions;
+
+import java.util.concurrent.Executor;
+
+/** Factory that instantiates a {@link KubernetesMultipleComponentLeaderElectionDriver}. */
+public class KubernetesMultipleComponentLeaderElectionDriverFactory
+        implements MultipleComponentLeaderElectionDriverFactory {
+    private final FlinkKubeClient kubeClient;
+
+    private final KubernetesLeaderElectionConfiguration kubernetesLeaderElectionConfiguration;
+
+    private final KubernetesConfigMapSharedWatcher configMapSharedWatcher;
+
+    private final Executor watchExecutor;
+
+    private final FatalErrorHandler fatalErrorHandler;
+
+    public KubernetesMultipleComponentLeaderElectionDriverFactory(
+            FlinkKubeClient kubeClient,
+            KubernetesLeaderElectionConfiguration kubernetesLeaderElectionConfiguration,
+            KubernetesConfigMapSharedWatcher configMapSharedWatcher,
+            Executor watchExecutor,
+            FatalErrorHandler fatalErrorHandler) {
+        this.kubeClient = Preconditions.checkNotNull(kubeClient);
+        this.kubernetesLeaderElectionConfiguration =
+                Preconditions.checkNotNull(kubernetesLeaderElectionConfiguration);
+        this.configMapSharedWatcher = Preconditions.checkNotNull(configMapSharedWatcher);
+        this.watchExecutor = Preconditions.checkNotNull(watchExecutor);
+        this.fatalErrorHandler = Preconditions.checkNotNull(fatalErrorHandler);
+    }
+
+    @Override
+    public KubernetesMultipleComponentLeaderElectionDriver create(
+            MultipleComponentLeaderElectionDriver.Listener leaderElectionListener)
+            throws Exception {
+        return new KubernetesMultipleComponentLeaderElectionDriver(
+                kubernetesLeaderElectionConfiguration,
+                kubeClient,
+                leaderElectionListener,
+                configMapSharedWatcher,
+                watchExecutor,
+                fatalErrorHandler);
+    }
+}

--- a/flink-kubernetes/src/main/java/org/apache/flink/kubernetes/highavailability/KubernetesMultipleComponentLeaderElectionHaServices.java
+++ b/flink-kubernetes/src/main/java/org/apache/flink/kubernetes/highavailability/KubernetesMultipleComponentLeaderElectionHaServices.java
@@ -149,8 +149,8 @@ public class KubernetesMultipleComponentLeaderElectionHaServices extends Abstrac
 
     @Override
     protected CheckpointRecoveryFactory createCheckpointRecoveryFactory() {
-        return new KubernetesCheckpointRecoveryFactory(
-                kubeClient, configuration, ioExecutor, this::getJobSpecificConfigMap, lockIdentity);
+        return KubernetesCheckpointRecoveryFactory.withoutLeadershipValidation(
+                kubeClient, configuration, ioExecutor, clusterId, this::getJobSpecificConfigMap);
     }
 
     private String getJobSpecificConfigMap(JobID jobID) {

--- a/flink-kubernetes/src/main/java/org/apache/flink/kubernetes/highavailability/KubernetesMultipleComponentLeaderElectionHaServices.java
+++ b/flink-kubernetes/src/main/java/org/apache/flink/kubernetes/highavailability/KubernetesMultipleComponentLeaderElectionHaServices.java
@@ -1,0 +1,252 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.flink.kubernetes.highavailability;
+
+import org.apache.flink.api.common.JobID;
+import org.apache.flink.configuration.Configuration;
+import org.apache.flink.kubernetes.configuration.KubernetesConfigOptions;
+import org.apache.flink.kubernetes.configuration.KubernetesLeaderElectionConfiguration;
+import org.apache.flink.kubernetes.kubeclient.FlinkKubeClient;
+import org.apache.flink.kubernetes.kubeclient.KubernetesConfigMapSharedWatcher;
+import org.apache.flink.kubernetes.utils.KubernetesUtils;
+import org.apache.flink.runtime.blob.BlobStoreService;
+import org.apache.flink.runtime.checkpoint.CheckpointRecoveryFactory;
+import org.apache.flink.runtime.highavailability.AbstractHaServices;
+import org.apache.flink.runtime.highavailability.RunningJobsRegistry;
+import org.apache.flink.runtime.jobmanager.JobGraphStore;
+import org.apache.flink.runtime.leaderelection.DefaultLeaderElectionService;
+import org.apache.flink.runtime.leaderelection.DefaultMultipleComponentLeaderElectionService;
+import org.apache.flink.runtime.leaderelection.LeaderElectionService;
+import org.apache.flink.runtime.leaderelection.MultipleComponentLeaderElectionService;
+import org.apache.flink.runtime.leaderretrieval.DefaultLeaderRetrievalService;
+import org.apache.flink.runtime.leaderretrieval.LeaderRetrievalService;
+import org.apache.flink.runtime.rpc.FatalErrorHandler;
+import org.apache.flink.util.ExceptionUtils;
+import org.apache.flink.util.ExecutorUtils;
+import org.apache.flink.util.FlinkRuntimeException;
+import org.apache.flink.util.concurrent.ExecutorThreadFactory;
+
+import javax.annotation.Nullable;
+import javax.annotation.concurrent.GuardedBy;
+
+import java.util.UUID;
+import java.util.concurrent.Executor;
+import java.util.concurrent.ExecutorService;
+import java.util.concurrent.Executors;
+import java.util.concurrent.TimeUnit;
+
+import static org.apache.flink.kubernetes.utils.Constants.LABEL_CONFIGMAP_TYPE_HIGH_AVAILABILITY;
+import static org.apache.flink.kubernetes.utils.Constants.NAME_SEPARATOR;
+import static org.apache.flink.util.Preconditions.checkNotNull;
+
+/** Kubernetes HA services that use a single leader election service per JobManager. */
+public class KubernetesMultipleComponentLeaderElectionHaServices extends AbstractHaServices {
+
+    private final Object lock = new Object();
+
+    private final String clusterId;
+
+    private final FlinkKubeClient kubeClient;
+
+    private final KubernetesConfigMapSharedWatcher configMapSharedWatcher;
+    private final ExecutorService watchExecutorService;
+
+    private final String lockIdentity;
+
+    private final FatalErrorHandler fatalErrorHandler;
+
+    @Nullable
+    @GuardedBy("lock")
+    private DefaultMultipleComponentLeaderElectionService multipleComponentLeaderElectionService =
+            null;
+
+    KubernetesMultipleComponentLeaderElectionHaServices(
+            FlinkKubeClient kubeClient,
+            Executor executor,
+            Configuration config,
+            BlobStoreService blobStoreService,
+            FatalErrorHandler fatalErrorHandler) {
+
+        super(config, executor, blobStoreService);
+        this.kubeClient = checkNotNull(kubeClient);
+        this.clusterId = checkNotNull(config.get(KubernetesConfigOptions.CLUSTER_ID));
+        this.fatalErrorHandler = checkNotNull(fatalErrorHandler);
+
+        this.configMapSharedWatcher =
+                this.kubeClient.createConfigMapSharedWatcher(
+                        KubernetesUtils.getConfigMapLabels(
+                                clusterId, LABEL_CONFIGMAP_TYPE_HIGH_AVAILABILITY));
+        this.watchExecutorService =
+                Executors.newCachedThreadPool(
+                        new ExecutorThreadFactory("config-map-watch-handler"));
+
+        lockIdentity = UUID.randomUUID().toString();
+    }
+
+    @Override
+    protected LeaderElectionService createLeaderElectionService(String leaderName) {
+        final MultipleComponentLeaderElectionService multipleComponentLeaderElectionService =
+                getOrInitializeSingleLeaderElectionService();
+
+        return new DefaultLeaderElectionService(
+                multipleComponentLeaderElectionService.createDriverFactory(leaderName));
+    }
+
+    private DefaultMultipleComponentLeaderElectionService
+            getOrInitializeSingleLeaderElectionService() {
+        synchronized (lock) {
+            if (multipleComponentLeaderElectionService == null) {
+                try {
+
+                    final KubernetesLeaderElectionConfiguration leaderElectionConfiguration =
+                            new KubernetesLeaderElectionConfiguration(
+                                    getClusterConfigMap(), lockIdentity, configuration);
+                    multipleComponentLeaderElectionService =
+                            new DefaultMultipleComponentLeaderElectionService(
+                                    fatalErrorHandler,
+                                    new KubernetesMultipleComponentLeaderElectionDriverFactory(
+                                            kubeClient,
+                                            leaderElectionConfiguration,
+                                            configMapSharedWatcher,
+                                            watchExecutorService,
+                                            fatalErrorHandler));
+                } catch (Exception e) {
+                    throw new FlinkRuntimeException(
+                            "Could not initialize the default single leader election service.", e);
+                }
+            }
+
+            return multipleComponentLeaderElectionService;
+        }
+    }
+
+    @Override
+    protected LeaderRetrievalService createLeaderRetrievalService(String componentId) {
+        return new DefaultLeaderRetrievalService(
+                new KubernetesMultipleComponentLeaderRetrievalDriverFactory(
+                        kubeClient,
+                        configMapSharedWatcher,
+                        watchExecutorService,
+                        getClusterConfigMap(),
+                        componentId));
+    }
+
+    @Override
+    protected CheckpointRecoveryFactory createCheckpointRecoveryFactory() {
+        return new KubernetesCheckpointRecoveryFactory(
+                kubeClient, configuration, ioExecutor, this::getJobSpecificConfigMap, lockIdentity);
+    }
+
+    private String getJobSpecificConfigMap(JobID jobID) {
+        return clusterId + NAME_SEPARATOR + jobID.toString() + NAME_SEPARATOR + "config-map";
+    }
+
+    @Override
+    protected JobGraphStore createJobGraphStore() throws Exception {
+        return KubernetesUtils.createJobGraphStore(
+                configuration, kubeClient, getClusterConfigMap(), lockIdentity);
+    }
+
+    private String getClusterConfigMap() {
+        return clusterId + NAME_SEPARATOR + "cluster-config-map";
+    }
+
+    @Override
+    protected RunningJobsRegistry createRunningJobsRegistry() {
+        return new KubernetesRunningJobsRegistry(kubeClient, getClusterConfigMap(), lockIdentity);
+    }
+
+    @Override
+    public void internalClose() throws Exception {
+        Exception exception = null;
+        try {
+            closeK8sServices();
+        } catch (Exception e) {
+            exception = e;
+        }
+
+        kubeClient.close();
+        ExecutorUtils.gracefulShutdown(5, TimeUnit.SECONDS, this.watchExecutorService);
+
+        ExceptionUtils.tryRethrowException(exception);
+    }
+
+    private void closeK8sServices() throws Exception {
+        Exception exception = null;
+        synchronized (lock) {
+            if (multipleComponentLeaderElectionService != null) {
+                try {
+                    multipleComponentLeaderElectionService.close();
+                } catch (Exception e) {
+                    exception = e;
+                }
+                multipleComponentLeaderElectionService = null;
+            }
+        }
+
+        configMapSharedWatcher.close();
+
+        ExceptionUtils.tryRethrowException(exception);
+    }
+
+    @Override
+    public void internalCleanup() throws Exception {
+        Exception exception = null;
+        // in order to clean up, we first need to stop the services that rely on the config maps
+        try {
+            closeK8sServices();
+        } catch (Exception e) {
+            exception = e;
+        }
+
+        kubeClient
+                .deleteConfigMapsByLabels(
+                        KubernetesUtils.getConfigMapLabels(
+                                clusterId, LABEL_CONFIGMAP_TYPE_HIGH_AVAILABILITY))
+                .get();
+
+        ExceptionUtils.tryRethrowException(exception);
+    }
+
+    @Override
+    public void internalCleanupJobData(JobID jobID) throws Exception {
+        kubeClient.deleteConfigMap(getJobSpecificConfigMap(jobID)).get();
+        // need to delete job specific leader address from leader config map
+    }
+
+    @Override
+    protected String getLeaderPathForResourceManager() {
+        return "resourcemanager";
+    }
+
+    @Override
+    protected String getLeaderPathForDispatcher() {
+        return "dispatcher";
+    }
+
+    @Override
+    protected String getLeaderPathForJobManager(JobID jobID) {
+        return jobID.toString();
+    }
+
+    @Override
+    protected String getLeaderPathForRestServer() {
+        return "restserver";
+    }
+}

--- a/flink-kubernetes/src/main/java/org/apache/flink/kubernetes/highavailability/KubernetesMultipleComponentLeaderElectionHaServicesFactory.java
+++ b/flink-kubernetes/src/main/java/org/apache/flink/kubernetes/highavailability/KubernetesMultipleComponentLeaderElectionHaServicesFactory.java
@@ -1,0 +1,46 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.flink.kubernetes.highavailability;
+
+import org.apache.flink.configuration.Configuration;
+import org.apache.flink.kubernetes.kubeclient.FlinkKubeClientFactory;
+import org.apache.flink.runtime.blob.BlobUtils;
+import org.apache.flink.runtime.highavailability.HighAvailabilityServices;
+import org.apache.flink.runtime.highavailability.HighAvailabilityServicesFactory;
+import org.apache.flink.util.FatalExitExceptionHandler;
+
+import java.util.concurrent.Executor;
+
+/** Factory for {@link KubernetesMultipleComponentLeaderElectionHaServices}. */
+public class KubernetesMultipleComponentLeaderElectionHaServicesFactory
+        implements HighAvailabilityServicesFactory {
+    @Override
+    public HighAvailabilityServices createHAServices(Configuration configuration, Executor executor)
+            throws Exception {
+        return new KubernetesMultipleComponentLeaderElectionHaServices(
+                FlinkKubeClientFactory.getInstance()
+                        .fromConfiguration(configuration, "kubernetes-ha-services"),
+                executor,
+                configuration,
+                BlobUtils.createBlobStoreFromConfig(configuration),
+                error ->
+                        FatalExitExceptionHandler.INSTANCE.uncaughtException(
+                                Thread.currentThread(), error));
+    }
+}

--- a/flink-kubernetes/src/main/java/org/apache/flink/kubernetes/highavailability/KubernetesMultipleComponentLeaderRetrievalDriverFactory.java
+++ b/flink-kubernetes/src/main/java/org/apache/flink/kubernetes/highavailability/KubernetesMultipleComponentLeaderRetrievalDriverFactory.java
@@ -7,7 +7,7 @@
  * "License"); you may not use this file except in compliance
  * with the License.  You may obtain a copy of the License at
  *
- *     http://www.apache.org/licenses/LICENSE-2.0
+ *    http://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,
@@ -20,36 +20,50 @@ package org.apache.flink.kubernetes.highavailability;
 
 import org.apache.flink.kubernetes.kubeclient.FlinkKubeClient;
 import org.apache.flink.kubernetes.kubeclient.KubernetesConfigMapSharedWatcher;
+import org.apache.flink.kubernetes.kubeclient.resources.KubernetesConfigMap;
 import org.apache.flink.kubernetes.utils.KubernetesUtils;
+import org.apache.flink.runtime.leaderelection.LeaderInformation;
+import org.apache.flink.runtime.leaderretrieval.LeaderRetrievalDriver;
 import org.apache.flink.runtime.leaderretrieval.LeaderRetrievalDriverFactory;
 import org.apache.flink.runtime.leaderretrieval.LeaderRetrievalEventHandler;
 import org.apache.flink.runtime.rpc.FatalErrorHandler;
+import org.apache.flink.util.Preconditions;
 
+import java.util.Map;
 import java.util.concurrent.Executor;
 
-/** {@link LeaderRetrievalDriverFactory} implementation for Kubernetes. */
-public class KubernetesLeaderRetrievalDriverFactory implements LeaderRetrievalDriverFactory {
+/**
+ * Factory that instantiates a {@link KubernetesLeaderRetrievalDriver} in single leader election
+ * mode.
+ */
+public class KubernetesMultipleComponentLeaderRetrievalDriverFactory
+        implements LeaderRetrievalDriverFactory {
 
     private final FlinkKubeClient kubeClient;
 
     private final KubernetesConfigMapSharedWatcher configMapSharedWatcher;
+
     private final Executor watchExecutor;
 
     private final String configMapName;
 
-    public KubernetesLeaderRetrievalDriverFactory(
+    private final String componentId;
+
+    public KubernetesMultipleComponentLeaderRetrievalDriverFactory(
             FlinkKubeClient kubeClient,
             KubernetesConfigMapSharedWatcher configMapSharedWatcher,
             Executor watchExecutor,
-            String configMapName) {
-        this.kubeClient = kubeClient;
-        this.configMapSharedWatcher = configMapSharedWatcher;
-        this.watchExecutor = watchExecutor;
-        this.configMapName = configMapName;
+            String configMapName,
+            String componentId) {
+        this.kubeClient = Preconditions.checkNotNull(kubeClient);
+        this.configMapSharedWatcher = Preconditions.checkNotNull(configMapSharedWatcher);
+        this.watchExecutor = Preconditions.checkNotNull(watchExecutor);
+        this.configMapName = Preconditions.checkNotNull(configMapName);
+        this.componentId = Preconditions.checkNotNull(componentId);
     }
 
     @Override
-    public KubernetesLeaderRetrievalDriver createLeaderRetrievalDriver(
+    public LeaderRetrievalDriver createLeaderRetrievalDriver(
             LeaderRetrievalEventHandler leaderEventHandler, FatalErrorHandler fatalErrorHandler) {
         return new KubernetesLeaderRetrievalDriver(
                 kubeClient,
@@ -57,7 +71,20 @@ public class KubernetesLeaderRetrievalDriverFactory implements LeaderRetrievalDr
                 watchExecutor,
                 configMapName,
                 leaderEventHandler,
-                KubernetesUtils::getLeaderInformationFromConfigMap,
+                this::extractLeaderInformation,
                 fatalErrorHandler);
+    }
+
+    public LeaderInformation extractLeaderInformation(KubernetesConfigMap configMap) {
+        final String configDataLeaderKey = KubernetesUtils.createSingleLeaderKey(componentId);
+
+        final Map<String, String> data = configMap.getData();
+
+        if (data.containsKey(configDataLeaderKey)) {
+            return KubernetesUtils.parseLeaderInformationSafely(data.get(configDataLeaderKey))
+                    .orElse(LeaderInformation.empty());
+        } else {
+            return LeaderInformation.empty();
+        }
     }
 }

--- a/flink-kubernetes/src/main/java/org/apache/flink/kubernetes/kubeclient/KubernetesSharedWatcher.java
+++ b/flink-kubernetes/src/main/java/org/apache/flink/kubernetes/kubeclient/KubernetesSharedWatcher.java
@@ -22,7 +22,7 @@ import org.apache.flink.kubernetes.kubeclient.FlinkKubeClient.WatchCallbackHandl
 
 import javax.annotation.Nullable;
 
-import java.util.concurrent.ExecutorService;
+import java.util.concurrent.Executor;
 
 /** The interface for the Kubernetes shared watcher. */
 public interface KubernetesSharedWatcher<T> extends AutoCloseable {
@@ -36,13 +36,10 @@ public interface KubernetesSharedWatcher<T> extends AutoCloseable {
      *
      * @param name name to filter the resource to watch
      * @param callbackHandler callbackHandler which reacts to resource events
-     * @param executorService to run callback
+     * @param executor to run callback
      * @return Return a watch for the Kubernetes resource. It needs to be closed after use.
      */
-    Watch watch(
-            String name,
-            WatchCallbackHandler<T> callbackHandler,
-            @Nullable ExecutorService executorService);
+    Watch watch(String name, WatchCallbackHandler<T> callbackHandler, @Nullable Executor executor);
 
     /** The Watch returned after creating watching, which can be used to close the watching. */
     interface Watch extends AutoCloseable {

--- a/flink-kubernetes/src/test/java/org/apache/flink/kubernetes/highavailability/KubernetesHighAvailabilityTestBase.java
+++ b/flink-kubernetes/src/test/java/org/apache/flink/kubernetes/highavailability/KubernetesHighAvailabilityTestBase.java
@@ -30,7 +30,6 @@ import org.apache.flink.kubernetes.kubeclient.resources.KubernetesException;
 import org.apache.flink.kubernetes.kubeclient.resources.KubernetesLeaderElector;
 import org.apache.flink.kubernetes.utils.KubernetesUtils;
 import org.apache.flink.runtime.leaderelection.LeaderElectionDriver;
-import org.apache.flink.runtime.leaderelection.LeaderInformation;
 import org.apache.flink.runtime.leaderelection.TestingLeaderElectionEventHandler;
 import org.apache.flink.runtime.leaderretrieval.LeaderRetrievalDriver;
 import org.apache.flink.runtime.leaderretrieval.TestingLeaderRetrievalEventHandler;
@@ -65,11 +64,9 @@ public class KubernetesHighAvailabilityTestBase extends TestLogger {
     private static final String CLUSTER_ID = "leader-test-cluster";
 
     public static final String LOCK_IDENTITY = UUID.randomUUID().toString();
-    public static final String LEADER_URL = "akka.tcp://flink@172.20.1.21:6123/user/rpc/dispatcher";
+    public static final String LEADER_ADDRESS =
+            "akka.tcp://flink@172.20.1.21:6123/user/rpc/dispatcher";
     public static final String LEADER_CONFIGMAP_NAME = "leader-test-cluster";
-
-    public static final LeaderInformation LEADER_INFORMATION =
-            LeaderInformation.known(UUID.randomUUID(), LEADER_URL);
 
     protected static final long TIMEOUT = 30L * 1000L;
 
@@ -125,7 +122,7 @@ public class KubernetesHighAvailabilityTestBase extends TestLogger {
                             KubernetesUtils.getConfigMapLabels(
                                     CLUSTER_ID, LABEL_CONFIGMAP_TYPE_HIGH_AVAILABILITY));
 
-            electionEventHandler = new TestingLeaderElectionEventHandler(LEADER_INFORMATION);
+            electionEventHandler = new TestingLeaderElectionEventHandler(LEADER_ADDRESS);
             leaderElectionDriver = createLeaderElectionDriver();
 
             retrievalEventHandler = new TestingLeaderRetrievalEventHandler();
@@ -270,7 +267,7 @@ public class KubernetesHighAvailabilityTestBase extends TestLogger {
                             watchCallbackExecutorService,
                             leaderConfig);
             return factory.createLeaderElectionDriver(
-                    electionEventHandler, electionEventHandler::handleError, LEADER_URL);
+                    electionEventHandler, electionEventHandler::handleError, LEADER_ADDRESS);
         }
 
         private LeaderRetrievalDriver createLeaderRetrievalDriver() {

--- a/flink-kubernetes/src/test/java/org/apache/flink/kubernetes/highavailability/KubernetesHighAvailabilityTestBase.java
+++ b/flink-kubernetes/src/test/java/org/apache/flink/kubernetes/highavailability/KubernetesHighAvailabilityTestBase.java
@@ -19,16 +19,11 @@
 package org.apache.flink.kubernetes.highavailability;
 
 import org.apache.flink.configuration.Configuration;
-import org.apache.flink.kubernetes.configuration.KubernetesConfigOptions;
 import org.apache.flink.kubernetes.configuration.KubernetesLeaderElectionConfiguration;
 import org.apache.flink.kubernetes.kubeclient.FlinkKubeClient;
-import org.apache.flink.kubernetes.kubeclient.KubernetesConfigMapSharedWatcher;
 import org.apache.flink.kubernetes.kubeclient.TestingFlinkKubeClient;
-import org.apache.flink.kubernetes.kubeclient.TestingFlinkKubeClient.TestingKubernetesConfigMapSharedWatcher;
 import org.apache.flink.kubernetes.kubeclient.resources.KubernetesConfigMap;
-import org.apache.flink.kubernetes.kubeclient.resources.KubernetesException;
 import org.apache.flink.kubernetes.kubeclient.resources.KubernetesLeaderElector;
-import org.apache.flink.kubernetes.utils.KubernetesUtils;
 import org.apache.flink.runtime.leaderelection.LeaderElectionDriver;
 import org.apache.flink.runtime.leaderelection.TestingLeaderElectionEventHandler;
 import org.apache.flink.runtime.leaderretrieval.LeaderRetrievalDriver;
@@ -36,28 +31,17 @@ import org.apache.flink.runtime.leaderretrieval.TestingLeaderRetrievalEventHandl
 import org.apache.flink.util.ExecutorUtils;
 import org.apache.flink.util.TestLogger;
 import org.apache.flink.util.concurrent.ExecutorThreadFactory;
-import org.apache.flink.util.concurrent.FutureUtils;
 import org.apache.flink.util.function.RunnableWithException;
 
 import org.junit.After;
 import org.junit.Before;
 
-import java.util.ArrayList;
-import java.util.HashMap;
-import java.util.List;
 import java.util.Map;
-import java.util.Optional;
 import java.util.UUID;
 import java.util.concurrent.CompletableFuture;
-import java.util.concurrent.CompletionException;
 import java.util.concurrent.ExecutorService;
 import java.util.concurrent.Executors;
 import java.util.concurrent.TimeUnit;
-
-import static org.apache.flink.kubernetes.kubeclient.resources.KubernetesLeaderElector.LEADER_ANNOTATION_KEY;
-import static org.apache.flink.kubernetes.utils.Constants.LABEL_CONFIGMAP_TYPE_HIGH_AVAILABILITY;
-import static org.hamcrest.MatcherAssert.assertThat;
-import static org.hamcrest.Matchers.is;
 
 /** Base class for high availability unit tests with a configured testing Kubernetes client. */
 public class KubernetesHighAvailabilityTestBase extends TestLogger {
@@ -72,12 +56,9 @@ public class KubernetesHighAvailabilityTestBase extends TestLogger {
 
     protected ExecutorService executorService;
     protected ExecutorService watchCallbackExecutorService;
-    protected Configuration configuration;
 
     @Before
     public void setup() {
-        configuration = new Configuration();
-        configuration.setString(KubernetesConfigOptions.CLUSTER_ID, CLUSTER_ID);
         executorService = Executors.newFixedThreadPool(4, new ExecutorThreadFactory("IO-Executor"));
         watchCallbackExecutorService =
                 Executors.newCachedThreadPool(new ExecutorThreadFactory("Watch-Callback"));
@@ -86,28 +67,12 @@ public class KubernetesHighAvailabilityTestBase extends TestLogger {
     @After
     public void teardown() {
         ExecutorUtils.gracefulShutdown(
-                TIMEOUT, TimeUnit.MILLISECONDS, executorService, watchCallbackExecutorService);
+                TIMEOUT, TimeUnit.MILLISECONDS, watchCallbackExecutorService, executorService);
     }
 
     /** Context to leader election and retrieval tests. */
     protected class Context {
-        private final Map<String, KubernetesConfigMap> configMapStore = new HashMap<>();
-
-        final List<CompletableFuture<FlinkKubeClient.WatchCallbackHandler<KubernetesConfigMap>>>
-                configMapCallbackFutures = new ArrayList<>();
-
-        final List<TestingFlinkKubeClient.MockKubernetesWatch> configMapWatches = new ArrayList<>();
-
-        final CompletableFuture<Map<String, String>> deleteConfigMapByLabelsFuture =
-                new CompletableFuture<>();
-        final CompletableFuture<Void> closeKubeClientFuture = new CompletableFuture<>();
-
-        final CompletableFuture<KubernetesLeaderElector.LeaderCallbackHandler>
-                leaderCallbackHandlerFuture = new CompletableFuture<>();
-
-        final FlinkKubeClient flinkKubeClient;
-
-        final KubernetesConfigMapSharedWatcher configMapSharedWatcher;
+        private final KubernetesTestFixture kubernetesTestFixture;
 
         final LeaderElectionDriver leaderElectionDriver;
         final TestingLeaderElectionEventHandler electionEventHandler;
@@ -115,13 +80,20 @@ public class KubernetesHighAvailabilityTestBase extends TestLogger {
         final LeaderRetrievalDriver leaderRetrievalDriver;
         final TestingLeaderRetrievalEventHandler retrievalEventHandler;
 
-        Context() {
-            flinkKubeClient = createFlinkKubeClient();
-            configMapSharedWatcher =
-                    flinkKubeClient.createConfigMapSharedWatcher(
-                            KubernetesUtils.getConfigMapLabels(
-                                    CLUSTER_ID, LABEL_CONFIGMAP_TYPE_HIGH_AVAILABILITY));
+        final FlinkKubeClient flinkKubeClient;
+        final Configuration configuration;
 
+        final CompletableFuture<Void> closeKubeClientFuture;
+        final CompletableFuture<Map<String, String>> deleteConfigMapByLabelsFuture;
+
+        Context() {
+            kubernetesTestFixture =
+                    new KubernetesTestFixture(CLUSTER_ID, LEADER_CONFIGMAP_NAME, LOCK_IDENTITY);
+            flinkKubeClient = kubernetesTestFixture.getFlinkKubeClient();
+            configuration = kubernetesTestFixture.getConfiguration();
+            closeKubeClientFuture = kubernetesTestFixture.getCloseKubeClientFuture();
+            deleteConfigMapByLabelsFuture =
+                    kubernetesTestFixture.getDeleteConfigMapByLabelsFuture();
             electionEventHandler = new TestingLeaderElectionEventHandler(LEADER_ADDRESS);
             leaderElectionDriver = createLeaderElectionDriver();
 
@@ -131,129 +103,43 @@ public class KubernetesHighAvailabilityTestBase extends TestLogger {
 
         void runTest(RunnableWithException testMethod) throws Exception {
             electionEventHandler.init(leaderElectionDriver);
-            testMethod.run();
 
-            electionEventHandler.close();
-            leaderElectionDriver.close();
-            leaderRetrievalDriver.close();
-            configMapSharedWatcher.close();
+            try {
+                testMethod.run();
+            } finally {
+                electionEventHandler.close();
+                leaderElectionDriver.close();
+                leaderRetrievalDriver.close();
+                kubernetesTestFixture.close();
+            }
+        }
+
+        TestingFlinkKubeClient.Builder createFlinkKubeClientBuilder() {
+            return kubernetesTestFixture.createFlinkKubeClientBuilder();
         }
 
         KubernetesConfigMap getLeaderConfigMap() {
-            final Optional<KubernetesConfigMap> configMapOpt =
-                    flinkKubeClient.getConfigMap(LEADER_CONFIGMAP_NAME);
-            assertThat(configMapOpt.isPresent(), is(true));
-            return configMapOpt.get();
+            return kubernetesTestFixture.getLeaderConfigMap();
         }
 
         // Use the leader callback to manually grant leadership
         void leaderCallbackGrantLeadership() throws Exception {
-            createLeaderConfigMap();
-            getLeaderCallback().isLeader();
+            kubernetesTestFixture.leaderCallbackGrantLeadership();
             electionEventHandler.waitForLeader(TIMEOUT);
         }
 
         FlinkKubeClient.WatchCallbackHandler<KubernetesConfigMap>
                 getLeaderElectionConfigMapCallback() throws Exception {
-            assertThat(configMapCallbackFutures.size(), is(2));
-            return configMapCallbackFutures.get(0).get(TIMEOUT, TimeUnit.MILLISECONDS);
+            return kubernetesTestFixture.getLeaderElectionConfigMapCallback();
         }
 
         FlinkKubeClient.WatchCallbackHandler<KubernetesConfigMap>
                 getLeaderRetrievalConfigMapCallback() throws Exception {
-            assertThat(configMapCallbackFutures.size(), is(2));
-            return configMapCallbackFutures.get(1).get(TIMEOUT, TimeUnit.MILLISECONDS);
+            return kubernetesTestFixture.getLeaderRetrievalConfigMapCallback();
         }
 
         KubernetesLeaderElector.LeaderCallbackHandler getLeaderCallback() throws Exception {
-            return leaderCallbackHandlerFuture.get(TIMEOUT, TimeUnit.MILLISECONDS);
-        }
-
-        private FlinkKubeClient createFlinkKubeClient() {
-            return createFlinkKubeClientBuilder().build();
-        }
-
-        TestingFlinkKubeClient.Builder createFlinkKubeClientBuilder() {
-            return TestingFlinkKubeClient.builder()
-                    .setCreateConfigMapFunction(
-                            configMap -> {
-                                configMapStore.put(configMap.getName(), configMap);
-                                return CompletableFuture.completedFuture(null);
-                            })
-                    .setGetConfigMapFunction(
-                            configMapName -> Optional.ofNullable(configMapStore.get(configMapName)))
-                    .setCheckAndUpdateConfigMapFunction(
-                            (configMapName, updateFunction) -> {
-                                final KubernetesConfigMap configMap =
-                                        configMapStore.get(configMapName);
-                                if (configMap != null) {
-                                    try {
-                                        final boolean updated =
-                                                updateFunction
-                                                        .apply(configMap)
-                                                        .map(
-                                                                updateConfigMap -> {
-                                                                    configMapStore.put(
-                                                                            configMap.getName(),
-                                                                            updateConfigMap);
-                                                                    return true;
-                                                                })
-                                                        .orElse(false);
-                                        return CompletableFuture.completedFuture(updated);
-                                    } catch (Throwable throwable) {
-                                        throw new CompletionException(throwable);
-                                    }
-                                }
-                                throw new CompletionException(
-                                        new KubernetesException(
-                                                "ConfigMap " + configMapName + " does not exist."));
-                            })
-                    .setDeleteConfigMapFunction(
-                            name -> {
-                                configMapStore.remove(name);
-                                return FutureUtils.completedVoidFuture();
-                            })
-                    .setDeleteConfigMapByLabelFunction(
-                            labels -> {
-                                if (deleteConfigMapByLabelsFuture.isDone()) {
-                                    return FutureUtils.completedExceptionally(
-                                            new KubernetesException(
-                                                    "ConfigMap with labels "
-                                                            + labels
-                                                            + " has already be deleted."));
-                                } else {
-                                    deleteConfigMapByLabelsFuture.complete(labels);
-                                    return FutureUtils.completedVoidFuture();
-                                }
-                            })
-                    .setCloseConsumer(closeKubeClientFuture::complete)
-                    .setCreateLeaderElectorFunction(
-                            (leaderConfig, callbackHandler) -> {
-                                leaderCallbackHandlerFuture.complete(callbackHandler);
-                                return new TestingFlinkKubeClient.TestingKubernetesLeaderElector(
-                                        leaderConfig, callbackHandler);
-                            })
-                    .setCreateConfigMapSharedWatcherFunction(
-                            (labels) -> {
-                                final TestingKubernetesConfigMapSharedWatcher watcher =
-                                        new TestingKubernetesConfigMapSharedWatcher(labels);
-                                watcher.setWatchFunction(
-                                        (ignore, handler) -> {
-                                            final CompletableFuture<
-                                                            FlinkKubeClient.WatchCallbackHandler<
-                                                                    KubernetesConfigMap>>
-                                                    future =
-                                                            CompletableFuture.completedFuture(
-                                                                    handler);
-                                            configMapCallbackFutures.add(future);
-                                            final TestingFlinkKubeClient.MockKubernetesWatch watch =
-                                                    new TestingFlinkKubeClient
-                                                            .MockKubernetesWatch();
-                                            configMapWatches.add(watch);
-                                            return watch;
-                                        });
-                                return watcher;
-                            });
+            return kubernetesTestFixture.getLeaderCallback();
         }
 
         private LeaderElectionDriver createLeaderElectionDriver() {
@@ -263,7 +149,7 @@ public class KubernetesHighAvailabilityTestBase extends TestLogger {
             final KubernetesLeaderElectionDriverFactory factory =
                     new KubernetesLeaderElectionDriverFactory(
                             flinkKubeClient,
-                            configMapSharedWatcher,
+                            kubernetesTestFixture.getConfigMapSharedWatcher(),
                             watchCallbackExecutorService,
                             leaderConfig);
             return factory.createLeaderElectionDriver(
@@ -274,21 +160,11 @@ public class KubernetesHighAvailabilityTestBase extends TestLogger {
             final KubernetesLeaderRetrievalDriverFactory factory =
                     new KubernetesLeaderRetrievalDriverFactory(
                             flinkKubeClient,
-                            configMapSharedWatcher,
+                            kubernetesTestFixture.getConfigMapSharedWatcher(),
                             watchCallbackExecutorService,
                             LEADER_CONFIGMAP_NAME);
             return factory.createLeaderRetrievalDriver(
                     retrievalEventHandler, retrievalEventHandler::handleError);
-        }
-
-        // This method need be called when before the leader is granted. Since the
-        // TestingKubernetesLeaderElector
-        // will not create the leader ConfigMap automatically.
-        private void createLeaderConfigMap() {
-            final KubernetesConfigMap configMap =
-                    new TestingFlinkKubeClient.MockKubernetesConfigMap(LEADER_CONFIGMAP_NAME);
-            configMap.getAnnotations().put(LEADER_ANNOTATION_KEY, LOCK_IDENTITY);
-            flinkKubeClient.createConfigMap(configMap);
         }
     }
 }

--- a/flink-kubernetes/src/test/java/org/apache/flink/kubernetes/highavailability/KubernetesLeaderElectionAndRetrievalITCase.java
+++ b/flink-kubernetes/src/test/java/org/apache/flink/kubernetes/highavailability/KubernetesLeaderElectionAndRetrievalITCase.java
@@ -39,8 +39,6 @@ import java.util.concurrent.ExecutorService;
 import java.util.concurrent.Executors;
 import java.util.concurrent.TimeUnit;
 
-import static org.apache.flink.kubernetes.highavailability.KubernetesHighAvailabilityTestBase.LEADER_ADDRESS;
-import static org.apache.flink.kubernetes.highavailability.KubernetesHighAvailabilityTestBase.LEADER_CONFIGMAP_NAME;
 import static org.apache.flink.kubernetes.utils.Constants.LABEL_CONFIGMAP_TYPE_HIGH_AVAILABILITY;
 import static org.hamcrest.MatcherAssert.assertThat;
 import static org.hamcrest.Matchers.is;
@@ -53,6 +51,9 @@ import static org.hamcrest.Matchers.is;
  */
 public class KubernetesLeaderElectionAndRetrievalITCase extends TestLogger {
 
+    private static final String LEADER_CONFIGMAP_NAME = "leader-test-cluster";
+    private static final String LEADER_ADDRESS =
+            "akka.tcp://flink@172.20.1.21:6123/user/rpc/dispatcher";
     @ClassRule public static KubernetesResource kubernetesResource = new KubernetesResource();
 
     private static final long TIMEOUT = 120L * 1000L;

--- a/flink-kubernetes/src/test/java/org/apache/flink/kubernetes/highavailability/KubernetesLeaderElectionAndRetrievalITCase.java
+++ b/flink-kubernetes/src/test/java/org/apache/flink/kubernetes/highavailability/KubernetesLeaderElectionAndRetrievalITCase.java
@@ -97,6 +97,7 @@ public class KubernetesLeaderElectionAndRetrievalITCase extends TestLogger {
                             watchExecutorService,
                             configMapName,
                             retrievalEventHandler,
+                            KubernetesUtils::getLeaderInformationFromConfigMap,
                             retrievalEventHandler::handleError);
 
             electionEventHandler.waitForLeader(TIMEOUT);

--- a/flink-kubernetes/src/test/java/org/apache/flink/kubernetes/highavailability/KubernetesLeaderElectionDriverTest.java
+++ b/flink-kubernetes/src/test/java/org/apache/flink/kubernetes/highavailability/KubernetesLeaderElectionDriverTest.java
@@ -51,8 +51,10 @@ public class KubernetesLeaderElectionDriverTest extends KubernetesHighAvailabili
                             leaderCallbackGrantLeadership();
                             assertThat(electionEventHandler.isLeader(), is(true));
                             assertThat(
-                                    electionEventHandler.getConfirmedLeaderInformation(),
-                                    is(LEADER_INFORMATION));
+                                    electionEventHandler
+                                            .getConfirmedLeaderInformation()
+                                            .getLeaderAddress(),
+                                    is(LEADER_ADDRESS));
                         });
             }
         };
@@ -113,7 +115,7 @@ public class KubernetesLeaderElectionDriverTest extends KubernetesHighAvailabili
                             leaderCallbackGrantLeadership();
 
                             final LeaderInformation leader =
-                                    LeaderInformation.known(UUID.randomUUID(), LEADER_URL);
+                                    LeaderInformation.known(UUID.randomUUID(), LEADER_ADDRESS);
                             leaderElectionDriver.writeLeaderInformation(leader);
 
                             assertThat(
@@ -133,7 +135,8 @@ public class KubernetesLeaderElectionDriverTest extends KubernetesHighAvailabili
             {
                 runTest(
                         () -> {
-                            leaderElectionDriver.writeLeaderInformation(LEADER_INFORMATION);
+                            leaderElectionDriver.writeLeaderInformation(
+                                    LeaderInformation.known(UUID.randomUUID(), LEADER_ADDRESS));
                             electionEventHandler.waitForError(TIMEOUT);
 
                             final String errorMsg =
@@ -161,6 +164,9 @@ public class KubernetesLeaderElectionDriverTest extends KubernetesHighAvailabili
                                     callbackHandler = getLeaderElectionConfigMapCallback();
                             // Update ConfigMap with wrong data
                             final KubernetesConfigMap updatedConfigMap = getLeaderConfigMap();
+                            final UUID leaderSessionId =
+                                    UUID.fromString(
+                                            updatedConfigMap.getData().get(LEADER_SESSION_ID_KEY));
                             final LeaderInformation faultyLeader =
                                     LeaderInformation.known(
                                             UUID.randomUUID(), "faultyLeaderAddress");
@@ -177,10 +183,10 @@ public class KubernetesLeaderElectionDriverTest extends KubernetesHighAvailabili
                             // The leader should be corrected
                             assertThat(
                                     getLeaderConfigMap().getData().get(LEADER_ADDRESS_KEY),
-                                    is(LEADER_INFORMATION.getLeaderAddress()));
+                                    is(LEADER_ADDRESS));
                             assertThat(
                                     getLeaderConfigMap().getData().get(LEADER_SESSION_ID_KEY),
-                                    is(LEADER_INFORMATION.getLeaderSessionID().toString()));
+                                    is(leaderSessionId.toString()));
                         });
             }
         };

--- a/flink-kubernetes/src/test/java/org/apache/flink/kubernetes/highavailability/KubernetesLeaderRetrievalDriverTest.java
+++ b/flink-kubernetes/src/test/java/org/apache/flink/kubernetes/highavailability/KubernetesLeaderRetrievalDriverTest.java
@@ -69,7 +69,7 @@ public class KubernetesLeaderRetrievalDriverTest extends KubernetesHighAvailabil
                                     callbackHandler = getLeaderRetrievalConfigMapCallback();
 
                             // Leader changed
-                            final String newLeader = LEADER_URL + "_" + 2;
+                            final String newLeader = LEADER_ADDRESS + "_" + 2;
                             getLeaderConfigMap()
                                     .getData()
                                     .put(Constants.LEADER_ADDRESS_KEY, newLeader);

--- a/flink-kubernetes/src/test/java/org/apache/flink/kubernetes/highavailability/KubernetesMultipleComponentLeaderElectionDriverTest.java
+++ b/flink-kubernetes/src/test/java/org/apache/flink/kubernetes/highavailability/KubernetesMultipleComponentLeaderElectionDriverTest.java
@@ -1,0 +1,114 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.flink.kubernetes.highavailability;
+
+import org.apache.flink.configuration.Configuration;
+import org.apache.flink.kubernetes.configuration.KubernetesConfigOptions;
+import org.apache.flink.kubernetes.configuration.KubernetesLeaderElectionConfiguration;
+import org.apache.flink.kubernetes.kubeclient.FlinkKubeClient;
+import org.apache.flink.kubernetes.kubeclient.KubernetesConfigMapSharedWatcher;
+import org.apache.flink.kubernetes.kubeclient.TestingFlinkKubeClient;
+import org.apache.flink.kubernetes.kubeclient.resources.KubernetesLeaderElector;
+import org.apache.flink.kubernetes.utils.KubernetesUtils;
+import org.apache.flink.runtime.leaderelection.LeaderElectionEvent;
+import org.apache.flink.runtime.leaderelection.TestingLeaderElectionListener;
+import org.apache.flink.runtime.util.TestingFatalErrorHandlerExtension;
+import org.apache.flink.testutils.executor.TestExecutorExtension;
+import org.apache.flink.util.TestLoggerExtension;
+
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.junit.jupiter.api.extension.RegisterExtension;
+
+import java.util.concurrent.CompletableFuture;
+import java.util.concurrent.ExecutorService;
+import java.util.concurrent.Executors;
+
+import static org.apache.flink.kubernetes.utils.Constants.LABEL_CONFIGMAP_TYPE_HIGH_AVAILABILITY;
+
+@ExtendWith(TestLoggerExtension.class)
+public class KubernetesMultipleComponentLeaderElectionDriverTest {
+
+    private static final String CLUSTER_ID = "test-cluster";
+
+    @RegisterExtension
+    private final TestingFatalErrorHandlerExtension testingFatalErrorHandlerExtension =
+            new TestingFatalErrorHandlerExtension();
+
+    @RegisterExtension
+    private final TestExecutorExtension<ExecutorService> testExecutorExtension =
+            new TestExecutorExtension<>(Executors::newSingleThreadScheduledExecutor);
+
+    @Test
+    public void testElectionDriverGainsLeadership() throws InterruptedException {
+        final Configuration configuration = new Configuration();
+        configuration.setString(KubernetesConfigOptions.CLUSTER_ID, CLUSTER_ID);
+        final KubernetesLeaderElectionConfiguration leaderElectionConfiguration =
+                new KubernetesLeaderElectionConfiguration("foobar", "barfoo", configuration);
+
+        CompletableFuture<KubernetesLeaderElector.LeaderCallbackHandler>
+                leaderCallbackHandlerFuture = new CompletableFuture<>();
+        final FlinkKubeClient flinkKubeClient =
+                TestingFlinkKubeClient.builder()
+                        .setCreateLeaderElectorFunction(
+                                (leaderConfig, callbackHandler) -> {
+                                    leaderCallbackHandlerFuture.complete(callbackHandler);
+                                    return new TestingFlinkKubeClient
+                                            .TestingKubernetesLeaderElector(
+                                            leaderConfig, callbackHandler);
+                                })
+                        .build();
+
+        final KubernetesConfigMapSharedWatcher configMapSharedWatcher =
+                flinkKubeClient.createConfigMapSharedWatcher(
+                        KubernetesUtils.getConfigMapLabels(
+                                CLUSTER_ID, LABEL_CONFIGMAP_TYPE_HIGH_AVAILABILITY));
+
+        final TestingLeaderElectionListener leaderElectionListener =
+                new TestingLeaderElectionListener();
+
+        final KubernetesMultipleComponentLeaderElectionDriver leaderElectionDriver =
+                new KubernetesMultipleComponentLeaderElectionDriver(
+                        leaderElectionConfiguration,
+                        flinkKubeClient,
+                        leaderElectionListener,
+                        configMapSharedWatcher,
+                        testExecutorExtension.getExecutor(),
+                        testingFatalErrorHandlerExtension.getTestingFatalErrorHandler());
+
+        final KubernetesLeaderElector.LeaderCallbackHandler leaderCallbackHandler =
+                leaderCallbackHandlerFuture.join();
+
+        leaderCallbackHandler.isLeader();
+
+        leaderElectionListener.await(LeaderElectionEvent.IsLeaderEvent.class);
+    }
+
+    @Test
+    public void testElectionDriverLosesLeadership() throws Exception {}
+
+    @Test
+    public void testPublishLeaderInformation() throws Exception {}
+
+    @Test
+    public void testLeaderInformationChange() throws Exception {}
+
+    @Test
+    public void testLeaderElectionWithMultipleDrivers() throws Exception {}
+}

--- a/flink-kubernetes/src/test/java/org/apache/flink/kubernetes/highavailability/KubernetesStateHandleStoreITCase.java
+++ b/flink-kubernetes/src/test/java/org/apache/flink/kubernetes/highavailability/KubernetesStateHandleStoreITCase.java
@@ -33,7 +33,6 @@ import org.junit.Test;
 
 import java.util.UUID;
 
-import static org.apache.flink.kubernetes.highavailability.KubernetesHighAvailabilityTestBase.LEADER_CONFIGMAP_NAME;
 import static org.hamcrest.MatcherAssert.assertThat;
 import static org.hamcrest.Matchers.is;
 import static org.hamcrest.Matchers.notNullValue;
@@ -47,6 +46,7 @@ import static org.hamcrest.Matchers.notNullValue;
  */
 public class KubernetesStateHandleStoreITCase extends TestLogger {
 
+    private static final String LEADER_CONFIGMAP_NAME = "leader-test-cluster";
     @ClassRule public static KubernetesResource kubernetesResource = new KubernetesResource();
 
     private final FlinkKubeClientFactory kubeClientFactory = new FlinkKubeClientFactory();

--- a/flink-kubernetes/src/test/java/org/apache/flink/kubernetes/highavailability/KubernetesTestFixture.java
+++ b/flink-kubernetes/src/test/java/org/apache/flink/kubernetes/highavailability/KubernetesTestFixture.java
@@ -1,0 +1,236 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.flink.kubernetes.highavailability;
+
+import org.apache.flink.configuration.Configuration;
+import org.apache.flink.kubernetes.configuration.KubernetesConfigOptions;
+import org.apache.flink.kubernetes.kubeclient.FlinkKubeClient;
+import org.apache.flink.kubernetes.kubeclient.KubernetesConfigMapSharedWatcher;
+import org.apache.flink.kubernetes.kubeclient.TestingFlinkKubeClient;
+import org.apache.flink.kubernetes.kubeclient.resources.KubernetesConfigMap;
+import org.apache.flink.kubernetes.kubeclient.resources.KubernetesException;
+import org.apache.flink.kubernetes.kubeclient.resources.KubernetesLeaderElector;
+import org.apache.flink.kubernetes.utils.KubernetesUtils;
+import org.apache.flink.util.concurrent.FutureUtils;
+
+import java.util.ArrayList;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+import java.util.Optional;
+import java.util.concurrent.CompletableFuture;
+import java.util.concurrent.CompletionException;
+import java.util.concurrent.TimeUnit;
+
+import static org.apache.flink.kubernetes.kubeclient.resources.KubernetesLeaderElector.LEADER_ANNOTATION_KEY;
+import static org.apache.flink.kubernetes.utils.Constants.LABEL_CONFIGMAP_TYPE_HIGH_AVAILABILITY;
+import static org.hamcrest.MatcherAssert.assertThat;
+import static org.hamcrest.Matchers.greaterThanOrEqualTo;
+import static org.hamcrest.Matchers.is;
+
+/** Test fixture for Kubernetes tests that sets up a mock {@link FlinkKubeClient}. */
+class KubernetesTestFixture {
+    private static final long TIMEOUT = 30L * 1000L;
+
+    private final String leaderConfigmapName;
+    private final String lockIdentity;
+
+    private final Configuration configuration;
+
+    private final Map<String, KubernetesConfigMap> configMapStore = new HashMap<>();
+
+    private final List<CompletableFuture<FlinkKubeClient.WatchCallbackHandler<KubernetesConfigMap>>>
+            configMapCallbackFutures = new ArrayList<>();
+
+    private final List<TestingFlinkKubeClient.MockKubernetesWatch> configMapWatches =
+            new ArrayList<>();
+
+    private final CompletableFuture<Map<String, String>> deleteConfigMapByLabelsFuture =
+            new CompletableFuture<>();
+    private final CompletableFuture<Void> closeKubeClientFuture = new CompletableFuture<>();
+
+    private final CompletableFuture<KubernetesLeaderElector.LeaderCallbackHandler>
+            leaderCallbackHandlerFuture = new CompletableFuture<>();
+
+    private final FlinkKubeClient flinkKubeClient;
+
+    private final KubernetesConfigMapSharedWatcher configMapSharedWatcher;
+
+    KubernetesTestFixture(String clusterId, String leaderConfigmapName, String lockIdentity) {
+        this.leaderConfigmapName = leaderConfigmapName;
+        this.lockIdentity = lockIdentity;
+        configuration = new Configuration();
+        configuration.setString(KubernetesConfigOptions.CLUSTER_ID, clusterId);
+
+        flinkKubeClient = createFlinkKubeClient();
+        configMapSharedWatcher =
+                flinkKubeClient.createConfigMapSharedWatcher(
+                        KubernetesUtils.getConfigMapLabels(
+                                clusterId, LABEL_CONFIGMAP_TYPE_HIGH_AVAILABILITY));
+    }
+
+    void close() {
+        configMapSharedWatcher.close();
+    }
+
+    FlinkKubeClient getFlinkKubeClient() {
+        return flinkKubeClient;
+    }
+
+    CompletableFuture<Void> getCloseKubeClientFuture() {
+        return closeKubeClientFuture;
+    }
+
+    CompletableFuture<Map<String, String>> getDeleteConfigMapByLabelsFuture() {
+        return deleteConfigMapByLabelsFuture;
+    }
+
+    KubernetesConfigMapSharedWatcher getConfigMapSharedWatcher() {
+        return configMapSharedWatcher;
+    }
+
+    Configuration getConfiguration() {
+        return configuration;
+    }
+
+    KubernetesConfigMap getLeaderConfigMap() {
+        final Optional<KubernetesConfigMap> configMapOpt =
+                flinkKubeClient.getConfigMap(leaderConfigmapName);
+        assertThat(configMapOpt.isPresent(), is(true));
+        return configMapOpt.get();
+    }
+
+    // Use the leader callback to manually grant leadership
+    void leaderCallbackGrantLeadership() throws Exception {
+        createLeaderConfigMap();
+        getLeaderCallback().isLeader();
+    }
+
+    FlinkKubeClient.WatchCallbackHandler<KubernetesConfigMap> getLeaderElectionConfigMapCallback()
+            throws Exception {
+        assertThat(configMapCallbackFutures.size(), is(greaterThanOrEqualTo(1)));
+        return configMapCallbackFutures.get(0).get(TIMEOUT, TimeUnit.MILLISECONDS);
+    }
+
+    FlinkKubeClient.WatchCallbackHandler<KubernetesConfigMap> getLeaderRetrievalConfigMapCallback()
+            throws Exception {
+        assertThat(configMapCallbackFutures.size(), is(2));
+        return configMapCallbackFutures.get(1).get(TIMEOUT, TimeUnit.MILLISECONDS);
+    }
+
+    KubernetesLeaderElector.LeaderCallbackHandler getLeaderCallback() throws Exception {
+        return leaderCallbackHandlerFuture.get(TIMEOUT, TimeUnit.MILLISECONDS);
+    }
+
+    private FlinkKubeClient createFlinkKubeClient() {
+        return createFlinkKubeClientBuilder().build();
+    }
+
+    TestingFlinkKubeClient.Builder createFlinkKubeClientBuilder() {
+        return TestingFlinkKubeClient.builder()
+                .setCreateConfigMapFunction(
+                        configMap -> {
+                            configMapStore.put(configMap.getName(), configMap);
+                            return CompletableFuture.completedFuture(null);
+                        })
+                .setGetConfigMapFunction(
+                        configMapName -> Optional.ofNullable(configMapStore.get(configMapName)))
+                .setCheckAndUpdateConfigMapFunction(
+                        (configMapName, updateFunction) -> {
+                            final KubernetesConfigMap configMap = configMapStore.get(configMapName);
+                            if (configMap != null) {
+                                try {
+                                    final boolean updated =
+                                            updateFunction
+                                                    .apply(configMap)
+                                                    .map(
+                                                            updateConfigMap -> {
+                                                                configMapStore.put(
+                                                                        configMap.getName(),
+                                                                        updateConfigMap);
+                                                                return true;
+                                                            })
+                                                    .orElse(false);
+                                    return CompletableFuture.completedFuture(updated);
+                                } catch (Throwable throwable) {
+                                    throw new CompletionException(throwable);
+                                }
+                            }
+                            throw new CompletionException(
+                                    new KubernetesException(
+                                            "ConfigMap " + configMapName + " does not exist."));
+                        })
+                .setDeleteConfigMapFunction(
+                        name -> {
+                            configMapStore.remove(name);
+                            return FutureUtils.completedVoidFuture();
+                        })
+                .setDeleteConfigMapByLabelFunction(
+                        labels -> {
+                            if (deleteConfigMapByLabelsFuture.isDone()) {
+                                return FutureUtils.completedExceptionally(
+                                        new KubernetesException(
+                                                "ConfigMap with labels "
+                                                        + labels
+                                                        + " has already be deleted."));
+                            } else {
+                                deleteConfigMapByLabelsFuture.complete(labels);
+                                return FutureUtils.completedVoidFuture();
+                            }
+                        })
+                .setCloseConsumer(closeKubeClientFuture::complete)
+                .setCreateLeaderElectorFunction(
+                        (leaderConfig, callbackHandler) -> {
+                            leaderCallbackHandlerFuture.complete(callbackHandler);
+                            return new TestingFlinkKubeClient.TestingKubernetesLeaderElector(
+                                    leaderConfig, callbackHandler);
+                        })
+                .setCreateConfigMapSharedWatcherFunction(
+                        (labels) -> {
+                            final TestingFlinkKubeClient.TestingKubernetesConfigMapSharedWatcher
+                                    watcher =
+                                            new TestingFlinkKubeClient
+                                                    .TestingKubernetesConfigMapSharedWatcher(
+                                                    labels);
+                            watcher.setWatchFunction(
+                                    (ignore, handler) -> {
+                                        final CompletableFuture<
+                                                        FlinkKubeClient.WatchCallbackHandler<
+                                                                KubernetesConfigMap>>
+                                                future = CompletableFuture.completedFuture(handler);
+                                        configMapCallbackFutures.add(future);
+                                        final TestingFlinkKubeClient.MockKubernetesWatch watch =
+                                                new TestingFlinkKubeClient.MockKubernetesWatch();
+                                        configMapWatches.add(watch);
+                                        return watch;
+                                    });
+                            return watcher;
+                        });
+    }
+
+    // This method need be called when before the leader is granted. Since the
+    // TestingKubernetesLeaderElector
+    // will not create the leader ConfigMap automatically.
+    private void createLeaderConfigMap() {
+        final KubernetesConfigMap configMap =
+                new TestingFlinkKubeClient.MockKubernetesConfigMap(leaderConfigmapName);
+        configMap.getAnnotations().put(LEADER_ANNOTATION_KEY, lockIdentity);
+        flinkKubeClient.createConfigMap(configMap);
+    }
+}

--- a/flink-kubernetes/src/test/java/org/apache/flink/kubernetes/kubeclient/TestingFlinkKubeClient.java
+++ b/flink-kubernetes/src/test/java/org/apache/flink/kubernetes/kubeclient/TestingFlinkKubeClient.java
@@ -39,7 +39,7 @@ import java.util.List;
 import java.util.Map;
 import java.util.Optional;
 import java.util.concurrent.CompletableFuture;
-import java.util.concurrent.ExecutorService;
+import java.util.concurrent.Executor;
 import java.util.function.BiFunction;
 import java.util.function.Consumer;
 import java.util.function.Function;
@@ -475,7 +475,7 @@ public class TestingFlinkKubeClient implements FlinkKubeClient {
         public Watch watch(
                 String name,
                 WatchCallbackHandler<KubernetesConfigMap> callbackHandler,
-                @Nullable ExecutorService executorService) {
+                @Nullable Executor executor) {
             return watchFunction.apply(name, callbackHandler);
         }
     }

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/highavailability/AbstractHaServices.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/highavailability/AbstractHaServices.java
@@ -253,8 +253,10 @@ public abstract class AbstractHaServices implements HighAvailabilityServices {
     /**
      * Closes the components which is used for external operations(e.g. Zookeeper Client, Kubernetes
      * Client).
+     *
+     * @throws Exception if the close operation failed
      */
-    protected abstract void internalClose();
+    protected abstract void internalClose() throws Exception;
 
     /**
      * Clean up the meta data in the distributed system(e.g. Zookeeper, Kubernetes ConfigMap).

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/highavailability/HighAvailabilityServicesUtils.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/highavailability/HighAvailabilityServicesUtils.java
@@ -32,8 +32,10 @@ import org.apache.flink.runtime.dispatcher.Dispatcher;
 import org.apache.flink.runtime.highavailability.nonha.embedded.EmbeddedHaServices;
 import org.apache.flink.runtime.highavailability.nonha.standalone.StandaloneClientHAServices;
 import org.apache.flink.runtime.highavailability.nonha.standalone.StandaloneHaServices;
+import org.apache.flink.runtime.highavailability.zookeeper.CuratorFrameworkWithUnhandledErrorListener;
 import org.apache.flink.runtime.highavailability.zookeeper.ZooKeeperClientHAServices;
 import org.apache.flink.runtime.highavailability.zookeeper.ZooKeeperHaServices;
+import org.apache.flink.runtime.highavailability.zookeeper.ZooKeeperMultipleComponentLeaderElectionHaServices;
 import org.apache.flink.runtime.jobmanager.HighAvailabilityMode;
 import org.apache.flink.runtime.resourcemanager.ResourceManager;
 import org.apache.flink.runtime.rpc.AddressResolution;
@@ -65,13 +67,7 @@ public class HighAvailabilityServicesUtils {
                 return new EmbeddedHaServices(executor);
 
             case ZOOKEEPER:
-                BlobStoreService blobStoreService = BlobUtils.createBlobStoreFromConfig(config);
-
-                return new ZooKeeperHaServices(
-                        ZooKeeperUtils.startCuratorFramework(config, fatalErrorHandler),
-                        executor,
-                        config,
-                        blobStoreService);
+                return createZooKeeperHaServices(config, executor, fatalErrorHandler);
 
             case FACTORY_CLASS:
                 return createCustomHAServices(config, executor);
@@ -79,6 +75,30 @@ public class HighAvailabilityServicesUtils {
             default:
                 throw new Exception(
                         "High availability mode " + highAvailabilityMode + " is not supported.");
+        }
+    }
+
+    private static HighAvailabilityServices createZooKeeperHaServices(
+            Configuration configuration, Executor executor, FatalErrorHandler fatalErrorHandler)
+            throws Exception {
+        final boolean useOldHaServices =
+                configuration.get(HighAvailabilityOptions.USE_OLD_HA_SERVICES);
+
+        BlobStoreService blobStoreService = BlobUtils.createBlobStoreFromConfig(configuration);
+
+        final CuratorFrameworkWithUnhandledErrorListener curatorFrameworkWrapper =
+                ZooKeeperUtils.startCuratorFramework(configuration, fatalErrorHandler);
+
+        if (useOldHaServices) {
+            return new ZooKeeperHaServices(
+                    curatorFrameworkWrapper, executor, configuration, blobStoreService);
+        } else {
+            return new ZooKeeperMultipleComponentLeaderElectionHaServices(
+                    curatorFrameworkWrapper,
+                    configuration,
+                    executor,
+                    blobStoreService,
+                    fatalErrorHandler);
         }
     }
 
@@ -117,14 +137,7 @@ public class HighAvailabilityServicesUtils {
                 return new StandaloneHaServices(
                         resourceManagerRpcUrl, dispatcherRpcUrl, webMonitorAddress);
             case ZOOKEEPER:
-                BlobStoreService blobStoreService =
-                        BlobUtils.createBlobStoreFromConfig(configuration);
-
-                return new ZooKeeperHaServices(
-                        ZooKeeperUtils.startCuratorFramework(configuration, fatalErrorHandler),
-                        executor,
-                        configuration,
-                        blobStoreService);
+                return createZooKeeperHaServices(configuration, executor, fatalErrorHandler);
 
             case FACTORY_CLASS:
                 return createCustomHAServices(configuration, executor);

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/highavailability/zookeeper/AbstractZooKeeperHaServices.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/highavailability/zookeeper/AbstractZooKeeperHaServices.java
@@ -1,0 +1,148 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.flink.runtime.highavailability.zookeeper;
+
+import org.apache.flink.api.common.JobID;
+import org.apache.flink.configuration.Configuration;
+import org.apache.flink.runtime.blob.BlobStoreService;
+import org.apache.flink.runtime.checkpoint.CheckpointRecoveryFactory;
+import org.apache.flink.runtime.checkpoint.ZooKeeperCheckpointRecoveryFactory;
+import org.apache.flink.runtime.highavailability.AbstractHaServices;
+import org.apache.flink.runtime.highavailability.RunningJobsRegistry;
+import org.apache.flink.runtime.jobmanager.JobGraphStore;
+import org.apache.flink.runtime.util.ZooKeeperUtils;
+
+import org.apache.flink.shaded.curator4.org.apache.curator.framework.CuratorFramework;
+import org.apache.flink.shaded.curator4.org.apache.curator.utils.ZKPaths;
+import org.apache.flink.shaded.zookeeper3.org.apache.zookeeper.KeeperException;
+
+import java.util.concurrent.Executor;
+
+import static org.apache.flink.util.Preconditions.checkNotNull;
+
+/** Abstract ZooKeeper based HA services. */
+public abstract class AbstractZooKeeperHaServices extends AbstractHaServices {
+    /** The curator resource to use. */
+    private final CuratorFrameworkWithUnhandledErrorListener curatorFrameworkWrapper;
+
+    public AbstractZooKeeperHaServices(
+            CuratorFrameworkWithUnhandledErrorListener curatorFrameworkWrapper,
+            Executor executor,
+            Configuration configuration,
+            BlobStoreService blobStoreService) {
+        super(configuration, executor, blobStoreService);
+        this.curatorFrameworkWrapper = checkNotNull(curatorFrameworkWrapper);
+    }
+
+    protected final CuratorFramework getCuratorFramework() {
+        return curatorFrameworkWrapper.asCuratorFramework();
+    }
+
+    @Override
+    public CheckpointRecoveryFactory createCheckpointRecoveryFactory() throws Exception {
+        return new ZooKeeperCheckpointRecoveryFactory(
+                ZooKeeperUtils.useNamespaceAndEnsurePath(
+                        curatorFrameworkWrapper.asCuratorFramework(), ZooKeeperUtils.getJobsPath()),
+                configuration,
+                ioExecutor);
+    }
+
+    @Override
+    public JobGraphStore createJobGraphStore() throws Exception {
+        return ZooKeeperUtils.createJobGraphs(
+                curatorFrameworkWrapper.asCuratorFramework(), configuration);
+    }
+
+    @Override
+    public RunningJobsRegistry createRunningJobsRegistry() {
+        return new ZooKeeperRunningJobsRegistry(
+                curatorFrameworkWrapper.asCuratorFramework(), configuration);
+    }
+
+    @Override
+    protected void internalClose() throws Exception {
+        curatorFrameworkWrapper.close();
+    }
+
+    @Override
+    protected void internalCleanup() throws Exception {
+        cleanupZooKeeperPaths();
+    }
+
+    @Override
+    protected void internalCleanupJobData(JobID jobID) throws Exception {
+        deleteZNode(ZooKeeperUtils.getLeaderPathForJob(jobID));
+    }
+
+    /** Cleans up leftover ZooKeeper paths. */
+    private void cleanupZooKeeperPaths() throws Exception {
+        deleteOwnedZNode();
+        tryDeleteEmptyParentZNodes();
+    }
+
+    private void deleteOwnedZNode() throws Exception {
+        deleteZNode("/");
+    }
+
+    protected void deleteZNode(String path) throws Exception {
+        ZooKeeperUtils.deleteZNode(curatorFrameworkWrapper.asCuratorFramework(), path);
+    }
+
+    /**
+     * Tries to delete empty parent znodes.
+     *
+     * <p>IMPORTANT: This method can be removed once all supported ZooKeeper versions support the
+     * container {@link org.apache.zookeeper.CreateMode}.
+     *
+     * @throws Exception if the deletion fails for other reason than {@link
+     *     KeeperException.NotEmptyException}
+     */
+    private void tryDeleteEmptyParentZNodes() throws Exception {
+        // try to delete the parent znodes if they are empty
+        String remainingPath =
+                getParentPath(
+                        getNormalizedPath(
+                                curatorFrameworkWrapper.asCuratorFramework().getNamespace()));
+        final CuratorFramework nonNamespaceClient =
+                curatorFrameworkWrapper.asCuratorFramework().usingNamespace(null);
+
+        while (!isRootPath(remainingPath)) {
+            try {
+                nonNamespaceClient.delete().forPath(remainingPath);
+            } catch (KeeperException.NotEmptyException ignored) {
+                // We can only delete empty znodes
+                break;
+            }
+
+            remainingPath = getParentPath(remainingPath);
+        }
+    }
+
+    private static boolean isRootPath(String remainingPath) {
+        return ZKPaths.PATH_SEPARATOR.equals(remainingPath);
+    }
+
+    private static String getNormalizedPath(String path) {
+        return ZKPaths.makePath(path, "");
+    }
+
+    private static String getParentPath(String path) {
+        return ZKPaths.getPathAndNode(path).getPath();
+    }
+}

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/highavailability/zookeeper/ZooKeeperHaServices.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/highavailability/zookeeper/ZooKeeperHaServices.java
@@ -82,7 +82,10 @@ import java.util.concurrent.Executor;
  * <p>In the case of a standalone cluster, that cluster-id needs to be configured via {@link
  * HighAvailabilityOptions#HA_CLUSTER_ID}. All nodes with the same cluster id will join the same
  * cluster and participate in the execution of the same set of jobs.
+ *
+ * @deprecated in favour of {@link ZooKeeperMultipleComponentLeaderElectionHaServices}
  */
+@Deprecated
 public class ZooKeeperHaServices extends AbstractZooKeeperHaServices {
 
     // ------------------------------------------------------------------------

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/highavailability/zookeeper/ZooKeeperHaServices.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/highavailability/zookeeper/ZooKeeperHaServices.java
@@ -22,25 +22,12 @@ import org.apache.flink.api.common.JobID;
 import org.apache.flink.configuration.Configuration;
 import org.apache.flink.configuration.HighAvailabilityOptions;
 import org.apache.flink.runtime.blob.BlobStoreService;
-import org.apache.flink.runtime.checkpoint.CheckpointRecoveryFactory;
-import org.apache.flink.runtime.checkpoint.ZooKeeperCheckpointRecoveryFactory;
 import org.apache.flink.runtime.highavailability.AbstractHaServices;
-import org.apache.flink.runtime.highavailability.RunningJobsRegistry;
-import org.apache.flink.runtime.jobmanager.JobGraphStore;
 import org.apache.flink.runtime.leaderelection.LeaderElectionService;
 import org.apache.flink.runtime.leaderretrieval.LeaderRetrievalService;
 import org.apache.flink.runtime.util.ZooKeeperUtils;
 
-import org.apache.flink.shaded.curator4.org.apache.curator.framework.CuratorFramework;
-import org.apache.flink.shaded.curator4.org.apache.curator.utils.ZKPaths;
-import org.apache.flink.shaded.zookeeper3.org.apache.zookeeper.KeeperException;
-import org.apache.flink.shaded.zookeeper3.org.apache.zookeeper.data.Stat;
-
-import javax.annotation.Nonnull;
-
 import java.util.concurrent.Executor;
-
-import static org.apache.flink.util.Preconditions.checkNotNull;
 
 /**
  * An implementation of the {@link AbstractHaServices} using Apache ZooKeeper. The services store
@@ -96,68 +83,27 @@ import static org.apache.flink.util.Preconditions.checkNotNull;
  * HighAvailabilityOptions#HA_CLUSTER_ID}. All nodes with the same cluster id will join the same
  * cluster and participate in the execution of the same set of jobs.
  */
-public class ZooKeeperHaServices extends AbstractHaServices {
+public class ZooKeeperHaServices extends AbstractZooKeeperHaServices {
 
     // ------------------------------------------------------------------------
-
-    /** The curator resource to use. */
-    private final CuratorFrameworkWithUnhandledErrorListener curatorFrameworkWrapper;
 
     public ZooKeeperHaServices(
             CuratorFrameworkWithUnhandledErrorListener curatorFrameworkWrapper,
             Executor executor,
             Configuration configuration,
             BlobStoreService blobStoreService) {
-        super(configuration, executor, blobStoreService);
-        this.curatorFrameworkWrapper = checkNotNull(curatorFrameworkWrapper);
-    }
-
-    @Override
-    public CheckpointRecoveryFactory createCheckpointRecoveryFactory() throws Exception {
-        return new ZooKeeperCheckpointRecoveryFactory(
-                ZooKeeperUtils.useNamespaceAndEnsurePath(
-                        curatorFrameworkWrapper.asCuratorFramework(), ZooKeeperUtils.getJobsPath()),
-                configuration,
-                ioExecutor);
-    }
-
-    @Override
-    public JobGraphStore createJobGraphStore() throws Exception {
-        return ZooKeeperUtils.createJobGraphs(
-                curatorFrameworkWrapper.asCuratorFramework(), configuration);
-    }
-
-    @Override
-    public RunningJobsRegistry createRunningJobsRegistry() {
-        return new ZooKeeperRunningJobsRegistry(
-                curatorFrameworkWrapper.asCuratorFramework(), configuration);
+        super(curatorFrameworkWrapper, executor, configuration, blobStoreService);
     }
 
     @Override
     protected LeaderElectionService createLeaderElectionService(String leaderPath) {
-        return ZooKeeperUtils.createLeaderElectionService(
-                curatorFrameworkWrapper.asCuratorFramework(), leaderPath);
+        return ZooKeeperUtils.createLeaderElectionService(getCuratorFramework(), leaderPath);
     }
 
     @Override
     protected LeaderRetrievalService createLeaderRetrievalService(String leaderPath) {
         return ZooKeeperUtils.createLeaderRetrievalService(
-                curatorFrameworkWrapper.asCuratorFramework(), leaderPath, configuration);
-    }
-
-    @Override
-    public void internalClose() {
-        curatorFrameworkWrapper.close();
-    }
-
-    @Override
-    public void internalCleanup() throws Exception {
-        cleanupZooKeeperPaths();
-    }
-
-    @Override
-    public void internalCleanupJobData(JobID jobID) throws Exception {
-        deleteZNode(ZooKeeperUtils.getLeaderPathForJob(jobID));
+                getCuratorFramework(), leaderPath, configuration);
     }
 
     @Override
@@ -178,92 +124,5 @@ public class ZooKeeperHaServices extends AbstractHaServices {
     @Override
     protected String getLeaderPathForRestServer() {
         return ZooKeeperUtils.getLeaderPathForRestServer();
-    }
-
-    // ------------------------------------------------------------------------
-    //  Utilities
-    // ------------------------------------------------------------------------
-
-    /** Cleans up leftover ZooKeeper paths. */
-    private void cleanupZooKeeperPaths() throws Exception {
-        deleteOwnedZNode();
-        tryDeleteEmptyParentZNodes();
-    }
-
-    private void deleteOwnedZNode() throws Exception {
-        deleteZNode("/");
-    }
-
-    private void deleteZNode(String path) throws Exception {
-        // delete the HA_CLUSTER_ID znode which is owned by this cluster
-
-        // Since we are using Curator version 2.12 there is a bug in deleting the children
-        // if there is a concurrent delete operation. Therefore we need to add this retry
-        // logic. See https://issues.apache.org/jira/browse/CURATOR-430 for more information.
-        // The retry logic can be removed once we upgrade to Curator version >= 4.0.1.
-        boolean zNodeDeleted = false;
-        while (!zNodeDeleted) {
-            Stat stat = curatorFrameworkWrapper.asCuratorFramework().checkExists().forPath(path);
-            if (stat == null) {
-                logger.debug("znode {} has been deleted", path);
-                return;
-            }
-            try {
-                curatorFrameworkWrapper
-                        .asCuratorFramework()
-                        .delete()
-                        .deletingChildrenIfNeeded()
-                        .forPath(path);
-                zNodeDeleted = true;
-            } catch (KeeperException.NoNodeException ignored) {
-                // concurrent delete operation. Try again.
-                logger.debug(
-                        "Retrying to delete znode because of other concurrent delete operation.");
-            }
-        }
-    }
-
-    /**
-     * Tries to delete empty parent znodes.
-     *
-     * <p>IMPORTANT: This method can be removed once all supported ZooKeeper versions support the
-     * container {@link org.apache.zookeeper.CreateMode}.
-     *
-     * @throws Exception if the deletion fails for other reason than {@link
-     *     KeeperException.NotEmptyException}
-     */
-    private void tryDeleteEmptyParentZNodes() throws Exception {
-        // try to delete the parent znodes if they are empty
-        String remainingPath =
-                getParentPath(
-                        getNormalizedPath(
-                                curatorFrameworkWrapper.asCuratorFramework().getNamespace()));
-        final CuratorFramework nonNamespaceClient =
-                curatorFrameworkWrapper.asCuratorFramework().usingNamespace(null);
-
-        while (!isRootPath(remainingPath)) {
-            try {
-                nonNamespaceClient.delete().forPath(remainingPath);
-            } catch (KeeperException.NotEmptyException ignored) {
-                // We can only delete empty znodes
-                break;
-            }
-
-            remainingPath = getParentPath(remainingPath);
-        }
-    }
-
-    private static boolean isRootPath(String remainingPath) {
-        return ZKPaths.PATH_SEPARATOR.equals(remainingPath);
-    }
-
-    @Nonnull
-    private static String getNormalizedPath(String path) {
-        return ZKPaths.makePath(path, "");
-    }
-
-    @Nonnull
-    private static String getParentPath(String path) {
-        return ZKPaths.getPathAndNode(path).getPath();
     }
 }

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/highavailability/zookeeper/ZooKeeperMultipleComponentLeaderElectionHaServices.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/highavailability/zookeeper/ZooKeeperMultipleComponentLeaderElectionHaServices.java
@@ -1,0 +1,168 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.flink.runtime.highavailability.zookeeper;
+
+import org.apache.flink.api.common.JobID;
+import org.apache.flink.configuration.Configuration;
+import org.apache.flink.runtime.blob.BlobStoreService;
+import org.apache.flink.runtime.leaderelection.DefaultLeaderElectionService;
+import org.apache.flink.runtime.leaderelection.DefaultMultipleComponentLeaderElectionService;
+import org.apache.flink.runtime.leaderelection.LeaderElectionService;
+import org.apache.flink.runtime.leaderelection.MultipleComponentLeaderElectionService;
+import org.apache.flink.runtime.leaderelection.ZooKeeperMultipleComponentLeaderElectionDriverFactory;
+import org.apache.flink.runtime.leaderretrieval.LeaderRetrievalService;
+import org.apache.flink.runtime.rpc.FatalErrorHandler;
+import org.apache.flink.runtime.util.ZooKeeperUtils;
+import org.apache.flink.util.ExceptionUtils;
+import org.apache.flink.util.FlinkRuntimeException;
+
+import org.apache.flink.shaded.curator4.org.apache.curator.framework.CuratorFramework;
+
+import javax.annotation.Nullable;
+import javax.annotation.concurrent.GuardedBy;
+
+import java.util.concurrent.Executor;
+
+/**
+ * ZooKeeper HA services that only use a single leader election per process.
+ *
+ * <pre>
+ * /flink
+ *      +/cluster_id_1/leader/latch
+ *      |            |       /resource_manager/connection_info
+ *      |            |       /dispatcher/connection_info
+ *      |            |       /rest_server/connection_info
+ *      |            |       /job-id-1/connection_info
+ *      |            |       /job-id-2/connection_info
+ *      |            |
+ *      |            |
+ *      |            +jobgraphs/job-id-1
+ *      |            |         /job-id-2
+ *      |            +jobs/job-id-1/checkpoints/latest
+ *      |                 |                    /latest-1
+ *      |                 |                    /latest-2
+ *      |                 |       /checkpoint_id_counter
+ * </pre>
+ */
+public class ZooKeeperMultipleComponentLeaderElectionHaServices
+        extends AbstractZooKeeperHaServices {
+
+    private final Object lock = new Object();
+
+    private final CuratorFramework leaderNamespacedCuratorFramework;
+
+    private final FatalErrorHandler fatalErrorHandler;
+
+    @Nullable
+    @GuardedBy("lock")
+    private MultipleComponentLeaderElectionService multipleComponentLeaderElectionService = null;
+
+    public ZooKeeperMultipleComponentLeaderElectionHaServices(
+            CuratorFrameworkWithUnhandledErrorListener curatorFrameworkWrapper,
+            Configuration config,
+            Executor ioExecutor,
+            BlobStoreService blobStoreService,
+            FatalErrorHandler fatalErrorHandler)
+            throws Exception {
+        super(curatorFrameworkWrapper, ioExecutor, config, blobStoreService);
+        this.leaderNamespacedCuratorFramework =
+                ZooKeeperUtils.useNamespaceAndEnsurePath(
+                        getCuratorFramework(), ZooKeeperUtils.getLeaderPath());
+        this.fatalErrorHandler = fatalErrorHandler;
+    }
+
+    @Override
+    protected LeaderElectionService createLeaderElectionService(String leaderName) {
+        return new DefaultLeaderElectionService(
+                getOrInitializeSingleLeaderElectionService().createDriverFactory(leaderName));
+    }
+
+    private MultipleComponentLeaderElectionService getOrInitializeSingleLeaderElectionService() {
+        synchronized (lock) {
+            if (multipleComponentLeaderElectionService == null) {
+                try {
+                    multipleComponentLeaderElectionService =
+                            new DefaultMultipleComponentLeaderElectionService(
+                                    fatalErrorHandler,
+                                    new ZooKeeperMultipleComponentLeaderElectionDriverFactory(
+                                            leaderNamespacedCuratorFramework));
+                } catch (Exception e) {
+                    throw new FlinkRuntimeException(
+                            String.format(
+                                    "Could not initialize the %s",
+                                    DefaultMultipleComponentLeaderElectionService.class
+                                            .getSimpleName()),
+                            e);
+                }
+            }
+
+            return multipleComponentLeaderElectionService;
+        }
+    }
+
+    @Override
+    protected LeaderRetrievalService createLeaderRetrievalService(String leaderPath) {
+        // Maybe use a single service for leader retrieval
+        return ZooKeeperUtils.createLeaderRetrievalService(
+                leaderNamespacedCuratorFramework, leaderPath, configuration);
+    }
+
+    @Override
+    protected void internalClose() throws Exception {
+        Exception exception = null;
+        synchronized (lock) {
+            if (multipleComponentLeaderElectionService != null) {
+                try {
+                    multipleComponentLeaderElectionService.close();
+                } catch (Exception e) {
+                    exception = e;
+                }
+                multipleComponentLeaderElectionService = null;
+            }
+        }
+
+        try {
+            super.internalClose();
+        } catch (Exception e) {
+            exception = ExceptionUtils.firstOrSuppressed(e, exception);
+        }
+
+        ExceptionUtils.tryRethrowException(exception);
+    }
+
+    @Override
+    protected String getLeaderPathForResourceManager() {
+        return ZooKeeperUtils.getResourceManagerNode();
+    }
+
+    @Override
+    protected String getLeaderPathForDispatcher() {
+        return ZooKeeperUtils.getDispatcherNode();
+    }
+
+    @Override
+    protected String getLeaderPathForJobManager(JobID jobID) {
+        return jobID.toString();
+    }
+
+    @Override
+    protected String getLeaderPathForRestServer() {
+        return ZooKeeperUtils.getRestServerNode();
+    }
+}

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/leaderelection/DefaultLeaderElectionService.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/leaderelection/DefaultLeaderElectionService.java
@@ -81,6 +81,7 @@ public class DefaultLeaderElectionService
         Preconditions.checkState(leaderContender == null, "Contender was already set.");
 
         synchronized (lock) {
+            running = true;
             leaderContender = contender;
             leaderElectionDriver =
                     leaderElectionDriverFactory.createLeaderElectionDriver(
@@ -88,8 +89,6 @@ public class DefaultLeaderElectionService
                             new LeaderElectionFatalErrorHandler(),
                             leaderContender.getDescription());
             LOG.info("Starting DefaultLeaderElectionService with {}.", leaderElectionDriver);
-
-            running = true;
         }
     }
 

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/leaderelection/DefaultLeaderElectionService.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/leaderelection/DefaultLeaderElectionService.java
@@ -189,10 +189,10 @@ public class DefaultLeaderElectionService
 
     @Override
     @GuardedBy("lock")
-    public void onGrantLeadership() {
+    public void onGrantLeadership(UUID newLeaderSessionId) {
         synchronized (lock) {
             if (running) {
-                issuedLeaderSessionID = UUID.randomUUID();
+                issuedLeaderSessionID = newLeaderSessionId;
                 clearConfirmedLeaderInformation();
 
                 if (LOG.isDebugEnabled()) {

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/leaderelection/DefaultMultipleComponentLeaderElectionService.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/leaderelection/DefaultMultipleComponentLeaderElectionService.java
@@ -1,0 +1,278 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.flink.runtime.leaderelection;
+
+import org.apache.flink.annotation.VisibleForTesting;
+import org.apache.flink.runtime.rpc.FatalErrorHandler;
+import org.apache.flink.util.ExecutorUtils;
+import org.apache.flink.util.FlinkException;
+import org.apache.flink.util.Preconditions;
+import org.apache.flink.util.concurrent.ExecutorThreadFactory;
+
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import javax.annotation.Nullable;
+import javax.annotation.concurrent.GuardedBy;
+
+import java.util.Collection;
+import java.util.HashMap;
+import java.util.Map;
+import java.util.UUID;
+import java.util.concurrent.ExecutorService;
+import java.util.concurrent.Executors;
+import java.util.concurrent.TimeUnit;
+import java.util.function.Consumer;
+import java.util.stream.Collectors;
+
+/**
+ * Default implementation of a {@link MultipleComponentLeaderElectionService} that allows to
+ * register multiple {@link LeaderElectionEventHandler}.
+ */
+public class DefaultMultipleComponentLeaderElectionService
+        implements MultipleComponentLeaderElectionService,
+                MultipleComponentLeaderElectionDriver.Listener {
+    private static final Logger LOG =
+            LoggerFactory.getLogger(DefaultMultipleComponentLeaderElectionService.class);
+
+    private final Object lock = new Object();
+
+    private final MultipleComponentLeaderElectionDriver multipleComponentLeaderElectionDriver;
+
+    private final FatalErrorHandler fatalErrorHandler;
+
+    @GuardedBy("lock")
+    private final ExecutorService leadershipOperationExecutor;
+
+    @GuardedBy("lock")
+    private final Map<String, LeaderElectionEventHandler> leaderElectionEventHandlers;
+
+    @GuardedBy("lock")
+    private boolean running = true;
+
+    @Nullable
+    @GuardedBy("lock")
+    private UUID currentLeaderSessionId = null;
+
+    @VisibleForTesting
+    DefaultMultipleComponentLeaderElectionService(
+            FatalErrorHandler fatalErrorHandler,
+            MultipleComponentLeaderElectionDriverFactory
+                    multipleComponentLeaderElectionDriverFactory,
+            ExecutorService leadershipOperationExecutor)
+            throws Exception {
+        this.fatalErrorHandler = Preconditions.checkNotNull(fatalErrorHandler);
+
+        this.leadershipOperationExecutor = Preconditions.checkNotNull(leadershipOperationExecutor);
+
+        leaderElectionEventHandlers = new HashMap<>();
+
+        multipleComponentLeaderElectionDriver =
+                multipleComponentLeaderElectionDriverFactory.create(this);
+    }
+
+    public DefaultMultipleComponentLeaderElectionService(
+            FatalErrorHandler fatalErrorHandler,
+            MultipleComponentLeaderElectionDriverFactory
+                    multipleComponentLeaderElectionDriverFactory)
+            throws Exception {
+        this(
+                fatalErrorHandler,
+                multipleComponentLeaderElectionDriverFactory,
+                Executors.newSingleThreadExecutor(
+                        new ExecutorThreadFactory("leadershipOperationExecutor")));
+    }
+
+    @Override
+    public void close() throws Exception {
+        synchronized (lock) {
+            if (!running) {
+                return;
+            }
+            running = false;
+
+            LOG.info("Closing {}.", this.getClass().getSimpleName());
+
+            ExecutorUtils.gracefulShutdown(10L, TimeUnit.SECONDS, leadershipOperationExecutor);
+
+            multipleComponentLeaderElectionDriver.close();
+        }
+    }
+
+    @Override
+    public LeaderElectionDriverFactory createDriverFactory(String componentId) {
+        return new MultipleComponentLeaderElectionDriverAdapterFactory(componentId, this);
+    }
+
+    @Override
+    public void publishLeaderInformation(String componentId, LeaderInformation leaderInformation) {
+        try {
+            multipleComponentLeaderElectionDriver.publishLeaderInformation(
+                    componentId, leaderInformation);
+        } catch (Exception e) {
+            fatalErrorHandler.onFatalError(
+                    new FlinkException(
+                            String.format(
+                                    "Could not write leader information %s for leader %s.",
+                                    leaderInformation, componentId),
+                            e));
+        }
+    }
+
+    @Override
+    public void registerLeaderElectionEventHandler(
+            String componentId, LeaderElectionEventHandler leaderElectionEventHandler) {
+
+        synchronized (lock) {
+            Preconditions.checkArgument(
+                    !leaderElectionEventHandlers.containsKey(componentId),
+                    "Do not support duplicate LeaderElectionEventHandler registration under %s",
+                    componentId);
+            leaderElectionEventHandlers.put(componentId, leaderElectionEventHandler);
+
+            if (currentLeaderSessionId != null) {
+                final UUID leaderSessionId = currentLeaderSessionId;
+                leadershipOperationExecutor.execute(
+                        () -> leaderElectionEventHandler.onGrantLeadership(leaderSessionId));
+            }
+        }
+    }
+
+    @Override
+    public void unregisterLeaderElectionEventHandler(String componentId) throws Exception {
+        final LeaderElectionEventHandler unregisteredLeaderElectionEventHandler;
+        synchronized (lock) {
+            unregisteredLeaderElectionEventHandler =
+                    leaderElectionEventHandlers.remove(componentId);
+
+            if (unregisteredLeaderElectionEventHandler != null) {
+                leadershipOperationExecutor.execute(
+                        unregisteredLeaderElectionEventHandler::onRevokeLeadership);
+            } else {
+                LOG.debug(
+                        "Could not find leader election event handler for componentId {}. Ignoring the unregister call.",
+                        componentId);
+            }
+        }
+
+        multipleComponentLeaderElectionDriver.deleteLeaderInformation(componentId);
+    }
+
+    @Override
+    public boolean hasLeadership(String componentId) {
+        synchronized (lock) {
+            Preconditions.checkState(running);
+
+            return leaderElectionEventHandlers.containsKey(componentId)
+                    && multipleComponentLeaderElectionDriver.hasLeadership();
+        }
+    }
+
+    @Override
+    public void isLeader() {
+        final UUID newLeaderSessionId = UUID.randomUUID();
+        synchronized (lock) {
+            if (!running) {
+                return;
+            }
+
+            currentLeaderSessionId = UUID.randomUUID();
+
+            forEachLeaderElectionEventHandler(
+                    leaderElectionEventHandler ->
+                            leaderElectionEventHandler.onGrantLeadership(newLeaderSessionId));
+        }
+    }
+
+    @Override
+    public void notLeader() {
+        synchronized (lock) {
+            if (!running) {
+                return;
+            }
+
+            currentLeaderSessionId = null;
+
+            forEachLeaderElectionEventHandler(LeaderElectionEventHandler::onRevokeLeadership);
+        }
+    }
+
+    @GuardedBy("lock")
+    private void forEachLeaderElectionEventHandler(
+            Consumer<? super LeaderElectionEventHandler> action) {
+
+        for (LeaderElectionEventHandler leaderElectionEventHandler :
+                leaderElectionEventHandlers.values()) {
+            leadershipOperationExecutor.execute(() -> action.accept(leaderElectionEventHandler));
+        }
+    }
+
+    @Override
+    public void notifyLeaderInformationChange(
+            String componentId, LeaderInformation leaderInformation) {
+        synchronized (lock) {
+            if (!running) {
+                return;
+            }
+
+            final LeaderElectionEventHandler leaderElectionEventHandler =
+                    leaderElectionEventHandlers.get(componentId);
+
+            if (leaderElectionEventHandler != null) {
+                leadershipOperationExecutor.execute(
+                        () ->
+                                leaderElectionEventHandler.onLeaderInformationChange(
+                                        leaderInformation));
+            }
+        }
+    }
+
+    @Override
+    public void notifyAllKnownLeaderInformation(
+            Collection<LeaderInformationWithComponentId> leaderInformationWithComponentIds) {
+        synchronized (lock) {
+            if (!running) {
+                return;
+            }
+
+            final Map<String, LeaderInformation> leaderInformationByName =
+                    leaderInformationWithComponentIds.stream()
+                            .collect(
+                                    Collectors.toMap(
+                                            LeaderInformationWithComponentId::getComponentId,
+                                            LeaderInformationWithComponentId
+                                                    ::getLeaderInformation));
+
+            for (Map.Entry<String, LeaderElectionEventHandler>
+                    leaderNameLeaderElectionEventHandlerPair :
+                            leaderElectionEventHandlers.entrySet()) {
+                final String leaderName = leaderNameLeaderElectionEventHandlerPair.getKey();
+                if (leaderInformationByName.containsKey(leaderName)) {
+                    leaderNameLeaderElectionEventHandlerPair
+                            .getValue()
+                            .onLeaderInformationChange(leaderInformationByName.get(leaderName));
+                } else {
+                    leaderNameLeaderElectionEventHandlerPair
+                            .getValue()
+                            .onLeaderInformationChange(LeaderInformation.empty());
+                }
+            }
+        }
+    }
+}

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/leaderelection/LeaderElectionEventHandler.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/leaderelection/LeaderElectionEventHandler.java
@@ -18,6 +18,8 @@
 
 package org.apache.flink.runtime.leaderelection;
 
+import java.util.UUID;
+
 /**
  * Interface which should be implemented to respond to leader changes in {@link
  * LeaderElectionDriver}.
@@ -30,8 +32,12 @@ package org.apache.flink.runtime.leaderelection;
  */
 public interface LeaderElectionEventHandler {
 
-    /** Called by specific {@link LeaderElectionDriver} when the leadership is granted. */
-    void onGrantLeadership();
+    /**
+     * Called by specific {@link LeaderElectionDriver} when the leadership is granted.
+     *
+     * @param newLeaderSessionId the valid leader session id
+     */
+    void onGrantLeadership(UUID newLeaderSessionId);
 
     /** Called by specific {@link LeaderElectionDriver} when the leadership is revoked. */
     void onRevokeLeadership();

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/leaderelection/LeaderInformationWithComponentId.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/leaderelection/LeaderInformationWithComponentId.java
@@ -1,0 +1,65 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.flink.runtime.leaderelection;
+
+import java.util.Objects;
+
+/** Leader information and its corresponding leader name. */
+public final class LeaderInformationWithComponentId {
+    private final String componentId;
+
+    private final LeaderInformation leaderInformation;
+
+    private LeaderInformationWithComponentId(
+            String componentId, LeaderInformation leaderInformation) {
+        this.componentId = componentId;
+        this.leaderInformation = leaderInformation;
+    }
+
+    LeaderInformation getLeaderInformation() {
+        return leaderInformation;
+    }
+
+    String getComponentId() {
+        return componentId;
+    }
+
+    public static LeaderInformationWithComponentId create(
+            String componentId, LeaderInformation leaderInformation) {
+        return new LeaderInformationWithComponentId(componentId, leaderInformation);
+    }
+
+    @Override
+    public boolean equals(Object o) {
+        if (this == o) {
+            return true;
+        }
+        if (o == null || getClass() != o.getClass()) {
+            return false;
+        }
+        LeaderInformationWithComponentId that = (LeaderInformationWithComponentId) o;
+        return Objects.equals(componentId, that.componentId)
+                && Objects.equals(leaderInformation, that.leaderInformation);
+    }
+
+    @Override
+    public int hashCode() {
+        return Objects.hash(componentId, leaderInformation);
+    }
+}

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/leaderelection/MultipleComponentLeaderElectionDriver.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/leaderelection/MultipleComponentLeaderElectionDriver.java
@@ -1,0 +1,87 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.flink.runtime.leaderelection;
+
+import java.util.Collection;
+
+/**
+ * A leader election driver that allows to write {@link LeaderInformation} for multiple components.
+ */
+public interface MultipleComponentLeaderElectionDriver {
+
+    /**
+     * Closes the driver.
+     *
+     * @throws Exception if closing this driver fails
+     */
+    void close() throws Exception;
+
+    /**
+     * Returns whether the driver has currently leadership.
+     *
+     * @return {@code true} if the driver has leadership, otherwise {@code false}
+     */
+    boolean hasLeadership();
+
+    /**
+     * Publishes the leader information for the given component.
+     *
+     * @param componentId identifying the component for which to publish the leader information
+     * @param leaderInformation leader information of the respective component
+     * @throws Exception if publishing fails
+     */
+    void publishLeaderInformation(String componentId, LeaderInformation leaderInformation)
+            throws Exception;
+
+    /**
+     * Deletes the leader information for the given component.
+     *
+     * @param componentId identifying the component for which to delete the leader information
+     * @throws Exception if deleting fails
+     */
+    void deleteLeaderInformation(String componentId) throws Exception;
+
+    /**
+     * Listener interface for state changes of the {@link MultipleComponentLeaderElectionDriver}.
+     */
+    interface Listener {
+
+        /** Callback that is called once the driver obtains the leadership. */
+        void isLeader();
+
+        /** Callback that is called once the driver loses the leadership. */
+        void notLeader();
+
+        /**
+         * Notifies the listener about a changed leader information for the given component.
+         *
+         * @param componentId identifying the component whose leader information has changed
+         * @param leaderInformation new leader information
+         */
+        void notifyLeaderInformationChange(String componentId, LeaderInformation leaderInformation);
+
+        /**
+         * Notifies the listener about all currently known leader information.
+         *
+         * @param leaderInformationWithComponentIds leader information with component ids
+         */
+        void notifyAllKnownLeaderInformation(
+                Collection<LeaderInformationWithComponentId> leaderInformationWithComponentIds);
+    }
+}

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/leaderelection/MultipleComponentLeaderElectionDriverAdapter.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/leaderelection/MultipleComponentLeaderElectionDriverAdapter.java
@@ -1,0 +1,58 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.flink.runtime.leaderelection;
+
+import org.apache.flink.util.Preconditions;
+
+/**
+ * {@link LeaderElectionDriver} adapter that multiplexes the leader election of a component into a
+ * single leader election via {@link MultipleComponentLeaderElectionService}.
+ */
+final class MultipleComponentLeaderElectionDriverAdapter implements LeaderElectionDriver {
+    private final String componentId;
+    private final MultipleComponentLeaderElectionService multipleComponentLeaderElectionService;
+
+    MultipleComponentLeaderElectionDriverAdapter(
+            String componentId,
+            MultipleComponentLeaderElectionService multipleComponentLeaderElectionService,
+            LeaderElectionEventHandler leaderElectionEventHandler) {
+        this.componentId = Preconditions.checkNotNull(componentId);
+        this.multipleComponentLeaderElectionService =
+                Preconditions.checkNotNull(multipleComponentLeaderElectionService);
+
+        multipleComponentLeaderElectionService.registerLeaderElectionEventHandler(
+                this.componentId, leaderElectionEventHandler);
+    }
+
+    @Override
+    public void writeLeaderInformation(LeaderInformation leaderInformation) {
+        multipleComponentLeaderElectionService.publishLeaderInformation(
+                componentId, leaderInformation);
+    }
+
+    @Override
+    public boolean hasLeadership() {
+        return multipleComponentLeaderElectionService.hasLeadership(componentId);
+    }
+
+    @Override
+    public void close() throws Exception {
+        multipleComponentLeaderElectionService.unregisterLeaderElectionEventHandler(componentId);
+    }
+}

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/leaderelection/MultipleComponentLeaderElectionDriverAdapterFactory.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/leaderelection/MultipleComponentLeaderElectionDriverAdapterFactory.java
@@ -1,0 +1,45 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.flink.runtime.leaderelection;
+
+import org.apache.flink.runtime.rpc.FatalErrorHandler;
+import org.apache.flink.util.Preconditions;
+
+/** Factory for a {@link MultipleComponentLeaderElectionDriverAdapter}. */
+final class MultipleComponentLeaderElectionDriverAdapterFactory
+        implements LeaderElectionDriverFactory {
+    private final String leaderName;
+    private final MultipleComponentLeaderElectionService singleLeaderElectionService;
+
+    MultipleComponentLeaderElectionDriverAdapterFactory(
+            String leaderName, MultipleComponentLeaderElectionService singleLeaderElectionService) {
+        this.leaderName = Preconditions.checkNotNull(leaderName);
+        this.singleLeaderElectionService = Preconditions.checkNotNull(singleLeaderElectionService);
+    }
+
+    @Override
+    public LeaderElectionDriver createLeaderElectionDriver(
+            LeaderElectionEventHandler leaderEventHandler,
+            FatalErrorHandler fatalErrorHandler,
+            String leaderContenderDescription)
+            throws Exception {
+        return new MultipleComponentLeaderElectionDriverAdapter(
+                leaderName, singleLeaderElectionService, leaderEventHandler);
+    }
+}

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/leaderelection/MultipleComponentLeaderElectionDriverFactory.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/leaderelection/MultipleComponentLeaderElectionDriverFactory.java
@@ -1,0 +1,35 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.flink.runtime.leaderelection;
+
+/** Factory for {@link MultipleComponentLeaderElectionDriver}. */
+public interface MultipleComponentLeaderElectionDriverFactory {
+
+    /**
+     * Creates a {@link MultipleComponentLeaderElectionDriver} for the given leader contender
+     * description. Moreover, it registers the given leader election listener with the service.
+     *
+     * @param leaderElectionListener listener for the callbacks of the {@link
+     *     MultipleComponentLeaderElectionDriver}
+     * @return created {@link MultipleComponentLeaderElectionDriver} instance
+     * @throws Exception if the creation fails
+     */
+    MultipleComponentLeaderElectionDriver create(
+            MultipleComponentLeaderElectionDriver.Listener leaderElectionListener) throws Exception;
+}

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/leaderelection/MultipleComponentLeaderElectionService.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/leaderelection/MultipleComponentLeaderElectionService.java
@@ -1,0 +1,78 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.flink.runtime.leaderelection;
+
+/**
+ * Leader election service that allows to register multiple {@link LeaderElectionEventHandler
+ * LeaderElectionEventHandlers} that are identified by different names. For each event handler it is
+ * possible to write the corresponding {@link LeaderInformation}.
+ */
+public interface MultipleComponentLeaderElectionService {
+
+    /**
+     * Closes this service.
+     *
+     * @throws Exception if the service failed to close
+     */
+    void close() throws Exception;
+
+    /**
+     * Creates a {@link LeaderElectionDriverFactory} for the given leader name.
+     *
+     * @param componentId identifying the component for which to create a leader election driver
+     *     factory
+     * @return Leader election driver factory
+     */
+    LeaderElectionDriverFactory createDriverFactory(String componentId);
+
+    /**
+     * Publishes the given leader information for the component identified by the given leader name.
+     *
+     * @param componentId identifying the component
+     * @param leaderInformation leader information
+     */
+    void publishLeaderInformation(String componentId, LeaderInformation leaderInformation);
+
+    /**
+     * Registers a new leader election event handler under the given component id.
+     *
+     * @param componentId identifying the leader election event handler
+     * @param leaderElectionEventHandler leader election event handler to register
+     * @throws IllegalArgumentException if there is already a handler registered for the given
+     *     component id
+     */
+    void registerLeaderElectionEventHandler(
+            String componentId, LeaderElectionEventHandler leaderElectionEventHandler);
+
+    /**
+     * Unregisters the leader election event handler with the given component id.
+     *
+     * @param componentId identifying the component
+     * @throws Exception if the leader election event handler could not be unregistered
+     */
+    void unregisterLeaderElectionEventHandler(String componentId) throws Exception;
+
+    /**
+     * Returns whether the given component has leadership.
+     *
+     * @param componentId identifying the component
+     * @return {@code true} if the component has leadership otherwise {@code false}
+     */
+    boolean hasLeadership(String componentId);
+}

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/leaderelection/ZooKeeperLeaderElectionDriver.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/leaderelection/ZooKeeperLeaderElectionDriver.java
@@ -30,17 +30,10 @@ import org.apache.flink.shaded.curator4.org.apache.curator.framework.recipes.lea
 import org.apache.flink.shaded.curator4.org.apache.curator.framework.recipes.leader.LeaderLatchListener;
 import org.apache.flink.shaded.curator4.org.apache.curator.framework.state.ConnectionState;
 import org.apache.flink.shaded.curator4.org.apache.curator.framework.state.ConnectionStateListener;
-import org.apache.flink.shaded.zookeeper3.org.apache.zookeeper.CreateMode;
-import org.apache.flink.shaded.zookeeper3.org.apache.zookeeper.KeeperException;
-import org.apache.flink.shaded.zookeeper3.org.apache.zookeeper.data.Stat;
 
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
-import java.io.ByteArrayInputStream;
-import java.io.ByteArrayOutputStream;
-import java.io.ObjectInputStream;
-import java.io.ObjectOutputStream;
 import java.util.UUID;
 
 import static org.apache.flink.util.Preconditions.checkNotNull;
@@ -171,18 +164,8 @@ public class ZooKeeperLeaderElectionDriver implements LeaderElectionDriver, Lead
         if (leaderLatch.hasLeadership()) {
             ChildData childData = cache.getCurrentData(connectionInformationPath);
             if (childData != null) {
-                final byte[] data = childData.getData();
-                if (data != null && data.length > 0) {
-                    final ByteArrayInputStream bais = new ByteArrayInputStream(data);
-                    final ObjectInputStream ois = new ObjectInputStream(bais);
-
-                    final String leaderAddress = ois.readUTF();
-                    final UUID leaderSessionID = (UUID) ois.readObject();
-
-                    leaderElectionEventHandler.onLeaderInformationChange(
-                            LeaderInformation.known(leaderSessionID, leaderAddress));
-                    return;
-                }
+                leaderElectionEventHandler.onLeaderInformationChange(
+                        ZooKeeperUtils.readLeaderInformation(childData.getData()));
             }
             leaderElectionEventHandler.onLeaderInformationChange(LeaderInformation.empty());
         }
@@ -204,51 +187,11 @@ public class ZooKeeperLeaderElectionDriver implements LeaderElectionDriver, Lead
         }
 
         try {
-            final ByteArrayOutputStream baos = new ByteArrayOutputStream();
-            final ObjectOutputStream oos = new ObjectOutputStream(baos);
-
-            oos.writeUTF(leaderInformation.getLeaderAddress());
-            oos.writeObject(leaderInformation.getLeaderSessionID());
-
-            oos.close();
-
-            boolean dataWritten = false;
-
-            while (!dataWritten && leaderLatch.hasLeadership()) {
-                Stat stat = client.checkExists().forPath(connectionInformationPath);
-
-                if (stat != null) {
-                    long owner = stat.getEphemeralOwner();
-                    long sessionID = client.getZookeeperClient().getZooKeeper().getSessionId();
-
-                    if (owner == sessionID) {
-                        try {
-                            client.setData().forPath(connectionInformationPath, baos.toByteArray());
-
-                            dataWritten = true;
-                        } catch (KeeperException.NoNodeException noNode) {
-                            // node was deleted in the meantime
-                        }
-                    } else {
-                        try {
-                            client.delete().forPath(connectionInformationPath);
-                        } catch (KeeperException.NoNodeException noNode) {
-                            // node was deleted in the meantime --> try again
-                        }
-                    }
-                } else {
-                    try {
-                        client.create()
-                                .creatingParentsIfNeeded()
-                                .withMode(CreateMode.EPHEMERAL)
-                                .forPath(connectionInformationPath, baos.toByteArray());
-
-                        dataWritten = true;
-                    } catch (KeeperException.NodeExistsException nodeExists) {
-                        // node has been created in the meantime --> try again
-                    }
-                }
-            }
+            ZooKeeperUtils.writeLeaderInformationToZooKeeper(
+                    leaderInformation,
+                    client,
+                    leaderLatch::hasLeadership,
+                    connectionInformationPath);
 
             if (LOG.isDebugEnabled()) {
                 LOG.debug("Successfully wrote leader information: {}.", leaderInformation);

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/leaderelection/ZooKeeperLeaderElectionDriver.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/leaderelection/ZooKeeperLeaderElectionDriver.java
@@ -42,7 +42,10 @@ import static org.apache.flink.util.Preconditions.checkNotNull;
  * {@link LeaderElectionDriver} implementation for Zookeeper. The leading JobManager is elected
  * using ZooKeeper. The current leader's address as well as its leader session ID is published via
  * ZooKeeper.
+ *
+ * @deprecated in favour of {@link ZooKeeperMultipleComponentLeaderElectionDriver}
  */
+@Deprecated
 public class ZooKeeperLeaderElectionDriver implements LeaderElectionDriver, LeaderLatchListener {
 
     private static final Logger LOG = LoggerFactory.getLogger(ZooKeeperLeaderElectionDriver.class);

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/leaderelection/ZooKeeperLeaderElectionDriver.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/leaderelection/ZooKeeperLeaderElectionDriver.java
@@ -159,7 +159,7 @@ public class ZooKeeperLeaderElectionDriver implements LeaderElectionDriver, Lead
 
     @Override
     public void isLeader() {
-        leaderElectionEventHandler.onGrantLeadership();
+        leaderElectionEventHandler.onGrantLeadership(UUID.randomUUID());
     }
 
     @Override

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/leaderelection/ZooKeeperLeaderElectionDriverFactory.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/leaderelection/ZooKeeperLeaderElectionDriverFactory.java
@@ -22,7 +22,11 @@ import org.apache.flink.runtime.rpc.FatalErrorHandler;
 
 import org.apache.flink.shaded.curator4.org.apache.curator.framework.CuratorFramework;
 
-/** {@link LeaderElectionDriverFactory} implementation for Zookeeper. */
+/**
+ * {@link LeaderElectionDriverFactory} implementation for Zookeeper.
+ *
+ * @deprecated in favour of {@link ZooKeeperMultipleComponentLeaderElectionDriverFactory}
+ */
 public class ZooKeeperLeaderElectionDriverFactory implements LeaderElectionDriverFactory {
 
     private final CuratorFramework client;

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/leaderelection/ZooKeeperMultipleComponentLeaderElectionDriver.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/leaderelection/ZooKeeperMultipleComponentLeaderElectionDriver.java
@@ -1,0 +1,272 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.flink.runtime.leaderelection;
+
+import org.apache.flink.runtime.util.ZooKeeperUtils;
+import org.apache.flink.util.ExceptionUtils;
+import org.apache.flink.util.Preconditions;
+import org.apache.flink.util.concurrent.Executors;
+
+import org.apache.flink.shaded.curator4.org.apache.curator.framework.CuratorFramework;
+import org.apache.flink.shaded.curator4.org.apache.curator.framework.recipes.cache.ChildData;
+import org.apache.flink.shaded.curator4.org.apache.curator.framework.recipes.cache.TreeCache;
+import org.apache.flink.shaded.curator4.org.apache.curator.framework.recipes.cache.TreeCacheSelector;
+import org.apache.flink.shaded.curator4.org.apache.curator.framework.recipes.leader.LeaderLatch;
+import org.apache.flink.shaded.curator4.org.apache.curator.framework.recipes.leader.LeaderLatchListener;
+import org.apache.flink.shaded.curator4.org.apache.curator.framework.state.ConnectionState;
+import org.apache.flink.shaded.curator4.org.apache.curator.framework.state.ConnectionStateListener;
+
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import java.io.IOException;
+import java.util.concurrent.atomic.AtomicBoolean;
+
+/** ZooKeeper based {@link MultipleComponentLeaderElectionDriver} implementation. */
+public class ZooKeeperMultipleComponentLeaderElectionDriver
+        implements MultipleComponentLeaderElectionDriver, LeaderLatchListener {
+
+    private static final Logger LOG =
+            LoggerFactory.getLogger(ZooKeeperMultipleComponentLeaderElectionDriver.class);
+
+    private final CuratorFramework curatorFramework;
+
+    private final MultipleComponentLeaderElectionDriver.Listener leaderElectionListener;
+
+    private final LeaderLatch leaderLatch;
+
+    private final TreeCache treeCache;
+
+    private final ConnectionStateListener listener =
+            (client, newState) -> handleStateChange(newState);
+
+    private AtomicBoolean running = new AtomicBoolean(true);
+
+    public ZooKeeperMultipleComponentLeaderElectionDriver(
+            CuratorFramework curatorFramework,
+            MultipleComponentLeaderElectionDriver.Listener leaderElectionListener)
+            throws Exception {
+        this.curatorFramework = Preconditions.checkNotNull(curatorFramework);
+        this.leaderElectionListener = Preconditions.checkNotNull(leaderElectionListener);
+
+        this.leaderLatch = new LeaderLatch(curatorFramework, ZooKeeperUtils.getLeaderLatchPath());
+        this.treeCache =
+                TreeCache.newBuilder(curatorFramework, "/")
+                        .setCacheData(true)
+                        .setCreateParentNodes(false)
+                        .setSelector(
+                                new ZooKeeperMultipleComponentLeaderElectionDriver
+                                        .ConnectionInfoNodeSelector())
+                        .setExecutor(Executors.newDirectExecutorService())
+                        .build();
+        treeCache
+                .getListenable()
+                .addListener(
+                        (client, event) -> {
+                            switch (event.getType()) {
+                                case NODE_ADDED:
+                                case NODE_UPDATED:
+                                    Preconditions.checkNotNull(
+                                            event.getData(),
+                                            "The ZooKeeper event data must not be null.");
+                                    handleChangedLeaderInformation(event.getData());
+                                    break;
+                                case NODE_REMOVED:
+                                    Preconditions.checkNotNull(
+                                            event.getData(),
+                                            "The ZooKeeper event data must not be null.");
+                                    handleRemovedLeaderInformation(event.getData().getPath());
+                                    break;
+                            }
+                        });
+
+        leaderLatch.addListener(this);
+        curatorFramework.getConnectionStateListenable().addListener(listener);
+        leaderLatch.start();
+        treeCache.start();
+    }
+
+    @Override
+    public void close() throws Exception {
+        if (running.compareAndSet(true, false)) {
+            LOG.info("Closing {}.", this);
+
+            curatorFramework.getConnectionStateListenable().removeListener(listener);
+
+            Exception exception = null;
+
+            try {
+                treeCache.close();
+            } catch (Exception e) {
+                exception = e;
+            }
+
+            try {
+                leaderLatch.close();
+            } catch (Exception e) {
+                exception = ExceptionUtils.firstOrSuppressed(e, exception);
+            }
+
+            ExceptionUtils.tryRethrowException(exception);
+        }
+    }
+
+    @Override
+    public boolean hasLeadership() {
+        return leaderLatch.hasLeadership();
+    }
+
+    @Override
+    public void publishLeaderInformation(String componentId, LeaderInformation leaderInformation)
+            throws Exception {
+        Preconditions.checkState(running.get());
+
+        if (LOG.isDebugEnabled()) {
+            LOG.debug("Write leader information {} for {}.", leaderInformation, componentId);
+        }
+
+        if (!leaderLatch.hasLeadership()) {
+            return;
+        }
+
+        final String connectionInformationPath =
+                ZooKeeperUtils.generateConnectionInformationPath(componentId);
+
+        ZooKeeperUtils.writeLeaderInformationToZooKeeper(
+                leaderInformation,
+                curatorFramework,
+                leaderLatch::hasLeadership,
+                connectionInformationPath);
+    }
+
+    @Override
+    public void deleteLeaderInformation(String leaderName) throws Exception {
+        ZooKeeperUtils.deleteZNode(
+                curatorFramework, ZooKeeperUtils.generateZookeeperPath(leaderName));
+    }
+
+    private void handleStateChange(ConnectionState newState) {
+        switch (newState) {
+            case CONNECTED:
+                LOG.debug("Connected to ZooKeeper quorum. Leader election can start.");
+                break;
+            case SUSPENDED:
+                LOG.warn("Connection to ZooKeeper suspended, waiting for reconnection.");
+                break;
+            case RECONNECTED:
+                LOG.info(
+                        "Connection to ZooKeeper was reconnected. Leader election can be restarted.");
+                break;
+            case LOST:
+                // Maybe we have to throw an exception here to terminate the JobManager
+                LOG.warn(
+                        "Connection to ZooKeeper lost. The contender no longer participates in the leader election.");
+                break;
+        }
+    }
+
+    @Override
+    public void isLeader() {
+        LOG.debug("{} obtained the leadership.", this);
+        leaderElectionListener.isLeader();
+    }
+
+    @Override
+    public void notLeader() {
+        LOG.debug("{} lost the leadership.", this);
+        leaderElectionListener.notLeader();
+    }
+
+    private void handleChangedLeaderInformation(ChildData childData) {
+        if (shouldHandleLeaderInformationEvent(childData.getPath())) {
+            final String leaderName = extractLeaderName(childData.getPath());
+
+            final LeaderInformation leaderInformation =
+                    tryReadingLeaderInformation(childData, leaderName);
+
+            leaderElectionListener.notifyLeaderInformationChange(leaderName, leaderInformation);
+        }
+    }
+
+    private String extractLeaderName(String path) {
+        final String[] splits = ZooKeeperUtils.splitZooKeeperPath(path);
+
+        Preconditions.checkState(
+                splits.length >= 2,
+                String.format(
+                        "Expecting path consisting of /<leader_name>/connection_info. Got path '%s'",
+                        path));
+
+        return splits[splits.length - 2];
+    }
+
+    private void handleRemovedLeaderInformation(String removedNodePath) {
+        if (shouldHandleLeaderInformationEvent(removedNodePath)) {
+            final String leaderName = extractLeaderName(removedNodePath);
+
+            leaderElectionListener.notifyLeaderInformationChange(
+                    leaderName, LeaderInformation.empty());
+        }
+    }
+
+    private boolean shouldHandleLeaderInformationEvent(String path) {
+        return running.get() && leaderLatch.hasLeadership() && isConnectionInfoNode(path);
+    }
+
+    private boolean isConnectionInfoNode(String path) {
+        return path.endsWith(ZooKeeperUtils.CONNECTION_INFO_NODE);
+    }
+
+    private LeaderInformation tryReadingLeaderInformation(ChildData childData, String id) {
+        LeaderInformation leaderInformation;
+        try {
+            leaderInformation = ZooKeeperUtils.readLeaderInformation(childData.getData());
+
+            LOG.debug("Leader information for {} has changed to {}.", id, leaderInformation);
+        } catch (IOException | ClassNotFoundException e) {
+            LOG.debug(
+                    "Could not read leader information for {}. Rewriting the information.", id, e);
+            leaderInformation = LeaderInformation.empty();
+        }
+
+        return leaderInformation;
+    }
+
+    /**
+     * This selector finds all connection info nodes. See {@link
+     * org.apache.flink.runtime.highavailability.zookeeper.ZooKeeperMultipleComponentLeaderElectionHaServices}
+     * for more details on the Znode layout.
+     */
+    private static class ConnectionInfoNodeSelector implements TreeCacheSelector {
+        @Override
+        public boolean traverseChildren(String fullPath) {
+            return true;
+        }
+
+        @Override
+        public boolean acceptChild(String fullPath) {
+            return !fullPath.endsWith(ZooKeeperUtils.getLeaderLatchPath());
+        }
+    }
+
+    @Override
+    public String toString() {
+        return "ZooKeeperMultipleComponentLeaderElectionDriver";
+    }
+}

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/leaderelection/ZooKeeperMultipleComponentLeaderElectionDriverFactory.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/leaderelection/ZooKeeperMultipleComponentLeaderElectionDriverFactory.java
@@ -1,0 +1,43 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.flink.runtime.leaderelection;
+
+import org.apache.flink.util.Preconditions;
+
+import org.apache.flink.shaded.curator4.org.apache.curator.framework.CuratorFramework;
+
+/** Factory for {@link ZooKeeperMultipleComponentLeaderElectionDriver}. */
+public class ZooKeeperMultipleComponentLeaderElectionDriverFactory
+        implements MultipleComponentLeaderElectionDriverFactory {
+
+    private final CuratorFramework curatorFramework;
+
+    public ZooKeeperMultipleComponentLeaderElectionDriverFactory(
+            CuratorFramework curatorFramework) {
+        this.curatorFramework = Preconditions.checkNotNull(curatorFramework);
+    }
+
+    @Override
+    public ZooKeeperMultipleComponentLeaderElectionDriver create(
+            MultipleComponentLeaderElectionDriver.Listener leaderElectionListener)
+            throws Exception {
+        return new ZooKeeperMultipleComponentLeaderElectionDriver(
+                curatorFramework, leaderElectionListener);
+    }
+}

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/util/ZooKeeperUtils.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/util/ZooKeeperUtils.java
@@ -41,6 +41,7 @@ import org.apache.flink.runtime.jobmanager.ZooKeeperJobGraphStoreUtil;
 import org.apache.flink.runtime.jobmanager.ZooKeeperJobGraphStoreWatcher;
 import org.apache.flink.runtime.leaderelection.DefaultLeaderElectionService;
 import org.apache.flink.runtime.leaderelection.LeaderElectionDriverFactory;
+import org.apache.flink.runtime.leaderelection.LeaderInformation;
 import org.apache.flink.runtime.leaderelection.ZooKeeperLeaderElectionDriver;
 import org.apache.flink.runtime.leaderelection.ZooKeeperLeaderElectionDriverFactory;
 import org.apache.flink.runtime.leaderretrieval.DefaultLeaderRetrievalService;
@@ -66,8 +67,11 @@ import org.apache.flink.shaded.curator4.org.apache.curator.framework.recipes.cac
 import org.apache.flink.shaded.curator4.org.apache.curator.framework.recipes.cache.TreeCacheSelector;
 import org.apache.flink.shaded.curator4.org.apache.curator.framework.state.SessionConnectionStateErrorPolicy;
 import org.apache.flink.shaded.curator4.org.apache.curator.retry.ExponentialBackoffRetry;
+import org.apache.flink.shaded.zookeeper3.org.apache.zookeeper.CreateMode;
+import org.apache.flink.shaded.zookeeper3.org.apache.zookeeper.KeeperException;
 import org.apache.flink.shaded.zookeeper3.org.apache.zookeeper.ZooDefs;
 import org.apache.flink.shaded.zookeeper3.org.apache.zookeeper.data.ACL;
+import org.apache.flink.shaded.zookeeper3.org.apache.zookeeper.data.Stat;
 
 import org.apache.commons.lang3.StringUtils;
 import org.slf4j.Logger;
@@ -75,13 +79,19 @@ import org.slf4j.LoggerFactory;
 
 import javax.annotation.Nonnull;
 
+import java.io.ByteArrayInputStream;
+import java.io.ByteArrayOutputStream;
 import java.io.IOException;
+import java.io.ObjectInputStream;
+import java.io.ObjectOutputStream;
 import java.io.Serializable;
+import java.util.Arrays;
 import java.util.Collection;
 import java.util.List;
+import java.util.UUID;
 import java.util.concurrent.Executor;
+import java.util.function.BooleanSupplier;
 import java.util.stream.Collectors;
-import java.util.stream.Stream;
 
 import static org.apache.flink.util.Preconditions.checkNotNull;
 
@@ -96,13 +106,17 @@ public class ZooKeeperUtils {
     /** The prefix of the completed checkpoint file. */
     public static final String HA_STORAGE_COMPLETED_CHECKPOINT = "completedCheckpoint";
 
-    private static final String RESOURCE_MANAGER_LEADER = "/resource_manager";
+    private static final String RESOURCE_MANAGER_LEADER = "resource_manager";
 
-    private static final String DISPATCHER_LEADER = "/dispatcher";
+    private static final String DISPATCHER_LEADER = "dispatcher";
 
-    private static final String LEADER_NODE = "/leader";
+    private static final String LEADER_NODE = "leader";
 
-    private static final String REST_SERVER_LEADER = "/rest_server";
+    private static final String REST_SERVER_LEADER = "rest_server";
+
+    private static final String LEADER_LATCH_NODE = "latch";
+
+    public static final String CONNECTION_INFO_NODE = "connection_info";
 
     public static String getLeaderPathForResourceManager() {
         return getLeaderPath(RESOURCE_MANAGER_LEADER);
@@ -118,6 +132,10 @@ public class ZooKeeperUtils {
 
     public static String getLeaderPathForJobManager(JobID jobId) {
         return generateZookeeperPath(getLeaderPathForJob(jobId), LEADER_NODE);
+    }
+
+    public static String getSingleLeaderElectionPathForJobManager(JobID jobID) {
+        return getLeaderPath(jobID.toString());
     }
 
     @Nonnull
@@ -137,17 +155,37 @@ public class ZooKeeperUtils {
         return "/checkpoint_id_counter";
     }
 
+    public static String getLeaderPath() {
+        return generateZookeeperPath(LEADER_NODE);
+    }
+
+    public static String getDispatcherNode() {
+        return DISPATCHER_LEADER;
+    }
+
+    public static String getResourceManagerNode() {
+        return RESOURCE_MANAGER_LEADER;
+    }
+
+    public static String getRestServerNode() {
+        return REST_SERVER_LEADER;
+    }
+
+    public static String getLeaderLatchPath() {
+        return generateZookeeperPath(LEADER_LATCH_NODE);
+    }
+
     private static String getLeaderPath(String suffix) {
         return generateZookeeperPath(LEADER_NODE, suffix);
     }
 
     @Nonnull
     public static String generateConnectionInformationPath(String path) {
-        return generateZookeeperPath(path, "connection_info");
+        return generateZookeeperPath(path, CONNECTION_INFO_NODE);
     }
 
     public static String generateLeaderLatchPath(String path) {
-        return generateZookeeperPath(path, "latch");
+        return generateZookeeperPath(path, LEADER_LATCH_NODE);
     }
 
     /**
@@ -402,6 +440,87 @@ public class ZooKeeperUtils {
         return new ZooKeeperLeaderElectionDriverFactory(client, path);
     }
 
+    public static void writeLeaderInformationToZooKeeper(
+            LeaderInformation leaderInformation,
+            CuratorFramework curatorFramework,
+            BooleanSupplier hasLeadershipCheck,
+            String connectionInformationPath)
+            throws Exception {
+        final byte[] data;
+
+        if (leaderInformation.isEmpty()) {
+            data = null;
+        } else {
+            final ByteArrayOutputStream baos = new ByteArrayOutputStream();
+            final ObjectOutputStream oos = new ObjectOutputStream(baos);
+
+            oos.writeUTF(leaderInformation.getLeaderAddress());
+            oos.writeObject(leaderInformation.getLeaderSessionID());
+
+            oos.close();
+
+            data = baos.toByteArray();
+        }
+
+        boolean dataWritten = false;
+
+        while (!dataWritten && hasLeadershipCheck.getAsBoolean()) {
+            Stat stat = curatorFramework.checkExists().forPath(connectionInformationPath);
+
+            if (stat != null) {
+                long owner = stat.getEphemeralOwner();
+                long sessionID =
+                        curatorFramework.getZookeeperClient().getZooKeeper().getSessionId();
+
+                if (owner == sessionID) {
+                    try {
+                        curatorFramework.setData().forPath(connectionInformationPath, data);
+
+                        dataWritten = true;
+                    } catch (KeeperException.NoNodeException noNode) {
+                        // node was deleted in the meantime
+                    }
+                } else {
+                    try {
+                        curatorFramework.delete().forPath(connectionInformationPath);
+                    } catch (KeeperException.NoNodeException noNode) {
+                        // node was deleted in the meantime --> try again
+                    }
+                }
+            } else {
+                try {
+                    curatorFramework
+                            .create()
+                            .creatingParentsIfNeeded()
+                            .withMode(CreateMode.EPHEMERAL)
+                            .forPath(connectionInformationPath, data);
+
+                    dataWritten = true;
+                } catch (KeeperException.NodeExistsException nodeExists) {
+                    // node has been created in the meantime --> try again
+                }
+            }
+        }
+    }
+
+    public static LeaderInformation readLeaderInformation(byte[] data)
+            throws IOException, ClassNotFoundException {
+        if (data != null && data.length > 0) {
+            final ByteArrayInputStream bais = new ByteArrayInputStream(data);
+            final String leaderAddress;
+            final UUID leaderSessionID;
+
+            try (final ObjectInputStream ois = new ObjectInputStream(bais)) {
+                leaderAddress = ois.readUTF();
+                leaderSessionID = (UUID) ois.readObject();
+            }
+
+            return LeaderInformation.known(leaderSessionID, leaderAddress);
+        } else {
+            return LeaderInformation.empty();
+        }
+    }
+
     /**
      * Creates a {@link DefaultJobGraphStore} instance with {@link ZooKeeperStateHandleStore},
      * {@link ZooKeeperJobGraphStoreWatcher} and {@link ZooKeeperJobGraphStoreUtil}.
@@ -544,15 +663,25 @@ public class ZooKeeperUtils {
                 prefix);
     }
 
-    /** Creates a ZooKeeper path of the form "/root/child". */
-    public static String generateZookeeperPath(String root, String child) {
+    /** Creates a ZooKeeper path of the form "/a/b/.../z". */
+    public static String generateZookeeperPath(String... paths) {
         final String result =
-                Stream.of(root, child)
+                Arrays.stream(paths)
                         .map(ZooKeeperUtils::trimSlashes)
                         .filter(s -> !s.isEmpty())
                         .collect(Collectors.joining("/", "/", ""));
 
         return result;
+    }
+
+    /**
+     * Splits the given ZooKeeper path into its parts.
+     *
+     * @param path path to split
+     * @return splited path
+     */
+    public static String[] splitZooKeeperPath(String path) {
+        return path.split("/");
     }
 
     public static String trimStartingSlash(String path) {
@@ -697,6 +826,29 @@ public class ZooKeeperUtils {
                 String message = "Unsupported ACL option: [" + aclMode + "] provided";
                 LOG.error(message);
                 throw new IllegalConfigurationException(message);
+            }
+        }
+    }
+
+    public static void deleteZNode(CuratorFramework curatorFramework, String path)
+            throws Exception {
+        // Since we are using Curator version 2.12 there is a bug in deleting the children
+        // if there is a concurrent delete operation. Therefore we need to add this retry
+        // logic. See https://issues.apache.org/jira/browse/CURATOR-430 for more information.
+        // The retry logic can be removed once we upgrade to Curator version >= 4.0.1.
+        boolean zNodeDeleted = false;
+        while (!zNodeDeleted) {
+            Stat stat = curatorFramework.checkExists().forPath(path);
+            if (stat == null) {
+                LOG.debug("znode {} has been deleted", path);
+                return;
+            }
+            try {
+                curatorFramework.delete().deletingChildrenIfNeeded().forPath(path);
+                zNodeDeleted = true;
+            } catch (KeeperException.NoNodeException ignored) {
+                // concurrent delete operation. Try again.
+                LOG.debug("Retrying to delete znode because of other concurrent delete operation.");
             }
         }
     }

--- a/flink-runtime/src/test/java/org/apache/flink/runtime/leaderelection/DefaultMultipleComponentLeaderElectionServiceTest.java
+++ b/flink-runtime/src/test/java/org/apache/flink/runtime/leaderelection/DefaultMultipleComponentLeaderElectionServiceTest.java
@@ -1,0 +1,293 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.flink.runtime.leaderelection;
+
+import org.apache.flink.runtime.util.TestingFatalErrorHandlerExtension;
+import org.apache.flink.util.TestLoggerExtension;
+import org.apache.flink.util.concurrent.Executors;
+
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.junit.jupiter.api.extension.RegisterExtension;
+
+import javax.annotation.Nullable;
+
+import java.util.ArrayList;
+import java.util.Collection;
+import java.util.List;
+import java.util.UUID;
+import java.util.stream.Collectors;
+import java.util.stream.Stream;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+/** Tests for the {@link DefaultMultipleComponentLeaderElectionService}. */
+@ExtendWith(TestLoggerExtension.class)
+class DefaultMultipleComponentLeaderElectionServiceTest {
+
+    @RegisterExtension
+    public final TestingFatalErrorHandlerExtension fatalErrorHandlerExtension =
+            new TestingFatalErrorHandlerExtension();
+
+    @Test
+    public void isLeaderInformsAllRegisteredLeaderElectionEventHandlers() throws Exception {
+        final TestingMultipleComponentLeaderElectionDriver leaderElectionDriver =
+                TestingMultipleComponentLeaderElectionDriver.newBuilder().build();
+
+        final DefaultMultipleComponentLeaderElectionService leaderElectionService =
+                createDefaultMultiplexingLeaderElectionService(leaderElectionDriver);
+
+        try {
+            final Collection<SimpleTestingLeaderElectionEventListener> eventListeners =
+                    Stream.generate(SimpleTestingLeaderElectionEventListener::new)
+                            .limit(4)
+                            .collect(Collectors.toList());
+
+            int counter = 0;
+            for (SimpleTestingLeaderElectionEventListener eventListener : eventListeners) {
+                leaderElectionService.registerLeaderElectionEventHandler(
+                        String.valueOf(counter), eventListener);
+                counter++;
+            }
+
+            leaderElectionDriver.grantLeadership();
+
+            for (SimpleTestingLeaderElectionEventListener eventListener : eventListeners) {
+                assertThat(eventListener.hasLeadership()).isTrue();
+            }
+        } finally {
+            leaderElectionService.close();
+        }
+    }
+
+    private DefaultMultipleComponentLeaderElectionService
+            createDefaultMultiplexingLeaderElectionService(
+                    TestingMultipleComponentLeaderElectionDriver leaderElectionDriver)
+                    throws Exception {
+        return new DefaultMultipleComponentLeaderElectionService(
+                fatalErrorHandlerExtension.getTestingFatalErrorHandler(),
+                new TestingMultipleComponentLeaderElectionDriverFactory(leaderElectionDriver),
+                Executors.newDirectExecutorService());
+    }
+
+    @Test
+    public void notLeaderInformsAllRegisteredLeaderElectionEventHandlers() throws Exception {
+        final TestingMultipleComponentLeaderElectionDriver leaderElectionDriver =
+                TestingMultipleComponentLeaderElectionDriver.newBuilder().build();
+
+        final DefaultMultipleComponentLeaderElectionService leaderElectionService =
+                createDefaultMultiplexingLeaderElectionService(leaderElectionDriver);
+
+        try {
+            final Collection<SimpleTestingLeaderElectionEventListener> eventListeners =
+                    Stream.generate(SimpleTestingLeaderElectionEventListener::new)
+                            .limit(4)
+                            .collect(Collectors.toList());
+
+            int counter = 0;
+            for (SimpleTestingLeaderElectionEventListener eventListener : eventListeners) {
+                leaderElectionService.registerLeaderElectionEventHandler(
+                        String.valueOf(counter), eventListener);
+                counter++;
+            }
+
+            leaderElectionDriver.grantLeadership();
+            leaderElectionDriver.revokeLeadership();
+
+            for (SimpleTestingLeaderElectionEventListener eventListener : eventListeners) {
+                assertThat(eventListener.hasLeadership()).isFalse();
+            }
+        } finally {
+            leaderElectionService.close();
+        }
+    }
+
+    @Test
+    public void unregisteredEventHandlersAreNotNotified() throws Exception {
+        final TestingMultipleComponentLeaderElectionDriver leaderElectionDriver =
+                TestingMultipleComponentLeaderElectionDriver.newBuilder().build();
+
+        final DefaultMultipleComponentLeaderElectionService leaderElectionService =
+                createDefaultMultiplexingLeaderElectionService(leaderElectionDriver);
+
+        try {
+            final SimpleTestingLeaderElectionEventListener leaderElectionEventHandler =
+                    new SimpleTestingLeaderElectionEventListener();
+            final String componentId = "foobar";
+            leaderElectionService.registerLeaderElectionEventHandler(
+                    componentId, leaderElectionEventHandler);
+            leaderElectionService.unregisterLeaderElectionEventHandler(componentId);
+
+            leaderElectionDriver.grantLeadership();
+
+            assertThat(leaderElectionEventHandler.hasLeadership()).isFalse();
+        } finally {
+            leaderElectionService.close();
+        }
+    }
+
+    @Test
+    public void newlyRegisteredEventHandlersAreInformedAboutLeadership() throws Exception {
+        final TestingMultipleComponentLeaderElectionDriver leaderElectionDriver =
+                TestingMultipleComponentLeaderElectionDriver.newBuilder().build();
+        final DefaultMultipleComponentLeaderElectionService leaderElectionService =
+                createDefaultMultiplexingLeaderElectionService(leaderElectionDriver);
+
+        try {
+            leaderElectionDriver.grantLeadership();
+
+            final SimpleTestingLeaderElectionEventListener leaderElectionEventHandler =
+                    new SimpleTestingLeaderElectionEventListener();
+            leaderElectionService.registerLeaderElectionEventHandler(
+                    "foobar", leaderElectionEventHandler);
+
+            assertThat(leaderElectionEventHandler.hasLeadership()).isTrue();
+        } finally {
+            leaderElectionService.close();
+        }
+    }
+
+    @Test
+    public void allKnownLeaderInformationCallsEventHandlers() throws Exception {
+        final TestingMultipleComponentLeaderElectionDriver leaderElectionDriver =
+                TestingMultipleComponentLeaderElectionDriver.newBuilder().build();
+        final DefaultMultipleComponentLeaderElectionService leaderElectionService =
+                createDefaultMultiplexingLeaderElectionService(leaderElectionDriver);
+
+        try {
+            leaderElectionDriver.grantLeadership();
+
+            final Collection<Component> knownLeaderInformation = createComponents(3);
+            final Collection<Component> unknownLeaderInformation = createComponents(2);
+
+            registerLeaderElectionEventHandler(leaderElectionService, knownLeaderInformation);
+            registerLeaderElectionEventHandler(leaderElectionService, unknownLeaderInformation);
+
+            leaderElectionService.notifyAllKnownLeaderInformation(
+                    knownLeaderInformation.stream()
+                            .map(
+                                    component ->
+                                            LeaderInformationWithComponentId.create(
+                                                    component.getComponentId(),
+                                                    component.getLeaderInformation()))
+                            .collect(Collectors.toList()));
+
+            for (Component component : knownLeaderInformation) {
+                assertThat(component.getLeaderElectionEventListener().getLeaderInformation())
+                        .isEqualTo(component.getLeaderInformation());
+            }
+
+            for (Component component : unknownLeaderInformation) {
+                assertThat(component.getLeaderElectionEventListener().getLeaderInformation())
+                        .isEqualTo(LeaderInformation.empty());
+            }
+
+        } finally {
+            leaderElectionService.close();
+        }
+    }
+
+    private void registerLeaderElectionEventHandler(
+            DefaultMultipleComponentLeaderElectionService leaderElectionService,
+            Collection<Component> knownLeaderInformation) {
+        for (Component component : knownLeaderInformation) {
+            leaderElectionService.registerLeaderElectionEventHandler(
+                    component.getComponentId(), component.getLeaderElectionEventListener());
+        }
+    }
+
+    private Collection<Component> createComponents(int numberComponents) {
+        final List<Component> result = new ArrayList<>();
+
+        for (int i = 0; i < numberComponents; i++) {
+            result.add(
+                    new Component(
+                            UUID.randomUUID().toString(),
+                            new SimpleTestingLeaderElectionEventListener(),
+                            LeaderInformation.known(UUID.randomUUID(), "localhost")));
+        }
+
+        return result;
+    }
+
+    private static final class Component {
+        private final String componentId;
+        private final SimpleTestingLeaderElectionEventListener leaderElectionEventListener;
+        private final LeaderInformation leaderInformation;
+
+        private Component(
+                String componentId,
+                SimpleTestingLeaderElectionEventListener leaderElectionEventListener,
+                LeaderInformation leaderInformation) {
+            this.componentId = componentId;
+            this.leaderElectionEventListener = leaderElectionEventListener;
+            this.leaderInformation = leaderInformation;
+        }
+
+        String getComponentId() {
+            return componentId;
+        }
+
+        LeaderInformation getLeaderInformation() {
+            return leaderInformation;
+        }
+
+        SimpleTestingLeaderElectionEventListener getLeaderElectionEventListener() {
+            return leaderElectionEventListener;
+        }
+    }
+
+    private static final class SimpleTestingLeaderElectionEventListener
+            implements LeaderElectionEventHandler {
+
+        private boolean hasLeadership;
+
+        @Nullable private LeaderInformation leaderInformation;
+
+        SimpleTestingLeaderElectionEventListener() {
+            hasLeadership = false;
+            leaderInformation = null;
+        }
+
+        public boolean hasLeadership() {
+            return hasLeadership;
+        }
+
+        @Override
+        public void onGrantLeadership(UUID newLeaderSessionId) {
+            hasLeadership = true;
+        }
+
+        @Override
+        public void onRevokeLeadership() {
+            hasLeadership = false;
+            leaderInformation = null;
+        }
+
+        @Override
+        public void onLeaderInformationChange(LeaderInformation leaderInformation) {
+            this.leaderInformation = leaderInformation;
+        }
+
+        @Nullable
+        LeaderInformation getLeaderInformation() {
+            return leaderInformation;
+        }
+    }
+}

--- a/flink-runtime/src/test/java/org/apache/flink/runtime/leaderelection/LeaderElectionEvent.java
+++ b/flink-runtime/src/test/java/org/apache/flink/runtime/leaderelection/LeaderElectionEvent.java
@@ -1,0 +1,104 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.flink.runtime.leaderelection;
+
+import java.util.Collection;
+
+/** Leader election event. */
+public abstract class LeaderElectionEvent {
+    public boolean isIsLeaderEvent() {
+        return false;
+    }
+
+    public boolean isNotLeaderEvent() {
+        return false;
+    }
+
+    public boolean isLeaderInformationChangeEvent() {
+        return false;
+    }
+
+    public boolean isAllKnownLeaderInformationEvent() {
+        return false;
+    }
+
+    public IsLeaderEvent asIsLeaderEvent() {
+        return as(IsLeaderEvent.class);
+    }
+
+    public <T> T as(Class<T> clazz) {
+        if (clazz.isAssignableFrom(getClass())) {
+            return clazz.cast(this);
+        } else {
+            throw new IllegalStateException("Cannot cast object.");
+        }
+    }
+
+    public static class IsLeaderEvent extends LeaderElectionEvent {
+        @Override
+        public boolean isIsLeaderEvent() {
+            return true;
+        }
+    }
+
+    public static class NotLeaderEvent extends LeaderElectionEvent {
+        @Override
+        public boolean isNotLeaderEvent() {
+            return true;
+        }
+    }
+
+    public static class LeaderInformationChangeEvent extends LeaderElectionEvent {
+        private final String componentId;
+        private final LeaderInformation leaderInformation;
+
+        LeaderInformationChangeEvent(String componentId, LeaderInformation leaderInformation) {
+            this.componentId = componentId;
+            this.leaderInformation = leaderInformation;
+        }
+
+        public LeaderInformation getLeaderInformation() {
+            return leaderInformation;
+        }
+
+        public String getComponentId() {
+            return componentId;
+        }
+
+        @Override
+        public boolean isLeaderInformationChangeEvent() {
+            return true;
+        }
+    }
+
+    public static class AllKnownLeaderInformationEvent extends LeaderElectionEvent {
+        private final Collection<LeaderInformationWithComponentId>
+                leaderInformationWithComponentIds;
+
+        AllKnownLeaderInformationEvent(
+                Collection<LeaderInformationWithComponentId> leaderInformationWithComponentIds) {
+            this.leaderInformationWithComponentIds = leaderInformationWithComponentIds;
+        }
+
+        @Override
+        public boolean isAllKnownLeaderInformationEvent() {
+            return true;
+        }
+    }
+}

--- a/flink-runtime/src/test/java/org/apache/flink/runtime/leaderelection/LeaderElectionEvent.java
+++ b/flink-runtime/src/test/java/org/apache/flink/runtime/leaderelection/LeaderElectionEvent.java
@@ -100,5 +100,9 @@ public abstract class LeaderElectionEvent {
         public boolean isAllKnownLeaderInformationEvent() {
             return true;
         }
+
+        public Collection<LeaderInformationWithComponentId> getLeaderInformationWithComponentIds() {
+            return leaderInformationWithComponentIds;
+        }
     }
 }

--- a/flink-runtime/src/test/java/org/apache/flink/runtime/leaderelection/TestingLeaderElectionDriver.java
+++ b/flink-runtime/src/test/java/org/apache/flink/runtime/leaderelection/TestingLeaderElectionDriver.java
@@ -22,6 +22,7 @@ import org.apache.flink.runtime.rpc.FatalErrorHandler;
 
 import javax.annotation.Nullable;
 
+import java.util.UUID;
 import java.util.concurrent.atomic.AtomicBoolean;
 
 /**
@@ -71,7 +72,7 @@ public class TestingLeaderElectionDriver implements LeaderElectionDriver {
     public void isLeader() {
         synchronized (lock) {
             isLeader.set(true);
-            leaderElectionEventHandler.onGrantLeadership();
+            leaderElectionEventHandler.onGrantLeadership(UUID.randomUUID());
         }
     }
 

--- a/flink-runtime/src/test/java/org/apache/flink/runtime/leaderelection/TestingLeaderElectionListener.java
+++ b/flink-runtime/src/test/java/org/apache/flink/runtime/leaderelection/TestingLeaderElectionListener.java
@@ -1,0 +1,108 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.flink.runtime.leaderelection;
+
+import org.apache.flink.api.common.time.Deadline;
+import org.apache.flink.util.ExceptionUtils;
+
+import java.time.Duration;
+import java.util.Collection;
+import java.util.Optional;
+import java.util.concurrent.ArrayBlockingQueue;
+import java.util.concurrent.BlockingQueue;
+import java.util.concurrent.TimeUnit;
+
+/**
+ * Simple {@link MultipleComponentLeaderElectionDriver.Listener} implementation for testing
+ * purposes.
+ */
+public final class TestingLeaderElectionListener
+        implements MultipleComponentLeaderElectionDriver.Listener {
+    private final BlockingQueue<LeaderElectionEvent> leaderElectionEvents =
+            new ArrayBlockingQueue<>(10);
+
+    @Override
+    public void isLeader() {
+        put(new LeaderElectionEvent.IsLeaderEvent());
+    }
+
+    @Override
+    public void notLeader() {
+        put(new LeaderElectionEvent.NotLeaderEvent());
+    }
+
+    @Override
+    public void notifyLeaderInformationChange(
+            String componentId, LeaderInformation leaderInformation) {
+        put(new LeaderElectionEvent.LeaderInformationChangeEvent(componentId, leaderInformation));
+    }
+
+    @Override
+    public void notifyAllKnownLeaderInformation(
+            Collection<LeaderInformationWithComponentId> leaderInformationWithComponentIds) {
+        put(
+                new LeaderElectionEvent.AllKnownLeaderInformationEvent(
+                        leaderInformationWithComponentIds));
+    }
+
+    private void put(LeaderElectionEvent leaderElectionEvent) {
+        try {
+            leaderElectionEvents.put(leaderElectionEvent);
+        } catch (InterruptedException e) {
+            ExceptionUtils.rethrow(e);
+        }
+    }
+
+    public <T> T await(Class<T> clazz) throws InterruptedException {
+        while (true) {
+            final LeaderElectionEvent leaderElectionEvent = leaderElectionEvents.take();
+
+            if (clazz.isAssignableFrom(leaderElectionEvent.getClass())) {
+                return clazz.cast(leaderElectionEvent);
+            }
+        }
+    }
+
+    public <T> Optional<T> await(Class<T> clazz, Duration timeout) throws InterruptedException {
+        final Deadline deadline = Deadline.fromNow(timeout);
+
+        while (true) {
+            final Duration timeLeft = deadline.timeLeft();
+
+            if (timeLeft.isNegative()) {
+                return Optional.empty();
+            } else {
+                final Optional<LeaderElectionEvent> optLeaderElectionEvent =
+                        Optional.ofNullable(
+                                leaderElectionEvents.poll(
+                                        timeLeft.toMillis(), TimeUnit.MILLISECONDS));
+
+                if (optLeaderElectionEvent.isPresent()) {
+                    final LeaderElectionEvent leaderElectionEvent = optLeaderElectionEvent.get();
+
+                    if (clazz.isAssignableFrom(leaderElectionEvent.getClass())) {
+                        return Optional.of(clazz.cast(optLeaderElectionEvent));
+                    }
+                } else {
+                    return Optional.empty();
+                }
+            }
+        }
+    }
+}

--- a/flink-runtime/src/test/java/org/apache/flink/runtime/leaderelection/TestingMultipleComponentLeaderElectionDriver.java
+++ b/flink-runtime/src/test/java/org/apache/flink/runtime/leaderelection/TestingMultipleComponentLeaderElectionDriver.java
@@ -1,0 +1,113 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.flink.runtime.leaderelection;
+
+import org.apache.flink.util.Preconditions;
+import org.apache.flink.util.function.BiConsumerWithException;
+import org.apache.flink.util.function.ThrowingConsumer;
+
+import java.util.Optional;
+
+/** Testing implementation of {@link MultipleComponentLeaderElectionDriver}. */
+public class TestingMultipleComponentLeaderElectionDriver
+        implements MultipleComponentLeaderElectionDriver {
+
+    private final BiConsumerWithException<String, LeaderInformation, Exception>
+            publishLeaderInformationConsumer;
+    private final ThrowingConsumer<String, Exception> deleteLeaderInformationConsumer;
+    private boolean hasLeadership;
+
+    private Optional<Listener> listener;
+
+    private TestingMultipleComponentLeaderElectionDriver(
+            BiConsumerWithException<String, LeaderInformation, Exception>
+                    publishLeaderInformationConsumer,
+            ThrowingConsumer<String, Exception> deleteLeaderInformationConsumer) {
+        this.publishLeaderInformationConsumer = publishLeaderInformationConsumer;
+        this.deleteLeaderInformationConsumer = deleteLeaderInformationConsumer;
+        hasLeadership = false;
+        listener = Optional.empty();
+    }
+
+    public void grantLeadership() {
+        if (!hasLeadership) {
+            hasLeadership = true;
+            listener.ifPresent(Listener::isLeader);
+        }
+    }
+
+    public void revokeLeadership() {
+        if (hasLeadership) {
+            hasLeadership = false;
+            listener.ifPresent(Listener::notLeader);
+        }
+    }
+
+    public void setListener(Listener listener) {
+        Preconditions.checkState(!this.listener.isPresent(), "Can only set a single listener.");
+        this.listener = Optional.of(listener);
+    }
+
+    @Override
+    public void close() throws Exception {}
+
+    @Override
+    public boolean hasLeadership() {
+        return hasLeadership;
+    }
+
+    @Override
+    public void publishLeaderInformation(String componentId, LeaderInformation leaderInformation)
+            throws Exception {
+        publishLeaderInformationConsumer.accept(componentId, leaderInformation);
+    }
+
+    @Override
+    public void deleteLeaderInformation(String componentId) throws Exception {
+        deleteLeaderInformationConsumer.accept(componentId);
+    }
+
+    public static Builder newBuilder() {
+        return new Builder();
+    }
+
+    public static final class Builder {
+        private BiConsumerWithException<String, LeaderInformation, Exception>
+                publishLeaderInformationConsumer = (ignoredA, ignoredB) -> {};
+        private ThrowingConsumer<String, Exception> deleteLeaderInformationConsumer = ignored -> {};
+
+        public Builder setPublishLeaderInformationConsumer(
+                BiConsumerWithException<String, LeaderInformation, Exception>
+                        publishLeaderInformationConsumer) {
+            this.publishLeaderInformationConsumer = publishLeaderInformationConsumer;
+            return this;
+        }
+
+        public Builder setDeleteLeaderInformationConsumer(
+                ThrowingConsumer<String, Exception> deleteLeaderInformationConsumer) {
+            this.deleteLeaderInformationConsumer = deleteLeaderInformationConsumer;
+            return this;
+        }
+
+        public TestingMultipleComponentLeaderElectionDriver build() {
+            return new TestingMultipleComponentLeaderElectionDriver(
+                    publishLeaderInformationConsumer, deleteLeaderInformationConsumer);
+        }
+    }
+}

--- a/flink-runtime/src/test/java/org/apache/flink/runtime/leaderelection/TestingMultipleComponentLeaderElectionDriverFactory.java
+++ b/flink-runtime/src/test/java/org/apache/flink/runtime/leaderelection/TestingMultipleComponentLeaderElectionDriverFactory.java
@@ -1,0 +1,45 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.flink.runtime.leaderelection;
+
+/**
+ * Testing implementation of {@link MultipleComponentLeaderElectionDriverFactory} that returns a
+ * given {@link MultipleComponentLeaderElectionDriver}.
+ */
+public class TestingMultipleComponentLeaderElectionDriverFactory
+        implements MultipleComponentLeaderElectionDriverFactory {
+
+    final TestingMultipleComponentLeaderElectionDriver testingMultipleComponentLeaderElectionDriver;
+
+    public TestingMultipleComponentLeaderElectionDriverFactory(
+            TestingMultipleComponentLeaderElectionDriver
+                    testingMultipleComponentLeaderElectionDriver) {
+        this.testingMultipleComponentLeaderElectionDriver =
+                testingMultipleComponentLeaderElectionDriver;
+    }
+
+    @Override
+    public MultipleComponentLeaderElectionDriver create(
+            MultipleComponentLeaderElectionDriver.Listener leaderElectionListener)
+            throws Exception {
+        testingMultipleComponentLeaderElectionDriver.setListener(leaderElectionListener);
+
+        return testingMultipleComponentLeaderElectionDriver;
+    }
+}

--- a/flink-runtime/src/test/java/org/apache/flink/runtime/leaderelection/ZooKeeperLeaderElectionTest.java
+++ b/flink-runtime/src/test/java/org/apache/flink/runtime/leaderelection/ZooKeeperLeaderElectionTest.java
@@ -102,9 +102,7 @@ public class ZooKeeperLeaderElectionTest extends TestLogger {
 
     private CuratorFrameworkWithUnhandledErrorListener curatorFrameworkWrapper;
 
-    private static final String TEST_URL = "akka//user/jobmanager";
-    private static final LeaderInformation TEST_LEADER =
-            LeaderInformation.known(UUID.randomUUID(), TEST_URL);
+    private static final String LEADER_ADDRESS = "akka//user/jobmanager";
     private static final long timeout = 200L * 1000L;
 
     private static final Logger LOG = LoggerFactory.getLogger(ZooKeeperLeaderElectionTest.class);
@@ -150,7 +148,7 @@ public class ZooKeeperLeaderElectionTest extends TestLogger {
     public void testZooKeeperLeaderElectionRetrieval() throws Exception {
 
         final TestingLeaderElectionEventHandler electionEventHandler =
-                new TestingLeaderElectionEventHandler(TEST_LEADER);
+                new TestingLeaderElectionEventHandler(LEADER_ADDRESS);
         final TestingLeaderRetrievalEventHandler retrievalEventHandler =
                 new TestingLeaderRetrievalEventHandler();
         LeaderElectionDriver leaderElectionDriver = null;
@@ -167,14 +165,18 @@ public class ZooKeeperLeaderElectionTest extends TestLogger {
                                     retrievalEventHandler, retrievalEventHandler::handleError);
 
             electionEventHandler.waitForLeader(timeout);
-            assertThat(electionEventHandler.getConfirmedLeaderInformation(), is(TEST_LEADER));
+            final LeaderInformation confirmedLeaderInformation =
+                    electionEventHandler.getConfirmedLeaderInformation();
+            assertThat(confirmedLeaderInformation.getLeaderAddress(), is(LEADER_ADDRESS));
 
             retrievalEventHandler.waitForNewLeader(timeout);
 
             assertThat(
                     retrievalEventHandler.getLeaderSessionID(),
-                    is(TEST_LEADER.getLeaderSessionID()));
-            assertThat(retrievalEventHandler.getAddress(), is(TEST_LEADER.getLeaderAddress()));
+                    is(confirmedLeaderInformation.getLeaderSessionID()));
+            assertThat(
+                    retrievalEventHandler.getAddress(),
+                    is(confirmedLeaderInformation.getLeaderAddress()));
         } finally {
             electionEventHandler.close();
             if (leaderElectionDriver != null) {
@@ -224,7 +226,7 @@ public class ZooKeeperLeaderElectionTest extends TestLogger {
                 leaderElectionService[i].start(contenders[i]);
             }
 
-            String pattern = TEST_URL + "_" + "(\\d+)";
+            String pattern = LEADER_ADDRESS + "_" + "(\\d+)";
             Pattern regex = Pattern.compile(pattern);
 
             int numberSeenLeaders = 0;
@@ -276,7 +278,7 @@ public class ZooKeeperLeaderElectionTest extends TestLogger {
 
     @Nonnull
     private String createAddress(int i) {
-        return TEST_URL + "_" + i;
+        return LEADER_ADDRESS + "_" + i;
     }
 
     /**
@@ -308,12 +310,13 @@ public class ZooKeeperLeaderElectionTest extends TestLogger {
                         ZooKeeperUtils.createLeaderElectionService(
                                 curatorFrameworkWrapper.asCuratorFramework());
                 contenders[i] =
-                        new TestingContender(TEST_URL + "_" + i + "_0", leaderElectionService[i]);
+                        new TestingContender(
+                                LEADER_ADDRESS + "_" + i + "_0", leaderElectionService[i]);
 
                 leaderElectionService[i].start(contenders[i]);
             }
 
-            String pattern = TEST_URL + "_" + "(\\d+)" + "_" + "(\\d+)";
+            String pattern = LEADER_ADDRESS + "_" + "(\\d+)" + "_" + "(\\d+)";
             Pattern regex = Pattern.compile(pattern);
 
             for (int i = 0; i < numTries; i++) {
@@ -338,7 +341,7 @@ public class ZooKeeperLeaderElectionTest extends TestLogger {
                                     curatorFrameworkWrapper.asCuratorFramework());
                     contenders[index] =
                             new TestingContender(
-                                    TEST_URL + "_" + index + "_" + (lastTry + 1),
+                                    LEADER_ADDRESS + "_" + index + "_" + (lastTry + 1),
                                     leaderElectionService[index]);
 
                     leaderElectionService[index].start(contenders[index]);
@@ -370,7 +373,7 @@ public class ZooKeeperLeaderElectionTest extends TestLogger {
         final String faultyContenderUrl = "faultyContender";
 
         final TestingLeaderElectionEventHandler electionEventHandler =
-                new TestingLeaderElectionEventHandler(TEST_LEADER);
+                new TestingLeaderElectionEventHandler(LEADER_ADDRESS);
         final TestingLeaderRetrievalEventHandler retrievalEventHandler =
                 new TestingLeaderRetrievalEventHandler();
 
@@ -386,7 +389,9 @@ public class ZooKeeperLeaderElectionTest extends TestLogger {
                             curatorFrameworkWrapper.asCuratorFramework(), electionEventHandler);
 
             electionEventHandler.waitForLeader(timeout);
-            assertThat(electionEventHandler.getConfirmedLeaderInformation(), is(TEST_LEADER));
+            final LeaderInformation confirmedLeaderInformation =
+                    electionEventHandler.getConfirmedLeaderInformation();
+            assertThat(confirmedLeaderInformation.getLeaderAddress(), is(LEADER_ADDRESS));
 
             anotherCuratorFrameworkWrapper =
                     ZooKeeperUtils.startCuratorFramework(
@@ -437,8 +442,10 @@ public class ZooKeeperLeaderElectionTest extends TestLogger {
 
             assertThat(
                     retrievalEventHandler.getLeaderSessionID(),
-                    is(TEST_LEADER.getLeaderSessionID()));
-            assertThat(retrievalEventHandler.getAddress(), is(TEST_LEADER.getLeaderAddress()));
+                    is(confirmedLeaderInformation.getLeaderSessionID()));
+            assertThat(
+                    retrievalEventHandler.getAddress(),
+                    is(confirmedLeaderInformation.getLeaderAddress()));
         } finally {
             electionEventHandler.close();
             if (leaderElectionDriver != null) {
@@ -461,7 +468,7 @@ public class ZooKeeperLeaderElectionTest extends TestLogger {
     public void testExceptionForwarding() throws Exception {
         LeaderElectionDriver leaderElectionDriver = null;
         final TestingLeaderElectionEventHandler electionEventHandler =
-                new TestingLeaderElectionEventHandler(TEST_LEADER);
+                new TestingLeaderElectionEventHandler(LEADER_ADDRESS);
 
         CuratorFramework client = null;
         final CreateBuilder mockCreateBuilder =
@@ -513,7 +520,7 @@ public class ZooKeeperLeaderElectionTest extends TestLogger {
         ZooKeeperLeaderElectionDriver leaderElectionDriver = null;
         LeaderRetrievalDriver leaderRetrievalDriver = null;
         final TestingLeaderElectionEventHandler electionEventHandler =
-                new TestingLeaderElectionEventHandler(TEST_LEADER);
+                new TestingLeaderElectionEventHandler(LEADER_ADDRESS);
         final TestingLeaderRetrievalEventHandler retrievalEventHandler =
                 new TestingLeaderRetrievalEventHandler();
 
@@ -598,7 +605,7 @@ public class ZooKeeperLeaderElectionTest extends TestLogger {
     public void testNotLeaderShouldNotCleanUpTheLeaderInformation() throws Exception {
 
         final TestingLeaderElectionEventHandler electionEventHandler =
-                new TestingLeaderElectionEventHandler(TEST_LEADER);
+                new TestingLeaderElectionEventHandler(LEADER_ADDRESS);
         final TestingLeaderRetrievalEventHandler retrievalEventHandler =
                 new TestingLeaderRetrievalEventHandler();
         ZooKeeperLeaderElectionDriver leaderElectionDriver = null;
@@ -610,7 +617,9 @@ public class ZooKeeperLeaderElectionTest extends TestLogger {
                             curatorFrameworkWrapper.asCuratorFramework(), electionEventHandler);
 
             electionEventHandler.waitForLeader(timeout);
-            assertThat(electionEventHandler.getConfirmedLeaderInformation(), is(TEST_LEADER));
+            final LeaderInformation confirmedLeaderInformation =
+                    electionEventHandler.getConfirmedLeaderInformation();
+            assertThat(confirmedLeaderInformation.getLeaderAddress(), is(LEADER_ADDRESS));
 
             // Leader is revoked
             leaderElectionDriver.notLeader();
@@ -629,8 +638,10 @@ public class ZooKeeperLeaderElectionTest extends TestLogger {
 
             assertThat(
                     retrievalEventHandler.getLeaderSessionID(),
-                    is(TEST_LEADER.getLeaderSessionID()));
-            assertThat(retrievalEventHandler.getAddress(), is(TEST_LEADER.getLeaderAddress()));
+                    is(confirmedLeaderInformation.getLeaderSessionID()));
+            assertThat(
+                    retrievalEventHandler.getAddress(),
+                    is(confirmedLeaderInformation.getLeaderAddress()));
         } finally {
             electionEventHandler.close();
             if (leaderElectionDriver != null) {
@@ -650,7 +661,7 @@ public class ZooKeeperLeaderElectionTest extends TestLogger {
     public void testUnExpectedErrorForwarding() throws Exception {
         LeaderElectionDriver leaderElectionDriver = null;
         final TestingLeaderElectionEventHandler electionEventHandler =
-                new TestingLeaderElectionEventHandler(TEST_LEADER);
+                new TestingLeaderElectionEventHandler(LEADER_ADDRESS);
 
         final TestingFatalErrorHandler fatalErrorHandler = new TestingFatalErrorHandler();
         final FlinkRuntimeException testException =
@@ -749,7 +760,9 @@ public class ZooKeeperLeaderElectionTest extends TestLogger {
         final ZooKeeperLeaderElectionDriver leaderElectionDriver =
                 ZooKeeperUtils.createLeaderElectionDriverFactory(client)
                         .createLeaderElectionDriver(
-                                electionEventHandler, electionEventHandler::handleError, TEST_URL);
+                                electionEventHandler,
+                                electionEventHandler::handleError,
+                                LEADER_ADDRESS);
         electionEventHandler.init(leaderElectionDriver);
         return leaderElectionDriver;
     }

--- a/flink-runtime/src/test/java/org/apache/flink/runtime/leaderelection/ZooKeeperMultipleComponentLeaderElectionDriverTest.java
+++ b/flink-runtime/src/test/java/org/apache/flink/runtime/leaderelection/ZooKeeperMultipleComponentLeaderElectionDriverTest.java
@@ -1,0 +1,591 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.flink.runtime.leaderelection;
+
+import org.apache.flink.api.common.time.Deadline;
+import org.apache.flink.configuration.Configuration;
+import org.apache.flink.configuration.HighAvailabilityOptions;
+import org.apache.flink.core.testutils.EachCallbackWrapper;
+import org.apache.flink.runtime.highavailability.zookeeper.CuratorFrameworkWithUnhandledErrorListener;
+import org.apache.flink.runtime.leaderretrieval.DefaultLeaderRetrievalService;
+import org.apache.flink.runtime.leaderretrieval.ZooKeeperLeaderRetrievalDriver;
+import org.apache.flink.runtime.leaderretrieval.ZooKeeperLeaderRetrievalDriverFactory;
+import org.apache.flink.runtime.rest.util.NoOpFatalErrorHandler;
+import org.apache.flink.runtime.util.ZooKeeperUtils;
+import org.apache.flink.runtime.zookeeper.ZooKeeperExtension;
+import org.apache.flink.util.ExceptionUtils;
+import org.apache.flink.util.TestLoggerExtension;
+import org.apache.flink.util.function.RunnableWithException;
+
+import org.apache.flink.shaded.curator4.com.google.common.collect.Iterables;
+import org.apache.flink.shaded.curator4.org.apache.curator.framework.CuratorFramework;
+
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.junit.jupiter.api.extension.RegisterExtension;
+
+import java.time.Duration;
+import java.util.Collection;
+import java.util.Map;
+import java.util.Optional;
+import java.util.Set;
+import java.util.UUID;
+import java.util.concurrent.ArrayBlockingQueue;
+import java.util.concurrent.BlockingQueue;
+import java.util.concurrent.CompletableFuture;
+import java.util.concurrent.TimeUnit;
+import java.util.stream.Collectors;
+import java.util.stream.Stream;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+/** Tests for the {@link ZooKeeperMultipleComponentLeaderElectionDriver}. */
+@ExtendWith(TestLoggerExtension.class)
+class ZooKeeperMultipleComponentLeaderElectionDriverTest {
+
+    private final ZooKeeperExtension zooKeeperExtension = new ZooKeeperExtension();
+
+    @RegisterExtension
+    private final EachCallbackWrapper<ZooKeeperExtension> eachWrapper =
+            new EachCallbackWrapper<>(zooKeeperExtension);
+
+    @Test
+    public void testElectionDriverGainsLeadershipAtStartup() throws Exception {
+        new Context() {
+            {
+                runTest(() -> leaderElectionListener.await(IsLeaderEvent.class));
+            }
+        };
+    }
+
+    @Test
+    public void testElectionDriverLosesLeadership() throws Exception {
+        new Context() {
+            {
+                runTest(
+                        () -> {
+                            leaderElectionListener.await(IsLeaderEvent.class);
+                            zooKeeperExtension.stop();
+                            leaderElectionListener.await(NotLeaderEvent.class);
+                        });
+            }
+        };
+    }
+
+    @Test
+    public void testPublishLeaderInformation() throws Exception {
+        new Context() {
+            {
+                runTest(
+                        () -> {
+                            leaderElectionListener.await(IsLeaderEvent.class);
+
+                            final String componentId = "retrieved-component";
+                            final DefaultLeaderRetrievalService defaultLeaderRetrievalService =
+                                    new DefaultLeaderRetrievalService(
+                                            new ZooKeeperLeaderRetrievalDriverFactory(
+                                                    curatorFramework.asCuratorFramework(),
+                                                    componentId,
+                                                    ZooKeeperLeaderRetrievalDriver
+                                                            .LeaderInformationClearancePolicy
+                                                            .ON_LOST_CONNECTION));
+
+                            final TestingListener leaderRetrievalListener = new TestingListener();
+                            defaultLeaderRetrievalService.start(leaderRetrievalListener);
+
+                            final LeaderInformation leaderInformation =
+                                    LeaderInformation.known(UUID.randomUUID(), "foobar");
+                            leaderElectionDriver.publishLeaderInformation(
+                                    componentId, leaderInformation);
+
+                            leaderRetrievalListener.waitForNewLeader(10_000L);
+
+                            assertThat(leaderRetrievalListener.getLeader())
+                                    .isEqualTo(leaderInformation);
+                        });
+            }
+        };
+    }
+
+    @Test
+    public void testPublishEmptyLeaderInformation() throws Exception {
+        new Context() {
+            {
+                runTest(
+                        () -> {
+                            leaderElectionListener.await(IsLeaderEvent.class);
+
+                            final String componentId = "retrieved-component";
+                            final DefaultLeaderRetrievalService defaultLeaderRetrievalService =
+                                    new DefaultLeaderRetrievalService(
+                                            new ZooKeeperLeaderRetrievalDriverFactory(
+                                                    curatorFramework.asCuratorFramework(),
+                                                    componentId,
+                                                    ZooKeeperLeaderRetrievalDriver
+                                                            .LeaderInformationClearancePolicy
+                                                            .ON_LOST_CONNECTION));
+
+                            final TestingListener leaderRetrievalListener = new TestingListener();
+                            defaultLeaderRetrievalService.start(leaderRetrievalListener);
+
+                            leaderElectionDriver.publishLeaderInformation(
+                                    componentId,
+                                    LeaderInformation.known(UUID.randomUUID(), "foobar"));
+
+                            leaderRetrievalListener.waitForNewLeader(10_000L);
+
+                            leaderElectionDriver.publishLeaderInformation(
+                                    componentId, LeaderInformation.empty());
+
+                            leaderRetrievalListener.waitForEmptyLeaderInformation(10_000L);
+
+                            assertThat(leaderRetrievalListener.getLeader())
+                                    .isEqualTo(LeaderInformation.empty());
+                        });
+            }
+        };
+    }
+
+    @Test
+    public void testNonLeaderCannotPublishLeaderInformation() throws Exception {
+        new Context() {
+            {
+                runTest(
+                        () -> {
+                            ElectionDriver otherLeaderElectionDriver = null;
+                            try {
+                                leaderElectionListener.await(IsLeaderEvent.class);
+
+                                otherLeaderElectionDriver =
+                                        createLeaderElectionDriver(
+                                                curatorFramework.asCuratorFramework());
+
+                                assertThat(otherLeaderElectionDriver.hasLeadership()).isFalse();
+
+                                otherLeaderElectionDriver.publishLeaderInformation(
+                                        "componentId",
+                                        LeaderInformation.known(UUID.randomUUID(), "localhost"));
+
+                                assertThat(
+                                                leaderElectionListener.await(
+                                                        LeaderInformationChangeEvent.class,
+                                                        Duration.ofMillis(50L)))
+                                        .isEmpty();
+                            } finally {
+                                if (otherLeaderElectionDriver != null) {
+                                    otherLeaderElectionDriver.close();
+                                }
+                            }
+                        });
+            }
+        };
+    }
+
+    @Test
+    public void testLeaderInformationChange() throws Exception {
+        new Context() {
+            {
+                runTest(
+                        () -> {
+                            leaderElectionListener.await(IsLeaderEvent.class);
+
+                            final LeaderInformation leaderInformation =
+                                    LeaderInformation.known(UUID.randomUUID(), "foobar");
+                            final String componentId = "componentId";
+                            final String path =
+                                    ZooKeeperUtils.generateConnectionInformationPath(componentId);
+
+                            ZooKeeperUtils.writeLeaderInformationToZooKeeper(
+                                    leaderInformation,
+                                    curatorFramework.asCuratorFramework(),
+                                    () -> true,
+                                    path);
+
+                            final LeaderInformationChangeEvent leaderInformationChangeEvent =
+                                    leaderElectionListener.await(
+                                            LeaderInformationChangeEvent.class);
+
+                            assertThat(leaderInformationChangeEvent.getComponentId())
+                                    .isEqualTo(componentId);
+                            assertThat(leaderInformationChangeEvent.getLeaderInformation())
+                                    .isEqualTo(leaderInformation);
+                        });
+            }
+        };
+    }
+
+    @Test
+    public void testLeaderElectionWithMultipleDrivers() throws Exception {
+        final CuratorFrameworkWithUnhandledErrorListener curatorFramework = startCuratorFramework();
+
+        try {
+            Set<ElectionDriver> electionDrivers =
+                    Stream.generate(
+                                    () ->
+                                            createLeaderElectionDriver(
+                                                    curatorFramework.asCuratorFramework()))
+                            .limit(3)
+                            .collect(Collectors.toSet());
+
+            while (!electionDrivers.isEmpty()) {
+                final CompletableFuture<Object> anyLeader =
+                        CompletableFuture.anyOf(
+                                electionDrivers.stream()
+                                        .map(ElectionDriver::getLeadershipFuture)
+                                        .collect(Collectors.toList())
+                                        .toArray(new CompletableFuture[0]));
+
+                // wait for any leader
+                anyLeader.join();
+
+                final Map<Boolean, Set<ElectionDriver>> leaderAndRest =
+                        electionDrivers.stream()
+                                .collect(
+                                        Collectors.partitioningBy(
+                                                ElectionDriver::hasLeadership, Collectors.toSet()));
+
+                assertThat(leaderAndRest.get(true)).hasSize(1);
+                Iterables.getOnlyElement(leaderAndRest.get(true)).close();
+
+                electionDrivers = leaderAndRest.get(false);
+            }
+        } finally {
+            curatorFramework.close();
+        }
+    }
+
+    @Test
+    public void testLeaderConnectionInfoNodeRemovalLeadsToLeaderChangeWithEmptyLeaderInformation()
+            throws Exception {
+        new Context() {
+            {
+                runTest(
+                        () -> {
+                            leaderElectionListener.await(IsLeaderEvent.class);
+
+                            final LeaderInformation leaderInformation =
+                                    LeaderInformation.known(UUID.randomUUID(), "foobar");
+                            final String componentId = "componentId";
+                            final String path =
+                                    ZooKeeperUtils.generateConnectionInformationPath(componentId);
+
+                            ZooKeeperUtils.writeLeaderInformationToZooKeeper(
+                                    leaderInformation,
+                                    curatorFramework.asCuratorFramework(),
+                                    () -> true,
+                                    path);
+
+                            // wait for the publishing of the leader information
+                            leaderElectionListener.await(LeaderInformationChangeEvent.class);
+
+                            curatorFramework.asCuratorFramework().delete().forPath(path);
+
+                            // wait for the removal of the leader information
+                            final LeaderInformationChangeEvent leaderInformationChangeEvent =
+                                    leaderElectionListener.await(
+                                            LeaderInformationChangeEvent.class);
+                            assertThat(leaderInformationChangeEvent.getComponentId())
+                                    .isEqualTo(componentId);
+                            assertThat(leaderInformationChangeEvent.getLeaderInformation())
+                                    .isEqualTo(LeaderInformation.empty());
+                        });
+            }
+        };
+    }
+
+    private static ElectionDriver createLeaderElectionDriver(CuratorFramework curatorFramework) {
+        final SimpleLeaderElectionListener leaderElectionListener =
+                new SimpleLeaderElectionListener();
+
+        try {
+            final ZooKeeperMultipleComponentLeaderElectionDriver leaderElectionDriver =
+                    createLeaderElectionDriver(leaderElectionListener, curatorFramework);
+            return new ElectionDriver(leaderElectionDriver, leaderElectionListener);
+        } catch (Exception e) {
+            ExceptionUtils.rethrow(e);
+            return null;
+        }
+    }
+
+    private static final class ElectionDriver {
+        private final ZooKeeperMultipleComponentLeaderElectionDriver leaderElectionDriver;
+        private final SimpleLeaderElectionListener leaderElectionListener;
+
+        private ElectionDriver(
+                ZooKeeperMultipleComponentLeaderElectionDriver leaderElectionDriver,
+                SimpleLeaderElectionListener leaderElectionListener) {
+            this.leaderElectionDriver = leaderElectionDriver;
+            this.leaderElectionListener = leaderElectionListener;
+        }
+
+        void close() throws Exception {
+            leaderElectionDriver.close();
+        }
+
+        boolean hasLeadership() {
+            return leaderElectionDriver.hasLeadership();
+        }
+
+        CompletableFuture<Void> getLeadershipFuture() {
+            return leaderElectionListener.getLeadershipFuture();
+        }
+
+        void publishLeaderInformation(String componentId, LeaderInformation leaderInformation)
+                throws Exception {
+            leaderElectionDriver.publishLeaderInformation(componentId, leaderInformation);
+        }
+    }
+
+    private static final class SimpleLeaderElectionListener
+            implements MultipleComponentLeaderElectionDriver.Listener {
+
+        private final CompletableFuture<Void> leadershipFuture = new CompletableFuture<>();
+
+        CompletableFuture<Void> getLeadershipFuture() {
+            return leadershipFuture;
+        }
+
+        @Override
+        public void isLeader() {
+            leadershipFuture.complete(null);
+        }
+
+        @Override
+        public void notLeader() {}
+
+        @Override
+        public void notifyLeaderInformationChange(
+                String componentId, LeaderInformation leaderInformation) {}
+
+        @Override
+        public void notifyAllKnownLeaderInformation(
+                Collection<LeaderInformationWithComponentId> leaderInformationWithComponentIds) {}
+    }
+
+    private static ZooKeeperMultipleComponentLeaderElectionDriver createLeaderElectionDriver(
+            MultipleComponentLeaderElectionDriver.Listener leaderElectionListener,
+            CuratorFramework curatorFramework)
+            throws Exception {
+        return new ZooKeeperMultipleComponentLeaderElectionDriver(
+                curatorFramework, leaderElectionListener);
+    }
+
+    private CuratorFrameworkWithUnhandledErrorListener startCuratorFramework() {
+        final Configuration configuration = new Configuration();
+        configuration.set(
+                HighAvailabilityOptions.HA_ZOOKEEPER_QUORUM, zooKeeperExtension.getConnectString());
+        return ZooKeeperUtils.startCuratorFramework(configuration, NoOpFatalErrorHandler.INSTANCE);
+    }
+
+    private static final class TestingLeaderElectionListener
+            implements MultipleComponentLeaderElectionDriver.Listener {
+        private final BlockingQueue<LeaderElectionEvent> leaderElectionEvents =
+                new ArrayBlockingQueue<>(10);
+
+        @Override
+        public void isLeader() {
+            put(new IsLeaderEvent());
+        }
+
+        @Override
+        public void notLeader() {
+            put(new NotLeaderEvent());
+        }
+
+        @Override
+        public void notifyLeaderInformationChange(
+                String componentId, LeaderInformation leaderInformation) {
+            put(new LeaderInformationChangeEvent(componentId, leaderInformation));
+        }
+
+        @Override
+        public void notifyAllKnownLeaderInformation(
+                Collection<LeaderInformationWithComponentId> leaderInformationWithComponentIds) {
+            put(new AllKnownLeaderInformationEvent(leaderInformationWithComponentIds));
+        }
+
+        private void put(LeaderElectionEvent leaderElectionEvent) {
+            try {
+                leaderElectionEvents.put(leaderElectionEvent);
+            } catch (InterruptedException e) {
+                ExceptionUtils.rethrow(e);
+            }
+        }
+
+        public <T> T await(Class<T> clazz) throws InterruptedException {
+            while (true) {
+                final LeaderElectionEvent leaderElectionEvent = leaderElectionEvents.take();
+
+                if (clazz.isAssignableFrom(leaderElectionEvent.getClass())) {
+                    return clazz.cast(leaderElectionEvent);
+                }
+            }
+        }
+
+        public <T> Optional<T> await(Class<T> clazz, Duration timeout) throws InterruptedException {
+            final Deadline deadline = Deadline.fromNow(timeout);
+
+            while (true) {
+                final Duration timeLeft = deadline.timeLeft();
+
+                if (timeLeft.isNegative()) {
+                    return Optional.empty();
+                } else {
+                    final Optional<LeaderElectionEvent> optLeaderElectionEvent =
+                            Optional.ofNullable(
+                                    leaderElectionEvents.poll(
+                                            timeLeft.toMillis(), TimeUnit.MILLISECONDS));
+
+                    if (optLeaderElectionEvent.isPresent()) {
+                        final LeaderElectionEvent leaderElectionEvent =
+                                optLeaderElectionEvent.get();
+
+                        if (clazz.isAssignableFrom(leaderElectionEvent.getClass())) {
+                            return Optional.of(clazz.cast(optLeaderElectionEvent));
+                        }
+                    } else {
+                        return Optional.empty();
+                    }
+                }
+            }
+        }
+    }
+
+    private abstract static class LeaderElectionEvent {
+        boolean isIsLeaderEvent() {
+            return false;
+        }
+
+        boolean isNotLeaderEvent() {
+            return false;
+        }
+
+        boolean isLeaderInformationChangeEvent() {
+            return false;
+        }
+
+        boolean isAllKnownLeaderInformationEvent() {
+            return false;
+        }
+
+        IsLeaderEvent asIsLeaderEvent() {
+            return as(IsLeaderEvent.class);
+        }
+
+        NotLeaderEvent asNotLeaderEvent() {
+            return as(NotLeaderEvent.class);
+        }
+
+        LeaderInformationChangeEvent asLeaderInformationChangeEvent() {
+            return as(LeaderInformationChangeEvent.class);
+        }
+
+        AllKnownLeaderInformationEvent asAllKnownLeaderInformationEvent() {
+            return as(AllKnownLeaderInformationEvent.class);
+        }
+
+        <T> T as(Class<T> clazz) {
+            if (clazz.isAssignableFrom(getClass())) {
+                return clazz.cast(this);
+            } else {
+                throw new IllegalStateException("Cannot cast object.");
+            }
+        }
+    }
+
+    private static class IsLeaderEvent extends LeaderElectionEvent {
+        @Override
+        boolean isIsLeaderEvent() {
+            return true;
+        }
+    }
+
+    private static class NotLeaderEvent extends LeaderElectionEvent {
+        @Override
+        boolean isNotLeaderEvent() {
+            return true;
+        }
+    }
+
+    private static class LeaderInformationChangeEvent extends LeaderElectionEvent {
+        private final String componentId;
+        private final LeaderInformation leaderInformation;
+
+        private LeaderInformationChangeEvent(
+                String componentId, LeaderInformation leaderInformation) {
+            this.componentId = componentId;
+            this.leaderInformation = leaderInformation;
+        }
+
+        @Override
+        boolean isLeaderInformationChangeEvent() {
+            return true;
+        }
+
+        public String getComponentId() {
+            return componentId;
+        }
+
+        public LeaderInformation getLeaderInformation() {
+            return leaderInformation;
+        }
+    }
+
+    private static class AllKnownLeaderInformationEvent extends LeaderElectionEvent {
+        private final Collection<LeaderInformationWithComponentId>
+                leaderInformationWithComponentIds;
+
+        private AllKnownLeaderInformationEvent(
+                Collection<LeaderInformationWithComponentId> leaderInformationWithComponentIds) {
+            this.leaderInformationWithComponentIds = leaderInformationWithComponentIds;
+        }
+
+        @Override
+        boolean isAllKnownLeaderInformationEvent() {
+            return true;
+        }
+    }
+
+    private class Context {
+        protected final TestingLeaderElectionListener leaderElectionListener;
+        protected final CuratorFrameworkWithUnhandledErrorListener curatorFramework;
+        protected final ZooKeeperMultipleComponentLeaderElectionDriver leaderElectionDriver;
+
+        private Context() throws Exception {
+            this.leaderElectionListener = new TestingLeaderElectionListener();
+            this.curatorFramework = startCuratorFramework();
+            this.leaderElectionDriver =
+                    createLeaderElectionDriver(
+                            leaderElectionListener, curatorFramework.asCuratorFramework());
+        }
+
+        protected final void runTest(RunnableWithException test) throws Exception {
+            try {
+                test.run();
+            } finally {
+                close();
+            }
+        }
+
+        private void close() throws Exception {
+            this.leaderElectionDriver.close();
+            this.curatorFramework.close();
+        }
+    }
+}

--- a/flink-runtime/src/test/java/org/apache/flink/runtime/util/TestingFatalErrorHandlerExtension.java
+++ b/flink-runtime/src/test/java/org/apache/flink/runtime/util/TestingFatalErrorHandlerExtension.java
@@ -1,0 +1,56 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.flink.runtime.util;
+
+import org.apache.flink.util.Preconditions;
+
+import org.junit.jupiter.api.extension.AfterEachCallback;
+import org.junit.jupiter.api.extension.BeforeEachCallback;
+import org.junit.jupiter.api.extension.ExtensionContext;
+
+import javax.annotation.Nullable;
+
+/** {@link TestingFatalErrorHandler} extension for Junit5. */
+public class TestingFatalErrorHandlerExtension implements BeforeEachCallback, AfterEachCallback {
+
+    @Nullable private TestingFatalErrorHandler testingFatalErrorHandler;
+
+    public TestingFatalErrorHandler getTestingFatalErrorHandler() {
+        return Preconditions.checkNotNull(
+                testingFatalErrorHandler,
+                "The %s has not been properly initialized.",
+                TestingFatalErrorHandlerExtension.class.getSimpleName());
+    }
+
+    @Override
+    public void beforeEach(ExtensionContext context) throws Exception {
+        // instantiate a fresh fatal error handler
+        testingFatalErrorHandler = new TestingFatalErrorHandler();
+    }
+
+    @Override
+    public void afterEach(ExtensionContext context) throws Exception {
+        final Throwable exception = getTestingFatalErrorHandler().getException();
+
+        if (exception != null) {
+            throw new AssertionError(
+                    "The TestingFatalErrorHandler caught an exception.", exception);
+        }
+    }
+}

--- a/flink-runtime/src/test/java/org/apache/flink/runtime/util/TestingFatalErrorHandlerResource.java
+++ b/flink-runtime/src/test/java/org/apache/flink/runtime/util/TestingFatalErrorHandlerResource.java
@@ -29,7 +29,10 @@ import javax.annotation.Nullable;
 /**
  * Resource which provides a {@link TestingFatalErrorHandler} and checks whether no exception has
  * been caught when calling {@link #after()}.
+ *
+ * @deprecated Continue using {@link TestingFatalErrorHandlerExtension} with Junit5 tests
  */
+@Deprecated
 public final class TestingFatalErrorHandlerResource implements TestRule {
 
     @Nullable private TestingFatalErrorHandler testingFatalErrorHandler;

--- a/flink-runtime/src/test/java/org/apache/flink/runtime/util/ZooKeeperUtilsITCase.java
+++ b/flink-runtime/src/test/java/org/apache/flink/runtime/util/ZooKeeperUtilsITCase.java
@@ -1,0 +1,104 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.flink.runtime.util;
+
+import org.apache.flink.configuration.Configuration;
+import org.apache.flink.configuration.HighAvailabilityOptions;
+import org.apache.flink.core.testutils.EachCallbackWrapper;
+import org.apache.flink.runtime.highavailability.zookeeper.CuratorFrameworkWithUnhandledErrorListener;
+import org.apache.flink.runtime.leaderelection.LeaderInformation;
+import org.apache.flink.runtime.rest.util.NoOpFatalErrorHandler;
+import org.apache.flink.runtime.zookeeper.ZooKeeperExtension;
+import org.apache.flink.util.TestLoggerExtension;
+
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.junit.jupiter.api.extension.RegisterExtension;
+
+import javax.annotation.Nonnull;
+
+import java.util.UUID;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+/** Integration tests for the {@link ZooKeeperUtils}. */
+@ExtendWith(TestLoggerExtension.class)
+class ZooKeeperUtilsITCase {
+    private final ZooKeeperExtension zooKeeperExtension = new ZooKeeperExtension();
+
+    @RegisterExtension
+    private final EachCallbackWrapper<ZooKeeperExtension> eachWrapper =
+            new EachCallbackWrapper<>(zooKeeperExtension);
+
+    @Test
+    public void testWriteAndReadLeaderInformation() throws Exception {
+        runWriteAndReadLeaderInformationTest(LeaderInformation.known(UUID.randomUUID(), "barfoo"));
+    }
+
+    @Test
+    public void testWriteAndReadEmptyLeaderInformation() throws Exception {
+        runWriteAndReadLeaderInformationTest(LeaderInformation.empty());
+    }
+
+    private void runWriteAndReadLeaderInformationTest(LeaderInformation leaderInformation)
+            throws Exception {
+        final CuratorFrameworkWithUnhandledErrorListener curatorFramework = startCuratorFramework();
+
+        final String path = "/foobar";
+
+        try {
+            ZooKeeperUtils.writeLeaderInformationToZooKeeper(
+                    leaderInformation, curatorFramework.asCuratorFramework(), () -> true, path);
+
+            final LeaderInformation readLeaderInformation =
+                    ZooKeeperUtils.readLeaderInformation(
+                            curatorFramework.asCuratorFramework().getData().forPath(path));
+
+            assertThat(readLeaderInformation).isEqualTo(leaderInformation);
+        } finally {
+            curatorFramework.close();
+        }
+    }
+
+    @Nonnull
+    private CuratorFrameworkWithUnhandledErrorListener startCuratorFramework() {
+        final Configuration configuration = new Configuration();
+        configuration.set(
+                HighAvailabilityOptions.HA_ZOOKEEPER_QUORUM, zooKeeperExtension.getConnectString());
+        final CuratorFrameworkWithUnhandledErrorListener curatorFramework =
+                ZooKeeperUtils.startCuratorFramework(configuration, NoOpFatalErrorHandler.INSTANCE);
+        return curatorFramework;
+    }
+
+    @Test
+    public void testDeleteZNode() throws Exception {
+        final CuratorFrameworkWithUnhandledErrorListener curatorFramework = startCuratorFramework();
+
+        try {
+            final String path = "/foobar";
+            curatorFramework.asCuratorFramework().create().forPath(path, new byte[4]);
+            curatorFramework.asCuratorFramework().create().forPath(path + "/bar", new byte[4]);
+            ZooKeeperUtils.deleteZNode(curatorFramework.asCuratorFramework(), path);
+
+            assertThat(curatorFramework.asCuratorFramework().getChildren().forPath("/")).isEmpty();
+        } finally {
+            curatorFramework.close();
+        }
+    }
+}

--- a/flink-runtime/src/test/java/org/apache/flink/runtime/util/ZooKeeperUtilsTest.java
+++ b/flink-runtime/src/test/java/org/apache/flink/runtime/util/ZooKeeperUtilsTest.java
@@ -37,13 +37,15 @@ public class ZooKeeperUtilsTest extends TestLogger {
 
     @Test
     public void testZookeeperPathGeneration() {
-        runZookeeperPathGenerationTest("root", "namespace", "/root/namespace");
-        runZookeeperPathGenerationTest("/root/", "/namespace/", "/root/namespace");
-        runZookeeperPathGenerationTest("//root//", "//namespace//", "/root/namespace");
-        runZookeeperPathGenerationTest("////", "namespace", "/namespace");
-        runZookeeperPathGenerationTest("//a//", "/b/", "/a/b");
-        runZookeeperPathGenerationTest("", "", "/");
-        runZookeeperPathGenerationTest("root", "////", "/root");
+        runZookeeperPathGenerationTest("/root/namespace", "root", "namespace");
+        runZookeeperPathGenerationTest("/root/namespace", "/root/", "/namespace/");
+        runZookeeperPathGenerationTest("/root/namespace", "//root//", "//namespace//");
+        runZookeeperPathGenerationTest("/namespace", "////", "namespace");
+        runZookeeperPathGenerationTest("/a/b", "//a//", "/b/");
+        runZookeeperPathGenerationTest("/", "", "");
+        runZookeeperPathGenerationTest("/root", "root", "////");
+        runZookeeperPathGenerationTest("/", "");
+        runZookeeperPathGenerationTest("/a/b/c/d", "a", "b", "c", "d");
     }
 
     @Test
@@ -106,9 +108,8 @@ public class ZooKeeperUtilsTest extends TestLogger {
         Assert.assertEquals(errorMsg, handler.getErrorFuture().get().getMessage());
     }
 
-    private void runZookeeperPathGenerationTest(
-            String root, String namespace, String expectedValue) {
-        final String result = ZooKeeperUtils.generateZookeeperPath(root, namespace);
+    private void runZookeeperPathGenerationTest(String expectedValue, String... paths) {
+        final String result = ZooKeeperUtils.generateZookeeperPath(paths);
 
         assertThat(result, is(expectedValue));
     }


### PR DESCRIPTION
This PR adds two new high availability services `ZooKeeperMultipleComponentLeaderElectionHaServices` and `KuberntesMultipleComponentLeaderElectionHaServices` that only use a single leader election per process. Both services internally rely on the `DefaultMultipleComponentLeaderElectionService` that uses a single `MultipleComponentLeaderElectionDriver` (responsible for the leader election) and allows to register multiple components. All components either obtain together the leadership or lose it together.

For the `MultipleComponentLeaderElectionDriver`, there are two implementations `ZooKeeperMultipleComponentLeaderElectionDriver` and the `KubernetesMultipleComponentLeaderElectionDriver` that implement the leader election based on ZooKeeper and Kubernetes, respectively.

In order to keep the old ha services implementation for safety purposes (users can switch back by setting `high-availability.use-old-ha-services: true`), I have reused the `DefaultLeaderElectionService` implementation and introduced a `MultipleComponentLeaderElectionDriverAdapter` that internally registers a component at the `MultipleComponentLeaderElectionService`. Once we remove the old HA service implementations I think that we can remove these temporary bridges and simplify the `DefaultLeaderElectionService` implementation to directly work against the `MultipleComponentLeaderElectionService`.