### PR TITLE
[FLINK-23620] Replace Flink Configuration YAML parser with SnakeYAML

### DIFF
--- a/flink-core/pom.xml
+++ b/flink-core/pom.xml
@@ -93,6 +93,13 @@ under the License.
 			<artifactId>flink-shaded-guava</artifactId>
 		</dependency>
 
+
+		<!-- YAML parsing for the global config -->
+		<dependency>
+			<groupId>org.yaml</groupId>
+			<artifactId>snakeyaml</artifactId>
+		</dependency>
+
 		<!-- ================== test dependencies ================== -->
 
 		<dependency>

--- a/flink-dist/src/main/resources/META-INF/NOTICE
+++ b/flink-dist/src/main/resources/META-INF/NOTICE
@@ -19,6 +19,7 @@ This project bundles the following dependencies under the Apache Software Licens
 - org.lz4:lz4-java:1.8.0
 - org.objenesis:objenesis:2.1
 - org.xerial.snappy:snappy-java:1.1.8.3
+- org.yaml:snakeyaml:1.27
 
 This project bundles the following dependencies under the BSD license.
 See bundled license files for details.

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/clusterframework/BootstrapTools.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/clusterframework/BootstrapTools.java
@@ -34,13 +34,14 @@ import org.apache.commons.cli.CommandLine;
 import org.apache.commons.cli.Option;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
+import org.yaml.snakeyaml.Yaml;
+import org.yaml.snakeyaml.constructor.SafeConstructor;
 
 import javax.annotation.Nullable;
 
 import java.io.File;
 import java.io.FileWriter;
 import java.io.IOException;
-import java.io.PrintWriter;
 import java.util.HashMap;
 import java.util.Map;
 import java.util.stream.Stream;
@@ -61,6 +62,8 @@ public class BootstrapTools {
     private static final Escaper WINDOWS_DOUBLE_QUOTE_ESCAPER =
             Escapers.builder().addEscape('"', "\\\"").addEscape('^', "\"^^\"").build();
 
+    private static final Yaml yaml = new Yaml(new SafeConstructor());
+
     /**
      * Writes a Flink YAML config file from a Flink Configuration object.
      *
@@ -69,13 +72,8 @@ public class BootstrapTools {
      * @throws IOException
      */
     public static void writeConfiguration(Configuration cfg, File file) throws IOException {
-        try (FileWriter fwrt = new FileWriter(file);
-                PrintWriter out = new PrintWriter(fwrt)) {
-            for (Map.Entry<String, String> entry : cfg.toMap().entrySet()) {
-                out.print(entry.getKey());
-                out.print(": ");
-                out.println(entry.getValue());
-            }
+        try (FileWriter fwrt = new FileWriter(file)) {
+            yaml.dump(cfg.toMap(), fwrt);
         }
     }
 


### PR DESCRIPTION
<!--
*Thank you very much for contributing to Apache Flink - we are happy that you want to help us improve Flink. To help the community review your contribution in the best possible way, please go through the checklist below, which will get the contribution into a shape in which it can be best reviewed.*

*Please understand that we do not do this to make contributions to Flink a hassle. In order to uphold a high standard of quality for code contributions, while at the same time managing a large number of contributions, we need contributors to prepare the contributions well, and give reviewers enough contextual information for the review. Please also understand that contributions that do not follow this guide will take longer to review and thus typically be picked up with lower priority by the community.*

## Contribution Checklist

  - Make sure that the pull request corresponds to a [JIRA issue](https://issues.apache.org/jira/projects/FLINK/issues). Exceptions are made for typos in JavaDoc or documentation files, which need no JIRA issue.
  
  - Name the pull request in the form "[FLINK-XXXX] [component] Title of the pull request", where *FLINK-XXXX* should be replaced by the actual issue number. Skip *component* if you are unsure about which is the best component.
  Typo fixes that have no associated JIRA issue should be named following this pattern: `[hotfix] [docs] Fix typo in event time introduction` or `[hotfix] [javadocs] Expand JavaDoc for PuncuatedWatermarkGenerator`.

  - Fill out the template below to describe the changes contributed by the pull request. That will give reviewers the context they need to do the review.
  
  - Make sure that the change passes the automated tests, i.e., `mvn clean verify` passes. You can set up Azure Pipelines CI to do that following [this guide](https://cwiki.apache.org/confluence/display/FLINK/Azure+Pipelines#AzurePipelines-Tutorial:SettingupAzurePipelinesforaforkoftheFlinkrepository).

  - Each pull request should address only one issue, not mix up code from multiple issues.
  
  - Each commit in the pull request has a meaningful commit message (including the JIRA id)

  - Once all items of the checklist are addressed, remove the above text and this checklist, leaving only the filled out template below.


**(The sections below can be removed for hotfixes of typos)**
-->

## What is the purpose of the change

This PR exchanges the self-written YAML parser for `flink-conf.yml` with `snakeyaml`. This has several benefits. For one, it will address issues like FLINK-15358, where the Flink configuration parser erronously considers anything after a '#' as a comment, even when the '#' occurs within a string.

Secondly, this means that we can support nested YAML keys, such that:

```
KeyA:
  KeyB:
    KeyC: "Hello"
    KeyD: "World"
```

and

```
KeyA.KeyB.KeyC: "Hello"
KeyA.KeyB.KeyD: "World"
```

are equivalent configurations, letting users avoid repetition in their config files.

Thirdly, this lets the Flink config loader support any valid YAML (and reject invalid YAML, which the parser was previously accepting).

**However, this change could result in breaking behaviour**. For one, the old yaml parser read row-by-row and just skipped invalid yaml rows. However, snakeyaml reads the entire document at once and rejects it if any invalid yaml files are present, which means that configurations before this change would be accepted, whereas now they would not.

A potential way of getting around this might be to read the configuration file line by line as its own yaml document, discarding invalid ones, but this would mean that we wouldnt be able to have the nested keys structure outlined above.

However, the nested key structure can also introduce problems. For example:

```
high-availability: zookeeper
high-availability.storageDir: hdfs://flink/ha
high-availability.zookeeper.quorum: localhost:2181
high-availability.zookeeper.client.acl: open
```

Could not be written as

```
high-availability: zookeeper
high-avilability:
    storageDir: hdfs://flink/ha
    zookeeper:
        quorum: localhost:2181
        client.acl: open
```

As this would mean that the `high-availability: zookeeper` key would be overwritten.


## Brief change log

- *The YAML parser for the global `flink-conf.yml` file now uses `snakeyaml`*


## Verifying this change

*(Please pick either of the following options)*

This change is already covered by existing tests, such as `GlobalConfigurationTest`.

## Does this pull request potentially affect one of the following parts:

  - Dependencies (does it add or upgrade a dependency): (yes)
  - The public API, i.e., is any changed class annotated with `@Public(Evolving)`: ( no)
  - The serializers: (no)
  - The runtime per-record code paths (performance sensitive): (no)
  - Anything that affects deployment or recovery: JobManager (and its components), Checkpointing, Kubernetes/Yarn, ZooKeeper: (yes)
  - The S3 file system connector: (no)

## Documentation

  - Does this pull request introduce a new feature? (no)
  - If yes, how is the feature documented? (not applicable)
