### PR TITLE
FLINK-25029: Hadoop Caller Context Setting in Flink

### DIFF
--- a/docs/layouts/shortcodes/generated/hadoop_configuration.html
+++ b/docs/layouts/shortcodes/generated/hadoop_configuration.html
@@ -1,0 +1,18 @@
+<table class="configuration table table-bordered">
+    <thead>
+        <tr>
+            <th class="text-left" style="width: 20%">Key</th>
+            <th class="text-left" style="width: 15%">Default</th>
+            <th class="text-left" style="width: 10%">Type</th>
+            <th class="text-left" style="width: 55%">Description</th>
+        </tr>
+    </thead>
+    <tbody>
+        <tr>
+            <td><h5>execution.caller-context-app-id</h5></td>
+            <td style="word-wrap: break-word;">(none)</td>
+            <td>String</td>
+            <td>A text means the hadoop caller context app id.</td>
+        </tr>
+    </tbody>
+</table>

--- a/flink-core/src/main/java/org/apache/flink/configuration/HadoopOptions.java
+++ b/flink-core/src/main/java/org/apache/flink/configuration/HadoopOptions.java
@@ -1,0 +1,32 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.flink.configuration;
+
+import org.apache.flink.annotation.PublicEvolving;
+
+/** The set of configuration options relating to hadoop settings. */
+@PublicEvolving
+public class HadoopOptions {
+
+    public static final ConfigOption<String> CALLER_CONTEXT_APP_ID =
+            ConfigOptions.key("execution.caller-context-app-id")
+                    .stringType()
+                    .noDefaultValue()
+                    .withDescription("A text means the hadoop caller context app id.");
+}

--- a/flink-filesystems/flink-hadoop-fs/src/main/java/org/apache/flink/runtime/fs/hdfs/HadoopFsFactory.java
+++ b/flink-filesystems/flink-hadoop-fs/src/main/java/org/apache/flink/runtime/fs/hdfs/HadoopFsFactory.java
@@ -75,6 +75,12 @@ public class HadoopFsFactory implements FileSystemFactory {
         // from here on, we need to handle errors due to missing optional
         // dependency classes
         try {
+            // -- (0) set hadoop caller context
+
+            if (getCurrent() != null && flinkConfig != null) {
+                HadoopUtils.setCallerContext(getCurrent(), flinkConfig);
+            }
+
             // -- (1) get the loaded Hadoop config (or fall back to one loaded from the classpath)
 
             final org.apache.hadoop.conf.Configuration hadoopConfig;
@@ -223,5 +229,22 @@ public class HadoopFsFactory implements FileSystemFactory {
                     limitSettings.streamOpenTimeout,
                     limitSettings.streamInactivityTimeout);
         }
+    }
+
+    /**
+     * The thread local current caller context.
+     *
+     * <p>Internal class for defered singleton idiom.
+     */
+    private static final class CurrentCallerContextHolder {
+        static final ThreadLocal<String> CALLER_CONTEXT = new InheritableThreadLocal<>();
+    }
+
+    public static String getCurrent() {
+        return HadoopFsFactory.CurrentCallerContextHolder.CALLER_CONTEXT.get();
+    }
+
+    public static void setCurrent(String callerContext) {
+        HadoopFsFactory.CurrentCallerContextHolder.CALLER_CONTEXT.set(callerContext);
     }
 }

--- a/flink-filesystems/flink-hadoop-fs/src/test/java/org/apache/flink/runtime/fs/hdfs/HadoopFsFactoryTest.java
+++ b/flink-filesystems/flink-hadoop-fs/src/test/java/org/apache/flink/runtime/fs/hdfs/HadoopFsFactoryTest.java
@@ -18,9 +18,11 @@
 
 package org.apache.flink.runtime.fs.hdfs;
 
+import org.apache.flink.configuration.Configuration;
 import org.apache.flink.core.fs.FileSystem;
 import org.apache.flink.util.TestLogger;
 
+import org.apache.hadoop.ipc.CallerContext;
 import org.junit.Test;
 
 import java.io.IOException;
@@ -57,5 +59,21 @@ public class HadoopFsFactoryTest extends TestLogger {
         } catch (IOException e) {
             assertTrue(e.getMessage().contains("authority"));
         }
+    }
+
+    @Test
+    public void testCreateHadoopFsWithCallerContext() throws Exception {
+        String callerContextContent = "test_caller_context";
+        HadoopFsFactory.setCurrent(callerContextContent);
+        final URI uri = URI.create("hdfs://localhost:12345/");
+
+        HadoopFsFactory factory = new HadoopFsFactory();
+        factory.configure(new Configuration());
+        FileSystem fs = factory.create(uri);
+
+        assertEquals(uri.getScheme(), fs.getUri().getScheme());
+        assertEquals(uri.getAuthority(), fs.getUri().getAuthority());
+        assertEquals(uri.getPort(), fs.getUri().getPort());
+        assertEquals(CallerContext.getCurrent().getContext(), callerContextContent);
     }
 }

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/taskmanager/Task.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/taskmanager/Task.java
@@ -25,6 +25,7 @@ import org.apache.flink.api.common.TaskInfo;
 import org.apache.flink.api.common.cache.DistributedCache;
 import org.apache.flink.api.common.time.Deadline;
 import org.apache.flink.configuration.Configuration;
