### PR TITLE
[FLINK-21406][RecordFormat] build AvroParquetRecordFormat for the new FileSource

### DIFF
--- a/flink-connectors/flink-connector-files/src/main/java/org/apache/flink/connector/file/src/impl/StreamFormatAdapter.java
+++ b/flink-connectors/flink-connector-files/src/main/java/org/apache/flink/connector/file/src/impl/StreamFormatAdapter.java
@@ -36,6 +36,9 @@ import org.apache.flink.core.fs.Path;
 import org.apache.flink.util.IOUtils;
 import org.apache.flink.util.MathUtils;
 
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
 import javax.annotation.Nullable;
 
 import java.io.IOException;
@@ -50,6 +53,8 @@ import static org.apache.flink.util.Preconditions.checkNotNull;
 public final class StreamFormatAdapter<T> implements BulkFormat<T, FileSourceSplit> {
 
     private static final long serialVersionUID = 1L;
+
+    static final Logger LOG = LoggerFactory.getLogger(StreamFormatAdapter.class);
 
     private final StreamFormat<T> streamFormat;
 
@@ -118,6 +123,11 @@ public final class StreamFormatAdapter<T> implements BulkFormat<T, FileSourceSpl
                                 long toSkip = checkpointedPosition.getRecordsAfterOffset();
                                 while (toSkip > 0 && streamReader.read() != null) {
                                     toSkip--;
+                                }
+                                if (LOG.isDebugEnabled()) {
+                                    LOG.debug(
+                                            "{} records have been skipped.",
+                                            checkpointedPosition.getRecordsAfterOffset());
                                 }
                             });
 

--- a/flink-formats/flink-parquet/pom.xml
+++ b/flink-formats/flink-parquet/pom.xml
@@ -55,6 +55,17 @@ under the License.
 			<optional>true</optional>
 		</dependency>
 
+		<!-- Flink-avro -->
+
+		<dependency>
+			<groupId>org.apache.flink</groupId>
+			<artifactId>flink-avro</artifactId>
+			<version>${project.version}</version>
+			<optional>true</optional>
+		</dependency>
+
+		<!-- Table ecosystem -->
+
 		<dependency>
 			<groupId>org.apache.flink</groupId>
 			<artifactId>flink-connector-files</artifactId>
@@ -154,13 +165,6 @@ under the License.
 		<dependency>
 			<groupId>org.apache.flink</groupId>
 			<artifactId>flink-streaming-java</artifactId>
-			<version>${project.version}</version>
-			<scope>test</scope>
-		</dependency>
-
-		<dependency>
-			<groupId>org.apache.flink</groupId>
-			<artifactId>flink-avro</artifactId>
 			<version>${project.version}</version>
 			<scope>test</scope>
 		</dependency>

