### PR TITLE
[FLINK-24543][runtime] Avoid possible inconsistencies of ZookeeperSta…

### DIFF
--- a/flink-runtime/src/main/java/org/apache/flink/runtime/zookeeper/ZooKeeperStateHandleStore.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/zookeeper/ZooKeeperStateHandleStore.java
@@ -39,15 +39,16 @@ import org.slf4j.LoggerFactory;
 import java.io.IOException;
 import java.io.Serializable;
 import java.util.ArrayList;
+import java.util.Arrays;
 import java.util.Collection;
 import java.util.Collections;
+import java.util.HashSet;
 import java.util.List;
 import java.util.Set;
 import java.util.UUID;
 
 import static org.apache.flink.runtime.util.StateHandleStoreUtils.deserialize;
 import static org.apache.flink.runtime.util.StateHandleStoreUtils.serializeOrDiscard;
-import static org.apache.flink.shaded.guava30.com.google.common.collect.Sets.newHashSet;
 import static org.apache.flink.util.Preconditions.checkNotNull;
 
 /**
@@ -87,18 +88,19 @@ public class ZooKeeperStateHandleStore<T extends Serializable>
 
     private static final Logger LOG = LoggerFactory.getLogger(ZooKeeperStateHandleStore.class);
 
-    @VisibleForTesting
-    static final Set<Class<? extends KeeperException>> PRE_COMMIT_EXCEPTIONS =
-            newHashSet(
-                    KeeperException.NodeExistsException.class,
-                    KeeperException.BadArgumentsException.class,
-                    KeeperException.NoNodeException.class,
-                    KeeperException.NoAuthException.class,
-                    KeeperException.BadVersionException.class,
-                    KeeperException.AuthFailedException.class,
-                    KeeperException.InvalidACLException.class,
-                    KeeperException.SessionMovedException.class,
-                    KeeperException.NotReadOnlyException.class);
+    /** Pre-commit exceptions that don't imply data inconsistency. */
+    private static final Set<Class<? extends KeeperException>> SAFE_PRE_COMMIT_EXCEPTIONS =
+            new HashSet<>(
+                    Arrays.asList(
+                            KeeperException.NodeExistsException.class,
+                            KeeperException.BadArgumentsException.class,
+                            KeeperException.NoNodeException.class,
+                            KeeperException.NoAuthException.class,
+                            KeeperException.BadVersionException.class,
+                            KeeperException.AuthFailedException.class,
+                            KeeperException.InvalidACLException.class,
+                            KeeperException.SessionMovedException.class,
+                            KeeperException.NotReadOnlyException.class));
 
     /** Curator ZooKeeper client. */
     private final CuratorFramework client;
@@ -139,7 +141,7 @@ public class ZooKeeperStateHandleStore<T extends Serializable>
      * but create a state handle and store it in ZooKeeper. This level of indirection makes sure
      * that data in ZooKeeper is small.
      *
-     * <p>The operation will fail if there is already an node under the given path
+     * <p>The operation will fail if there is already a node under the given path.
      *
      * @param pathInZooKeeper Destination path in ZooKeeper (expected to *not* exist yet)
      * @param state State to be added
@@ -154,43 +156,40 @@ public class ZooKeeperStateHandleStore<T extends Serializable>
             throws PossibleInconsistentStateException, Exception {
         checkNotNull(pathInZooKeeper, "Path in ZooKeeper");
         checkNotNull(state, "State");
-
         final String path = normalizePath(pathInZooKeeper);
-
-        RetrievableStateHandle<T> storeHandle = storage.store(state);
-
-        byte[] serializedStoreHandle = serializeOrDiscard(storeHandle);
-
+        if (exists(path).isExisting()) {
+            throw new AlreadyExistException(
+                    String.format("ZooKeeper node %s already exists.", path));
+        }
+        final RetrievableStateHandle<T> storeHandle = storage.store(state);
+        final byte[] serializedStoreHandle = serializeOrDiscard(storeHandle);
         try {
             writeStoreHandleTransactionally(path, serializedStoreHandle);
+            return storeHandle;
+        } catch (KeeperException.NodeExistsException e) {
+            // Transactions are not idempotent in the curator version we're currently using, so it
+            // is actually possible that we've re-tried a transaction that has already succeeded.
+            // We've ensured that the node hasn't been present prior executing the transaction, so
+            // we can assume that this is a result of the retry mechanism.
             return storeHandle;
         } catch (Exception e) {
             if (indicatesPossiblyInconsistentState(e)) {
                 throw new PossibleInconsistentStateException(e);
             }
-
-            // in any other failure case: discard the state
+            // In case of any other failure, discard the state and rethrow the exception.
             storeHandle.discardState();
-
-            // We wrap the exception here so that it could be caught in DefaultJobGraphStore
-            throw ExceptionUtils.findThrowable(e, KeeperException.NodeExistsException.class)
-                    .map(
-                            nee ->
-                                    new AlreadyExistException(
-                                            "ZooKeeper node " + path + " already exists.", nee))
-                    .orElseThrow(() -> e);
+            throw e;
         }
     }
 
     // this method is provided for the sole purpose of easier testing
     @VisibleForTesting
