### PR TITLE
[FLINK-25056][Web Frontend] Modify Flink dashboard task manager page,…

### DIFF
--- a/flink-runtime-web/web-dashboard/src/app/pages/task-manager/list/task-manager-list.component.html
+++ b/flink-runtime-web/web-dashboard/src/app/pages/task-manager/list/task-manager-list.component.html
@@ -28,7 +28,7 @@
   >
     <thead>
       <tr>
-        <th nzLeft="0px" [nzWidth]="'280px'">Path, ID</th>
+        <th nzLeft="0px" [nzSortFn]="sortIdFn" [nzWidth]="'280px'">Path, ID</th>
         <th [nzSortFn]="sortDataPortFn" [nzWidth]="'100px'">Data Port</th>
         <th [nzSortFn]="sortHeartBeatFn" [nzWidth]="'160px'">Last Heartbeat</th>
         <th [nzSortFn]="sortSlotsNumberFn" [nzWidth]="'90px'">All Slots</th>

--- a/flink-runtime-web/web-dashboard/src/app/pages/task-manager/list/task-manager-list.component.ts
+++ b/flink-runtime-web/web-dashboard/src/app/pages/task-manager/list/task-manager-list.component.ts
@@ -39,6 +39,7 @@ function createSortFn(selector: (item: TaskmanagersItem) => number): NzTableSort
 export class TaskManagerListComponent implements OnInit, OnDestroy {
   public readonly trackById = (_: number, node: TaskmanagersItem): string => node.id;
 
+  public readonly sortIdFn = createSortFn(item => item.id);
   public readonly sortDataPortFn = createSortFn(item => item.dataPort);
   public readonly sortHeartBeatFn = createSortFn(item => item.timeSinceLastHeartbeat);
   public readonly sortSlotsNumberFn = createSortFn(item => item.slotsNumber);


### PR DESCRIPTION
## What is the purpose of the change

Modify Flink dashboard task manager page, "Path, ID" column，to support sorting by id，So we can find the missing taskmanager more quickly. Especially when the job is deployed in a Kubernetes environment. For example: We have requested 100 Pods, but some pods(TM) have not been registered with JM due to internal errors, but it seems to be running normally. At this time, it is impossible to determine which pod has a problem. If you sort by ID and combine with the kubectl command, you can quickly locate which pod(TM) is not registered to JM, so as to quickly solve the problem.


## Brief change log
Modify Flink dashboard task manager page, "Path, ID" column，to support sorting by id


## Verifying this change
This change is already covered by existing tests.

## Does this pull request potentially affect one of the following parts:

  - Dependencies (does it add or upgrade a dependency): (no)
  - The public API, i.e., is any changed class annotated with `@Public(Evolving)`: (no)
  - The serializers: (yes / no / don't know)
  - The runtime per-record code paths (performance sensitive): (no)
  - Anything that affects deployment or recovery: JobManager (and its components), Checkpointing, Kubernetes/Yarn, ZooKeeper: (no)
  - The S3 file system connector: (no)

## Documentation
  - Does this pull request introduce a new feature? (no)
