### PR TITLE
[FLINK-25060][table-common] Replace DataType.projectFields with Projection type

### DIFF
--- a/flink-connectors/flink-connector-elasticsearch-base/src/main/java/org/apache/flink/connector/elasticsearch/table/ElasticsearchDynamicSinkFactoryBase.java
+++ b/flink-connectors/flink-connector-elasticsearch-base/src/main/java/org/apache/flink/connector/elasticsearch/table/ElasticsearchDynamicSinkFactoryBase.java
@@ -25,6 +25,7 @@ import org.apache.flink.configuration.Configuration;
 import org.apache.flink.table.api.ValidationException;
 import org.apache.flink.table.catalog.Column;
 import org.apache.flink.table.catalog.ResolvedSchema;
+import org.apache.flink.table.connector.Projection;
 import org.apache.flink.table.connector.format.EncodingFormat;
 import org.apache.flink.table.connector.sink.DynamicTableSink;
 import org.apache.flink.table.data.RowData;
@@ -170,7 +171,7 @@ abstract class ElasticsearchDynamicSinkFactoryBase implements DynamicTableSinkFa
         DataType physicalRowDataType = context.getPhysicalRowDataType();
         int[] primaryKeyIndexes = context.getPrimaryKeyIndexes();
         if (primaryKeyIndexes.length != 0) {
-            DataType pkDataType = DataType.projectFields(physicalRowDataType, primaryKeyIndexes);
+            DataType pkDataType = Projection.of(primaryKeyIndexes).project(physicalRowDataType);
 
             ElasticsearchValidationUtils.validatePrimaryKey(pkDataType);
         }

--- a/flink-connectors/flink-connector-hbase-base/src/main/java/org/apache/flink/connector/hbase/source/AbstractHBaseDynamicTableSource.java
+++ b/flink-connectors/flink-connector-hbase-base/src/main/java/org/apache/flink/connector/hbase/source/AbstractHBaseDynamicTableSource.java
@@ -24,6 +24,7 @@ import org.apache.flink.api.common.io.InputFormat;
 import org.apache.flink.connector.hbase.options.HBaseLookupOptions;
 import org.apache.flink.connector.hbase.util.HBaseTableSchema;
 import org.apache.flink.table.connector.ChangelogMode;
+import org.apache.flink.table.connector.Projection;
 import org.apache.flink.table.connector.source.InputFormatProvider;
 import org.apache.flink.table.connector.source.LookupTableSource;
 import org.apache.flink.table.connector.source.ScanTableSource;
@@ -96,7 +97,7 @@ public abstract class AbstractHBaseDynamicTableSource
     public void applyProjection(int[][] projectedFields, DataType producedDataType) {
         this.hbaseSchema =
                 HBaseTableSchema.fromDataType(
-                        DataType.projectFields(hbaseSchema.convertToDataType(), projectedFields));
+                        Projection.of(projectedFields).project(hbaseSchema.convertToDataType()));
     }
 
     @Override

--- a/flink-connectors/flink-connector-jdbc/src/main/java/org/apache/flink/connector/jdbc/table/JdbcDynamicTableSource.java
+++ b/flink-connectors/flink-connector-jdbc/src/main/java/org/apache/flink/connector/jdbc/table/JdbcDynamicTableSource.java
@@ -25,6 +25,7 @@ import org.apache.flink.connector.jdbc.internal.options.JdbcLookupOptions;
 import org.apache.flink.connector.jdbc.internal.options.JdbcReadOptions;
 import org.apache.flink.connector.jdbc.split.JdbcNumericBetweenParametersProvider;
 import org.apache.flink.table.connector.ChangelogMode;
+import org.apache.flink.table.connector.Projection;
 import org.apache.flink.table.connector.source.DynamicTableSource;
 import org.apache.flink.table.connector.source.InputFormatProvider;
 import org.apache.flink.table.connector.source.LookupTableSource;
@@ -143,7 +144,7 @@ public class JdbcDynamicTableSource
 
     @Override
     public void applyProjection(int[][] projectedFields, DataType producedDataType) {
-        this.physicalRowDataType = DataType.projectFields(physicalRowDataType, projectedFields);
+        this.physicalRowDataType = Projection.of(projectedFields).project(physicalRowDataType);
     }
 
     @Override

--- a/flink-connectors/flink-connector-kafka/src/main/java/org/apache/flink/streaming/connectors/kafka/table/KafkaDynamicSink.java
+++ b/flink-connectors/flink-connector-kafka/src/main/java/org/apache/flink/streaming/connectors/kafka/table/KafkaDynamicSink.java
@@ -30,6 +30,7 @@ import org.apache.flink.streaming.api.datastream.DataStreamSink;
 import org.apache.flink.streaming.connectors.kafka.partitioner.FlinkKafkaPartitioner;
 import org.apache.flink.table.api.DataTypes;
 import org.apache.flink.table.connector.ChangelogMode;
+import org.apache.flink.table.connector.Projection;
 import org.apache.flink.table.connector.format.EncodingFormat;
 import org.apache.flink.table.connector.sink.DataStreamSinkProvider;
 import org.apache.flink.table.connector.sink.DynamicTableSink;
@@ -375,8 +376,7 @@ public class KafkaDynamicSink implements DynamicTableSink, SupportsWritingMetada
         if (format == null) {
             return null;
         }