-    protected void writeStoreHandleTransactionally(String path, byte[] serializedStoreHandle)
+    void writeStoreHandleTransactionally(String path, byte[] serializedStoreHandle)
             throws Exception {
-        // Write state handle (not the actual state) to ZooKeeper. This is expected to be
-        // smaller than the state itself. This level of indirection makes sure that data in
-        // ZooKeeper is small, because ZooKeeper is designed for data in the KB range, but
-        // the state can be larger.
-        // Create the lock node in a transaction with the actual state node. That way we can
+        // Write state handle (not the actual state) to ZooKeeper. This is expected to be smaller
+        // than the state itself. This level of indirection makes sure that data in ZooKeeper is
+        // small, because ZooKeeper is designed for data in the KB range, but the state can be
+        // larger. Create the lock node in a transaction with the actual state node. That way we can
         // prevent race conditions with a concurrent delete operation.
         client.inTransaction()
                 .create()
@@ -270,7 +269,7 @@ public class ZooKeeperStateHandleStore<T extends Serializable>
     }
 
     private boolean indicatesPossiblyInconsistentState(Exception e) {
-        return !PRE_COMMIT_EXCEPTIONS.contains(e.getClass());
+        return !SAFE_PRE_COMMIT_EXCEPTIONS.contains(e.getClass());
     }
 
     /**
@@ -467,7 +466,6 @@ public class ZooKeeperStateHandleStore<T extends Serializable>
     @Override
     public void release(String pathInZooKeeper) throws Exception {
         final String path = normalizePath(pathInZooKeeper);
-
         try {
             client.delete().forPath(getLockPath(path));
         } catch (KeeperException.NoNodeException ignored) {
@@ -529,7 +527,8 @@ public class ZooKeeperStateHandleStore<T extends Serializable>
      * @param rootPath Root path under which the lock node shall be created
      * @return Path for the lock node
      */
