### PR TITLE
[FLINK-25031][runtime] Job finishes iff all job vertices finish.

### DIFF
--- a/flink-runtime/src/main/java/org/apache/flink/runtime/executiongraph/ArchivedExecutionGraph.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/executiongraph/ArchivedExecutionGraph.java
@@ -286,11 +286,8 @@ public class ArchivedExecutionGraph implements AccessExecutionGraph, Serializabl
                 statusOverride == null || !statusOverride.isGloballyTerminalState(),
                 "Status override is only allowed for non-globally-terminal states.");
 
-        final int numberVertices = executionGraph.getTotalNumberOfVertices();
-
-        Map<JobVertexID, ArchivedExecutionJobVertex> archivedTasks = new HashMap<>(numberVertices);
-        List<ArchivedExecutionJobVertex> archivedVerticesInCreationOrder =
-                new ArrayList<>(numberVertices);
+        Map<JobVertexID, ArchivedExecutionJobVertex> archivedTasks = new HashMap<>();
+        List<ArchivedExecutionJobVertex> archivedVerticesInCreationOrder = new ArrayList<>();
 
         for (ExecutionJobVertex task : executionGraph.getVerticesTopologically()) {
             ArchivedExecutionJobVertex archivedTask = task.archive();

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/executiongraph/DefaultExecutionGraph.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/executiongraph/DefaultExecutionGraph.java
@@ -636,11 +636,6 @@ public class DefaultExecutionGraph implements ExecutionGraph, InternalExecutionG
     }
 
     @Override
-    public int getTotalNumberOfVertices() {
-        return numVerticesTotal;
-    }
-
-    @Override
     public Map<IntermediateDataSetID, IntermediateResult> getAllIntermediateResults() {
         return Collections.unmodifiableMap(this.intermediateResults);
     }

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/executiongraph/DefaultExecutionGraph.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/executiongraph/DefaultExecutionGraph.java
@@ -174,8 +174,8 @@ public class DefaultExecutionGraph implements ExecutionGraph, InternalExecutionG
     /** Blob writer used to offload RPC messages. */
     private final BlobWriter blobWriter;
 
-    /** The total number of vertices currently in the execution graph. */
-    private int numVerticesTotal;
+    /** Number of total job vertices. */
+    private int numJobVerticesTotal;
 
     private final PartitionGroupReleaseStrategy.Factory partitionGroupReleaseStrategyFactory;
 
@@ -199,7 +199,8 @@ public class DefaultExecutionGraph implements ExecutionGraph, InternalExecutionG
     // ------ Execution status and progress. These values are volatile, and accessed under the lock
     // -------
 
-    private int numFinishedVertices;
+    /** Number of finished job vertices. */
+    private int numFinishedJobVertices;
 
     /** Current status of the job execution. */
     private volatile JobStatus state = JobStatus.CREATED;
@@ -587,7 +588,10 @@ public class DefaultExecutionGraph implements ExecutionGraph, InternalExecutionG
 
     @Override
     public int getNumFinishedVertices() {
-        return numFinishedVertices;
+        return IterableUtils.toStream(getVerticesTopologically())
+                .map(ExecutionJobVertex::getNumExecutionVertexFinished)
+                .mapToInt(Integer::intValue)
+                .sum();
     }
 
     @Override
@@ -809,7 +813,7 @@ public class DefaultExecutionGraph implements ExecutionGraph, InternalExecutionG
             }
 
             this.verticesInCreationOrder.add(ejv);
-            this.numVerticesTotal += ejv.getParallelism();
+            this.numJobVerticesTotal++;
         }
 
         registerExecutionVerticesAndResultPartitions(this.verticesInCreationOrder);
@@ -1063,14 +1067,14 @@ public class DefaultExecutionGraph implements ExecutionGraph, InternalExecutionG
     // ------------------------------------------------------------------------
 
     /**
-     * Called whenever a vertex reaches state FINISHED (completed successfully). Once all vertices
-     * are in the FINISHED state, the program is successfully done.
+     * Called whenever a job vertex reaches state FINISHED (completed successfully). Once all job
+     * vertices are in the FINISHED state, the program is successfully done.
      */
     @Override
