### PR TITLE
[FLINK-24758][Connectors / FileSystem]  filesystem sink: add partitiontime-extractor.formatter-pattern to allow user to speify DateTimeFormatter

### DIFF
--- a/docs/content.zh/docs/connectors/table/filesystem.md
+++ b/docs/content.zh/docs/connectors/table/filesystem.md
@@ -277,6 +277,13 @@ file sink 支持文件合并，以允许应用程序可以使用较小的检查�
         <td>实现了接口 PartitionTimeExtractor 的提取器类.</td>
     </tr>
     <tr>
+        <td><h5>partition.time-extractor.timestamp-formatter</h5></td>
+        <td style="word-wrap: break-word;">yyyy-MM-dd&nbsp;HH:mm:ss</td>
+        <td>String</td>
+        <td>指定时间格式，可以与 'partition.time-extractor.timestamp-pattern' 结合使用，支持从多个字段提取时间戳。
+          <br>它与 Java's <a href="https://docs.oracle.com/javase/8/docs/api/java/time/format/DateTimeFormatter.html">DateTimeFormatter</a> 完全兼容。
+    </tr>
+    <tr>
         <td><h5>partition.time-extractor.timestamp-pattern</h5></td>
         <td style="word-wrap: break-word;">(none)</td>
         <td>String</td>

--- a/docs/content/docs/connectors/table/filesystem.md
+++ b/docs/content/docs/connectors/table/filesystem.md
@@ -336,7 +336,7 @@ Time extractors define extracting time from partition values.
         <td><h5>partition.time-extractor.kind</h5></td>
         <td style="word-wrap: break-word;">default</td>
         <td>String</td>
-        <td>Time extractor to extract time from partition values. Support default and custom. For default, can configure timestamp pattern. For custom, should configure extractor class.</td>
+        <td>Time extractor to extract time from partition values. Support default and custom. For default, can configure timestamp pattern\formatter. For custom, should configure extractor class.</td>
     </tr>
     <tr>
         <td><h5>partition.time-extractor.class</h5></td>
@@ -349,6 +349,14 @@ Time extractors define extracting time from partition values.
         <td style="word-wrap: break-word;">(none)</td>
         <td>String</td>
         <td>The 'default' construction way allows users to use partition fields to get a legal timestamp pattern. Default support 'yyyy-MM-dd hh:mm:ss' from first field. If timestamp should be extracted from a single partition field 'dt', can configure: '$dt'. If timestamp should be extracted from multiple partition fields, say 'year', 'month', 'day' and 'hour', can configure: '$year-$month-$day $hour:00:00'. If timestamp should be extracted from two partition fields 'dt' and 'hour', can configure: '$dt $hour:00:00'.</td>
+    </tr>
+    <tr>
+        <td><h5>partition.time-extractor.timestamp-formatter</h5></td>
+        <td style="word-wrap: break-word;">yyyy-MM-dd&nbsp;HH:mm:ss</td>
+        <td>String</td>
+        <td>The formatter that formats the partition timestamp string value to timestamp, the partition timestamp string value is expressed by 'partition.time-extractor.timestamp-pattern'. For example, the partition timestamp is extracted from multiple partition fields, say 'year', 'month' and 'day', you can configure 'partition.time-extractor.timestamp-pattern' to '$year$month$day', and configure `partition.time-extractor.timestamp-formatter` to 'yyyyMMdd'. By default the formatter is 'yyyy-MM-dd HH:mm:ss'.
+            <br>The timestamp-formatter is compatible with Java's <a href="https://docs.oracle.com/javase/8/docs/api/java/time/format/DateTimeFormatter.html">DateTimeFormatter</a>
+ 				</td>
     </tr>
   </tbody>
 </table>

