### PR TITLE
[FLINK-24227][connectors/kinesis] Relocated flink-connector-aws-base in flink-connector-kinesis shaded jar

### DIFF
--- a/flink-connectors/flink-connector-kinesis/pom.xml
+++ b/flink-connectors/flink-connector-kinesis/pom.xml
@@ -318,6 +318,14 @@ under the License.
 								<!-- Do not relocate guava because it is exposed in the Kinesis API (KinesisProducer#addUserRecord).
 								 	Users may be using other affected API's, so relocations may break user-code -->
 								<relocation>
+									<pattern>org.apache.flink.connector.aws.config</pattern>
+									<shadedPattern>org.apache.flink.kinesis.shaded.org.apache.flink.connector.aws.config</shadedPattern>
+								</relocation>
+								<relocation>
+									<pattern>org.apache.flink.connector.aws.util</pattern>
+									<shadedPattern>org.apache.flink.kinesis.shaded.org.apache.flink.connector.aws.util</shadedPattern>
+								</relocation>
+								<relocation>
 									<pattern>com.google.protobuf</pattern>
 									<shadedPattern>org.apache.flink.kinesis.shaded.com.google.protobuf</shadedPattern>
 								</relocation>


### PR DESCRIPTION
## What is the purpose of the change

- If a package depended on both `flink-connector-aws-base` and `flink-connector-kinesis`, there would be a duplication of the classes from the first from the shaded JAR of the second
- This change relocates classes from `flink-connector-aws-base` in the shaded JAR of `flink-connector-kinesis`

## Brief change log

- The `pom.xml` of `flink-connector-kinesis` has been updated to relocate used classes from `flink-connector-aws-base`

## Verifying this change

This change is a trivial rework / code cleanup without any test coverage.

## Does this pull request potentially affect one of the following parts:

  - Dependencies (does it add or upgrade a dependency): no
  - The public API, i.e., is any changed class annotated with `@Public(Evolving)`: no
  - The serializers: no
  - The runtime per-record code paths (performance sensitive): no
  - Anything that affects deployment or recovery: JobManager (and its components), Checkpointing, Kubernetes/Yarn, ZooKeeper: no
  - The S3 file system connector: no

## Documentation

  - Does this pull request introduce a new feature? no
  - If yes, how is the feature documented? not applicable
