### PR TITLE
[FLINK-24673][formats] Deprecate old Row SerializationSchema/DeserializationSchema

### DIFF
--- a/flink-formats/flink-avro/src/main/java/org/apache/flink/formats/avro/AvroRowDeserializationSchema.java
+++ b/flink-formats/flink-avro/src/main/java/org/apache/flink/formats/avro/AvroRowDeserializationSchema.java
@@ -19,6 +19,7 @@ package org.apache.flink.formats.avro;
 
 import org.apache.flink.annotation.PublicEvolving;
 import org.apache.flink.api.common.serialization.AbstractDeserializationSchema;
+import org.apache.flink.api.common.serialization.DeserializationSchema;
 import org.apache.flink.api.common.typeinfo.BasicArrayTypeInfo;
 import org.apache.flink.api.common.typeinfo.TypeInformation;
 import org.apache.flink.api.common.typeinfo.Types;
@@ -76,8 +77,13 @@ import java.util.TimeZone;
  *
  * <p>Note: Changes in this class need to be kept in sync with the corresponding runtime class
  * {@link AvroRowSerializationSchema} and schema converter {@link AvroSchemaConverter}.
+ *
+ * @deprecated The format was developed for the Table API users and will not be maintained for
+ *     DataStream API users anymore. Either use Table API or switch to Data Stream, defining your
+ *     own {@link DeserializationSchema}.
  */
 @PublicEvolving
+@Deprecated
 public class AvroRowDeserializationSchema extends AbstractDeserializationSchema<Row> {
     /** Used for time conversions into SQL types. */
     private static final TimeZone LOCAL_TZ = TimeZone.getDefault();

--- a/flink-formats/flink-avro/src/main/java/org/apache/flink/formats/avro/AvroRowSerializationSchema.java
+++ b/flink-formats/flink-avro/src/main/java/org/apache/flink/formats/avro/AvroRowSerializationSchema.java
@@ -65,7 +65,12 @@ import java.util.TimeZone;
  *
  * <p>Note: Changes in this class need to be kept in sync with the corresponding runtime class
  * {@link AvroRowDeserializationSchema} and schema converter {@link AvroSchemaConverter}.
+ *
+ * @deprecated The format was developed for the Table API users and will not be maintained for
+ *     DataStream API users anymore. Either use Table API or switch to Data Stream, defining your
+ *     own {@link SerializationSchema}.
  */
+@Deprecated
 public class AvroRowSerializationSchema implements SerializationSchema<Row> {
 
     /** Used for time conversions from SQL types. */

--- a/flink-formats/flink-csv/src/main/java/org/apache/flink/formats/csv/CsvRowDeserializationSchema.java
+++ b/flink-formats/flink-csv/src/main/java/org/apache/flink/formats/csv/CsvRowDeserializationSchema.java
@@ -57,8 +57,13 @@ import static org.apache.flink.formats.common.TimeFormats.SQL_TIMESTAMP_WITH_LOC
  * Row}.
  *
  * <p>Failure during deserialization are forwarded as wrapped {@link IOException}s.
+ *
+ * @deprecated The format was developed for the Table API users and will not be maintained for
+ *     DataStream API users anymore. Either use Table API or switch to Data Stream, defining your
+ *     own {@link DeserializationSchema}.
  */
 @PublicEvolving
+@Deprecated
 public final class CsvRowDeserializationSchema implements DeserializationSchema<Row> {
 
     private static final long serialVersionUID = 2135553495874539201L;

--- a/flink-formats/flink-csv/src/main/java/org/apache/flink/formats/csv/CsvRowSerializationSchema.java
+++ b/flink-formats/flink-csv/src/main/java/org/apache/flink/formats/csv/CsvRowSerializationSchema.java
@@ -56,8 +56,13 @@ import static org.apache.flink.formats.common.TimeFormats.SQL_TIMESTAMP_WITH_LOC
  *
  * <p>Result <code>byte[]</code> messages can be deserialized using {@link
  * CsvRowDeserializationSchema}.
+ *
+ * @deprecated The format was developed for the Table API users and will not be maintained for
+ *     DataStream API users anymore. Either use Table API or switch to Data Stream, defining your
+ *     own {@link SerializationSchema}.
  */
 @PublicEvolving
+@Deprecated
 public final class CsvRowSerializationSchema implements SerializationSchema<Row> {
 
     private static final long serialVersionUID = 2098447220136965L;

--- a/flink-formats/flink-json/src/main/java/org/apache/flink/formats/json/JsonRowDeserializationSchema.java
+++ b/flink-formats/flink-json/src/main/java/org/apache/flink/formats/json/JsonRowDeserializationSchema.java
@@ -77,8 +77,13 @@ import static org.apache.flink.util.Preconditions.checkNotNull;
  * <p>Deserializes a <code>byte[]</code> message as a JSON object and reads the specified fields.
  *
  * <p>Failures during deserialization are forwarded as wrapped IOExceptions.
+ *
+ * @deprecated The format was developed for the Table API users and will not be maintained for
+ *     DataStream API users anymore. Either use Table API or switch to Data Stream, defining your
+ *     own {@link DeserializationSchema}.
  */
 @PublicEvolving
+@Deprecated
 public class JsonRowDeserializationSchema implements DeserializationSchema<Row> {
 
     private static final long serialVersionUID = -228294330688809195L;

--- a/flink-formats/flink-json/src/main/java/org/apache/flink/formats/json/JsonRowSerializationSchema.java
+++ b/flink-formats/flink-json/src/main/java/org/apache/flink/formats/json/JsonRowSerializationSchema.java
@@ -64,8 +64,13 @@ import static org.apache.flink.util.Preconditions.checkNotNull;
  *
  * <p>Result <code>byte[]</code> messages can be deserialized using {@link
  * JsonRowDeserializationSchema}.
+ *
+ * @deprecated The format was developed for the Table API users and will not be maintained for
+ *     DataStream API users anymore. Either use Table API or switch to Data Stream, defining your
+ *     own {@link SerializationSchema}.
  */
 @PublicEvolving
+@Deprecated
 public class JsonRowSerializationSchema implements SerializationSchema<Row> {
 
     private static final long serialVersionUID = -2885556750743978636L;


### PR DESCRIPTION
## What is the purpose of the change

Deprecate old Row SerializationSchema/DeserializationSchema. For more details: https://lists.apache.org/thread.html/red2f04ac782f2cd156a639a44c9962b7b92659b76e5ff683de664534%40%3Cdev.flink.apache.org%3E

## Brief change log

Deprecated:
   - org.apache.flink.formats.json.JsonRowSerializationSchema
   - org.apache.flink.formats.json.JsonRowDeserializationSchema
   - org.apache.flink.formats.avro.AvroRowSerializationSchema
   - org.apache.flink.formats.avro.AvroRowDeserializationSchema
   - org.apache.flink.formats.csv.CsvRowDeserializationSchema
   - org.apache.flink.formats.csv.CsvRowSerializationSchema

## Verifying this change

This change is a trivial rework / code cleanup without any test coverage.

## Does this pull request potentially affect one of the following parts:

  - Dependencies (does it add or upgrade a dependency): no
  - The public API, i.e., is any changed class annotated with `@Public(Evolving)`: yes
  - The serializers: yes
  - The runtime per-record code paths (performance sensitive): no
  - Anything that affects deployment or recovery: JobManager (and its components), Checkpointing, Kubernetes/Yarn, ZooKeeper: no
  - The S3 file system connector: no

## Documentation

  - Does this pull request introduce a new feature? no
  - If yes, how is the feature documented? not applicable
