### PR TITLE
[FLINK-24507][table] Cleanup DateTimeUtils

### DIFF
--- a/flink-connectors/flink-connector-hbase-1.4/src/test/java/org/apache/flink/connector/hbase1/util/HBaseTestBase.java
+++ b/flink-connectors/flink-connector-hbase-1.4/src/test/java/org/apache/flink/connector/hbase1/util/HBaseTestBase.java
@@ -19,7 +19,6 @@
 package org.apache.flink.connector.hbase1.util;
 
 import org.apache.flink.table.api.EnvironmentSettings;
-import org.apache.flink.table.utils.DateTimeUtils;
 
 import org.apache.hadoop.hbase.TableName;
 import org.apache.hadoop.hbase.client.HTable;
@@ -260,15 +259,11 @@ public abstract class HBaseTestBase extends HBaseTestingClusterAutoStarter {
 
         // family 4
         put.addColumn(
-                Bytes.toBytes(FAMILY4),
-                Bytes.toBytes(F4COL1),
-                Bytes.toBytes(DateTimeUtils.toInternal(f4c1)));
+                Bytes.toBytes(FAMILY4), Bytes.toBytes(F4COL1), Bytes.toBytes(toInternal(f4c1)));
         put.addColumn(
                 Bytes.toBytes(FAMILY4), Bytes.toBytes(F4COL2), Bytes.toBytes(toInternal(f4c2)));
         put.addColumn(
-                Bytes.toBytes(FAMILY4),
-                Bytes.toBytes(F4COL3),
-                Bytes.toBytes(DateTimeUtils.toInternal(f4c3)));
+                Bytes.toBytes(FAMILY4), Bytes.toBytes(F4COL3), Bytes.toBytes(toInternal(f4c3)));
         put.addColumn(Bytes.toBytes(FAMILY4), Bytes.toBytes(F4COL4), Bytes.toBytes(f4c4));
         return put;
     }

--- a/flink-connectors/flink-connector-hbase-1.4/src/test/java/org/apache/flink/connector/hbase1/util/HBaseTestBase.java
+++ b/flink-connectors/flink-connector-hbase-1.4/src/test/java/org/apache/flink/connector/hbase1/util/HBaseTestBase.java
@@ -19,6 +19,7 @@
 package org.apache.flink.connector.hbase1.util;
 
 import org.apache.flink.table.api.EnvironmentSettings;
+import org.apache.flink.table.utils.DateTimeUtils;
 
 import org.apache.hadoop.hbase.TableName;
 import org.apache.hadoop.hbase.client.HTable;
@@ -35,9 +36,7 @@ import java.sql.Timestamp;
 import java.util.ArrayList;
 import java.util.List;
 
-import static org.apache.flink.table.utils.DateTimeUtils.dateToInternal;
-import static org.apache.flink.table.utils.DateTimeUtils.timeToInternal;
-import static org.apache.flink.table.utils.DateTimeUtils.timestampToInternal;
+import static org.apache.flink.table.utils.DateTimeUtils.toInternal;
 
 /** Abstract IT case class for HBase. */
 public abstract class HBaseTestBase extends HBaseTestingClusterAutoStarter {
@@ -263,11 +262,13 @@ public abstract class HBaseTestBase extends HBaseTestingClusterAutoStarter {
         put.addColumn(
                 Bytes.toBytes(FAMILY4),
                 Bytes.toBytes(F4COL1),
-                Bytes.toBytes(timestampToInternal(f4c1)));
+                Bytes.toBytes(DateTimeUtils.toInternal(f4c1)));
         put.addColumn(
-                Bytes.toBytes(FAMILY4), Bytes.toBytes(F4COL2), Bytes.toBytes(dateToInternal(f4c2)));
+                Bytes.toBytes(FAMILY4), Bytes.toBytes(F4COL2), Bytes.toBytes(toInternal(f4c2)));
         put.addColumn(
-                Bytes.toBytes(FAMILY4), Bytes.toBytes(F4COL3), Bytes.toBytes(timeToInternal(f4c3)));
+                Bytes.toBytes(FAMILY4),
+                Bytes.toBytes(F4COL3),
+                Bytes.toBytes(DateTimeUtils.toInternal(f4c3)));
         put.addColumn(Bytes.toBytes(FAMILY4), Bytes.toBytes(F4COL4), Bytes.toBytes(f4c4));
         return put;
     }

--- a/flink-connectors/flink-connector-hbase-2.2/src/test/java/org/apache/flink/connector/hbase2/util/HBaseTestBase.java
+++ b/flink-connectors/flink-connector-hbase-2.2/src/test/java/org/apache/flink/connector/hbase2/util/HBaseTestBase.java
@@ -19,6 +19,7 @@
 package org.apache.flink.connector.hbase2.util;
 
 import org.apache.flink.table.api.EnvironmentSettings;
+import org.apache.flink.table.utils.DateTimeUtils;
 
 import org.apache.hadoop.hbase.TableName;
 import org.apache.hadoop.hbase.client.Put;
@@ -35,9 +36,7 @@ import java.sql.Timestamp;
 import java.util.ArrayList;
 import java.util.List;
 
-import static org.apache.flink.table.utils.DateTimeUtils.dateToInternal;
-import static org.apache.flink.table.utils.DateTimeUtils.timeToInternal;
-import static org.apache.flink.table.utils.DateTimeUtils.timestampToInternal;
+import static org.apache.flink.table.utils.DateTimeUtils.toInternal;
 
 /** Abstract IT case class for HBase. */
 public abstract class HBaseTestBase extends HBaseTestingClusterAutoStarter {
@@ -263,11 +262,13 @@ public abstract class HBaseTestBase extends HBaseTestingClusterAutoStarter {
         put.addColumn(
                 Bytes.toBytes(FAMILY4),
                 Bytes.toBytes(F4COL1),
-                Bytes.toBytes(timestampToInternal(f4c1)));
+                Bytes.toBytes(DateTimeUtils.toInternal(f4c1)));
         put.addColumn(
-                Bytes.toBytes(FAMILY4), Bytes.toBytes(F4COL2), Bytes.toBytes(dateToInternal(f4c2)));
+                Bytes.toBytes(FAMILY4), Bytes.toBytes(F4COL2), Bytes.toBytes(toInternal(f4c2)));
         put.addColumn(
-                Bytes.toBytes(FAMILY4), Bytes.toBytes(F4COL3), Bytes.toBytes(timeToInternal(f4c3)));
+                Bytes.toBytes(FAMILY4),
+                Bytes.toBytes(F4COL3),
+                Bytes.toBytes(DateTimeUtils.toInternal(f4c3)));
         put.addColumn(Bytes.toBytes(FAMILY4), Bytes.toBytes(F4COL4), Bytes.toBytes(f4c4));
         return put;
     }

--- a/flink-connectors/flink-connector-hbase-2.2/src/test/java/org/apache/flink/connector/hbase2/util/HBaseTestBase.java
+++ b/flink-connectors/flink-connector-hbase-2.2/src/test/java/org/apache/flink/connector/hbase2/util/HBaseTestBase.java
@@ -19,7 +19,6 @@
 package org.apache.flink.connector.hbase2.util;
 
 import org.apache.flink.table.api.EnvironmentSettings;
-import org.apache.flink.table.utils.DateTimeUtils;
 
 import org.apache.hadoop.hbase.TableName;
 import org.apache.hadoop.hbase.client.Put;
@@ -260,15 +259,11 @@ public abstract class HBaseTestBase extends HBaseTestingClusterAutoStarter {
 
         // family 4
         put.addColumn(
-                Bytes.toBytes(FAMILY4),
-                Bytes.toBytes(F4COL1),
-                Bytes.toBytes(DateTimeUtils.toInternal(f4c1)));
+                Bytes.toBytes(FAMILY4), Bytes.toBytes(F4COL1), Bytes.toBytes(toInternal(f4c1)));
         put.addColumn(
                 Bytes.toBytes(FAMILY4), Bytes.toBytes(F4COL2), Bytes.toBytes(toInternal(f4c2)));
         put.addColumn(
-                Bytes.toBytes(FAMILY4),
-                Bytes.toBytes(F4COL3),
-                Bytes.toBytes(DateTimeUtils.toInternal(f4c3)));
+                Bytes.toBytes(FAMILY4), Bytes.toBytes(F4COL3), Bytes.toBytes(toInternal(f4c3)));
         put.addColumn(Bytes.toBytes(FAMILY4), Bytes.toBytes(F4COL4), Bytes.toBytes(f4c4));
         return put;
     }

--- a/flink-formats/flink-orc-nohive/src/main/java/org/apache/flink/orc/nohive/vector/AbstractOrcNoHiveVector.java
+++ b/flink-formats/flink-orc-nohive/src/main/java/org/apache/flink/orc/nohive/vector/AbstractOrcNoHiveVector.java
@@ -36,7 +36,7 @@ import java.sql.Timestamp;
 import java.time.LocalDate;
 import java.time.LocalDateTime;
 
-import static org.apache.flink.table.utils.DateTimeUtils.dateToInternal;
+import static org.apache.flink.table.utils.DateTimeUtils.toInternal;
 
 /** This column vector is used to adapt hive's ColumnVector to Flink's ColumnVector. */
 public abstract class AbstractOrcNoHiveVector
@@ -107,7 +107,7 @@ public abstract class AbstractOrcNoHiveVector
                 if (value instanceof LocalDate) {
                     value = Date.valueOf((LocalDate) value);
                 }
-                return createLongVector(batchSize, dateToInternal((Date) value));
+                return createLongVector(batchSize, toInternal((Date) value));
             case TIMESTAMP_WITHOUT_TIME_ZONE:
                 return createTimestampVector(batchSize, value);
             default:

--- a/flink-formats/flink-orc/src/main/java/org/apache/flink/orc/vector/AbstractOrcColumnVector.java
+++ b/flink-formats/flink-orc/src/main/java/org/apache/flink/orc/vector/AbstractOrcColumnVector.java
@@ -41,7 +41,7 @@ import java.nio.charset.StandardCharsets;
 import java.sql.Date;
 import java.time.LocalDate;
 
-import static org.apache.flink.table.utils.DateTimeUtils.dateToInternal;
+import static org.apache.flink.table.utils.DateTimeUtils.toInternal;
 
 /** This column vector is used to adapt hive's ColumnVector to Flink's ColumnVector. */
 public abstract class AbstractOrcColumnVector
@@ -122,7 +122,7 @@ public abstract class AbstractOrcColumnVector
                 if (value instanceof LocalDate) {
                     value = Date.valueOf((LocalDate) value);
                 }
-                return createLongVector(batchSize, dateToInternal((Date) value));
+                return createLongVector(batchSize, toInternal((Date) value));
             case TIMESTAMP_WITHOUT_TIME_ZONE:
                 return TimestampUtil.createVectorFromConstant(batchSize, value);
             default:

--- a/flink-formats/flink-orc/src/test/java/org/apache/flink/orc/OrcColumnarRowSplitReaderTest.java
+++ b/flink-formats/flink-orc/src/test/java/org/apache/flink/orc/OrcColumnarRowSplitReaderTest.java
@@ -54,7 +54,7 @@ import java.util.HashMap;
 import java.util.Map;
 import java.util.stream.IntStream;
 
-import static org.apache.flink.table.utils.DateTimeUtils.internalToDate;
+import static org.apache.flink.table.utils.DateTimeUtils.toSQLDate;
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertFalse;
 import static org.junit.Assert.assertNotNull;
