### PR TITLE
[FLINK-24562][yarn] YarnResourceManagerDriverTest should not use ContainerStatusPBImpl.newInstance

### DIFF
--- a/flink-yarn/src/test/java/org/apache/flink/yarn/YarnResourceManagerDriverTest.java
+++ b/flink-yarn/src/test/java/org/apache/flink/yarn/YarnResourceManagerDriverTest.java
@@ -49,7 +49,6 @@ import org.apache.hadoop.yarn.api.records.LocalResourceVisibility;
 import org.apache.hadoop.yarn.api.records.NodeId;
 import org.apache.hadoop.yarn.api.records.Priority;
 import org.apache.hadoop.yarn.api.records.Resource;
-import org.apache.hadoop.yarn.api.records.impl.pb.ContainerStatusPBImpl;
 import org.apache.hadoop.yarn.client.api.AMRMClient;
 import org.apache.hadoop.yarn.client.api.async.AMRMClientAsync;
 import org.apache.hadoop.yarn.client.api.async.NMClientAsync;
@@ -710,7 +709,7 @@ public class YarnResourceManagerDriverTest extends ResourceManagerDriverTestBase
     }
 
     private ContainerStatus createSuccessfulCompletedContainerStatus() {
-        return ContainerStatusPBImpl.newInstance(
+        return new TestingContainerStatus(
                 testingContainer.getId(),
                 ContainerState.COMPLETE,
                 "success exit code",
@@ -727,7 +726,7 @@ public class YarnResourceManagerDriverTest extends ResourceManagerDriverTestBase
     }
 
     private ContainerStatus createCompletedContainerStatusBecauseItWasPreempted() {
-        return ContainerStatusPBImpl.newInstance(
+        return new TestingContainerStatus(
                 testingContainer.getId(),
                 ContainerState.COMPLETE,
                 "preempted exit code",
@@ -743,7 +742,7 @@ public class YarnResourceManagerDriverTest extends ResourceManagerDriverTestBase
     }
 
     private ContainerStatus createCompletedContainerStatusBecauseItWasInvalid() {
-        return ContainerStatusPBImpl.newInstance(
+        return new TestingContainerStatus(
                 testingContainer.getId(),
                 ContainerState.COMPLETE,
                 "invalid exit code",
@@ -761,7 +760,7 @@ public class YarnResourceManagerDriverTest extends ResourceManagerDriverTestBase
     }
 
     private ContainerStatus createCompletedContainerStatusBecauseItWasAborted() {
-        return ContainerStatusPBImpl.newInstance(
+        return new TestingContainerStatus(
                 testingContainer.getId(),
                 ContainerState.COMPLETE,
                 "aborted exit code",
@@ -780,7 +779,7 @@ public class YarnResourceManagerDriverTest extends ResourceManagerDriverTestBase
     }
 
     private ContainerStatus createCompletedContainerStatusBecauseDisksFailed() {
-        return ContainerStatusPBImpl.newInstance(
+        return new TestingContainerStatus(
                 testingContainer.getId(),
                 ContainerState.COMPLETE,
                 "disk failed exit code",
@@ -798,7 +797,7 @@ public class YarnResourceManagerDriverTest extends ResourceManagerDriverTestBase
     }
 
     private ContainerStatus createCompletedContainerStatusForUnknownCause() {
-        return ContainerStatusPBImpl.newInstance(
+        return new TestingContainerStatus(
                 testingContainer.getId(), ContainerState.COMPLETE, "unknown exit code", -1);
     }
 


### PR DESCRIPTION
## What is the purpose of the change

This pull request fix misuse ContainerStatusPBImpl.newInstance in YarnResourceManagerDriverTest.


## Brief change log

  - *make TestingContainerStatus extends ContainerStatus (extends ContainerStatusPBImpl before)*
  - *YarnResourceManagerDriverTest use TestingContainerStatus rather than  ContainerStatusPBImpl*


## Verifying this change

This change is a trivial rework / code cleanup without any test coverage.


## Does this pull request potentially affect one of the following parts:

  - Dependencies (does it add or upgrade a dependency): no
  - The public API, i.e., is any changed class annotated with `@Public(Evolving)`: no
  - The serializers: no
  - The runtime per-record code paths (performance sensitive): no
  - Anything that affects deployment or recovery: JobManager (and its components), Checkpointing, Kubernetes/Yarn, ZooKeeper: no
  - The S3 file system connector: no

## Documentation

  - Does this pull request introduce a new feature? no