### PR TITLE
[FLINK-24647][runtime/coordination] Log thrown exception if UncaughtE…

### DIFF
--- a/flink-runtime/src/main/java/org/apache/flink/runtime/util/ClusterUncaughtExceptionHandler.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/util/ClusterUncaughtExceptionHandler.java
@@ -45,7 +45,8 @@ public class ClusterUncaughtExceptionHandler implements Thread.UncaughtException
             LOG.error(
                     "WARNING: Thread '{}' produced an uncaught exception. If you want to fail on uncaught exceptions, then configure {} accordingly",
                     t.getName(),
-                    ClusterOptions.UNCAUGHT_EXCEPTION_HANDLING.key());
+                    ClusterOptions.UNCAUGHT_EXCEPTION_HANDLING.key(),
+                    e);
         } else { // by default, fail the job
             FatalExitExceptionHandler.INSTANCE.uncaughtException(t, e);
         }


### PR DESCRIPTION
…xceptionHandleMode.LOG is set
 Unchanged backport of #17567 