--- a/flink-formats/flink-parquet/src/main/java/org/apache/flink/formats/parquet/avro/AvroParquetReaders.java
+++ b/flink-formats/flink-parquet/src/main/java/org/apache/flink/formats/parquet/avro/AvroParquetReaders.java
@@ -1,0 +1,105 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.flink.formats.parquet.avro;
+
+import org.apache.flink.api.java.typeutils.TypeExtractor;
+import org.apache.flink.formats.avro.typeutils.AvroTypeInfo;
+import org.apache.flink.formats.avro.typeutils.GenericRecordAvroTypeInfo;
+
+import org.apache.avro.Schema;
+import org.apache.avro.generic.GenericData;
+import org.apache.avro.generic.GenericRecord;
+import org.apache.avro.reflect.ReflectData;
+import org.apache.avro.specific.SpecificData;
+import org.apache.avro.specific.SpecificRecordBase;
+
+/**
+ * Convenience builder to create {@link AvroParquetRecordFormat} instances for the different Avro
+ * types.
+ */
+public class AvroParquetReaders {
+
+    /**
+     * Creates a new {@link AvroParquetRecordFormat} that reads the parquet file into Avro {@link
+     * org.apache.avro.specific.SpecificRecord SpecificRecords}.
+     *
+     * <p>To read into Avro {@link GenericRecord GenericRecords}, use the {@link
+     * #forGenericRecord(Schema)} method.
+     *
+     * @see #forGenericRecord(Schema)
+     */
+    public static <T extends SpecificRecordBase> AvroParquetRecordFormat<T> forSpecificRecord(
+            final Class<T> typeClass) {
+        return new AvroParquetRecordFormat<>(
+                new AvroTypeInfo<>(typeClass), () -> SpecificData.get());
+    }
+
+    /**
+     * Creates a new {@link AvroParquetRecordFormat} that reads the parquet file into Avro records
+     * via reflection.
+     *
+     * <p>To read into Avro {@link GenericRecord GenericRecords}, use the {@link
+     * #forGenericRecord(Schema)} method.
+     *
+     * <p>To read into Avro {@link org.apache.avro.specific.SpecificRecord SpecificRecords}, use the
+     * {@link #forSpecificRecord(Class)} method.
+     *
+     * @see #forGenericRecord(Schema)
+     * @see #forSpecificRecord(Class)
+     */
+    public static <T> AvroParquetRecordFormat<T> forReflectRecord(final Class<T> typeClass) {
+        if (SpecificRecordBase.class.isAssignableFrom(typeClass)) {
+            throw new IllegalArgumentException(
+                    "Please use AvroParquetReaders.forSpecificRecord(Class<T>) for SpecificRecord.");
+        } else if (GenericRecord.class.isAssignableFrom(typeClass)) {
+            throw new IllegalArgumentException(
+                    "Please use AvroParquetReaders.forGenericRecord(Class<T>) for GenericRecord."
+                            + "Cannot read and create Avro GenericRecord without specifying the Avro Schema. "
+                            + "This is because Flink needs to be able serialize the results in its data flow, which is"
+                            + "very inefficient without the schema. And while the Schema is stored in the Avro file header,"
+                            + "Flink needs this schema during 'pre-flight' time when the data flow is set up and wired,"
+                            + "which is before there is access to the files");
+        }
+
+        // this is a PoJo that Avo will reader via reflect de-serialization
+        // for Flink, this is just a plain PoJo type
+        return new AvroParquetRecordFormat<>(
+                TypeExtractor.createTypeInfo(typeClass), () -> ReflectData.get());
+    }
+
+    /**
+     * Creates a new {@link AvroParquetRecordFormat} that reads the parquet file into Avro {@link
+     * GenericRecord GenericRecords}.
+     *
+     * <p>To read into {@link GenericRecord GenericRecords}, this method needs an Avro Schema. That
+     * is because Flink needs to be able to serialize the results in its data flow, which is very
+     * inefficient without the schema. And while the Schema is stored in the Avro file header, Flink
+     * needs this schema during 'pre-flight' time when the data flow is set up and wired, which is
+     * before there is access to the files.
+     */
+    public static AvroParquetRecordFormat<GenericRecord> forGenericRecord(final Schema schema) {
+        return new AvroParquetRecordFormat<>(
+                new GenericRecordAvroTypeInfo(schema), () -> GenericData.get());
+    }
+
+    // ------------------------------------------------------------------------
+
+    /** Class is not meant to be instantiated. */
+    private AvroParquetReaders() {}
+}

