### PR TITLE
[FLINK-24663][Python] Quote bash argument for PythonEnvironmentManagerUtils

### DIFF
--- a/flink-python/src/main/java/org/apache/flink/python/util/PythonEnvironmentManagerUtils.java
+++ b/flink-python/src/main/java/org/apache/flink/python/util/PythonEnvironmentManagerUtils.java
@@ -150,7 +150,8 @@ public class PythonEnvironmentManagerUtils {
         if (environmentVariables.containsKey(PYFLINK_UDF_RUNNER_DIR)) {
             runnerDir = environmentVariables.get(PYFLINK_UDF_RUNNER_DIR);
         } else {
-            String[] commands = new String[] {pythonExecutable, "-c", GET_RUNNER_DIR_SCRIPT};
+            String[] commands =
+                    new String[] {pythonExecutable, "-c", bashQuoteString(GET_RUNNER_DIR_SCRIPT)};
             String out = execute(commands, environmentVariables, false);
             runnerDir = out.trim();
         }
@@ -167,7 +168,9 @@ public class PythonEnvironmentManagerUtils {
             String prefix, String pythonExecutable, Map<String, String> environmentVariables)
             throws IOException {
         String[] commands =
-                new String[] {pythonExecutable, "-c", GET_SITE_PACKAGES_PATH_SCRIPT, prefix};
+                new String[] {
+                    pythonExecutable, "-c", bashQuoteString(GET_SITE_PACKAGES_PATH_SCRIPT), prefix
+                };
         String out = execute(commands, environmentVariables, false);
         return String.join(File.pathSeparator, out.trim().split("\n"));
     }
@@ -176,7 +179,9 @@ public class PythonEnvironmentManagerUtils {
             String pipVersion, String pythonExecutable, Map<String, String> environmentVariables)
             throws IOException {
         String[] commands =
-                new String[] {pythonExecutable, "-c", CHECK_PIP_VERSION_SCRIPT, pipVersion};
+                new String[] {
+                    pythonExecutable, "-c", bashQuoteString(CHECK_PIP_VERSION_SCRIPT), pipVersion
+                };
         String out = execute(commands, environmentVariables, false);
         return Boolean.parseBoolean(out.trim());
     }
@@ -226,5 +231,20 @@ public class PythonEnvironmentManagerUtils {
         } else {
             env.put(key, value);
         }
+    }
+
+    /**
+     * Quote the given bash arg so that bash will interpret it as a single value. Note this only
+     * quotes the input argument for one level for bash.
+     *
+     * @param arg the argument to quote
+     * @return the quoted string
+     */
+    static String bashQuoteString(String arg) {
+        StringBuilder sb = new StringBuilder(arg.length() + 2);
+        sb.append('\'');
+        sb.append(arg.replace("'", "'\\''"));
+        sb.append('\'');
+        return sb.toString();
     }
 }

--- a/flink-python/src/test/java/org/apache/flink/python/util/PythonEnvironmentManagerUtilsTest.java
+++ b/flink-python/src/test/java/org/apache/flink/python/util/PythonEnvironmentManagerUtilsTest.java
@@ -1,0 +1,35 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.flink.python.util;
+
+import org.junit.Test;
+
+import static org.junit.Assert.assertEquals;
+
+/** Tests for PythonEnvironmentManagerUtils. */
+public class PythonEnvironmentManagerUtilsTest {
+
+    @Test
+    public void testBashQuoteString() {
+        String quotedArg = PythonEnvironmentManagerUtils.bashQuoteString("arg1");
+        assertEquals("'arg1'", quotedArg);
+
+        quotedArg = PythonEnvironmentManagerUtils.bashQuoteString("print('str')");
+        assertEquals("'print('\\''str'\\'')'", quotedArg);
+    }
+}


### PR DESCRIPTION
## What is the purpose of the change
PyFlink failed to get the site packege path and thus failed install 3rd party dependencies because of SyntaxError in shell command. This PR quotes long bash argument for PythonEnvironmentManagerUtils to solve this issue.


## Brief change log
Quote long python bash argument for PythonEnvironmentManagerUtils


## Verifying this change

This change added tests and can be verified as follows:
  - *Add new test `testBashQuoteString()` in PythonEnvironmentManagerUtilsTest to test the string quoting. *
The functionality of `PythonEnvironmentManagerUtils`  already be covered by existing tests.

## Does this pull request potentially affect one of the following parts:

  - Dependencies (does it add or upgrade a dependency): no
  - The public API, i.e., is any changed class annotated with `@Public(Evolving)`: no
  - The serializers: no
  - The runtime per-record code paths (performance sensitive): no
  - Anything that affects deployment or recovery: JobManager (and its components), Checkpointing, Kubernetes/Yarn, ZooKeeper: no
  - The S3 file system connector: no

## Documentation

  - Does this pull request introduce a new feature? no
  - If yes, how is the feature documented? not applicable
