### PR TITLE
[FLINK-24670][docs] Restructure unaligned checkpoints docs to checkpointing under backpressure

### DIFF
--- a/docs/content.zh/docs/ops/state/checkpointing_under_backpressure.md
+++ b/docs/content.zh/docs/ops/state/checkpointing_under_backpressure.md
@@ -71,6 +71,41 @@ backpressure. Then, checkpointing time becomes mostly independent of the end-to-
 aware unaligned checkpointing adds to I/O to the state storage, so you shouldn't use it when the
 I/O to the state storage is actually the bottleneck during checkpointing.
 
+In order to enable unaligned checkpoints you can:
+
+{{< tabs "4b9c6a74-8a45-4ad2-9e80-52fe44a85991" >}}
+{{< tab "Java" >}}
+```java
+StreamExecutionEnvironment env = StreamExecutionEnvironment.getExecutionEnvironment();
+
+// enables the unaligned checkpoints
+env.getCheckpointConfig().enableUnalignedCheckpoints();
+```
+{{< /tab >}}
+{{< tab "Scala" >}}
+```scala
+val env = StreamExecutionEnvironment.getExecutionEnvironment()
+
+// enables the unaligned checkpoints
+env.getCheckpointConfig.enableUnalignedCheckpoints()
+```
+{{< /tab >}}
+{{< tab "Python" >}}
+```python
+env = StreamExecutionEnvironment.get_execution_environment()
+
+# enables the unaligned checkpoints
+env.get_checkpoint_config().enable_unaligned_checkpoints()
+```
+{{< /tab >}}
+{{< /tabs >}}
+
+or in the `flink-conf.yml` configuration file:
+
+```
+execution.checkpointing.unaligned: true
+```
+
 ### Aligned checkpoint timeout
 
 After enabling unaligned checkpoints, you can also specify the aligned checkpoint timeout

--- a/docs/content/docs/dev/datastream/fault-tolerance/checkpointing.md
+++ b/docs/content/docs/dev/datastream/fault-tolerance/checkpointing.md
@@ -115,7 +115,7 @@ env.getCheckpointConfig().setMaxConcurrentCheckpoints(1);
 env.getCheckpointConfig().enableExternalizedCheckpoints(
     ExternalizedCheckpointCleanup.RETAIN_ON_CANCELLATION);
 
-// enables the experimental unaligned checkpoints
+// enables the unaligned checkpoints
 env.getCheckpointConfig().enableUnalignedCheckpoints();
 
 // sets the checkpoint storage where checkpoint snapshots will be written
@@ -156,7 +156,7 @@ env.getCheckpointConfig.setMaxConcurrentCheckpoints(1)
 env.getCheckpointConfig().enableExternalizedCheckpoints(
     ExternalizedCheckpointCleanup.RETAIN_ON_CANCELLATION)
 
-// enables the experimental unaligned checkpoints
+// enables the unaligned checkpoints
 env.getCheckpointConfig.enableUnalignedCheckpoints()
 
 // sets the checkpoint storage where checkpoint snapshots will be written
@@ -195,7 +195,7 @@ env.get_checkpoint_config().set_max_concurrent_checkpoints(1)
 # enable externalized checkpoints which are retained after job cancellation
 env.get_checkpoint_config().enable_externalized_checkpoints(ExternalizedCheckpointCleanup.RETAIN_ON_CANCELLATION)
 
-# enables the experimental unaligned checkpoints
+# enables the unaligned checkpoints
 env.get_checkpoint_config().enable_unaligned_checkpoints()
 ```
 {{< /tab >}}

--- a/docs/content/docs/ops/state/checkpointing_under_backpressure.md
+++ b/docs/content/docs/ops/state/checkpointing_under_backpressure.md
@@ -71,6 +71,41 @@ backpressure. Then, checkpointing time becomes mostly independent of the end-to-
 aware unaligned checkpointing adds to I/O to the state storage, so you shouldn't use it when the
 I/O to the state storage is actually the bottleneck during checkpointing.
 
+In order to enable unaligned checkpoints you can:
+
+{{< tabs "4b9c6a74-8a45-4ad2-9e80-52fe44a85991" >}}
+{{< tab "Java" >}}
+```java
+StreamExecutionEnvironment env = StreamExecutionEnvironment.getExecutionEnvironment();
+
+// enables the unaligned checkpoints
+env.getCheckpointConfig().enableUnalignedCheckpoints();
+```
+{{< /tab >}}
+{{< tab "Scala" >}}
+```scala
+val env = StreamExecutionEnvironment.getExecutionEnvironment()
+
+// enables the unaligned checkpoints
+env.getCheckpointConfig.enableUnalignedCheckpoints()
+```
+{{< /tab >}}
+{{< tab "Python" >}}
+```python
+env = StreamExecutionEnvironment.get_execution_environment()
+
+# enables the unaligned checkpoints
+env.get_checkpoint_config().enable_unaligned_checkpoints()
+```
+{{< /tab >}}
+{{< /tabs >}}
+
+or in the `flink-conf.yml` configuration file:
+
+```
+execution.checkpointing.unaligned: true
+```
+
 ### Aligned checkpoint timeout
 
 After enabling unaligned checkpoints, you can also specify the aligned checkpoint timeout


### PR DESCRIPTION
This PR makes some minor changes and add more cross references to the docs.

## Does this pull request potentially affect one of the following parts:

  - Dependencies (does it add or upgrade a dependency): (yes / **no**)
  - The public API, i.e., is any changed class annotated with `@Public(Evolving)`: (yes / **no**)
  - The serializers: (yes / **no** / don't know)
  - The runtime per-record code paths (performance sensitive): (yes / **no** / don't know)
  - Anything that affects deployment or recovery: JobManager (and its components), Checkpointing, Kubernetes/Yarn, ZooKeeper: (yes / **no** / don't know)
  - The S3 file system connector: (yes / **no** / don't know)

## Documentation

  - Does this pull request introduce a new feature? (yes / **no**)
  - If yes, how is the feature documented? (not applicable / **docs** / JavaDocs / not documented)
