### PR TITLE
[FLINK-24414][table-planner] Remove example test for left padding of decimals

### DIFF
--- a/flink-table/flink-table-planner/src/test/java/org/apache/flink/table/planner/functions/CastFunctionITCase.java
+++ b/flink-table/flink-table-planner/src/test/java/org/apache/flink/table/planner/functions/CastFunctionITCase.java
@@ -160,9 +160,6 @@ public class CastFunctionITCase extends BuiltInFunctionTestBase {
                         .fromCase(BYTES(), DEFAULT_BYTES, "\u0000\u0001\u0002\u0003\u0004")
                         .fromCase(DECIMAL(4, 3), 9.87, "9.870")
                         .fromCase(DECIMAL(10, 5), 1, "1.00000")
-                        // https://issues.apache.org/jira/browse/FLINK-24414 - Left zero padding
-                        // currently not working
-                        // .fromCase(DECIMAL(5, 3), 09.87, "09.870")
                         .fromCase(
                                 TINYINT(),
                                 DEFAULT_POSITIVE_TINY_INT,


### PR DESCRIPTION
After discussion on the issue, was decided to not support left padding of decimals,
to the integral digits specified by precision-scale, as major DBs also don't support
it. Removing the example issue in the IT cast tests.