### PR TITLE
[FLINK-24712] [Library/CEP] NFATest#testSimpleNFA:  fix test flaxiness

### DIFF
--- a/flink-libraries/flink-cep/src/test/java/org/apache/flink/cep/nfa/NFATest.java
+++ b/flink-libraries/flink-cep/src/test/java/org/apache/flink/cep/nfa/NFATest.java
@@ -36,9 +36,11 @@ import java.io.ByteArrayOutputStream;
 import java.util.ArrayList;
 import java.util.Collection;
 import java.util.Collections;
+import java.util.Comparator;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
+import java.util.stream.Collectors;
 
 import static org.apache.flink.cep.utils.NFAUtils.compile;
 import static org.junit.Assert.assertEquals;
@@ -101,8 +103,10 @@ public class NFATest extends TestLogger {
         NFA<Event> nfa = new NFA<>(states, 0, false);
         NFATestHarness nfaTestHarness = NFATestHarness.forNFA(nfa).build();
 
-        Collection<Map<String, List<Event>>> actualPatterns =
-                nfaTestHarness.consumeRecords(streamEvents);
+        List<Map<String, List<Event>>> actualPatterns =
+                nfaTestHarness.consumeRecords(streamEvents).stream()
+                        .sorted(Comparator.comparing(m -> m.get("start").get(0).getId()))
+                        .collect(Collectors.toList());
 
         assertEquals(expectedPatterns, actualPatterns);
     }


### PR DESCRIPTION
## What is the purpose of the change

`org.apache.flink.cep.nfa.NFATest#testSimpleNFA` was flaky under [NonDex](https://github.com/TestingResearchIllinois/NonDex) due to the outer order of event patterns being unconstrained.  This test sorts them by start-id, which is unique in this particular case, as a quick way to ensure robust comparison.

## Brief change log

Forced the `actualPatterns` to be ordered the same as the `expectedPatterns`.

## Verifying this change

This change is already covered by existing tests, being _itself_ a test.

## Does this pull request potentially affect one of the following parts:

  - Dependencies (does it add or upgrade a dependency): **no**
  - The public API, i.e., is any changed class annotated with `@Public(Evolving)`: **no**
  - The serializers: **no**
  - The runtime per-record code paths (performance sensitive): **no**
  - Anything that affects deployment or recovery: JobManager (and its components), Checkpointing, Kubernetes/Yarn, ZooKeeper: **no**
  - The S3 file system connector: **no**

## Documentation

  - Does this pull request introduce a new feature? **no**
  - If yes, how is the feature documented? **not applicable**
