### PR TITLE
[FLINK-25005][build] Add java17-target profile

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -943,6 +943,28 @@ under the License.
 		</profile>
 
 		<profile>
+			<id>java17-target</id>
+			<build>
+				<plugins>
+					<plugin>
+						<groupId>org.apache.maven.plugins</groupId>
+						<artifactId>maven-compiler-plugin</artifactId>
+						<configuration>
+							<source>17</source>
+							<target>17</target>
+							<compilerArgs combine.children="append">
+								<arg>--add-exports=java.base/sun.net.util=ALL-UNNAMED</arg>
+								<arg>--add-exports=java.management/sun.management=ALL-UNNAMED</arg>
+								<arg>--add-exports=java.rmi/sun.rmi.registry=ALL-UNNAMED</arg>
+								<arg>--add-exports=java.security.jgss/sun.security.krb5=ALL-UNNAMED</arg>
+							</compilerArgs>
+						</configuration>
+					</plugin>
+				</plugins>
+			</build>
+		</profile>
+
+		<profile>
 			<id>fast</id>
 			<activation>
 				<property>


### PR DESCRIPTION
Provides an opt-in switch to compile to Java 17 bytecode, similar to the java11-target profile.

Note that so far I have not tested at all what happens if you _don't_ use this profile with Java 17 (i.e., compile to Java 8).