### PR TITLE
[FLINK-24689][runtime-web] Add log's last modify time in log list view

### DIFF
--- a/flink-runtime-web/src/test/resources/rest_api_v1.snapshot
+++ b/flink-runtime-web/src/test/resources/rest_api_v1.snapshot
@@ -505,6 +505,9 @@
               },
               "size" : {
                 "type" : "integer"
+              },
+              "mtime" : {
+                "type" : "integer"
               }
             }
           }
@@ -3301,6 +3304,9 @@
                 "type" : "string"
               },
               "size" : {
+                "type" : "integer"
+              },
+              "mtime" : {
                 "type" : "integer"
               }
             }

--- a/flink-runtime-web/web-dashboard/src/app/interfaces/job-manager.ts
+++ b/flink-runtime-web/web-dashboard/src/app/interfaces/job-manager.ts
@@ -16,21 +16,8 @@
  * limitations under the License.
  */
 
-export * from './configuration';
-export * from './jar';
-export * from './job-overview';
-export * from './job-detail';
-export * from './job-exception';
-export * from './job-timeline';
-export * from './job-config';
-export * from './job-vertex-task-manager';
-export * from './job-checkpoint';
-export * from './job-subtask';
-export * from './job-backpressure';
-export * from './job-flamegraph';
-export * from './plan';
-export * from './overview';
-export * from './task-manager';
-export * from './job-accumulators';
-export * from './job-manager';
-export * from './safe-any';
+export interface JobManagerLogItemInterface {
+  name: string;
+  size: number;
+  mtime: number;
+}

--- a/flink-runtime-web/web-dashboard/src/app/interfaces/task-manager.ts
+++ b/flink-runtime-web/web-dashboard/src/app/interfaces/task-manager.ts
@@ -32,8 +32,10 @@ export interface TaskManagerDetailInterface {
   memoryConfiguration: MemoryConfiguration;
 }
 