-    protected String getLockPath(String rootPath) {
+    @VisibleForTesting
+    String getLockPath(String rootPath) {
         return rootPath + '/' + lockNode;
     }
 

--- a/flink-runtime/src/test/java/org/apache/flink/runtime/zookeeper/ZooKeeperStateHandleStoreTest.java
+++ b/flink-runtime/src/test/java/org/apache/flink/runtime/zookeeper/ZooKeeperStateHandleStoreTest.java
@@ -58,6 +58,7 @@ import static org.junit.Assert.assertNotEquals;
 import static org.junit.Assert.assertNotNull;
 import static org.junit.Assert.assertNull;
 import static org.junit.Assert.assertThat;
+import static org.junit.Assert.assertThrows;
 import static org.junit.Assert.assertTrue;
 import static org.junit.Assert.fail;
 import static org.mockito.Mockito.spy;
@@ -79,9 +80,7 @@ public class ZooKeeperStateHandleStoreTest extends TestLogger {
 
     @AfterClass
     public static void tearDown() throws Exception {
-        if (ZOOKEEPER != null) {
-            ZOOKEEPER.shutdown();
-        }
+        ZOOKEEPER.shutdown();
     }
 
     @Before
@@ -147,8 +146,7 @@ public class ZooKeeperStateHandleStoreTest extends TestLogger {
         final TestingLongStateHandleHelper stateHandleProvider = new TestingLongStateHandleHelper();
 
         CuratorFramework client = spy(ZOOKEEPER.getClient());
-        when(client.inTransaction().create())
-                .thenThrow(new RuntimeException("Expected test Exception."));
+        when(client.inTransaction()).thenThrow(new RuntimeException("Expected test Exception."));
 
         ZooKeeperStateHandleStore<TestingLongStateHandleHelper.LongStateHandle> store =
                 new ZooKeeperStateHandleStore<>(client, stateHandleProvider);
@@ -173,10 +171,64 @@ public class ZooKeeperStateHandleStoreTest extends TestLogger {
     }
 
     @Test
-    public void testAddFailureHandlingForNodeExistsException() {
-        testFailingAddWithStateDiscardTriggeredFor(
-                new KeeperException.NodeExistsException(),
-                StateHandleStore.AlreadyExistException.class);
+    public void testAddAndLockExistingNode() throws Exception {
+        final TestingLongStateHandleHelper stateHandleProvider = new TestingLongStateHandleHelper();
+        final CuratorFramework client = ZOOKEEPER.getClient();
+        final ZooKeeperStateHandleStore<TestingLongStateHandleHelper.LongStateHandle> store =
+                new ZooKeeperStateHandleStore<>(client, stateHandleProvider);
+        final String path = "/test";
+        final long firstState = 1337L;
+        final long secondState = 7331L;
+        store.addAndLock(path, new TestingLongStateHandleHelper.LongStateHandle(firstState));
+        assertThrows(
+                StateHandleStore.AlreadyExistException.class,
+                () ->
+                        store.addAndLock(
+                                path,
+                                new TestingLongStateHandleHelper.LongStateHandle(secondState)));
+        // There should be only single state handle from the first successful attempt.
+        assertEquals(1, TestingLongStateHandleHelper.getGlobalStorageSize());
+        assertEquals(firstState, TestingLongStateHandleHelper.getStateHandleValueByIndex(0));
+        // No state should have been discarded.
+        assertEquals(0, TestingLongStateHandleHelper.getDiscardCallCountForStateHandleByIndex(0));
+        // Get state handle from zookeeper.
+        assertEquals(firstState, store.getAndLock(path).retrieveState().getValue());
+    }
+
+    /**
+     * Transactions are not idempotent in the Curator version we're currently using, therefore we
+     * may end up retrying the transaction that has already (eg. in case of connection failure).
+     * Retry of a successful transaction would result in {@link KeeperException.NodeExistsException}
+     * in this case.
+     *
+     * @see <a href="https://issues.apache.org/jira/browse/CURATOR-584">CURATOR-584</a>
+     */
+    @Test
+    public void testAddAndLockRetrySuccessfulTransaction() throws Exception {
+        final TestingLongStateHandleHelper stateHandleProvider = new TestingLongStateHandleHelper();
+        final CuratorFramework client = ZOOKEEPER.getClient();
+        final ZooKeeperStateHandleStore<TestingLongStateHandleHelper.LongStateHandle> store =
+                new ZooKeeperStateHandleStore<TestingLongStateHandleHelper.LongStateHandle>(
+                        client, stateHandleProvider) {
+
+                    @Override
+                    protected void writeStoreHandleTransactionally(
+                            String path, byte[] serializedStoreHandle) throws Exception {
+                        super.writeStoreHandleTransactionally(path, serializedStoreHandle);
+                        throw new KeeperException.NodeExistsException(
+                                "Committed transaction has been retried.");
+                    }
+                };
+        final String path = "/test";
+        final long firstState = 1337L;
+        store.addAndLock(path, new TestingLongStateHandleHelper.LongStateHandle(firstState));
+        // There should be only single state handle from the first successful attempt.
+        assertEquals(1, TestingLongStateHandleHelper.getGlobalStorageSize());
+        assertEquals(firstState, TestingLongStateHandleHelper.getStateHandleValueByIndex(0));
+        // No state should have been discarded.
+        assertEquals(0, TestingLongStateHandleHelper.getDiscardCallCountForStateHandleByIndex(0));
+        // Get state handle from zookeeper.
+        assertEquals(firstState, store.getAndLock(path).retrieveState().getValue());
     }
 
     @Test


### PR DESCRIPTION
This PR introduces idempotent transactions in `ZooKeeperStateHandleStore#addAndLock` method. In case of unstable connection we may actually retry transactions that have already succeeded and therefore encounter NodeAlreadyExists exception.

https://issues.apache.org/jira/browse/FLINK-24543