### PR TITLE
[FLINK-24724][buildsystem] Update Sun XML Bind dependencies to v3.0.2

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -880,17 +880,17 @@ under the License.
 								<dependency>
 									<groupId>javax.xml.bind</groupId>
 									<artifactId>jaxb-api</artifactId>
-									<version>2.3.0</version>
+									<version>${jaxb.api.version}</version>
 								</dependency>
 								<dependency>
 									<groupId>com.sun.xml.bind</groupId>
 									<artifactId>jaxb-impl</artifactId>
-									<version>2.3.0</version>
+									<version>3.0.2</version>
 								</dependency>
 								<dependency>
 									<groupId>com.sun.xml.bind</groupId>
 									<artifactId>jaxb-core</artifactId>
-									<version>2.3.0</version>
+									<version>3.0.2</version>
 								</dependency>
 								<dependency>
 									<groupId>javax.activation</groupId>


### PR DESCRIPTION
## What is the purpose of the change

* Dependency updates for com.sun.xml.bind:jaxb-impl and com.sun.xml.bind:jaxb-core

## Brief change log

* Updated POM file

## Verifying this change

This change is a trivial rework / code cleanup without any test coverage.

## Does this pull request potentially affect one of the following parts:

  - Dependencies (does it add or upgrade a dependency): (**yes** / no)
  - The public API, i.e., is any changed class annotated with `@Public(Evolving)`: (yes / **no**)
  - The serializers: (yes / **no** / don't know)
  - The runtime per-record code paths (performance sensitive): (yes / **no** / don't know)
  - Anything that affects deployment or recovery: JobManager (and its components), Checkpointing, Kubernetes/Yarn, ZooKeeper: (yes / **no** / don't know)
  - The S3 file system connector: (yes / **no** / don't know)

## Documentation

  - Does this pull request introduce a new feature? (yes / **no**)
  - If yes, how is the feature documented? (**not applicable** / docs / JavaDocs / not documented)
