### PR TITLE
[FLINK-25138][Table SQL/Client] SQL Client improve completion for com…

### DIFF
--- a/docs/layouts/shortcodes/generated/sql_client_configuration.html
+++ b/docs/layouts/shortcodes/generated/sql_client_configuration.html
@@ -9,6 +9,12 @@
     </thead>
     <tbody>
         <tr>
+            <td><h5>sql-client.completion-description</h5><br> <span class="label label-primary">Streaming</span></td>
+            <td style="word-wrap: break-word;">false</td>
+            <td>Boolean</td>
+            <td>Determine whether Flink SQL Client should show description for autocompletion options.</td>
+        </tr>
+        <tr>
             <td><h5>sql-client.display.max-column-width</h5><br> <span class="label label-primary">Streaming</span></td>
             <td style="word-wrap: break-word;">30</td>
             <td>Integer</td>

--- a/flink-table/flink-sql-client/pom.xml
+++ b/flink-table/flink-sql-client/pom.xml
@@ -94,13 +94,13 @@ under the License.
 		<dependency>
 			<groupId>org.jline</groupId>
 			<artifactId>jline-terminal</artifactId>
-			<version>3.9.0</version>
+			<version>3.21.0</version>
 		</dependency>
 
 		<dependency>
 			<groupId>org.jline</groupId>
 			<artifactId>jline-reader</artifactId>
-			<version>3.9.0</version>
+			<version>3.21.0</version>
 		</dependency>
 
 		<!-- configuration -->

