### PR TITLE
[FLINK-24610][table-planner] Support sql projection common expression…

### DIFF
--- a/flink-table/flink-table-planner/src/main/java/org/apache/flink/table/planner/plan/nodes/exec/batch/BatchExecCalc.java
+++ b/flink-table/flink-table-planner/src/main/java/org/apache/flink/table/planner/plan/nodes/exec/batch/BatchExecCalc.java
@@ -25,7 +25,6 @@ import org.apache.flink.table.planner.plan.nodes.exec.common.CommonExecCalc;
 import org.apache.flink.table.runtime.operators.TableStreamOperator;
 import org.apache.flink.table.types.logical.RowType;
 
-import org.apache.calcite.rex.RexLocalRef;
 import org.apache.calcite.rex.RexNode;
 
 import javax.annotation.Nullable;
@@ -38,7 +37,7 @@ public class BatchExecCalc extends CommonExecCalc implements BatchExecNode<RowDa
 
     public BatchExecCalc(
             List<RexNode> projection,
-            List<RexLocalRef> localRefs,
+            List<RexNode> localRefs,
             List<RexNode> expandLocalRefs,
             @Nullable RexNode condition,
             InputProperty inputProperty,

--- a/flink-table/flink-table-planner/src/main/java/org/apache/flink/table/planner/plan/nodes/exec/batch/BatchExecCalc.java
+++ b/flink-table/flink-table-planner/src/main/java/org/apache/flink/table/planner/plan/nodes/exec/batch/BatchExecCalc.java
@@ -25,6 +25,7 @@ import org.apache.flink.table.planner.plan.nodes.exec.common.CommonExecCalc;
 import org.apache.flink.table.runtime.operators.TableStreamOperator;
 import org.apache.flink.table.types.logical.RowType;
 
+import org.apache.calcite.rex.RexLocalRef;
 import org.apache.calcite.rex.RexNode;
 
 import javax.annotation.Nullable;
@@ -37,12 +38,14 @@ public class BatchExecCalc extends CommonExecCalc implements BatchExecNode<RowDa
 
     public BatchExecCalc(
             List<RexNode> projection,
+            List<RexLocalRef> localRefs,
             @Nullable RexNode condition,
             InputProperty inputProperty,
             RowType outputType,
             String description) {
         super(
                 projection,
+                localRefs,
                 condition,
                 TableStreamOperator.class,
                 false, // retainHeader

--- a/flink-table/flink-table-planner/src/main/java/org/apache/flink/table/planner/plan/nodes/exec/batch/BatchExecCalc.java
+++ b/flink-table/flink-table-planner/src/main/java/org/apache/flink/table/planner/plan/nodes/exec/batch/BatchExecCalc.java
@@ -36,17 +36,17 @@ import java.util.List;
 public class BatchExecCalc extends CommonExecCalc implements BatchExecNode<RowData> {
 
     public BatchExecCalc(
-            List<RexNode> projection,
+            List<RexNode> expList,
             List<RexNode> localRefs,
-            List<RexNode> expandLocalRefs,
+            List<RexNode> projection,
             @Nullable RexNode condition,
             InputProperty inputProperty,
             RowType outputType,
             String description) {
         super(
-                projection,
+                expList,
                 localRefs,
-                expandLocalRefs,
+                projection,
                 condition,
                 TableStreamOperator.class,
                 false, // retainHeader

--- a/flink-table/flink-table-planner/src/main/java/org/apache/flink/table/planner/plan/nodes/exec/batch/BatchExecCalc.java
+++ b/flink-table/flink-table-planner/src/main/java/org/apache/flink/table/planner/plan/nodes/exec/batch/BatchExecCalc.java
@@ -39,6 +39,7 @@ public class BatchExecCalc extends CommonExecCalc implements BatchExecNode<RowDa
     public BatchExecCalc(
             List<RexNode> projection,
             List<RexLocalRef> localRefs,
+            List<RexNode> expandLocalRefs,
             @Nullable RexNode condition,
             InputProperty inputProperty,
             RowType outputType,
@@ -46,6 +47,7 @@ public class BatchExecCalc extends CommonExecCalc implements BatchExecNode<RowDa
         super(
                 projection,
                 localRefs,
+                expandLocalRefs,
                 condition,
                 TableStreamOperator.class,
                 false, // retainHeader

--- a/flink-table/flink-table-planner/src/main/java/org/apache/flink/table/planner/plan/nodes/exec/common/CommonExecCalc.java
+++ b/flink-table/flink-table-planner/src/main/java/org/apache/flink/table/planner/plan/nodes/exec/common/CommonExecCalc.java
@@ -54,6 +54,7 @@ public abstract class CommonExecCalc extends ExecNodeBase<RowData>
         implements SingleTransformationTranslator<RowData> {
     public static final String FIELD_NAME_PROJECTION = "projection";
     public static final String FIELD_NAME_LOCAL_REFS = "localRefs";
+    public static final String FIELD_EXPAND_LOCAL_REF = "expandLocalRef";
     public static final String FIELD_NAME_CONDITION = "condition";
 
     @JsonProperty(FIELD_NAME_PROJECTION)
@@ -61,6 +62,9 @@ public abstract class CommonExecCalc extends ExecNodeBase<RowData>
 
     @JsonProperty(FIELD_NAME_LOCAL_REFS)
     private final List<RexLocalRef> localRefs;
+
+    @JsonProperty(FIELD_EXPAND_LOCAL_REF)
+    private final List<RexNode> expandLocalRefs;
 
     @JsonProperty(FIELD_NAME_CONDITION)
     private final @Nullable RexNode condition;
@@ -71,6 +75,7 @@ public abstract class CommonExecCalc extends ExecNodeBase<RowData>
     protected CommonExecCalc(
             List<RexNode> projection,
             List<RexLocalRef> localRefs,
+            List<RexNode> expandLocalRefs,
             @Nullable RexNode condition,
             Class<?> operatorBaseClass,
             boolean retainHeader,
@@ -82,6 +87,7 @@ public abstract class CommonExecCalc extends ExecNodeBase<RowData>
         checkArgument(inputProperties.size() == 1);
         this.projection = checkNotNull(projection);
         this.localRefs = localRefs;
+        this.expandLocalRefs = expandLocalRefs;
         this.condition = condition;
         this.operatorBaseClass = checkNotNull(operatorBaseClass);
         this.retainHeader = retainHeader;
@@ -97,6 +103,7 @@ public abstract class CommonExecCalc extends ExecNodeBase<RowData>
                 new CodeGeneratorContext(planner.getTableConfig())
                         .setOperatorBaseClass(operatorBaseClass)
                         .setLocalRefs(localRefs)
+                        .setExpendLocalRefs(expandLocalRefs)
                         .loadProjection(projection);
 
         final CodeGenOperatorFactory<RowData> substituteStreamOperator =

--- a/flink-table/flink-table-planner/src/main/java/org/apache/flink/table/planner/plan/nodes/exec/common/CommonExecCalc.java
+++ b/flink-table/flink-table-planner/src/main/java/org/apache/flink/table/planner/plan/nodes/exec/common/CommonExecCalc.java
@@ -38,7 +38,6 @@ import org.apache.flink.shaded.jackson2.com.fasterxml.jackson.annotation.JsonIgn
 import org.apache.flink.shaded.jackson2.com.fasterxml.jackson.annotation.JsonIgnoreProperties;
 import org.apache.flink.shaded.jackson2.com.fasterxml.jackson.annotation.JsonProperty;
 
-import org.apache.calcite.rex.RexLocalRef;
 import org.apache.calcite.rex.RexNode;
 
 import javax.annotation.Nullable;
@@ -53,12 +52,17 @@ import static org.apache.flink.util.Preconditions.checkNotNull;
 @JsonIgnoreProperties(ignoreUnknown = true)
 public abstract class CommonExecCalc extends ExecNodeBase<RowData>
         implements SingleTransformationTranslator<RowData> {
+
+    public static final String FIELD_NAME_EXP_LIST = "expList";
+    public static final String FIELD_NAME_LOCAL_REFS = "localRefs";
     public static final String FIELD_NAME_PROJECTION = "projection";
     public static final String FIELD_NAME_CONDITION = "condition";
 
-    @JsonIgnore private final List<RexNode> expList;
+    @JsonProperty(FIELD_NAME_EXP_LIST)
+    private final List<RexNode> expList;
 
-    @JsonIgnore private final List<RexLocalRef> localRefs;
+    @JsonProperty(FIELD_NAME_LOCAL_REFS)
+    private final List<RexNode> localRefs;
 
     @JsonProperty(FIELD_NAME_PROJECTION)
     private final List<RexNode> projection;
@@ -71,7 +75,7 @@ public abstract class CommonExecCalc extends ExecNodeBase<RowData>
 
     protected CommonExecCalc(
             List<RexNode> expList,
-            List<RexLocalRef> localRefs,
+            List<RexNode> localRefs,
             List<RexNode> projection,
             @Nullable RexNode condition,
             Class<?> operatorBaseClass,

--- a/flink-table/flink-table-planner/src/main/java/org/apache/flink/table/planner/plan/nodes/exec/common/CommonExecCalc.java
+++ b/flink-table/flink-table-planner/src/main/java/org/apache/flink/table/planner/plan/nodes/exec/common/CommonExecCalc.java
@@ -88,7 +88,7 @@ public abstract class CommonExecCalc extends ExecNodeBase<RowData>
         checkArgument(inputProperties.size() == 1);
         this.expList = checkNotNull(expList);
         this.localRefs = localRefs;
-        this.projection = projection;
+        this.projection = checkNotNull(projection);
         this.condition = condition;
         this.operatorBaseClass = checkNotNull(operatorBaseClass);
         this.retainHeader = retainHeader;

--- a/flink-table/flink-table-planner/src/main/java/org/apache/flink/table/planner/plan/nodes/exec/common/CommonExecCalc.java
+++ b/flink-table/flink-table-planner/src/main/java/org/apache/flink/table/planner/plan/nodes/exec/common/CommonExecCalc.java
@@ -56,12 +56,12 @@ public abstract class CommonExecCalc extends ExecNodeBase<RowData>
     public static final String FIELD_NAME_PROJECTION = "projection";
     public static final String FIELD_NAME_CONDITION = "condition";
 
-    @JsonIgnore private final List<RexNode> projection;
+    @JsonIgnore private final List<RexNode> expList;
 
     @JsonIgnore private final List<RexLocalRef> localRefs;
 
     @JsonProperty(FIELD_NAME_PROJECTION)
-    private final List<RexNode> expandLocalRefs;
+    private final List<RexNode> projection;
 
     @JsonProperty(FIELD_NAME_CONDITION)
     private final @Nullable RexNode condition;
@@ -70,9 +70,9 @@ public abstract class CommonExecCalc extends ExecNodeBase<RowData>
     @JsonIgnore private final boolean retainHeader;
 
     protected CommonExecCalc(
-            List<RexNode> projection,
+            List<RexNode> expList,
             List<RexLocalRef> localRefs,
-            List<RexNode> expandLocalRefs,
+            List<RexNode> projection,
             @Nullable RexNode condition,
             Class<?> operatorBaseClass,
             boolean retainHeader,
@@ -82,9 +82,9 @@ public abstract class CommonExecCalc extends ExecNodeBase<RowData>
             String description) {
         super(id, inputProperties, outputType, description);
         checkArgument(inputProperties.size() == 1);
-        this.projection = checkNotNull(projection);
+        this.expList = checkNotNull(expList);
         this.localRefs = localRefs;
-        this.expandLocalRefs = expandLocalRefs;
+        this.projection = projection;
         this.condition = condition;
         this.operatorBaseClass = checkNotNull(operatorBaseClass);
         this.retainHeader = retainHeader;
@@ -99,9 +99,9 @@ public abstract class CommonExecCalc extends ExecNodeBase<RowData>
         final CodeGeneratorContext ctx =
                 new ProjectCodeGeneratorContext(
                                 planner.getTableConfig(),
-                                projection,
+                                expList,
                                 JavaScalaConversionUtil.toScala(localRefs),
-                                JavaScalaConversionUtil.toScala(expandLocalRefs))
+                                JavaScalaConversionUtil.toScala(projection))
                         .setOperatorBaseClass(operatorBaseClass);
 
         final CodeGenOperatorFactory<RowData> substituteStreamOperator =
@@ -109,7 +109,7 @@ public abstract class CommonExecCalc extends ExecNodeBase<RowData>
                         ctx,
                         inputTransform,
                         (RowType) getOutputType(),
-                        JavaScalaConversionUtil.toScala(projection),
+                        JavaScalaConversionUtil.toScala(expList),
                         JavaScalaConversionUtil.toScala(Optional.ofNullable(this.condition)),
                         retainHeader,
                         getClass().getSimpleName());

--- a/flink-table/flink-table-planner/src/main/java/org/apache/flink/table/planner/plan/nodes/exec/serde/RexNodeJsonSerializer.java
+++ b/flink-table/flink-table-planner/src/main/java/org/apache/flink/table/planner/plan/nodes/exec/serde/RexNodeJsonSerializer.java
@@ -36,6 +36,7 @@ import org.apache.calcite.rex.RexCorrelVariable;
 import org.apache.calcite.rex.RexFieldAccess;
 import org.apache.calcite.rex.RexInputRef;
 import org.apache.calcite.rex.RexLiteral;
+import org.apache.calcite.rex.RexLocalRef;
 import org.apache.calcite.rex.RexNode;
 import org.apache.calcite.rex.RexPatternFieldRef;
 import org.apache.calcite.runtime.FlatLists;
@@ -89,6 +90,7 @@ public class RexNodeJsonSerializer extends StdSerializer<RexNode> {
     // supported SqlKinds
     public static final String SQL_KIND_PATTERN_INPUT_REF = "PATTERN_INPUT_REF";
     public static final String SQL_KIND_INPUT_REF = "INPUT_REF";
+    public static final String SQL_KIND_LOCAL_REF = "LOCAL_REF";
     public static final String SQL_KIND_LITERAL = "LITERAL";
     public static final String SQL_KIND_FIELD_ACCESS = "FIELD_ACCESS";
     public static final String SQL_KIND_CORREL_VARIABLE = "CORREL_VARIABLE";
@@ -120,6 +122,9 @@ public class RexNodeJsonSerializer extends StdSerializer<RexNode> {
             case PATTERN_INPUT_REF:
                 serialize((RexPatternFieldRef) rexNode, jsonGenerator);
                 break;
+            case LOCAL_REF:
+                serialize((RexLocalRef) rexNode, jsonGenerator);
+                break;
             default:
                 if (rexNode instanceof RexCall) {
                     serialize((RexCall) rexNode, jsonGenerator);
@@ -127,6 +132,14 @@ public class RexNodeJsonSerializer extends StdSerializer<RexNode> {
                     throw new TableException("Unknown RexNode: " + rexNode);
                 }
         }
+    }
+
+    private void serialize(RexLocalRef localRef, JsonGenerator gen) throws IOException {
+        gen.writeStartObject();
+        gen.writeStringField(FIELD_NAME_KIND, SQL_KIND_LOCAL_REF);
+        gen.writeNumberField(FIELD_NAME_INPUT_INDEX, localRef.getIndex());
+        gen.writeObjectField(FIELD_NAME_TYPE, localRef.getType());
+        gen.writeEndObject();
     }
 
     private void serialize(RexPatternFieldRef inputRef, JsonGenerator gen) throws IOException {

--- a/flink-table/flink-table-planner/src/main/java/org/apache/flink/table/planner/plan/nodes/exec/stream/StreamExecCalc.java
+++ b/flink-table/flink-table-planner/src/main/java/org/apache/flink/table/planner/plan/nodes/exec/stream/StreamExecCalc.java
@@ -62,9 +62,9 @@ public class StreamExecCalc extends CommonExecCalc implements StreamExecNode<Row
 
     @JsonCreator
     public StreamExecCalc(
-            @JsonProperty(FIELD_NAME_PROJECTION) List<RexNode> projection,
-            @JsonProperty(FIELD_NAME_LOCAL_REFS) List<RexLocalRef> localRefs,
-            @JsonProperty(FIELD_EXPAND_LOCAL_REF) List<RexNode> expandLocalRef,
+            List<RexNode> projection,
+            List<RexLocalRef> localRefs,
+            @JsonProperty(FIELD_NAME_PROJECTION) List<RexNode> expandLocalRef,
             @JsonProperty(FIELD_NAME_CONDITION) @Nullable RexNode condition,
             @JsonProperty(FIELD_NAME_ID) int id,
             @JsonProperty(FIELD_NAME_INPUT_PROPERTIES) List<InputProperty> inputProperties,

--- a/flink-table/flink-table-planner/src/main/java/org/apache/flink/table/planner/plan/nodes/exec/stream/StreamExecCalc.java
+++ b/flink-table/flink-table-planner/src/main/java/org/apache/flink/table/planner/plan/nodes/exec/stream/StreamExecCalc.java
@@ -41,17 +41,17 @@ import java.util.List;
 public class StreamExecCalc extends CommonExecCalc implements StreamExecNode<RowData> {
 
     public StreamExecCalc(
-            List<RexNode> projection,
+            List<RexNode> expList,
             List<RexNode> localRefs,
-            List<RexNode> expandLocalRef,
+            List<RexNode> projection,
             @Nullable RexNode condition,
             InputProperty inputProperty,
             RowType outputType,
             String description) {
         this(
-                projection,
+                expList,
                 localRefs,
-                expandLocalRef,
+                projection,
                 condition,
                 getNewNodeId(),
                 Collections.singletonList(inputProperty),

--- a/flink-table/flink-table-planner/src/main/java/org/apache/flink/table/planner/plan/nodes/exec/stream/StreamExecCalc.java
+++ b/flink-table/flink-table-planner/src/main/java/org/apache/flink/table/planner/plan/nodes/exec/stream/StreamExecCalc.java
@@ -62,18 +62,18 @@ public class StreamExecCalc extends CommonExecCalc implements StreamExecNode<Row
 
     @JsonCreator
     public StreamExecCalc(
-            List<RexNode> projection,
+            List<RexNode> expList,
             List<RexLocalRef> localRefs,
-            @JsonProperty(FIELD_NAME_PROJECTION) List<RexNode> expandLocalRef,
+            @JsonProperty(FIELD_NAME_PROJECTION) List<RexNode> projection,
             @JsonProperty(FIELD_NAME_CONDITION) @Nullable RexNode condition,
             @JsonProperty(FIELD_NAME_ID) int id,
             @JsonProperty(FIELD_NAME_INPUT_PROPERTIES) List<InputProperty> inputProperties,
             @JsonProperty(FIELD_NAME_OUTPUT_TYPE) RowType outputType,
             @JsonProperty(FIELD_NAME_DESCRIPTION) String description) {
         super(
-                projection,
+                expList,
                 localRefs,
-                expandLocalRef,
+                projection,
                 condition,
                 TableStreamOperator.class,
                 true, // retainHeader

--- a/flink-table/flink-table-planner/src/main/java/org/apache/flink/table/planner/plan/nodes/exec/stream/StreamExecCalc.java
+++ b/flink-table/flink-table-planner/src/main/java/org/apache/flink/table/planner/plan/nodes/exec/stream/StreamExecCalc.java
@@ -29,7 +29,6 @@ import org.apache.flink.shaded.jackson2.com.fasterxml.jackson.annotation.JsonCre
 import org.apache.flink.shaded.jackson2.com.fasterxml.jackson.annotation.JsonIgnoreProperties;
 import org.apache.flink.shaded.jackson2.com.fasterxml.jackson.annotation.JsonProperty;
 
-import org.apache.calcite.rex.RexLocalRef;
 import org.apache.calcite.rex.RexNode;
 
 import javax.annotation.Nullable;
@@ -43,7 +42,7 @@ public class StreamExecCalc extends CommonExecCalc implements StreamExecNode<Row
 
     public StreamExecCalc(
             List<RexNode> projection,
-            List<RexLocalRef> localRefs,
+            List<RexNode> localRefs,
             List<RexNode> expandLocalRef,
             @Nullable RexNode condition,
             InputProperty inputProperty,
@@ -62,8 +61,8 @@ public class StreamExecCalc extends CommonExecCalc implements StreamExecNode<Row
 
     @JsonCreator
     public StreamExecCalc(
-            List<RexNode> expList,
-            List<RexLocalRef> localRefs,
+            @JsonProperty(FIELD_NAME_EXP_LIST) List<RexNode> expList,
+            @JsonProperty(FIELD_NAME_LOCAL_REFS) List<RexNode> localRefs,
             @JsonProperty(FIELD_NAME_PROJECTION) List<RexNode> projection,
             @JsonProperty(FIELD_NAME_CONDITION) @Nullable RexNode condition,
             @JsonProperty(FIELD_NAME_ID) int id,

--- a/flink-table/flink-table-planner/src/main/java/org/apache/flink/table/planner/plan/nodes/exec/stream/StreamExecCalc.java
+++ b/flink-table/flink-table-planner/src/main/java/org/apache/flink/table/planner/plan/nodes/exec/stream/StreamExecCalc.java
@@ -29,6 +29,7 @@ import org.apache.flink.shaded.jackson2.com.fasterxml.jackson.annotation.JsonCre
 import org.apache.flink.shaded.jackson2.com.fasterxml.jackson.annotation.JsonIgnoreProperties;
 import org.apache.flink.shaded.jackson2.com.fasterxml.jackson.annotation.JsonProperty;
 
+import org.apache.calcite.rex.RexLocalRef;
 import org.apache.calcite.rex.RexNode;
 
 import javax.annotation.Nullable;
@@ -42,12 +43,14 @@ public class StreamExecCalc extends CommonExecCalc implements StreamExecNode<Row
 
     public StreamExecCalc(
             List<RexNode> projection,
+            List<RexLocalRef> localRefs,
             @Nullable RexNode condition,
             InputProperty inputProperty,
             RowType outputType,
             String description) {
         this(
                 projection,
+                localRefs,
                 condition,
                 getNewNodeId(),
                 Collections.singletonList(inputProperty),
@@ -58,6 +61,7 @@ public class StreamExecCalc extends CommonExecCalc implements StreamExecNode<Row
     @JsonCreator
     public StreamExecCalc(
             @JsonProperty(FIELD_NAME_PROJECTION) List<RexNode> projection,
+            @JsonProperty(FIELD_NAME_LOCAL_REFS) List<RexLocalRef> localRefs,
             @JsonProperty(FIELD_NAME_CONDITION) @Nullable RexNode condition,
             @JsonProperty(FIELD_NAME_ID) int id,
             @JsonProperty(FIELD_NAME_INPUT_PROPERTIES) List<InputProperty> inputProperties,
@@ -65,6 +69,7 @@ public class StreamExecCalc extends CommonExecCalc implements StreamExecNode<Row
             @JsonProperty(FIELD_NAME_DESCRIPTION) String description) {
         super(
                 projection,
+                localRefs,
                 condition,
                 TableStreamOperator.class,
                 true, // retainHeader

--- a/flink-table/flink-table-planner/src/main/java/org/apache/flink/table/planner/plan/nodes/exec/stream/StreamExecCalc.java
+++ b/flink-table/flink-table-planner/src/main/java/org/apache/flink/table/planner/plan/nodes/exec/stream/StreamExecCalc.java
@@ -44,6 +44,7 @@ public class StreamExecCalc extends CommonExecCalc implements StreamExecNode<Row
     public StreamExecCalc(
             List<RexNode> projection,
             List<RexLocalRef> localRefs,
+            List<RexNode> expandLocalRef,
             @Nullable RexNode condition,
             InputProperty inputProperty,
             RowType outputType,
@@ -51,6 +52,7 @@ public class StreamExecCalc extends CommonExecCalc implements StreamExecNode<Row
         this(
                 projection,
                 localRefs,
+                expandLocalRef,
                 condition,
                 getNewNodeId(),
                 Collections.singletonList(inputProperty),
@@ -62,6 +64,7 @@ public class StreamExecCalc extends CommonExecCalc implements StreamExecNode<Row
     public StreamExecCalc(
             @JsonProperty(FIELD_NAME_PROJECTION) List<RexNode> projection,
             @JsonProperty(FIELD_NAME_LOCAL_REFS) List<RexLocalRef> localRefs,
+            @JsonProperty(FIELD_EXPAND_LOCAL_REF) List<RexNode> expandLocalRef,
             @JsonProperty(FIELD_NAME_CONDITION) @Nullable RexNode condition,
             @JsonProperty(FIELD_NAME_ID) int id,
             @JsonProperty(FIELD_NAME_INPUT_PROPERTIES) List<InputProperty> inputProperties,
@@ -70,6 +73,7 @@ public class StreamExecCalc extends CommonExecCalc implements StreamExecNode<Row
         super(
                 projection,
                 localRefs,
+                expandLocalRef,
                 condition,
                 TableStreamOperator.class,
                 true, // retainHeader

--- a/flink-table/flink-table-planner/src/main/scala/org/apache/flink/table/planner/codegen/CalcCodeGenerator.scala
+++ b/flink-table/flink-table-planner/src/main/scala/org/apache/flink/table/planner/codegen/CalcCodeGenerator.scala
@@ -123,7 +123,7 @@ object CalcCodeGenerator {
         .bindInput(inputType, inputTerm = inputTerm)
 
     val checkNodesList = ctx match {
-      case projectCtx: ProjectCodeGeneratorContext => projectCtx.getExpandLocalRefs
+      case projectCtx: ProjectCodeGeneratorContext => projectCtx.getProjection
       case _ => projection
     }
     val onlyFilter = checkNodesList.lengthCompare(inputType.getFieldCount) == 0 &&

--- a/flink-table/flink-table-planner/src/main/scala/org/apache/flink/table/planner/codegen/CalcCodeGenerator.scala
+++ b/flink-table/flink-table-planner/src/main/scala/org/apache/flink/table/planner/codegen/CalcCodeGenerator.scala
@@ -122,8 +122,13 @@ object CalcCodeGenerator {
     val exprGenerator = new ExprCodeGenerator(ctx, false)
         .bindInput(inputType, inputTerm = inputTerm)
 
-    val onlyFilter = ctx.getLocalRefs.lengthCompare(inputType.getFieldCount) == 0 &&
-      projection.zipWithIndex.forall { case (rexNode, index) =>
+    val checkNodesList = if (ctx.getExpandLocalRefs == null) {
+      projection
+    } else {
+      ctx.getExpandLocalRefs
+    }
+    val onlyFilter = checkNodesList.lengthCompare(inputType.getFieldCount) == 0 &&
+      checkNodesList.zipWithIndex.forall { case (rexNode, index) =>
         rexNode.isInstanceOf[RexInputRef] && rexNode.asInstanceOf[RexInputRef].getIndex == index
       }
 

--- a/flink-table/flink-table-planner/src/main/scala/org/apache/flink/table/planner/codegen/CalcCodeGenerator.scala
+++ b/flink-table/flink-table-planner/src/main/scala/org/apache/flink/table/planner/codegen/CalcCodeGenerator.scala
@@ -122,7 +122,7 @@ object CalcCodeGenerator {
     val exprGenerator = new ExprCodeGenerator(ctx, false)
         .bindInput(inputType, inputTerm = inputTerm)
 
-    val onlyFilter = projection.lengthCompare(inputType.getFieldCount) == 0 &&
+    val onlyFilter = ctx.getLocalRefs.lengthCompare(inputType.getFieldCount) == 0 &&
       projection.zipWithIndex.forall { case (rexNode, index) =>
         rexNode.isInstanceOf[RexInputRef] && rexNode.asInstanceOf[RexInputRef].getIndex == index
       }
@@ -134,7 +134,9 @@ object CalcCodeGenerator {
     }
 
     def produceProjectionCode: String = {
-      val projectionExprs = projection.map(exprGenerator.generateExpression)
+      ctx.cleanupCommonExpression()
+      var projectionExprs = projection.map(exprGenerator.generateExpression)
+      projectionExprs = ctx.commonExpressionElimination(projectionExprs)
       val projectionExpression = exprGenerator.generateResultExpression(
         projectionExprs,
         outRowType,

--- a/flink-table/flink-table-planner/src/main/scala/org/apache/flink/table/planner/codegen/CodeGeneratorContext.scala
+++ b/flink-table/flink-table-planner/src/main/scala/org/apache/flink/table/planner/codegen/CodeGeneratorContext.scala
@@ -36,9 +36,9 @@ import org.apache.flink.table.types.logical.LogicalTypeRoot._
 import org.apache.flink.table.types.logical._
 import org.apache.flink.util.InstantiationUtil
 
-import java.time.ZoneId
 import java.util.TimeZone
 import java.util.function.{Supplier => JSupplier}
+import java.time.ZoneId
 
 import scala.collection.mutable
 

--- a/flink-table/flink-table-planner/src/main/scala/org/apache/flink/table/planner/codegen/CodeGeneratorContext.scala
+++ b/flink-table/flink-table-planner/src/main/scala/org/apache/flink/table/planner/codegen/CodeGeneratorContext.scala
@@ -18,10 +18,6 @@
 
 package org.apache.flink.table.planner.codegen
 
-import java.time.ZoneId
-import java.util.TimeZone
-import java.util.function.{Supplier => JSupplier}
-
 import org.apache.flink.api.common.functions.{Function, RuntimeContext}
 import org.apache.flink.api.common.typeutils.TypeSerializer
 import org.apache.flink.table.api.TableConfig
@@ -39,6 +35,10 @@ import org.apache.flink.table.types.DataType
 import org.apache.flink.table.types.logical.LogicalTypeRoot._
 import org.apache.flink.table.types.logical._
 import org.apache.flink.util.InstantiationUtil
+
+import java.time.ZoneId
+import java.util.TimeZone
+import java.util.function.{Supplier => JSupplier}
 
 import scala.collection.mutable
 
@@ -134,10 +134,10 @@ class CodeGeneratorContext(val tableConfig: TableConfig) {
     */
   private var operatorBaseClass: Class[_] = classOf[TableStreamOperator[_]]
 
-
   // ---------------------------------------------------------------------------------
   // Getter
   // ---------------------------------------------------------------------------------
+
   def getReusableInputUnboxingExprs(inputTerm: String, index: Int): Option[GeneratedExpression] =
     reusableInputUnboxingExprs.get((inputTerm, index))
 

--- a/flink-table/flink-table-planner/src/main/scala/org/apache/flink/table/planner/codegen/CodeGeneratorContext.scala
+++ b/flink-table/flink-table-planner/src/main/scala/org/apache/flink/table/planner/codegen/CodeGeneratorContext.scala
@@ -137,6 +137,7 @@ class CodeGeneratorContext(val tableConfig: TableConfig) {
   private var operatorBaseClass: Class[_] = classOf[TableStreamOperator[_]]
 
   private var localRefs: Seq[RexLocalRef] = null
+  private var expandLocalRefs: Seq[RexNode] = null
 
   private val projectionIndexMapping: mutable.Map[Int, RexNode] =
     mutable.Map[Int, RexNode]()
@@ -165,7 +166,9 @@ class CodeGeneratorContext(val tableConfig: TableConfig) {
 
   def commonExpressionElimination(fieldExprs: Seq[GeneratedExpression]):
     Seq[GeneratedExpression] = {
-
+    if(localRefs == null) {
+      return fieldExprs
+    }
     var result:Seq[GeneratedExpression] = List()
     var offset = 0
     localRefs.foreach(localRef => {
@@ -186,9 +189,19 @@ class CodeGeneratorContext(val tableConfig: TableConfig) {
 
   def setLocalRefs(localRefs: java.util.List[RexLocalRef]) : CodeGeneratorContext = {
     if(localRefs == null) {
-      return this;
+      return this
     }
     this.localRefs = JavaScalaConversionUtil.toScala(localRefs)
+    this
+  }
+
+  def getExpandLocalRefs = expandLocalRefs;
+
+  def setExpendLocalRefs(expandLocalRefs: java.util.List[RexNode]) : CodeGeneratorContext = {
+    if(expandLocalRefs == null) {
+      return this
+    }
+    this.expandLocalRefs = JavaScalaConversionUtil.toScala(expandLocalRefs)
     this
   }
 

--- a/flink-table/flink-table-planner/src/main/scala/org/apache/flink/table/planner/codegen/CodeGeneratorContext.scala
+++ b/flink-table/flink-table-planner/src/main/scala/org/apache/flink/table/planner/codegen/CodeGeneratorContext.scala
@@ -18,6 +18,10 @@
 
 package org.apache.flink.table.planner.codegen
 
+import java.time.ZoneId
+import java.util.TimeZone
+import java.util.function.{Supplier => JSupplier}
+
 import org.apache.flink.api.common.functions.{Function, RuntimeContext}
 import org.apache.flink.api.common.typeutils.TypeSerializer
 import org.apache.flink.table.api.TableConfig
@@ -26,7 +30,7 @@ import org.apache.flink.table.data.conversion.{DataStructureConverter, DataStruc
 import org.apache.flink.table.functions.{FunctionContext, UserDefinedFunction}
 import org.apache.flink.table.planner.codegen.CodeGenUtils._
 import org.apache.flink.table.planner.codegen.GenerateUtils.generateRecordStatement
-import org.apache.flink.table.planner.utils.{InternalConfigOptions, JavaScalaConversionUtil}
+import org.apache.flink.table.planner.utils.InternalConfigOptions
 import org.apache.flink.table.runtime.functions.SqlDateTimeUtils
 import org.apache.flink.table.runtime.operators.TableStreamOperator
 import org.apache.flink.table.runtime.typeutils.{ExternalSerializer, InternalSerializers}
@@ -35,14 +39,8 @@ import org.apache.flink.table.types.DataType
 import org.apache.flink.table.types.logical.LogicalTypeRoot._
 import org.apache.flink.table.types.logical._
 import org.apache.flink.util.InstantiationUtil
-import java.util.TimeZone
-import java.util.function.{Supplier => JSupplier}
-import java.time.ZoneId
-import java.util
 
-import org.apache.calcite.rex.{RexLocalRef, RexNode}
-
-import scala.collection.{JavaConverters, mutable}
+import scala.collection.mutable
 
 /**
   * The context for code generator, maintaining various reusable statements that could be insert
@@ -136,89 +134,10 @@ class CodeGeneratorContext(val tableConfig: TableConfig) {
     */
   private var operatorBaseClass: Class[_] = classOf[TableStreamOperator[_]]
 
-  private var localRefs: Seq[RexLocalRef] = null
-  private var expandLocalRefs: Seq[RexNode] = null
-
-  private val projectionIndexMapping: mutable.Map[Int, RexNode] =
-    mutable.Map[Int, RexNode]()
-
-  private val reuseExpression: mutable.Map[RexNode, GeneratedExpression] =
-    mutable.Map[RexNode, GeneratedExpression]()
-
 
   // ---------------------------------------------------------------------------------
   // Getter
   // ---------------------------------------------------------------------------------
-
-  def addCommonExpression(rexNode: RexNode, expression: GeneratedExpression):
-    GeneratedExpression = {
-    reuseExpression.put(rexNode, expression)
-    expression
-  }
-
-  def cleanupCommonExpression() = {
-    reuseExpression.clear()
-  }
-
-  def getCommonExpression(rexNode: RexNode): GeneratedExpression = {
-    reuseExpression.getOrElse(rexNode, null)
-  }
-
-  def commonExpressionElimination(fieldExprs: Seq[GeneratedExpression]):
-    Seq[GeneratedExpression] = {
-    if(localRefs == null) {
-      return fieldExprs
-    }
-    var result:Seq[GeneratedExpression] = List()
-    var offset = 0
-    localRefs.foreach(localRef => {
-      var code = ""
-      for(i <- offset until localRef.getIndex + 1) {
-        val expression = fieldExprs(i)
-        code =
-          s"""$code
-             |${expression.code}""".stripMargin
-      }
-      result = result :+  fieldExprs(localRef.getIndex).copy(code = code)
-      offset = localRef.getIndex + 1
-    })
-    result
-  }
-
-  def getLocalRefs = localRefs
-
-  def setLocalRefs(localRefs: java.util.List[RexLocalRef]) : CodeGeneratorContext = {
-    if(localRefs == null) {
-      return this
-    }
-    this.localRefs = JavaScalaConversionUtil.toScala(localRefs)
-    this
-  }
-
-  def getExpandLocalRefs = expandLocalRefs;
-
-  def setExpendLocalRefs(expandLocalRefs: java.util.List[RexNode]) : CodeGeneratorContext = {
-    if(expandLocalRefs == null) {
-      return this
-    }
-    this.expandLocalRefs = JavaScalaConversionUtil.toScala(expandLocalRefs)
-    this
-  }
-
-  def getRexNodeIndex(index: Int) : RexNode = {
-    projectionIndexMapping.getOrElse(index, null)
-  }
-
-  def loadProjection(projection: util.List[RexNode]) : CodeGeneratorContext = {
-    if(projection != null && !projection.isEmpty) {
-      JavaScalaConversionUtil.toScala(projection).zipWithIndex.foreach {
-          case(rexNode, index)=>
-            projectionIndexMapping.put(index, rexNode)
-      }
-    }
-    this
-  }
-
   def getReusableInputUnboxingExprs(inputTerm: String, index: Int): Option[GeneratedExpression] =
     reusableInputUnboxingExprs.get((inputTerm, index))
 

--- a/flink-table/flink-table-planner/src/main/scala/org/apache/flink/table/planner/codegen/CodeGeneratorContext.scala
+++ b/flink-table/flink-table-planner/src/main/scala/org/apache/flink/table/planner/codegen/CodeGeneratorContext.scala
@@ -166,10 +166,6 @@ class CodeGeneratorContext(val tableConfig: TableConfig) {
   def commonExpressionElimination(fieldExprs: Seq[GeneratedExpression]):
     Seq[GeneratedExpression] = {
 
-    if(localRefs == null) {
-      return fieldExprs
-    }
-
     var result:Seq[GeneratedExpression] = List()
     var offset = 0
     localRefs.foreach(localRef => {

--- a/flink-table/flink-table-planner/src/main/scala/org/apache/flink/table/planner/codegen/JsonGenerateUtils.scala
+++ b/flink-table/flink-table-planner/src/main/scala/org/apache/flink/table/planner/codegen/JsonGenerateUtils.scala
@@ -26,15 +26,14 @@ import org.apache.flink.table.runtime.functions.SqlJsonUtils
 import org.apache.flink.table.runtime.typeutils.TypeCheckUtils.isCharacterString
 import org.apache.flink.table.types.logical.LogicalTypeRoot._
 import org.apache.flink.table.types.logical._
-
 import org.apache.flink.shaded.jackson2.com.fasterxml.jackson.databind.JsonNode
 import org.apache.flink.shaded.jackson2.com.fasterxml.jackson.databind.node.{ArrayNode, ObjectNode}
 import org.apache.flink.shaded.jackson2.com.fasterxml.jackson.databind.util.RawValue
-
 import org.apache.calcite.rex.{RexCall, RexNode}
 import org.apache.calcite.sql.SqlJsonConstructorNullClause
-
 import java.time.format.DateTimeFormatter
+
+import org.apache.flink.table.planner.plan.utils.FlinkRexUtil
 
 /** Utility for generating JSON function calls. */
 object JsonGenerateUtils {
@@ -47,7 +46,8 @@ object JsonGenerateUtils {
       ctx: CodeGeneratorContext,
       expression: GeneratedExpression,
       operand: RexNode): String = {
-    if (isJsonFunctionOperand(operand)) {
+    val newOperand = FlinkRexUtil.replaceRexNodeLocalRef(operand, ctx)
+    if (isJsonFunctionOperand(newOperand)) {
       createRawNodeTerm(expression)
     } else {
       createNodeTerm(ctx, expression)

--- a/flink-table/flink-table-planner/src/main/scala/org/apache/flink/table/planner/codegen/ProjectCodeGeneratorContext.scala
+++ b/flink-table/flink-table-planner/src/main/scala/org/apache/flink/table/planner/codegen/ProjectCodeGeneratorContext.scala
@@ -1,0 +1,91 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.flink.table.planner.codegen
+
+import java.util
+
+import org.apache.calcite.rex.{RexLocalRef, RexNode}
+import org.apache.flink.table.api.TableConfig
+import org.apache.flink.table.planner.utils.JavaScalaConversionUtil
+
+import scala.collection.mutable
+
+/**
+ * The context for code generator, maintaining reusable common expressions.
+ */
+class ProjectCodeGeneratorContext(
+  tableConfig: TableConfig,
+  projection: util.List[RexNode],
+  localRefs: Seq[RexLocalRef],
+  expandLocalRefs: Seq[RexNode])
+  extends CodeGeneratorContext(tableConfig) {
+
+  private val projectionIndexMapping: mutable.Map[Int, RexNode] =
+    mutable.Map[Int, RexNode]()
+  JavaScalaConversionUtil.toScala(projection).zipWithIndex.foreach {
+    case(rexNode, index)=>
+      projectionIndexMapping.put(index, rexNode)
+  }
+
+  private val reuseExpression: mutable.Map[RexNode, GeneratedExpression] =
+    mutable.Map[RexNode, GeneratedExpression]()
+
+  def addCommonExpression(rexNode: RexNode, expression: GeneratedExpression):
+  GeneratedExpression = {
+    reuseExpression.put(rexNode, expression)
+    expression
+  }
+
+  def cleanupCommonExpression() = {
+    reuseExpression.clear()
+  }
+
+  def getCommonExpression(rexNode: RexNode): GeneratedExpression = {
+    reuseExpression.getOrElse(rexNode, null)
+  }
+
+  def commonExpressionElimination(fieldExprs: Seq[GeneratedExpression]):
+    Seq[GeneratedExpression] = {
+      if(localRefs == null) {
+        return fieldExprs
+      }
+      var result:Seq[GeneratedExpression] = List()
+      var offset = 0
+      localRefs.foreach(localRef => {
+        var code = ""
+        for(i <- offset until localRef.getIndex + 1) {
+          val expression = fieldExprs(i)
+          code =
+            s"""$code
+               |${expression.code}""".stripMargin
+        }
+        result = result :+  fieldExprs(localRef.getIndex).copy(code = code)
+        offset = localRef.getIndex + 1
+      })
+      result
+  }
+
+  def getLocalRefs = localRefs
+
+  def getExpandLocalRefs = expandLocalRefs
+
+  def getRexNodeIndex(index: Int) : RexNode = {
+    projectionIndexMapping.getOrElse(index, null)
+  }
+}

--- a/flink-table/flink-table-planner/src/main/scala/org/apache/flink/table/planner/codegen/ProjectCodeGeneratorContext.scala
+++ b/flink-table/flink-table-planner/src/main/scala/org/apache/flink/table/planner/codegen/ProjectCodeGeneratorContext.scala
@@ -32,10 +32,11 @@ import scala.collection.mutable
 class ProjectCodeGeneratorContext(
    tableConfig: TableConfig,
    expList: util.List[RexNode],
-   localRefs: Seq[RexLocalRef],
+   localRef: Seq[RexNode],
    projection: Seq[RexNode])
   extends CodeGeneratorContext(tableConfig) {
 
+  private val localRefs = localRef.map(v => v.asInstanceOf[RexLocalRef])
   private val projectionIndexMapping: mutable.Map[Int, RexNode] =
     mutable.Map[Int, RexNode]()
   JavaScalaConversionUtil.toScala(expList).zipWithIndex.foreach {

--- a/flink-table/flink-table-planner/src/main/scala/org/apache/flink/table/planner/codegen/ProjectCodeGeneratorContext.scala
+++ b/flink-table/flink-table-planner/src/main/scala/org/apache/flink/table/planner/codegen/ProjectCodeGeneratorContext.scala
@@ -30,15 +30,15 @@ import scala.collection.mutable
  * The context for code generator, maintaining reusable common expressions.
  */
 class ProjectCodeGeneratorContext(
-  tableConfig: TableConfig,
-  projection: util.List[RexNode],
-  localRefs: Seq[RexLocalRef],
-  expandLocalRefs: Seq[RexNode])
+   tableConfig: TableConfig,
+   expList: util.List[RexNode],
+   localRefs: Seq[RexLocalRef],
+   projection: Seq[RexNode])
   extends CodeGeneratorContext(tableConfig) {
 
   private val projectionIndexMapping: mutable.Map[Int, RexNode] =
     mutable.Map[Int, RexNode]()
-  JavaScalaConversionUtil.toScala(projection).zipWithIndex.foreach {
+  JavaScalaConversionUtil.toScala(expList).zipWithIndex.foreach {
     case(rexNode, index)=>
       projectionIndexMapping.put(index, rexNode)
   }
@@ -83,7 +83,7 @@ class ProjectCodeGeneratorContext(
 
   def getLocalRefs = localRefs
 
-  def getExpandLocalRefs = expandLocalRefs
+  def getProjection = projection
 
   def getRexNodeIndex(index: Int) : RexNode = {
     projectionIndexMapping.getOrElse(index, null)

--- a/flink-table/flink-table-planner/src/main/scala/org/apache/flink/table/planner/codegen/calls/BridgingSqlFunctionCallGen.scala
+++ b/flink-table/flink-table-planner/src/main/scala/org/apache/flink/table/planner/codegen/calls/BridgingSqlFunctionCallGen.scala
@@ -26,10 +26,10 @@ import org.apache.flink.table.planner.functions.bridging.BridgingSqlFunction
 import org.apache.flink.table.planner.functions.inference.OperatorBindingCallContext
 import org.apache.flink.table.runtime.collector.WrappingCollector
 import org.apache.flink.table.types.logical.LogicalType
-
 import org.apache.calcite.rex.{RexCall, RexCallBinding}
-
 import java.util.Collections
+
+import org.apache.flink.table.planner.plan.utils.FlinkRexUtil
 
 /**
  * Generates a call to a user-defined [[ScalarFunction]] or [[TableFunction]].
@@ -52,14 +52,15 @@ class BridgingSqlFunctionCallGen(call: RexCall) extends CallGenerator {
 
     // we could have implemented a dedicated code generation context but the closer we are to
     // Calcite the more consistent is the type inference during the data type enrichment
+    val newCall = FlinkRexUtil.replaceRexCallLocalRef(call, ctx)
     val callContext = new OperatorBindingCallContext(
       dataTypeFactory,
       definition,
       RexCallBinding.create(
         function.getTypeFactory,
-        call,
+        newCall,
         Collections.emptyList()),
-      call.getType)
+      newCall.getType)
 
     // create the final UDF for runtime
     val udf = UserDefinedFunctionHelper.createSpecializedFunction(

--- a/flink-table/flink-table-planner/src/main/scala/org/apache/flink/table/planner/plan/nodes/physical/batch/BatchPhysicalCalc.scala
+++ b/flink-table/flink-table-planner/src/main/scala/org/apache/flink/table/planner/plan/nodes/physical/batch/BatchPhysicalCalc.scala
@@ -45,9 +45,9 @@ class BatchPhysicalCalc(
   }
 
   override def translateToExecNode(): ExecNode[_] = {
-    val projection = calcProgram.getExprList
+    val expList = calcProgram.getExprList
     val localRefs = calcProgram.getProjectList.map(_.asInstanceOf[RexNode])
-    val expandLocalRef = calcProgram.getProjectList.map(calcProgram.expandLocalRef)
+    val projection = calcProgram.getProjectList.map(calcProgram.expandLocalRef)
     val condition = if (calcProgram.getCondition != null) {
       calcProgram.expandLocalRef(calcProgram.getCondition)
     } else {
@@ -55,9 +55,9 @@ class BatchPhysicalCalc(
     }
 
     new BatchExecCalc(
-      projection,
+      expList,
       localRefs,
-      expandLocalRef,
+      projection,
       condition,
       InputProperty.DEFAULT,
       FlinkTypeFactory.toLogicalRowType(getRowType),

--- a/flink-table/flink-table-planner/src/main/scala/org/apache/flink/table/planner/plan/nodes/physical/batch/BatchPhysicalCalc.scala
+++ b/flink-table/flink-table-planner/src/main/scala/org/apache/flink/table/planner/plan/nodes/physical/batch/BatchPhysicalCalc.scala
@@ -48,6 +48,7 @@ class BatchPhysicalCalc(
   override def translateToExecNode(): ExecNode[_] = {
     val projection = calcProgram.getExprList
     val localRefs = calcProgram.getProjectList
+    val expandLocalRef = calcProgram.getProjectList.map(calcProgram.expandLocalRef)
     val condition = if (calcProgram.getCondition != null) {
       calcProgram.expandLocalRef(calcProgram.getCondition)
     } else {
@@ -57,6 +58,7 @@ class BatchPhysicalCalc(
     new BatchExecCalc(
       projection,
       localRefs,
+      expandLocalRef,
       condition,
       InputProperty.DEFAULT,
       FlinkTypeFactory.toLogicalRowType(getRowType),

--- a/flink-table/flink-table-planner/src/main/scala/org/apache/flink/table/planner/plan/nodes/physical/batch/BatchPhysicalCalc.scala
+++ b/flink-table/flink-table-planner/src/main/scala/org/apache/flink/table/planner/plan/nodes/physical/batch/BatchPhysicalCalc.scala
@@ -46,7 +46,8 @@ class BatchPhysicalCalc(
   }
 
   override def translateToExecNode(): ExecNode[_] = {
-    val projection = calcProgram.getProjectList.map(calcProgram.expandLocalRef)
+    val projection = calcProgram.getExprList
+    val localRefs = calcProgram.getProjectList
     val condition = if (calcProgram.getCondition != null) {
       calcProgram.expandLocalRef(calcProgram.getCondition)
     } else {
@@ -55,6 +56,7 @@ class BatchPhysicalCalc(
 
     new BatchExecCalc(
       projection,
+      localRefs,
       condition,
       InputProperty.DEFAULT,
       FlinkTypeFactory.toLogicalRowType(getRowType),

--- a/flink-table/flink-table-planner/src/main/scala/org/apache/flink/table/planner/plan/nodes/physical/batch/BatchPhysicalCalc.scala
+++ b/flink-table/flink-table-planner/src/main/scala/org/apache/flink/table/planner/plan/nodes/physical/batch/BatchPhysicalCalc.scala
@@ -20,13 +20,12 @@ package org.apache.flink.table.planner.plan.nodes.physical.batch
 
 import org.apache.flink.table.planner.calcite.FlinkTypeFactory
 import org.apache.flink.table.planner.plan.nodes.exec.batch.BatchExecCalc
-import org.apache.flink.table.planner.plan.nodes.exec.{InputProperty, ExecNode}
-
+import org.apache.flink.table.planner.plan.nodes.exec.{ExecNode, InputProperty}
 import org.apache.calcite.plan._
 import org.apache.calcite.rel._
 import org.apache.calcite.rel.`type`.RelDataType
 import org.apache.calcite.rel.core.Calc
-import org.apache.calcite.rex.RexProgram
+import org.apache.calcite.rex.{RexNode, RexProgram}
 
 import scala.collection.JavaConversions._
 
@@ -47,7 +46,7 @@ class BatchPhysicalCalc(
 
   override def translateToExecNode(): ExecNode[_] = {
     val projection = calcProgram.getExprList
-    val localRefs = calcProgram.getProjectList
+    val localRefs = calcProgram.getProjectList.map(_.asInstanceOf[RexNode])
     val expandLocalRef = calcProgram.getProjectList.map(calcProgram.expandLocalRef)
     val condition = if (calcProgram.getCondition != null) {
       calcProgram.expandLocalRef(calcProgram.getCondition)

--- a/flink-table/flink-table-planner/src/main/scala/org/apache/flink/table/planner/plan/nodes/physical/stream/StreamPhysicalCalc.scala
+++ b/flink-table/flink-table-planner/src/main/scala/org/apache/flink/table/planner/plan/nodes/physical/stream/StreamPhysicalCalc.scala
@@ -46,7 +46,8 @@ class StreamPhysicalCalc(
   }
 
   override def translateToExecNode(): ExecNode[_] = {
-    val projection = calcProgram.getProjectList.map(calcProgram.expandLocalRef)
+    val projection = calcProgram.getExprList
+    val localRefs = calcProgram.getProjectList
     val condition = if (calcProgram.getCondition != null) {
       calcProgram.expandLocalRef(calcProgram.getCondition)
     } else {
@@ -55,6 +56,7 @@ class StreamPhysicalCalc(
 
     new StreamExecCalc(
       projection,
+      localRefs,
       condition,
       InputProperty.DEFAULT,
       FlinkTypeFactory.toLogicalRowType(getRowType),

--- a/flink-table/flink-table-planner/src/main/scala/org/apache/flink/table/planner/plan/nodes/physical/stream/StreamPhysicalCalc.scala
+++ b/flink-table/flink-table-planner/src/main/scala/org/apache/flink/table/planner/plan/nodes/physical/stream/StreamPhysicalCalc.scala
@@ -45,9 +45,9 @@ class StreamPhysicalCalc(
   }
 
   override def translateToExecNode(): ExecNode[_] = {
-    val projection = calcProgram.getExprList
+    val expList = calcProgram.getExprList
     val localRefs = calcProgram.getProjectList.map(_.asInstanceOf[RexNode])
-    val expandLocalRef = calcProgram.getProjectList.map(calcProgram.expandLocalRef)
+    val projection = calcProgram.getProjectList.map(calcProgram.expandLocalRef)
     val condition = if (calcProgram.getCondition != null) {
       calcProgram.expandLocalRef(calcProgram.getCondition)
     } else {
@@ -56,9 +56,9 @@ class StreamPhysicalCalc(
 
 
     new StreamExecCalc(
-      projection,
+      expList,
       localRefs,
-      expandLocalRef,
+      projection,
       condition,
       InputProperty.DEFAULT,
       FlinkTypeFactory.toLogicalRowType(getRowType),

--- a/flink-table/flink-table-planner/src/main/scala/org/apache/flink/table/planner/plan/nodes/physical/stream/StreamPhysicalCalc.scala
+++ b/flink-table/flink-table-planner/src/main/scala/org/apache/flink/table/planner/plan/nodes/physical/stream/StreamPhysicalCalc.scala
@@ -48,15 +48,18 @@ class StreamPhysicalCalc(
   override def translateToExecNode(): ExecNode[_] = {
     val projection = calcProgram.getExprList
     val localRefs = calcProgram.getProjectList
+    val expandLocalRef = calcProgram.getProjectList.map(calcProgram.expandLocalRef)
     val condition = if (calcProgram.getCondition != null) {
       calcProgram.expandLocalRef(calcProgram.getCondition)
     } else {
       null
     }
 
+
     new StreamExecCalc(
       projection,
       localRefs,
+      expandLocalRef,
       condition,
       InputProperty.DEFAULT,
       FlinkTypeFactory.toLogicalRowType(getRowType),

--- a/flink-table/flink-table-planner/src/main/scala/org/apache/flink/table/planner/plan/nodes/physical/stream/StreamPhysicalCalc.scala
+++ b/flink-table/flink-table-planner/src/main/scala/org/apache/flink/table/planner/plan/nodes/physical/stream/StreamPhysicalCalc.scala
@@ -21,12 +21,11 @@ package org.apache.flink.table.planner.plan.nodes.physical.stream
 import org.apache.flink.table.planner.calcite.FlinkTypeFactory
 import org.apache.flink.table.planner.plan.nodes.exec.stream.StreamExecCalc
 import org.apache.flink.table.planner.plan.nodes.exec.{ExecNode, InputProperty}
-
 import org.apache.calcite.plan.{RelOptCluster, RelTraitSet}
 import org.apache.calcite.rel.RelNode
 import org.apache.calcite.rel.`type`.RelDataType
 import org.apache.calcite.rel.core.Calc
-import org.apache.calcite.rex.RexProgram
+import org.apache.calcite.rex.{RexNode, RexProgram}
 
 import scala.collection.JavaConversions._
 
@@ -47,7 +46,7 @@ class StreamPhysicalCalc(
 
   override def translateToExecNode(): ExecNode[_] = {
     val projection = calcProgram.getExprList
-    val localRefs = calcProgram.getProjectList
+    val localRefs = calcProgram.getProjectList.map(_.asInstanceOf[RexNode])
     val expandLocalRef = calcProgram.getProjectList.map(calcProgram.expandLocalRef)
     val condition = if (calcProgram.getCondition != null) {
       calcProgram.expandLocalRef(calcProgram.getCondition)

--- a/flink-table/flink-table-planner/src/main/scala/org/apache/flink/table/planner/plan/utils/FlinkRexUtil.scala
+++ b/flink-table/flink-table-planner/src/main/scala/org/apache/flink/table/planner/plan/utils/FlinkRexUtil.scala
@@ -35,7 +35,7 @@ import java.lang.{Iterable => JIterable}
 import java.util
 import java.util.function.Predicate
 
-import org.apache.flink.table.planner.codegen.CodeGeneratorContext
+import org.apache.flink.table.planner.codegen.{CodeGeneratorContext, ProjectCodeGeneratorContext}
 
 import scala.collection.JavaConversions._
 import scala.collection.mutable
@@ -403,16 +403,20 @@ object FlinkRexUtil {
   }
 
   def replaceRexNodeLocalRef(call: RexNode, ctx: CodeGeneratorContext) : RexNode = {
-    call.accept(new RexShuttle() {
-      override def visitLocalRef(localRef: RexLocalRef): RexNode = {
-        val real = ctx.getRexNodeIndex(localRef.getIndex)
-        if(real == null) {
-          super.visitLocalRef(localRef)
-        } else {
-          real
-        }
-      }
-    })
+    ctx match {
+      case projectCtx:ProjectCodeGeneratorContext =>
+        call.accept(new RexShuttle() {
+          override def visitLocalRef(localRef: RexLocalRef): RexNode = {
+            val real = projectCtx.getRexNodeIndex(localRef.getIndex)
+            if(real == null) {
+              super.visitLocalRef(localRef)
+            } else {
+              real
+            }
+          }
+        })
+      case _ => call
+    }
   }
 
 

--- a/flink-table/flink-table-planner/src/main/scala/org/apache/flink/table/planner/plan/utils/FlinkRexUtil.scala
+++ b/flink-table/flink-table-planner/src/main/scala/org/apache/flink/table/planner/plan/utils/FlinkRexUtil.scala
@@ -31,10 +31,12 @@ import org.apache.calcite.sql.fun.SqlStdOperatorTable
 import org.apache.calcite.sql.fun.SqlStdOperatorTable._
 import org.apache.calcite.sql.{SqlAsOperator, SqlKind, SqlOperator}
 import org.apache.calcite.util.{ControlFlowException, ImmutableBitSet, Sarg, Util}
-
 import java.lang.{Iterable => JIterable}
 import java.util
 import java.util.function.Predicate
+
+import org.apache.flink.table.planner.codegen.CodeGeneratorContext
+
 import scala.collection.JavaConversions._
 import scala.collection.mutable
 
@@ -399,6 +401,25 @@ object FlinkRexUtil {
       rexBuilder.makeLiteral(range.lowerEndpoint(), sargLiteral.getType, false))
     List(call.getOperands.head) ++ sargOperands
   }
+
+  def replaceRexNodeLocalRef(call: RexNode, ctx: CodeGeneratorContext) : RexNode = {
+    call.accept(new RexShuttle() {
+      override def visitLocalRef(localRef: RexLocalRef): RexNode = {
+        val real = ctx.getRexNodeIndex(localRef.getIndex)
+        if(real == null) {
+          super.visitLocalRef(localRef)
+        } else {
+          real
+        }
+      }
+    })
+  }
+
+
+  def replaceRexCallLocalRef(call: RexCall, ctx: CodeGeneratorContext) : RexCall = {
+    replaceRexNodeLocalRef(call, ctx).asInstanceOf[RexCall]
+  }
+
 
   /**
     * Adjust the expression's field indices according to fieldsOldToNewIndexMapping.

--- a/flink-table/flink-table-planner/src/test/scala/org/apache/flink/table/planner/runtime/stream/table/CalcITCase.scala
+++ b/flink-table/flink-table-planner/src/test/scala/org/apache/flink/table/planner/runtime/stream/table/CalcITCase.scala
@@ -391,7 +391,6 @@ class CalcITCase(mode: StateBackendMode) extends StreamingWithStateTestBase(mode
 
     result.toAppendStream[Row].addSink(sink)
     env.execute()
-    println(sink.getAppendResults.sorted)
   }
 
   class NonStaticClassScalarFunction extends ScalarFunction {

--- a/flink-table/flink-table-planner/src/test/scala/org/apache/flink/table/planner/runtime/utils/UserDefinedFunctionTestUtils.scala
+++ b/flink-table/flink-table-planner/src/test/scala/org/apache/flink/table/planner/runtime/utils/UserDefinedFunctionTestUtils.scala
@@ -30,10 +30,8 @@ import org.apache.flink.table.data.{RowData, StringData}
 import org.apache.flink.table.functions.{AggregateFunction, FunctionContext, ScalarFunction}
 import org.apache.flink.table.planner.{JInt, JLong}
 import org.apache.flink.types.Row
-
 import com.google.common.base.Charsets
 import com.google.common.io.Files
-
 import java.io.File
 import java.lang.{Iterable => JIterable}
 import java.sql.{Date, Timestamp}
@@ -41,6 +39,8 @@ import java.time.{Instant, LocalDate, LocalDateTime, LocalTime}
 import java.util
 import java.util.TimeZone
 import java.util.concurrent.atomic.AtomicInteger
+
+import org.junit.Assert
 
 import scala.annotation.varargs
 
@@ -313,6 +313,17 @@ object UserDefinedFunctionTestUtils {
 
     def eval(id: String): String = {
       id
+    }
+  }
+
+  @SerialVersionUID(1L)
+  class TestCommonExpressionEliminationFunction extends ScalarFunction {
+    var count = 0
+    def eval(value: String, split:String, alertCount:Int): Array[String] = {
+      val result = value.split(split)
+      count += 1
+      Assert.assertTrue(count <= alertCount)
+      result
     }
   }
 


### PR DESCRIPTION
… elimination

<!--
*Thank you very much for contributing to Apache Flink - we are happy that you want to help us improve Flink. To help the community review your contribution in the best possible way, please go through the checklist below, which will get the contribution into a shape in which it can be best reviewed.*

*Please understand that we do not do this to make contributions to Flink a hassle. In order to uphold a high standard of quality for code contributions, while at the same time managing a large number of contributions, we need contributors to prepare the contributions well, and give reviewers enough contextual information for the review. Please also understand that contributions that do not follow this guide will take longer to review and thus typically be picked up with lower priority by the community.*

## Contribution Checklist

  - Make sure that the pull request corresponds to a [JIRA issue](https://issues.apache.org/jira/projects/FLINK/issues). Exceptions are made for typos in JavaDoc or documentation files, which need no JIRA issue.
  
  - Name the pull request in the form "[FLINK-XXXX] [component] Title of the pull request", where *FLINK-XXXX* should be replaced by the actual issue number. Skip *component* if you are unsure about which is the best component.
  Typo fixes that have no associated JIRA issue should be named following this pattern: `[hotfix] [docs] Fix typo in event time introduction` or `[hotfix] [javadocs] Expand JavaDoc for PuncuatedWatermarkGenerator`.

  - Fill out the template below to describe the changes contributed by the pull request. That will give reviewers the context they need to do the review.
  
  - Make sure that the change passes the automated tests, i.e., `mvn clean verify` passes. You can set up Azure Pipelines CI to do that following [this guide](https://cwiki.apache.org/confluence/display/FLINK/Azure+Pipelines#AzurePipelines-Tutorial:SettingupAzurePipelinesforaforkoftheFlinkrepository).

  - Each pull request should address only one issue, not mix up code from multiple issues.
  
  - Each commit in the pull request has a meaningful commit message (including the JIRA id)

  - Once all items of the checklist are addressed, remove the above text and this checklist, leaving only the filled out template below.


**(The sections below can be removed for hotfixes of typos)**
-->

## What is the purpose of the change

*(For example: This pull request makes task deployment go through the blob server, rather than through RPC. That way we avoid re-transferring them on each deployment (during recovery).)*


## Brief change log

*(for example:)*
  - *The TaskInfo is stored in the blob store on job creation time as a persistent artifact*
  - *Deployments RPC transmits only the blob storage reference*
  - *TaskManagers retrieve the TaskInfo from the blob cache*


## Verifying this change

*(Please pick either of the following options)*

This change is a trivial rework / code cleanup without any test coverage.

*(or)*

This change is already covered by existing tests, such as *(please describe tests)*.

*(or)*

This change added tests and can be verified as follows:

*(example:)*
  - *Added integration tests for end-to-end deployment with large payloads (100MB)*
  - *Extended integration test for recovery after master (JobManager) failure*
  - *Added test that validates that TaskInfo is transferred only once across recoveries*
  - *Manually verified the change by running a 4 node cluser with 2 JobManagers and 4 TaskManagers, a stateful streaming program, and killing one JobManager and two TaskManagers during the execution, verifying that recovery happens correctly.*

## Does this pull request potentially affect one of the following parts:

  - Dependencies (does it add or upgrade a dependency): (yes / no)
  - The public API, i.e., is any changed class annotated with `@Public(Evolving)`: (yes / no)
  - The serializers: (yes / no / don't know)
  - The runtime per-record code paths (performance sensitive): (yes / no / don't know)
  - Anything that affects deployment or recovery: JobManager (and its components), Checkpointing, Kubernetes/Yarn, ZooKeeper: (yes / no / don't know)
  - The S3 file system connector: (yes / no / don't know)

## Documentation

  - Does this pull request introduce a new feature? (yes / no)
  - If yes, how is the feature documented? (not applicable / docs / JavaDocs / not documented)
