### PR TITLE
[FLINK-15816][k8s] Prevent labels using kubernetes.cluster-id to exceed the limit of 63 characters

### DIFF
--- a/flink-kubernetes/src/main/java/org/apache/flink/kubernetes/KubernetesClusterClientFactory.java
+++ b/flink-kubernetes/src/main/java/org/apache/flink/kubernetes/KubernetesClusterClientFactory.java
@@ -26,7 +26,7 @@ import org.apache.flink.configuration.DeploymentOptions;
 import org.apache.flink.kubernetes.configuration.KubernetesConfigOptions;
 import org.apache.flink.kubernetes.configuration.KubernetesDeploymentTarget;
 import org.apache.flink.kubernetes.kubeclient.FlinkKubeClientFactory;
-import org.apache.flink.kubernetes.utils.Constants;
+import org.apache.flink.kubernetes.utils.KubernetesLabel;
 import org.apache.flink.util.AbstractID;
 
 import javax.annotation.Nullable;
@@ -75,7 +75,6 @@ public class KubernetesClusterClientFactory
 
     private String generateClusterId() {
         final String randomID = new AbstractID().toString();
-        return (CLUSTER_ID_PREFIX + randomID)
-                .substring(0, Constants.MAXIMUM_CHARACTERS_OF_CLUSTER_ID);
+        return (CLUSTER_ID_PREFIX + randomID).substring(0, KubernetesLabel.getClusterIdMaxLength());
     }
 }

--- a/flink-kubernetes/src/main/java/org/apache/flink/kubernetes/configuration/KubernetesConfigOptions.java
+++ b/flink-kubernetes/src/main/java/org/apache/flink/kubernetes/configuration/KubernetesConfigOptions.java
@@ -25,6 +25,7 @@ import org.apache.flink.configuration.ConfigOptions;
 import org.apache.flink.configuration.ExternalResourceOptions;
 import org.apache.flink.configuration.description.Description;
 import org.apache.flink.kubernetes.utils.Constants;
+import org.apache.flink.kubernetes.utils.KubernetesLabel;
 import org.apache.flink.runtime.util.EnvironmentInformation;
 
 import java.util.List;
