### PR TITLE
[FLINK-24822][table-planner]Improve CatalogTableSpecBase and its subclass related method parameter

### DIFF
--- a/flink-table/flink-table-planner/src/main/java/org/apache/flink/table/planner/plan/nodes/exec/common/CommonExecLookupJoin.java
+++ b/flink-table/flink-table-planner/src/main/java/org/apache/flink/table/planner/plan/nodes/exec/common/CommonExecLookupJoin.java
@@ -212,7 +212,8 @@ public abstract class CommonExecLookupJoin extends ExecNodeBase<RowData>
     @Override
     @SuppressWarnings("unchecked")
     public Transformation<RowData> translateToPlanInternal(PlannerBase planner) {
-        RelOptTable temporalTable = temporalTableSourceSpec.getTemporalTable(planner);
+        RelOptTable temporalTable =
+                temporalTableSourceSpec.getTemporalTable(planner.getFlinkContext());
         // validate whether the node is valid and supported.
         validate(temporalTable);
         final ExecEdge inputEdge = getInputEdges().get(0);

--- a/flink-table/flink-table-planner/src/main/java/org/apache/flink/table/planner/plan/nodes/exec/common/CommonExecSink.java
+++ b/flink-table/flink-table-planner/src/main/java/org/apache/flink/table/planner/plan/nodes/exec/common/CommonExecSink.java
@@ -114,7 +114,7 @@ public abstract class CommonExecSink extends ExecNodeBase<Object>
             Transformation<RowData> inputTransform,
             int rowtimeFieldIndex,
             boolean upsertMaterialize) {
-        final DynamicTableSink tableSink = tableSinkSpec.getTableSink(planner);
+        final DynamicTableSink tableSink = tableSinkSpec.getTableSink(planner.getFlinkContext());
         final ChangelogMode changelogMode = tableSink.getChangelogMode(inputChangelogMode);
         final ResolvedSchema schema = tableSinkSpec.getCatalogTable().getResolvedSchema();
 

--- a/flink-table/flink-table-planner/src/main/java/org/apache/flink/table/planner/plan/nodes/exec/common/CommonExecTableSourceScan.java
+++ b/flink-table/flink-table-planner/src/main/java/org/apache/flink/table/planner/plan/nodes/exec/common/CommonExecTableSourceScan.java
@@ -79,7 +79,8 @@ public abstract class CommonExecTableSourceScan extends ExecNodeBase<RowData>
         final String operatorName = getDescription();
         final InternalTypeInfo<RowData> outputTypeInfo =
                 InternalTypeInfo.of((RowType) getOutputType());
-        final ScanTableSource tableSource = tableSourceSpec.getScanTableSource(planner);
+        final ScanTableSource tableSource =
+                tableSourceSpec.getScanTableSource(planner.getFlinkContext());
         ScanTableSource.ScanRuntimeProvider provider =
                 tableSource.getScanRuntimeProvider(ScanRuntimeProviderContext.INSTANCE);
         if (provider instanceof SourceFunctionProvider) {

--- a/flink-table/flink-table-planner/src/main/java/org/apache/flink/table/planner/plan/nodes/exec/spec/DynamicTableSinkSpec.java
+++ b/flink-table/flink-table-planner/src/main/java/org/apache/flink/table/planner/plan/nodes/exec/spec/DynamicTableSinkSpec.java
@@ -24,7 +24,7 @@ import org.apache.flink.table.connector.sink.DynamicTableSink;
 import org.apache.flink.table.factories.DynamicTableSinkFactory;
 import org.apache.flink.table.factories.FactoryUtil;
 import org.apache.flink.table.module.Module;
-import org.apache.flink.table.planner.delegation.PlannerBase;
+import org.apache.flink.table.planner.calcite.FlinkContext;
 import org.apache.flink.table.planner.plan.abilities.sink.SinkAbilitySpec;
 
 import org.apache.flink.shaded.jackson2.com.fasterxml.jackson.annotation.JsonCreator;
@@ -62,10 +62,10 @@ public class DynamicTableSinkSpec extends CatalogTableSpecBase {
         this.sinkAbilitySpecs = sinkAbilitySpecs;
     }
 
-    public DynamicTableSink getTableSink(PlannerBase planner) {
+    public DynamicTableSink getTableSink(FlinkContext flinkContext) {
         if (tableSink == null) {
             final DynamicTableSinkFactory factory =
-                    planner.getFlinkContext()
+                    flinkContext
                             .getModuleManager()
                             .getFactory(Module::getTableSinkFactory)
                             .orElse(null);

--- a/flink-table/flink-table-planner/src/main/java/org/apache/flink/table/planner/plan/nodes/exec/spec/DynamicTableSourceSpec.java
+++ b/flink-table/flink-table-planner/src/main/java/org/apache/flink/table/planner/plan/nodes/exec/spec/DynamicTableSourceSpec.java
@@ -27,7 +27,7 @@ import org.apache.flink.table.connector.source.ScanTableSource;
 import org.apache.flink.table.factories.DynamicTableSourceFactory;
 import org.apache.flink.table.factories.FactoryUtil;
 import org.apache.flink.table.module.Module;
-import org.apache.flink.table.planner.delegation.PlannerBase;
+import org.apache.flink.table.planner.calcite.FlinkContext;
 import org.apache.flink.table.planner.plan.abilities.source.SourceAbilityContext;
 import org.apache.flink.table.planner.plan.abilities.source.SourceAbilitySpec;
 import org.apache.flink.table.types.logical.RowType;
@@ -70,11 +70,11 @@ public class DynamicTableSourceSpec extends CatalogTableSpecBase {
     }
 
     @JsonIgnore
-    private DynamicTableSource getTableSource(PlannerBase planner) {
+    private DynamicTableSource getTableSource(FlinkContext flinkContext) {
         checkNotNull(configuration);
         if (tableSource == null) {
             final DynamicTableSourceFactory factory =
-                    planner.getFlinkContext()
+                    flinkContext
                             .getModuleManager()
                             .getFactory(Module::getTableSourceFactory)
                             .orElse(null);
@@ -99,7 +99,7 @@ public class DynamicTableSourceSpec extends CatalogTableSpecBase {
                                         .getLogicalType();
                 for (SourceAbilitySpec spec : sourceAbilitySpecs) {
                     SourceAbilityContext context =
-                            new SourceAbilityContext(planner.getFlinkContext(), newProducedType);
+                            new SourceAbilityContext(flinkContext, newProducedType);
                     spec.apply(tableSource, context);
                     if (spec.getProducedType().isPresent()) {
                         newProducedType = spec.getProducedType().get();
@@ -111,8 +111,8 @@ public class DynamicTableSourceSpec extends CatalogTableSpecBase {
     }
 
     @JsonIgnore
-    public ScanTableSource getScanTableSource(PlannerBase planner) {
-        DynamicTableSource tableSource = getTableSource(planner);
+    public ScanTableSource getScanTableSource(FlinkContext flinkContext) {
+        DynamicTableSource tableSource = getTableSource(flinkContext);
         if (tableSource instanceof ScanTableSource) {
             return (ScanTableSource) tableSource;
         } else {
@@ -124,8 +124,8 @@ public class DynamicTableSourceSpec extends CatalogTableSpecBase {
     }
 
     @JsonIgnore
-    public LookupTableSource getLookupTableSource(PlannerBase planner) {
-        DynamicTableSource tableSource = getTableSource(planner);
+    public LookupTableSource getLookupTableSource(FlinkContext flinkContext) {
+        DynamicTableSource tableSource = getTableSource(flinkContext);
         if (tableSource instanceof LookupTableSource) {
             return (LookupTableSource) tableSource;
         } else {

--- a/flink-table/flink-table-planner/src/main/java/org/apache/flink/table/planner/plan/nodes/exec/spec/TemporalTableSourceSpec.java
+++ b/flink-table/flink-table-planner/src/main/java/org/apache/flink/table/planner/plan/nodes/exec/spec/TemporalTableSourceSpec.java
@@ -23,7 +23,7 @@ import org.apache.flink.table.api.TableException;
 import org.apache.flink.table.catalog.ObjectIdentifier;
 import org.apache.flink.table.catalog.ResolvedCatalogTable;
 import org.apache.flink.table.connector.source.LookupTableSource;
-import org.apache.flink.table.planner.delegation.PlannerBase;
+import org.apache.flink.table.planner.calcite.FlinkContext;
 import org.apache.flink.table.planner.plan.abilities.source.SourceAbilitySpec;
 import org.apache.flink.table.planner.plan.schema.TableSourceTable;
 import org.apache.flink.table.planner.plan.stats.FlinkStatistic;
@@ -85,12 +85,13 @@ public class TemporalTableSourceSpec {
     }
 
     @JsonIgnore
-    public RelOptTable getTemporalTable(PlannerBase planner) {
+    public RelOptTable getTemporalTable(FlinkContext flinkContext) {
         if (null != temporalTable) {
             return temporalTable;
         }
         if (null != tableSourceSpec && null != outputType) {
-            LookupTableSource lookupTableSource = tableSourceSpec.getLookupTableSource(planner);
+            LookupTableSource lookupTableSource =
+                    tableSourceSpec.getLookupTableSource(flinkContext);
             ObjectIdentifier objectIdentifier = tableSourceSpec.getObjectIdentifier();
             ResolvedCatalogTable catalogTable = tableSourceSpec.getCatalogTable();
             SourceAbilitySpec[] sourceAbilitySpecs = null;
@@ -106,7 +107,7 @@ public class TemporalTableSourceSpec {
                     lookupTableSource,
                     true,
                     catalogTable,
-                    planner.getFlinkContext(),
+                    flinkContext,
                     sourceAbilitySpecs);
         }
         throw new TableException("Can not obtain temporalTable correctly!");

--- a/flink-table/flink-table-planner/src/test/java/org/apache/flink/table/planner/plan/nodes/exec/serde/DynamicTableSinkSpecSerdeTest.java
+++ b/flink-table/flink-table-planner/src/test/java/org/apache/flink/table/planner/plan/nodes/exec/serde/DynamicTableSinkSpecSerdeTest.java
@@ -98,7 +98,7 @@ public class DynamicTableSinkSpecSerdeTest {
         TableEnvironmentImpl tableEnv =
                 (TableEnvironmentImpl)
                         TableEnvironment.create(EnvironmentSettings.inStreamingMode());
-        assertNotNull(actual.getTableSink((PlannerBase) tableEnv.getPlanner()));
+        assertNotNull(actual.getTableSink(((PlannerBase) tableEnv.getPlanner()).getFlinkContext()));
     }
 
     @Parameterized.Parameters(name = "{0}")

--- a/flink-table/flink-table-planner/src/test/java/org/apache/flink/table/planner/plan/nodes/exec/serde/DynamicTableSourceSpecSerdeTest.java
+++ b/flink-table/flink-table-planner/src/test/java/org/apache/flink/table/planner/plan/nodes/exec/serde/DynamicTableSourceSpecSerdeTest.java
@@ -121,7 +121,8 @@ public class DynamicTableSourceSpecSerdeTest {
         TableEnvironmentImpl tableEnv =
                 (TableEnvironmentImpl)
                         TableEnvironment.create(EnvironmentSettings.inStreamingMode());
-        assertNotNull(actual.getScanTableSource((PlannerBase) tableEnv.getPlanner()));
+        assertNotNull(
+                actual.getScanTableSource(((PlannerBase) tableEnv.getPlanner()).getFlinkContext()));
     }
 
     @Parameterized.Parameters(name = "{0}")


### PR DESCRIPTION
## What is the purpose of the change
Currently, CatalogTableSpecBase and its subclass related method use PlannerBase as parameter, we can improve it use FlinkContext enough.


## Brief change log
Currently, CatalogTableSpecBase and its subclass related method use PlannerBase as parameter, we can improve it use FlinkContext enough.


## Verifying this change

*(Please pick either of the following options)*

This change is already covered by existing tests, such as *DynamicTableSinkSpecSerdeTest, DynamicTableSourceSpecSerdeTest*.


## Does this pull request potentially affect one of the following parts:

  - Dependencies (does it add or upgrade a dependency): ( no)
  - The public API, i.e., is any changed class annotated with `@Public(Evolving)`: (no)
  - The serializers: ( no)
  - The runtime per-record code paths (performance sensitive): (no)
  - Anything that affects deployment or recovery: JobManager (and its components), Checkpointing, Kubernetes/Yarn, ZooKeeper: (no)
  - The S3 file system connector: (no)

## Documentation

  - Does this pull request introduce a new feature? (no)
  - If yes, how is the feature documented? (n not documented)
