### PR TITLE
[FLINK-24778][table-common] Add DataTypes#ROW(List<Field>) to reduce friction when using Stream of fields

### DIFF
--- a/flink-table/flink-table-common/src/main/java/org/apache/flink/table/api/DataTypes.java
+++ b/flink-table/flink-table-common/src/main/java/org/apache/flink/table/api/DataTypes.java
@@ -744,6 +744,11 @@ public final class DataTypes {
         return new FieldsDataType(new RowType(logicalFields), fieldDataTypes);
     }
 
+    /** @see #ROW(Field...) */
+    public static DataType ROW(List<Field> fields) {
+        return ROW(fields.toArray(new Field[0]));
+    }
+
     /**
      * Data type of a sequence of fields.
      *

--- a/flink-table/flink-table-common/src/main/java/org/apache/flink/table/catalog/ResolvedSchema.java
+++ b/flink-table/flink-table-common/src/main/java/org/apache/flink/table/catalog/ResolvedSchema.java
@@ -25,7 +25,6 @@ import org.apache.flink.table.expressions.Expression;
 import org.apache.flink.table.expressions.ResolvedExpression;
 import org.apache.flink.table.types.AbstractDataType;
 import org.apache.flink.table.types.DataType;
-import org.apache.flink.table.types.FieldsDataType;
 import org.apache.flink.util.Preconditions;
 
 import javax.annotation.Nullable;
@@ -41,7 +40,6 @@ import java.util.stream.Collectors;
 import java.util.stream.IntStream;
 
 import static org.apache.flink.table.api.DataTypes.FIELD;
-import static org.apache.flink.table.api.DataTypes.ROW;
 import static org.apache.flink.table.types.utils.DataTypeUtils.removeTimeAttribute;
 
 /**
@@ -257,14 +255,13 @@ public final class ResolvedSchema {
 
     // --------------------------------------------------------------------------------------------
 
-    private FieldsDataType toRowDataType(Predicate<Column> columnPredicate) {
-        final DataTypes.Field[] fields =
-                columns.stream()
-                        .filter(columnPredicate)
-                        .map(ResolvedSchema::columnToField)
-                        .toArray(DataTypes.Field[]::new);
-        // the row should never be null
-        return (FieldsDataType) ROW(fields).notNull();
+    private DataType toRowDataType(Predicate<Column> columnPredicate) {
+        return columns.stream()
+                .filter(columnPredicate)
+                .map(ResolvedSchema::columnToField)
+                .collect(Collectors.collectingAndThen(Collectors.toList(), DataTypes::ROW))
+                // the row should never be null
+                .notNull();
     }
 
     private static DataTypes.Field columnToField(Column column) {

--- a/flink-table/flink-table-common/src/main/java/org/apache/flink/table/types/utils/DataTypeUtils.java
+++ b/flink-table/flink-table-common/src/main/java/org/apache/flink/table/types/utils/DataTypeUtils.java
@@ -162,28 +162,8 @@ public final class DataTypeUtils {
         if (fields.size() == 0) {
             return dataType;
         }
-
-        final RowType rowType = (RowType) dataType.getLogicalType();
-        final List<RowField> newFields =
-                Stream.concat(
-                                rowType.getFields().stream(),
-                                fields.stream()
-                                        .map(
-                                                f ->
-                                                        new RowField(
-                                                                f.getName(),
-                                                                f.getDataType().getLogicalType(),
-                                                                f.getDescription().orElse(null))))
-                        .collect(Collectors.toList());
-        final RowType newRowType = new RowType(rowType.isNullable(), newFields);
-
-        final List<DataType> newFieldDataTypes =
-                Stream.concat(
-                                dataType.getChildren().stream(),
-                                fields.stream().map(DataTypes.Field::getDataType))
-                        .collect(Collectors.toList());
-
-        return new FieldsDataType(newRowType, dataType.getConversionClass(), newFieldDataTypes);
+        return Stream.concat(DataType.getFields(dataType).stream(), fields.stream())
+                .collect(Collectors.collectingAndThen(Collectors.toList(), DataTypes::ROW));
     }
 
     /**


### PR DESCRIPTION
Signed-off-by: slinkydeveloper <francescoguard@gmail.com>

<!--
*Thank you very much for contributing to Apache Flink - we are happy that you want to help us improve Flink. To help the community review your contribution in the best possible way, please go through the checklist below, which will get the contribution into a shape in which it can be best reviewed.*

*Please understand that we do not do this to make contributions to Flink a hassle. In order to uphold a high standard of quality for code contributions, while at the same time managing a large number of contributions, we need contributors to prepare the contributions well, and give reviewers enough contextual information for the review. Please also understand that contributions that do not follow this guide will take longer to review and thus typically be picked up with lower priority by the community.*

## Contribution Checklist

  - Make sure that the pull request corresponds to a [JIRA issue](https://issues.apache.org/jira/projects/FLINK/issues). Exceptions are made for typos in JavaDoc or documentation files, which need no JIRA issue.
  
  - Name the pull request in the form "[FLINK-XXXX] [component] Title of the pull request", where *FLINK-XXXX* should be replaced by the actual issue number. Skip *component* if you are unsure about which is the best component.
  Typo fixes that have no associated JIRA issue should be named following this pattern: `[hotfix] [docs] Fix typo in event time introduction` or `[hotfix] [javadocs] Expand JavaDoc for PuncuatedWatermarkGenerator`.

  - Fill out the template below to describe the changes contributed by the pull request. That will give reviewers the context they need to do the review.
  
  - Make sure that the change passes the automated tests, i.e., `mvn clean verify` passes. You can set up Azure Pipelines CI to do that following [this guide](https://cwiki.apache.org/confluence/display/FLINK/Azure+Pipelines#AzurePipelines-Tutorial:SettingupAzurePipelinesforaforkoftheFlinkrepository).

  - Each pull request should address only one issue, not mix up code from multiple issues.
  
  - Each commit in the pull request has a meaningful commit message (including the JIRA id)

  - Once all items of the checklist are addressed, remove the above text and this checklist, leaving only the filled out template below.


**(The sections below can be removed for hotfixes of typos)**
-->

## What is the purpose of the change

Connectors and format developers very often destructure `DataType` in a `Stream` of `DataTypes.Field`, and to rebuild it they need to go through instantiating an array.

This PR adds an overload of `DataTypes#ROW` that accepts `List<Field>` to reduce the friction.

## Brief change log

- Add `DataTypes#ROW(List<Field>)`
- Show the usage of the new overload in combination with `Stream`

## Verifying this change

This change is a trivial rework / code cleanup without any test coverage.

## Does this pull request potentially affect one of the following parts:

  - Dependencies (does it add or upgrade a dependency): no
  - The public API, i.e., is any changed class annotated with `@Public(Evolving)`: yes
  - The serializers: no
  - The runtime per-record code paths (performance sensitive): no
  - Anything that affects deployment or recovery: JobManager (and its components), Checkpointing, Kubernetes/Yarn, ZooKeeper: no
  - The S3 file system connector: no

## Documentation

  - Does this pull request introduce a new feature? yes
  - If yes, how is the feature documented? JavaDocs
