### PR TITLE
[FLINK-24784][runtime] Enable state.backend.latency-track.state-name-as-variable by default

### DIFF
--- a/docs/layouts/shortcodes/generated/state_backend_configuration.html
+++ b/docs/layouts/shortcodes/generated/state_backend_configuration.html
@@ -34,7 +34,7 @@
         </tr>
         <tr>
             <td><h5>state.backend.latency-track.state-name-as-variable</h5></td>
-            <td style="word-wrap: break-word;">false</td>
+            <td style="word-wrap: break-word;">true</td>
             <td>Boolean</td>
             <td>Whether to expose state name as a variable if tracking latency.</td>
         </tr>

--- a/docs/layouts/shortcodes/generated/state_backend_latency_tracking_section.html
+++ b/docs/layouts/shortcodes/generated/state_backend_latency_tracking_section.html
@@ -28,7 +28,7 @@
         </tr>
         <tr>
             <td><h5>state.backend.latency-track.state-name-as-variable</h5></td>
-            <td style="word-wrap: break-word;">false</td>
+            <td style="word-wrap: break-word;">true</td>
             <td>Boolean</td>
             <td>Whether to expose state name as a variable if tracking latency.</td>
         </tr>

--- a/flink-core/src/main/java/org/apache/flink/configuration/StateBackendOptions.java
+++ b/flink-core/src/main/java/org/apache/flink/configuration/StateBackendOptions.java
@@ -93,7 +93,7 @@ public class StateBackendOptions {
     public static final ConfigOption<Boolean> LATENCY_TRACK_STATE_NAME_AS_VARIABLE =
             ConfigOptions.key("state.backend.latency-track.state-name-as-variable")
                     .booleanType()
-                    .defaultValue(false)
+                    .defaultValue(true)
                     .withDescription(
                             "Whether to expose state name as a variable if tracking latency.");
 }

--- a/flink-runtime/src/test/java/org/apache/flink/runtime/state/metrics/LatencyTrackingStateConfigTest.java
+++ b/flink-runtime/src/test/java/org/apache/flink/runtime/state/metrics/LatencyTrackingStateConfigTest.java
@@ -50,6 +50,9 @@ public class LatencyTrackingStateConfigTest {
         Assert.assertEquals(
                 (long) StateBackendOptions.LATENCY_TRACK_HISTORY_SIZE.defaultValue(),
                 latencyTrackingStateConfig.getHistorySize());
+        Assert.assertEquals(
+                StateBackendOptions.LATENCY_TRACK_STATE_NAME_AS_VARIABLE.defaultValue(),
+                latencyTrackingStateConfig.isStateNameAsVariable());
     }
 
     @Test


### PR DESCRIPTION
## What is the purpose of the change

*Enabling the `state.backend.latency-track.state-name-as-variable` by default could help improve the usablility of state access latency.*

## Brief change log

  - *Update the default value of the `state.backend.latency-track.state-name-as-variable` option to true.*

## Verifying this change

  - *Update the `testDefaultEnabledLatencyTrackingStateConfig` test case in `LatencyTrackingStateConfigTest` to verify the default value of `state.backend.latency-track.state-name-as-variable` is true.*

## Does this pull request potentially affect one of the following parts:

  - Dependencies (does it add or upgrade a dependency): (yes / **no**)
  - The public API, i.e., is any changed class annotated with `@Public(Evolving)`: (yes / **no**)
  - The serializers: (yes / **no** / don't know)
  - The runtime per-record code paths (performance sensitive): (yes / **no** / don't know)
  - Anything that affects deployment or recovery: JobManager (and its components), Checkpointing, Kubernetes/Yarn, ZooKeeper: (yes / **no** / don't know)
  - The S3 file system connector: (yes / **no** / don't know)

## Documentation

  - Does this pull request introduce a new feature? (yes / **no**)
  - If yes, how is the feature documented? (**not applicable** / docs / JavaDocs / not documented)