### PR TITLE
[FLINK-23486][state][metrics] Add metrics for the Changelog uploader

### DIFF
--- a/flink-dstl/flink-dstl-dfs/src/main/java/org/apache/flink/changelog/fs/ChangelogStorageMetricGroup.java
+++ b/flink-dstl/flink-dstl-dfs/src/main/java/org/apache/flink/changelog/fs/ChangelogStorageMetricGroup.java
@@ -1,0 +1,143 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.flink.changelog.fs;
+
+import org.apache.flink.metrics.Counter;
+import org.apache.flink.metrics.Gauge;
+import org.apache.flink.metrics.Histogram;
+import org.apache.flink.metrics.MetricGroup;
+import org.apache.flink.runtime.metrics.DescriptiveStatisticsHistogram;
+import org.apache.flink.runtime.metrics.groups.ProxyMetricGroup;
+
+import javax.annotation.concurrent.ThreadSafe;
+
+import java.util.concurrent.atomic.LongAdder;
+
+/**
+ * Metrics related to the Changelog Storage used by the Changelog State Backend. Thread-safety is
+ * required because it is used by multiple uploader threads.
+ */
+@ThreadSafe
+public class ChangelogStorageMetricGroup extends ProxyMetricGroup<MetricGroup> {
+    private static final int WINDOW_SIZE = 1000;
+
+    private final Counter uploadsCounter;
+    private final Counter uploadFailuresCounter;
+    private final Histogram uploadBatchSizes;
+    private final Histogram uploadSizes;
+    private final Histogram uploadLatenciesNanos;
+    private final Histogram attemptsPerUpload;
+
+    public ChangelogStorageMetricGroup(MetricGroup parent) {
+        super(parent);
+        this.uploadsCounter =
+                counter(CHANGELOG_STORAGE_NUM_UPLOAD_REQUESTS, new ThreadSafeCounter());
+        this.uploadBatchSizes =
+                histogram(
+                        CHANGELOG_STORAGE_UPLOAD_BATCH_SIZES,
+                        new DescriptiveStatisticsHistogram(WINDOW_SIZE));
+        this.attemptsPerUpload =
+                histogram(
+                        CHANGELOG_STORAGE_ATTEMPTS_PER_UPLOAD,
+                        new DescriptiveStatisticsHistogram(WINDOW_SIZE));
+        this.uploadSizes =
+                histogram(
+                        CHANGELOG_STORAGE_UPLOAD_SIZES,
+                        new DescriptiveStatisticsHistogram(WINDOW_SIZE));
+        this.uploadLatenciesNanos =
+                histogram(
+                        CHANGELOG_STORAGE_UPLOAD_LATENCIES_NANOS,
+                        new DescriptiveStatisticsHistogram(WINDOW_SIZE));
+        this.uploadFailuresCounter =
+                counter(CHANGELOG_STORAGE_NUM_UPLOAD_FAILURES, new ThreadSafeCounter());
+    }
+
+    public Counter getUploadsCounter() {
+        return uploadsCounter;
+    }
+
+    public Counter getUploadFailuresCounter() {
+        return uploadFailuresCounter;
+    }
+
+    public Histogram getAttemptsPerUpload() {
+        return attemptsPerUpload;
+    }
+
+    /**
+     * The number of upload tasks (coming from one or more writers, i.e. backends/tasks) that were
+     * grouped together and form a single upload resulting in a single file.
+     */
+    public Histogram getUploadBatchSizes() {
+        return uploadBatchSizes;
+    }
+
+    public Histogram getUploadSizes() {
+        return uploadSizes;
+    }
+
+    public Histogram getUploadLatenciesNanos() {
+        return uploadLatenciesNanos;
+    }
+
+    public void registerUploadQueueSizeGauge(Gauge<Integer> gauge) {
+        gauge(CHANGELOG_STORAGE_UPLOAD_QUEUE_SIZE, gauge);
+    }
+
+    private static class ThreadSafeCounter implements Counter {
+        private final LongAdder longAdder = new LongAdder();
+
+        @Override
+        public void inc() {
+            longAdder.increment();
+        }
+
+        @Override
+        public void inc(long n) {
+            longAdder.add(n);
+        }
+
+        @Override
+        public void dec() {
+            longAdder.decrement();
+        }
+
+        @Override
+        public void dec(long n) {
+            longAdder.add(-n);
+        }
+
+        @Override
+        public long getCount() {
+            return longAdder.longValue();
+        }
+    }
+
+    private static final String PREFIX = "ChangelogStorage";
+    public static final String CHANGELOG_STORAGE_NUM_UPLOAD_REQUESTS =
+            PREFIX + ".numberOfUploadRequests";
+    public static final String CHANGELOG_STORAGE_NUM_UPLOAD_FAILURES =
+            PREFIX + ".numberOfUploadFailures";
+    public static final String CHANGELOG_STORAGE_UPLOAD_SIZES = PREFIX + ".uploadSizes";
+    public static final String CHANGELOG_STORAGE_UPLOAD_LATENCIES_NANOS =
+            PREFIX + ".uploadLatenciesNanos";
+    public static final String CHANGELOG_STORAGE_ATTEMPTS_PER_UPLOAD =
+            PREFIX + ".attemptsPerUpload";
+    public static final String CHANGELOG_STORAGE_UPLOAD_BATCH_SIZES = PREFIX + ".uploadBatchSizes";
+    public static final String CHANGELOG_STORAGE_UPLOAD_QUEUE_SIZE = PREFIX + ".uploadQueueSize";
+}

--- a/flink-dstl/flink-dstl-dfs/src/main/java/org/apache/flink/changelog/fs/FsStateChangelogStorage.java
+++ b/flink-dstl/flink-dstl-dfs/src/main/java/org/apache/flink/changelog/fs/FsStateChangelogStorage.java
@@ -22,6 +22,7 @@ import org.apache.flink.annotation.VisibleForTesting;
 import org.apache.flink.configuration.Configuration;
 import org.apache.flink.core.fs.Path;
 import org.apache.flink.runtime.io.AvailabilityProvider;
+import org.apache.flink.runtime.metrics.groups.TaskManagerJobMetricGroup;
 import org.apache.flink.runtime.state.KeyGroupRange;
 import org.apache.flink.runtime.state.changelog.ChangelogStateHandleStreamImpl;
 import org.apache.flink.runtime.state.changelog.StateChangelogHandleReader;
@@ -55,22 +56,29 @@ public class FsStateChangelogStorage
      */
     private final AtomicInteger logIdGenerator = new AtomicInteger(0);
 
-    public FsStateChangelogStorage(Configuration config) throws IOException {
+    public FsStateChangelogStorage(Configuration config, TaskManagerJobMetricGroup metricGroup)
+            throws IOException {
         this(
-                StateChangeUploader.fromConfig(config),
+                StateChangeUploader.fromConfig(
+                        config, new ChangelogStorageMetricGroup(metricGroup)),
                 config.get(PREEMPTIVE_PERSIST_THRESHOLD).getBytes());
     }
 
     @VisibleForTesting
-    public FsStateChangelogStorage(Path basePath, boolean compression, int bufferSize)
+    public FsStateChangelogStorage(
+            Path basePath,
+            boolean compression,
+            int bufferSize,
+            ChangelogStorageMetricGroup metricGroup)
             throws IOException {
         this(
                 new StateChangeFsUploader(
-                        basePath, basePath.getFileSystem(), compression, bufferSize),
+                        basePath, basePath.getFileSystem(), compression, bufferSize, metricGroup),
                 PREEMPTIVE_PERSIST_THRESHOLD.defaultValue().getBytes());
     }
 
