### PR TITLE
[FLINK-25163] replace setIncreaseParallelism with setMaxBackgroundJobs.

### DIFF
--- a/flink-state-backends/flink-statebackend-rocksdb/src/main/java/org/apache/flink/contrib/streaming/state/DefaultConfigurableOptionsFactory.java
+++ b/flink-state-backends/flink-statebackend-rocksdb/src/main/java/org/apache/flink/contrib/streaming/state/DefaultConfigurableOptionsFactory.java
@@ -83,7 +83,7 @@ public class DefaultConfigurableOptionsFactory implements ConfigurableRocksDBOpt
     public DBOptions createDBOptions(
             DBOptions currentOptions, Collection<AutoCloseable> handlesToClose) {
         if (isOptionConfigured(MAX_BACKGROUND_THREADS)) {
-            currentOptions.setIncreaseParallelism(getMaxBackgroundThreads());
+            currentOptions.setMaxBackgroundJobs(getMaxBackgroundThreads());
         }
 
         if (isOptionConfigured(MAX_OPEN_FILES)) {

--- a/flink-state-backends/flink-statebackend-rocksdb/src/main/java/org/apache/flink/contrib/streaming/state/PredefinedOptions.java
+++ b/flink-state-backends/flink-statebackend-rocksdb/src/main/java/org/apache/flink/contrib/streaming/state/PredefinedOptions.java
@@ -75,7 +75,7 @@ public enum PredefinedOptions {
      * <ul>
      *   <li>setCompactionStyle(CompactionStyle.LEVEL)
      *   <li>setLevelCompactionDynamicLevelBytes(true)
-     *   <li>setIncreaseParallelism(4)
+     *   <li>setMaxBackgroundJobs(4)
      *   <li>setDisableDataSync(true)
      *   <li>setMaxOpenFiles(-1)
      *   <li>setInfoLogLevel(InfoLogLevel.HEADER_LEVEL)
@@ -112,7 +112,7 @@ public enum PredefinedOptions {
      *   <li>setTargetFileSizeBase(256 MBytes)
      *   <li>setMaxBytesForLevelBase(1 GByte)
      *   <li>setWriteBufferSize(64 MBytes)
-     *   <li>setIncreaseParallelism(4)
+     *   <li>setMaxBackgroundJobs(4)
      *   <li>setMinWriteBufferNumberToMerge(3)
      *   <li>setMaxWriteBufferNumber(4)
      *   <li>setMaxOpenFiles(-1)
@@ -156,7 +156,7 @@ public enum PredefinedOptions {
      * <p>The following options are set:
      *
      * <ul>
-     *   <li>setIncreaseParallelism(4)
+     *   <li>setMaxBackgroundJobs(4)
      *   <li>setDisableDataSync(true)
      *   <li>setMaxOpenFiles(-1)
      *   <li>setInfoLogLevel(InfoLogLevel.HEADER_LEVEL)

--- a/flink-state-backends/flink-statebackend-rocksdb/src/main/java/org/apache/flink/contrib/streaming/state/RocksDBResourceContainer.java
+++ b/flink-state-backends/flink-statebackend-rocksdb/src/main/java/org/apache/flink/contrib/streaming/state/RocksDBResourceContainer.java
@@ -288,7 +288,7 @@ public final class RocksDBResourceContainer implements AutoCloseable {
     @SuppressWarnings("ConstantConditions")
     private DBOptions setDBOptionsFromConfigurableOptions(DBOptions currentOptions) {
 
-        currentOptions.setIncreaseParallelism(
+        currentOptions.setMaxBackgroundJobs(
                 internalGetOption(RocksDBConfigurableOptions.MAX_BACKGROUND_THREADS));
 
         currentOptions.setMaxOpenFiles(

--- a/flink-state-backends/flink-statebackend-rocksdb/src/test/java/org/apache/flink/contrib/streaming/state/RocksDBResource.java
+++ b/flink-state-backends/flink-statebackend-rocksdb/src/test/java/org/apache/flink/contrib/streaming/state/RocksDBResource.java
@@ -91,7 +91,7 @@ public class RocksDBResource extends ExternalResource {
                         }
 
                         return new DBOptions()
-                                .setIncreaseParallelism(4)
+                                .setMaxBackgroundJobs(4)
                                 .setUseFsync(false)
                                 .setMaxOpenFiles(-1)
                                 .setInfoLogLevel(InfoLogLevel.HEADER_LEVEL)


### PR DESCRIPTION
## What is the purpose of the change

Now flink setIncreaseParallelism (the most we can do for the rocksdb backend background threads) seems like can do little thing for flink rocksdb tuning. It can't change the flush threads. It's necessary to make rocksdb configuration flexible. This change will replace setIncreaseParallelism with setMaxBackgroundJobs.


## Brief change log



## Verifying this change


## Does this pull request potentially affect one of the following parts:

  - Dependencies (does it add or upgrade a dependency): (no)
  - The public API, i.e., is any changed class annotated with `@Public(Evolving)`: (no)
  - The serializers: (no)
  - The runtime per-record code paths (performance sensitive): (no)
  - Anything that affects deployment or recovery: JobManager (and its components), Checkpointing, Kubernetes/Yarn, ZooKeeper: (no)
  - The S3 file system connector: (no)

## Documentation

  - Does this pull request introduce a new feature? (no)
  - If yes, how is the feature documented? (not applicable / docs / JavaDocs / not documented)
