### PR TITLE
[FLINK-24561][build] Build archetype jars in compile phase

### DIFF
--- a/flink-quickstart/flink-quickstart-java/pom.xml
+++ b/flink-quickstart/flink-quickstart-java/pom.xml
@@ -35,4 +35,21 @@ under the License.
 	<packaging>maven-archetype</packaging>
 	<name>Flink : Quickstart : Java</name>
 
+	<build>
+		<plugins>
+			<plugin>
+				<groupId>org.apache.maven.plugins</groupId>
+				<artifactId>maven-archetype-plugin</artifactId>
+				<executions>
+					<execution>
+						<goals>
+							<goal>jar</goal>
+						</goals>
+						<phase>compile</phase>
+					</execution>
+				</executions>
+			</plugin>
+		</plugins>
+	</build>
+
 </project>

--- a/flink-quickstart/flink-quickstart-scala/pom.xml
+++ b/flink-quickstart/flink-quickstart-scala/pom.xml
@@ -35,4 +35,21 @@ under the License.
 	<packaging>maven-archetype</packaging>
 	<name>Flink : Quickstart : Scala</name>
 
+	<build>
+		<plugins>
+			<plugin>
+				<groupId>org.apache.maven.plugins</groupId>
+				<artifactId>maven-archetype-plugin</artifactId>
+				<executions>
+					<execution>
+						<goals>
+							<goal>jar</goal>
+						</goals>
+						<phase>compile</phase>
+					</execution>
+				</executions>
+			</plugin>
+		</plugins>
+	</build>
+
 </project>


### PR DESCRIPTION
Build the archetype jars in the compile phase so that the quickstart e2e test can resolve the dependency properly when running `mvn (test-)compile/test`.