### PR TITLE
[FLINK-24355][runtime] Expose the flag for enabling checkpoints after tasks finish in the Web UI

### DIFF
--- a/docs/layouts/shortcodes/generated/rest_v1_dispatcher.html
+++ b/docs/layouts/shortcodes/generated/rest_v1_dispatcher.html
@@ -2237,6 +2237,9 @@ Using 'curl' you can upload a jar via 'curl -X POST -H "Expect:" -F "jarfile=@pa
     },
     "unaligned_checkpoints" : {
       "type" : "boolean"
+    },
+    "checkpoints_after_tasks_finish" : {
+      "type" : "boolean"
     }
   }
 }            </code>

--- a/flink-runtime-web/src/test/resources/rest_api_v1.snapshot
+++ b/flink-runtime-web/src/test/resources/rest_api_v1.snapshot
@@ -1275,6 +1275,9 @@
         },
         "aligned_checkpoint_timeout" : {
           "type" : "integer"
+        },
+        "checkpoints_after_tasks_finish" : {
+           "type" : "boolean"
         }
       }
     }

--- a/flink-runtime-web/web-dashboard/src/app/interfaces/job-checkpoint.ts
+++ b/flink-runtime-web/web-dashboard/src/app/interfaces/job-checkpoint.ts
@@ -127,6 +127,7 @@ export interface CheckPointConfigInterface {
   unaligned_checkpoints: boolean;
   tolerable_failed_checkpoints: number;
   aligned_checkpoint_timeout: number;
+  checkpoints_after_tasks_finish: boolean;
 }
 
 export interface CheckPointDetailInterface {

--- a/flink-runtime-web/web-dashboard/src/app/pages/job/checkpoints/job-checkpoints.component.html
+++ b/flink-runtime-web/web-dashboard/src/app/pages/job/checkpoints/job-checkpoints.component.html
@@ -501,6 +501,12 @@
             <td>Tolerable Failed Checkpoints</td>
             <td>{{ checkPointConfig['tolerable_failed_checkpoints'] }}</td>
           </tr>
+          <tr>
+            <td>Checkpoints With Finished Tasks</td>
+            <td>
+              {{ checkPointConfig['checkpoints_after_tasks_finish'] ? 'Enabled' : 'Disabled' }}
+            </td>
+          </tr>
         </ng-container>
       </tbody>
     </nz-table>

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/rest/handler/job/checkpoints/CheckpointConfigHandler.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/rest/handler/job/checkpoints/CheckpointConfigHandler.java
@@ -130,7 +130,8 @@ public class CheckpointConfigHandler
                     checkpointStorageName,
                     checkpointCoordinatorConfiguration.isUnalignedCheckpointsEnabled(),
                     checkpointCoordinatorConfiguration.getTolerableCheckpointFailureNumber(),
-                    checkpointCoordinatorConfiguration.getAlignedCheckpointTimeout());
+                    checkpointCoordinatorConfiguration.getAlignedCheckpointTimeout(),
+                    checkpointCoordinatorConfiguration.isEnableCheckpointsAfterTasksFinish());
         }
     }
 }

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/rest/messages/checkpoints/CheckpointConfigInfo.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/rest/messages/checkpoints/CheckpointConfigInfo.java
@@ -62,6 +62,9 @@ public class CheckpointConfigInfo implements ResponseBody {
 
     public static final String FIELD_NAME_ALIGNED_CHECKPOINT_TIMEOUT = "aligned_checkpoint_timeout";
 
+    public static final String FIELD_NAME_CHECKPOINTS_AFTER_TASKS_FINISH =
+            "checkpoints_after_tasks_finish";
+
     @JsonProperty(FIELD_NAME_PROCESSING_MODE)
     private final ProcessingMode processingMode;
 
@@ -95,6 +98,9 @@ public class CheckpointConfigInfo implements ResponseBody {
     @JsonProperty(FIELD_NAME_ALIGNED_CHECKPOINT_TIMEOUT)
     private final long alignedCheckpointTimeout;
 
+    @JsonProperty(FIELD_NAME_CHECKPOINTS_AFTER_TASKS_FINISH)
+    private final boolean checkpointsWithFinishedTasks;
+
     @JsonCreator
     public CheckpointConfigInfo(
             @JsonProperty(FIELD_NAME_PROCESSING_MODE) ProcessingMode processingMode,
@@ -108,7 +114,9 @@ public class CheckpointConfigInfo implements ResponseBody {
             @JsonProperty(FIELD_NAME_CHECKPOINT_STORAGE) String checkpointStorage,
             @JsonProperty(FIELD_NAME_UNALIGNED_CHECKPOINTS) boolean unalignedCheckpoints,
             @JsonProperty(FIELD_NAME_TOLERABLE_FAILED_CHECKPOINTS) int tolerableFailedCheckpoints,
-            @JsonProperty(FIELD_NAME_ALIGNED_CHECKPOINT_TIMEOUT) long alignedCheckpointTimeout) {
+            @JsonProperty(FIELD_NAME_ALIGNED_CHECKPOINT_TIMEOUT) long alignedCheckpointTimeout,
+            @JsonProperty(FIELD_NAME_CHECKPOINTS_AFTER_TASKS_FINISH)
+                    boolean checkpointsWithFinishedTasks) {
         this.processingMode = Preconditions.checkNotNull(processingMode);
         this.checkpointInterval = checkpointInterval;
         this.checkpointTimeout = checkpointTimeout;
@@ -120,6 +128,7 @@ public class CheckpointConfigInfo implements ResponseBody {
         this.unalignedCheckpoints = unalignedCheckpoints;
         this.tolerableFailedCheckpoints = tolerableFailedCheckpoints;
         this.alignedCheckpointTimeout = alignedCheckpointTimeout;
+        this.checkpointsWithFinishedTasks = checkpointsWithFinishedTasks;
     }
 
     @Override
@@ -141,7 +150,8 @@ public class CheckpointConfigInfo implements ResponseBody {
                 && Objects.equals(checkpointStorage, that.checkpointStorage)
                 && unalignedCheckpoints == that.unalignedCheckpoints
                 && tolerableFailedCheckpoints == that.tolerableFailedCheckpoints
-                && alignedCheckpointTimeout == that.alignedCheckpointTimeout;
+                && alignedCheckpointTimeout == that.alignedCheckpointTimeout
+                && checkpointsWithFinishedTasks == that.checkpointsWithFinishedTasks;
     }
 
     @Override
@@ -157,7 +167,8 @@ public class CheckpointConfigInfo implements ResponseBody {
                 checkpointStorage,
                 unalignedCheckpoints,
                 tolerableFailedCheckpoints,
-                alignedCheckpointTimeout);
+                alignedCheckpointTimeout,
+                checkpointsWithFinishedTasks);
     }
 
     /** Contains information about the externalized checkpoint configuration. */

--- a/flink-runtime/src/test/java/org/apache/flink/runtime/rest/messages/checkpoints/CheckpointConfigInfoTest.java
+++ b/flink-runtime/src/test/java/org/apache/flink/runtime/rest/messages/checkpoints/CheckpointConfigInfoTest.java
@@ -44,6 +44,7 @@ public class CheckpointConfigInfoTest
                 "checkpointStorageName",
                 true,
                 3,
-                4);
+                4,
+                true);
     }
 }


