### PR TITLE
[FLINK-25071][parquet] SerializableConfiguration should not load resources

### DIFF
--- a/flink-formats/flink-parquet/src/main/java/org/apache/flink/formats/parquet/utils/SerializableConfiguration.java
+++ b/flink-formats/flink-parquet/src/main/java/org/apache/flink/formats/parquet/utils/SerializableConfiguration.java
@@ -30,7 +30,7 @@ public class SerializableConfiguration implements Serializable {
 
     private static final long serialVersionUID = 1L;
 
-    private Configuration conf;
+    private transient Configuration conf;
 
     public SerializableConfiguration(Configuration conf) {
         this.conf = conf;
@@ -41,13 +41,12 @@ public class SerializableConfiguration implements Serializable {
     }
 
     private void writeObject(ObjectOutputStream out) throws IOException {
+        out.defaultWriteObject();
         conf.write(out);
     }
 
     private void readObject(ObjectInputStream in) throws IOException, ClassNotFoundException {
-        if (conf == null) {
-            conf = new Configuration();
-        }
+        conf = new Configuration(false);
         conf.readFields(in);
     }
 }

--- a/flink-formats/flink-parquet/src/test/java/org/apache/flink/formats/parquet/ParquetFileSystemITCase.java
+++ b/flink-formats/flink-parquet/src/test/java/org/apache/flink/formats/parquet/ParquetFileSystemITCase.java
@@ -27,7 +27,6 @@ import org.apache.hadoop.conf.Configuration;
 import org.apache.hadoop.fs.Path;
 import org.apache.parquet.hadoop.metadata.ParquetMetadata;
 import org.junit.Assert;
-import org.junit.Ignore;
 import org.junit.Test;
 import org.junit.runner.RunWith;
 import org.junit.runners.Parameterized;
@@ -116,7 +115,6 @@ public class ParquetFileSystemITCase extends BatchFileSystemITCaseBase {
         }
     }
 
-    @Ignore
     @Test
     public void testLimitableBulkFormat() throws ExecutionException, InterruptedException {
         super.tableEnv()

--- a/flink-formats/flink-parquet/src/test/java/org/apache/flink/formats/parquet/utils/SerializableConfigurationTest.java
+++ b/flink-formats/flink-parquet/src/test/java/org/apache/flink/formats/parquet/utils/SerializableConfigurationTest.java
@@ -1,0 +1,49 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.flink.formats.parquet.utils;
+
+import org.apache.hadoop.conf.Configuration;
+import org.jetbrains.annotations.Nullable;
+import org.junit.Test;
+
+import java.io.IOException;
+import java.net.URL;
+
+import static org.apache.flink.util.InstantiationUtil.deserializeObject;
+import static org.apache.flink.util.InstantiationUtil.serializeObject;
+
+/** Test for {@link SerializableConfiguration}. */
+public class SerializableConfigurationTest {
+
+    @Test
+    public void testResource() throws IOException, ClassNotFoundException {
+        ClassLoader cl =
+                new ClassLoader(Thread.currentThread().getContextClassLoader()) {
+                    @Nullable
+                    @Override
+                    public URL getResource(String name) {
+                        throw new RuntimeException();
+                    }
+                };
+        SerializableConfiguration conf =
+                deserializeObject(
+                        serializeObject(new SerializableConfiguration(new Configuration())), cl);
+        conf.conf().getInt("one-key", 0);
+    }
+}


### PR DESCRIPTION
## What is the purpose of the change

SerializableConfiguration load resources from ClassLoader lead to many unstable tests:
https://issues.apache.org/jira/browse/FLINK-24763
https://issues.apache.org/jira/browse/FLINK-25102

But this is not necessary, because from serialization, the resources to be read are already serialized into properties.

## Brief change log

- SerializableConfiguration should not load resources
- Enable ParquetFileSystemITCase.testLimitableBulkFormat

## Verifying this change

`SerializableConfigurationTest`

## Does this pull request potentially affect one of the following parts:

  - Dependencies (does it add or upgrade a dependency): (yes / **no**)
  - The public API, i.e., is any changed class annotated with `@Public(Evolving)`: (yes / **no**)
  - The serializers: (yes / **no** / don't know)
  - The runtime per-record code paths (performance sensitive): (yes / **no** / don't know)
  - Anything that affects deployment or recovery: JobManager (and its components), Checkpointing, Kubernetes/Yarn, ZooKeeper: (yes / **no** / don't know)
  - The S3 file system connector: (yes / **no** / don't know)

## Documentation

  - Does this pull request introduce a new feature? (yes / **no**)