### PR TITLE
[FLINK-24785][runtime] Relocate RocksDB's log under flink log directory by default

### DIFF
--- a/docs/layouts/shortcodes/generated/rocksdb_configurable_configuration.html
+++ b/docs/layouts/shortcodes/generated/rocksdb_configurable_configuration.html
@@ -72,7 +72,7 @@
             <td><h5>state.backend.rocksdb.log.dir</h5></td>
             <td style="word-wrap: break-word;">(none)</td>
             <td>String</td>
-            <td>The directory for RocksDB's information logging files. If empty (Flink default setting), log files will be in the same directory as data files. If non-empty, this directory will be used and the data directory's absolute path will be used as the prefix of the log file name.</td>
+            <td>The directory for RocksDB's information logging files. If empty (Flink default setting), log files will be in the same directory as the Flink log. If non-empty, this directory will be used and the data directory's absolute path will be used as the prefix of the log file name.</td>
         </tr>
         <tr>
             <td><h5>state.backend.rocksdb.log.file-num</h5></td>

--- a/flink-end-to-end-tests/test-scripts/common.sh
+++ b/flink-end-to-end-tests/test-scripts/common.sh
@@ -369,6 +369,7 @@ function check_logs_for_errors {
       | grep -v "error_prone_annotations" \
       | grep -v "Error sending fetch request" \
       | grep -v "WARN  akka.remote.ReliableDeliverySupervisor" \
+      | grep -v "Options.*error_*" \
       | grep -ic "error" || true)
   if [[ ${error_count} -gt 0 ]]; then
     echo "Found error in log files; printing first 500 lines; see full logs for details:"

--- a/flink-state-backends/flink-statebackend-rocksdb/src/main/java/org/apache/flink/contrib/streaming/state/RocksDBConfigurableOptions.java
+++ b/flink-state-backends/flink-statebackend-rocksdb/src/main/java/org/apache/flink/contrib/streaming/state/RocksDBConfigurableOptions.java
@@ -93,7 +93,7 @@ public class RocksDBConfigurableOptions implements Serializable {
                     .noDefaultValue()
                     .withDescription(
                             "The directory for RocksDB's information logging files. "
-                                    + "If empty (Flink default setting), log files will be in the same directory as data files. "
+                                    + "If empty (Flink default setting), log files will be in the same directory as the Flink log. "
                                     + "If non-empty, this directory will be used and the data directory's absolute path will be used as the prefix of the log file name.");
 
     public static final ConfigOption<InfoLogLevel> LOG_LEVEL =

--- a/flink-state-backends/flink-statebackend-rocksdb/src/test/java/org/apache/flink/contrib/streaming/state/RocksDBStateBackendConfigTest.java
+++ b/flink-state-backends/flink-statebackend-rocksdb/src/test/java/org/apache/flink/contrib/streaming/state/RocksDBStateBackendConfigTest.java
@@ -97,6 +97,19 @@ public class RocksDBStateBackendConfigTest {
         assertEquals(defaultIncremental, backend.isIncrementalCheckpointsEnabled());
     }
 
+    @Test
+    public void testDefaultDbLogDir() throws Exception {
+        final EmbeddedRocksDBStateBackend backend = new EmbeddedRocksDBStateBackend();
+        final File logFile = File.createTempFile(getClass().getSimpleName() + "-", ".log");
+        // set the environment variable 'log.file' with the Flink log file location
+        System.setProperty("log.file", logFile.getPath());
+        try (RocksDBResourceContainer container = backend.createOptionsAndResourceContainer()) {
+            assertEquals(logFile.getParent(), container.getDbOptions().dbLogDir());
+        } finally {
+            logFile.delete();
+        }
+    }
+
     // ------------------------------------------------------------------------
     //  RocksDB local file directory
     // ------------------------------------------------------------------------


### PR DESCRIPTION
## What is the purpose of the change

*Previously, RocksDB's log locates at its own DB folder, which makes the debuging RocksDB not so easy. We could let RocksDB's log stay in Flink's log directory by default. The default `log_dir` of the `DBOptions` should be the Flink log directory path.*

## Brief change log

  - *Relocates the RocksDB's log directory option of the `DBOptions` to the Flink log directory in `RocksDBResourceContainer`.*

## Verifying this change

  - *Adds the test `testRelocateDBOptionsLogDir` in `RocksDBResourceContainerTest` to verify whether the log directory of the RocksDB reloates to the Flink log directory by default.*

## Does this pull request potentially affect one of the following parts:

  - Dependencies (does it add or upgrade a dependency): (yes / **no**)
  - The public API, i.e., is any changed class annotated with `@Public(Evolving)`: (yes / **no**)
  - The serializers: (yes / **no** / don't know)
  - The runtime per-record code paths (performance sensitive): (yes / **no** / don't know)
  - Anything that affects deployment or recovery: JobManager (and its components), Checkpointing, Kubernetes/Yarn, ZooKeeper: (yes / **no** / don't know)
  - The S3 file system connector: (yes / **no** / don't know)

## Documentation

  - Does this pull request introduce a new feature? (yes / **no**)
  - If yes, how is the feature documented? (**not applicable** / docs / JavaDocs / not documented)