### PR TITLE
[FLINK-24674][kubernetes] Create corresponding resouces for task manager Pods

### DIFF
--- a/flink-kubernetes/src/main/java/org/apache/flink/kubernetes/KubernetesResourceManagerDriver.java
+++ b/flink-kubernetes/src/main/java/org/apache/flink/kubernetes/KubernetesResourceManagerDriver.java
@@ -194,7 +194,8 @@ public class KubernetesResourceManagerDriver
                                         finalPodName,
                                         exception);
                                 CompletableFuture<KubernetesWorkerNode> future =
-                                        requestResourceFutures.remove(finalTaskManagerPod.getName());
+                                        requestResourceFutures.remove(
+                                                finalTaskManagerPod.getName());
                                 if (future != null) {
                                     future.completeExceptionally(exception);
                                 }

--- a/flink-kubernetes/src/main/java/org/apache/flink/kubernetes/kubeclient/Fabric8FlinkKubeClient.java
+++ b/flink-kubernetes/src/main/java/org/apache/flink/kubernetes/kubeclient/Fabric8FlinkKubeClient.java
@@ -117,7 +117,11 @@ public class Fabric8FlinkKubeClient implements FlinkKubeClient {
     }
 
     @Override
-    public CompletableFuture<Void> createTaskManagerPod(KubernetesPod kubernetesPod) {
+    public CompletableFuture<Void> createTaskManagerPod(
+            KubernetesTaskManagerSpecification kubernetesTMSpec) {
+        final KubernetesPod kubernetesPod = kubernetesTMSpec.getKubernetesPod();
+        final List<HasMetadata> accompanyingResources = kubernetesTMSpec.getAccompanyingResources();
+
         return CompletableFuture.runAsync(
                 () -> {
                     final Deployment masterDeployment =
@@ -140,6 +144,12 @@ public class Fabric8FlinkKubeClient implements FlinkKubeClient {
                     setOwnerReference(
                             masterDeployment,
                             Collections.singletonList(kubernetesPod.getInternalResource()));
+                    setOwnerReference(masterDeployment, accompanyingResources);
+
+                    this.internalClient
+                            .resourceList(accompanyingResources)
+                            .inNamespace(this.namespace)
+                            .createOrReplace();
 
                     LOG.debug(
                             "Start to create pod with spec {}{}",

--- a/flink-kubernetes/src/main/java/org/apache/flink/kubernetes/kubeclient/FlinkKubeClient.java
+++ b/flink-kubernetes/src/main/java/org/apache/flink/kubernetes/kubeclient/FlinkKubeClient.java
@@ -36,8 +36,8 @@ import java.util.function.Function;
 /**
  * The client to talk with kubernetes. The interfaces will be called both in Client and
  * ResourceManager. To avoid potentially blocking the execution of RpcEndpoint's main thread, these
- * interfaces {@link #createTaskManagerPod(KubernetesPod)}, {@link #stopPod(String)} should be
- * implemented asynchronously.
+ * interfaces {@link #createTaskManagerPod(KubernetesTaskManagerSpecification)}, {@link
+ * #stopPod(String)} should be implemented asynchronously.
  */
 public interface FlinkKubeClient extends AutoCloseable {
 
@@ -52,10 +52,11 @@ public interface FlinkKubeClient extends AutoCloseable {
     /**
      * Create task manager pod.
      *
-     * @param kubernetesPod taskmanager pod
+     * @param kubernetesTMSpec taskmanager specification
      * @return Return the taskmanager pod creation future
      */
-    CompletableFuture<Void> createTaskManagerPod(KubernetesPod kubernetesPod);
+    CompletableFuture<Void> createTaskManagerPod(
+            KubernetesTaskManagerSpecification kubernetesTMSpec);
 
     /**
      * Stop a specified pod by name.

--- a/flink-kubernetes/src/main/java/org/apache/flink/kubernetes/kubeclient/KubernetesTaskManagerSpecification.java
+++ b/flink-kubernetes/src/main/java/org/apache/flink/kubernetes/kubeclient/KubernetesTaskManagerSpecification.java
@@ -1,0 +1,46 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.flink.kubernetes.kubeclient;
+
+import org.apache.flink.kubernetes.kubeclient.resources.KubernetesPod;
+
+import io.fabric8.kubernetes.api.model.HasMetadata;
+
+import java.util.List;
+
+/** Composition of the created Kubernetes components that represents a Flink Task Manager. */
+public class KubernetesTaskManagerSpecification {
+    private KubernetesPod kubernetesPod;
+
+    private List<HasMetadata> accompanyingResources;
+
+    public KubernetesTaskManagerSpecification(
+            KubernetesPod kubernetesPod, List<HasMetadata> accompanyingResources) {
+        this.kubernetesPod = kubernetesPod;
+        this.accompanyingResources = accompanyingResources;
+    }
+
+    public KubernetesPod getKubernetesPod() {
+        return kubernetesPod;
+    }
+
+    public List<HasMetadata> getAccompanyingResources() {
+        return accompanyingResources;
+    }
+}

--- a/flink-kubernetes/src/main/java/org/apache/flink/kubernetes/kubeclient/factory/KubernetesTaskManagerFactory.java
+++ b/flink-kubernetes/src/main/java/org/apache/flink/kubernetes/kubeclient/factory/KubernetesTaskManagerFactory.java
@@ -43,7 +43,7 @@ import java.util.List;
 /** Utility class for constructing the TaskManager Pod on the JobManager. */
 public class KubernetesTaskManagerFactory {
 
-    public static KubernetesTaskManagerSpecification buildTaskManagerKubernetesPod(
+    public static KubernetesTaskManagerSpecification buildKubernetesTaskManagerSpecification(
             FlinkPod podTemplate, KubernetesTaskManagerParameters kubernetesTaskManagerParameters)
             throws IOException {
         FlinkPod flinkPod = Preconditions.checkNotNull(podTemplate).copy();

--- a/flink-kubernetes/src/main/java/org/apache/flink/kubernetes/kubeclient/factory/KubernetesTaskManagerFactory.java
+++ b/flink-kubernetes/src/main/java/org/apache/flink/kubernetes/kubeclient/factory/KubernetesTaskManagerFactory.java
@@ -19,6 +19,7 @@
 package org.apache.flink.kubernetes.kubeclient.factory;
 
 import org.apache.flink.kubernetes.kubeclient.FlinkPod;
+import org.apache.flink.kubernetes.kubeclient.KubernetesTaskManagerSpecification;
 import org.apache.flink.kubernetes.kubeclient.decorators.CmdTaskManagerDecorator;
 import org.apache.flink.kubernetes.kubeclient.decorators.EnvSecretsDecorator;
 import org.apache.flink.kubernetes.kubeclient.decorators.FlinkConfMountDecorator;
@@ -31,15 +32,23 @@ import org.apache.flink.kubernetes.kubeclient.parameters.KubernetesTaskManagerPa
 import org.apache.flink.kubernetes.kubeclient.resources.KubernetesPod;
 import org.apache.flink.util.Preconditions;
 
+import io.fabric8.kubernetes.api.model.HasMetadata;
 import io.fabric8.kubernetes.api.model.Pod;
 import io.fabric8.kubernetes.api.model.PodBuilder;
+
+import java.io.IOException;
+import java.util.ArrayList;
+import java.util.List;
 
 /** Utility class for constructing the TaskManager Pod on the JobManager. */
 public class KubernetesTaskManagerFactory {
 
-    public static KubernetesPod buildTaskManagerKubernetesPod(
-            FlinkPod podTemplate, KubernetesTaskManagerParameters kubernetesTaskManagerParameters) {
+    public static KubernetesTaskManagerSpecification buildTaskManagerKubernetesPod(
+            FlinkPod podTemplate, KubernetesTaskManagerParameters kubernetesTaskManagerParameters)
+            throws IOException {
         FlinkPod flinkPod = Preconditions.checkNotNull(podTemplate).copy();
+
+        List<HasMetadata> accompanyingResources = new ArrayList<>();
 
         final KubernetesStepDecorator[] stepDecorators =
                 new KubernetesStepDecorator[] {
@@ -54,6 +63,7 @@ public class KubernetesTaskManagerFactory {
 
         for (KubernetesStepDecorator stepDecorator : stepDecorators) {
             flinkPod = stepDecorator.decorateFlinkPod(flinkPod);
+            accompanyingResources.addAll(stepDecorator.buildAccompanyingKubernetesResources());
         }
 
         final Pod resolvedPod =
@@ -63,6 +73,7 @@ public class KubernetesTaskManagerFactory {
                         .endSpec()
                         .build();
 
-        return new KubernetesPod(resolvedPod);
+        return new KubernetesTaskManagerSpecification(
+                new KubernetesPod(resolvedPod), accompanyingResources);
     }
 }

--- a/flink-kubernetes/src/test/java/org/apache/flink/kubernetes/kubeclient/Fabric8FlinkKubeClientTest.java
+++ b/flink-kubernetes/src/test/java/org/apache/flink/kubernetes/kubeclient/Fabric8FlinkKubeClientTest.java
@@ -51,6 +51,7 @@ import org.junit.Test;
 
 import java.util.ArrayList;
 import java.util.Arrays;
+import java.util.Collections;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
@@ -185,7 +186,9 @@ public class Fabric8FlinkKubeClientTest extends KubernetesClientTestBase {
                                 .editOrNewSpec()
                                 .endSpec()
                                 .build());
-        this.flinkKubeClient.createTaskManagerPod(kubernetesPod).get();
+        final KubernetesTaskManagerSpecification taskManagerSpecification =
+                new KubernetesTaskManagerSpecification(kubernetesPod, Collections.EMPTY_LIST);
+        this.flinkKubeClient.createTaskManagerPod(taskManagerSpecification).get();
 
         final Pod resultTaskManagerPod =
                 this.kubeClient.pods().inNamespace(NAMESPACE).withName(TASKMANAGER_POD_NAME).get();
@@ -335,7 +338,9 @@ public class Fabric8FlinkKubeClientTest extends KubernetesClientTestBase {
                                 .editOrNewSpec()
                                 .endSpec()
                                 .build());
-        this.flinkKubeClient.createTaskManagerPod(kubernetesPod).get();
+        final KubernetesTaskManagerSpecification taskManagerSpecification =
+                new KubernetesTaskManagerSpecification(kubernetesPod, Collections.EMPTY_LIST);
+        this.flinkKubeClient.createTaskManagerPod(taskManagerSpecification).get();
 
         assertEquals(
                 1,

--- a/flink-kubernetes/src/test/java/org/apache/flink/kubernetes/kubeclient/TestingFlinkKubeClient.java
+++ b/flink-kubernetes/src/test/java/org/apache/flink/kubernetes/kubeclient/TestingFlinkKubeClient.java
@@ -123,8 +123,9 @@ public class TestingFlinkKubeClient implements FlinkKubeClient {
     }
 
     @Override
-    public CompletableFuture<Void> createTaskManagerPod(KubernetesPod kubernetesPod) {
-        return createTaskManagerPodFunction.apply(kubernetesPod);
+    public CompletableFuture<Void> createTaskManagerPod(
+            KubernetesTaskManagerSpecification kubernetesTMSpec) {
+        return createTaskManagerPodFunction.apply(kubernetesTMSpec.getKubernetesPod());
     }
 
     @Override

--- a/flink-kubernetes/src/test/java/org/apache/flink/kubernetes/kubeclient/factory/KubernetesTaskManagerFactoryTest.java
+++ b/flink-kubernetes/src/test/java/org/apache/flink/kubernetes/kubeclient/factory/KubernetesTaskManagerFactoryTest.java
@@ -122,11 +122,11 @@ public class KubernetesTaskManagerFactoryTest extends KubernetesTaskManagerTestB
                                         x ->
                                                 x instanceof ConfigMap
                                                         && x.getMetadata()
-                                                        .getName()
-                                                        .equals(
-                                                                HadoopConfMountDecorator
-                                                                        .getHadoopConfConfigMapName(
-                                                                                CLUSTER_ID)))
+                                                                .getName()
+                                                                .equals(
+                                                                        HadoopConfMountDecorator
+                                                                                .getHadoopConfConfigMapName(
+                                                                                        CLUSTER_ID)))
                                 .collect(Collectors.toList())
                                 .get(0);
 

--- a/flink-kubernetes/src/test/java/org/apache/flink/kubernetes/kubeclient/factory/KubernetesTaskManagerFactoryTest.java
+++ b/flink-kubernetes/src/test/java/org/apache/flink/kubernetes/kubeclient/factory/KubernetesTaskManagerFactoryTest.java
@@ -46,6 +46,8 @@ public class KubernetesTaskManagerFactoryTest extends KubernetesTaskManagerTestB
 
     private Pod resultPod;
 
+    private KubernetesTaskManagerSpecification kubernetesJobManagerSpecification;
+
     @Override
     protected void setupFlinkConfig() {
         super.setupFlinkConfig();
@@ -69,11 +71,12 @@ public class KubernetesTaskManagerFactoryTest extends KubernetesTaskManagerTestB
 
         generateKerberosFileItems();
 
-        this.resultPod =
+        this.kubernetesJobManagerSpecification =
                 KubernetesTaskManagerFactory.buildKubernetesTaskManagerSpecification(
-                                new FlinkPod.Builder().build(), kubernetesTaskManagerParameters)
-                        .getKubernetesPod()
-                        .getInternalResource();
+                        new FlinkPod.Builder().build(), kubernetesTaskManagerParameters);
+
+        this.resultPod =
+                this.kubernetesJobManagerSpecification.getKubernetesPod().getInternalResource();
     }
 
     @Test
@@ -107,17 +110,9 @@ public class KubernetesTaskManagerFactoryTest extends KubernetesTaskManagerTestB
 
     @Test
     public void testHadoopConfConfigMap() throws IOException {
-        setHadoopConfDirEnv();
-        generateHadoopConfFileItems();
-
-        FlinkPod flinkPod = new FlinkPod.Builder().build();
-        KubernetesTaskManagerSpecification kubernetesJobManagerSpecification =
-                KubernetesTaskManagerFactory.buildKubernetesTaskManagerSpecification(
-                        flinkPod, kubernetesTaskManagerParameters);
-
         final ConfigMap resultConfigMap =
                 (ConfigMap)
-                        kubernetesJobManagerSpecification.getAccompanyingResources().stream()
+                        this.kubernetesJobManagerSpecification.getAccompanyingResources().stream()
                                 .filter(
                                         x ->
                                                 x instanceof ConfigMap

--- a/flink-kubernetes/src/test/java/org/apache/flink/kubernetes/kubeclient/factory/KubernetesTaskManagerFactoryTest.java
+++ b/flink-kubernetes/src/test/java/org/apache/flink/kubernetes/kubeclient/factory/KubernetesTaskManagerFactoryTest.java
@@ -21,14 +21,20 @@ package org.apache.flink.kubernetes.kubeclient.factory;
 import org.apache.flink.configuration.SecurityOptions;
 import org.apache.flink.kubernetes.KubernetesTestUtils;
 import org.apache.flink.kubernetes.kubeclient.FlinkPod;
+import org.apache.flink.kubernetes.kubeclient.KubernetesTaskManagerSpecification;
 import org.apache.flink.kubernetes.kubeclient.KubernetesTaskManagerTestBase;
+import org.apache.flink.kubernetes.kubeclient.decorators.HadoopConfMountDecorator;
 import org.apache.flink.kubernetes.utils.Constants;
 
+import io.fabric8.kubernetes.api.model.ConfigMap;
 import io.fabric8.kubernetes.api.model.Container;
 import io.fabric8.kubernetes.api.model.Pod;
 import org.junit.Test;
 
+import java.io.IOException;
 import java.util.List;
+import java.util.Map;
+import java.util.stream.Collectors;
 
 import static org.apache.flink.kubernetes.utils.Constants.CONFIG_FILE_LOG4J_NAME;
 import static org.apache.flink.kubernetes.utils.Constants.CONFIG_FILE_LOGBACK_NAME;
@@ -97,5 +103,38 @@ public class KubernetesTaskManagerFactoryTest extends KubernetesTaskManagerTestB
         // The args list is [bash, -c, 'java -classpath $FLINK_CLASSPATH ...'].
         assertEquals(3, resultMainContainer.getArgs().size());
         assertEquals(4, resultMainContainer.getVolumeMounts().size());
+    }
+
+    @Test
+    public void testHadoopConfConfigMap() throws IOException {
+        setHadoopConfDirEnv();
+        generateHadoopConfFileItems();
+
+        FlinkPod flinkPod = new FlinkPod.Builder().build();
+        KubernetesTaskManagerSpecification kubernetesJobManagerSpecification =
+                KubernetesTaskManagerFactory.buildKubernetesTaskManagerSpecification(
+                        flinkPod, kubernetesTaskManagerParameters);
+
+        final ConfigMap resultConfigMap =
+                (ConfigMap)
+                        kubernetesJobManagerSpecification.getAccompanyingResources().stream()
+                                .filter(
+                                        x ->
+                                                x instanceof ConfigMap
+                                                        && x.getMetadata()
+                                                        .getName()
+                                                        .equals(
+                                                                HadoopConfMountDecorator
+                                                                        .getHadoopConfConfigMapName(
+                                                                                CLUSTER_ID)))
+                                .collect(Collectors.toList())
+                                .get(0);
+
+        assertEquals(2, resultConfigMap.getMetadata().getLabels().size());
+
+        final Map<String, String> resultDatas = resultConfigMap.getData();
+        assertEquals(2, resultDatas.size());
+        assertEquals("some data", resultDatas.get("core-site.xml"));
+        assertEquals("some data", resultDatas.get("hdfs-site.xml"));
     }
 }

--- a/flink-kubernetes/src/test/java/org/apache/flink/kubernetes/kubeclient/factory/KubernetesTaskManagerFactoryTest.java
+++ b/flink-kubernetes/src/test/java/org/apache/flink/kubernetes/kubeclient/factory/KubernetesTaskManagerFactoryTest.java
@@ -64,7 +64,7 @@ public class KubernetesTaskManagerFactoryTest extends KubernetesTaskManagerTestB
         generateKerberosFileItems();
 
         this.resultPod =
-                KubernetesTaskManagerFactory.buildTaskManagerKubernetesPod(
+                KubernetesTaskManagerFactory.buildKubernetesTaskManagerSpecification(
                                 new FlinkPod.Builder().build(), kubernetesTaskManagerParameters)
                         .getKubernetesPod()
                         .getInternalResource();

--- a/flink-kubernetes/src/test/java/org/apache/flink/kubernetes/kubeclient/factory/KubernetesTaskManagerFactoryTest.java
+++ b/flink-kubernetes/src/test/java/org/apache/flink/kubernetes/kubeclient/factory/KubernetesTaskManagerFactoryTest.java
@@ -66,6 +66,7 @@ public class KubernetesTaskManagerFactoryTest extends KubernetesTaskManagerTestB
         this.resultPod =
                 KubernetesTaskManagerFactory.buildTaskManagerKubernetesPod(
                                 new FlinkPod.Builder().build(), kubernetesTaskManagerParameters)
+                        .getKubernetesPod()
                         .getInternalResource();
     }
 

--- a/flink-kubernetes/src/test/java/org/apache/flink/kubernetes/kubeclient/factory/KubernetesTaskManagerFactoryWithPodTemplateTest.java
+++ b/flink-kubernetes/src/test/java/org/apache/flink/kubernetes/kubeclient/factory/KubernetesTaskManagerFactoryWithPodTemplateTest.java
@@ -32,7 +32,7 @@ public class KubernetesTaskManagerFactoryWithPodTemplateTest
 
     @Override
     protected Pod getResultPod(FlinkPod podTemplate) throws IOException {
-        return KubernetesTaskManagerFactory.buildTaskManagerKubernetesPod(
+        return KubernetesTaskManagerFactory.buildKubernetesTaskManagerSpecification(
                         podTemplate,
                         KubernetesTestUtils.createTaskManagerParameters(
                                 flinkConfig, "taskmanager-" + UUID.randomUUID().toString()))

--- a/flink-kubernetes/src/test/java/org/apache/flink/kubernetes/kubeclient/factory/KubernetesTaskManagerFactoryWithPodTemplateTest.java
+++ b/flink-kubernetes/src/test/java/org/apache/flink/kubernetes/kubeclient/factory/KubernetesTaskManagerFactoryWithPodTemplateTest.java
@@ -23,6 +23,7 @@ import org.apache.flink.kubernetes.kubeclient.FlinkPod;
 
 import io.fabric8.kubernetes.api.model.Pod;
 
+import java.io.IOException;
 import java.util.UUID;
 
 /** General tests for the {@link KubernetesTaskManagerFactory} with pod template. */
@@ -30,11 +31,12 @@ public class KubernetesTaskManagerFactoryWithPodTemplateTest
         extends KubernetesFactoryWithPodTemplateTestBase {
 
     @Override
-    protected Pod getResultPod(FlinkPod podTemplate) {
+    protected Pod getResultPod(FlinkPod podTemplate) throws IOException {
         return KubernetesTaskManagerFactory.buildTaskManagerKubernetesPod(
                         podTemplate,
                         KubernetesTestUtils.createTaskManagerParameters(
                                 flinkConfig, "taskmanager-" + UUID.randomUUID().toString()))
+                .getKubernetesPod()
                 .getInternalResource();
     }
 }


### PR DESCRIPTION
## What is the purpose of the change

When creating Flink session cluster on K8S, Flink job manager won't create configmap for the Hadoop configuration stored in the Docker image.

Then when users submit Java application, the task manager Pods will not be abled to created, because it fails to mount the expected configmap of Hadoop configuration. This leads to a weird error and hard to understand for (new) Flink users.

This patch tries to fix this issue. So Flink users can include Hadoop classes and configuration in Docker image.

## Brief change log

  - *Create resouces for task manager Pods*

## Verifying this change

This change can be verified as follows:

  - *Manually verified the change by running a 6 node cluser with 1 JobManagers and 5 TaskManagers from a Docker image including Hadoop deps and configurations, a stateful streaming program, and verifying that TaskManage Pods can be created with Hadoop configmap.

## Does this pull request potentially affect one of the following parts:

  - Dependencies (does it add or upgrade a dependency): (yes / **no**)
  - The public API, i.e., is any changed class annotated with `@Public(Evolving)`: (yes / **no**)
  - The serializers: (yes / **no** / don't know)
  - The runtime per-record code paths (performance sensitive): (yes / **no** / don't know)
  - Anything that affects deployment or recovery: JobManager (and its components), Checkpointing, Kubernetes/Yarn, ZooKeeper: (yes / **no** / don't know)
  - The S3 file system connector: (yes / **no** / don't know)

## Documentation

  - Does this pull request introduce a new feature? (yes / **no**)
  - If yes, how is the feature documented? (not applicable / docs / JavaDocs / not documented)
