### PR TITLE
[FLINK-25073][streaming] Introduce TreeMode description for vertices

### DIFF
--- a/docs/layouts/shortcodes/generated/pipeline_configuration.html
+++ b/docs/layouts/shortcodes/generated/pipeline_configuration.html
@@ -116,5 +116,11 @@
             <td>List&lt;String&gt;</td>
             <td>Semicolon separated list of types to be registered with the serialization stack. If the type is eventually serialized as a POJO, then the type is registered with the POJO serializer. If the type ends up being serialized with Kryo, then it will be registered at Kryo to make sure that only tags are written.</td>
         </tr>
+        <tr>
+            <td><h5>pipeline.vertex-description-mode</h5></td>
+            <td style="word-wrap: break-word;">TREE</td>
+            <td><p>Enum</p></td>
+            <td>The mode how we organize description of a job vertex.<br /><br />Possible values:<ul><li>"TREE"</li><li>"CASCADING"</li></ul></td>
+        </tr>
     </tbody>
 </table>

--- a/flink-core/src/main/java/org/apache/flink/configuration/PipelineOptions.java
+++ b/flink-core/src/main/java/org/apache/flink/configuration/PipelineOptions.java
@@ -259,4 +259,19 @@ public class PipelineOptions {
                                             TextElement.code(
                                                     "name:file1,path:`file:///tmp/file1`;name:file2,path:`hdfs:///tmp/file2`"))
                                     .build());
+
+    public static final ConfigOption<VertexDescriptionMode> VERTEX_DESCRIPTION_MODE =
+            key("pipeline.vertex-description-mode")
+                    .enumType(VertexDescriptionMode.class)
+                    .defaultValue(VertexDescriptionMode.TREE)
+                    .withDescription("The mode how we organize description of a job vertex.");
+
+    /** The mode how we organize description of a vertex. */
+    @PublicEvolving
+    public enum VertexDescriptionMode {
+        /** Organizes the description in a multi line tree mode. */
+        TREE,
+        /** Organizes the description in a single line cascading mode, which is similar to name. */
+        CASCADING
+    }
 }

--- a/flink-runtime-web/web-dashboard/src/app/pages/job/overview/detail/job-overview-drawer-detail.component.html
+++ b/flink-runtime-web/web-dashboard/src/app/pages/job/overview/detail/job-overview-drawer-detail.component.html
@@ -17,8 +17,8 @@
   -->
 
 <ng-container *ngIf="node">
-  <div class="name">
-    {{ node.detail.name }}
+  <div class="name {{ multilineNameCSS }}">
+    {{ node.description }}
   </div>
   <div nz-row class="wrapper">
     <div nz-col [nzSpan]="12">

--- a/flink-runtime-web/web-dashboard/src/app/pages/job/overview/detail/job-overview-drawer-detail.component.less
+++ b/flink-runtime-web/web-dashboard/src/app/pages/job/overview/detail/job-overview-drawer-detail.component.less
@@ -40,6 +40,10 @@ nz-form-label {
   word-break: break-all;
 }
 
+.name-multi-line {
+  white-space: pre;
+}
+
 nz-form-item {
   margin-bottom: @margin-sm;
 }

