### PR TITLE
[FLINK-24697][flink-connectors-kafka] add auto.offset.reset configuration for group-offsets startup mode

### DIFF
--- a/flink-test-utils-parent/flink-test-utils-junit/src/main/java/org/apache/flink/core/testutils/FlinkAssertions.java
+++ b/flink-test-utils-parent/flink-test-utils-junit/src/main/java/org/apache/flink/core/testutils/FlinkAssertions.java
@@ -65,6 +65,47 @@ public final class FlinkAssertions {
     }
 
     /**
+     * Shorthand to assert the chain of causes includes a specific {@link Throwable}. Same as:
+     *
+     * <pre>{@code
+     * assertThatChainOfCauses(t)
+     *     .anySatisfy(
+     *          cause ->
+     *              assertThat(cause)
+     *                  .isInstanceOf(throwable.getClass())
+     *                  .hasMessage(throwable.getMessage()));
+     * }</pre>
+     */
+    public static ThrowingConsumer<? super Throwable> containsCause(Throwable throwable) {
+        return t ->
+                assertThatChainOfCauses(t)
+                        .anySatisfy(
+                                cause ->
+                                        assertThat(cause)
+                                                .isInstanceOf(throwable.getClass())
+                                                .hasMessage(throwable.getMessage()));
+    }
+
+    /**
+     * Shorthand to assert the chain of causes includes a {@link Throwable} matching a specific
+     * {@link Class}. Same as:
+     *
+     * <pre>{@code
+     * assertThatChainOfCauses(throwable)
+     *     .anySatisfy(
+     *          cause ->
+     *              assertThat(cause)
+     *                  .isInstanceOf(clazz));
+     * }</pre>
+     */
+    public static ThrowingConsumer<? super Throwable> anyCauseMatches(
+            Class<? extends Throwable> clazz) {
+        return t ->
+                assertThatChainOfCauses(t)
+                        .anySatisfy(cause -> assertThat(cause).isInstanceOf(clazz));
+    }
+
+    /**
      * Shorthand to assert the chain of causes includes a {@link Throwable} matching a specific
      * {@link Class} and containing the provided message. Same as:
      *


### PR DESCRIPTION
<!--
*Thank you very much for contributing to Apache Flink - we are happy that you want to help us improve Flink. To help the community review your contribution in the best possible way, please go through the checklist below, which will get the contribution into a shape in which it can be best reviewed.*

*Please understand that we do not do this to make contributions to Flink a hassle. In order to uphold a high standard of quality for code contributions, while at the same time managing a large number of contributions, we need contributors to prepare the contributions well, and give reviewers enough contextual information for the review. Please also understand that contributions that do not follow this guide will take longer to review and thus typically be picked up with lower priority by the community.*

## Contribution Checklist

  - Make sure that the pull request corresponds to a [JIRA issue](https://issues.apache.org/jira/projects/FLINK/issues). Exceptions are made for typos in JavaDoc or documentation files, which need no JIRA issue.
  
  - Name the pull request in the form "[FLINK-XXXX] [component] Title of the pull request", where *FLINK-XXXX* should be replaced by the actual issue number. Skip *component* if you are unsure about which is the best component.
  Typo fixes that have no associated JIRA issue should be named following this pattern: `[hotfix] [docs] Fix typo in event time introduction` or `[hotfix] [javadocs] Expand JavaDoc for PuncuatedWatermarkGenerator`.

  - Fill out the template below to describe the changes contributed by the pull request. That will give reviewers the context they need to do the review.
  
  - Make sure that the change passes the automated tests, i.e., `mvn clean verify` passes. You can set up Azure Pipelines CI to do that following [this guide](https://cwiki.apache.org/confluence/display/FLINK/Azure+Pipelines#AzurePipelines-Tutorial:SettingupAzurePipelinesforaforkoftheFlinkrepository).

  - Each pull request should address only one issue, not mix up code from multiple issues.
  
  - Each commit in the pull request has a meaningful commit message (including the JIRA id)

  - Once all items of the checklist are addressed, remove the above text and this checklist, leaving only the filled out template below.


**(The sections below can be removed for hotfixes of typos)**
-->

## What is the purpose of the change
 
This PR provides the way to change the 'auto.offset.reset' for kafka table source when use 'group-offsets' startup mode .

When 'auto.offset.reset' is set, the 'group-offsets' startup mode will use the provided auto offset reset strategy, or else 'none' reset strategy in order to be consistent with the DataStream API.

## Brief change log

  - When 'auto.offset.reset' is set, the 'group-offsets' startup mode will use the provided auto offset reset strategy, or else 'none' reset strategy as default


## Verifying this change

  - Added test that validates that the 'auto.offset.reset' is set for kafka consumers


## Does this pull request potentially affect one of the following parts:

  - Dependencies (does it add or upgrade a dependency): (no)
  - The public API, i.e., is any changed class annotated with `@Public(Evolving)`: (no)
  - The serializers: (no)
  - The runtime per-record code paths (performance sensitive): (no)
  - Anything that affects deployment or recovery: JobManager (and its components), Checkpointing, Kubernetes/Yarn, ZooKeeper: (no)
  - The S3 file system connector: (no)

## Documentation

  - Does this pull request introduce a new feature? (no)
