### PR TITLE
[FLINK-24874][runtime-web] Fixes missing dropdown menu introduced in FLINK-21867

### DIFF
--- a/flink-runtime-web/web-dashboard/src/app/pages/job/exceptions/job-exceptions.component.html
+++ b/flink-runtime-web/web-dashboard/src/app/pages/job/exceptions/job-exceptions.component.html
@@ -45,7 +45,7 @@
             <td class="select-td">
               <nz-select class="exception-select" [nzDisabled]="item.exceptions.length == 1" nzShowSearch [(ngModel)]="item.selected">
                 <nz-option *ngFor="let ex of item.exceptions;" nzCustomContent [nzLabel]="ex.taskName" [nzValue]="ex">
-                  <span nz-tooltip [nzTitle]="ex.taskName" nzMouseEnterDelay="0.5" nzPlacement="left">{{ ex.taskName  }}</span>
+                  <span nz-tooltip nzTooltipTitle="ex.taskName" nzTooltipMouseEnterDelay="0.5" nzTooltipPlacement="left">{{ ex.taskName  }}</span>
                 </nz-option>
               </nz-select>
             </td>

--- a/flink-runtime-web/web-dashboard/src/app/pages/job/job.module.ts
+++ b/flink-runtime-web/web-dashboard/src/app/pages/job/job.module.ts
@@ -35,9 +35,12 @@ import { NzCardModule } from 'ng-zorro-antd/card';
 import { NzCollapseModule } from 'ng-zorro-antd/collapse';
 import { NzDividerModule } from 'ng-zorro-antd/divider';
 import { NzEmptyModule } from 'ng-zorro-antd/empty';
+import { NzIconModule } from 'ng-zorro-antd/icon';
+import { NzSelectModule } from 'ng-zorro-antd/select';
 import { NzSkeletonModule } from 'ng-zorro-antd/skeleton';
 import { NzTableModule } from 'ng-zorro-antd/table';
 import { NzTabsModule } from 'ng-zorro-antd/tabs';
+import { NzToolTipModule } from 'ng-zorro-antd/tooltip';
 import { NzPopconfirmModule } from 'ng-zorro-antd/popconfirm';
 
 @NgModule({
@@ -53,7 +56,10 @@ import { NzPopconfirmModule } from 'ng-zorro-antd/popconfirm';
     NzDividerModule,
     NzCollapseModule,
     NzEmptyModule,
+    NzIconModule,
+    NzSelectModule,
     NzSkeletonModule,
+    NzToolTipModule,
     NzAlertModule,
     NzPopconfirmModule
   ],


### PR DESCRIPTION
## What is the purpose of the change

The dropdown menu introduced by [FLINK-21867](https://issues.apache.org/jira/browse/FLINK-21867) was not visualized due to missing imports. This issue is not present on `master`. It got fixed already as part of [903185d72c](https://github.com/apache/flink/commit/903185d72c#diff-b076916fff7fedff49389f5a54ec236ef413a1a43bc6a7b95406266d9fb12fe7R31). I added missing Modules to the imports to fix that.

## Brief change log

* Adds tooltip, select and icon modules
* Updates the corresponding HTML code accordingly

## Verifying this change

This change was tested manually.

## Does this pull request potentially affect one of the following parts:

  - Dependencies (does it add or upgrade a dependency): no
  - The public API, i.e., is any changed class annotated with `@Public(Evolving)`: no
  - The serializers: no
  - The runtime per-record code paths (performance sensitive): no
  - Anything that affects deployment or recovery: JobManager (and its components), Checkpointing, Kubernetes/Yarn, ZooKeeper: no
  - The S3 file system connector: no

## Documentation

  - Does this pull request introduce a new feature? no
  - If yes, how is the feature documented? not applicable
