### PR TITLE
[FLINK-24742][table][docs] Add info about SQL client key strokes to docs

### DIFF
--- a/docs/content.zh/docs/dev/table/sqlClient.md
+++ b/docs/content.zh/docs/dev/table/sqlClient.md
@@ -155,6 +155,40 @@ Received a total of 5 rows
 
 {{< top >}}
 
+### Key-strokes
+
+There is a list of available key-strokes in SQL client
+
+| Key-Stroke (Linux, Windows(WSL)) | Key-Stroke (Mac) | Description                                                                            |
+|:---------------------------------|------------------|:---------------------------------------------------------------------------------------|
+| `alt-b`, `ctrl+⍇`                | `Esc-b`          | Backward word                                                                          |
+| `alt-f`, `Ctrl+⍈`                | `Esc-f`          | Forward word                                                                           |
+| `alt-c`                          | `Esc-c`          | Capitalize word                                                                        |
+| `alt-l`                          | `Esc-l`          | Lowercase word                                                                         |
+| `alt-u`                          | `Esc-u`          | Uppercase word                                                                         |
+| `alt-d`                          | `Esc-d`          | Kill word                                                                              |
+| `alt-n`                          | `Esc-n`          | History search forward (behaves same as down line from history in case of empty input) |
+| `alt-p`                          | `Esc-p`          | History search backward (behaves same as up line from history in case of empty input)  |
+| `alt-t`                          | `Esc-t`          | Transpose words                                                                        |
+| `ctrl-a`                         | `⌘-a`            | To the beginning of line                                                               |
+| `ctrl-e`                         | `⌘-e`            | To the end of line                                                                     |
+| `ctrl-b`                         | `⌘-b`            | Backward char                                                                          |
+| `ctrl-f`                         | `⌘-f`            | Forward char                                                                           |
+| `ctrl-d`                         | `⌘-d`            | Delete char                                                                            |
+| `ctrl-h`                         | `⌘-h`            | Backward delete char                                                                   |
+| `ctrl-t`                         | `⌘-t`            | Transpose chars                                                                        |
+| `ctrl-i`                         | `⌘-i`            | Invoke completion                                                                      |
+| `ctrl-j`                         | `⌘-j`            | Submit a query                                                                         |
+| `ctrl-m`                         | `⌘-m`            | Submit a query                                                                         |
+| `ctrl-k`                         | `⌘-k`            | Kill the line to the right from the cursor                                             |
+| `ctrl-w`                         | `⌘-w`            | Kill the line to the left from the cursor                                              |
+| `ctrl-u`                         | `⌘-u`            | Kill the whole line                                                                    |
+| `ctrl-l`                         | `⌘-l`            | Clear screen                                                                           |
+| `ctrl-n`                         | `⌘-n`            | Down line from history                                                                 |
+| `ctrl-p`                         | `⌘-p`            | Up line from history                                                                   |
+| `ctrl-r`                         | `⌘-r`            | History incremental search backward                                                    |
+| `ctrl-s`                         | `⌘-s`            | History incremental search forward                                                     |
+
 <a name="configuration"></a>
 
 Configuration

