### PR TITLE
[FLINK-24657][runtime] Added metric of the total real size of input/o…

### DIFF
--- a/docs/content.zh/docs/ops/metrics.md
+++ b/docs/content.zh/docs/ops/metrics.md
@@ -916,10 +916,15 @@ Metrics related to data exchange between task executors using netty network comm
       <td>Gauge</td>
     </tr>
     <tr>
-      <th rowspan="18">Task</th>
-      <td rowspan="4">Shuffle.Netty.Input.Buffers</td>
+      <th rowspan="20">Task</th>
+      <td rowspan="5">Shuffle.Netty.Input.Buffers</td>
       <td>inputQueueLength</td>
       <td>The number of queued input buffers.</td>
+      <td>Gauge</td>
+    </tr>
+    <tr>
+      <td>inputQueueSize</td>
+      <td>The real size of queued input buffers in bytes. The size for local input channels is always `0` since the local channel takes records directly from the output queue.</td>
       <td>Gauge</td>
     </tr>
     <tr>
@@ -938,9 +943,14 @@ Metrics related to data exchange between task executors using netty network comm
       <td>Gauge</td>
     </tr>
     <tr>
-      <td rowspan="2">Shuffle.Netty.Output.Buffers</td>
+      <td rowspan="3">Shuffle.Netty.Output.Buffers</td>
       <td>outputQueueLength</td>
       <td>The number of queued output buffers.</td>
+      <td>Gauge</td>
+    </tr>
+    <tr>
+      <td>outputQueueSize</td>
+      <td>The real size of queued output buffers in bytes.</td>
       <td>Gauge</td>
     </tr>
     <tr>

--- a/docs/content/docs/ops/metrics.md
+++ b/docs/content/docs/ops/metrics.md
@@ -916,10 +916,15 @@ Metrics related to data exchange between task executors using netty network comm
       <td>Gauge</td>
     </tr>
     <tr>
-      <th rowspan="18">Task</th>
-      <td rowspan="4">Shuffle.Netty.Input.Buffers</td>
+      <th rowspan="20">Task</th>
+      <td rowspan="5">Shuffle.Netty.Input.Buffers</td>
       <td>inputQueueLength</td>
       <td>The number of queued input buffers.</td>
+      <td>Gauge</td>
+    </tr>
+    <tr>
+      <td>inputQueueSize</td>
+      <td>The real size of queued input buffers in bytes. The size for local input channels is always `0` since the local channel takes records directly from the output queue.</td>
       <td>Gauge</td>
     </tr>
     <tr>
@@ -938,9 +943,14 @@ Metrics related to data exchange between task executors using netty network comm
       <td>Gauge</td>
     </tr>
     <tr>
-      <td rowspan="2">Shuffle.Netty.Output.Buffers</td>
+      <td rowspan="3">Shuffle.Netty.Output.Buffers</td>
       <td>outputQueueLength</td>
       <td>The number of queued output buffers.</td>
