### PR TITLE
[FLINK-24720][tests] Remove flink-runtime-web dependency

### DIFF
--- a/flink-tests/pom.xml
+++ b/flink-tests/pom.xml
@@ -101,21 +101,6 @@ under the License.
 
 		<dependency>
 			<groupId>org.apache.flink</groupId>
-			<artifactId>flink-runtime-web</artifactId>
-			<version>${project.version}</version>
-			<scope>test</scope>
-		</dependency>
-
-		<dependency>
-			<groupId>org.apache.flink</groupId>
-			<artifactId>flink-runtime-web</artifactId>
-			<version>${project.version}</version>
-			<scope>test</scope>
-			<type>test-jar</type>
-		</dependency>
-
-		<dependency>
-			<groupId>org.apache.flink</groupId>
 			<artifactId>flink-clients</artifactId>
 			<version>${project.version}</version>
 			<scope>test</scope>


### PR DESCRIPTION
Removes a dependency to simplify the dependency graph. From now on you only need to build flink-runtime-web when dealing with flink-dist/flink-docs.