### PR TITLE
[hotfix][docs]fix kafka datastream connector mistake

### DIFF
--- a/docs/content.zh/docs/connectors/datastream/kafka.md
+++ b/docs/content.zh/docs/connectors/datastream/kafka.md
@@ -317,9 +317,9 @@ KafkaSink<String> sink = KafkaSink.<String>builder()
         .setRecordSerializer(KafkaRecordSerializationSchema.builder()
             .setTopic("topic-name")
             .setValueSerializationSchema(new SimpleStringSchema())
-            .setDeliveryGuarantee(DeliveryGuarantee.AT_LEAST_ONCE)
             .build()
         )
+        .setDeliverGuarantee(DeliveryGuarantee.AT_LEAST_ONCE)
         .build();
         
 stream.sinkTo(sink);

--- a/docs/content/docs/connectors/datastream/kafka.md
+++ b/docs/content/docs/connectors/datastream/kafka.md
@@ -359,9 +359,9 @@ KafkaSink<String> sink = KafkaSink.<String>builder()
         .setRecordSerializer(KafkaRecordSerializationSchema.builder()
             .setTopic("topic-name")
             .setValueSerializationSchema(new SimpleStringSchema())
-            .setDeliveryGuarantee(DeliveryGuarantee.AT_LEAST_ONCE)
             .build()
         )
+        .setDeliverGuarantee(DeliveryGuarantee.AT_LEAST_ONCE)
         .build();
         
 stream.sinkTo(sink);


### PR DESCRIPTION
## What is the purpose of the change

There is no setDeliveryGuarantee method in KafkaRecordSerializationSchemaBuilder class, but it is in KafkaSinkBuilder class and the method is setDeliverGuarantee


## Brief change log

change setDeliveryGuarantee(DeliveryGuarantee.AT_LEAST_ONCE) to setDeliverGuarantee(DeliveryGuarantee.AT_LEAST_ONCE)


## Verifying this change

This change is a trivial rework / code cleanup without any test coverage.


## Does this pull request potentially affect one of the following parts:

  - Dependencies (does it add or upgrade a dependency): (no)
  - The public API, i.e., is any changed class annotated with `@Public(Evolving)`: (no)
  - The serializers: (no)
  - The runtime per-record code paths (performance sensitive): (no)
  - Anything that affects deployment or recovery: JobManager (and its components), Checkpointing, Kubernetes/Yarn, ZooKeeper: (no)
  - The S3 file system connector: (no)

## Documentation

  - Does this pull request introduce a new feature? (no)
  - If yes, how is the feature documented? (no)