--- a/flink-formats/flink-parquet/src/main/java/org/apache/flink/formats/parquet/avro/AvroParquetRecordFormat.java
+++ b/flink-formats/flink-parquet/src/main/java/org/apache/flink/formats/parquet/avro/AvroParquetRecordFormat.java
@@ -1,0 +1,234 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.flink.formats.parquet.avro;
+
+import org.apache.flink.annotation.VisibleForTesting;
+import org.apache.flink.api.common.typeinfo.TypeInformation;
+import org.apache.flink.configuration.Configuration;
+import org.apache.flink.connector.file.src.reader.StreamFormat;
+import org.apache.flink.connector.file.src.util.CheckpointedPosition;
+import org.apache.flink.core.fs.FSDataInputStream;
+import org.apache.flink.util.function.SerializableSupplier;
+
+import org.apache.avro.generic.GenericData;
+import org.apache.avro.generic.GenericRecord;
+import org.apache.parquet.avro.AvroParquetReader;
+import org.apache.parquet.hadoop.ParquetReader;
+import org.apache.parquet.io.DelegatingSeekableInputStream;
+import org.apache.parquet.io.InputFile;
+import org.apache.parquet.io.SeekableInputStream;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import javax.annotation.Nullable;
+
+import java.io.IOException;
+
+import static org.apache.flink.util.Preconditions.checkArgument;
+
+/** */
+public class AvroParquetRecordFormat<E> implements StreamFormat<E> {
+
+    private static final long serialVersionUID = 1L;
+
+    static final Logger LOG = LoggerFactory.getLogger(AvroParquetRecordFormat.class);
+
+    private final TypeInformation<E> type;
+
+    private final SerializableSupplier<GenericData> dataModelSupplier;
+
+    AvroParquetRecordFormat(
+            TypeInformation<E> type, SerializableSupplier<GenericData> dataModelSupplier) {
+        this.type = type;
+        this.dataModelSupplier = dataModelSupplier;
+    }
+
+    /**
+     * Creates a new reader to read avro {@link GenericRecord} from Parquet input stream.
+     *
+     * <p>Several wrapper classes haven be created to Flink abstraction become compatible with the
+     * parquet abstraction. Please refer to the inner classes {@link AvroParquetRecordReader},
+     * {@link ParquetInputFile}, {@link FSDataInputStreamAdapter} for details.
+     */
+    @Override
+    public Reader<E> createReader(
+            Configuration config, FSDataInputStream stream, long fileLen, long splitEnd)
+            throws IOException {
+
+        // current version does not support splitting.
+        checkNotSplit(fileLen, splitEnd);
+
+        return new AvroParquetRecordReader<E>(
+                AvroParquetReader.<E>builder(new ParquetInputFile(stream, fileLen))
+                        .withDataModel(getDataModel())
+                        .build());
+    }
+
+    /**
+     * Restores the reader from a checkpointed position. It is in fact identical since only {@link
+     * CheckpointedPosition#NO_OFFSET} as the {@code restoredOffset} is support.
+     */
+    @Override
+    public Reader<E> restoreReader(
+            Configuration config,
+            FSDataInputStream stream,
+            long restoredOffset,
+            long fileLen,
+            long splitEnd)
+            throws IOException {
+
+        // current version does not support splitting.
+        checkNotSplit(fileLen, splitEnd);
+
+        checkArgument(
+                restoredOffset == CheckpointedPosition.NO_OFFSET,
+                "The restoredOffset should always be NO_OFFSET");
+
+        return createReader(config, stream, fileLen, splitEnd);
+    }
+
+    @VisibleForTesting
+    GenericData getDataModel() {
+        return dataModelSupplier.get();
+    }
+
+    /** Current version does not support splitting. */
+    @Override
+    public boolean isSplittable() {
+        return false;
+    }
+
+    /**
+     * Gets the type produced by this format. This type will be the type produced by the file source
+     * as a whole.
+     */
+    @Override
+    public TypeInformation<E> getProducedType() {
+        return type;
+    }
+
+    private static void checkNotSplit(long fileLen, long splitEnd) {
+        if (splitEnd != fileLen) {
+            throw new IllegalArgumentException(
+                    String.format(
+                            "Current version of AvroParquetRecordFormat is not splittable, "
+                                    + "but found split end (%d) different from file length (%d)",
+                            splitEnd, fileLen));
+        }
+    }
+
+    /**
+     * {@link StreamFormat.Reader} implementation. Using {@link ParquetReader} internally to read
+     * avro {@link GenericRecord} from parquet {@link InputFile}.
+     */
+    private static class AvroParquetRecordReader<E> implements StreamFormat.Reader<E> {
+
+        private final ParquetReader<E> parquetReader;
+
+        private long skipCount;
+        private final boolean checkpointed;
+
+        private AvroParquetRecordReader(ParquetReader<E> parquetReader) {
+            this(parquetReader, 0, false);
+        }
+
+        private AvroParquetRecordReader(
+                ParquetReader<E> parquetReader, long skipCount, boolean checkpointed) {
+            this.parquetReader = parquetReader;
+            this.skipCount = skipCount;
+            this.checkpointed = checkpointed;
+        }
+
+        @Nullable
+        @Override
+        public E read() throws IOException {
+            E record = parquetReader.read();
+            incrementPosition();
+            return record;
+        }
+
+        @Override
+        public void close() throws IOException {
+            parquetReader.close();
+        }
+
+        @Nullable
+        @Override
+        public CheckpointedPosition getCheckpointedPosition() {
+            // Since ParquetReader does not expose the offset, always use
+            // CheckpointedPosition.NO_OFFSET.
+            return checkpointed
+                    ? new CheckpointedPosition(CheckpointedPosition.NO_OFFSET, skipCount)
+                    : null;
+        }
+
+        private void incrementPosition() {
+            skipCount++;
+        }
+    }
+
+    /**
+     * Parquet {@link InputFile} implementation, {@link #newStream()} call will delegate to Flink
+     * {@link FSDataInputStream}.
+     */
+    private static class ParquetInputFile implements InputFile {
+
+        private final FSDataInputStream inputStream;
+        private final long length;
+
+        private ParquetInputFile(FSDataInputStream inputStream, long length) {
+            this.inputStream = inputStream;
+            this.length = length;
+        }
+
+        @Override
+        public long getLength() {
+            return length;
+        }
+
+        @Override
+        public SeekableInputStream newStream() {
+            return new FSDataInputStreamAdapter(inputStream);
+        }
+    }
+
+    /**
+     * Adapter which makes {@link FSDataInputStream} become compatible with parquet {@link
+     * SeekableInputStream}.
+     */
+    private static class FSDataInputStreamAdapter extends DelegatingSeekableInputStream {
+
+        private final FSDataInputStream inputStream;
+
+        private FSDataInputStreamAdapter(FSDataInputStream inputStream) {
+            super(inputStream);
+            this.inputStream = inputStream;
+        }
+
+        @Override
+        public long getPos() throws IOException {
+            return inputStream.getPos();
+        }
+
+        @Override
+        public void seek(long newPos) throws IOException {
+            inputStream.seek(newPos);
+        }
+    }
+}

