### PR TITLE
[hotfix][table-planner] Move EnrichedRowData to table-runtime

### DIFF
--- a/flink-table/flink-table-runtime/src/main/java/org/apache/flink/table/filesystem/EnrichedRowData.java
+++ b/flink-table/flink-table-runtime/src/main/java/org/apache/flink/table/filesystem/EnrichedRowData.java
@@ -16,9 +16,9 @@
  * limitations under the License.
  */
 
-package org.apache.flink.table.data.utils;
+package org.apache.flink.table.filesystem;
 
-import org.apache.flink.annotation.PublicEvolving;
+import org.apache.flink.annotation.Internal;
 import org.apache.flink.table.data.ArrayData;
 import org.apache.flink.table.data.DecimalData;
 import org.apache.flink.table.data.MapData;
@@ -36,7 +36,7 @@ import java.util.Objects;
  * index mapping, One of the rows is fixed, while the other can be swapped for performant changes in
  * hot code paths. The {@link RowKind} is inherited from the mutable row.
  */
-@PublicEvolving
+@Internal
 public class EnrichedRowData implements RowData {
 
     private final RowData fixedRow;

--- a/flink-table/flink-table-runtime/src/main/java/org/apache/flink/table/filesystem/FileInfoExtractorBulkFormat.java
+++ b/flink-table/flink-table-runtime/src/main/java/org/apache/flink/table/filesystem/FileInfoExtractorBulkFormat.java
@@ -26,7 +26,6 @@ import org.apache.flink.connector.file.src.util.RecordMapperWrapperRecordIterato
 import org.apache.flink.table.api.DataTypes;
 import org.apache.flink.table.data.GenericRowData;
 import org.apache.flink.table.data.RowData;
-import org.apache.flink.table.data.utils.EnrichedRowData;
 import org.apache.flink.table.runtime.typeutils.InternalTypeInfo;
 import org.apache.flink.table.types.DataType;
 import org.apache.flink.table.utils.PartitionPathUtils;

--- a/flink-table/flink-table-runtime/src/test/java/org/apache/flink/table/filesystem/EnrichedRowDataTest.java
+++ b/flink-table/flink-table-runtime/src/test/java/org/apache/flink/table/filesystem/EnrichedRowDataTest.java
@@ -16,10 +16,11 @@
  * limitations under the License.
  */
 
-package org.apache.flink.table.data.utils;
+package org.apache.flink.table.filesystem;
 
 import org.apache.flink.table.data.GenericRowData;
 import org.apache.flink.table.data.RowData;
+import org.apache.flink.table.data.utils.JoinedRowData;
 import org.apache.flink.types.RowKind;
 
 import org.junit.jupiter.api.Test;
@@ -33,7 +34,7 @@ import static org.junit.jupiter.api.Assertions.assertEquals;
 public class EnrichedRowDataTest {
 
     @Test
-    public void testJoinedRows() {
+    public void testEnrichedRow() {
         final List<String> completeRowFields =
                 Arrays.asList(
                         "fixedRow1",


### PR DESCRIPTION
## What is the purpose of the change

https://github.com/apache/flink/commit/1ea210278f1da41f193a7520306cab20596fd10f introduced `EnrichedRowData` as `@PublicEvolving`. After careful consideration, I propose to move it back to runtime as it's very specific to filesystem and probably not useful to the users.

## Brief change log

* Move `EnrichedRowData` from common to runtime, changing the annotation from `@PublicEvolving` to `@Internal`.

## Verifying this change

This change is a trivial rework / code cleanup without any test coverage.

## Does this pull request potentially affect one of the following parts:

  - Dependencies (does it add or upgrade a dependency): no
  - The public API, i.e., is any changed class annotated with `@Public(Evolving)`: yes, but just on master, no changes across released versions
  - The serializers: no
  - The runtime per-record code paths (performance sensitive): no
  - Anything that affects deployment or recovery: JobManager (and its components), Checkpointing, Kubernetes/Yarn, ZooKeeper: no
  - The S3 file system connector: no

## Documentation

  - Does this pull request introduce a new feature? no
  - If yes, how is the feature documented? not applicable
