### PR TITLE
[FLINK-24227][connectors] Async Base Sink Hotfix - Introduced maxRecordSizeInBytes and changed the behaviour of flushOnBufferSizeInBytes

### DIFF
--- a/flink-connectors/flink-connector-base/src/main/java/org/apache/flink/connector/base/sink/AsyncSinkBase.java
+++ b/flink-connectors/flink-connector-base/src/main/java/org/apache/flink/connector/base/sink/AsyncSinkBase.java
@@ -54,22 +54,25 @@ public abstract class AsyncSinkBase<InputT, RequestEntryT extends Serializable>
     private final int maxBatchSize;
     private final int maxInFlightRequests;
     private final int maxBufferedRequests;
-    private final long flushOnBufferSizeInBytes;
+    private final long maxBatchSizeInBytes;
     private final long maxTimeInBufferMS;
+    private final long maxRecordSizeInBytes;
 
     protected AsyncSinkBase(
             ElementConverter<InputT, RequestEntryT> elementConverter,
             int maxBatchSize,
             int maxInFlightRequests,
             int maxBufferedRequests,
-            long flushOnBufferSizeInBytes,
-            long maxTimeInBufferMS) {
+            long maxBatchSizeInBytes,
+            long maxTimeInBufferMS,
+            long maxRecordSizeInBytes) {
         this.elementConverter = elementConverter;
         this.maxBatchSize = maxBatchSize;
         this.maxInFlightRequests = maxInFlightRequests;
         this.maxBufferedRequests = maxBufferedRequests;
-        this.flushOnBufferSizeInBytes = flushOnBufferSizeInBytes;
+        this.maxBatchSizeInBytes = maxBatchSizeInBytes;
         this.maxTimeInBufferMS = maxTimeInBufferMS;
+        this.maxRecordSizeInBytes = maxRecordSizeInBytes;
     }
 
     @Override
@@ -108,11 +111,15 @@ public abstract class AsyncSinkBase<InputT, RequestEntryT extends Serializable>
         return maxBufferedRequests;
     }
 
-    protected long getFlushOnBufferSizeInBytes() {
-        return flushOnBufferSizeInBytes;
+    protected long getMaxBatchSizeInBytes() {
+        return maxBatchSizeInBytes;
     }
 
     protected long getMaxTimeInBufferMS() {
         return maxTimeInBufferMS;
+    }
+
+    protected long getMaxRecordSizeInBytes() {
+        return maxRecordSizeInBytes;
     }
 }

--- a/flink-connectors/flink-connector-base/src/main/java/org/apache/flink/connector/base/sink/AsyncSinkBaseBuilder.java
+++ b/flink-connectors/flink-connector-base/src/main/java/org/apache/flink/connector/base/sink/AsyncSinkBaseBuilder.java
@@ -40,8 +40,9 @@ public abstract class AsyncSinkBaseBuilder<
     private Integer maxBatchSize;
     private Integer maxInFlightRequests;
     private Integer maxBufferedRequests;
-    private Long flushOnBufferSizeInBytes;
+    private Long maxBatchSizeInBytes;
     private Long maxTimeInBufferMS;
+    private Long maxRecordSizeInBytes;
 
     /**
      * @param elementConverter the {@link ElementConverter} to be used for the sink
@@ -87,13 +88,15 @@ public abstract class AsyncSinkBaseBuilder<
     }
 
     /**
-     * @param flushOnBufferSizeInBytes a flush will be attempted if the most recent call to write
+     * @param maxBatchSizeInBytes a flush will be attempted if the most recent call to write
      *     introduces an element to the buffer such that the total size of the buffer is greater
-     *     than or equal to this threshold value.
+     *     than or equal to this threshold value. If this happens, the maximum number of elements
+     *     from the head of the buffer will be selected, that is smaller than {@code
+     *     maxBatchSizeInBytes} in size will be flushed.
      * @return {@link ConcreteBuilderT} itself
      */
