### PR TITLE
[BP-1.14][FLINK-24624][k8s] Clean up residual k8s resources  when starting kubernetes session or application cluster failed

### DIFF
--- a/flink-kubernetes/src/test/java/org/apache/flink/kubernetes/KubernetesClientTestBase.java
+++ b/flink-kubernetes/src/test/java/org/apache/flink/kubernetes/KubernetesClientTestBase.java
@@ -92,6 +92,14 @@ public class KubernetesClientTestBase extends KubernetesTestBase {
         server.expect().get().withPath(path).andReturn(200, expectedService).always();
     }
 
+    protected void mockFirstEmptyFollowByExpectedServiceFromServerSide(Service expectedService) {
+        final String serviceName = expectedService.getMetadata().getName();
+        final String path =
+                String.format("/api/v1/namespaces/%s/services/%s", NAMESPACE, serviceName);
+        server.expect().get().withPath(path).andReturn(404, new Service()).once();
+        server.expect().get().withPath(path).andReturn(200, expectedService).always();
+    }
+
     protected void mockCreateConfigMapAlreadyExisting(ConfigMap configMap) {
         final String path =
                 String.format(

--- a/flink-kubernetes/src/test/java/org/apache/flink/kubernetes/KubernetesClusterDescriptorTest.java
+++ b/flink-kubernetes/src/test/java/org/apache/flink/kubernetes/KubernetesClusterDescriptorTest.java
@@ -131,16 +131,14 @@ public class KubernetesClusterDescriptorTest extends KubernetesClientTestBase {
     }
 
     @Test
-    public void testDeployApplicationCluster() {
+    public void testDeployApplicationCluster() throws ClusterDeploymentException {
         flinkConfig.set(
                 PipelineOptions.JARS, Collections.singletonList("local:///path/of/user.jar"));
         flinkConfig.set(DeploymentOptions.TARGET, KubernetesDeploymentTarget.APPLICATION.getName());
-        try {
-            descriptor.deployApplicationCluster(clusterSpecification, appConfig);
-        } catch (Exception ignored) {
-        }
 
-        mockExpectedServiceFromServerSide(loadBalancerSvc);
+        mockFirstEmptyFollowByExpectedServiceFromServerSide(loadBalancerSvc);
+        descriptor.deployApplicationCluster(clusterSpecification, appConfig);
+
         final ClusterClient<String> clusterClient =
                 descriptor.retrieve(CLUSTER_ID).getClusterClient();
         checkClusterClient(clusterClient);


### PR DESCRIPTION
Backport #17554 to 1.14.