### PR TITLE
[FLINK-24835][table-planner] Fix bug in `RelTimeIndicatorConverter` when materialize time attribute fields of regular join's inputs

### DIFF
--- a/flink-table/flink-table-planner/src/main/java/org/apache/flink/table/planner/calcite/RelTimeIndicatorConverter.java
+++ b/flink-table/flink-table-planner/src/main/java/org/apache/flink/table/planner/calcite/RelTimeIndicatorConverter.java
@@ -265,7 +265,7 @@ public final class RelTimeIndicatorConverter extends RelHomogeneousShuttle {
         int leftFieldCount = newLeft.getRowType().getFieldCount();
 
         // temporal table join
-        if (TemporalJoinUtil.satisfyTemporalJoin(join)) {
+        if (TemporalJoinUtil.satisfyTemporalJoin(join, newLeft, newRight)) {
             RelNode rewrittenTemporalJoin =
                     join.copy(
                             join.getTraitSet(),
@@ -282,7 +282,7 @@ public final class RelTimeIndicatorConverter extends RelHomogeneousShuttle {
                             .collect(Collectors.toSet());
             return createCalcToMaterializeTimeIndicators(rewrittenTemporalJoin, rightIndices);
         } else {
-            if (JoinUtil.satisfyRegularJoin(join, join.getRight())) {
+            if (JoinUtil.satisfyRegularJoin(join, newLeft, newRight)) {
                 // materialize time attribute fields of regular join's inputs
                 newLeft = materializeTimeIndicators(newLeft);
                 newRight = materializeTimeIndicators(newRight);

--- a/flink-table/flink-table-planner/src/main/scala/org/apache/flink/table/planner/plan/rules/physical/stream/StreamPhysicalJoinRule.scala
+++ b/flink-table/flink-table-planner/src/main/scala/org/apache/flink/table/planner/plan/rules/physical/stream/StreamPhysicalJoinRule.scala
@@ -44,7 +44,7 @@ class StreamPhysicalJoinRule
     val left: FlinkLogicalRel = call.rel(1).asInstanceOf[FlinkLogicalRel]
     val right: FlinkLogicalRel = call.rel(2).asInstanceOf[FlinkLogicalRel]
 
-    if (!satisfyRegularJoin(join, right)) {
+    if (!satisfyRegularJoin(join, left, right)) {
       return false
     }
 

--- a/flink-table/flink-table-planner/src/main/scala/org/apache/flink/table/planner/plan/utils/JoinUtil.scala
+++ b/flink-table/flink-table-planner/src/main/scala/org/apache/flink/table/planner/plan/utils/JoinUtil.scala
@@ -237,34 +237,23 @@ object JoinUtil {
    * Check whether input join node satisfy preconditions to convert into regular join.
    *
    * @param join input join to analyze.
+   * @param newLeft new left child of join
+   * @param newRight new right child of join
    *
    * @return True if input join node satisfy preconditions to convert into regular join,
    *         else false.
    */
-  def satisfyRegularJoin(join: FlinkLogicalJoin): Boolean = {
-    satisfyRegularJoin(join, join.getRight)
-  }
-
-  /**
-   * Check whether input join node satisfy preconditions to convert into regular join.
-   *
-   * @param join input join to analyze.
-   * @param right right child of input join
-   *
-   * @return True if input join node satisfy preconditions to convert into regular join,
-   *         else false.
-   */
-  def satisfyRegularJoin(join: FlinkLogicalJoin, right: RelNode): Boolean = {
-    if (right.isInstanceOf[FlinkLogicalSnapshot]) {
+  def satisfyRegularJoin(join: FlinkLogicalJoin, newLeft: RelNode, newRight: RelNode): Boolean = {
+    if (newRight.isInstanceOf[FlinkLogicalSnapshot]) {
       // exclude lookup join
       false
-    } else if (satisfyTemporalJoin(join)) {
+    } else if (satisfyTemporalJoin(join, newLeft, newRight)) {
       // exclude temporal table join
       false
-    } else if (satisfyIntervalJoin(join)) {
+    } else if (satisfyIntervalJoin(join, newLeft, newRight)) {
       // exclude interval join
       false
-    } else if (satisfyWindowJoin(join)) {
+    } else if (satisfyWindowJoin(join, newLeft, newRight)) {
       // exclude window join
       false
     } else {

--- a/flink-table/flink-table-planner/src/main/scala/org/apache/flink/table/planner/plan/utils/TemporalJoinUtil.scala
+++ b/flink-table/flink-table-planner/src/main/scala/org/apache/flink/table/planner/plan/utils/TemporalJoinUtil.scala
@@ -24,6 +24,7 @@ import org.apache.flink.table.planner.plan.nodes.exec.spec.JoinSpec
 import org.apache.flink.util.Preconditions.checkState
 
 import org.apache.calcite.rel.core.{JoinInfo, JoinRelType}
+import org.apache.calcite.rel.RelNode
 import org.apache.calcite.rex._
 import org.apache.calcite.sql.`type`.{OperandTypes, ReturnTypes}
 import org.apache.calcite.sql.{SqlFunction, SqlFunctionCategory, SqlKind}
@@ -424,10 +425,14 @@ object TemporalJoinUtil {
    *         else false.
    */
   def satisfyTemporalJoin(join: FlinkLogicalJoin): Boolean = {
+    satisfyTemporalJoin(join, join.getLeft, join.getRight)
+  }
+
+  def satisfyTemporalJoin(join: FlinkLogicalJoin, newLeft: RelNode, newRight: RelNode): Boolean = {
     if (!containsTemporalJoinCondition(join.getCondition)) {
       return false
     }
-    val joinInfo = JoinInfo.of(join.getLeft, join.getRight, join.getCondition)
+    val joinInfo = JoinInfo.of(newLeft, newRight, join.getCondition)
     if (isTemporalFunctionJoin(join.getCluster.getRexBuilder, joinInfo)) {
       // Temporal table function join currently only support INNER JOIN
       join.getJoinType match {

--- a/flink-table/flink-table-planner/src/main/scala/org/apache/flink/table/planner/plan/utils/WindowJoinUtil.scala
+++ b/flink-table/flink-table-planner/src/main/scala/org/apache/flink/table/planner/plan/utils/WindowJoinUtil.scala
@@ -23,6 +23,7 @@ import org.apache.flink.table.planner.plan.metadata.FlinkRelMetadataQuery
 import org.apache.flink.table.planner.plan.nodes.logical.FlinkLogicalJoin
 import org.apache.flink.table.planner.utils.Logging
 
+import org.apache.calcite.rel.RelNode
 import org.apache.calcite.rex.{RexInputRef, RexNode, RexUtil}
 import org.apache.calcite.sql.fun.SqlStdOperatorTable
 
@@ -60,7 +61,11 @@ object WindowJoinUtil extends Logging {
    *         ends equality of input tables, else false.
    */
   def satisfyWindowJoin(join: FlinkLogicalJoin): Boolean = {
-    excludeWindowStartEqualityAndEndEqualityFromJoinInfoPairs(join) match {
+    satisfyWindowJoin(join, join.getLeft, join.getRight)
+  }
+
+  def satisfyWindowJoin(join: FlinkLogicalJoin, newLeft: RelNode, newRight: RelNode): Boolean = {
+    excludeWindowStartEqualityAndEndEqualityFromJoinInfoPairs(join, newLeft, newRight) match {
       case Some((windowStartEqualityLeftKeys, windowEndEqualityLeftKeys, _, _)) =>
         windowStartEqualityLeftKeys.nonEmpty && windowEndEqualityLeftKeys.nonEmpty
       case _ => false
@@ -166,6 +171,13 @@ object WindowJoinUtil extends Logging {
    */
   private def excludeWindowStartEqualityAndEndEqualityFromJoinInfoPairs(
       join: FlinkLogicalJoin): Option[(Array[Int], Array[Int], Array[Int], Array[Int])] = {
+    excludeWindowStartEqualityAndEndEqualityFromJoinInfoPairs(join, join.getLeft, join.getRight)
+  }
+
+  private def excludeWindowStartEqualityAndEndEqualityFromJoinInfoPairs(
+      join: FlinkLogicalJoin,
+      newLeft: RelNode,
+      newRight: RelNode): Option[(Array[Int], Array[Int], Array[Int], Array[Int])] = {
     val joinInfo = join.analyzeCondition()
     val (leftWindowProperties, rightWindowProperties) = getChildWindowProperties(join)
 
@@ -222,8 +234,8 @@ object WindowJoinUtil extends Logging {
         )
       }
     } else if (windowStartEqualityLeftKeys.nonEmpty || windowEndEqualityLeftKeys.nonEmpty) {
-      val leftFieldNames = join.getLeft.getRowType.getFieldNames.toList
-      val rightFieldNames = join.getRight.getRowType.getFieldNames.toList
+      val leftFieldNames = newLeft.getRowType.getFieldNames.toList
+      val rightFieldNames = newRight.getRowType.getFieldNames.toList
       val inputFieldNames = leftFieldNames ++ rightFieldNames
       val condition = join.getExpressionString(
         join.getCondition,

--- a/flink-table/flink-table-planner/src/test/resources/org/apache/flink/table/planner/plan/stream/sql/join/IntervalJoinTest.xml
+++ b/flink-table/flink-table-planner/src/test/resources/org/apache/flink/table/planner/plan/stream/sql/join/IntervalJoinTest.xml
@@ -16,6 +16,51 @@ See the License for the specific language governing permissions and
 limitations under the License.
 -->
 <Root>
+  <TestCase name="testFallbackToRegularJoin">
+		<Resource name="sql">
+			<![CDATA[
+SELECT t1.a FROM MyTable t1 WHERE t1.a IN (
+ SELECT t2.a FROM MyTable2 t2
+   WHERE t1.b = t2.b AND t1.rowtime between t2.rowtime and t2.rowtime + INTERVAL '5' MINUTE
+   GROUP BY t2.a
+)
+    ]]>
+		</Resource>
+		<Resource name="ast">
+			<![CDATA[
+LogicalProject(a=[$0])
++- LogicalFilter(condition=[IN($0, {
+LogicalAggregate(group=[{0}])
+  LogicalProject(a=[$0])
+    LogicalFilter(condition=[AND(=($cor0.b, $1), >=($cor0.rowtime, $4), <=($cor0.rowtime, +($4, 300000:INTERVAL MINUTE)))])
+      LogicalTableScan(table=[[default_catalog, default_database, MyTable2]])
+})], variablesSet=[[$cor0]])
+   +- LogicalTableScan(table=[[default_catalog, default_database, MyTable]])
+]]>
+		</Resource>
+		<Resource name="optimized exec plan">
+			<![CDATA[
+Calc(select=[a])
++- Join(joinType=[InnerJoin], where=[((b = b0) AND (rowtime = rowtime0) AND (a = a0))], select=[a, b, rowtime, a0, b0, rowtime0], leftInputSpec=[NoUniqueKey], rightInputSpec=[JoinKeyContainsUniqueKey])
+   :- Exchange(distribution=[hash[b, rowtime, a]])
+   :  +- Calc(select=[a, b, CAST(rowtime) AS rowtime])
+   :     +- DataStreamScan(table=[[default_catalog, default_database, MyTable]], fields=[a, b, c, proctime, rowtime])(reuse_id=[1])
+   +- Exchange(distribution=[hash[b0, rowtime0, a]])
+      +- GroupAggregate(groupBy=[a, b0, rowtime0], select=[a, b0, rowtime0])
+         +- Exchange(distribution=[hash[a, b0, rowtime0]])
+            +- Calc(select=[a, b0, rowtime0])
+               +- Join(joinType=[InnerJoin], where=[((b0 = b) AND (rowtime0 >= rowtime) AND (rowtime0 <= (rowtime + 300000:INTERVAL MINUTE)))], select=[a, b, rowtime, b0, rowtime0], leftInputSpec=[NoUniqueKey], rightInputSpec=[HasUniqueKey])
+                  :- Exchange(distribution=[hash[b]])
+                  :  +- Calc(select=[a, b, CAST(rowtime) AS rowtime])
+                  :     +- DataStreamScan(table=[[default_catalog, default_database, MyTable2]], fields=[a, b, c, proctime, rowtime])
+                  +- Exchange(distribution=[hash[b]])
+                     +- GroupAggregate(groupBy=[b, rowtime], select=[b, rowtime])
+                        +- Exchange(distribution=[hash[b, rowtime]])
+                           +- Calc(select=[b, CAST(rowtime) AS rowtime])
+                              +- Reused(reference_id=[1])
+]]>
+		</Resource>
+	</TestCase>
   <TestCase name="testInteravalDiffTimeIndicator">
     <Resource name="sql">
       <![CDATA[
@@ -595,36 +640,6 @@ Calc(select=[a, b])
 ]]>
     </Resource>
   </TestCase>
-  <TestCase name="testRowTimeRightOuterJoin">
-    <Resource name="sql">
-      <![CDATA[
-SELECT t1.a, t2.b
-FROM MyTable t1 RIGHT OUTER JOIN MyTable2 t2 ON
-  t1.a = t2.a AND
-  t1.rowtime BETWEEN t2.rowtime - INTERVAL '10' SECOND AND t2.rowtime + INTERVAL '1' HOUR
-      ]]>
-    </Resource>
-    <Resource name="ast">
-      <![CDATA[
-LogicalProject(a=[$0], b=[$6])
-+- LogicalJoin(condition=[AND(=($0, $5), >=($4, -($9, 10000:INTERVAL SECOND)), <=($4, +($9, 3600000:INTERVAL HOUR)))], joinType=[right])
-   :- LogicalTableScan(table=[[default_catalog, default_database, MyTable]])
-   +- LogicalTableScan(table=[[default_catalog, default_database, MyTable2]])
-]]>
-    </Resource>
-    <Resource name="optimized exec plan">
-      <![CDATA[
-Calc(select=[a, b])
-+- IntervalJoin(joinType=[RightOuterJoin], windowBounds=[isRowTime=true, leftLowerBound=-10000, leftUpperBound=3600000, leftTimeIndex=1, rightTimeIndex=2], where=[((a = a0) AND (rowtime >= (rowtime0 - 10000:INTERVAL SECOND)) AND (rowtime <= (rowtime0 + 3600000:INTERVAL HOUR)))], select=[a, rowtime, a0, b, rowtime0])
-   :- Exchange(distribution=[hash[a]])
-   :  +- Calc(select=[a, rowtime])
-   :     +- DataStreamScan(table=[[default_catalog, default_database, MyTable]], fields=[a, b, c, proctime, rowtime])
-   +- Exchange(distribution=[hash[a]])
-      +- Calc(select=[a, b, rowtime])
-         +- DataStreamScan(table=[[default_catalog, default_database, MyTable2]], fields=[a, b, c, proctime, rowtime])
-]]>
-    </Resource>
-  </TestCase>
   <TestCase name="testRowTimeInnerJoinWithWhereClause">
     <Resource name="sql">
       <![CDATA[
@@ -682,6 +697,81 @@ Calc(select=[a, b])
    +- Exchange(distribution=[hash[a]])
       +- Calc(select=[a, b, rowtime])
          +- DataStreamScan(table=[[default_catalog, default_database, MyTable2]], fields=[a, b, c, proctime, rowtime])
+]]>
+    </Resource>
+  </TestCase>
+  <TestCase name="testRowTimeRightOuterJoin">
+    <Resource name="sql">
+      <![CDATA[
+SELECT t1.a, t2.b
+FROM MyTable t1 RIGHT OUTER JOIN MyTable2 t2 ON
+  t1.a = t2.a AND
+  t1.rowtime BETWEEN t2.rowtime - INTERVAL '10' SECOND AND t2.rowtime + INTERVAL '1' HOUR
+      ]]>
+    </Resource>
+    <Resource name="ast">
+      <![CDATA[
+LogicalProject(a=[$0], b=[$6])
++- LogicalJoin(condition=[AND(=($0, $5), >=($4, -($9, 10000:INTERVAL SECOND)), <=($4, +($9, 3600000:INTERVAL HOUR)))], joinType=[right])
+   :- LogicalTableScan(table=[[default_catalog, default_database, MyTable]])
+   +- LogicalTableScan(table=[[default_catalog, default_database, MyTable2]])
+]]>
+    </Resource>
+    <Resource name="optimized exec plan">
+      <![CDATA[
+Calc(select=[a, b])
++- IntervalJoin(joinType=[RightOuterJoin], windowBounds=[isRowTime=true, leftLowerBound=-10000, leftUpperBound=3600000, leftTimeIndex=1, rightTimeIndex=2], where=[((a = a0) AND (rowtime >= (rowtime0 - 10000:INTERVAL SECOND)) AND (rowtime <= (rowtime0 + 3600000:INTERVAL HOUR)))], select=[a, rowtime, a0, b, rowtime0])
+   :- Exchange(distribution=[hash[a]])
+   :  +- Calc(select=[a, rowtime])
+   :     +- DataStreamScan(table=[[default_catalog, default_database, MyTable]], fields=[a, b, c, proctime, rowtime])
+   +- Exchange(distribution=[hash[a]])
+      +- Calc(select=[a, b, rowtime])
+         +- DataStreamScan(table=[[default_catalog, default_database, MyTable2]], fields=[a, b, c, proctime, rowtime])
+]]>
+    </Resource>
+  </TestCase>
+  <TestCase name="testSemiIntervalJoinWithSimpleConditionAndGroup">
+    <Resource name="sql">
+      <![CDATA[
+SELECT t1.a FROM MyTable t1 WHERE t1.a IN (
+ SELECT t2.a FROM MyTable2 t2
+   WHERE t1.b = t2.b AND t1.rowtime between t2.rowtime and t2.rowtime + INTERVAL '5' MINUTE
+   GROUP BY t2.a
+)
+    ]]>
+    </Resource>
+    <Resource name="ast">
+      <![CDATA[
+LogicalProject(a=[$0])
++- LogicalFilter(condition=[IN($0, {
+LogicalAggregate(group=[{0}])
+  LogicalProject(a=[$0])
+    LogicalFilter(condition=[AND(=($cor0.b, $1), >=($cor0.rowtime, $4), <=($cor0.rowtime, +($4, 300000:INTERVAL MINUTE)))])
+      LogicalTableScan(table=[[default_catalog, default_database, MyTable2]])
+})], variablesSet=[[$cor0]])
+   +- LogicalTableScan(table=[[default_catalog, default_database, MyTable]])
+]]>
+    </Resource>
+    <Resource name="optimized exec plan">
+      <![CDATA[
+Calc(select=[a])
++- Join(joinType=[InnerJoin], where=[((b = b0) AND (rowtime = rowtime0) AND (a = a0))], select=[a, b, rowtime, a0, b0, rowtime0], leftInputSpec=[NoUniqueKey], rightInputSpec=[JoinKeyContainsUniqueKey])
+   :- Exchange(distribution=[hash[b, rowtime, a]])
+   :  +- Calc(select=[a, b, CAST(rowtime) AS rowtime])
+   :     +- DataStreamScan(table=[[default_catalog, default_database, MyTable]], fields=[a, b, c, proctime, rowtime])(reuse_id=[1])
+   +- Exchange(distribution=[hash[b0, rowtime0, a]])
+      +- GroupAggregate(groupBy=[a, b0, rowtime0], select=[a, b0, rowtime0])
+         +- Exchange(distribution=[hash[a, b0, rowtime0]])
+            +- Calc(select=[a, b0, rowtime0])
+               +- Join(joinType=[InnerJoin], where=[((b0 = b) AND (rowtime0 >= rowtime) AND (rowtime0 <= (rowtime + 300000:INTERVAL MINUTE)))], select=[a, b, rowtime, b0, rowtime0], leftInputSpec=[NoUniqueKey], rightInputSpec=[HasUniqueKey])
+                  :- Exchange(distribution=[hash[b]])
+                  :  +- Calc(select=[a, b, CAST(rowtime) AS rowtime])
+                  :     +- DataStreamScan(table=[[default_catalog, default_database, MyTable2]], fields=[a, b, c, proctime, rowtime])
+                  +- Exchange(distribution=[hash[b]])
+                     +- GroupAggregate(groupBy=[b, rowtime], select=[b, rowtime])
+                        +- Exchange(distribution=[hash[b, rowtime]])
+                           +- Calc(select=[b, CAST(rowtime) AS rowtime])
+                              +- Reused(reference_id=[1])
 ]]>
     </Resource>
   </TestCase>

--- a/flink-table/flink-table-runtime/src/main/java/org/apache/flink/table/runtime/operators/join/window/WindowJoinOperator.java
+++ b/flink-table/flink-table-runtime/src/main/java/org/apache/flink/table/runtime/operators/join/window/WindowJoinOperator.java
@@ -299,10 +299,8 @@ public abstract class WindowJoinOperator extends TableStreamOperator<RowData>
                 boolean matches = false;
                 for (RowData rightRecord : rightRecords) {
                     if (joinCondition.apply(leftRecord, rightRecord)) {
-                        if (joinCondition.apply(leftRecord, rightRecord)) {
-                            matches = true;
-                            break;
-                        }
+                        matches = true;
+                        break;
                     }
                 }
                 if (matches) {


### PR DESCRIPTION
## What is the purpose of the change

This pull request aims to fix bug in `RelTimeIndicatorConverter` when materialize time attribute fields of regular join's inputs.

## Brief change log

Updates utility method `JoinUtil#satisfyRegularJoin`, `IntervalJoinUtil#satisfyIntervalJoin`, `TemporalJoinUtil#satisfyTemporalJoin`, `WindowJoinUtil#satisfyWindowJoin`


## Verifying this change
  - UT `IntervalJoinTest#testFallbackToRegularJoin`
  
## Does this pull request potentially affect one of the following parts:

  - Dependencies (does it add or upgrade a dependency): (no)
  - The public API, i.e., is any changed class annotated with `@Public(Evolving)`: (no)
  - The serializers: (no)
  - The runtime per-record code paths (performance sensitive): (no)
  - Anything that affects deployment or recovery: JobManager (and its components), Checkpointing, Kubernetes/Yarn, ZooKeeper: (no)
  - The S3 file system connector: (no)

## Documentation

  - Does this pull request introduce a new feature? (no)
  - If yes, how is the feature documented? (not applicable)
