### PR TITLE
[FLINK-24560][build][yarn] Copy example jars in pre-integration-test phase

### DIFF
--- a/flink-yarn-tests/pom.xml
+++ b/flink-yarn-tests/pom.xml
@@ -375,7 +375,7 @@ under the License.
 				<executions>
 					<execution>
 						<id>copy</id>
-						<phase>process-test-resources</phase>
+						<phase>pre-integration-test</phase>
 						<goals>
 							<goal>copy</goal>
 						</goals>


### PR DESCRIPTION
Examples jars are now copied after the package phase, to allow commans such as {{mvn test}} to pass.