### PR TITLE
[FLINK-24771][jdbc][tests] Bump test dependencies mariadb-java-client to 2.7.4 and mysql-connector-java to 8.0.27

### DIFF
--- a/flink-connectors/flink-connector-jdbc/pom.xml
+++ b/flink-connectors/flink-connector-jdbc/pom.xml
@@ -130,19 +130,19 @@ under the License.
 			<scope>test</scope>
 		</dependency>
 		<!-- ch.vorburger.mariaDB4j:mariaDB4j has a dependency of mariadb-java-client:2.3.0,
-		 but we want to bump mariadb-java-client to 2.5.4 which fix a few notable bugs,
+		 but we want to bump mariadb-java-client to >= 2.5.4 which fix a few notable bugs,
 		 see: https://mariadb.com/kb/en/mariadb-connector-j-release-notes/
 		 and the lower version may cause the test stability issue FLINK-18082.-->
 		<dependency>
 			<groupId>org.mariadb.jdbc</groupId>
 			<artifactId>mariadb-java-client</artifactId>
-			<version>2.5.4</version>
+			<version>2.7.4</version>
 			<scope>test</scope>
 		</dependency>
 		<dependency>
 			<groupId>mysql</groupId>
 			<artifactId>mysql-connector-java</artifactId>
-			<version>8.0.20</version>
+			<version>8.0.27</version>
 			<scope>test</scope>
 		</dependency>
 
@@ -159,15 +159,15 @@ under the License.
 			<groupId>com.h2database</groupId>
 			<artifactId>h2</artifactId>
 			<version>1.4.200</version>
-        </dependency>
+		</dependency>
 
-        <dependency>
-            <groupId>org.testcontainers</groupId>
-            <artifactId>postgresql</artifactId>
-            <scope>test</scope>
-        </dependency>
+		<dependency>
+			<groupId>org.testcontainers</groupId>
+			<artifactId>postgresql</artifactId>
+			<scope>test</scope>
+		</dependency>
 
-        <dependency>
+		<dependency>
 			<groupId>org.testcontainers</groupId>
 			<artifactId>mysql</artifactId>
 			<scope>test</scope>


### PR DESCRIPTION
## What is the purpose of the change

* Update JDBC test dependencies to the latest versions

## Brief change log

* Bumped org.mariadb.jdbc:mariadb-java-client from 2.5.4 to 2.7.4
* Bumped mysql:mysql-connector-java from 8.0.20 to 8.0.27

## Verifying this change

This change is a trivial rework / code cleanup without any test coverage.

## Does this pull request potentially affect one of the following parts:

  - Dependencies (does it add or upgrade a dependency): (**yes** / no)
  - The public API, i.e., is any changed class annotated with `@Public(Evolving)`: (yes / **no**)
  - The serializers: (yes / **no** / don't know)
  - The runtime per-record code paths (performance sensitive): (yes / **no** / don't know)
  - Anything that affects deployment or recovery: JobManager (and its components), Checkpointing, Kubernetes/Yarn, ZooKeeper: (yes / **no** / don't know)
  - The S3 file system connector: (yes / **no** / don't know)

## Documentation

  - Does this pull request introduce a new feature? (yes / **no**)
  - If yes, how is the feature documented? (**not applicable** / docs / JavaDocs / not documented)
