### PR TITLE
[FLINK-24834][connectors / filesystem] Add typed builders to DefaultRollingPolicy

### DIFF
--- a/docs/content.zh/docs/connectors/datastream/file_sink.md
+++ b/docs/content.zh/docs/connectors/datastream/file_sink.md
@@ -64,13 +64,16 @@ File Sink 会将数据写入到桶中。由于输入流可能是无界的，因�
 字符串元素写入示例：
 
 
-{{< tabs "946da1d5-b046-404e-ab80-a5a5d251d8ee" >}}
+{{< tabs "08046394-3912-497d-ab4b-e07a0ef1f519" >}}
 {{< tab "Java" >}}
 ```java
 import org.apache.flink.api.common.serialization.SimpleStringEncoder;
 import org.apache.flink.core.fs.Path;
+import org.apache.flink.configuration.MemorySize;
 import org.apache.flink.connector.file.sink.FileSink;
 import org.apache.flink.streaming.api.functions.sink.filesystem.rollingpolicies.DefaultRollingPolicy;
+
+import java.time.Duration;
 
 DataStream<String> input = ...;
 
@@ -78,9 +81,9 @@ final FileSink<String> sink = FileSink
     .forRowFormat(new Path(outputPath), new SimpleStringEncoder<String>("UTF-8"))
     .withRollingPolicy(
         DefaultRollingPolicy.builder()
-            .withRolloverInterval(TimeUnit.MINUTES.toMillis(15))
-            .withInactivityInterval(TimeUnit.MINUTES.toMillis(5))
-            .withMaxPartSize(1024 * 1024 * 1024)
+            .withRolloverInterval(Duration.ofSeconds(10))
+            .withInactivityInterval(Duration.ofSeconds(10))
+            .withMaxPartSize(MemorySize.parse("1mb"))
             .build())
 	.build();
 
@@ -92,8 +95,11 @@ input.sinkTo(sink);
 ```scala
 import org.apache.flink.api.common.serialization.SimpleStringEncoder
 import org.apache.flink.core.fs.Path
+import org.apache.flink.configuration.MemorySize
 import org.apache.flink.connector.file.sink.FileSink
 import org.apache.flink.streaming.api.functions.sink.filesystem.rollingpolicies.DefaultRollingPolicy
+
+import java.time.Duration
 
 val input: DataStream[String] = ...
 
@@ -101,9 +107,9 @@ val sink: FileSink[String] = FileSink
     .forRowFormat(new Path(outputPath), new SimpleStringEncoder[String]("UTF-8"))
     .withRollingPolicy(
         DefaultRollingPolicy.builder()
-            .withRolloverInterval(TimeUnit.MINUTES.toMillis(15))
-            .withInactivityInterval(TimeUnit.MINUTES.toMillis(5))
-            .withMaxPartSize(1024 * 1024 * 1024)
+            .withRolloverInterval(Duration.ofSeconds(10))
+            .withInactivityInterval(Duration.ofSeconds(10))
+            .withMaxPartSize(MemorySize.parse("1mb"))
             .build())
     .build()
 

--- a/docs/content.zh/docs/connectors/datastream/streamfile_sink.md
+++ b/docs/content.zh/docs/connectors/datastream/streamfile_sink.md
@@ -104,9 +104,9 @@ val sink: StreamingFileSink[String] = StreamingFileSink
     .forRowFormat(new Path(outputPath), new SimpleStringEncoder[String]("UTF-8"))
     .withRollingPolicy(
         DefaultRollingPolicy.builder()
-            .withRolloverInterval(TimeUnit.MINUTES.toMillis(15))
-            .withInactivityInterval(TimeUnit.MINUTES.toMillis(5))
-            .withMaxPartSize(1024 * 1024 * 1024)
+            .withRolloverInterval(Duration.ofSeconds(10))
+            .withInactivityInterval(Duration.ofSeconds(10))
+            .withMaxPartSize(MemorySize.parse("1mb"))
             .build())
     .build()
 

--- a/docs/content/docs/connectors/datastream/file_sink.md
+++ b/docs/content/docs/connectors/datastream/file_sink.md
@@ -76,7 +76,7 @@ that is used for serializing individual rows to the `OutputStream` of the in-pro
 In addition to the bucket assigner, the RowFormatBuilder allows the user to specify:
 
  - Custom RollingPolicy : Rolling policy to override the DefaultRollingPolicy