--- a/flink-runtime-web/web-dashboard/src/app/pages/job/overview/detail/job-overview-drawer-detail.component.ts
+++ b/flink-runtime-web/web-dashboard/src/app/pages/job/overview/detail/job-overview-drawer-detail.component.ts
@@ -31,6 +31,7 @@ import { JobService } from 'services';
 })
 export class JobOverviewDrawerDetailComponent implements OnInit, OnDestroy {
   public node: NodesItemCorrect | null;
+  public multilineNameCSS = '';
 
   private readonly destroy$ = new Subject<void>();
 
@@ -39,6 +40,12 @@ export class JobOverviewDrawerDetailComponent implements OnInit, OnDestroy {
   public ngOnInit(): void {
     this.jobService.selectedVertex$.pipe(takeUntil(this.destroy$)).subscribe(node => {
       this.node = node;
+      if (this.node != null && this.node.description != null) {
+        if (this.node.description.indexOf('<br/>') > 0) {
+          this.multilineNameCSS = 'name-multi-line';
+          this.node.description = this.node.description.replace(/<br\/>/g, '\n');
+        }
+      }
       this.cdr.markForCheck();
     });
   }

--- a/flink-runtime-web/web-dashboard/src/app/share/common/dagre/node.component.ts
+++ b/flink-runtime-web/web-dashboard/src/app/share/common/dagre/node.component.ts
@@ -53,7 +53,10 @@ export class NodeComponent {
 
   @Input()
   set node(value: NodesItemCorrect) {
-    const description = this.decodeHTML(value.description);
+    let description = this.decodeHTML(value.description);
+    if (value.detail) {
+      description = this.decodeHTML(value.detail.name);
+    }
     this.operator = this.decodeHTML(value.operator);
     this.operatorStrategy = this.decodeHTML(value.operator_strategy);
     this.parallelism = value.parallelism;

--- a/flink-streaming-java/src/main/java/org/apache/flink/streaming/api/graph/StreamGraph.java
+++ b/flink-streaming-java/src/main/java/org/apache/flink/streaming/api/graph/StreamGraph.java
@@ -32,6 +32,7 @@ import org.apache.flink.api.java.functions.KeySelector;
 import org.apache.flink.api.java.tuple.Tuple2;
 import org.apache.flink.api.java.tuple.Tuple3;
 import org.apache.flink.api.java.typeutils.MissingTypeInfo;
+import org.apache.flink.configuration.PipelineOptions;
 import org.apache.flink.core.fs.Path;
 import org.apache.flink.core.memory.ManagedMemoryUseCase;
 import org.apache.flink.runtime.clusterframework.types.ResourceProfile;
@@ -128,6 +129,8 @@ public class StreamGraph implements Pipeline {
     private InternalTimeServiceManager.Provider timerServiceProvider;
     private JobType jobType = JobType.STREAMING;
     private Map<String, ResourceProfile> slotSharingGroupResources;
+    private PipelineOptions.VertexDescriptionMode descriptionMode =
+            PipelineOptions.VertexDescriptionMode.TREE;
 
     public StreamGraph(
             ExecutionConfig executionConfig,
@@ -980,5 +983,13 @@ public class StreamGraph implements Pipeline {
 
     public JobType getJobType() {
         return jobType;
+    }
+
+    public PipelineOptions.VertexDescriptionMode getVertexDescriptionMode() {
+        return descriptionMode;
+    }
+
+    public void setVertexDescriptionMode(PipelineOptions.VertexDescriptionMode mode) {
+        this.descriptionMode = mode;
     }
 }

--- a/flink-streaming-java/src/main/java/org/apache/flink/streaming/api/graph/StreamGraphGenerator.java
+++ b/flink-streaming-java/src/main/java/org/apache/flink/streaming/api/graph/StreamGraphGenerator.java
@@ -348,6 +348,7 @@ public class StreamGraphGenerator {
         graph.setChaining(chaining);
         graph.setUserArtifacts(userArtifacts);
         graph.setTimeCharacteristic(timeCharacteristic);
+        graph.setVertexDescriptionMode(configuration.get(PipelineOptions.VERTEX_DESCRIPTION_MODE));
 
         if (shouldExecuteInBatchMode) {
             configureStreamGraphBatch(graph);

--- a/flink-streaming-java/src/main/java/org/apache/flink/streaming/api/graph/StreamingJobGraphGenerator.java
+++ b/flink-streaming-java/src/main/java/org/apache/flink/streaming/api/graph/StreamingJobGraphGenerator.java
@@ -89,6 +89,7 @@ import java.util.Comparator;
 import java.util.HashMap;
 import java.util.HashSet;
 import java.util.IdentityHashMap;
+import java.util.LinkedList;
 import java.util.List;
 import java.util.Map;
 import java.util.Optional;
@@ -212,7 +213,134 @@ public class StreamingJobGraphGenerator {
                             + "This indicates that non-serializable types (like custom serializers) were registered");
         }
 
+        setVertexDescription();
+
         return jobGraph;
+    }
+
+    private void setVertexDescription() {
+        for (Map.Entry<Integer, JobVertex> headOpAndJobVertex : jobVertices.entrySet()) {
+            Integer headOpId = headOpAndJobVertex.getKey();
+            JobVertex vertex = headOpAndJobVertex.getValue();
+            StringBuilder builder = new StringBuilder();
+            switch (streamGraph.getVertexDescriptionMode()) {
+                case CASCADING:
+                    buildCascadingDescription(builder, headOpId, headOpId);
+                    break;
+                case TREE:
+                    buildTreeDescription(builder, headOpId, headOpId, "", true);
+                    break;
+                default:
+                    throw new IllegalArgumentException(
+                            String.format(
+                                    "Description mode %s not supported",
+                                    streamGraph.getVertexDescriptionMode()));
+            }
+            vertex.setOperatorPrettyName(builder.toString());
+        }
+    }
+
+    private void buildCascadingDescription(StringBuilder builder, int headOpId, int currentOpId) {
+        StreamNode node = streamGraph.getStreamNode(currentOpId);
+        builder.append(getDescriptionWithChainedSourcesInfo(node));
+
+        LinkedList<Integer> chainedOutput = getChainedOutputNodes(headOpId, node);
+        if (chainedOutput.isEmpty()) {
+            return;
+        }
+        builder.append(" -> ");
+
+        boolean multiOutput = chainedOutput.size() > 1;
+        if (multiOutput) {
+            builder.append("(");
+        }
+        while (true) {
+            Integer outputId = chainedOutput.pollFirst();
+            buildCascadingDescription(builder, headOpId, outputId);
+            if (chainedOutput.isEmpty()) {
+                break;
+            }
+            builder.append(" , ");
+        }
+        if (multiOutput) {
+            builder.append(")");
+        }
+    }
+
+    private LinkedList<Integer> getChainedOutputNodes(int headOpId, StreamNode node) {
+        LinkedList<Integer> chainedOutput = new LinkedList<>();
+        if (chainedConfigs.containsKey(headOpId)) {
+            for (StreamEdge edge : node.getOutEdges()) {
+                int targetId = edge.getTargetId();
+                if (chainedConfigs.get(headOpId).containsKey(targetId)) {
+                    chainedOutput.add(targetId);
+                }
+            }
+        }
+        return chainedOutput;
+    }
+
+    private void buildTreeDescription(
+            StringBuilder builder, int headOpId, int currentOpId, String prefix, boolean isLast) {
+        // Replace the '-' in prefix of current node with ' ', keep ':'
+        // HeadNode
+        // :- Node1
+        // :  :- Child1
+        // :  +- Child2
+        // +- Node2
+        //    :- Child3
+        //    +- Child4
+        String currentNodePrefix = "";
+        String childPrefix = "";
+        if (currentOpId != headOpId) {
+            if (isLast) {
+                currentNodePrefix = prefix + "+- ";
+                childPrefix = prefix + "   ";
+            } else {
+                currentNodePrefix = prefix + ":- ";
+                childPrefix = prefix + ":  ";
+            }
+        }
+
+        StreamNode node = streamGraph.getStreamNode(currentOpId);
+        builder.append(currentNodePrefix);
+        builder.append(getDescriptionWithChainedSourcesInfo(node));
+        builder.append("\n");
+
+        LinkedList<Integer> chainedOutput = getChainedOutputNodes(headOpId, node);
+        while (!chainedOutput.isEmpty()) {
+            Integer outputId = chainedOutput.pollFirst();
+            buildTreeDescription(builder, headOpId, outputId, childPrefix, chainedOutput.isEmpty());
+        }
+    }
+
+    private String getDescriptionWithChainedSourcesInfo(StreamNode node) {
+
+        List<StreamNode> chainedSources;
+        if (!chainedConfigs.containsKey(node.getId())) {
+            // node is not head operator of a vertex
+            chainedSources = Collections.emptyList();
+        } else {
+            chainedSources =
+                    node.getInEdges().stream()
+                            .map(StreamEdge::getSourceId)
+                            .filter(
+                                    id ->
+                                            streamGraph.getSourceIDs().contains(id)
+                                                    && chainedConfigs
+                                                            .get(node.getId())
+                                                            .containsKey(id))
+                            .map(streamGraph::getStreamNode)
+                            .collect(Collectors.toList());
+        }
+        return chainedSources.isEmpty()
+                ? node.getOperatorDescription()
+                : String.format(
+                        "%s [%s]",
+                        node.getOperatorDescription(),
+                        chainedSources.stream()
+                                .map(StreamNode::getOperatorDescription)
+                                .collect(Collectors.joining(", ")));
     }
 
     @SuppressWarnings("deprecation")


### PR DESCRIPTION
## What is the purpose of the change

This PR is part of https://cwiki.apache.org/confluence/display/FLINK/FLIP-195%3A+Improve+the+name+and+structure+of+vertex+and+operator+name+for+job and a following up PR of FLINK-25072, inits the operatorPrettyName of JobVertex according to the description of operators introduced in FLINK-25072 and exposes the description in web ui.

## Brief change log
- init operatorPrettyName of JobVertex in streaming jobs according to description of operators.
- introduce an new  tree mode description to make the operatorPrettyName easier to understand.
- update web ui: display name in DAG of web ui and display description in detail of job vertex.

## Verifying this change

This change added tests and can be verified as follows:

  - *Added unit tests for StreamingJobGraphGeneratorTest to verify the generation of description *
  - *verified changed in web ui manually, following is the result in examples. *
![image](https://user-images.githubusercontent.com/20785829/143826827-c1134468-7f3c-4f5c-ba56-42468983f468.png)

## Does this pull request potentially affect one of the following parts:

  - Dependencies (does it add or upgrade a dependency): (no)
  - The public API, i.e., is any changed class annotated with `@Public(Evolving)`: (no)
  - The serializers: (no)
  - The runtime per-record code paths (performance sensitive): (no)
  - Anything that affects deployment or recovery: JobManager (and its components), Checkpointing, Kubernetes/Yarn, ZooKeeper: (no)
  - The S3 file system connector: (no)

## Documentation

  - Does this pull request introduce a new feature? (yes)
  - If yes, how is the feature documented? (JavaDocs)