+      <td>Gauge</td>
+    </tr>
+    <tr>
+      <td>outputQueueSize</td>
+      <td>The real size of queued output buffers in bytes. </td>
       <td>Gauge</td>
     </tr>
     <tr>

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/io/network/metrics/InputBuffersSizeGauge.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/io/network/metrics/InputBuffersSizeGauge.java
@@ -1,0 +1,45 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.flink.runtime.io.network.metrics;
+
+import org.apache.flink.metrics.Gauge;
+import org.apache.flink.runtime.io.network.partition.consumer.SingleInputGate;
+
+/**
+ * Gauge metric measuring the size in bytes of queued input buffers for {@link SingleInputGate}s.
+ */
+public class InputBuffersSizeGauge implements Gauge<Long> {
+
+    private final SingleInputGate[] inputGates;
+
+    public InputBuffersSizeGauge(SingleInputGate[] inputGates) {
+        this.inputGates = inputGates;
+    }
+
+    @Override
+    public Long getValue() {
+        long totalBuffers = 0;
+
+        for (SingleInputGate inputGate : inputGates) {
+            totalBuffers += inputGate.getSizeOfQueuedBuffers();
+        }
+
+        return totalBuffers;
+    }
+}

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/io/network/metrics/NettyShuffleMetricFactory.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/io/network/metrics/NettyShuffleMetricFactory.java
@@ -65,11 +65,13 @@ public class NettyShuffleMetricFactory {
     // task level output metrics: Shuffle.Netty.Output.*
 
     private static final String METRIC_OUTPUT_QUEUE_LENGTH = "outputQueueLength";
+    private static final String METRIC_OUTPUT_QUEUE_SIZE = "outputQueueSize";
     private static final String METRIC_OUTPUT_POOL_USAGE = "outPoolUsage";
 
     // task level input metrics: Shuffle.Netty.Input.*
 
     private static final String METRIC_INPUT_QUEUE_LENGTH = "inputQueueLength";
+    private static final String METRIC_INPUT_QUEUE_SIZE = "inputQueueSize";
     private static final String METRIC_INPUT_POOL_USAGE = "inPoolUsage";
     private static final String METRIC_INPUT_FLOATING_BUFFERS_USAGE = "inputFloatingBuffersUsage";
     private static final String METRIC_INPUT_EXCLUSIVE_BUFFERS_USAGE = "inputExclusiveBuffersUsage";
@@ -178,6 +180,7 @@ public class NettyShuffleMetricFactory {
             ResultPartitionMetrics.registerQueueLengthMetrics(outputGroup, resultPartitions);
         }
         buffersGroup.gauge(METRIC_OUTPUT_QUEUE_LENGTH, new OutputBuffersGauge(resultPartitions));
+        buffersGroup.gauge(METRIC_OUTPUT_QUEUE_SIZE, new OutputBuffersSizeGauge(resultPartitions));
         buffersGroup.gauge(
                 METRIC_OUTPUT_POOL_USAGE, new OutputBufferPoolUsageGauge(resultPartitions));
     }
@@ -201,6 +204,7 @@ public class NettyShuffleMetricFactory {
         }
 
         buffersGroup.gauge(METRIC_INPUT_QUEUE_LENGTH, new InputBuffersGauge(inputGates));
+        buffersGroup.gauge(METRIC_INPUT_QUEUE_SIZE, new InputBuffersSizeGauge(inputGates));
 
         FloatingBuffersUsageGauge floatingBuffersUsageGauge =
                 new FloatingBuffersUsageGauge(inputGates);

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/io/network/metrics/OutputBuffersSizeGauge.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/io/network/metrics/OutputBuffersSizeGauge.java
@@ -1,0 +1,45 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.flink.runtime.io.network.metrics;
+
+import org.apache.flink.metrics.Gauge;
+import org.apache.flink.runtime.io.network.partition.ResultPartition;
+
+/**
+ * Gauge metric measuring the size in bytes of queued output buffers for {@link ResultPartition}s.
+ */
+public class OutputBuffersSizeGauge implements Gauge<Long> {
+
+    private final ResultPartition[] resultPartitions;
+
+    public OutputBuffersSizeGauge(ResultPartition[] resultPartitions) {
+        this.resultPartitions = resultPartitions;
+    }
+
+    @Override
+    public Long getValue() {
+        long totalBuffers = 0;
+
+        for (ResultPartition producedPartition : resultPartitions) {
+            totalBuffers += producedPartition.getSizeOfQueuedBuffersUnsafe();
+        }
+
+        return totalBuffers;
+    }
+}

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/io/network/partition/BoundedBlockingSubpartition.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/io/network/partition/BoundedBlockingSubpartition.java
@@ -277,12 +277,12 @@ final class BoundedBlockingSubpartition extends ResultSubpartition {
     }
 
     @Override