-    private FsStateChangelogStorage(
+    @VisibleForTesting
+    public FsStateChangelogStorage(
             StateChangeUploader uploader, long preEmptivePersistThresholdInBytes) {
         this.uploader = uploader;
         this.preEmptivePersistThresholdInBytes = preEmptivePersistThresholdInBytes;

--- a/flink-dstl/flink-dstl-dfs/src/main/java/org/apache/flink/changelog/fs/FsStateChangelogStorageFactory.java
+++ b/flink-dstl/flink-dstl-dfs/src/main/java/org/apache/flink/changelog/fs/FsStateChangelogStorageFactory.java
@@ -19,6 +19,7 @@ package org.apache.flink.changelog.fs;
 
 import org.apache.flink.annotation.Internal;
 import org.apache.flink.configuration.Configuration;
+import org.apache.flink.runtime.metrics.groups.TaskManagerJobMetricGroup;
 import org.apache.flink.runtime.state.changelog.StateChangelogStorage;
 import org.apache.flink.runtime.state.changelog.StateChangelogStorageFactory;
 
@@ -40,8 +41,9 @@ public class FsStateChangelogStorageFactory implements StateChangelogStorageFact
     }
 
     @Override
-    public StateChangelogStorage<?> createStorage(Configuration configuration) throws IOException {
-        return new FsStateChangelogStorage(configuration);
+    public StateChangelogStorage<?> createStorage(
+            Configuration configuration, TaskManagerJobMetricGroup metricGroup) throws IOException {
+        return new FsStateChangelogStorage(configuration, metricGroup);
     }
 
     public static void configure(Configuration configuration, File newFolder) {

--- a/flink-dstl/flink-dstl-dfs/src/main/java/org/apache/flink/changelog/fs/StateChangeUploader.java
+++ b/flink-dstl/flink-dstl-dfs/src/main/java/org/apache/flink/changelog/fs/StateChangeUploader.java
@@ -68,7 +68,8 @@ interface StateChangeUploader extends AutoCloseable {
         }
     }
 
-    static StateChangeUploader fromConfig(ReadableConfig config) throws IOException {
+    static StateChangeUploader fromConfig(
+            ReadableConfig config, ChangelogStorageMetricGroup metricGroup) throws IOException {
         Path basePath = new Path(config.get(BASE_PATH));
         long bytes = config.get(UPLOAD_BUFFER_SIZE).getBytes();
         checkArgument(bytes <= Integer.MAX_VALUE);
@@ -78,7 +79,8 @@ interface StateChangeUploader extends AutoCloseable {
                         basePath,
                         basePath.getFileSystem(),
                         config.get(COMPRESSION_ENABLED),
-                        bufferSize);
+                        bufferSize,
+                        metricGroup);
         BatchingStateChangeUploader batchingStore =
                 new BatchingStateChangeUploader(
                         config.get(PERSIST_DELAY).toMillis(),
@@ -86,7 +88,8 @@ interface StateChangeUploader extends AutoCloseable {
                         RetryPolicy.fromConfig(config),
                         store,
                         config.get(NUM_UPLOAD_THREADS),
-                        config.get(IN_FLIGHT_DATA_LIMIT).getBytes());
+                        config.get(IN_FLIGHT_DATA_LIMIT).getBytes(),
+                        metricGroup);
         return batchingStore;
     }
 

--- a/flink-dstl/flink-dstl-dfs/src/test/java/org/apache/flink/changelog/fs/BatchingStateChangeUploaderTest.java
+++ b/flink-dstl/flink-dstl-dfs/src/test/java/org/apache/flink/changelog/fs/BatchingStateChangeUploaderTest.java
@@ -43,6 +43,7 @@ import java.util.stream.Collectors;
 import static java.util.Collections.emptyList;
 import static java.util.Collections.singletonList;
 import static java.util.concurrent.TimeUnit.MILLISECONDS;
+import static org.apache.flink.changelog.fs.UnregisteredChangelogStorageMetricGroup.createUnregisteredChangelogStorageMetricGroup;
 import static org.apache.flink.util.ExceptionUtils.findThrowable;
 import static org.apache.flink.util.ExceptionUtils.rethrow;
 import static org.junit.Assert.assertEquals;
@@ -152,7 +153,11 @@ public class BatchingStateChangeUploaderTest {
                             }
                         },
                         new DirectScheduledExecutorService(),
-                        new RetryingExecutor(new DirectScheduledExecutorService()))) {
+                        new RetryingExecutor(
+                                new DirectScheduledExecutorService(),
+                                createUnregisteredChangelogStorageMetricGroup()
+                                        .getAttemptsPerUpload()),
+                        createUnregisteredChangelogStorageMetricGroup())) {
             CompletableFuture<List<UploadResult>> completionFuture = new CompletableFuture<>();
             store.upload(
                     new UploadTask(
@@ -176,7 +181,11 @@ public class BatchingStateChangeUploaderTest {
                         RetryPolicy.NONE,
                         probe,
                         scheduler,
-                        new RetryingExecutor(5))) {
+                        new RetryingExecutor(
+                                5,
+                                createUnregisteredChangelogStorageMetricGroup()
+                                        .getAttemptsPerUpload()),
+                        createUnregisteredChangelogStorageMetricGroup())) {
             scheduler.shutdown();
             upload(store, getChanges(4));
         }
@@ -194,7 +203,11 @@ public class BatchingStateChangeUploaderTest {
                         RetryPolicy.NONE,
                         probe,
                         scheduler,
-                        new RetryingExecutor(retryScheduler))
+                        new RetryingExecutor(
+                                retryScheduler,
+                                createUnregisteredChangelogStorageMetricGroup()
+                                        .getAttemptsPerUpload()),
+                        createUnregisteredChangelogStorageMetricGroup())
                 .close();
         assertTrue(probe.isClosed());
         assertTrue(scheduler.isShutdown());
@@ -295,7 +308,11 @@ public class BatchingStateChangeUploaderTest {
                         RetryPolicy.NONE,
                         probe,
                         scheduler,
-                        new RetryingExecutor(new DirectScheduledExecutorService()))) {
+                        new RetryingExecutor(
+                                new DirectScheduledExecutorService(),
+                                createUnregisteredChangelogStorageMetricGroup()
+                                        .getAttemptsPerUpload()),
+                        createUnregisteredChangelogStorageMetricGroup())) {
             test.accept(store, probe);
         }
     }

