### PR TITLE
[FLINK-24980] Introduce numBytesProduced counter into ResultPartition to record the size of result partition.

### DIFF
--- a/flink-runtime/src/main/java/org/apache/flink/runtime/executiongraph/IOMetrics.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/executiongraph/IOMetrics.java
@@ -18,9 +18,13 @@
 
 package org.apache.flink.runtime.executiongraph;
 
+import org.apache.flink.metrics.Counter;
 import org.apache.flink.metrics.Meter;
+import org.apache.flink.runtime.jobgraph.IntermediateResultPartitionID;
 
 import java.io.Serializable;
+import java.util.HashMap;
+import java.util.Map;
 
 /** An instance of this class represents a snapshot of the io-related metrics of a single task. */
 public class IOMetrics implements Serializable {
@@ -33,11 +37,24 @@ public class IOMetrics implements Serializable {
     protected long numBytesIn;
     protected long numBytesOut;
 
-    public IOMetrics(Meter recordsIn, Meter recordsOut, Meter bytesIn, Meter bytesOut) {
+    protected final Map<IntermediateResultPartitionID, Long> numBytesProducedOfPartitions =
+            new HashMap<>();
+
+    public IOMetrics(
+            Meter recordsIn,
+            Meter recordsOut,
+            Meter bytesIn,
+            Meter bytesOut,
+            Map<IntermediateResultPartitionID, Counter> numBytesProducedCounters) {
         this.numRecordsIn = recordsIn.getCount();
         this.numRecordsOut = recordsOut.getCount();
         this.numBytesIn = bytesIn.getCount();
         this.numBytesOut = bytesOut.getCount();
+
+        for (Map.Entry<IntermediateResultPartitionID, Counter> counter :
+                numBytesProducedCounters.entrySet()) {
+            numBytesProducedOfPartitions.put(counter.getKey(), counter.getValue().getCount());
+        }
     }
 
     public IOMetrics(long numBytesIn, long numBytesOut, long numRecordsIn, long numRecordsOut) {
@@ -61,5 +78,9 @@ public class IOMetrics implements Serializable {
 
     public long getNumBytesOut() {
         return numBytesOut;
+    }
+
+    public Map<IntermediateResultPartitionID, Long> getNumBytesProducedOfPartitions() {
+        return numBytesProducedOfPartitions;
     }
 }

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/io/network/partition/BufferWritingResultPartition.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/io/network/partition/BufferWritingResultPartition.java
@@ -391,7 +391,9 @@ public abstract class BufferWritingResultPartition extends ResultPartition {
     private void finishUnicastBufferBuilder(int targetSubpartition) {
         final BufferBuilder bufferBuilder = unicastBufferBuilders[targetSubpartition];
         if (bufferBuilder != null) {
-            numBytesOut.inc(bufferBuilder.finish());
+            int bytes = bufferBuilder.finish();
+            numBytesProduced.inc(bytes);
+            numBytesOut.inc(bytes);
             numBuffersOut.inc();
             unicastBufferBuilders[targetSubpartition] = null;
             bufferBuilder.close();
@@ -406,7 +408,9 @@ public abstract class BufferWritingResultPartition extends ResultPartition {
 
     private void finishBroadcastBufferBuilder() {
         if (broadcastBufferBuilder != null) {
-            numBytesOut.inc(broadcastBufferBuilder.finish() * numSubpartitions);
+            int bytes = broadcastBufferBuilder.finish();
+            numBytesProduced.inc(bytes);
+            numBytesOut.inc(bytes * numSubpartitions);
             numBuffersOut.inc(numSubpartitions);
             broadcastBufferBuilder.close();
             broadcastBufferBuilder = null;

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/io/network/partition/ResultPartition.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/io/network/partition/ResultPartition.java
@@ -111,6 +111,14 @@ public abstract class ResultPartition implements ResultPartitionWriter {
 
     protected Counter numBuffersOut = new SimpleCounter();
 
+    /**
+     * The difference with {@link #numBytesOut} : numBytesProduced represents the number of bytes
+     * actually produced, and numBytesOut represents the number of bytes sent to downstream tasks.
+     * In unicast scenarios, these two values should be equal. In broadcast scenarios, numBytesOut
+     * should be (N * numBytesProduced), where N refers to the number of subpartitions.
+     */
+    protected Counter numBytesProduced = new SimpleCounter();
+
     public ResultPartition(
             String owningTaskName,
             int partitionIndex,
@@ -281,6 +289,8 @@ public abstract class ResultPartition implements ResultPartitionWriter {
     public void setMetricGroup(TaskIOMetricGroup metrics) {
         numBytesOut = metrics.getNumBytesOutCounter();
         numBuffersOut = metrics.getNumBuffersOutCounter();
+        metrics.registerNumBytesProducedCounterForPartition(
+                partitionId.getPartitionId(), numBytesProduced);
     }
 
     /**

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/io/network/partition/SortMergeResultPartition.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/io/network/partition/SortMergeResultPartition.java
@@ -362,6 +362,7 @@ public class SortMergeResultPartition extends ResultPartition {
     private void updateStatistics(Buffer buffer, boolean isBroadcast) {
         numBuffersOut.inc(isBroadcast ? numSubpartitions : 1);
         long readableBytes = buffer.readableBytes();
+        numBytesProduced.inc(readableBytes);
         numBytesOut.inc(isBroadcast ? readableBytes * numSubpartitions : readableBytes);
     }
 

--- a/flink-runtime/src/test/java/org/apache/flink/runtime/io/network/partition/ResultPartitionTest.java
+++ b/flink-runtime/src/test/java/org/apache/flink/runtime/io/network/partition/ResultPartitionTest.java
@@ -822,6 +822,44 @@ public class ResultPartitionTest {
         assertEquals(bufferSize, subpartition1.pollBuffer().buffer().getSize());
     }
 
+    @Test
+    public void testNumBytesProducedCounterForUnicast() throws IOException {
+        testNumBytesProducedCounter(false);
+    }
+
+    @Test
+    public void testNumBytesProducedCounterForBroadcast() throws IOException {
+        testNumBytesProducedCounter(true);
+    }
+
+    private void testNumBytesProducedCounter(boolean isBroadcast) throws IOException {
+        TestResultPartitionConsumableNotifier notifier =
+                new TestResultPartitionConsumableNotifier();
+        JobID jobId = new JobID();
+        TaskActions taskActions = new NoOpTaskActions();
+        BufferWritingResultPartition bufferWritingResultPartition =
+                createResultPartition(ResultPartitionType.BLOCKING);
+        ResultPartitionWriter partitionWriter =
+                ConsumableNotifyingResultPartitionWriterDecorator.decorate(
+                        Collections.singleton(
+                                PartitionTestUtils.createPartitionDeploymentDescriptor(
+                                        ResultPartitionType.BLOCKING)),
+                        new ResultPartitionWriter[] {bufferWritingResultPartition},
+                        taskActions,
+                        jobId,
+                        notifier)[0];
+
+        if (isBroadcast) {
+            partitionWriter.broadcastRecord(ByteBuffer.allocate(bufferSize));
+            assertEquals(bufferSize, bufferWritingResultPartition.numBytesProduced.getCount());
+            assertEquals(2 * bufferSize, bufferWritingResultPartition.numBytesOut.getCount());
+        } else {
+            partitionWriter.emitRecord(ByteBuffer.allocate(bufferSize), 0);
+            assertEquals(bufferSize, bufferWritingResultPartition.numBytesProduced.getCount());
+            assertEquals(bufferSize, bufferWritingResultPartition.numBytesOut.getCount());
+        }
+    }
+
     private static class TestResultPartitionConsumableNotifier
             implements ResultPartitionConsumableNotifier {
         private JobID jobID;

--- a/flink-runtime/src/test/java/org/apache/flink/runtime/metrics/groups/TaskIOMetricGroupTest.java
+++ b/flink-runtime/src/test/java/org/apache/flink/runtime/metrics/groups/TaskIOMetricGroupTest.java
@@ -21,8 +21,11 @@ package org.apache.flink.runtime.metrics.groups;
 import org.apache.flink.metrics.Counter;
 import org.apache.flink.metrics.SimpleCounter;
 import org.apache.flink.runtime.executiongraph.IOMetrics;
+import org.apache.flink.runtime.jobgraph.IntermediateResultPartitionID;
 
 import org.junit.Test;
+
+import java.util.Map;
 
 import static org.hamcrest.Matchers.greaterThanOrEqualTo;
 import static org.junit.Assert.assertEquals;
@@ -70,5 +73,29 @@ public class TaskIOMetricGroupTest {
         assertThat(taskIO.getIdleTimeMsPerSecond().getCount(), greaterThanOrEqualTo(sleepTime));
         assertThat(
                 taskIO.getBackPressuredTimePerSecond().getCount(), greaterThanOrEqualTo(sleepTime));
+    }
+
+    @Test
+    public void testNumBytesProducedOfPartitionsMetrics() {
+        TaskMetricGroup task = UnregisteredMetricGroups.createUnregisteredTaskMetricGroup();
+        TaskIOMetricGroup taskIO = task.getIOMetricGroup();
+
+        Counter c1 = new SimpleCounter();
+        c1.inc(32L);
+        Counter c2 = new SimpleCounter();
+        c2.inc(64L);
+
+        IntermediateResultPartitionID resultPartitionID1 = new IntermediateResultPartitionID();
+        IntermediateResultPartitionID resultPartitionID2 = new IntermediateResultPartitionID();
+
+        taskIO.registerNumBytesProducedCounterForPartition(resultPartitionID1, c1);
+        taskIO.registerNumBytesProducedCounterForPartition(resultPartitionID2, c2);
+
+        Map<IntermediateResultPartitionID, Long> numBytesProducedOfPartitions =
+                taskIO.createSnapshot().getNumBytesProducedOfPartitions();
+
+        assertEquals(2, numBytesProducedOfPartitions.size());
+        assertEquals(32L, numBytesProducedOfPartitions.get(resultPartitionID1).longValue());
+        assertEquals(64L, numBytesProducedOfPartitions.get(resultPartitionID2).longValue());
     }
 }


### PR DESCRIPTION
## What is the purpose of the change

The adaptive batch scheduler needs to know the size of each result partition when the task is finished.

This pr will introduce the numBytesProduced counter and register it into TaskIOMetricGroup, to record the size of each result partition. 

## Brief change log

  - Introduce numBytesProduced counter into ResultPartition to record the size of result partition.


## Verifying this change

Add some unit tests.

## Does this pull request potentially affect one of the following parts:

  - Dependencies (does it add or upgrade a dependency): (no)
  - The public API, i.e., is any changed class annotated with `@Public(Evolving)`: (no)
  - The serializers: (no)
  - The runtime per-record code paths (performance sensitive): (no)
  - Anything that affects deployment or recovery: JobManager (and its components), Checkpointing, Kubernetes/Yarn, ZooKeeper: (no)
  - The S3 file system connector: (no)

## Documentation

  - Does this pull request introduce a new feature? (no)
  - If yes, how is the feature documented? (not applicable)