-    public void vertexFinished() {
+    public void jobVertexFinished() {
         assertRunningInJobMasterMainThread();
-        final int numFinished = ++numFinishedVertices;
-        if (numFinished == numVerticesTotal) {
+        final int numFinished = ++numFinishedJobVertices;
+        if (numFinished == numJobVerticesTotal) {
             // done :-)
 
             // check whether we are still in "RUNNING" and trigger the final cleanup
@@ -1099,9 +1103,9 @@ public class DefaultExecutionGraph implements ExecutionGraph, InternalExecutionG
     }
 
     @Override
-    public void vertexUnFinished() {
+    public void jobVertexUnFinished() {
         assertRunningInJobMasterMainThread();
-        numFinishedVertices--;
+        numFinishedJobVertices--;
     }
 
     /**

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/executiongraph/ExecutionGraph.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/executiongraph/ExecutionGraph.java
@@ -121,8 +121,6 @@ public interface ExecutionGraph extends AccessExecutionGraph {
      */
     long getNumberOfRestarts();
 
-    int getTotalNumberOfVertices();
-
     Map<IntermediateDataSetID, IntermediateResult> getAllIntermediateResults();
 
     /**

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/executiongraph/ExecutionJobVertex.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/executiongraph/ExecutionJobVertex.java
@@ -105,6 +105,8 @@ public class ExecutionJobVertex
 
     private final ResourceProfile resourceProfile;
 
+    private int numExecutionVertexFinished;
+
     /**
      * Either store a serialized task information, which is for all sub tasks the same, or the
      * permanent blob key of the offloaded task information BLOB containing the serialized task
@@ -333,6 +335,10 @@ public class ExecutionJobVertex
         return operatorCoordinators;
     }
 
+    int getNumExecutionVertexFinished() {
+        return numExecutionVertexFinished;
+    }
+
     public Either<SerializedValue<TaskInformation>, PermanentBlobKey> getTaskInformationOrBlobKey()
             throws IOException {
         // only one thread should offload the task information, so let's also let only one thread
@@ -457,6 +463,20 @@ public class ExecutionJobVertex
         for (ExecutionVertex ev : getTaskVertices()) {
             ev.fail(t);
         }
+    }
+
+    void executionVertexFinished() {
+        numExecutionVertexFinished++;
+        if (numExecutionVertexFinished == parallelismInfo.getParallelism()) {
+            getGraph().jobVertexFinished();
+        }
+    }
+
+    void executionVertexUnFinished() {
+        if (numExecutionVertexFinished == parallelismInfo.getParallelism()) {
+            getGraph().jobVertexUnFinished();
+        }
+        numExecutionVertexFinished--;
     }
 
     // --------------------------------------------------------------------------------------------

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/executiongraph/ExecutionVertex.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/executiongraph/ExecutionVertex.java
@@ -401,7 +401,7 @@ public class ExecutionVertex
             // if the execution was 'FINISHED' before, tell the ExecutionGraph that
             // we take one step back on the road to reaching global FINISHED
             if (oldState == FINISHED) {
-                getExecutionGraphAccessor().vertexUnFinished();
+                getJobVertex().executionVertexUnFinished();
             }
 
             // reset the intermediate results
@@ -522,7 +522,7 @@ public class ExecutionVertex
     // --------------------------------------------------------------------------------------------
 
     void executionFinished(Execution execution) {
-        getExecutionGraphAccessor().vertexFinished();
+        getJobVertex().executionVertexFinished();
     }
 
     // --------------------------------------------------------------------------------------------

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/executiongraph/InternalExecutionGraphAccessor.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/executiongraph/InternalExecutionGraphAccessor.java
@@ -73,9 +73,9 @@ public interface InternalExecutionGraphAccessor {
 
     PartitionGroupReleaseStrategy getPartitionGroupReleaseStrategy();
 
-    void vertexFinished();
+    void jobVertexFinished();
 
-    void vertexUnFinished();
+    void jobVertexUnFinished();
 
     ExecutionDeploymentListener getExecutionDeploymentListener();
 

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/scheduler/adapter/DefaultExecutionTopology.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/scheduler/adapter/DefaultExecutionTopology.java
@@ -162,7 +162,6 @@ public class DefaultExecutionTopology implements SchedulingTopology {
         ExecutionGraphIndex executionGraphIndex =
                 computeExecutionGraphIndex(
                         executionGraph.getAllExecutionVertices(),
-                        executionGraph.getTotalNumberOfVertices(),
                         logicalPipelinedRegions,
                         edgeManager);
 
@@ -187,11 +186,10 @@ public class DefaultExecutionTopology implements SchedulingTopology {
 
     private static ExecutionGraphIndex computeExecutionGraphIndex(
             Iterable<ExecutionVertex> executionVertices,
-            int vertexNumber,
             Iterable<DefaultLogicalPipelinedRegion> logicalPipelinedRegions,
             EdgeManager edgeManager) {
         Map<ExecutionVertexID, DefaultExecutionVertex> executionVerticesById = new HashMap<>();
-        List<DefaultExecutionVertex> executionVerticesList = new ArrayList<>(vertexNumber);
+        List<DefaultExecutionVertex> executionVerticesList = new ArrayList<>();
         Map<IntermediateResultPartitionID, DefaultResultPartition> resultPartitionsById =
                 new HashMap<>();
         Map<DefaultLogicalPipelinedRegion, List<DefaultExecutionVertex>>

--- a/flink-runtime/src/test/java/org/apache/flink/runtime/executiongraph/ExecutionGraphFinishTest.java
+++ b/flink-runtime/src/test/java/org/apache/flink/runtime/executiongraph/ExecutionGraphFinishTest.java
@@ -1,0 +1,82 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.flink.runtime.executiongraph;
+
+import org.apache.flink.api.common.JobStatus;
+import org.apache.flink.runtime.concurrent.ComponentMainThreadExecutorServiceAdapter;
+import org.apache.flink.runtime.jobgraph.JobGraph;
+import org.apache.flink.runtime.jobgraph.JobGraphTestUtils;
+import org.apache.flink.runtime.scheduler.SchedulerBase;
+import org.apache.flink.runtime.scheduler.SchedulerTestingUtils;
+import org.apache.flink.runtime.testtasks.NoOpInvokable;
+import org.apache.flink.util.TestLogger;
+
+import org.junit.Test;
+
+import java.util.Arrays;
+import java.util.Iterator;
+import java.util.List;
+
+import static org.junit.Assert.assertEquals;
+
+/** Tests the finish behaviour of the {@link ExecutionGraph}. */
+public class ExecutionGraphFinishTest extends TestLogger {
+
+    @Test
+    public void testJobFinishes() throws Exception {
+
+        JobGraph jobGraph =
+                JobGraphTestUtils.streamingJobGraph(
+                        ExecutionGraphTestUtils.createJobVertex("Task1", 2, NoOpInvokable.class),
+                        ExecutionGraphTestUtils.createJobVertex("Task2", 2, NoOpInvokable.class));
+
+        SchedulerBase scheduler =
+                SchedulerTestingUtils.newSchedulerBuilder(
+                                jobGraph, ComponentMainThreadExecutorServiceAdapter.forMainThread())
+                        .build();
+
+        ExecutionGraph eg = scheduler.getExecutionGraph();
+
+        scheduler.startScheduling();
+        ExecutionGraphTestUtils.switchAllVerticesToRunning(eg);
+
+        Iterator<ExecutionJobVertex> jobVertices = eg.getVerticesTopologically().iterator();
+
+        ExecutionJobVertex sender = jobVertices.next();
+        ExecutionJobVertex receiver = jobVertices.next();
+
+        List<ExecutionVertex> senderVertices = Arrays.asList(sender.getTaskVertices());
+        List<ExecutionVertex> receiverVertices = Arrays.asList(receiver.getTaskVertices());
+
+        // test getNumExecutionVertexFinished
+        senderVertices.get(0).getCurrentExecutionAttempt().markFinished();
+        assertEquals(1, sender.getNumExecutionVertexFinished());
+        assertEquals(JobStatus.RUNNING, eg.getState());
+
+        senderVertices.get(1).getCurrentExecutionAttempt().markFinished();
+        assertEquals(2, sender.getNumExecutionVertexFinished());
+        assertEquals(JobStatus.RUNNING, eg.getState());
+
+        // test job finishes
+        receiverVertices.get(0).getCurrentExecutionAttempt().markFinished();
+        receiverVertices.get(1).getCurrentExecutionAttempt().markFinished();
+        assertEquals(4, eg.getNumFinishedVertices());
+        assertEquals(JobStatus.FINISHED, eg.getState());
+    }
+}

--- a/flink-runtime/src/test/java/org/apache/flink/runtime/scheduler/adaptive/ExecutingTest.java
+++ b/flink-runtime/src/test/java/org/apache/flink/runtime/scheduler/adaptive/ExecutingTest.java
@@ -899,10 +899,10 @@ public class ExecutingTest extends TestLogger {
                 boolean releasePartitions) {}
 
         @Override
-        public void vertexFinished() {}
+        public void jobVertexFinished() {}
 
         @Override
-        public void vertexUnFinished() {}
+        public void jobVertexUnFinished() {}
 
         @Override
         public ExecutionDeploymentListener getExecutionDeploymentListener() {

--- a/flink-runtime/src/test/java/org/apache/flink/runtime/scheduler/adaptive/StateTrackingMockExecutionGraph.java
+++ b/flink-runtime/src/test/java/org/apache/flink/runtime/scheduler/adaptive/StateTrackingMockExecutionGraph.java
@@ -143,11 +143,6 @@ class StateTrackingMockExecutionGraph implements ExecutionGraph {
     // --- interface implementations: methods for creating an archived execution graph
 
     @Override
-    public int getTotalNumberOfVertices() {
-        return 0;
-    }
-
-    @Override
     public Iterable<ExecutionJobVertex> getVerticesTopologically() {
         return Collections.emptyList();
     }


### PR DESCRIPTION
## What is the purpose of the change
Let the job finish iff all job vertices are finish, since execution vertices can be lazily created when using adaptive batch scheduler.

## Brief change log
Job finishes iff all job vertices finish.

## Verifying this change
This change can be covered by existing tests.

## Does this pull request potentially affect one of the following parts:

  - Dependencies (does it add or upgrade a dependency): (no)
  - The public API, i.e., is any changed class annotated with `@Public(Evolving)`: (no)
  - The serializers: (no)
  - The runtime per-record code paths (performance sensitive): (no)
  - Anything that affects deployment or recovery: JobManager (and its components), Checkpointing, Kubernetes/Yarn, ZooKeeper: (no)
  - The S3 file system connector: (no)

## Documentation

  - Does this pull request introduce a new feature? (no)
  - If yes, how is the feature documented? (not applicable)
