### PR TITLE
[FLINK-24579][table-api][sql-client] Support toString for arrays as c…

### DIFF
--- a/flink-table/flink-sql-client/src/main/java/org/apache/flink/table/client/cli/CliUtils.java
+++ b/flink-table/flink-sql-client/src/main/java/org/apache/flink/table/client/cli/CliUtils.java
@@ -66,7 +66,7 @@ public final class CliUtils {
         final AttributedStringBuilder line1 = new AttributedStringBuilder();
         final AttributedStringBuilder line2 = new AttributedStringBuilder();
 
-        // we assume that every options has not more than 11 characters (+ key and space)
+        // we assume that every option has not more than 11 characters (+ key and space)
         final int columns = (int) Math.ceil(((double) options.size()) / 2);
         final int space = (width - CliStrings.DEFAULT_MARGIN.length() - columns * 13) / columns;
         final Iterator<Tuple2<String, String>> iter = options.iterator();
@@ -121,7 +121,7 @@ public final class CliUtils {
         }
     }
 
-    /** Get time zone from the the given session config. */
+    /** Get time zone from the given session config. */
     public static ZoneId getSessionTimeZone(ReadableConfig sessionConfig) {
         final String zone = sessionConfig.get(TableConfigOptions.LOCAL_TIME_ZONE);
         return TableConfigOptions.LOCAL_TIME_ZONE.defaultValue().equals(zone)

--- a/flink-table/flink-sql-client/src/test/java/org/apache/flink/table/client/cli/CliTableauResultViewTest.java
+++ b/flink-table/flink-sql-client/src/test/java/org/apache/flink/table/client/cli/CliTableauResultViewTest.java
@@ -231,9 +231,9 @@ public class CliTableauResultViewTest {
 
         // submit result display in another thread
         ExecutorService executorService = Executors.newSingleThreadExecutor();
-        Future<?> furture = executorService.submit(view::displayResults);
+        Future<?> future = executorService.submit(view::displayResults);
 
-        // wait until we trying to get batch result
+        // wait until we are trying to get batch result
         CommonTestUtils.waitUntilCondition(
                 () -> mockExecutor.getNumRetrieveResultChancesCalls() > 1,
                 Deadline.now().plus(Duration.ofSeconds(5)),
@@ -241,7 +241,7 @@ public class CliTableauResultViewTest {
 
         // send signal to cancel
         terminal.raise(Terminal.Signal.INT);
-        furture.get(5, TimeUnit.SECONDS);
+        future.get(5, TimeUnit.SECONDS);
 
         Assert.assertEquals(
                 "Query terminated, received a total of 0 row" + System.lineSeparator(),
@@ -425,7 +425,7 @@ public class CliTableauResultViewTest {
 
         // submit result display in another thread
         ExecutorService executorService = Executors.newSingleThreadExecutor();
-        Future<?> furture = executorService.submit(view::displayResults);
+        Future<?> future = executorService.submit(view::displayResults);
 
         // wait until we processed first result
         CommonTestUtils.waitUntilCondition(
@@ -435,7 +435,7 @@ public class CliTableauResultViewTest {
 
         // send signal to cancel
         terminal.raise(Terminal.Signal.INT);
-        furture.get(5, TimeUnit.SECONDS);
+        future.get(5, TimeUnit.SECONDS);
         view.close();
 
         Assert.assertEquals(

--- a/flink-table/flink-sql-client/src/test/java/org/apache/flink/table/client/cli/utils/SqlParserHelper.java
+++ b/flink-table/flink-sql-client/src/test/java/org/apache/flink/table/client/cli/utils/SqlParserHelper.java
@@ -28,7 +28,7 @@ import org.apache.flink.table.delegation.Parser;
 
 /** An utility class that provides pre-prepared tables and sql parser. */
 public class SqlParserHelper {
-    // return the sql parser instance hold by this table evn.
+    // return the sql parser instance hold by this table env.
     private TableEnvironment tableEnv;
 
     public SqlParserHelper() {

--- a/flink-table/flink-table-common/src/test/java/org/apache/flink/table/utils/PrintUtilsTest.java
+++ b/flink-table/flink-table-common/src/test/java/org/apache/flink/table/utils/PrintUtilsTest.java
@@ -139,6 +139,49 @@ public class PrintUtilsTest {
     }
 
     @Test
+    public void testNestedMapAndArraysToString() {
+        Row row = new Row(2);
+        Map<int[], String[]> intArray2StringArrayMap = new HashMap<>();
+        intArray2StringArrayMap.put(new int[] {1, 2}, new String[] {"hello", "world"});
+        row.setField(0, intArray2StringArrayMap);
+        Row row1 = new Row(2);
+        Map<Integer, String> map1 = new HashMap<>();
+        map1.put(123, "string");
+        Map<Integer, String>[] arrayOfMaps = new Map[] {map1};
+        row1.setField(0, arrayOfMaps);
+        Map<TimestampData[], boolean[]> map = new HashMap<>();
+        map.put(
+                new TimestampData[] {
+                    TimestampData.fromEpochMillis(1000), TimestampData.fromEpochMillis(2000)
+                },
+                new boolean[] {false, true});
+        row1.setField(1, map);
+        row.setField(1, row1);
+        ResolvedSchema resolvedSchema =
+                ResolvedSchema.of(
+                        Arrays.asList(
+                                Column.physical(
+                                        "f0",
+                                        DataTypes.MAP(
+                                                DataTypes.ARRAY(DataTypes.INT()),
+                                                DataTypes.ARRAY(DataTypes.STRING()))),
+                                Column.physical(
+                                        "f1",
+                                        DataTypes.ROW(
+                                                DataTypes.ARRAY(
+                                                        DataTypes.MAP(
+                                                                DataTypes.INT(),
+                                                                DataTypes.STRING())),
+                                                DataTypes.MAP(
+                                                        DataTypes.ARRAY(DataTypes.TIMESTAMP_LTZ(3)),
+                                                        DataTypes.ARRAY(DataTypes.BOOLEAN()))))));
+        assertEquals(
+                "[{[1, 2]=[hello, world]},"
+                        + " +I[[{123=string}], {[1970-01-01 00:00:01.000, 1970-01-01 00:00:02.000]=[false, true]}]]",
+                Arrays.toString(PrintUtils.rowToString(row, resolvedSchema, UTC_ZONE_ID)));
+    }
+
+    @Test
     public void testNestedMapToString() {
         Row row = new Row(2);
         row.setField(0, new int[] {1, 2});


### PR DESCRIPTION
## What is the purpose of the change

The PRs makes pretty printing of arrays nested into maps .


## Brief change log

  - *PrintUtils#deepToString* supporting maps
  - *Correction of found misprints*


## Verifying this change

This change added tests and can be verified as follows:
There has been added *PrintUtilsTest#testNestedMapAndArraysToString* which highlights the issue and which could be used to check the fix.

## Does this pull request potentially affect one of the following parts:

  - Dependencies (does it add or upgrade a dependency): (yes / **no**)
  - The public API, i.e., is any changed class annotated with `@Public(Evolving)`: (yes / **no**)
  - The serializers: (yes / **no** / don't know)
  - The runtime per-record code paths (performance sensitive): (yes / no / **don't know**)
  - Anything that affects deployment or recovery: JobManager (and its components), Checkpointing, Kubernetes/Yarn, ZooKeeper: (yes / **no** / don't know)
  - The S3 file system connector: (yes / **no** / don't know)

## Documentation

  - Does this pull request introduce a new feature? (yes / **no**)
  - If yes, how is the feature documented? (**not applicable** / docs / JavaDocs / not documented)
