### PR TITLE
[FLINK-24937][e2e] Return correct exit code in build_image

### DIFF
--- a/flink-end-to-end-tests/test-scripts/common_docker.sh
+++ b/flink-end-to-end-tests/test-scripts/common_docker.sh
@@ -54,7 +54,9 @@ function build_image() {
 
     echo "Building images"
     run_with_timeout 600 docker build --no-cache --network="host" -t ${image_name} dev/${image_name}-debian
+    local build_image_result=$?
     popd
+    return $build_image_result
 }
 
 function start_file_server() {


### PR DESCRIPTION
Backport #17823 to 1.13.