### PR TITLE
[FLINK-24680][runtime/coordinator] Use UserCodeClassLoader when closing coordinator and register hook in ClassLoader to prevent releasing before coordinator close

### DIFF
--- a/flink-runtime/src/main/java/org/apache/flink/runtime/dispatcher/JobMasterServiceLeadershipRunnerFactory.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/dispatcher/JobMasterServiceLeadershipRunnerFactory.java
@@ -39,6 +39,7 @@ import org.apache.flink.runtime.leaderelection.LeaderElectionService;
 import org.apache.flink.runtime.rpc.FatalErrorHandler;
 import org.apache.flink.runtime.rpc.RpcService;
 import org.apache.flink.util.Preconditions;
+import org.apache.flink.util.UserCodeClassLoader;
 
 import static org.apache.flink.util.Preconditions.checkArgument;
 
@@ -86,11 +87,9 @@ public enum JobMasterServiceLeadershipRunnerFactory implements JobManagerRunnerF
                         .getLibraryCacheManager()
                         .registerClassLoaderLease(jobGraph.getJobID());
 
-        final ClassLoader userCodeClassLoader =
-                classLoaderLease
-                        .getOrResolveClassLoader(
-                                jobGraph.getUserJarBlobKeys(), jobGraph.getClasspaths())
-                        .asClassLoader();
+        final UserCodeClassLoader userCodeClassLoader =
+                classLoaderLease.getOrResolveClassLoader(
+                        jobGraph.getUserJarBlobKeys(), jobGraph.getClasspaths());
 
         final DefaultJobMasterServiceFactory jobMasterServiceFactory =
                 new DefaultJobMasterServiceFactory(

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/executiongraph/ExecutionJobVertex.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/executiongraph/ExecutionJobVertex.java
@@ -209,7 +209,7 @@ public class ExecutionJobVertex
                         coordinatorProviders) {
                     coordinators.add(
                             OperatorCoordinatorHolder.create(
-                                    provider, this, graph.getUserClassLoader()));
+                                    provider, this, graph.getUserClassLoader().asClassLoader()));
                 }
             } catch (Exception | LinkageError e) {
                 IOUtils.closeAllQuietly(coordinators);
@@ -228,7 +228,7 @@ public class ExecutionJobVertex
             if (splitSource != null) {
                 Thread currentThread = Thread.currentThread();
                 ClassLoader oldContextClassLoader = currentThread.getContextClassLoader();
-                currentThread.setContextClassLoader(graph.getUserClassLoader());
+                currentThread.setContextClassLoader(graph.getUserClassLoader().asClassLoader());
                 try {
                     inputSplits =
                             splitSource.createInputSplits(this.parallelismInfo.getParallelism());

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/executiongraph/InternalExecutionGraphAccessor.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/executiongraph/InternalExecutionGraphAccessor.java
@@ -31,6 +31,7 @@ import org.apache.flink.runtime.scheduler.strategy.ExecutionVertexID;
 import org.apache.flink.runtime.shuffle.ShuffleMaster;
 import org.apache.flink.types.Either;
 import org.apache.flink.util.SerializedValue;
+import org.apache.flink.util.UserCodeClassLoader;
 
 import javax.annotation.Nonnull;
 
@@ -43,7 +44,7 @@ import java.util.concurrent.Executor;
  */
 public interface InternalExecutionGraphAccessor {
 
-    ClassLoader getUserClassLoader();
+    UserCodeClassLoader getUserClassLoader();
 
     JobID getJobID();
 

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/jobmaster/DefaultSlotPoolServiceSchedulerFactory.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/jobmaster/DefaultSlotPoolServiceSchedulerFactory.java
@@ -44,6 +44,7 @@ import org.apache.flink.runtime.scheduler.SchedulerNG;
 import org.apache.flink.runtime.scheduler.SchedulerNGFactory;
 import org.apache.flink.runtime.scheduler.adaptive.AdaptiveSchedulerFactory;
 import org.apache.flink.runtime.shuffle.ShuffleMaster;
+import org.apache.flink.util.UserCodeClassLoader;
 import org.apache.flink.util.clock.SystemClock;
 
 import org.slf4j.Logger;
@@ -93,7 +94,7 @@ public final class DefaultSlotPoolServiceSchedulerFactory
             Configuration configuration,
             SlotPoolService slotPoolService,
             ScheduledExecutorService futureExecutor,
-            ClassLoader userCodeLoader,
+            UserCodeClassLoader userCodeLoader,
             CheckpointRecoveryFactory checkpointRecoveryFactory,
             Time rpcTimeout,
             BlobWriter blobWriter,

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/jobmaster/SlotPoolServiceSchedulerFactory.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/jobmaster/SlotPoolServiceSchedulerFactory.java
@@ -33,6 +33,7 @@ import org.apache.flink.runtime.metrics.groups.JobManagerJobMetricGroup;
 import org.apache.flink.runtime.rpc.FatalErrorHandler;
 import org.apache.flink.runtime.scheduler.SchedulerNG;
 import org.apache.flink.runtime.shuffle.ShuffleMaster;
+import org.apache.flink.util.UserCodeClassLoader;
 
 import org.slf4j.Logger;
 
@@ -70,7 +71,7 @@ public interface SlotPoolServiceSchedulerFactory {
             Configuration configuration,
             SlotPoolService slotPoolService,
             ScheduledExecutorService futureExecutor,
-            ClassLoader userCodeLoader,
+            UserCodeClassLoader userCodeLoader,
             CheckpointRecoveryFactory checkpointRecoveryFactory,
             Time rpcTimeout,
             BlobWriter blobWriter,

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/jobmaster/factories/DefaultJobMasterServiceFactory.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/jobmaster/factories/DefaultJobMasterServiceFactory.java
@@ -35,6 +35,7 @@ import org.apache.flink.runtime.jobmaster.SlotPoolServiceSchedulerFactory;
 import org.apache.flink.runtime.rpc.FatalErrorHandler;
 import org.apache.flink.runtime.rpc.RpcService;
 import org.apache.flink.runtime.shuffle.ShuffleMaster;
+import org.apache.flink.util.UserCodeClassLoader;
 import org.apache.flink.util.function.FunctionUtils;
 
 import java.util.UUID;
@@ -53,7 +54,7 @@ public class DefaultJobMasterServiceFactory implements JobMasterServiceFactory {
     private final HeartbeatServices heartbeatServices;
     private final JobManagerJobMetricGroupFactory jobManagerJobMetricGroupFactory;
     private final FatalErrorHandler fatalErrorHandler;
-    private final ClassLoader userCodeClassloader;
+    private final UserCodeClassLoader userCodeClassloader;
     private final ShuffleMaster<?> shuffleMaster;
     private final long initializationTimestamp;
 
@@ -68,7 +69,7 @@ public class DefaultJobMasterServiceFactory implements JobMasterServiceFactory {
             HeartbeatServices heartbeatServices,
             JobManagerJobMetricGroupFactory jobManagerJobMetricGroupFactory,
             FatalErrorHandler fatalErrorHandler,
-            ClassLoader userCodeClassloader,
+            UserCodeClassLoader userCodeClassloader,
             long initializationTimestamp) {
         this.executor = executor;
         this.rpcService = rpcService;

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/operators/coordination/OperatorCoordinator.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/operators/coordination/OperatorCoordinator.java
@@ -23,6 +23,7 @@ import org.apache.flink.api.common.state.CheckpointListener;
 import org.apache.flink.runtime.executiongraph.ExecutionAttemptID;
 import org.apache.flink.runtime.jobgraph.OperatorID;
 import org.apache.flink.runtime.messages.Acknowledge;
+import org.apache.flink.util.UserCodeClassLoader;
 
 import javax.annotation.Nullable;
 
@@ -253,7 +254,7 @@ public interface OperatorCoordinator extends CheckpointListener, AutoCloseable {
          * Gets the classloader that contains the additional dependencies, which are not part of the
          * JVM's classpath.
          */
-        ClassLoader getUserCodeClassloader();
+        UserCodeClassLoader getUserCodeClassloader();
     }
 
     // ------------------------------------------------------------------------

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/operators/coordination/OperatorCoordinatorHolder.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/operators/coordination/OperatorCoordinatorHolder.java
@@ -28,6 +28,7 @@ import org.apache.flink.util.ExceptionUtils;
 import org.apache.flink.util.FlinkException;
 import org.apache.flink.util.SerializedValue;
 import org.apache.flink.util.TemporaryClassLoaderContext;
+import org.apache.flink.util.UserCodeClassLoader;
 import org.apache.flink.util.concurrent.FutureUtils;
 
 import org.slf4j.Logger;
@@ -450,7 +451,7 @@ public class OperatorCoordinatorHolder
             final OperatorID opId,
             final OperatorCoordinator.Provider coordinatorProvider,
             final String operatorName,
-            final ClassLoader userCodeClassLoader,
+            final UserCodeClassLoader userCodeClassLoader,
             final int operatorParallelism,
             final int operatorMaxParallelism,
             final SubtaskAccess.SubtaskAccessFactory taskAccesses)
@@ -492,7 +493,7 @@ public class OperatorCoordinatorHolder
 
         private final OperatorID operatorId;
         private final String operatorName;
-        private final ClassLoader userCodeClassLoader;
+        private final UserCodeClassLoader userCodeClassLoader;
         private final int operatorParallelism;
 
         private Consumer<Throwable> globalFailureHandler;
@@ -503,7 +504,7 @@ public class OperatorCoordinatorHolder
         public LazyInitializedCoordinatorContext(
                 final OperatorID operatorId,
                 final String operatorName,
-                final ClassLoader userCodeClassLoader,
+                final UserCodeClassLoader userCodeClassLoader,
                 final int operatorParallelism) {
             this.operatorId = checkNotNull(operatorId);
             this.operatorName = checkNotNull(operatorName);
@@ -569,7 +570,7 @@ public class OperatorCoordinatorHolder
         }
 
         @Override
-        public ClassLoader getUserCodeClassloader() {
+        public UserCodeClassLoader getUserCodeClassloader() {
             return userCodeClassLoader;
         }
     }

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/operators/coordination/RecreateOnResetOperatorCoordinator.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/operators/coordination/RecreateOnResetOperatorCoordinator.java
@@ -21,6 +21,7 @@ package org.apache.flink.runtime.operators.coordination;
 import org.apache.flink.annotation.VisibleForTesting;
 import org.apache.flink.runtime.jobgraph.OperatorID;
 import org.apache.flink.util.Preconditions;
+import org.apache.flink.util.UserCodeClassLoader;
 import org.apache.flink.util.function.ThrowingConsumer;
 import org.apache.flink.util.function.ThrowingRunnable;
 
@@ -229,7 +230,7 @@ public class RecreateOnResetOperatorCoordinator implements OperatorCoordinator {
         }
 
         @Override
-        public ClassLoader getUserCodeClassloader() {
+        public UserCodeClassLoader getUserCodeClassloader() {
             return context.getUserCodeClassloader();
         }
 

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/scheduler/DefaultExecutionGraphFactory.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/scheduler/DefaultExecutionGraphFactory.java
@@ -40,6 +40,7 @@ import org.apache.flink.runtime.jobmaster.ExecutionDeploymentTracker;
 import org.apache.flink.runtime.jobmaster.ExecutionDeploymentTrackerDeploymentListenerAdapter;
 import org.apache.flink.runtime.metrics.groups.JobManagerJobMetricGroup;
 import org.apache.flink.runtime.shuffle.ShuffleMaster;
+import org.apache.flink.util.UserCodeClassLoader;
 import org.apache.flink.util.function.CachingSupplier;
 
 import org.slf4j.Logger;
@@ -53,7 +54,7 @@ import java.util.function.Supplier;
 public class DefaultExecutionGraphFactory implements ExecutionGraphFactory {
 
     private final Configuration configuration;
-    private final ClassLoader userCodeClassLoader;
+    private final UserCodeClassLoader userCodeClassLoader;
     private final ExecutionDeploymentTracker executionDeploymentTracker;
     private final ScheduledExecutorService futureExecutor;
     private final Executor ioExecutor;
@@ -66,7 +67,7 @@ public class DefaultExecutionGraphFactory implements ExecutionGraphFactory {
 
     public DefaultExecutionGraphFactory(
             Configuration configuration,
-            ClassLoader userCodeClassLoader,
+            UserCodeClassLoader userCodeClassLoader,
             ExecutionDeploymentTracker executionDeploymentTracker,
             ScheduledExecutorService futureExecutor,
             Executor ioExecutor,
@@ -177,7 +178,7 @@ public class DefaultExecutionGraphFactory implements ExecutionGraphFactory {
                         savepointRestoreSettings.getRestorePath(),
                         savepointRestoreSettings.allowNonRestoredState(),
                         executionGraphToRestore.getAllVertices(),
-                        userCodeClassLoader);
+                        userCodeClassLoader.asClassLoader());
             }
         }
     }

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/scheduler/DefaultSchedulerFactory.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/scheduler/DefaultSchedulerFactory.java
@@ -37,6 +37,7 @@ import org.apache.flink.runtime.jobmaster.slotpool.SlotPoolService;
 import org.apache.flink.runtime.metrics.groups.JobManagerJobMetricGroup;
 import org.apache.flink.runtime.rpc.FatalErrorHandler;
 import org.apache.flink.runtime.shuffle.ShuffleMaster;
+import org.apache.flink.util.UserCodeClassLoader;
 import org.apache.flink.util.concurrent.ScheduledExecutorServiceAdapter;
 
 import org.slf4j.Logger;
@@ -57,7 +58,7 @@ public class DefaultSchedulerFactory implements SchedulerNGFactory {
             final Configuration jobMasterConfiguration,
             final SlotPoolService slotPoolService,
             final ScheduledExecutorService futureExecutor,
-            final ClassLoader userCodeLoader,
+            final UserCodeClassLoader userCodeLoader,
             final CheckpointRecoveryFactory checkpointRecoveryFactory,
             final Time rpcTimeout,
             final BlobWriter blobWriter,
@@ -90,7 +91,7 @@ public class DefaultSchedulerFactory implements SchedulerNGFactory {
         final RestartBackoffTimeStrategy restartBackoffTimeStrategy =
                 RestartBackoffTimeStrategyFactoryLoader.createRestartBackoffTimeStrategyFactory(
                                 jobGraph.getSerializedExecutionConfig()
-                                        .deserializeValue(userCodeLoader)
+                                        .deserializeValue(userCodeLoader.asClassLoader())
                                         .getRestartStrategy(),
                                 jobMasterConfiguration,
                                 jobGraph.isCheckpointingEnabled())
@@ -121,7 +122,7 @@ public class DefaultSchedulerFactory implements SchedulerNGFactory {
                 jobMasterConfiguration,
                 schedulerComponents.getStartUpAction(),
                 new ScheduledExecutorServiceAdapter(futureExecutor),
-                userCodeLoader,
+                userCodeLoader.asClassLoader(),
                 checkpointRecoveryFactory,
                 jobManagerJobMetricGroup,
                 schedulerComponents.getSchedulingStrategyFactory(),

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/scheduler/SchedulerNGFactory.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/scheduler/SchedulerNGFactory.java
@@ -33,6 +33,7 @@ import org.apache.flink.runtime.jobmaster.slotpool.SlotPoolService;
 import org.apache.flink.runtime.metrics.groups.JobManagerJobMetricGroup;
 import org.apache.flink.runtime.rpc.FatalErrorHandler;
 import org.apache.flink.runtime.shuffle.ShuffleMaster;
+import org.apache.flink.util.UserCodeClassLoader;
 
 import org.slf4j.Logger;
 
@@ -49,7 +50,7 @@ public interface SchedulerNGFactory {
             Configuration jobMasterConfiguration,
             SlotPoolService slotPoolService,
             ScheduledExecutorService futureExecutor,
-            ClassLoader userCodeLoader,
+            UserCodeClassLoader userCodeLoader,
             CheckpointRecoveryFactory checkpointRecoveryFactory,
             Time rpcTimeout,
             BlobWriter blobWriter,

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/scheduler/adaptive/AdaptiveSchedulerFactory.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/scheduler/adaptive/AdaptiveSchedulerFactory.java
@@ -40,6 +40,7 @@ import org.apache.flink.runtime.scheduler.SchedulerNG;
 import org.apache.flink.runtime.scheduler.SchedulerNGFactory;
 import org.apache.flink.runtime.scheduler.adaptive.allocator.SlotSharingSlotAllocator;
 import org.apache.flink.runtime.shuffle.ShuffleMaster;
+import org.apache.flink.util.UserCodeClassLoader;
 
 import org.slf4j.Logger;
 
@@ -67,7 +68,7 @@ public class AdaptiveSchedulerFactory implements SchedulerNGFactory {
             Configuration jobMasterConfiguration,
             SlotPoolService slotPoolService,
             ScheduledExecutorService futureExecutor,
-            ClassLoader userCodeLoader,
+            UserCodeClassLoader userCodeLoader,
             CheckpointRecoveryFactory checkpointRecoveryFactory,
             Time rpcTimeout,
             BlobWriter blobWriter,
@@ -91,7 +92,7 @@ public class AdaptiveSchedulerFactory implements SchedulerNGFactory {
         final RestartBackoffTimeStrategy restartBackoffTimeStrategy =
                 RestartBackoffTimeStrategyFactoryLoader.createRestartBackoffTimeStrategyFactory(
                                 jobGraph.getSerializedExecutionConfig()
-                                        .deserializeValue(userCodeLoader)
+                                        .deserializeValue(userCodeLoader.asClassLoader())
                                         .getRestartStrategy(),
                                 jobMasterConfiguration,
                                 jobGraph.isCheckpointingEnabled())
@@ -124,7 +125,7 @@ public class AdaptiveSchedulerFactory implements SchedulerNGFactory {
                 declarativeSlotPool,
                 slotAllocator,
                 ioExecutor,
-                userCodeLoader,
+                userCodeLoader.asClassLoader(),
                 checkpointRecoveryFactory,
                 initialResourceAllocationTimeout,
                 resourceStabilizationTimeout,

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/source/coordinator/SourceCoordinator.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/source/coordinator/SourceCoordinator.java
@@ -122,7 +122,7 @@ public class SourceCoordinator<SplitT extends SourceSplit, EnumChkT>
         // it here
         if (enumerator == null) {
             final ClassLoader userCodeClassLoader =
-                    context.getCoordinatorContext().getUserCodeClassloader();
+                    context.getCoordinatorContext().getUserCodeClassloader().asClassLoader();
             try (TemporaryClassLoaderContext ignored =
                     TemporaryClassLoaderContext.of(userCodeClassLoader)) {
                 enumerator = source.createEnumerator(context);
@@ -303,7 +303,7 @@ public class SourceCoordinator<SplitT extends SourceSplit, EnumChkT>
         LOG.info("Restoring SplitEnumerator of source {} from checkpoint.", operatorName);
 
         final ClassLoader userCodeClassLoader =
-                context.getCoordinatorContext().getUserCodeClassloader();
+                context.getCoordinatorContext().getUserCodeClassloader().asClassLoader();
         try (TemporaryClassLoaderContext ignored =
                 TemporaryClassLoaderContext.of(userCodeClassLoader)) {
             final EnumChkT enumeratorCheckpoint = deserializeCheckpoint(checkpointData);

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/source/coordinator/SourceCoordinatorProvider.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/source/coordinator/SourceCoordinatorProvider.java
@@ -70,7 +70,7 @@ public class SourceCoordinatorProvider<SplitT extends SourceSplit>
         final String coordinatorThreadName = "SourceCoordinator-" + operatorName;
         CoordinatorExecutorThreadFactory coordinatorThreadFactory =
                 new CoordinatorExecutorThreadFactory(
-                        coordinatorThreadName, context.getUserCodeClassloader());
+                        coordinatorThreadName, context.getUserCodeClassloader().asClassLoader());
         ExecutorService coordinatorExecutor =
                 Executors.newSingleThreadExecutor(coordinatorThreadFactory);
 

--- a/flink-runtime/src/test/java/org/apache/flink/runtime/executiongraph/TestingDefaultExecutionGraphBuilder.java
+++ b/flink-runtime/src/test/java/org/apache/flink/runtime/executiongraph/TestingDefaultExecutionGraphBuilder.java
@@ -43,6 +43,7 @@ import org.apache.flink.runtime.scheduler.VertexParallelismStore;
 import org.apache.flink.runtime.shuffle.ShuffleMaster;
 import org.apache.flink.runtime.shuffle.ShuffleTestUtils;
 import org.apache.flink.runtime.testutils.TestingUtils;
+import org.apache.flink.util.SimpleUserCodeClassLoader;
 
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
@@ -169,7 +170,7 @@ public class TestingDefaultExecutionGraphBuilder {
                 jobMasterConfig,
                 futureExecutor,
                 ioExecutor,
-                userClassLoader,
+                SimpleUserCodeClassLoader.create(userClassLoader),
                 completedCheckpointStore,
                 new CheckpointsCleaner(),
                 checkpointIdCounter,

--- a/flink-runtime/src/test/java/org/apache/flink/runtime/jobmaster/JobMasterSchedulerTest.java
+++ b/flink-runtime/src/test/java/org/apache/flink/runtime/jobmaster/JobMasterSchedulerTest.java
@@ -40,6 +40,7 @@ import org.apache.flink.runtime.scheduler.TestingSchedulerNG;
 import org.apache.flink.runtime.shuffle.ShuffleMaster;
 import org.apache.flink.util.FlinkRuntimeException;
 import org.apache.flink.util.TestLogger;
+import org.apache.flink.util.UserCodeClassLoader;
 
 import org.junit.ClassRule;
 import org.junit.Test;
@@ -100,7 +101,7 @@ public class JobMasterSchedulerTest extends TestLogger {
                 Configuration jobMasterConfiguration,
                 SlotPoolService slotPoolService,
                 ScheduledExecutorService futureExecutor,
-                ClassLoader userCodeLoader,
+                UserCodeClassLoader userCodeLoader,
                 CheckpointRecoveryFactory checkpointRecoveryFactory,
                 Time rpcTimeout,
                 BlobWriter blobWriter,

--- a/flink-runtime/src/test/java/org/apache/flink/runtime/jobmaster/utils/JobMasterBuilder.java
+++ b/flink-runtime/src/test/java/org/apache/flink/runtime/jobmaster/utils/JobMasterBuilder.java
@@ -45,6 +45,7 @@ import org.apache.flink.runtime.rpc.RpcService;
 import org.apache.flink.runtime.scheduler.ExecutionGraphInfo;
 import org.apache.flink.runtime.shuffle.ShuffleMaster;
 import org.apache.flink.runtime.shuffle.ShuffleTestUtils;
+import org.apache.flink.util.SimpleUserCodeClassLoader;
 
 import java.util.concurrent.CompletableFuture;
 
@@ -193,7 +194,7 @@ public class JobMasterBuilder {
                 UnregisteredJobManagerJobMetricGroupFactory.INSTANCE,
                 onCompletionActions,
                 fatalErrorHandler,
-                JobMasterBuilder.class.getClassLoader(),
+                SimpleUserCodeClassLoader.create(JobMasterBuilder.class.getClassLoader()),
                 shuffleMaster,
                 partitionTrackerFactory,
                 executionDeploymentTracker,

--- a/flink-runtime/src/test/java/org/apache/flink/runtime/operators/coordination/MockOperatorCoordinatorContext.java
+++ b/flink-runtime/src/test/java/org/apache/flink/runtime/operators/coordination/MockOperatorCoordinatorContext.java
@@ -19,27 +19,34 @@ limitations under the License.
 package org.apache.flink.runtime.operators.coordination;
 
 import org.apache.flink.runtime.jobgraph.OperatorID;
+import org.apache.flink.util.SimpleUserCodeClassLoader;
+import org.apache.flink.util.UserCodeClassLoader;
 
 /** A simple implementation of {@link OperatorCoordinator.Context} for testing purposes. */
 public class MockOperatorCoordinatorContext implements OperatorCoordinator.Context {
 
     private final OperatorID operatorID;
-    private final ClassLoader userCodeClassLoader;
+    private final UserCodeClassLoader userCodeClassLoader;
     private final int numSubtasks;
 
     private boolean jobFailed;
     private Throwable jobFailureReason;
 
     public MockOperatorCoordinatorContext(OperatorID operatorID, int numSubtasks) {
-        this(operatorID, numSubtasks, MockOperatorCoordinatorContext.class.getClassLoader());
+        this(
+                operatorID,
+                numSubtasks,
+                SimpleUserCodeClassLoader.create(
+                        MockOperatorCoordinatorContext.class.getClassLoader()));
     }
 
-    public MockOperatorCoordinatorContext(OperatorID operatorID, ClassLoader userCodeClassLoader) {
+    public MockOperatorCoordinatorContext(
+            OperatorID operatorID, UserCodeClassLoader userCodeClassLoader) {
         this(operatorID, 1, userCodeClassLoader);
     }
 
     public MockOperatorCoordinatorContext(
-            OperatorID operatorID, int numSubtasks, ClassLoader userCodeClassLoader) {
+            OperatorID operatorID, int numSubtasks, UserCodeClassLoader userCodeClassLoader) {
         this.operatorID = operatorID;
         this.numSubtasks = numSubtasks;
         this.jobFailed = false;
@@ -64,7 +71,7 @@ public class MockOperatorCoordinatorContext implements OperatorCoordinator.Conte
     }
 
     @Override
-    public ClassLoader getUserCodeClassloader() {
+    public UserCodeClassLoader getUserCodeClassloader() {
         return userCodeClassLoader;
     }
 

--- a/flink-runtime/src/test/java/org/apache/flink/runtime/operators/coordination/OperatorCoordinatorHolderTest.java
+++ b/flink-runtime/src/test/java/org/apache/flink/runtime/operators/coordination/OperatorCoordinatorHolderTest.java
@@ -26,6 +26,7 @@ import org.apache.flink.runtime.jobgraph.OperatorID;
 import org.apache.flink.runtime.messages.Acknowledge;
 import org.apache.flink.runtime.operators.coordination.EventReceivingTasks.EventWithSubtask;
 import org.apache.flink.util.ExceptionUtils;
+import org.apache.flink.util.SimpleUserCodeClassLoader;
 import org.apache.flink.util.TestLogger;
 
 import org.junit.After;
@@ -507,7 +508,7 @@ public class OperatorCoordinatorHolderTest extends TestLogger {
                         opId,
                         provider,
                         "test-coordinator-name",
-                        getClass().getClassLoader(),
+                        SimpleUserCodeClassLoader.create(getClass().getClassLoader()),
                         3,
                         1775,
                         eventTarget);

--- a/flink-runtime/src/test/java/org/apache/flink/runtime/scheduler/DefaultExecutionGraphFactoryTest.java
+++ b/flink-runtime/src/test/java/org/apache/flink/runtime/scheduler/DefaultExecutionGraphFactoryTest.java
@@ -39,6 +39,7 @@ import org.apache.flink.runtime.metrics.groups.UnregisteredMetricGroups;
 import org.apache.flink.runtime.shuffle.ShuffleTestUtils;
 import org.apache.flink.runtime.testtasks.NoOpInvokable;
 import org.apache.flink.runtime.testutils.TestingUtils;
+import org.apache.flink.util.SimpleUserCodeClassLoader;
 import org.apache.flink.util.TestLogger;
 
 import org.hamcrest.MatcherAssert;
@@ -119,7 +120,7 @@ public class DefaultExecutionGraphFactoryTest extends TestLogger {
         final ExecutionGraphFactory executionGraphFactory =
                 new DefaultExecutionGraphFactory(
                         new Configuration(),
-                        ClassLoader.getSystemClassLoader(),
+                        SimpleUserCodeClassLoader.create(ClassLoader.getSystemClassLoader()),
                         new DefaultExecutionDeploymentTracker(),
                         TestingUtils.defaultExecutor(),
                         TestingUtils.defaultExecutor(),

--- a/flink-runtime/src/test/java/org/apache/flink/runtime/scheduler/SchedulerTestingUtils.java
+++ b/flink-runtime/src/test/java/org/apache/flink/runtime/scheduler/SchedulerTestingUtils.java
@@ -68,6 +68,7 @@ import org.apache.flink.runtime.taskexecutor.TaskExecutorOperatorEventGateway;
 import org.apache.flink.runtime.taskmanager.TaskExecutionState;
 import org.apache.flink.runtime.testutils.TestingUtils;
 import org.apache.flink.util.SerializedValue;
+import org.apache.flink.util.SimpleUserCodeClassLoader;
 import org.apache.flink.util.TernaryBoolean;
 import org.apache.flink.util.concurrent.ScheduledExecutor;
 import org.apache.flink.util.concurrent.ScheduledExecutorServiceAdapter;
@@ -535,7 +536,7 @@ public class SchedulerTestingUtils {
             final ExecutionGraphFactory executionGraphFactory =
                     new DefaultExecutionGraphFactory(
                             jobMasterConfiguration,
-                            userCodeLoader,
+                            SimpleUserCodeClassLoader.create(userCodeLoader),
                             new DefaultExecutionDeploymentTracker(),
                             futureExecutor,
                             ioExecutor,

--- a/flink-runtime/src/test/java/org/apache/flink/runtime/scheduler/TestingSchedulerNGFactory.java
+++ b/flink-runtime/src/test/java/org/apache/flink/runtime/scheduler/TestingSchedulerNGFactory.java
@@ -32,6 +32,7 @@ import org.apache.flink.runtime.jobmaster.slotpool.SlotPoolService;
 import org.apache.flink.runtime.metrics.groups.JobManagerJobMetricGroup;
 import org.apache.flink.runtime.rpc.FatalErrorHandler;
 import org.apache.flink.runtime.shuffle.ShuffleMaster;
+import org.apache.flink.util.UserCodeClassLoader;
 
 import org.slf4j.Logger;
 
@@ -57,7 +58,7 @@ public class TestingSchedulerNGFactory implements SchedulerNGFactory {
             Configuration jobMasterConfiguration,
             SlotPoolService slotPoolService,
             ScheduledExecutorService futureExecutor,
-            ClassLoader userCodeLoader,
+            UserCodeClassLoader userCodeLoader,
             CheckpointRecoveryFactory checkpointRecoveryFactory,
             Time rpcTimeout,
             BlobWriter blobWriter,

--- a/flink-runtime/src/test/java/org/apache/flink/runtime/scheduler/adaptive/AdaptiveSchedulerBuilder.java
+++ b/flink-runtime/src/test/java/org/apache/flink/runtime/scheduler/adaptive/AdaptiveSchedulerBuilder.java
@@ -45,6 +45,7 @@ import org.apache.flink.runtime.shuffle.ShuffleMaster;
 import org.apache.flink.runtime.shuffle.ShuffleTestUtils;
 import org.apache.flink.runtime.testutils.TestingUtils;
 import org.apache.flink.util.FatalExitExceptionHandler;
+import org.apache.flink.util.SimpleUserCodeClassLoader;
 
 import javax.annotation.Nullable;
 
@@ -188,7 +189,7 @@ public class AdaptiveSchedulerBuilder {
         final ExecutionGraphFactory executionGraphFactory =
                 new DefaultExecutionGraphFactory(
                         jobMasterConfiguration,
-                        userCodeLoader,
+                        SimpleUserCodeClassLoader.create(userCodeLoader),
                         new DefaultExecutionDeploymentTracker(),
                         futureExecutor,
                         ioExecutor,

--- a/flink-runtime/src/test/java/org/apache/flink/runtime/scheduler/adaptive/ExecutingTest.java
+++ b/flink-runtime/src/test/java/org/apache/flink/runtime/scheduler/adaptive/ExecutingTest.java
@@ -60,6 +60,7 @@ import org.apache.flink.runtime.taskmanager.TaskExecutionState;
 import org.apache.flink.types.Either;
 import org.apache.flink.util.SerializedValue;
 import org.apache.flink.util.TestLogger;
+import org.apache.flink.util.UserCodeClassLoader;
 
 import org.junit.Test;
 import org.slf4j.Logger;
@@ -835,7 +836,7 @@ public class ExecutingTest extends TestLogger {
         // --- mocked methods
 
         @Override
-        public ClassLoader getUserClassLoader() {
+        public UserCodeClassLoader getUserClassLoader() {
             return null;
         }
 

--- a/flink-runtime/src/test/java/org/apache/flink/runtime/source/coordinator/SourceCoordinatorTest.java
+++ b/flink-runtime/src/test/java/org/apache/flink/runtime/source/coordinator/SourceCoordinatorTest.java
@@ -36,6 +36,7 @@ import org.apache.flink.runtime.jobgraph.OperatorID;
 import org.apache.flink.runtime.operators.coordination.MockOperatorCoordinatorContext;
 import org.apache.flink.runtime.operators.coordination.OperatorCoordinator;
 import org.apache.flink.runtime.source.event.SourceEventWrapper;
+import org.apache.flink.util.SimpleUserCodeClassLoader;
 
 import org.junit.Test;
 
@@ -309,7 +310,8 @@ public class SourceCoordinatorTest extends SourceCoordinatorTestBase {
     public void testUserClassLoaderWhenCreatingNewEnumerator() throws Exception {
         final ClassLoader testClassLoader = new URLClassLoader(new URL[0]);
         final OperatorCoordinator.Context context =
-                new MockOperatorCoordinatorContext(new OperatorID(), testClassLoader);
+                new MockOperatorCoordinatorContext(
+                        new OperatorID(), SimpleUserCodeClassLoader.create(testClassLoader));
 
         final EnumeratorCreatingSource<?, ClassLoaderTestEnumerator> source =
                 new EnumeratorCreatingSource<>(ClassLoaderTestEnumerator::new);
@@ -331,7 +333,8 @@ public class SourceCoordinatorTest extends SourceCoordinatorTestBase {
     public void testUserClassLoaderWhenRestoringEnumerator() throws Exception {
         final ClassLoader testClassLoader = new URLClassLoader(new URL[0]);
         final OperatorCoordinator.Context context =
-                new MockOperatorCoordinatorContext(new OperatorID(), testClassLoader);
+                new MockOperatorCoordinatorContext(
+                        new OperatorID(), SimpleUserCodeClassLoader.create(testClassLoader));
 
         final EnumeratorCreatingSource<?, ClassLoaderTestEnumerator> source =
                 new EnumeratorCreatingSource<>(ClassLoaderTestEnumerator::new);


### PR DESCRIPTION
## What is the purpose of the change

This pull request exposes `UserCodeClassLoader` in operator coordinator context, uses `UserCodeClassLoader` when closing coordinator, and register hook in ClassLoader to prevent releasing before coordinator close.


## Brief change log

*(for example:)*
  - Expose UserCodeClassLoader in operator coordinator context
  - Use UserCodeClassLoader when closing coordinator and register hook in ClassLoader to prevent releasing before coordinator close


## Verifying this change

This change added tests and can be verified as follows:

- Added unit tests for validating that `UserCodeClassLoader` won't be released until OperatorCoordinator finishes async close.


## Does this pull request potentially affect one of the following parts:

  - Dependencies (does it add or upgrade a dependency): (no)
  - The public API, i.e., is any changed class annotated with `@Public(Evolving)`: (no)
  - The serializers: (no)
  - The runtime per-record code paths (performance sensitive): (no)
  - Anything that affects deployment or recovery: JobManager (and its components), Checkpointing, Kubernetes/Yarn, ZooKeeper: (no)
  - The S3 file system connector: (no)

## Documentation

  - Does this pull request introduce a new feature? (no)
  - If yes, how is the feature documented? (not applicable)
