### PR TITLE
[FLINK-24770] Remove error from JobStatusListener

### DIFF
--- a/flink-runtime/src/main/java/org/apache/flink/runtime/checkpoint/CheckpointCoordinatorDeActivator.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/checkpoint/CheckpointCoordinatorDeActivator.java
@@ -37,8 +37,7 @@ public class CheckpointCoordinatorDeActivator implements JobStatusListener {
     }
 
     @Override
-    public void jobStatusChanges(
-            JobID jobId, JobStatus newJobStatus, long timestamp, Throwable error) {
+    public void jobStatusChanges(JobID jobId, JobStatus newJobStatus, long timestamp) {
         if (newJobStatus == JobStatus.RUNNING) {
             // start the checkpoint scheduler
             coordinator.startCheckpointScheduler();

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/executiongraph/DefaultExecutionGraph.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/executiongraph/DefaultExecutionGraph.java
@@ -1045,6 +1045,7 @@ public class DefaultExecutionGraph implements ExecutionGraph, InternalExecutionG
                     newState,
                     error);
 
+            stateTimestamps[newState.ordinal()] = System.currentTimeMillis();
             notifyJobStatusChange(newState);
             return true;
         } else {

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/executiongraph/DefaultExecutionGraph.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/executiongraph/DefaultExecutionGraph.java
@@ -79,7 +79,6 @@ import org.apache.flink.util.ExceptionUtils;
 import org.apache.flink.util.FlinkException;
 import org.apache.flink.util.IterableUtils;
 import org.apache.flink.util.OptionalFailure;
-import org.apache.flink.util.SerializedThrowable;
 import org.apache.flink.util.SerializedValue;
 import org.apache.flink.util.concurrent.FutureUtils;
 import org.apache.flink.util.concurrent.FutureUtils.ConjunctFuture;
@@ -1046,8 +1045,7 @@ public class DefaultExecutionGraph implements ExecutionGraph, InternalExecutionG
                     newState,
                     error);
 
-            stateTimestamps[newState.ordinal()] = System.currentTimeMillis();
-            notifyJobStatusChange(newState, error);
+            notifyJobStatusChange(newState);
             return true;
         } else {
             return false;
@@ -1439,14 +1437,13 @@ public class DefaultExecutionGraph implements ExecutionGraph, InternalExecutionG
         }
     }
 
