### PR TITLE
[FLINK-24604] Remove tests which use decimal -> boolean cast

### DIFF
--- a/flink-table/flink-table-planner/src/test/resources/org/apache/flink/table/planner/plan/rules/logical/SimplifyJoinConditionRuleTest.xml
+++ b/flink-table/flink-table-planner/src/test/resources/org/apache/flink/table/planner/plan/rules/logical/SimplifyJoinConditionRuleTest.xml
@@ -74,7 +74,7 @@ LogicalProject(d=[$3])
   </TestCase>
   <TestCase name="testSimplifyJoinConditionWithCastToTrue">
     <Resource name="sql">
-      <![CDATA[SELECT d FROM MyTable1 JOIN MyTable2 ON CAST(1.1 AS BOOLEAN)]]>
+      <![CDATA[SELECT d FROM MyTable1 JOIN MyTable2 ON CAST(1 AS BOOLEAN)]]>
     </Resource>
     <Resource name="ast">
       <![CDATA[
@@ -95,7 +95,7 @@ LogicalProject(d=[$3])
   </TestCase>
   <TestCase name="testSimplifyJoinConditionWithCastToFalse">
     <Resource name="sql">
-      <![CDATA[SELECT d FROM MyTable1 JOIN MyTable2 ON CAST(0.0 AS BOOLEAN)]]>
+      <![CDATA[SELECT d FROM MyTable1 JOIN MyTable2 ON CAST(0 AS BOOLEAN)]]>
     </Resource>
     <Resource name="ast">
       <![CDATA[

--- a/flink-table/flink-table-planner/src/test/scala/org/apache/flink/table/planner/plan/rules/logical/SimplifyJoinConditionRuleTest.scala
+++ b/flink-table/flink-table-planner/src/test/scala/org/apache/flink/table/planner/plan/rules/logical/SimplifyJoinConditionRuleTest.scala
@@ -68,13 +68,13 @@ class SimplifyJoinConditionRuleTest extends TableTestBase {
 
   @Test
   def testSimplifyJoinConditionWithCastToTrue(): Unit = {
-    val sqlQuery = "SELECT d FROM MyTable1 JOIN MyTable2 ON CAST(1.1 AS BOOLEAN)"
+    val sqlQuery = "SELECT d FROM MyTable1 JOIN MyTable2 ON CAST(1 AS BOOLEAN)"
     util.verifyRelPlan(sqlQuery)
   }
 
   @Test
   def testSimplifyJoinConditionWithCastToFalse(): Unit = {
-    val sqlQuery = "SELECT d FROM MyTable1 JOIN MyTable2 ON CAST(0.0 AS BOOLEAN)"
+    val sqlQuery = "SELECT d FROM MyTable1 JOIN MyTable2 ON CAST(0 AS BOOLEAN)"
     util.verifyRelPlan(sqlQuery)
   }
 }

--- a/flink-table/flink-table-planner/src/test/scala/org/apache/flink/table/planner/plan/utils/FlinkRexUtilTest.scala
+++ b/flink-table/flink-table-planner/src/test/scala/org/apache/flink/table/planner/plan/utils/FlinkRexUtilTest.scala
@@ -481,18 +481,6 @@ class FlinkRexUtilTest {
     val predicate23Cast = makeToBooleanCast(predicate23CastFromData)
     val newPredicate23 = simplify(rexBuilder, predicate23Cast)
     assertEquals(rexBuilder.makeLiteral(true).toString, newPredicate23.toString)
-
-    //CAST(1.1 AS BOOLEAN)
-    val predicate24CastFromData = rexBuilder.makeExactLiteral(BigDecimal.valueOf(1.1))
-    val predicate24Cast = makeToBooleanCast(predicate24CastFromData)
-    val newPredicate24 = simplify(rexBuilder, predicate24Cast)
-    assertEquals(rexBuilder.makeLiteral(true).toString, newPredicate24.toString)
-
-    //CAST(0.000 AS BOOLEAN)
-    val predicate25CastFromData = rexBuilder.makeExactLiteral(BigDecimal.valueOf(0.000))
-    val predicate25Cast = makeToBooleanCast(predicate25CastFromData)
-    val newPredicate25 = simplify(rexBuilder, predicate25Cast)
-    assertEquals(rexBuilder.makeLiteral(false).toString, newPredicate25.toString)
   }
 
   def intLiteral(x: Int): RexLiteral = rexBuilder.makeExactLiteral(BigDecimal.valueOf(x))

--- a/flink-table/flink-table-planner/src/test/scala/org/apache/flink/table/planner/runtime/stream/sql/CalcITCase.scala
+++ b/flink-table/flink-table-planner/src/test/scala/org/apache/flink/table/planner/runtime/stream/sql/CalcITCase.scala
@@ -54,11 +54,9 @@ class CalcITCase extends StreamingTestBase {
   @Test
   def testCastNumericToBooleanInProjection(): Unit ={
     val sqlQuery =
-      "SELECT CAST(1 AS BOOLEAN), CAST(0 AS BOOLEAN), CAST(1.1 AS BOOLEAN), CAST(0.00 AS BOOLEAN)"
+      "SELECT CAST(1 AS BOOLEAN), CAST(0 AS BOOLEAN)"
 
     val outputType = InternalTypeInfo.ofFields(
-      new BooleanType(),
-      new BooleanType(),
       new BooleanType(),
       new BooleanType()
     )
@@ -69,7 +67,7 @@ class CalcITCase extends StreamingTestBase {
     env.execute()
 
     val expected = List(
-      "+I(true,false,true,false)"
+      "+I(true,false)"
     )
     assertEquals(expected.sorted, sink.getAppendResults.sorted)
   }
@@ -81,10 +79,6 @@ class CalcITCase extends StreamingTestBase {
          | SELECT * FROM MyTableRow WHERE b = CAST(1 AS BOOLEAN)
          | UNION ALL
          | SELECT * FROM MyTableRow WHERE b = CAST(0 AS BOOLEAN)
-         | UNION ALL
-         | SELECT * FROM MyTableRow WHERE b = CAST(1.1 AS BOOLEAN)
-         | UNION ALL
-         | SELECT * FROM MyTableRow WHERE b = CAST(0.0 AS BOOLEAN)
          |""".stripMargin
 
     val rowData1: GenericRowData = new GenericRowData(2)
@@ -117,8 +111,6 @@ class CalcITCase extends StreamingTestBase {
     env.execute()
 
     val expected = List(
-      "+I(1,true)",
-      "+I(2,false)",
       "+I(1,true)",
       "+I(2,false)"
     )


### PR DESCRIPTION
The decimal->boolean cast has been dropped but another PR added some
tests using this cast, removing the casts, and keep only the ones that
cast integer numerics to boolean.

Follows: 32f7cc9e34be67eaf1b746697f2fabefcd5f46c5
Follows: fc92a8830d07416d37be0ed4c5fe472ac0531c25

## Does this pull request potentially affect one of the following parts:

  - Dependencies (does it add or upgrade a dependency): no
  - The public API, i.e., is any changed class annotated with `@Public(Evolving)`: no
  - The serializers: no
  - The runtime per-record code paths (performance sensitive): no
  - Anything that affects deployment or recovery: JobManager (and its components), Checkpointing, Kubernetes/Yarn, ZooKeeper: no
  - The S3 file system connector: no

## Documentation

  - Does this pull request introduce a new feature? no
  - If yes, how is the feature documented? not applicable
