### PR TITLE
[FLINK-24986][tests] Replace anonymous StreamStateHandle class

### DIFF
--- a/flink-state-backends/flink-statebackend-rocksdb/src/test/java/org/apache/flink/contrib/streaming/state/RocksDBStateDownloaderTest.java
+++ b/flink-state-backends/flink-statebackend-rocksdb/src/test/java/org/apache/flink/contrib/streaming/state/RocksDBStateDownloaderTest.java
@@ -56,26 +56,7 @@ public class RocksDBStateDownloaderTest extends TestLogger {
     public void testMultiThreadRestoreThreadPoolExceptionRethrow() {
         SpecifiedException expectedException =
                 new SpecifiedException("throw exception while multi thread restore.");
-        StreamStateHandle stateHandle =
-                new StreamStateHandle() {
-                    @Override
-                    public FSDataInputStream openInputStream() throws IOException {
-                        throw expectedException;
-                    }
-
-                    @Override
-                    public Optional<byte[]> asBytesIfInMemory() {
-                        return Optional.empty();
-                    }
-
-                    @Override
-                    public void discardState() {}
-
-                    @Override
-                    public long getStateSize() {
-                        return 0;
-                    }
-                };
+        StreamStateHandle stateHandle = new ThrowingStateHandle(expectedException);
 
         Map<StateHandleID, StreamStateHandle> stateHandles = new HashMap<>(1);
         stateHandles.put(new StateHandleID("state1"), stateHandle);
@@ -153,6 +134,34 @@ public class RocksDBStateDownloaderTest extends TestLogger {
     private static class SpecifiedException extends IOException {
         SpecifiedException(String message) {
             super(message);
+        }
+    }
+
+    private static class ThrowingStateHandle implements StreamStateHandle {
+        private static final long serialVersionUID = -2102069659550694805L;
+
+        private final IOException expectedException;
+
+        private ThrowingStateHandle(IOException expectedException) {
+            this.expectedException = expectedException;
+        }
+
+        @Override
+        public FSDataInputStream openInputStream() throws IOException {
+            throw expectedException;
+        }
+
+        @Override
+        public Optional<byte[]> asBytesIfInMemory() {
+            return Optional.empty();
+        }
+
+        @Override
+        public void discardState() {}
+
+        @Override
+        public long getStateSize() {
+            return 0;
         }
     }
 }


### PR DESCRIPTION
Anonymous StreamStateHandle classes are not allowed by the StateHandleSerializationTest.