### PR TITLE
[FLINK-24480][table-planner] Reduce number of fields in test

### DIFF
--- a/flink-table/flink-table-planner/src/test/java/org/apache/flink/table/planner/codegen/EqualiserCodeGeneratorTest.java
+++ b/flink-table/flink-table-planner/src/test/java/org/apache/flink/table/planner/codegen/EqualiserCodeGeneratorTest.java
@@ -88,7 +88,7 @@ public class EqualiserCodeGeneratorTest {
     @Test
     public void testManyFields() {
         final LogicalType[] fieldTypes =
-                IntStream.range(0, 999)
+                IntStream.range(0, 499)
                         .mapToObj(i -> new VarCharType())
                         .toArray(LogicalType[]::new);
 
@@ -98,7 +98,7 @@ public class EqualiserCodeGeneratorTest {
                         .newInstance(Thread.currentThread().getContextClassLoader());
 
         final StringData[] fields =
-                IntStream.range(0, 999)
+                IntStream.range(0, 499)
                         .mapToObj(i -> StringData.fromString("Entry " + i))
                         .toArray(StringData[]::new);
         assertTrue(


### PR DESCRIPTION
## What is the purpose of the change

The affected test was written due to a 64kB compilation issue. While that issue is fixed, there seems to be a limitation in Janino that can trigger a false-positive stack overflow. We reduce the number of fields in the test to workaround this issue; 500 fields is still plenty for the time being.

## Verifying this change

This change is already covered by existing tests.

## Does this pull request potentially affect one of the following parts:

  - Dependencies (does it add or upgrade a dependency): no
  - The public API, i.e., is any changed class annotated with `@Public(Evolving)`: no
  - The serializers: no
  - The runtime per-record code paths (performance sensitive): no
  - Anything that affects deployment or recovery: JobManager (and its components), Checkpointing, Kubernetes/Yarn, ZooKeeper: no
  - The S3 file system connector: no

## Documentation

  - Does this pull request introduce a new feature? no
  - If yes, how is the feature documented? not applicable