-export interface TaskManagerLogInterface {
-  logs: Array<{ name: string; size: number }>;
+export interface TaskManagerLogItemInterface {
+  name: string;
+  size: number;
+  mtime: number;
 }
 
 export interface TaskmanagersItemInterface {

--- a/flink-runtime-web/web-dashboard/src/app/pages/job-manager/log-list/job-manager-log-list.component.html
+++ b/flink-runtime-web/web-dashboard/src/app/pages/job-manager/log-list/job-manager-log-list.component.html
@@ -32,7 +32,8 @@
     <thead>
       <tr>
         <th nzWidth="50%">Log Name</th>
-        <th nzWidth="50%">Size (KB)</th>
+        <th [nzSortFn]="sortLastModifiedTimeFn">Last Modified Time</th>
+        <th [nzSortFn]="sortSizeFn">Size (KB)</th>
       </tr>
     </thead>
     <tbody>
@@ -42,6 +43,7 @@
             <td>
               <a [routerLink]="[narrowData.name]">{{ narrowData.name }}</a>
             </td>
+            <td>{{ narrowData.mtime | humanizeDate: 'yyyy-MM-dd HH:mm:ss' }}</td>
             <td>{{ narrowData.size / 1024 | number: '1.0-2' }}</td>
           </tr>
         </ng-container>

--- a/flink-runtime-web/web-dashboard/src/app/pages/job-manager/log-list/job-manager-log-list.component.ts
+++ b/flink-runtime-web/web-dashboard/src/app/pages/job-manager/log-list/job-manager-log-list.component.ts
@@ -19,6 +19,7 @@
 import { ChangeDetectionStrategy, ChangeDetectorRef, Component, OnInit } from '@angular/core';
 import { finalize } from 'rxjs/operators';
 
+import { JobManagerLogItemInterface } from 'interfaces';
 import { JobManagerService } from 'services';
 
 import { typeDefinition } from '../../../utils/strong-type';
@@ -30,11 +31,15 @@ import { typeDefinition } from '../../../utils/strong-type';
   changeDetection: ChangeDetectionStrategy.OnPush
 })
 export class JobManagerLogListComponent implements OnInit {
-  listOfLog: Array<{ name: string; size: number }> = [];
+  listOfLog: JobManagerLogItemInterface[] = [];
   isLoading = true;
 
-  trackByName = (_: number, log: { name: string; size: number }): string => log.name;
-  readonly narrowLogData = typeDefinition<{ name: string; size: number }>();
+  trackByName = (_: number, log: JobManagerLogItemInterface): string => log.name;
+  readonly narrowLogData = typeDefinition<JobManagerLogItemInterface>();
+
+  sortLastModifiedTimeFn = (pre: JobManagerLogItemInterface, next: JobManagerLogItemInterface): number =>
+    pre.mtime - next.mtime;
+  sortSizeFn = (pre: JobManagerLogItemInterface, next: JobManagerLogItemInterface): number => pre.size - next.size;
 
   constructor(private jobManagerService: JobManagerService, private cdr: ChangeDetectorRef) {}
 

--- a/flink-runtime-web/web-dashboard/src/app/pages/task-manager/log-list/task-manager-log-list.component.html
+++ b/flink-runtime-web/web-dashboard/src/app/pages/task-manager/log-list/task-manager-log-list.component.html
@@ -31,7 +31,8 @@
     <thead>
       <tr>
         <th nzWidth="50%">Log Name</th>
-        <th nzWidth="50%">Size (KB)</th>
+        <th [nzSortFn]="sortLastModifiedTimeFn">Last Modified Time</th>
+        <th [nzSortFn]="sortSizeFn">Size (KB)</th>
       </tr>
     </thead>
     <tbody>
@@ -41,6 +42,7 @@
             <td>
               <a [routerLink]="[narrowData.name]">{{ narrowData.name }}</a>
             </td>
+            <td>{{ narrowData.mtime | humanizeDate: 'yyyy-MM-dd HH:mm:ss' }}</td>
             <td>{{ narrowData.size / 1024 | number: '1.0-2' }}</td>
           </tr>
         </ng-container>

--- a/flink-runtime-web/web-dashboard/src/app/pages/task-manager/log-list/task-manager-log-list.component.ts
+++ b/flink-runtime-web/web-dashboard/src/app/pages/task-manager/log-list/task-manager-log-list.component.ts
@@ -17,6 +17,7 @@
 import { ChangeDetectionStrategy, ChangeDetectorRef, Component, OnInit } from '@angular/core';
 import { first, flatMap } from 'rxjs/operators';
 
+import { TaskManagerLogItemInterface } from 'interfaces';
 import { TaskManagerService } from 'services';
 
 import { typeDefinition } from '../../../utils/strong-type';
@@ -27,11 +28,15 @@ import { typeDefinition } from '../../../utils/strong-type';
   changeDetection: ChangeDetectionStrategy.OnPush
 })
 export class TaskManagerLogListComponent implements OnInit {
-  listOfLog: Array<{ name: string; size: number }> = [];
+  listOfLog: TaskManagerLogItemInterface[] = [];
   isLoading = true;
 
-  trackByName = (_: number, log: { name: string; size: number }): string => log.name;
-  readonly narrowLogData = typeDefinition<{ name: string; size: number }>();
+  trackByName = (_: number, log: TaskManagerLogItemInterface): string => log.name;
+  readonly narrowLogData = typeDefinition<TaskManagerLogItemInterface>();
+
+  sortLastModifiedTimeFn = (pre: TaskManagerLogItemInterface, next: TaskManagerLogItemInterface): number =>
+    pre.mtime - next.mtime;
+  sortSizeFn = (pre: TaskManagerLogItemInterface, next: TaskManagerLogItemInterface): number => pre.size - next.size;
 
   constructor(private taskManagerService: TaskManagerService, private cdr: ChangeDetectorRef) {}
 

--- a/flink-runtime-web/web-dashboard/src/app/services/job-manager.service.ts
+++ b/flink-runtime-web/web-dashboard/src/app/services/job-manager.service.ts
@@ -22,6 +22,7 @@ import { Observable } from 'rxjs';
 import { map } from 'rxjs/operators';
 
 import { BASE_URL } from 'config';
+import { JobManagerLogItemInterface } from 'interfaces';
 
 @Injectable({
   providedIn: 'root'
@@ -56,9 +57,9 @@ export class JobManagerService {
   /**
    * Load JM log list
    */
-  loadLogList(): Observable<Array<{ name: string; size: number }>> {
+  loadLogList(): Observable<JobManagerLogItemInterface[]> {
     return this.httpClient
-      .get<{ logs: Array<{ name: string; size: number }> }>(`${BASE_URL}/jobmanager/logs`)
+      .get<{ logs: JobManagerLogItemInterface[] }>(`${BASE_URL}/jobmanager/logs`)
       .pipe(map(data => data.logs));
   }
 

--- a/flink-runtime-web/web-dashboard/src/app/services/task-manager.service.ts
+++ b/flink-runtime-web/web-dashboard/src/app/services/task-manager.service.ts
@@ -25,7 +25,7 @@ import { BASE_URL } from 'config';
 import {
   TaskManagerListInterface,
   TaskManagerDetailInterface,
-  TaskManagerLogInterface,
+  TaskManagerLogItemInterface,
   TaskManagerThreadDumpInterface,
   TaskmanagersItemInterface
 } from 'interfaces';
@@ -62,9 +62,9 @@ export class TaskManagerService {
    *
    * @param taskManagerId
    */
-  loadLogList(taskManagerId: string): Observable<Array<{ name: string; size: number }>> {
+  loadLogList(taskManagerId: string): Observable<TaskManagerLogItemInterface[]> {
     return this.httpClient
-      .get<TaskManagerLogInterface>(`${BASE_URL}/taskmanagers/${taskManagerId}/logs`)
+      .get<{ logs: TaskManagerLogItemInterface[] }>(`${BASE_URL}/taskmanagers/${taskManagerId}/logs`)
       .pipe(map(data => data.logs));
   }
 

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/rest/handler/cluster/JobManagerLogListHandler.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/rest/handler/cluster/JobManagerLogListHandler.java
@@ -73,11 +73,16 @@ public class JobManagerLogListHandler
             return FutureUtils.completedExceptionally(
                     new IOException("Could not list files in " + logDir));
         }
-        final List<LogInfo> logsWithLength =
+        final List<LogInfo> logs =
                 Arrays.stream(logFiles)
                         .filter(File::isFile)
-                        .map(logFile -> new LogInfo(logFile.getName(), logFile.length()))
+                        .map(
+                                logFile ->
+                                        new LogInfo(
+                                                logFile.getName(),
+                                                logFile.length(),
+                                                logFile.lastModified()))
                         .collect(Collectors.toList());
-        return CompletableFuture.completedFuture(new LogListInfo(logsWithLength));
+        return CompletableFuture.completedFuture(new LogListInfo(logs));
     }
 }

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/rest/messages/LogInfo.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/rest/messages/LogInfo.java
@@ -34,6 +34,8 @@ public class LogInfo implements Serializable {
 
     public static final String SIZE = "size";
 
+    public static final String MTIME = "mtime";
+
     private static final long serialVersionUID = -7371944349031708629L;
 
     @JsonProperty(NAME)
@@ -42,10 +44,17 @@ public class LogInfo implements Serializable {
     @JsonProperty(SIZE)
     private final long size;
 
+    @JsonProperty(MTIME)
+    private final long mtime;
+
     @JsonCreator
-    public LogInfo(@JsonProperty(NAME) String name, @JsonProperty(SIZE) long size) {
+    public LogInfo(
+            @JsonProperty(NAME) String name,
+            @JsonProperty(SIZE) long size,
+            @JsonProperty(MTIME) long mtime) {
         this.name = Preconditions.checkNotNull(name);
         this.size = size;
+        this.mtime = mtime;
     }
 
     @JsonIgnore
@@ -58,6 +67,11 @@ public class LogInfo implements Serializable {
         return size;
     }
 
+    @JsonIgnore
+    public long getMtime() {
+        return mtime;
+    }
+
     @Override
     public boolean equals(Object o) {
         if (this == o) {
@@ -67,11 +81,11 @@ public class LogInfo implements Serializable {
             return false;
         }
         LogInfo that = (LogInfo) o;
-        return Objects.equals(name, that.name) && size == that.size;
+        return Objects.equals(name, that.name) && size == that.size && mtime == that.mtime;
     }
 
     @Override
     public int hashCode() {
-        return Objects.hash(name, size);
+        return Objects.hash(name, size, mtime);
     }
 }

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/taskexecutor/TaskExecutor.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/taskexecutor/TaskExecutor.java
@@ -376,7 +376,12 @@ public class TaskExecutor extends RpcEndpoint implements TaskExecutorGateway {
 
                         return Arrays.stream(logFiles)
                                 .filter(File::isFile)
-                                .map(logFile -> new LogInfo(logFile.getName(), logFile.length()))
+                                .map(
+                                        logFile ->
+                                                new LogInfo(
+                                                        logFile.getName(),
+                                                        logFile.length(),
+                                                        logFile.lastModified()))
                                 .collect(Collectors.toList());
                     }
                     return Collections.emptyList();

--- a/flink-runtime/src/test/java/org/apache/flink/runtime/rest/handler/cluster/JobManagerLogListHandlerTest.java
+++ b/flink-runtime/src/test/java/org/apache/flink/runtime/rest/handler/cluster/JobManagerLogListHandlerTest.java
@@ -82,9 +82,9 @@ public class JobManagerLogListHandlerTest extends TestLogger {
         File logRoot = temporaryFolder.getRoot();
         List<LogInfo> expectedLogInfo =
                 Arrays.asList(
-                        new LogInfo("jobmanager.log", 5),
-                        new LogInfo("jobmanager.out", 7),
-                        new LogInfo("test.log", 13));
+                        new LogInfo("jobmanager.log", 5, 1632844800000L),
+                        new LogInfo("jobmanager.out", 7, 1632844800000L),
+                        new LogInfo("test.log", 13, 1632844800000L));
         createLogFiles(logRoot, expectedLogInfo);
 
         JobManagerLogListHandler jobManagerLogListHandler = createHandler(logRoot);
@@ -116,16 +116,17 @@ public class JobManagerLogListHandlerTest extends TestLogger {
 
     private void createLogFiles(final File logRoot, final List<LogInfo> expectedLogFiles) {
         for (LogInfo logInfo : expectedLogFiles) {
-            createFile(new File(logRoot, logInfo.getName()), logInfo.getSize());
+            createFile(new File(logRoot, logInfo.getName()), logInfo.getSize(), logInfo.getMtime());
         }
     }
 
-    private void createFile(final File file, final long size) {
+    private void createFile(final File file, final long size, final long mtime) {
         try {
             final String randomFileContent =
                     StringUtils.generateRandomAlphanumericString(
                             ThreadLocalRandom.current(), Math.toIntExact(size));
             FileUtils.writeStringToFile(file, randomFileContent, StandardCharsets.UTF_8);
+            file.setLastModified(mtime);
         } catch (IOException e) {
             throw new RuntimeException(e);
         }

--- a/flink-runtime/src/test/java/org/apache/flink/runtime/rest/handler/taskmanager/TaskManagerLogListHandlerTest.java
+++ b/flink-runtime/src/test/java/org/apache/flink/runtime/rest/handler/taskmanager/TaskManagerLogListHandlerTest.java
@@ -79,9 +79,9 @@ public class TaskManagerLogListHandlerTest extends TestLogger {
     public void testGetTaskManagerLogsList() throws Exception {
         List<LogInfo> logsList =
                 Arrays.asList(
-                        new LogInfo("taskmanager.log", 1024L),
-                        new LogInfo("taskmanager.out", 1024L),
-                        new LogInfo("taskmanager-2.out", 1024L));
+                        new LogInfo("taskmanager.log", 1024L, 1632844800000L),
+                        new LogInfo("taskmanager.out", 1024L, 1632844800000L),
+                        new LogInfo("taskmanager-2.out", 1024L, 1632844800000L));
         resourceManagerGateway.setRequestTaskManagerLogListFunction(
                 EXPECTED_TASK_MANAGER_ID -> CompletableFuture.completedFuture(logsList));
         LogListInfo logListInfo =

--- a/flink-runtime/src/test/java/org/apache/flink/runtime/rest/messages/taskmanager/LogListInfoTest.java
+++ b/flink-runtime/src/test/java/org/apache/flink/runtime/rest/messages/taskmanager/LogListInfoTest.java
@@ -38,7 +38,7 @@ public class LogListInfoTest extends RestResponseMarshallingTestBase {
     protected ResponseBody getTestResponseInstance() throws Exception {
         return new LogListInfo(
                 Arrays.asList(
-                        new LogInfo("taskmanager.log", 0),
-                        new LogInfo("taskmanager.out", Integer.MAX_VALUE)));
+                        new LogInfo("taskmanager.log", 0, 1632844800000L),
+                        new LogInfo("taskmanager.out", Integer.MAX_VALUE, 1632844800000L)));
     }
 }


### PR DESCRIPTION
## What is the purpose of the change

This pull request add log's **last modified time** in taskmanager log list view and jobmanager log list view, it will help us to choose correct log file and analyse problem exactly and quickly. 

See [FLINK-24689](https://issues.apache.org/jira/browse/FLINK-24689) for more.

## Brief change log

  - add `mtime` field in class `LogInfo` and put log file's last modified time into rest api's response
  - show `Last Modified Time` in TaskManager's log list view and JobManager's log list view (support sort)


## Verifying this change

This change is already covered by existing tests:
- org.apache.flink.runtime.rest.handler.cluster.JobManagerLogListHandlerTest#testGetJobManagerLogsList
- org.apache.flink.runtime.rest.handler.taskmanager.TaskManagerLogListHandlerTest#testGetTaskManagerLogsList
- org.apache.flink.runtime.rest.messages.taskmanager.LogListInfoTest#getTestResponseInstance

I filled mtime's value and pass these testcase.

## Does this pull request potentially affect one of the following parts:

  - Dependencies (does it add or upgrade a dependency):  no
  - The public API, i.e., is any changed class annotated with `@Public(Evolving)`:  no
  - The serializers: no 
  - The runtime per-record code paths (performance sensitive): no
  - Anything that affects deployment or recovery: JobManager (and its components), Checkpointing, Kubernetes/Yarn, ZooKeeper: no
  - The S3 file system connector: no

## Documentation

  - Does this pull request introduce a new feature?  no

