### PR TITLE
[FLINK-24887][rest] Triggers do not check previous result 

### DIFF
--- a/flink-runtime/src/main/java/org/apache/flink/runtime/rest/handler/async/CompletedOperationCache.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/rest/handler/async/CompletedOperationCache.java
@@ -157,6 +157,12 @@ public class CompletedOperationCache<K extends OperationKey, R> implements AutoC
         return terminationFuture == null;
     }
 
+    /** Returns whether this cache contains an operation under the given operation key. */
+    public boolean containsOperation(final K operationKey) {
+        return registeredOperationTriggers.containsKey(operationKey)
+                || completedOperations.getIfPresent(operationKey) != null;
+    }
+
     /**
      * Returns an optional containing the {@link OperationResult} for the specified key, or an empty
      * optional if no operation is registered under the key.


### PR DESCRIPTION
With this PR we no longer check the result of a previous operation when a new one is trigger under the same key. This made error-handling more complicated and, in the case of application clusters, could lead to an early shutdown.