### PR TITLE
[FLINK-20995][streaming] Refine java docs and exception message to state that result collecting is not supported when submitting jobs through web UI

### DIFF
--- a/flink-streaming-java/src/main/java/org/apache/flink/streaming/api/datastream/DataStream.java
+++ b/flink-streaming-java/src/main/java/org/apache/flink/streaming/api/datastream/DataStream.java
@@ -1272,6 +1272,9 @@ public class DataStream<T> {
      * thread through Flink's REST API.
      *
      * <p><b>IMPORTANT</b> The returned iterator must be closed to free all cluster resources.
+     *
+     * <p><b>NOTE</b> This method is not supported when submitting jobs through web UI as
+     * WebSubmissionJobClient cannot query for job results.
      */
     public CloseableIterator<T> executeAndCollect() throws Exception {
         return executeAndCollect("DataStream Collect");
@@ -1286,6 +1289,9 @@ public class DataStream<T> {
      * thread through Flink's REST API.
      *
      * <p><b>IMPORTANT</b> The returned iterator must be closed to free all cluster resources.
+     *
+     * <p><b>NOTE</b> This method is not supported when submitting jobs through web UI as
+     * WebSubmissionJobClient cannot query for job results.
      */
     public CloseableIterator<T> executeAndCollect(String jobExecutionName) throws Exception {
         return executeAndCollectWithClient(jobExecutionName).iterator;
@@ -1298,6 +1304,9 @@ public class DataStream<T> {
      * <p>The DataStream application is executed in the regular distributed manner on the target
      * environment, and the events from the stream are polled back to this application process and
      * thread through Flink's REST API.
+     *
+     * <p><b>NOTE</b> This method is not supported when submitting jobs through web UI as
+     * WebSubmissionJobClient cannot query for job results.
      */
     public List<T> executeAndCollect(int limit) throws Exception {
         return executeAndCollect("DataStream Collect", limit);
@@ -1310,6 +1319,9 @@ public class DataStream<T> {
      * <p>The DataStream application is executed in the regular distributed manner on the target
      * environment, and the events from the stream are polled back to this application process and
      * thread through Flink's REST API.
+     *
+     * <p><b>NOTE</b> This method is not supported when submitting jobs through web UI as *
+     * WebSubmissionJobClient cannot query for job results.
      */
     public List<T> executeAndCollect(String jobExecutionName, int limit) throws Exception {
         Preconditions.checkState(limit > 0, "Limit must be greater than 0");

--- a/flink-streaming-java/src/main/java/org/apache/flink/streaming/api/operators/collect/CollectResultFetcher.java
+++ b/flink-streaming-java/src/main/java/org/apache/flink/streaming/api/operators/collect/CollectResultFetcher.java
@@ -87,9 +87,12 @@ public class CollectResultFetcher<T> {
     }
 
     public void setJobClient(JobClient jobClient) {
-        Preconditions.checkArgument(
-                jobClient instanceof CoordinationRequestGateway,
-                "Job client must be a CoordinationRequestGateway. This is a bug.");
+        if (!(jobClient instanceof CoordinationRequestGateway)) {
+            throw new IllegalArgumentException(
+                    "Job client must be a CoordinationRequestGateway. "
+                            + "Result collecting is not supported when submitting job through web UI.\n"
+                            + "See also Java docs of DataStream#executeAndCollect or TableResult#collect.");
+        }
         this.jobClient = jobClient;
         this.gateway = (CoordinationRequestGateway) jobClient;
     }

--- a/flink-table/flink-table-api-java/src/main/java/org/apache/flink/table/api/TableResult.java
+++ b/flink-table/flink-table-api-java/src/main/java/org/apache/flink/table/api/TableResult.java
@@ -157,7 +157,8 @@ public interface TableResult {
      *   <li>For SELECT operation, the job will not be finished unless all result data has been
      *       collected. So we should actively close the job to avoid resource leak through
      *       CloseableIterator#close method. Calling CloseableIterator#close method will cancel the
-     *       job and release related resources.
+     *       job and release related resources. This method is not supported when submitting jobs
+     *       through web UI as WebSubmissionJobClient cannot query for job results.
      *   <li>For DML operation, Flink does not support getting the real affected row count now. So
      *       the affected row count is always -1 (unknown) for every sink, and them will be returned
      *       until the job is finished. Calling CloseableIterator#close method will cancel the job.


### PR DESCRIPTION
## What is the purpose of the change

Refine java docs and exception message to state that result collecting is not supported when submitting jobs through web UI.

## Verifying this change

This change is a trivial rework / code cleanup without any test coverage.

## Does this pull request potentially affect one of the following parts:

  - Dependencies (does it add or upgrade a dependency): no
  - The public API, i.e., is any changed class annotated with `@Public(Evolving)`: no
  - The serializers: no
  - The runtime per-record code paths (performance sensitive): no
  - Anything that affects deployment or recovery: JobManager (and its components), Checkpointing, Kubernetes/Yarn, ZooKeeper: no
  - The S3 file system connector: no

## Documentation

  - Does this pull request introduce a new feature? no
  - If yes, how is the feature documented? not applicable