@@ -220,10 +221,14 @@ public class KubernetesConfigOptions {
                     .withDescription(
                             Description.builder()
                                     .text(
-                                            "The cluster-id, which should be no more than 45 characters, is used for identifying a unique Flink cluster. "
+                                            "The cluster-id, which should be no more than %s characters, is used for identifying a unique Flink cluster. "
                                                     + "The id must only contain lowercase alphanumeric characters and \"-\". "
                                                     + "The required format is %s. "
                                                     + "If not set, the client will automatically generate it with a random ID.",
+                                            text(
+                                                    String.valueOf(
+                                                            KubernetesLabel
+                                                                    .getClusterIdMaxLength())),
                                             code("[a-z]([-a-z0-9]*[a-z0-9])"))
                                     .build());
 

--- a/flink-kubernetes/src/main/java/org/apache/flink/kubernetes/kubeclient/decorators/ExternalServiceDecorator.java
+++ b/flink-kubernetes/src/main/java/org/apache/flink/kubernetes/kubeclient/decorators/ExternalServiceDecorator.java
@@ -20,6 +20,7 @@ package org.apache.flink.kubernetes.kubeclient.decorators;
 
 import org.apache.flink.kubernetes.kubeclient.parameters.KubernetesJobManagerParameters;
 import org.apache.flink.kubernetes.utils.Constants;
+import org.apache.flink.kubernetes.utils.KubernetesLabel;
 
 import io.fabric8.kubernetes.api.model.HasMetadata;
 import io.fabric8.kubernetes.api.model.Service;
@@ -69,7 +70,7 @@ public class ExternalServiceDecorator extends AbstractKubernetesStepDecorator {
 
     /** Generate name of the external Service. */
     public static String getExternalServiceName(String clusterId) {
-        return clusterId + Constants.FLINK_REST_SERVICE_SUFFIX;
+        return KubernetesLabel.FLINK_REST_SERVICE.generateWith(clusterId);
     }
 
     /** Generate namespaced name of the external Service. */

--- a/flink-kubernetes/src/main/java/org/apache/flink/kubernetes/kubeclient/decorators/FlinkConfMountDecorator.java
+++ b/flink-kubernetes/src/main/java/org/apache/flink/kubernetes/kubeclient/decorators/FlinkConfMountDecorator.java
@@ -25,6 +25,7 @@ import org.apache.flink.kubernetes.configuration.KubernetesConfigOptions;
 import org.apache.flink.kubernetes.kubeclient.FlinkPod;
 import org.apache.flink.kubernetes.kubeclient.parameters.AbstractKubernetesParameters;
 import org.apache.flink.kubernetes.utils.Constants;
+import org.apache.flink.kubernetes.utils.KubernetesLabel;
 
 import org.apache.flink.shaded.guava30.com.google.common.io.Files;
 
@@ -55,7 +56,6 @@ import java.util.stream.Collectors;
 import static org.apache.flink.configuration.GlobalConfiguration.FLINK_CONF_FILENAME;
 import static org.apache.flink.kubernetes.utils.Constants.CONFIG_FILE_LOG4J_NAME;
 import static org.apache.flink.kubernetes.utils.Constants.CONFIG_FILE_LOGBACK_NAME;
-import static org.apache.flink.kubernetes.utils.Constants.CONFIG_MAP_PREFIX;
 import static org.apache.flink.kubernetes.utils.Constants.FLINK_CONF_VOLUME;
 import static org.apache.flink.util.Preconditions.checkNotNull;
 
@@ -192,6 +192,6 @@ public class FlinkConfMountDecorator extends AbstractKubernetesStepDecorator {
 
     @VisibleForTesting
     public static String getFlinkConfConfigMapName(String clusterId) {
-        return CONFIG_MAP_PREFIX + clusterId;
+        return KubernetesLabel.CONFIG_MAP.generateWith(clusterId);
     }
 }

--- a/flink-kubernetes/src/main/java/org/apache/flink/kubernetes/kubeclient/decorators/HadoopConfMountDecorator.java
+++ b/flink-kubernetes/src/main/java/org/apache/flink/kubernetes/kubeclient/decorators/HadoopConfMountDecorator.java
@@ -21,6 +21,7 @@ package org.apache.flink.kubernetes.kubeclient.decorators;
 import org.apache.flink.kubernetes.kubeclient.FlinkPod;
 import org.apache.flink.kubernetes.kubeclient.parameters.AbstractKubernetesParameters;
 import org.apache.flink.kubernetes.utils.Constants;
+import org.apache.flink.kubernetes.utils.KubernetesLabel;
 import org.apache.flink.util.FileUtils;
 
 import io.fabric8.kubernetes.api.model.ConfigMap;
@@ -202,6 +203,6 @@ public class HadoopConfMountDecorator extends AbstractKubernetesStepDecorator {
     }
 
     public static String getHadoopConfConfigMapName(String clusterId) {
-        return Constants.HADOOP_CONF_CONFIG_MAP_PREFIX + clusterId;
+        return KubernetesLabel.HADOOP_CONF_CONFIG_MAP.generateWith(clusterId);
     }
 }

--- a/flink-kubernetes/src/main/java/org/apache/flink/kubernetes/kubeclient/decorators/KerberosMountDecorator.java
+++ b/flink-kubernetes/src/main/java/org/apache/flink/kubernetes/kubeclient/decorators/KerberosMountDecorator.java
@@ -22,6 +22,7 @@ import org.apache.flink.configuration.SecurityOptions;
 import org.apache.flink.kubernetes.kubeclient.FlinkPod;
 import org.apache.flink.kubernetes.kubeclient.parameters.AbstractKubernetesParameters;
 import org.apache.flink.kubernetes.utils.Constants;
+import org.apache.flink.kubernetes.utils.KubernetesLabel;
 import org.apache.flink.runtime.security.SecurityConfiguration;
 import org.apache.flink.util.StringUtils;
 
@@ -198,10 +199,10 @@ public class KerberosMountDecorator extends AbstractKubernetesStepDecorator {
     }
 
     public static String getKerberosKeytabSecretName(String clusterId) {
-        return Constants.KERBEROS_KEYTAB_SECRET_PREFIX + clusterId;
+        return KubernetesLabel.KERBEROS_KEYTAB_SECRET.generateWith(clusterId);
     }
 
-    public static String getKerberosKrb5confConfigMapName(String clusterID) {
-        return Constants.KERBEROS_KRB5CONF_CONFIG_MAP_PREFIX + clusterID;
+    public static String getKerberosKrb5confConfigMapName(String clusterId) {
+        return KubernetesLabel.KERBEROS_KRB5CONF_CONFIG_MAP.generateWith(clusterId);
     }
 }

--- a/flink-kubernetes/src/main/java/org/apache/flink/kubernetes/kubeclient/decorators/PodTemplateMountDecorator.java
+++ b/flink-kubernetes/src/main/java/org/apache/flink/kubernetes/kubeclient/decorators/PodTemplateMountDecorator.java
@@ -22,6 +22,7 @@ import org.apache.flink.kubernetes.configuration.KubernetesConfigOptions;
 import org.apache.flink.kubernetes.kubeclient.FlinkPod;
 import org.apache.flink.kubernetes.kubeclient.parameters.AbstractKubernetesParameters;
 import org.apache.flink.kubernetes.utils.Constants;
+import org.apache.flink.kubernetes.utils.KubernetesLabel;
 import org.apache.flink.util.FlinkRuntimeException;
 import org.apache.flink.util.function.FunctionUtils;
 
@@ -63,7 +64,8 @@ public class PodTemplateMountDecorator extends AbstractKubernetesStepDecorator {
     public PodTemplateMountDecorator(AbstractKubernetesParameters kubernetesComponentConf) {
         this.kubernetesComponentConf = checkNotNull(kubernetesComponentConf);
         this.podTemplateConfigMapName =
-                Constants.POD_TEMPLATE_CONFIG_MAP_PREFIX + kubernetesComponentConf.getClusterId();
+                KubernetesLabel.POD_TEMPLATE_CONFIG_MAP.generateWith(
+                        kubernetesComponentConf.getClusterId());
     }
 
     @Override

--- a/flink-kubernetes/src/main/java/org/apache/flink/kubernetes/kubeclient/parameters/AbstractKubernetesParameters.java
+++ b/flink-kubernetes/src/main/java/org/apache/flink/kubernetes/kubeclient/parameters/AbstractKubernetesParameters.java
@@ -22,6 +22,7 @@ import org.apache.flink.configuration.Configuration;
 import org.apache.flink.configuration.DeploymentOptionsInternal;
 import org.apache.flink.kubernetes.configuration.KubernetesConfigOptions;
 import org.apache.flink.kubernetes.utils.Constants;
+import org.apache.flink.kubernetes.utils.KubernetesLabel;
 import org.apache.flink.kubernetes.utils.KubernetesUtils;
 
 import io.fabric8.kubernetes.api.model.LocalObjectReference;
@@ -38,6 +39,7 @@ import static org.apache.flink.kubernetes.utils.Constants.CONFIG_FILE_LOG4J_NAME
 import static org.apache.flink.kubernetes.utils.Constants.CONFIG_FILE_LOGBACK_NAME;
 import static org.apache.flink.util.Preconditions.checkArgument;
 import static org.apache.flink.util.Preconditions.checkNotNull;
+import static org.apache.flink.util.StringUtils.isNullOrWhitespaceOnly;
 
 /** Abstract class for the {@link KubernetesParameters}. */
 public abstract class AbstractKubernetesParameters implements KubernetesParameters {
@@ -67,16 +69,16 @@ public abstract class AbstractKubernetesParameters implements KubernetesParamete
     public String getClusterId() {
         final String clusterId = flinkConfig.getString(KubernetesConfigOptions.CLUSTER_ID);
 
-        if (StringUtils.isBlank(clusterId)) {
-            throw new IllegalArgumentException(
-                    KubernetesConfigOptions.CLUSTER_ID.key() + " must not be blank.");
-        } else if (clusterId.length() > Constants.MAXIMUM_CHARACTERS_OF_CLUSTER_ID) {
-            throw new IllegalArgumentException(
-                    KubernetesConfigOptions.CLUSTER_ID.key()
-                            + " must be no more than "
-                            + Constants.MAXIMUM_CHARACTERS_OF_CLUSTER_ID
-                            + " characters.");
-        }
+        checkArgument(
+                !isNullOrWhitespaceOnly(clusterId),
+                "%s must not be blank.",
+                KubernetesConfigOptions.CLUSTER_ID.key());
+        checkArgument(
+                clusterId.length() <= KubernetesLabel.getClusterIdMaxLength(),
+                "%s must be no more than %s characters. Please change %s.",
+                clusterId,
+                KubernetesLabel.getClusterIdMaxLength(),
+                KubernetesConfigOptions.CLUSTER_ID.key());
 
         return clusterId;
     }

--- a/flink-kubernetes/src/main/java/org/apache/flink/kubernetes/utils/Constants.java
+++ b/flink-kubernetes/src/main/java/org/apache/flink/kubernetes/utils/Constants.java
@@ -31,23 +31,17 @@ public class Constants {
     public static final String MAIN_CONTAINER_NAME = "flink-main-container";
 
     public static final String FLINK_CONF_VOLUME = "flink-config-volume";
-    public static final String CONFIG_MAP_PREFIX = "flink-config-";
 
     public static final String HADOOP_CONF_VOLUME = "hadoop-config-volume";
-    public static final String HADOOP_CONF_CONFIG_MAP_PREFIX = "hadoop-config-";
     public static final String HADOOP_CONF_DIR_IN_POD = "/opt/hadoop/conf";
     public static final String ENV_HADOOP_CONF_DIR = "HADOOP_CONF_DIR";
     public static final String ENV_HADOOP_HOME = "HADOOP_HOME";
 
     public static final String KERBEROS_KEYTAB_VOLUME = "kerberos-keytab-volume";
-    public static final String KERBEROS_KEYTAB_SECRET_PREFIX = "kerberos-keytab-";
     public static final String KERBEROS_KEYTAB_MOUNT_POINT = "/opt/kerberos/kerberos-keytab";
     public static final String KERBEROS_KRB5CONF_VOLUME = "kerberos-krb5conf-volume";
-    public static final String KERBEROS_KRB5CONF_CONFIG_MAP_PREFIX = "kerberos-krb5conf-";
     public static final String KERBEROS_KRB5CONF_MOUNT_DIR = "/etc";
     public static final String KERBEROS_KRB5CONF_FILE = "krb5.conf";
-
-    public static final String FLINK_REST_SERVICE_SUFFIX = "-rest";
 
     public static final String NAME_SEPARATOR = "-";
 
@@ -83,8 +77,6 @@ public class Constants {
 
     public static final String HEADLESS_SERVICE_CLUSTER_IP = "None";
 
-    public static final int MAXIMUM_CHARACTERS_OF_CLUSTER_ID = 45;
-
     public static final String RESTART_POLICY_OF_NEVER = "Never";
 
     // Constants for Kubernetes high availability
@@ -102,7 +94,6 @@ public class Constants {
     public static final String TASK_MANAGER_POD_TEMPLATE_FILE_NAME =
             "taskmanager-pod-template.yaml";
     public static final String POD_TEMPLATE_DIR_IN_POD = "/opt/flink/pod-template";
-    public static final String POD_TEMPLATE_CONFIG_MAP_PREFIX = "pod-template-";
     public static final String POD_TEMPLATE_VOLUME = "pod-template-volume";
 
     // Kubernetes start scripts

--- a/flink-kubernetes/src/main/java/org/apache/flink/kubernetes/utils/KubernetesLabel.java
+++ b/flink-kubernetes/src/main/java/org/apache/flink/kubernetes/utils/KubernetesLabel.java
@@ -1,0 +1,84 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.flink.kubernetes.utils;
+
+import org.apache.flink.kubernetes.configuration.KubernetesConfigOptions;
+
+import java.util.Arrays;
+
+import static org.apache.flink.util.Preconditions.checkArgument;
+import static org.apache.flink.util.StringUtils.isNullOrWhitespaceOnly;
+
+/** Collection of kubernetes labels and helper methods. */
+public enum KubernetesLabel {
+    CONFIG_MAP("flink-config-", ""),
+    HADOOP_CONF_CONFIG_MAP("hadoop-config-", ""),
+    KERBEROS_KEYTAB_SECRET("kerberos-keytab-", ""),
+    KERBEROS_KRB5CONF_CONFIG_MAP("kerberos-krb5conf-", ""),
+    POD_TEMPLATE_CONFIG_MAP("pod-template-", ""),
+    FLINK_REST_SERVICE("", "-rest");
+
+    private static final int KUBERNETES_LABEL_MAX_LENGTH = 63;
+
+    private final String prefix;
+    private final String suffix;
+
+    KubernetesLabel(String prefix, String suffix) {
+        this.prefix = prefix;
+        this.suffix = suffix;
+    }
+
+    private int getTotalLength() {
+        return prefix.length() + suffix.length();
+    }
+
+    public static int getClusterIdMaxLength() {
+        int longestAffixLength =
+                Arrays.stream(KubernetesLabel.values())
+                        .map(KubernetesLabel::getTotalLength)
+                        .max(Integer::compareTo)
+                        .orElseThrow(() -> new IllegalStateException("No enum value is present."));
+
+        return KUBERNETES_LABEL_MAX_LENGTH - longestAffixLength;
+    }
+
+    /**
+     * Generates the kubernetes label containing the clusterId.
+     *
+     * @param clusterId The clusterId
+     * @return a String containing the kubernetes label with the clusterId
+     */
+    public String generateWith(String clusterId) {
+        checkArgument(
+                !isNullOrWhitespaceOnly(clusterId),
+                "%s must not be blank.",
+                KubernetesConfigOptions.CLUSTER_ID.key());
+
+        String labelWithClusterId = prefix + clusterId + suffix;
+
+        checkArgument(
+                labelWithClusterId.length() <= KUBERNETES_LABEL_MAX_LENGTH,
+                "%s must be no more than %s characters. Please change %s.",
+                labelWithClusterId,
+                KUBERNETES_LABEL_MAX_LENGTH,
+                KubernetesConfigOptions.CLUSTER_ID.key());
+
+        return labelWithClusterId;
+    }
+}

--- a/flink-kubernetes/src/test/java/org/apache/flink/kubernetes/KubernetesClusterDescriptorTest.java
+++ b/flink-kubernetes/src/test/java/org/apache/flink/kubernetes/KubernetesClusterDescriptorTest.java
@@ -34,6 +34,7 @@ import org.apache.flink.kubernetes.configuration.KubernetesConfigOptions;
 import org.apache.flink.kubernetes.configuration.KubernetesDeploymentTarget;
 import org.apache.flink.kubernetes.kubeclient.decorators.InternalServiceDecorator;
 import org.apache.flink.kubernetes.utils.Constants;
+import org.apache.flink.kubernetes.utils.KubernetesLabel;
 import org.apache.flink.runtime.jobmanager.HighAvailabilityMode;
 
 import io.fabric8.kubernetes.api.model.Container;
@@ -207,7 +208,8 @@ public class KubernetesClusterDescriptorTest extends KubernetesClientTestBase {
                         .deployApplicationCluster(clusterSpecification, appConfig)
                         .getClusterClient();
 
-        final String address = CLUSTER_ID + Constants.FLINK_REST_SERVICE_SUFFIX + "." + NAMESPACE;
+        final String address =
+                KubernetesLabel.FLINK_REST_SERVICE.generateWith(CLUSTER_ID) + "." + NAMESPACE;
         final int port = flinkConfig.get(RestOptions.PORT);
         assertThat(
                 clusterClient.getWebInterfaceURL(),

--- a/flink-kubernetes/src/test/java/org/apache/flink/kubernetes/kubeclient/decorators/PodTemplateMountDecoratorTest.java
+++ b/flink-kubernetes/src/test/java/org/apache/flink/kubernetes/kubeclient/decorators/PodTemplateMountDecoratorTest.java
@@ -24,6 +24,7 @@ import org.apache.flink.kubernetes.configuration.KubernetesConfigOptions;
 import org.apache.flink.kubernetes.kubeclient.FlinkPod;
 import org.apache.flink.kubernetes.kubeclient.KubernetesJobManagerTestBase;
 import org.apache.flink.kubernetes.utils.Constants;
+import org.apache.flink.kubernetes.utils.KubernetesLabel;
 
 import io.fabric8.kubernetes.api.model.ConfigMap;
 import io.fabric8.kubernetes.api.model.HasMetadata;
@@ -136,7 +137,7 @@ public class PodTemplateMountDecoratorTest extends KubernetesJobManagerTestBase 
                 new VolumeBuilder()
                         .withName(Constants.POD_TEMPLATE_VOLUME)
                         .withNewConfigMap()
-                        .withName(Constants.POD_TEMPLATE_CONFIG_MAP_PREFIX + CLUSTER_ID)
+                        .withName(KubernetesLabel.POD_TEMPLATE_CONFIG_MAP.generateWith(CLUSTER_ID))
                         .withItems(keyToPaths)
                         .endConfigMap()
                         .build());

--- a/flink-kubernetes/src/test/java/org/apache/flink/kubernetes/kubeclient/parameters/AbstractKubernetesParametersTest.java
+++ b/flink-kubernetes/src/test/java/org/apache/flink/kubernetes/kubeclient/parameters/AbstractKubernetesParametersTest.java
@@ -23,6 +23,7 @@ import org.apache.flink.configuration.DeploymentOptionsInternal;
 import org.apache.flink.core.testutils.CommonTestUtils;
 import org.apache.flink.kubernetes.configuration.KubernetesConfigOptions;
 import org.apache.flink.kubernetes.utils.Constants;
+import org.apache.flink.kubernetes.utils.KubernetesLabel;
 import org.apache.flink.util.StringUtils;
 import org.apache.flink.util.TestLogger;
 import org.apache.flink.util.function.RunnableWithException;
@@ -64,12 +65,10 @@ public class AbstractKubernetesParametersTest extends TestLogger {
     public void testClusterIdLengthLimitation() {
         final String stringWithIllegalLength =
                 StringUtils.generateRandomAlphanumericString(
-                        new Random(), Constants.MAXIMUM_CHARACTERS_OF_CLUSTER_ID + 1);
+                        new Random(), KubernetesLabel.getClusterIdMaxLength() + 1);
         flinkConfig.set(KubernetesConfigOptions.CLUSTER_ID, stringWithIllegalLength);
         assertThrows(
-                "must be no more than "
-                        + Constants.MAXIMUM_CHARACTERS_OF_CLUSTER_ID
-                        + " characters",
+                "must be no more than " + KubernetesLabel.getClusterIdMaxLength() + " characters",
                 IllegalArgumentException.class,
                 testingKubernetesParameters::getClusterId);
     }


### PR DESCRIPTION
## What is the purpose of the change

Kubernetes labels have a maximum length of 63 characters. We generate a variety of labels by applying suffixes and prefixes to represent certain components. Previously they have often exceeded the maximum length because the label generation happened by just concatenating strings together. This PR aims to provide a safe mechanism for the label creation that also keeps the documentation up to date.


## Brief change log

  - Introduced KubernetesLabel enum with helper methods for label generation
  - Updated docs to always include the current maximum length

## Verifying this change


This change is already covered by existing tests, such as *(please describe tests)*.

 - AbstractKubernetesParametersTest#testClusterIdLengthLimitation


## Does this pull request potentially affect one of the following parts:

  - Dependencies (does it add or upgrade a dependency): (no)
  - The public API, i.e., is any changed class annotated with `@Public(Evolving)`: (no)
  - The serializers: (no)
  - The runtime per-record code paths (performance sensitive): (no)
  - Anything that affects deployment or recovery: JobManager (and its components), Checkpointing, Kubernetes/Yarn, ZooKeeper: (yes - kubernetes)
  - The S3 file system connector: (no)

## Documentation

  - Does this pull request introduce a new feature? (no)
  - If yes, how is the feature documented? (docs + JavaDocs)
