### PR TITLE
[FLINK-20370][table] part2: introduce 'table.exec.sink.keyed-shuffle' option to auto keyby on sink's pk if parallelism are not the same for insertOnly input

### DIFF
--- a/docs/layouts/shortcodes/generated/execution_config_configuration.html
+++ b/docs/layouts/shortcodes/generated/execution_config_configuration.html
@@ -58,6 +58,13 @@ By default no operator is disabled.</td>
             <td><p>Enum</p></td>
             <td>Determines whether string values for columns with CHAR(&lt;precision&gt;)/VARCHAR(&lt;precision&gt;) types will be trimmed or padded (only for CHAR(&lt;precision&gt;)), so that their length will match the one defined by the precision of their respective CHAR/VARCHAR column type.<br /><br />Possible values:<ul><li>"IGNORE": Don't apply any trimming and padding, and instead ignore the CHAR/VARCHAR precision directive.</li><li>"TRIM_PAD": Trim and pad string values to match the length defined by the CHAR/VARCHAR precision.</li></ul></td>
         </tr>
+        <tr>
+            <td><h5>table.exec.sink.keyed-shuffle</h5><br> <span class="label label-primary">Streaming</span></td>
+            <td style="word-wrap: break-word;">AUTO</td>
+            <td><p>Enum</p></td>
+            <td>In order to minimize the distributed disorder problem when writing data into table with primary keys that many users suffers. FLINK will auto add a keyed shuffle by default when the sink's parallelism differs from upstream operator and upstream is append only. This works only when the upstream ensures the multi-records' order on the primary key, if not, the added shuffle can not solve the problem (In this situation, a more proper way is to consider the deduplicate operation for the source firstly or use an upsert source with primary key definition which truly reflect the records evolution).<br />By default, the keyed shuffle will be added when the sink's parallelism differs from upstream operator. You can set to no shuffle(NONE) or force shuffle(FORCE).<br /><br />Possible values:<ul><li>"NONE"</li><li>"AUTO"</li><li>"FORCE"</li></ul></td>
+        </tr>
+        <tr>
             <td><h5>table.exec.sink.legacy-cast-behaviour</h5><br> <span class="label label-primary">Batch</span> <span class="label label-primary">Streaming</span></td>
             <td style="word-wrap: break-word;">ENABLED</td>
             <td><p>Enum</p></td>
@@ -68,12 +75,6 @@ By default no operator is disabled.</td>
             <td style="word-wrap: break-word;">ERROR</td>
             <td><p>Enum</p></td>
             <td>Determines how Flink enforces NOT NULL column constraints when inserting null values.<br /><br />Possible values:<ul><li>"ERROR": Throw a runtime exception when writing null values into NOT NULL column.</li><li>"DROP": Drop records silently if a null value would have to be inserted into a NOT NULL column.</li></ul></td>
-        </tr>
-        <tr>
-            <td><h5>table.exec.sink.pk-shuffle</h5><br> <span class="label label-primary">Streaming</span></td>
-            <td style="word-wrap: break-word;">AUTO</td>
-            <td><p>Enum</p></td>
-            <td>In order to minimize the distributed disorder problem when writing data into table with primary keys that many users suffers. FLINK will auto add a shuffle by default when the sink's parallelism differs from upstream operator and upstream is append only. This works only when the upstream ensures the multi-records' order on the primary key, if not, the added shuffle can not solve the problem (In this situation, a more proper way is to consider the deduplicate operation for the source firstly or use an upsert source with primary key definition which truly reflect the records evolution).<br />By default, the shuffle by primary key will be added when the sink's parallelism differs from upstream operator. You can set to no shuffle(NONE) or force shuffle(FORCE).<br /><br />Possible values:<ul><li>"NONE"</li><li>"AUTO"</li><li>"FORCE"</li></ul></td>
         </tr>
         <tr>
             <td><h5>table.exec.sink.upsert-materialize</h5><br> <span class="label label-primary">Streaming</span></td>

--- a/docs/layouts/shortcodes/generated/execution_config_configuration.html
+++ b/docs/layouts/shortcodes/generated/execution_config_configuration.html
@@ -70,6 +70,12 @@ By default no operator is disabled.</td>
             <td>Determines how Flink enforces NOT NULL column constraints when inserting null values.<br /><br />Possible values:<ul><li>"ERROR": Throw a runtime exception when writing null values into NOT NULL column.</li><li>"DROP": Drop records silently if a null value would have to be inserted into a NOT NULL column.</li></ul></td>
         </tr>
         <tr>
+            <td><h5>table.exec.sink.pk-shuffle</h5><br> <span class="label label-primary">Streaming</span></td>
+            <td style="word-wrap: break-word;">AUTO</td>
+            <td><p>Enum</p></td>
+            <td>In order to minimize the distributed disorder problem when writing data into table with primary keys that many users suffers. FLINK will auto add a shuffle by default when the sink's parallelism differs from upstream operator and upstream is append only. This works only when the upstream ensures the multi-records' order on the primary key, if not, the added shuffle can not solve the problem (In this situation, a more proper way is to consider the deduplicate operation for the source firstly or use an upsert source with primary key definition which truly reflect the records evolution).<br />By default, the shuffle by primary key will be added when the sink's parallelism differs from upstream operator. You can set to no shuffle(NONE) or force shuffle(FORCE).<br /><br />Possible values:<ul><li>"NONE"</li><li>"AUTO"</li><li>"FORCE"</li></ul></td>
+        </tr>
+        <tr>
             <td><h5>table.exec.sink.upsert-materialize</h5><br> <span class="label label-primary">Streaming</span></td>
             <td style="word-wrap: break-word;">AUTO</td>
             <td><p>Enum</p></td>

--- a/flink-table/flink-table-api-java/src/main/java/org/apache/flink/table/api/config/ExecutionConfigOptions.java
+++ b/flink-table/flink-table-api-java/src/main/java/org/apache/flink/table/api/config/ExecutionConfigOptions.java
@@ -150,6 +150,25 @@ public class ExecutionConfigOptions {
                                                     + "or force materialization(FORCE).")
                                     .build());
 
