### PR TITLE
[FLINK-24113] Add configuration option to disable automatic shutdown in application mode

### DIFF
--- a/docs/layouts/shortcodes/generated/deployment_configuration.html
+++ b/docs/layouts/shortcodes/generated/deployment_configuration.html
@@ -21,6 +21,12 @@
             <td>Custom JobListeners to be registered with the execution environment. The registered listeners cannot have constructors with arguments.</td>
         </tr>
         <tr>
+            <td><h5>execution.shutdown-on-application-finish</h5></td>
+            <td style="word-wrap: break-word;">true</td>
+            <td>Boolean</td>
+            <td>Whether a Flink Application cluster should shut down automatically after its application finishes (either successfully or as result of a failure). Has no effect for other deployment modes.</td>
+        </tr>
+        <tr>
             <td><h5>execution.shutdown-on-attached-exit</h5></td>
             <td style="word-wrap: break-word;">false</td>
             <td>Boolean</td>

--- a/flink-clients/src/test/java/org/apache/flink/client/deployment/application/ApplicationDispatcherBootstrapTest.java
+++ b/flink-clients/src/test/java/org/apache/flink/client/deployment/application/ApplicationDispatcherBootstrapTest.java
@@ -151,18 +151,12 @@ public class ApplicationDispatcherBootstrapTest extends TestLogger {
         final CompletableFuture<JobID> submittedJobId = new CompletableFuture<>();
 
         final TestingDispatcherGateway.Builder dispatcherBuilder =
-                new TestingDispatcherGateway.Builder()
+                finishedJobGatewayBuilder()
                         .setSubmitFunction(
                                 jobGraph -> {
                                     submittedJobId.complete(jobGraph.getJobID());
                                     return CompletableFuture.completedFuture(Acknowledge.get());
-                                })
-                        .setRequestJobStatusFunction(
-                                jobId -> CompletableFuture.completedFuture(JobStatus.FINISHED))
-                        .setRequestJobResultFunction(
-                                jobId ->
-                                        CompletableFuture.completedFuture(
-                                                createSuccessfulJobResult(jobId)));
+                                });
 
         final CompletableFuture<Void> applicationFuture =
                 runApplication(dispatcherBuilder, configurationUnderTest, 1);
@@ -183,18 +177,12 @@ public class ApplicationDispatcherBootstrapTest extends TestLogger {
         final CompletableFuture<JobID> submittedJobId = new CompletableFuture<>();
 
         final TestingDispatcherGateway.Builder dispatcherBuilder =
-                new TestingDispatcherGateway.Builder()
+                finishedJobGatewayBuilder()
                         .setSubmitFunction(
                                 jobGraph -> {
                                     submittedJobId.complete(jobGraph.getJobID());
                                     return CompletableFuture.completedFuture(Acknowledge.get());
-                                })
-                        .setRequestJobStatusFunction(
-                                jobId -> CompletableFuture.completedFuture(JobStatus.FINISHED))
-                        .setRequestJobResultFunction(
-                                jobId ->
-                                        CompletableFuture.completedFuture(
-                                                createSuccessfulJobResult(jobId)));
+                                });
 
         final CompletableFuture<Void> applicationFuture =
                 runApplication(dispatcherBuilder, configurationUnderTest, 1);
@@ -217,18 +205,12 @@ public class ApplicationDispatcherBootstrapTest extends TestLogger {
         final CompletableFuture<JobID> submittedJobId = new CompletableFuture<>();
 
         final TestingDispatcherGateway.Builder dispatcherBuilder =
-                new TestingDispatcherGateway.Builder()
+                finishedJobGatewayBuilder()
                         .setSubmitFunction(
                                 jobGraph -> {
                                     submittedJobId.complete(jobGraph.getJobID());
                                     return CompletableFuture.completedFuture(Acknowledge.get());
-                                })
-                        .setRequestJobStatusFunction(
-                                jobId -> CompletableFuture.completedFuture(JobStatus.FINISHED))
-                        .setRequestJobResultFunction(
-                                jobId ->
-                                        CompletableFuture.completedFuture(
-                                                createSuccessfulJobResult(jobId)));
+                                });
 
         final CompletableFuture<Void> applicationFuture =
                 runApplication(dispatcherBuilder, configurationUnderTest, 1);
