### PR TITLE
[FLINK-24599][table] Replace static methods with member methods

### DIFF
--- a/flink-connectors/flink-connector-elasticsearch-base/src/main/java/org/apache/flink/streaming/connectors/elasticsearch/table/ElasticsearchValidationUtils.java
+++ b/flink-connectors/flink-connector-elasticsearch-base/src/main/java/org/apache/flink/streaming/connectors/elasticsearch/table/ElasticsearchValidationUtils.java
@@ -31,8 +31,6 @@ import java.util.List;
 import java.util.Set;
 import java.util.stream.Collectors;
 
-import static org.apache.flink.table.types.logical.utils.LogicalTypeChecks.hasRoot;
-
 /** Utility methods for validating Elasticsearch properties. */
 @Internal
 class ElasticsearchValidationUtils {
@@ -70,8 +68,7 @@ class ElasticsearchValidationUtils {
                                                                 schema.getFieldDataType(fieldName)
                                                                         .get()
                                                                         .getLogicalType();
-                                                        if (hasRoot(
-                                                                logicalType,
+                                                        if (logicalType.is(
                                                                 LogicalTypeRoot.DISTINCT_TYPE)) {
                                                             return ((DistinctType) logicalType)
                                                                     .getSourceType()

--- a/flink-connectors/flink-connector-hbase-base/src/main/java/org/apache/flink/connector/hbase/util/HBaseSerde.java
+++ b/flink-connectors/flink-connector-hbase-base/src/main/java/org/apache/flink/connector/hbase/util/HBaseSerde.java
@@ -43,7 +43,6 @@ import java.nio.charset.StandardCharsets;
 import java.util.Arrays;
 
 import static org.apache.flink.table.types.logical.utils.LogicalTypeChecks.getPrecision;
-import static org.apache.flink.table.types.logical.utils.LogicalTypeChecks.hasFamily;
 import static org.apache.flink.util.Preconditions.checkArgument;
 
 /** Utilities for HBase serialization and deserialization. */
@@ -317,7 +316,7 @@ public class HBaseSerde {
             LogicalType fieldType, final byte[] nullStringBytes) {
         final FieldEncoder encoder = createFieldEncoder(fieldType);
         if (fieldType.isNullable()) {
-            if (hasFamily(fieldType, LogicalTypeFamily.CHARACTER_STRING)) {
+            if (fieldType.is(LogicalTypeFamily.CHARACTER_STRING)) {
                 // special logic for null string values, because HBase can store empty bytes for
                 // string
                 return (row, pos) -> {
@@ -431,7 +430,7 @@ public class HBaseSerde {
             LogicalType fieldType, final byte[] nullStringBytes) {
         final FieldDecoder decoder = createFieldDecoder(fieldType);
         if (fieldType.isNullable()) {
-            if (hasFamily(fieldType, LogicalTypeFamily.CHARACTER_STRING)) {
+            if (fieldType.is(LogicalTypeFamily.CHARACTER_STRING)) {
                 return value -> {
                     if (value == null || Arrays.equals(value, nullStringBytes)) {
                         return null;

--- a/flink-connectors/flink-connector-hive/src/main/java/org/apache/flink/connectors/hive/util/HivePartitionUtils.java
+++ b/flink-connectors/flink-connector-hive/src/main/java/org/apache/flink/connectors/hive/util/HivePartitionUtils.java
@@ -31,7 +31,6 @@ import org.apache.flink.table.types.DataType;
 import org.apache.flink.table.types.logical.LogicalType;
 import org.apache.flink.table.types.logical.LogicalTypeFamily;
 import org.apache.flink.table.types.logical.LogicalTypeRoot;
-import org.apache.flink.table.types.logical.utils.LogicalTypeChecks;
 
 import org.apache.hadoop.fs.FileStatus;
 import org.apache.hadoop.fs.FileSystem;
@@ -91,7 +90,7 @@ public class HivePartitionUtils {
     public static Object restorePartitionValueFromType(
             HiveShim shim, String valStr, LogicalType partitionType, String defaultPartitionName) {
         if (defaultPartitionName.equals(valStr)) {
-            if (LogicalTypeChecks.hasFamily(partitionType, LogicalTypeFamily.CHARACTER_STRING)) {
+            if (partitionType.is(LogicalTypeFamily.CHARACTER_STRING)) {
                 // this keeps align with Hive,
                 // maybe it should be null for string columns as well
                 return defaultPartitionName;

--- a/flink-connectors/flink-connector-jdbc/src/main/java/org/apache/flink/connector/jdbc/internal/converter/PostgresRowConverter.java
+++ b/flink-connectors/flink-connector-jdbc/src/main/java/org/apache/flink/connector/jdbc/internal/converter/PostgresRowConverter.java
@@ -25,7 +25,6 @@ import org.apache.flink.table.types.logical.LogicalType;
 import org.apache.flink.table.types.logical.LogicalTypeFamily;
 import org.apache.flink.table.types.logical.LogicalTypeRoot;
 import org.apache.flink.table.types.logical.RowType;
-import org.apache.flink.table.types.logical.utils.LogicalTypeChecks;
 import org.apache.flink.table.types.logical.utils.LogicalTypeUtils;
 
 import org.postgresql.jdbc.PgArray;
@@ -80,8 +79,7 @@ public class PostgresRowConverter extends AbstractJdbcRowConverter {
 
     private JdbcDeserializationConverter createPostgresArrayConverter(ArrayType arrayType) {
         // PG's bytea[] is wrapped in PGobject, rather than primitive byte arrays
-        if (LogicalTypeChecks.hasFamily(
-                arrayType.getElementType(), LogicalTypeFamily.BINARY_STRING)) {
+        if (arrayType.getElementType().is(LogicalTypeFamily.BINARY_STRING)) {
             final Class<?> elementClass =
                     LogicalTypeUtils.toInternalConversionClass(arrayType.getElementType());
             final JdbcDeserializationConverter elementConverter =

--- a/flink-connectors/flink-connector-kafka/src/main/java/org/apache/flink/streaming/connectors/kafka/table/KafkaConnectorOptionsUtil.java
+++ b/flink-connectors/flink-connector-kafka/src/main/java/org/apache/flink/streaming/connectors/kafka/table/KafkaConnectorOptionsUtil.java
@@ -66,7 +66,6 @@ import static org.apache.flink.streaming.connectors.kafka.table.KafkaConnectorOp
 import static org.apache.flink.streaming.connectors.kafka.table.KafkaConnectorOptions.VALUE_FIELDS_INCLUDE;
 import static org.apache.flink.streaming.connectors.kafka.table.KafkaConnectorOptions.VALUE_FORMAT;
 import static org.apache.flink.table.factories.FactoryUtil.FORMAT;
-import static org.apache.flink.table.types.logical.utils.LogicalTypeChecks.hasRoot;
 
 /** Utilities for {@link KafkaConnectorOptions}. */
 @Internal
@@ -412,7 +411,7 @@ class KafkaConnectorOptionsUtil {
             ReadableConfig options, DataType physicalDataType) {
         final LogicalType physicalType = physicalDataType.getLogicalType();
         Preconditions.checkArgument(
-                hasRoot(physicalType, LogicalTypeRoot.ROW), "Row data type expected.");
+                physicalType.is(LogicalTypeRoot.ROW), "Row data type expected.");
         final Optional<String> optionalKeyFormat = options.getOptional(KEY_FORMAT);
         final Optional<List<String>> optionalKeyFields = options.getOptional(KEY_FIELDS);
 
@@ -479,7 +478,7 @@ class KafkaConnectorOptionsUtil {
             ReadableConfig options, DataType physicalDataType) {
         final LogicalType physicalType = physicalDataType.getLogicalType();
         Preconditions.checkArgument(
-                hasRoot(physicalType, LogicalTypeRoot.ROW), "Row data type expected.");
+                physicalType.is(LogicalTypeRoot.ROW), "Row data type expected.");
         final int physicalFieldCount = LogicalTypeChecks.getFieldCount(physicalType);
         final IntStream physicalFields = IntStream.range(0, physicalFieldCount);
 

--- a/flink-formats/flink-avro/src/main/java/org/apache/flink/formats/avro/typeutils/AvroSchemaConverter.java
+++ b/flink-formats/flink-avro/src/main/java/org/apache/flink/formats/avro/typeutils/AvroSchemaConverter.java
@@ -37,7 +37,6 @@ import org.apache.flink.table.types.logical.RowType;
 import org.apache.flink.table.types.logical.TimeType;
 import org.apache.flink.table.types.logical.TimestampType;
 import org.apache.flink.table.types.logical.TypeInformationRawType;
-import org.apache.flink.table.types.logical.utils.LogicalTypeChecks;
 import org.apache.flink.types.Row;
 import org.apache.flink.util.Preconditions;
 
@@ -444,7 +443,7 @@ public class AvroSchemaConverter {
             keyType = multisetType.getElementType();
             valueType = new IntType();
         }
-        if (!LogicalTypeChecks.hasFamily(keyType, LogicalTypeFamily.CHARACTER_STRING)) {
+        if (!keyType.is(LogicalTypeFamily.CHARACTER_STRING)) {
             throw new UnsupportedOperationException(
                     "Avro format doesn't support non-string as key type of map. "
                             + "The key type is: "

--- a/flink-formats/flink-json/src/main/java/org/apache/flink/formats/json/JsonToRowDataConverters.java
+++ b/flink-formats/flink-json/src/main/java/org/apache/flink/formats/json/JsonToRowDataConverters.java
@@ -36,7 +36,6 @@ import org.apache.flink.table.types.logical.LogicalTypeFamily;
 import org.apache.flink.table.types.logical.MapType;
 import org.apache.flink.table.types.logical.MultisetType;
 import org.apache.flink.table.types.logical.RowType;
-import org.apache.flink.table.types.logical.utils.LogicalTypeChecks;
 import org.apache.flink.table.types.logical.utils.LogicalTypeUtils;
 
 import org.apache.flink.shaded.jackson2.com.fasterxml.jackson.databind.JsonNode;
@@ -310,7 +309,7 @@ public class JsonToRowDataConverters implements Serializable {
 
     private JsonToRowDataConverter createMapConverter(
             String typeSummary, LogicalType keyType, LogicalType valueType) {
-        if (!LogicalTypeChecks.hasFamily(keyType, LogicalTypeFamily.CHARACTER_STRING)) {
+        if (!keyType.is(LogicalTypeFamily.CHARACTER_STRING)) {
             throw new UnsupportedOperationException(
                     "JSON format doesn't support non-string as key type of map. "
                             + "The type is: "

--- a/flink-formats/flink-json/src/main/java/org/apache/flink/formats/json/RowDataToJsonConverters.java
+++ b/flink-formats/flink-json/src/main/java/org/apache/flink/formats/json/RowDataToJsonConverters.java
@@ -33,7 +33,6 @@ import org.apache.flink.table.types.logical.LogicalTypeFamily;
 import org.apache.flink.table.types.logical.MapType;
 import org.apache.flink.table.types.logical.MultisetType;
 import org.apache.flink.table.types.logical.RowType;
-import org.apache.flink.table.types.logical.utils.LogicalTypeChecks;
 
 import org.apache.flink.shaded.jackson2.com.fasterxml.jackson.databind.JsonNode;
 import org.apache.flink.shaded.jackson2.com.fasterxml.jackson.databind.ObjectMapper;
@@ -249,7 +248,7 @@ public class RowDataToJsonConverters implements Serializable {
 
     private RowDataToJsonConverter createMapConverter(
             String typeSummary, LogicalType keyType, LogicalType valueType) {
-        if (!LogicalTypeChecks.hasFamily(keyType, LogicalTypeFamily.CHARACTER_STRING)) {
+        if (!keyType.is(LogicalTypeFamily.CHARACTER_STRING)) {
             throw new UnsupportedOperationException(
                     "JSON format doesn't support non-string as key type of map. "
                             + "The type is: "

--- a/flink-table/flink-table-api-java/src/main/java/org/apache/flink/table/catalog/DataTypeFactoryImpl.java
+++ b/flink-table/flink-table-api-java/src/main/java/org/apache/flink/table/catalog/DataTypeFactoryImpl.java
@@ -42,7 +42,6 @@ import javax.annotation.Nullable;
 
 import java.util.function.Supplier;
 
-import static org.apache.flink.table.types.logical.utils.LogicalTypeChecks.hasRoot;
 import static org.apache.flink.table.types.utils.TypeConversions.fromLogicalToDataType;
 
 /** Implementation of a {@link DataTypeFactory}. */
@@ -172,7 +171,7 @@ final class DataTypeFactoryImpl implements DataTypeFactory {
 
         @Override
         protected LogicalType defaultMethod(LogicalType logicalType) {
-            if (hasRoot(logicalType, LogicalTypeRoot.UNRESOLVED)) {
+            if (logicalType.is(LogicalTypeRoot.UNRESOLVED)) {
                 final UnresolvedUserDefinedType unresolvedType =
                         (UnresolvedUserDefinedType) logicalType;
                 return resolveType(unresolvedType.getUnresolvedIdentifier())

--- a/flink-table/flink-table-api-java/src/main/java/org/apache/flink/table/catalog/SchemaTranslator.java
+++ b/flink-table/flink-table-api-java/src/main/java/org/apache/flink/table/catalog/SchemaTranslator.java
@@ -47,8 +47,6 @@ import java.util.Optional;
 import java.util.stream.Collectors;
 import java.util.stream.IntStream;
 
-import static org.apache.flink.table.types.logical.utils.LogicalTypeChecks.hasFamily;
-import static org.apache.flink.table.types.logical.utils.LogicalTypeChecks.hasRoot;
 import static org.apache.flink.table.types.utils.DataTypeUtils.flattenToDataTypes;
 import static org.apache.flink.table.types.utils.DataTypeUtils.flattenToNames;
 
@@ -239,9 +237,10 @@ public final class SchemaTranslator {
             return dataType;
         }
         // we only truncate timestamps
-        if (!hasFamily(
-                columnDataTypes.get(columnCount - 1).getLogicalType(),
-                LogicalTypeFamily.TIMESTAMP)) {
+        if (!columnDataTypes
+                .get(columnCount - 1)
+                .getLogicalType()
+                .is(LogicalTypeFamily.TIMESTAMP)) {
             return dataType;
         }
         // truncate last field
@@ -338,9 +337,9 @@ public final class SchemaTranslator {
         // the following lines make assumptions on what comes out of the TypeInfoDataTypeConverter
         // e.g. we can assume that there will be no DISTINCT type and only anonymously defined
         // structured types without a super type
-        if (hasRoot(type, LogicalTypeRoot.ROW)) {
+        if (type.is(LogicalTypeRoot.ROW)) {
             return patchRowDataType(dataType, columnName, columnDataType);
-        } else if (hasRoot(type, LogicalTypeRoot.STRUCTURED_TYPE)) {
+        } else if (type.is(LogicalTypeRoot.STRUCTURED_TYPE)) {
             return patchStructuredDataType(dataType, columnName, columnDataType);
         } else {
             // this also covers the case where a top-level generic type enters the

--- a/flink-table/flink-table-api-java/src/main/java/org/apache/flink/table/expressions/resolver/rules/OverWindowResolverRule.java
+++ b/flink-table/flink-table-api-java/src/main/java/org/apache/flink/table/expressions/resolver/rules/OverWindowResolverRule.java
@@ -37,7 +37,6 @@ import static java.util.Arrays.asList;
 import static org.apache.flink.table.expressions.ApiExpressionUtils.unresolvedCall;
 import static org.apache.flink.table.types.logical.LogicalTypeRoot.BIGINT;
 import static org.apache.flink.table.types.logical.LogicalTypeRoot.INTERVAL_DAY_TIME;
-import static org.apache.flink.table.types.logical.utils.LogicalTypeChecks.hasRoot;
 
 /**
  * Joins call to {@link BuiltInFunctionDefinitions#OVER} with corresponding over window and creates
@@ -129,9 +128,9 @@ final class OverWindowResolverRule implements ResolverRule {
         @Override
         public WindowKind visit(ValueLiteralExpression valueLiteral) {
             final LogicalType literalType = valueLiteral.getOutputDataType().getLogicalType();
-            if (hasRoot(literalType, BIGINT)) {
+            if (literalType.is(BIGINT)) {
                 return WindowKind.ROW;
-            } else if (hasRoot(literalType, INTERVAL_DAY_TIME)) {
+            } else if (literalType.is(INTERVAL_DAY_TIME)) {
                 return WindowKind.RANGE;
             }
             return defaultMethod(valueLiteral);

--- a/flink-table/flink-table-api-java/src/main/java/org/apache/flink/table/operations/utils/AggregateOperationFactory.java
+++ b/flink-table/flink-table-api-java/src/main/java/org/apache/flink/table/operations/utils/AggregateOperationFactory.java
@@ -51,7 +51,6 @@ import org.apache.flink.table.types.logical.LegacyTypeInformationType;
 import org.apache.flink.table.types.logical.LogicalType;
 import org.apache.flink.table.types.logical.LogicalTypeRoot;
 import org.apache.flink.table.types.logical.StructuredType;
-import org.apache.flink.table.types.logical.utils.LogicalTypeChecks;
 import org.apache.flink.table.types.logical.utils.LogicalTypeDefaultVisitor;
 import org.apache.flink.table.types.utils.DataTypeUtils;
 import org.apache.flink.table.types.utils.TypeConversions;
@@ -79,7 +78,6 @@ import static org.apache.flink.table.types.logical.LogicalTypeRoot.INTERVAL_DAY_
 import static org.apache.flink.table.types.logical.LogicalTypeRoot.TIMESTAMP_WITHOUT_TIME_ZONE;
 import static org.apache.flink.table.types.logical.LogicalTypeRoot.TIMESTAMP_WITH_LOCAL_TIME_ZONE;
 import static org.apache.flink.table.types.logical.utils.LogicalTypeChecks.getFieldCount;
-import static org.apache.flink.table.types.logical.utils.LogicalTypeChecks.hasRoot;
 import static org.apache.flink.table.types.logical.utils.LogicalTypeChecks.isRowtimeAttribute;
 import static org.apache.flink.table.types.logical.utils.LogicalTypeChecks.isTimeAttribute;
 
@@ -313,9 +311,9 @@ final class AggregateOperationFactory {
     }
 
     private void validateBatchTimeAttribute(LogicalType timeFieldType) {
-        if (!(hasRoot(timeFieldType, TIMESTAMP_WITHOUT_TIME_ZONE)
-                || hasRoot(timeFieldType, TIMESTAMP_WITH_LOCAL_TIME_ZONE)
-                || hasRoot(timeFieldType, BIGINT))) {
+        if (!(timeFieldType.is(TIMESTAMP_WITHOUT_TIME_ZONE)
+                || timeFieldType.is(TIMESTAMP_WITH_LOCAL_TIME_ZONE)
+                || timeFieldType.is(BIGINT))) {
             throw new ValidationException(
                     "A group window expects a time attribute for grouping "
                             + "in a batch environment.");
@@ -323,8 +321,8 @@ final class AggregateOperationFactory {
     }
 
     private void validateStreamTimeAttribute(LogicalType timeFieldType) {
-        if (!(hasRoot(timeFieldType, TIMESTAMP_WITHOUT_TIME_ZONE)
-                        || hasRoot(timeFieldType, TIMESTAMP_WITH_LOCAL_TIME_ZONE))
+        if (!(timeFieldType.is(TIMESTAMP_WITHOUT_TIME_ZONE)
+                        || timeFieldType.is(TIMESTAMP_WITH_LOCAL_TIME_ZONE))
                 || !isTimeAttribute(timeFieldType)) {
             throw new ValidationException(
                     "A group window expects a time attribute for grouping "
@@ -343,14 +341,13 @@ final class AggregateOperationFactory {
         final LogicalType timeFieldType = timeField.getOutputDataType().getLogicalType();
         final LogicalType windowSizeType = windowSize.getOutputDataType().getLogicalType();
 
-        if (!hasRoot(windowSizeType, BIGINT) && !hasRoot(windowSizeType, INTERVAL_DAY_TIME)) {
+        if (windowSizeType.isAnyOf(BIGINT, INTERVAL_DAY_TIME)) {
+            validateWindowIntervalType(timeFieldType, windowSizeType);
+            return ResolvedGroupWindow.tumblingWindow(windowName, timeField, windowSize);
+        } else {
             throw new ValidationException(
                     "Tumbling window expects a size literal of a day-time interval or BIGINT type.");
         }
-
-        validateWindowIntervalType(timeFieldType, windowSizeType);
-
-        return ResolvedGroupWindow.tumblingWindow(windowName, timeField, windowSize);
     }
 
     private ResolvedGroupWindow validateAndCreateSlideWindow(
@@ -368,7 +365,7 @@ final class AggregateOperationFactory {
         final LogicalType windowSizeType = windowSize.getOutputDataType().getLogicalType();
         final LogicalType windowSlideType = windowSlide.getOutputDataType().getLogicalType();
 
-        if (!hasRoot(windowSizeType, BIGINT) && !hasRoot(windowSizeType, INTERVAL_DAY_TIME)) {
+        if (!windowSizeType.is(BIGINT) && !windowSizeType.is(INTERVAL_DAY_TIME)) {
             throw new ValidationException(
                     "A sliding window expects a size literal of a day-time interval or BIGINT type.");
         }
@@ -392,7 +389,7 @@ final class AggregateOperationFactory {
 
         final LogicalType windowGapType = windowGap.getOutputDataType().getLogicalType();
 
-        if (!hasRoot(windowGapType, INTERVAL_DAY_TIME)) {
+        if (!windowGapType.is(INTERVAL_DAY_TIME)) {
             throw new ValidationException(
                     "A session window expects a gap literal of a day-time interval type.");
         }
@@ -401,9 +398,9 @@ final class AggregateOperationFactory {
     }
 
     private void validateWindowIntervalType(LogicalType timeFieldType, LogicalType intervalType) {
-        if (hasRoot(intervalType, TIMESTAMP_WITHOUT_TIME_ZONE)
+        if (intervalType.is(TIMESTAMP_WITHOUT_TIME_ZONE)
                 && isRowtimeAttribute(timeFieldType)
-                && hasRoot(intervalType, BIGINT)) {
+                && intervalType.is(BIGINT)) {
             // unsupported row intervals on event-time
             throw new ValidationException(
                     "Event-time grouping windows on row intervals in a stream environment "
@@ -424,7 +421,7 @@ final class AggregateOperationFactory {
         if (!windowProperties.isEmpty()) {
             if (window.getType() == TUMBLE || window.getType() == SLIDE) {
                 DataType windowType = window.getSize().get().getOutputDataType();
-                if (LogicalTypeChecks.hasRoot(windowType.getLogicalType(), BIGINT)) {
+                if (windowType.getLogicalType().is(BIGINT)) {
                     throw new ValidationException(
                             String.format(
                                     "Window start and Window end cannot be selected "

--- a/flink-table/flink-table-api-java/src/main/java/org/apache/flink/table/operations/utils/JoinOperationFactory.java
+++ b/flink-table/flink-table-api-java/src/main/java/org/apache/flink/table/operations/utils/JoinOperationFactory.java
@@ -32,11 +32,11 @@ import org.apache.flink.table.operations.JoinQueryOperation.JoinType;
 import org.apache.flink.table.operations.QueryOperation;
 import org.apache.flink.table.types.DataType;
 import org.apache.flink.table.types.logical.LogicalType;
-import org.apache.flink.table.types.logical.LogicalTypeRoot;
-import org.apache.flink.table.types.logical.utils.LogicalTypeChecks;
 
 import java.util.HashSet;
 import java.util.Set;
+
+import static org.apache.flink.table.types.logical.LogicalTypeRoot.BOOLEAN;
 
 /** Utility class for creating a valid {@link JoinQueryOperation} operation. */
 @Internal
@@ -101,7 +101,7 @@ final class JoinOperationFactory {
     private void verifyConditionType(ResolvedExpression condition) {
         DataType conditionType = condition.getOutputDataType();
         LogicalType logicalType = conditionType.getLogicalType();
-        if (!LogicalTypeChecks.hasRoot(logicalType, LogicalTypeRoot.BOOLEAN)) {
+        if (!logicalType.is(BOOLEAN)) {
             throw new ValidationException(
                     String.format(
                             "Filter operator requires a boolean expression as input, "

--- a/flink-table/flink-table-api-java/src/main/java/org/apache/flink/table/operations/utils/OperationTreeBuilder.java
+++ b/flink-table/flink-table-api-java/src/main/java/org/apache/flink/table/operations/utils/OperationTreeBuilder.java
@@ -50,8 +50,6 @@ import org.apache.flink.table.operations.QueryOperation;
 import org.apache.flink.table.operations.ValuesQueryOperation;
 import org.apache.flink.table.operations.WindowAggregateQueryOperation.ResolvedGroupWindow;
 import org.apache.flink.table.types.DataType;
-import org.apache.flink.table.types.logical.LogicalTypeRoot;
-import org.apache.flink.table.types.logical.utils.LogicalTypeChecks;
 import org.apache.flink.table.types.utils.DataTypeUtils;
 import org.apache.flink.table.types.utils.TypeConversions;
 import org.apache.flink.table.typeutils.FieldInfoUtils;
@@ -77,6 +75,8 @@ import static org.apache.flink.table.expressions.ApiExpressionUtils.valueLiteral
 import static org.apache.flink.table.operations.SetQueryOperation.SetQueryOperationType.INTERSECT;
 import static org.apache.flink.table.operations.SetQueryOperation.SetQueryOperationType.MINUS;
 import static org.apache.flink.table.operations.SetQueryOperation.SetQueryOperationType.UNION;
+import static org.apache.flink.table.types.logical.LogicalTypeRoot.BOOLEAN;
+import static org.apache.flink.table.types.logical.LogicalTypeRoot.ROW;
 
 /** A builder for constructing validated {@link QueryOperation}s. */
 @Internal
@@ -440,7 +440,7 @@ public final class OperationTreeBuilder {
         ExpressionResolver resolver = getResolver(child);
         ResolvedExpression resolvedExpression = resolveSingleExpression(condition, resolver);
         DataType conditionType = resolvedExpression.getOutputDataType();
-        if (!LogicalTypeChecks.hasRoot(conditionType.getLogicalType(), LogicalTypeRoot.BOOLEAN)) {
+        if (!conditionType.getLogicalType().is(BOOLEAN)) {
             throw new ValidationException(
                     "Filter operator requires a boolean expression as input,"
                             + " but $condition is of type "
@@ -570,7 +570,7 @@ public final class OperationTreeBuilder {
 
     public QueryOperation values(DataType rowType, Expression... expressions) {
         final ResolvedSchema valuesSchema;
-        if (LogicalTypeChecks.hasRoot(rowType.getLogicalType(), LogicalTypeRoot.ROW)) {
+        if (rowType.getLogicalType().is(ROW)) {
             valuesSchema = DataTypeUtils.expandCompositeTypeToSchema(rowType);
         } else {
             valuesSchema =

--- a/flink-table/flink-table-api-java/src/main/java/org/apache/flink/table/operations/utils/ProjectionOperationFactory.java
+++ b/flink-table/flink-table-api-java/src/main/java/org/apache/flink/table/operations/utils/ProjectionOperationFactory.java
@@ -51,7 +51,6 @@ import static org.apache.flink.table.functions.BuiltInFunctionDefinitions.GET;
 import static org.apache.flink.table.operations.utils.OperationExpressionsUtils.extractName;
 import static org.apache.flink.table.operations.utils.OperationExpressionsUtils.extractNames;
 import static org.apache.flink.table.types.logical.LogicalTypeRoot.INTEGER;
-import static org.apache.flink.table.types.logical.utils.LogicalTypeChecks.hasRoot;
 
 /** Utility class for creating valid {@link ProjectQueryOperation} operation. */
 @Internal
@@ -238,7 +237,7 @@ final class ProjectionOperationFactory {
             final LogicalType keyType = key.getOutputDataType().getLogicalType();
 
             final String keySuffix;
-            if (hasRoot(keyType, INTEGER)) {
+            if (keyType.is(INTEGER)) {
                 keySuffix =
                         "$_"
                                 + key.getValueAs(Integer.class)

--- a/flink-table/flink-table-api-java/src/main/java/org/apache/flink/table/typeutils/FieldInfoUtils.java
+++ b/flink-table/flink-table-api-java/src/main/java/org/apache/flink/table/typeutils/FieldInfoUtils.java
@@ -42,7 +42,6 @@ import org.apache.flink.table.types.DataType;
 import org.apache.flink.table.types.DataTypeQueryable;
 import org.apache.flink.table.types.logical.LocalZonedTimestampType;
 import org.apache.flink.table.types.logical.LogicalType;
-import org.apache.flink.table.types.logical.LogicalTypeRoot;
 import org.apache.flink.table.types.logical.TimestampKind;
 import org.apache.flink.table.types.logical.TimestampType;
 import org.apache.flink.table.types.logical.utils.LogicalTypeChecks;
@@ -64,7 +63,7 @@ import java.util.stream.IntStream;
 import java.util.stream.Stream;
 
 import static java.lang.String.format;
-import static org.apache.flink.table.types.logical.utils.LogicalTypeChecks.hasRoot;
+import static org.apache.flink.table.types.logical.LogicalTypeRoot.TIMESTAMP_WITHOUT_TIME_ZONE;
 import static org.apache.flink.table.types.logical.utils.LogicalTypeChecks.isCompositeType;
 import static org.apache.flink.table.types.logical.utils.LogicalTypeChecks.isProctimeAttribute;
 import static org.apache.flink.table.types.logical.utils.LogicalTypeChecks.isRowtimeAttribute;
@@ -749,14 +748,12 @@ public class FieldInfoUtils {
     }
 
     private static boolean isRowtimeField(FieldInfo field) {
-        DataType type = field.getType();
-        return hasRoot(type.getLogicalType(), LogicalTypeRoot.TIMESTAMP_WITHOUT_TIME_ZONE)
-                && isRowtimeAttribute(type.getLogicalType());
+        final LogicalType logicalType = field.getType().getLogicalType();
+        return logicalType.is(TIMESTAMP_WITHOUT_TIME_ZONE) && isRowtimeAttribute(logicalType);
     }
 
     private static boolean isProctimeField(FieldInfo field) {
-        DataType type = field.getType();
-        return isProctimeAttribute(type.getLogicalType());
+        return isProctimeAttribute(field.getType().getLogicalType());
     }
 
     private static boolean isRowTimeExpression(Expression origExpr) {

--- a/flink-table/flink-table-common/src/main/java/org/apache/flink/table/api/Schema.java
+++ b/flink-table/flink-table-common/src/main/java/org/apache/flink/table/api/Schema.java
@@ -50,8 +50,6 @@ import java.util.Optional;
 import java.util.stream.Collectors;
 import java.util.stream.IntStream;
 
-import static org.apache.flink.table.types.logical.utils.LogicalTypeChecks.hasRoot;
-
 /**
  * Schema of a table or view.
  *
@@ -196,7 +194,7 @@ public final class Schema {
         public Builder fromRowDataType(DataType dataType) {
             Preconditions.checkNotNull(dataType, "Data type must not be null.");
             Preconditions.checkArgument(
-                    hasRoot(dataType.getLogicalType(), LogicalTypeRoot.ROW),
+                    dataType.getLogicalType().is(LogicalTypeRoot.ROW),
                     "Data type of ROW expected.");
             final List<DataType> fieldDataTypes = dataType.getChildren();
             final List<String> fieldNames = ((RowType) dataType.getLogicalType()).getFieldNames();

--- a/flink-table/flink-table-common/src/main/java/org/apache/flink/table/types/CollectionDataType.java
+++ b/flink-table/flink-table-common/src/main/java/org/apache/flink/table/types/CollectionDataType.java
@@ -33,7 +33,6 @@ import java.util.Collections;
 import java.util.List;
 import java.util.Objects;
 
-import static org.apache.flink.table.types.logical.utils.LogicalTypeChecks.hasRoot;
 import static org.apache.flink.table.types.logical.utils.LogicalTypeUtils.toInternalConversionClass;
 
 /**
@@ -131,7 +130,7 @@ public final class CollectionDataType extends DataType {
         } else if (conversionClass == MapData.class) {
             return elementDataType.bridgedTo(
                     toInternalConversionClass(elementDataType.getLogicalType()));
-        } else if (hasRoot(logicalType, LogicalTypeRoot.ARRAY) && conversionClass.isArray()) {
+        } else if (logicalType.is(LogicalTypeRoot.ARRAY) && conversionClass.isArray()) {
             // arrays are a special case because their element conversion class depends on the
             // outer conversion class
             return elementDataType.bridgedTo(conversionClass.getComponentType());

--- a/flink-table/flink-table-common/src/main/java/org/apache/flink/table/types/DataType.java
+++ b/flink-table/flink-table-common/src/main/java/org/apache/flink/table/types/DataType.java
@@ -38,7 +38,6 @@ import java.util.Objects;
 import java.util.stream.Collectors;
 import java.util.stream.IntStream;
 
-import static org.apache.flink.table.types.logical.utils.LogicalTypeChecks.hasRoot;
 import static org.apache.flink.table.types.logical.utils.LogicalTypeChecks.isCompositeType;
 
 /**
@@ -155,7 +154,7 @@ public abstract class DataType implements AbstractDataType<DataType>, Serializab
      */
     public static List<String> getFieldNames(DataType dataType) {
         final LogicalType type = dataType.getLogicalType();
-        if (hasRoot(type, LogicalTypeRoot.DISTINCT_TYPE)) {
+        if (type.is(LogicalTypeRoot.DISTINCT_TYPE)) {
             return getFieldNames(dataType.getChildren().get(0));
         } else if (isCompositeType(type)) {
             return LogicalTypeChecks.getFieldNames(type);
@@ -171,7 +170,7 @@ public abstract class DataType implements AbstractDataType<DataType>, Serializab
      */
     public static List<DataType> getFieldDataTypes(DataType dataType) {
         final LogicalType type = dataType.getLogicalType();
-        if (hasRoot(type, LogicalTypeRoot.DISTINCT_TYPE)) {
+        if (type.is(LogicalTypeRoot.DISTINCT_TYPE)) {
             return getFieldDataTypes(dataType.getChildren().get(0));
         } else if (isCompositeType(type)) {
             return dataType.getChildren();

--- a/flink-table/flink-table-common/src/main/java/org/apache/flink/table/types/extraction/DataTypeExtractor.java
+++ b/flink-table/flink-table-common/src/main/java/org/apache/flink/table/types/extraction/DataTypeExtractor.java
@@ -72,7 +72,6 @@ import static org.apache.flink.table.types.extraction.ExtractionUtils.toClass;
 import static org.apache.flink.table.types.extraction.ExtractionUtils.validateStructuredClass;
 import static org.apache.flink.table.types.extraction.ExtractionUtils.validateStructuredFieldReadability;
 import static org.apache.flink.table.types.extraction.ExtractionUtils.validateStructuredSelfReference;
-import static org.apache.flink.table.types.logical.utils.LogicalTypeChecks.hasRoot;
 import static org.apache.flink.table.types.logical.utils.LogicalTypeChecks.isCompositeType;
 
 /**
@@ -610,13 +609,13 @@ public final class DataTypeExtractor {
 
         // view was annotated
         if (ListView.class.isAssignableFrom(clazz)) {
-            if (!hasRoot(dataType.getLogicalType(), LogicalTypeRoot.ARRAY)) {
+            if (!dataType.getLogicalType().is(LogicalTypeRoot.ARRAY)) {
                 throw extractionError("Annotated list views should have a logical type of ARRAY.");
             }
             final CollectionDataType collectionDataType = (CollectionDataType) dataType;
             return ListView.newListViewDataType(collectionDataType.getElementDataType());
         } else if (MapView.class.isAssignableFrom(clazz)) {
-            if (!hasRoot(dataType.getLogicalType(), LogicalTypeRoot.MAP)) {
+            if (!dataType.getLogicalType().is(LogicalTypeRoot.MAP)) {
                 throw extractionError("Annotated map views should have a logical type of MAP.");
             }
             final KeyValueDataType keyValueDataType = (KeyValueDataType) dataType;

--- a/flink-table/flink-table-common/src/main/java/org/apache/flink/table/types/inference/TypeInferenceUtil.java
+++ b/flink-table/flink-table-common/src/main/java/org/apache/flink/table/types/inference/TypeInferenceUtil.java
@@ -37,7 +37,6 @@ import java.util.stream.Collectors;
 import java.util.stream.IntStream;
 
 import static org.apache.flink.table.types.logical.utils.LogicalTypeCasts.supportsImplicitCast;
-import static org.apache.flink.table.types.logical.utils.LogicalTypeChecks.hasRoot;
 
 /**
  * Utility for performing type inference.
@@ -475,7 +474,7 @@ public final class TypeInferenceUtil {
     }
 
     private static boolean isUnknown(DataType dataType) {
-        return hasRoot(dataType.getLogicalType(), LogicalTypeRoot.NULL);
+        return dataType.getLogicalType().is(LogicalTypeRoot.NULL);
     }
 
     private TypeInferenceUtil() {

--- a/flink-table/flink-table-common/src/main/java/org/apache/flink/table/types/inference/strategies/ComparableTypeStrategy.java
+++ b/flink-table/flink-table-common/src/main/java/org/apache/flink/table/types/inference/strategies/ComparableTypeStrategy.java
@@ -41,9 +41,6 @@ import java.util.List;
 import java.util.Objects;
 import java.util.Optional;
 
-import static org.apache.flink.table.types.logical.utils.LogicalTypeChecks.hasFamily;
-import static org.apache.flink.table.types.logical.utils.LogicalTypeChecks.hasRoot;
-
 /**
  * An {@link InputTypeStrategy} that checks if all input arguments can be compared with each other
  * with the minimal provided comparison.
@@ -128,7 +125,7 @@ public final class ComparableTypeStrategy implements InputTypeStrategy {
         }
 
         // everything is comparable with null, it should return null in that case
-        if (hasRoot(firstType, LogicalTypeRoot.NULL) || hasRoot(secondType, LogicalTypeRoot.NULL)) {
+        if (firstType.is(LogicalTypeRoot.NULL) || secondType.is(LogicalTypeRoot.NULL)) {
             return true;
         }
 
@@ -136,26 +133,24 @@ public final class ComparableTypeStrategy implements InputTypeStrategy {
             return areTypesOfSameRootComparable(firstType, secondType);
         }
 
-        if (hasFamily(firstType, LogicalTypeFamily.NUMERIC)
-                && hasFamily(secondType, LogicalTypeFamily.NUMERIC)) {
+        if (firstType.is(LogicalTypeFamily.NUMERIC) && secondType.is(LogicalTypeFamily.NUMERIC)) {
             return true;
         }
 
         // DATE + ALL TIMESTAMPS
-        if (hasFamily(firstType, LogicalTypeFamily.DATETIME)
-                && hasFamily(secondType, LogicalTypeFamily.DATETIME)) {
+        if (firstType.is(LogicalTypeFamily.DATETIME) && secondType.is(LogicalTypeFamily.DATETIME)) {
             return true;
         }
 
         // VARCHAR + CHAR (we do not compare collations here)
-        if (hasFamily(firstType, LogicalTypeFamily.CHARACTER_STRING)
-                && hasFamily(secondType, LogicalTypeFamily.CHARACTER_STRING)) {
+        if (firstType.is(LogicalTypeFamily.CHARACTER_STRING)
+                && secondType.is(LogicalTypeFamily.CHARACTER_STRING)) {
             return true;
         }
 
         // VARBINARY + BINARY
-        if (hasFamily(firstType, LogicalTypeFamily.BINARY_STRING)
-                && hasFamily(secondType, LogicalTypeFamily.BINARY_STRING)) {
+        if (firstType.is(LogicalTypeFamily.BINARY_STRING)
+                && secondType.is(LogicalTypeFamily.BINARY_STRING)) {
             return true;
         }
 

--- a/flink-table/flink-table-common/src/main/java/org/apache/flink/table/types/inference/strategies/CurrentWatermarkTypeStrategy.java
+++ b/flink-table/flink-table-common/src/main/java/org/apache/flink/table/types/inference/strategies/CurrentWatermarkTypeStrategy.java
@@ -29,8 +29,6 @@ import org.apache.flink.table.types.logical.LogicalTypeRoot;
 
 import java.util.Optional;
 
-import static org.apache.flink.table.types.logical.utils.LogicalTypeChecks.hasRoot;
-
 /**
  * Type strategy for {@link BuiltInFunctionDefinitions#CURRENT_WATERMARK} which mirrors the type of
  * the passed rowtime column, but removes the rowtime kind and enforces the correct precision for
@@ -42,9 +40,9 @@ class CurrentWatermarkTypeStrategy implements TypeStrategy {
     @Override
     public Optional<DataType> inferType(CallContext callContext) {
         final LogicalType inputType = callContext.getArgumentDataTypes().get(0).getLogicalType();
-        if (hasRoot(inputType, LogicalTypeRoot.TIMESTAMP_WITHOUT_TIME_ZONE)) {
+        if (inputType.is(LogicalTypeRoot.TIMESTAMP_WITHOUT_TIME_ZONE)) {
             return Optional.of(DataTypes.TIMESTAMP(3));
-        } else if (hasRoot(inputType, LogicalTypeRoot.TIMESTAMP_WITH_LOCAL_TIME_ZONE)) {
+        } else if (inputType.is(LogicalTypeRoot.TIMESTAMP_WITH_LOCAL_TIME_ZONE)) {
             return Optional.of(DataTypes.TIMESTAMP_LTZ(3));
         }
 

--- a/flink-table/flink-table-common/src/main/java/org/apache/flink/table/types/inference/strategies/DecimalScale0TypeStrategy.java
+++ b/flink-table/flink-table-common/src/main/java/org/apache/flink/table/types/inference/strategies/DecimalScale0TypeStrategy.java
@@ -30,7 +30,6 @@ import org.apache.flink.table.types.logical.LogicalTypeRoot;
 import java.util.Optional;
 
 import static org.apache.flink.table.types.logical.utils.LogicalTypeChecks.getPrecision;
-import static org.apache.flink.table.types.logical.utils.LogicalTypeChecks.hasRoot;
 import static org.apache.flink.table.types.logical.utils.LogicalTypeChecks.hasScale;
 import static org.apache.flink.table.types.utils.TypeConversions.fromLogicalToDataType;
 
@@ -48,7 +47,7 @@ class DecimalScale0TypeStrategy implements TypeStrategy {
             return Optional.of(argumentDataType);
         }
 
-        if (hasRoot(argumentType, LogicalTypeRoot.DECIMAL)) {
+        if (argumentType.is(LogicalTypeRoot.DECIMAL)) {
             if (hasScale(argumentType, 0)) {
                 return Optional.of(argumentDataType);
             }

--- a/flink-table/flink-table-common/src/main/java/org/apache/flink/table/types/inference/strategies/MatchFamilyTypeStrategy.java
+++ b/flink-table/flink-table-common/src/main/java/org/apache/flink/table/types/inference/strategies/MatchFamilyTypeStrategy.java
@@ -28,8 +28,6 @@ import org.apache.flink.util.Preconditions;
 import java.util.Objects;
 import java.util.Optional;
 
-import static org.apache.flink.table.types.logical.utils.LogicalTypeChecks.hasFamily;
-
 /** Type strategy that returns the given argument if it is of the same logical type family. */
 @Internal
 public final class MatchFamilyTypeStrategy implements TypeStrategy {
@@ -46,7 +44,7 @@ public final class MatchFamilyTypeStrategy implements TypeStrategy {
     @Override
     public Optional<DataType> inferType(CallContext callContext) {
         final DataType argumentDataType = callContext.getArgumentDataTypes().get(argumentPos);
-        if (hasFamily(argumentDataType.getLogicalType(), matchingTypeFamily)) {
+        if (argumentDataType.getLogicalType().is(matchingTypeFamily)) {
             return Optional.of(argumentDataType);
         }
         return Optional.empty();

--- a/flink-table/flink-table-common/src/main/java/org/apache/flink/table/types/inference/strategies/OutputArgumentTypeStrategy.java
+++ b/flink-table/flink-table-common/src/main/java/org/apache/flink/table/types/inference/strategies/OutputArgumentTypeStrategy.java
@@ -27,8 +27,6 @@ import org.apache.flink.table.types.logical.LogicalTypeRoot;
 
 import java.util.Optional;
 
-import static org.apache.flink.table.types.logical.utils.LogicalTypeChecks.hasRoot;
-
 /**
  * Strategy for inferring an unknown argument type from the function's output {@link DataType} if
  * available.
@@ -40,7 +38,7 @@ public final class OutputArgumentTypeStrategy implements ArgumentTypeStrategy {
     public Optional<DataType> inferArgumentType(
             CallContext callContext, int argumentPos, boolean throwOnFailure) {
         final DataType actualDataType = callContext.getArgumentDataTypes().get(argumentPos);
-        if (hasRoot(actualDataType.getLogicalType(), LogicalTypeRoot.NULL)) {
+        if (actualDataType.getLogicalType().is(LogicalTypeRoot.NULL)) {
             return callContext.getOutputDataType();
         }
         return Optional.of(actualDataType);

--- a/flink-table/flink-table-common/src/main/java/org/apache/flink/table/types/inference/strategies/RoundTypeStrategy.java
+++ b/flink-table/flink-table-common/src/main/java/org/apache/flink/table/types/inference/strategies/RoundTypeStrategy.java
@@ -33,7 +33,6 @@ import java.util.Optional;
 
 import static org.apache.flink.table.types.logical.utils.LogicalTypeChecks.getPrecision;
 import static org.apache.flink.table.types.logical.utils.LogicalTypeChecks.getScale;
-import static org.apache.flink.table.types.logical.utils.LogicalTypeChecks.hasRoot;
 import static org.apache.flink.table.types.utils.TypeConversions.fromLogicalToDataType;
 
 /** Type strategy that returns the result of a rounding operation. */
@@ -51,7 +50,7 @@ class RoundTypeStrategy implements TypeStrategy {
             return Optional.of(argumentDataType);
         }
 
-        if (!hasRoot(argumentType, LogicalTypeRoot.DECIMAL)) {
+        if (!argumentType.is(LogicalTypeRoot.DECIMAL)) {
             return Optional.of(argumentDataType);
         }
 

--- a/flink-table/flink-table-common/src/main/java/org/apache/flink/table/types/inference/strategies/SourceWatermarkTypeStrategy.java
+++ b/flink-table/flink-table-common/src/main/java/org/apache/flink/table/types/inference/strategies/SourceWatermarkTypeStrategy.java
@@ -27,8 +27,6 @@ import org.apache.flink.table.types.logical.LogicalTypeFamily;
 
 import java.util.Optional;
 
-import static org.apache.flink.table.types.logical.utils.LogicalTypeChecks.hasFamily;
-
 /** Type strategy specific for source watermarks that depend on the output type. */
 @Internal
 class SourceWatermarkTypeStrategy implements TypeStrategy {
@@ -38,7 +36,7 @@ class SourceWatermarkTypeStrategy implements TypeStrategy {
         final DataType timestampDataType =
                 callContext
                         .getOutputDataType()
-                        .filter(dt -> hasFamily(dt.getLogicalType(), LogicalTypeFamily.TIMESTAMP))
+                        .filter(dt -> dt.getLogicalType().is(LogicalTypeFamily.TIMESTAMP))
                         .orElse(DataTypes.TIMESTAMP_LTZ(3));
         return Optional.of(timestampDataType);
     }

--- a/flink-table/flink-table-common/src/main/java/org/apache/flink/table/types/inference/strategies/StringConcatTypeStrategy.java
+++ b/flink-table/flink-table-common/src/main/java/org/apache/flink/table/types/inference/strategies/StringConcatTypeStrategy.java
@@ -33,7 +33,6 @@ import java.util.List;
 import java.util.Optional;
 
 import static org.apache.flink.table.types.logical.utils.LogicalTypeChecks.getLength;
-import static org.apache.flink.table.types.logical.utils.LogicalTypeChecks.hasFamily;
 import static org.apache.flink.table.types.logical.utils.LogicalTypeMerging.findCommonType;
 
 /**
@@ -57,11 +56,11 @@ class StringConcatTypeStrategy implements TypeStrategy {
         }
 
         final LogicalType minimumType;
-        if (hasFamily(type1, LogicalTypeFamily.CHARACTER_STRING)
-                || hasFamily(type2, LogicalTypeFamily.CHARACTER_STRING)) {
+        if (type1.is(LogicalTypeFamily.CHARACTER_STRING)
+                || type2.is(LogicalTypeFamily.CHARACTER_STRING)) {
             minimumType = new CharType(false, length);
-        } else if (hasFamily(type1, LogicalTypeFamily.BINARY_STRING)
-                || hasFamily(type2, LogicalTypeFamily.BINARY_STRING)) {
+        } else if (type1.is(LogicalTypeFamily.BINARY_STRING)
+                || type2.is(LogicalTypeFamily.BINARY_STRING)) {
             minimumType = new BinaryType(false, length);
         } else {
             return Optional.empty();

--- a/flink-table/flink-table-common/src/main/java/org/apache/flink/table/types/logical/LogicalType.java
+++ b/flink-table/flink-table-common/src/main/java/org/apache/flink/table/types/logical/LogicalType.java
@@ -78,6 +78,33 @@ public abstract class LogicalType implements Serializable {
     }
 
     /**
+     * Returns whether the root of the type equals to the {@code typeRoot} or not.
+     *
+     * @param typeRoot The root type to check against for equality
+     */
+    public boolean is(LogicalTypeRoot typeRoot) {
+        return this.typeRoot == typeRoot;
+    }
+
+    /**
+     * Returns whether the root of the type equals to at least on of the {@code typeRoots} or not.
+     *
+     * @param typeRoots The root types to check against for equality
+     */
+    public boolean isAnyOf(LogicalTypeRoot... typeRoots) {
+        return Arrays.stream(typeRoots).anyMatch(tr -> this.typeRoot == tr);
+    }
+
+    /**
+     * Returns whether the family type of the type equals to the {@code family} or not.
+     *
+     * @param family The family type to check against for equality
+     */
+    public boolean is(LogicalTypeFamily family) {
+        return typeRoot.getFamilies().contains(family);
+    }
+
+    /**
      * Returns a deep copy of this type with possibly different nullability.
      *
      * @param isNullable the intended nullability of the copied type

--- a/flink-table/flink-table-common/src/main/java/org/apache/flink/table/types/logical/utils/LogicalTypeMerging.java
+++ b/flink-table/flink-table-common/src/main/java/org/apache/flink/table/types/logical/utils/LogicalTypeMerging.java
@@ -101,8 +101,6 @@ import static org.apache.flink.table.types.logical.utils.LogicalTypeCasts.suppor
 import static org.apache.flink.table.types.logical.utils.LogicalTypeChecks.getLength;
 import static org.apache.flink.table.types.logical.utils.LogicalTypeChecks.getPrecision;
 import static org.apache.flink.table.types.logical.utils.LogicalTypeChecks.getScale;
-import static org.apache.flink.table.types.logical.utils.LogicalTypeChecks.hasFamily;
-import static org.apache.flink.table.types.logical.utils.LogicalTypeChecks.hasRoot;
 
 /** Utilities for merging multiple {@link LogicalType}. */
 @Internal
@@ -191,7 +189,7 @@ public final class LogicalTypeMerging {
         if (foundType != null) {
             final LogicalType typeWithNullability = foundType.copy(hasNullableTypes);
             // NULL is reserved for untyped literals only
-            if (hasRoot(typeWithNullability, NULL)) {
+            if (typeWithNullability.is(NULL)) {
                 return Optional.empty();
             }
             return Optional.of(typeWithNullability);
@@ -262,7 +260,7 @@ public final class LogicalTypeMerging {
     /** Finds the result type of a decimal average aggregation. */
     public static LogicalType findAvgAggType(LogicalType argType) {
         final LogicalType resultType;
-        if (hasRoot(argType, LogicalTypeRoot.DECIMAL)) {
+        if (argType.is(DECIMAL)) {
             // a hack to make legacy types possible until we drop them
             if (argType instanceof LegacyTypeInformationType) {
                 return argType;
@@ -283,7 +281,7 @@ public final class LogicalTypeMerging {
         // adopted from
         // https://docs.microsoft.com/en-us/sql/t-sql/functions/sum-transact-sql
         final LogicalType resultType;
-        if (hasRoot(argType, LogicalTypeRoot.DECIMAL)) {
+        if (argType.is(DECIMAL)) {
             // a hack to make legacy types possible until we drop them
             if (argType instanceof LegacyTypeInformationType) {
                 return argType;
@@ -391,19 +389,19 @@ public final class LogicalTypeMerging {
             }
 
             // for types of family CHARACTER_STRING or BINARY_STRING
-            if (hasFamily(type, CHARACTER_STRING) || hasFamily(type, BINARY_STRING)) {
+            if (type.is(CHARACTER_STRING) | type.is(BINARY_STRING)) {
                 final int length = combineLength(resultType, type);
 
-                if (hasRoot(resultType, VARCHAR) || hasRoot(resultType, VARBINARY)) {
+                if (resultType.isAnyOf(VARCHAR, VARBINARY)) {
                     // variable length types remain variable length types
                     resultType = createStringType(resultType.getTypeRoot(), length);
                 } else if (getLength(resultType) != getLength(type)) {
                     // for different fixed lengths
                     // this is different from the SQL standard but prevents whitespace
                     // padding/modification of strings
-                    if (hasRoot(resultType, CHAR)) {
+                    if (resultType.is(CHAR)) {
                         resultType = createStringType(VARCHAR, length);
-                    } else if (hasRoot(resultType, BINARY)) {
+                    } else if (resultType.is(BINARY)) {
                         resultType = createStringType(VARBINARY, length);
                     }
                 } else {
@@ -412,10 +410,10 @@ public final class LogicalTypeMerging {
                 }
             }
             // for EXACT_NUMERIC types
-            else if (hasFamily(type, EXACT_NUMERIC)) {
-                if (hasFamily(resultType, EXACT_NUMERIC)) {
+            else if (type.is(EXACT_NUMERIC)) {
+                if (resultType.is(EXACT_NUMERIC)) {
                     resultType = createCommonExactNumericType(resultType, type);
-                } else if (hasFamily(resultType, APPROXIMATE_NUMERIC)) {
+                } else if (resultType.is(APPROXIMATE_NUMERIC)) {
                     // the result is already approximate
                     if (typeRoot == DECIMAL) {
                         // in case of DECIMAL we enforce DOUBLE
@@ -426,10 +424,10 @@ public final class LogicalTypeMerging {
                 }
             }
             // for APPROXIMATE_NUMERIC types
-            else if (hasFamily(type, APPROXIMATE_NUMERIC)) {
-                if (hasFamily(resultType, APPROXIMATE_NUMERIC)) {
+            else if (type.is(APPROXIMATE_NUMERIC)) {
+                if (resultType.is(APPROXIMATE_NUMERIC)) {
                     resultType = createCommonApproximateNumericType(resultType, type);
-                } else if (hasFamily(resultType, EXACT_NUMERIC)) {
+                } else if (resultType.is(EXACT_NUMERIC)) {
                     // the result was exact so far
                     if (typeRoot == DECIMAL) {
                         // in case of DECIMAL we enforce DOUBLE
@@ -443,24 +441,24 @@ public final class LogicalTypeMerging {
                 }
             }
             // for DATE
-            else if (hasRoot(type, DATE)) {
-                if (hasRoot(resultType, DATE)) {
+            else if (type.is(DATE)) {
+                if (resultType.is(DATE)) {
                     resultType = new DateType(); // for enabling findCommonTypePattern
                 } else {
                     return null;
                 }
             }
             // for TIME
-            else if (hasFamily(type, TIME)) {
-                if (hasFamily(resultType, TIME)) {
+            else if (type.is(TIME)) {
+                if (resultType.is(TIME)) {
                     resultType = new TimeType(combinePrecision(resultType, type));
                 } else {
                     return null;
                 }
             }
             // for TIMESTAMP
-            else if (hasFamily(type, TIMESTAMP)) {
-                if (hasFamily(resultType, TIMESTAMP)) {
+            else if (type.is(TIMESTAMP)) {
+                if (resultType.is(TIMESTAMP)) {
                     resultType = createCommonTimestampType(resultType, type);
                 } else {
                     return null;
@@ -496,15 +494,15 @@ public final class LogicalTypeMerging {
         // two types are similar iff they can be the operands of an SQL equality predicate
 
         // similarity based on families
-        if (hasFamily(left, CHARACTER_STRING) && hasFamily(right, CHARACTER_STRING)) {
+        if (left.is(CHARACTER_STRING) && right.is(CHARACTER_STRING)) {
             return true;
-        } else if (hasFamily(left, BINARY_STRING) && hasFamily(right, BINARY_STRING)) {
+        } else if (left.is(BINARY_STRING) && right.is(BINARY_STRING)) {
             return true;
-        } else if (hasFamily(left, NUMERIC) && hasFamily(right, NUMERIC)) {
+        } else if (left.is(NUMERIC) && right.is(NUMERIC)) {
             return true;
-        } else if (hasFamily(left, TIME) && hasFamily(right, TIME)) {
+        } else if (left.is(TIME) && right.is(TIME)) {
             return true;
-        } else if (hasFamily(left, TIMESTAMP) && hasFamily(right, TIMESTAMP)) {
+        } else if (left.is(TIMESTAMP) && right.is(TIMESTAMP)) {
             return true;
         }
         // similarity based on root
@@ -523,15 +521,13 @@ public final class LogicalTypeMerging {
 
     private static @Nullable LogicalType findCommonTypePattern(
             LogicalType resultType, LogicalType type) {
-        if (hasFamily(resultType, DATETIME) && hasFamily(type, INTERVAL)) {
+        if (resultType.is(DATETIME) && type.is(INTERVAL)) {
             return resultType;
-        } else if (hasFamily(resultType, INTERVAL) && hasFamily(type, DATETIME)) {
+        } else if (resultType.is(INTERVAL) && type.is(DATETIME)) {
             return type;
-        } else if ((hasFamily(resultType, TIMESTAMP) || hasRoot(resultType, DATE))
-                && hasFamily(type, EXACT_NUMERIC)) {
+        } else if ((resultType.is(TIMESTAMP) || resultType.is(DATE)) && type.is(EXACT_NUMERIC)) {
             return resultType;
-        } else if (hasFamily(resultType, EXACT_NUMERIC)
-                && (hasFamily(type, TIMESTAMP) || hasRoot(type, DATE))) {
+        } else if (resultType.is(EXACT_NUMERIC) && (type.is(TIMESTAMP) || type.is(DATE))) {
             return type;
         }
         // for "DATETIME + EXACT_NUMERIC", EXACT_NUMERIC is always treated as an interval of days
@@ -663,7 +659,7 @@ public final class LogicalTypeMerging {
 
     private static LogicalType createCommonApproximateNumericType(
             LogicalType resultType, LogicalType type) {
-        if (hasRoot(resultType, DOUBLE) || hasRoot(type, DOUBLE)) {
+        if (resultType.is(DOUBLE) || type.is(DOUBLE)) {
             return new DoubleType();
         }
         return resultType;

--- a/flink-table/flink-table-common/src/main/java/org/apache/flink/table/types/utils/LegacyTypeInfoDataTypeConverter.java
+++ b/flink-table/flink-table-common/src/main/java/org/apache/flink/table/types/utils/LegacyTypeInfoDataTypeConverter.java
@@ -62,7 +62,18 @@ import java.util.Map;
 import java.util.stream.IntStream;
 
 import static org.apache.flink.table.types.extraction.ExtractionUtils.primitiveToWrapper;
-import static org.apache.flink.table.types.logical.utils.LogicalTypeChecks.hasRoot;
+import static org.apache.flink.table.types.logical.LogicalTypeRoot.ARRAY;
+import static org.apache.flink.table.types.logical.LogicalTypeRoot.CHAR;
+import static org.apache.flink.table.types.logical.LogicalTypeRoot.DECIMAL;
+import static org.apache.flink.table.types.logical.LogicalTypeRoot.MAP;
+import static org.apache.flink.table.types.logical.LogicalTypeRoot.MULTISET;
+import static org.apache.flink.table.types.logical.LogicalTypeRoot.RAW;
+import static org.apache.flink.table.types.logical.LogicalTypeRoot.ROW;
+import static org.apache.flink.table.types.logical.LogicalTypeRoot.STRUCTURED_TYPE;
+import static org.apache.flink.table.types.logical.LogicalTypeRoot.TIMESTAMP_WITHOUT_TIME_ZONE;
+import static org.apache.flink.table.types.logical.LogicalTypeRoot.TIMESTAMP_WITH_LOCAL_TIME_ZONE;
+import static org.apache.flink.table.types.logical.LogicalTypeRoot.TIME_WITHOUT_TIME_ZONE;
+import static org.apache.flink.table.types.logical.LogicalTypeRoot.VARCHAR;
 import static org.apache.flink.table.types.logical.utils.LogicalTypeChecks.isRowtimeAttribute;
 
 /**
@@ -108,7 +119,7 @@ public final class LegacyTypeInfoDataTypeConverter {
         addMapping(Types.LONG, DataTypes.BIGINT().bridgedTo(Long.class));
         addMapping(Types.FLOAT, DataTypes.FLOAT().bridgedTo(Float.class));
         addMapping(Types.DOUBLE, DataTypes.DOUBLE().bridgedTo(Double.class));
-        addMapping(Types.BIG_DEC, createLegacyType(LogicalTypeRoot.DECIMAL, Types.BIG_DEC));
+        addMapping(Types.BIG_DEC, createLegacyType(DECIMAL, Types.BIG_DEC));
         addMapping(Types.LOCAL_DATE, DataTypes.DATE().bridgedTo(LocalDate.class));
         addMapping(Types.LOCAL_TIME, DataTypes.TIME(0).bridgedTo(LocalTime.class));
         addMapping(Types.LOCAL_DATE_TIME, DataTypes.TIMESTAMP(3).bridgedTo(LocalDateTime.class));
@@ -177,16 +188,16 @@ public final class LegacyTypeInfoDataTypeConverter {
                     typeInfo.getTypeClass(),
                     ((ObjectArrayTypeInfo<?, ?>) typeInfo).getComponentInfo());
         } else if (typeInfo instanceof BasicArrayTypeInfo) {
-            return createLegacyType(LogicalTypeRoot.ARRAY, typeInfo);
+            return createLegacyType(ARRAY, typeInfo);
         } else if (typeInfo instanceof MultisetTypeInfo) {
             return convertToMultisetType(((MultisetTypeInfo<?>) typeInfo).getElementTypeInfo());
         } else if (typeInfo instanceof MapTypeInfo) {
             return convertToMapType((MapTypeInfo<?, ?>) typeInfo);
         } else if (typeInfo instanceof CompositeType || isRowData(typeInfo)) {
-            return createLegacyType(LogicalTypeRoot.STRUCTURED_TYPE, typeInfo);
+            return createLegacyType(STRUCTURED_TYPE, typeInfo);
         }
 
-        return createLegacyType(LogicalTypeRoot.RAW, typeInfo);
+        return createLegacyType(RAW, typeInfo);
     }
 
     public static TypeInformation<?> toLegacyTypeInfo(DataType dataType) {
@@ -208,34 +219,34 @@ public final class LegacyTypeInfoDataTypeConverter {
         // we are relaxing the constraint for DECIMAL, CHAR, VARCHAR, TIMESTAMP_WITHOUT_TIME_ZONE to
         // support value literals in legacy planner
         LogicalType logicalType = dataType.getLogicalType();
-        if (hasRoot(logicalType, LogicalTypeRoot.DECIMAL)) {
+        if (logicalType.is(DECIMAL)) {
             return Types.BIG_DEC;
-        } else if (hasRoot(logicalType, LogicalTypeRoot.CHAR)) {
+        } else if (logicalType.is(CHAR)) {
             return Types.STRING;
-        } else if (hasRoot(logicalType, LogicalTypeRoot.VARCHAR)) {
+        } else if (logicalType.is(VARCHAR)) {
             return Types.STRING;
         }
 
         // relax the precision constraint as Timestamp can store the highest precision
-        else if (hasRoot(logicalType, LogicalTypeRoot.TIMESTAMP_WITHOUT_TIME_ZONE)
+        else if (logicalType.is(TIMESTAMP_WITHOUT_TIME_ZONE)
                 && dataType.getConversionClass() == Timestamp.class) {
             return Types.SQL_TIMESTAMP;
         }
 
         // relax the precision constraint as LocalDateTime can store the highest precision
-        else if (hasRoot(logicalType, LogicalTypeRoot.TIMESTAMP_WITHOUT_TIME_ZONE)
+        else if (logicalType.is(TIMESTAMP_WITHOUT_TIME_ZONE)
                 && dataType.getConversionClass() == LocalDateTime.class) {
             return Types.LOCAL_DATE_TIME;
         }
 
         // convert proctime back
-        else if (hasRoot(logicalType, LogicalTypeRoot.TIMESTAMP_WITH_LOCAL_TIME_ZONE)
+        else if (logicalType.is(TIMESTAMP_WITH_LOCAL_TIME_ZONE)
                 && dataType.getConversionClass() == Timestamp.class) {
             return Types.SQL_TIMESTAMP;
         }
 
         // relax the precision constraint as LocalTime can store the highest precision
-        else if (hasRoot(logicalType, LogicalTypeRoot.TIME_WITHOUT_TIME_ZONE)
+        else if (logicalType.is(TIME_WITHOUT_TIME_ZONE)
                 && dataType.getConversionClass() == LocalTime.class) {
             return Types.LOCAL_TIME;
         } else if (canConvertToLegacyTypeInfo(dataType)) {
@@ -283,10 +294,9 @@ public final class LegacyTypeInfoDataTypeConverter {
     }
 
     private static boolean canConvertToTimeAttributeTypeInfo(DataType dataType) {
-        if (hasRoot(dataType.getLogicalType(), LogicalTypeRoot.TIMESTAMP_WITHOUT_TIME_ZONE)) {
+        if (dataType.getLogicalType().is(TIMESTAMP_WITHOUT_TIME_ZONE)) {
             return ((TimestampType) dataType.getLogicalType()).getKind() != TimestampKind.REGULAR;
-        } else if (hasRoot(
-                dataType.getLogicalType(), LogicalTypeRoot.TIMESTAMP_WITH_LOCAL_TIME_ZONE)) {
+        } else if (dataType.getLogicalType().is(TIMESTAMP_WITH_LOCAL_TIME_ZONE)) {
             return ((LocalZonedTimestampType) dataType.getLogicalType()).getKind()
                     != TimestampKind.REGULAR;
         } else {
@@ -318,7 +328,7 @@ public final class LegacyTypeInfoDataTypeConverter {
     }
 
     private static boolean canConvertToRowTypeInfo(DataType dataType) {
-        return hasRoot(dataType.getLogicalType(), LogicalTypeRoot.ROW)
+        return dataType.getLogicalType().is(ROW)
                 && dataType.getConversionClass().equals(Row.class)
                 && ((RowType) dataType.getLogicalType())
                         .getFields().stream().noneMatch(f -> f.getDescription().isPresent());
@@ -344,8 +354,7 @@ public final class LegacyTypeInfoDataTypeConverter {
     }
 
     private static boolean canConvertToObjectArrayTypeInfo(DataType dataType) {
-        return hasRoot(dataType.getLogicalType(), LogicalTypeRoot.ARRAY)
-                && dataType.getConversionClass().isArray();
+        return dataType.getLogicalType().is(ARRAY) && dataType.getConversionClass().isArray();
     }
 
     private static TypeInformation<?> convertToObjectArrayTypeInfo(
@@ -360,8 +369,7 @@ public final class LegacyTypeInfoDataTypeConverter {
     }
 
     private static boolean canConvertToMultisetTypeInfo(DataType dataType) {
-        return hasRoot(dataType.getLogicalType(), LogicalTypeRoot.MULTISET)
-                && dataType.getConversionClass() == Map.class;
+        return dataType.getLogicalType().is(MULTISET) && dataType.getConversionClass() == Map.class;
     }
 
     private static TypeInformation<?> convertToMultisetTypeInfo(
@@ -377,8 +385,7 @@ public final class LegacyTypeInfoDataTypeConverter {
     }
 
     private static boolean canConvertToMapTypeInfo(DataType dataType) {
-        return hasRoot(dataType.getLogicalType(), LogicalTypeRoot.MAP)
-                && dataType.getConversionClass() == Map.class;
+        return dataType.getLogicalType().is(MAP) && dataType.getConversionClass() == Map.class;
     }
 
     private static TypeInformation<?> convertToMapTypeInfo(KeyValueDataType dataType) {
@@ -397,8 +404,7 @@ public final class LegacyTypeInfoDataTypeConverter {
 
     private static boolean canConvertToRawTypeInfo(DataType dataType) {
         final LogicalType type = dataType.getLogicalType();
-        return hasRoot(type, LogicalTypeRoot.RAW)
-                && dataType.getConversionClass() == type.getDefaultConversion();
+        return type.is(RAW) && dataType.getConversionClass() == type.getDefaultConversion();
     }
 
     private static TypeInformation<?> convertToRawTypeInfo(DataType dataType) {

--- a/flink-table/flink-table-common/src/main/java/org/apache/flink/table/utils/TypeMappingUtils.java
+++ b/flink-table/flink-table-common/src/main/java/org/apache/flink/table/utils/TypeMappingUtils.java
@@ -48,7 +48,6 @@ import java.util.stream.IntStream;
 import java.util.stream.Stream;
 
 import static org.apache.flink.table.types.logical.utils.LogicalTypeCasts.supportsAvoidingCast;
-import static org.apache.flink.table.types.logical.utils.LogicalTypeChecks.hasFamily;
 
 /**
  * Utility methods for dealing with field types in {@link
@@ -200,7 +199,7 @@ public final class TypeMappingUtils {
 
     private static void verifyTimeAttributeType(
             TableColumn logicalColumn, String rowtimeOrProctime) {
-        if (!hasFamily(logicalColumn.getType().getLogicalType(), LogicalTypeFamily.TIMESTAMP)) {
+        if (!logicalColumn.getType().getLogicalType().is(LogicalTypeFamily.TIMESTAMP)) {
             throw new ValidationException(
                     String.format(
                             "%s field '%s' has invalid type %s. %s attributes must be of a Timestamp family.",

--- a/flink-table/flink-table-common/src/test/java/org/apache/flink/table/types/LogicalTypeParserTest.java
+++ b/flink-table/flink-table-common/src/test/java/org/apache/flink/table/types/LogicalTypeParserTest.java
@@ -74,7 +74,6 @@ import java.util.Collections;
 import java.util.List;
 
 import static org.apache.flink.table.types.logical.LogicalTypeRoot.UNRESOLVED;
-import static org.apache.flink.table.types.logical.utils.LogicalTypeChecks.hasRoot;
 import static org.hamcrest.CoreMatchers.equalTo;
 import static org.junit.Assert.assertThat;
 
@@ -278,9 +277,9 @@ public class LogicalTypeParserTest {
     @Test
     public void testSerializableParsing() {
         if (testSpec.expectedType != null) {
-            if (!hasRoot(testSpec.expectedType, UNRESOLVED)
+            if (!testSpec.expectedType.is(UNRESOLVED)
                     && testSpec.expectedType.getChildren().stream()
-                            .noneMatch(t -> hasRoot(t, UNRESOLVED))) {
+                            .noneMatch(t -> t.is(UNRESOLVED))) {
                 assertThat(
                         LogicalTypeParser.parse(testSpec.expectedType.asSerializableString()),
                         equalTo(testSpec.expectedType));

--- a/flink-table/flink-table-common/src/test/java/org/apache/flink/table/types/logical/utils/LogicalTypeChecksTest.java
+++ b/flink-table/flink-table-common/src/test/java/org/apache/flink/table/types/logical/utils/LogicalTypeChecksTest.java
@@ -38,7 +38,6 @@ import static org.apache.flink.table.api.DataTypes.FIELD;
 import static org.apache.flink.table.api.DataTypes.INT;
 import static org.apache.flink.table.api.DataTypes.ROW;
 import static org.apache.flink.table.api.DataTypes.STRING;
-import static org.apache.flink.table.types.logical.utils.LogicalTypeChecks.hasRoot;
 import static org.hamcrest.CoreMatchers.is;
 import static org.junit.Assert.assertThat;
 
@@ -50,17 +49,17 @@ public class LogicalTypeChecksTest {
         final DataType dataType = ROW(FIELD("f0", INT()), FIELD("f1", STRING()));
         assertThat(
                 LogicalTypeChecks.hasNested(
-                        dataType.getLogicalType(), t -> hasRoot(t, LogicalTypeRoot.VARCHAR)),
+                        dataType.getLogicalType(), t -> t.is(LogicalTypeRoot.VARCHAR)),
                 is(true));
 
         assertThat(
                 LogicalTypeChecks.hasNested(
-                        dataType.getLogicalType(), t -> hasRoot(t, LogicalTypeRoot.ROW)),
+                        dataType.getLogicalType(), t -> t.is(LogicalTypeRoot.ROW)),
                 is(true));
 
         assertThat(
                 LogicalTypeChecks.hasNested(
-                        dataType.getLogicalType(), t -> hasRoot(t, LogicalTypeRoot.BOOLEAN)),
+                        dataType.getLogicalType(), t -> t.is(LogicalTypeRoot.BOOLEAN)),
                 is(false));
     }
 

--- a/flink-table/flink-table-planner/src/main/java/org/apache/flink/table/planner/expressions/converter/OverConvertRule.java
+++ b/flink-table/flink-table-planner/src/main/java/org/apache/flink/table/planner/expressions/converter/OverConvertRule.java
@@ -30,7 +30,6 @@ import org.apache.flink.table.planner.calcite.FlinkTypeFactory;
 import org.apache.flink.table.planner.expressions.SqlAggFunctionVisitor;
 import org.apache.flink.table.types.logical.DecimalType;
 import org.apache.flink.table.types.logical.LogicalTypeRoot;
-import org.apache.flink.table.types.logical.utils.LogicalTypeChecks;
 
 import com.google.common.collect.ImmutableList;
 import org.apache.calcite.rel.RelFieldCollation;
@@ -112,10 +111,8 @@ public class OverConvertRule implements CallExpressionConvertRule {
             // assemble bounds
             Expression preceding = children.get(2);
             boolean isPhysical =
-                    LogicalTypeChecks.hasRoot(
-                            fromDataTypeToLogicalType(
-                                    ((ResolvedExpression) preceding).getOutputDataType()),
-                            LogicalTypeRoot.BIGINT);
+                    fromDataTypeToLogicalType(((ResolvedExpression) preceding).getOutputDataType())
+                            .is(LogicalTypeRoot.BIGINT);
             Expression following = children.get(3);
             RexWindowBound lowerBound = createBound(context, preceding, SqlKind.PRECEDING);
             RexWindowBound upperBound = createBound(context, following, SqlKind.FOLLOWING);

--- a/flink-table/flink-table-planner/src/main/java/org/apache/flink/table/planner/typeutils/DataViewUtils.java
+++ b/flink-table/flink-table-planner/src/main/java/org/apache/flink/table/planner/typeutils/DataViewUtils.java
@@ -34,7 +34,6 @@ import org.apache.flink.table.types.FieldsDataType;
 import org.apache.flink.table.types.KeyValueDataType;
 import org.apache.flink.table.types.inference.TypeTransformation;
 import org.apache.flink.table.types.logical.LogicalType;
-import org.apache.flink.table.types.logical.LogicalTypeRoot;
 import org.apache.flink.table.types.logical.RawType;
 import org.apache.flink.table.types.logical.StructuredType;
 import org.apache.flink.table.types.utils.DataTypeUtils;
@@ -48,9 +47,10 @@ import java.util.List;
 import java.util.Optional;
 import java.util.function.Function;
 
+import static org.apache.flink.table.types.logical.LogicalTypeRoot.ROW;
+import static org.apache.flink.table.types.logical.LogicalTypeRoot.STRUCTURED_TYPE;
 import static org.apache.flink.table.types.logical.utils.LogicalTypeChecks.getFieldNames;
 import static org.apache.flink.table.types.logical.utils.LogicalTypeChecks.hasNested;
-import static org.apache.flink.table.types.logical.utils.LogicalTypeChecks.hasRoot;
 
 /**
  * Utilities to deal with {@link DataView}s.
@@ -65,8 +65,7 @@ public final class DataViewUtils {
     /** Searches for data views in the data type of an accumulator and extracts them. */
     public static List<DataViewSpec> extractDataViews(int aggIndex, DataType accumulatorDataType) {
         final LogicalType accumulatorType = accumulatorDataType.getLogicalType();
-        if (!hasRoot(accumulatorType, LogicalTypeRoot.ROW)
-                && !hasRoot(accumulatorType, LogicalTypeRoot.STRUCTURED_TYPE)) {
+        if (!accumulatorType.is(ROW) && !accumulatorType.is(STRUCTURED_TYPE)) {
             return Collections.emptyList();
         }
         final List<String> fieldNames = getFieldNames(accumulatorType);
@@ -140,7 +139,7 @@ public final class DataViewUtils {
     // --------------------------------------------------------------------------------------------
 
     public static boolean isDataView(LogicalType t, Class<? extends DataView> viewClass) {
-        return hasRoot(t, LogicalTypeRoot.STRUCTURED_TYPE)
+        return t.is(STRUCTURED_TYPE)
                 && ((StructuredType) t)
                         .getImplementationClass()
                         .map(viewClass::isAssignableFrom)

--- a/flink-table/flink-table-planner/src/main/scala/org/apache/flink/table/planner/codegen/CodeGenUtils.scala
+++ b/flink-table/flink-table-planner/src/main/scala/org/apache/flink/table/planner/codegen/CodeGenUtils.scala
@@ -43,7 +43,7 @@ import org.apache.flink.table.types.DataType
 import org.apache.flink.table.types.logical.LogicalTypeRoot._
 import org.apache.flink.table.types.logical._
 import org.apache.flink.table.types.logical.utils.LogicalTypeChecks
-import org.apache.flink.table.types.logical.utils.LogicalTypeChecks.{getFieldCount, getPrecision, getScale, hasRoot}
+import org.apache.flink.table.types.logical.utils.LogicalTypeChecks.{getFieldCount, getPrecision, getScale}
 import org.apache.flink.table.types.logical.utils.LogicalTypeUtils.toInternalConversionClass
 import org.apache.flink.table.types.utils.DataTypeUtils.isInternal
 import org.apache.flink.types.{Row, RowKind}
@@ -911,7 +911,7 @@ object CodeGenUtils {
     val targetTypeTerm = boxedTypeTermForType(targetType)
 
     // untyped null literal
-    if (hasRoot(internalExpr.resultType, NULL)) {
+    if (internalExpr.resultType.is(NULL)) {
       return s"($targetTypeTerm) null"
     }
 
@@ -1030,7 +1030,7 @@ object CodeGenUtils {
     val targetTypeTerm = boxedTypeTermForType(targetType)
 
     // untyped null literal
-    if (hasRoot(internalExpr.resultType, NULL)) {
+    if (internalExpr.resultType.is(NULL)) {
       return s"($targetTypeTerm) null"
     }
 

--- a/flink-table/flink-table-planner/src/main/scala/org/apache/flink/table/planner/codegen/agg/batch/WindowCodeGenerator.scala
+++ b/flink-table/flink-table-planner/src/main/scala/org/apache/flink/table/planner/codegen/agg/batch/WindowCodeGenerator.scala
@@ -46,7 +46,6 @@ import org.apache.flink.table.runtime.operators.window.grouping.{HeapWindowsGrou
 import org.apache.flink.table.runtime.util.RowIterator
 import org.apache.flink.table.types.logical.LogicalTypeRoot.INTERVAL_DAY_TIME
 import org.apache.flink.table.types.logical._
-import org.apache.flink.table.types.logical.utils.LogicalTypeChecks.hasRoot
 
 import org.apache.calcite.avatica.util.DateTimeUtils
 import org.apache.calcite.rel.core.AggregateCall
@@ -737,7 +736,7 @@ object WindowCodeGenerator {
 
   def isTimeIntervalLiteral(expr: Expression): Boolean = expr match {
     case literal: ValueLiteralExpression if
-      hasRoot(literal.getOutputDataType.getLogicalType, INTERVAL_DAY_TIME) => true
+      literal.getOutputDataType.getLogicalType.is(INTERVAL_DAY_TIME) => true
     case _ => false
   }
 }

--- a/flink-table/flink-table-planner/src/main/scala/org/apache/flink/table/planner/codegen/calls/BridgingFunctionGenUtil.scala
+++ b/flink-table/flink-table-planner/src/main/scala/org/apache/flink/table/planner/codegen/calls/BridgingFunctionGenUtil.scala
@@ -32,7 +32,7 @@ import org.apache.flink.table.types.DataType
 import org.apache.flink.table.types.extraction.ExtractionUtils.primitiveToWrapper
 import org.apache.flink.table.types.inference.{CallContext, TypeInference, TypeInferenceUtil}
 import org.apache.flink.table.types.logical.utils.LogicalTypeCasts.supportsAvoidingCast
-import org.apache.flink.table.types.logical.utils.LogicalTypeChecks.{hasRoot, isCompositeType}
+import org.apache.flink.table.types.logical.utils.LogicalTypeChecks.{isCompositeType}
 import org.apache.flink.table.types.logical.{LogicalType, LogicalTypeRoot, RowType}
 import org.apache.flink.table.types.utils.DataTypeUtils.{isInternal, validateInputDataType, validateOutputDataType}
 import org.apache.flink.util.Preconditions
@@ -355,7 +355,7 @@ object BridgingFunctionGenUtil {
       // logically table functions wrap atomic types into ROW, however, the physical function might
       // return an atomic type
       Preconditions.checkState(
-        hasRoot(returnType, LogicalTypeRoot.ROW) && returnType.getChildren.size() == 1,
+        returnType.is(LogicalTypeRoot.ROW) && returnType.getChildren.size() == 1,
         "Logical output type of function call should be a ROW wrapping an atomic type.",
         Seq(): _*)
       val atomicOutputType = returnType.asInstanceOf[RowType].getChildren.get(0)

--- a/flink-table/flink-table-planner/src/main/scala/org/apache/flink/table/planner/codegen/calls/ScalarOperatorGens.scala
+++ b/flink-table/flink-table-planner/src/main/scala/org/apache/flink/table/planner/codegen/calls/ScalarOperatorGens.scala
@@ -36,7 +36,7 @@ import org.apache.flink.table.types.logical.LogicalTypeFamily.DATETIME
 import org.apache.flink.table.types.logical.LogicalTypeRoot._
 import org.apache.flink.table.types.logical._
 import org.apache.flink.table.types.logical.utils.LogicalTypeCasts.supportsExplicitCast
-import org.apache.flink.table.types.logical.utils.LogicalTypeChecks.{getFieldTypes, hasFamily}
+import org.apache.flink.table.types.logical.utils.LogicalTypeChecks.getFieldTypes
 import org.apache.flink.table.types.logical.utils.LogicalTypeMerging.findCommonType
 import org.apache.flink.table.utils.DateTimeUtils
 import org.apache.flink.util.Preconditions.checkArgument
@@ -1181,7 +1181,7 @@ object ScalarOperatorGens {
       }
 
     // NUMERIC TYPE -> Boolean
-    case (_, BOOLEAN) if hasFamily(operand.resultType, LogicalTypeFamily.INTEGER_NUMERIC) =>
+    case (_, BOOLEAN) if operand.resultType.is(LogicalTypeFamily.INTEGER_NUMERIC) =>
       generateUnaryOperatorIfNotNull(ctx, targetType, operand) {
         operandTerm => s"$operandTerm != 0"
       }

--- a/flink-table/flink-table-planner/src/main/scala/org/apache/flink/table/planner/expressions/PlannerExpressionConverter.scala
+++ b/flink-table/flink-table-planner/src/main/scala/org/apache/flink/table/planner/expressions/PlannerExpressionConverter.scala
@@ -26,7 +26,7 @@ import org.apache.flink.table.functions._
 import org.apache.flink.table.planner.functions.InternalFunctionDefinitions.THROW_EXCEPTION
 import org.apache.flink.table.runtime.types.TypeInfoDataTypeConverter.fromDataTypeToTypeInfo
 import org.apache.flink.table.types.logical.LogicalTypeRoot.{CHAR, DECIMAL, SYMBOL}
-import org.apache.flink.table.types.logical.utils.LogicalTypeChecks._
+import org.apache.flink.table.types.logical.utils.LogicalTypeChecks.{hasLength, hasPrecision, hasScale}
 
 import _root_.scala.collection.JavaConverters._
 
@@ -255,7 +255,7 @@ class PlannerExpressionConverter private extends ApiExpressionVisitor[PlannerExp
   }
 
   override def visit(literal: ValueLiteralExpression): PlannerExpression = {
-    if (hasRoot(literal.getOutputDataType.getLogicalType, SYMBOL)) {
+    if (literal.getOutputDataType.getLogicalType.is(SYMBOL)) {
       val plannerSymbol = getSymbol(literal.getValueAs(classOf[TableSymbol]).get())
       return SymbolPlannerExpression(plannerSymbol)
     }
@@ -276,7 +276,7 @@ class PlannerExpressionConverter private extends ApiExpressionVisitor[PlannerExp
   private def getLiteralTypeInfo(literal: ValueLiteralExpression): TypeInformation[_] = {
     val logicalType = literal.getOutputDataType.getLogicalType
 
-    if (hasRoot(logicalType, DECIMAL)) {
+    if (logicalType.is(DECIMAL)) {
       if (literal.isNull) {
         return Types.BIG_DEC
       }
@@ -286,7 +286,7 @@ class PlannerExpressionConverter private extends ApiExpressionVisitor[PlannerExp
       }
     }
 
-    else if (hasRoot(logicalType, CHAR)) {
+    else if (logicalType.is(CHAR)) {
       if (literal.isNull) {
         return Types.STRING
       }

--- a/flink-table/flink-table-planner/src/main/scala/org/apache/flink/table/planner/plan/rules/logical/LogicalCorrelateToJoinFromTemporalTableFunctionRule.scala
+++ b/flink-table/flink-table-planner/src/main/scala/org/apache/flink/table/planner/plan/rules/logical/LogicalCorrelateToJoinFromTemporalTableFunctionRule.scala
@@ -29,7 +29,7 @@ import org.apache.flink.table.planner.plan.utils.TemporalJoinUtil.{makeProcTimeT
 import org.apache.flink.table.planner.plan.utils.{ExpandTableScanShuttle, RexDefaultVisitor}
 import org.apache.flink.table.planner.utils.ShortcutUtils
 import org.apache.flink.table.types.logical.LogicalTypeRoot.{TIMESTAMP_WITHOUT_TIME_ZONE, TIMESTAMP_WITH_LOCAL_TIME_ZONE}
-import org.apache.flink.table.types.logical.utils.LogicalTypeChecks.{hasRoot, isProctimeAttribute}
+import org.apache.flink.table.types.logical.utils.LogicalTypeChecks.{isProctimeAttribute}
 import org.apache.flink.util.Preconditions.checkState
 
 import org.apache.calcite.plan.RelOptRule.{any, none, operand, some}
@@ -55,9 +55,9 @@ class LogicalCorrelateToJoinFromTemporalTableFunctionRule
   private def extractNameFromTimeAttribute(timeAttribute: Expression): String = {
     timeAttribute match {
       case f : FieldReferenceExpression
-        if hasRoot(f.getOutputDataType.getLogicalType, TIMESTAMP_WITHOUT_TIME_ZONE) ||
-          hasRoot(f.getOutputDataType.getLogicalType, TIMESTAMP_WITH_LOCAL_TIME_ZONE)
-      => f.getName
+        if f.getOutputDataType.getLogicalType.isAnyOf(
+          TIMESTAMP_WITHOUT_TIME_ZONE,
+          TIMESTAMP_WITH_LOCAL_TIME_ZONE) => f.getName
       case _ => throw new ValidationException(
         s"Invalid timeAttribute [$timeAttribute] in TemporalTableFunction")
     }

--- a/flink-table/flink-table-planner/src/main/scala/org/apache/flink/table/planner/plan/rules/logical/WindowPropertiesRule.scala
+++ b/flink-table/flink-table-planner/src/main/scala/org/apache/flink/table/planner/plan/rules/logical/WindowPropertiesRule.scala
@@ -25,7 +25,6 @@ import org.apache.flink.table.planner.plan.logical.LogicalWindow
 import org.apache.flink.table.planner.plan.nodes.calcite.LogicalWindowAggregate
 import org.apache.flink.table.planner.plan.utils.AggregateUtil
 import org.apache.flink.table.types.logical.LogicalTypeRoot.TIMESTAMP_WITHOUT_TIME_ZONE
-import org.apache.flink.table.types.logical.utils.LogicalTypeChecks.hasRoot
 
 import org.apache.calcite.plan.RelOptRule._
 import org.apache.calcite.plan.{RelOptRule, RelOptRuleCall}
@@ -154,9 +153,8 @@ object WindowPropertiesRules {
       'streamRowtime
     } else if (AggregateUtil.isProctimeAttribute(window.timeAttribute)) {
       'streamProctime
-    } else if (hasRoot(
-          window.timeAttribute.getOutputDataType.getLogicalType,
-          TIMESTAMP_WITHOUT_TIME_ZONE)) {
+    } else if (
+          window.timeAttribute.getOutputDataType.getLogicalType.is(TIMESTAMP_WITHOUT_TIME_ZONE)) {
       'batchRowtime
     } else {
       throw new TableException("Unknown window type encountered. Please report this bug.")

--- a/flink-table/flink-table-planner/src/main/scala/org/apache/flink/table/planner/plan/utils/AggregateUtil.scala
+++ b/flink-table/flink-table-planner/src/main/scala/org/apache/flink/table/planner/plan/utils/AggregateUtil.scala
@@ -48,7 +48,6 @@ import org.apache.flink.table.types.DataType
 import org.apache.flink.table.types.inference.TypeInferenceUtil
 import org.apache.flink.table.types.logical.LogicalTypeRoot._
 import org.apache.flink.table.types.logical.utils.LogicalTypeChecks
-import org.apache.flink.table.types.logical.utils.LogicalTypeChecks.hasRoot
 import org.apache.flink.table.types.logical.{LogicalTypeRoot, _}
 import org.apache.flink.table.types.utils.DataTypeUtils
 
@@ -1077,11 +1076,11 @@ object AggregateUtil extends Enumeration {
   }
 
   def hasTimeIntervalType(intervalType: ValueLiteralExpression): Boolean = {
-    hasRoot(intervalType.getOutputDataType.getLogicalType, LogicalTypeRoot.INTERVAL_DAY_TIME)
+    intervalType.getOutputDataType.getLogicalType.is(LogicalTypeRoot.INTERVAL_DAY_TIME)
   }
 
   def hasRowIntervalType(intervalType: ValueLiteralExpression): Boolean = {
-    hasRoot(intervalType.getOutputDataType.getLogicalType, LogicalTypeRoot.BIGINT)
+    intervalType.getOutputDataType.getLogicalType.is(LogicalTypeRoot.BIGINT)
   }
 
   def toLong(literalExpr: ValueLiteralExpression): JLong =

--- a/flink-table/flink-table-planner/src/test/scala/org/apache/flink/table/planner/calcite/FlinkTypeFactoryTest.scala
+++ b/flink-table/flink-table-planner/src/test/scala/org/apache/flink/table/planner/calcite/FlinkTypeFactoryTest.scala
@@ -22,7 +22,6 @@ import org.apache.flink.api.common.ExecutionConfig
 import org.apache.flink.api.common.typeinfo.Types
 import org.apache.flink.api.java.typeutils.runtime.kryo.KryoSerializer
 import org.apache.flink.table.types.logical._
-import org.apache.flink.table.types.logical.utils.LogicalTypeChecks.hasRoot
 import org.apache.flink.table.types.logical.utils.LogicalTypeMerging
 
 import junit.framework.TestCase.{assertFalse, assertTrue}
@@ -43,7 +42,7 @@ class FlinkTypeFactoryTest {
           typeFactory.createFieldTypeFromLogicalType(t.copy(true)))
       )
 
-      if (!hasRoot(t, LogicalTypeRoot.NULL)) {
+      if (!t.is(LogicalTypeRoot.NULL)) {
         Assert.assertEquals(
           t.copy(false),
           FlinkTypeFactory.toLogicalType(
@@ -58,7 +57,7 @@ class FlinkTypeFactoryTest {
           typeFactory.createFieldTypeFromLogicalType(t.copy(true)))
       )
 
-      if (!hasRoot(t, LogicalTypeRoot.NULL)) {
+      if (!t.is(LogicalTypeRoot.NULL)) {
         Assert.assertEquals(
           t.copy(false),
           FlinkTypeFactory.toLogicalType(

--- a/flink-table/flink-table-runtime/src/main/java/org/apache/flink/table/runtime/functions/SqlUnnestUtils.java
+++ b/flink-table/flink-table-runtime/src/main/java/org/apache/flink/table/runtime/functions/SqlUnnestUtils.java
@@ -29,13 +29,13 @@ import org.apache.flink.table.types.inference.TypeInference;
 import org.apache.flink.table.types.inference.TypeStrategies;
 import org.apache.flink.table.types.logical.ArrayType;
 import org.apache.flink.table.types.logical.LogicalType;
-import org.apache.flink.table.types.logical.LogicalTypeRoot;
 import org.apache.flink.table.types.logical.MapType;
 import org.apache.flink.table.types.logical.MultisetType;
 import org.apache.flink.table.types.logical.RowType;
 import org.apache.flink.table.types.utils.DataTypeUtils;
 
-import static org.apache.flink.table.types.logical.utils.LogicalTypeChecks.hasRoot;
+import static org.apache.flink.table.types.logical.LogicalTypeRoot.ROW;
+import static org.apache.flink.table.types.logical.LogicalTypeRoot.STRUCTURED_TYPE;
 
 /** Utility for handling SQL's {@code UNNEST}. */
 @Internal
@@ -80,8 +80,7 @@ public final class SqlUnnestUtils {
         }
 
         public LogicalType getWrappedOutputType() {
-            if (hasRoot(outputType, LogicalTypeRoot.ROW)
-                    || hasRoot(outputType, LogicalTypeRoot.STRUCTURED_TYPE)) {
+            if (outputType.isAnyOf(ROW, STRUCTURED_TYPE)) {
                 return outputType;
             }
             return RowType.of(outputType);


### PR DESCRIPTION
Make the code of calling `hasRoot`/`hasFamily` less verbose by
replacing the static utility methods with member methods
`LogicalType#is()`

## Does this pull request potentially affect one of the following parts:

  - Dependencies (does it add or upgrade a dependency): no
  - The public API, i.e., is any changed class annotated with `@Public(Evolving)`: yes
  - The serializers: no
  - The runtime per-record code paths (performance sensitive): no
  - Anything that affects deployment or recovery: JobManager (and its components), Checkpointing, Kubernetes/Yarn, ZooKeeper: no
  - The S3 file system connector: no

 
## Documentation

  - Does this pull request introduce a new feature? no
  - If yes, how is the feature documented? not applicable
