### PR TITLE
[FLINK-24290][table] Support structured types in JSON functions

### DIFF
--- a/flink-table/flink-table-common/src/main/java/org/apache/flink/table/types/inference/strategies/SpecificInputTypeStrategies.java
+++ b/flink-table/flink-table-common/src/main/java/org/apache/flink/table/types/inference/strategies/SpecificInputTypeStrategies.java
@@ -64,6 +64,8 @@ public final class SpecificInputTypeStrategies {
                     logical(LogicalTypeFamily.BINARY_STRING),
                     logical(LogicalTypeFamily.TIMESTAMP),
                     logical(LogicalTypeFamily.CONSTRUCTED),
+                    logical(LogicalTypeRoot.STRUCTURED_TYPE),
+                    logical(LogicalTypeRoot.DISTINCT_TYPE),
                     logical(LogicalTypeRoot.BOOLEAN),
                     logical(LogicalTypeFamily.NUMERIC));
 

--- a/flink-table/flink-table-planner/src/test/java/org/apache/flink/table/planner/functions/JsonFunctionsITCase.java
+++ b/flink-table/flink-table-planner/src/test/java/org/apache/flink/table/planner/functions/JsonFunctionsITCase.java
@@ -471,7 +471,6 @@ public class JsonFunctionsITCase extends BuiltInFunctionTestBase {
                                 BINARY(4).notNull(),
                                 VARBINARY(4).notNull(),
                                 ROW(ARRAY(ROW(INT(), INT()))).notNull())
