### PR TITLE
[FLINK-24681] set initial offset to OffsetResetStrategy.LATEST

### DIFF
--- a/flink-connectors/flink-connector-kafka/src/main/java/org/apache/flink/connector/kafka/source/enumerator/initializer/OffsetsInitializer.java
+++ b/flink-connectors/flink-connector-kafka/src/main/java/org/apache/flink/connector/kafka/source/enumerator/initializer/OffsetsInitializer.java
@@ -105,7 +105,7 @@ public interface OffsetsInitializer extends Serializable {
      * @return an offset initializer which initialize the offsets to the committed offsets.
      */
     static OffsetsInitializer committedOffsets() {
-        return committedOffsets(OffsetResetStrategy.NONE);
+        return committedOffsets(OffsetResetStrategy.LATEST);
     }
 
     /**


### PR DESCRIPTION
Currently, initial offset is OffsetResetStrategy.NONE, which cause NoOffsetForPartitionException. Fix initial offset to OffsetResetStrategy.LATEST.