### PR TITLE
[FLINK-24630][avro] Implement row projection in AvroToRowDataConverters#createRowConverter

### DIFF
--- a/flink-formats/flink-avro/src/main/java/org/apache/flink/formats/avro/AvroFileSystemFormatFactory.java
+++ b/flink-formats/flink-avro/src/main/java/org/apache/flink/formats/avro/AvroFileSystemFormatFactory.java
@@ -28,6 +28,7 @@ import org.apache.flink.table.data.GenericRowData;
 import org.apache.flink.table.data.RowData;
 import org.apache.flink.table.factories.FileSystemFormatFactory;
 import org.apache.flink.table.types.DataType;
+import org.apache.flink.table.types.logical.LogicalType;
 import org.apache.flink.table.types.logical.RowType;
 import org.apache.flink.table.utils.PartitionPathUtils;
 
@@ -41,7 +42,6 @@ import java.util.Arrays;
 import java.util.HashSet;
 import java.util.List;
 import java.util.Set;
-import java.util.stream.Collectors;
 
 import static org.apache.flink.formats.avro.AvroFormatOptions.AVRO_OUTPUT_CODEC;
 
@@ -70,35 +70,15 @@ public class AvroFileSystemFormatFactory implements FileSystemFormatFactory {
 
     @Override
     public InputFormat<RowData, ?> createReader(ReaderContext context) {
-        String[] fieldNames = context.getSchema().getFieldNames();
-        List<String> projectFields =
-                Arrays.stream(context.getProjectFields())
-                        .mapToObj(idx -> fieldNames[idx])
-                        .collect(Collectors.toList());
-        List<String> csvFields =
-                Arrays.stream(fieldNames)
-                        .filter(field -> !context.getPartitionKeys().contains(field))
-                        .collect(Collectors.toList());
-
-        int[] selectFieldToProjectField =
-                context.getFormatProjectFields().stream()
-                        .mapToInt(projectFields::indexOf)
-                        .toArray();
-        int[] selectFieldToFormatField =
-                context.getFormatProjectFields().stream().mapToInt(csvFields::indexOf).toArray();
-
         //noinspection unchecked
         return new RowDataAvroInputFormat(
                 context.getPaths(),
                 context.getFormatRowType(),
-                context.getSchema().getFieldDataTypes(),
-                context.getSchema().getFieldNames(),
+                context.getSchema().toRowDataType(),
                 context.getProjectFields(),
                 context.getPartitionKeys(),
                 context.getDefaultPartName(),
-                context.getPushedDownLimit(),
-                selectFieldToProjectField,
-                selectFieldToFormatField);
+                context.getPushedDownLimit());
     }
 
     /**
@@ -111,14 +91,11 @@ public class AvroFileSystemFormatFactory implements FileSystemFormatFactory {
 
         private static final long serialVersionUID = 1L;
 
-        private final DataType[] fieldTypes;
-        private final String[] fieldNames;
+        private final DataType schemaRowDataType;
         private final int[] selectFields;
         private final List<String> partitionKeys;
         private final String defaultPartValue;
         private final long limit;
-        private final int[] selectFieldToProjectField;
-        private final int[] selectFieldToFormatField;
         private final RowType formatRowType;
 
         private transient long emitted;
@@ -130,26 +107,20 @@ public class AvroFileSystemFormatFactory implements FileSystemFormatFactory {
         public RowDataAvroInputFormat(
                 Path[] filePaths,
                 RowType formatRowType,
-                DataType[] fieldTypes,
-                String[] fieldNames,
+                DataType schemaRowDataType,
                 int[] selectFields,
                 List<String> partitionKeys,
                 String defaultPartValue,
-                long limit,
-                int[] selectFieldToProjectField,
-                int[] selectFieldToFormatField) {
+                long limit) {
             super(filePaths[0], GenericRecord.class);
             super.setFilePaths(filePaths);
             this.formatRowType = formatRowType;
-            this.fieldTypes = fieldTypes;
-            this.fieldNames = fieldNames;
+            this.schemaRowDataType = schemaRowDataType;
             this.partitionKeys = partitionKeys;
             this.defaultPartValue = defaultPartValue;
             this.selectFields = selectFields;
             this.limit = limit;
             this.emitted = 0;
-            this.selectFieldToProjectField = selectFieldToProjectField;
-            this.selectFieldToFormatField = selectFieldToFormatField;
         }
 
         @Override
@@ -157,15 +128,31 @@ public class AvroFileSystemFormatFactory implements FileSystemFormatFactory {
             super.open(split);
             Schema schema = AvroSchemaConverter.convertToSchema(formatRowType);
             record = new GenericData.Record(schema);
+
+            String[] fieldNames =
+                    ((RowType) schemaRowDataType.getLogicalType())
+                            .getFieldNames()
+                            .toArray(new String[0]);
+            DataType[] fieldDataTypes = schemaRowDataType.getChildren().toArray(new DataType[0]);
             rowData =
                     PartitionPathUtils.fillPartitionValueForRecord(
                             fieldNames,
-                            fieldTypes,
+                            fieldDataTypes,
                             selectFields,
                             partitionKeys,
                             currentSplit.getPath(),
                             defaultPartValue);
-            this.converter = AvroToRowDataConverters.createRowConverter(formatRowType);
+
+            RowType producedRowType =
+                    RowType.of(
+                            Arrays.stream(selectFields)
+                                    .mapToObj(i -> fieldDataTypes[i].getLogicalType())
+                                    .toArray(LogicalType[]::new),
+                            Arrays.stream(selectFields)
+                                    .mapToObj(i -> fieldNames[i])
+                                    .toArray(String[]::new));
+            this.converter =
+                    AvroToRowDataConverters.createRowConverter(producedRowType, formatRowType);
         }
 
         @Override
@@ -180,12 +167,7 @@ public class AvroFileSystemFormatFactory implements FileSystemFormatFactory {
             if (r == null) {
                 return null;
             }
-            GenericRowData row = (GenericRowData) converter.convert(r);
-
-            for (int i = 0; i < selectFieldToFormatField.length; i++) {
-                rowData.setField(
-                        selectFieldToProjectField[i], row.getField(selectFieldToFormatField[i]));
-            }
+            converter.convert(r, rowData);
             emitted++;
             return rowData;
         }

--- a/flink-formats/flink-avro/src/test/java/org/apache/flink/formats/avro/AvroToRowDataConvertersTest.java
+++ b/flink-formats/flink-avro/src/test/java/org/apache/flink/formats/avro/AvroToRowDataConvertersTest.java
@@ -1,0 +1,69 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.flink.formats.avro;
+
+import org.apache.flink.formats.avro.typeutils.AvroSchemaConverter;
+import org.apache.flink.table.api.DataTypes;
+import org.apache.flink.table.data.GenericRowData;
+import org.apache.flink.table.data.StringData;
+import org.apache.flink.table.types.logical.LogicalType;
+import org.apache.flink.table.types.logical.RowType;
+
+import org.apache.avro.Schema;
+import org.apache.avro.generic.GenericRecord;
+import org.junit.Assert;
+import org.junit.Test;
+
+/** Tests for {@link AvroToRowDataConverters}. */
+public class AvroToRowDataConvertersTest {
+
+    @Test
+    public void testCreateRowConverter() {
+        GenericRowData input = GenericRowData.of(1, StringData.fromString("test"), true, 10.26);
+        RowType rowType =
+                RowType.of(
+                        new LogicalType[] {
+                            DataTypes.INT().getLogicalType(),
+                            DataTypes.STRING().getLogicalType(),
+                            DataTypes.BOOLEAN().getLogicalType(),
+                            DataTypes.DOUBLE().getLogicalType()
+                        },
+                        new String[] {"a", "b", "c", "d"});
+        Schema schema = AvroSchemaConverter.convertToSchema(rowType);
+        GenericRecord avroRecord =
+                (GenericRecord)
+                        RowDataToAvroConverters.createConverter(rowType).convert(schema, input);
+
+        Assert.assertEquals(
+                input, AvroToRowDataConverters.createRowConverter(rowType).convert(avroRecord));
+
+        GenericRowData projectedRow = GenericRowData.of(true, StringData.fromString("test"));
+        RowType projectedRowType =
+                RowType.of(
+                        new LogicalType[] {
+                            DataTypes.BOOLEAN().getLogicalType(),
+                            DataTypes.STRING().getLogicalType()
+                        },
+                        new String[] {"c", "b"});
+        Assert.assertEquals(
+                projectedRow,
+                AvroToRowDataConverters.createRowConverter(projectedRowType, rowType)
+                        .convert(avroRecord));
+    }
+}


### PR DESCRIPTION
## What is the purpose of the change

Currently `AvroToRowDataConverters#createRowConverter` converts avro records to Flink row data directly without any projection. However users of this method, such as `AvroFileSystemFormatFactory.RowDataAvroInputFormat`, need to implement their own projection logic to filter out the columns they needed.

This PR hides the logic of implementation in `AvroToRowDataConverters#createRowConverter` both for optimization (users do not need to copy the row for this) and for the ease of coding.

## Brief change log

 - Implement row projection in `AvroToRowDataConverters#createRowConverter`.

## Verifying this change

This change is already covered by existing tests, such as *AvroFilesystemITCase*. This change also added tests.

## Does this pull request potentially affect one of the following parts:

  - Dependencies (does it add or upgrade a dependency): no
  - The public API, i.e., is any changed class annotated with `@Public(Evolving)`: no
  - The serializers: no
  - The runtime per-record code paths (performance sensitive): no
  - Anything that affects deployment or recovery: JobManager (and its components), Checkpointing, Kubernetes/Yarn, ZooKeeper: no
  - The S3 file system connector: no

## Documentation

  - Does this pull request introduce a new feature? no
  - If yes, how is the feature documented? not applicable