-                        .withFunction(CreateMultiset.class)
                         .testResult(
                                 resultSpec(
                                         jsonString($("f0")),
@@ -608,6 +607,7 @@ public class JsonFunctionsITCase extends BuiltInFunctionTestBase {
                                 VARBINARY(4),
                                 ROW(ARRAY(ROW(INT(), INT()))))
                         .withFunction(CreateMultiset.class)
+                        .withFunction(CreateStructuredType.class)
                         .testResult(
                                 jsonObject(
                                         JsonOnNull.NULL,
@@ -645,7 +645,9 @@ public class JsonFunctionsITCase extends BuiltInFunctionTestBase {
                                         jsonArray(
                                                 JsonOnNull.NULL,
                                                 "A",
-                                                jsonObject(JsonOnNull.NULL, "K", "V"))),
+                                                jsonObject(JsonOnNull.NULL, "K", "V")),
+                                        "Q",
+                                        call("CreateStructuredType", $("f0"), $("f2"), $("f9"))),
                                 "JSON_OBJECT("
                                         + "'A' VALUE f0, "
                                         + "'B' VALUE f1, "
@@ -662,7 +664,8 @@ public class JsonFunctionsITCase extends BuiltInFunctionTestBase {
                                         + "'M' VALUE f12, "
                                         + "'N' VALUE f13, "
                                         + "'O' VALUE JSON_OBJECT(KEY 'A' VALUE 'B'), "
-                                        + "'P' VALUE JSON_ARRAY('A', JSON_OBJECT('K' VALUE 'V'))"
+                                        + "'P' VALUE JSON_ARRAY('A', JSON_OBJECT('K' VALUE 'V')), "
+                                        + "'Q' VALUE CreateStructuredType(f0, f2, f9)"
                                         + ")",
                                 "{"
                                         + "\"A\":\"V\","
@@ -680,7 +683,8 @@ public class JsonFunctionsITCase extends BuiltInFunctionTestBase {
                                         + "\"M\":\"VGVzdA==\","
                                         + "\"N\":{\"f0\":[{\"f0\":1,\"f1\":2}]},"
                                         + "\"O\":{\"A\":\"B\"},"
-                                        + "\"P\":[\"A\",{\"K\":\"V\"}]"
+                                        + "\"P\":[\"A\",{\"K\":\"V\"}],"
+                                        + "\"Q\":{\"age\":1,\"name\":\"V\",\"payload\":{\"M1\":\"V1\",\"M2\":\"V2\"}}"
                                         + "}",
                                 STRING().notNull(),
                                 STRING().notNull()));
@@ -748,6 +752,7 @@ public class JsonFunctionsITCase extends BuiltInFunctionTestBase {
                                 VARBINARY(4),
                                 ROW(ARRAY(ROW(INT(), INT()))))
                         .withFunction(CreateMultiset.class)
+                        .withFunction(CreateStructuredType.class)
                         .testResult(
                                 jsonArray(
                                         JsonOnNull.NULL,
@@ -769,7 +774,8 @@ public class JsonFunctionsITCase extends BuiltInFunctionTestBase {
                                         jsonObject(
                                                 JsonOnNull.NULL,
                                                 "K",
-                                                jsonArray(JsonOnNull.NULL, "V"))),
+                                                jsonArray(JsonOnNull.NULL, "V")),
+                                        call("CreateStructuredType", $("f0"), $("f2"), $("f9"))),
                                 "JSON_ARRAY("
                                         + "f0, "
                                         + "f1, "
@@ -786,7 +792,8 @@ public class JsonFunctionsITCase extends BuiltInFunctionTestBase {
                                         + "f12, "
                                         + "f13, "
                                         + "JSON_ARRAY('V'), "
-                                        + "JSON_OBJECT('K' VALUE JSON_ARRAY('V'))"
+                                        + "JSON_OBJECT('K' VALUE JSON_ARRAY('V')), "
+                                        + "CreateStructuredType(f0, f2, f9)"
                                         + ")",
                                 "["
                                         + "\"V\","
@@ -804,7 +811,8 @@ public class JsonFunctionsITCase extends BuiltInFunctionTestBase {
                                         + "\"VGVzdA==\","
                                         + "{\"f0\":[{\"f0\":1,\"f1\":2}]},"
                                         + "[\"V\"],"
-                                        + "{\"K\":[\"V\"]}"
+                                        + "{\"K\":[\"V\"]},"
+                                        + "{\"age\":1,\"name\":\"V\",\"payload\":{\"M1\":\"V1\",\"M2\":\"V2\"}}"
                                         + "]",
                                 STRING().notNull(),
                                 STRING().notNull()));
@@ -820,6 +828,28 @@ public class JsonFunctionsITCase extends BuiltInFunctionTestBase {
         public @DataTypeHint("MULTISET<STRING>") Map<String, Integer> eval(
                 Map<String, Integer> map) {
             return map;
+        }
+    }
+
+    /** Same reason as for {@link CreateMultiset}. */
+    public static class CreateStructuredType extends ScalarFunction {
+        public MyPojo eval(String name, Integer age, Map<String, String> payload) {
+            return new MyPojo(name, age, payload);
+        }
+    }
+
+    /** Helper POJO for testing structured types. */
+    public static class MyPojo {
+        public final String name;
+
+        public final Integer age;
+
+        public final Map<String, String> payload;
+
+        public MyPojo(String name, Integer age, Map<String, String> payload) {
+            this.name = name;
+            this.age = age;
+            this.payload = payload;
         }
     }
 


### PR DESCRIPTION
## What is the purpose of the change

Implements the remaining branches for user-defined types.

## Brief change log

Add support for structured types and initial support for distinct types but untested.

## Verifying this change

This change added tests and can be verified as follows: `JsonFunctionsITCase`

## Does this pull request potentially affect one of the following parts:

  - Dependencies (does it add or upgrade a dependency): no
  - The public API, i.e., is any changed class annotated with `@Public(Evolving)`: yes
  - The serializers: no
  - The runtime per-record code paths (performance sensitive): no
  - Anything that affects deployment or recovery: JobManager (and its components), Checkpointing, Kubernetes/Yarn, ZooKeeper: no
  - The S3 file system connector: no

## Documentation

  - Does this pull request introduce a new feature? yes
  - If yes, how is the feature documented? not applicable
