### PR TITLE
[FLINK-24615][table] Add infrastructure to support metadata for filesystem connector

### DIFF
--- a/docs/content/docs/connectors/table/filesystem.md
+++ b/docs/content/docs/connectors/table/filesystem.md
@@ -108,6 +108,41 @@ The file system connector can be used to read single files or entire directories
 
 When using a directory as the source path, there is **no defined order of ingestion** for the files inside the directory.
 
+### Available Metadata
+
+The following connector metadata can be accessed as metadata columns in a table definition. All the metadata are read only.
+
+<table class="table table-bordered">
+    <thead>
+    <tr>
+      <th class="text-left" style="width: 25%">Key</th>
+      <th class="text-center" style="width: 30%">Data Type</th>
+      <th class="text-center" style="width: 40%">Description</th>
+    </tr>
+    </thead>
+    <tbody>
+    <tr>
+      <td><code>filename</code></td>
+      <td><code>STRING NOT NULL</code></td>
+      <td>Full path of the input file.</td>
+    </tr>
+    </tbody>
+</table>
+
+The extended `CREATE TABLE` example demonstrates the syntax for exposing these metadata fields:
+
+```sql
+CREATE TABLE MyUserTableWithFilename (
+  column_name1 INT,
+  column_name2 STRING,
+  filename STRING NOT NULL METADATA
+) WITH (
+  'connector' = 'filesystem',
+  'path' = 'file:///path/to/whatever',
+  'format' = 'json'
+)
+```
+
 ## Streaming Sink
 
 The file system connector supports streaming writes, based on Flink's [Streaming File Sink]({{< ref "docs/connectors/datastream/streamfile_sink" >}})

--- a/docs/content/docs/connectors/table/filesystem.md
+++ b/docs/content/docs/connectors/table/filesystem.md
@@ -122,7 +122,7 @@ The following connector metadata can be accessed as metadata columns in a table 
     </thead>
     <tbody>
     <tr>
-      <td><code>filename</code></td>
+      <td><code>filepath</code></td>
       <td><code>STRING NOT NULL</code></td>
       <td>Full path of the input file.</td>
     </tr>
