### PR TITLE
[FLINK-24879][core] All ReducingStateDescriptor constructor check reduceFunction not a richFunction.

### DIFF
--- a/flink-core/src/test/java/org/apache/flink/api/common/state/ReducingStateDescriptorTest.java
+++ b/flink-core/src/test/java/org/apache/flink/api/common/state/ReducingStateDescriptorTest.java
@@ -49,12 +49,14 @@ public class ReducingStateDescriptorTest extends TestLogger {
         assertNotNull(descr.getSerializer());
         assertEquals(serializer, descr.getSerializer());
         assertEquals(reducer, descr.getReduceFunction());
+        assertEquals(StateDescriptor.Type.REDUCING, descr.getType());
 
         ReducingStateDescriptor<String> copy = CommonTestUtils.createCopySerializable(descr);
 
         assertEquals("testName", copy.getName());
         assertNotNull(copy.getSerializer());
         assertEquals(serializer, copy.getSerializer());
+        assertEquals(StateDescriptor.Type.REDUCING, copy.getType());
     }
 
     @Test

--- a/flink-streaming-java/src/main/java/org/apache/flink/streaming/runtime/streamrecord/StreamElementSerializer.java
+++ b/flink-streaming-java/src/main/java/org/apache/flink/streaming/runtime/streamrecord/StreamElementSerializer.java
@@ -81,7 +81,7 @@ public final class StreamElementSerializer<T> extends TypeSerializer<StreamEleme
     @Override
     public StreamElementSerializer<T> duplicate() {
         TypeSerializer<T> copy = typeSerializer.duplicate();
-        return (copy == typeSerializer) ? this : new StreamElementSerializer<T>(copy);
+        return (copy == typeSerializer) ? this : new StreamElementSerializer<>(copy);
     }
 
     // ------------------------------------------------------------------------
@@ -90,7 +90,7 @@ public final class StreamElementSerializer<T> extends TypeSerializer<StreamEleme
 
     @Override
     public StreamRecord<T> createInstance() {
-        return new StreamRecord<T>(typeSerializer.createInstance());
+        return new StreamRecord<>(typeSerializer.createInstance());
     }
 
     @Override
