### PR TITLE
[FLINK-24953][Connectors / Hive]Optime hive parallelism inference

### DIFF
--- a/flink-connectors/flink-connector-hive/src/main/java/org/apache/flink/connectors/hive/HiveParallelismInference.java
+++ b/flink-connectors/flink-connector-hive/src/main/java/org/apache/flink/connectors/hive/HiveParallelismInference.java
@@ -63,10 +63,10 @@ class HiveParallelismInference {
             return parallelism;
         }
 
-        if (limit != null) {
-            parallelism = Math.min(parallelism, (int) (limit / 1000));
+        if (!infer || limit == null) {
+            return parallelism;
         }
-
+        parallelism = Math.min(parallelism, (int) (limit / 1000));
         // make sure that parallelism is at least 1
         return Math.max(1, parallelism);
     }

--- a/flink-table/flink-table-api-java/src/main/java/org/apache/flink/table/api/internal/TableEnvironmentImpl.java
+++ b/flink-table/flink-table-api-java/src/main/java/org/apache/flink/table/api/internal/TableEnvironmentImpl.java
@@ -360,6 +360,11 @@ public class TableEnvironmentImpl implements TableEnvironmentInternal {
         return planner;
     }
 
+    @VisibleForTesting
+    public Executor getExecutor() {
+        return execEnv;
+    }
+
     @Override
     public Table fromTableSource(TableSource<?> source) {
         // only accept StreamTableSource and LookupableTableSource here


### PR DESCRIPTION
## What is the purpose of the change
Currently, when I disable hive table source parallelism inference using configuration  and set parallelism.default: 100. 
`table.exec.hive.infer-source-parallelism: false `
`parallelism.default: 100`
The result is that the parallelism of hive table source is 1, and the configuration of the default parallelism is not effective.

I will optimize this problem. In the future, when disable hive table source parallelism inference ，the  parallelism of hive table source will be determined according to the following order：
 
1. If `table.exec.resource.default-parallelism` is set, the configured value will be used

2. If `parallelism.default` is set, the configured value is used

3. If the above two configuration items are not set, the default value is 1

## Brief change log

  - `HiveParallelismInference#limit` return parallelism directly when hive table source parallelism inference is disabled


## Verifying this change

This change added tests and can be verified as follows:

  - Added integration tests for hive table source parallelism inference is disabled and set parallelism through configuration.

## Does this pull request potentially affect one of the following parts:

  - Dependencies (does it add or upgrade a dependency): no
  - The public API, i.e., is any changed class annotated with `@Public(Evolving)`: no
  - The serializers: no
  - The runtime per-record code paths (performance sensitive): no 
  - Anything that affects deployment or recovery: JobManager (and its components), Checkpointing, Kubernetes/Yarn, ZooKeeper: no
  - The S3 file system connector: no

## Documentation

  - Does this pull request introduce a new feature? no
  - If yes, how is the feature documented? not applicable