--- a/flink-dstl/flink-dstl-dfs/src/test/java/org/apache/flink/changelog/fs/ChangelogStorageMetricsTest.java
+++ b/flink-dstl/flink-dstl-dfs/src/test/java/org/apache/flink/changelog/fs/ChangelogStorageMetricsTest.java
@@ -1,0 +1,282 @@
+package org.apache.flink.changelog.fs;
+
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import org.apache.flink.api.common.JobID;
+import org.apache.flink.core.fs.Path;
+import org.apache.flink.core.testutils.ManuallyTriggeredScheduledExecutorService;
+import org.apache.flink.metrics.Gauge;
+import org.apache.flink.metrics.HistogramStatistics;
+import org.apache.flink.runtime.metrics.groups.TaskManagerJobMetricGroup;
+import org.apache.flink.runtime.metrics.util.TestingMetricRegistry;
+import org.apache.flink.runtime.state.testutils.EmptyStreamStateHandle;
+
+import org.junit.Rule;
+import org.junit.Test;
+import org.junit.rules.TemporaryFolder;
+
+import java.io.File;
+import java.io.IOException;
+import java.util.Collections;
+import java.util.HashMap;
+import java.util.Map;
+import java.util.concurrent.atomic.AtomicReference;
+
+import static java.util.concurrent.Executors.newSingleThreadScheduledExecutor;
+import static org.apache.flink.changelog.fs.ChangelogStorageMetricGroup.CHANGELOG_STORAGE_UPLOAD_QUEUE_SIZE;
+import static org.apache.flink.runtime.metrics.groups.UnregisteredMetricGroups.createUnregisteredTaskManagerJobMetricGroup;
+import static org.apache.flink.runtime.metrics.groups.UnregisteredMetricGroups.createUnregisteredTaskManagerMetricGroup;
+import static org.apache.flink.runtime.state.KeyGroupRange.EMPTY_KEY_GROUP_RANGE;
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertTrue;
+
+/** {@link ChangelogStorageMetricGroup} test. */
+public class ChangelogStorageMetricsTest {
+    @Rule public TemporaryFolder temporaryFolder = new TemporaryFolder();
+
+    @Test
+    public void testUploadsCounter() throws Exception {
+        ChangelogStorageMetricGroup metrics =
+                new ChangelogStorageMetricGroup(createUnregisteredTaskManagerJobMetricGroup());
+
+        try (FsStateChangelogStorage storage =
+                new FsStateChangelogStorage(
+                        Path.fromLocalFile(temporaryFolder.newFolder()), false, 100, metrics)) {
+            FsStateChangelogWriter writer = storage.createWriter("writer", EMPTY_KEY_GROUP_RANGE);
+
+            int numUploads = 5;
+            for (int i = 0; i < numUploads; i++) {
+                writer.append(0, new byte[] {0, 1, 2, 3});
+                writer.persist(writer.lastAppendedSequenceNumber()).get();
+            }
+            assertEquals(numUploads, metrics.getUploadsCounter().getCount());
+            assertTrue(metrics.getUploadLatenciesNanos().getStatistics().getMin() > 0);
+        }
+    }
+
+    @Test
+    public void testUploadSizes() throws Exception {
+        ChangelogStorageMetricGroup metrics =
+                new ChangelogStorageMetricGroup(createUnregisteredTaskManagerJobMetricGroup());
+
+        try (FsStateChangelogStorage storage =
+                new FsStateChangelogStorage(
+                        Path.fromLocalFile(temporaryFolder.newFolder()), false, 100, metrics)) {
+            FsStateChangelogWriter writer = storage.createWriter("writer", EMPTY_KEY_GROUP_RANGE);
+
+            // upload single byte to infer header size
+            writer.append(0, new byte[] {0});
+            writer.persist(writer.lastAppendedSequenceNumber()).get();
+            long headerSize = metrics.getUploadSizes().getStatistics().getMin() - 1;
+
+            byte[] upload = new byte[33];
+            for (int i = 0; i < 5; i++) {
+                writer.append(0, upload);
+                writer.persist(writer.lastAppendedSequenceNumber()).get();
+            }
+            long expected = upload.length + headerSize;
+            assertEquals(expected, metrics.getUploadSizes().getStatistics().getMax());
+        }
+    }
+
+    @Test
+    public void testUploadFailuresCounter() throws Exception {
+        File file = temporaryFolder.newFile(); // using file instead of folder will cause a failure
+        ChangelogStorageMetricGroup metrics =
+                new ChangelogStorageMetricGroup(createUnregisteredTaskManagerJobMetricGroup());
+        try (FsStateChangelogStorage storage =
+                new FsStateChangelogStorage(Path.fromLocalFile(file), false, 100, metrics)) {
+            FsStateChangelogWriter writer = storage.createWriter("writer", EMPTY_KEY_GROUP_RANGE);
+
+            int numUploads = 5;
+            for (int i = 0; i < numUploads; i++) {
+                writer.append(0, new byte[] {0, 1, 2, 3});
+                try {
+                    writer.persist(writer.lastAppendedSequenceNumber()).get();
+                } catch (IOException e) {
+                    // ignore
+                }
+            }
+            assertEquals(numUploads, metrics.getUploadFailuresCounter().getCount());
+        }
+    }
+
+    @Test
+    public void testUploadBatchSizes() throws Exception {
+        int numWriters = 5, numUploads = 5;
+
+        ChangelogStorageMetricGroup metrics =
+                new ChangelogStorageMetricGroup(createUnregisteredTaskManagerJobMetricGroup());
+        Path basePath = Path.fromLocalFile(temporaryFolder.newFolder());
+        StateChangeFsUploader uploader =
+                new StateChangeFsUploader(basePath, basePath.getFileSystem(), false, 100, metrics);
+        ManuallyTriggeredScheduledExecutorService scheduler =
+                new ManuallyTriggeredScheduledExecutorService();
+        BatchingStateChangeUploader batcher =
+                new BatchingStateChangeUploader(
+                        Long.MAX_VALUE,
+                        Long.MAX_VALUE,
+                        Long.MAX_VALUE,
+                        RetryPolicy.NONE,
+                        uploader,
+                        scheduler,
+                        new RetryingExecutor(1, metrics.getAttemptsPerUpload()),
+                        metrics);
+
+        FsStateChangelogStorage storage = new FsStateChangelogStorage(batcher, Integer.MAX_VALUE);
+        FsStateChangelogWriter[] writers = new FsStateChangelogWriter[numWriters];
+        for (int i = 0; i < numWriters; i++) {
+            writers[i] = storage.createWriter(Integer.toString(i), EMPTY_KEY_GROUP_RANGE);
+        }
+
+        try {
+            for (int upload = 0; upload < numUploads; upload++) {
+                for (int writer = 0; writer < numWriters; writer++) {
+                    // with all thresholds on MAX and manually triggered executor, this shouldn't
+                    // cause
+                    // actual uploads
+                    writers[writer].append(0, new byte[] {0, 1, 2, 3});
+                    writers[writer].persist(writers[writer].lastAppendedSequenceNumber());
+                }
+                // now the uploads should be grouped and executed at once
+                scheduler.triggerScheduledTasks();
+            }
+            assertEquals(numWriters, metrics.getUploadBatchSizes().getStatistics().getMin());
+            assertEquals(numWriters, metrics.getUploadBatchSizes().getStatistics().getMax());
+        } finally {
+            storage.close();
+        }
+    }
+
+    @Test
+    public void testAttemptsPerUpload() throws Exception {
+        int numUploads = 7, maxAttempts = 3;
+
+        ChangelogStorageMetricGroup metrics =
+                new ChangelogStorageMetricGroup(createUnregisteredTaskManagerJobMetricGroup());
+
+        BatchingStateChangeUploader batcher =
+                new BatchingStateChangeUploader(
+                        Long.MAX_VALUE,
+                        1,
+                        Long.MAX_VALUE,
+                        RetryPolicy.fixed(maxAttempts, Long.MAX_VALUE, 0),
+                        new MaxAttemptUploader(maxAttempts),
+                        newSingleThreadScheduledExecutor(),
+                        new RetryingExecutor(1, metrics.getAttemptsPerUpload()),
+                        metrics);
+
+        FsStateChangelogStorage storage = new FsStateChangelogStorage(batcher, Integer.MAX_VALUE);
+        FsStateChangelogWriter writer = storage.createWriter("writer", EMPTY_KEY_GROUP_RANGE);
+
+        try {
+            for (int upload = 0; upload < numUploads; upload++) {
+                writer.append(0, new byte[] {0, 1, 2, 3});
+                writer.persist(writer.lastAppendedSequenceNumber()).get();
+            }
+            HistogramStatistics histogram = metrics.getAttemptsPerUpload().getStatistics();
+            assertEquals(maxAttempts, histogram.getMin());
+            assertEquals(maxAttempts, histogram.getMax());
+        } finally {
+            storage.close();
+        }
+    }
+
+    @Test
+    public void testQueueSize() throws Exception {
+        AtomicReference<Gauge<Integer>> queueSizeGauge = new AtomicReference<>();
+        ChangelogStorageMetricGroup metrics =
+                new ChangelogStorageMetricGroup(
+                        new TaskManagerJobMetricGroup(
+                                TestingMetricRegistry.builder()
+                                        .setRegisterConsumer(
+                                                (metric, name, unused) -> {
+                                                    if (name.equals(
+                                                            CHANGELOG_STORAGE_UPLOAD_QUEUE_SIZE)) {
+                                                        queueSizeGauge.set((Gauge<Integer>) metric);
+                                                    }
+                                                })
+                                        .build(),
+                                createUnregisteredTaskManagerMetricGroup(),
+                                new JobID(),
+                                "test"));
+
+        Path path = Path.fromLocalFile(temporaryFolder.newFolder());
+        StateChangeFsUploader delegate =
+                new StateChangeFsUploader(path, path.getFileSystem(), false, 100, metrics);
+        ManuallyTriggeredScheduledExecutorService scheduler =
+                new ManuallyTriggeredScheduledExecutorService();
+        BatchingStateChangeUploader batcher =
+                new BatchingStateChangeUploader(
+                        Long.MAX_VALUE,
+                        Long.MAX_VALUE,
+                        Long.MAX_VALUE,
+                        RetryPolicy.NONE,
+                        delegate,
+                        scheduler,
+                        new RetryingExecutor(1, metrics.getAttemptsPerUpload()),
+                        metrics);
+        try (FsStateChangelogStorage storage =
+                new FsStateChangelogStorage(batcher, Long.MAX_VALUE)) {
+            FsStateChangelogWriter writer = storage.createWriter("writer", EMPTY_KEY_GROUP_RANGE);
+            int numUploads = 11;
+            for (int i = 0; i < numUploads; i++) {
+                writer.append(0, new byte[] {0});
+                writer.persist(writer.lastAppendedSequenceNumber());
+            }
+            assertEquals(numUploads, (int) queueSizeGauge.get().getValue());
+            scheduler.triggerScheduledTasks();
+            assertEquals(0, (int) queueSizeGauge.get().getValue());
+        }
+    }
+
+    private static class MaxAttemptUploader implements StateChangeUploader {
+        private final Map<UploadTask, Integer> attemptsPerTask;
+        private final int maxAttempts;
+
+        public MaxAttemptUploader(int maxAttempts) {
+            this.maxAttempts = maxAttempts;
+            this.attemptsPerTask = new HashMap<>();
+        }
+
+        @Override
+        public void upload(UploadTask uploadTask) throws IOException {
+            int currentAttempt = 1 + attemptsPerTask.getOrDefault(uploadTask, 0);
+            if (currentAttempt == maxAttempts) {
+                attemptsPerTask.remove(uploadTask);
+                uploadTask.complete(Collections.singletonList(getResult(uploadTask)));
+            } else {
+                attemptsPerTask.put(uploadTask, currentAttempt);
+                throw new IOException();
+            }
+        }
+
+        private UploadResult getResult(UploadTask uploadTask) {
+            return new UploadResult(
+                    new EmptyStreamStateHandle(),
+                    0,
+                    uploadTask.changeSets.iterator().next().getSequenceNumber(),
+                    uploadTask.getSize());
+        }
+
+        @Override
+        public void close() {
+            attemptsPerTask.clear();
+        }
+    }
+}