-    public ConcreteBuilderT setFlushOnBufferSizeInBytes(long flushOnBufferSizeInBytes) {
-        this.flushOnBufferSizeInBytes = flushOnBufferSizeInBytes;
+    public ConcreteBuilderT setMaxBatchSizeInBytes(long maxBatchSizeInBytes) {
+        this.maxBatchSizeInBytes = maxBatchSizeInBytes;
         return (ConcreteBuilderT) this;
     }
 
@@ -108,6 +111,16 @@ public abstract class AsyncSinkBaseBuilder<
      */
     public ConcreteBuilderT setMaxTimeInBufferMS(long maxTimeInBufferMS) {
         this.maxTimeInBufferMS = maxTimeInBufferMS;
+        return (ConcreteBuilderT) this;
+    }
+
+    /**
+     * @param maxRecordSizeInBytes the maximum size of each records in bytes. If a record larger
+     *     than this is passed to the sink, it will throw an {@code IllegalArgumentException}.
+     * @return {@link ConcreteBuilderT} itself
+     */
+    public ConcreteBuilderT setMaxRecordSizeInBytes(long maxRecordSizeInBytes) {
+        this.maxRecordSizeInBytes = maxRecordSizeInBytes;
         return (ConcreteBuilderT) this;
     }
 
@@ -130,11 +143,15 @@ public abstract class AsyncSinkBaseBuilder<
         return maxBufferedRequests;
     }
 
-    protected Long getFlushOnBufferSizeInBytes() {
-        return flushOnBufferSizeInBytes;
+    protected Long getMaxBatchSizeInBytes() {
+        return maxBatchSizeInBytes;
     }
 
     protected Long getMaxTimeInBufferMS() {
         return maxTimeInBufferMS;
+    }
+
+    protected Long getMaxRecordSizeInBytes() {
+        return maxRecordSizeInBytes;
     }
 }

--- a/flink-connectors/flink-connector-base/src/test/java/org/apache/flink/connector/base/sink/ArrayListAsyncSink.java
+++ b/flink-connectors/flink-connector-base/src/test/java/org/apache/flink/connector/base/sink/ArrayListAsyncSink.java
@@ -31,22 +31,24 @@ import java.util.function.Consumer;
 public class ArrayListAsyncSink extends AsyncSinkBase<String, Integer> {
 
     public ArrayListAsyncSink() {
-        this(25, 1, 100, 100000, 1000);
+        this(25, 1, 100, 100_000, 1000, 100_000);
     }
 
     public ArrayListAsyncSink(
             int maxBatchSize,
             int maxInFlightRequests,
             int maxBufferedRequests,
-            long flushOnBufferSizeInBytes,
-            long maxTimeInBufferMS) {
+            long maxBatchSizeInBytes,
+            long maxTimeInBufferMS,
+            long maxRecordSizeInBytes) {
         super(
                 (element, x) -> Integer.parseInt(element),
                 maxBatchSize,
                 maxInFlightRequests,
                 maxBufferedRequests,
-                flushOnBufferSizeInBytes,
-                maxTimeInBufferMS);
+                maxBatchSizeInBytes,
+                maxTimeInBufferMS,
+                maxRecordSizeInBytes);
     }
 
     @Override