@@ -359,7 +359,7 @@ public class OrcColumnarRowSplitReaderTest {
                 }
                 Assert.assertTrue(row.getBoolean(5));
                 Assert.assertEquals(
-                        new Date(562423).toString(), internalToDate(row.getInt(6)).toString());
+                        new Date(562423).toString(), toSQLDate(row.getInt(6)).toString());
 
                 Assert.assertEquals(
                         LocalDateTime.of(1999, 1, 1, 1, 1),

--- a/flink-formats/flink-parquet/src/main/java/org/apache/flink/formats/parquet/vector/ParquetSplitReaderUtil.java
+++ b/flink-formats/flink-parquet/src/main/java/org/apache/flink/formats/parquet/vector/ParquetSplitReaderUtil.java
@@ -70,7 +70,7 @@ import java.util.List;
 import java.util.Map;
 import java.util.stream.Collectors;
 
-import static org.apache.flink.table.utils.DateTimeUtils.dateToInternal;
+import static org.apache.flink.table.utils.DateTimeUtils.toInternal;
 import static org.apache.parquet.Preconditions.checkArgument;
 
 /** Util for generating {@link ParquetColumnarRowSplitReader}. */
@@ -243,9 +243,7 @@ public class ParquetSplitReaderUtil {
                     value = Date.valueOf((LocalDate) value);
                 }
                 return createVectorFromConstant(
-                        new IntType(),
-                        value == null ? null : dateToInternal((Date) value),
-                        batchSize);
+                        new IntType(), value == null ? null : toInternal((Date) value), batchSize);
             case TIMESTAMP_WITHOUT_TIME_ZONE:
                 HeapTimestampVector tv = new HeapTimestampVector(batchSize);
                 if (value == null) {

--- a/flink-formats/flink-parquet/src/test/java/org/apache/flink/formats/parquet/ParquetColumnarRowInputFormatTest.java
+++ b/flink-formats/flink-parquet/src/test/java/org/apache/flink/formats/parquet/ParquetColumnarRowInputFormatTest.java
@@ -618,7 +618,7 @@ public class ParquetColumnarRowInputFormatTest {
                         assertEquals(13, row.getFloat(8), 0);
                         assertEquals(6.6, row.getDouble(9), 0);
                         assertEquals(
-                                DateTimeUtils.dateToInternal(Date.valueOf("2020-11-23")),
+                                DateTimeUtils.toInternal(Date.valueOf("2020-11-23")),
                                 row.getInt(10));
                         assertEquals(
                                 LocalDateTime.of(1999, 1, 1, 1, 1),

--- a/flink-formats/flink-parquet/src/test/java/org/apache/flink/formats/parquet/vector/ParquetColumnarRowSplitReaderTest.java
+++ b/flink-formats/flink-parquet/src/test/java/org/apache/flink/formats/parquet/vector/ParquetColumnarRowSplitReaderTest.java
@@ -579,8 +579,7 @@ public class ParquetColumnarRowSplitReaderTest {
                 assertEquals(12, row.getLong(7));
                 assertEquals(13, row.getFloat(8), 0);
                 assertEquals(6.6, row.getDouble(9), 0);
-                assertEquals(
-                        DateTimeUtils.dateToInternal(Date.valueOf("2020-11-23")), row.getInt(10));
+                assertEquals(DateTimeUtils.toInternal(Date.valueOf("2020-11-23")), row.getInt(10));
                 assertEquals(
                         LocalDateTime.of(1999, 1, 1, 1, 1),
                         row.getTimestamp(11, 9).toLocalDateTime());

--- a/flink-python/src/main/java/org/apache/flink/table/runtime/typeutils/PythonTypeUtils.java
+++ b/flink-python/src/main/java/org/apache/flink/table/runtime/typeutils/PythonTypeUtils.java
@@ -56,7 +56,6 @@ import org.apache.flink.table.types.logical.TinyIntType;
 import org.apache.flink.table.types.logical.VarBinaryType;
 import org.apache.flink.table.types.logical.VarCharType;
 import org.apache.flink.table.types.logical.utils.LogicalTypeDefaultVisitor;
-import org.apache.flink.table.utils.DateTimeUtils;
 
 import java.math.BigDecimal;
 import java.math.RoundingMode;
@@ -101,40 +100,6 @@ public final class PythonTypeUtils {
             }
         }
         return bigDecimal;
-    }
-
-    /**
-     * Converts the internal representation of a SQL DATE (int) to the Java type used for UDF
-     * parameters ({@link java.sql.Date}).
-     *
-     * <p>Note: The implementation refers to {@link DateTimeUtils#internalToDate}.
-     */
-    public static java.sql.Date internalToDate(int v) {
-        // note that, in this case, can't handle Daylight Saving Time
-        final long t = v * MILLIS_PER_DAY;
-        return new java.sql.Date(t - LOCAL_TZ.getOffset(t));
-    }
-
-    /**
-     * Converts the Java type used for UDF parameters of SQL DATE type ({@link java.sql.Date}) to
-     * internal representation (int).
-     *
-     * <p>Note: The implementation refers to {@link DateTimeUtils#dateToInternal}.
-     */
-    public static int dateToInternal(java.sql.Date date) {
-        long ts = date.getTime() + LOCAL_TZ.getOffset(date.getTime());
-        return (int) (ts / MILLIS_PER_DAY);
-    }
-
-    /**
-     * Converts the Java type used for UDF parameters of SQL TIMESTAMP type ({@link
-     * java.sql.Timestamp}) to internal representation (long).
-     *
-     * <p>Note: The implementation refers to {@link DateTimeUtils#timestampToInternal}.
-     */
-    public static long timestampToInternal(java.sql.Timestamp ts) {
-        long time = ts.getTime();
-        return time + LOCAL_TZ.getOffset(time);
     }
 
     private static class LogicalTypetoInternalSerializerConverter

--- a/flink-python/src/main/java/org/apache/flink/table/runtime/typeutils/serializers/python/DateSerializer.java
+++ b/flink-python/src/main/java/org/apache/flink/table/runtime/typeutils/serializers/python/DateSerializer.java
@@ -24,7 +24,9 @@ import org.apache.flink.api.common.typeutils.TypeSerializerSnapshot;
 import org.apache.flink.api.common.typeutils.base.TypeSerializerSingleton;
 import org.apache.flink.core.memory.DataInputView;
 import org.apache.flink.core.memory.DataOutputView;
-import org.apache.flink.table.runtime.typeutils.PythonTypeUtils;
+import org.apache.flink.table.api.DataTypes;
+import org.apache.flink.table.data.conversion.DataStructureConverter;
+import org.apache.flink.table.data.conversion.DataStructureConverters;
 
 import java.io.IOException;
 import java.sql.Date;
@@ -38,6 +40,11 @@ public class DateSerializer extends TypeSerializerSingleton<Date> {
     private static final long serialVersionUID = 1L;
 
     public static final DateSerializer INSTANCE = new DateSerializer();
+
+    @SuppressWarnings({"unchecked", "rawtypes"})
+    private static final DataStructureConverter<Integer, Date> converter =
+            (DataStructureConverter)
+                    DataStructureConverters.getConverter(DataTypes.DATE().bridgedTo(Date.class));
 
     @Override
     public boolean isImmutableType() {
@@ -76,12 +83,12 @@ public class DateSerializer extends TypeSerializerSingleton<Date> {
         if (record == null) {
             throw new IllegalArgumentException("The Date record must not be null.");
         }
-        target.writeInt(PythonTypeUtils.dateToInternal(record));
+        target.writeInt(converter.toInternal(record));
     }
 
     @Override
     public Date deserialize(DataInputView source) throws IOException {
-        return PythonTypeUtils.internalToDate(source.readInt());
+        return converter.toExternalOrNull(source.readInt());
     }
 
     @Override

--- a/flink-python/src/main/java/org/apache/flink/table/runtime/typeutils/serializers/python/DateSerializer.java
+++ b/flink-python/src/main/java/org/apache/flink/table/runtime/typeutils/serializers/python/DateSerializer.java
@@ -24,9 +24,7 @@ import org.apache.flink.api.common.typeutils.TypeSerializerSnapshot;
 import org.apache.flink.api.common.typeutils.base.TypeSerializerSingleton;
 import org.apache.flink.core.memory.DataInputView;
 import org.apache.flink.core.memory.DataOutputView;
-import org.apache.flink.table.api.DataTypes;
-import org.apache.flink.table.data.conversion.DataStructureConverter;
-import org.apache.flink.table.data.conversion.DataStructureConverters;
+import org.apache.flink.table.utils.DateTimeUtils;
 
 import java.io.IOException;
 import java.sql.Date;
@@ -40,11 +38,6 @@ public class DateSerializer extends TypeSerializerSingleton<Date> {
     private static final long serialVersionUID = 1L;
 
     public static final DateSerializer INSTANCE = new DateSerializer();
-
-    @SuppressWarnings({"unchecked", "rawtypes"})
-    private static final DataStructureConverter<Integer, Date> converter =
-            (DataStructureConverter)
-                    DataStructureConverters.getConverter(DataTypes.DATE().bridgedTo(Date.class));
 
     @Override
     public boolean isImmutableType() {
@@ -83,12 +76,12 @@ public class DateSerializer extends TypeSerializerSingleton<Date> {
         if (record == null) {
             throw new IllegalArgumentException("The Date record must not be null.");
         }
-        target.writeInt(converter.toInternal(record));
+        target.writeInt(DateTimeUtils.toInternal(record));
     }
 
     @Override
     public Date deserialize(DataInputView source) throws IOException {
-        return converter.toExternalOrNull(source.readInt());
+        return DateTimeUtils.toSQLDate(source.readInt());
     }
 
     @Override

--- a/flink-table/flink-table-common/src/main/java/org/apache/flink/table/utils/DateTimeUtils.java
+++ b/flink-table/flink-table-common/src/main/java/org/apache/flink/table/utils/DateTimeUtils.java
@@ -68,7 +68,7 @@ public class DateTimeUtils {
     private static final Logger LOG = LoggerFactory.getLogger(DateTimeUtils.class);
 
     /** The julian date of the epoch, 1970-01-01. */
-    private static final int EPOCH_JULIAN = 2440588;
+    public static final int EPOCH_JULIAN = 2440588;
 
     /** The number of milliseconds in a second. */
     private static final long MILLIS_PER_SECOND = 1000L;
@@ -726,26 +726,12 @@ public class DateTimeUtils {
         return formatTimestamp(timestampWithLocalZoneToTimestamp(ts, tz), precision);
     }
 
-    /**
-     * Format a timestamp as specific.
-     *
-     * @param ts the {@link TimestampData} to format.
-     * @param format the string formatter.
-     * @param zoneId the ZoneId.
-     */
     private static String formatTimestamp(TimestampData ts, String format, ZoneId zoneId) {
         DateTimeFormatter formatter = DATETIME_FORMATTER_CACHE.get(format);
         Instant instant = ts.toInstant();
         return LocalDateTime.ofInstant(instant, zoneId).format(formatter);
     }
 
-    /**
-     * Format a timestamp as specific.
-     *
-     * @param ts the timestamp to format.
-     * @param format the string formatter.
-     * @param tz the time zone
-     */
     public static String formatTimestampMillis(long ts, String format, TimeZone tz) {
         SimpleDateFormat formatter = FORMATTER_CACHE.get(format);
         formatter.setTimeZone(tz);
@@ -753,14 +739,6 @@ public class DateTimeUtils {
         return formatter.format(dateTime);
     }
 
-    /**
-     * Format a string datetime as specific.
-     *
-     * @param dateStr the string datetime.
-     * @param fromFormat the original date format.
-     * @param toFormat the target date format.
-     * @param tz the time zone.
-     */
     public static String formatTimestampString(
             String dateStr, String fromFormat, String toFormat, TimeZone tz) {
         SimpleDateFormat fromFormatter = FORMATTER_CACHE.get(fromFormat);
@@ -1365,13 +1343,13 @@ public class DateTimeUtils {
      */
     public static String convertTz(String dateStr, String tzFrom, String tzTo) {
         try {
-            return dateFormatTz(parseTimestampTz(dateStr, tzFrom), tzTo);
+            return formatTimestampTz(parseTimestampTz(dateStr, tzFrom), tzTo);
         } catch (ParseException e) {
             return null;
         }
     }
 
-    private static String dateFormatTz(long ts, String tzStr) {
+    private static String formatTimestampTz(long ts, String tzStr) {
         TimeZone tz = TIMEZONE_CACHE.get(tzStr);
         return formatTimestampMillis(ts, DateTimeUtils.TIMESTAMP_FORMAT_STRING, tz);
     }

--- a/flink-table/flink-table-common/src/main/java/org/apache/flink/table/utils/DateTimeUtils.java
+++ b/flink-table/flink-table-common/src/main/java/org/apache/flink/table/utils/DateTimeUtils.java
@@ -59,8 +59,25 @@ import static java.time.temporal.ChronoField.SECOND_OF_MINUTE;
 import static java.time.temporal.ChronoField.YEAR;
 
 /**
- * Utility functions for datetime types: date, time, timestamp. Currently, it is a bit messy putting
- * date time functions in various classes because the runtime module does not depend on calcite..
+ * Utility functions for datetime types: date, time, timestamp.
+ *
+ * <p>These utils include:
+ *
+ * <ul>
+ *   <li>{@code parse[type]}: methods for parsing strings to date/time/timestamp
+ *   <li>{@code format[type]}: methods for formatting date/time/timestamp
+ *   <li>{@code to[externalTypeName]} and {@code toInternal}: methods for converting values from
+ *       internal date/time/timestamp types from/to java.sql or java.time types
+ *   <li>Various operations on timestamp, including floor, ceil and extract
+ *   <li>{@link TimeUnit} and {@link TimeUnitRange} enums
+ * </ul>
+ *
+ * Currently, this class is a bit messy because it includes a mix of functionalities both from
+ * common and planner. We should strive to reduce the number of functionalities here, eventually
+ * moving some methods closer to where they're needed. Connectors and formats should not use this
+ * class, but rather if a functionality is necessary, it should be part of the public APIs of our
+ * type system (e.g a new method in {@link TimestampData} or in {@link TimestampType}). Methods used
+ * only by the planner should live inside the planner whenever is possible.
  */
 @Internal
 public class DateTimeUtils {

--- a/flink-table/flink-table-common/src/main/java/org/apache/flink/table/utils/DateTimeUtils.java
+++ b/flink-table/flink-table-common/src/main/java/org/apache/flink/table/utils/DateTimeUtils.java
@@ -72,7 +72,7 @@ import static java.time.temporal.ChronoField.YEAR;
  *   <li>{@link TimeUnit} and {@link TimeUnitRange} enums
  * </ul>
  *
- * Currently, this class is a bit messy because it includes a mix of functionalities both from
+ * <p>Currently, this class is a bit messy because it includes a mix of functionalities both from
  * common and planner. We should strive to reduce the number of functionalities here, eventually
  * moving some methods closer to where they're needed. Connectors and formats should not use this
  * class, but rather if a functionality is necessary, it should be part of the public APIs of our

--- a/flink-table/flink-table-common/src/main/java/org/apache/flink/table/utils/DateTimeUtils.java
+++ b/flink-table/flink-table-common/src/main/java/org/apache/flink/table/utils/DateTimeUtils.java
@@ -42,7 +42,6 @@ import java.time.ZoneId;
 import java.time.ZonedDateTime;
 import java.time.format.DateTimeFormatter;
 import java.time.format.DateTimeParseException;
-import java.time.temporal.ChronoUnit;
 import java.time.temporal.TemporalAccessor;
 import java.util.Collections;
 import java.util.Date;
@@ -69,7 +68,7 @@ public class DateTimeUtils {
     private static final Logger LOG = LoggerFactory.getLogger(DateTimeUtils.class);
 
     /** The julian date of the epoch, 1970-01-01. */
-    public static final int EPOCH_JULIAN = 2440588;
+    private static final int EPOCH_JULIAN = 2440588;
 
     /** The number of milliseconds in a second. */
     private static final long MILLIS_PER_SECOND = 1000L;
@@ -101,7 +100,7 @@ public class DateTimeUtils {
     public static final TimeZone UTC_ZONE = TimeZone.getTimeZone("UTC");
 
     /** The local time zone. */
-    private static final TimeZone LOCAL_TZ = TimeZone.getDefault();
+    public static final TimeZone LOCAL_TZ = TimeZone.getDefault();
 
     /** The valid minimum epoch milliseconds ('0000-01-01 00:00:00.000 UTC+0'). */
     private static final long MIN_EPOCH_MILLS = -62167219200000L;
@@ -160,14 +159,14 @@ public class DateTimeUtils {
             };
 
     // --------------------------------------------------------------------------------------------
-    // Date/Time/Timestamp --> internal int/int/long conversion
+    // java.sql Date/Time/Timestamp --> internal data types
     // --------------------------------------------------------------------------------------------
 
     /**
      * Converts the internal representation of a SQL DATE (int) to the Java type used for UDF
      * parameters ({@link java.sql.Date}).
      */
-    public static java.sql.Date internalToDate(int v) {
+    public static java.sql.Date toSQLDate(int v) {
         // note that, in this case, can't handle Daylight Saving Time
         final long t = v * MILLIS_PER_DAY;
         return new java.sql.Date(t - LOCAL_TZ.getOffset(t));
@@ -177,7 +176,7 @@ public class DateTimeUtils {
      * Converts the internal representation of a SQL TIME (int) to the Java type used for UDF
      * parameters ({@link java.sql.Time}).
      */
-    public static java.sql.Time internalToTime(int v) {
+    public static java.sql.Time toSQLTime(int v) {
         // note that, in this case, can't handle Daylight Saving Time
         return new java.sql.Time(v - LOCAL_TZ.getOffset(v));
     }
@@ -186,7 +185,7 @@ public class DateTimeUtils {
      * Converts the internal representation of a SQL TIMESTAMP (long) to the Java type used for UDF
      * parameters ({@link java.sql.Timestamp}).
      */
-    public static java.sql.Timestamp internalToTimestamp(long v) {
+    public static java.sql.Timestamp toSQLTimestamp(long v) {
         return new java.sql.Timestamp(v - LOCAL_TZ.getOffset(v));
     }
 
@@ -194,9 +193,9 @@ public class DateTimeUtils {
      * Converts the Java type used for UDF parameters of SQL DATE type ({@link java.sql.Date}) to
      * internal representation (int).
      *
-     * <p>Converse of {@link #internalToDate(int)}.
+     * <p>Converse of {@link #toSQLDate(int)}.
      */
-    public static int dateToInternal(java.sql.Date date) {
+    public static int toInternal(java.sql.Date date) {
         long ts = date.getTime() + LOCAL_TZ.getOffset(date.getTime());
         return (int) (ts / MILLIS_PER_DAY);
     }
@@ -205,9 +204,9 @@ public class DateTimeUtils {
      * Converts the Java type used for UDF parameters of SQL TIME type ({@link java.sql.Time}) to
      * internal representation (int).
      *
-     * <p>Converse of {@link #internalToTime(int)}.
+     * <p>Converse of {@link #toSQLTime(int)}.
      */
-    public static int timeToInternal(java.sql.Time time) {
+    public static int toInternal(java.sql.Time time) {
         long ts = time.getTime() + LOCAL_TZ.getOffset(time.getTime());
         return (int) (ts % MILLIS_PER_DAY);
     }
@@ -216,36 +215,117 @@ public class DateTimeUtils {
      * Converts the Java type used for UDF parameters of SQL TIMESTAMP type ({@link
      * java.sql.Timestamp}) to internal representation (long).
      *
-     * <p>Converse of {@link #internalToTimestamp(long)}.
+     * <p>Converse of {@link #toSQLTimestamp(long)}.
      */
-    public static long timestampToInternal(java.sql.Timestamp ts) {
+    public static long toInternal(java.sql.Timestamp ts) {
         long time = ts.getTime();
         return time + LOCAL_TZ.getOffset(time);
     }
 
     // --------------------------------------------------------------------------------------------
-    // int/long/double/DecimalData --> Date/Timestamp internal representation
+    // Java 8 time conversion
     // --------------------------------------------------------------------------------------------
 
-    public static int toDate(int v) {
-        return v;
+    public static LocalDate toLocalDate(int date) {
+        return julianToLocalDate(date + EPOCH_JULIAN);
     }
 
-    public static long toTimestamp(long v) {
-        return v;
+    private static LocalDate julianToLocalDate(int julian) {
+        // this shifts the epoch back to astronomical year -4800 instead of the
+        // start of the Christian era in year AD 1 of the proleptic Gregorian
+        // calendar.
+        int j = julian + 32044;
+        int g = j / 146097;
+        int dg = j % 146097;
+        int c = (dg / 36524 + 1) * 3 / 4;
+        int dc = dg - c * 36524;
+        int b = dc / 1461;
+        int db = dc % 1461;
+        int a = (db / 365 + 1) * 3 / 4;
+        int da = db - a * 365;
+
+        // integer number of full years elapsed since March 1, 4801 BC
+        int y = g * 400 + c * 100 + b * 4 + a;
+        // integer number of full months elapsed since the last March 1
+        int m = (da * 5 + 308) / 153 - 2;
+        // number of days elapsed since day 1 of the month
+        int d = da - (m + 4) * 153 / 5 + 122;
+        int year = y - 4800 + (m + 2) / 12;
+        int month = (m + 2) % 12 + 1;
+        int day = d + 1;
+        return LocalDate.of(year, month, day);
     }
 
-    public static long toTimestamp(double v) {
-        return (long) v;
+    public static int toInternal(LocalDate date) {
+        return ymdToUnixDate(date.getYear(), date.getMonthValue(), date.getDayOfMonth());
     }
 
-    public static long toTimestamp(DecimalData v) {
-        return v.toBigDecimal().setScale(0, RoundingMode.DOWN).longValue();
+    private static int ymdToUnixDate(int year, int month, int day) {
+        final int julian = ymdToJulian(year, month, day);
+        return julian - EPOCH_JULIAN;
+    }
+
+    private static int ymdToJulian(int year, int month, int day) {
+        int a = (14 - month) / 12;
+        int y = year + 4800 - a;
+        int m = month + 12 * a - 3;
+        return day + (153 * m + 2) / 5 + 365 * y + y / 4 - y / 100 + y / 400 - 32045;
+    }
+
+    public static LocalTime toLocalTime(int time) {
+        int h = time / 3600000;
+        int time2 = time % 3600000;
+        int m = time2 / 60000;
+        int time3 = time2 % 60000;
+        int s = time3 / 1000;
+        int ms = time3 % 1000;
+        return LocalTime.of(h, m, s, ms * 1000_000);
+    }
+
+    public static int toInternal(LocalTime time) {
+        return time.getHour() * (int) MILLIS_PER_HOUR
+                + time.getMinute() * (int) MILLIS_PER_MINUTE
+                + time.getSecond() * (int) MILLIS_PER_SECOND
+                + time.getNano() / 1000_000;
+    }
+
+    public static LocalDateTime toLocalDateTime(long timestamp) {
+        int date = (int) (timestamp / MILLIS_PER_DAY);
+        int time = (int) (timestamp % MILLIS_PER_DAY);
+        if (time < 0) {
+            --date;
+            time += MILLIS_PER_DAY;
+        }
+        LocalDate localDate = toLocalDate(date);
+        LocalTime localTime = toLocalTime(time);
+        return LocalDateTime.of(localDate, localTime);
+    }
+
+    public static long toTimestampMillis(LocalDateTime dateTime) {
+        return unixTimestamp(
+                dateTime.getYear(),
+                dateTime.getMonthValue(),
+                dateTime.getDayOfMonth(),
+                dateTime.getHour(),
+                dateTime.getMinute(),
+                dateTime.getSecond(),
+                dateTime.getNano() / 1000_000);
+    }
+
+    private static long unixTimestamp(
+            int year, int month, int day, int hour, int minute, int second, int mills) {
+        final int date = ymdToUnixDate(year, month, day);
+        return (long) date * MILLIS_PER_DAY
+                + (long) hour * MILLIS_PER_HOUR
+                + (long) minute * MILLIS_PER_MINUTE
+                + (long) second * MILLIS_PER_SECOND
+                + mills;
     }
 
     // --------------------------------------------------------------------------------------------
-    // TO_TIMESTAMP_LTZ(numeric, precision) function supports precision 0 or 3.
+    // Numeric -> Timestamp conversion
     // --------------------------------------------------------------------------------------------
+
     public static TimestampData toTimestampData(long v, int precision) {
         switch (precision) {
             case 0:
@@ -295,7 +375,7 @@ public class DateTimeUtils {
                                 * MILLIS_PER_SECOND;
                 return timestampDataFromEpochMills(epochMills);
             case 3:
-                epochMills = toTimestamp(v);
+                epochMills = toMillis(v);
                 return timestampDataFromEpochMills(epochMills);
             default:
                 throw new TableException(
@@ -314,11 +394,15 @@ public class DateTimeUtils {
         return null;
     }
 
+    private static long toMillis(DecimalData v) {
+        return v.toBigDecimal().setScale(0, RoundingMode.DOWN).longValue();
+    }
+
     // --------------------------------------------------------------------------------------------
-    // String --> Timestamp conversion
+    // Parsing functions
     // --------------------------------------------------------------------------------------------
 
-    public static TimestampData toTimestampData(String dateStr) {
+    public static TimestampData parseTimestampData(String dateStr) {
         int length = dateStr.length();
         String format;
         if (length == 10) {
@@ -329,10 +413,10 @@ public class DateTimeUtils {
             // otherwise fall back to second's precision
             format = DEFAULT_DATETIME_FORMATS[0];
         }
-        return toTimestampData(dateStr, format);
+        return parseTimestampData(dateStr, format);
     }
 
-    public static TimestampData toTimestampData(String dateStr, String format) {
+    public static TimestampData parseTimestampData(String dateStr, String format) {
         DateTimeFormatter formatter = DATETIME_FORMATTER_CACHE.get(format);
 
         try {
@@ -375,10 +459,6 @@ public class DateTimeUtils {
         }
     }
 
-    public static Long toTimestamp(String dateStr) {
-        return toTimestamp(dateStr, UTC_ZONE);
-    }
-
     /**
      * Parse date time string to timestamp based on the given time zone and "yyyy-MM-dd HH:mm:ss"
      * format. Returns null if parsing failed.
@@ -386,7 +466,7 @@ public class DateTimeUtils {
      * @param dateStr the date time string
      * @param tz the time zone
      */
-    public static Long toTimestamp(String dateStr, TimeZone tz) {
+    public static long parseTimestampMillis(String dateStr, TimeZone tz) throws ParseException {
         int length = dateStr.length();
         String format;
         if (length == 10) {
@@ -401,7 +481,7 @@ public class DateTimeUtils {
             // otherwise fall back to the default
             format = DEFAULT_DATETIME_FORMATS[0];
         }
-        return toTimestamp(dateStr, format, tz);
+        return parseTimestampMillis(dateStr, format, tz);
     }
 
     /**
@@ -412,18 +492,11 @@ public class DateTimeUtils {
      * @param format date time string format
      * @param tz the time zone
      */
-    private static Long toTimestamp(String dateStr, String format, TimeZone tz) {
+    private static long parseTimestampMillis(String dateStr, String format, TimeZone tz)
+            throws ParseException {
         SimpleDateFormat formatter = FORMATTER_CACHE.get(format);
         formatter.setTimeZone(tz);
-        try {
-            return formatter.parse(dateStr).getTime();
-        } catch (ParseException e) {
-            return null;
-        }
-    }
-
-    public static Long toTimestamp(String dateStr, String format) {
-        return toTimestamp(dateStr, format, UTC_ZONE);
+        return formatter.parse(dateStr).getTime();
     }
 
     /**
@@ -431,37 +504,227 @@ public class DateTimeUtils {
      * null if parsing failed.
      *
      * @param dateStr the date time string
-     * @param format the date time string format
      * @param tzStr the time zone id string
      */
-    public static Long toTimestampTz(String dateStr, String format, String tzStr) {
+    private static long parseTimestampTz(String dateStr, String tzStr) throws ParseException {
         TimeZone tz = TIMEZONE_CACHE.get(tzStr);
-        return toTimestamp(dateStr, format, tz);
+        return parseTimestampMillis(dateStr, DateTimeUtils.TIMESTAMP_FORMAT_STRING, tz);
     }
-
-    public static Long toTimestampTz(String dateStr, String tzStr) {
-        // use "yyyy-MM-dd HH:mm:ss" as default format
-        return toTimestampTz(dateStr, TIMESTAMP_FORMAT_STRING, tzStr);
-    }
-
-    // --------------------------------------------------------------------------------------------
-    // String --> Date conversion
-    // --------------------------------------------------------------------------------------------
 
     /** Returns the epoch days since 1970-01-01. */
-    public static int strToDate(String dateStr, String fromFormat) {
+    public static int parseDate(String dateStr, String fromFormat) {
         // It is OK to use UTC, we just want get the epoch days
         // TODO  use offset, better performance
-        long ts = parseToTimeMillis(dateStr, fromFormat, TimeZone.getTimeZone("UTC"));
+        long ts = internalParseTimestampMillis(dateStr, fromFormat, TimeZone.getTimeZone("UTC"));
         ZoneId zoneId = ZoneId.of("UTC");
         Instant instant = Instant.ofEpochMilli(ts);
         ZonedDateTime zdt = ZonedDateTime.ofInstant(instant, zoneId);
         return ymdToUnixDate(zdt.getYear(), zdt.getMonthValue(), zdt.getDayOfMonth());
     }
 
+    public static Integer parseDate(String s) {
+        // allow timestamp str to date, e.g. 2017-12-12 09:30:00.0
+        int ws1 = s.indexOf(" ");
+        if (ws1 > 0) {
+            s = s.substring(0, ws1);
+        }
+        int hyphen1 = s.indexOf('-');
+        int y;
+        int m;
+        int d;
+        if (hyphen1 < 0) {
+            if (!isInteger(s.trim())) {
+                return null;
+            }
+            y = Integer.parseInt(s.trim());
+            m = 1;
+            d = 1;
+        } else {
+            if (!isInteger(s.substring(0, hyphen1).trim())) {
+                return null;
+            }
+            y = Integer.parseInt(s.substring(0, hyphen1).trim());
+            final int hyphen2 = s.indexOf('-', hyphen1 + 1);
+            if (hyphen2 < 0) {
+                if (!isInteger(s.substring(hyphen1 + 1).trim())) {
+                    return null;
+                }
+                m = Integer.parseInt(s.substring(hyphen1 + 1).trim());
+                d = 1;
+            } else {
+                if (!isInteger(s.substring(hyphen1 + 1, hyphen2).trim())) {
+                    return null;
+                }
+                m = Integer.parseInt(s.substring(hyphen1 + 1, hyphen2).trim());
+                if (!isInteger(s.substring(hyphen2 + 1).trim())) {
+                    return null;
+                }
+                d = Integer.parseInt(s.substring(hyphen2 + 1).trim());
+            }
+        }
+        if (!isIllegalDate(y, m, d)) {
+            return null;
+        }
+        return ymdToUnixDate(y, m, d);
+    }
+
+    public static Integer parseTime(String v) {
+        final int start = 0;
+        final int colon1 = v.indexOf(':', start);
+        // timezone hh:mm:ss[.ssssss][[+|-]hh:mm:ss]
+        // refer https://www.w3.org/TR/NOTE-datetime
+        int timezoneHour;
+        int timezoneMinute;
+        int hour;
+        int minute;
+        int second;
+        int milli;
+        int operator = -1;
+        int end = v.length();
+        int timezone = v.indexOf('-', start);
+        if (timezone < 0) {
+            timezone = v.indexOf('+', start);
+            operator = 1;
+        }
+        if (timezone < 0) {
+            timezoneHour = 0;
+            timezoneMinute = 0;
+        } else {
+            end = timezone;
+            final int colon3 = v.indexOf(':', timezone);
+            if (colon3 < 0) {
+                if (!isInteger(v.substring(timezone + 1).trim())) {
+                    return null;
+                }
+                timezoneHour = Integer.parseInt(v.substring(timezone + 1).trim());
+                timezoneMinute = 0;
+            } else {
+                if (!isInteger(v.substring(timezone + 1, colon3).trim())) {
+                    return null;
+                }
+                timezoneHour = Integer.parseInt(v.substring(timezone + 1, colon3).trim());
+                if (!isInteger(v.substring(colon3 + 1).trim())) {
+                    return null;
+                }
+                timezoneMinute = Integer.parseInt(v.substring(colon3 + 1).trim());
+            }
+        }
+        if (colon1 < 0) {
+            if (!isInteger(v.substring(start, end).trim())) {
+                return null;
+            }
+            hour = Integer.parseInt(v.substring(start, end).trim());
+            minute = 0;
+            second = 0;
+            milli = 0;
+        } else {
+            if (!isInteger(v.substring(start, colon1).trim())) {
+                return null;
+            }
+            hour = Integer.parseInt(v.substring(start, colon1).trim());
+            final int colon2 = v.indexOf(':', colon1 + 1);
+            if (colon2 < 0) {
+                if (!isInteger(v.substring(colon1 + 1, end).trim())) {
+                    return null;
+                }
+                minute = Integer.parseInt(v.substring(colon1 + 1, end).trim());
+                second = 0;
+                milli = 0;
+            } else {
+                if (!isInteger(v.substring(colon1 + 1, colon2).trim())) {
+                    return null;
+                }
+                minute = Integer.parseInt(v.substring(colon1 + 1, colon2).trim());
+                int dot = v.indexOf('.', colon2);
+                if (dot < 0) {
+                    if (!isInteger(v.substring(colon2 + 1, end).trim())) {
+                        return null;
+                    }
+                    second = Integer.parseInt(v.substring(colon2 + 1, end).trim());
+                    milli = 0;
+                } else {
+                    if (!isInteger(v.substring(colon2 + 1, dot).trim())) {
+                        return null;
+                    }
+                    second = Integer.parseInt(v.substring(colon2 + 1, dot).trim());
+                    milli = parseFraction(v.substring(dot + 1, end).trim());
+                }
+            }
+        }
+        hour += operator * timezoneHour;
+        minute += operator * timezoneMinute;
+        return hour * (int) MILLIS_PER_HOUR
+                + minute * (int) MILLIS_PER_MINUTE
+                + second * (int) MILLIS_PER_SECOND
+                + milli;
+    }
+
+    /**
+     * Parses a fraction, multiplying the first character by {@code multiplier}, the second
+     * character by {@code multiplier / 10}, the third character by {@code multiplier / 100}, and so
+     * forth.
+     *
+     * <p>For example, {@code parseFraction("1234", 100)} yields {@code 123}.
+     */
+    private static int parseFraction(String v) {
+        int multiplier = 100;
+        int r = 0;
+        for (int i = 0; i < v.length(); i++) {
+            char c = v.charAt(i);
+            int x = c < '0' || c > '9' ? 0 : (c - '0');
+            r += multiplier * x;
+            if (multiplier < 10) {
+                // We're at the last digit. Check for rounding.
+                if (i + 1 < v.length() && v.charAt(i + 1) >= '5') {
+                    ++r;
+                }
+                break;
+            }
+            multiplier /= 10;
+        }
+        return r;
+    }
+
     // --------------------------------------------------------------------------------------------
-    // DATE_FORMAT
+    // Format
     // --------------------------------------------------------------------------------------------
+
+    public static String formatTimestamp(TimestampData ts, String format) {
+        return formatTimestamp(ts, format, ZoneId.of("UTC"));
+    }
+
+    public static String formatTimestamp(TimestampData ts, String format, TimeZone zone) {
+        return formatTimestamp(ts, format, zone.toZoneId());
+    }
+
+    private static String formatTimestamp(TimestampData ts, int precision) {
+        LocalDateTime ldt = ts.toLocalDateTime();
+
+        String fraction = pad(9, ldt.getNano());
+        while (fraction.length() > precision && fraction.endsWith("0")) {
+            fraction = fraction.substring(0, fraction.length() - 1);
+        }
+
+        StringBuilder ymdhms =
+                ymdhms(
+                        new StringBuilder(),
+                        ldt.getYear(),
+                        ldt.getMonthValue(),
+                        ldt.getDayOfMonth(),
+                        ldt.getHour(),
+                        ldt.getMinute(),
+                        ldt.getSecond());
+
+        if (fraction.length() > 0) {
+            ymdhms.append(".").append(fraction);
+        }
+
+        return ymdhms.toString();
+    }
+
+    public static String formatTimestamp(TimestampData ts, TimeZone tz, int precision) {
+        return formatTimestamp(timestampWithLocalZoneToTimestamp(ts, tz), precision);
+    }
 
     /**
      * Format a timestamp as specific.
@@ -470,18 +733,10 @@ public class DateTimeUtils {
      * @param format the string formatter.
      * @param zoneId the ZoneId.
      */
-    public static String dateFormat(TimestampData ts, String format, ZoneId zoneId) {
+    private static String formatTimestamp(TimestampData ts, String format, ZoneId zoneId) {
         DateTimeFormatter formatter = DATETIME_FORMATTER_CACHE.get(format);
         Instant instant = ts.toInstant();
         return LocalDateTime.ofInstant(instant, zoneId).format(formatter);
-    }
-
-    public static String dateFormat(TimestampData ts, String format) {
-        return dateFormat(ts, format, ZoneId.of("UTC"));
-    }
-
-    public static String dateFormat(TimestampData ts, String format, TimeZone zone) {
-        return dateFormat(ts, format, zone.toZoneId());
     }
 
     /**
@@ -491,7 +746,7 @@ public class DateTimeUtils {
      * @param format the string formatter.
      * @param tz the time zone
      */
-    public static String dateFormat(long ts, String format, TimeZone tz) {
+    public static String formatTimestampMillis(long ts, String format, TimeZone tz) {
         SimpleDateFormat formatter = FORMATTER_CACHE.get(format);
         formatter.setTimeZone(tz);
         Date dateTime = new Date(ts);
@@ -506,7 +761,7 @@ public class DateTimeUtils {
      * @param toFormat the target date format.
      * @param tz the time zone.
      */
-    public static String dateFormat(
+    public static String formatTimestampString(
             String dateStr, String fromFormat, String toFormat, TimeZone tz) {
         SimpleDateFormat fromFormatter = FORMATTER_CACHE.get(fromFormat);
         fromFormatter.setTimeZone(tz);
@@ -528,87 +783,22 @@ public class DateTimeUtils {
         }
     }
 
-    public static String dateFormat(String dateStr, String toFormat, TimeZone tz) {
+    public static String formatTimestampString(String dateStr, String toFormat, TimeZone tz) {
         // use yyyy-MM-dd HH:mm:ss as default
-        return dateFormat(dateStr, TIMESTAMP_FORMAT_STRING, toFormat, tz);
+        return formatTimestampString(dateStr, TIMESTAMP_FORMAT_STRING, toFormat, tz);
     }
 
-    public static String dateFormat(long ts, String format) {
-        return dateFormat(ts, format, UTC_ZONE);
+    public static String formatTimestampString(String dateStr, String toFormat) {
+        return formatTimestampString(dateStr, toFormat, UTC_ZONE);
     }
 
-    public static String dateFormat(String dateStr, String fromFormat, String toFormat) {
-        return dateFormat(dateStr, fromFormat, toFormat, UTC_ZONE);
-    }
-
-    public static String dateFormat(String dateStr, String toFormat) {
-        return dateFormat(dateStr, toFormat, UTC_ZONE);
-    }
-
-    public static String dateFormatTz(long ts, String format, String tzStr) {
-        TimeZone tz = TIMEZONE_CACHE.get(tzStr);
-        return dateFormat(ts, format, tz);
-    }
-
-    public static String dateFormatTz(long ts, String tzStr) {
-        // use yyyy-MM-dd HH:mm:ss as default
-        return dateFormatTz(ts, TIMESTAMP_FORMAT_STRING, tzStr);
-    }
-
-    /**
-     * Convert datetime string from a time zone to another time zone.
-     *
-     * @param dateStr the date time string
-     * @param format the date time format
-     * @param tzFrom the original time zone
-     * @param tzTo the target time zone
-     */
-    public static String convertTz(String dateStr, String format, String tzFrom, String tzTo) {
-        Long ts = toTimestampTz(dateStr, format, tzFrom);
-        if (null != ts) { // avoid NPE
-            return dateFormatTz(ts, tzTo);
-        }
-        return null;
-    }
-
-    public static String convertTz(String dateStr, String tzFrom, String tzTo) {
-        // use yyyy-MM-dd HH:mm:ss as default
-        return convertTz(dateStr, TIMESTAMP_FORMAT_STRING, tzFrom, tzTo);
-    }
-
-    public static String timestampToString(long ts, int precision) {
-        int p = (precision <= 3 && precision >= 0) ? precision : 3;
-        String format = DEFAULT_DATETIME_FORMATS[p];
-        return dateFormat(ts, format, UTC_ZONE);
-    }
-
-    /**
-     * Convert a timestamp to string.
-     *
-     * @param ts the timestamp to convert.
-     * @param precision the milli second precision to preserve
-     * @param tz the time zone
-     */
-    public static String timestampToString(long ts, int precision, TimeZone tz) {
-        int p = (precision <= 3 && precision >= 0) ? precision : 3;
-        String format = DEFAULT_DATETIME_FORMATS[p];
-        return dateFormat(ts, format, tz);
-    }
-
-    /** Helper for CAST({time} AS VARCHAR(n)). */
-    public static String unixTimeToString(int time) {
-        final StringBuilder buf = new StringBuilder(8);
-        unixTimeToString(buf, time, 0); // set millisecond precision to 0
-        return buf.toString();
-    }
-
-    public static String unixTimeToString(int time, int precision) {
+    public static String formatTimestampMillis(int time, int precision) {
         final StringBuilder buf = new StringBuilder(8 + (precision > 0 ? precision + 1 : 0));
-        unixTimeToString(buf, time, precision);
+        formatTimestampMillis(buf, time, precision);
         return buf.toString();
     }
 
-    private static void unixTimeToString(StringBuilder buf, int time, int precision) {
+    private static void formatTimestampMillis(StringBuilder buf, int time, int precision) {
         // we copy this method from Calcite DateTimeUtils but add the following changes
         // time may be negative which means time milli seconds before 00:00:00
         // this maybe a bug in calcite avatica
@@ -649,13 +839,13 @@ public class DateTimeUtils {
     }
 
     /** Helper for CAST({date} AS VARCHAR(n)). */
-    public static String unixDateToString(int date) {
+    public static String formatDate(int date) {
         final StringBuilder buf = new StringBuilder(10);
-        unixDateToString(buf, date);
+        formatDate(buf, date);
         return buf.toString();
     }
 
-    private static void unixDateToString(StringBuilder buf, int date) {
+    private static void formatDate(StringBuilder buf, int date) {
         julianToString(buf, date + EPOCH_JULIAN);
     }
 
@@ -689,7 +879,7 @@ public class DateTimeUtils {
         int2(buf, day);
     }
 
-    public static String intervalYearMonthToString(int v) {
+    public static String formatIntervalYearMonth(int v) {
         final StringBuilder buf = new StringBuilder();
         if (v >= 0) {
             buf.append('+');
@@ -712,22 +902,13 @@ public class DateTimeUtils {
         return buf.append(v);
     }
 
-    public static int digitCount(int v) {
+    private static int digitCount(int v) {
         for (int n = 1; ; n++) {
             v /= 10;
             if (v == 0) {
                 return n;
             }
         }
-    }
-
-    private static int roundUp(int dividend, int divisor) {
-        int remainder = dividend % divisor;
-        dividend -= remainder;
-        if (remainder * 2 > divisor) {
-            dividend += divisor;
-        }
-        return dividend;
     }
 
     private static long roundUp(long dividend, long divisor) {
@@ -756,11 +937,8 @@ public class DateTimeUtils {
         return x;
     }
 
-    public static String intervalDayTimeToString(long v) {
-        return intervalDayTimeToString(v, 3);
-    }
-
-    public static String intervalDayTimeToString(long v, int scale) {
+    public static String formatIntervalDayTime(long v) {
+        final int scale = 3;
         final StringBuilder buf = new StringBuilder();
         if (v >= 0) {
             buf.append('+');
@@ -794,21 +972,7 @@ public class DateTimeUtils {
         return buf.toString();
     }
 
-    /**
-     * Parses a given datetime string to milli seconds since 1970-01-01 00:00:00 UTC using the
-     * default format "yyyy-MM-dd" or "yyyy-MM-dd HH:mm:ss" depends on the string length.
-     */
-    private static long parseToTimeMillis(String dateStr, TimeZone tz) {
-        String format;
-        if (dateStr.length() <= 10) {
-            format = DATE_FORMAT_STRING;
-        } else {
-            format = TIMESTAMP_FORMAT_STRING;
-        }
-        return parseToTimeMillis(dateStr, format, tz) + getMillis(dateStr);
-    }
-
-    private static long parseToTimeMillis(String dateStr, String format, TimeZone tz) {
+    private static long internalParseTimestampMillis(String dateStr, String format, TimeZone tz) {
         SimpleDateFormat formatter = FORMATTER_CACHE.get(format);
         formatter.setTimeZone(tz);
         try {
@@ -824,72 +988,21 @@ public class DateTimeUtils {
         }
     }
 
-    /** Returns the milli second part of the datetime. */
-    private static int getMillis(String dateStr) {
-        int length = dateStr.length();
-        if (length == 19) {
-            // "1999-12-31 12:34:56", no milli second left
-            return 0;
-        } else if (length == 21) {
-            // "1999-12-31 12:34:56.7", return 7
-            return Integer.parseInt(dateStr.substring(20)) * 100;
-        } else if (length == 22) {
-            // "1999-12-31 12:34:56.78", return 78
-            return Integer.parseInt(dateStr.substring(20)) * 10;
-        } else if (length >= 23 && length <= 26) {
-            // "1999-12-31 12:34:56.123" ~ "1999-12-31 12:34:56.123456"
-            return Integer.parseInt(dateStr.substring(20, 23));
-        } else {
-            return 0;
-        }
-    }
-
     // --------------------------------------------------------------------------------------------
-    // EXTRACT YEAR/MONTH/QUARTER
+    // EXTRACT
     // --------------------------------------------------------------------------------------------
 
-    public static int extractYearMonth(TimeUnitRange range, int v) {
-        switch (range) {
-            case YEAR:
-                return v / 12;
-            case MONTH:
-                return v % 12;
-            case QUARTER:
-                return (v % 12 + 2) / 3;
-            default:
-                throw new UnsupportedOperationException("Unsupported TimeUnitRange: " + range);
-        }
-    }
-
-    private static final DateType REUSE_DATE_TYPE = new DateType();
     private static final TimestampType REUSE_TIMESTAMP_TYPE = new TimestampType(9);
-
-    public static int unixTimeExtract(TimeUnitRange range, int time) {
-        assert time >= 0;
-        assert time < MILLIS_PER_DAY;
-        switch (range) {
-            case HOUR:
-                return time / (int) MILLIS_PER_HOUR;
-            case MINUTE:
-                final int minutes = time / (int) MILLIS_PER_MINUTE;
-                return minutes % 60;
-            case SECOND:
-                final int seconds = time / (int) MILLIS_PER_SECOND;
-                return seconds % 60;
-            default:
-                throw new AssertionError(range);
-        }
-    }
 
     public static long extractFromTimestamp(TimeUnitRange range, TimestampData ts, TimeZone tz) {
         return convertExtract(range, ts, REUSE_TIMESTAMP_TYPE, tz);
     }
 
-    public static long unixDateExtract(TimeUnitRange range, long date) {
-        return unixDateExtract(range, (int) date);
+    public static long extractFromDate(TimeUnitRange range, long date) {
+        return extractFromDate(range, (int) date);
     }
 
-    public static long unixDateExtract(TimeUnitRange range, int date) {
+    public static long extractFromDate(TimeUnitRange range, int date) {
         switch (range) {
             case EPOCH:
                 return date * 86400L;
@@ -1021,7 +1134,7 @@ public class DateTimeUtils {
             case WEEK:
                 if (type instanceof TimestampType) {
                     long d = divide(utcTs, TimeUnit.DAY.multiplier);
-                    return unixDateExtract(range, d);
+                    return extractFromDate(range, d);
                 } else if (type instanceof DateType) {
                     return divide(utcTs, TimeUnit.DAY.multiplier);
                 } else {
@@ -1107,12 +1220,8 @@ public class DateTimeUtils {
     }
 
     // --------------------------------------------------------------------------------------------
-    // Floor/Ceil
+    // Floor/Ceil/Convert tz
     // --------------------------------------------------------------------------------------------
-
-    public static long timestampFloor(TimeUnitRange range, long ts) {
-        return timestampFloor(range, ts, UTC_ZONE);
-    }
 
     public static long timestampFloor(TimeUnitRange range, long ts, TimeZone tz) {
         // assume that we are at UTC timezone, just for algorithm performance
@@ -1138,10 +1247,6 @@ public class DateTimeUtils {
                 // it is more effective to use arithmetic Method
                 throw new AssertionError(range);
         }
-    }
-
-    public static long timestampCeil(TimeUnitRange range, long ts) {
-        return timestampCeil(range, ts, UTC_ZONE);
     }
 
     /**
@@ -1251,133 +1356,24 @@ public class DateTimeUtils {
         }
     }
 
-    // --------------------------------------------------------------------------------------------
-    // DATE DIFF/ADD
-    // --------------------------------------------------------------------------------------------
-
     /**
-     * NOTE: (1). JDK relies on the operating system clock for time. Each operating system has its
-     * own method of handling date changes such as leap seconds(e.g. OS will slow down the clock to
-     * accommodate for this). (2). DST(Daylight Saving Time) is a legal issue, governments changed
-     * it over time. Some days are NOT exactly 24 hours long, it could be 23/25 hours long on the
-     * first or last day of daylight saving time. JDK can handle DST correctly. TODO: carefully
-     * written algorithm can improve the performance
-     */
-    public static int dateDiff(long t1, long t2, TimeZone tz) {
-        ZoneId zoneId = tz.toZoneId();
-        LocalDate ld1 = Instant.ofEpochMilli(t1).atZone(zoneId).toLocalDate();
-        LocalDate ld2 = Instant.ofEpochMilli(t2).atZone(zoneId).toLocalDate();
-        return (int) ChronoUnit.DAYS.between(ld2, ld1);
-    }
-
-    public static int dateDiff(String t1Str, long t2, TimeZone tz) {
-        long t1 = parseToTimeMillis(t1Str, tz);
-        return dateDiff(t1, t2, tz);
-    }
-
-    public static int dateDiff(long t1, String t2Str, TimeZone tz) {
-        long t2 = parseToTimeMillis(t2Str, tz);
-        return dateDiff(t1, t2, tz);
-    }
-
-    public static int dateDiff(String t1Str, String t2Str, TimeZone tz) {
-        long t1 = parseToTimeMillis(t1Str, tz);
-        long t2 = parseToTimeMillis(t2Str, tz);
-        return dateDiff(t1, t2, tz);
-    }
-
-    public static int dateDiff(long t1, long t2) {
-        return dateDiff(t1, t2, UTC_ZONE);
-    }
-
-    public static int dateDiff(String t1Str, long t2) {
-        return dateDiff(t1Str, t2, UTC_ZONE);
-    }
-
-    public static int dateDiff(long t1, String t2Str) {
-        return dateDiff(t1, t2Str, UTC_ZONE);
-    }
-
-    public static int dateDiff(String t1Str, String t2Str) {
-        return dateDiff(t1Str, t2Str, UTC_ZONE);
-    }
-
-    /**
-     * Do subtraction on date string.
+     * Convert datetime string from a time zone to another time zone.
      *
-     * @param dateStr formatted date string.
-     * @param days days count you want to subtract.
-     * @param tz time zone of the date time string
-     * @return datetime string.
+     * @param dateStr the date time string
+     * @param tzFrom the original time zone
+     * @param tzTo the target time zone
      */
-    public static String dateSub(String dateStr, int days, TimeZone tz) {
-        long ts = parseToTimeMillis(dateStr, tz);
-        if (ts == Long.MIN_VALUE) {
+    public static String convertTz(String dateStr, String tzFrom, String tzTo) {
+        try {
+            return dateFormatTz(parseTimestampTz(dateStr, tzFrom), tzTo);
+        } catch (ParseException e) {
             return null;
         }
-        return dateSub(ts, days, tz);
     }
 
-    /**
-     * Do subtraction on date string.
-     *
-     * @param ts the timestamp.
-     * @param days days count you want to subtract.
-     * @param tz time zone of the date time string
-     * @return datetime string.
-     */
-    public static String dateSub(long ts, int days, TimeZone tz) {
-        ZoneId zoneId = tz.toZoneId();
-        Instant instant = Instant.ofEpochMilli(ts);
-        ZonedDateTime zdt = ZonedDateTime.ofInstant(instant, zoneId);
-        long resultTs = zdt.minusDays(days).toInstant().toEpochMilli();
-        return dateFormat(resultTs, DATE_FORMAT_STRING, tz);
-    }
-
-    public static String dateSub(String dateStr, int days) {
-        return dateSub(dateStr, days, UTC_ZONE);
-    }
-
-    public static String dateSub(long ts, int days) {
-        return dateSub(ts, days, UTC_ZONE);
-    }
-
-    /**
-     * Do addition on date string.
-     *
-     * @param dateStr formatted date string.
-     * @param days days count you want to add.
-     * @return datetime string.
-     */
-    public static String dateAdd(String dateStr, int days, TimeZone tz) {
-        long ts = parseToTimeMillis(dateStr, tz);
-        if (ts == Long.MIN_VALUE) {
-            return null;
-        }
-        return dateAdd(ts, days, tz);
-    }
-
-    /**
-     * Do addition on timestamp.
-     *
-     * @param ts the timestamp.
-     * @param days days count you want to add.
-     * @return datetime string.
-     */
-    public static String dateAdd(long ts, int days, TimeZone tz) {
-        ZoneId zoneId = tz.toZoneId();
-        Instant instant = Instant.ofEpochMilli(ts);
-        ZonedDateTime zdt = ZonedDateTime.ofInstant(instant, zoneId);
-        long resultTs = zdt.plusDays(days).toInstant().toEpochMilli();
-        return dateFormat(resultTs, DATE_FORMAT_STRING, tz);
-    }
-
-    public static String dateAdd(String dateStr, int days) {
-        return dateAdd(dateStr, days, UTC_ZONE);
-    }
-
-    public static String dateAdd(long ts, int days) {
-        return dateAdd(ts, days, UTC_ZONE);
+    private static String dateFormatTz(long ts, String tzStr) {
+        TimeZone tz = TIMEZONE_CACHE.get(tzStr);
+        return formatTimestampMillis(ts, DateTimeUtils.TIMESTAMP_FORMAT_STRING, tz);
     }
 
     // --------------------------------------------------------------------------------------------
@@ -1390,7 +1386,7 @@ public class DateTimeUtils {
      * @param ts the timestamp in milliseconds.
      * @return the date in days.
      */
-    public static int getDateInDays(long ts) {
+    public static int timestampMillisToDate(long ts) {
         int days = (int) (ts / MILLIS_PER_DAY);
         if (days < 0) {
             days = days - 1;
@@ -1404,7 +1400,7 @@ public class DateTimeUtils {
      * @param ts the timestamp in milliseconds.
      * @return the time in milliseconds.
      */
-    public static int getTimeInMills(long ts) {
+    public static int timestampMillisToTime(long ts) {
         return (int) (ts % MILLIS_PER_DAY);
     }
 
@@ -1420,15 +1416,15 @@ public class DateTimeUtils {
      * Convert unix timestamp (seconds since '1970-01-01 00:00:00' UTC) to datetime string in the
      * "yyyy-MM-dd HH:mm:ss" format.
      */
-    public static String fromUnixtime(long unixtime, TimeZone tz) {
-        return fromUnixtime(unixtime, TIMESTAMP_FORMAT_STRING, tz);
+    public static String formatUnixTimestamp(long unixtime, TimeZone tz) {
+        return formatUnixTimestamp(unixtime, TIMESTAMP_FORMAT_STRING, tz);
     }
 
     /**
      * Convert unix timestamp (seconds since '1970-01-01 00:00:00' UTC) to datetime string in the
      * given format.
      */
-    public static String fromUnixtime(long unixtime, String format, TimeZone tz) {
+    public static String formatUnixTimestamp(long unixtime, String format, TimeZone tz) {
         SimpleDateFormat formatter = FORMATTER_CACHE.get(format);
         formatter.setTimeZone(tz);
         Date date = new Date(unixtime * 1000);
@@ -1440,35 +1436,16 @@ public class DateTimeUtils {
         }
     }
 
-    public static String fromUnixtime(double unixtime, TimeZone tz) {
-        return fromUnixtime((long) unixtime, tz);
-    }
-
-    public static String fromUnixtime(DecimalData unixtime, TimeZone tz) {
-        return fromUnixtime(toTimestamp(unixtime), tz);
-    }
-
-    public static String fromUnixtime(long unixtime) {
-        return fromUnixtime(unixtime, UTC_ZONE);
-    }
-
-    public static String fromUnixtime(long unixtime, String format) {
-        return fromUnixtime(unixtime, format, UTC_ZONE);
-    }
-
-    public static String fromUnixtime(double unixtime) {
-        return fromUnixtime(unixtime, UTC_ZONE);
-    }
-
-    public static String fromUnixtime(DecimalData unixtime) {
-        return fromUnixtime(unixtime, UTC_ZONE);
-    }
-
     /**
      * Returns a Unix timestamp in seconds since '1970-01-01 00:00:00' UTC as an unsigned integer.
      */
     public static long unixTimestamp() {
         return System.currentTimeMillis() / 1000;
+    }
+
+    /** Returns the value of the timestamp to seconds since '1970-01-01 00:00:00' UTC. */
+    public static long unixTimestamp(long ts) {
+        return ts / 1000;
     }
 
     /**
@@ -1484,7 +1461,7 @@ public class DateTimeUtils {
      * 00:00:00' UTC.
      */
     public static long unixTimestamp(String dateStr, String format, TimeZone tz) {
-        long ts = parseToTimeMillis(dateStr, format, tz);
+        long ts = internalParseTimestampMillis(dateStr, format, tz);
         if (ts == Long.MIN_VALUE) {
             return Long.MIN_VALUE;
         } else {
@@ -1493,114 +1470,9 @@ public class DateTimeUtils {
         }
     }
 
-    public static long unixTimestamp(String dateStr) {
-        return unixTimestamp(dateStr, UTC_ZONE);
-    }
-
-    public static long unixTimestamp(String dateStr, String format) {
-        return unixTimestamp(dateStr, format, UTC_ZONE);
-    }
-
-    /** Returns the value of the timestamp to seconds since '1970-01-01 00:00:00' UTC. */
-    public static long unixTimestamp(long ts) {
-        return ts / 1000;
-    }
-
-    public static LocalDate unixDateToLocalDate(int date) {
-        return julianToLocalDate(date + EPOCH_JULIAN);
-    }
-
-    private static LocalDate julianToLocalDate(int julian) {
-        // this shifts the epoch back to astronomical year -4800 instead of the
-        // start of the Christian era in year AD 1 of the proleptic Gregorian
-        // calendar.
-        int j = julian + 32044;
-        int g = j / 146097;
-        int dg = j % 146097;
-        int c = (dg / 36524 + 1) * 3 / 4;
-        int dc = dg - c * 36524;
-        int b = dc / 1461;
-        int db = dc % 1461;
-        int a = (db / 365 + 1) * 3 / 4;
-        int da = db - a * 365;
-
-        // integer number of full years elapsed since March 1, 4801 BC
-        int y = g * 400 + c * 100 + b * 4 + a;
-        // integer number of full months elapsed since the last March 1
-        int m = (da * 5 + 308) / 153 - 2;
-        // number of days elapsed since day 1 of the month
-        int d = da - (m + 4) * 153 / 5 + 122;
-        int year = y - 4800 + (m + 2) / 12;
-        int month = (m + 2) % 12 + 1;
-        int day = d + 1;
-        return LocalDate.of(year, month, day);
-    }
-
-    public static int localDateToUnixDate(LocalDate date) {
-        return ymdToUnixDate(date.getYear(), date.getMonthValue(), date.getDayOfMonth());
-    }
-
-    private static int ymdToUnixDate(int year, int month, int day) {
-        final int julian = ymdToJulian(year, month, day);
-        return julian - EPOCH_JULIAN;
-    }
-
-    private static int ymdToJulian(int year, int month, int day) {
-        int a = (14 - month) / 12;
-        int y = year + 4800 - a;
-        int m = month + 12 * a - 3;
-        return day + (153 * m + 2) / 5 + 365 * y + y / 4 - y / 100 + y / 400 - 32045;
-    }
-
-    public static LocalTime unixTimeToLocalTime(int time) {
-        int h = time / 3600000;
-        int time2 = time % 3600000;
-        int m = time2 / 60000;
-        int time3 = time2 % 60000;
-        int s = time3 / 1000;
-        int ms = time3 % 1000;
-        return LocalTime.of(h, m, s, ms * 1000_000);
-    }
-
-    public static int localTimeToUnixDate(LocalTime time) {
-        return time.getHour() * (int) MILLIS_PER_HOUR
-                + time.getMinute() * (int) MILLIS_PER_MINUTE
-                + time.getSecond() * (int) MILLIS_PER_SECOND
-                + time.getNano() / 1000_000;
-    }
-
-    public static LocalDateTime unixTimestampToLocalDateTime(long timestamp) {
-        int date = (int) (timestamp / MILLIS_PER_DAY);
-        int time = (int) (timestamp % MILLIS_PER_DAY);
-        if (time < 0) {
-            --date;
-            time += MILLIS_PER_DAY;
-        }
-        LocalDate localDate = unixDateToLocalDate(date);
-        LocalTime localTime = unixTimeToLocalTime(time);
-        return LocalDateTime.of(localDate, localTime);
-    }
-
-    public static long localDateTimeToUnixTimestamp(LocalDateTime dateTime) {
-        return unixTimestamp(
-                dateTime.getYear(),
-                dateTime.getMonthValue(),
-                dateTime.getDayOfMonth(),
-                dateTime.getHour(),
-                dateTime.getMinute(),
-                dateTime.getSecond(),
-                dateTime.getNano() / 1000_000);
-    }
-
-    private static long unixTimestamp(
-            int year, int month, int day, int hour, int minute, int second, int mills) {
-        final int date = ymdToUnixDate(year, month, day);
-        return (long) date * MILLIS_PER_DAY
-                + (long) hour * MILLIS_PER_HOUR
-                + (long) minute * MILLIS_PER_MINUTE
-                + (long) second * MILLIS_PER_SECOND
-                + mills;
-    }
+    // --------------------------------------------------------------------------------------------
+    // TIMESTAMP to TIMESTAMP_LTZ conversions
+    // --------------------------------------------------------------------------------------------
 
     public static TimestampData timestampToTimestampWithLocalZone(TimestampData ts, TimeZone tz) {
         return TimestampData.fromInstant(ts.toLocalDateTime().atZone(tz.toZoneId()).toInstant());
@@ -1611,25 +1483,27 @@ public class DateTimeUtils {
                 LocalDateTime.ofInstant(ts.toInstant(), tz.toZoneId()));
     }
 
-    public static int timestampWithLocalZoneToDate(long ts, TimeZone tz) {
-        return localDateToUnixDate(
-                LocalDateTime.ofInstant(Instant.ofEpochMilli(ts), tz.toZoneId()).toLocalDate());
+    public static int timestampWithLocalZoneToDate(TimestampData ts, TimeZone tz) {
+        return toInternal(
+                LocalDateTime.ofInstant(Instant.ofEpochMilli(ts.getMillisecond()), tz.toZoneId())
+                        .toLocalDate());
     }
 
-    public static int timestampWithLocalZoneToTime(long ts, TimeZone tz) {
-        return localTimeToUnixDate(
-                LocalDateTime.ofInstant(Instant.ofEpochMilli(ts), tz.toZoneId()).toLocalTime());
+    public static int timestampWithLocalZoneToTime(TimestampData ts, TimeZone tz) {
+        return toInternal(
+                LocalDateTime.ofInstant(Instant.ofEpochMilli(ts.getMillisecond()), tz.toZoneId())
+                        .toLocalTime());
     }
 
-    public static long dateToTimestampWithLocalZone(int date, TimeZone tz) {
-        return LocalDateTime.of(unixDateToLocalDate(date), LocalTime.MIDNIGHT)
-                .atZone(tz.toZoneId())
-                .toInstant()
-                .toEpochMilli();
+    public static TimestampData dateToTimestampWithLocalZone(int date, TimeZone tz) {
+        return TimestampData.fromInstant(
+                LocalDateTime.of(toLocalDate(date), LocalTime.MIDNIGHT)
+                        .atZone(tz.toZoneId())
+                        .toInstant());
     }
 
-    public static long timeToTimestampWithLocalZone(int time, TimeZone tz) {
-        return unixTimestampToLocalDateTime(time).atZone(tz.toZoneId()).toInstant().toEpochMilli();
+    public static TimestampData timeToTimestampWithLocalZone(int time, TimeZone tz) {
+        return TimestampData.fromInstant(toLocalDateTime(time).atZone(tz.toZoneId()).toInstant());
     }
 
     private static boolean isInteger(String s) {
@@ -1666,200 +1540,6 @@ public class DateTimeUtils {
             return false;
         }
         return true;
-    }
-
-    public static Integer dateStringToUnixDate(String s) {
-        // allow timestamp str to date, e.g. 2017-12-12 09:30:00.0
-        int ws1 = s.indexOf(" ");
-        if (ws1 > 0) {
-            s = s.substring(0, ws1);
-        }
-        int hyphen1 = s.indexOf('-');
-        int y;
-        int m;
-        int d;
-        if (hyphen1 < 0) {
-            if (!isInteger(s.trim())) {
-                return null;
-            }
-            y = Integer.parseInt(s.trim());
-            m = 1;
-            d = 1;
-        } else {
-            if (!isInteger(s.substring(0, hyphen1).trim())) {
-                return null;
-            }
-            y = Integer.parseInt(s.substring(0, hyphen1).trim());
-            final int hyphen2 = s.indexOf('-', hyphen1 + 1);
-            if (hyphen2 < 0) {
-                if (!isInteger(s.substring(hyphen1 + 1).trim())) {
-                    return null;
-                }
-                m = Integer.parseInt(s.substring(hyphen1 + 1).trim());
-                d = 1;
-            } else {
-                if (!isInteger(s.substring(hyphen1 + 1, hyphen2).trim())) {
-                    return null;
-                }
-                m = Integer.parseInt(s.substring(hyphen1 + 1, hyphen2).trim());
-                if (!isInteger(s.substring(hyphen2 + 1).trim())) {
-                    return null;
-                }
-                d = Integer.parseInt(s.substring(hyphen2 + 1).trim());
-            }
-        }
-        if (!isIllegalDate(y, m, d)) {
-            return null;
-        }
-        return ymdToUnixDate(y, m, d);
-    }
-
-    public static Integer timeStringToUnixDate(String v) {
-        return timeStringToUnixDate(v, 0);
-    }
-
-    private static Integer timeStringToUnixDate(String v, int start) {
-        final int colon1 = v.indexOf(':', start);
-        // timezone hh:mm:ss[.ssssss][[+|-]hh:mm:ss]
-        // refer https://www.w3.org/TR/NOTE-datetime
-        int timezoneHour;
-        int timezoneMinute;
-        int hour;
-        int minute;
-        int second;
-        int milli;
-        int operator = -1;
-        int end = v.length();
-        int timezone = v.indexOf('-', start);
-        if (timezone < 0) {
-            timezone = v.indexOf('+', start);
-            operator = 1;
-        }
-        if (timezone < 0) {
-            timezoneHour = 0;
-            timezoneMinute = 0;
-        } else {
-            end = timezone;
-            final int colon3 = v.indexOf(':', timezone);
-            if (colon3 < 0) {
-                if (!isInteger(v.substring(timezone + 1).trim())) {
-                    return null;
-                }
-                timezoneHour = Integer.parseInt(v.substring(timezone + 1).trim());
-                timezoneMinute = 0;
-            } else {
-                if (!isInteger(v.substring(timezone + 1, colon3).trim())) {
-                    return null;
-                }
-                timezoneHour = Integer.parseInt(v.substring(timezone + 1, colon3).trim());
-                if (!isInteger(v.substring(colon3 + 1).trim())) {
-                    return null;
-                }
-                timezoneMinute = Integer.parseInt(v.substring(colon3 + 1).trim());
-            }
-        }
-        if (colon1 < 0) {
-            if (!isInteger(v.substring(start, end).trim())) {
-                return null;
-            }
-            hour = Integer.parseInt(v.substring(start, end).trim());
-            minute = 0;
-            second = 0;
-            milli = 0;
-        } else {
-            if (!isInteger(v.substring(start, colon1).trim())) {
-                return null;
-            }
-            hour = Integer.parseInt(v.substring(start, colon1).trim());
-            final int colon2 = v.indexOf(':', colon1 + 1);
-            if (colon2 < 0) {
-                if (!isInteger(v.substring(colon1 + 1, end).trim())) {
-                    return null;
-                }
-                minute = Integer.parseInt(v.substring(colon1 + 1, end).trim());
-                second = 0;
-                milli = 0;
-            } else {
-                if (!isInteger(v.substring(colon1 + 1, colon2).trim())) {
-                    return null;
-                }
-                minute = Integer.parseInt(v.substring(colon1 + 1, colon2).trim());
-                int dot = v.indexOf('.', colon2);
-                if (dot < 0) {
-                    if (!isInteger(v.substring(colon2 + 1, end).trim())) {
-                        return null;
-                    }
-                    second = Integer.parseInt(v.substring(colon2 + 1, end).trim());
-                    milli = 0;
-                } else {
-                    if (!isInteger(v.substring(colon2 + 1, dot).trim())) {
-                        return null;
-                    }
-                    second = Integer.parseInt(v.substring(colon2 + 1, dot).trim());
-                    milli = parseFraction(v.substring(dot + 1, end).trim(), 100);
-                }
-            }
-        }
-        hour += operator * timezoneHour;
-        minute += operator * timezoneMinute;
-        return hour * (int) MILLIS_PER_HOUR
-                + minute * (int) MILLIS_PER_MINUTE
-                + second * (int) MILLIS_PER_SECOND
-                + milli;
-    }
-
-    /**
-     * Parses a fraction, multiplying the first character by {@code multiplier}, the second
-     * character by {@code multiplier / 10}, the third character by {@code multiplier / 100}, and so
-     * forth.
-     *
-     * <p>For example, {@code parseFraction("1234", 100)} yields {@code 123}.
-     */
-    private static int parseFraction(String v, int multiplier) {
-        int r = 0;
-        for (int i = 0; i < v.length(); i++) {
-            char c = v.charAt(i);
-            int x = c < '0' || c > '9' ? 0 : (c - '0');
-            r += multiplier * x;
-            if (multiplier < 10) {
-                // We're at the last digit. Check for rounding.
-                if (i + 1 < v.length() && v.charAt(i + 1) >= '5') {
-                    ++r;
-                }
-                break;
-            }
-            multiplier /= 10;
-        }
-        return r;
-    }
-
-    public static String timestampToString(TimestampData ts, int precision) {
-        LocalDateTime ldt = ts.toLocalDateTime();
-
-        String fraction = pad(9, (long) ldt.getNano());
-        while (fraction.length() > precision && fraction.endsWith("0")) {
-            fraction = fraction.substring(0, fraction.length() - 1);
-        }
-
-        StringBuilder ymdhms =
-                ymdhms(
-                        new StringBuilder(),
-                        ldt.getYear(),
-                        ldt.getMonthValue(),
-                        ldt.getDayOfMonth(),
-                        ldt.getHour(),
-                        ldt.getMinute(),
-                        ldt.getSecond());
-
-        if (fraction.length() > 0) {
-            ymdhms.append(".").append(fraction);
-        }
-
-        return ymdhms.toString();
-    }
-
-    public static String timestampToString(TimestampData ts, TimeZone tz, int precision) {
-        return timestampToString(timestampWithLocalZoneToTimestamp(ts, tz), precision);
     }
 
     private static String pad(int length, long v) {

--- a/flink-table/flink-table-common/src/test/java/org/apache/flink/table/utils/print/TableauStyleTest.java
+++ b/flink-table/flink-table-common/src/test/java/org/apache/flink/table/utils/print/TableauStyleTest.java
@@ -254,7 +254,7 @@ public class TableauStyleTest {
             results[5] =
                     rowData.isNullAt(5)
                             ? PrintStyle.NULL_VALUE
-                            : DateTimeUtils.timestampToString(
+                            : DateTimeUtils.formatTimestamp(
                                     rowData.getTimestamp(5, 6), DateTimeUtils.UTC_ZONE, 6);
 
             return results;

--- a/flink-table/flink-table-planner/src/main/java/org/apache/flink/table/planner/expressions/converter/ExpressionConverter.java
+++ b/flink-table/flink-table-planner/src/main/java/org/apache/flink/table/planner/expressions/converter/ExpressionConverter.java
@@ -64,8 +64,8 @@ import java.util.List;
 import java.util.Optional;
 import java.util.stream.Collectors;
 
+import static org.apache.flink.table.planner.utils.TimestampStringUtils.fromLocalDateTime;
 import static org.apache.flink.table.runtime.types.LogicalTypeDataTypeConverter.fromDataTypeToLogicalType;
-import static org.apache.flink.table.util.TimestampStringUtils.fromLocalDateTime;
 
 /** Visit expression to generator {@link RexNode}. */
 public class ExpressionConverter implements ExpressionVisitor<RexNode> {

--- a/flink-table/flink-table-planner/src/main/java/org/apache/flink/table/planner/functions/casting/AbstractCodeGeneratorCastRule.java
+++ b/flink-table/flink-table-planner/src/main/java/org/apache/flink/table/planner/functions/casting/AbstractCodeGeneratorCastRule.java
@@ -116,7 +116,6 @@ abstract class AbstractCodeGeneratorCastRule<IN, OUT> extends AbstractCastRule<I
             bodyWriter.tryCatchStmt(
                     tryWriter ->
                             tryWriter.append(codeBlock).stmt("return " + codeBlock.getReturnTerm()),
-                    Throwable.class,
                     (exceptionTerm, catchWriter) ->
                             catchWriter.throwStmt(
                                     constructorCall(

--- a/flink-table/flink-table-planner/src/main/java/org/apache/flink/table/planner/functions/casting/AbstractCodeGeneratorCastRule.java
+++ b/flink-table/flink-table-planner/src/main/java/org/apache/flink/table/planner/functions/casting/AbstractCodeGeneratorCastRule.java
@@ -36,6 +36,9 @@ import java.util.stream.Collectors;
 import java.util.stream.Stream;
 
 import static org.apache.flink.table.planner.codegen.CodeGenUtils.className;
+import static org.apache.flink.table.planner.functions.casting.CastRuleUtils.cast;
+import static org.apache.flink.table.planner.functions.casting.CastRuleUtils.constructorCall;
+import static org.apache.flink.table.planner.functions.casting.CastRuleUtils.strLiteral;
 
 /**
  * Base class for {@link CastRule} supporting code generation. This base class implements {@link
@@ -102,12 +105,32 @@ abstract class AbstractCodeGeneratorCastRule<IN, OUT> extends AbstractCastRule<I
         final String functionSignature =
                 "@Override public Object cast(Object _myInputObj) throws "
                         + className(TableException.class);
-        final String inputVarDecl =
-                inputTypeTerm + " " + inputTerm + " = (" + inputTypeTerm + ") _myInputObj;\n";
-        final String inputIsNullVarDecl =
-                "boolean " + inputIsNullTerm + " = _myInputObj == null;\n";
 
-        final String returnStmt = "return " + codeBlock.getReturnTerm() + ";\n";
+        // Write the function body
+        final CastRuleUtils.CodeWriter bodyWriter = new CastRuleUtils.CodeWriter();
+        bodyWriter.declStmt(inputTypeTerm, inputTerm, cast(inputTypeTerm, "_myInputObj"));
+        bodyWriter.declStmt("boolean", inputIsNullTerm, "_myInputObj == null");
+        ctx.variableDeclarationStatements.forEach(decl -> bodyWriter.appendBlock(decl + "\n"));
+
+        if (this.canFail()) {
+            bodyWriter.tryCatchStmt(
+                    tryWriter ->
+                            tryWriter.append(codeBlock).stmt("return " + codeBlock.getReturnTerm()),
+                    Throwable.class,
+                    (exceptionTerm, catchWriter) ->
+                            catchWriter.throwStmt(
+                                    constructorCall(
+                                            TableException.class,
+                                            strLiteral(
+                                                    "Error when casting "
+                                                            + inputLogicalType
+                                                            + " to "
+                                                            + targetLogicalType
+                                                            + "."),
+                                            exceptionTerm)));
+        } else {
+            bodyWriter.append(codeBlock).stmt("return " + codeBlock.getReturnTerm());
+        }
 
         final String classCode =
                 "public final class "
@@ -123,12 +146,7 @@ abstract class AbstractCodeGeneratorCastRule<IN, OUT> extends AbstractCastRule<I
                         + "}\n"
                         + functionSignature
                         + "{\n"
-                        + inputVarDecl
-                        + inputIsNullVarDecl
-                        + String.join("\n", ctx.variableDeclarationStatements)
-                        + codeBlock.getCode()
-                        + "\n"
-                        + returnStmt
+                        + bodyWriter
                         + "}\n}";
 
         try {

--- a/flink-table/flink-table-planner/src/main/java/org/apache/flink/table/planner/functions/casting/AbstractExpressionCodeGeneratorCastRule.java
+++ b/flink-table/flink-table-planner/src/main/java/org/apache/flink/table/planner/functions/casting/AbstractExpressionCodeGeneratorCastRule.java
@@ -61,6 +61,12 @@ abstract class AbstractExpressionCodeGeneratorCastRule<IN, OUT>
     @Override
     public CastExecutor<IN, OUT> create(
             CastRule.Context context, LogicalType inputLogicalType, LogicalType targetLogicalType) {
+        if (this.canFail()) {
+            // We can't use the ExpressionEvaluator because we need proper wrapping of the eventual
+            // exception
+            return super.create(context, inputLogicalType, targetLogicalType);
+        }
+
         final String inputArgumentName = "inputValue";
 
         final String expression =

--- a/flink-table/flink-table-planner/src/main/java/org/apache/flink/table/planner/functions/casting/CastRuleUtils.java
+++ b/flink-table/flink-table-planner/src/main/java/org/apache/flink/table/planner/functions/casting/CastRuleUtils.java
@@ -235,6 +235,12 @@ final class CastRuleUtils {
 
         public CodeWriter tryCatchStmt(
                 Consumer<CodeWriter> bodyWriterConsumer,
+                BiConsumer<String, CodeWriter> catchConsumer) {
+            return tryCatchStmt(bodyWriterConsumer, Throwable.class, catchConsumer);
+        }
+
+        public CodeWriter tryCatchStmt(
+                Consumer<CodeWriter> bodyWriterConsumer,
                 Class<? extends Throwable> catchClass,
                 BiConsumer<String, CodeWriter> catchConsumer) {
             final String exceptionTerm = newName("e");

--- a/flink-table/flink-table-planner/src/main/java/org/apache/flink/table/planner/functions/casting/CastRuleUtils.java
+++ b/flink-table/flink-table-planner/src/main/java/org/apache/flink/table/planner/functions/casting/CastRuleUtils.java
@@ -233,8 +233,36 @@ final class CastRuleUtils {
             return this;
         }
 
+        public CodeWriter tryCatchStmt(
+                Consumer<CodeWriter> bodyWriterConsumer,
+                Class<? extends Throwable> catchClass,
+                BiConsumer<String, CodeWriter> catchConsumer) {
+            final String exceptionTerm = newName("e");
+
+            final CodeWriter bodyWriter = new CodeWriter();
+            final CodeWriter catchWriter = new CodeWriter();
+
+            builder.append("try {\n");
+            bodyWriterConsumer.accept(bodyWriter);
+            builder.append(bodyWriter)
+                    .append("} catch (")
+                    .append(className(catchClass))
+                    .append(" ")
+                    .append(exceptionTerm)
+                    .append(") {\n");
+            catchConsumer.accept(exceptionTerm, catchWriter);
+            builder.append(catchWriter).append("}\n");
+
+            return this;
+        }
+
         public CodeWriter append(CastCodeBlock codeBlock) {
             builder.append(codeBlock.getCode());
+            return this;
+        }
+
+        public CodeWriter throwStmt(String expression) {
+            builder.append("throw ").append(expression).append(";");
             return this;
         }
 

--- a/flink-table/flink-table-planner/src/main/java/org/apache/flink/table/planner/functions/utils/HiveTableSqlFunction.java
+++ b/flink-table/flink-table-planner/src/main/java/org/apache/flink/table/planner/functions/utils/HiveTableSqlFunction.java
@@ -168,7 +168,7 @@ public class HiveTableSqlFunction extends TableSqlFunction {
             case TIME:
                 return LocalTime.ofNanoOfDay(((TimeString) value).getMillisOfDay() * 1000_000);
             case TIMESTAMP:
-                return DateTimeUtils.unixTimestampToLocalDateTime(
+                return DateTimeUtils.toLocalDateTime(
                         ((TimestampString) value).getMillisSinceEpoch());
             default:
                 throw new RuntimeException("Not support type: " + type);

--- a/flink-table/flink-table-planner/src/main/java/org/apache/flink/table/planner/utils/TimestampStringUtils.java
+++ b/flink-table/flink-table-planner/src/main/java/org/apache/flink/table/planner/utils/TimestampStringUtils.java
@@ -16,15 +16,19 @@
  * limitations under the License.
  */
 
-package org.apache.flink.table.util;
+package org.apache.flink.table.planner.utils;
+
+import org.apache.flink.annotation.Internal;
 
 import org.apache.calcite.util.TimestampString;
 
 import java.time.LocalDateTime;
 
 /** Utility functions for calcite's {@link TimestampString}. */
+@Internal
 public class TimestampStringUtils {
 
+    /** Convert a {@link LocalDateTime} to a calcite's {@link TimestampString}. */
     public static TimestampString fromLocalDateTime(LocalDateTime ldt) {
         return new TimestampString(
                         ldt.getYear(),
@@ -36,24 +40,25 @@ public class TimestampStringUtils {
                 .withNanos(ldt.getNano());
     }
 
+    /** Convert a calcite's {@link TimestampString} to a {@link LocalDateTime}. */
     public static LocalDateTime toLocalDateTime(TimestampString timestampString) {
         final String v = timestampString.toString();
-        final int year = Integer.valueOf(v.substring(0, 4));
-        final int month = Integer.valueOf(v.substring(5, 7));
-        final int day = Integer.valueOf(v.substring(8, 10));
-        final int h = Integer.valueOf(v.substring(11, 13));
-        final int m = Integer.valueOf(v.substring(14, 16));
-        final int s = Integer.valueOf(v.substring(17, 19));
+        final int year = Integer.parseInt(v.substring(0, 4));
+        final int month = Integer.parseInt(v.substring(5, 7));
+        final int day = Integer.parseInt(v.substring(8, 10));
+        final int h = Integer.parseInt(v.substring(11, 13));
+        final int m = Integer.parseInt(v.substring(14, 16));
+        final int s = Integer.parseInt(v.substring(17, 19));
         final int nano = getNanosInSecond(v);
         return LocalDateTime.of(year, month, day, h, m, s, nano);
     }
 
     private static int getNanosInSecond(String v) {
-        switch (v.length()) {
-            case 19: // "1999-12-31 12:34:56"
-                return 0;
-            default: // "1999-12-31 12:34:56.789123456"
-                return Integer.valueOf(v.substring(20)) * (int) Math.pow(10, 9 - (v.length() - 20));
+        if (v.length() == 19) { // "1999-12-31 12:34:56"
+            return 0;
         }
+
+        // "1999-12-31 12:34:56.789123456"
+        return Integer.parseInt(v.substring(20)) * (int) Math.pow(10, 9 - (v.length() - 20));
     }
 }

--- a/flink-table/flink-table-planner/src/main/scala/org/apache/flink/table/planner/codegen/CodeGeneratorContext.scala
+++ b/flink-table/flink-table-planner/src/main/scala/org/apache/flink/table/planner/codegen/CodeGeneratorContext.scala
@@ -531,7 +531,7 @@ class CodeGeneratorContext(val tableConfig: TableConfig) {
     // assignment
     val field =
     s"""
-       |$fieldTerm = $utilsName.getTimeInMills($localtimestamp.getMillisecond());
+       |$fieldTerm = $utilsName.timestampMillisToTime($localtimestamp.getMillisecond());
        |""".stripMargin
     reusablePerRecordStatements.add(field)
     fieldTerm
@@ -550,7 +550,7 @@ class CodeGeneratorContext(val tableConfig: TableConfig) {
     reusableMemberStatements.add(
       s"""
           |private static final int $fieldTerm =
-          | $utilsName.getTimeInMills($queryStartLocalTimestamp.getMillisecond());
+          | $utilsName.timestampMillisToTime($queryStartLocalTimestamp.getMillisecond());
           | """.stripMargin)
     fieldTerm
   }
@@ -568,7 +568,7 @@ class CodeGeneratorContext(val tableConfig: TableConfig) {
     reusableMemberStatements.add(s"private int $fieldTerm;")
 
     // assignment
-    val field = s"$fieldTerm = $utilsName.getDateInDays($timestamp.getMillisecond());"
+    val field = s"$fieldTerm = $utilsName.timestampMillisToDate($timestamp.getMillisecond());"
 
     reusablePerRecordStatements.add(field)
     fieldTerm
@@ -585,7 +585,7 @@ class CodeGeneratorContext(val tableConfig: TableConfig) {
     reusableMemberStatements.add(
     s"""
        |private static final int $fieldTerm =
-       | $fieldTerm = $utilsName.getDateInDays($timestamp.getMillisecond());
+       | $fieldTerm = $utilsName.timestampMillisToDate($timestamp.getMillisecond());
        |""".stripMargin)
 
     fieldTerm

--- a/flink-table/flink-table-planner/src/main/scala/org/apache/flink/table/planner/codegen/ExpressionReducer.scala
+++ b/flink-table/flink-table-planner/src/main/scala/org/apache/flink/table/planner/codegen/ExpressionReducer.scala
@@ -30,7 +30,7 @@ import org.apache.flink.table.planner.plan.utils.PythonUtil.containsPythonCall
 import org.apache.flink.table.planner.utils.Logging
 import org.apache.flink.table.types.DataType
 import org.apache.flink.table.types.logical.RowType
-import org.apache.flink.table.util.TimestampStringUtils.fromLocalDateTime
+import org.apache.flink.table.planner.utils.TimestampStringUtils.fromLocalDateTime
 
 import org.apache.calcite.avatica.util.ByteString
 import org.apache.calcite.rex.{RexBuilder, RexCall, RexExecutor, RexLiteral, RexNode, RexUtil}

--- a/flink-table/flink-table-planner/src/main/scala/org/apache/flink/table/planner/codegen/GenerateUtils.scala
+++ b/flink-table/flink-table-planner/src/main/scala/org/apache/flink/table/planner/codegen/GenerateUtils.scala
@@ -34,7 +34,7 @@ import org.apache.flink.table.runtime.typeutils.TypeCheckUtils.{isCharacterStrin
 import org.apache.flink.table.types.logical.LogicalTypeRoot._
 import org.apache.flink.table.types.logical._
 import org.apache.flink.table.types.logical.utils.LogicalTypeChecks.{getFieldCount, getFieldTypes}
-import org.apache.flink.table.util.TimestampStringUtils.toLocalDateTime
+import org.apache.flink.table.planner.utils.TimestampStringUtils.toLocalDateTime
 
 import org.apache.calcite.avatica.util.ByteString
 import org.apache.calcite.util.TimestampString

--- a/flink-table/flink-table-planner/src/main/scala/org/apache/flink/table/planner/codegen/calls/BuiltInMethods.scala
+++ b/flink-table/flink-table-planner/src/main/scala/org/apache/flink/table/planner/codegen/calls/BuiltInMethods.scala
@@ -228,32 +228,27 @@ object BuiltInMethods {
 
   val UNIX_TIME_TO_STRING = Types.lookupMethod(
     classOf[DateTimeUtils],
-    "unixTimeToString",
+    "formatTimestampMillis",
     classOf[Int], classOf[Int])
 
   val UNIX_DATE_TO_STRING = Types.lookupMethod(
     classOf[DateTimeUtils],
-    "unixDateToString",
+    "formatDate",
     classOf[Int])
-
-  val TIMESTAMP_TO_STRING = Types.lookupMethod(
-    classOf[DateTimeUtils],
-    "timestampToString",
-    classOf[TimestampData], classOf[Int])
 
   val INTERVAL_YEAR_MONTH_TO_STRING = Types.lookupMethod(
     classOf[DateTimeUtils],
-    "intervalYearMonthToString",
+    "formatIntervalYearMonth",
     classOf[Int])
 
   val INTERVAL_DAY_TIME_TO_STRING = Types.lookupMethod(
     classOf[DateTimeUtils],
-    "intervalDayTimeToString",
+    "formatIntervalDayTime",
     classOf[Long])
 
   val TIMESTAMP_TO_STRING_TIME_ZONE = Types.lookupMethod(
     classOf[DateTimeUtils],
-    "timestampToString",
+    "formatTimestamp",
     classOf[TimestampData], classOf[TimeZone], classOf[Int])
 
   val TIMESTAMP_TO_TIMESTAMP_WITH_LOCAL_ZONE = Types.lookupMethod(
@@ -268,28 +263,39 @@ object BuiltInMethods {
 
   val STRING_TO_DATE_WITH_FORMAT = Types.lookupMethod(
     classOf[DateTimeUtils],
-    "strToDate",
+    "parseDate",
     classOf[String], classOf[String])
 
-  val DATE_FORMAT_STRING_STRING_STRING_TIME_ZONE = Types.lookupMethod(
-    classOf[DateTimeUtils], "dateFormat", classOf[String],
-    classOf[String], classOf[String], classOf[TimeZone])
-
-  val DATE_FORMAT_STIRNG_STRING_TIME_ZONE = Types.lookupMethod(
-    classOf[DateTimeUtils], "dateFormat", classOf[String], classOf[String], classOf[TimeZone])
-
-  val DATE_FORMAT_TIMESTAMP_STRING_TIME_ZONE = Types.lookupMethod(
+  val FORMAT_TIMESTAMP_STRING_STRING_STRING_TIME_ZONE = Types.lookupMethod(
     classOf[DateTimeUtils],
-    "dateFormat",
-    classOf[TimestampData],
+    "formatTimestampString",
+    classOf[String],
+    classOf[String],
     classOf[String],
     classOf[TimeZone])
 
-  val DATE_FORMAT_STIRNG_STRING = Types.lookupMethod(
-    classOf[DateTimeUtils], "dateFormat", classOf[String], classOf[String])
+  val FORMAT_TIMESTAMP_STRING_STRING_TIME_ZONE = Types.lookupMethod(
+    classOf[DateTimeUtils],
+    "formatTimestampString",
+    classOf[String],
+    classOf[String],
+    classOf[TimeZone])
 
-  val DATE_FORMAT_TIMESTAMP_STRING = Types.lookupMethod(
-    classOf[DateTimeUtils], "dateFormat", classOf[TimestampData], classOf[String])
+  val FORMAT_TIMESTAMP_STRING_FORMAT_STRING_STRING = Types.lookupMethod(
+    classOf[DateTimeUtils],
+    "formatTimestampString",
+    classOf[String],
+    classOf[String])
+
+  val FORMAT_TIMESTAMP_DATA = Types.lookupMethod(
+    classOf[DateTimeUtils], "formatTimestamp", classOf[TimestampData], classOf[String])
+
+  val FORMAT_TIMESTAMP_DATA_WITH_TIME_ZONE = Types.lookupMethod(
+    classOf[DateTimeUtils],
+    "formatTimestamp",
+    classOf[TimestampData],
+    classOf[String],
+    classOf[TimeZone])
 
   val UNIX_TIMESTAMP_FORMAT = Types.lookupMethod(
     classOf[DateTimeUtils],
@@ -308,73 +314,14 @@ object BuiltInMethods {
     classOf[DateTimeUtils], "unixTimestamp", classOf[Long])
 
   val FROM_UNIXTIME_FORMAT = Types.lookupMethod(
-    classOf[DateTimeUtils], "fromUnixtime", classOf[Long], classOf[String], classOf[TimeZone])
+    classOf[DateTimeUtils],
+    "formatUnixTimestamp",
+    classOf[Long],
+    classOf[String],
+    classOf[TimeZone])
 
   val FROM_UNIXTIME = Types.lookupMethod(
-    classOf[DateTimeUtils], "fromUnixtime", classOf[Long], classOf[TimeZone])
-
-  val DATEDIFF_T_S_TIME_ZONE = Types.lookupMethod(
-    classOf[DateTimeUtils], "dateDiff", classOf[Long], classOf[String], classOf[TimeZone])
-
-  val DATEDIFF_S_S_TIME_ZONE = Types.lookupMethod(
-    classOf[DateTimeUtils], "dateDiff", classOf[String], classOf[String], classOf[TimeZone])
-
-  val DATEDIFF_S_T_TIME_ZONE = Types.lookupMethod(
-    classOf[DateTimeUtils], "dateDiff", classOf[String], classOf[Long], classOf[TimeZone])
-
-  val DATEDIFF_T_T_TIME_ZONE = Types.lookupMethod(
-    classOf[DateTimeUtils], "dateDiff", classOf[Long], classOf[Long], classOf[TimeZone])
-
-  val DATEDIFF_T_S = Types.lookupMethod(
-    classOf[DateTimeUtils], "dateDiff", classOf[Long], classOf[String])
-
-  val DATEDIFF_S_S = Types.lookupMethod(
-    classOf[DateTimeUtils], "dateDiff", classOf[String], classOf[String])
-
-  val DATEDIFF_S_T = Types.lookupMethod(
-    classOf[DateTimeUtils], "dateDiff", classOf[String], classOf[Long])
-
-  val DATEDIFF_T_T = Types.lookupMethod(
-    classOf[DateTimeUtils], "dateDiff", classOf[Long], classOf[Long])
-
-  val DATE_SUB_S_TIME_ZONE = Types.lookupMethod(
-    classOf[DateTimeUtils], "dateSub", classOf[String], classOf[Int], classOf[TimeZone])
-
-  val DATE_SUB_T_TIME_ZONE = Types.lookupMethod(
-    classOf[DateTimeUtils], "dateSub", classOf[Long], classOf[Int], classOf[TimeZone])
-
-  val DATE_SUB_S = Types.lookupMethod(
-    classOf[DateTimeUtils], "dateSub", classOf[String], classOf[Int])
-
-  val DATE_SUB_T = Types.lookupMethod(
-    classOf[DateTimeUtils], "dateSub", classOf[Long], classOf[Int])
-
-  val DATE_ADD_S_TIME_ZONE = Types.lookupMethod(
-    classOf[DateTimeUtils], "dateAdd", classOf[String], classOf[Int], classOf[TimeZone])
-
-  val DATE_ADD_T_TIME_ZONE = Types.lookupMethod(
-    classOf[DateTimeUtils], "dateAdd", classOf[Long], classOf[Int], classOf[TimeZone])
-
-  val DATE_ADD_S = Types.lookupMethod(
-    classOf[DateTimeUtils], "dateAdd", classOf[String], classOf[Int])
-
-  val DATE_ADD_T = Types.lookupMethod(
-    classOf[DateTimeUtils], "dateAdd", classOf[Long], classOf[Int])
-
-  val LONG_TO_TIMESTAMP = Types.lookupMethod(
-    classOf[DateTimeUtils],
-    "toTimestamp",
-    classOf[Long])
-
-  val DOUBLE_TO_TIMESTAMP = Types.lookupMethod(
-    classOf[DateTimeUtils],
-    "toTimestamp",
-    classOf[Double])
-
-  val DECIMAL_TO_TIMESTAMP = Types.lookupMethod(
-    classOf[DateTimeUtils],
-    "toTimestamp",
-    classOf[DecimalData])
+    classOf[DateTimeUtils], "formatUnixTimestamp", classOf[Long], classOf[TimeZone])
 
   val LONG_TO_TIMESTAMP_LTZ_WITH_PRECISION = Types.lookupMethod(
     classOf[DateTimeUtils],
@@ -393,23 +340,23 @@ object BuiltInMethods {
 
   val STRING_TO_TIMESTAMP = Types.lookupMethod(
     classOf[DateTimeUtils],
-    "toTimestampData",
+    "parseTimestampData",
     classOf[String])
 
   val STRING_TO_TIMESTAMP_WITH_FORMAT = Types.lookupMethod(
     classOf[DateTimeUtils],
-    "toTimestampData",
+    "parseTimestampData",
     classOf[String], classOf[String])
 
   val TIMESTAMP_WITH_LOCAL_TIME_ZONE_TO_DATE = Types.lookupMethod(
     classOf[DateTimeUtils],
     "timestampWithLocalZoneToDate",
-    classOf[Long], classOf[TimeZone])
+    classOf[TimestampData], classOf[TimeZone])
 
   val TIMESTAMP_WITH_LOCAL_TIME_ZONE_TO_TIME = Types.lookupMethod(
     classOf[DateTimeUtils],
     "timestampWithLocalZoneToTime",
-    classOf[Long], classOf[TimeZone])
+    classOf[TimestampData], classOf[TimeZone])
 
   val DATE_TO_TIMESTAMP_WITH_LOCAL_TIME_ZONE = Types.lookupMethod(
     classOf[DateTimeUtils],
@@ -431,16 +378,6 @@ object BuiltInMethods {
     "extractFromTimestamp",
     classOf[TimeUnitRange], classOf[TimestampData], classOf[TimeZone])
 
-  val UNIX_TIME_EXTRACT = Types.lookupMethod(
-    classOf[DateTimeUtils],
-    "unixTimeExtract",
-    classOf[TimeUnitRange], classOf[Int])
-
-  val EXTRACT_YEAR_MONTH = Types.lookupMethod(
-    classOf[DateTimeUtils],
-    "extractYearMonth",
-    classOf[TimeUnitRange], classOf[Int])
-
   val TIMESTAMP_FLOOR_TIME_ZONE = Types.lookupMethod(
     classOf[DateTimeUtils],
     "timestampFloor",
@@ -456,16 +393,11 @@ object BuiltInMethods {
     "convertTz",
     classOf[String], classOf[String], classOf[String])
 
-  val CONVERT_FORMAT_TZ = Types.lookupMethod(
-    classOf[DateTimeUtils],
-    "convertTz",
-    classOf[String], classOf[String], classOf[String], classOf[String])
-
   val STRING_TO_DATE = Types.lookupMethod(
-    classOf[DateTimeUtils], "dateStringToUnixDate", classOf[String])
+    classOf[DateTimeUtils], "parseDate", classOf[String])
 
   val STRING_TO_TIME = Types.lookupMethod(
-    classOf[DateTimeUtils], "timeStringToUnixDate", classOf[String])
+    classOf[DateTimeUtils], "parseTime", classOf[String])
 
   val TRUNCATE_DOUBLE_ONE = Types.lookupMethod(classOf[SqlFunctions], "struncate",
     classOf[Double])
@@ -501,7 +433,7 @@ object BuiltInMethods {
   val UNIX_TIMESTAMP_FLOOR = Types.lookupMethod(classOf[DateTimeUtils], "unixTimestampFloor",
     classOf[TimeUnitRange], classOf[Long])
 
-  val UNIX_DATE_EXTRACT = Types.lookupMethod(classOf[DateTimeUtils], "unixDateExtract",
+  val UNIX_DATE_EXTRACT = Types.lookupMethod(classOf[DateTimeUtils], "extractFromDate",
     classOf[TimeUnitRange], classOf[Int])
 
   val TRUNCATE_SQL_TIMESTAMP = Types.lookupMethod(classOf[DateTimeUtils], "truncate",

--- a/flink-table/flink-table-planner/src/main/scala/org/apache/flink/table/planner/codegen/calls/FunctionGenerator.scala
+++ b/flink-table/flink-table-planner/src/main/scala/org/apache/flink/table/planner/codegen/calls/FunctionGenerator.scala
@@ -723,20 +723,6 @@ class FunctionGenerator private(config: TableConfig) {
     new HashCodeCallGen())
 
   INTEGRAL_TYPES foreach (
-    dt => addSqlFunctionMethod(TO_TIMESTAMP,
-      Seq(dt),
-      BuiltInMethods.LONG_TO_TIMESTAMP))
-
-  FRACTIONAL_TYPES foreach (
-    dt => addSqlFunctionMethod(TO_TIMESTAMP,
-      Seq(dt),
-      BuiltInMethods.DOUBLE_TO_TIMESTAMP))
-
-  addSqlFunctionMethod(TO_TIMESTAMP,
-    Seq(DECIMAL),
-    BuiltInMethods.DECIMAL_TO_TIMESTAMP)
-
-  INTEGRAL_TYPES foreach (
     dt => {
       addSqlFunctionMethod(
         TO_TIMESTAMP_LTZ,

--- a/flink-table/flink-table-planner/src/main/scala/org/apache/flink/table/planner/codegen/calls/ScalarOperatorGens.scala
+++ b/flink-table/flink-table-planner/src/main/scala/org/apache/flink/table/planner/codegen/calls/ScalarOperatorGens.scala
@@ -1979,7 +1979,7 @@ object ScalarOperatorGens {
       GeneratedExpression(resultTerm, "false", "", resultType, Some(result))
     } catch {
       case e: Throwable =>
-        throw new ValidationException("Error when casting literal: " + e.getMessage, e)
+        throw new ValidationException("Error when casting literal. " + e.getMessage, e)
     }
   }
 

--- a/flink-table/flink-table-planner/src/main/scala/org/apache/flink/table/planner/codegen/calls/ScalarOperatorGens.scala
+++ b/flink-table/flink-table-planner/src/main/scala/org/apache/flink/table/planner/codegen/calls/ScalarOperatorGens.scala
@@ -1160,7 +1160,7 @@ object ScalarOperatorGens {
         generateUnaryOperatorIfNotNull(ctx, targetType, operand) { operandTerm =>
           val zone = ctx.addReusableSessionTimeZone()
           val method = qualifyMethod(BuiltInMethods.DATE_TO_TIMESTAMP_WITH_LOCAL_TIME_ZONE)
-          s"$TIMESTAMP_DATA.fromEpochMillis($method($operandTerm, $zone))"
+          s"$method($operandTerm, $zone)"
         }
 
       // Timestamp with local time zone -> Date
@@ -1168,7 +1168,7 @@ object ScalarOperatorGens {
         generateUnaryOperatorIfNotNull(ctx, targetType, operand) { operandTerm =>
           val zone = ctx.addReusableSessionTimeZone()
           val method = qualifyMethod(BuiltInMethods.TIMESTAMP_WITH_LOCAL_TIME_ZONE_TO_DATE)
-          s"$method($operandTerm.getMillisecond(), $zone)"
+          s"$method($operandTerm, $zone)"
         }
 
       // Time -> Timestamp with local time zone
@@ -1176,7 +1176,7 @@ object ScalarOperatorGens {
         generateUnaryOperatorIfNotNull(ctx, targetType, operand) { operandTerm =>
           val zone = ctx.addReusableSessionTimeZone()
           val method = qualifyMethod(BuiltInMethods.TIME_TO_TIMESTAMP_WITH_LOCAL_TIME_ZONE)
-          s"$TIMESTAMP_DATA.fromEpochMillis($method($operandTerm, $zone))"
+          s"$method($operandTerm, $zone)"
         }
 
       // Timestamp with local time zone -> Time
@@ -1184,7 +1184,7 @@ object ScalarOperatorGens {
         generateUnaryOperatorIfNotNull(ctx, targetType, operand) { operandTerm =>
           val zone = ctx.addReusableSessionTimeZone()
           val method = qualifyMethod(BuiltInMethods.TIMESTAMP_WITH_LOCAL_TIME_ZONE_TO_TIME)
-          s"$method($operandTerm.getMillisecond(), $zone)"
+          s"$method($operandTerm, $zone)"
         }
 
       // Disable cast conversion between Numeric type and Timestamp type

--- a/flink-table/flink-table-planner/src/main/scala/org/apache/flink/table/planner/codegen/calls/StringCallGen.scala
+++ b/flink-table/flink-table-planner/src/main/scala/org/apache/flink/table/planner/codegen/calls/StringCallGen.scala
@@ -205,17 +205,17 @@ object StringCallGen {
       case DATE_FORMAT if operands.size == 2 &&
           isTimestamp(operands.head.resultType) &&
           isCharacterString(operands(1).resultType) =>
-        methodGen(BuiltInMethods.DATE_FORMAT_TIMESTAMP_STRING)
+        methodGen(BuiltInMethods.FORMAT_TIMESTAMP_DATA)
 
       case DATE_FORMAT if operands.size == 2 &&
           isTimestampWithLocalZone(operands.head.resultType) &&
           isCharacterString(operands(1).resultType) =>
-        methodGen(BuiltInMethods.DATE_FORMAT_TIMESTAMP_STRING_TIME_ZONE)
+        methodGen(BuiltInMethods.FORMAT_TIMESTAMP_DATA_WITH_TIME_ZONE)
 
       case DATE_FORMAT if operands.size == 2 &&
           isCharacterString(operands.head.resultType) &&
           isCharacterString(operands(1).resultType) =>
-        methodGen(BuiltInMethods.DATE_FORMAT_STIRNG_STRING)
+        methodGen(BuiltInMethods.FORMAT_TIMESTAMP_STRING_FORMAT_STRING_STRING)
 
       case CONVERT_TZ if operands.size == 3 &&
           isCharacterString(operands.head.resultType) &&

--- a/flink-table/flink-table-planner/src/main/scala/org/apache/flink/table/planner/plan/utils/PartitionPruner.scala
+++ b/flink-table/flink-table-planner/src/main/scala/org/apache/flink/table/planner/plan/utils/PartitionPruner.scala
@@ -177,11 +177,11 @@ object PartitionPruner {
       case DECIMAL =>
         val decimalType = t.asInstanceOf[DecimalType]
         DecimalDataUtils.castFrom(v, decimalType.getPrecision, decimalType.getScale)
-      case DATE => DateTimeUtils.dateStringToUnixDate(v)
-      case TIME_WITHOUT_TIME_ZONE => DateTimeUtils.timeStringToUnixDate(v)
-      case TIMESTAMP_WITHOUT_TIME_ZONE => DateTimeUtils.toTimestampData(v)
+      case DATE => DateTimeUtils.parseDate(v)
+      case TIME_WITHOUT_TIME_ZONE => DateTimeUtils.parseTime(v)
+      case TIMESTAMP_WITHOUT_TIME_ZONE => DateTimeUtils.parseTimestampData(v)
       case TIMESTAMP_WITH_LOCAL_TIME_ZONE => TimestampData.fromInstant(
-        DateTimeUtils.toTimestampData(v).toLocalDateTime.atZone(timeZone).toInstant)
+        DateTimeUtils.parseTimestampData(v).toLocalDateTime.atZone(timeZone).toInstant)
       case _ =>
         throw new TableException(s"$t is not supported in PartitionPruner")
     }

--- a/flink-table/flink-table-planner/src/main/scala/org/apache/flink/table/planner/plan/utils/RexNodeExtractor.scala
+++ b/flink-table/flink-table-planner/src/main/scala/org/apache/flink/table/planner/plan/utils/RexNodeExtractor.scala
@@ -32,7 +32,7 @@ import org.apache.flink.table.runtime.types.LogicalTypeDataTypeConverter.fromLog
 import org.apache.flink.table.types.DataType
 import org.apache.flink.table.types.logical.LogicalTypeRoot._
 import org.apache.flink.table.types.logical.YearMonthIntervalType
-import org.apache.flink.table.util.TimestampStringUtils.toLocalDateTime
+import org.apache.flink.table.planner.utils.TimestampStringUtils.toLocalDateTime
 import org.apache.flink.util.Preconditions
 import org.apache.calcite.plan.RelOptUtil
 import org.apache.calcite.rex._

--- a/flink-table/flink-table-planner/src/test/java/org/apache/flink/table/planner/codegen/calls/BuiltInMethodsTest.java
+++ b/flink-table/flink-table-planner/src/test/java/org/apache/flink/table/planner/codegen/calls/BuiltInMethodsTest.java
@@ -29,7 +29,7 @@ import java.util.stream.Stream;
 import static org.junit.jupiter.api.Assertions.assertDoesNotThrow;
 import static org.junit.jupiter.api.Assertions.assertNotNull;
 
-/** This test class is checking if methods defined in {@link BuiltInMethods} are valid. */
+/** Check if the static methods defined in {@link BuiltInMethods} are valid. */
 class BuiltInMethodsTest {
 
     private static Stream<Method> testMethodsAreAvailable() {
@@ -44,7 +44,10 @@ class BuiltInMethodsTest {
     @MethodSource
     void testMethodsAreAvailable(Method m) throws Exception {
         assertDoesNotThrow(
-                () -> m.invoke(null),
+                () ->
+                        // Note that this null is because the method is static, hence no instance
+                        // should be supplied when calling the reflection
+                        m.invoke(null),
                 "Method " + m.getName() + " throws an exception, perhaps a bad definition?");
         assertNotNull(m.invoke(null));
     }

--- a/flink-table/flink-table-planner/src/test/java/org/apache/flink/table/planner/codegen/calls/BuiltInMethodsTest.java
+++ b/flink-table/flink-table-planner/src/test/java/org/apache/flink/table/planner/codegen/calls/BuiltInMethodsTest.java
@@ -1,0 +1,51 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.flink.table.planner.codegen.calls;
+
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.MethodSource;
+
+import java.lang.reflect.Method;
+import java.lang.reflect.Modifier;
+import java.util.Arrays;
+import java.util.stream.Stream;
+
+import static org.junit.jupiter.api.Assertions.assertDoesNotThrow;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+
+/** This test class is checking if methods defined in {@link BuiltInMethods} are valid. */
+class BuiltInMethodsTest {
+
+    private static Stream<Method> testMethodsAreAvailable() {
+        return Arrays.stream(BuiltInMethods.class.getMethods())
+                .filter(
+                        m ->
+                                Modifier.isStatic(m.getModifiers())
+                                        && Modifier.isPublic(m.getModifiers()));
+    }
+
+    @ParameterizedTest
+    @MethodSource
+    void testMethodsAreAvailable(Method m) throws Exception {
+        assertDoesNotThrow(
+                () -> m.invoke(null),
+                "Method " + m.getName() + " throws an exception, perhaps a bad definition?");
+        assertNotNull(m.invoke(null));
+    }
+}

--- a/flink-table/flink-table-planner/src/test/java/org/apache/flink/table/planner/functions/casting/CastRulesTest.java
+++ b/flink-table/flink-table-planner/src/test/java/org/apache/flink/table/planner/functions/casting/CastRulesTest.java
@@ -110,10 +110,8 @@ class CastRulesTest {
     private static final double DEFAULT_POSITIVE_DOUBLE = 123.456789d;
     private static final double DEFAULT_NEGATIVE_DOUBLE = -123.456789d;
 
-    private static final int DATE =
-            DateTimeUtils.localDateToUnixDate(LocalDate.parse("2021-09-24"));
-    private static final int TIME =
-            DateTimeUtils.localTimeToUnixDate(LocalTime.parse("12:34:56.123"));
+    private static final int DATE = DateTimeUtils.toInternal(LocalDate.parse("2021-09-24"));
+    private static final int TIME = DateTimeUtils.toInternal(LocalTime.parse("12:34:56.123"));
     private static final StringData DATE_STRING = StringData.fromString("2021-09-24");
     private static final StringData TIME_STRING = StringData.fromString("12:34:56.123");
 
@@ -402,15 +400,15 @@ class CastRulesTest {
                         .fromCase(
                                 STRING(),
                                 StringData.fromString("123"),
-                                DateTimeUtils.localDateToUnixDate(LocalDate.of(123, 1, 1)))
+                                DateTimeUtils.toInternal(LocalDate.of(123, 1, 1)))
                         .fromCase(
                                 STRING(),
                                 StringData.fromString("2021-09-27"),
-                                DateTimeUtils.localDateToUnixDate(LocalDate.of(2021, 9, 27)))
+                                DateTimeUtils.toInternal(LocalDate.of(2021, 9, 27)))
                         .fromCase(
                                 STRING(),
                                 StringData.fromString("2021-09-27 12:34:56.123456789"),
-                                DateTimeUtils.localDateToUnixDate(LocalDate.of(2021, 9, 27)))
+                                DateTimeUtils.toInternal(LocalDate.of(2021, 9, 27)))
                         .fail(STRING(), StringData.fromString("2021/09/27"), TableException.class),
                 CastTestSpecBuilder.testCastTo(TIME())
                         .fail(CHAR(3), StringData.fromString("foo"), TableException.class)
@@ -418,11 +416,11 @@ class CastRulesTest {
                         .fromCase(
                                 STRING(),
                                 StringData.fromString("23"),
-                                DateTimeUtils.localTimeToUnixDate(LocalTime.of(23, 0, 0)))
+                                DateTimeUtils.toInternal(LocalTime.of(23, 0, 0)))
                         .fromCase(
                                 STRING(),
                                 StringData.fromString("23:45"),
-                                DateTimeUtils.localTimeToUnixDate(LocalTime.of(23, 45, 0)))
+                                DateTimeUtils.toInternal(LocalTime.of(23, 45, 0)))
                         .fail(STRING(), StringData.fromString("2021-09-27"), TableException.class)
                         .fail(
                                 STRING(),
@@ -431,8 +429,7 @@ class CastRulesTest {
                         .fromCase(
                                 STRING(),
                                 StringData.fromString("12:34:56.123456789"),
-                                DateTimeUtils.localTimeToUnixDate(
-                                        LocalTime.of(12, 34, 56, 123_000_000)))
+                                DateTimeUtils.toInternal(LocalTime.of(12, 34, 56, 123_000_000)))
                         .fail(
                                 STRING(),
                                 StringData.fromString("2021-09-27 12:34:56.123456789"),

--- a/flink-table/flink-table-planner/src/test/java/org/apache/flink/table/planner/runtime/stream/jsonplan/TableSourceJsonPlanITCase.java
+++ b/flink-table/flink-table-planner/src/test/java/org/apache/flink/table/planner/runtime/stream/jsonplan/TableSourceJsonPlanITCase.java
@@ -29,7 +29,7 @@ import java.util.Arrays;
 import java.util.HashMap;
 import java.util.List;
 
-import static org.apache.flink.table.utils.DateTimeUtils.unixTimestampToLocalDateTime;
+import static org.apache.flink.table.utils.DateTimeUtils.toLocalDateTime;
 
 /** Test for table source json plan. */
 public class TableSourceJsonPlanITCase extends JsonPlanTestBase {
@@ -126,9 +126,9 @@ public class TableSourceJsonPlanITCase extends JsonPlanTestBase {
 
         assertResult(
                 Arrays.asList(
-                        "4,3," + unixTimestampToLocalDateTime(4000L),
-                        "5,3," + unixTimestampToLocalDateTime(5000L),
-                        "6,3," + unixTimestampToLocalDateTime(6000L)),
+                        "4,3," + toLocalDateTime(4000L),
+                        "5,3," + toLocalDateTime(5000L),
+                        "6,3," + toLocalDateTime(6000L)),
                 sinkPath);
     }
 
@@ -162,9 +162,7 @@ public class TableSourceJsonPlanITCase extends JsonPlanTestBase {
         tableEnv.executeJsonPlan(jsonPlan).await();
 
         assertResult(
-                Arrays.asList(
-                        "5," + unixTimestampToLocalDateTime(5000L),
-                        "6," + unixTimestampToLocalDateTime(6000L)),
+                Arrays.asList("5," + toLocalDateTime(5000L), "6," + toLocalDateTime(6000L)),
                 sinkPath);
     }
 }

--- a/flink-table/flink-table-planner/src/test/java/org/apache/flink/table/planner/runtime/stream/jsonplan/WatermarkAssignerJsonPlanITCase.java
+++ b/flink-table/flink-table-planner/src/test/java/org/apache/flink/table/planner/runtime/stream/jsonplan/WatermarkAssignerJsonPlanITCase.java
@@ -28,7 +28,7 @@ import java.io.File;
 import java.util.Arrays;
 import java.util.HashMap;
 
-import static org.apache.flink.table.utils.DateTimeUtils.unixTimestampToLocalDateTime;
+import static org.apache.flink.table.utils.DateTimeUtils.toLocalDateTime;
 
 /** Test for watermark assigner json plan. */
 public class WatermarkAssignerJsonPlanITCase extends JsonPlanTestBase {
@@ -59,9 +59,9 @@ public class WatermarkAssignerJsonPlanITCase extends JsonPlanTestBase {
 
         assertResult(
                 Arrays.asList(
-                        "4,3," + unixTimestampToLocalDateTime(4000L),
-                        "5,3," + unixTimestampToLocalDateTime(5000L),
-                        "6,3," + unixTimestampToLocalDateTime(6000L)),
+                        "4,3," + toLocalDateTime(4000L),
+                        "5,3," + toLocalDateTime(5000L),
+                        "6,3," + toLocalDateTime(6000L)),
                 sinkPath);
     }
 }

--- a/flink-table/flink-table-planner/src/test/scala/org/apache/flink/table/planner/expressions/validation/ScalarOperatorsValidationTest.scala
+++ b/flink-table/flink-table-planner/src/test/scala/org/apache/flink/table/planner/expressions/validation/ScalarOperatorsValidationTest.scala
@@ -88,24 +88,24 @@ class ScalarOperatorsValidationTest extends ScalarOperatorsTestBase {
   @Test
   def testTemporalTypeEqualsInvalidStringLiteral(): Unit = {
     testExpectedSqlException(
-      "f15 = 'invalid'", "java.time.DateTimeException",
+      "f15 = 'invalid'", "Error when casting CHAR(7) NOT NULL to DATE",
       classOf[ValidationException])
     testExpectedSqlException(
-      "'invalid' = f15", "java.time.DateTimeException",
-      classOf[ValidationException])
-
-    testExpectedSqlException(
-      "f21 = 'invalid'", "java.time.DateTimeException",
-      classOf[ValidationException])
-    testExpectedSqlException(
-      "'invalid' = f21", "java.time.DateTimeException",
+      "'invalid' = f15", "Error when casting CHAR(7) NOT NULL to DATE",
       classOf[ValidationException])
 
     testExpectedSqlException(
-      "f22 = 'invalid'", "java.time.DateTimeException",
+      "f21 = 'invalid'", "Error when casting CHAR(7) NOT NULL to TIME",
       classOf[ValidationException])
     testExpectedSqlException(
-      "'invalid' = f22", "java.time.DateTimeException",
+      "'invalid' = f21", "Error when casting CHAR(7) NOT NULL to TIME",
+      classOf[ValidationException])
+
+    testExpectedSqlException(
+      "f22 = 'invalid'", "Error when casting CHAR(7) NOT NULL to TIMESTAMP(6)",
+      classOf[ValidationException])
+    testExpectedSqlException(
+      "'invalid' = f22", "Error when casting CHAR(7) NOT NULL to TIMESTAMP(6)",
       classOf[ValidationException])
   }
 }

--- a/flink-table/flink-table-planner/src/test/scala/org/apache/flink/table/planner/runtime/batch/sql/CalcITCase.scala
+++ b/flink-table/flink-table-planner/src/test/scala/org/apache/flink/table/planner/runtime/batch/sql/CalcITCase.scala
@@ -40,7 +40,7 @@ import org.apache.flink.table.planner.runtime.utils.UserDefinedFunctionTestUtils
 import org.apache.flink.table.planner.runtime.utils.{BatchTableEnvUtil, BatchTestBase, TestData, UserDefinedFunctionTestUtils}
 import org.apache.flink.table.planner.utils.{DateTimeTestUtil, TestLegacyFilterableTableSource}
 import org.apache.flink.table.planner.utils.DateTimeTestUtil._
-import org.apache.flink.table.utils.DateTimeUtils.unixTimestampToLocalDateTime
+import org.apache.flink.table.utils.DateTimeUtils.toLocalDateTime
 import org.apache.flink.types.Row
 
 import org.junit.Assert.assertEquals
@@ -1127,7 +1127,7 @@ class CalcITCase extends BatchTestBase {
       Seq(row(true)))
 
     val d0 = LocalDateConverter.INSTANCE.toInternal(
-      unixTimestampToLocalDateTime(System.currentTimeMillis()).toLocalDate)
+      toLocalDateTime(System.currentTimeMillis()).toLocalDate)
 
     val table = parseQuery("SELECT CURRENT_DATE FROM testTable WHERE a = TRUE")
     val result = executeQuery(table)

--- a/flink-table/flink-table-planner/src/test/scala/org/apache/flink/table/planner/runtime/batch/sql/TableScanITCase.scala
+++ b/flink-table/flink-table-planner/src/test/scala/org/apache/flink/table/planner/runtime/batch/sql/TableScanITCase.scala
@@ -25,7 +25,7 @@ import org.apache.flink.table.api.{TableSchema, Types}
 import org.apache.flink.table.planner.runtime.utils.BatchTestBase
 import org.apache.flink.table.planner.runtime.utils.BatchTestBase.row
 import org.apache.flink.table.planner.utils.{TestTableSourceWithTime, WithoutTimeAttributesTableSource}
-import org.apache.flink.table.utils.DateTimeUtils.unixTimestampToLocalDateTime
+import org.apache.flink.table.utils.DateTimeUtils.toLocalDateTime
 import org.junit.Test
 import java.lang.{Integer => JInt}
 
@@ -69,10 +69,10 @@ class TableScanITCase extends BatchTestBase {
   def testRowtimeTableSource(): Unit = {
     val tableName = "MyTable"
     val data = Seq(
-      row("Mary", unixTimestampToLocalDateTime(1L), new JInt(10)),
-      row("Bob", unixTimestampToLocalDateTime(2L), new JInt(20)),
-      row("Mary", unixTimestampToLocalDateTime(2L), new JInt(30)),
-      row("Liz", unixTimestampToLocalDateTime(2001L), new JInt(40)))
+      row("Mary", toLocalDateTime(1L), new JInt(10)),
+      row("Bob", toLocalDateTime(2L), new JInt(20)),
+      row("Mary", toLocalDateTime(2L), new JInt(30)),
+      row("Liz", toLocalDateTime(2001L), new JInt(40)))
 
     val fieldNames = Array("name", "rtime", "amount")
     val schema = new TableSchema(fieldNames, Array(Types.STRING, LOCAL_DATE_TIME, Types.INT))
@@ -86,10 +86,10 @@ class TableScanITCase extends BatchTestBase {
     checkResult(
       s"SELECT * FROM $tableName",
       Seq(
-        row("Mary", unixTimestampToLocalDateTime(1L), new JInt(10)),
-        row("Mary", unixTimestampToLocalDateTime(2L), new JInt(30)),
-        row("Bob", unixTimestampToLocalDateTime(2L), new JInt(20)),
-        row("Liz", unixTimestampToLocalDateTime(2001L), new JInt(40)))
+        row("Mary", toLocalDateTime(1L), new JInt(10)),
+        row("Mary", toLocalDateTime(2L), new JInt(30)),
+        row("Bob", toLocalDateTime(2L), new JInt(20)),
+        row("Liz", toLocalDateTime(2001L), new JInt(40)))
     )
   }
 

--- a/flink-table/flink-table-planner/src/test/scala/org/apache/flink/table/planner/runtime/batch/sql/UnnestITCase.scala
+++ b/flink-table/flink-table-planner/src/test/scala/org/apache/flink/table/planner/runtime/batch/sql/UnnestITCase.scala
@@ -22,7 +22,7 @@ import org.apache.flink.api.java.typeutils.{ObjectArrayTypeInfo, RowTypeInfo}
 import org.apache.flink.table.api.Types
 import org.apache.flink.table.planner.runtime.utils.BatchTestBase.row
 import org.apache.flink.table.planner.runtime.utils.{BatchTestBase, TestData}
-import org.apache.flink.table.utils.DateTimeUtils.unixTimestampToLocalDateTime
+import org.apache.flink.table.utils.DateTimeUtils.toLocalDateTime
 import org.apache.flink.types.Row
 
 import org.junit.Test
@@ -151,7 +151,7 @@ class UnnestITCase extends BatchTestBase {
   @Test
   def testTumbleWindowAggregateWithCollectUnnest(): Unit = {
     val data = TestData.tupleData3.map {
-      case (i, l, s) => row(i, l, s, unixTimestampToLocalDateTime(i * 1000))
+      case (i, l, s) => row(i, l, s, toLocalDateTime(i * 1000))
     }
     registerCollection("T", data,
       new RowTypeInfo(Types.INT, Types.LONG, Types.STRING, Types.LOCAL_DATE_TIME),

--- a/flink-table/flink-table-planner/src/test/scala/org/apache/flink/table/planner/runtime/batch/sql/agg/AggregateReduceGroupingITCase.scala
+++ b/flink-table/flink-table-planner/src/test/scala/org/apache/flink/table/planner/runtime/batch/sql/agg/AggregateReduceGroupingITCase.scala
@@ -25,7 +25,7 @@ import org.apache.flink.table.planner.plan.stats.FlinkStatistic
 import org.apache.flink.table.planner.runtime.utils.BatchTestBase
 import org.apache.flink.table.planner.runtime.utils.BatchTestBase.row
 import org.apache.flink.table.planner.utils.DateTimeTestUtil.localDateTime
-import org.apache.flink.table.utils.DateTimeUtils.unixTimestampToLocalDateTime
+import org.apache.flink.table.utils.DateTimeUtils.toLocalDateTime
 
 import org.junit.{Before, Test}
 
@@ -105,7 +105,7 @@ class AggregateReduceGroupingITCase extends BatchTestBase {
     registerCollection("T6",
       (0 until 50000).map(
         i => row(i, 1L, if (i % 500 == 0) null else s"Hello$i", "Hello world", 10,
-          unixTimestampToLocalDateTime(i + 1531820000000L).toLocalDate)),
+          toLocalDateTime(i + 1531820000000L).toLocalDate)),
       new RowTypeInfo(Types.INT, Types.LONG, Types.STRING,
         Types.STRING, Types.INT, Types.LOCAL_DATE),
       "a6, b6, c6, d6, e6, f6",

--- a/flink-table/flink-table-planner/src/test/scala/org/apache/flink/table/planner/runtime/utils/TestData.scala
+++ b/flink-table/flink-table-planner/src/test/scala/org/apache/flink/table/planner/runtime/utils/TestData.scala
@@ -26,7 +26,7 @@ import org.apache.flink.table.planner.factories.TestValuesTableFactory.changelog
 import org.apache.flink.table.planner.{JHashMap, JInt}
 import org.apache.flink.table.planner.runtime.utils.BatchTestBase.row
 import org.apache.flink.table.planner.utils.DateTimeTestUtil._
-import org.apache.flink.table.utils.DateTimeUtils.unixTimestampToLocalDateTime
+import org.apache.flink.table.utils.DateTimeUtils.toLocalDateTime
 import org.apache.flink.types.Row
 
 import java.lang.{Boolean => JBool, Long => JLong}
@@ -258,27 +258,27 @@ object TestData {
   val nullablesOfData3WithTimestamp = Array(true, true, true, true)
 
   lazy val data3WithTimestamp: Seq[Row] = Seq(
-    row(2, 2L, "Hello", unixTimestampToLocalDateTime(2000L)),
-    row(1, 1L, "Hi", unixTimestampToLocalDateTime(1000L)),
-    row(3, 2L, "Hello world", unixTimestampToLocalDateTime(3000L)),
-    row(4, 3L, "Hello world, how are you?", unixTimestampToLocalDateTime(4000L)),
-    row(5, 3L, "I am fine.", unixTimestampToLocalDateTime(5000L)),
-    row(6, 3L, "Luke Skywalker", unixTimestampToLocalDateTime(6000L)),
-    row(7, 4L, "Comment#1", unixTimestampToLocalDateTime(7000L)),
-    row(8, 4L, "Comment#2", unixTimestampToLocalDateTime(8000L)),
-    row(9, 4L, "Comment#3", unixTimestampToLocalDateTime(9000L)),
-    row(10, 4L, "Comment#4", unixTimestampToLocalDateTime(10000L)),
-    row(11, 5L, "Comment#5", unixTimestampToLocalDateTime(11000L)),
-    row(12, 5L, "Comment#6", unixTimestampToLocalDateTime(12000L)),
-    row(13, 5L, "Comment#7", unixTimestampToLocalDateTime(13000L)),
-    row(15, 5L, "Comment#9", unixTimestampToLocalDateTime(15000L)),
-    row(14, 5L, "Comment#8", unixTimestampToLocalDateTime(14000L)),
-    row(16, 6L, "Comment#10", unixTimestampToLocalDateTime(16000L)),
-    row(17, 6L, "Comment#11", unixTimestampToLocalDateTime(17000L)),
-    row(18, 6L, "Comment#12", unixTimestampToLocalDateTime(18000L)),
-    row(19, 6L, "Comment#13", unixTimestampToLocalDateTime(19000L)),
-    row(20, 6L, "Comment#14", unixTimestampToLocalDateTime(20000L)),
-    row(21, 6L, "Comment#15", unixTimestampToLocalDateTime(21000L))
+    row(2, 2L, "Hello", toLocalDateTime(2000L)),
+    row(1, 1L, "Hi", toLocalDateTime(1000L)),
+    row(3, 2L, "Hello world", toLocalDateTime(3000L)),
+    row(4, 3L, "Hello world, how are you?", toLocalDateTime(4000L)),
+    row(5, 3L, "I am fine.", toLocalDateTime(5000L)),
+    row(6, 3L, "Luke Skywalker", toLocalDateTime(6000L)),
+    row(7, 4L, "Comment#1", toLocalDateTime(7000L)),
+    row(8, 4L, "Comment#2", toLocalDateTime(8000L)),
+    row(9, 4L, "Comment#3", toLocalDateTime(9000L)),
+    row(10, 4L, "Comment#4", toLocalDateTime(10000L)),
+    row(11, 5L, "Comment#5", toLocalDateTime(11000L)),
+    row(12, 5L, "Comment#6", toLocalDateTime(12000L)),
+    row(13, 5L, "Comment#7", toLocalDateTime(13000L)),
+    row(15, 5L, "Comment#9", toLocalDateTime(15000L)),
+    row(14, 5L, "Comment#8", toLocalDateTime(14000L)),
+    row(16, 6L, "Comment#10", toLocalDateTime(16000L)),
+    row(17, 6L, "Comment#11", toLocalDateTime(17000L)),
+    row(18, 6L, "Comment#12", toLocalDateTime(18000L)),
+    row(19, 6L, "Comment#13", toLocalDateTime(19000L)),
+    row(20, 6L, "Comment#14", toLocalDateTime(20000L)),
+    row(21, 6L, "Comment#15", toLocalDateTime(21000L))
   )
 
   lazy val smallNestedTupleData: Seq[((Int, Int), String)] = {

--- a/flink-table/flink-table-planner/src/test/scala/org/apache/flink/table/planner/utils/DateTimeTestUtil.scala
+++ b/flink-table/flink-table-planner/src/test/scala/org/apache/flink/table/planner/utils/DateTimeTestUtil.scala
@@ -29,7 +29,7 @@ object DateTimeTestUtil {
     if (s == null) {
       null
     } else {
-      LocalDateConverter.INSTANCE.toExternal(DateTimeUtils.dateStringToUnixDate(s))
+      LocalDateConverter.INSTANCE.toExternal(DateTimeUtils.parseDate(s))
     }
   }
 
@@ -37,7 +37,7 @@ object DateTimeTestUtil {
     if (s == null) {
       null
     } else {
-      LocalTimeConverter.INSTANCE.toExternal(DateTimeUtils.timeStringToUnixDate(s))
+      LocalTimeConverter.INSTANCE.toExternal(DateTimeUtils.parseTime(s))
     }
   }
 
@@ -45,7 +45,7 @@ object DateTimeTestUtil {
     if (s == null) {
       null
     } else {
-      DateTimeUtils.toTimestampData(s).toLocalDateTime
+      DateTimeUtils.parseTimestampData(s).toLocalDateTime
     }
   }
 

--- a/flink-table/flink-table-runtime/src/main/java/org/apache/flink/table/data/binary/BinaryStringDataUtil.java
+++ b/flink-table/flink-table-runtime/src/main/java/org/apache/flink/table/data/binary/BinaryStringDataUtil.java
@@ -31,6 +31,7 @@ import org.apache.flink.table.utils.EncodingUtils;
 import java.math.BigDecimal;
 import java.security.MessageDigest;
 import java.security.NoSuchAlgorithmException;
+import java.text.ParseException;
 import java.time.DateTimeException;
 import java.util.ArrayList;
 import java.util.Arrays;
@@ -582,7 +583,7 @@ public class BinaryStringDataUtil {
     }
 
     public static int toDate(BinaryStringData input) throws DateTimeException {
-        Integer date = DateTimeUtils.dateStringToUnixDate(input.toString());
+        Integer date = DateTimeUtils.parseDate(input.toString());
         if (date == null) {
             throw new DateTimeException("For input string: '" + input + "'.");
         }
@@ -591,7 +592,7 @@ public class BinaryStringDataUtil {
     }
 
     public static int toTime(BinaryStringData input) throws DateTimeException {
-        Integer date = DateTimeUtils.timeStringToUnixDate(input.toString());
+        Integer date = DateTimeUtils.parseTime(input.toString());
         if (date == null) {
             throw new DateTimeException("For input string: '" + input + "'.");
         }
@@ -600,7 +601,7 @@ public class BinaryStringDataUtil {
     }
 
     public static TimestampData toTimestamp(BinaryStringData input) throws DateTimeException {
-        TimestampData timestamp = DateTimeUtils.toTimestampData(input.toString());
+        TimestampData timestamp = DateTimeUtils.parseTimestampData(input.toString());
         if (timestamp == null) {
             throw new DateTimeException("For input string: '" + input + "'.");
         }
@@ -609,12 +610,8 @@ public class BinaryStringDataUtil {
     }
 
     public static TimestampData toTimestamp(BinaryStringData input, TimeZone timeZone)
-            throws DateTimeException {
-        Long timestamp = DateTimeUtils.toTimestamp(input.toString(), timeZone);
-        if (timestamp == null) {
-            throw new DateTimeException("For input string: '" + input + "'.");
-        }
-
+            throws ParseException {
+        long timestamp = DateTimeUtils.parseTimestampMillis(input.toString(), timeZone);
         return TimestampData.fromEpochMillis(timestamp);
     }
 

--- a/flink-table/flink-table-runtime/src/main/java/org/apache/flink/table/data/conversion/DateDateConverter.java
+++ b/flink-table/flink-table-runtime/src/main/java/org/apache/flink/table/data/conversion/DateDateConverter.java
@@ -30,11 +30,11 @@ public class DateDateConverter implements DataStructureConverter<Integer, java.s
 
     @Override
     public Integer toInternal(java.sql.Date external) {
-        return DateTimeUtils.dateToInternal(external);
+        return DateTimeUtils.toInternal(external);
     }
 
     @Override
     public java.sql.Date toExternal(Integer internal) {
-        return DateTimeUtils.internalToDate(internal);
+        return DateTimeUtils.toSQLDate(internal);
     }
 }

--- a/flink-table/flink-table-runtime/src/main/java/org/apache/flink/table/data/conversion/DateLocalDateConverter.java
+++ b/flink-table/flink-table-runtime/src/main/java/org/apache/flink/table/data/conversion/DateLocalDateConverter.java
@@ -31,11 +31,11 @@ public class DateLocalDateConverter
 
     @Override
     public Integer toInternal(java.time.LocalDate external) {
-        return DateTimeUtils.localDateToUnixDate(external);
+        return DateTimeUtils.toInternal(external);
     }
 
     @Override
     public java.time.LocalDate toExternal(Integer internal) {
-        return DateTimeUtils.unixDateToLocalDate(internal);
+        return DateTimeUtils.toLocalDate(internal);
     }
 }

--- a/flink-table/flink-table-runtime/src/main/java/org/apache/flink/table/data/conversion/TimeLocalTimeConverter.java
+++ b/flink-table/flink-table-runtime/src/main/java/org/apache/flink/table/data/conversion/TimeLocalTimeConverter.java
@@ -31,11 +31,11 @@ public class TimeLocalTimeConverter
 
     @Override
     public Integer toInternal(java.time.LocalTime external) {
-        return DateTimeUtils.localTimeToUnixDate(external);
+        return DateTimeUtils.toInternal(external);
     }
 
     @Override
     public java.time.LocalTime toExternal(Integer internal) {
-        return DateTimeUtils.unixTimeToLocalTime(internal);
+        return DateTimeUtils.toLocalTime(internal);
     }
 }

--- a/flink-table/flink-table-runtime/src/main/java/org/apache/flink/table/data/conversion/TimeTimeConverter.java
+++ b/flink-table/flink-table-runtime/src/main/java/org/apache/flink/table/data/conversion/TimeTimeConverter.java
@@ -30,11 +30,11 @@ public class TimeTimeConverter implements DataStructureConverter<Integer, java.s
 
     @Override
     public Integer toInternal(java.sql.Time external) {
-        return DateTimeUtils.timeToInternal(external);
+        return DateTimeUtils.toInternal(external);
     }
 
     @Override
     public java.sql.Time toExternal(Integer internal) {
-        return DateTimeUtils.internalToTime(internal);
+        return DateTimeUtils.toSQLTime(internal);
     }
 }

--- a/flink-table/flink-table-runtime/src/main/java/org/apache/flink/table/data/util/DataFormatConverters.java
+++ b/flink-table/flink-table-runtime/src/main/java/org/apache/flink/table/data/util/DataFormatConverters.java
@@ -730,12 +730,12 @@ public class DataFormatConverters {
 
         @Override
         Integer toInternalImpl(LocalDate value) {
-            return DateTimeUtils.localDateToUnixDate(value);
+            return DateTimeUtils.toInternal(value);
         }
 
         @Override
         LocalDate toExternalImpl(Integer value) {
-            return DateTimeUtils.unixDateToLocalDate(value);
+            return DateTimeUtils.toLocalDate(value);
         }
 
         @Override
@@ -755,12 +755,12 @@ public class DataFormatConverters {
 
         @Override
         Integer toInternalImpl(LocalTime value) {
-            return DateTimeUtils.localTimeToUnixDate(value);
+            return DateTimeUtils.toInternal(value);
         }
 
         @Override
         LocalTime toExternalImpl(Integer value) {
-            return DateTimeUtils.unixTimeToLocalTime(value);
+            return DateTimeUtils.toLocalTime(value);
         }
 
         @Override
@@ -835,12 +835,12 @@ public class DataFormatConverters {
 
         @Override
         Integer toInternalImpl(Date value) {
-            return DateTimeUtils.dateToInternal(value);
+            return DateTimeUtils.toInternal(value);
         }
 
         @Override
         Date toExternalImpl(Integer value) {
-            return DateTimeUtils.internalToDate(value);
+            return DateTimeUtils.toSQLDate(value);
         }
 
         @Override
@@ -860,12 +860,12 @@ public class DataFormatConverters {
 
         @Override
         Integer toInternalImpl(Time value) {
-            return DateTimeUtils.timeToInternal(value);
+            return DateTimeUtils.toInternal(value);
         }
 
         @Override
         Time toExternalImpl(Integer value) {
-            return DateTimeUtils.internalToTime(value);
+            return DateTimeUtils.toSQLTime(value);
         }
 
         @Override

--- a/flink-table/flink-table-runtime/src/test/java/org/apache/flink/table/data/DataFormatConvertersTest.java
+++ b/flink-table/flink-table-runtime/src/test/java/org/apache/flink/table/data/DataFormatConvertersTest.java
@@ -107,9 +107,9 @@ public class DataFormatConvertersTest {
                 new short[] {5, 1},
                 new byte[] {5, 1},
                 new char[] {5, 1},
-                DateTimeUtils.unixDateToLocalDate(5),
-                DateTimeUtils.unixTimeToLocalTime(11),
-                DateTimeUtils.unixTimestampToLocalDateTime(11),
+                DateTimeUtils.toLocalDate(5),
+                DateTimeUtils.toLocalTime(11),
+                DateTimeUtils.toLocalDateTime(11),
                 StringData.fromString("hahah")
             };
 

--- a/flink-table/flink-table-runtime/src/test/java/org/apache/flink/table/data/vector/VectorizedColumnBatchTest.java
+++ b/flink-table/flink-table-runtime/src/test/java/org/apache/flink/table/data/vector/VectorizedColumnBatchTest.java
@@ -176,7 +176,8 @@ public class VectorizedColumnBatchTest {
                             julianDay |= (bytes[i] & (0xff));
                         }
                         long millisecond =
-                                (julianDay - 2440588) * DateTimeUtils.MILLIS_PER_DAY
+                                (julianDay - DateTimeUtils.EPOCH_JULIAN)
+                                                * DateTimeUtils.MILLIS_PER_DAY
                                         + nanoOfDay / 1000000;
                         int nanoOfMillisecond = (int) (nanoOfDay % 1000000);
                         return TimestampData.fromEpochMillis(millisecond, nanoOfMillisecond);

--- a/flink-table/flink-table-runtime/src/test/java/org/apache/flink/table/data/vector/VectorizedColumnBatchTest.java
+++ b/flink-table/flink-table-runtime/src/test/java/org/apache/flink/table/data/vector/VectorizedColumnBatchTest.java
@@ -176,8 +176,7 @@ public class VectorizedColumnBatchTest {
                             julianDay |= (bytes[i] & (0xff));
                         }
                         long millisecond =
-                                (julianDay - DateTimeUtils.EPOCH_JULIAN)
-                                                * DateTimeUtils.MILLIS_PER_DAY
+                                (julianDay - 2440588) * DateTimeUtils.MILLIS_PER_DAY
                                         + nanoOfDay / 1000000;
                         int nanoOfMillisecond = (int) (nanoOfDay % 1000000);
                         return TimestampData.fromEpochMillis(millisecond, nanoOfMillisecond);


### PR DESCRIPTION
## What is the purpose of the change

This PR is the last step of reorganizing our printing and date time utils code, as followed by FLINK-21456. This PR cleanups the `DateTimeUtils` class, trying to reduce the surface of the class as much as possible.

## Brief change log

* Moved `TimestampStringUtil` in an appropriate package and document it
* Add a test for `BuildInMethods` class to make sure every reflection defined there is valid
* Cleanup of `DateTimeUtils`. This involves:
  * The types handled by this utils are: `TimestampData`, timestamp as millis, timestamp as unix timestamp, date and time as ints (internal types).
  * Renamed all the methods for parsing strings to date/time/timestamp as `parse[type]`
  * Renamed all the methods for formatting strings to `format[type]`
  * Renamed the methods to convert from internal to external types as `to[externalTypeName]` and `toInternal`
  * Moved methods around the class to reorganize them in categories. Future PRs might split these "categories" in different utils classes (where some of these can be moved back to planner and/or runtime)
  * Whenever possible, moved some methods in the only place where they're used
  * Removed all the date sub/add, which are unused by the runtime
  * Removed all the unused public overloads
  * Removed private unused methods
* Now AbstractCodeGeneratorCastRule generates a `CastExecutor` that properly wraps the generated exception in a `TableException`

## Verifying this change

Added `BuildInMethodsTest` to make sure the class `BuildInMethods` is sane and declares only existing methods. The rest of the changes should be widely covered by the expression tests.

## Does this pull request potentially affect one of the following parts:

  - Dependencies (does it add or upgrade a dependency): no
  - The public API, i.e., is any changed class annotated with `@Public(Evolving)`: no
  - The serializers: no
  - The runtime per-record code paths (performance sensitive): no
  - Anything that affects deployment or recovery: JobManager (and its components), Checkpointing, Kubernetes/Yarn, ZooKeeper: no
  - The S3 file system connector: no

## Documentation

  - Does this pull request introduce a new feature? no
  - If yes, how is the feature documented? not applicable
