### PR TITLE
[FLINK-24665][s3] Update Presto Hadoop dependency to v2.7.4-9

### DIFF
--- a/flink-filesystems/flink-s3-fs-presto/pom.xml
+++ b/flink-filesystems/flink-s3-fs-presto/pom.xml
@@ -273,7 +273,7 @@ under the License.
 		<dependency>
 			<groupId>com.facebook.presto.hadoop</groupId>
 			<artifactId>hadoop-apache2</artifactId>
-			<version>2.7.3-1</version>
+			<version>2.7.4-9</version>
 		</dependency>
 
 		<dependency>

--- a/flink-filesystems/flink-s3-fs-presto/src/main/resources/META-INF/NOTICE
+++ b/flink-filesystems/flink-s3-fs-presto/src/main/resources/META-INF/NOTICE
@@ -21,7 +21,7 @@ This project bundles the following dependencies under the Apache Software Licens
 - com.facebook.presto:presto-hive:0.257
 - com.facebook.presto:presto-hive-common:0.257
 - com.facebook.presto:presto-hive-metastore:0.257
-- com.facebook.presto.hadoop:hadoop-apache2:2.7.3-1
+- com.facebook.presto.hadoop:hadoop-apache2:2.7.4-9
 - com.fasterxml.jackson.core:jackson-annotations:2.13.0
 - com.fasterxml.jackson.core:jackson-core:2.13.0
 - com.fasterxml.jackson.core:jackson-databind:2.13.0


### PR DESCRIPTION
## What is the purpose of the change

* Update hadoop-apache2 dependency for Presto Hadoop

## Brief change log

* Upgraded com.facebook.presto.hadoop:hadoop-apache2 from 2.7.3-1 to 2.7.4-9

## Verifying this change

This change is a trivial rework / code cleanup without any test coverage.

## Does this pull request potentially affect one of the following parts:

  - Dependencies (does it add or upgrade a dependency): (**yes** / no)
  - The public API, i.e., is any changed class annotated with `@Public(Evolving)`: (yes / **no**)
  - The serializers: (yes / **no** / don't know)
  - The runtime per-record code paths (performance sensitive): (yes / **no** / don't know)
  - Anything that affects deployment or recovery: JobManager (and its components), Checkpointing, Kubernetes/Yarn, ZooKeeper: (yes / **no** / don't know)
  - The S3 file system connector: (**yes** / no / don't know)

## Documentation

  - Does this pull request introduce a new feature? (yes / **no**)
  - If yes, how is the feature documented? (**not applicable** / docs / JavaDocs / not documented)
