### PR TITLE
[FLINK-24603][e2e] Add test for Scala-free Flink 

### DIFF
--- a/flink-end-to-end-tests/flink-end-to-end-tests-common/src/main/java/org/apache/flink/tests/util/flink/FlinkDistribution.java
+++ b/flink-end-to-end-tests/flink-end-to-end-tests-common/src/main/java/org/apache/flink/tests/util/flink/FlinkDistribution.java
@@ -169,6 +169,13 @@ final class FlinkDistribution {
             commands.add("-p");
             commands.add(String.valueOf(jobSubmission.getParallelism()));
         }
+        jobSubmission
+                .getMainClass()
+                .ifPresent(
+                        mainClass -> {
+                            commands.add("--class");
+                            commands.add(mainClass);
+                        });
         commands.add(jobSubmission.getJar().toAbsolutePath().toString());
         commands.addAll(jobSubmission.getArguments());
 

--- a/flink-end-to-end-tests/flink-end-to-end-tests-common/src/main/java/org/apache/flink/tests/util/flink/FlinkDistribution.java
+++ b/flink-end-to-end-tests/flink-end-to-end-tests-common/src/main/java/org/apache/flink/tests/util/flink/FlinkDistribution.java
@@ -188,24 +188,14 @@ final class FlinkDistribution {
                     }
                 };
 
-        try (AutoClosableProcess flink =
-                AutoClosableProcess.create(commands.toArray(new String[0]))
-                        .setStdoutProcessor(stdoutProcessor)
-                        .runNonBlocking()) {
-            if (jobSubmission.isDetached()) {
-                try {
-                    flink.getProcess().waitFor();
-                } catch (InterruptedException e) {
-                    Thread.currentThread().interrupt();
-                }
-            }
+        AutoClosableProcess.create(commands.toArray(new String[0]))
+                .setStdoutProcessor(stdoutProcessor)
+                .runBlocking();
 
-            try {
-                return JobID.fromHexString(
-                        rawJobIdFuture.get(timeout.getSeconds(), TimeUnit.SECONDS));
-            } catch (Exception e) {
-                throw new IOException("Could not determine Job ID.", e);
-            }
+        try {
+            return JobID.fromHexString(rawJobIdFuture.get(timeout.getSeconds(), TimeUnit.SECONDS));
+        } catch (Exception e) {
+            throw new IOException("Could not determine Job ID.", e);
         }
     }
 

--- a/flink-end-to-end-tests/flink-end-to-end-tests-common/src/main/java/org/apache/flink/tests/util/flink/FlinkResourceSetup.java
+++ b/flink-end-to-end-tests/flink-end-to-end-tests-common/src/main/java/org/apache/flink/tests/util/flink/FlinkResourceSetup.java
@@ -22,6 +22,7 @@ import org.apache.flink.util.Preconditions;
 
 import javax.annotation.Nullable;
 
+import java.nio.file.Path;
 import java.util.ArrayList;
 import java.util.Collection;
 import java.util.Collections;
