### PR TITLE
[FLINK-15987][tabel-planner-blink]SELECT 1.0e0 / 0.0e0 throws NumberFormatException

### DIFF
--- a/flink-table/flink-table-planner-blink/src/test/scala/org/apache/flink/table/planner/expressions/ScalarFunctionsTest.scala
+++ b/flink-table/flink-table-planner-blink/src/test/scala/org/apache/flink/table/planner/expressions/ScalarFunctionsTest.scala
@@ -2506,6 +2506,14 @@ class ScalarFunctionsTest extends ScalarTypesTestBase {
       "LOG(cast (null AS DOUBLE), cast (null AS DOUBLE))",
       "null"
     )
+
+    // invalid log
+    val infiniteOrNaNException = "Infinite or NaN"
+    // Infinity
+    testExpectedSqlException("LOG(1, 100)", infiniteOrNaNException, classOf[NumberFormatException])
+    // NaN
+    testExpectedSqlException("LOG(-1)", infiniteOrNaNException, classOf[NumberFormatException])
+
   }
 
   @Test

--- a/flink-table/flink-table-planner-blink/src/test/scala/org/apache/flink/table/planner/expressions/SqlExpressionTest.scala
+++ b/flink-table/flink-table-planner-blink/src/test/scala/org/apache/flink/table/planner/expressions/SqlExpressionTest.scala
@@ -124,8 +124,8 @@ class SqlExpressionTest extends ExpressionTestBase {
     testSqlApi("ROUND(-12.345, 2)", "-12.35")
     testSqlApi("PI()", "3.141592653589793")
     testSqlApi("E()", "2.718281828459045")
-    testSqlApi("truncate(42.345)", "42")
-    testSqlApi("truncate(cast(42.345 as decimal(5, 3)), 2)", "42.34")
+    testSqlApi("truncate(42.345)", "42.000")
+    testSqlApi("truncate(cast(42.345 as decimal(5, 3)), 2)", "42.340")
   }
 
   @Test
@@ -144,6 +144,25 @@ class SqlExpressionTest extends ExpressionTestBase {
     // Decimal(2,1) / Decimal(10,0) => Decimal(23,12)
     testSqlApi("2.0/(-3)", "-0.666666666667")
     testSqlApi("-7.9/2", "-3.950000000000")
+
+
+    // invalid division
+    val divisorZeroException = "Division by zero"
+    testExpectedSqlException(
+      "1/cast(0.00 as decimal)", divisorZeroException, classOf[ArithmeticException])
+    testExpectedSqlException(
+      "1/cast(0.00 as double)", divisorZeroException, classOf[ArithmeticException])
+    testExpectedSqlException(
+      "1/cast(0.00 as float)", divisorZeroException, classOf[ArithmeticException])
+    testExpectedSqlException(
+      "1/cast(0 as tinyint)", divisorZeroException, classOf[ArithmeticException])
+    testExpectedSqlException(
+      "1/cast(0 as smallint)", divisorZeroException, classOf[ArithmeticException])
+    testExpectedSqlException(
+      "1/0", divisorZeroException, classOf[ArithmeticException])
+    testExpectedSqlException(
+      "1/cast(0 as bigint)", divisorZeroException, classOf[ArithmeticException])
+
   }
 
   @Test

--- a/flink-table/flink-table-planner-blink/src/test/scala/org/apache/flink/table/planner/expressions/utils/ExpressionTestBase.scala
+++ b/flink-table/flink-table-planner-blink/src/test/scala/org/apache/flink/table/planner/expressions/utils/ExpressionTestBase.scala
@@ -18,14 +18,7 @@
 
 package org.apache.flink.table.planner.expressions.utils
 
