### PR TITLE
[BP-1.14][FLINK-21289][deployment] FIX missing load pipeline.classpaths in application mode, for both k8s and yarn

### DIFF
--- a/flink-clients/src/test/java/org/apache/flink/client/program/DefaultPackagedProgramRetrieverTest.java
+++ b/flink-clients/src/test/java/org/apache/flink/client/program/DefaultPackagedProgramRetrieverTest.java
@@ -49,6 +49,7 @@ import java.net.MalformedURLException;
 import java.net.URL;
 import java.nio.file.Path;
 import java.util.ArrayList;
+import java.util.Collection;
 import java.util.List;
 import java.util.stream.Collectors;
 
@@ -416,6 +417,27 @@ public class DefaultPackagedProgramRetrieverTest extends TestLogger {
         assertThat(
                 actualClasspath,
                 IsIterableContainingInAnyOrder.containsInAnyOrder(expectedClasspath.toArray()));
+    }
+
+    @Test
+    public void testRetrieveCorrectUserClasspathsWithPipelineClasspaths() throws Exception {
+        final Configuration configuration = new Configuration();
+        final List<String> pipelineJars = new ArrayList<>();
+        final Collection<URL> expectedMergedURLs = new ArrayList<>();
+        for (URL jarFile : singleEntryClassClasspathProvider.getURLUserClasspath()) {
+            pipelineJars.add(jarFile.toString());
+            expectedMergedURLs.add(jarFile);
+        }
+        configuration.set(PipelineOptions.CLASSPATHS, pipelineJars);
+
+        final PackagedProgramRetriever retrieverUnderTest =
+                DefaultPackagedProgramRetriever.create(
+                        null,
+                        singleEntryClassClasspathProvider.getJobClassName(),
+                        ClasspathProvider.parametersForTestJob("suffix"),
+                        configuration);
+        final JobGraph jobGraph = retrieveJobGraph(retrieverUnderTest, new Configuration());
+        assertThat(jobGraph.getClasspaths(), containsInAnyOrder(expectedMergedURLs.toArray()));
     }
 
     @Test


### PR DESCRIPTION
Backport of #14891 to `release-1.14`.