@@ -61,8 +63,9 @@ public class ArrayListAsyncSink extends AsyncSinkBase<String, Integer> {
                 getMaxBatchSize(),
                 getMaxInFlightRequests(),
                 getMaxBufferedRequests(),
-                getFlushOnBufferSizeInBytes(),
-                getMaxTimeInBufferMS()) {
+                getMaxBatchSizeInBytes(),
+                getMaxTimeInBufferMS(),
+                getMaxRecordSizeInBytes()) {
 
             @Override
             protected void submitRequestEntries(

--- a/flink-connectors/flink-connector-base/src/test/java/org/apache/flink/connector/base/sink/AsyncSinkBaseITCase.java
+++ b/flink-connectors/flink-connector-base/src/test/java/org/apache/flink/connector/base/sink/AsyncSinkBaseITCase.java
@@ -42,7 +42,7 @@ public class AsyncSinkBaseITCase {
     public void testFailuresOnPersistingToDestinationAreCaughtAndRaised() {
         env.fromSequence(999_999, 1_000_100)
                 .map(Object::toString)
-                .sinkTo(new ArrayListAsyncSink(1, 1, 2, 10, 1000));
+                .sinkTo(new ArrayListAsyncSink(1, 1, 2, 10, 1000, 10));
         Exception e =
                 assertThrows(
                         JobExecutionException.class,


### PR DESCRIPTION
<!--
*Thank you very much for contributing to Apache Flink - we are happy that you want to help us improve Flink. To help the community review your contribution in the best possible way, please go through the checklist below, which will get the contribution into a shape in which it can be best reviewed.*

*Please understand that we do not do this to make contributions to Flink a hassle. In order to uphold a high standard of quality for code contributions, while at the same time managing a large number of contributions, we need contributors to prepare the contributions well, and give reviewers enough contextual information for the review. Please also understand that contributions that do not follow this guide will take longer to review and thus typically be picked up with lower priority by the community.*

## Contribution Checklist

  - Make sure that the pull request corresponds to a [JIRA issue](https://issues.apache.org/jira/projects/FLINK/issues). Exceptions are made for typos in JavaDoc or documentation files, which need no JIRA issue.
  
  - Name the pull request in the form "[FLINK-XXXX] [component] Title of the pull request", where *FLINK-XXXX* should be replaced by the actual issue number. Skip *component* if you are unsure about which is the best component.
  Typo fixes that have no associated JIRA issue should be named following this pattern: `[hotfix] [docs] Fix typo in event time introduction` or `[hotfix] [javadocs] Expand JavaDoc for PuncuatedWatermarkGenerator`.

  - Fill out the template below to describe the changes contributed by the pull request. That will give reviewers the context they need to do the review.
  
  - Make sure that the change passes the automated tests, i.e., `mvn clean verify` passes. You can set up Azure Pipelines CI to do that following [this guide](https://cwiki.apache.org/confluence/display/FLINK/Azure+Pipelines#AzurePipelines-Tutorial:SettingupAzurePipelinesforaforkoftheFlinkrepository).

  - Each pull request should address only one issue, not mix up code from multiple issues.
  
  - Each commit in the pull request has a meaningful commit message (including the JIRA id)

  - Once all items of the checklist are addressed, remove the above text and this checklist, leaving only the filled out template below.


**(The sections below can be removed for hotfixes of typos)**
-->

## What is the purpose of the change

https://github.com/apache/flink/pull/17345#discussion_r756760460


## Brief change log

*(for example:)*
Introduced maxRecordSizeInBytes and changed the behaviour of flushOnBufferSizeInBytes
changed name of flushOnBufferSizeInBytes to maxBufferSizeInBytes

## Verifying this change


This change is a trivial rework / code cleanup without any test coverage.
and
This change added tests and can be verified as follows:
new unit tests

## Does this pull request potentially affect one of the following parts:

  - Dependencies (does it add or upgrade a dependency): (yes / no)n
  - The public API, i.e., is any changed class annotated with `@Public(Evolving)`: (yes / no)y
  - The serializers: (yes / no / don't know)n
  - The runtime per-record code paths (performance sensitive): (yes / no / don't know)n
  - Anything that affects deployment or recovery: JobManager (and its components), Checkpointing, Kubernetes/Yarn, ZooKeeper: (yes / no / don't know)n
  - The S3 file system connector: (yes / no / don't know)n

## Documentation

  - Does this pull request introduce a new feature? (yes / no)y
  - If yes, how is the feature documented? (not applicable / docs / JavaDocs / not documented)javadocs
