### PR TITLE
[FLINK-24893][Table SQL/Client][FLIP-189] SQL Client prompts customization

### DIFF
--- a/docs/content.zh/docs/dev/table/sqlClient.md
+++ b/docs/content.zh/docs/dev/table/sqlClient.md
@@ -405,6 +405,51 @@ SET 'key' = 'value';
 
 {{< generated/sql_client_configuration >}}
 
+### SQL client prompts
+
+The CLI supports left and right prompts: at the start and at the end of the line.
+The prompts can be customized to your preference.
+The value of the selected prompt's properties are printed literally, except where a backslash sign (`\`) is encountered.
+Depending on the next character, some other text is substituted instead. Defined substitutions are:
+
+| Pattern | Description                                                                                                                                                                                                                                                                                   |
+|:--------|:----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------|
+| `\c`    | Current catalog.                                                                                                                                                                                                                                                                              |
+| `\d`    | Current database.                                                                                                                                                                                                                                                                             |
+| `\[…\]` | Prompts can contain terminal control characters which, for example, change the color, background, or style of the prompt text. These non-printing control characters must be designated as invisible by surrounding them with \[ and \]. Multiple pairs of these can occur within the prompt. |
+| `\{…\}` | Datetime pattern to convert current datetime. Compatible with Java’s SimpleDateFormat.                                                                                                                                                                                                        |
+| `\:…\:` | The value of Flink property_name property.                                                                                                                                                                                                                                                    |
+| `\D`    | The full current date (`yyyy-MM-dd HH:mm:ss.SSS`).                                                                                                                                                                                                                                            |
+| `\m`    | Minutes of the current time.                                                                                                                                                                                                                                                                  |
+| `\O`    | The current month in three-letter format (Jan, Feb, …).                                                                                                                                                                                                                                       |
+| `\o`    | The current month in numeric format.                                                                                                                                                                                                                                                          |
+| `\P`    | am/pm.                                                                                                                                                                                                                                                                                        |
+| `\R`    | The current time, in 24-hour military time (0–23).                                                                                                                                                                                                                                            |
+| `\r`    | The current time, standard 12-hour time (1–12).                                                                                                                                                                                                                                               |
+| `\s`    | Seconds of the current time.                                                                                                                                                                                                                                                                  |
+| `\w`    | The current day of the week in three-letter format (Mon, Tue, …).                                                                                                                                                                                                                             |
+| `\Y`    | The current year, four digits.                                                                                                                                                                                                                                                                |
+| `\y`    | The current year, two digits.                                                                                                                                                                                                                                                                 |
+| `\\`    | A literal \ backslash character.                                                                                                                                                                                                                                                              |
+| `\x`    | x, for any x not listed above.                                                                                                                                                                                                                                                                |
+
+#### Styles in prompt
+
+It is possible to use styles in prompt's patterns e.g.
+```
+SET 'sql-client.display.prompt.pattern'='\[f:g,bold\]FlinkSQL\[default\]>'
+```
+will print `FlinkSQL` in green bold and `>` in a default style.
+
+Style formats are the following `\[colorMode:color\]` or `\[style\]` or `\[colorMode:color,style\]`.
+
+There are 2 modes foreground: `f`, `fg`, `foreground` (all 3 are synonyms)
+and background: `b`, `bg`, `background` (all 3 are synonyms).
+
+Available colors: `black` or `k`, `red` or `r`, `green` or `g`, `yellow` or `y`, `blue` or `b`, `magenta` or `m`, `cyan` or `c`, `white` or `w`.
+
+Available styles: `default`, `bold`, `italic`, `underline`, `faint`, `flink`, `inverse`, `inverse-neg` or `inverseneg`, `conceal`, `crossedout` or `crossed-out`, `hidden`.
+
 ### SQL Client result modes
 
 The CLI supports **three modes** for maintaining and visualizing results.

--- a/docs/content/docs/dev/table/sqlClient.md
+++ b/docs/content/docs/dev/table/sqlClient.md
@@ -344,6 +344,51 @@ SET 'key' = 'value';
 
 {{< generated/sql_client_configuration >}}
 
+### SQL client prompts
+
+The CLI supports left and right prompts: at the start and at the end of the line.
+The prompts can be customized to your preference.
+The value of the selected prompt's properties are printed literally, except where a backslash sign (`\`) is encountered.
+Depending on the next character, some other text is substituted instead. Defined substitutions are:
+
+| Pattern | Description                                                                                                                                                                                                                                                                                   |
+|:--------|:----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------|
+| `\c`    | Current catalog.                                                                                                                                                                                                                                                                              |
+| `\d`    | Current database.                                                                                                                                                                                                                                                                             |
+| `\[…\]` | Prompts can contain terminal control characters which, for example, change the color, background, or style of the prompt text. These non-printing control characters must be designated as invisible by surrounding them with \[ and \]. Multiple pairs of these can occur within the prompt. |
+| `\{…\}` | Datetime pattern to convert current datetime. Compatible with Java’s SimpleDateFormat.                                                                                                                                                                                                        |
+| `\:…\:` | The value of Flink property_name property.                                                                                                                                                                                                                                                    |
+| `\D`    | The full current date (`yyyy-MM-dd HH:mm:ss.SSS`).                                                                                                                                                                                                                                            |
+| `\m`    | Minutes of the current time.                                                                                                                                                                                                                                                                  |
+| `\O`    | The current month in three-letter format (Jan, Feb, …).                                                                                                                                                                                                                                       |
+| `\o`    | The current month in numeric format.                                                                                                                                                                                                                                                          |
+| `\P`    | am/pm.                                                                                                                                                                                                                                                                                        |
+| `\R`    | The current time, in 24-hour military time (0–23).                                                                                                                                                                                                                                            |
+| `\r`    | The current time, standard 12-hour time (1–12).                                                                                                                                                                                                                                               |
+| `\s`    | Seconds of the current time.                                                                                                                                                                                                                                                                  |
+| `\w`    | The current day of the week in three-letter format (Mon, Tue, …).                                                                                                                                                                                                                             |
+| `\Y`    | The current year, four digits.                                                                                                                                                                                                                                                                |
+| `\y`    | The current year, two digits.                                                                                                                                                                                                                                                                 |
+| `\\`    | A literal \ backslash character.                                                                                                                                                                                                                                                              |
+| `\x`    | x, for any x not listed above.                                                                                                                                                                                                                                                                |
+
+#### Styles in prompt
+
+It is possible to use styles in prompt's patterns e.g.
+```
+SET 'sql-client.display.prompt.pattern'='\[f:g,bold\]FlinkSQL\[default\]>'
+```
+will print `FlinkSQL` in green bold and `>` in a default style.
+
+Style formats are the following `\[colorMode:color\]` or `\[style\]` or `\[colorMode:color,style\]`.
+
+There are 2 modes foreground: `f`, `fg`, `foreground` (all 3 are synonyms)
+and background: `b`, `bg`, `background` (all 3 are synonyms).
+
+Available colors: `black` or `k`, `red` or `r`, `green` or `g`, `yellow` or `y`, `blue` or `b`, `magenta` or `m`, `cyan` or `c`, `white` or `w`.
+
+Available styles: `default`, `bold`, `italic`, `underline`, `faint`, `flink`, `inverse`, `inverse-neg` or `inverseneg`, `conceal`, `crossedout` or `crossed-out`, `hidden`.
+
 ### SQL Client result modes
 
 The CLI supports **three modes** for maintaining and visualizing results.

--- a/docs/layouts/shortcodes/generated/sql_client_configuration.html
+++ b/docs/layouts/shortcodes/generated/sql_client_configuration.html
@@ -21,6 +21,18 @@
             <td>Deprecated, please use table.display.max-column-width instead. When printing the query results, this parameter determines the number of characters shown on screen before truncating. This only applies to columns with variable-length types (e.g. STRING) in streaming mode. Fixed-length types and all types in batch mode are printed using a deterministic column width.</td>
         </tr>
         <tr>
+            <td><h5>sql-client.display.prompt.pattern</h5><br> <span class="label label-primary">Batch</span> <span class="label label-primary">Streaming</span></td>
+            <td style="word-wrap: break-word;">"[32mFlink SQL[0m&gt; "</td>
+            <td>String</td>
+            <td>Determine what pattern will be used for prompt at the start of the line.</td>
+        </tr>
+        <tr>
+            <td><h5>sql-client.display.right-prompt.pattern</h5><br> <span class="label label-primary">Batch</span> <span class="label label-primary">Streaming</span></td>
+            <td style="word-wrap: break-word;">(none)</td>
+            <td>String</td>
+            <td>Determine what pattern will be used for prompt at the end of the line.</td>
+        </tr>
+        <tr>
             <td><h5>sql-client.execution.max-table-result.rows</h5><br> <span class="label label-primary">Batch</span> <span class="label label-primary">Streaming</span></td>
             <td style="word-wrap: break-word;">1000000</td>
             <td>Integer</td>

