### PR TITLE
[FLINK-24597][state] fix the problem that RocksStateKeysAndNamespaceIterator would return duplicate data

### DIFF
--- a/flink-runtime/src/test/java/org/apache/flink/runtime/state/StateBackendTestBase.java
+++ b/flink-runtime/src/test/java/org/apache/flink/runtime/state/StateBackendTestBase.java
@@ -451,7 +451,8 @@ public abstract class StateBackendTestBase<B extends AbstractStateBackend> exten
     @Test
     public void testGetKeysAndNamespaces() throws Exception {
         final int elementsNum = 1000;
-        String fieldName = "get-keys-test";
+        String valueStateFieldName = "value-state";
+        String mapStateFieldName = "map-state";
         CheckpointableKeyedStateBackend<Integer> backend =
                 createKeyedBackend(IntSerializer.INSTANCE);
         try {
@@ -460,22 +461,66 @@ public abstract class StateBackendTestBase<B extends AbstractStateBackend> exten
                     backend.getPartitionedState(
                             ns1,
                             StringSerializer.INSTANCE,
-                            new ValueStateDescriptor<>(fieldName, IntSerializer.INSTANCE));
+                            new ValueStateDescriptor<>(
+                                    valueStateFieldName, IntSerializer.INSTANCE));
+
+            MapState<Integer, Integer> keyedState2 =
+                    backend.getPartitionedState(
+                            ns1,
+                            StringSerializer.INSTANCE,
+                            new MapStateDescriptor<>(
+                                    mapStateFieldName,
+                                    IntSerializer.INSTANCE,
+                                    IntSerializer.INSTANCE));
 
             final String ns2 = "ns2";
-            ValueState<Integer> keyedState2 =
+            ValueState<Integer> keyedState3 =
                     backend.getPartitionedState(
                             ns2,
                             StringSerializer.INSTANCE,
-                            new ValueStateDescriptor<>(fieldName, IntSerializer.INSTANCE));
+                            new ValueStateDescriptor<>(
+                                    valueStateFieldName, IntSerializer.INSTANCE));
+
+            MapState<Integer, Integer> keyedState4 =
+                    backend.getPartitionedState(
+                            ns2,
+                            StringSerializer.INSTANCE,
+                            new MapStateDescriptor<>(
+                                    mapStateFieldName,
+                                    IntSerializer.INSTANCE,
+                                    IntSerializer.INSTANCE));
 
             for (int key = 0; key < elementsNum; key++) {
                 backend.setCurrentKey(key);
                 keyedState1.update(key * 2);
-                keyedState2.update(key * 2);
+                keyedState2.put(key * 2, key * 2);
+                keyedState2.put(key * 3, key * 2);
+                keyedState3.update(key * 2);
+                keyedState4.put(key * 2, key * 2);
+                keyedState4.put(key * 3, key * 2);
             }
 
