### PR TITLE
[FLINK-21214][kafka/IT] add retry rule for testScaleDownBeforeFirstCh…

### DIFF
--- a/flink-connectors/flink-connector-kafka/src/test/java/org/apache/flink/streaming/connectors/kafka/FlinkKafkaProducerITCase.java
+++ b/flink-connectors/flink-connector-kafka/src/test/java/org/apache/flink/streaming/connectors/kafka/FlinkKafkaProducerITCase.java
@@ -28,10 +28,13 @@ import org.apache.flink.streaming.connectors.kafka.internals.KeyedSerializationS
 import org.apache.flink.streaming.util.AbstractStreamOperatorTestHarness;
 import org.apache.flink.streaming.util.OneInputStreamOperatorTestHarness;
 import org.apache.flink.streaming.util.serialization.KeyedSerializationSchema;
+import org.apache.flink.testutils.junit.RetryOnFailure;
+import org.apache.flink.testutils.junit.RetryRule;
 
 import kafka.server.KafkaServer;
 import org.apache.kafka.common.errors.ProducerFencedException;
 import org.junit.Before;
+import org.junit.Rule;
 import org.junit.Test;
 
 import java.util.ArrayList;
@@ -52,7 +55,12 @@ import static org.junit.Assert.assertThat;
 import static org.junit.Assert.fail;
 
 /** IT cases for the {@link FlinkKafkaProducer}. */
+// This test is known to be unstable due to a known issue in Kafka.
+// It has been solved after bumping Kafka to 2.8.1 on the release 1.15
+@RetryOnFailure(times = 2)
 public class FlinkKafkaProducerITCase extends KafkaTestBase {
+
+    @Rule public final RetryRule retryRule = new RetryRule();
 
     protected String transactionalId;
     protected Properties extraProperties;


### PR DESCRIPTION
## What is the purpose of the change

hardening the test on the old releases with retry rules, the issue has been solved after bumping Kafka to 2.8.1.


## Brief change log

  - Test cases will be retried 2 time (total runs 3) before failing


## Verifying this change


This change is a trivial rework to add retry rule of one unit test case.


## Does this pull request potentially affect one of the following parts:

  - Dependencies (does it add or upgrade a dependency): (yes / **no**)
  - The public API, i.e., is any changed class annotated with `@Public(Evolving)`: (yes / **no**)
  - The serializers: (yes / **no** / don't know)
  - The runtime per-record code paths (performance sensitive): (yes / **no** / don't know)
  - Anything that affects deployment or recovery: JobManager (and its components), Checkpointing, Kubernetes/Yarn, ZooKeeper: (yes / **no** / don't know)
  - The S3 file system connector: (yes / **no** / don't know)

## Documentation

  - Does this pull request introduce a new feature? (yes / **no**)
