### PR TITLE
[hotfix][docs][git] Add hugo_build.lock to .gitignore

### DIFF
--- a/docs/.gitignore
+++ b/docs/.gitignore
@@ -6,3 +6,4 @@ ruby2/.bundle/
 ruby2/.rubydeps/
 public/
 resources/
+.hugo_build.lock


### PR DESCRIPTION
## What is the purpose of the change

Add hugo_build.lock to .gitignore
the same way it is done in hugo itself [1]
[1] https://github.com/gohugoio/hugoDocs/blob/master/.gitignore

## Does this pull request potentially affect one of the following parts:

  - Dependencies (does it add or upgrade a dependency): (yes / **no**)
  - The public API, i.e., is any changed class annotated with `@Public(Evolving)`: (yes / **no**)
  - The serializers: (yes / **no** / don't know)
  - The runtime per-record code paths (performance sensitive): (yes / **no** / don't know)
  - Anything that affects deployment or recovery: JobManager (and its components), Checkpointing, Kubernetes/Yarn, ZooKeeper: (yes / **no** / don't know)
  - The S3 file system connector: (yes / **no** / don't know)

## Documentation

  - Does this pull request introduce a new feature? (yes / **no**)
  - If yes, how is the feature documented? (**not applicable** / docs / JavaDocs / not documented)
