### PR TITLE
[FLINK-25015][Table SQL/Client] job name should not always be `collect` submitted by sql client

### DIFF
--- a/flink-table/flink-table-api-java/src/main/java/org/apache/flink/table/api/internal/TableEnvironmentImpl.java
+++ b/flink-table/flink-table-api-java/src/main/java/org/apache/flink/table/api/internal/TableEnvironmentImpl.java
@@ -802,10 +802,10 @@ public class TableEnvironmentImpl implements TableEnvironmentInternal {
                 new CollectModifyOperation(objectIdentifier, operation);
         List<Transformation<?>> transformations =
                 translate(Collections.singletonList(sinkOperation));
-        final String defaultJobName = "collect";
+        final String jobName =
+                operation.getQuerySql() == null ? "collect" : operation.getQuerySql();
         Pipeline pipeline =
-                execEnv.createPipeline(
-                        transformations, tableConfig.getConfiguration(), defaultJobName);
+                execEnv.createPipeline(transformations, tableConfig.getConfiguration(), jobName);
         try {
             JobClient jobClient = execEnv.executeAsync(pipeline);
             ResultProvider resultProvider = sinkOperation.getSelectResultProvider();

--- a/flink-table/flink-table-api-java/src/main/java/org/apache/flink/table/operations/QueryOperation.java
+++ b/flink-table/flink-table-api-java/src/main/java/org/apache/flink/table/operations/QueryOperation.java
@@ -53,4 +53,8 @@ public interface QueryOperation extends Operation {
     default <T> T accept(QueryOperationVisitor<T> visitor) {
         return visitor.visit(this);
     }
+
+    default String getQuerySql() {
+        return null;
+    }
 }

--- a/flink-table/flink-table-planner/src/main/java/org/apache/flink/table/planner/operations/PlannerQueryOperation.java
+++ b/flink-table/flink-table-planner/src/main/java/org/apache/flink/table/planner/operations/PlannerQueryOperation.java
@@ -40,8 +40,13 @@ public class PlannerQueryOperation implements QueryOperation {
 
     private final RelNode calciteTree;
     private final ResolvedSchema resolvedSchema;
+    private String querySql;
 
     public PlannerQueryOperation(RelNode calciteTree) {
+        this(calciteTree, null);
+    }
+
+    public PlannerQueryOperation(RelNode calciteTree, String querySql) {
         this.calciteTree = calciteTree;
 
         RelDataType rowType = calciteTree.getRowType();
@@ -55,6 +60,7 @@ public class PlannerQueryOperation implements QueryOperation {
                         .toArray(DataType[]::new);
 
         this.resolvedSchema = ResolvedSchema.physical(fieldNames, fieldTypes);
+        this.querySql = querySql;
     }
 
     public RelNode getCalciteTree() {
@@ -80,5 +86,10 @@ public class PlannerQueryOperation implements QueryOperation {
     @Override
     public <T> T accept(QueryOperationVisitor<T> visitor) {
         return visitor.visit(this);
+    }
+
+    @Override
+    public String getQuerySql() {
+        return querySql;
     }
 }

--- a/flink-table/flink-table-planner/src/main/java/org/apache/flink/table/planner/operations/SqlToOperationConverter.java
+++ b/flink-table/flink-table-planner/src/main/java/org/apache/flink/table/planner/operations/SqlToOperationConverter.java
@@ -1084,6 +1084,6 @@ public class SqlToOperationConverter {
     private PlannerQueryOperation toQueryOperation(FlinkPlannerImpl planner, SqlNode validated) {
         // transform to a relational tree
         RelRoot relational = planner.rel(validated);
-        return new PlannerQueryOperation(relational.project());
+        return new PlannerQueryOperation(relational.project(), getQuotedSqlString(validated));
     }
 }


### PR DESCRIPTION
## What is the purpose of the change
improvement for query job submitted by sql client, the job name should not always be `collect`,  and I change it to the query sql.

## Brief change log
get the query sql by SqlToOperationConverter#getQuotedSqlString method, and set it to PlannerQueryOperation in the constructed method, while submit the job, set the job name as the query sql which get from the QueryOperation


## Verifying this change
Test manually by running a sql query submitted by sql client, and the job name changes to the sql code. 

## Does this pull request potentially affect one of the following parts:

  - Dependencies (does it add or upgrade a dependency): no
  - The public API, i.e., is any changed class annotated with `@Public(Evolving)`: no
  - The serializers:  no 
  - The runtime per-record code paths (performance sensitive):  no
  - Anything that affects deployment or recovery: JobManager (and its components), Checkpointing, Kubernetes/Yarn, ZooKeeper: no 
  - The S3 file system connector:  no

## Documentation

  - Does this pull request introduce a new feature? no
  - If yes, how is the feature documented? (not applicable / docs / JavaDocs / not documented)