+    @Documentation.TableOption(execMode = Documentation.ExecMode.STREAMING)
+    public static final ConfigOption<SinkShuffleByPk> TABLE_EXEC_SINK_SHUFFLE_BY_PK =
+            key("table.exec.sink.pk-shuffle")
+                    .enumType(SinkShuffleByPk.class)
+                    .defaultValue(SinkShuffleByPk.AUTO)
+                    .withDescription(
+                            Description.builder()
+                                    .text(
+                                            "In order to minimize the distributed disorder problem when writing data into table with primary keys that many users suffers. "
+                                                    + "FLINK will auto add a shuffle by default when the sink's parallelism differs from upstream operator and upstream is append only. "
+                                                    + "This works only when the upstream ensures the multi-records' order on the primary key, if not, the added shuffle can not solve "
+                                                    + "the problem (In this situation, a more proper way is to consider the deduplicate operation for the source firstly or use an "
+                                                    + "upsert source with primary key definition which truly reflect the records evolution).")
+                                    .linebreak()
+                                    .text(
+                                            "By default, the shuffle by primary key will be added when the sink's parallelism differs from upstream operator. "
+                                                    + "You can set to no shuffle(NONE) or force shuffle(FORCE).")
+                                    .build());
+
     // ------------------------------------------------------------------------
     //  Sort Options
     // ------------------------------------------------------------------------
@@ -460,6 +479,20 @@ public class ExecutionConfigOptions {
         AUTO,
 
         /** Add materialize operator in any case. */
+        FORCE
+    }
+
+    /** Shuffle by primary key before sink. */
+    @PublicEvolving
+    public enum SinkShuffleByPk {
+
+        /** No shuffle stage will be added for sink. */
+        NONE,
+
+        /** Auto add shuffle by pk when the sink's parallelism differs from upstream operator. */
+        AUTO,
+
+        /** Add shuffle by pk in any case. */
         FORCE
     }
 

--- a/flink-table/flink-table-api-java/src/main/java/org/apache/flink/table/api/config/ExecutionConfigOptions.java
+++ b/flink-table/flink-table-api-java/src/main/java/org/apache/flink/table/api/config/ExecutionConfigOptions.java
@@ -151,21 +151,21 @@ public class ExecutionConfigOptions {
                                     .build());
 
     @Documentation.TableOption(execMode = Documentation.ExecMode.STREAMING)
-    public static final ConfigOption<SinkShuffleByPk> TABLE_EXEC_SINK_SHUFFLE_BY_PK =
-            key("table.exec.sink.pk-shuffle")
-                    .enumType(SinkShuffleByPk.class)
-                    .defaultValue(SinkShuffleByPk.AUTO)
+    public static final ConfigOption<SinkKeyedShuffle> TABLE_EXEC_SINK_KEYED_SHUFFLE =
+            key("table.exec.sink.keyed-shuffle")
+                    .enumType(SinkKeyedShuffle.class)
+                    .defaultValue(SinkKeyedShuffle.AUTO)
                     .withDescription(
                             Description.builder()
                                     .text(
                                             "In order to minimize the distributed disorder problem when writing data into table with primary keys that many users suffers. "
-                                                    + "FLINK will auto add a shuffle by default when the sink's parallelism differs from upstream operator and upstream is append only. "
+                                                    + "FLINK will auto add a keyed shuffle by default when the sink's parallelism differs from upstream operator and upstream is append only. "
                                                     + "This works only when the upstream ensures the multi-records' order on the primary key, if not, the added shuffle can not solve "
                                                     + "the problem (In this situation, a more proper way is to consider the deduplicate operation for the source firstly or use an "
                                                     + "upsert source with primary key definition which truly reflect the records evolution).")
                                     .linebreak()
                                     .text(
-                                            "By default, the shuffle by primary key will be added when the sink's parallelism differs from upstream operator. "
+                                            "By default, the keyed shuffle will be added when the sink's parallelism differs from upstream operator. "
                                                     + "You can set to no shuffle(NONE) or force shuffle(FORCE).")
                                     .build());
 
@@ -484,15 +484,15 @@ public class ExecutionConfigOptions {
 
     /** Shuffle by primary key before sink. */
     @PublicEvolving
-    public enum SinkShuffleByPk {
+    public enum SinkKeyedShuffle {
 
-        /** No shuffle stage will be added for sink. */
+        /** No keyed shuffle will be added for sink. */
         NONE,
 
-        /** Auto add shuffle by pk when the sink's parallelism differs from upstream operator. */
+        /** Auto add keyed shuffle when the sink's parallelism differs from upstream operator. */
         AUTO,
 
-        /** Add shuffle by pk in any case. */
+        /** Add keyed shuffle in any case except single parallelism. */
         FORCE
     }
 

--- a/flink-table/flink-table-planner/src/test/java/org/apache/flink/table/planner/factories/TestValuesTableFactory.java
+++ b/flink-table/flink-table-planner/src/test/java/org/apache/flink/table/planner/factories/TestValuesTableFactory.java
@@ -1676,7 +1676,7 @@ public final class TestValuesTableFactory
                                     + "' yet.");
                     sinkFunction = new RetractingSinkFunction(tableName, converter);
                 }
-                return SinkFunctionProvider.of(sinkFunction);
+                return SinkFunctionProvider.of(sinkFunction, this.parallelism);
             }
         }
 

--- a/flink-table/flink-table-planner/src/test/resources/META-INF/services/org.apache.flink.table.factories.Factory
+++ b/flink-table/flink-table-planner/src/test/resources/META-INF/services/org.apache.flink.table.factories.Factory
@@ -17,3 +17,4 @@ org.apache.flink.formats.testcsv.TestCsvFormatFactory
 org.apache.flink.table.planner.factories.TestValuesTableFactory
 org.apache.flink.table.planner.factories.TestFileFactory
 org.apache.flink.table.planner.factories.TableFactoryHarness$Factory
