### PR TITLE
[FLINK-11470][runtime] Pass configurations to filesystems when executing in LocalStreamEnvironment

### DIFF
--- a/flink-clients/src/test/java/org/apache/flink/client/testjar/LocalExecutionEnvironmentFileSystemTest.java
+++ b/flink-clients/src/test/java/org/apache/flink/client/testjar/LocalExecutionEnvironmentFileSystemTest.java
@@ -1,0 +1,93 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.flink.client.testjar;
+
+import org.apache.flink.api.common.functions.MapFunction;
+import org.apache.flink.configuration.Configuration;
+import org.apache.flink.core.fs.FileSystem;
+import org.apache.flink.core.fs.FileSystemFactory;
+import org.apache.flink.runtime.minicluster.MiniCluster;
+import org.apache.flink.streaming.api.environment.LocalStreamEnvironment;
+import org.apache.flink.streaming.api.environment.StreamExecutionEnvironment;
+import org.apache.flink.testutils.TestFileSystem;
+import org.apache.flink.testutils.junit.extensions.ContextClassLoaderExtension;
+
+import org.apache.flink.shaded.guava30.com.google.common.collect.ImmutableMap;
+
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.Extension;
+import org.junit.jupiter.api.extension.RegisterExtension;
+import org.junit.jupiter.api.io.TempDir;
+
+import java.io.IOException;
+import java.net.URI;
+import java.nio.file.Path;
+import java.util.Map;
+
+class LocalExecutionEnvironmentFileSystemTest {
+    @RegisterExtension
+    static final Extension CONTEXT_CLASS_LOADER_EXTENSION =
+            ContextClassLoaderExtension.builder()
+                    .withServiceEntry(
+                            FileSystemFactory.class,
+                            TestFileSystemFactoryWithConfiguration.class.getName())
+                    .build();
+
+    @TempDir Path tmp;
+
+    private static final Map<String, String> EXPECTED_CONFIGURATION =
+            ImmutableMap.of("s3.access-key", "user", "s3.secret-key", "secret");
+
+    @Test
+    void testConfigureFileSystem() throws Exception {
+        final Configuration config = new Configuration();
+        config.set(MiniCluster.PLUGIN_DIRECTORY, tmp.toAbsolutePath().toString());
+        EXPECTED_CONFIGURATION.forEach(config::setString);
+        final StreamExecutionEnvironment environment = new LocalStreamEnvironment(config);
+        environment.getCheckpointConfig().setCheckpointStorage("testConfig:/" + tmp);
+        environment.enableCheckpointing(100);
+        environment.fromElements(1, 2, 3, 4).map((MapFunction<Integer, Integer>) value -> value);
+        environment.execute("configureFilesystem");
+    }
+
+    /** Test filesystem to check that configurations are propagated. */
+    public static final class TestFileSystemFactoryWithConfiguration implements FileSystemFactory {
+
+        @Override
+        public String getScheme() {
+            return "testConfig";
+        }
+
+        @Override
+        public FileSystem create(URI fsUri) throws IOException {
+            return new TestFileSystem();
+        }
+
+        @Override
+        public void configure(Configuration config) {
+            EXPECTED_CONFIGURATION.forEach(
+                    (k, v) ->
+                            Assertions.assertEquals(
+                                    v,
+                                    config.getString(k, null),
+                                    "Unexpected config entry for " + k));
+        }
+    }
+}

--- a/flink-core/src/main/java/org/apache/flink/core/fs/FileSystem.java
+++ b/flink-core/src/main/java/org/apache/flink/core/fs/FileSystem.java
@@ -382,6 +382,15 @@ public abstract class FileSystem {
         }
     }
 
+    /** Resets the internal state of the {@link FileSystem} singleton. */
+    public static void uninitialize() {
+        LOCK.lock();
+        CACHE.clear();
+        FS_FACTORIES.clear();
+        ALLOWED_FALLBACK_FILESYSTEMS.clear();
+        LOCK.unlock();
+    }
+
     // ------------------------------------------------------------------------
     //  Obtaining File System Instances
     // ------------------------------------------------------------------------

--- a/flink-core/src/main/java/org/apache/flink/core/plugin/PluginConfig.java
+++ b/flink-core/src/main/java/org/apache/flink/core/plugin/PluginConfig.java
@@ -18,27 +18,18 @@
 
 package org.apache.flink.core.plugin;
 