@@ -132,10 +132,10 @@ The following connector metadata can be accessed as metadata columns in a table 
 The extended `CREATE TABLE` example demonstrates the syntax for exposing these metadata fields:
 
 ```sql
-CREATE TABLE MyUserTableWithFilename (
+CREATE TABLE MyUserTableWithFilepath (
   column_name1 INT,
   column_name2 STRING,
-  filename STRING NOT NULL METADATA
+  filepath STRING NOT NULL METADATA
 ) WITH (
   'connector' = 'filesystem',
   'path' = 'file:///path/to/whatever',

--- a/flink-connectors/flink-connector-files/src/main/java/org/apache/flink/connector/file/src/util/RecordMapperWrapperRecordIterator.java
+++ b/flink-connectors/flink-connector-files/src/main/java/org/apache/flink/connector/file/src/util/RecordMapperWrapperRecordIterator.java
@@ -1,0 +1,64 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.flink.connector.file.src.util;
+
+import org.apache.flink.connector.file.src.reader.BulkFormat;
+
+/**
+ * Implementation of {@link org.apache.flink.connector.file.src.reader.BulkFormat.RecordIterator}
+ * that wraps another iterator and performs the mapping of the records.
+ *
+ * @param <I> Input type
+ * @param <O> Mapped output type
+ */
+public class RecordMapperWrapperRecordIterator<I, O> implements BulkFormat.RecordIterator<O> {
+
+    /** Record mapper definition. */
+    @FunctionalInterface
+    public interface RecordMapper<I, O> {
+        /** Map the record. Both input value and output value are expected to be non-null. */
+        O map(I in);
+    }
+
+    private final BulkFormat.RecordIterator<I> wrapped;
+    private final RecordMapper<I, O> mapper;
+
+    public RecordMapperWrapperRecordIterator(
+            BulkFormat.RecordIterator<I> wrapped, RecordMapper<I, O> mapper) {
+        this.wrapped = wrapped;
+        this.mapper = mapper;
+    }
+
+    @SuppressWarnings({"unchecked", "rawtypes"})
+    @Override
+    public RecordAndPosition<O> next() {
+        RecordAndPosition record = this.wrapped.next();
+        if (record == null || record.getRecord() == null) {
+            return (RecordAndPosition<O>) record;
+        }
+
+        record.record = mapper.map((I) record.record);
+        return (RecordAndPosition<O>) record;
+    }
+
+    @Override
+    public void releaseBatch() {
+        this.wrapped.releaseBatch();
+    }
+}

--- a/flink-formats/flink-avro/src/test/java/org/apache/flink/formats/avro/AvroFilesystemITCase.java
+++ b/flink-formats/flink-avro/src/test/java/org/apache/flink/formats/avro/AvroFilesystemITCase.java
@@ -46,6 +46,11 @@ public class AvroFilesystemITCase extends BatchFileSystemITCaseBase {
     }
 
     @Override
+    public boolean supportsReadingMetadata() {
+        return false;
+    }
+
+    @Override
     public String[] formatProperties() {
         List<String> ret = new ArrayList<>();
         ret.add("'format'='avro'");

--- a/flink-formats/flink-csv/src/test/java/org/apache/flink/formats/csv/CsvFilesystemBatchITCase.java
+++ b/flink-formats/flink-csv/src/test/java/org/apache/flink/formats/csv/CsvFilesystemBatchITCase.java
@@ -40,6 +40,11 @@ public class CsvFilesystemBatchITCase {
     public static class GeneralCsvFilesystemBatchITCase extends BatchFileSystemITCaseBase {
 
         @Override
+        public boolean supportsReadingMetadata() {
+            return false;
+        }
+
+        @Override
         public String[] formatProperties() {
             List<String> ret = new ArrayList<>();
             ret.add("'format'='csv'");
@@ -54,6 +59,11 @@ public class CsvFilesystemBatchITCase {
      * in batch mode.
      */
     public static class EnrichedCsvFilesystemBatchITCase extends BatchFileSystemITCaseBase {
+
+        @Override
+        public boolean supportsReadingMetadata() {
+            return false;
+        }
 
         @Override
         public String[] formatProperties() {

--- a/flink-formats/flink-csv/src/test/java/org/apache/flink/formats/csv/CsvFilesystemStreamITCase.java
+++ b/flink-formats/flink-csv/src/test/java/org/apache/flink/formats/csv/CsvFilesystemStreamITCase.java
@@ -27,6 +27,11 @@ import java.util.List;
 public class CsvFilesystemStreamITCase extends StreamFileSystemITCaseBase {
 
     @Override
+    public boolean supportsReadingMetadata() {
+        return false;
+    }
+
+    @Override
     public String[] formatProperties() {
         List<String> ret = new ArrayList<>();
         ret.add("'format'='csv'");

--- a/flink-table/flink-table-common/src/main/java/org/apache/flink/table/data/utils/EnrichedRowData.java
+++ b/flink-table/flink-table-common/src/main/java/org/apache/flink/table/data/utils/EnrichedRowData.java
@@ -37,7 +37,7 @@ import java.util.Objects;
  * hot code paths. The {@link RowKind} is inherited from the mutable row.
  */
 @PublicEvolving
-public class ExtendedRowData implements RowData {
+public class EnrichedRowData implements RowData {
 
     private final RowData fixedRow;
     // The index mapping is built as follows: positive indexes are indexes refer to mutable row
@@ -53,18 +53,18 @@ public class ExtendedRowData implements RowData {
 
     private RowData mutableRow;
 
-    public ExtendedRowData(RowData fixedRow, int[] indexMapping) {
+    public EnrichedRowData(RowData fixedRow, int[] indexMapping) {
         this.fixedRow = fixedRow;
         this.indexMapping = indexMapping;
     }
 
     /**
-     * Replaces the mutable {@link RowData} backing this {@link ExtendedRowData}.
+     * Replaces the mutable {@link RowData} backing this {@link EnrichedRowData}.
      *
      * <p>This method replaces the mutable row data in place and does not return a new object. This
      * is done for performance reasons.
      */
-    public ExtendedRowData replaceMutableRow(RowData mutableRow) {
+    public EnrichedRowData replaceMutableRow(RowData mutableRow) {
         this.mutableRow = mutableRow;
         return this;
     }
@@ -78,12 +78,12 @@ public class ExtendedRowData implements RowData {
 
     @Override
     public RowKind getRowKind() {
-        return this.mutableRow.getRowKind();
+        return mutableRow.getRowKind();
     }
 
     @Override
     public void setRowKind(RowKind kind) {
-        this.mutableRow.setRowKind(kind);
+        mutableRow.setRowKind(kind);
     }
 
     @Override
@@ -254,7 +254,7 @@ public class ExtendedRowData implements RowData {
         if (o == null || getClass() != o.getClass()) {
             return false;
         }
-        ExtendedRowData that = (ExtendedRowData) o;
+        EnrichedRowData that = (EnrichedRowData) o;
         return Objects.equals(this.fixedRow, that.fixedRow)
                 && Objects.equals(this.mutableRow, that.mutableRow);
     }
@@ -276,20 +276,31 @@ public class ExtendedRowData implements RowData {
     }
 
     /**
-     * Creates a new {@link ExtendedRowData} with the provided {@code fixedRow} as the immutable
+     * Creates a new {@link EnrichedRowData} with the provided {@code fixedRow} as the immutable
      * static row, and uses the {@code completeRowFields}, {@code fixedRowFields} and {@code
      * mutableRowFields} arguments to compute the indexes mapping.
+     *
+     * <p>The {@code completeRowFields} should include the name of fields of the full row once
+     * mutable and fixed rows are merged, while {@code fixedRowFields} and {@code mutableRowFields}
+     * should contain respectively the field names of fixed row and mutable row. All the lists are
+     * ordered with indexes matching the position of the field in the row. As an example, for a
+     * complete row {@code (a, b, c)} the mutable row might be {@code (a, c)} and the fixed row
+     * might be {@code (b)}
      */
-    public static ExtendedRowData from(
+    public static EnrichedRowData from(
             RowData fixedRow,
             List<String> completeRowFields,
             List<String> mutableRowFields,
             List<String> fixedRowFields) {
-        return new ExtendedRowData(
+        return new EnrichedRowData(
                 fixedRow, computeIndexMapping(completeRowFields, mutableRowFields, fixedRowFields));
     }
 
-    /** This method computes the index mapping for {@link ExtendedRowData}. */
+    /**
+     * This method computes the index mapping for {@link EnrichedRowData}.
+     *
+     * @see EnrichedRowData#from(RowData, List, List, List)
+     */
     public static int[] computeIndexMapping(
             List<String> completeRowFields,
             List<String> mutableRowFields,

--- a/flink-table/flink-table-common/src/main/java/org/apache/flink/table/data/utils/EnrichedRowData.java
+++ b/flink-table/flink-table-common/src/main/java/org/apache/flink/table/data/utils/EnrichedRowData.java
@@ -277,10 +277,10 @@ public class EnrichedRowData implements RowData {
 
     /**
      * Creates a new {@link EnrichedRowData} with the provided {@code fixedRow} as the immutable
-     * static row, and uses the {@code completeRowFields}, {@code fixedRowFields} and {@code
+     * static row, and uses the {@code producedRowFields}, {@code fixedRowFields} and {@code
      * mutableRowFields} arguments to compute the indexes mapping.
      *
-     * <p>The {@code completeRowFields} should include the name of fields of the full row once
+     * <p>The {@code producedRowFields} should include the name of fields of the full row once
      * mutable and fixed rows are merged, while {@code fixedRowFields} and {@code mutableRowFields}
      * should contain respectively the field names of fixed row and mutable row. All the lists are
      * ordered with indexes matching the position of the field in the row. As an example, for a
@@ -289,11 +289,11 @@ public class EnrichedRowData implements RowData {
      */
     public static EnrichedRowData from(
             RowData fixedRow,
-            List<String> completeRowFields,
+            List<String> producedRowFields,
             List<String> mutableRowFields,
             List<String> fixedRowFields) {
         return new EnrichedRowData(
-                fixedRow, computeIndexMapping(completeRowFields, mutableRowFields, fixedRowFields));
+                fixedRow, computeIndexMapping(producedRowFields, mutableRowFields, fixedRowFields));
     }
 
     /**
@@ -302,13 +302,13 @@ public class EnrichedRowData implements RowData {
      * @see EnrichedRowData#from(RowData, List, List, List)
      */
     public static int[] computeIndexMapping(
-            List<String> completeRowFields,
+            List<String> producedRowFields,
             List<String> mutableRowFields,
             List<String> fixedRowFields) {
-        int[] indexMapping = new int[completeRowFields.size()];
+        int[] indexMapping = new int[producedRowFields.size()];
 
-        for (int i = 0; i < completeRowFields.size(); i++) {
-            String fieldName = completeRowFields.get(i);
+        for (int i = 0; i < producedRowFields.size(); i++) {
+            String fieldName = producedRowFields.get(i);
 
             int newIndex = mutableRowFields.indexOf(fieldName);
             if (newIndex < 0) {

--- a/flink-table/flink-table-common/src/main/java/org/apache/flink/table/data/utils/ExtendedRowData.java
+++ b/flink-table/flink-table-common/src/main/java/org/apache/flink/table/data/utils/ExtendedRowData.java
@@ -1,0 +1,312 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.flink.table.data.utils;
+
+import org.apache.flink.annotation.PublicEvolving;
+import org.apache.flink.table.data.ArrayData;
+import org.apache.flink.table.data.DecimalData;
+import org.apache.flink.table.data.MapData;
+import org.apache.flink.table.data.RawValueData;
+import org.apache.flink.table.data.RowData;
+import org.apache.flink.table.data.StringData;
+import org.apache.flink.table.data.TimestampData;
+import org.apache.flink.types.RowKind;
+
+import java.util.List;
+import java.util.Objects;
+
+/**
+ * An implementation of {@link RowData} which is backed by two {@link RowData} with a well-defined
+ * index mapping, One of the rows is fixed, while the other can be swapped for performant changes in
+ * hot code paths. The {@link RowKind} is inherited from the mutable row.
+ */
+@PublicEvolving
+public class ExtendedRowData implements RowData {
+
+    private final RowData fixedRow;
+    // The index mapping is built as follows: positive indexes are indexes refer to mutable row
+    // positions,
+    // while negative indexes (with -1 offset) refer to fixed row positions.
+    // For example an index mapping [0, 1, -1, -2, 2] means:
+    // * Index 0 -> mutable row index 0
+    // * Index 1 -> mutable row index 1
+    // * Index -1 -> fixed row index 0
+    // * Index -2 -> fixed row index 1
+    // * Index 2 -> mutable row index 2
+    private final int[] indexMapping;
+
+    private RowData mutableRow;
+
+    public ExtendedRowData(RowData fixedRow, int[] indexMapping) {
+        this.fixedRow = fixedRow;
+        this.indexMapping = indexMapping;
+    }
+
+    /**
+     * Replaces the mutable {@link RowData} backing this {@link ExtendedRowData}.
+     *
+     * <p>This method replaces the mutable row data in place and does not return a new object. This
+     * is done for performance reasons.
+     */
+    public ExtendedRowData replaceMutableRow(RowData mutableRow) {
+        this.mutableRow = mutableRow;
+        return this;
+    }
+
+    // ---------------------------------------------------------------------------------------------
+
+    @Override
+    public int getArity() {
+        return indexMapping.length;
+    }
+
+    @Override
+    public RowKind getRowKind() {
+        return this.mutableRow.getRowKind();
+    }
+
+    @Override
+    public void setRowKind(RowKind kind) {
+        this.mutableRow.setRowKind(kind);
+    }
+
+    @Override
+    public boolean isNullAt(int pos) {
+        int index = indexMapping[pos];
+        if (index >= 0) {
+            return mutableRow.isNullAt(index);
+        } else {
+            return fixedRow.isNullAt(-(index + 1));
+        }
+    }
+
+    @Override
+    public boolean getBoolean(int pos) {
+        int index = indexMapping[pos];
+        if (index >= 0) {
+            return mutableRow.getBoolean(index);
+        } else {
+            return fixedRow.getBoolean(-(index + 1));
+        }
+    }
+
+    @Override
+    public byte getByte(int pos) {
+        int index = indexMapping[pos];
+        if (index >= 0) {
+            return mutableRow.getByte(index);
+        } else {
+            return fixedRow.getByte(-(index + 1));
+        }
+    }
+
+    @Override
+    public short getShort(int pos) {
+        int index = indexMapping[pos];
+        if (index >= 0) {
+            return mutableRow.getShort(index);
+        } else {
+            return fixedRow.getShort(-(index + 1));
+        }
+    }
+
+    @Override
+    public int getInt(int pos) {
+        int index = indexMapping[pos];
+        if (index >= 0) {
+            return mutableRow.getInt(index);
+        } else {
+            return fixedRow.getInt(-(index + 1));
+        }
+    }
+
+    @Override
+    public long getLong(int pos) {
+        int index = indexMapping[pos];
+        if (index >= 0) {
+            return mutableRow.getLong(index);
+        } else {
+            return fixedRow.getLong(-(index + 1));
+        }
+    }
+
+    @Override
+    public float getFloat(int pos) {
+        int index = indexMapping[pos];
+        if (index >= 0) {
+            return mutableRow.getFloat(index);
+        } else {
+            return fixedRow.getFloat(-(index + 1));
+        }
+    }
+
+    @Override
+    public double getDouble(int pos) {
+        int index = indexMapping[pos];
+        if (index >= 0) {
+            return mutableRow.getDouble(index);
+        } else {
+            return fixedRow.getDouble(-(index + 1));
+        }
+    }
+
+    @Override
+    public StringData getString(int pos) {
+        int index = indexMapping[pos];
+        if (index >= 0) {
+            return mutableRow.getString(index);
+        } else {
+            return fixedRow.getString(-(index + 1));
+        }
+    }
+
+    @Override
+    public DecimalData getDecimal(int pos, int precision, int scale) {
+        int index = indexMapping[pos];
+        if (index >= 0) {
+            return mutableRow.getDecimal(index, precision, scale);
+        } else {
+            return fixedRow.getDecimal(-(index + 1), precision, scale);
+        }
+    }
+
+    @Override
+    public TimestampData getTimestamp(int pos, int precision) {
+        int index = indexMapping[pos];
+        if (index >= 0) {
+            return mutableRow.getTimestamp(index, precision);
+        } else {
+            return fixedRow.getTimestamp(-(index + 1), precision);
+        }
+    }
+
+    @Override
+    public <T> RawValueData<T> getRawValue(int pos) {
+        int index = indexMapping[pos];
+        if (index >= 0) {
+            return mutableRow.getRawValue(index);
+        } else {
+            return fixedRow.getRawValue(-(index + 1));
+        }
+    }
+
+    @Override
+    public byte[] getBinary(int pos) {
+        int index = indexMapping[pos];
+        if (index >= 0) {
+            return mutableRow.getBinary(index);
+        } else {
+            return fixedRow.getBinary(-(index + 1));
+        }
+    }
+
+    @Override
+    public ArrayData getArray(int pos) {
+        int index = indexMapping[pos];
+        if (index >= 0) {
+            return mutableRow.getArray(index);
+        } else {
+            return fixedRow.getArray(-(index + 1));
+        }
+    }
+
+    @Override
+    public MapData getMap(int pos) {
+        int index = indexMapping[pos];
+        if (index >= 0) {
+            return mutableRow.getMap(index);
+        } else {
+            return fixedRow.getMap(-(index + 1));
+        }
+    }
+
+    @Override
+    public RowData getRow(int pos, int numFields) {
+        int index = indexMapping[pos];
+        if (index >= 0) {
+            return mutableRow.getRow(index, numFields);
+        } else {
+            return fixedRow.getRow(-(index + 1), numFields);
+        }
+    }
+
+    @Override
+    public boolean equals(Object o) {
+        if (this == o) {
+            return true;
+        }
+        if (o == null || getClass() != o.getClass()) {
+            return false;
+        }
+        ExtendedRowData that = (ExtendedRowData) o;
+        return Objects.equals(this.fixedRow, that.fixedRow)
+                && Objects.equals(this.mutableRow, that.mutableRow);
+    }
+
+    @Override
+    public int hashCode() {
+        return Objects.hash(fixedRow, mutableRow);
+    }
+
+    @Override
+    public String toString() {
+        return mutableRow.getRowKind().shortString()
+                + "{"
+                + "fixedRow="
+                + fixedRow
+                + ", mutableRow="
+                + mutableRow
+                + '}';
+    }
+
+    /**
+     * Creates a new {@link ExtendedRowData} with the provided {@code fixedRow} as the immutable
+     * static row, and uses the {@code completeRowFields}, {@code fixedRowFields} and {@code
+     * mutableRowFields} arguments to compute the indexes mapping.
+     */
+    public static ExtendedRowData from(
+            RowData fixedRow,
+            List<String> completeRowFields,
+            List<String> mutableRowFields,
+            List<String> fixedRowFields) {
+        return new ExtendedRowData(
+                fixedRow, computeIndexMapping(completeRowFields, mutableRowFields, fixedRowFields));
+    }
+
+    /** This method computes the index mapping for {@link ExtendedRowData}. */
+    public static int[] computeIndexMapping(
+            List<String> completeRowFields,
+            List<String> mutableRowFields,
+            List<String> fixedRowFields) {
+        int[] indexMapping = new int[completeRowFields.size()];
+
+        for (int i = 0; i < completeRowFields.size(); i++) {
+            String fieldName = completeRowFields.get(i);
+
+            int newIndex = mutableRowFields.indexOf(fieldName);
+            if (newIndex < 0) {
+                newIndex = -(fixedRowFields.indexOf(fieldName) + 1);
+            }
+
+            indexMapping[i] = newIndex;
+        }
+
+        return indexMapping;
+    }
+}

--- a/flink-table/flink-table-common/src/test/java/org/apache/flink/table/data/utils/EnrichedRowDataTest.java
+++ b/flink-table/flink-table-common/src/test/java/org/apache/flink/table/data/utils/EnrichedRowDataTest.java
@@ -30,11 +30,11 @@ import java.util.List;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 
 /** Tests for {@link JoinedRowData}. */
-public class ExtendedRowDataTest {
+public class EnrichedRowDataTest {
 
     @Test
     public void testJoinedRows() {
-        List<String> completeRowFields =
+        final List<String> completeRowFields =
                 Arrays.asList(
                         "fixedRow1",
                         "mutableRow1",
@@ -42,34 +42,34 @@ public class ExtendedRowDataTest {
                         "mutableRow2",
                         "fixedRow2",
                         "mutableRow4");
-        List<String> mutableRowFields =
+        final List<String> mutableRowFields =
                 Arrays.asList("mutableRow1", "mutableRow2", "mutableRow3", "mutableRow4");
-        List<String> fixedRowFields = Arrays.asList("fixedRow1", "fixedRow2");
+        final List<String> fixedRowFields = Arrays.asList("fixedRow1", "fixedRow2");
 
         final RowData fixedRowData = GenericRowData.of(1L, 2L);
-        final ExtendedRowData extendedRowData =
-                ExtendedRowData.from(
+        final EnrichedRowData enrichedRowData =
+                EnrichedRowData.from(
                         fixedRowData, completeRowFields, mutableRowFields, fixedRowFields);
         final RowData mutableRowData = GenericRowData.of(3L, 4L, 5L, 6L);
-        extendedRowData.replaceMutableRow(mutableRowData);
+        enrichedRowData.replaceMutableRow(mutableRowData);
 
-        assertEquals(RowKind.INSERT, extendedRowData.getRowKind());
-        assertEquals(6, extendedRowData.getArity());
-        assertEquals(1L, extendedRowData.getLong(0));
-        assertEquals(3L, extendedRowData.getLong(1));
-        assertEquals(5L, extendedRowData.getLong(2));
-        assertEquals(4L, extendedRowData.getLong(3));
-        assertEquals(2L, extendedRowData.getLong(4));
-        assertEquals(6L, extendedRowData.getLong(5));
+        assertEquals(RowKind.INSERT, enrichedRowData.getRowKind());
+        assertEquals(6, enrichedRowData.getArity());
+        assertEquals(1L, enrichedRowData.getLong(0));
+        assertEquals(3L, enrichedRowData.getLong(1));
+        assertEquals(5L, enrichedRowData.getLong(2));
+        assertEquals(4L, enrichedRowData.getLong(3));
+        assertEquals(2L, enrichedRowData.getLong(4));
+        assertEquals(6L, enrichedRowData.getLong(5));
 
         final RowData newMutableRowData = GenericRowData.of(7L, 8L, 9L, 10L);
-        extendedRowData.replaceMutableRow(newMutableRowData);
+        enrichedRowData.replaceMutableRow(newMutableRowData);
 
-        assertEquals(1L, extendedRowData.getLong(0));
-        assertEquals(7L, extendedRowData.getLong(1));
-        assertEquals(9L, extendedRowData.getLong(2));
-        assertEquals(8L, extendedRowData.getLong(3));
-        assertEquals(2L, extendedRowData.getLong(4));
-        assertEquals(10L, extendedRowData.getLong(5));
+        assertEquals(1L, enrichedRowData.getLong(0));
+        assertEquals(7L, enrichedRowData.getLong(1));
+        assertEquals(9L, enrichedRowData.getLong(2));
+        assertEquals(8L, enrichedRowData.getLong(3));
+        assertEquals(2L, enrichedRowData.getLong(4));
+        assertEquals(10L, enrichedRowData.getLong(5));
     }
 }

--- a/flink-table/flink-table-common/src/test/java/org/apache/flink/table/data/utils/ExtendedRowDataTest.java
+++ b/flink-table/flink-table-common/src/test/java/org/apache/flink/table/data/utils/ExtendedRowDataTest.java
@@ -1,0 +1,75 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.flink.table.data.utils;
+
+import org.apache.flink.table.data.GenericRowData;
+import org.apache.flink.table.data.RowData;
+import org.apache.flink.types.RowKind;
+
+import org.junit.jupiter.api.Test;
+
+import java.util.Arrays;
+import java.util.List;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+
+/** Tests for {@link JoinedRowData}. */
+public class ExtendedRowDataTest {
+
+    @Test
+    public void testJoinedRows() {
+        List<String> completeRowFields =
+                Arrays.asList(
+                        "fixedRow1",
+                        "mutableRow1",
+                        "mutableRow3",
+                        "mutableRow2",
+                        "fixedRow2",
+                        "mutableRow4");
+        List<String> mutableRowFields =
+                Arrays.asList("mutableRow1", "mutableRow2", "mutableRow3", "mutableRow4");
+        List<String> fixedRowFields = Arrays.asList("fixedRow1", "fixedRow2");
+
+        final RowData fixedRowData = GenericRowData.of(1L, 2L);
+        final ExtendedRowData extendedRowData =
+                ExtendedRowData.from(
+                        fixedRowData, completeRowFields, mutableRowFields, fixedRowFields);
+        final RowData mutableRowData = GenericRowData.of(3L, 4L, 5L, 6L);
+        extendedRowData.replaceMutableRow(mutableRowData);
+
+        assertEquals(RowKind.INSERT, extendedRowData.getRowKind());
+        assertEquals(6, extendedRowData.getArity());
+        assertEquals(1L, extendedRowData.getLong(0));
+        assertEquals(3L, extendedRowData.getLong(1));
+        assertEquals(5L, extendedRowData.getLong(2));
+        assertEquals(4L, extendedRowData.getLong(3));
+        assertEquals(2L, extendedRowData.getLong(4));
+        assertEquals(6L, extendedRowData.getLong(5));
+
+        final RowData newMutableRowData = GenericRowData.of(7L, 8L, 9L, 10L);
+        extendedRowData.replaceMutableRow(newMutableRowData);
+
+        assertEquals(1L, extendedRowData.getLong(0));
+        assertEquals(7L, extendedRowData.getLong(1));
+        assertEquals(9L, extendedRowData.getLong(2));
+        assertEquals(8L, extendedRowData.getLong(3));
+        assertEquals(2L, extendedRowData.getLong(4));
+        assertEquals(10L, extendedRowData.getLong(5));
+    }
+}

--- a/flink-table/flink-table-planner/src/test/java/org/apache/flink/table/filesystem/FileSystemTableSourceTest.java
+++ b/flink-table/flink-table-planner/src/test/java/org/apache/flink/table/filesystem/FileSystemTableSourceTest.java
@@ -47,6 +47,18 @@ public class FileSystemTableSourceTest extends TableTestBase {
                         + " 'path' = '/tmp')";
         tEnv.executeSql(srcTableDdl);
 
+        String srcTableWithMetaDdl =
+                "CREATE TABLE MyTableWithMeta (\n"
+                        + "  a bigint,\n"
+                        + "  b int,\n"
+                        + "  c varchar,\n"
+                        + "  filemeta STRING METADATA FROM 'filename'\n"
+                        + ") with (\n"
+                        + " 'connector' = 'filesystem',"
+                        + " 'format' = 'testcsv',"
+                        + " 'path' = '/tmp')";
+        tEnv.executeSql(srcTableWithMetaDdl);
+
         String sinkTableDdl =
                 "CREATE TABLE MySink (\n"
                         + "  a bigint,\n"
@@ -61,5 +73,11 @@ public class FileSystemTableSourceTest extends TableTestBase {
     @Test
     public void testFilterPushDown() {
         util.verifyRelPlanInsert("insert into MySink select * from MyTable where a > 10");
+    }
+
+    @Test
+    public void testMetadataReading() {
+        util.verifyRelPlanInsert(
+                "insert into MySink(a, b, c) select a, b, filemeta from MyTableWithMeta");
     }
 }

--- a/flink-table/flink-table-planner/src/test/java/org/apache/flink/table/filesystem/FileSystemTableSourceTest.java
+++ b/flink-table/flink-table-planner/src/test/java/org/apache/flink/table/filesystem/FileSystemTableSourceTest.java
@@ -52,7 +52,7 @@ public class FileSystemTableSourceTest extends TableTestBase {
                         + "  a bigint,\n"
                         + "  b int,\n"
                         + "  c varchar,\n"
-                        + "  filemeta STRING METADATA FROM 'filename'\n"
+                        + "  filemeta STRING METADATA FROM 'filepath'\n"
                         + ") with (\n"
                         + " 'connector' = 'filesystem',"
                         + " 'format' = 'testcsv',"

--- a/flink-table/flink-table-planner/src/test/resources/org/apache/flink/table/filesystem/FileSystemTableSourceTest.xml
+++ b/flink-table/flink-table-planner/src/test/resources/org/apache/flink/table/filesystem/FileSystemTableSourceTest.xml
@@ -50,8 +50,8 @@ LogicalSink(table=[default_catalog.default_database.MySink], fields=[a, b, filem
     <Resource name="optimized rel plan">
       <![CDATA[
 Sink(table=[default_catalog.default_database.MySink], fields=[a, b, filemeta])
-+- Calc(select=[a, b, CAST(filename) AS filemeta])
-   +- TableSourceScan(table=[[default_catalog, default_database, MyTableWithMeta, project=[a, b, filename], metadata=[filename]]], fields=[a, b, filename])
++- Calc(select=[a, b, CAST(filepath) AS filemeta])
+   +- TableSourceScan(table=[[default_catalog, default_database, MyTableWithMeta, project=[a, b, filepath], metadata=[filepath]]], fields=[a, b, filepath])
 ]]>
     </Resource>
   </TestCase>

--- a/flink-table/flink-table-planner/src/test/resources/org/apache/flink/table/filesystem/FileSystemTableSourceTest.xml
+++ b/flink-table/flink-table-planner/src/test/resources/org/apache/flink/table/filesystem/FileSystemTableSourceTest.xml
@@ -51,7 +51,7 @@ LogicalSink(table=[default_catalog.default_database.MySink], fields=[a, b, filem
       <![CDATA[
 Sink(table=[default_catalog.default_database.MySink], fields=[a, b, filemeta])
 +- Calc(select=[a, b, CAST(filepath) AS filemeta])
-   +- TableSourceScan(table=[[default_catalog, default_database, MyTableWithMeta, project=[a, b, filepath], metadata=[filepath]]], fields=[a, b, filepath])
+   +- TableSourceScan(table=[[default_catalog, default_database, MyTableWithMeta, project=[a, b], metadata=[filepath]]], fields=[a, b, filepath])
 ]]>
     </Resource>
   </TestCase>

--- a/flink-table/flink-table-planner/src/test/resources/org/apache/flink/table/filesystem/FileSystemTableSourceTest.xml
+++ b/flink-table/flink-table-planner/src/test/resources/org/apache/flink/table/filesystem/FileSystemTableSourceTest.xml
@@ -36,4 +36,23 @@ Sink(table=[default_catalog.default_database.MySink], fields=[a, b, c])
 ]]>
     </Resource>
   </TestCase>
+  <TestCase name="testMetadataReading">
+    <Resource name="sql">
+      <![CDATA[insert into MySink(a, b, c) select a, b, filemeta from MyTableWithMeta]]>
+    </Resource>
+    <Resource name="ast">
+      <![CDATA[
+LogicalSink(table=[default_catalog.default_database.MySink], fields=[a, b, filemeta])
++- LogicalProject(a=[$0], b=[$1], filemeta=[CAST($3):VARCHAR(2147483647) CHARACTER SET "UTF-16LE"])
+   +- LogicalTableScan(table=[[default_catalog, default_database, MyTableWithMeta]])
+]]>
+    </Resource>
+    <Resource name="optimized rel plan">
+      <![CDATA[
+Sink(table=[default_catalog.default_database.MySink], fields=[a, b, filemeta])
++- Calc(select=[a, b, CAST(filename) AS filemeta])
+   +- TableSourceScan(table=[[default_catalog, default_database, MyTableWithMeta, project=[a, b, filename], metadata=[filename]]], fields=[a, b, filename])
+]]>
+    </Resource>
+  </TestCase>
 </Root>

--- a/flink-table/flink-table-planner/src/test/scala/org/apache/flink/table/planner/runtime/FileSystemITCaseBase.scala
+++ b/flink-table/flink-table-planner/src/test/scala/org/apache/flink/table/planner/runtime/FileSystemITCaseBase.scala
@@ -27,13 +27,11 @@ import org.apache.flink.table.planner.runtime.FileSystemITCaseBase._
 import org.apache.flink.table.planner.runtime.utils.BatchTableEnvUtil
 import org.apache.flink.table.planner.runtime.utils.BatchTestBase.row
 import org.apache.flink.types.Row
-
-import org.junit.Assert.assertTrue
+import org.junit.Assert.{assertEquals, assertNotNull, assertTrue}
 import org.junit.rules.TemporaryFolder
 import org.junit.{Rule, Test}
 
 import java.io.File
-
 import scala.collection.{JavaConverters, Seq}
 
 /**
@@ -51,12 +49,16 @@ trait FileSystemITCaseBase {
 
   def tableEnv: TableEnvironment
 
+  def checkPredicate(sqlQuery: String, checkFunc: Row => Unit): Unit
+
   def check(sqlQuery: String, expectedResult: Seq[Row]): Unit
 
   def check(sqlQuery: String, expectedResult: java.util.List[Row]): Unit = {
     check(sqlQuery,
       JavaConverters.asScalaIteratorConverter(expectedResult.iterator()).asScala.toSeq)
   }
+
+  def supportsReadingMetadata: Boolean = true
 
   def open(): Unit = {
     resultPath = fileTmpFolder.newFolder().toURI.toString
@@ -81,6 +83,24 @@ trait FileSystemITCaseBase {
          |)
        """.stripMargin
     )
+    if (supportsReadingMetadata) {
+      tableEnv.executeSql(
+        s"""
+           |create table partitionedTableWithMetadata (
+           |  x string,
+           |  y int,
+           |  a int,
+           |  b bigint,
+           |  c as b + 1,
+           |  f string metadata from 'filename'
+           |) partitioned by (a, b) with (
+           |  'connector' = 'filesystem',
+           |  'path' = '$resultPath',
+           |  ${formatProperties().mkString(",\n")}
+           |)
+           """.stripMargin
+      )
+    }
     tableEnv.executeSql(
       s"""
          |create table nonPartitionedTable (
@@ -95,6 +115,23 @@ trait FileSystemITCaseBase {
          |)
        """.stripMargin
     )
+    if (supportsReadingMetadata) {
+      tableEnv.executeSql(
+        s"""
+           |create table nonPartitionedTableWithMetadata (
+           |  x string,
+           |  y int,
+           |  a int,
+           |  f string metadata from 'filename',
+           |  b bigint
+           |) with (
+           |  'connector' = 'filesystem',
+           |  'path' = '$resultPath',
+           |  ${formatProperties().mkString(",\n")}
+           |)
+         """.stripMargin
+      )
+    }
 
     tableEnv.executeSql(
       s"""
@@ -180,6 +217,40 @@ trait FileSystemITCaseBase {
     check(
       "select x, y from partitionedTable",
       data_partition_2_1
+    )
+  }
+
+  @Test
+  def testAllStaticPartitionsWithMetadata(): Unit = {
+    if (!supportsReadingMetadata) {
+      return
+    }
+
+    tableEnv.executeSql("insert into partitionedTable " +
+      "partition(a='1', b='1') select x, y from originalT where a=1 and b=1").await()
+
+    checkPredicate(
+      "select x, f, y from partitionedTableWithMetadata where a=1 and b=1",
+      row => {
+        assertEquals(3, row.getArity)
+        assertNotNull(row.getField("f"))
+        assertNotNull(row.getField(1))
+        assertTrue(
+          "The filename value should begin with the temporary test path",
+          row.getFieldAs[String](1).contains(fileTmpFolder.getRoot.getPath))
+      }
+    )
+
+    checkPredicate(
+      "select x, f, y from partitionedTableWithMetadata",
+      row => {
+        assertEquals(3, row.getArity)
+        assertNotNull(row.getField("f"))
+        assertNotNull(row.getField(1))
+        assertTrue(
+          "The filename value should begin with the temporary test path",
+          row.getFieldAs[String](1).contains(fileTmpFolder.getRoot.getPath))
+      }
     )
   }
 
@@ -272,6 +343,28 @@ trait FileSystemITCaseBase {
     check(
       "select x, y from nonPartitionedTable where a=1 and b=1",
       data_partition_1_1
+    )
+  }
+
+  @Test
+  def testNonPartitionWithMetadata(): Unit = {
+    if (!supportsReadingMetadata) {
+      return
+    }
+
+    tableEnv.executeSql("insert into nonPartitionedTable " +
+      "select x, y, a, b from originalT where a=1 and b=1").await()
+
+    checkPredicate(
+      "select x, f, y from nonPartitionedTableWithMetadata where a=1 and b=1",
+      row => {
+        assertEquals(3, row.getArity)
+        assertNotNull(row.getField("f"))
+        assertNotNull(row.getField(1))
+        assertTrue(
+          "The filename value should begin with the temporary test path",
+          row.getFieldAs[String](1).contains(fileTmpFolder.getRoot.getPath))
+      }
     )
   }
 

--- a/flink-table/flink-table-planner/src/test/scala/org/apache/flink/table/planner/runtime/FileSystemITCaseBase.scala
+++ b/flink-table/flink-table-planner/src/test/scala/org/apache/flink/table/planner/runtime/FileSystemITCaseBase.scala
@@ -92,7 +92,7 @@ trait FileSystemITCaseBase {
            |  a int,
            |  b bigint,
            |  c as b + 1,
-           |  f string metadata from 'filename'
+           |  f string metadata from 'filepath'
            |) partitioned by (a, b) with (
            |  'connector' = 'filesystem',
            |  'path' = '$resultPath',
@@ -122,7 +122,7 @@ trait FileSystemITCaseBase {
            |  x string,
            |  y int,
            |  a int,
-           |  f string metadata from 'filename',
+           |  f string metadata from 'filepath',
            |  b bigint
            |) with (
            |  'connector' = 'filesystem',
@@ -236,7 +236,7 @@ trait FileSystemITCaseBase {
         assertNotNull(row.getField("f"))
         assertNotNull(row.getField(1))
         assertTrue(
-          "The filename value should begin with the temporary test path",
+          "The filepath value should begin with the temporary test path",
           row.getFieldAs[String](1).contains(fileTmpFolder.getRoot.getPath))
       }
     )
@@ -248,7 +248,7 @@ trait FileSystemITCaseBase {
         assertNotNull(row.getField("f"))
         assertNotNull(row.getField(1))
         assertTrue(
-          "The filename value should begin with the temporary test path",
+          "The filepath value should begin with the temporary test path",
           row.getFieldAs[String](1).contains(fileTmpFolder.getRoot.getPath))
       }
     )
@@ -362,7 +362,7 @@ trait FileSystemITCaseBase {
         assertNotNull(row.getField("f"))
         assertNotNull(row.getField(1))
         assertTrue(
-          "The filename value should begin with the temporary test path",
+          "The filepath value should begin with the temporary test path",
           row.getFieldAs[String](1).contains(fileTmpFolder.getRoot.getPath))
       }
     )

--- a/flink-table/flink-table-planner/src/test/scala/org/apache/flink/table/planner/runtime/batch/sql/BatchFileSystemITCaseBase.scala
+++ b/flink-table/flink-table-planner/src/test/scala/org/apache/flink/table/planner/runtime/batch/sql/BatchFileSystemITCaseBase.scala
@@ -22,9 +22,9 @@ import org.apache.flink.table.api.TableEnvironment
 import org.apache.flink.table.planner.runtime.FileSystemITCaseBase
 import org.apache.flink.table.planner.runtime.utils.BatchTestBase
 import org.apache.flink.types.Row
+import org.junit.{Assert, Before}
 
-import org.junit.Before
-
+import java.lang.AssertionError
 import scala.collection.Seq
 
 /**
@@ -44,5 +44,20 @@ abstract class BatchFileSystemITCaseBase extends BatchTestBase with FileSystemIT
 
   override def check(sqlQuery: String, expectedResult: Seq[Row]): Unit = {
     checkResult(sqlQuery, expectedResult)
+  }
+
+  override def checkPredicate(sqlQuery: String, checkFunc: Row => Unit): Unit = {
+    val table = parseQuery(sqlQuery)
+    val result = executeQuery(table)
+
+    try {
+      result.foreach(checkFunc)
+    } catch {
+      case e: AssertionError => throw new AssertionError(
+        s"""
+           |Results do not match for query:
+           |  $sqlQuery
+     """.stripMargin, e)
+    }
   }
 }

--- a/flink-table/flink-table-planner/src/test/scala/org/apache/flink/table/planner/runtime/stream/sql/StreamFileSystemITCaseBase.scala
+++ b/flink-table/flink-table-planner/src/test/scala/org/apache/flink/table/planner/runtime/stream/sql/StreamFileSystemITCaseBase.scala
@@ -19,16 +19,16 @@
 package org.apache.flink.table.planner.runtime.stream.sql
 
 import org.apache.flink.api.scala._
+import org.apache.flink.streaming.api.functions.sink.SinkFunction
 import org.apache.flink.table.api.TableEnvironment
 import org.apache.flink.table.api.bridge.scala._
 import org.apache.flink.table.planner.runtime.FileSystemITCaseBase
-import org.apache.flink.table.planner.runtime.utils.{StreamingTestBase, TestSinkUtil, TestingAppendSink}
+import org.apache.flink.table.planner.runtime.utils.{AbstractExactlyOnceSink, StreamingTestBase, TestSinkUtil, TestingAppendSink}
 import org.apache.flink.types.Row
-
 import org.junit.Assert.assertEquals
-import org.junit.{Before, Test}
+import org.junit.{Assert, Before, Test}
 
-import scala.collection.Seq
+import scala.collection.{Seq, mutable}
 
 /**
   * Streaming [[FileSystemITCaseBase]].
@@ -54,6 +54,28 @@ abstract class StreamFileSystemITCaseBase extends StreamingTestBase with FileSys
     assertEquals(
       expectedResult.map(TestSinkUtil.rowToString(_)).sorted,
       sink.getAppendResults.sorted)
+  }
+
+  override def checkPredicate(sqlQuery: String, checkFunc: Row => Unit): Unit = {
+    val result = tEnv.sqlQuery(sqlQuery).toAppendStream[Row]
+    val sinkResults = new mutable.MutableList[Row]
+
+    val sink = new AbstractExactlyOnceSink[Row] {
+      override def invoke(value: Row, context: SinkFunction.Context): Unit =
+        sinkResults += value
+    }
+    result.addSink(sink)
+    env.execute()
+
+    try {
+      sinkResults.foreach(checkFunc)
+    } catch {
+      case e: AssertionError => throw new AssertionError(
+        s"""
+           |Results do not match for query:
+           |  $sqlQuery
+       """.stripMargin, e)
+    }
   }
 
   // Streaming mode not support overwrite

--- a/flink-table/flink-table-planner/src/test/scala/org/apache/flink/table/planner/runtime/stream/sql/StreamFileSystemITCaseBase.scala
+++ b/flink-table/flink-table-planner/src/test/scala/org/apache/flink/table/planner/runtime/stream/sql/StreamFileSystemITCaseBase.scala
@@ -57,7 +57,7 @@ abstract class StreamFileSystemITCaseBase extends StreamingTestBase with FileSys
   }
 
   override def checkPredicate(sqlQuery: String, checkFunc: Row => Unit): Unit = {
-    val result = tEnv.sqlQuery(sqlQuery).toAppendStream[Row]
+    val result = tEnv.sqlQuery(sqlQuery).toDataStream
     val sinkResults = new mutable.MutableList[Row]
 
     val sink = new AbstractExactlyOnceSink[Row] {

--- a/flink-table/flink-table-planner/src/test/scala/org/apache/flink/table/planner/runtime/stream/sql/StreamFileSystemTestCsvITCase.scala
+++ b/flink-table/flink-table-planner/src/test/scala/org/apache/flink/table/planner/runtime/stream/sql/StreamFileSystemTestCsvITCase.scala
@@ -18,6 +18,8 @@
 
 package org.apache.flink.table.planner.runtime.stream.sql
 
+import org.apache.flink.types.Row
+
 import scala.collection.Seq
 
 /**

--- a/flink-table/flink-table-runtime/src/main/java/org/apache/flink/table/filesystem/AbstractFileSystemTable.java
+++ b/flink-table/flink-table-runtime/src/main/java/org/apache/flink/table/filesystem/AbstractFileSystemTable.java
@@ -40,7 +40,7 @@ abstract class AbstractFileSystemTable {
     final ObjectIdentifier tableIdentifier;
     final Configuration tableOptions;
     final ResolvedSchema schema;
-    final List<String> partitionKeys;
+    List<String> partitionKeys;
     final Path path;
     final String defaultPartName;
 

--- a/flink-table/flink-table-runtime/src/main/java/org/apache/flink/table/filesystem/AbstractFileSystemTable.java
+++ b/flink-table/flink-table-runtime/src/main/java/org/apache/flink/table/filesystem/AbstractFileSystemTable.java
@@ -40,9 +40,10 @@ abstract class AbstractFileSystemTable {
     final ObjectIdentifier tableIdentifier;
     final Configuration tableOptions;
     final ResolvedSchema schema;
-    List<String> partitionKeys;
     final Path path;
     final String defaultPartName;
+
+    List<String> partitionKeys;
 
     AbstractFileSystemTable(DynamicTableFactory.Context context) {
         this.context = context;
@@ -50,9 +51,10 @@ abstract class AbstractFileSystemTable {
         this.tableOptions = new Configuration();
         context.getCatalogTable().getOptions().forEach(tableOptions::setString);
         this.schema = context.getCatalogTable().getResolvedSchema();
-        this.partitionKeys = context.getCatalogTable().getPartitionKeys();
         this.path = new Path(tableOptions.get(PATH));
         this.defaultPartName = tableOptions.get(PARTITION_DEFAULT_NAME);
+
+        this.partitionKeys = context.getCatalogTable().getPartitionKeys();
     }
 
     ReadableConfig formatOptions(String identifier) {

--- a/flink-table/flink-table-runtime/src/main/java/org/apache/flink/table/filesystem/AbstractFileSystemTable.java
+++ b/flink-table/flink-table-runtime/src/main/java/org/apache/flink/table/filesystem/AbstractFileSystemTable.java
@@ -29,6 +29,7 @@ import org.apache.flink.table.factories.DynamicTableFactory;
 import org.apache.flink.table.types.DataType;
 
 import java.util.List;
+import java.util.stream.Collectors;
 
 import static org.apache.flink.table.filesystem.FileSystemConnectorOptions.PARTITION_DEFAULT_NAME;
 import static org.apache.flink.table.filesystem.FileSystemConnectorOptions.PATH;
@@ -66,9 +67,8 @@ abstract class AbstractFileSystemTable {
     }
 
     DataType getPhysicalDataTypeWithoutPartitionColumns() {
-        return DataTypes.ROW(
-                DataType.getFields(getPhysicalDataType()).stream()
-                        .filter(field -> !partitionKeys.contains(field.getName()))
-                        .toArray(DataTypes.Field[]::new));
+        return DataType.getFields(getPhysicalDataType()).stream()
+                .filter(field -> !partitionKeys.contains(field.getName()))
+                .collect(Collectors.collectingAndThen(Collectors.toList(), DataTypes::ROW));
     }
 }

--- a/flink-table/flink-table-runtime/src/main/java/org/apache/flink/table/filesystem/DeserializationSchemaAdapter.java
+++ b/flink-table/flink-table-runtime/src/main/java/org/apache/flink/table/filesystem/DeserializationSchemaAdapter.java
@@ -28,14 +28,7 @@ import org.apache.flink.connector.file.src.util.ArrayResultIterator;
 import org.apache.flink.core.fs.FileInputSplit;
 import org.apache.flink.core.fs.Path;
 import org.apache.flink.metrics.MetricGroup;
-import org.apache.flink.table.api.DataTypes;
-import org.apache.flink.table.data.GenericRowData;
 import org.apache.flink.table.data.RowData;
-import org.apache.flink.table.runtime.typeutils.InternalTypeInfo;
-import org.apache.flink.table.types.DataType;
-import org.apache.flink.table.types.logical.LogicalType;
-import org.apache.flink.table.types.logical.RowType;
-import org.apache.flink.table.utils.PartitionPathUtils;
 import org.apache.flink.util.Collector;
 import org.apache.flink.util.InstantiationUtil;
 import org.apache.flink.util.UserCodeClassLoader;
@@ -45,10 +38,7 @@ import javax.annotation.Nullable;
 import java.io.IOException;
 import java.util.ArrayDeque;
 import java.util.Arrays;
-import java.util.List;
-import java.util.Map;
 import java.util.Queue;
-import java.util.stream.Collectors;
 
 import static org.apache.flink.connector.file.src.util.CheckpointedPosition.NO_OFFSET;
 import static org.apache.flink.table.data.vector.VectorizedColumnBatch.DEFAULT_SIZE;
@@ -58,71 +48,10 @@ public class DeserializationSchemaAdapter implements BulkFormat<RowData, FileSou
 
     private static final int BATCH_SIZE = 100;
 
-    // NOTE, deserializationSchema produce full format fields with original order
     private final DeserializationSchema<RowData> deserializationSchema;
 
-    private final String[] fieldNames;
-    private final DataType[] fieldTypes;
-    private final int[] projectFields;
-    private final RowType projectedRowType;
-
-    private final List<String> partitionKeys;
-    private final String defaultPartValue;
-
-    private final int[] toProjectedField;
-    private final RowData.FieldGetter[] formatFieldGetters;
-
-    public DeserializationSchemaAdapter(
-            DeserializationSchema<RowData> deserializationSchema,
-            DataType physicalDataType,
-            int[] projectFields,
-            List<String> partitionKeys,
-            String defaultPartValue) {
+    public DeserializationSchemaAdapter(DeserializationSchema<RowData> deserializationSchema) {
         this.deserializationSchema = deserializationSchema;
-        this.fieldNames = DataType.getFieldNames(physicalDataType).toArray(new String[0]);
-        this.fieldTypes = DataType.getFieldDataTypes(physicalDataType).toArray(new DataType[0]);
-        this.projectFields = projectFields;
-        this.partitionKeys = partitionKeys;
-        this.defaultPartValue = defaultPartValue;
-
-        List<String> projectedNames =
-                Arrays.stream(projectFields)
-                        .mapToObj(idx -> this.fieldNames[idx])
-                        .collect(Collectors.toList());
-
-        this.projectedRowType =
-                RowType.of(
-                        Arrays.stream(projectFields)
-                                .mapToObj(idx -> this.fieldTypes[idx].getLogicalType())
-                                .toArray(LogicalType[]::new),
-                        projectedNames.toArray(new String[0]));
-
-        List<String> formatFields =
-                Arrays.stream(this.fieldNames)
-                        .filter(field -> !partitionKeys.contains(field))
-                        .collect(Collectors.toList());
-
-        List<String> formatProjectedFields =
-                projectedNames.stream()
-                        .filter(field -> !partitionKeys.contains(field))
-                        .collect(Collectors.toList());
-
-        this.toProjectedField =
-                formatProjectedFields.stream().mapToInt(projectedNames::indexOf).toArray();
-
-        this.formatFieldGetters = new RowData.FieldGetter[formatProjectedFields.size()];
-        final Map<String, DataType> fieldDataTypesMap =
-                DataType.getFields(physicalDataType).stream()
-                        .collect(
-                                Collectors.toMap(
-                                        DataTypes.Field::getName, DataTypes.Field::getDataType));
-        for (int i = 0; i < formatProjectedFields.size(); i++) {
-            String name = formatProjectedFields.get(i);
-            this.formatFieldGetters[i] =
-                    RowData.createFieldGetter(
-                            fieldDataTypesMap.get(name).getLogicalType(),
-                            formatFields.indexOf(name));
-        }
     }
 
     private DeserializationSchema<RowData> createDeserialization() throws IOException {
@@ -168,7 +97,7 @@ public class DeserializationSchemaAdapter implements BulkFormat<RowData, FileSou
 
     @Override
     public TypeInformation<RowData> getProducedType() {
-        return InternalTypeInfo.of(projectedRowType);
+        return deserializationSchema.getProducedType();
     }
 
     private class Reader implements BulkFormat.Reader<RowData> {
@@ -233,7 +162,6 @@ public class DeserializationSchemaAdapter implements BulkFormat<RowData, FileSou
 
         private transient boolean end;
         private transient RecordCollector collector;
-        private transient GenericRowData rowData;
 
         public LineBytesInputFormat(Path path, Configuration config) throws IOException {
             super(path, config);
@@ -245,22 +173,6 @@ public class DeserializationSchemaAdapter implements BulkFormat<RowData, FileSou
             super.open(split);
             this.end = false;
             this.collector = new RecordCollector();
-            this.rowData =
-                    PartitionPathUtils.fillPartitionValueForRecord(
-                            fieldNames,
-                            fieldTypes,
-                            projectFields,
-                            partitionKeys,
-                            currentSplit.getPath(),
-                            defaultPartValue);
-        }
-
-        private GenericRowData newOutputRow() {
-            GenericRowData row = new GenericRowData(rowData.getArity());
-            for (int i = 0; i < row.getArity(); i++) {
-                row.setField(i, rowData.getField(i));
-            }
-            return row;
         }
 
         @Override
@@ -284,24 +196,12 @@ public class DeserializationSchemaAdapter implements BulkFormat<RowData, FileSou
             return null;
         }
 
-        private RowData convert(RowData record) {
-            GenericRowData outputRow = newOutputRow();
-
-            for (int i = 0; i < toProjectedField.length; i++) {
-                outputRow.setField(
-                        toProjectedField[i], formatFieldGetters[i].getFieldOrNull(record));
-            }
-
-            outputRow.setRowKind(record.getRowKind());
-            return outputRow;
-        }
-
         @Override
         public RowData nextRecord(RowData reuse) throws IOException {
             while (true) {
                 RowData record = collector.records.poll();
                 if (record != null) {
-                    return convert(record);
+                    return record;
                 }
 
                 if (readLine()) {

--- a/flink-table/flink-table-runtime/src/main/java/org/apache/flink/table/filesystem/FileInfoExtractorBulkFormat.java
+++ b/flink-table/flink-table-runtime/src/main/java/org/apache/flink/table/filesystem/FileInfoExtractorBulkFormat.java
@@ -1,0 +1,142 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.flink.table.filesystem;
+
+import org.apache.flink.api.common.typeinfo.TypeInformation;
+import org.apache.flink.configuration.Configuration;
+import org.apache.flink.connector.file.src.FileSourceSplit;
+import org.apache.flink.connector.file.src.reader.BulkFormat;
+import org.apache.flink.connector.file.src.util.RecordMapperWrapperRecordIterator;
+import org.apache.flink.table.data.GenericRowData;
+import org.apache.flink.table.data.RowData;
+import org.apache.flink.table.data.utils.ExtendedRowData;
+import org.apache.flink.table.runtime.typeutils.InternalTypeInfo;
+import org.apache.flink.table.types.DataType;
+
+import javax.annotation.Nullable;
+
+import java.io.IOException;
+import java.util.ArrayList;
+import java.util.List;
+import java.util.Map;
+import java.util.stream.Collectors;
+
+/**
+ * This {@link BulkFormat} is a wrapper that attaches file information columns to the output
+ * records.
+ */
+class FileInfoExtractorBulkFormat implements BulkFormat<RowData, FileSourceSplit> {
+
+    private final BulkFormat<RowData, FileSourceSplit> wrapped;
+    private final TypeInformation<RowData> producedType;
+
+    private final List<FileSystemTableSource.FileInfoAccessor> metadataColumnsFunctions;
+    private final int[] extendedRowIndexMapping;
+
+    public FileInfoExtractorBulkFormat(
+            BulkFormat<RowData, FileSourceSplit> wrapped,
+            DataType fullDataType,
+            Map<String, FileSystemTableSource.FileInfoAccessor> metadataColumns) {
+        this.wrapped = wrapped;
+        this.producedType = InternalTypeInfo.of(fullDataType.getLogicalType());
+
+        // Compute index mapping for the extended row and the functions to compute metadata
+        List<String> completeRowFields = DataType.getFieldNames(fullDataType);
+        List<String> mutableRowFields =
+                completeRowFields.stream()
+                        .filter(key -> !metadataColumns.containsKey(key))
+                        .collect(Collectors.toList());
+        List<String> fixedRowFields = new ArrayList<>(metadataColumns.keySet());
+        this.extendedRowIndexMapping =
+                ExtendedRowData.computeIndexMapping(
+                        completeRowFields, mutableRowFields, fixedRowFields);
+        this.metadataColumnsFunctions =
+                fixedRowFields.stream().map(metadataColumns::get).collect(Collectors.toList());
+    }
+
+    @Override
+    public Reader<RowData> createReader(Configuration config, FileSourceSplit split)
+            throws IOException {
+        return wrapReader(wrapped.createReader(config, split), split);
+    }
+
+    @Override
+    public Reader<RowData> restoreReader(Configuration config, FileSourceSplit split)
+            throws IOException {
+        return wrapReader(wrapped.restoreReader(config, split), split);
+    }
+
+    @Override
+    public boolean isSplittable() {
+        return wrapped.isSplittable();
+    }
+
+    @Override
+    public TypeInformation<RowData> getProducedType() {
+        return producedType;
+    }
+
+    private Reader<RowData> wrapReader(Reader<RowData> superReader, FileSourceSplit split) {
+        // Fill the metadata row
+        final GenericRowData metadataRowData = new GenericRowData(metadataColumnsFunctions.size());
+        for (int i = 0; i < metadataColumnsFunctions.size(); i++) {
+            metadataRowData.setField(i, metadataColumnsFunctions.get(i).getValue(split));
+        }
+
+        // This row is going to be reused for every record
+        final ExtendedRowData extendedRowData =
+                new ExtendedRowData(metadataRowData, this.extendedRowIndexMapping);
+
+        return new ReaderWrapper(
+                superReader,
+                physicalRowData -> {
+                    extendedRowData.replaceMutableRow(physicalRowData);
+                    return extendedRowData;
+                });
+    }
+
+    private static final class ReaderWrapper implements Reader<RowData> {
+
+        private final Reader<RowData> wrappedReader;
+        private final RecordMapperWrapperRecordIterator.RecordMapper<RowData, RowData>
+                metadataMapper;
+
+        private ReaderWrapper(
+                Reader<RowData> wrappedReader,
+                RecordMapperWrapperRecordIterator.RecordMapper<RowData, RowData> metadataMapper) {
+            this.wrappedReader = wrappedReader;
+            this.metadataMapper = metadataMapper;
+        }
+
+        @Nullable
+        @Override
+        public RecordIterator<RowData> readBatch() throws IOException {
+            RecordIterator<RowData> iterator = wrappedReader.readBatch();
+            if (iterator == null) {
+                return null;
+            }
+            return new RecordMapperWrapperRecordIterator<>(iterator, this.metadataMapper);
+        }
+
+        @Override
+        public void close() throws IOException {
+            this.wrappedReader.close();
+        }
+    }
+}

--- a/flink-table/flink-table-runtime/src/main/java/org/apache/flink/table/filesystem/FileSystemTableSink.java
+++ b/flink-table/flink-table-runtime/src/main/java/org/apache/flink/table/filesystem/FileSystemTableSink.java
@@ -294,12 +294,12 @@ public class FileSystemTableSink extends AbstractFileSystemTable
             return Optional.empty();
         }
 
-        // Compute fullOutputDataType (including partition fields) and physicalDataType (excluding
+        // Compute producedDataType (including partition fields) and physicalDataType (excluding
         // partition fields)
-        final DataType fullOutputDataType = getPhysicalDataType();
+        final DataType producedDataType = getPhysicalDataType();
         final DataType physicalDataType =
                 DataTypes.ROW(
-                        DataType.getFields(fullOutputDataType).stream()
+                        DataType.getFields(producedDataType).stream()
                                 .filter(field -> !partitionKeys.contains(field.getName()))
                                 .toArray(DataTypes.Field[]::new));
 
@@ -308,7 +308,7 @@ public class FileSystemTableSink extends AbstractFileSystemTable
                     new FileInfoExtractorBulkFormat(
                             bulkReaderFormat.createRuntimeDecoder(
                                     createSourceContext(context), physicalDataType),
-                            fullOutputDataType,
+                            producedDataType,
                             Collections.emptyMap(),
                             partitionKeys,
                             defaultPartName);
@@ -320,7 +320,7 @@ public class FileSystemTableSink extends AbstractFileSystemTable
             final BulkFormat<RowData, FileSourceSplit> format =
                     new FileInfoExtractorBulkFormat(
                             new DeserializationSchemaAdapter(decoder),
-                            fullOutputDataType,
+                            producedDataType,
                             Collections.emptyMap(),
                             partitionKeys,
                             defaultPartName);

--- a/flink-table/flink-table-runtime/src/main/java/org/apache/flink/table/filesystem/FileSystemTableSink.java
+++ b/flink-table/flink-table-runtime/src/main/java/org/apache/flink/table/filesystem/FileSystemTableSink.java
@@ -44,6 +44,7 @@ import org.apache.flink.streaming.api.functions.sink.filesystem.StreamingFileSin
 import org.apache.flink.streaming.api.functions.sink.filesystem.StreamingFileSink.BucketsBuilder;
 import org.apache.flink.streaming.api.functions.sink.filesystem.bucketassigners.SimpleVersionedStringSerializer;
 import org.apache.flink.streaming.api.functions.sink.filesystem.rollingpolicies.CheckpointRollingPolicy;
+import org.apache.flink.table.api.DataTypes;
 import org.apache.flink.table.api.TableException;
 import org.apache.flink.table.api.TableSchema;
 import org.apache.flink.table.api.ValidationException;
@@ -281,12 +282,8 @@ public class FileSystemTableSink extends AbstractFileSystemTable
     }
 
     private Optional<CompactReader.Factory<RowData>> createCompactReaderFactory(Context context) {
-        if (bulkReaderFormat != null) {
-            final BulkFormat<RowData, FileSourceSplit> format =
-                    bulkReaderFormat.createRuntimeDecoder(
-                            createSourceContext(context), getPhysicalDataType());
-            return Optional.of(CompactBulkReader.factory(format));
-        } else if (formatFactory != null) {
+        // TODO FLINK-19845 old format factory, to be removed soon.
+        if (formatFactory != null) {
             final InputFormat<RowData, ?> format =
                     formatFactory.createReader(createReaderContext());
             if (format instanceof FileInputFormat) {
@@ -294,19 +291,37 @@ public class FileSystemTableSink extends AbstractFileSystemTable
                 return Optional.of(
                         FileInputFormatCompactReader.factory((FileInputFormat<RowData>) format));
             }
+            return Optional.empty();
+        }
+
+        // Compute fullOutputDataType (including partition fields) and physicalDataType (excluding
+        // partition fields)
+        final DataType fullOutputDataType = getPhysicalDataType();
+        final DataType physicalDataType =
+                DataTypes.ROW(
+                        DataType.getFields(fullOutputDataType).stream()
+                                .filter(field -> !partitionKeys.contains(field.getName()))
+                                .toArray(DataTypes.Field[]::new));
+
+        if (bulkReaderFormat != null) {
+            final BulkFormat<RowData, FileSourceSplit> format =
+                    new FileInfoExtractorBulkFormat(
+                            bulkReaderFormat.createRuntimeDecoder(
+                                    createSourceContext(context), physicalDataType),
+                            fullOutputDataType,
+                            Collections.emptyMap(),
+                            partitionKeys,
+                            defaultPartName);
+            return Optional.of(CompactBulkReader.factory(format));
         } else if (deserializationFormat != null) {
-            // NOTE, we need pass full format types to deserializationFormat
             final DeserializationSchema<RowData> decoder =
                     deserializationFormat.createRuntimeDecoder(
-                            createSourceContext(context),
-                            getPhysicalDataTypeWithoutPartitionColumns());
-            final int[] projectedFields =
-                    IntStream.range(0, DataType.getFieldCount(getPhysicalDataType())).toArray();
-            DeserializationSchemaAdapter format =
-                    new DeserializationSchemaAdapter(
-                            decoder,
-                            getPhysicalDataType(),
-                            projectedFields,
+                            createSourceContext(context), physicalDataType);
+            final BulkFormat<RowData, FileSourceSplit> format =
+                    new FileInfoExtractorBulkFormat(
+                            new DeserializationSchemaAdapter(decoder),
+                            fullOutputDataType,
+                            Collections.emptyMap(),
                             partitionKeys,
                             defaultPartName);
             return Optional.of(CompactBulkReader.factory(format));

--- a/flink-table/flink-table-runtime/src/main/java/org/apache/flink/table/filesystem/FileSystemTableSink.java
+++ b/flink-table/flink-table-runtime/src/main/java/org/apache/flink/table/filesystem/FileSystemTableSink.java
@@ -298,10 +298,9 @@ public class FileSystemTableSink extends AbstractFileSystemTable
         // partition fields)
         final DataType producedDataType = getPhysicalDataType();
         final DataType physicalDataType =
-                DataTypes.ROW(
-                        DataType.getFields(producedDataType).stream()
-                                .filter(field -> !partitionKeys.contains(field.getName()))
-                                .toArray(DataTypes.Field[]::new));
+                DataType.getFields(producedDataType).stream()
+                        .filter(field -> !partitionKeys.contains(field.getName()))
+                        .collect(Collectors.collectingAndThen(Collectors.toList(), DataTypes::ROW));
 
         if (bulkReaderFormat != null) {
             final BulkFormat<RowData, FileSourceSplit> format =

--- a/flink-table/flink-table-runtime/src/main/java/org/apache/flink/table/filesystem/FileSystemTableSource.java
+++ b/flink-table/flink-table-runtime/src/main/java/org/apache/flink/table/filesystem/FileSystemTableSource.java
@@ -123,7 +123,7 @@ public class FileSystemTableSource extends AbstractFileSystemTable
         // Physical type is computed from the full data type, filtering out partition and
         // metadata columns. This type is going to be used by formats to parse the input.
         List<DataTypes.Field> producedDataTypeFields = DataType.getFields(producedDataType);
-        if (metadataKeys != null) {
+        if (metadataKeys != null && !metadataKeys.isEmpty()) {
             // If metadata keys are present, then by SupportsReadingMetadata contract all the
             // metadata columns will be at the end of the producedDataType, so we can just remove
             // from the list the last metadataKeys.size() fields.
@@ -407,10 +407,8 @@ public class FileSystemTableSource extends AbstractFileSystemTable
 
     @Override
     public void applyReadableMetadata(List<String> metadataKeys, DataType producedDataType) {
-        if (!metadataKeys.isEmpty()) {
-            this.metadataKeys = metadataKeys;
-            this.producedDataType = producedDataType;
-        }
+        this.metadataKeys = metadataKeys;
+        this.producedDataType = producedDataType;
     }
 
     // --------------------------------------------------------------------------------------------
@@ -467,13 +465,13 @@ public class FileSystemTableSource extends AbstractFileSystemTable
         }
 
         public static ReadableFileInfo resolve(String key) {
-            switch (key) {
-                case "filepath":
-                    return ReadableFileInfo.FILEPATH;
-                default:
-                    throw new IllegalArgumentException(
-                            "Cannot resolve the provided ReadableMetadata key");
-            }
+            return Arrays.stream(ReadableFileInfo.values())
+                    .filter(readableFileInfo -> readableFileInfo.getKey().equals(key))
+                    .findFirst()
+                    .orElseThrow(
+                            () ->
+                                    new IllegalArgumentException(
+                                            "Cannot resolve the provided ReadableMetadata key"));
         }
     }
 }

--- a/flink-table/flink-table-runtime/src/main/java/org/apache/flink/table/filesystem/FileSystemTableSource.java
+++ b/flink-table/flink-table-runtime/src/main/java/org/apache/flink/table/filesystem/FileSystemTableSource.java
@@ -83,13 +83,13 @@ public class FileSystemTableSource extends AbstractFileSystemTable
     @Nullable private final DecodingFormat<DeserializationSchema<RowData>> deserializationFormat;
     @Nullable private final FileSystemFormatFactory formatFactory;
 
+    // These mutable fields
     private List<Map<String, String>> remainingPartitions;
     private List<ResolvedExpression> filters;
     private Long limit;
-
-    private DataType producedDataType;
-    private List<String> metadataKeys;
     private int[][] projectFields;
+    private List<String> metadataKeys;
+    private DataType producedDataType;
 
     public FileSystemTableSource(
             DynamicTableFactory.Context context,
@@ -367,13 +367,12 @@ public class FileSystemTableSource extends AbstractFileSystemTable
         FileSystemTableSource source =
                 new FileSystemTableSource(
                         context, bulkReaderFormat, deserializationFormat, formatFactory);
+        source.partitionKeys = partitionKeys;
         source.remainingPartitions = remainingPartitions;
         source.filters = filters;
         source.limit = limit;
-
         source.projectFields = projectFields;
         source.metadataKeys = metadataKeys;
-        source.partitionKeys = partitionKeys;
         source.producedDataType = producedDataType;
         return source;
     }

--- a/flink-table/flink-table-runtime/src/test/java/org/apache/flink/table/filesystem/TestCsvDeserializationSchema.java
+++ b/flink-table/flink-table-runtime/src/test/java/org/apache/flink/table/filesystem/TestCsvDeserializationSchema.java
@@ -43,25 +43,25 @@ import java.util.List;
  */
 public class TestCsvDeserializationSchema implements DeserializationSchema<RowData> {
 
-    @SuppressWarnings("rawtypes")
-    private final DataStructureConverter[] csvRowToRowDataConverters;
+    private final List<DataType> outputFieldTypes;
+    private final int outputFieldCount;
 
     private final TypeInformation<RowData> typeInfo;
-    private final int fieldCount;
-    private final List<DataType> fieldTypes;
+    private final int[] indexMapping;
+
+    @SuppressWarnings("rawtypes")
+    private transient DataStructureConverter[] csvRowToRowDataConverters;
 
     private transient FieldParser<?>[] fieldParsers;
 
-    public TestCsvDeserializationSchema(DataType dataType) {
-        this.fieldTypes = DataType.getFieldDataTypes(dataType);
-        this.fieldCount = fieldTypes.size();
+    public TestCsvDeserializationSchema(DataType outputDataType, List<String> orderedCsvColumns) {
+        this.outputFieldTypes = DataType.getFieldDataTypes(outputDataType);
+        this.outputFieldCount = outputFieldTypes.size();
+        this.typeInfo = InternalTypeInfo.of((RowType) outputDataType.getLogicalType());
 
-        this.csvRowToRowDataConverters =
-                fieldTypes.stream()
-                        .map(DataStructureConverters::getConverter)
-                        .toArray(DataStructureConverter[]::new);
-
-        this.typeInfo = InternalTypeInfo.of((RowType) dataType.getLogicalType());
+        List<String> outputTypeFields = DataType.getFieldNames(outputDataType);
+        this.indexMapping =
+                orderedCsvColumns.stream().mapToInt(outputTypeFields::indexOf).toArray();
 
         initFieldParsers();
     }
@@ -74,14 +74,18 @@ public class TestCsvDeserializationSchema implements DeserializationSchema<RowDa
     @SuppressWarnings("unchecked")
     @Override
     public RowData deserialize(byte[] message) throws IOException {
-        GenericRowData row = new GenericRowData(fieldCount);
+        GenericRowData row = new GenericRowData(outputFieldCount);
         int startIndex = 0;
-        for (int i = 0; i < fieldCount; i++) {
+        for (int csvColumn = 0; csvColumn < indexMapping.length; csvColumn++) {
             startIndex =
-                    this.fieldParsers[i].resetErrorStateAndParse(
+                    fieldParsers[csvColumn].resetErrorStateAndParse(
                             message, startIndex, message.length, new byte[] {','}, null);
-            row.setField(
-                    i, csvRowToRowDataConverters[i].toInternal(fieldParsers[i].getLastResult()));
+            if (indexMapping[csvColumn] != -1) {
+                row.setField(
+                        indexMapping[csvColumn],
+                        csvRowToRowDataConverters[csvColumn].toInternal(
+                                fieldParsers[csvColumn].getLastResult()));
+            }
         }
         return row;
     }
@@ -97,9 +101,19 @@ public class TestCsvDeserializationSchema implements DeserializationSchema<RowDa
     }
 
     private void initFieldParsers() {
-        this.fieldParsers = new FieldParser<?>[fieldCount];
-        for (int i = 0; i < fieldTypes.size(); i++) {
-            DataType fieldType = fieldTypes.get(i);
+        int csvRowLength = indexMapping.length;
+        this.fieldParsers = new FieldParser<?>[csvRowLength];
+        this.csvRowToRowDataConverters = new DataStructureConverter[csvRowLength];
+        for (int csvColumn = 0; csvColumn < csvRowLength; csvColumn++) {
+            if (indexMapping[csvColumn] == -1) {
+                // The output type doesn't include this field, so just assign a string parser to
+                // skip it
+                this.fieldParsers[csvColumn] =
+                        InstantiationUtil.instantiate(
+                                FieldParser.getParserForType(String.class), FieldParser.class);
+                continue;
+            }
+            DataType fieldType = outputFieldTypes.get(indexMapping[csvColumn]);
             Class<? extends FieldParser<?>> parserType =
                     FieldParser.getParserForType(
                             logicalTypeRootToFieldParserClass(
@@ -110,7 +124,9 @@ public class TestCsvDeserializationSchema implements DeserializationSchema<RowDa
 
             FieldParser<?> p = InstantiationUtil.instantiate(parserType, FieldParser.class);
 
-            this.fieldParsers[i] = p;
+            this.fieldParsers[csvColumn] = p;
+            this.csvRowToRowDataConverters[csvColumn] =
+                    DataStructureConverters.getConverter(fieldType);
         }
     }
 

--- a/flink-table/flink-table-runtime/src/test/java/org/apache/flink/table/filesystem/TestCsvDeserializationSchema.java
+++ b/flink-table/flink-table-runtime/src/test/java/org/apache/flink/table/filesystem/TestCsvDeserializationSchema.java
@@ -43,8 +43,8 @@ import java.util.List;
  */
 public class TestCsvDeserializationSchema implements DeserializationSchema<RowData> {
 
-    private final List<DataType> outputFieldTypes;
-    private final int outputFieldCount;
+    private final List<DataType> physicalFieldTypes;
+    private final int physicalFieldCount;
 
     private final TypeInformation<RowData> typeInfo;
     private final int[] indexMapping;
@@ -54,14 +54,14 @@ public class TestCsvDeserializationSchema implements DeserializationSchema<RowDa
 
     private transient FieldParser<?>[] fieldParsers;
 
-    public TestCsvDeserializationSchema(DataType outputDataType, List<String> orderedCsvColumns) {
-        this.outputFieldTypes = DataType.getFieldDataTypes(outputDataType);
-        this.outputFieldCount = outputFieldTypes.size();
-        this.typeInfo = InternalTypeInfo.of((RowType) outputDataType.getLogicalType());
+    public TestCsvDeserializationSchema(DataType physicalDataType, List<String> orderedCsvColumns) {
+        this.physicalFieldTypes = DataType.getFieldDataTypes(physicalDataType);
+        this.physicalFieldCount = physicalFieldTypes.size();
+        this.typeInfo = InternalTypeInfo.of((RowType) physicalDataType.getLogicalType());
 
-        List<String> outputTypeFields = DataType.getFieldNames(outputDataType);
+        List<String> physicalFieldNames = DataType.getFieldNames(physicalDataType);
         this.indexMapping =
-                orderedCsvColumns.stream().mapToInt(outputTypeFields::indexOf).toArray();
+                orderedCsvColumns.stream().mapToInt(physicalFieldNames::indexOf).toArray();
 
         initFieldParsers();
     }
@@ -74,7 +74,7 @@ public class TestCsvDeserializationSchema implements DeserializationSchema<RowDa
     @SuppressWarnings("unchecked")
     @Override
     public RowData deserialize(byte[] message) throws IOException {
-        GenericRowData row = new GenericRowData(outputFieldCount);
+        GenericRowData row = new GenericRowData(physicalFieldCount);
         int startIndex = 0;
         for (int csvColumn = 0; csvColumn < indexMapping.length; csvColumn++) {
             startIndex =
@@ -113,7 +113,7 @@ public class TestCsvDeserializationSchema implements DeserializationSchema<RowDa
                                 FieldParser.getParserForType(String.class), FieldParser.class);
                 continue;
             }
-            DataType fieldType = outputFieldTypes.get(indexMapping[csvColumn]);
+            DataType fieldType = physicalFieldTypes.get(indexMapping[csvColumn]);
             Class<? extends FieldParser<?>> parserType =
                     FieldParser.getParserForType(
                             logicalTypeRootToFieldParserClass(

--- a/flink-table/flink-table-runtime/src/test/java/org/apache/flink/table/filesystem/TestCsvFileSystemFormatFactory.java
+++ b/flink-table/flink-table-runtime/src/test/java/org/apache/flink/table/filesystem/TestCsvFileSystemFormatFactory.java
@@ -43,7 +43,9 @@ import java.io.OutputStream;
 import java.nio.charset.StandardCharsets;
 import java.util.Arrays;
 import java.util.HashSet;
+import java.util.List;
 import java.util.Set;
+import java.util.stream.Collectors;
 
 import static org.apache.flink.api.java.io.CsvOutputFormat.DEFAULT_FIELD_DELIMITER;
 import static org.apache.flink.api.java.io.CsvOutputFormat.DEFAULT_LINE_DELIMITER;
@@ -118,11 +120,24 @@ public class TestCsvFileSystemFormatFactory
     @Override
     public DecodingFormat<DeserializationSchema<RowData>> createDecodingFormat(
             DynamicTableFactory.Context context, ReadableConfig formatOptions) {
+        List<String> originalTypeFields =
+                DataType.getFieldNames(context.getPhysicalRowDataType()).stream()
+                        .filter(
+                                field ->
+                                        !context.getCatalogTable()
+                                                .getPartitionKeys()
+                                                .contains(field))
+                        .collect(Collectors.toList());
         return new DecodingFormat<DeserializationSchema<RowData>>() {
             @Override
             public DeserializationSchema<RowData> createRuntimeDecoder(
                     DynamicTableSource.Context context, DataType physicalDataType) {
-                return new TestCsvDeserializationSchema(physicalDataType);
+                // TestCsvDeserializationSchema has no knowledge of the field names, and the
+                // implicit assumption done by tests is that the csv rows are composed by only the
+                // physical fields (excluding partition fields) in the same order as defined in the
+                // table declaration. This is why TestCsvDeserializationSchema needs
+                // originalTypeFields.
+                return new TestCsvDeserializationSchema(physicalDataType, originalTypeFields);
             }
 
             @Override

--- a/flink-table/flink-table-runtime/src/test/java/org/apache/flink/table/filesystem/TestCsvFileSystemFormatFactory.java
+++ b/flink-table/flink-table-runtime/src/test/java/org/apache/flink/table/filesystem/TestCsvFileSystemFormatFactory.java
@@ -120,7 +120,7 @@ public class TestCsvFileSystemFormatFactory
     @Override
     public DecodingFormat<DeserializationSchema<RowData>> createDecodingFormat(
             DynamicTableFactory.Context context, ReadableConfig formatOptions) {
-        List<String> originalTypeFields =
+        List<String> schemaFields =
                 DataType.getFieldNames(context.getPhysicalRowDataType()).stream()
                         .filter(
                                 field ->
@@ -136,8 +136,8 @@ public class TestCsvFileSystemFormatFactory
                 // implicit assumption done by tests is that the csv rows are composed by only the
                 // physical fields (excluding partition fields) in the same order as defined in the
                 // table declaration. This is why TestCsvDeserializationSchema needs
-                // originalTypeFields.
-                return new TestCsvDeserializationSchema(physicalDataType, originalTypeFields);
+                // schemaFields.
+                return new TestCsvDeserializationSchema(physicalDataType, schemaFields);
             }
 
             @Override


### PR DESCRIPTION
## What is the purpose of the change

This PR adds support for metadata in filesystem connector. Only `filesystem` metadata is supported, but more will be supported in next iterations of the feature (see https://issues.apache.org/jira/browse/FLINK-19903 for more details).

**Note**: the feature is not implemented for formats using `FileSystemFormatFactory`, which is being removed https://issues.apache.org/jira/browse/FLINK-19845

## Brief change log

- Now `FileSystemTableSource` implements `SupportMetadataReading`
- When metadata is used, a bulk format called `FileInfoExtractorBulkFormat` takes care of adding metadata to the input row.
- Add `ExtendedRowData` to support merging 2 rows providing an index mapping.

## Verifying this change

* `ExtendedRowData` is tested with a new unit test
* A new test case in `FileSystemTableSourceTest` checks everything works during the planning
* `FileSystemITCaseBase` now has 2 new test cases to check metadata works both in combination with partition keys or without. These test cases run for every format that supports metadata. 

## Does this pull request potentially affect one of the following parts:

  - Dependencies (does it add or upgrade a dependency): no
  - The public API, i.e., is any changed class annotated with `@Public(Evolving)`: no
  - The serializers: no
  - The runtime per-record code paths (performance sensitive): no
  - Anything that affects deployment or recovery: JobManager (and its components), Checkpointing, Kubernetes/Yarn, ZooKeeper: no
  - The S3 file system connector: no

## Documentation

  - Does this pull request introduce a new feature? yes
  - If yes, how is the feature documented? docs, JavaDocs
