### PR TITLE
[FLINK-25142][Connectors / Hive]Fix user-defined hive udtf initialize exception in hive dialect

### DIFF
--- a/flink-connectors/flink-connector-hive/src/main/java/org/apache/flink/table/functions/hive/HiveGenericUDTF.java
+++ b/flink-connectors/flink-connector-hive/src/main/java/org/apache/flink/table/functions/hive/HiveGenericUDTF.java
@@ -168,13 +168,14 @@ public class HiveGenericUDTF extends TableFunction<Row> implements HiveFunction 
 
     public static StandardStructObjectInspector getStandardStructObjectInspector(
             ObjectInspector[] argumentInspectors) {
-        List<String> structFieldNames = new ArrayList<>();
+        List<String> dummyStructFieldNames = new ArrayList<>();
         for (int i = 0; i < argumentInspectors.length; i++) {
-            structFieldNames.add(String.valueOf(i));
+            // dummy column name just for place holder
+            dummyStructFieldNames.add("dummy_col_" + i);
         }
         StandardStructObjectInspector standardStructObjectInspector =
                 ObjectInspectorFactory.getStandardStructObjectInspector(
-                        structFieldNames, Arrays.asList(argumentInspectors));
+                        dummyStructFieldNames, Arrays.asList(argumentInspectors));
         return standardStructObjectInspector;
     }
 }

--- a/flink-connectors/flink-connector-hive/src/test/java/org/apache/flink/connectors/hive/HiveDialectITCase.java
+++ b/flink-connectors/flink-connector-hive/src/test/java/org/apache/flink/connectors/hive/HiveDialectITCase.java
@@ -35,6 +35,8 @@ import org.apache.flink.table.catalog.ObjectPath;
 import org.apache.flink.table.catalog.hive.HiveCatalog;
 import org.apache.flink.table.catalog.hive.HiveTestUtils;
 import org.apache.flink.table.delegation.Parser;
+import org.apache.flink.table.functions.hive.HiveGenericUDTFTest;
+import org.apache.flink.table.functions.hive.util.TestSplitUDTFInitializeWithStructObjectInspector;
 import org.apache.flink.table.operations.DescribeTableOperation;
 import org.apache.flink.table.operations.command.ClearOperation;
 import org.apache.flink.table.operations.command.HelpOperation;
@@ -663,6 +665,62 @@ public class HiveDialectITCase {
         functions = tableEnv.listUserDefinedFunctions();
         assertEquals(0, functions.length);
         tableEnv.executeSql("drop temporary function if exists foo");
+    }
+
+    @Test
+    public void testTemporaryFunctionUDTFInitializeWithObjectInspector() throws Exception {
+        // create temp function
+        tableEnv.executeSql(
+                String.format(
+                        "create temporary function temp_split as '%s'",
+                        HiveGenericUDTFTest.TestSplitUDTF.class.getName()));
+        String[] functions = tableEnv.listUserDefinedFunctions();
+        assertArrayEquals(new String[] {"temp_split"}, functions);
+        // call the function
+        tableEnv.executeSql("create table src(x string)");
+        tableEnv.executeSql("insert into src values ('a,b,c')").await();
+        assertEquals(
+                "[+I[a], +I[b], +I[c]]",
+                queryResult(tableEnv.sqlQuery("select temp_split(x) from src")).toString());
+        // switch DB and the temp function can still be used
+        tableEnv.executeSql("create database db1");
+        tableEnv.useDatabase("db1");
+        assertEquals(
+                "[+I[a], +I[b], +I[c]]",
+                queryResult(tableEnv.sqlQuery("select temp_split(x) from `default`.src"))
+                        .toString());
+        // drop the function
+        tableEnv.executeSql("drop temporary function temp_split");
+        functions = tableEnv.listUserDefinedFunctions();
+        assertEquals(0, functions.length);
+    }
+
+    @Test
+    public void testTemporaryFunctionUDTFInitializeWithStructObjectInspector() throws Exception {
+        // create temp function
+        tableEnv.executeSql(
+                String.format(
+                        "create temporary function temp_split as '%s'",
+                        TestSplitUDTFInitializeWithStructObjectInspector.class.getName()));
+        String[] functions = tableEnv.listUserDefinedFunctions();
+        assertArrayEquals(new String[] {"temp_split"}, functions);
+        // call the function
+        tableEnv.executeSql("create table src(x string)");
+        tableEnv.executeSql("insert into src values ('a,b,c')").await();
+        assertEquals(
+                "[+I[a], +I[b], +I[c]]",
+                queryResult(tableEnv.sqlQuery("select temp_split(x) from src")).toString());
+        // switch DB and the temp function can still be used
+        tableEnv.executeSql("create database db1");
+        tableEnv.useDatabase("db1");
+        assertEquals(
+                "[+I[a], +I[b], +I[c]]",
+                queryResult(tableEnv.sqlQuery("select temp_split(x) from `default`.src"))
+                        .toString());
+        // drop the function
+        tableEnv.executeSql("drop temporary function temp_split");
+        functions = tableEnv.listUserDefinedFunctions();
+        assertEquals(0, functions.length);
     }
 
     @Test

