### PR TITLE
[FLINK-25107][formats/gsr] Adding support to define AWS Credential Provider from property map

### DIFF
--- a/flink-connectors/flink-connector-aws-base/src/main/java/org/apache/flink/connector/aws/util/AWSGeneralUtil.java
+++ b/flink-connectors/flink-connector-aws-base/src/main/java/org/apache/flink/connector/aws/util/AWSGeneralUtil.java
@@ -43,6 +43,7 @@ import software.amazon.awssdk.utils.AttributeMap;
 
 import java.nio.file.Paths;
 import java.time.Duration;
+import java.util.Map;
 import java.util.Optional;
 import java.util.Properties;
 
@@ -85,6 +86,20 @@ public class AWSGeneralUtil {
         } else {
             return CredentialProvider.valueOf(configProps.getProperty(configPrefix));
         }
+    }
+
+    /**
+     * Return a {@link AwsCredentialsProvider} instance corresponding to the configuration
+     * properties.
+     *
+     * @param configProps the configuration property map
+     * @return The corresponding AWS Credentials Provider instance
+     */
+    public static AwsCredentialsProvider getCredentialsProvider(final Map<String, ?> configProps) {
+        Properties properties = new Properties();
+        properties.putAll(configProps);
+
+        return getCredentialsProvider(properties);
     }
 
     /**

--- a/flink-connectors/flink-connector-aws-base/src/test/java/org/apache/flink/connector/aws/util/AWSGeneralUtilTest.java
+++ b/flink-connectors/flink-connector-aws-base/src/test/java/org/apache/flink/connector/aws/util/AWSGeneralUtilTest.java
@@ -38,9 +38,11 @@ import software.amazon.awssdk.http.nio.netty.internal.NettyConfiguration;
 import software.amazon.awssdk.regions.Region;
 import software.amazon.awssdk.services.sts.auth.StsAssumeRoleCredentialsProvider;
 import software.amazon.awssdk.utils.AttributeMap;
+import software.amazon.awssdk.utils.ImmutableMap;
 
 import java.nio.file.Paths;
 import java.time.Duration;
+import java.util.Map;
 import java.util.Properties;
 
 import static org.apache.flink.connector.aws.config.AWSConfigConstants.AWS_CREDENTIALS_PROVIDER;
@@ -173,6 +175,15 @@ public class AWSGeneralUtilTest {
 
         AwsCredentialsProvider credentialsProvider =
                 AWSGeneralUtil.getCredentialsProvider(properties);
+
+        assertTrue(credentialsProvider instanceof DefaultCredentialsProvider);
+    }
+
+    @Test
+    public void testGetCredentialsProviderFromMap() {
+        Map<String, Object> config = ImmutableMap.of(AWS_CREDENTIALS_PROVIDER, "AUTO");
+
+        AwsCredentialsProvider credentialsProvider = AWSGeneralUtil.getCredentialsProvider(config);
 
         assertTrue(credentialsProvider instanceof DefaultCredentialsProvider);
     }

--- a/flink-end-to-end-tests/flink-glue-schema-registry-avro-test/src/test/java/org/apache/flink/glue/schema/registry/test/GlueSchemaRegistryAvroKinesisITCase.java
+++ b/flink-end-to-end-tests/flink-glue-schema-registry-avro-test/src/test/java/org/apache/flink/glue/schema/registry/test/GlueSchemaRegistryAvroKinesisITCase.java
@@ -35,7 +35,6 @@ import org.apache.avro.Schema;
 import org.apache.avro.generic.GenericData;
 import org.apache.avro.generic.GenericRecord;
 import org.junit.After;
-import org.junit.Assert;
 import org.junit.Assume;
 import org.junit.Before;
 import org.junit.ClassRule;
@@ -60,6 +59,7 @@ import java.util.concurrent.TimeUnit;
 import static org.apache.flink.connector.aws.config.AWSConfigConstants.AWS_ACCESS_KEY_ID;
 import static org.apache.flink.connector.aws.config.AWSConfigConstants.AWS_SECRET_ACCESS_KEY;
 import static org.apache.flink.streaming.connectors.kinesis.config.ConsumerConfigConstants.STREAM_INITIAL_POSITION;
+import static org.assertj.core.api.Assertions.assertThat;
 
 /** End-to-end test for Glue Schema Registry AVRO format using Kinesalite. */
 public class GlueSchemaRegistryAvroKinesisITCase extends TestLogger {
@@ -133,11 +133,7 @@ public class GlueSchemaRegistryAvroKinesisITCase extends TestLogger {
         }
         log.info("results: {}", results);
 
-        Assert.assertEquals(
-                "Results received from '" + OUTPUT_STREAM + "': " + results,
-                messages.size(),
-                results.size());
-        Assert.assertTrue(messages.containsAll(results));
+        assertThat(results).containsExactlyInAnyOrderElementsOf(messages);
     }
 
     private FlinkKinesisConsumer<GenericRecord> createSource() throws Exception {

--- a/flink-end-to-end-tests/flink-glue-schema-registry-avro-test/src/test/java/org/apache/flink/glue/schema/registry/test/GlueSchemaRegistryAvroKinesisITCase.java
+++ b/flink-end-to-end-tests/flink-glue-schema-registry-avro-test/src/test/java/org/apache/flink/glue/schema/registry/test/GlueSchemaRegistryAvroKinesisITCase.java
@@ -43,6 +43,8 @@ import org.junit.Test;
 import org.junit.rules.Timeout;
 import org.testcontainers.containers.Network;
 import org.testcontainers.utility.DockerImageName;
+import software.amazon.awssdk.auth.credentials.AwsBasicCredentials;
+import software.amazon.awssdk.auth.credentials.StaticCredentialsProvider;
 import software.amazon.awssdk.core.SdkSystemSetting;
 
 import java.io.IOException;
@@ -55,6 +57,8 @@ import java.util.Map;
 import java.util.Properties;
 import java.util.concurrent.TimeUnit;
 
+import static org.apache.flink.connector.aws.config.AWSConfigConstants.AWS_ACCESS_KEY_ID;
+import static org.apache.flink.connector.aws.config.AWSConfigConstants.AWS_SECRET_ACCESS_KEY;
 import static org.apache.flink.streaming.connectors.kinesis.config.ConsumerConfigConstants.STREAM_INITIAL_POSITION;
 
 /** End-to-end test for Glue Schema Registry AVRO format using Kinesalite. */
@@ -87,9 +91,13 @@ public class GlueSchemaRegistryAvroKinesisITCase extends TestLogger {
                 "Secret key not configured, skipping test...",
                 !StringUtils.isNullOrWhitespaceOnly(SECRET_KEY));
 
+        StaticCredentialsProvider gsrCredentialsProvider =
+                StaticCredentialsProvider.create(
+                        AwsBasicCredentials.create(ACCESS_KEY, SECRET_KEY));
+
         Properties properties = KINESALITE.getContainerProperties();
 
-        kinesisClient = new GSRKinesisPubsubClient(properties);
+        kinesisClient = new GSRKinesisPubsubClient(properties, gsrCredentialsProvider);
         kinesisClient.createStream(INPUT_STREAM, 2, properties);
         kinesisClient.createStream(OUTPUT_STREAM, 2, properties);
 
@@ -137,13 +145,10 @@ public class GlueSchemaRegistryAvroKinesisITCase extends TestLogger {
         properties.setProperty(
                 STREAM_INITIAL_POSITION,
                 ConsumerConfigConstants.InitialPosition.TRIM_HORIZON.name());
-        FlinkKinesisConsumer<GenericRecord> consumer =
-                new FlinkKinesisConsumer<>(
-                        INPUT_STREAM,
-                        GlueSchemaRegistryAvroDeserializationSchema.forGeneric(
-                                getSchema(), getConfigs()),
-                        properties);
-        return consumer;
+        return new FlinkKinesisConsumer<>(
+                INPUT_STREAM,
+                GlueSchemaRegistryAvroDeserializationSchema.forGeneric(getSchema(), getConfigs()),
+                properties);
     }
 
     private FlinkKinesisProducer<GenericRecord> createSink() throws Exception {
@@ -158,7 +163,7 @@ public class GlueSchemaRegistryAvroKinesisITCase extends TestLogger {
     }
 
     private Properties getProducerProperties() throws Exception {
-        Properties producerProperties = new Properties(KINESALITE.getContainerProperties());
+        Properties producerProperties = KINESALITE.getContainerProperties();
         // producer needs region even when URL is specified
         producerProperties.put(ConsumerConfigConstants.AWS_REGION, "ca-central-1");
         // test driver does not deaggregate
@@ -185,7 +190,9 @@ public class GlueSchemaRegistryAvroKinesisITCase extends TestLogger {
     }
 
     private Map<String, Object> getConfigs() {
-        Map<String, Object> configs = new HashMap();
+        Map<String, Object> configs = new HashMap<>();
+        configs.put(AWS_ACCESS_KEY_ID, ACCESS_KEY);
+        configs.put(AWS_SECRET_ACCESS_KEY, SECRET_KEY);
         configs.put(AWSSchemaRegistryConstants.AWS_REGION, "ca-central-1");
         configs.put(AWSSchemaRegistryConstants.SCHEMA_AUTO_REGISTRATION_SETTING, true);
         configs.put(

--- a/flink-end-to-end-tests/flink-glue-schema-registry-json-test/pom.xml
+++ b/flink-end-to-end-tests/flink-glue-schema-registry-json-test/pom.xml
@@ -33,7 +33,7 @@ under the License.
 	<packaging>jar</packaging>
 
 	<properties>
-		<guava.version>16.0.1</guava.version>
+		<guava.version>29.0-jre</guava.version>
 		<netty.version>4.1.68.Final</netty.version>
 		<kotlin.version>1.3.50</kotlin.version>
 		<classgraph.version>4.8.120</classgraph.version>

--- a/flink-end-to-end-tests/flink-glue-schema-registry-json-test/src/test/java/org/apache/flink/glue/schema/registry/test/json/GlueSchemaRegistryJsonKinesisITCase.java
+++ b/flink-end-to-end-tests/flink-glue-schema-registry-json-test/src/test/java/org/apache/flink/glue/schema/registry/test/json/GlueSchemaRegistryJsonKinesisITCase.java
@@ -40,6 +40,8 @@ import org.junit.Test;
 import org.junit.rules.Timeout;
 import org.testcontainers.containers.Network;
 import org.testcontainers.utility.DockerImageName;
+import software.amazon.awssdk.auth.credentials.AwsBasicCredentials;
+import software.amazon.awssdk.auth.credentials.StaticCredentialsProvider;
 import software.amazon.awssdk.core.SdkSystemSetting;
 
 import java.net.URL;
@@ -83,9 +85,13 @@ public class GlueSchemaRegistryJsonKinesisITCase extends TestLogger {
                 "Secret key not configured, skipping test...",
                 !StringUtils.isNullOrWhitespaceOnly(SECRET_KEY));
 
+        StaticCredentialsProvider gsrCredentialsProvider =
+                StaticCredentialsProvider.create(
+                        AwsBasicCredentials.create(ACCESS_KEY, SECRET_KEY));
+
         Properties properties = KINESALITE.getContainerProperties();
 
-        kinesisClient = new GSRKinesisPubsubClient(properties);
+        kinesisClient = new GSRKinesisPubsubClient(properties, gsrCredentialsProvider);
         kinesisClient.createStream(INPUT_STREAM, 2, properties);
         kinesisClient.createStream(OUTPUT_STREAM, 2, properties);
 
@@ -156,7 +162,7 @@ public class GlueSchemaRegistryJsonKinesisITCase extends TestLogger {
     }
 
     private Properties getProducerProperties() throws Exception {
-        Properties producerProperties = new Properties(KINESALITE.getContainerProperties());
+        Properties producerProperties = KINESALITE.getContainerProperties();
         // producer needs region even when URL is specified
         producerProperties.put(ConsumerConfigConstants.AWS_REGION, "ca-central-1");
         // test driver does not deaggregate

--- a/flink-formats/flink-avro-glue-schema-registry/pom.xml
+++ b/flink-formats/flink-avro-glue-schema-registry/pom.xml
@@ -92,6 +92,12 @@ under the License.
 		</dependency>
 
 		<dependency>
+			<groupId>org.apache.flink</groupId>
+			<artifactId>flink-connector-aws-base</artifactId>
+			<version>${project.version}</version>
+		</dependency>
+
+		<dependency>
 			<!-- This has a transitive dependency on mbknor-jackson-jsonschema which needs scala -->
 			<groupId>software.amazon.glue</groupId>
 			<artifactId>schema-registry-serde</artifactId>

--- a/flink-formats/flink-avro-glue-schema-registry/src/main/java/org/apache/flink/formats/avro/glue/schema/registry/GlueSchemaRegistryInputStreamDeserializer.java
+++ b/flink-formats/flink-avro-glue-schema-registry/src/main/java/org/apache/flink/formats/avro/glue/schema/registry/GlueSchemaRegistryInputStreamDeserializer.java
@@ -19,6 +19,7 @@
 package org.apache.flink.formats.avro.glue.schema.registry;
 
 import org.apache.flink.annotation.PublicEvolving;
+import org.apache.flink.connector.aws.util.AWSGeneralUtil;
 import org.apache.flink.formats.avro.utils.MutableByteArrayInputStream;
 
 import com.amazonaws.services.schemaregistry.deserializers.GlueSchemaRegistryDeserializationFacade;
@@ -26,7 +27,7 @@ import com.amazonaws.services.schemaregistry.exception.AWSSchemaRegistryExceptio
 import org.apache.avro.Schema;
 import org.apache.avro.Schema.Parser;
 import org.apache.avro.SchemaParseException;
-import software.amazon.awssdk.auth.credentials.DefaultCredentialsProvider;
+import software.amazon.awssdk.auth.credentials.AwsCredentialsProvider;
 
 import java.io.IOException;
 import java.io.InputStream;
@@ -46,9 +47,11 @@ public class GlueSchemaRegistryInputStreamDeserializer {
      * @param configs configuration map
      */
     public GlueSchemaRegistryInputStreamDeserializer(Map<String, Object> configs) {
+        AwsCredentialsProvider credentialsProvider = AWSGeneralUtil.getCredentialsProvider(configs);
+
         this.glueSchemaRegistryDeserializationFacade =
                 GlueSchemaRegistryDeserializationFacade.builder()
-                        .credentialProvider(DefaultCredentialsProvider.builder().build())
+                        .credentialProvider(credentialsProvider)
                         .configs(configs)
                         .build();
     }

--- a/flink-formats/flink-avro-glue-schema-registry/src/main/java/org/apache/flink/formats/avro/glue/schema/registry/GlueSchemaRegistryOutputStreamSerializer.java
+++ b/flink-formats/flink-avro-glue-schema-registry/src/main/java/org/apache/flink/formats/avro/glue/schema/registry/GlueSchemaRegistryOutputStreamSerializer.java
@@ -19,12 +19,13 @@
 package org.apache.flink.formats.avro.glue.schema.registry;
 
 import org.apache.flink.annotation.PublicEvolving;
+import org.apache.flink.connector.aws.util.AWSGeneralUtil;
 
 import com.amazonaws.services.schemaregistry.common.configs.GlueSchemaRegistryConfiguration;
 import com.amazonaws.services.schemaregistry.serializers.GlueSchemaRegistrySerializationFacade;
 import com.amazonaws.services.schemaregistry.utils.GlueSchemaRegistryUtils;
 import org.apache.avro.Schema;
-import software.amazon.awssdk.auth.credentials.DefaultCredentialsProvider;
+import software.amazon.awssdk.auth.credentials.AwsCredentialsProvider;
 import software.amazon.awssdk.services.glue.model.DataFormat;
 
 import java.io.IOException;
@@ -52,11 +53,14 @@ public class GlueSchemaRegistryOutputStreamSerializer {
             GlueSchemaRegistrySerializationFacade glueSchemaRegistrySerializationFacade) {
         this.transportName = transportName;
         this.configs = configs;
+
+        AwsCredentialsProvider credentialsProvider = AWSGeneralUtil.getCredentialsProvider(configs);
+
         this.glueSchemaRegistrySerializationFacade =
                 glueSchemaRegistrySerializationFacade != null
                         ? glueSchemaRegistrySerializationFacade
                         : GlueSchemaRegistrySerializationFacade.builder()
-                                .credentialProvider(DefaultCredentialsProvider.builder().build())
+                                .credentialProvider(credentialsProvider)
                                 .glueSchemaRegistryConfiguration(
                                         new GlueSchemaRegistryConfiguration(configs))
                                 .build();

--- a/flink-formats/flink-avro-glue-schema-registry/src/test/java/org/apache/flink/formats/avro/glue/schema/registry/GlueSchemaRegistryAvroDeserializationSchemaTest.java
+++ b/flink-formats/flink-avro-glue-schema-registry/src/test/java/org/apache/flink/formats/avro/glue/schema/registry/GlueSchemaRegistryAvroDeserializationSchemaTest.java
@@ -30,9 +30,7 @@ import java.io.IOException;
 import java.util.HashMap;
 import java.util.Map;
 
-import static org.hamcrest.CoreMatchers.instanceOf;
-import static org.hamcrest.CoreMatchers.notNullValue;
-import static org.hamcrest.MatcherAssert.assertThat;
+import static org.assertj.core.api.Assertions.assertThat;
 
 /** Tests for {@link GlueSchemaRegistryAvroDeserializationSchema}. */
 public class GlueSchemaRegistryAvroDeserializationSchemaTest extends TestLogger {
@@ -53,22 +51,18 @@ public class GlueSchemaRegistryAvroDeserializationSchemaTest extends TestLogger 
     /** Test whether forGeneric method works. */
     @Test
     public void testForGeneric_withValidParams_succeeds() {
-        assertThat(
-                GlueSchemaRegistryAvroDeserializationSchema.forGeneric(userSchema, configs),
-                notNullValue());
-        assertThat(
-                GlueSchemaRegistryAvroDeserializationSchema.forGeneric(userSchema, configs),
-                instanceOf(GlueSchemaRegistryAvroDeserializationSchema.class));
+        assertThat(GlueSchemaRegistryAvroDeserializationSchema.forGeneric(userSchema, configs))
+                .isNotNull();
+        assertThat(GlueSchemaRegistryAvroDeserializationSchema.forGeneric(userSchema, configs))
+                .isInstanceOf(GlueSchemaRegistryAvroDeserializationSchema.class);
     }
 
     /** Test whether forSpecific method works. */
     @Test
     public void testForSpecific_withValidParams_succeeds() {
-        assertThat(
-                GlueSchemaRegistryAvroDeserializationSchema.forSpecific(User.class, configs),
-                notNullValue());
-        assertThat(
-                GlueSchemaRegistryAvroDeserializationSchema.forSpecific(User.class, configs),
-                instanceOf(GlueSchemaRegistryAvroDeserializationSchema.class));
+        assertThat(GlueSchemaRegistryAvroDeserializationSchema.forSpecific(User.class, configs))
+                .isNotNull();
+        assertThat(GlueSchemaRegistryAvroDeserializationSchema.forSpecific(User.class, configs))
+                .isInstanceOf(GlueSchemaRegistryAvroDeserializationSchema.class);
     }
 }

--- a/flink-formats/flink-avro-glue-schema-registry/src/test/java/org/apache/flink/formats/avro/glue/schema/registry/GlueSchemaRegistryAvroSchemaCoderTest.java
+++ b/flink-formats/flink-avro-glue-schema-registry/src/test/java/org/apache/flink/formats/avro/glue/schema/registry/GlueSchemaRegistryAvroSchemaCoderTest.java
@@ -28,7 +28,6 @@ import com.amazonaws.services.schemaregistry.serializers.GlueSchemaRegistrySeria
 import com.amazonaws.services.schemaregistry.utils.AWSSchemaRegistryConstants;
 import lombok.NonNull;
 import org.apache.avro.Schema;
-import org.hamcrest.Matchers;
 import org.junit.BeforeClass;
 import org.junit.Rule;
 import org.junit.Test;
@@ -48,9 +47,7 @@ import java.util.HashMap;
 import java.util.Map;
 import java.util.UUID;
 
-import static org.hamcrest.CoreMatchers.equalTo;
-import static org.hamcrest.CoreMatchers.notNullValue;
-import static org.hamcrest.MatcherAssert.assertThat;
+import static org.assertj.core.api.Assertions.assertThat;
 
 /** Tests for {@link GlueSchemaRegistryAvroSchemaCoder}. */
 public class GlueSchemaRegistryAvroSchemaCoderTest extends TestLogger {
@@ -102,14 +99,10 @@ public class GlueSchemaRegistryAvroSchemaCoderTest extends TestLogger {
     /** Test whether constructor works. */
     @Test
     public void testConstructor_withConfigs_succeeds() {
-        assertThat(new GlueSchemaRegistryAvroSchemaCoder(testTopic, configs), notNullValue());
+        assertThat(new GlueSchemaRegistryAvroSchemaCoder(testTopic, configs)).isNotNull();
     }
 
-    /**
-     * Test whether readSchema method works.
-     *
-     * @throws IOException
-     */
+    /** Test whether readSchema method works. */
     @Test
     public void testReadSchema_withValidParams_succeeds() throws IOException {
         GlueSchemaRegistryAvroSchemaCoder glueSchemaRegistryAvroSchemaCoder =
@@ -117,14 +110,10 @@ public class GlueSchemaRegistryAvroSchemaCoderTest extends TestLogger {
         Schema resultSchema =
                 glueSchemaRegistryAvroSchemaCoder.readSchema(buildByteArrayInputStream());
 
-        assertThat(resultSchema, equalTo(userSchema));
+        assertThat(resultSchema).isEqualTo(userSchema);
     }
 
-    /**
-     * Test whether writeSchema method works.
-     *
-     * @throws IOException
-     */
+    /** Test whether writeSchema method works. */
     @Test
     public void testWriteSchema_withValidParams_succeeds() throws IOException {
         ByteArrayOutputStream outputStream = new ByteArrayOutputStream();
@@ -136,12 +125,7 @@ public class GlueSchemaRegistryAvroSchemaCoderTest extends TestLogger {
         testForSerializedData(outputStream.toByteArray());
     }
 
-    /**
-     * Test whether writeSchema method throws exception if auto registration un-enabled.
-     *
-     * @throws NoSuchFieldException
-     * @throws IllegalAccessException
-     */
+    /** Test whether writeSchema method throws exception if auto registration un-enabled. */
     @Test
     public void testWriteSchema_withoutAutoRegistration_throwsException() throws IOException {
         configs.put(AWSSchemaRegistryConstants.SCHEMA_AUTO_REGISTRATION_SETTING, false);
@@ -167,12 +151,12 @@ public class GlueSchemaRegistryAvroSchemaCoderTest extends TestLogger {
     }
 
     private void testForSerializedData(byte[] serializedData) {
-        assertThat(serializedData, Matchers.notNullValue());
+        assertThat(serializedData).isNotNull();
 
         ByteBuffer buffer = getByteBuffer(serializedData);
         byte headerVersionByte = getByte(buffer);
 
-        assertThat(headerVersionByte, equalTo(AWSSchemaRegistryConstants.HEADER_VERSION_BYTE));
+        assertThat(headerVersionByte).isEqualTo(AWSSchemaRegistryConstants.HEADER_VERSION_BYTE);
     }
 
     private ByteArrayInputStream buildByteArrayInputStream() {

--- a/flink-formats/flink-avro-glue-schema-registry/src/test/java/org/apache/flink/formats/avro/glue/schema/registry/GlueSchemaRegistryAvroSerializationSchemaTest.java
+++ b/flink-formats/flink-avro-glue-schema-registry/src/test/java/org/apache/flink/formats/avro/glue/schema/registry/GlueSchemaRegistryAvroSerializationSchemaTest.java
@@ -34,11 +34,7 @@ import java.io.IOException;
 import java.util.HashMap;
 import java.util.Map;
 
-import static org.hamcrest.CoreMatchers.equalTo;
-import static org.hamcrest.CoreMatchers.instanceOf;
-import static org.hamcrest.CoreMatchers.notNullValue;
-import static org.hamcrest.CoreMatchers.nullValue;
-import static org.hamcrest.MatcherAssert.assertThat;
+import static org.assertj.core.api.Assertions.assertThat;
 
 /** Tests for {@link GlueSchemaRegistryAvroSerializationSchema}. */
 public class GlueSchemaRegistryAvroSerializationSchemaTest extends TestLogger {
@@ -52,10 +48,10 @@ public class GlueSchemaRegistryAvroSerializationSchemaTest extends TestLogger {
             };
     private static Schema userSchema;
     private static User userDefinedPojo;
-    private static Map<String, Object> configs = new HashMap<>();
-    private static Map<String, String> metadata = new HashMap<>();
+    private static final Map<String, Object> configs = new HashMap<>();
+    private static final Map<String, String> metadata = new HashMap<>();
     private static GlueSchemaRegistryConfiguration glueSchemaRegistryConfiguration;
-    private static AwsCredentialsProvider credentialsProvider =
+    private static final AwsCredentialsProvider credentialsProvider =
             DefaultCredentialsProvider.builder().build();
     private static GlueSchemaRegistrySerializationFacade mockSerializationFacade;
 
@@ -87,26 +83,26 @@ public class GlueSchemaRegistryAvroSerializationSchemaTest extends TestLogger {
     @Test
     public void testForGeneric_withValidParams_succeeds() {
         assertThat(
-                GlueSchemaRegistryAvroSerializationSchema.forGeneric(
-                        userSchema, testTopic, configs),
-                notNullValue());
+                        GlueSchemaRegistryAvroSerializationSchema.forGeneric(
+                                userSchema, testTopic, configs))
+                .isNotNull();
         assertThat(
-                GlueSchemaRegistryAvroSerializationSchema.forGeneric(
-                        userSchema, testTopic, configs),
-                instanceOf(GlueSchemaRegistryAvroSerializationSchema.class));
+                        GlueSchemaRegistryAvroSerializationSchema.forGeneric(
+                                userSchema, testTopic, configs))
+                .isInstanceOf(GlueSchemaRegistryAvroSerializationSchema.class);
     }
 
     /** Test whether forSpecific method works. */
     @Test
     public void testForSpecific_withValidParams_succeeds() {
         assertThat(
-                GlueSchemaRegistryAvroSerializationSchema.forSpecific(
-                        User.class, testTopic, configs),
-                notNullValue());
+                        GlueSchemaRegistryAvroSerializationSchema.forSpecific(
+                                User.class, testTopic, configs))
+                .isNotNull();
         assertThat(
-                GlueSchemaRegistryAvroSerializationSchema.forSpecific(
-                        User.class, testTopic, configs),
-                instanceOf(GlueSchemaRegistryAvroSerializationSchema.class));
+                        GlueSchemaRegistryAvroSerializationSchema.forSpecific(
+                                User.class, testTopic, configs))
+                .isInstanceOf(GlueSchemaRegistryAvroSerializationSchema.class);
     }
 
     /** Test whether serialize method when compression is not enabled works. */
@@ -121,13 +117,13 @@ public class GlueSchemaRegistryAvroSerializationSchemaTest extends TestLogger {
                         testTopic, configs, mockSerializationFacade);
         GlueSchemaRegistryAvroSchemaCoder glueSchemaRegistryAvroSchemaCoder =
                 new GlueSchemaRegistryAvroSchemaCoder(glueSchemaRegistryOutputStreamSerializer);
-        GlueSchemaRegistryAvroSerializationSchema glueSchemaRegistryAvroSerializationSchema =
-                new GlueSchemaRegistryAvroSerializationSchema(
+        GlueSchemaRegistryAvroSerializationSchema<User> glueSchemaRegistryAvroSerializationSchema =
+                new GlueSchemaRegistryAvroSerializationSchema<>(
                         User.class, null, glueSchemaRegistryAvroSchemaCoder);
 
         byte[] serializedData =
                 glueSchemaRegistryAvroSerializationSchema.serialize(userDefinedPojo);
-        assertThat(serializedData, equalTo(specificBytes));
+        assertThat(serializedData).isEqualTo(specificBytes);
     }
 
     /** Test whether serialize method when compression is enabled works. */
@@ -142,22 +138,22 @@ public class GlueSchemaRegistryAvroSerializationSchemaTest extends TestLogger {
                         testTopic, configs, mockSerializationFacade);
         GlueSchemaRegistryAvroSchemaCoder glueSchemaRegistryAvroSchemaCoder =
                 new GlueSchemaRegistryAvroSchemaCoder(glueSchemaRegistryOutputStreamSerializer);
-        GlueSchemaRegistryAvroSerializationSchema glueSchemaRegistryAvroSerializationSchema =
-                new GlueSchemaRegistryAvroSerializationSchema(
+        GlueSchemaRegistryAvroSerializationSchema<User> glueSchemaRegistryAvroSerializationSchema =
+                new GlueSchemaRegistryAvroSerializationSchema<>(
                         User.class, null, glueSchemaRegistryAvroSchemaCoder);
 
         byte[] serializedData =
                 glueSchemaRegistryAvroSerializationSchema.serialize(userDefinedPojo);
-        assertThat(serializedData, equalTo(specificBytes));
+        assertThat(serializedData).isEqualTo(specificBytes);
     }
 
     /** Test whether serialize method returns null when input object is null. */
     @Test
     public void testSerialize_withNullObject_returnNull() {
-        GlueSchemaRegistryAvroSerializationSchema glueSchemaRegistryAvroSerializationSchema =
+        GlueSchemaRegistryAvroSerializationSchema<User> glueSchemaRegistryAvroSerializationSchema =
                 GlueSchemaRegistryAvroSerializationSchema.forSpecific(
                         User.class, testTopic, configs);
-        assertThat(glueSchemaRegistryAvroSerializationSchema.serialize(null), nullValue());
+        assertThat(glueSchemaRegistryAvroSerializationSchema.serialize(null)).isNull();
     }
 
     private static class MockGlueSchemaRegistrySerializationFacade

--- a/flink-formats/flink-avro-glue-schema-registry/src/test/java/org/apache/flink/formats/avro/glue/schema/registry/GlueSchemaRegistryOutputStreamSerializerTest.java
+++ b/flink-formats/flink-avro-glue-schema-registry/src/test/java/org/apache/flink/formats/avro/glue/schema/registry/GlueSchemaRegistryOutputStreamSerializerTest.java
@@ -35,9 +35,7 @@ import java.io.IOException;
 import java.util.HashMap;
 import java.util.Map;
 
-import static org.hamcrest.CoreMatchers.equalTo;
-import static org.hamcrest.MatcherAssert.assertThat;
-import static org.hamcrest.Matchers.instanceOf;
+import static org.assertj.core.api.Assertions.assertThat;
 
 /** Tests for {@link GlueSchemaRegistryOutputStreamSerializer}. */
 public class GlueSchemaRegistryOutputStreamSerializerTest extends TestLogger {
@@ -52,9 +50,9 @@ public class GlueSchemaRegistryOutputStreamSerializerTest extends TestLogger {
             };
     private static Schema userSchema;
     private static User userDefinedPojo;
-    private static Map<String, Object> configs = new HashMap<>();
-    private static Map<String, String> metadata = new HashMap<>();
-    private static AwsCredentialsProvider credentialsProvider =
+    private static final Map<String, Object> configs = new HashMap<>();
+    private static final Map<String, String> metadata = new HashMap<>();
+    private static final AwsCredentialsProvider credentialsProvider =
             DefaultCredentialsProvider.builder().build();
     private static GlueSchemaRegistrySerializationFacade mockSerializationFacade;
 
@@ -87,9 +85,8 @@ public class GlueSchemaRegistryOutputStreamSerializerTest extends TestLogger {
     public void testConstructor_withConfigsAndCredential_succeeds() {
         GlueSchemaRegistryOutputStreamSerializer glueSchemaRegistryOutputStreamSerializer =
                 new GlueSchemaRegistryOutputStreamSerializer(testTopic, configs);
-        assertThat(
-                glueSchemaRegistryOutputStreamSerializer,
-                instanceOf(GlueSchemaRegistryOutputStreamSerializer.class));
+        assertThat(glueSchemaRegistryOutputStreamSerializer)
+                .isInstanceOf(GlueSchemaRegistryOutputStreamSerializer.class);
     }
 
     /** Test whether constructor works with Glue Schema Registry SerializationFacade. */
@@ -98,9 +95,8 @@ public class GlueSchemaRegistryOutputStreamSerializerTest extends TestLogger {
         GlueSchemaRegistryOutputStreamSerializer glueSchemaRegistryOutputStreamSerializer =
                 new GlueSchemaRegistryOutputStreamSerializer(
                         testTopic, configs, mockSerializationFacade);
-        assertThat(
-                glueSchemaRegistryOutputStreamSerializer,
-                instanceOf(GlueSchemaRegistryOutputStreamSerializer.class));
+        assertThat(glueSchemaRegistryOutputStreamSerializer)
+                .isInstanceOf(GlueSchemaRegistryOutputStreamSerializer.class);
     }
 
     /** Test whether registerSchemaAndSerializeStream method works. */
@@ -113,7 +109,7 @@ public class GlueSchemaRegistryOutputStreamSerializerTest extends TestLogger {
         glueSchemaRegistryOutputStreamSerializer.registerSchemaAndSerializeStream(
                 userSchema, outputStream, actualBytes);
 
-        assertThat(outputStream.toByteArray(), equalTo(specificBytes));
+        assertThat(outputStream.toByteArray()).isEqualTo(specificBytes);
     }
 
     private static class MockGlueSchemaRegistrySerializationFacade

--- a/flink-formats/flink-json-glue-schema-registry/pom.xml
+++ b/flink-formats/flink-json-glue-schema-registry/pom.xml
@@ -99,6 +99,12 @@ under the License.
 		</dependency>
 
 		<dependency>
+			<groupId>org.apache.flink</groupId>
+			<artifactId>flink-connector-aws-base</artifactId>
+			<version>${project.version}</version>
+		</dependency>
+
+		<dependency>
 			<groupId>software.amazon.glue</groupId>
 			<artifactId>schema-registry-serde</artifactId>
 			<version>${glue.schema.registry.version}</version>

--- a/flink-formats/flink-json-glue-schema-registry/src/main/java/org/apache/flink/formats/json/glue/schema/registry/GlueSchemaRegistryJsonSchemaCoder.java
+++ b/flink-formats/flink-json-glue-schema-registry/src/main/java/org/apache/flink/formats/json/glue/schema/registry/GlueSchemaRegistryJsonSchemaCoder.java
@@ -20,6 +20,7 @@ package org.apache.flink.formats.json.glue.schema.registry;
 
 import org.apache.flink.annotation.PublicEvolving;
 import org.apache.flink.annotation.VisibleForTesting;
+import org.apache.flink.connector.aws.util.AWSGeneralUtil;
 
 import com.amazonaws.services.schemaregistry.common.AWSDeserializerInput;
 import com.amazonaws.services.schemaregistry.common.AWSSerializerInput;
@@ -27,7 +28,7 @@ import com.amazonaws.services.schemaregistry.common.configs.GlueSchemaRegistryCo
 import com.amazonaws.services.schemaregistry.deserializers.GlueSchemaRegistryDeserializationFacade;
 import com.amazonaws.services.schemaregistry.serializers.GlueSchemaRegistrySerializationFacade;
 import com.amazonaws.services.schemaregistry.utils.GlueSchemaRegistryUtils;
-import software.amazon.awssdk.auth.credentials.DefaultCredentialsProvider;
+import software.amazon.awssdk.auth.credentials.AwsCredentialsProvider;
 import software.amazon.awssdk.services.glue.model.DataFormat;
 
 import java.io.Serializable;
@@ -58,15 +59,18 @@ public class GlueSchemaRegistryJsonSchemaCoder implements Serializable {
             final String transportName, final Map<String, Object> configs) {
         this.transportName = transportName;
         this.configs = configs;
+
+        AwsCredentialsProvider credentialsProvider = AWSGeneralUtil.getCredentialsProvider(configs);
+
         this.glueSchemaRegistrySerializationFacade =
                 GlueSchemaRegistrySerializationFacade.builder()
-                        .credentialProvider(DefaultCredentialsProvider.builder().build())
+                        .credentialProvider(credentialsProvider)
                         .glueSchemaRegistryConfiguration(
                                 new GlueSchemaRegistryConfiguration(configs))
                         .build();
         this.glueSchemaRegistryDeserializationFacade =
                 GlueSchemaRegistryDeserializationFacade.builder()
-                        .credentialProvider(DefaultCredentialsProvider.builder().build())
+                        .credentialProvider(credentialsProvider)
                         .configs(configs)
                         .build();
     }

--- a/flink-formats/flink-json-glue-schema-registry/src/test/java/org/apache/flink/formats/json/glue/schema/registry/GlueSchemaRegistryJsonDeserializationSchemaTest.java
+++ b/flink-formats/flink-json-glue-schema-registry/src/test/java/org/apache/flink/formats/json/glue/schema/registry/GlueSchemaRegistryJsonDeserializationSchemaTest.java
@@ -46,7 +46,7 @@ import static org.hamcrest.MatcherAssert.assertThat;
 /** Tests for {@link GlueSchemaRegistryJsonDeserializationSchema}. */
 public class GlueSchemaRegistryJsonDeserializationSchemaTest {
     private static final String testTopic = "Test-Topic";
-    private static Map<String, Object> configs = new HashMap<>();
+    private static final Map<String, Object> configs = new HashMap<>();
     private static AwsCredentialsProvider credentialsProvider =
             DefaultCredentialsProvider.builder().build();
     private static final byte[] serializedBytes =
@@ -127,9 +127,10 @@ public class GlueSchemaRegistryJsonDeserializationSchemaTest {
                 new GlueSchemaRegistryJsonSchemaCoder(
                         testTopic, configs, null, mockDeserializationFacadeForSpecific);
 
-        GlueSchemaRegistryJsonDeserializationSchema glueSchemaRegistryJsonDeserializationSchema =
-                new GlueSchemaRegistryJsonDeserializationSchema(
-                        Car.class, glueSchemaRegistryJsonSchemaCoder);
+        GlueSchemaRegistryJsonDeserializationSchema<Car>
+                glueSchemaRegistryJsonDeserializationSchema =
+                        new GlueSchemaRegistryJsonDeserializationSchema<>(
+                                Car.class, glueSchemaRegistryJsonSchemaCoder);
 
         Object deserializedObject =
                 glueSchemaRegistryJsonDeserializationSchema.deserialize(serializedBytes);
@@ -144,9 +145,10 @@ public class GlueSchemaRegistryJsonDeserializationSchemaTest {
                 new GlueSchemaRegistryJsonSchemaCoder(
                         testTopic, configs, null, mockDeserializationFacadeForGeneric);
 
-        GlueSchemaRegistryJsonDeserializationSchema glueSchemaRegistryJsonDeserializationSchema =
-                new GlueSchemaRegistryJsonDeserializationSchema(
-                        Car.class, glueSchemaRegistryJsonSchemaCoder);
+        GlueSchemaRegistryJsonDeserializationSchema<Car>
+                glueSchemaRegistryJsonDeserializationSchema =
+                        new GlueSchemaRegistryJsonDeserializationSchema<>(
+                                Car.class, glueSchemaRegistryJsonSchemaCoder);
 
         Object deserializedObject =
                 glueSchemaRegistryJsonDeserializationSchema.deserialize(serializedBytes);
@@ -157,8 +159,10 @@ public class GlueSchemaRegistryJsonDeserializationSchemaTest {
     /** Test whether deserialize method returns null when input byte array is null. */
     @Test
     public void testDeserialize_withNullObject_returnNull() {
-        GlueSchemaRegistryJsonDeserializationSchema glueSchemaRegistryJsonDeserializationSchema =
-                new GlueSchemaRegistryJsonDeserializationSchema(Car.class, testTopic, configs);
+        GlueSchemaRegistryJsonDeserializationSchema<Car>
+                glueSchemaRegistryJsonDeserializationSchema =
+                        new GlueSchemaRegistryJsonDeserializationSchema<>(
+                                Car.class, testTopic, configs);
         assertThat(glueSchemaRegistryJsonDeserializationSchema.deserialize(null), nullValue());
     }
 

--- a/flink-formats/flink-json-glue-schema-registry/src/test/java/org/apache/flink/formats/json/glue/schema/registry/GlueSchemaRegistryJsonDeserializationSchemaTest.java
+++ b/flink-formats/flink-json-glue-schema-registry/src/test/java/org/apache/flink/formats/json/glue/schema/registry/GlueSchemaRegistryJsonDeserializationSchemaTest.java
@@ -37,17 +37,13 @@ import java.util.GregorianCalendar;
 import java.util.HashMap;
 import java.util.Map;
 
-import static org.hamcrest.CoreMatchers.instanceOf;
-import static org.hamcrest.CoreMatchers.is;
-import static org.hamcrest.CoreMatchers.notNullValue;
-import static org.hamcrest.CoreMatchers.nullValue;
-import static org.hamcrest.MatcherAssert.assertThat;
+import static org.assertj.core.api.Assertions.assertThat;
 
 /** Tests for {@link GlueSchemaRegistryJsonDeserializationSchema}. */
 public class GlueSchemaRegistryJsonDeserializationSchemaTest {
     private static final String testTopic = "Test-Topic";
     private static final Map<String, Object> configs = new HashMap<>();
-    private static AwsCredentialsProvider credentialsProvider =
+    private static final AwsCredentialsProvider credentialsProvider =
             DefaultCredentialsProvider.builder().build();
     private static final byte[] serializedBytes =
             new byte[] {
@@ -100,24 +96,22 @@ public class GlueSchemaRegistryJsonDeserializationSchemaTest {
     @Test
     public void testForGeneric_withValidParams_succeeds() {
         assertThat(
-                new GlueSchemaRegistryJsonDeserializationSchema<>(
-                        JsonDataWithSchema.class, testTopic, configs),
-                notNullValue());
+                        new GlueSchemaRegistryJsonDeserializationSchema<>(
+                                JsonDataWithSchema.class, testTopic, configs))
+                .isNotNull();
         assertThat(
-                new GlueSchemaRegistryJsonDeserializationSchema<>(
-                        JsonDataWithSchema.class, testTopic, configs),
-                instanceOf(GlueSchemaRegistryJsonDeserializationSchema.class));
+                        new GlueSchemaRegistryJsonDeserializationSchema<>(
+                                JsonDataWithSchema.class, testTopic, configs))
+                .isInstanceOf(GlueSchemaRegistryJsonDeserializationSchema.class);
     }
 
     /** Test initialization for specific type JSON Schema works. */
     @Test
     public void testForSpecific_withValidParams_succeeds() {
-        assertThat(
-                new GlueSchemaRegistryJsonDeserializationSchema<>(Car.class, testTopic, configs),
-                notNullValue());
-        assertThat(
-                new GlueSchemaRegistryJsonDeserializationSchema<>(Car.class, testTopic, configs),
-                instanceOf(GlueSchemaRegistryJsonDeserializationSchema.class));
+        assertThat(new GlueSchemaRegistryJsonDeserializationSchema<>(Car.class, testTopic, configs))
+                .isNotNull();
+        assertThat(new GlueSchemaRegistryJsonDeserializationSchema<>(Car.class, testTopic, configs))
+                .isInstanceOf(GlueSchemaRegistryJsonDeserializationSchema.class);
     }
 
     /** Test whether deserialize method for specific type JSON Schema data works. */
@@ -134,8 +128,8 @@ public class GlueSchemaRegistryJsonDeserializationSchemaTest {
 
         Object deserializedObject =
                 glueSchemaRegistryJsonDeserializationSchema.deserialize(serializedBytes);
-        assertThat(deserializedObject, instanceOf(Car.class));
-        assertThat(deserializedObject, is(userDefinedPojo));
+        assertThat(deserializedObject).isInstanceOf(Car.class);
+        assertThat(deserializedObject).isEqualTo(userDefinedPojo);
     }
 
     /** Test whether deserialize method for generic type JSON Schema data works. */
@@ -152,8 +146,8 @@ public class GlueSchemaRegistryJsonDeserializationSchemaTest {
 
         Object deserializedObject =
                 glueSchemaRegistryJsonDeserializationSchema.deserialize(serializedBytes);
-        assertThat(deserializedObject, instanceOf(JsonDataWithSchema.class));
-        assertThat(deserializedObject, is(userSchema));
+        assertThat(deserializedObject).isInstanceOf(JsonDataWithSchema.class);
+        assertThat(deserializedObject).isEqualTo(userSchema);
     }
 
     /** Test whether deserialize method returns null when input byte array is null. */
@@ -163,7 +157,7 @@ public class GlueSchemaRegistryJsonDeserializationSchemaTest {
                 glueSchemaRegistryJsonDeserializationSchema =
                         new GlueSchemaRegistryJsonDeserializationSchema<>(
                                 Car.class, testTopic, configs);
-        assertThat(glueSchemaRegistryJsonDeserializationSchema.deserialize(null), nullValue());
+        assertThat(glueSchemaRegistryJsonDeserializationSchema.deserialize(null)).isNull();
     }
 
     private static class MockGlueSchemaRegistrySerializationFacadeForSpecific

--- a/flink-formats/flink-json-glue-schema-registry/src/test/java/org/apache/flink/formats/json/glue/schema/registry/GlueSchemaRegistryJsonSchemaCoderTest.java
+++ b/flink-formats/flink-json-glue-schema-registry/src/test/java/org/apache/flink/formats/json/glue/schema/registry/GlueSchemaRegistryJsonSchemaCoderTest.java
@@ -30,9 +30,7 @@ import java.util.Map;
 
 import static org.apache.flink.connector.aws.config.AWSConfigConstants.AWS_ACCESS_KEY_ID;
 import static org.apache.flink.connector.aws.config.AWSConfigConstants.AWS_SECRET_ACCESS_KEY;
-import static org.hamcrest.MatcherAssert.assertThat;
-import static org.hamcrest.Matchers.equalTo;
-import static org.hamcrest.Matchers.instanceOf;
+import static org.assertj.core.api.Assertions.assertThat;
 
 /** Tests for {@link GlueSchemaRegistryJsonSchemaCoder}. */
 public class GlueSchemaRegistryJsonSchemaCoderTest {
@@ -46,7 +44,7 @@ public class GlueSchemaRegistryJsonSchemaCoderTest {
                 getField("glueSchemaRegistryDeserializationFacade", coder);
 
         AwsCredentialsProvider credentialsProvider = facade.getCredentialsProvider();
-        assertThat(credentialsProvider, instanceOf(DefaultCredentialsProvider.class));
+        assertThat(credentialsProvider).isInstanceOf(DefaultCredentialsProvider.class);
     }
 
     @Test
@@ -62,8 +60,8 @@ public class GlueSchemaRegistryJsonSchemaCoderTest {
                 getField("glueSchemaRegistryDeserializationFacade", coder);
 
         AwsCredentialsProvider credentialsProvider = facade.getCredentialsProvider();
-        assertThat(credentialsProvider.resolveCredentials().accessKeyId(), equalTo("ak"));
-        assertThat(credentialsProvider.resolveCredentials().secretAccessKey(), equalTo("sk"));
+        assertThat(credentialsProvider.resolveCredentials().accessKeyId()).isEqualTo("ak");
+        assertThat(credentialsProvider.resolveCredentials().secretAccessKey()).isEqualTo("sk");
     }
 
     private <T> T getField(final String fieldName, final Object instance) throws Exception {

--- a/flink-formats/flink-json-glue-schema-registry/src/test/java/org/apache/flink/formats/json/glue/schema/registry/GlueSchemaRegistryJsonSchemaCoderTest.java
+++ b/flink-formats/flink-json-glue-schema-registry/src/test/java/org/apache/flink/formats/json/glue/schema/registry/GlueSchemaRegistryJsonSchemaCoderTest.java
@@ -1,0 +1,82 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.flink.formats.json.glue.schema.registry;
+
+import com.amazonaws.services.schemaregistry.deserializers.GlueSchemaRegistryDeserializationFacade;
+import com.amazonaws.services.schemaregistry.utils.AWSSchemaRegistryConstants;
+import org.junit.Test;
+import software.amazon.awssdk.auth.credentials.AwsCredentialsProvider;
+import software.amazon.awssdk.auth.credentials.DefaultCredentialsProvider;
+
+import java.lang.reflect.Field;
+import java.util.HashMap;
+import java.util.Map;
+
+import static org.apache.flink.connector.aws.config.AWSConfigConstants.AWS_ACCESS_KEY_ID;
+import static org.apache.flink.connector.aws.config.AWSConfigConstants.AWS_SECRET_ACCESS_KEY;
+import static org.hamcrest.MatcherAssert.assertThat;
+import static org.hamcrest.Matchers.equalTo;
+import static org.hamcrest.Matchers.instanceOf;
+
+/** Tests for {@link GlueSchemaRegistryJsonSchemaCoder}. */
+public class GlueSchemaRegistryJsonSchemaCoderTest {
+
+    @Test
+    public void testDefaultAwsCredentialsProvider() throws Exception {
+        GlueSchemaRegistryJsonSchemaCoder coder =
+                new GlueSchemaRegistryJsonSchemaCoder("test", getBaseConfig());
+
+        GlueSchemaRegistryDeserializationFacade facade =
+                getField("glueSchemaRegistryDeserializationFacade", coder);
+
+        AwsCredentialsProvider credentialsProvider = facade.getCredentialsProvider();
+        assertThat(credentialsProvider, instanceOf(DefaultCredentialsProvider.class));
+    }
+
+    @Test
+    public void testAwsCredentialsProviderFromConfig() throws Exception {
+        Map<String, Object> config = new HashMap<>(getBaseConfig());
+        config.put(AWS_ACCESS_KEY_ID, "ak");
+        config.put(AWS_SECRET_ACCESS_KEY, "sk");
+
+        GlueSchemaRegistryJsonSchemaCoder coder =
+                new GlueSchemaRegistryJsonSchemaCoder("test", config);
+
+        GlueSchemaRegistryDeserializationFacade facade =
+                getField("glueSchemaRegistryDeserializationFacade", coder);
+
+        AwsCredentialsProvider credentialsProvider = facade.getCredentialsProvider();
+        assertThat(credentialsProvider.resolveCredentials().accessKeyId(), equalTo("ak"));
+        assertThat(credentialsProvider.resolveCredentials().secretAccessKey(), equalTo("sk"));
+    }
+
+    private <T> T getField(final String fieldName, final Object instance) throws Exception {
+        Field field = instance.getClass().getDeclaredField(fieldName);
+        field.setAccessible(true);
+        return (T) field.get(instance);
+    }
+
+    private Map<String, Object> getBaseConfig() {
+        Map<String, Object> configs = new HashMap<>();
+        configs.put(AWSSchemaRegistryConstants.AWS_REGION, "us-west-2");
+        configs.put(AWSSchemaRegistryConstants.AWS_ENDPOINT, "https://test");
+        configs.put(AWSSchemaRegistryConstants.SCHEMA_AUTO_REGISTRATION_SETTING, true);
+        return configs;
+    }
+}

--- a/flink-formats/flink-json-glue-schema-registry/src/test/java/org/apache/flink/formats/json/glue/schema/registry/GlueSchemaRegistryJsonSerializationSchemaTest.java
+++ b/flink-formats/flink-json-glue-schema-registry/src/test/java/org/apache/flink/formats/json/glue/schema/registry/GlueSchemaRegistryJsonSerializationSchemaTest.java
@@ -39,11 +39,8 @@ import java.util.HashMap;
 import java.util.Map;
 import java.util.UUID;
 
-import static org.hamcrest.CoreMatchers.equalTo;
-import static org.hamcrest.CoreMatchers.instanceOf;
-import static org.hamcrest.CoreMatchers.notNullValue;
-import static org.hamcrest.CoreMatchers.nullValue;
-import static org.hamcrest.MatcherAssert.assertThat;
+import static com.amazonaws.services.schemaregistry.utils.AWSSchemaRegistryConstants.COMPRESSION.NONE;
+import static org.assertj.core.api.Assertions.assertThat;
 
 /** Tests for {@link GlueSchemaRegistryJsonSerializationSchema}. */
 public class GlueSchemaRegistryJsonSerializationSchemaTest {
@@ -67,10 +64,10 @@ public class GlueSchemaRegistryJsonSerializationSchemaTest {
     private static final UUID schemaVersionId = UUID.randomUUID();
     private static JsonDataWithSchema userSchema;
     private static Car userDefinedPojo;
-    private static Map<String, Object> configs = new HashMap<>();
-    private static Map<String, String> metadata = new HashMap<>();
+    private static final Map<String, Object> configs = new HashMap<>();
+    private static final Map<String, String> metadata = new HashMap<>();
     private static GlueSchemaRegistryConfiguration glueSchemaRegistryConfiguration;
-    private static AwsCredentialsProvider credentialsProvider =
+    private static final AwsCredentialsProvider credentialsProvider =
             DefaultCredentialsProvider.builder().build();
     private static GlueSchemaRegistrySerializationFacade mockSerializationFacade;
 
@@ -107,12 +104,9 @@ public class GlueSchemaRegistryJsonSerializationSchemaTest {
     /** Test initialization works. */
     @Test
     public void testForGeneric_withValidParams_succeeds() {
-        assertThat(
-                new GlueSchemaRegistryJsonSerializationSchema<>(testTopic, configs),
-                notNullValue());
-        assertThat(
-                new GlueSchemaRegistryJsonSerializationSchema<>(testTopic, configs),
-                instanceOf(GlueSchemaRegistryJsonSerializationSchema.class));
+        assertThat(new GlueSchemaRegistryJsonSerializationSchema<>(testTopic, configs)).isNotNull();
+        assertThat(new GlueSchemaRegistryJsonSerializationSchema<>(testTopic, configs))
+                .isInstanceOf(GlueSchemaRegistryJsonSerializationSchema.class);
     }
 
     /**
@@ -121,20 +115,18 @@ public class GlueSchemaRegistryJsonSerializationSchemaTest {
      */
     @Test
     public void testSerializePOJO_withValidParams_withoutCompression_succeeds() {
-        AWSSchemaRegistryConstants.COMPRESSION compressionType =
-                AWSSchemaRegistryConstants.COMPRESSION.NONE;
-        configs.put(AWSSchemaRegistryConstants.COMPRESSION_TYPE, compressionType.name());
+        configs.put(AWSSchemaRegistryConstants.COMPRESSION_TYPE, NONE.name());
 
         GlueSchemaRegistryJsonSchemaCoder glueSchemaRegistryJsonSchemaCoder =
                 new GlueSchemaRegistryJsonSchemaCoder(
                         testTopic, configs, mockSerializationFacade, null);
 
-        GlueSchemaRegistryJsonSerializationSchema glueSchemaRegistryJsonSerializationSchema =
+        GlueSchemaRegistryJsonSerializationSchema<Car> glueSchemaRegistryJsonSerializationSchema =
                 new GlueSchemaRegistryJsonSerializationSchema<>(glueSchemaRegistryJsonSchemaCoder);
 
         byte[] serializedData =
                 glueSchemaRegistryJsonSerializationSchema.serialize(userDefinedPojo);
-        assertThat(serializedData, equalTo(serializedBytes));
+        assertThat(serializedData).isEqualTo(serializedBytes);
     }
 
     /**
@@ -143,19 +135,19 @@ public class GlueSchemaRegistryJsonSerializationSchemaTest {
      */
     @Test
     public void testSerializeGenericData_withValidParams_withoutCompression_succeeds() {
-        AWSSchemaRegistryConstants.COMPRESSION compressionType =
-                AWSSchemaRegistryConstants.COMPRESSION.NONE;
-        configs.put(AWSSchemaRegistryConstants.COMPRESSION_TYPE, compressionType.name());
+        configs.put(AWSSchemaRegistryConstants.COMPRESSION_TYPE, NONE.name());
 
         GlueSchemaRegistryJsonSchemaCoder glueSchemaRegistryJsonSchemaCoder =
                 new GlueSchemaRegistryJsonSchemaCoder(
                         testTopic, configs, mockSerializationFacade, null);
 
-        GlueSchemaRegistryJsonSerializationSchema glueSchemaRegistryJsonSerializationSchema =
-                new GlueSchemaRegistryJsonSerializationSchema<>(glueSchemaRegistryJsonSchemaCoder);
+        GlueSchemaRegistryJsonSerializationSchema<JsonDataWithSchema>
+                glueSchemaRegistryJsonSerializationSchema =
+                        new GlueSchemaRegistryJsonSerializationSchema<>(
+                                glueSchemaRegistryJsonSchemaCoder);
 
         byte[] serializedData = glueSchemaRegistryJsonSerializationSchema.serialize(userSchema);
-        assertThat(serializedData, equalTo(serializedBytes));
+        assertThat(serializedData).isEqualTo(serializedBytes);
     }
 
     /**
@@ -172,12 +164,12 @@ public class GlueSchemaRegistryJsonSerializationSchemaTest {
                 new GlueSchemaRegistryJsonSchemaCoder(
                         testTopic, configs, mockSerializationFacade, null);
 
-        GlueSchemaRegistryJsonSerializationSchema glueSchemaRegistryJsonSerializationSchema =
+        GlueSchemaRegistryJsonSerializationSchema<Car> glueSchemaRegistryJsonSerializationSchema =
                 new GlueSchemaRegistryJsonSerializationSchema<>(glueSchemaRegistryJsonSchemaCoder);
 
         byte[] serializedData =
                 glueSchemaRegistryJsonSerializationSchema.serialize(userDefinedPojo);
-        assertThat(serializedData, equalTo(serializedBytes));
+        assertThat(serializedData).isEqualTo(serializedBytes);
     }
 
     /**
@@ -194,19 +186,21 @@ public class GlueSchemaRegistryJsonSerializationSchemaTest {
                 new GlueSchemaRegistryJsonSchemaCoder(
                         testTopic, configs, mockSerializationFacade, null);
 
-        GlueSchemaRegistryJsonSerializationSchema glueSchemaRegistryJsonSerializationSchema =
-                new GlueSchemaRegistryJsonSerializationSchema<>(glueSchemaRegistryJsonSchemaCoder);
+        GlueSchemaRegistryJsonSerializationSchema<JsonDataWithSchema>
+                glueSchemaRegistryJsonSerializationSchema =
+                        new GlueSchemaRegistryJsonSerializationSchema<>(
+                                glueSchemaRegistryJsonSchemaCoder);
 
         byte[] serializedData = glueSchemaRegistryJsonSerializationSchema.serialize(userSchema);
-        assertThat(serializedData, equalTo(serializedBytes));
+        assertThat(serializedData).isEqualTo(serializedBytes);
     }
 
     /** Test whether serialize method returns null when input object is null. */
     @Test
     public void testSerialize_withNullObject_returnNull() {
-        GlueSchemaRegistryJsonSerializationSchema glueSchemaRegistryJsonSerializationSchema =
+        GlueSchemaRegistryJsonSerializationSchema<Car> glueSchemaRegistryJsonSerializationSchema =
                 new GlueSchemaRegistryJsonSerializationSchema<>(testTopic, configs);
-        assertThat(glueSchemaRegistryJsonSerializationSchema.serialize(null), nullValue());
+        assertThat(glueSchemaRegistryJsonSerializationSchema.serialize(null)).isNull();
     }
 
     private static class MockGlueSchemaRegistrySerializationFacade


### PR DESCRIPTION
## What is the purpose of the change

- Fixing Glue Schema Registry integration tests for Azure CI build

## Brief change log

- Glue Schema Registry avro and json format construct AWS Credential Provider using property map
- Updated e2e tests to pass AWS keys into client correctly

## Verifying this change

Please make sure both new and modified tests in this PR follows the conventions defined in our code quality guide: https://flink.apache.org/contributing/code-style-and-quality-common.html#testing

This change added tests and can be verified as follows:
- Added new unit tests to verify custom AWS Credential Provider is used
- Manually ran integration tests locally

## Does this pull request potentially affect one of the following parts:

  - Dependencies (does it add or upgrade a dependency): yes (guava update)
  - The public API, i.e., is any changed class annotated with `@Public(Evolving)`: no
  - The serializers: no
  - The runtime per-record code paths (performance sensitive): no
  - Anything that affects deployment or recovery: JobManager (and its components), Checkpointing, Kubernetes/Yarn, ZooKeeper: no
  - The S3 file system connector: no

## Documentation

  - Does this pull request introduce a new feature? yes
  - If yes, how is the feature documented? docs
