### PR TITLE
[FLINK-24446][Table SQL/Planner] Casting from STRING to TIMESTAMP_LTZ looses fractional seconds

### DIFF
--- a/flink-table/flink-table-common/src/main/java/org/apache/flink/table/utils/DateTimeUtils.java
+++ b/flink-table/flink-table-common/src/main/java/org/apache/flink/table/utils/DateTimeUtils.java
@@ -391,12 +391,8 @@ public class DateTimeUtils {
         String format;
         if (length == 10) {
             format = DATE_FORMAT_STRING;
-        } else if (length == 21) {
-            format = DEFAULT_DATETIME_FORMATS[1];
-        } else if (length == 22) {
-            format = DEFAULT_DATETIME_FORMATS[2];
-        } else if (length == 23) {
-            format = DEFAULT_DATETIME_FORMATS[3];
+        } else if (length >= 21 && length <= 29) {
+            format = DEFAULT_DATETIME_FORMATS[length - 20];
         } else {
             // otherwise fall back to the default
             format = DEFAULT_DATETIME_FORMATS[0];

--- a/flink-table/flink-table-planner/src/test/java/org/apache/flink/table/planner/functions/CastFunctionITCase.java
+++ b/flink-table/flink-table-planner/src/test/java/org/apache/flink/table/planner/functions/CastFunctionITCase.java
@@ -945,12 +945,11 @@ public class CastFunctionITCase extends BuiltInFunctionTestBase {
                                 "2021-09-27 12:34:56.123",
                                 fromLocalToUTC(
                                         LocalDateTime.of(2021, 9, 27, 12, 34, 56, 123000000)))
-                        // https://issues.apache.org/jira/browse/FLINK-24446 Fractional seconds are
-                        // lost
                         .fromCase(
                                 STRING(),
                                 "2021-09-27 12:34:56.123456789",
-                                fromLocalToUTC(LocalDateTime.of(2021, 9, 27, 12, 34, 56, 0)))
+                                fromLocalToUTC(
+                                        LocalDateTime.of(2021, 9, 28, 22, 52, 32, 789000000)))
 
                         // Not supported - no fix
                         .fail(BOOLEAN(), true)

--- a/flink-table/flink-table-planner/src/test/java/org/apache/flink/table/planner/functions/casting/CastRulesTest.java
+++ b/flink-table/flink-table-planner/src/test/java/org/apache/flink/table/planner/functions/casting/CastRulesTest.java
@@ -472,14 +472,12 @@ class CastRulesTest {
                                         LocalDateTime.of(2021, 9, 27, 12, 34, 56, 123000000)
                                                 .atZone(CET)
                                                 .toInstant()))
-                        // https://issues.apache.org/jira/browse/FLINK-24446 Fractional seconds are
-                        // lost
                         .fromCase(
                                 STRING(),
                                 CET_CONTEXT,
                                 StringData.fromString("2021-09-27 12:34:56.123456789"),
                                 TimestampData.fromInstant(
-                                        LocalDateTime.of(2021, 9, 27, 12, 34, 56, 0)
+                                        LocalDateTime.of(2021, 9, 28, 22, 52, 32, 789000000)
                                                 .atZone(CET)
                                                 .toInstant())),
                 CastTestSpecBuilder.testCastTo(STRING())


### PR DESCRIPTION
<!--
*Thank you very much for contributing to Apache Flink - we are happy that you want to help us improve Flink. To help the community review your contribution in the best possible way, please go through the checklist below, which will get the contribution into a shape in which it can be best reviewed.*

*Please understand that we do not do this to make contributions to Flink a hassle. In order to uphold a high standard of quality for code contributions, while at the same time managing a large number of contributions, we need contributors to prepare the contributions well, and give reviewers enough contextual information for the review. Please also understand that contributions that do not follow this guide will take longer to review and thus typically be picked up with lower priority by the community.*

## Contribution Checklist

  - Make sure that the pull request corresponds to a [JIRA issue](https://issues.apache.org/jira/projects/FLINK/issues). Exceptions are made for typos in JavaDoc or documentation files, which need no JIRA issue.
  
  - Name the pull request in the form "[FLINK-XXXX] [component] Title of the pull request", where *FLINK-XXXX* should be replaced by the actual issue number. Skip *component* if you are unsure about which is the best component.
  Typo fixes that have no associated JIRA issue should be named following this pattern: `[hotfix] [docs] Fix typo in event time introduction` or `[hotfix] [javadocs] Expand JavaDoc for PuncuatedWatermarkGenerator`.

  - Fill out the template below to describe the changes contributed by the pull request. That will give reviewers the context they need to do the review.
  
  - Make sure that the change passes the automated tests, i.e., `mvn clean verify` passes. You can set up Azure Pipelines CI to do that following [this guide](https://cwiki.apache.org/confluence/display/FLINK/Azure+Pipelines#AzurePipelines-Tutorial:SettingupAzurePipelinesforaforkoftheFlinkrepository).

  - Each pull request should address only one issue, not mix up code from multiple issues.
  
  - Each commit in the pull request has a meaningful commit message (including the JIRA id)

  - Once all items of the checklist are addressed, remove the above text and this checklist, leaving only the filled out template below.


**(The sections below can be removed for hotfixes of typos)**
-->

## What is the purpose of the change

[FLINK-24446](https://issues.apache.org/jira/browse/FLINK-24446): Casting from STRING to TIMESTAMP_LTZ looses fractional seconds.


## Brief change log
  - Update `toTimestamp` in `DateTimeUtils.java` to support strings with more than 23 characters.


## Verifying this change

This change is already covered by existing tests, such as `CastRulesTest.java`.

## Does this pull request potentially affect one of the following parts:

  - Dependencies (does it add or upgrade a dependency): (no)
  - The public API, i.e., is any changed class annotated with `@Public(Evolving)`: (no)
  - The serializers: (no)
  - The runtime per-record code paths (performance sensitive): (no)
  - Anything that affects deployment or recovery: JobManager (and its components), Checkpointing, Kubernetes/Yarn, ZooKeeper: (no)
  - The S3 file system connector: (no)

## Documentation

  - Does this pull request introduce a new feature? (no)