### PR TITLE
[FLINK-24614][Connectors/PARQUET] Add array,map,row types support for…

### DIFF
--- a/flink-formats/flink-parquet/src/main/java/org/apache/flink/formats/parquet/vector/ParquetDecimalVector.java
+++ b/flink-formats/flink-parquet/src/main/java/org/apache/flink/formats/parquet/vector/ParquetDecimalVector.java
@@ -32,7 +32,7 @@ import org.apache.flink.table.data.vector.LongColumnVector;
  */
 public class ParquetDecimalVector implements DecimalColumnVector {
 
-    private final ColumnVector vector;
+    public final ColumnVector vector;
 
     public ParquetDecimalVector(ColumnVector vector) {
         this.vector = vector;
@@ -40,10 +40,11 @@ public class ParquetDecimalVector implements DecimalColumnVector {
 
     @Override
     public DecimalData getDecimal(int i, int precision, int scale) {
-        if (DecimalDataUtils.is32BitDecimal(precision)) {
+        if (DecimalDataUtils.is32BitDecimal(precision) && vector instanceof IntColumnVector) {
             return DecimalData.fromUnscaledLong(
                     ((IntColumnVector) vector).getInt(i), precision, scale);
-        } else if (DecimalDataUtils.is64BitDecimal(precision)) {
+        } else if (DecimalDataUtils.is64BitDecimal(precision)
+                && vector instanceof LongColumnVector) {
             return DecimalData.fromUnscaledLong(
                     ((LongColumnVector) vector).getLong(i), precision, scale);
         } else {

--- a/flink-formats/flink-parquet/src/main/java/org/apache/flink/formats/parquet/vector/ParquetSplitReaderUtil.java
+++ b/flink-formats/flink-parquet/src/main/java/org/apache/flink/formats/parquet/vector/ParquetSplitReaderUtil.java
@@ -19,6 +19,7 @@
 package org.apache.flink.formats.parquet.vector;
 
 import org.apache.flink.core.fs.Path;
+import org.apache.flink.formats.parquet.vector.reader.ArrayColumnReader;
 import org.apache.flink.formats.parquet.vector.reader.BooleanColumnReader;
 import org.apache.flink.formats.parquet.vector.reader.ByteColumnReader;
 import org.apache.flink.formats.parquet.vector.reader.BytesColumnReader;
@@ -28,6 +29,8 @@ import org.apache.flink.formats.parquet.vector.reader.FixedLenBytesColumnReader;
 import org.apache.flink.formats.parquet.vector.reader.FloatColumnReader;
 import org.apache.flink.formats.parquet.vector.reader.IntColumnReader;
 import org.apache.flink.formats.parquet.vector.reader.LongColumnReader;
+import org.apache.flink.formats.parquet.vector.reader.MapColumnReader;
+import org.apache.flink.formats.parquet.vector.reader.RowColumnReader;
 import org.apache.flink.formats.parquet.vector.reader.ShortColumnReader;
 import org.apache.flink.formats.parquet.vector.reader.TimestampColumnReader;
 import org.apache.flink.table.data.DecimalData;
@@ -35,6 +38,7 @@ import org.apache.flink.table.data.DecimalDataUtils;
 import org.apache.flink.table.data.TimestampData;
 import org.apache.flink.table.data.vector.ColumnVector;
 import org.apache.flink.table.data.vector.VectorizedColumnBatch;
+import org.apache.flink.table.data.vector.heap.HeapArrayVector;
 import org.apache.flink.table.data.vector.heap.HeapBooleanVector;
 import org.apache.flink.table.data.vector.heap.HeapByteVector;
 import org.apache.flink.table.data.vector.heap.HeapBytesVector;
@@ -42,22 +46,31 @@ import org.apache.flink.table.data.vector.heap.HeapDoubleVector;
 import org.apache.flink.table.data.vector.heap.HeapFloatVector;
 import org.apache.flink.table.data.vector.heap.HeapIntVector;
 import org.apache.flink.table.data.vector.heap.HeapLongVector;
+import org.apache.flink.table.data.vector.heap.HeapMapColumnVector;
+import org.apache.flink.table.data.vector.heap.HeapRowColumnVector;
 import org.apache.flink.table.data.vector.heap.HeapShortVector;
 import org.apache.flink.table.data.vector.heap.HeapTimestampVector;
 import org.apache.flink.table.data.vector.writable.WritableColumnVector;
 import org.apache.flink.table.types.DataType;
+import org.apache.flink.table.types.logical.ArrayType;
 import org.apache.flink.table.types.logical.BigIntType;
 import org.apache.flink.table.types.logical.DecimalType;
 import org.apache.flink.table.types.logical.IntType;
 import org.apache.flink.table.types.logical.LogicalType;
+import org.apache.flink.table.types.logical.MapType;
+import org.apache.flink.table.types.logical.RowType;
 import org.apache.flink.table.types.logical.VarBinaryType;
 import org.apache.flink.util.Preconditions;
 
 import org.apache.hadoop.conf.Configuration;
+import org.apache.parquet.ParquetRuntimeException;
 import org.apache.parquet.column.ColumnDescriptor;
-import org.apache.parquet.column.page.PageReader;
+import org.apache.parquet.column.page.PageReadStore;
+import org.apache.parquet.schema.GroupType;
+import org.apache.parquet.schema.InvalidSchemaException;
 import org.apache.parquet.schema.OriginalType;
 import org.apache.parquet.schema.PrimitiveType;
+import org.apache.parquet.schema.Type;
 
 import java.io.IOException;
 import java.math.BigDecimal;
@@ -65,6 +78,7 @@ import java.nio.charset.StandardCharsets;
 import java.sql.Date;
 import java.time.LocalDate;
 import java.time.LocalDateTime;
+import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.List;
 import java.util.Map;
@@ -259,56 +273,136 @@ public class ParquetSplitReaderUtil {
         }
     }
 
+    private static List<ColumnDescriptor> getAllColumnDescriptorByType(
+            int depth, Type type, List<ColumnDescriptor> columns) throws ParquetRuntimeException {
+        List<ColumnDescriptor> res = new ArrayList<>();
+        for (ColumnDescriptor descriptor : columns) {
+            if (depth >= descriptor.getPath().length) {
+                throw new InvalidSchemaException("Corrupted Parquet schema");
+            }
+            if (type.getName().equals(descriptor.getPath()[depth])) {
+                res.add(descriptor);
+            }
+        }
+        return res;
+    }
+
     public static ColumnReader createColumnReader(
-            boolean utcTimestamp,
+            boolean isUtcTimestamp,
             LogicalType fieldType,
-            ColumnDescriptor descriptor,
-            PageReader pageReader)
+            Type type,
+            List<ColumnDescriptor> columnDescriptors,
+            PageReadStore pages,
+            int depth)
             throws IOException {
+        List<ColumnDescriptor> descriptors =
+                getAllColumnDescriptorByType(depth, type, columnDescriptors);
         switch (fieldType.getTypeRoot()) {
             case BOOLEAN:
-                return new BooleanColumnReader(descriptor, pageReader);
+                return new BooleanColumnReader(
+                        descriptors.get(0), pages.getPageReader(descriptors.get(0)));
             case TINYINT:
-                return new ByteColumnReader(descriptor, pageReader);
+                return new ByteColumnReader(
+                        descriptors.get(0), pages.getPageReader(descriptors.get(0)));
             case DOUBLE:
-                return new DoubleColumnReader(descriptor, pageReader);
+                return new DoubleColumnReader(
+                        descriptors.get(0), pages.getPageReader(descriptors.get(0)));
             case FLOAT:
-                return new FloatColumnReader(descriptor, pageReader);
+                return new FloatColumnReader(
+                        descriptors.get(0), pages.getPageReader(descriptors.get(0)));
             case INTEGER:
             case DATE:
             case TIME_WITHOUT_TIME_ZONE:
-                return new IntColumnReader(descriptor, pageReader);
+                return new IntColumnReader(
+                        descriptors.get(0), pages.getPageReader(descriptors.get(0)));
             case BIGINT:
-                return new LongColumnReader(descriptor, pageReader);
+                return new LongColumnReader(
+                        descriptors.get(0), pages.getPageReader(descriptors.get(0)));
             case SMALLINT:
-                return new ShortColumnReader(descriptor, pageReader);
+                return new ShortColumnReader(
+                        descriptors.get(0), pages.getPageReader(descriptors.get(0)));
             case CHAR:
             case VARCHAR:
             case BINARY:
             case VARBINARY:
-                return new BytesColumnReader(descriptor, pageReader);
+                return new BytesColumnReader(
+                        descriptors.get(0), pages.getPageReader(descriptors.get(0)));
             case TIMESTAMP_WITHOUT_TIME_ZONE:
             case TIMESTAMP_WITH_LOCAL_TIME_ZONE:
-                return new TimestampColumnReader(utcTimestamp, descriptor, pageReader);
+                return new TimestampColumnReader(
+                        isUtcTimestamp,
+                        descriptors.get(0),
+                        pages.getPageReader(descriptors.get(0)));
             case DECIMAL:
-                switch (descriptor.getPrimitiveType().getPrimitiveTypeName()) {
+                switch (descriptors.get(0).getPrimitiveType().getPrimitiveTypeName()) {
                     case INT32:
-                        return new IntColumnReader(descriptor, pageReader);
+                        return new IntColumnReader(
+                                descriptors.get(0), pages.getPageReader(descriptors.get(0)));
                     case INT64:
-                        return new LongColumnReader(descriptor, pageReader);
+                        return new LongColumnReader(
+                                descriptors.get(0), pages.getPageReader(descriptors.get(0)));
                     case BINARY:
-                        return new BytesColumnReader(descriptor, pageReader);
+                        return new BytesColumnReader(
+                                descriptors.get(0), pages.getPageReader(descriptors.get(0)));
                     case FIXED_LEN_BYTE_ARRAY:
                         return new FixedLenBytesColumnReader(
-                                descriptor, pageReader, ((DecimalType) fieldType).getPrecision());
+                                descriptors.get(0),
+                                pages.getPageReader(descriptors.get(0)),
+                                ((DecimalType) fieldType).getPrecision());
                 }
+            case ARRAY:
+                return new ArrayColumnReader(
+                        descriptors.get(0),
+                        pages.getPageReader(descriptors.get(0)),
+                        isUtcTimestamp,
+                        descriptors.get(0).getPrimitiveType(),
+                        fieldType);
+            case MAP:
+                MapType mapType = (MapType) fieldType;
+                ArrayColumnReader keyReader =
+                        new ArrayColumnReader(
+                                descriptors.get(0),
+                                pages.getPageReader(descriptors.get(0)),
+                                isUtcTimestamp,
+                                descriptors.get(0).getPrimitiveType(),
+                                new ArrayType(mapType.getKeyType()));
+                ArrayColumnReader valueReader =
+                        new ArrayColumnReader(
+                                descriptors.get(1),
+                                pages.getPageReader(descriptors.get(1)),
+                                isUtcTimestamp,
+                                descriptors.get(1).getPrimitiveType(),
+                                new ArrayType(mapType.getValueType()));
+                return new MapColumnReader(keyReader, valueReader, fieldType);
+            case ROW:
+                RowType rowType = (RowType) fieldType;
+                GroupType groupType = type.asGroupType();
+                List<ColumnReader> fieldReaders = new ArrayList<>();
+                for (int i = 0; i < rowType.getFieldCount(); i++) {
+                    fieldReaders.add(
+                            createColumnReader(
+                                    isUtcTimestamp,
+                                    rowType.getTypeAt(i),
+                                    groupType.getType(i),
+                                    descriptors,
+                                    pages,
+                                    depth + 1));
+                }
+                return new RowColumnReader(fieldReaders);
             default:
                 throw new UnsupportedOperationException(fieldType + " is not supported now.");
         }
     }
 
     public static WritableColumnVector createWritableColumnVector(
-            int batchSize, LogicalType fieldType, PrimitiveType primitiveType) {
+            int batchSize,
+            LogicalType fieldType,
+            Type type,
+            List<ColumnDescriptor> columnDescriptors,
+            int depth) {
+        List<ColumnDescriptor> descriptors =
+                getAllColumnDescriptorByType(depth, type, columnDescriptors);
+        PrimitiveType primitiveType = descriptors.get(0).getPrimitiveType();
         PrimitiveType.PrimitiveTypeName typeName = primitiveType.getPrimitiveTypeName();
         switch (fieldType.getTypeRoot()) {
             case BOOLEAN:
@@ -398,6 +492,48 @@ public class ParquetSplitReaderUtil {
                             typeName);
                     return new HeapBytesVector(batchSize);
                 }
+            case ARRAY:
+                ArrayType arrayType = (ArrayType) fieldType;
+                return new HeapArrayVector(
+                        batchSize,
+                        createWritableColumnVector(
+                                batchSize,
+                                arrayType.getElementType(),
+                                type,
+                                columnDescriptors,
+                                depth));
+            case MAP:
+                MapType mapType = (MapType) fieldType;
+                GroupType repeatedType = type.asGroupType().getType(0).asGroupType();
+                return new HeapMapColumnVector(
+                        batchSize,
+                        createWritableColumnVector(
+                                batchSize,
+                                mapType.getKeyType(),
+                                repeatedType.getType(0),
+                                descriptors,
+                                depth + 2),
+                        createWritableColumnVector(
+                                batchSize,
+                                mapType.getValueType(),
+                                repeatedType.getType(1),
+                                descriptors,
+                                depth + 2));
+            case ROW:
+                RowType rowType = (RowType) fieldType;
+                GroupType groupType = type.asGroupType();
+                WritableColumnVector[] columnVectors =
+                        new WritableColumnVector[rowType.getFieldCount()];
+                for (int i = 0; i < columnVectors.length; i++) {
+                    columnVectors[i] =
+                            createWritableColumnVector(
+                                    batchSize,
+                                    rowType.getTypeAt(i),
+                                    groupType.getType(i),
+                                    descriptors,
+                                    depth + 1);
+                }
+                return new HeapRowColumnVector(batchSize, columnVectors);
             default:
                 throw new UnsupportedOperationException(fieldType + " is not supported now.");
         }

--- a/flink-formats/flink-parquet/src/main/java/org/apache/flink/formats/parquet/vector/reader/ArrayColumnReader.java
+++ b/flink-formats/flink-parquet/src/main/java/org/apache/flink/formats/parquet/vector/reader/ArrayColumnReader.java
@@ -1,0 +1,464 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.flink.formats.parquet.vector.reader;
+
+import org.apache.flink.formats.parquet.vector.ParquetDecimalVector;
+import org.apache.flink.table.data.TimestampData;
+import org.apache.flink.table.data.vector.VectorizedColumnBatch;
+import org.apache.flink.table.data.vector.heap.HeapArrayVector;
+import org.apache.flink.table.data.vector.heap.HeapBooleanVector;
+import org.apache.flink.table.data.vector.heap.HeapByteVector;
+import org.apache.flink.table.data.vector.heap.HeapBytesVector;
+import org.apache.flink.table.data.vector.heap.HeapDoubleVector;
+import org.apache.flink.table.data.vector.heap.HeapFloatVector;
+import org.apache.flink.table.data.vector.heap.HeapIntVector;
+import org.apache.flink.table.data.vector.heap.HeapLongVector;
+import org.apache.flink.table.data.vector.heap.HeapShortVector;
+import org.apache.flink.table.data.vector.heap.HeapTimestampVector;
+import org.apache.flink.table.data.vector.writable.WritableColumnVector;
+import org.apache.flink.table.types.logical.ArrayType;
+import org.apache.flink.table.types.logical.LogicalType;
+
+import org.apache.parquet.column.ColumnDescriptor;
+import org.apache.parquet.column.page.PageReader;
+import org.apache.parquet.schema.PrimitiveType;
+import org.apache.parquet.schema.Type;
+
+import java.io.IOException;
+import java.util.ArrayList;
+import java.util.List;
+
+/** Array {@link ColumnReader}. */
+public class ArrayColumnReader extends BaseVectorizedColumnReader {
+
+    // The value read in last time
+    private Object lastValue;
+
+    // flag to indicate if there is no data in parquet data page
+    private boolean eof = false;
+
+    // flag to indicate if it's the first time to read parquet data page with this instance
+    boolean isFirstRow = true;
+
+    public ArrayColumnReader(
+            ColumnDescriptor descriptor,
+            PageReader pageReader,
+            boolean isUtcTimestamp,
+            Type type,
+            LogicalType logicalType)
+            throws IOException {
+        super(descriptor, pageReader, isUtcTimestamp, type, logicalType);
+    }
+
+    @Override
+    public void readToVector(int readNumber, WritableColumnVector vector) throws IOException {
+        HeapArrayVector lcv = (HeapArrayVector) vector;
+        // before readBatch, initial the size of offsets & lengths as the default value,
+        // the actual size will be assigned in setChildrenInfo() after reading complete.
+        lcv.offsets = new long[VectorizedColumnBatch.DEFAULT_SIZE];
+        lcv.lengths = new long[VectorizedColumnBatch.DEFAULT_SIZE];
+        // Because the length of ListColumnVector.child can't be known now,
+        // the valueList will save all data for ListColumnVector temporary.
+        List<Object> valueList = new ArrayList<>();
+
+        LogicalType category = ((ArrayType) logicalType).getElementType();
+
+        // read the first row in parquet data page, this will be only happened once for this
+        // instance
+        if (isFirstRow) {
+            if (!fetchNextValue(category)) {
+                return;
+            }
+            isFirstRow = false;
+        }
+
+        int index = collectDataFromParquetPage(readNumber, lcv, valueList, category);
+
+        // Convert valueList to array for the ListColumnVector.child
+        fillColumnVector(category, lcv, valueList, index);
+    }
+
+    /**
+     * Reads a single value from parquet page, puts it into lastValue. Returns a boolean indicating
+     * if there is more values to read (true).
+     *
+     * @param category
+     * @return boolean
+     * @throws IOException
+     */
+    private boolean fetchNextValue(LogicalType category) throws IOException {
+        int left = readPageIfNeed();
+        if (left > 0) {
+            // get the values of repetition and definitionLevel
+            readRepetitionAndDefinitionLevels();
+            // read the data if it isn't null
+            if (definitionLevel == maxDefLevel) {
+                if (isCurrentPageDictionaryEncoded) {
+                    lastValue = dataColumn.readValueDictionaryId();
+                } else {
+                    lastValue = readPrimitiveTypedRow(category);
+                }
+            } else {
+                lastValue = null;
+            }
+            return true;
+        } else {
+            eof = true;
+            return false;
+        }
+    }
+
+    private int readPageIfNeed() throws IOException {
+        // Compute the number of values we want to read in this page.
+        int leftInPage = (int) (endOfPageValueCount - valuesRead);
+        if (leftInPage == 0) {
+            // no data left in current page, load data from new page
+            readPage();
+            leftInPage = (int) (endOfPageValueCount - valuesRead);
+        }
+        return leftInPage;
+    }
+
+    // Need to be in consistent with that VectorizedPrimitiveColumnReader#readBatchHelper
+    // TODO Reduce the duplicated code
+    private Object readPrimitiveTypedRow(LogicalType category) {
+        switch (category.getTypeRoot()) {
+            case CHAR:
+            case VARCHAR:
+            case BINARY:
+            case VARBINARY:
+                return dataColumn.readString();
+            case BOOLEAN:
+                return dataColumn.readBoolean();
+            case TIME_WITHOUT_TIME_ZONE:
+            case DATE:
+            case INTEGER:
+                return dataColumn.readInteger();
+            case TINYINT:
+                return dataColumn.readTinyInt();
+            case SMALLINT:
+                return dataColumn.readSmallInt();
+            case BIGINT:
+                return dataColumn.readLong();
+            case FLOAT:
+                return dataColumn.readFloat();
+            case DOUBLE:
+                return dataColumn.readDouble();
+            case DECIMAL:
+                switch (descriptor.getPrimitiveType().getPrimitiveTypeName()) {
+                    case INT32:
+                        return dataColumn.readInteger();
+                    case INT64:
+                        return dataColumn.readLong();
+                    case BINARY:
+                    case FIXED_LEN_BYTE_ARRAY:
+                        return dataColumn.readString();
+                }
+            case TIMESTAMP_WITHOUT_TIME_ZONE:
+            case TIMESTAMP_WITH_LOCAL_TIME_ZONE:
+                return dataColumn.readTimestamp();
+            default:
+                throw new RuntimeException("Unsupported type in the list: " + type);
+        }
+    }
+
+    private Object dictionaryDecodeValue(LogicalType category, Integer dictionaryValue) {
+        if (dictionaryValue == null) {
+            return null;
+        }
+
+        switch (category.getTypeRoot()) {
+            case CHAR:
+            case VARCHAR:
+            case BINARY:
+            case VARBINARY:
+                return dictionary.readString(dictionaryValue);
+            case DATE:
+            case TIME_WITHOUT_TIME_ZONE:
+            case INTEGER:
+                return dictionary.readInteger(dictionaryValue);
+            case BOOLEAN:
+                return dictionary.readBoolean(dictionaryValue) ? 1 : 0;
+            case DOUBLE:
+                return dictionary.readDouble(dictionaryValue);
+            case FLOAT:
+                return dictionary.readFloat(dictionaryValue);
+            case TINYINT:
+                return dictionary.readTinyInt(dictionaryValue);
+            case SMALLINT:
+                return dictionary.readSmallInt(dictionaryValue);
+            case BIGINT:
+                return dictionary.readLong(dictionaryValue);
+            case DECIMAL:
+                switch (descriptor.getPrimitiveType().getPrimitiveTypeName()) {
+                    case INT32:
+                        return dictionary.readInteger(dictionaryValue);
+                    case INT64:
+                        return dictionary.readLong(dictionaryValue);
+                    case FIXED_LEN_BYTE_ARRAY:
+                    case BINARY:
+                        return dictionary.readString(dictionaryValue);
+                }
+            case TIMESTAMP_WITHOUT_TIME_ZONE:
+            case TIMESTAMP_WITH_LOCAL_TIME_ZONE:
+                return dictionary.readTimestamp(dictionaryValue);
+            default:
+                throw new RuntimeException("Unsupported type in the list: " + type);
+        }
+    }
+
+    /**
+     * Collects data from a parquet page and returns the final row index where it stopped. The
+     * returned index can be equal to or less than total.
+     *
+     * @param total maximum number of rows to collect
+     * @param lcv column vector to do initial setup in data collection time
+     * @param valueList collection of values that will be fed into the vector later
+     * @param category
+     * @return int
+     * @throws IOException
+     */
+    private int collectDataFromParquetPage(
+            int total, HeapArrayVector lcv, List<Object> valueList, LogicalType category)
+            throws IOException {
+        int index = 0;
+        /*
+         * Here is a nested loop for collecting all values from a parquet page.
+         * A column of array type can be considered as a list of lists, so the two loops are as below:
+         * 1. The outer loop iterates on rows (index is a row index, so points to a row in the batch), e.g.:
+         * [0, 2, 3]    <- index: 0
+         * [NULL, 3, 4] <- index: 1
+         *
+         * 2. The inner loop iterates on values within a row (sets all data from parquet data page
+         * for an element in ListColumnVector), so fetchNextValue returns values one-by-one:
+         * 0, 2, 3, NULL, 3, 4
+         *
+         * As described below, the repetition level (repetitionLevel != 0)
+         * can be used to decide when we'll start to read values for the next list.
+         */
+        while (!eof && index < total) {
+            // add element to ListColumnVector one by one
+            lcv.offsets[index] = valueList.size();
+            /*
+             * Let's collect all values for a single list.
+             * Repetition level = 0 means that a new list started there in the parquet page,
+             * in that case, let's exit from the loop, and start to collect value for a new list.
+             */
+            do {
+                /*
+                 * Definition level = 0 when a NULL value was returned instead of a list
+                 * (this is not the same as a NULL value in of a list).
+                 */
+                if (definitionLevel == 0) {
+                    lcv.setNullAt(index);
+                }
+                valueList.add(
+                        isCurrentPageDictionaryEncoded
+                                ? dictionaryDecodeValue(category, (Integer) lastValue)
+                                : lastValue);
+            } while (fetchNextValue(category) && (repetitionLevel != 0));
+
+            lcv.lengths[index] = valueList.size() - lcv.offsets[index];
+            index++;
+        }
+        return index;
+    }
+
+    /**
+     * The lengths & offsets will be initialized as default size (1024), it should be set to the
+     * actual size according to the element number.
+     */
+    private void setChildrenInfo(HeapArrayVector lcv, int itemNum, int elementNum) {
+        lcv.childCount = itemNum;
+        long[] lcvLength = new long[elementNum];
+        long[] lcvOffset = new long[elementNum];
+        System.arraycopy(lcv.lengths, 0, lcvLength, 0, elementNum);
+        System.arraycopy(lcv.offsets, 0, lcvOffset, 0, elementNum);
+        lcv.lengths = lcvLength;
+        lcv.offsets = lcvOffset;
+    }
+
+    private void fillColumnVector(
+            LogicalType category, HeapArrayVector lcv, List valueList, int elementNum) {
+        int total = valueList.size();
+        setChildrenInfo(lcv, total, elementNum);
+        switch (category.getTypeRoot()) {
+            case CHAR:
+            case VARCHAR:
+            case BINARY:
+            case VARBINARY:
+                lcv.child = new HeapBytesVector(total);
+                ((HeapBytesVector) lcv.child).reset();
+                for (int i = 0; i < valueList.size(); i++) {
+                    byte[] src = ((List<byte[]>) valueList).get(i);
+                    if (src == null) {
+                        ((HeapBytesVector) lcv.child).setNullAt(i);
+                    } else {
+                        ((HeapBytesVector) lcv.child).appendBytes(i, src, 0, src.length);
+                    }
+                }
+                break;
+            case BOOLEAN:
+                lcv.child = new HeapBooleanVector(total);
+                ((HeapBooleanVector) lcv.child).reset();
+                for (int i = 0; i < valueList.size(); i++) {
+                    if (valueList.get(i) == null) {
+                        ((HeapBooleanVector) lcv.child).setNullAt(i);
+                    } else {
+                        ((HeapBooleanVector) lcv.child).vector[i] =
+                                ((List<Boolean>) valueList).get(i);
+                    }
+                }
+                break;
+            case TINYINT:
+                lcv.child = new HeapByteVector(total);
+                ((HeapByteVector) lcv.child).reset();
+                for (int i = 0; i < valueList.size(); i++) {
+                    if (valueList.get(i) == null) {
+                        ((HeapByteVector) lcv.child).setNullAt(i);
+                    } else {
+                        ((HeapByteVector) lcv.child).vector[i] =
+                                (byte) ((List<Integer>) valueList).get(i).intValue();
+                    }
+                }
+                break;
+            case SMALLINT:
+                lcv.child = new HeapShortVector(total);
+                ((HeapShortVector) lcv.child).reset();
+                for (int i = 0; i < valueList.size(); i++) {
+                    if (valueList.get(i) == null) {
+                        ((HeapShortVector) lcv.child).setNullAt(i);
+                    } else {
+                        ((HeapShortVector) lcv.child).vector[i] =
+                                (short) ((List<Integer>) valueList).get(i).intValue();
+                    }
+                }
+                break;
+            case INTEGER:
+            case DATE:
+            case TIME_WITHOUT_TIME_ZONE:
+                lcv.child = new HeapIntVector(total);
+                ((HeapIntVector) lcv.child).reset();
+                for (int i = 0; i < valueList.size(); i++) {
+                    if (valueList.get(i) == null) {
+                        ((HeapIntVector) lcv.child).setNullAt(i);
+                    } else {
+                        ((HeapIntVector) lcv.child).vector[i] = ((List<Integer>) valueList).get(i);
+                    }
+                }
+                break;
+            case FLOAT:
+                lcv.child = new HeapFloatVector(total);
+                ((HeapFloatVector) lcv.child).reset();
+                for (int i = 0; i < valueList.size(); i++) {
+                    if (valueList.get(i) == null) {
+                        ((HeapFloatVector) lcv.child).setNullAt(i);
+                    } else {
+                        ((HeapFloatVector) lcv.child).vector[i] = ((List<Float>) valueList).get(i);
+                    }
+                }
+                break;
+            case BIGINT:
+                lcv.child = new HeapLongVector(total);
+                ((HeapLongVector) lcv.child).reset();
+                for (int i = 0; i < valueList.size(); i++) {
+                    if (valueList.get(i) == null) {
+                        ((HeapLongVector) lcv.child).setNullAt(i);
+                    } else {
+                        ((HeapLongVector) lcv.child).vector[i] = ((List<Long>) valueList).get(i);
+                    }
+                }
+                break;
+            case DOUBLE:
+                lcv.child = new HeapDoubleVector(total);
+                ((HeapDoubleVector) lcv.child).reset();
+                for (int i = 0; i < valueList.size(); i++) {
+                    if (valueList.get(i) == null) {
+                        ((HeapDoubleVector) lcv.child).setNullAt(i);
+                    } else {
+                        ((HeapDoubleVector) lcv.child).vector[i] =
+                                ((List<Double>) valueList).get(i);
+                    }
+                }
+                break;
+            case TIMESTAMP_WITHOUT_TIME_ZONE:
+            case TIMESTAMP_WITH_LOCAL_TIME_ZONE:
+                lcv.child = new HeapTimestampVector(total);
+                ((HeapTimestampVector) lcv.child).reset();
+                for (int i = 0; i < valueList.size(); i++) {
+                    if (valueList.get(i) == null) {
+                        ((HeapTimestampVector) lcv.child).setNullAt(i);
+                    } else {
+                        ((HeapTimestampVector) lcv.child)
+                                .setTimestamp(i, ((List<TimestampData>) valueList).get(i));
+                    }
+                }
+                break;
+            case DECIMAL:
+                PrimitiveType.PrimitiveTypeName primitiveTypeName =
+                        descriptor.getPrimitiveType().getPrimitiveTypeName();
+                switch (primitiveTypeName) {
+                    case INT32:
+                        lcv.child = new ParquetDecimalVector(new HeapIntVector(total));
+                        ((HeapIntVector) ((ParquetDecimalVector) lcv.child).vector).reset();
+                        for (int i = 0; i < valueList.size(); i++) {
+                            if (valueList.get(i) == null) {
+                                ((HeapIntVector) ((ParquetDecimalVector) lcv.child).vector)
+                                        .setNullAt(i);
+                            } else {
+                                ((HeapIntVector) ((ParquetDecimalVector) lcv.child).vector)
+                                                .vector[i] =
+                                        ((List<Integer>) valueList).get(i);
+                            }
+                        }
+                        break;
+                    case INT64:
+                        lcv.child = new ParquetDecimalVector(new HeapLongVector(total));
+                        ((HeapLongVector) ((ParquetDecimalVector) lcv.child).vector).reset();
+                        for (int i = 0; i < valueList.size(); i++) {
+                            if (valueList.get(i) == null) {
+                                ((HeapLongVector) ((ParquetDecimalVector) lcv.child).vector)
+                                        .setNullAt(i);
+                            } else {
+                                ((HeapLongVector) ((ParquetDecimalVector) lcv.child).vector)
+                                                .vector[i] =
+                                        ((List<Long>) valueList).get(i);
+                            }
+                        }
+                        break;
+                    default:
+                        lcv.child = new ParquetDecimalVector(new HeapBytesVector(total));
+                        ((HeapBytesVector) ((ParquetDecimalVector) lcv.child).vector).reset();
+                        for (int i = 0; i < valueList.size(); i++) {
+                            byte[] src = ((List<byte[]>) valueList).get(i);
+                            if (valueList.get(i) == null) {
+                                ((HeapBytesVector) ((ParquetDecimalVector) lcv.child).vector)
+                                        .setNullAt(i);
+                            } else {
+                                ((HeapBytesVector) ((ParquetDecimalVector) lcv.child).vector)
+                                        .appendBytes(i, src, 0, src.length);
+                            }
+                        }
+                        break;
+                }
+                break;
+            default:
+                throw new RuntimeException("Unsupported type in the list: " + type);
+        }
+    }
+}

--- a/flink-formats/flink-parquet/src/main/java/org/apache/flink/formats/parquet/vector/reader/BaseVectorizedColumnReader.java
+++ b/flink-formats/flink-parquet/src/main/java/org/apache/flink/formats/parquet/vector/reader/BaseVectorizedColumnReader.java
@@ -1,0 +1,291 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.flink.formats.parquet.vector.reader;
+
+import org.apache.flink.table.data.vector.writable.WritableColumnVector;
+import org.apache.flink.table.types.logical.LogicalType;
+
+import org.apache.parquet.bytes.ByteBufferInputStream;
+import org.apache.parquet.bytes.BytesInput;
+import org.apache.parquet.bytes.BytesUtils;
+import org.apache.parquet.column.ColumnDescriptor;
+import org.apache.parquet.column.Encoding;
+import org.apache.parquet.column.page.DataPage;
+import org.apache.parquet.column.page.DataPageV1;
+import org.apache.parquet.column.page.DataPageV2;
+import org.apache.parquet.column.page.DictionaryPage;
+import org.apache.parquet.column.page.PageReader;
+import org.apache.parquet.column.values.ValuesReader;
+import org.apache.parquet.column.values.rle.RunLengthBitPackingHybridDecoder;
+import org.apache.parquet.io.ParquetDecodingException;
+import org.apache.parquet.schema.Type;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import java.io.ByteArrayInputStream;
+import java.io.IOException;
+
+import static org.apache.parquet.column.ValuesType.DEFINITION_LEVEL;
+import static org.apache.parquet.column.ValuesType.REPETITION_LEVEL;
+import static org.apache.parquet.column.ValuesType.VALUES;
+
+/**
+ * Abstract {@link ColumnReader}. part of the code is referred from Apache Hive and Apache Parquet.
+ */
+public abstract class BaseVectorizedColumnReader implements ColumnReader<WritableColumnVector> {
+
+    private static final Logger LOG = LoggerFactory.getLogger(BaseVectorizedColumnReader.class);
+
+    protected boolean isUtcTimestamp;
+
+    /** Total number of values read. */
+    protected long valuesRead;
+
+    /**
+     * value that indicates the end of the current page. That is, if valuesRead ==
+     * endOfPageValueCount, we are at the end of the page.
+     */
+    protected long endOfPageValueCount;
+
+    /** The dictionary, if this column has dictionary encoding. */
+    protected final ParquetDataColumnReader dictionary;
+
+    /** If true, the current page is dictionary encoded. */
+    protected boolean isCurrentPageDictionaryEncoded;
+
+    /** Maximum definition level for this column. */
+    protected final int maxDefLevel;
+
+    protected int definitionLevel;
+    protected int repetitionLevel;
+
+    /** Repetition/Definition/Value readers. */
+    protected IntIterator repetitionLevelColumn;
+
+    protected IntIterator definitionLevelColumn;
+    protected ParquetDataColumnReader dataColumn;
+
+    /** Total values in the current page. */
+    protected int pageValueCount;
+
+    protected final PageReader pageReader;
+    protected final ColumnDescriptor descriptor;
+    protected final Type type;
+    protected final LogicalType logicalType;
+
+    public BaseVectorizedColumnReader(
+            ColumnDescriptor descriptor,
+            PageReader pageReader,
+            boolean isUtcTimestamp,
+            Type parquetType,
+            LogicalType logicalType)
+            throws IOException {
+        this.descriptor = descriptor;
+        this.type = parquetType;
+        this.pageReader = pageReader;
+        this.maxDefLevel = descriptor.getMaxDefinitionLevel();
+        this.isUtcTimestamp = isUtcTimestamp;
+        this.logicalType = logicalType;
+
+        DictionaryPage dictionaryPage = pageReader.readDictionaryPage();
+        if (dictionaryPage != null) {
+            try {
+                this.dictionary =
+                        ParquetDataColumnReaderFactory.getDataColumnReaderByTypeOnDictionary(
+                                parquetType.asPrimitiveType(),
+                                dictionaryPage
+                                        .getEncoding()
+                                        .initDictionary(descriptor, dictionaryPage),
+                                isUtcTimestamp);
+                this.isCurrentPageDictionaryEncoded = true;
+            } catch (IOException e) {
+                throw new IOException("could not decode the dictionary for " + descriptor, e);
+            }
+        } else {
+            this.dictionary = null;
+            this.isCurrentPageDictionaryEncoded = false;
+        }
+    }
+
+    protected void readRepetitionAndDefinitionLevels() {
+        repetitionLevel = repetitionLevelColumn.nextInt();
+        definitionLevel = definitionLevelColumn.nextInt();
+        valuesRead++;
+    }
+
+    protected void readPage() throws IOException {
+        DataPage page = pageReader.readPage();
+
+        if (page == null) {
+            return;
+        }
+
+        page.accept(
+                new DataPage.Visitor<Void>() {
+                    @Override
+                    public Void visit(DataPageV1 dataPageV1) {
+                        readPageV1(dataPageV1);
+                        return null;
+                    }
+
+                    @Override
+                    public Void visit(DataPageV2 dataPageV2) {
+                        readPageV2(dataPageV2);
+                        return null;
+                    }
+                });
+    }
+
+    private void initDataReader(Encoding dataEncoding, ByteBufferInputStream in, int valueCount)
+            throws IOException {
+        this.pageValueCount = valueCount;
+        this.endOfPageValueCount = valuesRead + pageValueCount;
+        if (dataEncoding.usesDictionary()) {
+            this.dataColumn = null;
+            if (dictionary == null) {
+                throw new IOException(
+                        "could not read page in col "
+                                + descriptor
+                                + " as the dictionary was missing for encoding "
+                                + dataEncoding);
+            }
+            dataColumn =
+                    ParquetDataColumnReaderFactory.getDataColumnReaderByType(
+                            type.asPrimitiveType(),
+                            dataEncoding.getDictionaryBasedValuesReader(
+                                    descriptor, VALUES, dictionary.getDictionary()),
+                            isUtcTimestamp);
+            this.isCurrentPageDictionaryEncoded = true;
+        } else {
+            dataColumn =
+                    ParquetDataColumnReaderFactory.getDataColumnReaderByType(
+                            type.asPrimitiveType(),
+                            dataEncoding.getValuesReader(descriptor, VALUES),
+                            isUtcTimestamp);
+            this.isCurrentPageDictionaryEncoded = false;
+        }
+
+        try {
+            dataColumn.initFromPage(pageValueCount, in);
+        } catch (IOException e) {
+            throw new IOException("could not read page in col " + descriptor, e);
+        }
+    }
+
+    private void readPageV1(DataPageV1 page) {
+        ValuesReader rlReader = page.getRlEncoding().getValuesReader(descriptor, REPETITION_LEVEL);
+        ValuesReader dlReader = page.getDlEncoding().getValuesReader(descriptor, DEFINITION_LEVEL);
+        this.repetitionLevelColumn = new ValuesReaderIntIterator(rlReader);
+        this.definitionLevelColumn = new ValuesReaderIntIterator(dlReader);
+        try {
+            BytesInput bytes = page.getBytes();
+            LOG.debug("page size " + bytes.size() + " bytes and " + pageValueCount + " records");
+            ByteBufferInputStream in = bytes.toInputStream();
+            LOG.debug("reading repetition levels at " + in.position());
+            rlReader.initFromPage(pageValueCount, in);
+            LOG.debug("reading definition levels at " + in.position());
+            dlReader.initFromPage(pageValueCount, in);
+            LOG.debug("reading data at " + in.position());
+            initDataReader(page.getValueEncoding(), in, page.getValueCount());
+        } catch (IOException e) {
+            throw new ParquetDecodingException(
+                    "could not read page " + page + " in col " + descriptor, e);
+        }
+    }
+
+    private void readPageV2(DataPageV2 page) {
+        this.pageValueCount = page.getValueCount();
+        this.repetitionLevelColumn =
+                newRLEIterator(descriptor.getMaxRepetitionLevel(), page.getRepetitionLevels());
+        this.definitionLevelColumn =
+                newRLEIterator(descriptor.getMaxDefinitionLevel(), page.getDefinitionLevels());
+        try {
+            LOG.debug(
+                    "page data size "
+                            + page.getData().size()
+                            + " bytes and "
+                            + pageValueCount
+                            + " records");
+            initDataReader(
+                    page.getDataEncoding(), page.getData().toInputStream(), page.getValueCount());
+        } catch (IOException e) {
+            throw new ParquetDecodingException(
+                    "could not read page " + page + " in col " + descriptor, e);
+        }
+    }
+
+    private IntIterator newRLEIterator(int maxLevel, BytesInput bytes) {
+        try {
+            if (maxLevel == 0) {
+                return new NullIntIterator();
+            }
+            return new RLEIntIterator(
+                    new RunLengthBitPackingHybridDecoder(
+                            BytesUtils.getWidthFromMaxInt(maxLevel),
+                            new ByteArrayInputStream(bytes.toByteArray())));
+        } catch (IOException e) {
+            throw new ParquetDecodingException(
+                    "could not read levels in page for col " + descriptor, e);
+        }
+    }
+
+    /** Utility classes to abstract over different way to read ints with different encodings. */
+    abstract static class IntIterator {
+        abstract int nextInt();
+    }
+
+    /** read ints from {@link ValuesReader}. */
+    protected static final class ValuesReaderIntIterator extends IntIterator {
+        ValuesReader delegate;
+
+        public ValuesReaderIntIterator(ValuesReader delegate) {
+            this.delegate = delegate;
+        }
+
+        @Override
+        int nextInt() {
+            return delegate.readInteger();
+        }
+    }
+
+    /** read ints from {@link RunLengthBitPackingHybridDecoder}. */
+    protected static final class RLEIntIterator extends IntIterator {
+        RunLengthBitPackingHybridDecoder delegate;
+
+        public RLEIntIterator(RunLengthBitPackingHybridDecoder delegate) {
+            this.delegate = delegate;
+        }
+
+        @Override
+        int nextInt() {
+            try {
+                return delegate.readInt();
+            } catch (IOException e) {
+                throw new ParquetDecodingException(e);
+            }
+        }
+    }
+
+    /** return zero. */
+    protected static final class NullIntIterator extends IntIterator {
+        @Override
+        int nextInt() {
+            return 0;
+        }
+    }
+}

--- a/flink-formats/flink-parquet/src/main/java/org/apache/flink/formats/parquet/vector/reader/MapColumnReader.java
+++ b/flink-formats/flink-parquet/src/main/java/org/apache/flink/formats/parquet/vector/reader/MapColumnReader.java
@@ -1,0 +1,70 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.flink.formats.parquet.vector.reader;
+
+import org.apache.flink.table.data.vector.ColumnVector;
+import org.apache.flink.table.data.vector.heap.HeapArrayVector;
+import org.apache.flink.table.data.vector.heap.HeapMapColumnVector;
+import org.apache.flink.table.data.vector.writable.WritableColumnVector;
+import org.apache.flink.table.types.logical.LogicalType;
+import org.apache.flink.table.types.logical.MapType;
+
+import java.io.IOException;
+
+/** Map {@link ColumnReader}. */
+public class MapColumnReader implements ColumnReader<WritableColumnVector> {
+
+    private LogicalType logicalType;
+    private ArrayColumnReader keyReader;
+    private ArrayColumnReader valueReader;
+
+    public MapColumnReader(
+            ArrayColumnReader keyReader, ArrayColumnReader valueReader, LogicalType logicalType) {
+        this.keyReader = keyReader;
+        this.valueReader = valueReader;
+        this.logicalType = logicalType;
+    }
+
+    public void readBatch(int total, ColumnVector column) throws IOException {
+        HeapMapColumnVector mapColumnVector = (HeapMapColumnVector) column;
+        MapType mapType = (MapType) logicalType;
+        // initialize 2 ListColumnVector for keys and values
+        HeapArrayVector keyArrayColumnVector = new HeapArrayVector(total);
+        HeapArrayVector valueArrayColumnVector = new HeapArrayVector(total);
+        // read the keys and values
+        keyReader.readToVector(total, keyArrayColumnVector);
+        valueReader.readToVector(total, valueArrayColumnVector);
+
+        // set the related attributes according to the keys and values
+        mapColumnVector.keys = keyArrayColumnVector.child;
+        mapColumnVector.values = valueArrayColumnVector.child;
+        mapColumnVector.offsets = keyArrayColumnVector.offsets;
+        mapColumnVector.lengths = keyArrayColumnVector.lengths;
+        mapColumnVector.childCount = keyArrayColumnVector.childCount;
+        for (int i = 0; i < keyArrayColumnVector.getLen(); i++) {
+            if (keyArrayColumnVector.isNullAt(i)) {
+                mapColumnVector.setNullAt(i);
+            }
+        }
+    }
+
+    @Override
+    public void readToVector(int readNumber, WritableColumnVector vector) throws IOException {
+        readBatch(readNumber, vector);
+    }
+}

--- a/flink-formats/flink-parquet/src/main/java/org/apache/flink/formats/parquet/vector/reader/ParquetDataColumnReader.java
+++ b/flink-formats/flink-parquet/src/main/java/org/apache/flink/formats/parquet/vector/reader/ParquetDataColumnReader.java
@@ -1,0 +1,166 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.flink.formats.parquet.vector.reader;
+
+import org.apache.flink.table.data.TimestampData;
+
+import org.apache.parquet.bytes.ByteBufferInputStream;
+import org.apache.parquet.column.Dictionary;
+
+import java.io.IOException;
+
+/**
+ * The interface to wrap the underlying Parquet dictionary and non dictionary encoded page reader.
+ */
+public interface ParquetDataColumnReader {
+
+    /**
+     * Initialize the reader by page data.
+     *
+     * @param valueCount value count
+     * @param in page data
+     * @throws IOException
+     */
+    void initFromPage(int valueCount, ByteBufferInputStream in) throws IOException;
+
+    /** @return the next Dictionary ID from the page */
+    int readValueDictionaryId();
+
+    /** @return the next Long from the page */
+    long readLong();
+
+    /** @return the next Integer from the page */
+    int readInteger();
+
+    /** @return the next SmallInt from the page */
+    int readSmallInt();
+
+    /** @return the next TinyInt from the page */
+    int readTinyInt();
+
+    /** @return the next Float from the page */
+    float readFloat();
+
+    /** @return the next Boolean from the page */
+    boolean readBoolean();
+
+    /** @return the next String from the page */
+    byte[] readString();
+
+    /** @return the next Varchar from the page */
+    byte[] readVarchar();
+
+    /** @return the next Char from the page */
+    byte[] readChar();
+
+    /** @return the next Bytes from the page */
+    byte[] readBytes();
+
+    /** @return the next Decimal from the page */
+    byte[] readDecimal();
+
+    /** @return the next Double from the page */
+    double readDouble();
+
+    /** @return the next TimestampData from the page */
+    TimestampData readTimestamp();
+
+    /** @return is data valid */
+    boolean isValid();
+
+    /** @return the underlying dictionary if current reader is dictionary encoded */
+    Dictionary getDictionary();
+
+    /**
+     * @param id in dictionary
+     * @return the Bytes from the dictionary by id
+     */
+    byte[] readBytes(int id);
+
+    /**
+     * @param id in dictionary
+     * @return the Float from the dictionary by id
+     */
+    float readFloat(int id);
+
+    /**
+     * @param id in dictionary
+     * @return the Double from the dictionary by id
+     */
+    double readDouble(int id);
+
+    /**
+     * @param id in dictionary
+     * @return the Integer from the dictionary by id
+     */
+    int readInteger(int id);
+
+    /**
+     * @param id in dictionary
+     * @return the Long from the dictionary by id
+     */
+    long readLong(int id);
+
+    /**
+     * @param id in dictionary
+     * @return the Small Int from the dictionary by id
+     */
+    int readSmallInt(int id);
+
+    /**
+     * @param id in dictionary
+     * @return the tiny int from the dictionary by id
+     */
+    int readTinyInt(int id);
+
+    /**
+     * @param id in dictionary
+     * @return the Boolean from the dictionary by id
+     */
+    boolean readBoolean(int id);
+
+    /**
+     * @param id in dictionary
+     * @return the Decimal from the dictionary by id
+     */
+    byte[] readDecimal(int id);
+
+    /**
+     * @param id in dictionary
+     * @return the TimestampData from the dictionary by id
+     */
+    TimestampData readTimestamp(int id);
+
+    /**
+     * @param id in dictionary
+     * @return the String from the dictionary by id
+     */
+    byte[] readString(int id);
+
+    /**
+     * @param id in dictionary
+     * @return the Varchar from the dictionary by id
+     */
+    byte[] readVarchar(int id);
+
+    /**
+     * @param id in dictionary
+     * @return the Char from the dictionary by id
+     */
+    byte[] readChar(int id);
+}

--- a/flink-formats/flink-parquet/src/main/java/org/apache/flink/formats/parquet/vector/reader/ParquetDataColumnReaderFactory.java
+++ b/flink-formats/flink-parquet/src/main/java/org/apache/flink/formats/parquet/vector/reader/ParquetDataColumnReaderFactory.java
@@ -1,0 +1,275 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.flink.formats.parquet.vector.reader;
+
+import org.apache.flink.table.data.TimestampData;
+
+import org.apache.parquet.bytes.ByteBufferInputStream;
+import org.apache.parquet.column.Dictionary;
+import org.apache.parquet.column.values.ValuesReader;
+import org.apache.parquet.io.api.Binary;
+import org.apache.parquet.schema.PrimitiveType;
+
+import java.io.IOException;
+import java.nio.ByteBuffer;
+import java.nio.ByteOrder;
+
+/**
+ * Parquet file has self-describing schema which may differ from the user required schema (e.g.
+ * schema evolution). This factory is used to retrieve user required typed data via corresponding
+ * reader which reads the underlying data.
+ */
+public final class ParquetDataColumnReaderFactory {
+
+    private ParquetDataColumnReaderFactory() {}
+
+    /** default reader for {@link ParquetDataColumnReader}. */
+    public static class DefaultParquetDataColumnReader implements ParquetDataColumnReader {
+        protected ValuesReader valuesReader;
+        protected Dictionary dict;
+
+        // After the data is read in the parquet type, isValid will be set to true if the data can
+        // be returned in the type defined in HMS.  Otherwise isValid is set to false.
+        boolean isValid = true;
+
+        public DefaultParquetDataColumnReader(ValuesReader valuesReader) {
+            this.valuesReader = valuesReader;
+        }
+
+        public DefaultParquetDataColumnReader(Dictionary dict) {
+            this.dict = dict;
+        }
+
+        @Override
+        public void initFromPage(int i, ByteBufferInputStream in) throws IOException {
+            valuesReader.initFromPage(i, in);
+        }
+
+        @Override
+        public boolean readBoolean() {
+            return valuesReader.readBoolean();
+        }
+
+        @Override
+        public boolean readBoolean(int id) {
+            return dict.decodeToBoolean(id);
+        }
+
+        @Override
+        public byte[] readString(int id) {
+            return dict.decodeToBinary(id).getBytesUnsafe();
+        }
+
+        @Override
+        public byte[] readString() {
+            return valuesReader.readBytes().getBytesUnsafe();
+        }
+
+        @Override
+        public byte[] readVarchar() {
+            // we need to enforce the size here even the types are the same
+            return valuesReader.readBytes().getBytesUnsafe();
+        }
+
+        @Override
+        public byte[] readVarchar(int id) {
+            return dict.decodeToBinary(id).getBytesUnsafe();
+        }
+
+        @Override
+        public byte[] readChar() {
+            return valuesReader.readBytes().getBytesUnsafe();
+        }
+
+        @Override
+        public byte[] readChar(int id) {
+            return dict.decodeToBinary(id).getBytesUnsafe();
+        }
+
+        @Override
+        public byte[] readBytes() {
+            return valuesReader.readBytes().getBytesUnsafe();
+        }
+
+        @Override
+        public byte[] readBytes(int id) {
+            return dict.decodeToBinary(id).getBytesUnsafe();
+        }
+
+        @Override
+        public byte[] readDecimal() {
+            return valuesReader.readBytes().getBytesUnsafe();
+        }
+
+        @Override
+        public byte[] readDecimal(int id) {
+            return dict.decodeToBinary(id).getBytesUnsafe();
+        }
+
+        @Override
+        public float readFloat() {
+            return valuesReader.readFloat();
+        }
+
+        @Override
+        public float readFloat(int id) {
+            return dict.decodeToFloat(id);
+        }
+
+        @Override
+        public double readDouble() {
+            return valuesReader.readDouble();
+        }
+
+        @Override
+        public double readDouble(int id) {
+            return dict.decodeToDouble(id);
+        }
+
+        @Override
+        public TimestampData readTimestamp() {
+            throw new RuntimeException("Unsupported operation");
+        }
+
+        @Override
+        public TimestampData readTimestamp(int id) {
+            throw new RuntimeException("Unsupported operation");
+        }
+
+        @Override
+        public int readInteger() {
+            return valuesReader.readInteger();
+        }
+
+        @Override
+        public int readInteger(int id) {
+            return dict.decodeToInt(id);
+        }
+
+        @Override
+        public boolean isValid() {
+            return isValid;
+        }
+
+        @Override
+        public long readLong(int id) {
+            return dict.decodeToLong(id);
+        }
+
+        @Override
+        public long readLong() {
+            return valuesReader.readLong();
+        }
+
+        @Override
+        public int readSmallInt() {
+            return valuesReader.readInteger();
+        }
+
+        @Override
+        public int readSmallInt(int id) {
+            return dict.decodeToInt(id);
+        }
+
+        @Override
+        public int readTinyInt() {
+            return valuesReader.readInteger();
+        }
+
+        @Override
+        public int readTinyInt(int id) {
+            return dict.decodeToInt(id);
+        }
+
+        @Override
+        public int readValueDictionaryId() {
+            return valuesReader.readValueDictionaryId();
+        }
+
+        public void skip() {
+            valuesReader.skip();
+        }
+
+        @Override
+        public Dictionary getDictionary() {
+            return dict;
+        }
+    }
+
+    /** The reader who reads from the underlying Timestamp value value. */
+    public static class TypesFromInt96PageReader extends DefaultParquetDataColumnReader {
+        private boolean isUtcTimestamp;
+
+        public TypesFromInt96PageReader(ValuesReader realReader, boolean isUtcTimestamp) {
+            super(realReader);
+            this.isUtcTimestamp = isUtcTimestamp;
+        }
+
+        public TypesFromInt96PageReader(Dictionary dict, boolean isUtcTimestamp) {
+            super(dict);
+            this.isUtcTimestamp = isUtcTimestamp;
+        }
+
+        private TimestampData convert(Binary binary) {
+            ByteBuffer buf = binary.toByteBuffer();
+            buf.order(ByteOrder.LITTLE_ENDIAN);
+            long timeOfDayNanos = buf.getLong();
+            int julianDay = buf.getInt();
+            return TimestampColumnReader.int96ToTimestamp(
+                    isUtcTimestamp, timeOfDayNanos, julianDay);
+        }
+
+        @Override
+        public TimestampData readTimestamp(int id) {
+            return convert(dict.decodeToBinary(id));
+        }
+
+        @Override
+        public TimestampData readTimestamp() {
+            return convert(valuesReader.readBytes());
+        }
+    }
+
+    private static ParquetDataColumnReader getDataColumnReaderByTypeHelper(
+            boolean isDictionary,
+            PrimitiveType parquetType,
+            Dictionary dictionary,
+            ValuesReader valuesReader,
+            boolean isUtcTimestamp) {
+        if (parquetType.getPrimitiveTypeName() == PrimitiveType.PrimitiveTypeName.INT96) {
+            return isDictionary
+                    ? new TypesFromInt96PageReader(dictionary, isUtcTimestamp)
+                    : new TypesFromInt96PageReader(valuesReader, isUtcTimestamp);
+        } else {
+            return isDictionary
+                    ? new DefaultParquetDataColumnReader(dictionary)
+                    : new DefaultParquetDataColumnReader(valuesReader);
+        }
+    }
+
+    public static ParquetDataColumnReader getDataColumnReaderByTypeOnDictionary(
+            PrimitiveType parquetType, Dictionary realReader, boolean isUtcTimestamp) {
+        return getDataColumnReaderByTypeHelper(true, parquetType, realReader, null, isUtcTimestamp);
+    }
+
+    public static ParquetDataColumnReader getDataColumnReaderByType(
+            PrimitiveType parquetType, ValuesReader realReader, boolean isUtcTimestamp) {
+        return getDataColumnReaderByTypeHelper(
+                false, parquetType, null, realReader, isUtcTimestamp);
+    }
+}

--- a/flink-formats/flink-parquet/src/main/java/org/apache/flink/formats/parquet/vector/reader/RowColumnReader.java
+++ b/flink-formats/flink-parquet/src/main/java/org/apache/flink/formats/parquet/vector/reader/RowColumnReader.java
@@ -1,0 +1,53 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.flink.formats.parquet.vector.reader;
+
+import org.apache.flink.table.data.vector.heap.HeapRowColumnVector;
+import org.apache.flink.table.data.vector.writable.WritableColumnVector;
+
+import java.io.IOException;
+import java.util.List;
+
+/** Row {@link ColumnReader}. */
+public class RowColumnReader implements ColumnReader<WritableColumnVector> {
+
+    private final List<ColumnReader> fieldReaders;
+
+    public RowColumnReader(List<ColumnReader> fieldReaders) {
+        this.fieldReaders = fieldReaders;
+    }
+
+    @Override
+    public void readToVector(int readNumber, WritableColumnVector vector) throws IOException {
+        HeapRowColumnVector rowColumnVector = (HeapRowColumnVector) vector;
+        WritableColumnVector[] vectors = rowColumnVector.fields;
+        for (int i = 0; i < vectors.length; i++) {
+            fieldReaders.get(i).readToVector(readNumber, vectors[i]);
+
+            for (int j = 0; j < readNumber; j++) {
+                boolean isNull =
+                        (i == 0)
+                                ? vectors[i].isNullAt(j)
+                                : rowColumnVector.isNullAt(j) && vectors[i].isNullAt(j);
+                if (isNull) {
+                    rowColumnVector.setNullAt(j);
+                }
+            }
+        }
+    }
+}

--- a/flink-formats/flink-parquet/src/main/java/org/apache/flink/formats/parquet/vector/reader/TimestampColumnReader.java
+++ b/flink-formats/flink-parquet/src/main/java/org/apache/flink/formats/parquet/vector/reader/TimestampColumnReader.java
@@ -95,7 +95,7 @@ public class TimestampColumnReader extends AbstractColumnReader<WritableTimestam
         return int96ToTimestamp(utcTimestamp, buffer.getLong(), buffer.getInt());
     }
 
-    private static TimestampData int96ToTimestamp(
+    public static TimestampData int96ToTimestamp(
             boolean utcTimestamp, long nanosOfDay, int julianDay) {
         long millisecond = julianDayToMillis(julianDay) + (nanosOfDay / NANOS_PER_MILLISECOND);
 

--- a/flink-formats/flink-parquet/src/test/java/org/apache/flink/formats/parquet/utils/ParquetWriterUtil.java
+++ b/flink-formats/flink-parquet/src/test/java/org/apache/flink/formats/parquet/utils/ParquetWriterUtil.java
@@ -19,24 +19,37 @@
 package org.apache.flink.formats.parquet.utils;
 
 import org.apache.flink.core.fs.Path;
-import org.apache.flink.types.Row;
+import org.apache.flink.table.data.ArrayData;
+import org.apache.flink.table.data.DecimalData;
+import org.apache.flink.table.data.MapData;
+import org.apache.flink.table.data.RowData;
+import org.apache.flink.table.data.StringData;
+import org.apache.flink.table.data.TimestampData;
+import org.apache.flink.table.types.logical.ArrayType;
+import org.apache.flink.table.types.logical.DecimalType;
+import org.apache.flink.table.types.logical.LocalZonedTimestampType;
+import org.apache.flink.table.types.logical.LogicalType;
+import org.apache.flink.table.types.logical.MapType;
+import org.apache.flink.table.types.logical.RowType;
+import org.apache.flink.table.types.logical.TimestampType;
+import org.apache.flink.util.Preconditions;
 
 import org.apache.hadoop.conf.Configuration;
 import org.apache.parquet.hadoop.ParquetWriter;
 import org.apache.parquet.hadoop.api.WriteSupport;
 import org.apache.parquet.io.api.Binary;
 import org.apache.parquet.io.api.RecordConsumer;
+import org.apache.parquet.schema.GroupType;
+import org.apache.parquet.schema.LogicalTypeAnnotation;
 import org.apache.parquet.schema.MessageType;
 import org.apache.parquet.schema.PrimitiveType;
+import org.apache.parquet.schema.Type;
 
 import java.io.File;
 import java.io.IOException;
-import java.math.BigDecimal;
 import java.nio.ByteBuffer;
 import java.nio.ByteOrder;
-import java.nio.charset.StandardCharsets;
 import java.sql.Timestamp;
-import java.time.LocalDateTime;
 import java.util.Arrays;
 import java.util.HashMap;
 import java.util.List;
@@ -50,98 +63,27 @@ import static org.apache.flink.formats.parquet.vector.reader.TimestampColumnRead
 public class ParquetWriterUtil {
 
     public static Path createTempParquetFile(
-            File folder, MessageType schema, List<Row> records, int rowGroupSize)
+            File folder,
+            MessageType schema,
+            RowType rowType,
+            List<RowData> records,
+            int rowGroupSize)
             throws IOException {
         Path path = new Path(folder.getPath(), UUID.randomUUID().toString());
-        writeParquetFile(path, schema, records, rowGroupSize);
+        writeParquetFile(path, schema, rowType, records, rowGroupSize);
         return path;
     }
 
     public static void writeParquetFile(
-            Path path, MessageType schema, List<Row> records, int rowGroupSize) throws IOException {
-        WriteSupport<Row> support =
-                new WriteSupport<Row>() {
-                    private RecordConsumer consumer;
-
-                    @Override
-                    public WriteContext init(Configuration configuration) {
-                        return new WriteContext(schema, new HashMap<>());
-                    }
-
-                    @Override
-                    public void prepareForWrite(RecordConsumer consumer) {
-                        this.consumer = consumer;
-                    }
-
-                    @Override
-                    public void write(Row row) {
-                        consumer.startMessage();
-                        for (int i = 0; i < row.getArity(); i++) {
-                            PrimitiveType type = schema.getColumns().get(i).getPrimitiveType();
-                            Object field = row.getField(i);
-                            if (field != null) {
-                                consumer.startField("f" + i, i);
-                                switch (type.getPrimitiveTypeName()) {
-                                    case INT64:
-                                        consumer.addLong(((Number) field).longValue());
-                                        break;
-                                    case INT32:
-                                        consumer.addInteger(((Number) field).intValue());
-                                        break;
-                                    case BOOLEAN:
-                                        consumer.addBoolean((Boolean) field);
-                                        break;
-                                    case BINARY:
-                                        if (field instanceof String) {
-                                            field =
-                                                    ((String) field)
-                                                            .getBytes(StandardCharsets.UTF_8);
-                                        } else if (field instanceof BigDecimal) {
-                                            field =
-                                                    ((BigDecimal) field)
-                                                            .unscaledValue()
-                                                            .toByteArray();
-                                        }
-                                        consumer.addBinary(
-                                                Binary.fromConstantByteArray((byte[]) field));
-                                        break;
-                                    case FLOAT:
-                                        consumer.addFloat(((Number) field).floatValue());
-                                        break;
-                                    case DOUBLE:
-                                        consumer.addDouble(((Number) field).doubleValue());
-                                        break;
-                                    case INT96:
-                                        consumer.addBinary(timestampToInt96((LocalDateTime) field));
-                                        break;
-                                    case FIXED_LEN_BYTE_ARRAY:
-                                        byte[] bytes =
-                                                ((BigDecimal) field).unscaledValue().toByteArray();
-                                        byte signByte = (byte) (bytes[0] < 0 ? -1 : 0);
-                                        int numBytes = 16;
-                                        byte[] newBytes = new byte[numBytes];
-                                        Arrays.fill(newBytes, 0, numBytes - bytes.length, signByte);
-                                        System.arraycopy(
-                                                bytes,
-                                                0,
-                                                newBytes,
-                                                numBytes - bytes.length,
-                                                bytes.length);
-                                        consumer.addBinary(Binary.fromConstantByteArray(newBytes));
-                                        break;
-                                }
-                                consumer.endField("f" + i, i);
-                            }
-                        }
-                        consumer.endMessage();
-                    }
-                };
-        ParquetWriter<Row> writer =
+            Path path, MessageType schema, RowType rowType, List<RowData> records, int rowGroupSize)
+            throws IOException {
+        WriteSupport<RowData> support = new ParquetWriteSupport(schema, rowType);
+        ParquetWriter<RowData> writer =
                 new ParquetWriterBuilder(new org.apache.hadoop.fs.Path(path.getPath()), support)
                         .withRowGroupSize(rowGroupSize)
                         .build();
 
-        for (Row record : records) {
+        for (RowData record : records) {
             writer.write(record);
         }
 
@@ -149,11 +91,12 @@ public class ParquetWriterUtil {
     }
 
     private static class ParquetWriterBuilder
-            extends ParquetWriter.Builder<Row, ParquetWriterBuilder> {
+            extends ParquetWriter.Builder<RowData, ParquetWriterBuilder> {
 
-        private final WriteSupport<Row> support;
+        private final WriteSupport<RowData> support;
 
-        private ParquetWriterBuilder(org.apache.hadoop.fs.Path path, WriteSupport<Row> support) {
+        private ParquetWriterBuilder(
+                org.apache.hadoop.fs.Path path, WriteSupport<RowData> support) {
             super(path);
             this.support = support;
         }
@@ -164,13 +107,530 @@ public class ParquetWriterUtil {
         }
 
         @Override
-        protected WriteSupport<Row> getWriteSupport(Configuration conf) {
+        protected WriteSupport<RowData> getWriteSupport(Configuration conf) {
             return support;
         }
     }
 
-    private static Binary timestampToInt96(LocalDateTime time) {
-        Timestamp timestamp = Timestamp.valueOf(time);
+    private static class ParquetWriteSupport extends WriteSupport<RowData> {
+
+        private RecordConsumer recordConsumer;
+        private MessageType schema;
+        private final FieldWriter[] filedWriters;
+        private final String[] fieldNames;
+
+        ParquetWriteSupport(MessageType schema, RowType rowType) {
+            this.schema = schema;
+            this.filedWriters = new FieldWriter[rowType.getFieldCount()];
+            this.fieldNames = rowType.getFieldNames().toArray(new String[0]);
+            for (int i = 0; i < rowType.getFieldCount(); i++) {
+                this.filedWriters[i] = createWriter(rowType.getTypeAt(i), schema.getType(i));
+            }
+        }
+
+        @Override
+        public WriteContext init(Configuration configuration) {
+            return new WriteContext(schema, new HashMap<>());
+        }
+
+        @Override
+        public void prepareForWrite(RecordConsumer recordConsumer) {
+            this.recordConsumer = recordConsumer;
+        }
+
+        @Override
+        public void write(RowData record) {
+            recordConsumer.startMessage();
+            for (int i = 0; i < filedWriters.length; i++) {
+                if (!record.isNullAt(i)) {
+                    String fieldName = fieldNames[i];
+                    FieldWriter writer = filedWriters[i];
+
+                    recordConsumer.startField(fieldName, i);
+                    writer.write(record, i);
+                    recordConsumer.endField(fieldName, i);
+                }
+            }
+            recordConsumer.endMessage();
+        }
+
+        private FieldWriter createWriter(LogicalType t, Type type) {
+            if (type.isPrimitive()) {
+                switch (t.getTypeRoot()) {
+                    case CHAR:
+                    case VARCHAR:
+                        return new StringWriter();
+                    case BOOLEAN:
+                        return new BooleanWriter();
+                    case BINARY:
+                    case VARBINARY:
+                        return new BinaryWriter();
+                    case DECIMAL:
+                        DecimalType decimalType = (DecimalType) t;
+                        PrimitiveType.PrimitiveTypeName primitiveTypeName =
+                                type.asPrimitiveType().getPrimitiveTypeName();
+                        return createDecimalWriter(
+                                primitiveTypeName,
+                                decimalType.getPrecision(),
+                                decimalType.getScale());
+                    case TINYINT:
+                        return new ByteWriter();
+                    case SMALLINT:
+                        return new ShortWriter();
+                    case DATE:
+                    case TIME_WITHOUT_TIME_ZONE:
+                    case INTEGER:
+                        return new IntWriter();
+                    case BIGINT:
+                        return new LongWriter();
+                    case FLOAT:
+                        return new FloatWriter();
+                    case DOUBLE:
+                        return new DoubleWriter();
+                    case TIMESTAMP_WITHOUT_TIME_ZONE:
+                        TimestampType timestampType = (TimestampType) t;
+                        return new TimestampWriter(timestampType.getPrecision());
+                    case TIMESTAMP_WITH_LOCAL_TIME_ZONE:
+                        LocalZonedTimestampType localZonedTimestampType =
+                                (LocalZonedTimestampType) t;
+                        return new TimestampWriter(localZonedTimestampType.getPrecision());
+                    default:
+                        throw new UnsupportedOperationException("Unsupported type: " + type);
+                }
+            } else {
+                GroupType groupType = type.asGroupType();
+                LogicalTypeAnnotation logicalType = type.getLogicalTypeAnnotation();
+
+                if (t instanceof ArrayType
+                        && logicalType instanceof LogicalTypeAnnotation.ListLogicalTypeAnnotation) {
+                    return new ArrayWriter(((ArrayType) t).getElementType(), groupType);
+                } else if (t instanceof MapType
+                        && logicalType instanceof LogicalTypeAnnotation.MapLogicalTypeAnnotation) {
+                    return new MapWriter(
+                            ((MapType) t).getKeyType(), ((MapType) t).getValueType(), groupType);
+                } else if (t instanceof RowType && type instanceof GroupType) {
+                    return new RowWriter(t, groupType);
+                } else {
+                    throw new UnsupportedOperationException("Unsupported type: " + type);
+                }
+            }
+        }
+
+        private FieldWriter createDecimalWriter(
+                PrimitiveType.PrimitiveTypeName primitiveTypeName, int precision, int scale) {
+            Preconditions.checkArgument(
+                    precision <= DecimalType.MAX_PRECISION,
+                    "Decimal precision %s exceeds max precision %s",
+                    precision,
+                    DecimalType.MAX_PRECISION);
+
+            class DecimalIntWriter implements FieldWriter {
+                @Override
+                public void write(Object value) {
+                    int v = ((DecimalData) value).toBigDecimal().unscaledValue().intValue();
+                    recordConsumer.addInteger(v);
+                }
+
+                @Override
+                public void write(RowData row, int ordinal) {
+                    int v =
+                            row.getDecimal(ordinal, precision, scale)
+                                    .toBigDecimal()
+                                    .unscaledValue()
+                                    .intValue();
+                    recordConsumer.addInteger(v);
+                }
+            }
+
+            class DecimalLongWriter implements FieldWriter {
+                @Override
+                public void write(Object value) {
+                    long v = ((DecimalData) value).toBigDecimal().unscaledValue().longValue();
+                    recordConsumer.addLong(v);
+                }
+
+                @Override
+                public void write(RowData row, int ordinal) {
+                    long v =
+                            row.getDecimal(ordinal, precision, scale)
+                                    .toBigDecimal()
+                                    .unscaledValue()
+                                    .longValue();
+                    recordConsumer.addLong(v);
+                }
+            }
+
+            class DecimalFixedLenWriter implements FieldWriter {
+                @Override
+                public void write(Object value) {
+                    byte[] bytes =
+                            ((DecimalData) value).toBigDecimal().unscaledValue().toByteArray();
+                    addRecord(bytes);
+                }
+
+                @Override
+                public void write(RowData row, int ordinal) {
+                    byte[] bytes =
+                            row.getDecimal(ordinal, precision, scale)
+                                    .toBigDecimal()
+                                    .unscaledValue()
+                                    .toByteArray();
+                    addRecord(bytes);
+                }
+
+                private void addRecord(byte[] bytes) {
+                    byte signByte = (byte) (bytes[0] < 0 ? -1 : 0);
+                    int numBytes = 16;
+                    byte[] newBytes = new byte[numBytes];
+                    Arrays.fill(newBytes, 0, numBytes - bytes.length, signByte);
+                    System.arraycopy(bytes, 0, newBytes, numBytes - bytes.length, bytes.length);
+                    recordConsumer.addBinary(Binary.fromConstantByteArray(newBytes));
+                }
+            }
+
+            class DecimalBytesWriter implements FieldWriter {
+                @Override
+                public void write(Object value) {
+                    recordConsumer.addBinary(
+                            Binary.fromConstantByteArray(
+                                    ((DecimalData) value)
+                                            .toBigDecimal()
+                                            .unscaledValue()
+                                            .toByteArray()));
+                }
+
+                @Override
+                public void write(RowData row, int ordinal) {
+                    byte[] bytes = row.getDecimal(ordinal, precision, scale).toUnscaledBytes();
+                    recordConsumer.addBinary(Binary.fromConstantByteArray(bytes));
+                }
+            }
+
+            switch (primitiveTypeName) {
+                case INT32:
+                    return new DecimalIntWriter();
+                case INT64:
+                    return new DecimalLongWriter();
+                case FIXED_LEN_BYTE_ARRAY:
+                    return new DecimalFixedLenWriter();
+                default:
+                    return new DecimalBytesWriter();
+            }
+        }
+
+        private interface FieldWriter {
+
+            void write(RowData row, int ordinal);
+
+            void write(Object value);
+        }
+
+        private class BooleanWriter implements FieldWriter {
+
+            @Override
+            public void write(RowData row, int ordinal) {
+                recordConsumer.addBoolean(row.getBoolean(ordinal));
+            }
+
+            @Override
+            public void write(Object value) {
+                recordConsumer.addBoolean((boolean) value);
+            }
+        }
+
+        private class ByteWriter implements FieldWriter {
+
+            @Override
+            public void write(RowData row, int ordinal) {
+                recordConsumer.addInteger(row.getByte(ordinal));
+            }
+
+            @Override
+            public void write(Object value) {
+                recordConsumer.addInteger((byte) value);
+            }
+        }
+
+        private class ShortWriter implements FieldWriter {
+
+            @Override
+            public void write(RowData row, int ordinal) {
+                recordConsumer.addInteger(row.getShort(ordinal));
+            }
+
+            @Override
+            public void write(Object value) {
+                recordConsumer.addInteger((short) value);
+            }
+        }
+
+        private class LongWriter implements FieldWriter {
+
+            @Override
+            public void write(RowData row, int ordinal) {
+                recordConsumer.addLong(row.getLong(ordinal));
+            }
+
+            @Override
+            public void write(Object value) {
+                recordConsumer.addLong((long) value);
+            }
+        }
+
+        private class FloatWriter implements FieldWriter {
+
+            @Override
+            public void write(RowData row, int ordinal) {
+                recordConsumer.addFloat(row.getFloat(ordinal));
+            }
+
+            @Override
+            public void write(Object value) {
+                recordConsumer.addFloat((float) value);
+            }
+        }
+
+        private class DoubleWriter implements FieldWriter {
+
+            @Override
+            public void write(RowData row, int ordinal) {
+                recordConsumer.addDouble(row.getDouble(ordinal));
+            }
+
+            @Override
+            public void write(Object value) {
+                recordConsumer.addDouble((double) value);
+            }
+        }
+
+        private class StringWriter implements FieldWriter {
+
+            @Override
+            public void write(RowData row, int ordinal) {
+                recordConsumer.addBinary(
+                        Binary.fromReusedByteArray(row.getString(ordinal).toBytes()));
+            }
+
+            @Override
+            public void write(Object value) {
+                recordConsumer.addBinary(
+                        Binary.fromReusedByteArray(((StringData) value).toBytes()));
+            }
+        }
+
+        private class BinaryWriter implements FieldWriter {
+
+            @Override
+            public void write(RowData row, int ordinal) {
+                recordConsumer.addBinary(Binary.fromReusedByteArray(row.getBinary(ordinal)));
+            }
+
+            @Override
+            public void write(Object value) {
+                recordConsumer.addBinary(Binary.fromReusedByteArray((byte[]) value));
+            }
+        }
+
+        private class IntWriter implements FieldWriter {
+
+            @Override
+            public void write(RowData row, int ordinal) {
+                recordConsumer.addInteger(row.getInt(ordinal));
+            }
+
+            @Override
+            public void write(Object value) {
+                recordConsumer.addInteger((int) value);
+            }
+        }
+
+        private class TimestampWriter implements FieldWriter {
+
+            private final int precision;
+
+            private TimestampWriter(int precision) {
+                this.precision = precision;
+            }
+
+            @Override
+            public void write(RowData row, int ordinal) {
+                recordConsumer.addBinary(timestampToInt96(row.getTimestamp(ordinal, precision)));
+            }
+
+            @Override
+            public void write(Object value) {
+                recordConsumer.addBinary(timestampToInt96((TimestampData) value));
+            }
+        }
+
+        private class MapWriter implements FieldWriter {
+
+            private String repeatedGroupName;
+            private String keyName, valueName;
+            private FieldWriter keyWriter, valueWriter;
+            private ArrayData.ElementGetter keyElementGetter, valueElementGetter;
+
+            private MapWriter(LogicalType keyType, LogicalType valueType, GroupType groupType) {
+
+                // Get the internal map structure (MAP_KEY_VALUE)
+                GroupType repeatedType = groupType.getType(0).asGroupType();
+                this.repeatedGroupName = repeatedType.getName();
+
+                // Get key element information
+                Type type = repeatedType.getType(0);
+                this.keyName = type.getName();
+                this.keyWriter = createWriter(keyType, type);
+
+                // Get value element information
+                Type valuetype = repeatedType.getType(1);
+                this.valueName = valuetype.getName();
+                this.valueWriter = createWriter(valueType, valuetype);
+
+                this.keyElementGetter = ArrayData.createElementGetter(keyType);
+                this.valueElementGetter = ArrayData.createElementGetter(valueType);
+            }
+
+            @Override
+            public void write(RowData row, int ordinal) {
+                recordConsumer.startGroup();
+
+                MapData mapData = row.getMap(ordinal);
+
+                if (mapData != null && mapData.size() > 0) {
+                    recordConsumer.startField(repeatedGroupName, 0);
+
+                    ArrayData keyArray = mapData.keyArray();
+                    ArrayData valueArray = mapData.valueArray();
+                    for (int i = 0; i < keyArray.size(); i++) {
+                        Object key = keyElementGetter.getElementOrNull(keyArray, i);
+                        Object value = valueElementGetter.getElementOrNull(valueArray, i);
+
+                        recordConsumer.startGroup();
+                        if (key != null) {
+                            // write key element
+                            recordConsumer.startField(keyName, 0);
+                            keyWriter.write(key);
+                            recordConsumer.endField(keyName, 0);
+
+                            // write value element
+                            if (value != null) {
+                                recordConsumer.startField(valueName, 1);
+                                valueWriter.write(value);
+                                recordConsumer.endField(valueName, 1);
+                            }
+                        }
+                        recordConsumer.endGroup();
+                    }
+
+                    recordConsumer.endField(repeatedGroupName, 0);
+                }
+                recordConsumer.endGroup();
+            }
+
+            @Override
+            public void write(Object value) {}
+        }
+
+        private class ArrayWriter implements FieldWriter {
+
+            private String elementName;
+            private FieldWriter elementWriter;
+            private String repeatedGroupName;
+            private ArrayData.ElementGetter elementGetter;
+
+            private ArrayWriter(LogicalType t, GroupType groupType) {
+
+                // Get the internal array structure
+                GroupType repeatedType = groupType.getType(0).asGroupType();
+                this.repeatedGroupName = repeatedType.getName();
+
+                Type elementType = repeatedType.getType(0);
+                this.elementName = elementType.getName();
+
+                this.elementWriter = createWriter(t, elementType);
+                this.elementGetter = ArrayData.createElementGetter(t);
+            }
+
+            @Override
+            public void write(RowData row, int ordinal) {
+                recordConsumer.startGroup();
+                ArrayData arrayData = row.getArray(ordinal);
+                int listLength = arrayData.size();
+
+                if (listLength > 0) {
+                    recordConsumer.startField(repeatedGroupName, 0);
+
+                    for (int i = 0; i < listLength; i++) {
+                        Object object = elementGetter.getElementOrNull(arrayData, i);
+                        recordConsumer.startGroup();
+                        if (object != null) {
+                            recordConsumer.startField(elementName, 0);
+                            elementWriter.write(object);
+                            recordConsumer.endField(elementName, 0);
+                        }
+                        recordConsumer.endGroup();
+                    }
+
+                    recordConsumer.endField(repeatedGroupName, 0);
+                }
+                recordConsumer.endGroup();
+            }
+
+            @Override
+            public void write(Object value) {}
+        }
+
+        private class GroupTypeWriter implements FieldWriter {
+            private List<Type> types;
+            private List<LogicalType> logicalTypes;
+            private FieldWriter[] fieldWriters;
+
+            public GroupTypeWriter(LogicalType t, GroupType groupType) {
+                this.types = groupType.getFields();
+                this.logicalTypes = t.getChildren();
+
+                this.fieldWriters = new FieldWriter[types.size()];
+                for (int i = 0; i < fieldWriters.length; i++) {
+                    fieldWriters[i] = createWriter(logicalTypes.get(i), types.get(i));
+                }
+            }
+
+            @Override
+            public void write(RowData row, int ordinal) {
+                RowData rowData = row.getRow(ordinal, types.size());
+                for (int i = 0; i < types.size(); i++) {
+                    Type type = types.get(i);
+                    FieldWriter writer = fieldWriters[i];
+
+                    if (!rowData.isNullAt(i)) {
+                        String fieldName = type.getName();
+                        recordConsumer.startField(fieldName, i);
+                        writer.write(rowData, i);
+                        recordConsumer.endField(fieldName, i);
+                    }
+                }
+            }
+
+            @Override
+            public void write(Object value) {}
+        }
+
+        private class RowWriter extends GroupTypeWriter implements FieldWriter {
+            public RowWriter(LogicalType t, GroupType groupType) {
+                super(t, groupType);
+            }
+
+            @Override
+            public void write(RowData row, int ordinal) {
+                recordConsumer.startGroup();
+                super.write(row, ordinal);
+                recordConsumer.endGroup();
+            }
+        }
+    }
+
+    private static Binary timestampToInt96(TimestampData timestampData) {
+        Timestamp timestamp = timestampData.toTimestamp();
         long mills = timestamp.getTime();
         int julianDay = (int) ((mills / MILLIS_IN_DAY) + JULIAN_EPOCH_OFFSET_DAYS);
         long nanosOfDay =

--- a/flink-formats/flink-parquet/src/test/java/org/apache/flink/formats/parquet/vector/ParquetColumnarRowSplitReaderTest.java
+++ b/flink-formats/flink-parquet/src/test/java/org/apache/flink/formats/parquet/vector/ParquetColumnarRowSplitReaderTest.java
@@ -21,8 +21,15 @@ package org.apache.flink.formats.parquet.vector;
 import org.apache.flink.core.fs.Path;
 import org.apache.flink.table.data.ColumnarRowData;
 import org.apache.flink.table.data.DecimalData;
+import org.apache.flink.table.data.GenericArrayData;
+import org.apache.flink.table.data.GenericMapData;
+import org.apache.flink.table.data.GenericRowData;
+import org.apache.flink.table.data.RowData;
+import org.apache.flink.table.data.StringData;
+import org.apache.flink.table.data.TimestampData;
 import org.apache.flink.table.data.vector.VectorizedColumnBatch;
 import org.apache.flink.table.types.DataType;
+import org.apache.flink.table.types.logical.ArrayType;
 import org.apache.flink.table.types.logical.BigIntType;
 import org.apache.flink.table.types.logical.BooleanType;
 import org.apache.flink.table.types.logical.DateType;
@@ -31,13 +38,14 @@ import org.apache.flink.table.types.logical.DoubleType;
 import org.apache.flink.table.types.logical.FloatType;
 import org.apache.flink.table.types.logical.IntType;
 import org.apache.flink.table.types.logical.LogicalType;
+import org.apache.flink.table.types.logical.MapType;
+import org.apache.flink.table.types.logical.RowType;
 import org.apache.flink.table.types.logical.SmallIntType;
 import org.apache.flink.table.types.logical.TimestampType;
 import org.apache.flink.table.types.logical.TinyIntType;
 import org.apache.flink.table.types.logical.VarCharType;
 import org.apache.flink.table.types.utils.TypeConversions;
 import org.apache.flink.table.utils.DateTimeUtils;
-import org.apache.flink.types.Row;
 
 import org.apache.hadoop.conf.Configuration;
 import org.apache.parquet.schema.MessageType;
@@ -72,7 +80,7 @@ import static org.junit.Assert.assertTrue;
 @RunWith(Parameterized.class)
 public class ParquetColumnarRowSplitReaderTest {
 
-    private static final int FIELD_NUMBER = 15;
+    private static final int FIELD_NUMBER = 33;
     private static final LocalDateTime BASE_TIME = LocalDateTime.now();
 
     private static final MessageType PARQUET_SCHEMA =
@@ -136,7 +144,204 @@ public class ParquetColumnarRowSplitReaderTest {
                             .length(16)
                             .precision(20)
                             .as(OriginalType.DECIMAL)
-                            .named("f14"));
+                            .named("f14"),
+                    Types.list(Type.Repetition.OPTIONAL)
+                            .element(
+                                    Types.primitive(
+                                                    PrimitiveType.PrimitiveTypeName.BINARY,
+                                                    Type.Repetition.OPTIONAL)
+                                            .named("element"))
+                            .named("f15"),
+                    Types.list(Type.Repetition.OPTIONAL)
+                            .element(
+                                    Types.primitive(
+                                                    PrimitiveType.PrimitiveTypeName.BOOLEAN,
+                                                    Type.Repetition.OPTIONAL)
+                                            .named("element"))
+                            .named("f16"),
+                    Types.list(Type.Repetition.OPTIONAL)
+                            .element(
+                                    Types.primitive(
+                                                    PrimitiveType.PrimitiveTypeName.INT32,
+                                                    Type.Repetition.OPTIONAL)
+                                            .named("element"))
+                            .named("f17"),
+                    Types.list(Type.Repetition.OPTIONAL)
+                            .element(
+                                    Types.primitive(
+                                                    PrimitiveType.PrimitiveTypeName.INT32,
+                                                    Type.Repetition.OPTIONAL)
+                                            .named("element"))
+                            .named("f18"),
+                    Types.list(Type.Repetition.OPTIONAL)
+                            .element(
+                                    Types.primitive(
+                                                    PrimitiveType.PrimitiveTypeName.INT32,
+                                                    Type.Repetition.OPTIONAL)
+                                            .named("element"))
+                            .named("f19"),
+                    Types.list(Type.Repetition.OPTIONAL)
+                            .element(
+                                    Types.primitive(
+                                                    PrimitiveType.PrimitiveTypeName.INT64,
+                                                    Type.Repetition.OPTIONAL)
+                                            .named("element"))
+                            .named("f20"),
+                    Types.list(Type.Repetition.OPTIONAL)
+                            .element(
+                                    Types.primitive(
+                                                    PrimitiveType.PrimitiveTypeName.FLOAT,
+                                                    Type.Repetition.OPTIONAL)
+                                            .named("element"))
+                            .named("f21"),
+                    Types.list(Type.Repetition.OPTIONAL)
+                            .element(
+                                    Types.primitive(
+                                                    PrimitiveType.PrimitiveTypeName.DOUBLE,
+                                                    Type.Repetition.OPTIONAL)
+                                            .named("element"))
+                            .named("f22"),
+                    Types.list(Type.Repetition.OPTIONAL)
+                            .element(
+                                    Types.primitive(
+                                                    PrimitiveType.PrimitiveTypeName.INT96,
+                                                    Type.Repetition.OPTIONAL)
+                                            .named("element"))
+                            .named("f23"),
+                    Types.list(Type.Repetition.OPTIONAL)
+                            .element(
+                                    Types.primitive(
+                                                    PrimitiveType.PrimitiveTypeName.INT32,
+                                                    Type.Repetition.OPTIONAL)
+                                            .precision(5)
+                                            .as(OriginalType.DECIMAL)
+                                            .named("element"))
+                            .named("f24"),
+                    Types.list(Type.Repetition.OPTIONAL)
+                            .element(
+                                    Types.primitive(
+                                                    PrimitiveType.PrimitiveTypeName.INT64,
+                                                    Type.Repetition.OPTIONAL)
+                                            .precision(15)
+                                            .as(OriginalType.DECIMAL)
+                                            .named("element"))
+                            .named("f25"),
+                    Types.list(Type.Repetition.OPTIONAL)
+                            .element(
+                                    Types.primitive(
+                                                    PrimitiveType.PrimitiveTypeName.BINARY,
+                                                    Type.Repetition.OPTIONAL)
+                                            .precision(20)
+                                            .as(OriginalType.DECIMAL)
+                                            .named("element"))
+                            .named("f26"),
+                    Types.list(Type.Repetition.OPTIONAL)
+                            .element(
+                                    Types.primitive(
+                                                    PrimitiveType.PrimitiveTypeName
+                                                            .FIXED_LEN_BYTE_ARRAY,
+                                                    Type.Repetition.OPTIONAL)
+                                            .length(16)
+                                            .precision(5)
+                                            .as(OriginalType.DECIMAL)
+                                            .named("element"))
+                            .named("f27"),
+                    Types.list(Type.Repetition.OPTIONAL)
+                            .element(
+                                    Types.primitive(
+                                                    PrimitiveType.PrimitiveTypeName
+                                                            .FIXED_LEN_BYTE_ARRAY,
+                                                    Type.Repetition.OPTIONAL)
+                                            .length(16)
+                                            .precision(15)
+                                            .as(OriginalType.DECIMAL)
+                                            .named("element"))
+                            .named("f28"),
+                    Types.list(Type.Repetition.OPTIONAL)
+                            .element(
+                                    Types.primitive(
+                                                    PrimitiveType.PrimitiveTypeName
+                                                            .FIXED_LEN_BYTE_ARRAY,
+                                                    Type.Repetition.OPTIONAL)
+                                            .length(16)
+                                            .precision(20)
+                                            .as(OriginalType.DECIMAL)
+                                            .named("element"))
+                            .named("f29"),
+                    Types.map(Type.Repetition.OPTIONAL)
+                            .key(
+                                    Types.primitive(
+                                                    PrimitiveType.PrimitiveTypeName.BINARY,
+                                                    Type.Repetition.OPTIONAL)
+                                            .named("key"))
+                            .value(
+                                    Types.primitive(
+                                                    PrimitiveType.PrimitiveTypeName.BINARY,
+                                                    Type.Repetition.OPTIONAL)
+                                            .named("value"))
+                            .named("f30"),
+                    Types.map(Type.Repetition.OPTIONAL)
+                            .key(
+                                    Types.primitive(
+                                                    PrimitiveType.PrimitiveTypeName.INT32,
+                                                    Type.Repetition.OPTIONAL)
+                                            .named("key"))
+                            .value(
+                                    Types.primitive(
+                                                    PrimitiveType.PrimitiveTypeName.BOOLEAN,
+                                                    Type.Repetition.OPTIONAL)
+                                            .named("value"))
+                            .named("f31"),
+                    Types.buildGroup(Type.Repetition.OPTIONAL)
+                            .addField(
+                                    Types.primitive(
+                                                    PrimitiveType.PrimitiveTypeName.BINARY,
+                                                    Type.Repetition.OPTIONAL)
+                                            .named("f32_1"))
+                            .addField(
+                                    Types.primitive(
+                                                    PrimitiveType.PrimitiveTypeName.INT32,
+                                                    Type.Repetition.OPTIONAL)
+                                            .named("f32_2"))
+                            .named("f32"));
+
+    private static final RowType ROW_TYPE =
+            RowType.of(
+                    new VarCharType(VarCharType.MAX_LENGTH),
+                    new BooleanType(),
+                    new TinyIntType(),
+                    new SmallIntType(),
+                    new IntType(),
+                    new BigIntType(),
+                    new FloatType(),
+                    new DoubleType(),
+                    new TimestampType(9),
+                    new DecimalType(5, 0),
+                    new DecimalType(15, 0),
+                    new DecimalType(20, 0),
+                    new DecimalType(5, 0),
+                    new DecimalType(15, 0),
+                    new DecimalType(20, 0),
+                    new ArrayType(new VarCharType(VarCharType.MAX_LENGTH)),
+                    new ArrayType(new BooleanType()),
+                    new ArrayType(new TinyIntType()),
+                    new ArrayType(new SmallIntType()),
+                    new ArrayType(new IntType()),
+                    new ArrayType(new BigIntType()),
+                    new ArrayType(new FloatType()),
+                    new ArrayType(new DoubleType()),
+                    new ArrayType(new TimestampType(9)),
+                    new ArrayType(new DecimalType(5, 0)),
+                    new ArrayType(new DecimalType(15, 0)),
+                    new ArrayType(new DecimalType(20, 0)),
+                    new ArrayType(new DecimalType(5, 0)),
+                    new ArrayType(new DecimalType(15, 0)),
+                    new ArrayType(new DecimalType(20, 0)),
+                    new MapType(
+                            new VarCharType(VarCharType.MAX_LENGTH),
+                            new VarCharType(VarCharType.MAX_LENGTH)),
+                    new MapType(new IntType(), new BooleanType()),
+                    RowType.of(new VarCharType(VarCharType.MAX_LENGTH), new IntType()));
 
     @ClassRule public static final TemporaryFolder TEMPORARY_FOLDER = new TemporaryFolder();
 
@@ -155,14 +360,14 @@ public class ParquetColumnarRowSplitReaderTest {
     public void testNormalTypesReadWithSplits() throws IOException {
         // prepare parquet file
         int number = 10000;
-        List<Row> records = new ArrayList<>(number);
+        List<RowData> records = new ArrayList<>(number);
         List<Integer> values = new ArrayList<>(number);
         Random random = new Random();
         for (int i = 0; i < number; i++) {
             Integer v = random.nextInt(number / 2);
             if (v % 10 == 0) {
                 values.add(null);
-                records.add(new Row(FIELD_NUMBER));
+                records.add(new GenericRowData(FIELD_NUMBER));
             } else {
                 values.add(v);
                 records.add(newRow(v));
@@ -176,19 +381,25 @@ public class ParquetColumnarRowSplitReaderTest {
     public void testReachEnd() throws Exception {
         // prepare parquet file
         int number = 5;
-        List<Row> records = new ArrayList<>(number);
+        List<RowData> records = new ArrayList<>(number);
         Random random = new Random();
         for (int i = 0; i < number; i++) {
             Integer v = random.nextInt(number / 2);
             if (v % 10 == 0) {
-                records.add(new Row(FIELD_NUMBER));
+                records.add(new GenericRowData(FIELD_NUMBER));
             } else {
                 records.add(newRow(v));
             }
         }
+
         Path testPath =
                 createTempParquetFile(
-                        TEMPORARY_FOLDER.newFolder(), PARQUET_SCHEMA, records, rowGroupSize);
+                        TEMPORARY_FOLDER.newFolder(),
+                        PARQUET_SCHEMA,
+                        ROW_TYPE,
+                        records,
+                        rowGroupSize);
+
         ParquetColumnarRowSplitReader reader =
                 createReader(
                         testPath, 0, testPath.getFileSystem().getFileStatus(testPath).getLen());
@@ -198,11 +409,15 @@ public class ParquetColumnarRowSplitReaderTest {
         assertTrue(reader.reachedEnd());
     }
 
-    private void testNormalTypes(int number, List<Row> records, List<Integer> values)
+    private void testNormalTypes(int number, List<RowData> records, List<Integer> values)
             throws IOException {
         Path testPath =
                 createTempParquetFile(
-                        TEMPORARY_FOLDER.newFolder(), PARQUET_SCHEMA, records, rowGroupSize);
+                        TEMPORARY_FOLDER.newFolder(),
+                        PARQUET_SCHEMA,
+                        ROW_TYPE,
+                        records,
+                        rowGroupSize);
 
         // test reading and splitting
         long fileLen = testPath.getFileSystem().getFileStatus(testPath).getLen();
@@ -221,33 +436,15 @@ public class ParquetColumnarRowSplitReaderTest {
 
     private ParquetColumnarRowSplitReader createReader(
             Path testPath, long splitStart, long splitLength) throws IOException {
-        LogicalType[] fieldTypes =
-                new LogicalType[] {
-                    new VarCharType(VarCharType.MAX_LENGTH),
-                    new BooleanType(),
-                    new TinyIntType(),
-                    new SmallIntType(),
-                    new IntType(),
-                    new BigIntType(),
-                    new FloatType(),
-                    new DoubleType(),
-                    new TimestampType(9),
-                    new DecimalType(5, 0),
-                    new DecimalType(15, 0),
-                    new DecimalType(20, 0),
-                    new DecimalType(5, 0),
-                    new DecimalType(15, 0),
-                    new DecimalType(20, 0)
-                };
-
         return new ParquetColumnarRowSplitReader(
                 false,
                 true,
                 new Configuration(),
-                fieldTypes,
+                ROW_TYPE.getChildren().toArray(new LogicalType[] {}),
                 new String[] {
                     "f0", "f1", "f2", "f3", "f4", "f5", "f6", "f7", "f8", "f9", "f10", "f11", "f12",
-                    "f13", "f14"
+                    "f13", "f14", "f15", "f16", "f17", "f18", "f19", "f20", "f21", "f22", "f23",
+                    "f24", "f25", "f26", "f27", "f28", "f29", "f30", "f31", "f32"
                 },
                 VectorizedColumnBatch::new,
                 500,
@@ -287,6 +484,24 @@ public class ParquetColumnarRowSplitReaderTest {
                 assertTrue(row.isNullAt(12));
                 assertTrue(row.isNullAt(13));
                 assertTrue(row.isNullAt(14));
+                assertTrue(row.isNullAt(15));
+                assertTrue(row.isNullAt(16));
+                assertTrue(row.isNullAt(17));
+                assertTrue(row.isNullAt(18));
+                assertTrue(row.isNullAt(19));
+                assertTrue(row.isNullAt(20));
+                assertTrue(row.isNullAt(21));
+                assertTrue(row.isNullAt(22));
+                assertTrue(row.isNullAt(23));
+                assertTrue(row.isNullAt(24));
+                assertTrue(row.isNullAt(25));
+                assertTrue(row.isNullAt(26));
+                assertTrue(row.isNullAt(27));
+                assertTrue(row.isNullAt(28));
+                assertTrue(row.isNullAt(29));
+                assertTrue(row.isNullAt(30));
+                assertTrue(row.isNullAt(31));
+                assertTrue(row.isNullAt(32));
             } else {
                 assertEquals("" + v, row.getString(0).toString());
                 assertEquals(v % 2 == 0, row.getBoolean(1));
@@ -297,12 +512,63 @@ public class ParquetColumnarRowSplitReaderTest {
                 assertEquals(v.floatValue(), row.getFloat(6), 0);
                 assertEquals(v.doubleValue(), row.getDouble(7), 0);
                 assertEquals(toDateTime(v), row.getTimestamp(8, 9).toLocalDateTime());
-                assertEquals(BigDecimal.valueOf(v), row.getDecimal(9, 5, 0).toBigDecimal());
-                assertEquals(BigDecimal.valueOf(v), row.getDecimal(10, 15, 0).toBigDecimal());
-                assertEquals(BigDecimal.valueOf(v), row.getDecimal(11, 20, 0).toBigDecimal());
-                assertEquals(BigDecimal.valueOf(v), row.getDecimal(12, 5, 0).toBigDecimal());
-                assertEquals(BigDecimal.valueOf(v), row.getDecimal(13, 15, 0).toBigDecimal());
-                assertEquals(BigDecimal.valueOf(v), row.getDecimal(14, 20, 0).toBigDecimal());
+                if (DecimalData.fromBigDecimal(BigDecimal.valueOf(v), 5, 0) == null) {
+                    assertTrue(row.isNullAt(9));
+                    assertTrue(row.isNullAt(12));
+                    assertTrue(row.isNullAt(24));
+                    assertTrue(row.isNullAt(27));
+                } else {
+                    assertEquals(
+                            DecimalData.fromBigDecimal(BigDecimal.valueOf(v), 5, 0),
+                            row.getDecimal(9, 5, 0));
+                    assertEquals(
+                            DecimalData.fromBigDecimal(BigDecimal.valueOf(v), 5, 0),
+                            row.getDecimal(12, 5, 0));
+                    assertEquals(
+                            DecimalData.fromBigDecimal(BigDecimal.valueOf(v), 5, 0),
+                            row.getArray(24).getDecimal(0, 5, 0));
+                    assertEquals(
+                            DecimalData.fromBigDecimal(BigDecimal.valueOf(v), 5, 0),
+                            row.getArray(27).getDecimal(0, 5, 0));
+                }
+                assertEquals(
+                        DecimalData.fromBigDecimal(BigDecimal.valueOf(v), 15, 0),
+                        row.getDecimal(10, 15, 0));
+                assertEquals(
+                        DecimalData.fromBigDecimal(BigDecimal.valueOf(v), 20, 0),
+                        row.getDecimal(11, 20, 0));
+                assertEquals(
+                        DecimalData.fromBigDecimal(BigDecimal.valueOf(v), 15, 0),
+                        row.getDecimal(13, 15, 0));
+                assertEquals(
+                        DecimalData.fromBigDecimal(BigDecimal.valueOf(v), 20, 0),
+                        row.getDecimal(14, 20, 0));
+                assertEquals("" + v, row.getArray(15).getString(0).toString());
+                assertEquals(v % 2 == 0, row.getArray(16).getBoolean(0));
+                assertEquals(v.byteValue(), row.getArray(17).getByte(0));
+                assertEquals(v.shortValue(), row.getArray(18).getShort(0));
+                assertEquals(v.intValue(), row.getArray(19).getInt(0));
+                assertEquals(v.longValue(), row.getArray(20).getLong(0));
+                assertEquals(v.floatValue(), row.getArray(21).getFloat(0), 0);
+                assertEquals(v.doubleValue(), row.getArray(22).getDouble(0), 0);
+                assertEquals(toDateTime(v), row.getArray(23).getTimestamp(0, 9).toLocalDateTime());
+
+                assertEquals(
+                        DecimalData.fromBigDecimal(BigDecimal.valueOf(v), 15, 0),
+                        row.getArray(25).getDecimal(0, 15, 0));
+                assertEquals(
+                        DecimalData.fromBigDecimal(BigDecimal.valueOf(v), 20, 0),
+                        row.getArray(26).getDecimal(0, 20, 0));
+                assertEquals(
+                        DecimalData.fromBigDecimal(BigDecimal.valueOf(v), 15, 0),
+                        row.getArray(28).getDecimal(0, 15, 0));
+                assertEquals(
+                        DecimalData.fromBigDecimal(BigDecimal.valueOf(v), 20, 0),
+                        row.getArray(29).getDecimal(0, 20, 0));
+                assertEquals("" + v, row.getMap(30).valueArray().getString(0).toString());
+                assertEquals(v % 2 == 0, row.getMap(31).valueArray().getBoolean(0));
+                assertEquals("" + v, row.getRow(32, 2).getString(0).toString());
+                assertEquals(v.intValue(), row.getRow(32, 2).getInt(1));
             }
             i++;
         }
@@ -310,23 +576,70 @@ public class ParquetColumnarRowSplitReaderTest {
         return i - start;
     }
 
-    private Row newRow(Integer v) {
-        return Row.of(
-                "" + v,
+    private RowData newRow(Integer v) {
+        Map<StringData, StringData> f30 = new HashMap<>();
+        f30.put(StringData.fromString("" + v), StringData.fromString("" + v));
+
+        Map<Integer, Boolean> f31 = new HashMap<>();
+        f31.put(v, v % 2 == 0);
+
+        return GenericRowData.of(
+                StringData.fromString("" + v),
                 v % 2 == 0,
-                v,
-                v,
+                v.byteValue(),
+                v.shortValue(),
                 v,
                 v.longValue(),
                 v.floatValue(),
                 v.doubleValue(),
-                toDateTime(v),
-                BigDecimal.valueOf(v),
-                BigDecimal.valueOf(v),
-                BigDecimal.valueOf(v),
-                BigDecimal.valueOf(v),
-                BigDecimal.valueOf(v),
-                BigDecimal.valueOf(v));
+                TimestampData.fromLocalDateTime(toDateTime(v)),
+                DecimalData.fromBigDecimal(BigDecimal.valueOf(v), 5, 0),
+                DecimalData.fromBigDecimal(BigDecimal.valueOf(v), 15, 0),
+                DecimalData.fromBigDecimal(BigDecimal.valueOf(v), 20, 0),
+                DecimalData.fromBigDecimal(BigDecimal.valueOf(v), 5, 0),
+                DecimalData.fromBigDecimal(BigDecimal.valueOf(v), 15, 0),
+                DecimalData.fromBigDecimal(BigDecimal.valueOf(v), 20, 0),
+                new GenericArrayData(new Object[] {StringData.fromString("" + v), null}),
+                new GenericArrayData(new Object[] {v % 2 == 0, null}),
+                new GenericArrayData(new Object[] {v.byteValue(), null}),
+                new GenericArrayData(new Object[] {v.shortValue(), null}),
+                new GenericArrayData(new Object[] {v, null}),
+                new GenericArrayData(new Object[] {v.longValue(), null}),
+                new GenericArrayData(new Object[] {v.floatValue(), null}),
+                new GenericArrayData(new Object[] {v.doubleValue(), null}),
+                new GenericArrayData(
+                        new Object[] {TimestampData.fromLocalDateTime(toDateTime(v)), null}),
+                DecimalData.fromBigDecimal(BigDecimal.valueOf(v), 5, 0) == null
+                        ? null
+                        : new GenericArrayData(
+                                new Object[] {
+                                    DecimalData.fromBigDecimal(BigDecimal.valueOf(v), 5, 0), null
+                                }),
+                new GenericArrayData(
+                        new Object[] {
+                            DecimalData.fromBigDecimal(BigDecimal.valueOf(v), 15, 0), null
+                        }),
+                new GenericArrayData(
+                        new Object[] {
+                            DecimalData.fromBigDecimal(BigDecimal.valueOf(v), 20, 0), null
+                        }),
+                DecimalData.fromBigDecimal(BigDecimal.valueOf(v), 5, 0) == null
+                        ? null
+                        : new GenericArrayData(
+                                new Object[] {
+                                    DecimalData.fromBigDecimal(BigDecimal.valueOf(v), 5, 0), null
+                                }),
+                new GenericArrayData(
+                        new Object[] {
+                            DecimalData.fromBigDecimal(BigDecimal.valueOf(v), 15, 0), null
+                        }),
+                new GenericArrayData(
+                        new Object[] {
+                            DecimalData.fromBigDecimal(BigDecimal.valueOf(v), 20, 0), null
+                        }),
+                new GenericMapData(f30),
+                new GenericMapData(f31),
+                GenericRowData.of(StringData.fromString("" + v), v));
     }
 
     private LocalDateTime toDateTime(Integer v) {
@@ -338,7 +651,7 @@ public class ParquetColumnarRowSplitReaderTest {
     public void testDictionary() throws IOException {
         // prepare parquet file
         int number = 10000;
-        List<Row> records = new ArrayList<>(number);
+        List<RowData> records = new ArrayList<>(number);
         List<Integer> values = new ArrayList<>(number);
         Random random = new Random();
         int[] intValues = new int[10];
@@ -350,7 +663,7 @@ public class ParquetColumnarRowSplitReaderTest {
             Integer v = intValues[random.nextInt(10)];
             if (v == 0) {
                 values.add(null);
-                records.add(new Row(FIELD_NUMBER));
+                records.add(new GenericRowData(FIELD_NUMBER));
             } else {
                 values.add(v);
                 records.add(newRow(v));
@@ -364,7 +677,7 @@ public class ParquetColumnarRowSplitReaderTest {
     public void testPartialDictionary() throws IOException {
         // prepare parquet file
         int number = 10000;
-        List<Row> records = new ArrayList<>(number);
+        List<RowData> records = new ArrayList<>(number);
         List<Integer> values = new ArrayList<>(number);
         Random random = new Random();
         int[] intValues = new int[10];
@@ -376,7 +689,7 @@ public class ParquetColumnarRowSplitReaderTest {
             Integer v = i < 5000 ? intValues[random.nextInt(10)] : i;
             if (v == 0) {
                 values.add(null);
-                records.add(new Row(FIELD_NUMBER));
+                records.add(new GenericRowData(FIELD_NUMBER));
             } else {
                 values.add(v);
                 records.add(newRow(v));
@@ -390,7 +703,7 @@ public class ParquetColumnarRowSplitReaderTest {
     public void testContinuousRepetition() throws IOException {
         // prepare parquet file
         int number = 10000;
-        List<Row> records = new ArrayList<>(number);
+        List<RowData> records = new ArrayList<>(number);
         List<Integer> values = new ArrayList<>(number);
         Random random = new Random();
         for (int i = 0; i < 100; i++) {
@@ -398,7 +711,7 @@ public class ParquetColumnarRowSplitReaderTest {
             for (int j = 0; j < 100; j++) {
                 if (v == 0) {
                     values.add(null);
-                    records.add(new Row(FIELD_NUMBER));
+                    records.add(new GenericRowData(FIELD_NUMBER));
                 } else {
                     values.add(v);
                     records.add(newRow(v));
@@ -413,14 +726,14 @@ public class ParquetColumnarRowSplitReaderTest {
     public void testLargeValue() throws IOException {
         // prepare parquet file
         int number = 10000;
-        List<Row> records = new ArrayList<>(number);
+        List<RowData> records = new ArrayList<>(number);
         List<Integer> values = new ArrayList<>(number);
         Random random = new Random();
         for (int i = 0; i < number; i++) {
             Integer v = random.nextInt();
             if (v % 10 == 0) {
                 values.add(null);
-                records.add(new Row(FIELD_NUMBER));
+                records.add(new GenericRowData(FIELD_NUMBER));
             } else {
                 values.add(v);
                 records.add(newRow(v));
@@ -434,25 +747,26 @@ public class ParquetColumnarRowSplitReaderTest {
     public void testProject() throws IOException {
         // prepare parquet file
         int number = 1000;
-        List<Row> records = new ArrayList<>(number);
+        List<RowData> records = new ArrayList<>(number);
         for (int i = 0; i < number; i++) {
             Integer v = i;
             records.add(newRow(v));
         }
-
         Path testPath =
                 createTempParquetFile(
-                        TEMPORARY_FOLDER.newFolder(), PARQUET_SCHEMA, records, rowGroupSize);
-
+                        TEMPORARY_FOLDER.newFolder(),
+                        PARQUET_SCHEMA,
+                        ROW_TYPE,
+                        records,
+                        rowGroupSize);
+        RowType rowType = RowType.of(new DoubleType(), new TinyIntType(), new IntType());
         // test reader
-        LogicalType[] fieldTypes =
-                new LogicalType[] {new DoubleType(), new TinyIntType(), new IntType()};
         ParquetColumnarRowSplitReader reader =
                 new ParquetColumnarRowSplitReader(
                         false,
                         true,
                         new Configuration(),
-                        fieldTypes,
+                        rowType.getChildren().toArray(new LogicalType[] {}),
                         new String[] {"f7", "f2", "f4"},
                         VectorizedColumnBatch::new,
                         500,
@@ -474,31 +788,34 @@ public class ParquetColumnarRowSplitReaderTest {
     public void testPartitionValues() throws IOException {
         // prepare parquet file
         int number = 1000;
-        List<Row> records = new ArrayList<>(number);
+        List<RowData> records = new ArrayList<>(number);
         for (int i = 0; i < number; i++) {
             Integer v = i;
             records.add(newRow(v));
         }
-
         Path testPath =
                 createTempParquetFile(
-                        TEMPORARY_FOLDER.newFolder(), PARQUET_SCHEMA, records, rowGroupSize);
+                        TEMPORARY_FOLDER.newFolder(),
+                        PARQUET_SCHEMA,
+                        ROW_TYPE,
+                        records,
+                        rowGroupSize);
 
         // test reader
         Map<String, Object> partSpec = new HashMap<>();
-        partSpec.put("f15", true);
-        partSpec.put("f16", Date.valueOf("2020-11-23"));
-        partSpec.put("f17", LocalDateTime.of(1999, 1, 1, 1, 1));
-        partSpec.put("f18", 6.6);
-        partSpec.put("f19", (byte) 9);
-        partSpec.put("f20", (short) 10);
-        partSpec.put("f21", 11);
-        partSpec.put("f22", 12L);
-        partSpec.put("f23", 13f);
-        partSpec.put("f24", new BigDecimal(24));
-        partSpec.put("f25", new BigDecimal(25));
-        partSpec.put("f26", new BigDecimal(26));
-        partSpec.put("f27", "f27");
+        partSpec.put("f33", true);
+        partSpec.put("f34", Date.valueOf("2020-11-23"));
+        partSpec.put("f35", LocalDateTime.of(1999, 1, 1, 1, 1));
+        partSpec.put("f36", 6.6);
+        partSpec.put("f37", (byte) 9);
+        partSpec.put("f38", (short) 10);
+        partSpec.put("f39", 11);
+        partSpec.put("f40", 12L);
+        partSpec.put("f41", 13f);
+        partSpec.put("f42", new BigDecimal(42));
+        partSpec.put("f43", new BigDecimal(43));
+        partSpec.put("f44", new BigDecimal(44));
+        partSpec.put("f45", "f45");
 
         innerTestPartitionValues(testPath, partSpec, false);
 
@@ -528,6 +845,26 @@ public class ParquetColumnarRowSplitReaderTest {
                     new DecimalType(5, 0),
                     new DecimalType(15, 0),
                     new DecimalType(20, 0),
+                    new ArrayType(new VarCharType(VarCharType.MAX_LENGTH)),
+                    new ArrayType(new BooleanType()),
+                    new ArrayType(new TinyIntType()),
+                    new ArrayType(new SmallIntType()),
+                    new ArrayType(new IntType()),
+                    new ArrayType(new BigIntType()),
+                    new ArrayType(new FloatType()),
+                    new ArrayType(new DoubleType()),
+                    new ArrayType(new TimestampType(9)),
+                    new ArrayType(new DecimalType(5, 0)),
+                    new ArrayType(new DecimalType(15, 0)),
+                    new ArrayType(new DecimalType(20, 0)),
+                    new ArrayType(new DecimalType(5, 0)),
+                    new ArrayType(new DecimalType(15, 0)),
+                    new ArrayType(new DecimalType(20, 0)),
+                    new MapType(
+                            new VarCharType(VarCharType.MAX_LENGTH),
+                            new VarCharType(VarCharType.MAX_LENGTH)),
+                    new MapType(new IntType(), new BooleanType()),
+                    RowType.of(new VarCharType(VarCharType.MAX_LENGTH), new IntType()),
                     new BooleanType(),
                     new DateType(),
                     new TimestampType(9),
@@ -547,12 +884,12 @@ public class ParquetColumnarRowSplitReaderTest {
                         false,
                         true,
                         new Configuration(),
-                        IntStream.range(0, 28).mapToObj(i -> "f" + i).toArray(String[]::new),
+                        IntStream.range(0, 46).mapToObj(i -> "f" + i).toArray(String[]::new),
                         Arrays.stream(fieldTypes)
                                 .map(TypeConversions::fromLogicalToDataType)
                                 .toArray(DataType[]::new),
                         partSpec,
-                        new int[] {7, 2, 4, 15, 19, 20, 21, 22, 23, 18, 16, 17, 24, 25, 26, 27},
+                        new int[] {7, 2, 4, 33, 37, 38, 39, 40, 41, 36, 34, 35, 42, 43, 44, 45},
                         rowGroupSize,
                         new Path(testPath.getPath()),
                         0,
@@ -585,15 +922,15 @@ public class ParquetColumnarRowSplitReaderTest {
                         LocalDateTime.of(1999, 1, 1, 1, 1),
                         row.getTimestamp(11, 9).toLocalDateTime());
                 assertEquals(
-                        DecimalData.fromBigDecimal(new BigDecimal(24), 5, 0),
+                        DecimalData.fromBigDecimal(new BigDecimal(42), 5, 0),
                         row.getDecimal(12, 5, 0));
                 assertEquals(
-                        DecimalData.fromBigDecimal(new BigDecimal(25), 15, 0),
+                        DecimalData.fromBigDecimal(new BigDecimal(43), 15, 0),
                         row.getDecimal(13, 15, 0));
                 assertEquals(
-                        DecimalData.fromBigDecimal(new BigDecimal(26), 20, 0),
+                        DecimalData.fromBigDecimal(new BigDecimal(44), 20, 0),
                         row.getDecimal(14, 20, 0));
-                assertEquals("f27", row.getString(15).toString());
+                assertEquals("f45", row.getString(15).toString());
             }
 
             i++;

--- a/flink-table/flink-table-runtime/src/main/java/org/apache/flink/table/data/vector/heap/AbstractHeapVector.java
+++ b/flink-table/flink-table-runtime/src/main/java/org/apache/flink/table/data/vector/heap/AbstractHeapVector.java
@@ -46,8 +46,11 @@ public abstract class AbstractHeapVector extends AbstractWritableVector {
     /** Reusable column for ids of dictionary. */
     protected HeapIntVector dictionaryIds;
 
+    private int len;
+
     public AbstractHeapVector(int len) {
         isNull = new boolean[len];
+        this.len = len;
     }
 
     /**
@@ -111,5 +114,9 @@ public abstract class AbstractHeapVector extends AbstractWritableVector {
     @Override
     public HeapIntVector getDictionaryIds() {
         return dictionaryIds;
+    }
+
+    public int getLen() {
+        return this.len;
     }
 }

--- a/flink-table/flink-table-runtime/src/main/java/org/apache/flink/table/data/vector/heap/HeapArrayVector.java
+++ b/flink-table/flink-table-runtime/src/main/java/org/apache/flink/table/data/vector/heap/HeapArrayVector.java
@@ -1,0 +1,55 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.flink.table.data.vector.heap;
+
+import org.apache.flink.table.data.ArrayData;
+import org.apache.flink.table.data.ColumnarArrayData;
+import org.apache.flink.table.data.vector.ArrayColumnVector;
+import org.apache.flink.table.data.vector.ColumnVector;
+import org.apache.flink.table.data.vector.writable.WritableColumnVector;
+
+/** This class represents a nullable heap array column vector. */
+public class HeapArrayVector extends AbstractHeapVector
+        implements WritableColumnVector, ArrayColumnVector {
+
+    public long[] offsets;
+    public long[] lengths;
+    public int childCount;
+    public ColumnVector child;
+
+    public HeapArrayVector(int len) {
+        super(len);
+        offsets = new long[len];
+        lengths = new long[len];
+    }
+
+    public HeapArrayVector(int len, ColumnVector vector) {
+        super(len);
+        offsets = new long[len];
+        lengths = new long[len];
+        this.child = vector;
+    }
+
+    @Override
+    public ArrayData getArray(int i) {
+        long offset = offsets[i];
+        long length = lengths[i];
+        return new ColumnarArrayData(child, (int) offset, (int) length);
+    }
+}

--- a/flink-table/flink-table-runtime/src/main/java/org/apache/flink/table/data/vector/heap/HeapMapColumnVector.java
+++ b/flink-table/flink-table-runtime/src/main/java/org/apache/flink/table/data/vector/heap/HeapMapColumnVector.java
@@ -1,0 +1,52 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.flink.table.data.vector.heap;
+
+import org.apache.flink.table.data.ColumnarMapData;
+import org.apache.flink.table.data.MapData;
+import org.apache.flink.table.data.vector.ColumnVector;
+import org.apache.flink.table.data.vector.MapColumnVector;
+import org.apache.flink.table.data.vector.writable.WritableColumnVector;
+
+/** This class represents a nullable heap map column vector. */
+public class HeapMapColumnVector extends AbstractHeapVector
+        implements WritableColumnVector, MapColumnVector {
+
+    public long[] offsets;
+    public long[] lengths;
+    public int childCount;
+    public ColumnVector keys;
+    public ColumnVector values;
+
+    public HeapMapColumnVector(int len, ColumnVector keys, ColumnVector values) {
+        super(len);
+        childCount = 0;
+        offsets = new long[len];
+        lengths = new long[len];
+        this.keys = keys;
+        this.values = values;
+    }
+
+    @Override
+    public MapData getMap(int i) {
+        long offset = offsets[i];
+        long length = lengths[i];
+        return new ColumnarMapData(keys, values, (int) offset, (int) length);
+    }
+}

--- a/flink-table/flink-table-runtime/src/main/java/org/apache/flink/table/data/vector/heap/HeapRowColumnVector.java
+++ b/flink-table/flink-table-runtime/src/main/java/org/apache/flink/table/data/vector/heap/HeapRowColumnVector.java
@@ -1,0 +1,25 @@
+package org.apache.flink.table.data.vector.heap;
+
+import org.apache.flink.table.data.ColumnarRowData;
+import org.apache.flink.table.data.vector.RowColumnVector;
+import org.apache.flink.table.data.vector.VectorizedColumnBatch;
+import org.apache.flink.table.data.vector.writable.WritableColumnVector;
+
+/** This class represents a nullable heap row column vector. */
+public class HeapRowColumnVector extends AbstractHeapVector
+        implements WritableColumnVector, RowColumnVector {
+
+    public WritableColumnVector[] fields;
+
+    public HeapRowColumnVector(int len, WritableColumnVector... fields) {
+        super(len);
+        this.fields = fields;
+    }
+
+    @Override
+    public ColumnarRowData getRow(int i) {
+        ColumnarRowData columnarRowData = new ColumnarRowData(new VectorizedColumnBatch(fields));
+        columnarRowData.setRowId(i);
+        return columnarRowData;
+    }
+}


### PR DESCRIPTION
## What is the purpose of the change

 Add array,map,row types support for parquet vectorized reader

## Does this pull request potentially affect one of the following parts:

  - Dependencies (does it add or upgrade a dependency): (no)
  - The public API, i.e., is any changed class annotated with `@Public(Evolving)`: (no)
  - The serializers: (no)
  - The runtime per-record code paths (performance sensitive): (no)
  - Anything that affects deployment or recovery: JobManager (and its components), Checkpointing, Kubernetes/Yarn, ZooKeeper: (no)
  - The S3 file system connector: (no)

## Documentation

  - Does this pull request introduce a new feature? (no)
  - If yes, how is the feature documented? (docs)
