### PR TITLE
[FLINK-24715][connectors][filesystems][formats] Update multiple Jackson dependencies to v2.13.0

### DIFF
--- a/flink-connectors/flink-connector-elasticsearch5/src/main/resources/META-INF/NOTICE
+++ b/flink-connectors/flink-connector-elasticsearch5/src/main/resources/META-INF/NOTICE
@@ -7,12 +7,12 @@ The Apache Software Foundation (http://www.apache.org/).
 This project bundles the following dependencies under the Apache Software License 2.0. (http://www.apache.org/licenses/LICENSE-2.0.txt)
 
 - com.carrotsearch:hppc:0.7.1
-- com.fasterxml.jackson.core:jackson-core:2.12.1
-- com.fasterxml.jackson.core:jackson-databind:2.12.1
-- com.fasterxml.jackson.core:jackson-annotations:2.12.1
-- com.fasterxml.jackson.dataformat:jackson-dataformat-cbor:2.12.1
-- com.fasterxml.jackson.dataformat:jackson-dataformat-smile:2.12.1
-- com.fasterxml.jackson.dataformat:jackson-dataformat-yaml:2.12.1
+- com.fasterxml.jackson.core:jackson-core:2.13.0
+- com.fasterxml.jackson.core:jackson-databind:2.13.0
+- com.fasterxml.jackson.core:jackson-annotations:2.13.0
+- com.fasterxml.jackson.dataformat:jackson-dataformat-cbor:2.13.0
+- com.fasterxml.jackson.dataformat:jackson-dataformat-smile:2.13.0
+- com.fasterxml.jackson.dataformat:jackson-dataformat-yaml:2.13.0
 - com.github.spullara.mustache.java:compiler:0.9.3
 - com.tdunning:t-digest:3.0
 - commons-codec:commons-codec:1.15

--- a/flink-connectors/flink-sql-connector-elasticsearch6/src/main/resources/META-INF/NOTICE
+++ b/flink-connectors/flink-sql-connector-elasticsearch6/src/main/resources/META-INF/NOTICE
@@ -6,12 +6,12 @@ The Apache Software Foundation (http://www.apache.org/).
 
 This project bundles the following dependencies under the Apache Software License 2.0. (http://www.apache.org/licenses/LICENSE-2.0.txt)
 
-- com.fasterxml.jackson.core:jackson-core:2.12.1
-- com.fasterxml.jackson.core:jackson-databind:2.12.1
-- com.fasterxml.jackson.core:jackson-annotations:2.12.1
-- com.fasterxml.jackson.dataformat:jackson-dataformat-cbor:2.12.1
-- com.fasterxml.jackson.dataformat:jackson-dataformat-smile:2.12.1
-- com.fasterxml.jackson.dataformat:jackson-dataformat-yaml:2.12.1
+- com.fasterxml.jackson.core:jackson-core:2.13.0
+- com.fasterxml.jackson.core:jackson-databind:2.13.0
+- com.fasterxml.jackson.core:jackson-annotations:2.13.0
+- com.fasterxml.jackson.dataformat:jackson-dataformat-cbor:2.13.0
+- com.fasterxml.jackson.dataformat:jackson-dataformat-smile:2.13.0
+- com.fasterxml.jackson.dataformat:jackson-dataformat-yaml:2.13.0
 - commons-codec:commons-codec:1.15
 - commons-logging:commons-logging:1.1.3
 - org.apache.httpcomponents:httpasyncclient:4.1.2

--- a/flink-connectors/flink-sql-connector-elasticsearch7/src/main/resources/META-INF/NOTICE
+++ b/flink-connectors/flink-sql-connector-elasticsearch7/src/main/resources/META-INF/NOTICE
@@ -7,12 +7,12 @@ The Apache Software Foundation (http://www.apache.org/).
 This project bundles the following dependencies under the Apache Software License 2.0. (http://www.apache.org/licenses/LICENSE-2.0.txt)
 
 - com.carrotsearch:hppc:0.8.1
-- com.fasterxml.jackson.core:jackson-core:2.12.1
-- com.fasterxml.jackson.core:jackson-databind:2.12.1
-- com.fasterxml.jackson.core:jackson-annotations:2.12.1
-- com.fasterxml.jackson.dataformat:jackson-dataformat-cbor:2.12.1
-- com.fasterxml.jackson.dataformat:jackson-dataformat-smile:2.12.1
-- com.fasterxml.jackson.dataformat:jackson-dataformat-yaml:2.12.1
+- com.fasterxml.jackson.core:jackson-core:2.13.0
+- com.fasterxml.jackson.core:jackson-databind:2.13.0
+- com.fasterxml.jackson.core:jackson-annotations:2.13.0
+- com.fasterxml.jackson.dataformat:jackson-dataformat-cbor:2.13.0
+- com.fasterxml.jackson.dataformat:jackson-dataformat-smile:2.13.0
+- com.fasterxml.jackson.dataformat:jackson-dataformat-yaml:2.13.0
 - com.github.spullara.mustache.java:compiler:0.9.6
 - commons-codec:commons-codec:1.15
 - commons-logging:commons-logging:1.1.3

--- a/flink-connectors/flink-sql-connector-kinesis/src/main/resources/META-INF/NOTICE
+++ b/flink-connectors/flink-sql-connector-kinesis/src/main/resources/META-INF/NOTICE
@@ -14,7 +14,7 @@ This project bundles the following dependencies under the Apache Software Licens
 - org.apache.commons:commons-lang3:3.3.2
 - com.google.guava:guava:29.0-jre
 - com.google.guava:failureaccess:1.0.1
-- com.fasterxml.jackson.core:jackson-annotations:2.12.1
-- com.fasterxml.jackson.core:jackson-databind:2.12.1
-- com.fasterxml.jackson.core:jackson-core:2.12.1
-- com.fasterxml.jackson.dataformat:jackson-dataformat-cbor:2.12.1
+- com.fasterxml.jackson.core:jackson-annotations:2.13.0
+- com.fasterxml.jackson.core:jackson-databind:2.13.0
+- com.fasterxml.jackson.core:jackson-core:2.13.0
+- com.fasterxml.jackson.dataformat:jackson-dataformat-cbor:2.13.0

--- a/flink-filesystems/flink-azure-fs-hadoop/src/main/resources/META-INF/NOTICE
+++ b/flink-filesystems/flink-azure-fs-hadoop/src/main/resources/META-INF/NOTICE
@@ -6,7 +6,7 @@ The Apache Software Foundation (http://www.apache.org/).
 
 This project bundles the following dependencies under the Apache Software License 2.0 (http://www.apache.org/licenses/LICENSE-2.0.txt)
 
-- com.fasterxml.jackson.core:jackson-core:2.12.1
+- com.fasterxml.jackson.core:jackson-core:2.13.0
 - com.google.errorprone:error_prone_annotations:2.2.0
 - com.google.guava:failureaccess:1.0
 - com.google.guava:guava:27.0-jre

--- a/flink-filesystems/flink-fs-hadoop-shaded/src/main/resources/META-INF/NOTICE
+++ b/flink-filesystems/flink-fs-hadoop-shaded/src/main/resources/META-INF/NOTICE
@@ -22,9 +22,9 @@ This project bundles the following dependencies under the Apache Software Licens
 - com.google.guava:guava:27.0-jre
 - com.google.guava:listenablefuture:9999.0-empty-to-avoid-conflict-with-guava
 - com.google.j2objc:j2objc-annotations:1.1
-- com.fasterxml.jackson.core:jackson-annotations:2.12.1
-- com.fasterxml.jackson.core:jackson-core:2.12.1
-- com.fasterxml.jackson.core:jackson-databind:2.12.1
+- com.fasterxml.jackson.core:jackson-annotations:2.13.0
+- com.fasterxml.jackson.core:jackson-core:2.13.0
+- com.fasterxml.jackson.core:jackson-databind:2.13.0
 - com.fasterxml.woodstox:woodstox-core:5.0.3
 
 This project bundles the following dependencies under the MIT (https://opensource.org/licenses/MIT)

--- a/flink-filesystems/flink-s3-fs-hadoop/src/main/resources/META-INF/NOTICE
+++ b/flink-filesystems/flink-s3-fs-hadoop/src/main/resources/META-INF/NOTICE
@@ -9,10 +9,10 @@ This project bundles the following dependencies under the Apache Software Licens
 - com.amazonaws:aws-java-sdk-s3:1.11.951
 - com.amazonaws:aws-java-sdk-sts:1.11.951
 - com.amazonaws:jmespath-java:1.11.951
-- com.fasterxml.jackson.core:jackson-annotations:2.12.1
-- com.fasterxml.jackson.core:jackson-core:2.12.1
-- com.fasterxml.jackson.core:jackson-databind:2.12.1
-- com.fasterxml.jackson.dataformat:jackson-dataformat-cbor:2.12.1
+- com.fasterxml.jackson.core:jackson-annotations:2.13.0
+- com.fasterxml.jackson.core:jackson-core:2.13.0
+- com.fasterxml.jackson.core:jackson-databind:2.13.0
+- com.fasterxml.jackson.dataformat:jackson-dataformat-cbor:2.13.0
 - com.fasterxml.woodstox:woodstox-core:5.0.3
 - com.google.errorprone:error_prone_annotations:2.2.0
 - com.google.guava:failureaccess:1.0

--- a/flink-filesystems/flink-s3-fs-presto/src/main/resources/META-INF/NOTICE
+++ b/flink-filesystems/flink-s3-fs-presto/src/main/resources/META-INF/NOTICE
@@ -22,10 +22,10 @@ This project bundles the following dependencies under the Apache Software Licens
 - com.facebook.presto:presto-hive-common:0.257
 - com.facebook.presto:presto-hive-metastore:0.257
 - com.facebook.presto.hadoop:hadoop-apache2:2.7.3-1
-- com.fasterxml.jackson.core:jackson-annotations:2.12.1
-- com.fasterxml.jackson.core:jackson-core:2.12.1
-- com.fasterxml.jackson.core:jackson-databind:2.12.1
-- com.fasterxml.jackson.dataformat:jackson-dataformat-cbor:2.12.1
+- com.fasterxml.jackson.core:jackson-annotations:2.13.0
+- com.fasterxml.jackson.core:jackson-core:2.13.0
+- com.fasterxml.jackson.core:jackson-databind:2.13.0
+- com.fasterxml.jackson.dataformat:jackson-dataformat-cbor:2.13.0
 - com.fasterxml.woodstox:woodstox-core:5.0.3
 - com.google.guava:guava:26.0-jre
 - com.google.inject:guice:4.2.2

--- a/flink-formats/flink-sql-avro-confluent-registry/src/main/resources/META-INF/NOTICE
+++ b/flink-formats/flink-sql-avro-confluent-registry/src/main/resources/META-INF/NOTICE
@@ -7,9 +7,9 @@ The Apache Software Foundation (http://www.apache.org/).
 This project bundles the following dependencies under the Apache Software License 2.0. (http://www.apache.org/licenses/LICENSE-2.0.txt)
 
 - org.apache.avro:avro:1.10.0
-- com.fasterxml.jackson.core:jackson-core:2.12.1
-- com.fasterxml.jackson.core:jackson-databind:2.12.1
-- com.fasterxml.jackson.core:jackson-annotations:2.12.1
+- com.fasterxml.jackson.core:jackson-core:2.13.0
+- com.fasterxml.jackson.core:jackson-databind:2.13.0
+- com.fasterxml.jackson.core:jackson-annotations:2.13.0
 - org.apache.commons:commons-compress:1.21
 - io.confluent:kafka-schema-registry-client:5.5.2
 - org.apache.kafka:kafka-clients:5.5.2-ccs

--- a/flink-formats/flink-sql-avro/src/main/resources/META-INF/NOTICE
+++ b/flink-formats/flink-sql-avro/src/main/resources/META-INF/NOTICE
@@ -7,7 +7,7 @@ The Apache Software Foundation (http://www.apache.org/).
 This project bundles the following dependencies under the Apache Software License 2.0. (http://www.apache.org/licenses/LICENSE-2.0.txt)
 
 - org.apache.avro:avro:1.10.0
-- com.fasterxml.jackson.core:jackson-core:2.12.1
-- com.fasterxml.jackson.core:jackson-databind:2.12.1
-- com.fasterxml.jackson.core:jackson-annotations:2.12.1
+- com.fasterxml.jackson.core:jackson-core:2.13.0
+- com.fasterxml.jackson.core:jackson-databind:2.13.0
+- com.fasterxml.jackson.core:jackson-annotations:2.13.0
 - org.apache.commons:commons-compress:1.21

--- a/flink-kubernetes/src/main/resources/META-INF/NOTICE
+++ b/flink-kubernetes/src/main/resources/META-INF/NOTICE
@@ -6,11 +6,11 @@ The Apache Software Foundation (http://www.apache.org/).
 
 This project bundles the following dependencies under the Apache Software License 2.0 (http://www.apache.org/licenses/LICENSE-2.0.txt)
 
-- com.fasterxml.jackson.core:jackson-annotations:2.12.1
-- com.fasterxml.jackson.core:jackson-core:2.12.1
-- com.fasterxml.jackson.core:jackson-databind:2.12.1
-- com.fasterxml.jackson.dataformat:jackson-dataformat-yaml:2.12.1
-- com.fasterxml.jackson.datatype:jackson-datatype-jsr310:2.12.1
+- com.fasterxml.jackson.core:jackson-annotations:2.13.0
+- com.fasterxml.jackson.core:jackson-core:2.13.0
+- com.fasterxml.jackson.core:jackson-databind:2.13.0
+- com.fasterxml.jackson.dataformat:jackson-dataformat-yaml:2.13.0
+- com.fasterxml.jackson.datatype:jackson-datatype-jsr310:2.13.0
 - com.squareup.okhttp3:logging-interceptor:3.14.9
 - com.squareup.okhttp3:okhttp:3.14.9
 - com.squareup.okio:okio:1.17.2

--- a/flink-python/src/main/resources/META-INF/NOTICE
+++ b/flink-python/src/main/resources/META-INF/NOTICE
@@ -6,9 +6,9 @@ The Apache Software Foundation (http://www.apache.org/).
 
 This project bundles the following dependencies under the Apache Software License 2.0 (http://www.apache.org/licenses/LICENSE-2.0.txt)
 
-- com.fasterxml.jackson.core:jackson-annotations:2.12.1
-- com.fasterxml.jackson.core:jackson-core:2.12.1
-- com.fasterxml.jackson.core:jackson-databind:2.12.1
+- com.fasterxml.jackson.core:jackson-annotations:2.13.0
+- com.fasterxml.jackson.core:jackson-core:2.13.0
+- com.fasterxml.jackson.core:jackson-databind:2.13.0
 - com.google.flatbuffers:flatbuffers-java:1.9.0
 - io.netty:netty-buffer:4.1.46.Final
 - io.netty:netty-common:4.1.46.Final

--- a/flink-table/flink-table-planner/pom.xml
+++ b/flink-table/flink-table-planner/pom.xml
@@ -356,6 +356,7 @@ under the License.
 										<exclude>META-INF/*.DSA</exclude>
 										<exclude>META-INF/*.RSA</exclude>
 										<exclude>META-INF/services/java.sql.Driver</exclude>
+										<exclude>META-INF/versions/11/module-info.class</exclude>
 										<!-- com.ibm.icu:icu4j includes a LICENSE file in its root folder -->
 										<exclude>LICENSE</exclude>
 									</excludes>

--- a/flink-table/flink-table-planner/src/main/resources/META-INF/NOTICE
+++ b/flink-table/flink-table-planner/src/main/resources/META-INF/NOTICE
@@ -9,9 +9,9 @@ This project bundles the following dependencies under the Apache Software Licens
 - com.google.guava:guava:29.0-jre
 - com.google.guava:failureaccess:1.0.1
 - com.esri.geometry:esri-geometry-api:2.2.0
-- com.fasterxml.jackson.core:jackson-annotations:2.12.1
-- com.fasterxml.jackson.core:jackson-core:2.12.1
-- com.fasterxml.jackson.core:jackson-databind:2.12.1
+- com.fasterxml.jackson.core:jackson-annotations:2.13.0
+- com.fasterxml.jackson.core:jackson-core:2.13.0
+- com.fasterxml.jackson.core:jackson-databind:2.13.0
 - com.jayway.jsonpath:json-path:2.4.0
 - org.apache.calcite:calcite-core:1.26.0
 - org.apache.calcite:calcite-linq4j:1.26.0

--- a/pom.xml
+++ b/pom.xml
@@ -539,7 +539,7 @@ under the License.
 				<artifactId>jackson-bom</artifactId>
 				<type>pom</type>
 				<scope>import</scope>
-				<version>2.12.1</version>
+				<version>2.13.0</version>
 			</dependency>
 			
 			<dependency>


### PR DESCRIPTION
## What is the purpose of the change

* Update multiple Jackson dependencies to the latest version

## Brief change log

* Updated POM file
* Excluded module-info.class from Table API JAR

## Verifying this change

This change is a trivial rework / code cleanup without any test coverage.

## Does this pull request potentially affect one of the following parts:

  - Dependencies (does it add or upgrade a dependency): (**yes** / no)
  - The public API, i.e., is any changed class annotated with `@Public(Evolving)`: (yes / **no**)
  - The serializers: (yes / **no** / don't know)
  - The runtime per-record code paths (performance sensitive): (yes / no / **don't know**)
  - Anything that affects deployment or recovery: JobManager (and its components), Checkpointing, Kubernetes/Yarn, ZooKeeper: (yes / **no** / don't know)
  - The S3 file system connector: (yes / **no** / don't know)

## Documentation

  - Does this pull request introduce a new feature? (yes / **no**)
  - If yes, how is the feature documented? (**not applicable** / docs / JavaDocs / not documented)