@@ -282,16 +264,7 @@ public class ApplicationDispatcherBootstrapTest extends TestLogger {
 
     @Test
     public void testApplicationSucceedsWhenAllJobsSucceed() throws Exception {
-        final TestingDispatcherGateway.Builder dispatcherBuilder =
-                new TestingDispatcherGateway.Builder()
-                        .setSubmitFunction(
-                                jobGraph -> CompletableFuture.completedFuture(Acknowledge.get()))
-                        .setRequestJobStatusFunction(
-                                jobId -> CompletableFuture.completedFuture(JobStatus.FINISHED))
-                        .setRequestJobResultFunction(
-                                jobId ->
-                                        CompletableFuture.completedFuture(
-                                                createSuccessfulJobResult(jobId)));
+        final TestingDispatcherGateway.Builder dispatcherBuilder = finishedJobGatewayBuilder();
 
         final CompletableFuture<Void> applicationFuture = runApplication(dispatcherBuilder, 3);
 
@@ -305,20 +278,12 @@ public class ApplicationDispatcherBootstrapTest extends TestLogger {
                 new CompletableFuture<>();
 
         final TestingDispatcherGateway.Builder dispatcherBuilder =
-                new TestingDispatcherGateway.Builder()
-                        .setSubmitFunction(
-                                jobGraph -> CompletableFuture.completedFuture(Acknowledge.get()))
-                        .setRequestJobStatusFunction(
-                                jobId -> CompletableFuture.completedFuture(JobStatus.CANCELED))
+                canceledJobGatewayBuilder()
                         .setClusterShutdownFunction(
                                 (status) -> {
                                     clusterShutdownStatus.complete(status);
                                     return CompletableFuture.completedFuture(Acknowledge.get());
-                                })
-                        .setRequestJobResultFunction(
-                                jobId ->
-                                        CompletableFuture.completedFuture(
-                                                createCancelledJobResult(jobId)));
+                                });
 
         ApplicationDispatcherBootstrap bootstrap =
                 createApplicationDispatcherBootstrap(
@@ -338,16 +303,7 @@ public class ApplicationDispatcherBootstrapTest extends TestLogger {
 
     @Test
     public void testApplicationTaskFinishesWhenApplicationFinishes() throws Exception {
-        final TestingDispatcherGateway.Builder dispatcherBuilder =
-                new TestingDispatcherGateway.Builder()
-                        .setSubmitFunction(
-                                jobGraph -> CompletableFuture.completedFuture(Acknowledge.get()))
-                        .setRequestJobStatusFunction(
-                                jobId -> CompletableFuture.completedFuture(JobStatus.FINISHED))
-                        .setRequestJobResultFunction(
-                                jobId ->
-                                        CompletableFuture.completedFuture(
-                                                createSuccessfulJobResult(jobId)));
+        final TestingDispatcherGateway.Builder dispatcherBuilder = finishedJobGatewayBuilder();
 
         ApplicationDispatcherBootstrap bootstrap =
                 createApplicationDispatcherBootstrap(
@@ -367,12 +323,7 @@ public class ApplicationDispatcherBootstrapTest extends TestLogger {
 
     @Test
     public void testApplicationIsStoppedWhenStoppingBootstrap() throws Exception {
-        final TestingDispatcherGateway.Builder dispatcherBuilder =
-                new TestingDispatcherGateway.Builder()
-                        .setSubmitFunction(
-                                jobGraph -> CompletableFuture.completedFuture(Acknowledge.get()))
-                        .setRequestJobStatusFunction(
-                                jobId -> CompletableFuture.completedFuture(JobStatus.RUNNING));
+        final TestingDispatcherGateway.Builder dispatcherBuilder = runningJobGatewayBuilder();
 
         // we're "listening" on this to be completed to verify that the error handler is called.
         // In production, this will shut down the cluster with an exception.
@@ -403,12 +354,7 @@ public class ApplicationDispatcherBootstrapTest extends TestLogger {
 
     @Test
     public void testErrorHandlerIsCalledWhenStoppingBootstrap() throws Exception {
-        final TestingDispatcherGateway.Builder dispatcherBuilder =
-                new TestingDispatcherGateway.Builder()
-                        .setSubmitFunction(
-                                jobGraph -> CompletableFuture.completedFuture(Acknowledge.get()))
-                        .setRequestJobStatusFunction(
-                                jobId -> CompletableFuture.completedFuture(JobStatus.RUNNING));
+        final TestingDispatcherGateway.Builder dispatcherBuilder = runningJobGatewayBuilder();
 
         // we're "listening" on this to be completed to verify that the error handler is called.
         // In production, this will shut down the cluster with an exception.
@@ -472,15 +418,7 @@ public class ApplicationDispatcherBootstrapTest extends TestLogger {
         final CompletableFuture<ApplicationStatus> clusterShutdown = new CompletableFuture<>();
 
         final TestingDispatcherGateway dispatcherGateway =
-                new TestingDispatcherGateway.Builder()
-                        .setSubmitFunction(
-                                jobGraph -> CompletableFuture.completedFuture(Acknowledge.get()))
-                        .setRequestJobStatusFunction(
-                                jobId -> CompletableFuture.completedFuture(JobStatus.CANCELED))
-                        .setRequestJobResultFunction(
-                                jobId ->
-                                        CompletableFuture.completedFuture(
-                                                createCancelledJobResult(jobId)))
+                canceledJobGatewayBuilder()
                         .setClusterShutdownFunction(
                                 status -> {
                                     clusterShutdown.complete(status);
@@ -526,15 +464,7 @@ public class ApplicationDispatcherBootstrapTest extends TestLogger {
                 new CompletableFuture<>();
 
         final TestingDispatcherGateway.Builder dispatcherBuilder =
-                new TestingDispatcherGateway.Builder()
-                        .setSubmitFunction(
-                                jobGraph -> CompletableFuture.completedFuture(Acknowledge.get()))
-                        .setRequestJobStatusFunction(
-                                jobId -> CompletableFuture.completedFuture(JobStatus.FINISHED))
-                        .setRequestJobResultFunction(
-                                jobId ->
-                                        CompletableFuture.completedFuture(
-                                                createSuccessfulJobResult(jobId)))
+                finishedJobGatewayBuilder()
                         .setClusterShutdownFunction(
                                 (status) -> {
                                     externalShutdownFuture.complete(status);
@@ -565,15 +495,7 @@ public class ApplicationDispatcherBootstrapTest extends TestLogger {
                 new CompletableFuture<>();
 
         final TestingDispatcherGateway.Builder dispatcherBuilder =
-                new TestingDispatcherGateway.Builder()
-                        .setSubmitFunction(
-                                jobGraph -> CompletableFuture.completedFuture(Acknowledge.get()))
-                        .setRequestJobStatusFunction(
-                                jobId -> CompletableFuture.completedFuture(JobStatus.FAILED))
-                        .setRequestJobResultFunction(
-                                jobId ->
-                                        CompletableFuture.completedFuture(
-                                                createFailedJobResult(jobId)))
+                failedJobGatewayBuilder()
                         .setClusterShutdownFunction(
                                 (status) -> {
                                     externalShutdownFuture.complete(status);
@@ -604,15 +526,7 @@ public class ApplicationDispatcherBootstrapTest extends TestLogger {
                 new CompletableFuture<>();
 
         final TestingDispatcherGateway.Builder dispatcherBuilder =
-                new TestingDispatcherGateway.Builder()
-                        .setSubmitFunction(
-                                jobGraph -> CompletableFuture.completedFuture(Acknowledge.get()))
-                        .setRequestJobStatusFunction(
-                                jobId -> CompletableFuture.completedFuture(JobStatus.CANCELED))
-                        .setRequestJobResultFunction(
-                                jobId ->
-                                        CompletableFuture.completedFuture(
-                                                createCancelledJobResult(jobId)))
+                canceledJobGatewayBuilder()
                         .setClusterShutdownFunction(
                                 (status) -> {
                                     externalShutdownFuture.complete(status);
@@ -640,15 +554,11 @@ public class ApplicationDispatcherBootstrapTest extends TestLogger {
         // we're "listening" on this to be completed to verify that the cluster
         // is being shut down from the ApplicationDispatcherBootstrap
         final TestingDispatcherGateway.Builder dispatcherBuilder =
-                new TestingDispatcherGateway.Builder()
-                        .setSubmitFunction(
-                                jobGraph -> CompletableFuture.completedFuture(Acknowledge.get()))
-                        .setRequestJobStatusFunction(
-                                jobId -> CompletableFuture.completedFuture(JobStatus.FAILED))
+                canceledJobGatewayBuilder()
                         .setRequestJobResultFunction(
-                                jobId ->
+                                jobID ->
                                         CompletableFuture.completedFuture(
-                                                createUnknownJobResult(jobId)))
+                                                createUnknownJobResult(jobID)))
                         .setClusterShutdownFunction(
                                 status -> {
                                     fail("We should not call shutdownCluster()");
@@ -676,18 +586,12 @@ public class ApplicationDispatcherBootstrapTest extends TestLogger {
         configurationUnderTest.set(
                 HighAvailabilityOptions.HA_MODE, HighAvailabilityMode.ZOOKEEPER.name());
         final TestingDispatcherGateway.Builder dispatcherBuilder =
-                new TestingDispatcherGateway.Builder()
+                finishedJobGatewayBuilder()
                         .setSubmitFunction(
                                 jobGraph ->
                                         FutureUtils.completedExceptionally(
                                                 DuplicateJobSubmissionException
-                                                        .ofGloballyTerminated(testJobID)))
-                        .setRequestJobStatusFunction(
-                                jobId -> CompletableFuture.completedFuture(JobStatus.FINISHED))
-                        .setRequestJobResultFunction(
-                                jobId ->
-                                        CompletableFuture.completedFuture(
-                                                createSuccessfulJobResult(jobId)));
+                                                        .ofGloballyTerminated(testJobID)));
         final CompletableFuture<Void> applicationFuture =
                 runApplication(dispatcherBuilder, configurationUnderTest, 1);
         applicationFuture.get(TIMEOUT_SECONDS, TimeUnit.SECONDS);
@@ -798,18 +702,7 @@ public class ApplicationDispatcherBootstrapTest extends TestLogger {
         configurationUnderTest.set(DeploymentOptions.SHUTDOWN_ON_APPLICATION_FINISH, false);
 
         final TestingDispatcherGateway dispatcherGateway =
-                new TestingDispatcherGateway.Builder()
-                        .setSubmitFunction(
-                                jobGraph -> CompletableFuture.completedFuture(Acknowledge.get()))
-                        .setRequestJobStatusFunction(
-                                jobId -> CompletableFuture.completedFuture(jobStatus))
-                        .setRequestJobResultFunction(
-                                jobId ->
-                                        CompletableFuture.completedFuture(
-                                                createJobResult(
-                                                        jobId,
-                                                        ApplicationStatus.fromJobStatus(
-                                                                jobStatus))))
+                dispatcherGatewayBuilder(jobStatus)
                         .setClusterShutdownFunction(
                                 (status) -> {
                                     fail("Cluster shutdown should not be called");
@@ -825,6 +718,39 @@ public class ApplicationDispatcherBootstrapTest extends TestLogger {
         bootstrap.getBootstrapCompletionFuture().get(TIMEOUT_SECONDS, TimeUnit.SECONDS);
     }
 
+    private TestingDispatcherGateway.Builder finishedJobGatewayBuilder() {
+        return dispatcherGatewayBuilder(JobStatus.FINISHED);
+    }
+
+    private TestingDispatcherGateway.Builder failedJobGatewayBuilder() {
+        return dispatcherGatewayBuilder(JobStatus.FAILED);
+    }
+
+    private TestingDispatcherGateway.Builder canceledJobGatewayBuilder() {
+        return dispatcherGatewayBuilder(JobStatus.CANCELED);
+    }
+
+    private TestingDispatcherGateway.Builder runningJobGatewayBuilder() {
+        return dispatcherGatewayBuilder(JobStatus.RUNNING);
+    }
+
+    private TestingDispatcherGateway.Builder dispatcherGatewayBuilder(JobStatus jobStatus) {
+        TestingDispatcherGateway.Builder builder =
+                new TestingDispatcherGateway.Builder()
+                        .setSubmitFunction(
+                                jobGraph -> CompletableFuture.completedFuture(Acknowledge.get()))
+                        .setRequestJobStatusFunction(
+                                jobId -> CompletableFuture.completedFuture(jobStatus));
+        if (jobStatus != JobStatus.RUNNING) {
+            builder.setRequestJobResultFunction(
+                    jobID ->
+                            CompletableFuture.completedFuture(
+                                    createJobResult(
+                                            jobID, ApplicationStatus.fromJobStatus(jobStatus))));
+        }
+        return builder;
+    }
+
     private CompletableFuture<Void> runApplication(
             TestingDispatcherGateway.Builder dispatcherBuilder, int noOfJobs)
             throws FlinkException {
@@ -835,16 +761,7 @@ public class ApplicationDispatcherBootstrapTest extends TestLogger {
     private CompletableFuture<Void> runApplication(
             final Configuration configuration, final int noOfJobs) throws Throwable {
 
-        final TestingDispatcherGateway.Builder dispatcherBuilder =
-                new TestingDispatcherGateway.Builder()
-                        .setSubmitFunction(
-                                jobGraph -> CompletableFuture.completedFuture(Acknowledge.get()))
-                        .setRequestJobStatusFunction(
-                                jobId -> CompletableFuture.completedFuture(JobStatus.FINISHED))
-                        .setRequestJobResultFunction(
-                                jobId ->
-                                        CompletableFuture.completedFuture(
-                                                createSuccessfulJobResult(jobId)));
+        final TestingDispatcherGateway.Builder dispatcherBuilder = finishedJobGatewayBuilder();
 
         return runApplication(dispatcherBuilder, configuration, noOfJobs);
     }
@@ -930,20 +847,12 @@ public class ApplicationDispatcherBootstrapTest extends TestLogger {
         }
     }
 
-    private static JobResult createUnknownJobResult(final JobID jobId) {
-        return createJobResult(jobId, ApplicationStatus.UNKNOWN);
-    }
-
     private static JobResult createFailedJobResult(final JobID jobId) {
         return createJobResult(jobId, ApplicationStatus.FAILED);
     }
 
-    private static JobResult createSuccessfulJobResult(final JobID jobId) {
-        return createJobResult(jobId, ApplicationStatus.SUCCEEDED);
-    }
-
-    private static JobResult createCancelledJobResult(final JobID jobId) {
-        return createJobResult(jobId, ApplicationStatus.CANCELED);
+    private static JobResult createUnknownJobResult(final JobID jobId) {
+        return createJobResult(jobId, ApplicationStatus.UNKNOWN);
     }
 
     private static JobResult createJobResult(

--- a/flink-clients/src/test/java/org/apache/flink/client/deployment/application/ApplicationDispatcherBootstrapTest.java
+++ b/flink-clients/src/test/java/org/apache/flink/client/deployment/application/ApplicationDispatcherBootstrapTest.java
@@ -324,11 +324,12 @@ public class ApplicationDispatcherBootstrapTest extends TestLogger {
                 createApplicationDispatcherBootstrap(
                         3, dispatcherBuilder.build(), scheduledExecutor);
 
-        final CompletableFuture<Acknowledge> shutdownFuture = bootstrap.getClusterShutdownFuture();
+        final CompletableFuture<Acknowledge> completionFuture =
+                bootstrap.getBootstrapCompletionFuture();
 
         // wait until the bootstrap "thinks" it's done, also makes sure that we don't
         // fail the future exceptionally with a JobCancelledException
-        shutdownFuture.get(TIMEOUT_SECONDS, TimeUnit.SECONDS);
+        completionFuture.get(TIMEOUT_SECONDS, TimeUnit.SECONDS);
 
         assertThat(
                 clusterShutdownStatus.get(TIMEOUT_SECONDS, TimeUnit.SECONDS),
@@ -352,12 +353,13 @@ public class ApplicationDispatcherBootstrapTest extends TestLogger {
                 createApplicationDispatcherBootstrap(
                         3, dispatcherBuilder.build(), scheduledExecutor);
 
-        final CompletableFuture<Acknowledge> shutdownFuture = bootstrap.getClusterShutdownFuture();
+        final CompletableFuture<Acknowledge> completionFuture =
+                bootstrap.getBootstrapCompletionFuture();
 
         ScheduledFuture<?> applicationExecutionFuture = bootstrap.getApplicationExecutionFuture();
 
         // wait until the bootstrap "thinks" it's done
-        shutdownFuture.get(TIMEOUT_SECONDS, TimeUnit.SECONDS);
+        completionFuture.get(TIMEOUT_SECONDS, TimeUnit.SECONDS);
 
         // make sure the task finishes
         applicationExecutionFuture.get(TIMEOUT_SECONDS, TimeUnit.SECONDS);
@@ -382,7 +384,8 @@ public class ApplicationDispatcherBootstrapTest extends TestLogger {
                         scheduledExecutor,
                         errorHandlerFuture::completeExceptionally);
 
-        final CompletableFuture<Acknowledge> shutdownFuture = bootstrap.getClusterShutdownFuture();
+        final CompletableFuture<Acknowledge> completionFuture =
+                bootstrap.getBootstrapCompletionFuture();
 
         ScheduledFuture<?> applicationExecutionFuture = bootstrap.getApplicationExecutionFuture();
 
@@ -392,7 +395,7 @@ public class ApplicationDispatcherBootstrapTest extends TestLogger {
         assertException(errorHandlerFuture, CancellationException.class);
 
         // we return a future that is completed exceptionally
-        assertException(shutdownFuture, CancellationException.class);
+        assertException(completionFuture, CancellationException.class);
 
         // verify that the application task is being cancelled
         assertThat(applicationExecutionFuture.isCancelled(), is(true));
@@ -417,7 +420,8 @@ public class ApplicationDispatcherBootstrapTest extends TestLogger {
                         scheduledExecutor,
                         errorHandlerFuture::completeExceptionally);
 
-        final CompletableFuture<Acknowledge> shutdownFuture = bootstrap.getClusterShutdownFuture();
+        final CompletableFuture<Acknowledge> completionFuture =
+                bootstrap.getBootstrapCompletionFuture();
 
         bootstrap.stop();
 
@@ -425,7 +429,7 @@ public class ApplicationDispatcherBootstrapTest extends TestLogger {
         assertException(errorHandlerFuture, CancellationException.class);
 
         // we return a future that is completed exceptionally
-        assertException(shutdownFuture, CancellationException.class);
+        assertException(completionFuture, CancellationException.class);
     }
 
     @Test
@@ -453,13 +457,14 @@ public class ApplicationDispatcherBootstrapTest extends TestLogger {
                         scheduledExecutor,
                         errorHandlerFuture::completeExceptionally);
 
-        final CompletableFuture<Acknowledge> shutdownFuture = bootstrap.getClusterShutdownFuture();
+        final CompletableFuture<Acknowledge> completionFuture =
+                bootstrap.getBootstrapCompletionFuture();
 
         // we call the error handler
         assertException(errorHandlerFuture, ApplicationExecutionException.class);
 
         // we return a future that is completed exceptionally
-        assertException(shutdownFuture, ApplicationExecutionException.class);
+        assertException(completionFuture, ApplicationExecutionException.class);
     }
 
     @Test
@@ -540,10 +545,11 @@ public class ApplicationDispatcherBootstrapTest extends TestLogger {
                 createApplicationDispatcherBootstrap(
                         3, dispatcherBuilder.build(), scheduledExecutor);
 
-        final CompletableFuture<Acknowledge> shutdownFuture = bootstrap.getClusterShutdownFuture();
+        final CompletableFuture<Acknowledge> completionFuture =
+                bootstrap.getBootstrapCompletionFuture();
 
         // wait until the bootstrap "thinks" it's done
-        shutdownFuture.get(TIMEOUT_SECONDS, TimeUnit.SECONDS);
+        completionFuture.get(TIMEOUT_SECONDS, TimeUnit.SECONDS);
 
         // verify that the dispatcher is actually being shut down
         assertThat(
@@ -578,10 +584,11 @@ public class ApplicationDispatcherBootstrapTest extends TestLogger {
                 createApplicationDispatcherBootstrap(
                         3, dispatcherBuilder.build(), scheduledExecutor);
 
-        final CompletableFuture<Acknowledge> shutdownFuture = bootstrap.getClusterShutdownFuture();
+        final CompletableFuture<Acknowledge> completionFuture =
+                bootstrap.getBootstrapCompletionFuture();
 
         // wait until the bootstrap "thinks" it's done
-        shutdownFuture.get(TIMEOUT_SECONDS, TimeUnit.SECONDS);
+        completionFuture.get(TIMEOUT_SECONDS, TimeUnit.SECONDS);
 
         // verify that the dispatcher is actually being shut down
         assertThat(
@@ -616,10 +623,11 @@ public class ApplicationDispatcherBootstrapTest extends TestLogger {
                 createApplicationDispatcherBootstrap(
                         3, dispatcherBuilder.build(), scheduledExecutor);
 
-        final CompletableFuture<Acknowledge> shutdownFuture = bootstrap.getClusterShutdownFuture();
+        final CompletableFuture<Acknowledge> completionFuture =
+                bootstrap.getBootstrapCompletionFuture();
 
         // wait until the bootstrap "thinks" it's done
-        shutdownFuture.get(TIMEOUT_SECONDS, TimeUnit.SECONDS);
+        completionFuture.get(TIMEOUT_SECONDS, TimeUnit.SECONDS);
 
         // verify that the dispatcher is actually being shut down
         assertThat(
@@ -652,7 +660,7 @@ public class ApplicationDispatcherBootstrapTest extends TestLogger {
                 createApplicationDispatcherBootstrap(3, dispatcherGateway, scheduledExecutor);
 
         final CompletableFuture<Acknowledge> applicationFuture =
-                bootstrap.getClusterShutdownFuture();
+                bootstrap.getBootstrapCompletionFuture();
 
         final UnsuccessfulExecutionException exception =
                 assertException(applicationFuture, UnsuccessfulExecutionException.class);
@@ -814,7 +822,7 @@ public class ApplicationDispatcherBootstrapTest extends TestLogger {
                         configurationUnderTest, dispatcherGateway, scheduledExecutor);
 
         // Wait until bootstrap is finished to make sure cluster shutdown isn't called
-        bootstrap.getClusterShutdownFuture().get(TIMEOUT_SECONDS, TimeUnit.SECONDS);
+        bootstrap.getBootstrapCompletionFuture().get(TIMEOUT_SECONDS, TimeUnit.SECONDS);
     }
 
     private CompletableFuture<Void> runApplication(

--- a/flink-core/src/main/java/org/apache/flink/configuration/DeploymentOptions.java
+++ b/flink-core/src/main/java/org/apache/flink/configuration/DeploymentOptions.java
@@ -76,4 +76,12 @@ public class DeploymentOptions {
                     .withDescription(
                             "Custom JobListeners to be registered with the execution environment."
                                     + " The registered listeners cannot have constructors with arguments.");
+
+    public static final ConfigOption<Boolean> SHUTDOWN_ON_APPLICATION_FINISH =
+            ConfigOptions.key("execution.shutdown-on-application-finish")
+                    .booleanType()
+                    .defaultValue(true)
+                    .withDescription(
+                            "Whether a Flink Application cluster should shut down automatically after its application finishes"
+                                    + " (either successfully or as result of a failure). Has no effect for other deployment modes.");
 }


### PR DESCRIPTION
## What is the purpose of the change

*Add a configuration option that allows to keep the cluster running after the application finishes in application mode. The default value is set to false (meaning that the cluster will shut down), so current behavior is unaffected.*


## Brief change log

  - *Added config option execution.shutdown-on-application-finish*
  - *Refactored code in ApplicationDispatcherBootstrap and corresponding tests to make it easier to understand/modify and reduce duplication*


## Verifying this change

This change added tests and can be verified as follows:

  - *Added unit tests in ApplicationDispatcherBootstrapTest that verify cluster shutdown is not called if the configuration option is enabled*
  - *Can be tested manually by starting a job in application mode with the new config option enabled, then cancelling the job. The cluster and Web UI stay alive and can be terminated via a call to https://nightlies.apache.org/flink/flink-docs-master/docs/ops/rest_api/#cluster*

## Does this pull request potentially affect one of the following parts:

  - Dependencies (does it add or upgrade a dependency): no
  - The public API, i.e., is any changed class annotated with `@Public(Evolving)`: no
  - The serializers: no
  - The runtime per-record code paths (performance sensitive): no
  - Anything that affects deployment or recovery: JobManager (and its components), Checkpointing, Kubernetes/Yarn, ZooKeeper: no
  - The S3 file system connector: no

## Documentation

  - Does this pull request introduce a new feature? yes
  - If yes, how is the feature documented? only via config option description
