### PR TITLE
[FLINK-24796][ci] Reduce size of compile build artifact

### DIFF
--- a/tools/azure-pipelines/create_build_artifact.sh
+++ b/tools/azure-pipelines/create_build_artifact.sh
@@ -38,3 +38,10 @@ rm -rf "$FLINK_ARTIFACT_DIR/.git"
 # AZ Pipelines has a problem with links.
 rm "$FLINK_ARTIFACT_DIR/build-target"
 
+# Remove javadocs because they are not used in later stages
+rm -rf "$FLINK_ARTIFACT_DIR/target/site"
+
+# Remove WebUI node directories; unnecessary because the UI is already fully built
+rm -rf "$FLINK_ARTIFACT_DIR/flink-runtime-web/web-dashboard/node"
+rm -rf "$FLINK_ARTIFACT_DIR/flink-runtime-web/web-dashboard/node_modules"
+


### PR DESCRIPTION
Exclude javadocs and the runtime-web node[_modules] directory from the CI compile artifact.

This reduces the amount of data that needs to be fetched to about a third.

Before:
```
Download statistics:
Total Content: 1,565.1 MB
Physical Content Downloaded: 469.4 MB
Compression Saved: 1,095.7 MB
```

After:
```
Download statistics:
Total Content: 410.3 MB
Physical Content Downloaded: 151.6 MB
Compression Saved: 258.7 MB
```