### PR TITLE
[FLINK-25072][streaming] Introduce description on Transformation and …

### DIFF
--- a/flink-core/src/main/java/org/apache/flink/api/dag/Transformation.java
+++ b/flink-core/src/main/java/org/apache/flink/api/dag/Transformation.java
@@ -119,7 +119,7 @@ public abstract class Transformation<T> {
 
     protected String name;
 
-    protected String desc;
+    protected String description;
 
     protected TypeInformation<T> outputType;
     // This is used to handle MissingTypeInfo. As long as the outputType has not been queried
@@ -207,13 +207,13 @@ public abstract class Transformation<T> {
 
     /** Changes the description of this {@code Transformation}. */
     public Transformation<T> setDescription(String desc) {
-        this.desc = desc;
+        this.description = desc;
         return this;
     }
 
     /** Returns the description of this {@code Transformation}. */
     public String getDescription() {
-        return desc;
+        return description;
     }
 
     /** Returns the parallelism of this {@code Transformation}. */

--- a/flink-core/src/main/java/org/apache/flink/api/dag/Transformation.java
+++ b/flink-core/src/main/java/org/apache/flink/api/dag/Transformation.java
@@ -206,8 +206,8 @@ public abstract class Transformation<T> {
     }
 
     /** Changes the description of this {@code Transformation}. */
-    public Transformation<T> setDescription(String desc) {
-        this.description = desc;
+    public Transformation<T> setDescription(String description) {
+        this.description = description;
         return this;
     }
 

--- a/flink-core/src/main/java/org/apache/flink/api/dag/Transformation.java
+++ b/flink-core/src/main/java/org/apache/flink/api/dag/Transformation.java
@@ -119,6 +119,8 @@ public abstract class Transformation<T> {
 
     protected String name;
 
+    protected String desc;
+
     protected TypeInformation<T> outputType;
     // This is used to handle MissingTypeInfo. As long as the outputType has not been queried
     // it can still be changed using setOutputType(). Afterwards an exception is thrown when
@@ -201,6 +203,17 @@ public abstract class Transformation<T> {
     /** Returns the name of this {@code Transformation}. */
     public String getName() {
         return name;
+    }
+
+    /** Changes the description of this {@code Transformation}. */
+    public Transformation<T> setDescription(String desc) {
+        this.desc = desc;
+        return this;
+    }
+
+    /** Returns the description of this {@code Transformation}. */
+    public String getDescription() {
+        return desc;
     }
 
     /** Returns the parallelism of this {@code Transformation}. */

--- a/flink-core/src/main/java/org/apache/flink/api/dag/Transformation.java
+++ b/flink-core/src/main/java/org/apache/flink/api/dag/Transformation.java
@@ -206,9 +206,8 @@ public abstract class Transformation<T> {
     }
 
     /** Changes the description of this {@code Transformation}. */
-    public Transformation<T> setDescription(String description) {
-        this.description = description;
-        return this;
+    public void setDescription(String description) {
+        this.description = Preconditions.checkNotNull(description);
     }
 
     /** Returns the description of this {@code Transformation}. */

--- a/flink-streaming-java/src/main/java/org/apache/flink/streaming/api/datastream/DataStreamSink.java
+++ b/flink-streaming-java/src/main/java/org/apache/flink/streaming/api/datastream/DataStreamSink.java
@@ -141,15 +141,20 @@ public class DataStreamSink<T> {
     }
 
     /**
-     * Sets the description for this sink. the description is used in json plan, is expected to
-     * provide more detail information about the operation than name.
+     * Sets the description for this sink.
      *
-     * @param desc The description for this sink.
+     * <p>Description is used in json plan and web ui, but not in logging and metrics where only
+     * name is available. Description is expected to provide detailed information about the sink,
+     * while name is expected to be more simple, providing summary information only, so that we can
+     * have more user-friendly logging messages and metric tags without losing useful messages for
+     * debugging.
+     *
+     * @param description The description for this sink.
      * @return The sink with new description.
      */
     @PublicEvolving
-    public DataStreamSink<T> setDescription(String desc) {
-        transformation.setDescription(desc);
+    public DataStreamSink<T> setDescription(String description) {
+        transformation.setDescription(description);
         return this;
     }
 

--- a/flink-streaming-java/src/main/java/org/apache/flink/streaming/api/datastream/DataStreamSink.java
+++ b/flink-streaming-java/src/main/java/org/apache/flink/streaming/api/datastream/DataStreamSink.java
@@ -140,6 +140,19 @@ public class DataStreamSink<T> {
         return this;
     }
 
+    /**
+     * Sets the description for this sink. the description is used in json plan, is expected to
+     * provide more detail information about the operation than name.
+     *
+     * @param desc The description for this sink.
+     * @return The sink with new description.
+     */
+    @PublicEvolving
+    public DataStreamSink<T> setDescription(String desc) {
+        transformation.setDescription(desc);
+        return this;
+    }
+
     //	---------------------------------------------------------------------------
     //	 Fine-grained resource profiles are an incomplete work-in-progress feature
     //	 The setters are hence private at this point.

--- a/flink-streaming-java/src/main/java/org/apache/flink/streaming/api/datastream/SingleOutputStreamOperator.java
+++ b/flink-streaming-java/src/main/java/org/apache/flink/streaming/api/datastream/SingleOutputStreamOperator.java
@@ -421,15 +421,20 @@ public class SingleOutputStreamOperator<T> extends DataStream<T> {
     }
 
     /**
-     * Sets the description for this operation. the description is used in json plan, is expected to
-     * provide more detailed information about the operation than name.
+     * Sets the description for this operation.
      *
-     * @param desc The description for this operation.
+     * <p>Description is used in json plan and web ui, but not in logging and metrics where only
+     * name is available. Description is expected to provide detailed information about the sink,
+     * while name is expected to be more simple, providing summary information only, so that we can
+     * have more user-friendly logging messages and metric tags without losing useful messages for
+     * debugging.
+     *
+     * @param description The description for this operation.
      * @return The operation with new description.
      */
     @PublicEvolving
-    public SingleOutputStreamOperator<T> setDescription(String desc) {
-        transformation.setDescription(desc);
+    public SingleOutputStreamOperator<T> setDescription(String description) {
+        transformation.setDescription(description);
         return this;
     }
 }

--- a/flink-streaming-java/src/main/java/org/apache/flink/streaming/api/datastream/SingleOutputStreamOperator.java
+++ b/flink-streaming-java/src/main/java/org/apache/flink/streaming/api/datastream/SingleOutputStreamOperator.java
@@ -419,4 +419,17 @@ public class SingleOutputStreamOperator<T> extends DataStream<T> {
                 new SideOutputTransformation<>(this.getTransformation(), sideOutputTag);
         return new DataStream<>(this.getExecutionEnvironment(), sideOutputTransformation);
     }
+
+    /**
+     * Sets the description for this operation. the description is used in json plan, is expected to
+     * provide more detailed information about the operation than name.
+     *
+     * @param desc The description for this operation.
+     * @return The operation with new description.
+     */
+    @PublicEvolving
+    public SingleOutputStreamOperator<T> setDescription(String desc) {
+        transformation.setDescription(desc);
+        return this;
+    }
 }

--- a/flink-streaming-java/src/main/java/org/apache/flink/streaming/api/graph/JSONGenerator.java
+++ b/flink-streaming-java/src/main/java/org/apache/flink/streaming/api/graph/JSONGenerator.java
@@ -182,7 +182,7 @@ public class JSONGenerator {
             node.put(PACT, "Operator");
         }
 
-        node.put(CONTENTS, vertex.getOperatorName());
+        node.put(CONTENTS, vertex.getOperatorDesc());
 
         node.put(PARALLELISM, streamGraph.getStreamNode(vertexID).getParallelism());
     }

--- a/flink-streaming-java/src/main/java/org/apache/flink/streaming/api/graph/JSONGenerator.java
+++ b/flink-streaming-java/src/main/java/org/apache/flink/streaming/api/graph/JSONGenerator.java
@@ -182,7 +182,7 @@ public class JSONGenerator {
             node.put(PACT, "Operator");
         }
 
-        node.put(CONTENTS, vertex.getOperatorDesc());
+        node.put(CONTENTS, vertex.getOperatorDescription());
 
         node.put(PARALLELISM, streamGraph.getStreamNode(vertexID).getParallelism());
     }

--- a/flink-streaming-java/src/main/java/org/apache/flink/streaming/api/graph/SimpleTransformationTranslator.java
+++ b/flink-streaming-java/src/main/java/org/apache/flink/streaming/api/graph/SimpleTransformationTranslator.java
@@ -124,7 +124,9 @@ public abstract class SimpleTransformationTranslator<OUT, T extends Transformati
             streamNode.setManagedMemoryUseCaseWeights(
                     transformation.getManagedMemoryOperatorScopeUseCaseWeights(),
                     transformation.getManagedMemorySlotScopeUseCases());
-            streamNode.setOperatorDescription(transformation.getDescription());
+            if (null != transformation.getDescription()) {
+                streamNode.setOperatorDescription(transformation.getDescription());
+            }
         }
     }
 }

--- a/flink-streaming-java/src/main/java/org/apache/flink/streaming/api/graph/SimpleTransformationTranslator.java
+++ b/flink-streaming-java/src/main/java/org/apache/flink/streaming/api/graph/SimpleTransformationTranslator.java
@@ -124,7 +124,7 @@ public abstract class SimpleTransformationTranslator<OUT, T extends Transformati
             streamNode.setManagedMemoryUseCaseWeights(
                     transformation.getManagedMemoryOperatorScopeUseCaseWeights(),
                     transformation.getManagedMemorySlotScopeUseCases());
-            streamNode.setOperatorDesc(transformation.getDescription());
+            streamNode.setOperatorDescription(transformation.getDescription());
         }
     }
 }

