### PR TITLE
[FLINK-14100][connectors] Add Oracle dialect

### DIFF
--- a/docs/content.zh/docs/connectors/table/jdbc.md
+++ b/docs/content.zh/docs/connectors/table/jdbc.md
@@ -47,8 +47,8 @@ JDBC 连接器允许使用 JDBC 驱动向任意类型的关系型数据库读取
 | :-----------| :------------------| :----------------------| :----------------|
 | MySQL       |       `mysql`      | `mysql-connector-java` | [下载](https://repo.maven.apache.org/maven2/mysql/mysql-connector-java/) |
 | PostgreSQL  |  `org.postgresql`  |      `postgresql`      | [下载](https://jdbc.postgresql.org/download.html) |
-| Derby       | `org.apache.derby` |        `derby`         | [下载](http://db.apache.org/derby/derby_downloads.html) |
-
+| Derby       | `org.apache.derby` |        `derby`         | [下载](http://db.apache.org/derby/derby_downloads.html) | |
+| Oracle      | `com.oracle.database.jdbc` |        `ojdbc8`        | [下载](https://mvnrepository.com/artifact/com.oracle.database.jdbc/ojdbc8)
 
 当前，JDBC 连接器和驱动不在 Flink 二进制发布包中，请参阅[这里]({{< ref "docs/dev/datastream/project-configuration" >}})了解在集群上执行时何连接它们。
 

--- a/docs/content.zh/docs/connectors/table/jdbc.md
+++ b/docs/content.zh/docs/connectors/table/jdbc.md
@@ -46,9 +46,9 @@ JDBC 连接器允许使用 JDBC 驱动向任意类型的关系型数据库读取
 | Driver      |      Group Id      |      Artifact Id       |      JAR         |
 | :-----------| :------------------| :----------------------| :----------------|
 | MySQL       |       `mysql`      | `mysql-connector-java` | [下载](https://repo.maven.apache.org/maven2/mysql/mysql-connector-java/) |
+| Oracle      | `com.oracle.database.jdbc` |        `ojdbc8`        | [下载](https://mvnrepository.com/artifact/com.oracle.database.jdbc/ojdbc8)
 | PostgreSQL  |  `org.postgresql`  |      `postgresql`      | [下载](https://jdbc.postgresql.org/download.html) |
 | Derby       | `org.apache.derby` |        `derby`         | [下载](http://db.apache.org/derby/derby_downloads.html) | |
-| Oracle      | `com.oracle.database.jdbc` |        `ojdbc8`        | [下载](https://mvnrepository.com/artifact/com.oracle.database.jdbc/ojdbc8)
 
 当前，JDBC 连接器和驱动不在 Flink 二进制发布包中，请参阅[这里]({{< ref "docs/dev/datastream/project-configuration" >}})了解在集群上执行时何连接它们。
 

--- a/docs/content.zh/docs/connectors/table/jdbc.md
+++ b/docs/content.zh/docs/connectors/table/jdbc.md
@@ -312,6 +312,12 @@ lookup cache 的主要目的是用于提高时态表关联 JDBC 连接器的性�
             <td>INSERT .. ON DUPLICATE KEY UPDATE ..</td>
         </tr>
         <tr>
+            <td>Oracle</td>
+            <td>MERGE INTO .. USING (..) ON (..) <br>
+                WHEN MATCHED THEN UPDATE SET (..) <br>
+                WHEN NOT MATCHED THEN INSERT (..) <br>
+                VALUES (..)</td>
+        <tr>
             <td>PostgreSQL</td>
             <td>INSERT .. ON CONFLICT .. DO UPDATE SET ..</td>
         </tr>
@@ -470,12 +476,13 @@ SELECT * FROM `custom_schema.test_table2`;
 
 数据类型映射
 ----------------
-Flink 支持连接到多个使用方言（dialect）的数据库，如 MySQL、PostgreSQL、Derby 等。其中，Derby 通常是用于测试目的。下表列出了从关系数据库数据类型到 Flink SQL 数据类型的类型映射，映射表可以使得在 Flink 中定义 JDBC 表更加简单。
+Flink 支持连接到多个使用方言（dialect）的数据库，如 MySQL、Oracle、PostgreSQL、Derby 等。其中，Derby 通常是用于测试目的。下表列出了从关系数据库数据类型到 Flink SQL 数据类型的类型映射，映射表可以使得在 Flink 中定义 JDBC 表更加简单。
 
 <table class="table table-bordered">
     <thead>
       <tr>
         <th class="text-left"><a href="https://dev.mysql.com/doc/refman/8.0/en/data-types.html">MySQL type</a></th>
+        <th class="text-left"><a href="https://docs.oracle.com/database/121/SQLRF/sql_elements001.htm#SQLRF30020">Oracle type</a></th>
         <th class="text-left"><a href="https://www.postgresql.org/docs/12/datatype.html">PostgreSQL type</a></th>
         <th class="text-left"><a href="{{< ref "docs/dev/table/types" >}}">Flink SQL type</a></th>
       </tr>
@@ -484,12 +491,14 @@ Flink 支持连接到多个使用方言（dialect）的数据库，如 MySQL、P
     <tr>
       <td><code>TINYINT</code></td>
       <td></td>
+      <td></td>
       <td><code>TINYINT</code></td>
     </tr>
     <tr>
       <td>
         <code>SMALLINT</code><br>
         <code>TINYINT UNSIGNED</code></td>
+      <td></td>
       <td>
         <code>SMALLINT</code><br>
         <code>INT2</code><br>
@@ -502,6 +511,7 @@ Flink 支持连接到多个使用方言（dialect）的数据库，如 MySQL、P
         <code>INT</code><br>
         <code>MEDIUMINT</code><br>
         <code>SMALLINT UNSIGNED</code></td>
+      <td></td>
       <td>
         <code>INTEGER</code><br>
         <code>SERIAL</code></td>
@@ -511,6 +521,7 @@ Flink 支持连接到多个使用方言（dialect）的数据库，如 MySQL、P
       <td>
         <code>BIGINT</code><br>
         <code>INT UNSIGNED</code></td>
+      <td></td>
       <td>
         <code>BIGINT</code><br>
         <code>BIGSERIAL</code></td>
@@ -519,15 +530,19 @@ Flink 支持连接到多个使用方言（dialect）的数据库，如 MySQL、P
    <tr>
       <td><code>BIGINT UNSIGNED</code></td>
       <td></td>
+      <td></td>
       <td><code>DECIMAL(20, 0)</code></td>
     </tr>
     <tr>
       <td><code>BIGINT</code></td>
+      <td></td>
       <td><code>BIGINT</code></td>
       <td><code>BIGINT</code></td>
     </tr>
     <tr>
       <td><code>FLOAT</code></td>
+      <td>
+        <code>BINARY_FLOAT</code></td>
       <td>
         <code>REAL</code><br>
         <code>FLOAT4</code></td>
@@ -537,6 +552,7 @@ Flink 支持连接到多个使用方言（dialect）的数据库，如 MySQL、P
       <td>
         <code>DOUBLE</code><br>
         <code>DOUBLE PRECISION</code></td>
+      <td><code>BINARY_DOUBLE</code></td>
       <td>
         <code>FLOAT8</code><br>
         <code>DOUBLE PRECISION</code></td>
@@ -545,7 +561,13 @@ Flink 支持连接到多个使用方言（dialect）的数据库，如 MySQL、P
     <tr>
       <td>
         <code>NUMERIC(p, s)</code><br>
-         <code>DECIMAL(p, s)</code></td>
+        <code>DECIMAL(p, s)</code></td>
+      <td>
+        <code>SMALLINT</code><br> 
+        <code>FLOAT(s)</code><br> 
+        <code>DOUBLE PRECISION</code><br> 
+        <code>REAL</code><br>
+        <code>NUMBER(p, s)</code></td>
       <td>
         <code>NUMERIC(p, s)</code><br>
         <code>DECIMAL(p, s)</code></td>
@@ -554,22 +576,26 @@ Flink 支持连接到多个使用方言（dialect）的数据库，如 MySQL、P
     <tr>
       <td>
         <code>BOOLEAN</code><br>
-         <code>TINYINT(1)</code></td>
+        <code>TINYINT(1)</code></td>
+      <td></td>
       <td><code>BOOLEAN</code></td>
       <td><code>BOOLEAN</code></td>
     </tr>
     <tr>
+      <td><code>DATE</code></td>
       <td><code>DATE</code></td>
       <td><code>DATE</code></td>
       <td><code>DATE</code></td>
     </tr>
     <tr>
       <td><code>TIME [(p)]</code></td>
+      <td><code>DATE</code></td>
       <td><code>TIME [(p)] [WITHOUT TIMEZONE]</code></td>
       <td><code>TIME [(p)] [WITHOUT TIMEZONE]</code></td>
     </tr>
     <tr>
       <td><code>DATETIME [(p)]</code></td>
+      <td><code>TIMESTAMP [(p)] [WITHOUT TIMEZONE]</code></td>
       <td><code>TIMESTAMP [(p)] [WITHOUT TIMEZONE]</code></td>
       <td><code>TIMESTAMP [(p)] [WITHOUT TIMEZONE]</code></td>
     </tr>
@@ -578,6 +604,10 @@ Flink 支持连接到多个使用方言（dialect）的数据库，如 MySQL、P
         <code>CHAR(n)</code><br>
         <code>VARCHAR(n)</code><br>
         <code>TEXT</code></td>
+      <td>
+        <code>CHAR(n)</code><br>
+        <code>VARCHAR(n)</code><br>
+        <code>CLOB</code></td>
       <td>
         <code>CHAR(n)</code><br>
         <code>CHARACTER(n)</code><br>
@@ -591,10 +621,14 @@ Flink 支持连接到多个使用方言（dialect）的数据库，如 MySQL、P
         <code>BINARY</code><br>
         <code>VARBINARY</code><br>
         <code>BLOB</code></td>
+      <td>
+        <code>RAW(s)</code><br>
+        <code>BLOB</code></td>
       <td><code>BYTEA</code></td>
       <td><code>BYTES</code></td>
     </tr>
     <tr>
+      <td></td>
       <td></td>
       <td><code>ARRAY</code></td>
       <td><code>ARRAY</code></td>

--- a/docs/content/docs/connectors/table/jdbc.md
+++ b/docs/content/docs/connectors/table/jdbc.md
@@ -47,6 +47,7 @@ A driver dependency is also required to connect to a specified database. Here ar
 | MySQL       |       `mysql`      | `mysql-connector-java` | [Download](https://repo.maven.apache.org/maven2/mysql/mysql-connector-java/) |
 | PostgreSQL  |  `org.postgresql`  |      `postgresql`      | [Download](https://jdbc.postgresql.org/download.html) |
 | Derby       | `org.apache.derby` |        `derby`         | [Download](http://db.apache.org/derby/derby_downloads.html) |
+| Oracle      | `com.oracle.database.jdbc` |        `ojdbc8`        | [Download](https://mvnrepository.com/artifact/com.oracle.database.jdbc/ojdbc8) |
 
 
 JDBC connector and drivers are not currently part of Flink's binary distribution. See how to link with them for cluster execution [here]({{< ref "docs/dev/datastream/project-configuration" >}}).

--- a/docs/content/docs/connectors/table/jdbc.md
+++ b/docs/content/docs/connectors/table/jdbc.md
@@ -45,9 +45,9 @@ A driver dependency is also required to connect to a specified database. Here ar
 | Driver      |      Group Id      |      Artifact Id       |      JAR         |
 | :-----------| :------------------| :----------------------| :----------------|
 | MySQL       |       `mysql`      | `mysql-connector-java` | [Download](https://repo.maven.apache.org/maven2/mysql/mysql-connector-java/) |
+| Oracle      | `com.oracle.database.jdbc` |        `ojdbc8`        | [Download](https://mvnrepository.com/artifact/com.oracle.database.jdbc/ojdbc8) |
 | PostgreSQL  |  `org.postgresql`  |      `postgresql`      | [Download](https://jdbc.postgresql.org/download.html) |
 | Derby       | `org.apache.derby` |        `derby`         | [Download](http://db.apache.org/derby/derby_downloads.html) |
-| Oracle      | `com.oracle.database.jdbc` |        `ojdbc8`        | [Download](https://mvnrepository.com/artifact/com.oracle.database.jdbc/ojdbc8) |
 
 
 JDBC connector and drivers are not currently part of Flink's binary distribution. See how to link with them for cluster execution [here]({{< ref "docs/dev/datastream/project-configuration" >}}).
@@ -312,6 +312,13 @@ As there is no standard syntax for upsert, the following table describes the dat
             <td>INSERT .. ON DUPLICATE KEY UPDATE ..</td>
         </tr>
         <tr>
+            <td>Oracle</td>
+            <td>MERGE INTO .. USING (..) ON (..) <br>
+                WHEN MATCHED THEN UPDATE SET (..) <br>
+                WHEN NOT MATCHED THEN INSERT (..) <br>
+                VALUES (..)</td>
+        </tr>
+        <tr>
             <td>PostgreSQL</td>
             <td>INSERT .. ON CONFLICT .. DO UPDATE SET ..</td>
         </tr>
@@ -470,12 +477,13 @@ SELECT * FROM `custom_schema.test_table2`;
 
 Data Type Mapping
 ----------------
-Flink supports connect to several databases which uses dialect like MySQL, PostgreSQL, Derby. The Derby dialect usually used for testing purpose. The field data type mappings from relational databases data types to Flink SQL data types are listed in the following table, the mapping table can help define JDBC table in Flink easily.
+Flink supports connect to several databases which uses dialect like MySQL, Oracle, PostgreSQL, Derby. The Derby dialect usually used for testing purpose. The field data type mappings from relational databases data types to Flink SQL data types are listed in the following table, the mapping table can help define JDBC table in Flink easily.
 
 <table class="table table-bordered">
     <thead>
       <tr>
         <th class="text-left"><a href="https://dev.mysql.com/doc/refman/8.0/en/data-types.html">MySQL type</a></th>
+        <th class="text-left"><a href="https://docs.oracle.com/database/121/SQLRF/sql_elements001.htm#SQLRF30020">Oracle type</a></th>
         <th class="text-left"><a href="https://www.postgresql.org/docs/12/datatype.html">PostgreSQL type</a></th>
         <th class="text-left"><a href="{{< ref "docs/dev/table/types" >}}">Flink SQL type</a></th>
       </tr>
@@ -484,12 +492,14 @@ Flink supports connect to several databases which uses dialect like MySQL, Postg
     <tr>
       <td><code>TINYINT</code></td>
       <td></td>
+      <td></td>
       <td><code>TINYINT</code></td>
     </tr>
     <tr>
       <td>
         <code>SMALLINT</code><br>
         <code>TINYINT UNSIGNED</code></td>
+      <td></td>
       <td>
         <code>SMALLINT</code><br>
         <code>INT2</code><br>
@@ -502,6 +512,7 @@ Flink supports connect to several databases which uses dialect like MySQL, Postg
         <code>INT</code><br>
         <code>MEDIUMINT</code><br>
         <code>SMALLINT UNSIGNED</code></td>
+      <td></td>
       <td>
         <code>INTEGER</code><br>
         <code>SERIAL</code></td>
@@ -511,6 +522,7 @@ Flink supports connect to several databases which uses dialect like MySQL, Postg
       <td>
         <code>BIGINT</code><br>
         <code>INT UNSIGNED</code></td>
+      <td></td>
       <td>
         <code>BIGINT</code><br>
         <code>BIGSERIAL</code></td>
@@ -519,15 +531,18 @@ Flink supports connect to several databases which uses dialect like MySQL, Postg
    <tr>
       <td><code>BIGINT UNSIGNED</code></td>
       <td></td>
+      <td></td>
       <td><code>DECIMAL(20, 0)</code></td>
     </tr>
     <tr>
       <td><code>BIGINT</code></td>
+      <td></td>
       <td><code>BIGINT</code></td>
       <td><code>BIGINT</code></td>
     </tr>
     <tr>
       <td><code>FLOAT</code></td>
+      <td></td>
       <td>
         <code>REAL</code><br>
         <code>FLOAT4</code></td>
@@ -537,6 +552,7 @@ Flink supports connect to several databases which uses dialect like MySQL, Postg
       <td>
         <code>DOUBLE</code><br>
         <code>DOUBLE PRECISION</code></td>
+      <td></td>
       <td>
         <code>FLOAT8</code><br>
         <code>DOUBLE PRECISION</code></td>
@@ -545,7 +561,9 @@ Flink supports connect to several databases which uses dialect like MySQL, Postg
     <tr>
       <td>
         <code>NUMERIC(p, s)</code><br>
-         <code>DECIMAL(p, s)</code></td>
+        <code>DECIMAL(p, s)</code></td>
+      <td>
+        <code>NUMBER(p, s)</code></td>
       <td>
         <code>NUMERIC(p, s)</code><br>
         <code>DECIMAL(p, s)</code></td>
@@ -554,22 +572,26 @@ Flink supports connect to several databases which uses dialect like MySQL, Postg
     <tr>
       <td>
         <code>BOOLEAN</code><br>
-         <code>TINYINT(1)</code></td>
+        <code>TINYINT(1)</code></td>
+      <td></td>
       <td><code>BOOLEAN</code></td>
       <td><code>BOOLEAN</code></td>
     </tr>
     <tr>
+      <td><code>DATE</code></td>
       <td><code>DATE</code></td>
       <td><code>DATE</code></td>
       <td><code>DATE</code></td>
     </tr>
     <tr>
       <td><code>TIME [(p)]</code></td>
+      <td></td>
       <td><code>TIME [(p)] [WITHOUT TIMEZONE]</code></td>
       <td><code>TIME [(p)] [WITHOUT TIMEZONE]</code></td>
     </tr>
     <tr>
       <td><code>DATETIME [(p)]</code></td>
+      <td><code>TIMESTAMP [(p)] [WITHOUT TIMEZONE]</code></td>
       <td><code>TIMESTAMP [(p)] [WITHOUT TIMEZONE]</code></td>
       <td><code>TIMESTAMP [(p)] [WITHOUT TIMEZONE]</code></td>
     </tr>
@@ -578,6 +600,9 @@ Flink supports connect to several databases which uses dialect like MySQL, Postg
         <code>CHAR(n)</code><br>
         <code>VARCHAR(n)</code><br>
         <code>TEXT</code></td>
+      <td>
+        <code>CHAR(n)</code><br>
+        <code>VARCHAR(n)</code><br>
       <td>
         <code>CHAR(n)</code><br>
         <code>CHARACTER(n)</code><br>
@@ -591,10 +616,12 @@ Flink supports connect to several databases which uses dialect like MySQL, Postg
         <code>BINARY</code><br>
         <code>VARBINARY</code><br>
         <code>BLOB</code></td>
+      <td></td>
       <td><code>BYTEA</code></td>
       <td><code>BYTES</code></td>
     </tr>
     <tr>
+      <td></td>
       <td></td>
       <td><code>ARRAY</code></td>
       <td><code>ARRAY</code></td>

--- a/docs/content/docs/connectors/table/jdbc.md
+++ b/docs/content/docs/connectors/table/jdbc.md
@@ -542,7 +542,7 @@ Flink supports connect to several databases which uses dialect like MySQL, Oracl
     </tr>
     <tr>
       <td><code>FLOAT</code></td>
-      <td></td>
+      <td><code>FLOAT</code></td>
       <td>
         <code>REAL</code><br>
         <code>FLOAT4</code></td>
@@ -585,7 +585,7 @@ Flink supports connect to several databases which uses dialect like MySQL, Oracl
     </tr>
     <tr>
       <td><code>TIME [(p)]</code></td>
-      <td></td>
+      <td><code>DATE</code></td>
       <td><code>TIME [(p)] [WITHOUT TIMEZONE]</code></td>
       <td><code>TIME [(p)] [WITHOUT TIMEZONE]</code></td>
     </tr>
@@ -603,6 +603,7 @@ Flink supports connect to several databases which uses dialect like MySQL, Oracl
       <td>
         <code>CHAR(n)</code><br>
         <code>VARCHAR(n)</code><br>
+        <code>CLOB</code></td>
       <td>
         <code>CHAR(n)</code><br>
         <code>CHARACTER(n)</code><br>
@@ -616,7 +617,7 @@ Flink supports connect to several databases which uses dialect like MySQL, Oracl
         <code>BINARY</code><br>
         <code>VARBINARY</code><br>
         <code>BLOB</code></td>
-      <td></td>
+      <td><code>RAW(s)</code></td>
       <td><code>BYTEA</code></td>
       <td><code>BYTES</code></td>
     </tr>

--- a/docs/content/docs/connectors/table/jdbc.md
+++ b/docs/content/docs/connectors/table/jdbc.md
@@ -542,7 +542,8 @@ Flink supports connect to several databases which uses dialect like MySQL, Oracl
     </tr>
     <tr>
       <td><code>FLOAT</code></td>
-      <td><code>FLOAT</code></td>
+      <td>
+        <code>BINARY_FLOAT</code></td>
       <td>
         <code>REAL</code><br>
         <code>FLOAT4</code></td>
@@ -552,7 +553,7 @@ Flink supports connect to several databases which uses dialect like MySQL, Oracl
       <td>
         <code>DOUBLE</code><br>
         <code>DOUBLE PRECISION</code></td>
-      <td></td>
+      <td><code>BINARY_DOUBLE</code></td>
       <td>
         <code>FLOAT8</code><br>
         <code>DOUBLE PRECISION</code></td>
@@ -563,6 +564,10 @@ Flink supports connect to several databases which uses dialect like MySQL, Oracl
         <code>NUMERIC(p, s)</code><br>
         <code>DECIMAL(p, s)</code></td>
       <td>
+        <code>SMALLINT</code><br> 
+        <code>FLOAT(s)</code><br> 
+        <code>DOUBLE PRECISION</code><br> 
+        <code>REAL</code><br>
         <code>NUMBER(p, s)</code></td>
       <td>
         <code>NUMERIC(p, s)</code><br>
@@ -617,7 +622,9 @@ Flink supports connect to several databases which uses dialect like MySQL, Oracl
         <code>BINARY</code><br>
         <code>VARBINARY</code><br>
         <code>BLOB</code></td>
-      <td><code>RAW(s)</code></td>
+      <td>
+        <code>RAW(s)</code><br>
+        <code>BLOB</code></td>
       <td><code>BYTEA</code></td>
       <td><code>BYTES</code></td>
     </tr>

--- a/flink-connectors/flink-connector-jdbc/pom.xml
+++ b/flink-connectors/flink-connector-jdbc/pom.xml
@@ -37,6 +37,7 @@ under the License.
 
 	<properties>
 		<postgres.version>42.2.10</postgres.version>
+		<oracle.version>19.3.0.0</oracle.version>
 		<otj-pg-embedded.version>0.13.4</otj-pg-embedded.version>
 	</properties>
 
@@ -58,6 +59,14 @@ under the License.
 			<groupId>org.postgresql</groupId>
 			<artifactId>postgresql</artifactId>
 			<version>${postgres.version}</version>
+			<scope>provided</scope>
+		</dependency>
+
+		<!-- Oracle -->
+		<dependency>
+			<groupId>com.oracle.database.jdbc</groupId>
+			<artifactId>ojdbc8</artifactId>
+			<version>${oracle.version}</version>
 			<scope>provided</scope>
 		</dependency>
 
@@ -161,12 +170,6 @@ under the License.
 		</dependency>
 
 		<!-- Oracle tests -->
-		<dependency>
-			<groupId>com.oracle.database.jdbc</groupId>
-			<artifactId>ojdbc8</artifactId>
-			<version>12.2.0.1</version>
-			<scope>test</scope>
-		</dependency>
 		<dependency>
 			<groupId>org.testcontainers</groupId>
 			<artifactId>oracle-xe</artifactId>

--- a/flink-connectors/flink-connector-jdbc/pom.xml
+++ b/flink-connectors/flink-connector-jdbc/pom.xml
@@ -160,6 +160,19 @@ under the License.
 			<scope>test</scope>
 		</dependency>
 
+		<!-- Oracle tests -->
+		<dependency>
+			<groupId>com.oracle.database.jdbc</groupId>
+			<artifactId>ojdbc8</artifactId>
+			<version>12.2.0.1</version>
+			<scope>test</scope>
+		</dependency>
+		<dependency>
+			<groupId>org.testcontainers</groupId>
+			<artifactId>oracle-xe</artifactId>
+			<scope>test</scope>
+		</dependency>
+
 		<!-- H2 tests -->
 		<dependency>
 			<groupId>com.h2database</groupId>
@@ -179,6 +192,7 @@ under the License.
 			<artifactId>mysql</artifactId>
 			<scope>test</scope>
 		</dependency>
+
 	</dependencies>
 
 	<build>

--- a/flink-connectors/flink-connector-jdbc/src/main/java/org/apache/flink/connector/jdbc/dialect/oracle/OracleDialect.java
+++ b/flink-connectors/flink-connector-jdbc/src/main/java/org/apache/flink/connector/jdbc/dialect/oracle/OracleDialect.java
@@ -52,7 +52,7 @@ class OracleDialect extends AbstractDialect {
 
     @Override
     public String getLimitClause(long limit) {
-        return "";
+        return "FETCH FIRST " + limit + " ROWS ONLY";
     }
 
     @Override
@@ -103,7 +103,7 @@ class OracleDialect extends AbstractDialect {
                         .collect(Collectors.joining(", "));
 
         // if we can't divide schema and table-name is risky to call quoteIdentifier(tableName)
-        // for example in SQL-server [tbo].[sometable] is ok but [tbo.sometable] is not
+        // for example [tbo].[sometable] is ok but [tbo.sometable] is not
         String mergeQuery =
                 " MERGE INTO "
                         + tableName
@@ -140,10 +140,6 @@ class OracleDialect extends AbstractDialect {
     public Set<LogicalTypeRoot> supportedTypes() {
         // The data types used in Oracle are list at:
         // https://www.techonthenet.com/oracle/datatypes.php
-
-        // TODO: We can't convert BINARY data type to
-        //  PrimitiveArrayTypeInfo.BYTE_PRIMITIVE_ARRAY_TYPE_INFO in
-        // LegacyTypeInfoDataTypeConverter.
 
         return EnumSet.of(
                 LogicalTypeRoot.CHAR,

--- a/flink-connectors/flink-connector-jdbc/src/main/java/org/apache/flink/connector/jdbc/dialect/oracle/OracleDialect.java
+++ b/flink-connectors/flink-connector-jdbc/src/main/java/org/apache/flink/connector/jdbc/dialect/oracle/OracleDialect.java
@@ -1,0 +1,166 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.flink.connector.jdbc.dialect.oracle;
+
+import org.apache.flink.connector.jdbc.converter.JdbcRowConverter;
+import org.apache.flink.connector.jdbc.dialect.AbstractDialect;
+import org.apache.flink.connector.jdbc.internal.converter.OracleRowConverter;
+import org.apache.flink.table.types.logical.LogicalTypeRoot;
+import org.apache.flink.table.types.logical.RowType;
+
+import java.util.Arrays;
+import java.util.EnumSet;
+import java.util.Optional;
+import java.util.Set;
+import java.util.stream.Collectors;
+
+/** JDBC dialect for Oracle. */
+class OracleDialect extends AbstractDialect {
+
+    private static final long serialVersionUID = 1L;
+
+    // Define MAX/MIN precision of TIMESTAMP type according to Oracle docs:
+    // https://www.techonthenet.com/oracle/datatypes.php
+    private static final int MAX_TIMESTAMP_PRECISION = 9;
+    private static final int MIN_TIMESTAMP_PRECISION = 1;
+
+    // Define MAX/MIN precision of DECIMAL type according to Oracle docs:
+    // https://www.techonthenet.com/oracle/datatypes.php
+    private static final int MAX_DECIMAL_PRECISION = 38;
+    private static final int MIN_DECIMAL_PRECISION = 1;
+
+    @Override
+    public JdbcRowConverter getRowConverter(RowType rowType) {
+        return new OracleRowConverter(rowType);
+    }
+
+    @Override
+    public String getLimitClause(long limit) {
+        return "";
+    }
+
+    @Override
+    public Optional<String> defaultDriverName() {
+        return Optional.of("oracle.jdbc.OracleDriver");
+    }
+
+    @Override
+    public String dialectName() {
+        return "Oracle";
+    }
+
+    @Override
+    public String quoteIdentifier(String identifier) {
+        return identifier;
+    }
+
+    @Override
+    public Optional<String> getUpsertStatement(
+            String tableName, String[] fieldNames, String[] uniqueKeyFields) {
+
+        String sourceFields =
+                Arrays.stream(fieldNames)
+                        .map(f -> "? " + quoteIdentifier(f))
+                        .collect(Collectors.joining(", "));
+
+        String onClause =
+                Arrays.stream(uniqueKeyFields)
+                        .map(f -> "t." + quoteIdentifier(f) + "=s." + quoteIdentifier(f))
+                        .collect(Collectors.joining(", "));
+
+        final Set<String> uniqueKeyFieldsSet =
+                Arrays.stream(uniqueKeyFields).collect(Collectors.toSet());
+        String updateClause =
+                Arrays.stream(fieldNames)
+                        .filter(f -> !uniqueKeyFieldsSet.contains(f))
+                        .map(f -> "t." + quoteIdentifier(f) + "=s." + quoteIdentifier(f))
+                        .collect(Collectors.joining(", "));
+
+        String insertFields =
+                Arrays.stream(fieldNames)
+                        .map(this::quoteIdentifier)
+                        .collect(Collectors.joining(", "));
+
+        String valuesClause =
+                Arrays.stream(fieldNames)
+                        .map(f -> "s." + quoteIdentifier(f))
+                        .collect(Collectors.joining(", "));
+
+        // if we can't divide schema and table-name is risky to call quoteIdentifier(tableName)
+        // for example in SQL-server [tbo].[sometable] is ok but [tbo.sometable] is not
+        String mergeQuery =
+                " MERGE INTO "
+                        + tableName
+                        + " t "
+                        + " USING (SELECT"
+                        + sourceFields
+                        + "FROM DUAL) s "
+                        + " ON ("
+                        + onClause
+                        + ") "
+                        + " WHEN MATCHED THEN UPDATE SET "
+                        + updateClause
+                        + " WHEN NOT MATCHED THEN INSERT ("
+                        + insertFields
+                        + ")"
+                        + " VALUES ("
+                        + valuesClause
+                        + ")";
+
+        return Optional.of(mergeQuery);
+    }
+
+    @Override
+    public Optional<Range> decimalPrecisionRange() {
+        return Optional.of(Range.of(MIN_DECIMAL_PRECISION, MAX_DECIMAL_PRECISION));
+    }
+
+    @Override
+    public Optional<Range> timestampPrecisionRange() {
+        return Optional.of(Range.of(MIN_TIMESTAMP_PRECISION, MAX_TIMESTAMP_PRECISION));
+    }
+
+    @Override
+    public Set<LogicalTypeRoot> supportedTypes() {
+        // The data types used in Oracle are list at:
+        // https://www.techonthenet.com/oracle/datatypes.php
+
+        // TODO: We can't convert BINARY data type to
+        //  PrimitiveArrayTypeInfo.BYTE_PRIMITIVE_ARRAY_TYPE_INFO in
+        // LegacyTypeInfoDataTypeConverter.
+
+        return EnumSet.of(
+                LogicalTypeRoot.CHAR,
+                LogicalTypeRoot.VARCHAR,
+                LogicalTypeRoot.BOOLEAN,
+                LogicalTypeRoot.VARBINARY,
+                LogicalTypeRoot.DECIMAL,
+                LogicalTypeRoot.TINYINT,
+                LogicalTypeRoot.SMALLINT,
+                LogicalTypeRoot.INTEGER,
+                LogicalTypeRoot.BIGINT,
+                LogicalTypeRoot.FLOAT,
+                LogicalTypeRoot.DOUBLE,
+                LogicalTypeRoot.DATE,
+                LogicalTypeRoot.TIME_WITHOUT_TIME_ZONE,
+                LogicalTypeRoot.TIMESTAMP_WITHOUT_TIME_ZONE,
+                LogicalTypeRoot.TIMESTAMP_WITH_LOCAL_TIME_ZONE,
+                LogicalTypeRoot.ARRAY);
+    }
+}

--- a/flink-connectors/flink-connector-jdbc/src/main/java/org/apache/flink/connector/jdbc/dialect/oracle/OracleDialect.java
+++ b/flink-connectors/flink-connector-jdbc/src/main/java/org/apache/flink/connector/jdbc/dialect/oracle/OracleDialect.java
@@ -76,13 +76,13 @@ class OracleDialect extends AbstractDialect {
 
         String sourceFields =
                 Arrays.stream(fieldNames)
-                        .map(f -> "? " + quoteIdentifier(f))
+                        .map(f -> ":" + f + " " + quoteIdentifier(f))
                         .collect(Collectors.joining(", "));
 
         String onClause =
                 Arrays.stream(uniqueKeyFields)
                         .map(f -> "t." + quoteIdentifier(f) + "=s." + quoteIdentifier(f))
-                        .collect(Collectors.joining(", "));
+                        .collect(Collectors.joining(" and "));
 
         final Set<String> uniqueKeyFieldsSet =
                 Arrays.stream(uniqueKeyFields).collect(Collectors.toSet());
@@ -108,9 +108,9 @@ class OracleDialect extends AbstractDialect {
                 " MERGE INTO "
                         + tableName
                         + " t "
-                        + " USING (SELECT"
+                        + " USING (SELECT "
                         + sourceFields
-                        + "FROM DUAL) s "
+                        + " FROM DUAL) s "
                         + " ON ("
                         + onClause
                         + ") "

--- a/flink-connectors/flink-connector-jdbc/src/main/java/org/apache/flink/connector/jdbc/dialect/oracle/OracleDialectFactory.java
+++ b/flink-connectors/flink-connector-jdbc/src/main/java/org/apache/flink/connector/jdbc/dialect/oracle/OracleDialectFactory.java
@@ -1,0 +1,37 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.flink.connector.jdbc.dialect.oracle;
+
+import org.apache.flink.annotation.Internal;
+import org.apache.flink.connector.jdbc.dialect.JdbcDialect;
+import org.apache.flink.connector.jdbc.dialect.JdbcDialectFactory;
+
+/** Factory for {@link OracleDialect}. */
+@Internal
+public class OracleDialectFactory implements JdbcDialectFactory {
+    @Override
+    public boolean acceptsURL(String url) {
+        return url.startsWith("jdbc:oracle:");
+    }
+
+    @Override
+    public JdbcDialect create() {
+        return new OracleDialect();
+    }
+}

--- a/flink-connectors/flink-connector-jdbc/src/main/java/org/apache/flink/connector/jdbc/internal/converter/OracleRowConverter.java
+++ b/flink-connectors/flink-connector-jdbc/src/main/java/org/apache/flink/connector/jdbc/internal/converter/OracleRowConverter.java
@@ -1,0 +1,40 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.flink.connector.jdbc.internal.converter;
+
+import org.apache.flink.connector.jdbc.converter.AbstractJdbcRowConverter;
+import org.apache.flink.table.types.logical.RowType;
+
+/**
+ * Runtime converter that responsible to convert between JDBC object and Flink internal object for
+ * Oracle.
+ */
+public class OracleRowConverter extends AbstractJdbcRowConverter {
+
+    private static final long serialVersionUID = 1L;
+
+    public OracleRowConverter(RowType rowType) {
+        super(rowType);
+    }
+
+    @Override
+    public String converterName() {
+        return "Oracle";
+    }
+}

--- a/flink-connectors/flink-connector-jdbc/src/main/java/org/apache/flink/connector/jdbc/internal/converter/OracleRowConverter.java
+++ b/flink-connectors/flink-connector-jdbc/src/main/java/org/apache/flink/connector/jdbc/internal/converter/OracleRowConverter.java
@@ -18,6 +18,12 @@
 
 package org.apache.flink.connector.jdbc.internal.converter;
 
+import oracle.jdbc.internal.OracleClob;
+
+import oracle.sql.TIMESTAMPLTZ;
+
+import oracle.sql.TIMESTAMPTZ;
+
 import org.apache.flink.connector.jdbc.converter.AbstractJdbcRowConverter;
 import org.apache.flink.table.data.DecimalData;
 import org.apache.flink.table.data.StringData;
@@ -33,12 +39,17 @@ import oracle.sql.DATE;
 import oracle.sql.NUMBER;
 import oracle.sql.RAW;
 import oracle.sql.TIMESTAMP;
+import oracle.sql.CLOB;
 
 import java.math.BigDecimal;
 import java.math.BigInteger;
 import java.sql.Date;
 import java.sql.Time;
 import java.sql.Timestamp;
+import java.time.LocalDateTime;
+import java.time.ZoneId;
+import java.time.ZoneOffset;
+import java.time.ZonedDateTime;
 
 /**
  * Runtime converter that responsible to convert between JDBC object and Flink internal object for
@@ -123,27 +134,50 @@ public class OracleRowConverter extends AbstractJdbcRowConverter {
                                         (((DATE) val).timeValue().toLocalTime().toNanoOfDay()
                                                 / 1_000_000L)
                                 : (int) (((Time) val).toLocalTime().toNanoOfDay() / 1_000_000L);
-            case TIMESTAMP_WITHOUT_TIME_ZONE:
-                return val ->
-                        val instanceof TIMESTAMP
-                                ? TimestampData.fromTimestamp(((TIMESTAMP) val).timestampValue())
-                                : TimestampData.fromTimestamp((Timestamp) val);
             case CHAR:
             case VARCHAR:
                 return val ->
                         (val instanceof CHAR)
                                 ? StringData.fromString(((CHAR) val).getString())
-                                : StringData.fromString((String) val);
+                                : (val instanceof OracleClob)
+                                    ? StringData.fromString(((OracleClob) val).stringValue())
+                                    : StringData.fromString((String) val);
             case BINARY:
             case VARBINARY:
+            case RAW:
                 return val -> (val instanceof RAW) ? ((RAW) val).getBytes() : val;
+            case TIMESTAMP_WITHOUT_TIME_ZONE:
+                return val ->
+                        val instanceof TIMESTAMP
+                                ? TimestampData.fromTimestamp(((TIMESTAMP) val).timestampValue())
+                                : TimestampData.fromTimestamp((Timestamp) val);
             case TIMESTAMP_WITH_TIME_ZONE:
+                return val -> {
+                    if (val instanceof TIMESTAMPTZ) {
+                        final TIMESTAMPTZ ts = (TIMESTAMPTZ) val;
+                        final ZonedDateTime zdt = ZonedDateTime
+                                .ofInstant(ts.timestampValue().toInstant(), ts.getTimeZone().toZoneId());
+                        return TimestampData.fromLocalDateTime(zdt.toLocalDateTime());
+                    } else {
+                        return TimestampData.fromTimestamp((Timestamp) val);
+                    }
+                };
             case TIMESTAMP_WITH_LOCAL_TIME_ZONE:
+                return val -> {
+                    if (val instanceof TIMESTAMPLTZ) {
+                        final TIMESTAMPLTZ ts = (TIMESTAMPLTZ) val;
+                        final ZonedDateTime zdt = ZonedDateTime
+                                .ofInstant(ts.timestampValue().toInstant(), ZoneId.systemDefault())
+                                .withZoneSameInstant(ZoneOffset.UTC);
+                        return TimestampData.fromLocalDateTime(zdt.toLocalDateTime());
+                    } else {
+                        return TimestampData.fromTimestamp((Timestamp) val);
+                    }
+                };
             case ARRAY:
             case ROW:
             case MAP:
             case MULTISET:
-            case RAW:
             default:
                 return super.createInternalConverter(type);
         }

--- a/flink-connectors/flink-connector-jdbc/src/main/resources/META-INF/services/org.apache.flink.connector.jdbc.dialect.JdbcDialectFactory
+++ b/flink-connectors/flink-connector-jdbc/src/main/resources/META-INF/services/org.apache.flink.connector.jdbc.dialect.JdbcDialectFactory
@@ -16,3 +16,4 @@
 org.apache.flink.connector.jdbc.dialect.derby.DerbyDialectFactory
 org.apache.flink.connector.jdbc.dialect.mysql.MySQLDialectFactory
 org.apache.flink.connector.jdbc.dialect.psql.PostgresDialectFactory
+org.apache.flink.connector.jdbc.dialect.oracle.OracleDialectFactory

--- a/flink-connectors/flink-connector-jdbc/src/test/java/org/apache/flink/connector/jdbc/JdbcDataTypeTest.java
+++ b/flink-connectors/flink-connector-jdbc/src/test/java/org/apache/flink/connector/jdbc/JdbcDataTypeTest.java
@@ -101,6 +101,22 @@ public class JdbcDataTypeTest {
                 createTestItem("postgresql", "TIMESTAMP WITHOUT TIME ZONE"),
                 createTestItem("postgresql", "VARBINARY"),
                 createTestItem("postgresql", "ARRAY<INTEGER>"),
+                createTestItem("oracle", "CHAR"),
+                createTestItem("oracle", "VARCHAR"),
+                createTestItem("oracle", "BOOLEAN"),
+                createTestItem("oracle", "TINYINT"),
+                createTestItem("oracle", "SMALLINT"),
+                createTestItem("oracle", "INTEGER"),
+                createTestItem("oracle", "BIGINT"),
+                createTestItem("oracle", "FLOAT"),
+                createTestItem("oracle", "DOUBLE"),
+                createTestItem("oracle", "DECIMAL(10, 4)"),
+                createTestItem("oracle", "DECIMAL(38, 18)"),
+                createTestItem("oracle", "DATE"),
+                createTestItem("oracle", "TIME"),
+                createTestItem("oracle", "TIMESTAMP(3)"),
+                createTestItem("oracle", "TIMESTAMP WITHOUT TIME ZONE"),
+                createTestItem("oracle", "VARBINARY"),
 
                 // Unsupported types throws errors.
                 createTestItem(
@@ -144,7 +160,13 @@ public class JdbcDataTypeTest {
                         "TIMESTAMP(9) WITHOUT TIME ZONE",
                         "The precision of field 'f0' is out of the TIMESTAMP precision range [1, 6] supported by PostgreSQL dialect."),
                 createTestItem(
-                        "postgresql", "TIMESTAMP_LTZ(3)", "Unsupported type:TIMESTAMP_LTZ(3)"));
+                        "postgresql", "TIMESTAMP_LTZ(3)", "Unsupported type:TIMESTAMP_LTZ(3)"),
+                createTestItem(
+                        "oracle", "BINARY", "The Oracle dialect doesn't support type: BINARY(1)."),
+                createTestItem(
+                        "oracle",
+                        "VARBINARY(10)",
+                        "The Oracle dialect doesn't support type: VARBINARY(10)."));
     }
 
     private static TestItem createTestItem(Object... args) {

--- a/flink-connectors/flink-connector-jdbc/src/test/java/org/apache/flink/connector/jdbc/JdbcTestFixture.java
+++ b/flink-connectors/flink-connector-jdbc/src/test/java/org/apache/flink/connector/jdbc/JdbcTestFixture.java
@@ -149,7 +149,7 @@ public class JdbcTestFixture {
         return "CREATE TABLE "
                 + tableName
                 + " ("
-                + "id INT NOT NULL DEFAULT 0,"
+                + "id INT DEFAULT 0 NOT NULL,"
                 + "title VARCHAR(50) DEFAULT NULL,"
                 + "author VARCHAR(50) DEFAULT NULL,"
                 + "price FLOAT DEFAULT NULL,"

--- a/flink-connectors/flink-connector-jdbc/src/test/java/org/apache/flink/connector/jdbc/dialect/oracle/OracleContainer.java
+++ b/flink-connectors/flink-connector-jdbc/src/test/java/org/apache/flink/connector/jdbc/dialect/oracle/OracleContainer.java
@@ -1,0 +1,81 @@
+package org.apache.flink.connector.jdbc.dialect.oracle;
+
+import org.testcontainers.containers.JdbcDatabaseContainer;
+import org.testcontainers.utility.DockerImageName;
+
+/** {@link OracleContainer}. */
+public class OracleContainer extends JdbcDatabaseContainer<OracleContainer> {
+    private static final String DEFAULT_TAG = "18.4.0-slim";
+    private static final String IMAGE = "gvenzl/oracle-xe";
+    private static final DockerImageName ORACLE_IMAGE =
+            DockerImageName.parse(IMAGE).withTag(DEFAULT_TAG);
+
+    private static final int ORACLE_PORT = 1521;
+    private static final int APEX_HTTP_PORT = 8080;
+
+    private static final int DEFAULT_STARTUP_TIMEOUT_SECONDS = 240;
+    private static final int DEFAULT_CONNECT_TIMEOUT_SECONDS = 120;
+
+    private String username = "system";
+    private String password = "oracle";
+
+    public OracleContainer() {
+        super(ORACLE_IMAGE);
+        preconfigure();
+    }
+
+    private void preconfigure() {
+        withStartupTimeoutSeconds(DEFAULT_STARTUP_TIMEOUT_SECONDS);
+        withConnectTimeoutSeconds(DEFAULT_CONNECT_TIMEOUT_SECONDS);
+        withEnv("ORACLE_PASSWORD", password);
+        addExposedPorts(ORACLE_PORT, APEX_HTTP_PORT);
+    }
+
+    @Override
+    public String getDriverClassName() {
+        return "oracle.jdbc.OracleDriver";
+    }
+
+    @Override
+    public String getJdbcUrl() {
+        return "jdbc:oracle:thin:"
+                + getUsername()
+                + "/"
+                + getPassword()
+                + "@"
+                + getHost()
+                + ":"
+                + getOraclePort()
+                + ":"
+                + getSid();
+    }
+
+    @Override
+    public String getUsername() {
+        return username;
+    }
+
+    @Override
+    public String getPassword() {
+        return password;
+    }
+
+    @SuppressWarnings("SameReturnValue")
+    public String getSid() {
+        return "xe";
+    }
+
+    public Integer getOraclePort() {
+        return getMappedPort(ORACLE_PORT);
+    }
+
+    @SuppressWarnings("unused")
+    public Integer getWebPort() {
+        return getMappedPort(APEX_HTTP_PORT);
+    }
+
+    @Override
+    public String getTestQueryString() {
+        return "SELECT 1 FROM DUAL";
+    }
+}

--- a/flink-connectors/flink-connector-jdbc/src/test/java/org/apache/flink/connector/jdbc/dialect/oracle/OracleContainer.java
+++ b/flink-connectors/flink-connector-jdbc/src/test/java/org/apache/flink/connector/jdbc/dialect/oracle/OracleContainer.java
@@ -1,3 +1,21 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
 package org.apache.flink.connector.jdbc.dialect.oracle;
 
 import org.testcontainers.containers.JdbcDatabaseContainer;

--- a/flink-connectors/flink-connector-jdbc/src/test/java/org/apache/flink/connector/jdbc/dialect/oracle/OraclePreparedStatementTest.java
+++ b/flink-connectors/flink-connector-jdbc/src/test/java/org/apache/flink/connector/jdbc/dialect/oracle/OraclePreparedStatementTest.java
@@ -1,0 +1,172 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.flink.connector.jdbc.dialect.oracle;
+
+import org.apache.flink.connector.jdbc.dialect.JdbcDialect;
+import org.apache.flink.connector.jdbc.dialect.JdbcDialectLoader;
+import org.apache.flink.connector.jdbc.statement.FieldNamedPreparedStatementImpl;
+
+import org.junit.Test;
+
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+
+import static java.util.Arrays.asList;
+import static java.util.Collections.singletonList;
+import static org.junit.Assert.assertEquals;
+
+/** Tests for {@link OraclePreparedStatementTest}. */
+public class OraclePreparedStatementTest {
+
+    private final JdbcDialect dialect = JdbcDialectLoader.load("jdbc:oracle://localhost:3306/test");
+    private final String[] fieldNames =
+            new String[] {"id", "name", "email", "ts", "field1", "field_2", "__field_3__"};
+    private final String[] keyFields = new String[] {"id", "__field_3__"};
+    private final String tableName = "tbl";
+
+    @Test
+    public void testInsertStatement() {
+        String insertStmt = dialect.getInsertIntoStatement(tableName, fieldNames);
+        assertEquals(
+                "INSERT INTO tbl(id, name, email, ts, field1, field_2, __field_3__) "
+                        + "VALUES (:id, :name, :email, :ts, :field1, :field_2, :__field_3__)",
+                insertStmt);
+        NamedStatementMatcher.parsedSql(
+                        "INSERT INTO tbl(id, name, email, ts, field1, field_2, __field_3__) "
+                                + "VALUES (?, ?, ?, ?, ?, ?, ?)")
+                .parameter("id", singletonList(1))
+                .parameter("name", singletonList(2))
+                .parameter("email", singletonList(3))
+                .parameter("ts", singletonList(4))
+                .parameter("field1", singletonList(5))
+                .parameter("field_2", singletonList(6))
+                .parameter("__field_3__", singletonList(7))
+                .matches(insertStmt);
+    }
+
+    @Test
+    public void testDeleteStatement() {
+        String deleteStmt = dialect.getDeleteStatement(tableName, keyFields);
+        assertEquals("DELETE FROM tbl WHERE id = :id AND __field_3__ = :__field_3__", deleteStmt);
+        NamedStatementMatcher.parsedSql("DELETE FROM tbl WHERE id = ? AND __field_3__ = ?")
+                .parameter("id", singletonList(1))
+                .parameter("__field_3__", singletonList(2))
+                .matches(deleteStmt);
+    }
+
+    @Test
+    public void testRowExistsStatement() {
+        String rowExistStmt = dialect.getRowExistsStatement(tableName, keyFields);
+        assertEquals(
+                "SELECT 1 FROM tbl WHERE id = :id AND __field_3__ = :__field_3__", rowExistStmt);
+        NamedStatementMatcher.parsedSql("SELECT 1 FROM tbl WHERE id = ? AND __field_3__ = ?")
+                .parameter("id", singletonList(1))
+                .parameter("__field_3__", singletonList(2))
+                .matches(rowExistStmt);
+    }
+
+    @Test
+    public void testUpdateStatement() {
+        String updateStmt = dialect.getUpdateStatement(tableName, fieldNames, keyFields);
+        assertEquals(
+                "UPDATE tbl SET id = :id, name = :name, email = :email, ts = :ts, "
+                        + "field1 = :field1, field_2 = :field_2, __field_3__ = :__field_3__ "
+                        + "WHERE id = :id AND __field_3__ = :__field_3__",
+                updateStmt);
+        NamedStatementMatcher.parsedSql(
+                        "UPDATE tbl SET id = ?, name = ?, email = ?, ts = ?, field1 = ?, "
+                                + "field_2 = ?, __field_3__ = ? WHERE id = ? AND __field_3__ = ?")
+                .parameter("id", asList(1, 8))
+                .parameter("name", singletonList(2))
+                .parameter("email", singletonList(3))
+                .parameter("ts", singletonList(4))
+                .parameter("field1", singletonList(5))
+                .parameter("field_2", singletonList(6))
+                .parameter("__field_3__", asList(7, 9))
+                .matches(updateStmt);
+    }
+
+    @Test
+    public void testUpsertStatement() {
+        String upsertStmt = dialect.getUpsertStatement(tableName, fieldNames, keyFields).get();
+        assertEquals(
+                " MERGE INTO tbl t "
+                        + " USING (SELECT :id id, :name name, :email email, :ts ts, :field1 field1, :field_2 field_2, :__field_3__ __field_3__ FROM DUAL) s "
+                        + " ON (t.id=s.id and t.__field_3__=s.__field_3__) "
+                        + " WHEN MATCHED THEN UPDATE SET t.name=s.name, t.email=s.email, t.ts=s.ts, t.field1=s.field1, t.field_2=s.field_2"
+                        + " WHEN NOT MATCHED THEN INSERT (id, name, email, ts, field1, field_2, __field_3__)"
+                        + " VALUES (s.id, s.name, s.email, s.ts, s.field1, s.field_2, s.__field_3__)",
+                upsertStmt);
+        NamedStatementMatcher.parsedSql(
+                        " MERGE INTO tbl t "
+                                + " USING (SELECT ? id, ? name, ? email, ? ts, ? field1, ? field_2, ? __field_3__ FROM DUAL) s "
+                                + " ON (t.id=s.id and t.__field_3__=s.__field_3__) "
+                                + " WHEN MATCHED THEN UPDATE SET t.name=s.name, t.email=s.email, t.ts=s.ts, t.field1=s.field1, t.field_2=s.field_2"
+                                + " WHEN NOT MATCHED THEN INSERT (id, name, email, ts, field1, field_2, __field_3__)"
+                                + " VALUES (s.id, s.name, s.email, s.ts, s.field1, s.field_2, s.__field_3__)")
+                .parameter("id", singletonList(1))
+                .parameter("name", singletonList(2))
+                .parameter("email", singletonList(3))
+                .parameter("ts", singletonList(4))
+                .parameter("field1", singletonList(5))
+                .parameter("field_2", singletonList(6))
+                .parameter("__field_3__", singletonList(7))
+                .matches(upsertStmt);
+    }
+
+    @Test
+    public void testSelectStatement() {
+        String selectStmt = dialect.getSelectFromStatement(tableName, fieldNames, keyFields);
+        assertEquals(
+                "SELECT id, name, email, ts, field1, field_2, __field_3__ FROM tbl "
+                        + "WHERE id = :id AND __field_3__ = :__field_3__",
+                selectStmt);
+        NamedStatementMatcher.parsedSql(
+                        "SELECT id, name, email, ts, field1, field_2, __field_3__ FROM tbl "
+                                + "WHERE id = ? AND __field_3__ = ?")
+                .parameter("id", singletonList(1))
+                .parameter("__field_3__", singletonList(2))
+                .matches(selectStmt);
+    }
+
+    private static class NamedStatementMatcher {
+        private String parsedSql;
+        private Map<String, List<Integer>> parameterMap = new HashMap<>();
+
+        public static NamedStatementMatcher parsedSql(String parsedSql) {
+            NamedStatementMatcher spec = new NamedStatementMatcher();
+            spec.parsedSql = parsedSql;
+            return spec;
+        }
+
+        public NamedStatementMatcher parameter(String name, List<Integer> index) {
+            this.parameterMap.put(name, index);
+            return this;
+        }
+
+        public void matches(String statement) {
+            Map<String, List<Integer>> actualParams = new HashMap<>();
+            String actualParsedStmt =
+                    FieldNamedPreparedStatementImpl.parseNamedStatement(statement, actualParams);
+            assertEquals(parsedSql, actualParsedStmt);
+            assertEquals(parameterMap, actualParams);
+        }
+    }
+}

--- a/flink-connectors/flink-connector-jdbc/src/test/java/org/apache/flink/connector/jdbc/dialect/oracle/OracleTableSinkITCase.java
+++ b/flink-connectors/flink-connector-jdbc/src/test/java/org/apache/flink/connector/jdbc/dialect/oracle/OracleTableSinkITCase.java
@@ -45,9 +45,7 @@ import org.apache.flink.table.runtime.connector.sink.SinkRuntimeProviderContext;
 import org.apache.flink.test.util.AbstractTestBase;
 import org.apache.flink.types.Row;
 
-import org.junit.After;
 import org.junit.AfterClass;
-import org.junit.Before;
 import org.junit.BeforeClass;
 import org.junit.Test;
 
@@ -67,7 +65,7 @@ import static org.apache.flink.connector.jdbc.internal.JdbcTableOutputFormatTest
 import static org.apache.flink.table.api.Expressions.$;
 import static org.apache.flink.table.factories.utils.FactoryMocks.createTableSink;
 
-/** The ITCase for {@link OracleTableSinkITCase}. */
+/** The Table Sink ITCase for {@link OracleDialect}. */
 public class OracleTableSinkITCase extends AbstractTestBase {
 
     private static final OracleContainer container = new OracleContainer();
@@ -81,18 +79,9 @@ public class OracleTableSinkITCase extends AbstractTestBase {
     public static final String USER_TABLE = "USER_TABLE";
 
     @BeforeClass
-    public static void beforeAll() {
+    public static void beforeAll() throws ClassNotFoundException, SQLException {
         container.start();
         containerUrl = container.getJdbcUrl();
-    }
-
-    @AfterClass
-    public static void afterAll() {
-        container.stop();
-    }
-
-    @Before
-    public void before() throws ClassNotFoundException, SQLException {
         Class.forName(container.getDriverClassName());
         try (Connection conn = DriverManager.getConnection(containerUrl);
                 Statement stat = conn.createStatement()) {
@@ -139,8 +128,8 @@ public class OracleTableSinkITCase extends AbstractTestBase {
         }
     }
 
-    @After
-    public void clearOutputTable() throws Exception {
+    @AfterClass
+    public static void afterAll() throws Exception {
         TestValuesTableFactory.clearAllData();
         Class.forName(container.getDriverClassName());
         try (Connection conn = DriverManager.getConnection(containerUrl);
@@ -152,6 +141,7 @@ public class OracleTableSinkITCase extends AbstractTestBase {
             stat.execute("DROP TABLE " + OUTPUT_TABLE5);
             stat.execute("DROP TABLE " + USER_TABLE);
         }
+        container.stop();
     }
 
     public static DataStream<Tuple4<Integer, Long, String, Timestamp>> get4TupleDataStream(

--- a/flink-connectors/flink-connector-jdbc/src/test/java/org/apache/flink/connector/jdbc/dialect/oracle/OracleTableSinkITCase.java
+++ b/flink-connectors/flink-connector-jdbc/src/test/java/org/apache/flink/connector/jdbc/dialect/oracle/OracleTableSinkITCase.java
@@ -1,0 +1,460 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.flink.connector.jdbc.dialect.oracle;
+
+import org.apache.flink.api.java.tuple.Tuple4;
+import org.apache.flink.configuration.Configuration;
+import org.apache.flink.connector.jdbc.internal.GenericJdbcSinkFunction;
+import org.apache.flink.runtime.state.StateSnapshotContextSynchronousImpl;
+import org.apache.flink.streaming.api.datastream.DataStream;
+import org.apache.flink.streaming.api.environment.StreamExecutionEnvironment;
+import org.apache.flink.streaming.api.functions.sink.SinkContextUtil;
+import org.apache.flink.streaming.api.functions.timestamps.AscendingTimestampExtractor;
+import org.apache.flink.streaming.util.MockStreamingRuntimeContext;
+import org.apache.flink.table.api.DataTypes;
+import org.apache.flink.table.api.EnvironmentSettings;
+import org.apache.flink.table.api.Table;
+import org.apache.flink.table.api.TableEnvironment;
+import org.apache.flink.table.api.TableResult;
+import org.apache.flink.table.api.bridge.java.StreamTableEnvironment;
+import org.apache.flink.table.catalog.Column;
+import org.apache.flink.table.catalog.ResolvedSchema;
+import org.apache.flink.table.connector.sink.DynamicTableSink;
+import org.apache.flink.table.connector.sink.SinkFunctionProvider;
+import org.apache.flink.table.data.GenericRowData;
+import org.apache.flink.table.data.RowData;
+import org.apache.flink.table.planner.factories.TestValuesTableFactory;
+import org.apache.flink.table.planner.runtime.utils.TestData;
+import org.apache.flink.table.runtime.connector.sink.SinkRuntimeProviderContext;
+import org.apache.flink.test.util.AbstractTestBase;
+import org.apache.flink.types.Row;
+
+import org.junit.After;
+import org.junit.AfterClass;
+import org.junit.Before;
+import org.junit.BeforeClass;
+import org.junit.Test;
+
+import java.math.BigDecimal;
+import java.sql.Connection;
+import java.sql.DriverManager;
+import java.sql.SQLException;
+import java.sql.Statement;
+import java.sql.Timestamp;
+import java.util.ArrayList;
+import java.util.Collections;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+
+import static org.apache.flink.connector.jdbc.internal.JdbcTableOutputFormatTest.check;
+import static org.apache.flink.table.api.Expressions.$;
+import static org.apache.flink.table.factories.utils.FactoryMocks.createTableSink;
+
+/** The ITCase for {@link OracleTableSinkITCase}. */
+public class OracleTableSinkITCase extends AbstractTestBase {
+
+    private static final OracleContainer container = new OracleContainer();
+    private static String containerUrl;
+
+    public static final String OUTPUT_TABLE1 = "dynamicSinkForUpsert";
+    public static final String OUTPUT_TABLE2 = "dynamicSinkForAppend";
+    public static final String OUTPUT_TABLE3 = "dynamicSinkForBatch";
+    public static final String OUTPUT_TABLE4 = "REAL_TABLE";
+    public static final String OUTPUT_TABLE5 = "checkpointTable";
+    public static final String USER_TABLE = "USER_TABLE";
+
+    @BeforeClass
+    public static void beforeAll() {
+        container.start();
+        containerUrl = container.getJdbcUrl();
+    }
+
+    @AfterClass
+    public static void afterAll() {
+        container.stop();
+    }
+
+    @Before
+    public void before() throws ClassNotFoundException, SQLException {
+        Class.forName(container.getDriverClassName());
+        try (Connection conn = DriverManager.getConnection(containerUrl);
+                Statement stat = conn.createStatement()) {
+            stat.executeUpdate(
+                    "CREATE TABLE "
+                            + OUTPUT_TABLE1
+                            + " ("
+                            + "cnt NUMBER(38,2) DEFAULT 0 NOT NULL,"
+                            + "lencnt NUMBER(38,2) DEFAULT 0 NOT NULL,"
+                            + "cTag INT DEFAULT 0 NOT NULL,"
+                            + "ts TIMESTAMP,"
+                            + "PRIMARY KEY (cnt, cTag))");
+
+            stat.executeUpdate(
+                    "CREATE TABLE "
+                            + OUTPUT_TABLE2
+                            + " ("
+                            + "id INT DEFAULT 0 NOT NULL,"
+                            + "num NUMBER DEFAULT 0 NOT NULL,"
+                            + "ts TIMESTAMP)");
+
+            stat.executeUpdate(
+                    "CREATE TABLE "
+                            + OUTPUT_TABLE3
+                            + " ("
+                            + "NAME VARCHAR(20) NOT NULL,"
+                            + "SCORE NUMBER DEFAULT 0 NOT NULL)");
+
+            stat.executeUpdate("CREATE TABLE " + OUTPUT_TABLE4 + " (real_data REAL)");
+
+            stat.executeUpdate(
+                    "CREATE TABLE " + OUTPUT_TABLE5 + " (" + "id NUMBER DEFAULT 0 NOT NULL)");
+
+            stat.executeUpdate(
+                    "CREATE TABLE "
+                            + USER_TABLE
+                            + " ("
+                            + "user_id VARCHAR(20) NOT NULL,"
+                            + "user_name VARCHAR(20) NOT NULL,"
+                            + "email VARCHAR(255),"
+                            + "balance DECIMAL(18,2),"
+                            + "balance2 DECIMAL(18,2),"
+                            + "PRIMARY KEY (user_id))");
+        }
+    }
+
+    @After
+    public void clearOutputTable() throws Exception {
+        TestValuesTableFactory.clearAllData();
+        Class.forName(container.getDriverClassName());
+        try (Connection conn = DriverManager.getConnection(containerUrl);
+                Statement stat = conn.createStatement()) {
+            stat.execute("DROP TABLE " + OUTPUT_TABLE1);
+            stat.execute("DROP TABLE " + OUTPUT_TABLE2);
+            stat.execute("DROP TABLE " + OUTPUT_TABLE3);
+            stat.execute("DROP TABLE " + OUTPUT_TABLE4);
+            stat.execute("DROP TABLE " + OUTPUT_TABLE5);
+            stat.execute("DROP TABLE " + USER_TABLE);
+        }
+    }
+
+    public static DataStream<Tuple4<Integer, Long, String, Timestamp>> get4TupleDataStream(
+            StreamExecutionEnvironment env) {
+        List<Tuple4<Integer, Long, String, Timestamp>> data = new ArrayList<>();
+        data.add(new Tuple4<>(1, 1L, "Hi", Timestamp.valueOf("1970-01-01 00:00:00.001")));
+        data.add(new Tuple4<>(2, 2L, "Hello", Timestamp.valueOf("1970-01-01 00:00:00.002")));
+        data.add(new Tuple4<>(3, 2L, "Hello world", Timestamp.valueOf("1970-01-01 00:00:00.003")));
+        data.add(
+                new Tuple4<>(
+                        4,
+                        3L,
+                        "Hello world, how are you?",
+                        Timestamp.valueOf("1970-01-01 00:00:00.004")));
+        data.add(new Tuple4<>(5, 3L, "I am fine.", Timestamp.valueOf("1970-01-01 00:00:00.005")));
+        data.add(
+                new Tuple4<>(
+                        6, 3L, "Luke Skywalker", Timestamp.valueOf("1970-01-01 00:00:00.006")));
+        data.add(new Tuple4<>(7, 4L, "Comment#1", Timestamp.valueOf("1970-01-01 00:00:00.007")));
+        data.add(new Tuple4<>(8, 4L, "Comment#2", Timestamp.valueOf("1970-01-01 00:00:00.008")));
+        data.add(new Tuple4<>(9, 4L, "Comment#3", Timestamp.valueOf("1970-01-01 00:00:00.009")));
+        data.add(new Tuple4<>(10, 4L, "Comment#4", Timestamp.valueOf("1970-01-01 00:00:00.010")));
+        data.add(new Tuple4<>(11, 5L, "Comment#5", Timestamp.valueOf("1970-01-01 00:00:00.011")));
+        data.add(new Tuple4<>(12, 5L, "Comment#6", Timestamp.valueOf("1970-01-01 00:00:00.012")));
+        data.add(new Tuple4<>(13, 5L, "Comment#7", Timestamp.valueOf("1970-01-01 00:00:00.013")));
+        data.add(new Tuple4<>(14, 5L, "Comment#8", Timestamp.valueOf("1970-01-01 00:00:00.014")));
+        data.add(new Tuple4<>(15, 5L, "Comment#9", Timestamp.valueOf("1970-01-01 00:00:00.015")));
+        data.add(new Tuple4<>(16, 6L, "Comment#10", Timestamp.valueOf("1970-01-01 00:00:00.016")));
+        data.add(new Tuple4<>(17, 6L, "Comment#11", Timestamp.valueOf("1970-01-01 00:00:00.017")));
+        data.add(new Tuple4<>(18, 6L, "Comment#12", Timestamp.valueOf("1970-01-01 00:00:00.018")));
+        data.add(new Tuple4<>(19, 6L, "Comment#13", Timestamp.valueOf("1970-01-01 00:00:00.019")));
+        data.add(new Tuple4<>(20, 6L, "Comment#14", Timestamp.valueOf("1970-01-01 00:00:00.020")));
+        data.add(new Tuple4<>(21, 6L, "Comment#15", Timestamp.valueOf("1970-01-01 00:00:00.021")));
+
+        Collections.shuffle(data);
+        return env.fromCollection(data);
+    }
+
+    @Test
+    public void testReal() throws Exception {
+        StreamExecutionEnvironment env = StreamExecutionEnvironment.getExecutionEnvironment();
+        env.getConfig().enableObjectReuse();
+        StreamTableEnvironment tEnv =
+                StreamTableEnvironment.create(env, EnvironmentSettings.inStreamingMode());
+
+        tEnv.executeSql(
+                "CREATE TABLE upsertSink ("
+                        + "  real_data float"
+                        + ") WITH ("
+                        + "  'connector'='jdbc',"
+                        + "  'url'='"
+                        + containerUrl
+                        + "',"
+                        + "  'table-name'='"
+                        + OUTPUT_TABLE4
+                        + "'"
+                        + ")");
+
+        tEnv.executeSql("INSERT INTO upsertSink SELECT CAST(1.1 as FLOAT)").await();
+        check(new Row[] {Row.of(1.1f)}, containerUrl, "REAL_TABLE", new String[] {"real_data"});
+    }
+
+    @Test
+    public void testUpsert() throws Exception {
+        StreamExecutionEnvironment env = StreamExecutionEnvironment.getExecutionEnvironment();
+        env.getConfig().enableObjectReuse();
+        StreamTableEnvironment tEnv = StreamTableEnvironment.create(env);
+
+        Table t =
+                tEnv.fromDataStream(
+                        get4TupleDataStream(env)
+                                .assignTimestampsAndWatermarks(
+                                        new AscendingTimestampExtractor<
+                                                Tuple4<Integer, Long, String, Timestamp>>() {
+                                            @Override
+                                            public long extractAscendingTimestamp(
+                                                    Tuple4<Integer, Long, String, Timestamp>
+                                                            element) {
+                                                return element.f0;
+                                            }
+                                        }),
+                        $("id"),
+                        $("num"),
+                        $("text"),
+                        $("ts"));
+
+        tEnv.createTemporaryView("T", t);
+        tEnv.executeSql(
+                "CREATE TABLE upsertSink ("
+                        + "  cnt DECIMAL(18,2),"
+                        + "  lencnt DECIMAL(18,2),"
+                        + "  cTag INT,"
+                        + "  ts TIMESTAMP(3),"
+                        + "  PRIMARY KEY (cnt, cTag) NOT ENFORCED"
+                        + ") WITH ("
+                        + "  'connector'='jdbc',"
+                        + "  'url'='"
+                        + containerUrl
+                        + "',"
+                        + "  'table-name'='"
+                        + OUTPUT_TABLE1
+                        + "',"
+                        + "  'sink.buffer-flush.max-rows' = '2',"
+                        + "  'sink.buffer-flush.interval' = '0',"
+                        + "  'sink.max-retries' = '0'"
+                        + ")");
+
+        tEnv.executeSql(
+                        "INSERT INTO upsertSink \n"
+                                + "SELECT cnt, COUNT(len) AS lencnt, cTag, MAX(ts) AS ts\n"
+                                + "FROM (\n"
+                                + "  SELECT len, COUNT(id) as cnt, cTag, MAX(ts) AS ts\n"
+                                + "  FROM (SELECT id, CHAR_LENGTH(text) AS len, (CASE WHEN id > 0 THEN 1 ELSE 0 END) cTag, ts FROM T)\n"
+                                + "  GROUP BY len, cTag\n"
+                                + ")\n"
+                                + "GROUP BY cnt, cTag")
+                .await();
+        check(
+                new Row[] {
+                    Row.of(1, 5, 1, Timestamp.valueOf("1970-01-01 00:00:00.006")),
+                    Row.of(7, 1, 1, Timestamp.valueOf("1970-01-01 00:00:00.021")),
+                    Row.of(9, 1, 1, Timestamp.valueOf("1970-01-01 00:00:00.015"))
+                },
+                containerUrl,
+                OUTPUT_TABLE1,
+                new String[] {"cnt", "lencnt", "cTag", "ts"});
+    }
+
+    @Test
+    public void testAppend() throws Exception {
+        StreamExecutionEnvironment env = StreamExecutionEnvironment.getExecutionEnvironment();
+        env.getConfig().enableObjectReuse();
+        env.getConfig().setParallelism(1);
+        StreamTableEnvironment tEnv = StreamTableEnvironment.create(env);
+
+        Table t =
+                tEnv.fromDataStream(
+                        get4TupleDataStream(env), $("id"), $("num"), $("text"), $("ts"));
+
+        tEnv.registerTable("T", t);
+
+        tEnv.executeSql(
+                "CREATE TABLE upsertSink ("
+                        + "  id INT,"
+                        + "  num BIGINT,"
+                        + "  ts TIMESTAMP(3)"
+                        + ") WITH ("
+                        + "  'connector'='jdbc',"
+                        + "  'url'='"
+                        + containerUrl
+                        + "',"
+                        + "  'table-name'='"
+                        + OUTPUT_TABLE2
+                        + "'"
+                        + ")");
+
+        tEnv.executeSql("INSERT INTO upsertSink SELECT id, num, ts FROM T WHERE id IN (2, 10, 20)")
+                .await();
+        check(
+                new Row[] {
+                    Row.of(2, 2, Timestamp.valueOf("1970-01-01 00:00:00.002")),
+                    Row.of(10, 4, Timestamp.valueOf("1970-01-01 00:00:00.01")),
+                    Row.of(20, 6, Timestamp.valueOf("1970-01-01 00:00:00.02"))
+                },
+                containerUrl,
+                OUTPUT_TABLE2,
+                new String[] {"id", "num", "ts"});
+    }
+
+    @Test
+    public void testBatchSink() throws Exception {
+        TableEnvironment tEnv = TableEnvironment.create(EnvironmentSettings.inBatchMode());
+
+        tEnv.executeSql(
+                "CREATE TABLE USER_RESULT("
+                        + "NAME VARCHAR,"
+                        + "SCORE BIGINT"
+                        + ") WITH ( "
+                        + "'connector' = 'jdbc',"
+                        + "'url'='"
+                        + containerUrl
+                        + "',"
+                        + "'table-name' = '"
+                        + OUTPUT_TABLE3
+                        + "',"
+                        + "'sink.buffer-flush.max-rows' = '2',"
+                        + "'sink.buffer-flush.interval' = '300ms',"
+                        + "'sink.max-retries' = '4'"
+                        + ")");
+
+        TableResult tableResult =
+                tEnv.executeSql(
+                        "INSERT INTO USER_RESULT\n"
+                                + "SELECT user_name, score "
+                                + "FROM (VALUES (1, 'Bob'), (22, 'Tom'), (42, 'Kim'), "
+                                + "(42, 'Kim'), (1, 'Bob')) "
+                                + "AS UserCountTable(score, user_name)");
+        tableResult.await();
+
+        check(
+                new Row[] {
+                    Row.of("Bob", 1),
+                    Row.of("Tom", 22),
+                    Row.of("Kim", 42),
+                    Row.of("Kim", 42),
+                    Row.of("Bob", 1)
+                },
+                containerUrl,
+                OUTPUT_TABLE3,
+                new String[] {"NAME", "SCORE"});
+    }
+
+    @Test
+    public void testReadingFromChangelogSource() throws Exception {
+        TableEnvironment tEnv = TableEnvironment.create(EnvironmentSettings.newInstance().build());
+        String dataId = TestValuesTableFactory.registerData(TestData.userChangelog());
+        tEnv.executeSql(
+                "CREATE TABLE user_logs (\n"
+                        + "  user_id STRING,\n"
+                        + "  user_name STRING,\n"
+                        + "  email STRING,\n"
+                        + "  balance DECIMAL(18,2),\n"
+                        + "  balance2 AS balance * 2\n"
+                        + ") WITH (\n"
+                        + " 'connector' = 'values',\n"
+                        + " 'data-id' = '"
+                        + dataId
+                        + "',\n"
+                        + " 'changelog-mode' = 'I,UA,UB,D'\n"
+                        + ")");
+        tEnv.executeSql(
+                "CREATE TABLE user_sink (\n"
+                        + "  user_id STRING PRIMARY KEY NOT ENFORCED,\n"
+                        + "  user_name STRING,\n"
+                        + "  email STRING,\n"
+                        + "  balance DECIMAL(18,2),\n"
+                        + "  balance2 DECIMAL(18,2)\n"
+                        + ") WITH (\n"
+                        + "  'connector' = 'jdbc',"
+                        + "  'url'='"
+                        + containerUrl
+                        + "',"
+                        + "  'table-name' = '"
+                        + USER_TABLE
+                        + "',"
+                        + "  'sink.buffer-flush.max-rows' = '2',"
+                        + "  'sink.buffer-flush.interval' = '0'"
+                        + // disable async flush
+                        ")");
+        tEnv.executeSql("INSERT INTO user_sink SELECT * FROM user_logs").await();
+
+        check(
+                new Row[] {
+                    Row.of(
+                            "user1",
+                            "Tom",
+                            "tom123@gmail.com",
+                            new BigDecimal("8.1"),
+                            new BigDecimal("16.2")),
+                    Row.of(
+                            "user3",
+                            "Bailey",
+                            "bailey@qq.com",
+                            new BigDecimal("9.99"),
+                            new BigDecimal("19.98")),
+                    Row.of(
+                            "user4",
+                            "Tina",
+                            "tina@gmail.com",
+                            new BigDecimal("11.3"),
+                            new BigDecimal("22.6"))
+                },
+                containerUrl,
+                USER_TABLE,
+                new String[] {"user_id", "user_name", "email", "balance", "balance2"});
+    }
+
+    @Test
+    public void testFlushBufferWhenCheckpoint() throws Exception {
+        Map<String, String> options = new HashMap<>();
+        options.put("connector", "jdbc");
+        options.put("url", containerUrl);
+        options.put("table-name", OUTPUT_TABLE5);
+        options.put("sink.buffer-flush.interval", "0");
+
+        ResolvedSchema schema =
+                ResolvedSchema.of(Column.physical("id", DataTypes.BIGINT().notNull()));
+
+        DynamicTableSink tableSink = createTableSink(schema, options);
+
+        SinkRuntimeProviderContext context = new SinkRuntimeProviderContext(false);
+        SinkFunctionProvider sinkProvider =
+                (SinkFunctionProvider) tableSink.getSinkRuntimeProvider(context);
+        GenericJdbcSinkFunction<RowData> sinkFunction =
+                (GenericJdbcSinkFunction<RowData>) sinkProvider.createSinkFunction();
+        sinkFunction.setRuntimeContext(new MockStreamingRuntimeContext(true, 1, 0));
+        sinkFunction.open(new Configuration());
+        sinkFunction.invoke(GenericRowData.of(1L), SinkContextUtil.forTimestamp(1));
+        sinkFunction.invoke(GenericRowData.of(2L), SinkContextUtil.forTimestamp(1));
+
+        check(new Row[] {}, containerUrl, OUTPUT_TABLE5, new String[] {"id"});
+        sinkFunction.snapshotState(new StateSnapshotContextSynchronousImpl(1, 1));
+        check(new Row[] {Row.of(1L), Row.of(2L)}, containerUrl, OUTPUT_TABLE5, new String[] {"id"});
+        sinkFunction.close();
+    }
+}

--- a/flink-connectors/flink-connector-jdbc/src/test/java/org/apache/flink/connector/jdbc/dialect/oracle/OracleTableSourceITCase.java
+++ b/flink-connectors/flink-connector-jdbc/src/test/java/org/apache/flink/connector/jdbc/dialect/oracle/OracleTableSourceITCase.java
@@ -16,13 +16,11 @@
  * limitations under the License.
  */
 
-package org.apache.flink.connector.jdbc.table;
+package org.apache.flink.connector.jdbc.dialect.oracle;
 
-import org.apache.flink.connector.jdbc.JdbcTestBase;
 import org.apache.flink.streaming.api.environment.StreamExecutionEnvironment;
 import org.apache.flink.table.api.TableEnvironment;
 import org.apache.flink.table.api.bridge.java.StreamTableEnvironment;
-import org.apache.flink.table.planner.runtime.utils.StreamTestSink;
 import org.apache.flink.test.util.AbstractTestBase;
 import org.apache.flink.types.Row;
 import org.apache.flink.util.CollectionUtil;
@@ -46,61 +44,56 @@ import java.util.stream.Stream;
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertTrue;
 
-/** ITCase for {@link JdbcDynamicTableSource}. */
-public class JdbcDynamicTableSourceITCase extends AbstractTestBase {
+/** The Table Source ITCase for {@link OracleDialect}. */
+public class OracleTableSourceITCase extends AbstractTestBase {
 
-    public static final String DRIVER_CLASS = "org.apache.derby.jdbc.EmbeddedDriver";
-    public static final String DB_URL = "jdbc:derby:memory:test";
-    public static final String INPUT_TABLE = "jdbDynamicTableSource";
+    private static final OracleContainer container = new OracleContainer();
+    private static String containerUrl;
+    private static final String INPUT_TABLE = "oracle_test_table";
 
-    public static StreamExecutionEnvironment env;
-    public static TableEnvironment tEnv;
+    private static StreamExecutionEnvironment env;
+    private static TableEnvironment tEnv;
 
     @BeforeClass
     public static void beforeAll() throws ClassNotFoundException, SQLException {
-        System.setProperty(
-                "derby.stream.error.field", JdbcTestBase.class.getCanonicalName() + ".DEV_NULL");
-        Class.forName(DRIVER_CLASS);
-
-        try (Connection conn = DriverManager.getConnection(DB_URL + ";create=true");
+        container.start();
+        containerUrl = container.getJdbcUrl();
+        Class.forName(container.getDriverClassName());
+        try (Connection conn = DriverManager.getConnection(containerUrl);
                 Statement statement = conn.createStatement()) {
             statement.executeUpdate(
                     "CREATE TABLE "
                             + INPUT_TABLE
                             + " ("
-                            + "id BIGINT NOT NULL,"
-                            + "timestamp6_col TIMESTAMP, "
-                            + "timestamp9_col TIMESTAMP, "
-                            + "time_col TIME, "
-                            + "real_col FLOAT(23), "
-                            + // A precision of 23 or less makes FLOAT equivalent to REAL.
-                            "double_col FLOAT(24),"
-                            + // A precision of 24 or greater makes FLOAT equivalent to DOUBLE
-                            // PRECISION.
-                            "decimal_col DECIMAL(10, 4))");
+                            + "id NUMBER(20, 0) NOT NULL,"
+                            + "timestamp6_col TIMESTAMP(6), "
+                            + "timestamp9_col TIMESTAMP(9), "
+                            + "float_col FLOAT(126), "
+                            + "double_col DOUBLE PRECISION ,"
+                            + "decimal_col NUMBER(10, 4))");
             statement.executeUpdate(
                     "INSERT INTO "
                             + INPUT_TABLE
                             + " VALUES ("
-                            + "1, TIMESTAMP('2020-01-01 15:35:00.123456'), TIMESTAMP('2020-01-01 15:35:00.123456789'), "
-                            + "TIME('15:35:00'), 1.175E-37, 1.79769E+308, 100.1234)");
+                            + "1, TIMESTAMP '2020-01-01 15:35:00.123456', TIMESTAMP '2020-01-01 15:35:00.123456789', "
+                            + "1.175E-10, 1.79769E+40, 100.1234)");
             statement.executeUpdate(
                     "INSERT INTO "
                             + INPUT_TABLE
                             + " VALUES ("
-                            + "2, TIMESTAMP('2020-01-01 15:36:01.123456'), TIMESTAMP('2020-01-01 15:36:01.123456789'), "
-                            + "TIME('15:36:01'), -1.175E-37, -1.79769E+308, 101.1234)");
+                            + "2, TIMESTAMP '2020-01-01 15:36:01.123456', TIMESTAMP '2020-01-01 15:36:01.123456789', "
+                            + "-1.175E-10, -1.79769E+40, 101.1234)");
         }
     }
 
     @AfterClass
     public static void afterAll() throws Exception {
-        Class.forName(DRIVER_CLASS);
-        try (Connection conn = DriverManager.getConnection(DB_URL);
-                Statement stat = conn.createStatement()) {
-            stat.executeUpdate("DROP TABLE " + INPUT_TABLE);
+        Class.forName(container.getDriverClassName());
+        try (Connection conn = DriverManager.getConnection(containerUrl);
+                Statement statement = conn.createStatement()) {
+            statement.executeUpdate("DROP TABLE " + INPUT_TABLE);
         }
-        StreamTestSink.clear();
+        container.stop();
     }
 
     @Before
@@ -118,14 +111,13 @@ public class JdbcDynamicTableSourceITCase extends AbstractTestBase {
                         + "id BIGINT,"
                         + "timestamp6_col TIMESTAMP(6),"
                         + "timestamp9_col TIMESTAMP(9),"
-                        + "time_col TIME,"
-                        + "real_col FLOAT,"
+                        + "float_col FLOAT,"
                         + "double_col DOUBLE,"
                         + "decimal_col DECIMAL(10, 4)"
                         + ") WITH ("
                         + "  'connector'='jdbc',"
                         + "  'url'='"
-                        + DB_URL
+                        + containerUrl
                         + "',"
                         + "  'table-name'='"
                         + INPUT_TABLE
@@ -140,8 +132,8 @@ public class JdbcDynamicTableSourceITCase extends AbstractTestBase {
                         .collect(Collectors.toList());
         List<String> expected =
                 Stream.of(
-                                "+I[1, 2020-01-01T15:35:00.123456, 2020-01-01T15:35:00.123456789, 15:35, 1.175E-37, 1.79769E308, 100.1234]",
-                                "+I[2, 2020-01-01T15:36:01.123456, 2020-01-01T15:36:01.123456789, 15:36:01, -1.175E-37, -1.79769E308, 101.1234]")
+                                "+I[1, 2020-01-01T15:35:00.123456, 2020-01-01T15:35:00.123456789, 1.175E-10, 1.79769E40, 100.1234]",
+                                "+I[2, 2020-01-01T15:36:01.123456, 2020-01-01T15:36:01.123456789, -1.175E-10, -1.79769E40, 101.1234]")
                         .sorted()
                         .collect(Collectors.toList());
         assertEquals(expected, result);
@@ -156,14 +148,13 @@ public class JdbcDynamicTableSourceITCase extends AbstractTestBase {
                         + "id BIGINT,"
                         + "timestamp6_col TIMESTAMP(6),"
                         + "timestamp9_col TIMESTAMP(9),"
-                        + "time_col TIME,"
-                        + "real_col FLOAT,"
+                        + "float_col FLOAT,"
                         + "double_col DOUBLE,"
                         + "decimal_col DECIMAL(10, 4)"
                         + ") WITH ("
                         + "  'connector'='jdbc',"
                         + "  'url'='"
-                        + DB_URL
+                        + containerUrl
                         + "',"
                         + "  'table-name'='"
                         + INPUT_TABLE
@@ -200,14 +191,13 @@ public class JdbcDynamicTableSourceITCase extends AbstractTestBase {
                         + "id BIGINT,\n"
                         + "timestamp6_col TIMESTAMP(6),\n"
                         + "timestamp9_col TIMESTAMP(9),\n"
-                        + "time_col TIME,\n"
-                        + "real_col FLOAT,\n"
+                        + "float_col FLOAT,\n"
                         + "double_col DOUBLE,\n"
                         + "decimal_col DECIMAL(10, 4)\n"
                         + ") WITH (\n"
                         + "  'connector'='jdbc',\n"
                         + "  'url'='"
-                        + DB_URL
+                        + containerUrl
                         + "',\n"
                         + "  'table-name'='"
                         + INPUT_TABLE
@@ -228,9 +218,9 @@ public class JdbcDynamicTableSourceITCase extends AbstractTestBase {
 
         Set<String> expected = new HashSet<>();
         expected.add(
-                "+I[1, 2020-01-01T15:35:00.123456, 2020-01-01T15:35:00.123456789, 15:35, 1.175E-37, 1.79769E308, 100.1234]");
+                "+I[1, 2020-01-01T15:35:00.123456, 2020-01-01T15:35:00.123456789, 1.175E-10, 1.79769E40, 100.1234]");
         expected.add(
-                "+I[2, 2020-01-01T15:36:01.123456, 2020-01-01T15:36:01.123456789, 15:36:01, -1.175E-37, -1.79769E308, 101.1234]");
+                "+I[2, 2020-01-01T15:36:01.123456, 2020-01-01T15:36:01.123456789, -1.175E-10, -1.79769E40, 101.1234]");
         assertEquals(1, result.size());
         assertTrue(
                 "The actual output is not a subset of the expected set.",

--- a/flink-connectors/flink-connector-jdbc/src/test/java/org/apache/flink/connector/jdbc/dialect/oracle/OracleTableSourceITCase.java
+++ b/flink-connectors/flink-connector-jdbc/src/test/java/org/apache/flink/connector/jdbc/dialect/oracle/OracleTableSourceITCase.java
@@ -66,7 +66,7 @@ public class OracleTableSourceITCase extends AbstractTestBase {
                             + INPUT_TABLE
                             + " ("
                             + "id INTEGER NOT NULL,"
-                            + "float_col FLOAT(126),"
+                            + "float_col FLOAT,"
                             + "double_col DOUBLE PRECISION ,"
                             + "decimal_col NUMBER(10, 4) NOT NULL,"
                             + "binary_float_col BINARY_FLOAT NOT NULL,"
@@ -84,14 +84,14 @@ public class OracleTableSourceITCase extends AbstractTestBase {
                     "INSERT INTO "
                             + INPUT_TABLE
                             + " VALUES ("
-                            + "1, 1.175E-10, 1.79769E+40, 100.1234, 1.175E-10, 1.79769E+40, 'a', 'abc', 'abcdef', "
+                            + "1, 1.12345, 2.12345678790, 100.1234, 1.175E-10, 1.79769E+40, 'a', 'abc', 'abcdef', "
                             + "TO_DATE('1997-01-01','yyyy-mm-dd'),TIMESTAMP '2020-01-01 15:35:00.123456',"
                             + " TIMESTAMP '2020-01-01 15:35:00.123456789', 'Hello World', hextoraw('453d7a34'))");
             statement.executeUpdate(
                     "INSERT INTO "
                             + INPUT_TABLE
                             + " VALUES ("
-                            + "2, -1.175E-10, -1.79769E+40, 101.1234, -1.175E-10, -1.79769E+40, 'a', 'abc', 'abcdef', "
+                            + "2, 1.12345, 2.12345678790, 101.1234, -1.175E-10, -1.79769E+40, 'a', 'abc', 'abcdef', "
                             + "TO_DATE('1997-01-02','yyyy-mm-dd'),  TIMESTAMP '2020-01-01 15:36:01.123456', "
                             + "TIMESTAMP '2020-01-01 15:36:01.123456789', 'Hey Leonard', hextoraw('453d7a34'))");
         }
@@ -120,8 +120,8 @@ public class OracleTableSourceITCase extends AbstractTestBase {
                         + INPUT_TABLE
                         + "("
                         + "id BIGINT,"
-                        + "float_col FLOAT,"
-                        + "double_col DOUBLE,"
+                        + "float_col DECIMAL(6, 5),"
+                        + "double_col DECIMAL(11, 10),"
                         + "decimal_col DECIMAL(10, 4),"
                         + "binary_float_col FLOAT,"
                         + "binary_double_col DOUBLE,"
@@ -151,8 +151,8 @@ public class OracleTableSourceITCase extends AbstractTestBase {
                         .collect(Collectors.toList());
         List<String> expected =
                 Stream.of(
-                                "+I[1, 1.175E-10, 1.79769E40, 100.1234, 1.175E-10, 1.79769E40, a, abc, abcdef, 1997-01-01, 2020-01-01T15:35:00.123456, 2020-01-01T15:35:00.123456789, Hello World, [69, 61, 122, 52]]",
-                                "+I[2, -1.175E-10, -1.79769E40, 101.1234, -1.175E-10, -1.79769E40, a, abc, abcdef, 1997-01-02, 2020-01-01T15:36:01.123456, 2020-01-01T15:36:01.123456789, Hey Leonard, [69, 61, 122, 52]]")
+                                "+I[1, 1.12345, 2.1234567879, 100.1234, 1.175E-10, 1.79769E40, a, abc, abcdef, 1997-01-01, 2020-01-01T15:35:00.123456, 2020-01-01T15:35:00.123456789, Hello World, [69, 61, 122, 52]]",
+                                "+I[2, 1.12345, 2.1234567879, 101.1234, -1.175E-10, -1.79769E40, a, abc, abcdef, 1997-01-02, 2020-01-01T15:36:01.123456, 2020-01-01T15:36:01.123456789, Hey Leonard, [69, 61, 122, 52]]")
                         .sorted()
                         .collect(Collectors.toList());
         assertEquals(expected, result);
@@ -167,8 +167,8 @@ public class OracleTableSourceITCase extends AbstractTestBase {
                         + "id BIGINT,"
                         + "timestamp6_col TIMESTAMP(6),"
                         + "timestamp9_col TIMESTAMP(9),"
-                        + "float_col FLOAT,"
-                        + "double_col DOUBLE,"
+                        + "binary_float_col FLOAT,"
+                        + "binary_double_col DOUBLE,"
                         + "decimal_col DECIMAL(10, 4)"
                         + ") WITH ("
                         + "  'connector'='jdbc',"
@@ -210,8 +210,8 @@ public class OracleTableSourceITCase extends AbstractTestBase {
                         + "id BIGINT,\n"
                         + "timestamp6_col TIMESTAMP(6),\n"
                         + "timestamp9_col TIMESTAMP(9),\n"
-                        + "float_col FLOAT,\n"
-                        + "double_col DOUBLE,\n"
+                        + "binary_float_col FLOAT,\n"
+                        + "binary_double_col DOUBLE,\n"
                         + "decimal_col DECIMAL(10, 4)\n"
                         + ") WITH (\n"
                         + "  'connector'='jdbc',\n"

--- a/flink-connectors/flink-connector-jdbc/src/test/java/org/apache/flink/connector/jdbc/dialect/oracle/OracleTableSourceITCase.java
+++ b/flink-connectors/flink-connector-jdbc/src/test/java/org/apache/flink/connector/jdbc/dialect/oracle/OracleTableSourceITCase.java
@@ -65,24 +65,35 @@ public class OracleTableSourceITCase extends AbstractTestBase {
                     "CREATE TABLE "
                             + INPUT_TABLE
                             + " ("
-                            + "id NUMBER(20, 0) NOT NULL,"
-                            + "timestamp6_col TIMESTAMP(6), "
-                            + "timestamp9_col TIMESTAMP(9), "
-                            + "float_col FLOAT(126), "
+                            + "id INTEGER NOT NULL,"
+                            + "float_col FLOAT(126),"
                             + "double_col DOUBLE PRECISION ,"
-                            + "decimal_col NUMBER(10, 4))");
+                            + "decimal_col NUMBER(10, 4) NOT NULL,"
+                            + "binary_float_col BINARY_FLOAT NOT NULL,"
+                            + "binary_double_col BINARY_DOUBLE NOT NULL,"
+                            + "char_col CHAR NOT NULL,"
+                            + "nchar_col NCHAR(3) NOT NULL,"
+                            + "varchar2_col VARCHAR2(30) NOT NULL,"
+                            + "date_col DATE NOT NULL,"
+                            + "timestamp6_col TIMESTAMP(6),"
+                            + "timestamp9_col TIMESTAMP(9),"
+                            + "clob_col CLOB,"
+                            + "blob_col BLOB"
+                            + ")");
             statement.executeUpdate(
                     "INSERT INTO "
                             + INPUT_TABLE
                             + " VALUES ("
-                            + "1, TIMESTAMP '2020-01-01 15:35:00.123456', TIMESTAMP '2020-01-01 15:35:00.123456789', "
-                            + "1.175E-10, 1.79769E+40, 100.1234)");
+                            + "1, 1.175E-10, 1.79769E+40, 100.1234, 1.175E-10, 1.79769E+40, 'a', 'abc', 'abcdef', "
+                            + "TO_DATE('1997-01-01','yyyy-mm-dd'),TIMESTAMP '2020-01-01 15:35:00.123456',"
+                            + " TIMESTAMP '2020-01-01 15:35:00.123456789', 'Hello World', hextoraw('453d7a34'))");
             statement.executeUpdate(
                     "INSERT INTO "
                             + INPUT_TABLE
                             + " VALUES ("
-                            + "2, TIMESTAMP '2020-01-01 15:36:01.123456', TIMESTAMP '2020-01-01 15:36:01.123456789', "
-                            + "-1.175E-10, -1.79769E+40, 101.1234)");
+                            + "2, -1.175E-10, -1.79769E+40, 101.1234, -1.175E-10, -1.79769E+40, 'a', 'abc', 'abcdef', "
+                            + "TO_DATE('1997-01-02','yyyy-mm-dd'),  TIMESTAMP '2020-01-01 15:36:01.123456', "
+                            + "TIMESTAMP '2020-01-01 15:36:01.123456789', 'Hey Leonard', hextoraw('453d7a34'))");
         }
     }
 
@@ -109,11 +120,19 @@ public class OracleTableSourceITCase extends AbstractTestBase {
                         + INPUT_TABLE
                         + "("
                         + "id BIGINT,"
-                        + "timestamp6_col TIMESTAMP(6),"
-                        + "timestamp9_col TIMESTAMP(9),"
                         + "float_col FLOAT,"
                         + "double_col DOUBLE,"
-                        + "decimal_col DECIMAL(10, 4)"
+                        + "decimal_col DECIMAL(10, 4),"
+                        + "binary_float_col FLOAT,"
+                        + "binary_double_col DOUBLE,"
+                        + "char_col CHAR(1),"
+                        + "nchar_col VARCHAR(3),"
+                        + "varchar2_col VARCHAR(30),"
+                        + "date_col DATE,"
+                        + "timestamp6_col TIMESTAMP(6),"
+                        + "timestamp9_col TIMESTAMP(9),"
+                        + "clob_col STRING,"
+                        + "blob_col BYTES"
                         + ") WITH ("
                         + "  'connector'='jdbc',"
                         + "  'url'='"
@@ -132,8 +151,8 @@ public class OracleTableSourceITCase extends AbstractTestBase {
                         .collect(Collectors.toList());
         List<String> expected =
                 Stream.of(
-                                "+I[1, 2020-01-01T15:35:00.123456, 2020-01-01T15:35:00.123456789, 1.175E-10, 1.79769E40, 100.1234]",
-                                "+I[2, 2020-01-01T15:36:01.123456, 2020-01-01T15:36:01.123456789, -1.175E-10, -1.79769E40, 101.1234]")
+                                "+I[1, 1.175E-10, 1.79769E40, 100.1234, 1.175E-10, 1.79769E40, a, abc, abcdef, 1997-01-01, 2020-01-01T15:35:00.123456, 2020-01-01T15:35:00.123456789, Hello World, [69, 61, 122, 52]]",
+                                "+I[2, -1.175E-10, -1.79769E40, 101.1234, -1.175E-10, -1.79769E40, a, abc, abcdef, 1997-01-02, 2020-01-01T15:36:01.123456, 2020-01-01T15:36:01.123456789, Hey Leonard, [69, 61, 122, 52]]")
                         .sorted()
                         .collect(Collectors.toList());
         assertEquals(expected, result);

--- a/flink-connectors/flink-connector-jdbc/src/test/java/org/apache/flink/connector/jdbc/table/JdbcDynamicTableSinkITCase.java
+++ b/flink-connectors/flink-connector-jdbc/src/test/java/org/apache/flink/connector/jdbc/table/JdbcDynamicTableSinkITCase.java
@@ -46,8 +46,8 @@ import org.apache.flink.table.runtime.connector.sink.SinkRuntimeProviderContext;
 import org.apache.flink.test.util.AbstractTestBase;
 import org.apache.flink.types.Row;
 
-import org.junit.After;
-import org.junit.Before;
+import org.junit.AfterClass;
+import org.junit.BeforeClass;
 import org.junit.Test;
 
 import java.math.BigDecimal;
@@ -78,8 +78,8 @@ public class JdbcDynamicTableSinkITCase extends AbstractTestBase {
     public static final String OUTPUT_TABLE5 = "checkpointTable";
     public static final String USER_TABLE = "USER_TABLE";
 
-    @Before
-    public void before() throws ClassNotFoundException, SQLException {
+    @BeforeClass
+    public static void beforeAll() throws ClassNotFoundException, SQLException {
         System.setProperty(
                 "derby.stream.error.field", JdbcTestFixture.class.getCanonicalName() + ".DEV_NULL");
 
@@ -129,8 +129,8 @@ public class JdbcDynamicTableSinkITCase extends AbstractTestBase {
         }
     }
 
-    @After
-    public void clearOutputTable() throws Exception {
+    @AfterClass
+    public static void afterAll() throws Exception {
         TestValuesTableFactory.clearAllData();
         Class.forName(DERBY_EBOOKSHOP_DB.getDriverClass());
         try (Connection conn = DriverManager.getConnection(DB_URL);

--- a/flink-connectors/flink-connector-jdbc/src/test/java/org/apache/flink/connector/jdbc/xa/JdbcExactlyOnceSinkE2eTest.java
+++ b/flink-connectors/flink-connector-jdbc/src/test/java/org/apache/flink/connector/jdbc/xa/JdbcExactlyOnceSinkE2eTest.java
@@ -29,6 +29,7 @@ import org.apache.flink.connector.jdbc.JdbcITCase;
 import org.apache.flink.connector.jdbc.JdbcSink;
 import org.apache.flink.connector.jdbc.JdbcTestBase;
 import org.apache.flink.connector.jdbc.JdbcTestFixture.TestEntry;
+import org.apache.flink.connector.jdbc.dialect.oracle.OracleContainer;
 import org.apache.flink.runtime.state.CheckpointListener;
 import org.apache.flink.runtime.state.FunctionInitializationContext;
 import org.apache.flink.runtime.state.FunctionSnapshotContext;
@@ -58,7 +59,6 @@ import org.slf4j.LoggerFactory;
 import org.testcontainers.containers.JdbcDatabaseContainer;
 import org.testcontainers.containers.MySQLContainer;
 import org.testcontainers.containers.PostgreSQLContainer;
-import org.testcontainers.utility.DockerImageName;
 
 import javax.sql.XADataSource;
 
@@ -840,83 +840,6 @@ public class JdbcExactlyOnceSinkE2eTest extends JdbcTestBase {
         @Override
         public String toString() {
             return db + ", parallelism=" + parallelism;
-        }
-
-        /** {@link OracleContainer}. */
-        private static final class OracleContainer extends JdbcDatabaseContainer<OracleContainer> {
-            private static final String DEFAULT_TAG = "18.4.0-slim";
-            private static final String IMAGE = "gvenzl/oracle-xe";
-            private static final DockerImageName ORACLE_IMAGE =
-                    DockerImageName.parse(IMAGE).withTag(DEFAULT_TAG);
-
-            private static final int ORACLE_PORT = 1521;
-            private static final int APEX_HTTP_PORT = 8080;
-
-            private static final int DEFAULT_STARTUP_TIMEOUT_SECONDS = 240;
-            private static final int DEFAULT_CONNECT_TIMEOUT_SECONDS = 120;
-
-            private String username = "system";
-            private String password = "oracle";
-
-            public OracleContainer() {
-                super(ORACLE_IMAGE);
-                preconfigure();
-            }
-
-            private void preconfigure() {
-                withStartupTimeoutSeconds(DEFAULT_STARTUP_TIMEOUT_SECONDS);
-                withConnectTimeoutSeconds(DEFAULT_CONNECT_TIMEOUT_SECONDS);
-                withEnv("ORACLE_PASSWORD", password);
-                addExposedPorts(ORACLE_PORT, APEX_HTTP_PORT);
-            }
-
-            @Override
-            public String getDriverClassName() {
-                return "oracle.jdbc.OracleDriver";
-            }
-
-            @Override
-            public String getJdbcUrl() {
-                return "jdbc:oracle:thin:"
-                        + getUsername()
-                        + "/"
-                        + getPassword()
-                        + "@"
-                        + getHost()
-                        + ":"
-                        + getOraclePort()
-                        + ":"
-                        + getSid();
-            }
-
-            @Override
-            public String getUsername() {
-                return username;
-            }
-
-            @Override
-            public String getPassword() {
-                return password;
-            }
-
-            @SuppressWarnings("SameReturnValue")
-            public String getSid() {
-                return "xe";
-            }
-
-            public Integer getOraclePort() {
-                return getMappedPort(ORACLE_PORT);
-            }
-
-            @SuppressWarnings("unused")
-            public Integer getWebPort() {
-                return getMappedPort(APEX_HTTP_PORT);
-            }
-
-            @Override
-            public String getTestQueryString() {
-                return "SELECT 1 FROM DUAL";
-            }
         }
 
         private static class OracleXaDataSourceFactory

--- a/flink-connectors/flink-connector-jdbc/src/test/java/org/apache/flink/connector/jdbc/xa/JdbcExactlyOnceSinkE2eTest.java
+++ b/flink-connectors/flink-connector-jdbc/src/test/java/org/apache/flink/connector/jdbc/xa/JdbcExactlyOnceSinkE2eTest.java
@@ -142,10 +142,9 @@ public class JdbcExactlyOnceSinkE2eTest extends JdbcTestBase {
         return Arrays.asList(
                 // PGSQL: check for issues with suspending connections (requires pooling) and
                 // honoring limits (properly closing connections).
-                // new PgSqlJdbcExactlyOnceSinkTestEnv(4)
-                //            ,
+                new PgSqlJdbcExactlyOnceSinkTestEnv(4),
                 // MYSQL: check for issues with errors on closing connections.
-                // new MySqlJdbcExactlyOnceSinkTestEnv(4)
+                new MySqlJdbcExactlyOnceSinkTestEnv(4),
                 // ORACLE - default tests.
                 new OracleJdbcExactlyOnceSinkTestEnv(4)
                 // MSSQL - not testing: XA transactions need to be enabled via GUI (plus EULA).
@@ -845,10 +844,10 @@ public class JdbcExactlyOnceSinkE2eTest extends JdbcTestBase {
 
         /** {@link OracleContainer}. */
         private static final class OracleContainer extends JdbcDatabaseContainer<OracleContainer> {
-            public static final String NAME = "oracle";
-            private static final String IMAGE = "wnameless/oracle-xe-11g-r2";
-
-            private static final DockerImageName ORACLE_IMAGE = DockerImageName.parse(IMAGE);
+            private static final String DEFAULT_TAG = "18.4.0-slim";
+            private static final String IMAGE = "gvenzl/oracle-xe";
+            private static final DockerImageName ORACLE_IMAGE =
+                    DockerImageName.parse(IMAGE).withTag(DEFAULT_TAG);
 
             private static final int ORACLE_PORT = 1521;
             private static final int APEX_HTTP_PORT = 8080;
@@ -867,12 +866,8 @@ public class JdbcExactlyOnceSinkE2eTest extends JdbcTestBase {
             private void preconfigure() {
                 withStartupTimeoutSeconds(DEFAULT_STARTUP_TIMEOUT_SECONDS);
                 withConnectTimeoutSeconds(DEFAULT_CONNECT_TIMEOUT_SECONDS);
+                withEnv("ORACLE_PASSWORD", password);
                 addExposedPorts(ORACLE_PORT, APEX_HTTP_PORT);
-            }
-
-            @Override
-            protected Integer getLivenessCheckPort() {
-                return getMappedPort(ORACLE_PORT);
             }
 
             @Override


### PR DESCRIPTION
## What is the purpose of the change
Add the implementation of the Oracle dialect for JDBC connectors

## Brief change log

- Implemented OracleDialect extending AbstractDialect 
- Added default OracleRowConverter

## Verifying this change

I tested this change connecting directly to a running database (but I didn't cover all the types).

And added coverage in JdbcDataTypeTest.java

## Does this pull request potentially affect one of the following parts:

  - Dependencies (does it add or upgrade a dependency): ( no)
  - The public API, i.e., is any changed class annotated with `@Public(Evolving)`: (/ no)
  - The serializers: ( no)
  - The runtime per-record code paths (performance sensitive): ( no )
  - Anything that affects deployment or recovery: JobManager (and its components), Checkpointing, Kubernetes/Yarn, ZooKeeper: ( no)
  - The S3 file system connector: ( no)

## Documentation

  - Does this pull request introduce a new feature? ( no)
  - If yes, how is the feature documented? ( docs )