--- a/docs/content/docs/dev/table/sqlClient.md
+++ b/docs/content/docs/dev/table/sqlClient.md
@@ -95,35 +95,35 @@ The [configuration section](#configuration) explains how to declare table source
 
 There is a list of available key-strokes in SQL client
 
-| Key-Stroke | Description                                |
-|:-----------|:-------------------------------------------|
-| `alt-b`    | Backward word                              |
-| `alt-f`    | Forward word                               |
-| `alt-c`    | Capitalize word                            |
-| `alt-l`    | Lowercase word                             |
-| `alt-u`    | Uppercase word                             |
-| `alt-d`    | Kill word                                  |
-| `alt-n`    | History search forward                     |
-| `alt-p`    | History search backward                    |
-| `alt-t`    | Transpose words                            |
-| `ctrl-a`   | To the beginning of line                   |
-| `ctrl-e`   | To the end of line                         |
-| `ctrl-b`   | Backward char                              |
-| `ctrl-f`   | Forward char                               |
-| `ctrl-d`   | Delete char                                |
-| `ctrl-h`   | Backward delete char                       |
-| `ctrl-t`   | Transpose chars                            |
-| `ctrl-i`   | Invoke completion                          |
-| `ctrl-j`   | Submit a query                             |
-| `ctrl-m`   | Submit a query                             |
-| `ctrl-k`   | Kill the line to the right from the cursor |
-| `ctrl-w`   | Kill the line to the left from the cursor  |
-| `ctrl-u`   | Kill the whole line                        |
-| `ctrl-l`   | Clear screen                               |
-| `ctrl-n`   | Down line from history                     |
-| `ctrl-p`   | Up line from history                       |
-| `ctrl-r`   | History incremental search backward        |
-| `ctrl-s`   | History incremental search forward         |
+| Key-Stroke (Linux, Windows(WSL)) | Key-Stroke (Mac) | Description                                |
+|:---------------------------------|------------------|:-------------------------------------------|
+| `alt-b`                          | `Esc-b`          | Backward word                              |
+| `alt-f`                          | `Esc-f`          | Forward word                               |
+| `alt-c`                          | `Esc-c`          | Capitalize word                            |
+| `alt-l`                          | `Esc-l`          | Lowercase word                             |
+| `alt-u`                          | `Esc-u`          | Uppercase word                             |
+| `alt-d`                          | `Esc-d`          | Kill word                                  |
+| `alt-n`                          | `Esc-n`          | History search forward                     |
+| `alt-p`                          | `Esc-p`          | History search backward                    |
+| `alt-t`                          | `Esc-t`          | Transpose words                            |
+| `ctrl-a`                         | `⌘-a`            | To the beginning of line                   |
+| `ctrl-e`                         | `⌘-e`            | To the end of line                         |
+| `ctrl-b`                         | `⌘-b`            | Backward char                              |
+| `ctrl-f`                         | `⌘-f`            | Forward char                               |
+| `ctrl-d`                         | `⌘-d`            | Delete char                                |
+| `ctrl-h`                         | `⌘-h`            | Backward delete char                       |
+| `ctrl-t`                         | `⌘-t`            | Transpose chars                            |
+| `ctrl-i`                         | `⌘-i`            | Invoke completion                          |
+| `ctrl-j`                         | `⌘-j`            | Submit a query                             |
+| `ctrl-m`                         | `⌘-m`            | Submit a query                             |
+| `ctrl-k`                         | `⌘-k`            | Kill the line to the right from the cursor |
+| `ctrl-w`                         | `⌘-w`            | Kill the line to the left from the cursor  |
+| `ctrl-u`                         | `⌘-u`            | Kill the whole line                        |
+| `ctrl-l`                         | `⌘-l`            | Clear screen                               |
+| `ctrl-n`                         | `⌘-n`            | Down line from history                     |
+| `ctrl-p`                         | `⌘-p`            | Up line from history                       |
+| `ctrl-r`                         | `⌘-r`            | History incremental search backward        |
+| `ctrl-s`                         | `⌘-s`            | History incremental search forward         |
 
 ### Getting help
 

--- a/docs/content/docs/dev/table/sqlClient.md
+++ b/docs/content/docs/dev/table/sqlClient.md
@@ -91,6 +91,40 @@ The `SET` command allows you to tune the job execution and the sql client behavi
 After a query is defined, it can be submitted to the cluster as a long-running, detached Flink job.
 The [configuration section](#configuration) explains how to declare table sources for reading data, how to declare table sinks for writing data, and how to configure other table program properties.
 
+### Key-strokes
+
+There is a list of available key-strokes in SQL client
+
+| Key-Stroke | Description                                |
+|:-----------|:-------------------------------------------|
+| `alt-b`    | Backward word                              |
+| `alt-f`    | Forward word                               |
+| `alt-c`    | Capitalize word                            |
+| `alt-l`    | Lowercase word                             |
+| `alt-u`    | Uppercase word                             |
+| `alt-d`    | Kill word                                  |
+| `alt-n`    | History search forward                     |
+| `alt-p`    | History search backward                    |
+| `alt-t`    | Transpose words                            |
+| `ctrl-a`   | To the beginning of line                   |
+| `ctrl-e`   | To the end of line                         |
+| `ctrl-b`   | Backward char                              |
+| `ctrl-f`   | Forward char                               |
+| `ctrl-d`   | Delete char                                |
+| `ctrl-h`   | Backward delete char                       |
+| `ctrl-t`   | Transpose chars                            |
+| `ctrl-i`   | Invoke completion                          |
+| `ctrl-j`   | Submit a query                             |
+| `ctrl-m`   | Submit a query                             |
+| `ctrl-k`   | Kill the line to the right from the cursor |
+| `ctrl-w`   | Kill the line to the left from the cursor  |
+| `ctrl-u`   | Kill the whole line                        |
+| `ctrl-l`   | Clear screen                               |
+| `ctrl-n`   | Down line from history                     |
+| `ctrl-p`   | Up line from history                       |
+| `ctrl-r`   | History incremental search backward        |
+| `ctrl-s`   | History incremental search forward         |
+
 ### Getting help
 
 The documentation of the SQL client commands can be accessed by typing the `HELP` command.

--- a/docs/content/docs/dev/table/sqlClient.md
+++ b/docs/content/docs/dev/table/sqlClient.md
@@ -95,35 +95,35 @@ The [configuration section](#configuration) explains how to declare table source
 
 There is a list of available key-strokes in SQL client
 
-| Key-Stroke (Linux, Windows(WSL)) | Key-Stroke (Mac) | Description                                |
-|:---------------------------------|------------------|:-------------------------------------------|
-| `alt-b`                          | `Esc-b`          | Backward word                              |
-| `alt-f`                          | `Esc-f`          | Forward word                               |
-| `alt-c`                          | `Esc-c`          | Capitalize word                            |
-| `alt-l`                          | `Esc-l`          | Lowercase word                             |
-| `alt-u`                          | `Esc-u`          | Uppercase word                             |
-| `alt-d`                          | `Esc-d`          | Kill word                                  |
-| `alt-n`                          | `Esc-n`          | History search forward                     |
-| `alt-p`                          | `Esc-p`          | History search backward                    |
-| `alt-t`                          | `Esc-t`          | Transpose words                            |
-| `ctrl-a`                         | `⌘-a`            | To the beginning of line                   |
-| `ctrl-e`                         | `⌘-e`            | To the end of line                         |
-| `ctrl-b`                         | `⌘-b`            | Backward char                              |
-| `ctrl-f`                         | `⌘-f`            | Forward char                               |
-| `ctrl-d`                         | `⌘-d`            | Delete char                                |
-| `ctrl-h`                         | `⌘-h`            | Backward delete char                       |
-| `ctrl-t`                         | `⌘-t`            | Transpose chars                            |
-| `ctrl-i`                         | `⌘-i`            | Invoke completion                          |
-| `ctrl-j`                         | `⌘-j`            | Submit a query                             |
-| `ctrl-m`                         | `⌘-m`            | Submit a query                             |
-| `ctrl-k`                         | `⌘-k`            | Kill the line to the right from the cursor |
-| `ctrl-w`                         | `⌘-w`            | Kill the line to the left from the cursor  |
-| `ctrl-u`                         | `⌘-u`            | Kill the whole line                        |
-| `ctrl-l`                         | `⌘-l`            | Clear screen                               |
-| `ctrl-n`                         | `⌘-n`            | Down line from history                     |
-| `ctrl-p`                         | `⌘-p`            | Up line from history                       |
-| `ctrl-r`                         | `⌘-r`            | History incremental search backward        |
-| `ctrl-s`                         | `⌘-s`            | History incremental search forward         |
+| Key-Stroke (Linux, Windows(WSL)) | Key-Stroke (Mac) | Description                                                                            |
+|:---------------------------------|------------------|:---------------------------------------------------------------------------------------|
+| `alt-b`, `ctrl+⍇`                | `Esc-b`          | Backward word                                                                          |
+| `alt-f`, `Ctrl+⍈`                | `Esc-f`          | Forward word                                                                           |
+| `alt-c`                          | `Esc-c`          | Capitalize word                                                                        |
+| `alt-l`                          | `Esc-l`          | Lowercase word                                                                         |
+| `alt-u`                          | `Esc-u`          | Uppercase word                                                                         |
+| `alt-d`                          | `Esc-d`          | Kill word                                                                              |
+| `alt-n`                          | `Esc-n`          | History search forward (behaves same as down line from history in case of empty input) |
+| `alt-p`                          | `Esc-p`          | History search backward (behaves same as up line from history in case of empty input)  |
+| `alt-t`                          | `Esc-t`          | Transpose words                                                                        |
+| `ctrl-a`                         | `⌘-a`            | To the beginning of line                                                               |
+| `ctrl-e`                         | `⌘-e`            | To the end of line                                                                     |
+| `ctrl-b`                         | `⌘-b`            | Backward char                                                                          |
+| `ctrl-f`                         | `⌘-f`            | Forward char                                                                           |
+| `ctrl-d`                         | `⌘-d`            | Delete char                                                                            |
+| `ctrl-h`                         | `⌘-h`            | Backward delete char                                                                   |
+| `ctrl-t`                         | `⌘-t`            | Transpose chars                                                                        |
+| `ctrl-i`                         | `⌘-i`            | Invoke completion                                                                      |
+| `ctrl-j`                         | `⌘-j`            | Submit a query                                                                         |
+| `ctrl-m`                         | `⌘-m`            | Submit a query                                                                         |
+| `ctrl-k`                         | `⌘-k`            | Kill the line to the right from the cursor                                             |
+| `ctrl-w`                         | `⌘-w`            | Kill the line to the left from the cursor                                              |
+| `ctrl-u`                         | `⌘-u`            | Kill the whole line                                                                    |
+| `ctrl-l`                         | `⌘-l`            | Clear screen                                                                           |
+| `ctrl-n`                         | `⌘-n`            | Down line from history                                                                 |
+| `ctrl-p`                         | `⌘-p`            | Up line from history                                                                   |
+| `ctrl-r`                         | `⌘-r`            | History incremental search backward                                                    |
+| `ctrl-s`                         | `⌘-s`            | History incremental search forward                                                     |
 
 ### Getting help
 


### PR DESCRIPTION
## What is the purpose of the change

The PR adds info about key-strokes in SQL client to docs

## Does this pull request potentially affect one of the following parts:

  - Dependencies (does it add or upgrade a dependency): (yes / **no**)
  - The public API, i.e., is any changed class annotated with `@Public(Evolving)`: (yes / **no**)
  - The serializers: (yes / **no** / don't know)
  - The runtime per-record code paths (performance sensitive): (yes / **no** / don't know)
  - Anything that affects deployment or recovery: JobManager (and its components), Checkpointing, Kubernetes/Yarn, ZooKeeper: (yes / **no** / don't know)
  - The S3 file system connector: (yes / **no** / don't know)

## Documentation

  - Does this pull request introduce a new feature? (yes / **no**)
  - If yes, how is the feature documented? (**not applicable** / docs / JavaDocs / not documented)