-import java.util.Collections
-import org.apache.calcite.plan.hep.{HepPlanner, HepProgramBuilder}
-import org.apache.calcite.rel.RelNode
-import org.apache.calcite.rel.logical.LogicalCalc
-import org.apache.calcite.rel.rules._
-import org.apache.calcite.rex.RexNode
-import org.apache.calcite.sql.`type`.SqlTypeName.VARCHAR
-import org.apache.flink.api.common.{JobID, TaskInfo}
+import org.apache.flink.api.common.TaskInfo
 import org.apache.flink.api.common.functions.util.RuntimeUDFContext
 import org.apache.flink.api.common.functions.{MapFunction, RichFunction, RichMapFunction}
 import org.apache.flink.api.java.typeutils.RowTypeInfo
@@ -49,9 +42,17 @@ import org.apache.flink.table.types.logical.{RowType, VarCharType}
 import org.apache.flink.table.types.utils.TypeConversions
 import org.apache.flink.types.Row
 
+import org.apache.calcite.plan.hep.{HepPlanner, HepProgramBuilder}
+import org.apache.calcite.rel.RelNode
+import org.apache.calcite.rel.logical.LogicalCalc
+import org.apache.calcite.rel.rules._
+import org.apache.calcite.rex.RexNode
+import org.apache.calcite.sql.`type`.SqlTypeName.VARCHAR
 import org.junit.Assert.{assertEquals, assertTrue, fail}
 import org.junit.rules.ExpectedException
 import org.junit.{After, Before, Rule}
+
+import java.util.Collections
 
 import scala.collection.JavaConverters._
 import scala.collection.mutable
@@ -303,6 +304,7 @@ abstract class ExpressionTestBase {
       exceptionClass: Class[_ <: Throwable],
       exprs: mutable.ArrayBuffer[_]): Unit = {
     val builder = new HepProgramBuilder()
+    builder.addRuleInstance(CoreRules.PROJECT_REDUCE_EXPRESSIONS)
     builder.addRuleInstance(CoreRules.PROJECT_TO_CALC)
     val hep = new HepPlanner(builder.build())
     hep.setRoot(relNode)

--- a/flink-table/flink-table-planner-blink/src/test/scala/org/apache/flink/table/planner/expressions/validation/ScalarFunctionsValidationTest.scala
+++ b/flink-table/flink-table-planner-blink/src/test/scala/org/apache/flink/table/planner/expressions/validation/ScalarFunctionsValidationTest.scala
@@ -32,22 +32,6 @@ class ScalarFunctionsValidationTest extends ScalarTypesTestBase {
   // Math functions
   // ----------------------------------------------------------------------------------------------
 
-  @Test
-  def testInvalidLog1(): Unit = {
-    testSqlApi(
-      "LOG(1, 100)",
-      "Infinity"
-    )
-  }
-
-  @Test
-  def testInvalidLog2(): Unit ={
-    testSqlApi(
-      "LOG(-1)",
-      "NaN"
-    )
-  }
-
   @Test(expected = classOf[ValidationException])
   def testInvalidBin1(): Unit = {
     testSqlApi("BIN(f12)", "101010") // float type


### PR DESCRIPTION
## What is the purpose of the change
This pull request mainly helps give users clearer exception messages when the divisor is zero. Before, 1.0e0 / 0.0e0 will be computed to infinity and when converting it to decimal, an exception "Infinite or NaN" is thrown . Now we follow the SQL Standard: throw "Division by zero".

## Brief change log
- add validate function in ExpressionReducer.
- add a rule in ExpressionTestBase to fire the expression reducer.
- change some existing test cases.
- add some test cases to verify this change.

## Verifying this change
- Some test cases have been added to verify this change.

## Does this pull request potentially affect one of the following parts:
- Dependencies (does it add or upgrade a dependency): no
- The public API, i.e., is any changed class annotated with @Public(Evolving): no
- The serializers: no
- The runtime per-record code paths (performance sensitive): no
- Anything that affects deployment or recovery: JobManager (and its components), Checkpointing, Kubernetes/Yarn, ZooKeeper: no
- The S3 file system connector: no
## Documentation
- Does this pull request introduce a new feature? no
- If yes, how is the feature documented?