### PR TITLE
[FLINK-24941][datadog] Support Boolean gauges

### DIFF
--- a/flink-metrics/flink-metrics-datadog/src/main/java/org/apache/flink/metrics/datadog/DGauge.java
+++ b/flink-metrics/flink-metrics-datadog/src/main/java/org/apache/flink/metrics/datadog/DGauge.java
@@ -23,16 +23,21 @@ import org.apache.flink.metrics.Gauge;
 import java.util.List;
 
 /** Mapping of gauge between Flink and Datadog. */
-public class DGauge extends DMetric {
-    private final Gauge<Number> gauge;
+public class DGauge<T> extends DMetric {
+    private final Gauge<T> gauge;
 
-    public DGauge(Gauge<Number> g, String metricName, String host, List<String> tags, Clock clock) {
+    public DGauge(Gauge<T> g, String metricName, String host, List<String> tags, Clock clock) {
         super(new MetricMetaData(MetricType.gauge, metricName, host, tags, clock));
         gauge = g;
     }
 
     @Override
     public Number getMetricValue() {
-        return gauge.getValue();
+        T value = gauge.getValue();
+        if (value instanceof Boolean) {
+            return ((Boolean) value) ? 1 : 0;
+        } else {
+            return (Number) value;
+        }
     }
 }

--- a/flink-metrics/flink-metrics-datadog/src/test/java/org/apache/flink/metrics/datadog/DCounterTest.java
+++ b/flink-metrics/flink-metrics-datadog/src/test/java/org/apache/flink/metrics/datadog/DCounterTest.java
@@ -70,7 +70,11 @@ public class DCounterTest extends TestLogger {
 
         final DGauge<Object> gauge =
                 new DGauge<>(
-                        () -> gaugeValue[0], "gauge", "localhost", Collections.emptyList(), () -> 0);
+                        () -> gaugeValue[0],
+                        "gauge",
+                        "localhost",
+                        Collections.emptyList(),
+                        () -> 0);
 
         // sane initial state
         assertNull(gauge.getMetricValue());

--- a/flink-metrics/flink-metrics-datadog/src/test/java/org/apache/flink/metrics/datadog/DCounterTest.java
+++ b/flink-metrics/flink-metrics-datadog/src/test/java/org/apache/flink/metrics/datadog/DCounterTest.java
@@ -26,7 +26,6 @@ import org.junit.Test;
 import java.util.Collections;
 
 import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertNull;
 
 /** Tests for the {@link DCounter}. */
 public class DCounterTest extends TestLogger {
@@ -62,42 +61,5 @@ public class DCounterTest extends TestLogger {
         // properly handle decrements
         backingCounter.dec(10);
         assertEquals(0L, counter.getMetricValue());
-    }
-
-    @Test
-    public void testGetMetricValueForGauge() {
-        Object[] gaugeValue = new Object[1];
-
-        final DGauge<Object> gauge =
-                new DGauge<>(
-                        () -> gaugeValue[0],
-                        "gauge",
-                        "localhost",
-                        Collections.emptyList(),
-                        () -> 0);
-
-        // sane initial state
-        assertNull(gauge.getMetricValue());
-        gauge.ackReport();
-
-        // true becomes 1
-        gaugeValue[0] = true;
-        assertEquals(gauge.getMetricValue(), 1);
-        gauge.ackReport();
-
-        // false becomes 0
-        gaugeValue[0] = false;
-        assertEquals(gauge.getMetricValue(), 0);
-        gauge.ackReport();
-
-        // integers stay the same
-        gaugeValue[0] = 42;
-        assertEquals(gauge.getMetricValue(), 42);
-        gauge.ackReport();
-
-        // floats stay the same
-        gaugeValue[0] = 3.142;
-        assertEquals(gauge.getMetricValue(), 3.142);
-        gauge.ackReport();
     }
 }

--- a/flink-metrics/flink-metrics-datadog/src/test/java/org/apache/flink/metrics/datadog/DCounterTest.java
+++ b/flink-metrics/flink-metrics-datadog/src/test/java/org/apache/flink/metrics/datadog/DCounterTest.java
@@ -26,6 +26,7 @@ import org.junit.Test;
 import java.util.Collections;
 
 import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertNull;
 
 /** Tests for the {@link DCounter}. */
 public class DCounterTest extends TestLogger {
@@ -61,5 +62,38 @@ public class DCounterTest extends TestLogger {
         // properly handle decrements
         backingCounter.dec(10);
         assertEquals(0L, counter.getMetricValue());
+    }
+
+    @Test
+    public void testGetMetricValueForGauge() {
+        Object[] gaugeValue = new Object[1];
+
+        final DGauge<Object> gauge =
+                new DGauge<>(
+                        () -> gaugeValue[0], "gauge", "localhost", Collections.emptyList(), () -> 0);
+
+        // sane initial state
+        assertNull(gauge.getMetricValue());
+        gauge.ackReport();
+
+        // true becomes 1
+        gaugeValue[0] = true;
+        assertEquals(gauge.getMetricValue(), 1);
+        gauge.ackReport();
+
+        // false becomes 0
+        gaugeValue[0] = false;
+        assertEquals(gauge.getMetricValue(), 0);
+        gauge.ackReport();
+
+        // integers stay the same
+        gaugeValue[0] = 42;
+        assertEquals(gauge.getMetricValue(), 42);
+        gauge.ackReport();
+
+        // floats stay the same
+        gaugeValue[0] = 3.142;
+        assertEquals(gauge.getMetricValue(), 3.142);
+        gauge.ackReport();
     }
 }

--- a/flink-metrics/flink-metrics-datadog/src/test/java/org/apache/flink/metrics/datadog/DGaugeTest.java
+++ b/flink-metrics/flink-metrics-datadog/src/test/java/org/apache/flink/metrics/datadog/DGaugeTest.java
@@ -30,7 +30,7 @@ import static org.junit.Assert.assertNull;
 public class DGaugeTest extends TestLogger {
 
     @Test
-    public void testGetMetricValueForGauge() {
+    public void testGetMetricValue() {
         Object[] gaugeValue = new Object[1];
 
         final DGauge<Object> gauge =

--- a/flink-metrics/flink-metrics-datadog/src/test/java/org/apache/flink/metrics/datadog/DGaugeTest.java
+++ b/flink-metrics/flink-metrics-datadog/src/test/java/org/apache/flink/metrics/datadog/DGaugeTest.java
@@ -1,0 +1,68 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.flink.metrics.datadog;
+
+import org.apache.flink.util.TestLogger;
+
+import org.junit.Test;
+
+import java.util.Collections;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertNull;
+
+/** Tests for the {@link DGauge}. */
+public class DGaugeTest extends TestLogger {
+
+    @Test
+    public void testGetMetricValueForGauge() {
+        Object[] gaugeValue = new Object[1];
+
+        final DGauge<Object> gauge =
+                new DGauge<>(
+                        () -> gaugeValue[0],
+                        "gauge",
+                        "localhost",
+                        Collections.emptyList(),
+                        () -> 0);
+
+        // sane initial state
+        assertNull(gauge.getMetricValue());
+        gauge.ackReport();
+
+        // true becomes 1
+        gaugeValue[0] = true;
+        assertEquals(gauge.getMetricValue(), 1);
+        gauge.ackReport();
+
+        // false becomes 0
+        gaugeValue[0] = false;
+        assertEquals(gauge.getMetricValue(), 0);
+        gauge.ackReport();
+
+        // integers stay the same
+        gaugeValue[0] = 42;
+        assertEquals(gauge.getMetricValue(), 42);
+        gauge.ackReport();
+
+        // floats stay the same
+        gaugeValue[0] = 3.142;
+        assertEquals(gauge.getMetricValue(), 3.142);
+        gauge.ackReport();
+    }
+}


### PR DESCRIPTION
## What is the purpose of the change

Supporting Boolean values for Datadog metrics reporter. Closes FLINK-24941.

#### Motivation

At the moment, anyone who uses Datadog reporter cannot monitor backpressure. This is in contrast to other metric reporters such as Prometheus, which will happily report Booleans as either 0 or 1. This is detrimental since it forces you to view backpressure only inside Flink UI, which means you only can see the backpressure at the present moment (and cannot know if there was a backpressure 2 hours ago), and you also cannot create alarms for when the backpressure is high.

Supporting Boolean values will allow people to see backpressure in Datadog, and will support any additional gauges which are Boolean instead of Numbers.

## Brief change log

  - `DGauge` is now parameterized in type `T` and will map boolean values to either `0` or `1` appropriately

## Verifying this change

*(Please pick either of the following options)*

This change added tests and can be verified as follows:

  - Add a test case for DGauges that checks both booleans, and Numbers

## Does this pull request potentially affect one of the following parts:

  - Dependencies (does it add or upgrade a dependency): (no)
  - The public API, i.e., is any changed class annotated with `@Public(Evolving)`: (no)
  - The serializers: (no)
  - The runtime per-record code paths (performance sensitive): (no)
  - Anything that affects deployment or recovery: JobManager (and its components), Checkpointing, Kubernetes/Yarn, ZooKeeper: (no)
  - The S3 file system connector: (no)

## Documentation

  - Does this pull request introduce a new feature? (yes)
  - If yes, how is the feature documented? (not applicable)
    Other reporters (such as Prometheus) know how to deal with Boolean values but their documentation does not mention it, so no reason to mention it in the Datadog reporter. Seems to be trivial.
