### PR TITLE
[FLINK-24989][build] Bump shade-plugin to 3.2.4

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -871,7 +871,7 @@ under the License.
 						<plugin>
 							<groupId>org.apache.maven.plugins</groupId>
 							<artifactId>maven-shade-plugin</artifactId>
-							<version>3.2.1</version>
+							<version>3.2.4</version>
 						</plugin>
 						<plugin>
 							<groupId>com.github.siom79.japicmp</groupId>


### PR DESCRIPTION
Use 3.2.4 on Java11+ for compatibility reasons.