### PR TITLE
[FLINK-24922][docs] Backport fix spelling errors in the word "parallism"

### DIFF
--- a/docs/content.zh/docs/dev/table/sqlClient.md
+++ b/docs/content.zh/docs/dev/table/sqlClient.md
@@ -437,8 +437,8 @@ SET pipeline.name=SqlJob;
 -- set the queue that the job submit to
 SET yarn.application.queue=root;
 
--- set the job parallism
-SET parallism.default=100;
+-- set the job parallelism
+SET parallelism.default=100;
 
 -- restore from the specific savepoint path
 SET execution.savepoint.path=/tmp/flink-savepoints/savepoint-cca7bc-bb1e257f0dab;

--- a/docs/content/docs/dev/table/sqlClient.md
+++ b/docs/content/docs/dev/table/sqlClient.md
@@ -443,8 +443,8 @@ SET pipeline.name=SqlJob;
 -- set the queue that the job submit to
 SET yarn.application.queue=root;
 
--- set the job parallism
-SET parallism.default=100;
+-- set the job parallelism
+SET parallelism.default=100;
 
 -- restore from the specific savepoint path
 SET execution.savepoint.path=/tmp/flink-savepoints/savepoint-cca7bc-bb1e257f0dab;


### PR DESCRIPTION
## What is the purpose of the change
Fix the spelling error of "parallism" in the document of SQL client.

## Brief change log
  - Replace "parallism" to  "parallelism"  in the document of SQL client.


## Verifying this change

This change is a trivial rework / code cleanup without any test coverage.

## Does this pull request potentially affect one of the following parts:

  - Dependencies (does it add or upgrade a dependency): no
  - The public API, i.e., is any changed class annotated with `@Public(Evolving)`: no
  - The serializers: no
  - The runtime per-record code paths (performance sensitive): no
  - Anything that affects deployment or recovery: JobManager (and its components), Checkpointing, Kubernetes/Yarn, ZooKeeper: no
  - The S3 file system connector: no

## Documentation

  - Does this pull request introduce a new feature? no
  - If yes, how is the feature documented? docs
