### PR TITLE
[FLINK-25085][runtime] Add a scheduled thread pool in Endpoint and close it when the endpoint is stopped

### DIFF
--- a/flink-rpc/flink-rpc-core/src/main/java/org/apache/flink/runtime/concurrent/ComponentMainThreadExecutor.java
+++ b/flink-rpc/flink-rpc-core/src/main/java/org/apache/flink/runtime/concurrent/ComponentMainThreadExecutor.java
@@ -30,10 +30,14 @@ import java.util.concurrent.TimeUnit;
  * Interface for an executor that runs tasks in the main thread of an {@link
  * org.apache.flink.runtime.rpc.RpcEndpoint}.
  */
-public interface ComponentMainThreadExecutor extends ScheduledExecutor {
+public interface ComponentMainThreadExecutor extends ScheduledExecutor, AutoCloseable {
 
     /** Returns true if the method was called in the thread of this executor. */
     void assertRunningInMainThread();
+
+    /** Close the executor. */
+    @Override
+    void close();
 
     /** Dummy implementation of ComponentMainThreadExecutor. */
     final class DummyComponentMainThreadExecutor implements ComponentMainThreadExecutor {
@@ -80,5 +84,8 @@ public interface ComponentMainThreadExecutor extends ScheduledExecutor {
         private UnsupportedOperationException createException() {
             return new UnsupportedOperationException(exceptionMessageOnInvocation);
         }
+
+        @Override
+        public void close() {}
     }
 }

--- a/flink-rpc/flink-rpc-core/src/main/java/org/apache/flink/runtime/concurrent/ThrowingScheduledFuture.java
+++ b/flink-rpc/flink-rpc-core/src/main/java/org/apache/flink/runtime/concurrent/ThrowingScheduledFuture.java
@@ -1,0 +1,76 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.flink.runtime.concurrent;
+
+import java.util.concurrent.Delayed;
+import java.util.concurrent.ExecutionException;
+import java.util.concurrent.ScheduledFuture;
+import java.util.concurrent.TimeUnit;
+import java.util.concurrent.TimeoutException;
+
+/**
+ * Completed {@link ScheduledFuture} implementation.
+ *
+ * @param <T> type of the {@link ScheduledFuture}
+ */
+public final class ThrowingScheduledFuture<T> implements ScheduledFuture<T> {
+    private static final ThrowingScheduledFuture instance = new ThrowingScheduledFuture();
+
+    private ThrowingScheduledFuture() {}
+
+    @Override
+    public long getDelay(TimeUnit unit) {
+        throw new UnsupportedOperationException();
+    }
+
+    @Override
+    public int compareTo(Delayed o) {
+        return Long.compare(getDelay(TimeUnit.MILLISECONDS), o.getDelay(TimeUnit.MILLISECONDS));
+    }
+
+    @Override
+    public boolean cancel(boolean mayInterruptIfRunning) {
+        return true;
+    }
+
+    @Override
+    public boolean isCancelled() {
+        return true;
+    }
+
+    @Override
+    public boolean isDone() {
+        return true;
+    }
+
+    @Override
+    public T get() throws InterruptedException, ExecutionException {
+        throw new UnsupportedOperationException();
+    }
+
+    @Override
+    public T get(long timeout, TimeUnit unit)
+            throws InterruptedException, ExecutionException, TimeoutException {
+        throw new UnsupportedOperationException();
+    }
+
+    public static <T> ThrowingScheduledFuture<T> create() {
+        return instance;
+    }
+}

--- a/flink-rpc/flink-rpc-core/src/main/java/org/apache/flink/runtime/rpc/RpcEndpoint.java
+++ b/flink-rpc/flink-rpc-core/src/main/java/org/apache/flink/runtime/rpc/RpcEndpoint.java
@@ -21,8 +21,10 @@ package org.apache.flink.runtime.rpc;
 import org.apache.flink.api.common.time.Time;
 import org.apache.flink.runtime.concurrent.ComponentMainThreadExecutor;
 import org.apache.flink.runtime.concurrent.ScheduledFutureAdapter;
+import org.apache.flink.runtime.concurrent.ThrowingScheduledFuture;
 import org.apache.flink.util.AutoCloseableAsync;
 import org.apache.flink.util.Preconditions;
+import org.apache.flink.util.concurrent.ExecutorThreadFactory;
 
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
@@ -32,7 +34,9 @@ import javax.annotation.Nonnull;
 import java.util.UUID;
 import java.util.concurrent.Callable;
 import java.util.concurrent.CompletableFuture;
+import java.util.concurrent.Executors;
 import java.util.concurrent.FutureTask;
+import java.util.concurrent.ScheduledExecutorService;
 import java.util.concurrent.ScheduledFuture;
 import java.util.concurrent.TimeUnit;
 import java.util.concurrent.TimeoutException;
@@ -126,7 +130,8 @@ public abstract class RpcEndpoint implements RpcGateway, AutoCloseableAsync {
 
         this.rpcServer = rpcService.startServer(this);
 
-        this.mainThreadExecutor = new MainThreadExecutor(rpcServer, this::validateRunsInMainThread);
+        this.mainThreadExecutor =
+                new MainThreadExecutor(rpcServer, this::validateRunsInMainThread, endpointId);
     }
 
     /**
@@ -228,6 +233,7 @@ public abstract class RpcEndpoint implements RpcGateway, AutoCloseableAsync {
      *     occurs this future is completed exceptionally
      */
     protected CompletableFuture<Void> onStop() {
+        mainThreadExecutor.close();
         return CompletableFuture.completedFuture(null);
     }
 
@@ -399,40 +405,72 @@ public abstract class RpcEndpoint implements RpcGateway, AutoCloseableAsync {
     //  Utilities
     // ------------------------------------------------------------------------
 
-    /** Executor which executes runnables in the main thread context. */
+    /**
+     * Executor which executes runnables in the main thread context. The executor will holds all the
+     * periodic tasks, sends them to akka thread pool via gateway when they should be executed.
+     */
     protected static class MainThreadExecutor implements ComponentMainThreadExecutor {
+        private final Logger log = LoggerFactory.getLogger(getClass());
 
         private final MainThreadExecutable gateway;
         private final Runnable mainThreadCheck;
+        private final ScheduledExecutorService scheduledExecutorService;
 
-        MainThreadExecutor(MainThreadExecutable gateway, Runnable mainThreadCheck) {
+        MainThreadExecutor(
+                MainThreadExecutable gateway, Runnable mainThreadCheck, String endpointId) {
             this.gateway = Preconditions.checkNotNull(gateway);
             this.mainThreadCheck = Preconditions.checkNotNull(mainThreadCheck);
-        }
-
-        private void scheduleRunAsync(Runnable runnable, long delayMillis) {
-            gateway.scheduleRunAsync(runnable, delayMillis);
+            this.scheduledExecutorService =
+                    Executors.newSingleThreadScheduledExecutor(
+                            new ExecutorThreadFactory(endpointId + "-scheduled-main-executor"));
         }
 
         @Override
         public void execute(@Nonnull Runnable command) {
-            gateway.runAsync(command);
+            if (!scheduledExecutorService.isShutdown()) {
+                gateway.runAsync(command);
+            } else {
+                log.warn(
+                        "The scheduled executor service is shutdown and main thread executor will ignore the command {}",
+                        command);
+            }
         }
 
+        /**
+         * The result future will be used to cancel the runnable, we return a throwing scheduled
+         * future when the scheduled executor service is shutdown.
+         *
+         * @param command the task to execute in the future
+         * @param delay the time from now to delay the execution
+         * @param unit the time unit of the delay parameter
+         * @return the result future
+         */
         @Override
         public ScheduledFuture<?> schedule(Runnable command, long delay, TimeUnit unit) {
-            final long delayMillis = TimeUnit.MILLISECONDS.convert(delay, unit);
-            FutureTask<Void> ft = new FutureTask<>(command, null);
-            scheduleRunAsync(ft, delayMillis);
-            return new ScheduledFutureAdapter<>(ft, delayMillis, TimeUnit.MILLISECONDS);
+            // If the scheduled executor service is shutdown, the command won't be executed.
+            if (scheduledExecutorService.isShutdown()) {
+                log.warn(
+                        "The scheduled executor service is shutdown and return throwing scheduled future for command {}",
+                        command);
+                return ThrowingScheduledFuture.create();
+            } else {
+                return scheduledExecutorService.schedule(() -> execute(command), delay, unit);
+            }
         }
 
         @Override
         public <V> ScheduledFuture<V> schedule(Callable<V> callable, long delay, TimeUnit unit) {
-            final long delayMillis = TimeUnit.MILLISECONDS.convert(delay, unit);
-            FutureTask<V> ft = new FutureTask<>(callable);
-            scheduleRunAsync(ft, delayMillis);
-            return new ScheduledFutureAdapter<>(ft, delayMillis, TimeUnit.MILLISECONDS);
+            // If the scheduled executor service is shutdown, the callable won't be executed.
+            if (scheduledExecutorService.isShutdown()) {
+                log.warn(
+                        "The scheduled executor service is shutdown and return throwing scheduled future for callable {}",
+                        callable);
+                return ThrowingScheduledFuture.create();
+            } else {
+                final FutureTask<V> ft = new FutureTask<>(callable);
+                scheduledExecutorService.schedule(() -> execute(ft), delay, unit);
+                return new ScheduledFutureAdapter<>(ft, delay, unit);
+            }
         }
 
         @Override
@@ -452,6 +490,17 @@ public abstract class RpcEndpoint implements RpcGateway, AutoCloseableAsync {
         @Override
         public void assertRunningInMainThread() {
             mainThreadCheck.run();
+        }
+
+        /**
+         * Shutdown the scheduled executor service and clear all the pending periodic tasks. The
+         * main thread executor will not execute periodic tasks later.
+         */
+        @Override
+        public void close() {
+            if (!scheduledExecutorService.isShutdown()) {
+                scheduledExecutorService.shutdownNow().clear();
+            }
         }
     }
 }

--- a/flink-runtime/src/test/java/org/apache/flink/runtime/concurrent/ComponentMainThreadExecutorServiceAdapter.java
+++ b/flink-runtime/src/test/java/org/apache/flink/runtime/concurrent/ComponentMainThreadExecutorServiceAdapter.java
@@ -87,6 +87,9 @@ public class ComponentMainThreadExecutorServiceAdapter implements ComponentMainT
     }
 
     @Override
+    public void close() {}
+
+    @Override
     public ScheduledFuture<?> schedule(
             final Runnable command, final long delay, final TimeUnit unit) {
         return scheduledExecutor.schedule(command, delay, unit);

--- a/flink-runtime/src/test/java/org/apache/flink/runtime/concurrent/ManuallyTriggeredComponentMainThreadExecutor.java
+++ b/flink-runtime/src/test/java/org/apache/flink/runtime/concurrent/ManuallyTriggeredComponentMainThreadExecutor.java
@@ -38,4 +38,7 @@ public class ManuallyTriggeredComponentMainThreadExecutor
         assertRunningInMainThread();
         super.trigger();
     }
+
+    @Override
+    public void close() {}
 }


### PR DESCRIPTION
## What is the purpose of the change

This PR adds a scheduled thread pool to hold the periodic tasks and send them to akka with gateway when they should be executed. These periodic tasks such as resource timeout checker, heartbeat checker and some other tasks are scheduled by akka thread pool now,  and they are alive even when the job or tasks reach termination, it will cause FullGC. 

## Brief change log
 - Add a scheduled thread pool to hold the periodic tasks and send them to akka with gateway when they should be executed
 - Create the scheduled thread pool in Endpoint and close it when Endpoint is closed.

## Verifying this change
This change added tests and can be verified as follows:
  - Added test ScheduledMainThreadExecutorTest that validates the ScheduledMainThreadExecutor
  - Endpoint related changes are covered by existing test RpcEndpointTest

## Does this pull request potentially affect one of the following parts:

  - Dependencies (does it add or upgrade a dependency): (yes / no) no
  - The public API, i.e., is any changed class annotated with `@Public(Evolving)`: (yes / no) no
  - The serializers: (yes / no / don't know) no
  - The runtime per-record code paths (performance sensitive): (yes / no / don't know) no
  - Anything that affects deployment or recovery: JobManager (and its components), Checkpointing, Kubernetes/Yarn, ZooKeeper: (yes / no / don't know) no
  - The S3 file system connector: (yes / no / don't know) no

## Documentation

  - Does this pull request introduce a new feature? (yes / no) no
  - If yes, how is the feature documented? (not applicable / docs / JavaDocs / not documented) not documented
