### PR TITLE
[FLINK-24954][network] Refresh read buffer request timeout on buffer recycling/requesting for sort-shuffle

### DIFF
--- a/flink-runtime/src/main/java/org/apache/flink/runtime/io/network/partition/SortMergeResultPartition.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/io/network/partition/SortMergeResultPartition.java
@@ -458,7 +458,7 @@ public class SortMergeResultPartition extends ResultPartition {
             checkState(!isReleased(), "Partition released.");
             checkState(isFinished(), "Trying to read unfinished blocking partition.");
 
-            return readScheduler.crateSubpartitionReader(
+            return readScheduler.createSubpartitionReader(
                     availabilityListener, subpartitionIndex, resultFile);
         }
     }

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/io/network/partition/SortMergeResultPartitionReadScheduler.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/io/network/partition/SortMergeResultPartitionReadScheduler.java
@@ -289,7 +289,7 @@ class SortMergeResultPartitionReadScheduler implements Runnable, BufferRecycler 
         }
     }
 
-    SortMergeSubpartitionReader crateSubpartitionReader(
+    SortMergeSubpartitionReader createSubpartitionReader(
             BufferAvailabilityListener availabilityListener,
             int targetSubpartition,
             PartitionedFile resultFile)

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/io/network/partition/SortMergeResultPartitionReadScheduler.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/io/network/partition/SortMergeResultPartitionReadScheduler.java
@@ -19,7 +19,6 @@
 package org.apache.flink.runtime.io.network.partition;
 
 import org.apache.flink.annotation.VisibleForTesting;
-import org.apache.flink.api.common.time.Deadline;
 import org.apache.flink.configuration.TaskManagerOptions;
 import org.apache.flink.core.memory.MemorySegment;
 import org.apache.flink.runtime.io.disk.BatchShuffleReadBufferPool;
@@ -65,10 +64,10 @@ class SortMergeResultPartitionReadScheduler implements Runnable, BufferRecycler 
             LoggerFactory.getLogger(SortMergeResultPartitionReadScheduler.class);
 
     /**
-     * Maximum time (5min) to wait when requesting read buffers from the buffer pool before throwing
-     * an exception.
+     * Default maximum time (5min) to wait when requesting read buffers from the buffer pool before
+     * throwing an exception.
      */
-    private static final Duration BUFFER_REQUEST_TIMEOUT = Duration.ofMinutes(5);
+    private static final Duration DEFAULT_BUFFER_REQUEST_TIMEOUT = Duration.ofMinutes(5);
 
     /** Lock used to synchronize multi-thread access to thread-unsafe fields. */
     private final Object lock;
@@ -87,6 +86,12 @@ class SortMergeResultPartitionReadScheduler implements Runnable, BufferRecycler 
 
     /** Maximum number of buffers can be allocated by this partition reader. */
     private final int maxRequestedBuffers;
+
+    /**
+     * Maximum time to wait when requesting read buffers from the buffer pool before throwing an
+     * exception.
+     */
+    private final Duration bufferRequestTimeout;
 
     /** All failed subpartition readers to be released. */
     @GuardedBy("lock")
@@ -121,12 +126,22 @@ class SortMergeResultPartitionReadScheduler implements Runnable, BufferRecycler 
 
     SortMergeResultPartitionReadScheduler(
             BatchShuffleReadBufferPool bufferPool, Executor ioExecutor, Object lock) {
+        this(bufferPool, ioExecutor, lock, DEFAULT_BUFFER_REQUEST_TIMEOUT);
+    }
+
+    SortMergeResultPartitionReadScheduler(
+            BatchShuffleReadBufferPool bufferPool,
+            Executor ioExecutor,
+            Object lock,
+            Duration bufferRequestTimeout) {
+
         this.lock = checkNotNull(lock);
         this.bufferPool = checkNotNull(bufferPool);
         this.ioExecutor = checkNotNull(ioExecutor);
         // one partition reader can consume at most 32M (the expected buffers per request is 8M)
         // buffers for data read. Currently, it is only an empirical value can not be configured
         this.maxRequestedBuffers = Math.max(1, 4 * bufferPool.getNumBuffersPerRequest());
+        this.bufferRequestTimeout = checkNotNull(bufferRequestTimeout);
 
         // initialize the buffer pool eagerly to avoid reporting errors like OOM too late
         bufferPool.initialize();
@@ -147,21 +162,22 @@ class SortMergeResultPartitionReadScheduler implements Runnable, BufferRecycler 
         removeFinishedAndFailedReaders(numBuffersRead, finishedReaders);
     }
 
-    private Queue<MemorySegment> allocateBuffers(
-            Queue<SortMergeSubpartitionReader> availableReaders) {
+    @VisibleForTesting
+    Queue<MemorySegment> allocateBuffers(Queue<SortMergeSubpartitionReader> availableReaders) {
         if (availableReaders.isEmpty()) {
             return new ArrayDeque<>();
         }
 
         try {
-            Deadline deadline = Deadline.fromNow(BUFFER_REQUEST_TIMEOUT);
-            while (deadline.hasTimeLeft()) {
+            long timeoutTime = getBufferRequestTimeoutTime();
+            do {
                 List<MemorySegment> buffers = bufferPool.requestBuffers();
                 if (!buffers.isEmpty()) {
                     return new ArrayDeque<>(buffers);
                 }
                 checkState(!isReleased, "Result partition has been already released.");
-            }
+            } while (System.nanoTime() < timeoutTime
+                    || System.nanoTime() < (timeoutTime = getBufferRequestTimeoutTime()));
 
             if (numRequestedBuffers <= 0) {
                 throw new TimeoutException(
@@ -176,6 +192,10 @@ class SortMergeResultPartitionReadScheduler implements Runnable, BufferRecycler 
             LOG.error("Failed to request buffers for data reading.", throwable);
         }
         return new ArrayDeque<>();
+    }
+
+    private long getBufferRequestTimeoutTime() {
+        return bufferPool.getLastBufferOperationTimestamp() + bufferRequestTimeout.toNanos();
     }
 
     private void releaseBuffers(Queue<MemorySegment> buffers) {

--- a/flink-runtime/src/test/java/org/apache/flink/runtime/io/network/partition/SortMergeResultPartitionReadSchedulerTest.java
+++ b/flink-runtime/src/test/java/org/apache/flink/runtime/io/network/partition/SortMergeResultPartitionReadSchedulerTest.java
@@ -105,7 +105,7 @@ public class SortMergeResultPartitionReadSchedulerTest extends TestLogger {
     @Test
     public void testCreateSubpartitionReader() throws Exception {
         SortMergeSubpartitionReader subpartitionReader =
-                readScheduler.crateSubpartitionReader(
+                readScheduler.createSubpartitionReader(
                         new NoOpBufferAvailablityListener(), 0, partitionedFile);
 
         assertTrue(readScheduler.isRunning());
@@ -128,7 +128,7 @@ public class SortMergeResultPartitionReadSchedulerTest extends TestLogger {
     @Test
     public void testOnSubpartitionReaderError() throws Exception {
         SortMergeSubpartitionReader subpartitionReader =
-                readScheduler.crateSubpartitionReader(
+                readScheduler.createSubpartitionReader(
                         new NoOpBufferAvailablityListener(), 0, partitionedFile);
 
         subpartitionReader.releaseAllResources();
@@ -139,7 +139,7 @@ public class SortMergeResultPartitionReadSchedulerTest extends TestLogger {
     @Test
     public void testReleaseWhileReading() throws Exception {
         SortMergeSubpartitionReader subpartitionReader =
-                readScheduler.crateSubpartitionReader(
+                readScheduler.createSubpartitionReader(
                         new NoOpBufferAvailablityListener(), 0, partitionedFile);
 
         Thread.sleep(1000);
@@ -158,7 +158,7 @@ public class SortMergeResultPartitionReadSchedulerTest extends TestLogger {
     public void testCreateSubpartitionReaderAfterReleased() throws Exception {
         readScheduler.release();
         try {
-            readScheduler.crateSubpartitionReader(
+            readScheduler.createSubpartitionReader(
                     new NoOpBufferAvailablityListener(), 0, partitionedFile);
         } finally {
             assertAllResourcesReleased();
@@ -168,7 +168,7 @@ public class SortMergeResultPartitionReadSchedulerTest extends TestLogger {
     @Test
     public void testOnDataReadError() throws Exception {
         SortMergeSubpartitionReader subpartitionReader =
-                readScheduler.crateSubpartitionReader(
+                readScheduler.createSubpartitionReader(
                         new NoOpBufferAvailablityListener(), 0, partitionedFile);
 
         // close file channel to trigger data read exception
@@ -191,7 +191,7 @@ public class SortMergeResultPartitionReadSchedulerTest extends TestLogger {
     @Test
     public void testOnReadBufferRequestError() throws Exception {
         SortMergeSubpartitionReader subpartitionReader =
-                readScheduler.crateSubpartitionReader(
+                readScheduler.createSubpartitionReader(
                         new NoOpBufferAvailablityListener(), 0, partitionedFile);
 
         bufferPool.destroy();
@@ -212,7 +212,7 @@ public class SortMergeResultPartitionReadSchedulerTest extends TestLogger {
                         bufferPool, executor, this, bufferRequestTimeout);
 
         SortMergeSubpartitionReader subpartitionReader =
-                readScheduler.crateSubpartitionReader(
+                readScheduler.createSubpartitionReader(
                         new NoOpBufferAvailablityListener(), 0, partitionedFile);
 
         PriorityQueue<SortMergeSubpartitionReader> allReaders = new PriorityQueue<>();

--- a/flink-runtime/src/test/java/org/apache/flink/runtime/io/network/partition/SortMergeResultPartitionReadSchedulerTest.java
+++ b/flink-runtime/src/test/java/org/apache/flink/runtime/io/network/partition/SortMergeResultPartitionReadSchedulerTest.java
@@ -18,8 +18,10 @@
 
 package org.apache.flink.runtime.io.network.partition;
 
+import org.apache.flink.core.memory.MemorySegment;
 import org.apache.flink.runtime.io.disk.BatchShuffleReadBufferPool;
 import org.apache.flink.runtime.io.network.buffer.Buffer;
+import org.apache.flink.util.ExceptionUtils;
 import org.apache.flink.util.TestLogger;
 
 import org.junit.After;
@@ -29,7 +31,16 @@ import org.junit.Test;
 import org.junit.rules.TemporaryFolder;
 import org.junit.rules.Timeout;
 
+import java.io.IOException;
 import java.nio.ByteBuffer;
+import java.nio.channels.FileChannel;
+import java.nio.file.Path;
+import java.nio.file.StandardOpenOption;
+import java.time.Duration;
+import java.util.LinkedList;
+import java.util.List;
+import java.util.PriorityQueue;
+import java.util.Queue;
 import java.util.Random;
 import java.util.concurrent.ExecutorService;
 import java.util.concurrent.Executors;
@@ -190,6 +201,102 @@ public class SortMergeResultPartitionReadSchedulerTest extends TestLogger {
         assertNotNull(subpartitionReader.getFailureCause());
         assertTrue(subpartitionReader.getAvailabilityAndBacklog(0).isAvailable());
         assertAllResourcesReleased();
+    }
+
+    @Test
+    public void testRequestBufferTimeoutAndFailed() throws Exception {
+        Duration bufferRequestTimeout = Duration.ofSeconds(3);
+        List<MemorySegment> buffers = bufferPool.requestBuffers();
+        SortMergeResultPartitionReadScheduler readScheduler =
+                new SortMergeResultPartitionReadScheduler(
+                        bufferPool, executor, this, bufferRequestTimeout);
+
+        SortMergeSubpartitionReader subpartitionReader =
+                readScheduler.crateSubpartitionReader(
+                        new NoOpBufferAvailablityListener(), 0, partitionedFile);
+
+        PriorityQueue<SortMergeSubpartitionReader> allReaders = new PriorityQueue<>();
+        allReaders.add(subpartitionReader);
+
+        long startTimestamp = System.nanoTime();
+        Queue<MemorySegment> allocatedBuffers = readScheduler.allocateBuffers(allReaders);
+        long requestDuration = System.nanoTime() - startTimestamp;
+
+        assertEquals(0, allocatedBuffers.size());
+        assertTrue(requestDuration > bufferRequestTimeout.toNanos());
+        assertExpectedTimeoutException(subpartitionReader.getFailureCause());
+
+        bufferPool.recycle(buffers);
+        readScheduler.release();
+    }
+
+    @Test
+    public void testRequestTimeoutIsRefreshedAndSuccess() throws Exception {
+        Duration bufferRequestTimeout = Duration.ofSeconds(3);
+        FakeBatchShuffleReadBufferPool bufferPool =
+                new FakeBatchShuffleReadBufferPool(bufferSize * 3, bufferSize);
+        SortMergeResultPartitionReadScheduler readScheduler =
+                new SortMergeResultPartitionReadScheduler(
+                        bufferPool, executor, this, bufferRequestTimeout);
+
+        FileChannel dataFileChannel = openFileChannel(partitionedFile.getDataFilePath());
+        FileChannel indexFileChannel = openFileChannel(partitionedFile.getIndexFilePath());
+
+        PartitionedFileReader fileReader =
+                new PartitionedFileReader(partitionedFile, 0, dataFileChannel, indexFileChannel);
+
+        SortMergeSubpartitionReader subpartitionReader =
+                new SortMergeSubpartitionReader(new NoOpBufferAvailablityListener(), fileReader);
+
+        PriorityQueue<SortMergeSubpartitionReader> allReaders = new PriorityQueue<>();
+        allReaders.add(subpartitionReader);
+
+        long startTimestamp = System.nanoTime();
+        Queue<MemorySegment> allocatedBuffers = readScheduler.allocateBuffers(allReaders);
+        long requestDuration = System.nanoTime() - startTimestamp;
+
+        assertEquals(3, allocatedBuffers.size());
+        assertTrue(requestDuration > bufferRequestTimeout.toNanos() * 2);
+        assertNull(subpartitionReader.getFailureCause());
+
+        bufferPool.recycle(allocatedBuffers);
+        bufferPool.destroy();
+        dataFileChannel.close();
+        indexFileChannel.close();
+        readScheduler.release();
+    }
+
+    private static class FakeBatchShuffleReadBufferPool extends BatchShuffleReadBufferPool {
+        private final Queue<MemorySegment> requestedBuffers;
+
+        FakeBatchShuffleReadBufferPool(long totalBytes, int bufferSize) throws Exception {
+            super(totalBytes, bufferSize);
+            this.requestedBuffers = new LinkedList<>(requestBuffers());
+        }
+
+        @Override
+        public long getLastBufferOperationTimestamp() {
+            recycle(requestedBuffers.poll());
+            return super.getLastBufferOperationTimestamp();
+        }
+
+        @Override
+        public void destroy() {
+            recycle(requestedBuffers);
+            requestedBuffers.clear();
+            super.destroy();
+        }
+    }
+
+    private static FileChannel openFileChannel(Path path) throws IOException {
+        return FileChannel.open(path, StandardOpenOption.READ);
+    }
+
+    private static void assertExpectedTimeoutException(Throwable throwable) {
+        assertNotNull(throwable);
+        assertTrue(
+                ExceptionUtils.findThrowableWithMessage(throwable, "Buffer request timeout")
+                        .isPresent());
     }
 
     private void assertAllResourcesReleased() {


### PR DESCRIPTION
<!--
*Thank you very much for contributing to Apache Flink - we are happy that you want to help us improve Flink. To help the community review your contribution in the best possible way, please go through the checklist below, which will get the contribution into a shape in which it can be best reviewed.*

*Please understand that we do not do this to make contributions to Flink a hassle. In order to uphold a high standard of quality for code contributions, while at the same time managing a large number of contributions, we need contributors to prepare the contributions well, and give reviewers enough contextual information for the review. Please also understand that contributions that do not follow this guide will take longer to review and thus typically be picked up with lower priority by the community.*

## Contribution Checklist

  - Make sure that the pull request corresponds to a [JIRA issue](https://issues.apache.org/jira/projects/FLINK/issues). Exceptions are made for typos in JavaDoc or documentation files, which need no JIRA issue.
  
  - Name the pull request in the form "[FLINK-XXXX] [component] Title of the pull request", where *FLINK-XXXX* should be replaced by the actual issue number. Skip *component* if you are unsure about which is the best component.
  Typo fixes that have no associated JIRA issue should be named following this pattern: `[hotfix] [docs] Fix typo in event time introduction` or `[hotfix] [javadocs] Expand JavaDoc for PuncuatedWatermarkGenerator`.

  - Fill out the template below to describe the changes contributed by the pull request. That will give reviewers the context they need to do the review.
  
  - Make sure that the change passes the automated tests, i.e., `mvn clean verify` passes. You can set up Azure Pipelines CI to do that following [this guide](https://cwiki.apache.org/confluence/display/FLINK/Azure+Pipelines#AzurePipelines-Tutorial:SettingupAzurePipelinesforaforkoftheFlinkrepository).

  - Each pull request should address only one issue, not mix up code from multiple issues.
  
  - Each commit in the pull request has a meaningful commit message (including the JIRA id)

  - Once all items of the checklist are addressed, remove the above text and this checklist, leaving only the filled out template below.


**(The sections below can be removed for hotfixes of typos)**
-->

## What is the purpose of the change

Currently, the read buffer request timeout implementation of sort-shuffle is a little aggressive. As reported in the mailing list: https://lists.apache.org/thread/bd3s5bqfg9oxlb1g1gg3pxs3577lhf88. The `TimeoutException` may be triggered if there is data skew and the downstream task is slow. Actually, we can further improve this case by reseting the request timeout on buffer recycling. 

When at least one buffer is recycled, we know that the downstream is in a normal state, so the buffer request timeout should be reset to avoid throwing a timeout exception.

## Brief change log

  - *Reset the request buffer timeout if at least one buffer is recycled*
  - *Fix spelling error in method name `SortMergeResultPartitionReadScheduler#createSubpartitionReader`*

## Verifying this change

This change added tests and can be verified as follows:

  - *Added test that validates that the buffer request timeout when there was no recycled buffer*
  - *Added test that validates that the buffer request timeout would be increased when at least one buffer is recycled, and the request will not be timeout*

## Does this pull request potentially affect one of the following parts:

  - Dependencies (does it add or upgrade a dependency): (yes / **no**)
  - The public API, i.e., is any changed class annotated with `@Public(Evolving)`: (yes / **no**)
  - The serializers: (yes / **no** / don't know)
  - The runtime per-record code paths (performance sensitive): (yes / **no** / don't know)
  - Anything that affects deployment or recovery: JobManager (and its components), Checkpointing, Kubernetes/Yarn, ZooKeeper: (yes / **no** / don't know)
  - The S3 file system connector: (yes / **no** / don't know)

## Documentation

  - Does this pull request introduce a new feature? (yes / **no**)
  - If yes, how is the feature documented? (**not applicable** / docs / JavaDocs / not documented)
