### PR TITLE
[FLINK-24793][tests] Skip DefaultSchedulerLocalRecoveryITCase when testing AdaptiveScheduler

### DIFF
--- a/flink-tests/src/test/java/org/apache/flink/test/runtime/DefaultSchedulerLocalRecoveryITCase.java
+++ b/flink-tests/src/test/java/org/apache/flink/test/runtime/DefaultSchedulerLocalRecoveryITCase.java
@@ -40,9 +40,11 @@ import org.apache.flink.runtime.minicluster.MiniClusterConfiguration;
 import org.apache.flink.runtime.scheduler.DefaultScheduler;
 import org.apache.flink.runtime.testutils.CommonTestUtils;
 import org.apache.flink.runtime.testutils.WaitingCancelableInvokable;
+import org.apache.flink.testutils.junit.FailsWithAdaptiveScheduler;
 import org.apache.flink.util.TestLogger;
 
 import org.junit.Test;
+import org.junit.experimental.categories.Category;
 
 import java.io.IOException;
 import java.time.Duration;
@@ -61,11 +63,13 @@ public class DefaultSchedulerLocalRecoveryITCase extends TestLogger {
     private static final long TIMEOUT = 10_000L;
 
     @Test
+    @Category(FailsWithAdaptiveScheduler.class) // FLINK-21450
     public void testLocalRecoveryFull() throws Exception {
         testLocalRecoveryInternal("full");
     }
 
     @Test
+    @Category(FailsWithAdaptiveScheduler.class) // FLINK-21450
     public void testLocalRecoveryRegion() throws Exception {
         testLocalRecoveryInternal("region");
     }


### PR DESCRIPTION
## What is the purpose of the change

DefaultSchedulerLocalRecoveryITCase does not work with AdaptiveScheduler before FLINK-21450 is done.
So we skip these tests when testing AdaptiveScheduler.

## Verifying this change

This change is already covered by existing tests

## Does this pull request potentially affect one of the following parts:

  - Dependencies (does it add or upgrade a dependency): (yes / **no**)
  - The public API, i.e., is any changed class annotated with `@Public(Evolving)`: (yes / **no**)
  - The serializers: (yes / **no** / don't know)
  - The runtime per-record code paths (performance sensitive): (yes / **no** / don't know)
  - Anything that affects deployment or recovery: JobManager (and its components), Checkpointing, Kubernetes/Yarn, ZooKeeper: (yes / **no** / don't know)
  - The S3 file system connector: (yes / **no** / don't know)

## Documentation

  - Does this pull request introduce a new feature? (yes / **no**)
  - If yes, how is the feature documented? (**not applicable** / docs / JavaDocs / not documented)
