### PR TITLE
[FLINK-24740][testinfrastructure] Update testcontainers dependency to v1.16.2

### DIFF
--- a/flink-formats/flink-avro-glue-schema-registry/pom.xml
+++ b/flink-formats/flink-avro-glue-schema-registry/pom.xml
@@ -96,6 +96,13 @@ under the License.
 			<groupId>software.amazon.glue</groupId>
 			<artifactId>schema-registry-serde</artifactId>
 			<version>${glue.schema.registry.version}</version>
+			<exclusions>
+				<!-- Testcontainers dependency includes a newer version -->
+				<exclusion>
+					<groupId>org.jetbrains</groupId>
+					<artifactId>annotations</artifactId>
+				</exclusion>
+			</exclusions>
 		</dependency>
 
 		<dependency>

--- a/flink-formats/flink-json-glue-schema-registry/pom.xml
+++ b/flink-formats/flink-json-glue-schema-registry/pom.xml
@@ -120,6 +120,13 @@ under the License.
 			<groupId>com.kjetland</groupId>
 			<artifactId>mbknor-jackson-jsonschema_${scala.binary.version}</artifactId>
 			<version>1.0.39</version>
+			<exclusions>
+				<!-- Testcontainers dependency includes a newer version -->
+				<exclusion>
+					<groupId>org.jetbrains</groupId>
+					<artifactId>annotations</artifactId>
+				</exclusion>
+			</exclusions>
 		</dependency>
 
 		<dependency>

--- a/pom.xml
+++ b/pom.xml
@@ -136,7 +136,7 @@ under the License.
 		<protoc.version>3.17.3</protoc.version>
 		<arrow.version>0.16.0</arrow.version>
 		<okhttp.version>3.14.9</okhttp.version>
-		<testcontainers.version>1.16.0</testcontainers.version>
+		<testcontainers.version>1.16.2</testcontainers.version>
 		<lz4.version>1.8.0</lz4.version>
 		<japicmp.skip>false</japicmp.skip>
 		<flink.convergence.phase>validate</flink.convergence.phase>


### PR DESCRIPTION
## What is the purpose of the change

* Update testcontainers dependency to the latest version for various improvements

## Brief change log

* Updated POM
* Excluded org.jetbrains:annotations from com.kjetland:mbknor-jackson-jsonschema to address dependency convergence on glue-schema-registry:

```
Dependency convergence error for org.jetbrains:annotations:13.0 paths to dependency are:
+-org.apache.flink:flink-json-glue-schema-registry_2.12:1.15-SNAPSHOT
  +-com.kjetland:mbknor-jackson-jsonschema_2.12:1.0.39
    +-org.jetbrains.kotlin:kotlin-scripting-compiler-embeddable:1.3.50
      +-org.jetbrains.kotlin:kotlin-stdlib:1.3.50
        +-org.jetbrains:annotations:13.0
and
+-org.apache.flink:flink-json-glue-schema-registry_2.12:1.15-SNAPSHOT
  +-org.testcontainers:junit-jupiter:1.16.2
    +-org.testcontainers:testcontainers:1.16.2
      +-org.rnorth.duct-tape:duct-tape:1.0.8
        +-org.jetbrains:annotations:17.0.0
```

```
Dependency convergence error for org.jetbrains:annotations:17.0.0 paths to dependency are:
+-org.apache.flink:flink-glue-schema-registry-avro-test_2.12:1.15-SNAPSHOT
  +-org.apache.flink:flink-streaming-kinesis-test:1.15-SNAPSHOT
    +-org.apache.flink:flink-end-to-end-tests-common:1.15-SNAPSHOT
      +-org.testcontainers:testcontainers:1.16.2
        +-org.rnorth.duct-tape:duct-tape:1.0.8
          +-org.jetbrains:annotations:17.0.0
and
+-org.apache.flink:flink-glue-schema-registry-avro-test_2.12:1.15-SNAPSHOT
  +-org.apache.flink:flink-avro-glue-schema-registry_2.12:1.15-SNAPSHOT
    +-software.amazon.glue:schema-registry-serde:1.1.5
      +-com.kjetland:mbknor-jackson-jsonschema_2.12:1.0.39
        +-org.jetbrains.kotlin:kotlin-scripting-compiler-embeddable:1.3.50
          +-org.jetbrains.kotlin:kotlin-stdlib:1.3.50
            +-org.jetbrains:annotations:13.0
```

## Verifying this change

This change is a trivial rework / code cleanup without any test coverage.

## Does this pull request potentially affect one of the following parts:

  - Dependencies (does it add or upgrade a dependency): (**yes** / no)
  - The public API, i.e., is any changed class annotated with `@Public(Evolving)`: (yes / **no**)
  - The serializers: (yes / **no** / don't know)
  - The runtime per-record code paths (performance sensitive): (yes / **no** / don't know)
  - Anything that affects deployment or recovery: JobManager (and its components), Checkpointing, Kubernetes/Yarn, ZooKeeper: (yes / **no** / don't know)
  - The S3 file system connector: (yes / **no** / don't know)

## Documentation

  - Does this pull request introduce a new feature? (yes / **no**)
  - If yes, how is the feature documented? (**not applicable** / docs / JavaDocs / not documented)