-import org.apache.flink.configuration.ConfigConstants;
-import org.apache.flink.configuration.Configuration;
-import org.apache.flink.configuration.CoreOptions;
-
-import org.slf4j.Logger;
-import org.slf4j.LoggerFactory;
-
-import java.io.File;
 import java.nio.file.Path;
 import java.util.Optional;
 
 /** Stores the configuration for plugins mechanism. */
 @SuppressWarnings("OptionalUsedAsFieldOrParameterType")
 public class PluginConfig {
-    private static final Logger LOG = LoggerFactory.getLogger(PluginConfig.class);
 
     private final Optional<Path> pluginsPath;
 
     private final String[] alwaysParentFirstPatterns;
 
-    private PluginConfig(Optional<Path> pluginsPath, String[] alwaysParentFirstPatterns) {
+    public PluginConfig(Optional<Path> pluginsPath, String[] alwaysParentFirstPatterns) {
         this.pluginsPath = pluginsPath;
         this.alwaysParentFirstPatterns = alwaysParentFirstPatterns;
     }
@@ -49,26 +40,5 @@ public class PluginConfig {
 
     public String[] getAlwaysParentFirstPatterns() {
         return alwaysParentFirstPatterns;
-    }
-
-    public static PluginConfig fromConfiguration(Configuration configuration) {
-        return new PluginConfig(
-                getPluginsDir().map(File::toPath),
-                CoreOptions.getPluginParentFirstLoaderPatterns(configuration));
-    }
-
-    public static Optional<File> getPluginsDir() {
-        String pluginsDir =
-                System.getenv()
-                        .getOrDefault(
-                                ConfigConstants.ENV_FLINK_PLUGINS_DIR,
-                                ConfigConstants.DEFAULT_FLINK_PLUGINS_DIRS);
-
-        File pluginsDirFile = new File(pluginsDir);
-        if (!pluginsDirFile.isDirectory()) {
-            LOG.warn("The plugins directory [{}] does not exist.", pluginsDirFile);
-            return Optional.empty();
-        }
-        return Optional.of(pluginsDirFile);
     }
 }

--- a/flink-core/src/test/java/org/apache/flink/core/plugin/PluginConfigTest.java
+++ b/flink-core/src/test/java/org/apache/flink/core/plugin/PluginConfigTest.java
@@ -65,7 +65,7 @@ public class PluginConfigTest extends TestLogger {
                         ConfigConstants.ENV_FLINK_PLUGINS_DIR, pluginsDirectory.getAbsolutePath());
         CommonTestUtils.setEnv(envVariables);
 
-        assertThat(PluginConfig.getPluginsDir().get(), is(pluginsDirectory));
+        assertThat(PluginUtils.getPluginsDirFromEnvironment().get(), is(pluginsDirectory));
     }
 
     @Test
@@ -77,6 +77,6 @@ public class PluginConfigTest extends TestLogger {
                                 .getAbsolutePath());
         CommonTestUtils.setEnv(envVariables);
 
-        assertFalse(PluginConfig.getPluginsDir().isPresent());
+        assertFalse(PluginUtils.getPluginsDirFromEnvironment().isPresent());
     }
 }

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/minicluster/MiniCluster.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/minicluster/MiniCluster.java
@@ -26,10 +26,14 @@ import org.apache.flink.api.common.JobSubmissionResult;
 import org.apache.flink.api.common.io.FileOutputFormat;
 import org.apache.flink.api.common.time.Time;
 import org.apache.flink.configuration.ClusterOptions;
+import org.apache.flink.configuration.ConfigOption;
 import org.apache.flink.configuration.Configuration;
 import org.apache.flink.configuration.ConfigurationUtils;
 import org.apache.flink.configuration.HighAvailabilityOptions;
 import org.apache.flink.configuration.IllegalConfigurationException;
+import org.apache.flink.core.fs.FileSystem;
+import org.apache.flink.core.plugin.PluginManager;
+import org.apache.flink.core.plugin.PluginUtils;
 import org.apache.flink.runtime.blob.BlobCacheService;
 import org.apache.flink.runtime.blob.BlobClient;
 import org.apache.flink.runtime.blob.BlobServer;
@@ -103,6 +107,7 @@ import java.io.IOException;
 import java.net.InetAddress;
 import java.net.InetSocketAddress;
 import java.net.URI;
+import java.nio.file.Paths;
 import java.time.Duration;
 import java.util.ArrayList;
 import java.util.Collection;
@@ -120,11 +125,19 @@ import java.util.concurrent.TimeUnit;
 import java.util.function.Function;
 import java.util.stream.Collectors;
 
