### PR TITLE
[FLINK-25010][Connectors/Hive] Speed up hive's createMRSplits by multi thread

### DIFF
--- a/docs/content.zh/docs/connectors/table/hive/hive_read_write.md
+++ b/docs/content.zh/docs/connectors/table/hive/hive_read_write.md
@@ -166,6 +166,10 @@ following parameters in `TableConfig` (note that these parameters affect all sou
   </tbody>
 </table>
 
+### Load Partition Splits
+
+Multi-thread is used to split hive's partitions. You can use `table.exec.hive.load-partition-splits.thread-num` to configure the thread number. The default value is 3 and the configured value should be bigger than 0.
+
 ## Temporal Table Join
 
 You can use a Hive table as a temporal table, and then a stream can correlate the Hive table by temporal join. 

--- a/docs/content/docs/connectors/table/hive/hive_read_write.md
+++ b/docs/content/docs/connectors/table/hive/hive_read_write.md
@@ -166,6 +166,10 @@ following parameters in `TableConfig` (note that these parameters affect all sou
   </tbody>
 </table>
 
+### Load Partition Splits
+
+Multi-thread is used to split hive's partitions. You can use `table.exec.hive.load-partition-splits.thread-num` to configure the thread number. The default value is 3 and the configured value should be bigger than 0.
+
 ## Temporal Table Join
 
 You can use a Hive table as a temporal table, and then a stream can correlate the Hive table by temporal join. 

--- a/flink-connectors/flink-connector-hive/src/main/java/org/apache/flink/connectors/hive/ContinuousHiveSplitEnumerator.java
+++ b/flink-connectors/flink-connector-hive/src/main/java/org/apache/flink/connectors/hive/ContinuousHiveSplitEnumerator.java
@@ -23,6 +23,7 @@ import org.apache.flink.api.connector.source.SourceEvent;
 import org.apache.flink.api.connector.source.SplitEnumerator;
 import org.apache.flink.api.connector.source.SplitEnumeratorContext;
 import org.apache.flink.api.java.tuple.Tuple2;
+import org.apache.flink.configuration.ReadableConfig;
 import org.apache.flink.connector.file.src.FileSourceSplit;
 import org.apache.flink.connector.file.src.PendingSplitsCheckpoint;
 import org.apache.flink.connector.file.src.assigners.FileSplitAssigner;
@@ -77,6 +78,7 @@ public class ContinuousHiveSplitEnumerator<T extends Comparable<T>>
             Collection<List<String>> seenPartitionsSinceOffset,
             FileSplitAssigner splitAssigner,
             long discoveryInterval,
+            ReadableConfig flinkConf,
             JobConf jobConf,
             ObjectPath tablePath,
             ContinuousPartitionFetcher<Partition, T> fetcher,
@@ -93,6 +95,7 @@ public class ContinuousHiveSplitEnumerator<T extends Comparable<T>>
                         currentReadOffset,
                         seenPartitionsSinceOffset,
                         tablePath,
+                        flinkConf,
                         jobConf,
                         fetcher,
                         fetcherContext);
@@ -185,6 +188,7 @@ public class ContinuousHiveSplitEnumerator<T extends Comparable<T>>
         private final Set<List<String>> seenPartitionsSinceOffset;
 
         private final ObjectPath tablePath;
+        private final ReadableConfig flinkConf;
         private final JobConf jobConf;
         private final ContinuousPartitionFetcher<Partition, T> fetcher;
         private final HiveContinuousPartitionContext<Partition, T> fetcherContext;
@@ -193,12 +197,14 @@ public class ContinuousHiveSplitEnumerator<T extends Comparable<T>>
                 T currentReadOffset,
                 Collection<List<String>> seenPartitionsSinceOffset,
                 ObjectPath tablePath,
+                ReadableConfig flinkConf,
                 JobConf jobConf,
                 ContinuousPartitionFetcher<Partition, T> fetcher,
                 HiveContinuousPartitionContext<Partition, T> fetcherContext) {
             this.currentReadOffset = currentReadOffset;
             this.seenPartitionsSinceOffset = new HashSet<>(seenPartitionsSinceOffset);
             this.tablePath = tablePath;
+            this.flinkConf = flinkConf;
             this.jobConf = jobConf;
             this.fetcher = fetcher;
             this.fetcherContext = fetcherContext;
@@ -238,6 +244,7 @@ public class ContinuousHiveSplitEnumerator<T extends Comparable<T>>
                                     0,
                                     Collections.singletonList(
                                             fetcherContext.toHiveTablePartition(partition)),
+                                    flinkConf,
                                     jobConf));
                 }
             }

