### PR TITLE
[FLINK-24885][table-runtime] Fix NullPointerException in SinkConversion and OutputConversion when row time is null

### DIFF
--- a/flink-table/flink-table-planner/src/main/scala/org/apache/flink/table/planner/codegen/OperatorCodeGenerator.scala
+++ b/flink-table/flink-table-planner/src/main/scala/org/apache/flink/table/planner/codegen/OperatorCodeGenerator.scala
@@ -262,5 +262,13 @@ object OperatorCodeGenerator extends Logging {
     s"$DEFAULT_OPERATOR_COLLECTOR_TERM.collect($OUT_ELEMENT.replace($emit));"
 
   def generateCollectWithTimestamp(emit: String, timestampTerm: String): String =
-    s"$DEFAULT_OPERATOR_COLLECTOR_TERM.collect($OUT_ELEMENT.replace($emit, $timestampTerm));"
+    s"""
+       |if ($timestampTerm == null) {
+       |  $OUT_ELEMENT.eraseTimestamp();
+       |  $DEFAULT_OPERATOR_COLLECTOR_TERM.collect($OUT_ELEMENT.replace($emit));
+       |} else {
+       |  $DEFAULT_OPERATOR_COLLECTOR_TERM.collect(
+       |    $OUT_ELEMENT.replace($emit, $timestampTerm.getMillisecond()));
+       |}
+       |""".stripMargin
 }

--- a/flink-table/flink-table-planner/src/main/scala/org/apache/flink/table/planner/codegen/SinkCodeGenerator.scala
+++ b/flink-table/flink-table-planner/src/main/scala/org/apache/flink/table/planner/codegen/SinkCodeGenerator.scala
@@ -26,7 +26,7 @@ import org.apache.flink.api.java.typeutils.{PojoTypeInfo, TupleTypeInfo}
 import org.apache.flink.api.scala.createTuple2TypeInformation
 import org.apache.flink.table.api.TableException
 import org.apache.flink.table.data.util.RowDataUtil
-import org.apache.flink.table.data.{GenericRowData, RowData}
+import org.apache.flink.table.data.{GenericRowData, RowData, TimestampData}
 import org.apache.flink.table.planner.codegen.CodeGenUtils.genToExternalConverterWithLegacy
 import org.apache.flink.table.planner.codegen.GeneratedExpression.NO_CODE
 import org.apache.flink.table.planner.codegen.OperatorCodeGenerator.{generateCollect, generateCollectWithTimestamp}
@@ -168,9 +168,9 @@ object SinkCodeGenerator {
     if (modifiedRowtimeIndex >= 0) {
       val rowtimeTerm = CodeGenUtils.newName("rowtime")
       s"""
-         | Long $rowtimeTerm =
-         | $afterIndexModify.getTimestamp($modifiedRowtimeIndex, 3).getMillisecond();
-         | ${generateCollectWithTimestamp(resultTerm, rowtimeTerm)}
+         |${classOf[TimestampData].getCanonicalName} $rowtimeTerm =
+         |  $afterIndexModify.getTimestamp($modifiedRowtimeIndex, 3);
+         |${generateCollectWithTimestamp(resultTerm, rowtimeTerm)}
           """.stripMargin
     } else {
       generateCollect(resultTerm)


### PR DESCRIPTION
## What is the purpose of the change

Currently `SinkConversion` (generated code) and `OutputConversionOperator` are not handling the case when row time is null. This PR fixes the issue.

## Brief change log

 - Fix NullPointerException in SinkConversion and OutputConversion when row time is null.

## Verifying this change

This change added tests and can be verified by running the added tests.

## Does this pull request potentially affect one of the following parts:

  - Dependencies (does it add or upgrade a dependency): no
  - The public API, i.e., is any changed class annotated with `@Public(Evolving)`: no
  - The serializers: no
  - The runtime per-record code paths (performance sensitive): no
  - Anything that affects deployment or recovery: JobManager (and its components), Checkpointing, Kubernetes/Yarn, ZooKeeper: no
  - The S3 file system connector: no

## Documentation

  - Does this pull request introduce a new feature? no
  - If yes, how is the feature documented? not applicable
