### PR TITLE
[FLINK-24596][kafka] Fix buffered KafkaUpsert sink

### DIFF
--- a/flink-connectors/flink-connector-cassandra/src/main/java/org/apache/flink/streaming/connectors/cassandra/CassandraSink.java
+++ b/flink-connectors/flink-connector-cassandra/src/main/java/org/apache/flink/streaming/connectors/cassandra/CassandraSink.java
@@ -62,7 +62,7 @@ public class CassandraSink<IN> {
     }
 
     private LegacySinkTransformation<IN> getSinkTransformation() {
-        return sink1.getTransformation();
+        return sink1.getLegacyTransformation();
     }
 
     private Transformation<IN> getTransformation() {

--- a/flink-connectors/flink-connector-elasticsearch-base/src/main/java/org/apache/flink/connector/elasticsearch/table/KeyExtractor.java
+++ b/flink-connectors/flink-connector-elasticsearch-base/src/main/java/org/apache/flink/connector/elasticsearch/table/KeyExtractor.java
@@ -23,6 +23,7 @@ import org.apache.flink.table.api.TableColumn;
 import org.apache.flink.table.data.RowData;
 import org.apache.flink.table.types.logical.DistinctType;
 import org.apache.flink.table.types.logical.LogicalType;
+import org.apache.flink.util.function.SerializableFunction;
 
 import java.io.Serializable;
 import java.time.Duration;

--- a/flink-connectors/flink-connector-jdbc/src/main/java/org/apache/flink/connector/jdbc/internal/JdbcOutputFormat.java
+++ b/flink-connectors/flink-connector-jdbc/src/main/java/org/apache/flink/connector/jdbc/internal/JdbcOutputFormat.java
@@ -40,6 +40,7 @@ import org.apache.flink.connector.jdbc.utils.JdbcUtils;
 import org.apache.flink.types.Row;
 import org.apache.flink.util.Preconditions;
 import org.apache.flink.util.concurrent.ExecutorThreadFactory;
+import org.apache.flink.util.function.SerializableFunction;
 
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
@@ -99,7 +100,7 @@ public class JdbcOutputFormat<In, JdbcIn, JdbcExec extends JdbcBatchStatementExe
      * @param <T> The type of instance.
      */
     public interface StatementExecutorFactory<T extends JdbcBatchStatementExecutor<?>>
-            extends Function<RuntimeContext, T>, Serializable {}
+            extends SerializableFunction<RuntimeContext, T> {}
 
     private static final long serialVersionUID = 1L;
 

--- a/flink-connectors/flink-connector-kafka/src/main/java/org/apache/flink/streaming/connectors/kafka/table/KafkaDynamicSink.java
+++ b/flink-connectors/flink-connector-kafka/src/main/java/org/apache/flink/streaming/connectors/kafka/table/KafkaDynamicSink.java
@@ -56,7 +56,6 @@ import java.util.List;
 import java.util.Map;
 import java.util.Objects;
 import java.util.Properties;
-import java.util.function.Function;
 import java.util.stream.Stream;
 
 import static org.apache.flink.util.Preconditions.checkNotNull;
@@ -231,7 +230,7 @@ public class KafkaDynamicSink implements DynamicTableSink, SupportsWritingMetada
                                                                 context,
                                                                 dataStream.getExecutionConfig())
                                                         ::copy
