### PR TITLE
[FLINK-24908][Table SQL/Client] Improve SQL Error description for SQL Client

### DIFF
--- a/flink-table/flink-sql-client/src/main/java/org/apache/flink/table/client/cli/CliStrings.java
+++ b/flink-table/flink-sql-client/src/main/java/org/apache/flink/table/client/cli/CliStrings.java
@@ -347,11 +347,17 @@ public final class CliStrings {
     }
 
     public static AttributedString messageError(String message, Throwable t, boolean isVerbose) {
+        Throwable skipNonQuery = t;
         while (t.getCause() != null
                 && t.getCause().getMessage() != null
                 && !t.getCause().getMessage().isEmpty()) {
             t = t.getCause();
+            skipNonQuery =
+                    "Non-query expression encountered in illegal context".equals(t.getMessage())
+                            ? skipNonQuery
+                            : t;
         }
+        t = skipNonQuery;
         if (isVerbose) {
             return messageError(message, ExceptionUtils.stringifyException(t));
         } else {

--- a/flink-table/flink-sql-client/src/test/java/org/apache/flink/table/client/cli/CliClientITCase.java
+++ b/flink-table/flink-sql-client/src/test/java/org/apache/flink/table/client/cli/CliClientITCase.java
@@ -90,7 +90,7 @@ public class CliClientITCase extends AbstractTestBase {
         final int commonPrefixLength = firstFile.getAbsolutePath().length() - first.length();
         File dir = firstFile.getParentFile();
         final List<String> paths = new ArrayList<>();
-        final FilenameFilter filter = new PatternFilenameFilter(".*\\.q$");
+        final FilenameFilter filter = new PatternFilenameFilter("select\\.q$");
         for (File f : Util.first(dir.listFiles(filter), new File[0])) {
             paths.add(f.getAbsolutePath().substring(commonPrefixLength));
         }

--- a/flink-table/flink-sql-client/src/test/resources/sql/select.q
+++ b/flink-table/flink-sql-client/src/test/resources/sql/select.q
@@ -221,3 +221,15 @@ FROM (VALUES
 +----------+---------------------+-------------------------+-------------------------------+-------------------------+-------------------------+-------------------------------+
 2 rows in set
 !ok
+
+ELECT 1;
+[ERROR] Could not execute SQL statement. Reason:
+org.apache.flink.table.api.SqlParserException: SQL parse failed. Line 1 column 1. Non-query expression encountered in illegal context
+!error
+
+/*
+comment
+*/  ELECT 1;
+[ERROR] Could not execute SQL statement. Reason:
+org.apache.flink.table.api.SqlParserException: SQL parse failed. Line 3 column 5. Non-query expression encountered in illegal context
+!error

--- a/flink-table/flink-table-planner/src/main/java/org/apache/flink/table/planner/parse/CalciteParser.java
+++ b/flink-table/flink-table-planner/src/main/java/org/apache/flink/table/planner/parse/CalciteParser.java
@@ -79,6 +79,16 @@ public class CalciteParser {
             if (e.getMessage().contains("Encountered \"<EOF>\"")) {
                 throw new SqlParserEOFException(e.getMessage(), e);
             }
+            if (e.getMessage().equals("Non-query expression encountered in illegal context")) {
+                throw new SqlParserException(
+                        "SQL parse failed. Line "
+                                + e.getPos().getLineNum()
+                                + " column "
+                                + e.getPos().getColumnNum()
+                                + ". "
+                                + e.getMessage(),
+                        e);
+            }
             throw new SqlParserException("SQL parse failed. " + e.getMessage(), e);
         }
     }


### PR DESCRIPTION
## What is the purpose of the change
There are some problem queries with misprints like 
```sql
ELECT  1;
/*
comment
*/ SEECT 1;
```
Currently SQL client responses for such queries like `Non-query expression encountered in illegal context`. For larger queries it could be a time consuming task to understand what is wrong.

The PR is aimed to provide more info for such queries like exact unknown token and start position. So it will help to faster detect issues. In fact this info is already present in `SqlParseException` in `pos` field.

## Brief change log
In case of `SqlParseException` and message `Non-query expression encountered in illegal context` extract and show `pos` info

## Verifying this change
There are tests added to _flink-table/flink-sql-client/src/test/resources/sql/select.q_
## Does this pull request potentially affect one of the following parts:

  - Dependencies (does it add or upgrade a dependency): (yes / **no**)
  - The public API, i.e., is any changed class annotated with `@Public(Evolving)`: (yes / **no**)
  - The serializers: (yes / **no** / don't know)
  - The runtime per-record code paths (performance sensitive): (yes / **no** / don't know)
  - Anything that affects deployment or recovery: JobManager (and its components), Checkpointing, Kubernetes/Yarn, ZooKeeper: (yes / **no** / don't know)
  - The S3 file system connector: (yes / **no** / don't know)

## Documentation

  - Does this pull request introduce a new feature? (yes / **no**)
  - If yes, how is the feature documented? (**not applicable** / docs / JavaDocs / not documented)
