### PR TITLE
[FLINK-24563][table-planner][test] Re-enable tests for invalid strings->timestamp_tz cast

### DIFF
--- a/flink-table/flink-table-planner/src/test/java/org/apache/flink/table/planner/functions/CastFunctionITCase.java
+++ b/flink-table/flink-table-planner/src/test/java/org/apache/flink/table/planner/functions/CastFunctionITCase.java
@@ -750,10 +750,9 @@ public class CastFunctionITCase extends BuiltInFunctionTestBase {
                         // RAW
                         .build(),
                 CastTestSpecBuilder.testCastTo(TIMESTAMP_LTZ(9))
-                        // https://issues.apache.org/jira/browse/FLINK-24424 - Throws NPE
-                        // .fromCase(CHAR(3), "foo", null)
-                        // .fromCase(VARCHAR(5), "Flink", null)
-                        // .fromCase(STRING(), "123", null)
+                        .fromCase(CHAR(3), "foo", null)
+                        .fromCase(VARCHAR(5), "Flink", null)
+                        .fromCase(STRING(), "123", null)
                         .fromCase(
                                 STRING(),
                                 "2021-09-27",


### PR DESCRIPTION
Re-enable tests for invalid strings->timestamp_tz cast conversion

Follows: 75e5a89529f4c1bec87d7090e527ce64e9188bc1

## Does this pull request potentially affect one of the following parts:

  - Dependencies (does it add or upgrade a dependency): no
  - The public API, i.e., is any changed class annotated with `@Public(Evolving)`: no
  - The serializers: no
  - The runtime per-record code paths (performance sensitive): no
  - Anything that affects deployment or recovery: JobManager (and its components), Checkpointing, Kubernetes/Yarn, ZooKeeper: no
  - The S3 file system connector: no

## Documentation

  - Does this pull request introduce a new feature? no
  - If yes, how is the feature documented? not applicable
