### PR TITLE
[hotfix][e2e] Adds missing quotes

### DIFF
--- a/flink-end-to-end-tests/run-nightly-tests.sh
+++ b/flink-end-to-end-tests/run-nightly-tests.sh
@@ -265,9 +265,9 @@ function run_group_2 {
     EXIT_CODE=$?
 }
 
-if [ $1 == "1" ]; then
+if [ "$1" == "1" ]; then
     run_group_1
-elif [ $1 == "2" ]; then
+elif [ "$1" == "2" ]; then
     run_group_2
 else
     run_group_1


### PR DESCRIPTION
There's going to be a parsing issue reported if no parameter is passed due to
the if condition being rendered to [ == '1' ]. Adding the quotes fixes this
problem.

This is not really an issue in CI because we always pass a parameter. The `README.md`, though, still states calling this script without a parameter which reveals the issue.

## What is the purpose of the change

Fixing this issue removes the warning that is printed when calling `flink-end-to-end-tests/run-nightly-tests.sh` without a parameter:
```
$ FLINK_DIR=build-target/ ./flink-end-to-end-tests/run-nightly-tests.sh
[...]
==============================================================================
Running bash end-to-end tests
==============================================================================
flink-end-to-end-tests/run-nightly-tests.sh: line 268: [: ==: unary operator expected
flink-end-to-end-tests/run-nightly-tests.sh: line 270: [: ==: unary operator expected
[...]
```

## Brief change log

Adds quotes


## Verifying this change

Testted manually

## Does this pull request potentially affect one of the following parts:

  - Dependencies (does it add or upgrade a dependency): no
  - The public API, i.e., is any changed class annotated with `@Public(Evolving)`: no
  - The serializers: no
  - The runtime per-record code paths (performance sensitive): no
  - Anything that affects deployment or recovery: JobManager (and its components), Checkpointing, Kubernetes/Yarn, ZooKeeper: no
  - The S3 file system connector: no

## Documentation

  - Does this pull request introduce a new feature? no
  - If yes, how is the feature documented? not applicable
