### PR TITLE
[FLINK-25023] Prevent leaking classloaders from filesystems through AccessControlContext.

### DIFF
--- a/flink-core/src/main/java/org/apache/flink/core/fs/FileSystem.java
+++ b/flink-core/src/main/java/org/apache/flink/core/fs/FileSystem.java
@@ -325,14 +325,18 @@ public abstract class FileSystem {
             FS_FACTORIES.clear();
 
             Collection<Supplier<Iterator<FileSystemFactory>>> factorySuppliers = new ArrayList<>(2);
-            factorySuppliers.add(() -> ServiceLoader.load(FileSystemFactory.class).iterator());
+            factorySuppliers.add(
+                    () ->
+                            Iterators.transform(
+                                    ServiceLoader.load(FileSystemFactory.class).iterator(),
+                                    SafeFileSystemFactory::of));
 
             if (pluginManager != null) {
                 factorySuppliers.add(
                         () ->
                                 Iterators.transform(
                                         pluginManager.load(FileSystemFactory.class),
-                                        PluginFileSystemFactory::of));
+                                        SafeFileSystemFactory::of));
             }
 
             final List<FileSystemFactory> fileSystemFactories =

--- a/flink-core/src/test/java/org/apache/flink/core/fs/EntropyInjectorTest.java
+++ b/flink-core/src/test/java/org/apache/flink/core/fs/EntropyInjectorTest.java
@@ -178,8 +178,8 @@ public class EntropyInjectorTest {
         final Path path = new Path(Path.fromLocalFile(folder), entropyKey + "/path/");
         final Path pathWithEntropy = new Path(Path.fromLocalFile(folder), entropyValue + "/path/");
 
-        PluginFileSystemFactory pluginFsFactory =
-                PluginFileSystemFactory.of(new TestFileSystemFactory(entropyKey, entropyValue));
+        SafeFileSystemFactory pluginFsFactory =
+                SafeFileSystemFactory.of(new TestFileSystemFactory(entropyKey, entropyValue));
         FileSystem testFs = pluginFsFactory.create(URI.create("test"));
 
         FileSystemSafetyNet.initializeSafetyNetForThread();
@@ -204,8 +204,8 @@ public class EntropyInjectorTest {
         final Path path = new Path(Path.fromLocalFile(folder), entropyKey + "/path/");
         final Path pathWithEntropy = new Path(Path.fromLocalFile(folder), entropyValue + "/path/");
 
-        PluginFileSystemFactory pluginFsFactory =
-                PluginFileSystemFactory.of(new TestFileSystemFactory(entropyKey, entropyValue));
+        SafeFileSystemFactory pluginFsFactory =
+                SafeFileSystemFactory.of(new TestFileSystemFactory(entropyKey, entropyValue));
         FileSystem testFs = pluginFsFactory.create(URI.create("test"));
 
         OutputStreamAndPath streamAndPath =

--- a/flink-core/src/test/java/org/apache/flink/core/fs/SafeFileSystemFactoryTest.java
+++ b/flink-core/src/test/java/org/apache/flink/core/fs/SafeFileSystemFactoryTest.java
@@ -1,0 +1,187 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.flink.core.fs;
+
+import org.apache.flink.util.ChildFirstClassLoader;
+
+import org.junit.jupiter.api.Test;
+
+import java.io.IOException;
+import java.lang.reflect.Constructor;
+import java.lang.reflect.Field;
+import java.lang.reflect.InvocationTargetException;
+import java.lang.reflect.Method;
+import java.net.URI;
+import java.net.URL;
+import java.security.AccessControlContext;
+import java.security.AccessController;
+import java.security.ProtectionDomain;
+import java.util.List;
+import java.util.Vector;
+import java.util.stream.Collectors;
+import java.util.stream.Stream;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatExceptionOfType;
+import static org.assertj.core.api.Assertions.assertThatIOException;
+
+/** Tests for the {@link SafeFileSystemFactory}. */
+public class SafeFileSystemFactoryTest {
+
+    /**
+     * We need to load this class in separate classloader to leak the classloader through the {@link
+     * ProtectionDomain}.
+     */
+    private static class ProtectionDomainLeakTest {
+
+        ProtectionDomainLeakTest(FileSystemFactory factory) throws Exception {
+            factory.create(URI.create("test://filesystem"));
+        }
+    }
+
+    private abstract static class TestFileSystemFactory implements FileSystemFactory {
+
+        @Override
+        public String getScheme() {
+            throw new UnsupportedOperationException("Test.");
+        }
+    }
+
+    private static Stream<Class<?>> getLoadedClasses(ClassLoader classLoader) throws Exception {
+        final Field field = ClassLoader.class.getDeclaredField("classes");
+        field.setAccessible(true);
+        @SuppressWarnings("unchecked")
+        final Vector<Class<?>> classes = (Vector<Class<?>>) field.get(classLoader);
+        return classes.stream();
+    }
+
+    private static List<Class<?>> getLoadedFlinkClasses(ClassLoader classLoader) throws Exception {
+        return getLoadedClasses(classLoader)
+                .filter(c -> c.getName().startsWith("org.apache.flink"))
+                .collect(Collectors.toList());
+    }
+
+    private static ProtectionDomain[] getProtectionDomains() {
+        try {
+            final AccessControlContext context = AccessController.getContext();
+            final Method domainResolver = context.getClass().getDeclaredMethod("getContext");
+            domainResolver.setAccessible(true);
+            return (ProtectionDomain[]) domainResolver.invoke(context);
+        } catch (NoSuchMethodException | InvocationTargetException | IllegalAccessException e) {
+            throw new RuntimeException(e);
+        }
+    }
+
+    @Test
+    void testProtectionDomainLeaksWithRegularFileSystemFactory() throws Exception {
+        testProtectionDomainLeak(
+                new TestFileSystemFactory() {
+
+                    @Override
+                    public FileSystem create(URI fsUri) {
+                        boolean leak = false;
+                        for (ProtectionDomain protectionDomain : getProtectionDomains()) {
+                            if (protectionDomain.getClassLoader()
+                                    instanceof ChildFirstClassLoader) {
+                                leak = true;
+                                break;
+                            }
+                        }
+                        assertThat(leak).isTrue();
+                        return null;
+                    }
+                });
+    }
+
+    @Test
+    void testProtectionDomainDoesNotLeakWithWrappedFileSystemFactory() throws Exception {
+        testProtectionDomainLeak(
+                SafeFileSystemFactory.of(
+                        new TestFileSystemFactory() {
+
+                            @Override
+                            public FileSystem create(URI fsUri) {
+                                for (ProtectionDomain protectionDomain : getProtectionDomains()) {
+                                    assertThat(protectionDomain.getCodeSource())
+                                            .isNotInstanceOf(ChildFirstClassLoader.class);
+                                }
+                                return null;
+                            }
+                        }));
+    }
+
+    private void testProtectionDomainLeak(FileSystemFactory factory) throws Exception {
+        final URL testClassLocation =
+                getClass().getProtectionDomain().getCodeSource().getLocation();
+        final ChildFirstClassLoader leakyClassLoader =
+                new ChildFirstClassLoader(
+                        new URL[] {testClassLocation},
+                        Thread.currentThread().getContextClassLoader(),
+                        new String[] {"java."},
+                        error -> {
+                            // No-op.
+                        });
+        final Class<?> clazz =
+                Class.forName(ProtectionDomainLeakTest.class.getName(), true, leakyClassLoader);
+        final Constructor<?> declaredConstructor =
+                clazz.getDeclaredConstructor(FileSystemFactory.class);
+        declaredConstructor.setAccessible(true);
+        declaredConstructor.newInstance(factory);
+        // We have to assert class name here, because the class we want to assert has been loaded in
+        // a different classloader.
+        assertThat(getLoadedFlinkClasses(leakyClassLoader))
+                .map(Class::getName)
+                .singleElement()
+                .isEqualTo(ProtectionDomainLeakTest.class.getName());
+    }
+
+    @Test
+    void testIOExceptionHandlingDuringFileSystemCreation() {
+        final FileSystemFactory factory =
+                SafeFileSystemFactory.of(
+                        new TestFileSystemFactory() {
+
+                            @Override
+                            public FileSystem create(URI fsUri) throws IOException {
+                                throw new IOException("Test.");
+                            }
+                        });
+        assertThatIOException()
+                .isThrownBy(() -> factory.create(URI.create("test://filesystem")))
+                .withNoCause()
+                .withMessage("Test.");
+    }
+
+    @Test
+    void testUncheckedExceptionHandlingDuringFileSystemCreation() {
+        final FileSystemFactory factory =
+                SafeFileSystemFactory.of(
+                        new TestFileSystemFactory() {
+
+                            @Override
+                            public FileSystem create(URI fsUri) {
+                                throw new IllegalStateException("Test.");
+                            }
+                        });
+        assertThatExceptionOfType(IOException.class)
+                .isThrownBy(() -> factory.create(URI.create("test://filesystem")))
+                .withCauseExactlyInstanceOf(IllegalStateException.class)
+                .havingCause()
+                .withMessage("Test.");
+    }
+}

--- a/flink-filesystems/flink-s3-fs-presto/src/test/java/org/apache/flink/fs/s3presto/PrestoS3FileSystemTest.java
+++ b/flink-filesystems/flink-s3-fs-presto/src/test/java/org/apache/flink/fs/s3presto/PrestoS3FileSystemTest.java
@@ -22,6 +22,7 @@ import org.apache.flink.configuration.Configuration;
 import org.apache.flink.core.fs.FileSystem;
 import org.apache.flink.fs.s3.common.FlinkS3FileSystem;
 import org.apache.flink.runtime.util.HadoopConfigLoader;
+import org.apache.flink.util.WrappingProxy;
 
 import com.amazonaws.auth.AWSCredentialsProvider;
 import com.amazonaws.auth.AWSStaticCredentialsProvider;
@@ -97,10 +98,15 @@ public class PrestoS3FileSystemTest {
     //  utilities
     // ------------------------------------------------------------------------
 
-    private static void validateBasicCredentials(FileSystem fs) throws Exception {
-        assertTrue(fs instanceof FlinkS3FileSystem);
+    private static void validateBasicCredentials(FileSystem wrappedFileSystem) throws Exception {
+        assertTrue(wrappedFileSystem instanceof WrappingProxy);
+        @SuppressWarnings("unchecked")
+        final FileSystem fileSystem =
+                ((WrappingProxy<FileSystem>) wrappedFileSystem).getWrappedDelegate();
+        assertTrue(fileSystem instanceof FlinkS3FileSystem);
 
-        org.apache.hadoop.fs.FileSystem hadoopFs = ((FlinkS3FileSystem) fs).getHadoopFileSystem();
+        org.apache.hadoop.fs.FileSystem hadoopFs =
+                ((FlinkS3FileSystem) fileSystem).getHadoopFileSystem();
         assertTrue(hadoopFs instanceof PrestoS3FileSystem);
 
         try (PrestoS3FileSystem prestoFs = (PrestoS3FileSystem) hadoopFs) {


### PR DESCRIPTION
https://issues.apache.org/jira/browse/FLINK-25023