### PR TITLE
[FLINK-24704][table] Fix exception when the input record loses monotonicity on the sort key field of UpdatableTopNFunction

### DIFF
--- a/flink-table/flink-table-planner/src/test/scala/org/apache/flink/table/planner/runtime/harness/RankHarnessTest.scala
+++ b/flink-table/flink-table-planner/src/test/scala/org/apache/flink/table/planner/runtime/harness/RankHarnessTest.scala
@@ -265,7 +265,6 @@ class RankHarnessTest(mode: StateBackendMode) extends HarnessTestBase(mode) {
 
     testHarness.processElement(binaryRecord(UPDATE_AFTER, "b", 1: JInt, 10: JInt))
 
-
     val result = dropWatermarks(testHarness.getOutput.toArray)
     val expectedOutput = new ConcurrentLinkedQueue[Object]()
 

--- a/flink-table/flink-table-planner/src/test/scala/org/apache/flink/table/planner/runtime/harness/RankHarnessTest.scala
+++ b/flink-table/flink-table-planner/src/test/scala/org/apache/flink/table/planner/runtime/harness/RankHarnessTest.scala
@@ -22,6 +22,7 @@ import org.apache.flink.api.scala._
 import org.apache.flink.table.api._
 import org.apache.flink.table.api.bridge.scala._
 import org.apache.flink.table.api.bridge.scala.internal.StreamTableEnvironmentImpl
+import org.apache.flink.table.planner.JInt
 import org.apache.flink.table.planner.runtime.utils.JavaUserDefinedTableFunctions
 import org.apache.flink.table.planner.runtime.utils.StreamingWithStateTestBase.StateBackendMode
 import org.apache.flink.table.runtime.util.RowDataHarnessAssertor
@@ -216,6 +217,77 @@ class RankHarnessTest(mode: StateBackendMode) extends HarnessTestBase(mode) {
     // expectedOutput.add(binaryRecord(INSERT, "a", "1", 1L: JLong, "1"))
 
     expectedOutput.add(binaryRecord(INSERT, "a", "1", 2L: JLong, "1"))
+
+    assertor.assertOutputEqualsSorted("result mismatch", expectedOutput, result)
+    testHarness.close()
+  }
+
+  @Test
+  def testUpdateRankWithRowNumber(): Unit = {
+    val data = new mutable.MutableList[(String, Int, Int)]
+    val t = env.fromCollection(data).toTable(tEnv, 'word, 'cnt, 'type)
+    tEnv.createTemporaryView("T", t)
+    tEnv.getConfig.setIdleStateRetention(Duration.ofSeconds(1))
+
+    val sql =
+      """
+        |SELECT word, cnt, rank_num
+        |FROM (
+        |  SELECT word, cnt,
+        |      ROW_NUMBER() OVER (PARTITION BY type ORDER BY cnt DESC) as rank_num
+        |  FROM (
+        |     select word, type, sum(cnt) filter (where cnt > 0) cnt from T group by word, type
+        |   )
+        |  )
+        |WHERE rank_num <= 6
+      """.stripMargin
+
+    val t1 = tEnv.sqlQuery(sql)
+
+    val testHarness = createHarnessTester(
+      t1.toRetractStream[Row],
+      "Rank(strategy=[UpdateFastStrategy")
+    val assertor = new RowDataHarnessAssertor(
+      Array(
+        DataTypes.STRING().getLogicalType,
+        DataTypes.INT().getLogicalType,
+        DataTypes.INT().getLogicalType,
+        DataTypes.BIGINT().getLogicalType))
+
+    testHarness.open()
+
+    testHarness.processElement(binaryRecord(INSERT, "a", 1: JInt, 100: JInt))
+    testHarness.processElement(binaryRecord(INSERT, "b", 1: JInt, 90: JInt))
+    testHarness.processElement(binaryRecord(INSERT, "c", 1: JInt, 90: JInt))
+    testHarness.processElement(binaryRecord(INSERT, "d", 1: JInt, 80: JInt))
+    testHarness.processElement(binaryRecord(INSERT, "e", 1: JInt, 80: JInt))
+    testHarness.processElement(binaryRecord(INSERT, "f", 1: JInt, 70: JInt))
+
+    testHarness.processElement(binaryRecord(UPDATE_AFTER, "b", 1: JInt, 10: JInt))
+
+
+    val result = dropWatermarks(testHarness.getOutput.toArray)
+    val expectedOutput = new ConcurrentLinkedQueue[Object]()
+
+    expectedOutput.add(binaryRecord(INSERT, "a", 1: JInt, 100: JInt, 1L: JLong))
+    expectedOutput.add(binaryRecord(INSERT, "b", 1: JInt, 90: JInt, 2L: JLong))
+    expectedOutput.add(binaryRecord(INSERT, "c", 1: JInt, 90: JInt, 3L: JLong))
+    expectedOutput.add(binaryRecord(INSERT, "d", 1: JInt, 80: JInt, 4L: JLong))
+    expectedOutput.add(binaryRecord(INSERT, "e", 1: JInt, 80: JInt, 5L: JLong))
+    expectedOutput.add(binaryRecord(INSERT, "f", 1: JInt, 70: JInt, 6L: JLong))
+
+    expectedOutput.add(binaryRecord(UPDATE_BEFORE, "b", 1: JInt, 90: JInt, 2L: JLong))
+
+    expectedOutput.add(binaryRecord(UPDATE_BEFORE, "c", 1: JInt, 90: JInt, 3L: JLong))
+    expectedOutput.add(binaryRecord(UPDATE_AFTER, "c", 1: JInt, 90: JInt, 2L: JLong))
+    expectedOutput.add(binaryRecord(UPDATE_BEFORE, "d", 1: JInt, 80: JInt, 4L: JLong))
+    expectedOutput.add(binaryRecord(UPDATE_AFTER, "d", 1: JInt, 80: JInt, 3L: JLong))
+    expectedOutput.add(binaryRecord(UPDATE_BEFORE, "e", 1: JInt, 80: JInt, 5L: JLong))
+    expectedOutput.add(binaryRecord(UPDATE_AFTER, "e", 1: JInt, 80: JInt, 4L: JLong))
+    expectedOutput.add(binaryRecord(UPDATE_BEFORE, "f", 1: JInt, 70: JInt, 6L: JLong))
+    expectedOutput.add(binaryRecord(UPDATE_AFTER, "f", 1: JInt, 70: JInt, 5L: JLong))
+
+    expectedOutput.add(binaryRecord(UPDATE_AFTER, "b", 1: JInt, 10: JInt, 6L: JLong))
 
     assertor.assertOutputEqualsSorted("result mismatch", expectedOutput, result)
     testHarness.close()

--- a/flink-table/flink-table-planner/src/test/scala/org/apache/flink/table/planner/runtime/harness/RankHarnessTest.scala
+++ b/flink-table/flink-table-planner/src/test/scala/org/apache/flink/table/planner/runtime/harness/RankHarnessTest.scala
@@ -19,9 +19,11 @@
 package org.apache.flink.table.planner.runtime.harness
 
 import org.apache.flink.api.scala._
+import org.apache.flink.streaming.util.KeyedOneInputStreamOperatorTestHarness
 import org.apache.flink.table.api._
 import org.apache.flink.table.api.bridge.scala._
 import org.apache.flink.table.api.bridge.scala.internal.StreamTableEnvironmentImpl
+import org.apache.flink.table.data.RowData
 import org.apache.flink.table.planner.JInt
 import org.apache.flink.table.planner.runtime.utils.JavaUserDefinedTableFunctions
 import org.apache.flink.table.planner.runtime.utils.StreamingWithStateTestBase.StateBackendMode
@@ -222,8 +224,8 @@ class RankHarnessTest(mode: StateBackendMode) extends HarnessTestBase(mode) {
     testHarness.close()
   }
 
-  @Test
-  def testUpdateRankWithRowNumber(): Unit = {
+  def prepareUpdateRankWithRowNumberTester():
+    (KeyedOneInputStreamOperatorTestHarness[RowData, RowData, RowData], RowDataHarnessAssertor) = {
     val data = new mutable.MutableList[(String, Int, Int)]
     val t = env.fromCollection(data).toTable(tEnv, 'word, 'cnt, 'type)
     tEnv.createTemporaryView("T", t)
@@ -253,7 +255,12 @@ class RankHarnessTest(mode: StateBackendMode) extends HarnessTestBase(mode) {
         DataTypes.INT().getLogicalType,
         DataTypes.INT().getLogicalType,
         DataTypes.BIGINT().getLogicalType))
+    (testHarness, assertor)
+  }
 
+  @Test
+  def testUpdateRankWithRowNumberSortKeyDropsToLast(): Unit = {
+    val (testHarness, assertor) = prepareUpdateRankWithRowNumberTester()
     testHarness.open()
 
     testHarness.processElement(binaryRecord(INSERT, "a", 1: JInt, 100: JInt))
@@ -287,6 +294,161 @@ class RankHarnessTest(mode: StateBackendMode) extends HarnessTestBase(mode) {
     expectedOutput.add(binaryRecord(UPDATE_AFTER, "f", 1: JInt, 70: JInt, 5L: JLong))
 
     expectedOutput.add(binaryRecord(UPDATE_AFTER, "b", 1: JInt, 10: JInt, 6L: JLong))
+
+    assertor.assertOutputEqualsSorted("result mismatch", expectedOutput, result)
+    testHarness.close()
+  }
+
+  @Test
+  def testUpdateRankWithRowNumberSortKeyDropsButRankUnchange(): Unit = {
+    val (testHarness, assertor) = prepareUpdateRankWithRowNumberTester()
+    testHarness.open()
+
+    testHarness.processElement(binaryRecord(INSERT, "a", 1: JInt, 100: JInt))
+    testHarness.processElement(binaryRecord(INSERT, "b", 1: JInt, 90: JInt))
+    testHarness.processElement(binaryRecord(INSERT, "c", 1: JInt, 90: JInt))
+    testHarness.processElement(binaryRecord(INSERT, "d", 1: JInt, 80: JInt))
+    testHarness.processElement(binaryRecord(INSERT, "e", 1: JInt, 80: JInt))
+    testHarness.processElement(binaryRecord(INSERT, "f", 1: JInt, 70: JInt))
+
+    testHarness.processElement(binaryRecord(UPDATE_AFTER, "c", 1: JInt, 88: JInt))
+
+    val result = dropWatermarks(testHarness.getOutput.toArray)
+    val expectedOutput = new ConcurrentLinkedQueue[Object]()
+
+    expectedOutput.add(binaryRecord(INSERT, "a", 1: JInt, 100: JInt, 1L: JLong))
+    expectedOutput.add(binaryRecord(INSERT, "b", 1: JInt, 90: JInt, 2L: JLong))
+    expectedOutput.add(binaryRecord(INSERT, "c", 1: JInt, 90: JInt, 3L: JLong))
+    expectedOutput.add(binaryRecord(INSERT, "d", 1: JInt, 80: JInt, 4L: JLong))
+    expectedOutput.add(binaryRecord(INSERT, "e", 1: JInt, 80: JInt, 5L: JLong))
+    expectedOutput.add(binaryRecord(INSERT, "f", 1: JInt, 70: JInt, 6L: JLong))
+
+    expectedOutput.add(binaryRecord(UPDATE_BEFORE, "c", 1: JInt, 90: JInt, 3L: JLong))
+    expectedOutput.add(binaryRecord(UPDATE_AFTER, "c", 1: JInt, 88: JInt, 3L: JLong))
+
+    assertor.assertOutputEqualsSorted("result mismatch", expectedOutput, result)
+    testHarness.close()
+  }
+
+  @Test
+  def testUpdateRankWithRowNumberSortKeyDropsToNotLast(): Unit = {
+    val (testHarness, assertor) = prepareUpdateRankWithRowNumberTester()
+    testHarness.open()
+
+    testHarness.processElement(binaryRecord(INSERT, "a", 1: JInt, 100: JInt))
+    testHarness.processElement(binaryRecord(INSERT, "b", 1: JInt, 90: JInt))
+    testHarness.processElement(binaryRecord(INSERT, "c", 1: JInt, 90: JInt))
+    testHarness.processElement(binaryRecord(INSERT, "d", 1: JInt, 80: JInt))
+    testHarness.processElement(binaryRecord(INSERT, "e", 1: JInt, 80: JInt))
+    testHarness.processElement(binaryRecord(INSERT, "f", 1: JInt, 70: JInt))
+
+    testHarness.processElement(binaryRecord(UPDATE_AFTER, "b", 1: JInt, 80: JInt))
+
+    val result = dropWatermarks(testHarness.getOutput.toArray)
+    val expectedOutput = new ConcurrentLinkedQueue[Object]()
+
+    expectedOutput.add(binaryRecord(INSERT, "a", 1: JInt, 100: JInt, 1L: JLong))
+    expectedOutput.add(binaryRecord(INSERT, "b", 1: JInt, 90: JInt, 2L: JLong))
+    expectedOutput.add(binaryRecord(INSERT, "c", 1: JInt, 90: JInt, 3L: JLong))
+    expectedOutput.add(binaryRecord(INSERT, "d", 1: JInt, 80: JInt, 4L: JLong))
+    expectedOutput.add(binaryRecord(INSERT, "e", 1: JInt, 80: JInt, 5L: JLong))
+    expectedOutput.add(binaryRecord(INSERT, "f", 1: JInt, 70: JInt, 6L: JLong))
+
+    expectedOutput.add(binaryRecord(UPDATE_BEFORE, "b", 1: JInt, 90: JInt, 2L: JLong))
+
+    expectedOutput.add(binaryRecord(UPDATE_BEFORE, "c", 1: JInt, 90: JInt, 3L: JLong))
+    expectedOutput.add(binaryRecord(UPDATE_AFTER, "c", 1: JInt, 90: JInt, 2L: JLong))
+    expectedOutput.add(binaryRecord(UPDATE_BEFORE, "d", 1: JInt, 80: JInt, 4L: JLong))
+    expectedOutput.add(binaryRecord(UPDATE_AFTER, "d", 1: JInt, 80: JInt, 3L: JLong))
+    expectedOutput.add(binaryRecord(UPDATE_BEFORE, "e", 1: JInt, 80: JInt, 5L: JLong))
+    expectedOutput.add(binaryRecord(UPDATE_AFTER, "e", 1: JInt, 80: JInt, 4L: JLong))
+
+    expectedOutput.add(binaryRecord(UPDATE_AFTER, "b", 1: JInt, 80: JInt, 5L: JLong))
+
+    assertor.assertOutputEqualsSorted("result mismatch", expectedOutput, result)
+    testHarness.close()
+  }
+
+  @Test
+  def testUpdateRankWithRowNumberCandidatesLargerThanRankEnd(): Unit = {
+    val (testHarness, assertor) = prepareUpdateRankWithRowNumberTester()
+    testHarness.open()
+
+    testHarness.processElement(binaryRecord(INSERT, "a", 1: JInt, 100: JInt))
+    testHarness.processElement(binaryRecord(INSERT, "b", 1: JInt, 90: JInt))
+    testHarness.processElement(binaryRecord(INSERT, "c", 1: JInt, 90: JInt))
+    testHarness.processElement(binaryRecord(INSERT, "d", 1: JInt, 80: JInt))
+    testHarness.processElement(binaryRecord(INSERT, "e", 1: JInt, 80: JInt))
+    testHarness.processElement(binaryRecord(INSERT, "f", 1: JInt, 70: JInt))
+    testHarness.processElement(binaryRecord(INSERT, "g", 1: JInt, 60: JInt))
+    testHarness.processElement(binaryRecord(INSERT, "h", 1: JInt, 50: JInt))
+
+    testHarness.processElement(binaryRecord(UPDATE_AFTER, "b", 1: JInt, 80: JInt))
+
+    val result = dropWatermarks(testHarness.getOutput.toArray)
+    val expectedOutput = new ConcurrentLinkedQueue[Object]()
+
+    expectedOutput.add(binaryRecord(INSERT, "a", 1: JInt, 100: JInt, 1L: JLong))
+    expectedOutput.add(binaryRecord(INSERT, "b", 1: JInt, 90: JInt, 2L: JLong))
+    expectedOutput.add(binaryRecord(INSERT, "c", 1: JInt, 90: JInt, 3L: JLong))
+    expectedOutput.add(binaryRecord(INSERT, "d", 1: JInt, 80: JInt, 4L: JLong))
+    expectedOutput.add(binaryRecord(INSERT, "e", 1: JInt, 80: JInt, 5L: JLong))
+    expectedOutput.add(binaryRecord(INSERT, "f", 1: JInt, 70: JInt, 6L: JLong))
+
+    expectedOutput.add(binaryRecord(UPDATE_BEFORE, "b", 1: JInt, 90: JInt, 2L: JLong))
+
+    expectedOutput.add(binaryRecord(UPDATE_BEFORE, "c", 1: JInt, 90: JInt, 3L: JLong))
+    expectedOutput.add(binaryRecord(UPDATE_AFTER, "c", 1: JInt, 90: JInt, 2L: JLong))
+    expectedOutput.add(binaryRecord(UPDATE_BEFORE, "d", 1: JInt, 80: JInt, 4L: JLong))
+    expectedOutput.add(binaryRecord(UPDATE_AFTER, "d", 1: JInt, 80: JInt, 3L: JLong))
+    expectedOutput.add(binaryRecord(UPDATE_BEFORE, "e", 1: JInt, 80: JInt, 5L: JLong))
+    expectedOutput.add(binaryRecord(UPDATE_AFTER, "e", 1: JInt, 80: JInt, 4L: JLong))
+
+    expectedOutput.add(binaryRecord(UPDATE_AFTER, "b", 1: JInt, 80: JInt, 5L: JLong))
+
+    assertor.assertOutputEqualsSorted("result mismatch", expectedOutput, result)
+    testHarness.close()
+  }
+
+  @Test
+  def testUpdateRankWithRowNumberSortKeyDropsOutOfRandEnd(): Unit = {
+    // Calc Top6: 8 candidates, old rank 2 drops to rank 7 (but it is still "rank 6")
+    val (testHarness, assertor) = prepareUpdateRankWithRowNumberTester()
+    testHarness.open()
+
+    testHarness.processElement(binaryRecord(INSERT, "a", 1: JInt, 100: JInt))
+    testHarness.processElement(binaryRecord(INSERT, "b", 1: JInt, 90: JInt))
+    testHarness.processElement(binaryRecord(INSERT, "c", 1: JInt, 90: JInt))
+    testHarness.processElement(binaryRecord(INSERT, "d", 1: JInt, 80: JInt))
+    testHarness.processElement(binaryRecord(INSERT, "e", 1: JInt, 80: JInt))
+    testHarness.processElement(binaryRecord(INSERT, "f", 1: JInt, 70: JInt))
+    testHarness.processElement(binaryRecord(INSERT, "g", 1: JInt, 60: JInt))
+    testHarness.processElement(binaryRecord(INSERT, "h", 1: JInt, 50: JInt))
+
+    testHarness.processElement(binaryRecord(UPDATE_AFTER, "b", 1: JInt, 55: JInt))
+
+    val result = dropWatermarks(testHarness.getOutput.toArray)
+    val expectedOutput = new ConcurrentLinkedQueue[Object]()
+
+    expectedOutput.add(binaryRecord(INSERT, "a", 1: JInt, 100: JInt, 1L: JLong))
+    expectedOutput.add(binaryRecord(INSERT, "b", 1: JInt, 90: JInt, 2L: JLong))
+    expectedOutput.add(binaryRecord(INSERT, "c", 1: JInt, 90: JInt, 3L: JLong))
+    expectedOutput.add(binaryRecord(INSERT, "d", 1: JInt, 80: JInt, 4L: JLong))
+    expectedOutput.add(binaryRecord(INSERT, "e", 1: JInt, 80: JInt, 5L: JLong))
+    expectedOutput.add(binaryRecord(INSERT, "f", 1: JInt, 70: JInt, 6L: JLong))
+
+    expectedOutput.add(binaryRecord(UPDATE_BEFORE, "b", 1: JInt, 90: JInt, 2L: JLong))
+
+    expectedOutput.add(binaryRecord(UPDATE_BEFORE, "c", 1: JInt, 90: JInt, 3L: JLong))
+    expectedOutput.add(binaryRecord(UPDATE_AFTER, "c", 1: JInt, 90: JInt, 2L: JLong))
+    expectedOutput.add(binaryRecord(UPDATE_BEFORE, "d", 1: JInt, 80: JInt, 4L: JLong))
+    expectedOutput.add(binaryRecord(UPDATE_AFTER, "d", 1: JInt, 80: JInt, 3L: JLong))
+    expectedOutput.add(binaryRecord(UPDATE_BEFORE, "e", 1: JInt, 80: JInt, 5L: JLong))
+    expectedOutput.add(binaryRecord(UPDATE_AFTER, "e", 1: JInt, 80: JInt, 4L: JLong))
+    expectedOutput.add(binaryRecord(UPDATE_BEFORE, "f", 1: JInt, 70: JInt, 6L: JLong))
+    expectedOutput.add(binaryRecord(UPDATE_AFTER, "f", 1: JInt, 70: JInt, 5L: JLong))
+
+    expectedOutput.add(binaryRecord(UPDATE_AFTER, "b", 1: JInt, 55: JInt, 6L: JLong))
 
     assertor.assertOutputEqualsSorted("result mismatch", expectedOutput, result)
     testHarness.close()

--- a/flink-table/flink-table-runtime/src/main/java/org/apache/flink/table/runtime/operators/rank/UpdatableTopNFunction.java
+++ b/flink-table/flink-table-runtime/src/main/java/org/apache/flink/table/runtime/operators/rank/UpdatableTopNFunction.java
@@ -32,6 +32,8 @@ import org.apache.flink.runtime.state.FunctionInitializationContext;
 import org.apache.flink.runtime.state.FunctionSnapshotContext;
 import org.apache.flink.streaming.api.checkpoint.CheckpointedFunction;
 import org.apache.flink.table.data.RowData;
+import org.apache.flink.table.data.conversion.DataStructureConverter;
+import org.apache.flink.table.data.conversion.RowRowConverter;
 import org.apache.flink.table.runtime.generated.GeneratedRecordComparator;
 import org.apache.flink.table.runtime.keyselector.RowDataKeySelector;
 import org.apache.flink.table.runtime.typeutils.InternalTypeInfo;
@@ -75,6 +77,12 @@ public class UpdatableTopNFunction extends AbstractTopNFunction implements Check
     private final InternalTypeInfo<RowData> rowKeyType;
     private final long cacheSize;
 
+    // flag to skip records with non-exist error instead to fail, true by default.
+    private final boolean lenient = true;
+    // data converter for logging only.
+    private transient DataStructureConverter rowConverter;
+    private transient DataStructureConverter sortKeyConverter;
+
     // a map state stores mapping from row key to record which is in topN
     // in tuple2, f0 is the record row, f1 is the index in the list of the same sort_key
     // the f1 is used to preserve the record order in the same sort_key
@@ -116,6 +124,9 @@ public class UpdatableTopNFunction extends AbstractTopNFunction implements Check
         this.cacheSize = cacheSize;
         this.inputRowSer = inputRowType.createSerializer(new ExecutionConfig());
         this.rowKeySelector = rowKeySelector;
+        this.rowConverter = RowRowConverter.create(inputRowType.getDataType());
+        this.sortKeyConverter =
+                RowRowConverter.create(sortKeySelector.getProducedType().getDataType());
     }
 
     @Override
@@ -137,6 +148,9 @@ public class UpdatableTopNFunction extends AbstractTopNFunction implements Check
                 "Top{} operator is using LRU caches key-size: {}",
                 getDefaultTopNSize(),
                 lruCacheSize);
+
+        rowConverter.open(getRuntimeContext().getUserCodeClassLoader());
+        sortKeyConverter.open(getRuntimeContext().getUserCodeClassLoader());
 
         TupleTypeInfo<Tuple2<RowData, Integer>> valueTypeInfo =
                 new TupleTypeInfo<>(inputRowType, Types.INT);
@@ -249,7 +263,8 @@ public class UpdatableTopNFunction extends AbstractTopNFunction implements Check
             // the new sort key must be higher than old sort key, this is guaranteed by rules
             RankRow oldRow = rowKeyMap.get(rowKey);
             RowData oldSortKey = sortKeySelector.getKey(oldRow.row);
-            if (oldSortKey.equals(sortKey)) {
+            int compare = sortKeyComparator.compare(sortKey, oldSortKey);
+            if (compare == 0) {
                 // sort key is not changed, so the rank is the same, only output the row
                 Tuple2<Integer, Integer> rankAndInnerRank = rowNumber(sortKey, rowKey, buffer);
                 int rank = rankAndInnerRank.f0;
@@ -258,20 +273,47 @@ public class UpdatableTopNFunction extends AbstractTopNFunction implements Check
                 collectUpdateBefore(out, oldRow.row, rank); // retract old record
                 collectUpdateAfter(out, inputRow, rank);
                 return;
+            } else {
+                Tuple2<Integer, Integer> oldRankAndInnerRank =
+                        rowNumber(oldSortKey, rowKey, buffer);
+                int oldRank = oldRankAndInnerRank.f0;
+                // remove old sort key
+                buffer.remove(oldSortKey, rowKey);
+                // add new sort key
+                int size = buffer.put(sortKey, rowKey);
+                rowKeyMap.put(rowKey, new RankRow(inputRowSer.copy(inputRow), size, true));
+                // update inner rank of records under the old sort key
+                updateInnerRank(oldSortKey);
+
+                if (compare < 0) {
+                    // sortKey is higher than oldSortKey
+                    emitRecordsWithRowNumber(sortKey, inputRow, out, oldSortKey, oldRow, oldRank);
+                } else {
+                    String inputRowStr = rowConverter.toExternal(inputRow).toString();
+                    String errorMsg =
+                            String.format(
+                                    "The input retract record:{%s}'s sort key: %s is lower than old"
+                                            + " sort key: %s, this break the monotonicity on sort key field"
+                                            + " which is guaranteed by the sql semantic. It's highly "
+                                            + "possible upstream stateful operator has shorter state ttl "
+                                            + "than the stream records is that cause the staled record "
+                                            + "cleared by state ttl.",
+                                    inputRowStr,
+                                    sortKeyConverter.toExternal(sortKey).toString(),
+                                    sortKeyConverter.toExternal(oldSortKey).toString());
+                    if (lenient) {
+                        LOG.warn(errorMsg);
+                        Tuple2<Integer, Integer> newRankAndInnerRank =
+                                rowNumber(sortKey, rowKey, buffer);
+                        int newRank = newRankAndInnerRank.f0;
+                        // affect rank range: [oldRank, newRank]
+                        emitRecordsWithRowNumberIgnoreStateError(
+                                sortKey, inputRow, newRank, oldSortKey, oldRow, oldRank, out);
+                    } else {
+                        throw new RuntimeException(errorMsg);
+                    }
+                }
             }
-
-            Tuple2<Integer, Integer> oldRankAndInnerRank = rowNumber(oldSortKey, rowKey, buffer);
-            int oldRank = oldRankAndInnerRank.f0;
-            // remove old sort key
-            buffer.remove(oldSortKey, rowKey);
-            // add new sort key
-            int size = buffer.put(sortKey, rowKey);
-            rowKeyMap.put(rowKey, new RankRow(inputRowSer.copy(inputRow), size, true));
-            // update inner rank of records under the old sort key
-            updateInnerRank(oldSortKey);
-
-            // emit records
-            emitRecordsWithRowNumber(sortKey, inputRow, out, oldSortKey, oldRow, oldRank);
         } else if (checkSortKeyInBufferRange(sortKey, buffer)) {
             // it is a new record but is in the topN, insert sort key into buffer
             int size = buffer.put(sortKey, rowKey);
@@ -310,6 +352,70 @@ public class UpdatableTopNFunction extends AbstractTopNFunction implements Check
                 rowKey);
         throw new RuntimeException(
                 "Failed to find the sortKey, rowkey in the buffer. This should never happen");
+    }
+
+    private void emitRecordsWithRowNumberIgnoreStateError(
+            RowData newSortKey,
+            RowData newRow,
+            int newRank,
+            RowData oldSortKey,
+            RankRow oldRow,
+            int oldRank,
+            Collector<RowData> out)
+            throws Exception {
+        Iterator<Map.Entry<RowData, Collection<RowData>>> iterator = buffer.entrySet().iterator();
+        int currentRank = 0;
+        RowData currentRow = null;
+        RowData prevRow = null;
+        boolean findAllAffected = false;
+
+        while (iterator.hasNext() && isInRankEnd(currentRank) && !findAllAffected) {
+            Map.Entry<RowData, Collection<RowData>> entry = iterator.next();
+            RowData curSortKey = entry.getKey();
+            Collection<RowData> rowKeys = entry.getValue();
+            Iterator<RowData> rowKeyIter = rowKeys.iterator();
+            while (rowKeyIter.hasNext() && !findAllAffected) {
+                RowData rowKey = rowKeyIter.next();
+                currentRank += 1;
+                currentRow = rowKeyMap.get(rowKey).row;
+                if (oldRank <= currentRank && currentRank <= newRank) {
+                    if (currentRank == oldRank) {
+                        checkArgument(0 == sortKeyComparator.compare(curSortKey, oldSortKey));
+                        collectUpdateBefore(out, oldRow.row, oldRank);
+                    } else if (currentRank <= newRank) {
+                        checkArgument(0 >= sortKeyComparator.compare(curSortKey, newSortKey));
+                        collectUpdateBefore(out, prevRow, currentRank);
+                        collectUpdateAfter(out, prevRow, currentRank - 1);
+                        if (currentRank == newRank) {
+                            collectUpdateAfter(out, newRow, currentRank);
+                        }
+                    } else {
+                        // currentRank > newRank, current sort key is smaller than newSortKey,
+                        // the following rank is not changed, so skip
+                        findAllAffected = true;
+                    }
+                }
+                prevRow = currentRow;
+            }
+        }
+        if (!isInRankEnd(currentRank)) {
+            // remove the records associated to the sort key which is out of topN
+            List<RowData> toDeleteSortKeys = new ArrayList<>();
+            while (iterator.hasNext()) {
+                Map.Entry<RowData, Collection<RowData>> entry = iterator.next();
+                Collection<RowData> rowKeys = entry.getValue();
+                Iterator<RowData> rowKeyIter = rowKeys.iterator();
+                while (rowKeyIter.hasNext()) {
+                    RowData rowKey = rowKeyIter.next();
+                    rowKeyMap.remove(rowKey);
+                    dataState.remove(rowKey);
+                }
+                toDeleteSortKeys.add(entry.getKey());
+            }
+            for (RowData toDeleteKey : toDeleteSortKeys) {
+                buffer.removeAll(toDeleteKey);
+            }
+        }
     }
 
     private void emitRecordsWithRowNumber(RowData sortKey, RowData inputRow, Collector<RowData> out)

--- a/flink-table/flink-table-runtime/src/main/java/org/apache/flink/table/runtime/operators/rank/UpdatableTopNFunction.java
+++ b/flink-table/flink-table-runtime/src/main/java/org/apache/flink/table/runtime/operators/rank/UpdatableTopNFunction.java
@@ -79,9 +79,10 @@ public class UpdatableTopNFunction extends AbstractTopNFunction implements Check
 
     // flag to skip records with non-exist error instead to fail, true by default.
     private final boolean lenient = true;
+
     // data converter for logging only.
-    private transient DataStructureConverter rowConverter;
-    private transient DataStructureConverter sortKeyConverter;
+    private final DataStructureConverter rowConverter;
+    private final DataStructureConverter sortKeyConverter;
 
     // a map state stores mapping from row key to record which is in topN
     // in tuple2, f0 is the record row, f1 is the index in the list of the same sort_key


### PR DESCRIPTION
## What is the purpose of the change

Fix the exception when the input record loses monotonicity on the sort key field of UpdatableTopNFunction

## Verifying this change

This change is already covered by RankHarnessTest

## Does this pull request potentially affect one of the following parts:

    - Dependencies (does it add or upgrade a dependency): (no)
    - The public API, i.e., is any changed class annotated with @Public(Evolving): (no)
    - The serializers: (no )
    - The runtime per-record code paths (performance sensitive): (no)
    - Anything that affects deployment or recovery: JobManager (and its components), Checkpointing, Kubernetes/Yarn, ZooKeeper: (no)
    - The S3 file system connector: (no)

## Documentation

  - Does this pull request introduce a new feature? (no)
