### PR TITLE
[FLINK-24816][rabbitmq] Bump amqp-client to v5.13.1

### DIFF
--- a/flink-connectors/flink-connector-rabbitmq/pom.xml
+++ b/flink-connectors/flink-connector-rabbitmq/pom.xml
@@ -37,7 +37,7 @@ under the License.
 
 	<!-- Allow users to pass custom connector versions -->
 	<properties>
-		<rabbitmq.version>5.9.0</rabbitmq.version>
+		<rabbitmq.version>5.13.1</rabbitmq.version>
 	</properties>
 
 	<dependencies>

--- a/flink-connectors/flink-sql-connector-rabbitmq/src/main/resources/META-INF/NOTICE
+++ b/flink-connectors/flink-sql-connector-rabbitmq/src/main/resources/META-INF/NOTICE
@@ -6,4 +6,4 @@ The Apache Software Foundation (http://www.apache.org/).
 
 This project bundles the following dependencies under the Apache Software License 2.0 (http://www.apache.org/licenses/LICENSE-2.0.txt)
 
-- com.rabbitmq:amqp-client:5.9.0
+- com.rabbitmq:amqp-client:5.13.1

--- a/flink-test-utils-parent/flink-test-utils-junit/src/main/java/org/apache/flink/util/DockerImageVersions.java
+++ b/flink-test-utils-parent/flink-test-utils-junit/src/main/java/org/apache/flink/util/DockerImageVersions.java
@@ -35,7 +35,7 @@ public class DockerImageVersions {
 
     public static final String KAFKA = "confluentinc/cp-kafka:5.5.2";
 
-    public static final String RABBITMQ = "rabbitmq:3.7.25-management-alpine";
+    public static final String RABBITMQ = "rabbitmq:3.9.8-management-alpine";
 
     public static final String KINESALITE = "instructure/kinesalite:latest";
 


### PR DESCRIPTION
## What is the purpose of the change

* Update RabbitMQ Java client to the latest available version

## Brief change log

* Updated com.rabbitmq:amqp-client from 5.9.0 to 5.13.1

## Verifying this change

This change is a trivial rework / code cleanup without any test coverage.

## Does this pull request potentially affect one of the following parts:

  - Dependencies (does it add or upgrade a dependency): (**yes** / no)
  - The public API, i.e., is any changed class annotated with `@Public(Evolving)`: (yes / **no**)
  - The serializers: (yes / **no** / don't know)
  - The runtime per-record code paths (performance sensitive): (yes / **no** / don't know)
  - Anything that affects deployment or recovery: JobManager (and its components), Checkpointing, Kubernetes/Yarn, ZooKeeper: (yes / **no** / don't know)
  - The S3 file system connector: (yes / **no** / don't know)

## Documentation

  - Does this pull request introduce a new feature? (yes / **no**)
  - If yes, how is the feature documented? (**not applicable** / docs / JavaDocs / not documented)