-        DataType physicalFormatDataType =
-                DataTypeUtils.projectRow(this.physicalDataType, projection);
+        DataType physicalFormatDataType = Projection.of(projection).project(this.physicalDataType);
         if (prefix != null) {
             physicalFormatDataType = DataTypeUtils.stripRowPrefix(physicalFormatDataType, prefix);
         }

--- a/flink-connectors/flink-connector-kafka/src/main/java/org/apache/flink/streaming/connectors/kafka/table/KafkaDynamicSource.java
+++ b/flink-connectors/flink-connector-kafka/src/main/java/org/apache/flink/streaming/connectors/kafka/table/KafkaDynamicSource.java
@@ -35,6 +35,7 @@ import org.apache.flink.streaming.connectors.kafka.internals.KafkaTopicPartition
 import org.apache.flink.streaming.connectors.kafka.table.DynamicKafkaDeserializationSchema.MetadataConverter;
 import org.apache.flink.table.api.DataTypes;
 import org.apache.flink.table.connector.ChangelogMode;
+import org.apache.flink.table.connector.Projection;
 import org.apache.flink.table.connector.format.DecodingFormat;
 import org.apache.flink.table.connector.source.DataStreamScanProvider;
 import org.apache.flink.table.connector.source.DynamicTableSource;
@@ -467,8 +468,7 @@ public class KafkaDynamicSource
         if (format == null) {
             return null;
         }
-        DataType physicalFormatDataType =
-                DataTypeUtils.projectRow(this.physicalDataType, projection);
+        DataType physicalFormatDataType = Projection.of(projection).project(this.physicalDataType);
         if (prefix != null) {
             physicalFormatDataType = DataTypeUtils.stripRowPrefix(physicalFormatDataType, prefix);
         }

--- a/flink-formats/flink-avro-confluent-registry/src/main/java/org/apache/flink/formats/avro/registry/confluent/RegistryAvroFormatFactory.java
+++ b/flink-formats/flink-avro-confluent-registry/src/main/java/org/apache/flink/formats/avro/registry/confluent/RegistryAvroFormatFactory.java
@@ -31,6 +31,7 @@ import org.apache.flink.formats.avro.RowDataToAvroConverters;
 import org.apache.flink.formats.avro.typeutils.AvroSchemaConverter;
 import org.apache.flink.table.api.ValidationException;
 import org.apache.flink.table.connector.ChangelogMode;
+import org.apache.flink.table.connector.Projection;
 import org.apache.flink.table.connector.format.DecodingFormat;
 import org.apache.flink.table.connector.format.EncodingFormat;
 import org.apache.flink.table.connector.format.ProjectableDecodingFormat;
