### PR TITLE
[FLINK-21467][docs] Clarify javadocs of Bounded(One/Multi)Input interfaces

### DIFF
--- a/flink-streaming-java/src/main/java/org/apache/flink/streaming/api/operators/BoundedMultiInput.java
+++ b/flink-streaming-java/src/main/java/org/apache/flink/streaming/api/operators/BoundedMultiInput.java
@@ -19,13 +19,25 @@ package org.apache.flink.streaming.api.operators;
 
 import org.apache.flink.annotation.PublicEvolving;
 
-/** Interface for the multi-input operators that can process EndOfInput event. */
+/**
+ * Interface for multi-input operators that need to be notified about the logical/semantical end of
+ * input.
+ *
+ * <p><b>NOTE:</b> Classes should not implement both {@link BoundedOneInput} and {@link
+ * BoundedMultiInput} at the same time!
+ *
+ * @see BoundedOneInput
+ */
 @PublicEvolving
 public interface BoundedMultiInput {
 
     /**
-     * It is notified that no more data will arrive on the input identified by the {@code inputId}.
-     * The {@code inputId} is numbered starting from 1, and `1` indicates the first input.
+     * It is notified that no more data will arrive from the input identified by the {@code
+     * inputId}. The {@code inputId} is numbered starting from 1, and `1` indicates the first input.
+     *
+     * <p><b>WARNING:</b> It is not safe to use this method to commit any transactions or other side
+     * effects! You can use this method to e.g. flush data buffered for the given input or implement
+     * an ordered reading from multiple inputs via {@link InputSelectable}.
      */
     void endInput(int inputId) throws Exception;
 }

--- a/flink-streaming-java/src/main/java/org/apache/flink/streaming/api/operators/BoundedOneInput.java
+++ b/flink-streaming-java/src/main/java/org/apache/flink/streaming/api/operators/BoundedOneInput.java
@@ -19,10 +19,28 @@ package org.apache.flink.streaming.api.operators;
 
 import org.apache.flink.annotation.PublicEvolving;
 
-/** Interface for the one-input operators that can process EndOfInput event. */
+/**
+ * Interface for one-input operators that need to be notified about the logical/semantical end of
+ * input.
+ *
+ * <p><b>NOTE:</b> Classes should not implement both {@link BoundedOneInput} and {@link
+ * BoundedMultiInput} at the same time!
+ *
+ * @see BoundedMultiInput
+ * @see StreamOperator#finish()
+ */
 @PublicEvolving
 public interface BoundedOneInput {
 
-    /** It is notified that no more data will arrive on the input. */
+    /**
+     * It is notified that no more data will arrive from the input.
+     *
+     * <p><b>WARNING:</b> It is not safe to use this method to commit any transactions or other side
+     * effects! You can use this method to flush any buffered data that can later on be committed
+     * e.g. in a {@link StreamOperator#notifyCheckpointComplete(long)}.
+     *
+     * <p><b>NOTE:</b> Given it is semantically very similar to the {@link StreamOperator#finish()}
+     * method. It might be dropped in favour of the other method at some point in time.
+     */
     void endInput() throws Exception;
 }

--- a/flink-streaming-java/src/main/java/org/apache/flink/streaming/api/operators/StreamOperator.java
+++ b/flink-streaming-java/src/main/java/org/apache/flink/streaming/api/operators/StreamOperator.java
@@ -65,11 +65,15 @@ public interface StreamOperator<OUT> extends CheckpointListener, KeyContext, Ser
      * This method is called at the end of data processing.
      *
      * <p>The method is expected to flush all remaining buffered data. Exceptions during this
-     * flushing of buffered should be propagated, in order to cause the operation to be recognized
-     * as failed, because the last data items are not processed properly.
+     * flushing of buffered data should be propagated, in order to cause the operation to be
+     * recognized as failed, because the last data items are not processed properly.
      *
      * <p><b>After this method is called, no more records can be produced for the downstream
      * operators.</b>
+     *
+     * <p><b>WARNING:</b> It is not safe to use this method to commit any transactions or other side
+     * effects! You can use this method to flush any buffered data that can later on be committed
+     * e.g. in a {@link StreamOperator#notifyCheckpointComplete(long)}.
      *
      * <p><b>NOTE:</b>This method does not need to close any resources. You should release external
      * resources in the {@link #close()} method.


### PR DESCRIPTION

## What is the purpose of the change

We clarify contracts of Bounded(One/Multi)Input interfaces. Especially
adding a warning none of those interfaces should be used for commiting
side effects.


## Verifying this change

This change is a trivial rework / code cleanup without any test coverage.

## Does this pull request potentially affect one of the following parts:

  - Dependencies (does it add or upgrade a dependency): (yes / **no**)
  - The public API, i.e., is any changed class annotated with `@Public(Evolving)`: (yes / **no**)
  - The serializers: (yes / **no** / don't know)
  - The runtime per-record code paths (performance sensitive): (yes / **no** / don't know)
  - Anything that affects deployment or recovery: JobManager (and its components), Checkpointing, Kubernetes/Yarn, ZooKeeper: (yes / **no** / don't know)
  - The S3 file system connector: (yes / **no** / don't know)

## Documentation

  - Does this pull request introduce a new feature? (yes / **no**)
  - If yes, how is the feature documented? (not applicable / docs / **JavaDocs** / not documented)