--- a/flink-formats/flink-parquet/src/test/java/org/apache/flink/formats/parquet/avro/AvroParquetFileReadITCase.java
+++ b/flink-formats/flink-parquet/src/test/java/org/apache/flink/formats/parquet/avro/AvroParquetFileReadITCase.java
@@ -1,0 +1,171 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.flink.formats.parquet.avro;
+
+import org.apache.flink.api.common.eventtime.WatermarkStrategy;
+import org.apache.flink.api.common.serialization.BulkWriter;
+import org.apache.flink.connector.file.src.FileSource;
+import org.apache.flink.core.fs.FileSystem;
+import org.apache.flink.core.fs.Path;
+import org.apache.flink.formats.parquet.ParquetWriterFactory;
+import org.apache.flink.streaming.api.datastream.DataStream;
+import org.apache.flink.streaming.api.environment.StreamExecutionEnvironment;
+import org.apache.flink.test.util.AbstractTestBase;
+import org.apache.flink.util.CloseableIterator;
+
+import org.apache.avro.Schema;
+import org.apache.avro.generic.GenericData;
+import org.apache.avro.generic.GenericRecord;
+import org.junit.Before;
+import org.junit.Test;
+
+import java.io.IOException;
+import java.time.Duration;
+import java.util.ArrayList;
+import java.util.List;
+
+import static org.apache.flink.util.Preconditions.checkArgument;
+import static org.apache.flink.util.Preconditions.checkNotNull;
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertTrue;
+
+/** ITCase for {@link AvroParquetRecordFormat}. */
+public class AvroParquetFileReadITCase extends AbstractTestBase {
+
+    private static final int PARALLELISM = 4;
+    private static final String USER_PARQUET_FILE_1 = "user1.parquet";
+    private static final String USER_PARQUET_FILE_2 = "user2.parquet";
+    private static final String USER_PARQUET_FILE_3 = "user3.parquet";
+
+    private Schema schema;
+    private final List<GenericRecord> userRecords = new ArrayList<>(3);
+
+    @Before
+    public void setup() throws IOException {
+        // Generic records
+        schema =
+                new Schema.Parser()
+                        .parse(
+                                "{\"type\": \"record\", "
+                                        + "\"name\": \"User\", "
+                                        + "\"fields\": [\n"
+                                        + "        {\"name\": \"name\", \"type\": \"string\" },\n"
+                                        + "        {\"name\": \"favoriteNumber\",  \"type\": [\"int\", \"null\"] },\n"
+                                        + "        {\"name\": \"favoriteColor\", \"type\": [\"string\", \"null\"] }\n"
+                                        + "    ]\n"
+                                        + "    }");
+
+        userRecords.add(createUser("Peter", 1, "red"));
+        userRecords.add(createUser("Tom", 2, "yellow"));
+        userRecords.add(createUser("Jack", 3, "green"));
+
+        createParquetFile(
+                ParquetAvroWriters.forGenericRecord(schema),
+                Path.fromLocalFile(TEMPORARY_FOLDER.newFile(USER_PARQUET_FILE_1)),
+                userRecords.toArray(new GenericRecord[0]));
+
+        GenericRecord user = createUser("Max", 4, "blue");
+        userRecords.add(user);
+        createParquetFile(
+                ParquetAvroWriters.forGenericRecord(schema),
+                Path.fromLocalFile(TEMPORARY_FOLDER.newFile(USER_PARQUET_FILE_2)),
+                user);
+
+        user = createUser("Alex", 5, "White");
+        GenericRecord user1 = createUser("Anna", 6, "Pink");
+
+        userRecords.add(user);
+        userRecords.add(user1);
+        createParquetFile(
+                ParquetAvroWriters.forGenericRecord(schema),
+                Path.fromLocalFile(TEMPORARY_FOLDER.newFile(USER_PARQUET_FILE_3)),
+                user,
+                user1);
+    }
+
+    @Test
+    public void testReadAvroRecord() throws Exception {
+        final FileSource<GenericRecord> source =
+                FileSource.forRecordStreamFormat(
+                                AvroParquetReaders.forGenericRecord(schema),
+                                Path.fromLocalFile(TEMPORARY_FOLDER.getRoot()))
+                        .monitorContinuously(Duration.ofMillis(5))
+                        .build();
+        final StreamExecutionEnvironment env = StreamExecutionEnvironment.getExecutionEnvironment();
+        env.setParallelism(PARALLELISM);
+        env.enableCheckpointing(10L);
+
+        DataStream<GenericRecord> stream =
+                env.fromSource(source, WatermarkStrategy.noWatermarks(), "file-source");
+
+        try (CloseableIterator<GenericRecord> iterator =
+                stream.executeAndCollect("Reading Avro GenericRecords")) {
+            List<GenericRecord> list = collectRecords(iterator, 6);
+            assertEquals(list.size(), 6);
+
+            for (int i = 0; i < 6; i++) {
+                assertTrue(list.contains(userRecords.get(i)));
+            }
+        }
+    }
+
+    private static <E> List<E> collectRecords(
+            final CloseableIterator<E> iterator, final int numElements) {
+
+        checkNotNull(iterator, "iterator");
+        checkArgument(numElements > 0, "numElement must be > 0");
+
+        final ArrayList<E> result = new ArrayList<>(numElements);
+
+        while (iterator.hasNext()) {
+            result.add(iterator.next());
+            if (result.size() == numElements) {
+                break;
+            }
+        }
+
+        return result;
+    }
+
+    @SafeVarargs
+    private static <T> void createParquetFile(
+            ParquetWriterFactory<T> writerFactory, Path parquetFilePath, T... records)
+            throws IOException {
+        BulkWriter<T> writer =
+                writerFactory.create(
+                        parquetFilePath
+                                .getFileSystem()
+                                .create(parquetFilePath, FileSystem.WriteMode.OVERWRITE));
+
+        for (T record : records) {
+            writer.addElement(record);
+        }
+
+        writer.flush();
+        writer.finish();
+    }
+
+    private GenericRecord createUser(String name, int favoriteNumber, String favoriteColor) {
+        GenericRecord record = new GenericData.Record(schema);
+        record.put("name", name);
+        record.put("favoriteNumber", favoriteNumber);
+        record.put("favoriteColor", favoriteColor);
+        return record;
+    }
+}