- - bucketCheckInterval (default = 1 min) : Millisecond interval for checking time based rolling policies
+ - bucketCheckInterval (default = 1 min) : Interval for checking time based rolling policies
 
 Basic usage for writing String elements thus looks like this:
 
@@ -86,8 +86,11 @@ Basic usage for writing String elements thus looks like this:
 ```java
 import org.apache.flink.api.common.serialization.SimpleStringEncoder;
 import org.apache.flink.core.fs.Path;
+import org.apache.flink.configuration.MemorySize;
 import org.apache.flink.connector.file.sink.FileSink;
 import org.apache.flink.streaming.api.functions.sink.filesystem.rollingpolicies.DefaultRollingPolicy;
+
+import java.time.Duration;
 
 DataStream<String> input = ...;
 
@@ -95,9 +98,9 @@ final FileSink<String> sink = FileSink
     .forRowFormat(new Path(outputPath), new SimpleStringEncoder<String>("UTF-8"))
     .withRollingPolicy(
         DefaultRollingPolicy.builder()
-            .withRolloverInterval(TimeUnit.MINUTES.toMillis(15))
-            .withInactivityInterval(TimeUnit.MINUTES.toMillis(5))
-            .withMaxPartSize(1024 * 1024 * 1024)
+            .withRolloverInterval(Duration.ofSeconds(10))
+            .withInactivityInterval(Duration.ofSeconds(10))
+            .withMaxPartSize(MemorySize.parse("1mb"))
             .build())
 	.build();
 
@@ -109,8 +112,11 @@ input.sinkTo(sink);
 ```scala
 import org.apache.flink.api.common.serialization.SimpleStringEncoder
 import org.apache.flink.core.fs.Path
+import org.apache.flink.configuration.MemorySize
 import org.apache.flink.connector.file.sink.FileSink
 import org.apache.flink.streaming.api.functions.sink.filesystem.rollingpolicies.DefaultRollingPolicy
+
+import java.time.Duration
 
 val input: DataStream[String] = ...
 
@@ -118,9 +124,9 @@ val sink: FileSink[String] = FileSink
     .forRowFormat(new Path(outputPath), new SimpleStringEncoder[String]("UTF-8"))
     .withRollingPolicy(
         DefaultRollingPolicy.builder()
-            .withRolloverInterval(TimeUnit.MINUTES.toMillis(15))
-            .withInactivityInterval(TimeUnit.MINUTES.toMillis(5))
-            .withMaxPartSize(1024 * 1024 * 1024)
+            .withRolloverInterval(Duration.ofSeconds(10))
+            .withInactivityInterval(Duration.ofSeconds(10))
+            .withMaxPartSize(MemorySize.parse("1mb"))
             .build())
     .build()
 

--- a/docs/content/docs/connectors/datastream/streamfile_sink.md
+++ b/docs/content/docs/connectors/datastream/streamfile_sink.md
@@ -91,9 +91,9 @@ final StreamingFileSink<String> sink = StreamingFileSink
     .forRowFormat(new Path(outputPath), new SimpleStringEncoder<String>("UTF-8"))
     .withRollingPolicy(
         DefaultRollingPolicy.builder()
-            .withRolloverInterval(TimeUnit.MINUTES.toMillis(15))
-            .withInactivityInterval(TimeUnit.MINUTES.toMillis(5))
-            .withMaxPartSize(1024 * 1024 * 1024)
+            .withRolloverInterval(Duration.ofSeconds(10))
+            .withInactivityInterval(Duration.ofSeconds(10))
+            .withMaxPartSize(MemorySize.parse("1mb"))
             .build())
 	.build();
 
@@ -114,9 +114,9 @@ val sink: StreamingFileSink[String] = StreamingFileSink
     .forRowFormat(new Path(outputPath), new SimpleStringEncoder[String]("UTF-8"))
     .withRollingPolicy(
         DefaultRollingPolicy.builder()
-            .withRolloverInterval(TimeUnit.MINUTES.toMillis(15))
-            .withInactivityInterval(TimeUnit.MINUTES.toMillis(5))
-            .withMaxPartSize(1024 * 1024 * 1024)
+            .withRolloverInterval(Duration.ofSeconds(10))
+            .withInactivityInterval(Duration.ofSeconds(10))
+            .withMaxPartSize(MemorySize.parse("1mb"))
             .build())
     .build()
 

