### PR TITLE
[FLINK-24828][tests][testinfrastructure] Bump Powermock to v2.0.9

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -129,7 +129,7 @@ under the License.
 		<junit4.version>4.13.2</junit4.version>
 		<junit5.version>5.7.2</junit5.version>
 		<mockito.version>2.21.0</mockito.version>
-		<powermock.version>2.0.4</powermock.version>
+		<powermock.version>2.0.9</powermock.version>
 		<hamcrest.version>1.3</hamcrest.version>
 		<py4j.version>0.10.8.1</py4j.version>
 		<beam.version>2.27.0</beam.version>


### PR DESCRIPTION
## What is the purpose of the change

* Update Powermock to the latest available version (currently v2.0.9)

## Brief change log

* Updated POM file

## Verifying this change

This change is a trivial rework / code cleanup without any test coverage.

## Does this pull request potentially affect one of the following parts:

  - Dependencies (does it add or upgrade a dependency): (**yes** / no)
  - The public API, i.e., is any changed class annotated with `@Public(Evolving)`: (yes / **no**)
  - The serializers: (yes / **no** / don't know)
  - The runtime per-record code paths (performance sensitive): (yes / **no** / don't know)
  - Anything that affects deployment or recovery: JobManager (and its components), Checkpointing, Kubernetes/Yarn, ZooKeeper: (yes / **no** / don't know)
  - The S3 file system connector: (yes / **no** / don't know)

## Documentation

  - Does this pull request introduce a new feature? (yes / **no**)
  - If yes, how is the feature documented? (**not applicable** / docs / JavaDocs / not documented)
