### PR TITLE
[FLINK-24489][CEP] The size of entryCache & eventsBufferCache in the SharedBuffer should be defined with a threshold to limit the number of the elements in the cache

### DIFF
--- a/docs/content.zh/docs/libs/cep.md
+++ b/docs/content.zh/docs/libs/cep.md
@@ -1635,6 +1635,14 @@ public interface TimeContext {
 使用`ProcessingTime`时，这个值等于事件进入CEP算子的时间点（在`PatternProcessFunction`中是匹配产生的时间）。
 这意味着多次调用这个方法得到的值是一致的。
 
+## 可选的参数设置
+
+用于配置 Flink CEP 的 `SharedBuffer` 缓存容量的选项。它可以加快 CEP 算子的处理速度，并限制内存中缓存的元素数量。
+
+<span class="label label-info">Note</span> 仅当 `state.backend` 设置为 `rocksdb` 时限制内存使用才有效，这会将超过缓存数量的元素传输到 `rocksdb` 状态存储而不是内存状态存储。当 `state.backend` 设置为 `rocksdb` 时，这些配置项有助于限制内存。相比之下，当 `state.backend` 设置为非 `rocksdb` 时，缓存会导致性能下降。与使用 `Map` 实现的旧缓存相比，状态部分将包含更多从 `guava-cache` 换出的元素，这将使得 `copy on write` 时的状态处理增加一些开销。
+
+{{< generated/cep_cache_configuration >}}
+
 ## 例子
 
 下面的例子在一个分片的`Events`流上检测模式`start, middle(name = "error") -> end(name = "critical")`。

--- a/docs/content/docs/libs/cep.md
+++ b/docs/content/docs/libs/cep.md
@@ -1508,6 +1508,16 @@ Call to `TimeContext#currentProcessingTime` always gives you the value of curren
 In case of `TimeContext#timestamp()` the returned value is equal to assigned timestamp in case of `EventTime`. In `ProcessingTime` this will equal to the point of time when said event entered
 cep operator (or when the match was generated in case of `PatternProcessFunction`). This means that the value will be consistent across multiple calls to that method.
 
+## Optional Configuration
+
+Options to configure the cache capacity of Flink CEP `SharedBuffer`.
+It could accelerate the CEP operate process speed and limit the number of elements of cache in pure memory. 
+
+<span class="label label-info">Note</span> It's only effective to limit usage of memory when `state.backend` was set as `rocksdb`, which would transport the elements exceeded the number of the cache into the rocksdb state storage instead of memory state storage.
+The configuration items are helpful for memory limitation when the `state.backend` is set as rocksdb. By contrast，when the `state.backend` is set as not `rocksdb`, the cache would cause performance decreased. Compared with old cache implemented with `Map`, the state part will contain more elements swapped out from new guava-cache, which would make it heavier to `copy on write` for state.
+
+{{< generated/cep_cache_configuration >}}
+
 ## Examples
 
 The following example detects the pattern `start, middle(name = "error") -> end(name = "critical")` on a keyed data

--- a/docs/layouts/shortcodes/generated/cep_cache_configuration.html
+++ b/docs/layouts/shortcodes/generated/cep_cache_configuration.html
@@ -1,0 +1,30 @@
+<table class="configuration table table-bordered">
+    <thead>
+        <tr>
+            <th class="text-left" style="width: 20%">Key</th>
+            <th class="text-left" style="width: 15%">Default</th>
+            <th class="text-left" style="width: 10%">Type</th>
+            <th class="text-left" style="width: 55%">Description</th>
+        </tr>
+    </thead>
+    <tbody>
+        <tr>
+            <td><h5>pipeline.cep.sharedbuffer.cache.entry-slots</h5></td>
+            <td style="word-wrap: break-word;">1024</td>
+            <td>Integer</td>
+            <td>The Config option to set the maximum element number the entryCache of SharedBuffer could hold. And it could accelerate the CEP operate process speed with state.And it could accelerate the CEP operate process speed and limit the capacity of cache in pure memory. Note: It's only effective to limit usage of memory when 'state.backend' was set as 'rocksdb', which would transport the elements exceeded the number of the cache into the rocksdb state storage instead of memory state storage.</td>
+        </tr>
+        <tr>
+            <td><h5>pipeline.cep.sharedbuffer.cache.event-slots</h5></td>
+            <td style="word-wrap: break-word;">1024</td>
+            <td>Integer</td>
+            <td>The Config option to set the maximum element number the eventsBufferCache of SharedBuffer could hold. And it could accelerate the CEP operate process speed and limit the capacity of cache in pure memory. Note: It's only effective to limit usage of memory when 'state.backend' was set as 'rocksdb', which would transport the elements exceeded the number of the cache into the rocksdb state storage instead of memory state storage.</td>
+        </tr>
+        <tr>
+            <td><h5>pipeline.cep.sharedbuffer.cache.statistics-interval</h5></td>
+            <td style="word-wrap: break-word;">30 min</td>
+            <td>Duration</td>
+            <td>The interval to log the information of cache state statistics in CEP operator.</td>
+        </tr>
+    </tbody>
+</table>

--- a/flink-docs/pom.xml
+++ b/flink-docs/pom.xml
@@ -127,6 +127,12 @@ under the License.
 		</dependency>
 
 		<dependency>
+			<groupId>org.apache.flink</groupId>
+			<artifactId>flink-cep</artifactId>
+			<version>${project.version}</version>
+		</dependency>
+
+		<dependency>
 			<groupId>org.apache.logging.log4j</groupId>
 			<artifactId>log4j-slf4j-impl</artifactId>
 			<scope>compile</scope>

--- a/flink-docs/src/main/java/org/apache/flink/docs/configuration/ConfigOptionsDocGenerator.java
+++ b/flink-docs/src/main/java/org/apache/flink/docs/configuration/ConfigOptionsDocGenerator.java
@@ -101,7 +101,9 @@ public class ConfigOptionsDocGenerator {
                         "org.apache.flink.connector.pulsar.common.config"),
                 new OptionsClassLocation(
                         "flink-connectors/flink-connector-pulsar",
-                        "org.apache.flink.connector.pulsar.source")
+                        "org.apache.flink.connector.pulsar.source"),
+                new OptionsClassLocation(
+                        "flink-libraries/flink-cep", "org.apache.flink.cep.configuration")
             };
 
     static final Set<String> EXCLUSIONS =
@@ -112,7 +114,8 @@ public class ConfigOptionsDocGenerator {
                             "org.apache.flink.configuration.ConfigOptions",
                             "org.apache.flink.streaming.api.environment.CheckpointConfig",
                             "org.apache.flink.contrib.streaming.state.PredefinedOptions",
-                            "org.apache.flink.python.PythonConfig"));
+                            "org.apache.flink.python.PythonConfig",
+                            "org.apache.flink.cep.configuration.SharedBufferCacheConfig"));
 
     static final String DEFAULT_PATH_PREFIX = "src/main/java";
 

