### PR TITLE
[FLINK-24971][tests] Adding retry mechanism in case git clone fails

### DIFF
--- a/flink-end-to-end-tests/test-scripts/common.sh
+++ b/flink-end-to-end-tests/test-scripts/common.sh
@@ -821,6 +821,27 @@ function retry_times_with_backoff_and_cleanup() {
     return 1
 }
 
+function retry_times_with_exponential_backoff {
+  local retries=$1
+  shift
+
+  local count=0
+  echo "Executing command:" "$@"
+  until "$@"; do
+    exit=$?
+    wait=$((2 ** $count))
+    count=$(($count + 1))
+    if [ $count -lt $retries ]; then
+      echo "Retry $count/$retries exited $exit, retrying in $wait seconds..."
+      sleep $wait
+    else
+      echo "Retry $count/$retries exited $exit, no more retries left."
+      return $exit
+    fi
+  done
+  return 0
+}
+
 JOB_ID_REGEX_EXTRACTOR=".*JobID ([0-9,a-f]*)"
 
 function extract_job_id_from_job_submission_return() {

--- a/flink-end-to-end-tests/test-scripts/common_ssl.sh
+++ b/flink-end-to-end-tests/test-scripts/common_ssl.sh
@@ -77,7 +77,8 @@ function _set_conf_ssl_helper {
         # -> we need to build it ourselves
         FLINK_SHADED_VERSION=$(cat ${END_TO_END_DIR}/../pom.xml | sed -n 's/.*<flink.shaded.version>\(.*\)<\/flink.shaded.version>/\1/p')
         echo "BUILDING flink-shaded-netty-tcnative-static"
-        git clone https://github.com/apache/flink-shaded.git
+        # Adding retry to git clone, due to FLINK-24971
+        retry_times_with_exponential_backoff 5 git clone https://github.com/apache/flink-shaded.git
         cd flink-shaded
         git checkout "release-${FLINK_SHADED_VERSION}"
         run_mvn clean package -Pinclude-netty-tcnative-static -pl flink-shaded-netty-tcnative-static


### PR DESCRIPTION
## What is the purpose of the change

* There are multiple occurrences of the Bash based `Streaming File Sink s3 end-to-end test stalled on azure` failing. After analysis, all failures have in common that git clone of flink-shaded is failing. This PR introduces a retry mechanism in case a git clone fails. 

## Brief change log

* Added retry mechanism to git clone of flink-shaded

## Verifying this change

This change is a trivial rework / code cleanup without any test coverage.

## Does this pull request potentially affect one of the following parts:

  - Dependencies (does it add or upgrade a dependency): (yes / **no**)
  - The public API, i.e., is any changed class annotated with `@Public(Evolving)`: (yes / **no**)
  - The serializers: (yes / **no** / don't know)
  - The runtime per-record code paths (performance sensitive): (yes / **no** / don't know)
  - Anything that affects deployment or recovery: JobManager (and its components), Checkpointing, Kubernetes/Yarn, ZooKeeper: (yes / **no** / don't know)
  - The S3 file system connector: (yes / **no** / don't know)

## Documentation

  - Does this pull request introduce a new feature? (yes / **no**)
  - If yes, how is the feature documented? (**not applicable** / docs / JavaDocs / not documented)
