### PR TITLE
[FLINK-25091] change Official website document "FileSink" orc compression attribute reference error

### DIFF
--- a/docs/content.zh/docs/connectors/datastream/file_sink.md
+++ b/docs/content.zh/docs/connectors/datastream/file_sink.md
@@ -448,7 +448,7 @@ String schema = ...;
 Configuration conf = ...;
 Properties writerProperties = new Properties();
 
-writerProps.setProperty("orc.compress", "LZ4");
+writerProperties.setProperty("orc.compress", "LZ4");
 // 其它 ORC 支持的属性也可以类似设置。
 
 final OrcBulkWriterFactory<Person> writerFactory = new OrcBulkWriterFactory<>(
@@ -462,7 +462,7 @@ val schema: String = ...
 val conf: Configuration = ...
 val writerProperties: Properties = new Properties()
 
-writerProps.setProperty("orc.compress", "LZ4")
+writerProperties.setProperty("orc.compress", "LZ4")
 // 其它 ORC 支持的属性也可以类似设置。
 
 val writerFactory = new OrcBulkWriterFactory(

--- a/docs/content/docs/connectors/datastream/file_sink.md
+++ b/docs/content/docs/connectors/datastream/file_sink.md
@@ -477,7 +477,7 @@ String schema = ...;
 Configuration conf = ...;
 Properties writerProperties = new Properties();
 
-writerProps.setProperty("orc.compress", "LZ4");
+writerProperties.setProperty("orc.compress", "LZ4");
 // Other ORC supported properties can also be set similarly.
 
 final OrcBulkWriterFactory<Person> writerFactory = new OrcBulkWriterFactory<>(
@@ -491,7 +491,7 @@ val schema: String = ...
 val conf: Configuration = ...
 val writerProperties: Properties = new Properties()
 
-writerProps.setProperty("orc.compress", "LZ4")
+writerProperties.setProperty("orc.compress", "LZ4")
 // Other ORC supported properties can also be set similarly.
 
 val writerFactory = new OrcBulkWriterFactory(


### PR DESCRIPTION
## What is the purpose of the change

#### Problem Description
-  What should be quoted here is writerProperties Shouldn't be is writerProps
-  I checked all versions and found that 1.11 version and above need to be modified here
- Please use cherry-pick to fix all branches involved in the problem （1.11 +  and Chinese documents ）

![image](https://user-images.githubusercontent.com/42398474/143981420-52fbf0dc-3da4-41f2-8f9e-0e961fa301d3.png)

- [Official website document FileSink orc compression attribute reference error --- issue](https://issues.apache.org/jira/projects/FLINK/issues/FLINK-25091?filter=reportedbyme)
