### PR TITLE
[FLINK-24761][table] Fix PartitionPruner code gen compile fail

### DIFF
--- a/flink-table/flink-sql-client/src/test/java/org/apache/flink/table/client/cli/CliClientITCase.java
+++ b/flink-table/flink-sql-client/src/test/java/org/apache/flink/table/client/cli/CliClientITCase.java
@@ -25,7 +25,8 @@ import org.apache.flink.table.client.config.Environment;
 import org.apache.flink.table.client.gateway.Executor;
 import org.apache.flink.table.client.gateway.context.DefaultContext;
 import org.apache.flink.table.client.gateway.local.LocalExecutor;
-import org.apache.flink.table.client.gateway.utils.TestUserClassLoaderJar;
+import org.apache.flink.table.client.gateway.utils.UserDefinedFunctions;
+import org.apache.flink.table.utils.TestUserClassLoaderJar;
 import org.apache.flink.test.util.AbstractTestBase;
 
 import org.apache.flink.shaded.guava18.com.google.common.io.PatternFilenameFilter;
@@ -101,7 +102,10 @@ public class CliClientITCase extends AbstractTestBase {
     public static void setup() throws IOException {
         File udfJar =
                 TestUserClassLoaderJar.createJarFile(
-                        tempFolder.newFolder("test-jar"), "test-classloader-udf.jar");
+                        tempFolder.newFolder("test-jar"),
+                        "test-classloader-udf.jar",
+                        UserDefinedFunctions.GENERATED_UDF_CLASS,
+                        UserDefinedFunctions.GENERATED_UDF_CODE);
         udfDependency = udfJar.toURI().toURL();
         historyPath = tempFolder.newFile("history").toPath();
 

--- a/flink-table/flink-sql-client/src/test/java/org/apache/flink/table/client/gateway/local/LocalExecutorITCase.java
+++ b/flink-table/flink-sql-client/src/test/java/org/apache/flink/table/client/gateway/local/LocalExecutorITCase.java
@@ -35,11 +35,12 @@ import org.apache.flink.table.client.gateway.TypedResult;
 import org.apache.flink.table.client.gateway.context.DefaultContext;
 import org.apache.flink.table.client.gateway.utils.EnvironmentFileUtil;
 import org.apache.flink.table.client.gateway.utils.SimpleCatalogFactory;
-import org.apache.flink.table.client.gateway.utils.TestUserClassLoaderJar;
+import org.apache.flink.table.client.gateway.utils.UserDefinedFunctions;
 import org.apache.flink.table.functions.ScalarFunction;
 import org.apache.flink.table.operations.Operation;
 import org.apache.flink.table.operations.QueryOperation;
 import org.apache.flink.table.planner.factories.utils.TestCollectionTableFactory;
+import org.apache.flink.table.utils.TestUserClassLoaderJar;
 import org.apache.flink.test.util.MiniClusterWithClientResource;
 import org.apache.flink.test.util.TestBaseUtils;
 import org.apache.flink.types.Row;
@@ -100,7 +101,10 @@ public class LocalExecutorITCase extends TestLogger {
         clusterClient = MINI_CLUSTER_RESOURCE.getClusterClient();
         File udfJar =
                 TestUserClassLoaderJar.createJarFile(
-                        tempFolder.newFolder("test-jar"), "test-classloader-udf.jar");
+                        tempFolder.newFolder("test-jar"),
+                        "test-classloader-udf.jar",
+                        UserDefinedFunctions.GENERATED_UDF_CLASS,
+                        UserDefinedFunctions.GENERATED_UDF_CODE);
         udfDependency = Collections.singletonList(udfJar.toURI().toURL());
     }
 

