### PR TITLE
[FLINK-24600][Runtime / Web Frontend] fix the problem that job checkpoint page has two p99 which is duplicated

### DIFF
--- a/flink-runtime-web/web-dashboard/src/app/pages/job/checkpoints/job-checkpoints.component.html
+++ b/flink-runtime-web/web-dashboard/src/app/pages/job/checkpoints/job-checkpoints.component.html
@@ -397,18 +397,6 @@
                 </td>
               </tr>
               <tr>
-                <td><strong>99% percentile</strong></td>
-                <td>
-                  {{ checkPointStats['summary']['end_to_end_duration']['p99'] | humanizeDuration }}
-                </td>
-                <td>{{ checkPointStats['summary']['state_size']['p99'] | humanizeBytes }}</td>
-                <td>
-                  {{ checkPointStats['summary']['processed_data']['p99'] | humanizeBytes }} ({{
-                    checkPointStats['summary']['persisted_data']['p99'] | humanizeBytes
-                  }})
-                </td>
-              </tr>
-              <tr>
                 <td><strong>99.9% percentile</strong></td>
                 <td>
                   {{ checkPointStats['summary']['end_to_end_duration']['p999'] | humanizeDuration }}


### PR DESCRIPTION
fix the problem that job checkpoint page has two p99 which is duplicated


## What is the purpose of the change

job checkpoint pag have two p99 costtime

![image](https://user-images.githubusercontent.com/5066512/138056428-32654f48-120a-4f3b-9955-e7697298b118.png)



## Brief change log

  - *fix checkpoint summary page Percentiles have two p99 item*



## Verifying this change


This change is a trivial rework / code cleanup without any test coverage.


## Does this pull request potentially affect one of the following parts:

  - Dependencies (does it add or upgrade a dependency): no
  - The public API, i.e., is any changed class annotated with `@Public(Evolving)`: no
  - The serializers: no
  - The runtime per-record code paths (performance sensitive): no
  - Anything that affects deployment or recovery: JobManager (and its components), Checkpointing, Kubernetes/Yarn, ZooKeeper: no
  - The S3 file system connector: no

## Documentation

  - Does this pull request introduce a new feature? 
     no
