### PR TITLE
[FLINK-24995][tests] EnumValueSerializerCompatibilityTest doesn't compile on later Scala versions

### DIFF
--- a/flink-scala/src/test/scala/org/apache/flink/api/scala/typeutils/EnumValueSerializerCompatibilityTest.scala
+++ b/flink-scala/src/test/scala/org/apache/flink/api/scala/typeutils/EnumValueSerializerCompatibilityTest.scala
@@ -189,6 +189,9 @@ object EnumValueSerializerCompatibilityTest {
 
     run.compile(List(file.getAbsolutePath))
 
-    reporter.printSummary()
+    if (reporter.hasWarnings || reporter.hasErrors) {
+      reporter.finish()
+      fail("Scala compiler reported warnings or errors")
+    }
   }
 }

--- a/flink-scala/src/test/scala/org/apache/flink/api/scala/typeutils/EnumValueSerializerCompatibilityTest.scala
+++ b/flink-scala/src/test/scala/org/apache/flink/api/scala/typeutils/EnumValueSerializerCompatibilityTest.scala
@@ -30,7 +30,7 @@ import java.io._
 import java.net.{URL, URLClassLoader}
 
 import scala.reflect.NameTransformer
-import scala.tools.nsc.{GenericRunnerSettings, Global}
+import scala.tools.nsc.{Global, Settings}
 import scala.tools.nsc.reporters.ConsoleReporter
 
 class EnumValueSerializerCompatibilityTest extends TestLogger with JUnitSuiteLike {
@@ -177,10 +177,7 @@ object EnumValueSerializerCompatibilityTest {
   }
 
   def compileScalaFile(file: File): Unit = {
-    val in = new BufferedReader(new StringReader(""))
-    val out = new PrintWriter(new BufferedWriter(new OutputStreamWriter(System.out)))
-
-    val settings = new GenericRunnerSettings(out.println _)
+    val settings = new Settings()
 
     // use the java classpath so that scala libraries are available to the compiler
     settings.usejavacp.value = true


### PR DESCRIPTION
`ConsoleReporter#printSummary` was removed in 2.12.13 and 2.13.0. We can use `#finish` instead which is equivalent and available in all versions.

https://www.scala-lang.org/api/2.12.7/scala-compiler/scala/tools/nsc/reporters/ConsoleReporter.html#finish():Unit
https://www.scala-lang.org/api/2.12.12/scala-compiler/scala/tools/nsc/reporters/ConsoleReporter.html#finish():Unit
https://www.scala-lang.org/api/2.13.7/scala-compiler/scala/tools/nsc/reporters/ConsoleReporter.html#finish():Unit

Additionally the test now fails if the compiler reports a warning or error, so we actually get some benefit from the summary.
Alternatively, we could also just remove it, but I can't really decide that.
