### PR TITLE
[FLINK-24741]Deprecate FileRecordFormat

### DIFF
--- a/flink-connectors/flink-connector-files/src/main/java/org/apache/flink/connector/file/src/AbstractFileSource.java
+++ b/flink-connectors/flink-connector-files/src/main/java/org/apache/flink/connector/file/src/AbstractFileSource.java
@@ -33,7 +33,6 @@ import org.apache.flink.connector.file.src.impl.ContinuousFileSplitEnumerator;
 import org.apache.flink.connector.file.src.impl.FileSourceReader;
 import org.apache.flink.connector.file.src.impl.StaticFileSplitEnumerator;
 import org.apache.flink.connector.file.src.reader.BulkFormat;
-import org.apache.flink.connector.file.src.reader.FileRecordFormat;
 import org.apache.flink.connector.file.src.reader.StreamFormat;
 import org.apache.flink.core.fs.Path;
 import org.apache.flink.core.io.SimpleVersionedSerializer;
@@ -55,8 +54,8 @@ import static org.apache.flink.util.Preconditions.checkNotNull;
  * also has the majority of the documentation.
  *
  * <p>To read new formats, one commonly does NOT need to extend this class, but should implement a
- * new Format Reader (like {@link StreamFormat}, {@link BulkFormat}, {@link FileRecordFormat}) and
- * use it with the {@code FileSource}.
+ * new Format Reader (like {@link StreamFormat}, {@link BulkFormat} and use it with the {@code
+ * FileSource}.
  *
  * <p>The only reason to extend this class is when a source needs a different type of <i>split</i>,
  * meaning an extension of the {@link FileSourceSplit} to carry additional information.

--- a/flink-connectors/flink-connector-files/src/main/java/org/apache/flink/connector/file/src/FileSource.java
+++ b/flink-connectors/flink-connector-files/src/main/java/org/apache/flink/connector/file/src/FileSource.java
@@ -51,7 +51,6 @@ import static org.apache.flink.util.Preconditions.checkNotNull;
  * <ul>
  *   <li>{@link FileSource#forRecordStreamFormat(StreamFormat, Path...)}
  *   <li>{@link FileSource#forBulkFileFormat(BulkFormat, Path...)}
- *   <li>{@link FileSource#forRecordFileFormat(FileRecordFormat, Path...)}
  * </ul>
  *
  * <p>This creates a {@link FileSource.FileSourceBuilder} on which you can configure all the
@@ -82,8 +81,6 @@ import static org.apache.flink.util.Preconditions.checkNotNull;
  *   <li>A {@link BulkFormat} reads batches of records from a file at a time. It is the most "low
  *       level" format to implement, but offers the greatest flexibility to optimize the
  *       implementation.
- *   <li>A {@link FileRecordFormat} is in the middle of the trade-off spectrum between the {@code
- *       StreamFormat} and the {@code BulkFormat}.
  * </ul>
  *
  * <h2>Discovering / Enumerating Files</h2>
@@ -186,7 +183,10 @@ public final class FileSource<T> extends AbstractFileSource<T, FileSourceSplit> 
      *
      * <p>A {@code FileRecordFormat} is more general than the {@link StreamFormat}, but also
      * requires often more careful parametrization.
+     *
+     * @deprecated Please use {@link #forRecordStreamFormat(StreamFormat, Path...)} instead.
      */
+    @Deprecated
     public static <T> FileSourceBuilder<T> forRecordFileFormat(
             final FileRecordFormat<T> recordFormat, final Path... paths) {
         return forBulkFileFormat(new FileRecordFormatAdapter<>(recordFormat), paths);
@@ -204,7 +204,6 @@ public final class FileSource<T> extends AbstractFileSource<T, FileSourceSplit> 
      * <ul>
      *   <li>{@link FileSource#forRecordStreamFormat(StreamFormat, Path...)}
      *   <li>{@link FileSource#forBulkFileFormat(BulkFormat, Path...)}
-     *   <li>{@link FileSource#forRecordFileFormat(FileRecordFormat, Path...)}
      * </ul>
      */
     public static final class FileSourceBuilder<T>

--- a/flink-connectors/flink-connector-files/src/main/java/org/apache/flink/connector/file/src/impl/FileRecordFormatAdapter.java
+++ b/flink-connectors/flink-connector-files/src/main/java/org/apache/flink/connector/file/src/impl/FileRecordFormatAdapter.java
@@ -37,7 +37,12 @@ import static org.apache.flink.connector.file.src.util.Utils.doWithCleanupOnExce
 import static org.apache.flink.util.Preconditions.checkArgument;
 import static org.apache.flink.util.Preconditions.checkNotNull;
 
-/** The FormatReaderAdapter turns a {@link FileRecordFormat} into a {@link BulkFormat}. */
+/**
+ * The FormatReaderAdapter turns a {@link FileRecordFormat} into a {@link BulkFormat}.
+ *
+ * @deprecated Please use {@link StreamFormatAdapter} instead.
+ */
+@Deprecated
 @Internal
 public final class FileRecordFormatAdapter<T> implements BulkFormat<T, FileSourceSplit> {
 
@@ -123,7 +128,11 @@ public final class FileRecordFormatAdapter<T> implements BulkFormat<T, FileSourc
 
     // ------------------------------------------------------------------------
 
-    /** The reader adapter, from {@link FileRecordFormat.Reader} to {@link BulkFormat.Reader}. */
+    /**
+     * This interface is Deprecated, use {@link StreamFormatAdapter.Reader} instead.
+     *
+     * <p>The reader adapter, from {@link FileRecordFormat.Reader} to {@link BulkFormat.Reader}.
+     */
     public static final class Reader<T> implements BulkFormat.Reader<T> {
 
         private final FileRecordFormat.Reader<T> reader;

--- a/flink-connectors/flink-connector-files/src/main/java/org/apache/flink/connector/file/src/reader/FileRecordFormat.java
+++ b/flink-connectors/flink-connector-files/src/main/java/org/apache/flink/connector/file/src/reader/FileRecordFormat.java
@@ -90,7 +90,15 @@ import java.io.Serializable;
  *
  * <p>This batching is by default based a number of records. See {@link
  * FileRecordFormat#RECORDS_PER_FETCH} to configure that handover batch size.
+ *
+ * @deprecated Please use {@link StreamFormat} instead. The main motivation for removing it is the
+ *     inherent design flaw in the batching of FileRecordFormat: StreamFormat can guarantee that
+ *     only a certain amount of memory is being used (unless a single record exceeds that already),
+ *     but FileRecordFormat can only batch by the number of records. By removing FileRecordFormat,
+ *     we relay the responsibility of implementing the batching to the format developer; they need
+ *     to use BulkFormat and find a better way than batch by number of records.
  */
+@Deprecated
 @PublicEvolving
 public interface FileRecordFormat<T> extends Serializable, ResultTypeQueryable<T> {
 
@@ -158,7 +166,11 @@ public interface FileRecordFormat<T> extends Serializable, ResultTypeQueryable<T
 
     // ------------------------------------------------------------------------
 
-    /** The actual reader that reads the records. */
+    /**
+     * This interface is Deprecated, use {@link StreamFormat.Reader} instead.
+     *
+     * <p>The actual reader that reads the records.
+     */
     interface Reader<T> extends Closeable {
 
         /** Reads the next record. Returns {@code null} when the input has reached its end. */

--- a/flink-connectors/flink-connector-files/src/test/java/org/apache/flink/connector/file/src/impl/TestIntReader.java
+++ b/flink-connectors/flink-connector-files/src/test/java/org/apache/flink/connector/file/src/impl/TestIntReader.java
@@ -32,6 +32,9 @@ import java.io.IOException;
 /**
  * Simple reader for integers, that is both a {@link StreamFormat.Reader} and a {@link
  * FileRecordFormat.Reader}.
+ *
+ * <p>The interface {@link FileRecordFormat} is deprecated, use {@link StreamFormat} instead. This
+ * test class will be refactored once we remove the {@link FileRecordFormat}.
  */
 class TestIntReader implements StreamFormat.Reader<Integer>, FileRecordFormat.Reader<Integer> {
 


### PR DESCRIPTION
## What is the purpose of the change

The FileRecordFormat and StreamFormat have too much commons. This makes user confused. The main motivation for removing it is the inherent design flaw in the batching of FileRecordFormat: StreamFormat can guarantee that only a certain amount of memory is being used (unless a single record exceeds that already), but FileRecordFormat can only batch by the number of records. By removing FileRecordFormat, we relay the responsibility of implementing the batching to the format developer; they need to use BulkFormat and find a better way than batch by number of records.


## Brief change log

- marked FileRecordFormat and FileRecordFormatAdapter as @Deprecated.
- refactored the relevant usages.
- updated javadoc.



## Verifying this change

This change only marked some classes as deprecated and update relevant comments without any test coverage.

## Does this pull request potentially affect one of the following parts:

  - Dependencies (does it add or upgrade a dependency): (yes / **no**)
  - The public API, i.e., is any changed class annotated with `@Public(Evolving)`: (**yes** / no)
  - The serializers: (yes / **no** / don't know)
  - The runtime per-record code paths (performance sensitive): (yes / **no** / don't know)
  - Anything that affects deployment or recovery: JobManager (and its components), Checkpointing, Kubernetes/Yarn, ZooKeeper: (yes / **no** / don't know)
  - The S3 file system connector: (yes / **no** / don't know)

## Documentation

  - Does this pull request introduce a new feature? (yes / **no**)
