### PR TITLE
[FLINK-24938][scheduler] Shutdown checkpoint cleaner after shutting down checkpoints services

### DIFF
--- a/flink-runtime/src/main/java/org/apache/flink/runtime/scheduler/SchedulerBase.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/scheduler/SchedulerBase.java
@@ -610,12 +610,12 @@ public abstract class SchedulerBase implements SchedulerNG, CheckpointScheduling
         final FlinkException cause = new FlinkException("Scheduler is being stopped.");
 
         final CompletableFuture<Void> checkpointServicesShutdownFuture =
-                CompletableFuture.allOf(
-                        executionGraph
-                                .getTerminationFuture()
-                                .thenAcceptAsync(
-                                        this::shutDownCheckpointServices, getMainThreadExecutor()),
-                        checkpointsCleaner.closeAsync());
+                executionGraph
+                        .getTerminationFuture()
+                        .thenAcceptAsync(this::shutDownCheckpointServices, getMainThreadExecutor())
+                        // checkpoints cleaner is used when stopping checkpoint services, thus it
+                        // must be closed afterwards
+                        .thenAcceptAsync(ignored -> checkpointsCleaner.closeAsync());
         FutureUtils.assertNoException(checkpointServicesShutdownFuture);
 
         incrementVersionsOfAllVertices();


### PR DESCRIPTION
## What is the purpose of the change


Checkpoint services might use the checkpoint cleaner when shutting down.
Therefore the cleaner must be shut afterwards.


## Verifying this change

Added tests in `DefaultSchedulerTest` & `AdaptiveSchedulerTest`
## Does this pull request potentially affect one of the following parts:

  - Dependencies (does it add or upgrade a dependency): (yes / **no**)
  - The public API, i.e., is any changed class annotated with `@Public(Evolving)`: (yes / **no**)
  - The serializers: (yes / **no** / don't know)
  - The runtime per-record code paths (performance sensitive): (yes / **no** / don't know)
  - Anything that affects deployment or recovery: JobManager (and its components), Checkpointing, Kubernetes/Yarn, ZooKeeper: (**yes** / no / don't know)
  - The S3 file system connector: (yes / **no** / don't know)

## Documentation

  - Does this pull request introduce a new feature? (yes / **no**)
  - If yes, how is the feature documented? (**not applicable** / docs / JavaDocs / not documented)
