### PR TITLE
[hotfix][docs] Fix Scala example for MiniCluster test

### DIFF
--- a/docs/content.zh/docs/dev/datastream/testing.md
+++ b/docs/content.zh/docs/dev/datastream/testing.md
@@ -485,7 +485,7 @@ public class ExampleIntegrationTest {
 class StreamingJobIntegrationTest extends FlatSpec with Matchers with BeforeAndAfter {
 
   val flinkCluster = new MiniClusterWithClientResource(new MiniClusterResourceConfiguration.Builder()
-    .setNumberSlotsPerTaskManager(1)
+    .setNumberSlotsPerTaskManager(2)
     .setNumberTaskManagers(1)
     .build)
 
@@ -509,7 +509,7 @@ class StreamingJobIntegrationTest extends FlatSpec with Matchers with BeforeAndA
     CollectSink.values.clear()
 
     // create a stream of custom elements and apply transformations
-    env.fromElements(1, 21, 22)
+    env.fromElements(1L, 21L, 22L)
        .map(new IncrementMapFunction())
        .addSink(new CollectSink())
 

--- a/docs/content/docs/dev/datastream/testing.md
+++ b/docs/content/docs/dev/datastream/testing.md
@@ -483,7 +483,7 @@ public class ExampleIntegrationTest {
 class StreamingJobIntegrationTest extends FlatSpec with Matchers with BeforeAndAfter {
 
   val flinkCluster = new MiniClusterWithClientResource(new MiniClusterResourceConfiguration.Builder()
-    .setNumberSlotsPerTaskManager(1)
+    .setNumberSlotsPerTaskManager(2)
     .setNumberTaskManagers(1)
     .build)
 
@@ -507,7 +507,7 @@ class StreamingJobIntegrationTest extends FlatSpec with Matchers with BeforeAndA
     CollectSink.values.clear()
 
     // create a stream of custom elements and apply transformations
-    env.fromElements(1, 21, 22)
+    env.fromElements(1L, 21L, 22L)
        .map(new IncrementMapFunction())
        .addSink(new CollectSink())
 


### PR DESCRIPTION
## What is the purpose of the change

The current Scala example for the MiniCluster test fails to run because:
- `numberSlotsPerTaskManager` is incorrectly set to 1, which causes the test to hang
- Scala complains about the `Int` type since the example functions expect a `Long`
