### PR TITLE
[FLINK-25067][doc] Correct the description of RocksDB's background threads for flush and compaction

### DIFF
--- a/docs/layouts/shortcodes/generated/rocksdb_configurable_configuration.html
+++ b/docs/layouts/shortcodes/generated/rocksdb_configurable_configuration.html
@@ -96,7 +96,7 @@
             <td><h5>state.backend.rocksdb.thread.num</h5></td>
             <td style="word-wrap: break-word;">(none)</td>
             <td>Integer</td>
-            <td>The maximum number of concurrent background flush and compaction jobs (per stateful operator). RocksDB has default configuration as '1'.</td>
+            <td>The maximum number of concurrent background flush and compaction jobs (per stateful operator). RocksDB has default configuration as '2'.</td>
         </tr>
         <tr>
             <td><h5>state.backend.rocksdb.use-bloom-filter</h5></td>

--- a/flink-state-backends/flink-statebackend-rocksdb/src/main/java/org/apache/flink/contrib/streaming/state/RocksDBConfigurableOptions.java
+++ b/flink-state-backends/flink-statebackend-rocksdb/src/main/java/org/apache/flink/contrib/streaming/state/RocksDBConfigurableOptions.java
@@ -58,7 +58,7 @@ public class RocksDBConfigurableOptions implements Serializable {
                     .noDefaultValue()
                     .withDescription(
                             "The maximum number of concurrent background flush and compaction jobs (per stateful operator). "
-                                    + "RocksDB has default configuration as '1'.");
+                                    + "RocksDB has default configuration as '2'.");
 
     public static final ConfigOption<Integer> MAX_OPEN_FILES =
             key("state.backend.rocksdb.files.open")


### PR DESCRIPTION
## What is the purpose of the change

Correct the description of RocksDB's background threads for flush and compaction.


## Verifying this change

This change is a trivial rework / code cleanup without any test coverage.


## Does this pull request potentially affect one of the following parts:

  - Dependencies (does it add or upgrade a dependency): no
  - The public API, i.e., is any changed class annotated with `@Public(Evolving)`: no
  - The serializers: no
  - The runtime per-record code paths (performance sensitive): no
  - Anything that affects deployment or recovery: JobManager (and its components), Checkpointing, Kubernetes/Yarn, ZooKeeper: no
  - The S3 file system connector: no

## Documentation

  - Does this pull request introduce a new feature? no
  - If yes, how is the feature documented? not applicable