-    private void notifyJobStatusChange(JobStatus newState, Throwable error) {
+    private void notifyJobStatusChange(JobStatus newState) {
         if (jobStatusListeners.size() > 0) {
             final long timestamp = System.currentTimeMillis();
-            final Throwable serializedError = error == null ? null : new SerializedThrowable(error);
 
             for (JobStatusListener listener : jobStatusListeners) {
                 try {
-                    listener.jobStatusChanges(getJobID(), newState, timestamp, serializedError);
+                    listener.jobStatusChanges(getJobID(), newState, timestamp);
                 } catch (Throwable t) {
                     LOG.warn("Error while notifying JobStatusListener", t);
                 }

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/executiongraph/JobStatusListener.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/executiongraph/JobStatusListener.java
@@ -30,8 +30,6 @@ public interface JobStatusListener {
      * @param jobId The ID of the job.
      * @param newJobStatus The status the job switched to.
      * @param timestamp The timestamp when the status transition occurred.
-     * @param error In case the job status switches to a failure state, this is the exception that
-     *     caused the failure.
      */
-    void jobStatusChanges(JobID jobId, JobStatus newJobStatus, long timestamp, Throwable error);
+    void jobStatusChanges(JobID jobId, JobStatus newJobStatus, long timestamp);
 }

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/jobmaster/JobMaster.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/jobmaster/JobMaster.java
@@ -1304,10 +1304,7 @@ public class JobMaster extends PermanentlyFencedRpcEndpoint<JobMasterId>
 
         @Override
         public void jobStatusChanges(
-                final JobID jobId,
-                final JobStatus newJobStatus,
-                final long timestamp,
-                final Throwable error) {
+                final JobID jobId, final JobStatus newJobStatus, final long timestamp) {
 
             if (running) {
                 // run in rpc thread to avoid concurrency

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/scheduler/adaptive/AdaptiveScheduler.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/scheduler/adaptive/AdaptiveScheduler.java
@@ -1072,8 +1072,7 @@ public class AdaptiveScheduler
             jobStatusListener.jobStatusChanges(
                     jobInformation.getJobID(),
                     archivedExecutionGraph.getState(),
-                    archivedExecutionGraph.getStatusTimestamp(archivedExecutionGraph.getState()),
-                    optionalFailure);
+                    archivedExecutionGraph.getStatusTimestamp(archivedExecutionGraph.getState()));
         }
 
         jobTerminationFuture.complete(archivedExecutionGraph.getState());

--- a/flink-runtime/src/test/java/org/apache/flink/runtime/scheduler/GloballyTerminalJobStatusListener.java
+++ b/flink-runtime/src/test/java/org/apache/flink/runtime/scheduler/GloballyTerminalJobStatusListener.java
@@ -31,8 +31,7 @@ public class GloballyTerminalJobStatusListener implements JobStatusListener {
             new CompletableFuture<>();
 
     @Override
-    public void jobStatusChanges(
-            JobID jobId, JobStatus newJobStatus, long timestamp, Throwable error) {
+    public void jobStatusChanges(JobID jobId, JobStatus newJobStatus, long timestamp) {
         if (newJobStatus.isGloballyTerminalState()) {
             globallyTerminalJobStatusFuture.complete(newJobStatus);
         }

--- a/flink-runtime/src/test/java/org/apache/flink/runtime/scheduler/SchedulerTestingUtils.java
+++ b/flink-runtime/src/test/java/org/apache/flink/runtime/scheduler/SchedulerTestingUtils.java
@@ -417,8 +417,7 @@ public class SchedulerTestingUtils {
         private ExecutionVertexVersioner executionVertexVersioner = new ExecutionVertexVersioner();
         private ExecutionSlotAllocatorFactory executionSlotAllocatorFactory =
                 new TestExecutionSlotAllocatorFactory();
-        private JobStatusListener jobStatusListener =
-                (ignoredA, ignoredB, ignoredC, ignoredD) -> {};
+        private JobStatusListener jobStatusListener = (ignoredA, ignoredB, ignoredC) -> {};
 
         public DefaultSchedulerBuilder(
                 final JobGraph jobGraph, ComponentMainThreadExecutor mainThreadExecutor) {

--- a/flink-runtime/src/test/java/org/apache/flink/runtime/scheduler/adaptive/AdaptiveSchedulerBuilder.java
+++ b/flink-runtime/src/test/java/org/apache/flink/runtime/scheduler/adaptive/AdaptiveSchedulerBuilder.java
@@ -78,7 +78,7 @@ public class AdaptiveSchedulerBuilder {
             error ->
                     FatalExitExceptionHandler.INSTANCE.uncaughtException(
                             Thread.currentThread(), error);
-    private JobStatusListener jobStatusListener = (ignoredA, ignoredB, ignoredC, ignoredD) -> {};
+    private JobStatusListener jobStatusListener = (ignoredA, ignoredB, ignoredC) -> {};
     private long initializationTimestamp = System.currentTimeMillis();
 
     @Nullable private SlotAllocator slotAllocator;

--- a/flink-runtime/src/test/java/org/apache/flink/runtime/scheduler/adaptive/AdaptiveSchedulerTest.java
+++ b/flink-runtime/src/test/java/org/apache/flink/runtime/scheduler/adaptive/AdaptiveSchedulerTest.java
@@ -612,7 +612,7 @@ public class AdaptiveSchedulerTest extends TestLogger {
         final AdaptiveScheduler scheduler =
                 new AdaptiveSchedulerBuilder(createJobGraph(), mainThreadExecutor)
                         .setJobStatusListener(
-                                (jobId, newJobStatus, timestamp, error) ->
+                                (jobId, newJobStatus, timestamp) ->
                                         jobStatusUpdate.set(newJobStatus))
                         .build();
 


### PR DESCRIPTION
The error is not currently used anywhere and makes it harder to add more uses of the interface.

Specifically I want to extend the AdaptiveScheduler to send the status updates, but doing that in a generic fashion without having to touch all scheduler states isn't currently possible because the existence of a failure cause is an implementation detail of the satte.