### PR TITLE
[FLINK-24747][table-planner] Add producedDataType to SupportsProjectionPushDown.applyProjection

### DIFF
--- a/flink-connectors/flink-connector-hbase-base/src/main/java/org/apache/flink/connector/hbase/source/AbstractHBaseDynamicTableSource.java
+++ b/flink-connectors/flink-connector-hbase-base/src/main/java/org/apache/flink/connector/hbase/source/AbstractHBaseDynamicTableSource.java
@@ -93,7 +93,7 @@ public abstract class AbstractHBaseDynamicTableSource
     }
 
     @Override
-    public void applyProjection(int[][] projectedFields) {
+    public void applyProjection(int[][] projectedFields, DataType producedDataType) {
         this.hbaseSchema =
                 HBaseTableSchema.fromDataType(
                         DataType.projectFields(hbaseSchema.convertToDataType(), projectedFields));

--- a/flink-connectors/flink-connector-hive/src/main/java/org/apache/flink/connectors/hive/HiveTableSource.java
+++ b/flink-connectors/flink-connector-hive/src/main/java/org/apache/flink/connectors/hive/HiveTableSource.java
@@ -226,7 +226,7 @@ public class HiveTableSource
     }
 
     @Override
-    public void applyProjection(int[][] projectedFields) {
+    public void applyProjection(int[][] projectedFields, DataType producedDataType) {
         this.projectedFields = Arrays.stream(projectedFields).mapToInt(value -> value[0]).toArray();
     }
 

--- a/flink-connectors/flink-connector-jdbc/src/main/java/org/apache/flink/connector/jdbc/table/JdbcDynamicTableSource.java
+++ b/flink-connectors/flink-connector-jdbc/src/main/java/org/apache/flink/connector/jdbc/table/JdbcDynamicTableSource.java
@@ -142,7 +142,7 @@ public class JdbcDynamicTableSource
     }
 
     @Override
-    public void applyProjection(int[][] projectedFields) {
+    public void applyProjection(int[][] projectedFields, DataType producedDataType) {
         this.physicalRowDataType = DataType.projectFields(physicalRowDataType, projectedFields);
     }
 

--- a/flink-table/flink-table-common/src/main/java/org/apache/flink/table/connector/source/abilities/SupportsProjectionPushDown.java
+++ b/flink-table/flink-table-common/src/main/java/org/apache/flink/table/connector/source/abilities/SupportsProjectionPushDown.java
@@ -52,6 +52,15 @@ public interface SupportsProjectionPushDown {
     /** Returns whether this source supports nested projection. */
     boolean supportsNestedProjection();
 
+    /** @deprecated You should implement {@link #applyProjection(int[][], DataType)} */
+    @Deprecated
+    default void applyProjection(int[][] projectedFields) {
+        throw new IllegalStateException(
+                "No implementation provided for SupportsProjectionPushDown. "
+                        + "You should implement "
+                        + "SupportsProjectionPushDown#applyProjection(int[][], DataType)");
+    }
+
     /**
      * Provides the field index paths that should be used for a projection. The indices are 0-based
      * and support fields within (possibly nested) structures if this is enabled via {@link
@@ -73,5 +82,7 @@ public interface SupportsProjectionPushDown {
      *     produced data
      * @param producedDataType the final output type of the source, with the projection applied
      */
-    void applyProjection(int[][] projectedFields, DataType producedDataType);
+    default void applyProjection(int[][] projectedFields, DataType producedDataType) {
+        applyProjection(projectedFields);
+    }
 }

--- a/flink-table/flink-table-common/src/main/java/org/apache/flink/table/connector/source/abilities/SupportsProjectionPushDown.java
+++ b/flink-table/flink-table-common/src/main/java/org/apache/flink/table/connector/source/abilities/SupportsProjectionPushDown.java
@@ -52,13 +52,12 @@ public interface SupportsProjectionPushDown {
     /** Returns whether this source supports nested projection. */
     boolean supportsNestedProjection();
 
-    /** @deprecated You should implement {@link #applyProjection(int[][], DataType)} */
+    /** @deprecated Please implement {@link #applyProjection(int[][], DataType)} */
     @Deprecated
     default void applyProjection(int[][] projectedFields) {
-        throw new IllegalStateException(
+        throw new UnsupportedOperationException(
                 "No implementation provided for SupportsProjectionPushDown. "
-                        + "You should implement "
-                        + "SupportsProjectionPushDown#applyProjection(int[][], DataType)");
+                        + "Please implement SupportsProjectionPushDown#applyProjection(int[][], DataType)");
     }
 
     /**

--- a/flink-table/flink-table-common/src/main/java/org/apache/flink/table/connector/source/abilities/SupportsProjectionPushDown.java
+++ b/flink-table/flink-table-common/src/main/java/org/apache/flink/table/connector/source/abilities/SupportsProjectionPushDown.java
@@ -19,7 +19,10 @@
 package org.apache.flink.table.connector.source.abilities;
 
 import org.apache.flink.annotation.PublicEvolving;
+import org.apache.flink.api.common.typeinfo.TypeInformation;
+import org.apache.flink.table.catalog.ResolvedSchema;
 import org.apache.flink.table.connector.source.ScanTableSource;
+import org.apache.flink.table.types.DataType;
 
 /**
  * Enables to push down a (possibly nested) projection into a {@link ScanTableSource}.
@@ -63,8 +66,12 @@ public interface SupportsProjectionPushDown {
      *       #supportsNestedProjection()} returns true.
      * </ul>
      *
+     * <p>Note: Use the passed data type instead of {@link ResolvedSchema#toPhysicalRowDataType()}
+     * for describing the final output data type when creating {@link TypeInformation}.
+     *
      * @param projectedFields field index paths of all fields that must be present in the physically
      *     produced data
+     * @param producedDataType the final output type of the source, with the projection applied
      */
-    void applyProjection(int[][] projectedFields);
+    void applyProjection(int[][] projectedFields, DataType producedDataType);
 }

--- a/flink-table/flink-table-common/src/main/java/org/apache/flink/table/connector/source/abilities/SupportsReadingMetadata.java
+++ b/flink-table/flink-table-common/src/main/java/org/apache/flink/table/connector/source/abilities/SupportsReadingMetadata.java
@@ -123,8 +123,8 @@ public interface SupportsReadingMetadata {
      * <p>Note: Use the passed data type instead of {@link ResolvedSchema#toPhysicalRowDataType()}
      * for describing the final output data type when creating {@link TypeInformation}. If the
      * source implements {@link SupportsProjectionPushDown}, the projection is already considered in
-     * the given output data type, so you should reuse the {@code producedDataType} provided by this
-     * method instead of the {@code producedDataType} provided by {@link
+     * the given output data type, use the {@code producedDataType} provided by this method instead
+     * of the {@code producedDataType} provided by {@link
      * SupportsProjectionPushDown#applyProjection(int[][], DataType)}.
      *
      * @param metadataKeys a subset of the keys returned by {@link #listReadableMetadata()}, ordered

--- a/flink-table/flink-table-common/src/main/java/org/apache/flink/table/connector/source/abilities/SupportsReadingMetadata.java
+++ b/flink-table/flink-table-common/src/main/java/org/apache/flink/table/connector/source/abilities/SupportsReadingMetadata.java
@@ -123,7 +123,9 @@ public interface SupportsReadingMetadata {
      * <p>Note: Use the passed data type instead of {@link ResolvedSchema#toPhysicalRowDataType()}
      * for describing the final output data type when creating {@link TypeInformation}. If the
      * source implements {@link SupportsProjectionPushDown}, the projection is already considered in
-     * the given output data type.
+     * the given output data type, so you should reuse the {@code producedDataType} provided by this
+     * method instead of the {@code producedDataType} provided by {@link
+     * SupportsProjectionPushDown#applyProjection(int[][], DataType)}.
      *
      * @param metadataKeys a subset of the keys returned by {@link #listReadableMetadata()}, ordered
      *     by the iteration order of returned map

--- a/flink-table/flink-table-planner/src/main/java/org/apache/flink/table/planner/plan/abilities/source/ProjectPushDownSpec.java
+++ b/flink-table/flink-table-planner/src/main/java/org/apache/flink/table/planner/plan/abilities/source/ProjectPushDownSpec.java
@@ -18,6 +18,7 @@
 
 package org.apache.flink.table.planner.plan.abilities.source;
 
+import org.apache.flink.table.api.DataTypes;
 import org.apache.flink.table.api.TableException;
 import org.apache.flink.table.connector.source.DynamicTableSource;
 import org.apache.flink.table.connector.source.abilities.SupportsProjectionPushDown;
@@ -53,7 +54,8 @@ public class ProjectPushDownSpec extends SourceAbilitySpecBase {
     @Override
     public void apply(DynamicTableSource tableSource, SourceAbilityContext context) {
         if (tableSource instanceof SupportsProjectionPushDown) {
-            ((SupportsProjectionPushDown) tableSource).applyProjection(projectedFields);
+            ((SupportsProjectionPushDown) tableSource)
+                    .applyProjection(projectedFields, DataTypes.of(getProducedType().get()));
         } else {
             throw new TableException(
                     String.format(

--- a/flink-table/flink-table-planner/src/main/java/org/apache/flink/table/planner/plan/rules/logical/PushProjectIntoTableSourceScanRule.java
+++ b/flink-table/flink-table-planner/src/main/java/org/apache/flink/table/planner/plan/rules/logical/PushProjectIntoTableSourceScanRule.java
@@ -292,24 +292,22 @@ public class PushProjectIntoTableSourceScanRule
             metaColumn.setIndexOfLeafInNewSchema(newIndex++);
         }
 
+        if (supportsProjectionPushDown(source.tableSource())) {
+            final RowType projectedPhysicalType =
+                    (RowType)
+                            DataTypeUtils.projectRow(
+                                            TypeConversions.fromLogicalToDataType(producedType),
+                                            physicalProjections)
+                                    .getLogicalType();
+            abilitySpecs.add(new ProjectPushDownSpec(physicalProjections, projectedPhysicalType));
+        }
+
         final RowType newProducedType =
                 (RowType)
                         DataTypeUtils.projectRow(
                                         TypeConversions.fromLogicalToDataType(producedType),
                                         projectedFields)
                                 .getLogicalType();
-
-        if (supportsProjectionPushDown(source.tableSource())) {
-            abilitySpecs.add(
-                    new ProjectPushDownSpec(
-                            physicalProjections,
-                            (RowType)
-                                    DataTypeUtils.projectRow(
-                                                    TypeConversions.fromLogicalToDataType(
-                                                            producedType),
-                                                    physicalProjections)
-                                            .getLogicalType()));
-        }
 
         if (supportsMetadata(source.tableSource())) {
             final List<String> projectedMetadataKeys =

--- a/flink-table/flink-table-planner/src/main/java/org/apache/flink/table/planner/plan/rules/logical/PushProjectIntoTableSourceScanRule.java
+++ b/flink-table/flink-table-planner/src/main/java/org/apache/flink/table/planner/plan/rules/logical/PushProjectIntoTableSourceScanRule.java
@@ -300,7 +300,15 @@ public class PushProjectIntoTableSourceScanRule
                                 .getLogicalType();
 
         if (supportsProjectionPushDown(source.tableSource())) {
-            abilitySpecs.add(new ProjectPushDownSpec(physicalProjections, newProducedType));
+            abilitySpecs.add(
+                    new ProjectPushDownSpec(
+                            physicalProjections,
+                            (RowType)
+                                    DataTypeUtils.projectRow(
+                                                    TypeConversions.fromLogicalToDataType(
+                                                            producedType),
+                                                    physicalProjections)
+                                            .getLogicalType()));
         }
 
         if (supportsMetadata(source.tableSource())) {

--- a/flink-table/flink-table-planner/src/test/java/org/apache/flink/table/planner/factories/TestValuesTableFactory.java
+++ b/flink-table/flink-table-planner/src/test/java/org/apache/flink/table/planner/factories/TestValuesTableFactory.java
@@ -1216,8 +1216,8 @@ public final class TestValuesTableFactory
         }
 
         @Override
-        public void applyProjection(int[][] projectedFields) {
-            this.producedDataType = DataTypeUtils.projectRow(producedDataType, projectedFields);
+        public void applyProjection(int[][] projectedFields, DataType producedDataType) {
+            this.producedDataType = producedDataType;
             this.projectedPhysicalFields = projectedFields;
         }
     }

--- a/flink-table/flink-table-planner/src/test/resources/org/apache/flink/table/planner/plan/batch/sql/TableSourceTest.xml
+++ b/flink-table/flink-table-planner/src/test/resources/org/apache/flink/table/planner/plan/batch/sql/TableSourceTest.xml
@@ -114,7 +114,7 @@ LogicalProject(id=[$0], nested1=[$1.nested1], results=[+(+($1.nested1.value, $1.
     <Resource name="optimized exec plan">
       <![CDATA[
 Calc(select=[id, deepNested_nested1 AS nested1, ((deepNested_nested1.value + deepNested_nested2_num) + metadata_1) AS results])
-+- TableSourceScan(table=[[default_catalog, default_database, T, project=[id, deepNested_nested1, deepNested_nested2_num, metadata_1], metadata=[metadata_1]]], fields=[id, deepNested_nested1, deepNested_nested2_num, metadata_1])
++- TableSourceScan(table=[[default_catalog, default_database, T, project=[id, deepNested_nested1, deepNested_nested2_num], metadata=[metadata_1]]], fields=[id, deepNested_nested1, deepNested_nested2_num, metadata_1])
 ]]>
     </Resource>
   </TestCase>

--- a/flink-table/flink-table-planner/src/test/resources/org/apache/flink/table/planner/plan/nodes/exec/stream/TableSourceJsonPlanTest_jsonplan/testReadingMetadata.out
+++ b/flink-table/flink-table-planner/src/test/resources/org/apache/flink/table/planner/plan/nodes/exec/stream/TableSourceJsonPlanTest_jsonplan/testReadingMetadata.out
@@ -33,8 +33,6 @@
             "a" : "BIGINT"
           }, {
             "b" : "INT"
-          }, {
-            "m" : "VARCHAR(2147483647)"
           } ]
         }
       }, {
@@ -65,7 +63,7 @@
         "m" : "VARCHAR(2147483647)"
       } ]
     },
-    "description" : "TableSourceScan(table=[[default_catalog, default_database, MyTable2, project=[a, b, m], metadata=[m]]], fields=[a, b, m])",
+    "description" : "TableSourceScan(table=[[default_catalog, default_database, MyTable2, project=[a, b], metadata=[m]]], fields=[a, b, m])",
     "inputProperties" : [ ]
   }, {
     "class" : "org.apache.flink.table.planner.plan.nodes.exec.stream.StreamExecSink",

--- a/flink-table/flink-table-planner/src/test/resources/org/apache/flink/table/planner/plan/rules/logical/PushProjectIntoTableSourceScanRuleTest.xml
+++ b/flink-table/flink-table-planner/src/test/resources/org/apache/flink/table/planner/plan/rules/logical/PushProjectIntoTableSourceScanRuleTest.xml
@@ -50,23 +50,6 @@ LogicalProject(a=[$0], c=[$2], d=[+($0, 1)], EXPR$3=[+($1, 1)])
 ]]>
     </Resource>
   </TestCase>
-  <TestCase name="testNestedProjectFieldAccessWithITEMWithConstantIndex">
-    <Resource name="sql">
-      <![CDATA[SELECT `Result`.`Mid`.data_arr[2].`value`, `Result`.`Mid`.data_arr FROM NestedItemTable]]>
-    </Resource>
-    <Resource name="ast">
-      <![CDATA[
-LogicalProject(EXPR$0=[ITEM($2.Mid.data_arr, 2).value], data_arr=[$2.Mid.data_arr])
-+- LogicalTableScan(table=[[default_catalog, default_database, NestedItemTable]])
-]]>
-    </Resource>
-    <Resource name="optimized rel plan">
-      <![CDATA[
-LogicalProject(EXPR$0=[ITEM($0, 2).value], data_arr=[$0])
-+- LogicalTableScan(table=[[default_catalog, default_database, NestedItemTable, project=[Result_Mid_data_arr], metadata=[]]])
-]]>
-    </Resource>
-  </TestCase>
   <TestCase name="testComplicatedNestedProject">
     <Resource name="sql">
       <![CDATA[SELECT id,    deepNested.nested1.name AS nestedName,
@@ -209,6 +192,23 @@ LogicalProject(EXPR$0=[ITEM($0.data_arr, 2).value], EXPR$1=[ITEM($0.data_arr, $1
 ]]>
     </Resource>
   </TestCase>
+  <TestCase name="testNestedProjectFieldAccessWithITEMWithConstantIndex">
+    <Resource name="sql">
+      <![CDATA[SELECT `Result`.`Mid`.data_arr[2].`value`, `Result`.`Mid`.data_arr FROM NestedItemTable]]>
+    </Resource>
+    <Resource name="ast">
+      <![CDATA[
+LogicalProject(EXPR$0=[ITEM($2.Mid.data_arr, 2).value], data_arr=[$2.Mid.data_arr])
++- LogicalTableScan(table=[[default_catalog, default_database, NestedItemTable]])
+]]>
+    </Resource>
+    <Resource name="optimized rel plan">
+      <![CDATA[
+LogicalProject(EXPR$0=[ITEM($0, 2).value], data_arr=[$0])
++- LogicalTableScan(table=[[default_catalog, default_database, NestedItemTable, project=[Result_Mid_data_arr], metadata=[]]])
+]]>
+    </Resource>
+  </TestCase>
   <TestCase name="testNestProjectWithMetadata">
     <Resource name="sql">
       <![CDATA[SELECT id,    deepNested.nested1 AS nested1,
@@ -224,7 +224,7 @@ LogicalProject(id=[$0], nested1=[$1.nested1], results=[+(+($1.nested1.value, $1.
     <Resource name="optimized rel plan">
       <![CDATA[
 LogicalProject(id=[$0], nested1=[$1], results=[+(+($1.value, $2), $3)])
-+- LogicalTableScan(table=[[default_catalog, default_database, MetadataTable, project=[id, deepNested_nested1, deepNested_nested2_num, metadata_1], metadata=[metadata_1]]])
++- LogicalTableScan(table=[[default_catalog, default_database, MetadataTable, project=[id, deepNested_nested1, deepNested_nested2_num], metadata=[metadata_1]]])
 ]]>
     </Resource>
   </TestCase>
@@ -243,7 +243,57 @@ LogicalProject(id=[$0], nested1=[$1.nested1], results=[+(+($1.nested1.value, $1.
     <Resource name="optimized rel plan">
       <![CDATA[
 LogicalProject(id=[$0], nested1=[$1], results=[+(+($1.value, $2), $3)])
-+- LogicalTableScan(table=[[default_catalog, default_database, MetadataTable, project=[id, deepNested_nested1, deepNested_nested2_num, metadata_1], metadata=[metadata_1]]])
++- LogicalTableScan(table=[[default_catalog, default_database, MetadataTable, project=[id, deepNested_nested1, deepNested_nested2_num], metadata=[metadata_1]]])
+]]>
+    </Resource>
+  </TestCase>
+  <TestCase name="testProjectFieldAccessWithITEM">
+    <Resource name="sql">
+      <![CDATA[SELECT `Result`.data_arr[ID].`value`, `Result`.data_map['item'].`value`, `outer_array`[1], `outer_array`[ID], `outer_map`['item'] FROM ItemTable]]>
+    </Resource>
+    <Resource name="ast">
+      <![CDATA[
+LogicalProject(EXPR$0=[ITEM($2.data_arr, $0).value], EXPR$1=[ITEM($2.data_map, _UTF-16LE'item').value], EXPR$2=[ITEM($3, 1)], EXPR$3=[ITEM($3, $0)], EXPR$4=[ITEM($4, _UTF-16LE'item')])
++- LogicalTableScan(table=[[default_catalog, default_database, ItemTable]])
+]]>
+    </Resource>
+    <Resource name="optimized rel plan">
+      <![CDATA[
+LogicalProject(EXPR$0=[ITEM($0.data_arr, $1).value], EXPR$1=[ITEM($0.data_map, _UTF-16LE'item').value], EXPR$2=[ITEM($2, 1)], EXPR$3=[ITEM($2, $1)], EXPR$4=[ITEM($3, _UTF-16LE'item')])
++- LogicalTableScan(table=[[default_catalog, default_database, ItemTable, project=[Result, ID, outer_array, outer_map], metadata=[]]])
+]]>
+    </Resource>
+  </TestCase>
+  <TestCase name="testProjectionWithMetadataAndPhysicalFields">
+    <Resource name="sql">
+      <![CDATA[SELECT metadata, f1 FROM T5]]>
+    </Resource>
+    <Resource name="ast">
+      <![CDATA[
+LogicalProject(metadata=[$1], f1=[$0])
++- LogicalTableScan(table=[[default_catalog, default_database, T5]])
+]]>
+    </Resource>
+    <Resource name="optimized rel plan">
+      <![CDATA[
+LogicalProject(metadata=[$1], f1=[$0])
++- LogicalTableScan(table=[[default_catalog, default_database, T5, project=[f1], metadata=[m2]]])
+]]>
+    </Resource>
+  </TestCase>
+  <TestCase name="testProjectionIncludingOnlyMetadata">
+    <Resource name="sql">
+      <![CDATA[SELECT metadata FROM T5]]>
+    </Resource>
+    <Resource name="ast">
+      <![CDATA[
+LogicalProject(metadata=[$1])
++- LogicalTableScan(table=[[default_catalog, default_database, T5]])
+]]>
+    </Resource>
+    <Resource name="optimized rel plan">
+      <![CDATA[
+LogicalTableScan(table=[[default_catalog, default_database, T5, project=[], metadata=[m2]]])
 ]]>
     </Resource>
   </TestCase>
@@ -262,23 +312,6 @@ LogicalProject(id=[$0], EXPR$1=[ITEM($5, _UTF-16LE'e')])
       <![CDATA[
 LogicalProject(id=[$0], EXPR$1=[ITEM($1, _UTF-16LE'e')])
 +- LogicalTableScan(table=[[default_catalog, default_database, NestedTable, project=[id, testMap], metadata=[]]])
-]]>
-    </Resource>
-  </TestCase>
-  <TestCase name="testProjectFieldAccessWithITEM">
-    <Resource name="sql">
-      <![CDATA[SELECT `Result`.data_arr[ID].`value`, `Result`.data_map['item'].`value`, `outer_array`[1], `outer_array`[ID], `outer_map`['item'] FROM ItemTable]]>
-    </Resource>
-    <Resource name="ast">
-      <![CDATA[
-LogicalProject(EXPR$0=[ITEM($2.data_arr, $0).value], EXPR$1=[ITEM($2.data_map, _UTF-16LE'item').value], EXPR$2=[ITEM($3, 1)], EXPR$3=[ITEM($3, $0)], EXPR$4=[ITEM($4, _UTF-16LE'item')])
-+- LogicalTableScan(table=[[default_catalog, default_database, ItemTable]])
-]]>
-    </Resource>
-    <Resource name="optimized rel plan">
-      <![CDATA[
-LogicalProject(EXPR$0=[ITEM($0.data_arr, $1).value], EXPR$1=[ITEM($0.data_map, _UTF-16LE'item').value], EXPR$2=[ITEM($2, 1)], EXPR$3=[ITEM($2, $1)], EXPR$4=[ITEM($3, _UTF-16LE'item')])
-+- LogicalTableScan(table=[[default_catalog, default_database, ItemTable, project=[Result, ID, outer_array, outer_map], metadata=[]]])
 ]]>
     </Resource>
   </TestCase>

--- a/flink-table/flink-table-planner/src/test/resources/org/apache/flink/table/planner/plan/rules/physical/batch/PushLocalAggIntoTableSourceScanRuleTest.xml
+++ b/flink-table/flink-table-planner/src/test/resources/org/apache/flink/table/planner/plan/rules/physical/batch/PushLocalAggIntoTableSourceScanRuleTest.xml
@@ -222,7 +222,7 @@ LogicalProject(EXPR$0=[$2], EXPR$1=[$3], name=[$0], type=[$1])
 Calc(select=[EXPR$0, EXPR$1, name, type])
 +- HashAggregate(isMerge=[true], groupBy=[name, type], select=[name, type, Final_SUM(sum$0) AS EXPR$0, Final_MAX(max$1) AS EXPR$1])
    +- Exchange(distribution=[hash[name, type]])
-      +- TableSourceScan(table=[[default_catalog, default_database, inventory_meta, filter=[=(id, 123:BIGINT)], project=[name, type, amount, metadata_1], metadata=[metadata_1], aggregates=[grouping=[name,type], aggFunctions=[LongSumAggFunction(amount),LongMaxAggFunction(metadata_1)]]]], fields=[name, type, sum$0, max$1])
+      +- TableSourceScan(table=[[default_catalog, default_database, inventory_meta, filter=[=(id, 123:BIGINT)], project=[name, type, amount], metadata=[metadata_1], aggregates=[grouping=[name,type], aggFunctions=[LongSumAggFunction(amount),LongMaxAggFunction(metadata_1)]]]], fields=[name, type, sum$0, max$1])
 ]]>
     </Resource>
   </TestCase>

--- a/flink-table/flink-table-planner/src/test/resources/org/apache/flink/table/planner/plan/stream/sql/SourceWatermarkTest.xml
+++ b/flink-table/flink-table-planner/src/test/resources/org/apache/flink/table/planner/plan/stream/sql/SourceWatermarkTest.xml
@@ -144,7 +144,7 @@ LogicalProject(a=[$0], b=[$1])
     <Resource name="optimized exec plan">
       <![CDATA[
 Calc(select=[a, b])
-+- TableSourceScan(table=[[default_catalog, default_database, MyLtzTable, project=[a, b, originTime], metadata=[originTime], watermark=[TO_TIMESTAMP_LTZ(originTime, 3)]]], fields=[a, b, originTime])
++- TableSourceScan(table=[[default_catalog, default_database, MyLtzTable, project=[a, b], metadata=[originTime], watermark=[TO_TIMESTAMP_LTZ(originTime, 3)]]], fields=[a, b, originTime])
 ]]>
     </Resource>
   </TestCase>
@@ -182,7 +182,7 @@ LogicalProject(a=[$0], b=[$1])
     <Resource name="optimized exec plan">
       <![CDATA[
 Calc(select=[a, b])
-+- TableSourceScan(table=[[default_catalog, default_database, MyTable, project=[a, b, originTime], metadata=[originTime], watermark=[TO_TIMESTAMP(FROM_UNIXTIME(/(originTime, 1000)), _UTF-16LE'yyyy-MM-dd HH:mm:ss')]]], fields=[a, b, originTime])
++- TableSourceScan(table=[[default_catalog, default_database, MyTable, project=[a, b], metadata=[originTime], watermark=[TO_TIMESTAMP(FROM_UNIXTIME(/(originTime, 1000)), _UTF-16LE'yyyy-MM-dd HH:mm:ss')]]], fields=[a, b, originTime])
 ]]>
     </Resource>
   </TestCase>

--- a/flink-table/flink-table-planner/src/test/resources/org/apache/flink/table/planner/plan/stream/sql/TableScanTest.xml
+++ b/flink-table/flink-table-planner/src/test/resources/org/apache/flink/table/planner/plan/stream/sql/TableScanTest.xml
@@ -210,7 +210,7 @@ LogicalProject(b=[$1], other_metadata=[CAST($4):INTEGER])
     <Resource name="optimized exec plan">
       <![CDATA[
 Calc(select=[b, CAST(metadata_3) AS other_metadata])
-+- TableSourceScan(table=[[default_catalog, default_database, MetadataTable, project=[b, metadata_3], metadata=[metadata_3]]], fields=[b, metadata_3])
++- TableSourceScan(table=[[default_catalog, default_database, MetadataTable, project=[b], metadata=[metadata_3]]], fields=[b, metadata_3])
 ]]>
     </Resource>
   </TestCase>

--- a/flink-table/flink-table-planner/src/test/resources/org/apache/flink/table/planner/plan/stream/sql/TableSinkTest.xml
+++ b/flink-table/flink-table-planner/src/test/resources/org/apache/flink/table/planner/plan/stream/sql/TableSinkTest.xml
@@ -117,7 +117,7 @@ LogicalSink(table=[default_catalog.default_database.MetadataTable], fields=[a, b
       <![CDATA[
 Sink(table=[default_catalog.default_database.MetadataTable], fields=[a, b, c, metadata_1, metadata_2])
 +- Calc(select=[a, b, c, metadata_1, CAST(CAST(metadata_2)) AS metadata_2])
-   +- TableSourceScan(table=[[default_catalog, default_database, MetadataTable, project=[a, b, c, metadata_1, metadata_2], metadata=[metadata_1, metadata_2]]], fields=[a, b, c, metadata_1, metadata_2])
+   +- TableSourceScan(table=[[default_catalog, default_database, MetadataTable, project=[a, b, c], metadata=[metadata_1, metadata_2]]], fields=[a, b, c, metadata_1, metadata_2])
 ]]>
     </Resource>
   </TestCase>

--- a/flink-table/flink-table-planner/src/test/resources/org/apache/flink/table/planner/plan/stream/sql/TableSourceTest.xml
+++ b/flink-table/flink-table-planner/src/test/resources/org/apache/flink/table/planner/plan/stream/sql/TableSourceTest.xml
@@ -80,7 +80,7 @@ LogicalProject(id=[$0], nested1=[$1.nested1], results=[+(+($1.nested1.value, $1.
     <Resource name="optimized exec plan">
       <![CDATA[
 Calc(select=[id, deepNested_nested1 AS nested1, ((deepNested_nested1.value + deepNested_nested2_num) + metadata_1) AS results])
-+- TableSourceScan(table=[[default_catalog, default_database, T, project=[id, deepNested_nested1, deepNested_nested2_num, metadata_1], metadata=[metadata_1]]], fields=[id, deepNested_nested1, deepNested_nested2_num, metadata_1])
++- TableSourceScan(table=[[default_catalog, default_database, T, project=[id, deepNested_nested1, deepNested_nested2_num], metadata=[metadata_1]]], fields=[id, deepNested_nested1, deepNested_nested2_num, metadata_1])
 ]]>
     </Resource>
   </TestCase>

--- a/flink-table/flink-table-runtime/src/main/java/org/apache/flink/table/filesystem/FileSystemTableSource.java
+++ b/flink-table/flink-table-runtime/src/main/java/org/apache/flink/table/filesystem/FileSystemTableSource.java
@@ -271,7 +271,7 @@ public class FileSystemTableSource extends AbstractFileSystemTable
     }
 
     @Override
-    public void applyProjection(int[][] projectedFields) {
+    public void applyProjection(int[][] projectedFields, DataType producedDataType) {
         this.projectedFields = projectedFields;
     }
 


### PR DESCRIPTION
## What is the purpose of the change

Add `producedDataType` to `SupportsProjectionPushDown.applyProjection`, in order to simplify usage of the interface for implementers.

## Brief change log

* Modified interface of `SupportsProjectionPushDown.applyProjection` to add `producedDataType`
* Now `ProjectPushDownSpec` is built using the projected type without metadata (Change in [`PushProjectIntoTableSourceScanRule`](https://github.com/apache/flink/compare/master...slinkydeveloper:FLINK-24747?diff-d50428315c54343309267ad023b634dac2961f1f3e8e8501072ad5ababb368b3R303#diff-d50428315c54343309267ad023b634dac2961f1f3e8e8501072ad5ababb368b3R303))

## Verifying this change

Added 2 tests in `PushProjectIntoTableSourceScanRuleTest` to verify the change. Modified test plans to make sure they take in account the change to the `ProjectPushDownSpec` https://github.com/apache/flink/compare/master...slinkydeveloper:FLINK-24747?diff-d50428315c54343309267ad023b634dac2961f1f3e8e8501072ad5ababb368b3R303#diff-d50428315c54343309267ad023b634dac2961f1f3e8e8501072ad5ababb368b3R303.

## Does this pull request potentially affect one of the following parts:

  - Dependencies (does it add or upgrade a dependency): no
  - The public API, i.e., is any changed class annotated with `@Public(Evolving)`: yes
  - The serializers: no
  - The runtime per-record code paths (performance sensitive): no
  - Anything that affects deployment or recovery: JobManager (and its components), Checkpointing, Kubernetes/Yarn, ZooKeeper: no
  - The S3 file system connector: no

## Documentation

  - Does this pull request introduce a new feature? no
  - If yes, how is the feature documented? not applicable
