### PR TITLE
[hotfix][table-planner] Add back support for decimal to boolean

### DIFF
--- a/flink-table/flink-table-planner/src/main/java/org/apache/flink/table/planner/functions/casting/CastRuleProvider.java
+++ b/flink-table/flink-table-planner/src/main/java/org/apache/flink/table/planner/functions/casting/CastRuleProvider.java
@@ -52,7 +52,7 @@ public class CastRuleProvider {
                 .addRule(NumericPrimitiveCastRule.INSTANCE)
                 // Boolean <-> numeric rules
                 .addRule(BooleanToNumericCastRule.INSTANCE)
-                .addRule(IntegerNumericToBooleanCastRule.INSTANCE)
+                .addRule(NumericToBooleanCastRule.INSTANCE)
                 // To string rules
                 .addRule(NumericToStringCastRule.INSTANCE)
                 .addRule(BooleanToStringCastRule.INSTANCE)

--- a/flink-table/flink-table-planner/src/main/java/org/apache/flink/table/planner/functions/casting/NumericToBooleanCastRule.java
+++ b/flink-table/flink-table-planner/src/main/java/org/apache/flink/table/planner/functions/casting/NumericToBooleanCastRule.java
@@ -22,16 +22,20 @@ import org.apache.flink.table.types.logical.LogicalType;
 import org.apache.flink.table.types.logical.LogicalTypeFamily;
 import org.apache.flink.table.types.logical.LogicalTypeRoot;
 
-/** {@link LogicalTypeFamily#INTEGER_NUMERIC} to {@link LogicalTypeRoot#BOOLEAN} conversions. */
-class IntegerNumericToBooleanCastRule
-        extends AbstractExpressionCodeGeneratorCastRule<Number, Boolean> {
+import static org.apache.flink.table.planner.codegen.calls.BuiltInMethods.DECIMAL_TO_BOOLEAN;
+import static org.apache.flink.table.planner.functions.casting.CastRuleUtils.staticCall;
 
-    static final IntegerNumericToBooleanCastRule INSTANCE = new IntegerNumericToBooleanCastRule();
+// Should be changed to INTEGER_NUMERIC when https://issues.apache.org/jira/browse/FLINK-24576 is
+// fixed
+/** {@link LogicalTypeFamily#NUMERIC} to {@link LogicalTypeRoot#BOOLEAN} conversions. */
+class NumericToBooleanCastRule extends AbstractExpressionCodeGeneratorCastRule<Number, Boolean> {
 
-    private IntegerNumericToBooleanCastRule() {
+    static final NumericToBooleanCastRule INSTANCE = new NumericToBooleanCastRule();
+
+    private NumericToBooleanCastRule() {
         super(
                 CastRulePredicate.builder()
-                        .input(LogicalTypeFamily.INTEGER_NUMERIC)
+                        .input(LogicalTypeFamily.NUMERIC)
                         .target(LogicalTypeRoot.BOOLEAN)
                         .build());
     }
@@ -42,6 +46,11 @@ class IntegerNumericToBooleanCastRule
             String inputTerm,
             LogicalType inputLogicalType,
             LogicalType targetLogicalType) {
+
+        // Should be removed when https://issues.apache.org/jira/browse/FLINK-24576 is fixed
+        if (inputLogicalType.is(LogicalTypeRoot.DECIMAL)) {
+            return staticCall(DECIMAL_TO_BOOLEAN(), inputTerm);
+        }
         return inputTerm + " != 0";
     }
 }

--- a/flink-table/flink-table-planner/src/main/scala/org/apache/flink/table/planner/codegen/calls/BuiltInMethods.scala
+++ b/flink-table/flink-table-planner/src/main/scala/org/apache/flink/table/planner/codegen/calls/BuiltInMethods.scala
@@ -536,6 +536,10 @@ object BuiltInMethods {
     classOf[DecimalDataUtils],
     "doubleValue", classOf[DecimalData])
 
+  val DECIMAL_TO_BOOLEAN = Types.lookupMethod(
+    classOf[DecimalDataUtils],
+    "castToBoolean", classOf[DecimalData])
+
   val INTEGRAL_TO_DECIMAL = Types.lookupMethod(
     classOf[DecimalDataUtils],
     "castFrom", classOf[Long], classOf[Int], classOf[Int])

--- a/flink-table/flink-table-planner/src/test/java/org/apache/flink/table/planner/functions/casting/CastRulesTest.java
+++ b/flink-table/flink-table-planner/src/test/java/org/apache/flink/table/planner/functions/casting/CastRulesTest.java
@@ -633,6 +633,16 @@ class CastRulesTest {
                         .fail(STRING(), StringData.fromString("Apache Flink"), TableException.class)
                         .fromCase(STRING(), StringData.fromString("TRUE"), true)
                         .fail(STRING(), StringData.fromString(""), TableException.class)
+                        // Should fail when https://issues.apache.org/jira/browse/FLINK-24576 is
+                        // fixed
+                        .fromCase(
+                                DECIMAL(5, 3),
+                                DecimalData.fromBigDecimal(new BigDecimal("0.000"), 5, 3),
+                                false)
+                        .fromCase(
+                                DECIMAL(4, 3),
+                                DecimalData.fromBigDecimal(new BigDecimal("1.987"), 4, 3),
+                                true)
                         .fromCase(TINYINT(), DEFAULT_POSITIVE_TINY_INT, true)
                         .fromCase(TINYINT(), DEFAULT_NEGATIVE_TINY_INT, true)
                         .fromCase(TINYINT(), (byte) 0, false)
@@ -644,7 +654,13 @@ class CastRulesTest {
                         .fromCase(INT(), 0, false)
                         .fromCase(BIGINT(), DEFAULT_POSITIVE_BIGINT, true)
                         .fromCase(BIGINT(), DEFAULT_NEGATIVE_BIGINT, true)
-                        .fromCase(BIGINT(), 0L, false),
+                        .fromCase(BIGINT(), 0L, false)
+                        // Should fail when https://issues.apache.org/jira/browse/FLINK-24576 is
+                        // fixed
+                        .fromCase(FLOAT(), 0f, false)
+                        .fromCase(FLOAT(), 1.1234f, true)
+                        .fromCase(DOUBLE(), 0.0d, false)
+                        .fromCase(DOUBLE(), -0.12345678d, true),
                 CastTestSpecBuilder.testCastTo(BINARY(2))
                         .fromCase(CHAR(3), StringData.fromString("foo"), new byte[] {102, 111, 111})
                         .fromCase(

--- a/flink-table/flink-table-runtime/src/main/java/org/apache/flink/table/data/DecimalDataUtils.java
+++ b/flink-table/flink-table-runtime/src/main/java/org/apache/flink/table/data/DecimalDataUtils.java
@@ -193,6 +193,10 @@ public final class DecimalDataUtils {
         return fromBigDecimal(BigDecimal.valueOf(val), p, s);
     }
 
+    public static boolean castToBoolean(DecimalData dec) {
+        return dec.toBigDecimal().compareTo(BigDecimal.ZERO) != 0;
+    }
+
     /**
      * SQL <code>SIGN</code> operator applied to BigDecimal values. preserve precision and scale.
      */

--- a/flink-table/flink-table-runtime/src/test/java/org/apache/flink/table/data/DecimalDataTest.java
+++ b/flink-table/flink-table-runtime/src/test/java/org/apache/flink/table/data/DecimalDataTest.java
@@ -25,6 +25,7 @@ import java.math.BigDecimal;
 import static org.apache.flink.table.data.DecimalDataUtils.abs;
 import static org.apache.flink.table.data.DecimalDataUtils.add;
 import static org.apache.flink.table.data.DecimalDataUtils.castFrom;
+import static org.apache.flink.table.data.DecimalDataUtils.castToBoolean;
 import static org.apache.flink.table.data.DecimalDataUtils.castToDecimal;
 import static org.apache.flink.table.data.DecimalDataUtils.castToIntegral;
 import static org.apache.flink.table.data.DecimalDataUtils.ceil;
@@ -97,6 +98,7 @@ public class DecimalDataTest {
                 divideToIntegralValue(decimal1, DecimalData.fromUnscaledLong(2, 5, 0), 5, 0)
                         .toUnscaledLong());
         assertEquals(10, castToIntegral(decimal1));
+        assertTrue(castToBoolean(decimal1));
         assertEquals(0, compare(decimal1, 10));
         assertTrue(compare(decimal1, 5) > 0);
         assertEquals(castFrom(1.0, 10, 5), sign(castFrom(5.556, 10, 5)));
@@ -156,6 +158,7 @@ public class DecimalDataTest {
                         .toBigDecimal()
                         .longValue());
         assertEquals(10, castToIntegral(decimal1));
+        assertTrue(castToBoolean(decimal1));
         assertEquals(0, compare(decimal1, 10));
         assertTrue(compare(decimal1, 5) > 0);
         assertTrue(compare(DecimalData.fromBigDecimal(new BigDecimal("10.5"), 20, 2), 10) > 0);


### PR DESCRIPTION
Since FLINK-24576 and the relevant CALCITE-4777 are still open, add back
the support to cast from decimal/float/double to a boolean with a comment
to remove in the future, pointing to that issue.

Follows: #17911

## Does this pull request potentially affect one of the following parts:

  - Dependencies (does it add or upgrade a dependency): **no**
  - The public API, i.e., is any changed class annotated with `@Public(Evolving)`: **no**
  - The serializers: **no**
  - The runtime per-record code paths (performance sensitive): **no**
  - Anything that affects deployment or recovery: JobManager (and its components), Checkpointing, Kubernetes/Yarn, ZooKeeper: **no**
  - The S3 file system connector: **no**

## Documentation

  - Does this pull request introduce a new feature? **no**
  - If yes, how is the feature documented? **not applicable**