--- a/flink-dstl/flink-dstl-dfs/src/test/java/org/apache/flink/changelog/fs/FsStateChangelogStorageTest.java
+++ b/flink-dstl/flink-dstl-dfs/src/test/java/org/apache/flink/changelog/fs/FsStateChangelogStorageTest.java
@@ -26,6 +26,8 @@ import org.junit.runners.Parameterized;
 
 import java.io.IOException;
 
+import static org.apache.flink.changelog.fs.UnregisteredChangelogStorageMetricGroup.createUnregisteredChangelogStorageMetricGroup;
+
 /** {@link FsStateChangelogStorage} test. */
 @RunWith(Parameterized.class)
 public class FsStateChangelogStorageTest extends StateChangelogStorageTest {
@@ -39,6 +41,9 @@ public class FsStateChangelogStorageTest extends StateChangelogStorageTest {
     @Override
     protected StateChangelogStorage<?> getFactory() throws IOException {
         return new FsStateChangelogStorage(
-                Path.fromLocalFile(temporaryFolder.newFolder()), compression, 1024 * 1024 * 10);
+                Path.fromLocalFile(temporaryFolder.newFolder()),
+                compression,
+                1024 * 1024 * 10,
+                createUnregisteredChangelogStorageMetricGroup());
     }
 }

--- a/flink-dstl/flink-dstl-dfs/src/test/java/org/apache/flink/changelog/fs/RetryingExecutorTest.java
+++ b/flink-dstl/flink-dstl-dfs/src/test/java/org/apache/flink/changelog/fs/RetryingExecutorTest.java
@@ -33,6 +33,7 @@ import java.util.concurrent.TimeUnit;
 import java.util.concurrent.TimeoutException;
 import java.util.concurrent.atomic.AtomicInteger;
 
+import static org.apache.flink.changelog.fs.UnregisteredChangelogStorageMetricGroup.createUnregisteredChangelogStorageMetricGroup;
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.fail;
 