--- a/flink-connectors/flink-connector-files/src/test/java/org/apache/flink/connector/file/sink/writer/FileWriterBucketStateSerializerMigrationTest.java
+++ b/flink-connectors/flink-connector-files/src/test/java/org/apache/flink/connector/file/sink/writer/FileWriterBucketStateSerializerMigrationTest.java
@@ -19,6 +19,7 @@
 package org.apache.flink.connector.file.sink.writer;
 
 import org.apache.flink.api.common.serialization.SimpleStringEncoder;
+import org.apache.flink.configuration.MemorySize;
 import org.apache.flink.connector.file.sink.FileSinkCommittable;
 import org.apache.flink.connector.file.sink.committer.FileCommitter;
 import org.apache.flink.core.fs.FileSystem;
@@ -257,7 +258,7 @@ public class FileWriterBucketStateSerializerMigrationTest {
             throws IOException {
         return FileWriterBucket.restore(
                 createBucketWriter(),
-                DefaultRollingPolicy.builder().withMaxPartSize(10).build(),
+                DefaultRollingPolicy.builder().withMaxPartSize(new MemorySize(10)).build(),
                 bucketState,
                 OutputFileConfig.builder().build());
     }

--- a/flink-connectors/flink-connector-files/src/test/java/org/apache/flink/connector/file/sink/writer/FileWriterBucketTest.java
+++ b/flink-connectors/flink-connector-files/src/test/java/org/apache/flink/connector/file/sink/writer/FileWriterBucketTest.java
@@ -46,6 +46,7 @@ import org.junit.rules.TemporaryFolder;
 
 import java.io.File;
 import java.io.IOException;
+import java.time.Duration;
 import java.util.ArrayList;
 import java.util.HashMap;
 import java.util.List;
@@ -200,7 +201,7 @@ public class FileWriterBucketTest {
         Path path = new Path(outDir.toURI());
 
         RollingPolicy<String, String> onProcessingTimeRollingPolicy =
-                DefaultRollingPolicy.builder().withRolloverInterval(10).build();
+                DefaultRollingPolicy.builder().withRolloverInterval(Duration.ofMillis(10)).build();
 
         TestRecoverableWriter recoverableWriter = getRecoverableWriter(path);
         FileWriterBucket<String> bucket =

--- a/flink-connectors/flink-connector-files/src/test/java/org/apache/flink/connector/file/sink/writer/FileWriterTest.java
+++ b/flink-connectors/flink-connector-files/src/test/java/org/apache/flink/connector/file/sink/writer/FileWriterTest.java
@@ -50,6 +50,7 @@ import org.junit.rules.TemporaryFolder;
 
 import java.io.File;
 import java.io.IOException;
+import java.time.Duration;
 import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.Collections;
@@ -219,7 +220,9 @@ public class FileWriterTest {
                 createWriter(
                         path,
                         new FileSinkTestUtils.StringIdentityBucketAssigner(),
-                        DefaultRollingPolicy.builder().withRolloverInterval(10).build(),
+                        DefaultRollingPolicy.builder()
+                                .withRolloverInterval(Duration.ofMillis(10))
+                                .build(),
                         new OutputFileConfig("part-", ""),
                         processingTimeService,
                         5);
@@ -311,7 +314,9 @@ public class FileWriterTest {
                 createWriter(
                         path,
                         new VerifyingBucketAssigner(timestamp, watermark, processingTime),
-                        DefaultRollingPolicy.builder().withRolloverInterval(10).build(),
+                        DefaultRollingPolicy.builder()
+                                .withRolloverInterval(Duration.ofMillis(10))
+                                .build(),
                         new OutputFileConfig("part-", ""),
                         processingTimeService,
                         5);

--- a/flink-streaming-java/src/test/java/org/apache/flink/streaming/api/functions/sink/filesystem/BucketAssignerITCases.java
+++ b/flink-streaming-java/src/test/java/org/apache/flink/streaming/api/functions/sink/filesystem/BucketAssignerITCases.java
@@ -19,6 +19,7 @@
 package org.apache.flink.streaming.api.functions.sink.filesystem;
 
 import org.apache.flink.api.common.serialization.SimpleStringEncoder;
+import org.apache.flink.configuration.MemorySize;
 import org.apache.flink.core.fs.FileSystem;
 import org.apache.flink.core.fs.Path;
 import org.apache.flink.streaming.api.functions.sink.filesystem.bucketassigners.BasePathBucketAssigner;
@@ -43,7 +44,7 @@ public class BucketAssignerITCases {
         final long time = 1000L;
 
         final RollingPolicy<String, String> rollingPolicy =
-                DefaultRollingPolicy.builder().withMaxPartSize(7L).build();
+                DefaultRollingPolicy.builder().withMaxPartSize(new MemorySize(7L)).build();
 
         final Buckets<String, String> buckets =
                 new Buckets<>(

--- a/flink-streaming-java/src/test/java/org/apache/flink/streaming/api/functions/sink/filesystem/BucketStateGenerator.java
+++ b/flink-streaming-java/src/test/java/org/apache/flink/streaming/api/functions/sink/filesystem/BucketStateGenerator.java
@@ -19,6 +19,7 @@
 package org.apache.flink.streaming.api.functions.sink.filesystem;
 
 import org.apache.flink.api.common.serialization.SimpleStringEncoder;
+import org.apache.flink.configuration.MemorySize;
 import org.apache.flink.core.fs.FileSystem;
 import org.apache.flink.core.fs.Path;
 import org.apache.flink.core.io.SimpleVersionedSerialization;
@@ -166,7 +167,7 @@ public class BucketStateGenerator {
                 bucketPath,
                 0,
                 createBucketWriter(),
-                DefaultRollingPolicy.builder().withMaxPartSize(10).build(),
+                DefaultRollingPolicy.builder().withMaxPartSize(new MemorySize(10)).build(),
                 null,
                 OutputFileConfig.builder().build());
     }

--- a/flink-streaming-java/src/test/java/org/apache/flink/streaming/api/functions/sink/filesystem/BucketStateSerializerTest.java
+++ b/flink-streaming-java/src/test/java/org/apache/flink/streaming/api/functions/sink/filesystem/BucketStateSerializerTest.java
@@ -19,6 +19,7 @@
 package org.apache.flink.streaming.api.functions.sink.filesystem;
 
 import org.apache.flink.api.common.serialization.SimpleStringEncoder;
+import org.apache.flink.configuration.MemorySize;
 import org.apache.flink.core.fs.FileSystem;
 import org.apache.flink.core.fs.Path;
 import org.apache.flink.core.io.SimpleVersionedSerialization;
@@ -242,7 +243,7 @@ public class BucketStateSerializerTest {
                 0,
                 initialPartCounter,
                 createBucketWriter(),
-                DefaultRollingPolicy.builder().withMaxPartSize(10).build(),
+                DefaultRollingPolicy.builder().withMaxPartSize(new MemorySize(10)).build(),
                 bucketState,
                 null,
                 OutputFileConfig.builder().build());

--- a/flink-streaming-java/src/test/java/org/apache/flink/streaming/api/functions/sink/filesystem/BucketsRollingPolicyTest.java
+++ b/flink-streaming-java/src/test/java/org/apache/flink/streaming/api/functions/sink/filesystem/BucketsRollingPolicyTest.java
@@ -19,6 +19,7 @@
 package org.apache.flink.streaming.api.functions.sink.filesystem;
 
 import org.apache.flink.api.common.serialization.SimpleStringEncoder;
+import org.apache.flink.configuration.MemorySize;
 import org.apache.flink.core.fs.FileSystem;
 import org.apache.flink.core.fs.Path;
 import org.apache.flink.streaming.api.functions.sink.filesystem.rollingpolicies.DefaultRollingPolicy;
@@ -32,6 +33,7 @@ import org.junit.rules.TemporaryFolder;
 
 import java.io.File;
 import java.io.IOException;
+import java.time.Duration;
 
 /** Tests for different {@link RollingPolicy rolling policies}. */
 public class BucketsRollingPolicyTest {
@@ -45,9 +47,9 @@ public class BucketsRollingPolicyTest {
 
         final RollingPolicy<String, String> originalRollingPolicy =
                 DefaultRollingPolicy.builder()
-                        .withMaxPartSize(10L)
-                        .withInactivityInterval(4L)
-                        .withRolloverInterval(11L)
+                        .withMaxPartSize(new MemorySize(10L))
+                        .withInactivityInterval(Duration.ofMillis(4L))
+                        .withRolloverInterval(Duration.ofMillis(11L))
                         .build();
 
         final MethodCallCountingPolicyWrapper<String, String> rollingPolicy =
@@ -87,10 +89,10 @@ public class BucketsRollingPolicyTest {
     @Test
     public void testDefaultRollingPolicyDeprecatedCreate() throws Exception {
         DefaultRollingPolicy policy =
-                DefaultRollingPolicy.create()
-                        .withInactivityInterval(10)
-                        .withMaxPartSize(20)
-                        .withRolloverInterval(30)
+                DefaultRollingPolicy.builder()
+                        .withInactivityInterval(Duration.ofMillis(10))
+                        .withMaxPartSize(new MemorySize(20))
+                        .withRolloverInterval(Duration.ofMillis(30))
                         .build();
 
         Assert.assertEquals(10, policy.getInactivityInterval());

--- a/flink-streaming-java/src/test/java/org/apache/flink/streaming/api/functions/sink/filesystem/BucketsTest.java
+++ b/flink-streaming-java/src/test/java/org/apache/flink/streaming/api/functions/sink/filesystem/BucketsTest.java
@@ -21,6 +21,7 @@ package org.apache.flink.streaming.api.functions.sink.filesystem;
 import org.apache.flink.api.common.serialization.SimpleStringEncoder;
 import org.apache.flink.api.common.state.ListState;
 import org.apache.flink.api.java.tuple.Tuple2;
+import org.apache.flink.configuration.MemorySize;
 import org.apache.flink.core.fs.FileSystem;
 import org.apache.flink.core.fs.Path;
 import org.apache.flink.core.io.SimpleVersionedSerializer;
@@ -128,7 +129,7 @@ public class BucketsTest {
 
         final RollingPolicy<String, String> onCheckpointRP =
                 DefaultRollingPolicy.builder()
-                        .withMaxPartSize(7L) // roll with 2 elements
+                        .withMaxPartSize(new MemorySize(7L)) // roll with 2 elements
                         .build();
 
         final MockListState<byte[]> bucketStateContainerOne = new MockListState<>();

--- a/flink-streaming-java/src/test/java/org/apache/flink/streaming/api/functions/sink/filesystem/LocalStreamingFileSinkTest.java
+++ b/flink-streaming-java/src/test/java/org/apache/flink/streaming/api/functions/sink/filesystem/LocalStreamingFileSinkTest.java
@@ -19,6 +19,7 @@
 package org.apache.flink.streaming.api.functions.sink.filesystem;
 
 import org.apache.flink.api.java.tuple.Tuple2;
+import org.apache.flink.configuration.MemorySize;
 import org.apache.flink.runtime.checkpoint.OperatorSubtaskState;
 import org.apache.flink.streaming.api.functions.sink.filesystem.TestUtils.Tuple2Encoder;
 import org.apache.flink.streaming.api.functions.sink.filesystem.TestUtils.TupleToIntegerBucketer;
@@ -34,6 +35,7 @@ import org.junit.Test;
 import org.junit.rules.TemporaryFolder;
 
 import java.io.File;
+import java.time.Duration;
 import java.util.Map;
 
 /** Tests for the {@link StreamingFileSink}. */
@@ -423,9 +425,9 @@ public class LocalStreamingFileSinkTest extends TestLogger {
         final long inactivityInterval = 100L;
         final RollingPolicy<Tuple2<String, Integer>, Integer> rollingPolicy =
                 DefaultRollingPolicy.builder()
-                        .withMaxPartSize(partMaxSize)
-                        .withRolloverInterval(inactivityInterval)
-                        .withInactivityInterval(inactivityInterval)
+                        .withMaxPartSize(new MemorySize(partMaxSize))
+                        .withRolloverInterval(Duration.ofMillis(inactivityInterval))
+                        .withInactivityInterval(Duration.ofMillis(inactivityInterval))
                         .build();
 
         try (OneInputStreamOperatorTestHarness<Tuple2<String, Integer>, Object> testHarness =

--- a/flink-streaming-java/src/test/java/org/apache/flink/streaming/api/functions/sink/filesystem/TestUtils.java
+++ b/flink-streaming-java/src/test/java/org/apache/flink/streaming/api/functions/sink/filesystem/TestUtils.java
@@ -22,6 +22,7 @@ import org.apache.flink.api.common.serialization.BulkWriter;
 import org.apache.flink.api.common.serialization.Encoder;
 import org.apache.flink.api.common.state.ListState;
 import org.apache.flink.api.java.tuple.Tuple2;
+import org.apache.flink.configuration.MemorySize;
 import org.apache.flink.core.fs.Path;
 import org.apache.flink.core.io.SimpleVersionedSerializer;
 import org.apache.flink.streaming.api.functions.sink.SinkFunction;
@@ -42,6 +43,7 @@ import java.io.OutputStream;
 import java.nio.ByteBuffer;
 import java.nio.ByteOrder;
 import java.nio.charset.StandardCharsets;
+import java.time.Duration;
 import java.util.ArrayList;
 import java.util.Collection;
 import java.util.HashMap;
@@ -67,9 +69,9 @@ public class TestUtils {
 
         final RollingPolicy<Tuple2<String, Integer>, String> rollingPolicy =
                 DefaultRollingPolicy.builder()
-                        .withMaxPartSize(partMaxSize)
-                        .withRolloverInterval(inactivityInterval)
-                        .withInactivityInterval(inactivityInterval)
+                        .withMaxPartSize(new MemorySize(partMaxSize))
+                        .withRolloverInterval(Duration.ofMillis(inactivityInterval))
+                        .withInactivityInterval(Duration.ofMillis(inactivityInterval))
                         .build();
 
         return createRescalingTestSink(

--- a/flink-tests/src/test/java/org/apache/flink/test/streaming/api/functions/source/ContinuousFileReaderOperatorITCase.java
+++ b/flink-tests/src/test/java/org/apache/flink/test/streaming/api/functions/source/ContinuousFileReaderOperatorITCase.java
@@ -18,6 +18,7 @@
 package org.apache.flink.test.streaming.api.functions.source;
 
 import org.apache.flink.api.common.serialization.SimpleStringEncoder;
+import org.apache.flink.configuration.MemorySize;
 import org.apache.flink.connector.file.sink.FileSink;
 import org.apache.flink.core.fs.Path;
 import org.apache.flink.streaming.api.datastream.DataStream;
@@ -53,7 +54,9 @@ public class ContinuousFileReaderOperatorITCase {
                                 new SimpleStringEncoder<String>())
                         .withOutputFileConfig(OutputFileConfig.builder().build())
                         .withRollingPolicy(
-                                DefaultRollingPolicy.builder().withMaxPartSize(1024 * 1024).build())
+                                DefaultRollingPolicy.builder()
+                                        .withMaxPartSize(MemorySize.ofMebiBytes(1))
+                                        .build())
                         .build();
         stream.sinkTo(sink);
         env.execute("test");


### PR DESCRIPTION
## What is the purpose of the change

The default RollingPolicy is configured based on durations and memory sizes, but these parameters are specified via longs (milliseconds and bytes). We can provide a better user experience by adding methods that accept `java.time.Duration` and `org.apache.flink.configuration.MemorySize` instead. 

## Brief change log

- `withMaxPartSize(MemorySize)`
- `withInactivityInterval(Duration)`
- `withRolloverInterval(Duration)`


## Verifying this change

This change is a trivial rework / code cleanup without any test coverage.

## Does this pull request potentially affect one of the following parts:

  - Dependencies (does it add or upgrade a dependency): (yes / **no**)
  - The public API, i.e., is any changed class annotated with `@Public(Evolving)`: (**yes** / no)
  - The serializers: (yes / **no** / don't know)
  - The runtime per-record code paths (performance sensitive): (yes / **no** / don't know)
  - Anything that affects deployment or recovery: JobManager (and its components), Checkpointing, Kubernetes/Yarn, ZooKeeper: (yes / **no** / don't know)
  - The S3 file system connector: (yes / **no** / don't know)

## Documentation

  - Does this pull request introduce a new feature? (**yes** / no)
  - If yes, how is the feature documented? (not applicable / **docs** / JavaDocs / not documented)
