### PR TITLE
[FLINK-24639][kinesis] Add UniformShardAssigner

### DIFF
--- a/docs/content.zh/docs/connectors/datastream/kinesis.md
+++ b/docs/content.zh/docs/connectors/datastream/kinesis.md
@@ -121,10 +121,13 @@ then some consumer subtasks will simply be idle and wait until it gets assigned
 new shards (i.e., when the streams are resharded to increase the
 number of shards for higher provisioned Kinesis service throughput).
 
-Also note that the assignment of shards to subtasks may not be optimal when
-shard IDs are not consecutive (as result of dynamic re-sharding in Kinesis).
-For cases where skew in the assignment leads to significant imbalanced consumption,
-a custom implementation of `KinesisShardAssigner` can be set on the consumer.
+Also note that the default assignment of shards to subtasks is based on the hashes of the shard and stream names,
+which will more-or-less balance the shards across the subtasks.
+However, assuming the default Kinesis shard management is used on the stream (UpdateShardCount with `UNIFORM_SCALING`),
+setting `UniformShardAssigner` as the shard assigner on the consumer will much more evenly distribute shards to subtasks.
+Assuming the incoming Kinesis records are assigned random Kinesis `PartitionKey` or `ExplicitHashKey` values,
+the result is consistent subtask loading.
+If neither the default assigner nor the `UniformShardAssigner` suffice, a custom implementation of `KinesisShardAssigner` can be set.
 
 ### The `DeserializationSchema`
 

--- a/docs/content/docs/connectors/datastream/kinesis.md
+++ b/docs/content/docs/connectors/datastream/kinesis.md
@@ -121,10 +121,13 @@ then some consumer subtasks will simply be idle and wait until it gets assigned
 new shards (i.e., when the streams are resharded to increase the
 number of shards for higher provisioned Kinesis service throughput).
 
-Also note that the assignment of shards to subtasks may not be optimal when
-shard IDs are not consecutive (as result of dynamic re-sharding in Kinesis).
-For cases where skew in the assignment leads to significant imbalanced consumption,
-a custom implementation of `KinesisShardAssigner` can be set on the consumer.
+Also note that the default assignment of shards to subtasks is based on the hashes of the shard and stream names,
+which will more-or-less balance the shards across the subtasks.
+However, assuming the default Kinesis shard management is used on the stream (UpdateShardCount with `UNIFORM_SCALING`),
+setting `UniformShardAssigner` as the shard assigner on the consumer will much more evenly distribute shards to subtasks.
+Assuming the incoming Kinesis records are assigned random Kinesis `PartitionKey` or `ExplicitHashKey` values,
+the result is consistent subtask loading.
+If neither the default assigner nor the `UniformShardAssigner` suffice, a custom implementation of `KinesisShardAssigner` can be set.
 
 ### The `DeserializationSchema`
 

--- a/flink-connectors/flink-connector-kinesis/pom.xml
+++ b/flink-connectors/flink-connector-kinesis/pom.xml
@@ -174,6 +174,12 @@ under the License.
 		</dependency>
 		<dependency>
 			<groupId>org.apache.flink</groupId>
+			<artifactId>flink-connector-testing</artifactId>
+			<version>${project.version}</version>
+			<scope>test</scope>
+		</dependency>
+		<dependency>
+			<groupId>org.apache.flink</groupId>
 			<artifactId>flink-test-utils</artifactId>
 			<version>${project.version}</version>
 			<scope>test</scope>

--- a/flink-connectors/flink-connector-kinesis/src/main/java/org/apache/flink/streaming/connectors/kinesis/util/UniformShardAssigner.java
+++ b/flink-connectors/flink-connector-kinesis/src/main/java/org/apache/flink/streaming/connectors/kinesis/util/UniformShardAssigner.java
@@ -48,7 +48,11 @@ public class UniformShardAssigner implements KinesisShardAssigner {
         BigInteger hashKeyStart = new BigInteger(range.getStartingHashKey());
         BigInteger hashKeyEnd = new BigInteger(range.getEndingHashKey());
         BigInteger hashKeyMid = hashKeyStart.add(hashKeyEnd).divide(TWO);
-        // index = hashKeyMid / HASH_KEY_BOUND * nSubtasks
-        return hashKeyMid.multiply(BigInteger.valueOf(nSubtasks)).divide(HASH_KEY_BOUND).intValue();
+        // index = hashKeyMid / HASH_KEY_BOUND * nSubtasks + stream-specific offset
+        // The stream specific offset is added so that different streams will be less likely to be
+        // distributed in the same way, even if they are sharded in the same way.
+        // (The caller takes result modulo nSubtasks.)
+        return hashKeyMid.multiply(BigInteger.valueOf(nSubtasks)).divide(HASH_KEY_BOUND).intValue()
+                + streamShardHandle.getStreamName().hashCode();
     }
 }

