### PR TITLE
[FLINK-24990][tests] Make InMemory[Async]LookupFunction public

### DIFF
--- a/flink-table/flink-table-planner/src/test/scala/org/apache/flink/table/planner/runtime/utils/InMemoryLookupableTableSource.scala
+++ b/flink-table/flink-table-planner/src/test/scala/org/apache/flink/table/planner/runtime/utils/InMemoryLookupableTableSource.scala
@@ -141,7 +141,7 @@ object InMemoryLookupableTableSource {
   /**
     * A lookup function which find matched rows with the given fields.
     */
-  private class InMemoryLookupFunction(
+  class InMemoryLookupFunction(
       data: Map[Row, List[Row]],
       resourceCounter: AtomicInteger)
     extends TableFunction[Row] {
@@ -170,7 +170,7 @@ object InMemoryLookupableTableSource {
     * An async lookup function which find matched rows with the given fields.
     */
   @SerialVersionUID(1L)
-  private class InMemoryAsyncLookupFunction(
+  class InMemoryAsyncLookupFunction(
       data: Map[Row, List[Row]],
       resourceCounter: AtomicInteger,
       delayedReturn: Int = 0)


### PR DESCRIPTION
The UserDefinedFunctionHelper validates that a given function is public.

The InMemory[Async]LookupFunction classes are not public however. Probably some Java<->Scala interplay that causes this to not be detected at this time.