@@ -163,7 +164,10 @@ public class RetryingExecutorTest {
             throws Exception {
         AtomicInteger attemptsMade = new AtomicInteger(0);
         CountDownLatch firstAttemptCompletedLatch = new CountDownLatch(1);
-        try (RetryingExecutor executor = new RetryingExecutor(scheduler)) {
+        try (RetryingExecutor executor =
+                new RetryingExecutor(
+                        scheduler,
+                        createUnregisteredChangelogStorageMetricGroup().getAttemptsPerUpload())) {
             executor.execute(
                     policy,
                     () -> {

--- a/flink-dstl/flink-dstl-dfs/src/test/java/org/apache/flink/changelog/fs/UnregisteredChangelogStorageMetricGroup.java
+++ b/flink-dstl/flink-dstl-dfs/src/test/java/org/apache/flink/changelog/fs/UnregisteredChangelogStorageMetricGroup.java
@@ -1,0 +1,31 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.flink.changelog.fs;
+
+import org.apache.flink.runtime.metrics.groups.UnregisteredMetricGroups;
+
+/** A safe drop-in replacement for {@link ChangelogStorageMetricGroup}s. */
+class UnregisteredChangelogStorageMetricGroup extends ChangelogStorageMetricGroup {
+    public UnregisteredChangelogStorageMetricGroup() {
+        super(new UnregisteredMetricGroups.UnregisteredTaskManagerJobMetricGroup());
+    }
+
+    public static ChangelogStorageMetricGroup createUnregisteredChangelogStorageMetricGroup() {
+        return new UnregisteredChangelogStorageMetricGroup();
+    }
+}

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/metrics/groups/TaskManagerJobMetricGroup.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/metrics/groups/TaskManagerJobMetricGroup.java
@@ -47,7 +47,7 @@ public class TaskManagerJobMetricGroup extends JobMetricGroup<TaskManagerMetricG
 
     // ------------------------------------------------------------------------
 
-    TaskManagerJobMetricGroup(
+    public TaskManagerJobMetricGroup(
             MetricRegistry registry,
             TaskManagerMetricGroup parent,
             JobID jobId,

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/state/TaskExecutorStateChangelogStoragesManager.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/state/TaskExecutorStateChangelogStoragesManager.java
@@ -21,6 +21,7 @@ package org.apache.flink.runtime.state;
 import org.apache.flink.annotation.VisibleForTesting;
 import org.apache.flink.api.common.JobID;
 import org.apache.flink.configuration.Configuration;
+import org.apache.flink.runtime.metrics.groups.TaskManagerJobMetricGroup;
 import org.apache.flink.runtime.state.changelog.StateChangelogStorage;
 import org.apache.flink.runtime.state.changelog.StateChangelogStorageLoader;
 import org.apache.flink.util.ShutdownHookUtil;
@@ -69,7 +70,10 @@ public class TaskExecutorStateChangelogStoragesManager {
 
     @Nullable
     public StateChangelogStorage<?> stateChangelogStorageForJob(
-            @Nonnull JobID jobId, Configuration configuration) throws IOException {
+            @Nonnull JobID jobId,
+            Configuration configuration,
+            TaskManagerJobMetricGroup metricGroup)
+            throws IOException {
         if (closed) {
             throw new IllegalStateException(
                     "TaskExecutorStateChangelogStoragesManager is already closed and cannot "
@@ -80,7 +84,8 @@ public class TaskExecutorStateChangelogStoragesManager {
                 changelogStoragesByJobId.get(jobId);
 
         if (stateChangelogStorage == null) {
-            StateChangelogStorage<?> loaded = StateChangelogStorageLoader.load(configuration);
+            StateChangelogStorage<?> loaded =
+                    StateChangelogStorageLoader.load(configuration, metricGroup);
             stateChangelogStorage = Optional.ofNullable(loaded);
             changelogStoragesByJobId.put(jobId, stateChangelogStorage);
 

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/state/changelog/StateChangelogStorageFactory.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/state/changelog/StateChangelogStorageFactory.java
@@ -20,6 +20,7 @@ package org.apache.flink.runtime.state.changelog;
 
 import org.apache.flink.annotation.Internal;
 import org.apache.flink.configuration.Configuration;
+import org.apache.flink.runtime.metrics.groups.TaskManagerJobMetricGroup;
 
 import java.io.IOException;
 
@@ -33,5 +34,6 @@ public interface StateChangelogStorageFactory {
     String getIdentifier();
 
     /** Create the storage based on a configuration. */
-    StateChangelogStorage<?> createStorage(Configuration configuration) throws IOException;
+    StateChangelogStorage<?> createStorage(
+            Configuration configuration, TaskManagerJobMetricGroup metricGroup) throws IOException;
 }

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/state/changelog/StateChangelogStorageLoader.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/state/changelog/StateChangelogStorageLoader.java
@@ -21,6 +21,7 @@ import org.apache.flink.annotation.Internal;
 import org.apache.flink.configuration.Configuration;
 import org.apache.flink.configuration.StateChangelogOptions;
 import org.apache.flink.core.plugin.PluginManager;
+import org.apache.flink.runtime.metrics.groups.TaskManagerJobMetricGroup;
 
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
@@ -82,7 +83,8 @@ public class StateChangelogStorageLoader {
     }
 
     @Nullable
-    public static StateChangelogStorage<?> load(Configuration configuration) throws IOException {
+    public static StateChangelogStorage<?> load(
+            Configuration configuration, TaskManagerJobMetricGroup metricGroup) throws IOException {
         final String identifier =
                 configuration
                         .getString(StateChangelogOptions.STATE_CHANGE_LOG_STORAGE)
@@ -94,7 +96,7 @@ public class StateChangelogStorageLoader {
             return null;
         } else {
             LOG.info("Creating a changelog storage with name '{}'.", identifier);
-            return factory.createStorage(configuration);
+            return factory.createStorage(configuration, metricGroup);
         }
     }
 }

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/state/changelog/inmemory/InMemoryStateChangelogStorageFactory.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/state/changelog/inmemory/InMemoryStateChangelogStorageFactory.java
@@ -18,6 +18,7 @@
 package org.apache.flink.runtime.state.changelog.inmemory;
 
 import org.apache.flink.configuration.Configuration;
+import org.apache.flink.runtime.metrics.groups.TaskManagerJobMetricGroup;
 import org.apache.flink.runtime.state.changelog.StateChangelogStorage;
 import org.apache.flink.runtime.state.changelog.StateChangelogStorageFactory;
 
@@ -32,7 +33,8 @@ public class InMemoryStateChangelogStorageFactory implements StateChangelogStora
     }
 
     @Override
-    public StateChangelogStorage<?> createStorage(Configuration configuration) {
+    public StateChangelogStorage<?> createStorage(
+            Configuration configuration, TaskManagerJobMetricGroup metricGroup) {
         return new InMemoryStateChangelogStorage();
     }
 }

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/taskexecutor/TaskExecutor.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/taskexecutor/TaskExecutor.java
@@ -692,7 +692,7 @@ public class TaskExecutor extends RpcEndpoint implements TaskExecutorGateway {
             try {
                 changelogStorage =
                         changelogStoragesManager.stateChangelogStorageForJob(
-                                jobId, taskManagerConfiguration.getConfiguration());
+                                jobId, taskManagerConfiguration.getConfiguration(), jobGroup);
             } catch (IOException e) {
                 throw new TaskSubmissionException(e);
             }

--- a/flink-runtime/src/test/java/org/apache/flink/runtime/metrics/CollectingMetricsReporter.java
+++ b/flink-runtime/src/test/java/org/apache/flink/runtime/metrics/CollectingMetricsReporter.java
@@ -1,0 +1,100 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.flink.runtime.metrics;
+
+import org.apache.flink.metrics.CharacterFilter;
+import org.apache.flink.metrics.Metric;
+import org.apache.flink.metrics.MetricGroup;
+import org.apache.flink.runtime.metrics.util.TestReporter;
+
+import javax.annotation.Nullable;
+
+import java.util.ArrayList;
+import java.util.List;
+
+import static java.util.Collections.unmodifiableList;
+
+/**
+ * Reporter that collects added and removed metrics so that it can be verified in the test (e.g.
+ * that the configured delimiter is applied correctly when generating the metric identifier).
+ */
+public class CollectingMetricsReporter extends TestReporter {
+
+    @Nullable private final CharacterFilter characterFilter;
+    private final List<MetricGroupAndName> addedMetrics = new ArrayList<>();
+    private final List<MetricGroupAndName> removedMetrics = new ArrayList<>();
+
+    public CollectingMetricsReporter() {
+        this(null);
+    }
+
+    public CollectingMetricsReporter(@Nullable CharacterFilter characterFilter) {
+        this.characterFilter = characterFilter;
+    }
+
+    @Override
+    public String filterCharacters(String input) {
+        return characterFilter == null ? input : characterFilter.filterCharacters(input);
+    }
+
+    @Override
+    public void notifyOfAddedMetric(Metric metric, String metricName, MetricGroup group) {
+        addedMetrics.add(new MetricGroupAndName(metricName, group));
+    }
+
+    @Override
+    public void notifyOfRemovedMetric(Metric metric, String metricName, MetricGroup group) {
+        removedMetrics.add(new MetricGroupAndName(metricName, group));
+    }
+
+    public List<MetricGroupAndName> getAddedMetrics() {
+        return unmodifiableList(addedMetrics);
+    }
+
+    public List<MetricGroupAndName> getRemovedMetrics() {
+        return unmodifiableList(removedMetrics);
+    }
+
+    public MetricGroupAndName findAdded(String name) {
+        return getMetricGroupAndName(name, addedMetrics);
+    }
+
+    MetricGroupAndName findRemoved(String name) {
+        return getMetricGroupAndName(name, removedMetrics);
+    }
+
+    @SuppressWarnings("OptionalGetWithoutIsPresent")
+    private MetricGroupAndName getMetricGroupAndName(
+            String name, List<MetricGroupAndName> removedMetrics) {
+        return removedMetrics.stream()
+                .filter(groupAndName -> groupAndName.name.equals(name))
+                .findAny()
+                .get();
+    }
+
+    /** Metric group and name. */
+    public static class MetricGroupAndName {
+        public final String name;
+        public final MetricGroup group;
+
+        MetricGroupAndName(String name, MetricGroup group) {
+            this.name = name;
+            this.group = group;
+        }
+    }
+}

--- a/flink-runtime/src/test/java/org/apache/flink/runtime/metrics/groups/AbstractMetricGroupTest.java
+++ b/flink-runtime/src/test/java/org/apache/flink/runtime/metrics/groups/AbstractMetricGroupTest.java
@@ -23,11 +23,11 @@ import org.apache.flink.configuration.Configuration;
 import org.apache.flink.configuration.MetricOptions;
 import org.apache.flink.core.testutils.BlockerSync;
 import org.apache.flink.metrics.CharacterFilter;
-import org.apache.flink.metrics.Metric;
 import org.apache.flink.metrics.MetricConfig;
 import org.apache.flink.metrics.MetricGroup;
-import org.apache.flink.metrics.reporter.MetricReporter;
 import org.apache.flink.runtime.clusterframework.types.ResourceID;
+import org.apache.flink.runtime.metrics.CollectingMetricsReporter;
+import org.apache.flink.runtime.metrics.CollectingMetricsReporter.MetricGroupAndName;
 import org.apache.flink.runtime.metrics.MetricRegistry;
 import org.apache.flink.runtime.metrics.MetricRegistryImpl;
 import org.apache.flink.runtime.metrics.MetricRegistryTestUtils;
@@ -35,7 +35,6 @@ import org.apache.flink.runtime.metrics.NoOpMetricRegistry;
 import org.apache.flink.runtime.metrics.ReporterSetup;
 import org.apache.flink.runtime.metrics.dump.QueryScopeInfo;
 import org.apache.flink.runtime.metrics.scope.ScopeFormat;
-import org.apache.flink.runtime.metrics.util.TestReporter;
 import org.apache.flink.runtime.metrics.util.TestingMetricRegistry;
 import org.apache.flink.util.TestLogger;
 
@@ -148,6 +147,7 @@ public class AbstractMetricGroupTest extends TestLogger {
 
     @Test
     public void testScopeCachingForMultipleReporters() throws Exception {
+        String counterName = "1";
         Configuration config = new Configuration();
         config.setString(MetricOptions.SCOPE_NAMING_TM, "A.B.C.D");
 
@@ -161,7 +161,7 @@ public class AbstractMetricGroupTest extends TestLogger {
                 ConfigConstants.METRICS_REPORTER_PREFIX
                         + "test1."
                         + ConfigConstants.METRICS_REPORTER_CLASS_SUFFIX,
-                TestReporter1.class.getName());
+                CollectingMetricsReporter.class.getName());
         config.setString(
                 ConfigConstants.METRICS_REPORTER_PREFIX
                         + "test1."
@@ -171,35 +171,80 @@ public class AbstractMetricGroupTest extends TestLogger {
                 ConfigConstants.METRICS_REPORTER_PREFIX
                         + "test2."
                         + ConfigConstants.METRICS_REPORTER_CLASS_SUFFIX,
-                TestReporter2.class.getName());
+                CollectingMetricsReporter.class.getName());
         config.setString(
                 ConfigConstants.METRICS_REPORTER_PREFIX
                         + "test2."
                         + ConfigConstants.METRICS_REPORTER_SCOPE_DELIMITER,
                 "!");
 
+        CollectingMetricsReporter reporter1 = new CollectingMetricsReporter(FILTER_B);
+        CollectingMetricsReporter reporter2 = new CollectingMetricsReporter(FILTER_C);
         MetricRegistryImpl testRegistry =
                 new MetricRegistryImpl(
                         MetricRegistryTestUtils.fromConfiguration(config),
                         Arrays.asList(
-                                ReporterSetup.forReporter(
-                                        "test1", metricConfig1, new TestReporter1()),
-                                ReporterSetup.forReporter(
-                                        "test2", metricConfig2, new TestReporter2())));
+                                ReporterSetup.forReporter("test1", metricConfig1, reporter1),
+                                ReporterSetup.forReporter("test2", metricConfig2, reporter2)));
         try {
             MetricGroup tmGroup =
                     TaskManagerMetricGroup.createTaskManagerMetricGroup(
                             testRegistry, "host", new ResourceID("id"));
-            tmGroup.counter("1");
+            tmGroup.counter(counterName);
             assertEquals(
                     "Reporters were not properly instantiated",
                     2,
                     testRegistry.getReporters().size());
-            for (MetricReporter reporter : testRegistry.getReporters()) {
-                ScopeCheckingTestReporter typedReporter = (ScopeCheckingTestReporter) reporter;
-                if (typedReporter.failureCause != null) {
-                    throw typedReporter.failureCause;
-                }
+            {
+                // verify reporter1
+                MetricGroupAndName nameAndGroup =
+                        reporter1.getAddedMetrics().stream()
+                                .filter(nag -> nag.name.equals(counterName))
+                                .findAny()
+                                .get();
+                String metricName = nameAndGroup.name;
+                MetricGroup group = nameAndGroup.group;
+
+                // the first call determines which filter is applied to all future
+                // calls; in
+                // this case
+                // no filter is used at all
+                assertEquals("A-B-C-D-1", group.getMetricIdentifier(metricName));
+                // from now on the scope string is cached and should not be reliant
+                // on the
+                // given filter
+                assertEquals("A-B-C-D-1", group.getMetricIdentifier(metricName, FILTER_C));
+                assertEquals("A-B-C-D-1", group.getMetricIdentifier(metricName, reporter1));
+                // the metric name however is still affected by the filter as it is
+                // not
+                // cached
+                assertEquals(
+                        "A-B-C-D-4",
+                        group.getMetricIdentifier(
+                                metricName,
+                                input -> input.replace("B", "X").replace(counterName, "4")));
+            }
+            {
+                // verify reporter2
+                MetricGroupAndName nameAndGroup =
+                        reporter2.getAddedMetrics().stream()
+                                .filter(nag -> nag.name.equals(counterName))
+                                .findAny()
+                                .get();
+                String metricName = nameAndGroup.name;
+                MetricGroup group = nameAndGroup.group;
+                // the first call determines which filter is applied to all future calls
+                assertEquals("A!B!X!D!1", group.getMetricIdentifier(metricName, reporter2));
+                // from now on the scope string is cached and should not be reliant on the given
+                // filter
+                assertEquals("A!B!X!D!1", group.getMetricIdentifier(metricName));
+                assertEquals("A!B!X!D!1", group.getMetricIdentifier(metricName, FILTER_C));
+                // the metric name however is still affected by the filter as it is not cached
+                assertEquals(
+                        "A!B!X!D!3",
+                        group.getMetricIdentifier(
+                                metricName,
+                                input -> input.replace("A", "X").replace(counterName, "3")));
             }
         } finally {
             testRegistry.shutdown().get();
@@ -207,136 +252,40 @@ public class AbstractMetricGroupTest extends TestLogger {
     }
 
     @Test
+    @SuppressWarnings("unchecked")
     public void testLogicalScopeCachingForMultipleReporters() throws Exception {
+        String counterName = "1";
+        CollectingMetricsReporter reporter1 = new CollectingMetricsReporter(FILTER_B);
+        CollectingMetricsReporter reporter2 = new CollectingMetricsReporter(FILTER_C);
         MetricRegistryImpl testRegistry =
                 new MetricRegistryImpl(
                         MetricRegistryTestUtils.defaultMetricRegistryConfiguration(),
                         Arrays.asList(
-                                ReporterSetup.forReporter("test1", new LogicalScopeReporter1()),
-                                ReporterSetup.forReporter("test2", new LogicalScopeReporter2())));
+                                ReporterSetup.forReporter("test1", reporter1),
+                                ReporterSetup.forReporter("test2", reporter2)));
         try {
             MetricGroup tmGroup =
                     TaskManagerMetricGroup.createTaskManagerMetricGroup(
                                     testRegistry, "host", new ResourceID("id"))
                             .addGroup("B")
                             .addGroup("C");
-            tmGroup.counter("1");
+            tmGroup.counter(counterName);
             assertEquals(
                     "Reporters were not properly instantiated",
                     2,
                     testRegistry.getReporters().size());
-            for (MetricReporter reporter : testRegistry.getReporters()) {
-                ScopeCheckingTestReporter typedReporter = (ScopeCheckingTestReporter) reporter;
-                if (typedReporter.failureCause != null) {
-                    throw typedReporter.failureCause;
-                }
-            }
+            assertEquals(
+                    "taskmanager-X-C",
+                    ((FrontMetricGroup<AbstractMetricGroup<?>>)
+                                    reporter1.findAdded(counterName).group)
+                            .getLogicalScope(reporter1, '-'));
+            assertEquals(
+                    "taskmanager,B,X",
+                    ((FrontMetricGroup<AbstractMetricGroup<?>>)
+                                    reporter2.findAdded(counterName).group)
+                            .getLogicalScope(reporter2, ','));
         } finally {
             testRegistry.shutdown().get();
-        }
-    }
-
-    private abstract static class ScopeCheckingTestReporter extends TestReporter {
-        protected Exception failureCause;
-
-        @Override
-        public void notifyOfAddedMetric(Metric metric, String metricName, MetricGroup group) {
-            try {
-                checkScopes(metric, metricName, group);
-            } catch (Exception e) {
-                if (failureCause == null) {
-                    failureCause = e;
-                }
-            }
-        }
-
-        public abstract void checkScopes(Metric metric, String metricName, MetricGroup group);
-    }
-
-    /** Reporter that verifies the scope caching behavior. */
-    public static class TestReporter1 extends ScopeCheckingTestReporter {
-        @Override
-        public String filterCharacters(String input) {
-            return FILTER_B.filterCharacters(input);
-        }
-
-        @Override
-        public void checkScopes(Metric metric, String metricName, MetricGroup group) {
-            // the first call determines which filter is applied to all future calls; in this case
-            // no filter is used at all
-            assertEquals("A-B-C-D-1", group.getMetricIdentifier(metricName));
-            // from now on the scope string is cached and should not be reliant on the given filter
-            assertEquals("A-B-C-D-1", group.getMetricIdentifier(metricName, FILTER_C));
-            assertEquals("A-B-C-D-1", group.getMetricIdentifier(metricName, this));
-            // the metric name however is still affected by the filter as it is not cached
-            assertEquals(
-                    "A-B-C-D-4",
-                    group.getMetricIdentifier(
-                            metricName,
-                            new CharacterFilter() {
-                                @Override
-                                public String filterCharacters(String input) {
-                                    return input.replace("B", "X").replace("1", "4");
-                                }
-                            }));
-        }
-    }
-
-    /** Reporter that verifies the scope caching behavior. */
-    public static class TestReporter2 extends ScopeCheckingTestReporter {
-        @Override
-        public String filterCharacters(String input) {
-            return FILTER_C.filterCharacters(input);
-        }
-
-        @Override
-        public void checkScopes(Metric metric, String metricName, MetricGroup group) {
-            // the first call determines which filter is applied to all future calls
-            assertEquals("A!B!X!D!1", group.getMetricIdentifier(metricName, this));
-            // from now on the scope string is cached and should not be reliant on the given filter
-            assertEquals("A!B!X!D!1", group.getMetricIdentifier(metricName));
-            assertEquals("A!B!X!D!1", group.getMetricIdentifier(metricName, FILTER_C));
-            // the metric name however is still affected by the filter as it is not cached
-            assertEquals(
-                    "A!B!X!D!3",
-                    group.getMetricIdentifier(
-                            metricName,
-                            new CharacterFilter() {
-                                @Override
-                                public String filterCharacters(String input) {
-                                    return input.replace("A", "X").replace("1", "3");
-                                }
-                            }));
-        }
-    }
-
-    /** Reporter that verifies the logical-scope caching behavior. */
-    public static final class LogicalScopeReporter1 extends ScopeCheckingTestReporter {
-        @Override
-        public String filterCharacters(String input) {
-            return FILTER_B.filterCharacters(input);
-        }
-
-        @Override
-        public void checkScopes(Metric metric, String metricName, MetricGroup group) {
-            final String logicalScope =
-                    ((FrontMetricGroup<AbstractMetricGroup<?>>) group).getLogicalScope(this, '-');
-            assertEquals("taskmanager-X-C", logicalScope);
-        }
-    }
-
-    /** Reporter that verifies the logical-scope caching behavior. */
-    public static final class LogicalScopeReporter2 extends ScopeCheckingTestReporter {
-        @Override
-        public String filterCharacters(String input) {
-            return FILTER_C.filterCharacters(input);
-        }
-
-        @Override
-        public void checkScopes(Metric metric, String metricName, MetricGroup group) {
-            final String logicalScope =
-                    ((FrontMetricGroup<AbstractMetricGroup<?>>) group).getLogicalScope(this, ',');
-            assertEquals("taskmanager,B,X", logicalScope);
         }
     }
 

--- a/flink-runtime/src/test/java/org/apache/flink/runtime/metrics/groups/TaskMetricGroupTest.java
+++ b/flink-runtime/src/test/java/org/apache/flink/runtime/metrics/groups/TaskMetricGroupTest.java
@@ -178,18 +178,19 @@ public class TaskMetricGroupTest extends TestLogger {
                 TaskManagerMetricGroup.createTaskManagerMetricGroup(
                         registry, "localhost", new ResourceID("0"));
 
+        int initialMetricsCount = registry.getNumberRegisteredMetrics();
         TaskMetricGroup taskMetricGroup =
                 taskManagerMetricGroup
                         .addJob(new JobID(), "job")
                         .addTask(new JobVertexID(), new ExecutionAttemptID(), "task", 0, 0);
 
         // the io metric should have registered predefined metrics
-        assertTrue(registry.getNumberRegisteredMetrics() > 0);
+        assertTrue(registry.getNumberRegisteredMetrics() > initialMetricsCount);
 
         taskMetricGroup.close();
 
         // now all registered metrics should have been unregistered
-        assertEquals(0, registry.getNumberRegisteredMetrics());
+        assertEquals(initialMetricsCount, registry.getNumberRegisteredMetrics());
 
         registry.shutdown().get();
     }

--- a/flink-runtime/src/test/java/org/apache/flink/runtime/state/TaskExecutorStateChangelogStoragesManagerTest.java
+++ b/flink-runtime/src/test/java/org/apache/flink/runtime/state/TaskExecutorStateChangelogStoragesManagerTest.java
@@ -22,6 +22,7 @@ import org.apache.flink.api.common.JobID;
 import org.apache.flink.configuration.Configuration;
 import org.apache.flink.configuration.StateChangelogOptions;
 import org.apache.flink.core.plugin.PluginManager;
+import org.apache.flink.runtime.metrics.groups.TaskManagerJobMetricGroup;
 import org.apache.flink.runtime.state.changelog.ChangelogStateHandle;
 import org.apache.flink.runtime.state.changelog.StateChangelogHandleReader;
 import org.apache.flink.runtime.state.changelog.StateChangelogStorage;
@@ -36,6 +37,7 @@ import java.io.IOException;
 import java.util.Iterator;
 
 import static java.util.Collections.singletonList;
+import static org.apache.flink.runtime.metrics.groups.UnregisteredMetricGroups.createUnregisteredTaskManagerJobMetricGroup;
 import static org.apache.flink.util.Preconditions.checkArgument;
 
 /** Tests for {@link TaskExecutorStateChangelogStoragesManager}. */
@@ -48,14 +50,17 @@ public class TaskExecutorStateChangelogStoragesManagerTest {
         Configuration configuration = new Configuration();
         JobID jobId1 = new JobID(1L, 1L);
         StateChangelogStorage<?> storage1 =
-                manager.stateChangelogStorageForJob(jobId1, configuration);
+                manager.stateChangelogStorageForJob(
+                        jobId1, configuration, createUnregisteredTaskManagerJobMetricGroup());
         StateChangelogStorage<?> storage2 =
-                manager.stateChangelogStorageForJob(jobId1, configuration);
+                manager.stateChangelogStorageForJob(
+                        jobId1, configuration, createUnregisteredTaskManagerJobMetricGroup());
         Assert.assertEquals(storage1, storage2);
 
         JobID jobId2 = new JobID(1L, 2L);
         StateChangelogStorage<?> storage3 =
-                manager.stateChangelogStorageForJob(jobId2, configuration);
+                manager.stateChangelogStorageForJob(
+                        jobId2, configuration, createUnregisteredTaskManagerJobMetricGroup());
         Assert.assertNotEquals(storage1, storage3);
         manager.shutdown();
     }
@@ -71,14 +76,16 @@ public class TaskExecutorStateChangelogStoragesManagerTest {
                 TestStateChangelogStorageFactory.identifier);
         JobID jobId1 = new JobID(1L, 1L);
         StateChangelogStorage<?> storage1 =
-                manager.stateChangelogStorageForJob(jobId1, configuration);
+                manager.stateChangelogStorageForJob(
+                        jobId1, configuration, createUnregisteredTaskManagerJobMetricGroup());
         Assert.assertTrue(storage1 instanceof TestStateChangelogStorage);
         Assert.assertFalse(((TestStateChangelogStorage) storage1).closed);
         manager.releaseStateChangelogStorageForJob(jobId1);
         Assert.assertTrue(((TestStateChangelogStorage) storage1).closed);
 
         StateChangelogStorage<?> storage2 =
-                manager.stateChangelogStorageForJob(jobId1, configuration);
+                manager.stateChangelogStorageForJob(
+                        jobId1, configuration, createUnregisteredTaskManagerJobMetricGroup());
         Assert.assertNotEquals(storage1, storage2);
 
         manager.shutdown();
@@ -94,7 +101,8 @@ public class TaskExecutorStateChangelogStoragesManagerTest {
 
         JobID jobId1 = new JobID(1L, 1L);
         StateChangelogStorage<?> storage1 =
-                manager.stateChangelogStorageForJob(jobId1, configuration);
+                manager.stateChangelogStorageForJob(
+                        jobId1, configuration, createUnregisteredTaskManagerJobMetricGroup());
         Assert.assertNull(storage1);
 
         // change configuration, assert the result not change.
@@ -102,17 +110,20 @@ public class TaskExecutorStateChangelogStoragesManagerTest {
                 StateChangelogOptions.STATE_CHANGE_LOG_STORAGE,
                 StateChangelogOptions.STATE_CHANGE_LOG_STORAGE.defaultValue());
         StateChangelogStorage<?> storage2 =
-                manager.stateChangelogStorageForJob(jobId1, configuration);
+                manager.stateChangelogStorageForJob(
+                        jobId1, configuration, createUnregisteredTaskManagerJobMetricGroup());
         Assert.assertNull(storage2);
 
         JobID jobId2 = new JobID(1L, 2L);
         StateChangelogStorage<?> storage3 =
-                manager.stateChangelogStorageForJob(jobId2, configuration);
+                manager.stateChangelogStorageForJob(
+                        jobId2, configuration, createUnregisteredTaskManagerJobMetricGroup());
         Assert.assertNotNull(storage3);
 
         configuration.set(StateChangelogOptions.STATE_CHANGE_LOG_STORAGE, "invalid");
         StateChangelogStorage<?> storage4 =
-                manager.stateChangelogStorageForJob(jobId2, configuration);
+                manager.stateChangelogStorageForJob(
+                        jobId2, configuration, createUnregisteredTaskManagerJobMetricGroup());
         Assert.assertNotNull(storage4);
         Assert.assertEquals(storage3, storage4);
 
@@ -130,13 +141,15 @@ public class TaskExecutorStateChangelogStoragesManagerTest {
                 TestStateChangelogStorageFactory.identifier);
         JobID jobId1 = new JobID(1L, 1L);
         StateChangelogStorage<?> storage1 =
-                manager.stateChangelogStorageForJob(jobId1, configuration);
+                manager.stateChangelogStorageForJob(
+                        jobId1, configuration, createUnregisteredTaskManagerJobMetricGroup());
         Assert.assertTrue(storage1 instanceof TestStateChangelogStorage);
         Assert.assertFalse(((TestStateChangelogStorage) storage1).closed);
 
         JobID jobId2 = new JobID(1L, 2L);
         StateChangelogStorage<?> storage2 =
-                manager.stateChangelogStorageForJob(jobId1, configuration);
+                manager.stateChangelogStorageForJob(
+                        jobId1, configuration, createUnregisteredTaskManagerJobMetricGroup());
         Assert.assertTrue(storage2 instanceof TestStateChangelogStorage);
         Assert.assertFalse(((TestStateChangelogStorage) storage2).closed);
 
@@ -191,7 +204,8 @@ public class TaskExecutorStateChangelogStoragesManagerTest {
         }
 
         @Override
-        public StateChangelogStorage<?> createStorage(Configuration configuration) {
+        public StateChangelogStorage<?> createStorage(
+                Configuration configuration, TaskManagerJobMetricGroup metricGroup) {
             return new TestStateChangelogStorage();
         }
     }

--- a/flink-runtime/src/test/java/org/apache/flink/runtime/state/changelog/inmemory/StateChangelogStorageLoaderTest.java
+++ b/flink-runtime/src/test/java/org/apache/flink/runtime/state/changelog/inmemory/StateChangelogStorageLoaderTest.java
@@ -20,6 +20,7 @@ package org.apache.flink.runtime.state.changelog.inmemory;
 import org.apache.flink.configuration.Configuration;
 import org.apache.flink.configuration.StateChangelogOptions;
 import org.apache.flink.core.plugin.PluginManager;
+import org.apache.flink.runtime.metrics.groups.TaskManagerJobMetricGroup;
 import org.apache.flink.runtime.state.KeyGroupRange;
 import org.apache.flink.runtime.state.changelog.ChangelogStateHandle;
 import org.apache.flink.runtime.state.changelog.StateChangelogHandleReader;
@@ -35,6 +36,7 @@ import java.util.Iterator;
 
 import static java.util.Collections.emptyIterator;
 import static java.util.Collections.singletonList;
+import static org.apache.flink.runtime.metrics.groups.UnregisteredMetricGroups.createUnregisteredTaskManagerJobMetricGroup;
 import static org.apache.flink.util.Preconditions.checkArgument;
 import static org.junit.Assert.assertNotNull;
 import static org.junit.Assert.assertNull;
@@ -46,7 +48,9 @@ public class StateChangelogStorageLoaderTest {
     @Test
     public void testLoadSpiImplementation() throws IOException {
         StateChangelogStorageLoader.initialize(getPluginManager(emptyIterator()));
-        assertNotNull(StateChangelogStorageLoader.load(new Configuration()));
+        assertNotNull(
+                StateChangelogStorageLoader.load(
+                        new Configuration(), createUnregisteredTaskManagerJobMetricGroup()));
     }
 
     @Test
@@ -55,7 +59,8 @@ public class StateChangelogStorageLoaderTest {
         assertNull(
                 StateChangelogStorageLoader.load(
                         new Configuration()
-                                .set(StateChangelogOptions.STATE_CHANGE_LOG_STORAGE, "not_exist")));
+                                .set(StateChangelogOptions.STATE_CHANGE_LOG_STORAGE, "not_exist"),
+                        createUnregisteredTaskManagerJobMetricGroup()));
     }
 
     @Test
@@ -64,7 +69,9 @@ public class StateChangelogStorageLoaderTest {
         StateChangelogStorageFactory factory = new TestStateChangelogStorageFactory();
         PluginManager pluginManager = getPluginManager(singletonList(factory).iterator());
         StateChangelogStorageLoader.initialize(pluginManager);
-        StateChangelogStorage loaded = StateChangelogStorageLoader.load(new Configuration());
+        StateChangelogStorage loaded =
+                StateChangelogStorageLoader.load(
+                        new Configuration(), createUnregisteredTaskManagerJobMetricGroup());
         assertTrue(loaded instanceof TestStateChangelogStorage);
     }
 
@@ -104,7 +111,8 @@ public class StateChangelogStorageLoaderTest {
         }
 
         @Override
-        public StateChangelogStorage<?> createStorage(Configuration configuration) {
+        public StateChangelogStorage<?> createStorage(
+                Configuration configuration, TaskManagerJobMetricGroup metricGroup) {
             return new TestStateChangelogStorage();
         }
     }

--- a/flink-state-backends/flink-statebackend-changelog/src/test/java/org/apache/flink/state/changelog/ChangelogStateBackendTestUtils.java
+++ b/flink-state-backends/flink-statebackend-changelog/src/test/java/org/apache/flink/state/changelog/ChangelogStateBackendTestUtils.java
@@ -26,12 +26,14 @@ import org.apache.flink.api.common.typeinfo.TypeInformation;
 import org.apache.flink.api.common.typeutils.TypeSerializer;
 import org.apache.flink.api.common.typeutils.base.IntSerializer;
 import org.apache.flink.api.java.typeutils.GenericTypeInfo;
+import org.apache.flink.changelog.fs.ChangelogStorageMetricGroup;
 import org.apache.flink.changelog.fs.FsStateChangelogStorage;
 import org.apache.flink.core.fs.CloseableRegistry;
 import org.apache.flink.core.fs.Path;
 import org.apache.flink.metrics.groups.UnregisteredMetricsGroup;
 import org.apache.flink.runtime.checkpoint.CheckpointOptions;
 import org.apache.flink.runtime.execution.Environment;
+import org.apache.flink.runtime.metrics.groups.UnregisteredMetricGroups;
 import org.apache.flink.runtime.state.CheckpointStorageAccess;
 import org.apache.flink.runtime.state.CheckpointStorageLocation;
 import org.apache.flink.runtime.state.CheckpointStorageLocationReference;
@@ -117,7 +119,12 @@ public class ChangelogStateBackendTestUtils {
         return TestTaskStateManager.builder()
                 .setStateChangelogStorage(
                         new FsStateChangelogStorage(
-                                Path.fromLocalFile(changelogStoragePath), false, 1024))
+                                Path.fromLocalFile(changelogStoragePath),
+                                false,
+                                1024,
+                                new ChangelogStorageMetricGroup(
+                                        UnregisteredMetricGroups
+                                                .createUnregisteredTaskManagerJobMetricGroup())))
                 .build();
     }
 


### PR DESCRIPTION
## What is the purpose of the change

Add metrics for Changelog uploader.

`BatchingStateChangeUploader`:
- Queue size (num requests)
- Logs per upload
- Attempts per upload

`StateChangeFsUploader`:
- Errors count
- Requests count
- Requests size
- Requests latency

These components are shared across tasks on TM (per job).

See [design doc](https://docs.google.com/document/d/1k5WkWIYzs3n3GYQC76H9BLGxvN3wuq7qUHJuBPR9YX0/edit?usp=sharing).

## Verifying this change

Added `ChangelogStorageMetricsTest`

## Does this pull request potentially affect one of the following parts:

  - Dependencies (does it add or upgrade a dependency): no
  - The public API, i.e., is any changed class annotated with `@Public(Evolving)`: no
  - The serializers: no
  - The runtime per-record code paths (performance sensitive): no
  - Anything that affects deployment or recovery: JobManager (and its components), Checkpointing, Kubernetes/Yarn/Mesos, ZooKeeper: no
  - The S3 file system connector: no

## Documentation

  - Does this pull request introduce a new feature? no
  - If yes, how is the feature documented? no