--- a/flink-formats/flink-parquet/src/test/java/org/apache/flink/formats/parquet/avro/AvroParquetRecordFormatTest.java
+++ b/flink-formats/flink-parquet/src/test/java/org/apache/flink/formats/parquet/avro/AvroParquetRecordFormatTest.java
@@ -1,0 +1,321 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.flink.formats.parquet.avro;
+
+import org.apache.flink.api.common.serialization.BulkWriter;
+import org.apache.flink.configuration.Configuration;
+import org.apache.flink.connector.file.src.reader.StreamFormat;
+import org.apache.flink.connector.file.src.util.CheckpointedPosition;
+import org.apache.flink.core.fs.FSDataInputStream;
+import org.apache.flink.core.fs.FileStatus;
+import org.apache.flink.core.fs.FileSystem;
+import org.apache.flink.core.fs.Path;
+import org.apache.flink.formats.parquet.ParquetWriterFactory;
+import org.apache.flink.formats.parquet.generated.Address;
+
+import org.apache.avro.Schema;
+import org.apache.avro.generic.GenericData;
+import org.apache.avro.generic.GenericRecord;
+import org.apache.avro.reflect.ReflectData;
+import org.apache.avro.specific.SpecificData;
+import org.junit.jupiter.api.BeforeAll;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.io.TempDir;
+
+import java.io.IOException;
+import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.List;
+import java.util.Objects;
+
+import static org.apache.flink.util.Preconditions.checkArgument;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+
+/**
+ * Unit test for {@link AvroParquetRecordFormat} and {@link
+ * org.apache.flink.connector.file.src.reader.StreamFormat}.
+ */
+class AvroParquetRecordFormatTest {
+
+    private static final String USER_PARQUET_FILE = "user.parquet";
+    private static final String ADDRESS_PARQUET_FILE = "address.parquet";
+    private static final String DATUM_PARQUET_FILE = "datum.parquet";
+
+    private static Path userPath;
+    private static Path addressPath;
+    private static Path datumPath;
+
+    private static Schema schema;
+
+    private static final List<GenericRecord> userRecords = new ArrayList<>(3);
+    private static final List<Address> addressRecords = new ArrayList<>(3);
+    private static final List<Datum> datumRecords = new ArrayList<>(3);
+
+    @TempDir static java.nio.file.Path temporaryFolder;
+
+    /**
+     * Create a parquet file in the {@code TEMPORARY_FOLDER} directory.
+     *
+     * @throws IOException if new file can not be created.
+     */
+    @BeforeAll
+    static void setup() throws IOException {
+        // Generic records
+        schema =
+                new Schema.Parser()
+                        .parse(
+                                "{\"type\": \"record\", "
+                                        + "\"name\": \"User\", "
+                                        + "\"fields\": [\n"
+                                        + "        {\"name\": \"name\", \"type\": \"string\" },\n"
+                                        + "        {\"name\": \"favoriteNumber\",  \"type\": [\"int\", \"null\"] },\n"
+                                        + "        {\"name\": \"favoriteColor\", \"type\": [\"string\", \"null\"] }\n"
+                                        + "    ]\n"
+                                        + "    }");
+
+        userRecords.add(createUser("Peter", 1, "red"));
+        userRecords.add(createUser("Tom", 2, "yellow"));
+        userRecords.add(createUser("Jack", 3, "green"));
+
+        userPath = new Path(temporaryFolder.resolve(USER_PARQUET_FILE).toUri());
+        createParquetFile(ParquetAvroWriters.forGenericRecord(schema), userPath, userRecords);
+
+        // Specific records
+        addressRecords.addAll(createAddressList());
+        addressPath = new Path(temporaryFolder.resolve(ADDRESS_PARQUET_FILE).toUri());
+        createParquetFile(
+                ParquetAvroWriters.forSpecificRecord(Address.class), addressPath, addressRecords);
+
+        // Reflect records
+        datumRecords.addAll(createDatumList());
+        datumPath = new Path(temporaryFolder.resolve(DATUM_PARQUET_FILE).toUri());
+        createParquetFile(
+                ParquetAvroWriters.forReflectRecord(Datum.class), datumPath, datumRecords);
+    }
+
+    @Test
+    void testCreateSpecificReader() throws IOException {
+        StreamFormat.Reader<Address> reader =
+                createReader(
+                        AvroParquetReaders.forSpecificRecord(Address.class),
+                        new Configuration(),
+                        addressPath,
+                        0,
+                        addressPath.getFileSystem().getFileStatus(addressPath).getLen());
+        for (Address address : addressRecords) {
+            Address address1 = Objects.requireNonNull(reader.read());
+            assertEquals(address1, address);
+        }
+    }
+
+    @Test
+    void testCreateReflectReader() throws IOException {
+        StreamFormat.Reader<Datum> reader =
+                createReader(
+                        AvroParquetReaders.forReflectRecord(Datum.class),
+                        new Configuration(),
+                        datumPath,
+                        0,
+                        datumPath.getFileSystem().getFileStatus(datumPath).getLen());
+        for (Datum datum : datumRecords) {
+            assertEquals(Objects.requireNonNull(reader.read()), datum);
+        }
+    }
+
+    @Test
+    void testCreateGenericReader() throws IOException {
+        StreamFormat.Reader<GenericRecord> reader =
+                createReader(
+                        AvroParquetReaders.forGenericRecord(schema),
+                        new Configuration(),
+                        userPath,
+                        0,
+                        userPath.getFileSystem().getFileStatus(userPath).getLen());
+        for (GenericRecord record : userRecords) {
+            assertUserEquals(Objects.requireNonNull(reader.read()), record);
+        }
+    }
+
+    /** Expect exception since splitting is not supported now. */
+    @Test
+    void testCreateGenericReaderWithSplitting() {
+        assertThrows(
+                IllegalArgumentException.class,
+                () ->
+                        createReader(
+                                AvroParquetReaders.forGenericRecord(schema),
+                                new Configuration(),
+                                userPath,
+                                5,
+                                5));
+    }
+
+    @Test
+    void testRestoreGenericReaderWithWrongOffset() {
+        assertThrows(
+                IllegalArgumentException.class,
+                () ->
+                        restoreReader(
+                                AvroParquetReaders.forGenericRecord(schema),
+                                new Configuration(),
+                                userPath,
+                                10,
+                                0,
+                                userPath.getFileSystem().getFileStatus(userPath).getLen()));
+    }
+
+    @Test
+    void testReadWithRestoreGenericReader() throws IOException {
+        StreamFormat.Reader<GenericRecord> reader =
+                restoreReader(
+                        AvroParquetReaders.forGenericRecord(schema),
+                        new Configuration(),
+                        userPath,
+                        CheckpointedPosition.NO_OFFSET,
+                        0,
+                        userPath.getFileSystem().getFileStatus(userPath).getLen());
+        for (GenericRecord record : userRecords) {
+            assertUserEquals(Objects.requireNonNull(reader.read()), record);
+        }
+    }
+
+    @Test
+    void testSplittable() {
+        assertFalse(AvroParquetReaders.forGenericRecord(schema).isSplittable());
+    }
+
+    @Test
+    void getProducedType() {
+        assertEquals(
+                AvroParquetReaders.forGenericRecord(schema).getProducedType().getTypeClass(),
+                GenericRecord.class);
+    }
+
+    @Test
+    void getDataModel() {
+        assertEquals(
+                AvroParquetReaders.forGenericRecord(schema).getDataModel().getClass(),
+                GenericData.class);
+        assertEquals(
+                AvroParquetReaders.forSpecificRecord(Address.class).getDataModel().getClass(),
+                SpecificData.class);
+        assertEquals(
+                AvroParquetReaders.forReflectRecord(Datum.class).getDataModel().getClass(),
+                ReflectData.class);
+    }
+
+    // ------------------------------------------------------------------------
+    //  helper methods
+    // ------------------------------------------------------------------------
+
+    private <T> StreamFormat.Reader<T> createReader(
+            AvroParquetRecordFormat<T> format,
+            Configuration config,
+            Path filePath,
+            long splitOffset,
+            long splitLength)
+            throws IOException {
+
+        final FileSystem fileSystem = filePath.getFileSystem();
+        final FileStatus fileStatus = fileSystem.getFileStatus(filePath);
+        final FSDataInputStream inputStream = fileSystem.open(filePath);
+
+        if (format.isSplittable()) {
+            inputStream.seek(splitOffset);
+        } else {
+            inputStream.seek(0);
+            checkArgument(splitLength == fileStatus.getLen());
+        }
+
+        return format.createReader(
+                config, inputStream, fileStatus.getLen(), splitOffset + splitLength);
+    }
+
+    private <T> StreamFormat.Reader<T> restoreReader(
+            AvroParquetRecordFormat<T> format,
+            Configuration config,
+            Path filePath,
+            long restoredOffset,
+            long splitOffset,
+            long splitLength)
+            throws IOException {
+
+        final FileSystem fileSystem = filePath.getFileSystem();
+        final FileStatus fileStatus = fileSystem.getFileStatus(filePath);
+        final FSDataInputStream inputStream = fileSystem.open(filePath);
+
+        if (format.isSplittable()) {
+            inputStream.seek(splitOffset);
+        } else {
+            inputStream.seek(0);
+            checkArgument(splitLength == fileStatus.getLen());
+        }
+
+        return format.restoreReader(
+                config,
+                inputStream,
+                restoredOffset,
+                fileStatus.getLen(),
+                splitOffset + splitLength);
+    }
+
+    private static <T> void createParquetFile(
+            ParquetWriterFactory<T> writerFactory, Path parquetFilePath, List<T> records)
+            throws IOException {
+        BulkWriter<T> writer =
+                writerFactory.create(
+                        parquetFilePath
+                                .getFileSystem()
+                                .create(parquetFilePath, FileSystem.WriteMode.OVERWRITE));
+
+        for (T record : records) {
+            writer.addElement(record);
+        }
+
+        writer.flush();
+        writer.finish();
+    }
+
+    private static GenericRecord createUser(String name, int favoriteNumber, String favoriteColor) {
+        GenericRecord record = new GenericData.Record(schema);
+        record.put("name", name);
+        record.put("favoriteNumber", favoriteNumber);
+        record.put("favoriteColor", favoriteColor);
+        return record;
+    }
+
+    private void assertUserEquals(GenericRecord user, GenericRecord expected) {
+        assertEquals(user.get("name").toString(), expected.get("name"));
+        assertEquals(user.get("favoriteNumber"), expected.get("favoriteNumber"));
+        assertEquals(user.get("favoriteColor").toString(), expected.get("favoriteColor"));
+    }
+
+    private static List<Address> createAddressList() {
+        return Arrays.asList(
+                new Address(1, "a", "b", "c", "12345"),
+                new Address(2, "p", "q", "r", "12345"),
+                new Address(3, "x", "y", "z", "12345"));
+    }
+
+    private static List<Datum> createDatumList() {
+        return Arrays.asList(new Datum("a", 1), new Datum("b", 2), new Datum("c", 3));
+    }
+}

