### PR TITLE
[FLINK-18779][table sql/planner]Support the SupportsFilterPushDown for LookupTableSource

### DIFF
--- a/flink-table/flink-table-planner/src/main/java/org/apache/flink/table/planner/plan/rules/logical/FlinkFilterSnapshotTransposeRule.java
+++ b/flink-table/flink-table-planner/src/main/java/org/apache/flink/table/planner/plan/rules/logical/FlinkFilterSnapshotTransposeRule.java
@@ -1,0 +1,80 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.flink.table.planner.plan.rules.logical;
+
+import org.apache.calcite.plan.RelOptRuleCall;
+import org.apache.calcite.plan.RelRule;
+import org.apache.calcite.rel.core.Filter;
+import org.apache.calcite.rel.core.Snapshot;
+import org.apache.calcite.rel.logical.LogicalSnapshot;
+
+/**
+ * Planner rule that tries to push a {@link Filter} past a {@link LogicalSnapshot}, which will be
+ * added if it is a TemporalJoin or LookupJoin. This rule makes {@link
+ * PushFilterIntoSourceScanRuleBase}'s subclasses applicable.
+ */
+public class FlinkFilterSnapshotTransposeRule
+        extends RelRule<FlinkFilterSnapshotTransposeRule.Config> {
+
+    public static final FlinkFilterSnapshotTransposeRule INSTANCE =
+            FlinkFilterSnapshotTransposeRule.Config.EMPTY
+                    .withDescription("FLINK_FILTER_SNAPSHOT_TRANSPOSE_RULE")
+                    .as(Config.class)
+                    .toRule();
+
+    public FlinkFilterSnapshotTransposeRule(Config config) {
+        super(config);
+    }
+
+    @Override
+    public boolean matches(RelOptRuleCall call) {
+        return super.matches(call);
+    }
+
+    @Override
+    public void onMatch(RelOptRuleCall call) {
+        Filter filter = call.rel(0);
+        LogicalSnapshot snapshot = call.rel(1);
+
+        Filter newFilter =
+                filter.copy(filter.getTraitSet(), snapshot.getInput(), filter.getCondition());
+        Snapshot newSnapshot =
+                snapshot.copy(snapshot.getTraitSet(), newFilter, snapshot.getPeriod());
+        call.transformTo(newSnapshot);
+    }
+
+    /** Rule configuration. */
+    public interface Config extends RelRule.Config {
+
+        @Override
+        default FlinkFilterSnapshotTransposeRule toRule() {
+            return new FlinkFilterSnapshotTransposeRule(
+                    withOperandSupplier(
+                                    b0 ->
+                                            b0.operand(Filter.class)
+                                                    .oneInput(
+                                                            b1 ->
+                                                                    b1.operand(
+                                                                                    LogicalSnapshot
+                                                                                            .class)
+                                                                            .anyInputs()))
+                            .as(Config.class));
+        }
+    }
+}

