### PR TITLE
[FLINK-24348][FLINK-24740][testinfrastructure][kafka] Update testcont…

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -135,7 +135,7 @@ under the License.
 		<protoc.version>3.17.3</protoc.version>
 		<arrow.version>0.16.0</arrow.version>
 		<okhttp.version>3.14.9</okhttp.version>
-		<testcontainers.version>1.16.0</testcontainers.version>
+		<testcontainers.version>1.16.2</testcontainers.version>
 		<lz4.version>1.8.0</lz4.version>
 		<japicmp.skip>false</japicmp.skip>
 		<flink.convergence.phase>validate</flink.convergence.phase>


### PR DESCRIPTION
…ainers dependency to v1.16.2

(cherry picked from commit 8176d5809e2b13c465662706e3df343b2d4f9028)

This is a backport of https://github.com/apache/flink/pull/17646 minus the exclusions. This PR is linked to https://issues.apache.org/jira/browse/FLINK-24740. The backport should resolve https://issues.apache.org/jira/browse/FLINK-24348