--- a/flink-formats/flink-parquet/src/test/java/org/apache/flink/formats/parquet/avro/Datum.java
+++ b/flink-formats/flink-parquet/src/test/java/org/apache/flink/formats/parquet/avro/Datum.java
@@ -1,0 +1,55 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.flink.formats.parquet.avro;
+
+import java.io.Serializable;
+
+/** Test datum. */
+public class Datum implements Serializable {
+
+    public String a;
+    public int b;
+
+    public Datum() {}
+
+    public Datum(String a, int b) {
+        this.a = a;
+        this.b = b;
+    }
+
+    @Override
+    public boolean equals(Object o) {
+        if (this == o) {
+            return true;
+        }
+        if (o == null || getClass() != o.getClass()) {
+            return false;
+        }
+
+        Datum datum = (Datum) o;
+        return b == datum.b && (a != null ? a.equals(datum.a) : datum.a == null);
+    }
+
+    @Override
+    public int hashCode() {
+        int result = a != null ? a.hashCode() : 0;
+        result = 31 * result + b;
+        return result;
+    }
+}

--- a/flink-formats/flink-parquet/src/test/java/org/apache/flink/formats/parquet/avro/ParquetAvroStreamingFileSinkITCase.java
+++ b/flink-formats/flink-parquet/src/test/java/org/apache/flink/formats/parquet/avro/ParquetAvroStreamingFileSinkITCase.java
@@ -224,37 +224,4 @@ public class ParquetAvroStreamingFileSinkITCase extends AbstractTestBase {
 
     // ------------------------------------------------------------------------
 
-    /** Test datum. */
-    public static class Datum implements Serializable {
-
-        public String a;
-        public int b;
-
-        public Datum() {}
-
-        public Datum(String a, int b) {
-            this.a = a;
-            this.b = b;
-        }
-
-        @Override
-        public boolean equals(Object o) {
-            if (this == o) {
-                return true;
-            }
-            if (o == null || getClass() != o.getClass()) {
-                return false;
-            }
-
-            Datum datum = (Datum) o;
-            return b == datum.b && (a != null ? a.equals(datum.a) : datum.a == null);
-        }
-
-        @Override
-        public int hashCode() {
-            int result = a != null ? a.hashCode() : 0;
-            result = 31 * result + b;
-            return result;
-        }
-    }
 }

