### PR TITLE
[FLINK-23014][table-planner] Support streaming window Deduplicate in planner

### DIFF
--- a/flink-table/flink-table-planner/src/main/java/org/apache/flink/table/planner/plan/nodes/exec/stream/StreamExecWindowDeduplicate.java
+++ b/flink-table/flink-table-planner/src/main/java/org/apache/flink/table/planner/plan/nodes/exec/stream/StreamExecWindowDeduplicate.java
@@ -1,0 +1,171 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.flink.table.planner.plan.nodes.exec.stream;
+
+import org.apache.flink.api.dag.Transformation;
+import org.apache.flink.streaming.api.operators.OneInputStreamOperator;
+import org.apache.flink.streaming.api.operators.SimpleOperatorFactory;
+import org.apache.flink.streaming.api.transformations.OneInputTransformation;
+import org.apache.flink.table.api.TableConfig;
+import org.apache.flink.table.api.TableException;
+import org.apache.flink.table.data.RowData;
+import org.apache.flink.table.planner.delegation.PlannerBase;
+import org.apache.flink.table.planner.plan.logical.WindowAttachedWindowingStrategy;
+import org.apache.flink.table.planner.plan.logical.WindowingStrategy;
+import org.apache.flink.table.planner.plan.nodes.exec.ExecEdge;
+import org.apache.flink.table.planner.plan.nodes.exec.ExecNode;
+import org.apache.flink.table.planner.plan.nodes.exec.ExecNodeBase;
+import org.apache.flink.table.planner.plan.nodes.exec.InputProperty;
+import org.apache.flink.table.planner.plan.nodes.exec.SingleTransformationTranslator;
+import org.apache.flink.table.planner.plan.nodes.exec.utils.ExecNodeUtil;
+import org.apache.flink.table.planner.plan.utils.KeySelectorUtil;
+import org.apache.flink.table.runtime.keyselector.RowDataKeySelector;
+import org.apache.flink.table.runtime.operators.deduplicate.window.RowTimeWindowDeduplicateOperatorBuilder;
+import org.apache.flink.table.runtime.typeutils.InternalTypeInfo;
+import org.apache.flink.table.runtime.typeutils.PagedTypeSerializer;
+import org.apache.flink.table.runtime.typeutils.RowDataSerializer;
+import org.apache.flink.table.runtime.util.TimeWindowUtil;
+import org.apache.flink.table.types.logical.RowType;
+
+import org.apache.flink.shaded.jackson2.com.fasterxml.jackson.annotation.JsonCreator;
+import org.apache.flink.shaded.jackson2.com.fasterxml.jackson.annotation.JsonIgnoreProperties;
+import org.apache.flink.shaded.jackson2.com.fasterxml.jackson.annotation.JsonProperty;
+
+import java.time.ZoneId;
+import java.util.Collections;
+import java.util.List;
+
+import static org.apache.flink.util.Preconditions.checkArgument;
+import static org.apache.flink.util.Preconditions.checkNotNull;
+
+/** Stream {@link ExecNode} for Window Deduplicate. */
+@JsonIgnoreProperties(ignoreUnknown = true)
+public class StreamExecWindowDeduplicate extends ExecNodeBase<RowData>
+        implements StreamExecNode<RowData>, SingleTransformationTranslator<RowData> {
+
+    private static final long WINDOW_RANK_MEMORY_RATIO = 100;
+
+    public static final String FIELD_NAME_PARTITION_KEYS = "partitionKeys";
+    public static final String FIELD_NAME_ORDER_KEY = "orderKey";
+    public static final String FIELD_NAME_KEEP_LAST_ROW = "keepLastRow";
+    public static final String FIELD_NAME_WINDOWING = "windowing";
+
+    @JsonProperty(FIELD_NAME_PARTITION_KEYS)
+    private final int[] partitionKeys;
+
+    @JsonProperty(FIELD_NAME_ORDER_KEY)
+    private final int orderKey;
+
+    @JsonProperty(FIELD_NAME_KEEP_LAST_ROW)
+    private final boolean keepLastRow;
+
+    @JsonProperty(FIELD_NAME_WINDOWING)
+    private final WindowingStrategy windowing;
+
+    public StreamExecWindowDeduplicate(
+            int[] partitionKeys,
+            int orderKey,
+            boolean keepLastRow,
+            WindowingStrategy windowing,
+            InputProperty inputProperty,
+            RowType outputType,
+            String description) {
+        this(
+                partitionKeys,
+                orderKey,
+                keepLastRow,
+                windowing,
+                getNewNodeId(),
+                Collections.singletonList(inputProperty),
+                outputType,
+                description);
+    }
+
+    @JsonCreator
+    public StreamExecWindowDeduplicate(
+            @JsonProperty(FIELD_NAME_PARTITION_KEYS) int[] partitionKeys,
+            @JsonProperty(FIELD_NAME_ORDER_KEY) int orderKey,
+            @JsonProperty(FIELD_NAME_KEEP_LAST_ROW) boolean keepLastRow,
+            @JsonProperty(FIELD_NAME_WINDOWING) WindowingStrategy windowing,
+            @JsonProperty(FIELD_NAME_ID) int id,
+            @JsonProperty(FIELD_NAME_INPUT_PROPERTIES) List<InputProperty> inputProperties,
+            @JsonProperty(FIELD_NAME_OUTPUT_TYPE) RowType outputType,
+            @JsonProperty(FIELD_NAME_DESCRIPTION) String description) {
+        super(id, inputProperties, outputType, description);
+        checkArgument(inputProperties.size() == 1);
+        this.partitionKeys = checkNotNull(partitionKeys);
+        this.orderKey = orderKey;
+        this.keepLastRow = keepLastRow;
+        this.windowing = checkNotNull(windowing);
+    }
+
+    @SuppressWarnings("unchecked")
+    @Override
+    protected Transformation<RowData> translateToPlanInternal(PlannerBase planner) {
+        // validate window strategy
+        if (!windowing.isRowtime()) {
+            throw new TableException("Processing time Window Deduplication is not supported yet.");
+        }
+        int windowEndIndex;
+        if (windowing instanceof WindowAttachedWindowingStrategy) {
+            windowEndIndex = ((WindowAttachedWindowingStrategy) windowing).getWindowEnd();
+        } else {
+            throw new UnsupportedOperationException(
+                    windowing.getClass().getName() + " is not supported yet.");
+        }
+
+        ExecEdge inputEdge = getInputEdges().get(0);
+        Transformation<RowData> inputTransform =
+                (Transformation<RowData>) inputEdge.translateToPlan(planner);
+
+        TableConfig tableConfig = planner.getTableConfig();
+        ZoneId shiftTimeZone =
+                TimeWindowUtil.getShiftTimeZone(windowing.getTimeAttributeType(), tableConfig);
+
+        RowType inputType = (RowType) inputEdge.getOutputType();
+        RowDataKeySelector selector =
+                KeySelectorUtil.getRowDataSelector(partitionKeys, InternalTypeInfo.of(inputType));
+
+        OneInputStreamOperator<RowData, RowData> operator =
+                RowTimeWindowDeduplicateOperatorBuilder.builder()
+                        .inputSerializer(new RowDataSerializer(inputType))
+                        .shiftTimeZone(shiftTimeZone)
+                        .keySerializer(
+                                (PagedTypeSerializer<RowData>)
+                                        selector.getProducedType().toSerializer())
+                        .keepLastRow(keepLastRow)
+                        .rowtimeIndex(orderKey)
+                        .windowEndIndex(windowEndIndex)
+                        .build();
+
+        OneInputTransformation<RowData, RowData> transform =
+                ExecNodeUtil.createOneInputTransformation(
+                        inputTransform,
+                        getDescription(),
+                        SimpleOperatorFactory.of(operator),
+                        InternalTypeInfo.of(getOutputType()),
+                        inputTransform.getParallelism(),
+                        WINDOW_RANK_MEMORY_RATIO);
+
+        // set KeyType and Selector for state
+        transform.setStateKeySelector(selector);
+        transform.setStateKeyType(selector.getProducedType());
+        return transform;
+    }
+}

--- a/flink-table/flink-table-planner/src/main/java/org/apache/flink/table/planner/plan/rules/physical/stream/SimplifyWindowTableFunctionRules.java
+++ b/flink-table/flink-table-planner/src/main/java/org/apache/flink/table/planner/plan/rules/physical/stream/SimplifyWindowTableFunctionRules.java
@@ -20,6 +20,7 @@ package org.apache.flink.table.planner.plan.rules.physical.stream;
 
 import org.apache.flink.table.planner.plan.nodes.physical.stream.StreamPhysicalCalc;
 import org.apache.flink.table.planner.plan.nodes.physical.stream.StreamPhysicalExchange;
+import org.apache.flink.table.planner.plan.nodes.physical.stream.StreamPhysicalWindowDeduplicate;
 import org.apache.flink.table.planner.plan.nodes.physical.stream.StreamPhysicalWindowJoin;
 import org.apache.flink.table.planner.plan.nodes.physical.stream.StreamPhysicalWindowRank;
 import org.apache.flink.table.planner.plan.nodes.physical.stream.StreamPhysicalWindowTableFunction;
@@ -42,6 +43,10 @@ public interface SimplifyWindowTableFunctionRules {
             new SimplifyWindowTableFunctionWithWindowRankRule();
     SimplifyWindowTableFunctionWithCalcWindowRankRule WITH_CALC_WINDOW_RANK =
             new SimplifyWindowTableFunctionWithCalcWindowRankRule();
+    SimplifyWindowTableFunctionWithWindowDeduplicateRule WITH_WINDOW_DEDUPLICATE =
+            new SimplifyWindowTableFunctionWithWindowDeduplicateRule();
+    SimplifyWindowTableFunctionWithCalcWindowDeduplicateRule WITH_CALC_WINDOW_DEDUPLICATE =
+            new SimplifyWindowTableFunctionWithCalcWindowDeduplicateRule();
     SimplifyWindowTableFunctionRuleWithWindowJoinRule WITH_WINDOW_JOIN =
             new SimplifyWindowTableFunctionRuleWithWindowJoinRule();
     SimplifyWindowTableFunctionRuleWithLeftCalcWindowJoinRule WITH_LEFT_CALC_WINDOW_JOIN =
@@ -134,6 +139,36 @@ class SimplifyWindowTableFunctionWithCalcWindowRankRule
                                         StreamPhysicalCalc.class,
                                         operand(StreamPhysicalWindowTableFunction.class, any())))),
                 "SimplifyWindowTableFunctionWithCalcWindowRankRule");
+    }
+}
+
+class SimplifyWindowTableFunctionWithWindowDeduplicateRule
+        extends SimplifyWindowTableFunctionWithWindowRankRuleBase {
+
+    SimplifyWindowTableFunctionWithWindowDeduplicateRule() {
+        super(
+                operand(
+                        StreamPhysicalWindowDeduplicate.class,
+                        operand(
+                                StreamPhysicalExchange.class,
+                                operand(StreamPhysicalWindowTableFunction.class, any()))),
+                "SimplifyWindowTableFunctionWithWindowDeduplicateRule");
+    }
+}
+
+class SimplifyWindowTableFunctionWithCalcWindowDeduplicateRule
+        extends SimplifyWindowTableFunctionWithWindowRankRuleBase {
+
+    SimplifyWindowTableFunctionWithCalcWindowDeduplicateRule() {
+        super(
+                operand(
+                        StreamPhysicalWindowDeduplicate.class,
+                        operand(
+                                StreamPhysicalExchange.class,
+                                operand(
+                                        StreamPhysicalCalc.class,
+                                        operand(StreamPhysicalWindowTableFunction.class, any())))),
+                "SimplifyWindowTableFunctionWithCalcWindowDeduplicateRule");
     }
 }
 

--- a/flink-table/flink-table-planner/src/main/scala/org/apache/flink/table/planner/plan/nodes/physical/stream/StreamPhysicalWindowDeduplicate.scala
+++ b/flink-table/flink-table-planner/src/main/scala/org/apache/flink/table/planner/plan/nodes/physical/stream/StreamPhysicalWindowDeduplicate.scala
@@ -1,0 +1,91 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.flink.table.planner.plan.nodes.physical.stream
+
+import org.apache.flink.table.planner.calcite.FlinkTypeFactory
+import org.apache.flink.table.planner.plan.logical.WindowingStrategy
+import org.apache.flink.table.planner.plan.nodes.exec.stream.StreamExecWindowDeduplicate
+import org.apache.flink.table.planner.plan.nodes.exec.{ExecNode, InputProperty}
+import org.apache.flink.table.planner.plan.utils._
+
+import org.apache.calcite.plan.{RelOptCluster, RelTraitSet}
+import org.apache.calcite.rel._
+import org.apache.calcite.rel.`type`.RelDataType
+
+import java.util
+
+import scala.collection.JavaConverters._
+
+/**
+ * Stream physical RelNode which deduplicate on keys and keeps only first row or last row for each
+ * window. This node is an optimization of [[StreamPhysicalWindowRank]].
+ * Compared to [[StreamPhysicalWindowRank]], this node could access/write state with higher
+ * performance. The RelNode also requires PARTITION BY clause contains start and end columns of
+ * the windowing TVF.
+ */
+class StreamPhysicalWindowDeduplicate(
+    cluster: RelOptCluster,
+    traitSet: RelTraitSet,
+    inputRel: RelNode,
+    partitionKeys: Array[Int],
+    orderKey: Int,
+    keepLastRow: Boolean,
+    windowing: WindowingStrategy)
+  extends SingleRel(cluster, traitSet, inputRel)
+  with StreamPhysicalRel {
+
+  override def requireWatermark: Boolean = windowing.isRowtime
+
+  override def deriveRowType(): RelDataType = getInput.getRowType
+
+  override def copy(traitSet: RelTraitSet, inputs: util.List[RelNode]): RelNode = {
+    new StreamPhysicalWindowDeduplicate(
+      cluster,
+      traitSet,
+      inputs.get(0),
+      partitionKeys,
+      orderKey,
+      keepLastRow,
+      windowing)
+  }
+
+  override def explainTerms(pw: RelWriter): RelWriter = {
+    val inputRowType = inputRel.getRowType
+    val inputFieldNames = inputRowType.getFieldNames.asScala.toArray
+    val keep = if (keepLastRow) "LastRow" else "FirstRow"
+    val orderString = if (windowing.isRowtime) "ROWTIME" else "PROCTIME"
+    pw.input("input", getInput)
+      .item("window", windowing.toSummaryString(inputFieldNames))
+      .item("keep", keep)
+      .item("partitionKeys",  RelExplainUtil.fieldToString(partitionKeys, inputRowType))
+      .item("orderKey", inputFieldNames(orderKey))
+      .item("order", orderString)
+  }
+
+  override def translateToExecNode(): ExecNode[_] = {
+    new StreamExecWindowDeduplicate(
+      partitionKeys,
+      orderKey,
+      keepLastRow,
+      windowing,
+      InputProperty.DEFAULT,
+      FlinkTypeFactory.toLogicalRowType(getRowType),
+      getRelDetailedDescription
+    )
+  }
+}