--- a/flink-connectors/flink-connector-hive/src/test/java/org/apache/flink/table/functions/hive/HiveGenericUDTFTest.java
+++ b/flink-connectors/flink-connector-hive/src/test/java/org/apache/flink/table/functions/hive/HiveGenericUDTFTest.java
@@ -242,28 +242,4 @@ public class HiveGenericUDTFTest {
         @Override
         public void close() {}
     }
-
-    /** Test split udtf initialize with StructObjectInspector. */
-    public static class TestSplitUDTFInitializeWithStructObjectInspector extends GenericUDTF {
-
-        @Override
-        public StructObjectInspector initialize(StructObjectInspector argOIs)
-                throws UDFArgumentException {
-            return ObjectInspectorFactory.getStandardStructObjectInspector(
-                    Collections.singletonList("col1"),
-                    Collections.singletonList(
-                            PrimitiveObjectInspectorFactory.javaStringObjectInspector));
-        }
-
-        @Override
-        public void process(Object[] args) throws HiveException {
-            String str = (String) args[0];
-            for (String s : str.split(",")) {
-                forward(s);
-            }
-        }
-
-        @Override
-        public void close() {}
-    }
 }

--- a/flink-connectors/flink-connector-hive/src/test/java/org/apache/flink/table/functions/hive/util/TestSplitUDTFInitializeWithStructObjectInspector.java
+++ b/flink-connectors/flink-connector-hive/src/test/java/org/apache/flink/table/functions/hive/util/TestSplitUDTFInitializeWithStructObjectInspector.java
@@ -1,0 +1,52 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.flink.table.functions.hive.util;
+
+import org.apache.hadoop.hive.ql.exec.UDFArgumentException;
+import org.apache.hadoop.hive.ql.metadata.HiveException;
+import org.apache.hadoop.hive.ql.udf.generic.GenericUDTF;
+import org.apache.hadoop.hive.serde2.objectinspector.ObjectInspectorFactory;
+import org.apache.hadoop.hive.serde2.objectinspector.StructObjectInspector;
+import org.apache.hadoop.hive.serde2.objectinspector.primitive.PrimitiveObjectInspectorFactory;
+
+import java.util.Collections;
+
+/** Test split udtf initialize with StructObjectInspector. */
+public class TestSplitUDTFInitializeWithStructObjectInspector extends GenericUDTF {
+
+    @Override
+    public StructObjectInspector initialize(StructObjectInspector argOIs)
+            throws UDFArgumentException {
+        return ObjectInspectorFactory.getStandardStructObjectInspector(
+                Collections.singletonList("col1"),
+                Collections.singletonList(
+                        PrimitiveObjectInspectorFactory.javaStringObjectInspector));
+    }
+
+    @Override
+    public void process(Object[] args) throws HiveException {
+        String str = (String) args[0];
+        for (String s : str.split(",")) {
+            forward(s);
+        }
+    }
+
+    @Override
+    public void close() {}
+}


### PR DESCRIPTION
## What is the purpose of the change

Fix user-defined hive udtf initialize exception in hive dialect


## Brief change log
  - HiveGenericUDTF Compatible with new udtf implementations. Refer to this issue： 
    [https://issues.apache.org/jira/browse/HIVE-5737](https://issues.apache.org/jira/browse/HIVE-5737)


## Verifying this change

This change added tests and can be verified as follows:
  - Added unit test HiveDialectITCase#testTemporaryFunctionUDTFInitializeWithObjectInspector for create temporary udtf function which Initialized with ObjectInspector
  - Added unit test HiveDialectITCase#testTemporaryFunctionUDTFInitializeWithStructObjectInspector for create temporary udtf function which Initialized with StructObjectInspector

## Does this pull request potentially affect one of the following parts:

  - Dependencies (does it add or upgrade a dependency): (no)
  - The public API, i.e., is any changed class annotated with `@Public(Evolving)`: (no)
  - The serializers: (no)
  - The runtime per-record code paths (performance sensitive): (no)
  - Anything that affects deployment or recovery: JobManager (and its components), Checkpointing, Kubernetes/Yarn, ZooKeeper: (no)
  - The S3 file system connector: (no)

## Documentation

  - Does this pull request introduce a new feature? (no)
  - If yes, how is the feature documented? (not applicable)
