### PR TITLE
[FLINK-24991] FlinkStatistic compiles on later Scala versions

### DIFF
--- a/flink-table/flink-table-planner/src/main/scala/org/apache/flink/table/planner/plan/stats/FlinkStatistic.scala
+++ b/flink-table/flink-table-planner/src/main/scala/org/apache/flink/table/planner/plan/stats/FlinkStatistic.scala
@@ -143,9 +143,9 @@ class FlinkStatistic(
       builder.append(relWindowProperties.toString).append(", ")
     }
 
-    if (builder.nonEmpty && builder.length() > 2) {
+    if (builder.nonEmpty && builder.length > 2) {
       // delete `, ` if build is not empty
-      builder.delete(builder.length() - 2, builder.length())
+      builder.delete(builder.length - 2, builder.length)
     }
     builder.toString()
   }


### PR DESCRIPTION
```
[ERROR] FlinkStatistic.scala:146: error: Int does not take parameters
[ERROR]     if (builder.nonEmpty && builder.length() > 2) {
```