--- a/flink-connectors/flink-connector-files/src/main/java/org/apache/flink/connector/file/table/FileSystemConnectorOptions.java
+++ b/flink-connectors/flink-connector-files/src/main/java/org/apache/flink/connector/file/table/FileSystemConnectorOptions.java
@@ -163,7 +163,7 @@ public class FileSystemConnectorOptions {
                     .withDescription(
                             Description.builder()
                                     .text(
-                                            "It can combine with 'partition.time-extractor.timestamp-patter', "
+                                            "The formatter to format timestamp from string, it can be used with 'partition.time-extractor.timestamp-pattern', "
                                                     + "creates a formatter using the specified value. "
                                                     + "Supports multiple partition fields like '$year-$month-$day $hour:00:00'.")
                                     .list(

--- a/flink-connectors/flink-connector-files/src/main/java/org/apache/flink/connector/file/table/FileSystemConnectorOptions.java
+++ b/flink-connectors/flink-connector-files/src/main/java/org/apache/flink/connector/file/table/FileSystemConnectorOptions.java
@@ -156,6 +156,22 @@ public class FileSystemConnectorOptions {
                     .withDescription(
                             "The extractor class for implement PartitionTimeExtractor interface.");
 
+    public static final ConfigOption<String> PARTITION_TIME_EXTRACTOR_TIMESTAMP_FORMATTER =
+            key("partition.time-extractor.timestamp-formatter")
+                    .stringType()
+                    .noDefaultValue()
+                    .withDescription(
+                            Description.builder()
+                                    .text(
+                                            "It can combine with 'partition.time-extractor.timestamp-patter', "
+                                                    + "creates a formatter using the specified value. "
+                                                    + "Supports multiple partition fields like '$year-$month-$day $hour:00:00'.")
+                                    .list(
+                                            text(
+                                                    "The timestamp-formatter is compatible with "
+                                                            + "Java's DateTimeFormatter."))
+                                    .build());
+
     public static final ConfigOption<String> PARTITION_TIME_EXTRACTOR_TIMESTAMP_PATTERN =
             key("partition.time-extractor.timestamp-pattern")
                     .stringType()
@@ -164,7 +180,8 @@ public class FileSystemConnectorOptions {
                             Description.builder()
                                     .text(
                                             "When 'partition.time-extractor.kind' is set to 'default', "
-                                                    + "you can specify a pattern to get a timestamp from partitions.")
+                                                    + "you can specify a pattern to get a timestamp from partitions. "
+                                                    + "the formatter pattern is defined by 'partition.time-extractor.timestamp-formatter'.")
                                     .list(
                                             text(
                                                     "By default, a format of 'yyyy-MM-dd hh:mm:ss' is read from the first field."),
@@ -173,7 +190,12 @@ public class FileSystemConnectorOptions {
                                             text(
                                                     "If it is spread across multiple fields for year, month, day, and hour, you can use '$year-$month-$day $hour:00:00'."),
                                             text(
-                                                    "If the timestamp is in fields dt and hour, you can use '$dt $hour:00:00'."))
+                                                    "If the timestamp is in fields dt and hour, you can use '$dt "
+                                                            + "$hour:00:00'."),
+                                            text(
+                                                    "By basicDate, a format of 'yyyyMMdd' is read from the first field."),
+                                            text(
+                                                    "If the timestamp in the partition is a single field called 'dt', you can use '$dt'."))
                                     .build());
 
     public static final ConfigOption<Duration> LOOKUP_JOIN_CACHE_TTL =

--- a/flink-connectors/flink-connector-files/src/main/java/org/apache/flink/connector/file/table/FileSystemTableFactory.java
+++ b/flink-connectors/flink-connector-files/src/main/java/org/apache/flink/connector/file/table/FileSystemTableFactory.java
@@ -107,6 +107,7 @@ public class FileSystemTableFactory implements DynamicTableSourceFactory, Dynami
         options.add(FileSystemConnectorOptions.SINK_SHUFFLE_BY_PARTITION);
         options.add(FileSystemConnectorOptions.PARTITION_TIME_EXTRACTOR_KIND);
         options.add(FileSystemConnectorOptions.PARTITION_TIME_EXTRACTOR_CLASS);
+        options.add(FileSystemConnectorOptions.PARTITION_TIME_EXTRACTOR_TIMESTAMP_FORMATTER);
         options.add(FileSystemConnectorOptions.PARTITION_TIME_EXTRACTOR_TIMESTAMP_PATTERN);
         options.add(FileSystemConnectorOptions.SINK_PARTITION_COMMIT_TRIGGER);
         options.add(FileSystemConnectorOptions.SINK_PARTITION_COMMIT_DELAY);

--- a/flink-connectors/flink-connector-files/src/main/java/org/apache/flink/connector/file/table/PartitionTimeExtractor.java
+++ b/flink-connectors/flink-connector-files/src/main/java/org/apache/flink/connector/file/table/PartitionTimeExtractor.java
@@ -38,10 +38,11 @@ public interface PartitionTimeExtractor extends Serializable {
             ClassLoader userClassLoader,
             String extractorKind,
             String extractorClass,
+            String formatterPattern,
             String extractorPattern) {
         switch (extractorKind) {
             case DEFAULT:
-                return new DefaultPartTimeExtractor(extractorPattern);
+                return new DefaultPartTimeExtractor(extractorPattern, formatterPattern);
             case CUSTOM:
                 try {
                     return (PartitionTimeExtractor)

--- a/flink-connectors/flink-connector-files/src/main/java/org/apache/flink/connector/file/table/PartitionTimeExtractor.java
+++ b/flink-connectors/flink-connector-files/src/main/java/org/apache/flink/connector/file/table/PartitionTimeExtractor.java
@@ -38,8 +38,8 @@ public interface PartitionTimeExtractor extends Serializable {
             ClassLoader userClassLoader,
             String extractorKind,
             String extractorClass,
-            String formatterPattern,
-            String extractorPattern) {
+            String extractorPattern,
+            String formatterPattern) {
         switch (extractorKind) {
             case DEFAULT:
                 return new DefaultPartTimeExtractor(extractorPattern, formatterPattern);

--- a/flink-connectors/flink-connector-files/src/main/java/org/apache/flink/connector/file/table/stream/PartitionTimeCommitPredicate.java
+++ b/flink-connectors/flink-connector-files/src/main/java/org/apache/flink/connector/file/table/stream/PartitionTimeCommitPredicate.java
@@ -29,6 +29,7 @@ import java.util.List;
 
 import static org.apache.flink.connector.file.table.FileSystemConnectorOptions.PARTITION_TIME_EXTRACTOR_CLASS;
 import static org.apache.flink.connector.file.table.FileSystemConnectorOptions.PARTITION_TIME_EXTRACTOR_KIND;
+import static org.apache.flink.connector.file.table.FileSystemConnectorOptions.PARTITION_TIME_EXTRACTOR_TIMESTAMP_FORMATTER;
 import static org.apache.flink.connector.file.table.FileSystemConnectorOptions.PARTITION_TIME_EXTRACTOR_TIMESTAMP_PATTERN;
 import static org.apache.flink.connector.file.table.FileSystemConnectorOptions.SINK_PARTITION_COMMIT_DELAY;
 import static org.apache.flink.connector.file.table.FileSystemConnectorOptions.SINK_PARTITION_COMMIT_WATERMARK_TIME_ZONE;
@@ -56,6 +57,7 @@ public class PartitionTimeCommitPredicate implements PartitionCommitPredicate {
                         cl,
                         conf.get(PARTITION_TIME_EXTRACTOR_KIND),
                         conf.get(PARTITION_TIME_EXTRACTOR_CLASS),
+                        conf.get(PARTITION_TIME_EXTRACTOR_TIMESTAMP_FORMATTER),
                         conf.get(PARTITION_TIME_EXTRACTOR_TIMESTAMP_PATTERN));
         this.watermarkTimeZone =
                 ZoneId.of(conf.getString(SINK_PARTITION_COMMIT_WATERMARK_TIME_ZONE));

--- a/flink-connectors/flink-connector-files/src/main/java/org/apache/flink/connector/file/table/stream/PartitionTimeCommitPredicate.java
+++ b/flink-connectors/flink-connector-files/src/main/java/org/apache/flink/connector/file/table/stream/PartitionTimeCommitPredicate.java
@@ -57,8 +57,8 @@ public class PartitionTimeCommitPredicate implements PartitionCommitPredicate {
                         cl,
                         conf.get(PARTITION_TIME_EXTRACTOR_KIND),
                         conf.get(PARTITION_TIME_EXTRACTOR_CLASS),
-                        conf.get(PARTITION_TIME_EXTRACTOR_TIMESTAMP_FORMATTER),
-                        conf.get(PARTITION_TIME_EXTRACTOR_TIMESTAMP_PATTERN));
+                        conf.get(PARTITION_TIME_EXTRACTOR_TIMESTAMP_PATTERN),
+                        conf.get(PARTITION_TIME_EXTRACTOR_TIMESTAMP_FORMATTER));
         this.watermarkTimeZone =
                 ZoneId.of(conf.getString(SINK_PARTITION_COMMIT_WATERMARK_TIME_ZONE));
     }

--- a/flink-connectors/flink-connector-files/src/test/java/org/apache/flink/connector/file/table/stream/StreamingFileWriterTest.java
+++ b/flink-connectors/flink-connector-files/src/test/java/org/apache/flink/connector/file/table/stream/StreamingFileWriterTest.java
@@ -55,6 +55,7 @@ import java.util.Collections;
 import java.util.Date;
 import java.util.List;
 
+import static org.apache.flink.connector.file.table.FileSystemConnectorOptions.PARTITION_TIME_EXTRACTOR_TIMESTAMP_FORMATTER;
 import static org.apache.flink.connector.file.table.FileSystemConnectorOptions.SINK_PARTITION_COMMIT_DELAY;
 import static org.apache.flink.connector.file.table.FileSystemConnectorOptions.SINK_PARTITION_COMMIT_POLICY_KIND;
 import static org.apache.flink.connector.file.table.FileSystemConnectorOptions.SINK_PARTITION_COMMIT_TRIGGER;
@@ -379,6 +380,7 @@ public class StreamingFileWriterTest {
     private Configuration getPartitionCommitTriggerConf(long commitDelay) {
         Configuration configuration = new Configuration();
         configuration.setString(SINK_PARTITION_COMMIT_POLICY_KIND, "success-file");
+        configuration.setString(PARTITION_TIME_EXTRACTOR_TIMESTAMP_FORMATTER.key(), "yyyy-MM-dd");
         configuration.setString(SINK_PARTITION_COMMIT_TRIGGER.key(), "partition-time");
         configuration.setLong(SINK_PARTITION_COMMIT_DELAY.key(), commitDelay);
         configuration.setString(SINK_PARTITION_COMMIT_WATERMARK_TIME_ZONE.key(), "UTC");

--- a/flink-connectors/flink-connector-hive/src/main/java/org/apache/flink/connectors/hive/HiveTableSource.java
+++ b/flink-connectors/flink-connector-hive/src/main/java/org/apache/flink/connectors/hive/HiveTableSource.java
@@ -26,6 +26,7 @@ import org.apache.flink.api.common.typeutils.base.StringSerializer;
 import org.apache.flink.configuration.Configuration;
 import org.apache.flink.configuration.ReadableConfig;
 import org.apache.flink.connector.file.table.ContinuousPartitionFetcher;
+import org.apache.flink.connector.file.table.DefaultPartTimeExtractor;
 import org.apache.flink.connectors.hive.read.HiveContinuousPartitionContext;
 import org.apache.flink.connectors.hive.read.HivePartitionFetcherContextBase;
 import org.apache.flink.connectors.hive.util.HivePartitionUtils;
@@ -46,6 +47,7 @@ import org.apache.flink.table.connector.source.abilities.SupportsLimitPushDown;
 import org.apache.flink.table.connector.source.abilities.SupportsPartitionPushDown;
 import org.apache.flink.table.connector.source.abilities.SupportsProjectionPushDown;
 import org.apache.flink.table.data.RowData;
+import org.apache.flink.table.data.TimestampData;
 import org.apache.flink.table.types.DataType;
 import org.apache.flink.util.Preconditions;
 
@@ -56,12 +58,13 @@ import org.apache.thrift.TException;
 
 import javax.annotation.Nullable;
 
+import java.time.LocalDateTime;
 import java.util.Arrays;
 import java.util.List;
 import java.util.Map;
 import java.util.Optional;
 
-import static org.apache.flink.connector.file.table.DefaultPartTimeExtractor.toMills;
+import static org.apache.flink.connector.file.table.FileSystemConnectorOptions.PARTITION_TIME_EXTRACTOR_TIMESTAMP_FORMATTER;
 import static org.apache.flink.connector.file.table.FileSystemConnectorOptions.STREAMING_SOURCE_CONSUME_START_OFFSET;
 import static org.apache.flink.connector.file.table.FileSystemConnectorOptions.STREAMING_SOURCE_ENABLE;
 import static org.apache.flink.connectors.hive.util.HivePartitionUtils.getAllPartitions;
@@ -293,7 +296,18 @@ public class HiveTableSource
                     if (configuration.contains(STREAMING_SOURCE_CONSUME_START_OFFSET)) {
                         String consumeOffsetStr =
                                 configuration.getString(STREAMING_SOURCE_CONSUME_START_OFFSET);
-                        consumeStartOffset = (T) Long.valueOf(toMills(consumeOffsetStr));
+
+                        LocalDateTime localDateTime =
+                                DefaultPartTimeExtractor.toLocalDateTime(
+                                        consumeOffsetStr,
+                                        configuration.getString(
+                                                PARTITION_TIME_EXTRACTOR_TIMESTAMP_FORMATTER));
+
+                        consumeStartOffset =
+                                (T)
+                                        Long.valueOf(
+                                                TimestampData.fromLocalDateTime(localDateTime)
+                                                        .getMillisecond());
                     } else {
                         consumeStartOffset = (T) DEFAULT_MIN_TIME_OFFSET;
                     }

--- a/flink-connectors/flink-connector-hive/src/main/java/org/apache/flink/connectors/hive/read/HivePartitionFetcherContextBase.java
+++ b/flink-connectors/flink-connector-hive/src/main/java/org/apache/flink/connectors/hive/read/HivePartitionFetcherContextBase.java
@@ -51,6 +51,7 @@ import java.util.stream.Collectors;
 import static org.apache.flink.connector.file.table.DefaultPartTimeExtractor.toMills;
 import static org.apache.flink.connector.file.table.FileSystemConnectorOptions.PARTITION_TIME_EXTRACTOR_CLASS;
 import static org.apache.flink.connector.file.table.FileSystemConnectorOptions.PARTITION_TIME_EXTRACTOR_KIND;
+import static org.apache.flink.connector.file.table.FileSystemConnectorOptions.PARTITION_TIME_EXTRACTOR_TIMESTAMP_FORMATTER;
 import static org.apache.flink.connector.file.table.FileSystemConnectorOptions.PARTITION_TIME_EXTRACTOR_TIMESTAMP_PATTERN;
 import static org.apache.flink.connector.file.table.FileSystemConnectorOptions.STREAMING_SOURCE_PARTITION_ORDER;
 
@@ -107,6 +108,7 @@ public abstract class HivePartitionFetcherContextBase<P> implements HivePartitio
 
         String extractorKind = configuration.get(PARTITION_TIME_EXTRACTOR_KIND);
         String extractorClass = configuration.get(PARTITION_TIME_EXTRACTOR_CLASS);
+        String formatterPattern = configuration.get(PARTITION_TIME_EXTRACTOR_TIMESTAMP_FORMATTER);
         String extractorPattern = configuration.get(PARTITION_TIME_EXTRACTOR_TIMESTAMP_PATTERN);
 
         extractor =
@@ -114,6 +116,7 @@ public abstract class HivePartitionFetcherContextBase<P> implements HivePartitio
                         Thread.currentThread().getContextClassLoader(),
                         extractorKind,
                         extractorClass,
+                        formatterPattern,
                         extractorPattern);
         tableLocation = new Path(table.getSd().getLocation());
         partValuesToCreateTime = new HashMap<>();

--- a/flink-connectors/flink-connector-hive/src/main/java/org/apache/flink/connectors/hive/read/HivePartitionFetcherContextBase.java
+++ b/flink-connectors/flink-connector-hive/src/main/java/org/apache/flink/connectors/hive/read/HivePartitionFetcherContextBase.java
@@ -116,8 +116,8 @@ public abstract class HivePartitionFetcherContextBase<P> implements HivePartitio
                         Thread.currentThread().getContextClassLoader(),
                         extractorKind,
                         extractorClass,
-                        formatterPattern,
-                        extractorPattern);
+                        extractorPattern,
+                        formatterPattern);
         tableLocation = new Path(table.getSd().getLocation());
         partValuesToCreateTime = new HashMap<>();
     }

--- a/flink-table/flink-table-planner/src/test/scala/org/apache/flink/table/planner/runtime/stream/FsStreamingSinkITCaseBase.scala
+++ b/flink-table/flink-table-planner/src/test/scala/org/apache/flink/table/planner/runtime/stream/FsStreamingSinkITCaseBase.scala
@@ -21,13 +21,13 @@ package org.apache.flink.table.planner.runtime.stream
 import org.apache.flink.api.common.state.CheckpointListener
 import org.apache.flink.api.common.typeinfo.Types
 import org.apache.flink.api.java.typeutils.RowTypeInfo
+import org.apache.flink.connector.file.table.FileSystemConnectorOptions._
 import org.apache.flink.streaming.api.CheckpointingMode
 import org.apache.flink.streaming.api.functions.source.SourceFunction
 import org.apache.flink.streaming.api.scala.DataStream
 import org.apache.flink.streaming.api.watermark.Watermark
 import org.apache.flink.table.api.Expressions.$
-import org.apache.flink.connector.file.table.DefaultPartTimeExtractor.{toLocalDateTime, toMills}
-import org.apache.flink.connector.file.table.FileSystemConnectorOptions._
+import org.apache.flink.table.data.TimestampData
 import org.apache.flink.table.planner.runtime.utils.{StreamingTestBase, TestSinkUtil}
 import org.apache.flink.types.Row
 import org.apache.flink.util.CollectionUtil

--- a/flink-table/flink-table-planner/src/test/scala/org/apache/flink/table/planner/runtime/stream/FsStreamingSinkITCaseBase.scala
+++ b/flink-table/flink-table-planner/src/test/scala/org/apache/flink/table/planner/runtime/stream/FsStreamingSinkITCaseBase.scala
@@ -18,8 +18,10 @@
 
 package org.apache.flink.table.planner.runtime.stream
 
+import org.apache.flink.api.common.state.CheckpointListener
 import org.apache.flink.api.common.typeinfo.Types
 import org.apache.flink.api.java.typeutils.RowTypeInfo
+import org.apache.flink.streaming.api.CheckpointingMode
 import org.apache.flink.streaming.api.functions.source.SourceFunction
 import org.apache.flink.streaming.api.scala.DataStream
 import org.apache.flink.streaming.api.watermark.Watermark
@@ -32,11 +34,11 @@ import org.apache.flink.util.CollectionUtil
 import org.junit.Assert.assertEquals
 import org.junit.rules.Timeout
 import org.junit.{Assert, Before, Rule, Test}
+
 import java.io.File
 import java.net.URI
-
-import org.apache.flink.api.common.state.CheckpointListener
-
+import java.time.format.DateTimeFormatter
+import java.time.{LocalDate, LocalDateTime, LocalTime}
 import scala.collection.JavaConversions._
 import scala.collection.Seq
 
@@ -50,82 +52,150 @@ abstract class FsStreamingSinkITCaseBase extends StreamingTestBase {
 
   protected var resultPath: String = _
 
-  private val data = Seq(
-    Row.of(Integer.valueOf(1), "a", "b", "2020-05-03", "7"),
-    Row.of(Integer.valueOf(2), "p", "q", "2020-05-03", "8"),
-    Row.of(Integer.valueOf(3), "x", "y", "2020-05-03", "9"),
-    Row.of(Integer.valueOf(4), "x", "y", "2020-05-03", "10"),
-    Row.of(Integer.valueOf(5), "x", "y", "2020-05-03", "11"))
+  // iso date
+  private val data: Seq[Row] = Seq(
+    Row.of(Integer.valueOf(1), "a", "b", "05-03-2020", "07"),
+    Row.of(Integer.valueOf(2), "p", "q", "05-03-2020", "08"),
+    Row.of(Integer.valueOf(3), "x", "y", "05-03-2020", "09"),
+    Row.of(Integer.valueOf(4), "x", "y", "05-03-2020", "10"),
+    Row.of(Integer.valueOf(5), "x", "y", "05-03-2020", "11"))
+
+  // basic iso date
+  private val data2 = Seq(
+    Row.of(Integer.valueOf(1), "a", "b", "20200503", "07"),
+    Row.of(Integer.valueOf(2), "p", "q", "20200503", "08"),
+    Row.of(Integer.valueOf(3), "x", "y", "20200503", "09"),
+    Row.of(Integer.valueOf(4), "x", "y", "20200504", "10"),
+    Row.of(Integer.valueOf(5), "x", "y", "20200504", "11"))
 
   @Before
   override def before(): Unit = {
     super.before()
-    resultPath = tempFolder.newFolder().toURI.toString
 
     env.setParallelism(1)
     env.enableCheckpointing(100)
-
-    val stream = new DataStream(env.getJavaEnv.addSource(
-      new FiniteTestSource(data),
-      new RowTypeInfo(Types.INT, Types.STRING, Types.STRING, Types.STRING, Types.STRING)))
-
-    tEnv.createTemporaryView("my_table", stream, $("a"), $("b"), $("c"), $("d"), $("e"))
+    env.getCheckpointConfig.setCheckpointingMode(CheckpointingMode.EXACTLY_ONCE)
   }
 
   def additionalProperties(): Array[String] = Array()
 
   @Test
   def testNonPart(): Unit = {
-    test(partition = false)
+    testPartitionCustomFormatDate(partition = false)
   }
 
   @Test
   def testPart(): Unit = {
-    test(partition = true)
-    val basePath = new File(new URI(resultPath).getPath, "d=2020-05-03")
+    testPartitionCustomFormatDate(partition = true)
+    val basePath = new File(new URI(resultPath).getPath, "d=05-03-2020")
     Assert.assertEquals(5, basePath.list().length)
-    Assert.assertTrue(new File(new File(basePath, "e=7"), "_MY_SUCCESS").exists())
-    Assert.assertTrue(new File(new File(basePath, "e=8"), "_MY_SUCCESS").exists())
-    Assert.assertTrue(new File(new File(basePath, "e=9"), "_MY_SUCCESS").exists())
+    Assert.assertTrue(new File(new File(basePath, "e=07"), "_MY_SUCCESS").exists())
+    Assert.assertTrue(new File(new File(basePath, "e=08"), "_MY_SUCCESS").exists())
+    Assert.assertTrue(new File(new File(basePath, "e=09"), "_MY_SUCCESS").exists())
     Assert.assertTrue(new File(new File(basePath, "e=10"), "_MY_SUCCESS").exists())
     Assert.assertTrue(new File(new File(basePath, "e=11"), "_MY_SUCCESS").exists())
-  }
-
-  private def test(partition: Boolean, policy: String = "success-file"): Unit = {
-    val dollar = '$'
-    val ddl = s"""
-                 |create table sink_table (
-                 |  a int,
-                 |  b string,
-                 |  c string,
-                 |  d string,
-                 |  e string
-                 |)
-                 |${if (partition) "partitioned by (d, e)" else ""}
-                 |with (
-                 |  'connector' = 'filesystem',
-                 |  'path' = '$resultPath',
-                 |  '${PARTITION_TIME_EXTRACTOR_TIMESTAMP_PATTERN.key()}' =
-                 |      '${dollar}d ${dollar}e:00:00',
-                 |  '${SINK_PARTITION_COMMIT_DELAY.key()}' = '1h',
-                 |  '${SINK_PARTITION_COMMIT_POLICY_KIND.key()}' = '$policy',
-                 |  '${SINK_PARTITION_COMMIT_SUCCESS_FILE_NAME.key()}' = '_MY_SUCCESS',
-                 |  ${additionalProperties().mkString(",\n")}
-                 |)
-       """.stripMargin
-    tEnv.executeSql(ddl)
-
-    tEnv.sqlQuery("select * from my_table").executeInsert("sink_table").await()
-
-    check("select * from sink_table", data)
   }
 
   @Test
   def testMetastorePolicy(): Unit = {
     thrown.expectMessage(
       "Can not configure a 'metastore' partition commit policy for a file system table." +
-          " You can only configure 'metastore' partition commit policy for a hive table.")
-    test(partition = true, "metastore")
+        " You can only configure 'metastore' partition commit policy for a hive table.")
+    testPartitionCustomFormatDate(partition = true, "metastore")
+  }
+
+  @Test
+  def testPartitionWithBasicDate(): Unit = {
+
+    // create source test data stream
+    val fun = (t: Row) => {
+      val localDateTime = LocalDateTime.of(
+        LocalDate.parse(t.getFieldAs[String](3), DateTimeFormatter.BASIC_ISO_DATE),
+        LocalTime.MIDNIGHT)
+      TimestampData.fromLocalDateTime(localDateTime).getMillisecond
+    }
+
+    val stream: DataStream[Row] = new DataStream(env.getJavaEnv.addSource(
+      new FiniteTestSource(data2, fun),
+      new RowTypeInfo(Types.INT, Types.STRING, Types.STRING, Types.STRING, Types.STRING)))
+
+    // write out the data
+    test(stream, "default", "yyyyMMdd", "$d", "d", "partition-time", "1d", data2)
+
+    // verify that the written data is correct
+    val basePath = new File(new URI(resultPath).getPath)
+    Assert.assertEquals(2, basePath.list().length)
+    Assert.assertTrue(new File(new File(basePath, "d=20200503"), "_MY_SUCCESS").exists())
+    Assert.assertTrue(new File(new File(basePath, "d=20200504"), "_MY_SUCCESS").exists())
+  }
+
+  def testPartitionCustomFormatDate(partition: Boolean, policy: String = "success-file"): Unit = {
+
+    val fun = (t: Row) => {
+      val localDateTime = LocalDateTime.parse(s"${t.getField(3)} ${t.getField(4)}:00:00",
+        DateTimeFormatter.ofPattern("MM-dd-yyyy HH:mm:ss"))
+      TimestampData.fromLocalDateTime(localDateTime).getMillisecond
+    }
+
+    val stream = new DataStream(env.getJavaEnv.addSource(
+      new FiniteTestSource(data, fun),
+      new RowTypeInfo(Types.INT, Types.STRING, Types.STRING, Types.STRING, Types.STRING)))
+
+    test(stream, "default", "MM-dd-yyyy HH:mm:ss", "$d $e:00:00", if (partition) "d,e" else "",
+      "process-time", "1h", data, policy)
+  }
+
+  private def test(dataStream: DataStream[Row],
+                   timeExtractorKind: String,
+                   timeExtractorFormatterPattern: String,
+                   timeExtractorPattern: String,
+                   partition: String,
+                   commitTrigger: String,
+                   commitDelay: String,
+                   dataTest: Seq[Row],
+                   policy: String = "success-file",
+                   successFileName: String = "_MY_SUCCESS"
+                  ): Unit = {
+
+    resultPath = tempFolder.newFolder().toURI.toString
+
+    tEnv.createTemporaryView("my_table", dataStream, $("a"), $("b"), $("c"), $("d"), $("e"))
+
+    val ddl =
+      s"""
+         |create table sink_table (
+         |  a int,
+         |  b string,
+         |  c string,
+         |  d string,
+         |  e string
+         |)
+         |${if (partition.nonEmpty) s"partitioned by ($partition) " else " "}
+         |with (
+         |  'connector' = 'filesystem',
+         |  'path' = '$resultPath',
+         |  '${PARTITION_TIME_EXTRACTOR_KIND.key()}' = '$timeExtractorKind',
+         |${
+        if (timeExtractorFormatterPattern.nonEmpty) s" '" +
+          s"${PARTITION_TIME_EXTRACTOR_TIMESTAMP_FORMATTER.key()}' = " +
+          s"'$timeExtractorFormatterPattern',"
+        else ""
+      }
+         |
+         |  '${PARTITION_TIME_EXTRACTOR_TIMESTAMP_PATTERN.key()}' =
+         |      '$timeExtractorPattern',
+         |  '${SINK_PARTITION_COMMIT_TRIGGER.key()}' = '$commitTrigger',
+         |  '${SINK_PARTITION_COMMIT_DELAY.key()}' = '$commitDelay',
+         |  '${SINK_PARTITION_COMMIT_POLICY_KIND.key()}' = '$policy',
+         |  '${SINK_PARTITION_COMMIT_SUCCESS_FILE_NAME.key()}' = '$successFileName',
+         |  ${additionalProperties().mkString(",\n")}
+         |)
+       """.stripMargin
+    tEnv.executeSql(ddl)
+
+    tEnv.sqlQuery("select * from my_table").executeInsert("sink_table").await()
+
+    check("select * from sink_table", dataTest)
   }
 
   def check(sqlQuery: String, expectedResult: Seq[Row]): Unit = {
@@ -139,7 +209,8 @@ abstract class FsStreamingSinkITCaseBase extends StreamingTestBase {
   }
 }
 
-class FiniteTestSource(elements: Iterable[Row]) extends SourceFunction[Row] with CheckpointListener{
+class FiniteTestSource(elements: Iterable[Row], watermarkGenerator: Row => Long) extends
+  SourceFunction[Row] with CheckpointListener {
 
   private var running: Boolean = true
 
@@ -151,8 +222,7 @@ class FiniteTestSource(elements: Iterable[Row]) extends SourceFunction[Row] with
     lock.synchronized {
       for (t <- elements) {
         ctx.collect(t)
-        ctx.emitWatermark(new Watermark(
-          toMills(toLocalDateTime(s"${t.getField(3)} ${t.getField(4)}:00:00"))))
+        ctx.emitWatermark(new Watermark(watermarkGenerator(t)))
       }
     }
 


### PR DESCRIPTION
<!--
*Thank you very much for contributing to Apache Flink - we are happy that you want to help us improve Flink. To help the community review your contribution in the best possible way, please go through the checklist below, which will get the contribution into a shape in which it can be best reviewed.*

*Please understand that we do not do this to make contributions to Flink a hassle. In order to uphold a high standard of quality for code contributions, while at the same time managing a large number of contributions, we need contributors to prepare the contributions well, and give reviewers enough contextual information for the review. Please also understand that contributions that do not follow this guide will take longer to review and thus typically be picked up with lower priority by the community.*

## Contribution Checklist

  - Make sure that the pull request corresponds to a [JIRA issue](https://issues.apache.org/jira/projects/FLINK/issues). Exceptions are made for typos in JavaDoc or documentation files, which need no JIRA issue.
  
  - Name the pull request in the form "[FLINK-XXXX] [component] Title of the pull request", where *FLINK-XXXX* should be replaced by the actual issue number. Skip *component* if you are unsure about which is the best component.
  Typo fixes that have no associated JIRA issue should be named following this pattern: `[hotfix] [docs] Fix typo in event time introduction` or `[hotfix] [javadocs] Expand JavaDoc for PuncuatedWatermarkGenerator`.

  - Fill out the template below to describe the changes contributed by the pull request. That will give reviewers the context they need to do the review.
  
  - Make sure that the change passes the automated tests, i.e., `mvn clean verify` passes. You can set up Azure Pipelines CI to do that following [this guide](https://cwiki.apache.org/confluence/display/FLINK/Azure+Pipelines#AzurePipelines-Tutorial:SettingupAzurePipelinesforaforkoftheFlinkrepository).

  - Each pull request should address only one issue, not mix up code from multiple issues.
  
  - Each commit in the pull request has a meaningful commit message (including the JIRA id)

  - Once all items of the checklist are addressed, remove the above text and this checklist, leaving only the filled out template below.


**(The sections below can be removed for hotfixes of typos)**
-->

## What is the purpose of the change

Now, only supports yyyy-mm-dd hh:mm:ss, we can add a new time-extractor kind to support yyyyMMdd in a single partition field

https://issues.apache.org/jira/browse/FLINK-24758

## Brief change log

1. add partition.time-extractor.formatter-pattern to allow user to speify DateTimeFormatter

```
CREATE TABLE MyUserTable (
  column_name1 INT,
  column_name2 STRING,
  ...
  part_name1 INT,
  part_name2 STRING
) PARTITIONED BY (part_name1, part_name2) WITH (
  'connector' = 'filesystem',           -- required: specify the connector
  ...
  'partition.time-extractor.formatter-pattern' = 'yyyyMMdd',
  ...
)
```


## Verifying this change

This change added tests and can be verified as follows:

org.apache.flink.table.planner.runtime.stream.FsStreamingSinkITCaseBase#testBasicDate


## Does this pull request potentially affect one of the following parts:

  - Dependencies (does it add or upgrade a dependency): (yes / **no**)
  - The public API, i.e., is any changed class annotated with `@Public(Evolving)`: (yes / **no**)
  - The serializers: (yes / **no** / don't know)
  - The runtime per-record code paths (performance sensitive): (yes / **no** / don't know)
  - Anything that affects deployment or recovery: JobManager (and its components), Checkpointing, Kubernetes/Yarn, ZooKeeper: (yes / **no** / don't know)
  - The S3 file system connector: (yes / no / don't know)

## Documentation

  - Does this pull request introduce a new feature? (**yes** / no)
  - If yes, how is the feature documented? (not applicable / **docs** / **JavaDocs** / not documented)