--- a/flink-connectors/flink-connector-hive/src/main/java/org/apache/flink/connectors/hive/HiveLookupTableSource.java
+++ b/flink-connectors/flink-connector-hive/src/main/java/org/apache/flink/connectors/hive/HiveLookupTableSource.java
@@ -242,6 +242,7 @@ public class HiveLookupTableSource extends HiveTableSource implements LookupTabl
 
         PartitionReader<HiveTablePartition, RowData> partitionReader =
                 new HiveInputFormatPartitionReader(
+                        flinkConf,
                         jobConf,
                         hiveVersion,
                         tablePath,

--- a/flink-connectors/flink-connector-hive/src/main/java/org/apache/flink/connectors/hive/HiveOptions.java
+++ b/flink-connectors/flink-connector-hive/src/main/java/org/apache/flink/connectors/hive/HiveOptions.java
@@ -51,4 +51,11 @@ public class HiveOptions {
                     .withDescription(
                             "If it is false, using flink native writer to write parquet and orc files; "
                                     + "If it is true, using hadoop mapred record writer to write parquet and orc files.");
+
+    public static final ConfigOption<Integer> TABLE_EXEC_HIVE_PARTITION_SPLIT_THREAD_NUM =
+            key("table.exec.hive.partition-split.thread.num")
+                    .intType()
+                    .defaultValue(3)
+                    .withDescription(
+                            "The thread number to split hive's partitions to splits. It should be bigger than 0.");
 }

--- a/flink-connectors/flink-connector-hive/src/main/java/org/apache/flink/connectors/hive/HiveOptions.java
+++ b/flink-connectors/flink-connector-hive/src/main/java/org/apache/flink/connectors/hive/HiveOptions.java
@@ -52,8 +52,8 @@ public class HiveOptions {
                             "If it is false, using flink native writer to write parquet and orc files; "
                                     + "If it is true, using hadoop mapred record writer to write parquet and orc files.");
 
-    public static final ConfigOption<Integer> TABLE_EXEC_HIVE_PARTITION_SPLIT_THREAD_NUM =
-            key("table.exec.hive.partition-split.thread.num")
+    public static final ConfigOption<Integer> TABLE_EXEC_HIVE_LOAD_PARTITION_SPLITS_THREAD_NUM =
+            key("table.exec.hive.load-partition-splits.thread-num")
                     .intType()
                     .defaultValue(3)
                     .withDescription(

--- a/flink-connectors/flink-connector-hive/src/main/java/org/apache/flink/connectors/hive/HiveSource.java
+++ b/flink-connectors/flink-connector-hive/src/main/java/org/apache/flink/connectors/hive/HiveSource.java
@@ -22,6 +22,7 @@ import org.apache.flink.annotation.PublicEvolving;
 import org.apache.flink.api.connector.source.Boundedness;
 import org.apache.flink.api.connector.source.SplitEnumerator;
 import org.apache.flink.api.connector.source.SplitEnumeratorContext;
+import org.apache.flink.configuration.ReadableConfig;
 import org.apache.flink.connector.file.src.AbstractFileSource;
 import org.apache.flink.connector.file.src.ContinuousEnumerationSettings;
 import org.apache.flink.connector.file.src.PendingSplitsCheckpoint;
@@ -59,6 +60,7 @@ public class HiveSource<T> extends AbstractFileSource<T, HiveSourceSplit> {
 
     private static final long serialVersionUID = 1L;
 
+    private final ReadableConfig flinkConf;
     private final JobConfWrapper jobConfWrapper;
     private final List<String> partitionKeys;
     private final ContinuousPartitionFetcher<Partition, ?> fetcher;
@@ -71,6 +73,7 @@ public class HiveSource<T> extends AbstractFileSource<T, HiveSourceSplit> {
             FileSplitAssigner.Provider splitAssigner,
             BulkFormat<T, HiveSourceSplit> readerFormat,
             @Nullable ContinuousEnumerationSettings continuousEnumerationSettings,
+            ReadableConfig flinkConf,
             JobConf jobConf,
             ObjectPath tablePath,
             List<String> partitionKeys,
@@ -82,6 +85,11 @@ public class HiveSource<T> extends AbstractFileSource<T, HiveSourceSplit> {
                 splitAssigner,
                 readerFormat,
                 continuousEnumerationSettings);
+        Preconditions.checkArgument(
+                flinkConf.get(HiveOptions.TABLE_EXEC_HIVE_PARTITION_SPLIT_THREAD_NUM) >= 1,
+                HiveOptions.TABLE_EXEC_HIVE_PARTITION_SPLIT_THREAD_NUM.key()
+                        + " cannot be less than 1");
+        this.flinkConf = flinkConf;
         this.jobConfWrapper = new JobConfWrapper(jobConf);
         this.tablePath = tablePath;
         this.partitionKeys = partitionKeys;
@@ -156,6 +164,7 @@ public class HiveSource<T> extends AbstractFileSource<T, HiveSourceSplit> {
                 seenPartitions,
                 getAssignerFactory().create(new ArrayList<>(splits)),
                 getContinuousEnumerationSettings().getDiscoveryInterval().toMillis(),
+                flinkConf,
                 jobConfWrapper.conf(),
                 tablePath,
                 fetcher,

--- a/flink-connectors/flink-connector-hive/src/main/java/org/apache/flink/connectors/hive/HiveSource.java
+++ b/flink-connectors/flink-connector-hive/src/main/java/org/apache/flink/connectors/hive/HiveSource.java
@@ -86,8 +86,8 @@ public class HiveSource<T> extends AbstractFileSource<T, HiveSourceSplit> {
                 readerFormat,
                 continuousEnumerationSettings);
         Preconditions.checkArgument(
-                flinkConf.get(HiveOptions.TABLE_EXEC_HIVE_PARTITION_SPLIT_THREAD_NUM) >= 1,
-                HiveOptions.TABLE_EXEC_HIVE_PARTITION_SPLIT_THREAD_NUM.key()
+                flinkConf.get(HiveOptions.TABLE_EXEC_HIVE_LOAD_PARTITION_SPLITS_THREAD_NUM) >= 1,
+                HiveOptions.TABLE_EXEC_HIVE_LOAD_PARTITION_SPLITS_THREAD_NUM.key()
                         + " cannot be less than 1");
         this.flinkConf = flinkConf;
         this.jobConfWrapper = new JobConfWrapper(jobConf);

--- a/flink-connectors/flink-connector-hive/src/main/java/org/apache/flink/connectors/hive/HiveSourceBuilder.java
+++ b/flink-connectors/flink-connector-hive/src/main/java/org/apache/flink/connectors/hive/HiveSourceBuilder.java
@@ -232,10 +232,12 @@ public class HiveSourceBuilder {
                 new Path[1],
                 new HiveSourceFileEnumerator.Provider(
                         partitions != null ? partitions : Collections.emptyList(),
+                        flinkConf,
                         new JobConfWrapper(jobConf)),
                 splitAssigner,
                 bulkFormat,
                 continuousSourceSettings,
+                flinkConf,
                 jobConf,
                 tablePath,
                 partitionKeys,

--- a/flink-connectors/flink-connector-hive/src/main/java/org/apache/flink/connectors/hive/HiveSourceFileEnumerator.java
+++ b/flink-connectors/flink-connector-hive/src/main/java/org/apache/flink/connectors/hive/HiveSourceFileEnumerator.java
@@ -70,7 +70,8 @@ public class HiveSourceFileEnumerator implements FileEnumerator {
         List<HiveSourceSplit> hiveSplits = new ArrayList<>();
         try (MRSplitsGetter splitsGetter =
                 new MRSplitsGetter(
-                        flinkConf.get(HiveOptions.TABLE_EXEC_HIVE_PARTITION_SPLIT_THREAD_NUM))) {
+                        flinkConf.get(
+                                HiveOptions.TABLE_EXEC_HIVE_LOAD_PARTITION_SPLITS_THREAD_NUM))) {
             for (HiveTablePartitionSplits partitionSplits :
                     splitsGetter.getHiveTablePartitionMRSplits(minNumSplits, partitions, jobConf)) {
                 HiveTablePartition partition = partitionSplits.getHiveTablePartition();

--- a/flink-connectors/flink-connector-hive/src/main/java/org/apache/flink/connectors/hive/HiveSourceFileEnumerator.java
+++ b/flink-connectors/flink-connector-hive/src/main/java/org/apache/flink/connectors/hive/HiveSourceFileEnumerator.java
@@ -18,6 +18,7 @@
 
 package org.apache.flink.connectors.hive;
 
+import org.apache.flink.configuration.ReadableConfig;
 import org.apache.flink.connector.file.src.FileSourceSplit;
 import org.apache.flink.connector.file.src.enumerate.FileEnumerator;
 import org.apache.flink.connectors.hive.read.HiveSourceSplit;
@@ -27,18 +28,13 @@ import org.apache.flink.util.Preconditions;
 import org.apache.hadoop.fs.FileSystem;
 import org.apache.hadoop.hive.metastore.api.StorageDescriptor;
 import org.apache.hadoop.mapred.FileSplit;
-import org.apache.hadoop.mapred.InputFormat;
 import org.apache.hadoop.mapred.InputSplit;
 import org.apache.hadoop.mapred.JobConf;
-import org.apache.hadoop.util.ReflectionUtils;
-import org.apache.hadoop.util.StringUtils;
 
 import java.io.IOException;
 import java.util.ArrayList;
 import java.util.Collection;
 import java.util.List;
-
-import static org.apache.hadoop.mapreduce.lib.input.FileInputFormat.INPUT_DIR;
 
 /**
  * A {@link FileEnumerator} implementation for hive source, which generates splits based on {@link
@@ -49,62 +45,45 @@ public class HiveSourceFileEnumerator implements FileEnumerator {
     // For non-partition hive table, partitions only contains one partition which partitionValues is
     // empty.
     private final List<HiveTablePartition> partitions;
+    private final ReadableConfig flinkConf;
     private final JobConf jobConf;
 
-    public HiveSourceFileEnumerator(List<HiveTablePartition> partitions, JobConf jobConf) {
+    public HiveSourceFileEnumerator(
+            List<HiveTablePartition> partitions, ReadableConfig flinkConf, JobConf jobConf) {
         this.partitions = partitions;
+        this.flinkConf = flinkConf;
         this.jobConf = jobConf;
     }
 
     @Override
     public Collection<FileSourceSplit> enumerateSplits(Path[] paths, int minDesiredSplits)
             throws IOException {
-        return new ArrayList<>(createInputSplits(minDesiredSplits, partitions, jobConf));
+        return new ArrayList<>(createInputSplits(minDesiredSplits, partitions, flinkConf, jobConf));
     }
 
     public static List<HiveSourceSplit> createInputSplits(
-            int minNumSplits, List<HiveTablePartition> partitions, JobConf jobConf)
+            int minNumSplits,
+            List<HiveTablePartition> partitions,
+            ReadableConfig flinkConf,
+            JobConf jobConf)
             throws IOException {
         List<HiveSourceSplit> hiveSplits = new ArrayList<>();
-        for (HiveTablePartition partition : partitions) {
-            for (InputSplit inputSplit :
-                    createMRSplits(minNumSplits, partition.getStorageDescriptor(), jobConf)) {
-                Preconditions.checkState(
-                        inputSplit instanceof FileSplit,
-                        "Unsupported InputSplit type: " + inputSplit.getClass().getName());
-                hiveSplits.add(new HiveSourceSplit((FileSplit) inputSplit, partition, null));
+        try (MRSplitsGetter splitsGetter =
+                new MRSplitsGetter(
+                        flinkConf.get(HiveOptions.TABLE_EXEC_HIVE_PARTITION_SPLIT_THREAD_NUM))) {
+            for (HiveTablePartitionSplits partitionSplits :
+                    splitsGetter.getHiveTablePartitionMRSplits(minNumSplits, partitions, jobConf)) {
+                HiveTablePartition partition = partitionSplits.getHiveTablePartition();
+                for (InputSplit inputSplit : partitionSplits.getInputSplits()) {
+                    Preconditions.checkState(
+                            inputSplit instanceof FileSplit,
+                            "Unsupported InputSplit type: " + inputSplit.getClass().getName());
+                    hiveSplits.add(new HiveSourceSplit((FileSplit) inputSplit, partition, null));
+                }
             }
         }
 
         return hiveSplits;
-    }
-
-    public static InputSplit[] createMRSplits(
-            int minNumSplits, StorageDescriptor sd, JobConf jobConf) throws IOException {
-        org.apache.hadoop.fs.Path inputPath = new org.apache.hadoop.fs.Path(sd.getLocation());
-        FileSystem fs = inputPath.getFileSystem(jobConf);
-        // it's possible a partition exists in metastore but the data has been removed
-        if (!fs.exists(inputPath)) {
-            return new InputSplit[0];
-        }
-        InputFormat format;
-        try {
-            format =
-                    (InputFormat)
-                            Class.forName(
-                                            sd.getInputFormat(),
-                                            true,
-                                            Thread.currentThread().getContextClassLoader())
-                                    .newInstance();
-        } catch (Exception e) {
-            throw new FlinkHiveException("Unable to instantiate the hadoop input format", e);
-        }
-        ReflectionUtils.setConf(format, jobConf);
-        // need to escape comma in the location path
-        jobConf.set(INPUT_DIR, StringUtils.escapeString(sd.getLocation()));
-        // TODO: we should consider how to calculate the splits according to minNumSplits in the
-        // future.
-        return format.getSplits(jobConf, minNumSplits);
     }
 
     public static int getNumFiles(List<HiveTablePartition> partitions, JobConf jobConf)
@@ -129,16 +108,21 @@ public class HiveSourceFileEnumerator implements FileEnumerator {
         private static final long serialVersionUID = 1L;
 
         private final List<HiveTablePartition> partitions;
+        private final ReadableConfig flinkConf;
         private final JobConfWrapper jobConfWrapper;
 
-        public Provider(List<HiveTablePartition> partitions, JobConfWrapper jobConfWrapper) {
+        public Provider(
+                List<HiveTablePartition> partitions,
+                ReadableConfig flinkConf,
+                JobConfWrapper jobConfWrapper) {
             this.partitions = partitions;
+            this.flinkConf = flinkConf;
             this.jobConfWrapper = jobConfWrapper;
         }
 
         @Override
         public FileEnumerator create() {
-            return new HiveSourceFileEnumerator(partitions, jobConfWrapper.conf());
+            return new HiveSourceFileEnumerator(partitions, flinkConf, jobConfWrapper.conf());
         }
     }
 }

--- a/flink-connectors/flink-connector-hive/src/main/java/org/apache/flink/connectors/hive/HiveTablePartitionSplits.java
+++ b/flink-connectors/flink-connector-hive/src/main/java/org/apache/flink/connectors/hive/HiveTablePartitionSplits.java
@@ -1,0 +1,48 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.flink.connectors.hive;
+
+import org.apache.hadoop.mapred.InputSplit;
+import org.apache.hadoop.mapred.JobConf;
+
+/** Wrap HiveTablePartition, JobConf and the corresponding inputSplits. */
+public class HiveTablePartitionSplits {
+    private final HiveTablePartition hiveTablePartition;
+    private final JobConf jobConf;
+    private final InputSplit[] inputSplits;
+
+    public HiveTablePartitionSplits(
+            HiveTablePartition hiveTablePartition, JobConf jobConf, InputSplit[] inputSplits) {
+        this.hiveTablePartition = hiveTablePartition;
+        this.jobConf = jobConf;
+        this.inputSplits = inputSplits;
+    }
+
+    public HiveTablePartition getHiveTablePartition() {
+        return hiveTablePartition;
+    }
+
+    public JobConf getJobConf() {
+        return jobConf;
+    }
+
+    public InputSplit[] getInputSplits() {
+        return inputSplits;
+    }
+}

--- a/flink-connectors/flink-connector-hive/src/main/java/org/apache/flink/connectors/hive/HiveTableSource.java
+++ b/flink-connectors/flink-connector-hive/src/main/java/org/apache/flink/connectors/hive/HiveTableSource.java
@@ -147,7 +147,10 @@ public class HiveTableSource
                                                     hivePartitionsToRead, jobConf),
                                     () ->
                                             HiveSourceFileEnumerator.createInputSplits(
-                                                            0, hivePartitionsToRead, jobConf)
+                                                            0,
+                                                            hivePartitionsToRead,
+                                                            flinkConf,
+                                                            jobConf)
                                                     .size())
                             .limit(limit);
             return toDataStreamSource(

--- a/flink-connectors/flink-connector-hive/src/main/java/org/apache/flink/connectors/hive/MRSplitsGetter.java
+++ b/flink-connectors/flink-connector-hive/src/main/java/org/apache/flink/connectors/hive/MRSplitsGetter.java
@@ -1,0 +1,142 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.flink.connectors.hive;
+
+import org.apache.hadoop.fs.FileSystem;
+import org.apache.hadoop.hive.metastore.api.StorageDescriptor;
+import org.apache.hadoop.mapred.InputFormat;
+import org.apache.hadoop.mapred.InputSplit;
+import org.apache.hadoop.mapred.JobConf;
+import org.apache.hadoop.util.ReflectionUtils;
+import org.apache.hadoop.util.StringUtils;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import java.io.Closeable;
+import java.io.IOException;
+import java.util.ArrayList;
+import java.util.List;
+import java.util.concurrent.Callable;
+import java.util.concurrent.ExecutionException;
+import java.util.concurrent.ExecutorService;
+import java.util.concurrent.Executors;
+import java.util.concurrent.Future;
+
+import static org.apache.flink.util.concurrent.Executors.newDirectExecutorService;
+import static org.apache.hadoop.mapreduce.lib.input.FileInputFormat.INPUT_DIR;
+
+/** Create MR splits by multi-thread for hive partitions. */
+public class MRSplitsGetter implements Closeable {
+    private static final Logger LOG = LoggerFactory.getLogger(MRSplitsGetter.class);
+
+    private final ExecutorService executorService;
+
+    public MRSplitsGetter(int threadNum) {
+        if (threadNum > 1) {
+            executorService = Executors.newFixedThreadPool(threadNum);
+        } else if (threadNum == 1) {
+            executorService = newDirectExecutorService();
+        } else {
+            throw new IllegalArgumentException(
+                    "The thread number to create hive partition splits cannot be less than 1");
+        }
+        LOG.info("Open {} threads to create hive partition splits.", threadNum);
+    }
+
+    public List<HiveTablePartitionSplits> getHiveTablePartitionMRSplits(
+            int minNumSplits, List<HiveTablePartition> partitions, JobConf jobConf)
+            throws IOException {
+        LOG.info("Begin to create MR splits.");
+        long startTime = System.currentTimeMillis();
+
+        final List<Future<HiveTablePartitionSplits>> futures = new ArrayList<>();
+        for (HiveTablePartition partition : partitions) {
+            futures.add(
+                    executorService.submit(
+                            new MRSplitter(minNumSplits, partition, new JobConf(jobConf))));
+        }
+
+        int splitNum = 0;
+        List<HiveTablePartitionSplits> hiveTablePartitionSplitsList = new ArrayList<>();
+        try {
+            for (Future<HiveTablePartitionSplits> future : futures) {
+                HiveTablePartitionSplits hiveTablePartitionSplits = future.get();
+                splitNum += hiveTablePartitionSplits.getInputSplits().length;
+                hiveTablePartitionSplitsList.add(hiveTablePartitionSplits);
+            }
+        } catch (InterruptedException | ExecutionException e) {
+            throw new IOException("Fail to create input splits.", e);
+        }
+
+        LOG.info(
+                "It took {} seconds to create {} MR splits for {} hive partitions.",
+                (System.currentTimeMillis() - startTime) / 1000,
+                splitNum,
+                partitions.size());
+
+        return hiveTablePartitionSplitsList;
+    }
+
+    private static class MRSplitter implements Callable<HiveTablePartitionSplits> {
+        private final int minNumSplits;
+        private final HiveTablePartition partition;
+        private final JobConf jobConf;
+
+        public MRSplitter(int minNumSplits, HiveTablePartition partition, JobConf jobConf) {
+            this.minNumSplits = minNumSplits;
+            this.partition = partition;
+            this.jobConf = jobConf;
+        }
+
+        @Override
+        public HiveTablePartitionSplits call() throws Exception {
+            StorageDescriptor sd = partition.getStorageDescriptor();
+            org.apache.hadoop.fs.Path inputPath = new org.apache.hadoop.fs.Path(sd.getLocation());
+            FileSystem fs = inputPath.getFileSystem(jobConf);
+            // it's possible a partition exists in metastore but the data has been removed
+            if (!fs.exists(inputPath)) {
+                return new HiveTablePartitionSplits(partition, jobConf, new InputSplit[0]);
+            }
+            InputFormat format;
+            try {
+                format =
+                        (InputFormat)
+                                Class.forName(
+                                                sd.getInputFormat(),
+                                                true,
+                                                Thread.currentThread().getContextClassLoader())
+                                        .newInstance();
+            } catch (Exception e) {
+                throw new FlinkHiveException("Unable to instantiate the hadoop input format", e);
+            }
+            ReflectionUtils.setConf(format, jobConf);
+            // need to escape comma in the location path
+            jobConf.set(INPUT_DIR, StringUtils.escapeString(sd.getLocation()));
+            // TODO: we should consider how to calculate the splits according to minNumSplits in the
+            // future.
+            return new HiveTablePartitionSplits(
+                    partition, jobConf, format.getSplits(jobConf, minNumSplits));
+        }
+    }
+
+    @Override
+    public void close() throws IOException {
+        executorService.shutdownNow();
+    }
+}

--- a/flink-connectors/flink-connector-hive/src/main/java/org/apache/flink/connectors/hive/read/HiveInputFormatPartitionReader.java
+++ b/flink-connectors/flink-connector-hive/src/main/java/org/apache/flink/connectors/hive/read/HiveInputFormatPartitionReader.java
@@ -18,6 +18,7 @@
 
 package org.apache.flink.connectors.hive.read;
 
+import org.apache.flink.configuration.ReadableConfig;
 import org.apache.flink.connector.file.table.PartitionReader;
 import org.apache.flink.connectors.hive.HiveTablePartition;
 import org.apache.flink.connectors.hive.JobConfWrapper;
@@ -35,6 +36,7 @@ public class HiveInputFormatPartitionReader
         implements PartitionReader<HiveTablePartition, RowData> {
 
     private static final long serialVersionUID = 1L;
+    private final ReadableConfig flinkConf;
     private final JobConfWrapper jobConfWrapper;
     private final String hiveVersion;
     protected final ObjectPath tablePath;
@@ -49,6 +51,7 @@ public class HiveInputFormatPartitionReader
     private transient int readingSplitId;
 
     public HiveInputFormatPartitionReader(
+            ReadableConfig flinkConf,
             JobConf jobConf,
             String hiveVersion,
             ObjectPath tablePath,
@@ -57,6 +60,7 @@ public class HiveInputFormatPartitionReader
             List<String> partitionKeys,
             int[] selectedFields,
             boolean useMapRedReader) {
+        this.flinkConf = flinkConf;
         this.jobConfWrapper = new JobConfWrapper(jobConf);
         this.hiveVersion = hiveVersion;
         this.tablePath = tablePath;
@@ -71,6 +75,7 @@ public class HiveInputFormatPartitionReader
     public void open(List<HiveTablePartition> partitions) throws IOException {
         hiveTableInputFormat =
                 new HiveTableInputFormat(
+                        this.flinkConf,
                         this.jobConfWrapper.conf(),
                         this.partitionKeys,
                         this.fieldTypes,

--- a/flink-connectors/flink-connector-hive/src/main/java/org/apache/flink/connectors/hive/read/HiveTableInputFormat.java
+++ b/flink-connectors/flink-connector-hive/src/main/java/org/apache/flink/connectors/hive/read/HiveTableInputFormat.java
@@ -23,9 +23,12 @@ import org.apache.flink.api.common.io.CheckpointableInputFormat;
 import org.apache.flink.api.common.io.LocatableInputSplitAssigner;
 import org.apache.flink.api.common.io.statistics.BaseStatistics;
 import org.apache.flink.api.java.hadoop.common.HadoopInputFormatCommonBase;
-import org.apache.flink.connectors.hive.HiveSourceFileEnumerator;
+import org.apache.flink.configuration.ReadableConfig;
+import org.apache.flink.connectors.hive.HiveOptions;
 import org.apache.flink.connectors.hive.HiveTablePartition;
+import org.apache.flink.connectors.hive.HiveTablePartitionSplits;
 import org.apache.flink.connectors.hive.JobConfWrapper;
+import org.apache.flink.connectors.hive.MRSplitsGetter;
 import org.apache.flink.core.io.InputSplitAssigner;
 import org.apache.flink.table.catalog.hive.client.HiveShimLoader;
 import org.apache.flink.table.catalog.hive.util.HiveTypeUtil;
@@ -66,6 +69,8 @@ public class HiveTableInputFormat extends HadoopInputFormatCommonBase<RowData, H
     private static final String SCHEMA_EVOLUTION_COLUMNS = "schema.evolution.columns";
     private static final String SCHEMA_EVOLUTION_COLUMNS_TYPES = "schema.evolution.columns.types";
 
+    private final ReadableConfig flinkConf;
+
     private final JobConfWrapper jobConf;
 
     private final String hiveVersion;
@@ -93,6 +98,7 @@ public class HiveTableInputFormat extends HadoopInputFormatCommonBase<RowData, H
     @VisibleForTesting protected transient SplitReader reader;
 
     public HiveTableInputFormat(
+            ReadableConfig flinkConf,
             JobConf jobConf,
             List<String> partitionKeys,
             DataType[] fieldTypes,
@@ -103,6 +109,7 @@ public class HiveTableInputFormat extends HadoopInputFormatCommonBase<RowData, H
             boolean useMapRedReader,
             List<HiveTablePartition> partitions) {
         super(jobConf.getCredentials());
+        this.flinkConf = flinkConf;
         this.jobConf = new JobConfWrapper(new JobConf(jobConf));
         this.partitionKeys = partitionKeys;
         this.fieldTypes = fieldTypes;
@@ -310,19 +317,30 @@ public class HiveTableInputFormat extends HadoopInputFormatCommonBase<RowData, H
 
     @Override
     public HiveTableInputSplit[] createInputSplits(int minNumSplits) throws IOException {
-        return createInputSplits(minNumSplits, partitions, jobConf.conf());
+        return createInputSplits(minNumSplits, partitions, flinkConf, jobConf.conf());
     }
 
     public static HiveTableInputSplit[] createInputSplits(
-            int minNumSplits, List<HiveTablePartition> partitions, JobConf jobConf)
+            int minNumSplits,
+            List<HiveTablePartition> partitions,
+            ReadableConfig flinkConf,
+            JobConf jobConf)
             throws IOException {
         List<HiveTableInputSplit> hiveSplits = new ArrayList<>();
         int splitNum = 0;
-        for (HiveTablePartition partition : partitions) {
-            for (InputSplit inputSplit :
-                    HiveSourceFileEnumerator.createMRSplits(
-                            minNumSplits, partition.getStorageDescriptor(), jobConf)) {
-                hiveSplits.add(new HiveTableInputSplit(splitNum++, inputSplit, jobConf, partition));
+        try (MRSplitsGetter splitsGetter =
+                new MRSplitsGetter(
+                        flinkConf.get(HiveOptions.TABLE_EXEC_HIVE_PARTITION_SPLIT_THREAD_NUM))) {
+            for (HiveTablePartitionSplits partitionSplits :
+                    splitsGetter.getHiveTablePartitionMRSplits(minNumSplits, partitions, jobConf)) {
+                for (InputSplit inputSplit : partitionSplits.getInputSplits()) {
+                    hiveSplits.add(
+                            new HiveTableInputSplit(
+                                    splitNum++,
+                                    inputSplit,
+                                    partitionSplits.getJobConf(),
+                                    partitionSplits.getHiveTablePartition()));
+                }
             }
         }
 

--- a/flink-connectors/flink-connector-hive/src/main/java/org/apache/flink/connectors/hive/read/HiveTableInputFormat.java
+++ b/flink-connectors/flink-connector-hive/src/main/java/org/apache/flink/connectors/hive/read/HiveTableInputFormat.java
@@ -330,7 +330,8 @@ public class HiveTableInputFormat extends HadoopInputFormatCommonBase<RowData, H
         int splitNum = 0;
         try (MRSplitsGetter splitsGetter =
                 new MRSplitsGetter(
-                        flinkConf.get(HiveOptions.TABLE_EXEC_HIVE_PARTITION_SPLIT_THREAD_NUM))) {
+                        flinkConf.get(
+                                HiveOptions.TABLE_EXEC_HIVE_LOAD_PARTITION_SPLITS_THREAD_NUM))) {
             for (HiveTablePartitionSplits partitionSplits :
                     splitsGetter.getHiveTablePartitionMRSplits(minNumSplits, partitions, jobConf)) {
                 for (InputSplit inputSplit : partitionSplits.getInputSplits()) {

--- a/flink-connectors/flink-connector-hive/src/test/java/org/apache/flink/connectors/hive/PartitionMonitorTest.java
+++ b/flink-connectors/flink-connector-hive/src/test/java/org/apache/flink/connectors/hive/PartitionMonitorTest.java
@@ -182,6 +182,7 @@ public class PartitionMonitorTest {
                         0L,
                         seenPartitionsSinceOffset,
                         tablePath,
+                        configuration,
                         jobConf,
                         continuousPartitionFetcher,
                         fetcherContext);

--- a/flink-connectors/flink-connector-hive/src/test/java/org/apache/flink/connectors/hive/read/HiveInputFormatPartitionReaderITCase.java
+++ b/flink-connectors/flink-connector-hive/src/test/java/org/apache/flink/connectors/hive/read/HiveInputFormatPartitionReaderITCase.java
@@ -17,6 +17,7 @@
 
 package org.apache.flink.connectors.hive.read;
 
+import org.apache.flink.configuration.Configuration;
 import org.apache.flink.connectors.hive.HiveTablePartition;
 import org.apache.flink.table.api.SqlDialect;
 import org.apache.flink.table.api.TableEnvironment;
@@ -61,6 +62,7 @@ public class HiveInputFormatPartitionReaderITCase {
         // create partition reader
         HiveInputFormatPartitionReader partitionReader =
                 new HiveInputFormatPartitionReader(
+                        new Configuration(),
                         new JobConf(hiveCatalog.getHiveConf()),
                         hiveCatalog.getHiveVersion(),
                         tablePath,


### PR DESCRIPTION
## What is the purpose of the change

*If there are many hive partitions, creating splits will take much time, for example, up to ten minutes. This mr speeds up the process by multi threads for different partitions.*


## Brief change log

  - *Add class MRSplitsGetter to create splits by multi thread.*
  - *Add class HiveTablePartitionSplits to wrap hive partition and the corresponding inputSplits.*
  - *Transfer flinkConf to init MRSplitsGetter's thread num.*
  - *Adapt the related calls.*


## Verifying this change
This change is already covered by existing tests, such as HiveTableSourceITCase.

## Does this pull request potentially affect one of the following parts:

  - Dependencies (does it add or upgrade a dependency): (no)
  - The public API, i.e., is any changed class annotated with `@Public(Evolving)`: (no)
  - The serializers: (no)
  - The runtime per-record code paths (performance sensitive): (no)
  - Anything that affects deployment or recovery: JobManager (and its components), Checkpointing, Kubernetes/Yarn, ZooKeeper: (no)
  - The S3 file system connector: (no)

## Documentation

  - Does this pull request introduce a new feature? (yes)
  - If yes, how is the feature documented? (not documented)
