### PR TITLE
[FLINK-24886][core] TimeUtils supports the form of m.

### DIFF
--- a/flink-core/src/main/java/org/apache/flink/util/TimeUtils.java
+++ b/flink-core/src/main/java/org/apache/flink/util/TimeUtils.java
@@ -50,7 +50,7 @@ public class TimeUtils {
      * <ul>
      *   <li>DAYS： "d", "day"
      *   <li>HOURS： "h", "hour"
-     *   <li>MINUTES： "min", "minute"
+     *   <li>MINUTES： "m", "min", "minute"
      *   <li>SECONDS： "s", "sec", "second"
      *   <li>MILLISECONDS： "ms", "milli", "millisecond"
      *   <li>MICROSECONDS： "µs", "micro", "microsecond"
@@ -178,7 +178,7 @@ public class TimeUtils {
     private enum TimeUnit {
         DAYS(ChronoUnit.DAYS, singular("d"), plural("day")),
         HOURS(ChronoUnit.HOURS, singular("h"), plural("hour")),
-        MINUTES(ChronoUnit.MINUTES, singular("min"), plural("minute")),
+        MINUTES(ChronoUnit.MINUTES, singular("m"), singular("min"), plural("minute")),
         SECONDS(ChronoUnit.SECONDS, singular("s"), plural("sec"), plural("second")),
         MILLISECONDS(ChronoUnit.MILLIS, singular("ms"), plural("milli"), plural("millisecond")),
         MICROSECONDS(ChronoUnit.MICROS, singular("µs"), plural("micro"), plural("microsecond")),

--- a/flink-core/src/main/java/org/apache/flink/util/TimeUtils.java
+++ b/flink-core/src/main/java/org/apache/flink/util/TimeUtils.java
@@ -178,7 +178,7 @@ public class TimeUtils {
     private enum TimeUnit {
         DAYS(ChronoUnit.DAYS, singular("d"), plural("day")),
         HOURS(ChronoUnit.HOURS, singular("h"), plural("hour")),
-        MINUTES(ChronoUnit.MINUTES, singular("m"), singular("min"), plural("minute")),
+        MINUTES(ChronoUnit.MINUTES, singular("min"), singular("m"), plural("minute")),
         SECONDS(ChronoUnit.SECONDS, singular("s"), plural("sec"), plural("second")),
         MILLISECONDS(ChronoUnit.MILLIS, singular("ms"), plural("milli"), plural("millisecond")),
         MICROSECONDS(ChronoUnit.MICROS, singular("µs"), plural("micro"), plural("microsecond")),

--- a/flink-core/src/test/java/org/apache/flink/util/TimeUtilsTest.java
+++ b/flink-core/src/test/java/org/apache/flink/util/TimeUtilsTest.java
@@ -78,6 +78,7 @@ public class TimeUtilsTest {
 
     @Test
     public void testParseDurationMinutes() {
+        assertEquals(7657623, TimeUtils.parseDuration("7657623m").toMinutes());
         assertEquals(7657623, TimeUtils.parseDuration("7657623min").toMinutes());
         assertEquals(7657623, TimeUtils.parseDuration("7657623minute").toMinutes());
         assertEquals(7657623, TimeUtils.parseDuration("7657623minutes").toMinutes());


### PR DESCRIPTION
## What is the purpose of the change

*TimeUtils supports the form of m, which fits user habits*
