### PR TITLE
[FLINK-24740][BP-1.13][testinfrastructure] Update testcontainers dependency to the latest version

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -135,7 +135,7 @@ under the License.
 		<beam.version>2.27.0</beam.version>
 		<protoc.version>3.11.1</protoc.version>
 		<arrow.version>0.16.0</arrow.version>
-		<testcontainers.version>1.16.0</testcontainers.version>
+		<testcontainers.version>1.16.2</testcontainers.version>
 		<japicmp.skip>false</japicmp.skip>
 		<flink.convergence.phase>validate</flink.convergence.phase>
 		<!--


### PR DESCRIPTION
(cherry picked from commit 8176d5809e2b13c465662706e3df343b2d4f9028)

Backport of https://github.com/apache/flink/pull/17646