### PR TITLE
[FLINK-24869][BuildSystem] flink-core should be provided in flink-file-sink-common

### DIFF
--- a/flink-connectors/flink-file-sink-common/pom.xml
+++ b/flink-connectors/flink-file-sink-common/pom.xml
@@ -39,6 +39,7 @@ under the License.
 			<groupId>org.apache.flink</groupId>
 			<artifactId>flink-core</artifactId>
 			<version>${project.version}</version>
+			<scope>provided</scope>
 		</dependency>
 	</dependencies>
 


### PR DESCRIPTION
As example flink-connector-files brings flink-core with compile scope via flink-file-sink-common.