### PR TITLE
[FLINK-24640][table] CEIL, FLOOR built-in functions for Timestamp should res…

### DIFF
--- a/flink-table/flink-table-common/src/main/java/org/apache/flink/table/utils/DateTimeUtils.java
+++ b/flink-table/flink-table-common/src/main/java/org/apache/flink/table/utils/DateTimeUtils.java
@@ -1209,7 +1209,8 @@ public class DateTimeUtils {
             case HOUR:
                 return floor(utcTs, MILLIS_PER_HOUR) - offset;
             case DAY:
-                return floor(utcTs, MILLIS_PER_DAY) - offset;
+                long millis = floor(utcTs, MILLIS_PER_DAY);
+                return millis - tz.getOffset(millis);
             case MILLENNIUM:
             case CENTURY:
             case DECADE:
@@ -1218,7 +1219,8 @@ public class DateTimeUtils {
             case QUARTER:
             case WEEK:
                 int days = (int) (utcTs / MILLIS_PER_DAY + EPOCH_JULIAN);
-                return julianDateFloor(range, days, true) * MILLIS_PER_DAY - offset;
+                long dateInMillis = julianDateFloor(range, days, true) * MILLIS_PER_DAY;
+                return dateInMillis - tz.getOffset(dateInMillis);
             default:
                 // for MINUTE and SECONDS etc...,
                 // it is more effective to use arithmetic Method
@@ -1248,7 +1250,8 @@ public class DateTimeUtils {
             case QUARTER:
             case WEEK:
                 int days = (int) (utcTs / MILLIS_PER_DAY + EPOCH_JULIAN);
-                return julianDateFloor(range, days, false) * MILLIS_PER_DAY - offset;
+                long dateInMillis = julianDateFloor(range, days, false) * MILLIS_PER_DAY;
+                return dateInMillis - tz.getOffset(dateInMillis);
             default:
                 // for MINUTE and SECONDS etc...,
                 // it is more effective to use arithmetic Method

--- a/flink-table/flink-table-common/src/test/java/org/apache/flink/table/utils/DateTimeUtilsTest.java
+++ b/flink-table/flink-table-common/src/test/java/org/apache/flink/table/utils/DateTimeUtilsTest.java
@@ -1,0 +1,220 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.flink.table.utils;
+
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.MethodSource;
+
+import java.time.Instant;
+import java.time.LocalDateTime;
+import java.time.ZonedDateTime;
+import java.util.TimeZone;
+import java.util.stream.Stream;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+/** Tests for {@link org.apache.flink.table.utils.DateTimeUtils}. */
+class DateTimeUtilsTest {
+
+    @ParameterizedTest
+    @MethodSource("ceilParameters")
+    void testCeilWithDSTTransition(TestSpec testSpec) {
+        assertThat(testSpec.expected.toInstant())
+                .isEqualTo(
+                        Instant.ofEpochMilli(
+                                DateTimeUtils.timestampCeil(
+                                        testSpec.timeUnitRange,
+                                        testSpec.input.toEpochSecond() * 1000,
+                                        testSpec.timeZone)));
+    }
+
+    @ParameterizedTest
+    @MethodSource("floorParameters")
+    void testFloorWithDSTTransition(TestSpec testSpec) {
+        assertThat(testSpec.expected.toInstant())
+                .isEqualTo(
+                        Instant.ofEpochMilli(
+                                DateTimeUtils.timestampFloor(
+                                        testSpec.timeUnitRange,
+                                        testSpec.input.toEpochSecond() * 1000,
+                                        testSpec.timeZone)));
+    }
+
+    // ----------------------------------------------------------------------------------------------
+
+    private static final class TestSpec {
+        private final ZonedDateTime input;
+        private final TimeZone timeZone;
+        private final DateTimeUtils.TimeUnitRange timeUnitRange;
+        private final ZonedDateTime expected;
+
+        public TestSpec(
+                LocalDateTime input,
+                TimeZone timeZone,
+                DateTimeUtils.TimeUnitRange timeUnitRange,
+                LocalDateTime expected) {
+            this.input = ZonedDateTime.of(input, timeZone.toZoneId());
+            this.timeZone = timeZone;
+            this.timeUnitRange = timeUnitRange;
+            this.expected = ZonedDateTime.of(expected, timeZone.toZoneId());
+        }
+
+        @Override
+        public String toString() {
+            return "TestSpec{"
+                    + "timeUnitRange="
+                    + timeUnitRange
+                    + ", input="
+                    + input
+                    + ", timeZone="
+                    + timeZone
+                    + ", expected="
+                    + expected
+                    + '}';
+        }
+    }
+
+    static Stream<TestSpec> floorParameters() {
+        return Stream.of(
+                new TestSpec(
+                        LocalDateTime.of(2021, 3, 31, 11, 22, 33, 555555555),
+                        TimeZone.getTimeZone("Europe/Rome"),
+                        DateTimeUtils.TimeUnitRange.YEAR,
+                        LocalDateTime.of(2021, 1, 1, 0, 0, 0, 0)),
+                new TestSpec(
+                        LocalDateTime.of(2021, 3, 31, 23, 34, 56, 567123567),
+                        TimeZone.getTimeZone("America/Los_Angeles"),
+                        DateTimeUtils.TimeUnitRange.YEAR,
+                        LocalDateTime.of(2021, 1, 1, 0, 0, 0, 0)),
+                new TestSpec(
+                        LocalDateTime.of(2021, 3, 31, 0, 0, 0, 0),
+                        TimeZone.getTimeZone("Europe/Rome"),
+                        DateTimeUtils.TimeUnitRange.QUARTER,
+                        LocalDateTime.of(2021, 1, 1, 0, 0, 0, 0)),
+                new TestSpec(
+                        LocalDateTime.of(2021, 3, 31, 23, 59, 59, 999999999),
+                        TimeZone.getTimeZone("America/Los_Angeles"),
+                        DateTimeUtils.TimeUnitRange.QUARTER,
+                        LocalDateTime.of(2021, 1, 1, 0, 0, 0, 0)),
+                new TestSpec(
+                        LocalDateTime.of(2021, 3, 31, 0, 0, 0, 0),
+                        TimeZone.getTimeZone("Europe/Rome"),
+                        DateTimeUtils.TimeUnitRange.MONTH,
+                        LocalDateTime.of(2021, 3, 1, 0, 0, 0, 0)),
+                new TestSpec(
+                        LocalDateTime.of(2021, 3, 31, 18, 56, 23, 123123123),
+                        TimeZone.getTimeZone("America/Los_Angeles"),
+                        DateTimeUtils.TimeUnitRange.MONTH,
+                        LocalDateTime.of(2021, 3, 1, 0, 0, 0, 0)),
+                new TestSpec(
+                        LocalDateTime.of(2021, 3, 31, 18, 49, 57, 123789123),
+                        TimeZone.getTimeZone("Europe/Rome"),
+                        DateTimeUtils.TimeUnitRange.WEEK,
+                        LocalDateTime.of(2021, 3, 28, 0, 0, 0, 0)),
+                new TestSpec(
+                        LocalDateTime.of(2021, 3, 31, 21, 59, 34, 987987987),
+                        TimeZone.getTimeZone("America/Los_Angeles"),
+                        DateTimeUtils.TimeUnitRange.WEEK,
+                        LocalDateTime.of(2021, 3, 28, 0, 0, 0, 0)),
+                new TestSpec(
+                        LocalDateTime.of(2021, 3, 31, 23, 54, 59, 999_999_999),
+                        TimeZone.getTimeZone("Europe/Rome"),
+                        DateTimeUtils.TimeUnitRange.DAY,
+                        LocalDateTime.of(2021, 3, 31, 0, 0, 0, 0)),
+                new TestSpec(
+                        LocalDateTime.of(2021, 3, 31, 23, 23, 45, 987312),
+                        TimeZone.getTimeZone("America/Los_Angeles"),
+                        DateTimeUtils.TimeUnitRange.DAY,
+                        LocalDateTime.of(2021, 3, 31, 0, 0, 0, 0)),
+                new TestSpec(
+                        LocalDateTime.of(2021, 3, 31, 1, 34, 2, 123456),
+                        TimeZone.getTimeZone("Europe/Rome"),
+                        DateTimeUtils.TimeUnitRange.HOUR,
+                        LocalDateTime.of(2021, 3, 31, 1, 0, 0, 0)),
+                new TestSpec(
+                        LocalDateTime.of(2021, 3, 31, 1, 23, 56, 987431),
+                        TimeZone.getTimeZone("America/Los_Angeles"),
+                        DateTimeUtils.TimeUnitRange.HOUR,
+                        LocalDateTime.of(2021, 3, 31, 1, 0, 0, 0)));
+    }
+
+    static Stream<TestSpec> ceilParameters() {
+        return Stream.of(
+                new TestSpec(
+                        LocalDateTime.of(2021, 3, 31, 4, 39, 34, 56731),
+                        TimeZone.getTimeZone("Europe/Rome"),
+                        DateTimeUtils.TimeUnitRange.YEAR,
+                        LocalDateTime.of(2022, 1, 1, 0, 0, 0, 0)),
+                new TestSpec(
+                        LocalDateTime.of(2021, 3, 31, 4, 39, 34, 56731),
+                        TimeZone.getTimeZone("America/Los_Angeles"),
+                        DateTimeUtils.TimeUnitRange.YEAR,
+                        LocalDateTime.of(2022, 1, 1, 0, 0, 0, 0)),
+                new TestSpec(
+                        LocalDateTime.of(2021, 10, 25, 16, 23, 34, 123456),
+                        TimeZone.getTimeZone("Europe/Rome"),
+                        DateTimeUtils.TimeUnitRange.QUARTER,
+                        LocalDateTime.of(2022, 1, 1, 0, 0, 0, 0)),
+                new TestSpec(
+                        LocalDateTime.of(2021, 10, 25, 16, 23, 34, 123456),
+                        TimeZone.getTimeZone("America/Los_Angeles"),
+                        DateTimeUtils.TimeUnitRange.QUARTER,
+                        LocalDateTime.of(2022, 1, 1, 0, 0, 0, 0)),
+                new TestSpec(
+                        LocalDateTime.of(2021, 10, 25, 0, 0, 0, 0),
+                        TimeZone.getTimeZone("Europe/Rome"),
+                        DateTimeUtils.TimeUnitRange.MONTH,
+                        LocalDateTime.of(2021, 11, 1, 0, 0, 0, 0)),
+                new TestSpec(
+                        LocalDateTime.of(2021, 10, 25, 0, 0, 0, 0),
+                        TimeZone.getTimeZone("America/Los_Angeles"),
+                        DateTimeUtils.TimeUnitRange.MONTH,
+                        LocalDateTime.of(2021, 11, 1, 0, 0, 0, 0)),
+                new TestSpec(
+                        LocalDateTime.of(2021, 10, 25, 6, 32, 56, 987654321),
+                        TimeZone.getTimeZone("Europe/Rome"),
+                        DateTimeUtils.TimeUnitRange.WEEK,
+                        LocalDateTime.of(2021, 10, 31, 0, 0, 0, 0)),
+                new TestSpec(
+                        LocalDateTime.of(2021, 10, 25, 6, 32, 56, 987654321),
+                        TimeZone.getTimeZone("America/Los_Angeles"),
+                        DateTimeUtils.TimeUnitRange.WEEK,
+                        LocalDateTime.of(2021, 10, 31, 0, 0, 0, 0)),
+                new TestSpec(
+                        LocalDateTime.of(2021, 10, 25, 3, 4, 45, 123456789),
+                        TimeZone.getTimeZone("Europe/Rome"),
+                        DateTimeUtils.TimeUnitRange.DAY,
+                        LocalDateTime.of(2021, 10, 26, 0, 0, 0, 0)),
+                new TestSpec(
+                        LocalDateTime.of(2021, 10, 25, 3, 4, 45, 123456789),
+                        TimeZone.getTimeZone("America/Los_Angeles"),
+                        DateTimeUtils.TimeUnitRange.DAY,
+                        LocalDateTime.of(2021, 10, 26, 0, 0, 0, 0)),
+                new TestSpec(
+                        LocalDateTime.of(2021, 10, 25, 0, 30, 45, 123657),
+                        TimeZone.getTimeZone("Europe/Rome"),
+                        DateTimeUtils.TimeUnitRange.HOUR,
+                        LocalDateTime.of(2021, 10, 25, 1, 0, 0, 0)),
+                new TestSpec(
+                        LocalDateTime.of(2021, 10, 25, 0, 30, 45, 123657),
+                        TimeZone.getTimeZone("America/Los_Angeles"),
+                        DateTimeUtils.TimeUnitRange.HOUR,
+                        LocalDateTime.of(2021, 10, 25, 1, 0, 0, 0)));
+    }
+}

--- a/flink-table/flink-table-planner/src/test/java/org/apache/flink/table/planner/functions/TimeFunctionsITCase.java
+++ b/flink-table/flink-table-planner/src/test/java/org/apache/flink/table/planner/functions/TimeFunctionsITCase.java
@@ -27,6 +27,8 @@ import java.time.Instant;
 import java.time.LocalDate;
 import java.time.LocalDateTime;
 import java.time.LocalTime;
+import java.time.ZoneId;
+import java.time.ZonedDateTime;
 import java.util.stream.Stream;
 
 import static org.apache.flink.table.api.DataTypes.BIGINT;
@@ -439,8 +441,11 @@ class TimeFunctionsITCase extends BuiltInFunctionTestBase {
                                 // Fractional seconds are lost
                                 LocalTime.of(11, 22, 33),
                                 LocalDate.of(1990, 10, 14),
-                                LocalDateTime.of(2020, 2, 29, 1, 56, 59, 987654321))
-                        .andDataTypes(TIME(), DATE(), TIMESTAMP())
+                                LocalDateTime.of(2020, 2, 29, 1, 56, 59, 987654321),
+                                // DST in EU finishes October 31
+                                ZonedDateTime.of(2021, 10, 25, 0, 0, 0, 0, ZoneId.systemDefault())
+                                        .toInstant())
+                        .andDataTypes(TIME(), DATE(), TIMESTAMP(), TIMESTAMP_LTZ(3))
                         .testResult(
                                 $("f0").ceil(TimeIntervalUnit.MILLISECOND),
                                 "CEIL(f0 TO MILLISECOND)",
@@ -522,6 +527,12 @@ class TimeFunctionsITCase extends BuiltInFunctionTestBase {
                                 LocalDateTime.of(2020, 3, 1, 0, 0),
                                 TIMESTAMP().nullable())
                         .testResult(
+                                $("f3").ceil(TimeIntervalUnit.WEEK),
+                                "CEIL(f3 TO WEEK)",
+                                ZonedDateTime.of(2021, 10, 31, 0, 0, 0, 0, ZoneId.systemDefault())
+                                        .toInstant(),
+                                TIMESTAMP_LTZ(3).nullable())
+                        .testResult(
                                 $("f1").ceil(TimeIntervalUnit.MONTH),
                                 "CEIL(f1 TO MONTH)",
                                 LocalDate.of(1990, 11, 1),
@@ -531,6 +542,12 @@ class TimeFunctionsITCase extends BuiltInFunctionTestBase {
                                 "CEIL(f2 TO MONTH)",
                                 LocalDateTime.of(2020, 3, 1, 0, 0),
                                 TIMESTAMP().nullable())
+                        .testResult(
+                                $("f3").ceil(TimeIntervalUnit.MONTH),
+                                "CEIL(f3 TO MONTH)",
+                                ZonedDateTime.of(2021, 11, 1, 0, 0, 0, 0, ZoneId.systemDefault())
+                                        .toInstant(),
+                                TIMESTAMP_LTZ(3).nullable())
                         .testResult(
                                 $("f1").ceil(TimeIntervalUnit.QUARTER),
                                 "CEIL(f1 TO QUARTER)",
@@ -542,6 +559,12 @@ class TimeFunctionsITCase extends BuiltInFunctionTestBase {
                                 LocalDateTime.of(2020, 4, 1, 0, 0),
                                 TIMESTAMP().nullable())
                         .testResult(
+                                $("f3").ceil(TimeIntervalUnit.QUARTER),
+                                "CEIL(f3 TO QUARTER)",
+                                ZonedDateTime.of(2022, 1, 1, 0, 0, 0, 0, ZoneId.systemDefault())
+                                        .toInstant(),
+                                TIMESTAMP_LTZ(3).nullable())
+                        .testResult(
                                 $("f1").ceil(TimeIntervalUnit.YEAR),
                                 "CEIL(f1 TO YEAR)",
                                 LocalDate.of(1991, 1, 1),
@@ -551,6 +574,12 @@ class TimeFunctionsITCase extends BuiltInFunctionTestBase {
                                 "CEIL(f2 TO YEAR)",
                                 LocalDateTime.of(2021, 1, 1, 0, 0),
                                 TIMESTAMP().nullable())
+                        .testResult(
+                                $("f3").ceil(TimeIntervalUnit.YEAR),
+                                "CEIL(f3 TO YEAR)",
+                                ZonedDateTime.of(2022, 1, 1, 0, 0, 0, 0, ZoneId.systemDefault())
+                                        .toInstant(),
+                                TIMESTAMP_LTZ(3).nullable())
                         .testResult(
                                 $("f1").ceil(TimeIntervalUnit.DECADE),
                                 "CEIL(f1 TO DECADE)",
@@ -562,6 +591,12 @@ class TimeFunctionsITCase extends BuiltInFunctionTestBase {
                                 LocalDateTime.of(2030, 1, 1, 0, 0),
                                 TIMESTAMP().nullable())
                         .testResult(
+                                $("f3").ceil(TimeIntervalUnit.DECADE),
+                                "CEIL(f3 TO DECADE)",
+                                ZonedDateTime.of(2030, 1, 1, 0, 0, 0, 0, ZoneId.systemDefault())
+                                        .toInstant(),
+                                TIMESTAMP_LTZ(3).nullable())
+                        .testResult(
                                 $("f1").ceil(TimeIntervalUnit.CENTURY),
                                 "CEIL(f1 TO CENTURY)",
                                 LocalDate.of(2001, 1, 1),
@@ -572,6 +607,12 @@ class TimeFunctionsITCase extends BuiltInFunctionTestBase {
                                 LocalDateTime.of(2101, 1, 1, 0, 0),
                                 TIMESTAMP().nullable())
                         .testResult(
+                                $("f3").ceil(TimeIntervalUnit.CENTURY),
+                                "CEIL(f3 TO CENTURY)",
+                                ZonedDateTime.of(2101, 1, 1, 0, 0, 0, 0, ZoneId.systemDefault())
+                                        .toInstant(),
+                                TIMESTAMP_LTZ(3).nullable())
+                        .testResult(
                                 $("f1").ceil(TimeIntervalUnit.MILLENNIUM),
                                 "CEIL(f1 TO MILLENNIUM)",
                                 LocalDate.of(2001, 1, 1),
@@ -580,7 +621,13 @@ class TimeFunctionsITCase extends BuiltInFunctionTestBase {
                                 $("f2").ceil(TimeIntervalUnit.MILLENNIUM),
                                 "CEIL(f2 TO MILLENNIUM)",
                                 LocalDateTime.of(3001, 1, 1, 0, 0),
-                                TIMESTAMP().nullable()));
+                                TIMESTAMP().nullable())
+                        .testResult(
+                                $("f3").ceil(TimeIntervalUnit.MILLENNIUM),
+                                "CEIL(f3 TO MILLENNIUM)",
+                                ZonedDateTime.of(3001, 1, 1, 0, 0, 0, 0, ZoneId.systemDefault())
+                                        .toInstant(),
+                                TIMESTAMP_LTZ(3).nullable()));
     }
 
     private Stream<TestSetSpec> floorTestCases() {
@@ -591,8 +638,10 @@ class TimeFunctionsITCase extends BuiltInFunctionTestBase {
                                 // Fractional seconds are lost
                                 LocalTime.of(11, 22, 33),
                                 LocalDate.of(1990, 10, 14),
-                                LocalDateTime.of(2020, 2, 29, 1, 56, 59, 987654321))
-                        .andDataTypes(TIME(), DATE(), TIMESTAMP())
+                                LocalDateTime.of(2020, 2, 29, 1, 56, 59, 987654321),
+                                // DST in the USA started 14.03.2021
+                                Instant.ofEpochSecond(1635000000))
+                        .andDataTypes(TIME(), DATE(), TIMESTAMP(), TIMESTAMP_LTZ(3))
                         .testResult(
                                 $("f0").floor(TimeIntervalUnit.MILLISECOND),
                                 "FLOOR(f0 TO MILLISECOND)",
@@ -674,6 +723,12 @@ class TimeFunctionsITCase extends BuiltInFunctionTestBase {
                                 LocalDateTime.of(2020, 2, 23, 0, 0),
                                 TIMESTAMP().nullable())
                         .testResult(
+                                $("f3").floor(TimeIntervalUnit.WEEK),
+                                "FLOOR(f3 TO WEEK)",
+                                ZonedDateTime.of(2021, 10, 17, 0, 0, 0, 0, ZoneId.systemDefault())
+                                        .toInstant(),
+                                TIMESTAMP_LTZ(3).nullable())
+                        .testResult(
                                 $("f1").floor(TimeIntervalUnit.MONTH),
                                 "FLOOR(f1 TO MONTH)",
                                 LocalDate.of(1990, 10, 1),
@@ -683,6 +738,12 @@ class TimeFunctionsITCase extends BuiltInFunctionTestBase {
                                 "FLOOR(f2 TO MONTH)",
                                 LocalDateTime.of(2020, 2, 1, 0, 0),
                                 TIMESTAMP().nullable())
+                        .testResult(
+                                $("f3").floor(TimeIntervalUnit.MONTH),
+                                "FLOOR(f3 TO MONTH)",
+                                ZonedDateTime.of(2021, 10, 1, 0, 0, 0, 0, ZoneId.systemDefault())
+                                        .toInstant(),
+                                TIMESTAMP_LTZ(3).nullable())
                         .testResult(
                                 $("f1").floor(TimeIntervalUnit.QUARTER),
                                 "FLOOR(f1 TO QUARTER)",
@@ -694,6 +755,12 @@ class TimeFunctionsITCase extends BuiltInFunctionTestBase {
                                 LocalDateTime.of(2020, 1, 1, 0, 0),
                                 TIMESTAMP().nullable())
                         .testResult(
+                                $("f3").floor(TimeIntervalUnit.QUARTER),
+                                "FLOOR(f3 TO QUARTER)",
+                                ZonedDateTime.of(2021, 10, 1, 0, 0, 0, 0, ZoneId.systemDefault())
+                                        .toInstant(),
+                                TIMESTAMP_LTZ(3).nullable())
+                        .testResult(
                                 $("f1").floor(TimeIntervalUnit.YEAR),
                                 "FLOOR(f1 TO YEAR)",
                                 LocalDate.of(1990, 1, 1),
@@ -703,6 +770,12 @@ class TimeFunctionsITCase extends BuiltInFunctionTestBase {
                                 "FLOOR(f2 TO YEAR)",
                                 LocalDateTime.of(2020, 1, 1, 0, 0),
                                 TIMESTAMP().nullable())
+                        .testResult(
+                                $("f3").floor(TimeIntervalUnit.YEAR),
+                                "FLOOR(f3 TO YEAR)",
+                                ZonedDateTime.of(2021, 1, 1, 0, 0, 0, 0, ZoneId.systemDefault())
+                                        .toInstant(),
+                                TIMESTAMP_LTZ(3).nullable())
                         .testResult(
                                 $("f1").floor(TimeIntervalUnit.DECADE),
                                 "FLOOR(f1 TO DECADE)",
@@ -714,6 +787,12 @@ class TimeFunctionsITCase extends BuiltInFunctionTestBase {
                                 LocalDateTime.of(2020, 1, 1, 0, 0),
                                 TIMESTAMP().nullable())
                         .testResult(
+                                $("f3").floor(TimeIntervalUnit.DECADE),
+                                "FLOOR(f3 TO DECADE)",
+                                ZonedDateTime.of(2020, 1, 1, 0, 0, 0, 0, ZoneId.systemDefault())
+                                        .toInstant(),
+                                TIMESTAMP_LTZ(3).nullable())
+                        .testResult(
                                 $("f1").floor(TimeIntervalUnit.CENTURY),
                                 "FLOOR(f1 TO CENTURY)",
                                 LocalDate.of(1901, 1, 1),
@@ -724,6 +803,12 @@ class TimeFunctionsITCase extends BuiltInFunctionTestBase {
                                 LocalDateTime.of(2001, 1, 1, 0, 0),
                                 TIMESTAMP().nullable())
                         .testResult(
+                                $("f3").floor(TimeIntervalUnit.CENTURY),
+                                "FLOOR(f3 TO CENTURY)",
+                                ZonedDateTime.of(2001, 1, 1, 0, 0, 0, 0, ZoneId.systemDefault())
+                                        .toInstant(),
+                                TIMESTAMP_LTZ(3).nullable())
+                        .testResult(
                                 $("f1").floor(TimeIntervalUnit.MILLENNIUM),
                                 "FLOOR(f1 TO MILLENNIUM)",
                                 LocalDate.of(1001, 1, 1),
@@ -732,6 +817,12 @@ class TimeFunctionsITCase extends BuiltInFunctionTestBase {
                                 $("f2").floor(TimeIntervalUnit.MILLENNIUM),
                                 "FLOOR(f2 TO MILLENNIUM)",
                                 LocalDateTime.of(2001, 1, 1, 0, 0),
-                                TIMESTAMP().nullable()));
+                                TIMESTAMP().nullable())
+                        .testResult(
+                                $("f3").floor(TimeIntervalUnit.MILLENNIUM),
+                                "FLOOR(f3 TO MILLENNIUM)",
+                                ZonedDateTime.of(2001, 1, 1, 0, 0, 0, 0, ZoneId.systemDefault())
+                                        .toInstant(),
+                                TIMESTAMP_LTZ(3).nullable()));
     }
 }


### PR DESCRIPTION

## What is the purpose of the change
The PR makes `org.apache.flink.table.utils.DateTimeUtils#timestampCeil` and `org.apache.flink.table.utils.DateTimeUtils#timestampFloor` respecting DST


## Verifying this change

There is `org.apache.flink.table.utils.DateTimeUtilsTest` introduced

## Does this pull request potentially affect one of the following parts:

  - Dependencies (does it add or upgrade a dependency): (yes / **no**)
  - The public API, i.e., is any changed class annotated with `@Public(Evolving)`: (yes / **no**)
  - The serializers: (yes / **no** / don't know)
  - The runtime per-record code paths (performance sensitive): (yes / **no** / don't know)
  - Anything that affects deployment or recovery: JobManager (and its components), Checkpointing, Kubernetes/Yarn, ZooKeeper: (yes / **no** / don't know)
  - The S3 file system connector: (yes / **no** / don't know)

## Documentation

  - Does this pull request introduce a new feature? (yes / **no**)
  - If yes, how is the feature documented? (**not applicable** / docs / JavaDocs / not documented)
