### PR TITLE
[FLINK-22702][tests] Add test data supplier which provide null timestamp field to kafka connector tests

### DIFF
--- a/flink-connectors/flink-connector-kafka/src/main/java/org/apache/flink/connector/kafka/source/split/KafkaPartitionSplit.java
+++ b/flink-connectors/flink-connector-kafka/src/main/java/org/apache/flink/connector/kafka/source/split/KafkaPartitionSplit.java
@@ -32,9 +32,9 @@ import java.util.Set;
 /** A {@link SourceSplit} for a Kafka partition. */
 public class KafkaPartitionSplit implements SourceSplit {
     public static final long NO_STOPPING_OFFSET = Long.MIN_VALUE;
-    // Indicating the split should consume from the earliest.
-    public static final long LATEST_OFFSET = -1;
     // Indicating the split should consume from the latest.
+    public static final long LATEST_OFFSET = -1;
+    // Indicating the split should consume from the earliest.
     public static final long EARLIEST_OFFSET = -2;
     // Indicating the split should consume from the last committed offset.
     public static final long COMMITTED_OFFSET = -3;

--- a/flink-connectors/flink-connector-kafka/src/test/java/org/apache/flink/connector/kafka/source/KafkaSourceITCase.java
+++ b/flink-connectors/flink-connector-kafka/src/test/java/org/apache/flink/connector/kafka/source/KafkaSourceITCase.java
@@ -64,8 +64,10 @@ public class KafkaSourceITCase {
     @BeforeClass
     public static void setup() throws Throwable {
         KafkaSourceTestEnv.setup();
-        KafkaSourceTestEnv.setupTopic(TOPIC1, true, true);
-        KafkaSourceTestEnv.setupTopic(TOPIC2, true, true);
+        KafkaSourceTestEnv.setupTopic(
+                TOPIC1, true, true, KafkaSourceTestEnv::getRecordsForTopicWithoutTimestamp);
+        KafkaSourceTestEnv.setupTopic(
+                TOPIC2, true, true, KafkaSourceTestEnv::getRecordsForTopicWithoutTimestamp);
     }
 
     @AfterClass
@@ -76,12 +78,13 @@ public class KafkaSourceITCase {
     @Test
     public void testTimestamp() throws Throwable {
         final String topic = "testTimestamp";
+        final long currentTimestamp = System.currentTimeMillis();
         KafkaSourceTestEnv.createTestTopic(topic, 1, 1);
         KafkaSourceTestEnv.produceToKafka(
                 Arrays.asList(
-                        new ProducerRecord<>(topic, 0, 1L, "key0", 0),
-                        new ProducerRecord<>(topic, 0, 2L, "key1", 1),
-                        new ProducerRecord<>(topic, 0, 3L, "key2", 2)));
+                        new ProducerRecord<>(topic, 0, currentTimestamp + 1L, "key0", 0),
+                        new ProducerRecord<>(topic, 0, currentTimestamp + 2L, "key1", 1),
+                        new ProducerRecord<>(topic, 0, currentTimestamp + 3L, "key2", 2)));
 
         KafkaSource<PartitionAndValue> source =
                 KafkaSource.<PartitionAndValue>builder()
@@ -106,7 +109,9 @@ public class KafkaSourceITCase {
         stream.addSink(new DiscardingSink<>());
         JobExecutionResult result = env.execute();
 
-        assertEquals(Arrays.asList(1L, 2L, 3L), result.getAccumulatorResult("timestamp"));
+        assertEquals(
+                Arrays.asList(currentTimestamp + 1L, currentTimestamp + 2L, currentTimestamp + 3L),
+                result.getAccumulatorResult("timestamp"));
     }
 
     @Test

--- a/flink-connectors/flink-connector-kafka/src/test/java/org/apache/flink/connector/kafka/source/enumerator/KafkaEnumeratorTest.java
+++ b/flink-connectors/flink-connector-kafka/src/test/java/org/apache/flink/connector/kafka/source/enumerator/KafkaEnumeratorTest.java
@@ -79,8 +79,8 @@ public class KafkaEnumeratorTest {
     @BeforeClass
     public static void setup() throws Throwable {
         KafkaSourceTestEnv.setup();
-        KafkaSourceTestEnv.setupTopic(TOPIC1, true, true);
-        KafkaSourceTestEnv.setupTopic(TOPIC2, true, true);
+        KafkaSourceTestEnv.setupTopic(TOPIC1, true, true, KafkaSourceTestEnv::getRecordsForTopic);
+        KafkaSourceTestEnv.setupTopic(TOPIC2, true, true, KafkaSourceTestEnv::getRecordsForTopic);
     }
 
     @AfterClass

--- a/flink-connectors/flink-connector-kafka/src/test/java/org/apache/flink/connector/kafka/source/enumerator/initializer/OffsetsInitializerTest.java
+++ b/flink-connectors/flink-connector-kafka/src/test/java/org/apache/flink/connector/kafka/source/enumerator/initializer/OffsetsInitializerTest.java
@@ -47,8 +47,8 @@ public class OffsetsInitializerTest {
     @BeforeClass
     public static void setup() throws Throwable {
         KafkaSourceTestEnv.setup();
-        KafkaSourceTestEnv.setupTopic(TOPIC, true, true);
-        KafkaSourceTestEnv.setupTopic(TOPIC2, false, false);
+        KafkaSourceTestEnv.setupTopic(TOPIC, true, true, KafkaSourceTestEnv::getRecordsForTopic);
+        KafkaSourceTestEnv.setupTopic(TOPIC2, false, false, KafkaSourceTestEnv::getRecordsForTopic);
         retriever =
                 new KafkaSourceEnumerator.PartitionOffsetsRetrieverImpl(
                         KafkaSourceTestEnv.getConsumer(),

--- a/flink-connectors/flink-connector-kafka/src/test/java/org/apache/flink/connector/kafka/source/reader/KafkaPartitionSplitReaderTest.java
+++ b/flink-connectors/flink-connector-kafka/src/test/java/org/apache/flink/connector/kafka/source/reader/KafkaPartitionSplitReaderTest.java
@@ -66,8 +66,8 @@ public class KafkaPartitionSplitReaderTest {
     @BeforeClass
     public static void setup() throws Throwable {
         KafkaSourceTestEnv.setup();
-        KafkaSourceTestEnv.setupTopic(TOPIC1, true, true);
-        KafkaSourceTestEnv.setupTopic(TOPIC2, true, true);
+        KafkaSourceTestEnv.setupTopic(TOPIC1, true, true, KafkaSourceTestEnv::getRecordsForTopic);
+        KafkaSourceTestEnv.setupTopic(TOPIC2, true, true, KafkaSourceTestEnv::getRecordsForTopic);
         splitsByOwners =
                 KafkaSourceTestEnv.getSplitsByOwners(Arrays.asList(TOPIC1, TOPIC2), NUM_SUBTASKS);
         earliestOffsets =


### PR DESCRIPTION
This PR cherry-picks the PR from #16974 to the release-1.13 branch.