### PR TITLE
[FLINK-25164] DogStatsD Metrics Reporter

### DIFF
--- a/docs/content/docs/deployment/metric_reporters.md
+++ b/docs/content/docs/deployment/metric_reporters.md
@@ -254,6 +254,36 @@ metrics.reporter.dghttp.maxMetricsPerRequest: 2000
 metrics.reporter.dghttp.interval: 60 SECONDS
 ```
 
+### DogStatsD
+#### (org.apache.flink.metrics.dogstatsd.DogStatsDReporter)
+
+This reporter uses [DogStatsD](https://docs.datadoghq.com/developers/dogstatsd/) protocol, which is a superset of StatsD.
+
+Note any variables in Flink metrics, such as `<host>`, `<job_name>`, `<tm_id>`, `<subtask_index>`, `<task_name>`, and `<operator_name>`,
+will be sent to Datadog as tags. Tags will look like `host:localhost` and `job_name:myjobname`.
+
+In `shortids` mode, Flink variables like `<tm_id>`, `<task_id>`, `<job_id>`, `<task_attempt_id>` will print only the first
+8 hex characters of the 32 hex character value.  This is to provide good enough distinction and identification, while
+avoiding truncation in the case where metrics are otherwise too long.
+
+<span class="label label-info">Note</span> Histograms are exposed as a series of gauges following the naming convention of Datadog histograms (`<metric_name>.<aggregation>`).
+
+Parameters:
+
+- `host` - the DogStatsD server host
+- `port` - (optional) the DogStatsD server port, defaults to `8125`
+- `tags` - (optional) the global tags that will be applied to metrics when sending to Datadog. Tags should be separated by comma only
+- `shortids` - (optional) the flag to use short ids, defaults to `false`
+
+Example configuration:
+
+```yaml
+metrics.reporter.dog.class: org.apache.flink.metrics.dogstatsd.DogStatsDReporter
+metrics.reporter.dog.host: $HOST_IP
+metrics.reporter.dog.port: 8125
+metrics.reporter.dog.tags: environment:production
+metrics.reporter.dog.shortids: false
+```
 
 ### Slf4j
 #### (org.apache.flink.metrics.slf4j.Slf4jReporter)

--- a/flink-dist/pom.xml
+++ b/flink-dist/pom.xml
@@ -284,6 +284,13 @@ under the License.
 
 		<dependency>
 			<groupId>org.apache.flink</groupId>
+			<artifactId>flink-metrics-dogstatsd</artifactId>
+			<version>${project.version}</version>
+			<scope>provided</scope>
+		</dependency>
+
+		<dependency>
+			<groupId>org.apache.flink</groupId>
 			<artifactId>flink-metrics-slf4j</artifactId>
 			<version>${project.version}</version>
 			<scope>provided</scope>

--- a/flink-dist/src/main/assemblies/plugins.xml
+++ b/flink-dist/src/main/assemblies/plugins.xml
@@ -74,6 +74,13 @@
 		</file>
 
 		<file>
+			<source>../flink-metrics/flink-metrics-dogstatsd/target/flink-metrics-dogstatsd-${project.version}.jar</source>
+			<outputDirectory>plugins/metrics-dogstatsd/</outputDirectory>
+			<destName>flink-metrics-dogstatsd-${project.version}.jar</destName>
+			<fileMode>0644</fileMode>
+		</file>
+
+		<file>
 			<source>../flink-metrics/flink-metrics-slf4j/target/flink-metrics-slf4j-${project.version}.jar</source>
 			<outputDirectory>plugins/metrics-slf4j/</outputDirectory>
 			<destName>flink-metrics-slf4j-${project.version}.jar</destName>

--- a/flink-metrics/flink-metrics-dogstatsd/pom.xml
+++ b/flink-metrics/flink-metrics-dogstatsd/pom.xml
@@ -24,47 +24,56 @@ under the License.
 
 	<parent>
 		<groupId>org.apache.flink</groupId>
-		<artifactId>flink-parent</artifactId>
+		<artifactId>flink-metrics</artifactId>
 		<version>1.15-SNAPSHOT</version>
 		<relativePath>..</relativePath>
 	</parent>
 
-	<artifactId>flink-metrics</artifactId>
-	<name>Flink : Metrics : </name>
-	<packaging>pom</packaging>
-
-	<properties>
-		<dropwizard.version>3.2.6</dropwizard.version>
-	</properties>
-
-	<modules>
-		<module>flink-metrics-core</module>
-		<module>flink-metrics-dropwizard</module>
-		<module>flink-metrics-graphite</module>
-		<module>flink-metrics-influxdb</module>
-		<module>flink-metrics-jmx</module>
-		<module>flink-metrics-prometheus</module>
-		<module>flink-metrics-statsd</module>
-		<module>flink-metrics-datadog</module>
-		<module>flink-metrics-dogstatsd</module>
-		<module>flink-metrics-slf4j</module>
-	</modules>
-
-	<!-- override these root dependencies as 'provided', so they don't end up
-		in the jars-with-dependencies. They are already contained
-		in the flink-dist build -->
+	<artifactId>flink-metrics-dogstatsd</artifactId>
+	<name>Flink : Metrics : DogStatsD</name>
 
 	<dependencies>
 		<dependency>
-			<groupId>org.slf4j</groupId>
-			<artifactId>slf4j-api</artifactId>
+			<groupId>org.apache.flink</groupId>
+			<artifactId>flink-annotations</artifactId>
+			<version>${project.version}</version>
 			<scope>provided</scope>
 		</dependency>
+
 		<dependency>
-			<groupId>com.google.code.findbugs</groupId>
-			<artifactId>jsr305</artifactId>
+			<groupId>org.apache.flink</groupId>
+			<artifactId>flink-metrics-core</artifactId>
+			<version>${project.version}</version>
 			<scope>provided</scope>
+		</dependency>
+
+		<!-- test dependencies -->
+
+		<dependency>
+			<groupId>org.apache.flink</groupId>
+			<artifactId>flink-metrics-core</artifactId>
+			<version>${project.version}</version>
+			<scope>test</scope>
+			<type>test-jar</type>
+		</dependency>
+
+		<dependency>
+			<groupId>org.apache.flink</groupId>
+			<artifactId>flink-core</artifactId>
+			<version>${project.version}</version>
+			<scope>test</scope>
+		</dependency>
+
+		<dependency>
+			<groupId>org.apache.flink</groupId>
+			<artifactId>flink-runtime</artifactId>
+			<version>${project.version}</version>
+			<scope>test</scope>
+		</dependency>
+
+		<dependency>
+			<groupId>org.apache.flink</groupId>
+			<artifactId>flink-test-utils-junit</artifactId>
 		</dependency>
 	</dependencies>
-
 </project>

--- a/flink-metrics/flink-metrics-dogstatsd/src/main/java/org/apache/flink/metrics/dogstatsd/DogStatsDReporter.java
+++ b/flink-metrics/flink-metrics-dogstatsd/src/main/java/org/apache/flink/metrics/dogstatsd/DogStatsDReporter.java
@@ -1,0 +1,485 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.flink.metrics.dogstatsd;
+
+import org.apache.flink.metrics.CharacterFilter;
+import org.apache.flink.metrics.Counter;
+import org.apache.flink.metrics.Gauge;
+import org.apache.flink.metrics.Histogram;
+import org.apache.flink.metrics.HistogramStatistics;
+import org.apache.flink.metrics.Meter;
+import org.apache.flink.metrics.Metric;
+import org.apache.flink.metrics.MetricConfig;
+import org.apache.flink.metrics.MetricGroup;
+import org.apache.flink.metrics.reporter.InstantiateViaFactory;
+import org.apache.flink.metrics.reporter.MetricReporter;
+import org.apache.flink.metrics.reporter.Scheduled;
+
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import java.io.IOException;
+import java.net.DatagramPacket;
+import java.net.DatagramSocket;
+import java.net.InetSocketAddress;
+import java.net.SocketException;
+import java.nio.charset.StandardCharsets;
+import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.ConcurrentModificationException;
+import java.util.List;
+import java.util.Map;
+import java.util.NoSuchElementException;
+import java.util.concurrent.ConcurrentHashMap;
+import java.util.regex.Matcher;
+import java.util.regex.Pattern;
+
+/**
+ * Metrics reporter for DogStatsD protocol, inspired by DatadogHttpReporter, StatsDReporter and the
+ * work in FLINK-7009.
+ */
+@InstantiateViaFactory(
+        factoryClassName = "org.apache.flink.metrics.dogstatsd.DogStatsDReporterFactory")
+public class DogStatsDReporter implements MetricReporter, Scheduled, CharacterFilter {
+
+    enum DMetricType {
+        COUNTER("c"),
+        GAUGE("g");
+
+        final String typeEncoding;
+
+        private DMetricType(String typeEncoding) {
+            this.typeEncoding = typeEncoding;
+        }
+    }
+
+    static class DMetric {
+        private final String name;
+        private final List<String> tags;
+
+        DMetric(String name, List<String> tags) {
+            this.name = name;
+            this.tags = tags;
+        }
+
+        String getName() {
+            return name;
+        }
+
+        List<String> getTags() {
+            return tags;
+        }
+    }
+
+    private static final Logger LOG = LoggerFactory.getLogger(DogStatsDReporter.class);
+
+    private static final String ARG_HOST = "host";
+    private static final String ARG_PORT = "port";
+    private static final String ARG_TAGS = "tags";
+    private static final String ARG_SHORTIDS = "shortids";
+
+    private boolean closed = false;
+
+    private DatagramSocket socket;
+    private InetSocketAddress address;
+
+    private List<String> configTags;
+    private boolean shortIds;
+
+    private final Pattern instanceRef = Pattern.compile("@[a-f0-9]+");
+    private final Pattern flinkId = Pattern.compile("[a-f0-9]{32}");
+    private static final char SCOPE_SEPARATOR = '.';
+
+    protected final Map<Gauge<?>, DMetric> gauges = new ConcurrentHashMap<>();
+    protected final Map<Counter, DMetric> counters = new ConcurrentHashMap<>();
+    protected final Map<Histogram, DMetric> histograms = new ConcurrentHashMap<>();
+    protected final Map<Meter, DMetric> meters = new ConcurrentHashMap<>();
+
+    @Override
+    public void open(MetricConfig config) {
+        String host = config.getString(ARG_HOST, null);
+        int port = config.getInteger(ARG_PORT, 8125);
+        String tags = config.getString(ARG_TAGS, "");
+
+        configTags = getTagsFromConfig(tags);
+        shortIds = config.getBoolean(ARG_SHORTIDS, false);
+
+        if (host == null || host.length() == 0 || port < 1) {
+            throw new IllegalArgumentException(
+                    "Invalid host/port configuration. Host: " + host + " Port: " + port);
+        }
+
+        establishConnection(host, port);
+
+        LOG.info("Configured DogStatsDReporter with config: {}", config);
+    }
+
+    protected void establishConnection(String host, Integer port) {
+        this.address = new InetSocketAddress(host, port);
+
+        try {
+            this.socket = new DatagramSocket(0);
+        } catch (SocketException e) {
+            throw new RuntimeException("Could not create datagram socket. ", e);
+        }
+    }
+
+    @Override
+    public void close() {
+        closed = true;
+        if (socket != null && !socket.isClosed()) {
+            socket.close();
+        }
+    }
+
+    @Override
+    public void notifyOfAddedMetric(Metric metric, String metricName, MetricGroup group) {
+        String name = group.getMetricIdentifier(metricName, this);
+
+        List<String> tags = new ArrayList<>(configTags);
+        tags.addAll(getTagsFromMetricGroup(group));
+
+        DMetric dMetric = new DMetric(name, tags);
+
+        if (metric instanceof Counter) {
+            counters.put((Counter) metric, dMetric);
+        } else if (metric instanceof Gauge) {
+            gauges.put((Gauge<?>) metric, dMetric);
+        } else if (metric instanceof Histogram) {
+            histograms.put((Histogram) metric, dMetric);
+        } else if (metric instanceof Meter) {
+            meters.put((Meter) metric, dMetric);
+        } else {
+            LOG.warn(
+                    "Cannot add unknown metric type {}. This indicates that the reporter "
+                            + "does not support this metric type.",
+                    metric.getClass().getName());
+        }
+    }
+
+    @Override
+    public void notifyOfRemovedMetric(Metric metric, String metricName, MetricGroup group) {
+        if (metric instanceof Counter) {
+            counters.remove(metric);
+        } else if (metric instanceof Gauge) {
+            gauges.remove(metric);
+        } else if (metric instanceof Histogram) {
+            histograms.remove(metric);
+        } else if (metric instanceof Meter) {
+            meters.remove(metric);
+        } else {
+            LOG.warn(
+                    "Cannot remove unknown metric type {}. This indicates that the reporter "
+                            + "does not support this metric type.",
+                    metric.getClass().getName());
+        }
+    }
+
+    @Override
+    public void report() {
+        // instead of locking here, we tolerate exceptions
+        // we do this to prevent holding the lock for very long and blocking
+        // operator creation and shutdown
+        try {
+            for (Map.Entry<Gauge<?>, DMetric> entry : gauges.entrySet()) {
+                if (closed) {
+                    return;
+                }
+                reportGauge(entry.getValue(), entry.getKey());
+            }
+
+            for (Map.Entry<Counter, DMetric> entry : counters.entrySet()) {
+                if (closed) {
+                    return;
+                }
+                reportCounter(entry.getValue(), entry.getKey());
+            }
+
+            for (Map.Entry<Histogram, DMetric> entry : histograms.entrySet()) {
+                if (closed) {
+                    return;
+                }
+                reportHistogram(entry.getValue(), entry.getKey());
+            }
+
+            for (Map.Entry<Meter, DMetric> entry : meters.entrySet()) {
+                if (closed) {
+                    return;
+                }
+                reportMeter(entry.getValue(), entry.getKey());
+            }
+        } catch (ConcurrentModificationException | NoSuchElementException e) {
+            // ignore - may happen when metrics are concurrently added or removed
+            // report next time
+        }
+    }
+
+    // ------------------------------------------------------------------------
+
+    private void reportCounter(final DMetric metric, final Counter counter) {
+        send(metric.getName(), counter.getCount(), DMetricType.COUNTER, metric.getTags());
+    }
+
+    private void reportGauge(final DMetric metric, final Gauge<?> gauge) {
+        Object value = gauge.getValue();
+        if (value == null) {
+            return;
+        }
+
+        // enforce numeric values and skip values like "n/a", "false", etc.
+        if (value instanceof Number) {
+            send(metric.getName(), value.toString(), DMetricType.GAUGE, metric.getTags());
+        } else {
+            LOG.debug(
+                    "Metric [{}] will not be reported as the value type is not a number. Only number types are supported by this reporter",
+                    metric.getName());
+        }
+    }
+
+    private void reportHistogram(final DMetric metric, final Histogram histogram) {
+        if (histogram != null) {
+            HistogramStatistics statistics = histogram.getStatistics();
+
+            if (statistics != null) {
+                // this selection is based on
+                // https://docs.datadoghq.com/developers/metrics/types/?tab=histogram
+                // we only exclude 'sum' (which is optional), because we cannot compute it
+                // the semantics for count are also slightly different, because we don't reset it
+                // after a
+                // report
+                send(
+                        prefix(metric.getName(), "count"),
+                        histogram.getCount(),
+                        DMetricType.COUNTER,
+                        metric.getTags());
+                send(
+                        prefix(metric.getName(), "max"),
+                        statistics.getMax(),
+                        DMetricType.GAUGE,
+                        metric.getTags());
+                send(
+                        prefix(metric.getName(), "min"),
+                        statistics.getMin(),
+                        DMetricType.GAUGE,
+                        metric.getTags());
+                send(
+                        prefix(metric.getName(), "avg"),
+                        statistics.getMean(),
+                        DMetricType.GAUGE,
+                        metric.getTags());
+                send(
+                        prefix(metric.getName(), "median"),
+                        statistics.getQuantile(0.50),
+                        DMetricType.GAUGE,
+                        metric.getTags());
+                send(
+                        prefix(metric.getName(), "95percentile"),
+                        statistics.getQuantile(0.95),
+                        DMetricType.GAUGE,
+                        metric.getTags());
+            }
+        }
+    }
+
+    private void reportMeter(final DMetric metric, final Meter meter) {
+        if (meter != null) {
+            send(
+                    prefix(metric.getName(), "rate"),
+                    meter.getRate(),
+                    DMetricType.GAUGE,
+                    metric.getTags());
+            send(
+                    prefix(metric.getName(), "count"),
+                    meter.getCount(),
+                    DMetricType.COUNTER,
+                    metric.getTags());
+        }
+    }
+
+    private String prefix(String... names) {
+        if (names.length > 0) {
+            StringBuilder stringBuilder = new StringBuilder(names[0]);
+
+            for (int i = 1; i < names.length; i++) {
+                stringBuilder.append(SCOPE_SEPARATOR).append(names[i]);
+            }
+
+            return stringBuilder.toString();
+        } else {
+            return "";
+        }
+    }
+
+    private void send(String name, double value, DMetricType type, List<String> tags) {
+        send(name, String.valueOf(value), type, tags);
+    }
+
+    private void send(String name, long value, DMetricType type, List<String> tags) {
+        send(name, String.valueOf(value), type, tags);
+    }
+
+    private void send(
+            final String name,
+            final String value,
+            final DMetricType type,
+            final List<String> tags) {
+        String typeString = type.typeEncoding;
+        String tagsString = tags.isEmpty() ? "" : "|#" + String.join(",", tags);
+
+        String formatted = String.format("%s:%s|%s%s", name, value, typeString, tagsString);
+
+        try {
+            byte[] data = formatted.getBytes(StandardCharsets.UTF_8);
+            socket.send(new DatagramPacket(data, data.length, this.address));
+        } catch (IOException e) {
+            LOG.error(
+                    "Unable to send packet to DogStatsD at '{}:{}'",
+                    address.getHostName(),
+                    address.getPort());
+        }
+    }
+
+    /** Get tags from MetricGroup#getAllVariables(). */
+    private List<String> getTagsFromMetricGroup(MetricGroup metricGroup) {
+        List<String> tags = new ArrayList<>();
+
+        for (Map.Entry<String, String> entry : metricGroup.getAllVariables().entrySet()) {
+            tags.add(stripBrackets(entry.getKey()) + ":" + entry.getValue());
+        }
+        return tags;
+    }
+
+    /** Removes leading and trailing angle brackets. */
+    private String stripBrackets(String str) {
+        return str.substring(1, str.length() - 1);
+    }
+
+    private List<String> getTagsFromConfig(String str) {
+        if (str.trim().isEmpty()) {
+            return new ArrayList<>();
+        } else {
+            return Arrays.asList(str.split(","));
+        }
+    }
+
+    /**
+     * DogStatsD names should: start with letter, uses ascii alphanumerics and underscore, separated
+     * by periods. Collapse runs of invalid characters into an underscore. Discard invalid prefix
+     * and suffix. Eg: ":::metric:::name:::" -> "metric_name"
+     */
+    private boolean isValidStatsdChar(char c) {
+        return (c >= 'A' && c <= 'Z')
+                || (c >= 'a' && c <= 'z')
+                || (c >= '0' && c <= '9')
+                || (c == '_')
+                || (c == '.');
+    }
+
+    private String filterNCharacters(String input, int limit) {
+        char[] chars = null;
+        final int strLen = input.length();
+        int pos = 0;
+        boolean insertFiller = false;
+
+        for (int i = 0; i < strLen && pos < limit; i++) {
+            final char c = input.charAt(i);
+            if (isValidStatsdChar(c)) {
+                if (chars != null) {
+                    // skip invalid suffix, only fill if followed by valid character
+                    if (insertFiller) {
+                        chars[pos++] = '_';
+                        insertFiller = false;
+                    }
+                    chars[pos] = c;
+                }
+                pos++;
+            } else {
+                if (chars == null) {
+                    chars = input.toCharArray();
+                }
+                // skip invalid prefix, until pos > 0
+                if (pos > 0) {
+                    // collapse sequence of invalid char into one filler
+                    insertFiller = true;
+                }
+            }
+        }
+
+        if (chars == null) {
+            if (strLen > limit) {
+                return input.substring(0, limit);
+            } else {
+                return input; // happy path, input is entirely valid and under the limit
+            }
+        } else {
+            return new String(chars, 0, pos);
+        }
+    }
+
+    /**
+     * filterCharacters() is called on each delimited segment of the metric.
+     *
+     * <p>We might get a string that has coded structures, references to instances of serializers
+     * and reducers, and even if we normalize all the odd characters could be overly long for a
+     * metric name, likely to be truncated downstream. Our choices here appear to be either to
+     * discard invalid metrics, or to pragmatically handle each of the various issues and produce
+     * something that might be useful in aggregate even though the named parts are hard to read.
+     *
+     * <p>This function will find and remove all object references like @abcd0123, so that task and
+     * operator names are stable. The name of an operator should be the same every time it is run,
+     * so we should ignore object hash ids like these.
+     *
+     * <p>If the segment is a tm_id, task_id, job_id, task_attempt_id, we can optionally trim those
+     * to the first 8 chars. This can reduce overall length substantially while still preserving
+     * enough to distinguish metrics from each other.
+     *
+     * <p>If the segment is 50 chars or longer, we will compress it to avoid truncation. The
+     * compression will look like the first 10 valid chars followed by a hash of the original. This
+     * sacrifices readability for utility as a metric, so that latency metrics might survive with
+     * valid and useful dimensions for aggregation, even if it is very hard to reverse engineer the
+     * particular operator name. Application developers can of course still supply their own names
+     * and are not forced to rely on the defaults.
+     *
+     * <p>This will turn something like: "TriggerWindow(TumblingProcessingTimeWindows(5000),
+     * ReducingStateDescriptor{serializer=org.apache.flink.api.java
+     * .typeutils.runtime.PojoSerializer@f3395ffa,
+     * reduceFunction=org.apache.flink.streaming.examples.socket. SocketWindowWordCount$1@4201c465},
+     * ProcessingTimeTrigger(), WindowedStream.reduce(WindowedStream.java-301))"
+     *
+     * <p>into: "TriggerWin_c2910b88"
+     */
+    @Override
+    public String filterCharacters(String input) {
+        // remove instance references
+        Matcher hasRefs = instanceRef.matcher(input);
+        if (hasRefs.find()) {
+            input = hasRefs.replaceAll("");
+        }
+        // compress segments too long
+        if (input.length() >= 50) {
+            return filterNCharacters(input, 10) + "_" + Integer.toHexString(input.hashCode());
+        }
+        int limit = Integer.MAX_VALUE;
+        // optionally shrink flink ids
+        if (shortIds && input.length() == 32 && flinkId.matcher(input).matches()) {
+            limit = 8;
+        }
+        return filterNCharacters(input, limit);
+    }
+}

--- a/flink-metrics/flink-metrics-dogstatsd/src/main/java/org/apache/flink/metrics/dogstatsd/DogStatsDReporterFactory.java
+++ b/flink-metrics/flink-metrics-dogstatsd/src/main/java/org/apache/flink/metrics/dogstatsd/DogStatsDReporterFactory.java
@@ -1,0 +1,36 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.flink.metrics.dogstatsd;
+
+import org.apache.flink.metrics.reporter.InterceptInstantiationViaReflection;
+import org.apache.flink.metrics.reporter.MetricReporter;
+import org.apache.flink.metrics.reporter.MetricReporterFactory;
+
+import java.util.Properties;
+
+/** {@link MetricReporterFactory} for {@link DogStatsDReporter}. */
+@InterceptInstantiationViaReflection(
+        reporterClassName = "org.apache.flink.metrics.dogstatsd.DogStatsDReporter")
+public class DogStatsDReporterFactory implements MetricReporterFactory {
+
+    @Override
+    public MetricReporter createMetricReporter(Properties properties) {
+        return new DogStatsDReporter();
+    }
+}

--- a/flink-metrics/flink-metrics-dogstatsd/src/main/resources/META-INF/services/org.apache.flink.metrics.reporter.MetricReporterFactory
+++ b/flink-metrics/flink-metrics-dogstatsd/src/main/resources/META-INF/services/org.apache.flink.metrics.reporter.MetricReporterFactory
@@ -1,0 +1,16 @@
+# Licensed to the Apache Software Foundation (ASF) under one or more
+# contributor license agreements.  See the NOTICE file distributed with
+# this work for additional information regarding copyright ownership.
+# The ASF licenses this file to You under the Apache License, Version 2.0
+# (the "License"); you may not use this file except in compliance with
+# the License.  You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+org.apache.flink.metrics.dogstatsd.DogStatsDReporterFactory

--- a/flink-metrics/flink-metrics-dogstatsd/src/test/java/org/apache/flink/metrics/dogstatsd/DogStatsDReporterFactoryTest.java
+++ b/flink-metrics/flink-metrics-dogstatsd/src/test/java/org/apache/flink/metrics/dogstatsd/DogStatsDReporterFactoryTest.java
@@ -1,0 +1,33 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.flink.metrics.dogstatsd;
+
+import org.apache.flink.metrics.util.MetricReporterTestUtils;
+import org.apache.flink.util.TestLogger;
+
+import org.junit.Test;
+
+/** Tests for the {@link DogStatsDReporterFactory}. */
+public class DogStatsDReporterFactoryTest extends TestLogger {
+
+    @Test
+    public void testMetricReporterSetupViaSPI() {
+        MetricReporterTestUtils.testMetricReporterSetupViaSPI(DogStatsDReporterFactory.class);
+    }
+}

--- a/flink-metrics/flink-metrics-dogstatsd/src/test/java/org/apache/flink/metrics/dogstatsd/DogStatsDReporterTest.java
+++ b/flink-metrics/flink-metrics-dogstatsd/src/test/java/org/apache/flink/metrics/dogstatsd/DogStatsDReporterTest.java
@@ -1,0 +1,548 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.flink.metrics.dogstatsd;
+
+import org.apache.flink.api.common.JobID;
+import org.apache.flink.configuration.ConfigConstants;
+import org.apache.flink.configuration.Configuration;
+import org.apache.flink.configuration.DelegatingConfiguration;
+import org.apache.flink.configuration.MetricOptions;
+import org.apache.flink.metrics.Counter;
+import org.apache.flink.metrics.Gauge;
+import org.apache.flink.metrics.Metric;
+import org.apache.flink.metrics.MetricConfig;
+import org.apache.flink.metrics.MetricGroup;
+import org.apache.flink.metrics.SimpleCounter;
+import org.apache.flink.metrics.groups.UnregisteredMetricsGroup;
+import org.apache.flink.metrics.reporter.MetricReporter;
+import org.apache.flink.metrics.util.TestCounter;
+import org.apache.flink.metrics.util.TestHistogram;
+import org.apache.flink.metrics.util.TestMeter;
+import org.apache.flink.runtime.clusterframework.types.ResourceID;
+import org.apache.flink.runtime.executiongraph.ExecutionAttemptID;
+import org.apache.flink.runtime.jobgraph.JobVertexID;
+import org.apache.flink.runtime.jobgraph.OperatorID;
+import org.apache.flink.runtime.metrics.MetricRegistryConfiguration;
+import org.apache.flink.runtime.metrics.MetricRegistryImpl;
+import org.apache.flink.runtime.metrics.ReporterSetup;
+import org.apache.flink.runtime.metrics.groups.InternalOperatorMetricGroup;
+import org.apache.flink.runtime.metrics.groups.TaskManagerMetricGroup;
+import org.apache.flink.util.TestLogger;
+
+import org.junit.Test;
+
+import java.io.IOException;
+import java.net.DatagramPacket;
+import java.net.DatagramSocket;
+import java.net.SocketException;
+import java.util.Collections;
+import java.util.HashMap;
+import java.util.HashSet;
+import java.util.List;
+import java.util.Map;
+import java.util.Set;
+import java.util.concurrent.ConcurrentHashMap;
+import java.util.concurrent.TimeoutException;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertTrue;
+
+/** Tests for the DogStatsDReporter. */
+public class DogStatsDReporterTest extends TestLogger {
+
+    @Test
+    public void testReplaceInvalidChars() {
+        DogStatsDReporter reporter = new DogStatsDReporter();
+        String triggerWindowName =
+                "TriggerWindow(TumblingProcessingTimeWindows(5000), ReducingStateDescriptor{serializer=org.apache.flink.api.java.typeutils.runtime.PojoSerializer@f3395ffa, reduceFunction=org.apache.flink.streaming.examples.socket.SocketWindowWordCount$1@4201c465}, ProcessingTimeTrigger(), WindowedStream.reduce(WindowedStream.java-301))";
+        String triggerWindowAltInstance =
+                triggerWindowName
+                        .replace("@f3395ffa", "@f3395ffb")
+                        .replace("@4201c465", "@564c1024");
+
+        assertEquals("", reporter.filterCharacters(""));
+        assertEquals("abc", reporter.filterCharacters("abc"));
+        assertEquals("a_b", reporter.filterCharacters("a:b::"));
+        assertEquals("metric_name", reporter.filterCharacters(" (metric -> name) "));
+        assertEquals("TriggerWin_c2910b88", reporter.filterCharacters(triggerWindowName));
+        assertEquals("TriggerWin_c2910b88", reporter.filterCharacters(triggerWindowAltInstance));
+    }
+
+    @Test
+    public void testShortIds() throws Exception {
+        Configuration config = new Configuration();
+        config.setString(MetricOptions.REPORTERS_LIST, "test");
+        config.setString(
+                ConfigConstants.METRICS_REPORTER_PREFIX
+                        + "test."
+                        + ConfigConstants.METRICS_REPORTER_CLASS_SUFFIX,
+                DogStatsDReporter.class.getName());
+        config.setString(ConfigConstants.METRICS_REPORTER_PREFIX + "test.shortids", "true");
+        config.setString(ConfigConstants.METRICS_REPORTER_PREFIX + "test.host", "localhost");
+        config.setString(ConfigConstants.METRICS_REPORTER_PREFIX + "test.port", "" + 8125);
+
+        MetricRegistryImpl metricRegistry = createRegistry(config);
+
+        DogStatsDReporter reporter = (DogStatsDReporter) metricRegistry.getReporters().get(0);
+
+        assertEquals("0c3d7952", reporter.filterCharacters("0c3d7952a3c76c029ecf80ef239d475b"));
+        assertEquals("ad25ca60", reporter.filterCharacters("ad25ca6074f1ec1a20030e9b9e11c476"));
+        assertEquals(
+                "this_isn_t_an_id_but_same_length",
+                reporter.filterCharacters("this_isn_t_an_id_but_same_length"));
+
+        metricRegistry.shutdown().get();
+    }
+
+    /** Tests that the registered metrics' names don't contain invalid characters. */
+    @Test
+    public void testAddingMetrics() throws Exception {
+        Configuration configuration = new Configuration();
+        String taskName = "testTask";
+        String jobName = "testJob:-!ax..?";
+        String hostname = "local::host:";
+        String taskManagerId = "tas:kMana::ger";
+        String operatorName = "operator";
+        String taskManager = "taskmanager";
+        int subtaskIndex = 0;
+        String counterName = "testCounter";
+
+        configuration.setString(MetricOptions.REPORTERS_LIST, "test");
+        configuration.setString(
+                ConfigConstants.METRICS_REPORTER_PREFIX
+                        + "test."
+                        + ConfigConstants.METRICS_REPORTER_CLASS_SUFFIX,
+                "org.apache.flink.metrics.dogstatsd.DogStatsDReporterTest$TestingStatsDReporter");
+        configuration.setString(ConfigConstants.METRICS_REPORTER_PREFIX + "test.host", "localhost");
+        configuration.setString(ConfigConstants.METRICS_REPORTER_PREFIX + "test.port", "" + 8125);
+
+        configuration.setString(MetricOptions.SCOPE_NAMING_TASK, "<host>.<tm_id>.<job_name>");
+        configuration.setString(MetricOptions.SCOPE_DELIMITER, "_");
+
+        MetricRegistryImpl metricRegistry = createRegistry(configuration);
+
+        char delimiter = metricRegistry.getDelimiter();
+
+        InternalOperatorMetricGroup operatorGroup =
+                TaskManagerMetricGroup.createTaskManagerMetricGroup(
+                                metricRegistry, hostname, new ResourceID(taskManagerId))
+                        .addJob(new JobID(), jobName)
+                        .addTask(
+                                new JobVertexID(),
+                                new ExecutionAttemptID(),
+                                taskName,
+                                subtaskIndex,
+                                0)
+                        .getOrAddOperator(operatorName);
+
+        SimpleCounter myCounter = new SimpleCounter();
+
+        operatorGroup.counter(counterName, myCounter);
+
+        List<MetricReporter> reporters = metricRegistry.getReporters();
+
+        assertEquals(1, reporters.size());
+
+        MetricReporter metricReporter = reporters.get(0);
+
+        assertTrue(
+                "Reporter should be of type DogStatsDReporter",
+                metricReporter instanceof DogStatsDReporter);
+
+        TestingDogStatsDReporter reporter = (TestingDogStatsDReporter) metricReporter;
+
+        Map<Counter, DogStatsDReporter.DMetric> counters = reporter.getCounters();
+
+        assertTrue(counters.containsKey(myCounter));
+
+        String expectedCounterName =
+                reporter.filterCharacters(hostname)
+                        + delimiter
+                        + taskManager
+                        + delimiter
+                        + reporter.filterCharacters(taskManagerId)
+                        + delimiter
+                        + reporter.filterCharacters(jobName)
+                        + delimiter
+                        + operatorName
+                        + delimiter
+                        + subtaskIndex
+                        + delimiter
+                        + reporter.filterCharacters(counterName);
+
+        assertEquals(expectedCounterName, counters.get(myCounter).getName());
+
+        metricRegistry.shutdown().get();
+    }
+
+    /** Tests that statsd lines are valid. */
+    @Test
+    public void testIgnoreInvalidValues() throws Exception {
+        Set<String> expectedLines = new HashSet<>();
+        expectedLines.add("metric:1.23|g");
+
+        testMetricAndAssert((Gauge) () -> "n/a", "metric", new HashSet<>());
+        testMetricAndAssert((Gauge) () -> Double.NaN, "metric", new HashSet<>());
+        testMetricAndAssert((Gauge) () -> 1.23, "metric", expectedLines);
+    }
+
+    @Test
+    public void testTags() throws Exception {
+        MetricRegistryImpl registry = null;
+        DatagramSocketReceiver receiver = null;
+        Thread receiverThread = null;
+        long timeout = 5000;
+        long joinTimeout = 30000;
+
+        try {
+            receiver = new DatagramSocketReceiver();
+
+            receiverThread = new Thread(receiver);
+
+            receiverThread.start();
+
+            int port = receiver.getPort();
+
+            Configuration config = new Configuration();
+            config.setString(MetricOptions.REPORTERS_LIST, "test");
+            config.setString(
+                    ConfigConstants.METRICS_REPORTER_PREFIX
+                            + "test."
+                            + ConfigConstants.METRICS_REPORTER_CLASS_SUFFIX,
+                    DogStatsDReporter.class.getName());
+            config.setString(
+                    ConfigConstants.METRICS_REPORTER_PREFIX
+                            + "test."
+                            + ConfigConstants.METRICS_REPORTER_INTERVAL_SUFFIX,
+                    "1 SECONDS");
+            config.setString(ConfigConstants.METRICS_REPORTER_PREFIX + "test.host", "localhost");
+            config.setString(ConfigConstants.METRICS_REPORTER_PREFIX + "test.port", "" + port);
+            config.setString(ConfigConstants.METRICS_REPORTER_PREFIX + "test.shortids", "true");
+
+            registry = createRegistry(config, new DogStatsDReporter());
+
+            JobID jobID = new JobID();
+            JobVertexID taskId = new JobVertexID();
+            ExecutionAttemptID attemptId = new ExecutionAttemptID();
+            OperatorID operatorID = new OperatorID();
+
+            InternalOperatorMetricGroup operatorGroup =
+                    TaskManagerMetricGroup.createTaskManagerMetricGroup(
+                                    registry, "hostName", new ResourceID("taskManagerId"))
+                            .addJob(jobID, "jobName")
+                            .addTask(taskId, attemptId, "taskName", 1, 2)
+                            .getOrAddOperator(operatorID, "operatorName");
+
+            Gauge<Double> sample =
+                    new Gauge<Double>() {
+                        @Override
+                        public Double getValue() {
+                            return 1.23;
+                        }
+                    };
+
+            operatorGroup.gauge("sample", sample);
+
+            receiver.waitUntilNumLines(10, timeout);
+            Set<String> lines = receiver.getLines();
+
+            Map<String, String> expectedTags = new HashMap<>();
+            expectedTags.put("host", "hostName");
+            expectedTags.put("job_id", jobID.toString().substring(0, 8));
+            expectedTags.put("job_name", "jobName");
+            expectedTags.put("operator_name", "operatorName");
+            expectedTags.put("subtask_index", "1");
+            expectedTags.put("task_attempt_id", attemptId.toString().substring(0, 8));
+            expectedTags.put("task_attempt_num", "2");
+            expectedTags.put("task_id", taskId.toString().substring(0, 8));
+            expectedTags.put("task_name", "taskName");
+            expectedTags.put("tm_id", "taskManagerId");
+
+            String expectedName =
+                    "hostName.taskmanager.taskManagerId.jobName.operatorName.1.sample";
+
+            Boolean gotName = false;
+            for (String line : lines) {
+                if (line.startsWith(expectedName + ':')) {
+                    gotName = true;
+                    for (Map.Entry<String, String> tag : expectedTags.entrySet()) {
+                        String tagLine = tag.getKey() + ':' + tag.getValue();
+                        assertTrue(
+                                "expecting to find " + tagLine + " in " + line,
+                                line.contains(tagLine));
+                    }
+                    break;
+                }
+            }
+            assertTrue("expecting to find " + expectedName, gotName);
+
+        } finally {
+            if (registry != null) {
+                registry.shutdown().get();
+            }
+
+            if (receiver != null) {
+                receiver.stop();
+            }
+
+            if (receiverThread != null) {
+                receiverThread.join(joinTimeout);
+            }
+        }
+    }
+
+    /** Tests that histograms are properly reported via the StatsD reporter. */
+    @Test
+    public void testHistogramReporting() throws Exception {
+        Set<String> expectedLines = new HashSet<>(6);
+        expectedLines.add("metric.count:1|c");
+        expectedLines.add("metric.avg:4.0|g");
+        expectedLines.add("metric.min:7|g");
+        expectedLines.add("metric.max:6|g");
+        expectedLines.add("metric.95percentile:0.95|g");
+        expectedLines.add("metric.median:0.5|g");
+
+        testMetricAndAssert(new TestHistogram(), "metric", expectedLines);
+    }
+
+    @Test
+    public void testHistogramReportingOfNegativeValues() throws Exception {
+        TestHistogram histogram = new TestHistogram();
+        histogram.setCount(-101);
+        histogram.setMean(-104);
+        histogram.setMin(-107);
+        histogram.setMax(-106);
+        histogram.setStdDev(-105);
+
+        Set<String> expectedLines = new HashSet<>();
+        expectedLines.add("metric.count:-101|c");
+        expectedLines.add("metric.avg:-104.0|g");
+        expectedLines.add("metric.min:-107|g");
+        expectedLines.add("metric.max:-106|g");
+        expectedLines.add("metric.95percentile:0.95|g");
+        expectedLines.add("metric.median:0.5|g");
+
+        testMetricAndAssert(histogram, "metric", expectedLines);
+    }
+
+    /** Tests that meters are properly reported via the StatsD reporter. */
+    @Test
+    public void testMetersReporting() throws Exception {
+        Set<String> expectedLines = new HashSet<>(4);
+        expectedLines.add("metric.rate:5.0|g");
+        expectedLines.add("metric.count:100|c");
+
+        testMetricAndAssert(new TestMeter(), "metric", expectedLines);
+    }
+
+    @Test
+    public void testMetersReportingOfNegativeValues() throws Exception {
+        Set<String> expectedLines = new HashSet<>();
+        expectedLines.add("metric.rate:-5.3|g");
+        expectedLines.add("metric.count:-50|c");
+
+        testMetricAndAssert(new TestMeter(-50, -5.3), "metric", expectedLines);
+    }
+
+    /** Tests that counter are properly reported via the StatsD reporter. */
+    @Test
+    public void testCountersReporting() throws Exception {
+        Set<String> expectedLines = new HashSet<>(2);
+        expectedLines.add("metric:100|c");
+
+        testMetricAndAssert(new TestCounter(100), "metric", expectedLines);
+    }
+
+    @Test
+    public void testCountersReportingOfNegativeValues() throws Exception {
+        Set<String> expectedLines = new HashSet<>();
+        expectedLines.add("metric:-51|c");
+
+        testMetricAndAssert(new TestCounter(-51), "metric", expectedLines);
+    }
+
+    @Test
+    public void testGaugesReporting() throws Exception {
+        Set<String> expectedLines = new HashSet<>(2);
+        expectedLines.add("metric:75|g");
+
+        testMetricAndAssert((Gauge) () -> 75, "metric", expectedLines);
+    }
+
+    @Test
+    public void testGaugesReportingOfNegativeValues() throws Exception {
+        Set<String> expectedLines = new HashSet<>();
+        expectedLines.add("metric:-12345|g");
+
+        testMetricAndAssert((Gauge) () -> -12345, "metric", expectedLines);
+    }
+
+    private MetricRegistryImpl createRegistry(Configuration config) {
+        return createRegistry(config, new TestingDogStatsDReporter());
+    }
+
+    private MetricRegistryImpl createRegistry(Configuration config, MetricReporter metricReporter) {
+        String reporterName = "test";
+
+        MetricConfig metricConfig = new MetricConfig();
+        DelegatingConfiguration delegatingConfiguration =
+                new DelegatingConfiguration(
+                        config, ConfigConstants.METRICS_REPORTER_PREFIX + reporterName + '.');
+        delegatingConfiguration.addAllToProperties(metricConfig);
+
+        return new MetricRegistryImpl(
+                MetricRegistryConfiguration.fromConfiguration(config, 10485760),
+                Collections.singletonList(
+                        ReporterSetup.forReporter(reporterName, metricConfig, metricReporter)));
+    }
+
+    private void testMetricAndAssert(Metric metric, String metricName, Set<String> expectation)
+            throws Exception {
+        DogStatsDReporter reporter = null;
+        DatagramSocketReceiver receiver = null;
+        Thread receiverThread = null;
+        long timeout = 5000;
+        long joinTimeout = 30000;
+
+        try {
+            receiver = new DatagramSocketReceiver();
+
+            receiverThread = new Thread(receiver);
+
+            receiverThread.start();
+
+            int port = receiver.getPort();
+
+            MetricConfig config = new MetricConfig();
+            config.setProperty("host", "localhost");
+            config.setProperty("port", String.valueOf(port));
+
+            reporter = new DogStatsDReporter();
+            ReporterSetup.forReporter("test", config, reporter);
+            MetricGroup metricGroup = new UnregisteredMetricsGroup();
+
+            reporter.notifyOfAddedMetric(metric, metricName, metricGroup);
+            reporter.report();
+
+            receiver.waitUntilNumLines(expectation.size(), timeout);
+            assertEquals(expectation, receiver.getLines());
+
+        } finally {
+            if (reporter != null) {
+                reporter.close();
+            }
+
+            if (receiver != null) {
+                receiver.stop();
+            }
+
+            if (receiverThread != null) {
+                receiverThread.join(joinTimeout);
+            }
+        }
+    }
+
+    /** Testing StatsDReporter which disables the socket creation. */
+    public static class TestingDogStatsDReporter extends DogStatsDReporter {
+        @Override
+        protected void establishConnection(String host, Integer port) {
+            // disable the socket creation
+        }
+
+        public Map<Counter, DMetric> getCounters() {
+            return counters;
+        }
+    }
+
+    private static class DatagramSocketReceiver implements Runnable {
+        private static final Object obj = new Object();
+
+        private final DatagramSocket socket;
+        private final ConcurrentHashMap<String, Object> lines;
+
+        private boolean running = true;
+
+        public DatagramSocketReceiver() throws SocketException {
+            socket = new DatagramSocket();
+            lines = new ConcurrentHashMap<>();
+        }
+
+        public int getPort() {
+            return socket.getLocalPort();
+        }
+
+        public void stop() {
+            running = false;
+            socket.close();
+        }
+
+        public void waitUntilNumLines(int numberLines, long timeout) throws TimeoutException {
+            long endTimeout = System.currentTimeMillis() + timeout;
+            long remainingTimeout = timeout;
+
+            synchronized (lines) {
+                while (numberLines > lines.size() && remainingTimeout > 0) {
+                    try {
+                        lines.wait(remainingTimeout);
+                    } catch (InterruptedException e) {
+                        // ignore interruption exceptions
+                    }
+
+                    remainingTimeout = endTimeout - System.currentTimeMillis();
+                }
+            }
+
+            if (remainingTimeout <= 0) {
+                throw new TimeoutException("Have not received " + numberLines + " in time.");
+            }
+        }
+
+        public Set<String> getLines() {
+            return lines.keySet();
+        }
+
+        @Override
+        public void run() {
+            while (running) {
+                try {
+                    byte[] buffer = new byte[1024];
+
+                    DatagramPacket packet = new DatagramPacket(buffer, buffer.length);
+
+                    socket.receive(packet);
+
+                    String line =
+                            new String(
+                                    packet.getData(),
+                                    0,
+                                    packet.getLength(),
+                                    ConfigConstants.DEFAULT_CHARSET);
+
+                    lines.put(line, obj);
+
+                    synchronized (lines) {
+                        lines.notifyAll();
+                    }
+                } catch (IOException ex) {
+                    // ignore the exceptions
+                }
+            }
+        }
+    }
+}

--- a/flink-metrics/flink-metrics-dogstatsd/src/test/resources/log4j2-test.properties
+++ b/flink-metrics/flink-metrics-dogstatsd/src/test/resources/log4j2-test.properties
@@ -1,0 +1,28 @@
+################################################################################
+#  Licensed to the Apache Software Foundation (ASF) under one
+#  or more contributor license agreements.  See the NOTICE file
+#  distributed with this work for additional information
+#  regarding copyright ownership.  The ASF licenses this file
+#  to you under the Apache License, Version 2.0 (the
+#  "License"); you may not use this file except in compliance
+#  with the License.  You may obtain a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+#  Unless required by applicable law or agreed to in writing, software
+#  distributed under the License is distributed on an "AS IS" BASIS,
+#  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+#  See the License for the specific language governing permissions and
+# limitations under the License.
+################################################################################
+
+# Set root logger level to OFF to not flood build logs
+# set manually to INFO for debugging purposes
+rootLogger.level = OFF
+rootLogger.appenderRef.test.ref = TestLogger
+
+appender.testlogger.name = TestLogger
+appender.testlogger.type = CONSOLE
+appender.testlogger.target = SYSTEM_ERR
+appender.testlogger.layout.type = PatternLayout
+appender.testlogger.layout.pattern = %-4r [%t] %-5p %c %x - %m%n

--- a/tools/ci/stage.sh
+++ b/tools/ci/stage.sh
@@ -113,6 +113,7 @@ flink-metrics/flink-metrics-influxdb,\
 flink-metrics/flink-metrics-prometheus,\
 flink-metrics/flink-metrics-statsd,\
 flink-metrics/flink-metrics-datadog,\
+flink-metrics/flink-metrics-dogstatsd,\
 flink-metrics/flink-metrics-slf4j,\
 flink-queryable-state/flink-queryable-state-runtime,\
 flink-queryable-state/flink-queryable-state-client-java"


### PR DESCRIPTION
## What is the purpose of the change

This pull request adds a new metrics reporter for the DogStatsD protocol.

## Brief change log

- Adding new `flink-metrics/flink-metrics-dogstatsd` module
- New `DogStatsDReporter` / `DogStatsDReporterFactory` with corresponding tests
- Updating documentation for metrics reporters

## Verifying this change

This change added tests and can be verified as follows:

- Running `DogStatsDReporterTest` / `DogStatsDReporterFactoryTest` that cover complete functionality
- Also manually verified the change by using the new reporter in many Flink applications deployed in different environments

## Does this pull request potentially affect one of the following parts:

  - Dependencies (does it add or upgrade a dependency): no
  - The public API, i.e., is any changed class annotated with no
  - The serializers: no
  - The runtime per-record code paths (performance sensitive): no
  - Anything that affects deployment or recovery: no
  - The S3 file system connector: no

## Documentation

  - Does this pull request introduce a new feature? yes
  - If yes, how is the feature documented? docs