--- a/flink-connectors/flink-connector-kinesis/src/main/java/org/apache/flink/streaming/connectors/kinesis/util/UniformShardAssigner.java
+++ b/flink-connectors/flink-connector-kinesis/src/main/java/org/apache/flink/streaming/connectors/kinesis/util/UniformShardAssigner.java
@@ -1,0 +1,54 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.flink.streaming.connectors.kinesis.util;
+
+import org.apache.flink.annotation.PublicEvolving;
+import org.apache.flink.streaming.connectors.kinesis.KinesisShardAssigner;
+import org.apache.flink.streaming.connectors.kinesis.model.StreamShardHandle;
+
+import com.amazonaws.services.kinesis.model.HashKeyRange;
+
+import java.math.BigInteger;
+
+/**
+ * A {@link KinesisShardAssigner} that maps Kinesis shard hash-key ranges to Flink subtasks. It
+ * creates a more uniform distribution of shards across subtasks than {@link
+ * org.apache.flink.streaming.connectors.kinesis.internals.KinesisDataFetcher#DEFAULT_SHARD_ASSIGNER}
+ * when the Kinesis records in the stream have hash keys that are uniformly distributed over all
+ * possible hash keys, which is the case if records have randomly-generated partition keys. (This is
+ * the same assumption made if you use the Kinesis UpdateShardCount operation with UNIFORM_SCALING.)
+ */
+@PublicEvolving
+public class UniformShardAssigner implements KinesisShardAssigner {
+
+    // BigInteger.TWO only available in Java versions > 8
+    private static final BigInteger TWO = BigInteger.valueOf(2);
+
+    // Kinesis data stream hash keys are < 2^128.
+    private static final BigInteger HASH_KEY_BOUND = TWO.pow(128);
+
+    @Override
+    public int assign(StreamShardHandle streamShardHandle, int nSubtasks) {
+        HashKeyRange range = streamShardHandle.getShard().getHashKeyRange();
+        BigInteger hashKeyStart = new BigInteger(range.getStartingHashKey());
+        BigInteger hashKeyEnd = new BigInteger(range.getEndingHashKey());
+        BigInteger hashKeyMid = hashKeyStart.add(hashKeyEnd).divide(TWO);
+        // index = hashKeyMid / HASH_KEY_BOUND * nSubtasks
+        return hashKeyMid.multiply(BigInteger.valueOf(nSubtasks)).divide(HASH_KEY_BOUND).intValue();
+    }
+}

--- a/flink-connectors/flink-connector-kinesis/src/test/java/org/apache/flink/streaming/connectors/kinesis/util/UniformShardAssignerTest.java
+++ b/flink-connectors/flink-connector-kinesis/src/test/java/org/apache/flink/streaming/connectors/kinesis/util/UniformShardAssignerTest.java
@@ -65,9 +65,11 @@ public class UniformShardAssignerTest {
                                 new HashKeyRange()
                                         .withStartingHashKey(rangeStart.toString())
                                         .withEndingHashKey(rangeEnd.toString()));
-        StreamShardHandle handle = new StreamShardHandle("streamName", shard);
+        StreamShardHandle handle = new StreamShardHandle("", shard);
+        // streamName = "" hashes to zero
 
         Assertions.assertEquals(
-                expectedSubtask, new UniformShardAssigner().assign(handle, nSubtasks));
+                expectedSubtask,
+                Math.abs(new UniformShardAssigner().assign(handle, nSubtasks)) % nSubtasks);
     }
 }