--- a/flink-table/flink-table-planner/src/main/scala/org/apache/flink/table/planner/plan/optimize/program/FlinkChangelogModeInferenceProgram.scala
+++ b/flink-table/flink-table-planner/src/main/scala/org/apache/flink/table/planner/plan/optimize/program/FlinkChangelogModeInferenceProgram.scala
@@ -210,7 +210,8 @@ class FlinkChangelogModeInferenceProgram extends FlinkOptimizeProgram[StreamOpti
         val providedTrait = new ModifyKindSetTrait(builder.build())
         createNewNode(window, children, providedTrait, requiredTrait, requester)
 
-      case _: StreamPhysicalWindowAggregate | _: StreamPhysicalWindowRank =>
+      case _: StreamPhysicalWindowAggregate | _: StreamPhysicalWindowRank |
+           _: StreamPhysicalWindowDeduplicate =>
         // WindowAggregate and WindowRank support insert-only in input
         val children = visitChildren(rel, ModifyKindSetTrait.INSERT_ONLY)
         val providedTrait = ModifyKindSetTrait.INSERT_ONLY
@@ -480,7 +481,8 @@ class FlinkChangelogModeInferenceProgram extends FlinkOptimizeProgram[StreamOpti
         createNewNode(rel, children, requiredTrait)
 
       case _: StreamPhysicalWindowAggregate | _: StreamPhysicalWindowRank |
-           _: StreamPhysicalDeduplicate | _: StreamPhysicalTemporalSort | _: StreamPhysicalMatch |
+           _: StreamPhysicalWindowDeduplicate | _: StreamPhysicalDeduplicate |
+           _: StreamPhysicalTemporalSort | _: StreamPhysicalMatch |
            _: StreamPhysicalOverAggregate | _: StreamPhysicalIntervalJoin |
            _: StreamPhysicalPythonOverAggregate | _: StreamPhysicalWindowJoin =>
         // WindowAggregate, WindowTableAggregate, Deduplicate, TemporalSort, CEP,

--- a/flink-table/flink-table-planner/src/main/scala/org/apache/flink/table/planner/plan/optimize/program/FlinkChangelogModeInferenceProgram.scala
+++ b/flink-table/flink-table-planner/src/main/scala/org/apache/flink/table/planner/plan/optimize/program/FlinkChangelogModeInferenceProgram.scala
@@ -212,7 +212,7 @@ class FlinkChangelogModeInferenceProgram extends FlinkOptimizeProgram[StreamOpti
 
       case _: StreamPhysicalWindowAggregate | _: StreamPhysicalWindowRank |
            _: StreamPhysicalWindowDeduplicate =>
-        // WindowAggregate and WindowRank support insert-only in input
+        // WindowAggregate, WindowRank, WindowDeduplicate support insert-only in input
         val children = visitChildren(rel, ModifyKindSetTrait.INSERT_ONLY)
         val providedTrait = ModifyKindSetTrait.INSERT_ONLY
         createNewNode(rel, children, providedTrait, requiredTrait, requester)
@@ -485,8 +485,9 @@ class FlinkChangelogModeInferenceProgram extends FlinkOptimizeProgram[StreamOpti
            _: StreamPhysicalTemporalSort | _: StreamPhysicalMatch |
            _: StreamPhysicalOverAggregate | _: StreamPhysicalIntervalJoin |
            _: StreamPhysicalPythonOverAggregate | _: StreamPhysicalWindowJoin =>
-        // WindowAggregate, WindowTableAggregate, Deduplicate, TemporalSort, CEP,
-        // OverAggregate, and IntervalJoin, WindowJoin require nothing about UpdateKind.
+        // WindowAggregate, WindowTableAggregate, WindowRank, WindowDeduplicate, Deduplicate,
+        // TemporalSort, CEP, OverAggregate, and IntervalJoin, WindowJoin require nothing about
+        // UpdateKind.
         val children = visitChildren(rel, UpdateKindTrait.NONE)
         createNewNode(rel, children, requiredTrait)
 

--- a/flink-table/flink-table-planner/src/main/scala/org/apache/flink/table/planner/plan/rules/FlinkStreamRuleSets.scala
+++ b/flink-table/flink-table-planner/src/main/scala/org/apache/flink/table/planner/plan/rules/FlinkStreamRuleSets.scala
@@ -439,7 +439,7 @@ object FlinkStreamRuleSets {
     StreamPhysicalTemporalSortRule.INSTANCE,
     // rank
     StreamPhysicalRankRule.INSTANCE,
-    StreamPhysicalDeduplicateRule.RANK_INSTANCE,
+    StreamPhysicalDeduplicateRule.INSTANCE,
     // expand
     StreamPhysicalExpandRule.INSTANCE,
     // group agg
@@ -460,6 +460,7 @@ object FlinkStreamRuleSets {
     PullUpWindowTableFunctionIntoWindowAggregateRule.INSTANCE,
     ExpandWindowTableFunctionTransposeRule.INSTANCE,
     StreamPhysicalWindowRankRule.INSTANCE,
+    StreamPhysicalWindowDeduplicateRule.INSTANCE,
     // join
     StreamPhysicalJoinRule.INSTANCE,
     StreamPhysicalIntervalJoinRule.INSTANCE,
@@ -507,6 +508,8 @@ object FlinkStreamRuleSets {
     // simplify window tvf
     SimplifyWindowTableFunctionRules.WITH_CALC_WINDOW_RANK,
     SimplifyWindowTableFunctionRules.WITH_WINDOW_RANK,
+    SimplifyWindowTableFunctionRules.WITH_CALC_WINDOW_DEDUPLICATE,
+    SimplifyWindowTableFunctionRules.WITH_WINDOW_DEDUPLICATE,
     SimplifyWindowTableFunctionRules.WITH_LEFT_RIGHT_CALC_WINDOW_JOIN,
     SimplifyWindowTableFunctionRules.WITH_LEFT_CALC_WINDOW_JOIN,
     SimplifyWindowTableFunctionRules.WITH_RIGHT_CALC_WINDOW_JOIN,

--- a/flink-table/flink-table-planner/src/main/scala/org/apache/flink/table/planner/plan/rules/physical/stream/StreamPhysicalRankRule.scala
+++ b/flink-table/flink-table-planner/src/main/scala/org/apache/flink/table/planner/plan/rules/physical/stream/StreamPhysicalRankRule.scala
@@ -21,12 +21,13 @@ package org.apache.flink.table.planner.plan.rules.physical.stream
 import org.apache.flink.table.planner.plan.`trait`.FlinkRelDistribution
 import org.apache.flink.table.planner.plan.nodes.FlinkConventions
 import org.apache.flink.table.planner.plan.nodes.logical.FlinkLogicalRank
+import org.apache.flink.table.planner.plan.nodes.physical.stream.StreamPhysicalDeduplicate
 import org.apache.flink.table.planner.plan.nodes.physical.stream.StreamPhysicalRank
+import org.apache.flink.table.planner.plan.utils.{RankProcessStrategy, RankUtil}
+
 import org.apache.calcite.plan.{RelOptRule, RelOptRuleCall}
 import org.apache.calcite.rel.RelNode
 import org.apache.calcite.rel.convert.ConverterRule
-import org.apache.flink.table.planner.plan.utils.RankProcessStrategy
-import org.apache.flink.table.planner.plan.nodes.physical.stream.StreamPhysicalDeduplicate
 
 /**
   * Rule that converts [[FlinkLogicalRank]] with fetch to [[StreamPhysicalRank]].
@@ -41,7 +42,7 @@ class StreamPhysicalRankRule
 
   override def matches(call: RelOptRuleCall): Boolean = {
     val rank: FlinkLogicalRank = call.rel(0)
-    !StreamPhysicalDeduplicateRule.canConvertToDeduplicate(rank)
+    !RankUtil.canConvertToDeduplicate(rank)
   }
 
   override def convert(rel: RelNode): RelNode = {

--- a/flink-table/flink-table-planner/src/main/scala/org/apache/flink/table/planner/plan/rules/physical/stream/StreamPhysicalWindowAggregateRule.scala
+++ b/flink-table/flink-table-planner/src/main/scala/org/apache/flink/table/planner/plan/rules/physical/stream/StreamPhysicalWindowAggregateRule.scala
@@ -74,10 +74,8 @@ class StreamPhysicalWindowAggregateRule
     val relWindowProperties = fmq.getRelWindowProperties(agg.getInput)
     val grouping = agg.getGroupSet
     // we have check there is only one start and end in groupingContainsWindowStartEnd()
-    val startColumns = relWindowProperties.getWindowStartColumns.intersect(grouping)
-    val endColumns = relWindowProperties.getWindowEndColumns.intersect(grouping)
-    val timeColumns = relWindowProperties.getWindowTimeColumns.intersect(grouping)
-    val newGrouping = grouping.except(startColumns).except(endColumns).except(timeColumns)
+    val (startColumns, endColumns, timeColumns, newGrouping) =
+      WindowUtil.groupingExcludeWindowStartEndTimeColumns(grouping, relWindowProperties)
 
     // step-1: build window aggregate node
     val windowAgg = buildWindowAggregateNode(

--- a/flink-table/flink-table-planner/src/main/scala/org/apache/flink/table/planner/plan/utils/WindowUtil.scala
+++ b/flink-table/flink-table-planner/src/main/scala/org/apache/flink/table/planner/plan/utils/WindowUtil.scala
@@ -70,6 +70,20 @@ object WindowUtil {
   }
 
   /**
+   * Excludes window_start, window_end and window_time properties from grouping keys.
+   */
+  def groupingExcludeWindowStartEndTimeColumns(
+      grouping: ImmutableBitSet,
+      windowProperties: RelWindowProperties): (
+    ImmutableBitSet, ImmutableBitSet, ImmutableBitSet, ImmutableBitSet) = {
+    val startColumns = windowProperties.getWindowStartColumns.intersect(grouping)
+    val endColumns = windowProperties.getWindowEndColumns.intersect(grouping)
+    val timeColumns = windowProperties.getWindowTimeColumns.intersect(grouping)
+    val newGrouping = grouping.except(startColumns).except(endColumns).except(timeColumns)
+    (startColumns, endColumns, timeColumns, newGrouping)
+  }
+
+  /**
    * Returns true if the [[RexNode]] is a window table-valued function call.
    */
   def isWindowTableFunctionCall(node: RexNode): Boolean = node match {

--- a/flink-table/flink-table-planner/src/test/java/org/apache/flink/table/planner/runtime/stream/jsonplan/WindowDeduplicateJsonITCase.java
+++ b/flink-table/flink-table-planner/src/test/java/org/apache/flink/table/planner/runtime/stream/jsonplan/WindowDeduplicateJsonITCase.java
@@ -1,0 +1,110 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.flink.table.planner.runtime.stream.jsonplan;
+
+import org.apache.flink.table.planner.factories.TestValuesTableFactory;
+import org.apache.flink.table.planner.runtime.utils.TestData;
+import org.apache.flink.table.planner.utils.JavaScalaConversionUtil;
+import org.apache.flink.table.planner.utils.JsonPlanTestBase;
+
+import org.junit.Before;
+import org.junit.Test;
+
+import java.util.Arrays;
+import java.util.HashMap;
+import java.util.List;
+
+/** Test for window deduplicate json plan. */
+public class WindowDeduplicateJsonITCase extends JsonPlanTestBase {
+
+    @Before
+    public void setup() throws Exception {
+        super.setup();
+        createTestValuesSourceTable(
+                "MyTable",
+                JavaScalaConversionUtil.toJava(TestData.windowDataWithTimestamp()),
+                new String[] {
+                    "ts STRING",
+                    "`int` INT",
+                    "`double` DOUBLE",
+                    "`float` FLOAT",
+                    "`bigdec` DECIMAL(10, 2)",
+                    "`string` STRING",
+                    "`name` STRING",
+                    "`rowtime` AS TO_TIMESTAMP(`ts`)",
+                    "WATERMARK for `rowtime` AS `rowtime` - INTERVAL '1' SECOND",
+                },
+                new HashMap<String, String>() {
+                    {
+                        put("enable-watermark-push-down", "true");
+                        put("failing-source", "true");
+                    }
+                });
+    }
+
+    @Test
+    public void testEventTimeTumbleWindow() throws Exception {
+        createTestValuesSinkTable(
+                "MySink",
+                "ts STRING",
+                "`int` INT",
+                "`double` DOUBLE",
+                "`float` FLOAT",
+                "`bigdec` DECIMAL(10, 2)",
+                "`string` STRING",
+                "`name` STRING",
+                "`rowtime` STRING",
+                "window_start TIMESTAMP(3)",
+                "window_end TIMESTAMP(3)",
+                "window_time TIMESTAMP(3)");
+        String jsonPlan =
+                tableEnv.getJsonPlan(
+                        "insert into MySink select\n"
+                                + "  `ts`,\n"
+                                + "  `int`,\n"
+                                + "  `double`,\n"
+                                + "  `float`, \n"
+                                + "  `bigdec`, \n"
+                                + "  `string`, \n"
+                                + "  `name`, \n"
+                                + "  CAST(`rowtime` AS STRING), \n"
+                                + "  window_start, \n"
+                                + "  window_end, \n"
+                                + "  window_time \n"
+                                + "FROM (\n"
+                                + "      SELECT *,\n"
+                                + "       ROW_NUMBER() OVER( \n"
+                                + "            PARTITION BY window_start, window_end, `name` ORDER BY rowtime DESC) as rownum \n"
+                                + "      FROM TABLE( \n"
+                                + "              TUMBLE(TABLE MyTable, DESCRIPTOR(rowtime), INTERVAL '5' SECOND))) \n"
+                                + "WHERE rownum <= 1");
+        tableEnv.executeJsonPlan(jsonPlan).await();
+
+        List<String> result = TestValuesTableFactory.getResults("MySink");
+        assertResult(
+                Arrays.asList(
+                        "+I[2020-10-10 00:00:04, 5, 5.0, 5.0, 5.55, null, a, 2020-10-10 00:00:04.000, 2020-10-10T00:00, 2020-10-10T00:00:05, 2020-10-10T00:00:04.999]",
+                        "+I[2020-10-10 00:00:08, 3, null, 3.0, 3.33, Comment#2, a, 2020-10-10 00:00:08.000, 2020-10-10T00:00:05, 2020-10-10T00:00:10, 2020-10-10T00:00:09.999]",
+                        "+I[2020-10-10 00:00:07, 3, 3.0, 3.0, null, Hello, b, 2020-10-10 00:00:07.000, 2020-10-10T00:00:05, 2020-10-10T00:00:10, 2020-10-10T00:00:09.999]",
+                        "+I[2020-10-10 00:00:16, 4, 4.0, 4.0, 4.44, Hi, b, 2020-10-10 00:00:16.000, 2020-10-10T00:00:15, 2020-10-10T00:00:20, 2020-10-10T00:00:19.999]",
+                        "+I[2020-10-10 00:00:32, 7, 7.0, 7.0, 7.77, null, null, 2020-10-10 00:00:32.000, 2020-10-10T00:00:30, 2020-10-10T00:00:35, 2020-10-10T00:00:34.999]",
+                        "+I[2020-10-10 00:00:34, 1, 3.0, 3.0, 3.33, Comment#3, b, 2020-10-10 00:00:34.000, 2020-10-10T00:00:30, 2020-10-10T00:00:35, 2020-10-10T00:00:34.999]"),
+                result);
+    }
+}

--- a/flink-table/flink-table-planner/src/test/resources/org/apache/flink/table/planner/plan/nodes/exec/stream/WindowTableFunctionJsonPlanTest_jsonplan/testFollowedByWindowDeduplicate.out
+++ b/flink-table/flink-table-planner/src/test/resources/org/apache/flink/table/planner/plan/nodes/exec/stream/WindowTableFunctionJsonPlanTest_jsonplan/testFollowedByWindowDeduplicate.out
@@ -1,0 +1,667 @@
+{
+  "flinkVersion" : "",
+  "nodes" : [ {
+    "class" : "org.apache.flink.table.planner.plan.nodes.exec.stream.StreamExecTableSourceScan",
+    "scanTableSource" : {
+      "identifier" : {
+        "catalogName" : "default_catalog",
+        "databaseName" : "default_database",
+        "tableName" : "MyTable"
+      },
+      "catalogTable" : {
+        "schema.watermark.0.strategy.expr" : "`rowtime` - INTERVAL '1' SECOND",
+        "schema.4.expr" : "PROCTIME()",
+        "schema.0.data-type" : "INT",
+        "schema.2.name" : "c",
+        "schema.1.name" : "b",
+        "schema.4.name" : "proctime",
+        "schema.1.data-type" : "BIGINT",
+        "schema.3.data-type" : "TIMESTAMP(3)",
+        "schema.2.data-type" : "VARCHAR(2147483647)",
+        "schema.3.name" : "rowtime",
+        "connector" : "values",
+        "schema.watermark.0.rowtime" : "rowtime",
+        "schema.watermark.0.strategy.data-type" : "TIMESTAMP(3)",
+        "schema.3.expr" : "TO_TIMESTAMP(`c`)",
+        "schema.4.data-type" : "TIMESTAMP(3) WITH LOCAL TIME ZONE NOT NULL",
+        "schema.0.name" : "a"
+      }
+    },
+    "id" : 1,
+    "outputType" : {
+      "type" : "ROW",
+      "nullable" : true,
+      "fields" : [ {
+        "a" : "INT"
+      }, {
+        "b" : "BIGINT"
+      }, {
+        "c" : "VARCHAR(2147483647)"
+      } ]
+    },
+    "description" : "TableSourceScan(table=[[default_catalog, default_database, MyTable]], fields=[a, b, c])",
+    "inputProperties" : [ ]
+  }, {
+    "class" : "org.apache.flink.table.planner.plan.nodes.exec.stream.StreamExecCalc",
+    "projection" : [ {
+      "kind" : "INPUT_REF",
+      "inputIndex" : 0,
+      "type" : {
+        "typeName" : "INTEGER",
+        "nullable" : true
+      }
+    }, {
+      "kind" : "INPUT_REF",
+      "inputIndex" : 1,
+      "type" : {
+        "typeName" : "BIGINT",
+        "nullable" : true
+      }
+    }, {
+      "kind" : "INPUT_REF",
+      "inputIndex" : 2,
+      "type" : {
+        "typeName" : "VARCHAR",
+        "nullable" : true,
+        "precision" : 2147483647
+      }
+    }, {
+      "kind" : "REX_CALL",
+      "operator" : {
+        "name" : "TO_TIMESTAMP",
+        "kind" : "OTHER_FUNCTION",
+        "syntax" : "FUNCTION"
+      },
+      "operands" : [ {
+        "kind" : "INPUT_REF",
+        "inputIndex" : 2,
+        "type" : {
+          "typeName" : "VARCHAR",
+          "nullable" : true,
+          "precision" : 2147483647
+        }
+      } ],
+      "type" : {
+        "typeName" : "TIMESTAMP",
+        "nullable" : true,
+        "precision" : 3
+      }
+    }, {
+      "kind" : "REX_CALL",
+      "operator" : {
+        "name" : "PROCTIME",
+        "kind" : "OTHER_FUNCTION",
+        "syntax" : "FUNCTION"
+      },
+      "operands" : [ ],
+      "type" : {
+        "timestampKind" : "PROCTIME",
+        "typeName" : "TIMESTAMP_WITH_LOCAL_TIME_ZONE",
+        "nullable" : false
+      }
+    } ],
+    "condition" : null,
+    "id" : 2,
+    "inputProperties" : [ {
+      "requiredDistribution" : {
+        "type" : "UNKNOWN"
+      },
+      "damBehavior" : "PIPELINED",
+      "priority" : 0
+    } ],
+    "outputType" : {
+      "type" : "ROW",
+      "nullable" : true,
+      "fields" : [ {
+        "a" : "INT"
+      }, {
+        "b" : "BIGINT"
+      }, {
+        "c" : "VARCHAR(2147483647)"
+      }, {
+        "rowtime" : {
+          "type" : "TIMESTAMP_WITHOUT_TIME_ZONE",
+          "nullable" : true,
+          "precision" : 3,
+          "kind" : "REGULAR"
+        }
+      }, {
+        "proctime" : {
+          "type" : "TIMESTAMP_WITH_LOCAL_TIME_ZONE",
+          "nullable" : false,
+          "precision" : 3,
+          "kind" : "PROCTIME"
+        }
+      } ]
+    },
+    "description" : "Calc(select=[a, b, c, TO_TIMESTAMP(c) AS rowtime, PROCTIME() AS proctime])"
+  }, {
+    "class" : "org.apache.flink.table.planner.plan.nodes.exec.stream.StreamExecWatermarkAssigner",
+    "watermarkExpr" : {
+      "kind" : "REX_CALL",
+      "operator" : {
+        "name" : "-",
+        "kind" : "MINUS",
+        "syntax" : "SPECIAL"
+      },
+      "operands" : [ {
+        "kind" : "INPUT_REF",
+        "inputIndex" : 3,
+        "type" : {
+          "typeName" : "TIMESTAMP",
+          "nullable" : true,
+          "precision" : 3
+        }
+      }, {
+        "kind" : "LITERAL",
+        "value" : 1000,
+        "type" : {
+          "typeName" : "INTERVAL_SECOND",
+          "nullable" : false,
+          "precision" : 2,
+          "scale" : 6
+        }
+      } ],
+      "type" : {
+        "typeName" : "TIMESTAMP",
+        "nullable" : true,
+        "precision" : 3
+      }
+    },
+    "rowtimeFieldIndex" : 3,
+    "id" : 3,
+    "inputProperties" : [ {
+      "requiredDistribution" : {
+        "type" : "UNKNOWN"
+      },
+      "damBehavior" : "PIPELINED",
+      "priority" : 0
+    } ],
+    "outputType" : {
+      "type" : "ROW",
+      "nullable" : true,
+      "fields" : [ {
+        "a" : "INT"
+      }, {
+        "b" : "BIGINT"
+      }, {
+        "c" : "VARCHAR(2147483647)"
+      }, {
+        "rowtime" : {
+          "type" : "TIMESTAMP_WITHOUT_TIME_ZONE",
+          "nullable" : true,
+          "precision" : 3,
+          "kind" : "ROWTIME"
+        }
+      }, {
+        "proctime" : {
+          "type" : "TIMESTAMP_WITH_LOCAL_TIME_ZONE",
+          "nullable" : false,
+          "precision" : 3,
+          "kind" : "PROCTIME"
+        }
+      } ]
+    },
+    "description" : "WatermarkAssigner(rowtime=[rowtime], watermark=[(rowtime - 1000:INTERVAL SECOND)])"
+  }, {
+    "class" : "org.apache.flink.table.planner.plan.nodes.exec.stream.StreamExecWindowTableFunction",
+    "windowing" : {
+      "strategy" : "TimeAttribute",
+      "window" : {
+        "type" : "TumblingWindow",
+        "size" : "PT15M"
+      },
+      "timeAttributeType" : {
+        "type" : "TIMESTAMP_WITHOUT_TIME_ZONE",
+        "nullable" : true,
+        "precision" : 3,
+        "kind" : "ROWTIME"
+      },
+      "timeAttributeIndex" : 3,
+      "isRowtime" : true
+    },
+    "emitPerRecord" : true,
+    "id" : 4,
+    "inputProperties" : [ {
+      "requiredDistribution" : {
+        "type" : "UNKNOWN"
+      },
+      "damBehavior" : "PIPELINED",
+      "priority" : 0
+    } ],
+    "outputType" : {
+      "type" : "ROW",
+      "nullable" : true,
+      "fields" : [ {
+        "a" : "INT"
+      }, {
+        "b" : "BIGINT"
+      }, {
+        "c" : "VARCHAR(2147483647)"
+      }, {
+        "rowtime" : {
+          "type" : "TIMESTAMP_WITHOUT_TIME_ZONE",
+          "nullable" : true,
+          "precision" : 3,
+          "kind" : "ROWTIME"
+        }
+      }, {
+        "proctime" : {
+          "type" : "TIMESTAMP_WITH_LOCAL_TIME_ZONE",
+          "nullable" : false,
+          "precision" : 3,
+          "kind" : "PROCTIME"
+        }
+      }, {
+        "window_start" : {
+          "type" : "TIMESTAMP_WITHOUT_TIME_ZONE",
+          "nullable" : false,
+          "precision" : 3,
+          "kind" : "REGULAR"
+        }
+      }, {
+        "window_end" : {
+          "type" : "TIMESTAMP_WITHOUT_TIME_ZONE",
+          "nullable" : false,
+          "precision" : 3,
+          "kind" : "REGULAR"
+        }
+      }, {
+        "window_time" : {
+          "type" : "TIMESTAMP_WITHOUT_TIME_ZONE",
+          "nullable" : false,
+          "precision" : 3,
+          "kind" : "ROWTIME"
+        }
+      } ]
+    },
+    "description" : "WindowTableFunction(window=[TUMBLE(time_col=[rowtime], size=[15 min])], emitPerRecord=[true])"
+  }, {
+    "class" : "org.apache.flink.table.planner.plan.nodes.exec.stream.StreamExecCalc",
+    "projection" : [ {
+      "kind" : "INPUT_REF",
+      "inputIndex" : 0,
+      "type" : {
+        "typeName" : "INTEGER",
+        "nullable" : true
+      }
+    }, {
+      "kind" : "INPUT_REF",
+      "inputIndex" : 1,
+      "type" : {
+        "typeName" : "BIGINT",
+        "nullable" : true
+      }
+    }, {
+      "kind" : "INPUT_REF",
+      "inputIndex" : 2,
+      "type" : {
+        "typeName" : "VARCHAR",
+        "nullable" : true,
+        "precision" : 2147483647
+      }
+    }, {
+      "kind" : "INPUT_REF",
+      "inputIndex" : 3,
+      "type" : {
+        "timestampKind" : "ROWTIME",
+        "typeName" : "TIMESTAMP",
+        "nullable" : true
+      }
+    }, {
+      "kind" : "INPUT_REF",
+      "inputIndex" : 5,
+      "type" : {
+        "typeName" : "TIMESTAMP",
+        "nullable" : false,
+        "precision" : 3
+      }
+    }, {
+      "kind" : "INPUT_REF",
+      "inputIndex" : 6,
+      "type" : {
+        "typeName" : "TIMESTAMP",
+        "nullable" : false,
+        "precision" : 3
+      }
+    } ],
+    "condition" : null,
+    "id" : 5,
+    "inputProperties" : [ {
+      "requiredDistribution" : {
+        "type" : "UNKNOWN"
+      },
+      "damBehavior" : "PIPELINED",
+      "priority" : 0
+    } ],
+    "outputType" : {
+      "type" : "ROW",
+      "nullable" : true,
+      "fields" : [ {
+        "a" : "INT"
+      }, {
+        "b" : "BIGINT"
+      }, {
+        "c" : "VARCHAR(2147483647)"
+      }, {
+        "rowtime" : {
+          "type" : "TIMESTAMP_WITHOUT_TIME_ZONE",
+          "nullable" : true,
+          "precision" : 3,
+          "kind" : "ROWTIME"
+        }
+      }, {
+        "window_start" : {
+          "type" : "TIMESTAMP_WITHOUT_TIME_ZONE",
+          "nullable" : false,
+          "precision" : 3,
+          "kind" : "REGULAR"
+        }
+      }, {
+        "window_end" : {
+          "type" : "TIMESTAMP_WITHOUT_TIME_ZONE",
+          "nullable" : false,
+          "precision" : 3,
+          "kind" : "REGULAR"
+        }
+      } ]
+    },
+    "description" : "Calc(select=[a, b, c, rowtime, window_start, window_end])"
+  }, {
+    "class" : "org.apache.flink.table.planner.plan.nodes.exec.stream.StreamExecExchange",
+    "id" : 6,
+    "inputProperties" : [ {
+      "requiredDistribution" : {
+        "type" : "HASH",
+        "keys" : [ 0 ]
+      },
+      "damBehavior" : "PIPELINED",
+      "priority" : 0
+    } ],
+    "outputType" : {
+      "type" : "ROW",
+      "nullable" : true,
+      "fields" : [ {
+        "a" : "INT"
+      }, {
+        "b" : "BIGINT"
+      }, {
+        "c" : "VARCHAR(2147483647)"
+      }, {
+        "rowtime" : {
+          "type" : "TIMESTAMP_WITHOUT_TIME_ZONE",
+          "nullable" : true,
+          "precision" : 3,
+          "kind" : "ROWTIME"
+        }
+      }, {
+        "window_start" : {
+          "type" : "TIMESTAMP_WITHOUT_TIME_ZONE",
+          "nullable" : false,
+          "precision" : 3,
+          "kind" : "REGULAR"
+        }
+      }, {
+        "window_end" : {
+          "type" : "TIMESTAMP_WITHOUT_TIME_ZONE",
+          "nullable" : false,
+          "precision" : 3,
+          "kind" : "REGULAR"
+        }
+      } ]
+    },
+    "description" : "Exchange(distribution=[hash[a]])"
+  }, {
+    "class" : "org.apache.flink.table.planner.plan.nodes.exec.stream.StreamExecWindowDeduplicate",
+    "partitionKeys" : [ 0 ],
+    "orderKey" : 3,
+    "keepLastRow" : true,
+    "windowing" : {
+      "strategy" : "WindowAttached",
+      "window" : {
+        "type" : "TumblingWindow",
+        "size" : "PT15M"
+      },
+      "timeAttributeType" : {
+        "type" : "TIMESTAMP_WITHOUT_TIME_ZONE",
+        "nullable" : true,
+        "precision" : 3,
+        "kind" : "ROWTIME"
+      },
+      "windowStart" : 4,
+      "windowEnd" : 5,
+      "isRowtime" : true
+    },
+    "id" : 7,
+    "inputProperties" : [ {
+      "requiredDistribution" : {
+        "type" : "UNKNOWN"
+      },
+      "damBehavior" : "PIPELINED",
+      "priority" : 0
+    } ],
+    "outputType" : {
+      "type" : "ROW",
+      "nullable" : true,
+      "fields" : [ {
+        "a" : "INT"
+      }, {
+        "b" : "BIGINT"
+      }, {
+        "c" : "VARCHAR(2147483647)"
+      }, {
+        "rowtime" : {
+          "type" : "TIMESTAMP_WITHOUT_TIME_ZONE",
+          "nullable" : true,
+          "precision" : 3,
+          "kind" : "ROWTIME"
+        }
+      }, {
+        "window_start" : {
+          "type" : "TIMESTAMP_WITHOUT_TIME_ZONE",
+          "nullable" : false,
+          "precision" : 3,
+          "kind" : "REGULAR"
+        }
+      }, {
+        "window_end" : {
+          "type" : "TIMESTAMP_WITHOUT_TIME_ZONE",
+          "nullable" : false,
+          "precision" : 3,
+          "kind" : "REGULAR"
+        }
+      } ]
+    },
+    "description" : "WindowDeduplicate(window=[TUMBLE(win_start=[window_start], win_end=[window_end], size=[15 min])], keep=[LastRow], partitionKeys=[a], orderKey=[rowtime], order=[ROWTIME])"
+  }, {
+    "class" : "org.apache.flink.table.planner.plan.nodes.exec.stream.StreamExecCalc",
+    "projection" : [ {
+      "kind" : "INPUT_REF",
+      "inputIndex" : 4,
+      "type" : {
+        "typeName" : "TIMESTAMP",
+        "nullable" : false,
+        "precision" : 3
+      }
+    }, {
+      "kind" : "INPUT_REF",
+      "inputIndex" : 5,
+      "type" : {
+        "typeName" : "TIMESTAMP",
+        "nullable" : false,
+        "precision" : 3
+      }
+    }, {
+      "kind" : "INPUT_REF",
+      "inputIndex" : 0,
+      "type" : {
+        "typeName" : "INTEGER",
+        "nullable" : true
+      }
+    }, {
+      "kind" : "INPUT_REF",
+      "inputIndex" : 1,
+      "type" : {
+        "typeName" : "BIGINT",
+        "nullable" : true
+      }
+    }, {
+      "kind" : "INPUT_REF",
+      "inputIndex" : 2,
+      "type" : {
+        "typeName" : "VARCHAR",
+        "nullable" : true,
+        "precision" : 2147483647
+      }
+    } ],
+    "condition" : null,
+    "id" : 8,
+    "inputProperties" : [ {
+      "requiredDistribution" : {
+        "type" : "UNKNOWN"
+      },
+      "damBehavior" : "PIPELINED",
+      "priority" : 0
+    } ],
+    "outputType" : {
+      "type" : "ROW",
+      "nullable" : true,
+      "fields" : [ {
+        "window_start" : {
+          "type" : "TIMESTAMP_WITHOUT_TIME_ZONE",
+          "nullable" : false,
+          "precision" : 3,
+          "kind" : "REGULAR"
+        }
+      }, {
+        "window_end" : {
+          "type" : "TIMESTAMP_WITHOUT_TIME_ZONE",
+          "nullable" : false,
+          "precision" : 3,
+          "kind" : "REGULAR"
+        }
+      }, {
+        "a" : "INT"
+      }, {
+        "b" : "BIGINT"
+      }, {
+        "c" : "VARCHAR(2147483647)"
+      } ]
+    },
+    "description" : "Calc(select=[window_start, window_end, a, b, c])"
+  }, {
+    "class" : "org.apache.flink.table.planner.plan.nodes.exec.stream.StreamExecSink",
+    "dynamicTableSink" : {
+      "identifier" : {
+        "catalogName" : "default_catalog",
+        "databaseName" : "default_database",
+        "tableName" : "MySink"
+      },
+      "catalogTable" : {
+        "schema.3.data-type" : "BIGINT",
+        "schema.2.data-type" : "INT",
+        "schema.3.name" : "b",
+        "connector" : "values",
+        "schema.0.data-type" : "TIMESTAMP(3)",
+        "schema.2.name" : "a",
+        "schema.1.name" : "window_end",
+        "schema.4.data-type" : "VARCHAR(2147483647)",
+        "schema.4.name" : "c",
+        "schema.0.name" : "window_start",
+        "schema.1.data-type" : "TIMESTAMP(3)"
+      }
+    },
+    "inputChangelogMode" : [ "INSERT" ],
+    "id" : 9,
+    "inputProperties" : [ {
+      "requiredDistribution" : {
+        "type" : "UNKNOWN"
+      },
+      "damBehavior" : "PIPELINED",
+      "priority" : 0
+    } ],
+    "outputType" : {
+      "type" : "ROW",
+      "nullable" : true,
+      "fields" : [ {
+        "window_start" : {
+          "type" : "TIMESTAMP_WITHOUT_TIME_ZONE",
+          "nullable" : false,
+          "precision" : 3,
+          "kind" : "REGULAR"
+        }
+      }, {
+        "window_end" : {
+          "type" : "TIMESTAMP_WITHOUT_TIME_ZONE",
+          "nullable" : false,
+          "precision" : 3,
+          "kind" : "REGULAR"
+        }
+      }, {
+        "a" : "INT"
+      }, {
+        "b" : "BIGINT"
+      }, {
+        "c" : "VARCHAR(2147483647)"
+      } ]
+    },
+    "description" : "Sink(table=[default_catalog.default_database.MySink], fields=[window_start, window_end, a, b, c])"
+  } ],
+  "edges" : [ {
+    "source" : 1,
+    "target" : 2,
+    "shuffle" : {
+      "type" : "FORWARD"
+    },
+    "shuffleMode" : "PIPELINED"
+  }, {
+    "source" : 2,
+    "target" : 3,
+    "shuffle" : {
+      "type" : "FORWARD"
+    },
+    "shuffleMode" : "PIPELINED"
+  }, {
+    "source" : 3,
+    "target" : 4,
+    "shuffle" : {
+      "type" : "FORWARD"
+    },
+    "shuffleMode" : "PIPELINED"
+  }, {
+    "source" : 4,
+    "target" : 5,
+    "shuffle" : {
+      "type" : "FORWARD"
+    },
+    "shuffleMode" : "PIPELINED"
+  }, {
+    "source" : 5,
+    "target" : 6,
+    "shuffle" : {
+      "type" : "FORWARD"
+    },
+    "shuffleMode" : "PIPELINED"
+  }, {
+    "source" : 6,
+    "target" : 7,
+    "shuffle" : {
+      "type" : "FORWARD"
+    },
+    "shuffleMode" : "PIPELINED"
+  }, {
+    "source" : 7,
+    "target" : 8,
+    "shuffle" : {
+      "type" : "FORWARD"
+    },
+    "shuffleMode" : "PIPELINED"
+  }, {
+    "source" : 8,
+    "target" : 9,
+    "shuffle" : {
+      "type" : "FORWARD"
+    },
+    "shuffleMode" : "PIPELINED"
+  } ]
+}

--- a/flink-table/flink-table-planner/src/test/resources/org/apache/flink/table/planner/plan/stream/sql/WindowDeduplicateTest.xml
+++ b/flink-table/flink-table-planner/src/test/resources/org/apache/flink/table/planner/plan/stream/sql/WindowDeduplicateTest.xml
@@ -16,6 +16,80 @@ See the License for the specific language governing permissions and
 limitations under the License.
 -->
 <Root>
+  <TestCase name="testFallbackToWindowTopNForUnmatchedCondition">
+    <Resource name="sql">
+      <![CDATA[
+SELECT *
+FROM (
+  SELECT *,
+    ROW_NUMBER() OVER(PARTITION BY a, window_start, window_end
+    ORDER BY rowtime DESC) as rownum
+FROM TABLE(TUMBLE(TABLE MyTable, DESCRIPTOR(rowtime), INTERVAL '15' MINUTE))
+)
+WHERE rownum < 3
+      ]]>
+    </Resource>
+    <Resource name="ast">
+      <![CDATA[
+LogicalProject(a=[$0], b=[$1], c=[$2], d=[$3], e=[$4], rowtime=[$5], proctime=[$6], window_start=[$7], window_end=[$8], window_time=[$9], rownum=[$10])
++- LogicalFilter(condition=[<($10, 3)])
+   +- LogicalProject(a=[$0], b=[$1], c=[$2], d=[$3], e=[$4], rowtime=[$5], proctime=[$6], window_start=[$7], window_end=[$8], window_time=[$9], rownum=[ROW_NUMBER() OVER (PARTITION BY $0, $7, $8 ORDER BY $5 DESC NULLS LAST)])
+      +- LogicalTableFunctionScan(invocation=[TUMBLE($6, DESCRIPTOR($5), 900000:INTERVAL MINUTE)], rowType=[RecordType(INTEGER a, BIGINT b, VARCHAR(2147483647) c, DECIMAL(10, 3) d, BIGINT e, TIMESTAMP(3) *ROWTIME* rowtime, TIMESTAMP_LTZ(3) *PROCTIME* proctime, TIMESTAMP(3) window_start, TIMESTAMP(3) window_end, TIMESTAMP(3) *ROWTIME* window_time)])
+         +- LogicalProject(a=[$0], b=[$1], c=[$2], d=[$3], e=[$4], rowtime=[$5], proctime=[$6])
+            +- LogicalWatermarkAssigner(rowtime=[rowtime], watermark=[-($5, 1000:INTERVAL SECOND)])
+               +- LogicalProject(a=[$0], b=[$1], c=[$2], d=[$3], e=[$4], rowtime=[$5], proctime=[PROCTIME()])
+                  +- LogicalTableScan(table=[[default_catalog, default_database, MyTable]])
+]]>
+    </Resource>
+    <Resource name="optimized rel plan">
+      <![CDATA[
+Calc(select=[a, b, c, d, e, rowtime, PROCTIME_MATERIALIZE(proctime) AS proctime, window_start, window_end, window_time, w0$o0])
++- WindowRank(window=[TUMBLE(win_start=[window_start], win_end=[window_end], size=[15 min])], rankType=[ROW_NUMBER], rankRange=[rankStart=1, rankEnd=2], partitionBy=[a], orderBy=[rowtime DESC], select=[a, b, c, d, e, rowtime, proctime, window_start, window_end, window_time, w0$o0])
+   +- Exchange(distribution=[hash[a]])
+      +- WindowTableFunction(window=[TUMBLE(time_col=[rowtime], size=[15 min])], emitPerRecord=[true])
+         +- WatermarkAssigner(rowtime=[rowtime], watermark=[-(rowtime, 1000:INTERVAL SECOND)])
+            +- Calc(select=[a, b, c, d, e, rowtime, PROCTIME() AS proctime])
+               +- TableSourceScan(table=[[default_catalog, default_database, MyTable]], fields=[a, b, c, d, e, rowtime])
+]]>
+    </Resource>
+  </TestCase>
+  <TestCase name="testFallbackToWindowTopNForUnmatchedOrderKey">
+    <Resource name="sql">
+      <![CDATA[
+SELECT *
+FROM (
+  SELECT *,
+    ROW_NUMBER() OVER(PARTITION BY a, window_start, window_end
+    ORDER BY b DESC) as rownum
+FROM TABLE(TUMBLE(TABLE MyTable, DESCRIPTOR(rowtime), INTERVAL '15' MINUTE))
+)
+WHERE rownum <= 1
+      ]]>
+    </Resource>
+    <Resource name="ast">
+      <![CDATA[
+LogicalProject(a=[$0], b=[$1], c=[$2], d=[$3], e=[$4], rowtime=[$5], proctime=[$6], window_start=[$7], window_end=[$8], window_time=[$9], rownum=[$10])
++- LogicalFilter(condition=[<=($10, 1)])
+   +- LogicalProject(a=[$0], b=[$1], c=[$2], d=[$3], e=[$4], rowtime=[$5], proctime=[$6], window_start=[$7], window_end=[$8], window_time=[$9], rownum=[ROW_NUMBER() OVER (PARTITION BY $0, $7, $8 ORDER BY $1 DESC NULLS LAST)])
+      +- LogicalTableFunctionScan(invocation=[TUMBLE($6, DESCRIPTOR($5), 900000:INTERVAL MINUTE)], rowType=[RecordType(INTEGER a, BIGINT b, VARCHAR(2147483647) c, DECIMAL(10, 3) d, BIGINT e, TIMESTAMP(3) *ROWTIME* rowtime, TIMESTAMP_LTZ(3) *PROCTIME* proctime, TIMESTAMP(3) window_start, TIMESTAMP(3) window_end, TIMESTAMP(3) *ROWTIME* window_time)])
+         +- LogicalProject(a=[$0], b=[$1], c=[$2], d=[$3], e=[$4], rowtime=[$5], proctime=[$6])
+            +- LogicalWatermarkAssigner(rowtime=[rowtime], watermark=[-($5, 1000:INTERVAL SECOND)])
+               +- LogicalProject(a=[$0], b=[$1], c=[$2], d=[$3], e=[$4], rowtime=[$5], proctime=[PROCTIME()])
+                  +- LogicalTableScan(table=[[default_catalog, default_database, MyTable]])
+]]>
+    </Resource>
+    <Resource name="optimized rel plan">
+      <![CDATA[
+Calc(select=[a, b, c, d, e, rowtime, PROCTIME_MATERIALIZE(proctime) AS proctime, window_start, window_end, window_time, 1:BIGINT AS w0$o0])
++- WindowRank(window=[TUMBLE(win_start=[window_start], win_end=[window_end], size=[15 min])], rankType=[ROW_NUMBER], rankRange=[rankStart=1, rankEnd=1], partitionBy=[a], orderBy=[b DESC], select=[a, b, c, d, e, rowtime, proctime, window_start, window_end, window_time])
+   +- Exchange(distribution=[hash[a]])
+      +- WindowTableFunction(window=[TUMBLE(time_col=[rowtime], size=[15 min])], emitPerRecord=[true])
+         +- WatermarkAssigner(rowtime=[rowtime], watermark=[-(rowtime, 1000:INTERVAL SECOND)])
+            +- Calc(select=[a, b, c, d, e, rowtime, PROCTIME() AS proctime])
+               +- TableSourceScan(table=[[default_catalog, default_database, MyTable]], fields=[a, b, c, d, e, rowtime])
+]]>
+    </Resource>
+  </TestCase>
   <TestCase name="testTimeAttributePropagateForWindowDeduplicate">
     <Resource name="sql">
       <![CDATA[
@@ -100,43 +174,6 @@ Calc(select=[a, b, c, d, e, rowtime, PROCTIME_MATERIALIZE(proctime) AS proctime,
 ]]>
     </Resource>
   </TestCase>
-  <TestCase name="testOnWindowTVFKeepFirstRow">
-    <Resource name="sql">
-      <![CDATA[
-SELECT *
-FROM (
-SELECT *,
-   ROW_NUMBER() OVER(PARTITION BY a, window_start, window_end
-   ORDER BY rowtime ASC) as rownum
-FROM TABLE(TUMBLE(TABLE MyTable, DESCRIPTOR(rowtime), INTERVAL '15' MINUTE))
-)
-WHERE rownum <= 1
-      ]]>
-    </Resource>
-    <Resource name="ast">
-      <![CDATA[
-LogicalProject(a=[$0], b=[$1], c=[$2], d=[$3], e=[$4], rowtime=[$5], proctime=[$6], window_start=[$7], window_end=[$8], window_time=[$9], rownum=[$10])
-+- LogicalFilter(condition=[<=($10, 1)])
-   +- LogicalProject(a=[$0], b=[$1], c=[$2], d=[$3], e=[$4], rowtime=[$5], proctime=[$6], window_start=[$7], window_end=[$8], window_time=[$9], rownum=[ROW_NUMBER() OVER (PARTITION BY $0, $7, $8 ORDER BY $5 NULLS FIRST)])
-      +- LogicalTableFunctionScan(invocation=[TUMBLE($6, DESCRIPTOR($5), 900000:INTERVAL MINUTE)], rowType=[RecordType(INTEGER a, BIGINT b, VARCHAR(2147483647) c, DECIMAL(10, 3) d, BIGINT e, TIMESTAMP(3) *ROWTIME* rowtime, TIMESTAMP_LTZ(3) *PROCTIME* proctime, TIMESTAMP(3) window_start, TIMESTAMP(3) window_end, TIMESTAMP(3) *ROWTIME* window_time)])
-         +- LogicalProject(a=[$0], b=[$1], c=[$2], d=[$3], e=[$4], rowtime=[$5], proctime=[$6])
-            +- LogicalWatermarkAssigner(rowtime=[rowtime], watermark=[-($5, 1000:INTERVAL SECOND)])
-               +- LogicalProject(a=[$0], b=[$1], c=[$2], d=[$3], e=[$4], rowtime=[$5], proctime=[PROCTIME()])
-                  +- LogicalTableScan(table=[[default_catalog, default_database, MyTable]])
-]]>
-    </Resource>
-    <Resource name="optimized rel plan">
-      <![CDATA[
-Calc(select=[a, b, c, d, e, rowtime, PROCTIME_MATERIALIZE(proctime) AS proctime, window_start, window_end, window_time, 1:BIGINT AS w0$o0])
-+- WindowDeduplicate(window=[TUMBLE(win_start=[window_start], win_end=[window_end], size=[15 min])], keep=[FirstRow], partitionKeys=[a], orderKey=[rowtime], order=[ROWTIME])
-   +- Exchange(distribution=[hash[a]])
-      +- WindowTableFunction(window=[TUMBLE(time_col=[rowtime], size=[15 min])], emitPerRecord=[true])
-         +- WatermarkAssigner(rowtime=[rowtime], watermark=[-(rowtime, 1000:INTERVAL SECOND)])
-            +- Calc(select=[a, b, c, d, e, rowtime, PROCTIME() AS proctime])
-               +- TableSourceScan(table=[[default_catalog, default_database, MyTable]], fields=[a, b, c, d, e, rowtime])
-]]>
-    </Resource>
-  </TestCase>
   <TestCase name="testOnWindowTVFWithCalc">
     <Resource name="sql">
       <![CDATA[
@@ -172,6 +209,80 @@ Calc(select=[window_start, window_end, window_time, a, b, c, d, e])
             +- WatermarkAssigner(rowtime=[rowtime], watermark=[-(rowtime, 1000:INTERVAL SECOND)])
                +- Calc(select=[a, b, c, d, e, rowtime, PROCTIME() AS proctime])
                   +- TableSourceScan(table=[[default_catalog, default_database, MyTable]], fields=[a, b, c, d, e, rowtime])
+]]>
+    </Resource>
+  </TestCase>
+  <TestCase name="testOnWindowTVFWithValidCondition">
+    <Resource name="sql">
+      <![CDATA[
+SELECT *
+FROM (
+  SELECT *,
+    ROW_NUMBER() OVER(PARTITION BY a, window_start, window_end
+    ORDER BY rowtime DESC) as rownum
+FROM TABLE(TUMBLE(TABLE MyTable, DESCRIPTOR(rowtime), INTERVAL '15' MINUTE))
+)
+WHERE rownum < 2
+      ]]>
+    </Resource>
+    <Resource name="ast">
+      <![CDATA[
+LogicalProject(a=[$0], b=[$1], c=[$2], d=[$3], e=[$4], rowtime=[$5], proctime=[$6], window_start=[$7], window_end=[$8], window_time=[$9], rownum=[$10])
++- LogicalFilter(condition=[<($10, 2)])
+   +- LogicalProject(a=[$0], b=[$1], c=[$2], d=[$3], e=[$4], rowtime=[$5], proctime=[$6], window_start=[$7], window_end=[$8], window_time=[$9], rownum=[ROW_NUMBER() OVER (PARTITION BY $0, $7, $8 ORDER BY $5 DESC NULLS LAST)])
+      +- LogicalTableFunctionScan(invocation=[TUMBLE($6, DESCRIPTOR($5), 900000:INTERVAL MINUTE)], rowType=[RecordType(INTEGER a, BIGINT b, VARCHAR(2147483647) c, DECIMAL(10, 3) d, BIGINT e, TIMESTAMP(3) *ROWTIME* rowtime, TIMESTAMP_LTZ(3) *PROCTIME* proctime, TIMESTAMP(3) window_start, TIMESTAMP(3) window_end, TIMESTAMP(3) *ROWTIME* window_time)])
+         +- LogicalProject(a=[$0], b=[$1], c=[$2], d=[$3], e=[$4], rowtime=[$5], proctime=[$6])
+            +- LogicalWatermarkAssigner(rowtime=[rowtime], watermark=[-($5, 1000:INTERVAL SECOND)])
+               +- LogicalProject(a=[$0], b=[$1], c=[$2], d=[$3], e=[$4], rowtime=[$5], proctime=[PROCTIME()])
+                  +- LogicalTableScan(table=[[default_catalog, default_database, MyTable]])
+]]>
+    </Resource>
+    <Resource name="optimized rel plan">
+      <![CDATA[
+Calc(select=[a, b, c, d, e, rowtime, PROCTIME_MATERIALIZE(proctime) AS proctime, window_start, window_end, window_time, 1:BIGINT AS w0$o0])
++- WindowDeduplicate(window=[TUMBLE(win_start=[window_start], win_end=[window_end], size=[15 min])], keep=[LastRow], partitionKeys=[a], orderKey=[rowtime], order=[ROWTIME])
+   +- Exchange(distribution=[hash[a]])
+      +- WindowTableFunction(window=[TUMBLE(time_col=[rowtime], size=[15 min])], emitPerRecord=[true])
+         +- WatermarkAssigner(rowtime=[rowtime], watermark=[-(rowtime, 1000:INTERVAL SECOND)])
+            +- Calc(select=[a, b, c, d, e, rowtime, PROCTIME() AS proctime])
+               +- TableSourceScan(table=[[default_catalog, default_database, MyTable]], fields=[a, b, c, d, e, rowtime])
+]]>
+    </Resource>
+  </TestCase>
+  <TestCase name="testOnWindowTVFKeepFirstRow">
+    <Resource name="sql">
+      <![CDATA[
+SELECT *
+FROM (
+SELECT *,
+   ROW_NUMBER() OVER(PARTITION BY a, window_start, window_end
+   ORDER BY rowtime ASC) as rownum
+FROM TABLE(TUMBLE(TABLE MyTable, DESCRIPTOR(rowtime), INTERVAL '15' MINUTE))
+)
+WHERE rownum <= 1
+      ]]>
+    </Resource>
+    <Resource name="ast">
+      <![CDATA[
+LogicalProject(a=[$0], b=[$1], c=[$2], d=[$3], e=[$4], rowtime=[$5], proctime=[$6], window_start=[$7], window_end=[$8], window_time=[$9], rownum=[$10])
++- LogicalFilter(condition=[<=($10, 1)])
+   +- LogicalProject(a=[$0], b=[$1], c=[$2], d=[$3], e=[$4], rowtime=[$5], proctime=[$6], window_start=[$7], window_end=[$8], window_time=[$9], rownum=[ROW_NUMBER() OVER (PARTITION BY $0, $7, $8 ORDER BY $5 NULLS FIRST)])
+      +- LogicalTableFunctionScan(invocation=[TUMBLE($6, DESCRIPTOR($5), 900000:INTERVAL MINUTE)], rowType=[RecordType(INTEGER a, BIGINT b, VARCHAR(2147483647) c, DECIMAL(10, 3) d, BIGINT e, TIMESTAMP(3) *ROWTIME* rowtime, TIMESTAMP_LTZ(3) *PROCTIME* proctime, TIMESTAMP(3) window_start, TIMESTAMP(3) window_end, TIMESTAMP(3) *ROWTIME* window_time)])
+         +- LogicalProject(a=[$0], b=[$1], c=[$2], d=[$3], e=[$4], rowtime=[$5], proctime=[$6])
+            +- LogicalWatermarkAssigner(rowtime=[rowtime], watermark=[-($5, 1000:INTERVAL SECOND)])
+               +- LogicalProject(a=[$0], b=[$1], c=[$2], d=[$3], e=[$4], rowtime=[$5], proctime=[PROCTIME()])
+                  +- LogicalTableScan(table=[[default_catalog, default_database, MyTable]])
+]]>
+    </Resource>
+    <Resource name="optimized rel plan">
+      <![CDATA[
+Calc(select=[a, b, c, d, e, rowtime, PROCTIME_MATERIALIZE(proctime) AS proctime, window_start, window_end, window_time, 1:BIGINT AS w0$o0])
++- WindowDeduplicate(window=[TUMBLE(win_start=[window_start], win_end=[window_end], size=[15 min])], keep=[FirstRow], partitionKeys=[a], orderKey=[rowtime], order=[ROWTIME])
+   +- Exchange(distribution=[hash[a]])
+      +- WindowTableFunction(window=[TUMBLE(time_col=[rowtime], size=[15 min])], emitPerRecord=[true])
+         +- WatermarkAssigner(rowtime=[rowtime], watermark=[-(rowtime, 1000:INTERVAL SECOND)])
+            +- Calc(select=[a, b, c, d, e, rowtime, PROCTIME() AS proctime])
+               +- TableSourceScan(table=[[default_catalog, default_database, MyTable]], fields=[a, b, c, d, e, rowtime])
 ]]>
     </Resource>
   </TestCase>

--- a/flink-table/flink-table-planner/src/test/resources/org/apache/flink/table/planner/plan/stream/sql/WindowDeduplicateTest.xml
+++ b/flink-table/flink-table-planner/src/test/resources/org/apache/flink/table/planner/plan/stream/sql/WindowDeduplicateTest.xml
@@ -1,0 +1,178 @@
+<?xml version="1.0" ?>
+<!--
+Licensed to the Apache Software Foundation (ASF) under one or more
+contributor license agreements.  See the NOTICE file distributed with
+this work for additional information regarding copyright ownership.
+The ASF licenses this file to you under the Apache License, Version 2.0
+(the "License"); you may not use this file except in compliance with
+the License.  You may obtain a copy of the License at
+
+http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+-->
+<Root>
+  <TestCase name="testTimeAttributePropagateForWindowDeduplicate">
+    <Resource name="sql">
+      <![CDATA[
+SELECT
+   window_start,
+   window_end,
+   count(*),
+   sum(d),
+   max(d) filter (where b > 1000),
+   weightedAvg(b, e) AS wAvg,
+   count(distinct c) AS uv
+FROM TABLE(TUMBLE(TABLE tmp, DESCRIPTOR(rowtime), INTERVAL '15' MINUTE))
+GROUP BY window_start, window_end
+      ]]>
+    </Resource>
+    <Resource name="ast">
+      <![CDATA[
+LogicalAggregate(group=[{0, 1}], EXPR$2=[COUNT()], EXPR$3=[SUM($2)], EXPR$4=[MAX($2) FILTER $3], wAvg=[weightedAvg($4, $5)], uv=[COUNT(DISTINCT $6)])
++- LogicalProject(window_start=[$6], window_end=[$7], d=[$4], $f3=[IS TRUE(>($2, 1000))], b=[$2], e=[$5], c=[$3])
+   +- LogicalTableFunctionScan(invocation=[TUMBLE($5, DESCRIPTOR($0), 900000:INTERVAL MINUTE)], rowType=[RecordType(TIMESTAMP(3) *ROWTIME* rowtime, INTEGER a, BIGINT b, VARCHAR(2147483647) c, DECIMAL(10, 3) d, BIGINT e, TIMESTAMP(3) window_start, TIMESTAMP(3) window_end, TIMESTAMP(3) *ROWTIME* window_time)])
+      +- LogicalProject(rowtime=[$9], a=[$0], b=[$1], c=[$2], d=[$3], e=[$4])
+         +- LogicalFilter(condition=[<=($10, 1)])
+            +- LogicalProject(a=[$0], b=[$1], c=[$2], d=[$3], e=[$4], rowtime=[$5], proctime=[$6], window_start=[$7], window_end=[$8], window_time=[$9], rownum=[ROW_NUMBER() OVER (PARTITION BY $0, $7, $8 ORDER BY $5 DESC NULLS LAST)])
+               +- LogicalTableFunctionScan(invocation=[TUMBLE($6, DESCRIPTOR($5), 900000:INTERVAL MINUTE)], rowType=[RecordType(INTEGER a, BIGINT b, VARCHAR(2147483647) c, DECIMAL(10, 3) d, BIGINT e, TIMESTAMP(3) *ROWTIME* rowtime, TIMESTAMP_LTZ(3) *PROCTIME* proctime, TIMESTAMP(3) window_start, TIMESTAMP(3) window_end, TIMESTAMP(3) *ROWTIME* window_time)])
+                  +- LogicalProject(a=[$0], b=[$1], c=[$2], d=[$3], e=[$4], rowtime=[$5], proctime=[$6])
+                     +- LogicalWatermarkAssigner(rowtime=[rowtime], watermark=[-($5, 1000:INTERVAL SECOND)])
+                        +- LogicalProject(a=[$0], b=[$1], c=[$2], d=[$3], e=[$4], rowtime=[$5], proctime=[PROCTIME()])
+                           +- LogicalTableScan(table=[[default_catalog, default_database, MyTable]])
+]]>
+    </Resource>
+    <Resource name="optimized rel plan">
+      <![CDATA[
+Calc(select=[window_start, window_end, EXPR$2, EXPR$3, EXPR$4, wAvg, uv])
++- GlobalWindowAggregate(window=[TUMBLE(slice_end=[$slice_end], size=[15 min])], select=[COUNT(count1$0) AS EXPR$2, SUM(sum$1) AS EXPR$3, MAX(max$2) AS EXPR$4, weightedAvg(weightedavg$3) AS wAvg, COUNT(distinct$0 count$4) AS uv, start('w$) AS window_start, end('w$) AS window_end])
+   +- Exchange(distribution=[single])
+      +- LocalWindowAggregate(window=[TUMBLE(time_col=[rowtime], size=[15 min])], select=[COUNT(*) AS count1$0, SUM(d) AS sum$1, MAX(d) FILTER $f3 AS max$2, weightedAvg(b, e) AS weightedavg$3, COUNT(distinct$0 c) AS count$4, DISTINCT(c) AS distinct$0, slice_end('w$) AS $slice_end])
+         +- Calc(select=[d, IS TRUE(>(b, 1000)) AS $f3, b, e, c, window_time AS rowtime])
+            +- WindowDeduplicate(window=[TUMBLE(win_start=[window_start], win_end=[window_end], size=[15 min])], keep=[LastRow], partitionKeys=[a], orderKey=[rowtime], order=[ROWTIME])
+               +- Exchange(distribution=[hash[a]])
+                  +- Calc(select=[a, b, c, d, e, rowtime, window_start, window_end, window_time])
+                     +- WindowTableFunction(window=[TUMBLE(time_col=[rowtime], size=[15 min])], emitPerRecord=[true])
+                        +- WatermarkAssigner(rowtime=[rowtime], watermark=[-(rowtime, 1000:INTERVAL SECOND)])
+                           +- Calc(select=[a, b, c, d, e, rowtime, PROCTIME() AS proctime])
+                              +- TableSourceScan(table=[[default_catalog, default_database, MyTable]], fields=[a, b, c, d, e, rowtime])
+]]>
+    </Resource>
+  </TestCase>
+  <TestCase name="testOnWindowTVF">
+    <Resource name="sql">
+      <![CDATA[
+SELECT *
+FROM (
+SELECT *,
+   ROW_NUMBER() OVER(PARTITION BY a, window_start, window_end
+   ORDER BY rowtime DESC) as rownum
+FROM TABLE(TUMBLE(TABLE MyTable, DESCRIPTOR(rowtime), INTERVAL '15' MINUTE))
+)
+WHERE rownum <= 1
+      ]]>
+    </Resource>
+    <Resource name="ast">
+      <![CDATA[
+LogicalProject(a=[$0], b=[$1], c=[$2], d=[$3], e=[$4], rowtime=[$5], proctime=[$6], window_start=[$7], window_end=[$8], window_time=[$9], rownum=[$10])
++- LogicalFilter(condition=[<=($10, 1)])
+   +- LogicalProject(a=[$0], b=[$1], c=[$2], d=[$3], e=[$4], rowtime=[$5], proctime=[$6], window_start=[$7], window_end=[$8], window_time=[$9], rownum=[ROW_NUMBER() OVER (PARTITION BY $0, $7, $8 ORDER BY $5 DESC NULLS LAST)])
+      +- LogicalTableFunctionScan(invocation=[TUMBLE($6, DESCRIPTOR($5), 900000:INTERVAL MINUTE)], rowType=[RecordType(INTEGER a, BIGINT b, VARCHAR(2147483647) c, DECIMAL(10, 3) d, BIGINT e, TIMESTAMP(3) *ROWTIME* rowtime, TIMESTAMP_LTZ(3) *PROCTIME* proctime, TIMESTAMP(3) window_start, TIMESTAMP(3) window_end, TIMESTAMP(3) *ROWTIME* window_time)])
+         +- LogicalProject(a=[$0], b=[$1], c=[$2], d=[$3], e=[$4], rowtime=[$5], proctime=[$6])
+            +- LogicalWatermarkAssigner(rowtime=[rowtime], watermark=[-($5, 1000:INTERVAL SECOND)])
+               +- LogicalProject(a=[$0], b=[$1], c=[$2], d=[$3], e=[$4], rowtime=[$5], proctime=[PROCTIME()])
+                  +- LogicalTableScan(table=[[default_catalog, default_database, MyTable]])
+]]>
+    </Resource>
+    <Resource name="optimized rel plan">
+      <![CDATA[
+Calc(select=[a, b, c, d, e, rowtime, PROCTIME_MATERIALIZE(proctime) AS proctime, window_start, window_end, window_time, 1:BIGINT AS w0$o0])
++- WindowDeduplicate(window=[TUMBLE(win_start=[window_start], win_end=[window_end], size=[15 min])], keep=[LastRow], partitionKeys=[a], orderKey=[rowtime], order=[ROWTIME])
+   +- Exchange(distribution=[hash[a]])
+      +- WindowTableFunction(window=[TUMBLE(time_col=[rowtime], size=[15 min])], emitPerRecord=[true])
+         +- WatermarkAssigner(rowtime=[rowtime], watermark=[-(rowtime, 1000:INTERVAL SECOND)])
+            +- Calc(select=[a, b, c, d, e, rowtime, PROCTIME() AS proctime])
+               +- TableSourceScan(table=[[default_catalog, default_database, MyTable]], fields=[a, b, c, d, e, rowtime])
+]]>
+    </Resource>
+  </TestCase>
+  <TestCase name="testOnWindowTVFKeepFirstRow">
+    <Resource name="sql">
+      <![CDATA[
+SELECT *
+FROM (
+SELECT *,
+   ROW_NUMBER() OVER(PARTITION BY a, window_start, window_end
+   ORDER BY rowtime ASC) as rownum
+FROM TABLE(TUMBLE(TABLE MyTable, DESCRIPTOR(rowtime), INTERVAL '15' MINUTE))
+)
+WHERE rownum <= 1
+      ]]>
+    </Resource>
+    <Resource name="ast">
+      <![CDATA[
+LogicalProject(a=[$0], b=[$1], c=[$2], d=[$3], e=[$4], rowtime=[$5], proctime=[$6], window_start=[$7], window_end=[$8], window_time=[$9], rownum=[$10])
++- LogicalFilter(condition=[<=($10, 1)])
+   +- LogicalProject(a=[$0], b=[$1], c=[$2], d=[$3], e=[$4], rowtime=[$5], proctime=[$6], window_start=[$7], window_end=[$8], window_time=[$9], rownum=[ROW_NUMBER() OVER (PARTITION BY $0, $7, $8 ORDER BY $5 NULLS FIRST)])
+      +- LogicalTableFunctionScan(invocation=[TUMBLE($6, DESCRIPTOR($5), 900000:INTERVAL MINUTE)], rowType=[RecordType(INTEGER a, BIGINT b, VARCHAR(2147483647) c, DECIMAL(10, 3) d, BIGINT e, TIMESTAMP(3) *ROWTIME* rowtime, TIMESTAMP_LTZ(3) *PROCTIME* proctime, TIMESTAMP(3) window_start, TIMESTAMP(3) window_end, TIMESTAMP(3) *ROWTIME* window_time)])
+         +- LogicalProject(a=[$0], b=[$1], c=[$2], d=[$3], e=[$4], rowtime=[$5], proctime=[$6])
+            +- LogicalWatermarkAssigner(rowtime=[rowtime], watermark=[-($5, 1000:INTERVAL SECOND)])
+               +- LogicalProject(a=[$0], b=[$1], c=[$2], d=[$3], e=[$4], rowtime=[$5], proctime=[PROCTIME()])
+                  +- LogicalTableScan(table=[[default_catalog, default_database, MyTable]])
+]]>
+    </Resource>
+    <Resource name="optimized rel plan">
+      <![CDATA[
+Calc(select=[a, b, c, d, e, rowtime, PROCTIME_MATERIALIZE(proctime) AS proctime, window_start, window_end, window_time, 1:BIGINT AS w0$o0])
++- WindowDeduplicate(window=[TUMBLE(win_start=[window_start], win_end=[window_end], size=[15 min])], keep=[FirstRow], partitionKeys=[a], orderKey=[rowtime], order=[ROWTIME])
+   +- Exchange(distribution=[hash[a]])
+      +- WindowTableFunction(window=[TUMBLE(time_col=[rowtime], size=[15 min])], emitPerRecord=[true])
+         +- WatermarkAssigner(rowtime=[rowtime], watermark=[-(rowtime, 1000:INTERVAL SECOND)])
+            +- Calc(select=[a, b, c, d, e, rowtime, PROCTIME() AS proctime])
+               +- TableSourceScan(table=[[default_catalog, default_database, MyTable]], fields=[a, b, c, d, e, rowtime])
+]]>
+    </Resource>
+  </TestCase>
+  <TestCase name="testOnWindowTVFWithCalc">
+    <Resource name="sql">
+      <![CDATA[
+SELECT window_start, window_end, window_time, a, b, c, d, e
+FROM (
+SELECT *,
+   ROW_NUMBER() OVER(PARTITION BY a, window_start, window_end
+   ORDER BY rowtime DESC) as rownum
+FROM TABLE(TUMBLE(TABLE MyTable, DESCRIPTOR(rowtime), INTERVAL '15' MINUTE))
+)
+WHERE rownum <= 1
+      ]]>
+    </Resource>
+    <Resource name="ast">
+      <![CDATA[
+LogicalProject(window_start=[$7], window_end=[$8], window_time=[$9], a=[$0], b=[$1], c=[$2], d=[$3], e=[$4])
++- LogicalFilter(condition=[<=($10, 1)])
+   +- LogicalProject(a=[$0], b=[$1], c=[$2], d=[$3], e=[$4], rowtime=[$5], proctime=[$6], window_start=[$7], window_end=[$8], window_time=[$9], rownum=[ROW_NUMBER() OVER (PARTITION BY $0, $7, $8 ORDER BY $5 DESC NULLS LAST)])
+      +- LogicalTableFunctionScan(invocation=[TUMBLE($6, DESCRIPTOR($5), 900000:INTERVAL MINUTE)], rowType=[RecordType(INTEGER a, BIGINT b, VARCHAR(2147483647) c, DECIMAL(10, 3) d, BIGINT e, TIMESTAMP(3) *ROWTIME* rowtime, TIMESTAMP_LTZ(3) *PROCTIME* proctime, TIMESTAMP(3) window_start, TIMESTAMP(3) window_end, TIMESTAMP(3) *ROWTIME* window_time)])
+         +- LogicalProject(a=[$0], b=[$1], c=[$2], d=[$3], e=[$4], rowtime=[$5], proctime=[$6])
+            +- LogicalWatermarkAssigner(rowtime=[rowtime], watermark=[-($5, 1000:INTERVAL SECOND)])
+               +- LogicalProject(a=[$0], b=[$1], c=[$2], d=[$3], e=[$4], rowtime=[$5], proctime=[PROCTIME()])
+                  +- LogicalTableScan(table=[[default_catalog, default_database, MyTable]])
+]]>
+    </Resource>
+    <Resource name="optimized rel plan">
+      <![CDATA[
+Calc(select=[window_start, window_end, window_time, a, b, c, d, e])
++- WindowDeduplicate(window=[TUMBLE(win_start=[window_start], win_end=[window_end], size=[15 min])], keep=[LastRow], partitionKeys=[a], orderKey=[rowtime], order=[ROWTIME])
+   +- Exchange(distribution=[hash[a]])
+      +- Calc(select=[a, b, c, d, e, rowtime, window_start, window_end, window_time])
+         +- WindowTableFunction(window=[TUMBLE(time_col=[rowtime], size=[15 min])], emitPerRecord=[true])
+            +- WatermarkAssigner(rowtime=[rowtime], watermark=[-(rowtime, 1000:INTERVAL SECOND)])
+               +- Calc(select=[a, b, c, d, e, rowtime, PROCTIME() AS proctime])
+                  +- TableSourceScan(table=[[default_catalog, default_database, MyTable]], fields=[a, b, c, d, e, rowtime])
+]]>
+    </Resource>
+  </TestCase>
+</Root>

--- a/flink-table/flink-table-planner/src/test/scala/org/apache/flink/table/planner/plan/stream/sql/WindowDeduplicateTest.scala
+++ b/flink-table/flink-table-planner/src/test/scala/org/apache/flink/table/planner/plan/stream/sql/WindowDeduplicateTest.scala
@@ -1,0 +1,172 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.flink.table.planner.plan.stream.sql
+
+import org.apache.flink.table.api.TableException
+import org.apache.flink.table.planner.plan.utils.JavaUserDefinedAggFunctions.WeightedAvgWithMerge
+import org.apache.flink.table.planner.utils.TableTestBase
+
+import org.junit.Test
+
+/**
+ * Tests for window deduplicate.
+ */
+class WindowDeduplicateTest extends TableTestBase {
+
+  private val util = streamTestUtil()
+  util.addTemporarySystemFunction("weightedAvg", classOf[WeightedAvgWithMerge])
+  util.tableEnv.executeSql(
+    s"""
+       |CREATE TABLE MyTable (
+       |  a INT,
+       |  b BIGINT,
+       |  c STRING NOT NULL,
+       |  d DECIMAL(10, 3),
+       |  e BIGINT,
+       |  rowtime TIMESTAMP(3),
+       |  proctime as PROCTIME(),
+       |  WATERMARK FOR rowtime AS rowtime - INTERVAL '1' SECOND
+       |) with (
+       |  'connector' = 'values'
+       |)
+       |""".stripMargin)
+
+  // ----------------------------------------------------------------------------------------
+  // Tests for queries Deduplicate on window TVF
+  // ----------------------------------------------------------------------------------------
+
+  @Test
+  def testOnWindowTVFWithCalc(): Unit = {
+    val sql =
+      """
+        |SELECT window_start, window_end, window_time, a, b, c, d, e
+        |FROM (
+        |SELECT *,
+        |   ROW_NUMBER() OVER(PARTITION BY a, window_start, window_end
+        |   ORDER BY rowtime DESC) as rownum
+        |FROM TABLE(TUMBLE(TABLE MyTable, DESCRIPTOR(rowtime), INTERVAL '15' MINUTE))
+        |)
+        |WHERE rownum <= 1
+      """.stripMargin
+    util.verifyRelPlan(sql)
+  }
+
+  @Test
+  def testOnWindowTVF(): Unit = {
+    val sql =
+      """
+        |SELECT *
+        |FROM (
+        |SELECT *,
+        |   ROW_NUMBER() OVER(PARTITION BY a, window_start, window_end
+        |   ORDER BY rowtime DESC) as rownum
+        |FROM TABLE(TUMBLE(TABLE MyTable, DESCRIPTOR(rowtime), INTERVAL '15' MINUTE))
+        |)
+        |WHERE rownum <= 1
+      """.stripMargin
+    util.verifyRelPlan(sql)
+  }
+
+  @Test
+  def testOnWindowTVFKeepFirstRow(): Unit = {
+    val sql =
+      """
+        |SELECT *
+        |FROM (
+        |SELECT *,
+        |   ROW_NUMBER() OVER(PARTITION BY a, window_start, window_end
+        |   ORDER BY rowtime ASC) as rownum
+        |FROM TABLE(TUMBLE(TABLE MyTable, DESCRIPTOR(rowtime), INTERVAL '15' MINUTE))
+        |)
+        |WHERE rownum <= 1
+      """.stripMargin
+    util.verifyRelPlan(sql)
+  }
+
+  @Test
+  def testUnsupportedWindowTVFOnProctime(): Unit = {
+    val sql =
+      """
+        |SELECT window_start, window_end, window_time, a, b, c, d, e
+        |FROM (
+        |SELECT *,
+        |   ROW_NUMBER() OVER(PARTITION BY a, window_start, window_end
+        |   ORDER BY proctime DESC) as rownum
+        |FROM TABLE(TUMBLE(TABLE MyTable, DESCRIPTOR(proctime), INTERVAL '15' MINUTE))
+        |)
+        |WHERE rownum <= 1
+      """.stripMargin
+
+    thrown.expectMessage("Processing time Window Deduplication is not supported yet.")
+    thrown.expect(classOf[TableException])
+    util.verifyExplain(sql)
+  }
+
+  @Test
+  def testUnsupportedWindowTVFOnProctimeKeepFirstRow(): Unit = {
+    val sql =
+      """
+        |SELECT window_start, window_end, window_time, a, b, c, d, e
+        |FROM (
+        |SELECT *,
+        |   ROW_NUMBER() OVER(PARTITION BY a, window_start, window_end
+        |   ORDER BY proctime) as rownum
+        |FROM TABLE(TUMBLE(TABLE MyTable, DESCRIPTOR(proctime), INTERVAL '15' MINUTE))
+        |)
+        |WHERE rownum <= 1
+      """.stripMargin
+
+    thrown.expectMessage("Processing time Window Deduplication is not supported yet.")
+    thrown.expect(classOf[TableException])
+    util.verifyExplain(sql)
+  }
+
+  // ----------------------------------------------------------------------------------------
+  // Tests for queries window deduplicate could propagate time attribute
+  // ----------------------------------------------------------------------------------------
+  @Test
+  def testTimeAttributePropagateForWindowDeduplicate(): Unit = {
+    util.tableEnv.executeSql(
+      """
+        |CREATE VIEW tmp AS
+        |SELECT window_time as rowtime, a, b, c, d, e
+        |FROM (
+        |SELECT *,
+        |   ROW_NUMBER() OVER(PARTITION BY a, window_start, window_end
+        |   ORDER BY rowtime DESC) as rownum
+        |FROM TABLE(TUMBLE(TABLE MyTable, DESCRIPTOR(rowtime), INTERVAL '15' MINUTE))
+        |)
+        |WHERE rownum <= 1
+      """.stripMargin)
+    val sql =
+      """
+        |SELECT
+        |   window_start,
+        |   window_end,
+        |   count(*),
+        |   sum(d),
+        |   max(d) filter (where b > 1000),
+        |   weightedAvg(b, e) AS wAvg,
+        |   count(distinct c) AS uv
+        |FROM TABLE(TUMBLE(TABLE tmp, DESCRIPTOR(rowtime), INTERVAL '15' MINUTE))
+        |GROUP BY window_start, window_end
+      """.stripMargin
+    util.verifyRelPlan(sql)
+  }
+}

--- a/flink-table/flink-table-planner/src/test/scala/org/apache/flink/table/planner/runtime/stream/sql/WindowDeduplicateITCase.scala
+++ b/flink-table/flink-table-planner/src/test/scala/org/apache/flink/table/planner/runtime/stream/sql/WindowDeduplicateITCase.scala
@@ -1,0 +1,268 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.flink.table.planner.runtime.stream.sql
+
+import org.apache.flink.api.common.restartstrategy.RestartStrategies
+import org.apache.flink.api.scala._
+import org.apache.flink.streaming.api.CheckpointingMode
+import org.apache.flink.table.api.bridge.scala._
+import org.apache.flink.table.planner.factories.TestValuesTableFactory
+import org.apache.flink.table.planner.plan.utils.JavaUserDefinedAggFunctions.ConcatDistinctAggFunction
+import org.apache.flink.table.planner.runtime.utils.StreamingWithStateTestBase.StateBackendMode
+import org.apache.flink.table.planner.runtime.utils.{FailingCollectionSource, StreamingWithStateTestBase, TestData, TestingAppendSink}
+import org.apache.flink.types.Row
+
+import org.junit.Assert.assertEquals
+import org.junit.runner.RunWith
+import org.junit.runners.Parameterized
+import org.junit.{Before, Test}
+
+@RunWith(classOf[Parameterized])
+class WindowDeduplicateITCase(mode: StateBackendMode)
+  extends StreamingWithStateTestBase(mode) {
+
+  @Before
+  override def before(): Unit = {
+    super.before()
+    // enable checkpoint, we are using failing source to force have a complete checkpoint
+    // and cover restore path
+    env.enableCheckpointing(100, CheckpointingMode.EXACTLY_ONCE)
+    env.setRestartStrategy(RestartStrategies.fixedDelayRestart(1, 0))
+    FailingCollectionSource.reset()
+
+    val dataId = TestValuesTableFactory.registerData(TestData.windowDataWithTimestamp)
+    tEnv.executeSql(
+      s"""
+        |CREATE TABLE T1 (
+        | `ts` STRING,
+        | `int` INT,
+        | `double` DOUBLE,
+        | `float` FLOAT,
+        | `bigdec` DECIMAL(10, 2),
+        | `string` STRING,
+        | `name` STRING,
+        | `rowtime` AS TO_TIMESTAMP(`ts`),
+        | WATERMARK for `rowtime` AS `rowtime` - INTERVAL '1' SECOND
+        |) WITH (
+        | 'connector' = 'values',
+        | 'data-id' = '$dataId',
+        | 'failing-source' = 'true'
+        |)
+        |""".stripMargin)
+    tEnv.createFunction("concat_distinct_agg", classOf[ConcatDistinctAggFunction])
+  }
+
+  @Test
+  def testTumbleWindowKeepLastRow(): Unit = {
+    val sql =
+      s"""
+         |SELECT
+         |  TO_TIMESTAMP(`ts`),
+         |  `int`,
+         |  `double`,
+         |  `float`,
+         |  `bigdec`,
+         |  `string`,
+         |  `name`,
+         |  CAST(`rowtime` AS STRING),
+         |  window_start,
+         |  window_end,
+         |  window_time
+         |FROM (
+         |  SELECT *,
+         |    ROW_NUMBER() OVER(
+         |      PARTITION BY window_start, window_end, `name` ORDER BY rowtime DESC) as rownum
+         |  FROM TABLE(
+         |      TUMBLE(TABLE T1, DESCRIPTOR(rowtime), INTERVAL '5' SECOND))
+         |)
+         |WHERE rownum <= 1
+      """.stripMargin
+
+    val sink = new TestingAppendSink
+    tEnv.sqlQuery(sql).toAppendStream[Row].addSink(sink)
+    env.execute()
+
+    val expected =
+      Seq(
+        "2020-10-10T00:00:04,5,5.0,5.0,5.55,null,a,2020-10-10 00:00:04.000," +
+          "2020-10-10T00:00,2020-10-10T00:00:05,2020-10-10T00:00:04.999",
+        "2020-10-10T00:00:08,3,null,3.0,3.33,Comment#2,a,2020-10-10 00:00:08.000," +
+          "2020-10-10T00:00:05,2020-10-10T00:00:10,2020-10-10T00:00:09.999",
+        "2020-10-10T00:00:07,3,3.0,3.0,null,Hello,b,2020-10-10 00:00:07.000," +
+          "2020-10-10T00:00:05,2020-10-10T00:00:10,2020-10-10T00:00:09.999",
+        "2020-10-10T00:00:16,4,4.0,4.0,4.44,Hi,b,2020-10-10 00:00:16.000," +
+          "2020-10-10T00:00:15,2020-10-10T00:00:20,2020-10-10T00:00:19.999",
+        "2020-10-10T00:00:32,7,7.0,7.0,7.77,null,null,2020-10-10 00:00:32.000," +
+          "2020-10-10T00:00:30,2020-10-10T00:00:35,2020-10-10T00:00:34.999",
+        "2020-10-10T00:00:34,1,3.0,3.0,3.33,Comment#3,b,2020-10-10 00:00:34.000," +
+          "2020-10-10T00:00:30,2020-10-10T00:00:35,2020-10-10T00:00:34.999")
+    assertEquals(expected.sorted.mkString("\n"), sink.getAppendResults.sorted.mkString("\n"))
+  }
+
+  @Test
+  def testTumbleWindowKeepFirstRow(): Unit = {
+    val sql =
+      s"""
+         |SELECT
+         |  TO_TIMESTAMP(`ts`),
+         |  `int`,
+         |  `double`,
+         |  `float`,
+         |  `bigdec`,
+         |  `string`,
+         |  `name`,
+         |  CAST(`rowtime` AS STRING),
+         |  window_start,
+         |  window_end,
+         |  window_time
+         |FROM (
+         |  SELECT *,
+         |    ROW_NUMBER() OVER(
+         |      PARTITION BY window_start, window_end, `name` ORDER BY rowtime) as rownum
+         |  FROM TABLE(
+         |      TUMBLE(TABLE T1, DESCRIPTOR(rowtime), INTERVAL '5' SECOND))
+         |)
+         |WHERE rownum <= 1
+      """.stripMargin
+
+    val sink = new TestingAppendSink
+    tEnv.sqlQuery(sql).toAppendStream[Row].addSink(sink)
+    env.execute()
+
+    val expected =
+      Seq(
+        "2020-10-10T00:00:01,1,1.0,1.0,1.11,Hi,a,2020-10-10 00:00:01.000," +
+          "2020-10-10T00:00,2020-10-10T00:00:05,2020-10-10T00:00:04.999",
+        "2020-10-10T00:00:08,3,null,3.0,3.33,Comment#2,a,2020-10-10 00:00:08.000," +
+          "2020-10-10T00:00:05,2020-10-10T00:00:10,2020-10-10T00:00:09.999",
+        "2020-10-10T00:00:06,6,6.0,6.0,6.66,Hi,b,2020-10-10 00:00:06.000," +
+          "2020-10-10T00:00:05,2020-10-10T00:00:10,2020-10-10T00:00:09.999",
+        "2020-10-10T00:00:16,4,4.0,4.0,4.44,Hi,b,2020-10-10 00:00:16.000," +
+          "2020-10-10T00:00:15,2020-10-10T00:00:20,2020-10-10T00:00:19.999",
+        "2020-10-10T00:00:32,7,7.0,7.0,7.77,null,null,2020-10-10 00:00:32.000," +
+          "2020-10-10T00:00:30,2020-10-10T00:00:35,2020-10-10T00:00:34.999",
+        "2020-10-10T00:00:34,1,3.0,3.0,3.33,Comment#3,b,2020-10-10 00:00:34.000," +
+          "2020-10-10T00:00:30,2020-10-10T00:00:35,2020-10-10T00:00:34.999"
+      )
+    assertEquals(expected.sorted.mkString("\n"), sink.getAppendResults.sorted.mkString("\n"))
+  }
+
+  @Test
+  def testTumbleWindowKeepLastRowWithCalc(): Unit = {
+    val sql =
+      """
+        |SELECT
+        |  `int`,
+        |  `string`,
+        |  `name`,
+        |  window_start,
+        |  window_end,
+        |  window_time
+        |FROM (
+        |  SELECT *,
+        |    ROW_NUMBER() OVER(
+        |      PARTITION BY window_start, window_end, `name` ORDER BY rowtime DESC) as rownum
+        |  FROM TABLE(
+        |      TUMBLE(TABLE T1, DESCRIPTOR(rowtime), INTERVAL '5' SECOND))
+        |)
+        |WHERE rownum <= 1
+      """.stripMargin
+
+    val sink = new TestingAppendSink
+    tEnv.sqlQuery(sql).toAppendStream[Row].addSink(sink)
+    env.execute()
+
+    val expected =
+      Seq(
+        "5,null,a,2020-10-10T00:00,2020-10-10T00:00:05,2020-10-10T00:00:04.999",
+        "3,Comment#2,a,2020-10-10T00:00:05,2020-10-10T00:00:10,2020-10-10T00:00:09.999",
+        "3,Hello,b,2020-10-10T00:00:05,2020-10-10T00:00:10,2020-10-10T00:00:09.999",
+        "4,Hi,b,2020-10-10T00:00:15,2020-10-10T00:00:20,2020-10-10T00:00:19.999",
+        "7,null,null,2020-10-10T00:00:30,2020-10-10T00:00:35,2020-10-10T00:00:34.999",
+        "1,Comment#3,b,2020-10-10T00:00:30,2020-10-10T00:00:35,2020-10-10T00:00:34.999")
+    assertEquals(expected.sorted.mkString("\n"), sink.getAppendResults.sorted.mkString("\n"))
+  }
+
+  @Test
+  def testCumulateWindowKeepLastRow(): Unit = {
+    val sql =
+      s"""
+         |SELECT
+         |  TO_TIMESTAMP(`ts`),
+         |  `int`,
+         |  `double`,
+         |  `float`,
+         |  `bigdec`,
+         |  `string`,
+         |  `name`,
+         |  CAST(`rowtime` AS STRING),
+         |  window_start,
+         |  window_end,
+         |  window_time
+         |FROM (
+         |  SELECT *,
+         |    ROW_NUMBER() OVER(
+         |      PARTITION BY window_start, window_end, `name` ORDER BY rowtime DESC) as rownum
+         |  FROM TABLE(
+         |      CUMULATE(
+         |        TABLE T1,
+         |        DESCRIPTOR(rowtime),
+         |        INTERVAL '5' SECOND,
+         |        INTERVAL '15' SECOND))
+         |)
+         |WHERE rownum <= 1
+      """.stripMargin
+
+    val sink = new TestingAppendSink
+    tEnv.sqlQuery(sql).toAppendStream[Row].addSink(sink)
+    env.execute()
+
+    val expected =
+      Seq(
+        "2020-10-10T00:00:04,5,5.0,5.0,5.55,null,a,2020-10-10 00:00:04.000," +
+          "2020-10-10T00:00,2020-10-10T00:00:05,2020-10-10T00:00:04.999",
+        "2020-10-10T00:00:08,3,null,3.0,3.33,Comment#2,a,2020-10-10 00:00:08.000," +
+          "2020-10-10T00:00,2020-10-10T00:00:10,2020-10-10T00:00:09.999",
+        "2020-10-10T00:00:08,3,null,3.0,3.33,Comment#2,a,2020-10-10 00:00:08.000," +
+          "2020-10-10T00:00,2020-10-10T00:00:15,2020-10-10T00:00:14.999",
+        "2020-10-10T00:00:07,3,3.0,3.0,null,Hello,b,2020-10-10 00:00:07.000," +
+          "2020-10-10T00:00,2020-10-10T00:00:10,2020-10-10T00:00:09.999",
+        "2020-10-10T00:00:07,3,3.0,3.0,null,Hello,b,2020-10-10 00:00:07.000," +
+          "2020-10-10T00:00,2020-10-10T00:00:15,2020-10-10T00:00:14.999",
+        "2020-10-10T00:00:16,4,4.0,4.0,4.44,Hi,b,2020-10-10 00:00:16.000," +
+          "2020-10-10T00:00:15,2020-10-10T00:00:20,2020-10-10T00:00:19.999",
+        "2020-10-10T00:00:16,4,4.0,4.0,4.44,Hi,b,2020-10-10 00:00:16.000," +
+          "2020-10-10T00:00:15,2020-10-10T00:00:25,2020-10-10T00:00:24.999",
+        "2020-10-10T00:00:16,4,4.0,4.0,4.44,Hi,b,2020-10-10 00:00:16.000," +
+          "2020-10-10T00:00:15,2020-10-10T00:00:30,2020-10-10T00:00:29.999",
+        "2020-10-10T00:00:32,7,7.0,7.0,7.77,null,null,2020-10-10 00:00:32.000," +
+          "2020-10-10T00:00:30,2020-10-10T00:00:35,2020-10-10T00:00:34.999",
+        "2020-10-10T00:00:32,7,7.0,7.0,7.77,null,null,2020-10-10 00:00:32.000," +
+          "2020-10-10T00:00:30,2020-10-10T00:00:40,2020-10-10T00:00:39.999",
+        "2020-10-10T00:00:32,7,7.0,7.0,7.77,null,null,2020-10-10 00:00:32.000," +
+          "2020-10-10T00:00:30,2020-10-10T00:00:45,2020-10-10T00:00:44.999",
+        "2020-10-10T00:00:34,1,3.0,3.0,3.33,Comment#3,b,2020-10-10 00:00:34.000," +
+          "2020-10-10T00:00:30,2020-10-10T00:00:35,2020-10-10T00:00:34.999",
+        "2020-10-10T00:00:34,1,3.0,3.0,3.33,Comment#3,b,2020-10-10 00:00:34.000," +
+          "2020-10-10T00:00:30,2020-10-10T00:00:40,2020-10-10T00:00:39.999",
+        "2020-10-10T00:00:34,1,3.0,3.0,3.33,Comment#3,b,2020-10-10 00:00:34.000," +
+          "2020-10-10T00:00:30,2020-10-10T00:00:45,2020-10-10T00:00:44.999")
+    assertEquals(expected.sorted.mkString("\n"), sink.getAppendResults.sorted.mkString("\n"))
+  }
+}


### PR DESCRIPTION
## What is the purpose of the change

This pull request aims to support streaming window Deduplicate in planner


## Brief change log
  - Introduces `StreamPhysicalWindowDeduplicate`
  - Introduces `StreamExecWindowDeduplicate`
  - Introduces `StreamPhysicalWindowDeduplicateRule`

## Verifying this change

  - Adds `WindowDeduplicateTest` to test planner
  - Adds `WindowDeduplicateITCase` to test query result
  - Adds `WindowTableFunctionJsonPlanTest#testFollowedByWindowDeduplicate` to test json for window deduplicate

## Does this pull request potentially affect one of the following parts:

  - Dependencies (does it add or upgrade a dependency): (yes / no)
  - The public API, i.e., is any changed class annotated with `@Public(Evolving)`: (yes / no)
  - The serializers: (yes / no / don't know)
  - The runtime per-record code paths (performance sensitive): (yes / no / don't know)
  - Anything that affects deployment or recovery: JobManager (and its components), Checkpointing, Kubernetes/Yarn, ZooKeeper: (yes / no / don't know)
  - The S3 file system connector: (yes / no / don't know)

## Documentation

  - Does this pull request introduce a new feature? (yes )
  - If yes, how is the feature documented? (docs)
