### PR TITLE
[FLINK-25132][connector/kafka] Move record deserializing from SplitFetcher to RecordEmitter to support object-reusing deserializer

### DIFF
--- a/flink-connectors/flink-connector-kafka/src/main/java/org/apache/flink/connector/kafka/source/reader/KafkaRecordEmitter.java
+++ b/flink-connectors/flink-connector-kafka/src/main/java/org/apache/flink/connector/kafka/source/reader/KafkaRecordEmitter.java
@@ -19,21 +19,61 @@
 package org.apache.flink.connector.kafka.source.reader;
 
 import org.apache.flink.api.connector.source.SourceOutput;
-import org.apache.flink.api.java.tuple.Tuple3;
 import org.apache.flink.connector.base.source.reader.RecordEmitter;
+import org.apache.flink.connector.kafka.source.reader.deserializer.KafkaRecordDeserializationSchema;
 import org.apache.flink.connector.kafka.source.split.KafkaPartitionSplitState;
+import org.apache.flink.util.Collector;
+
+import org.apache.kafka.clients.consumer.ConsumerRecord;
+
+import java.io.IOException;
 
 /** The {@link RecordEmitter} implementation for {@link KafkaSourceReader}. */
 public class KafkaRecordEmitter<T>
-        implements RecordEmitter<Tuple3<T, Long, Long>, T, KafkaPartitionSplitState> {
+        implements RecordEmitter<ConsumerRecord<byte[], byte[]>, T, KafkaPartitionSplitState> {
+
+    private final KafkaRecordDeserializationSchema<T> deserializationSchema;
+    private final SourceOutputWrapper<T> sourceOutputWrapper = new SourceOutputWrapper<>();
+
+    public KafkaRecordEmitter(KafkaRecordDeserializationSchema<T> deserializationSchema) {
+        this.deserializationSchema = deserializationSchema;
+    }
 
     @Override
     public void emitRecord(
-            Tuple3<T, Long, Long> element,
+            ConsumerRecord<byte[], byte[]> consumerRecord,
             SourceOutput<T> output,
             KafkaPartitionSplitState splitState)
             throws Exception {
-        output.collect(element.f0, element.f2);
-        splitState.setCurrentOffset(element.f1 + 1);
+        try {
+            sourceOutputWrapper.setSourceOutput(output);
+            sourceOutputWrapper.setTimestamp(consumerRecord.timestamp());
+            deserializationSchema.deserialize(consumerRecord, sourceOutputWrapper);
+            splitState.setCurrentOffset(consumerRecord.offset() + 1);
+        } catch (Exception e) {
+            throw new IOException("Failed to deserialize consumer record due to", e);
+        }
+    }
+
+    private static class SourceOutputWrapper<T> implements Collector<T> {
+
+        private SourceOutput<T> sourceOutput;
+        private long timestamp;
+
+        @Override
+        public void collect(T record) {
+            sourceOutput.collect(record, timestamp);
+        }
+
+        @Override
+        public void close() {}
+
+        private void setSourceOutput(SourceOutput<T> sourceOutput) {
+            this.sourceOutput = sourceOutput;
+        }
+
+        private void setTimestamp(long timestamp) {
+            this.timestamp = timestamp;
+        }
     }
 }

--- a/flink-connectors/flink-connector-kafka/src/main/java/org/apache/flink/connector/kafka/source/reader/fetcher/KafkaSourceFetcherManager.java
+++ b/flink-connectors/flink-connector-kafka/src/main/java/org/apache/flink/connector/kafka/source/reader/fetcher/KafkaSourceFetcherManager.java
@@ -18,7 +18,6 @@
 
 package org.apache.flink.connector.kafka.source.reader.fetcher;
 
-import org.apache.flink.api.java.tuple.Tuple3;
 import org.apache.flink.connector.base.source.reader.RecordsWithSplitIds;
 import org.apache.flink.connector.base.source.reader.SourceReaderBase;
 import org.apache.flink.connector.base.source.reader.fetcher.SingleThreadFetcherManager;
@@ -29,6 +28,7 @@ import org.apache.flink.connector.base.source.reader.synchronization.FutureCompl
 import org.apache.flink.connector.kafka.source.reader.KafkaPartitionSplitReader;
 import org.apache.flink.connector.kafka.source.split.KafkaPartitionSplit;
 
+import org.apache.kafka.clients.consumer.ConsumerRecord;
 import org.apache.kafka.clients.consumer.OffsetAndMetadata;
 import org.apache.kafka.clients.consumer.OffsetCommitCallback;
 import org.apache.kafka.common.TopicPartition;
@@ -46,8 +46,8 @@ import java.util.function.Supplier;
  * Kafka using the KafkaConsumer inside the {@link
  * org.apache.flink.connector.kafka.source.reader.KafkaPartitionSplitReader}.
  */
-public class KafkaSourceFetcherManager<T>
-        extends SingleThreadFetcherManager<Tuple3<T, Long, Long>, KafkaPartitionSplit> {
+public class KafkaSourceFetcherManager
+        extends SingleThreadFetcherManager<ConsumerRecord<byte[], byte[]>, KafkaPartitionSplit> {
     private static final Logger LOG = LoggerFactory.getLogger(KafkaSourceFetcherManager.class);
 
     /**
@@ -61,8 +61,10 @@ public class KafkaSourceFetcherManager<T>
      * @param splitFinishedHook Hook for handling finished splits in split fetchers.
      */
     public KafkaSourceFetcherManager(
-            FutureCompletingBlockingQueue<RecordsWithSplitIds<Tuple3<T, Long, Long>>> elementsQueue,
-            Supplier<SplitReader<Tuple3<T, Long, Long>, KafkaPartitionSplit>> splitReaderSupplier,
+            FutureCompletingBlockingQueue<RecordsWithSplitIds<ConsumerRecord<byte[], byte[]>>>
+                    elementsQueue,
+            Supplier<SplitReader<ConsumerRecord<byte[], byte[]>, KafkaPartitionSplit>>
+                    splitReaderSupplier,
             Consumer<Collection<String>> splitFinishedHook) {
         super(elementsQueue, splitReaderSupplier, splitFinishedHook);
     }
@@ -73,7 +75,8 @@ public class KafkaSourceFetcherManager<T>
         if (offsetsToCommit.isEmpty()) {
             return;
         }
-        SplitFetcher<Tuple3<T, Long, Long>, KafkaPartitionSplit> splitFetcher = fetchers.get(0);
+        SplitFetcher<ConsumerRecord<byte[], byte[]>, KafkaPartitionSplit> splitFetcher =
+                fetchers.get(0);
         if (splitFetcher != null) {
             // The fetcher thread is still running. This should be the majority of the cases.
             enqueueOffsetsCommitTask(splitFetcher, offsetsToCommit, callback);
@@ -85,11 +88,11 @@ public class KafkaSourceFetcherManager<T>
     }
 
     private void enqueueOffsetsCommitTask(
-            SplitFetcher<Tuple3<T, Long, Long>, KafkaPartitionSplit> splitFetcher,
+            SplitFetcher<ConsumerRecord<byte[], byte[]>, KafkaPartitionSplit> splitFetcher,
             Map<TopicPartition, OffsetAndMetadata> offsetsToCommit,
             OffsetCommitCallback callback) {
-        KafkaPartitionSplitReader<T> kafkaReader =
-                (KafkaPartitionSplitReader<T>) splitFetcher.getSplitReader();
+        KafkaPartitionSplitReader kafkaReader =
+                (KafkaPartitionSplitReader) splitFetcher.getSplitReader();
 
         splitFetcher.enqueueTask(
                 new SplitFetcherTask() {

--- a/flink-connectors/flink-connector-kafka/src/test/java/org/apache/flink/connector/kafka/source/KafkaSourceITCase.java
+++ b/flink-connectors/flink-connector-kafka/src/test/java/org/apache/flink/connector/kafka/source/KafkaSourceITCase.java
@@ -56,6 +56,8 @@ import org.junit.jupiter.api.Nested;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.TestInstance;
 import org.junit.jupiter.api.TestInstance.Lifecycle;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.ValueSource;
 import org.testcontainers.containers.KafkaContainer;
 import org.testcontainers.utility.DockerImageName;
 
@@ -67,6 +69,7 @@ import java.util.Collections;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
+import java.util.concurrent.ThreadLocalRandom;
 import java.util.concurrent.atomic.AtomicInteger;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
@@ -93,9 +96,11 @@ public class KafkaSourceITCase {
             KafkaSourceTestEnv.tearDown();
         }
 
-        @Test
-        public void testTimestamp() throws Throwable {
-            final String topic = "testTimestamp";
+        @ParameterizedTest(name = "Object reuse in deserializer = {arguments}")
+        @ValueSource(booleans = {false, true})
+        public void testTimestamp(boolean enableObjectReuse) throws Throwable {
+            final String topic =
+                    "testTimestamp-" + ThreadLocalRandom.current().nextLong(0, Long.MAX_VALUE);
             final long currentTimestamp = System.currentTimeMillis();
             KafkaSourceTestEnv.createTestTopic(topic, 1, 1);
             KafkaSourceTestEnv.produceToKafka(
@@ -109,7 +114,8 @@ public class KafkaSourceITCase {
                             .setBootstrapServers(KafkaSourceTestEnv.brokerConnectionStrings)
                             .setGroupId("testTimestampAndWatermark")
                             .setTopics(topic)
-                            .setDeserializer(new TestingKafkaRecordDeserializationSchema())
+                            .setDeserializer(
+                                    new TestingKafkaRecordDeserializationSchema(enableObjectReuse))
                             .setStartingOffsets(OffsetsInitializer.earliest())
                             .setBounded(OffsetsInitializer.latest())
                             .build();
@@ -133,14 +139,16 @@ public class KafkaSourceITCase {
                     result.getAccumulatorResult("timestamp"));
         }
 
-        @Test
-        public void testBasicRead() throws Exception {
+        @ParameterizedTest(name = "Object reuse in deserializer = {arguments}")
+        @ValueSource(booleans = {false, true})
+        public void testBasicRead(boolean enableObjectReuse) throws Exception {
             KafkaSource<PartitionAndValue> source =
                     KafkaSource.<PartitionAndValue>builder()
                             .setBootstrapServers(KafkaSourceTestEnv.brokerConnectionStrings)
                             .setGroupId("testBasicRead")
                             .setTopics(Arrays.asList(TOPIC1, TOPIC2))
-                            .setDeserializer(new TestingKafkaRecordDeserializationSchema())
+                            .setDeserializer(
+                                    new TestingKafkaRecordDeserializationSchema(enableObjectReuse))
                             .setStartingOffsets(OffsetsInitializer.earliest())
                             .setBounded(OffsetsInitializer.latest())
                             .build();
@@ -197,14 +205,16 @@ public class KafkaSourceITCase {
             assertEquals(expectedSum, actualSum.get());
         }
 
-        @Test
-        public void testRedundantParallelism() throws Exception {
+        @ParameterizedTest(name = "Object reuse in deserializer = {arguments}")
+        @ValueSource(booleans = {false, true})
+        public void testRedundantParallelism(boolean enableObjectReuse) throws Exception {
             KafkaSource<PartitionAndValue> source =
                     KafkaSource.<PartitionAndValue>builder()
                             .setBootstrapServers(KafkaSourceTestEnv.brokerConnectionStrings)
                             .setGroupId("testRedundantParallelism")
                             .setTopics(Collections.singletonList(TOPIC1))
-                            .setDeserializer(new TestingKafkaRecordDeserializationSchema())
+                            .setDeserializer(
+                                    new TestingKafkaRecordDeserializationSchema(enableObjectReuse))
                             .setStartingOffsets(OffsetsInitializer.earliest())
                             .setBounded(OffsetsInitializer.latest())
                             .build();
@@ -221,13 +231,15 @@ public class KafkaSourceITCase {
             executeAndVerify(env, stream);
         }
 
-        @Test
-        public void testBasicReadWithoutGroupId() throws Exception {
+        @ParameterizedTest(name = "Object reuse in deserializer = {arguments}")
+        @ValueSource(booleans = {false, true})
+        public void testBasicReadWithoutGroupId(boolean enableObjectReuse) throws Exception {
             KafkaSource<PartitionAndValue> source =
                     KafkaSource.<PartitionAndValue>builder()
                             .setBootstrapServers(KafkaSourceTestEnv.brokerConnectionStrings)
                             .setTopics(Arrays.asList(TOPIC1, TOPIC2))
-                            .setDeserializer(new TestingKafkaRecordDeserializationSchema())
+                            .setDeserializer(
+                                    new TestingKafkaRecordDeserializationSchema(enableObjectReuse))
                             .setStartingOffsets(OffsetsInitializer.earliest())
                             .setBounded(OffsetsInitializer.latest())
                             .build();
@@ -278,8 +290,10 @@ public class KafkaSourceITCase {
 
     private static class PartitionAndValue implements Serializable {
         private static final long serialVersionUID = 4813439951036021779L;
-        private final String tp;
-        private final int value;
+        private String tp;
+        private int value;
+
+        public PartitionAndValue() {}
 
         private PartitionAndValue(TopicPartition tp, int value) {
             this.tp = tp.toString();
@@ -291,6 +305,12 @@ public class KafkaSourceITCase {
             implements KafkaRecordDeserializationSchema<PartitionAndValue> {
         private static final long serialVersionUID = -3765473065594331694L;
         private transient Deserializer<Integer> deserializer;
+        private final boolean enableObjectReuse;
+        private final PartitionAndValue reuse = new PartitionAndValue();
+
+        public TestingKafkaRecordDeserializationSchema(boolean enableObjectReuse) {
+            this.enableObjectReuse = enableObjectReuse;
+        }
 
         @Override
         public void deserialize(
@@ -299,10 +319,17 @@ public class KafkaSourceITCase {
             if (deserializer == null) {
                 deserializer = new IntegerDeserializer();
             }
-            collector.collect(
-                    new PartitionAndValue(
-                            new TopicPartition(record.topic(), record.partition()),
-                            deserializer.deserialize(record.topic(), record.value())));
+
+            if (enableObjectReuse) {
+                reuse.tp = new TopicPartition(record.topic(), record.partition()).toString();
+                reuse.value = deserializer.deserialize(record.topic(), record.value());
+                collector.collect(reuse);
+            } else {
+                collector.collect(
+                        new PartitionAndValue(
+                                new TopicPartition(record.topic(), record.partition()),
+                                deserializer.deserialize(record.topic(), record.value())));
+            }
         }
 
         @Override

--- a/flink-connectors/flink-connector-kafka/src/test/java/org/apache/flink/connector/kafka/source/reader/KafkaPartitionSplitReaderTest.java
+++ b/flink-connectors/flink-connector-kafka/src/test/java/org/apache/flink/connector/kafka/source/reader/KafkaPartitionSplitReaderTest.java
@@ -18,16 +18,13 @@
 
 package org.apache.flink.connector.kafka.source.reader;
 
-import org.apache.flink.api.java.tuple.Tuple3;
 import org.apache.flink.configuration.Configuration;
 import org.apache.flink.connector.base.source.reader.RecordsWithSplitIds;
 import org.apache.flink.connector.base.source.reader.splitreader.SplitsAddition;
 import org.apache.flink.connector.base.source.reader.splitreader.SplitsChange;
 import org.apache.flink.connector.kafka.source.metrics.KafkaSourceReaderMetrics;
-import org.apache.flink.connector.kafka.source.reader.deserializer.KafkaRecordDeserializationSchema;
 import org.apache.flink.connector.kafka.source.split.KafkaPartitionSplit;
 import org.apache.flink.connector.kafka.source.testutils.KafkaSourceTestEnv;
-import org.apache.flink.connector.testutils.source.deserialization.TestingDeserializationContext;
 import org.apache.flink.connector.testutils.source.reader.TestingReaderContext;
 import org.apache.flink.metrics.Counter;
 import org.apache.flink.metrics.Gauge;
@@ -40,6 +37,7 @@ import org.apache.flink.runtime.metrics.groups.InternalSourceReaderMetricGroup;
 import org.apache.flink.runtime.metrics.groups.UnregisteredMetricGroups;
 
 import org.apache.kafka.clients.consumer.ConsumerConfig;
+import org.apache.kafka.clients.consumer.ConsumerRecord;
 import org.apache.kafka.common.TopicPartition;
 import org.apache.kafka.common.serialization.ByteArrayDeserializer;
 import org.apache.kafka.common.serialization.IntegerDeserializer;
@@ -82,6 +80,8 @@ public class KafkaPartitionSplitReaderTest {
     private static Map<Integer, Map<String, KafkaPartitionSplit>> splitsByOwners;
     private static Map<TopicPartition, Long> earliestOffsets;
 
+    private final IntegerDeserializer deserializer = new IntegerDeserializer();
+
     @BeforeAll
     public static void setup() throws Throwable {
         KafkaSourceTestEnv.setup();
@@ -101,14 +101,14 @@ public class KafkaPartitionSplitReaderTest {
 
     @Test
     public void testHandleSplitChangesAndFetch() throws Exception {
-        KafkaPartitionSplitReader<Integer> reader = createReader();
+        KafkaPartitionSplitReader reader = createReader();
         assignSplitsAndFetchUntilFinish(reader, 0);
         assignSplitsAndFetchUntilFinish(reader, 1);
     }
 
     @Test
     public void testWakeUp() throws Exception {
-        KafkaPartitionSplitReader<Integer> reader = createReader();
+        KafkaPartitionSplitReader reader = createReader();
         TopicPartition nonExistingTopicPartition = new TopicPartition("NotExist", 0);
         assignSplits(
                 reader,
@@ -141,7 +141,7 @@ public class KafkaPartitionSplitReaderTest {
                 UnregisteredMetricGroups.createUnregisteredOperatorMetricGroup();
         final Counter numBytesInCounter =
                 operatorMetricGroup.getIOMetricGroup().getNumBytesInCounter();
-        KafkaPartitionSplitReader<Integer> reader =
+        KafkaPartitionSplitReader reader =
                 createReader(
                         new Properties(),
                         InternalSourceReaderMetricGroup.wrap(operatorMetricGroup));
@@ -180,7 +180,7 @@ public class KafkaPartitionSplitReaderTest {
         MetricListener metricListener = new MetricListener();
         final Properties props = new Properties();
         props.setProperty(ConsumerConfig.MAX_POLL_RECORDS_CONFIG, "1");
-        KafkaPartitionSplitReader<Integer> reader =
+        KafkaPartitionSplitReader reader =
                 createReader(
                         props,
                         InternalSourceReaderMetricGroup.mock(metricListener.getMetricGroup()));
@@ -217,7 +217,7 @@ public class KafkaPartitionSplitReaderTest {
 
     @Test
     public void testAssignEmptySplit() throws Exception {
-        KafkaPartitionSplitReader<Integer> reader = createReader();
+        KafkaPartitionSplitReader reader = createReader();
         final KafkaPartitionSplit normalSplit =
                 new KafkaPartitionSplit(
                         new TopicPartition(TOPIC1, 0),
@@ -231,7 +231,7 @@ public class KafkaPartitionSplitReaderTest {
         reader.handleSplitsChanges(new SplitsAddition<>(Arrays.asList(normalSplit, emptySplit)));
 
         // Fetch and check empty splits is added to finished splits
-        RecordsWithSplitIds<Tuple3<Integer, Long, Long>> recordsWithSplitIds = reader.fetch();
+        RecordsWithSplitIds<ConsumerRecord<byte[], byte[]>> recordsWithSplitIds = reader.fetch();
         assertTrue(recordsWithSplitIds.finishedSplits().contains(emptySplit.splitId()));
 
         // Assign another valid split to avoid consumer.poll() blocking
@@ -250,20 +250,20 @@ public class KafkaPartitionSplitReaderTest {
 
     // ------------------
 
-    private void assignSplitsAndFetchUntilFinish(
-            KafkaPartitionSplitReader<Integer> reader, int readerId) throws IOException {
+    private void assignSplitsAndFetchUntilFinish(KafkaPartitionSplitReader reader, int readerId)
+            throws IOException {
         Map<String, KafkaPartitionSplit> splits =
                 assignSplits(reader, splitsByOwners.get(readerId));
 
         Map<String, Integer> numConsumedRecords = new HashMap<>();
         Set<String> finishedSplits = new HashSet<>();
         while (finishedSplits.size() < splits.size()) {
-            RecordsWithSplitIds<Tuple3<Integer, Long, Long>> recordsBySplitIds = reader.fetch();
+            RecordsWithSplitIds<ConsumerRecord<byte[], byte[]>> recordsBySplitIds = reader.fetch();
             String splitId = recordsBySplitIds.nextSplit();
             while (splitId != null) {
                 // Collect the records in this split.
-                List<Tuple3<Integer, Long, Long>> splitFetch = new ArrayList<>();
-                Tuple3<Integer, Long, Long> record;
+                List<ConsumerRecord<byte[], byte[]>> splitFetch = new ArrayList<>();
+                ConsumerRecord<byte[], byte[]> record;
                 while ((record = recordsBySplitIds.nextRecordFromSplit()) != null) {
                     splitFetch.add(record);
                 }
@@ -305,34 +305,29 @@ public class KafkaPartitionSplitReaderTest {
 
     // ------------------
 
-    private KafkaPartitionSplitReader<Integer> createReader() throws Exception {
+    private KafkaPartitionSplitReader createReader() {
         return createReader(
                 new Properties(), UnregisteredMetricsGroup.createSourceReaderMetricGroup());
     }
 
-    private KafkaPartitionSplitReader<Integer> createReader(
-            Properties additionalProperties, SourceReaderMetricGroup sourceReaderMetricGroup)
-            throws Exception {
+    private KafkaPartitionSplitReader createReader(
+            Properties additionalProperties, SourceReaderMetricGroup sourceReaderMetricGroup) {
         Properties props = new Properties();
         props.putAll(KafkaSourceTestEnv.getConsumerProperties(ByteArrayDeserializer.class));
         props.setProperty(ConsumerConfig.AUTO_OFFSET_RESET_CONFIG, "none");
         if (!additionalProperties.isEmpty()) {
             props.putAll(additionalProperties);
         }
-        KafkaRecordDeserializationSchema<Integer> deserializationSchema =
-                KafkaRecordDeserializationSchema.valueOnly(IntegerDeserializer.class);
-        deserializationSchema.open(new TestingDeserializationContext());
         KafkaSourceReaderMetrics kafkaSourceReaderMetrics =
                 new KafkaSourceReaderMetrics(sourceReaderMetricGroup);
-        return new KafkaPartitionSplitReader<>(
+        return new KafkaPartitionSplitReader(
                 props,
-                deserializationSchema,
                 new TestingReaderContext(new Configuration(), sourceReaderMetricGroup),
                 kafkaSourceReaderMetrics);
     }
 
     private Map<String, KafkaPartitionSplit> assignSplits(
-            KafkaPartitionSplitReader<Integer> reader, Map<String, KafkaPartitionSplit> splits) {
+            KafkaPartitionSplitReader reader, Map<String, KafkaPartitionSplit> splits) {
         SplitsChange<KafkaPartitionSplit> splitsChange =
                 new SplitsAddition<>(new ArrayList<>(splits.values()));
         reader.handleSplitsChanges(splitsChange);
@@ -342,16 +337,16 @@ public class KafkaPartitionSplitReaderTest {
     private boolean verifyConsumed(
             final KafkaPartitionSplit split,
             final long expectedStartingOffset,
-            final Collection<Tuple3<Integer, Long, Long>> consumed) {
+            final Collection<ConsumerRecord<byte[], byte[]>> consumed) {
         long expectedOffset = expectedStartingOffset;
 
-        for (Tuple3<Integer, Long, Long> record : consumed) {
+        for (ConsumerRecord<byte[], byte[]> record : consumed) {
             int expectedValue = (int) expectedOffset;
             long expectedTimestamp = expectedOffset * 1000L;
 
-            assertEquals(expectedValue, (int) record.f0);
-            assertEquals(expectedOffset, (long) record.f1);
-            assertEquals(expectedTimestamp, (long) record.f2);
+            assertEquals(expectedValue, deserializer.deserialize(record.topic(), record.value()));
+            assertEquals(expectedOffset, record.offset());
+            assertEquals(expectedTimestamp, record.timestamp());
 
             expectedOffset++;
         }


### PR DESCRIPTION
## What is the purpose of the change

This pull request moves record deserializing in KafkaSource from SplitFetcher to RecordEmitter to support object-reusing deserializer

## Brief change log
- Move record deserializing from `KafkaPartitionSplitFetcher` to `KafkaRecordEmitter`

## Verifying this change

- Added cases for testing KafkaSource with deserializer enabling object reuse.


## Does this pull request potentially affect one of the following parts:

  - Dependencies (does it add or upgrade a dependency): (yes / **no**)
  - The public API, i.e., is any changed class annotated with `@Public(Evolving)`: (yes / **no**)
  - The serializers: (yes / **no** / don't know)
  - The runtime per-record code paths (performance sensitive): (yes / **no** / don't know)
  - Anything that affects deployment or recovery: JobManager (and its components), Checkpointing, Kubernetes/Yarn, ZooKeeper: (yes / **no** / don't know)
  - The S3 file system connector: (yes / **no** / don't know)

## Documentation

  - Does this pull request introduce a new feature? (yes / **no**)
  - If yes, how is the feature documented? (**not applicable** / docs / JavaDocs / not documented)