--- a/flink-table/flink-sql-client/src/main/java/org/apache/flink/table/client/cli/CliClient.java
+++ b/flink-table/flink-sql-client/src/main/java/org/apache/flink/table/client/cli/CliClient.java
@@ -175,13 +175,19 @@ public class CliClient implements AutoCloseable {
         String line;
 
         SqlMultiLineParser parser = (SqlMultiLineParser) lineReader.getParser();
+        final PromptHandler promptHandler = new PromptHandler(executor, terminalFactory);
         while (isRunning) {
             // make some space to previous command
             terminal.writer().append("\n");
             terminal.flush();
             try {
                 // read a statement from terminal and parse it
-                line = lineReader.readLine(NEWLINE_PROMPT, null, inputTransformer, null);
+                line =
+                        lineReader.readLine(
+                                promptHandler.getPrompt(),
+                                promptHandler.getRightPrompt(),
+                                inputTransformer,
+                                null);
                 if (line.trim().isEmpty()) {
                     continue;
                 }

--- a/flink-table/flink-sql-client/src/main/java/org/apache/flink/table/client/cli/PromptHandler.java
+++ b/flink-table/flink-sql-client/src/main/java/org/apache/flink/table/client/cli/PromptHandler.java
@@ -1,0 +1,186 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.flink.table.client.cli;
+
+import org.apache.flink.configuration.Configuration;
+import org.apache.flink.table.client.config.SqlClientOptions;
+import org.apache.flink.table.client.gateway.Executor;
+
+import org.jline.terminal.Terminal;
+import org.jline.utils.AttributedStringBuilder;
+import org.jline.utils.AttributedStyle;
+import org.jline.utils.StyleResolver;
+
+import java.io.PrintWriter;
+import java.text.SimpleDateFormat;
+import java.util.Date;
+import java.util.HashMap;
+import java.util.Locale;
+import java.util.Map;
+import java.util.function.Supplier;
+
+/**
+ * Prompt handler class which allows customization for the prompt shown at the start (left prompt)
+ * and the end (right prompt) of each line.
+ */
+public class PromptHandler {
+    private static final char ESCAPE_BACKSLASH = '\\';
+    private static final Map<String, SimpleDateFormat> FORMATTER_CACHE = new HashMap<>();
+
+    static {
+        FORMATTER_CACHE.put("D", new SimpleDateFormat("yyyy-MM-dd HH:mm:ss.SSS", Locale.ROOT));
+        FORMATTER_CACHE.put("m", new SimpleDateFormat("mm", Locale.ROOT));
+        FORMATTER_CACHE.put("o", new SimpleDateFormat("MM", Locale.ROOT));
+        FORMATTER_CACHE.put("O", new SimpleDateFormat("MMM", Locale.ROOT));
+        FORMATTER_CACHE.put("P", new SimpleDateFormat("aa", Locale.ROOT));
+        FORMATTER_CACHE.put("r", new SimpleDateFormat("hh:mm", Locale.ROOT));
+        FORMATTER_CACHE.put("R", new SimpleDateFormat("HH:mm", Locale.ROOT));
+        FORMATTER_CACHE.put("s", new SimpleDateFormat("ss", Locale.ROOT));
+        FORMATTER_CACHE.put("w", new SimpleDateFormat("d", Locale.ROOT));
+        FORMATTER_CACHE.put("W", new SimpleDateFormat("E", Locale.ROOT));
+        FORMATTER_CACHE.put("y", new SimpleDateFormat("yy", Locale.ROOT));
+        FORMATTER_CACHE.put("Y", new SimpleDateFormat("yyyy", Locale.ROOT));
+    }
+
+    private static final StyleResolver STYLE_RESOLVER = new StyleResolver(s -> "");
+
+    private final Executor executor;
+    private final Supplier<Terminal> terminalSupplier;
+
+    public PromptHandler(Executor executor, Supplier<Terminal> terminalSupplier) {
+        this.executor = executor;
+        this.terminalSupplier = terminalSupplier;
+    }
+
+    public String getPrompt() {
+        return buildPrompt(
+                executor.getSessionConfig().get(SqlClientOptions.PROMPT),
+                SqlClientOptions.PROMPT.defaultValue());
+    }
+
+    public String getRightPrompt() {
+        return buildPrompt(
+                executor.getSessionConfig().get(SqlClientOptions.RIGHT_PROMPT),
+                SqlClientOptions.RIGHT_PROMPT.defaultValue());
+    }
+
+    private String buildPrompt(String pattern, String defaultValue) {
+        if (pattern == null) {
+            return defaultValue;
+        }
+        AttributedStringBuilder promptStringBuilder = new AttributedStringBuilder();
+        try {
+            String currentCatalog = null;
+            String currentDatabase = null;
+            for (int i = 0; i < pattern.length(); i++) {
+                final char c = pattern.charAt(i);
+                if (c == ESCAPE_BACKSLASH) {
+                    if (i == pattern.length() - 1) {
+                        continue;
+                    }
+                    final char nextChar = pattern.charAt(i + 1);
+                    switch (nextChar) {
+                        case 'D':
+                        case 'm':
+                        case 'o':
+                        case 'O':
+                        case 'P':
+                        case 'r':
+                        case 'R':
+                        case 's':
+                        case 'w':
+                        case 'W':
+                        case 'y':
+                        case 'Y':
+                            promptStringBuilder.append(
+                                    FORMATTER_CACHE
+                                            .get(String.valueOf(nextChar))
+                                            .format(new Date()));
+                            i++;
+                            break;
+                        case 'c':
+                            if (currentCatalog == null) {
+                                currentCatalog = executor.getCurrentCatalog();
+                            }
+                            promptStringBuilder.append(currentCatalog);
+                            i++;
+                            break;
+                        case 'd':
+                            if (currentDatabase == null) {
+                                currentDatabase = executor.getCurrentDatabase();
+                            }
+                            promptStringBuilder.append(currentDatabase);
+                            i++;
+                            break;
+                        case ESCAPE_BACKSLASH:
+                            promptStringBuilder.append(ESCAPE_BACKSLASH);
+                            i++;
+                            break;
+                            // date time pattern \{...\}
+                        case '{':
+                            int dateTimeMaskCloseIndex =
+                                    pattern.indexOf(ESCAPE_BACKSLASH + "}", i + 1);
+                            if (dateTimeMaskCloseIndex > 0) {
+                                String mask = pattern.substring(i + 2, dateTimeMaskCloseIndex);
+                                FORMATTER_CACHE.computeIfAbsent(
+                                        mask, v -> new SimpleDateFormat(mask, Locale.ROOT));
+                                promptStringBuilder.append(
+                                        FORMATTER_CACHE.get(mask).format(new Date()));
+                                i = dateTimeMaskCloseIndex + 1;
+                            }
+                            break;
+                            // color and style pattern \[...\]
+                        case '[':
+                            int closeBracketIndex = pattern.indexOf(ESCAPE_BACKSLASH + "]", i + 1);
+                            if (closeBracketIndex > 0) {
+                                String color = pattern.substring(i + 2, closeBracketIndex);
+                                AttributedStyle style = STYLE_RESOLVER.resolve(color);
+                                promptStringBuilder.style(style);
+                                i = closeBracketIndex + 1;
+                            }
+                            break;
+                            // property value pattern \:...\:
+                        case ':':
+                            int nextColonIndex = pattern.indexOf(ESCAPE_BACKSLASH + ":", i + 1);
+                            String propertyValue;
+                            if (nextColonIndex > 0) {
+                                String propertyName = pattern.substring(i + 2, nextColonIndex);
+                                propertyValue =
+                                        ((Configuration) executor.getSessionConfig())
+                                                .toMap()
+                                                .get(propertyName);
+                                promptStringBuilder.append(propertyValue);
+                                i = nextColonIndex + 1;
+                            }
+                            break;
+                    }
+                } else {
+                    promptStringBuilder.append(c);
+                }
+            }
+            return promptStringBuilder.toAnsi();
+        } catch (Exception e) {
+            final boolean isVerbose = executor.getSessionConfig().get(SqlClientOptions.VERBOSE);
+            try (PrintWriter writer = terminalSupplier.get().writer()) {
+                writer.println(CliStrings.messageError(e.getMessage(), e, isVerbose).toAnsi());
+            }
+            return defaultValue;
+        }
+    }
+}

--- a/flink-table/flink-sql-client/src/main/java/org/apache/flink/table/client/cli/PromptHandler.java
+++ b/flink-table/flink-sql-client/src/main/java/org/apache/flink/table/client/cli/PromptHandler.java
@@ -27,6 +27,9 @@ import org.jline.utils.AttributedStringBuilder;
 import org.jline.utils.AttributedStyle;
 import org.jline.utils.StyleResolver;
 
+import javax.annotation.Nonnull;
+import javax.annotation.Nullable;
+
 import java.io.PrintWriter;
 import java.text.SimpleDateFormat;
 import java.util.Date;
@@ -80,7 +83,8 @@ public class PromptHandler {
                 SqlClientOptions.RIGHT_PROMPT.defaultValue());
     }
 
-    private String buildPrompt(String pattern, String defaultValue) {
+    @Nonnull
+    private String buildPrompt(@Nullable String pattern, String defaultValue) {
         if (pattern == null) {
             return defaultValue;
         }

--- a/flink-table/flink-sql-client/src/main/java/org/apache/flink/table/client/config/SqlClientOptions.java
+++ b/flink-table/flink-sql-client/src/main/java/org/apache/flink/table/client/config/SqlClientOptions.java
@@ -24,6 +24,9 @@ import org.apache.flink.configuration.ConfigOptions;
 import org.apache.flink.table.api.config.TableConfigOptions;
 import org.apache.flink.table.client.cli.parser.SyntaxHighlightStyle;
 
+import org.jline.utils.AttributedStringBuilder;
+import org.jline.utils.AttributedStyle;
+
 /** Options used in sql client. */
 public class SqlClientOptions {
     private SqlClientOptions() {}
@@ -77,4 +80,28 @@ public class SqlClientOptions {
                     .defaultValue(SyntaxHighlightStyle.BuiltInStyle.DEFAULT.name())
                     .withDescription(
                             "SQL highlight color schema to be used at SQL client. Possible values: 'default', 'dark', 'light', 'chester', 'vs2010', 'solarized', 'obsidian', 'geshi'");
+
+    @Documentation.TableOption(execMode = Documentation.ExecMode.BATCH_STREAMING)
+    public static final ConfigOption<String> PROMPT =
+            ConfigOptions.key("sql-client.display.prompt.pattern")
+                    .stringType()
+                    .defaultValue(
+                            new AttributedStringBuilder()
+                                    .style(
+                                            AttributedStyle.DEFAULT.foreground(
+                                                    AttributedStyle.GREEN))
+                                    .append("Flink SQL")
+                                    .style(AttributedStyle.DEFAULT)
+                                    .append("> ")
+                                    .toAnsi())
+                    .withDescription(
+                            "Determine what pattern will be used for prompt at the start of the line.");
+
+    @Documentation.TableOption(execMode = Documentation.ExecMode.BATCH_STREAMING)
+    public static final ConfigOption<String> RIGHT_PROMPT =
+            ConfigOptions.key("sql-client.display.right-prompt.pattern")
+                    .stringType()
+                    .defaultValue("")
+                    .withDescription(
+                            "Determine what pattern will be used for prompt at the end of the line.");
 }

--- a/flink-table/flink-sql-client/src/main/java/org/apache/flink/table/client/gateway/Executor.java
+++ b/flink-table/flink-sql-client/src/main/java/org/apache/flink/table/client/gateway/Executor.java
@@ -70,6 +70,10 @@ public interface Executor extends Closeable {
      */
     List<String> completeStatement(String statement, int position);
 
+    String getCurrentCatalog();
+
+    String getCurrentDatabase();
+
     /** Close the {@link Executor} and process all exceptions. */
     void close();
 }

--- a/flink-table/flink-sql-client/src/main/java/org/apache/flink/table/client/gateway/ExecutorImpl.java
+++ b/flink-table/flink-sql-client/src/main/java/org/apache/flink/table/client/gateway/ExecutorImpl.java
@@ -50,6 +50,8 @@ import org.apache.flink.table.gateway.rest.header.statement.ExecuteStatementHead
 import org.apache.flink.table.gateway.rest.header.statement.FetchResultsHeaders;
 import org.apache.flink.table.gateway.rest.header.util.GetApiVersionHeaders;
 import org.apache.flink.table.gateway.rest.header.util.UrlPrefixDecorator;
+import org.apache.flink.table.gateway.rest.header.util.GetCurrentCatalogHeaders;
+import org.apache.flink.table.gateway.rest.header.util.GetCurrentDatabaseHeaders;
 import org.apache.flink.table.gateway.rest.message.operation.OperationMessageParameters;
 import org.apache.flink.table.gateway.rest.message.operation.OperationStatusResponseBody;
 import org.apache.flink.table.gateway.rest.message.session.CloseSessionResponseBody;
@@ -282,6 +284,24 @@ public class ExecutorImpl implements Executor {
                                 new SessionMessageParameters(sessionHandle),
                                 new CompleteStatementRequestBody(statement, position)))
                 .getCandidates();
+    }
+
+    public String getCurrentCatalog() {
+        return getResponse(
+                        sendRequest(
+                                GetCurrentCatalogHeaders.getInstance(),
+                                new SessionMessageParameters(sessionHandle),
+                                EmptyRequestBody.getInstance()))
+                .getCurrentCatalog();
+    }
+
+    public String getCurrentDatabase() {
+        return getResponse(
+                        sendRequest(
+                                GetCurrentDatabaseHeaders.getInstance(),
+                                new SessionMessageParameters(sessionHandle),
+                                EmptyRequestBody.getInstance()))
+                .getCurrentDatabase();
     }
 
     @Override

--- a/flink-table/flink-sql-client/src/main/java/org/apache/flink/table/client/gateway/ExecutorImpl.java
+++ b/flink-table/flink-sql-client/src/main/java/org/apache/flink/table/client/gateway/ExecutorImpl.java
@@ -49,9 +49,9 @@ import org.apache.flink.table.gateway.rest.header.statement.CompleteStatementHea
 import org.apache.flink.table.gateway.rest.header.statement.ExecuteStatementHeaders;
 import org.apache.flink.table.gateway.rest.header.statement.FetchResultsHeaders;
 import org.apache.flink.table.gateway.rest.header.util.GetApiVersionHeaders;
-import org.apache.flink.table.gateway.rest.header.util.UrlPrefixDecorator;
 import org.apache.flink.table.gateway.rest.header.util.GetCurrentCatalogHeaders;
 import org.apache.flink.table.gateway.rest.header.util.GetCurrentDatabaseHeaders;
+import org.apache.flink.table.gateway.rest.header.util.UrlPrefixDecorator;
 import org.apache.flink.table.gateway.rest.message.operation.OperationMessageParameters;
 import org.apache.flink.table.gateway.rest.message.operation.OperationStatusResponseBody;
 import org.apache.flink.table.gateway.rest.message.session.CloseSessionResponseBody;

--- a/flink-table/flink-sql-client/src/test/java/org/apache/flink/table/client/cli/CliClientTest.java
+++ b/flink-table/flink-sql-client/src/test/java/org/apache/flink/table/client/cli/CliClientTest.java
@@ -459,6 +459,16 @@ class CliClientTest {
         }
 
         @Override
+        public String getCurrentCatalog() {
+            return null;
+        }
+
+        @Override
+        public String getCurrentDatabase() {
+            return null;
+        }
+
+        @Override
         public void close() {
             // do nothing
         }

--- a/flink-table/flink-sql-client/src/test/java/org/apache/flink/table/client/cli/PromptHandlerTest.java
+++ b/flink-table/flink-sql-client/src/test/java/org/apache/flink/table/client/cli/PromptHandlerTest.java
@@ -1,0 +1,322 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.flink.table.client.cli;
+
+import org.apache.flink.configuration.Configuration;
+import org.apache.flink.configuration.ReadableConfig;
+import org.apache.flink.table.client.config.SqlClientOptions;
+import org.apache.flink.table.client.gateway.Executor;
+import org.apache.flink.table.client.gateway.SqlExecutionException;
+import org.apache.flink.table.client.gateway.StatementResult;
+
+import org.apache.commons.lang3.tuple.Pair;
+import org.jline.terminal.Terminal;
+import org.jline.terminal.TerminalBuilder;
+import org.jline.utils.AttributedStringBuilder;
+import org.jline.utils.AttributedStyle;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.Arguments;
+import org.junit.jupiter.params.provider.MethodSource;
+
+import java.io.IOException;
+import java.text.ParseException;
+import java.text.SimpleDateFormat;
+import java.util.Collections;
+import java.util.Date;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Locale;
+import java.util.Map;
+import java.util.stream.Stream;
+
+import static org.apache.commons.lang3.tuple.Pair.of;
+import static org.apache.flink.table.client.cli.PromptHandlerTest.TestSpec.forPromptPattern;
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.jline.utils.AttributedStyle.DEFAULT;
+import static org.jline.utils.AttributedStyle.RED;
+import static org.junit.jupiter.params.provider.Arguments.of;
+
+/** Tests for {@link PromptHandler}. */
+class PromptHandlerTest {
+    private static final String CURRENT_CATALOG = "current_catalog";
+    private static final String CURRENT_DATABASE = "current_database";
+    private static final Map<String, SimpleDateFormat> FORMATTER_CACHE = new HashMap<>();
+
+    private static final Terminal TERMINAL;
+
+    static {
+        try {
+            TERMINAL = TerminalBuilder.terminal();
+            FORMATTER_CACHE.put("D", new SimpleDateFormat("yyyy-MM-dd HH:mm:ss.SSS", Locale.ROOT));
+            FORMATTER_CACHE.put("m", new SimpleDateFormat("mm", Locale.ROOT));
+            FORMATTER_CACHE.put("o", new SimpleDateFormat("MM", Locale.ROOT));
+            FORMATTER_CACHE.put("O", new SimpleDateFormat("MMM", Locale.ROOT));
+            FORMATTER_CACHE.put("P", new SimpleDateFormat("a", Locale.ROOT));
+            FORMATTER_CACHE.put("r", new SimpleDateFormat("hh:mm", Locale.ROOT));
+            FORMATTER_CACHE.put("R", new SimpleDateFormat("HH:mm", Locale.ROOT));
+            FORMATTER_CACHE.put("s", new SimpleDateFormat("ss", Locale.ROOT));
+            FORMATTER_CACHE.put("w", new SimpleDateFormat("d", Locale.ROOT));
+            FORMATTER_CACHE.put("W", new SimpleDateFormat("E", Locale.ROOT));
+            FORMATTER_CACHE.put("y", new SimpleDateFormat("yy", Locale.ROOT));
+            FORMATTER_CACHE.put("Y", new SimpleDateFormat("yyyy", Locale.ROOT));
+        } catch (IOException e) {
+            throw new RuntimeException(e);
+        }
+    }
+
+    @ParameterizedTest(name = "{0}")
+    @MethodSource("promptSupplier")
+    public void promptTest(TestSpec spec) {
+        Map<String, String> map = new HashMap<>();
+        map.put(SqlClientOptions.VERBOSE.key(), Boolean.FALSE.toString());
+        map.put(SqlClientOptions.PROMPT.key(), spec.promptPattern);
+        map.put("my_prop", "my_prop_value");
+        map.put("my_another_prop", "my_another_prop_value");
+        map.put("test", "my_prop_value");
+        PromptHandler dumbPromptHandler = getDumbPromptHandler(map);
+
+        SimpleDateFormat sdf;
+        if (spec.promptPattern.length() > 1
+                && (sdf = FORMATTER_CACHE.get(spec.promptPattern.substring(1))) != null) {
+            final Date start;
+            final Date parsed;
+            final Date end;
+            try {
+                start = sdf.parse(sdf.format(new Date()));
+                parsed = sdf.parse(dumbPromptHandler.getPrompt());
+                end = sdf.parse(sdf.format(new Date()));
+            } catch (ParseException e) {
+                throw new RuntimeException(e);
+            }
+            assertThat(parsed).isAfterOrEqualTo(start).isBeforeOrEqualTo(end);
+        } else {
+            assertThat(dumbPromptHandler.getPrompt()).isEqualTo(spec.expectedPromptValue);
+        }
+    }
+
+    static Stream<Arguments> promptSupplier() {
+        return Stream.of(
+                of(forPromptPattern(toAnsi("")).expectedPromptValue("")),
+                of(forPromptPattern(toAnsi("simple_prompt")).expectedPromptValue("simple_prompt")),
+                of(forPromptPattern(toAnsi("\\")).expectedPromptValue("")),
+                of(forPromptPattern(toAnsi("\\\\")).expectedPromptValue("\\")),
+                of(forPromptPattern(toAnsi("\\\\\\")).expectedPromptValue("\\")),
+                of(forPromptPattern(toAnsi("\\\\\\\\")).expectedPromptValue("\\\\")),
+                of(
+                        forPromptPattern(toAnsi(of("", DEFAULT.foreground(RED).bold())))
+                                .expectedPromptValue("")),
+                of(forPromptPattern(toAnsi("\\d")).expectedPromptValue(CURRENT_DATABASE)),
+                of(forPromptPattern(toAnsi("\\c")).expectedPromptValue(CURRENT_CATALOG)),
+                of(
+                        forPromptPattern(
+                                        toAnsi(
+                                                of("\\", DEFAULT),
+                                                of(
+                                                        "my prompt",
+                                                        DEFAULT.foreground(AttributedStyle.GREEN)
+                                                                .underline())))
+                                .expectedPromptValue(
+                                        toAnsi(
+                                                of(
+                                                        "my prompt",
+                                                        DEFAULT.foreground(AttributedStyle.GREEN)
+                                                                .underline())))),
+                // property value in prompt
+                of(
+                        forPromptPattern(toAnsi("\\:my_prop\\:>"))
+                                .propertyKey("my_prop")
+                                .propertyValue("my_prop_value")
+                                .expectedPromptValue("my_prop_value>")),
+                // escaping of backslash \
+                of(
+                        forPromptPattern(
+                                        toAnsi(
+                                                of(
+                                                        "\\\\[b:y,italic\\]\\:test\\:\\[default\\]>",
+                                                        DEFAULT)))
+                                .propertyKey("test")
+                                .propertyValue("my_prop_value")
+                                .expectedPromptValue("\\[b:y,italic]my_prop_value>")),
+                // not specified \X will be handled as X
+                of(forPromptPattern(toAnsi("\\X>")).expectedPromptValue("X>")),
+                // if any of patterns \[...\], \{...\}, \:...\: not closed it will be handled as \X
+                of(
+                        forPromptPattern(toAnsi("\\{ \\:my_another_prop\\:\\[default\\]>"))
+                                .propertyKey("my_another_prop")
+                                .propertyValue("my_another_prop_value")
+                                .expectedPromptValue("{ my_another_prop_value>")),
+                of(
+                        forPromptPattern(toAnsi("\\[default]\\:my_another_prop\\:>"))
+                                .propertyKey("my_another_prop")
+                                .propertyValue("my_another_prop_value")
+                                .expectedPromptValue("[default]my_another_prop_value>")),
+                // No need for expected value for date time since each time it could be different
+                of(forPromptPattern(toAnsi("\\D"))),
+                of(forPromptPattern(toAnsi("\\m"))),
+                of(forPromptPattern(toAnsi("\\o"))),
+                of(forPromptPattern(toAnsi("\\O"))),
+                of(forPromptPattern(toAnsi("\\P"))),
+                of(forPromptPattern(toAnsi("\\r"))),
+                of(forPromptPattern(toAnsi("\\R"))),
+                of(forPromptPattern(toAnsi("\\s"))),
+                of(forPromptPattern(toAnsi("\\w"))),
+                of(forPromptPattern(toAnsi("\\W"))),
+                of(forPromptPattern(toAnsi("\\y"))),
+                of(forPromptPattern(toAnsi("\\Y"))));
+    }
+
+    @ParameterizedTest(name = "{0}")
+    @MethodSource("invalidPromptSupplier")
+    void promptTestForInvalidInput(TestSpec spec) {
+        PromptHandler promptHandler =
+                getDumbPromptHandler(
+                        Collections.singletonMap(
+                                SqlClientOptions.VERBOSE.key(), Boolean.FALSE.toString()));
+        assertThat(promptHandler.getPrompt())
+                .as(SqlClientOptions.PROMPT.defaultValue())
+                .isEqualTo(SqlClientOptions.PROMPT.defaultValue());
+    }
+
+    static Stream<Arguments> invalidPromptSupplier() {
+        return Stream.of(
+                of(
+                        forPromptPattern(toAnsi("\\d"))
+                                .expectedPromptValue(SqlClientOptions.PROMPT.defaultValue())),
+                of(
+                        forPromptPattern(toAnsi("\\c"))
+                                .expectedPromptValue(SqlClientOptions.PROMPT.defaultValue())));
+    }
+
+    private static PromptHandler getDumbPromptHandler(Map<String, String> map) {
+        return new PromptHandler(
+                new Executor() {
+
+                    @Override
+                    public void configureSession(String statement) {}
+
+                    @Override
+                    public ReadableConfig getSessionConfig() throws SqlExecutionException {
+                        return Configuration.fromMap(map);
+                    }
+
+                    @Override
+                    public StatementResult executeStatement(String statement) {
+                        return null;
+                    }
+
+                    @Override
+                    public List<String> completeStatement(String statement, int position) {
+                        return null;
+                    }
+
+                    @Override
+                    public String getCurrentCatalog() {
+                        return CURRENT_CATALOG;
+                    }
+
+                    @Override
+                    public String getCurrentDatabase() {
+                        return CURRENT_DATABASE;
+                    }
+
+                    @Override
+                    public void close() {}
+                },
+                () -> TERMINAL);
+    }
+
+    // ------------------------------------------------------------------------------------------
+
+    static class TestSpec {
+        String expectedPromptValue;
+        boolean isDatePattern;
+
+        final String promptPattern;
+
+        String auxiliaryPropertyKey;
+
+        String auxiliaryPropertyValue;
+
+        private TestSpec(String promptPattern) {
+            this.promptPattern = promptPattern;
+        }
+
+        static TestSpec forPromptPattern(String promptPattern) {
+            return new TestSpec(promptPattern);
+        }
+
+        TestSpec expectedPromptValue(String expectedPromptValue) {
+            this.expectedPromptValue = expectedPromptValue;
+            return this;
+        }
+
+        TestSpec propertyKey(String propertyKey) {
+            this.auxiliaryPropertyKey = propertyKey;
+            return this;
+        }
+
+        TestSpec propertyValue(String propertyValue) {
+            this.auxiliaryPropertyValue = propertyValue;
+            return this;
+        }
+
+        TestSpec setDatePattern(boolean datePattern) {
+            isDatePattern = datePattern;
+            return this;
+        }
+
+        public String toString() {
+            return "Expected: "
+                    + expectedPromptValue
+                    + ", pattern: "
+                    + promptPattern
+                    + ", propertyKey: "
+                    + auxiliaryPropertyKey
+                    + ", propertyValue: "
+                    + auxiliaryPropertyValue;
+        }
+    }
+
+    private static Arguments params(String expectedAnsi, String promptPattern) {
+        return params(expectedAnsi, promptPattern, null, null);
+    }
+
+    private static Arguments params(
+            String expectedAnsi, String promptPattern, String propName, String propValue) {
+        return of(expectedAnsi, promptPattern, propName, propValue);
+    }
+
+    private static String toAnsi(String input) {
+        return toAnsi(of(input, DEFAULT));
+    }
+
+    private static String toAnsi(Pair<String, AttributedStyle> pair) {
+        AttributedStringBuilder builder = new AttributedStringBuilder();
+        builder.append(pair.getLeft(), pair.getRight());
+        return builder.toAnsi();
+    }
+
+    private static String toAnsi(
+            Pair<String, AttributedStyle> pair1, Pair<String, AttributedStyle> pair2) {
+        AttributedStringBuilder builder = new AttributedStringBuilder();
+        builder.append(pair1.getLeft(), pair1.getRight());
+        builder.append(pair2.getLeft(), pair2.getRight());
+        return builder.toAnsi();
+    }
+}

--- a/flink-table/flink-sql-gateway-api/src/main/java/org/apache/flink/table/gateway/api/SqlGatewayService.java
+++ b/flink-table/flink-sql-gateway-api/src/main/java/org/apache/flink/table/gateway/api/SqlGatewayService.java
@@ -221,6 +221,14 @@ public interface SqlGatewayService {
     String getCurrentCatalog(SessionHandle sessionHandle) throws SqlGatewayException;
 
     /**
+     * Return current database name.
+     *
+     * @param sessionHandle handle to identify the session.
+     * @return name of the current catalog.
+     */
+    String getCurrentDatabase(SessionHandle sessionHandle) throws SqlGatewayException;
+
+    /**
      * Return all available catalogs in the current session.
      *
      * @param sessionHandle handle to identify the session.

--- a/flink-table/flink-sql-gateway-api/src/test/java/org/apache/flink/table/gateway/api/utils/MockedSqlGatewayService.java
+++ b/flink-table/flink-sql-gateway-api/src/test/java/org/apache/flink/table/gateway/api/utils/MockedSqlGatewayService.java
@@ -135,6 +135,11 @@ public class MockedSqlGatewayService implements SqlGatewayService {
     }
 
     @Override
+    public String getCurrentDatabase(SessionHandle sessionHandle) throws SqlGatewayException {
+        throw new UnsupportedOperationException();
+    }
+
+    @Override
     public Set<String> listCatalogs(SessionHandle sessionHandle) throws SqlGatewayException {
         throw new UnsupportedOperationException();
     }

--- a/flink-table/flink-sql-gateway/src/main/java/org/apache/flink/table/gateway/rest/SqlGatewayRestEndpoint.java
+++ b/flink-table/flink-sql-gateway/src/main/java/org/apache/flink/table/gateway/rest/SqlGatewayRestEndpoint.java
@@ -36,6 +36,8 @@ import org.apache.flink.table.gateway.rest.handler.statement.CompleteStatementHa
 import org.apache.flink.table.gateway.rest.handler.statement.ExecuteStatementHandler;
 import org.apache.flink.table.gateway.rest.handler.statement.FetchResultsHandler;
 import org.apache.flink.table.gateway.rest.handler.util.GetApiVersionHandler;
+import org.apache.flink.table.gateway.rest.handler.util.GetCurrentCatalogHandler;
+import org.apache.flink.table.gateway.rest.handler.util.GetCurrentDatabaseHandler;
 import org.apache.flink.table.gateway.rest.handler.util.GetInfoHandler;
 import org.apache.flink.table.gateway.rest.header.operation.CancelOperationHeaders;
 import org.apache.flink.table.gateway.rest.header.operation.CloseOperationHeaders;
@@ -49,6 +51,8 @@ import org.apache.flink.table.gateway.rest.header.statement.CompleteStatementHea
 import org.apache.flink.table.gateway.rest.header.statement.ExecuteStatementHeaders;
 import org.apache.flink.table.gateway.rest.header.statement.FetchResultsHeaders;
 import org.apache.flink.table.gateway.rest.header.util.GetApiVersionHeaders;
+import org.apache.flink.table.gateway.rest.header.util.GetCurrentCatalogHeaders;
+import org.apache.flink.table.gateway.rest.header.util.GetCurrentDatabaseHeaders;
 import org.apache.flink.table.gateway.rest.header.util.GetInfoHeaders;
 import org.apache.flink.util.ConfigurationException;
 
@@ -114,6 +118,12 @@ public class SqlGatewayRestEndpoint extends RestServerEndpoint implements SqlGat
                 Tuple2.of(
                         TriggerSessionHeartbeatHeaders.getInstance(),
                         triggerSessionHeartbeatHandler));
+
+        // Get current catalog
+        GetCurrentCatalogHandler getCurrentCatalogHandler =
+                new GetCurrentCatalogHandler(
+                        service, responseHeaders, GetCurrentCatalogHeaders.getInstance());
+        handlers.add(Tuple2.of(GetCurrentCatalogHeaders.getInstance(), getCurrentCatalogHandler));
     }
 
     protected void addOperationRelatedHandlers(
@@ -150,6 +160,12 @@ public class SqlGatewayRestEndpoint extends RestServerEndpoint implements SqlGat
                 new GetApiVersionHandler(
                         service, responseHeaders, GetApiVersionHeaders.getInstance());
         handlers.add(Tuple2.of(GetApiVersionHeaders.getInstance(), getApiVersionHandler));
+
+        // Get current database
+        GetCurrentDatabaseHandler getCurrentDatabaseHandler =
+                new GetCurrentDatabaseHandler(
+                        service, responseHeaders, GetCurrentDatabaseHeaders.getInstance());
+        handlers.add(Tuple2.of(GetCurrentDatabaseHeaders.getInstance(), getCurrentDatabaseHandler));
     }
 
     private void addStatementRelatedHandlers(

--- a/flink-table/flink-sql-gateway/src/main/java/org/apache/flink/table/gateway/rest/handler/util/GetCurrentCatalogHandler.java
+++ b/flink-table/flink-sql-gateway/src/main/java/org/apache/flink/table/gateway/rest/handler/util/GetCurrentCatalogHandler.java
@@ -1,0 +1,75 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.flink.table.gateway.rest.handler.util;
+
+import org.apache.flink.annotation.VisibleForTesting;
+import org.apache.flink.runtime.rest.handler.HandlerRequest;
+import org.apache.flink.runtime.rest.handler.RestHandlerException;
+import org.apache.flink.runtime.rest.messages.EmptyRequestBody;
+import org.apache.flink.runtime.rest.messages.MessageHeaders;
+import org.apache.flink.table.gateway.api.SqlGatewayService;
+import org.apache.flink.table.gateway.api.session.SessionHandle;
+import org.apache.flink.table.gateway.api.utils.SqlGatewayException;
+import org.apache.flink.table.gateway.rest.handler.AbstractSqlGatewayRestHandler;
+import org.apache.flink.table.gateway.rest.message.session.SessionHandleIdPathParameter;
+import org.apache.flink.table.gateway.rest.message.session.SessionMessageParameters;
+import org.apache.flink.table.gateway.rest.message.util.GetCurrentCatalogResponseBody;
+import org.apache.flink.table.gateway.rest.util.SqlGatewayRestAPIVersion;
+
+import org.apache.flink.shaded.netty4.io.netty.handler.codec.http.HttpResponseStatus;
+
+import javax.annotation.Nonnull;
+import javax.annotation.Nullable;
+
+import java.util.Map;
+import java.util.concurrent.CompletableFuture;
+
+/** GetCurrentCatalogHandler. */
+public class GetCurrentCatalogHandler
+        extends AbstractSqlGatewayRestHandler<
+                EmptyRequestBody, GetCurrentCatalogResponseBody, SessionMessageParameters> {
+
+    @VisibleForTesting
+    public GetCurrentCatalogHandler(
+            SqlGatewayService service,
+            Map<String, String> responseHeaders,
+            MessageHeaders<
+                            EmptyRequestBody,
+                            GetCurrentCatalogResponseBody,
+                            SessionMessageParameters>
+                    messageHeaders) {
+        super(service, responseHeaders, messageHeaders);
+    }
+
+    @Override
+    protected CompletableFuture<GetCurrentCatalogResponseBody> handleRequest(
+            @Nullable SqlGatewayRestAPIVersion version,
+            @Nonnull HandlerRequest<EmptyRequestBody> request)
+            throws RestHandlerException {
+        try {
+            SessionHandle sessionHandle =
+                    request.getPathParameter(SessionHandleIdPathParameter.class);
+            return CompletableFuture.completedFuture(
+                    new GetCurrentCatalogResponseBody(service.getCurrentCatalog(sessionHandle)));
+        } catch (SqlGatewayException e) {
+            throw new RestHandlerException(
+                    e.getMessage(), HttpResponseStatus.INTERNAL_SERVER_ERROR, e);
+        }
+    }
+}

--- a/flink-table/flink-sql-gateway/src/main/java/org/apache/flink/table/gateway/rest/handler/util/GetCurrentDatabaseHandler.java
+++ b/flink-table/flink-sql-gateway/src/main/java/org/apache/flink/table/gateway/rest/handler/util/GetCurrentDatabaseHandler.java
@@ -1,0 +1,65 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.flink.table.gateway.rest.handler.util;
+
+import org.apache.flink.annotation.VisibleForTesting;
+import org.apache.flink.runtime.rest.handler.HandlerRequest;
+import org.apache.flink.runtime.rest.messages.EmptyRequestBody;
+import org.apache.flink.runtime.rest.messages.MessageHeaders;
+import org.apache.flink.table.gateway.api.SqlGatewayService;
+import org.apache.flink.table.gateway.api.session.SessionHandle;
+import org.apache.flink.table.gateway.rest.handler.AbstractSqlGatewayRestHandler;
+import org.apache.flink.table.gateway.rest.message.session.SessionHandleIdPathParameter;
+import org.apache.flink.table.gateway.rest.message.session.SessionMessageParameters;
+import org.apache.flink.table.gateway.rest.message.util.GetCurrentDatabaseResponseBody;
+import org.apache.flink.table.gateway.rest.util.SqlGatewayRestAPIVersion;
+
+import javax.annotation.Nonnull;
+import javax.annotation.Nullable;
+
+import java.util.Map;
+import java.util.concurrent.CompletableFuture;
+
+/** GetCurrentDatabaseHandler. */
+public class GetCurrentDatabaseHandler
+        extends AbstractSqlGatewayRestHandler<
+                EmptyRequestBody, GetCurrentDatabaseResponseBody, SessionMessageParameters> {
+
+    @VisibleForTesting
+    public GetCurrentDatabaseHandler(
+            SqlGatewayService service,
+            Map<String, String> responseHeaders,
+            MessageHeaders<
+                            EmptyRequestBody,
+                            GetCurrentDatabaseResponseBody,
+                            SessionMessageParameters>
+                    messageHeaders) {
+        super(service, responseHeaders, messageHeaders);
+    }
+
+    @Override
+    protected CompletableFuture<GetCurrentDatabaseResponseBody> handleRequest(
+            @Nullable SqlGatewayRestAPIVersion version,
+            @Nonnull HandlerRequest<EmptyRequestBody> request) {
+        final SessionHandle sessionHandle =
+                request.getPathParameter(SessionHandleIdPathParameter.class);
+        return CompletableFuture.completedFuture(
+                new GetCurrentDatabaseResponseBody(service.getCurrentDatabase(sessionHandle)));
+    }
+}

--- a/flink-table/flink-sql-gateway/src/main/java/org/apache/flink/table/gateway/rest/header/SqlGatewayMessageHeaders.java
+++ b/flink-table/flink-sql-gateway/src/main/java/org/apache/flink/table/gateway/rest/header/SqlGatewayMessageHeaders.java
@@ -27,6 +27,7 @@ import org.apache.flink.table.gateway.rest.util.SqlGatewayRestAPIVersion;
 
 import java.util.Arrays;
 import java.util.Collection;
+import java.util.EnumSet;
 import java.util.stream.Collectors;
 
 /**
@@ -45,8 +46,16 @@ public interface SqlGatewayMessageHeaders<
 
     @Override
     default Collection<? extends RestAPIVersion<?>> getSupportedAPIVersions() {
+        final int firstSupportedVersionOrdinal = getFirstSupportedAPIVersion().ordinal();
         return Arrays.stream(SqlGatewayRestAPIVersion.values())
                 .filter(SqlGatewayRestAPIVersion::isStableVersion)
-                .collect(Collectors.toList());
+                .filter(v -> v.ordinal() >= firstSupportedVersionOrdinal)
+                .collect(
+                        Collectors.toCollection(
+                                () -> EnumSet.noneOf(SqlGatewayRestAPIVersion.class)));
+    }
+
+    default SqlGatewayRestAPIVersion getFirstSupportedAPIVersion() {
+        return SqlGatewayRestAPIVersion.V0;
     }
 }

--- a/flink-table/flink-sql-gateway/src/main/java/org/apache/flink/table/gateway/rest/header/session/ConfigureSessionHeaders.java
+++ b/flink-table/flink-sql-gateway/src/main/java/org/apache/flink/table/gateway/rest/header/session/ConfigureSessionHeaders.java
@@ -20,7 +20,6 @@ package org.apache.flink.table.gateway.rest.header.session;
 
 import org.apache.flink.runtime.rest.HttpMethodWrapper;
 import org.apache.flink.runtime.rest.messages.EmptyResponseBody;
-import org.apache.flink.runtime.rest.versioning.RestAPIVersion;
 import org.apache.flink.table.gateway.rest.header.SqlGatewayMessageHeaders;
 import org.apache.flink.table.gateway.rest.message.session.ConfigureSessionRequestBody;
 import org.apache.flink.table.gateway.rest.message.session.SessionHandleIdPathParameter;
@@ -28,9 +27,6 @@ import org.apache.flink.table.gateway.rest.message.session.SessionMessageParamet
 import org.apache.flink.table.gateway.rest.util.SqlGatewayRestAPIVersion;
 
 import org.apache.flink.shaded.netty4.io.netty.handler.codec.http.HttpResponseStatus;
-
-import java.util.Collection;
-import java.util.Collections;
 
 /** Message headers for configuring a session. */
 public class ConfigureSessionHeaders
@@ -86,8 +82,8 @@ public class ConfigureSessionHeaders
     }
 
     @Override
-    public Collection<? extends RestAPIVersion<?>> getSupportedAPIVersions() {
-        return Collections.singleton(SqlGatewayRestAPIVersion.V2);
+    public SqlGatewayRestAPIVersion getFirstSupportedAPIVersion() {
+        return SqlGatewayRestAPIVersion.V2;
     }
 
     public static ConfigureSessionHeaders getInstance() {

--- a/flink-table/flink-sql-gateway/src/main/java/org/apache/flink/table/gateway/rest/header/util/GetCurrentCatalogHeaders.java
+++ b/flink-table/flink-sql-gateway/src/main/java/org/apache/flink/table/gateway/rest/header/util/GetCurrentCatalogHeaders.java
@@ -16,54 +16,28 @@
  * limitations under the License.
  */
 
-package org.apache.flink.table.gateway.rest.header.statement;
+package org.apache.flink.table.gateway.rest.header.util;
 
 import org.apache.flink.runtime.rest.HttpMethodWrapper;
+import org.apache.flink.runtime.rest.messages.EmptyRequestBody;
 import org.apache.flink.table.gateway.rest.header.SqlGatewayMessageHeaders;
 import org.apache.flink.table.gateway.rest.message.session.SessionHandleIdPathParameter;
 import org.apache.flink.table.gateway.rest.message.session.SessionMessageParameters;
-import org.apache.flink.table.gateway.rest.message.statement.CompleteStatementRequestBody;
-import org.apache.flink.table.gateway.rest.message.statement.CompleteStatementResponseBody;
+import org.apache.flink.table.gateway.rest.message.util.GetCurrentCatalogResponseBody;
 import org.apache.flink.table.gateway.rest.util.SqlGatewayRestAPIVersion;
 
 import org.apache.flink.shaded.netty4.io.netty.handler.codec.http.HttpResponseStatus;
 
-/** Message headers for completing a statement. */
-public class CompleteStatementHeaders
+/** GetCurrentCatalogHeaders. */
+public class GetCurrentCatalogHeaders
         implements SqlGatewayMessageHeaders<
-                CompleteStatementRequestBody,
-                CompleteStatementResponseBody,
-                SessionMessageParameters> {
-
-    private static final CompleteStatementHeaders INSTANCE = new CompleteStatementHeaders();
+                EmptyRequestBody, GetCurrentCatalogResponseBody, SessionMessageParameters> {
 
     private static final String URL =
-            "/sessions/:" + SessionHandleIdPathParameter.KEY + "/complete-statement";
+            "/sessions/:" + SessionHandleIdPathParameter.KEY + "/currentCatalog";
+    private static final GetCurrentCatalogHeaders INSTANCE = new GetCurrentCatalogHeaders();
 
-    @Override
-    public Class<CompleteStatementResponseBody> getResponseClass() {
-        return CompleteStatementResponseBody.class;
-    }
-
-    @Override
-    public HttpResponseStatus getResponseStatusCode() {
-        return HttpResponseStatus.OK;
-    }
-
-    @Override
-    public String getDescription() {
-        return "Get the completion hints for the given statement at the given position.";
-    }
-
-    @Override
-    public Class<CompleteStatementRequestBody> getRequestClass() {
-        return CompleteStatementRequestBody.class;
-    }
-
-    @Override
-    public SessionMessageParameters getUnresolvedMessageParameters() {
-        return new SessionMessageParameters();
-    }
+    private GetCurrentCatalogHeaders() {}
 
     @Override
     public HttpMethodWrapper getHttpMethod() {
@@ -76,16 +50,41 @@ public class CompleteStatementHeaders
     }
 
     @Override
-    public SqlGatewayRestAPIVersion getFirstSupportedAPIVersion() {
-        return SqlGatewayRestAPIVersion.V2;
+    public Class<GetCurrentCatalogResponseBody> getResponseClass() {
+        return GetCurrentCatalogResponseBody.class;
     }
 
-    public static CompleteStatementHeaders getInstance() {
+    @Override
+    public HttpResponseStatus getResponseStatusCode() {
+        return HttpResponseStatus.OK;
+    }
+
+    @Override
+    public String getDescription() {
+        return "Get current catalog.";
+    }
+
+    @Override
+    public Class<EmptyRequestBody> getRequestClass() {
+        return EmptyRequestBody.class;
+    }
+
+    @Override
+    public SessionMessageParameters getUnresolvedMessageParameters() {
+        return new SessionMessageParameters();
+    }
+
+    @Override
+    public SqlGatewayRestAPIVersion getFirstSupportedAPIVersion() {
+        return SqlGatewayRestAPIVersion.V3;
+    }
+
+    public static GetCurrentCatalogHeaders getInstance() {
         return INSTANCE;
     }
 
     @Override
     public String operationId() {
-        return "completeStatement";
+        return "getCurrentCatalog";
     }
 }

--- a/flink-table/flink-sql-gateway/src/main/java/org/apache/flink/table/gateway/rest/header/util/GetCurrentDatabaseHeaders.java
+++ b/flink-table/flink-sql-gateway/src/main/java/org/apache/flink/table/gateway/rest/header/util/GetCurrentDatabaseHeaders.java
@@ -16,54 +16,28 @@
  * limitations under the License.
  */
 
-package org.apache.flink.table.gateway.rest.header.statement;
+package org.apache.flink.table.gateway.rest.header.util;
 
 import org.apache.flink.runtime.rest.HttpMethodWrapper;
+import org.apache.flink.runtime.rest.messages.EmptyRequestBody;
 import org.apache.flink.table.gateway.rest.header.SqlGatewayMessageHeaders;
 import org.apache.flink.table.gateway.rest.message.session.SessionHandleIdPathParameter;
 import org.apache.flink.table.gateway.rest.message.session.SessionMessageParameters;
-import org.apache.flink.table.gateway.rest.message.statement.CompleteStatementRequestBody;
-import org.apache.flink.table.gateway.rest.message.statement.CompleteStatementResponseBody;
+import org.apache.flink.table.gateway.rest.message.util.GetCurrentDatabaseResponseBody;
 import org.apache.flink.table.gateway.rest.util.SqlGatewayRestAPIVersion;
 
 import org.apache.flink.shaded.netty4.io.netty.handler.codec.http.HttpResponseStatus;
 
-/** Message headers for completing a statement. */
-public class CompleteStatementHeaders
+/** GetCurrentDatabaseHeaders. */
+public class GetCurrentDatabaseHeaders
         implements SqlGatewayMessageHeaders<
-                CompleteStatementRequestBody,
-                CompleteStatementResponseBody,
-                SessionMessageParameters> {
-
-    private static final CompleteStatementHeaders INSTANCE = new CompleteStatementHeaders();
+                EmptyRequestBody, GetCurrentDatabaseResponseBody, SessionMessageParameters> {
 
     private static final String URL =
-            "/sessions/:" + SessionHandleIdPathParameter.KEY + "/complete-statement";
+            "/sessions/:" + SessionHandleIdPathParameter.KEY + "/currentDatabase";
+    private static final GetCurrentDatabaseHeaders INSTANCE = new GetCurrentDatabaseHeaders();
 
-    @Override
-    public Class<CompleteStatementResponseBody> getResponseClass() {
-        return CompleteStatementResponseBody.class;
-    }
-
-    @Override
-    public HttpResponseStatus getResponseStatusCode() {
-        return HttpResponseStatus.OK;
-    }
-
-    @Override
-    public String getDescription() {
-        return "Get the completion hints for the given statement at the given position.";
-    }
-
-    @Override
-    public Class<CompleteStatementRequestBody> getRequestClass() {
-        return CompleteStatementRequestBody.class;
-    }
-
-    @Override
-    public SessionMessageParameters getUnresolvedMessageParameters() {
-        return new SessionMessageParameters();
-    }
+    private GetCurrentDatabaseHeaders() {}
 
     @Override
     public HttpMethodWrapper getHttpMethod() {
@@ -76,16 +50,41 @@ public class CompleteStatementHeaders
     }
 
     @Override
-    public SqlGatewayRestAPIVersion getFirstSupportedAPIVersion() {
-        return SqlGatewayRestAPIVersion.V2;
+    public Class<GetCurrentDatabaseResponseBody> getResponseClass() {
+        return GetCurrentDatabaseResponseBody.class;
     }
 
-    public static CompleteStatementHeaders getInstance() {
+    @Override
+    public HttpResponseStatus getResponseStatusCode() {
+        return HttpResponseStatus.OK;
+    }
+
+    @Override
+    public String getDescription() {
+        return "Get current database.";
+    }
+
+    @Override
+    public Class<EmptyRequestBody> getRequestClass() {
+        return EmptyRequestBody.class;
+    }
+
+    @Override
+    public SessionMessageParameters getUnresolvedMessageParameters() {
+        return new SessionMessageParameters();
+    }
+
+    @Override
+    public SqlGatewayRestAPIVersion getFirstSupportedAPIVersion() {
+        return SqlGatewayRestAPIVersion.V3;
+    }
+
+    public static GetCurrentDatabaseHeaders getInstance() {
         return INSTANCE;
     }
 
     @Override
     public String operationId() {
-        return "completeStatement";
+        return "getCurrentDatabase";
     }
 }

--- a/flink-table/flink-sql-gateway/src/main/java/org/apache/flink/table/gateway/rest/message/util/GetCurrentCatalogResponseBody.java
+++ b/flink-table/flink-sql-gateway/src/main/java/org/apache/flink/table/gateway/rest/message/util/GetCurrentCatalogResponseBody.java
@@ -1,0 +1,45 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.flink.table.gateway.rest.message.util;
+
+import org.apache.flink.runtime.rest.messages.ResponseBody;
+
+import org.apache.flink.shaded.jackson2.com.fasterxml.jackson.annotation.JsonCreator;
+import org.apache.flink.shaded.jackson2.com.fasterxml.jackson.annotation.JsonInclude;
+import org.apache.flink.shaded.jackson2.com.fasterxml.jackson.annotation.JsonProperty;
+
+/** {@link ResponseBody} for getting current catalog. */
+@JsonInclude(JsonInclude.Include.NON_NULL)
+public class GetCurrentCatalogResponseBody implements ResponseBody {
+
+    private static final String FIELD_CURRENT_CATALOG = "currentCatalog";
+
+    @JsonProperty(FIELD_CURRENT_CATALOG)
+    private final String currentCatalog;
+
+    @JsonCreator
+    public GetCurrentCatalogResponseBody(
+            @JsonProperty(FIELD_CURRENT_CATALOG) String currentCatalog) {
+        this.currentCatalog = currentCatalog;
+    }
+
+    public String getCurrentCatalog() {
+        return currentCatalog;
+    }
+}

--- a/flink-table/flink-sql-gateway/src/main/java/org/apache/flink/table/gateway/rest/message/util/GetCurrentDatabaseResponseBody.java
+++ b/flink-table/flink-sql-gateway/src/main/java/org/apache/flink/table/gateway/rest/message/util/GetCurrentDatabaseResponseBody.java
@@ -1,0 +1,45 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.flink.table.gateway.rest.message.util;
+
+import org.apache.flink.runtime.rest.messages.ResponseBody;
+
+import org.apache.flink.shaded.jackson2.com.fasterxml.jackson.annotation.JsonCreator;
+import org.apache.flink.shaded.jackson2.com.fasterxml.jackson.annotation.JsonInclude;
+import org.apache.flink.shaded.jackson2.com.fasterxml.jackson.annotation.JsonProperty;
+
+/** {@link ResponseBody} for getting current catalog. */
+@JsonInclude(JsonInclude.Include.NON_NULL)
+public class GetCurrentDatabaseResponseBody implements ResponseBody {
+
+    private static final String FIELD_CURRENT_DATABASE = "currentDatabase";
+
+    @JsonProperty(FIELD_CURRENT_DATABASE)
+    private final String currentDatabase;
+
+    @JsonCreator
+    public GetCurrentDatabaseResponseBody(
+            @JsonProperty(FIELD_CURRENT_DATABASE) String currentDatabase) {
+        this.currentDatabase = currentDatabase;
+    }
+
+    public String getCurrentDatabase() {
+        return currentDatabase;
+    }
+}

--- a/flink-table/flink-sql-gateway/src/main/java/org/apache/flink/table/gateway/rest/util/SqlGatewayRestAPIVersion.java
+++ b/flink-table/flink-sql-gateway/src/main/java/org/apache/flink/table/gateway/rest/util/SqlGatewayRestAPIVersion.java
@@ -48,7 +48,10 @@ public enum SqlGatewayRestAPIVersion
 
     // V2 adds support for configuring Session and allows to serialize the RowData with PLAIN_TEXT
     // or JSON format.
-    V2(true, true);
+    V2(false, true),
+
+    // V3 adds support for getting of current catalog and database
+    V3(true, true);
 
     private final boolean isDefaultVersion;
 

--- a/flink-table/flink-sql-gateway/src/main/java/org/apache/flink/table/gateway/service/SqlGatewayServiceImpl.java
+++ b/flink-table/flink-sql-gateway/src/main/java/org/apache/flink/table/gateway/service/SqlGatewayServiceImpl.java
@@ -252,6 +252,11 @@ public class SqlGatewayServiceImpl implements SqlGatewayService {
     }
 
     @Override
+    public String getCurrentDatabase(SessionHandle sessionHandle) {
+        return getSession(sessionHandle).createExecutor().getCurrentDatabase();
+    }
+
+    @Override
     public Set<String> listCatalogs(SessionHandle sessionHandle) throws SqlGatewayException {
         try {
             return getSession(sessionHandle).createExecutor().listCatalogs();

--- a/flink-table/flink-sql-gateway/src/main/java/org/apache/flink/table/gateway/service/operation/OperationExecutor.java
+++ b/flink-table/flink-sql-gateway/src/main/java/org/apache/flink/table/gateway/service/operation/OperationExecutor.java
@@ -199,6 +199,10 @@ public class OperationExecutor {
         return sessionContext.getSessionState().catalogManager.getCurrentCatalog();
     }
 
+    public String getCurrentDatabase() {
+        return sessionContext.getSessionState().catalogManager.getCurrentDatabase();
+    }
+
     public Set<String> listCatalogs() {
         return sessionContext.getSessionState().catalogManager.listCatalogs();
     }

--- a/flink-table/flink-sql-gateway/src/test/resources/sql_gateway_rest_api_v3.snapshot
+++ b/flink-table/flink-sql-gateway/src/test/resources/sql_gateway_rest_api_v3.snapshot
@@ -1,0 +1,437 @@
+{
+  "calls" : [ {
+    "url" : "/api_versions",
+    "method" : "GET",
+    "status-code" : "200 OK",
+    "file-upload" : false,
+    "path-parameters" : {
+      "pathParameters" : [ ]
+    },
+    "query-parameters" : {
+      "queryParameters" : [ ]
+    },
+    "request" : {
+      "type" : "object",
+      "id" : "urn:jsonschema:org:apache:flink:runtime:rest:messages:EmptyRequestBody"
+    },
+    "response" : {
+      "type" : "object",
+      "id" : "urn:jsonschema:org:apache:flink:table:gateway:rest:message:util:GetApiVersionResponseBody",
+      "properties" : {
+        "versions" : {
+          "type" : "array",
+          "items" : {
+            "type" : "string"
+          }
+        }
+      }
+    }
+  }, {
+    "url" : "/info",
+    "method" : "GET",
+    "status-code" : "200 OK",
+    "file-upload" : false,
+    "path-parameters" : {
+      "pathParameters" : [ ]
+    },
+    "query-parameters" : {
+      "queryParameters" : [ ]
+    },
+    "request" : {
+      "type" : "object",
+      "id" : "urn:jsonschema:org:apache:flink:runtime:rest:messages:EmptyRequestBody"
+    },
+    "response" : {
+      "type" : "object",
+      "id" : "urn:jsonschema:org:apache:flink:table:gateway:rest:message:util:GetInfoResponseBody",
+      "properties" : {
+        "productName" : {
+          "type" : "string"
+        },
+        "version" : {
+          "type" : "string"
+        }
+      }
+    }
+  }, {
+    "url" : "/sessions",
+    "method" : "POST",
+    "status-code" : "200 OK",
+    "file-upload" : false,
+    "path-parameters" : {
+      "pathParameters" : [ ]
+    },
+    "query-parameters" : {
+      "queryParameters" : [ ]
+    },
+    "request" : {
+      "type" : "object",
+      "id" : "urn:jsonschema:org:apache:flink:table:gateway:rest:message:session:OpenSessionRequestBody",
+      "properties" : {
+        "sessionName" : {
+          "type" : "string"
+        },
+        "properties" : {
+          "type" : "object",
+          "additionalProperties" : {
+            "type" : "string"
+          }
+        }
+      }
+    },
+    "response" : {
+      "type" : "object",
+      "id" : "urn:jsonschema:org:apache:flink:table:gateway:rest:message:session:OpenSessionResponseBody",
+      "properties" : {
+        "sessionHandle" : {
+          "type" : "string"
+        }
+      }
+    }
+  }, {
+    "url" : "/sessions/:session_handle",
+    "method" : "DELETE",
+    "status-code" : "200 OK",
+    "file-upload" : false,
+    "path-parameters" : {
+      "pathParameters" : [ {
+        "key" : "session_handle"
+      } ]
+    },
+    "query-parameters" : {
+      "queryParameters" : [ ]
+    },
+    "request" : {
+      "type" : "object",
+      "id" : "urn:jsonschema:org:apache:flink:runtime:rest:messages:EmptyRequestBody"
+    },
+    "response" : {
+      "type" : "object",
+      "id" : "urn:jsonschema:org:apache:flink:table:gateway:rest:message:session:CloseSessionResponseBody",
+      "properties" : {
+        "status" : {
+          "type" : "string"
+        }
+      }
+    }
+  }, {
+    "url" : "/sessions/:session_handle",
+    "method" : "GET",
+    "status-code" : "200 OK",
+    "file-upload" : false,
+    "path-parameters" : {
+      "pathParameters" : [ {
+        "key" : "session_handle"
+      } ]
+    },
+    "query-parameters" : {
+      "queryParameters" : [ ]
+    },
+    "request" : {
+      "type" : "object",
+      "id" : "urn:jsonschema:org:apache:flink:runtime:rest:messages:EmptyRequestBody"
+    },
+    "response" : {
+      "type" : "object",
+      "id" : "urn:jsonschema:org:apache:flink:table:gateway:rest:message:session:GetSessionConfigResponseBody",
+      "properties" : {
+        "properties" : {
+          "type" : "object",
+          "additionalProperties" : {
+            "type" : "string"
+          }
+        }
+      }
+    }
+  }, {
+    "url" : "/sessions/:session_handle/complete-statement",
+    "method" : "GET",
+    "status-code" : "200 OK",
+    "file-upload" : false,
+    "path-parameters" : {
+      "pathParameters" : [ {
+        "key" : "session_handle"
+      } ]
+    },
+    "query-parameters" : {
+      "queryParameters" : [ ]
+    },
+    "request" : {
+      "type" : "object",
+      "id" : "urn:jsonschema:org:apache:flink:table:gateway:rest:message:statement:CompleteStatementRequestBody",
+      "properties" : {
+        "statement" : {
+          "type" : "string"
+        },
+        "position" : {
+          "type" : "integer"
+        }
+      }
+    },
+    "response" : {
+      "type" : "object",
+      "id" : "urn:jsonschema:org:apache:flink:table:gateway:rest:message:statement:CompleteStatementResponseBody",
+      "properties" : {
+        "candidates" : {
+          "type" : "array",
+          "items" : {
+            "type" : "string"
+          }
+        }
+      }
+    }
+  }, {
+    "url" : "/sessions/:session_handle/configure-session",
+    "method" : "POST",
+    "status-code" : "200 OK",
+    "file-upload" : false,
+    "path-parameters" : {
+      "pathParameters" : [ {
+        "key" : "session_handle"
+      } ]
+    },
+    "query-parameters" : {
+      "queryParameters" : [ ]
+    },
+    "request" : {
+      "type" : "object",
+      "id" : "urn:jsonschema:org:apache:flink:table:gateway:rest:message:session:ConfigureSessionRequestBody",
+      "properties" : {
+        "statement" : {
+          "type" : "string"
+        },
+        "executionTimeout" : {
+          "type" : "integer"
+        }
+      }
+    },
+    "response" : {
+      "type" : "object",
+      "id" : "urn:jsonschema:org:apache:flink:runtime:rest:messages:EmptyResponseBody"
+    }
+  }, {
+    "url" : "/sessions/:session_handle/currentCatalog",
+    "method" : "GET",
+    "status-code" : "200 OK",
+    "file-upload" : false,
+    "path-parameters" : {
+      "pathParameters" : [ {
+        "key" : "session_handle"
+      } ]
+    },
+    "query-parameters" : {
+      "queryParameters" : [ ]
+    },
+    "request" : {
+      "type" : "object",
+      "id" : "urn:jsonschema:org:apache:flink:runtime:rest:messages:EmptyRequestBody"
+    },
+    "response" : {
+      "type" : "object",
+      "id" : "urn:jsonschema:org:apache:flink:table:gateway:rest:message:util:GetCurrentCatalogResponseBody",
+      "properties" : {
+        "currentCatalog" : {
+          "type" : "string"
+        }
+      }
+    }
+  }, {
+    "url" : "/sessions/:session_handle/currentDatabase",
+    "method" : "GET",
+    "status-code" : "200 OK",
+    "file-upload" : false,
+    "path-parameters" : {
+      "pathParameters" : [ {
+        "key" : "session_handle"
+      } ]
+    },
+    "query-parameters" : {
+      "queryParameters" : [ ]
+    },
+    "request" : {
+      "type" : "object",
+      "id" : "urn:jsonschema:org:apache:flink:runtime:rest:messages:EmptyRequestBody"
+    },
+    "response" : {
+      "type" : "object",
+      "id" : "urn:jsonschema:org:apache:flink:table:gateway:rest:message:util:GetCurrentDatabaseResponseBody",
+      "properties" : {
+        "currentDatabase" : {
+          "type" : "string"
+        }
+      }
+    }
+  }, {
+    "url" : "/sessions/:session_handle/heartbeat",
+    "method" : "POST",
+    "status-code" : "200 OK",
+    "file-upload" : false,
+    "path-parameters" : {
+      "pathParameters" : [ {
+        "key" : "session_handle"
+      } ]
+    },
+    "query-parameters" : {
+      "queryParameters" : [ ]
+    },
+    "request" : {
+      "type" : "object",
+      "id" : "urn:jsonschema:org:apache:flink:runtime:rest:messages:EmptyRequestBody"
+    },
+    "response" : {
+      "type" : "object",
+      "id" : "urn:jsonschema:org:apache:flink:runtime:rest:messages:EmptyResponseBody"
+    }
+  }, {
+    "url" : "/sessions/:session_handle/operations/:operation_handle/cancel",
+    "method" : "POST",
+    "status-code" : "200 OK",
+    "file-upload" : false,
+    "path-parameters" : {
+      "pathParameters" : [ {
+        "key" : "session_handle"
+      }, {
+        "key" : "operation_handle"
+      } ]
+    },
+    "query-parameters" : {
+      "queryParameters" : [ ]
+    },
+    "request" : {
+      "type" : "object",
+      "id" : "urn:jsonschema:org:apache:flink:runtime:rest:messages:EmptyRequestBody"
+    },
+    "response" : {
+      "type" : "object",
+      "id" : "urn:jsonschema:org:apache:flink:table:gateway:rest:message:operation:OperationStatusResponseBody",
+      "properties" : {
+        "status" : {
+          "type" : "string"
+        }
+      }
+    }
+  }, {
+    "url" : "/sessions/:session_handle/operations/:operation_handle/close",
+    "method" : "DELETE",
+    "status-code" : "200 OK",
+    "file-upload" : false,
+    "path-parameters" : {
+      "pathParameters" : [ {
+        "key" : "session_handle"
+      }, {
+        "key" : "operation_handle"
+      } ]
+    },
+    "query-parameters" : {
+      "queryParameters" : [ ]
+    },
+    "request" : {
+      "type" : "object",
+      "id" : "urn:jsonschema:org:apache:flink:runtime:rest:messages:EmptyRequestBody"
+    },
+    "response" : {
+      "type" : "object",
+      "id" : "urn:jsonschema:org:apache:flink:table:gateway:rest:message:operation:OperationStatusResponseBody",
+      "properties" : {
+        "status" : {
+          "type" : "string"
+        }
+      }
+    }
+  }, {
+    "url" : "/sessions/:session_handle/operations/:operation_handle/result/:token",
+    "method" : "GET",
+    "status-code" : "200 OK",
+    "file-upload" : false,
+    "path-parameters" : {
+      "pathParameters" : [ {
+        "key" : "session_handle"
+      }, {
+        "key" : "operation_handle"
+      }, {
+        "key" : "token"
+      } ]
+    },
+    "query-parameters" : {
+      "queryParameters" : [ {
+        "key" : "rowFormat",
+        "mandatory" : true
+      } ]
+    },
+    "request" : {
+      "type" : "object",
+      "id" : "urn:jsonschema:org:apache:flink:runtime:rest:messages:EmptyRequestBody"
+    },
+    "response" : {
+      "type" : "any"
+    }
+  }, {
+    "url" : "/sessions/:session_handle/operations/:operation_handle/status",
+    "method" : "GET",
+    "status-code" : "200 OK",
+    "file-upload" : false,
+    "path-parameters" : {
+      "pathParameters" : [ {
+        "key" : "session_handle"
+      }, {
+        "key" : "operation_handle"
+      } ]
+    },
+    "query-parameters" : {
+      "queryParameters" : [ ]
+    },
+    "request" : {
+      "type" : "object",
+      "id" : "urn:jsonschema:org:apache:flink:runtime:rest:messages:EmptyRequestBody"
+    },
+    "response" : {
+      "type" : "object",
+      "id" : "urn:jsonschema:org:apache:flink:table:gateway:rest:message:operation:OperationStatusResponseBody",
+      "properties" : {
+        "status" : {
+          "type" : "string"
+        }
+      }
+    }
+  }, {
+    "url" : "/sessions/:session_handle/statements",
+    "method" : "POST",
+    "status-code" : "200 OK",
+    "file-upload" : false,
+    "path-parameters" : {
+      "pathParameters" : [ {
+        "key" : "session_handle"
+      } ]
+    },
+    "query-parameters" : {
+      "queryParameters" : [ ]
+    },
+    "request" : {
+      "type" : "object",
+      "id" : "urn:jsonschema:org:apache:flink:table:gateway:rest:message:statement:ExecuteStatementRequestBody",
+      "properties" : {
+        "statement" : {
+          "type" : "string"
+        },
+        "executionTimeout" : {
+          "type" : "integer"
+        },
+        "executionConfig" : {
+          "type" : "object",
+          "additionalProperties" : {
+            "type" : "string"
+          }
+        }
+      }
+    },
+    "response" : {
+      "type" : "object",
+      "id" : "urn:jsonschema:org:apache:flink:table:gateway:rest:message:statement:ExecuteStatementResponseBody",
+      "properties" : {
+        "operationHandle" : {
+          "type" : "string"
+        }
+      }
+    }
+  } ]
+}


### PR DESCRIPTION
## What is the purpose of the change

This PR is a part of FLIP-189 about prompt customization.

There are left and right prompt which could be customized in the same way.
Left prompt could be customized via `sql-client.display.prompt.pattern` property and right prompt via `sql-client.display.right-prompt.pattern`.
There is a number of things which could be done: different datetime patterns (compatible with SimpleDateFormat), colors, styles, showing current database and catalog, showing specified current property's values.
Examples:
```
-- change left prompt to "my_prompt>"
SET 'sql-client.display.prompt.pattern'='my_prompt>'; 


-- show current database in prompt like "default_database prompt>"
SET 'sql-client.display.prompt.pattern'='\d prompt>'; 


-- show current catalog in prompt like "default_catalog prompt>"
SET 'sql-client.display.prompt.pattern'='\c prompt>'; 


-- show current timestamp in prompt like "2022-04-21 11:11:39.071 prompt>"
SET 'sql-client.display.prompt.pattern'='\D prompt>'; 


-- show property value like "localhost prompt>"
SET 'sql-client.display.prompt.pattern'='\:taskmanager.host\: prompt>';


-- apply style and colors
SET 'sql-client.display.prompt.pattern'='\[f-rgb:#aaaaaa,bold\]\:taskmanager.host\: \[f:g,underline\]prompt>';
```
The same could be applied to right prompts.
The whole range is covered in documentation with some examples at [1]
Also there are some details at FLIP's page [2]

[1]  https://github.com/apache/flink/pull/17830/files#diff-c12a360080e42a64d69dd6c65fd8af77c0d6ef337fa7833c3a8b16b1759d1a11R237-R281
[2] https://cwiki.apache.org/confluence/display/FLINK/FLIP-189%3A+SQL+Client+Usability+Improvements#FLIP189:SQLClientUsabilityImprovements-Supportedpromptoptions(bothforleftandrightprompts) 

## Brief change log

- Enable left and right prompt customization via properties
- Enable styles, property values, datetime patterns compatible with SimpleDateFormat

## Verifying this change
There is a class with tests
`org.apache.flink.table.client.cli.PromptHandlerTest`

## Does this pull request potentially affect one of the following parts:

  - Dependencies (does it add or upgrade a dependency): (yes / **no**)
  - The public API, i.e., is any changed class annotated with `@Public(Evolving)`: (yes / **no**)
  - The serializers: (yes / **no** / don't know)
  - The runtime per-record code paths (performance sensitive): (yes / **no** / don't know)
  - Anything that affects deployment or recovery: JobManager (and its components), Checkpointing, Kubernetes/Yarn, ZooKeeper: (yes / **no** / don't know)
  - The S3 file system connector: (yes / **no** / don't know)

## Documentation

  - Does this pull request introduce a new feature? (**yes** / no)
  - If yes, how is the feature documented? (not applicable / **docs** / JavaDocs / not documented)
