### PR TITLE
[FLINK-24352] [flink-table-planner] Add null check for temporal table check on SqlSnapshot

### DIFF
--- a/flink-table/flink-table-planner/src/main/java/org/apache/calcite/sql/validate/SqlValidatorImpl.java
+++ b/flink-table/flink-table-planner/src/main/java/org/apache/calcite/sql/validate/SqlValidatorImpl.java
@@ -4712,8 +4712,8 @@ public class SqlValidatorImpl implements SqlValidatorWithHints {
                                 dataType.getSqlTypeName().getName()));
             }
             if (ns instanceof IdentifierNamespace && ns.resolve() instanceof WithItemNamespace) {
-                // If the snapshot is used over a CTE, and then we don't have a concrete underlying
-                // table to operate on.
+                // If the snapshot is used over a CTE, then we don't have a concrete underlying
+                // table to operate on. This will be rechecked later in the planner rules.
                 return;
             }
             if (!ns.getTable().isTemporal()) {

--- a/flink-table/flink-table-planner/src/main/java/org/apache/calcite/sql/validate/SqlValidatorImpl.java
+++ b/flink-table/flink-table-planner/src/main/java/org/apache/calcite/sql/validate/SqlValidatorImpl.java
@@ -4711,7 +4711,12 @@ public class SqlValidatorImpl implements SqlValidatorWithHints {
                         Static.RESOURCE.illegalExpressionForTemporal(
                                 dataType.getSqlTypeName().getName()));
             }
