### PR TITLE
[FLINK-25186][table-common] Fix ServiceLoaderUtil#load to work with Java 11

### DIFF
--- a/flink-table/flink-table-common/src/main/java/org/apache/flink/table/factories/FactoryUtil.java
+++ b/flink-table/flink-table-common/src/main/java/org/apache/flink/table/factories/FactoryUtil.java
@@ -690,7 +690,7 @@ public final class FactoryUtil {
     static List<Factory> discoverFactories(ClassLoader classLoader) {
         final List<Factory> result = new LinkedList<>();
         ServiceLoaderUtil.load(Factory.class, classLoader)
-                .forEachRemaining(
+                .forEach(
                         loadResult -> {
                             if (loadResult.hasFailed()) {
                                 if (loadResult.getError() instanceof NoClassDefFoundError) {


### PR DESCRIPTION
## What is the purpose of the change

This commit https://github.com/apache/flink/pull/17897/commits/45d5d31a0b6d23777c6878728ff6f0e26fa3ba0c introduces a utility to safely wrap `NoClassDefFoundError` when using the `ServiceLoader` iterator. This util doesn't work with Java 11, and this PR fixes it.

## Brief change log

* Fix `ServiceLoaderUtil#load` to work correctly with Java 11

## Verifying this change

The tests in `FactoryUtil` are already covering this issue, and same the tests that catched the problem in `flink-connector-files`. I tested this patch both with Java 8 and Java 11.

## Does this pull request potentially affect one of the following parts:

  - Dependencies (does it add or upgrade a dependency): no
  - The public API, i.e., is any changed class annotated with `@Public(Evolving)`: no
  - The serializers: no
  - The runtime per-record code paths (performance sensitive): no
  - Anything that affects deployment or recovery: JobManager (and its components), Checkpointing, Kubernetes/Yarn, ZooKeeper: no
  - The S3 file system connector: no

## Documentation

  - Does this pull request introduce a new feature? no
  - If yes, how is the feature documented? not applicable
