### PR TITLE
[FLINK-24774] Adaptive scheduler notifies listeners for all job state transitions

### DIFF
--- a/flink-runtime/src/main/java/org/apache/flink/runtime/scheduler/adaptive/State.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/scheduler/adaptive/State.java
@@ -51,7 +51,8 @@ interface State {
     void suspend(Throwable cause);
 
     /**
-     * Gets the current {@link JobStatus}.
+     * Gets the current {@link JobStatus}. The returned job status will remain unchanged at least
+     * until the scheduler transitions to a different state.
      *
      * @return the current {@link JobStatus}
      */

--- a/flink-runtime/src/test/java/org/apache/flink/runtime/scheduler/adaptive/AdaptiveSchedulerTest.java
+++ b/flink-runtime/src/test/java/org/apache/flink/runtime/scheduler/adaptive/AdaptiveSchedulerTest.java
@@ -89,6 +89,7 @@ import javax.annotation.Nullable;
 import java.io.IOException;
 import java.time.Duration;
 import java.util.ArrayList;
+import java.util.Collection;
 import java.util.List;
 import java.util.Optional;
 import java.util.concurrent.ArrayBlockingQueue;
@@ -98,7 +99,7 @@ import java.util.concurrent.Executors;
 import java.util.concurrent.ScheduledExecutorService;
 import java.util.concurrent.TimeUnit;
 import java.util.concurrent.atomic.AtomicBoolean;
-import java.util.concurrent.atomic.AtomicReference;
+import java.util.concurrent.atomic.AtomicInteger;
 import java.util.function.Consumer;
 
 import static org.apache.flink.core.testutils.FlinkMatchers.futureFailedWith;
@@ -107,6 +108,7 @@ import static org.apache.flink.runtime.jobgraph.JobGraphTestUtils.streamingJobGr
 import static org.apache.flink.runtime.jobmaster.slotpool.DefaultDeclarativeSlotPoolTest.createSlotOffersForResourceRequirements;
 import static org.apache.flink.runtime.jobmaster.slotpool.SlotPoolTestUtils.offerSlots;
 import static org.hamcrest.Matchers.contains;
+import static org.hamcrest.Matchers.hasItems;
 import static org.hamcrest.Matchers.instanceOf;
 import static org.hamcrest.core.Is.is;
 import static org.junit.Assert.assertFalse;
@@ -607,21 +609,79 @@ public class AdaptiveSchedulerTest extends TestLogger {
     }
 
     @Test
-    public void testGoToFinishedNotifiesJobListener() throws Exception {
-        final AtomicReference<JobStatus> jobStatusUpdate = new AtomicReference<>();
+    public void testJobStatusListenerOnlyCalledIfJobStatusChanges() throws Exception {
+        final AtomicInteger numStatusUpdates = new AtomicInteger();
         final AdaptiveScheduler scheduler =
                 new AdaptiveSchedulerBuilder(createJobGraph(), mainThreadExecutor)
                         .setJobStatusListener(
                                 (jobId, newJobStatus, timestamp) ->
-                                        jobStatusUpdate.set(newJobStatus))
+                                        numStatusUpdates.incrementAndGet())
                         .build();
 
-        final ArchivedExecutionGraph archivedExecutionGraph =
-                new ArchivedExecutionGraphBuilder().setState(JobStatus.FAILED).build();
+        // sanity check
+        assertThat(
+                "Assumption about job status for Scheduler@Created is incorrect.",
+                scheduler.requestJobStatus(),
+                is(JobStatus.INITIALIZING));
 
-        scheduler.goToFinished(archivedExecutionGraph);
+        // transition into next state, for which the job state is still INITIALIZING
+        scheduler.goToWaitingForResources();
 
-        assertThat(jobStatusUpdate.get(), is(archivedExecutionGraph.getState()));
+        // sanity check
+        assertThat(
+                "Assumption about job status for Scheduler@WaitingForResources is incorrect.",
+                scheduler.requestJobStatus(),
+                is(JobStatus.INITIALIZING));
+
+        assertThat(numStatusUpdates.get(), is(0));
+    }
+
+    @Test
+    public void testJobStatusListenerNotifiedOfJobStatusChanges() throws Exception {
+        final JobGraph jobGraph = createJobGraph();
+        final DefaultDeclarativeSlotPool declarativeSlotPool =
+                createDeclarativeSlotPool(jobGraph.getJobID());
+
+        final Configuration configuration = new Configuration();
+        configuration.set(JobManagerOptions.RESOURCE_WAIT_TIMEOUT, Duration.ofMillis(1L));
+
+        final Collection<JobStatus> jobStatusNotifications = new ArrayList<>();
+        final AdaptiveScheduler scheduler =
+                new AdaptiveSchedulerBuilder(jobGraph, singleThreadMainThreadExecutor)
+                        .setJobMasterConfiguration(configuration)
+                        .setJobStatusListener(
+                                (jobId, newJobStatus, timestamp) ->
+                                        jobStatusNotifications.add(newJobStatus))
+                        .setDeclarativeSlotPool(declarativeSlotPool)
+                        .build();
+
+        final SubmissionBufferingTaskManagerGateway taskManagerGateway =
+                new SubmissionBufferingTaskManagerGateway(1 + PARALLELISM);
+
+        singleThreadMainThreadExecutor.execute(
+                () -> {
+                    scheduler.startScheduling();
+
+                    offerSlots(
+                            declarativeSlotPool,
+                            createSlotOffersForResourceRequirements(
+                                    ResourceCounter.withResource(ResourceProfile.UNKNOWN, 1)),
+                            taskManagerGateway);
+                });
+
+        // wait for the task submission
+        final TaskDeploymentDescriptor submittedTask = taskManagerGateway.submittedTasks.take();
+
+        // let the job finish
+        singleThreadMainThreadExecutor.execute(
+                () ->
+                        scheduler.updateTaskExecutionState(
+                                new TaskExecutionState(
+                                        submittedTask.getExecutionAttemptId(),
+                                        ExecutionState.FINISHED)));
+        scheduler.getJobTerminationFuture().get();
+
+        assertThat(jobStatusNotifications, hasItems(JobStatus.RUNNING, JobStatus.FINISHED));
     }
 
     @Test


### PR DESCRIPTION
The AdaptiveScheduler now informs the JobStatusListener of all state transitions. The current behavior of only reporting terminal states is surprising, and I intend to later hook into these notifications to capture the state timestamps directly in the AdaptiveScheduler for the job lifecycle metrics (FLINK-24775).

This change also sets up a contract that `State#getJobStatus` must return a constant value.