-            if (ns.getTable() != null && !ns.getTable().isTemporal()) {
+            if (ns instanceof IdentifierNamespace && ns.resolve() instanceof WithItemNamespace) {
+                // If the snapshot is used over a CTE, and then we don't have a concrete underlying
+                // table to operate on.
+                return;
+            }
+            if (!ns.getTable().isTemporal()) {
                 List<String> qualifiedName = ns.getTable().getQualifiedName();
                 String tableName = qualifiedName.get(qualifiedName.size() - 1);
                 throw newValidationError(

--- a/flink-table/flink-table-planner/src/main/java/org/apache/calcite/sql/validate/SqlValidatorImpl.java
+++ b/flink-table/flink-table-planner/src/main/java/org/apache/calcite/sql/validate/SqlValidatorImpl.java
@@ -4711,7 +4711,7 @@ public class SqlValidatorImpl implements SqlValidatorWithHints {
                         Static.RESOURCE.illegalExpressionForTemporal(
                                 dataType.getSqlTypeName().getName()));
             }
-            if (!ns.getTable().isTemporal()) {
+            if (ns.getTable() != null && !ns.getTable().isTemporal()) {
                 List<String> qualifiedName = ns.getTable().getQualifiedName();
                 String tableName = qualifiedName.get(qualifiedName.size() - 1);
                 throw newValidationError(

--- a/flink-table/flink-table-planner/src/test/resources/org/apache/flink/table/planner/plan/stream/sql/join/LookupJoinTest.xml
+++ b/flink-table/flink-table-planner/src/test/resources/org/apache/flink/table/planner/plan/stream/sql/join/LookupJoinTest.xml
@@ -264,6 +264,68 @@ Calc(select=[a, b, c, name, age, nominal_age])
 ]]>
     </Resource>
   </TestCase>
+  <TestCase name="testJoinTemporalTableWithCTE[LegacyTableSource=false]">
+    <Resource name="sql">
+      <![CDATA[
+WITH MyLookupTable AS (SELECT * FROM MyTable),
+OtherLookupTable AS (SELECT * FROM LookupTable)
+SELECT MyLookupTable.b FROM MyLookupTable
+JOIN OtherLookupTable FOR SYSTEM_TIME AS OF MyLookupTable.proctime AS D
+ON MyLookupTable.a = D.id AND D.age = 10
+      ]]>
+    </Resource>
+    <Resource name="ast">
+      <![CDATA[
+LogicalProject(b=[$1])
++- LogicalCorrelate(correlation=[$cor0], joinType=[inner], requiredColumns=[{0, 3}])
+   :- LogicalProject(a=[$0], b=[$1], c=[$2], proctime=[$3], rowtime=[$4])
+   :  +- LogicalTableScan(table=[[default_catalog, default_database, MyTable]])
+   +- LogicalFilter(condition=[AND(=($cor0.a, $0), =($2, 10))])
+      +- LogicalSnapshot(period=[$cor0.proctime])
+         +- LogicalProject(id=[$0], name=[$1], age=[$2])
+            +- LogicalTableScan(table=[[default_catalog, default_database, LookupTable]])
+]]>
+    </Resource>
+    <Resource name="optimized exec plan">
+      <![CDATA[
+Calc(select=[b])
++- LookupJoin(table=[default_catalog.default_database.LookupTable], joinType=[InnerJoin], async=[false], lookup=[age=10, id=a], where=[(age = 10)], select=[a, b, id])
+   +- Calc(select=[a, b])
+      +- DataStreamScan(table=[[default_catalog, default_database, MyTable]], fields=[a, b, c, proctime, rowtime])
+]]>
+    </Resource>
+  </TestCase>
+  <TestCase name="testJoinTemporalTableWithCTE[LegacyTableSource=true]">
+    <Resource name="sql">
+      <![CDATA[
+WITH MyLookupTable AS (SELECT * FROM MyTable),
+OtherLookupTable AS (SELECT * FROM LookupTable)
+SELECT MyLookupTable.b FROM MyLookupTable
+JOIN OtherLookupTable FOR SYSTEM_TIME AS OF MyLookupTable.proctime AS D
+ON MyLookupTable.a = D.id AND D.age = 10
+      ]]>
+    </Resource>
+    <Resource name="ast">
+      <![CDATA[
+LogicalProject(b=[$1])
++- LogicalCorrelate(correlation=[$cor0], joinType=[inner], requiredColumns=[{0, 3}])
+   :- LogicalProject(a=[$0], b=[$1], c=[$2], proctime=[$3], rowtime=[$4])
+   :  +- LogicalTableScan(table=[[default_catalog, default_database, MyTable]])
+   +- LogicalFilter(condition=[AND(=($cor0.a, $0), =($2, 10))])
+      +- LogicalSnapshot(period=[$cor0.proctime])
+         +- LogicalProject(id=[$0], name=[$1], age=[$2])
+            +- LogicalTableScan(table=[[default_catalog, default_database, LookupTable, source: [TestTemporalTable(id, name, age)]]])
+]]>
+    </Resource>
+    <Resource name="optimized exec plan">
+      <![CDATA[
+Calc(select=[b])
++- LookupJoin(table=[default_catalog.default_database.LookupTable], joinType=[InnerJoin], async=[false], lookup=[age=10, id=a], where=[(age = 10)], select=[a, b, id])
+   +- Calc(select=[a, b])
+      +- DataStreamScan(table=[[default_catalog, default_database, MyTable]], fields=[a, b, c, proctime, rowtime])
+]]>
+    </Resource>
+  </TestCase>
   <TestCase name="testJoinTemporalTableWithFilterPushDown[LegacyTableSource=false]">
     <Resource name="sql">
       <![CDATA[

--- a/flink-table/flink-table-planner/src/test/scala/org/apache/flink/table/api/TableEnvironmentITCase.scala
+++ b/flink-table/flink-table-planner/src/test/scala/org/apache/flink/table/api/TableEnvironmentITCase.scala
@@ -808,38 +808,6 @@ class TableEnvironmentITCase(tableEnvName: String, isStreaming: Boolean) extends
     listener.close()
   }
 
-  @Test
-  def testSqlSnapshotWithCTE(): Unit = {
-    tEnv.executeSql(
-      """
-        |CREATE TABLE T1 (
-        |  a INT,
-        |  b STRING,
-        |  proctime AS PROCTIME()
-        |) WITH (
-        |  'connector' = 'values',
-        |  'bounded' = 'true'
-        |)
-        |""".stripMargin)
-    tEnv.executeSql(
-      """
-        |CREATE TABLE T2 (
-        |  a INT,
-        |  b STRING
-        |) WITH (
-        |  'connector' = 'values',
-        |  'bounded' = 'true'
-        |)
-        |""".stripMargin)
-    tEnv.explainSql(
-      """
-        |WITH MyView(a, b) AS (SELECT a, b FROM T2)
-        |SELECT * FROM T1 AS T
-        |LEFT JOIN MyView FOR SYSTEM_TIME AS OF T.proctime AS D
-        |ON T.a = D.a
-        |""".stripMargin)
-  }
-
   def getPersonData: List[(String, Int, Double, String)] = {
     val data = new mutable.MutableList[(String, Int, Double, String)]
     data.+=(("Mike", 1, 12.3, "Smith"))

--- a/flink-table/flink-table-planner/src/test/scala/org/apache/flink/table/api/TableEnvironmentITCase.scala
+++ b/flink-table/flink-table-planner/src/test/scala/org/apache/flink/table/api/TableEnvironmentITCase.scala
@@ -808,6 +808,38 @@ class TableEnvironmentITCase(tableEnvName: String, isStreaming: Boolean) extends
     listener.close()
   }
 
+  @Test
+  def testSqlSnapshotWithCTE(): Unit = {
+    tEnv.executeSql(
+      """
+        |CREATE TABLE T1 (
+        |  a INT,
+        |  b STRING,
+        |  proctime AS PROCTIME()
+        |) WITH (
+        |  'connector' = 'values',
+        |  'bounded' = 'true'
+        |)
+        |""".stripMargin)
+    tEnv.executeSql(
+      """
+        |CREATE TABLE T2 (
+        |  a INT,
+        |  b STRING
+        |) WITH (
+        |  'connector' = 'values',
+        |  'bounded' = 'true'
+        |)
+        |""".stripMargin)
+    tEnv.explainSql(
+      """
+        |WITH MyView(a, b) AS (SELECT a, b FROM T2)
+        |SELECT * FROM T1 AS T
+        |LEFT JOIN MyView FOR SYSTEM_TIME AS OF T.proctime AS D
+        |ON T.a = D.a
+        |""".stripMargin)
+  }
+
   def getPersonData: List[(String, Int, Double, String)] = {
     val data = new mutable.MutableList[(String, Int, Double, String)]
     data.+=(("Mike", 1, 12.3, "Smith"))

--- a/flink-table/flink-table-planner/src/test/scala/org/apache/flink/table/planner/plan/stream/sql/join/LookupJoinTest.scala
+++ b/flink-table/flink-table-planner/src/test/scala/org/apache/flink/table/planner/plan/stream/sql/join/LookupJoinTest.scala
@@ -525,7 +525,21 @@ class LookupJoinTest(legacyTableSource: Boolean) extends TableTestBase with Seri
     verifyTranslationSuccess(sql)
   }
 
-  // ==========================================================================================
+  @Test
+  def testJoinTemporalTableWithCTE(): Unit = {
+    val sql =
+      """
+        |WITH MyLookupTable AS (SELECT * FROM MyTable),
+        |OtherLookupTable AS (SELECT * FROM LookupTable)
+        |SELECT MyLookupTable.b FROM MyLookupTable
+        |JOIN OtherLookupTable FOR SYSTEM_TIME AS OF MyLookupTable.proctime AS D
+        |ON MyLookupTable.a = D.id AND D.age = 10
+      """.stripMargin
+
+    verifyTranslationSuccess(sql)
+  }
+
+    // ==========================================================================================
 
   private def createLookupTable(tableName: String, lookupFunction: UserDefinedFunction): Unit = {
     if (legacyTableSource) {

--- a/flink-table/flink-table-planner/src/test/scala/org/apache/flink/table/planner/plan/stream/sql/join/LookupJoinTest.scala
+++ b/flink-table/flink-table-planner/src/test/scala/org/apache/flink/table/planner/plan/stream/sql/join/LookupJoinTest.scala
@@ -536,7 +536,7 @@ class LookupJoinTest(legacyTableSource: Boolean) extends TableTestBase with Seri
         |ON MyLookupTable.a = D.id AND D.age = 10
       """.stripMargin
 
-    verifyTranslationSuccess(sql)
+    util.verifyExecPlan(sql)
   }
 
     // ==========================================================================================


### PR DESCRIPTION
<!--
*Thank you very much for contributing to Apache Flink - we are happy that you want to help us improve Flink. To help the community review your contribution in the best possible way, please go through the checklist below, which will get the contribution into a shape in which it can be best reviewed.*

*Please understand that we do not do this to make contributions to Flink a hassle. In order to uphold a high standard of quality for code contributions, while at the same time managing a large number of contributions, we need contributors to prepare the contributions well, and give reviewers enough contextual information for the review. Please also understand that contributions that do not follow this guide will take longer to review and thus typically be picked up with lower priority by the community.*

## Contribution Checklist

  - Make sure that the pull request corresponds to a [JIRA issue](https://issues.apache.org/jira/projects/FLINK/issues). Exceptions are made for typos in JavaDoc or documentation files, which need no JIRA issue.
  
  - Name the pull request in the form "[FLINK-XXXX] [component] Title of the pull request", where *FLINK-XXXX* should be replaced by the actual issue number. Skip *component* if you are unsure about which is the best component.
  Typo fixes that have no associated JIRA issue should be named following this pattern: `[hotfix] [docs] Fix typo in event time introduction` or `[hotfix] [javadocs] Expand JavaDoc for PuncuatedWatermarkGenerator`.

  - Fill out the template below to describe the changes contributed by the pull request. That will give reviewers the context they need to do the review.
  
  - Make sure that the change passes the automated tests, i.e., `mvn clean verify` passes. You can set up Azure Pipelines CI to do that following [this guide](https://cwiki.apache.org/confluence/display/FLINK/Azure+Pipelines#AzurePipelines-Tutorial:SettingupAzurePipelinesforaforkoftheFlinkrepository).

  - Each pull request should address only one issue, not mix up code from multiple issues.
  
  - Each commit in the pull request has a meaningful commit message (including the JIRA id)

  - Once all items of the checklist are addressed, remove the above text and this checklist, leaving only the filled out template below.


**(The sections below can be removed for hotfixes of typos)**
-->

## What is the purpose of the change

Purpose of this change is to resolve https://issues.apache.org/jira/browse/FLINK-24352 and it's duplicate https://issues.apache.org/jira/browse/FLINK-24956.

The below test which uses a lookup table join with a CTE fails due to a `NullPointerException`

```scala
package foo.bar

import org.apache.flink.api.scala.createTypeInformation
import org.apache.flink.streaming.api.scala.StreamExecutionEnvironment
import org.apache.flink.table.api.DataTypes
import org.apache.flink.table.api.Schema
import org.apache.flink.table.api.bridge.scala.StreamTableEnvironment
object Test {
  final case class Person(name: String, age: Int)

  def main(args: Array[String]): Unit = {
    val ee = StreamExecutionEnvironment.getExecutionEnvironment
    val te = StreamTableEnvironment.create(ee)    
    val personSchema = Schema.newBuilder().column("name", DataTypes.STRING()).column("age", DataTypes.INT()).build()
    val x = ee.fromCollection(List(Person("a", 1)))
    te.createTemporaryView(
      "my_table",
      x,
      personSchema
    )
    val y = ee.fromCollection(List(Person("b", 2)))
    te.createTemporaryView(
      "my_table_2",
      y,
      personSchema
    )
    val res =
      te.executeSql("""
                      |WITH A AS (
                      |  select name, age + 1 from my_table
                      |),
                      |B AS (
                      |  select name, age + 2 from my_table_2
                      |)
                      |
                      |SELECT A.name, B.age
                      |FROM A
                      |JOIN B
                      |FOR SYSTEM_TIME AS OF PROCTIME() on (A.name = B.name)
                      |""".stripMargin)
    res.print()
  }
}
```

@tsreaper waiting on your comments. I'm not entirely sure a null check is sufficient to determine the underlying table is actually temporal.

## Brief change log

- Add null check for `SqlValidatorImpl.validateSnapshot` before checking the underling table, which may be null in the case the expression is a CTE.

## Verifying this change

This change added tests and can be verified as follows:

- Added a test to TableEnvironmentITCase which validates calling a lookup join on a CTE no longer throws a NPE.

## Does this pull request potentially affect one of the following parts:

  - Dependencies (does it add or upgrade a dependency): (yes / **no**)
  - The public API, i.e., is any changed class annotated with `@Public(Evolving)`: (yes / **no**)
  - The serializers: (yes / **no** / don't know)
  - The runtime per-record code paths (performance sensitive): (yes / **no** / don't know)
  - Anything that affects deployment or recovery: JobManager (and its components), Checkpointing, Kubernetes/Yarn, ZooKeeper: (yes / **no** / don't know)
  - The S3 file system connector: (yes / **no** / don't know)

## Documentation

  - Does this pull request introduce a new feature? (yes / no)
  - If yes, how is the feature documented? (not applicable / docs / JavaDocs / not documented)
