### PR TITLE
[FLINK-24580][Connectors/Kinesis] Make ConnectTimeoutException recoverable

### DIFF
--- a/flink-connectors/flink-connector-kinesis/src/main/java/org/apache/flink/streaming/connectors/kinesis/proxy/KinesisProxy.java
+++ b/flink-connectors/flink-connector-kinesis/src/main/java/org/apache/flink/streaming/connectors/kinesis/proxy/KinesisProxy.java
@@ -45,6 +45,7 @@ import com.amazonaws.services.kinesis.model.ResourceNotFoundException;
 import com.amazonaws.services.kinesis.model.Shard;
 import com.amazonaws.services.kinesis.model.ShardIteratorType;
 import com.amazonaws.services.kinesis.model.StreamStatus;
+import org.apache.http.conn.ConnectTimeoutException;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
@@ -420,6 +421,8 @@ public class KinesisProxy implements KinesisProxyInterface {
     protected boolean isRecoverableSdkClientException(SdkClientException ex) {
         if (ex instanceof AmazonServiceException) {
             return KinesisProxy.isRecoverableException((AmazonServiceException) ex);
+        } else if (ex.getCause() instanceof ConnectTimeoutException) {
+            return true;
         }
         // customizations may decide to retry other errors, such as read timeouts
         return false;

--- a/flink-connectors/flink-connector-kinesis/src/main/java/org/apache/flink/streaming/connectors/kinesis/proxy/KinesisProxy.java
+++ b/flink-connectors/flink-connector-kinesis/src/main/java/org/apache/flink/streaming/connectors/kinesis/proxy/KinesisProxy.java
@@ -22,6 +22,7 @@ import org.apache.flink.streaming.connectors.kinesis.config.ConsumerConfigConsta
 import org.apache.flink.streaming.connectors.kinesis.model.StreamShardHandle;
 import org.apache.flink.streaming.connectors.kinesis.util.AWSUtil;
 import org.apache.flink.streaming.connectors.kinesis.util.KinesisConfigUtil;
+import org.apache.flink.util.ExceptionUtils;
 
 import com.amazonaws.AmazonServiceException;
 import com.amazonaws.ClientConfiguration;
@@ -45,12 +46,12 @@ import com.amazonaws.services.kinesis.model.ResourceNotFoundException;
 import com.amazonaws.services.kinesis.model.Shard;
 import com.amazonaws.services.kinesis.model.ShardIteratorType;
 import com.amazonaws.services.kinesis.model.StreamStatus;
-import org.apache.http.conn.ConnectTimeoutException;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
 import javax.annotation.Nullable;
 
+import java.net.SocketTimeoutException;
 import java.util.ArrayList;
 import java.util.Date;
 import java.util.List;
@@ -421,7 +422,7 @@ public class KinesisProxy implements KinesisProxyInterface {
     protected boolean isRecoverableSdkClientException(SdkClientException ex) {
         if (ex instanceof AmazonServiceException) {
             return KinesisProxy.isRecoverableException((AmazonServiceException) ex);
-        } else if (ex.getCause() instanceof ConnectTimeoutException) {
+        } else if (ExceptionUtils.findThrowable(ex, SocketTimeoutException.class).isPresent()) {
             return true;
         }
         // customizations may decide to retry other errors, such as read timeouts

--- a/flink-connectors/flink-connector-kinesis/src/test/java/org/apache/flink/streaming/connectors/kinesis/proxy/KinesisProxyTest.java
+++ b/flink-connectors/flink-connector-kinesis/src/test/java/org/apache/flink/streaming/connectors/kinesis/proxy/KinesisProxyTest.java
@@ -38,6 +38,7 @@ import com.amazonaws.services.kinesis.model.ListShardsResult;
 import com.amazonaws.services.kinesis.model.ProvisionedThroughputExceededException;
 import com.amazonaws.services.kinesis.model.Shard;
 import org.apache.commons.lang3.mutable.MutableInt;
+import org.apache.http.conn.ConnectTimeoutException;
 import org.hamcrest.Description;
 import org.hamcrest.TypeSafeDiagnosingMatcher;
 import org.junit.Assert;
@@ -71,6 +72,15 @@ import static org.mockito.hamcrest.MockitoHamcrest.argThat;
 
 /** Test for methods in the {@link KinesisProxy} class. */
 public class KinesisProxyTest {
+
+    @Test
+    public void testIsRecoverableExceptionWithConnectError() {
+        Properties kinesisConsumerConfig = new Properties();
+        kinesisConsumerConfig.setProperty(ConsumerConfigConstants.AWS_REGION, "us-east-1");
+        KinesisProxy kinesisProxy = new KinesisProxy(kinesisConsumerConfig);
+        final SdkClientException ex = new SdkClientException("asdf", new ConnectTimeoutException());
+        assertTrue(kinesisProxy.isRecoverableSdkClientException(ex));
+    }
 
     @Test
     public void testIsRecoverableExceptionWithProvisionedThroughputExceeded() {

--- a/flink-connectors/flink-connector-kinesis/src/test/java/org/apache/flink/streaming/connectors/kinesis/proxy/KinesisProxyTest.java
+++ b/flink-connectors/flink-connector-kinesis/src/test/java/org/apache/flink/streaming/connectors/kinesis/proxy/KinesisProxyTest.java
@@ -38,6 +38,7 @@ import com.amazonaws.services.kinesis.model.ListShardsResult;
 import com.amazonaws.services.kinesis.model.ProvisionedThroughputExceededException;
 import com.amazonaws.services.kinesis.model.Shard;
 import org.apache.commons.lang3.mutable.MutableInt;
+import org.apache.http.HttpHost;
 import org.apache.http.conn.ConnectTimeoutException;
 import org.hamcrest.Description;
 import org.hamcrest.TypeSafeDiagnosingMatcher;
@@ -48,6 +49,8 @@ import org.mockito.invocation.InvocationOnMock;
 import org.mockito.stubbing.Answer;
 import org.powermock.reflect.Whitebox;
 
+import java.net.InetAddress;
+import java.net.UnknownHostException;
 import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.Collections;
@@ -74,11 +77,19 @@ import static org.mockito.hamcrest.MockitoHamcrest.argThat;
 public class KinesisProxyTest {
 
     @Test
-    public void testIsRecoverableExceptionWithConnectError() {
+    public void testIsRecoverableExceptionWithConnectError() throws UnknownHostException {
         Properties kinesisConsumerConfig = new Properties();
         kinesisConsumerConfig.setProperty(ConsumerConfigConstants.AWS_REGION, "us-east-1");
         KinesisProxy kinesisProxy = new KinesisProxy(kinesisConsumerConfig);
-        final SdkClientException ex = new SdkClientException("asdf", new ConnectTimeoutException());
+        final SdkClientException ex =
+                new SdkClientException(
+                        "Unable to execute HTTP request",
+                        new ConnectTimeoutException(
+                                new java.net.SocketTimeoutException("connect timed out"),
+                                new HttpHost("kinesis.us-east-1.amazonaws.com", 443),
+                                InetAddress.getByAddress(
+                                        "kinesis.us-east-1.amazonaws.com",
+                                        new byte[] {3, 91, (byte) 171, (byte) 253})));
         assertTrue(kinesisProxy.isRecoverableSdkClientException(ex));
     }
 


### PR DESCRIPTION
## What is the purpose of the change

High-volume Kinesis consumers can sporadically get Connect errors when connecting to the Kinesis endpoint.
Current behavior is to consider this a fatal error, causing Flink to roll back to previous checkpoint. However retries will typically lead to success, so this patch causes connect errors to be considered recoverable.

## Brief change log

- Make ConnectTimeoutException recoverable
- Unit test for above

## Verifying this change

- New unit test
- Applying this patch has allowed one of our Flink jobs to run continuously, instead of failing several times per day.

## Does this pull request potentially affect one of the following parts:

  - Dependencies (does it add or upgrade a dependency): no
  - The public API, i.e., is any changed class annotated with `@Public(Evolving)`: no
  - The serializers: no
  - The runtime per-record code paths (performance sensitive): no
  - Anything that affects deployment or recovery: JobManager (and its components), Checkpointing, Kubernetes/Yarn, ZooKeeper: no
  - The S3 file system connector: no

## Documentation

  - Does this pull request introduce a new feature? no
  - If yes, how is the feature documented? not applicable
