### PR TITLE
[FLINK-24851][Connectors / Kafka] KafkaSourceBuilder: auto.offset.reset is ignored

### DIFF
--- a/flink-connectors/flink-connector-kafka/src/test/java/org/apache/flink/streaming/connectors/kafka/KafkaConsumerTestBase.java
+++ b/flink-connectors/flink-connector-kafka/src/test/java/org/apache/flink/streaming/connectors/kafka/KafkaConsumerTestBase.java
@@ -85,6 +85,7 @@ import org.apache.flink.shaded.guava30.com.google.common.collect.Iterables;
 import org.apache.commons.io.output.ByteArrayOutputStream;
 import org.apache.kafka.clients.consumer.ConsumerRecord;
 import org.apache.kafka.clients.consumer.OffsetResetStrategy;
+import org.apache.kafka.clients.producer.KafkaProducer;
 import org.apache.kafka.clients.producer.ProducerConfig;
 import org.apache.kafka.clients.producer.ProducerRecord;
 import org.apache.kafka.common.TopicPartition;
@@ -302,15 +303,11 @@ public abstract class KafkaConsumerTestBase extends KafkaTestBaseWithFlink {
         final int parallelism = 3;
         final int recordsInEachPartition = 50;
 
-        final String topicName =
-                writeSequence(
-                        "testAutoOffsetRetrievalAndCommitToKafkaTopic",
-                        recordsInEachPartition,
-                        parallelism,
-                        1);
+        final String topicName = "testAutoOffsetRetrievalAndCommitToKafkaTopic";
+
+        createTestTopic(topicName, parallelism, 1);
 
         final StreamExecutionEnvironment env = StreamExecutionEnvironment.getExecutionEnvironment();
-        env.getConfig().setRestartStrategy(RestartStrategies.noRestart());
         env.setParallelism(parallelism);
         env.enableCheckpointing(200);
 
@@ -338,6 +335,29 @@ public abstract class KafkaConsumerTestBase extends KafkaTestBaseWithFlink {
                     }
                 };
         runner.start();
+
+        int waitCount = 5;
+        while (getRunningJobs(client).isEmpty() && waitCount >= 0) {
+            Thread.sleep(1000L);
+            waitCount--;
+        }
+
+        Properties producerProperties =
+                FlinkKafkaProducerBase.getPropertiesFromBrokerList(brokerConnectionStrings);
+        producerProperties.setProperty("retries", "0");
+        producerProperties.setProperty(
+                "key.serializer", "org.apache.kafka.common.serialization.StringSerializer");
+        producerProperties.setProperty(
+                "value.serializer", "org.apache.kafka.common.serialization.StringSerializer");
+        producerProperties.putAll(secureProps);
+        KafkaProducer<String, String> kafkaProducer = new KafkaProducer<>(producerProperties);
+
+        for (int i = 0; i < parallelism; i++) {
+            for (int l = 0; l < recordsInEachPartition; l++) {
+                kafkaProducer.send(new ProducerRecord<>(topicName, i, "", String.valueOf(l)));
+            }
+        }
+        kafkaProducer.close();
 
         KafkaTestEnvironment.KafkaOffsetHandler kafkaOffsetHandler =
                 kafkaServer.createOffsetHandler();


### PR DESCRIPTION
<!--
*Thank you very much for contributing to Apache Flink - we are happy that you want to help us improve Flink. To help the community review your contribution in the best possible way, please go through the checklist below, which will get the contribution into a shape in which it can be best reviewed.*

*Please understand that we do not do this to make contributions to Flink a hassle. In order to uphold a high standard of quality for code contributions, while at the same time managing a large number of contributions, we need contributors to prepare the contributions well, and give reviewers enough contextual information for the review. Please also understand that contributions that do not follow this guide will take longer to review and thus typically be picked up with lower priority by the community.*

## Contribution Checklist

  - Make sure that the pull request corresponds to a [JIRA issue](https://issues.apache.org/jira/projects/FLINK/issues). Exceptions are made for typos in JavaDoc or documentation files, which need no JIRA issue.
  
  - Name the pull request in the form "[FLINK-XXXX] [component] Title of the pull request", where *FLINK-XXXX* should be replaced by the actual issue number. Skip *component* if you are unsure about which is the best component.
  Typo fixes that have no associated JIRA issue should be named following this pattern: `[hotfix] [docs] Fix typo in event time introduction` or `[hotfix] [javadocs] Expand JavaDoc for PuncuatedWatermarkGenerator`.

  - Fill out the template below to describe the changes contributed by the pull request. That will give reviewers the context they need to do the review.
  
  - Make sure that the change passes the automated tests, i.e., `mvn clean verify` passes. You can set up Azure Pipelines CI to do that following [this guide](https://cwiki.apache.org/confluence/display/FLINK/Azure+Pipelines#AzurePipelines-Tutorial:SettingupAzurePipelinesforaforkoftheFlinkrepository).

  - Each pull request should address only one issue, not mix up code from multiple issues.
  
  - Each commit in the pull request has a meaningful commit message (including the JIRA id)

  - Once all items of the checklist are addressed, remove the above text and this checklist, leaving only the filled out template below.


**(The sections below can be removed for hotfixes of typos)**
-->

## What is the purpose of the change

Creating KafkaSource like this:
```

val props = new Properties()
props.put("bootstrap.servers", "localhost:9092")
props.put("group.id", "group1")
props.put("auto.offset.reset", "latest")
val kafkaSource = KafkaSource.builder[String]()
      .setProperties(props)
      .build()
```
The actually used value for "auto.offset.reset" is "earliest" instead of configured "latest".
This occurs because "auto.offset.reset" gets overridden by startingOffsetsInitializer.getAutoOffsetResetStrategy().name().toLowerCase(). The default value for startingOffsetsInitializer is "earliest".

This behavior is misleading.

This behavior imposes an inconvenience on configuring the Kafka connector. We cannot use the Kafka setting "auto.offset.reset" as-is. Instead we must extract this particular setting from other settings and propagate to KafkaSourceBuilder.setStartingOffsets():

```
val kafkaSource = KafkaSource.builder[String]()
      .setProperties(props)
      .setStartingOffsets(
        OffsetsInitializer.committedOffsets(
          OffsetResetStrategy.valueOf(
            props.get(ConsumerConfig.AUTO_OFFSET_RESET_CONFIG)
              .asInstanceOf[String]
              .toUpperCase(Locale.ROOT)
          )
        )
      )
      .build()
```
The expected behavior is to use the value of "auto.offset.reset" provided by KafkaSourceBuilder.setProperties() - unless overridden via KafkaSourceBuilder. setStartingOffsets().

https://issues.apache.org/jira/browse/FLINK-24851

## Brief change log


## Verifying this change


## Does this pull request potentially affect one of the following parts:

  - Dependencies (does it add or upgrade a dependency): (yes / **no**)
  - The public API, i.e., is any changed class annotated with `@Public(Evolving)`: (yes / **no**)
  - The serializers: (yes / **no** / don't know)
  - The runtime per-record code paths (performance sensitive): (yes / **no** / don't know)
  - Anything that affects deployment or recovery: JobManager (and its components), Checkpointing, Kubernetes/Yarn, ZooKeeper: (yes / **no** / don't know)
  - The S3 file system connector: (yes / **no** / don't know)

## Documentation

  - Does this pull request introduce a new feature? (yes / **no**)
  - If yes, how is the feature documented? (not applicable / docs / JavaDocs / not documented)