--- a/flink-connectors/flink-connector-kinesis/src/test/java/org/apache/flink/streaming/connectors/kinesis/util/UniformShardAssignerTest.java
+++ b/flink-connectors/flink-connector-kinesis/src/test/java/org/apache/flink/streaming/connectors/kinesis/util/UniformShardAssignerTest.java
@@ -1,0 +1,73 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.flink.streaming.connectors.kinesis.util;
+
+import org.apache.flink.connectors.test.common.junit.extensions.TestLoggerExtension;
+import org.apache.flink.streaming.connectors.kinesis.model.StreamShardHandle;
+
+import com.amazonaws.services.kinesis.model.HashKeyRange;
+import com.amazonaws.services.kinesis.model.Shard;
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.Arguments;
+import org.junit.jupiter.params.provider.MethodSource;
+
+import java.math.BigInteger;
+import java.util.stream.Stream;
+
+/** Tests for the {@link UniformShardAssigner}. */
+@ExtendWith(TestLoggerExtension.class)
+public class UniformShardAssignerTest {
+
+    static Stream<Arguments> testCaseProvider() {
+        BigInteger two = BigInteger.valueOf(2);
+        BigInteger three = BigInteger.valueOf(3);
+        // split the hash key range into thirds
+        BigInteger maxHashKey = two.pow(128).subtract(BigInteger.ONE);
+        BigInteger[] rangeBoundaries = {
+            BigInteger.ZERO,
+            maxHashKey.divide(three),
+            maxHashKey.divide(three).multiply(two),
+            maxHashKey
+        };
+        return Stream.of(
+                Arguments.of(BigInteger.ZERO, BigInteger.ZERO, 3, 0),
+                Arguments.of(rangeBoundaries[0], rangeBoundaries[1], 3, 0),
+                Arguments.of(rangeBoundaries[1], rangeBoundaries[2], 3, 1),
+                Arguments.of(rangeBoundaries[2], rangeBoundaries[3], 3, 2),
+                Arguments.of(maxHashKey, maxHashKey, 3, 2));
+    }
+
+    @ParameterizedTest
+    @MethodSource("testCaseProvider")
+    public void testAssignment(
+            BigInteger rangeStart, BigInteger rangeEnd, int nSubtasks, int expectedSubtask) {
+        Shard shard =
+                new Shard()
+                        .withShardId("shardId-000000003378")
+                        .withHashKeyRange(
+                                new HashKeyRange()
+                                        .withStartingHashKey(rangeStart.toString())
+                                        .withEndingHashKey(rangeEnd.toString()));
+        StreamShardHandle handle = new StreamShardHandle("streamName", shard);
+
+        Assertions.assertEquals(
+                expectedSubtask, new UniformShardAssigner().assign(handle, nSubtasks));
+    }
+}


### PR DESCRIPTION
## What is the purpose of the change

Add UniformShardAssigner to assign Kinesis shards to subtasks. This algorithm takes advantage of the Kinesis hash-key space that each shard occupies. By default, each shard is assigned an equal-sized range of hash-key space. And UpdateShardCount (with `UNIFORM_SCALING`) tries to preserve this. So we can nicely assign shards to subtasks by mapping through hash-key space.

However, some users may have customized how shards are distributed, such that they occupy ranges of hash-key space that vary greatly in size. For such users, the default shard assignment will likely work better. Hence, I have not changed the default here.

Please refer to the Jira ticket for a longer write-up, including performance comparison with the default assigner.

## Brief change log

 - Add UniformShardAssigner
 - Unit testing for above
 - Documentation for above

## Verifying this change

This change added tests and can be verified as follows:

- Added unit test to ensure hash key space is correctly mapped to subtask-index space.

## Does this pull request potentially affect one of the following parts:

  - Dependencies (does it add or upgrade a dependency): no
  - The public API, i.e., is any changed class annotated with `@Public(Evolving)`: yes - a new class with `@PublicEvolving` annotation
  - The serializers: no
  - The runtime per-record code paths (performance sensitive): no
  - Anything that affects deployment or recovery: JobManager (and its components), Checkpointing, Kubernetes/Yarn, ZooKeeper: no
  - The S3 file system connector: no

## Documentation

  - Does this pull request introduce a new feature? yes
  - If yes, how is the feature documented? docs + JavaDocs