+org.apache.flink.table.planner.plan.stream.sql.TestTableFactory

--- a/flink-table/flink-table-planner/src/test/resources/org/apache/flink/table/planner/plan/stream/sql/TableSinkTest.xml
+++ b/flink-table/flink-table-planner/src/test/resources/org/apache/flink/table/planner/plan/stream/sql/TableSinkTest.xml
@@ -32,6 +32,44 @@ Sink(table=[default_catalog.default_database.appendSink], fields=[EXPR$0, c], ch
 ]]>
     </Resource>
   </TestCase>
+  <TestCase name="testAppendStreamToSinkWithoutPkForceKeyBy">
+    <Resource name="explain">
+      <![CDATA[== Abstract Syntax Tree ==
+LogicalSink(table=[default_catalog.default_database.sink], fields=[id, city_name])
++- LogicalProject(id=[$0], city_name=[$1])
+   +- LogicalTableScan(table=[[default_catalog, default_database, source]])
+
+== Optimized Physical Plan ==
+Sink(table=[default_catalog.default_database.sink], fields=[id, city_name])
++- TableSourceScan(table=[[default_catalog, default_database, source]], fields=[id, city_name])
+
+== Optimized Execution Plan ==
+Sink(table=[default_catalog.default_database.sink], fields=[id, city_name])
++- TableSourceScan(table=[[default_catalog, default_database, source]], fields=[id, city_name])
+
+== Physical Execution Plan ==
+{
+  "nodes" : [ {
+    "id" : ,
+    "type" : "Source: TableSourceScan(table=[[default_catalog, default_database, source]], fields=[id, city_name])",
+    "pact" : "Data Source",
+    "contents" : "Source: TableSourceScan(table=[[default_catalog, default_database, source]], fields=[id, city_name])",
+    "parallelism" : 4
+  }, {
+    "id" : ,
+    "type" : "Sink: Sink(table=[default_catalog.default_database.sink], fields=[id, city_name])",
+    "pact" : "Data Sink",
+    "contents" : "Sink: Sink(table=[default_catalog.default_database.sink], fields=[id, city_name])",
+    "parallelism" : 4,
+    "predecessors" : [ {
+      "id" : ,
+      "ship_strategy" : "FORWARD",
+      "side" : "second"
+    } ]
+  } ]
+}]]>
+    </Resource>
+  </TestCase>
   <TestCase name="testAppendStreamToSinkWithPkAutoKeyBy">
     <Resource name="explain">
       <![CDATA[== Abstract Syntax Tree ==
@@ -57,9 +95,9 @@ Sink(table=[default_catalog.default_database.sink], fields=[id, city_name])
     "parallelism" : 1
   }, {
     "id" : ,
-    "type" : "NotNullEnforcer(fields=[id])",
+    "type" : "ConstraintEnforcer[NotNullEnforcer(fields=[id])]",
     "pact" : "Operator",
-    "contents" : "NotNullEnforcer(fields=[id])",
+    "contents" : "ConstraintEnforcer[NotNullEnforcer(fields=[id])]",
     "parallelism" : 1,
     "predecessors" : [ {
       "id" : ,
@@ -106,9 +144,9 @@ Sink(table=[default_catalog.default_database.sink], fields=[id, city_name])
     "parallelism" : 4
   }, {
     "id" : ,
-    "type" : "NotNullEnforcer(fields=[id])",
+    "type" : "ConstraintEnforcer[NotNullEnforcer(fields=[id])]",
     "pact" : "Operator",
-    "contents" : "NotNullEnforcer(fields=[id])",
+    "contents" : "ConstraintEnforcer[NotNullEnforcer(fields=[id])]",
     "parallelism" : 4,
     "predecessors" : [ {
       "id" : ,
@@ -155,9 +193,9 @@ Sink(table=[default_catalog.default_database.sink], fields=[id, city_name])
     "parallelism" : 1
   }, {
     "id" : ,
-    "type" : "NotNullEnforcer(fields=[id])",
+    "type" : "ConstraintEnforcer[NotNullEnforcer(fields=[id])]",
     "pact" : "Operator",
-    "contents" : "NotNullEnforcer(fields=[id])",
+    "contents" : "ConstraintEnforcer[NotNullEnforcer(fields=[id])]",
     "parallelism" : 1,
     "predecessors" : [ {
       "id" : ,
@@ -321,25 +359,6 @@ Sink(table=[default_catalog.default_database.upsertSink], fields=[cnt, frequency
 ]]>
     </Resource>
   </TestCase>
-  <TestCase name="testUpsertSink">
-    <Resource name="ast">
-      <![CDATA[
-LogicalSink(table=[default_catalog.default_database.upsertSink], fields=[a, cnt])
-+- LogicalAggregate(group=[{0}], cnt=[COUNT()])
-   +- LogicalProject(a=[$0])
-      +- LogicalTableScan(table=[[default_catalog, default_database, MyTable]])
-]]>
-    </Resource>
-    <Resource name="optimized rel plan">
-      <![CDATA[
-Sink(table=[default_catalog.default_database.upsertSink], fields=[a, cnt], changelogMode=[NONE])
-+- GroupAggregate(groupBy=[a], select=[a, COUNT(*) AS cnt], changelogMode=[I,UA])
-   +- Exchange(distribution=[hash[a]], changelogMode=[I])
-      +- Calc(select=[a], changelogMode=[I])
-         +- DataStreamScan(table=[[default_catalog, default_database, MyTable]], fields=[a, b, c], changelogMode=[I])
-]]>
-    </Resource>
-  </TestCase>
   <TestCase name="testRetractSink1">
     <Resource name="ast">
       <![CDATA[
@@ -380,6 +399,74 @@ Sink(table=[default_catalog.default_database.retractSink], fields=[cnt, a], chan
             +- Calc(select=[a], changelogMode=[I])
                +- DataStreamScan(table=[[default_catalog, default_database, MyTable]], fields=[a, b, c], changelogMode=[I])
 ]]>
+    </Resource>
+  </TestCase>
+  <TestCase name="testUpsertSink">
+    <Resource name="ast">
+      <![CDATA[
+LogicalSink(table=[default_catalog.default_database.upsertSink], fields=[a, cnt])
++- LogicalAggregate(group=[{0}], cnt=[COUNT()])
+   +- LogicalProject(a=[$0])
+      +- LogicalTableScan(table=[[default_catalog, default_database, MyTable]])
+]]>
+    </Resource>
+    <Resource name="optimized rel plan">
+      <![CDATA[
+Sink(table=[default_catalog.default_database.upsertSink], fields=[a, cnt], changelogMode=[NONE])
++- GroupAggregate(groupBy=[a], select=[a, COUNT(*) AS cnt], changelogMode=[I,UA])
+   +- Exchange(distribution=[hash[a]], changelogMode=[I])
+      +- Calc(select=[a], changelogMode=[I])
+         +- DataStreamScan(table=[[default_catalog, default_database, MyTable]], fields=[a, b, c], changelogMode=[I])
+]]>
+    </Resource>
+  </TestCase>
+  <TestCase name="testSingleParallelismAppendStreamToSinkWithPkForceKeyBy">
+    <Resource name="explain">
+      <![CDATA[== Abstract Syntax Tree ==
+LogicalSink(table=[default_catalog.default_database.sink], fields=[id, city_name])
++- LogicalProject(id=[$0], city_name=[$1])
+   +- LogicalTableScan(table=[[default_catalog, default_database, source]])
+
+== Optimized Physical Plan ==
+Sink(table=[default_catalog.default_database.sink], fields=[id, city_name])
++- TableSourceScan(table=[[default_catalog, default_database, source]], fields=[id, city_name])
+
+== Optimized Execution Plan ==
+Sink(table=[default_catalog.default_database.sink], fields=[id, city_name])
++- TableSourceScan(table=[[default_catalog, default_database, source]], fields=[id, city_name])
+
+== Physical Execution Plan ==
+{
+  "nodes" : [ {
+    "id" : ,
+    "type" : "Source: TableSourceScan(table=[[default_catalog, default_database, source]], fields=[id, city_name])",
+    "pact" : "Data Source",
+    "contents" : "Source: TableSourceScan(table=[[default_catalog, default_database, source]], fields=[id, city_name])",
+    "parallelism" : 1
+  }, {
+    "id" : ,
+    "type" : "ConstraintEnforcer[NotNullEnforcer(fields=[id])]",
+    "pact" : "Operator",
+    "contents" : "ConstraintEnforcer[NotNullEnforcer(fields=[id])]",
+    "parallelism" : 1,
+    "predecessors" : [ {
+      "id" : ,
+      "ship_strategy" : "FORWARD",
+      "side" : "second"
+    } ]
+  }, {
+    "id" : ,
+    "type" : "Sink: Sink(table=[default_catalog.default_database.sink], fields=[id, city_name])",
+    "pact" : "Data Sink",
+    "contents" : "Sink: Sink(table=[default_catalog.default_database.sink], fields=[id, city_name])",
+    "parallelism" : 1,
+    "predecessors" : [ {
+      "id" : ,
+      "ship_strategy" : "FORWARD",
+      "side" : "second"
+    } ]
+  } ]
+}]]>
     </Resource>
   </TestCase>
   <TestCase name="testSinkDisorderChangeLogWithRank">

--- a/flink-table/flink-table-planner/src/test/resources/org/apache/flink/table/planner/plan/stream/sql/TableSinkTest.xml
+++ b/flink-table/flink-table-planner/src/test/resources/org/apache/flink/table/planner/plan/stream/sql/TableSinkTest.xml
@@ -32,6 +32,153 @@ Sink(table=[default_catalog.default_database.appendSink], fields=[EXPR$0, c], ch
 ]]>
     </Resource>
   </TestCase>
+  <TestCase name="testAppendStreamToSinkWithPkAutoKeyBy">
+    <Resource name="explain">
+      <![CDATA[== Abstract Syntax Tree ==
+LogicalSink(table=[default_catalog.default_database.sink], fields=[id, city_name])
++- LogicalProject(id=[$0], city_name=[$1])
+   +- LogicalTableScan(table=[[default_catalog, default_database, source]])
+
+== Optimized Physical Plan ==
+Sink(table=[default_catalog.default_database.sink], fields=[id, city_name])
++- TableSourceScan(table=[[default_catalog, default_database, source]], fields=[id, city_name])
+
+== Optimized Execution Plan ==
+Sink(table=[default_catalog.default_database.sink], fields=[id, city_name])
++- TableSourceScan(table=[[default_catalog, default_database, source]], fields=[id, city_name])
+
+== Physical Execution Plan ==
+{
+  "nodes" : [ {
+    "id" : ,
+    "type" : "Source: TableSourceScan(table=[[default_catalog, default_database, source]], fields=[id, city_name])",
+    "pact" : "Data Source",
+    "contents" : "Source: TableSourceScan(table=[[default_catalog, default_database, source]], fields=[id, city_name])",
+    "parallelism" : 1
+  }, {
+    "id" : ,
+    "type" : "NotNullEnforcer(fields=[id])",
+    "pact" : "Operator",
+    "contents" : "NotNullEnforcer(fields=[id])",
+    "parallelism" : 1,
+    "predecessors" : [ {
+      "id" : ,
+      "ship_strategy" : "FORWARD",
+      "side" : "second"
+    } ]
+  }, {
+    "id" : ,
+    "type" : "Sink: Sink(table=[default_catalog.default_database.sink], fields=[id, city_name])",
+    "pact" : "Data Sink",
+    "contents" : "Sink: Sink(table=[default_catalog.default_database.sink], fields=[id, city_name])",
+    "parallelism" : 9,
+    "predecessors" : [ {
+      "id" : ,
+      "ship_strategy" : "HASH",
+      "side" : "second"
+    } ]
+  } ]
+}]]>
+    </Resource>
+  </TestCase>
+  <TestCase name="testAppendStreamToSinkWithPkForceKeyBy">
+    <Resource name="explain">
+      <![CDATA[== Abstract Syntax Tree ==
+LogicalSink(table=[default_catalog.default_database.sink], fields=[id, city_name])
++- LogicalProject(id=[$0], city_name=[$1])
+   +- LogicalTableScan(table=[[default_catalog, default_database, source]])
+
+== Optimized Physical Plan ==
+Sink(table=[default_catalog.default_database.sink], fields=[id, city_name])
++- TableSourceScan(table=[[default_catalog, default_database, source]], fields=[id, city_name])
+
+== Optimized Execution Plan ==
+Sink(table=[default_catalog.default_database.sink], fields=[id, city_name])
++- TableSourceScan(table=[[default_catalog, default_database, source]], fields=[id, city_name])
+
+== Physical Execution Plan ==
+{
+  "nodes" : [ {
+    "id" : ,
+    "type" : "Source: TableSourceScan(table=[[default_catalog, default_database, source]], fields=[id, city_name])",
+    "pact" : "Data Source",
+    "contents" : "Source: TableSourceScan(table=[[default_catalog, default_database, source]], fields=[id, city_name])",
+    "parallelism" : 4
+  }, {
+    "id" : ,
+    "type" : "NotNullEnforcer(fields=[id])",
+    "pact" : "Operator",
+    "contents" : "NotNullEnforcer(fields=[id])",
+    "parallelism" : 4,
+    "predecessors" : [ {
+      "id" : ,
+      "ship_strategy" : "FORWARD",
+      "side" : "second"
+    } ]
+  }, {
+    "id" : ,
+    "type" : "Sink: Sink(table=[default_catalog.default_database.sink], fields=[id, city_name])",
+    "pact" : "Data Sink",
+    "contents" : "Sink: Sink(table=[default_catalog.default_database.sink], fields=[id, city_name])",
+    "parallelism" : 4,
+    "predecessors" : [ {
+      "id" : ,
+      "ship_strategy" : "HASH",
+      "side" : "second"
+    } ]
+  } ]
+}]]>
+    </Resource>
+  </TestCase>
+  <TestCase name="testAppendStreamToSinkWithPkNoKeyBy">
+    <Resource name="explain">
+      <![CDATA[== Abstract Syntax Tree ==
+LogicalSink(table=[default_catalog.default_database.sink], fields=[id, city_name])
++- LogicalProject(id=[$0], city_name=[$1])
+   +- LogicalTableScan(table=[[default_catalog, default_database, source]])
+
+== Optimized Physical Plan ==
+Sink(table=[default_catalog.default_database.sink], fields=[id, city_name])
++- TableSourceScan(table=[[default_catalog, default_database, source]], fields=[id, city_name])
+
+== Optimized Execution Plan ==
+Sink(table=[default_catalog.default_database.sink], fields=[id, city_name])
++- TableSourceScan(table=[[default_catalog, default_database, source]], fields=[id, city_name])
+
+== Physical Execution Plan ==
+{
+  "nodes" : [ {
+    "id" : ,
+    "type" : "Source: TableSourceScan(table=[[default_catalog, default_database, source]], fields=[id, city_name])",
+    "pact" : "Data Source",
+    "contents" : "Source: TableSourceScan(table=[[default_catalog, default_database, source]], fields=[id, city_name])",
+    "parallelism" : 1
+  }, {
+    "id" : ,
+    "type" : "NotNullEnforcer(fields=[id])",
+    "pact" : "Operator",
+    "contents" : "NotNullEnforcer(fields=[id])",
+    "parallelism" : 1,
+    "predecessors" : [ {
+      "id" : ,
+      "ship_strategy" : "FORWARD",
+      "side" : "second"
+    } ]
+  }, {
+    "id" : ,
+    "type" : "Sink: Sink(table=[default_catalog.default_database.sink], fields=[id, city_name])",
+    "pact" : "Data Sink",
+    "contents" : "Sink: Sink(table=[default_catalog.default_database.sink], fields=[id, city_name])",
+    "parallelism" : 9,
+    "predecessors" : [ {
+      "id" : ,
+      "ship_strategy" : "REBALANCE",
+      "side" : "second"
+    } ]
+  } ]
+}]]>
+    </Resource>
+  </TestCase>
   <TestCase name="testAppendUpsertAndRetractSink">
     <Resource name="ast">
       <![CDATA[

--- a/flink-table/flink-table-planner/src/test/resources/org/apache/flink/table/planner/plan/stream/sql/join/TemporalJoinTest.xml
+++ b/flink-table/flink-table-planner/src/test/resources/org/apache/flink/table/planner/plan/stream/sql/join/TemporalJoinTest.xml
@@ -148,6 +148,45 @@ Calc(select=[amount, currency, ts, rowtime, currency0, rate, ts0, CAST(rowtime0)
 ]]>
     </Resource>
   </TestCase>
+  <TestCase name="testEventTimeTemporalJoinToSinkWithPk">
+    <Resource name="explain">
+      <![CDATA[== Abstract Syntax Tree ==
+LogicalSink(table=[default_catalog.default_database.rowtime_default_sink], fields=[order_id, currency, amount, order_time, rate, currency_time])
++- LogicalProject(order_id=[$0], currency=[$1], amount=[$3], order_time=[$4], rate=[$7], currency_time=[$8])
+   +- LogicalCorrelate(correlation=[$cor0], joinType=[inner], requiredColumns=[{1, 2, 4}])
+      :- LogicalWatermarkAssigner(rowtime=[order_time], watermark=[$4])
+      :  +- LogicalTableScan(table=[[default_catalog, default_database, orders_rowtime]])
+      +- LogicalFilter(condition=[AND(=($cor0.currency_no, $1), =($cor0.currency, $0))])
+         +- LogicalSnapshot(period=[$cor0.order_time])
+            +- LogicalWatermarkAssigner(rowtime=[currency_time], watermark=[-($3, 10000:INTERVAL SECOND)])
+               +- LogicalTableScan(table=[[default_catalog, default_database, versioned_currency_with_multi_key]])
+
+== Optimized Physical Plan ==
+Sink(table=[default_catalog.default_database.rowtime_default_sink], fields=[order_id, currency, amount, order_time, rate, currency_time], changelogMode=[NONE])
++- Calc(select=[order_id, currency, amount, order_time, rate, CAST(currency_time) AS currency_time], changelogMode=[I,UB,UA,D])
+   +- TemporalJoin(joinType=[InnerJoin], where=[AND(=(currency_no, currency_no0), =(currency, currency0), __TEMPORAL_JOIN_CONDITION(order_time, currency_time, __TEMPORAL_JOIN_CONDITION_PRIMARY_KEY(currency0, currency_no0), __TEMPORAL_JOIN_LEFT_KEY(currency_no, currency), __TEMPORAL_JOIN_RIGHT_KEY(currency_no0, currency0)))], select=[order_id, currency, currency_no, amount, order_time, currency0, currency_no0, rate, currency_time], changelogMode=[I,UB,UA,D])
+      :- Exchange(distribution=[hash[currency_no, currency]], changelogMode=[I,UB,UA,D])
+      :  +- WatermarkAssigner(rowtime=[order_time], watermark=[order_time], changelogMode=[I,UB,UA,D])
+      :     +- TableSourceScan(table=[[default_catalog, default_database, orders_rowtime]], fields=[order_id, currency, currency_no, amount, order_time], changelogMode=[I,UB,UA,D])
+      +- Exchange(distribution=[hash[currency_no, currency]], changelogMode=[I,UA,D])
+         +- WatermarkAssigner(rowtime=[currency_time], watermark=[-(currency_time, 10000:INTERVAL SECOND)], changelogMode=[I,UA,D])
+            +- DropUpdateBefore(changelogMode=[I,UA,D])
+               +- TableSourceScan(table=[[default_catalog, default_database, versioned_currency_with_multi_key]], fields=[currency, currency_no, rate, currency_time], changelogMode=[I,UB,UA,D])
+
+== Optimized Execution Plan ==
+Sink(table=[default_catalog.default_database.rowtime_default_sink], fields=[order_id, currency, amount, order_time, rate, currency_time], upsertMaterialize=[true])
++- Calc(select=[order_id, currency, amount, order_time, rate, CAST(currency_time) AS currency_time])
+   +- TemporalJoin(joinType=[InnerJoin], where=[((currency_no = currency_no0) AND (currency = currency0) AND __TEMPORAL_JOIN_CONDITION(order_time, currency_time, __TEMPORAL_JOIN_CONDITION_PRIMARY_KEY(currency0, currency_no0), __TEMPORAL_JOIN_LEFT_KEY(currency_no, currency), __TEMPORAL_JOIN_RIGHT_KEY(currency_no0, currency0)))], select=[order_id, currency, currency_no, amount, order_time, currency0, currency_no0, rate, currency_time])
+      :- Exchange(distribution=[hash[currency_no, currency]])
+      :  +- WatermarkAssigner(rowtime=[order_time], watermark=[order_time])
+      :     +- TableSourceScan(table=[[default_catalog, default_database, orders_rowtime]], fields=[order_id, currency, currency_no, amount, order_time])
+      +- Exchange(distribution=[hash[currency_no, currency]])
+         +- WatermarkAssigner(rowtime=[currency_time], watermark=[(currency_time - 10000:INTERVAL SECOND)])
+            +- DropUpdateBefore
+               +- TableSourceScan(table=[[default_catalog, default_database, versioned_currency_with_multi_key]], fields=[currency, currency_no, rate, currency_time])
+]]>
+    </Resource>
+  </TestCase>
   <TestCase name="testEventTimeTemporalJoinWithComputedColumnAndPushDown">
     <Resource name="sql">
       <![CDATA[SELECT o.currency, r.currency, rate1 FROM Orders AS o JOIN RatesBinlogWithComputedColumn FOR SYSTEM_TIME AS OF o.rowtime AS r on o.currency = r.currency AND o.amount > 10 AND r.rate < 100]]>

--- a/flink-table/flink-table-planner/src/test/scala/org/apache/flink/table/planner/plan/stream/sql/TableSinkTest.scala
+++ b/flink-table/flink-table-planner/src/test/scala/org/apache/flink/table/planner/plan/stream/sql/TableSinkTest.scala
@@ -19,10 +19,19 @@
 package org.apache.flink.table.planner.plan.stream.sql
 
 import org.apache.flink.api.scala._
+import org.apache.flink.configuration.ConfigOption
+import org.apache.flink.streaming.api.functions.source.{ParallelSourceFunction, SourceFunction}
 import org.apache.flink.table.api._
-import org.apache.flink.table.planner.utils.TableTestBase
+import org.apache.flink.table.api.config.ExecutionConfigOptions
+import org.apache.flink.table.connector.ChangelogMode
+import org.apache.flink.table.connector.source.{DynamicTableSource, ScanTableSource, SourceFunctionProvider}
+import org.apache.flink.table.data.RowData
+import org.apache.flink.table.factories.{DynamicTableFactory, DynamicTableSourceFactory}
+import org.apache.flink.table.planner.utils.{TableTestBase, TestingTableEnvironment}
 
 import org.junit.Test
+
+import java.util
 
 class TableSinkTest extends TableTestBase {
 
@@ -463,5 +472,128 @@ class TableSinkTest extends TableTestBase {
         |      GROUP BY person))
         |   WHERE rank_number < 10
         |""".stripMargin)
+  }
+
+  @Test def testAppendStreamToSinkWithPkAutoKeyBy(): Unit = {
+    val tEnv = util.tableEnv
+    tEnv.executeSql(
+      """
+        |create table source (
+        | id varchar,
+        | city_name varchar
+        |) with (
+        | 'connector' = 'values',
+        | 'changelog-mode' = 'I'
+        |)""".stripMargin)
+    tEnv.executeSql(
+      """
+        |create table sink (
+        | id varchar,
+        | city_name varchar,
+        | primary key (id) not enforced
+        |) with (
+        | 'connector' = 'values',
+        | 'sink-insert-only' = 'false',
+        | 'sink.parallelism' = '9'
+        |)""".stripMargin)
+    val stmtSet = tEnv.asInstanceOf[TestingTableEnvironment].createStatementSet
+    stmtSet.addInsertSql("insert into sink select * from source")
+    // we set the sink parallelism to 9 which differs from the source, expect 'keyby' was added.
+    util.verifyExplain(stmtSet, ExplainDetail.JSON_EXECUTION_PLAN)
+  }
+
+  @Test def testAppendStreamToSinkWithPkNoKeyBy(): Unit = {
+    val tEnv = util.tableEnv
+    tEnv.getConfig.getConfiguration.set(ExecutionConfigOptions.TABLE_EXEC_SINK_SHUFFLE_BY_PK,
+      ExecutionConfigOptions.SinkShuffleByPk.NONE)
+    tEnv.executeSql(
+      """
+        |create table source (
+        | id varchar,
+        | city_name varchar
+        |) with (
+        | 'connector' = 'values',
+        | 'changelog-mode' = 'I'
+        |)""".stripMargin)
+    tEnv.executeSql(
+      """
+        |create table sink (
+        | id varchar,
+        | city_name varchar,
+        | primary key (id) not enforced
+        |) with (
+        | 'connector' = 'values',
+        | 'sink-insert-only' = 'false',
+        | 'sink.parallelism' = '9'
+        |)""".stripMargin)
+    val stmtSet = tEnv.asInstanceOf[TestingTableEnvironment].createStatementSet
+    stmtSet.addInsertSql("insert into sink select * from source")
+    // we set the sink parallelism to 9 which differs from the source, but disable auto keyby
+    util.verifyExplain(stmtSet, ExplainDetail.JSON_EXECUTION_PLAN)
+  }
+
+  @Test def testAppendStreamToSinkWithPkForceKeyBy(): Unit = {
+    util.getStreamEnv.setParallelism(4)
+    val tEnv = util.tableEnv
+    tEnv.getConfig.getConfiguration.set(ExecutionConfigOptions.TABLE_EXEC_SINK_SHUFFLE_BY_PK,
+      ExecutionConfigOptions.SinkShuffleByPk.FORCE)
+    tEnv.executeSql(
+      """
+        |create table source (
+        | id varchar,
+        | city_name varchar
+        |) with (
+        | 'connector' = 'test_source'
+        |)""".stripMargin)
+
+    tEnv.executeSql(
+      """
+        |create table sink (
+        | id varchar,
+        | city_name varchar,
+        | primary key (id) not enforced
+        |) with (
+        | 'connector' = 'values',
+        | 'sink-insert-only' = 'false',
+        | 'sink.parallelism' = '4'
+        |)""".stripMargin)
+    val stmtSet = tEnv.asInstanceOf[TestingTableEnvironment].createStatementSet
+    stmtSet.addInsertSql("insert into sink select * from source")
+    // source and sink has same parallelism, but sink shuffle by pk is enforced
+    util.verifyExplain(stmtSet, ExplainDetail.JSON_EXECUTION_PLAN)
+  }
+}
+
+/** tests table factory use ParallelSourceFunction which support parallelism by env*/
+class TestTableFactory extends DynamicTableSourceFactory {
+  override def createDynamicTableSource(context: DynamicTableFactory.Context):
+    DynamicTableSource = {
+    new TestParallelSource()
+  }
+
+  override def factoryIdentifier = "test_source"
+
+  override def requiredOptions = new util.HashSet[ConfigOption[_]]
+
+  override def optionalOptions = {
+    new util.HashSet[ConfigOption[_]]()
+  }
+
+}
+
+/** tests table source provide a {@link ParallelSourceFunction}. */
+class TestParallelSource() extends ScanTableSource {
+  override def copy = throw new TableException("Not supported")
+
+  override def asSummaryString = "test source"
+
+  override def getChangelogMode: ChangelogMode = ChangelogMode.insertOnly()
+
+  override def getScanRuntimeProvider(runtimeProviderContext: ScanTableSource.ScanContext):
+    ScanTableSource.ScanRuntimeProvider = {
+    SourceFunctionProvider.of(new ParallelSourceFunction[RowData] {
+      override def run(ctx: SourceFunction.SourceContext[RowData]): Unit = ???
+      override def cancel(): Unit = ???
+    }, false)
   }
 }

--- a/flink-table/flink-table-planner/src/test/scala/org/apache/flink/table/planner/runtime/stream/sql/ChangelogSourceITCase.scala
+++ b/flink-table/flink-table-planner/src/test/scala/org/apache/flink/table/planner/runtime/stream/sql/ChangelogSourceITCase.scala
@@ -121,9 +121,10 @@ class ChangelogSourceITCase(
       "user4,Tina,tina@gmail.com,11.30,22.60")
     assertEquals(expected.sorted, TestValuesTableFactory.getResults("user_sink").sorted)
 
-    // verify the update_before messages haven been filtered when scanning changelog source
     sourceMode match {
-      case CHANGELOG_SOURCE | CHANGELOG_SOURCE_WITH_EVENTS_DUPLICATE =>
+      // verify the update_before messages haven been filtered when scanning changelog source
+      // the CHANGELOG_SOURCE has I,UA,UB,D but no primary key, so we can not omit UB
+      case CHANGELOG_SOURCE_WITH_EVENTS_DUPLICATE =>
         val rawResult = TestValuesTableFactory.getRawResults("user_sink")
         val hasUB = rawResult.exists(r => r.startsWith("-U"))
         assertFalse(

--- a/flink-table/flink-table-planner/src/test/scala/org/apache/flink/table/planner/runtime/stream/table/TableSinkITCase.scala
+++ b/flink-table/flink-table-planner/src/test/scala/org/apache/flink/table/planner/runtime/stream/table/TableSinkITCase.scala
@@ -687,16 +687,10 @@ class TableSinkITCase extends StreamingTestBase {
          |  'sink-changelog-mode-enforced' = 'I,D'
          |)
          |""".stripMargin)
+    // source is insert only, it never produce a delete, so we do not require a pk for the sink
     Try(tEnv
       .executeSql(s"INSERT INTO $sinkTableWithoutPkName SELECT * FROM $sourceTableName")
-      .await()) match {
-      case Failure(e) =>
-        val exception = ExceptionUtils
-          .findThrowableWithMessage(
-            e,
-            "a primary key is required")
-        assertTrue(exception.isPresent)
-    }
+      .await()).isSuccess
 
     tEnv.executeSql(
       s"""

--- a/flink-table/flink-table-planner/src/test/scala/org/apache/flink/table/planner/runtime/stream/table/TableSinkITCase.scala
+++ b/flink-table/flink-table-planner/src/test/scala/org/apache/flink/table/planner/runtime/stream/table/TableSinkITCase.scala
@@ -21,6 +21,7 @@ package org.apache.flink.table.planner.runtime.stream.table
 import org.apache.flink.api.scala._
 import org.apache.flink.table.api._
 import org.apache.flink.table.api.bridge.scala._
+import org.apache.flink.table.api.config.ExecutionConfigOptions
 import org.apache.flink.table.planner.factories.TestValuesTableFactory
 import org.apache.flink.table.planner.factories.TestValuesTableFactory.changelogRow
 import org.apache.flink.table.planner.runtime.utils.BatchTestBase.row
@@ -28,6 +29,7 @@ import org.apache.flink.table.planner.runtime.utils.StreamingTestBase
 import org.apache.flink.table.planner.runtime.utils.TestData.{data1, nullData4, smallTupleData3, tupleData2, tupleData3, tupleData5}
 import org.apache.flink.table.utils.LegacyRowResource
 import org.apache.flink.util.ExceptionUtils
+
 import org.junit.Assert.{assertEquals, assertFalse, assertTrue, fail}
 import org.junit.{Rule, Test}
 import org.junit.rules.ExpectedException
@@ -35,6 +37,7 @@ import org.junit.rules.ExpectedException
 import java.lang.{Long => JLong}
 import java.math.{BigDecimal => JBigDecimal}
 import java.util.concurrent.atomic.AtomicInteger
+
 import scala.collection.JavaConversions._
 import scala.collection.Seq
 import scala.util.{Failure, Success, Try}
@@ -1242,5 +1245,41 @@ class TableSinkITCase extends StreamingTestBase {
       tEnv.from("T3")
     ).execute().await()
     assertEquals(Seq("+I(42)"), TestValuesTableFactory.getOnlyRawResults.toList)
+  }
+
+  @Test
+  def testAppendStreamToSinkWithoutPkForceKeyBy(): Unit = {
+    val t = env.fromCollection(tupleData3)
+        .assignAscendingTimestamps(_._1.toLong)
+        .toTable(tEnv, 'id, 'num, 'text, 'rowtime.rowtime)
+    tEnv.getConfig.getConfiguration.set(ExecutionConfigOptions.TABLE_EXEC_SINK_KEYED_SHUFFLE,
+      ExecutionConfigOptions.SinkKeyedShuffle.FORCE)
+
+    tEnv.executeSql(
+      s"""
+         |CREATE TABLE sink (
+         |  `t` TIMESTAMP(3),
+         |  `icnt` BIGINT,
+         |  `nsum` BIGINT
+         |) WITH (
+         |  'connector' = 'values',
+         |  'sink-insert-only' = 'false',
+         |  'sink.parallelism' = '4'
+         |)
+         |""".stripMargin)
+
+    val table = t.window(Tumble over 5.millis on 'rowtime as 'w)
+        .groupBy('w)
+        .select('w.end as 't, 'id.count as 'icnt, 'num.sum as 'nsum)
+    table.executeInsert("sink").await()
+
+    val result = TestValuesTableFactory.getResults("sink")
+    val expected = List(
+      "1970-01-01T00:00:00.005,4,8",
+      "1970-01-01T00:00:00.010,5,18",
+      "1970-01-01T00:00:00.015,5,24",
+      "1970-01-01T00:00:00.020,5,29",
+      "1970-01-01T00:00:00.025,2,12")
+    assertEquals(expected.sorted, result.sorted)
   }
 }


### PR DESCRIPTION
## What is the purpose of the change
In order to minimize the distributed disorder problem when writing data into table with primary keys that many users suffers.  We introduce 'table.exec.sink.pk-shuffle' option, by default  it will auto add a shuffle by default when the sink's parallelism differs from upstream operator and upstream is append only.
This works only when the upstream ensures the multi-records' order on the primary key, if not, the added shuffle can not solve the problem (In this situation, a more proper way is to consider the deduplicate operation for the source firstly or use an upsert source with primary key definition which truly reflect the records evolution.

## Brief change log
add new option 'table.exec.sink.pk-shuffle' and related test cases.

## Verifying this change
Streaming sql's `RankTest`, `AggregateTest` and `JoinTest`

## Does this pull request potentially affect one of the following parts:
  - Dependencies (does it add or upgrade a dependency): (no)
  - The public API, i.e., is any changed class annotated with @Public(Evolving): (no)
  - The serializers: (no )
  - The runtime per-record code paths (performance sensitive): (no)
  - Anything that affects deployment or recovery: JobManager (and its components), Checkpointing, Kubernetes/Yarn, ZooKeeper: (no)
  - The S3 file system connector: (no)


## Documentation

  - Does this pull request introduce a new feature? (yes)
