### PR TITLE
[FLINK-25150][API] Fix the violation of api annotation

### DIFF
--- a/flink-connectors/flink-connector-files/src/main/java/org/apache/flink/connector/file/src/reader/StreamFormat.java
+++ b/flink-connectors/flink-connector-files/src/main/java/org/apache/flink/connector/file/src/reader/StreamFormat.java
@@ -188,6 +188,7 @@ public interface StreamFormat<T> extends Serializable, ResultTypeQueryable<T> {
     // ------------------------------------------------------------------------
 
     /** The actual reader that reads the records. */
+    @PublicEvolving
     interface Reader<T> extends Closeable {
 
         /** Reads the next record. Returns {@code null} when the input has reached its end. */

--- a/flink-connectors/flink-connector-files/src/main/java/org/apache/flink/connector/file/src/reader/TextLineInputFormat.java
+++ b/flink-connectors/flink-connector-files/src/main/java/org/apache/flink/connector/file/src/reader/TextLineInputFormat.java
@@ -73,6 +73,7 @@ public class TextLineInputFormat extends SimpleStreamFormat<String> {
     // ------------------------------------------------------------------------
 
     /** The actual reader for the {@code TextLineInputFormat}. */
+    @PublicEvolving
     public static final class Reader implements StreamFormat.Reader<String> {
 
         private final BufferedReader reader;


### PR DESCRIPTION
## What is the purpose of the change

This PR tries to fix the api annotation violation.


## Brief change log

- ccaf8bc1a612ade65b53ab38bc71359f4b063c55 adds the @PublicEvolving to the `org.apache.flink.connector.file.src.reader.StreamFormat$Reader`.


## Verifying this change

This change is a trivial rework / code cleanup without any test coverage.


## Does this pull request potentially affect one of the following parts:

  - Dependencies (does it add or upgrade a dependency): **no**
  - The public API, i.e., is any changed class annotated with `@Public(Evolving)`: **no**
  - The serializers: **no**
  - The runtime per-record code paths (performance sensitive): **no**
  - Anything that affects deployment or recovery: JobManager (and its components), Checkpointing, Kubernetes/Yarn, ZooKeeper: **no**
  - The S3 file system connector: **no**

## Documentation

  - Does this pull request introduce a new feature? **no**
  - If yes, how is the feature documented? **not applicable** 