### PR TITLE
[FLINK-24408][table-planner] Enable code splitting for large number of VALUES clause

### DIFF
--- a/flink-table/flink-table-code-splitter/src/main/java/org/apache/flink/table/codesplit/JavaCodeSplitter.java
+++ b/flink-table/flink-table-code-splitter/src/main/java/org/apache/flink/table/codesplit/JavaCodeSplitter.java
@@ -32,6 +32,9 @@ public class JavaCodeSplitter {
 
     public static String split(String code, int maxMethodLength, int maxClassMemberCount) {
         try {
+            if (code.length() <= maxMethodLength) {
+                return code;
+            }
             return splitImpl(code, maxMethodLength, maxClassMemberCount);
         } catch (Throwable t) {
             System.out.println(code);

--- a/flink-table/flink-table-planner/src/main/scala/org/apache/flink/table/planner/codegen/InputFormatCodeGenerator.scala
+++ b/flink-table/flink-table-planner/src/main/scala/org/apache/flink/table/planner/codegen/InputFormatCodeGenerator.scala
@@ -72,17 +72,17 @@ object InputFormatCodeGenerator {
 
         @Override
         public Object nextRecord(Object reuse) {
-          switch (nextIdx) {
-            ${records.zipWithIndex.map { case (r, i) =>
-              s"""
-                 |case $i:
-                 |  $r
-                 |break;
-                       """.stripMargin
-            }.mkString("\n")}
-          }
-          nextIdx++;
-          return $outRecordTerm;
+          ${records.zipWithIndex.map { case (r, i) =>
+            s"""
+              |if (nextIdx == $i) {
+              |  $r
+              |  nextIdx++;
+              |  return $outRecordTerm;
+              |}
+              |""".stripMargin
+          }.mkString("")}
+          throw new IllegalStateException(
+            "Invalid nextIdx " + nextIdx + ". This is a bug. Please file an issue");
         }
       }
     """.stripMargin

--- a/flink-table/flink-table-planner/src/test/scala/org/apache/flink/table/planner/runtime/batch/sql/CodeSplitITCase.scala
+++ b/flink-table/flink-table-planner/src/test/scala/org/apache/flink/table/planner/runtime/batch/sql/CodeSplitITCase.scala
@@ -24,11 +24,11 @@ import org.apache.flink.table.planner.runtime.utils.BatchTestBase
 import org.apache.flink.table.planner.runtime.utils.BatchTestBase.row
 import org.apache.flink.table.planner.runtime.utils.TestData.{nullablesOfData3, smallData3, type3}
 import org.apache.flink.types.Row
-
 import org.hamcrest.MatcherAssert
 import org.junit.{Assert, Before, Test}
-
 import java.io.{OutputStream, PrintStream}
+
+import org.apache.flink.table.planner.factories.TestValuesTableFactory
 
 import scala.collection.Seq
 
@@ -90,6 +90,34 @@ class CodeSplitITCase extends BatchTestBase {
     }
 
     runTest(sql.mkString, Seq(result))
+  }
+
+  @Test
+  def testManyValues(): Unit = {
+    tEnv.executeSql(
+      s"""
+         |CREATE TABLE test_many_values (
+         |${Range(0, 100).map(i => s"  f$i INT").mkString(",\n")}
+         |) WITH (
+         |  'connector' = 'values'
+         |)
+         |""".stripMargin
+    ).await()
+
+    tEnv.executeSql(
+      s"""
+         |INSERT INTO test_many_values VALUES
+         |${Range(0, 100)
+        .map(i => "(" + Range(0, 100).map(_ => s"$i").mkString(", ") + ")")
+        .mkString(", ")}
+         |""".stripMargin
+    ).await()
+
+    val expected = new java.util.ArrayList[String]()
+    for (i <- 0 until 100) {
+      expected.add(s"+I[${Range(0, 100).map(_ => s"$i").mkString(", ")}]")
+    }
+    Assert.assertEquals(expected, TestValuesTableFactory.getResults("test_many_values"))
   }
 
   private[flink] def runTest(sql: String, results: Seq[Row]): Unit = {

--- a/flink-table/flink-table-planner/src/test/scala/org/apache/flink/table/planner/runtime/batch/sql/CodeSplitITCase.scala
+++ b/flink-table/flink-table-planner/src/test/scala/org/apache/flink/table/planner/runtime/batch/sql/CodeSplitITCase.scala
@@ -20,15 +20,16 @@ package org.apache.flink.table.planner.runtime.batch.sql
 
 import org.apache.flink.core.testutils.FlinkMatchers
 import org.apache.flink.table.api.config.TableConfigOptions
+import org.apache.flink.table.planner.factories.TestValuesTableFactory
 import org.apache.flink.table.planner.runtime.utils.BatchTestBase
 import org.apache.flink.table.planner.runtime.utils.BatchTestBase.row
 import org.apache.flink.table.planner.runtime.utils.TestData.{nullablesOfData3, smallData3, type3}
 import org.apache.flink.types.Row
+
 import org.hamcrest.MatcherAssert
 import org.junit.{Assert, Before, Test}
-import java.io.{OutputStream, PrintStream}
 
-import org.apache.flink.table.planner.factories.TestValuesTableFactory
+import java.io.{OutputStream, PrintStream}
 
 import scala.collection.Seq
 


### PR DESCRIPTION
## What is the purpose of the change

Currently `VALUES` clause are implemented using `switch` java statements. However the java code splitter module does not handle `switch` statements. To enable code splitting for `VALUES` clause, this PR changes the implementation from `switch` to `if`.

## Brief change log

 - Enable code splitting for large number of VALUES clause.

## Verifying this change

This change added tests and can be verified by running the added tests.

## Does this pull request potentially affect one of the following parts:

  - Dependencies (does it add or upgrade a dependency): no
  - The public API, i.e., is any changed class annotated with `@Public(Evolving)`: no
  - The serializers: no
  - The runtime per-record code paths (performance sensitive): no
  - Anything that affects deployment or recovery: JobManager (and its components), Checkpointing, Kubernetes/Yarn, ZooKeeper: no
  - The S3 file system connector: no

## Documentation

  - Does this pull request introduce a new feature? no
  - If yes, how is the feature documented? not applicable
