### PR TITLE
[hotfix][flink-connector-jdbc] Removed un-used variable from test fixture

### DIFF
--- a/flink-connectors/flink-connector-jdbc/src/test/java/org/apache/flink/connector/jdbc/JdbcTestFixture.java
+++ b/flink-connectors/flink-connector-jdbc/src/test/java/org/apache/flink/connector/jdbc/JdbcTestFixture.java
@@ -45,7 +45,6 @@ public class JdbcTestFixture {
     public static final String OUTPUT_TABLE_3 = "newbooks3";
     public static final String WORDS_TABLE = "words";
     public static final String SELECT_ALL_BOOKS = "select * from " + INPUT_TABLE;
-    public static final String SELECT_ID_BOOKS = "select id from " + INPUT_TABLE;
     public static final String SELECT_ALL_NEWBOOKS = "select * from " + OUTPUT_TABLE;
     public static final String SELECT_ALL_NEWBOOKS_2 = "select * from " + OUTPUT_TABLE_2;
     public static final String SELECT_ALL_NEWBOOKS_3 = "select * from " + OUTPUT_TABLE_3;


### PR DESCRIPTION

## What is the purpose of the change

* JdbcTestFixture does not use SELECT_ID_BOOKS variable 

## Brief change log

* Removed un-used variable 

## Verifying this change

This change is a trivial rework / code cleanup without any test coverage.

## Does this pull request potentially affect one of the following parts:

  - Dependencies (does it add or upgrade a dependency): no
  - The public API, i.e., is any changed class annotated with `@Public(Evolving)`: no
  - The serializers: no 
  - The runtime per-record code paths (performance sensitive): no 
  - Anything that affects deployment or recovery: JobManager (and its components), Checkpointing, Kubernetes/Yarn, ZooKeeper: no 
  - The S3 file system connector: no

## Documentation

  - Does this pull request introduce a new feature? no
  - If yes, how is the feature documented? not applicable