-    protected long getTotalNumberOfBuffers() {
+    protected long getTotalNumberOfBuffersUnsafe() {
         return numBuffersAndEventsWritten;
     }
 
     @Override
-    protected long getTotalNumberOfBytes() {
+    protected long getTotalNumberOfBytesUnsafe() {
         return data.getSize();
     }
 

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/io/network/partition/BufferWritingResultPartition.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/io/network/partition/BufferWritingResultPartition.java
@@ -118,7 +118,7 @@ public abstract class BufferWritingResultPartition extends ResultPartition {
         long totalNumberOfBytes = 0;
 
         for (ResultSubpartition subpartition : subpartitions) {
-            totalNumberOfBytes += Math.max(0, subpartition.getTotalNumberOfBytes());
+            totalNumberOfBytes += Math.max(0, subpartition.getTotalNumberOfBytesUnsafe());
         }
 
         return totalWrittenBytes - totalNumberOfBytes;

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/io/network/partition/BufferWritingResultPartition.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/io/network/partition/BufferWritingResultPartition.java
@@ -64,6 +64,8 @@ public abstract class BufferWritingResultPartition extends ResultPartition {
 
     private TimerGauge backPressuredTimeMsPerSecond = new TimerGauge();
 
+    private long totalWrittenBytes;
+
     public BufferWritingResultPartition(
             String owningTaskName,
             int partitionIndex,
@@ -112,6 +114,17 @@ public abstract class BufferWritingResultPartition extends ResultPartition {
     }
 
     @Override
+    public long getSizeOfQueuedBuffersUnsafe() {
+        long totalNumberOfBytes = 0;
+
+        for (ResultSubpartition subpartition : subpartitions) {
+            totalNumberOfBytes += Math.max(0, subpartition.getTotalNumberOfBytes());
+        }
+
+        return totalWrittenBytes - totalNumberOfBytes;
+    }
+
+    @Override
     public int getNumberOfQueuedBuffers(int targetSubpartition) {
         checkArgument(targetSubpartition >= 0 && targetSubpartition < numSubpartitions);
         return subpartitions[targetSubpartition].unsynchronizedGetNumberOfQueuedBuffers();
@@ -139,6 +152,8 @@ public abstract class BufferWritingResultPartition extends ResultPartition {
 
     @Override
     public void emitRecord(ByteBuffer record, int targetSubpartition) throws IOException {
+        totalWrittenBytes += record.remaining();
+
         BufferBuilder buffer = appendUnicastDataForNewRecord(record, targetSubpartition);
 
         while (record.hasRemaining()) {
@@ -157,6 +172,8 @@ public abstract class BufferWritingResultPartition extends ResultPartition {
 
     @Override
     public void broadcastRecord(ByteBuffer record) throws IOException {
+        totalWrittenBytes += ((long) record.remaining() * numSubpartitions);
+
         BufferBuilder buffer = appendBroadcastDataForNewRecord(record);
 
         while (record.hasRemaining()) {
@@ -181,6 +198,7 @@ public abstract class BufferWritingResultPartition extends ResultPartition {
 
         try (BufferConsumer eventBufferConsumer =
                 EventSerializer.toBufferConsumer(event, isPriorityEvent)) {
+            totalWrittenBytes += ((long) eventBufferConsumer.getWrittenBytes() * numSubpartitions);
             for (ResultSubpartition subpartition : subpartitions) {
                 // Retain the buffer so that it can be recycled by each channel of targetPartition
                 subpartition.add(eventBufferConsumer.copy(), 0);

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/io/network/partition/PipelinedSubpartition.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/io/network/partition/PipelinedSubpartition.java
@@ -474,8 +474,8 @@ public class PipelinedSubpartition extends ResultSubpartition
         final boolean hasReadView;
 
         synchronized (buffers) {
-            numBuffers = getTotalNumberOfBuffers();
-            numBytes = getTotalNumberOfBytes();
+            numBuffers = getTotalNumberOfBuffersUnsafe();
+            numBytes = getTotalNumberOfBytesUnsafe();
             finished = isFinished;
             hasReadView = readView != null;
         }
@@ -517,12 +517,12 @@ public class PipelinedSubpartition extends ResultSubpartition
     }
 
     @Override
-    protected long getTotalNumberOfBuffers() {
+    protected long getTotalNumberOfBuffersUnsafe() {
         return totalNumberOfBuffers;
     }
 
     @Override
-    protected long getTotalNumberOfBytes() {
+    protected long getTotalNumberOfBytesUnsafe() {
         return totalNumberOfBytes;
     }
 

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/io/network/partition/ResultPartition.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/io/network/partition/ResultPartition.java
@@ -186,6 +186,9 @@ public abstract class ResultPartition implements ResultPartitionWriter {
     /** Returns the total number of queued buffers of all subpartitions. */
     public abstract int getNumberOfQueuedBuffers();
 
+    /** Returns the total size in bytes of queued buffers of all subpartitions. */
+    public abstract long getSizeOfQueuedBuffersUnsafe();
+
     /** Returns the number of queued buffers of the given target subpartition. */
     public abstract int getNumberOfQueuedBuffers(int targetSubpartition);
 

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/io/network/partition/ResultSubpartition.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/io/network/partition/ResultSubpartition.java
@@ -48,9 +48,9 @@ public abstract class ResultSubpartition {
     }
 
     /** Gets the total numbers of buffers (data buffers plus events). */
-    protected abstract long getTotalNumberOfBuffers();
+    protected abstract long getTotalNumberOfBuffersUnsafe();
 
-    protected abstract long getTotalNumberOfBytes();
+    protected abstract long getTotalNumberOfBytesUnsafe();
 
     public int getSubPartitionIndex() {
         return subpartitionInfo.getSubPartitionIdx();

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/io/network/partition/SortMergeResultPartition.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/io/network/partition/SortMergeResultPartition.java
@@ -494,6 +494,11 @@ public class SortMergeResultPartition extends ResultPartition {
     }
 
     @Override
+    public long getSizeOfQueuedBuffersUnsafe() {
+        return 0;
+    }
+
+    @Override
     public int getNumberOfQueuedBuffers(int targetSubpartition) {
         return 0;
     }

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/io/network/partition/SortMergeSubpartitionReader.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/io/network/partition/SortMergeSubpartitionReader.java
@@ -68,6 +68,8 @@ class SortMergeSubpartitionReader
     /** Sequence number of the next buffer to be sent to the consumer. */
     private int sequenceNumber;
 
+    private long totalBuffersSize;
+
     SortMergeSubpartitionReader(
             BufferAvailabilityListener listener, PartitionedFileReader fileReader) {
         this.availabilityListener = checkNotNull(listener);
@@ -86,6 +88,7 @@ class SortMergeSubpartitionReader
             if (buffer.isBuffer()) {
                 --dataBufferBacklog;
             }
+            totalBuffersSize -= buffer.getSize();
 
             Buffer lookAhead = buffersRead.peek();
             return BufferAndBacklog.fromBufferAndLookahead(
@@ -110,6 +113,7 @@ class SortMergeSubpartitionReader
             if (buffer.isBuffer()) {
                 ++dataBufferBacklog;
             }
+            totalBuffersSize += buffer.getSize();
         }
 
         if (notifyAvailable) {

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/io/network/partition/consumer/InputChannel.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/io/network/partition/consumer/InputChannel.java
@@ -298,6 +298,10 @@ public abstract class InputChannel {
         return 0;
     }
 
+    public long unsynchronizedGetSizeOfQueuedBuffers() {
+        return 0;
+    }
+
     // ------------------------------------------------------------------------
 
     /**

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/io/network/partition/consumer/SingleInputGate.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/io/network/partition/consumer/SingleInputGate.java
@@ -457,7 +457,27 @@ public class SingleInputGate extends IndexedInputGate {
                 }
 
                 return totalBuffers;
-            } catch (Exception ignored) {
+            } catch (Exception ex) {
+                LOG.debug("Fail to get number of queued buffers :", ex);
+            }
+        }
+
+        return 0;
+    }
+
+    public long getSizeOfQueuedBuffers() {
+        // re-try 3 times, if fails, return 0 for "unknown"
+        for (int retry = 0; retry < 3; retry++) {
+            try {
+                long totalSize = 0;
+
+                for (InputChannel channel : inputChannels.values()) {
+                    totalSize += channel.unsynchronizedGetSizeOfQueuedBuffers();
+                }
+
+                return totalSize;
+            } catch (Exception ex) {
+                LOG.debug("Fail to get size of queued buffers :", ex);
             }
         }
 

--- a/flink-runtime/src/test/java/org/apache/flink/runtime/io/network/partition/PipelinedSubpartitionTest.java
+++ b/flink-runtime/src/test/java/org/apache/flink/runtime/io/network/partition/PipelinedSubpartitionTest.java
@@ -275,8 +275,8 @@ public class PipelinedSubpartitionTest extends SubpartitionTestBase {
         if (!buffer2Recycled) {
             Assert.fail("buffer 2 not recycled");
         }
-        assertEquals(2, partition.getTotalNumberOfBuffers());
-        assertEquals(0, partition.getTotalNumberOfBytes()); // buffer data is never consumed
+        assertEquals(2, partition.getTotalNumberOfBuffersUnsafe());
+        assertEquals(0, partition.getTotalNumberOfBytesUnsafe()); // buffer data is never consumed
     }
 
     @Test

--- a/flink-runtime/src/test/java/org/apache/flink/runtime/io/network/partition/PipelinedSubpartitionWithReadViewTest.java
+++ b/flink-runtime/src/test/java/org/apache/flink/runtime/io/network/partition/PipelinedSubpartitionWithReadViewTest.java
@@ -256,10 +256,11 @@ public class PipelinedSubpartitionWithReadViewTest {
         subpartition.add(createFilledFinishedBufferConsumer(BUFFER_SIZE));
         assertFalse(readView.getAvailabilityAndBacklog(0).isAvailable());
 
-        assertEquals(1, subpartition.getTotalNumberOfBuffers());
+        assertEquals(1, subpartition.getTotalNumberOfBuffersUnsafe());
         assertEquals(0, subpartition.getBuffersInBacklogUnsafe());
         assertEquals(
-                0, subpartition.getTotalNumberOfBytes()); // only updated when getting the buffer
+                0,
+                subpartition.getTotalNumberOfBytesUnsafe()); // only updated when getting the buffer
 
         assertEquals(0, availablityListener.getNumNotifications());
 
@@ -267,7 +268,7 @@ public class PipelinedSubpartitionWithReadViewTest {
         assertNextBuffer(readView, BUFFER_SIZE, false, 0, false, true);
         assertEquals(
                 BUFFER_SIZE,
-                subpartition.getTotalNumberOfBytes()); // only updated when getting the buffer
+                subpartition.getTotalNumberOfBytesUnsafe()); // only updated when getting the buffer
         assertEquals(0, subpartition.getBuffersInBacklogUnsafe());
         assertNoNextBuffer(readView);
         assertEquals(0, subpartition.getBuffersInBacklogUnsafe());
@@ -276,17 +277,17 @@ public class PipelinedSubpartitionWithReadViewTest {
         subpartition.add(createFilledFinishedBufferConsumer(BUFFER_SIZE));
         assertFalse(readView.getAvailabilityAndBacklog(0).isAvailable());
 
-        assertEquals(2, subpartition.getTotalNumberOfBuffers());
+        assertEquals(2, subpartition.getTotalNumberOfBuffersUnsafe());
         assertEquals(0, subpartition.getBuffersInBacklogUnsafe());
         assertEquals(
                 BUFFER_SIZE,
-                subpartition.getTotalNumberOfBytes()); // only updated when getting the buffer
+                subpartition.getTotalNumberOfBytesUnsafe()); // only updated when getting the buffer
         assertEquals(0, availablityListener.getNumNotifications());
 
         assertNextBuffer(readView, BUFFER_SIZE, false, 0, false, true);
         assertEquals(
                 2 * BUFFER_SIZE,
-                subpartition.getTotalNumberOfBytes()); // only updated when getting the buffer
+                subpartition.getTotalNumberOfBytesUnsafe()); // only updated when getting the buffer
         assertEquals(0, subpartition.getBuffersInBacklogUnsafe());
         assertNoNextBuffer(readView);
         assertEquals(0, subpartition.getBuffersInBacklogUnsafe());
@@ -301,41 +302,41 @@ public class PipelinedSubpartitionWithReadViewTest {
         subpartition.add(createFilledFinishedBufferConsumer(BUFFER_SIZE));
         assertFalse(readView.getAvailabilityAndBacklog(0).isAvailable());
 
-        assertEquals(5, subpartition.getTotalNumberOfBuffers());
+        assertEquals(5, subpartition.getTotalNumberOfBuffersUnsafe());
         assertEquals(
                 1, subpartition.getBuffersInBacklogUnsafe()); // two buffers (events don't count)
         assertEquals(
                 2 * BUFFER_SIZE,
-                subpartition.getTotalNumberOfBytes()); // only updated when getting the buffer
+                subpartition.getTotalNumberOfBytesUnsafe()); // only updated when getting the buffer
         assertEquals(1, availablityListener.getNumNotifications());
 
         // the first buffer
         assertNextBuffer(readView, BUFFER_SIZE, true, 0, true, true);
         assertEquals(
                 3 * BUFFER_SIZE,
-                subpartition.getTotalNumberOfBytes()); // only updated when getting the buffer
+                subpartition.getTotalNumberOfBytesUnsafe()); // only updated when getting the buffer
         assertEquals(0, subpartition.getBuffersInBacklogUnsafe());
 
         // the event
         assertNextEvent(readView, BUFFER_SIZE, null, false, 0, false, true);
         assertEquals(
                 4 * BUFFER_SIZE,
-                subpartition.getTotalNumberOfBytes()); // only updated when getting the buffer
+                subpartition.getTotalNumberOfBytesUnsafe()); // only updated when getting the buffer
         assertEquals(0, subpartition.getBuffersInBacklogUnsafe());
 
         // the remaining buffer
         assertNextBuffer(readView, BUFFER_SIZE, false, 0, false, true);
         assertEquals(
                 5 * BUFFER_SIZE,
-                subpartition.getTotalNumberOfBytes()); // only updated when getting the buffer
+                subpartition.getTotalNumberOfBytesUnsafe()); // only updated when getting the buffer
         assertEquals(0, subpartition.getBuffersInBacklogUnsafe());
 
         // nothing more
         assertNoNextBuffer(readView);
         assertEquals(0, subpartition.getBuffersInBacklogUnsafe());
 
-        assertEquals(5, subpartition.getTotalNumberOfBuffers());
-        assertEquals(5 * BUFFER_SIZE, subpartition.getTotalNumberOfBytes());
+        assertEquals(5, subpartition.getTotalNumberOfBuffersUnsafe());
+        assertEquals(5 * BUFFER_SIZE, subpartition.getTotalNumberOfBytesUnsafe());
         assertEquals(1, availablityListener.getNumNotifications());
     }
 

--- a/flink-runtime/src/test/java/org/apache/flink/runtime/io/network/partition/ResultPartitionTest.java
+++ b/flink-runtime/src/test/java/org/apache/flink/runtime/io/network/partition/ResultPartitionTest.java
@@ -861,6 +861,82 @@ public class ResultPartitionTest {
         }
     }
 
+    @Test
+    public void testSizeOfQueuedBuffers() throws IOException {
+        // given: Configured pipelined result with 2 subpartitions.
+        BufferWritingResultPartition bufferWritingResultPartition =
+                createResultPartition(ResultPartitionType.PIPELINED);
+
+        ResultSubpartition[] subpartitions = bufferWritingResultPartition.subpartitions;
+        assertEquals(2, subpartitions.length);
+
+        PipelinedSubpartition subpartition0 = (PipelinedSubpartition) subpartitions[0];
+        PipelinedSubpartition subpartition1 = (PipelinedSubpartition) subpartitions[1];
+
+        // and: Set the buffers size.
+        subpartition0.bufferSize(10);
+        subpartition1.bufferSize(10);
+
+        // when: Emit different records into different subpartitions.
+        // Emit the record less than buffer size.
+        bufferWritingResultPartition.emitRecord(ByteBuffer.allocate(3), 0);
+        assertEquals(3, bufferWritingResultPartition.getSizeOfQueuedBuffersUnsafe());
+
+        bufferWritingResultPartition.emitRecord(ByteBuffer.allocate(3), 1);
+        assertEquals(6, bufferWritingResultPartition.getSizeOfQueuedBuffersUnsafe());
+
+        // Emit the record the equal to buffer size.
+        bufferWritingResultPartition.emitRecord(ByteBuffer.allocate(10), 0);
+        assertEquals(16, bufferWritingResultPartition.getSizeOfQueuedBuffersUnsafe());
+
+        bufferWritingResultPartition.emitRecord(ByteBuffer.allocate(10), 1);
+        assertEquals(26, bufferWritingResultPartition.getSizeOfQueuedBuffersUnsafe());
+
+        // Broadcast event.
+        bufferWritingResultPartition.broadcastEvent(EndOfPartitionEvent.INSTANCE, false);
+        assertEquals(34, bufferWritingResultPartition.getSizeOfQueuedBuffersUnsafe());
+
+        // Emit one more record to the one subpartition.
+        bufferWritingResultPartition.emitRecord(ByteBuffer.allocate(5), 0);
+        assertEquals(39, bufferWritingResultPartition.getSizeOfQueuedBuffersUnsafe());
+
+        // Broadcast record.
+        bufferWritingResultPartition.broadcastRecord(ByteBuffer.allocate(7));
+        assertEquals(53, bufferWritingResultPartition.getSizeOfQueuedBuffersUnsafe());
+
+        // when: Poll finished buffers.
+        assertEquals(10, subpartition0.pollBuffer().buffer().getSize());
+        assertEquals(43, bufferWritingResultPartition.getSizeOfQueuedBuffersUnsafe());
+
+        assertEquals(10, subpartition1.pollBuffer().buffer().getSize());
+        assertEquals(33, bufferWritingResultPartition.getSizeOfQueuedBuffersUnsafe());
+
+        // Poll records which were unfinished because of broadcasting event.
+        assertEquals(3, subpartition0.pollBuffer().buffer().getSize());
+        assertEquals(30, bufferWritingResultPartition.getSizeOfQueuedBuffersUnsafe());
+
+        assertEquals(3, subpartition1.pollBuffer().buffer().getSize());
+        assertEquals(27, bufferWritingResultPartition.getSizeOfQueuedBuffersUnsafe());
+
+        // Poll the event.
+        assertEquals(4, subpartition0.pollBuffer().buffer().getSize());
+        assertEquals(23, bufferWritingResultPartition.getSizeOfQueuedBuffersUnsafe());
+
+        assertEquals(4, subpartition1.pollBuffer().buffer().getSize());
+        assertEquals(19, bufferWritingResultPartition.getSizeOfQueuedBuffersUnsafe());
+
+        // Poll the unfinished buffer.
+        assertEquals(5, subpartition0.pollBuffer().buffer().getSize());
+        assertEquals(14, bufferWritingResultPartition.getSizeOfQueuedBuffersUnsafe());
+
+        // Poll broadcasted record.
+        assertEquals(7, subpartition0.pollBuffer().buffer().getSize());
+        assertEquals(7, bufferWritingResultPartition.getSizeOfQueuedBuffersUnsafe());
+
+        assertEquals(7, subpartition1.pollBuffer().buffer().getSize());
+        assertEquals(0, bufferWritingResultPartition.getSizeOfQueuedBuffersUnsafe());
+    }
+
     private static class TestResultPartitionConsumableNotifier
             implements ResultPartitionConsumableNotifier {
         private JobID jobID;

--- a/flink-runtime/src/test/java/org/apache/flink/runtime/io/network/partition/ResultPartitionTest.java
+++ b/flink-runtime/src/test/java/org/apache/flink/runtime/io/network/partition/ResultPartitionTest.java
@@ -631,7 +631,7 @@ public class ResultPartitionTest {
                 bufferWritingResultPartition.getAllDataProcessedFuture();
         assertFalse(allRecordsProcessedFuture.isDone());
         for (ResultSubpartition resultSubpartition : bufferWritingResultPartition.subpartitions) {
-            assertEquals(1, resultSubpartition.getTotalNumberOfBuffers());
+            assertEquals(1, resultSubpartition.getTotalNumberOfBuffersUnsafe());
             Buffer nextBuffer = ((PipelinedSubpartition) resultSubpartition).pollBuffer().buffer();
             assertFalse(nextBuffer.isBuffer());
             assertEquals(

--- a/flink-runtime/src/test/java/org/apache/flink/runtime/io/network/partition/SubpartitionTestBase.java
+++ b/flink-runtime/src/test/java/org/apache/flink/runtime/io/network/partition/SubpartitionTestBase.java
@@ -60,7 +60,7 @@ public abstract class SubpartitionTestBase extends TestLogger {
 
         try {
             subpartition.finish();
-            assertEquals(1, subpartition.getTotalNumberOfBuffers());
+            assertEquals(1, subpartition.getTotalNumberOfBuffersUnsafe());
             assertEquals(0, subpartition.getBuffersInBacklogUnsafe());
 
             BufferConsumer bufferConsumer = createFilledFinishedBufferConsumer(4096);
@@ -68,7 +68,7 @@ public abstract class SubpartitionTestBase extends TestLogger {
             assertEquals(-1, subpartition.add(bufferConsumer));
             assertTrue(bufferConsumer.isRecycled());
 
-            assertEquals(1, subpartition.getTotalNumberOfBuffers());
+            assertEquals(1, subpartition.getTotalNumberOfBuffersUnsafe());
             assertEquals(0, subpartition.getBuffersInBacklogUnsafe());
         } finally {
             if (subpartition != null) {


### PR DESCRIPTION
…utput buffers queue

<!--
*Thank you very much for contributing to Apache Flink - we are happy that you want to help us improve Flink. To help the community review your contribution in the best possible way, please go through the checklist below, which will get the contribution into a shape in which it can be best reviewed.*

*Please understand that we do not do this to make contributions to Flink a hassle. In order to uphold a high standard of quality for code contributions, while at the same time managing a large number of contributions, we need contributors to prepare the contributions well, and give reviewers enough contextual information for the review. Please also understand that contributions that do not follow this guide will take longer to review and thus typically be picked up with lower priority by the community.*

## Contribution Checklist

  - Make sure that the pull request corresponds to a [JIRA issue](https://issues.apache.org/jira/projects/FLINK/issues). Exceptions are made for typos in JavaDoc or documentation files, which need no JIRA issue.
  
  - Name the pull request in the form "[FLINK-XXXX] [component] Title of the pull request", where *FLINK-XXXX* should be replaced by the actual issue number. Skip *component* if you are unsure about which is the best component.
  Typo fixes that have no associated JIRA issue should be named following this pattern: `[hotfix] [docs] Fix typo in event time introduction` or `[hotfix] [javadocs] Expand JavaDoc for PuncuatedWatermarkGenerator`.

  - Fill out the template below to describe the changes contributed by the pull request. That will give reviewers the context they need to do the review.
  
  - Make sure that the change passes the automated tests, i.e., `mvn clean verify` passes. You can set up Azure Pipelines CI to do that following [this guide](https://cwiki.apache.org/confluence/display/FLINK/Azure+Pipelines#AzurePipelines-Tutorial:SettingupAzurePipelinesforaforkoftheFlinkrepository).

  - Each pull request should address only one issue, not mix up code from multiple issues.
  
  - Each commit in the pull request has a meaningful commit message (including the JIRA id)

  - Once all items of the checklist are addressed, remove the above text and this checklist, leaving only the filled out template below.


**(The sections below can be removed for hotfixes of typos)**
-->

## What is the purpose of the change

*This PR adds two new metrics - outputQueueSize and inputQueueSize*


## Brief change log

  - *PipelinedSubpartitin#totalNumberOfBytes is calculated only for data buffer*
  - *Output queue buffers size is calculated based on numBytesOut metric and totalNumberOfBytes*


## Verifying this change

This change added tests and can be verified as follows:

  - *Added new test for checking queue size for PartitionResult*

## Does this pull request potentially affect one of the following parts:

  - Dependencies (does it add or upgrade a dependency): (yes / **no**)
  - The public API, i.e., is any changed class annotated with `@Public(Evolving)`: (**yes** / no)
  - The serializers: (yes / **no** / don't know)
  - The runtime per-record code paths (performance sensitive): (yes / **no** / don't know)
  - Anything that affects deployment or recovery: JobManager (and its components), Checkpointing, Kubernetes/Yarn, ZooKeeper: (yes / **no** / don't know)
  - The S3 file system connector: (yes / **no** / don't know)

## Documentation

  - Does this pull request introduce a new feature? (yes / **no**)
  - If yes, how is the feature documented? (not applicable / docs / JavaDocs / not documented)
