### PR TITLE
[FLINK-24704][table] Fix exception when the input record loses monotonicity on the sort key field of UpdatableTopNFunction 

### DIFF
--- a/flink-table/flink-table-planner/src/test/scala/org/apache/flink/table/planner/runtime/harness/RankHarnessTest.scala
+++ b/flink-table/flink-table-planner/src/test/scala/org/apache/flink/table/planner/runtime/harness/RankHarnessTest.scala
@@ -1,0 +1,223 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.flink.table.planner.runtime.harness
+
+import org.apache.flink.api.scala._
+import org.apache.flink.table.api._
+import org.apache.flink.table.api.bridge.scala._
+import org.apache.flink.table.api.bridge.scala.internal.StreamTableEnvironmentImpl
+import org.apache.flink.table.planner.runtime.utils.JavaUserDefinedTableFunctions
+import org.apache.flink.table.planner.runtime.utils.StreamingWithStateTestBase.StateBackendMode
+import org.apache.flink.table.runtime.util.RowDataHarnessAssertor
+import org.apache.flink.table.runtime.util.StreamRecordUtils.binaryRecord
+import org.apache.flink.types.Row
+import org.apache.flink.types.RowKind._
+
+import org.junit.runner.RunWith
+import org.junit.runners.Parameterized
+import org.junit.{Before, Test}
+
+import java.lang.{Long => JLong}
+import java.time.Duration
+import java.util.concurrent.ConcurrentLinkedQueue
+
+import scala.collection.mutable
+
+@RunWith(classOf[Parameterized])
+class RankHarnessTest(mode: StateBackendMode) extends HarnessTestBase(mode) {
+
+  @Before
+  override def before(): Unit = {
+    super.before()
+    val setting = EnvironmentSettings.newInstance().inStreamingMode().build()
+    val config = new TestTableConfig
+    this.tEnv = StreamTableEnvironmentImpl.create(env, setting, config)
+  }
+
+  @Test
+  def testRetractRankWithRowNumber(): Unit = {
+    val data = new mutable.MutableList[(String, String, Long)]
+    val t = env.fromCollection(data).toTable(tEnv, 'a, 'b, 'c)
+    tEnv.createTemporaryView("T", t)
+    tEnv.createTemporarySystemFunction(
+      "STRING_SPLIT", new JavaUserDefinedTableFunctions.StringSplit)
+    tEnv.getConfig.setIdleStateRetention(Duration.ofSeconds(1))
+
+    val sql =
+      """
+        |SELECT a, b, c, id, rn1
+        |FROM (
+        |   SELECT a, b, c, t3.id id,
+        |    ROW_NUMBER() OVER (PARTITION BY a, t3.id ORDER BY c DESC) AS rn1
+        |   FROM (
+        |       SELECT a, b, c, rn
+        |       FROM
+        |       (
+        |           -- append rank
+        |           SELECT a, b, c,
+        |               ROW_NUMBER() OVER (PARTITION BY a ORDER BY c DESC) AS rn
+        |           FROM T
+        |       ) t1
+        |       WHERE rn = 1
+        |   ) t2, LATERAL TABLE(STRING_SPLIT(b, '#')) AS t3(id)
+        |) WHERE rn1 <= 2
+      """.stripMargin
+
+    val t1 = tEnv.sqlQuery(sql)
+
+    val testHarness = createHarnessTester(t1.toRetractStream[Row], "Rank(strategy=[RetractStrategy")
+    val assertor = new RowDataHarnessAssertor(
+      Array(
+        DataTypes.STRING().getLogicalType,
+        DataTypes.STRING().getLogicalType,
+        DataTypes.BIGINT().getLogicalType,
+        DataTypes.STRING().getLogicalType,
+        DataTypes.BIGINT().getLogicalType))
+
+    testHarness.open()
+
+    // set TtlTimeProvider with 1
+    testHarness.setStateTtlProcessingTime(1)
+
+    testHarness.processElement(binaryRecord(INSERT, "a", "1", 2L: JLong, "1"))
+    testHarness.processElement(binaryRecord(INSERT, "a", "1", 2L: JLong, "1"))
+    testHarness.processElement(binaryRecord(INSERT, "a", "1", 2L: JLong, "1"))
+    testHarness.processElement(binaryRecord(INSERT, "a", "1", 2L: JLong, "1"))
+    testHarness.processElement(binaryRecord(INSERT, "a", "1", 1L: JLong, "1"))
+
+    testHarness.setStateTtlProcessingTime(1000)
+    testHarness.processElement(binaryRecord(DELETE, "a", "1", 2L: JLong, "1"))
+    testHarness.processElement(binaryRecord(DELETE, "a", "1", 2L: JLong, "1"))
+
+    // set TtlTimeProvider with 1001 to trigger expired state cleanup
+    testHarness.setStateTtlProcessingTime(1001)
+    testHarness.processElement(binaryRecord(DELETE, "a", "1", 2L: JLong, "1"))
+
+    // currently there should only exists one record in state, test adding two new record
+    testHarness.processElement(binaryRecord(INSERT, "a", "1", 2L: JLong, "1"))
+    testHarness.processElement(binaryRecord(INSERT, "a", "1", 2L: JLong, "1"))
+
+    val result = dropWatermarks(testHarness.getOutput.toArray)
+
+    val expectedOutput = new ConcurrentLinkedQueue[Object]()
+
+    expectedOutput.add(binaryRecord(INSERT, "a", "1", 2L: JLong, "1", 1L: JLong))
+    expectedOutput.add(binaryRecord(INSERT, "a", "1", 2L: JLong, "1", 2L: JLong))
+
+    expectedOutput.add(binaryRecord(UPDATE_BEFORE, "a", "1", 2L: JLong, "1", 1L: JLong))
+    expectedOutput.add(binaryRecord(UPDATE_AFTER, "a", "1", 2L: JLong, "1", 1L: JLong))
+    expectedOutput.add(binaryRecord(UPDATE_BEFORE, "a", "1", 2L: JLong, "1", 2L: JLong))
+    expectedOutput.add(binaryRecord(UPDATE_AFTER, "a", "1", 2L: JLong, "1", 2L: JLong))
+    expectedOutput.add(binaryRecord(UPDATE_BEFORE, "a", "1", 2L: JLong, "1", 1L: JLong))
+    expectedOutput.add(binaryRecord(UPDATE_AFTER, "a", "1", 2L: JLong, "1", 1L: JLong))
+    expectedOutput.add(binaryRecord(UPDATE_BEFORE, "a", "1", 2L: JLong, "1", 2L: JLong))
+    expectedOutput.add(binaryRecord(UPDATE_AFTER, "a", "1", 2L: JLong, "1", 2L: JLong))
+
+    expectedOutput.add(binaryRecord(UPDATE_BEFORE, "a", "1", 2L: JLong, "1", 1L: JLong))
+    expectedOutput.add(binaryRecord(UPDATE_AFTER, "a", "1", 2L: JLong, "1", 1L: JLong))
+
+    expectedOutput.add(binaryRecord(DELETE, "a", "1", 2L: JLong, "1", 2L: JLong))
+
+    // if not expired, this is expected result
+    // expectedOutput.add(binaryRecord(INSERT, "a", "1", 1L: JLong, "1", 2L: JLong))
+
+    // only output one result
+    expectedOutput.add(binaryRecord(INSERT, "a", "1", 2L: JLong, "1", 2L: JLong))
+
+    assertor.assertOutputEqualsSorted("result mismatch", expectedOutput, result)
+    testHarness.close()
+  }
+
+  @Test
+  def testRetractRankWithoutRowNumber(): Unit = {
+    val data = new mutable.MutableList[(String, String, Long)]
+    val t = env.fromCollection(data).toTable(tEnv, 'a, 'b, 'c)
+    tEnv.createTemporaryView("T", t)
+    tEnv.createTemporarySystemFunction(
+      "STRING_SPLIT", new JavaUserDefinedTableFunctions.StringSplit)
+    tEnv.getConfig.setIdleStateRetention(Duration.ofSeconds(1))
+
+    val sql =
+      """
+        |SELECT a, b, c, id
+        |FROM (
+        |   SELECT a, b, c, t3.id id,
+        |    ROW_NUMBER() OVER (PARTITION BY a, t3.id ORDER BY c DESC) AS rn1
+        |   FROM (
+        |       SELECT a, b, c, rn
+        |       FROM
+        |       (
+        |           -- append rank
+        |           SELECT a, b, c,
+        |               ROW_NUMBER() OVER (PARTITION BY a ORDER BY c DESC) AS rn
+        |           FROM T
+        |       ) t1
+        |       WHERE rn = 1
+        |   ) t2, LATERAL TABLE(STRING_SPLIT(b, '#')) AS t3(id)
+        |) WHERE rn1 = 1
+      """.stripMargin
+
+    val t1 = tEnv.sqlQuery(sql)
+
+    val testHarness = createHarnessTester(t1.toRetractStream[Row], "Rank(strategy=[RetractStrategy")
+    val assertor = new RowDataHarnessAssertor(
+      Array(
+        DataTypes.STRING().getLogicalType,
+        DataTypes.STRING().getLogicalType,
+        DataTypes.BIGINT().getLogicalType,
+        DataTypes.STRING().getLogicalType))
+
+    testHarness.open()
+
+    // set TtlTimeProvider with 1
+    testHarness.setStateTtlProcessingTime(1)
+
+    testHarness.processElement(binaryRecord(INSERT, "a", "1", 2L: JLong, "1"))
+    testHarness.processElement(binaryRecord(INSERT, "a", "1", 2L: JLong, "1"))
+    testHarness.processElement(binaryRecord(INSERT, "a", "1", 1L: JLong, "1"))
+
+    testHarness.setStateTtlProcessingTime(1000)
+    testHarness.processElement(binaryRecord(DELETE, "a", "1", 2L: JLong, "1"))
+
+    // set TtlTimeProvider with 1001 to trigger expired state cleanup
+    testHarness.setStateTtlProcessingTime(1001)
+    testHarness.processElement(binaryRecord(DELETE, "a", "1", 2L: JLong, "1"))
+
+    // currently there should not exists any record in state, test adding two new record
+    testHarness.processElement(binaryRecord(INSERT, "a", "1", 2L: JLong, "1"))
+    testHarness.processElement(binaryRecord(INSERT, "a", "1", 2L: JLong, "1"))
+
+    val result = dropWatermarks(testHarness.getOutput.toArray)
+
+    val expectedOutput = new ConcurrentLinkedQueue[Object]()
+
+    expectedOutput.add(binaryRecord(INSERT, "a", "1", 2L: JLong, "1"))
+    expectedOutput.add(binaryRecord(DELETE, "a", "1", 2L: JLong, "1"))
+    expectedOutput.add(binaryRecord(INSERT, "a", "1", 2L: JLong, "1"))
+    expectedOutput.add(binaryRecord(DELETE, "a", "1", 2L: JLong, "1"))
+
+    // if not expired, this is expected result
+    // expectedOutput.add(binaryRecord(INSERT, "a", "1", 1L: JLong, "1"))
+
+    expectedOutput.add(binaryRecord(INSERT, "a", "1", 2L: JLong, "1"))
+
+    assertor.assertOutputEqualsSorted("result mismatch", expectedOutput, result)
+    testHarness.close()
+  }
+}

--- a/flink-table/flink-table-runtime/src/main/java/org/apache/flink/table/runtime/operators/rank/RetractableTopNFunction.java
+++ b/flink-table/flink-table-runtime/src/main/java/org/apache/flink/table/runtime/operators/rank/RetractableTopNFunction.java
@@ -224,6 +224,18 @@ public class RetractableTopNFunction extends AbstractTopNFunction {
 
     // ------------- ROW_NUMBER-------------------------------
 
+    private void processStateStaled(Iterator<Map.Entry<RowData, Long>> sortedMapIterator)
+            throws RuntimeException {
+        // Skip the data if it's state is cleared because of state ttl.
+        if (lenient) {
+            // Sync with dataState
+            sortedMapIterator.remove();
+            LOG.warn(STATE_CLEARED_WARN_MSG);
+        } else {
+            throw new RuntimeException(STATE_CLEARED_WARN_MSG);
+        }
+    }
+
     private void emitRecordsWithRowNumber(
             SortedMap<RowData, Long> sortedMap,
             RowData sortKey,
@@ -244,12 +256,7 @@ public class RetractableTopNFunction extends AbstractTopNFunction {
             } else if (findsSortKey) {
                 List<RowData> inputs = dataState.get(key);
                 if (inputs == null) {
-                    // Skip the data if it's state is cleared because of state ttl.
-                    if (lenient) {
-                        LOG.warn(STATE_CLEARED_WARN_MSG);
-                    } else {
-                        throw new RuntimeException(STATE_CLEARED_WARN_MSG);
-                    }
+                    processStateStaled(iterator);
                 } else {
                     int i = 0;
                     while (i < inputs.size() && isInRankEnd(currentRank)) {
@@ -294,12 +301,7 @@ public class RetractableTopNFunction extends AbstractTopNFunction {
             } else if (findsSortKey) {
                 List<RowData> inputs = dataState.get(key);
                 if (inputs == null) {
-                    // Skip the data if it's state is cleared because of state ttl.
-                    if (lenient) {
-                        LOG.warn(STATE_CLEARED_WARN_MSG);
-                    } else {
-                        throw new RuntimeException(STATE_CLEARED_WARN_MSG);
-                    }
+                    processStateStaled(iterator);
                 } else {
                     long count = entry.getValue();
                     // gets the rank of last record with same sortKey
@@ -346,12 +348,7 @@ public class RetractableTopNFunction extends AbstractTopNFunction {
             if (!findsSortKey && key.equals(sortKey)) {
                 List<RowData> inputs = dataState.get(key);
                 if (inputs == null) {
-                    // Skip the data if it's state is cleared because of state ttl.
-                    if (lenient) {
-                        LOG.warn(STATE_CLEARED_WARN_MSG);
-                    } else {
-                        throw new RuntimeException(STATE_CLEARED_WARN_MSG);
-                    }
+                    processStateStaled(iterator);
                 } else {
                     Iterator<RowData> inputIter = inputs.iterator();
                     while (inputIter.hasNext() && isInRankEnd(currentRank)) {
@@ -375,14 +372,18 @@ public class RetractableTopNFunction extends AbstractTopNFunction {
                 }
             } else if (findsSortKey) {
                 List<RowData> inputs = dataState.get(key);
-                int i = 0;
-                while (i < inputs.size() && isInRankEnd(currentRank)) {
-                    RowData currentRow = inputs.get(i);
-                    collectUpdateBefore(out, prevRow, currentRank);
-                    collectUpdateAfter(out, currentRow, currentRank);
-                    prevRow = currentRow;
-                    currentRank += 1;
-                    i++;
+                if (inputs == null) {
+                    processStateStaled(iterator);
+                } else {
+                    int i = 0;
+                    while (i < inputs.size() && isInRankEnd(currentRank)) {
+                        RowData currentRow = inputs.get(i);
+                        collectUpdateBefore(out, prevRow, currentRank);
+                        collectUpdateAfter(out, currentRow, currentRank);
+                        prevRow = currentRow;
+                        currentRank += 1;
+                        i++;
+                    }
                 }
             } else {
                 currentRank += entry.getValue();
@@ -417,12 +418,7 @@ public class RetractableTopNFunction extends AbstractTopNFunction {
             if (!findsSortKey && key.equals(sortKey)) {
                 List<RowData> inputs = dataState.get(key);
                 if (inputs == null) {
-                    // Skip the data if it's state is cleared because of state ttl.
-                    if (lenient) {
-                        LOG.warn(STATE_CLEARED_WARN_MSG);
-                    } else {
-                        throw new RuntimeException(STATE_CLEARED_WARN_MSG);
-                    }
+                    processStateStaled(iterator);
                 } else {
                     Iterator<RowData> inputIter = inputs.iterator();
                     while (inputIter.hasNext() && isInRankEnd(nextRank)) {
@@ -455,9 +451,13 @@ public class RetractableTopNFunction extends AbstractTopNFunction {
                     // sends the record if there is a record recently upgrades to Top-N
                     int index = Long.valueOf(rankEnd - nextRank).intValue();
                     List<RowData> inputs = dataState.get(key);
-                    RowData toAdd = inputs.get(index);
-                    collectInsert(out, toAdd);
-                    break;
+                    if (inputs == null) {
+                        processStateStaled(iterator);
+                    } else {
+                        RowData toAdd = inputs.get(index);
+                        collectInsert(out, toAdd);
+                        break;
+                    }
                 }
             } else {
                 nextRank += entry.getValue();

--- a/flink-table/flink-table-runtime/src/main/java/org/apache/flink/table/runtime/operators/rank/UpdatableTopNFunction.java
+++ b/flink-table/flink-table-runtime/src/main/java/org/apache/flink/table/runtime/operators/rank/UpdatableTopNFunction.java
@@ -32,6 +32,8 @@ import org.apache.flink.runtime.state.FunctionInitializationContext;
 import org.apache.flink.runtime.state.FunctionSnapshotContext;
 import org.apache.flink.streaming.api.checkpoint.CheckpointedFunction;
 import org.apache.flink.table.data.RowData;
+import org.apache.flink.table.data.conversion.DataStructureConverter;
+import org.apache.flink.table.data.conversion.RowRowConverter;
 import org.apache.flink.table.runtime.generated.GeneratedRecordComparator;
 import org.apache.flink.table.runtime.keyselector.RowDataKeySelector;
 import org.apache.flink.table.runtime.typeutils.InternalTypeInfo;
@@ -74,6 +76,13 @@ public class UpdatableTopNFunction extends AbstractTopNFunction implements Check
 
     private final InternalTypeInfo<RowData> rowKeyType;
     private final long cacheSize;
+
+    // flag to skip records with non-exist error instead to fail, true by default.
+    private final boolean lenient = true;
+
+    // data converter for logging only.
+    private transient DataStructureConverter rowConverter;
+    private transient DataStructureConverter sortKeyConverter;
 
     // a map state stores mapping from row key to record which is in topN
     // in tuple2, f0 is the record row, f1 is the index in the list of the same sort_key
@@ -137,6 +146,14 @@ public class UpdatableTopNFunction extends AbstractTopNFunction implements Check
                 "Top{} operator is using LRU caches key-size: {}",
                 getDefaultTopNSize(),
                 lruCacheSize);
+
+        this.rowConverter = RowRowConverter.create(inputRowType.getDataType());
+        this.sortKeyConverter =
+                RowRowConverter.create(
+                        ((RowDataKeySelector) sortKeySelector).getProducedType().getDataType());
+
+        rowConverter.open(getRuntimeContext().getUserCodeClassLoader());
+        sortKeyConverter.open(getRuntimeContext().getUserCodeClassLoader());
 
         TupleTypeInfo<Tuple2<RowData, Integer>> valueTypeInfo =
                 new TupleTypeInfo<>(inputRowType, Types.INT);
@@ -249,7 +266,8 @@ public class UpdatableTopNFunction extends AbstractTopNFunction implements Check
             // the new sort key must be higher than old sort key, this is guaranteed by rules
             RankRow oldRow = rowKeyMap.get(rowKey);
             RowData oldSortKey = sortKeySelector.getKey(oldRow.row);
-            if (oldSortKey.equals(sortKey)) {
+            int compare = sortKeyComparator.compare(sortKey, oldSortKey);
+            if (compare == 0) {
                 // sort key is not changed, so the rank is the same, only output the row
                 Tuple2<Integer, Integer> rankAndInnerRank = rowNumber(sortKey, rowKey, buffer);
                 int rank = rankAndInnerRank.f0;
@@ -258,20 +276,47 @@ public class UpdatableTopNFunction extends AbstractTopNFunction implements Check
                 collectUpdateBefore(out, oldRow.row, rank); // retract old record
                 collectUpdateAfter(out, inputRow, rank);
                 return;
+            } else {
+                Tuple2<Integer, Integer> oldRankAndInnerRank =
+                        rowNumber(oldSortKey, rowKey, buffer);
+                int oldRank = oldRankAndInnerRank.f0;
+                // remove old sort key
+                buffer.remove(oldSortKey, rowKey);
+                // add new sort key
+                int size = buffer.put(sortKey, rowKey);
+                rowKeyMap.put(rowKey, new RankRow(inputRowSer.copy(inputRow), size, true));
+                // update inner rank of records under the old sort key
+                updateInnerRank(oldSortKey);
+
+                if (compare < 0) {
+                    // sortKey is higher than oldSortKey
+                    emitRecordsWithRowNumber(sortKey, inputRow, out, oldSortKey, oldRow, oldRank);
+                } else {
+                    String inputRowStr = rowConverter.toExternal(inputRow).toString();
+                    String errorMsg =
+                            String.format(
+                                    "The input retract record:{%s}'s sort key: %s is lower than old"
+                                            + " sort key: %s, this break the monotonicity on sort key field"
+                                            + " which is guaranteed by the sql semantic. It's highly "
+                                            + "possible upstream stateful operator has shorter state ttl "
+                                            + "than the stream records is that cause the staled record "
+                                            + "cleared by state ttl.",
+                                    inputRowStr,
+                                    sortKeyConverter.toExternal(sortKey).toString(),
+                                    sortKeyConverter.toExternal(oldSortKey).toString());
+                    if (lenient) {
+                        LOG.warn(errorMsg);
+                        Tuple2<Integer, Integer> newRankAndInnerRank =
+                                rowNumber(sortKey, rowKey, buffer);
+                        int newRank = newRankAndInnerRank.f0;
+                        // affect rank range: [oldRank, newRank]
+                        emitRecordsWithRowNumberIgnoreStateError(
+                                inputRow, newRank, oldRow, oldRank, out);
+                    } else {
+                        throw new RuntimeException(errorMsg);
+                    }
+                }
             }
-
-            Tuple2<Integer, Integer> oldRankAndInnerRank = rowNumber(oldSortKey, rowKey, buffer);
-            int oldRank = oldRankAndInnerRank.f0;
-            // remove old sort key
-            buffer.remove(oldSortKey, rowKey);
-            // add new sort key
-            int size = buffer.put(sortKey, rowKey);
-            rowKeyMap.put(rowKey, new RankRow(inputRowSer.copy(inputRow), size, true));
-            // update inner rank of records under the old sort key
-            updateInnerRank(oldSortKey);
-
-            // emit records
-            emitRecordsWithRowNumber(sortKey, inputRow, out, oldSortKey, oldRow, oldRank);
         } else if (checkSortKeyInBufferRange(sortKey, buffer)) {
             // it is a new record but is in the topN, insert sort key into buffer
             int size = buffer.put(sortKey, rowKey);
@@ -310,6 +355,37 @@ public class UpdatableTopNFunction extends AbstractTopNFunction implements Check
                 rowKey);
         throw new RuntimeException(
                 "Failed to find the sortKey, rowkey in the buffer. This should never happen");
+    }
+
+    private void emitRecordsWithRowNumberIgnoreStateError(
+            RowData newRow, int newRank, RankRow oldRow, int oldRank, Collector<RowData> out) {
+        Iterator<Map.Entry<RowData, Collection<RowData>>> iterator = buffer.entrySet().iterator();
+        int currentRank = 0;
+        RowData currentRow = null;
+
+        // emit UB of the old row first
+        collectUpdateBefore(out, oldRow.row, oldRank);
+        // update all other affected rank rows
+        affected:
+        while (iterator.hasNext()) {
+            Map.Entry<RowData, Collection<RowData>> entry = iterator.next();
+            Collection<RowData> rowKeys = entry.getValue();
+            Iterator<RowData> rowKeyIter = rowKeys.iterator();
+            while (rowKeyIter.hasNext()) {
+                RowData rowKey = rowKeyIter.next();
+                currentRank += 1;
+                currentRow = rowKeyMap.get(rowKey).row;
+                if (currentRank == newRank) {
+                    break affected;
+                }
+                if (oldRank <= currentRank) {
+                    collectUpdateBefore(out, currentRow, currentRank + 1);
+                    collectUpdateAfter(out, currentRow, currentRank);
+                }
+            }
+        }
+        // at last emit UA of the new row
+        collectUpdateAfter(out, newRow, newRank);
     }
 
     private void emitRecordsWithRowNumber(RowData sortKey, RowData inputRow, Collector<RowData> out)


### PR DESCRIPTION
This pr cherry-pick FLINK-24704 & FLINK-24654  from master to release-1.14

## What is the purpose of the change

Fix the exception when the input record loses monotonicity on the sort key field of UpdatableTopNFunction

## Verifying this change

This change is already covered by RankHarnessTest

## Does this pull request potentially affect one of the following parts:

    - Dependencies (does it add or upgrade a dependency): (no)
    - The public API, i.e., is any changed class annotated with @Public(Evolving): (no)
    - The serializers: (no )
    - The runtime per-record code paths (performance sensitive): (no)
    - Anything that affects deployment or recovery: JobManager (and its components), Checkpointing, Kubernetes/Yarn, ZooKeeper: (no)
    - The S3 file system connector: (no)

## Documentation

  - Does this pull request introduce a new feature? (no)
