### PR TITLE
[FLINK-24717][table-planner]Push down partitions before filters

### DIFF
--- a/flink-table/flink-table-planner/src/main/scala/org/apache/flink/table/planner/plan/optimize/program/FlinkBatchProgram.scala
+++ b/flink-table/flink-table-planner/src/main/scala/org/apache/flink/table/planner/plan/optimize/program/FlinkBatchProgram.scala
@@ -126,6 +126,8 @@ object FlinkBatchProgram {
                 .build(), "other predicate rewrite")
             .setIterations(5).build(), "predicate rewrite")
         .addProgram(
+          // PUSH_PARTITION_DOWN_RULES should always be in front of PUSH_FILTER_DOWN_RULES
+          // to prevent PUSH_FILTER_DOWN_RULES from consuming the predicates in partitions
           FlinkGroupProgramBuilder.newBuilder[BatchOptimizeContext]
              .addProgram(
                FlinkHepRuleSetProgramBuilder.newBuilder

--- a/flink-table/flink-table-planner/src/main/scala/org/apache/flink/table/planner/plan/optimize/program/FlinkBatchProgram.scala
+++ b/flink-table/flink-table-planner/src/main/scala/org/apache/flink/table/planner/plan/optimize/program/FlinkBatchProgram.scala
@@ -126,10 +126,19 @@ object FlinkBatchProgram {
                 .build(), "other predicate rewrite")
             .setIterations(5).build(), "predicate rewrite")
         .addProgram(
-          FlinkHepRuleSetProgramBuilder.newBuilder
-            .setHepRulesExecutionType(HEP_RULES_EXECUTION_TYPE.RULE_SEQUENCE)
-            .setHepMatchOrder(HepMatchOrder.BOTTOM_UP)
-            .add(FlinkBatchRuleSets.FILTER_TABLESCAN_PUSHDOWN_RULES)
+          FlinkGroupProgramBuilder.newBuilder[BatchOptimizeContext]
+             .addProgram(
+               FlinkHepRuleSetProgramBuilder.newBuilder
+                 .setHepRulesExecutionType(HEP_RULES_EXECUTION_TYPE.RULE_SEQUENCE)
+                 .setHepMatchOrder(HepMatchOrder.BOTTOM_UP)
+                 .add(FlinkBatchRuleSets.PUSH_PARTITION_DOWN_RULES)
+                 .build(), "push down partitions into table scan")
+            .addProgram(
+              FlinkHepRuleSetProgramBuilder.newBuilder
+                .setHepRulesExecutionType(HEP_RULES_EXECUTION_TYPE.RULE_SEQUENCE)
+                .setHepMatchOrder(HepMatchOrder.BOTTOM_UP)
+                .add(FlinkBatchRuleSets.PUSH_FILTER_DOWN_RULES)
+                .build(), "push down filters into table scan")
             .build(), "push predicate into table scan")
         .addProgram(
           FlinkHepRuleSetProgramBuilder.newBuilder

--- a/flink-table/flink-table-planner/src/main/scala/org/apache/flink/table/planner/plan/optimize/program/FlinkStreamProgram.scala
+++ b/flink-table/flink-table-planner/src/main/scala/org/apache/flink/table/planner/plan/optimize/program/FlinkStreamProgram.scala
@@ -136,6 +136,8 @@ object FlinkStreamProgram {
                 .build(), "filter rules")
             .setIterations(5).build(), "predicate rewrite")
         .addProgram(
+          // PUSH_PARTITION_DOWN_RULES should always be in front of PUSH_FILTER_DOWN_RULES
+          // to prevent PUSH_FILTER_DOWN_RULES from consuming the predicates in partitions
           FlinkGroupProgramBuilder.newBuilder[StreamOptimizeContext]
             .addProgram(
               FlinkHepRuleSetProgramBuilder.newBuilder

--- a/flink-table/flink-table-planner/src/main/scala/org/apache/flink/table/planner/plan/optimize/program/FlinkStreamProgram.scala
+++ b/flink-table/flink-table-planner/src/main/scala/org/apache/flink/table/planner/plan/optimize/program/FlinkStreamProgram.scala
@@ -136,10 +136,19 @@ object FlinkStreamProgram {
                 .build(), "filter rules")
             .setIterations(5).build(), "predicate rewrite")
         .addProgram(
-          FlinkHepRuleSetProgramBuilder.newBuilder
-            .setHepRulesExecutionType(HEP_RULES_EXECUTION_TYPE.RULE_SEQUENCE)
-            .setHepMatchOrder(HepMatchOrder.BOTTOM_UP)
-            .add(FlinkStreamRuleSets.FILTER_TABLESCAN_PUSHDOWN_RULES)
+          FlinkGroupProgramBuilder.newBuilder[StreamOptimizeContext]
+            .addProgram(
+              FlinkHepRuleSetProgramBuilder.newBuilder
+                .setHepRulesExecutionType(HEP_RULES_EXECUTION_TYPE.RULE_SEQUENCE)
+                .setHepMatchOrder(HepMatchOrder.BOTTOM_UP)
+                .add(FlinkStreamRuleSets.PUSH_PARTITION_DOWN_RULES)
+                .build(), "push down partitions into table scan")
+            .addProgram(
+              FlinkHepRuleSetProgramBuilder.newBuilder
+                .setHepRulesExecutionType(HEP_RULES_EXECUTION_TYPE.RULE_SEQUENCE)
+                .setHepMatchOrder(HepMatchOrder.BOTTOM_UP)
+                .add(FlinkStreamRuleSets.PUSH_FILTER_DOWN_RULES)
+                .build(), "push down filters into table scan")
             .build(), "push predicate into table scan")
         .addProgram(
           FlinkHepRuleSetProgramBuilder.newBuilder

--- a/flink-table/flink-table-planner/src/main/scala/org/apache/flink/table/planner/plan/rules/FlinkBatchRuleSets.scala
+++ b/flink-table/flink-table-planner/src/main/scala/org/apache/flink/table/planner/plan/rules/FlinkBatchRuleSets.scala
@@ -179,7 +179,7 @@ object FlinkBatchRuleSets {
     // push partition into the table scan
     PushPartitionIntoLegacyTableSourceScanRule.INSTANCE,
     // push partition into the dynamic table scan
-    PushPartitionIntoTableSourceScanRule.INSTANCE,
+    PushPartitionIntoTableSourceScanRule.INSTANCE
   )
 
   /**

--- a/flink-table/flink-table-planner/src/main/scala/org/apache/flink/table/planner/plan/rules/FlinkBatchRuleSets.scala
+++ b/flink-table/flink-table-planner/src/main/scala/org/apache/flink/table/planner/plan/rules/FlinkBatchRuleSets.scala
@@ -173,13 +173,19 @@ object FlinkBatchRuleSets {
   )
 
   /**
-    * RuleSet to do push predicate/partition into table scan
-    */
-  val FILTER_TABLESCAN_PUSHDOWN_RULES: RuleSet = RuleSets.ofList(
+   * RuleSet to push down partitions into table source
+   */
+  val PUSH_PARTITION_DOWN_RULES: RuleSet = RuleSets.ofList(
     // push partition into the table scan
     PushPartitionIntoLegacyTableSourceScanRule.INSTANCE,
     // push partition into the dynamic table scan
     PushPartitionIntoTableSourceScanRule.INSTANCE,
+  )
+
+  /**
+   * RuleSet to push down filters into table source
+   */
+  val PUSH_FILTER_DOWN_RULES: RuleSet = RuleSets.ofList(
     // push a filter down into the table scan
     PushFilterIntoTableSourceScanRule.INSTANCE,
     PushFilterIntoLegacyTableSourceScanRule.INSTANCE

--- a/flink-table/flink-table-planner/src/main/scala/org/apache/flink/table/planner/plan/rules/FlinkBatchRuleSets.scala
+++ b/flink-table/flink-table-planner/src/main/scala/org/apache/flink/table/planner/plan/rules/FlinkBatchRuleSets.scala
@@ -176,13 +176,13 @@ object FlinkBatchRuleSets {
     * RuleSet to do push predicate/partition into table scan
     */
   val FILTER_TABLESCAN_PUSHDOWN_RULES: RuleSet = RuleSets.ofList(
-    // push a filter down into the table scan
-    PushFilterIntoTableSourceScanRule.INSTANCE,
-    PushFilterIntoLegacyTableSourceScanRule.INSTANCE,
     // push partition into the table scan
     PushPartitionIntoLegacyTableSourceScanRule.INSTANCE,
     // push partition into the dynamic table scan
-    PushPartitionIntoTableSourceScanRule.INSTANCE
+    PushPartitionIntoTableSourceScanRule.INSTANCE,
+    // push a filter down into the table scan
+    PushFilterIntoTableSourceScanRule.INSTANCE,
+    PushFilterIntoLegacyTableSourceScanRule.INSTANCE
   )
 
   /**

--- a/flink-table/flink-table-planner/src/main/scala/org/apache/flink/table/planner/plan/rules/FlinkStreamRuleSets.scala
+++ b/flink-table/flink-table-planner/src/main/scala/org/apache/flink/table/planner/plan/rules/FlinkStreamRuleSets.scala
@@ -180,14 +180,20 @@ object FlinkStreamRuleSets {
     ).asJava)
 
   /**
-    * RuleSet to do push predicate/partition into table scan
-    */
-  val FILTER_TABLESCAN_PUSHDOWN_RULES: RuleSet = RuleSets.ofList(
+   * RuleSet to push down partitions into table source
+   */
+  val PUSH_PARTITION_DOWN_RULES: RuleSet = RuleSets.ofList(
     // push partition into the table scan
     PushPartitionIntoLegacyTableSourceScanRule.INSTANCE,
     // push partition into the dynamic table scan
     PushPartitionIntoTableSourceScanRule.INSTANCE,
-      // push a filter down into the table scan
+  )
+
+  /**
+   * RuleSet to push down filters into table source
+   */
+  val PUSH_FILTER_DOWN_RULES: RuleSet = RuleSets.ofList(
+    // push a filter down into the table scan
     PushFilterIntoTableSourceScanRule.INSTANCE,
     PushFilterIntoLegacyTableSourceScanRule.INSTANCE
   )

--- a/flink-table/flink-table-planner/src/main/scala/org/apache/flink/table/planner/plan/rules/FlinkStreamRuleSets.scala
+++ b/flink-table/flink-table-planner/src/main/scala/org/apache/flink/table/planner/plan/rules/FlinkStreamRuleSets.scala
@@ -183,13 +183,13 @@ object FlinkStreamRuleSets {
     * RuleSet to do push predicate/partition into table scan
     */
   val FILTER_TABLESCAN_PUSHDOWN_RULES: RuleSet = RuleSets.ofList(
-    // push a filter down into the table scan
-    PushFilterIntoTableSourceScanRule.INSTANCE,
-    PushFilterIntoLegacyTableSourceScanRule.INSTANCE,
     // push partition into the table scan
     PushPartitionIntoLegacyTableSourceScanRule.INSTANCE,
     // push partition into the dynamic table scan
-    PushPartitionIntoTableSourceScanRule.INSTANCE
+    PushPartitionIntoTableSourceScanRule.INSTANCE,
+      // push a filter down into the table scan
+    PushFilterIntoTableSourceScanRule.INSTANCE,
+    PushFilterIntoLegacyTableSourceScanRule.INSTANCE
   )
 
   /**

--- a/flink-table/flink-table-planner/src/main/scala/org/apache/flink/table/planner/plan/rules/FlinkStreamRuleSets.scala
+++ b/flink-table/flink-table-planner/src/main/scala/org/apache/flink/table/planner/plan/rules/FlinkStreamRuleSets.scala
@@ -186,7 +186,7 @@ object FlinkStreamRuleSets {
     // push partition into the table scan
     PushPartitionIntoLegacyTableSourceScanRule.INSTANCE,
     // push partition into the dynamic table scan
-    PushPartitionIntoTableSourceScanRule.INSTANCE,
+    PushPartitionIntoTableSourceScanRule.INSTANCE
   )
 
   /**

--- a/flink-table/flink-table-planner/src/test/java/org/apache/flink/table/planner/factories/TestValuesTableFactory.java
+++ b/flink-table/flink-table-planner/src/test/java/org/apache/flink/table/planner/factories/TestValuesTableFactory.java
@@ -1101,16 +1101,16 @@ public final class TestValuesTableFactory
                     remainingPartitions = (List<Map<String, String>>) Collections.emptyMap();
                 }
             }
-            // only keep the data in the remain partitions
-            this.data = pruneDataByRemainPartitions(remainingPartitions, this.data);
+            // only keep the data in the remaining partitions
+            this.data = pruneDataByRemainingPartitions(remainingPartitions, this.data);
         }
 
-        private static Map<Map<String, String>, Collection<Row>> pruneDataByRemainPartitions(
-                List<Map<String, String>> remainPartitions,
+        private Map<Map<String, String>, Collection<Row>> pruneDataByRemainingPartitions(
+                List<Map<String, String>> remainingPartitions,
                 Map<Map<String, String>, Collection<Row>> allData) {
             Map<Map<String, String>, Collection<Row>> result = new HashMap<>();
-            for (Map<String, String> remainPartition : remainPartitions) {
-                result.put(remainPartition, allData.get(remainPartition));
+            for (Map<String, String> remainingPartition : remainingPartitions) {
+                result.put(remainingPartition, allData.get(remainingPartition));
             }
             return result;
         }

--- a/flink-table/flink-table-planner/src/test/java/org/apache/flink/table/planner/factories/TestValuesTableFactory.java
+++ b/flink-table/flink-table-planner/src/test/java/org/apache/flink/table/planner/factories/TestValuesTableFactory.java
@@ -855,6 +855,9 @@ public final class TestValuesTableFactory
                 }
             }
             this.filterPredicates = acceptedFilters;
+
+            this.data = filterAllData(this.data);
+
             return Result.of(acceptedFilters, remainingFilters);
         }
 
@@ -893,13 +896,8 @@ public final class TestValuesTableFactory
 
         protected Collection<RowData> convertToRowData(DataStructureConverter converter) {
             List<RowData> result = new ArrayList<>();
-            List<Map<String, String>> keys =
-                    allPartitions.isEmpty()
-                            ? Collections.singletonList(Collections.emptyMap())
-                            : allPartitions;
-
             int numSkipped = 0;
-            for (Map<String, String> partition : keys) {
+            for (Map<String, String> partition : data.keySet()) {
                 Collection<Row> rowsInPartition = data.get(partition);
 
                 // handle element skipping
@@ -910,14 +908,13 @@ public final class TestValuesTableFactory
                 }
                 numSkipped += numToSkipInPartition;
 
-                // handle predicates and projection
+                // handle projection
+                // Now we don't do it in applyProjections and applyReadableMetadata like
+                // applyPartitions and applyFilters, Because in periods before we can't confirm the
+                // final fields.
                 List<Row> rowsRetained =
                         rowsInPartition.stream()
                                 .skip(numToSkipInPartition)
-                                .filter(
-                                        row ->
-                                                FilterUtils.isRetainedAfterApplyingFilterPredicates(
-                                                        filterPredicates, getValueGetter(row)))
                                 .map(
                                         row -> {
                                             Row projectedRow = projectRow(row);
@@ -1024,6 +1021,25 @@ public final class TestValuesTableFactory
             return result;
         }
 
+        private Map<Map<String, String>, Collection<Row>> filterAllData(
+                Map<Map<String, String>, Collection<Row>> allData) {
+            final Map<Map<String, String>, Collection<Row>> result = new HashMap<>();
+
+            for (Map<String, String> partition : allData.keySet()) {
+                List<Row> remainData = new ArrayList<>();
+                for (Row row : allData.get(partition)) {
+                    boolean isRetained =
+                            FilterUtils.isRetainedAfterApplyingFilterPredicates(
+                                    filterPredicates, getValueGetter(row));
+                    if (isRetained) {
+                        remainData.add(row);
+                    }
+                }
+                result.put(partition, remainData);
+            }
+            return result;
+        }
+
         private Row projectRow(Row row) {
             if (projectedPhysicalFields == null) {
                 return row;
@@ -1075,14 +1091,28 @@ public final class TestValuesTableFactory
                 } else {
                     // we will read data from Collections.emptyList() if allPartitions is empty.
                     // therefore, we should clear all data manually.
+                    remainingPartitions = (List<Map<String, String>>) Collections.emptyMap();
                     this.data.put(Collections.emptyMap(), Collections.emptyList());
                 }
+
             } else {
                 this.allPartitions = remainingPartitions;
                 if (remainingPartitions.isEmpty()) {
-                    this.data.put(Collections.emptyMap(), Collections.emptyList());
+                    remainingPartitions = (List<Map<String, String>>) Collections.emptyMap();
                 }
             }
+            // only keep the data in the remain partitions
+            this.data = pruneDataByRemainPartitions(remainingPartitions, this.data);
+        }
+
+        private static Map<Map<String, String>, Collection<Row>> pruneDataByRemainPartitions(
+                List<Map<String, String>> remainPartitions,
+                Map<Map<String, String>, Collection<Row>> allData) {
+            Map<Map<String, String>, Collection<Row>> result = new HashMap<>();
+            for (Map<String, String> remainPartition : remainPartitions) {
+                result.put(remainPartition, allData.get(remainPartition));
+            }
+            return result;
         }
 
         @Override
@@ -1219,6 +1249,8 @@ public final class TestValuesTableFactory
         public void applyProjection(int[][] projectedFields) {
             this.producedDataType = DataTypeUtils.projectRow(producedDataType, projectedFields);
             this.projectedPhysicalFields = projectedFields;
+            // we can't immediately project the data here,
+            // because ReadingMetadataSpec may bring new fields
         }
     }
 

--- a/flink-table/flink-table-planner/src/test/resources/org/apache/flink/table/planner/plan/batch/sql/PartitionableSourceTest.xml
+++ b/flink-table/flink-table-planner/src/test/resources/org/apache/flink/table/planner/plan/batch/sql/PartitionableSourceTest.xml
@@ -18,229 +18,286 @@ limitations under the License.
 <Root>
   <TestCase name="testPartialPartitionFieldPredicatePushDown[sourceFetchPartitions=false, useCatalogFilter=false]">
     <Resource name="sql">
-      <![CDATA[SELECT * FROM MyTable WHERE (id > 2 OR part1 = 'A') AND part2 > 1]]>
+      <![CDATA[SELECT * FROM PartitionableTable WHERE (id > 2 OR part1 = 'A') AND part2 > 1]]>
     </Resource>
     <Resource name="ast">
       <![CDATA[
 LogicalProject(id=[$0], name=[$1], part1=[$2], part2=[$3], virtualField=[$4])
 +- LogicalFilter(condition=[AND(OR(>($0, 2), =($2, _UTF-16LE'A')), >($3, 1))])
    +- LogicalProject(id=[$0], name=[$1], part1=[$2], part2=[$3], virtualField=[+($3, 1)])
-      +- LogicalTableScan(table=[[test_catalog, test_database, MyTable]])
+      +- LogicalTableScan(table=[[test_catalog, test_database, PartitionableTable]])
 ]]>
     </Resource>
     <Resource name="optimized exec plan">
       <![CDATA[
 Calc(select=[id, name, part1, part2, (part2 + 1) AS virtualField], where=[((id > 2) OR (part1 = _UTF-16LE'A':VARCHAR(2147483647) CHARACTER SET "UTF-16LE"))])
-+- TableSourceScan(table=[[test_catalog, test_database, MyTable, filter=[], partitions=[{part1=A, part2=2}, {part1=B, part2=3}]]], fields=[id, name, part1, part2])
++- TableSourceScan(table=[[test_catalog, test_database, PartitionableTable, partitions=[{part1=A, part2=2}, {part1=B, part2=3}], filter=[]]], fields=[id, name, part1, part2])
 ]]>
     </Resource>
   </TestCase>
   <TestCase name="testPartialPartitionFieldPredicatePushDown[sourceFetchPartitions=false, useCatalogFilter=true]">
     <Resource name="sql">
-      <![CDATA[SELECT * FROM MyTable WHERE (id > 2 OR part1 = 'A') AND part2 > 1]]>
+      <![CDATA[SELECT * FROM PartitionableTable WHERE (id > 2 OR part1 = 'A') AND part2 > 1]]>
     </Resource>
     <Resource name="ast">
       <![CDATA[
 LogicalProject(id=[$0], name=[$1], part1=[$2], part2=[$3], virtualField=[$4])
 +- LogicalFilter(condition=[AND(OR(>($0, 2), =($2, _UTF-16LE'A')), >($3, 1))])
    +- LogicalProject(id=[$0], name=[$1], part1=[$2], part2=[$3], virtualField=[+($3, 1)])
-      +- LogicalTableScan(table=[[test_catalog, test_database, MyTable]])
+      +- LogicalTableScan(table=[[test_catalog, test_database, PartitionableTable]])
 ]]>
     </Resource>
     <Resource name="optimized exec plan">
       <![CDATA[
 Calc(select=[id, name, part1, part2, (part2 + 1) AS virtualField], where=[((id > 2) OR (part1 = _UTF-16LE'A':VARCHAR(2147483647) CHARACTER SET "UTF-16LE"))])
-+- TableSourceScan(table=[[test_catalog, test_database, MyTable, filter=[], partitions=[{part1=A, part2=2}, {part1=B, part2=3}]]], fields=[id, name, part1, part2])
++- TableSourceScan(table=[[test_catalog, test_database, PartitionableTable, partitions=[{part1=A, part2=2}, {part1=B, part2=3}], filter=[]]], fields=[id, name, part1, part2])
 ]]>
     </Resource>
   </TestCase>
   <TestCase name="testPartialPartitionFieldPredicatePushDown[sourceFetchPartitions=true, useCatalogFilter=false]">
     <Resource name="sql">
-      <![CDATA[SELECT * FROM MyTable WHERE (id > 2 OR part1 = 'A') AND part2 > 1]]>
+      <![CDATA[SELECT * FROM PartitionableTable WHERE (id > 2 OR part1 = 'A') AND part2 > 1]]>
     </Resource>
     <Resource name="ast">
       <![CDATA[
 LogicalProject(id=[$0], name=[$1], part1=[$2], part2=[$3], virtualField=[$4])
 +- LogicalFilter(condition=[AND(OR(>($0, 2), =($2, _UTF-16LE'A')), >($3, 1))])
    +- LogicalProject(id=[$0], name=[$1], part1=[$2], part2=[$3], virtualField=[+($3, 1)])
-      +- LogicalTableScan(table=[[default_catalog, default_database, MyTable]])
+      +- LogicalTableScan(table=[[default_catalog, default_database, PartitionableTable]])
 ]]>
     </Resource>
     <Resource name="optimized exec plan">
       <![CDATA[
 Calc(select=[id, name, part1, part2, (part2 + 1) AS virtualField], where=[((id > 2) OR (part1 = _UTF-16LE'A':VARCHAR(2147483647) CHARACTER SET "UTF-16LE"))])
-+- TableSourceScan(table=[[default_catalog, default_database, MyTable, filter=[], partitions=[{part1=A, part2=2}, {part1=B, part2=3}]]], fields=[id, name, part1, part2])
++- TableSourceScan(table=[[default_catalog, default_database, PartitionableTable, partitions=[{part1=A, part2=2}, {part1=B, part2=3}], filter=[]]], fields=[id, name, part1, part2])
+]]>
+    </Resource>
+  </TestCase>
+  <TestCase name="testPushDownPartitionAndFiltersContainPartitionKeys[sourceFetchPartitions=false, useCatalogFilter=false]">
+    <Resource name="sql">
+      <![CDATA[select * from PartitionableAndFilterableTable where part1 = 'A' and part2 > 1 and id > 1]]>
+    </Resource>
+    <Resource name="ast">
+      <![CDATA[
+LogicalProject(id=[$0], name=[$1], part1=[$2], part2=[$3], virtualField=[$4])
++- LogicalFilter(condition=[AND(=($2, _UTF-16LE'A'), >($3, 1), >($0, 1))])
+   +- LogicalProject(id=[$0], name=[$1], part1=[$2], part2=[$3], virtualField=[+($3, 1)])
+      +- LogicalTableScan(table=[[test_catalog, test_database, PartitionableAndFilterableTable]])
+]]>
+    </Resource>
+    <Resource name="optimized exec plan">
+      <![CDATA[
+Calc(select=[id, name, CAST(_UTF-16LE'A':VARCHAR(2147483647) CHARACTER SET "UTF-16LE") AS part1, part2, (part2 + 1) AS virtualField])
++- TableSourceScan(table=[[test_catalog, test_database, PartitionableAndFilterableTable, partitions=[{part1=A, part2=2}], filter=[>(id, 1)], project=[id, name, part2], metadata=[]]], fields=[id, name, part2])
+]]>
+    </Resource>
+  </TestCase>
+  <TestCase name="testPushDownPartitionAndFiltersContainPartitionKeys[sourceFetchPartitions=false, useCatalogFilter=true]">
+    <Resource name="sql">
+      <![CDATA[select * from PartitionableAndFilterableTable where part1 = 'A' and part2 > 1 and id > 1]]>
+    </Resource>
+    <Resource name="ast">
+      <![CDATA[
+LogicalProject(id=[$0], name=[$1], part1=[$2], part2=[$3], virtualField=[$4])
++- LogicalFilter(condition=[AND(=($2, _UTF-16LE'A'), >($3, 1), >($0, 1))])
+   +- LogicalProject(id=[$0], name=[$1], part1=[$2], part2=[$3], virtualField=[+($3, 1)])
+      +- LogicalTableScan(table=[[test_catalog, test_database, PartitionableAndFilterableTable]])
+]]>
+    </Resource>
+    <Resource name="optimized exec plan">
+      <![CDATA[
+Calc(select=[id, name, CAST(_UTF-16LE'A':VARCHAR(2147483647) CHARACTER SET "UTF-16LE") AS part1, part2, (part2 + 1) AS virtualField])
++- TableSourceScan(table=[[test_catalog, test_database, PartitionableAndFilterableTable, partitions=[{part1=A, part2=2}], filter=[>(id, 1)], project=[id, name, part2], metadata=[]]], fields=[id, name, part2])
+]]>
+    </Resource>
+  </TestCase>
+  <TestCase name="testPushDownPartitionAndFiltersContainPartitionKeys[sourceFetchPartitions=true, useCatalogFilter=false]">
+    <Resource name="sql">
+      <![CDATA[select * from PartitionableAndFilterableTable where part1 = 'A' and part2 > 1 and id > 1]]>
+    </Resource>
+    <Resource name="ast">
+      <![CDATA[
+LogicalProject(id=[$0], name=[$1], part1=[$2], part2=[$3], virtualField=[$4])
++- LogicalFilter(condition=[AND(=($2, _UTF-16LE'A'), >($3, 1), >($0, 1))])
+   +- LogicalProject(id=[$0], name=[$1], part1=[$2], part2=[$3], virtualField=[+($3, 1)])
+      +- LogicalTableScan(table=[[default_catalog, default_database, PartitionableAndFilterableTable]])
+]]>
+    </Resource>
+    <Resource name="optimized exec plan">
+      <![CDATA[
+Calc(select=[id, name, CAST(_UTF-16LE'A':VARCHAR(2147483647) CHARACTER SET "UTF-16LE") AS part1, part2, (part2 + 1) AS virtualField])
++- TableSourceScan(table=[[default_catalog, default_database, PartitionableAndFilterableTable, partitions=[{part1=A, part2=2}], filter=[>(id, 1)], project=[id, name, part2], metadata=[]]], fields=[id, name, part2])
 ]]>
     </Resource>
   </TestCase>
   <TestCase name="testSimplePartitionFieldPredicate1[sourceFetchPartitions=false, useCatalogFilter=false]">
     <Resource name="sql">
-      <![CDATA[SELECT * FROM MyTable WHERE part1 = 'A']]>
+      <![CDATA[SELECT * FROM PartitionableTable WHERE part1 = 'A']]>
     </Resource>
     <Resource name="ast">
       <![CDATA[
 LogicalProject(id=[$0], name=[$1], part1=[$2], part2=[$3], virtualField=[$4])
 +- LogicalFilter(condition=[=($2, _UTF-16LE'A')])
    +- LogicalProject(id=[$0], name=[$1], part1=[$2], part2=[$3], virtualField=[+($3, 1)])
-      +- LogicalTableScan(table=[[test_catalog, test_database, MyTable]])
+      +- LogicalTableScan(table=[[test_catalog, test_database, PartitionableTable]])
 ]]>
     </Resource>
     <Resource name="optimized exec plan">
       <![CDATA[
 Calc(select=[id, name, CAST(_UTF-16LE'A':VARCHAR(2147483647) CHARACTER SET "UTF-16LE") AS part1, part2, (part2 + 1) AS virtualField])
-+- TableSourceScan(table=[[test_catalog, test_database, MyTable, filter=[], partitions=[{part1=A, part2=1}, {part1=A, part2=2}], project=[id, name, part2], metadata=[]]], fields=[id, name, part2])
++- TableSourceScan(table=[[test_catalog, test_database, PartitionableTable, partitions=[{part1=A, part2=1}, {part1=A, part2=2}], project=[id, name, part2], metadata=[]]], fields=[id, name, part2])
 ]]>
     </Resource>
   </TestCase>
   <TestCase name="testSimplePartitionFieldPredicate1[sourceFetchPartitions=false, useCatalogFilter=true]">
     <Resource name="sql">
-      <![CDATA[SELECT * FROM MyTable WHERE part1 = 'A']]>
+      <![CDATA[SELECT * FROM PartitionableTable WHERE part1 = 'A']]>
     </Resource>
     <Resource name="ast">
       <![CDATA[
 LogicalProject(id=[$0], name=[$1], part1=[$2], part2=[$3], virtualField=[$4])
 +- LogicalFilter(condition=[=($2, _UTF-16LE'A')])
    +- LogicalProject(id=[$0], name=[$1], part1=[$2], part2=[$3], virtualField=[+($3, 1)])
-      +- LogicalTableScan(table=[[test_catalog, test_database, MyTable]])
+      +- LogicalTableScan(table=[[test_catalog, test_database, PartitionableTable]])
 ]]>
     </Resource>
     <Resource name="optimized exec plan">
       <![CDATA[
 Calc(select=[id, name, CAST(_UTF-16LE'A':VARCHAR(2147483647) CHARACTER SET "UTF-16LE") AS part1, part2, (part2 + 1) AS virtualField])
-+- TableSourceScan(table=[[test_catalog, test_database, MyTable, filter=[], partitions=[{part1=A, part2=1}, {part1=A, part2=2}], project=[id, name, part2], metadata=[]]], fields=[id, name, part2])
++- TableSourceScan(table=[[test_catalog, test_database, PartitionableTable, partitions=[{part1=A, part2=1}, {part1=A, part2=2}], project=[id, name, part2], metadata=[]]], fields=[id, name, part2])
 ]]>
     </Resource>
   </TestCase>
   <TestCase name="testSimplePartitionFieldPredicate1[sourceFetchPartitions=true, useCatalogFilter=false]">
     <Resource name="sql">
-      <![CDATA[SELECT * FROM MyTable WHERE part1 = 'A']]>
+      <![CDATA[SELECT * FROM PartitionableTable WHERE part1 = 'A']]>
     </Resource>
     <Resource name="ast">
       <![CDATA[
 LogicalProject(id=[$0], name=[$1], part1=[$2], part2=[$3], virtualField=[$4])
 +- LogicalFilter(condition=[=($2, _UTF-16LE'A')])
    +- LogicalProject(id=[$0], name=[$1], part1=[$2], part2=[$3], virtualField=[+($3, 1)])
-      +- LogicalTableScan(table=[[default_catalog, default_database, MyTable]])
+      +- LogicalTableScan(table=[[default_catalog, default_database, PartitionableTable]])
 ]]>
     </Resource>
     <Resource name="optimized exec plan">
       <![CDATA[
 Calc(select=[id, name, CAST(_UTF-16LE'A':VARCHAR(2147483647) CHARACTER SET "UTF-16LE") AS part1, part2, (part2 + 1) AS virtualField])
-+- TableSourceScan(table=[[default_catalog, default_database, MyTable, filter=[], partitions=[{part1=A, part2=1}, {part1=A, part2=2}], project=[id, name, part2], metadata=[]]], fields=[id, name, part2])
++- TableSourceScan(table=[[default_catalog, default_database, PartitionableTable, partitions=[{part1=A, part2=1}, {part1=A, part2=2}], project=[id, name, part2], metadata=[]]], fields=[id, name, part2])
 ]]>
     </Resource>
   </TestCase>
   <TestCase name="testUnconvertedExpression[sourceFetchPartitions=false, useCatalogFilter=false]">
     <Resource name="sql">
-      <![CDATA[select * from MyTable where trim(part1) = 'A' and part2 > 1]]>
+      <![CDATA[select * from PartitionableTable where trim(part1) = 'A' and part2 > 1]]>
     </Resource>
     <Resource name="ast">
       <![CDATA[
 LogicalProject(id=[$0], name=[$1], part1=[$2], part2=[$3], virtualField=[$4])
 +- LogicalFilter(condition=[AND(=(TRIM(FLAG(BOTH), _UTF-16LE' ', $2), _UTF-16LE'A'), >($3, 1))])
    +- LogicalProject(id=[$0], name=[$1], part1=[$2], part2=[$3], virtualField=[+($3, 1)])
-      +- LogicalTableScan(table=[[test_catalog, test_database, MyTable]])
+      +- LogicalTableScan(table=[[test_catalog, test_database, PartitionableTable]])
 ]]>
     </Resource>
     <Resource name="optimized exec plan">
       <![CDATA[
 Calc(select=[id, name, part1, part2, (part2 + 1) AS virtualField])
-+- TableSourceScan(table=[[test_catalog, test_database, MyTable, filter=[], partitions=[{part1=A, part2=2}]]], fields=[id, name, part1, part2])
++- TableSourceScan(table=[[test_catalog, test_database, PartitionableTable, partitions=[{part1=A, part2=2}]]], fields=[id, name, part1, part2])
 ]]>
     </Resource>
   </TestCase>
   <TestCase name="testUnconvertedExpression[sourceFetchPartitions=false, useCatalogFilter=true]">
     <Resource name="sql">
-      <![CDATA[select * from MyTable where trim(part1) = 'A' and part2 > 1]]>
+      <![CDATA[select * from PartitionableTable where trim(part1) = 'A' and part2 > 1]]>
     </Resource>
     <Resource name="ast">
       <![CDATA[
 LogicalProject(id=[$0], name=[$1], part1=[$2], part2=[$3], virtualField=[$4])
 +- LogicalFilter(condition=[AND(=(TRIM(FLAG(BOTH), _UTF-16LE' ', $2), _UTF-16LE'A'), >($3, 1))])
    +- LogicalProject(id=[$0], name=[$1], part1=[$2], part2=[$3], virtualField=[+($3, 1)])
-      +- LogicalTableScan(table=[[test_catalog, test_database, MyTable]])
+      +- LogicalTableScan(table=[[test_catalog, test_database, PartitionableTable]])
 ]]>
     </Resource>
     <Resource name="optimized exec plan">
       <![CDATA[
 Calc(select=[id, name, part1, part2, (part2 + 1) AS virtualField])
-+- TableSourceScan(table=[[test_catalog, test_database, MyTable, filter=[], partitions=[{part1=A, part2=2}]]], fields=[id, name, part1, part2])
++- TableSourceScan(table=[[test_catalog, test_database, PartitionableTable, partitions=[{part1=A, part2=2}]]], fields=[id, name, part1, part2])
 ]]>
     </Resource>
   </TestCase>
   <TestCase name="testWithUdfAndVirtualColumn[sourceFetchPartitions=true, useCatalogFilter=false]">
     <Resource name="sql">
-      <![CDATA[SELECT * FROM MyTable WHERE id > 2 AND MyUdf(part2) < 3]]>
+      <![CDATA[SELECT * FROM PartitionableTable WHERE id > 2 AND MyUdf(part2) < 3]]>
     </Resource>
     <Resource name="ast">
       <![CDATA[
 LogicalProject(id=[$0], name=[$1], part1=[$2], part2=[$3], virtualField=[$4])
 +- LogicalFilter(condition=[AND(>($0, 2), <(MyUdf($3), 3))])
    +- LogicalProject(id=[$0], name=[$1], part1=[$2], part2=[$3], virtualField=[+($3, 1)])
-      +- LogicalTableScan(table=[[default_catalog, default_database, MyTable]])
+      +- LogicalTableScan(table=[[default_catalog, default_database, PartitionableTable]])
 ]]>
     </Resource>
     <Resource name="optimized exec plan">
       <![CDATA[
 Calc(select=[id, name, part1, part2, (part2 + 1) AS virtualField], where=[(id > 2)])
-+- TableSourceScan(table=[[default_catalog, default_database, MyTable, filter=[], partitions=[{part1=A, part2=1}, {part1=C, part2=1}]]], fields=[id, name, part1, part2])
++- TableSourceScan(table=[[default_catalog, default_database, PartitionableTable, partitions=[{part1=A, part2=1}, {part1=C, part2=1}], filter=[]]], fields=[id, name, part1, part2])
 ]]>
     </Resource>
   </TestCase>
   <TestCase name="testUnconvertedExpression[sourceFetchPartitions=true, useCatalogFilter=false]">
     <Resource name="sql">
-      <![CDATA[select * from MyTable where trim(part1) = 'A' and part2 > 1]]>
+      <![CDATA[select * from PartitionableTable where trim(part1) = 'A' and part2 > 1]]>
     </Resource>
     <Resource name="ast">
       <![CDATA[
 LogicalProject(id=[$0], name=[$1], part1=[$2], part2=[$3], virtualField=[$4])
 +- LogicalFilter(condition=[AND(=(TRIM(FLAG(BOTH), _UTF-16LE' ', $2), _UTF-16LE'A'), >($3, 1))])
    +- LogicalProject(id=[$0], name=[$1], part1=[$2], part2=[$3], virtualField=[+($3, 1)])
-      +- LogicalTableScan(table=[[default_catalog, default_database, MyTable]])
+      +- LogicalTableScan(table=[[default_catalog, default_database, PartitionableTable]])
 ]]>
     </Resource>
     <Resource name="optimized exec plan">
       <![CDATA[
 Calc(select=[id, name, part1, part2, (part2 + 1) AS virtualField])
-+- TableSourceScan(table=[[default_catalog, default_database, MyTable, filter=[], partitions=[{part1=A, part2=2}]]], fields=[id, name, part1, part2])
++- TableSourceScan(table=[[default_catalog, default_database, PartitionableTable, partitions=[{part1=A, part2=2}]]], fields=[id, name, part1, part2])
 ]]>
     </Resource>
   </TestCase>
   <TestCase name="testWithUdfAndVirtualColumn[sourceFetchPartitions=false, useCatalogFilter=false]">
     <Resource name="sql">
-      <![CDATA[SELECT * FROM MyTable WHERE id > 2 AND MyUdf(part2) < 3]]>
+      <![CDATA[SELECT * FROM PartitionableTable WHERE id > 2 AND MyUdf(part2) < 3]]>
     </Resource>
     <Resource name="ast">
       <![CDATA[
 LogicalProject(id=[$0], name=[$1], part1=[$2], part2=[$3], virtualField=[$4])
 +- LogicalFilter(condition=[AND(>($0, 2), <(MyUdf($3), 3))])
    +- LogicalProject(id=[$0], name=[$1], part1=[$2], part2=[$3], virtualField=[+($3, 1)])
-      +- LogicalTableScan(table=[[test_catalog, test_database, MyTable]])
+      +- LogicalTableScan(table=[[test_catalog, test_database, PartitionableTable]])
 ]]>
     </Resource>
     <Resource name="optimized exec plan">
       <![CDATA[
 Calc(select=[id, name, part1, part2, (part2 + 1) AS virtualField], where=[(id > 2)])
-+- TableSourceScan(table=[[test_catalog, test_database, MyTable, filter=[], partitions=[{part1=A, part2=1}, {part1=C, part2=1}]]], fields=[id, name, part1, part2])
++- TableSourceScan(table=[[test_catalog, test_database, PartitionableTable, partitions=[{part1=A, part2=1}, {part1=C, part2=1}], filter=[]]], fields=[id, name, part1, part2])
 ]]>
     </Resource>
   </TestCase>
   <TestCase name="testWithUdfAndVirtualColumn[sourceFetchPartitions=false, useCatalogFilter=true]">
     <Resource name="sql">
-      <![CDATA[SELECT * FROM MyTable WHERE id > 2 AND MyUdf(part2) < 3]]>
+      <![CDATA[SELECT * FROM PartitionableTable WHERE id > 2 AND MyUdf(part2) < 3]]>
     </Resource>
     <Resource name="ast">
       <![CDATA[
 LogicalProject(id=[$0], name=[$1], part1=[$2], part2=[$3], virtualField=[$4])
 +- LogicalFilter(condition=[AND(>($0, 2), <(MyUdf($3), 3))])
    +- LogicalProject(id=[$0], name=[$1], part1=[$2], part2=[$3], virtualField=[+($3, 1)])
-      +- LogicalTableScan(table=[[test_catalog, test_database, MyTable]])
+      +- LogicalTableScan(table=[[test_catalog, test_database, PartitionableTable]])
 ]]>
     </Resource>
     <Resource name="optimized exec plan">
       <![CDATA[
 Calc(select=[id, name, part1, part2, (part2 + 1) AS virtualField], where=[(id > 2)])
-+- TableSourceScan(table=[[test_catalog, test_database, MyTable, filter=[], partitions=[{part1=A, part2=1}, {part1=C, part2=1}]]], fields=[id, name, part1, part2])
++- TableSourceScan(table=[[test_catalog, test_database, PartitionableTable, partitions=[{part1=A, part2=1}, {part1=C, part2=1}], filter=[]]], fields=[id, name, part1, part2])
 ]]>
     </Resource>
   </TestCase>

--- a/flink-table/flink-table-planner/src/test/resources/org/apache/flink/table/planner/plan/batch/sql/PartitionableSourceTest.xml
+++ b/flink-table/flink-table-planner/src/test/resources/org/apache/flink/table/planner/plan/batch/sql/PartitionableSourceTest.xml
@@ -130,6 +130,60 @@ Calc(select=[id, name, CAST(_UTF-16LE'A':VARCHAR(2147483647) CHARACTER SET "UTF-
 ]]>
     </Resource>
   </TestCase>
+  <TestCase name="testPushDownPartitionAndFiltersContainPartitionKeysWithSingleProjection[sourceFetchPartitions=false, useCatalogFilter=false]">
+    <Resource name="sql">
+      <![CDATA[select name from PartitionableAndFilterableTable where part1 = 'A' and part2 > 1 and id > 1]]>
+    </Resource>
+    <Resource name="ast">
+      <![CDATA[
+LogicalProject(name=[$1])
++- LogicalFilter(condition=[AND(=($2, _UTF-16LE'A'), >($3, 1), >($0, 1))])
+   +- LogicalProject(id=[$0], name=[$1], part1=[$2], part2=[$3], virtualField=[+($3, 1)])
+      +- LogicalTableScan(table=[[test_catalog, test_database, PartitionableAndFilterableTable]])
+]]>
+    </Resource>
+    <Resource name="optimized exec plan">
+      <![CDATA[
+TableSourceScan(table=[[test_catalog, test_database, PartitionableAndFilterableTable, partitions=[{part1=A, part2=2}], filter=[>(id, 1)], project=[name], metadata=[]]], fields=[name])
+]]>
+    </Resource>
+  </TestCase>
+  <TestCase name="testPushDownPartitionAndFiltersContainPartitionKeysWithSingleProjection[sourceFetchPartitions=false, useCatalogFilter=true]">
+    <Resource name="sql">
+      <![CDATA[select name from PartitionableAndFilterableTable where part1 = 'A' and part2 > 1 and id > 1]]>
+    </Resource>
+    <Resource name="ast">
+      <![CDATA[
+LogicalProject(name=[$1])
++- LogicalFilter(condition=[AND(=($2, _UTF-16LE'A'), >($3, 1), >($0, 1))])
+   +- LogicalProject(id=[$0], name=[$1], part1=[$2], part2=[$3], virtualField=[+($3, 1)])
+      +- LogicalTableScan(table=[[test_catalog, test_database, PartitionableAndFilterableTable]])
+]]>
+    </Resource>
+    <Resource name="optimized exec plan">
+      <![CDATA[
+TableSourceScan(table=[[test_catalog, test_database, PartitionableAndFilterableTable, partitions=[{part1=A, part2=2}], filter=[>(id, 1)], project=[name], metadata=[]]], fields=[name])
+]]>
+    </Resource>
+  </TestCase>
+  <TestCase name="testPushDownPartitionAndFiltersContainPartitionKeysWithSingleProjection[sourceFetchPartitions=true, useCatalogFilter=false]">
+    <Resource name="sql">
+      <![CDATA[select name from PartitionableAndFilterableTable where part1 = 'A' and part2 > 1 and id > 1]]>
+    </Resource>
+    <Resource name="ast">
+      <![CDATA[
+LogicalProject(name=[$1])
++- LogicalFilter(condition=[AND(=($2, _UTF-16LE'A'), >($3, 1), >($0, 1))])
+   +- LogicalProject(id=[$0], name=[$1], part1=[$2], part2=[$3], virtualField=[+($3, 1)])
+      +- LogicalTableScan(table=[[default_catalog, default_database, PartitionableAndFilterableTable]])
+]]>
+    </Resource>
+    <Resource name="optimized exec plan">
+      <![CDATA[
+TableSourceScan(table=[[default_catalog, default_database, PartitionableAndFilterableTable, partitions=[{part1=A, part2=2}], filter=[>(id, 1)], project=[name], metadata=[]]], fields=[name])
+]]>
+    </Resource>
+  </TestCase>
   <TestCase name="testSimplePartitionFieldPredicate1[sourceFetchPartitions=false, useCatalogFilter=false]">
     <Resource name="sql">
       <![CDATA[SELECT * FROM PartitionableTable WHERE part1 = 'A']]>

--- a/flink-table/flink-table-planner/src/test/resources/org/apache/flink/table/planner/plan/nodes/exec/stream/TableSourceJsonPlanTest_jsonplan/testPartitionPushDown.out
+++ b/flink-table/flink-table-planner/src/test/resources/org/apache/flink/table/planner/plan/nodes/exec/stream/TableSourceJsonPlanTest_jsonplan/testPartitionPushDown.out
@@ -21,9 +21,6 @@
         "partition.keys.0.name" : "p"
       },
       "sourceAbilitySpecs" : [ {
-        "type" : "FilterPushDown",
-        "predicates" : [ ]
-      }, {
         "type" : "PartitionPushDown",
         "partitions" : [ {
           "p" : "A"
@@ -64,7 +61,7 @@
         "b" : "INT"
       } ]
     },
-    "description" : "TableSourceScan(table=[[default_catalog, default_database, PartitionTable, filter=[], partitions=[{p=A}], project=[a, b], metadata=[]]], fields=[a, b])",
+    "description" : "TableSourceScan(table=[[default_catalog, default_database, PartitionTable, partitions=[{p=A}], project=[a, b], metadata=[]]], fields=[a, b])",
     "inputProperties" : [ ]
   }, {
     "class" : "org.apache.flink.table.planner.plan.nodes.exec.stream.StreamExecCalc",

--- a/flink-table/flink-table-planner/src/test/resources/org/apache/flink/table/planner/plan/rules/physical/batch/PushLocalAggIntoTableSourceScanRuleTest.xml
+++ b/flink-table/flink-table-planner/src/test/resources/org/apache/flink/table/planner/plan/rules/physical/batch/PushLocalAggIntoTableSourceScanRuleTest.xml
@@ -250,7 +250,7 @@ LogicalProject(EXPR$0=[$2], type=[$0], name=[$1])
 Calc(select=[EXPR$0, type, name])
 +- HashAggregate(isMerge=[true], groupBy=[type, name], select=[type, name, Final_SUM(sum$0) AS EXPR$0])
    +- Exchange(distribution=[hash[type, name]])
-      +- TableSourceScan(table=[[default_catalog, default_database, inventory_part, filter=[=(id, 123:BIGINT)], partitions=[{type=a}, {type=b}], project=[type, name, amount], metadata=[], aggregates=[grouping=[type,name], aggFunctions=[LongSumAggFunction(amount)]]]], fields=[type, name, sum$0])
+      +- TableSourceScan(table=[[default_catalog, default_database, inventory_part, partitions=[{type=a}, {type=b}], filter=[=(id, 123:BIGINT)], project=[type, name, amount], metadata=[], aggregates=[grouping=[type,name], aggFunctions=[LongSumAggFunction(amount)]]]], fields=[type, name, sum$0])
 ]]>
     </Resource>
   </TestCase>

--- a/flink-table/flink-table-planner/src/test/resources/org/apache/flink/table/planner/plan/stream/sql/PartitionableSourceTest.xml
+++ b/flink-table/flink-table-planner/src/test/resources/org/apache/flink/table/planner/plan/stream/sql/PartitionableSourceTest.xml
@@ -18,229 +18,286 @@ limitations under the License.
 <Root>
   <TestCase name="testPartialPartitionFieldPredicatePushDown[sourceFetchPartitions=false, useCatalogFilter=false]">
     <Resource name="sql">
-      <![CDATA[SELECT * FROM MyTable WHERE (id > 2 OR part1 = 'A') AND part2 > 1]]>
+      <![CDATA[SELECT * FROM PartitionableTable WHERE (id > 2 OR part1 = 'A') AND part2 > 1]]>
     </Resource>
     <Resource name="ast">
       <![CDATA[
 LogicalProject(id=[$0], name=[$1], part1=[$2], part2=[$3], virtualField=[$4])
 +- LogicalFilter(condition=[AND(OR(>($0, 2), =($2, _UTF-16LE'A')), >($3, 1))])
    +- LogicalProject(id=[$0], name=[$1], part1=[$2], part2=[$3], virtualField=[+($3, 1)])
-      +- LogicalTableScan(table=[[test_catalog, test_database, MyTable]])
+      +- LogicalTableScan(table=[[test_catalog, test_database, PartitionableTable]])
 ]]>
     </Resource>
     <Resource name="optimized exec plan">
       <![CDATA[
 Calc(select=[id, name, part1, part2, (part2 + 1) AS virtualField], where=[((id > 2) OR (part1 = _UTF-16LE'A':VARCHAR(2147483647) CHARACTER SET "UTF-16LE"))])
-+- TableSourceScan(table=[[test_catalog, test_database, MyTable, filter=[], partitions=[{part1=A, part2=2}, {part1=B, part2=3}]]], fields=[id, name, part1, part2])
++- TableSourceScan(table=[[test_catalog, test_database, PartitionableTable, partitions=[{part1=A, part2=2}, {part1=B, part2=3}], filter=[]]], fields=[id, name, part1, part2])
 ]]>
     </Resource>
   </TestCase>
   <TestCase name="testPartialPartitionFieldPredicatePushDown[sourceFetchPartitions=false, useCatalogFilter=true]">
     <Resource name="sql">
-      <![CDATA[SELECT * FROM MyTable WHERE (id > 2 OR part1 = 'A') AND part2 > 1]]>
+      <![CDATA[SELECT * FROM PartitionableTable WHERE (id > 2 OR part1 = 'A') AND part2 > 1]]>
     </Resource>
     <Resource name="ast">
       <![CDATA[
 LogicalProject(id=[$0], name=[$1], part1=[$2], part2=[$3], virtualField=[$4])
 +- LogicalFilter(condition=[AND(OR(>($0, 2), =($2, _UTF-16LE'A')), >($3, 1))])
    +- LogicalProject(id=[$0], name=[$1], part1=[$2], part2=[$3], virtualField=[+($3, 1)])
-      +- LogicalTableScan(table=[[test_catalog, test_database, MyTable]])
+      +- LogicalTableScan(table=[[test_catalog, test_database, PartitionableTable]])
 ]]>
     </Resource>
     <Resource name="optimized exec plan">
       <![CDATA[
 Calc(select=[id, name, part1, part2, (part2 + 1) AS virtualField], where=[((id > 2) OR (part1 = _UTF-16LE'A':VARCHAR(2147483647) CHARACTER SET "UTF-16LE"))])
-+- TableSourceScan(table=[[test_catalog, test_database, MyTable, filter=[], partitions=[{part1=A, part2=2}, {part1=B, part2=3}]]], fields=[id, name, part1, part2])
++- TableSourceScan(table=[[test_catalog, test_database, PartitionableTable, partitions=[{part1=A, part2=2}, {part1=B, part2=3}], filter=[]]], fields=[id, name, part1, part2])
 ]]>
     </Resource>
   </TestCase>
   <TestCase name="testPartialPartitionFieldPredicatePushDown[sourceFetchPartitions=true, useCatalogFilter=false]">
     <Resource name="sql">
-      <![CDATA[SELECT * FROM MyTable WHERE (id > 2 OR part1 = 'A') AND part2 > 1]]>
+      <![CDATA[SELECT * FROM PartitionableTable WHERE (id > 2 OR part1 = 'A') AND part2 > 1]]>
     </Resource>
     <Resource name="ast">
       <![CDATA[
 LogicalProject(id=[$0], name=[$1], part1=[$2], part2=[$3], virtualField=[$4])
 +- LogicalFilter(condition=[AND(OR(>($0, 2), =($2, _UTF-16LE'A')), >($3, 1))])
    +- LogicalProject(id=[$0], name=[$1], part1=[$2], part2=[$3], virtualField=[+($3, 1)])
-      +- LogicalTableScan(table=[[default_catalog, default_database, MyTable]])
+      +- LogicalTableScan(table=[[default_catalog, default_database, PartitionableTable]])
 ]]>
     </Resource>
     <Resource name="optimized exec plan">
       <![CDATA[
 Calc(select=[id, name, part1, part2, (part2 + 1) AS virtualField], where=[((id > 2) OR (part1 = _UTF-16LE'A':VARCHAR(2147483647) CHARACTER SET "UTF-16LE"))])
-+- TableSourceScan(table=[[default_catalog, default_database, MyTable, filter=[], partitions=[{part1=A, part2=2}, {part1=B, part2=3}]]], fields=[id, name, part1, part2])
++- TableSourceScan(table=[[default_catalog, default_database, PartitionableTable, partitions=[{part1=A, part2=2}, {part1=B, part2=3}], filter=[]]], fields=[id, name, part1, part2])
+]]>
+    </Resource>
+  </TestCase>
+  <TestCase name="testPushDownPartitionAndFiltersContainPartitionKeys[sourceFetchPartitions=false, useCatalogFilter=false]">
+    <Resource name="sql">
+      <![CDATA[select * from PartitionableAndFilterableTable where part1 = 'A' and part2 > 1 and id > 1]]>
+    </Resource>
+    <Resource name="ast">
+      <![CDATA[
+LogicalProject(id=[$0], name=[$1], part1=[$2], part2=[$3], virtualField=[$4])
++- LogicalFilter(condition=[AND(=($2, _UTF-16LE'A'), >($3, 1), >($0, 1))])
+   +- LogicalProject(id=[$0], name=[$1], part1=[$2], part2=[$3], virtualField=[+($3, 1)])
+      +- LogicalTableScan(table=[[test_catalog, test_database, PartitionableAndFilterableTable]])
+]]>
+    </Resource>
+    <Resource name="optimized exec plan">
+      <![CDATA[
+Calc(select=[id, name, CAST(_UTF-16LE'A':VARCHAR(2147483647) CHARACTER SET "UTF-16LE") AS part1, part2, (part2 + 1) AS virtualField])
++- TableSourceScan(table=[[test_catalog, test_database, PartitionableAndFilterableTable, partitions=[{part1=A, part2=2}], filter=[>(id, 1)], project=[id, name, part2], metadata=[]]], fields=[id, name, part2])
+]]>
+    </Resource>
+  </TestCase>
+  <TestCase name="testPushDownPartitionAndFiltersContainPartitionKeys[sourceFetchPartitions=false, useCatalogFilter=true]">
+    <Resource name="sql">
+      <![CDATA[select * from PartitionableAndFilterableTable where part1 = 'A' and part2 > 1 and id > 1]]>
+    </Resource>
+    <Resource name="ast">
+      <![CDATA[
+LogicalProject(id=[$0], name=[$1], part1=[$2], part2=[$3], virtualField=[$4])
++- LogicalFilter(condition=[AND(=($2, _UTF-16LE'A'), >($3, 1), >($0, 1))])
+   +- LogicalProject(id=[$0], name=[$1], part1=[$2], part2=[$3], virtualField=[+($3, 1)])
+      +- LogicalTableScan(table=[[test_catalog, test_database, PartitionableAndFilterableTable]])
+]]>
+    </Resource>
+    <Resource name="optimized exec plan">
+      <![CDATA[
+Calc(select=[id, name, CAST(_UTF-16LE'A':VARCHAR(2147483647) CHARACTER SET "UTF-16LE") AS part1, part2, (part2 + 1) AS virtualField])
++- TableSourceScan(table=[[test_catalog, test_database, PartitionableAndFilterableTable, partitions=[{part1=A, part2=2}], filter=[>(id, 1)], project=[id, name, part2], metadata=[]]], fields=[id, name, part2])
+]]>
+    </Resource>
+  </TestCase>
+  <TestCase name="testPushDownPartitionAndFiltersContainPartitionKeys[sourceFetchPartitions=true, useCatalogFilter=false]">
+    <Resource name="sql">
+      <![CDATA[select * from PartitionableAndFilterableTable where part1 = 'A' and part2 > 1 and id > 1]]>
+    </Resource>
+    <Resource name="ast">
+      <![CDATA[
+LogicalProject(id=[$0], name=[$1], part1=[$2], part2=[$3], virtualField=[$4])
++- LogicalFilter(condition=[AND(=($2, _UTF-16LE'A'), >($3, 1), >($0, 1))])
+   +- LogicalProject(id=[$0], name=[$1], part1=[$2], part2=[$3], virtualField=[+($3, 1)])
+      +- LogicalTableScan(table=[[default_catalog, default_database, PartitionableAndFilterableTable]])
+]]>
+    </Resource>
+    <Resource name="optimized exec plan">
+      <![CDATA[
+Calc(select=[id, name, CAST(_UTF-16LE'A':VARCHAR(2147483647) CHARACTER SET "UTF-16LE") AS part1, part2, (part2 + 1) AS virtualField])
++- TableSourceScan(table=[[default_catalog, default_database, PartitionableAndFilterableTable, partitions=[{part1=A, part2=2}], filter=[>(id, 1)], project=[id, name, part2], metadata=[]]], fields=[id, name, part2])
 ]]>
     </Resource>
   </TestCase>
   <TestCase name="testSimplePartitionFieldPredicate1[sourceFetchPartitions=false, useCatalogFilter=false]">
     <Resource name="sql">
-      <![CDATA[SELECT * FROM MyTable WHERE part1 = 'A']]>
+      <![CDATA[SELECT * FROM PartitionableTable WHERE part1 = 'A']]>
     </Resource>
     <Resource name="ast">
       <![CDATA[
 LogicalProject(id=[$0], name=[$1], part1=[$2], part2=[$3], virtualField=[$4])
 +- LogicalFilter(condition=[=($2, _UTF-16LE'A')])
    +- LogicalProject(id=[$0], name=[$1], part1=[$2], part2=[$3], virtualField=[+($3, 1)])
-      +- LogicalTableScan(table=[[test_catalog, test_database, MyTable]])
+      +- LogicalTableScan(table=[[test_catalog, test_database, PartitionableTable]])
 ]]>
     </Resource>
     <Resource name="optimized exec plan">
       <![CDATA[
 Calc(select=[id, name, CAST(_UTF-16LE'A':VARCHAR(2147483647) CHARACTER SET "UTF-16LE") AS part1, part2, (part2 + 1) AS virtualField])
-+- TableSourceScan(table=[[test_catalog, test_database, MyTable, filter=[], partitions=[{part1=A, part2=1}, {part1=A, part2=2}], project=[id, name, part2], metadata=[]]], fields=[id, name, part2])
++- TableSourceScan(table=[[test_catalog, test_database, PartitionableTable, partitions=[{part1=A, part2=1}, {part1=A, part2=2}], project=[id, name, part2], metadata=[]]], fields=[id, name, part2])
 ]]>
     </Resource>
   </TestCase>
   <TestCase name="testSimplePartitionFieldPredicate1[sourceFetchPartitions=false, useCatalogFilter=true]">
     <Resource name="sql">
-      <![CDATA[SELECT * FROM MyTable WHERE part1 = 'A']]>
+      <![CDATA[SELECT * FROM PartitionableTable WHERE part1 = 'A']]>
     </Resource>
     <Resource name="ast">
       <![CDATA[
 LogicalProject(id=[$0], name=[$1], part1=[$2], part2=[$3], virtualField=[$4])
 +- LogicalFilter(condition=[=($2, _UTF-16LE'A')])
    +- LogicalProject(id=[$0], name=[$1], part1=[$2], part2=[$3], virtualField=[+($3, 1)])
-      +- LogicalTableScan(table=[[test_catalog, test_database, MyTable]])
+      +- LogicalTableScan(table=[[test_catalog, test_database, PartitionableTable]])
 ]]>
     </Resource>
     <Resource name="optimized exec plan">
       <![CDATA[
 Calc(select=[id, name, CAST(_UTF-16LE'A':VARCHAR(2147483647) CHARACTER SET "UTF-16LE") AS part1, part2, (part2 + 1) AS virtualField])
-+- TableSourceScan(table=[[test_catalog, test_database, MyTable, filter=[], partitions=[{part1=A, part2=1}, {part1=A, part2=2}], project=[id, name, part2], metadata=[]]], fields=[id, name, part2])
++- TableSourceScan(table=[[test_catalog, test_database, PartitionableTable, partitions=[{part1=A, part2=1}, {part1=A, part2=2}], project=[id, name, part2], metadata=[]]], fields=[id, name, part2])
 ]]>
     </Resource>
   </TestCase>
   <TestCase name="testSimplePartitionFieldPredicate1[sourceFetchPartitions=true, useCatalogFilter=false]">
     <Resource name="sql">
-      <![CDATA[SELECT * FROM MyTable WHERE part1 = 'A']]>
+      <![CDATA[SELECT * FROM PartitionableTable WHERE part1 = 'A']]>
     </Resource>
     <Resource name="ast">
       <![CDATA[
 LogicalProject(id=[$0], name=[$1], part1=[$2], part2=[$3], virtualField=[$4])
 +- LogicalFilter(condition=[=($2, _UTF-16LE'A')])
    +- LogicalProject(id=[$0], name=[$1], part1=[$2], part2=[$3], virtualField=[+($3, 1)])
-      +- LogicalTableScan(table=[[default_catalog, default_database, MyTable]])
+      +- LogicalTableScan(table=[[default_catalog, default_database, PartitionableTable]])
 ]]>
     </Resource>
     <Resource name="optimized exec plan">
       <![CDATA[
 Calc(select=[id, name, CAST(_UTF-16LE'A':VARCHAR(2147483647) CHARACTER SET "UTF-16LE") AS part1, part2, (part2 + 1) AS virtualField])
-+- TableSourceScan(table=[[default_catalog, default_database, MyTable, filter=[], partitions=[{part1=A, part2=1}, {part1=A, part2=2}], project=[id, name, part2], metadata=[]]], fields=[id, name, part2])
++- TableSourceScan(table=[[default_catalog, default_database, PartitionableTable, partitions=[{part1=A, part2=1}, {part1=A, part2=2}], project=[id, name, part2], metadata=[]]], fields=[id, name, part2])
 ]]>
     </Resource>
   </TestCase>
   <TestCase name="testUnconvertedExpression[sourceFetchPartitions=false, useCatalogFilter=false]">
     <Resource name="sql">
-      <![CDATA[select * from MyTable where trim(part1) = 'A' and part2 > 1]]>
+      <![CDATA[select * from PartitionableTable where trim(part1) = 'A' and part2 > 1]]>
     </Resource>
     <Resource name="ast">
       <![CDATA[
 LogicalProject(id=[$0], name=[$1], part1=[$2], part2=[$3], virtualField=[$4])
 +- LogicalFilter(condition=[AND(=(TRIM(FLAG(BOTH), _UTF-16LE' ', $2), _UTF-16LE'A'), >($3, 1))])
    +- LogicalProject(id=[$0], name=[$1], part1=[$2], part2=[$3], virtualField=[+($3, 1)])
-      +- LogicalTableScan(table=[[test_catalog, test_database, MyTable]])
+      +- LogicalTableScan(table=[[test_catalog, test_database, PartitionableTable]])
 ]]>
     </Resource>
     <Resource name="optimized exec plan">
       <![CDATA[
 Calc(select=[id, name, part1, part2, (part2 + 1) AS virtualField])
-+- TableSourceScan(table=[[test_catalog, test_database, MyTable, filter=[], partitions=[{part1=A, part2=2}]]], fields=[id, name, part1, part2])
++- TableSourceScan(table=[[test_catalog, test_database, PartitionableTable, partitions=[{part1=A, part2=2}]]], fields=[id, name, part1, part2])
 ]]>
     </Resource>
   </TestCase>
   <TestCase name="testUnconvertedExpression[sourceFetchPartitions=false, useCatalogFilter=true]">
     <Resource name="sql">
-      <![CDATA[select * from MyTable where trim(part1) = 'A' and part2 > 1]]>
+      <![CDATA[select * from PartitionableTable where trim(part1) = 'A' and part2 > 1]]>
     </Resource>
     <Resource name="ast">
       <![CDATA[
 LogicalProject(id=[$0], name=[$1], part1=[$2], part2=[$3], virtualField=[$4])
 +- LogicalFilter(condition=[AND(=(TRIM(FLAG(BOTH), _UTF-16LE' ', $2), _UTF-16LE'A'), >($3, 1))])
    +- LogicalProject(id=[$0], name=[$1], part1=[$2], part2=[$3], virtualField=[+($3, 1)])
-      +- LogicalTableScan(table=[[test_catalog, test_database, MyTable]])
+      +- LogicalTableScan(table=[[test_catalog, test_database, PartitionableTable]])
 ]]>
     </Resource>
     <Resource name="optimized exec plan">
       <![CDATA[
 Calc(select=[id, name, part1, part2, (part2 + 1) AS virtualField])
-+- TableSourceScan(table=[[test_catalog, test_database, MyTable, filter=[], partitions=[{part1=A, part2=2}]]], fields=[id, name, part1, part2])
++- TableSourceScan(table=[[test_catalog, test_database, PartitionableTable, partitions=[{part1=A, part2=2}]]], fields=[id, name, part1, part2])
 ]]>
     </Resource>
   </TestCase>
   <TestCase name="testWithUdfAndVirtualColumn[sourceFetchPartitions=true, useCatalogFilter=false]">
     <Resource name="sql">
-      <![CDATA[SELECT * FROM MyTable WHERE id > 2 AND MyUdf(part2) < 3]]>
+      <![CDATA[SELECT * FROM PartitionableTable WHERE id > 2 AND MyUdf(part2) < 3]]>
     </Resource>
     <Resource name="ast">
       <![CDATA[
 LogicalProject(id=[$0], name=[$1], part1=[$2], part2=[$3], virtualField=[$4])
 +- LogicalFilter(condition=[AND(>($0, 2), <(MyUdf($3), 3))])
    +- LogicalProject(id=[$0], name=[$1], part1=[$2], part2=[$3], virtualField=[+($3, 1)])
-      +- LogicalTableScan(table=[[default_catalog, default_database, MyTable]])
+      +- LogicalTableScan(table=[[default_catalog, default_database, PartitionableTable]])
 ]]>
     </Resource>
     <Resource name="optimized exec plan">
       <![CDATA[
 Calc(select=[id, name, part1, part2, (part2 + 1) AS virtualField], where=[(id > 2)])
-+- TableSourceScan(table=[[default_catalog, default_database, MyTable, filter=[], partitions=[{part1=A, part2=1}, {part1=C, part2=1}]]], fields=[id, name, part1, part2])
++- TableSourceScan(table=[[default_catalog, default_database, PartitionableTable, partitions=[{part1=A, part2=1}, {part1=C, part2=1}], filter=[]]], fields=[id, name, part1, part2])
 ]]>
     </Resource>
   </TestCase>
   <TestCase name="testUnconvertedExpression[sourceFetchPartitions=true, useCatalogFilter=false]">
     <Resource name="sql">
-      <![CDATA[select * from MyTable where trim(part1) = 'A' and part2 > 1]]>
+      <![CDATA[select * from PartitionableTable where trim(part1) = 'A' and part2 > 1]]>
     </Resource>
     <Resource name="ast">
       <![CDATA[
 LogicalProject(id=[$0], name=[$1], part1=[$2], part2=[$3], virtualField=[$4])
 +- LogicalFilter(condition=[AND(=(TRIM(FLAG(BOTH), _UTF-16LE' ', $2), _UTF-16LE'A'), >($3, 1))])
    +- LogicalProject(id=[$0], name=[$1], part1=[$2], part2=[$3], virtualField=[+($3, 1)])
-      +- LogicalTableScan(table=[[default_catalog, default_database, MyTable]])
+      +- LogicalTableScan(table=[[default_catalog, default_database, PartitionableTable]])
 ]]>
     </Resource>
     <Resource name="optimized exec plan">
       <![CDATA[
 Calc(select=[id, name, part1, part2, (part2 + 1) AS virtualField])
-+- TableSourceScan(table=[[default_catalog, default_database, MyTable, filter=[], partitions=[{part1=A, part2=2}]]], fields=[id, name, part1, part2])
++- TableSourceScan(table=[[default_catalog, default_database, PartitionableTable, partitions=[{part1=A, part2=2}]]], fields=[id, name, part1, part2])
 ]]>
     </Resource>
   </TestCase>
   <TestCase name="testWithUdfAndVirtualColumn[sourceFetchPartitions=false, useCatalogFilter=false]">
     <Resource name="sql">
-      <![CDATA[SELECT * FROM MyTable WHERE id > 2 AND MyUdf(part2) < 3]]>
+      <![CDATA[SELECT * FROM PartitionableTable WHERE id > 2 AND MyUdf(part2) < 3]]>
     </Resource>
     <Resource name="ast">
       <![CDATA[
 LogicalProject(id=[$0], name=[$1], part1=[$2], part2=[$3], virtualField=[$4])
 +- LogicalFilter(condition=[AND(>($0, 2), <(MyUdf($3), 3))])
    +- LogicalProject(id=[$0], name=[$1], part1=[$2], part2=[$3], virtualField=[+($3, 1)])
-      +- LogicalTableScan(table=[[test_catalog, test_database, MyTable]])
+      +- LogicalTableScan(table=[[test_catalog, test_database, PartitionableTable]])
 ]]>
     </Resource>
     <Resource name="optimized exec plan">
       <![CDATA[
 Calc(select=[id, name, part1, part2, (part2 + 1) AS virtualField], where=[(id > 2)])
-+- TableSourceScan(table=[[test_catalog, test_database, MyTable, filter=[], partitions=[{part1=A, part2=1}, {part1=C, part2=1}]]], fields=[id, name, part1, part2])
++- TableSourceScan(table=[[test_catalog, test_database, PartitionableTable, partitions=[{part1=A, part2=1}, {part1=C, part2=1}], filter=[]]], fields=[id, name, part1, part2])
 ]]>
     </Resource>
   </TestCase>
   <TestCase name="testWithUdfAndVirtualColumn[sourceFetchPartitions=false, useCatalogFilter=true]">
     <Resource name="sql">
-      <![CDATA[SELECT * FROM MyTable WHERE id > 2 AND MyUdf(part2) < 3]]>
+      <![CDATA[SELECT * FROM PartitionableTable WHERE id > 2 AND MyUdf(part2) < 3]]>
     </Resource>
     <Resource name="ast">
       <![CDATA[
 LogicalProject(id=[$0], name=[$1], part1=[$2], part2=[$3], virtualField=[$4])
 +- LogicalFilter(condition=[AND(>($0, 2), <(MyUdf($3), 3))])
    +- LogicalProject(id=[$0], name=[$1], part1=[$2], part2=[$3], virtualField=[+($3, 1)])
-      +- LogicalTableScan(table=[[test_catalog, test_database, MyTable]])
+      +- LogicalTableScan(table=[[test_catalog, test_database, PartitionableTable]])
 ]]>
     </Resource>
     <Resource name="optimized exec plan">
       <![CDATA[
 Calc(select=[id, name, part1, part2, (part2 + 1) AS virtualField], where=[(id > 2)])
-+- TableSourceScan(table=[[test_catalog, test_database, MyTable, filter=[], partitions=[{part1=A, part2=1}, {part1=C, part2=1}]]], fields=[id, name, part1, part2])
++- TableSourceScan(table=[[test_catalog, test_database, PartitionableTable, partitions=[{part1=A, part2=1}, {part1=C, part2=1}], filter=[]]], fields=[id, name, part1, part2])
 ]]>
     </Resource>
   </TestCase>

--- a/flink-table/flink-table-planner/src/test/resources/org/apache/flink/table/planner/plan/stream/sql/PartitionableSourceTest.xml
+++ b/flink-table/flink-table-planner/src/test/resources/org/apache/flink/table/planner/plan/stream/sql/PartitionableSourceTest.xml
@@ -130,6 +130,60 @@ Calc(select=[id, name, CAST(_UTF-16LE'A':VARCHAR(2147483647) CHARACTER SET "UTF-
 ]]>
     </Resource>
   </TestCase>
+  <TestCase name="testPushDownPartitionAndFiltersContainPartitionKeysWithSingleProjection[sourceFetchPartitions=false, useCatalogFilter=false]">
+    <Resource name="sql">
+      <![CDATA[select name from PartitionableAndFilterableTable where part1 = 'A' and part2 > 1 and id > 1]]>
+    </Resource>
+    <Resource name="ast">
+      <![CDATA[
+LogicalProject(name=[$1])
++- LogicalFilter(condition=[AND(=($2, _UTF-16LE'A'), >($3, 1), >($0, 1))])
+   +- LogicalProject(id=[$0], name=[$1], part1=[$2], part2=[$3], virtualField=[+($3, 1)])
+      +- LogicalTableScan(table=[[test_catalog, test_database, PartitionableAndFilterableTable]])
+]]>
+    </Resource>
+    <Resource name="optimized exec plan">
+      <![CDATA[
+TableSourceScan(table=[[test_catalog, test_database, PartitionableAndFilterableTable, partitions=[{part1=A, part2=2}], filter=[>(id, 1)], project=[name], metadata=[]]], fields=[name])
+]]>
+    </Resource>
+  </TestCase>
+  <TestCase name="testPushDownPartitionAndFiltersContainPartitionKeysWithSingleProjection[sourceFetchPartitions=false, useCatalogFilter=true]">
+    <Resource name="sql">
+      <![CDATA[select name from PartitionableAndFilterableTable where part1 = 'A' and part2 > 1 and id > 1]]>
+    </Resource>
+    <Resource name="ast">
+      <![CDATA[
+LogicalProject(name=[$1])
++- LogicalFilter(condition=[AND(=($2, _UTF-16LE'A'), >($3, 1), >($0, 1))])
+   +- LogicalProject(id=[$0], name=[$1], part1=[$2], part2=[$3], virtualField=[+($3, 1)])
+      +- LogicalTableScan(table=[[test_catalog, test_database, PartitionableAndFilterableTable]])
+]]>
+    </Resource>
+    <Resource name="optimized exec plan">
+      <![CDATA[
+TableSourceScan(table=[[test_catalog, test_database, PartitionableAndFilterableTable, partitions=[{part1=A, part2=2}], filter=[>(id, 1)], project=[name], metadata=[]]], fields=[name])
+]]>
+    </Resource>
+  </TestCase>
+  <TestCase name="testPushDownPartitionAndFiltersContainPartitionKeysWithSingleProjection[sourceFetchPartitions=true, useCatalogFilter=false]">
+    <Resource name="sql">
+      <![CDATA[select name from PartitionableAndFilterableTable where part1 = 'A' and part2 > 1 and id > 1]]>
+    </Resource>
+    <Resource name="ast">
+      <![CDATA[
+LogicalProject(name=[$1])
++- LogicalFilter(condition=[AND(=($2, _UTF-16LE'A'), >($3, 1), >($0, 1))])
+   +- LogicalProject(id=[$0], name=[$1], part1=[$2], part2=[$3], virtualField=[+($3, 1)])
+      +- LogicalTableScan(table=[[default_catalog, default_database, PartitionableAndFilterableTable]])
+]]>
+    </Resource>
+    <Resource name="optimized exec plan">
+      <![CDATA[
+TableSourceScan(table=[[default_catalog, default_database, PartitionableAndFilterableTable, partitions=[{part1=A, part2=2}], filter=[>(id, 1)], project=[name], metadata=[]]], fields=[name])
+]]>
+    </Resource>
+  </TestCase>
   <TestCase name="testSimplePartitionFieldPredicate1[sourceFetchPartitions=false, useCatalogFilter=false]">
     <Resource name="sql">
       <![CDATA[SELECT * FROM PartitionableTable WHERE part1 = 'A']]>

--- a/flink-table/flink-table-planner/src/test/scala/org/apache/flink/table/planner/plan/batch/sql/PartitionableSourceTest.scala
+++ b/flink-table/flink-table-planner/src/test/scala/org/apache/flink/table/planner/plan/batch/sql/PartitionableSourceTest.scala
@@ -134,6 +134,13 @@ class PartitionableSourceTest(
       "select * from PartitionableAndFilterableTable " +
         "where part1 = 'A' and part2 > 1 and id > 1")
   }
+
+  @Test
+  def testPushDownPartitionAndFiltersContainPartitionKeysWithSingleProjection(): Unit = {
+    util.verifyExecPlan(
+      "select name from PartitionableAndFilterableTable " +
+        "where part1 = 'A' and part2 > 1 and id > 1")
+  }
 }
 
 object PartitionableSourceTest {

--- a/flink-table/flink-table-planner/src/test/scala/org/apache/flink/table/planner/plan/batch/sql/PartitionableSourceTest.scala
+++ b/flink-table/flink-table-planner/src/test/scala/org/apache/flink/table/planner/plan/batch/sql/PartitionableSourceTest.scala
@@ -39,9 +39,9 @@ class PartitionableSourceTest(
 
   @Before
   def setup() : Unit = {
-    val ddlTemp =
+    val partitionableTable =
       """
-        |CREATE TABLE MyTable (
+        |CREATE TABLE PartitionableTable (
         |  id int,
         |  name string,
         |  part1 string,
@@ -55,17 +55,39 @@ class PartitionableSourceTest(
         |)
         |""".stripMargin
 
+    // test when PushDownFilter can consume all filters including fields partitionKeys
+    val partitionableAndFilterableTable =
+      """
+        |CREATE TABLE PartitionableAndFilterableTable (
+        |  id int,
+        |  name string,
+        |  part1 string,
+        |  part2 int,
+        |  virtualField as part2 + 1)
+        |  partitioned by (part1, part2)
+        |  with (
+        |    'connector' = 'values',
+        |    'bounded' = 'true',
+        |    'partition-list' = '%s',
+        |    'filterable-fields' = 'id;part1;part2'
+        |)
+        |""".stripMargin
+
     if (sourceFetchPartitions) {
       val partitions = "part1:A,part2:1;part1:A,part2:2;part1:B,part2:3;part1:C,part2:1"
-      util.tableEnv.executeSql(String.format(ddlTemp, partitions))
+      util.tableEnv.executeSql(String.format(partitionableTable, partitions))
+      util.tableEnv.executeSql(String.format(partitionableAndFilterableTable, partitions))
     } else {
       val catalog =
         new TestValuesCatalog("test_catalog", "test_database", useCatalogFilter)
       util.tableEnv.registerCatalog("test_catalog", catalog)
       util.tableEnv.useCatalog("test_catalog")
       // register table without partitions
-      util.tableEnv.executeSql(String.format(ddlTemp, ""))
-      val mytablePath = ObjectPath.fromString("test_database.MyTable")
+      util.tableEnv.executeSql(String.format(partitionableTable, ""))
+      util.tableEnv.executeSql(String.format(partitionableAndFilterableTable, ""))
+      val partitionableTablePath = ObjectPath.fromString("test_database.PartitionableTable")
+      val partitionableAndFilterableTablePath =
+        ObjectPath.fromString("test_database.PartitionableAndFilterableTable")
       // partition map
       val partitions = Seq(
         Map("part1"->"A", "part2"->"1"),
@@ -76,30 +98,41 @@ class PartitionableSourceTest(
         val catalogPartitionSpec = new CatalogPartitionSpec(partition)
         val catalogPartition = new CatalogPartitionImpl(
           new java.util.HashMap[String, String](), "")
-        catalog.createPartition(mytablePath, catalogPartitionSpec, catalogPartition, true)
+        catalog.createPartition(
+          partitionableTablePath, catalogPartitionSpec, catalogPartition, true)
+        catalog.createPartition(
+          partitionableAndFilterableTablePath, catalogPartitionSpec, catalogPartition, true)
       })
     }
   }
 
   @Test
   def testSimplePartitionFieldPredicate1(): Unit = {
-    util.verifyExecPlan("SELECT * FROM MyTable WHERE part1 = 'A'")
+    util.verifyExecPlan("SELECT * FROM PartitionableTable WHERE part1 = 'A'")
   }
 
   @Test
   def testPartialPartitionFieldPredicatePushDown(): Unit = {
-    util.verifyExecPlan("SELECT * FROM MyTable WHERE (id > 2 OR part1 = 'A') AND part2 > 1")
+    util.verifyExecPlan(
+      "SELECT * FROM PartitionableTable WHERE (id > 2 OR part1 = 'A') AND part2 > 1")
   }
 
   @Test
   def testWithUdfAndVirtualColumn(): Unit = {
     util.addFunction("MyUdf", Func1)
-    util.verifyExecPlan("SELECT * FROM MyTable WHERE id > 2 AND MyUdf(part2) < 3")
+    util.verifyExecPlan("SELECT * FROM PartitionableTable WHERE id > 2 AND MyUdf(part2) < 3")
   }
 
   @Test
   def testUnconvertedExpression(): Unit = {
-    util.verifyExecPlan("select * from MyTable where trim(part1) = 'A' and part2 > 1")
+    util.verifyExecPlan("select * from PartitionableTable where trim(part1) = 'A' and part2 > 1")
+  }
+
+  @Test
+  def testPushDownPartitionAndFiltersContainPartitionKeys(): Unit = {
+    util.verifyExecPlan(
+      "select * from PartitionableAndFilterableTable " +
+        "where part1 = 'A' and part2 > 1 and id > 1")
   }
 }
 

--- a/flink-table/flink-table-planner/src/test/scala/org/apache/flink/table/planner/plan/stream/sql/PartitionableSourceTest.scala
+++ b/flink-table/flink-table-planner/src/test/scala/org/apache/flink/table/planner/plan/stream/sql/PartitionableSourceTest.scala
@@ -135,6 +135,13 @@ class PartitionableSourceTest(
       "select * from PartitionableAndFilterableTable " +
         "where part1 = 'A' and part2 > 1 and id > 1")
   }
+
+  @Test
+  def testPushDownPartitionAndFiltersContainPartitionKeysWithSingleProjection(): Unit = {
+    util.verifyExecPlan(
+      "select name from PartitionableAndFilterableTable " +
+        "where part1 = 'A' and part2 > 1 and id > 1")
+  }
 }
 
 object PartitionableSourceTest {

--- a/flink-table/flink-table-planner/src/test/scala/org/apache/flink/table/planner/plan/stream/sql/PartitionableSourceTest.scala
+++ b/flink-table/flink-table-planner/src/test/scala/org/apache/flink/table/planner/plan/stream/sql/PartitionableSourceTest.scala
@@ -39,9 +39,9 @@ class PartitionableSourceTest(
 
   @Before
   def setup() : Unit = {
-    val ddlTemp =
+    val partitionableTable =
       """
-        |CREATE TABLE MyTable (
+        |CREATE TABLE PartitionableTable (
         |  id int,
         |  name string,
         |  part1 string,
@@ -55,17 +55,40 @@ class PartitionableSourceTest(
         |)
         |""".stripMargin
 
+    // test when PushDownFilter can consume all filters including fields partitionKeys
+    val partitionableAndFilterableTable =
+      """
+        |CREATE TABLE PartitionableAndFilterableTable (
+        |  id int,
+        |  name string,
+        |  part1 string,
+        |  part2 int,
+        |  virtualField as part2 + 1)
+        |  partitioned by (part1, part2)
+        |  with (
+        |    'connector' = 'values',
+        |    'bounded' = 'true',
+        |    'partition-list' = '%s',
+        |    'filterable-fields' = 'id;part1;part2'
+        |)
+        |""".stripMargin
+
     if (sourceFetchPartitions) {
       val partitions = "part1:A,part2:1;part1:A,part2:2;part1:B,part2:3;part1:C,part2:1"
-      util.tableEnv.executeSql(String.format(ddlTemp, partitions))
+      util.tableEnv.executeSql(String.format(partitionableTable, partitions))
+      util.tableEnv.executeSql(String.format(partitionableAndFilterableTable, partitions))
     } else {
       val catalog =
         new TestValuesCatalog("test_catalog", "test_database", useCatalogFilter)
       util.tableEnv.registerCatalog("test_catalog", catalog)
       util.tableEnv.useCatalog("test_catalog")
       // register table without partitions
-      util.tableEnv.executeSql(String.format(ddlTemp, ""))
-      val mytablePath = ObjectPath.fromString("test_database.MyTable")
+      util.tableEnv.executeSql(String.format(partitionableTable, ""))
+      util.tableEnv.executeSql(String.format(partitionableAndFilterableTable, ""))
+      val partitionableTablePath = ObjectPath.fromString("test_database.PartitionableTable")
+      val partitionableAndFilterableTablePath =
+        ObjectPath.fromString("test_database.PartitionableAndFilterableTable")
+
       // partition map
       val partitions = Seq(
         Map("part1"->"A", "part2"->"1"),
@@ -76,30 +99,41 @@ class PartitionableSourceTest(
         val catalogPartitionSpec = new CatalogPartitionSpec(partition)
         val catalogPartition = new CatalogPartitionImpl(
           new java.util.HashMap[String, String](), "")
-        catalog.createPartition(mytablePath, catalogPartitionSpec, catalogPartition, true)
+        catalog.createPartition(
+          partitionableTablePath, catalogPartitionSpec, catalogPartition, true)
+        catalog.createPartition(
+          partitionableAndFilterableTablePath, catalogPartitionSpec, catalogPartition, true)
       })
     }
   }
 
   @Test
   def testSimplePartitionFieldPredicate1(): Unit = {
-    util.verifyExecPlan("SELECT * FROM MyTable WHERE part1 = 'A'")
+    util.verifyExecPlan("SELECT * FROM PartitionableTable WHERE part1 = 'A'")
   }
 
   @Test
   def testPartialPartitionFieldPredicatePushDown(): Unit = {
-    util.verifyExecPlan("SELECT * FROM MyTable WHERE (id > 2 OR part1 = 'A') AND part2 > 1")
+    util.verifyExecPlan(
+      "SELECT * FROM PartitionableTable WHERE (id > 2 OR part1 = 'A') AND part2 > 1")
   }
 
   @Test
   def testWithUdfAndVirtualColumn(): Unit = {
     util.addFunction("MyUdf", Func1)
-    util.verifyExecPlan("SELECT * FROM MyTable WHERE id > 2 AND MyUdf(part2) < 3")
+    util.verifyExecPlan("SELECT * FROM PartitionableTable WHERE id > 2 AND MyUdf(part2) < 3")
   }
 
   @Test
   def testUnconvertedExpression(): Unit = {
-    util.verifyExecPlan("select * from MyTable where trim(part1) = 'A' and part2 > 1")
+    util.verifyExecPlan("select * from PartitionableTable where trim(part1) = 'A' and part2 > 1")
+  }
+
+  @Test
+  def testPushDownPartitionAndFiltersContainPartitionKeys(): Unit = {
+    util.verifyExecPlan(
+      "select * from PartitionableAndFilterableTable " +
+        "where part1 = 'A' and part2 > 1 and id > 1")
   }
 }
 

--- a/flink-table/flink-table-planner/src/test/scala/org/apache/flink/table/planner/runtime/batch/sql/PartitionableSourceITCase.scala
+++ b/flink-table/flink-table-planner/src/test/scala/org/apache/flink/table/planner/runtime/batch/sql/PartitionableSourceITCase.scala
@@ -46,11 +46,11 @@ class PartitionableSourceITCase(
       row(4, "Tom", "B", 3),
       row(5, "Vivi", "C", 1)
     )
-    val myTableDataId = TestValuesTableFactory.registerData(data)
+    val dataId = TestValuesTableFactory.registerData(data)
 
-    val ddlTemp =
+    val partitionableTable =
       s"""
-        |CREATE TABLE MyTable (
+        |CREATE TABLE PartitionableTable (
         |  id int,
         |  name string,
         |  part1 string,
@@ -59,24 +59,46 @@ class PartitionableSourceITCase(
         |  partitioned by (part1, part2)
         |  with (
         |    'connector' = 'values',
-        |    'data-id' = '$myTableDataId',
+        |    'data-id' = '$dataId',
         |    'bounded' = 'true',
         |    'partition-list' = '%s'
         |)
         |""".stripMargin
 
+    // test when PushDownFilter can consume all filters including fields partitionKeys
+    val partitionableAndFilterableTable =
+      s"""
+        |CREATE TABLE PartitionableAndFilterableTable (
+        |  id int,
+        |  name string,
+        |  part1 string,
+        |  part2 int,
+        |  virtualField as part2 + 1)
+        |  partitioned by (part1, part2)
+        |  with (
+        |    'connector' = 'values',
+        |    'data-id' = '$dataId',
+        |    'bounded' = 'true',
+        |    'partition-list' = '%s',
+        |    'filterable-fields' = 'id;part1;part2'
+        |)
+        |""".stripMargin
+
     if (sourceFetchPartitions) {
       val partitions = "part1:A,part2:1;part1:A,part2:2;part1:B,part2:3;part1:C,part2:1"
-      tEnv.executeSql(String.format(ddlTemp, partitions))
+      tEnv.executeSql(String.format(partitionableTable, partitions))
+      tEnv.executeSql(String.format(partitionableAndFilterableTable, partitions))
     } else {
       val catalog =
         new TestValuesCatalog("test_catalog", "test_database", useCatalogFilter)
       tEnv.registerCatalog("test_catalog", catalog)
       tEnv.useCatalog("test_catalog")
       // register table without partitions
-      tEnv.executeSql(String.format(ddlTemp, ""))
-      val mytablePath = ObjectPath.fromString("test_database.MyTable")
-      // partition map
+      tEnv.executeSql(String.format(partitionableTable, ""))
+      tEnv.executeSql(String.format(partitionableAndFilterableTable, ""))
+      val partitionableTablePath = ObjectPath.fromString("test_database.PartitionableTable")
+      val partitionableAndFilterableTablePath =
+        ObjectPath.fromString("test_database.PartitionableAndFilterableTable")
       val partitions = Seq(
         Map("part1"->"A", "part2"->"1"),
         Map("part1"->"A", "part2"->"2"),
@@ -86,14 +108,17 @@ class PartitionableSourceITCase(
         val catalogPartitionSpec = new CatalogPartitionSpec(partition)
         val catalogPartition = new CatalogPartitionImpl(
           new java.util.HashMap[String, String](), "")
-        catalog.createPartition(mytablePath, catalogPartitionSpec, catalogPartition, true)
+        catalog.createPartition(
+          partitionableTablePath, catalogPartitionSpec, catalogPartition, true)
+        catalog.createPartition(
+          partitionableAndFilterableTablePath, catalogPartitionSpec, catalogPartition, true)
       })
     }
   }
 
   @Test
   def testSimplePartitionFieldPredicate1(): Unit = {
-    checkResult("SELECT * FROM MyTable WHERE part1 = 'A'",
+    checkResult("SELECT * FROM PartitionableTable WHERE part1 = 'A'",
       Seq(
         row(1, "ZhangSan", "A", 1, 2),
         row(2, "LiSi", "A", 1, 2),
@@ -104,7 +129,7 @@ class PartitionableSourceITCase(
 
   @Test
   def testPartialPartitionFieldPredicatePushDown(): Unit = {
-    checkResult("SELECT * FROM MyTable WHERE (id > 2 OR part1 = 'A') AND part2 > 1",
+    checkResult("SELECT * FROM PartitionableTable WHERE (id > 2 OR part1 = 'A') AND part2 > 1",
       Seq(
         row(3, "Jack", "A", 2, 3),
         row(4, "Tom", "B", 3, 4)
@@ -114,11 +139,21 @@ class PartitionableSourceITCase(
 
   @Test
   def testUnconvertedExpression(): Unit = {
-    checkResult("select * from MyTable where trim(part1) = 'A' and part2 > 1",
+    checkResult("select * from PartitionableTable where trim(part1) = 'A' and part2 > 1",
       Seq(
         row(3, "Jack", "A", 2, 3)
       )
     )
+  }
+
+  @Test
+  def testPushDownPartitionAndFiltersContainPartitionKeys(): Unit = {
+    checkResult(
+      "SELECT * FROM PartitionableAndFilterableTable WHERE part1 = 'A' AND id > 1",
+      Seq(
+        row(2, "LiSi", "A", 1, 2),
+        row(3, "Jack", "A", 2, 3)
+      ))
   }
 }
 

--- a/flink-table/flink-table-planner/src/test/scala/org/apache/flink/table/planner/runtime/batch/sql/PartitionableSourceITCase.scala
+++ b/flink-table/flink-table-planner/src/test/scala/org/apache/flink/table/planner/runtime/batch/sql/PartitionableSourceITCase.scala
@@ -155,6 +155,16 @@ class PartitionableSourceITCase(
         row(3, "Jack", "A", 2, 3)
       ))
   }
+
+  @Test
+  def testPushDownPartitionAndFiltersContainPartitionKeysWithSingleProjection(): Unit = {
+    checkResult(
+      "SELECT name FROM PartitionableAndFilterableTable WHERE part1 = 'A' AND id > 1",
+      Seq(
+        row("LiSi"),
+        row("Jack")
+      ))
+  }
 }
 
 object PartitionableSourceITCase {

--- a/flink-table/flink-table-planner/src/test/scala/org/apache/flink/table/planner/runtime/stream/sql/PartitionableSourceITCase.scala
+++ b/flink-table/flink-table-planner/src/test/scala/org/apache/flink/table/planner/runtime/stream/sql/PartitionableSourceITCase.scala
@@ -50,11 +50,11 @@ class PartitionableSourceITCase(
       row(4, "Tom", "B", 3),
       row(5, "Vivi", "C", 1)
     )
-    val myTableDataId = TestValuesTableFactory.registerData(data)
+    val dataId = TestValuesTableFactory.registerData(data)
 
-    val ddlTemp =
+    val partitionableTable =
       s"""
-         |CREATE TABLE MyTable (
+         |CREATE TABLE PartitionableTable (
          |  id int,
          |  name string,
          |  part1 string,
@@ -63,23 +63,46 @@ class PartitionableSourceITCase(
          |  partitioned by (part1, part2)
          |  with (
          |    'connector' = 'values',
-         |    'data-id' = '$myTableDataId',
+         |    'data-id' = '$dataId',
          |    'bounded' = 'true',
          |    'partition-list' = '%s'
          |)
          |""".stripMargin
 
+    // test when PushDownFilter can consume all filters including fields partitionKeys
+    val partitionableAndFilterableTable =
+      s"""
+         |CREATE TABLE PartitionableAndFilterableTable (
+         |  id int,
+         |  name string,
+         |  part1 string,
+         |  part2 int,
+         |  virtualField as part2 + 1)
+         |  partitioned by (part1, part2)
+         |  with (
+         |    'connector' = 'values',
+         |    'data-id' = '$dataId',
+         |    'bounded' = 'true',
+         |    'partition-list' = '%s',
+         |    'filterable-fields' = 'id;part1;part2'
+         |)
+         |""".stripMargin
+
     if (sourceFetchPartitions) {
       val partitions = "part1:A,part2:1;part1:A,part2:2;part1:B,part2:3;part1:C,part2:1"
-      tEnv.executeSql(String.format(ddlTemp, partitions))
+      tEnv.executeSql(String.format(partitionableTable, partitions))
+      tEnv.executeSql(String.format(partitionableAndFilterableTable, partitions))
     } else {
       val catalog =
         new TestValuesCatalog("test_catalog", "test_database", useCatalogFilter)
       tEnv.registerCatalog("test_catalog", catalog)
       tEnv.useCatalog("test_catalog")
       // register table without partitions
-      tEnv.executeSql(String.format(ddlTemp, ""))
-      val mytablePath = ObjectPath.fromString("test_database.MyTable")
+      tEnv.executeSql(String.format(partitionableTable, ""))
+      tEnv.executeSql(String.format(partitionableAndFilterableTable, ""))
+      val partitionableTablePath = ObjectPath.fromString("test_database.PartitionableTable")
+      val partitionableAndFilterableTablePath =
+        ObjectPath.fromString("test_database.PartitionableAndFilterableTable")
       // partition map
       val partitions = Seq(
         Map("part1"->"A", "part2"->"1"),
@@ -90,14 +113,17 @@ class PartitionableSourceITCase(
         val catalogPartitionSpec = new CatalogPartitionSpec(partition)
         val catalogPartition = new CatalogPartitionImpl(
           new java.util.HashMap[String, String](), "")
-        catalog.createPartition(mytablePath, catalogPartitionSpec, catalogPartition, true)
+        catalog.createPartition(
+          partitionableTablePath, catalogPartitionSpec, catalogPartition, true)
+        catalog.createPartition(
+          partitionableAndFilterableTablePath, catalogPartitionSpec, catalogPartition, true)
       })
     }
   }
 
   @Test
   def testSimplePartitionFieldPredicate1(): Unit = {
-    val query = "SELECT * FROM MyTable WHERE part1 = 'A'"
+    val query = "SELECT * FROM PartitionableTable WHERE part1 = 'A'"
     val result = tEnv.sqlQuery(query).toAppendStream[Row]
     val sink = new TestingAppendSink
     result.addSink(sink)
@@ -113,7 +139,7 @@ class PartitionableSourceITCase(
 
   @Test
   def testPartialPartitionFieldPredicatePushDown(): Unit = {
-    val query = "SELECT * FROM MyTable WHERE (id > 2 OR part1 = 'A') AND part2 > 1"
+    val query = "SELECT * FROM PartitionableTable WHERE (id > 2 OR part1 = 'A') AND part2 > 1"
     val result = tEnv.sqlQuery(query).toAppendStream[Row]
     val sink = new TestingAppendSink
     result.addSink(sink)
@@ -128,13 +154,28 @@ class PartitionableSourceITCase(
 
   @Test
   def testUnconvertedExpression(): Unit = {
-    val query = "select * from MyTable where trim(part1) = 'A' and part2 > 1"
+    val query = "select * from PartitionableTable where trim(part1) = 'A' and part2 > 1"
     val result = tEnv.sqlQuery(query).toAppendStream[Row]
     val sink = new TestingAppendSink
     result.addSink(sink)
     env.execute()
 
     val expected = Seq(
+      "3,Jack,A,2,3"
+    )
+    assertEquals(expected.sorted, sink.getAppendResults.sorted)
+  }
+
+  @Test
+  def testPushDownPartitionAndFiltersContainPartitionKeys(): Unit = {
+    val query = "SELECT * FROM PartitionableAndFilterableTable WHERE part1 = 'A' AND id > 1"
+    val result = tEnv.sqlQuery(query).toAppendStream[Row]
+    val sink = new TestingAppendSink
+    result.addSink(sink)
+    env.execute()
+
+    val expected = Seq(
+      "2,LiSi,A,1,2",
       "3,Jack,A,2,3"
     )
     assertEquals(expected.sorted, sink.getAppendResults.sorted)

--- a/flink-table/flink-table-planner/src/test/scala/org/apache/flink/table/planner/runtime/stream/sql/PartitionableSourceITCase.scala
+++ b/flink-table/flink-table-planner/src/test/scala/org/apache/flink/table/planner/runtime/stream/sql/PartitionableSourceITCase.scala
@@ -180,6 +180,21 @@ class PartitionableSourceITCase(
     )
     assertEquals(expected.sorted, sink.getAppendResults.sorted)
   }
+
+  @Test
+  def testPushDownPartitionAndFiltersContainPartitionKeysWithSingleProjection(): Unit = {
+    val query = "SELECT name FROM PartitionableAndFilterableTable WHERE part1 = 'A' AND id > 1"
+    val result = tEnv.sqlQuery(query).toAppendStream[Row]
+    val sink = new TestingAppendSink
+    result.addSink(sink)
+    env.execute()
+
+    val expected = Seq(
+      "LiSi",
+      "Jack"
+    )
+    assertEquals(expected.sorted, sink.getAppendResults.sorted)
+  }
 }
 
 object PartitionableSourceITCase {


### PR DESCRIPTION
## What is the purpose of the change

In the optimized period, put the rule PushPartitionsDown before the rule PushFiltersDown to avoid PushFiltersDown consumes all filters and cause that PushFiltersDown will never be applied.

## Brief change log

  - *Change the order between PushPartitionIntoLegacyTableSourceScanRule / PushPartitionIntoTableSourceScanRule and PushFilterIntoTableSourceScanRule / PushFilterIntoLegacyTableSourceScanRule in FlinkStreamRuleSets and FlinkBatchRuleSets.*
  - *Add some test cases to verify this change.*

## Verifying this change

Some test cases are added to verify this change.

## Does this pull request potentially affect one of the following parts:

  - Dependencies (does it add or upgrade a dependency): no
  - The public API, i.e., is any changed class annotated with `@Public(Evolving)`: no
  - The serializers: no
  - The runtime per-record code paths (performance sensitive): no
  - Anything that affects deployment or recovery: JobManager (and its components), Checkpointing, Kubernetes/Yarn, ZooKeeper: no
  - The S3 file system connector: no

## Documentation

  - Does this pull request introduce a new feature? no
  - If yes, how is the feature documented? 
