### PR TITLE
[FLINK-24506][config] Adds checkpoint directory to CheckpointConfig

### DIFF
--- a/flink-streaming-java/src/main/java/org/apache/flink/streaming/api/environment/CheckpointConfig.java
+++ b/flink-streaming-java/src/main/java/org/apache/flink/streaming/api/environment/CheckpointConfig.java
@@ -22,6 +22,7 @@ import org.apache.flink.annotation.Experimental;
 import org.apache.flink.annotation.Public;
 import org.apache.flink.annotation.PublicEvolving;
 import org.apache.flink.api.common.JobStatus;
+import org.apache.flink.configuration.CheckpointingOptions;
 import org.apache.flink.configuration.ReadableConfig;
 import org.apache.flink.core.fs.Path;
 import org.apache.flink.runtime.state.CheckpointStorage;
@@ -784,5 +785,8 @@ public class CheckpointConfig implements java.io.Serializable {
         configuration
                 .getOptional(ExecutionCheckpointingOptions.FORCE_UNALIGNED)
                 .ifPresent(this::setForceUnalignedCheckpoints);
+        configuration
+                .getOptional(CheckpointingOptions.CHECKPOINTS_DIRECTORY)
+                .ifPresent(this::setCheckpointStorage);
     }
 }

--- a/flink-streaming-java/src/test/java/org/apache/flink/streaming/api/environment/CheckpointConfigFromConfigurationTest.java
+++ b/flink-streaming-java/src/test/java/org/apache/flink/streaming/api/environment/CheckpointConfigFromConfigurationTest.java
@@ -26,14 +26,12 @@ import org.apache.flink.runtime.state.storage.FileSystemCheckpointStorage;
 import org.apache.flink.streaming.api.CheckpointingMode;
 
 import org.assertj.core.api.InstanceOfAssertFactories;
-import org.junit.Test;
-import org.junit.runner.RunWith;
-import org.junit.runners.Parameterized;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.MethodSource;
 
-import java.util.Arrays;
-import java.util.Collection;
 import java.util.function.BiConsumer;
 import java.util.function.Function;
+import java.util.stream.Stream;
 
 import static org.assertj.core.api.Assertions.assertThat;
 
@@ -41,12 +39,10 @@ import static org.assertj.core.api.Assertions.assertThat;
  * Tests for configuring {@link CheckpointConfig} via {@link
  * CheckpointConfig#configure(ReadableConfig)}.
  */
-@RunWith(Parameterized.class)
 public class CheckpointConfigFromConfigurationTest {
 
-    @Parameterized.Parameters(name = "{0}")
-    public static Collection<TestSpec> specs() {
-        return Arrays.asList(
+    private static Stream<TestSpec<?>> specs() {
+        return Stream.of(
                 TestSpec.testValue(CheckpointingMode.AT_LEAST_ONCE)
                         .whenSetFromFile("execution.checkpointing.mode", "AT_LEAST_ONCE")
                         .viaSetter(CheckpointConfig::setCheckpointingMode)
@@ -121,10 +117,9 @@ public class CheckpointConfigFromConfigurationTest {
                                                                 .getCheckpointPath())));
     }
 
-    @Parameterized.Parameter public TestSpec spec;
-
-    @Test
-    public void testLoadingFromConfiguration() {
+    @ParameterizedTest
+    @MethodSource("specs")
+    public void testLoadingFromConfiguration(TestSpec<?> spec) {
         CheckpointConfig configFromSetters = new CheckpointConfig();
         CheckpointConfig configFromFile = new CheckpointConfig();
 
@@ -136,8 +131,9 @@ public class CheckpointConfigFromConfigurationTest {
         spec.assertEqual(configFromFile, configFromSetters);
     }
 
-    @Test
-    public void testNotOverridingIfNotSet() {
+    @ParameterizedTest
+    @MethodSource("specs")
+    public void testNotOverridingIfNotSet(TestSpec<?> spec) {
         CheckpointConfig config = new CheckpointConfig();
 
         spec.setNonDefaultValue(config);


### PR DESCRIPTION
This enables the user to pass in the checkpoint directory through the Flink
configuration again. This fixes an issue that was introduced by [FLINK-19463](https://issues.apache.org/jira/browse/FLINK-19463).

## What is the purpose of the change

This fixes an issue where the checkpoint directory couldn't be set anymore through the Flink configuration. See a more detailed description in the ticket [FLINK-24506](https://issues.apache.org/jira/browse/FLINK-24506)

## Brief change log

* Adds the `state.checkpoints.dir` to `CheckpointConfig.configure`

## Verifying this change

* A test was added to the corresponding `CheckpointConfigFromConfigurationTest`

## Does this pull request potentially affect one of the following parts:

  - Dependencies (does it add or upgrade a dependency): no
  - The public API, i.e., is any changed class annotated with `@Public(Evolving)`: yes
  - The serializers: no
  - The runtime per-record code paths (performance sensitive): no
  - Anything that affects deployment or recovery: JobManager (and its components), Checkpointing, Kubernetes/Yarn, ZooKeeper: yes
  - The S3 file system connector: no

## Documentation

  - Does this pull request introduce a new feature? no
  - If yes, how is the feature documented? not applicable
