### PR TITLE
[FLINK-24609][akka][build] Use same Scala properties as root pom

### DIFF
--- a/flink-rpc/flink-rpc-akka/pom.xml
+++ b/flink-rpc/flink-rpc-akka/pom.xml
@@ -35,8 +35,8 @@ under the License.
 
 	<properties>
 		<akka.version>2.6.15</akka.version>
-		<akka.scala.binary.version>2.12</akka.scala.binary.version>
-		<akka.scala.version>2.12.7</akka.scala.version>
+		<scala.binary.version>2.12</scala.binary.version>
+		<scala.version>2.12.7</scala.version>
 	</properties>
 
 	<dependencies>
@@ -72,12 +72,12 @@ under the License.
 
 		<dependency>
 			<groupId>com.typesafe.akka</groupId>
-			<artifactId>akka-actor_${akka.scala.binary.version}</artifactId>
+			<artifactId>akka-actor_${scala.binary.version}</artifactId>
 			<version>${akka.version}</version>
 		</dependency>
 		<dependency>
 			<groupId>com.typesafe.akka</groupId>
-			<artifactId>akka-remote_${akka.scala.binary.version}</artifactId>
+			<artifactId>akka-remote_${scala.binary.version}</artifactId>
 			<version>${akka.version}</version>
 			<exclusions>
 				<exclusion>
@@ -94,7 +94,7 @@ under the License.
 		</dependency>
 		<dependency>
 			<groupId>com.typesafe.akka</groupId>
-			<artifactId>akka-slf4j_${akka.scala.binary.version}</artifactId>
+			<artifactId>akka-slf4j_${scala.binary.version}</artifactId>
 			<version>${akka.version}</version>
 		</dependency>
 		<dependency>
@@ -105,7 +105,7 @@ under the License.
 
 		<dependency>
 			<groupId>org.clapper</groupId>
-			<artifactId>grizzled-slf4j_${akka.scala.binary.version}</artifactId>
+			<artifactId>grizzled-slf4j_${scala.binary.version}</artifactId>
 			<version>1.3.2</version>
 		</dependency>
 
@@ -140,17 +140,17 @@ under the License.
 			<dependency>
 				<groupId>org.scala-lang</groupId>
 				<artifactId>scala-compiler</artifactId>
-				<version>${akka.scala.version}</version>
+				<version>${scala.version}</version>
 			</dependency>
 			<dependency>
 				<groupId>org.scala-lang</groupId>
 				<artifactId>scala-library</artifactId>
-				<version>${akka.scala.version}</version>
+				<version>${scala.version}</version>
 			</dependency>
 			<dependency>
 				<groupId>org.scala-lang</groupId>
 				<artifactId>scala-reflect</artifactId>
-				<version>${akka.scala.version}</version>
+				<version>${scala.version}</version>
 			</dependency>
 			<dependency>
 				<groupId>org.scala-lang.modules</groupId>


### PR DESCRIPTION
Maven does not properly resolve `dependencyManagement` entries if the parent/child module declare one for the same dependency with different properties being used in the `artifactId.` Our builds were only as expected because we were accidentally using the plain `scala.binary.version` property for `parser-combinators.`
Hence we unfortunately need to use the same property names, which should however not cause issues in the future (if say, a 2.13 profile is introduced), because the properties defined in the child take precedence.