@@ -88,7 +89,7 @@ public class RegistryAvroFormatFactory
                     DynamicTableSource.Context context,
                     DataType producedDataType,
                     int[][] projections) {
-                producedDataType = DataType.projectFields(producedDataType, projections);
+                producedDataType = Projection.of(projections).project(producedDataType);
                 final RowType rowType = (RowType) producedDataType.getLogicalType();
                 final TypeInformation<RowData> rowDataTypeInfo =
                         context.createTypeInformation(producedDataType);

--- a/flink-formats/flink-avro-confluent-registry/src/main/java/org/apache/flink/formats/avro/registry/confluent/debezium/DebeziumAvroFormatFactory.java
+++ b/flink-formats/flink-avro-confluent-registry/src/main/java/org/apache/flink/formats/avro/registry/confluent/debezium/DebeziumAvroFormatFactory.java
@@ -26,6 +26,7 @@ import org.apache.flink.configuration.ConfigOption;
 import org.apache.flink.configuration.ReadableConfig;
 import org.apache.flink.table.api.ValidationException;
 import org.apache.flink.table.connector.ChangelogMode;
+import org.apache.flink.table.connector.Projection;
 import org.apache.flink.table.connector.format.DecodingFormat;
 import org.apache.flink.table.connector.format.EncodingFormat;
 import org.apache.flink.table.connector.format.ProjectableDecodingFormat;
@@ -82,7 +83,7 @@ public class DebeziumAvroFormatFactory
                     DynamicTableSource.Context context,
                     DataType producedDataType,
                     int[][] projections) {
-                producedDataType = DataType.projectFields(producedDataType, projections);
+                producedDataType = Projection.of(projections).project(producedDataType);
                 final RowType rowType = (RowType) producedDataType.getLogicalType();
                 final TypeInformation<RowData> producedTypeInfo =
                         context.createTypeInformation(producedDataType);

--- a/flink-formats/flink-avro/src/main/java/org/apache/flink/formats/avro/AvroFormatFactory.java
+++ b/flink-formats/flink-avro/src/main/java/org/apache/flink/formats/avro/AvroFormatFactory.java
@@ -25,6 +25,7 @@ import org.apache.flink.api.common.typeinfo.TypeInformation;
 import org.apache.flink.configuration.ConfigOption;
 import org.apache.flink.configuration.ReadableConfig;
 import org.apache.flink.table.connector.ChangelogMode;
+import org.apache.flink.table.connector.Projection;
 import org.apache.flink.table.connector.format.DecodingFormat;
 import org.apache.flink.table.connector.format.EncodingFormat;
 import org.apache.flink.table.connector.format.ProjectableDecodingFormat;
@@ -62,7 +63,7 @@ public class AvroFormatFactory implements DeserializationFormatFactory, Serializ
                     DataType physicalDataType,
                     int[][] projections) {
                 final DataType producedDataType =
-                        DataType.projectFields(physicalDataType, projections);
+                        Projection.of(projections).project(physicalDataType);
                 final RowType rowType = (RowType) producedDataType.getLogicalType();
                 final TypeInformation<RowData> rowDataTypeInfo =
                         context.createTypeInformation(producedDataType);

--- a/flink-formats/flink-json/src/main/java/org/apache/flink/formats/json/JsonFormatFactory.java
+++ b/flink-formats/flink-json/src/main/java/org/apache/flink/formats/json/JsonFormatFactory.java
@@ -26,6 +26,7 @@ import org.apache.flink.configuration.ConfigOption;
 import org.apache.flink.configuration.ReadableConfig;
 import org.apache.flink.formats.common.TimestampFormat;
 import org.apache.flink.table.connector.ChangelogMode;
+import org.apache.flink.table.connector.Projection;
 import org.apache.flink.table.connector.format.DecodingFormat;
 import org.apache.flink.table.connector.format.EncodingFormat;
 import org.apache.flink.table.connector.format.ProjectableDecodingFormat;
@@ -76,7 +77,7 @@ public class JsonFormatFactory implements DeserializationFormatFactory, Serializ
                     DataType physicalDataType,
                     int[][] projections) {
                 final DataType producedDataType =
-                        DataType.projectFields(physicalDataType, projections);
+                        Projection.of(projections).project(physicalDataType);
                 final RowType rowType = (RowType) producedDataType.getLogicalType();
                 final TypeInformation<RowData> rowDataTypeInfo =
                         context.createTypeInformation(producedDataType);

--- a/flink-formats/flink-json/src/main/java/org/apache/flink/formats/json/canal/CanalJsonDecodingFormat.java
+++ b/flink-formats/flink-json/src/main/java/org/apache/flink/formats/json/canal/CanalJsonDecodingFormat.java
@@ -24,6 +24,7 @@ import org.apache.flink.formats.common.TimestampFormat;
 import org.apache.flink.formats.json.canal.CanalJsonDeserializationSchema.MetadataConverter;
 import org.apache.flink.table.api.DataTypes;
 import org.apache.flink.table.connector.ChangelogMode;
+import org.apache.flink.table.connector.Projection;
 import org.apache.flink.table.connector.format.DecodingFormat;
 import org.apache.flink.table.connector.format.ProjectableDecodingFormat;
 import org.apache.flink.table.connector.source.DynamicTableSource;
@@ -80,7 +81,7 @@ public class CanalJsonDecodingFormat
     @Override
     public DeserializationSchema<RowData> createRuntimeDecoder(
             DynamicTableSource.Context context, DataType physicalDataType, int[][] projections) {
-        physicalDataType = DataType.projectFields(physicalDataType, projections);
+        physicalDataType = Projection.of(projections).project(physicalDataType);
         final List<ReadableMetadata> readableMetadata =
                 metadataKeys.stream()
                         .map(

--- a/flink-formats/flink-json/src/main/java/org/apache/flink/formats/json/debezium/DebeziumJsonDecodingFormat.java
+++ b/flink-formats/flink-json/src/main/java/org/apache/flink/formats/json/debezium/DebeziumJsonDecodingFormat.java
@@ -24,6 +24,7 @@ import org.apache.flink.formats.common.TimestampFormat;
 import org.apache.flink.formats.json.debezium.DebeziumJsonDeserializationSchema.MetadataConverter;
 import org.apache.flink.table.api.DataTypes;
 import org.apache.flink.table.connector.ChangelogMode;
+import org.apache.flink.table.connector.Projection;
 import org.apache.flink.table.connector.format.DecodingFormat;
 import org.apache.flink.table.connector.format.ProjectableDecodingFormat;
 import org.apache.flink.table.connector.source.DynamicTableSource;
@@ -74,7 +75,7 @@ public class DebeziumJsonDecodingFormat
     @Override
     public DeserializationSchema<RowData> createRuntimeDecoder(
             DynamicTableSource.Context context, DataType physicalDataType, int[][] projections) {
-        physicalDataType = DataType.projectFields(physicalDataType, projections);
+        physicalDataType = Projection.of(projections).project(physicalDataType);
 
         final List<ReadableMetadata> readableMetadata =
                 metadataKeys.stream()

--- a/flink-formats/flink-json/src/main/java/org/apache/flink/formats/json/maxwell/MaxwellJsonDecodingFormat.java
+++ b/flink-formats/flink-json/src/main/java/org/apache/flink/formats/json/maxwell/MaxwellJsonDecodingFormat.java
@@ -24,6 +24,7 @@ import org.apache.flink.formats.common.TimestampFormat;
 import org.apache.flink.formats.json.maxwell.MaxwellJsonDeserializationSchema.MetadataConverter;
 import org.apache.flink.table.api.DataTypes;
 import org.apache.flink.table.connector.ChangelogMode;
+import org.apache.flink.table.connector.Projection;
 import org.apache.flink.table.connector.format.DecodingFormat;
 import org.apache.flink.table.connector.format.ProjectableDecodingFormat;
 import org.apache.flink.table.connector.source.DynamicTableSource;
@@ -65,7 +66,7 @@ public class MaxwellJsonDecodingFormat
     @Override
     public DeserializationSchema<RowData> createRuntimeDecoder(
             DynamicTableSource.Context context, DataType physicalDataType, int[][] projections) {
-        physicalDataType = DataType.projectFields(physicalDataType, projections);
+        physicalDataType = Projection.of(projections).project(physicalDataType);
 
         final List<ReadableMetadata> readableMetadata =
                 metadataKeys.stream()

--- a/flink-formats/flink-parquet/src/main/java/org/apache/flink/formats/parquet/ParquetFileFormatFactory.java
+++ b/flink-formats/flink-parquet/src/main/java/org/apache/flink/formats/parquet/ParquetFileFormatFactory.java
@@ -25,6 +25,7 @@ import org.apache.flink.connector.file.src.FileSourceSplit;
 import org.apache.flink.connector.file.src.reader.BulkFormat;
 import org.apache.flink.formats.parquet.row.ParquetRowDataBuilder;
 import org.apache.flink.table.connector.ChangelogMode;
+import org.apache.flink.table.connector.Projection;
 import org.apache.flink.table.connector.format.BulkDecodingFormat;
 import org.apache.flink.table.connector.format.EncodingFormat;
 import org.apache.flink.table.connector.format.ProjectableDecodingFormat;
@@ -128,8 +129,7 @@ public class ParquetFileFormatFactory implements BulkReaderFormatFactory, BulkWr
 
             return ParquetColumnarRowInputFormat.createPartitionedFormat(
                     getParquetConfiguration(formatOptions),
-                    (RowType)
-                            DataType.projectFields(producedDataType, projections).getLogicalType(),
+                    (RowType) Projection.of(projections).project(producedDataType).getLogicalType(),
                     Collections.emptyList(),
                     null,
                     VectorizedColumnBatch.DEFAULT_SIZE,

--- a/flink-table/flink-table-api-java/src/main/java/org/apache/flink/table/catalog/SchemaTranslator.java
+++ b/flink-table/flink-table-api-java/src/main/java/org/apache/flink/table/catalog/SchemaTranslator.java
@@ -27,6 +27,7 @@ import org.apache.flink.table.api.Schema.UnresolvedMetadataColumn;
 import org.apache.flink.table.api.Schema.UnresolvedPhysicalColumn;
 import org.apache.flink.table.api.Schema.UnresolvedPrimaryKey;
 import org.apache.flink.table.api.ValidationException;
+import org.apache.flink.table.connector.Projection;
 import org.apache.flink.table.types.AbstractDataType;
 import org.apache.flink.table.types.DataType;
 import org.apache.flink.table.types.logical.LogicalType;
@@ -36,7 +37,6 @@ import org.apache.flink.table.types.logical.RowType;
 import org.apache.flink.table.types.logical.StructuredType;
 import org.apache.flink.table.types.logical.utils.LogicalTypeChecks;
 import org.apache.flink.table.types.logical.utils.LogicalTypeUtils;
-import org.apache.flink.table.types.utils.DataTypeUtils;
 import org.apache.flink.table.types.utils.TypeInfoDataTypeConverter;
 
 import javax.annotation.Nullable;
@@ -245,7 +245,7 @@ public final class SchemaTranslator {
         }
         // truncate last field
         final int[] indices = IntStream.range(0, columnCount - 1).toArray();
-        return DataTypeUtils.projectRow(dataType, indices);
+        return Projection.of(indices).project(dataType);
     }
 
     private static @Nullable List<String> extractProjections(

--- a/flink-table/flink-table-common/src/main/java/org/apache/flink/table/connector/Projection.java
+++ b/flink-table/flink-table-common/src/main/java/org/apache/flink/table/connector/Projection.java
@@ -19,15 +19,24 @@
 package org.apache.flink.table.connector;
 
 import org.apache.flink.annotation.PublicEvolving;
+import org.apache.flink.table.api.DataTypes;
 import org.apache.flink.table.data.RowData;
 import org.apache.flink.table.types.DataType;
+import org.apache.flink.table.types.FieldsDataType;
+import org.apache.flink.table.types.logical.LogicalType;
+import org.apache.flink.table.types.logical.RowType;
+import org.apache.flink.util.Preconditions;
 
 import java.util.ArrayList;
 import java.util.Arrays;
+import java.util.HashSet;
 import java.util.List;
 import java.util.ListIterator;
+import java.util.Set;
 import java.util.stream.Collectors;
 import java.util.stream.IntStream;
+
+import static org.apache.flink.table.types.logical.LogicalTypeRoot.ROW;
 
 /**
  * {@link Projection} represents a list of (possibly nested) indexes that can be used to project
@@ -39,8 +48,24 @@ public abstract class Projection {
     // sealed class
     private Projection() {}
 
-    /** Project the provided {@link DataType} using this {@link Projection}. */
+    /**
+     * Projects a (possibly nested) row data type by returning a new data type that only includes
+     * fields of the given index paths.
+     *
+     * <p>When extracting nested fields, the name of the resulting fields is the full path of the
+     * field separated by {@code _}. For example, the field {@code b} inside the row field {@code a}
+     * of the root {@link DataType} is named {@code a_b} in the result {@link DataType}. In case of
+     * naming conflicts the postfix notation '_$%d' is used, where {@code %d} is an arbitrary
+     * number, in order to generate a unique field name. For example if the root {@link DataType}
+     * includes both a field {@code a_b} and a nested row {@code a} with field {@code b}, the result
+     * {@link DataType} will contain one field named {@code a_b} and the other named {@code a_b_1}.
+     */
     public abstract DataType project(DataType dataType);
+
+    /** Same as {@link #project(DataType)}, but accepting and returning {@link LogicalType}. */
+    public LogicalType project(LogicalType logicalType) {
+        return this.project(DataTypes.of(logicalType)).getLogicalType();
+    }
 
     /** @return {@code true} whether this projection is nested or not. */
     public abstract boolean isNested();
@@ -188,7 +213,7 @@ public abstract class Projection {
 
         @Override
         public DataType project(DataType dataType) {
-            return DataType.projectFields(dataType, toTopLevelIndexes());
+            return new NestedProjection(toNestedIndexes()).project(dataType);
         }
 
         @Override
@@ -229,7 +254,38 @@ public abstract class Projection {
 
         @Override
         public DataType project(DataType dataType) {
-            return DataType.projectFields(dataType, projection);
+            final List<RowType.RowField> updatedFields = new ArrayList<>();
+            final List<DataType> updatedChildren = new ArrayList<>();
+            Set<String> nameDomain = new HashSet<>();
+            int duplicateCount = 0;
+            for (int[] indexPath : this.projection) {
+                DataType fieldType = dataType.getChildren().get(indexPath[0]);
+                LogicalType fieldLogicalType = fieldType.getLogicalType();
+                StringBuilder builder =
+                        new StringBuilder(
+                                ((RowType) dataType.getLogicalType())
+                                        .getFieldNames()
+                                        .get(indexPath[0]));
+                for (int index = 1; index < indexPath.length; index++) {
+                    Preconditions.checkArgument(
+                            fieldLogicalType.is(ROW), "Row data type expected.");
+                    RowType rowtype = ((RowType) fieldLogicalType);
+                    builder.append("_").append(rowtype.getFieldNames().get(indexPath[index]));
+                    fieldLogicalType = rowtype.getFields().get(indexPath[index]).getType();
+                    fieldType = fieldType.getChildren().get(indexPath[index]);
+                }
+                String path = builder.toString();
+                while (nameDomain.contains(path)) {
+                    path = builder.append("_$").append(duplicateCount++).toString();
+                }
+                updatedFields.add(new RowType.RowField(path, fieldLogicalType));
+                updatedChildren.add(fieldType);
+                nameDomain.add(path);
+            }
+            return new FieldsDataType(
+                    new RowType(dataType.getLogicalType().isNullable(), updatedFields),
+                    dataType.getConversionClass(),
+                    updatedChildren);
         }
 
         @Override
@@ -314,7 +370,7 @@ public abstract class Projection {
 
         @Override
         public DataType project(DataType dataType) {
-            return DataType.projectFields(dataType, this.projection);
+            return new NestedProjection(toNestedIndexes()).project(dataType);
         }
 
         @Override

--- a/flink-table/flink-table-common/src/main/java/org/apache/flink/table/connector/format/DecodingFormat.java
+++ b/flink-table/flink-table-common/src/main/java/org/apache/flink/table/connector/format/DecodingFormat.java
@@ -52,7 +52,7 @@ import java.util.Map;
  * produced {@link RowData}, then it should implement {@link ProjectableDecodingFormat}. {@link
  * ProjectableDecodingFormat#createRuntimeDecoder(DynamicTableSource.Context, DataType, int[][])}
  * provides the {@code physicalDataType} as described above and provides {@code projections} to
- * compute the type to produce using {@code DataType.projectFields(physicalDataType, projections)}.
+ * compute the type to produce using {@code Projection.of(projections).project(physicalDataType)}.
  * For example, a JSON format implementation may match the fields based on the JSON object keys,
  * hence it can easily produce {@link RowData} excluding unused object values and set values inside
  * the {@link RowData} using the index provided by the {@code projections} array.
@@ -76,7 +76,7 @@ import java.util.Map;
  *       ProjectableDecodingFormat#createRuntimeDecoder(DynamicTableSource.Context, DataType,
  *       int[][])} providing a non null {@code projections} array excluding auxiliary fields. The
  *       built runtime implementation will take care of projections, producing records of type
- *       {@code DataType.projectFields(physicalDataType, projections)}.
+ *       {@code Projection.of(projections).project(physicalDataType)}.
  *   <li>If no, then the connector must take care of performing the projection, for example using
  *       {@link ProjectedRowData} to project physical {@link RowData} emitted from the decoder
  *       runtime implementation.

--- a/flink-table/flink-table-common/src/main/java/org/apache/flink/table/connector/format/ProjectableDecodingFormat.java
+++ b/flink-table/flink-table-common/src/main/java/org/apache/flink/table/connector/format/ProjectableDecodingFormat.java
@@ -43,7 +43,7 @@ public interface ProjectableDecodingFormat<I> extends DecodingFormat<I> {
 
     /**
      * Creates runtime decoder implementation that is configured to produce data of type {@code
-     * DataType.projectFields(physicalDataType, projections)}. For more details on the usage, check
+     * Projection.of(projections).project(physicalDataType)}. For more details on the usage, check
      * {@link DecodingFormat} documentation.
      *
      * @param context the context provides several utilities required to instantiate the runtime

--- a/flink-table/flink-table-common/src/main/java/org/apache/flink/table/factories/DynamicTableFactory.java
+++ b/flink-table/flink-table-common/src/main/java/org/apache/flink/table/factories/DynamicTableFactory.java
@@ -96,12 +96,12 @@ public interface DynamicTableFactory extends Factory {
          *
          * <pre>{@code
          * // Project some fields into a new data type
-         * DataType projectedDataType = DataType.projectFields(
-         *      context.getPhysicalRowDataType(), projectedIndexes);
+         * DataType projectedDataType = Projection.of(projectedIndexes)
+         *     .project(context.getPhysicalRowDataType());
          *
          * // Create key data type
-         * DataType keyDataType = DataType.projectFields(
-         *      context.getPhysicalRowDataType(), context.getPrimaryKeyIndexes());
+         * DataType keyDataType = Projection.of(context.getPrimaryKeyIndexes())
+         *     .project(context.getPhysicalRowDataType());
          *
          * // Create a new data type filtering columns of the original data type
          * DataType myOwnDataType = DataTypes.ROW(
@@ -121,8 +121,8 @@ public interface DynamicTableFactory extends Factory {
 
         /**
          * Returns the primary key indexes, if any, otherwise returns an empty array. A factory can
-         * use it to compute the schema projection of the key fields with {@link
-         * DataType#projectFields(DataType, int[])}.
+         * use it to compute the schema projection of the key fields with {@code
+         * Projection.of(ctx.getPrimaryKeyIndexes()).project(dataType)}.
          *
          * <p>Shortcut for {@code getCatalogTable().getResolvedSchema().getPrimaryKeyIndexes()}.
          *

--- a/flink-table/flink-table-common/src/main/java/org/apache/flink/table/types/DataType.java
+++ b/flink-table/flink-table-common/src/main/java/org/apache/flink/table/types/DataType.java
@@ -33,10 +33,8 @@ import javax.annotation.Nullable;
 
 import java.io.Serializable;
 import java.util.Collections;
-import java.util.HashSet;
 import java.util.List;
 import java.util.Objects;
-import java.util.Set;
 import java.util.stream.Collectors;
 import java.util.stream.IntStream;
 
@@ -190,55 +188,6 @@ public abstract class DataType implements AbstractDataType<DataType>, Serializab
      */
     public static int getFieldCount(DataType dataType) {
         return getFieldDataTypes(dataType).size();
-    }
-
-    /**
-     * Projects a (possibly nested) row data type by returning a new data type that only includes
-     * fields of the given index paths.
-     *
-     * <p>Note: Index paths allow for arbitrary deep nesting. For example, {@code [[0, 2, 1], ...]}
-     * specifies to include the 2nd field of the 3rd field of the 1st field in the top-level row.
-     * Sometimes, name conflicts might occur when extracting fields from a row. Considering the path
-     * is unique to extract fields, it makes sense to use the path to the fields with delimiter `_`
-     * as the new name of the field. For example, the new name of the field `b` in the row `a` is
-     * `a_b` rather than `b`. However, name conflicts are still possible in some cases, e.g. if the
-     * field name is`a_b` in the top level row. In this case, the method will use a postfix in the
-     * format '_$%d' to resolve the name conflicts.
-     */
-    public static DataType projectFields(DataType dataType, int[][] indexPaths) {
-        return DataTypeUtils.projectRow(dataType, indexPaths);
-    }
-
-    /**
-     * Projects a (possibly nested) row data type by returning a new data type that only includes
-     * fields of the given indices.
-     *
-     * <p>Note: This method only projects (possibly nested) fields in the top-level row.
-     */
-    public static DataType projectFields(DataType dataType, int[] indexes) {
-        return DataTypeUtils.projectRow(dataType, indexes);
-    }
-
-    /**
-     * Exclude fields with the provided {@code indexes} from the {@code dataType}. This method
-     * behaves as the inverse method of {@link #projectFields(DataType, int[])}.
-     *
-     * <p>Note: This method only excludes (possibly nested) fields in the top-level row.
-     */
-    public static DataType excludeFields(DataType dataType, int[] indexes) {
-        // Convert indexes to set
-        final Set<Integer> indexesSet = new HashSet<>();
-        for (int index : indexes) {
-            indexesSet.add(index);
-        }
-
-        // Compute projection
-        final int[] projection =
-                IntStream.range(0, DataType.getFieldCount(dataType))
-                        .filter(i -> !indexesSet.contains(i))
-                        .toArray();
-
-        return DataType.projectFields(dataType, projection);
     }
 
     /**

--- a/flink-table/flink-table-common/src/main/java/org/apache/flink/table/types/utils/DataTypeUtils.java
+++ b/flink-table/flink-table-common/src/main/java/org/apache/flink/table/types/utils/DataTypeUtils.java
@@ -26,6 +26,7 @@ import org.apache.flink.table.catalog.Column;
 import org.apache.flink.table.catalog.DataTypeFactory;
 import org.apache.flink.table.catalog.ObjectIdentifier;
 import org.apache.flink.table.catalog.ResolvedSchema;
+import org.apache.flink.table.connector.Projection;
 import org.apache.flink.table.types.AtomicDataType;
 import org.apache.flink.table.types.CollectionDataType;
 import org.apache.flink.table.types.DataType;
@@ -53,13 +54,10 @@ import org.apache.flink.util.Preconditions;
 
 import javax.annotation.Nullable;
 
-import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.Collections;
-import java.util.HashSet;
 import java.util.List;
 import java.util.Optional;
-import java.util.Set;
 import java.util.stream.Collectors;
 import java.util.stream.IntStream;
 import java.util.stream.Stream;
@@ -79,62 +77,21 @@ import static org.apache.flink.table.types.logical.utils.LogicalTypeUtils.toInte
 public final class DataTypeUtils {
 
     /**
-     * Projects a (possibly nested) row data type by returning a new data type that only includes
-     * fields of the given index paths.
-     *
-     * <p>Note: Index paths allow for arbitrary deep nesting. For example, {@code [[0, 2, 1], ...]}
-     * specifies to include the 2nd field of the 3rd field of the 1st field in the top-level row.
-     * Sometimes, it may get name conflicts when extract fields from the row field. Considering the
-     * the path is unique to extract fields, it makes sense to use the path to the fields with
-     * delimiter `_` as the new name of the field. For example, the new name of the field `b` in the
-     * row `a` is `a_b` rather than `b`. But it may still gets name conflicts in some situation,
-     * such as the field `a_b` in the top level schema. In such situation, it will use the postfix
-     * in the format '_$%d' to resolve the name conflicts.
+     * @deprecated Use the {@link Projection} type
+     * @see Projection#project(DataType)
      */
+    @Deprecated
     public static DataType projectRow(DataType dataType, int[][] indexPaths) {
-        final List<RowField> updatedFields = new ArrayList<>();
-        final List<DataType> updatedChildren = new ArrayList<>();
-        Set<String> nameDomain = new HashSet<>();
-        int duplicateCount = 0;
-        for (int[] indexPath : indexPaths) {
-            DataType fieldType = dataType.getChildren().get(indexPath[0]);
-            LogicalType fieldLogicalType = fieldType.getLogicalType();
-            StringBuilder builder =
-                    new StringBuilder(
-                            ((RowType) dataType.getLogicalType())
-                                    .getFieldNames()
-                                    .get(indexPath[0]));
-            for (int index = 1; index < indexPath.length; index++) {
-                Preconditions.checkArgument(fieldLogicalType.is(ROW), "Row data type expected.");
-                RowType rowtype = ((RowType) fieldLogicalType);
-                builder.append("_").append(rowtype.getFieldNames().get(indexPath[index]));
-                fieldLogicalType = rowtype.getFields().get(indexPath[index]).getType();
-                fieldType = fieldType.getChildren().get(indexPath[index]);
-            }
-            String path = builder.toString();
-            while (nameDomain.contains(path)) {
-                path = builder.append("_$").append(duplicateCount++).toString();
-            }
-            updatedFields.add(new RowField(path, fieldLogicalType));
-            updatedChildren.add(fieldType);
-            nameDomain.add(path);
-        }
-        return new FieldsDataType(
-                new RowType(dataType.getLogicalType().isNullable(), updatedFields),
-                dataType.getConversionClass(),
-                updatedChildren);
+        return Projection.of(indexPaths).project(dataType);
     }
 
     /**
-     * Projects a (possibly nested) row data type by returning a new data type that only includes
-     * fields of the given indices.
-     *
-     * <p>Note: This method only projects (possibly nested) fields in the top-level row.
+     * @deprecated Use the {@link Projection} type
+     * @see Projection#project(DataType)
      */
-    public static DataType projectRow(DataType dataType, int[] indices) {
-        final int[][] indexPaths =
-                IntStream.of(indices).mapToObj(i -> new int[] {i}).toArray(int[][]::new);
-        return projectRow(dataType, indexPaths);
+    @Deprecated
+    public static DataType projectRow(DataType dataType, int[] indexPaths) {
+        return Projection.of(indexPaths).project(dataType);
     }
 
     /** Removes a string prefix from the fields of the given row data type. */

--- a/flink-table/flink-table-common/src/test/java/org/apache/flink/table/types/DataTypeTest.java
+++ b/flink-table/flink-table-common/src/test/java/org/apache/flink/table/types/DataTypeTest.java
@@ -220,21 +220,4 @@ public class DataTypeTest {
         assertEquals(Collections.emptyList(), DataType.getFields(ARRAY(INT())));
         assertEquals(Collections.emptyList(), DataType.getFields(INT()));
     }
-
-    @Test
-    public void testExcludeFields() {
-        assertEquals(
-                ROW(FIELD("c0", BOOLEAN()), FIELD("c2", INT())),
-                DataType.excludeFields(
-                        ROW(FIELD("c0", BOOLEAN()), FIELD("c1", DOUBLE()), FIELD("c2", INT())),
-                        new int[] {1}));
-        assertEquals(
-                ROW(FIELD("c0", BOOLEAN())),
-                DataType.excludeFields(
-                        ROW(
-                                FIELD("c0", BOOLEAN()),
-                                FIELD("c1", ROW(FIELD("c11", BOOLEAN()), FIELD("c12", BOOLEAN()))),
-                                FIELD("c2", INT())),
-                        new int[] {1, 2}));
-    }
 }

--- a/flink-table/flink-table-common/src/test/java/org/apache/flink/table/types/utils/DataTypeUtilsTest.java
+++ b/flink-table/flink-table-common/src/test/java/org/apache/flink/table/types/utils/DataTypeUtilsTest.java
@@ -60,37 +60,6 @@ import static org.junit.Assert.fail;
 public class DataTypeUtilsTest {
 
     @Test
-    public void testProjectRow() {
-        final DataType thirdLevelRow =
-                ROW(FIELD("c0", BOOLEAN()), FIELD("c1", DOUBLE()), FIELD("c2", INT()));
-        final DataType secondLevelRow =
-                ROW(FIELD("b0", BOOLEAN()), FIELD("b1", thirdLevelRow), FIELD("b2", INT()));
-        final DataType topLevelRow =
-                ROW(FIELD("a0", INT()), FIELD("a1", secondLevelRow), FIELD("a1_b1_c0", INT()));
-
-        assertThat(
-                DataTypeUtils.projectRow(topLevelRow, new int[][] {{0}, {1, 1, 0}}),
-                equalTo(ROW(FIELD("a0", INT()), FIELD("a1_b1_c0", BOOLEAN()))));
-
-        assertThat(
-                DataTypeUtils.projectRow(topLevelRow, new int[][] {{1, 1}, {0}}),
-                equalTo(ROW(FIELD("a1_b1", thirdLevelRow), FIELD("a0", INT()))));
-
-        assertThat(
-                DataTypeUtils.projectRow(
-                        topLevelRow, new int[][] {{1, 1, 2}, {1, 1, 1}, {1, 1, 0}}),
-                equalTo(
-                        ROW(
-                                FIELD("a1_b1_c2", INT()),
-                                FIELD("a1_b1_c1", DOUBLE()),
-                                FIELD("a1_b1_c0", BOOLEAN()))));
-
-        assertThat(
-                DataTypeUtils.projectRow(topLevelRow, new int[][] {{1, 1, 0}, {2}}),
-                equalTo(ROW(FIELD("a1_b1_c0", BOOLEAN()), FIELD("a1_b1_c0_$0", INT()))));
-    }
-
-    @Test
     public void testAppendRowFields() {
         {
             final DataType row =

--- a/flink-table/flink-table-runtime/src/test/java/org/apache/flink/table/filesystem/TestCsvFileSystemFormatFactory.java
+++ b/flink-table/flink-table-runtime/src/test/java/org/apache/flink/table/filesystem/TestCsvFileSystemFormatFactory.java
@@ -23,6 +23,7 @@ import org.apache.flink.api.common.serialization.DeserializationSchema;
 import org.apache.flink.configuration.ConfigOption;
 import org.apache.flink.configuration.ReadableConfig;
 import org.apache.flink.table.connector.ChangelogMode;
+import org.apache.flink.table.connector.Projection;
 import org.apache.flink.table.connector.format.DecodingFormat;
 import org.apache.flink.table.connector.format.EncodingFormat;
 import org.apache.flink.table.connector.format.ProjectableDecodingFormat;
@@ -126,7 +127,7 @@ public class TestCsvFileSystemFormatFactory
                     DataType physicalDataType,
                     int[][] projections) {
                 DataType projectedPhysicalDataType =
-                        DataType.projectFields(physicalDataType, projections);
+                        Projection.of(projections).project(physicalDataType);
                 return new TestCsvDeserializationSchema(
                         projectedPhysicalDataType, DataType.getFieldNames(physicalDataType));
             }


### PR DESCRIPTION
## What is the purpose of the change

[FLINK-24399](https://issues.apache.org/jira/browse/FLINK-24399) introduced new methods to perform data types projections in `DataType`. **Note**: no release included such changes.

[FLINK-24776](https://issues.apache.org/jira/browse/FLINK-24776) introduced a new, more powerful, type to perform operations on projections, that is project types, but also difference and complement.

In spite of avoiding to provide different entrypoints for the same functionality, this PR cleanups the new methods introduced by FLINK-24399 and replaces them with the new `Projection` type. It also deprecates the old methods in `DataTypeUtils` for cleanup in future releases.

## Brief change log

* Replace every usage of `DataType#projectFields` and `DataTypeUtils#projectRow` with the new `Projection` type 
* Remove `DataType#projectFields`
* Deprecate `DataTypeUtils#projectRow`

## Verifying this change

This change is a trivial rework / code cleanup without any test coverage.

## Does this pull request potentially affect one of the following parts:

  - Dependencies (does it add or upgrade a dependency): no
  - The public API, i.e., is any changed class annotated with `@Public(Evolving)`: no
  - The serializers: no
  - The runtime per-record code paths (performance sensitive): no
  - Anything that affects deployment or recovery: JobManager (and its components), Checkpointing, Kubernetes/Yarn, ZooKeeper: no
  - The S3 file system connector: no

## Documentation

  - Does this pull request introduce a new feature? no
  - If yes, how is the feature documented? not applicable
