### PR TITLE
[1.12][FLINK-24812][ci] Upgrade to ubuntu-20.04

### DIFF
--- a/tools/azure-pipelines/build-python-wheels.yml
+++ b/tools/azure-pipelines/build-python-wheels.yml
@@ -16,7 +16,7 @@
 jobs:
   - job: compile_${{parameters.stage_name}}
     pool:
-      vmImage: 'ubuntu-16.04'
+      vmImage: 'ubuntu-20.04'
     container: flink-build-container
     workspace:
       clean: all


### PR DESCRIPTION
Looks like the backport of FLINK-22856 missed one reference.