--- a/flink-table/flink-table-planner/src/main/scala/org/apache/flink/table/planner/plan/rules/FlinkBatchRuleSets.scala
+++ b/flink-table/flink-table-planner/src/main/scala/org/apache/flink/table/planner/plan/rules/FlinkBatchRuleSets.scala
@@ -133,7 +133,9 @@ object FlinkBatchRuleSets {
     // push a filter past a project
     CoreRules.FILTER_PROJECT_TRANSPOSE,
     CoreRules.FILTER_SET_OP_TRANSPOSE,
-    CoreRules.FILTER_MERGE
+    CoreRules.FILTER_MERGE,
+    // push a filter past LogicalSnapshot
+    FlinkFilterSnapshotTransposeRule.INSTANCE
   )
 
   val JOIN_NULL_FILTER_RULES: RuleSet = RuleSets.ofList(

--- a/flink-table/flink-table-planner/src/main/scala/org/apache/flink/table/planner/plan/rules/FlinkStreamRuleSets.scala
+++ b/flink-table/flink-table-planner/src/main/scala/org/apache/flink/table/planner/plan/rules/FlinkStreamRuleSets.scala
@@ -170,6 +170,8 @@ object FlinkStreamRuleSets {
 
   /** RuleSet to push down filters into table source */
   val PUSH_FILTER_DOWN_RULES: RuleSet = RuleSets.ofList(
+    // transpose a filter and snapshot
+    FlinkFilterSnapshotTransposeRule.INSTANCE,
     // push a filter down into the table scan
     PushFilterIntoTableSourceScanRule.INSTANCE,
     PushFilterIntoLegacyTableSourceScanRule.INSTANCE
@@ -228,6 +230,7 @@ object FlinkStreamRuleSets {
   /** RuleSet to do logical optimize. This RuleSet is a sub-set of [[LOGICAL_OPT_RULES]]. */
   private val LOGICAL_RULES: RuleSet = RuleSets.ofList(
     // scan optimization
+    FlinkFilterSnapshotTransposeRule.INSTANCE,
     PushProjectIntoTableSourceScanRule.INSTANCE,
     PushProjectIntoLegacyTableSourceScanRule.INSTANCE,
     PushFilterIntoTableSourceScanRule.INSTANCE,

--- a/flink-table/flink-table-planner/src/test/java/org/apache/flink/table/planner/plan/rules/logical/FilterSnapshotTransposeRuleTest.java
+++ b/flink-table/flink-table-planner/src/test/java/org/apache/flink/table/planner/plan/rules/logical/FilterSnapshotTransposeRuleTest.java
@@ -1,0 +1,195 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.flink.table.planner.plan.rules.logical;
+
+import org.apache.flink.table.api.TableConfig;
+import org.apache.flink.table.planner.calcite.CalciteConfig;
+import org.apache.flink.table.planner.plan.optimize.program.BatchOptimizeContext;
+import org.apache.flink.table.planner.plan.optimize.program.FlinkBatchProgram;
+import org.apache.flink.table.planner.plan.optimize.program.FlinkHepRuleSetProgramBuilder;
+import org.apache.flink.table.planner.plan.optimize.program.HEP_RULES_EXECUTION_TYPE;
+import org.apache.flink.table.planner.utils.BatchTableTestUtil;
+import org.apache.flink.table.planner.utils.TableConfigUtils;
+import org.apache.flink.table.planner.utils.TableTestBase;
+
+import org.apache.calcite.plan.hep.HepMatchOrder;
+import org.apache.calcite.rel.rules.CoreRules;
+import org.apache.calcite.tools.RuleSets;
+import org.junit.Before;
+import org.junit.Test;
+
+/** Test for {@link FlinkFilterSnapshotTransposeRule}. */
+public class FilterSnapshotTransposeRuleTest extends TableTestBase {
+    private final BatchTableTestUtil util = batchTestUtil(TableConfig.getDefault());
+
+    @Before
+    public void setup() {
+        util.buildBatchProgram(FlinkBatchProgram.DEFAULT_REWRITE());
+        CalciteConfig calciteConfig =
+                TableConfigUtils.getCalciteConfig(util.tableEnv().getConfig());
+        calciteConfig
+                .getBatchProgram()
+                .get()
+                .addLast(
+                        "rules",
+                        FlinkHepRuleSetProgramBuilder.<BatchOptimizeContext>newBuilder()
+                                .setHepRulesExecutionType(HEP_RULES_EXECUTION_TYPE.RULE_SEQUENCE())
+                                .setHepMatchOrder(HepMatchOrder.BOTTOM_UP)
+                                .add(
+                                        RuleSets.ofList(
+                                                CoreRules.FILTER_INTO_JOIN,
+                                                FlinkFilterSnapshotTransposeRule.INSTANCE,
+                                                PushFilterIntoTableSourceScanRule.INSTANCE))
+                                .build());
+        String ddl1 =
+                "CREATE TABLE ScanTable (\n"
+                        + "  `id` BIGINT,\n"
+                        + "  `len` BIGINT,\n"
+                        + "  `content` STRING,\n"
+                        + "  `proctime` AS PROCTIME()"
+                        + ") WITH (\n"
+                        + "  'connector' = 'values',\n"
+                        + "  'bounded' = 'true'\n"
+                        + ")";
+        util.tableEnv().executeSql(ddl1);
+        String ddl2 =
+                "CREATE TABLE LookupTable (\n"
+                        + "  `age` INT,\n"
+                        + "  `id` BIGINT,\n"
+                        + "  `name` STRING,\n"
+                        + "  `info` STRING,\n"
+                        + "  `price` DOUBLE\n"
+                        + ") WITH ("
+                        + "  'connector' = 'values',\n"
+                        + "  'bounded' = 'true', \n"
+                        + "  'filterable-fields' =  'price;age;info'\n"
+                        + ")";
+        util.tableEnv().executeSql(ddl2);
+    }
+
+    @Test
+    public void testCanPushDown() {
+        String ddl =
+                "SELECT ScanTable.id, ScanTable.len, LookupTable.age, LookupTable.name "
+                        + "FROM ScanTable "
+                        + "JOIN LookupTable FOR system_time AS OF ScanTable.proctime ON ScanTable.id = LookupTable.id "
+                        + "WHERE LookupTable.age > 10";
+
+        util.verifyRelPlan(ddl);
+    }
+
+    @Test
+    public void testCannotPushDown() {
+        String ddl =
+                "SELECT ScanTable.id, ScanTable.len, LookupTable.age, LookupTable.name "
+                        + "FROM ScanTable "
+                        + "JOIN LookupTable FOR system_time AS OF ScanTable.proctime ON ScanTable.id = LookupTable.id "
+                        + "WHERE LookupTable.name = 'flink'";
+
+        util.verifyRelPlan(ddl);
+    }
+
+    @Test
+    public void testCannotPushDown2() {
+        String ddl =
+                "SELECT ScanTable.id, ScanTable.len, LookupTable.age, LookupTable.name "
+                        + "FROM ScanTable "
+                        + "JOIN LookupTable FOR system_time AS OF ScanTable.proctime ON ScanTable.id = LookupTable.id "
+                        + "WHERE LookupTable.name <> 'beam' AND LookupTable.name <> 'spark'";
+
+        util.verifyRelPlan(ddl);
+    }
+
+    @Test
+    public void testCannotPushDown3() {
+        String ddl =
+                "SELECT ScanTable.id, ScanTable.len, LookupTable.age, LookupTable.name "
+                        + "FROM ScanTable "
+                        + "JOIN LookupTable FOR system_time AS OF ScanTable.proctime ON ScanTable.id = LookupTable.id "
+                        + "WHERE LookupTable.name = 'beam' OR LookupTable.name = 'spark'";
+
+        util.verifyRelPlan(ddl);
+    }
+
+    @Test
+    public void testWithUdf() {
+        String ddl =
+                "SELECT ScanTable.id, ScanTable.len, LookupTable.age, LookupTable.name, LookupTable.info "
+                        + "FROM ScanTable "
+                        + "JOIN LookupTable FOR system_time AS OF ScanTable.proctime ON ScanTable.id = LookupTable.id "
+                        + "WHERE UPPER(LookupTable.info) = 'test'";
+
+        util.verifyRelPlan(ddl);
+    }
+
+    @Test
+    public void testPartialPushDown() {
+        String ddl =
+                "SELECT ScanTable.id, ScanTable.len, LookupTable.age, LookupTable.name "
+                        + "FROM ScanTable "
+                        + "JOIN LookupTable FOR system_time AS OF ScanTable.proctime ON ScanTable.id = LookupTable.id "
+                        + "WHERE LookupTable.name = 'flink' AND LookupTable.age > 10";
+
+        util.verifyRelPlan(ddl);
+    }
+
+    @Test
+    public void testCanNotPartialPushDown() {
+        String ddl =
+                "SELECT ScanTable.id, ScanTable.len, LookupTable.age, LookupTable.name "
+                        + "FROM ScanTable "
+                        + "JOIN LookupTable FOR system_time AS OF ScanTable.proctime ON ScanTable.id = LookupTable.id "
+                        + "WHERE LookupTable.name = 'flink' OR LookupTable.age > 10";
+
+        util.verifyRelPlan(ddl);
+    }
+
+    @Test
+    public void testFullyPushDown() {
+        String ddl =
+                "SELECT ScanTable.id, ScanTable.len, LookupTable.age, LookupTable.name "
+                        + "FROM ScanTable "
+                        + "JOIN LookupTable FOR system_time AS OF ScanTable.proctime ON ScanTable.id = LookupTable.id "
+                        + "WHERE LookupTable.age < 100 AND LookupTable.age > 10";
+
+        util.verifyRelPlan(ddl);
+    }
+
+    @Test
+    public void testUnconvertedExpression() {
+        String ddl =
+                "SELECT ScanTable.id, ScanTable.len, LookupTable.age, LookupTable.name "
+                        + "FROM ScanTable "
+                        + "JOIN LookupTable FOR system_time AS OF ScanTable.proctime ON ScanTable.id = LookupTable.id "
+                        + "WHERE LookupTable.age < 100 AND LookupTable.age > 10 AND CAST(LookupTable.price AS BIGINT) < 1000";
+
+        util.verifyRelPlan(ddl);
+    }
+
+    @Test
+    public void testComplicatedPartialPushDown() {
+        String ddl =
+                "SELECT ScanTable.id, ScanTable.len, LookupTable.age, LookupTable.name "
+                        + "FROM ScanTable "
+                        + "JOIN LookupTable FOR system_time AS OF ScanTable.proctime ON ScanTable.id = LookupTable.id "
+                        + "WHERE LookupTable.name = 'flink' AND LookupTable.age > 10 AND ScanTable.content <> 'flink'";
+
+        util.verifyRelPlan(ddl);
+    }
+}

--- a/flink-table/flink-table-planner/src/test/resources/org/apache/flink/table/planner/plan/batch/sql/join/LookupJoinTest.xml
+++ b/flink-table/flink-table-planner/src/test/resources/org/apache/flink/table/planner/plan/batch/sql/join/LookupJoinTest.xml
@@ -53,7 +53,7 @@ HashAggregate(isMerge=[true], groupBy=[b], select=[b, Final_COUNT(count$0) AS EX
 +- Exchange(distribution=[hash[b]])
    +- LocalHashAggregate(groupBy=[b], select=[b, Partial_COUNT(a) AS count$0, Partial_SUM(c) AS sum$1, Partial_SUM(d) AS sum$2])
       +- Calc(select=[b, a, c, d])
-         +- LookupJoin(table=[default_catalog.default_database.LookupTable], joinType=[InnerJoin], async=[false], lookup=[id=a], where=[(age > 10)], select=[b, a, c, d, id])
+         +- LookupJoin(table=[default_catalog.default_database.LookupTable, filter=[]], joinType=[InnerJoin], async=[false], lookup=[id=a], where=[(age > 10)], select=[b, a, c, d, id])
             +- Calc(select=[b, a, c, d])
                +- HashAggregate(isMerge=[true], groupBy=[a, b], select=[a, b, Final_SUM(sum$0) AS c, Final_SUM(sum$1) AS d])
                   +- Exchange(distribution=[hash[a, b]])
@@ -90,7 +90,7 @@ LogicalAggregate(group=[{0}], EXPR$1=[COUNT($1)], EXPR$2=[SUM($2)], EXPR$3=[SUM(
          :     +- LogicalTableScan(table=[[default_catalog, default_database, T1]])
          +- LogicalFilter(condition=[=($cor0.a, $0)])
             +- LogicalSnapshot(period=[$cor0.proctime])
-               +- LogicalTableScan(table=[[default_catalog, default_database, LookupTable, source: [TestTemporalTable(id, name, age)]]])
+               +- LogicalTableScan(table=[[default_catalog, default_database, LookupTable, source: [TestTemporalTable(id, name, age, info)]]])
 ]]>
     </Resource>
     <Resource name="optimized exec plan">
@@ -114,7 +114,7 @@ HashAggregate(isMerge=[true], groupBy=[b], select=[b, Final_COUNT(count$0) AS EX
     </Resource>
     <Resource name="ast">
       <![CDATA[
-LogicalProject(a=[$0], b=[$1], c=[$2], proctime=[$3], id=[$4], name=[$5], age=[$6])
+LogicalProject(a=[$0], b=[$1], c=[$2], proctime=[$3], id=[$4], name=[$5], age=[$6], info=[$7])
 +- LogicalCorrelate(correlation=[$cor0], joinType=[inner], requiredColumns=[{0, 3}])
    :- LogicalProject(a=[$0], b=[$1], c=[$2], proctime=[PROCTIME()])
    :  +- LogicalTableScan(table=[[default_catalog, default_database, T0]])
@@ -125,8 +125,8 @@ LogicalProject(a=[$0], b=[$1], c=[$2], proctime=[$3], id=[$4], name=[$5], age=[$
     </Resource>
     <Resource name="optimized exec plan">
       <![CDATA[
-Calc(select=[a, b, c, PROCTIME_MATERIALIZE(proctime) AS proctime, id, name, age])
-+- LookupJoin(table=[default_catalog.default_database.LookupTable], joinType=[InnerJoin], async=[false], lookup=[id=a], select=[a, b, c, proctime, id, name, age])
+Calc(select=[a, b, c, PROCTIME_MATERIALIZE(proctime) AS proctime, id, name, age, info])
++- LookupJoin(table=[default_catalog.default_database.LookupTable], joinType=[InnerJoin], async=[false], lookup=[id=a], select=[a, b, c, proctime, id, name, age, info])
    +- Calc(select=[a, b, c, PROCTIME() AS proctime])
       +- BoundedStreamScan(table=[[default_catalog, default_database, T0]], fields=[a, b, c])
 ]]>
@@ -138,19 +138,19 @@ Calc(select=[a, b, c, PROCTIME_MATERIALIZE(proctime) AS proctime, id, name, age]
     </Resource>
     <Resource name="ast">
       <![CDATA[
-LogicalProject(a=[$0], b=[$1], c=[$2], proctime=[$3], id=[$4], name=[$5], age=[$6])
+LogicalProject(a=[$0], b=[$1], c=[$2], proctime=[$3], id=[$4], name=[$5], age=[$6], info=[$7])
 +- LogicalCorrelate(correlation=[$cor0], joinType=[inner], requiredColumns=[{0, 3}])
    :- LogicalProject(a=[$0], b=[$1], c=[$2], proctime=[PROCTIME()])
    :  +- LogicalTableScan(table=[[default_catalog, default_database, T0]])
    +- LogicalFilter(condition=[=($cor0.a, $0)])
       +- LogicalSnapshot(period=[$cor0.proctime])
-         +- LogicalTableScan(table=[[default_catalog, default_database, LookupTable, source: [TestTemporalTable(id, name, age)]]])
+         +- LogicalTableScan(table=[[default_catalog, default_database, LookupTable, source: [TestTemporalTable(id, name, age, info)]]])
 ]]>
     </Resource>
     <Resource name="optimized exec plan">
       <![CDATA[
-Calc(select=[a, b, c, PROCTIME_MATERIALIZE(proctime) AS proctime, id, name, age])
-+- LookupJoin(table=[default_catalog.default_database.LookupTable], joinType=[InnerJoin], async=[false], lookup=[id=a], select=[a, b, c, proctime, id, name, age])
+Calc(select=[a, b, c, PROCTIME_MATERIALIZE(proctime) AS proctime, id, name, age, info])
++- LookupJoin(table=[default_catalog.default_database.LookupTable], joinType=[InnerJoin], async=[false], lookup=[id=a], select=[a, b, c, proctime, id, name, age, info])
    +- Calc(select=[a, b, c, PROCTIME() AS proctime])
       +- BoundedStreamScan(table=[[default_catalog, default_database, T0]], fields=[a, b, c])
 ]]>
@@ -211,7 +211,7 @@ LogicalProject(a=[$0], b=[$1], c=[$2], name=[$5], age=[$6], nominal_age=[$7])
     <Resource name="optimized exec plan">
       <![CDATA[
 Calc(select=[a, b, c, name, age, nominal_age])
-+- LookupJoin(table=[default_catalog.default_database.LookupTableWithComputedColumn], joinType=[InnerJoin], async=[false], lookup=[id=a], where=[((age + 1) > 12)], select=[a, b, c, id, name, age, (age + 1) AS nominal_age])
++- LookupJoin(table=[default_catalog.default_database.LookupTableWithComputedColumn, filter=[]], joinType=[InnerJoin], async=[false], lookup=[id=a], where=[((age + 1) > 12)], select=[a, b, c, id, name, age, (age + 1) AS nominal_age])
    +- BoundedStreamScan(table=[[default_catalog, default_database, T0]], fields=[a, b, c])
 ]]>
     </Resource>
@@ -227,7 +227,7 @@ WHERE T.c > 1000
     </Resource>
     <Resource name="ast">
       <![CDATA[
-LogicalProject(a=[$0], b=[$1], c=[$2], proctime=[$3], id=[$4], name=[$5], age=[$6])
+LogicalProject(a=[$0], b=[$1], c=[$2], proctime=[$3], id=[$4], name=[$5], age=[$6], info=[$7])
 +- LogicalFilter(condition=[>($2, 1000)])
    +- LogicalCorrelate(correlation=[$cor0], joinType=[inner], requiredColumns=[{0, 3}])
       :- LogicalProject(a=[$0], b=[$1], c=[$2], proctime=[PROCTIME()])
@@ -239,8 +239,8 @@ LogicalProject(a=[$0], b=[$1], c=[$2], proctime=[$3], id=[$4], name=[$5], age=[$
     </Resource>
     <Resource name="optimized exec plan">
       <![CDATA[
-Calc(select=[a, b, c, PROCTIME_MATERIALIZE(proctime) AS proctime, id, name, CAST(10 AS INTEGER) AS age])
-+- LookupJoin(table=[default_catalog.default_database.LookupTable], joinType=[InnerJoin], async=[false], lookup=[age=10, id=a], where=[(age = 10)], select=[a, b, c, proctime, id, name])
+Calc(select=[a, b, c, PROCTIME_MATERIALIZE(proctime) AS proctime, id, name, CAST(10 AS INTEGER) AS age, info])
++- LookupJoin(table=[default_catalog.default_database.LookupTable, filter=[]], joinType=[InnerJoin], async=[false], lookup=[age=10, id=a], where=[(age = 10)], select=[a, b, c, proctime, id, name, info])
    +- Calc(select=[a, b, c, PROCTIME() AS proctime], where=[(c > 1000)])
       +- BoundedStreamScan(table=[[default_catalog, default_database, T0]], fields=[a, b, c])
 ]]>
@@ -257,20 +257,20 @@ WHERE T.c > 1000
     </Resource>
     <Resource name="ast">
       <![CDATA[
-LogicalProject(a=[$0], b=[$1], c=[$2], proctime=[$3], id=[$4], name=[$5], age=[$6])
+LogicalProject(a=[$0], b=[$1], c=[$2], proctime=[$3], id=[$4], name=[$5], age=[$6], info=[$7])
 +- LogicalFilter(condition=[>($2, 1000)])
    +- LogicalCorrelate(correlation=[$cor0], joinType=[inner], requiredColumns=[{0, 3}])
       :- LogicalProject(a=[$0], b=[$1], c=[$2], proctime=[PROCTIME()])
       :  +- LogicalTableScan(table=[[default_catalog, default_database, T0]])
       +- LogicalFilter(condition=[AND(=($cor0.a, $0), =($2, 10))])
          +- LogicalSnapshot(period=[$cor0.proctime])
-            +- LogicalTableScan(table=[[default_catalog, default_database, LookupTable, source: [TestTemporalTable(id, name, age)]]])
+            +- LogicalTableScan(table=[[default_catalog, default_database, LookupTable, source: [TestTemporalTable(id, name, age, info)]]])
 ]]>
     </Resource>
     <Resource name="optimized exec plan">
       <![CDATA[
-Calc(select=[a, b, c, PROCTIME_MATERIALIZE(proctime) AS proctime, id, name, CAST(10 AS INTEGER) AS age])
-+- LookupJoin(table=[default_catalog.default_database.LookupTable], joinType=[InnerJoin], async=[false], lookup=[age=10, id=a], where=[(age = 10)], select=[a, b, c, proctime, id, name])
+Calc(select=[a, b, c, PROCTIME_MATERIALIZE(proctime) AS proctime, id, name, CAST(10 AS INTEGER) AS age, info])
++- LookupJoin(table=[default_catalog.default_database.LookupTable], joinType=[InnerJoin], async=[false], lookup=[age=10, id=a], where=[(age = 10)], select=[a, b, c, proctime, id, name, info])
    +- Calc(select=[a, b, c, PROCTIME() AS proctime], where=[(c > 1000)])
       +- BoundedStreamScan(table=[[default_catalog, default_database, T0]], fields=[a, b, c])
 ]]>
@@ -282,7 +282,7 @@ Calc(select=[a, b, c, PROCTIME_MATERIALIZE(proctime) AS proctime, id, name, CAST
     </Resource>
     <Resource name="ast">
       <![CDATA[
-LogicalProject(a=[$0], b=[$1], proctime=[$2], id=[$3], name=[$4], age=[$5])
+LogicalProject(a=[$0], b=[$1], proctime=[$2], id=[$3], name=[$4], age=[$5], info=[$6])
 +- LogicalCorrelate(correlation=[$cor0], joinType=[inner], requiredColumns=[{0, 2}])
    :- LogicalProject(a=[$0], b=[$1], proctime=[$3])
    :  +- LogicalFilter(condition=[>($2, 1000)])
@@ -295,8 +295,8 @@ LogicalProject(a=[$0], b=[$1], proctime=[$2], id=[$3], name=[$4], age=[$5])
     </Resource>
     <Resource name="optimized exec plan">
       <![CDATA[
-Calc(select=[a, b, PROCTIME_MATERIALIZE(proctime) AS proctime, id, name, age])
-+- LookupJoin(table=[default_catalog.default_database.LookupTable], joinType=[InnerJoin], async=[false], lookup=[id=a], select=[a, b, proctime, id, name, age])
+Calc(select=[a, b, PROCTIME_MATERIALIZE(proctime) AS proctime, id, name, age, info])
++- LookupJoin(table=[default_catalog.default_database.LookupTable], joinType=[InnerJoin], async=[false], lookup=[id=a], select=[a, b, proctime, id, name, age, info])
    +- Calc(select=[a, b, PROCTIME() AS proctime], where=[(c > 1000)])
       +- BoundedStreamScan(table=[[default_catalog, default_database, T0]], fields=[a, b, c])
 ]]>
@@ -308,7 +308,7 @@ Calc(select=[a, b, PROCTIME_MATERIALIZE(proctime) AS proctime, id, name, age])
     </Resource>
     <Resource name="ast">
       <![CDATA[
-LogicalProject(a=[$0], b=[$1], proctime=[$2], id=[$3], name=[$4], age=[$5])
+LogicalProject(a=[$0], b=[$1], proctime=[$2], id=[$3], name=[$4], age=[$5], info=[$6])
 +- LogicalCorrelate(correlation=[$cor0], joinType=[inner], requiredColumns=[{0, 2}])
    :- LogicalProject(a=[$0], b=[$1], proctime=[$3])
    :  +- LogicalFilter(condition=[>($2, 1000)])
@@ -316,13 +316,13 @@ LogicalProject(a=[$0], b=[$1], proctime=[$2], id=[$3], name=[$4], age=[$5])
    :        +- LogicalTableScan(table=[[default_catalog, default_database, T0]])
    +- LogicalFilter(condition=[=($cor0.a, $0)])
       +- LogicalSnapshot(period=[$cor0.proctime])
-         +- LogicalTableScan(table=[[default_catalog, default_database, LookupTable, source: [TestTemporalTable(id, name, age)]]])
+         +- LogicalTableScan(table=[[default_catalog, default_database, LookupTable, source: [TestTemporalTable(id, name, age, info)]]])
 ]]>
     </Resource>
     <Resource name="optimized exec plan">
       <![CDATA[
-Calc(select=[a, b, PROCTIME_MATERIALIZE(proctime) AS proctime, id, name, age])
-+- LookupJoin(table=[default_catalog.default_database.LookupTable], joinType=[InnerJoin], async=[false], lookup=[id=a], select=[a, b, proctime, id, name, age])
+Calc(select=[a, b, PROCTIME_MATERIALIZE(proctime) AS proctime, id, name, age, info])
++- LookupJoin(table=[default_catalog.default_database.LookupTable], joinType=[InnerJoin], async=[false], lookup=[id=a], select=[a, b, proctime, id, name, age, info])
    +- Calc(select=[a, b, PROCTIME() AS proctime], where=[(c > 1000)])
       +- BoundedStreamScan(table=[[default_catalog, default_database, T0]], fields=[a, b, c])
 ]]>
@@ -363,19 +363,19 @@ Calc(select=[a, b, c, PROCTIME_MATERIALIZE(proctime) AS proctime, id])
     </Resource>
     <Resource name="ast">
       <![CDATA[
-LogicalProject(a=[$0], b=[$1], c=[$2], proctime=[$3], id=[$4], name=[$5], age=[$6])
+LogicalProject(a=[$0], b=[$1], c=[$2], proctime=[$3], id=[$4], name=[$5], age=[$6], info=[$7])
 +- LogicalCorrelate(correlation=[$cor0], joinType=[left], requiredColumns=[{0, 3}])
    :- LogicalProject(a=[$0], b=[$1], c=[$2], proctime=[PROCTIME()])
    :  +- LogicalTableScan(table=[[default_catalog, default_database, T0]])
    +- LogicalFilter(condition=[=($cor0.a, $0)])
       +- LogicalSnapshot(period=[$cor0.proctime])
-         +- LogicalTableScan(table=[[default_catalog, default_database, LookupTable, source: [TestTemporalTable(id, name, age)]]])
+         +- LogicalTableScan(table=[[default_catalog, default_database, LookupTable, source: [TestTemporalTable(id, name, age, info)]]])
 ]]>
     </Resource>
     <Resource name="optimized exec plan">
       <![CDATA[
-Calc(select=[a, b, c, PROCTIME_MATERIALIZE(proctime) AS proctime, id, name, age])
-+- LookupJoin(table=[default_catalog.default_database.LookupTable], joinType=[LeftOuterJoin], async=[false], lookup=[id=a], select=[a, b, c, proctime, id, name, age])
+Calc(select=[a, b, c, PROCTIME_MATERIALIZE(proctime) AS proctime, id, name, age, info])
++- LookupJoin(table=[default_catalog.default_database.LookupTable], joinType=[LeftOuterJoin], async=[false], lookup=[id=a], select=[a, b, c, proctime, id, name, age, info])
    +- Calc(select=[a, b, c, PROCTIME() AS proctime])
       +- BoundedStreamScan(table=[[default_catalog, default_database, T0]], fields=[a, b, c])
 ]]>
@@ -398,7 +398,7 @@ LogicalProject(a=[$0], b=[$1], c=[$2], proctime=[$3], id=[$4])
    :  +- LogicalTableScan(table=[[default_catalog, default_database, T0]])
    +- LogicalFilter(condition=[=($cor0.a, $0)])
       +- LogicalSnapshot(period=[$cor0.proctime])
-         +- LogicalTableScan(table=[[default_catalog, default_database, LookupTable, source: [TestTemporalTable(id, name, age)]]])
+         +- LogicalTableScan(table=[[default_catalog, default_database, LookupTable, source: [TestTemporalTable(id, name, age, info)]]])
 ]]>
     </Resource>
     <Resource name="optimized exec plan">
@@ -416,7 +416,7 @@ Calc(select=[a, b, c, PROCTIME_MATERIALIZE(proctime) AS proctime, id])
     </Resource>
     <Resource name="ast">
       <![CDATA[
-LogicalProject(a=[$0], b=[$1], c=[$2], proctime=[$3], id=[$4], name=[$5], age=[$6])
+LogicalProject(a=[$0], b=[$1], c=[$2], proctime=[$3], id=[$4], name=[$5], age=[$6], info=[$7])
 +- LogicalCorrelate(correlation=[$cor0], joinType=[left], requiredColumns=[{0, 3}])
    :- LogicalProject(a=[$0], b=[$1], c=[$2], proctime=[PROCTIME()])
    :  +- LogicalTableScan(table=[[default_catalog, default_database, T0]])
@@ -427,8 +427,8 @@ LogicalProject(a=[$0], b=[$1], c=[$2], proctime=[$3], id=[$4], name=[$5], age=[$
     </Resource>
     <Resource name="optimized exec plan">
       <![CDATA[
-Calc(select=[a, b, c, PROCTIME_MATERIALIZE(proctime) AS proctime, id, name, age])
-+- LookupJoin(table=[default_catalog.default_database.LookupTable], joinType=[LeftOuterJoin], async=[false], lookup=[id=a], select=[a, b, c, proctime, id, name, age])
+Calc(select=[a, b, c, PROCTIME_MATERIALIZE(proctime) AS proctime, id, name, age, info])
++- LookupJoin(table=[default_catalog.default_database.LookupTable], joinType=[LeftOuterJoin], async=[false], lookup=[id=a], select=[a, b, c, proctime, id, name, age, info])
    +- Calc(select=[a, b, c, PROCTIME() AS proctime])
       +- BoundedStreamScan(table=[[default_catalog, default_database, T0]], fields=[a, b, c])
 ]]>
@@ -475,7 +475,7 @@ FlinkLogicalAggregate(group=[{0}], EXPR$1=[COUNT($1)], EXPR$2=[SUM($2)], EXPR$3=
       :     +- FlinkLogicalDataStreamTableScan(table=[[default_catalog, default_database, T1]], fields=[a, b, c, d])
       +- FlinkLogicalSnapshot(period=[$cor0.proctime])
          +- FlinkLogicalCalc(select=[id], where=[>(age, 10)])
-            +- FlinkLogicalTableSourceScan(table=[[default_catalog, default_database, LookupTable]], fields=[id, name, age])
+            +- FlinkLogicalTableSourceScan(table=[[default_catalog, default_database, LookupTable, filter=[]]], fields=[id, name, age, info])
 ]]>
     </Resource>
   </TestCase>
@@ -507,7 +507,7 @@ LogicalAggregate(group=[{0}], EXPR$1=[COUNT($1)], EXPR$2=[SUM($2)], EXPR$3=[SUM(
          :     +- LogicalTableScan(table=[[default_catalog, default_database, T1]])
          +- LogicalFilter(condition=[=($cor0.a, $0)])
             +- LogicalSnapshot(period=[$cor0.proctime])
-               +- LogicalTableScan(table=[[default_catalog, default_database, LookupTable, source: [TestTemporalTable(id, name, age)]]])
+               +- LogicalTableScan(table=[[default_catalog, default_database, LookupTable, source: [TestTemporalTable(id, name, age, info)]]])
 ]]>
     </Resource>
     <Resource name="optimized rel plan">
@@ -520,7 +520,7 @@ FlinkLogicalAggregate(group=[{0}], EXPR$1=[COUNT($1)], EXPR$2=[SUM($2)], EXPR$3=
       :     +- FlinkLogicalDataStreamTableScan(table=[[default_catalog, default_database, T1]], fields=[a, b, c, d])
       +- FlinkLogicalSnapshot(period=[$cor0.proctime])
          +- FlinkLogicalCalc(select=[id], where=[>(age, 10)])
-            +- FlinkLogicalLegacyTableSourceScan(table=[[default_catalog, default_database, LookupTable, source: [TestTemporalTable(id, name, age)]]], fields=[id, name, age])
+            +- FlinkLogicalLegacyTableSourceScan(table=[[default_catalog, default_database, LookupTable, source: [TestTemporalTable(id, name, age, info)]]], fields=[id, name, age, info])
 ]]>
     </Resource>
   </TestCase>
@@ -557,10 +557,10 @@ GROUP BY T1.b, T2.b
       <![CDATA[
 LogicalProject(EXPR$0=[$2], EXPR$1=[$3], EXPR$2=[$4])
 +- LogicalAggregate(group=[{0, 1}], EXPR$0=[COUNT($2)], EXPR$1=[COUNT($3)], EXPR$2=[SUM($4)])
-   +- LogicalProject(b=[$0], b0=[$9], a=[$1], id=[$5], a0=[$8])
-      +- LogicalFilter(condition=[=($1, $8)])
+   +- LogicalProject(b=[$0], b0=[$10], a=[$1], id=[$5], a0=[$9])
+      +- LogicalFilter(condition=[=($1, $9)])
          +- LogicalJoin(condition=[true], joinType=[inner])
-            :- LogicalProject(b=[$0], a=[$1], c=[$2], d=[$3], proctime=[$4], id=[$5], name=[$6], age=[$7])
+            :- LogicalProject(b=[$0], a=[$1], c=[$2], d=[$3], proctime=[$4], id=[$5], name=[$6], age=[$7], info=[$8])
             :  +- LogicalFilter(condition=[>($7, 10)])
             :     +- LogicalCorrelate(correlation=[$cor0], joinType=[inner], requiredColumns=[{1, 4}])
             :        :- LogicalProject(b=[$1], a=[$0], c=[$2], d=[$3], proctime=[PROCTIME()])
@@ -568,7 +568,7 @@ LogicalProject(EXPR$0=[$2], EXPR$1=[$3], EXPR$2=[$4])
             :        :     +- LogicalTableScan(table=[[default_catalog, default_database, T1]])
             :        +- LogicalFilter(condition=[=($cor0.a, $0)])
             :           +- LogicalSnapshot(period=[$cor0.proctime])
-            :              +- LogicalTableScan(table=[[default_catalog, default_database, LookupTable, source: [TestTemporalTable(id, name, age)]]])
+            :              +- LogicalTableScan(table=[[default_catalog, default_database, LookupTable, source: [TestTemporalTable(id, name, age, info)]]])
             +- LogicalProject(a=[$5], b=[$0])
                +- LogicalFilter(condition=[>($7, 10)])
                   +- LogicalCorrelate(correlation=[$cor1], joinType=[inner], requiredColumns=[{1, 4}])
@@ -577,7 +577,7 @@ LogicalProject(EXPR$0=[$2], EXPR$1=[$3], EXPR$2=[$4])
                      :     +- LogicalTableScan(table=[[default_catalog, default_database, T1]])
                      +- LogicalFilter(condition=[=($cor1.a, $0)])
                         +- LogicalSnapshot(period=[$cor1.proctime])
-                           +- LogicalTableScan(table=[[default_catalog, default_database, LookupTable, source: [TestTemporalTable(id, name, age)]]])
+                           +- LogicalTableScan(table=[[default_catalog, default_database, LookupTable, source: [TestTemporalTable(id, name, age, info)]]])
 ]]>
     </Resource>
     <Resource name="optimized exec plan">
@@ -633,10 +633,10 @@ GROUP BY T1.b, T2.b
       <![CDATA[
 LogicalProject(EXPR$0=[$2], EXPR$1=[$3], EXPR$2=[$4])
 +- LogicalAggregate(group=[{0, 1}], EXPR$0=[COUNT($2)], EXPR$1=[COUNT($3)], EXPR$2=[SUM($4)])
-   +- LogicalProject(b=[$0], b0=[$9], a=[$1], id=[$5], a0=[$8])
-      +- LogicalFilter(condition=[=($1, $8)])
+   +- LogicalProject(b=[$0], b0=[$10], a=[$1], id=[$5], a0=[$9])
+      +- LogicalFilter(condition=[=($1, $9)])
          +- LogicalJoin(condition=[true], joinType=[inner])
-            :- LogicalProject(b=[$0], a=[$1], c=[$2], d=[$3], proctime=[$4], id=[$5], name=[$6], age=[$7])
+            :- LogicalProject(b=[$0], a=[$1], c=[$2], d=[$3], proctime=[$4], id=[$5], name=[$6], age=[$7], info=[$8])
             :  +- LogicalFilter(condition=[>($7, 10)])
             :     +- LogicalCorrelate(correlation=[$cor0], joinType=[inner], requiredColumns=[{1, 4}])
             :        :- LogicalProject(b=[$1], a=[$0], c=[$2], d=[$3], proctime=[PROCTIME()])
@@ -664,7 +664,7 @@ Calc(select=[EXPR$0, EXPR$1, EXPR$2])
       +- LocalHashAggregate(groupBy=[b, b0], select=[b, b0, Partial_COUNT(a) AS count$0, Partial_COUNT(id) AS count$1, Partial_SUM(a0) AS sum$2])
          +- HashJoin(joinType=[InnerJoin], where=[(a = a0)], select=[b, a, id, a0, b0], build=[right])
             :- Exchange(distribution=[hash[a]], shuffle_mode=[BATCH])
-            :  +- LookupJoin(table=[default_catalog.default_database.LookupTable], joinType=[InnerJoin], async=[false], lookup=[id=a], where=[(age > 10)], select=[b, a, id])(reuse_id=[1])
+            :  +- LookupJoin(table=[default_catalog.default_database.LookupTable, filter=[]], joinType=[InnerJoin], async=[false], lookup=[id=a], where=[(age > 10)], select=[b, a, id])(reuse_id=[1])
             :     +- Calc(select=[b, a])
             :        +- HashAggregate(isMerge=[true], groupBy=[a, b], select=[a, b])
             :           +- Exchange(distribution=[hash[a, b]])
@@ -673,6 +673,126 @@ Calc(select=[EXPR$0, EXPR$1, EXPR$2])
             +- Exchange(distribution=[hash[a]])
                +- Calc(select=[id AS a, b])
                   +- Reused(reference_id=[1])
+]]>
+    </Resource>
+  </TestCase>
+  <TestCase name="testTemporalTableFilterPartialPushDown[LegacyTableSource=true]">
+	<Resource name="sql">
+      <![CDATA[
+SELECT * FROM MyTable as T
+JOIN LookupTable FOR SYSTEM_TIME AS OF T.proctime AS D
+ON T.a = D.id
+WHERE D.info = 'flink' AND D.age > 10
+]]>
+	</Resource>
+	<Resource name="ast">
+	  <![CDATA[
+LogicalProject(a=[$0], b=[$1], c=[$2], proctime=[$3], id=[$4], name=[$5], age=[$6], info=[$7])
++- LogicalFilter(condition=[AND(=($7, _UTF-16LE'flink'), >($6, 10))])
+   +- LogicalCorrelate(correlation=[$cor0], joinType=[inner], requiredColumns=[{0, 3}])
+      :- LogicalProject(a=[$0], b=[$1], c=[$2], proctime=[PROCTIME()])
+      :  +- LogicalTableScan(table=[[default_catalog, default_database, T0]])
+      +- LogicalFilter(condition=[=($cor0.a, $0)])
+         +- LogicalSnapshot(period=[$cor0.proctime])
+            +- LogicalTableScan(table=[[default_catalog, default_database, LookupTable, source: [TestTemporalTable(id, name, age, info)]]])
+]]>
+	</Resource>
+	<Resource name="optimized exec plan">
+	  <![CDATA[
+Calc(select=[a, b, c, PROCTIME_MATERIALIZE(proctime) AS proctime, id, name, age, CAST('flink' AS VARCHAR(2147483647)) AS info])
++- LookupJoin(table=[default_catalog.default_database.LookupTable], joinType=[InnerJoin], async=[false], lookup=[info=_UTF-16LE'flink', id=a], where=[((info = 'flink') AND (age > 10))], select=[a, b, c, proctime, id, name, age])
+   +- Calc(select=[a, b, c, PROCTIME() AS proctime])
+      +- BoundedStreamScan(table=[[default_catalog, default_database, T0]], fields=[a, b, c])
+]]>
+	</Resource>
+  </TestCase>
+  <TestCase name="testTemporalTableFilterPartialPushDown[LegacyTableSource=false]">
+	<Resource name="sql">
+	  <![CDATA[
+SELECT * FROM MyTable as T
+JOIN LookupTable FOR SYSTEM_TIME AS OF T.proctime AS D
+ON T.a = D.id
+WHERE D.info = 'flink' AND D.age > 10
+]]>
+	</Resource>
+	<Resource name="ast">
+	  <![CDATA[
+LogicalProject(a=[$0], b=[$1], c=[$2], proctime=[$3], id=[$4], name=[$5], age=[$6], info=[$7])
++- LogicalFilter(condition=[AND(=($7, _UTF-16LE'flink'), >($6, 10))])
+   +- LogicalCorrelate(correlation=[$cor0], joinType=[inner], requiredColumns=[{0, 3}])
+      :- LogicalProject(a=[$0], b=[$1], c=[$2], proctime=[PROCTIME()])
+      :  +- LogicalTableScan(table=[[default_catalog, default_database, T0]])
+      +- LogicalFilter(condition=[=($cor0.a, $0)])
+         +- LogicalSnapshot(period=[$cor0.proctime])
+            +- LogicalTableScan(table=[[default_catalog, default_database, LookupTable]])
+]]>
+	</Resource>
+	<Resource name="optimized exec plan">
+      <![CDATA[
+Calc(select=[a, b, c, PROCTIME_MATERIALIZE(proctime) AS proctime, id, name, age, CAST('flink' AS VARCHAR(2147483647)) AS info])
++- LookupJoin(table=[default_catalog.default_database.LookupTable, filter=[=(info, _UTF-16LE'flink':VARCHAR(2147483647) CHARACTER SET "UTF-16LE")]], joinType=[InnerJoin], async=[false], lookup=[id=a], where=[(age > 10)], select=[a, b, c, proctime, id, name, age])
+   +- Calc(select=[a, b, c, PROCTIME() AS proctime])
+      +- BoundedStreamScan(table=[[default_catalog, default_database, T0]], fields=[a, b, c])
+]]>
+	</Resource>
+  </TestCase>
+  <TestCase name="testTemporalTableFilterPushDownWithUdf[LegacyTableSource=true]">
+	<Resource name="sql">
+	  <![CDATA[
+SELECT * FROM MyTable as T
+JOIN LookupTable FOR SYSTEM_TIME AS OF T.proctime AS D
+ON T.a = D.id
+WHERE UPPER(D.info) = 'flink'
+]]>
+	</Resource>
+	<Resource name="ast">
+	  <![CDATA[
+LogicalProject(a=[$0], b=[$1], c=[$2], proctime=[$3], id=[$4], name=[$5], age=[$6], info=[$7])
++- LogicalFilter(condition=[=(UPPER($7), _UTF-16LE'flink')])
+   +- LogicalCorrelate(correlation=[$cor0], joinType=[inner], requiredColumns=[{0, 3}])
+      :- LogicalProject(a=[$0], b=[$1], c=[$2], proctime=[PROCTIME()])
+      :  +- LogicalTableScan(table=[[default_catalog, default_database, T0]])
+      +- LogicalFilter(condition=[=($cor0.a, $0)])
+         +- LogicalSnapshot(period=[$cor0.proctime])
+            +- LogicalTableScan(table=[[default_catalog, default_database, LookupTable, source: [TestTemporalTable(id, name, age, info)]]])
+]]>
+	</Resource>
+	<Resource name="optimized exec plan">
+	  <![CDATA[
+Calc(select=[a, b, c, PROCTIME_MATERIALIZE(proctime) AS proctime, id, name, age, info])
++- LookupJoin(table=[default_catalog.default_database.LookupTable], joinType=[InnerJoin], async=[false], lookup=[id=a], where=[(UPPER(info) = 'flink')], select=[a, b, c, proctime, id, name, age, info])
+   +- Calc(select=[a, b, c, PROCTIME() AS proctime])
+      +- BoundedStreamScan(table=[[default_catalog, default_database, T0]], fields=[a, b, c])
+]]>
+	</Resource>
+  </TestCase>
+  <TestCase name="testTemporalTableFilterPushDownWithUdf[LegacyTableSource=false]">
+	<Resource name="sql">
+      <![CDATA[
+SELECT * FROM MyTable as T
+JOIN LookupTable FOR SYSTEM_TIME AS OF T.proctime AS D
+ON T.a = D.id
+WHERE UPPER(D.info) = 'flink'
+]]>
+	</Resource>
+	<Resource name="ast">
+	  <![CDATA[
+LogicalProject(a=[$0], b=[$1], c=[$2], proctime=[$3], id=[$4], name=[$5], age=[$6], info=[$7])
++- LogicalFilter(condition=[=(UPPER($7), _UTF-16LE'flink')])
+   +- LogicalCorrelate(correlation=[$cor0], joinType=[inner], requiredColumns=[{0, 3}])
+      :- LogicalProject(a=[$0], b=[$1], c=[$2], proctime=[PROCTIME()])
+      :  +- LogicalTableScan(table=[[default_catalog, default_database, T0]])
+      +- LogicalFilter(condition=[=($cor0.a, $0)])
+         +- LogicalSnapshot(period=[$cor0.proctime])
+            +- LogicalTableScan(table=[[default_catalog, default_database, LookupTable]])
+]]>
+	</Resource>
+    <Resource name="optimized exec plan">
+	  <![CDATA[
+Calc(select=[a, b, c, PROCTIME_MATERIALIZE(proctime) AS proctime, id, name, age, info])
++- LookupJoin(table=[default_catalog.default_database.LookupTable, filter=[=(UPPER(info), _UTF-16LE'flink':VARCHAR(2147483647) CHARACTER SET "UTF-16LE")]], joinType=[InnerJoin], async=[false], lookup=[id=a], select=[a, b, c, proctime, id, name, age, info])
+   +- Calc(select=[a, b, c, PROCTIME() AS proctime])
+      +- BoundedStreamScan(table=[[default_catalog, default_database, T0]], fields=[a, b, c])
 ]]>
     </Resource>
   </TestCase>

--- a/flink-table/flink-table-planner/src/test/resources/org/apache/flink/table/planner/plan/rules/logical/FilterSnapshotTransposeRuleTest.xml
+++ b/flink-table/flink-table-planner/src/test/resources/org/apache/flink/table/planner/plan/rules/logical/FilterSnapshotTransposeRuleTest.xml
@@ -1,0 +1,297 @@
+<?xml version="1.0" ?>
+<!--
+Licensed to the Apache Software Foundation (ASF) under one or more
+contributor license agreements.  See the NOTICE file distributed with
+this work for additional information regarding copyright ownership.
+The ASF licenses this file to you under the Apache License, Version 2.0
+(the "License"); you may not use this file except in compliance with
+the License.  You may obtain a copy of the License at
+
+http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+-->
+<Root>
+  <TestCase name="testCanNotPartialPushDown">
+    <Resource name="sql">
+      <![CDATA[SELECT ScanTable.id, ScanTable.len, LookupTable.age, LookupTable.name FROM ScanTable JOIN LookupTable FOR system_time AS OF ScanTable.proctime ON ScanTable.id = LookupTable.id WHERE LookupTable.name = 'flink' OR LookupTable.age > 10]]>
+    </Resource>
+    <Resource name="ast">
+      <![CDATA[
+LogicalProject(id=[$0], len=[$1], age=[$4], name=[$6])
++- LogicalFilter(condition=[OR(=($6, _UTF-16LE'flink'), >($4, 10))])
+   +- LogicalCorrelate(correlation=[$cor0], joinType=[inner], requiredColumns=[{0, 3}])
+      :- LogicalProject(id=[$0], len=[$1], content=[$2], proctime=[PROCTIME()])
+      :  +- LogicalTableScan(table=[[default_catalog, default_database, ScanTable]])
+      +- LogicalFilter(condition=[=($cor0.id, $1)])
+         +- LogicalSnapshot(period=[$cor0.proctime])
+            +- LogicalTableScan(table=[[default_catalog, default_database, LookupTable]])
+]]>
+    </Resource>
+    <Resource name="optimized rel plan">
+      <![CDATA[
+LogicalProject(id=[$0], len=[$1], age=[$4], name=[$6])
++- LogicalJoin(condition=[=($0, $5)], joinType=[inner])
+   :- LogicalProject(id=[$0], len=[$1], content=[$2], proctime=[PROCTIME()])
+   :  +- LogicalTableScan(table=[[default_catalog, default_database, ScanTable]])
+   +- LogicalSnapshot(period=[$cor0.proctime])
+      +- LogicalFilter(condition=[OR(=($2, _UTF-16LE'flink'), >($0, 10))])
+         +- LogicalTableScan(table=[[default_catalog, default_database, LookupTable, filter=[]]])
+]]>
+    </Resource>
+  </TestCase>
+  <TestCase name="testCannotPushDown">
+    <Resource name="sql">
+      <![CDATA[SELECT ScanTable.id, ScanTable.len, LookupTable.age, LookupTable.name FROM ScanTable JOIN LookupTable FOR system_time AS OF ScanTable.proctime ON ScanTable.id = LookupTable.id WHERE LookupTable.name = 'flink']]>
+    </Resource>
+    <Resource name="ast">
+      <![CDATA[
+LogicalProject(id=[$0], len=[$1], age=[$4], name=[$6])
++- LogicalFilter(condition=[=($6, _UTF-16LE'flink')])
+   +- LogicalCorrelate(correlation=[$cor0], joinType=[inner], requiredColumns=[{0, 3}])
+      :- LogicalProject(id=[$0], len=[$1], content=[$2], proctime=[PROCTIME()])
+      :  +- LogicalTableScan(table=[[default_catalog, default_database, ScanTable]])
+      +- LogicalFilter(condition=[=($cor0.id, $1)])
+         +- LogicalSnapshot(period=[$cor0.proctime])
+            +- LogicalTableScan(table=[[default_catalog, default_database, LookupTable]])
+]]>
+    </Resource>
+    <Resource name="optimized rel plan">
+      <![CDATA[
+LogicalProject(id=[$0], len=[$1], age=[$4], name=[$6])
++- LogicalJoin(condition=[=($0, $5)], joinType=[inner])
+   :- LogicalProject(id=[$0], len=[$1], content=[$2], proctime=[PROCTIME()])
+   :  +- LogicalTableScan(table=[[default_catalog, default_database, ScanTable]])
+   +- LogicalSnapshot(period=[$cor0.proctime])
+      +- LogicalFilter(condition=[=($2, _UTF-16LE'flink')])
+         +- LogicalTableScan(table=[[default_catalog, default_database, LookupTable, filter=[]]])
+]]>
+    </Resource>
+  </TestCase>
+  <TestCase name="testCannotPushDown2">
+    <Resource name="sql">
+      <![CDATA[SELECT ScanTable.id, ScanTable.len, LookupTable.age, LookupTable.name FROM ScanTable JOIN LookupTable FOR system_time AS OF ScanTable.proctime ON ScanTable.id = LookupTable.id WHERE LookupTable.name <> 'beam' AND LookupTable.name <> 'spark']]>
+    </Resource>
+    <Resource name="ast">
+      <![CDATA[
+LogicalProject(id=[$0], len=[$1], age=[$4], name=[$6])
++- LogicalFilter(condition=[AND(<>($6, _UTF-16LE'beam'), <>($6, _UTF-16LE'spark'))])
+   +- LogicalCorrelate(correlation=[$cor0], joinType=[inner], requiredColumns=[{0, 3}])
+      :- LogicalProject(id=[$0], len=[$1], content=[$2], proctime=[PROCTIME()])
+      :  +- LogicalTableScan(table=[[default_catalog, default_database, ScanTable]])
+      +- LogicalFilter(condition=[=($cor0.id, $1)])
+         +- LogicalSnapshot(period=[$cor0.proctime])
+            +- LogicalTableScan(table=[[default_catalog, default_database, LookupTable]])
+]]>
+    </Resource>
+    <Resource name="optimized rel plan">
+      <![CDATA[
+LogicalProject(id=[$0], len=[$1], age=[$4], name=[$6])
++- LogicalJoin(condition=[=($0, $5)], joinType=[inner])
+   :- LogicalProject(id=[$0], len=[$1], content=[$2], proctime=[PROCTIME()])
+   :  +- LogicalTableScan(table=[[default_catalog, default_database, ScanTable]])
+   +- LogicalSnapshot(period=[$cor0.proctime])
+      +- LogicalFilter(condition=[SEARCH($2, Sarg[(-∞.._UTF-16LE'beam':VARCHAR(2147483647) CHARACTER SET "UTF-16LE"), (_UTF-16LE'beam':VARCHAR(2147483647) CHARACTER SET "UTF-16LE".._UTF-16LE'spark':VARCHAR(2147483647) CHARACTER SET "UTF-16LE"), (_UTF-16LE'spark':VARCHAR(2147483647) CHARACTER SET "UTF-16LE"..+∞)]:VARCHAR(2147483647) CHARACTER SET "UTF-16LE")])
+         +- LogicalTableScan(table=[[default_catalog, default_database, LookupTable, filter=[]]])
+]]>
+    </Resource>
+  </TestCase>
+  <TestCase name="testCannotPushDown3">
+    <Resource name="sql">
+      <![CDATA[SELECT ScanTable.id, ScanTable.len, LookupTable.age, LookupTable.name FROM ScanTable JOIN LookupTable FOR system_time AS OF ScanTable.proctime ON ScanTable.id = LookupTable.id WHERE LookupTable.name = 'beam' OR LookupTable.name = 'spark']]>
+    </Resource>
+    <Resource name="ast">
+      <![CDATA[
+LogicalProject(id=[$0], len=[$1], age=[$4], name=[$6])
++- LogicalFilter(condition=[OR(=($6, _UTF-16LE'beam'), =($6, _UTF-16LE'spark'))])
+   +- LogicalCorrelate(correlation=[$cor0], joinType=[inner], requiredColumns=[{0, 3}])
+      :- LogicalProject(id=[$0], len=[$1], content=[$2], proctime=[PROCTIME()])
+      :  +- LogicalTableScan(table=[[default_catalog, default_database, ScanTable]])
+      +- LogicalFilter(condition=[=($cor0.id, $1)])
+         +- LogicalSnapshot(period=[$cor0.proctime])
+            +- LogicalTableScan(table=[[default_catalog, default_database, LookupTable]])
+]]>
+    </Resource>
+    <Resource name="optimized rel plan">
+      <![CDATA[
+LogicalProject(id=[$0], len=[$1], age=[$4], name=[$6])
++- LogicalJoin(condition=[=($0, $5)], joinType=[inner])
+   :- LogicalProject(id=[$0], len=[$1], content=[$2], proctime=[PROCTIME()])
+   :  +- LogicalTableScan(table=[[default_catalog, default_database, ScanTable]])
+   +- LogicalSnapshot(period=[$cor0.proctime])
+      +- LogicalFilter(condition=[SEARCH($2, Sarg[_UTF-16LE'beam':VARCHAR(2147483647) CHARACTER SET "UTF-16LE", _UTF-16LE'spark':VARCHAR(2147483647) CHARACTER SET "UTF-16LE"]:VARCHAR(2147483647) CHARACTER SET "UTF-16LE")])
+         +- LogicalTableScan(table=[[default_catalog, default_database, LookupTable, filter=[]]])
+]]>
+    </Resource>
+  </TestCase>
+  <TestCase name="testCanPushDown">
+    <Resource name="sql">
+      <![CDATA[SELECT ScanTable.id, ScanTable.len, LookupTable.age, LookupTable.name FROM ScanTable JOIN LookupTable FOR system_time AS OF ScanTable.proctime ON ScanTable.id = LookupTable.id WHERE LookupTable.age > 10]]>
+    </Resource>
+    <Resource name="ast">
+      <![CDATA[
+LogicalProject(id=[$0], len=[$1], age=[$4], name=[$6])
++- LogicalFilter(condition=[>($4, 10)])
+   +- LogicalCorrelate(correlation=[$cor0], joinType=[inner], requiredColumns=[{0, 3}])
+      :- LogicalProject(id=[$0], len=[$1], content=[$2], proctime=[PROCTIME()])
+      :  +- LogicalTableScan(table=[[default_catalog, default_database, ScanTable]])
+      +- LogicalFilter(condition=[=($cor0.id, $1)])
+         +- LogicalSnapshot(period=[$cor0.proctime])
+            +- LogicalTableScan(table=[[default_catalog, default_database, LookupTable]])
+]]>
+    </Resource>
+    <Resource name="optimized rel plan">
+      <![CDATA[
+LogicalProject(id=[$0], len=[$1], age=[$4], name=[$6])
++- LogicalJoin(condition=[=($0, $5)], joinType=[inner])
+   :- LogicalProject(id=[$0], len=[$1], content=[$2], proctime=[PROCTIME()])
+   :  +- LogicalTableScan(table=[[default_catalog, default_database, ScanTable]])
+   +- LogicalSnapshot(period=[$cor0.proctime])
+      +- LogicalTableScan(table=[[default_catalog, default_database, LookupTable, filter=[>(age, 10)]]])
+]]>
+    </Resource>
+  </TestCase>
+  <TestCase name="testComplicatedPartialPushDown">
+    <Resource name="sql">
+      <![CDATA[SELECT ScanTable.id, ScanTable.len, LookupTable.age, LookupTable.name FROM ScanTable JOIN LookupTable FOR system_time AS OF ScanTable.proctime ON ScanTable.id = LookupTable.id WHERE LookupTable.name = 'flink' AND LookupTable.age > 10 AND ScanTable.content <> 'flink']]>
+    </Resource>
+    <Resource name="ast">
+      <![CDATA[
+LogicalProject(id=[$0], len=[$1], age=[$4], name=[$6])
++- LogicalFilter(condition=[AND(=($6, _UTF-16LE'flink'), >($4, 10), <>($2, _UTF-16LE'flink'))])
+   +- LogicalCorrelate(correlation=[$cor0], joinType=[inner], requiredColumns=[{0, 3}])
+      :- LogicalProject(id=[$0], len=[$1], content=[$2], proctime=[PROCTIME()])
+      :  +- LogicalTableScan(table=[[default_catalog, default_database, ScanTable]])
+      +- LogicalFilter(condition=[=($cor0.id, $1)])
+         +- LogicalSnapshot(period=[$cor0.proctime])
+            +- LogicalTableScan(table=[[default_catalog, default_database, LookupTable]])
+]]>
+    </Resource>
+    <Resource name="optimized rel plan">
+      <![CDATA[
+LogicalProject(id=[$0], len=[$1], age=[$4], name=[$6])
++- LogicalJoin(condition=[=($0, $5)], joinType=[inner])
+   :- LogicalFilter(condition=[<>($2, _UTF-16LE'flink')])
+   :  +- LogicalProject(id=[$0], len=[$1], content=[$2], proctime=[PROCTIME()])
+   :     +- LogicalTableScan(table=[[default_catalog, default_database, ScanTable]])
+   +- LogicalSnapshot(period=[$cor0.proctime])
+      +- LogicalFilter(condition=[=($2, _UTF-16LE'flink')])
+         +- LogicalTableScan(table=[[default_catalog, default_database, LookupTable, filter=[>(age, 10)]]])
+]]>
+    </Resource>
+  </TestCase>
+  <TestCase name="testFullyPushDown">
+    <Resource name="sql">
+      <![CDATA[SELECT ScanTable.id, ScanTable.len, LookupTable.age, LookupTable.name FROM ScanTable JOIN LookupTable FOR system_time AS OF ScanTable.proctime ON ScanTable.id = LookupTable.id WHERE LookupTable.age < 100 AND LookupTable.age > 10]]>
+    </Resource>
+    <Resource name="ast">
+      <![CDATA[
+LogicalProject(id=[$0], len=[$1], age=[$4], name=[$6])
++- LogicalFilter(condition=[AND(<($4, 100), >($4, 10))])
+   +- LogicalCorrelate(correlation=[$cor0], joinType=[inner], requiredColumns=[{0, 3}])
+      :- LogicalProject(id=[$0], len=[$1], content=[$2], proctime=[PROCTIME()])
+      :  +- LogicalTableScan(table=[[default_catalog, default_database, ScanTable]])
+      +- LogicalFilter(condition=[=($cor0.id, $1)])
+         +- LogicalSnapshot(period=[$cor0.proctime])
+            +- LogicalTableScan(table=[[default_catalog, default_database, LookupTable]])
+]]>
+    </Resource>
+    <Resource name="optimized rel plan">
+      <![CDATA[
+LogicalProject(id=[$0], len=[$1], age=[$4], name=[$6])
++- LogicalJoin(condition=[=($0, $5)], joinType=[inner])
+   :- LogicalProject(id=[$0], len=[$1], content=[$2], proctime=[PROCTIME()])
+   :  +- LogicalTableScan(table=[[default_catalog, default_database, ScanTable]])
+   +- LogicalSnapshot(period=[$cor0.proctime])
+      +- LogicalTableScan(table=[[default_catalog, default_database, LookupTable, filter=[and(>(age, 10), <(age, 100))]]])
+]]>
+    </Resource>
+  </TestCase>
+  <TestCase name="testUnconvertedExpression">
+    <Resource name="sql">
+      <![CDATA[SELECT ScanTable.id, ScanTable.len, LookupTable.age, LookupTable.name FROM ScanTable JOIN LookupTable FOR system_time AS OF ScanTable.proctime ON ScanTable.id = LookupTable.id WHERE LookupTable.age < 100 AND LookupTable.age > 10 AND CAST(LookupTable.price AS BIGINT) < 1000]]>
+    </Resource>
+    <Resource name="ast">
+      <![CDATA[
+LogicalProject(id=[$0], len=[$1], age=[$4], name=[$6])
++- LogicalFilter(condition=[AND(<($4, 100), >($4, 10), <(CAST($8):BIGINT, 1000))])
+   +- LogicalCorrelate(correlation=[$cor0], joinType=[inner], requiredColumns=[{0, 3}])
+      :- LogicalProject(id=[$0], len=[$1], content=[$2], proctime=[PROCTIME()])
+      :  +- LogicalTableScan(table=[[default_catalog, default_database, ScanTable]])
+      +- LogicalFilter(condition=[=($cor0.id, $1)])
+         +- LogicalSnapshot(period=[$cor0.proctime])
+            +- LogicalTableScan(table=[[default_catalog, default_database, LookupTable]])
+]]>
+    </Resource>
+    <Resource name="optimized rel plan">
+      <![CDATA[
+LogicalProject(id=[$0], len=[$1], age=[$4], name=[$6])
++- LogicalJoin(condition=[=($0, $5)], joinType=[inner])
+   :- LogicalProject(id=[$0], len=[$1], content=[$2], proctime=[PROCTIME()])
+   :  +- LogicalTableScan(table=[[default_catalog, default_database, ScanTable]])
+   +- LogicalSnapshot(period=[$cor0.proctime])
+      +- LogicalFilter(condition=[AND(SEARCH($0, Sarg[(10..100)]), <(CAST($4):BIGINT, 1000))])
+         +- LogicalTableScan(table=[[default_catalog, default_database, LookupTable, filter=[]]])
+]]>
+    </Resource>
+  </TestCase>
+  <TestCase name="testPartialPushDown">
+    <Resource name="sql">
+      <![CDATA[SELECT ScanTable.id, ScanTable.len, LookupTable.age, LookupTable.name FROM ScanTable JOIN LookupTable FOR system_time AS OF ScanTable.proctime ON ScanTable.id = LookupTable.id WHERE LookupTable.name = 'flink' AND LookupTable.age > 10]]>
+    </Resource>
+    <Resource name="ast">
+      <![CDATA[
+LogicalProject(id=[$0], len=[$1], age=[$4], name=[$6])
++- LogicalFilter(condition=[AND(=($6, _UTF-16LE'flink'), >($4, 10))])
+   +- LogicalCorrelate(correlation=[$cor0], joinType=[inner], requiredColumns=[{0, 3}])
+      :- LogicalProject(id=[$0], len=[$1], content=[$2], proctime=[PROCTIME()])
+      :  +- LogicalTableScan(table=[[default_catalog, default_database, ScanTable]])
+      +- LogicalFilter(condition=[=($cor0.id, $1)])
+         +- LogicalSnapshot(period=[$cor0.proctime])
+            +- LogicalTableScan(table=[[default_catalog, default_database, LookupTable]])
+]]>
+    </Resource>
+    <Resource name="optimized rel plan">
+      <![CDATA[
+LogicalProject(id=[$0], len=[$1], age=[$4], name=[$6])
++- LogicalJoin(condition=[=($0, $5)], joinType=[inner])
+   :- LogicalProject(id=[$0], len=[$1], content=[$2], proctime=[PROCTIME()])
+   :  +- LogicalTableScan(table=[[default_catalog, default_database, ScanTable]])
+   +- LogicalSnapshot(period=[$cor0.proctime])
+      +- LogicalFilter(condition=[=($2, _UTF-16LE'flink')])
+         +- LogicalTableScan(table=[[default_catalog, default_database, LookupTable, filter=[>(age, 10)]]])
+]]>
+    </Resource>
+  </TestCase>
+  <TestCase name="testWithUdf">
+    <Resource name="sql">
+      <![CDATA[SELECT ScanTable.id, ScanTable.len, LookupTable.age, LookupTable.name, LookupTable.info FROM ScanTable JOIN LookupTable FOR system_time AS OF ScanTable.proctime ON ScanTable.id = LookupTable.id WHERE UPPER(LookupTable.info) = 'test']]>
+    </Resource>
+    <Resource name="ast">
+      <![CDATA[
+LogicalProject(id=[$0], len=[$1], age=[$4], name=[$6], info=[$7])
++- LogicalFilter(condition=[=(UPPER($7), _UTF-16LE'test')])
+   +- LogicalCorrelate(correlation=[$cor0], joinType=[inner], requiredColumns=[{0, 3}])
+      :- LogicalProject(id=[$0], len=[$1], content=[$2], proctime=[PROCTIME()])
+      :  +- LogicalTableScan(table=[[default_catalog, default_database, ScanTable]])
+      +- LogicalFilter(condition=[=($cor0.id, $1)])
+         +- LogicalSnapshot(period=[$cor0.proctime])
+            +- LogicalTableScan(table=[[default_catalog, default_database, LookupTable]])
+]]>
+    </Resource>
+    <Resource name="optimized rel plan">
+      <![CDATA[
+LogicalProject(id=[$0], len=[$1], age=[$4], name=[$6], info=[$7])
++- LogicalJoin(condition=[=($0, $5)], joinType=[inner])
+   :- LogicalProject(id=[$0], len=[$1], content=[$2], proctime=[PROCTIME()])
+   :  +- LogicalTableScan(table=[[default_catalog, default_database, ScanTable]])
+   +- LogicalSnapshot(period=[$cor0.proctime])
+      +- LogicalTableScan(table=[[default_catalog, default_database, LookupTable, filter=[=(UPPER(info), _UTF-16LE'test':VARCHAR(2147483647) CHARACTER SET "UTF-16LE")]]])
+]]>
+    </Resource>
+  </TestCase>
+</Root>

--- a/flink-table/flink-table-planner/src/test/resources/org/apache/flink/table/planner/plan/stream/sql/join/LookupJoinTest.xml
+++ b/flink-table/flink-table-planner/src/test/resources/org/apache/flink/table/planner/plan/stream/sql/join/LookupJoinTest.xml
@@ -52,7 +52,7 @@ LogicalAggregate(group=[{0}], EXPR$1=[COUNT($1)], EXPR$2=[SUM($2)], EXPR$3=[SUM(
 GroupAggregate(groupBy=[b], select=[b, COUNT_RETRACT(a) AS EXPR$1, SUM_RETRACT(c) AS EXPR$2, SUM_RETRACT(d) AS EXPR$3])
 +- Exchange(distribution=[hash[b]])
    +- Calc(select=[b, a, c, d])
-      +- LookupJoin(table=[default_catalog.default_database.LookupTable], joinType=[InnerJoin], async=[false], lookup=[id=a], where=[(age > 10)], select=[b, a, c, d, id])
+      +- LookupJoin(table=[default_catalog.default_database.LookupTable, filter=[]], joinType=[InnerJoin], async=[false], lookup=[id=a], where=[(age > 10)], select=[b, a, c, d, id])
          +- Calc(select=[b, a, c, d])
             +- GroupAggregate(groupBy=[a, b], select=[a, b, SUM(c) AS c, SUM(d) AS d])
                +- Exchange(distribution=[hash[a, b]])
@@ -71,19 +71,19 @@ WHERE cast(D.name as bigint) > 1000
     </Resource>
     <Resource name="ast">
       <![CDATA[
-LogicalProject(a=[$0], b=[$1], c=[$2], proctime=[$3], rowtime=[$4], id=[$5], name=[$6], age=[$7])
+LogicalProject(a=[$0], b=[$1], c=[$2], proctime=[$3], rowtime=[$4], id=[$5], name=[$6], age=[$7], info=[$8])
 +- LogicalFilter(condition=[>(CAST($6):BIGINT, 1000)])
    +- LogicalCorrelate(correlation=[$cor0], joinType=[inner], requiredColumns=[{0, 3}])
       :- LogicalTableScan(table=[[default_catalog, default_database, MyTable]])
       +- LogicalFilter(condition=[AND(=($cor0.a, $0), =($2, 10))])
          +- LogicalSnapshot(period=[$cor0.proctime])
-            +- LogicalTableScan(table=[[default_catalog, default_database, LookupTable, source: [TestTemporalTable(id, name, age)]]])
+            +- LogicalTableScan(table=[[default_catalog, default_database, LookupTable, source: [TestTemporalTable(id, name, age, info)]]])
 ]]>
     </Resource>
     <Resource name="optimized exec plan">
       <![CDATA[
-Calc(select=[a, b, c, PROCTIME_MATERIALIZE(proctime) AS proctime, rowtime, id, name, CAST(10 AS INTEGER) AS age])
-+- LookupJoin(table=[default_catalog.default_database.LookupTable], joinType=[InnerJoin], async=[false], lookup=[age=10, id=a], where=[((age = 10) AND (CAST(name AS BIGINT) > 1000))], select=[a, b, c, proctime, rowtime, id, name])
+Calc(select=[a, b, c, PROCTIME_MATERIALIZE(proctime) AS proctime, rowtime, id, name, CAST(10 AS INTEGER) AS age, info])
++- LookupJoin(table=[default_catalog.default_database.LookupTable], joinType=[InnerJoin], async=[false], lookup=[age=10, id=a], where=[((age = 10) AND (CAST(name AS BIGINT) > 1000))], select=[a, b, c, proctime, rowtime, id, name, info])
    +- DataStreamScan(table=[[default_catalog, default_database, MyTable]], fields=[a, b, c, proctime, rowtime])
 ]]>
     </Resource>
@@ -116,7 +116,7 @@ LogicalAggregate(group=[{0}], EXPR$1=[COUNT($1)], EXPR$2=[SUM($2)], EXPR$3=[SUM(
          :     +- LogicalTableScan(table=[[default_catalog, default_database, T1]])
          +- LogicalFilter(condition=[=($cor0.a, $0)])
             +- LogicalSnapshot(period=[$cor0.proc])
-               +- LogicalTableScan(table=[[default_catalog, default_database, LookupTable, source: [TestTemporalTable(id, name, age)]]])
+               +- LogicalTableScan(table=[[default_catalog, default_database, LookupTable, source: [TestTemporalTable(id, name, age, info)]]])
 ]]>
     </Resource>
     <Resource name="optimized exec plan">
@@ -138,7 +138,7 @@ GroupAggregate(groupBy=[b], select=[b, COUNT_RETRACT(a) AS EXPR$1, SUM_RETRACT(c
     </Resource>
     <Resource name="ast">
       <![CDATA[
-LogicalProject(a=[$0], b=[$1], c=[$2], proctime=[$3], rowtime=[$4], id=[$5], name=[$6], age=[$7])
+LogicalProject(a=[$0], b=[$1], c=[$2], proctime=[$3], rowtime=[$4], id=[$5], name=[$6], age=[$7], info=[$8])
 +- LogicalCorrelate(correlation=[$cor0], joinType=[inner], requiredColumns=[{0, 3}])
    :- LogicalTableScan(table=[[default_catalog, default_database, MyTable]])
    +- LogicalFilter(condition=[=($cor0.a, $0)])
@@ -148,8 +148,8 @@ LogicalProject(a=[$0], b=[$1], c=[$2], proctime=[$3], rowtime=[$4], id=[$5], nam
     </Resource>
     <Resource name="optimized exec plan">
       <![CDATA[
-Calc(select=[a, b, c, PROCTIME_MATERIALIZE(proctime) AS proctime, rowtime, id, name, age])
-+- LookupJoin(table=[default_catalog.default_database.LookupTable], joinType=[InnerJoin], async=[false], lookup=[id=a], select=[a, b, c, proctime, rowtime, id, name, age])
+Calc(select=[a, b, c, PROCTIME_MATERIALIZE(proctime) AS proctime, rowtime, id, name, age, info])
++- LookupJoin(table=[default_catalog.default_database.LookupTable], joinType=[InnerJoin], async=[false], lookup=[id=a], select=[a, b, c, proctime, rowtime, id, name, age, info])
    +- DataStreamScan(table=[[default_catalog, default_database, MyTable]], fields=[a, b, c, proctime, rowtime])
 ]]>
     </Resource>
@@ -160,18 +160,18 @@ Calc(select=[a, b, c, PROCTIME_MATERIALIZE(proctime) AS proctime, rowtime, id, n
     </Resource>
     <Resource name="ast">
       <![CDATA[
-LogicalProject(a=[$0], b=[$1], c=[$2], proctime=[$3], rowtime=[$4], id=[$5], name=[$6], age=[$7])
+LogicalProject(a=[$0], b=[$1], c=[$2], proctime=[$3], rowtime=[$4], id=[$5], name=[$6], age=[$7], info=[$8])
 +- LogicalCorrelate(correlation=[$cor0], joinType=[inner], requiredColumns=[{0, 3}])
    :- LogicalTableScan(table=[[default_catalog, default_database, MyTable]])
    +- LogicalFilter(condition=[=($cor0.a, $0)])
       +- LogicalSnapshot(period=[$cor0.proctime])
-         +- LogicalTableScan(table=[[default_catalog, default_database, LookupTable, source: [TestTemporalTable(id, name, age)]]])
+         +- LogicalTableScan(table=[[default_catalog, default_database, LookupTable, source: [TestTemporalTable(id, name, age, info)]]])
 ]]>
     </Resource>
     <Resource name="optimized exec plan">
       <![CDATA[
-Calc(select=[a, b, c, PROCTIME_MATERIALIZE(proctime) AS proctime, rowtime, id, name, age])
-+- LookupJoin(table=[default_catalog.default_database.LookupTable], joinType=[InnerJoin], async=[false], lookup=[id=a], select=[a, b, c, proctime, rowtime, id, name, age])
+Calc(select=[a, b, c, PROCTIME_MATERIALIZE(proctime) AS proctime, rowtime, id, name, age, info])
++- LookupJoin(table=[default_catalog.default_database.LookupTable], joinType=[InnerJoin], async=[false], lookup=[id=a], select=[a, b, c, proctime, rowtime, id, name, age, info])
    +- DataStreamScan(table=[[default_catalog, default_database, MyTable]], fields=[a, b, c, proctime, rowtime])
 ]]>
     </Resource>
@@ -187,7 +187,7 @@ WHERE cast(D.name as bigint) > 1000
     </Resource>
     <Resource name="ast">
       <![CDATA[
-LogicalProject(a=[$0], b=[$1], c=[$2], proctime=[$3], rowtime=[$4], id=[$5], name=[$6], age=[$7])
+LogicalProject(a=[$0], b=[$1], c=[$2], proctime=[$3], rowtime=[$4], id=[$5], name=[$6], age=[$7], info=[$8])
 +- LogicalFilter(condition=[>(CAST($6):BIGINT, 1000)])
    +- LogicalCorrelate(correlation=[$cor0], joinType=[inner], requiredColumns=[{0, 3}])
       :- LogicalTableScan(table=[[default_catalog, default_database, MyTable]])
@@ -198,8 +198,8 @@ LogicalProject(a=[$0], b=[$1], c=[$2], proctime=[$3], rowtime=[$4], id=[$5], nam
     </Resource>
     <Resource name="optimized exec plan">
       <![CDATA[
-Calc(select=[a, b, c, PROCTIME_MATERIALIZE(proctime) AS proctime, rowtime, id, name, CAST(10 AS INTEGER) AS age])
-+- LookupJoin(table=[default_catalog.default_database.LookupTable], joinType=[InnerJoin], async=[false], lookup=[age=10, id=a], where=[((age = 10) AND (CAST(name AS BIGINT) > 1000))], select=[a, b, c, proctime, rowtime, id, name])
+Calc(select=[a, b, c, PROCTIME_MATERIALIZE(proctime) AS proctime, rowtime, id, name, CAST(10 AS INTEGER) AS age, info])
++- LookupJoin(table=[default_catalog.default_database.LookupTable, filter=[]], joinType=[InnerJoin], async=[false], lookup=[age=10, id=a], where=[((age = 10) AND (CAST(name AS BIGINT) > 1000))], select=[a, b, c, proctime, rowtime, id, name, info])
    +- DataStreamScan(table=[[default_catalog, default_database, MyTable]], fields=[a, b, c, proctime, rowtime])
 ]]>
     </Resource>
@@ -258,7 +258,7 @@ LogicalProject(a=[$0], b=[$1], c=[$2], name=[$6], age=[$7], nominal_age=[$8])
     <Resource name="optimized exec plan">
       <![CDATA[
 Calc(select=[a, b, c, name, age, nominal_age])
-+- LookupJoin(table=[default_catalog.default_database.LookupTableWithComputedColumn], joinType=[InnerJoin], async=[false], lookup=[id=a], where=[((age + 1) > 12)], select=[a, b, c, id, name, age, (age + 1) AS nominal_age])
++- LookupJoin(table=[default_catalog.default_database.LookupTableWithComputedColumn, filter=[]], joinType=[InnerJoin], async=[false], lookup=[id=a], where=[((age + 1) > 12)], select=[a, b, c, id, name, age, (age + 1) AS nominal_age])
    +- Calc(select=[a, b, c])
       +- DataStreamScan(table=[[default_catalog, default_database, MyTable]], fields=[a, b, c, proctime, rowtime])
 ]]>
@@ -282,14 +282,14 @@ LogicalProject(b=[$1])
    :  +- LogicalTableScan(table=[[default_catalog, default_database, MyTable]])
    +- LogicalFilter(condition=[AND(=($cor0.a, $0), =($2, 10))])
       +- LogicalSnapshot(period=[$cor0.proctime])
-         +- LogicalProject(id=[$0], name=[$1], age=[$2])
+         +- LogicalProject(id=[$0], name=[$1], age=[$2], info=[$3])
             +- LogicalTableScan(table=[[default_catalog, default_database, LookupTable]])
 ]]>
     </Resource>
     <Resource name="optimized exec plan">
       <![CDATA[
 Calc(select=[b])
-+- LookupJoin(table=[default_catalog.default_database.LookupTable], joinType=[InnerJoin], async=[false], lookup=[age=10, id=a], where=[(age = 10)], select=[a, b, id])
++- LookupJoin(table=[default_catalog.default_database.LookupTable, filter=[]], joinType=[InnerJoin], async=[false], lookup=[age=10, id=a], where=[(age = 10)], select=[a, b, id])
    +- Calc(select=[a, b])
       +- DataStreamScan(table=[[default_catalog, default_database, MyTable]], fields=[a, b, c, proctime, rowtime])
 ]]>
@@ -313,8 +313,8 @@ LogicalProject(b=[$1])
    :  +- LogicalTableScan(table=[[default_catalog, default_database, MyTable]])
    +- LogicalFilter(condition=[AND(=($cor0.a, $0), =($2, 10))])
       +- LogicalSnapshot(period=[$cor0.proctime])
-         +- LogicalProject(id=[$0], name=[$1], age=[$2])
-            +- LogicalTableScan(table=[[default_catalog, default_database, LookupTable, source: [TestTemporalTable(id, name, age)]]])
+         +- LogicalProject(id=[$0], name=[$1], age=[$2], info=[$3])
+            +- LogicalTableScan(table=[[default_catalog, default_database, LookupTable, source: [TestTemporalTable(id, name, age, info)]]])
 ]]>
     </Resource>
     <Resource name="optimized exec plan">
@@ -337,7 +337,7 @@ WHERE T.c > 1000
     </Resource>
     <Resource name="ast">
       <![CDATA[
-LogicalProject(a=[$0], b=[$1], c=[$2], proctime=[$3], rowtime=[$4], id=[$5], name=[$6], age=[$7])
+LogicalProject(a=[$0], b=[$1], c=[$2], proctime=[$3], rowtime=[$4], id=[$5], name=[$6], age=[$7], info=[$8])
 +- LogicalFilter(condition=[>($2, 1000)])
    +- LogicalCorrelate(correlation=[$cor0], joinType=[inner], requiredColumns=[{0, 3}])
       :- LogicalTableScan(table=[[default_catalog, default_database, MyTable]])
@@ -348,8 +348,8 @@ LogicalProject(a=[$0], b=[$1], c=[$2], proctime=[$3], rowtime=[$4], id=[$5], nam
     </Resource>
     <Resource name="optimized exec plan">
       <![CDATA[
-Calc(select=[a, b, c, PROCTIME_MATERIALIZE(proctime) AS proctime, rowtime, id, name, CAST(10 AS INTEGER) AS age])
-+- LookupJoin(table=[default_catalog.default_database.LookupTable], joinType=[InnerJoin], async=[false], lookup=[age=10, id=a], where=[(age = 10)], select=[a, b, c, proctime, rowtime, id, name])
+Calc(select=[a, b, c, PROCTIME_MATERIALIZE(proctime) AS proctime, rowtime, id, name, CAST(10 AS INTEGER) AS age, info])
++- LookupJoin(table=[default_catalog.default_database.LookupTable, filter=[]], joinType=[InnerJoin], async=[false], lookup=[age=10, id=a], where=[(age = 10)], select=[a, b, c, proctime, rowtime, id, name, info])
    +- Calc(select=[a, b, c, proctime, rowtime], where=[(c > 1000)])
       +- DataStreamScan(table=[[default_catalog, default_database, MyTable]], fields=[a, b, c, proctime, rowtime])
 ]]>
@@ -366,19 +366,19 @@ WHERE T.c > 1000
     </Resource>
     <Resource name="ast">
       <![CDATA[
-LogicalProject(a=[$0], b=[$1], c=[$2], proctime=[$3], rowtime=[$4], id=[$5], name=[$6], age=[$7])
+LogicalProject(a=[$0], b=[$1], c=[$2], proctime=[$3], rowtime=[$4], id=[$5], name=[$6], age=[$7], info=[$8])
 +- LogicalFilter(condition=[>($2, 1000)])
    +- LogicalCorrelate(correlation=[$cor0], joinType=[inner], requiredColumns=[{0, 3}])
       :- LogicalTableScan(table=[[default_catalog, default_database, MyTable]])
       +- LogicalFilter(condition=[AND(=($cor0.a, $0), =($2, 10))])
          +- LogicalSnapshot(period=[$cor0.proctime])
-            +- LogicalTableScan(table=[[default_catalog, default_database, LookupTable, source: [TestTemporalTable(id, name, age)]]])
+            +- LogicalTableScan(table=[[default_catalog, default_database, LookupTable, source: [TestTemporalTable(id, name, age, info)]]])
 ]]>
     </Resource>
     <Resource name="optimized exec plan">
       <![CDATA[
-Calc(select=[a, b, c, PROCTIME_MATERIALIZE(proctime) AS proctime, rowtime, id, name, CAST(10 AS INTEGER) AS age])
-+- LookupJoin(table=[default_catalog.default_database.LookupTable], joinType=[InnerJoin], async=[false], lookup=[age=10, id=a], where=[(age = 10)], select=[a, b, c, proctime, rowtime, id, name])
+Calc(select=[a, b, c, PROCTIME_MATERIALIZE(proctime) AS proctime, rowtime, id, name, CAST(10 AS INTEGER) AS age, info])
++- LookupJoin(table=[default_catalog.default_database.LookupTable], joinType=[InnerJoin], async=[false], lookup=[age=10, id=a], where=[(age = 10)], select=[a, b, c, proctime, rowtime, id, name, info])
    +- Calc(select=[a, b, c, proctime, rowtime], where=[(c > 1000)])
       +- DataStreamScan(table=[[default_catalog, default_database, MyTable]], fields=[a, b, c, proctime, rowtime])
 ]]>
@@ -394,7 +394,7 @@ ON T.b = concat(D.name, '!') AND D.age = 11
     </Resource>
     <Resource name="ast">
       <![CDATA[
-LogicalProject(a=[$0], b=[$1], c=[$2], proctime=[$3], rowtime=[$4], id=[$5], name=[$6], age=[$7])
+LogicalProject(a=[$0], b=[$1], c=[$2], proctime=[$3], rowtime=[$4], id=[$5], name=[$6], age=[$7], info=[$8])
 +- LogicalCorrelate(correlation=[$cor0], joinType=[inner], requiredColumns=[{1, 3}])
    :- LogicalTableScan(table=[[default_catalog, default_database, MyTable]])
    +- LogicalFilter(condition=[AND(=($cor0.b, CONCAT($1, _UTF-16LE'!')), =($2, 11))])
@@ -404,8 +404,8 @@ LogicalProject(a=[$0], b=[$1], c=[$2], proctime=[$3], rowtime=[$4], id=[$5], nam
     </Resource>
     <Resource name="optimized exec plan">
       <![CDATA[
-Calc(select=[a, b, c, PROCTIME_MATERIALIZE(proctime) AS proctime, rowtime, id, name, CAST(11 AS INTEGER) AS age])
-+- LookupJoin(table=[default_catalog.default_database.LookupTable], joinType=[InnerJoin], async=[false], lookup=[age=11], where=[(age = 11)], joinCondition=[(b = $f3)], select=[a, b, c, proctime, rowtime, id, name, CONCAT(name, '!') AS $f3])
+Calc(select=[a, b, c, PROCTIME_MATERIALIZE(proctime) AS proctime, rowtime, id, name, CAST(11 AS INTEGER) AS age, info])
++- LookupJoin(table=[default_catalog.default_database.LookupTable, filter=[]], joinType=[InnerJoin], async=[false], lookup=[age=11], where=[(age = 11)], joinCondition=[(b = $f4)], select=[a, b, c, proctime, rowtime, id, name, info, CONCAT(name, '!') AS $f4])
    +- DataStreamScan(table=[[default_catalog, default_database, MyTable]], fields=[a, b, c, proctime, rowtime])
 ]]>
     </Resource>
@@ -416,20 +416,20 @@ Calc(select=[a, b, c, PROCTIME_MATERIALIZE(proctime) AS proctime, rowtime, id, n
     </Resource>
     <Resource name="ast">
       <![CDATA[
-LogicalProject(a=[$0], b=[$1], proctime=[$2], id=[$3], name=[$4], age=[$5])
+LogicalProject(a=[$0], b=[$1], proctime=[$2], id=[$3], name=[$4], age=[$5], info=[$6])
 +- LogicalCorrelate(correlation=[$cor0], joinType=[inner], requiredColumns=[{0, 2}])
    :- LogicalProject(a=[$0], b=[$1], proctime=[$3])
    :  +- LogicalFilter(condition=[>($2, 1000)])
    :     +- LogicalTableScan(table=[[default_catalog, default_database, MyTable]])
    +- LogicalFilter(condition=[=($cor0.a, $0)])
       +- LogicalSnapshot(period=[$cor0.proctime])
-         +- LogicalTableScan(table=[[default_catalog, default_database, LookupTable, source: [TestTemporalTable(id, name, age)]]])
+         +- LogicalTableScan(table=[[default_catalog, default_database, LookupTable, source: [TestTemporalTable(id, name, age, info)]]])
 ]]>
     </Resource>
     <Resource name="optimized exec plan">
       <![CDATA[
-Calc(select=[a, b, PROCTIME_MATERIALIZE(proctime) AS proctime, id, name, age])
-+- LookupJoin(table=[default_catalog.default_database.LookupTable], joinType=[InnerJoin], async=[false], lookup=[id=a], select=[a, b, proctime, id, name, age])
+Calc(select=[a, b, PROCTIME_MATERIALIZE(proctime) AS proctime, id, name, age, info])
++- LookupJoin(table=[default_catalog.default_database.LookupTable], joinType=[InnerJoin], async=[false], lookup=[id=a], select=[a, b, proctime, id, name, age, info])
    +- Calc(select=[a, b, proctime], where=[(c > 1000)])
       +- DataStreamScan(table=[[default_catalog, default_database, MyTable]], fields=[a, b, c, proctime, rowtime])
 ]]>
@@ -445,18 +445,18 @@ ON T.b = concat(D.name, '!') AND D.age = 11
     </Resource>
     <Resource name="ast">
       <![CDATA[
-LogicalProject(a=[$0], b=[$1], c=[$2], proctime=[$3], rowtime=[$4], id=[$5], name=[$6], age=[$7])
+LogicalProject(a=[$0], b=[$1], c=[$2], proctime=[$3], rowtime=[$4], id=[$5], name=[$6], age=[$7], info=[$8])
 +- LogicalCorrelate(correlation=[$cor0], joinType=[inner], requiredColumns=[{1, 3}])
    :- LogicalTableScan(table=[[default_catalog, default_database, MyTable]])
    +- LogicalFilter(condition=[AND(=($cor0.b, CONCAT($1, _UTF-16LE'!')), =($2, 11))])
       +- LogicalSnapshot(period=[$cor0.proctime])
-         +- LogicalTableScan(table=[[default_catalog, default_database, LookupTable, source: [TestTemporalTable(id, name, age)]]])
+         +- LogicalTableScan(table=[[default_catalog, default_database, LookupTable, source: [TestTemporalTable(id, name, age, info)]]])
 ]]>
     </Resource>
     <Resource name="optimized exec plan">
       <![CDATA[
-Calc(select=[a, b, c, PROCTIME_MATERIALIZE(proctime) AS proctime, rowtime, id, name, CAST(11 AS INTEGER) AS age])
-+- LookupJoin(table=[default_catalog.default_database.LookupTable], joinType=[InnerJoin], async=[false], lookup=[age=11], where=[(age = 11)], joinCondition=[(b = $f3)], select=[a, b, c, proctime, rowtime, id, name, CONCAT(name, '!') AS $f3])
+Calc(select=[a, b, c, PROCTIME_MATERIALIZE(proctime) AS proctime, rowtime, id, name, CAST(11 AS INTEGER) AS age, info])
++- LookupJoin(table=[default_catalog.default_database.LookupTable], joinType=[InnerJoin], async=[false], lookup=[age=11], where=[(age = 11)], joinCondition=[(b = $f4)], select=[a, b, c, proctime, rowtime, id, name, info, CONCAT(name, '!') AS $f4])
    +- DataStreamScan(table=[[default_catalog, default_database, MyTable]], fields=[a, b, c, proctime, rowtime])
 ]]>
     </Resource>
@@ -472,7 +472,7 @@ WHERE D.name LIKE 'Jack%'
     </Resource>
     <Resource name="ast">
       <![CDATA[
-LogicalProject(a=[$0], b=[$1], c=[$2], proctime=[$3], rowtime=[$4], id=[$5], name=[$6], age=[$7])
+LogicalProject(a=[$0], b=[$1], c=[$2], proctime=[$3], rowtime=[$4], id=[$5], name=[$6], age=[$7], info=[$8])
 +- LogicalFilter(condition=[LIKE($6, _UTF-16LE'Jack%')])
    +- LogicalCorrelate(correlation=[$cor0], joinType=[inner], requiredColumns=[{0, 1, 3}])
       :- LogicalTableScan(table=[[default_catalog, default_database, MyTable]])
@@ -483,8 +483,8 @@ LogicalProject(a=[$0], b=[$1], c=[$2], proctime=[$3], rowtime=[$4], id=[$5], nam
     </Resource>
     <Resource name="optimized exec plan">
       <![CDATA[
-Calc(select=[a, b, c, PROCTIME_MATERIALIZE(proctime) AS proctime, rowtime, id, name, age])
-+- LookupJoin(table=[default_catalog.default_database.LookupTable], joinType=[InnerJoin], async=[false], lookup=[id=a], where=[LIKE(name, 'Jack%')], joinCondition=[(b = $f3)], select=[a, b, c, proctime, rowtime, id, name, age, CONCAT(name, '!') AS $f3])
+Calc(select=[a, b, c, PROCTIME_MATERIALIZE(proctime) AS proctime, rowtime, id, name, age, info])
++- LookupJoin(table=[default_catalog.default_database.LookupTable, filter=[]], joinType=[InnerJoin], async=[false], lookup=[id=a], where=[LIKE(name, 'Jack%')], joinCondition=[(b = $f4)], select=[a, b, c, proctime, rowtime, id, name, age, info, CONCAT(name, '!') AS $f4])
    +- DataStreamScan(table=[[default_catalog, default_database, MyTable]], fields=[a, b, c, proctime, rowtime])
 ]]>
     </Resource>
@@ -500,19 +500,19 @@ WHERE D.name LIKE 'Jack%'
     </Resource>
     <Resource name="ast">
       <![CDATA[
-LogicalProject(a=[$0], b=[$1], c=[$2], proctime=[$3], rowtime=[$4], id=[$5], name=[$6], age=[$7])
+LogicalProject(a=[$0], b=[$1], c=[$2], proctime=[$3], rowtime=[$4], id=[$5], name=[$6], age=[$7], info=[$8])
 +- LogicalFilter(condition=[LIKE($6, _UTF-16LE'Jack%')])
    +- LogicalCorrelate(correlation=[$cor0], joinType=[inner], requiredColumns=[{0, 1, 3}])
       :- LogicalTableScan(table=[[default_catalog, default_database, MyTable]])
       +- LogicalFilter(condition=[AND(=($cor0.a, $0), =($cor0.b, CONCAT($1, _UTF-16LE'!')))])
          +- LogicalSnapshot(period=[$cor0.proctime])
-            +- LogicalTableScan(table=[[default_catalog, default_database, LookupTable, source: [TestTemporalTable(id, name, age)]]])
+            +- LogicalTableScan(table=[[default_catalog, default_database, LookupTable, source: [TestTemporalTable(id, name, age, info)]]])
 ]]>
     </Resource>
     <Resource name="optimized exec plan">
       <![CDATA[
-Calc(select=[a, b, c, PROCTIME_MATERIALIZE(proctime) AS proctime, rowtime, id, name, age])
-+- LookupJoin(table=[default_catalog.default_database.LookupTable], joinType=[InnerJoin], async=[false], lookup=[id=a], where=[LIKE(name, 'Jack%')], joinCondition=[(b = $f3)], select=[a, b, c, proctime, rowtime, id, name, age, CONCAT(name, '!') AS $f3])
+Calc(select=[a, b, c, PROCTIME_MATERIALIZE(proctime) AS proctime, rowtime, id, name, age, info])
++- LookupJoin(table=[default_catalog.default_database.LookupTable], joinType=[InnerJoin], async=[false], lookup=[id=a], where=[LIKE(name, 'Jack%')], joinCondition=[(b = $f4)], select=[a, b, c, proctime, rowtime, id, name, age, info, CONCAT(name, '!') AS $f4])
    +- DataStreamScan(table=[[default_catalog, default_database, MyTable]], fields=[a, b, c, proctime, rowtime])
 ]]>
     </Resource>
@@ -523,7 +523,7 @@ Calc(select=[a, b, c, PROCTIME_MATERIALIZE(proctime) AS proctime, rowtime, id, n
     </Resource>
     <Resource name="ast">
       <![CDATA[
-LogicalProject(a=[$0], b=[$1], c=[$2], proctime=[$3], rowtime=[$4], id=[$5], name=[$6], age=[$7])
+LogicalProject(a=[$0], b=[$1], c=[$2], proctime=[$3], rowtime=[$4], id=[$5], name=[$6], age=[$7], info=[$8])
 +- LogicalCorrelate(correlation=[$cor0], joinType=[inner], requiredColumns=[{0, 2, 3}])
    :- LogicalTableScan(table=[[default_catalog, default_database, MyTable]])
    +- LogicalFilter(condition=[AND(=($cor0.a, $0), =(CAST($cor0.c):INTEGER, $0))])
@@ -533,8 +533,8 @@ LogicalProject(a=[$0], b=[$1], c=[$2], proctime=[$3], rowtime=[$4], id=[$5], nam
     </Resource>
     <Resource name="optimized exec plan">
       <![CDATA[
-Calc(select=[a, b, c, PROCTIME_MATERIALIZE(proctime) AS proctime, rowtime, id, name, age])
-+- LookupJoin(table=[default_catalog.default_database.LookupTable], joinType=[InnerJoin], async=[false], lookup=[id=c0], joinCondition=[(a = id)], select=[a, b, c, proctime, rowtime, c0, id, name, age])
+Calc(select=[a, b, c, PROCTIME_MATERIALIZE(proctime) AS proctime, rowtime, id, name, age, info])
++- LookupJoin(table=[default_catalog.default_database.LookupTable], joinType=[InnerJoin], async=[false], lookup=[id=c0], joinCondition=[(a = id)], select=[a, b, c, proctime, rowtime, c0, id, name, age, info])
    +- Calc(select=[a, b, c, proctime, rowtime, CAST(c AS INTEGER) AS c0])
       +- DataStreamScan(table=[[default_catalog, default_database, MyTable]], fields=[a, b, c, proctime, rowtime])
 ]]>
@@ -546,18 +546,18 @@ Calc(select=[a, b, c, PROCTIME_MATERIALIZE(proctime) AS proctime, rowtime, id, n
     </Resource>
     <Resource name="ast">
       <![CDATA[
-LogicalProject(a=[$0], b=[$1], c=[$2], proctime=[$3], rowtime=[$4], id=[$5], name=[$6], age=[$7])
+LogicalProject(a=[$0], b=[$1], c=[$2], proctime=[$3], rowtime=[$4], id=[$5], name=[$6], age=[$7], info=[$8])
 +- LogicalCorrelate(correlation=[$cor0], joinType=[inner], requiredColumns=[{0, 2, 3}])
    :- LogicalTableScan(table=[[default_catalog, default_database, MyTable]])
    +- LogicalFilter(condition=[AND(=($cor0.a, $0), =(CAST($cor0.c):INTEGER, $0))])
       +- LogicalSnapshot(period=[$cor0.proctime])
-         +- LogicalTableScan(table=[[default_catalog, default_database, LookupTable, source: [TestTemporalTable(id, name, age)]]])
+         +- LogicalTableScan(table=[[default_catalog, default_database, LookupTable, source: [TestTemporalTable(id, name, age, info)]]])
 ]]>
     </Resource>
     <Resource name="optimized exec plan">
       <![CDATA[
-Calc(select=[a, b, c, PROCTIME_MATERIALIZE(proctime) AS proctime, rowtime, id, name, age])
-+- LookupJoin(table=[default_catalog.default_database.LookupTable], joinType=[InnerJoin], async=[false], lookup=[id=c0], joinCondition=[(a = id)], select=[a, b, c, proctime, rowtime, c0, id, name, age])
+Calc(select=[a, b, c, PROCTIME_MATERIALIZE(proctime) AS proctime, rowtime, id, name, age, info])
++- LookupJoin(table=[default_catalog.default_database.LookupTable], joinType=[InnerJoin], async=[false], lookup=[id=c0], joinCondition=[(a = id)], select=[a, b, c, proctime, rowtime, c0, id, name, age, info])
    +- Calc(select=[a, b, c, proctime, rowtime, CAST(c AS INTEGER) AS c0])
       +- DataStreamScan(table=[[default_catalog, default_database, MyTable]], fields=[a, b, c, proctime, rowtime])
 ]]>
@@ -573,7 +573,7 @@ ON T.a = D.id + 1 AND T.b = concat(D.name, '!') AND D.age = 11
     </Resource>
     <Resource name="ast">
       <![CDATA[
-LogicalProject(a=[$0], b=[$1], c=[$2], proctime=[$3], rowtime=[$4], id=[$5], name=[$6], age=[$7])
+LogicalProject(a=[$0], b=[$1], c=[$2], proctime=[$3], rowtime=[$4], id=[$5], name=[$6], age=[$7], info=[$8])
 +- LogicalCorrelate(correlation=[$cor0], joinType=[inner], requiredColumns=[{0, 1, 3}])
    :- LogicalTableScan(table=[[default_catalog, default_database, MyTable]])
    +- LogicalFilter(condition=[AND(=($cor0.a, +($0, 1)), =($cor0.b, CONCAT($1, _UTF-16LE'!')), =($2, 11))])
@@ -583,8 +583,8 @@ LogicalProject(a=[$0], b=[$1], c=[$2], proctime=[$3], rowtime=[$4], id=[$5], nam
     </Resource>
     <Resource name="optimized exec plan">
       <![CDATA[
-Calc(select=[a, b, c, PROCTIME_MATERIALIZE(proctime) AS proctime, rowtime, id, name, CAST(11 AS INTEGER) AS age])
-+- LookupJoin(table=[default_catalog.default_database.LookupTable], joinType=[InnerJoin], async=[false], lookup=[age=11], where=[(age = 11)], joinCondition=[((a = $f3) AND (b = $f4))], select=[a, b, c, proctime, rowtime, id, name, (id + 1) AS $f3, CONCAT(name, '!') AS $f4])
+Calc(select=[a, b, c, PROCTIME_MATERIALIZE(proctime) AS proctime, rowtime, id, name, CAST(11 AS INTEGER) AS age, info])
++- LookupJoin(table=[default_catalog.default_database.LookupTable, filter=[]], joinType=[InnerJoin], async=[false], lookup=[age=11], where=[(age = 11)], joinCondition=[((a = $f4) AND (b = $f5))], select=[a, b, c, proctime, rowtime, id, name, info, (id + 1) AS $f4, CONCAT(name, '!') AS $f5])
    +- DataStreamScan(table=[[default_catalog, default_database, MyTable]], fields=[a, b, c, proctime, rowtime])
 ]]>
     </Resource>
@@ -599,18 +599,18 @@ ON T.a = D.id + 1 AND T.b = concat(D.name, '!') AND D.age = 11
     </Resource>
     <Resource name="ast">
       <![CDATA[
-LogicalProject(a=[$0], b=[$1], c=[$2], proctime=[$3], rowtime=[$4], id=[$5], name=[$6], age=[$7])
+LogicalProject(a=[$0], b=[$1], c=[$2], proctime=[$3], rowtime=[$4], id=[$5], name=[$6], age=[$7], info=[$8])
 +- LogicalCorrelate(correlation=[$cor0], joinType=[inner], requiredColumns=[{0, 1, 3}])
    :- LogicalTableScan(table=[[default_catalog, default_database, MyTable]])
    +- LogicalFilter(condition=[AND(=($cor0.a, +($0, 1)), =($cor0.b, CONCAT($1, _UTF-16LE'!')), =($2, 11))])
       +- LogicalSnapshot(period=[$cor0.proctime])
-         +- LogicalTableScan(table=[[default_catalog, default_database, LookupTable, source: [TestTemporalTable(id, name, age)]]])
+         +- LogicalTableScan(table=[[default_catalog, default_database, LookupTable, source: [TestTemporalTable(id, name, age, info)]]])
 ]]>
     </Resource>
     <Resource name="optimized exec plan">
       <![CDATA[
-Calc(select=[a, b, c, PROCTIME_MATERIALIZE(proctime) AS proctime, rowtime, id, name, CAST(11 AS INTEGER) AS age])
-+- LookupJoin(table=[default_catalog.default_database.LookupTable], joinType=[InnerJoin], async=[false], lookup=[age=11], where=[(age = 11)], joinCondition=[((a = $f3) AND (b = $f4))], select=[a, b, c, proctime, rowtime, id, name, (id + 1) AS $f3, CONCAT(name, '!') AS $f4])
+Calc(select=[a, b, c, PROCTIME_MATERIALIZE(proctime) AS proctime, rowtime, id, name, CAST(11 AS INTEGER) AS age, info])
++- LookupJoin(table=[default_catalog.default_database.LookupTable], joinType=[InnerJoin], async=[false], lookup=[age=11], where=[(age = 11)], joinCondition=[((a = $f4) AND (b = $f5))], select=[a, b, c, proctime, rowtime, id, name, info, (id + 1) AS $f4, CONCAT(name, '!') AS $f5])
    +- DataStreamScan(table=[[default_catalog, default_database, MyTable]], fields=[a, b, c, proctime, rowtime])
 ]]>
     </Resource>
@@ -626,7 +626,7 @@ WHERE T.c > 1000
     </Resource>
     <Resource name="ast">
       <![CDATA[
-LogicalProject(a=[$0], b=[$1], c=[$2], proctime=[$3], rowtime=[$4], id=[$5], name=[$6], age=[$7])
+LogicalProject(a=[$0], b=[$1], c=[$2], proctime=[$3], rowtime=[$4], id=[$5], name=[$6], age=[$7], info=[$8])
 +- LogicalFilter(condition=[>($2, 1000)])
    +- LogicalCorrelate(correlation=[$cor0], joinType=[inner], requiredColumns=[{0, 3}])
       :- LogicalTableScan(table=[[default_catalog, default_database, MyTable]])
@@ -637,8 +637,8 @@ LogicalProject(a=[$0], b=[$1], c=[$2], proctime=[$3], rowtime=[$4], id=[$5], nam
     </Resource>
     <Resource name="optimized exec plan">
       <![CDATA[
-Calc(select=[a, b, c, PROCTIME_MATERIALIZE(proctime) AS proctime, rowtime, id, CAST('AAA' AS VARCHAR(2147483647)) AS name, CAST(10 AS INTEGER) AS age])
-+- LookupJoin(table=[default_catalog.default_database.LookupTable], joinType=[InnerJoin], async=[false], lookup=[age=10, name=_UTF-16LE'AAA', id=a], where=[((age = 10) AND (name = 'AAA'))], select=[a, b, c, proctime, rowtime, id])
+Calc(select=[a, b, c, PROCTIME_MATERIALIZE(proctime) AS proctime, rowtime, id, CAST('AAA' AS VARCHAR(2147483647)) AS name, CAST(10 AS INTEGER) AS age, info])
++- LookupJoin(table=[default_catalog.default_database.LookupTable, filter=[]], joinType=[InnerJoin], async=[false], lookup=[age=10, name=_UTF-16LE'AAA', id=a], where=[((age = 10) AND (name = 'AAA'))], select=[a, b, c, proctime, rowtime, id, info])
    +- Calc(select=[a, b, c, proctime, rowtime], where=[(c > 1000)])
       +- DataStreamScan(table=[[default_catalog, default_database, MyTable]], fields=[a, b, c, proctime, rowtime])
 ]]>
@@ -655,19 +655,19 @@ WHERE T.c > 1000
     </Resource>
     <Resource name="ast">
       <![CDATA[
-LogicalProject(a=[$0], b=[$1], c=[$2], proctime=[$3], rowtime=[$4], id=[$5], name=[$6], age=[$7])
+LogicalProject(a=[$0], b=[$1], c=[$2], proctime=[$3], rowtime=[$4], id=[$5], name=[$6], age=[$7], info=[$8])
 +- LogicalFilter(condition=[>($2, 1000)])
    +- LogicalCorrelate(correlation=[$cor0], joinType=[inner], requiredColumns=[{0, 3}])
       :- LogicalTableScan(table=[[default_catalog, default_database, MyTable]])
       +- LogicalFilter(condition=[AND(=($cor0.a, $0), =($2, 10), =($1, _UTF-16LE'AAA'))])
          +- LogicalSnapshot(period=[$cor0.proctime])
-            +- LogicalTableScan(table=[[default_catalog, default_database, LookupTable, source: [TestTemporalTable(id, name, age)]]])
+            +- LogicalTableScan(table=[[default_catalog, default_database, LookupTable, source: [TestTemporalTable(id, name, age, info)]]])
 ]]>
     </Resource>
     <Resource name="optimized exec plan">
       <![CDATA[
-Calc(select=[a, b, c, PROCTIME_MATERIALIZE(proctime) AS proctime, rowtime, id, CAST('AAA' AS VARCHAR(2147483647)) AS name, CAST(10 AS INTEGER) AS age])
-+- LookupJoin(table=[default_catalog.default_database.LookupTable], joinType=[InnerJoin], async=[false], lookup=[age=10, name=_UTF-16LE'AAA', id=a], where=[((age = 10) AND (name = 'AAA'))], select=[a, b, c, proctime, rowtime, id])
+Calc(select=[a, b, c, PROCTIME_MATERIALIZE(proctime) AS proctime, rowtime, id, CAST('AAA' AS VARCHAR(2147483647)) AS name, CAST(10 AS INTEGER) AS age, info])
++- LookupJoin(table=[default_catalog.default_database.LookupTable], joinType=[InnerJoin], async=[false], lookup=[age=10, name=_UTF-16LE'AAA', id=a], where=[((age = 10) AND (name = 'AAA'))], select=[a, b, c, proctime, rowtime, id, info])
    +- Calc(select=[a, b, c, proctime, rowtime], where=[(c > 1000)])
       +- DataStreamScan(table=[[default_catalog, default_database, MyTable]], fields=[a, b, c, proctime, rowtime])
 ]]>
@@ -679,7 +679,7 @@ Calc(select=[a, b, c, PROCTIME_MATERIALIZE(proctime) AS proctime, rowtime, id, C
     </Resource>
     <Resource name="ast">
       <![CDATA[
-LogicalProject(a=[$0], b=[$1], proctime=[$2], id=[$3], name=[$4], age=[$5])
+LogicalProject(a=[$0], b=[$1], proctime=[$2], id=[$3], name=[$4], age=[$5], info=[$6])
 +- LogicalCorrelate(correlation=[$cor0], joinType=[inner], requiredColumns=[{0, 2}])
    :- LogicalProject(a=[$0], b=[$1], proctime=[$3])
    :  +- LogicalFilter(condition=[>($2, 1000)])
@@ -691,8 +691,8 @@ LogicalProject(a=[$0], b=[$1], proctime=[$2], id=[$3], name=[$4], age=[$5])
     </Resource>
     <Resource name="optimized exec plan">
       <![CDATA[
-Calc(select=[a, b, PROCTIME_MATERIALIZE(proctime) AS proctime, id, name, age])
-+- LookupJoin(table=[default_catalog.default_database.LookupTable], joinType=[InnerJoin], async=[false], lookup=[id=a], select=[a, b, proctime, id, name, age])
+Calc(select=[a, b, PROCTIME_MATERIALIZE(proctime) AS proctime, id, name, age, info])
++- LookupJoin(table=[default_catalog.default_database.LookupTable], joinType=[InnerJoin], async=[false], lookup=[id=a], select=[a, b, proctime, id, name, age, info])
    +- Calc(select=[a, b, proctime], where=[(c > 1000)])
       +- DataStreamScan(table=[[default_catalog, default_database, MyTable]], fields=[a, b, c, proctime, rowtime])
 ]]>
@@ -731,18 +731,18 @@ Calc(select=[a, b, c, PROCTIME_MATERIALIZE(proctime) AS proctime, rowtime, id])
     </Resource>
     <Resource name="ast">
       <![CDATA[
-LogicalProject(a=[$0], b=[$1], c=[$2], proctime=[$3], rowtime=[$4], id=[$5], name=[$6], age=[$7])
+LogicalProject(a=[$0], b=[$1], c=[$2], proctime=[$3], rowtime=[$4], id=[$5], name=[$6], age=[$7], info=[$8])
 +- LogicalCorrelate(correlation=[$cor0], joinType=[left], requiredColumns=[{0, 3}])
    :- LogicalTableScan(table=[[default_catalog, default_database, MyTable]])
    +- LogicalFilter(condition=[=($cor0.a, $0)])
       +- LogicalSnapshot(period=[$cor0.proctime])
-         +- LogicalTableScan(table=[[default_catalog, default_database, LookupTable, source: [TestTemporalTable(id, name, age)]]])
+         +- LogicalTableScan(table=[[default_catalog, default_database, LookupTable, source: [TestTemporalTable(id, name, age, info)]]])
 ]]>
     </Resource>
     <Resource name="optimized exec plan">
       <![CDATA[
-Calc(select=[a, b, c, PROCTIME_MATERIALIZE(proctime) AS proctime, rowtime, id, name, age])
-+- LookupJoin(table=[default_catalog.default_database.LookupTable], joinType=[LeftOuterJoin], async=[false], lookup=[id=a], select=[a, b, c, proctime, rowtime, id, name, age])
+Calc(select=[a, b, c, PROCTIME_MATERIALIZE(proctime) AS proctime, rowtime, id, name, age, info])
++- LookupJoin(table=[default_catalog.default_database.LookupTable], joinType=[LeftOuterJoin], async=[false], lookup=[id=a], select=[a, b, c, proctime, rowtime, id, name, age, info])
    +- DataStreamScan(table=[[default_catalog, default_database, MyTable]], fields=[a, b, c, proctime, rowtime])
 ]]>
     </Resource>
@@ -763,7 +763,7 @@ LogicalProject(a=[$0], b=[$1], c=[$2], proctime=[$3], rowtime=[$4], id=[$5])
    :- LogicalTableScan(table=[[default_catalog, default_database, MyTable]])
    +- LogicalFilter(condition=[=($cor0.a, $0)])
       +- LogicalSnapshot(period=[$cor0.proctime])
-         +- LogicalTableScan(table=[[default_catalog, default_database, LookupTable, source: [TestTemporalTable(id, name, age)]]])
+         +- LogicalTableScan(table=[[default_catalog, default_database, LookupTable, source: [TestTemporalTable(id, name, age, info)]]])
 ]]>
     </Resource>
     <Resource name="optimized exec plan">
@@ -798,7 +798,7 @@ LogicalProject(a=[$0], b=[$1], c=[$2], name=[$6])
     <Resource name="optimized exec plan">
       <![CDATA[
 Calc(select=[a, b, c, name])
-+- LookupJoin(table=[default_catalog.default_database.LookupTable], joinType=[InnerJoin], async=[false], lookup=[id=a], where=[(CONCAT('Hello-', name) = 'Hello-Jark')], select=[a, b, c, id, name])
++- LookupJoin(table=[default_catalog.default_database.LookupTable, filter=[]], joinType=[InnerJoin], async=[false], lookup=[id=a], where=[(CONCAT('Hello-', name) = 'Hello-Jark')], select=[a, b, c, id, name])
    +- Calc(select=[a, b, c])
       +- DataStreamScan(table=[[default_catalog, default_database, MyTable]], fields=[a, b, c, proctime, rowtime])
 ]]>
@@ -822,7 +822,7 @@ LogicalProject(a=[$0], b=[$1], c=[$2], name=[$6])
       :- LogicalTableScan(table=[[default_catalog, default_database, MyTable]])
       +- LogicalFilter(condition=[=($cor0.a, $0)])
          +- LogicalSnapshot(period=[$cor0.proctime])
-            +- LogicalTableScan(table=[[default_catalog, default_database, LookupTable, source: [TestTemporalTable(id, name, age)]]])
+            +- LogicalTableScan(table=[[default_catalog, default_database, LookupTable, source: [TestTemporalTable(id, name, age, info)]]])
 ]]>
     </Resource>
     <Resource name="optimized exec plan">
@@ -840,7 +840,7 @@ Calc(select=[a, b, c, name])
     </Resource>
     <Resource name="ast">
       <![CDATA[
-LogicalProject(a=[$0], b=[$1], c=[$2], proctime=[$3], rowtime=[$4], id=[$5], name=[$6], age=[$7])
+LogicalProject(a=[$0], b=[$1], c=[$2], proctime=[$3], rowtime=[$4], id=[$5], name=[$6], age=[$7], info=[$8])
 +- LogicalCorrelate(correlation=[$cor0], joinType=[left], requiredColumns=[{0, 3}])
    :- LogicalTableScan(table=[[default_catalog, default_database, MyTable]])
    +- LogicalFilter(condition=[=($cor0.a, $0)])
@@ -850,8 +850,120 @@ LogicalProject(a=[$0], b=[$1], c=[$2], proctime=[$3], rowtime=[$4], id=[$5], nam
     </Resource>
     <Resource name="optimized exec plan">
       <![CDATA[
-Calc(select=[a, b, c, PROCTIME_MATERIALIZE(proctime) AS proctime, rowtime, id, name, age])
-+- LookupJoin(table=[default_catalog.default_database.LookupTable], joinType=[LeftOuterJoin], async=[false], lookup=[id=a], select=[a, b, c, proctime, rowtime, id, name, age])
+Calc(select=[a, b, c, PROCTIME_MATERIALIZE(proctime) AS proctime, rowtime, id, name, age, info])
++- LookupJoin(table=[default_catalog.default_database.LookupTable], joinType=[LeftOuterJoin], async=[false], lookup=[id=a], select=[a, b, c, proctime, rowtime, id, name, age, info])
+   +- DataStreamScan(table=[[default_catalog, default_database, MyTable]], fields=[a, b, c, proctime, rowtime])
+]]>
+    </Resource>
+  </TestCase>
+  <TestCase name="testTemporalTableFilterPartialPushDown[LegacyTableSource=true]">
+    <Resource name="sql">
+      <![CDATA[
+SELECT * FROM MyTable as T
+JOIN LookupTable FOR SYSTEM_TIME AS OF T.proctime AS D
+ON T.a = D.id
+WHERE D.info = 'flink' AND D.age > 10
+]]>
+    </Resource>
+    <Resource name="ast">
+       <![CDATA[
+LogicalProject(a=[$0], b=[$1], c=[$2], proctime=[$3], rowtime=[$4], id=[$5], name=[$6], age=[$7], info=[$8])
++- LogicalFilter(condition=[AND(=($8, _UTF-16LE'flink'), >($7, 10))])
+   +- LogicalCorrelate(correlation=[$cor0], joinType=[inner], requiredColumns=[{0, 3}])
+      :- LogicalTableScan(table=[[default_catalog, default_database, MyTable]])
+      +- LogicalFilter(condition=[=($cor0.a, $0)])
+         +- LogicalSnapshot(period=[$cor0.proctime])
+            +- LogicalTableScan(table=[[default_catalog, default_database, LookupTable, source: [TestTemporalTable(id, name, age, info)]]])
+]]>
+    </Resource>
+    <Resource name="optimized exec plan">
+        <![CDATA[
+Calc(select=[a, b, c, PROCTIME_MATERIALIZE(proctime) AS proctime, rowtime, id, name, age, CAST('flink' AS VARCHAR(2147483647)) AS info])
++- LookupJoin(table=[default_catalog.default_database.LookupTable], joinType=[InnerJoin], async=[false], lookup=[info=_UTF-16LE'flink', id=a], where=[((info = 'flink') AND (age > 10))], select=[a, b, c, proctime, rowtime, id, name, age])
+   +- DataStreamScan(table=[[default_catalog, default_database, MyTable]], fields=[a, b, c, proctime, rowtime])
+]]>
+    </Resource>
+  </TestCase>
+  <TestCase name="testTemporalTableFilterPartialPushDown[LegacyTableSource=false]">
+    <Resource name="sql">
+        <![CDATA[
+SELECT * FROM MyTable as T
+JOIN LookupTable FOR SYSTEM_TIME AS OF T.proctime AS D
+ON T.a = D.id
+WHERE D.info = 'flink' AND D.age > 10
+]]>
+    </Resource>
+    <Resource name="ast">
+        <![CDATA[
+LogicalProject(a=[$0], b=[$1], c=[$2], proctime=[$3], rowtime=[$4], id=[$5], name=[$6], age=[$7], info=[$8])
++- LogicalFilter(condition=[AND(=($8, _UTF-16LE'flink'), >($7, 10))])
+   +- LogicalCorrelate(correlation=[$cor0], joinType=[inner], requiredColumns=[{0, 3}])
+      :- LogicalTableScan(table=[[default_catalog, default_database, MyTable]])
+      +- LogicalFilter(condition=[=($cor0.a, $0)])
+         +- LogicalSnapshot(period=[$cor0.proctime])
+            +- LogicalTableScan(table=[[default_catalog, default_database, LookupTable]])
+]]>
+    </Resource>
+    <Resource name="optimized exec plan">
+        <![CDATA[
+Calc(select=[a, b, c, PROCTIME_MATERIALIZE(proctime) AS proctime, rowtime, id, name, age, CAST('flink' AS VARCHAR(2147483647)) AS info])
++- LookupJoin(table=[default_catalog.default_database.LookupTable, filter=[=(info, _UTF-16LE'flink':VARCHAR(2147483647) CHARACTER SET "UTF-16LE")]], joinType=[InnerJoin], async=[false], lookup=[id=a], where=[(age > 10)], select=[a, b, c, proctime, rowtime, id, name, age])
+   +- DataStreamScan(table=[[default_catalog, default_database, MyTable]], fields=[a, b, c, proctime, rowtime])
+]]>
+    </Resource>
+  </TestCase>
+  <TestCase name="testTemporalTableFilterPushDownWithUdf[LegacyTableSource=true]">
+    <Resource name="sql">
+        <![CDATA[
+SELECT * FROM MyTable as T
+JOIN LookupTable FOR SYSTEM_TIME AS OF T.proctime AS D
+ON T.a = D.id
+WHERE UPPER(D.info) = 'flink'
+]]>
+    </Resource>
+    <Resource name="ast">
+         <![CDATA[
+LogicalProject(a=[$0], b=[$1], c=[$2], proctime=[$3], rowtime=[$4], id=[$5], name=[$6], age=[$7], info=[$8])
++- LogicalFilter(condition=[=(UPPER($8), _UTF-16LE'flink')])
+   +- LogicalCorrelate(correlation=[$cor0], joinType=[inner], requiredColumns=[{0, 3}])
+      :- LogicalTableScan(table=[[default_catalog, default_database, MyTable]])
+      +- LogicalFilter(condition=[=($cor0.a, $0)])
+         +- LogicalSnapshot(period=[$cor0.proctime])
+            +- LogicalTableScan(table=[[default_catalog, default_database, LookupTable, source: [TestTemporalTable(id, name, age, info)]]])
+]]>
+    </Resource>
+    <Resource name="optimized exec plan">
+        <![CDATA[
+Calc(select=[a, b, c, PROCTIME_MATERIALIZE(proctime) AS proctime, rowtime, id, name, age, info])
++- LookupJoin(table=[default_catalog.default_database.LookupTable], joinType=[InnerJoin], async=[false], lookup=[id=a], where=[(UPPER(info) = 'flink')], select=[a, b, c, proctime, rowtime, id, name, age, info])
+   +- DataStreamScan(table=[[default_catalog, default_database, MyTable]], fields=[a, b, c, proctime, rowtime])
+]]>
+    </Resource>
+  </TestCase>
+  <TestCase name="testTemporalTableFilterPushDownWithUdf[LegacyTableSource=false]">
+    <Resource name="sql">
+        <![CDATA[
+SELECT * FROM MyTable as T
+JOIN LookupTable FOR SYSTEM_TIME AS OF T.proctime AS D
+ON T.a = D.id
+WHERE UPPER(D.info) = 'flink'
+]]>
+    </Resource>
+    <Resource name="ast">
+        <![CDATA[
+LogicalProject(a=[$0], b=[$1], c=[$2], proctime=[$3], rowtime=[$4], id=[$5], name=[$6], age=[$7], info=[$8])
++- LogicalFilter(condition=[=(UPPER($8), _UTF-16LE'flink')])
+   +- LogicalCorrelate(correlation=[$cor0], joinType=[inner], requiredColumns=[{0, 3}])
+      :- LogicalTableScan(table=[[default_catalog, default_database, MyTable]])
+      +- LogicalFilter(condition=[=($cor0.a, $0)])
+         +- LogicalSnapshot(period=[$cor0.proctime])
+            +- LogicalTableScan(table=[[default_catalog, default_database, LookupTable]])
+]]>
+    </Resource>
+    <Resource name="optimized exec plan">
+        <![CDATA[
+Calc(select=[a, b, c, PROCTIME_MATERIALIZE(proctime) AS proctime, rowtime, id, name, age, info])
++- LookupJoin(table=[default_catalog.default_database.LookupTable, filter=[=(UPPER(info), _UTF-16LE'flink':VARCHAR(2147483647) CHARACTER SET "UTF-16LE")]], joinType=[InnerJoin], async=[false], lookup=[id=a], select=[a, b, c, proctime, rowtime, id, name, age, info])
    +- DataStreamScan(table=[[default_catalog, default_database, MyTable]], fields=[a, b, c, proctime, rowtime])
 ]]>
     </Resource>

--- a/flink-table/flink-table-planner/src/test/scala/org/apache/flink/table/planner/plan/batch/sql/join/LookupJoinTest.scala
+++ b/flink-table/flink-table-planner/src/test/scala/org/apache/flink/table/planner/plan/batch/sql/join/LookupJoinTest.scala
@@ -375,7 +375,7 @@ class LookupJoinTest(legacyTableSource: Boolean) extends TableTestBase {
   }
 
   @Test
-  def testTemporalTableFilterPushDownWithUdf(): Unit ={
+  def testTemporalTableFilterPushDownWithUdf(): Unit = {
     val sql =
       """
         |SELECT * FROM MyTable as T

--- a/flink-table/flink-table-planner/src/test/scala/org/apache/flink/table/planner/plan/metadata/FlinkRelMdModifiedMonotonicityTest.scala
+++ b/flink-table/flink-table-planner/src/test/scala/org/apache/flink/table/planner/plan/metadata/FlinkRelMdModifiedMonotonicityTest.scala
@@ -410,6 +410,7 @@ class FlinkRelMdModifiedMonotonicityTest extends FlinkRelMdHandlerTestBase {
           CONSTANT,
           CONSTANT,
           CONSTANT,
+          CONSTANT,
           CONSTANT)),
       mq.getRelModifiedMonotonicity(streamLookupJoin)
     )

--- a/flink-table/flink-table-planner/src/test/scala/org/apache/flink/table/planner/runtime/stream/sql/LookupJoinITCase.scala
+++ b/flink-table/flink-table-planner/src/test/scala/org/apache/flink/table/planner/runtime/stream/sql/LookupJoinITCase.scala
@@ -57,7 +57,8 @@ class LookupJoinITCase(legacyTableSource: Boolean) extends StreamingTestBase {
     rowOf(22, 2L, "Jark", "cat"),
     rowOf(33, 3L, "Fabian", "golden fish"),
     rowOf(11, 4L, "Hello world", "tiger"),
-    rowOf(11, 5L, "Hello world", "ant"))
+    rowOf(11, 5L, "Hello world", "ant")
+  )
 
   val userDataWithNull = List(
     rowOf(11, 1L, "Julian", "dog"),


### PR DESCRIPTION
1. Add rule that will transpose the filter and snapshot, so that PushFilterIntoTableSourceScanRule will push filter into DynamicTableSource.
2. Add filter info into CommonPhysicalLookupJoin#explainTerms‘s table info
3. Add tests including ut, itcase.

## What is the purpose of the change

*This pull request add a rule that will transpose the filter and snapshot, so that PushFilterIntoTableSourceScanRule will push filter into DynamicTableSource.*

## Brief change log

- *Add rule that will transpose filter and snapshot, to push filter down.*

## Verifying this change

This change added tests and can be verified as follows:

- *Added single rule test.*
- *Added test with all rules.*
- *Added e2e tests.*

## Does this pull request potentially affect one of the following parts:

  - Dependencies (does it add or upgrade a dependency): (yes / *no*)
  - The public API, i.e., is any changed class annotated with `@Public(Evolving)`: (yes / *no*)
  - The serializers: (yes / *no* / don't know)
  - The runtime per-record code paths (performance sensitive): (yes / *no* / don't know)
  - Anything that affects deployment or recovery: JobManager (and its components), Checkpointing, Kubernetes/Yarn, ZooKeeper: (yes / *no* / don't know)
  - The S3 file system connector: (yes / *no* / don't know)

## Documentation

  - Does this pull request introduce a new feature? (*yes* / no)
  - If yes, how is the feature documented? (not applicable / docs / *JavaDocs* / not documented)
