### PR TITLE
[FLINK-24661][core][table] ConfigOption add isSecret method to judge sensitive options

### DIFF
--- a/flink-core/src/main/java/org/apache/flink/configuration/ConfigOption.java
+++ b/flink-core/src/main/java/org/apache/flink/configuration/ConfigOption.java
@@ -72,6 +72,8 @@ public class ConfigOption<T> {
 
     private final boolean isList;
 
+    private boolean isSecret;
+
     // ------------------------------------------------------------------------
 
     Class<?> getClazz() {
@@ -80,6 +82,10 @@ public class ConfigOption<T> {
 
     boolean isList() {
         return isList;
+    }
+
+    public boolean isSecret() {
+        return isSecret;
     }
 
     /**
@@ -106,6 +112,31 @@ public class ConfigOption<T> {
         this.fallbackKeys = fallbackKeys == null || fallbackKeys.length == 0 ? EMPTY : fallbackKeys;
         this.clazz = checkNotNull(clazz);
         this.isList = isList;
+        this.isSecret = false;
+    }
+
+    /**
+     * Creates a new config option with fallback keys.
+     *
+     * @param key The current key for that config option
+     * @param clazz describes type of the ConfigOption, see description of the clazz field
+     * @param description Description for that option
+     * @param defaultValue The default value for this option
+     * @param isList tells if the ConfigOption describes a list option, see description of the clazz
+     *     field
+     * @param isSecret make the ConfigOption sensitive.
+     * @param fallbackKeys The list of fallback keys, in the order to be checked
+     */
+    ConfigOption(
+            String key,
+            Class<?> clazz,
+            Description description,
+            T defaultValue,
+            boolean isList,
+            boolean isSecret,
+            FallbackKey... fallbackKeys) {
+        this(key, clazz, description, defaultValue, isList, fallbackKeys);
+        this.isSecret = isSecret;
     }
 
     // ------------------------------------------------------------------------
@@ -178,7 +209,18 @@ public class ConfigOption<T> {
      * @return A new config option, with given description.
      */
     public ConfigOption<T> withDescription(final Description description) {
-        return new ConfigOption<>(key, clazz, description, defaultValue, isList, fallbackKeys);
+        return new ConfigOption<>(
+                key, clazz, description, defaultValue, isList, false, fallbackKeys);
+    }
+
+    /**
+     * Create a new config option, and enable this option sensitive.
+     *
+     * @return A new config option, with setting secret.
+     */
+    public ConfigOption<T> enableSecret() {
+        return new ConfigOption<>(
+                key, clazz, description, defaultValue, isList, true, fallbackKeys);
     }
 
     // ------------------------------------------------------------------------

--- a/flink-table/flink-table-common/src/test/java/org/apache/flink/table/factories/FactoryUtilTest.java
+++ b/flink-table/flink-table-common/src/test/java/org/apache/flink/table/factories/FactoryUtilTest.java
@@ -163,6 +163,26 @@ public class FactoryUtilTest {
     }
 
     @Test
+    public void testCustomSecretOption() {
+        assertCreateTableSourceWithOptionModifier(
+                options -> {
+                    options.remove("target");
+                    options.put("secret", "456");
+                },
+                "Table options are:\n"
+                        + "\n"
+                        + "'buffer-size'='1000'\n"
+                        + "'connector'='test-connector'\n"
+                        + "'key.format'='test-format'\n"
+                        + "'key.test-format.delimiter'=','\n"
+                        + "'property-version'='1'\n"
+                        + "'secret'='******'\n"
+                        + "'value.format'='test-format'\n"
+                        + "'value.test-format.delimiter'='|'\n"
+                        + "'value.test-format.fail-on-missing'='true'");
+    }
+
+    @Test
     public void testUnconsumedOption() {
         assertCreateTableSourceWithOptionModifier(
                 options -> {
@@ -188,6 +208,7 @@ public class FactoryUtilTest {
                         + "key.test-format.readable-metadata\n"
                         + "password\n"
                         + "property-version\n"
+                        + "secret\n"
                         + "target\n"
                         + "value.format\n"
                         + "value.test-format.changelog-mode\n"

--- a/flink-table/flink-table-common/src/test/java/org/apache/flink/table/factories/TestDynamicTableFactory.java
+++ b/flink-table/flink-table-common/src/test/java/org/apache/flink/table/factories/TestDynamicTableFactory.java
@@ -64,6 +64,9 @@ public final class TestDynamicTableFactory
     public static final ConfigOption<String> PASSWORD =
             ConfigOptions.key("password").stringType().noDefaultValue();
 
+    public static final ConfigOption<String> SECRET =
+            ConfigOptions.key("secret").stringType().noDefaultValue().enableSecret();
+
     public static final ConfigOption<String> KEY_FORMAT =
             ConfigOptions.key("key" + FORMAT_SUFFIX).stringType().noDefaultValue();
 
@@ -130,6 +133,7 @@ public final class TestDynamicTableFactory
         options.add(FORMAT);
         options.add(VALUE_FORMAT);
         options.add(PASSWORD);
+        options.add(SECRET);
         return options;
     }
 


### PR DESCRIPTION
## What is the purpose of the change

When Flink SQL throw exception, value of secret options is displayed. This PR add a declaration flag in ConfigOption to judge secret options.

## Brief change log

 - *Added a declaration flag like isSecret to ConfigOption.
 - *FactoryUtil judge isSecret flag in ConfigOption.

## Verifying this change

This change added tests and can be verified as follows:

  - *Added a test case for using ConfigOption secret flag.

## Does this pull request potentially affect one of the following parts:

  - Dependencies (does it add or upgrade a dependency): (no)
  - The public API, i.e., is any changed class annotated with `@Public(Evolving)`: (yes)
  - The serializers: (no)
  - The runtime per-record code paths (performance sensitive): (no)
  - Anything that affects deployment or recovery: JobManager (and its components), Checkpointing, Kubernetes/Yarn, ZooKeeper: (no)
  - The S3 file system connector: (no)

## Documentation

  - Does this pull request introduce a new feature? (no)
  - If yes, how is the feature documented? (no)
