### PR TITLE
[FLINK-24077][hbase2/HBaseConnectorITCase] fix flaky tests

### DIFF
--- a/flink-connectors/flink-connector-hbase-2.2/src/test/java/org/apache/flink/connector/hbase2/HBaseConnectorITCase.java
+++ b/flink-connectors/flink-connector-hbase-2.2/src/test/java/org/apache/flink/connector/hbase2/HBaseConnectorITCase.java
@@ -21,10 +21,12 @@ package org.apache.flink.connector.hbase2;
 import org.apache.flink.api.common.typeinfo.TypeInformation;
 import org.apache.flink.api.common.typeinfo.Types;
 import org.apache.flink.api.java.typeutils.RowTypeInfo;
+import org.apache.flink.configuration.Configuration;
 import org.apache.flink.connector.hbase.util.HBaseTableSchema;
 import org.apache.flink.connector.hbase2.source.AbstractTableInputFormat;
 import org.apache.flink.connector.hbase2.source.HBaseRowDataInputFormat;
 import org.apache.flink.connector.hbase2.util.HBaseTestBase;
+import org.apache.flink.runtime.testutils.MiniClusterResourceConfiguration;
 import org.apache.flink.streaming.api.datastream.DataStream;
 import org.apache.flink.streaming.api.environment.StreamExecutionEnvironment;
 import org.apache.flink.table.api.Table;
@@ -32,6 +34,7 @@ import org.apache.flink.table.api.TableEnvironment;
 import org.apache.flink.table.api.TableResult;
 import org.apache.flink.table.api.bridge.java.StreamTableEnvironment;
 import org.apache.flink.table.functions.ScalarFunction;
+import org.apache.flink.test.util.MiniClusterWithClientResource;
 import org.apache.flink.test.util.TestBaseUtils;
 import org.apache.flink.types.Row;
 import org.apache.flink.types.RowKind;
@@ -41,6 +44,7 @@ import org.apache.flink.shaded.guava30.com.google.common.collect.Lists;
 
 import org.apache.hadoop.hbase.TableName;
 import org.apache.hadoop.hbase.util.Bytes;
+import org.junit.ClassRule;
 import org.junit.Test;
 
 import java.io.IOException;
@@ -56,6 +60,13 @@ import static org.junit.Assert.assertNull;
 
 /** IT cases for HBase connector (including source and sink). */
 public class HBaseConnectorITCase extends HBaseTestBase {
+
+    @ClassRule
+    public static final MiniClusterWithClientResource MINI_CLUSTER =
+            new MiniClusterWithClientResource(
+                    new MiniClusterResourceConfiguration.Builder()
+                            .setConfiguration(new Configuration())
+                            .build());
 
     // -------------------------------------------------------------------------------------
     // HBaseTableSource tests
@@ -294,8 +305,6 @@ public class HBaseConnectorITCase extends HBaseTestBase {
                                 + " AS h");
 
         TableResult tableResult2 = table.execute();
-        // wait to finish
-        tableResult2.getJobClient().get().getJobExecutionResult().get();
 
         List<Row> results = CollectionUtil.iteratorToList(tableResult2.collect());
 
@@ -379,8 +388,6 @@ public class HBaseConnectorITCase extends HBaseTestBase {
                         + " AS h";
 
         TableResult tableResult3 = batchEnv.executeSql(query);
-        // wait to finish
-        tableResult3.getJobClient().get().getJobExecutionResult().get();
 
         List<String> result =
                 Lists.newArrayList(tableResult3.collect()).stream()


### PR DESCRIPTION
## What is the purpose of the change

there are multiple failing tests during CI only happened for `hbase2`. The potential reason might be some race conditions while running the CI on azure. This PR adds some additional checks and explicitly method calls to make sure the result has been fetched before doing the assertions. Local checks haven been done multiple times and none failing test happened.

## Brief change log

  - add check of row count after insert
  - explicitly call await() for batch select

## Verifying this change

This change is a trivial rework / test case improvement.

## Does this pull request potentially affect one of the following parts:

  - Dependencies (does it add or upgrade a dependency): (yes / **no**)
  - The public API, i.e., is any changed class annotated with `@Public(Evolving)`: (yes / **no**)
  - The serializers: (yes / **no** / don't know)
  - The runtime per-record code paths (performance sensitive): (yes / **no** / don't know)
  - Anything that affects deployment or recovery: JobManager (and its components), Checkpointing, Kubernetes/Yarn, ZooKeeper: (yes / **no** / don't know)
  - The S3 file system connector: (yes / **no** / don't know)

## Documentation

  - Does this pull request introduce a new feature? (yes / **no**)