-            try (Stream<Tuple2<Integer, String>> stream = backend.getKeysAndNamespaces(fieldName)) {
+            // valid for valueState
+            try (Stream<Tuple2<Integer, String>> stream =
+                    backend.getKeysAndNamespaces(valueStateFieldName)) {
+                final Map<String, Set<Integer>> keysByNamespace = new HashMap<>();
+                stream.forEach(
+                        entry -> {
+                            assertThat("Unexpected namespace", entry.f1, isOneOf(ns1, ns2));
+                            assertThat(
+                                    "Unexpected key",
+                                    entry.f0,
+                                    is(both(greaterThanOrEqualTo(0)).and(lessThan(elementsNum))));
+
+                            Set<Integer> keys =
+                                    keysByNamespace.computeIfAbsent(entry.f1, k -> new HashSet<>());
+                            assertTrue("Duplicate key for namespace", keys.add(entry.f0));
+                        });
+            }
+
+            // valid for mapState
+            try (Stream<Tuple2<Integer, String>> stream =
+                    backend.getKeysAndNamespaces(mapStateFieldName)) {
                 final Map<String, Set<Integer>> keysByNamespace = new HashMap<>();
                 stream.forEach(
                         entry -> {

--- a/flink-state-backends/flink-statebackend-rocksdb/src/test/java/org/apache/flink/contrib/streaming/state/RocksDBRocksStateKeysAndNamespacesIteratorTest.java
+++ b/flink-state-backends/flink-statebackend-rocksdb/src/test/java/org/apache/flink/contrib/streaming/state/RocksDBRocksStateKeysAndNamespacesIteratorTest.java
@@ -17,8 +17,6 @@
 
 package org.apache.flink.contrib.streaming.state;
 
-import org.apache.flink.api.common.state.MapState;
-import org.apache.flink.api.common.state.MapStateDescriptor;
 import org.apache.flink.api.common.state.ValueState;
 import org.apache.flink.api.common.state.ValueStateDescriptor;
 import org.apache.flink.api.common.typeutils.TypeSerializer;
@@ -106,76 +104,6 @@ public class RocksDBRocksStateKeysAndNamespacesIteratorTest {
                                     iterator,
                                     testStateName,
                                     keySerializer,
-                                    StringSerializer.INSTANCE,
-                                    keyedStateBackend.getKeyGroupPrefixBytes(),
-                                    ambiguousKeyPossible)) {
-
-                iterator.seekToFirst();
-
-                // valid record
-                List<Tuple2<Integer, String>> fetchedKeys = new ArrayList<>(1000);
-                while (iteratorWrapper.hasNext()) {
-                    Tuple2 entry = iteratorWrapper.next();
-                    entry.f0 = Integer.parseInt(entry.f0.toString());
-
-                    fetchedKeys.add((Tuple2<Integer, String>) entry);
-                }
-
-                fetchedKeys.sort(Comparator.comparingInt(a -> a.f0));
-                Assert.assertEquals(1000, fetchedKeys.size());
-
-                for (int i = 0; i < 1000; ++i) {
-                    Assert.assertEquals(i, fetchedKeys.get(i).f0.intValue());
-                    Assert.assertEquals(namespace, fetchedKeys.get(i).f1);
-                }
-            }
-        }
-    }
-
-    @Test
-    public void testIteratorUpdateMapStateMultipleTimes() throws Exception {
-
-        String testStateName = "testMapState";
-        String namespace = "ns";
-
-        try (RocksDBKeyedStateBackendTestFactory factory =
-                new RocksDBKeyedStateBackendTestFactory()) {
-            RocksDBKeyedStateBackend<Integer> keyedStateBackend =
-                    factory.create(tmp, IntSerializer.INSTANCE, 128);
-
-            MapState<String, Integer> testMapState =
-                    keyedStateBackend.getPartitionedState(
-                            namespace,
-                            StringSerializer.INSTANCE,
-                            new MapStateDescriptor<>(testStateName, String.class, Integer.class));
-
-            // insert record
-            for (int i = 0; i < 1000; ++i) {
-                keyedStateBackend.setCurrentKey(i);
-                testMapState.put("key_a_" + i, i);
-                testMapState.put("key_b_" + i, i);
-            }
-
-            DataOutputSerializer outputStream = new DataOutputSerializer(8);
-            boolean ambiguousKeyPossible =
-                    CompositeKeySerializationUtils.isAmbiguousKeyPossible(
-                            IntSerializer.INSTANCE, StringSerializer.INSTANCE);
-            CompositeKeySerializationUtils.writeNameSpace(
-                    namespace, StringSerializer.INSTANCE, outputStream, ambiguousKeyPossible);
-
-            // already created with the state, should be closed with the backend
-            ColumnFamilyHandle handle = keyedStateBackend.getColumnFamilyHandle(testStateName);
-
-            try (RocksIteratorWrapper iterator =
-                            RocksDBOperationUtils.getRocksIterator(
-                                    keyedStateBackend.db,
-                                    handle,
-                                    keyedStateBackend.getReadOptions());
-                    RocksStateKeysAndNamespaceIterator<Integer, String> iteratorWrapper =
-                            new RocksStateKeysAndNamespaceIterator<>(
-                                    iterator,
-                                    testStateName,
-                                    IntSerializer.INSTANCE,
                                     StringSerializer.INSTANCE,
                                     keyedStateBackend.getKeyGroupPrefixBytes(),
                                     ambiguousKeyPossible)) {


### PR DESCRIPTION
…terator would return duplicate data

<!--
*Thank you very much for contributing to Apache Flink - we are happy that you want to help us improve Flink. To help the community review your contribution in the best possible way, please go through the checklist below, which will get the contribution into a shape in which it can be best reviewed.*

*Please understand that we do not do this to make contributions to Flink a hassle. In order to uphold a high standard of quality for code contributions, while at the same time managing a large number of contributions, we need contributors to prepare the contributions well, and give reviewers enough contextual information for the review. Please also understand that contributions that do not follow this guide will take longer to review and thus typically be picked up with lower priority by the community.*

## Contribution Checklist

  - Make sure that the pull request corresponds to a [JIRA issue](https://issues.apache.org/jira/projects/FLINK/issues). Exceptions are made for typos in JavaDoc or documentation files, which need no JIRA issue.
  
  - Name the pull request in the form "[FLINK-XXXX] [component] Title of the pull request", where *FLINK-XXXX* should be replaced by the actual issue number. Skip *component* if you are unsure about which is the best component.
  Typo fixes that have no associated JIRA issue should be named following this pattern: `[hotfix] [docs] Fix typo in event time introduction` or `[hotfix] [javadocs] Expand JavaDoc for PuncuatedWatermarkGenerator`.

  - Fill out the template below to describe the changes contributed by the pull request. That will give reviewers the context they need to do the review.
  
  - Make sure that the change passes the automated tests, i.e., `mvn clean verify` passes. You can set up Azure Pipelines CI to do that following [this guide](https://cwiki.apache.org/confluence/display/FLINK/Azure+Pipelines#AzurePipelines-Tutorial:SettingupAzurePipelinesforaforkoftheFlinkrepository).

  - Each pull request should address only one issue, not mix up code from multiple issues.
  
  - Each commit in the pull request has a meaningful commit message (including the JIRA id)

  - Once all items of the checklist are addressed, remove the above text and this checklist, leaving only the filled out template below.


**(The sections below can be removed for hotfixes of typos)**
-->

## What is the purpose of the change

fix the problem that RocksStateKeysAndNamespaceIterator would return duplicate data

## Brief change log

- Added the logic of filtering the same keyAndNamespace to the next method of RocksStateKeysAndNamespaceIterator
- add unit test for the case that with MapState and update userKey multiple times under the same key


## Verifying this change

Added test that validates that duplicate data could be filtered in `testIteratorUpdateMapStateMultipleTimes`

## Does this pull request potentially affect one of the following parts:

  - Dependencies (does it add or upgrade a dependency): (no)
  - The public API, i.e., is any changed class annotated with `@Public(Evolving)`: (no)
  - The serializers: (no)
  - The runtime per-record code paths (performance sensitive): ( no /)
  - Anything that affects deployment or recovery: JobManager (and its components), Checkpointing, Kubernetes/Yarn, ZooKeeper: ( no )
  - The S3 file system connector: ( no )

## Documentation

  - Does this pull request introduce a new feature?  no)
