### PR TITLE
[FLINK-24592][Table SQL/Client] FlinkSQL Client multiline parser improvements

### DIFF
--- a/flink-table/flink-sql-client/src/main/java/org/apache/flink/table/client/cli/parser/SqlClientParserState.java
+++ b/flink-table/flink-sql-client/src/main/java/org/apache/flink/table/client/cli/parser/SqlClientParserState.java
@@ -1,0 +1,164 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.flink.table.client.cli.parser;
+
+import org.apache.flink.table.api.SqlDialect;
+
+import org.jline.utils.AttributedStringBuilder;
+
+import java.util.Arrays;
+import java.util.List;
+import java.util.Set;
+import java.util.function.BiConsumer;
+import java.util.function.Function;
+import java.util.stream.Collectors;
+
+/**
+ * State of parser used while preparing highlighted output, multiline parsing. This class represents
+ * a state machine.
+ *
+ * <pre>
+ *      MultiLine Comment           Single Line Comment
+ *           |                              |
+ *   (&#47;*,*&#47;) |                              | (--, \n)
+ *           *------------Default-----------*
+ *                        |    |
+ *                        |    |
+ *           *------------*    *------------*
+ *  (&#47;*+,*&#47;) |            |    |            | (', ')
+ *           |            |    |            |
+ *         Hint           |    |          String
+ *                        |    |
+ *                        |    |
+ *           *------------*    *------------*
+ *    (&quot;, &quot;) |                              | (`, `)
+ *           |                              |
+ *     Hive Identifier           Flink Default Identifier
+ * </pre>
+ */
+public enum SqlClientParserState {
+    QUOTED("'", "'", dialect -> true, (asb, style) -> asb.style(style.getQuotedStyle())),
+    SQL_QUOTED_IDENTIFIER(
+            "`",
+            "`",
+            (dialect) -> dialect == SqlDialect.DEFAULT || dialect == null,
+            (asb, style) -> asb.style(style.getSqlIdentifierStyle())),
+    HIVE_SQL_QUOTED_IDENTIFIER(
+            "\"",
+            "\"",
+            (dialect) -> dialect == SqlDialect.HIVE,
+            (asb, style) -> asb.style(style.getSqlIdentifierStyle())),
+    ONE_LINE_COMMENTED(
+            "--", "\n", dialect -> true, (asb, style) -> asb.style(style.getCommentStyle())),
+    HINTED("/*+", "*/", dialect -> true, (asb, style) -> asb.style(style.getHintStyle())),
+    MULTILINE_COMMENTED(
+            "/*", "*/", dialect -> true, (asb, style) -> asb.style(style.getCommentStyle())),
+
+    // DEFAULT state should be the last one in this list since it is kind a fallback.
+    DEFAULT(null, null, dialect -> true, (asb, style) -> asb.style(style.getDefaultStyle()));
+
+    private final String start;
+    private final String end;
+    private final Function<SqlDialect, Boolean> condition;
+
+    private final BiConsumer<AttributedStringBuilder, SyntaxHighlightStyle> styleSetter;
+
+    private static final List<SqlClientParserState> STATE_LIST_WITHOUT_DEFAULT =
+            Arrays.stream(SqlClientParserState.values())
+                    .filter(t -> t != DEFAULT)
+                    .collect(Collectors.toList());
+    private static final Set<Character> STATE_START_SYMBOLS =
+            Arrays.stream(SqlClientParserState.values())
+                    .filter(t -> t != DEFAULT)
+                    .map(t -> t.start.charAt(0))
+                    .collect(Collectors.toSet());
+
+    SqlClientParserState(
+            String start,
+            String end,
+            Function<SqlDialect, Boolean> condition,
+            BiConsumer<AttributedStringBuilder, SyntaxHighlightStyle> styleSetter) {
+        this.start = start;
+        this.end = end;
+        this.condition = condition;
+        this.styleSetter = styleSetter;
+    }
+
+    static SqlClientParserState computeStateAt(String input, int pos, SqlDialect dialect) {
+        final char currentChar = input.charAt(pos);
+        if (!STATE_START_SYMBOLS.contains(currentChar)) {
+            return DEFAULT;
+        }
+        for (SqlClientParserState state : STATE_LIST_WITHOUT_DEFAULT) {
+            if (state.condition.apply(dialect)
+                    && state.start.regionMatches(0, input, pos, state.start.length())) {
+                return state;
+            }
+        }
+        return DEFAULT;
+    }
+
+    public static SqlClientParserState computeCurrentStateAtTheEndOfLine(
+            String line, SqlDialect dialect) {
+        SqlClientParserState prevParseState = SqlClientParserState.DEFAULT;
+        SqlClientParserState currentParseState = SqlClientParserState.DEFAULT;
+        for (int i = 0; i < line.length(); i++) {
+            if (prevParseState == SqlClientParserState.DEFAULT) {
+                currentParseState = SqlClientParserState.computeStateAt(line, i, dialect);
+                if (currentParseState != SqlClientParserState.DEFAULT) {
+                    i += currentParseState.getStart().length() - 1;
+                }
+            } else {
+                if (currentParseState.isEndMarkerOfState(line, i)) {
+                    currentParseState = SqlClientParserState.DEFAULT;
+                }
+            }
+            prevParseState = currentParseState;
+        }
+        return currentParseState;
+    }
+
+    /**
+     * Returns whether at current {@code pos} of {@code input} there is {@code end} marker of the
+     * state. In case {@code end} marker is null it returns false.
+     *
+     * @param input a string to look at
+     * @param pos a position to check if anything matches to {@code end} starting from this position
+     * @return whether end marker of the current state is reached of false case of end marker of
+     *     current state is null.
+     */
+    boolean isEndMarkerOfState(String input, int pos) {
+        if (end == null) {
+            return false;
+        }
+        return end.length() > 0 && input.regionMatches(pos, end, 0, end.length());
+    }
+
+    public BiConsumer<AttributedStringBuilder, SyntaxHighlightStyle> getStyleSetter() {
+        return styleSetter;
+    }
+
+    public String getStart() {
+        return start;
+    }
+
+    public String getEnd() {
+        return end;
+    }
+}

