### PR TITLE
[hotfix][docs] Fix the outdated upgrading instruction for Kafka Connector

### DIFF
--- a/docs/content.zh/docs/connectors/datastream/kafka.md
+++ b/docs/content.zh/docs/connectors/datastream/kafka.md
@@ -427,7 +427,7 @@ Flink 通过 Kafka 连接器提供了一流的支持，可以对 Kerberos 配置
 
 通用的升级步骤概述见 [升级 Jobs 和 Flink 版本指南]({{< ref "docs/ops/upgrading" >}})。对于 Kafka，你还需要遵循这些步骤：
 
-* 不要同时升级 Flink 和 Kafka 连接器
+* 不要同时升级 Flink 和 Kafka 客户端
 * 确保你对 Consumer 设置了 `group.id`
 * 在 Consumer 上设置 `setCommitOffsetsOnCheckpoints(true)`，以便读 offset 提交到 Kafka。务必在停止和恢复 savepoint 前执行此操作。你可能需要在旧的连接器版本上进行停止/重启循环来启用此设置。
 * 在 Consumer 上设置 `setStartFromGroupOffsets(true)`，以便我们从 Kafka 获取读 offset。这只会在 Flink 状态中没有读 offset 时生效，这也是为什么下一步非要重要的原因。

--- a/docs/content/docs/connectors/datastream/kafka.md
+++ b/docs/content/docs/connectors/datastream/kafka.md
@@ -492,7 +492,7 @@ The generic upgrade steps are outlined in [upgrading jobs and Flink versions
 guide]({{< ref "docs/ops/upgrading" >}}). For Kafka, you additionally need
 to follow these steps:
 
-* Do not upgrade Flink and the Kafka Connector version at the same time.
+* Do not upgrade Flink and the Kafka client version at the same time.
 * Make sure you have a `group.id` configured for your Consumer.
 * Set `setCommitOffsetsOnCheckpoints(true)` on the consumer so that read
   offsets are committed to Kafka. It's important to do this before stopping and


### PR DESCRIPTION
## What is the purpose of the change

This PR fixes the outdated instruction on upgrading to the latest version for Kafka Connector.


## Verifying this change

This change is a trivial rework / code cleanup without any test coverage.

## Does this pull request potentially affect one of the following parts:

  - Dependencies (does it add or upgrade a dependency): **no**
  - The public API, i.e., is any changed class annotated with `@Public(Evolving)`: **no**
  - The serializers: **no**
  - The runtime per-record code paths (performance sensitive): **no**
  - Anything that affects deployment or recovery: JobManager (and its components), Checkpointing, Kubernetes/Yarn, ZooKeeper: **no**
  - The S3 file system connector: **no**

## Documentation

  - Does this pull request introduce a new feature? **no**
  - If yes, how is the feature documented? **not applicable**