### PR TITLE
[FLINK-24208][rest] Support user-supplied Savepoint triggerId

### DIFF
--- a/docs/content/docs/ops/rest_api.md
+++ b/docs/content/docs/ops/rest_api.md
@@ -66,6 +66,13 @@ Querying unsupported/non-existing versions will return a 404 error.
 
 There exist several async operations among these APIs, e.g. `trigger savepoint`, `rescale a job`. They would return a `triggerid` to identify the operation you just POST and then you need to use that `triggerid` to query for the status of the operation.
 
+For (stop-with-)savepoint operations you can control this `triggerId` by setting it in the body of the request that triggers the operation.
+This allow you to safely* retry such operations without triggering multiple savepoints.
+
+{{< hint info >}}
+The retry is only safe until the [async operation store duration]({{< ref "docs/deployment/config#rest-async-store-duration" >}}) has elapsed.
+{{</ hint >}}
+
 {{< tabs "f00ed142-b05f-44f0-bafc-799080c1d40d" >}}
 {{< tab "v1" >}}
 #### JobManager

--- a/docs/layouts/shortcodes/generated/rest_v1_dispatcher.html
+++ b/docs/layouts/shortcodes/generated/rest_v1_dispatcher.html
@@ -3260,6 +3260,9 @@ Using 'curl' you can upload a jar via 'curl -X POST -H "Expect:" -F "jarfile=@pa
     },
     "target-directory" : {
       "type" : "string"
+    },
+    "triggerId" : {
+      "type" : "any"
     }
   }
 }            </code>
@@ -3432,6 +3435,9 @@ Using 'curl' you can upload a jar via 'curl -X POST -H "Expect:" -F "jarfile=@pa
     },
     "targetDirectory" : {
       "type" : "string"
+    },
+    "triggerId" : {
+      "type" : "any"
     }
   }
 }            </code>

--- a/docs/layouts/shortcodes/generated/rest_v1_dispatcher.html
+++ b/docs/layouts/shortcodes/generated/rest_v1_dispatcher.html
@@ -2202,6 +2202,9 @@ Using 'curl' you can upload a jar via 'curl -X POST -H "Expect:" -F "jarfile=@pa
     "checkpoint_storage" : {
       "type" : "string"
     },
+    "checkpoints_after_tasks_finish" : {
+      "type" : "boolean"
+    },
     "externalization" : {
       "type" : "object",
       "id" : "urn:jsonschema:org:apache:flink:runtime:rest:messages:checkpoints:CheckpointConfigInfo:ExternalizedCheckpointInfo",
@@ -2236,9 +2239,6 @@ Using 'curl' you can upload a jar via 'curl -X POST -H "Expect:" -F "jarfile=@pa
       "type" : "integer"
     },
     "unaligned_checkpoints" : {
-      "type" : "boolean"
-    },
-    "checkpoints_after_tasks_finish" : {
       "type" : "boolean"
     }
   }