--- a/flink-table/flink-sql-client/src/test/java/org/apache/flink/table/client/gateway/utils/UserDefinedFunctions.java
+++ b/flink-table/flink-sql-client/src/test/java/org/apache/flink/table/client/gateway/utils/UserDefinedFunctions.java
@@ -29,6 +29,17 @@ import org.apache.flink.types.Row;
 /** A bunch of UDFs for testing the SQL Client. */
 public class UserDefinedFunctions {
 
+    public static final String GENERATED_UDF_CLASS = "LowerUDF";
+
+    public static final String GENERATED_UDF_CODE =
+            "public class "
+                    + GENERATED_UDF_CLASS
+                    + " extends org.apache.flink.table.functions.ScalarFunction {\n"
+                    + "  public String eval(String str) {\n"
+                    + "    return str.toLowerCase();\n"
+                    + "  }\n"
+                    + "}\n";
+
     /** The scalar function for SQL Client test. */
     public static class ScalarUDF extends ScalarFunction {
 

--- a/flink-table/flink-table-planner-blink/src/main/scala/org/apache/flink/table/planner/plan/utils/PartitionPruner.scala
+++ b/flink-table/flink-table-planner-blink/src/main/scala/org/apache/flink/table/planner/plan/utils/PartitionPruner.scala
@@ -109,7 +109,7 @@ object PartitionPruner {
       inputType,
       collectorTerm = collectorTerm)
 
-    val function = genFunction.newInstance(getClass.getClassLoader)
+    val function = genFunction.newInstance(Thread.currentThread().getContextClassLoader)
     val richMapFunction = function match {
       case r: RichMapFunction[GenericRowData, Boolean] => r
       case _ => throw new TableException("RichMapFunction[GenericRowData, Boolean] required here")

--- a/flink-table/flink-table-planner-blink/src/test/java/org/apache/flink/table/utils/TestUserClassLoaderJar.java
+++ b/flink-table/flink-table-planner-blink/src/test/java/org/apache/flink/table/utils/TestUserClassLoaderJar.java
@@ -16,7 +16,7 @@
  * limitations under the License.
  */
 
-package org.apache.flink.table.client.gateway.utils;
+package org.apache.flink.table.utils;
 
 import org.apache.flink.util.FileUtils;
 
@@ -34,27 +34,17 @@ import java.util.Collections;
 import java.util.jar.JarEntry;
 import java.util.jar.JarOutputStream;
 
-/** Mainly used for testing classloading of UDF dependencies. */
+/** Mainly used for testing classloading. */
 public class TestUserClassLoaderJar {
 
-    private static final String GENERATED_UDF_CLASS = "LowerUDF";
-
-    private static final String GENERATED_UDF_CODE =
-            "public class "
-                    + GENERATED_UDF_CLASS
-                    + " extends org.apache.flink.table.functions.ScalarFunction {\n"
-                    + "  public String eval(String str) {\n"
-                    + "    return str.toLowerCase();\n"
-                    + "  }\n"
-                    + "}\n";
-
     /** Pack the generated UDF class into a JAR and return the path of the JAR. */
-    public static File createJarFile(File tmpDir, String jarName) throws IOException {
+    public static File createJarFile(File tmpDir, String jarName, String className, String javaCode)
+            throws IOException {
         // write class source code to file
-        File javaFile = Paths.get(tmpDir.toString(), GENERATED_UDF_CLASS + ".java").toFile();
+        File javaFile = Paths.get(tmpDir.toString(), className + ".java").toFile();
         //noinspection ResultOfMethodCallIgnored
         javaFile.createNewFile();
-        FileUtils.writeFileUtf8(javaFile, GENERATED_UDF_CODE);
+        FileUtils.writeFileUtf8(javaFile, javaCode);
 
         // compile class source code
         DiagnosticCollector<JavaFileObject> diagnostics = new DiagnosticCollector<>();
@@ -74,10 +64,10 @@ public class TestUserClassLoaderJar {
         task.call();
 
         // pack class file to jar
-        File classFile = Paths.get(tmpDir.toString(), GENERATED_UDF_CLASS + ".class").toFile();
+        File classFile = Paths.get(tmpDir.toString(), className + ".class").toFile();
         File jarFile = Paths.get(tmpDir.toString(), jarName).toFile();
         JarOutputStream jos = new JarOutputStream(new FileOutputStream(jarFile));
-        JarEntry jarEntry = new JarEntry(GENERATED_UDF_CLASS + ".class");
+        JarEntry jarEntry = new JarEntry(className + ".class");
         jos.putNextEntry(jarEntry);
         byte[] classBytes = FileUtils.readAllBytes(classFile.toPath());
         jos.write(classBytes);

--- a/flink-table/flink-table-planner-blink/src/test/scala/org/apache/flink/table/planner/runtime/batch/sql/PartitionableSourceITCase.scala
+++ b/flink-table/flink-table-planner-blink/src/test/scala/org/apache/flink/table/planner/runtime/batch/sql/PartitionableSourceITCase.scala
@@ -18,15 +18,23 @@
 
 package org.apache.flink.table.planner.runtime.batch.sql
 
-import java.util
-
+import org.apache.flink.client.ClientUtils
+import org.apache.flink.configuration.Configuration
 import org.apache.flink.table.catalog.{CatalogPartitionImpl, CatalogPartitionSpec, ObjectPath}
 import org.apache.flink.table.planner.factories.{TestValuesCatalog, TestValuesTableFactory}
+import org.apache.flink.table.planner.runtime.utils.BatchAbstractTestBase.TEMPORARY_FOLDER
 import org.apache.flink.table.planner.runtime.utils.BatchTestBase
 import org.apache.flink.table.planner.runtime.utils.BatchTestBase.row
+import org.apache.flink.table.utils.TestUserClassLoaderJar
+import org.apache.flink.util.TemporaryClassLoaderContext
+
 import org.junit.{Before, Test}
 import org.junit.runner.RunWith
 import org.junit.runners.Parameterized
+
+import java.io.File
+import java.net.URL
+import java.util
 
 import scala.collection.JavaConversions._
 
@@ -119,6 +127,35 @@ class PartitionableSourceITCase(
         row(3, "Jack", "A", 2, 3)
       )
     )
+  }
+
+  @Test
+  def testPartitionPrunerCompileClassLoader(): Unit = {
+    val udfJavaCode =
+      s"""
+         |public class TrimUDF extends org.apache.flink.table.functions.ScalarFunction {
+         |   public String eval(String str) {
+         |     return str.trim();
+         |   }
+         |}
+         |""".stripMargin
+    val tmpDir: File = TEMPORARY_FOLDER.newFolder()
+    val udfJarFile: File = TestUserClassLoaderJar.createJarFile(
+      tmpDir, "flink-test-udf.jar", "TrimUDF", udfJavaCode)
+    val jars: util.List[URL] = util.Collections.singletonList(udfJarFile.toURI.toURL)
+    val cl = ClientUtils.buildUserCodeClassLoader(jars, util.Collections.emptyList(),
+      getClass.getClassLoader, new Configuration())
+    val ctx = TemporaryClassLoaderContext.of(cl)
+    try {
+      tEnv.executeSql("create temporary function trimUDF as 'TrimUDF'")
+      checkResult("select * from MyTable where trimUDF(part1) = 'A' and part2 > 1",
+        Seq(
+          row(3, "Jack", "A", 2, 3)
+        )
+      )
+    } finally {
+      ctx.close()
+    }
   }
 }
 


### PR DESCRIPTION
## What is the purpose of the change

Solve the problem of compile fail of PartitionPruner generated code due to classloader error.

## Brief change log

Change `PartitionPruner` compile classloader to `Thread.currentThread().getContextClassLoader` 

## Verifying this change

* add test `PartitionableSourceITCase#testPartitionPrunerCompileClassLoader`

## Does this pull request potentially affect one of the following parts:

  - Dependencies (does it add or upgrade a dependency): (no)
  - The public API, i.e., is any changed class annotated with `@Public(Evolving)`: (no)
  - The serializers: (no)
  - The runtime per-record code paths (performance sensitive): (no)
  - Anything that affects deployment or recovery: JobManager (and its components), Checkpointing, Kubernetes/Yarn, ZooKeeper: (no)
  - The S3 file system connector: (no)

## Documentation

  - Does this pull request introduce a new feature? (no)
  - If yes, how is the feature documented? (not documented)