--- a/flink-table/flink-sql-client/src/main/java/org/apache/flink/table/client/cli/parser/SqlClientSyntaxHighlighter.java
+++ b/flink-table/flink-sql-client/src/main/java/org/apache/flink/table/client/cli/parser/SqlClientSyntaxHighlighter.java
@@ -34,11 +34,8 @@ import org.slf4j.LoggerFactory;
 
 import java.util.Arrays;
 import java.util.Collections;
-import java.util.List;
 import java.util.Locale;
 import java.util.Set;
-import java.util.function.BiConsumer;
-import java.util.function.Function;
 import java.util.stream.Collectors;
 
 /** Sql Client syntax highlighter. */
@@ -77,14 +74,14 @@ public class SqlClientSyntaxHighlighter extends DefaultHighlighter {
     static AttributedString getHighlightedOutput(
             String buffer, SyntaxHighlightStyle style, SqlDialect dialect) {
         final AttributedStringBuilder highlightedOutput = new AttributedStringBuilder();
-        State prevParseState = State.DEFAULT;
-        State currentParseState = State.DEFAULT;
+        SqlClientParserState prevParseState = SqlClientParserState.DEFAULT;
+        SqlClientParserState currentParseState = SqlClientParserState.DEFAULT;
         final StringBuilder word = new StringBuilder();
         for (int i = 0; i < buffer.length(); i++) {
             final char currentChar = buffer.charAt(i);
-            if (prevParseState == State.DEFAULT) {
-                currentParseState = State.computeStateAt(buffer, i, dialect);
-                if (currentParseState == State.DEFAULT) {
+            if (prevParseState == SqlClientParserState.DEFAULT) {
+                currentParseState = SqlClientParserState.computeStateAt(buffer, i, dialect);
+                if (currentParseState == SqlClientParserState.DEFAULT) {
                     if (isPartOfWord(currentChar)) {
                         word.append(currentChar);
                     } else {
@@ -93,20 +90,20 @@ public class SqlClientSyntaxHighlighter extends DefaultHighlighter {
                         word.setLength(0);
                     }
                 } else {
-                    handleWord(word, highlightedOutput, State.DEFAULT, style);
-                    currentParseState.styleSetter.accept(highlightedOutput, style);
-                    highlightedOutput.append(currentParseState.start);
-                    i += currentParseState.start.length() - 1;
+                    handleWord(word, highlightedOutput, SqlClientParserState.DEFAULT, style);
+                    currentParseState.getStyleSetter().accept(highlightedOutput, style);
+                    highlightedOutput.append(currentParseState.getStart());
+                    i += currentParseState.getStart().length() - 1;
                 }
             } else {
                 if (currentParseState.isEndMarkerOfState(buffer, i)) {
                     highlightedOutput
                             .append(word)
-                            .append(currentParseState.end)
+                            .append(currentParseState.getEnd())
                             .style(style.getDefaultStyle());
                     word.setLength(0);
-                    i += currentParseState.end.length() - 1;
-                    currentParseState = State.DEFAULT;
+                    i += currentParseState.getEnd().length() - 1;
+                    currentParseState = SqlClientParserState.DEFAULT;
                 } else {
                     word.append(currentChar);
                 }
@@ -124,10 +121,10 @@ public class SqlClientSyntaxHighlighter extends DefaultHighlighter {
     private static void handleWord(
             StringBuilder word,
             AttributedStringBuilder highlightedOutput,
-            State currentState,
+            SqlClientParserState currentState,
             SyntaxHighlightStyle style) {
         final String wordStr = word.toString();
-        if (currentState == State.DEFAULT) {
+        if (currentState == SqlClientParserState.DEFAULT) {
             if (KEYWORDS.contains(wordStr.toUpperCase(Locale.ROOT))) {
                 highlightedOutput.style(style.getKeywordStyle());
             } else {
@@ -136,107 +133,5 @@ public class SqlClientSyntaxHighlighter extends DefaultHighlighter {
         }
         highlightedOutput.append(wordStr).style(style.getDefaultStyle());
         word.setLength(0);
-    }
-
-    /**
-     * State of parser while preparing highlighted output. This class represents a state machine.
-     *
-     * <pre>
-     *      MultiLine Comment           Single Line Comment
-     *           |                              |
-     *   (&#47;*,*&#47;) |                              | (--, \n)
-     *           *------------Default-----------*
-     *                        |    |
-     *                        |    |
-     *           *------------*    *------------*
-     *  (&#47;*+,*&#47;) |            |    |            | (', ')
-     *           |            |    |            |
-     *         Hint           |    |          String
-     *                        |    |
-     *                        |    |
-     *           *------------*    *------------*
-     *    (&quot;, &quot;) |                              | (`, `)
-     *           |                              |
-     *     Hive Identifier           Flink Default Identifier
-     * </pre>
-     */
-    private enum State {
-        QUOTED("'", "'", dialect -> true, (asb, style) -> asb.style(style.getQuotedStyle())),
-        SQL_QUOTED_IDENTIFIER(
-                "`",
-                "`",
-                (dialect) -> dialect == SqlDialect.DEFAULT || dialect == null,
-                (asb, style) -> asb.style(style.getSqlIdentifierStyle())),
-        HIVE_SQL_QUOTED_IDENTIFIER(
-                "\"",
-                "\"",
-                (dialect) -> dialect == SqlDialect.HIVE,
-                (asb, style) -> asb.style(style.getSqlIdentifierStyle())),
-        ONE_LINE_COMMENTED(
-                "--", "\n", dialect -> true, (asb, style) -> asb.style(style.getCommentStyle())),
-        HINTED("/*+", "*/", dialect -> true, (asb, style) -> asb.style(style.getHintStyle())),
-        MULTILINE_COMMENTED(
-                "/*", "*/", dialect -> true, (asb, style) -> asb.style(style.getCommentStyle())),
-
-        // DEFAULT state should be the last one in this list since it is kind a fallback.
-        DEFAULT(null, null, dialect -> true, (asb, style) -> asb.style(style.getDefaultStyle()));
-
-        private final String start;
-        private final String end;
-        private final Function<SqlDialect, Boolean> condition;
-
-        private final BiConsumer<AttributedStringBuilder, SyntaxHighlightStyle> styleSetter;
-
-        private static final List<State> STATE_LIST_WITHOUT_DEFAULT =
-                Arrays.stream(State.values())
-                        .filter(t -> t != DEFAULT)
-                        .collect(Collectors.toList());
-        private static final Set<Character> STATE_START_SYMBOLS =
-                Arrays.stream(State.values())
-                        .filter(t -> t != DEFAULT)
-                        .map(t -> t.start.charAt(0))
-                        .collect(Collectors.toSet());
-
-        State(
-                String start,
-                String end,
-                Function<SqlDialect, Boolean> condition,
-                BiConsumer<AttributedStringBuilder, SyntaxHighlightStyle> styleSetter) {
-            this.start = start;
-            this.end = end;
-            this.condition = condition;
-            this.styleSetter = styleSetter;
-        }
-
-        static State computeStateAt(String input, int pos, SqlDialect dialect) {
-            final char currentChar = input.charAt(pos);
-            if (!STATE_START_SYMBOLS.contains(currentChar)) {
-                return DEFAULT;
-            }
-            for (State state : STATE_LIST_WITHOUT_DEFAULT) {
-                if (state.condition.apply(dialect)
-                        && state.start.regionMatches(0, input, pos, state.start.length())) {
-                    return state;
-                }
-            }
-            return DEFAULT;
-        }
-
-        /**
-         * Returns whether at current {@code pos} of {@code input} there is {@code end} marker of
-         * the state. In case {@code end} marker is null it returns false.
-         *
-         * @param input a string to look at
-         * @param pos a position to check if anything matches to {@code end} starting from this
-         *     position
-         * @return whether end marker of the current state is reached of false case of end marker of
-         *     current state is null.
-         */
-        boolean isEndMarkerOfState(String input, int pos) {
-            if (end == null) {
-                return false;
-            }
-            return end.length() > 0 && input.regionMatches(pos, end, 0, end.length());
-        }
     }
 }

--- a/flink-table/flink-sql-client/src/main/java/org/apache/flink/table/client/cli/parser/SqlMultiLineParser.java
+++ b/flink-table/flink-sql-client/src/main/java/org/apache/flink/table/client/cli/parser/SqlMultiLineParser.java
@@ -19,7 +19,9 @@
 package org.apache.flink.table.client.cli.parser;
 
 import org.apache.flink.configuration.ReadableConfig;
+import org.apache.flink.table.api.SqlDialect;
 import org.apache.flink.table.api.SqlParserEOFException;
+import org.apache.flink.table.api.config.TableConfigOptions;
 import org.apache.flink.table.client.cli.CliClient;
 import org.apache.flink.table.client.cli.Printer;
 import org.apache.flink.table.client.config.ResultMode;
@@ -74,7 +76,16 @@ public class SqlMultiLineParser extends DefaultParser {
         if (context != ParseContext.ACCEPT_LINE) {
             return parseInternal(line, cursor, context);
         }
-        if (!line.trim().endsWith(STATEMENT_DELIMITER)) {
+        ReadableConfig configuration = executor.getSessionConfig();
+        final String dialectName = configuration.get(TableConfigOptions.TABLE_SQL_DIALECT);
+        final SqlDialect dialect =
+                SqlDialect.HIVE.name().equalsIgnoreCase(dialectName)
+                        ? SqlDialect.HIVE
+                        : SqlDialect.DEFAULT;
+        SqlClientParserState currentParseState =
+                SqlClientParserState.computeCurrentStateAtTheEndOfLine(line, dialect);
+        if (currentParseState != SqlClientParserState.DEFAULT
+                || !line.trim().endsWith(STATEMENT_DELIMITER)) {
             throw new EOFError(-1, -1, "New line without EOF character.", NEW_LINE_PROMPT);
         }
         try {

--- a/flink-table/flink-sql-client/src/test/java/org/apache/flink/table/client/cli/utils/SqlScriptReader.java
+++ b/flink-table/flink-sql-client/src/test/java/org/apache/flink/table/client/cli/utils/SqlScriptReader.java
@@ -18,6 +18,9 @@
 
 package org.apache.flink.table.client.cli.utils;
 
+import org.apache.flink.table.api.SqlDialect;
+import org.apache.flink.table.client.cli.parser.SqlClientParserState;
+
 import javax.annotation.Nullable;
 
 import java.io.BufferedReader;
@@ -25,6 +28,8 @@ import java.io.IOException;
 import java.io.StringReader;
 import java.util.ArrayList;
 import java.util.List;
+
+import static org.apache.flink.table.client.cli.parser.SqlClientParserState.computeCurrentStateAtTheEndOfLine;
 
 /**
  * A utility to read and parse content of a SQL script. The SQL script is located in "resources/sql"
@@ -96,7 +101,11 @@ public final class SqlScriptReader implements AutoCloseable {
                         status = ReadingStatus.RESULT_CONTENT;
                     } else {
                         sqlLines.append(currentLine).append("\n");
-                        if (!enableMultiStatement && currentLine.trim().endsWith(";")) {
+                        if (!enableMultiStatement
+                                && currentLine.trim().endsWith(";")
+                                && computeCurrentStateAtTheEndOfLine(
+                                                sqlLines.toString().trim(), SqlDialect.DEFAULT)
+                                        == SqlClientParserState.DEFAULT) {
                             // SQL statement is finished, begin to read result content
                             status = ReadingStatus.RESULT_CONTENT;
                         }

--- a/flink-table/flink-sql-client/src/test/resources/sql/select.q
+++ b/flink-table/flink-sql-client/src/test/resources/sql/select.q
@@ -337,7 +337,33 @@ SELECT INTERVAL '1' DAY as dayInterval, INTERVAL '1' YEAR as yearInterval;
 1 row in set
 !ok
 
+SELECT ';
+';
++--------+
+| EXPR$0 |
++--------+
+|     ;
+ |
++--------+
+1 row in set
+!ok
+
 SELECT /*;
-[ERROR] Could not execute SQL statement. Reason:
-org.apache.flink.sql.parser.impl.TokenMgrError: Lexical error at line 1, column 11.  Encountered: <EOF> after : ""
-!error
+'*/ 1;
++--------+
+| EXPR$0 |
++--------+
+|      1 |
++--------+
+1 row in set
+!ok
+
+SELECT --;
+1;
++--------+
+| EXPR$0 |
++--------+
+|      1 |
++--------+
+1 row in set
+!ok


### PR DESCRIPTION
## What is the purpose of the change

The PR is a part of FLIP-189 [1].
This PR fixes queries for corner cases mention at FLINK-24592 e.g.
```sql
select ';
';
select /*;
*/1;
select --;
1;
```
and others.

[1] https://cwiki.apache.org/confluence/display/FLINK/FLIP-189%3A+SQL+Client+Usability+Improvements#FLIP189:SQLClientUsabilityImprovements-Supportedprompthintvaluesinsqlclient

## Brief change log

  - Reworked SqlMultilineParser

## Verifying this change
There is _flink-table/flink-sql-client/src/test/java/org/apache/flink/table/client/cli/SqlMultilineParserTest.java_
and updated _flink-table/flink-sql-client/src/test/java/org/apache/flink/table/client/cli/CliStatementSplitterTest.java_

## Does this pull request potentially affect one of the following parts:

  - Dependencies (does it add or upgrade a dependency): ( **no**)
  - The public API, i.e., is any changed class annotated with `@Public(Evolving)`: ( **no**)
  - The serializers: ( **no** )
  - The runtime per-record code paths (performance sensitive): ( **no** )
  - Anything that affects deployment or recovery: JobManager (and its components), Checkpointing, Kubernetes/Yarn, ZooKeeper: ( **no** )
  - The S3 file system connector: ( **no** )

## Documentation

  - Does this pull request introduce a new feature? (**yes** )
  - If yes, how is the feature documented? (not applicable  )
