### PR TITLE
[FLINK-24891][METRICS] PrometheusPushGatewayReporter support filter label keys

### DIFF
--- a/flink-metrics/flink-metrics-prometheus/src/main/java/org/apache/flink/metrics/prometheus/PrometheusPushGatewayReporterOptions.java
+++ b/flink-metrics/flink-metrics-prometheus/src/main/java/org/apache/flink/metrics/prometheus/PrometheusPushGatewayReporterOptions.java
@@ -93,4 +93,15 @@ public class PrometheusPushGatewayReporterOptions {
                                                     "https://prometheus.io/docs/concepts/data_model/#metric-names-and-labels",
                                                     "Prometheus requirements"))
                                     .build());
+
+    public static final ConfigOption<String> FILTER_LABEL_KEYS =
+            ConfigOptions.key("filterLabelKeys")
+                    .defaultValue("")
+                    .withDescription(
+                            Description.builder()
+                                    .text(
+                                            "Specifies whether to filter label keys."
+                                                    + "The label keys are separated by ';', e.g., %s.",
+                                            TextElement.code("k1;k2"))
+                                    .build());
 }

--- a/flink-metrics/flink-metrics-prometheus/src/test/java/org/apache/flink/metrics/prometheus/PrometheusPushGatewayReporterTest.java
+++ b/flink-metrics/flink-metrics-prometheus/src/test/java/org/apache/flink/metrics/prometheus/PrometheusPushGatewayReporterTest.java
@@ -23,6 +23,7 @@ import org.apache.flink.util.TestLogger;
 import org.junit.Assert;
 import org.junit.Test;
 
+import java.util.List;
 import java.util.Map;
 
 /** Test for {@link PrometheusPushGatewayReporter}. */
@@ -48,5 +49,14 @@ public class PrometheusPushGatewayReporterTest extends TestLogger {
 
         groupingKey = PrometheusPushGatewayReporterFactory.parseGroupingKey("k1");
         Assert.assertTrue(groupingKey.isEmpty());
+    }
+
+    @Test
+    public void testParseFilterLabelKeys() {
+        List<String> filterLabelKey =
+                AbstractPrometheusReporter.parseFilterLabelKeys("k1;k2");
+        Assert.assertNotNull(filterLabelKey);
+        Assert.assertEquals("k1", filterLabelKey.get(0));
+        Assert.assertEquals("k2", filterLabelKey.get(1));
     }
 }


### PR DESCRIPTION
## What is the purpose of the change

This pull request makes PrometheusPushGatewayReporter support filter label keys, 


## Brief change log

1. Add parameter filterLabelKeys
2. notifyOfAddedMetric adds conditional filtering


## Verifying this change

1. Add parameter filterLabelKeys
2. notifyOfAddedMetric adds conditional filtering

## Does this pull request potentially affect one of the following parts:

  - Dependencies (does it add or upgrade a dependency): (no)
  - The public API, i.e., is any changed class annotated with `@Public(Evolving)`: (no)
  - The serializers: (no)
  - The runtime per-record code paths (performance sensitive): (no)
  - Anything that affects deployment or recovery: JobManager (and its components), Checkpointing, Kubernetes/Yarn, ZooKeeper: (no)
  - The S3 file system connector: (no)

## Documentation

  - Does this pull request introduce a new feature? (yes)
  - If yes, how is the feature documented? (JavaDocs)
