### PR TITLE
[FLINK-25011][runtime] Introduce vertex parallelism decider and the default implementation.

### DIFF
--- a/docs/layouts/shortcodes/generated/all_jobmanager_section.html
+++ b/docs/layouts/shortcodes/generated/all_jobmanager_section.html
@@ -75,6 +75,30 @@
             <td>The config parameter defining the network port to connect to for communication with the job manager. Like jobmanager.rpc.address, this value is only interpreted in setups where a single JobManager with static name/address and port exists (simple standalone setups, or container setups with dynamic service name resolution). This config option is not used in many high-availability setups, when a leader-election service (like ZooKeeper) is used to elect and discover the JobManager leader from potentially multiple standby JobManagers.</td>
         </tr>
         <tr>
+            <td><h5>jobmanager.scheduler.adaptive-batch.data-volume-per-task</h5></td>
+            <td style="word-wrap: break-word;">1 gb</td>
+            <td>MemorySize</td>
+            <td>The size of data volume to expect each task instance to process if <code class="highlighter-rouge">jobmanager.scheduler</code> has been set to <code class="highlighter-rouge">AdaptiveBatch</code></td>
+        </tr>
+        <tr>
+            <td><h5>jobmanager.scheduler.adaptive-batch.max-parallelism</h5></td>
+            <td style="word-wrap: break-word;">128</td>
+            <td>Integer</td>
+            <td>The upper bound of allowed parallelism to set adaptively if <code class="highlighter-rouge">jobmanager.scheduler</code> has been set to <code class="highlighter-rouge">AdaptiveBatch</code></td>
+        </tr>
+        <tr>
+            <td><h5>jobmanager.scheduler.adaptive-batch.min-parallelism</h5></td>
+            <td style="word-wrap: break-word;">1</td>
+            <td>Integer</td>
+            <td>The lower bound of allowed parallelism to set adaptively if <code class="highlighter-rouge">jobmanager.scheduler</code> has been set to <code class="highlighter-rouge">AdaptiveBatch</code></td>
+        </tr>
+        <tr>
+            <td><h5>jobmanager.scheduler.adaptive-batch.source-parallelism.default</h5></td>
+            <td style="word-wrap: break-word;">1</td>
+            <td>Integer</td>
+            <td>The default parallelism of source vertices if <code class="highlighter-rouge">jobmanager.scheduler</code> has been set to <code class="highlighter-rouge">AdaptiveBatch</code></td>
+        </tr>
+        <tr>
             <td><h5>jobstore.cache-size</h5></td>
             <td style="word-wrap: break-word;">52428800</td>
             <td>Long</td>

--- a/docs/layouts/shortcodes/generated/expert_scheduling_section.html
+++ b/docs/layouts/shortcodes/generated/expert_scheduling_section.html
@@ -45,6 +45,30 @@
             <td>The maximum time the JobManager will wait to acquire all required resources after a job submission or restart. Once elapsed it will try to run the job with a lower parallelism, or fail if the minimum amount of resources could not be acquired.<br />Increasing this value will make the cluster more resilient against temporary resources shortages (e.g., there is more time for a failed TaskManager to be restarted).<br />Setting a negative duration will disable the resource timeout: The JobManager will wait indefinitely for resources to appear.<br />If <code class="highlighter-rouge">scheduler-mode</code> is configured to <code class="highlighter-rouge">REACTIVE</code>, this configuration value will default to a negative value to disable the resource timeout.</td>
         </tr>
         <tr>