--- a/flink-libraries/flink-cep/src/main/java/org/apache/flink/cep/configuration/CEPCacheOptions.java
+++ b/flink-libraries/flink-cep/src/main/java/org/apache/flink/cep/configuration/CEPCacheOptions.java
@@ -1,0 +1,65 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.flink.cep.configuration;
+
+import org.apache.flink.configuration.ConfigOption;
+import org.apache.flink.configuration.ConfigOptions;
+import org.apache.flink.util.TimeUtils;
+
+import java.time.Duration;
+
+/** CEP Cache Options. */
+public class CEPCacheOptions {
+
+    private CEPCacheOptions() {}
+
+    private static final String COMMON_HINT =
+            "And it could accelerate the CEP operate process "
+                    + "speed and limit the capacity of cache in pure memory. Note: It's only effective to "
+                    + "limit usage of memory when 'state.backend' was set as 'rocksdb', which would "
+                    + "transport the elements exceeded the number of the cache into the rocksdb state "
+                    + "storage instead of memory state storage.";
+
+    public static final ConfigOption<Integer> CEP_SHARED_BUFFER_EVENT_CACHE_SLOTS =
+            ConfigOptions.key("pipeline.cep.sharedbuffer.cache.event-slots")
+                    .intType()
+                    .defaultValue(1024)
+                    .withDescription(
+                            "The Config option to set the maximum element number the "
+                                    + "eventsBufferCache of SharedBuffer could hold. "
+                                    + COMMON_HINT);
+
+    public static final ConfigOption<Integer> CEP_SHARED_BUFFER_ENTRY_CACHE_SLOTS =
+            ConfigOptions.key("pipeline.cep.sharedbuffer.cache.entry-slots")
+                    .intType()
+                    .defaultValue(1024)
+                    .withDescription(
+                            "The Config option to set the maximum element number the entryCache"
+                                    + " of SharedBuffer could hold. And it could accelerate the"
+                                    + " CEP operate process speed with state."
+                                    + COMMON_HINT);
+
+    public static final ConfigOption<Duration> CEP_CACHE_STATISTICS_INTERVAL =
+            ConfigOptions.key("pipeline.cep.sharedbuffer.cache.statistics-interval")
+                    .durationType()
+                    .defaultValue(TimeUtils.parseDuration("30 min"))
+                    .withDescription(
+                            "The interval to log the information of cache state statistics in "
+                                    + "CEP operator.");
+}

--- a/flink-libraries/flink-cep/src/main/java/org/apache/flink/cep/configuration/SharedBufferCacheConfig.java
+++ b/flink-libraries/flink-cep/src/main/java/org/apache/flink/cep/configuration/SharedBufferCacheConfig.java
@@ -1,0 +1,70 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.flink.cep.configuration;
+
+import org.apache.flink.configuration.ReadableConfig;
+
+import java.io.Serializable;
+import java.time.Duration;
+
+/** Configuration immutable class. */
+public final class SharedBufferCacheConfig implements Serializable {
+    private final int eventsBufferCacheSlots;
+    private final int entryCacheSlots;
+    private final Duration cacheStatisticsInterval;
+
+    public int getEventsBufferCacheSlots() {
+        return eventsBufferCacheSlots;
+    }
+
+    public int getEntryCacheSlots() {
+        return entryCacheSlots;
+    }
+
+    public Duration getCacheStatisticsInterval() {
+        return cacheStatisticsInterval;
+    }
+
+    public SharedBufferCacheConfig() {
+        this.cacheStatisticsInterval = CEPCacheOptions.CEP_CACHE_STATISTICS_INTERVAL.defaultValue();
+        this.entryCacheSlots = CEPCacheOptions.CEP_SHARED_BUFFER_ENTRY_CACHE_SLOTS.defaultValue();
+        this.eventsBufferCacheSlots =
+                CEPCacheOptions.CEP_SHARED_BUFFER_EVENT_CACHE_SLOTS.defaultValue();
+    }
+
+    public SharedBufferCacheConfig(
+            final int eventsBufferCacheSlots,
+            final int entryCacheSlots,
+            final Duration cacheStatisticsInterval) {
+        this.cacheStatisticsInterval = cacheStatisticsInterval;
+        this.entryCacheSlots = entryCacheSlots;
+        this.eventsBufferCacheSlots = eventsBufferCacheSlots;
+    }
+
+    public static SharedBufferCacheConfig of(ReadableConfig readableConfig) {
+        int eventsBufferCacheSlots =
+                readableConfig.get(CEPCacheOptions.CEP_SHARED_BUFFER_EVENT_CACHE_SLOTS);
+        int entryCacheSlots =
+                readableConfig.get(CEPCacheOptions.CEP_SHARED_BUFFER_ENTRY_CACHE_SLOTS);
+        Duration cacheStatisticsInterval =
+                readableConfig.get(CEPCacheOptions.CEP_CACHE_STATISTICS_INTERVAL);
+        return new SharedBufferCacheConfig(
+                eventsBufferCacheSlots, entryCacheSlots, cacheStatisticsInterval);
+    }
+}

--- a/flink-libraries/flink-cep/src/main/java/org/apache/flink/cep/nfa/sharedbuffer/SharedBuffer.java
+++ b/flink-libraries/flink-cep/src/main/java/org/apache/flink/cep/nfa/sharedbuffer/SharedBuffer.java
@@ -26,6 +26,7 @@ import org.apache.flink.api.common.state.ValueState;
 import org.apache.flink.api.common.typeutils.TypeSerializer;
 import org.apache.flink.api.common.typeutils.base.IntSerializer;
 import org.apache.flink.api.common.typeutils.base.LongSerializer;
+import org.apache.flink.cep.configuration.SharedBufferCacheConfig;
 import org.apache.flink.cep.nfa.DeweyNumber;
 import org.apache.flink.cep.nfa.NFAState;
 import org.apache.flink.runtime.state.KeyedStateBackend;
@@ -33,11 +34,20 @@ import org.apache.flink.runtime.state.VoidNamespace;
 import org.apache.flink.runtime.state.VoidNamespaceSerializer;
 import org.apache.flink.util.WrappingRuntimeException;
 
+import org.apache.flink.shaded.guava30.com.google.common.cache.Cache;
+import org.apache.flink.shaded.guava30.com.google.common.cache.CacheBuilder;
+import org.apache.flink.shaded.guava30.com.google.common.cache.RemovalCause;
+import org.apache.flink.shaded.guava30.com.google.common.cache.RemovalListener;
 import org.apache.flink.shaded.guava30.com.google.common.collect.Iterables;
 
-import java.util.HashMap;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
 import java.util.Iterator;
 import java.util.Map;