@@ -32,11 +33,15 @@ public class FlinkResourceSetup {
 
     @Nullable private final Configuration config;
     private final Collection<JarOperation> jarOperations;
+    private final Collection<JarAddition> jarAdditions;
 
     private FlinkResourceSetup(
-            @Nullable Configuration config, Collection<JarOperation> jarOperations) {
+            @Nullable Configuration config,
+            Collection<JarOperation> jarOperations,
+            Collection<JarAddition> jarAdditions) {
         this.config = config;
         this.jarOperations = Preconditions.checkNotNull(jarOperations);
+        this.jarAdditions = Preconditions.checkNotNull(jarAdditions);
     }
 
     public Optional<Configuration> getConfig() {
@@ -45,6 +50,10 @@ public class FlinkResourceSetup {
 
     public Collection<JarOperation> getJarOperations() {
         return jarOperations;
+    }
+
+    public Collection<JarAddition> getJarAdditions() {
+        return jarAdditions;
     }
 
     public static FlinkResourceSetupBuilder builder() {
@@ -56,11 +65,17 @@ public class FlinkResourceSetup {
 
         private Configuration config;
         private final Collection<JarOperation> jarOperations = new ArrayList<>();
+        private final Collection<JarAddition> jarAdditions = new ArrayList<>();
 
         private FlinkResourceSetupBuilder() {}
 
         public FlinkResourceSetupBuilder addConfiguration(Configuration config) {
             this.config = config;
+            return this;
+        }
+
+        public FlinkResourceSetupBuilder addJar(Path jar, JarLocation target) {
+            this.jarAdditions.add(new JarAddition(jar, target));
             return this;
         }
 
@@ -82,7 +97,9 @@ public class FlinkResourceSetup {
 
         public FlinkResourceSetup build() {
             return new FlinkResourceSetup(
-                    config, Collections.unmodifiableCollection(jarOperations));
+                    config,
+                    Collections.unmodifiableCollection(jarOperations),
+                    Collections.unmodifiableCollection(jarAdditions));
         }
     }
 }

--- a/flink-end-to-end-tests/flink-end-to-end-tests-common/src/main/java/org/apache/flink/tests/util/flink/JarAddition.java
+++ b/flink-end-to-end-tests/flink-end-to-end-tests-common/src/main/java/org/apache/flink/tests/util/flink/JarAddition.java
@@ -1,0 +1,40 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.flink.tests.util.flink;
+
+import java.nio.file.Path;
+
+/** Represents an add operation for a jar. */
+class JarAddition {
+
+    private final Path jar;
+    private final JarLocation target;
+
+    JarAddition(Path jar, JarLocation target) {
+        this.jar = jar;
+        this.target = target;
+    }
+
+    public Path getJar() {
+        return jar;
+    }
+
+    public JarLocation getTarget() {
+        return target;
+    }
+}

--- a/flink-end-to-end-tests/flink-end-to-end-tests-common/src/main/java/org/apache/flink/tests/util/flink/JobSubmission.java
+++ b/flink-end-to-end-tests/flink-end-to-end-tests-common/src/main/java/org/apache/flink/tests/util/flink/JobSubmission.java
@@ -20,25 +20,32 @@ package org.apache.flink.tests.util.flink;
 
 import org.apache.flink.util.Preconditions;
 
+import javax.annotation.Nullable;
+
 import java.nio.file.Path;
 import java.util.ArrayList;
 import java.util.Collections;
 import java.util.List;
+import java.util.Optional;
 
 /** Programmatic definition of a job-submission. */
 public class JobSubmission {
 
     private final Path jar;
+
+    private final String mainClass;
     private final int parallelism;
     private final boolean detached;
     private final List<String> arguments;
 
     JobSubmission(
             final Path jar,
+            @Nullable final String mainClass,
             final int parallelism,
             final boolean detached,
             final List<String> arguments) {
         this.jar = jar;
+        this.mainClass = mainClass;
         this.parallelism = parallelism;
         this.detached = detached;
         this.arguments = Collections.unmodifiableList(arguments);
@@ -60,17 +67,33 @@ public class JobSubmission {
         return jar;
     }
 
+    public Optional<String> getMainClass() {
+        return Optional.ofNullable(mainClass);
+    }
+
     /** Builder for the {@link JobSubmission}. */
     public static class JobSubmissionBuilder {
         private final Path jar;
         private int parallelism = 0;
         private final List<String> arguments = new ArrayList<>(2);
         private boolean detached = false;
+        private String mainClass = null;
 
         public JobSubmissionBuilder(final Path jar) {
             Preconditions.checkNotNull(jar);
             Preconditions.checkArgument(jar.isAbsolute(), "Jar path must be absolute.");
             this.jar = jar;
+        }
+
+        /**
+         * Sets the main class for the job.
+         *
+         * @param mainClass main class for the job
+         * @return the modified builder
+         */
+        public JobSubmissionBuilder setMainClass(final String mainClass) {
+            this.mainClass = mainClass;
+            return this;
         }
 
         /**
@@ -122,7 +145,7 @@ public class JobSubmission {
         }
 
         public JobSubmission build() {
-            return new JobSubmission(jar, parallelism, detached, arguments);
+            return new JobSubmission(jar, mainClass, parallelism, detached, arguments);
         }
     }
 }

--- a/flink-end-to-end-tests/flink-end-to-end-tests-common/src/main/java/org/apache/flink/tests/util/flink/LocalStandaloneFlinkResource.java
+++ b/flink-end-to-end-tests/flink-end-to-end-tests-common/src/main/java/org/apache/flink/tests/util/flink/LocalStandaloneFlinkResource.java
@@ -85,6 +85,9 @@ public class LocalStandaloneFlinkResource implements FlinkResource {
         for (JarOperation jarOperation : setup.getJarOperations()) {
             distribution.performJarOperation(jarOperation);
         }
+        for (JarAddition jarAddition : setup.getJarAdditions()) {
+            distribution.performJarAddition(jarAddition);
+        }
         if (setup.getConfig().isPresent()) {
             distribution.appendConfiguration(setup.getConfig().get());
         }

--- a/flink-end-to-end-tests/flink-end-to-end-tests-scala/pom.xml
+++ b/flink-end-to-end-tests/flink-end-to-end-tests-scala/pom.xml
@@ -1,0 +1,229 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!--
+Licensed to the Apache Software Foundation (ASF) under one
+or more contributor license agreements.  See the NOTICE file
+distributed with this work for additional information
+regarding copyright ownership.  The ASF licenses this file
+to you under the Apache License, Version 2.0 (the
+"License"); you may not use this file except in compliance
+with the License.  You may obtain a copy of the License at
+  http://www.apache.org/licenses/LICENSE-2.0
+Unless required by applicable law or agreed to in writing,
+software distributed under the License is distributed on an
+"AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+KIND, either express or implied.  See the License for the
+specific language governing permissions and limitations
+under the License.
+-->
+<project xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd"
+		 xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance">
+
+	<parent>
+		<artifactId>flink-end-to-end-tests</artifactId>
+		<groupId>org.apache.flink</groupId>
+		<version>1.15-SNAPSHOT</version>
+	</parent>
+
+	<modelVersion>4.0.0</modelVersion>
+
+	<artifactId>flink-end-to-end-tests-scala</artifactId>
+	<name>Flink : E2E Tests : Scala</name>
+
+	<properties>
+		<!-- Use an old version that is not actively supported by Flink.
+		 	2.11 still 'just works' with our current maven setup,
+		 	and going forward we won't add support for it again.-->
+		<scala.version>2.11.12</scala.version>
+	</properties>
+
+	<dependencies>
+		<dependency>
+			<groupId>org.apache.flink</groupId>
+			<artifactId>flink-streaming-java</artifactId>
+			<version>${project.version}</version>
+			<scope>provided</scope>
+		</dependency>
+		<dependency>
+			<groupId>org.apache.flink</groupId>
+			<artifactId>flink-clients</artifactId>
+			<version>${project.version}</version>
+			<scope>provided</scope>
+		</dependency>
+
+		<dependency>
+			<groupId>org.scala-lang</groupId>
+			<artifactId>scala-reflect</artifactId>
+			<version>${scala.version}</version>
+		</dependency>
+		<dependency>
+			<groupId>org.scala-lang</groupId>
+			<artifactId>scala-library</artifactId>
+			<version>${scala.version}</version>
+		</dependency>
+		<dependency>
+			<groupId>org.scala-lang</groupId>
+			<artifactId>scala-compiler</artifactId>
+			<version>${scala.version}</version>
+		</dependency>
+
+		<dependency>
+			<groupId>org.apache.flink</groupId>
+			<artifactId>flink-test-utils-junit</artifactId>
+			<version>${project.version}</version>
+			<scope>test</scope>
+		</dependency>
+		<dependency>
+			<groupId>org.apache.flink</groupId>
+			<artifactId>flink-end-to-end-tests-common</artifactId>
+			<version>${project.version}</version>
+			<scope>test</scope>
+		</dependency>
+	</dependencies>
+
+	<build>
+		<plugins>
+			<plugin>
+				<groupId>org.apache.maven.plugins</groupId>
+				<artifactId>maven-enforcer-plugin</artifactId>
+				<executions>
+					<!-- we intentionally use an unsupported scala version -->
+					<execution>
+						<id>enforce-versions</id>
+						<goals>
+							<goal>enforce</goal>
+						</goals>
+						<phase>none</phase>
+					</execution>
+				</executions>
+			</plugin>
+
+			<plugin>
+				<groupId>org.apache.maven.plugins</groupId>
+				<artifactId>maven-shade-plugin</artifactId>
+				<executions>
+					<execution>
+						<id>Scala</id>
+						<phase>package</phase>
+						<goals>
+							<goal>shade</goal>
+						</goals>
+						<configuration>
+							<finalName>scala</finalName>
+							<artifactSet>
+								<includes>
+									<include>org.scala-lang*:*</include>
+								</includes>
+							</artifactSet>
+						</configuration>
+					</execution>
+					<execution>
+						<id>Jobs</id>
+						<phase>package</phase>
+						<goals>
+							<goal>shade</goal>
+						</goals>
+						<configuration>
+							<finalName>jobs</finalName>
+							<artifactSet>
+								<includes>
+									<include>${project.groupId}:${project.artifactId}</include>
+								</includes>
+							</artifactSet>
+						</configuration>
+					</execution>
+				</executions>
+			</plugin>
+
+			<!-- Scala Compiler -->
+			<plugin>
+				<groupId>net.alchim31.maven</groupId>
+				<artifactId>scala-maven-plugin</artifactId>
+				<executions>
+					<!-- Run scala compiler in the process-resources phase, so that dependencies on
+						scala classes can be resolved later in the (Java) compile phase -->
+					<execution>
+						<id>scala-compile-first</id>
+						<phase>process-resources</phase>
+						<goals>
+							<goal>compile</goal>
+						</goals>
+					</execution>
+
+					<!-- Run scala compiler in the process-test-resources phase, so that dependencies on
+						 scala classes can be resolved later in the (Java) test-compile phase -->
+					<execution>
+						<id>scala-test-compile</id>
+						<phase>process-test-resources</phase>
+						<goals>
+							<goal>testCompile</goal>
+						</goals>
+					</execution>
+				</executions>
+				<configuration>
+					<jvmArgs>
+						<jvmArg>-Xms128m</jvmArg>
+						<jvmArg>-Xmx512m</jvmArg>
+					</jvmArgs>
+				</configuration>
+			</plugin>
+
+			<!-- Adding scala source directories to build path -->
+			<plugin>
+				<groupId>org.codehaus.mojo</groupId>
+				<artifactId>build-helper-maven-plugin</artifactId>
+				<executions>
+					<!-- Add src/main/scala to eclipse build path -->
+					<execution>
+						<id>add-source</id>
+						<phase>generate-sources</phase>
+						<goals>
+							<goal>add-source</goal>
+						</goals>
+						<configuration>
+							<sources>
+								<source>src/main/scala</source>
+							</sources>
+						</configuration>
+					</execution>
+					<!-- Add src/test/scala to eclipse build path -->
+					<execution>
+						<id>add-test-source</id>
+						<phase>generate-test-sources</phase>
+						<goals>
+							<goal>add-test-source</goal>
+						</goals>
+						<configuration>
+							<sources>
+								<source>src/test/java</source>
+								<source>src/test/scala</source>
+							</sources>
+						</configuration>
+					</execution>
+				</executions>
+			</plugin>
+
+			<!-- Scala Code Style, most of the configuration done via plugin management -->
+			<plugin>
+				<groupId>org.scalastyle</groupId>
+				<artifactId>scalastyle-maven-plugin</artifactId>
+				<configuration>
+					<configLocation>${project.basedir}/../../tools/maven/scalastyle-config.xml</configLocation>
+				</configuration>
+			</plugin>
+
+			<!-- Add Scala test classes to test jar in order to test Scala type information. -->
+			<plugin>
+				<groupId>org.apache.maven.plugins</groupId>
+				<artifactId>maven-jar-plugin</artifactId>
+				<executions>
+					<execution>
+						<goals>
+							<goal>test-jar</goal>
+						</goals>
+					</execution>
+				</executions>
+			</plugin>
+		</plugins>
+	</build>
+
+</project>

--- a/flink-end-to-end-tests/flink-end-to-end-tests-scala/src/main/java/org/apache/flink/tests/scala/JavaJob.java
+++ b/flink-end-to-end-tests/flink-end-to-end-tests-scala/src/main/java/org/apache/flink/tests/scala/JavaJob.java
@@ -1,0 +1,34 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.flink.tests.scala;
+
+import org.apache.flink.streaming.api.environment.StreamExecutionEnvironment;
+
+/** Simple batch job in pure Java. */
+public class JavaJob {
+    public static void main(String[] args) throws Exception {
+        final StreamExecutionEnvironment env = StreamExecutionEnvironment.getExecutionEnvironment();
+
+        // we want to go through serialization to check for kryo issues
+        env.disableOperatorChaining();
+
+        env.fromElements(new NonPojo()).map(x -> x);
+
+        env.execute();
+    }
+}

--- a/flink-end-to-end-tests/flink-end-to-end-tests-scala/src/main/java/org/apache/flink/tests/scala/JavaJobWithKryoSerializer.java
+++ b/flink-end-to-end-tests/flink-end-to-end-tests-scala/src/main/java/org/apache/flink/tests/scala/JavaJobWithKryoSerializer.java
@@ -1,0 +1,36 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.flink.tests.scala;
+
+import org.apache.flink.streaming.api.environment.StreamExecutionEnvironment;
+
+/** Simple batch job in pure Java that uses a custom Kryo serializer. */
+public class JavaJobWithKryoSerializer {
+    public static void main(String[] args) throws Exception {
+        final StreamExecutionEnvironment env = StreamExecutionEnvironment.getExecutionEnvironment();
+
+        // we want to go through serialization to check for kryo issues
+        env.disableOperatorChaining();
+
+        env.addDefaultKryoSerializer(NonPojo.class, NonPojoSerializer.class);
+
+        env.fromElements(new NonPojo()).map(x -> x);
+
+        env.execute();
+    }
+}

--- a/flink-end-to-end-tests/flink-end-to-end-tests-scala/src/main/java/org/apache/flink/tests/scala/NonPojo.java
+++ b/flink-end-to-end-tests/flink-end-to-end-tests-scala/src/main/java/org/apache/flink/tests/scala/NonPojo.java
@@ -1,0 +1,28 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.flink.tests.scala;
+
+/** Simple type that needs to go through Kryo for serialization. */
+public class NonPojo {
+    private final int someInt = 34;
+    private final String someString = "hello";
+
+    public int getSomeInt() {
+        return someInt;
+    }
+}

--- a/flink-end-to-end-tests/flink-end-to-end-tests-scala/src/main/java/org/apache/flink/tests/scala/NonPojoSerializer.java
+++ b/flink-end-to-end-tests/flink-end-to-end-tests-scala/src/main/java/org/apache/flink/tests/scala/NonPojoSerializer.java
@@ -1,0 +1,38 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.flink.tests.scala;
+
+import com.esotericsoftware.kryo.Kryo;
+import com.esotericsoftware.kryo.Serializer;
+import com.esotericsoftware.kryo.io.Input;
+import com.esotericsoftware.kryo.io.Output;
+
+/** Kryo serializer for {@link NonPojo}. */
+public class NonPojoSerializer extends Serializer<NonPojo> {
+
+    @Override
+    public void write(Kryo kryo, Output output, NonPojo object) {
+        output.writeInt(object.getSomeInt());
+    }
+
+    @Override
+    public NonPojo read(Kryo kryo, Input input, Class<NonPojo> type) {
+        input.readInt();
+        return new NonPojo();
+    }
+}

--- a/flink-end-to-end-tests/flink-end-to-end-tests-scala/src/main/scala/org/apache/flink/tests/scala/ScalaJob.scala
+++ b/flink-end-to-end-tests/flink-end-to-end-tests-scala/src/main/scala/org/apache/flink/tests/scala/ScalaJob.scala
@@ -1,0 +1,47 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.flink.tests.scala
+
+import org.apache.flink.api.common.functions.MapFunction
+import org.apache.flink.streaming.api.environment.StreamExecutionEnvironment
+
+import scala.runtime.BoxesRunTime
+
+/**
+ * A Scala job that can only run with Scala 2.11.
+ *
+ * <p>This job also acts as a stand-on for Java jobs using some Scala library.
+ */
+object ScalaJob {
+  def main(args: Array[String]): Unit = {
+    val env = StreamExecutionEnvironment.getExecutionEnvironment()
+
+    // we want to go through serialization to check for kryo issues
+    env.disableOperatorChaining()
+
+    env.fromElements(new NonPojo()).map(new MapFunction[NonPojo, NonPojo] {
+      override def map(value: NonPojo): NonPojo = {
+        // use some method that was removed in 2.12+
+        BoxesRunTime.hashFromNumber(value.getSomeInt)
+        value
+      }
+    })
+
+    env.execute();
+  }
+}

--- a/flink-end-to-end-tests/flink-end-to-end-tests-scala/src/test/java/org/apache/flink/tests/scala/ScalaFreeITCase.java
+++ b/flink-end-to-end-tests/flink-end-to-end-tests-scala/src/test/java/org/apache/flink/tests/scala/ScalaFreeITCase.java
@@ -1,0 +1,130 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.flink.tests.scala;
+
+import org.apache.flink.tests.util.TestUtils;
+import org.apache.flink.tests.util.categories.TravisGroup1;
+import org.apache.flink.tests.util.flink.ClusterController;
+import org.apache.flink.tests.util.flink.FlinkResource;
+import org.apache.flink.tests.util.flink.FlinkResourceSetup;
+import org.apache.flink.tests.util.flink.JarLocation;
+import org.apache.flink.tests.util.flink.JobSubmission;
+import org.apache.flink.testutils.executor.TestExecutorResource;
+import org.apache.flink.util.TestLogger;
+
+import org.junit.Rule;
+import org.junit.Test;
+import org.junit.experimental.categories.Category;
+import org.junit.runner.RunWith;
+import org.junit.runners.Parameterized;
+
+import java.nio.file.Path;
+import java.time.Duration;
+import java.util.Arrays;
+import java.util.Collection;
+import java.util.concurrent.ScheduledExecutorService;
+import java.util.function.Consumer;
+
+/**
+ * Tests that Flink does not require Scala for jobs that do not use the Scala APIs. This covers both
+ * pure Java jobs, and Scala jobs that use the Java APIs exclusively with Scala types.
+ */
+@Category(value = {TravisGroup1.class})
+@RunWith(Parameterized.class)
+public class ScalaFreeITCase extends TestLogger {
+
+    @Rule
+    public final TestExecutorResource<ScheduledExecutorService> testExecutorResource =
+            new TestExecutorResource<>(
+                    java.util.concurrent.Executors::newSingleThreadScheduledExecutor);
+
+    @Rule public final FlinkResource flink;
+    private final String mainClass;
+
+    @Parameterized.Parameters(name = "{index}: {0}")
+    public static Collection<TestParams> testParameters() {
+        return Arrays.asList(
+                new TestParams("Java job, without Scala in lib/", JavaJob.class.getCanonicalName()),
+                new TestParams(
+                        "Java job with Kryo serializer, without Scala in lib/",
+                        JavaJobWithKryoSerializer.class.getCanonicalName()),
+                new TestParams(
+                        "Scala job, with user-provided Scala in lib/",
+                        ScalaJob.class.getCanonicalName(),
+                        builder ->
+                                builder.addJar(
+                                        TestUtils.getResource("/scala.jar"), JarLocation.LIB)));
+    }
+
+    public ScalaFreeITCase(TestParams testParams) {
+        final FlinkResourceSetup.FlinkResourceSetupBuilder builder =
+                FlinkResourceSetup.builder()
+                        .moveJar("flink-scala", JarLocation.LIB, JarLocation.OPT);
+        testParams.builderSetup.accept(builder);
+        flink = FlinkResource.get(builder.build());
+        mainClass = testParams.mainClass;
+    }
+
+    @Test
+    public void testScalaFreeJobExecution() throws Exception {
+        final Path jobJar = TestUtils.getResource("/jobs.jar");
+
+        try (final ClusterController clusterController = flink.startCluster(1)) {
+            // if the job fails then this throws an exception
+            clusterController.submitJob(
+                    new JobSubmission.JobSubmissionBuilder(jobJar)
+                            .setDetached(false)
+                            .setMainClass(mainClass)
+                            .build(),
+                    Duration.ofHours(1));
+        }
+    }
+
+    static class TestParams {
+
+        private final String description;
+        private final String mainClass;
+        private final Consumer<FlinkResourceSetup.FlinkResourceSetupBuilder> builderSetup;
+
+        TestParams(String description, String mainClass) {
+            this(description, mainClass, ignored -> {});
+        }
+
+        TestParams(
+                String description,
+                String mainClass,
+                Consumer<FlinkResourceSetup.FlinkResourceSetupBuilder> builderSetup) {
+            this.description = description;
+            this.mainClass = mainClass;
+            this.builderSetup = builderSetup;
+        }
+
+        public String getMainClass() {
+            return mainClass;
+        }
+
+        public Consumer<FlinkResourceSetup.FlinkResourceSetupBuilder> getBuilderSetup() {
+            return builderSetup;
+        }
+
+        @Override
+        public String toString() {
+            return description;
+        }
+    }
+}

--- a/flink-end-to-end-tests/flink-end-to-end-tests-scala/src/test/resources/log4j2-test.properties
+++ b/flink-end-to-end-tests/flink-end-to-end-tests-scala/src/test/resources/log4j2-test.properties
@@ -1,0 +1,28 @@
+################################################################################
+#  Licensed to the Apache Software Foundation (ASF) under one
+#  or more contributor license agreements.  See the NOTICE file
+#  distributed with this work for additional information
+#  regarding copyright ownership.  The ASF licenses this file
+#  to you under the Apache License, Version 2.0 (the
+#  "License"); you may not use this file except in compliance
+#  with the License.  You may obtain a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+#  Unless required by applicable law or agreed to in writing, software
+#  distributed under the License is distributed on an "AS IS" BASIS,
+#  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+#  See the License for the specific language governing permissions and
+# limitations under the License.
+################################################################################
+
+# Set root logger level to OFF to not flood build logs
+# set manually to INFO for debugging purposes
+rootLogger.level = OFF
+rootLogger.appenderRef.test.ref = TestLogger
+
+appender.testlogger.name = TestLogger
+appender.testlogger.type = CONSOLE
+appender.testlogger.target = SYSTEM_ERR
+appender.testlogger.layout.type = PatternLayout
+appender.testlogger.layout.pattern = %-4r [%t] %-5p %c %x - %m%n

--- a/flink-end-to-end-tests/pom.xml
+++ b/flink-end-to-end-tests/pom.xml
@@ -90,6 +90,7 @@ under the License.
 		<module>flink-end-to-end-tests-pulsar</module>
 		<module>flink-glue-schema-registry-avro-test</module>
 		<module>flink-glue-schema-registry-json-test</module>
+		<module>flink-end-to-end-tests-scala</module>
 	</modules>
 
 	<dependencyManagement>


### PR DESCRIPTION
This PR adds an e2e test for the Scala-free job execution.

It covers cases where the flink-scala jar was removed from lib/ and:
a) a Java job is run
b) a Java job is run with a custom KryoSerializer (for completeness sake because we touched Kryo)
c) Scala 2.11 is manually added to lib/, after which Scala job is run that uses the Java APIs.