### PR TITLE
[BP-1.13][FLINK-23696][connectors/rabbitmq] Fix RMQSourceTest.testRedeliveredSessionIDsAck

### DIFF
--- a/flink-connectors/flink-connector-rabbitmq/src/test/java/org/apache/flink/streaming/connectors/rabbitmq/RMQSourceTest.java
+++ b/flink-connectors/flink-connector-rabbitmq/src/test/java/org/apache/flink/streaming/connectors/rabbitmq/RMQSourceTest.java
@@ -118,6 +118,7 @@ public class RMQSourceTest {
         source.initializeState(mockContext);
         source.open(config);
 
+        DummySourceContext.numElementsCollected = 0;
         messageId = 0;
         generateCorrelationIds = true;
 
@@ -400,12 +401,14 @@ public class RMQSourceTest {
             testHarness.snapshot(snapshotId, System.currentTimeMillis());
             source.notifyCheckpointComplete(snapshotId);
             lastMessageId = messageId;
+
+            // check if all the messages are being collected and acknowledged
+            long totalNumberOfAcks = numMsgRedelivered + lastMessageId;
+            assertEquals(lastMessageId, DummySourceContext.numElementsCollected);
+            assertEquals(totalNumberOfAcks, ((RMQTestSource) source).addIdCalls);
         }
 
-        // check if all the messages are being acknowledged
-        long totalNumberOfAcks = numMsgRedelivered + lastMessageId;
-        assertEquals(lastMessageId, DummySourceContext.numElementsCollected);
-        assertEquals(totalNumberOfAcks, ((RMQTestSource) source).addIdCalls);
+        // check if all the acks are being sent
         Mockito.verify(source.channel, Mockito.times((int) lastMessageId))
                 .basicAck(Mockito.anyLong(), Mockito.eq(false));
         Mockito.verify(source.channel, Mockito.times((int) numMsgRedelivered))


### PR DESCRIPTION
This is a backport of #17708 (fixing FLINK-23696) to release-1.13. The fix is exactly the same as in #17708.

Please see #17708 for a detailed description.