### PR TITLE
[FLINK-24189] Perform buffer debloating per single gate 

### DIFF
--- a/flink-libraries/flink-state-processing-api/src/main/java/org/apache/flink/state/api/runtime/SavepointEnvironment.java
+++ b/flink-libraries/flink-state-processing-api/src/main/java/org/apache/flink/state/api/runtime/SavepointEnvironment.java
@@ -53,12 +53,10 @@ import org.apache.flink.runtime.query.TaskKvStateRegistry;
 import org.apache.flink.runtime.state.TaskStateManager;
 import org.apache.flink.runtime.taskexecutor.GlobalAggregateManager;
 import org.apache.flink.runtime.taskmanager.TaskManagerRuntimeInfo;
-import org.apache.flink.runtime.throughput.ThroughputCalculator;
 import org.apache.flink.util.ExceptionUtils;
 import org.apache.flink.util.Preconditions;
 import org.apache.flink.util.SerializedValue;
 import org.apache.flink.util.UserCodeClassLoader;
-import org.apache.flink.util.clock.SystemClock;
 
 import java.util.Collections;
 import java.util.Map;
@@ -285,13 +283,6 @@ public class SavepointEnvironment implements Environment {
     @Override
     public TaskEventDispatcher getTaskEventDispatcher() {
         throw new UnsupportedOperationException(ERROR_MSG);
-    }
-
-    @Override
-    public ThroughputCalculator getThroughputCalculator() {
-        // The throughput calculator doesn't make sense for savepoint but the not null value is
-        // preferable when StreamTask is instantiated.
-        return new ThroughputCalculator(SystemClock.getInstance());
     }
 
     /** {@link SavepointEnvironment} builder. */

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/execution/Environment.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/execution/Environment.java
@@ -46,7 +46,6 @@ import org.apache.flink.runtime.state.TaskStateManager;
 import org.apache.flink.runtime.state.internal.InternalKvState;
 import org.apache.flink.runtime.taskexecutor.GlobalAggregateManager;
 import org.apache.flink.runtime.taskmanager.TaskManagerRuntimeInfo;
-import org.apache.flink.runtime.throughput.ThroughputCalculator;
 import org.apache.flink.util.UserCodeClassLoader;
 
 import java.util.Map;
@@ -236,13 +235,6 @@ public interface Environment {
     IndexedInputGate[] getAllInputGates();
 
     TaskEventDispatcher getTaskEventDispatcher();
-
-    /**
-     * Returns the throughput meter for calculation the throughput for certain period.
-     *
-     * @return the throughput calculation service.
-     */
-    ThroughputCalculator getThroughputCalculator();
 
     // --------------------------------------------------------------------------------------------
     //  Fields set in the StreamTask to provide access to mailbox and other runtime resources

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/io/network/NettyShuffleEnvironment.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/io/network/NettyShuffleEnvironment.java
@@ -29,7 +29,6 @@ import org.apache.flink.runtime.io.disk.BatchShuffleReadBufferPool;
 import org.apache.flink.runtime.io.disk.FileChannelManager;
 import org.apache.flink.runtime.io.network.api.writer.ResultPartitionWriter;
 import org.apache.flink.runtime.io.network.buffer.NetworkBufferPool;
-import org.apache.flink.runtime.io.network.metrics.InputChannelMetrics;
 import org.apache.flink.runtime.io.network.metrics.NettyShuffleMetricFactory;
 import org.apache.flink.runtime.io.network.partition.PartitionProducerStateProvider;
 import org.apache.flink.runtime.io.network.partition.ResultPartition;
@@ -64,6 +63,7 @@ import java.util.concurrent.ExecutorService;
 import static org.apache.flink.runtime.io.network.metrics.NettyShuffleMetricFactory.METRIC_GROUP_INPUT;
 import static org.apache.flink.runtime.io.network.metrics.NettyShuffleMetricFactory.METRIC_GROUP_OUTPUT;
 import static org.apache.flink.runtime.io.network.metrics.NettyShuffleMetricFactory.createShuffleIOOwnerMetricGroup;
+import static org.apache.flink.runtime.io.network.metrics.NettyShuffleMetricFactory.registerDebloatingTaskMetrics;
 import static org.apache.flink.runtime.io.network.metrics.NettyShuffleMetricFactory.registerInputMetrics;
 import static org.apache.flink.runtime.io.network.metrics.NettyShuffleMetricFactory.registerOutputMetrics;
 import static org.apache.flink.util.Preconditions.checkArgument;
@@ -248,9 +248,6 @@ public class NettyShuffleEnvironment
                     !isClosed, "The NettyShuffleEnvironment has already been shut down.");
 
             MetricGroup networkInputGroup = ownerContext.getInputGroup();
-            @SuppressWarnings("deprecation")
-            InputChannelMetrics inputChannelMetrics =
-                    new InputChannelMetrics(networkInputGroup, ownerContext.getParentGroup());
 
             SingleInputGate[] inputGates =
                     new SingleInputGate[inputGateDeploymentDescriptors.size()];
@@ -259,17 +256,17 @@ public class NettyShuffleEnvironment
                         inputGateDeploymentDescriptors.get(gateIndex);
                 SingleInputGate inputGate =
                         singleInputGateFactory.create(
-                                ownerContext.getOwnerName(),
-                                gateIndex,
-                                igdd,
-                                partitionProducerStateProvider,
-                                inputChannelMetrics);
+                                ownerContext, gateIndex, igdd, partitionProducerStateProvider);
                 InputGateID id =
                         new InputGateID(
                                 igdd.getConsumedResultId(), ownerContext.getExecutionAttemptID());
                 inputGatesById.put(id, inputGate);
                 inputGate.getCloseFuture().thenRun(() -> inputGatesById.remove(id));
                 inputGates[gateIndex] = inputGate;
+            }
+
+            if (config.getDebloatConfiguration().isEnabled()) {
+                registerDebloatingTaskMetrics(inputGates, ownerContext.getParentGroup());
             }
 
             registerInputMetrics(config.isNetworkDetailedMetrics(), networkInputGroup, inputGates);

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/io/network/metrics/NettyShuffleMetricFactory.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/io/network/metrics/NettyShuffleMetricFactory.java
@@ -24,6 +24,7 @@ import org.apache.flink.runtime.io.network.buffer.NetworkBufferPool;
 import org.apache.flink.runtime.io.network.partition.ResultPartition;
 import org.apache.flink.runtime.io.network.partition.consumer.InputGate;
 import org.apache.flink.runtime.io.network.partition.consumer.SingleInputGate;
+import org.apache.flink.runtime.metrics.MetricNames;
 
 import java.util.Arrays;
 
@@ -211,5 +212,11 @@ public class NettyShuffleMetricFactory {
         buffersGroup.gauge(METRIC_INPUT_EXCLUSIVE_BUFFERS_USAGE, exclusiveBuffersUsageGauge);
         buffersGroup.gauge(METRIC_INPUT_FLOATING_BUFFERS_USAGE, floatingBuffersUsageGauge);
         buffersGroup.gauge(METRIC_INPUT_POOL_USAGE, creditBasedInputBuffersUsageGauge);
+    }
+
+    public static void registerDebloatingTaskMetrics(
+            SingleInputGate[] inputGates, MetricGroup taskGroup) {
+        taskGroup.gauge(
+                MetricNames.ESTIMATED_TIME_TO_CONSUME_BUFFERS, new TimeToConsumeGauge(inputGates));
     }
 }

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/io/network/metrics/TimeToConsumeGauge.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/io/network/metrics/TimeToConsumeGauge.java
@@ -1,0 +1,42 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.flink.runtime.io.network.metrics;
+
+import org.apache.flink.metrics.Gauge;
+import org.apache.flink.runtime.io.network.partition.consumer.SingleInputGate;
+
+/** Gauge metric measuring the maximal time to consume all buffers of all input gates. */
+public class TimeToConsumeGauge implements Gauge<Long> {
+
+    private final SingleInputGate[] gates;
+
+    public TimeToConsumeGauge(SingleInputGate[] gates) {
+        this.gates = gates;
+    }
+
+    @Override
+    public Long getValue() {
+        long result = Long.MIN_VALUE;
+        for (SingleInputGate gate : gates) {
+            result = Math.max(gate.getLastEstimatedTimeToConsume().toMillis(), result);
+        }
+
+        return result;
+    }
+}

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/io/network/partition/consumer/IndexedInputGate.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/io/network/partition/consumer/IndexedInputGate.java
@@ -65,7 +65,5 @@ public abstract class IndexedInputGate extends InputGate implements Checkpointab
         getChannel(channelIndex).convertToPriorityEvent(sequenceNumber);
     }
 
