### PR TITLE
[FLINK-24857][test][Kafka] Upgrade SourceReaderTestBase t…

### DIFF
--- a/flink-connectors/flink-connector-base/src/test/java/org/apache/flink/connector/base/source/reader/SourceReaderBaseTest.java
+++ b/flink-connectors/flink-connector-base/src/test/java/org/apache/flink/connector/base/source/reader/SourceReaderBaseTest.java
@@ -38,9 +38,7 @@ import org.apache.flink.connector.testutils.source.reader.TestingReaderContext;
 import org.apache.flink.connector.testutils.source.reader.TestingReaderOutput;
 import org.apache.flink.core.io.InputStatus;
 
-import org.junit.Rule;
-import org.junit.Test;
-import org.junit.rules.ExpectedException;
+import org.junit.jupiter.api.Test;
 
 import java.util.ArrayList;
 import java.util.Arrays;
@@ -50,75 +48,81 @@ import java.util.Map;
 import java.util.concurrent.CompletableFuture;
 import java.util.function.Supplier;
 
-import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertFalse;
-import static org.junit.Assert.assertNotEquals;
-import static org.junit.Assert.assertTrue;
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
 
 /** A unit test class for {@link SourceReaderBase}. */
 public class SourceReaderBaseTest extends SourceReaderTestBase<MockSourceSplit> {
 
-    @Rule public ExpectedException expectedException = ExpectedException.none();
-
     @Test
-    public void testExceptionInSplitReader() throws Exception {
-        expectedException.expect(RuntimeException.class);
-        expectedException.expectMessage("One or more fetchers have encountered exception");
-        final String errMsg = "Testing Exception";
+    void testExceptionInSplitReader() {
+        assertThatThrownBy(
+                        () -> {
+                            final String errMsg = "Testing Exception";
 
-        FutureCompletingBlockingQueue<RecordsWithSplitIds<int[]>> elementsQueue =
-                new FutureCompletingBlockingQueue<>();
-        // We have to handle split changes first, otherwise fetch will not be called.
-        try (MockSourceReader reader =
-                new MockSourceReader(
-                        elementsQueue,
-                        () ->
-                                new SplitReader<int[], MockSourceSplit>() {
-                                    @Override
-                                    public RecordsWithSplitIds<int[]> fetch() {
-                                        throw new RuntimeException(errMsg);
-                                    }
+                            FutureCompletingBlockingQueue<RecordsWithSplitIds<int[]>>
+                                    elementsQueue = new FutureCompletingBlockingQueue<>();
+                            // We have to handle split changes first, otherwise fetch will not be
+                            // called.
+                            try (MockSourceReader reader =
+                                    new MockSourceReader(
+                                            elementsQueue,
+                                            () ->
+                                                    new SplitReader<int[], MockSourceSplit>() {
+                                                        @Override
+                                                        public RecordsWithSplitIds<int[]> fetch() {
+                                                            throw new RuntimeException(errMsg);
+                                                        }
 
-                                    @Override
-                                    public void handleSplitsChanges(
-                                            SplitsChange<MockSourceSplit> splitsChanges) {}
+                                                        @Override
+                                                        public void handleSplitsChanges(
+                                                                SplitsChange<MockSourceSplit>
+                                                                        splitsChanges) {}
 
-                                    @Override
-                                    public void wakeUp() {}
+                                                        @Override
+                                                        public void wakeUp() {}
 
-                                    @Override
-                                    public void close() {}
-                                },
-                        getConfig(),
-                        new TestingReaderContext())) {
-            ValidatingSourceOutput output = new ValidatingSourceOutput();
-            reader.addSplits(
-                    Collections.singletonList(
-                            getSplit(0, NUM_RECORDS_PER_SPLIT, Boundedness.CONTINUOUS_UNBOUNDED)));
-            reader.notifyNoMoreSplits();
-            // This is not a real infinite loop, it is supposed to throw exception after two polls.
-            while (true) {
-                InputStatus inputStatus = reader.pollNext(output);
-                assertNotEquals(InputStatus.END_OF_INPUT, inputStatus);
-                // Add a sleep to avoid tight loop.
-                Thread.sleep(1);
-            }
-        }
+                                                        @Override
+                                                        public void close() {}
+                                                    },
+                                            getConfig(),
+                                            new TestingReaderContext())) {
+                                ValidatingSourceOutput output = new ValidatingSourceOutput();
+                                reader.addSplits(
+                                        Collections.singletonList(
+                                                getSplit(
+                                                        0,
+                                                        NUM_RECORDS_PER_SPLIT,
+                                                        Boundedness.CONTINUOUS_UNBOUNDED)));
+                                reader.notifyNoMoreSplits();
+                                // This is not a real infinite loop, it is supposed to throw
+                                // exception after
+                                // two polls.
+                                while (true) {
+                                    InputStatus inputStatus = reader.pollNext(output);
+                                    assertThat(inputStatus).isNotEqualTo(InputStatus.END_OF_INPUT);
+                                    // Add a sleep to avoid tight loop.
+                                    Thread.sleep(1);
+                                }
+                            }
+                        })
+                .isInstanceOf(RuntimeException.class)
+                .hasMessage("One or more fetchers have encountered exception");
     }
 
     @Test
-    public void testRecordsWithSplitsNotRecycledWhenRecordsLeft() throws Exception {
+    void testRecordsWithSplitsNotRecycledWhenRecordsLeft() throws Exception {
         final TestingRecordsWithSplitIds<String> records =
                 new TestingRecordsWithSplitIds<>("test-split", "value1", "value2");
         final SourceReader<?, ?> reader = createReaderAndAwaitAvailable("test-split", records);
 
         reader.pollNext(new TestingReaderOutput<>());
 
-        assertFalse(records.isRecycled());
+        assertThat(records.isRecycled()).isFalse();
     }
 
     @Test
-    public void testRecordsWithSplitsRecycledWhenEmpty() throws Exception {
+    void testRecordsWithSplitsRecycledWhenEmpty() throws Exception {
         final TestingRecordsWithSplitIds<String> records =
                 new TestingRecordsWithSplitIds<>("test-split", "value1", "value2");
         final SourceReader<?, ?> reader = createReaderAndAwaitAvailable("test-split", records);
@@ -129,11 +133,11 @@ public class SourceReaderBaseTest extends SourceReaderTestBase<MockSourceSplit> 
         reader.pollNext(new TestingReaderOutput<>());
         reader.pollNext(new TestingReaderOutput<>());
 
-        assertTrue(records.isRecycled());
+        assertThat(records.isRecycled()).isTrue();
     }
 
     @Test
-    public void testMultipleSplitsWithDifferentFinishingMoments() throws Exception {
+    void testMultipleSplitsWithDifferentFinishingMoments() throws Exception {
         FutureCompletingBlockingQueue<RecordsWithSplitIds<int[]>> elementsQueue =
                 new FutureCompletingBlockingQueue<>();
         MockSplitReader mockSplitReader =
@@ -169,7 +173,7 @@ public class SourceReaderBaseTest extends SourceReaderTestBase<MockSourceSplit> 
     }
 
     @Test
-    public void testMultipleSplitsWithSeparatedFinishedRecord() throws Exception {
+    void testMultipleSplitsWithSeparatedFinishedRecord() throws Exception {
         FutureCompletingBlockingQueue<RecordsWithSplitIds<int[]>> elementsQueue =
                 new FutureCompletingBlockingQueue<>();
         MockSplitReader mockSplitReader =
@@ -205,7 +209,7 @@ public class SourceReaderBaseTest extends SourceReaderTestBase<MockSourceSplit> 
     }
 
     @Test
-    public void testPollNextReturnMoreAvailableWhenAllSplitFetcherCloseWithLeftoverElementInQueue()
+    void testPollNextReturnMoreAvailableWhenAllSplitFetcherCloseWithLeftoverElementInQueue()
             throws Exception {
 
         FutureCompletingBlockingQueue<RecordsWithSplitIds<int[]>> elementsQueue =
@@ -231,8 +235,8 @@ public class SourceReaderBaseTest extends SourceReaderTestBase<MockSourceSplit> 
 
         // Add the last record to the split when the splitFetcherManager shutting down SplitFetchers
         splitFetcherManager.getInShutdownSplitFetcherFuture().thenRun(() -> split.addRecord(1));
-        assertEquals(
-                InputStatus.MORE_AVAILABLE, sourceReader.pollNext(new TestingReaderOutput<>()));
+        assertThat(sourceReader.pollNext(new TestingReaderOutput<>()))
+                .isEqualTo(InputStatus.MORE_AVAILABLE);
     }
 
     // ---------------- helper methods -----------------

--- a/flink-test-utils-parent/flink-connector-test-utils/pom.xml
+++ b/flink-test-utils-parent/flink-connector-test-utils/pom.xml
@@ -55,6 +55,12 @@
 		</dependency>
 
 		<dependency>
+			<groupId>org.assertj</groupId>
+			<artifactId>assertj-core</artifactId>
+			<scope>compile</scope>
+		</dependency>
+
+		<dependency>
 			<groupId>org.junit.vintage</groupId>
 			<artifactId>junit-vintage-engine</artifactId>
 			<scope>compile</scope>


### PR DESCRIPTION
…o JUnit 5

<!--
*Thank you very much for contributing to Apache Flink - we are happy that you want to help us improve Flink. To help the community review your contribution in the best possible way, please go through the checklist below, which will get the contribution into a shape in which it can be best reviewed.*

*Please understand that we do not do this to make contributions to Flink a hassle. In order to uphold a high standard of quality for code contributions, while at the same time managing a large number of contributions, we need contributors to prepare the contributions well, and give reviewers enough contextual information for the review. Please also understand that contributions that do not follow this guide will take longer to review and thus typically be picked up with lower priority by the community.*

## Contribution Checklist

  - Make sure that the pull request corresponds to a [JIRA issue](https://issues.apache.org/jira/projects/FLINK/issues). Exceptions are made for typos in JavaDoc or documentation files, which need no JIRA issue.
  
  - Name the pull request in the form "[FLINK-XXXX] [component] Title of the pull request", where *FLINK-XXXX* should be replaced by the actual issue number. Skip *component* if you are unsure about which is the best component.
  Typo fixes that have no associated JIRA issue should be named following this pattern: `[hotfix] [docs] Fix typo in event time introduction` or `[hotfix] [javadocs] Expand JavaDoc for PuncuatedWatermarkGenerator`.

  - Fill out the template below to describe the changes contributed by the pull request. That will give reviewers the context they need to do the review.
  
  - Make sure that the change passes the automated tests, i.e., `mvn clean verify` passes. You can set up Azure Pipelines CI to do that following [this guide](https://cwiki.apache.org/confluence/display/FLINK/Azure+Pipelines#AzurePipelines-Tutorial:SettingupAzurePipelinesforaforkoftheFlinkrepository).

  - Each pull request should address only one issue, not mix up code from multiple issues.
  
  - Each commit in the pull request has a meaningful commit message (including the JIRA id)

  - Once all items of the checklist are addressed, remove the above text and this checklist, leaving only the filled out template below.


**(The sections below can be removed for hotfixes of typos)**
-->

## What is the purpose of the change

 `SourceReaderTestBase` uses JUnit 4 which will be deprecated. Migrating to use JUnit 5 API.

There are two derived tests classes, so changed their implementation to JUnit 5 as well.
- KafkaSourceReaderTest
- SourceReaderBaseTest

## Brief change log

- uses AssertThrows instead of JUnit 4 expectedException rule
- Uses JUnit 5 api



## Verifying this change

Please make sure both new and modified tests in this PR follows the conventions defined in our code quality guide: https://flink.apache.org/contributing/code-style-and-quality-common.html#testing



This change is a trivial rework (test change) without any test coverage.




## Does this pull request potentially affect one of the following parts:

  - Dependencies (does it add or upgrade a dependency): (no)
  - The public API, i.e., is any changed class annotated with `@Public(Evolving)`: ( no)
  - The serializers: (no)
  - The runtime per-record code paths (performance sensitive): (no)
  - Anything that affects deployment or recovery: JobManager (and its components), Checkpointing, Kubernetes/Yarn, ZooKeeper: (no)
  - The S3 file system connector: (no)

## Documentation

  - Does this pull request introduce a new feature? ( no)
  - If yes, how is the feature documented? (not applicable)
