### PR TITLE
[FLINK-24631][Kubernetes]Use minimal selector to select jobManager and taskManager pod

### DIFF
--- a/flink-kubernetes/src/main/java/org/apache/flink/kubernetes/KubernetesResourceManagerDriver.java
+++ b/flink-kubernetes/src/main/java/org/apache/flink/kubernetes/KubernetesResourceManagerDriver.java
@@ -211,7 +211,8 @@ public class KubernetesResourceManagerDriver
 
     private void recoverWorkerNodesFromPreviousAttempts() throws ResourceManagerException {
         List<KubernetesPod> podList =
-                flinkKubeClient.getPodsWithLabels(KubernetesUtils.getTaskManagerLabels(clusterId));
+                flinkKubeClient.getPodsWithLabels(
+                        KubernetesUtils.getTaskManagerSelectors(clusterId));
         final List<KubernetesWorkerNode> recoveredWorkers = new ArrayList<>();
 
         for (KubernetesPod pod : podList) {
@@ -329,7 +330,7 @@ public class KubernetesResourceManagerDriver
     private Optional<KubernetesWatch> watchTaskManagerPods() throws Exception {
         return Optional.of(
                 flinkKubeClient.watchPodsAndDoCallback(
-                        KubernetesUtils.getTaskManagerLabels(clusterId),
+                        KubernetesUtils.getTaskManagerSelectors(clusterId),
                         new PodCallbackHandlerImpl()));
     }
 

--- a/flink-kubernetes/src/main/java/org/apache/flink/kubernetes/kubeclient/decorators/ExternalServiceDecorator.java
+++ b/flink-kubernetes/src/main/java/org/apache/flink/kubernetes/kubeclient/decorators/ExternalServiceDecorator.java
@@ -55,7 +55,7 @@ public class ExternalServiceDecorator extends AbstractKubernetesStepDecorator {
                         .endMetadata()
                         .withNewSpec()
                         .withType(kubernetesJobManagerParameters.getRestServiceExposedType().name())
-                        .withSelector(kubernetesJobManagerParameters.getLabels())
+                        .withSelector(kubernetesJobManagerParameters.getSelectors())
                         .addNewPort()
                         .withName(Constants.REST_PORT_NAME)
                         .withPort(kubernetesJobManagerParameters.getRestPort())

--- a/flink-kubernetes/src/main/java/org/apache/flink/kubernetes/kubeclient/decorators/InternalServiceDecorator.java
+++ b/flink-kubernetes/src/main/java/org/apache/flink/kubernetes/kubeclient/decorators/InternalServiceDecorator.java
@@ -63,7 +63,7 @@ public class InternalServiceDecorator extends AbstractKubernetesStepDecorator {
                         .endMetadata()
                         .withNewSpec()
                         .withClusterIP(Constants.HEADLESS_SERVICE_CLUSTER_IP)
-                        .withSelector(kubernetesJobManagerParameters.getLabels())
+                        .withSelector(kubernetesJobManagerParameters.getSelectors())
                         .addNewPort()
                         .withName(Constants.JOB_MANAGER_RPC_PORT_NAME)
                         .withPort(kubernetesJobManagerParameters.getRPCPort())

--- a/flink-kubernetes/src/main/java/org/apache/flink/kubernetes/kubeclient/factory/KubernetesJobManagerFactory.java
+++ b/flink-kubernetes/src/main/java/org/apache/flink/kubernetes/kubeclient/factory/KubernetesJobManagerFactory.java
@@ -47,7 +47,6 @@ import io.fabric8.kubernetes.api.model.apps.DeploymentBuilder;
 import java.io.IOException;
 import java.util.ArrayList;
 import java.util.List;
-import java.util.Map;
 import java.util.stream.Collectors;
 
 /**
@@ -98,8 +97,6 @@ public class KubernetesJobManagerFactory {
                         .endSpec()
                         .build();
 
-        final Map<String, String> labels = resolvedPod.getMetadata().getLabels();
-
         return new DeploymentBuilder()
                 .withApiVersion(Constants.APPS_API_VERSION)
                 .editOrNewMetadata()
@@ -120,7 +117,7 @@ public class KubernetesJobManagerFactory {
                 .withSpec(resolvedPod.getSpec())
                 .endTemplate()
                 .editOrNewSelector()
-                .addToMatchLabels(labels)
+                .addToMatchLabels(kubernetesJobManagerParameters.getSelectors())
                 .endSelector()
                 .endSpec()
                 .build();

--- a/flink-kubernetes/src/main/java/org/apache/flink/kubernetes/kubeclient/parameters/KubernetesJobManagerParameters.java
+++ b/flink-kubernetes/src/main/java/org/apache/flink/kubernetes/kubeclient/parameters/KubernetesJobManagerParameters.java
@@ -28,7 +28,6 @@ import org.apache.flink.configuration.ResourceManagerOptions;
 import org.apache.flink.configuration.RestOptions;
 import org.apache.flink.kubernetes.configuration.KubernetesConfigOptions;
 import org.apache.flink.kubernetes.configuration.KubernetesConfigOptionsInternal;
-import org.apache.flink.kubernetes.utils.Constants;
 import org.apache.flink.kubernetes.utils.KubernetesUtils;
 import org.apache.flink.runtime.jobmanager.HighAvailabilityMode;
 
@@ -63,9 +62,13 @@ public class KubernetesJobManagerParameters extends AbstractKubernetesParameters
                 flinkConfig
                         .getOptional(KubernetesConfigOptions.JOB_MANAGER_LABELS)
                         .orElse(Collections.emptyMap()));
-        labels.putAll(getCommonLabels());
-        labels.put(Constants.LABEL_COMPONENT_KEY, Constants.LABEL_COMPONENT_JOB_MANAGER);
+        labels.putAll(getSelectors());
         return Collections.unmodifiableMap(labels);
+    }
+
+    @Override
+    public Map<String, String> getSelectors() {
+        return KubernetesUtils.getJobManagerSelectors(getClusterId());
     }
 
     @Override

--- a/flink-kubernetes/src/main/java/org/apache/flink/kubernetes/kubeclient/parameters/KubernetesParameters.java
+++ b/flink-kubernetes/src/main/java/org/apache/flink/kubernetes/kubeclient/parameters/KubernetesParameters.java
@@ -53,6 +53,9 @@ public interface KubernetesParameters {
     /** A collection of labels that are attached to the JobManager and TaskManager Pod(s). */
     Map<String, String> getLabels();
 
+    /** A stable subset of labels attached to the resource to select the related resources. */
+    Map<String, String> getSelectors();
+
     /**
      * A collection of node selector to constrain a pod to only be able to run on particular
      * node(s).

--- a/flink-kubernetes/src/main/java/org/apache/flink/kubernetes/kubeclient/parameters/KubernetesTaskManagerParameters.java
+++ b/flink-kubernetes/src/main/java/org/apache/flink/kubernetes/kubeclient/parameters/KubernetesTaskManagerParameters.java
@@ -72,8 +72,13 @@ public class KubernetesTaskManagerParameters extends AbstractKubernetesParameter
                 flinkConfig
                         .getOptional(KubernetesConfigOptions.TASK_MANAGER_LABELS)
                         .orElse(Collections.emptyMap()));
-        labels.putAll(KubernetesUtils.getTaskManagerLabels(getClusterId()));
+        labels.putAll(getSelectors());
         return Collections.unmodifiableMap(labels);
+    }
+
+    @Override
+    public Map<String, String> getSelectors() {
+        return KubernetesUtils.getTaskManagerSelectors(getClusterId());
     }
 
     @Override

--- a/flink-kubernetes/src/main/java/org/apache/flink/kubernetes/utils/KubernetesUtils.java
+++ b/flink-kubernetes/src/main/java/org/apache/flink/kubernetes/utils/KubernetesUtils.java
@@ -132,14 +132,25 @@ public class KubernetesUtils {
     }
 
     /**
-     * Get task manager labels for the current Flink cluster. They could be used to watch the pods
-     * status.
+     * Get task manager selectors for the current Flink cluster. They could be used to watch the
+     * pods status.
      *
      * @return Task manager labels.
      */
-    public static Map<String, String> getTaskManagerLabels(String clusterId) {
+    public static Map<String, String> getTaskManagerSelectors(String clusterId) {
         final Map<String, String> labels = getCommonLabels(clusterId);
         labels.put(Constants.LABEL_COMPONENT_KEY, Constants.LABEL_COMPONENT_TASK_MANAGER);
+        return Collections.unmodifiableMap(labels);
+    }
+
+    /**
+     * Get job manager selectors for the current Flink cluster.
+     *
+     * @return JobManager selectors.
+     */
+    public static Map<String, String> getJobManagerSelectors(String clusterId) {
+        final Map<String, String> labels = getCommonLabels(clusterId);
+        labels.put(Constants.LABEL_COMPONENT_KEY, Constants.LABEL_COMPONENT_JOB_MANAGER);
         return Collections.unmodifiableMap(labels);
     }
 

--- a/flink-kubernetes/src/test/java/org/apache/flink/kubernetes/kubeclient/decorators/ExternalServiceDecoratorTest.java
+++ b/flink-kubernetes/src/test/java/org/apache/flink/kubernetes/kubeclient/decorators/ExternalServiceDecoratorTest.java
@@ -93,7 +93,6 @@ public class ExternalServiceDecoratorTest extends KubernetesJobManagerTestBase {
         assertEquals(expectedServicePorts, restService.getSpec().getPorts());
 
         expectedLabels.put(Constants.LABEL_COMPONENT_KEY, Constants.LABEL_COMPONENT_JOB_MANAGER);
-        expectedLabels.putAll(userLabels);
         assertEquals(expectedLabels, restService.getSpec().getSelector());
 
         final Map<String, String> resultAnnotations = restService.getMetadata().getAnnotations();

--- a/flink-kubernetes/src/test/java/org/apache/flink/kubernetes/kubeclient/decorators/InternalServiceDecoratorTest.java
+++ b/flink-kubernetes/src/test/java/org/apache/flink/kubernetes/kubeclient/decorators/InternalServiceDecoratorTest.java
@@ -88,7 +88,6 @@ public class InternalServiceDecoratorTest extends KubernetesJobManagerTestBase {
         assertEquals(expectedServicePorts, internalService.getSpec().getPorts());
 
         expectedLabels.put(Constants.LABEL_COMPONENT_KEY, Constants.LABEL_COMPONENT_JOB_MANAGER);
-        expectedLabels.putAll(userLabels);
         assertEquals(expectedLabels, internalService.getSpec().getSelector());
     }
 

--- a/flink-kubernetes/src/test/java/org/apache/flink/kubernetes/kubeclient/factory/KubernetesJobManagerFactoryTest.java
+++ b/flink-kubernetes/src/test/java/org/apache/flink/kubernetes/kubeclient/factory/KubernetesJobManagerFactoryTest.java
@@ -159,10 +159,11 @@ public class KubernetesJobManagerFactoryTest extends KubernetesJobManagerTestBas
 
         final Map<String, String> expectedLabels = new HashMap<>(getCommonLabels());
         expectedLabels.put(Constants.LABEL_COMPONENT_KEY, Constants.LABEL_COMPONENT_JOB_MANAGER);
-        expectedLabels.putAll(userLabels);
 
-        assertEquals(expectedLabels, resultDeploymentSpec.getTemplate().getMetadata().getLabels());
         assertEquals(expectedLabels, resultDeploymentSpec.getSelector().getMatchLabels());
+
+        expectedLabels.putAll(userLabels);
+        assertEquals(expectedLabels, resultDeploymentSpec.getTemplate().getMetadata().getLabels());
 
         assertThat(
                 resultDeploymentSpec.getTemplate().getMetadata().getAnnotations(),
@@ -289,14 +290,14 @@ public class KubernetesJobManagerFactoryTest extends KubernetesJobManagerTestBas
                 Constants.HEADLESS_SERVICE_CLUSTER_IP,
                 resultInternalService.getSpec().getClusterIP());
         assertEquals(2, resultInternalService.getSpec().getPorts().size());
-        assertEquals(5, resultInternalService.getSpec().getSelector().size());
+        assertEquals(3, resultInternalService.getSpec().getSelector().size());
 
         final Service resultRestService = restServiceCandidates.get(0);
         assertEquals(2, resultRestService.getMetadata().getLabels().size());
 
         assertEquals("ClusterIP", resultRestService.getSpec().getType());
         assertEquals(1, resultRestService.getSpec().getPorts().size());
-        assertEquals(5, resultRestService.getSpec().getSelector().size());
+        assertEquals(3, resultRestService.getSpec().getSelector().size());
     }
 
     @Test

--- a/flink-kubernetes/src/test/java/org/apache/flink/kubernetes/kubeclient/parameters/AbstractKubernetesParametersTest.java
+++ b/flink-kubernetes/src/test/java/org/apache/flink/kubernetes/kubeclient/parameters/AbstractKubernetesParametersTest.java
@@ -170,6 +170,11 @@ public class AbstractKubernetesParametersTest extends TestLogger {
         }
 
         @Override
+        public Map<String, String> getSelectors() {
+            throw new UnsupportedOperationException("NOT supported");
+        }
+
+        @Override
         public Map<String, String> getNodeSelector() {
             throw new UnsupportedOperationException("NOT supported");
         }


### PR DESCRIPTION
## What is the purpose of the change

The PR is meant to use the minimal selector to select jobManager and taskManger pod.


## Verifying this change

This change is already covered by existing tests.

