### PR TITLE
[FLINK-24806][connectors/rabbitmq] Fix container startup in RMQSourceITCase

### DIFF
--- a/flink-connectors/flink-connector-rabbitmq/src/test/java/org/apache/flink/streaming/connectors/rabbitmq/RMQSourceITCase.java
+++ b/flink-connectors/flink-connector-rabbitmq/src/test/java/org/apache/flink/streaming/connectors/rabbitmq/RMQSourceITCase.java
@@ -50,7 +50,6 @@ import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 import org.testcontainers.containers.RabbitMQContainer;
 import org.testcontainers.containers.output.Slf4jLogConsumer;
-import org.testcontainers.containers.wait.strategy.Wait;
 import org.testcontainers.utility.DockerImageName;
 
 import java.io.IOException;
@@ -90,8 +89,7 @@ public class RMQSourceITCase {
     public static final RabbitMQContainer RMQ_CONTAINER =
             new RabbitMQContainer(DockerImageName.parse(DockerImageVersions.RABBITMQ))
                     .withExposedPorts(RABBITMQ_PORT)
-                    .withLogConsumer(LOG_CONSUMER)
-                    .waitingFor(Wait.forListeningPort());
+                    .withLogConsumer(LOG_CONSUMER);
 
     @Before
     public void setUp() throws Exception {


### PR DESCRIPTION
## What is the purpose of the change

Fix RabbitMQ container startup wait condition causing issue described in FLINK-24806 (set-up code in the test fails when trying to connect to RabbitMQ service that has not been initialized yet).

## Brief change log

Remove the custom wait strategy (wait for listening port) that overrides the default RabbitMQContainer wait strategy (wait for a specific log message: "Server startup complete"). 

## Verifying this change

This change is already covered by existing tests in RMQSourceITCase.

## Does this pull request potentially affect one of the following parts:

  - Dependencies (does it add or upgrade a dependency): (yes / **no**)
  - The public API, i.e., is any changed class annotated with `@Public(Evolving)`: (yes / **no**)
  - The serializers: (yes / **no** / don't know)
  - The runtime per-record code paths (performance sensitive): (yes / **no** / don't know)
  - Anything that affects deployment or recovery: JobManager (and its components), Checkpointing, Kubernetes/Yarn, ZooKeeper: (yes / **no** / don't know)
  - The S3 file system connector: (yes / **no** / don't know)

## Documentation

  - Does this pull request introduce a new feature? (yes / **no**)
  - If yes, how is the feature documented? (**not applicable** / docs / JavaDocs / not documented)
