### PR TITLE
[FLINK-24728][table-runtime] Close output stream in batch SQL file sink

### DIFF
--- a/flink-table/flink-table-runtime/src/main/java/org/apache/flink/table/filesystem/FileSystemTableSink.java
+++ b/flink-table/flink-table-runtime/src/main/java/org/apache/flink/table/filesystem/FileSystemTableSink.java
@@ -437,15 +437,15 @@ public class FileSystemTableSink extends AbstractFileSystemTable
             private static final long serialVersionUID = 1L;
 
             private transient BulkWriter<RowData> writer;
+            private transient FSDataOutputStream stream;
 
             @Override
             public void configure(Configuration parameters) {}
 
             @Override
             public void open(int taskNumber, int numTasks) throws IOException {
-                this.writer =
-                        factory.create(
-                                path.getFileSystem().create(path, FileSystem.WriteMode.OVERWRITE));
+                this.stream = path.getFileSystem().create(path, FileSystem.WriteMode.OVERWRITE);
+                this.writer = factory.create(stream);
             }
 
             @Override
@@ -457,6 +457,7 @@ public class FileSystemTableSink extends AbstractFileSystemTable
             public void close() throws IOException {
                 writer.flush();
                 writer.finish();
+                stream.close();
             }
         };
     }


### PR DESCRIPTION
## What is the purpose of the change

Currently the output format created in `FileSystemTableSink#createBulkWriterOutputFormat` only finishes the `BulkWriter` and does not close the output stream. This will cause some problems with some file systems for example HDFS.

This PR fixes this issue.

## Brief change log

 - Close output stream in batch SQL file sink.

## Verifying this change

This change is a trivial rework / code cleanup without any test coverage.

## Does this pull request potentially affect one of the following parts:

  - Dependencies (does it add or upgrade a dependency): no
  - The public API, i.e., is any changed class annotated with `@Public(Evolving)`: no
  - The serializers: no
  - The runtime per-record code paths (performance sensitive): no
  - Anything that affects deployment or recovery: JobManager (and its components), Checkpointing, Kubernetes/Yarn, ZooKeeper: no
  - The S3 file system connector: no

## Documentation

  - Does this pull request introduce a new feature? no
  - If yes, how is the feature documented? not applicable