+            <td><h5>jobmanager.scheduler.adaptive-batch.data-volume-per-task</h5></td>
+            <td style="word-wrap: break-word;">1 gb</td>
+            <td>MemorySize</td>
+            <td>The size of data volume to expect each task instance to process if <code class="highlighter-rouge">jobmanager.scheduler</code> has been set to <code class="highlighter-rouge">AdaptiveBatch</code></td>
+        </tr>
+        <tr>
+            <td><h5>jobmanager.scheduler.adaptive-batch.max-parallelism</h5></td>
+            <td style="word-wrap: break-word;">128</td>
+            <td>Integer</td>
+            <td>The upper bound of allowed parallelism to set adaptively if <code class="highlighter-rouge">jobmanager.scheduler</code> has been set to <code class="highlighter-rouge">AdaptiveBatch</code></td>
+        </tr>
+        <tr>
+            <td><h5>jobmanager.scheduler.adaptive-batch.min-parallelism</h5></td>
+            <td style="word-wrap: break-word;">1</td>
+            <td>Integer</td>
+            <td>The lower bound of allowed parallelism to set adaptively if <code class="highlighter-rouge">jobmanager.scheduler</code> has been set to <code class="highlighter-rouge">AdaptiveBatch</code></td>
+        </tr>
+        <tr>
+            <td><h5>jobmanager.scheduler.adaptive-batch.source-parallelism.default</h5></td>
+            <td style="word-wrap: break-word;">1</td>
+            <td>Integer</td>
+            <td>The default parallelism of source vertices if <code class="highlighter-rouge">jobmanager.scheduler</code> has been set to <code class="highlighter-rouge">AdaptiveBatch</code></td>
+        </tr>
+        <tr>
             <td><h5>scheduler-mode</h5></td>
             <td style="word-wrap: break-word;">(none)</td>
             <td><p>Enum</p></td>

--- a/docs/layouts/shortcodes/generated/job_manager_configuration.html
+++ b/docs/layouts/shortcodes/generated/job_manager_configuration.html
@@ -141,6 +141,30 @@
             <td>The config parameter defining the network port to connect to for communication with the job manager. Like jobmanager.rpc.address, this value is only interpreted in setups where a single JobManager with static name/address and port exists (simple standalone setups, or container setups with dynamic service name resolution). This config option is not used in many high-availability setups, when a leader-election service (like ZooKeeper) is used to elect and discover the JobManager leader from potentially multiple standby JobManagers.</td>
         </tr>
         <tr>
+            <td><h5>jobmanager.scheduler.adaptive-batch.data-volume-per-task</h5></td>
+            <td style="word-wrap: break-word;">1 gb</td>
+            <td>MemorySize</td>
+            <td>The size of data volume to expect each task instance to process if <code class="highlighter-rouge">jobmanager.scheduler</code> has been set to <code class="highlighter-rouge">AdaptiveBatch</code></td>
+        </tr>
+        <tr>
+            <td><h5>jobmanager.scheduler.adaptive-batch.max-parallelism</h5></td>
+            <td style="word-wrap: break-word;">128</td>
+            <td>Integer</td>
+            <td>The upper bound of allowed parallelism to set adaptively if <code class="highlighter-rouge">jobmanager.scheduler</code> has been set to <code class="highlighter-rouge">AdaptiveBatch</code></td>
+        </tr>
+        <tr>
+            <td><h5>jobmanager.scheduler.adaptive-batch.min-parallelism</h5></td>
+            <td style="word-wrap: break-word;">1</td>
+            <td>Integer</td>
+            <td>The lower bound of allowed parallelism to set adaptively if <code class="highlighter-rouge">jobmanager.scheduler</code> has been set to <code class="highlighter-rouge">AdaptiveBatch</code></td>
+        </tr>
+        <tr>
+            <td><h5>jobmanager.scheduler.adaptive-batch.source-parallelism.default</h5></td>
+            <td style="word-wrap: break-word;">1</td>
+            <td>Integer</td>
+            <td>The default parallelism of source vertices if <code class="highlighter-rouge">jobmanager.scheduler</code> has been set to <code class="highlighter-rouge">AdaptiveBatch</code></td>
+        </tr>
+        <tr>
             <td><h5>jobstore.cache-size</h5></td>
             <td style="word-wrap: break-word;">52428800</td>
             <td>Long</td>

