### PR TITLE
[FLINK-24376][runtime] Use operator name for constructing OperatorCoordinatorProvider instead of chained name

### DIFF
--- a/flink-streaming-java/src/main/java/org/apache/flink/streaming/api/graph/StreamingJobGraphGenerator.java
+++ b/flink-streaming-java/src/main/java/org/apache/flink/streaming/api/graph/StreamingJobGraphGenerator.java
@@ -437,7 +437,9 @@ public class StreamingJobGraphGenerator {
                     createChainedPreferredResources(currentNodeId, chainableOutputs));
 
             OperatorID currentOperatorId =
-                    chainInfo.addNodeToChain(currentNodeId, chainedNames.get(currentNodeId));
+                    chainInfo.addNodeToChain(
+                            currentNodeId,
+                            streamGraph.getStreamNode(currentNodeId).getOperatorName());
 
             if (currentNode.getInputFormat() != null) {
                 getOrCreateFormatContainer(startNodeId)


### PR DESCRIPTION
Unchanged back port of #17355 on release-1.13