@@ -114,7 +114,9 @@ public final class StreamElementSerializer<T> extends TypeSerializer<StreamEleme
 
     @Override
     public StreamElement copy(StreamElement from, StreamElement reuse) {
-        if (from.isRecord() && reuse.isRecord()) {
+        // need not check reuse is really a StreamRecord, otherwise reuse.asRecord() will throw
+        // ClassCastException, similar as cannot copy does.
+        if (from.isRecord()) {
             StreamRecord<T> fromRecord = from.asRecord();
             StreamRecord<T> reuseRecord = reuse.asRecord();
 
@@ -136,19 +138,16 @@ public final class StreamElementSerializer<T> extends TypeSerializer<StreamEleme
 
         if (tag == TAG_REC_WITH_TIMESTAMP) {
             // move timestamp
-            target.writeLong(source.readLong());
+            target.write(source, 8);
             typeSerializer.copy(source, target);
         } else if (tag == TAG_REC_WITHOUT_TIMESTAMP) {
             typeSerializer.copy(source, target);
         } else if (tag == TAG_WATERMARK) {
-            target.writeLong(source.readLong());
+            target.write(source, 8);
         } else if (tag == TAG_STREAM_STATUS) {
-            target.writeInt(source.readInt());
+            target.write(source, 4);
         } else if (tag == TAG_LATENCY_MARKER) {
-            target.writeLong(source.readLong());
-            target.writeLong(source.readLong());
-            target.writeLong(source.readLong());
-            target.writeInt(source.readInt());
+            target.write(source, 28);
         } else {
             throw new IOException("Corrupt stream, found tag: " + tag);
         }
@@ -188,9 +187,9 @@ public final class StreamElementSerializer<T> extends TypeSerializer<StreamEleme
         int tag = source.readByte();
         if (tag == TAG_REC_WITH_TIMESTAMP) {
             long timestamp = source.readLong();
-            return new StreamRecord<T>(typeSerializer.deserialize(source), timestamp);
+            return new StreamRecord<>(typeSerializer.deserialize(source), timestamp);
         } else if (tag == TAG_REC_WITHOUT_TIMESTAMP) {
-            return new StreamRecord<T>(typeSerializer.deserialize(source));
+            return new StreamRecord<>(typeSerializer.deserialize(source));
         } else if (tag == TAG_WATERMARK) {
             return new Watermark(source.readLong());
         } else if (tag == TAG_STREAM_STATUS) {
@@ -221,6 +220,8 @@ public final class StreamElementSerializer<T> extends TypeSerializer<StreamEleme
             return reuseRecord;
         } else if (tag == TAG_WATERMARK) {
             return new Watermark(source.readLong());
+        } else if (tag == TAG_STREAM_STATUS) {
+            return new WatermarkStatus(source.readInt());
         } else if (tag == TAG_LATENCY_MARKER) {
             return new LatencyMarker(
                     source.readLong(),
@@ -237,7 +238,9 @@ public final class StreamElementSerializer<T> extends TypeSerializer<StreamEleme
 
     @Override
     public boolean equals(Object obj) {
-        if (obj instanceof StreamElementSerializer) {
+        if (obj == this) {
+            return true;
+        } else if (obj instanceof StreamElementSerializer) {
             StreamElementSerializer<?> other = (StreamElementSerializer<?>) obj;
 
             return typeSerializer.equals(other.typeSerializer);

--- a/flink-streaming-java/src/test/java/org/apache/flink/streaming/runtime/streamrecord/StreamElementSerializerTest.java
+++ b/flink-streaming-java/src/test/java/org/apache/flink/streaming/runtime/streamrecord/StreamElementSerializerTest.java
@@ -25,11 +25,14 @@ import org.apache.flink.core.memory.DataInputDeserializer;
 import org.apache.flink.core.memory.DataOutputSerializer;
 import org.apache.flink.runtime.jobgraph.OperatorID;
 import org.apache.flink.streaming.api.watermark.Watermark;
+import org.apache.flink.streaming.runtime.watermarkstatus.WatermarkStatus;
 
 import org.junit.Test;
 
 import java.io.IOException;
 
+import static org.apache.flink.streaming.runtime.watermarkstatus.WatermarkStatus.ACTIVE_STATUS;
+import static org.apache.flink.streaming.runtime.watermarkstatus.WatermarkStatus.IDLE_STATUS;
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertFalse;
 import static org.junit.Assert.assertNotEquals;
@@ -49,7 +52,7 @@ public class StreamElementSerializerTest {
 
         when(serializer1.duplicate()).thenReturn(serializer2);
 
-        StreamElementSerializer<Long> streamRecSer = new StreamElementSerializer<Long>(serializer1);
+        StreamElementSerializer<Long> streamRecSer = new StreamElementSerializer<>(serializer1);
 
         assertEquals(serializer1, streamRecSer.getContainedTypeSerializer());
 
@@ -62,7 +65,7 @@ public class StreamElementSerializerTest {
     @Test
     public void testBasicProperties() {
         StreamElementSerializer<Long> streamRecSer =
-                new StreamElementSerializer<Long>(LongSerializer.INSTANCE);
+                new StreamElementSerializer<>(LongSerializer.INSTANCE);
 
         assertFalse(streamRecSer.isImmutableType());
         assertEquals(Long.class, streamRecSer.createInstance().getValue().getClass());
@@ -70,9 +73,72 @@ public class StreamElementSerializerTest {
     }
 
     @Test
+    public void testCopy() throws IOException {
+        final StreamElementSerializer<String> serializer =
+                new StreamElementSerializer<>(StringSerializer.INSTANCE);
+
+        StreamRecord<String> withoutTimestamp = new StreamRecord<>("test 1 2 分享基督耶穌的愛給們，開拓雙贏!");
+        assertEquals(withoutTimestamp, serializer.copy(withoutTimestamp));
+
+        StreamRecord<String> withTimestamp = new StreamRecord<>("one more test 拓 們 分", 77L);
+        assertEquals(withTimestamp, serializer.copy(withTimestamp));
+
+        StreamRecord<String> negativeTimestamp = new StreamRecord<>("他", Long.MIN_VALUE);
+        assertEquals(negativeTimestamp, serializer.copy(negativeTimestamp));
+
+        Watermark positiveWatermark = new Watermark(13);
+        assertEquals(positiveWatermark, serializer.copy(positiveWatermark));
+
+        Watermark negativeWatermark = new Watermark(-4647654567676555876L);
+        assertEquals(negativeWatermark, serializer.copy(negativeWatermark));
+
+        final WatermarkStatus idle = new WatermarkStatus(IDLE_STATUS);
+        assertEquals(idle, serializer.copy(idle));
+
+        final WatermarkStatus active = new WatermarkStatus(ACTIVE_STATUS);
+        assertEquals(active, serializer.copy(active));
+
+        LatencyMarker latencyMarker =
+                new LatencyMarker(System.currentTimeMillis(), new OperatorID(-1, 1), 2);
+        assertEquals(latencyMarker, serializer.copy(latencyMarker));
+    }
+
+    @Test
+    public void testCopyWithReuse() {
+        final StreamElementSerializer<String> serializer =
+                new StreamElementSerializer<>(StringSerializer.INSTANCE);
+        final StreamRecord<String> reuse = new StreamRecord<>("");
+
+        StreamRecord<String> withoutTimestamp = new StreamRecord<>("test 1 2 分享基督耶穌的愛給們，開拓雙贏!");
+        assertEquals(withoutTimestamp, serializer.copy(withoutTimestamp, reuse));
+
+        StreamRecord<String> withTimestamp = new StreamRecord<>("one more test 拓 們 分", 77L);
+        assertEquals(withTimestamp, serializer.copy(withTimestamp, reuse));
+
+        StreamRecord<String> negativeTimestamp = new StreamRecord<>("他", Long.MIN_VALUE);
+        assertEquals(negativeTimestamp, serializer.copy(negativeTimestamp, reuse));
+
+        Watermark positiveWatermark = new Watermark(13);
+        assertEquals(positiveWatermark, serializer.copy(positiveWatermark, reuse));
+
+        Watermark negativeWatermark = new Watermark(-4647654567676555876L);
+        assertEquals(negativeWatermark, serializer.copy(negativeWatermark, reuse));
+
+        final WatermarkStatus idle = new WatermarkStatus(IDLE_STATUS);
+        assertEquals(idle, serializer.copy(idle, reuse));
+
+        final WatermarkStatus active = new WatermarkStatus(ACTIVE_STATUS);
+        assertEquals(active, serializer.copy(active, reuse));
+
+        LatencyMarker latencyMarker =
+                new LatencyMarker(System.currentTimeMillis(), new OperatorID(-1, 1), 2);
+        assertEquals(latencyMarker, serializer.copy(latencyMarker, reuse));
+    }
+
+    @Test
     public void testSerialization() throws Exception {
         final StreamElementSerializer<String> serializer =
-                new StreamElementSerializer<String>(StringSerializer.INSTANCE);
+                new StreamElementSerializer<>(StringSerializer.INSTANCE);
 
         StreamRecord<String> withoutTimestamp = new StreamRecord<>("test 1 2 分享基督耶穌的愛給們，開拓雙贏!");
         assertEquals(withoutTimestamp, serializeAndDeserialize(withoutTimestamp, serializer));
@@ -89,9 +155,57 @@ public class StreamElementSerializerTest {
         Watermark negativeWatermark = new Watermark(-4647654567676555876L);
         assertEquals(negativeWatermark, serializeAndDeserialize(negativeWatermark, serializer));
 
+        final WatermarkStatus idle = new WatermarkStatus(IDLE_STATUS);
+        assertEquals(idle, serializeAndDeserialize(idle, serializer));
+
+        final WatermarkStatus active = new WatermarkStatus(ACTIVE_STATUS);
+        assertEquals(active, serializeAndDeserialize(active, serializer));
+
         LatencyMarker latencyMarker =
                 new LatencyMarker(System.currentTimeMillis(), new OperatorID(-1, -1), 1);
         assertEquals(latencyMarker, serializeAndDeserialize(latencyMarker, serializer));
+    }
+
+    @Test
+    public void testSerializationWithReuse() throws Exception {
+        final StreamElementSerializer<String> serializer =
+                new StreamElementSerializer<>(StringSerializer.INSTANCE);
+        final StreamRecord<String> reuse = new StreamRecord<>("");
+
+        StreamRecord<String> withoutTimestamp = new StreamRecord<>("test 1 2 分享基督耶穌的愛給們，開拓雙贏!");
+        assertEquals(
+                withoutTimestamp,
+                serializeAndDeserializeWithReuse(withoutTimestamp, serializer, reuse));
+
+        StreamRecord<String> withTimestamp = new StreamRecord<>("one more test 拓 們 分", 77L);
+        assertEquals(
+                withTimestamp, serializeAndDeserializeWithReuse(withTimestamp, serializer, reuse));
+
+        StreamRecord<String> negativeTimestamp = new StreamRecord<>("他", Long.MIN_VALUE);
+        assertEquals(
+                negativeTimestamp,
+                serializeAndDeserializeWithReuse(negativeTimestamp, serializer, reuse));
+
+        Watermark positiveWatermark = new Watermark(13);
+        assertEquals(
+                positiveWatermark,
+                serializeAndDeserializeWithReuse(positiveWatermark, serializer, reuse));
+
+        Watermark negativeWatermark = new Watermark(-4647654567676555876L);
+        assertEquals(
+                negativeWatermark,
+                serializeAndDeserializeWithReuse(negativeWatermark, serializer, reuse));
+
+        final WatermarkStatus idle = new WatermarkStatus(IDLE_STATUS);
+        assertEquals(idle, serializeAndDeserializeWithReuse(idle, serializer, reuse));
+
+        final WatermarkStatus active = new WatermarkStatus(ACTIVE_STATUS);
+        assertEquals(active, serializeAndDeserializeWithReuse(active, serializer, reuse));
+
+        LatencyMarker latencyMarker =
+                new LatencyMarker(System.currentTimeMillis(), new OperatorID(-1, -1), 1);
+        assertEquals(
+                latencyMarker, serializeAndDeserializeWithReuse(latencyMarker, serializer, reuse));
     }
 
     @SuppressWarnings("unchecked")
@@ -103,12 +217,31 @@ public class StreamElementSerializerTest {
 
         // additional binary copy step
         DataInputDeserializer copyInput =
-                new DataInputDeserializer(output.getByteArray(), 0, output.length());
+                new DataInputDeserializer(output.getSharedBuffer(), 0, output.length());
         DataOutputSerializer copyOutput = new DataOutputSerializer(32);
         serializer.copy(copyInput, copyOutput);
 
         DataInputDeserializer input =
-                new DataInputDeserializer(copyOutput.getByteArray(), 0, copyOutput.length());
+                new DataInputDeserializer(copyOutput.getSharedBuffer(), 0, copyOutput.length());
         return (X) serializer.deserialize(input);
+    }
+
+    @SuppressWarnings("unchecked")
+    private static <T, X extends StreamElement> X serializeAndDeserializeWithReuse(
+            X record, StreamElementSerializer<T> serializer, StreamElement reuse)
+            throws IOException {
+
+        DataOutputSerializer output = new DataOutputSerializer(32);
+        serializer.serialize(record, output);
+
+        // additional binary copy step
+        DataInputDeserializer copyInput =
+                new DataInputDeserializer(output.getSharedBuffer(), 0, output.length());
+        DataOutputSerializer copyOutput = new DataOutputSerializer(32);
+        serializer.copy(copyInput, copyOutput);
+
+        DataInputDeserializer input =
+                new DataInputDeserializer(copyOutput.getSharedBuffer(), 0, copyOutput.length());
+        return (X) serializer.deserialize(reuse, input);
     }
 }


### PR DESCRIPTION
<!--
*Thank you very much for contributing to Apache Flink - we are happy that you want to help us improve Flink. To help the community review your contribution in the best possible way, please go through the checklist below, which will get the contribution into a shape in which it can be best reviewed.*

*Please understand that we do not do this to make contributions to Flink a hassle. In order to uphold a high standard of quality for code contributions, while at the same time managing a large number of contributions, we need contributors to prepare the contributions well, and give reviewers enough contextual information for the review. Please also understand that contributions that do not follow this guide will take longer to review and thus typically be picked up with lower priority by the community.*

## Contribution Checklist

  - Make sure that the pull request corresponds to a [JIRA issue](https://issues.apache.org/jira/projects/FLINK/issues). Exceptions are made for typos in JavaDoc or documentation files, which need no JIRA issue.
  
  - Name the pull request in the form "[FLINK-XXXX] [component] Title of the pull request", where *FLINK-XXXX* should be replaced by the actual issue number. Skip *component* if you are unsure about which is the best component.
  Typo fixes that have no associated JIRA issue should be named following this pattern: `[hotfix] [docs] Fix typo in event time introduction` or `[hotfix] [javadocs] Expand JavaDoc for PuncuatedWatermarkGenerator`.

  - Fill out the template below to describe the changes contributed by the pull request. That will give reviewers the context they need to do the review.
  
  - Make sure that the change passes the automated tests, i.e., `mvn clean verify` passes. You can set up Azure Pipelines CI to do that following [this guide](https://cwiki.apache.org/confluence/display/FLINK/Azure+Pipelines#AzurePipelines-Tutorial:SettingupAzurePipelinesforaforkoftheFlinkrepository).

  - Each pull request should address only one issue, not mix up code from multiple issues.
  
  - Each commit in the pull request has a meaningful commit message (including the JIRA id)

  - Once all items of the checklist are addressed, remove the above text and this checklist, leaving only the filled out template below.


**(The sections below can be removed for hotfixes of typos)**
-->

## What is the purpose of the change

All the constructor should check reduceFunction is not a richFunction, not just when passing typeClass as parameter.

## Brief change log

extract a function to check the reduceFunction and call it in all constructors.

## Verifying this change

This change is a trivial rework / code cleanup.

add test to check the Type is Type.REDUCING.

## Does this pull request potentially affect one of the following parts:

  - Dependencies (does it add or upgrade a dependency): (no)
  - The public API, i.e., is any changed class annotated with `@Public(Evolving)`: (no)
  - The serializers: (no)
  - The runtime per-record code paths (performance sensitive): (no)
  - Anything that affects deployment or recovery: JobManager (and its components), Checkpointing, Kubernetes/Yarn, ZooKeeper: (no)
  - The S3 file system connector: (no)

## Documentation

  - Does this pull request introduce a new feature? (no)
  - If yes, how is the feature documented? (not applicable / docs / JavaDocs / not documented)