--- a/flink-formats/flink-sql-parquet/pom.xml
+++ b/flink-formats/flink-sql-parquet/pom.xml
@@ -67,7 +67,6 @@ under the License.
 									<include>org.apache.parquet:parquet-jackson</include>
 									<include>org.codehaus.jackson:jackson-core-asl</include>
 									<include>org.codehaus.jackson:jackson-mapper-asl</include>
-									<include>org.apache.commons:commons-compress</include>
 									<include>commons-pool:commons-pool</include>
 									<include>commons-codec:commons-codec</include>
 								</includes>


### PR DESCRIPTION
## What is the purpose of the change

The goal of this PR is to provide AvroParquetRecordFormat implementation to read avro GenericRecords from parquet via the new Flink FileSource. 

Another goal of this PR is to make everyone on the same page w.r.t. the implementation design. Once the design is settled down, the splitting support and more avro record types beyond the GenericRecord as new features will be easily done in a follow-up PRs.

This is the draft PR, there is one failed unit test case, which is documented out for now with TODO comment. I am still working on it.

## Brief change log

- Create RecordFormat interface which focuses on Path with default methods implementation and delegate createReader() calls to the overloaded methods from StreamFormat that focuses on FDDataInputStream.
- Create AvroParquetRecordFormat implementation. Only reading avro GenericRecord from parquet file or stream is supported in this version. Support for other avro record types will be implemented later.
- Splitting is not supported in this version. 