-                                                : Function.identity());
+                                                : rowData -> rowData);
                         final DataStreamSink<RowData> end = dataStream.sinkTo(sink);
                         if (parallelism != null) {
                             end.setParallelism(parallelism);

--- a/flink-connectors/flink-connector-kafka/src/main/java/org/apache/flink/streaming/connectors/kafka/table/ReducingUpsertSink.java
+++ b/flink-connectors/flink-connector-kafka/src/main/java/org/apache/flink/streaming/connectors/kafka/table/ReducingUpsertSink.java
@@ -24,11 +24,11 @@ import org.apache.flink.api.connector.sink.SinkWriter;
 import org.apache.flink.core.io.SimpleVersionedSerializer;
 import org.apache.flink.table.data.RowData;
 import org.apache.flink.table.types.DataType;
+import org.apache.flink.util.function.SerializableFunction;
 
 import java.io.IOException;
 import java.util.List;
 import java.util.Optional;
-import java.util.function.Function;
 
 /**
  * A wrapper of a {@link Sink}. It will buffer the data emitted by the wrapper {@link SinkWriter}
@@ -43,14 +43,14 @@ class ReducingUpsertSink<WriterState> implements Sink<RowData, Void, WriterState
     private final DataType physicalDataType;
     private final int[] keyProjection;
     private final SinkBufferFlushMode bufferFlushMode;
-    private final Function<RowData, RowData> valueCopyFunction;
+    private final SerializableFunction<RowData, RowData> valueCopyFunction;
 
     ReducingUpsertSink(
             Sink<RowData, ?, WriterState, ?> wrappedSink,
             DataType physicalDataType,
             int[] keyProjection,
             SinkBufferFlushMode bufferFlushMode,
-            Function<RowData, RowData> valueCopyFunction) {
+            SerializableFunction<RowData, RowData> valueCopyFunction) {
         this.wrappedSink = wrappedSink;
         this.physicalDataType = physicalDataType;
         this.keyProjection = keyProjection;

--- a/flink-connectors/flink-connector-kafka/src/main/java/org/apache/flink/streaming/connectors/kafka/table/SinkBufferFlushMode.java
+++ b/flink-connectors/flink-connector-kafka/src/main/java/org/apache/flink/streaming/connectors/kafka/table/SinkBufferFlushMode.java
@@ -18,10 +18,11 @@
 
 package org.apache.flink.streaming.connectors.kafka.table;
 
+import java.io.Serializable;
 import java.util.Objects;
 
 /** Sink buffer flush configuration. */
-public class SinkBufferFlushMode {
+public class SinkBufferFlushMode implements Serializable {
 
     private static final int DISABLED_BATCH_SIZE = 0;
     private static final long DISABLED_BATCH_INTERVAL = 0L;

--- a/flink-connectors/flink-connector-kafka/src/test/java/org/apache/flink/streaming/connectors/kafka/table/ReducingUpsertWriterTest.java
+++ b/flink-connectors/flink-connector-kafka/src/test/java/org/apache/flink/streaming/connectors/kafka/table/ReducingUpsertWriterTest.java
@@ -45,7 +45,6 @@ import java.util.HashMap;
 import java.util.Iterator;
 import java.util.List;
 import java.util.Map;
-import java.util.function.Function;
 
 import static org.apache.flink.types.RowKind.DELETE;
 import static org.apache.flink.types.RowKind.INSERT;
@@ -321,7 +320,7 @@ public class ReducingUpsertWriterTest {
                 },
                 enableObjectReuse
                         ? typeInformation.createSerializer(new ExecutionConfig())::copy
-                        : Function.identity());
+                        : r -> r);
     }
 
     private static class MockedSinkWriter implements SinkWriter<RowData, Void, Void> {

--- a/flink-core/src/main/java/org/apache/flink/util/function/SerializableFunction.java
+++ b/flink-core/src/main/java/org/apache/flink/util/function/SerializableFunction.java
@@ -16,9 +16,14 @@
  * limitations under the License.
  */
 
-package org.apache.flink.connector.elasticsearch.table;
+package org.apache.flink.util.function;
+
+import org.apache.flink.annotation.Public;
 
 import java.io.Serializable;
 import java.util.function.Function;
 
-interface SerializableFunction<T, R> extends Function<T, R>, Serializable {}
+/** A {@link Function} that is also {@link Serializable}. */
+@Public
+@FunctionalInterface
+public interface SerializableFunction<T, R> extends Function<T, R>, Serializable {}

--- a/flink-runtime/src/test/java/org/apache/flink/runtime/operators/coordination/TestingOperatorCoordinator.java
+++ b/flink-runtime/src/test/java/org/apache/flink/runtime/operators/coordination/TestingOperatorCoordinator.java
@@ -19,7 +19,7 @@
 package org.apache.flink.runtime.operators.coordination;
 
 import org.apache.flink.runtime.jobgraph.OperatorID;
-import org.apache.flink.runtime.util.SerializableFunction;
+import org.apache.flink.util.function.SerializableFunction;
 
 import javax.annotation.Nullable;
 

--- a/flink-runtime/src/test/java/org/apache/flink/runtime/util/SerializableFunction.java
+++ b/flink-runtime/src/test/java/org/apache/flink/runtime/util/SerializableFunction.java
@@ -23,7 +23,12 @@ import org.apache.flink.annotation.Public;
 import java.io.Serializable;
 import java.util.function.Function;
 
-/** A {@link Function} that is also {@link Serializable}. */
+/**
+ * A {@link Function} that is also {@link Serializable}.
+ *
+ * @deprecated Please use {@link org.apache.flink.util.function.SerializableFunction}
+ */
+@Deprecated
 @Public
 @FunctionalInterface
 public interface SerializableFunction<T, R> extends Function<T, R>, Serializable {}

--- a/flink-streaming-java/src/main/java/org/apache/flink/streaming/api/datastream/DataStream.java
+++ b/flink-streaming-java/src/main/java/org/apache/flink/streaming/api/datastream/DataStream.java
@@ -1244,7 +1244,7 @@ public class DataStream<T> {
 
         DataStreamSink<T> sink = new DataStreamSink<>(this, sinkOperator);
 
-        getExecutionEnvironment().addOperator(sink.getTransformation());
+        getExecutionEnvironment().addOperator(sink.getLegacyTransformation());
         return sink;
     }
 

--- a/flink-streaming-java/src/main/java/org/apache/flink/streaming/api/datastream/DataStreamSink.java
+++ b/flink-streaming-java/src/main/java/org/apache/flink/streaming/api/datastream/DataStreamSink.java
@@ -23,6 +23,7 @@ import org.apache.flink.annotation.PublicEvolving;
 import org.apache.flink.api.common.operators.ResourceSpec;
 import org.apache.flink.api.common.operators.SlotSharingGroup;
 import org.apache.flink.api.connector.sink.Sink;
+import org.apache.flink.api.dag.Transformation;
 import org.apache.flink.streaming.api.operators.ChainingStrategy;
 import org.apache.flink.streaming.api.operators.StreamSink;
 import org.apache.flink.streaming.api.transformations.LegacySinkTransformation;
@@ -64,7 +65,12 @@ public class DataStreamSink<T> {
 
     /** Returns the transformation that contains the actual sink operator of this sink. */
     @Internal
-    public LegacySinkTransformation<T> getTransformation() {
+    public Transformation<T> getTransformation() {
+        return transformation;
+    }
+
+    @Internal
+    public LegacySinkTransformation<T> getLegacyTransformation() {
         if (transformation instanceof LegacySinkTransformation) {
             return (LegacySinkTransformation<T>) transformation;
         } else {

--- a/flink-streaming-java/src/main/java/org/apache/flink/streaming/api/datastream/KeyedStream.java
+++ b/flink-streaming-java/src/main/java/org/apache/flink/streaming/api/datastream/KeyedStream.java
@@ -299,8 +299,8 @@ public class KeyedStream<T, KEY> extends DataStream<T> {
     @Override
     public DataStreamSink<T> addSink(SinkFunction<T> sinkFunction) {
         DataStreamSink<T> result = super.addSink(sinkFunction);
-        result.getTransformation().setStateKeySelector(keySelector);
-        result.getTransformation().setStateKeyType(keyType);
+        result.getLegacyTransformation().setStateKeySelector(keySelector);
+        result.getLegacyTransformation().setStateKeyType(keyType);
         return result;
     }
 

--- a/flink-streaming-java/src/main/java/org/apache/flink/streaming/api/operators/collect/CollectStreamSink.java
+++ b/flink-streaming-java/src/main/java/org/apache/flink/streaming/api/operators/collect/CollectStreamSink.java
@@ -18,10 +18,12 @@
 package org.apache.flink.streaming.api.operators.collect;
 
 import org.apache.flink.annotation.Internal;
+import org.apache.flink.api.dag.Transformation;
 import org.apache.flink.streaming.api.datastream.DataStream;
 import org.apache.flink.streaming.api.datastream.DataStreamSink;
 import org.apache.flink.streaming.api.operators.ChainingStrategy;
 import org.apache.flink.streaming.api.transformations.LegacySinkTransformation;
+import org.apache.flink.streaming.api.transformations.PhysicalTransformation;
 
 /**
  * A {@link DataStreamSink} which is used to collect results of a data stream. It completely
@@ -30,17 +32,17 @@ import org.apache.flink.streaming.api.transformations.LegacySinkTransformation;
 @Internal
 public class CollectStreamSink<T> extends DataStreamSink<T> {
 
-    private final LegacySinkTransformation<T> transformation;
+    private final PhysicalTransformation<T> transformation;
 
     public CollectStreamSink(DataStream<T> inputStream, CollectSinkOperatorFactory<T> factory) {
         super(inputStream, (CollectSinkOperator<T>) factory.getOperator());
         this.transformation =
-                new LegacySinkTransformation<>(
+                new LegacySinkTransformation<T>(
                         inputStream.getTransformation(), "Collect Stream Sink", factory, 1);
     }
 
     @Override
-    public LegacySinkTransformation<T> getTransformation() {
+    public Transformation<T> getTransformation() {
         return transformation;
     }
 

--- a/flink-streaming-java/src/main/java/org/apache/flink/streaming/api/transformations/LegacySinkTransformation.java
+++ b/flink-streaming-java/src/main/java/org/apache/flink/streaming/api/transformations/LegacySinkTransformation.java
@@ -23,7 +23,6 @@ import org.apache.flink.annotation.VisibleForTesting;
 import org.apache.flink.api.common.typeinfo.TypeInformation;
 import org.apache.flink.api.dag.Transformation;
 import org.apache.flink.api.java.functions.KeySelector;
-import org.apache.flink.api.java.typeutils.TypeExtractor;
 import org.apache.flink.streaming.api.operators.ChainingStrategy;
 import org.apache.flink.streaming.api.operators.SimpleOperatorFactory;
 import org.apache.flink.streaming.api.operators.StreamOperatorFactory;
@@ -40,7 +39,7 @@ import java.util.List;
  * @param <T> The type of the elements in the input {@code LegacySinkTransformation}
  */
 @Internal
-public class LegacySinkTransformation<T> extends PhysicalTransformation<Object> {
+public class LegacySinkTransformation<T> extends PhysicalTransformation<T> {
 
     private final Transformation<T> input;
 
@@ -70,7 +69,7 @@ public class LegacySinkTransformation<T> extends PhysicalTransformation<Object> 
             String name,
             StreamOperatorFactory<Object> operatorFactory,
             int parallelism) {
-        super(name, TypeExtractor.getForClass(Object.class), parallelism);
+        super(name, input.getOutputType(), parallelism);
         this.input = input;
         this.operatorFactory = operatorFactory;
     }

--- a/flink-streaming-java/src/main/java/org/apache/flink/streaming/runtime/translators/LegacySinkTransformationTranslator.java
+++ b/flink-streaming-java/src/main/java/org/apache/flink/streaming/runtime/translators/LegacySinkTransformationTranslator.java
@@ -42,7 +42,7 @@ import static org.apache.flink.util.Preconditions.checkState;
  */
 @Internal
 public class LegacySinkTransformationTranslator<IN>
-        extends SimpleTransformationTranslator<Object, LegacySinkTransformation<IN>> {
+        extends SimpleTransformationTranslator<IN, LegacySinkTransformation<IN>> {
 
     @Override
     protected Collection<Integer> translateForBatchInternal(

--- a/flink-streaming-java/src/test/java/org/apache/flink/streaming/api/datastream/DataStreamSinkTest.java
+++ b/flink-streaming-java/src/test/java/org/apache/flink/streaming/api/datastream/DataStreamSinkTest.java
@@ -17,18 +17,24 @@
 
 package org.apache.flink.streaming.api.datastream;
 
+import org.apache.flink.api.dag.Transformation;
 import org.apache.flink.streaming.api.environment.StreamExecutionEnvironment;
+import org.apache.flink.streaming.api.transformations.SinkTransformation;
 import org.apache.flink.streaming.runtime.operators.sink.TestSink;
 
 import org.junit.Test;
 
+import static org.junit.Assert.assertTrue;
+
 /** Unit test for {@link DataStreamSink}. */
 public class DataStreamSinkTest {
 
-    @Test(expected = IllegalStateException.class)
+    @Test
     public void throwExceptionWhenGettingTransformationWithNewSinkAPI() {
         StreamExecutionEnvironment env = StreamExecutionEnvironment.getExecutionEnvironment();
-        env.fromElements(1, 2).sinkTo(TestSink.newBuilder().build()).getTransformation();
+        final Transformation<Integer> transformation =
+                env.fromElements(1, 2).sinkTo(TestSink.newBuilder().build()).getTransformation();
+        assertTrue(transformation instanceof SinkTransformation);
     }
 
     @Test(expected = UnsupportedOperationException.class)

--- a/flink-table/flink-table-api-java-bridge/src/main/java/org/apache/flink/connector/datagen/table/types/DataGeneratorMapper.java
+++ b/flink-table/flink-table-api-java-bridge/src/main/java/org/apache/flink/connector/datagen/table/types/DataGeneratorMapper.java
@@ -22,9 +22,7 @@ import org.apache.flink.annotation.Internal;
 import org.apache.flink.api.common.functions.RuntimeContext;
 import org.apache.flink.runtime.state.FunctionInitializationContext;
 import org.apache.flink.streaming.api.functions.source.datagen.DataGenerator;
-
-import java.io.Serializable;
-import java.util.function.Function;
+import org.apache.flink.util.function.SerializableFunction;
 
 /** Utility for mapping the output of a {@link DataGenerator}. */
 @Internal
@@ -55,7 +53,4 @@ public class DataGeneratorMapper<A, B> implements DataGenerator<B> {
     public B next() {
         return mapper.apply(generator.next());
     }
-
-    /** A simple serializable function. */
-    public interface SerializableFunction<A, B> extends Function<A, B>, Serializable {}
 }

--- a/flink-table/flink-table-planner/src/main/java/org/apache/flink/table/planner/plan/nodes/exec/batch/BatchExecLegacySink.java
+++ b/flink-table/flink-table-planner/src/main/java/org/apache/flink/table/planner/plan/nodes/exec/batch/BatchExecLegacySink.java
@@ -37,8 +37,7 @@ import java.lang.reflect.Modifier;
  *
  * @param <T> The return type of the {@link TableSink}.
  */
-public class BatchExecLegacySink<T> extends CommonExecLegacySink<T>
-        implements BatchExecNode<Object> {
+public class BatchExecLegacySink<T> extends CommonExecLegacySink<T> implements BatchExecNode<T> {
 
     public BatchExecLegacySink(
             TableSink<T> tableSink,

--- a/flink-table/flink-table-planner/src/main/java/org/apache/flink/table/planner/plan/nodes/exec/stream/StreamExecLegacySink.java
+++ b/flink-table/flink-table-planner/src/main/java/org/apache/flink/table/planner/plan/nodes/exec/stream/StreamExecLegacySink.java
@@ -40,8 +40,7 @@ import java.util.stream.Collectors;
  *
  * @param <T> The return type of the {@link TableSink}.
  */
-public class StreamExecLegacySink<T> extends CommonExecLegacySink<T>
-        implements StreamExecNode<Object> {
+public class StreamExecLegacySink<T> extends CommonExecLegacySink<T> implements StreamExecNode<T> {
 
     public StreamExecLegacySink(
             TableSink<T> tableSink,


### PR DESCRIPTION
<!--
*Thank you very much for contributing to Apache Flink - we are happy that you want to help us improve Flink. To help the community review your contribution in the best possible way, please go through the checklist below, which will get the contribution into a shape in which it can be best reviewed.*

*Please understand that we do not do this to make contributions to Flink a hassle. In order to uphold a high standard of quality for code contributions, while at the same time managing a large number of contributions, we need contributors to prepare the contributions well, and give reviewers enough contextual information for the review. Please also understand that contributions that do not follow this guide will take longer to review and thus typically be picked up with lower priority by the community.*

## Contribution Checklist

  - Make sure that the pull request corresponds to a [JIRA issue](https://issues.apache.org/jira/projects/FLINK/issues). Exceptions are made for typos in JavaDoc or documentation files, which need no JIRA issue.
  
  - Name the pull request in the form "[FLINK-XXXX] [component] Title of the pull request", where *FLINK-XXXX* should be replaced by the actual issue number. Skip *component* if you are unsure about which is the best component.
  Typo fixes that have no associated JIRA issue should be named following this pattern: `[hotfix] [docs] Fix typo in event time introduction` or `[hotfix] [javadocs] Expand JavaDoc for PuncuatedWatermarkGenerator`.

  - Fill out the template below to describe the changes contributed by the pull request. That will give reviewers the context they need to do the review.
  
  - Make sure that the change passes the automated tests, i.e., `mvn clean verify` passes. You can set up Azure Pipelines CI to do that following [this guide](https://cwiki.apache.org/confluence/display/FLINK/Azure+Pipelines#AzurePipelines-Tutorial:SettingupAzurePipelinesforaforkoftheFlinkrepository).

  - Each pull request should address only one issue, not mix up code from multiple issues.
  
  - Each commit in the pull request has a meaningful commit message (including the JIRA id)

  - Once all items of the checklist are addressed, remove the above text and this checklist, leaving only the filled out template below.


**(The sections below can be removed for hotfixes of typos)**
-->

## What is the purpose of the change

When migrating the buffered Kafka upsert sink to the unified Sink a few problems were discovered i.e. input lambdas were not serializable, unified sinks did not work with the DataStreamSink Provider.

With this PR the points should be addressed. 


## Brief change log

- Make input lambdas serializable 
- Differentiate in DataStreamSink between legacy and unified sinks transformation to support both in the DataStreamSinkProvider


## Verifying this change

- Added ITCase to cover the functionality of the buffered KafkaUpsert sink.
- Added a test to verify that unified sinks work with the DataStreamSinkProvider.

## Does this pull request potentially affect one of the following parts:

  - Dependencies (does it add or upgrade a dependency): (yes / **no**)
  - The public API, i.e., is any changed class annotated with `@Public(Evolving)`: (yes / **no**)
  - The serializers: (yes / **no** / don't know)
  - The runtime per-record code paths (performance sensitive): (yes / **no** / don't know)
  - Anything that affects deployment or recovery: JobManager (and its components), Checkpointing, Kubernetes/Yarn, ZooKeeper: (yes / **no** / don't know)
  - The S3 file system connector: (yes / **no** / don't know)

## Documentation

  - Does this pull request introduce a new feature? (yes / **no**)
  - If yes, how is the feature documented? (**not applicable** / docs / JavaDocs / not documented)