+import org.apache.flink.configuration.HadoopOptions;
 import org.apache.flink.configuration.TaskManagerOptions;
 import org.apache.flink.core.fs.FileSystemSafetyNet;
 import org.apache.flink.core.fs.Path;
@@ -49,6 +50,7 @@ import org.apache.flink.runtime.executiongraph.JobInformation;
 import org.apache.flink.runtime.executiongraph.TaskInformation;
 import org.apache.flink.runtime.externalresource.ExternalResourceInfoProvider;
 import org.apache.flink.runtime.filecache.FileCache;
+import org.apache.flink.runtime.fs.hdfs.HadoopFsFactory;
 import org.apache.flink.runtime.io.disk.iomanager.IOManager;
 import org.apache.flink.runtime.io.network.NettyShuffleEnvironment;
 import org.apache.flink.runtime.io.network.TaskEventDispatcher;
@@ -432,6 +434,19 @@ public class Task
 
         // finally, create the executing thread, but do not start it
         executingThread = new Thread(TASK_THREADS_GROUP, this, taskNameWithSubtask);
+
+        // Add CallerContext.
+        String callerContext =
+                "Flink_Task_"
+                        + "JobID_"
+                        + jobId
+                        + "_TaskName_"
+                        + taskInfo.getTaskName()
+                        + "_"
+                        + taskInfo.getAttemptNumber();
+
+        HadoopFsFactory.setCurrent(
+                tmConfig.getOptional(HadoopOptions.CALLER_CONTEXT_APP_ID).orElse(callerContext));
     }
 
     // ------------------------------------------------------------------------


### PR DESCRIPTION
<!--
*Thank you very much for contributing to Apache Flink - we are happy that you want to help us improve Flink. To help the community review your contribution in the best possible way, please go through the checklist below, which will get the contribution into a shape in which it can be best reviewed.*

*Please understand that we do not do this to make contributions to Flink a hassle. In order to uphold a high standard of quality for code contributions, while at the same time managing a large number of contributions, we need contributors to prepare the contributions well, and give reviewers enough contextual information for the review. Please also understand that contributions that do not follow this guide will take longer to review and thus typically be picked up with lower priority by the community.*

## Contribution Checklist

  - Make sure that the pull request corresponds to a [JIRA issue](https://issues.apache.org/jira/projects/FLINK/issues). Exceptions are made for typos in JavaDoc or documentation files, which need no JIRA issue.
  
  - Name the pull request in the form "[FLINK-XXXX] [component] Title of the pull request", where *FLINK-XXXX* should be replaced by the actual issue number. Skip *component* if you are unsure about which is the best component.
  Typo fixes that have no associated JIRA issue should be named following this pattern: `[hotfix] [docs] Fix typo in event time introduction` or `[hotfix] [javadocs] Expand JavaDoc for PuncuatedWatermarkGenerator`.

  - Fill out the template below to describe the changes contributed by the pull request. That will give reviewers the context they need to do the review.
  
  - Make sure that the change passes the automated tests, i.e., `mvn clean verify` passes. You can set up Azure Pipelines CI to do that following [this guide](https://cwiki.apache.org/confluence/display/FLINK/Azure+Pipelines#AzurePipelines-Tutorial:SettingupAzurePipelinesforaforkoftheFlinkrepository).

  - Each pull request should address only one issue, not mix up code from multiple issues.
  
  - Each commit in the pull request has a meaningful commit message (including the JIRA id)

  - Once all items of the checklist are addressed, remove the above text and this checklist, leaving only the filled out template below.


**(The sections below can be removed for hotfixes of typos)**
-->

## What is the purpose of the change

For a given HDFS operation (e.g. delete file), it's very helpful to track which upper level job issues it. The upper level callers may be specific Oozie tasks, MR jobs, and hive queries. One scenario is that the namenode (NN) is abused/spammed, the operator may want to know immediately which MR job should be blamed so that she can kill it. To this end, the caller context contains at least the application-dependent "tracking id".

The above is the main effect of the Caller Context. HDFS Client set Caller Context, then name node get it in audit log to do some work.

Now FLink need to have the Caller Context to meet the HDFS Job Audit requirement.


## Brief change log


## Verifying this change


## Does this pull request potentially affect one of the following parts:

  - Dependencies (does it add or upgrade a dependency): (no)
  - The public API, i.e., is any changed class annotated with `@Public(Evolving)`: (no)
  - The serializers: (no)
  - The runtime per-record code paths (performance sensitive): (no)
  - Anything that affects deployment or recovery: JobManager (and its components), Checkpointing, Kubernetes/Yarn, ZooKeeper: (no)
  - The S3 file system connector: (no)

## Documentation

  - Does this pull request introduce a new feature? (no)
  - If yes, how is the feature documented? (not applicable / docs / JavaDocs / not documented)
