### PR TITLE
[FLINK-24611] Prevent JM from discarding state on checkpoint abortion

### DIFF
--- a/flink-runtime/src/main/java/org/apache/flink/runtime/checkpoint/CheckpointCoordinator.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/checkpoint/CheckpointCoordinator.java
@@ -42,7 +42,6 @@ import org.apache.flink.runtime.state.CheckpointStorage;
 import org.apache.flink.runtime.state.CheckpointStorageCoordinatorView;
 import org.apache.flink.runtime.state.CheckpointStorageLocation;
 import org.apache.flink.runtime.state.CompletedCheckpointStorageLocation;
-import org.apache.flink.runtime.state.SharedStateRegistry;
 import org.apache.flink.runtime.state.memory.ByteStreamStateHandle;
 import org.apache.flink.util.ExceptionUtils;
 import org.apache.flink.util.FlinkRuntimeException;
@@ -1084,6 +1083,21 @@ public class CheckpointCoordinator {
 
             final PendingCheckpoint checkpoint = pendingCheckpoints.get(checkpointId);
 
+            if (message.getSubtaskState() != null) {
+                // Register shared state regardless of checkpoint state and task ACK state.
+                // This way, shared state is
+                // 1. kept if the message is late or state will be used by the task otherwise
+                // 2. removed eventually upon checkpoint subsumption (or job cancellation)
+                // Do not register savepoints' shared state, as Flink is not in charge of
+                // savepoints' lifecycle
+                if (checkpoint == null || !checkpoint.getProps().isSavepoint()) {
+                    message.getSubtaskState()
+                            .registerSharedStates(
+                                    completedCheckpointStore.getSharedStateRegistry(),
+                                    checkpointId);
+                }
+            }
+
             if (checkpoint != null && !checkpoint.isDisposed()) {
 
                 switch (checkpoint.acknowledgeTask(
@@ -1205,13 +1219,6 @@ public class CheckpointCoordinator {
         final CompletedCheckpoint lastSubsumed;
         final CheckpointProperties props = pendingCheckpoint.getProps();
 
-        // As a first step to complete the checkpoint, we register its state with the registry
-        // we do not register savepoints' shared state, as Flink is not in charge of savepoints'
-        // lifecycle
-        if (!props.isSavepoint()) {
-            registerSharedStates(pendingCheckpoint);
-        }
-
         try {
             completedCheckpoint = finalizeCheckpoint(pendingCheckpoint);
 
@@ -1252,13 +1259,6 @@ public class CheckpointCoordinator {
                     completedCheckpoint.getTimestamp(),
                     extractIdIfDiscardedOnSubsumed(lastSubsumed));
         }
-    }
-
-    private void registerSharedStates(PendingCheckpoint pendingCheckpoint) {
-        Map<OperatorID, OperatorState> operatorStates = pendingCheckpoint.getOperatorStates();
-        SharedStateRegistry sharedStateRegistry = completedCheckpointStore.getSharedStateRegistry();
-        sharedStateRegistry.registerAll(
-                operatorStates.values(), pendingCheckpoint.getCheckpointID());
     }
 
     private void logCheckpointInfo(CompletedCheckpoint completedCheckpoint) {

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/checkpoint/CheckpointCoordinator.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/checkpoint/CheckpointCoordinator.java
@@ -1257,7 +1257,8 @@ public class CheckpointCoordinator {
     private void registerSharedStates(PendingCheckpoint pendingCheckpoint) {
         Map<OperatorID, OperatorState> operatorStates = pendingCheckpoint.getOperatorStates();
         SharedStateRegistry sharedStateRegistry = completedCheckpointStore.getSharedStateRegistry();
-        sharedStateRegistry.registerAll(operatorStates.values());
+        sharedStateRegistry.registerAll(
+                operatorStates.values(), pendingCheckpoint.getCheckpointID());
     }
 
     private void logCheckpointInfo(CompletedCheckpoint completedCheckpoint) {

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/checkpoint/CheckpointCoordinator.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/checkpoint/CheckpointCoordinator.java
@@ -1219,6 +1219,8 @@ public class CheckpointCoordinator {
         final CompletedCheckpoint lastSubsumed;
         final CheckpointProperties props = pendingCheckpoint.getProps();
 
+        completedCheckpointStore.getSharedStateRegistry().checkpointCompleted(checkpointId);
+
         try {
             completedCheckpoint = finalizeCheckpoint(pendingCheckpoint);
 

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/checkpoint/CompletedCheckpoint.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/checkpoint/CompletedCheckpoint.java
@@ -204,7 +204,7 @@ public class CompletedCheckpoint implements Serializable, Checkpoint {
      * @param sharedStateRegistry The registry where shared states are registered
      */
     public void registerSharedStatesAfterRestored(SharedStateRegistry sharedStateRegistry) {
-        sharedStateRegistry.registerAll(operatorStates.values());
+        sharedStateRegistry.registerAll(operatorStates.values(), checkpointID);
     }
 
     // ------------------------------------------------------------------------

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/checkpoint/DeactivatedCheckpointCompletedCheckpointStore.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/checkpoint/DeactivatedCheckpointCompletedCheckpointStore.java
@@ -24,7 +24,7 @@ import org.apache.flink.runtime.state.SharedStateRegistry;
 import java.util.List;
 
 /**
- * This class represents a {@link CompletedCheckpointStore} if checkpointing has been enabled.
+ * This class represents a {@link CompletedCheckpointStore} if checkpointing has been disabled.
  * Consequently, no component should use methods other than {@link
  * CompletedCheckpointStore#shutdown}.
  */

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/checkpoint/DefaultCompletedCheckpointStore.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/checkpoint/DefaultCompletedCheckpointStore.java
@@ -179,19 +179,32 @@ public class DefaultCompletedCheckpointStore<R extends ResourceVersion<R>>
         if (running.compareAndSet(true, false)) {
             if (jobStatus.isGloballyTerminalState()) {
                 LOG.info("Shutting down");
+                long lowestRetained = Long.MAX_VALUE;
                 for (CompletedCheckpoint checkpoint : completedCheckpoints) {
                     try {
-                        tryRemoveCompletedCheckpoint(
+                        if (!tryRemoveCompletedCheckpoint(
                                 checkpoint,
                                 checkpoint.shouldBeDiscardedOnShutdown(jobStatus),
                                 checkpointsCleaner,
-                                () -> {});
+                                () -> {})) {
+                            lowestRetained = Math.min(lowestRetained, checkpoint.getCheckpointID());
+                        }
                     } catch (Exception e) {
                         LOG.warn("Fail to remove checkpoint during shutdown.", e);
+                        if (!checkpoint.shouldBeDiscardedOnShutdown(jobStatus)) {
+                            lowestRetained = Math.min(lowestRetained, checkpoint.getCheckpointID());
+                        }
                     }
                 }
                 completedCheckpoints.clear();
                 checkpointStateHandleStore.clearEntries();
+                // Now discard the shared state of not subsumed checkpoints - only if:
+                // - the job is in a globally terminal state. Otherwise,
+                // it can be a suspension, after which this state might still be needed.
+                // - checkpoint is not retained (it might be used externally)
+                // - checkpoint handle removal succeeded (e.g. from ZK) - otherwise, it might still
+                // be used in recovery if the job status is lost
+                getSharedStateRegistry().unregisterUnusedState(lowestRetained);
             } else {
                 LOG.info("Suspending");
                 // Clear the local handles, but don't remove any state
@@ -205,7 +218,7 @@ public class DefaultCompletedCheckpointStore<R extends ResourceVersion<R>>
     // Private methods
     // ---------------------------------------------------------------------------------------------------------
 
-    private void tryRemoveCompletedCheckpoint(
+    private boolean tryRemoveCompletedCheckpoint(
             CompletedCheckpoint completedCheckpoint,
             boolean shouldDiscard,
             CheckpointsCleaner checkpointsCleaner,
@@ -214,7 +227,9 @@ public class DefaultCompletedCheckpointStore<R extends ResourceVersion<R>>
         if (tryRemove(completedCheckpoint.getCheckpointID())) {
             checkpointsCleaner.cleanCheckpoint(
                     completedCheckpoint, shouldDiscard, postCleanup, ioExecutor);
+            return shouldDiscard;
         }
+        return shouldDiscard;
     }
 
     /**

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/checkpoint/DefaultCompletedCheckpointStore.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/checkpoint/DefaultCompletedCheckpointStore.java
@@ -147,6 +147,7 @@ public class DefaultCompletedCheckpointStore<R extends ResourceVersion<R>>
                                         completedCheckpoint.shouldBeDiscardedOnSubsume(),
                                         checkpointsCleaner,
                                         postCleanup));
+        unregisterUnusedState(completedCheckpoints);
 
         if (subsume.isPresent()) {
             LOG.debug("Added {} to {} without any older checkpoint to subsume.", checkpoint, path);

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/checkpoint/EmbeddedCompletedCheckpointStore.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/checkpoint/EmbeddedCompletedCheckpointStore.java
@@ -86,15 +86,23 @@ public class EmbeddedCompletedCheckpointStore extends AbstractCompleteCheckpoint
         }
         checkpoints.addLast(checkpoint);
 
-        return CheckpointSubsumeHelper.subsume(
-                        checkpoints, maxRetainedCheckpoints, CompletedCheckpoint::discardOnSubsume)
-                .orElse(null);
+        CompletedCheckpoint completedCheckpoint =
+                CheckpointSubsumeHelper.subsume(
+                                checkpoints,
+                                maxRetainedCheckpoints,
+                                CompletedCheckpoint::discardOnSubsume)
+                        .orElse(null);
+
+        unregisterUnusedState(checkpoints);
+
+        return completedCheckpoint;
     }
 
     @VisibleForTesting
     void removeOldestCheckpoint() throws Exception {
         CompletedCheckpoint checkpointToSubsume = checkpoints.removeFirst();
         checkpointToSubsume.discardOnSubsume();
+        unregisterUnusedState(checkpoints);
     }
 
     @Override

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/checkpoint/OperatorState.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/checkpoint/OperatorState.java
@@ -171,9 +171,9 @@ public class OperatorState implements CompositeStateHandle {
     }
 
     @Override
-    public void registerSharedStates(SharedStateRegistry sharedStateRegistry) {
+    public void registerSharedStates(SharedStateRegistry sharedStateRegistry, long checkpointID) {
         for (OperatorSubtaskState operatorSubtaskState : operatorSubtaskStates.values()) {
-            operatorSubtaskState.registerSharedStates(sharedStateRegistry);
+            operatorSubtaskState.registerSharedStates(sharedStateRegistry, checkpointID);
         }
     }
 

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/checkpoint/OperatorSubtaskState.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/checkpoint/OperatorSubtaskState.java
@@ -205,16 +205,18 @@ public class OperatorSubtaskState implements CompositeStateHandle {
     }
 
     @Override
-    public void registerSharedStates(SharedStateRegistry sharedStateRegistry) {
-        registerSharedState(sharedStateRegistry, managedKeyedState);
-        registerSharedState(sharedStateRegistry, rawKeyedState);
+    public void registerSharedStates(SharedStateRegistry sharedStateRegistry, long checkpointID) {
+        registerSharedState(sharedStateRegistry, managedKeyedState, checkpointID);
+        registerSharedState(sharedStateRegistry, rawKeyedState, checkpointID);
     }
 
     private static void registerSharedState(
-            SharedStateRegistry sharedStateRegistry, Iterable<KeyedStateHandle> stateHandles) {
+            SharedStateRegistry sharedStateRegistry,
+            Iterable<KeyedStateHandle> stateHandles,
+            long checkpointID) {
         for (KeyedStateHandle stateHandle : stateHandles) {
             if (stateHandle != null) {
-                stateHandle.registerSharedStates(sharedStateRegistry);
+                stateHandle.registerSharedStates(sharedStateRegistry, checkpointID);
             }
         }
     }

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/checkpoint/StandaloneCompletedCheckpointStore.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/checkpoint/StandaloneCompletedCheckpointStore.java
@@ -97,11 +97,16 @@ public class StandaloneCompletedCheckpointStore extends AbstractCompleteCheckpoi
 
         checkpoints.addLast(checkpoint);
 
-        return CheckpointSubsumeHelper.subsume(
-                        checkpoints,
-                        maxNumberOfCheckpointsToRetain,
-                        CompletedCheckpoint::discardOnSubsume)
-                .orElse(null);
+        CompletedCheckpoint completedCheckpoint =
+                CheckpointSubsumeHelper.subsume(
+                                checkpoints,
+                                maxNumberOfCheckpointsToRetain,
+                                CompletedCheckpoint::discardOnSubsume)
+                        .orElse(null);
+
+        unregisterUnusedState(checkpoints);
+
+        return completedCheckpoint;
     }
 
     @Override

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/checkpoint/StandaloneCompletedCheckpointStore.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/checkpoint/StandaloneCompletedCheckpointStore.java
@@ -131,9 +131,22 @@ public class StandaloneCompletedCheckpointStore extends AbstractCompleteCheckpoi
         try {
             LOG.info("Shutting down");
 
+            long lowestRetained = Long.MAX_VALUE;
             for (CompletedCheckpoint checkpoint : checkpoints) {
-                checkpoint.discardOnShutdown(jobStatus);
+                if (!checkpoint.discardOnShutdown(jobStatus)) {
+                    lowestRetained = Math.min(checkpoint.getCheckpointID(), lowestRetained);
+                }
             }
+            if (jobStatus.isGloballyTerminalState()) {
+                // Now discard the shared state of not subsumed checkpoints - only if:
+                // - the job is in a globally terminal state. Otherwise,
+                // it can be a suspension, after which this state might still be needed.
+                // - checkpoint is not retained (it might be used externally)
+                // - checkpoint handle removal succeeded (e.g. from ZK) - otherwise, it might still
+                // be used in recovery if the job status is lost
+                getSharedStateRegistry().unregisterUnusedState(lowestRetained);
+            }
+
         } finally {
             checkpoints.clear();
         }

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/checkpoint/SubtaskState.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/checkpoint/SubtaskState.java
@@ -124,13 +124,13 @@ public class SubtaskState implements CompositeStateHandle {
     }
 
     @Override
-    public void registerSharedStates(SharedStateRegistry sharedStateRegistry) {
+    public void registerSharedStates(SharedStateRegistry sharedStateRegistry, long checkpointID) {
         if (managedKeyedState != null) {
-            managedKeyedState.registerSharedStates(sharedStateRegistry);
+            managedKeyedState.registerSharedStates(sharedStateRegistry, checkpointID);
         }
 
         if (rawKeyedState != null) {
-            rawKeyedState.registerSharedStates(sharedStateRegistry);
+            rawKeyedState.registerSharedStates(sharedStateRegistry, checkpointID);
         }
     }
 

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/checkpoint/TaskState.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/checkpoint/TaskState.java
@@ -136,9 +136,9 @@ public class TaskState implements CompositeStateHandle {
     }
 
     @Override
-    public void registerSharedStates(SharedStateRegistry sharedStateRegistry) {
+    public void registerSharedStates(SharedStateRegistry sharedStateRegistry, long checkpointID) {
         for (SubtaskState subtaskState : subtaskStates.values()) {
-            subtaskState.registerSharedStates(sharedStateRegistry);
+            subtaskState.registerSharedStates(sharedStateRegistry, checkpointID);
         }
     }
 

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/checkpoint/TaskStateSnapshot.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/checkpoint/TaskStateSnapshot.java
@@ -167,10 +167,10 @@ public class TaskStateSnapshot implements CompositeStateHandle {
     }
 
     @Override
-    public void registerSharedStates(SharedStateRegistry stateRegistry) {
+    public void registerSharedStates(SharedStateRegistry stateRegistry, long checkpointID) {
         for (OperatorSubtaskState operatorSubtaskState : subtaskStatesByOperatorID.values()) {
             if (operatorSubtaskState != null) {
-                operatorSubtaskState.registerSharedStates(stateRegistry);
+                operatorSubtaskState.registerSharedStates(stateRegistry, checkpointID);
             }
         }
     }

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/state/CompositeStateHandle.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/state/CompositeStateHandle.java
@@ -28,9 +28,9 @@ package org.apache.flink.runtime.state;
  * checkpoint is discarded.
  *
  * <p>The {@link SharedStateRegistry} is responsible for the discarding of registered shared states.
- * Before their first registration through {@link #registerSharedStates(SharedStateRegistry)}, newly
- * created shared state is still owned by this handle and considered as private state until it is
- * registered for the first time. Registration transfers ownership to the {@link
+ * Before their first registration through {@link #registerSharedStates(SharedStateRegistry, long)},
+ * newly created shared state is still owned by this handle and considered as private state until it
+ * is registered for the first time. Registration transfers ownership to the {@link
  * SharedStateRegistry}. The composite state handle should only delete all private states in the
  * {@link StateObject#discardState()} method, the {@link SharedStateRegistry} is responsible for
  * deleting shared states after they were registered.
@@ -49,5 +49,5 @@ public interface CompositeStateHandle extends StateObject {
      *
      * @param stateRegistry The registry where shared states are registered.
      */
-    void registerSharedStates(SharedStateRegistry stateRegistry);
+    void registerSharedStates(SharedStateRegistry stateRegistry, long checkpointID);
 }

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/state/DirectoryKeyedStateHandle.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/state/DirectoryKeyedStateHandle.java
@@ -71,7 +71,7 @@ public class DirectoryKeyedStateHandle implements KeyedStateHandle {
     }
 
     @Override
-    public void registerSharedStates(SharedStateRegistry stateRegistry) {
+    public void registerSharedStates(SharedStateRegistry stateRegistry, long checkpointID) {
         // Nothing to do, this is for local use only.
     }
 

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/state/IncrementalRemoteKeyedStateHandle.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/state/IncrementalRemoteKeyedStateHandle.java
@@ -216,7 +216,7 @@ public class IncrementalRemoteKeyedStateHandle implements IncrementalKeyedStateH
     }
 
     @Override
-    public void registerSharedStates(SharedStateRegistry stateRegistry) {
+    public void registerSharedStates(SharedStateRegistry stateRegistry, long checkpointID) {
 
         // This is a quick check to avoid that we register twice with the same registry. However,
         // the code allows to
@@ -245,7 +245,8 @@ public class IncrementalRemoteKeyedStateHandle implements IncrementalKeyedStateH
                     createSharedStateRegistryKeyFromFileName(sharedStateHandle.getKey());
 
             SharedStateRegistry.Result result =
-                    stateRegistry.registerReference(registryKey, sharedStateHandle.getValue());
+                    stateRegistry.registerReference(
+                            registryKey, sharedStateHandle.getValue(), checkpointID);
 
             // This step consolidates our shared handles with the registry, which does two things:
             //

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/state/KeyGroupsStateHandle.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/state/KeyGroupsStateHandle.java
@@ -92,7 +92,7 @@ public class KeyGroupsStateHandle implements StreamStateHandle, KeyedStateHandle
     }
 
     @Override
-    public void registerSharedStates(SharedStateRegistry stateRegistry) {
+    public void registerSharedStates(SharedStateRegistry stateRegistry, long checkpointID) {
         // No shared states
     }
 

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/state/SharedStateRegistry.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/state/SharedStateRegistry.java
@@ -37,7 +37,7 @@ public interface SharedStateRegistry extends AutoCloseable {
                 SharedStateRegistry sharedStateRegistry =
                         new SharedStateRegistryImpl(deleteExecutor);
                 for (CompletedCheckpoint checkpoint : checkpoints) {
-                    sharedStateRegistry.registerAll(checkpoint.getOperatorStates().values());
+                    checkpoint.registerSharedStatesAfterRestored(sharedStateRegistry);
                 }
                 return sharedStateRegistry;
             };
@@ -54,10 +54,12 @@ public interface SharedStateRegistry extends AutoCloseable {
      * to replace the one from the registration request.
      *
      * @param state the shared state for which we register a reference.
+     * @param checkpointID which uses the state
      * @return the result of this registration request, consisting of the state handle that is
      *     registered under the key by the end of the operation and its current reference count.
      */
-    Result registerReference(SharedStateRegistryKey registrationKey, StreamStateHandle state);
+    Result registerReference(
+            SharedStateRegistryKey registrationKey, StreamStateHandle state, long checkpointID);
 
     /**
      * Releases one reference to the given shared state in the registry. This decreases the
@@ -74,8 +76,9 @@ public interface SharedStateRegistry extends AutoCloseable {
      * Register given shared states in the registry.
      *
      * @param stateHandles The shared states to register.
+     * @param checkpointID which uses the states.
      */
-    void registerAll(Iterable<? extends CompositeStateHandle> stateHandles);
+    void registerAll(Iterable<? extends CompositeStateHandle> stateHandles, long checkpointID);
 
     /** An entry in the registry, tracking the handle and the corresponding reference count. */
     class SharedStateEntry {

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/state/SharedStateRegistry.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/state/SharedStateRegistry.java
@@ -70,4 +70,6 @@ public interface SharedStateRegistry extends AutoCloseable {
      * @param checkpointID which uses the states.
      */
     void registerAll(Iterable<? extends CompositeStateHandle> stateHandles, long checkpointID);
+
+    void checkpointCompleted(long checkpointId);
 }

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/state/SharedStateRegistry.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/state/SharedStateRegistry.java
@@ -20,59 +20,27 @@ package org.apache.flink.runtime.state;
 
 import org.apache.flink.runtime.checkpoint.CompletedCheckpoint;
 import org.apache.flink.util.Preconditions;
-import org.apache.flink.util.concurrent.Executors;
-
-import org.slf4j.Logger;
-import org.slf4j.LoggerFactory;
-
-import java.util.HashMap;
-import java.util.Map;
-import java.util.Objects;
-import java.util.concurrent.Executor;
-import java.util.concurrent.RejectedExecutionException;
 
 /**
  * This registry manages state that is shared across (incremental) checkpoints, and is responsible
  * for deleting shared state that is no longer used in any valid checkpoint.
  *
  * <p>A {@code SharedStateRegistry} will be deployed in the {@link
- * org.apache.flink.runtime.checkpoint.CheckpointCoordinator} to maintain the reference count of
- * {@link StreamStateHandle}s by a key that (logically) identifies them.
+ * org.apache.flink.runtime.checkpoint.CheckpointCoordinator CheckpointCoordinator} to keep track of
+ * usage of {@link StreamStateHandle}s by a key that (logically) identifies them.
  */
-public class SharedStateRegistry implements AutoCloseable {
-
-    private static final Logger LOG = LoggerFactory.getLogger(SharedStateRegistry.class);
+public interface SharedStateRegistry extends AutoCloseable {
 
     /** A singleton object for the default implementation of a {@link SharedStateRegistryFactory} */
-    public static final SharedStateRegistryFactory DEFAULT_FACTORY =
+    SharedStateRegistryFactory DEFAULT_FACTORY =
             (deleteExecutor, checkpoints) -> {
-                SharedStateRegistry sharedStateRegistry = new SharedStateRegistry(deleteExecutor);
+                SharedStateRegistry sharedStateRegistry =
+                        new SharedStateRegistryImpl(deleteExecutor);
                 for (CompletedCheckpoint checkpoint : checkpoints) {
                     sharedStateRegistry.registerAll(checkpoint.getOperatorStates().values());
                 }
                 return sharedStateRegistry;
             };
-
-    /** All registered state objects by an artificial key */
-    private final Map<SharedStateRegistryKey, SharedStateRegistry.SharedStateEntry>
-            registeredStates;
-
-    /** This flag indicates whether or not the registry is open or if close() was called */
-    private boolean open;
-
-    /** Executor for async state deletion */
-    private final Executor asyncDisposalExecutor;
-
-    /** Default uses direct executor to delete unreferenced state */
-    public SharedStateRegistry() {
-        this(Executors.directExecutor());
-    }
-
-    public SharedStateRegistry(Executor asyncDisposalExecutor) {
-        this.registeredStates = new HashMap<>();
-        this.asyncDisposalExecutor = Preconditions.checkNotNull(asyncDisposalExecutor);
-        this.open = true;
-    }
 
     /**
      * Register a reference to the given shared state in the registry. This does the following: We
@@ -89,50 +57,7 @@ public class SharedStateRegistry implements AutoCloseable {
      * @return the result of this registration request, consisting of the state handle that is
      *     registered under the key by the end of the operation and its current reference count.
      */
-    public Result registerReference(
-            SharedStateRegistryKey registrationKey, StreamStateHandle state) {
-
-        Preconditions.checkNotNull(state);
-
-        StreamStateHandle scheduledStateDeletion = null;
-        SharedStateRegistry.SharedStateEntry entry;
-
-        synchronized (registeredStates) {
-            Preconditions.checkState(
-                    open, "Attempt to register state to closed SharedStateRegistry.");
-
-            entry = registeredStates.get(registrationKey);
-
-            if (entry == null) {
-
-                // Additional check that should never fail, because only state handles that are not
-                // placeholders should
-                // ever be inserted to the registry.
-                Preconditions.checkState(
-                        !isPlaceholder(state),
-                        "Attempt to reference unknown state: " + registrationKey);
-
-                entry = new SharedStateRegistry.SharedStateEntry(state);
-                registeredStates.put(registrationKey, entry);
-            } else {
-                // delete if this is a real duplicate
-                if (!Objects.equals(state, entry.stateHandle)) {
-                    scheduledStateDeletion = state;
-                    LOG.trace(
-                            "Identified duplicate state registration under key {}. New state {} was determined to "
-                                    + "be an unnecessary copy of existing state {} and will be dropped.",
-                            registrationKey,
-                            state,
-                            entry.stateHandle);
-                }
-                entry.increaseReferenceCount();
-            }
-        }
-
-        scheduleAsyncDelete(scheduledStateDeletion);
-        LOG.trace("Registered shared state {} under key {}.", entry, registrationKey);
-        return new Result(entry);
-    }
+    Result registerReference(SharedStateRegistryKey registrationKey, StreamStateHandle state);
 
     /**
      * Releases one reference to the given shared state in the registry. This decreases the
@@ -143,126 +68,42 @@ public class SharedStateRegistry implements AutoCloseable {
      *     the state handle, or null if the state handle was deleted through this request. Returns
      *     null if the registry was previously closed.
      */
-    public Result unregisterReference(SharedStateRegistryKey registrationKey) {
-
-        Preconditions.checkNotNull(registrationKey);
-
-        final Result result;
-        final StreamStateHandle scheduledStateDeletion;
-        SharedStateRegistry.SharedStateEntry entry;
-
-        synchronized (registeredStates) {
-            entry = registeredStates.get(registrationKey);
-
-            Preconditions.checkState(
-                    entry != null,
-                    "Cannot unregister a state that is not registered: %s",
-                    registrationKey);
-
-            entry.decreaseReferenceCount();
-
-            // Remove the state from the registry when it's not referenced any more.
-            if (entry.getReferenceCount() <= 0) {
-                registeredStates.remove(registrationKey);
-                scheduledStateDeletion = entry.getStateHandle();
-                result = new Result(null, 0);
-            } else {
-                scheduledStateDeletion = null;
-                result = new Result(entry);
-            }
-        }
-
-        LOG.trace("Unregistered shared state {} under key {}.", entry, registrationKey);
-        scheduleAsyncDelete(scheduledStateDeletion);
-        return result;
-    }
+    SharedStateRegistry.Result unregisterReference(SharedStateRegistryKey registrationKey);
 
     /**
      * Register given shared states in the registry.
      *
      * @param stateHandles The shared states to register.
      */
-    public void registerAll(Iterable<? extends CompositeStateHandle> stateHandles) {
-
-        if (stateHandles == null) {
-            return;
-        }
-
-        synchronized (registeredStates) {
-            for (CompositeStateHandle stateHandle : stateHandles) {
-                stateHandle.registerSharedStates(this);
-            }
-        }
-    }
-
-    @Override
-    public String toString() {
-        synchronized (registeredStates) {
-            return "SharedStateRegistry{" + "registeredStates=" + registeredStates + '}';
-        }
-    }
-
-    private void scheduleAsyncDelete(StreamStateHandle streamStateHandle) {
-        // We do the small optimization to not issue discards for placeholders, which are NOPs.
-        if (streamStateHandle != null && !isPlaceholder(streamStateHandle)) {
-            LOG.trace("Scheduled delete of state handle {}.", streamStateHandle);
-            AsyncDisposalRunnable asyncDisposalRunnable =
-                    new AsyncDisposalRunnable(streamStateHandle);
-            try {
-                asyncDisposalExecutor.execute(asyncDisposalRunnable);
-            } catch (RejectedExecutionException ex) {
-                // TODO This is a temporary fix for a problem during
-                // ZooKeeperCompletedCheckpointStore#shutdown:
-                // Disposal is issued in another async thread and the shutdown proceeds to close the
-                // I/O Executor pool.
-                // This leads to RejectedExecutionException once the async deletes are triggered by
-                // ZK. We need to
-                // wait for all pending ZK deletes before closing the I/O Executor pool. We can
-                // simply call #run()
-                // because we are already in the async ZK thread that disposes the handles.
-                asyncDisposalRunnable.run();
-            }
-        }
-    }
-
-    private boolean isPlaceholder(StreamStateHandle stateHandle) {
-        return stateHandle instanceof PlaceholderStreamStateHandle;
-    }
-
-    @Override
-    public void close() {
-        synchronized (registeredStates) {
-            open = false;
-        }
-    }
+    void registerAll(Iterable<? extends CompositeStateHandle> stateHandles);
 
     /** An entry in the registry, tracking the handle and the corresponding reference count. */
-    private static class SharedStateEntry {
+    class SharedStateEntry {
 
         /** The shared state handle */
-        private final StreamStateHandle stateHandle;
+        public final StreamStateHandle stateHandle;
 
         /** The current reference count of the state handle */
         private int referenceCount;
 
-        SharedStateEntry(StreamStateHandle value) {
+        public SharedStateEntry(StreamStateHandle value) {
             this.stateHandle = value;
             this.referenceCount = 1;
         }
 
-        StreamStateHandle getStateHandle() {
+        public StreamStateHandle getStateHandle() {
             return stateHandle;
         }
 
-        int getReferenceCount() {
+        public int getReferenceCount() {
             return referenceCount;
         }
 
-        void increaseReferenceCount() {
+        public void increaseReferenceCount() {
             ++referenceCount;
         }
 
-        void decreaseReferenceCount() {
+        public void decreaseReferenceCount() {
             --referenceCount;
         }
 
@@ -278,7 +119,7 @@ public class SharedStateRegistry implements AutoCloseable {
     }
 
     /** The result of an attempt to (un)/reference state */
-    public static class Result {
+    class Result {
 
         /** The (un)registered state handle from the request */
         private final StreamStateHandle reference;
@@ -286,7 +127,7 @@ public class SharedStateRegistry implements AutoCloseable {
         /** The reference count to the state handle after the request to (un)register */
         private final int referenceCount;
 
-        private Result(SharedStateEntry sharedStateEntry) {
+        public Result(SharedStateEntry sharedStateEntry) {
             this.reference = sharedStateEntry.getStateHandle();
             this.referenceCount = sharedStateEntry.getReferenceCount();
         }
@@ -308,34 +149,7 @@ public class SharedStateRegistry implements AutoCloseable {
 
         @Override
         public String toString() {
-            return "Result{"
-                    + "reference="
-                    + reference
-                    + ", referenceCount="
-                    + referenceCount
-                    + '}';
-        }
-    }
-
-    /** Encapsulates the operation the delete state handles asynchronously. */
-    private static final class AsyncDisposalRunnable implements Runnable {
-
-        private final StateObject toDispose;
-
-        public AsyncDisposalRunnable(StateObject toDispose) {
-            this.toDispose = Preconditions.checkNotNull(toDispose);
-        }
-
-        @Override
-        public void run() {
-            try {
-                toDispose.discardState();
-            } catch (Exception e) {
-                LOG.warn(
-                        "A problem occurred during asynchronous disposal of a shared state object: {}",
-                        toDispose,
-                        e);
-            }
+            return "Result{" + "reference=" + reference + '}';
         }
     }
 }

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/state/SharedStateRegistryImpl.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/state/SharedStateRegistryImpl.java
@@ -1,0 +1,218 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.flink.runtime.state;
+
+import org.apache.flink.annotation.Internal;
+import org.apache.flink.util.concurrent.Executors;
+
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import java.util.HashMap;
+import java.util.Map;
+import java.util.Objects;
+import java.util.concurrent.Executor;
+import java.util.concurrent.RejectedExecutionException;
+
+import static org.apache.flink.util.Preconditions.checkNotNull;
+import static org.apache.flink.util.Preconditions.checkState;
+
+/** {@link SharedStateRegistry} implementation. */
+@Internal
+public class SharedStateRegistryImpl implements SharedStateRegistry {
+
+    private static final Logger LOG = LoggerFactory.getLogger(SharedStateRegistryImpl.class);
+
+    /** All registered state objects by an artificial key */
+    private final Map<SharedStateRegistryKey, SharedStateEntry> registeredStates;
+
+    /** This flag indicates whether or not the registry is open or if close() was called */
+    private boolean open;
+
+    /** Executor for async state deletion */
+    private final Executor asyncDisposalExecutor;
+
+    /** Default uses direct executor to delete unreferenced state */
+    public SharedStateRegistryImpl() {
+        this(Executors.directExecutor());
+    }
+
+    public SharedStateRegistryImpl(Executor asyncDisposalExecutor) {
+        this.registeredStates = new HashMap<>();
+        this.asyncDisposalExecutor = checkNotNull(asyncDisposalExecutor);
+        this.open = true;
+    }
+
+    @Override
+    public Result registerReference(
+            SharedStateRegistryKey registrationKey, StreamStateHandle state) {
+
+        checkNotNull(state);
+
+        StreamStateHandle scheduledStateDeletion = null;
+        SharedStateEntry entry;
+
+        synchronized (registeredStates) {
+            checkState(open, "Attempt to register state to closed SharedStateRegistry.");
+
+            entry = registeredStates.get(registrationKey);
+
+            if (entry == null) {
+                // Additional check that should never fail, because only state handles that are not
+                // placeholders should
+                // ever be inserted to the registry.
+                checkState(
+                        !isPlaceholder(state),
+                        "Attempt to reference unknown state: " + registrationKey);
+
+                entry = new SharedStateEntry(state);
+                registeredStates.put(registrationKey, entry);
+
+            } else {
+                // delete if this is a real duplicate
+                if (!Objects.equals(state, entry.stateHandle)) {
+                    scheduledStateDeletion = state;
+                    LOG.trace(
+                            "Identified duplicate state registration under key {}. New state {} was determined to "
+                                    + "be an unnecessary copy of existing state {} and will be dropped.",
+                            registrationKey,
+                            state,
+                            entry.stateHandle);
+                }
+                entry.increaseReferenceCount();
+            }
+        }
+
+        scheduleAsyncDelete(scheduledStateDeletion);
+        LOG.trace("Registered shared state {} under key {}.", entry, registrationKey);
+        return new Result(entry);
+    }
+
+    @Override
+    public Result unregisterReference(SharedStateRegistryKey registrationKey) {
+
+        checkNotNull(registrationKey);
+
+        final Result result;
+        final StreamStateHandle scheduledStateDeletion;
+        SharedStateEntry entry;
+
+        synchronized (registeredStates) {
+            entry = registeredStates.get(registrationKey);
+
+            checkState(
+                    entry != null,
+                    "Cannot unregister a state that is not registered: %s",
+                    registrationKey);
+
+            entry.decreaseReferenceCount();
+
+            // Remove the state from the registry when it's not referenced any more.
+            if (entry.getReferenceCount() <= 0) {
+                registeredStates.remove(registrationKey);
+                scheduledStateDeletion = entry.getStateHandle();
+                result = new Result(null, 0);
+            } else {
+                scheduledStateDeletion = null;
+                result = new Result(entry);
+            }
+        }
+
+        LOG.trace("Unregistered shared state {} under key {}.", entry, registrationKey);
+        scheduleAsyncDelete(scheduledStateDeletion);
+        return result;
+    }
+
+    @Override
+    public void registerAll(Iterable<? extends CompositeStateHandle> stateHandles) {
+
+        if (stateHandles == null) {
+            return;
+        }
+
+        synchronized (registeredStates) {
+            for (CompositeStateHandle stateHandle : stateHandles) {
+                stateHandle.registerSharedStates(this);
+            }
+        }
+    }
+
+    @Override
+    public String toString() {
+        synchronized (registeredStates) {
+            return "SharedStateRegistry{" + "registeredStates=" + registeredStates + '}';
+        }
+    }
+
+    private void scheduleAsyncDelete(StreamStateHandle streamStateHandle) {
+        // We do the small optimization to not issue discards for placeholders, which are NOPs.
+        if (streamStateHandle != null && !isPlaceholder(streamStateHandle)) {
+            LOG.trace("Scheduled delete of state handle {}.", streamStateHandle);
+            AsyncDisposalRunnable asyncDisposalRunnable =
+                    new AsyncDisposalRunnable(streamStateHandle);
+            try {
+                asyncDisposalExecutor.execute(asyncDisposalRunnable);
+            } catch (RejectedExecutionException ex) {
+                // TODO This is a temporary fix for a problem during
+                // ZooKeeperCompletedCheckpointStore#shutdown:
+                // Disposal is issued in another async thread and the shutdown proceeds to close the
+                // I/O Executor pool.
+                // This leads to RejectedExecutionException once the async deletes are triggered by
+                // ZK. We need to
+                // wait for all pending ZK deletes before closing the I/O Executor pool. We can
+                // simply call #run()
+                // because we are already in the async ZK thread that disposes the handles.
+                asyncDisposalRunnable.run();
+            }
+        }
+    }
+
+    private boolean isPlaceholder(StreamStateHandle stateHandle) {
+        return stateHandle instanceof PlaceholderStreamStateHandle;
+    }
+
+    @Override
+    public void close() {
+        synchronized (registeredStates) {
+            open = false;
+        }
+    }
+
+    /** Encapsulates the operation the delete state handles asynchronously. */
+    private static final class AsyncDisposalRunnable implements Runnable {
+
+        private final StateObject toDispose;
+
+        public AsyncDisposalRunnable(StateObject toDispose) {
+            this.toDispose = checkNotNull(toDispose);
+        }
+
+        @Override
+        public void run() {
+            try {
+                toDispose.discardState();
+            } catch (Exception e) {
+                LOG.warn(
+                        "A problem occurred during asynchronous disposal of a shared state object: {}",
+                        toDispose,
+                        e);
+            }
+        }
+    }
+}

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/state/SharedStateRegistryImpl.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/state/SharedStateRegistryImpl.java
@@ -61,7 +61,7 @@ public class SharedStateRegistryImpl implements SharedStateRegistry {
 
     @Override
     public Result registerReference(
-            SharedStateRegistryKey registrationKey, StreamStateHandle state) {
+            SharedStateRegistryKey registrationKey, StreamStateHandle state, long checkpointID) {
 
         checkNotNull(state);
 
@@ -140,7 +140,8 @@ public class SharedStateRegistryImpl implements SharedStateRegistry {
     }
 
     @Override
-    public void registerAll(Iterable<? extends CompositeStateHandle> stateHandles) {
+    public void registerAll(
+            Iterable<? extends CompositeStateHandle> stateHandles, long checkpointID) {
 
         if (stateHandles == null) {
             return;
@@ -148,7 +149,7 @@ public class SharedStateRegistryImpl implements SharedStateRegistry {
 
         synchronized (registeredStates) {
             for (CompositeStateHandle stateHandle : stateHandles) {
-                stateHandle.registerSharedStates(this);
+                stateHandle.registerSharedStates(this, checkpointID);
             }
         }
     }

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/state/SharedStateRegistryImpl.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/state/SharedStateRegistryImpl.java
@@ -85,6 +85,7 @@ public class SharedStateRegistryImpl implements SharedStateRegistry {
 
                 entry = new SharedStateEntry(state, checkpointID);
                 registeredStates.put(registrationKey, entry);
+                LOG.trace("Registered new shared state {} under key {}.", entry, registrationKey);
 
             } else {
                 // Delete if this is a real duplicate.
@@ -100,12 +101,16 @@ public class SharedStateRegistryImpl implements SharedStateRegistry {
                             state,
                             entry.stateHandle);
                 }
+                LOG.trace(
+                        "Updating last checkpoint for {} from {} to {}",
+                        registrationKey,
+                        entry.lastUsedCheckpointID,
+                        checkpointID);
                 entry.advanceLastUsingCheckpointID(checkpointID);
             }
         }
 
         scheduleAsyncDelete(scheduledStateDeletion);
-        LOG.trace("Registered shared state {} under key {}.", entry, registrationKey);
         return entry.stateHandle;
     }
 

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/state/changelog/ChangelogStateBackendHandle.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/state/changelog/ChangelogStateBackendHandle.java
@@ -65,9 +65,9 @@ public interface ChangelogStateBackendHandle extends KeyedStateHandle {
         }
 
         @Override
-        public void registerSharedStates(SharedStateRegistry stateRegistry) {
-            stateRegistry.registerAll(materialized);
-            stateRegistry.registerAll(nonMaterialized);
+        public void registerSharedStates(SharedStateRegistry stateRegistry, long checkpointID) {
+            stateRegistry.registerAll(materialized, checkpointID);
+            stateRegistry.registerAll(nonMaterialized, checkpointID);
         }
 
         @Override

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/state/changelog/ChangelogStateHandleStreamImpl.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/state/changelog/ChangelogStateHandleStreamImpl.java
@@ -31,6 +31,9 @@ import javax.annotation.Nullable;
 
 import java.util.Collections;
 import java.util.List;
+import java.util.stream.Collectors;
+
+import static org.apache.flink.runtime.state.StateUtil.bestEffortDiscardAllStateObjects;
 
 /** {@link ChangelogStateHandle} implementation based on {@link StreamStateHandle}. */
 @Internal
@@ -79,15 +82,11 @@ public final class ChangelogStateHandleStreamImpl implements ChangelogStateHandl
     }
 
     @Override
-    public void discardState() {
+    public void discardState() throws Exception {
+        // discard only on TM; on JM, shared state is removed on subsumption
         if (stateRegistry == null) {
-            // todo: discard private state (FLINK-23139)
-            // discarding the state here will fail some tests
-            // by invalidating checkpoints on abortion
-        } else {
-            handlesAndOffsets.forEach(
-                    handleAndOffset ->
-                            stateRegistry.unregisterReference(getKey(handleAndOffset.f0)));
+            bestEffortDiscardAllStateObjects(
+                    handlesAndOffsets.stream().map(t2 -> t2.f0).collect(Collectors.toList()));
         }
     }
 

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/state/changelog/ChangelogStateHandleStreamImpl.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/state/changelog/ChangelogStateHandleStreamImpl.java
@@ -55,12 +55,12 @@ public final class ChangelogStateHandleStreamImpl implements ChangelogStateHandl
     }
 
     @Override
-    public void registerSharedStates(SharedStateRegistry stateRegistry) {
+    public void registerSharedStates(SharedStateRegistry stateRegistry, long checkpointID) {
         this.stateRegistry = stateRegistry;
         handlesAndOffsets.forEach(
                 handleAndOffset ->
                         stateRegistry.registerReference(
-                                getKey(handleAndOffset.f0), handleAndOffset.f0));
+                                getKey(handleAndOffset.f0), handleAndOffset.f0, checkpointID));
     }
 
     @Override

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/state/changelog/inmemory/InMemoryChangelogStateHandle.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/state/changelog/inmemory/InMemoryChangelogStateHandle.java
@@ -83,7 +83,7 @@ public class InMemoryChangelogStateHandle implements ChangelogStateHandle {
     }
 
     @Override
-    public void registerSharedStates(SharedStateRegistry stateRegistry) {
+    public void registerSharedStates(SharedStateRegistry stateRegistry, long checkpointID) {
         // do nothing
     }
 

--- a/flink-runtime/src/test/java/org/apache/flink/runtime/checkpoint/CheckpointCoordinatorRestoringTest.java
+++ b/flink-runtime/src/test/java/org/apache/flink/runtime/checkpoint/CheckpointCoordinatorRestoringTest.java
@@ -86,6 +86,7 @@ import static org.junit.Assert.assertFalse;
 import static org.junit.Assert.assertTrue;
 import static org.junit.Assert.fail;
 import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.eq;
 import static org.mockito.Mockito.times;
 import static org.mockito.Mockito.verify;
 
@@ -259,7 +260,9 @@ public class CheckpointCoordinatorRestoringTest extends TestLogger {
             for (OperatorState taskState : completedCheckpoint.getOperatorStates().values()) {
                 for (OperatorSubtaskState subtaskState : taskState.getStates()) {
                     verify(subtaskState, times(2))
-                            .registerSharedStates(any(SharedStateRegistry.class));
+                            .registerSharedStates(
+                                    any(SharedStateRegistry.class),
+                                    eq(completedCheckpoint.getCheckpointID()));
                 }
             }
         }

--- a/flink-runtime/src/test/java/org/apache/flink/runtime/checkpoint/CompletedCheckpointStoreTest.java
+++ b/flink-runtime/src/test/java/org/apache/flink/runtime/checkpoint/CompletedCheckpointStoreTest.java
@@ -241,7 +241,7 @@ public abstract class CompletedCheckpointStoreTest extends TestLogger {
             operatorState.putState(i, subtaskState);
         }
 
-        operatorState.registerSharedStates(sharedStateRegistry);
+        operatorState.registerSharedStates(sharedStateRegistry, id);
 
         return new TestCompletedCheckpoint(new JobID(), id, 0, operatorGroupState, props);
     }
@@ -392,8 +392,9 @@ public abstract class CompletedCheckpointStoreTest extends TestLogger {
         }
 
         @Override
-        public void registerSharedStates(SharedStateRegistry sharedStateRegistry) {
-            super.registerSharedStates(sharedStateRegistry);
+        public void registerSharedStates(
+                SharedStateRegistry sharedStateRegistry, long checkpointID) {
+            super.registerSharedStates(sharedStateRegistry, checkpointID);
             Assert.assertFalse(discarded);
             registered = true;
         }

--- a/flink-runtime/src/test/java/org/apache/flink/runtime/checkpoint/CompletedCheckpointStoreTest.java
+++ b/flink-runtime/src/test/java/org/apache/flink/runtime/checkpoint/CompletedCheckpointStoreTest.java
@@ -22,6 +22,7 @@ import org.apache.flink.api.common.JobID;
 import org.apache.flink.api.common.JobStatus;
 import org.apache.flink.runtime.jobgraph.OperatorID;
 import org.apache.flink.runtime.state.SharedStateRegistry;
+import org.apache.flink.runtime.state.SharedStateRegistryImpl;
 import org.apache.flink.runtime.state.testutils.TestCompletedCheckpointStorageLocation;
 import org.apache.flink.util.TestLogger;
 import org.apache.flink.util.concurrent.Executors;
@@ -65,7 +66,7 @@ public abstract class CompletedCheckpointStoreTest extends TestLogger {
     /** Tests adding and getting a checkpoint. */
     @Test
     public void testAddAndGetLatestCheckpoint() throws Exception {
-        SharedStateRegistry sharedStateRegistry = new SharedStateRegistry();
+        SharedStateRegistry sharedStateRegistry = new SharedStateRegistryImpl();
         CompletedCheckpointStore checkpoints = createRecoveredCompletedCheckpointStore(4);
 
         // Empty state
@@ -96,7 +97,7 @@ public abstract class CompletedCheckpointStoreTest extends TestLogger {
      */
     @Test
     public void testAddCheckpointMoreThanMaxRetained() throws Exception {
-        SharedStateRegistry sharedStateRegistry = new SharedStateRegistry();
+        SharedStateRegistry sharedStateRegistry = new SharedStateRegistryImpl();
         CompletedCheckpointStore checkpoints = createRecoveredCompletedCheckpointStore(1);
 
         TestCompletedCheckpoint[] expected =
@@ -144,7 +145,7 @@ public abstract class CompletedCheckpointStoreTest extends TestLogger {
     /** Tests that all added checkpoints are returned. */
     @Test
     public void testGetAllCheckpoints() throws Exception {
-        SharedStateRegistry sharedStateRegistry = new SharedStateRegistry();
+        SharedStateRegistry sharedStateRegistry = new SharedStateRegistryImpl();
         CompletedCheckpointStore checkpoints = createRecoveredCompletedCheckpointStore(4);
 
         TestCompletedCheckpoint[] expected =
@@ -172,7 +173,7 @@ public abstract class CompletedCheckpointStoreTest extends TestLogger {
     /** Tests that all checkpoints are discarded (using the correct class loader). */
     @Test
     public void testDiscardAllCheckpoints() throws Exception {
-        SharedStateRegistry sharedStateRegistry = new SharedStateRegistry();
+        SharedStateRegistry sharedStateRegistry = new SharedStateRegistryImpl();
         CompletedCheckpointStore checkpoints = createRecoveredCompletedCheckpointStore(4);
 
         TestCompletedCheckpoint[] expected =
@@ -205,7 +206,7 @@ public abstract class CompletedCheckpointStoreTest extends TestLogger {
 
     @Test
     public void testAcquireLatestCompletedCheckpointId() throws Exception {
-        SharedStateRegistry sharedStateRegistry = new SharedStateRegistry();
+        SharedStateRegistry sharedStateRegistry = new SharedStateRegistryImpl();
         CompletedCheckpointStore checkpoints = createRecoveredCompletedCheckpointStore(1);
         assertEquals(0, checkpoints.getLatestCheckpointId());
 

--- a/flink-runtime/src/test/java/org/apache/flink/runtime/checkpoint/CompletedCheckpointStoreTest.java
+++ b/flink-runtime/src/test/java/org/apache/flink/runtime/checkpoint/CompletedCheckpointStoreTest.java
@@ -38,6 +38,7 @@ import java.util.concurrent.CountDownLatch;
 import java.util.concurrent.Executor;
 import java.util.concurrent.TimeUnit;
 
+import static org.apache.flink.runtime.checkpoint.CheckpointRetentionPolicy.NEVER_RETAIN_AFTER_TERMINATION;
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertNull;
 import static org.junit.Assert.assertTrue;
@@ -223,11 +224,16 @@ public abstract class CompletedCheckpointStoreTest extends TestLogger {
 
     public static TestCompletedCheckpoint createCheckpoint(
             long id, SharedStateRegistry sharedStateRegistry) {
+        return createCheckpoint(
+                id,
+                sharedStateRegistry,
+                CheckpointProperties.forCheckpoint(NEVER_RETAIN_AFTER_TERMINATION));
+    }
+
+    public static TestCompletedCheckpoint createCheckpoint(
+            long id, SharedStateRegistry sharedStateRegistry, CheckpointProperties props) {
 
         int numberOfStates = 4;
-        CheckpointProperties props =
-                CheckpointProperties.forCheckpoint(
-                        CheckpointRetentionPolicy.NEVER_RETAIN_AFTER_TERMINATION);
 
         OperatorID operatorID = new OperatorID();
 

--- a/flink-runtime/src/test/java/org/apache/flink/runtime/checkpoint/CompletedCheckpointTest.java
+++ b/flink-runtime/src/test/java/org/apache/flink/runtime/checkpoint/CompletedCheckpointTest.java
@@ -24,6 +24,7 @@ import org.apache.flink.core.testutils.CommonTestUtils;
 import org.apache.flink.runtime.jobgraph.JobVertexID;
 import org.apache.flink.runtime.jobgraph.OperatorID;
 import org.apache.flink.runtime.state.SharedStateRegistry;
+import org.apache.flink.runtime.state.SharedStateRegistryImpl;
 import org.apache.flink.runtime.state.testutils.EmptyStreamStateHandle;
 import org.apache.flink.runtime.state.testutils.TestCompletedCheckpointStorageLocation;
 
@@ -224,7 +225,7 @@ public class CompletedCheckpointTest {
                                 CheckpointRetentionPolicy.RETAIN_ON_FAILURE),
                         new TestCompletedCheckpointStorageLocation());
 
-        SharedStateRegistry sharedStateRegistry = new SharedStateRegistry();
+        SharedStateRegistry sharedStateRegistry = new SharedStateRegistryImpl();
         checkpoint.registerSharedStatesAfterRestored(sharedStateRegistry);
         verify(state, times(1)).registerSharedStates(sharedStateRegistry);
     }
@@ -255,7 +256,7 @@ public class CompletedCheckpointTest {
                         props,
                         location);
 
-        SharedStateRegistry sharedStateRegistry = new SharedStateRegistry();
+        SharedStateRegistry sharedStateRegistry = new SharedStateRegistryImpl();
         checkpoint.registerSharedStatesAfterRestored(sharedStateRegistry);
         verify(state, times(1)).registerSharedStates(sharedStateRegistry);
 

--- a/flink-runtime/src/test/java/org/apache/flink/runtime/checkpoint/CompletedCheckpointTest.java
+++ b/flink-runtime/src/test/java/org/apache/flink/runtime/checkpoint/CompletedCheckpointTest.java
@@ -227,7 +227,7 @@ public class CompletedCheckpointTest {
 
         SharedStateRegistry sharedStateRegistry = new SharedStateRegistryImpl();
         checkpoint.registerSharedStatesAfterRestored(sharedStateRegistry);
-        verify(state, times(1)).registerSharedStates(sharedStateRegistry);
+        verify(state, times(1)).registerSharedStates(sharedStateRegistry, 0L);
     }
 
     /** Tests that the garbage collection properties are respected when subsuming checkpoints. */
@@ -258,7 +258,7 @@ public class CompletedCheckpointTest {
 
         SharedStateRegistry sharedStateRegistry = new SharedStateRegistryImpl();
         checkpoint.registerSharedStatesAfterRestored(sharedStateRegistry);
-        verify(state, times(1)).registerSharedStates(sharedStateRegistry);
+        verify(state, times(1)).registerSharedStates(sharedStateRegistry, 0L);
 
         // Subsume
         checkpoint.discardOnSubsume();

--- a/flink-runtime/src/test/java/org/apache/flink/runtime/checkpoint/DefaultCompletedCheckpointStoreTest.java
+++ b/flink-runtime/src/test/java/org/apache/flink/runtime/checkpoint/DefaultCompletedCheckpointStoreTest.java
@@ -27,6 +27,7 @@ import org.apache.flink.runtime.persistence.TestingRetrievableStateStorageHelper
 import org.apache.flink.runtime.persistence.TestingStateHandleStore;
 import org.apache.flink.runtime.state.RetrievableStateHandle;
 import org.apache.flink.runtime.state.SharedStateRegistry;
+import org.apache.flink.runtime.state.SharedStateRegistryImpl;
 import org.apache.flink.runtime.state.testutils.TestCompletedCheckpointStorageLocation;
 import org.apache.flink.util.ExceptionUtils;
 import org.apache.flink.util.FlinkException;
@@ -200,7 +201,7 @@ public class DefaultCompletedCheckpointStoreTest extends TestLogger {
 
         final long ckpId = 100L;
         final CompletedCheckpoint ckp =
-                CompletedCheckpointStoreTest.createCheckpoint(ckpId, new SharedStateRegistry());
+                CompletedCheckpointStoreTest.createCheckpoint(ckpId, new SharedStateRegistryImpl());
         completedCheckpointStore.addCheckpointAndSubsumeOldestOne(
                 ckp, new CheckpointsCleaner(), () -> {});
 
@@ -233,7 +234,7 @@ public class DefaultCompletedCheckpointStoreTest extends TestLogger {
 
         final long ckpId = 100L;
         final CompletedCheckpoint ckp =
-                CompletedCheckpointStoreTest.createCheckpoint(ckpId, new SharedStateRegistry());
+                CompletedCheckpointStoreTest.createCheckpoint(ckpId, new SharedStateRegistryImpl());
 
         try {
             completedCheckpointStore.addCheckpointAndSubsumeOldestOne(
@@ -319,7 +320,7 @@ public class DefaultCompletedCheckpointStoreTest extends TestLogger {
                     () ->
                             completedCheckpointStore.addCheckpointAndSubsumeOldestOne(
                                     CompletedCheckpointStoreTest.createCheckpoint(
-                                            0L, new SharedStateRegistry()),
+                                            0L, new SharedStateRegistryImpl()),
                                     checkpointsCleaner,
                                     () -> {
                                         // No-op.
@@ -333,7 +334,7 @@ public class DefaultCompletedCheckpointStoreTest extends TestLogger {
                 new ArrayList<>();
         for (int i = 1; i <= num; i++) {
             final CompletedCheckpointStoreTest.TestCompletedCheckpoint completedCheckpoint =
-                    CompletedCheckpointStoreTest.createCheckpoint(i, new SharedStateRegistry());
+                    CompletedCheckpointStoreTest.createCheckpoint(i, new SharedStateRegistryImpl());
             final RetrievableStateHandle<CompletedCheckpoint> checkpointStateHandle =
                     checkpointStorageHelper.store(completedCheckpoint);
             stateHandles.add(new Tuple2<>(checkpointStateHandle, String.valueOf(i)));

--- a/flink-runtime/src/test/java/org/apache/flink/runtime/checkpoint/PendingCheckpointTest.java
+++ b/flink-runtime/src/test/java/org/apache/flink/runtime/checkpoint/PendingCheckpointTest.java
@@ -74,6 +74,7 @@ import static org.junit.Assert.assertTrue;
 import static org.junit.Assert.fail;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.ArgumentMatchers.anyLong;
+import static org.mockito.ArgumentMatchers.eq;
 import static org.mockito.ArgumentMatchers.nullable;
 import static org.mockito.Mockito.doNothing;
 import static org.mockito.Mockito.mock;
@@ -223,7 +224,7 @@ public class PendingCheckpointTest {
         QueueExecutor executor = new QueueExecutor();
 
         OperatorState state = mock(OperatorState.class);
-        doNothing().when(state).registerSharedStates(any(SharedStateRegistry.class));
+        doNothing().when(state).registerSharedStates(any(SharedStateRegistry.class), eq(0L));
 
         // Abort declined
         PendingCheckpoint pending = createPendingCheckpoint(props, executor);

--- a/flink-runtime/src/test/java/org/apache/flink/runtime/checkpoint/StandaloneCompletedCheckpointStoreTest.java
+++ b/flink-runtime/src/test/java/org/apache/flink/runtime/checkpoint/StandaloneCompletedCheckpointStoreTest.java
@@ -21,6 +21,7 @@ package org.apache.flink.runtime.checkpoint;
 import org.apache.flink.api.common.JobID;
 import org.apache.flink.api.common.JobStatus;
 import org.apache.flink.runtime.state.SharedStateRegistry;
+import org.apache.flink.runtime.state.SharedStateRegistryImpl;
 import org.apache.flink.runtime.state.testutils.TestCompletedCheckpointStorageLocation;
 import org.apache.flink.util.concurrent.Executors;
 
@@ -47,7 +48,7 @@ public class StandaloneCompletedCheckpointStoreTest extends CompletedCheckpointS
     /** Tests that shutdown discards all checkpoints. */
     @Test
     public void testShutdownDiscardsCheckpoints() throws Exception {
-        SharedStateRegistry sharedStateRegistry = new SharedStateRegistry();
+        SharedStateRegistry sharedStateRegistry = new SharedStateRegistryImpl();
         CompletedCheckpointStore store = createRecoveredCompletedCheckpointStore(1);
         TestCompletedCheckpoint checkpoint = createCheckpoint(0, sharedStateRegistry);
         Collection<OperatorState> operatorStates = checkpoint.getOperatorStates().values();
@@ -68,7 +69,7 @@ public class StandaloneCompletedCheckpointStoreTest extends CompletedCheckpointS
      */
     @Test
     public void testSuspendDiscardsCheckpoints() throws Exception {
-        SharedStateRegistry sharedStateRegistry = new SharedStateRegistry();
+        SharedStateRegistry sharedStateRegistry = new SharedStateRegistryImpl();
         CompletedCheckpointStore store = createRecoveredCompletedCheckpointStore(1);
         TestCompletedCheckpoint checkpoint = createCheckpoint(0, sharedStateRegistry);
         Collection<OperatorState> taskStates = checkpoint.getOperatorStates().values();

--- a/flink-runtime/src/test/java/org/apache/flink/runtime/checkpoint/StateHandleDummyUtil.java
+++ b/flink-runtime/src/test/java/org/apache/flink/runtime/checkpoint/StateHandleDummyUtil.java
@@ -185,7 +185,7 @@ public class StateHandleDummyUtil {
         }
 
         @Override
-        public void registerSharedStates(SharedStateRegistry stateRegistry) {}
+        public void registerSharedStates(SharedStateRegistry stateRegistry, long checkpointID) {}
 
         @Override
         public void discardState() throws Exception {}

--- a/flink-runtime/src/test/java/org/apache/flink/runtime/checkpoint/ZooKeeperCompletedCheckpointStoreITCase.java
+++ b/flink-runtime/src/test/java/org/apache/flink/runtime/checkpoint/ZooKeeperCompletedCheckpointStoreITCase.java
@@ -23,6 +23,7 @@ import org.apache.flink.api.common.JobStatus;
 import org.apache.flink.api.common.time.Deadline;
 import org.apache.flink.runtime.state.RetrievableStateHandle;
 import org.apache.flink.runtime.state.SharedStateRegistry;
+import org.apache.flink.runtime.state.SharedStateRegistryImpl;
 import org.apache.flink.runtime.testutils.CommonTestUtils;
 import org.apache.flink.runtime.util.ZooKeeperUtils;
 import org.apache.flink.runtime.zookeeper.ZooKeeperStateHandleStore;
@@ -104,7 +105,7 @@ public class ZooKeeperCompletedCheckpointStoreITCase extends CompletedCheckpoint
     @Test
     public void testRecover() throws Exception {
 
-        SharedStateRegistry sharedStateRegistry = new SharedStateRegistry();
+        SharedStateRegistry sharedStateRegistry = new SharedStateRegistryImpl();
         CompletedCheckpointStore checkpoints = createRecoveredCompletedCheckpointStore(3);
 
         TestCompletedCheckpoint[] expected =
@@ -132,7 +133,7 @@ public class ZooKeeperCompletedCheckpointStoreITCase extends CompletedCheckpoint
 
         // Recover
         sharedStateRegistry.close();
-        sharedStateRegistry = new SharedStateRegistry();
+        sharedStateRegistry = new SharedStateRegistryImpl();
 
         assertEquals(3, ZOOKEEPER.getClient().getChildren().forPath(CHECKPOINT_PATH).size());
         assertEquals(3, checkpoints.getNumberOfRetainedCheckpoints());
@@ -161,7 +162,7 @@ public class ZooKeeperCompletedCheckpointStoreITCase extends CompletedCheckpoint
     public void testShutdownDiscardsCheckpoints() throws Exception {
         CuratorFramework client = ZOOKEEPER.getClient();
 
-        SharedStateRegistry sharedStateRegistry = new SharedStateRegistry();
+        SharedStateRegistry sharedStateRegistry = new SharedStateRegistryImpl();
         CompletedCheckpointStore store = createRecoveredCompletedCheckpointStore(1);
         TestCompletedCheckpoint checkpoint = createCheckpoint(0, sharedStateRegistry);
 
@@ -197,7 +198,7 @@ public class ZooKeeperCompletedCheckpointStoreITCase extends CompletedCheckpoint
     public void testSuspendKeepsCheckpoints() throws Exception {
         CuratorFramework client = ZOOKEEPER.getClient();
 
-        SharedStateRegistry sharedStateRegistry = new SharedStateRegistry();
+        SharedStateRegistry sharedStateRegistry = new SharedStateRegistryImpl();
         CompletedCheckpointStore store = createRecoveredCompletedCheckpointStore(1);
         TestCompletedCheckpoint checkpoint = createCheckpoint(0, sharedStateRegistry);
 
@@ -238,7 +239,7 @@ public class ZooKeeperCompletedCheckpointStoreITCase extends CompletedCheckpoint
     @Test
     public void testLatestCheckpointRecovery() throws Exception {
         final int numCheckpoints = 3;
-        SharedStateRegistry sharedStateRegistry = new SharedStateRegistry();
+        SharedStateRegistry sharedStateRegistry = new SharedStateRegistryImpl();
         CompletedCheckpointStore checkpointStore =
                 createRecoveredCompletedCheckpointStore(numCheckpoints);
         List<CompletedCheckpoint> checkpoints = new ArrayList<>(numCheckpoints);
@@ -273,7 +274,7 @@ public class ZooKeeperCompletedCheckpointStoreITCase extends CompletedCheckpoint
         final CompletedCheckpointStore zkCheckpointStore1 =
                 createRecoveredCompletedCheckpointStore(numberOfCheckpoints);
 
-        SharedStateRegistry sharedStateRegistry = new SharedStateRegistry();
+        SharedStateRegistry sharedStateRegistry = new SharedStateRegistryImpl();
 
         TestCompletedCheckpoint completedCheckpoint = createCheckpoint(1, sharedStateRegistry);
 
@@ -283,7 +284,7 @@ public class ZooKeeperCompletedCheckpointStoreITCase extends CompletedCheckpoint
 
         // recover the checkpoint by a different checkpoint store
         sharedStateRegistry.close();
-        sharedStateRegistry = new SharedStateRegistry();
+        sharedStateRegistry = new SharedStateRegistryImpl();
         final CompletedCheckpointStore zkCheckpointStore2 =
                 createRecoveredCompletedCheckpointStore(numberOfCheckpoints);
 

--- a/flink-runtime/src/test/java/org/apache/flink/runtime/checkpoint/ZooKeeperCompletedCheckpointStoreTest.java
+++ b/flink-runtime/src/test/java/org/apache/flink/runtime/checkpoint/ZooKeeperCompletedCheckpointStoreTest.java
@@ -29,6 +29,7 @@ import org.apache.flink.runtime.operators.testutils.ExpectedTestException;
 import org.apache.flink.runtime.rest.util.NoOpFatalErrorHandler;
 import org.apache.flink.runtime.state.RetrievableStateHandle;
 import org.apache.flink.runtime.state.SharedStateRegistry;
+import org.apache.flink.runtime.state.SharedStateRegistryImpl;
 import org.apache.flink.runtime.state.testutils.TestCompletedCheckpointStorageLocation;
 import org.apache.flink.runtime.util.ZooKeeperUtils;
 import org.apache.flink.runtime.zookeeper.ZooKeeperResource;
@@ -118,7 +119,7 @@ public class ZooKeeperCompletedCheckpointStoreTest extends TestLogger {
     /** Tests that subsumed checkpoints are discarded. */
     @Test
     public void testDiscardingSubsumedCheckpoints() throws Exception {
-        final SharedStateRegistry sharedStateRegistry = new SharedStateRegistry();
+        final SharedStateRegistry sharedStateRegistry = new SharedStateRegistryImpl();
         final Configuration configuration = new Configuration();
         configuration.setString(
                 HighAvailabilityOptions.HA_ZOOKEEPER_QUORUM, zooKeeperResource.getConnectString());
@@ -157,7 +158,7 @@ public class ZooKeeperCompletedCheckpointStoreTest extends TestLogger {
      */
     @Test
     public void testDiscardingCheckpointsAtShutDown() throws Exception {
-        final SharedStateRegistry sharedStateRegistry = new SharedStateRegistry();
+        final SharedStateRegistry sharedStateRegistry = new SharedStateRegistryImpl();
         final Configuration configuration = new Configuration();
         configuration.setString(
                 HighAvailabilityOptions.HA_ZOOKEEPER_QUORUM, zooKeeperResource.getConnectString());

--- a/flink-runtime/src/test/java/org/apache/flink/runtime/scheduler/SchedulerUtilsTest.java
+++ b/flink-runtime/src/test/java/org/apache/flink/runtime/scheduler/SchedulerUtilsTest.java
@@ -112,7 +112,7 @@ public class SchedulerUtilsTest extends TestLogger {
 
         IncrementalRemoteKeyedStateHandle newHandle =
                 buildIncrementalHandle(key, new PlaceholderStreamStateHandle(), backendId);
-        newHandle.registerSharedStates(sharedStateRegistry);
+        newHandle.registerSharedStates(sharedStateRegistry, 1L);
 
         assertSame(handle, newHandle.getSharedState().get(key));
     }

--- a/flink-runtime/src/test/java/org/apache/flink/runtime/state/IncrementalRemoteKeyedStateHandleTest.java
+++ b/flink-runtime/src/test/java/org/apache/flink/runtime/state/IncrementalRemoteKeyedStateHandleTest.java
@@ -62,7 +62,7 @@ public class IncrementalRemoteKeyedStateHandleTest {
     @Test
     public void testSharedStateDeRegistration() throws Exception {
 
-        SharedStateRegistry registry = spy(new SharedStateRegistry());
+        SharedStateRegistry registry = spy(new SharedStateRegistryImpl());
 
         // Create two state handles with overlapping shared state
         IncrementalRemoteKeyedStateHandle stateHandle1 = create(new Random(42));
@@ -191,7 +191,7 @@ public class IncrementalRemoteKeyedStateHandleTest {
     @Test
     public void testSharedStateReRegistration() throws Exception {
 
-        SharedStateRegistry stateRegistryA = spy(new SharedStateRegistry());
+        SharedStateRegistry stateRegistryA = spy(new SharedStateRegistryImpl());
 
         IncrementalRemoteKeyedStateHandle stateHandleX = create(new Random(1));
         IncrementalRemoteKeyedStateHandle stateHandleY = create(new Random(2));
@@ -240,7 +240,7 @@ public class IncrementalRemoteKeyedStateHandleTest {
         }
 
         // We re-register the handle with a new registry
-        SharedStateRegistry sharedStateRegistryB = spy(new SharedStateRegistry());
+        SharedStateRegistry sharedStateRegistryB = spy(new SharedStateRegistryImpl());
         stateHandleX.registerSharedStates(sharedStateRegistryB);
         stateHandleX.discardState();
 

--- a/flink-runtime/src/test/java/org/apache/flink/runtime/state/IncrementalRemoteKeyedStateHandleTest.java
+++ b/flink-runtime/src/test/java/org/apache/flink/runtime/state/IncrementalRemoteKeyedStateHandleTest.java
@@ -80,6 +80,7 @@ public class IncrementalRemoteKeyedStateHandleTest {
 
         // Now we register both ...
         stateHandle1.registerSharedStates(registry, 0L);
+        registry.checkpointCompleted(0L);
         stateHandle2.registerSharedStates(registry, 0L);
 
         for (Map.Entry<StateHandleID, StreamStateHandle> stateHandleEntry :

--- a/flink-runtime/src/test/java/org/apache/flink/runtime/state/IncrementalRemoteKeyedStateHandleTest.java
+++ b/flink-runtime/src/test/java/org/apache/flink/runtime/state/IncrementalRemoteKeyedStateHandleTest.java
@@ -90,8 +90,8 @@ public class IncrementalRemoteKeyedStateHandleTest {
         }
 
         // Now we register both ...
-        stateHandle1.registerSharedStates(registry);
-        stateHandle2.registerSharedStates(registry);
+        stateHandle1.registerSharedStates(registry, 0L);
+        stateHandle2.registerSharedStates(registry, 0L);
 
         for (Map.Entry<StateHandleID, StreamStateHandle> stateHandleEntry :
                 stateHandle1.getSharedState().entrySet()) {
@@ -100,7 +100,7 @@ public class IncrementalRemoteKeyedStateHandleTest {
                     stateHandle1.createSharedStateRegistryKeyFromFileName(
                             stateHandleEntry.getKey());
 
-            verify(registry).registerReference(registryKey, stateHandleEntry.getValue());
+            verify(registry).registerReference(registryKey, stateHandleEntry.getValue(), 0L);
         }
 
         for (Map.Entry<StateHandleID, StreamStateHandle> stateHandleEntry :
@@ -110,7 +110,7 @@ public class IncrementalRemoteKeyedStateHandleTest {
                     stateHandle1.createSharedStateRegistryKeyFromFileName(
                             stateHandleEntry.getKey());
 
-            verify(registry).registerReference(registryKey, stateHandleEntry.getValue());
+            verify(registry).registerReference(registryKey, stateHandleEntry.getValue(), 0L);
         }
 
         // We discard the first
@@ -198,13 +198,13 @@ public class IncrementalRemoteKeyedStateHandleTest {
         IncrementalRemoteKeyedStateHandle stateHandleZ = create(new Random(3));
 
         // Now we register first time ...
-        stateHandleX.registerSharedStates(stateRegistryA);
-        stateHandleY.registerSharedStates(stateRegistryA);
-        stateHandleZ.registerSharedStates(stateRegistryA);
+        stateHandleX.registerSharedStates(stateRegistryA, 0L);
+        stateHandleY.registerSharedStates(stateRegistryA, 0L);
+        stateHandleZ.registerSharedStates(stateRegistryA, 0L);
 
         try {
             // Second attempt should fail
-            stateHandleX.registerSharedStates(stateRegistryA);
+            stateHandleX.registerSharedStates(stateRegistryA, 0L);
             fail("Should not be able to register twice with the same registry.");
         } catch (IllegalStateException ignore) {
         }
@@ -221,7 +221,7 @@ public class IncrementalRemoteKeyedStateHandleTest {
 
         // Attempt to register to closed registry should trigger exception
         try {
-            create(new Random(4)).registerSharedStates(stateRegistryA);
+            create(new Random(4)).registerSharedStates(stateRegistryA, 0L);
             fail("Should not be able to register new state to closed registry.");
         } catch (IllegalStateException ignore) {
         }
@@ -241,7 +241,7 @@ public class IncrementalRemoteKeyedStateHandleTest {
 
         // We re-register the handle with a new registry
         SharedStateRegistry sharedStateRegistryB = spy(new SharedStateRegistryImpl());
-        stateHandleX.registerSharedStates(sharedStateRegistryB);
+        stateHandleX.registerSharedStates(sharedStateRegistryB, 0L);
         stateHandleX.discardState();
 
         // Should be completely discarded because it is tracked through the new registry

--- a/flink-runtime/src/test/java/org/apache/flink/runtime/state/SharedStateRegistryTest.java
+++ b/flink-runtime/src/test/java/org/apache/flink/runtime/state/SharedStateRegistryTest.java
@@ -35,7 +35,7 @@ public class SharedStateRegistryTest {
     @Test
     public void testRegistryNormal() {
 
-        SharedStateRegistry sharedStateRegistry = new SharedStateRegistry();
+        SharedStateRegistry sharedStateRegistry = new SharedStateRegistryImpl();
 
         // register one state
         TestSharedState firstState = new TestSharedState("first");
@@ -89,7 +89,7 @@ public class SharedStateRegistryTest {
     /** Validate that unregister a nonexistent key will throw exception */
     @Test(expected = IllegalStateException.class)
     public void testUnregisterWithUnexistedKey() {
-        SharedStateRegistry sharedStateRegistry = new SharedStateRegistry();
+        SharedStateRegistry sharedStateRegistry = new SharedStateRegistryImpl();
         sharedStateRegistry.unregisterReference(new SharedStateRegistryKey("non-existent"));
     }
 

--- a/flink-runtime/src/test/java/org/apache/flink/runtime/state/SharedStateRegistryTest.java
+++ b/flink-runtime/src/test/java/org/apache/flink/runtime/state/SharedStateRegistryTest.java
@@ -40,7 +40,8 @@ public class SharedStateRegistryTest {
         // register one state
         TestSharedState firstState = new TestSharedState("first");
         SharedStateRegistry.Result result =
-                sharedStateRegistry.registerReference(firstState.getRegistrationKey(), firstState);
+                sharedStateRegistry.registerReference(
+                        firstState.getRegistrationKey(), firstState, 0L);
         assertEquals(1, result.getReferenceCount());
         assertTrue(firstState == result.getReference());
         assertFalse(firstState.isDiscarded());
@@ -49,7 +50,7 @@ public class SharedStateRegistryTest {
         TestSharedState secondState = new TestSharedState("second");
         result =
                 sharedStateRegistry.registerReference(
-                        secondState.getRegistrationKey(), secondState);
+                        secondState.getRegistrationKey(), secondState, 0L);
         assertEquals(1, result.getReferenceCount());
         assertTrue(secondState == result.getReference());
         assertFalse(firstState.isDiscarded());
@@ -60,7 +61,7 @@ public class SharedStateRegistryTest {
                 new TestSharedState(firstState.getRegistrationKey().getKeyString());
         result =
                 sharedStateRegistry.registerReference(
-                        firstState.getRegistrationKey(), firstStatePrime);
+                        firstState.getRegistrationKey(), firstStatePrime, 0L);
         assertEquals(2, result.getReferenceCount());
         assertFalse(firstStatePrime == result.getReference());
         assertTrue(firstState == result.getReference());
@@ -68,7 +69,9 @@ public class SharedStateRegistryTest {
         assertFalse(firstState.isDiscarded());
 
         // reference the first state again
-        result = sharedStateRegistry.registerReference(firstState.getRegistrationKey(), firstState);
+        result =
+                sharedStateRegistry.registerReference(
+                        firstState.getRegistrationKey(), firstState, 0L);
         assertEquals(3, result.getReferenceCount());
         assertTrue(firstState == result.getReference());
         assertFalse(firstState.isDiscarded());

--- a/flink-runtime/src/test/java/org/apache/flink/runtime/state/StateBackendMigrationTestBase.java
+++ b/flink-runtime/src/test/java/org/apache/flink/runtime/state/StateBackendMigrationTestBase.java
@@ -157,7 +157,7 @@ public abstract class StateBackendMigrationTestBase<B extends AbstractStateBacke
             throws Exception {
 
         CheckpointStreamFactory streamFactory = createStreamFactory();
-        SharedStateRegistry sharedStateRegistry = new SharedStateRegistry();
+        SharedStateRegistry sharedStateRegistry = new SharedStateRegistryImpl();
 
         AbstractKeyedStateBackend<Integer> backend = createKeyedBackend(IntSerializer.INSTANCE);
 
@@ -274,7 +274,7 @@ public abstract class StateBackendMigrationTestBase<B extends AbstractStateBacke
             throws Exception {
 
         CheckpointStreamFactory streamFactory = createStreamFactory();
-        SharedStateRegistry sharedStateRegistry = new SharedStateRegistry();
+        SharedStateRegistry sharedStateRegistry = new SharedStateRegistryImpl();
 
         AbstractKeyedStateBackend<Integer> backend = createKeyedBackend(IntSerializer.INSTANCE);
 
@@ -422,7 +422,7 @@ public abstract class StateBackendMigrationTestBase<B extends AbstractStateBacke
             MapStateDescriptor<Integer, TestType> newAccessDescriptorAfterRestore)
             throws Exception {
         CheckpointStreamFactory streamFactory = createStreamFactory();
-        SharedStateRegistry sharedStateRegistry = new SharedStateRegistry();
+        SharedStateRegistry sharedStateRegistry = new SharedStateRegistryImpl();
 
         AbstractKeyedStateBackend<Integer> backend = createKeyedBackend(IntSerializer.INSTANCE);
 
@@ -530,7 +530,7 @@ public abstract class StateBackendMigrationTestBase<B extends AbstractStateBacke
     public void testPriorityQueueStateCreationFailsIfNewSerializerIsNotCompatible()
             throws Exception {
         CheckpointStreamFactory streamFactory = createStreamFactory();
-        SharedStateRegistry sharedStateRegistry = new SharedStateRegistry();
+        SharedStateRegistry sharedStateRegistry = new SharedStateRegistryImpl();
 
         AbstractKeyedStateBackend<Integer> backend = createKeyedBackend(IntSerializer.INSTANCE);
 
@@ -613,7 +613,7 @@ public abstract class StateBackendMigrationTestBase<B extends AbstractStateBacke
             throws Exception {
 
         CheckpointStreamFactory streamFactory = createStreamFactory();
-        SharedStateRegistry sharedStateRegistry = new SharedStateRegistry();
+        SharedStateRegistry sharedStateRegistry = new SharedStateRegistryImpl();
 
         AbstractKeyedStateBackend<TestType> backend = createKeyedBackend(initialKeySerializer);
 
@@ -718,7 +718,7 @@ public abstract class StateBackendMigrationTestBase<B extends AbstractStateBacke
             throws Exception {
 
         CheckpointStreamFactory streamFactory = createStreamFactory();
-        SharedStateRegistry sharedStateRegistry = new SharedStateRegistry();
+        SharedStateRegistry sharedStateRegistry = new SharedStateRegistryImpl();
 
         AbstractKeyedStateBackend<Integer> backend = createKeyedBackend(IntSerializer.INSTANCE);
 

--- a/flink-runtime/src/test/java/org/apache/flink/runtime/state/StateBackendMigrationTestBase.java
+++ b/flink-runtime/src/test/java/org/apache/flink/runtime/state/StateBackendMigrationTestBase.java
@@ -1349,7 +1349,7 @@ public abstract class StateBackendMigrationTestBase<B extends AbstractStateBacke
         SnapshotResult<KeyedStateHandle> snapshotResult = snapshotRunnableFuture.get();
         KeyedStateHandle jobManagerOwnedSnapshot = snapshotResult.getJobManagerOwnedSnapshot();
         if (jobManagerOwnedSnapshot != null) {
-            jobManagerOwnedSnapshot.registerSharedStates(sharedStateRegistry);
+            jobManagerOwnedSnapshot.registerSharedStates(sharedStateRegistry, 0L);
         }
         return jobManagerOwnedSnapshot;
     }

--- a/flink-runtime/src/test/java/org/apache/flink/runtime/state/StateBackendTestBase.java
+++ b/flink-runtime/src/test/java/org/apache/flink/runtime/state/StateBackendTestBase.java
@@ -5289,7 +5289,7 @@ public abstract class StateBackendTestBase<B extends AbstractStateBackend> exten
         SnapshotResult<KeyedStateHandle> snapshotResult = snapshotRunnableFuture.get();
         KeyedStateHandle jobManagerOwnedSnapshot = snapshotResult.getJobManagerOwnedSnapshot();
         if (jobManagerOwnedSnapshot != null) {
-            jobManagerOwnedSnapshot.registerSharedStates(sharedStateRegistry);
+            jobManagerOwnedSnapshot.registerSharedStates(sharedStateRegistry, 0L);
         }
         return jobManagerOwnedSnapshot;
     }

--- a/flink-runtime/src/test/java/org/apache/flink/runtime/state/StateBackendTestBase.java
+++ b/flink-runtime/src/test/java/org/apache/flink/runtime/state/StateBackendTestBase.java
@@ -510,7 +510,7 @@ public abstract class StateBackendTestBase<B extends AbstractStateBackend> exten
     @SuppressWarnings("unchecked")
     public void testBackendUsesRegisteredKryoDefaultSerializer() throws Exception {
         CheckpointStreamFactory streamFactory = createStreamFactory();
-        SharedStateRegistry sharedStateRegistry = new SharedStateRegistry();
+        SharedStateRegistry sharedStateRegistry = new SharedStateRegistryImpl();
         CheckpointableKeyedStateBackend<Integer> backend =
                 createKeyedBackend(IntSerializer.INSTANCE, env);
 
@@ -581,7 +581,7 @@ public abstract class StateBackendTestBase<B extends AbstractStateBackend> exten
     @SuppressWarnings("unchecked")
     public void testBackendUsesRegisteredKryoDefaultSerializerUsingGetOrCreate() throws Exception {
         CheckpointStreamFactory streamFactory = createStreamFactory();
-        SharedStateRegistry sharedStateRegistry = new SharedStateRegistry();
+        SharedStateRegistry sharedStateRegistry = new SharedStateRegistryImpl();
         CheckpointableKeyedStateBackend<Integer> backend =
                 createKeyedBackend(IntSerializer.INSTANCE, env);
 
@@ -654,7 +654,7 @@ public abstract class StateBackendTestBase<B extends AbstractStateBackend> exten
     @Test
     public void testBackendUsesRegisteredKryoSerializer() throws Exception {
         CheckpointStreamFactory streamFactory = createStreamFactory();
-        SharedStateRegistry sharedStateRegistry = new SharedStateRegistry();
+        SharedStateRegistry sharedStateRegistry = new SharedStateRegistryImpl();
         env.getExecutionConfig()
                 .registerTypeWithKryoSerializer(
                         TestPojo.class, ExceptionThrowingTestSerializer.class);
@@ -722,7 +722,7 @@ public abstract class StateBackendTestBase<B extends AbstractStateBackend> exten
     @SuppressWarnings("unchecked")
     public void testBackendUsesRegisteredKryoSerializerUsingGetOrCreate() throws Exception {
         CheckpointStreamFactory streamFactory = createStreamFactory();
-        SharedStateRegistry sharedStateRegistry = new SharedStateRegistry();
+        SharedStateRegistry sharedStateRegistry = new SharedStateRegistryImpl();
 
         env.getExecutionConfig()
                 .registerTypeWithKryoSerializer(
@@ -799,7 +799,7 @@ public abstract class StateBackendTestBase<B extends AbstractStateBackend> exten
     @Test
     public void testKryoRegisteringRestoreResilienceWithRegisteredType() throws Exception {
         CheckpointStreamFactory streamFactory = createStreamFactory();
-        SharedStateRegistry sharedStateRegistry = new SharedStateRegistry();
+        SharedStateRegistry sharedStateRegistry = new SharedStateRegistryImpl();
 
         TypeInformation<TestPojo> pojoType = new GenericTypeInfo<>(TestPojo.class);
 
@@ -877,7 +877,7 @@ public abstract class StateBackendTestBase<B extends AbstractStateBackend> exten
     public void testKryoRegisteringRestoreResilienceWithDefaultSerializer() throws Exception {
         assumeTrue(supportsMetaInfoVerification());
         CheckpointStreamFactory streamFactory = createStreamFactory();
-        SharedStateRegistry sharedStateRegistry = new SharedStateRegistry();
+        SharedStateRegistry sharedStateRegistry = new SharedStateRegistryImpl();
         CheckpointableKeyedStateBackend<Integer> backend =
                 createKeyedBackend(IntSerializer.INSTANCE, env);
         try {
@@ -1000,7 +1000,7 @@ public abstract class StateBackendTestBase<B extends AbstractStateBackend> exten
     public void testKryoRegisteringRestoreResilienceWithRegisteredSerializer() throws Exception {
         assumeTrue(supportsMetaInfoVerification());
         CheckpointStreamFactory streamFactory = createStreamFactory();
-        SharedStateRegistry sharedStateRegistry = new SharedStateRegistry();
+        SharedStateRegistry sharedStateRegistry = new SharedStateRegistryImpl();
 
         CheckpointableKeyedStateBackend<Integer> backend = null;
 
@@ -1109,7 +1109,7 @@ public abstract class StateBackendTestBase<B extends AbstractStateBackend> exten
     @SuppressWarnings("unchecked")
     public void testKryoRestoreResilienceWithDifferentRegistrationOrder() throws Exception {
         CheckpointStreamFactory streamFactory = createStreamFactory();
-        SharedStateRegistry sharedStateRegistry = new SharedStateRegistry();
+        SharedStateRegistry sharedStateRegistry = new SharedStateRegistryImpl();
 
         // register A first then B
         env.getExecutionConfig().registerKryoType(TestNestedPojoClassA.class);
@@ -1238,7 +1238,7 @@ public abstract class StateBackendTestBase<B extends AbstractStateBackend> exten
     @Test
     public void testPojoRestoreResilienceWithDifferentRegistrationOrder() throws Exception {
         CheckpointStreamFactory streamFactory = createStreamFactory();
-        SharedStateRegistry sharedStateRegistry = new SharedStateRegistry();
+        SharedStateRegistry sharedStateRegistry = new SharedStateRegistryImpl();
 
         // register A first then B
         env.getExecutionConfig().registerPojoType(TestNestedPojoClassA.class);
@@ -1338,7 +1338,7 @@ public abstract class StateBackendTestBase<B extends AbstractStateBackend> exten
     @SuppressWarnings("unchecked")
     public void testValueState() throws Exception {
         CheckpointStreamFactory streamFactory = createStreamFactory();
-        SharedStateRegistry sharedStateRegistry = new SharedStateRegistry();
+        SharedStateRegistry sharedStateRegistry = new SharedStateRegistryImpl();
 
         ValueStateDescriptor<String> kvId = new ValueStateDescriptor<>("id", String.class);
 
@@ -1701,7 +1701,7 @@ public abstract class StateBackendTestBase<B extends AbstractStateBackend> exten
     @SuppressWarnings("unchecked")
     public void testMultipleValueStates() throws Exception {
         CheckpointStreamFactory streamFactory = createStreamFactory();
-        SharedStateRegistry sharedStateRegistry = new SharedStateRegistry();
+        SharedStateRegistry sharedStateRegistry = new SharedStateRegistryImpl();
 
         ValueStateDescriptor<String> desc1 =
                 new ValueStateDescriptor<>("a-string", StringSerializer.INSTANCE);
@@ -1793,7 +1793,7 @@ public abstract class StateBackendTestBase<B extends AbstractStateBackend> exten
         }
 
         CheckpointStreamFactory streamFactory = createStreamFactory();
-        SharedStateRegistry sharedStateRegistry = new SharedStateRegistry();
+        SharedStateRegistry sharedStateRegistry = new SharedStateRegistryImpl();
         CheckpointableKeyedStateBackend<Integer> backend =
                 createKeyedBackend(IntSerializer.INSTANCE);
         try {
@@ -1852,7 +1852,7 @@ public abstract class StateBackendTestBase<B extends AbstractStateBackend> exten
     @SuppressWarnings("unchecked,rawtypes")
     public void testListState() throws Exception {
         CheckpointStreamFactory streamFactory = createStreamFactory();
-        SharedStateRegistry sharedStateRegistry = new SharedStateRegistry();
+        SharedStateRegistry sharedStateRegistry = new SharedStateRegistryImpl();
 
         ListStateDescriptor<String> kvId = new ListStateDescriptor<>("id", String.class);
 
@@ -2418,7 +2418,7 @@ public abstract class StateBackendTestBase<B extends AbstractStateBackend> exten
     @SuppressWarnings("unchecked")
     public void testReducingState() throws Exception {
         CheckpointStreamFactory streamFactory = createStreamFactory();
-        SharedStateRegistry sharedStateRegistry = new SharedStateRegistry();
+        SharedStateRegistry sharedStateRegistry = new SharedStateRegistryImpl();
 
         ReducingStateDescriptor<String> kvId =
                 new ReducingStateDescriptor<>("id", new AppendingReduce(), String.class);
@@ -3174,7 +3174,7 @@ public abstract class StateBackendTestBase<B extends AbstractStateBackend> exten
     @SuppressWarnings("unchecked,rawtypes")
     public void testMapState() throws Exception {
         CheckpointStreamFactory streamFactory = createStreamFactory();
-        SharedStateRegistry sharedStateRegistry = new SharedStateRegistry();
+        SharedStateRegistry sharedStateRegistry = new SharedStateRegistryImpl();
 
         MapStateDescriptor<Integer, String> kvId =
                 new MapStateDescriptor<>("id", Integer.class, String.class);
@@ -3647,7 +3647,7 @@ public abstract class StateBackendTestBase<B extends AbstractStateBackend> exten
                                     1L,
                                     createStreamFactory(),
                                     CheckpointOptions.forCheckpointWithDefaultLocation()),
-                            new SharedStateRegistry());
+                            new SharedStateRegistryImpl());
         } finally {
             IOUtils.closeQuietly(backend);
             backend.dispose();
@@ -3757,7 +3757,7 @@ public abstract class StateBackendTestBase<B extends AbstractStateBackend> exten
     @Test
     public void testSnapshotNonAccessedState() throws Exception {
         CheckpointStreamFactory streamFactory = createStreamFactory();
-        SharedStateRegistry sharedStateRegistry = new SharedStateRegistry();
+        SharedStateRegistry sharedStateRegistry = new SharedStateRegistryImpl();
         final String stateName = "test-name";
 
         CheckpointableKeyedStateBackend<String> backend =
@@ -3913,7 +3913,7 @@ public abstract class StateBackendTestBase<B extends AbstractStateBackend> exten
         }
 
         CheckpointStreamFactory streamFactory = createStreamFactory();
-        SharedStateRegistry sharedStateRegistry = new SharedStateRegistry();
+        SharedStateRegistry sharedStateRegistry = new SharedStateRegistryImpl();
 
         List<KeyedStateHandle> snapshots = new ArrayList<>(sourceParallelism);
         for (int i = 0; i < sourceParallelism; ++i) {
@@ -4002,7 +4002,7 @@ public abstract class StateBackendTestBase<B extends AbstractStateBackend> exten
         assumeTrue(supportsMetaInfoVerification());
         CheckpointStreamFactory streamFactory = createStreamFactory();
 
-        SharedStateRegistry sharedStateRegistry = new SharedStateRegistry();
+        SharedStateRegistry sharedStateRegistry = new SharedStateRegistryImpl();
 
         ValueStateDescriptor<String> kvId = new ValueStateDescriptor<>("id", String.class);
 
@@ -4052,7 +4052,7 @@ public abstract class StateBackendTestBase<B extends AbstractStateBackend> exten
     public void testValueStateRestoreWithWrongSerializers() throws Exception {
         assumeTrue(supportsMetaInfoVerification());
         CheckpointStreamFactory streamFactory = createStreamFactory();
-        SharedStateRegistry sharedStateRegistry = new SharedStateRegistry();
+        SharedStateRegistry sharedStateRegistry = new SharedStateRegistryImpl();
         CheckpointableKeyedStateBackend<Integer> backend =
                 createKeyedBackend(IntSerializer.INSTANCE);
 
@@ -4111,7 +4111,7 @@ public abstract class StateBackendTestBase<B extends AbstractStateBackend> exten
     public void testListStateRestoreWithWrongSerializers() throws Exception {
         assumeTrue(supportsMetaInfoVerification());
         CheckpointStreamFactory streamFactory = createStreamFactory();
-        SharedStateRegistry sharedStateRegistry = new SharedStateRegistry();
+        SharedStateRegistry sharedStateRegistry = new SharedStateRegistryImpl();
         CheckpointableKeyedStateBackend<Integer> backend =
                 createKeyedBackend(IntSerializer.INSTANCE);
 
@@ -4169,7 +4169,7 @@ public abstract class StateBackendTestBase<B extends AbstractStateBackend> exten
     public void testReducingStateRestoreWithWrongSerializers() throws Exception {
         assumeTrue(supportsMetaInfoVerification());
         CheckpointStreamFactory streamFactory = createStreamFactory();
-        SharedStateRegistry sharedStateRegistry = new SharedStateRegistry();
+        SharedStateRegistry sharedStateRegistry = new SharedStateRegistryImpl();
         CheckpointableKeyedStateBackend<Integer> backend =
                 createKeyedBackend(IntSerializer.INSTANCE);
 
@@ -4231,7 +4231,7 @@ public abstract class StateBackendTestBase<B extends AbstractStateBackend> exten
     public void testMapStateRestoreWithWrongSerializers() throws Exception {
         assumeTrue(supportsMetaInfoVerification());
         CheckpointStreamFactory streamFactory = createStreamFactory();
-        SharedStateRegistry sharedStateRegistry = new SharedStateRegistry();
+        SharedStateRegistry sharedStateRegistry = new SharedStateRegistryImpl();
         CheckpointableKeyedStateBackend<Integer> backend =
                 createKeyedBackend(IntSerializer.INSTANCE);
 
@@ -4475,7 +4475,7 @@ public abstract class StateBackendTestBase<B extends AbstractStateBackend> exten
         KvStateRegistry registry = env.getKvStateRegistry();
 
         CheckpointStreamFactory streamFactory = createStreamFactory();
-        SharedStateRegistry sharedStateRegistry = new SharedStateRegistry();
+        SharedStateRegistry sharedStateRegistry = new SharedStateRegistryImpl();
         CheckpointableKeyedStateBackend<Integer> backend =
                 createKeyedBackend(IntSerializer.INSTANCE, env);
         try {
@@ -4548,7 +4548,7 @@ public abstract class StateBackendTestBase<B extends AbstractStateBackend> exten
                 createKeyedBackend(IntSerializer.INSTANCE);
         try {
             CheckpointStreamFactory streamFactory = createStreamFactory();
-            SharedStateRegistry sharedStateRegistry = new SharedStateRegistry();
+            SharedStateRegistry sharedStateRegistry = new SharedStateRegistryImpl();
 
             ListStateDescriptor<String> kvId = new ListStateDescriptor<>("id", String.class);
 

--- a/flink-runtime/src/test/java/org/apache/flink/runtime/state/ttl/StateBackendTestContext.java
+++ b/flink-runtime/src/test/java/org/apache/flink/runtime/state/ttl/StateBackendTestContext.java
@@ -32,6 +32,7 @@ import org.apache.flink.runtime.state.CheckpointableKeyedStateBackend;
 import org.apache.flink.runtime.state.KeyGroupRange;
 import org.apache.flink.runtime.state.KeyedStateHandle;
 import org.apache.flink.runtime.state.SharedStateRegistry;
+import org.apache.flink.runtime.state.SharedStateRegistryImpl;
 import org.apache.flink.runtime.state.SnapshotResult;
 import org.apache.flink.runtime.state.StateBackend;
 import org.apache.flink.runtime.state.internal.InternalKvState;
@@ -66,7 +67,7 @@ public abstract class StateBackendTestContext {
         this.stateBackend = Preconditions.checkNotNull(createStateBackend());
         this.checkpointOptions = CheckpointOptions.forCheckpointWithDefaultLocation();
         this.checkpointStreamFactory = createCheckpointStreamFactory();
-        this.sharedStateRegistry = new SharedStateRegistry();
+        this.sharedStateRegistry = new SharedStateRegistryImpl();
         this.snapshots = new ArrayList<>();
     }
 

--- a/flink-runtime/src/test/java/org/apache/flink/runtime/state/ttl/StateBackendTestContext.java
+++ b/flink-runtime/src/test/java/org/apache/flink/runtime/state/ttl/StateBackendTestContext.java
@@ -150,7 +150,7 @@ public abstract class StateBackendTestContext {
         SnapshotResult<KeyedStateHandle> snapshotResult = triggerSnapshot().get();
         KeyedStateHandle jobManagerOwnedSnapshot = snapshotResult.getJobManagerOwnedSnapshot();
         if (jobManagerOwnedSnapshot != null) {
-            jobManagerOwnedSnapshot.registerSharedStates(sharedStateRegistry);
+            jobManagerOwnedSnapshot.registerSharedStates(sharedStateRegistry, 0L);
         }
         return jobManagerOwnedSnapshot;
     }

--- a/flink-runtime/src/test/java/org/apache/flink/runtime/state/ttl/mock/MockKeyedStateBackend.java
+++ b/flink-runtime/src/test/java/org/apache/flink/runtime/state/ttl/mock/MockKeyedStateBackend.java
@@ -320,7 +320,7 @@ public class MockKeyedStateBackend<K> extends AbstractKeyedStateBackend<K> {
         }
 
         @Override
-        public void registerSharedStates(SharedStateRegistry stateRegistry) {}
+        public void registerSharedStates(SharedStateRegistry stateRegistry, long checkpointID) {}
 
         @Override
         public KeyGroupRange getKeyGroupRange() {

--- a/flink-state-backends/flink-statebackend-changelog/src/test/java/org/apache/flink/state/changelog/ChangelogStateBackendTestUtils.java
+++ b/flink-state-backends/flink-statebackend-changelog/src/test/java/org/apache/flink/state/changelog/ChangelogStateBackendTestUtils.java
@@ -44,6 +44,7 @@ import org.apache.flink.runtime.state.KeyGroupRange;
 import org.apache.flink.runtime.state.KeyGroupedInternalPriorityQueue;
 import org.apache.flink.runtime.state.KeyedStateHandle;
 import org.apache.flink.runtime.state.SharedStateRegistry;
+import org.apache.flink.runtime.state.SharedStateRegistryImpl;
 import org.apache.flink.runtime.state.StateBackend;
 import org.apache.flink.runtime.state.StateBackendTestBase;
 import org.apache.flink.runtime.state.TestTaskStateManager;
@@ -140,7 +141,7 @@ public class ChangelogStateBackendTestUtils {
     public static void testMaterializedRestore(
             StateBackend stateBackend, Environment env, CheckpointStreamFactory streamFactory)
             throws Exception {
-        SharedStateRegistry sharedStateRegistry = new SharedStateRegistry();
+        SharedStateRegistry sharedStateRegistry = new SharedStateRegistryImpl();
 
         TypeInformation<StateBackendTestBase.TestPojo> pojoType =
                 new GenericTypeInfo<>(StateBackendTestBase.TestPojo.class);
@@ -232,7 +233,7 @@ public class ChangelogStateBackendTestUtils {
     public static void testMaterializedRestoreForPriorityQueue(
             StateBackend stateBackend, Environment env, CheckpointStreamFactory streamFactory)
             throws Exception {
-        SharedStateRegistry sharedStateRegistry = new SharedStateRegistry();
+        SharedStateRegistry sharedStateRegistry = new SharedStateRegistryImpl();
         String fieldName = "key-grouped-priority-queue";
         ChangelogKeyedStateBackend<Integer> keyedBackend =
                 (ChangelogKeyedStateBackend<Integer>) createKeyedBackend(stateBackend, env);

--- a/flink-state-backends/flink-statebackend-rocksdb/src/main/java/org/apache/flink/contrib/streaming/state/snapshot/RocksIncrementalSnapshotStrategy.java
+++ b/flink-state-backends/flink-statebackend-rocksdb/src/main/java/org/apache/flink/contrib/streaming/state/snapshot/RocksIncrementalSnapshotStrategy.java
@@ -68,6 +68,7 @@ import java.util.HashMap;
 import java.util.LinkedHashMap;
 import java.util.List;
 import java.util.Map;
+import java.util.Optional;
 import java.util.Set;
 import java.util.SortedMap;
 import java.util.UUID;
@@ -96,12 +97,24 @@ public class RocksIncrementalSnapshotStrategy<K>
     @Nonnull private final UUID backendUID;
 
     /**
-     * Stores the materialized sstable files from all snapshots that build the incremental history.
+     * Stores the {@link StateHandleID IDs} of uploaded SST files that build the incremental
+     * history. Once the checkpoint is confirmed by JM, only the ID paired with {@link
+     * PlaceholderStreamStateHandle} can be sent. Until that, original {@link StreamStateHandle}
+     * must be used (held in {@link #lastUploadedSstFiles}).
      */
-    @Nonnull private final SortedMap<Long, Set<StateHandleID>> materializedSstFiles;
+    @Nonnull private final SortedMap<Long, Set<StateHandleID>> uploadedStateIDs;
+
+    /**
+     * Last uploaded but potentially not confirmed SST files. Used if {@link #uploadedStateIDs}
+     * doesn't contain the corresponding {@link StateHandleID}.
+     */
+    @Nonnull private final Map<StateHandleID, StreamStateHandle> lastUploadedSstFiles;
 
     /** The identifier of the last completed checkpoint. */
     private long lastCompletedCheckpointId;
+
+    /** The identifier of the checkpoint for which SST files were uploaded (grows monotonically). */
+    private long lastCheckpointIdUploadedSst = -1;
 
     /** The help class used to upload state files. */
     private final RocksDBStateUploader stateUploader;
@@ -120,7 +133,7 @@ public class RocksIncrementalSnapshotStrategy<K>
             @Nonnull CloseableRegistry cancelStreamRegistry,
             @Nonnull File instanceBasePath,
             @Nonnull UUID backendUID,
-            @Nonnull SortedMap<Long, Set<StateHandleID>> materializedSstFiles,
+            @Nonnull SortedMap<Long, Set<StateHandleID>> uploadedStateIDs,
             @Nonnull RocksDBStateUploader rocksDBStateUploader,
             long lastCompletedCheckpointId) {
 
@@ -136,10 +149,11 @@ public class RocksIncrementalSnapshotStrategy<K>
 
         this.instanceBasePath = instanceBasePath;
         this.backendUID = backendUID;
-        this.materializedSstFiles = materializedSstFiles;
+        this.uploadedStateIDs = uploadedStateIDs;
         this.stateUploader = rocksDBStateUploader;
         this.lastCompletedCheckpointId = lastCompletedCheckpointId;
         this.localDirectoryName = backendUID.toString().replaceAll("[\\-]", "");
+        this.lastUploadedSstFiles = new HashMap<>();
     }
 
     @Override
@@ -151,13 +165,13 @@ public class RocksIncrementalSnapshotStrategy<K>
 
         final List<StateMetaInfoSnapshot> stateMetaInfoSnapshots =
                 new ArrayList<>(kvStateInformation.size());
-        final Set<StateHandleID> baseSstFiles =
+        final PreviousSnapshot previousSnapshot =
                 snapshotMetaData(checkpointId, stateMetaInfoSnapshots);
 
         takeDBNativeCheckpoint(snapshotDirectory);
 
         return new IncrementalRocksDBSnapshotResources(
-                snapshotDirectory, baseSstFiles, stateMetaInfoSnapshots);
+                snapshotDirectory, previousSnapshot, stateMetaInfoSnapshots);
     }
 
     @Override
@@ -181,19 +195,19 @@ public class RocksIncrementalSnapshotStrategy<K>
                 checkpointId,
                 checkpointStreamFactory,
                 snapshotResources.snapshotDirectory,
-                snapshotResources.baseSstFiles,
+                snapshotResources.previousSnapshot,
                 snapshotResources.stateMetaInfoSnapshots);
     }
 
     @Override
     public void notifyCheckpointComplete(long completedCheckpointId) {
-        synchronized (materializedSstFiles) {
+        synchronized (uploadedStateIDs) {
             // FLINK-23949: materializedSstFiles.keySet().contains(completedCheckpointId) make sure
             // the notified checkpointId is not a savepoint, otherwise next checkpoint will
             // degenerate into a full checkpoint
             if (completedCheckpointId > lastCompletedCheckpointId
-                    && materializedSstFiles.keySet().contains(completedCheckpointId)) {
-                materializedSstFiles
+                    && uploadedStateIDs.containsKey(completedCheckpointId)) {
+                uploadedStateIDs
                         .keySet()
                         .removeIf(checkpointId -> checkpointId < completedCheckpointId);
                 lastCompletedCheckpointId = completedCheckpointId;
@@ -203,8 +217,8 @@ public class RocksIncrementalSnapshotStrategy<K>
 
     @Override
     public void notifyCheckpointAborted(long abortedCheckpointId) {
-        synchronized (materializedSstFiles) {
-            materializedSstFiles.keySet().remove(abortedCheckpointId);
+        synchronized (uploadedStateIDs) {
+            uploadedStateIDs.keySet().remove(abortedCheckpointId);
         }
     }
 
@@ -258,30 +272,37 @@ public class RocksIncrementalSnapshotStrategy<K>
         }
     }
 
-    private Set<StateHandleID> snapshotMetaData(
+    private PreviousSnapshot snapshotMetaData(
             long checkpointId, @Nonnull List<StateMetaInfoSnapshot> stateMetaInfoSnapshots) {
 
         final long lastCompletedCheckpoint;
-        final Set<StateHandleID> baseSstFiles;
+        final Set<StateHandleID> confirmedSstFiles;
+        final Map<StateHandleID, StreamStateHandle> uploadedSstFiles;
 
         // use the last completed checkpoint as the comparison base.
-        synchronized (materializedSstFiles) {
+        synchronized (uploadedStateIDs) {
             lastCompletedCheckpoint = lastCompletedCheckpointId;
-            baseSstFiles = materializedSstFiles.get(lastCompletedCheckpoint);
+            confirmedSstFiles = uploadedStateIDs.get(lastCompletedCheckpoint);
+            uploadedSstFiles = new HashMap<>(lastUploadedSstFiles);
+            LOG.trace(
+                    "Use lastUploadedSstFiles for checkpoint {}: {}",
+                    checkpointId,
+                    uploadedSstFiles);
         }
         LOG.trace(
                 "Taking incremental snapshot for checkpoint {}. Snapshot is based on last completed checkpoint {} "
-                        + "assuming the following (shared) files as base: {}.",
+                        + "assuming the following (shared) confirmed files as base: {}, uploaded: {}.",
                 checkpointId,
                 lastCompletedCheckpoint,
-                baseSstFiles);
+                confirmedSstFiles,
+                uploadedSstFiles);
 
         // snapshot meta data to save
         for (Map.Entry<String, RocksDbKvStateInfo> stateMetaInfoEntry :
                 kvStateInformation.entrySet()) {
             stateMetaInfoSnapshots.add(stateMetaInfoEntry.getValue().metaInfo.snapshot());
         }
-        return baseSstFiles;
+        return new PreviousSnapshot(confirmedSstFiles, uploadedSstFiles);
     }
 
     private void takeDBNativeCheckpoint(@Nonnull SnapshotDirectory outputDirectory)
@@ -319,17 +340,17 @@ public class RocksIncrementalSnapshotStrategy<K>
         @Nonnull private final SnapshotDirectory localBackupDirectory;
 
         /** All sst files that were part of the last previously completed checkpoint. */
-        @Nullable private final Set<StateHandleID> baseSstFiles;
+        @Nonnull private final PreviousSnapshot previousSnapshot;
 
         private RocksDBIncrementalSnapshotOperation(
                 long checkpointId,
                 @Nonnull CheckpointStreamFactory checkpointStreamFactory,
                 @Nonnull SnapshotDirectory localBackupDirectory,
-                @Nullable Set<StateHandleID> baseSstFiles,
+                @Nonnull PreviousSnapshot previousSnapshot,
                 @Nonnull List<StateMetaInfoSnapshot> stateMetaInfoSnapshots) {
 
             this.checkpointStreamFactory = checkpointStreamFactory;
-            this.baseSstFiles = baseSstFiles;
+            this.previousSnapshot = previousSnapshot;
             this.checkpointId = checkpointId;
             this.localBackupDirectory = localBackupDirectory;
             this.stateMetaInfoSnapshots = stateMetaInfoSnapshots;
@@ -359,10 +380,6 @@ public class RocksIncrementalSnapshotStrategy<K>
                         "Metadata for job manager was not properly created.");
 
                 uploadSstFiles(sstFiles, miscFiles, snapshotCloseableRegistry);
-
-                synchronized (materializedSstFiles) {
-                    materializedSstFiles.put(checkpointId, sstFiles.keySet());
-                }
 
                 final IncrementalRemoteKeyedStateHandle jmIncrementalKeyedStateHandle =
                         new IncrementalRemoteKeyedStateHandle(
@@ -453,6 +470,20 @@ public class RocksIncrementalSnapshotStrategy<K>
                 miscFiles.putAll(
                         stateUploader.uploadFilesToCheckpointFs(
                                 miscFilePaths, checkpointStreamFactory, snapshotCloseableRegistry));
+
+                synchronized (uploadedStateIDs) {
+                    // ignore an older upload if it completed after a newer one has completed
+                    if (checkpointId > lastCheckpointIdUploadedSst) {
+                        lastCheckpointIdUploadedSst = checkpointId;
+                        lastUploadedSstFiles.clear();
+                        LOG.trace(
+                                "Update lastUploadedSstFiles for checkpoint {}: {}",
+                                checkpointId,
+                                sstFiles);
+                        lastUploadedSstFiles.putAll(sstFiles);
+                    }
+                    uploadedStateIDs.put(checkpointId, sstFiles.keySet());
+                }
             }
         }
 
@@ -466,16 +497,12 @@ public class RocksIncrementalSnapshotStrategy<K>
                 final StateHandleID stateHandleID = new StateHandleID(fileName);
 
                 if (fileName.endsWith(SST_FILE_SUFFIX)) {
-                    final boolean existsAlready =
-                            baseSstFiles != null && baseSstFiles.contains(stateHandleID);
-
-                    if (existsAlready) {
-                        // we introduce a placeholder state handle, that is replaced with the
-                        // original from the shared state registry (created from a previous
-                        // checkpoint)
-                        sstFiles.put(stateHandleID, new PlaceholderStreamStateHandle());
+                    Optional<StreamStateHandle> uploaded =
+                            previousSnapshot.getUploaded(stateHandleID);
+                    if (uploaded.isPresent()) {
+                        sstFiles.put(stateHandleID, uploaded.get());
                     } else {
-                        sstFilePaths.put(stateHandleID, filePath);
+                        sstFilePaths.put(stateHandleID, filePath); // re-upload
                     }
                 } else {
                     miscFilePaths.put(stateHandleID, filePath);
@@ -531,15 +558,15 @@ public class RocksIncrementalSnapshotStrategy<K>
 
     static class IncrementalRocksDBSnapshotResources implements SnapshotResources {
         @Nonnull private final SnapshotDirectory snapshotDirectory;
-        @Nonnull private final Set<StateHandleID> baseSstFiles;
+        @Nonnull private final PreviousSnapshot previousSnapshot;
         @Nonnull private final List<StateMetaInfoSnapshot> stateMetaInfoSnapshots;
 
         public IncrementalRocksDBSnapshotResources(
                 SnapshotDirectory snapshotDirectory,
-                Set<StateHandleID> baseSstFiles,
+                PreviousSnapshot previousSnapshot,
                 List<StateMetaInfoSnapshot> stateMetaInfoSnapshots) {
             this.snapshotDirectory = snapshotDirectory;
-            this.baseSstFiles = baseSstFiles;
+            this.previousSnapshot = previousSnapshot;
             this.stateMetaInfoSnapshots = stateMetaInfoSnapshots;
         }
 
@@ -559,6 +586,39 @@ public class RocksIncrementalSnapshotStrategy<K>
             } catch (IOException e) {
                 LOG.warn("Could not properly cleanup local RocksDB backup directory.", e);
             }
+        }
+    }
+
+    private static class PreviousSnapshot {
+
+        @Nullable private final Set<StateHandleID> confirmedSstFiles;
+        private final Map<StateHandleID, StreamStateHandle> uploadedSstFiles;
+
+        private PreviousSnapshot(
+                @Nullable Set<StateHandleID> confirmedSstFiles,
+                @Nonnull Map<StateHandleID, StreamStateHandle> uploadedSstFiles) {
+            this.confirmedSstFiles = confirmedSstFiles;
+            this.uploadedSstFiles = Preconditions.checkNotNull(uploadedSstFiles);
+        }
+
+        private Optional<StreamStateHandle> getUploaded(StateHandleID stateHandleID) {
+            if (isConfirmed(stateHandleID)) {
+                // we introduce a placeholder state handle, that is replaced with the
+                // original from the shared state registry (created from a previous checkpoint)
+                return Optional.of(new PlaceholderStreamStateHandle());
+            } else {
+                // If the file was uploaded but not confirmed by JM the handle has to be resent
+                // because JM might lose it during changing the leadership
+                StreamStateHandle value = uploadedSstFiles.get(stateHandleID);
+                if (value != null) {
+                    LOG.trace("Using uploaded non-confirmed file: {}", value);
+                }
+                return Optional.ofNullable(value);
+            }
+        }
+
+        private boolean isConfirmed(StateHandleID stateHandleID) {
+            return confirmedSstFiles != null && confirmedSstFiles.contains(stateHandleID);
         }
     }
 }

--- a/flink-state-backends/flink-statebackend-rocksdb/src/test/java/org/apache/flink/contrib/streaming/state/EmbeddedRocksDBStateBackendTest.java
+++ b/flink-state-backends/flink-statebackend-rocksdb/src/test/java/org/apache/flink/contrib/streaming/state/EmbeddedRocksDBStateBackendTest.java
@@ -585,14 +585,15 @@ public class EmbeddedRocksDBStateBackendTest
                     Map<StateHandleID, StreamStateHandle> sharedState =
                             new HashMap<>(stateHandle.getSharedState());
 
-                    stateHandle.registerSharedStates(sharedStateRegistry);
+                    stateHandle.registerSharedStates(sharedStateRegistry, checkpointId);
 
                     for (Map.Entry<StateHandleID, StreamStateHandle> e : sharedState.entrySet()) {
                         verify(sharedStateRegistry)
                                 .registerReference(
                                         stateHandle.createSharedStateRegistryKeyFromFileName(
                                                 e.getKey()),
-                                        e.getValue());
+                                        e.getValue(),
+                                        checkpointId);
                     }
 
                     previousStateHandles.add(stateHandle);

--- a/flink-state-backends/flink-statebackend-rocksdb/src/test/java/org/apache/flink/contrib/streaming/state/EmbeddedRocksDBStateBackendTest.java
+++ b/flink-state-backends/flink-statebackend-rocksdb/src/test/java/org/apache/flink/contrib/streaming/state/EmbeddedRocksDBStateBackendTest.java
@@ -34,6 +34,7 @@ import org.apache.flink.runtime.state.ConfigurableStateBackend;
 import org.apache.flink.runtime.state.IncrementalRemoteKeyedStateHandle;
 import org.apache.flink.runtime.state.KeyedStateHandle;
 import org.apache.flink.runtime.state.SharedStateRegistry;
+import org.apache.flink.runtime.state.SharedStateRegistryImpl;
 import org.apache.flink.runtime.state.SnapshotResult;
 import org.apache.flink.runtime.state.StateBackendTestBase;
 import org.apache.flink.runtime.state.StateHandleID;
@@ -558,7 +559,7 @@ public class EmbeddedRocksDBStateBackendTest
                                 VoidNamespace.INSTANCE, VoidNamespaceSerializer.INSTANCE, kvId);
 
                 Queue<IncrementalRemoteKeyedStateHandle> previousStateHandles = new LinkedList<>();
-                SharedStateRegistry sharedStateRegistry = spy(new SharedStateRegistry());
+                SharedStateRegistry sharedStateRegistry = spy(new SharedStateRegistryImpl());
                 for (int checkpointId = 0; checkpointId < 3; ++checkpointId) {
 
                     reset(sharedStateRegistry);

--- a/flink-state-backends/flink-statebackend-rocksdb/src/test/java/org/apache/flink/contrib/streaming/state/EmbeddedRocksDBStateBackendTest.java
+++ b/flink-state-backends/flink-statebackend-rocksdb/src/test/java/org/apache/flink/contrib/streaming/state/EmbeddedRocksDBStateBackendTest.java
@@ -602,7 +602,7 @@ public class EmbeddedRocksDBStateBackendTest
                     // -----------------------------------------------------------------
 
                     if (previousStateHandles.size() > 1) {
-                        checkRemove(previousStateHandles.remove(), sharedStateRegistry);
+                        previousStateHandles.remove().discardState();
                     }
                 }
 
@@ -610,27 +610,12 @@ public class EmbeddedRocksDBStateBackendTest
 
                     reset(sharedStateRegistry);
 
-                    checkRemove(previousStateHandles.remove(), sharedStateRegistry);
+                    previousStateHandles.remove().discardState();
                 }
             } finally {
                 IOUtils.closeQuietly(backend);
                 backend.dispose();
             }
-        }
-    }
-
-    private void checkRemove(IncrementalRemoteKeyedStateHandle remove, SharedStateRegistry registry)
-            throws Exception {
-        for (StateHandleID id : remove.getSharedState().keySet()) {
-            verify(registry, times(0))
-                    .unregisterReference(remove.createSharedStateRegistryKeyFromFileName(id));
-        }
-
-        remove.discardState();
-
-        for (StateHandleID id : remove.getSharedState().keySet()) {
-            verify(registry)
-                    .unregisterReference(remove.createSharedStateRegistryKeyFromFileName(id));
         }
     }
 

--- a/flink-streaming-java/src/test/java/org/apache/flink/streaming/runtime/tasks/StreamTaskTest.java
+++ b/flink-streaming-java/src/test/java/org/apache/flink/streaming/runtime/tasks/StreamTaskTest.java
@@ -2371,7 +2371,7 @@ public class StreamTaskTest extends TestLogger {
         }
 
         @Override
-        public void registerSharedStates(SharedStateRegistry stateRegistry) {}
+        public void registerSharedStates(SharedStateRegistry stateRegistry, long checkpointID) {}
 
         @Override
         public void discardState() {


### PR DESCRIPTION
This PR depends on: #17179 to use `SharedStateStrategy` in `CompletedCheckpointStore`.

## What is the purpose of the change

Prevent JM from deleting state when a checkpoint is aborted.
For that, reference counts in `SharedStateStrategy` are replaced with `latestUsingCheckpointID`.
Please see JIRA description for more details: FLINK-24611.

## Verifying this change
- Added `CheckpointCoordinatorTest.testSharedStateNotDiscaredOnAbort` to cover the end goal scenario
- Existing tests: `CheckpointCoordinatorTest`, `DefaultCompletedCheckpointStoreTest`, `IncrementalRemoteKeyedStateHandleTest`;

## Brief change log

- Copied from #17179 (please ignore it in review):
`[FLINK-24086][checkpoint] Rebuilding the SharedStateRegistry only when the restore method is called for the first time.`

- Not very significant changes that touch many files:
` [hotfix][runtime] Extract SharedStateRegistry interface `
` [FLINK-24611] Pass checkpoint ID to SharedStateRegistry `

- Mostly changes `CheckpointCoordinator`:
` [FLINK-24611] Register shared state on checkpoint ACK `

- Mostly changes `SharedStateStrategy` and state handles:
` [FLINK-24611] Discard shared state on checkpoint subsumption `

- Mostly changes `CompletedCheckpointStore`:
` [FLINK-24611] Discard shared state on job termination `

- Mostly changes  RocksDB snapshot strategy - should probably be extracted into a separate ticket and PR:
` [FLINK-24611] Don't re-upload unconfirmed RocksDB SST `
(no tests yet since some aspects are being discussed (placeholder))

- Mostly changes `SharedStateStrategy` and state handles:
`[FLINK-24611] Adjust shared state entry de-duplication`

## Does this pull request potentially affect one of the following parts:

  - Dependencies (does it add or upgrade a dependency): no
  - The public API, i.e., is any changed class annotated with `@Public(Evolving)`: no
  - The serializers: no
  - The runtime per-record code paths (performance sensitive): no
  - Anything that affects deployment or recovery: JobManager (and its components), Checkpointing, Kubernetes/Yarn/Mesos, ZooKeeper: yes
  - The S3 file system connector: no

## Documentation

  - Does this pull request introduce a new feature? no
  - If yes, how is the feature documented? no