--- a/flink-table/flink-sql-client/src/main/java/org/apache/flink/table/client/cli/CliClient.java
+++ b/flink-table/flink-sql-client/src/main/java/org/apache/flink/table/client/cli/CliClient.java
@@ -685,7 +685,7 @@ public class CliClient implements AutoCloseable {
                         .terminal(terminal)
                         .appName(CliStrings.CLI_NAME)
                         .parser(new SqlMultiLineParser())
-                        .completer(new SqlCompleter(sessionId, executor))
+                        .completer(new FlinkSqlCompleter(sessionId, executor))
                         .build();
         // this option is disabled for now for correct backslash escaping
         // a "SELECT '\'" query should return a string with a backslash

--- a/flink-table/flink-sql-client/src/main/java/org/apache/flink/table/client/cli/CliCommandAggregateCompleter.java
+++ b/flink-table/flink-sql-client/src/main/java/org/apache/flink/table/client/cli/CliCommandAggregateCompleter.java
@@ -1,0 +1,139 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.flink.table.client.cli;
+
+import org.apache.flink.table.client.config.SqlClientOptions;
+import org.apache.flink.table.client.gateway.Executor;
+
+import org.jline.reader.Candidate;
+import org.jline.reader.Completer;
+import org.jline.reader.impl.completer.AggregateCompleter;
+import org.jline.reader.impl.completer.ArgumentCompleter;
+import org.jline.reader.impl.completer.NullCompleter;
+import org.jline.reader.impl.completer.StringsCompleter;
+
+import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.EnumMap;
+import java.util.HashSet;
+import java.util.List;
+import java.util.Map;
+import java.util.Set;
+
+/**
+ * Completer which contains multiple Flink SQL CLI command completers and aggregates them together.
+ */
+public class CliCommandAggregateCompleter extends AggregateCompleter {
+    private final Map<CliStrings.SQLCliCommandsDescriptions, List<Completer>>
+            command2dynamicCompleters = new EnumMap<>(CliStrings.SQLCliCommandsDescriptions.class);
+
+    public CliCommandAggregateCompleter(String sessionId, Executor executor) {
+        super(new ArrayList<>());
+        initDynamicCompleter(sessionId, executor);
+        List<Completer> completers = new ArrayList<>();
+
+        for (CliStrings.SQLCliCommandsDescriptions command :
+                CliStrings.SQLCliCommandsDescriptions.values()) {
+            Set<String> names = new HashSet<>();
+            names.add(command.getName());
+            names.addAll(command.getOtherNames());
+            for (String name : names) {
+                List<Completer> compl = new ArrayList<>();
+                for (String part : name.split("\\s+")) {
+                    int semicolonPos = part.lastIndexOf(';');
+                    compl.add(
+                            new StringsCompleter(
+                                    new FlinkCliCandidate(
+                                            sessionId,
+                                            executor,
+                                            part,
+                                            // for some command it makes sense to complete with ;
+                                            // at the end however do not show it during completion
+                                            // suggestion
+                                            semicolonPos == part.length() - 1
+                                                    ? part.substring(0, semicolonPos)
+                                                    : part,
+                                            null,
+                                            command.getDescription(),
+                                            null,
+                                            // for equal command key should be same, e.g. QUIT and
+                                            // EXIT
+                                            name.indexOf(' ') == -1
+                                                    ? command.getName()
+                                                    : command.getName().replace(' ', '_')
+                                                            + "_"
+                                                            + part,
+                                            true)));
+                }
+
+                if (command2dynamicCompleters.get(command) != null) {
+                    compl.addAll(command2dynamicCompleters.get(command));
+                }
+                compl.add(new NullCompleter());
+                completers.add(new ArgumentCompleter(compl));
+            }
+        }
+        getCompleters().addAll(completers);
+    }
+
+    // In case completers require runtime info from executor then here it is a place to define them
+    private void initDynamicCompleter(String sessionId, Executor executor) {
+        command2dynamicCompleters.put(
+                CliStrings.SQLCliCommandsDescriptions.RESET,
+                Arrays.asList(
+                        new PropertyKeyCompleter(sessionId, executor), new StringsCompleter("=")));
+        command2dynamicCompleters.put(
+                CliStrings.SQLCliCommandsDescriptions.SET,
+                Arrays.asList(
+                        new PropertyKeyCompleter(sessionId, executor), new StringsCompleter("=")));
+    }
+
+    /**
+     * Completer candidate which shows/doesn't show description depending on {@code
+     * SqlClientOptions.SHOW_COMPLETION_DESCRIPTION} option value.
+     */
+    public static class FlinkCliCandidate extends Candidate {
+        private final Executor executor;
+        private final String sessionId;
+
+        FlinkCliCandidate(
+                String sessionId,
+                Executor executor,
+                String value,
+                String displ,
+                String group,
+                String descr,
+                String suffix,
+                String key,
+                boolean complete) {
+            super(value, displ, group, descr, suffix, key, complete);
+            this.executor = executor;
+            this.sessionId = sessionId;
+        }
+
+        @Override
+        public String descr() {
+            if (executor.getSessionConfig(sessionId)
+                    .get(SqlClientOptions.SHOW_COMPLETION_DESCRIPTION)) {
+                return super.descr();
+            }
+            return null;
+        }
+    }
+}

--- a/flink-table/flink-sql-client/src/main/java/org/apache/flink/table/client/cli/FlinkSqlCompleter.java
+++ b/flink-table/flink-sql-client/src/main/java/org/apache/flink/table/client/cli/FlinkSqlCompleter.java
@@ -1,0 +1,62 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.flink.table.client.cli;
+
+import org.apache.flink.table.client.gateway.Executor;
+
+import org.jline.reader.Buffer;
+import org.jline.reader.Candidate;
+import org.jline.reader.Completer;
+import org.jline.reader.LineReader;
+import org.jline.reader.ParsedLine;
+
+import java.util.List;
+
+/** Completer which aggregates SQL and command completers. */
+public class FlinkSqlCompleter implements Completer {
+
+    private final SqlCompleter sqlCompleter;
+    private final CliCommandAggregateCompleter cliCommandAggregateCompleter;
+
+    public FlinkSqlCompleter(String sessionId, Executor executor) {
+        sqlCompleter = new SqlCompleter(sessionId, executor);
+        cliCommandAggregateCompleter = new CliCommandAggregateCompleter(sessionId, executor);
+    }
+
+    @Override
+    public void complete(LineReader reader, ParsedLine line, List<Candidate> candidates) {
+        int i = 0;
+        Buffer buffer = reader.getBuffer();
+        while (i < buffer.length() && Character.isWhitespace(buffer.atChar(i))) {
+            i++;
+        }
+        StringBuilder firstWord = new StringBuilder();
+        while (i < buffer.length() && !Character.isWhitespace(buffer.atChar(i))) {
+            firstWord.append((char) buffer.atChar(i));
+            i++;
+        }
+        String string = firstWord.toString();
+
+        final Completer completer =
+                (string.isEmpty() || CliStrings.SQLCliCommandsDescriptions.isCommand(string))
+                        ? cliCommandAggregateCompleter
+                        : sqlCompleter;
+        completer.complete(reader, line, candidates);
+    }
+}

--- a/flink-table/flink-sql-client/src/main/java/org/apache/flink/table/client/cli/PropertyKeyCompleter.java
+++ b/flink-table/flink-sql-client/src/main/java/org/apache/flink/table/client/cli/PropertyKeyCompleter.java
@@ -1,0 +1,48 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.flink.table.client.cli;
+
+import org.apache.flink.table.client.gateway.Executor;
+
+import org.jline.reader.Candidate;
+import org.jline.reader.Completer;
+import org.jline.reader.LineReader;
+import org.jline.reader.ParsedLine;
+
+import java.util.List;
+import java.util.Set;
+
+/** tse. */
+public class PropertyKeyCompleter implements Completer {
+    private final String sessionId;
+    private final Executor executor;
+
+    public PropertyKeyCompleter(String sessionId, Executor executor) {
+        this.sessionId = sessionId;
+        this.executor = executor;
+    }
+
+    @Override
+    public void complete(LineReader reader, ParsedLine line, List<Candidate> candidates) {
+        Set<String> set = executor.getSessionConfigMap(sessionId).keySet();
+        for (String str : set) {
+            candidates.add(new Candidate("'" + str + "'"));
+        }
+    }
+}

--- a/flink-table/flink-sql-client/src/main/java/org/apache/flink/table/client/cli/PropertyKeyCompleter.java
+++ b/flink-table/flink-sql-client/src/main/java/org/apache/flink/table/client/cli/PropertyKeyCompleter.java
@@ -28,7 +28,7 @@ import org.jline.reader.ParsedLine;
 import java.util.List;
 import java.util.Set;
 
-/** tse. */
+/** Completer to complete property keys based on information from session config. */
 public class PropertyKeyCompleter implements Completer {
     private final String sessionId;
     private final Executor executor;

--- a/flink-table/flink-sql-client/src/main/java/org/apache/flink/table/client/config/SqlClientOptions.java
+++ b/flink-table/flink-sql-client/src/main/java/org/apache/flink/table/client/config/SqlClientOptions.java
@@ -63,4 +63,12 @@ public class SqlClientOptions {
                             "When printing the query results, this parameter determines the number of characters shown on screen before truncating."
                                     + "This only applies to columns with variable-length types (e.g. STRING) in streaming mode."
                                     + "Fixed-length types and all types in batch mode are printed using a deterministic column width");
+
+    @Documentation.TableOption(execMode = Documentation.ExecMode.STREAMING)
+    public static final ConfigOption<Boolean> SHOW_COMPLETION_DESCRIPTION =
+            ConfigOptions.key("sql-client.completion-description")
+                    .booleanType()
+                    .defaultValue(false)
+                    .withDescription(
+                            "Determine whether Flink SQL Client should show description for autocompletion options.");
 }

--- a/flink-table/flink-sql-client/src/main/resources/META-INF/NOTICE
+++ b/flink-table/flink-sql-client/src/main/resources/META-INF/NOTICE
@@ -7,5 +7,5 @@ The Apache Software Foundation (http://www.apache.org/).
 This project bundles the following dependencies under the BSD license.
 See bundled license files for details.
 
-- org.jline:jline-terminal:3.9.0
-- org.jline:jline-reader:3.9.0
+- org.jline:jline-terminal:3.21.0
+- org.jline:jline-reader:3.21.0

--- a/flink-table/flink-sql-client/src/test/java/org/apache/flink/table/client/SqlClientTest.java
+++ b/flink-table/flink-sql-client/src/test/java/org/apache/flink/table/client/SqlClientTest.java
@@ -23,6 +23,7 @@ import org.apache.flink.table.client.cli.TerminalUtils;
 import org.apache.flink.util.FileUtils;
 
 import org.jline.terminal.Terminal;
+import org.jline.utils.AttributedString;
 import org.junit.After;
 import org.junit.Before;
 import org.junit.Rule;
@@ -196,7 +197,7 @@ public class SqlClientTest {
         List<String> statements = Collections.singletonList("HELP;\n");
         String sqlFilePath = createSqlFile(statements, "test-sql.sql");
         String[] args = new String[] {"-f", sqlFilePath};
-        String output = runSqlClient(args);
+        String output = AttributedString.stripAnsi(runSqlClient(args));
         final URL url = getClass().getClassLoader().getResource("sql-client-help-command.out");
         final String help = FileUtils.readFileUtf8(new File(url.getFile()));
 

--- a/flink-table/flink-sql-client/src/test/java/org/apache/flink/table/client/cli/CliClientITCase.java
+++ b/flink-table/flink-sql-client/src/test/java/org/apache/flink/table/client/cli/CliClientITCase.java
@@ -36,6 +36,7 @@ import org.apache.commons.lang3.StringUtils;
 import org.jline.reader.MaskingCallback;
 import org.jline.terminal.Terminal;
 import org.jline.terminal.impl.DumbTerminal;
+import org.jline.utils.AttributedString;
 import org.junit.Before;
 import org.junit.BeforeClass;
 import org.junit.ClassRule;
@@ -131,7 +132,7 @@ public class CliClientITCase extends AbstractTestBase {
         List<String> sqlStatements =
                 testSqlStatements.stream().map(s -> s.sql).collect(Collectors.toList());
         List<Result> actualResults = runSqlStatements(sqlStatements);
-        String out = transformOutput(testSqlStatements, actualResults);
+        String out = AttributedString.stripAnsi(transformOutput(testSqlStatements, actualResults));
         String errorMsg = "SQL script " + sqlPath + " is not passed.";
         assertEquals(errorMsg, in, out);
     }

--- a/flink-table/flink-sql-client/src/test/resources/sql-client-help-command.out
+++ b/flink-table/flink-sql-client/src/test/resources/sql-client-help-command.out
@@ -1,19 +1,29 @@
 The following commands are available:
 
-HELP               		Prints the available commands.
-QUIT/EXIT          		Quits the SQL CLI client.
-CLEAR              		Clears the current terminal.
-SET                		Sets a session configuration property. Syntax: "SET '<key>'='<value>';". Use "SET;" for listing all properties.
-RESET              		Resets a session configuration property. Syntax: "RESET '<key>';". Use "RESET;" for reset all session properties.
-INSERT INTO        		Inserts the results of a SQL SELECT query into a declared table sink.
-INSERT OVERWRITE   		Inserts the results of a SQL SELECT query into a declared table sink and overwrite existing data.
-SELECT             		Executes a SQL SELECT query on the Flink cluster.
-EXPLAIN            		Describes the execution plan of a query or table with the given name.
-BEGIN STATEMENT SET		Begins a statement set. Syntax: "BEGIN STATEMENT SET;"
-END                		Ends a statement set. Syntax: "END;"
-ADD JAR            		Adds the specified jar file to the submitted jobs' classloader. Syntax: "ADD JAR '<path_to_filename>.jar'"
-REMOVE JAR         		Removes the specified jar file from the submitted jobs' classloader. Syntax: "REMOVE JAR '<path_to_filename>.jar'"
-SHOW JARS          		Shows the list of user-specified jar dependencies. This list is impacted by the --jar and --library startup options as well as the ADD/REMOVE JAR commands.
+HELP                 		Prints the available commands.
+QUIT/EXIT            		Quits the SQL CLI client.
+CLEAR                		Clears the current terminal.
+SET                  		Sets a session configuration property. Syntax: "SET '<key>'='<value>';". Use "SET;" for listing all properties.
+RESET                		Resets a session configuration property. Syntax: "RESET '<key>';". Use "RESET;" for reset all session properties.
+INSERT INTO          		Inserts the results of a SQL SELECT query into a declared table sink.
+INSERT OVERWRITE     		Inserts the results of a SQL SELECT query into a declared table sink and overwrite existing data.
+SELECT               		Executes a SQL SELECT query on the Flink cluster.
+EXPLAIN              		Describes the execution plan of a query or table with the given name.
+BEGIN STATEMENT SET  		Begins a statement set. Syntax: "BEGIN STATEMENT SET;"
+END                  		Ends a statement set. Syntax: "END;"
+ADD JAR              		Adds the specified jar file to the submitted jobs' classloader. Syntax: "ADD JAR '<path_to_filename>.jar'"
+REMOVE JAR           		Removes the specified jar file from the submitted jobs' classloader. Syntax: "REMOVE JAR '<path_to_filename>.jar'"
+SHOW JARS            		Shows the list of user-specified jar dependencies. This list is impacted by the --jar and --library startup options as well as the ADD/REMOVE JAR commands.
+SHOW CATALOGS        		Show all catalogs.
+SHOW CURRENT CATALOG 		Show current catalog.
+SHOW DATABASES       		Show all databases in the current catalog.
+SHOW CURRENT DATABASE		Show current database.
+SHOW FUNCTIONS       		Show all functions including system functions and user-defined functions in the current catalog and current database.
+SHOW USER FUNCTIONS  		Show only user-defined functions in the current catalog and current database.
+SHOW TABLES          		Show all tables in the current catalog and the current database.
+SHOW VIEWS           		Show all views in the current catalog and the current database.
+SHOW MODULES         		Show all enabled module names with resolution order.
+SHOW FULL MODULES    		Show all loaded modules and enabled status with resolution order.
 
 Hint: Make sure that a statement ends with ";" for finalizing (multi-line) statements.
 You can also type any Flink SQL statement, please visit https://nightlies.apache.org/flink/flink-docs-stable/docs/dev/table/sql/overview/ for more details.

--- a/flink-table/flink-sql-client/src/test/resources/sql/misc.q
+++ b/flink-table/flink-sql-client/src/test/resources/sql/misc.q
@@ -19,20 +19,30 @@
 help;
 The following commands are available:
 
-HELP               		Prints the available commands.
-QUIT/EXIT          		Quits the SQL CLI client.
-CLEAR              		Clears the current terminal.
-SET                		Sets a session configuration property. Syntax: "SET '<key>'='<value>';". Use "SET;" for listing all properties.
-RESET              		Resets a session configuration property. Syntax: "RESET '<key>';". Use "RESET;" for reset all session properties.
-INSERT INTO        		Inserts the results of a SQL SELECT query into a declared table sink.
-INSERT OVERWRITE   		Inserts the results of a SQL SELECT query into a declared table sink and overwrite existing data.
-SELECT             		Executes a SQL SELECT query on the Flink cluster.
-EXPLAIN            		Describes the execution plan of a query or table with the given name.
-BEGIN STATEMENT SET		Begins a statement set. Syntax: "BEGIN STATEMENT SET;"
-END                		Ends a statement set. Syntax: "END;"
-ADD JAR            		Adds the specified jar file to the submitted jobs' classloader. Syntax: "ADD JAR '<path_to_filename>.jar'"
-REMOVE JAR         		Removes the specified jar file from the submitted jobs' classloader. Syntax: "REMOVE JAR '<path_to_filename>.jar'"
-SHOW JARS          		Shows the list of user-specified jar dependencies. This list is impacted by the --jar and --library startup options as well as the ADD/REMOVE JAR commands.
+HELP                 		Prints the available commands.
+QUIT/EXIT            		Quits the SQL CLI client.
+CLEAR                		Clears the current terminal.
+SET                  		Sets a session configuration property. Syntax: "SET '<key>'='<value>';". Use "SET;" for listing all properties.
+RESET                		Resets a session configuration property. Syntax: "RESET '<key>';". Use "RESET;" for reset all session properties.
+INSERT INTO          		Inserts the results of a SQL SELECT query into a declared table sink.
+INSERT OVERWRITE     		Inserts the results of a SQL SELECT query into a declared table sink and overwrite existing data.
+SELECT               		Executes a SQL SELECT query on the Flink cluster.
+EXPLAIN              		Describes the execution plan of a query or table with the given name.
+BEGIN STATEMENT SET  		Begins a statement set. Syntax: "BEGIN STATEMENT SET;"
+END                  		Ends a statement set. Syntax: "END;"
+ADD JAR              		Adds the specified jar file to the submitted jobs' classloader. Syntax: "ADD JAR '<path_to_filename>.jar'"
+REMOVE JAR           		Removes the specified jar file from the submitted jobs' classloader. Syntax: "REMOVE JAR '<path_to_filename>.jar'"
+SHOW JARS            		Shows the list of user-specified jar dependencies. This list is impacted by the --jar and --library startup options as well as the ADD/REMOVE JAR commands.
+SHOW CATALOGS        		Show all catalogs.
+SHOW CURRENT CATALOG 		Show current catalog.
+SHOW DATABASES       		Show all databases in the current catalog.
+SHOW CURRENT DATABASE		Show current database.
+SHOW FUNCTIONS       		Show all functions including system functions and user-defined functions in the current catalog and current database.
+SHOW USER FUNCTIONS  		Show only user-defined functions in the current catalog and current database.
+SHOW TABLES          		Show all tables in the current catalog and the current database.
+SHOW VIEWS           		Show all views in the current catalog and the current database.
+SHOW MODULES         		Show all enabled module names with resolution order.
+SHOW FULL MODULES    		Show all loaded modules and enabled status with resolution order.
 
 Hint: Make sure that a statement ends with ";" for finalizing (multi-line) statements.
 You can also type any Flink SQL statement, please visit https://nightlies.apache.org/flink/flink-docs-stable/docs/dev/table/sql/overview/ for more details.


### PR DESCRIPTION

## What is the purpose of the change

This is a part of FLIP-189 which improves completion of Flink SQL CLI command completion.

From user's side it looks like that 
https://asciinema.org/a/453046?speed=2.0

## Brief change log

It introduces `CliCommandAggregateCompleter` which could build completion for each command.
Also there has been introduced a `FlinkCliCandidate` which could show/hide completion description depending on a corresponding property value.

Another thing that is done here: introduction of `MockLineReaderImpl` in tests to allow tests of several words completion.

it includes update of jline as it is required for completion candidate description

## Verifying this change

There are tests in `CliClientTest#testSqlCompletion`

## Does this pull request potentially affect one of the following parts:

  - Dependencies (does it add or upgrade a dependency): (yes)   update of jline to 3.21.0
  - The public API, i.e., is any changed class annotated with `@Public(Evolving)`: (no)
  - The serializers: (no)
  - The runtime per-record code paths (performance sensitive): (no)
  - Anything that affects deployment or recovery: JobManager (and its components), Checkpointing, Kubernetes/Yarn, ZooKeeper: (no)
  - The S3 file system connector: (no)

## Documentation

  - Does this pull request introduce a new feature? (yes)
  - If yes, how is the feature documented? (docs)
