### PR TITLE
[FLINK-24676][table-planner] Fix schema mismatch exception if explain insert with partial column

### DIFF
--- a/flink-table/flink-table-planner/src/test/resources/explain/testExecuteSqlWithExplainInsertPartialColumn.out
+++ b/flink-table/flink-table-planner/src/test/resources/explain/testExecuteSqlWithExplainInsertPartialColumn.out
@@ -1,0 +1,15 @@
+== Abstract Syntax Tree ==
+LogicalLegacySink(name=[`default_catalog`.`default_database`.`MySink`], fields=[d, e])
++- LogicalProject(a=[$0], EXPR$1=[null:INTEGER])
+   +- LogicalFilter(condition=[>($0, 10)])
+      +- LogicalTableScan(table=[[default_catalog, default_database, MyTable, source: [CollectionTableSource(a, b, c)]]])
+
+== Optimized Physical Plan ==
+LegacySink(name=[`default_catalog`.`default_database`.`MySink`], fields=[d, e])
++- Calc(select=[a, null:INTEGER AS EXPR$1], where=[>(a, 10)])
+   +- LegacyTableSourceScan(table=[[default_catalog, default_database, MyTable, source: [CollectionTableSource(a, b, c)]]], fields=[a, b, c])
+
+== Optimized Execution Plan ==
+LegacySink(name=[`default_catalog`.`default_database`.`MySink`], fields=[d, e])
++- Calc(select=[a, null:INTEGER AS EXPR$1], where=[(a > 10)])
+   +- LegacyTableSourceScan(table=[[default_catalog, default_database, MyTable, source: [CollectionTableSource(a, b, c)]]], fields=[a, b, c])

--- a/flink-table/flink-table-planner/src/test/scala/org/apache/flink/table/api/TableEnvironmentTest.scala
+++ b/flink-table/flink-table-planner/src/test/scala/org/apache/flink/table/api/TableEnvironmentTest.scala
@@ -1258,6 +1258,9 @@ class TableEnvironmentTest {
 
     checkExplain("explain plan for insert into MySink select a, b from MyTable where a > 10",
       "/explain/testExecuteSqlWithExplainInsert.out")
+
+    checkExplain("explain plan for insert into MySink(d) select a from MyTable where a > 10",
+      "/explain/testExecuteSqlWithExplainInsertPartialColumn.out")
   }
 
   @Test


### PR DESCRIPTION

## What is the purpose of the change

*Fix schema mismatch exception if explain insert with partial column, please refer to the desc of FLINK-24676 to see the example*


## Brief change log

  - *PreValidateReWriter should consider SqlRichExplain if the statement is insert*


## Verifying this change


This change added tests and can be verified as follows:

  - *Extended test in TableEnvironmentTest#testExecuteSqlWithExplainInsert to test the change*

## Does this pull request potentially affect one of the following parts:

  - Dependencies (does it add or upgrade a dependency): (yes / **no**)
  - The public API, i.e., is any changed class annotated with `@Public(Evolving)`: (yes / **no**)
  - The serializers: (yes / **no** / don't know)
  - The runtime per-record code paths (performance sensitive): (yes / **no** / don't know)
  - Anything that affects deployment or recovery: JobManager (and its components), Checkpointing, Kubernetes/Yarn, ZooKeeper: (yes / **no** / don't know)
  - The S3 file system connector: (yes / **no** / don't know)

## Documentation

  - Does this pull request introduce a new feature? (yes / **no**)
  - If yes, how is the feature documented? (not applicable / docs / JavaDocs / **not documented**)
