### PR TITLE
[FLINK-25092][tests][elasticsearch] Refactor test to use artifact cacher

### DIFF
--- a/flink-end-to-end-tests/test-scripts/elasticsearch-common.sh
+++ b/flink-end-to-end-tests/test-scripts/elasticsearch-common.sh
@@ -22,6 +22,8 @@ if [[ -z $TEST_DATA_DIR ]]; then
   exit 1
 fi
 
+source "$(dirname "$0")"/common_artifact_download_cacher.sh
+
 function setup_elasticsearch {
     mkdir -p $TEST_DATA_DIR
 
@@ -37,20 +39,11 @@ function setup_elasticsearch {
     local elasticsearchDir=$TEST_DATA_DIR/elasticsearch
     mkdir -p $elasticsearchDir
     echo "Downloading Elasticsearch from $downloadUrl ..."
-    for i in {1..10};
-    do
-        wget "$downloadUrl" -O $TEST_DATA_DIR/elasticsearch.tar.gz
-        if [ $? -eq 0 ]; then
-            echo "Download successful."
-            echo "Extracting..."
-            tar xzf $TEST_DATA_DIR/elasticsearch.tar.gz -C $elasticsearchDir --strip-components=1
-            if [ $? -eq 0 ]; then
-                break
-            fi
-        fi
-        echo "Attempt $i failed."
-        sleep 5
-    done
+    cache_path=$(get_artifact $downloadUrl)
+    ln "$cache_path" "${TEST_DATA_DIR}/elasticsearch.tar.gz"
+    echo "Download successful."
+    echo "Extracting..."
+    tar xzf $TEST_DATA_DIR/elasticsearch.tar.gz -C $elasticsearchDir --strip-components=1
     echo "Extraction successful."
 
     if [ `uname -i` == 'aarch64' ] && [ $elasticsearch_version -ge 6 ]; then


### PR DESCRIPTION
## What is the purpose of the change

* The Elasticsearch test download Elasticsearch binaries. To harden the test, we retry if the download fails. This PR refactors the Elasticsearch test to use the cache for Bash based e2e tests.

## Brief change log

* Refactored Elasticsearch Bash e2e test to use get_artifact function.

## Verifying this change

This change is a trivial rework / code cleanup without any test coverage.

## Does this pull request potentially affect one of the following parts:

  - Dependencies (does it add or upgrade a dependency): no
  - The public API, i.e., is any changed class annotated with `@Public(Evolving)`: no
  - The serializers: no
  - The runtime per-record code paths (performance sensitive): no
  - Anything that affects deployment or recovery: JobManager (and its components), Checkpointing, Kubernetes/Yarn, ZooKeeper: no
  - The S3 file system connector: no

## Documentation

  - Does this pull request introduce a new feature? no
  - If yes, how is the feature documented?not applicable
