### PR TITLE
[FLINK-24854][tests] StateHandleSerializationTest unit test error

### DIFF
--- a/flink-state-backends/flink-statebackend-rocksdb/src/test/java/org/apache/flink/contrib/streaming/state/RocksDBStateDownloaderTest.java
+++ b/flink-state-backends/flink-statebackend-rocksdb/src/test/java/org/apache/flink/contrib/streaming/state/RocksDBStateDownloaderTest.java
@@ -58,6 +58,8 @@ public class RocksDBStateDownloaderTest extends TestLogger {
                 new SpecifiedException("throw exception while multi thread restore.");
         StreamStateHandle stateHandle =
                 new StreamStateHandle() {
+                    private static final long serialVersionUID = 1L;
+
                     @Override
                     public FSDataInputStream openInputStream() throws IOException {
                         throw expectedException;

--- a/flink-tests/src/test/java/org/apache/flink/test/state/StateHandleSerializationTest.java
+++ b/flink-tests/src/test/java/org/apache/flink/test/state/StateHandleSerializationTest.java
@@ -27,7 +27,6 @@ import java.lang.reflect.Field;
 import java.lang.reflect.Modifier;
 import java.util.Set;
 
-import static org.junit.Assert.assertFalse;
 import static org.junit.Assert.fail;
 
 /**
@@ -58,11 +57,6 @@ public class StateHandleSerializationTest {
     private static void validataSerialVersionUID(Class<?> clazz) {
         // all non-interface types must have a serial version UID
         if (!clazz.isInterface()) {
-            assertFalse(
-                    "Anonymous state handle classes have problematic serialization behavior: "
-                            + clazz,
-                    clazz.isAnonymousClass());
-
             try {
                 Field versionUidField = clazz.getDeclaredField("serialVersionUID");
 


### PR DESCRIPTION
## What is the purpose of the change

*Fix the unit test case StateHandleSerializationTest*


## Brief change log

  - *delete the assertFalse sentence and add serialVersionUID for the anonymous class*


## Verifying this change


This change is already covered by existing tests, such as *StateHandleSerializationTest*.


## Does this pull request potentially affect one of the following parts:

  - Dependencies (does it add or upgrade a dependency): (no)
  - The public API, i.e., is any changed class annotated with `@Public(Evolving)`: (no)
  - The serializers: (no)
  - The runtime per-record code paths (performance sensitive): (no)
  - Anything that affects deployment or recovery: JobManager (and its components), Checkpointing, Kubernetes/Yarn, ZooKeeper: (no)
  - The S3 file system connector: (no)

## Documentation

  - Does this pull request introduce a new feature? (no)
  - If yes, how is the feature documented? (not applicable)