+import java.util.Objects;
+import java.util.Timer;
+import java.util.TimerTask;
 
 /**
  * A shared buffer implementation which stores values under according state. Additionally, the
@@ -61,10 +71,12 @@ import java.util.Map;
  */
 public class SharedBuffer<V> {
 
-    private static final String legacyEntriesStateName = "sharedBuffer-entries";
-    private static final String entriesStateName = "sharedBuffer-entries-with-lockable-edges";
-    private static final String eventsStateName = "sharedBuffer-events";
-    private static final String eventsCountStateName = "sharedBuffer-events-count";
+    private static final Logger LOG = LoggerFactory.getLogger(SharedBuffer.class);
+
+    private static final String LEGACY_ENTRIES_STATE_NAME = "sharedBuffer-entries";
+    private static final String ENTRIES_STATE_NAME = "sharedBuffer-entries-with-lockable-edges";
+    private static final String EVENTS_STATE_NAME = "sharedBuffer-events";
+    private static final String EVENTS_COUNT_STATE_NAME = "sharedBuffer-events-count";
 
     private final MapState<EventId, Lockable<V>> eventsBuffer;
     /** The number of events seen so far in the stream per timestamp. */
@@ -73,23 +85,33 @@ public class SharedBuffer<V> {
     private final MapState<NodeId, Lockable<SharedBufferNode>> entries;
 
     /** The cache of eventsBuffer State. */
-    private final Map<EventId, Lockable<V>> eventsBufferCache = new HashMap<>();
+    private final Cache<EventId, Lockable<V>> eventsBufferCache;
 
     /** The cache of sharedBufferNode. */
-    private final Map<NodeId, Lockable<SharedBufferNode>> entryCache = new HashMap<>();
+    private final Cache<NodeId, Lockable<SharedBufferNode>> entryCache;
 
+    private final Timer cacheStatisticsTimer;
+
+    @VisibleForTesting
     public SharedBuffer(KeyedStateStore stateStore, TypeSerializer<V> valueSerializer) {
+        this(stateStore, valueSerializer, new SharedBufferCacheConfig());
+    }
+
+    public SharedBuffer(
+            KeyedStateStore stateStore,
+            TypeSerializer<V> valueSerializer,
+            SharedBufferCacheConfig cacheConfig) {
         this.eventsBuffer =
                 stateStore.getMapState(
                         new MapStateDescriptor<>(
-                                eventsStateName,
+                                EVENTS_STATE_NAME,
                                 EventId.EventIdSerializer.INSTANCE,
                                 new Lockable.LockableTypeSerializer<>(valueSerializer)));
 
         this.entries =
                 stateStore.getMapState(
                         new MapStateDescriptor<>(
-                                entriesStateName,
+                                ENTRIES_STATE_NAME,
                                 new NodeId.NodeIdSerializer(),
                                 new Lockable.LockableTypeSerializer<>(
                                         new SharedBufferNodeSerializer())));
@@ -97,9 +119,65 @@ public class SharedBuffer<V> {
         this.eventsCount =
                 stateStore.getMapState(
                         new MapStateDescriptor<>(
-                                eventsCountStateName,
+                                EVENTS_COUNT_STATE_NAME,
                                 LongSerializer.INSTANCE,
                                 IntSerializer.INSTANCE));
+
+        // set the events buffer cache and strategy of exchanging out
+        this.eventsBufferCache =
+                CacheBuilder.newBuilder()
+                        .maximumSize(cacheConfig.getEventsBufferCacheSlots())
+                        .removalListener(
+                                (RemovalListener<EventId, Lockable<V>>)
+                                        removalNotification -> {
+                                            if (RemovalCause.SIZE
+                                                    == removalNotification.getCause()) {
+                                                try {
+                                                    eventsBuffer.put(
+                                                            removalNotification.getKey(),
+                                                            removalNotification.getValue());
+                                                } catch (Exception e) {
+                                                    LOG.error(
+                                                            "Error in putting value into eventsBuffer.",
+                                                            e);
+                                                }
+                                            }
+                                        })
+                        .build();
+        // set the entry cache and strategy of exchanging out
+        this.entryCache =
+                CacheBuilder.newBuilder()
+                        .maximumSize(cacheConfig.getEntryCacheSlots())
+                        .removalListener(
+                                (RemovalListener<NodeId, Lockable<SharedBufferNode>>)
+                                        removalNotification -> {
+                                            if (RemovalCause.SIZE
+                                                    == removalNotification.getCause()) {
+                                                try {
+                                                    entries.put(
+                                                            removalNotification.getKey(),
+                                                            removalNotification.getValue());
+                                                } catch (Exception e) {
+                                                    LOG.error(
+                                                            "Error in putting value into entries.",
+                                                            e);
+                                                }
+                                            }
+                                        })
+                        .build();
+        cacheStatisticsTimer = new Timer();
+        cacheStatisticsTimer.schedule(
+                new TimerTask() {
+                    @Override
+                    public void run() {
+                        LOG.info(
+                                "Statistics details of eventsBufferCache: {}, statistics details of entryCache: {}.",
+                                eventsBufferCache.stats(),
+                                entryCache.stats());
+                    }
+                },
+                cacheConfig.getCacheStatisticsInterval().toMillis(),
+                cacheConfig.getCacheStatisticsInterval().toMillis());
     }
 
     public void migrateOldState(
@@ -109,7 +187,7 @@ public class SharedBuffer<V> {
                 VoidNamespace.INSTANCE,
                 VoidNamespaceSerializer.INSTANCE,
                 new MapStateDescriptor<>(
-                        legacyEntriesStateName,
+                        LEGACY_ENTRIES_STATE_NAME,
                         new NodeId.NodeIdSerializer(),
                         new Lockable.LockableTypeSerializer<>(
                                 new SharedBufferNode.SharedBufferNodeSerializer())),
@@ -215,8 +293,14 @@ public class SharedBuffer<V> {
      * @throws Exception Thrown if the system cannot access the state.
      */
     public boolean isEmpty() throws Exception {
-        return Iterables.isEmpty(eventsBufferCache.keySet())
+        return Iterables.isEmpty(eventsBufferCache.asMap().keySet())
                 && Iterables.isEmpty(eventsBuffer.keys());
+    }
+
+    public void releaseCacheStatisticsTimer() {
+        if (cacheStatisticsTimer != null) {
+            cacheStatisticsTimer.cancel();
+        }
     }
 
     /**
@@ -245,7 +329,7 @@ public class SharedBuffer<V> {
      * @param eventId id of the event
      */
     void removeEvent(EventId eventId) throws Exception {
-        this.eventsBufferCache.remove(eventId);
+        this.eventsBufferCache.invalidate(eventId);
         this.eventsBuffer.remove(eventId);
     }
 
@@ -255,7 +339,7 @@ public class SharedBuffer<V> {
      * @param nodeId id of the event
      */
     void removeEntry(NodeId nodeId) throws Exception {
-        this.entryCache.remove(nodeId);
+        this.entryCache.invalidate(nodeId);
         this.entries.remove(nodeId);
     }
 
@@ -266,15 +350,20 @@ public class SharedBuffer<V> {
      * @return SharedBufferNode
      */
     Lockable<SharedBufferNode> getEntry(NodeId nodeId) {
-        return entryCache.computeIfAbsent(
-                nodeId,
-                id -> {
-                    try {
-                        return entries.get(id);
-                    } catch (Exception ex) {
-                        throw new WrappingRuntimeException(ex);
-                    }
-                });
+        try {
+            Lockable<SharedBufferNode> lockableFromCache = entryCache.getIfPresent(nodeId);
+            if (Objects.nonNull(lockableFromCache)) {
+                return lockableFromCache;
+            } else {
+                Lockable<SharedBufferNode> lockableFromState = entries.get(nodeId);
+                if (Objects.nonNull(lockableFromState)) {
+                    entryCache.put(nodeId, lockableFromState);
+                }
+                return lockableFromState;
+            }
+        } catch (Exception ex) {
+            throw new WrappingRuntimeException(ex);
+        }
     }
 
     /**
@@ -284,15 +373,20 @@ public class SharedBuffer<V> {
      * @return event
      */
     Lockable<V> getEvent(EventId eventId) {
-        return eventsBufferCache.computeIfAbsent(
-                eventId,
-                id -> {
-                    try {
-                        return eventsBuffer.get(id);
-                    } catch (Exception ex) {
-                        throw new WrappingRuntimeException(ex);
-                    }
-                });
+        try {
+            Lockable<V> lockableFromCache = eventsBufferCache.getIfPresent(eventId);
+            if (Objects.nonNull(lockableFromCache)) {
+                return lockableFromCache;
+            } else {
+                Lockable<V> lockableFromState = eventsBuffer.get(eventId);
+                if (Objects.nonNull(lockableFromState)) {
+                    eventsBufferCache.put(eventId, lockableFromState);
+                }
+                return lockableFromState;
+            }
+        } catch (Exception ex) {
+            throw new WrappingRuntimeException(ex);
+        }
     }
 
     /**
@@ -301,13 +395,13 @@ public class SharedBuffer<V> {
      * @throws Exception Thrown if the system cannot access the state.
      */
     void flushCache() throws Exception {
-        if (!entryCache.isEmpty()) {
-            entries.putAll(entryCache);
-            entryCache.clear();
+        if (!entryCache.asMap().isEmpty()) {
+            entries.putAll(entryCache.asMap());
+            entryCache.invalidateAll();
         }
-        if (!eventsBufferCache.isEmpty()) {
-            eventsBuffer.putAll(eventsBufferCache);
-            eventsBufferCache.clear();
+        if (!eventsBufferCache.asMap().isEmpty()) {
+            eventsBuffer.putAll(eventsBufferCache.asMap());
+            eventsBufferCache.invalidateAll();
         }
     }
 
@@ -318,7 +412,7 @@ public class SharedBuffer<V> {
 
     @VisibleForTesting
     public int getEventsBufferCacheSize() {
-        return eventsBufferCache.size();
+        return (int) eventsBufferCache.size();
     }
 
     @VisibleForTesting
@@ -333,6 +427,6 @@ public class SharedBuffer<V> {
 
     @VisibleForTesting
     public int getSharedBufferNodeCacheSize() throws Exception {
-        return entryCache.size();
+        return (int) entryCache.size();
     }
 }

--- a/flink-libraries/flink-cep/src/main/java/org/apache/flink/cep/operator/CepOperator.java
+++ b/flink-libraries/flink-cep/src/main/java/org/apache/flink/cep/operator/CepOperator.java
@@ -30,6 +30,7 @@ import org.apache.flink.api.common.typeutils.base.ListSerializer;
 import org.apache.flink.api.common.typeutils.base.LongSerializer;
 import org.apache.flink.api.java.tuple.Tuple2;
 import org.apache.flink.cep.EventComparator;
+import org.apache.flink.cep.configuration.SharedBufferCacheConfig;
 import org.apache.flink.cep.functions.PatternProcessFunction;
 import org.apache.flink.cep.functions.TimedOutPartialMatchHandler;
 import org.apache.flink.cep.nfa.NFA;
@@ -180,7 +181,11 @@ public class CepOperator<IN, KEY, OUT>
                                 new ValueStateDescriptor<>(
                                         NFA_STATE_NAME, new NFAStateSerializer()));
 
-        partialMatches = new SharedBuffer<>(context.getKeyedStateStore(), inputSerializer);
+        partialMatches =
+                new SharedBuffer<>(
+                        context.getKeyedStateStore(),
+                        inputSerializer,
+                        SharedBufferCacheConfig.of(getOperatorConfig().getConfiguration()));
 
         elementQueueState =
                 context.getKeyedStateStore()
@@ -218,6 +223,9 @@ public class CepOperator<IN, KEY, OUT>
         super.close();
         if (nfa != null) {
             nfa.close();
+        }
+        if (partialMatches != null) {
+            partialMatches.releaseCacheStatisticsTimer();
         }
     }
 

--- a/flink-libraries/flink-cep/src/test/java/org/apache/flink/cep/nfa/NFAIterativeConditionTimeContextTest.java
+++ b/flink-libraries/flink-cep/src/test/java/org/apache/flink/cep/nfa/NFAIterativeConditionTimeContextTest.java
@@ -35,7 +35,7 @@ import static org.apache.flink.cep.utils.EventBuilder.event;
 import static org.apache.flink.cep.utils.NFATestHarness.forPattern;
 import static org.apache.flink.cep.utils.NFATestUtilities.comparePatterns;
 
-/** Tests for accesing time properties from {@link IterativeCondition}. */
+/** Tests for accessing time properties from {@link IterativeCondition}. */
 public class NFAIterativeConditionTimeContextTest extends TestLogger {
 
     @Test

--- a/flink-libraries/flink-cep/src/test/java/org/apache/flink/cep/nfa/sharedbuffer/SharedBufferTest.java
+++ b/flink-libraries/flink-cep/src/test/java/org/apache/flink/cep/nfa/sharedbuffer/SharedBufferTest.java
@@ -19,13 +19,19 @@
 package org.apache.flink.cep.nfa.sharedbuffer;
 
 import org.apache.flink.cep.Event;
+import org.apache.flink.cep.configuration.SharedBufferCacheConfig;
 import org.apache.flink.cep.nfa.DeweyNumber;
 import org.apache.flink.cep.utils.TestSharedBuffer;
 import org.apache.flink.util.TestLogger;
 
 import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.junit.runners.Parameterized;
 
+import java.time.Duration;
 import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.Collection;
 import java.util.HashMap;
 import java.util.Iterator;
 import java.util.LinkedHashMap;
@@ -37,12 +43,22 @@ import static org.junit.Assert.assertFalse;
 import static org.junit.Assert.assertTrue;
 
 /** Tests for {@link SharedBuffer}. */
+@RunWith(Parameterized.class)
 public class SharedBufferTest extends TestLogger {
+
+    @Parameterized.Parameter public SharedBufferCacheConfig cacheConfig;
+
+    @Parameterized.Parameters
+    public static Collection<SharedBufferCacheConfig> prepareSharedBufferCacheConfig() {
+        return Arrays.asList(
+                new SharedBufferCacheConfig(1, 1, Duration.ofSeconds(1L)),
+                new SharedBufferCacheConfig(10240, 10240, Duration.ofSeconds(1L)));
+    }
 
     @Test
     public void testSharedBuffer() throws Exception {
         SharedBuffer<Event> sharedBuffer =
-                TestSharedBuffer.createTestBuffer(Event.createTypeSerializer());
+                TestSharedBuffer.createTestBuffer(Event.createTypeSerializer(), cacheConfig);
         int numberEvents = 8;
         Event[] events = new Event[numberEvents];
         EventId[] eventIds = new EventId[numberEvents];
@@ -161,7 +177,7 @@ public class SharedBufferTest extends TestLogger {
     @Test
     public void testClearingSharedBufferWithMultipleEdgesBetweenEntries() throws Exception {
         SharedBuffer<Event> sharedBuffer =
-                TestSharedBuffer.createTestBuffer(Event.createTypeSerializer());
+                TestSharedBuffer.createTestBuffer(Event.createTypeSerializer(), cacheConfig);
         int numberEvents = 8;
         Event[] events = new Event[numberEvents];
         EventId[] eventIds = new EventId[numberEvents];
@@ -208,7 +224,7 @@ public class SharedBufferTest extends TestLogger {
     @Test
     public void testSharedBufferExtractOrder() throws Exception {
         SharedBuffer<Event> sharedBuffer =
-                TestSharedBuffer.createTestBuffer(Event.createTypeSerializer());
+                TestSharedBuffer.createTestBuffer(Event.createTypeSerializer(), cacheConfig);
         int numberEvents = 5;
         Event[] events = new Event[numberEvents];
         EventId[] eventIds = new EventId[numberEvents];
@@ -268,7 +284,7 @@ public class SharedBufferTest extends TestLogger {
     @Test
     public void testSharedBufferCountersClearing() throws Exception {
         SharedBuffer<Event> sharedBuffer =
-                TestSharedBuffer.createTestBuffer(Event.createTypeSerializer());
+                TestSharedBuffer.createTestBuffer(Event.createTypeSerializer(), cacheConfig);
         int numberEvents = 4;
         Event[] events = new Event[numberEvents];
 
@@ -289,7 +305,7 @@ public class SharedBufferTest extends TestLogger {
     @Test
     public void testSharedBufferAccessor() throws Exception {
         TestSharedBuffer<Event> sharedBuffer =
-                TestSharedBuffer.createTestBuffer(Event.createTypeSerializer());
+                TestSharedBuffer.createTestBuffer(Event.createTypeSerializer(), cacheConfig);
         int numberEvents = 8;
         Event[] events = new Event[numberEvents];
         EventId[] eventIds = new EventId[numberEvents];
@@ -300,7 +316,8 @@ public class SharedBufferTest extends TestLogger {
                 events[i] = new Event(i + 1, "e" + (i + 1), i);
                 eventIds[i] = sharedBufferAccessor.registerEvent(events[i], timestamp);
             }
-            assertEquals(8, sharedBuffer.getEventsBufferCacheSize());
+            int expectedEvents = Math.min(cacheConfig.getEventsBufferCacheSlots(), numberEvents);
+            assertEquals(expectedEvents, sharedBuffer.getEventsBufferCacheSize());
             assertEquals(0, sharedBuffer.getSharedBufferNodeCacheSize());
 
             NodeId start =
@@ -318,8 +335,10 @@ public class SharedBufferTest extends TestLogger {
             sharedBufferAccessor.put(
                     "branching", eventIds[4], b00, DeweyNumber.fromString("1.0.0.0"));
 
-            assertEquals(4, sharedBuffer.getSharedBufferNodeCacheSize());
-            assertEquals(0, sharedBuffer.getSharedBufferNodeSize());
+            int expectedEntries = Math.min(cacheConfig.getEntryCacheSlots(), 4);
+            assertEquals(expectedEntries, sharedBuffer.getSharedBufferNodeCacheSize());
+            System.out.println(expectedEntries);
+            assertEquals(4 - expectedEntries, sharedBuffer.getSharedBufferNodeSize());
 
             sharedBufferAccessor.lockNode(b0, DeweyNumber.fromString("1.0.0"));
 
@@ -342,7 +361,7 @@ public class SharedBufferTest extends TestLogger {
     @Test
     public void testReleaseNodesWithLongPath() throws Exception {
         SharedBuffer<Event> sharedBuffer =
-                TestSharedBuffer.createTestBuffer(Event.createTypeSerializer());
+                TestSharedBuffer.createTestBuffer(Event.createTypeSerializer(), cacheConfig);
 
         final int numberEvents = 100000;
         Event[] events = new Event[numberEvents];

--- a/flink-libraries/flink-cep/src/test/java/org/apache/flink/cep/operator/CEPMigrationTest.java
+++ b/flink-libraries/flink-cep/src/test/java/org/apache/flink/cep/operator/CEPMigrationTest.java
@@ -26,6 +26,7 @@ import org.apache.flink.cep.nfa.NFA;
 import org.apache.flink.cep.nfa.compiler.NFACompiler;
 import org.apache.flink.cep.pattern.Pattern;
 import org.apache.flink.cep.pattern.conditions.SimpleCondition;
+import org.apache.flink.cep.utils.CepOperatorTestUtilities;
 import org.apache.flink.runtime.checkpoint.OperatorSubtaskState;
 import org.apache.flink.streaming.api.watermark.Watermark;
 import org.apache.flink.streaming.api.windowing.time.Time;
@@ -46,7 +47,6 @@ import java.util.List;
 import java.util.Map;
 import java.util.concurrent.ConcurrentLinkedQueue;
 
-import static org.apache.flink.cep.operator.CepOperatorTestUtilities.getKeyedCepOpearator;
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertTrue;
 
@@ -109,7 +109,7 @@ public class CEPMigrationTest {
 
         OneInputStreamOperatorTestHarness<Event, Map<String, List<Event>>> harness =
                 new KeyedOneInputStreamOperatorTestHarness<>(
-                        getKeyedCepOpearator(false, new NFAFactory()),
+                        CepOperatorTestUtilities.getKeyedCepOperator(false, new NFAFactory()),
                         keySelector,
                         BasicTypeInfo.INT_TYPE_INFO);
 
@@ -158,7 +158,7 @@ public class CEPMigrationTest {
 
         OneInputStreamOperatorTestHarness<Event, Map<String, List<Event>>> harness =
                 new KeyedOneInputStreamOperatorTestHarness<>(
-                        getKeyedCepOpearator(false, new NFAFactory()),
+                        CepOperatorTestUtilities.getKeyedCepOperator(false, new NFAFactory()),
                         keySelector,
                         BasicTypeInfo.INT_TYPE_INFO);
 
@@ -222,7 +222,7 @@ public class CEPMigrationTest {
 
             harness =
                     new KeyedOneInputStreamOperatorTestHarness<>(
-                            getKeyedCepOpearator(false, new NFAFactory()),
+                            CepOperatorTestUtilities.getKeyedCepOperator(false, new NFAFactory()),
                             keySelector,
                             BasicTypeInfo.INT_TYPE_INFO);
 
@@ -276,7 +276,7 @@ public class CEPMigrationTest {
 
         OneInputStreamOperatorTestHarness<Event, Map<String, List<Event>>> harness =
                 new KeyedOneInputStreamOperatorTestHarness<>(
-                        getKeyedCepOpearator(false, new NFAFactory()),
+                        CepOperatorTestUtilities.getKeyedCepOperator(false, new NFAFactory()),
                         keySelector,
                         BasicTypeInfo.INT_TYPE_INFO);
 
@@ -323,7 +323,7 @@ public class CEPMigrationTest {
 
         OneInputStreamOperatorTestHarness<Event, Map<String, List<Event>>> harness =
                 new KeyedOneInputStreamOperatorTestHarness<>(
-                        getKeyedCepOpearator(false, new NFAFactory()),
+                        CepOperatorTestUtilities.getKeyedCepOperator(false, new NFAFactory()),
                         keySelector,
                         BasicTypeInfo.INT_TYPE_INFO);
 
@@ -403,7 +403,7 @@ public class CEPMigrationTest {
 
             harness =
                     new KeyedOneInputStreamOperatorTestHarness<>(
-                            getKeyedCepOpearator(false, new NFAFactory()),
+                            CepOperatorTestUtilities.getKeyedCepOperator(false, new NFAFactory()),
                             keySelector,
                             BasicTypeInfo.INT_TYPE_INFO);
 
@@ -456,7 +456,8 @@ public class CEPMigrationTest {
 
         OneInputStreamOperatorTestHarness<Event, Map<String, List<Event>>> harness =
                 new KeyedOneInputStreamOperatorTestHarness<>(
-                        getKeyedCepOpearator(false, new SinglePatternNFAFactory()),
+                        CepOperatorTestUtilities.getKeyedCepOperator(
+                                false, new SinglePatternNFAFactory()),
                         keySelector,
                         BasicTypeInfo.INT_TYPE_INFO);
 
@@ -494,7 +495,8 @@ public class CEPMigrationTest {
 
         OneInputStreamOperatorTestHarness<Event, Map<String, List<Event>>> harness =
                 new KeyedOneInputStreamOperatorTestHarness<>(
-                        getKeyedCepOpearator(false, new SinglePatternNFAFactory()),
+                        CepOperatorTestUtilities.getKeyedCepOperator(
+                                false, new SinglePatternNFAFactory()),
                         keySelector,
                         BasicTypeInfo.INT_TYPE_INFO);
 
@@ -552,7 +554,8 @@ public class CEPMigrationTest {
 
         OneInputStreamOperatorTestHarness<Event, Map<String, List<Event>>> harness =
                 new KeyedOneInputStreamOperatorTestHarness<>(
-                        getKeyedCepOpearator(false, new NFAComplexConditionsFactory()),
+                        CepOperatorTestUtilities.getKeyedCepOperator(
+                                false, new NFAComplexConditionsFactory()),
                         keySelector,
                         BasicTypeInfo.INT_TYPE_INFO);
 
@@ -591,7 +594,8 @@ public class CEPMigrationTest {
 
         OneInputStreamOperatorTestHarness<Event, Map<String, List<Event>>> harness =
                 new KeyedOneInputStreamOperatorTestHarness<>(
-                        getKeyedCepOpearator(false, new NFAComplexConditionsFactory()),
+                        CepOperatorTestUtilities.getKeyedCepOperator(
+                                false, new NFAComplexConditionsFactory()),
                         keySelector,
                         BasicTypeInfo.INT_TYPE_INFO);
 

--- a/flink-libraries/flink-cep/src/test/java/org/apache/flink/cep/operator/CEPOperatorTest.java
+++ b/flink-libraries/flink-cep/src/test/java/org/apache/flink/cep/operator/CEPOperatorTest.java
@@ -38,6 +38,7 @@ import org.apache.flink.cep.pattern.Pattern;
 import org.apache.flink.cep.pattern.conditions.IterativeCondition;
 import org.apache.flink.cep.pattern.conditions.SimpleCondition;
 import org.apache.flink.cep.time.TimerService;
+import org.apache.flink.cep.utils.CepOperatorTestUtilities;
 import org.apache.flink.contrib.streaming.state.RocksDBStateBackend;
 import org.apache.flink.mock.Whitebox;
 import org.apache.flink.runtime.checkpoint.OperatorSubtaskState;
@@ -362,7 +363,7 @@ public class CEPOperatorTest extends TestLogger {
     public void testKeyedCEPOperatorNFAUpdate() throws Exception {
 
         CepOperator<Event, Integer, Map<String, List<Event>>> operator =
-                CepOperatorTestUtilities.getKeyedCepOpearator(true, new SimpleNFAFactory());
+                CepOperatorTestUtilities.getKeyedCepOperator(true, new SimpleNFAFactory());
         OneInputStreamOperatorTestHarness<Event, Map<String, List<Event>>> harness =
                 CepOperatorTestUtilities.getCepTestHarness(operator);
 
@@ -379,7 +380,7 @@ public class CEPOperatorTest extends TestLogger {
             OperatorSubtaskState snapshot = harness.snapshot(0L, 0L);
             harness.close();
 
-            operator = CepOperatorTestUtilities.getKeyedCepOpearator(true, new SimpleNFAFactory());
+            operator = CepOperatorTestUtilities.getKeyedCepOperator(true, new SimpleNFAFactory());
             harness = CepOperatorTestUtilities.getCepTestHarness(operator);
 
             harness.setup();
@@ -390,7 +391,7 @@ public class CEPOperatorTest extends TestLogger {
             OperatorSubtaskState snapshot2 = harness.snapshot(0L, 0L);
             harness.close();
 
-            operator = CepOperatorTestUtilities.getKeyedCepOpearator(true, new SimpleNFAFactory());
+            operator = CepOperatorTestUtilities.getKeyedCepOperator(true, new SimpleNFAFactory());
             harness = CepOperatorTestUtilities.getCepTestHarness(operator);
 
             harness.setup();
@@ -421,7 +422,7 @@ public class CEPOperatorTest extends TestLogger {
         rocksDBStateBackend.setDbStoragePath(rocksDbPath);
 
         CepOperator<Event, Integer, Map<String, List<Event>>> operator =
-                CepOperatorTestUtilities.getKeyedCepOpearator(true, new SimpleNFAFactory());
+                CepOperatorTestUtilities.getKeyedCepOperator(true, new SimpleNFAFactory());
         OneInputStreamOperatorTestHarness<Event, Map<String, List<Event>>> harness =
                 CepOperatorTestUtilities.getCepTestHarness(operator);
 
@@ -440,7 +441,7 @@ public class CEPOperatorTest extends TestLogger {
             OperatorSubtaskState snapshot = harness.snapshot(0L, 0L);
             harness.close();
 
-            operator = CepOperatorTestUtilities.getKeyedCepOpearator(true, new SimpleNFAFactory());
+            operator = CepOperatorTestUtilities.getKeyedCepOperator(true, new SimpleNFAFactory());
             harness = CepOperatorTestUtilities.getCepTestHarness(operator);
 
             rocksDBStateBackend = new RocksDBStateBackend(new MemoryStateBackend());
@@ -454,7 +455,7 @@ public class CEPOperatorTest extends TestLogger {
             OperatorSubtaskState snapshot2 = harness.snapshot(0L, 0L);
             harness.close();
 
-            operator = CepOperatorTestUtilities.getKeyedCepOpearator(true, new SimpleNFAFactory());
+            operator = CepOperatorTestUtilities.getKeyedCepOperator(true, new SimpleNFAFactory());
             harness = CepOperatorTestUtilities.getCepTestHarness(operator);
 
             rocksDBStateBackend = new RocksDBStateBackend(new MemoryStateBackend());
@@ -482,7 +483,7 @@ public class CEPOperatorTest extends TestLogger {
     @Test
     public void testKeyedCEPOperatorNFAUpdateTimes() throws Exception {
         CepOperator<Event, Integer, Map<String, List<Event>>> operator =
-                CepOperatorTestUtilities.getKeyedCepOpearator(true, new SimpleNFAFactory());
+                CepOperatorTestUtilities.getKeyedCepOperator(true, new SimpleNFAFactory());
         OneInputStreamOperatorTestHarness<Event, Map<String, List<Event>>> harness =
                 CepOperatorTestUtilities.getCepTestHarness(operator);
 
@@ -526,7 +527,7 @@ public class CEPOperatorTest extends TestLogger {
         rocksDBStateBackend.setDbStoragePath(rocksDbPath);
 
         CepOperator<Event, Integer, Map<String, List<Event>>> operator =
-                CepOperatorTestUtilities.getKeyedCepOpearator(true, new SimpleNFAFactory());
+                CepOperatorTestUtilities.getKeyedCepOperator(true, new SimpleNFAFactory());
         OneInputStreamOperatorTestHarness<Event, Map<String, List<Event>>> harness =
                 CepOperatorTestUtilities.getCepTestHarness(operator);
 
@@ -678,7 +679,7 @@ public class CEPOperatorTest extends TestLogger {
         Event middle2Event1 = new Event(41, "b", 5.0);
 
         CepOperator<Event, Integer, Map<String, List<Event>>> operator =
-                CepOperatorTestUtilities.getKeyedCepOpearator(false, new ComplexNFAFactory());
+                CepOperatorTestUtilities.getKeyedCepOperator(false, new ComplexNFAFactory());
         OneInputStreamOperatorTestHarness<Event, Map<String, List<Event>>> harness =
                 CepOperatorTestUtilities.getCepTestHarness(operator);
 
@@ -783,7 +784,7 @@ public class CEPOperatorTest extends TestLogger {
                 new OutputTag<Event>("late-data", TypeInformation.of(Event.class));
 
         CepOperator<Event, Integer, Map<String, List<Event>>> operator =
-                CepOperatorTestUtilities.getKeyedCepOpearator(
+                CepOperatorTestUtilities.getKeyedCepOperator(
                         false, new ComplexNFAFactory(), null, lateDataTag);
         try (OneInputStreamOperatorTestHarness<Event, Map<String, List<Event>>> harness =
                 CepOperatorTestUtilities.getCepTestHarness(operator)) {
@@ -991,7 +992,7 @@ public class CEPOperatorTest extends TestLogger {
                                 });
 
         CepOperator<Event, Integer, Map<String, List<Event>>> operator =
-                CepOperatorTestUtilities.getKeyedCepOpearator(
+                CepOperatorTestUtilities.getKeyedCepOperator(
                         false,
                         new NFACompiler.NFAFactory<Event>() {
                             private static final long serialVersionUID = 477082663248051994L;
@@ -1199,13 +1200,13 @@ public class CEPOperatorTest extends TestLogger {
 
     private CepOperator<Event, Integer, Map<String, List<Event>>> getKeyedCepOperator(
             boolean isProcessingTime) {
-        return CepOperatorTestUtilities.getKeyedCepOpearator(isProcessingTime, new NFAFactory());
+        return CepOperatorTestUtilities.getKeyedCepOperator(isProcessingTime, new NFAFactory());
     }
 
     private CepOperator<Event, Integer, Map<String, List<Event>>> getKeyedCepOperatorWithComparator(
             boolean isProcessingTime) {
 
-        return CepOperatorTestUtilities.getKeyedCepOpearator(
+        return CepOperatorTestUtilities.getKeyedCepOperator(
                 isProcessingTime,
                 new NFAFactory(),
                 new org.apache.flink.cep.EventComparator<Event>() {
@@ -1278,7 +1279,7 @@ public class CEPOperatorTest extends TestLogger {
 
     private CepOperator<Event, Integer, Map<String, List<Event>>> getKeyedCepOpearator(
             boolean isProcessingTime) {
-        return CepOperatorTestUtilities.getKeyedCepOpearator(
+        return CepOperatorTestUtilities.getKeyedCepOperator(
                 isProcessingTime, new CEPOperatorTest.NFAFactory());
     }
 

--- a/flink-libraries/flink-cep/src/test/java/org/apache/flink/cep/operator/CEPRescalingTest.java
+++ b/flink-libraries/flink-cep/src/test/java/org/apache/flink/cep/operator/CEPRescalingTest.java
@@ -26,6 +26,7 @@ import org.apache.flink.cep.nfa.NFA;
 import org.apache.flink.cep.nfa.compiler.NFACompiler;
 import org.apache.flink.cep.pattern.Pattern;
 import org.apache.flink.cep.pattern.conditions.SimpleCondition;
+import org.apache.flink.cep.utils.CepOperatorTestUtilities;
 import org.apache.flink.contrib.streaming.state.RocksDBStateBackend;
 import org.apache.flink.runtime.checkpoint.OperatorSubtaskState;
 import org.apache.flink.runtime.state.KeyGroupRangeAssignment;
@@ -43,7 +44,6 @@ import java.util.List;
 import java.util.Map;
 import java.util.Queue;
 
-import static org.apache.flink.cep.operator.CepOperatorTestUtilities.getKeyedCepOpearator;
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertTrue;
 
@@ -420,7 +420,7 @@ public class CEPRescalingTest {
         KeySelector<Event, Integer> keySelector = new TestKeySelector();
         KeyedOneInputStreamOperatorTestHarness<Integer, Event, Map<String, List<Event>>> harness =
                 new KeyedOneInputStreamOperatorTestHarness<>(
-                        getKeyedCepOpearator(false, new NFAFactory()),
+                        CepOperatorTestUtilities.getKeyedCepOperator(false, new NFAFactory()),
                         keySelector,
                         BasicTypeInfo.INT_TYPE_INFO,
                         maxParallelism,

--- a/flink-libraries/flink-cep/src/test/java/org/apache/flink/cep/operator/CepProcessFunctionContextTest.java
+++ b/flink-libraries/flink-cep/src/test/java/org/apache/flink/cep/operator/CepProcessFunctionContextTest.java
@@ -36,7 +36,7 @@ import java.util.List;
 import java.util.Map;
 import java.util.function.Function;
 
-import static org.apache.flink.cep.operator.CepOperatorTestUtilities.getCepTestHarness;
+import static org.apache.flink.cep.utils.CepOperatorTestUtilities.getCepTestHarness;
 import static org.apache.flink.cep.utils.EventBuilder.event;
 import static org.apache.flink.cep.utils.OutputAsserter.assertOutput;
 

--- a/flink-libraries/flink-cep/src/test/java/org/apache/flink/cep/operator/CepRuntimeContextTest.java
+++ b/flink-libraries/flink-cep/src/test/java/org/apache/flink/cep/operator/CepRuntimeContextTest.java
@@ -47,9 +47,9 @@ import org.junit.Test;
 import java.util.List;
 import java.util.Map;
 
-import static org.apache.flink.cep.operator.CepOperatorTestUtilities.getCepTestHarness;
 import static org.apache.flink.cep.operator.CepRuntimeContextTest.MockProcessFunctionAsserter.assertFunction;
 import static org.apache.flink.cep.utils.CepOperatorBuilder.createOperatorForNFA;
+import static org.apache.flink.cep.utils.CepOperatorTestUtilities.getCepTestHarness;
 import static org.apache.flink.cep.utils.EventBuilder.event;
 import static org.hamcrest.core.Is.is;
 import static org.junit.Assert.assertEquals;

--- a/flink-libraries/flink-cep/src/test/java/org/apache/flink/cep/utils/CepOperatorTestUtilities.java
+++ b/flink-libraries/flink-cep/src/test/java/org/apache/flink/cep/utils/CepOperatorTestUtilities.java
@@ -16,7 +16,7 @@
  * limitations under the License.
  */
 
-package org.apache.flink.cep.operator;
+package org.apache.flink.cep.utils;
 
 import org.apache.flink.api.common.typeinfo.BasicTypeInfo;
 import org.apache.flink.api.java.functions.KeySelector;
@@ -24,6 +24,7 @@ import org.apache.flink.cep.Event;
 import org.apache.flink.cep.EventComparator;
 import org.apache.flink.cep.functions.PatternProcessFunction;
 import org.apache.flink.cep.nfa.compiler.NFACompiler;
+import org.apache.flink.cep.operator.CepOperator;
 import org.apache.flink.streaming.util.KeyedOneInputStreamOperatorTestHarness;
 import org.apache.flink.streaming.util.OneInputStreamOperatorTestHarness;
 import org.apache.flink.util.Collector;
@@ -53,21 +54,21 @@ public class CepOperatorTestUtilities {
                 cepOperator, keySelector, BasicTypeInfo.INT_TYPE_INFO);
     }
 
-    public static <K> CepOperator<Event, K, Map<String, List<Event>>> getKeyedCepOpearator(
+    public static <K> CepOperator<Event, K, Map<String, List<Event>>> getKeyedCepOperator(
             boolean isProcessingTime, NFACompiler.NFAFactory<Event> nfaFactory) {
 
-        return getKeyedCepOpearator(isProcessingTime, nfaFactory, null);
+        return getKeyedCepOperator(isProcessingTime, nfaFactory, null);
     }
 
-    public static <K> CepOperator<Event, K, Map<String, List<Event>>> getKeyedCepOpearator(
+    public static <K> CepOperator<Event, K, Map<String, List<Event>>> getKeyedCepOperator(
             boolean isProcessingTime,
             NFACompiler.NFAFactory<Event> nfaFactory,
             EventComparator<Event> comparator) {
 
-        return getKeyedCepOpearator(isProcessingTime, nfaFactory, comparator, null);
+        return getKeyedCepOperator(isProcessingTime, nfaFactory, comparator, null);
     }
 
-    public static <K> CepOperator<Event, K, Map<String, List<Event>>> getKeyedCepOpearator(
+    public static <K> CepOperator<Event, K, Map<String, List<Event>>> getKeyedCepOperator(
             boolean isProcessingTime,
             NFACompiler.NFAFactory<Event> nfaFactory,
             EventComparator<Event> comparator,

--- a/flink-libraries/flink-cep/src/test/java/org/apache/flink/cep/utils/TestSharedBuffer.java
+++ b/flink-libraries/flink-cep/src/test/java/org/apache/flink/cep/utils/TestSharedBuffer.java
@@ -30,6 +30,7 @@ import org.apache.flink.api.common.state.ReducingStateDescriptor;
 import org.apache.flink.api.common.state.ValueState;
 import org.apache.flink.api.common.state.ValueStateDescriptor;
 import org.apache.flink.api.common.typeutils.TypeSerializer;
+import org.apache.flink.cep.configuration.SharedBufferCacheConfig;
 import org.apache.flink.cep.nfa.sharedbuffer.SharedBuffer;
 
 import java.io.IOException;
@@ -48,6 +49,14 @@ public class TestSharedBuffer<V> extends SharedBuffer<V> {
 
     private TestSharedBuffer(MockKeyedStateStore stateStore, TypeSerializer<V> valueSerializer) {
         super(stateStore, valueSerializer);
+        this.keyedStateStore = stateStore;
+    }
+
+    private TestSharedBuffer(
+            MockKeyedStateStore stateStore,
+            TypeSerializer<V> valueSerializer,
+            SharedBufferCacheConfig sharedBufferCacheConfig) {
+        super(stateStore, valueSerializer, sharedBufferCacheConfig);
         this.keyedStateStore = stateStore;
     }
 
@@ -72,6 +81,12 @@ public class TestSharedBuffer<V> extends SharedBuffer<V> {
      */
     public static <T> TestSharedBuffer<T> createTestBuffer(TypeSerializer<T> typeSerializer) {
         return new TestSharedBuffer<>(new MockKeyedStateStore(), typeSerializer);
+    }
+
+    public static <T> TestSharedBuffer<T> createTestBuffer(
+            TypeSerializer<T> typeSerializer, SharedBufferCacheConfig sharedBufferCacheConfig) {
+        return new TestSharedBuffer<>(
+                new MockKeyedStateStore(), typeSerializer, sharedBufferCacheConfig);
     }
 
     private static class MockKeyedStateStore implements KeyedStateStore {


### PR DESCRIPTION
<!--
*Thank you very much for contributing to Apache Flink - we are happy that you want to help us improve Flink. To help the community review your contribution in the best possible way, please go through the checklist below, which will get the contribution into a shape in which it can be best reviewed.*

*Please understand that we do not do this to make contributions to Flink a hassle. In order to uphold a high standard of quality for code contributions, while at the same time managing a large number of contributions, we need contributors to prepare the contributions well, and give reviewers enough contextual information for the review. Please also understand that contributions that do not follow this guide will take longer to review and thus typically be picked up with lower priority by the community.*

## Contribution Checklist

  - Make sure that the pull request corresponds to a [JIRA issue](https://issues.apache.org/jira/projects/FLINK/issues). Exceptions are made for typos in JavaDoc or documentation files, which need no JIRA issue.
  
  - Name the pull request in the form "[FLINK-XXXX] [component] Title of the pull request", where *FLINK-XXXX* should be replaced by the actual issue number. Skip *component* if you are unsure about which is the best component.
  Typo fixes that have no associated JIRA issue should be named following this pattern: `[hotfix] [docs] Fix typo in event time introduction` or `[hotfix] [javadocs] Expand JavaDoc for PuncuatedWatermarkGenerator`.

  - Fill out the template below to describe the changes contributed by the pull request. That will give reviewers the context they need to do the review.
  
  - Make sure that the change passes the automated tests, i.e., `mvn clean verify` passes. You can set up Azure Pipelines CI to do that following [this guide](https://cwiki.apache.org/confluence/display/FLINK/Azure+Pipelines#AzurePipelines-Tutorial:SettingupAzurePipelinesforaforkoftheFlinkrepository).

  - Each pull request should address only one issue, not mix up code from multiple issues.
  
  - Each commit in the pull request has a meaningful commit message (including the JIRA id)

  - Once all items of the checklist are addressed, remove the above text and this checklist, leaving only the filled out template below.


**(The sections below can be removed for hotfixes of typos)**
-->

## What is the purpose of the change

The size of entryCache & eventsBufferCache in the SharedBuffer should be defined with a threshold to limit the number of the elements in the cache


## Brief change log

- Introduce `CEPCacheOptions` class.
- Replace the HashMap with google guava LocalCache in `SharedBuffer`. 
- The number of elements in the new cache will be limited by the configuration items from job global-parameters

## Verifying this change

- add ITest cases in `CEPITCase`
- add Test cases in `SharedBufferTest`

## Does this pull request potentially affect one of the following parts:

  - Dependencies (does it add or upgrade a dependency): (yes / **no**)
  - The public API, i.e., is any changed class annotated with `@Public(Evolving)`: (yes / **no**)
  - The serializers: (yes / **no** / don't know)
  - The runtime per-record code paths (performance sensitive): (yes / **no** / don't know)
  - Anything that affects deployment or recovery: JobManager (and its components), Checkpointing, Kubernetes/Yarn, ZooKeeper: (yes / **no** / don't know)
  - The S3 file system connector: (yes / **no** / don't know)

## Documentation

  - Does this pull request introduce a new feature? (yes / **no**)
  - If yes, how is the feature documented? (**not applicable** / docs / JavaDocs / not documented)
