### PR TITLE
[hotfix][docs]Example Change the interval day precision limit

### DIFF
--- a/docs/content/docs/dev/table/types.md
+++ b/docs/content/docs/dev/table/types.md
@@ -1057,7 +1057,7 @@ DataTypes.INTERVAL(DataTypes.SECOND(p2))
 
 The type can be declared using the above combinations where `p1` is the number of digits of days
 (*day precision*) and `p2` is the number of digits of fractional seconds (*fractional precision*).
-`p1` must have a value between `1` and `6` (both inclusive). `p2` must have a value between `0`
+`p1` must have a value between `1` and `3` (both inclusive). `p2` must have a value between `0`
 and `9` (both inclusive). If no `p1` is specified, it is equal to `2` by default. If no `p2` is
 specified, it is equal to `6` by default.
 

--- a/flink-table/flink-table-planner/src/main/java/org/apache/flink/table/planner/operations/MergeTableLikeUtil.java
+++ b/flink-table/flink-table-planner/src/main/java/org/apache/flink/table/planner/operations/MergeTableLikeUtil.java
@@ -494,7 +494,12 @@ class MergeTableLikeUtil {
                     boolean nullable = type.getNullable() == null ? true : type.getNullable();
                     RelDataType relType = type.deriveType(sqlValidator, nullable);
                     // add field name and field type to physical field list
-                    physicalFieldNamesToTypes.put(name, relType);
+                    RelDataType oldType = physicalFieldNamesToTypes.put(name, relType);
+                    if (oldType != null) {
+                        throw new ValidationException(
+                                String.format( "A column named '%s' already exists in the physical field list.",
+                                        name));
+                    }
                 }
             }
         }


### PR DESCRIPTION
Flink uses the precision limit of interval day in the documentation to be 6, and the source code has a precision limit of 3 for DAY_INTERVAL_TYPES after reviewing the source code

## What is the purpose of the change

Flink uses a precision limit of 6 for interval day in the documentation, and a review of the source code shows a precision limit of 3 for DAY_INTERVAL_TYPES in FlinkTypeFactory


## Brief change log

  - Change p1 limit from 6 to 3


## Verifying this change

  - This change is a trivial rework / code cleanup without any test coverage.

## Does this pull request potentially affect one of the following parts:

  - Dependencies (does it add or upgrade a dependency): (no)
  - The public API, i.e., is any changed class annotated with `@Public(Evolving)`: (no)
  - The serializers: (no)
  - The runtime per-record code paths (performance sensitive): (no)
  - Anything that affects deployment or recovery: JobManager (and its components), Checkpointing, Kubernetes/Yarn, ZooKeeper: (no)
  - The S3 file system connector: (no)

## Documentation

  - Does this pull request introduce a new feature? (no)
  - If yes, how is the feature documented? (no)