### PR TITLE
added the definition of done to the github templates

### DIFF
--- a/.github/CONTRIBUTING.md
+++ b/.github/CONTRIBUTING.md
@@ -9,3 +9,4 @@ To make the process smooth for the project *committers* (those who review and ac
 Please check out the [How to Contribute guide](https://flink.apache.org/contributing/how-to-contribute.html) to understand how contributions are made.
 A detailed explanation can be found in our [Contribute Code Guide](https://flink.apache.org/contributing/contribute-code.html) which also contains a list of coding guidelines that you should follow.
 For pull requests, there is a [check list](PULL_REQUEST_TEMPLATE.md) with criteria taken from the How to Contribute Guide and the Coding Guidelines.
+In order to get the change merged make sure the [Definition of Done](https://flink.apache.org/contributing/contribute-code.html#definition-of-done) is fullfilled.

--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -70,3 +70,12 @@ This change added tests and can be verified as follows:
 
   - Does this pull request introduce a new feature? (yes / no)
   - If yes, how is the feature documented? (not applicable / docs / JavaDocs / not documented)
+  - If no, was the documentation adjusted? (yes / no)
+
+## Definition of Done
+
+1. The implementation is following the [code contribution process](#code-contribution-process). (yes / no)
+2. It is implemented according to the [code style and quality guide]({{ site.base }}/contributing/code-style-and-quality-preamble.html). (yes / no)
+3. In case of user facing changes the documentation has been updated acording to the [documentation style guide]({{ site.base }}/contributing/docs-style.html). (yes / no)
+4. The PR is covered by tests. (yes / no)
+5. All tests passed. (yes / no)


### PR DESCRIPTION
This is a companion PR for the one i just created in the flink-web repo to introduce a definition of done: https://github.com/apache/flink-web/pull/481

> To increase awareness for coding standards, test and documentation we are suggesting to introduce a definition of done.
> 
> The goal of this initiative:
> 
> increase the stability of master
> increase test coverage
> increase awareness for code quality
> improve documentation