--- a/flink-clients/src/main/java/org/apache/flink/client/program/rest/RestClusterClient.java
+++ b/flink-clients/src/main/java/org/apache/flink/client/program/rest/RestClusterClient.java
@@ -463,7 +463,8 @@ public class RestClusterClient<T> implements ClusterClient<T> {
                 sendRequest(
                         stopWithSavepointTriggerHeaders,
                         stopWithSavepointTriggerMessageParameters,
-                        new StopWithSavepointRequestBody(savepointDirectory, advanceToEndOfTime));
+                        new StopWithSavepointRequestBody(
+                                savepointDirectory, advanceToEndOfTime, null));
 
         return responseFuture
                 .thenCompose(
@@ -536,7 +537,7 @@ public class RestClusterClient<T> implements ClusterClient<T> {
                 sendRequest(
                         savepointTriggerHeaders,
                         savepointTriggerMessageParameters,
-                        new SavepointTriggerRequestBody(savepointDirectory, cancelJob));
+                        new SavepointTriggerRequestBody(savepointDirectory, cancelJob, null));
 
         return responseFuture
                 .thenCompose(

--- a/flink-clients/src/test/java/org/apache/flink/client/program/rest/RestClusterClientSavepointTriggerTest.java
+++ b/flink-clients/src/test/java/org/apache/flink/client/program/rest/RestClusterClientSavepointTriggerTest.java
@@ -70,11 +70,11 @@ import java.util.concurrent.ExecutorService;
 import java.util.concurrent.Executors;
 import java.util.concurrent.atomic.AtomicBoolean;
 
+import static org.hamcrest.CoreMatchers.is;
 import static org.hamcrest.Matchers.equalTo;
 import static org.hamcrest.Matchers.instanceOf;
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertFalse;
-import static org.junit.Assert.assertNull;
 import static org.junit.Assert.assertThat;
 import static org.junit.Assert.assertTrue;
 
@@ -129,7 +129,7 @@ public class RestClusterClientSavepointTriggerTest extends TestLogger {
         try (final RestServerEndpoint restServerEndpoint =
                 createRestServerEndpoint(
                         request -> {
-                            assertNull(request.getTargetDirectory());
+                            assertThat(request.getTargetDirectory().isPresent(), is(false));
                             assertFalse(request.isCancelJob());
                             return triggerId;
                         },
@@ -158,7 +158,7 @@ public class RestClusterClientSavepointTriggerTest extends TestLogger {
                         triggerRequestBody -> {
                             assertEquals(
                                     expectedSubmittedSavepointDir,
-                                    triggerRequestBody.getTargetDirectory());
+                                    triggerRequestBody.getTargetDirectory().get());
                             assertFalse(triggerRequestBody.isCancelJob());
                             return triggerId;
                         },

--- a/flink-runtime-web/src/test/resources/rest_api_v1.snapshot
+++ b/flink-runtime-web/src/test/resources/rest_api_v1.snapshot
@@ -1874,6 +1874,9 @@
         },
         "cancel-job" : {
           "type" : "boolean"
+        },
+        "triggerId" : {
+          "type" : "any"
         }
       }
     },
@@ -1946,6 +1949,9 @@
         },
         "drain" : {
           "type" : "boolean"
+        },
+        "triggerId" : {
+          "type" : "any"
         }
       }
     },