--- a/flink-core/src/main/java/org/apache/flink/configuration/JobManagerOptions.java
+++ b/flink-core/src/main/java/org/apache/flink/configuration/JobManagerOptions.java
@@ -387,13 +387,16 @@ public class JobManagerOptions {
                                     .list(
                                             text("'Ng': new generation scheduler"),
                                             text(
-                                                    "'Adaptive': adaptive scheduler; supports reactive mode"))
+                                                    "'Adaptive': adaptive scheduler; supports reactive mode"),
+                                            text(
+                                                    "'AdaptiveBatch': adaptive batch scheduler, which can automatically decide parallelisms of job vertices for batch jobs"))
                                     .build());
 
     /** Type of scheduler implementation. */
     public enum SchedulerType {
         Ng,
-        Adaptive
+        Adaptive,
+        AdaptiveBatch
     }
 
     @Documentation.Section(Documentation.Sections.EXPERT_SCHEDULING)
@@ -479,6 +482,70 @@ public class JobManagerOptions {
                     .defaultValue(true)
                     .withDescription(
                             "Controls whether partitions should already be released during the job execution.");
+
+    @Documentation.Section({
+        Documentation.Sections.EXPERT_SCHEDULING,
+        Documentation.Sections.ALL_JOB_MANAGER
+    })
+    public static final ConfigOption<Integer> ADAPTIVE_BATCH_SCHEDULER_MIN_PARALLELISM =
+            key("jobmanager.scheduler.adaptive-batch.min-parallelism")
+                    .intType()
+                    .defaultValue(1)
+                    .withDescription(
+                            Description.builder()
+                                    .text(
+                                            "The lower bound of allowed parallelism to set adaptively if %s has been set to %s",
+                                            code(SCHEDULER.key()),
+                                            code(SchedulerType.AdaptiveBatch.name()))
+                                    .build());
+
+    @Documentation.Section({
+        Documentation.Sections.EXPERT_SCHEDULING,
+        Documentation.Sections.ALL_JOB_MANAGER
+    })
+    public static final ConfigOption<Integer> ADAPTIVE_BATCH_SCHEDULER_MAX_PARALLELISM =
+            key("jobmanager.scheduler.adaptive-batch.max-parallelism")
+                    .intType()
+                    .defaultValue(128)
+                    .withDescription(
+                            Description.builder()
+                                    .text(
+                                            "The upper bound of allowed parallelism to set adaptively if %s has been set to %s",
+                                            code(SCHEDULER.key()),
+                                            code(SchedulerType.AdaptiveBatch.name()))
+                                    .build());
+
+    @Documentation.Section({
+        Documentation.Sections.EXPERT_SCHEDULING,
+        Documentation.Sections.ALL_JOB_MANAGER
+    })
+    public static final ConfigOption<MemorySize> ADAPTIVE_BATCH_SCHEDULER_DATA_VOLUME_PER_TASK =
+            key("jobmanager.scheduler.adaptive-batch.data-volume-per-task")
+                    .memoryType()
+                    .defaultValue(MemorySize.ofMebiBytes(1024))
+                    .withDescription(
+                            Description.builder()
+                                    .text(
+                                            "The size of data volume to expect each task instance to process if %s has been set to %s",
+                                            code(SCHEDULER.key()),
+                                            code(SchedulerType.AdaptiveBatch.name()))
+                                    .build());
+
+    @Documentation.Section({
+        Documentation.Sections.EXPERT_SCHEDULING,
+        Documentation.Sections.ALL_JOB_MANAGER
+    })
+    public static final ConfigOption<Integer> ADAPTIVE_BATCH_SCHEDULER_DEFAULT_SOURCE_PARALLELISM =
+            key("jobmanager.scheduler.adaptive-batch.source-parallelism.default")
+                    .intType()
+                    .defaultValue(1)
+                    .withDescription(
+                            Description.builder()
+                                    .text(
+                                            "The default parallelism of source vertices if %s has been set to %s",
+                                            code(SCHEDULER.key()),
+                                            code(SchedulerType.AdaptiveBatch.name()))
+                                    .build());
 
     // ---------------------------------------------------------------------------------------------
 

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/scheduler/adaptivebatch/BlockingResultInfo.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/scheduler/adaptivebatch/BlockingResultInfo.java
@@ -1,0 +1,51 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.flink.runtime.scheduler.adaptivebatch;
+
+import java.util.List;
+
+/** The blocking result info, which will be used to calculate the vertex parallelism. */
+public class BlockingResultInfo {
+
+    private final List<Long> blockingPartitionSizes;
+
+    private final boolean isBroadcast;
+
+    private BlockingResultInfo(List<Long> blockingPartitionSizes, boolean isBroadcast) {
+        this.blockingPartitionSizes = blockingPartitionSizes;
+        this.isBroadcast = isBroadcast;
+    }
+
+    public List<Long> getBlockingPartitionSizes() {
+        return blockingPartitionSizes;
+    }
+
+    public boolean isBroadcast() {
+        return isBroadcast;
+    }
+
+    public static BlockingResultInfo createFromBroadcastResult(List<Long> blockingPartitionSizes) {
+        return new BlockingResultInfo(blockingPartitionSizes, true);
+    }
+
+    public static BlockingResultInfo createFromNonBroadcastResult(
+            List<Long> blockingPartitionSizes) {
+        return new BlockingResultInfo(blockingPartitionSizes, false);
+    }
+}

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/scheduler/adaptivebatch/DefaultVertexParallelismDecider.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/scheduler/adaptivebatch/DefaultVertexParallelismDecider.java
@@ -1,0 +1,162 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.flink.runtime.scheduler.adaptivebatch;
+
+import org.apache.flink.configuration.Configuration;
+import org.apache.flink.configuration.JobManagerOptions;
+import org.apache.flink.configuration.MemorySize;
+
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import java.util.List;
+
+import static org.apache.flink.util.Preconditions.checkArgument;
+import static org.apache.flink.util.Preconditions.checkNotNull;
+
+/** Default implementation of {@link VertexParallelismDecider}. */
+public class DefaultVertexParallelismDecider implements VertexParallelismDecider {
+
+    private static final Logger LOG =
+            LoggerFactory.getLogger(DefaultVertexParallelismDecider.class);
+
+    /**
+     * The cap ratio of broadcast bytes to data volume per task. The cap ratio is 0.5 currently
+     * because we usually expect the broadcast dataset to be smaller than non-broadcast. We can make
+     * it configurable later if we see users requesting for it.
+     */
+    private static final double CAP_RATIO_OF_BROADCAST = 0.5;
+
+    private final int maxParallelism;
+    private final int minParallelism;
+    private final long dataVolumePerTask;
+    private final int defaultSourceParallelism;
+
+    private DefaultVertexParallelismDecider(
+            int maxParallelism,
+            int minParallelism,
+            MemorySize dataVolumePerTask,
+            int defaultSourceParallelism) {
+
+        checkArgument(minParallelism > 0, "The minimum parallelism must be larger than 0.");
+        checkArgument(
+                maxParallelism >= minParallelism,
+                "Maximum parallelism should be greater than or equal to the minimum parallelism.");
+        checkArgument(
+                defaultSourceParallelism > 0,
+                "The default source parallelism must be larger than 0.");
+        checkNotNull(dataVolumePerTask);
+
+        this.maxParallelism = maxParallelism;
+        this.minParallelism = minParallelism;
+        this.dataVolumePerTask = dataVolumePerTask.getBytes();
+        this.defaultSourceParallelism = defaultSourceParallelism;
+    }
+
+    @Override
+    public int decideParallelismForVertex(List<BlockingResultInfo> consumedResults) {
+
+        if (consumedResults.isEmpty()) {
+            // source job vertex
+            return defaultSourceParallelism;
+        } else {
+            return calculateParallelism(consumedResults);
+        }
+    }
+
+    private int calculateParallelism(List<BlockingResultInfo> consumedResults) {
+
+        long broadcastBytes =
+                consumedResults.stream()
+                        .filter(BlockingResultInfo::isBroadcast)
+                        .mapToLong(
+                                consumedResult ->
+                                        consumedResult.getBlockingPartitionSizes().stream()
+                                                .reduce(0L, Long::sum))
+                        .sum();
+
+        long nonBroadcastBytes =
+                consumedResults.stream()
+                        .filter(consumedResult -> !consumedResult.isBroadcast())
+                        .mapToLong(
+                                consumedResult ->
+                                        consumedResult.getBlockingPartitionSizes().stream()
+                                                .reduce(0L, Long::sum))
+                        .sum();
+
+        long expectedMaxBroadcastBytes =
+                (long) Math.ceil((dataVolumePerTask * CAP_RATIO_OF_BROADCAST));
+
+        if (broadcastBytes > expectedMaxBroadcastBytes) {
+            LOG.info(
+                    "The size of broadcast data {} is larger than the expected maximum value {} ('{}' * {})."
+                            + " Use {} as the size of broadcast data to decide the parallelism.",
+                    new MemorySize(broadcastBytes),
+                    new MemorySize(expectedMaxBroadcastBytes),
+                    JobManagerOptions.ADAPTIVE_BATCH_SCHEDULER_DATA_VOLUME_PER_TASK.key(),
+                    CAP_RATIO_OF_BROADCAST,
+                    new MemorySize(expectedMaxBroadcastBytes));
+
+            broadcastBytes = expectedMaxBroadcastBytes;
+        }
+
+        int parallelism =
+                (int) Math.ceil((double) nonBroadcastBytes / (dataVolumePerTask - broadcastBytes));
+
+        LOG.debug(
+                "The size of broadcast data is {}, the size of non-broadcast data is {}, "
+                        + "the initially decided parallelism is {}.",
+                new MemorySize(broadcastBytes),
+                new MemorySize(nonBroadcastBytes),
+                parallelism);
+
+        if (parallelism < minParallelism) {
+            LOG.info(
+                    "The initially decided parallelism {} is smaller than the minimum parallelism {} "
+                            + "(which is configured by '{}'). Use {} as the finally decided parallelism.",
+                    parallelism,
+                    minParallelism,
+                    JobManagerOptions.ADAPTIVE_BATCH_SCHEDULER_MIN_PARALLELISM.key(),
+                    minParallelism);
+            parallelism = minParallelism;
+        } else if (parallelism > maxParallelism) {
+            LOG.info(
+                    "The initially decided parallelism {} is larger than the maximum parallelism {} "
+                            + "(which is configured by '{}'). Use {} as the finally decided parallelism.",
+                    parallelism,
+                    maxParallelism,
+                    JobManagerOptions.ADAPTIVE_BATCH_SCHEDULER_MAX_PARALLELISM.key(),
+                    maxParallelism);
+            parallelism = maxParallelism;
+        }
+
+        return parallelism;
+    }
+
+    public static DefaultVertexParallelismDecider from(Configuration configuration) {
+        return new DefaultVertexParallelismDecider(
+                configuration.getInteger(
+                        JobManagerOptions.ADAPTIVE_BATCH_SCHEDULER_MAX_PARALLELISM),
+                configuration.getInteger(
+                        JobManagerOptions.ADAPTIVE_BATCH_SCHEDULER_MIN_PARALLELISM),
+                configuration.get(JobManagerOptions.ADAPTIVE_BATCH_SCHEDULER_DATA_VOLUME_PER_TASK),
+                configuration.get(
+                        JobManagerOptions.ADAPTIVE_BATCH_SCHEDULER_DEFAULT_SOURCE_PARALLELISM));
+    }
+}

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/scheduler/adaptivebatch/VertexParallelismDecider.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/scheduler/adaptivebatch/VertexParallelismDecider.java
@@ -1,0 +1,36 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.flink.runtime.scheduler.adaptivebatch;
+
+import java.util.List;
+
+/**
+ * {@link VertexParallelismDecider} is responsible for determining the parallelism of a job vertex,
+ * based on the size of the consumed blocking results.
+ */
+public interface VertexParallelismDecider {
+
+    /**
+     * Computing the parallelism.
+     *
+     * @param consumedResults The information of consumed blocking results.
+     * @return the parallelism of the job vertex.
+     */
+    int decideParallelismForVertex(List<BlockingResultInfo> consumedResults);
+}

--- a/flink-runtime/src/test/java/org/apache/flink/runtime/scheduler/adaptivebatch/DefaultVertexParallelismDeciderTest.java
+++ b/flink-runtime/src/test/java/org/apache/flink/runtime/scheduler/adaptivebatch/DefaultVertexParallelismDeciderTest.java
@@ -1,0 +1,141 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.flink.runtime.scheduler.adaptivebatch;
+
+import org.apache.flink.configuration.Configuration;
+import org.apache.flink.configuration.JobManagerOptions;
+import org.apache.flink.configuration.MemorySize;
+
+import org.junit.Before;
+import org.junit.Test;
+
+import java.util.Arrays;
+import java.util.Collections;
+
+import static org.hamcrest.CoreMatchers.is;
+import static org.hamcrest.MatcherAssert.assertThat;
+
+/** Test for {@link DefaultVertexParallelismDecider}. */
+public class DefaultVertexParallelismDeciderTest {
+
+    private static final long BYTE_256_MB = 256 * 1024 * 1024L;
+    private static final long BYTE_512_MB = 512 * 1024 * 1024L;
+    private static final long BYTE_1_GB = 1024 * 1024 * 1024L;
+    private static final long BYTE_8_GB = 8 * 1024 * 1024 * 1024L;
+    private static final long BYTE_1_TB = 1024 * 1024 * 1024 * 1024L;
+
+    private static final int MAX_PARALLELISM = 100;
+    private static final int MIN_PARALLELISM = 2;
+    private static final int DEFAULT_SOURCE_PARALLELISM = 10;
+    private static final long DATA_VOLUME_PER_TASK = 1024 * 1024 * 1024L;
+
+    private VertexParallelismDecider decider;
+
+    @Before
+    public void before() throws Exception {
+        Configuration configuration = new Configuration();
+
+        configuration.setInteger(
+                JobManagerOptions.ADAPTIVE_BATCH_SCHEDULER_MAX_PARALLELISM, MAX_PARALLELISM);
+        configuration.setInteger(
+                JobManagerOptions.ADAPTIVE_BATCH_SCHEDULER_MIN_PARALLELISM, MIN_PARALLELISM);
+        configuration.set(
+                JobManagerOptions.ADAPTIVE_BATCH_SCHEDULER_DATA_VOLUME_PER_TASK,
+                new MemorySize(DATA_VOLUME_PER_TASK));
+        configuration.setInteger(
+                JobManagerOptions.ADAPTIVE_BATCH_SCHEDULER_DEFAULT_SOURCE_PARALLELISM,
+                DEFAULT_SOURCE_PARALLELISM);
+
+        decider = DefaultVertexParallelismDecider.from(configuration);
+    }
+
+    @Test
+    public void testSourceJobVertex() {
+        int parallelism = decider.decideParallelismForVertex(Collections.emptyList());
+        assertThat(parallelism, is(DEFAULT_SOURCE_PARALLELISM));
+    }
+
+    @Test
+    public void testDecideParallelism() {
+        BlockingResultInfo resultInfo1 =
+                BlockingResultInfo.createFromBroadcastResult(Arrays.asList(BYTE_256_MB));
+        BlockingResultInfo resultInfo2 =
+                BlockingResultInfo.createFromNonBroadcastResult(
+                        Arrays.asList(BYTE_256_MB, BYTE_8_GB));
+
+        int parallelism =
+                decider.decideParallelismForVertex(Arrays.asList(resultInfo1, resultInfo2));
+
+        assertThat(parallelism, is(11));
+    }
+
+    @Test
+    public void testInitiallyDecidedParallelismIsLargerThanMaxParallelism() {
+        BlockingResultInfo resultInfo1 =
+                BlockingResultInfo.createFromBroadcastResult(Arrays.asList(BYTE_256_MB));
+        BlockingResultInfo resultInfo2 =
+                BlockingResultInfo.createFromNonBroadcastResult(
+                        Arrays.asList(BYTE_8_GB, BYTE_1_TB));
+
+        int parallelism =
+                decider.decideParallelismForVertex(Arrays.asList(resultInfo1, resultInfo2));
+
+        assertThat(parallelism, is(MAX_PARALLELISM));
+    }
+
+    @Test
+    public void testInitiallyDecidedParallelismIsSmallerThanMinParallelism() {
+        BlockingResultInfo resultInfo1 =
+                BlockingResultInfo.createFromBroadcastResult(Arrays.asList(BYTE_256_MB));
+        BlockingResultInfo resultInfo2 =
+                BlockingResultInfo.createFromNonBroadcastResult(Arrays.asList(BYTE_512_MB));
+
+        int parallelism =
+                decider.decideParallelismForVertex(Arrays.asList(resultInfo1, resultInfo2));
+
+        assertThat(parallelism, is(MIN_PARALLELISM));
+    }
+
+    @Test
+    public void testBroadcastRatioExceedsCapRatio() {
+        BlockingResultInfo resultInfo1 =
+                BlockingResultInfo.createFromBroadcastResult(Arrays.asList(BYTE_1_GB));
+        BlockingResultInfo resultInfo2 =
+                BlockingResultInfo.createFromNonBroadcastResult(Arrays.asList(BYTE_8_GB));
+
+        int parallelism =
+                decider.decideParallelismForVertex(Arrays.asList(resultInfo1, resultInfo2));
+
+        assertThat(parallelism, is(16));
+    }
+
+    @Test
+    public void testNonBroadcastBytesCanNotDividedEvenly() {
+        BlockingResultInfo resultInfo1 =
+                BlockingResultInfo.createFromBroadcastResult(Arrays.asList(BYTE_512_MB));
+        BlockingResultInfo resultInfo2 =
+                BlockingResultInfo.createFromNonBroadcastResult(
+                        Arrays.asList(BYTE_256_MB, BYTE_8_GB));
+
+        int parallelism =
+                decider.decideParallelismForVertex(Arrays.asList(resultInfo1, resultInfo2));
+
+        assertThat(parallelism, is(17));
+    }
+}


### PR DESCRIPTION
## What is the purpose of the change
Introduce VertexParallelismDecider and default implementation for adaptive batch scheduler.


## Brief change log
Introduce VertexParallelismDecider and default implementation for adaptive batch scheduler.


## Verifying this change
Unit tests for the default implementation.

## Does this pull request potentially affect one of the following parts:

  - Dependencies (does it add or upgrade a dependency): (no)
  - The public API, i.e., is any changed class annotated with `@Public(Evolving)`: (no)
  - The serializers: (no)
  - The runtime per-record code paths (performance sensitive): (no)
  - Anything that affects deployment or recovery: JobManager (and its components), Checkpointing, Kubernetes/Yarn, ZooKeeper: (no)
  - The S3 file system connector: (no)

## Documentation

  - Does this pull request introduce a new feature? (no)
  - If yes, how is the feature documented? (not applicable)