### PR TITLE
[FLINK-24985][tests] Relax assumptions of stacktrace layout

### DIFF
--- a/flink-runtime/src/test/java/org/apache/flink/runtime/io/network/buffer/LocalBufferPoolDestroyTest.java
+++ b/flink-runtime/src/test/java/org/apache/flink/runtime/io/network/buffer/LocalBufferPoolDestroyTest.java
@@ -119,8 +119,15 @@ public class LocalBufferPoolDestroyTest {
      */
     public static boolean isInBlockingBufferRequest(StackTraceElement[] stackTrace) {
         if (stackTrace.length >= 8) {
-            return stackTrace[5].getMethodName().equals("get")
-                    && stackTrace[7].getClassName().equals(LocalBufferPool.class.getName());
+            for (int x = 0; x < stackTrace.length - 2; x++) {
+                if (stackTrace[x].getMethodName().equals("get")
+                        && stackTrace[x + 2]
+                                .getClassName()
+                                .equals(LocalBufferPool.class.getName())) {
+                    return true;
+                }
+            }
+            return false;
         } else {
             return false;
         }

--- a/flink-runtime/src/test/java/org/apache/flink/runtime/io/network/buffer/LocalBufferPoolDestroyTest.java
+++ b/flink-runtime/src/test/java/org/apache/flink/runtime/io/network/buffer/LocalBufferPoolDestroyTest.java
@@ -127,10 +127,8 @@ public class LocalBufferPoolDestroyTest {
                     return true;
                 }
             }
-            return false;
-        } else {
-            return false;
         }
+        return false;
     }
 
     /** Task triggering a blocking buffer request (the test assumes that no buffer is available). */


### PR DESCRIPTION
The stacktrace layout of a blocking thread is slightly different on Java 17, causing `isInBlockingBufferRequest` to always return false.
IIRC the total depth increased by one.