### PR DESCRIPTION
## What is the purpose of the change

*The checkpointing configuration should present the value of `execution.checkpointing.checkpoints-after-tasks-finish.enabled` in the Web UI.*

## Brief change log

  - *`CheckpointConfigInfo` of `CheckpointConfigHandler` adds the `checkpoints_after_tasks_finish` to return the value of `execution.checkpointing.checkpoints-after-tasks-finish.enabled`.*

## Verifying this change

  - *Update the `getTestResponseInstance()` of `CheckpointConfigInfoTest` with the value of `checkpoints_after_tasks_finish` to verify the return `CheckpointConfigInfo` instance.*

## Does this pull request potentially affect one of the following parts:

  - Dependencies (does it add or upgrade a dependency): (yes / **no**)
  - The public API, i.e., is any changed class annotated with `@Public(Evolving)`: (yes / **no**)
  - The serializers: (yes / **no** / don't know)
  - The runtime per-record code paths (performance sensitive): (yes / **no** / don't know)
  - Anything that affects deployment or recovery: JobManager (and its components), Checkpointing, Kubernetes/Yarn, ZooKeeper: (yes / **no** / don't know)
  - The S3 file system connector: (yes / **no** / don't know)

## Documentation

  - Does this pull request introduce a new feature? (yes / **no**)
  - If yes, how is the feature documented? (**not applicable** / docs / JavaDocs / not documented)