### PR TITLE
[FLINK-24789][runtime] Trigger checkpoint disposal prior completing t…

### DIFF
--- a/flink-core/src/main/java/org/apache/flink/util/concurrent/FutureUtils.java
+++ b/flink-core/src/main/java/org/apache/flink/util/concurrent/FutureUtils.java
@@ -677,7 +677,7 @@ public class FutureUtils {
 
     /**
      * Run the given action after the completion of the given future. The given future can be
-     * completed normally or exceptionally. In case of an exceptional completion the, the action's
+     * completed normally or exceptionally. In case of an exceptional completion the action's
      * exception will be added to the initial exception.
      *
      * @param future to wait for its completion

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/scheduler/DefaultScheduler.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/scheduler/DefaultScheduler.java
@@ -23,6 +23,7 @@ import org.apache.flink.api.common.JobStatus;
 import org.apache.flink.api.common.time.Time;
 import org.apache.flink.configuration.Configuration;
 import org.apache.flink.runtime.checkpoint.CheckpointRecoveryFactory;
+import org.apache.flink.runtime.checkpoint.CheckpointsCleaner;
 import org.apache.flink.runtime.clusterframework.types.AllocationID;
 import org.apache.flink.runtime.clusterframework.types.ResourceProfile;
 import org.apache.flink.runtime.concurrent.ComponentMainThreadExecutor;
@@ -119,6 +120,7 @@ public class DefaultScheduler extends SchedulerBase implements SchedulerOperatio
             final Consumer<ComponentMainThreadExecutor> startUpAction,
             final ScheduledExecutor delayExecutor,
             final ClassLoader userCodeLoader,
+            final CheckpointsCleaner checkpointsCleaner,
             final CheckpointRecoveryFactory checkpointRecoveryFactory,
             final JobManagerJobMetricGroup jobManagerJobMetricGroup,
             final SchedulingStrategyFactory schedulingStrategyFactory,
@@ -141,6 +143,7 @@ public class DefaultScheduler extends SchedulerBase implements SchedulerOperatio
                 ioExecutor,
                 jobMasterConfiguration,
                 userCodeLoader,
+                checkpointsCleaner,
                 checkpointRecoveryFactory,
                 jobManagerJobMetricGroup,
                 executionVertexVersioner,

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/scheduler/DefaultSchedulerFactory.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/scheduler/DefaultSchedulerFactory.java
@@ -24,6 +24,7 @@ import org.apache.flink.configuration.Configuration;
 import org.apache.flink.configuration.JobManagerOptions;
 import org.apache.flink.runtime.blob.BlobWriter;
 import org.apache.flink.runtime.checkpoint.CheckpointRecoveryFactory;
+import org.apache.flink.runtime.checkpoint.CheckpointsCleaner;
 import org.apache.flink.runtime.concurrent.ComponentMainThreadExecutor;
 import org.apache.flink.runtime.executiongraph.JobStatusListener;
 import org.apache.flink.runtime.executiongraph.failover.flip1.FailoverStrategyFactoryLoader;
@@ -122,6 +123,7 @@ public class DefaultSchedulerFactory implements SchedulerNGFactory {
                 schedulerComponents.getStartUpAction(),
                 new ScheduledExecutorServiceAdapter(futureExecutor),
                 userCodeLoader,
+                new CheckpointsCleaner(),
                 checkpointRecoveryFactory,
                 jobManagerJobMetricGroup,
                 schedulerComponents.getSchedulingStrategyFactory(),

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/scheduler/SchedulerBase.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/scheduler/SchedulerBase.java
@@ -162,6 +162,7 @@ public abstract class SchedulerBase implements SchedulerNG, CheckpointScheduling
             final Executor ioExecutor,
             final Configuration jobMasterConfiguration,
             final ClassLoader userCodeLoader,
+            final CheckpointsCleaner checkpointsCleaner,
             final CheckpointRecoveryFactory checkpointRecoveryFactory,
             final JobManagerJobMetricGroup jobManagerJobMetricGroup,
             final ExecutionVertexVersioner executionVertexVersioner,
@@ -179,7 +180,7 @@ public abstract class SchedulerBase implements SchedulerNG, CheckpointScheduling
         this.executionVertexVersioner = checkNotNull(executionVertexVersioner);
         this.mainThreadExecutor = mainThreadExecutor;
 
-        this.checkpointsCleaner = new CheckpointsCleaner();
+        this.checkpointsCleaner = checkpointsCleaner;
         this.completedCheckpointStore =
                 SchedulerUtils.createCompletedCheckpointStoreIfCheckpointingIsEnabled(
                         jobGraph,
@@ -610,12 +611,13 @@ public abstract class SchedulerBase implements SchedulerNG, CheckpointScheduling
         final FlinkException cause = new FlinkException("Scheduler is being stopped.");
 
         final CompletableFuture<Void> checkpointServicesShutdownFuture =
-                CompletableFuture.allOf(
+                FutureUtils.composeAfterwards(
                         executionGraph
                                 .getTerminationFuture()
                                 .thenAcceptAsync(
                                         this::shutDownCheckpointServices, getMainThreadExecutor()),
-                        checkpointsCleaner.closeAsync());
+                        checkpointsCleaner::closeAsync);
+
         FutureUtils.assertNoException(checkpointServicesShutdownFuture);
 
         incrementVersionsOfAllVertices();

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/scheduler/adaptive/AdaptiveScheduler.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/scheduler/adaptive/AdaptiveScheduler.java
@@ -167,9 +167,9 @@ public class AdaptiveScheduler
     private final ClassLoader userCodeClassLoader;
     private final JobManagerJobMetricGroup jobManagerJobMetricGroup;
 
+    private final CheckpointsCleaner checkpointsCleaner;
     private final CompletedCheckpointStore completedCheckpointStore;
     private final CheckpointIDCounter checkpointIdCounter;
-    private final CheckpointsCleaner checkpointsCleaner;
 
     private final CompletableFuture<JobStatus> jobTerminationFuture = new CompletableFuture<>();
 
@@ -210,6 +210,7 @@ public class AdaptiveScheduler
             SlotAllocator slotAllocator,
             Executor ioExecutor,
             ClassLoader userCodeClassLoader,
+            CheckpointsCleaner checkpointsCleaner,
             CheckpointRecoveryFactory checkpointRecoveryFactory,
             Duration initialResourceAllocationTimeout,
             Duration resourceStabilizationTimeout,
@@ -238,6 +239,7 @@ public class AdaptiveScheduler
         this.restartBackoffTimeStrategy = restartBackoffTimeStrategy;
         this.jobManagerJobMetricGroup = jobManagerJobMetricGroup;
         this.fatalErrorHandler = fatalErrorHandler;
+        this.checkpointsCleaner = checkpointsCleaner;
         this.completedCheckpointStore =
                 SchedulerUtils.createCompletedCheckpointStoreIfCheckpointingIsEnabled(
                         jobGraph,
@@ -248,7 +250,6 @@ public class AdaptiveScheduler
         this.checkpointIdCounter =
                 SchedulerUtils.createCheckpointIDCounterIfCheckpointingIsEnabled(
                         jobGraph, checkpointRecoveryFactory);
-        this.checkpointsCleaner = new CheckpointsCleaner();
 
         this.slotAllocator = slotAllocator;
 
@@ -418,12 +419,12 @@ public class AdaptiveScheduler
 
         backgroundTask.abort();
         // wait for the background task to finish and then close services
-        return CompletableFuture.allOf(
+        return FutureUtils.composeAfterwards(
                 FutureUtils.runAfterwardsAsync(
                         backgroundTask.getTerminationFuture(),
                         () -> stopCheckpointServicesSafely(jobTerminationFuture.get()),
                         getMainThreadExecutor()),
-                checkpointsCleaner.closeAsync());
+                checkpointsCleaner::closeAsync);
     }
 
     private void stopCheckpointServicesSafely(JobStatus terminalState) {

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/scheduler/adaptive/AdaptiveSchedulerFactory.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/scheduler/adaptive/AdaptiveSchedulerFactory.java
@@ -23,6 +23,7 @@ import org.apache.flink.configuration.Configuration;
 import org.apache.flink.configuration.JobManagerOptions;
 import org.apache.flink.runtime.blob.BlobWriter;
 import org.apache.flink.runtime.checkpoint.CheckpointRecoveryFactory;
+import org.apache.flink.runtime.checkpoint.CheckpointsCleaner;
 import org.apache.flink.runtime.concurrent.ComponentMainThreadExecutor;
 import org.apache.flink.runtime.executiongraph.JobStatusListener;
 import org.apache.flink.runtime.executiongraph.failover.flip1.RestartBackoffTimeStrategy;
@@ -125,6 +126,7 @@ public class AdaptiveSchedulerFactory implements SchedulerNGFactory {
                 slotAllocator,
                 ioExecutor,
                 userCodeLoader,
+                new CheckpointsCleaner(),
                 checkpointRecoveryFactory,
                 initialResourceAllocationTimeout,
                 resourceStabilizationTimeout,

--- a/flink-runtime/src/test/java/org/apache/flink/runtime/scheduler/SchedulerTestingUtils.java
+++ b/flink-runtime/src/test/java/org/apache/flink/runtime/scheduler/SchedulerTestingUtils.java
@@ -28,6 +28,7 @@ import org.apache.flink.runtime.checkpoint.CheckpointException;
 import org.apache.flink.runtime.checkpoint.CheckpointMetrics;
 import org.apache.flink.runtime.checkpoint.CheckpointRecoveryFactory;
 import org.apache.flink.runtime.checkpoint.CheckpointRetentionPolicy;
+import org.apache.flink.runtime.checkpoint.CheckpointsCleaner;
 import org.apache.flink.runtime.checkpoint.CompletedCheckpoint;
 import org.apache.flink.runtime.checkpoint.PendingCheckpoint;
 import org.apache.flink.runtime.checkpoint.StandaloneCheckpointRecoveryFactory;
@@ -400,6 +401,7 @@ public class SchedulerTestingUtils {
         private ScheduledExecutor delayExecutor =
                 new ScheduledExecutorServiceAdapter(futureExecutor);
         private ClassLoader userCodeLoader = ClassLoader.getSystemClassLoader();
+        private CheckpointsCleaner checkpointCleaner = new CheckpointsCleaner();
         private CheckpointRecoveryFactory checkpointRecoveryFactory =
                 new StandaloneCheckpointRecoveryFactory();
         private Time rpcTimeout = DEFAULT_TIMEOUT;
@@ -454,6 +456,12 @@ public class SchedulerTestingUtils {
 
         public DefaultSchedulerBuilder setUserCodeLoader(final ClassLoader userCodeLoader) {
             this.userCodeLoader = userCodeLoader;
+            return this;
+        }
+
+        public DefaultSchedulerBuilder setCheckpointCleaner(
+                final CheckpointsCleaner checkpointsCleaner) {
+            this.checkpointCleaner = checkpointsCleaner;
             return this;
         }
 
@@ -553,6 +561,7 @@ public class SchedulerTestingUtils {
                     componentMainThreadExecutor -> {},
                     delayExecutor,
                     userCodeLoader,
+                    checkpointCleaner,
                     checkpointRecoveryFactory,
                     jobManagerJobMetricGroup,
                     schedulingStrategyFactory,

--- a/flink-runtime/src/test/java/org/apache/flink/runtime/scheduler/adaptive/AdaptiveSchedulerBuilder.java
+++ b/flink-runtime/src/test/java/org/apache/flink/runtime/scheduler/adaptive/AdaptiveSchedulerBuilder.java
@@ -23,6 +23,7 @@ import org.apache.flink.configuration.JobManagerOptions;
 import org.apache.flink.runtime.blob.BlobWriter;
 import org.apache.flink.runtime.blob.VoidBlobWriter;
 import org.apache.flink.runtime.checkpoint.CheckpointRecoveryFactory;
+import org.apache.flink.runtime.checkpoint.CheckpointsCleaner;
 import org.apache.flink.runtime.checkpoint.StandaloneCheckpointRecoveryFactory;
 import org.apache.flink.runtime.concurrent.ComponentMainThreadExecutor;
 import org.apache.flink.runtime.executiongraph.JobStatusListener;
@@ -63,6 +64,7 @@ public class AdaptiveSchedulerBuilder {
     private Configuration jobMasterConfiguration = new Configuration();
     private ScheduledExecutorService futureExecutor = TestingUtils.defaultExecutor();
     private ClassLoader userCodeLoader = ClassLoader.getSystemClassLoader();
+    private CheckpointsCleaner checkpointsCleaner = new CheckpointsCleaner();
     private CheckpointRecoveryFactory checkpointRecoveryFactory =
             new StandaloneCheckpointRecoveryFactory();
     private DeclarativeSlotPool declarativeSlotPool;
@@ -116,6 +118,12 @@ public class AdaptiveSchedulerBuilder {
 
     public AdaptiveSchedulerBuilder setUserCodeLoader(final ClassLoader userCodeLoader) {
         this.userCodeLoader = userCodeLoader;
+        return this;
+    }
+
+    public AdaptiveSchedulerBuilder setCheckpointCleaner(
+            final CheckpointsCleaner checkpointsCleaner) {
+        this.checkpointsCleaner = checkpointsCleaner;
         return this;
     }
 
@@ -208,6 +216,7 @@ public class AdaptiveSchedulerBuilder {
                         : slotAllocator,
                 ioExecutor,
                 userCodeLoader,
+                checkpointsCleaner,
                 checkpointRecoveryFactory,
                 jobMasterConfiguration.get(JobManagerOptions.RESOURCE_WAIT_TIMEOUT),
                 jobMasterConfiguration.get(JobManagerOptions.RESOURCE_STABILIZATION_TIMEOUT),


### PR DESCRIPTION
https://issues.apache.org/jira/browse/FLINK-24789

Reproducing the issue:

```diff
diff --git a/flink-core/src/main/java/org/apache/flink/util/FatalExitExceptionHandler.java b/flink-core/src/main/java/org/apache/flink/util/FatalExitExceptionHandler.java
index 8ff0e9b7b0a..2898df0e458 100644
--- a/flink-core/src/main/java/org/apache/flink/util/FatalExitExceptionHandler.java
+++ b/flink-core/src/main/java/org/apache/flink/util/FatalExitExceptionHandler.java
@@ -43,6 +43,7 @@ public final class FatalExitExceptionHandler implements Thread.UncaughtException
                     "FATAL: Thread '{}' produced an uncaught exception. Stopping the process...",
                     t.getName(),
                     e);
+            e.printStackTrace();
         } finally {
             FlinkSecurityManager.forceProcessExit(EXIT_CODE);
         }
diff --git a/flink-runtime/src/main/java/org/apache/flink/runtime/checkpoint/PendingCheckpoint.java b/flink-runtime/src/main/java/org/apache/flink/runtime/checkpoint/PendingCheckpoint.java
index af15c82a398..8791a0ab78f 100644
--- a/flink-runtime/src/main/java/org/apache/flink/runtime/checkpoint/PendingCheckpoint.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/checkpoint/PendingCheckpoint.java
@@ -547,6 +547,11 @@ public class PendingCheckpoint implements Checkpoint {
             reportFailedCheckpoint(failureCause, statsCallback);
             assertAbortSubsumedForced(reason);
         } finally {
+            try {
+                Thread.sleep(1000);
+            } catch (InterruptedException e) {
+                e.printStackTrace();
+            }
             dispose(true, checkpointsCleaner, postCleanup, executor);
         }
```

+ repeated run of `OperatorCoordinatorSchedulerTest#testSnapshotAsyncFailureFailsCheckpoint`