+import static org.apache.flink.configuration.ConfigOptions.key;
 import static org.apache.flink.util.Preconditions.checkNotNull;
 import static org.apache.flink.util.Preconditions.checkState;
 
 /** MiniCluster to execute Flink jobs locally. */
 public class MiniCluster implements AutoCloseableAsync {
+
+    public static final ConfigOption<String> PLUGIN_DIRECTORY =
+            key("minicluster.plugin.directory")
+                    .stringType()
+                    .noDefaultValue()
+                    .withDescription(
+                            "The config parameter pointing to the local directory to initialize plugins.");
 
     private static final Logger LOG = LoggerFactory.getLogger(MiniCluster.class);
 
@@ -203,6 +216,9 @@ public class MiniCluster implements AutoCloseableAsync {
     @GuardedBy("lock")
     private RpcSystem rpcSystem;
 
+    @GuardedBy("lock")
+    private volatile boolean initializedFilesystems = false;
+
     // ------------------------------------------------------------------------
 
     /**
@@ -279,6 +295,14 @@ public class MiniCluster implements AutoCloseableAsync {
                     miniClusterConfiguration.getRpcServiceSharing() == RpcServiceSharing.SHARED;
 
             try {
+                if (configuration.contains(PLUGIN_DIRECTORY)) {
+                    final PluginManager pluginManager =
+                            PluginUtils.createPluginManagerFromFolder(
+                                    configuration, Paths.get(configuration.get(PLUGIN_DIRECTORY)));
+                    FileSystem.initialize(configuration, pluginManager);
+                    initializedFilesystems = true;
+                }
+
                 initializeIOFormatClasses(configuration);
 
                 rpcSystem = RpcSystem.load(configuration);
@@ -540,6 +564,9 @@ public class MiniCluster implements AutoCloseableAsync {
     public CompletableFuture<Void> closeAsync() {
         synchronized (lock) {
             if (running) {
+                if (initializedFilesystems) {
+                    FileSystem.uninitialize();
+                }
                 LOG.info("Shutting down Flink Mini Cluster");
                 try {
                     final long shutdownTimeoutMillis =

--- a/flink-yarn/src/main/java/org/apache/flink/yarn/YarnClusterDescriptor.java
+++ b/flink-yarn/src/main/java/org/apache/flink/yarn/YarnClusterDescriptor.java
@@ -41,7 +41,6 @@ import org.apache.flink.configuration.PipelineOptions;
 import org.apache.flink.configuration.ResourceManagerOptions;
 import org.apache.flink.configuration.RestOptions;
 import org.apache.flink.configuration.SecurityOptions;
-import org.apache.flink.core.plugin.PluginConfig;
 import org.apache.flink.core.plugin.PluginUtils;
 import org.apache.flink.runtime.clusterframework.BootstrapTools;
 import org.apache.flink.runtime.entrypoint.ClusterEntrypoint;
@@ -1690,7 +1689,7 @@ public class YarnClusterDescriptor implements ClusterDescriptor<ApplicationId> {
 
     @VisibleForTesting
     void addPluginsFoldersToShipFiles(Collection<File> effectiveShipFiles) {
-        final Optional<File> pluginsDir = PluginConfig.getPluginsDir();
+        final Optional<File> pluginsDir = PluginUtils.getPluginsDirFromEnvironment();
         pluginsDir.ifPresent(effectiveShipFiles::add);
     }
 


### PR DESCRIPTION


<!--
*Thank you very much for contributing to Apache Flink - we are happy that you want to help us improve Flink. To help the community review your contribution in the best possible way, please go through the checklist below, which will get the contribution into a shape in which it can be best reviewed.*

*Please understand that we do not do this to make contributions to Flink a hassle. In order to uphold a high standard of quality for code contributions, while at the same time managing a large number of contributions, we need contributors to prepare the contributions well, and give reviewers enough contextual information for the review. Please also understand that contributions that do not follow this guide will take longer to review and thus typically be picked up with lower priority by the community.*

## Contribution Checklist




**(The sections below can be removed for hotfixes of typos)**
-->

## What is the purpose of the change

Before this change, Flink's configuration where not passed to the
filesytems if used in LocalStreamEnvironment. This may lead to i.e.
missing credentials. This change initializes the filesytems through the
pluginloader which forwards the configuration as it is done when
running a real cluster.

## Brief change log

Build the pluginloader in the Minicluster and initialize the filesystems with it.

## Verifying this change

- Added a test to verify that the configuration is available within the filesystem while running in the LocalStreamEnvironment 

## Does this pull request potentially affect one of the following parts:

  - Dependencies (does it add or upgrade a dependency): (yes / **no**)
  - The public API, i.e., is any changed class annotated with `@Public(Evolving)`: (yes / **no**)
  - The serializers: (yes / **no** / don't know)
  - The runtime per-record code paths (performance sensitive): (yes / **no** / don't know)
  - Anything that affects deployment or recovery: JobManager (and its components), Checkpointing, Kubernetes/Yarn, ZooKeeper: (yes / **no** / don't know)
  - The S3 file system connector: (yes / **no** / don't know)

## Documentation

  - Does this pull request introduce a new feature? (yes / **no**)
  - If yes, how is the feature documented? (**not applicable** / docs / JavaDocs / not documented)