## Open Questions

To give you some background, the original idea was to let AvroParquetRecordFormat implement FileRecordFormat. After considering that FileRecordFormat and StreamFormat have too many commons and StreamFormat has more built-in features like compression support(via StreamFormatAdapter), current design is based on StreamFormat. In order to keep SIP clear, 2-levels interfaces have been defined.  Let StreamFormat focuses on the abstract input stream and let RecordFormat pay attention to the concrete FileSystem, i.e. the Path. RecordFormat provides default implementation for the overloaded createReader(...) methods. Subclasses are therefore not forced to implement them.

Following are some questions open for discussion:

1. Compare to the 2-levels interfaces design, as another option, all default methods implemented in the RecordFormat could be merged into the StreamFormat. Such design keeps all createReader(...) methods in one interface(StreamFormat only, no more RecordFormat) that is in some ways easier to use. The downside is the SIP violation. Based on these consideration, I chose the current 2-levels API design.
2. After considering priorities, Splitting is currently not supported, since we didn't get strong requirement from the business side. It will be implemented later, when the time comes.
3. If this design works well, as next step, we should consider replacing the FileRecordFormat with the RecordFormat. In this way, the duplicated code and javacode could be avoided. This question is a little bit out of the scope of this PR, but does relate to the topic, could be therefore discussed too.

## Verifying this change

This change added tests and can be verified as follows:

  New unit test validates that : 
- Reader can be created and restored correctly via Path.
- Violation constraint checks for no splitting, null path, and no restoreOffset are working well.
- GenericRecords can be read correctly from parquet file.


## Does this pull request potentially affect one of the following parts:

  - Dependencies (does it add or upgrade a dependency): (**yes** / no)
  - The public API, i.e., is any changed class annotated with `@Public(Evolving)`: (**yes** / no)
  - The serializers: (yes / **no** / don't know)
  - The runtime per-record code paths (performance sensitive): (**yes** / no / don't know)
  - Anything that affects deployment or recovery: JobManager (and its components), Checkpointing, Kubernetes/Yarn, ZooKeeper: (yes / **no** / don't know)
  - The S3 file system connector: (yes / **no** / don't know)

## Documentation

  - Does this pull request introduce a new feature? (**yes** / no)
  - If yes, how is the feature documented? (not applicable / docs / **JavaDocs** / not documented)
