### PR TITLE
[FLINK-24686][doc] Make doc clear on AsyncFunction#timeout() overriding

### DIFF
--- a/docs/content.zh/docs/dev/datastream/operators/asyncio.md
+++ b/docs/content.zh/docs/dev/datastream/operators/asyncio.md
@@ -174,6 +174,8 @@ val resultStream: DataStream[(String, String)] =
 
 当异步 I/O 请求超时的时候，默认会抛出异常并重启作业。
 如果你想处理超时，可以重写 `AsyncFunction#timeout` 方法。
+重写`AsyncFunction#timeout`时别忘了调用`ResultFuture.complete()` 或者 `ResultFuture.completeExceptionally()`
+以便告诉Flink这条记录的处理已经完成。
 
 ### 结果的顺序
 

--- a/docs/content.zh/docs/dev/datastream/operators/asyncio.md
+++ b/docs/content.zh/docs/dev/datastream/operators/asyncio.md
@@ -174,8 +174,8 @@ val resultStream: DataStream[(String, String)] =
 
 当异步 I/O 请求超时的时候，默认会抛出异常并重启作业。
 如果你想处理超时，可以重写 `AsyncFunction#timeout` 方法。
-重写`AsyncFunction#timeout`时别忘了调用`ResultFuture.complete()` 或者 `ResultFuture.completeExceptionally()`
-以便告诉Flink这条记录的处理已经完成。
+重写 `AsyncFunction#timeout` 时别忘了调用 `ResultFuture.complete()` 或者 `ResultFuture.completeExceptionally()`
+以便告诉Flink这条记录的处理已经完成。如果超时发生时你不想发出任何记录，你可以调用 `ResultFuture.complete(Collections.emptyList())` 。
 
 ### 结果的顺序
 

--- a/docs/content/docs/dev/datastream/operators/asyncio.md
+++ b/docs/content/docs/dev/datastream/operators/asyncio.md
@@ -194,6 +194,8 @@ The following two parameters control the asynchronous operations:
 
 When an async I/O request times out, by default an exception is thrown and job is restarted.
 If you want to handle timeouts, you can override the `AsyncFunction#timeout` method.
+Make sure you call `ResultFuture.complete()` or `ResultFuture.completeExceptionally()` when overriding
+in order to indicate to Flink that the processing of this input record has completed.
 
 
 ### Order of Results

--- a/docs/content/docs/dev/datastream/operators/asyncio.md
+++ b/docs/content/docs/dev/datastream/operators/asyncio.md
@@ -195,7 +195,8 @@ The following two parameters control the asynchronous operations:
 When an async I/O request times out, by default an exception is thrown and job is restarted.
 If you want to handle timeouts, you can override the `AsyncFunction#timeout` method.
 Make sure you call `ResultFuture.complete()` or `ResultFuture.completeExceptionally()` when overriding
-in order to indicate to Flink that the processing of this input record has completed.
+in order to indicate to Flink that the processing of this input record has completed. You can call 
+`ResultFuture.complete(Collections.emptyList())` if you do not want to emit any record when timeouts happen.
 
 
 ### Order of Results


### PR DESCRIPTION
## What is the purpose of the change

Sometimes, a user overrides AsyncFunction#timeout() with an empty method or with only logging code. This causes the timeout does not signal back to the framework and job stuck especially when using orderedWait(). This change to make the doc clear on this.

## Brief change log

  - updated the doc to make it clear

## Verifying this change

This change is a trivial doc improvement.

## Does this pull request potentially affect one of the following parts:

  - Dependencies (does it add or upgrade a dependency): no
  - The public API, i.e., is any changed class annotated with `@Public(Evolving)`: no
  - The serializers: no
  - The runtime per-record code paths (performance sensitive): no
  - Anything that affects deployment or recovery: JobManager (and its components), Checkpointing, Kubernetes/Yarn, ZooKeeper: no
  - The S3 file system connector: no

## Documentation

  - Does this pull request introduce a new feature? no
  - If yes, how is the feature documented? not applicable
