### PR TITLE
[FLINK-24559][build] Fix flink-rpc-akka packaging

### DIFF
--- a/flink-rpc/flink-rpc-akka-loader/pom.xml
+++ b/flink-rpc/flink-rpc-akka-loader/pom.xml
@@ -78,7 +78,7 @@ under the License.
 				<executions>
 					<execution>
 						<id>copy-rpc-akka-jars</id>
-						<phase>package</phase>
+						<phase>prepare-package</phase>
 						<goals>
 							<goal>copy</goal>
 						</goals>

--- a/flink-runtime/pom.xml
+++ b/flink-runtime/pom.xml
@@ -304,33 +304,6 @@ under the License.
 					</execution>
 				</executions>
 			</plugin>
-
-			<plugin>
-				<groupId>org.apache.maven.plugins</groupId>
-				<artifactId>maven-dependency-plugin</artifactId>
-				<executions>
-					<execution>
-						<id>copy-rpc-akka-jars</id>
-						<phase>process-resources</phase>
-						<goals>
-							<goal>copy</goal>
-						</goals>
-						<configuration>
-							<artifactItems>
-								<artifactItem>
-									<groupId>org.apache.flink</groupId>
-									<artifactId>flink-rpc-akka</artifactId>
-									<version>${project.version}</version>
-									<type>jar</type>
-									<overWrite>true</overWrite>
-									<destFileName>flink-rpc-akka.jar</destFileName>
-								</artifactItem>
-							</artifactItems>
-							<outputDirectory>${project.build.directory}/classes</outputDirectory>
-						</configuration>
-					</execution>
-				</executions>
-			</plugin>
 		</plugins>
 	</build>
 </project>


### PR DESCRIPTION
This PR makes sure that the dependency-plugin in flink-rpc-akka-loader runs before the shade-plugin by moving it to the `prepare-package` phase.

Additionally, this PR removes an unnecessary dependency-plugin configuration in flink-runtime, which masked the issue.