-    public abstract int getBuffersInUseCount();
-
-    public abstract void announceBufferSize(int bufferSize);
+    public abstract void triggerDebloating();
 }

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/io/network/partition/consumer/SingleInputGateFactory.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/io/network/partition/consumer/SingleInputGateFactory.java
@@ -19,6 +19,7 @@
 package org.apache.flink.runtime.io.network.partition.consumer;
 
 import org.apache.flink.annotation.VisibleForTesting;
+import org.apache.flink.metrics.MetricGroup;
 import org.apache.flink.runtime.clusterframework.types.ResourceID;
 import org.apache.flink.runtime.deployment.InputGateDeploymentDescriptor;
 import org.apache.flink.runtime.io.network.ConnectionManager;
@@ -32,10 +33,16 @@ import org.apache.flink.runtime.io.network.metrics.InputChannelMetrics;
 import org.apache.flink.runtime.io.network.partition.PartitionProducerStateProvider;
 import org.apache.flink.runtime.io.network.partition.ResultPartitionID;
 import org.apache.flink.runtime.io.network.partition.ResultPartitionManager;
+import org.apache.flink.runtime.metrics.MetricNames;
 import org.apache.flink.runtime.shuffle.NettyShuffleDescriptor;
 import org.apache.flink.runtime.shuffle.NettyShuffleUtils;
 import org.apache.flink.runtime.shuffle.ShuffleDescriptor;
+import org.apache.flink.runtime.shuffle.ShuffleIOOwnerContext;
 import org.apache.flink.runtime.taskmanager.NettyShuffleEnvironmentConfiguration;
+import org.apache.flink.runtime.throughput.BufferDebloatConfiguration;
+import org.apache.flink.runtime.throughput.BufferDebloater;
+import org.apache.flink.runtime.throughput.ThroughputCalculator;
+import org.apache.flink.util.clock.SystemClock;
 import org.apache.flink.util.function.SupplierWithException;
 
 import org.apache.commons.lang3.tuple.Pair;
