### PR TITLE
[FLINK-24706][rpc] Forward deserialization errors to returned future

### DIFF
--- a/flink-runtime/src/main/java/org/apache/flink/runtime/heartbeat/HeartbeatManagerImpl.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/heartbeat/HeartbeatManagerImpl.java
@@ -20,6 +20,7 @@ package org.apache.flink.runtime.heartbeat;
 
 import org.apache.flink.runtime.clusterframework.types.ResourceID;
 import org.apache.flink.runtime.rpc.exceptions.RecipientUnreachableException;
+import org.apache.flink.util.ExceptionUtils;
 import org.apache.flink.util.Preconditions;
 import org.apache.flink.util.concurrent.FutureUtils;
 import org.apache.flink.util.concurrent.ScheduledExecutor;
@@ -244,7 +245,8 @@ public class HeartbeatManagerImpl<I, O> implements HeartbeatManager<I, O> {
     protected BiConsumer<Void, Throwable> handleHeartbeatRpc(ResourceID heartbeatTarget) {
         return (unused, failure) -> {
             if (failure != null) {
-                handleHeartbeatRpcFailure(heartbeatTarget, failure);
+                handleHeartbeatRpcFailure(
+                        heartbeatTarget, ExceptionUtils.stripCompletionException(failure));
             } else {
                 handleHeartbeatRpcSuccess(heartbeatTarget);
             }

--- a/flink-tests/src/test/java/org/apache/flink/test/recovery/TaskManagerProcessFailureBatchRecoveryITCase.java
+++ b/flink-tests/src/test/java/org/apache/flink/test/recovery/TaskManagerProcessFailureBatchRecoveryITCase.java
@@ -67,7 +67,7 @@ public class TaskManagerProcessFailureBatchRecoveryITCase
         ExecutionEnvironment env =
                 ExecutionEnvironment.createRemoteEnvironment("localhost", 1337, configuration);
         env.setParallelism(PARALLELISM);
-        env.setRestartStrategy(RestartStrategies.fixedDelayRestart(1, 1500L));
+        env.setRestartStrategy(RestartStrategies.fixedDelayRestart(1, 5000L));
         env.getConfig().setExecutionMode(executionMode);
 
         final long numElements = 100000L;


### PR DESCRIPTION
Fixes an issue where issues during the deserialization of RPC messages were silently ignored. We now forward the error to the returned future instead.

@tillrohrmann Could you take a look?