--- a/flink-streaming-java/src/main/java/org/apache/flink/streaming/api/graph/SimpleTransformationTranslator.java
+++ b/flink-streaming-java/src/main/java/org/apache/flink/streaming/api/graph/SimpleTransformationTranslator.java
@@ -124,6 +124,7 @@ public abstract class SimpleTransformationTranslator<OUT, T extends Transformati
             streamNode.setManagedMemoryUseCaseWeights(
                     transformation.getManagedMemoryOperatorScopeUseCaseWeights(),
                     transformation.getManagedMemorySlotScopeUseCases());
+            streamNode.setOperatorDesc(transformation.getDescription());
         }
     }
 }

--- a/flink-streaming-java/src/main/java/org/apache/flink/streaming/api/graph/StreamNode.java
+++ b/flink-streaming-java/src/main/java/org/apache/flink/streaming/api/graph/StreamNode.java
@@ -65,6 +65,7 @@ public class StreamNode {
     private final Set<ManagedMemoryUseCase> managedMemorySlotScopeUseCases = new HashSet<>();
     private long bufferTimeout;
     private final String operatorName;
+    private @Nullable String operatorDesc;
     private @Nullable String slotSharingGroup;
     private @Nullable String coLocationGroup;
     private KeySelector<?, ?>[] statePartitioners = new KeySelector[0];
@@ -240,6 +241,14 @@ public class StreamNode {
 
     public String getOperatorName() {
         return operatorName;
+    }
+
+    public String getOperatorDesc() {
+        return null == operatorDesc ? operatorName : operatorDesc;
+    }
+
+    public void setOperatorDesc(String operatorDesc) {
+        this.operatorDesc = operatorDesc;
     }
 
     public void setSerializersIn(TypeSerializer<?>... typeSerializersIn) {

--- a/flink-streaming-java/src/main/java/org/apache/flink/streaming/api/graph/StreamNode.java
+++ b/flink-streaming-java/src/main/java/org/apache/flink/streaming/api/graph/StreamNode.java
@@ -65,7 +65,7 @@ public class StreamNode {
     private final Set<ManagedMemoryUseCase> managedMemorySlotScopeUseCases = new HashSet<>();
     private long bufferTimeout;
     private final String operatorName;
-    private @Nullable String operatorDesc;
+    private @Nullable String operatorDescription;
     private @Nullable String slotSharingGroup;
     private @Nullable String coLocationGroup;
     private KeySelector<?, ?>[] statePartitioners = new KeySelector[0];
@@ -243,12 +243,12 @@ public class StreamNode {
         return operatorName;
     }
 
-    public String getOperatorDesc() {
-        return null == operatorDesc ? operatorName : operatorDesc;
+    public String getOperatorDescription() {
+        return null == operatorDescription ? operatorName : operatorDescription;
     }
 
-    public void setOperatorDesc(String operatorDesc) {
-        this.operatorDesc = operatorDesc;
+    public void setOperatorDescription(String operatorDescription) {
+        this.operatorDescription = operatorDescription;
     }
 
     public void setSerializersIn(TypeSerializer<?>... typeSerializersIn) {

--- a/flink-streaming-java/src/main/java/org/apache/flink/streaming/api/graph/StreamNode.java
+++ b/flink-streaming-java/src/main/java/org/apache/flink/streaming/api/graph/StreamNode.java
@@ -65,7 +65,7 @@ public class StreamNode {
     private final Set<ManagedMemoryUseCase> managedMemorySlotScopeUseCases = new HashSet<>();
     private long bufferTimeout;
     private final String operatorName;
-    private @Nullable String operatorDescription;
+    private String operatorDescription;
     private @Nullable String slotSharingGroup;
     private @Nullable String coLocationGroup;
     private KeySelector<?, ?>[] statePartitioners = new KeySelector[0];
@@ -114,6 +114,7 @@ public class StreamNode {
             Class<? extends TaskInvokable> jobVertexClass) {
         this.id = id;
         this.operatorName = operatorName;
+        this.operatorDescription = operatorName;
         this.operatorFactory = operatorFactory;
         this.jobVertexClass = jobVertexClass;
         this.slotSharingGroup = slotSharingGroup;
@@ -244,7 +245,7 @@ public class StreamNode {
     }
 
     public String getOperatorDescription() {
-        return null == operatorDescription ? operatorName : operatorDescription;
+        return operatorDescription;
     }
 
     public void setOperatorDescription(String operatorDescription) {

--- a/flink-streaming-scala/src/main/scala/org/apache/flink/streaming/api/scala/DataStream.scala
+++ b/flink-streaming-scala/src/main/scala/org/apache/flink/streaming/api/scala/DataStream.scala
@@ -1227,14 +1227,19 @@ class DataStream[T](stream: JavaStream[T]) {
   }
 
   /**
-   * Sets the description of the current data stream. This description is in json plan,
-   * is expected to provide more detailed information about the operation than name.
+   * Sets the description of this data stream.
+   *
+   * <p>Description is used in json plan and web ui, but not in logging and metrics where only
+   * name is available. Description is expected to provide detailed information about
+   * this operation, while name is expected to be more simple, providing summary information only,
+   * so that we can have more user-friendly logging messages and metric tags
+   * without losing useful messages for debugging.
    *
    * @return The operator with new description
    */
   @PublicEvolving
-  def setDescription(desc: String) : DataStream[T] = stream match {
-    case stream : SingleOutputStreamOperator[T] => asScalaStream(stream.setDescription(desc))
+  def setDescription(description: String) : DataStream[T] = stream match {
+    case stream : SingleOutputStreamOperator[T] => asScalaStream(stream.setDescription(description))
     case _ => throw new UnsupportedOperationException("Only supported for operators.")
       this
   }

--- a/flink-streaming-scala/src/main/scala/org/apache/flink/streaming/api/scala/DataStream.scala
+++ b/flink-streaming-scala/src/main/scala/org/apache/flink/streaming/api/scala/DataStream.scala
@@ -1225,4 +1225,17 @@ class DataStream[T](stream: JavaStream[T]) {
       operator: OneInputStreamOperator[T, R]): DataStream[R] = {
     asScalaStream(stream.transform(operatorName, implicitly[TypeInformation[R]], operator))
   }
+
+  /**
+   * Sets the description of the current data stream. This description is in json plan,
+   * is expected to provide more detailed information about the operation than name.
+   *
+   * @return The operator with new description
+   */
+  @PublicEvolving
+  def setDescription(desc: String) : DataStream[T] = stream match {
+    case stream : SingleOutputStreamOperator[T] => asScalaStream(stream.setDescription(desc))
+    case _ => throw new UnsupportedOperationException("Only supported for operators.")
+      this
+  }
 }

--- a/flink-streaming-scala/src/test/scala/org/apache/flink/streaming/api/scala/DataStreamTest.scala
+++ b/flink-streaming-scala/src/test/scala/org/apache/flink/streaming/api/scala/DataStreamTest.scala
@@ -137,8 +137,8 @@ class DataStreamTest extends AbstractTestBase {
   def testPartitioning(): Unit = {
     val env = StreamExecutionEnvironment.getExecutionEnvironment
 
-    val src1 = env.fromElements((0L, 0L))
-    val src2 = env.fromElements((0L, 0L))
+    val src1: DataStream[(Long, Long)] = env.fromElements((0L, 0L))
+    val src2: DataStream[(Long, Long)] = env.fromElements((0L, 0L))
 
     val connected = src1.connect(src2)
 
@@ -157,10 +157,10 @@ class DataStreamTest extends AbstractTestBase {
     assert(isPartitioned(getStreamGraph(env).getStreamEdgesOrThrow(src1.getId, gid4)))
 
     //Testing DataStream partitioning
-    val partition1 = src1.keyBy(0)
-    val partition2 = src1.keyBy(1, 0)
-    val partition3 = src1.keyBy("_1")
-    val partition4 = src1.keyBy((x : (Long, Long)) => x._1)
+    val partition1: DataStream[_] = src1.keyBy(0)
+    val partition2: DataStream[_] = src1.keyBy(1, 0)
+    val partition3: DataStream[_] = src1.keyBy("_1")
+    val partition4: DataStream[_] = src1.keyBy((x : (Long, Long)) => x._1)
 
     val pid1 = createDownStreamId(partition1)
     val pid2 = createDownStreamId(partition2)
@@ -173,15 +173,15 @@ class DataStreamTest extends AbstractTestBase {
     assert(isPartitioned(getStreamGraph(env).getStreamEdgesOrThrow(src1.getId, pid4)))
 
     // Testing DataStream custom partitioning
-    val longPartitioner = new Partitioner[Long] {
-      override def partition(key: Long, numPartitions: Int) = 0
+    val longPartitioner: Partitioner[Long] = new Partitioner[Long] {
+      override def partition(key: Long, numPartitions: Int): Int = 0
     }
 
-    val customPartition1 =
+    val customPartition1: DataStream[_] =
       src1.partitionCustom(longPartitioner, 0)
-    val customPartition3 =
+    val customPartition3: DataStream[_] =
       src1.partitionCustom(longPartitioner, "_1")
-    val customPartition4 =
+    val customPartition4: DataStream[_] =
       src1.partitionCustom(longPartitioner, (x : (Long, Long)) => x._1)
 
     val cpid1 = createDownStreamId(customPartition1)
@@ -192,21 +192,21 @@ class DataStreamTest extends AbstractTestBase {
     assert(isCustomPartitioned(getStreamGraph(env).getStreamEdgesOrThrow(src1.getId, cpid3)))
 
     //Testing ConnectedStreams grouping
-    val connectedGroup1 = connected.keyBy(0, 0)
-    val downStreamId1 = createDownStreamId(connectedGroup1)
+    val connectedGroup1: ConnectedStreams[_, _] = connected.keyBy(0, 0)
+    val downStreamId1: Integer = createDownStreamId(connectedGroup1)
 
-    val connectedGroup2 = connected.keyBy(Array[Int](0), Array[Int](0))
-    val downStreamId2 = createDownStreamId(connectedGroup2)
+    val connectedGroup2: ConnectedStreams[_, _] = connected.keyBy(Array[Int](0), Array[Int](0))
+    val downStreamId2: Integer = createDownStreamId(connectedGroup2)
 
-    val connectedGroup3 = connected.keyBy("_1", "_1")
-    val downStreamId3 = createDownStreamId(connectedGroup3)
+    val connectedGroup3: ConnectedStreams[_, _] = connected.keyBy("_1", "_1")
+    val downStreamId3: Integer = createDownStreamId(connectedGroup3)
 
-    val connectedGroup4 =
+    val connectedGroup4: ConnectedStreams[_, _] =
       connected.keyBy(Array[String]("_1"), Array[String]("_1"))
-    val downStreamId4 = createDownStreamId(connectedGroup4)
+    val downStreamId4: Integer = createDownStreamId(connectedGroup4)
 
-    val connectedGroup5 = connected.keyBy(x => x._1, x => x._1)
-    val downStreamId5 = createDownStreamId(connectedGroup5)
+    val connectedGroup5: ConnectedStreams[_, _] = connected.keyBy(x => x._1, x => x._1)
+    val downStreamId5: Integer = createDownStreamId(connectedGroup5)
 
     assert(isPartitioned(getStreamGraph(env).getStreamEdgesOrThrow(src1.getId, downStreamId1)))
     assert(isPartitioned(getStreamGraph(env).getStreamEdgesOrThrow(src2.getId, downStreamId1)))
@@ -224,23 +224,23 @@ class DataStreamTest extends AbstractTestBase {
     assert(isPartitioned(getStreamGraph(env).getStreamEdgesOrThrow(src2.getId, downStreamId5)))
 
     //Testing ConnectedStreams partitioning
-    val connectedPartition1 = connected.keyBy(0, 0)
-    val connectDownStreamId1 = createDownStreamId(connectedPartition1)
+    val connectedPartition1: ConnectedStreams[_, _] = connected.keyBy(0, 0)
+    val connectDownStreamId1: Integer = createDownStreamId(connectedPartition1)
 
-    val connectedPartition2 =
+    val connectedPartition2: ConnectedStreams[_, _] =
       connected.keyBy(Array[Int](0), Array[Int](0))
-    val connectDownStreamId2 = createDownStreamId(connectedPartition2)
+    val connectDownStreamId2: Integer = createDownStreamId(connectedPartition2)
 
-    val connectedPartition3 = connected.keyBy("_1", "_1")
-    val connectDownStreamId3 = createDownStreamId(connectedPartition3)
+    val connectedPartition3: ConnectedStreams[_, _] = connected.keyBy("_1", "_1")
+    val connectDownStreamId3: Integer = createDownStreamId(connectedPartition3)
 
-    val connectedPartition4 =
+    val connectedPartition4: ConnectedStreams[_, _] =
       connected.keyBy(Array[String]("_1"), Array[String]("_1"))
-    val connectDownStreamId4 = createDownStreamId(connectedPartition4)
+    val connectDownStreamId4: Integer = createDownStreamId(connectedPartition4)
 
-    val connectedPartition5 =
+    val connectedPartition5: ConnectedStreams[_, _] =
       connected.keyBy(x => x._1, x => x._1)
-    val connectDownStreamId5 = createDownStreamId(connectedPartition5)
+    val connectDownStreamId5: Integer = createDownStreamId(connectedPartition5)
 
     assert(
       isPartitioned(getStreamGraph(env).getStreamEdgesOrThrow(src1.getId, connectDownStreamId1))


### PR DESCRIPTION
…StreamGraph

## What is the purpose of the change
Introduce an optional field `description` on transformation and StreamGraph which allow use to set a more detailed information about an operation without affecting name of job vertex, will be used to construct description of job vertex in FLINK-25073.

## Brief change log

  - *introduce a new interface to set description on DataStream API*
  - *transpose the description from Transformation to StreamGraph*

## Verifying this change

This change added tests and can be verified as follows:

*(example:)*
  - *Added tests in DataStreamTest to make sure that description is transposed exactly *

## Does this pull request potentially affect one of the following parts:

  - Dependencies (does it add or upgrade a dependency): (no)
  - The public API, i.e., is any changed class annotated with `@Public(Evolving)`: (no)
  - The serializers: (no)
  - The runtime per-record code paths (performance sensitive): (no)
  - Anything that affects deployment or recovery: JobManager (and its components), Checkpointing, Kubernetes/Yarn, ZooKeeper: (no)
  - The S3 file system connector: (no)

## Documentation

  - Does this pull request introduce a new feature? (yes)
  - If yes, how is the feature documented? (JavaDocs)
