### PR TITLE
[FLINK-24714][table-api-java] Validate partition keys for ResolvedCatalogTable

### DIFF
--- a/flink-table/flink-table-api-java/src/main/java/org/apache/flink/table/catalog/CatalogManager.java
+++ b/flink-table/flink-table-api-java/src/main/java/org/apache/flink/table/catalog/CatalogManager.java
@@ -35,7 +35,6 @@ import org.apache.flink.table.catalog.exceptions.TableAlreadyExistException;
 import org.apache.flink.table.catalog.exceptions.TableNotExistException;
 import org.apache.flink.table.delegation.Planner;
 import org.apache.flink.table.expressions.resolver.ExpressionResolver.ExpressionResolverBuilder;
-import org.apache.flink.table.types.DataType;
 import org.apache.flink.util.Preconditions;
 import org.apache.flink.util.StringUtils;
 
@@ -880,7 +879,10 @@ public final class CatalogManager {
         final ResolvedSchema resolvedSchema = table.getUnresolvedSchema().resolve(schemaResolver);
 
         final List<String> physicalColumns =
-                DataType.getFieldNames(resolvedSchema.toPhysicalRowDataType());
+                resolvedSchema.getColumns().stream()
+                        .filter(Column::isPhysical)
+                        .map(Column::getName)
+                        .collect(Collectors.toList());
         table.getPartitionKeys()
                 .forEach(
                         partitionKey -> {

--- a/flink-table/flink-table-api-java/src/test/java/org/apache/flink/table/catalog/CatalogBaseTableResolutionTest.java
+++ b/flink-table/flink-table-api-java/src/test/java/org/apache/flink/table/catalog/CatalogBaseTableResolutionTest.java
@@ -181,7 +181,7 @@ public class CatalogBaseTableResolutionTest {
 
         try {
             resolveCatalogBaseTable(ResolvedCatalogTable.class, catalogTable);
-            fail();
+            fail("Invalid partition keys expected.");
         } catch (Exception e) {
             assertThat(
                     e,

--- a/flink-table/flink-table-api-java/src/test/java/org/apache/flink/table/catalog/CatalogBaseTableResolutionTest.java
+++ b/flink-table/flink-table-api-java/src/test/java/org/apache/flink/table/catalog/CatalogBaseTableResolutionTest.java
@@ -45,8 +45,8 @@ import static org.apache.flink.core.testutils.FlinkMatchers.containsMessage;
 import static org.apache.flink.table.utils.CatalogManagerMocks.DEFAULT_CATALOG;
 import static org.apache.flink.table.utils.CatalogManagerMocks.DEFAULT_DATABASE;
 import static org.hamcrest.CoreMatchers.equalTo;
+import static org.hamcrest.MatcherAssert.assertThat;
 import static org.junit.Assert.assertNotNull;
-import static org.junit.Assert.assertThat;
 import static org.junit.Assert.assertTrue;
 import static org.junit.Assert.fail;
 
@@ -167,6 +167,28 @@ public class CatalogBaseTableResolutionTest {
             fail();
         } catch (Exception e) {
             assertThat(e, containsMessage("Could not find property key 'schema.4.data-type'."));
+        }
+    }
+
+    @Test
+    public void testInvalidPartitionKeys() {
+        final CatalogTable catalogTable =
+                CatalogTable.of(
+                        TABLE_SCHEMA,
+                        null,
+                        Arrays.asList("region", "countyINVALID"),
+                        Collections.emptyMap());
+
+        try {
+            resolveCatalogBaseTable(ResolvedCatalogTable.class, catalogTable);
+            fail();
+        } catch (Exception e) {
+            assertThat(
+                    e,
+                    containsMessage(
+                            "Invalid partition key 'countyINVALID'. A partition key must "
+                                    + "reference a physical column in the schema. Available "
+                                    + "columns are: [id, region, county]"));
         }
     }
 


### PR DESCRIPTION
## What is the purpose of the change

This adds a validation for the partition keys of a `CatalogTable` during resolution to `ResolvedCatalogTable`.

## Brief change log

Check if partition keys exist in physical table schema.

## Verifying this change

This change added tests and can be verified as follows: `CatalogBaseTableResolutionTest`

## Does this pull request potentially affect one of the following parts:

  - Dependencies (does it add or upgrade a dependency): no
  - The public API, i.e., is any changed class annotated with `@Public(Evolving)`: no
  - The serializers: no
  - The runtime per-record code paths (performance sensitive): no
  - Anything that affects deployment or recovery: JobManager (and its components), Checkpointing, Kubernetes/Yarn, ZooKeeper: no
  - The S3 file system connector: no

## Documentation

  - Does this pull request introduce a new feature? no
  - If yes, how is the feature documented? not applicable
