### PR TITLE
[FLINK-24401][runtime] Fix the bug of TM cannot exit after Metaspace OOM

### DIFF
--- a/flink-runtime/src/main/java/org/apache/flink/runtime/taskexecutor/TaskManagerRunner.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/taskexecutor/TaskManagerRunner.java
@@ -331,12 +331,7 @@ public class TaskManagerRunner implements FatalErrorHandler {
                 "Fatal error occurred while executing the TaskManager. Shutting it down...",
                 exception);
 
-        // In case of the Metaspace OutOfMemoryError, we expect that the graceful shutdown is
-        // possible,
-        // as it does not usually require more class loading to fail again with the Metaspace
-        // OutOfMemoryError.
-        if (ExceptionUtils.isJvmFatalOrOutOfMemoryError(exception)
-                && !ExceptionUtils.isMetaspaceOutOfMemoryError(exception)) {
+        if (ExceptionUtils.isJvmFatalOrOutOfMemoryError(exception)) {
             terminateJVM();
         } else {
             closeAsync(Result.FAILURE);


### PR DESCRIPTION
## What is the purpose of the change

This PR fix the bug of TM cannot exit after Metaspace OOM. You can get more details in JIRA.


## Brief change log

When Metaspace OOM, call terminateJVM() directly.


## Verifying this change

This change is a trivial rework / code cleanup without any test coverage.


## Does this pull request potentially affect one of the following parts:

  - Dependencies (does it add or upgrade a dependency): no
  - The public API, i.e., is any changed class annotated with `@Public(Evolving)`: no
  - The serializers: no
  - The runtime per-record code paths (performance sensitive): no
  - Anything that affects deployment or recovery: JobManager (and its components), Checkpointing, Kubernetes/Yarn, ZooKeeper: no
  - The S3 file system connector: no

## Documentation

  - Does this pull request introduce a new feature? no
  - If yes, how is the feature documented? not documented
