### PR TITLE
[FLINK-24719][jdbc] Update Postgres test dependencies to 0.13.4

### DIFF
--- a/flink-connectors/flink-connector-jdbc/pom.xml
+++ b/flink-connectors/flink-connector-jdbc/pom.xml
@@ -37,7 +37,7 @@ under the License.
 
 	<properties>
 		<postgres.version>42.2.10</postgres.version>
-		<otj-pg-embedded.version>0.13.3</otj-pg-embedded.version>
+		<otj-pg-embedded.version>0.13.4</otj-pg-embedded.version>
 	</properties>
 
 	<dependencies>


### PR DESCRIPTION
## What is the purpose of the change

* Update Postgres and Postgres test dependencies to latest version, currently used by JDBC connector

## Brief change log

* Updated dependencies in POM

## Verifying this change

This change is a trivial rework / code cleanup without any test coverage.

## Does this pull request potentially affect one of the following parts:

  - Dependencies (does it add or upgrade a dependency): (**yes** / no)
  - The public API, i.e., is any changed class annotated with `@Public(Evolving)`: (yes / **no**)
  - The serializers: (yes / **no** / don't know)
  - The runtime per-record code paths (performance sensitive): (yes / **no** / don't know)
  - Anything that affects deployment or recovery: JobManager (and its components), Checkpointing, Kubernetes/Yarn, ZooKeeper: (yes / **no** / don't know)
  - The S3 file system connector: (yes / **no** / don't know)

## Documentation

  - Does this pull request introduce a new feature? (yes / **no**)
  - If yes, how is the feature documented? (**not applicable** / docs / JavaDocs / not documented)