--- a/flink-runtime-web/src/test/resources/rest_api_v1.snapshot
+++ b/flink-runtime-web/src/test/resources/rest_api_v1.snapshot
@@ -1277,7 +1277,7 @@
           "type" : "integer"
         },
         "checkpoints_after_tasks_finish" : {
-           "type" : "boolean"
+          "type" : "boolean"
         }
       }
     }

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/rest/handler/job/savepoints/SavepointHandlers.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/rest/handler/job/savepoints/SavepointHandlers.java
@@ -179,9 +179,10 @@ public class SavepointHandlers {
                 AsynchronousJobOperationKey operationKey,
                 final RestfulGateway gateway)
                 throws RestHandlerException {
-            final String requestedTargetDirectory = request.getRequestBody().getTargetDirectory();
+            final Optional<String> requestedTargetDirectory =
+                    request.getRequestBody().getTargetDirectory();
 
-            if (requestedTargetDirectory == null && defaultSavepointDir == null) {
+            if (!requestedTargetDirectory.isPresent() && defaultSavepointDir == null) {
                 throw new RestHandlerException(
                         String.format(
                                 "Config key [%s] is not set. Property [%s] must be provided.",
@@ -194,10 +195,7 @@ public class SavepointHandlers {
                     request.getRequestBody().shouldDrain()
                             ? TriggerSavepointMode.TERMINATE_WITH_SAVEPOINT
                             : TriggerSavepointMode.SUSPEND_WITH_SAVEPOINT;
-            final String targetDirectory =
-                    requestedTargetDirectory != null
-                            ? requestedTargetDirectory
-                            : defaultSavepointDir;
+            final String targetDirectory = requestedTargetDirectory.orElse(defaultSavepointDir);
             return gateway.stopWithSavepoint(
                     operationKey, targetDirectory, savepointMode, RpcUtils.INF_TIMEOUT);
         }
@@ -224,9 +222,10 @@ public class SavepointHandlers {
                 AsynchronousJobOperationKey operationKey,
                 RestfulGateway gateway)
                 throws RestHandlerException {
-            final String requestedTargetDirectory = request.getRequestBody().getTargetDirectory();
+            final Optional<String> requestedTargetDirectory =
+                    request.getRequestBody().getTargetDirectory();
 
-            if (requestedTargetDirectory == null && defaultSavepointDir == null) {
+            if (!requestedTargetDirectory.isPresent() && defaultSavepointDir == null) {
                 throw new RestHandlerException(
                         String.format(
                                 "Config key [%s] is not set. Property [%s] must be provided.",
@@ -239,10 +238,7 @@ public class SavepointHandlers {
                     request.getRequestBody().isCancelJob()
                             ? TriggerSavepointMode.CANCEL_WITH_SAVEPOINT
                             : TriggerSavepointMode.SAVEPOINT;
-            final String targetDirectory =
-                    requestedTargetDirectory != null
-                            ? requestedTargetDirectory
-                            : defaultSavepointDir;
+            final String targetDirectory = requestedTargetDirectory.orElse(defaultSavepointDir);
             return gateway.triggerSavepoint(
                     operationKey, targetDirectory, savepointMode, RpcUtils.INF_TIMEOUT);
         }

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/rest/handler/job/savepoints/SavepointHandlers.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/rest/handler/job/savepoints/SavepointHandlers.java
@@ -54,6 +54,7 @@ import javax.annotation.Nonnull;
 import javax.annotation.Nullable;
 
 import java.util.Map;
+import java.util.Optional;
 import java.util.concurrent.CompletableFuture;
 
 /**
@@ -130,8 +131,11 @@ public class SavepointHandlers {
 
         protected AsynchronousJobOperationKey createOperationKey(final HandlerRequest<B> request) {
             final JobID jobId = request.getPathParameter(JobIDPathParameter.class);
-            return AsynchronousJobOperationKey.of(new TriggerId(), jobId);
+            return AsynchronousJobOperationKey.of(
+                    extractTriggerId(request.getRequestBody()).orElseGet(TriggerId::new), jobId);
         }
+
+        protected abstract Optional<TriggerId> extractTriggerId(B request);
 
         public CompletableFuture<TriggerResponse> handleRequest(
                 @Nonnull HandlerRequest<B> request, @Nonnull RestfulGateway gateway)
@@ -162,6 +166,11 @@ public class SavepointHandlers {
                     timeout,
                     responseHeaders,
                     StopWithSavepointTriggerHeaders.getInstance());
+        }
+
+        @Override
+        protected Optional<TriggerId> extractTriggerId(StopWithSavepointRequestBody request) {
+            return request.getTriggerId();
         }
 
         @Override
@@ -202,6 +211,11 @@ public class SavepointHandlers {
                 final Time timeout,
                 final Map<String, String> responseHeaders) {
             super(leaderRetriever, timeout, responseHeaders, SavepointTriggerHeaders.getInstance());
+        }
+
+        @Override
+        protected Optional<TriggerId> extractTriggerId(SavepointTriggerRequestBody request) {
+            return request.getTriggerId();
         }
 
         @Override

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/rest/messages/job/savepoints/SavepointTriggerRequestBody.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/rest/messages/job/savepoints/SavepointTriggerRequestBody.java
@@ -59,9 +59,9 @@ public class SavepointTriggerRequestBody implements RequestBody {
         this.triggerId = triggerId;
     }
 
-    @Nullable
-    public String getTargetDirectory() {
-        return targetDirectory;
+    @JsonIgnore
+    public Optional<String> getTargetDirectory() {
+        return Optional.ofNullable(targetDirectory);
     }
 
     @JsonIgnore

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/rest/messages/job/savepoints/SavepointTriggerRequestBody.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/rest/messages/job/savepoints/SavepointTriggerRequestBody.java
@@ -19,11 +19,15 @@
 package org.apache.flink.runtime.rest.messages.job.savepoints;
 
 import org.apache.flink.runtime.rest.messages.RequestBody;
+import org.apache.flink.runtime.rest.messages.TriggerId;
 
 import org.apache.flink.shaded.jackson2.com.fasterxml.jackson.annotation.JsonCreator;
+import org.apache.flink.shaded.jackson2.com.fasterxml.jackson.annotation.JsonIgnore;
 import org.apache.flink.shaded.jackson2.com.fasterxml.jackson.annotation.JsonProperty;
 
 import javax.annotation.Nullable;
+
+import java.util.Optional;
 
 /** {@link RequestBody} to trigger savepoints. */
 public class SavepointTriggerRequestBody implements RequestBody {
@@ -32,6 +36,8 @@ public class SavepointTriggerRequestBody implements RequestBody {
 
     private static final String FIELD_NAME_CANCEL_JOB = "cancel-job";
 
+    private static final String FIELD_NAME_TRIGGER_ID = "triggerId";
+
     @JsonProperty(FIELD_NAME_TARGET_DIRECTORY)
     @Nullable
     private final String targetDirectory;
@@ -39,17 +45,28 @@ public class SavepointTriggerRequestBody implements RequestBody {
     @JsonProperty(FIELD_NAME_CANCEL_JOB)
     private final boolean cancelJob;
 
+    @JsonProperty(FIELD_NAME_TRIGGER_ID)
+    @Nullable
+    private final TriggerId triggerId;
+
     @JsonCreator
     public SavepointTriggerRequestBody(
             @Nullable @JsonProperty(FIELD_NAME_TARGET_DIRECTORY) final String targetDirectory,
-            @Nullable @JsonProperty(FIELD_NAME_CANCEL_JOB) final Boolean cancelJob) {
+            @Nullable @JsonProperty(FIELD_NAME_CANCEL_JOB) final Boolean cancelJob,
+            @Nullable @JsonProperty(FIELD_NAME_TRIGGER_ID) TriggerId triggerId) {
         this.targetDirectory = targetDirectory;
         this.cancelJob = cancelJob != null ? cancelJob : false;
+        this.triggerId = triggerId;
     }
 
     @Nullable
     public String getTargetDirectory() {
         return targetDirectory;
+    }
+
+    @JsonIgnore
+    public Optional<TriggerId> getTriggerId() {
+        return Optional.ofNullable(triggerId);
     }
 
     public boolean isCancelJob() {

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/rest/messages/job/savepoints/stop/StopWithSavepointRequestBody.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/rest/messages/job/savepoints/stop/StopWithSavepointRequestBody.java
@@ -19,11 +19,15 @@
 package org.apache.flink.runtime.rest.messages.job.savepoints.stop;
 
 import org.apache.flink.runtime.rest.messages.RequestBody;
+import org.apache.flink.runtime.rest.messages.TriggerId;
 
 import org.apache.flink.shaded.jackson2.com.fasterxml.jackson.annotation.JsonCreator;
+import org.apache.flink.shaded.jackson2.com.fasterxml.jackson.annotation.JsonIgnore;
 import org.apache.flink.shaded.jackson2.com.fasterxml.jackson.annotation.JsonProperty;
 
 import javax.annotation.Nullable;
+
+import java.util.Optional;
 
 /** {@link RequestBody} for stopping a job with a savepoint. */
 public class StopWithSavepointRequestBody implements RequestBody {
@@ -32,6 +36,8 @@ public class StopWithSavepointRequestBody implements RequestBody {
 
     private static final String FIELD_NAME_DRAIN = "drain";
 
+    private static final String FIELD_NAME_TRIGGER_ID = "triggerId";
+
     @JsonProperty(FIELD_NAME_TARGET_DIRECTORY)
     @Nullable
     private final String targetDirectory;
@@ -39,12 +45,18 @@ public class StopWithSavepointRequestBody implements RequestBody {
     @JsonProperty(FIELD_NAME_DRAIN)
     private final boolean drain;
 
+    @JsonProperty(FIELD_NAME_TRIGGER_ID)
+    @Nullable
+    private final TriggerId triggerId;
+
     @JsonCreator
     public StopWithSavepointRequestBody(
             @Nullable @JsonProperty(FIELD_NAME_TARGET_DIRECTORY) final String targetDirectory,
-            @Nullable @JsonProperty(FIELD_NAME_DRAIN) final Boolean drain) {
+            @Nullable @JsonProperty(FIELD_NAME_DRAIN) final Boolean drain,
+            @Nullable @JsonProperty(FIELD_NAME_TRIGGER_ID) TriggerId triggerId) {
         this.targetDirectory = targetDirectory;
         this.drain = drain != null ? drain : false;
+        this.triggerId = triggerId;
     }
 
     @Nullable
@@ -54,5 +66,10 @@ public class StopWithSavepointRequestBody implements RequestBody {
 
     public boolean shouldDrain() {
         return drain;
+    }
+
+    @JsonIgnore
+    public Optional<TriggerId> getTriggerId() {
+        return Optional.ofNullable(triggerId);
     }
 }

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/rest/messages/job/savepoints/stop/StopWithSavepointRequestBody.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/rest/messages/job/savepoints/stop/StopWithSavepointRequestBody.java
@@ -59,9 +59,9 @@ public class StopWithSavepointRequestBody implements RequestBody {
         this.triggerId = triggerId;
     }
 
-    @Nullable
-    public String getTargetDirectory() {
-        return targetDirectory;
+    @JsonIgnore
+    public Optional<String> getTargetDirectory() {
+        return Optional.ofNullable(targetDirectory);
     }
 
     public boolean shouldDrain() {

--- a/flink-runtime/src/test/java/org/apache/flink/runtime/rest/handler/job/savepoints/SavepointHandlersTest.java
+++ b/flink-runtime/src/test/java/org/apache/flink/runtime/rest/handler/job/savepoints/SavepointHandlersTest.java
@@ -46,6 +46,8 @@ import org.apache.flink.shaded.netty4.io.netty.handler.codec.http.HttpResponseSt
 import org.junit.Before;
 import org.junit.Test;
 
+import javax.annotation.Nullable;
+
 import java.util.Collections;
 import java.util.HashMap;
 import java.util.Map;
@@ -57,6 +59,7 @@ import static org.apache.flink.runtime.rest.handler.job.savepoints.SavepointTest
 import static org.hamcrest.Matchers.equalTo;
 import static org.hamcrest.Matchers.instanceOf;
 import static org.hamcrest.Matchers.notNullValue;
+import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertThat;
 import static org.junit.Assert.fail;
 
@@ -208,20 +211,61 @@ public class SavepointHandlersTest extends TestLogger {
         assertThat(savepointError, instanceOf(RuntimeException.class));
     }
 
+    @Test
+    public void testProvidedTriggerId() throws Exception {
+        final OperationResult<String> successfulResult =
+                OperationResult.success(COMPLETED_SAVEPOINT_EXTERNAL_POINTER);
+        AtomicReference<AsynchronousJobOperationKey> keyReference = new AtomicReference<>();
+        final TestingRestfulGateway testingRestfulGateway =
+                new TestingRestfulGateway.Builder()
+                        .setTriggerSavepointFunction(setReferenceToOperationKey(keyReference))
+                        .setGetSavepointStatusFunction(
+                                getResultIfKeyMatches(successfulResult, keyReference))
+                        .build();
+
+        final TriggerId providedTriggerId = new TriggerId();
+
+        final TriggerId returnedTriggerId =
+                savepointTriggerHandler
+                        .handleRequest(
+                                triggerSavepointRequest(
+                                        DEFAULT_REQUESTED_SAVEPOINT_TARGET_DIRECTORY,
+                                        providedTriggerId),
+                                testingRestfulGateway)
+                        .get()
+                        .getTriggerId();
+
+        assertEquals(providedTriggerId, returnedTriggerId);
+
+        AsynchronousOperationResult<SavepointInfo> savepointResponseBody;
+        savepointResponseBody =
+                savepointStatusHandler
+                        .handleRequest(
+                                savepointStatusRequest(providedTriggerId), testingRestfulGateway)
+                        .get();
+
+        assertThat(savepointResponseBody.queueStatus().getId(), equalTo(QueueStatus.Id.COMPLETED));
+        assertThat(savepointResponseBody.resource(), notNullValue());
+        assertThat(
+                savepointResponseBody.resource().getLocation(),
+                equalTo(COMPLETED_SAVEPOINT_EXTERNAL_POINTER));
+    }
+
     private static HandlerRequest<SavepointTriggerRequestBody> triggerSavepointRequest()
             throws HandlerRequestException {
-        return triggerSavepointRequest(DEFAULT_REQUESTED_SAVEPOINT_TARGET_DIRECTORY);
+        return triggerSavepointRequest(DEFAULT_REQUESTED_SAVEPOINT_TARGET_DIRECTORY, null);
     }
 
     private static HandlerRequest<SavepointTriggerRequestBody>
             triggerSavepointRequestWithDefaultDirectory() throws HandlerRequestException {
-        return triggerSavepointRequest(null);
+        return triggerSavepointRequest(null, null);
     }
 
     private static HandlerRequest<SavepointTriggerRequestBody> triggerSavepointRequest(
-            final String targetDirectory) throws HandlerRequestException {
+            final String targetDirectory, @Nullable TriggerId triggerId)
+            throws HandlerRequestException {
         return HandlerRequest.resolveParametersAndCreate(
-                new SavepointTriggerRequestBody(targetDirectory, false),
+                new SavepointTriggerRequestBody(targetDirectory, false, triggerId),
                 new SavepointTriggerMessageParameters(),
                 Collections.singletonMap(JobIDPathParameter.KEY, JOB_ID.toString()),
                 Collections.emptyMap(),

--- a/flink-runtime/src/test/java/org/apache/flink/runtime/rest/handler/job/savepoints/SavepointHandlersTest.java
+++ b/flink-runtime/src/test/java/org/apache/flink/runtime/rest/handler/job/savepoints/SavepointHandlersTest.java
@@ -262,7 +262,7 @@ public class SavepointHandlersTest extends TestLogger {
     }
 
     private static HandlerRequest<SavepointTriggerRequestBody> triggerSavepointRequest(
-            final String targetDirectory, @Nullable TriggerId triggerId)
+            @Nullable final String targetDirectory, @Nullable TriggerId triggerId)
             throws HandlerRequestException {
         return HandlerRequest.resolveParametersAndCreate(
                 new SavepointTriggerRequestBody(targetDirectory, false, triggerId),

--- a/flink-runtime/src/test/java/org/apache/flink/runtime/rest/handler/job/savepoints/StopWithSavepointHandlersTest.java
+++ b/flink-runtime/src/test/java/org/apache/flink/runtime/rest/handler/job/savepoints/StopWithSavepointHandlersTest.java
@@ -267,7 +267,7 @@ public class StopWithSavepointHandlersTest extends TestLogger {
     }
 
     private static HandlerRequest<StopWithSavepointRequestBody> triggerSavepointRequest(
-            final String targetDirectory, @Nullable TriggerId triggerId)
+            @Nullable final String targetDirectory, @Nullable TriggerId triggerId)
             throws HandlerRequestException {
         return HandlerRequest.resolveParametersAndCreate(
                 new StopWithSavepointRequestBody(targetDirectory, false, triggerId),

--- a/flink-runtime/src/test/java/org/apache/flink/runtime/rest/handler/job/savepoints/StopWithSavepointHandlersTest.java
+++ b/flink-runtime/src/test/java/org/apache/flink/runtime/rest/handler/job/savepoints/StopWithSavepointHandlersTest.java
@@ -46,6 +46,8 @@ import org.apache.flink.shaded.netty4.io.netty.handler.codec.http.HttpResponseSt
 import org.junit.Before;
 import org.junit.Test;
 
+import javax.annotation.Nullable;
+
 import java.util.Collections;
 import java.util.HashMap;
 import java.util.Map;
@@ -57,6 +59,7 @@ import static org.apache.flink.runtime.rest.handler.job.savepoints.SavepointTest
 import static org.hamcrest.Matchers.equalTo;
 import static org.hamcrest.Matchers.instanceOf;
 import static org.hamcrest.Matchers.notNullValue;
+import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertThat;
 import static org.junit.Assert.fail;
 
@@ -213,20 +216,61 @@ public class StopWithSavepointHandlersTest extends TestLogger {
         assertThat(savepointError, instanceOf(RuntimeException.class));
     }
 
+    @Test
+    public void testProvidedTriggerId() throws Exception {
+        final OperationResult<String> successfulResult =
+                OperationResult.success(COMPLETED_SAVEPOINT_EXTERNAL_POINTER);
+        AtomicReference<AsynchronousJobOperationKey> keyReference = new AtomicReference<>();
+        final TestingRestfulGateway testingRestfulGateway =
+                new TestingRestfulGateway.Builder()
+                        .setStopWithSavepointFunction(setReferenceToOperationKey(keyReference))
+                        .setGetSavepointStatusFunction(
+                                getResultIfKeyMatches(successfulResult, keyReference))
+                        .build();
+
+        final TriggerId providedTriggerId = new TriggerId();
+
+        final TriggerId returnedTriggerId =
+                savepointTriggerHandler
+                        .handleRequest(
+                                triggerSavepointRequest(
+                                        DEFAULT_REQUESTED_SAVEPOINT_TARGET_DIRECTORY,
+                                        providedTriggerId),
+                                testingRestfulGateway)
+                        .get()
+                        .getTriggerId();
+
+        assertEquals(providedTriggerId, returnedTriggerId);
+
+        AsynchronousOperationResult<SavepointInfo> savepointResponseBody;
+        savepointResponseBody =
+                savepointStatusHandler
+                        .handleRequest(
+                                savepointStatusRequest(providedTriggerId), testingRestfulGateway)
+                        .get();
+
+        assertThat(savepointResponseBody.queueStatus().getId(), equalTo(QueueStatus.Id.COMPLETED));
+        assertThat(savepointResponseBody.resource(), notNullValue());
+        assertThat(
+                savepointResponseBody.resource().getLocation(),
+                equalTo(COMPLETED_SAVEPOINT_EXTERNAL_POINTER));
+    }
+
     private static HandlerRequest<StopWithSavepointRequestBody> triggerSavepointRequest()
             throws HandlerRequestException {
-        return triggerSavepointRequest(DEFAULT_REQUESTED_SAVEPOINT_TARGET_DIRECTORY);
+        return triggerSavepointRequest(DEFAULT_REQUESTED_SAVEPOINT_TARGET_DIRECTORY, null);
     }
 
     private static HandlerRequest<StopWithSavepointRequestBody>
             triggerSavepointRequestWithDefaultDirectory() throws HandlerRequestException {
-        return triggerSavepointRequest(null);
+        return triggerSavepointRequest(null, null);
     }
 
     private static HandlerRequest<StopWithSavepointRequestBody> triggerSavepointRequest(
-            final String targetDirectory) throws HandlerRequestException {
+            final String targetDirectory, @Nullable TriggerId triggerId)
+            throws HandlerRequestException {
         return HandlerRequest.resolveParametersAndCreate(
-                new StopWithSavepointRequestBody(targetDirectory, false),
+                new StopWithSavepointRequestBody(targetDirectory, false, triggerId),
                 new SavepointTriggerMessageParameters(),
                 Collections.singletonMap(JobIDPathParameter.KEY, JOB_ID.toString()),
                 Collections.emptyMap(),

--- a/flink-runtime/src/test/java/org/apache/flink/runtime/rest/messages/SavepointHandlerRequestBodyTest.java
+++ b/flink-runtime/src/test/java/org/apache/flink/runtime/rest/messages/SavepointHandlerRequestBodyTest.java
@@ -27,7 +27,6 @@ import org.apache.flink.shaded.jackson2.com.fasterxml.jackson.databind.ObjectMap
 import org.junit.Test;
 
 import static org.hamcrest.CoreMatchers.is;
-import static org.hamcrest.CoreMatchers.nullValue;
 import static org.junit.Assert.assertThat;
 
 /** Tests for the savepoint request bodies. */
@@ -40,7 +39,7 @@ public class SavepointHandlerRequestBodyTest {
 
         assertThat(defaultParseResult.isCancelJob(), is(false));
 
-        assertThat(defaultParseResult.getTargetDirectory(), nullValue());
+        assertThat(defaultParseResult.getTargetDirectory().isPresent(), is(false));
     }
 
     @Test
@@ -51,7 +50,7 @@ public class SavepointHandlerRequestBodyTest {
 
         assertThat(defaultParseResult.shouldDrain(), is(false));
 
-        assertThat(defaultParseResult.getTargetDirectory(), nullValue());
+        assertThat(defaultParseResult.getTargetDirectory().isPresent(), is(false));
     }
 
     private static <T> T getDefaultParseResult(Class<T> clazz) throws JsonProcessingException {

--- a/flink-runtime/src/test/java/org/apache/flink/runtime/rest/messages/job/savepoints/SavepointTriggerRequestBodyTest.java
+++ b/flink-runtime/src/test/java/org/apache/flink/runtime/rest/messages/job/savepoints/SavepointTriggerRequestBodyTest.java
@@ -19,6 +19,7 @@
 package org.apache.flink.runtime.rest.messages.job.savepoints;
 
 import org.apache.flink.runtime.rest.messages.RestRequestMarshallingTestBase;
+import org.apache.flink.runtime.rest.messages.TriggerId;
 
 import org.junit.runner.RunWith;
 import org.junit.runners.Parameterized;
@@ -44,8 +45,10 @@ public class SavepointTriggerRequestBodyTest
     public static Collection<Object[]> data() {
         return Arrays.asList(
                 new Object[][] {
-                    {new SavepointTriggerRequestBody("/tmp", true)},
-                    {new SavepointTriggerRequestBody("/tmp", false)}
+                    {new SavepointTriggerRequestBody("/tmp", true, null)},
+                    {new SavepointTriggerRequestBody("/tmp", false, null)},
+                    {new SavepointTriggerRequestBody("/tmp", true, new TriggerId())},
+                    {new SavepointTriggerRequestBody("/tmp", false, new TriggerId())},
                 });
     }
 
@@ -63,5 +66,6 @@ public class SavepointTriggerRequestBodyTest
     protected void assertOriginalEqualsToUnmarshalled(
             final SavepointTriggerRequestBody expected, final SavepointTriggerRequestBody actual) {
         assertEquals(expected.getTargetDirectory(), actual.getTargetDirectory());
+        assertEquals(expected.getTriggerId(), actual.getTriggerId());
     }
 }

--- a/flink-runtime/src/test/java/org/apache/flink/runtime/rest/messages/job/savepoints/StopWithSavepointTriggerRequestBodyTest.java
+++ b/flink-runtime/src/test/java/org/apache/flink/runtime/rest/messages/job/savepoints/StopWithSavepointTriggerRequestBodyTest.java
@@ -1,0 +1,74 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.flink.runtime.rest.messages.job.savepoints;
+
+import org.apache.flink.runtime.rest.messages.RestRequestMarshallingTestBase;
+import org.apache.flink.runtime.rest.messages.TriggerId;
+import org.apache.flink.runtime.rest.messages.job.savepoints.stop.StopWithSavepointRequestBody;
+
+import org.junit.runner.RunWith;
+import org.junit.runners.Parameterized;
+
+import java.util.Arrays;
+import java.util.Collection;
+
+import static org.junit.Assert.assertEquals;
+
+/** Tests for {@link StopWithSavepointRequestBody}. */
+@RunWith(Parameterized.class)
+public class StopWithSavepointTriggerRequestBodyTest
+        extends RestRequestMarshallingTestBase<StopWithSavepointRequestBody> {
+
+    private final StopWithSavepointRequestBody savepointTriggerRequestBody;
+
+    public StopWithSavepointTriggerRequestBodyTest(
+            final StopWithSavepointRequestBody savepointTriggerRequestBody) {
+        this.savepointTriggerRequestBody = savepointTriggerRequestBody;
+    }
+
+    @Parameterized.Parameters
+    public static Collection<Object[]> data() {
+        return Arrays.asList(
+                new Object[][] {
+                    {new StopWithSavepointRequestBody("/tmp", true, null)},
+                    {new StopWithSavepointRequestBody("/tmp", false, null)},
+                    {new StopWithSavepointRequestBody("/tmp", true, new TriggerId())},
+                    {new StopWithSavepointRequestBody("/tmp", false, new TriggerId())},
+                });
+    }
+
+    @Override
+    protected Class<StopWithSavepointRequestBody> getTestRequestClass() {
+        return StopWithSavepointRequestBody.class;
+    }
+
+    @Override
+    protected StopWithSavepointRequestBody getTestRequestInstance() {
+        return savepointTriggerRequestBody;
+    }
+
+    @Override
+    protected void assertOriginalEqualsToUnmarshalled(
+            final StopWithSavepointRequestBody expected,
+            final StopWithSavepointRequestBody actual) {
+        assertEquals(expected.getTargetDirectory(), actual.getTargetDirectory());
+        assertEquals(expected.getTriggerId(), actual.getTriggerId());
+        assertEquals(expected.shouldDrain(), actual.shouldDrain());
+    }
+}


### PR DESCRIPTION
With this PR users can provide the triggerId when triggering a (stop-with-)savepoint. This effectively allows users to safely retry a savepoint operation within the caching interval.
The runtime already handles this appropriately.