### PR TITLE
[FLINK-15816][k8s] Limit kubernetes.cluster-id to a maximum of 40 characters

### DIFF
--- a/docs/layouts/shortcodes/generated/kubernetes_config_configuration.html
+++ b/docs/layouts/shortcodes/generated/kubernetes_config_configuration.html
@@ -24,7 +24,7 @@
             <td><h5>kubernetes.cluster-id</h5></td>
             <td style="word-wrap: break-word;">(none)</td>
             <td>String</td>
-            <td>The cluster-id, which should be no more than 45 characters, is used for identifying a unique Flink cluster. The id must only contain lowercase alphanumeric characters and "-". The required format is <code class="highlighter-rouge">[a-z]([-a-z0-9]*[a-z0-9])</code>. If not set, the client will automatically generate it with a random ID.</td>
+            <td>The cluster-id, which should be no more than 40 characters, is used for identifying a unique Flink cluster. The id must only contain lowercase alphanumeric characters and "-". The required format is <code class="highlighter-rouge">[a-z]([-a-z0-9]*[a-z0-9])</code>. If not set, the client will automatically generate it with a random ID.</td>
         </tr>
         <tr>
             <td><h5>kubernetes.config.file</h5></td>

--- a/flink-kubernetes/src/main/java/org/apache/flink/kubernetes/configuration/KubernetesConfigOptions.java
+++ b/flink-kubernetes/src/main/java/org/apache/flink/kubernetes/configuration/KubernetesConfigOptions.java
@@ -200,7 +200,7 @@ public class KubernetesConfigOptions {
                     .withDescription(
                             Description.builder()
                                     .text(
-                                            "The cluster-id, which should be no more than 45 characters, is used for identifying a unique Flink cluster. "
+                                            "The cluster-id, which should be no more than 40 characters, is used for identifying a unique Flink cluster. "
                                                     + "The id must only contain lowercase alphanumeric characters and \"-\". "
                                                     + "The required format is %s. "
                                                     + "If not set, the client will automatically generate it with a random ID.",

--- a/flink-kubernetes/src/main/java/org/apache/flink/kubernetes/utils/Constants.java
+++ b/flink-kubernetes/src/main/java/org/apache/flink/kubernetes/utils/Constants.java
@@ -82,7 +82,7 @@ public class Constants {
 
     public static final String HEADLESS_SERVICE_CLUSTER_IP = "None";
 
-    public static final int MAXIMUM_CHARACTERS_OF_CLUSTER_ID = 45;
+    public static final int MAXIMUM_CHARACTERS_OF_CLUSTER_ID = 40;
 
     public static final String RESTART_POLICY_OF_NEVER = "Never";
 


### PR DESCRIPTION
## What is the purpose of the change

Kubernetes labels have a maximum length of 63 characters. The longest created label is `{cluster-id}-resourcemanager-leader`, therefore the cluster-id has to be limited to 40 characters to not create failures on deployment.


## Brief change log

  - Updated `MAXIMUM_CHARACTERS_OF_CLUSTER_ID` to 40
  - Updated docs

## Verifying this change


This change is already covered by existing tests, such as *(please describe tests)*.

 - AbstractKubernetesParametersTest#testClusterIdLengthLimitation


## Does this pull request potentially affect one of the following parts:

  - Dependencies (does it add or upgrade a dependency): (no)
  - The public API, i.e., is any changed class annotated with `@Public(Evolving)`: (no)
  - The serializers: (no)
  - The runtime per-record code paths (performance sensitive): (no)
  - Anything that affects deployment or recovery: JobManager (and its components), Checkpointing, Kubernetes/Yarn, ZooKeeper: (yes - kubernetes)
  - The S3 file system connector: (no)

## Documentation

  - Does this pull request introduce a new feature? (no)
  - If yes, how is the feature documented? (docs + JavaDocs)