@@ -76,6 +83,8 @@ public class SingleInputGateFactory {
 
     private final int networkBufferSize;
 
+    private final BufferDebloatConfiguration debloatConfiguration;
+
     public SingleInputGateFactory(
             @Nonnull ResourceID taskExecutorResourceId,
             @Nonnull NettyShuffleEnvironmentConfiguration networkConfig,
@@ -98,15 +107,15 @@ public class SingleInputGateFactory {
         this.partitionManager = partitionManager;
         this.taskEventPublisher = taskEventPublisher;
         this.networkBufferPool = networkBufferPool;
+        this.debloatConfiguration = networkConfig.getDebloatConfiguration();
     }
 
     /** Creates an input gate and all of its input channels. */
     public SingleInputGate create(
-            @Nonnull String owningTaskName,
+            @Nonnull ShuffleIOOwnerContext owner,
             int gateIndex,
             @Nonnull InputGateDeploymentDescriptor igdd,
-            @Nonnull PartitionProducerStateProvider partitionProducerStateProvider,
-            @Nonnull InputChannelMetrics metrics) {
+            @Nonnull PartitionProducerStateProvider partitionProducerStateProvider) {
         SupplierWithException<BufferPool, IOException> bufferPoolFactory =
                 createBufferPoolFactory(networkBufferPool, floatingNetworkBuffersPerGate);
 
@@ -115,6 +124,8 @@ public class SingleInputGateFactory {
             bufferDecompressor = new BufferDecompressor(networkBufferSize, compressionCodec);
         }
 
+        final String owningTaskName = owner.getOwnerName();
+        final MetricGroup networkInputGroup = owner.getInputGroup();
         SingleInputGate inputGate =
                 new SingleInputGate(
                         owningTaskName,
@@ -127,10 +138,33 @@ public class SingleInputGateFactory {
                         bufferPoolFactory,
                         bufferDecompressor,
                         networkBufferPool,
-                        networkBufferSize);
+                        networkBufferSize,
+                        new ThroughputCalculator(SystemClock.getInstance()),
+                        maybeCreateBufferDebloater(networkInputGroup.addGroup(gateIndex)));
 
+        InputChannelMetrics metrics =
+                new InputChannelMetrics(networkInputGroup, owner.getParentGroup());
         createInputChannels(owningTaskName, igdd, inputGate, metrics);
         return inputGate;
+    }
+
+    private BufferDebloater maybeCreateBufferDebloater(MetricGroup inputGroup) {
+        if (debloatConfiguration.isEnabled()) {
+            final BufferDebloater bufferDebloater =
+                    new BufferDebloater(
+                            debloatConfiguration.getTargetTotalBufferSize().toMillis(),
+                            debloatConfiguration.getMaxBufferSize(),
+                            debloatConfiguration.getMinBufferSize(),
+                            debloatConfiguration.getBufferDebloatThresholdPercentages(),
+                            debloatConfiguration.getNumberOfSamples());
+            inputGroup.gauge(
+                    MetricNames.ESTIMATED_TIME_TO_CONSUME_BUFFERS,
+                    () -> bufferDebloater.getLastEstimatedTimeToConsumeBuffers().toMillis());
+            inputGroup.gauge(MetricNames.DEBLOATED_BUFFER_SIZE, bufferDebloater::getLastBufferSize);
+            return bufferDebloater;
+        }
+
+        return null;
     }
 
     private void createInputChannels(

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/taskmanager/InputGateWithMetrics.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/taskmanager/InputGateWithMetrics.java
@@ -27,7 +27,6 @@ import org.apache.flink.runtime.io.network.partition.consumer.IndexedInputGate;
 import org.apache.flink.runtime.io.network.partition.consumer.InputChannel;
 import org.apache.flink.runtime.io.network.partition.consumer.InputGate;
 import org.apache.flink.runtime.metrics.groups.TaskIOMetricGroup;
-import org.apache.flink.runtime.throughput.ThroughputCalculator;
 
 import java.io.IOException;
 import java.util.List;
@@ -46,15 +45,9 @@ public class InputGateWithMetrics extends IndexedInputGate {
 
     private final Counter numBytesIn;
 
-    private final ThroughputCalculator throughputCalculator;
-
-    public InputGateWithMetrics(
-            IndexedInputGate inputGate,
-            Counter numBytesIn,
-            ThroughputCalculator throughputCalculator) {
+    public InputGateWithMetrics(IndexedInputGate inputGate, Counter numBytesIn) {
         this.inputGate = checkNotNull(inputGate);
         this.numBytesIn = checkNotNull(numBytesIn);
-        this.throughputCalculator = throughputCalculator;
     }
 
     @Override
@@ -93,13 +86,8 @@ public class InputGateWithMetrics extends IndexedInputGate {
     }
 
     @Override
-    public int getBuffersInUseCount() {
-        return inputGate.getBuffersInUseCount();
-    }
-
-    @Override
-    public void announceBufferSize(int bufferSize) {
-        inputGate.announceBufferSize(bufferSize);
+    public void triggerDebloating() {
+        inputGate.triggerDebloating();
     }
 
     @Override
@@ -166,7 +154,6 @@ public class InputGateWithMetrics extends IndexedInputGate {
         int incomingDataSize = bufferOrEvent.getSize();
 
         numBytesIn.inc(incomingDataSize);
-        throughputCalculator.incomingDataSize(incomingDataSize);
 
         return bufferOrEvent;
     }

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/taskmanager/NettyShuffleEnvironmentConfiguration.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/taskmanager/NettyShuffleEnvironmentConfiguration.java
@@ -25,6 +25,7 @@ import org.apache.flink.configuration.NettyShuffleEnvironmentOptions;
 import org.apache.flink.configuration.TaskManagerOptions;
 import org.apache.flink.runtime.io.network.netty.NettyConfig;
 import org.apache.flink.runtime.io.network.partition.BoundedBlockingSubpartitionType;
+import org.apache.flink.runtime.throughput.BufferDebloatConfiguration;
 import org.apache.flink.runtime.util.ConfigurationParserUtils;
 import org.apache.flink.util.Preconditions;
 
@@ -87,6 +88,8 @@ public class NettyShuffleEnvironmentConfiguration {
 
     private final int maxBuffersPerChannel;
 
+    private final BufferDebloatConfiguration debloatConfiguration;
+
     public NettyShuffleEnvironmentConfiguration(
             int numNetworkBuffers,
             int networkBufferSize,
@@ -104,7 +107,8 @@ public class NettyShuffleEnvironmentConfiguration {
             int maxBuffersPerChannel,
             long batchShuffleReadMemoryBytes,
             int sortShuffleMinBuffers,
-            int sortShuffleMinParallelism) {
+            int sortShuffleMinParallelism,
+            BufferDebloatConfiguration debloatConfiguration) {
 
         this.numNetworkBuffers = numNetworkBuffers;
         this.networkBufferSize = networkBufferSize;
@@ -123,6 +127,7 @@ public class NettyShuffleEnvironmentConfiguration {
         this.batchShuffleReadMemoryBytes = batchShuffleReadMemoryBytes;
         this.sortShuffleMinBuffers = sortShuffleMinBuffers;
         this.sortShuffleMinParallelism = sortShuffleMinParallelism;
+        this.debloatConfiguration = debloatConfiguration;
     }
 
     // ------------------------------------------------------------------------
@@ -185,6 +190,10 @@ public class NettyShuffleEnvironmentConfiguration {
 
     public boolean isBlockingShuffleCompressionEnabled() {
         return blockingShuffleCompressionEnabled;
+    }
+
+    public BufferDebloatConfiguration getDebloatConfiguration() {
+        return debloatConfiguration;
     }
 
     public boolean isSSLEnabled() {
@@ -297,7 +306,8 @@ public class NettyShuffleEnvironmentConfiguration {
                 maxBuffersPerChannel,
                 batchShuffleReadMemoryBytes,
                 sortShuffleMinBuffers,
-                sortShuffleMinParallelism);
+                sortShuffleMinParallelism,
+                BufferDebloatConfiguration.fromConfiguration(configuration));
     }
 
     /**

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/taskmanager/RuntimeEnvironment.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/taskmanager/RuntimeEnvironment.java
@@ -45,7 +45,6 @@ import org.apache.flink.runtime.query.TaskKvStateRegistry;
 import org.apache.flink.runtime.state.CheckpointStorageAccess;
 import org.apache.flink.runtime.state.TaskStateManager;
 import org.apache.flink.runtime.taskexecutor.GlobalAggregateManager;
-import org.apache.flink.runtime.throughput.ThroughputCalculator;
 import org.apache.flink.util.UserCodeClassLoader;
 
 import javax.annotation.Nullable;
@@ -99,8 +98,6 @@ public class RuntimeEnvironment implements Environment {
 
     private final Task containingTask;
 
-    private final ThroughputCalculator throughputCalculator;
-
     @Nullable private MailboxExecutor mainMailboxExecutor;
 
     @Nullable private ExecutorService asyncOperationsThreadPool;
@@ -135,8 +132,7 @@ public class RuntimeEnvironment implements Environment {
             TaskManagerRuntimeInfo taskManagerInfo,
             TaskMetricGroup metrics,
             Task containingTask,
-            ExternalResourceInfoProvider externalResourceInfoProvider,
-            ThroughputCalculator throughputCalculator) {
+            ExternalResourceInfoProvider externalResourceInfoProvider) {
 
         this.jobId = checkNotNull(jobId);
         this.jobVertexId = checkNotNull(jobVertexId);
@@ -164,7 +160,6 @@ public class RuntimeEnvironment implements Environment {
         this.containingTask = containingTask;
         this.metrics = metrics;
         this.externalResourceInfoProvider = checkNotNull(externalResourceInfoProvider);
-        this.throughputCalculator = throughputCalculator;
     }
 
     // ------------------------------------------------------------------------
@@ -323,11 +318,6 @@ public class RuntimeEnvironment implements Environment {
     @Override
     public void failExternally(Throwable cause) {
         this.containingTask.failExternally(cause);
-    }
-
-    @Override
-    public ThroughputCalculator getThroughputCalculator() {
-        return throughputCalculator;
     }
 
     @Override

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/throughput/BufferDebloatConfiguration.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/throughput/BufferDebloatConfiguration.java
@@ -16,7 +16,7 @@
  * limitations under the License.
  */
 
-package org.apache.flink.streaming.runtime.tasks.bufferdebloat;
+package org.apache.flink.runtime.throughput;
 
 import org.apache.flink.configuration.ReadableConfig;
 import org.apache.flink.configuration.TaskManagerOptions;

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/throughput/BufferSizeEMA.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/throughput/BufferSizeEMA.java
@@ -16,7 +16,7 @@
  * limitations under the License.
  */
 
-package org.apache.flink.streaming.runtime.tasks.bufferdebloat;
+package org.apache.flink.runtime.throughput;
 
 import static org.apache.flink.util.Preconditions.checkArgument;
 

--- a/flink-runtime/src/test/java/org/apache/flink/runtime/io/network/NettyShuffleEnvironmentBuilder.java
+++ b/flink-runtime/src/test/java/org/apache/flink/runtime/io/network/NettyShuffleEnvironmentBuilder.java
@@ -18,6 +18,7 @@
 
 package org.apache.flink.runtime.io.network;
 
+import org.apache.flink.configuration.Configuration;
 import org.apache.flink.metrics.MetricGroup;
 import org.apache.flink.runtime.clusterframework.types.ResourceID;
 import org.apache.flink.runtime.io.network.netty.NettyConfig;
@@ -25,6 +26,7 @@ import org.apache.flink.runtime.io.network.partition.BoundedBlockingSubpartition
 import org.apache.flink.runtime.io.network.partition.ResultPartitionManager;
 import org.apache.flink.runtime.metrics.groups.UnregisteredMetricGroups;
 import org.apache.flink.runtime.taskmanager.NettyShuffleEnvironmentConfiguration;
+import org.apache.flink.runtime.throughput.BufferDebloatConfiguration;
 import org.apache.flink.runtime.util.EnvironmentInformation;
 import org.apache.flink.util.concurrent.Executors;
 
@@ -76,6 +78,8 @@ public class NettyShuffleEnvironmentBuilder {
     private ResultPartitionManager resultPartitionManager = new ResultPartitionManager();
 
     private Executor ioExecutor = Executors.directExecutor();
+    private BufferDebloatConfiguration debloatConfiguration =
+            BufferDebloatConfiguration.fromConfiguration(new Configuration());
 
     public NettyShuffleEnvironmentBuilder setTaskManagerLocation(ResourceID taskManagerLocation) {
         this.taskManagerLocation = taskManagerLocation;
@@ -170,6 +174,12 @@ public class NettyShuffleEnvironmentBuilder {
         return this;
     }
 
+    public NettyShuffleEnvironmentBuilder setDebloatConfig(
+            BufferDebloatConfiguration debloatConfiguration) {
+        this.debloatConfiguration = debloatConfiguration;
+        return this;
+    }
+
     public NettyShuffleEnvironment build() {
         return NettyShuffleServiceFactory.createNettyShuffleEnvironment(
                 new NettyShuffleEnvironmentConfiguration(
@@ -189,7 +199,8 @@ public class NettyShuffleEnvironmentBuilder {
                         maxBuffersPerChannel,
                         batchShuffleReadMemoryBytes,
                         sortShuffleMinBuffers,
-                        sortShuffleMinParallelism),
+                        sortShuffleMinParallelism,
+                        debloatConfiguration),
                 taskManagerLocation,
                 new TaskEventDispatcher(),
                 resultPartitionManager,

--- a/flink-runtime/src/test/java/org/apache/flink/runtime/io/network/NettyShuffleEnvironmentTest.java
+++ b/flink-runtime/src/test/java/org/apache/flink/runtime/io/network/NettyShuffleEnvironmentTest.java
@@ -18,8 +18,17 @@
 
 package org.apache.flink.runtime.io.network;
 
+import org.apache.flink.api.common.JobID;
+import org.apache.flink.configuration.Configuration;
 import org.apache.flink.configuration.NettyShuffleEnvironmentOptions;
+import org.apache.flink.configuration.TaskManagerOptions;
 import org.apache.flink.core.testutils.BlockerSync;
+import org.apache.flink.metrics.CharacterFilter;
+import org.apache.flink.metrics.Gauge;
+import org.apache.flink.metrics.Metric;
+import org.apache.flink.runtime.clusterframework.types.ResourceID;
+import org.apache.flink.runtime.deployment.InputGateDeploymentDescriptor;
+import org.apache.flink.runtime.executiongraph.ExecutionAttemptID;
 import org.apache.flink.runtime.io.disk.FileChannelManager;
 import org.apache.flink.runtime.io.disk.FileChannelManagerImpl;
 import org.apache.flink.runtime.io.network.api.writer.ResultPartitionWriter;
@@ -33,8 +42,18 @@ import org.apache.flink.runtime.io.network.partition.consumer.InputGate;
 import org.apache.flink.runtime.io.network.partition.consumer.RemoteInputChannel;
 import org.apache.flink.runtime.io.network.partition.consumer.SingleInputGate;
 import org.apache.flink.runtime.io.network.partition.consumer.SingleInputGateBuilder;
+import org.apache.flink.runtime.jobgraph.IntermediateDataSetID;
+import org.apache.flink.runtime.jobgraph.JobVertexID;
+import org.apache.flink.runtime.metrics.MetricNames;
+import org.apache.flink.runtime.metrics.NoOpMetricRegistry;
+import org.apache.flink.runtime.metrics.groups.AbstractMetricGroup;
+import org.apache.flink.runtime.metrics.groups.TaskManagerMetricGroup;
+import org.apache.flink.runtime.metrics.groups.TaskMetricGroup;
+import org.apache.flink.runtime.shuffle.ShuffleDescriptor;
 import org.apache.flink.runtime.taskmanager.Task;
+import org.apache.flink.runtime.throughput.BufferDebloatConfiguration;
 import org.apache.flink.runtime.util.EnvironmentInformation;
+import org.apache.flink.runtime.util.NettyShuffleDescriptorBuilder;
 import org.apache.flink.util.TestLogger;
 
 import org.junit.AfterClass;
@@ -44,7 +63,10 @@ import org.junit.Test;
 import org.junit.rules.ExpectedException;
 
 import java.io.IOException;
+import java.util.Arrays;
 import java.util.Collections;
+import java.util.Map;
+import java.util.concurrent.ConcurrentHashMap;
 import java.util.concurrent.Executors;
 
 import static org.apache.flink.runtime.io.network.partition.InputChannelTestUtils.createDummyConnectionManager;
@@ -129,6 +151,61 @@ public class NettyShuffleEnvironmentTest extends TestLogger {
         shuffleEnvironment.releasePartitionsLocally(Collections.singleton(new ResultPartitionID()));
         sync.awaitBlocker();
         sync.releaseBlocker();
+    }
+
+    @Test
+    @SuppressWarnings("unchecked")
+    public void testRegisteringDebloatingMetrics() throws IOException {
+        Map<String, Metric> metrics = new ConcurrentHashMap<>();
+        final TaskMetricGroup taskMetricGroup = createTaskMetricGroup(metrics);
+        final Configuration config = new Configuration();
+        config.set(TaskManagerOptions.BUFFER_DEBLOAT_ENABLED, true);
+        final NettyShuffleEnvironment shuffleEnvironment =
+                new NettyShuffleEnvironmentBuilder()
+                        .setDebloatConfig(BufferDebloatConfiguration.fromConfiguration(config))
+                        .build();
+        shuffleEnvironment.createInputGates(
+                shuffleEnvironment.createShuffleIOOwnerContext(
+                        "test", new ExecutionAttemptID(), taskMetricGroup),
+                (dsid, id, consumer) -> {},
+                Arrays.asList(
+                        new InputGateDeploymentDescriptor(
+                                new IntermediateDataSetID(),
+                                ResultPartitionType.PIPELINED,
+                                0,
+                                new ShuffleDescriptor[] {
+                                    new NettyShuffleDescriptorBuilder().buildRemote()
+                                }),
+                        new InputGateDeploymentDescriptor(
+                                new IntermediateDataSetID(),
+                                ResultPartitionType.PIPELINED,
+                                1,
+                                new ShuffleDescriptor[] {
+                                    new NettyShuffleDescriptorBuilder().buildRemote()
+                                })));
+        for (int i = 0; i < 2; i++) {
+            assertEquals(
+                    TaskManagerOptions.MEMORY_SEGMENT_SIZE.defaultValue().getBytes(),
+                    (long)
+                            ((Gauge<Integer>)
+                                            getDebloatingMetric(
+                                                    metrics, i, MetricNames.DEBLOATED_BUFFER_SIZE))
+                                    .getValue());
+            assertEquals(
+                    0L,
+                    (long)
+                            ((Gauge<Long>)
+                                            getDebloatingMetric(
+                                                    metrics,
+                                                    i,
+                                                    MetricNames.ESTIMATED_TIME_TO_CONSUME_BUFFERS))
+                                    .getValue());
+        }
+    }
+
+    private Metric getDebloatingMetric(Map<String, Metric> metrics, int i, String metricName) {
+        final String inputScope = "taskmanager.job.task.Shuffle.Netty.Input";
+        return metrics.get(inputScope + "." + i + "." + metricName);
     }
 
     private void testRegisterTaskWithLimitedBuffers(int bufferPoolSize) throws Exception {
@@ -263,5 +340,34 @@ public class NettyShuffleEnvironmentTest extends TestLogger {
                 .setPartitionId(resultPartition.getPartitionId())
                 .setConnectionManager(connManager)
                 .buildRemoteChannel(inputGate);
+    }
+
+    private static TaskMetricGroup createTaskMetricGroup(Map<String, Metric> metrics) {
+        return TaskManagerMetricGroup.createTaskManagerMetricGroup(
+                        new TestMetricRegistry(metrics), "localhost", ResourceID.generate())
+                .addTaskForJob(
+                        new JobID(),
+                        "jobName",
+                        new JobVertexID(0, 0),
+                        new ExecutionAttemptID(),
+                        "test",
+                        0,
+                        0);
+    }
+
+    /** The metric registry for storing the registered metrics to verify in tests. */
+    private static class TestMetricRegistry extends NoOpMetricRegistry {
+        private final Map<String, Metric> metrics;
+
+        TestMetricRegistry(Map<String, Metric> metrics) {
+            super();
+            this.metrics = metrics;
+        }
+
+        @Override
+        public void register(Metric metric, String metricName, AbstractMetricGroup group) {
+            metrics.put(
+                    group.getLogicalScope(CharacterFilter.NO_OP_FILTER) + "." + metricName, metric);
+        }
     }
 }

--- a/flink-runtime/src/test/java/org/apache/flink/runtime/io/network/partition/InputGateFairnessTest.java
+++ b/flink-runtime/src/test/java/org/apache/flink/runtime/io/network/partition/InputGateFairnessTest.java
@@ -34,6 +34,8 @@ import org.apache.flink.runtime.io.network.partition.consumer.SingleInputGate;
 import org.apache.flink.runtime.io.network.partition.consumer.SingleInputGateBuilder;
 import org.apache.flink.runtime.io.network.util.TestBufferFactory;
 import org.apache.flink.runtime.jobgraph.IntermediateDataSetID;
+import org.apache.flink.runtime.throughput.ThroughputCalculator;
+import org.apache.flink.util.clock.SystemClock;
 import org.apache.flink.util.function.SupplierWithException;
 
 import org.junit.Test;
@@ -374,7 +376,9 @@ public class InputGateFairnessTest {
                     STUB_BUFFER_POOL_FACTORY,
                     null,
                     new UnpooledMemorySegmentProvider(BUFFER_SIZE),
-                    BUFFER_SIZE);
+                    BUFFER_SIZE,
+                    new ThroughputCalculator(SystemClock.getInstance()),
+                    null);
 
             channelsWithData = getInputChannelsWithData();
 

--- a/flink-runtime/src/test/java/org/apache/flink/runtime/io/network/partition/consumer/SingleInputGateBuilder.java
+++ b/flink-runtime/src/test/java/org/apache/flink/runtime/io/network/partition/consumer/SingleInputGateBuilder.java
@@ -18,6 +18,7 @@
 
 package org.apache.flink.runtime.io.network.partition.consumer;
 
+import org.apache.flink.configuration.Configuration;
 import org.apache.flink.core.memory.MemorySegmentProvider;
 import org.apache.flink.runtime.checkpoint.channel.ChannelStateWriter;
 import org.apache.flink.runtime.io.network.NettyShuffleEnvironment;
@@ -29,12 +30,17 @@ import org.apache.flink.runtime.io.network.partition.PartitionProducerStateProvi
 import org.apache.flink.runtime.io.network.partition.ResultPartitionType;
 import org.apache.flink.runtime.jobgraph.IntermediateDataSetID;
 import org.apache.flink.runtime.taskmanager.NettyShuffleEnvironmentConfiguration;
+import org.apache.flink.runtime.throughput.BufferDebloatConfiguration;
+import org.apache.flink.runtime.throughput.BufferDebloater;
+import org.apache.flink.runtime.throughput.ThroughputCalculator;
+import org.apache.flink.util.clock.SystemClock;
 import org.apache.flink.util.function.SupplierWithException;
 
 import javax.annotation.Nullable;
 
 import java.io.IOException;
 import java.util.function.BiFunction;
+import java.util.function.Function;
 import java.util.stream.IntStream;
 
 /** Utility class to encapsulate the logic of building a {@link SingleInputGate} instance. */
@@ -68,6 +74,10 @@ public class SingleInputGateBuilder {
     private BiFunction<InputChannelBuilder, SingleInputGate, InputChannel> channelFactory = null;
 
     private SupplierWithException<BufferPool, IOException> bufferPoolFactory = NoOpBufferPool::new;
+    private BufferDebloatConfiguration bufferDebloatConfiguration =
+            BufferDebloatConfiguration.fromConfiguration(new Configuration());
+    private Function<BufferDebloatConfiguration, ThroughputCalculator> createThroughputCalculator =
+            config -> new ThroughputCalculator(SystemClock.getInstance());
 
     public SingleInputGateBuilder setPartitionProducerStateProvider(
             PartitionProducerStateProvider partitionProducerStateProvider) {
@@ -132,6 +142,18 @@ public class SingleInputGateBuilder {
         return this;
     }
 
+    public SingleInputGateBuilder setBufferDebloatConfiguration(
+            BufferDebloatConfiguration configuration) {
+        this.bufferDebloatConfiguration = configuration;
+        return this;
+    }
+
+    public SingleInputGateBuilder setThroughputCalculator(
+            Function<BufferDebloatConfiguration, ThroughputCalculator> createThroughputCalculator) {
+        this.createThroughputCalculator = createThroughputCalculator;
+        return this;
+    }
+
     public SingleInputGate build() {
         SingleInputGate gate =
                 new SingleInputGate(
@@ -145,7 +167,9 @@ public class SingleInputGateBuilder {
                         bufferPoolFactory,
                         bufferDecompressor,
                         segmentProvider,
-                        bufferSize);
+                        bufferSize,
+                        createThroughputCalculator.apply(bufferDebloatConfiguration),
+                        maybeCreateBufferDebloater());
         if (channelFactory != null) {
             gate.setInputChannels(
                     IntStream.range(0, numberOfChannels)
@@ -159,5 +183,18 @@ public class SingleInputGateBuilder {
                             .toArray(InputChannel[]::new));
         }
         return gate;
+    }
+
+    private BufferDebloater maybeCreateBufferDebloater() {
+        if (bufferDebloatConfiguration.isEnabled()) {
+            return new BufferDebloater(
+                    bufferDebloatConfiguration.getTargetTotalBufferSize().toMillis(),
+                    bufferDebloatConfiguration.getMaxBufferSize(),
+                    bufferDebloatConfiguration.getMinBufferSize(),
+                    bufferDebloatConfiguration.getBufferDebloatThresholdPercentages(),
+                    bufferDebloatConfiguration.getNumberOfSamples());
+        }
+
+        return null;
     }
 }

--- a/flink-runtime/src/test/java/org/apache/flink/runtime/io/network/partition/consumer/SingleInputGateTest.java
+++ b/flink-runtime/src/test/java/org/apache/flink/runtime/io/network/partition/consumer/SingleInputGateTest.java
@@ -44,7 +44,6 @@ import org.apache.flink.runtime.io.network.buffer.NetworkBuffer;
 import org.apache.flink.runtime.io.network.buffer.NetworkBufferPool;
 import org.apache.flink.runtime.io.network.partition.BufferAvailabilityListener;
 import org.apache.flink.runtime.io.network.partition.BufferWritingResultPartition;
-import org.apache.flink.runtime.io.network.partition.InputChannelTestUtils;
 import org.apache.flink.runtime.io.network.partition.NoOpResultSubpartitionView;
 import org.apache.flink.runtime.io.network.partition.PartitionNotFoundException;
 import org.apache.flink.runtime.io.network.partition.ResultPartition;
@@ -56,6 +55,8 @@ import org.apache.flink.runtime.io.network.partition.ResultSubpartitionView;
 import org.apache.flink.runtime.io.network.util.TestTaskEvent;
 import org.apache.flink.runtime.jobgraph.IntermediateDataSetID;
 import org.apache.flink.runtime.jobgraph.IntermediateResultPartitionID;
+import org.apache.flink.runtime.metrics.groups.TaskMetricGroup;
+import org.apache.flink.runtime.metrics.groups.UnregisteredMetricGroups;
 import org.apache.flink.runtime.shuffle.NettyShuffleDescriptor;
 import org.apache.flink.runtime.shuffle.ShuffleDescriptor;
 import org.apache.flink.runtime.shuffle.UnknownShuffleDescriptor;
@@ -543,6 +544,8 @@ public class SingleInputGateTest extends InputGateTestBase {
                         .setPartitionRequestMaxBackoff(maxBackoff)
                         .build();
 
+        final TaskMetricGroup taskMetricGroup =
+                UnregisteredMetricGroups.createUnregisteredTaskMetricGroup();
         SingleInputGate gate =
                 new SingleInputGateFactory(
                                 localLocation,
@@ -552,11 +555,11 @@ public class SingleInputGateTest extends InputGateTestBase {
                                 new TaskEventDispatcher(),
                                 netEnv.getNetworkBufferPool())
                         .create(
-                                "TestTask",
+                                netEnv.createShuffleIOOwnerContext(
+                                        "TestTask", taskMetricGroup.executionId(), taskMetricGroup),
                                 0,
                                 gateDesc,
-                                SingleInputGateBuilder.NO_OP_PRODUCER_CHECKER,
-                                InputChannelTestUtils.newUnregisteredInputChannelMetrics());
+                                SingleInputGateBuilder.NO_OP_PRODUCER_CHECKER);
         gate.setChannelStateWriter(ChannelStateWriter.NO_OP);
 
         gate.finishReadRecoveredState();

--- a/flink-runtime/src/test/java/org/apache/flink/runtime/io/network/partition/consumer/TestSingleInputGate.java
+++ b/flink-runtime/src/test/java/org/apache/flink/runtime/io/network/partition/consumer/TestSingleInputGate.java
@@ -18,6 +18,9 @@
 
 package org.apache.flink.runtime.io.network.partition.consumer;
 
+import org.apache.flink.configuration.Configuration;
+import org.apache.flink.runtime.throughput.BufferDebloatConfiguration;
+
 import static org.apache.flink.util.Preconditions.checkArgument;
 
 /** A test input gate to mock reading data. */
@@ -28,12 +31,25 @@ public class TestSingleInputGate {
     protected final TestInputChannel[] inputChannels;
 
     public TestSingleInputGate(int numberOfInputChannels, int gateIndex, boolean initialize) {
+        this(
+                numberOfInputChannels,
+                gateIndex,
+                initialize,
+                BufferDebloatConfiguration.fromConfiguration(new Configuration()));
+    }
+
+    public TestSingleInputGate(
+            int numberOfInputChannels,
+            int gateIndex,
+            boolean initialize,
+            BufferDebloatConfiguration bufferDebloatConfiguration) {
         checkArgument(numberOfInputChannels >= 1);
 
         inputGate =
                 new SingleInputGateBuilder()
                         .setNumberOfChannels(numberOfInputChannels)
                         .setSingleInputGateIndex(gateIndex)
+                        .setBufferDebloatConfiguration(bufferDebloatConfiguration)
                         .build();
         inputChannels = new TestInputChannel[numberOfInputChannels];
 

--- a/flink-runtime/src/test/java/org/apache/flink/runtime/operators/testutils/DummyEnvironment.java
+++ b/flink-runtime/src/test/java/org/apache/flink/runtime/operators/testutils/DummyEnvironment.java
@@ -49,11 +49,9 @@ import org.apache.flink.runtime.taskexecutor.GlobalAggregateManager;
 import org.apache.flink.runtime.taskexecutor.TestGlobalAggregateManager;
 import org.apache.flink.runtime.taskmanager.NoOpTaskOperatorEventGateway;
 import org.apache.flink.runtime.taskmanager.TaskManagerRuntimeInfo;
-import org.apache.flink.runtime.throughput.ThroughputCalculator;
 import org.apache.flink.runtime.util.TestingTaskManagerRuntimeInfo;
 import org.apache.flink.runtime.util.TestingUserCodeClassLoader;
 import org.apache.flink.util.UserCodeClassLoader;
-import org.apache.flink.util.clock.SystemClock;
 
 import java.util.Collections;
 import java.util.Map;
@@ -249,11 +247,6 @@ public class DummyEnvironment implements Environment {
     @Override
     public TaskEventDispatcher getTaskEventDispatcher() {
         throw new UnsupportedOperationException();
-    }
-
-    @Override
-    public ThroughputCalculator getThroughputCalculator() {
-        return new ThroughputCalculator(SystemClock.getInstance());
     }
 
     public void setTaskStateManager(TaskStateManager taskStateManager) {

--- a/flink-runtime/src/test/java/org/apache/flink/runtime/operators/testutils/MockEnvironment.java
+++ b/flink-runtime/src/test/java/org/apache/flink/runtime/operators/testutils/MockEnvironment.java
@@ -51,7 +51,6 @@ import org.apache.flink.runtime.state.TaskStateManager;
 import org.apache.flink.runtime.taskexecutor.GlobalAggregateManager;
 import org.apache.flink.runtime.taskmanager.NoOpTaskOperatorEventGateway;
 import org.apache.flink.runtime.taskmanager.TaskManagerRuntimeInfo;
-import org.apache.flink.runtime.throughput.ThroughputCalculator;
 import org.apache.flink.types.Record;
 import org.apache.flink.util.MutableObjectIterator;
 import org.apache.flink.util.Preconditions;
@@ -128,8 +127,6 @@ public class MockEnvironment implements Environment, AutoCloseable {
 
     private final ExternalResourceInfoProvider externalResourceInfoProvider;
 
-    private final ThroughputCalculator throughputCalculator;
-
     private MailboxExecutor mainMailboxExecutor;
 
     private ExecutorService asyncOperationsThreadPool;
@@ -158,12 +155,10 @@ public class MockEnvironment implements Environment, AutoCloseable {
             TaskMetricGroup taskMetricGroup,
             TaskManagerRuntimeInfo taskManagerRuntimeInfo,
             MemoryManager memManager,
-            ExternalResourceInfoProvider externalResourceInfoProvider,
-            ThroughputCalculator throughputCalculator) {
+            ExternalResourceInfoProvider externalResourceInfoProvider) {
 
         this.jobID = jobID;
         this.jobVertexID = jobVertexID;
-        this.throughputCalculator = throughputCalculator;
 
         this.taskInfo = new TaskInfo(taskName, maxParallelism, subtaskIndex, parallelism, 0);
         this.jobConfiguration = new Configuration();
@@ -318,11 +313,6 @@ public class MockEnvironment implements Environment, AutoCloseable {
     @Override
     public TaskEventDispatcher getTaskEventDispatcher() {
         return taskEventDispatcher;
-    }
-
-    @Override
-    public ThroughputCalculator getThroughputCalculator() {
-        return throughputCalculator;
     }
 
     @Override

--- a/flink-runtime/src/test/java/org/apache/flink/runtime/operators/testutils/MockEnvironmentBuilder.java
+++ b/flink-runtime/src/test/java/org/apache/flink/runtime/operators/testutils/MockEnvironmentBuilder.java
@@ -34,11 +34,9 @@ import org.apache.flink.runtime.state.TestTaskStateManager;
 import org.apache.flink.runtime.taskexecutor.GlobalAggregateManager;
 import org.apache.flink.runtime.taskexecutor.TestGlobalAggregateManager;
 import org.apache.flink.runtime.taskmanager.TaskManagerRuntimeInfo;
-import org.apache.flink.runtime.throughput.ThroughputCalculator;
 import org.apache.flink.runtime.util.TestingTaskManagerRuntimeInfo;
 import org.apache.flink.runtime.util.TestingUserCodeClassLoader;
 import org.apache.flink.util.UserCodeClassLoader;
-import org.apache.flink.util.clock.SystemClock;
 
 public class MockEnvironmentBuilder {
     private String taskName = "mock-task";
@@ -63,8 +61,6 @@ public class MockEnvironmentBuilder {
             buildMemoryManager(1024 * MemoryManager.DEFAULT_PAGE_SIZE);
     private ExternalResourceInfoProvider externalResourceInfoProvider =
             ExternalResourceInfoProvider.NO_EXTERNAL_RESOURCES;
-    private ThroughputCalculator throughputCalculator =
-            new ThroughputCalculator(SystemClock.getInstance());
 
     private MemoryManager buildMemoryManager(long memorySize) {
         return MemoryManagerBuilder.newBuilder().setMemorySize(memorySize).build();
@@ -163,12 +159,6 @@ public class MockEnvironmentBuilder {
         return this;
     }
 
-    public MockEnvironmentBuilder setThroughputCalculator(
-            ThroughputCalculator throughputCalculator) {
-        this.throughputCalculator = throughputCalculator;
-        return this;
-    }
-
     public MockEnvironment build() {
         if (ioManager == null) {
             ioManager = new IOManagerAsync();
@@ -191,7 +181,6 @@ public class MockEnvironmentBuilder {
                 taskMetricGroup,
                 taskManagerRuntimeInfo,
                 memoryManager,
-                externalResourceInfoProvider,
-                throughputCalculator);
+                externalResourceInfoProvider);
     }
 }

--- a/flink-runtime/src/test/java/org/apache/flink/runtime/throughput/BufferDebloatConfigurationTest.java
+++ b/flink-runtime/src/test/java/org/apache/flink/runtime/throughput/BufferDebloatConfigurationTest.java
@@ -16,7 +16,7 @@
  * limitations under the License.
  */
 
-package org.apache.flink.streaming.runtime.tasks.bufferdebloat;
+package org.apache.flink.runtime.throughput;
 
 import org.apache.flink.configuration.Configuration;
 import org.apache.flink.configuration.MemorySize;

--- a/flink-runtime/src/test/java/org/apache/flink/runtime/throughput/BufferSizeEMATest.java
+++ b/flink-runtime/src/test/java/org/apache/flink/runtime/throughput/BufferSizeEMATest.java
@@ -16,7 +16,7 @@
  * limitations under the License.
  */
 
-package org.apache.flink.streaming.runtime.tasks.bufferdebloat;
+package org.apache.flink.runtime.throughput;
 
 import org.apache.flink.util.TestLogger;
 

--- a/flink-streaming-java/src/main/java/org/apache/flink/streaming/runtime/tasks/bufferdebloat/BufferDebloatConfiguration.java
+++ b/flink-streaming-java/src/main/java/org/apache/flink/streaming/runtime/tasks/bufferdebloat/BufferDebloatConfiguration.java
@@ -1,0 +1,105 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.flink.streaming.runtime.tasks.bufferdebloat;
+
+import org.apache.flink.configuration.ReadableConfig;
+import org.apache.flink.configuration.TaskManagerOptions;
+
+import java.time.Duration;
+
+import static org.apache.flink.configuration.TaskManagerOptions.BUFFER_DEBLOAT_SAMPLES;
+import static org.apache.flink.configuration.TaskManagerOptions.BUFFER_DEBLOAT_TARGET;
+import static org.apache.flink.configuration.TaskManagerOptions.BUFFER_DEBLOAT_THRESHOLD_PERCENTAGES;
+import static org.apache.flink.util.Preconditions.checkArgument;
+import static org.apache.flink.util.Preconditions.checkNotNull;
+
+/** Configuration for {@link BufferDebloater}. */
+public final class BufferDebloatConfiguration {
+    private final Duration targetTotalBufferSize;
+    private final int maxBufferSize;
+    private final int minBufferSize;
+    private final int bufferDebloatThresholdPercentages;
+    private final int numberOfSamples;
+    private final boolean enabled;
+
+    private BufferDebloatConfiguration(
+            boolean enabled,
+            Duration targetTotalBufferSize,
+            int maxBufferSize,
+            int minBufferSize,
+            int bufferDebloatThresholdPercentages,
+            int numberOfSamples) {
+        this.targetTotalBufferSize = checkNotNull(targetTotalBufferSize);
+        this.maxBufferSize = maxBufferSize;
+        this.minBufferSize = minBufferSize;
+        this.bufferDebloatThresholdPercentages = bufferDebloatThresholdPercentages;
+        this.numberOfSamples = numberOfSamples;
+        this.enabled = enabled;
+    }
+
+    public boolean isEnabled() {
+        return enabled;
+    }
+
+    public Duration getTargetTotalBufferSize() {
+        return targetTotalBufferSize;
+    }
+
+    public int getMaxBufferSize() {
+        return maxBufferSize;
+    }
+
+    public int getMinBufferSize() {
+        return minBufferSize;
+    }
+
+    public int getBufferDebloatThresholdPercentages() {
+        return bufferDebloatThresholdPercentages;
+    }
+
+    public int getNumberOfSamples() {
+        return numberOfSamples;
+    }
+
+    public static BufferDebloatConfiguration fromConfiguration(ReadableConfig config) {
+        Duration targetTotalBufferSize = config.get(BUFFER_DEBLOAT_TARGET);
+        int maxBufferSize =
+                Math.toIntExact(config.get(TaskManagerOptions.MEMORY_SEGMENT_SIZE).getBytes());
+        int minBufferSize =
+                Math.toIntExact(config.get(TaskManagerOptions.MIN_MEMORY_SEGMENT_SIZE).getBytes());
+
+        int bufferDebloatThresholdPercentages = config.get(BUFFER_DEBLOAT_THRESHOLD_PERCENTAGES);
+        final int numberOfSamples = config.get(BUFFER_DEBLOAT_SAMPLES);
+
+        // Right now the buffer size can not be grater than integer max value according to
+        // MemorySegment and buffer implementation.
+        checkArgument(maxBufferSize > 0);
+        checkArgument(minBufferSize > 0);
+        checkArgument(numberOfSamples > 0);
+        checkArgument(maxBufferSize >= minBufferSize);
+        checkArgument(targetTotalBufferSize.toMillis() > 0.0);
+        return new BufferDebloatConfiguration(
+                config.get(TaskManagerOptions.BUFFER_DEBLOAT_ENABLED),
+                targetTotalBufferSize,
+                maxBufferSize,
+                minBufferSize,
+                bufferDebloatThresholdPercentages,
+                numberOfSamples);
+    }
+}

--- a/flink-streaming-java/src/test/java/org/apache/flink/streaming/runtime/io/MockIndexedInputGate.java
+++ b/flink-streaming-java/src/test/java/org/apache/flink/streaming/runtime/io/MockIndexedInputGate.java
@@ -127,10 +127,5 @@ public class MockIndexedInputGate extends IndexedInputGate {
     }
 
     @Override
-    public int getBuffersInUseCount() {
-        return 0;
-    }
-
-    @Override
-    public void announceBufferSize(int bufferSize) {}
+    public void triggerDebloating() {}
 }

--- a/flink-streaming-java/src/test/java/org/apache/flink/streaming/runtime/io/MockInputGate.java
+++ b/flink-streaming-java/src/test/java/org/apache/flink/streaming/runtime/io/MockInputGate.java
@@ -164,12 +164,7 @@ public class MockInputGate extends IndexedInputGate {
     }
 
     @Override
-    public int getBuffersInUseCount() {
-        return 0;
-    }
-
-    @Override
-    public void announceBufferSize(int bufferSize) {}
+    public void triggerDebloating() {}
 
     public Set<Integer> getBlockedChannels() {
         return blockedChannels;

--- a/flink-streaming-java/src/test/java/org/apache/flink/streaming/runtime/io/checkpointing/AlignedCheckpointsMassiveRandomTest.java
+++ b/flink-streaming-java/src/test/java/org/apache/flink/streaming/runtime/io/checkpointing/AlignedCheckpointsMassiveRandomTest.java
@@ -241,12 +241,7 @@ public class AlignedCheckpointsMassiveRandomTest {
         public void checkpointStopped(long cancelledCheckpointId) {}
 
         @Override
-        public int getBuffersInUseCount() {
-            return 0;
-        }
-
-        @Override
-        public void announceBufferSize(int bufferSize) {}
+        public void triggerDebloating() {}
 
         public void acknowledgeAllRecordsProcessed(InputChannelInfo channelInfo)
                 throws IOException {}

--- a/flink-streaming-java/src/test/java/org/apache/flink/streaming/runtime/operators/StreamTaskTimerTest.java
+++ b/flink-streaming-java/src/test/java/org/apache/flink/streaming/runtime/operators/StreamTaskTimerTest.java
@@ -20,6 +20,7 @@ package org.apache.flink.streaming.runtime.operators;
 
 import org.apache.flink.api.common.functions.MapFunction;
 import org.apache.flink.api.common.typeinfo.BasicTypeInfo;
+import org.apache.flink.configuration.Configuration;
 import org.apache.flink.configuration.TaskManagerOptions;
 import org.apache.flink.core.testutils.OneShotLatch;
 import org.apache.flink.streaming.api.graph.StreamConfig;
@@ -186,10 +187,9 @@ public class StreamTaskTimerTest extends TestLogger {
 
         testHarness.setupOutputForSingletonOperatorChain();
         // Making it impossible to execute the throughput calculation even once during the test.
-        testHarness
-                .getTaskManagerRuntimeInfo()
-                .getConfiguration()
-                .set(TaskManagerOptions.BUFFER_DEBLOAT_PERIOD, Duration.ofMinutes(10));
+        final Configuration taskConfig = testHarness.getTaskManagerRuntimeInfo().getConfiguration();
+        taskConfig.set(TaskManagerOptions.BUFFER_DEBLOAT_ENABLED, true);
+        taskConfig.set(TaskManagerOptions.BUFFER_DEBLOAT_PERIOD, Duration.ofMinutes(10));
 
         StreamConfig streamConfig = testHarness.getStreamConfig();
         streamConfig.setChainIndex(0);

--- a/flink-streaming-java/src/test/java/org/apache/flink/streaming/runtime/tasks/StreamMockEnvironment.java
+++ b/flink-streaming-java/src/test/java/org/apache/flink/streaming/runtime/tasks/StreamMockEnvironment.java
@@ -56,12 +56,10 @@ import org.apache.flink.runtime.taskmanager.CheckpointResponder;
 import org.apache.flink.runtime.taskmanager.NoOpCheckpointResponder;
 import org.apache.flink.runtime.taskmanager.NoOpTaskOperatorEventGateway;
 import org.apache.flink.runtime.taskmanager.TaskManagerRuntimeInfo;
-import org.apache.flink.runtime.throughput.ThroughputCalculator;
 import org.apache.flink.runtime.util.TestingTaskManagerRuntimeInfo;
 import org.apache.flink.runtime.util.TestingUserCodeClassLoader;
 import org.apache.flink.util.Preconditions;
 import org.apache.flink.util.UserCodeClassLoader;
-import org.apache.flink.util.clock.SystemClock;
 
 import javax.annotation.Nullable;
 
@@ -129,8 +127,6 @@ public class StreamMockEnvironment implements Environment {
 
     private CheckpointResponder checkpointResponder = NoOpCheckpointResponder.INSTANCE;
 
-    private ThroughputCalculator throughputCalculator;
-
     public StreamMockEnvironment(
             Configuration jobConfig,
             Configuration taskConfig,
@@ -149,7 +145,6 @@ public class StreamMockEnvironment implements Environment {
                 inputSplitProvider,
                 bufferSize,
                 taskStateManager,
-                new ThroughputCalculator(SystemClock.getInstance()),
                 false);
     }
 
@@ -163,7 +158,6 @@ public class StreamMockEnvironment implements Environment {
             MockInputSplitProvider inputSplitProvider,
             int bufferSize,
             TaskStateManager taskStateManager,
-            ThroughputCalculator throughputCalculator,
             boolean collectNetworkEvents) {
 
         this.jobID = jobID;
@@ -194,7 +188,6 @@ public class StreamMockEnvironment implements Environment {
 
         KvStateRegistry registry = new KvStateRegistry();
         this.kvStateRegistry = registry.createTaskRegistry(jobID, getJobVertexId());
-        this.throughputCalculator = throughputCalculator;
         this.collectNetworkEvents = collectNetworkEvents;
     }
 
@@ -313,11 +306,6 @@ public class StreamMockEnvironment implements Environment {
     @Override
     public TaskEventDispatcher getTaskEventDispatcher() {
         return taskEventDispatcher;
-    }
-
-    @Override
-    public ThroughputCalculator getThroughputCalculator() {
-        return throughputCalculator;
     }
 
     @Override

--- a/flink-streaming-java/src/test/java/org/apache/flink/streaming/runtime/tasks/bufferdebloat/BufferDebloatConfigurationTest.java
+++ b/flink-streaming-java/src/test/java/org/apache/flink/streaming/runtime/tasks/bufferdebloat/BufferDebloatConfigurationTest.java
@@ -1,0 +1,53 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.flink.streaming.runtime.tasks.bufferdebloat;
+
+import org.apache.flink.configuration.Configuration;
+import org.apache.flink.configuration.MemorySize;
+import org.apache.flink.configuration.TaskManagerOptions;
+import org.apache.flink.util.TestLogger;
+
+import org.junit.jupiter.api.Test;
+
+import java.time.Duration;
+
+import static org.junit.jupiter.api.Assertions.assertThrows;
+
+/** Tests for validation of {@link BufferDebloatConfiguration}. */
+class BufferDebloatConfigurationTest extends TestLogger {
+
+    @Test
+    public void testMinGreaterThanMaxBufferSize() {
+        final Configuration config = new Configuration();
+        config.set(TaskManagerOptions.MIN_MEMORY_SEGMENT_SIZE, new MemorySize(50));
+        config.set(TaskManagerOptions.MEMORY_SEGMENT_SIZE, new MemorySize(49));
+        assertThrows(
+                IllegalArgumentException.class,
+                () -> BufferDebloatConfiguration.fromConfiguration(config));
+    }
+
+    @Test
+    public void testNegativeConsumptionTime() {
+        final Configuration config = new Configuration();
+        config.set(TaskManagerOptions.BUFFER_DEBLOAT_TARGET, Duration.ofMillis(-1));
+        assertThrows(
+                IllegalArgumentException.class,
+                () -> BufferDebloatConfiguration.fromConfiguration(config));
+    }
+}


### PR DESCRIPTION
## What is the purpose of the change

This PR moves calculating throughput as well debloating buffers to
the gate level. It should help with situations when there is a
significant difference in gates throughput.


## Does this pull request potentially affect one of the following parts:

  - Dependencies (does it add or upgrade a dependency): (yes / **no**)
  - The public API, i.e., is any changed class annotated with `@Public(Evolving)`: (yes / **no**)
  - The serializers: (yes / **no** / don't know)
  - The runtime per-record code paths (performance sensitive): (**yes** / no / don't know)
  - Anything that affects deployment or recovery: JobManager (and its components), Checkpointing, Kubernetes/Yarn, ZooKeeper: (yes / **no** / don't know)
  - The S3 file system connector: (yes / **no** / don't know)

## Documentation

  - Does this pull request introduce a new feature? (yes / **no**)
  - If yes, how is the feature documented? (not applicable / **docs** / JavaDocs / not documented)
