### PR TITLE
[FLINK-24827][buildsystem] Bump maven-dependency-plugin to v3.2.0

### DIFF
--- a/flink-python/pyflink/pyflink_gateway_server.py
+++ b/flink-python/pyflink/pyflink_gateway_server.py
@@ -240,7 +240,7 @@ def download_apache_avro():
                         avro_version_output)
     check_output(
         [mvn,
-         "org.apache.maven.plugins:maven-dependency-plugin:2.10:copy",
+         "org.apache.maven.plugins:maven-dependency-plugin:3.2.0:copy",
          "-Dartifact=org.apache.avro:avro:%s:jar" % avro_version,
          "-DoutputDirectory=%s/flink-formats/flink-avro/target" % flink_source_root],
         cwd=flink_source_root)

--- a/pom.xml
+++ b/pom.xml
@@ -1870,15 +1870,7 @@ under the License.
 				<plugin>
 					<groupId>org.apache.maven.plugins</groupId>
 					<artifactId>maven-dependency-plugin</artifactId>
-					<version>3.1.1</version>
-					<dependencies>
-						<dependency>
-							<!-- Required for Java 11 support until 3.1.2 is released -->
-							<groupId>org.apache.maven.shared</groupId>
-							<artifactId>maven-dependency-analyzer</artifactId>
-							<version>1.11.1</version>
-						</dependency>
-					</dependencies>
+					<version>3.2.0</version>
 					<configuration>
 						<ignoredUsedUndeclaredDependencies combine.children="append">
 							<!-- allow using transitive Flink dependencies for brevity -->


### PR DESCRIPTION
## What is the purpose of the change

* Bump maven-dependency-plugin to latest available version (3.2.0)

## Brief change log

* Updated POM to use new version 3.2.0
* Changed outdated version used in PyFlink also to 3.2.0

## Verifying this change

This change is a trivial rework / code cleanup without any test coverage.

## Does this pull request potentially affect one of the following parts:

  - Dependencies (does it add or upgrade a dependency): (**yes** / no)
  - The public API, i.e., is any changed class annotated with `@Public(Evolving)`: (yes / **no**)
  - The serializers: (yes / **no** / don't know)
  - The runtime per-record code paths (performance sensitive): (yes / **no** / don't know)
  - Anything that affects deployment or recovery: JobManager (and its components), Checkpointing, Kubernetes/Yarn, ZooKeeper: (yes / **no** / don't know)
  - The S3 file system connector: (yes / **no** / don't know)

## Documentation

  - Does this pull request introduce a new feature? (yes / **no**)
  - If yes, how is the feature documented? (**not applicable** / docs / JavaDocs / not documented)
