### PR TITLE
[FLINK-24996][ci] Update CI image to contain Java 17

### DIFF
--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -38,7 +38,7 @@ resources:
   containers:
   # Container with Maven 3.2.5, SSL to have the same environment everywhere.
   - container: flink-build-container
-    image: rmetzger/flink-ci:ubuntu-amd64-02878c6
+    image: chesnay/flink-ci:java_8_11_17
     # On AZP provided machines, set this flag to allow writing coredumps in docker
     options: --privileged
 

--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -37,6 +37,7 @@ trigger:
 resources:
   containers:
   # Container with Maven 3.2.5, SSL to have the same environment everywhere.
+  # see https://github.com/flink-ci/flink-ci-docker
   - container: flink-build-container
     image: chesnay/flink-ci:java_8_11_17
     # On AZP provided machines, set this flag to allow writing coredumps in docker

--- a/tools/azure-pipelines/build-apache-repo.yml
+++ b/tools/azure-pipelines/build-apache-repo.yml
@@ -37,6 +37,7 @@ trigger:
 resources:
   containers:
   # Container with Maven 3.2.5, SSL to have the same environment everywhere.
+  # see https://github.com/flink-ci/flink-ci-docker
   - container: flink-build-container
     image: chesnay/flink-ci:java_8_11_17
 

--- a/tools/azure-pipelines/build-apache-repo.yml
+++ b/tools/azure-pipelines/build-apache-repo.yml
@@ -38,7 +38,7 @@ resources:
   containers:
   # Container with Maven 3.2.5, SSL to have the same environment everywhere.
   - container: flink-build-container
-    image: rmetzger/flink-ci:ubuntu-amd64-02878c6
+    image: chesnay/flink-ci:java_8_11_17
 
 variables:
   MAVEN_CACHE_FOLDER: $(Pipeline.Workspace)/.m2/repository


### PR DESCRIPTION
This allows us to run the compile/tests phases with Java 17. E2E tests are a separate issue.

Here's the corresponding Dockerfile:

```
FROM chesnay/flink-ci:base

RUN wget -q https://github.com/adoptium/temurin17-binaries/releases/download/jdk-17.0.1%2B12/OpenJDK17U-jdk_x64_linux_hotspot_17.0.1_12.tar.gz

RUN tar -C /usr/lib/jvm -xzf OpenJDK17U-jdk_x64_linux_hotspot_17.0.1_12.tar.gz

RUN echo "JAVA_HOME_17_X64=/usr/lib/jvm/jdk-17.0.1+12" >> /etc/environment

ENV JAVA_HOME_17_X64 "/usr/lib/jvm/jdk-17.0.1+12"
```