### PR TITLE
[FLINK-25032] Allow to create execution vertices and execution edges lazily

### DIFF
--- a/flink-runtime/src/main/java/org/apache/flink/runtime/executiongraph/DefaultExecutionGraph.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/executiongraph/DefaultExecutionGraph.java
@@ -757,18 +757,34 @@ public class DefaultExecutionGraph implements ExecutionGraph, InternalExecutionG
 
     @Override
     public void attachJobGraph(List<JobVertex> topologicallySorted) throws JobException {
+        attachJobGraph(topologicallySorted, topologicallySorted);
+    }
+
+    private void attachJobGraph(
+            List<JobVertex> verticesToAttach, List<JobVertex> verticesToInitialize)
+            throws JobException {
 
         assertRunningInJobMasterMainThread();
 
         LOG.debug(
                 "Attaching {} topologically sorted vertices to existing job graph with {} "
                         + "vertices and {} intermediate results.",
-                topologicallySorted.size(),
+                verticesToAttach.size(),
                 tasks.size(),
                 intermediateResults.size());
 
-        final long createTimestamp = System.currentTimeMillis();
+        attachJobVertices(verticesToAttach);
+        initializeJobVertices(verticesToInitialize);
 
+        // the topology assigning should happen before notifying new vertices to failoverStrategy
+        executionTopology = DefaultExecutionTopology.fromExecutionGraph(this);
+
+        partitionGroupReleaseStrategy =
+                partitionGroupReleaseStrategyFactory.createInstance(getSchedulingTopology());
+    }
+
+    /** Attach job vertices without initializing them. */
+    private void attachJobVertices(List<JobVertex> topologicallySorted) throws JobException {
         for (JobVertex jobVertex : topologicallySorted) {
 
             if (jobVertex.isInputVertex() && !jobVertex.isStoppable()) {
@@ -779,17 +795,7 @@ public class DefaultExecutionGraph implements ExecutionGraph, InternalExecutionG
                     parallelismStore.getParallelismInfo(jobVertex.getID());
 
             // create the execution job vertex and attach it to the graph
-            ExecutionJobVertex ejv =
-                    new ExecutionJobVertex(
-                            this,
-                            jobVertex,
-                            maxPriorAttemptsHistoryLength,
-                            rpcTimeout,
-                            createTimestamp,
-                            parallelismInfo,
-                            initialAttemptCounts.getAttemptCounts(jobVertex.getID()));
-
-            ejv.connectToPredecessors(this.intermediateResults);
+            ExecutionJobVertex ejv = new ExecutionJobVertex(this, jobVertex, parallelismInfo);
 
             ExecutionJobVertex previousTask = this.tasks.putIfAbsent(jobVertex.getID(), ejv);
             if (previousTask != null) {
@@ -799,28 +805,46 @@ public class DefaultExecutionGraph implements ExecutionGraph, InternalExecutionG
                                 jobVertex.getID(), ejv, previousTask));
             }
 
-            for (IntermediateResult res : ejv.getProducedDataSets()) {
-                IntermediateResult previousDataSet =
-                        this.intermediateResults.putIfAbsent(res.getId(), res);
-                if (previousDataSet != null) {
-                    throw new JobException(
-                            String.format(
-                                    "Encountered two intermediate data set with ID %s : previous=[%s] / new=[%s]",
-                                    res.getId(), res, previousDataSet));
-                }
-            }
-
             this.verticesInCreationOrder.add(ejv);
             this.numJobVerticesTotal++;
         }
+    }
 
-        registerExecutionVerticesAndResultPartitions(this.verticesInCreationOrder);
+    private void initializeJobVertices(List<JobVertex> topologicallySorted) throws JobException {
+        final long createTimestamp = System.currentTimeMillis();
 
-        // the topology assigning should happen before notifying new vertices to failoverStrategy
-        executionTopology = DefaultExecutionTopology.fromExecutionGraph(this);
+        for (JobVertex jobVertex : topologicallySorted) {
+            final ExecutionJobVertex ejv = tasks.get(jobVertex.getID());
+            initializeJobVertex(ejv, createTimestamp);
+        }
+    }
 
-        partitionGroupReleaseStrategy =
-                partitionGroupReleaseStrategyFactory.createInstance(getSchedulingTopology());
+    @Override
+    public void initializeJobVertex(ExecutionJobVertex ejv, long createTimestamp)
+            throws JobException {
+
+        checkNotNull(ejv);
+
+        ejv.initialize(
+                maxPriorAttemptsHistoryLength,
+                rpcTimeout,
+                createTimestamp,
+                this.initialAttemptCounts.getAttemptCounts(ejv.getJobVertexId()));
+
+        ejv.connectToPredecessors(this.intermediateResults);
+
+        for (IntermediateResult res : ejv.getProducedDataSets()) {
+            IntermediateResult previousDataSet =
+                    this.intermediateResults.putIfAbsent(res.getId(), res);
+            if (previousDataSet != null) {
+                throw new JobException(
+                        String.format(
+                                "Encountered two intermediate data set with ID %s : previous=[%s] / new=[%s]",
+                                res.getId(), res, previousDataSet));
+            }
+        }
+
+        registerExecutionVerticesAndResultPartitionsFor(ejv);
     }
 
     @Override
@@ -1395,13 +1419,11 @@ public class DefaultExecutionGraph implements ExecutionGraph, InternalExecutionG
         }
     }
 
-    private void registerExecutionVerticesAndResultPartitions(
-            List<ExecutionJobVertex> executionJobVertices) {
-        for (ExecutionJobVertex executionJobVertex : executionJobVertices) {
-            for (ExecutionVertex executionVertex : executionJobVertex.getTaskVertices()) {
-                executionVerticesById.put(executionVertex.getID(), executionVertex);
-                resultPartitionsById.putAll(executionVertex.getProducedPartitions());
-            }
+    private void registerExecutionVerticesAndResultPartitionsFor(
+            ExecutionJobVertex executionJobVertex) {
+        for (ExecutionVertex executionVertex : executionJobVertex.getTaskVertices()) {
+            executionVerticesById.put(executionVertex.getID(), executionVertex);
+            resultPartitionsById.putAll(executionVertex.getProducedPartitions());
         }
     }
 

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/executiongraph/DefaultExecutionGraph.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/executiongraph/DefaultExecutionGraph.java
@@ -267,6 +267,8 @@ public class DefaultExecutionGraph implements ExecutionGraph, InternalExecutionG
     private final Map<IntermediateResultPartitionID, IntermediateResultPartition>
             resultPartitionsById;
 
+    private final boolean isDynamic;
+
     // --------------------------------------------------------------------------------------------
     //   Constructors
     // --------------------------------------------------------------------------------------------
@@ -287,7 +289,8 @@ public class DefaultExecutionGraph implements ExecutionGraph, InternalExecutionG
             ExecutionStateUpdateListener executionStateUpdateListener,
             long initializationTimestamp,
             VertexAttemptNumberStore initialAttemptCounts,
-            VertexParallelismStore vertexParallelismStore)
+            VertexParallelismStore vertexParallelismStore,
+            boolean isDynamic)
             throws IOException {
 
         this.jobInformation = checkNotNull(jobInformation);
@@ -350,6 +353,8 @@ public class DefaultExecutionGraph implements ExecutionGraph, InternalExecutionG
         this.edgeManager = new EdgeManager();
         this.executionVerticesById = new HashMap<>();
         this.resultPartitionsById = new HashMap<>();
+
+        this.isDynamic = isDynamic;
     }
 
     @Override
@@ -757,7 +762,11 @@ public class DefaultExecutionGraph implements ExecutionGraph, InternalExecutionG
 
     @Override
     public void attachJobGraph(List<JobVertex> topologicallySorted) throws JobException {
-        attachJobGraph(topologicallySorted, topologicallySorted);
+        if (isDynamic) {
+            attachJobGraph(topologicallySorted, Collections.emptyList());
+        } else {
+            attachJobGraph(topologicallySorted, topologicallySorted);
+        }
     }
 
     private void attachJobGraph(

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/executiongraph/DefaultExecutionGraphBuilder.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/executiongraph/DefaultExecutionGraphBuilder.java
@@ -89,7 +89,8 @@ public class DefaultExecutionGraphBuilder {
             long initializationTimestamp,
             VertexAttemptNumberStore vertexAttemptNumberStore,
             VertexParallelismStore vertexParallelismStore,
-            Supplier<CheckpointStatsTracker> checkpointStatsTrackerFactory)
+            Supplier<CheckpointStatsTracker> checkpointStatsTrackerFactory,
+            boolean isDynamicGraph)
             throws JobExecutionException, JobException {
 
         checkNotNull(jobGraph, "job graph cannot be null");
@@ -133,7 +134,8 @@ public class DefaultExecutionGraphBuilder {
                             executionStateUpdateListener,
                             initializationTimestamp,
                             vertexAttemptNumberStore,
-                            vertexParallelismStore);
+                            vertexParallelismStore,
+                            isDynamicGraph);
         } catch (IOException e) {
             throw new JobException("Could not create the ExecutionGraph.", e);
         }
@@ -197,7 +199,10 @@ public class DefaultExecutionGraphBuilder {
         }
 
         // configure the state checkpointing
-        if (isCheckpointingEnabled(jobGraph)) {
+        if (isDynamicGraph) {
+            // dynamic graph does not support checkpointing so we skip it
+            log.warn("Skip setting up checkpointing for a job with dynamic graph.");
+        } else if (isCheckpointingEnabled(jobGraph)) {
             JobCheckpointingSettings snapshotSettings = jobGraph.getCheckpointingSettings();
 
             // load the state backend from the application settings

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/executiongraph/ExecutionGraph.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/executiongraph/ExecutionGraph.java
@@ -210,4 +210,14 @@ public interface ExecutionGraph extends AccessExecutionGraph {
 
     @Nonnull
     ComponentMainThreadExecutor getJobMasterMainThreadExecutor();
+
+    /**
+     * Initialize the given execution job vertex, mainly includes creating execution vertices
+     * according to the parallelism, and connecting to the predecessors.
+     *
+     * @param ejv The execution job vertex that needs to be initialized.
+     * @param createTimestamp The timestamp for creating execution vertices, used to initialize the
+     *     first Execution with.
+     */
+    void initializeJobVertex(ExecutionJobVertex ejv, long createTimestamp) throws JobException;
 }

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/executiongraph/ExecutionJobVertex.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/executiongraph/ExecutionJobVertex.java
@@ -284,6 +284,10 @@ public class ExecutionJobVertex
         return graph;
     }
 
+    public void setParallelism(int parallelism) {
+        parallelismInfo.setParallelism(parallelism);
+    }
+
     public JobVertex getJobVertex() {
         return jobVertex;
     }

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/executiongraph/ExecutionJobVertex.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/executiongraph/ExecutionJobVertex.java
@@ -69,6 +69,7 @@ import java.util.function.Function;
 import java.util.stream.Collectors;
 
 import static org.apache.flink.util.Preconditions.checkNotNull;
+import static org.apache.flink.util.Preconditions.checkState;
 
 /**
  * An {@code ExecutionJobVertex} is part of the {@link ExecutionGraph}, and the peer to the {@link
@@ -89,11 +90,11 @@ public class ExecutionJobVertex
 
     private final JobVertex jobVertex;
 
-    private final ExecutionVertex[] taskVertices;
+    @Nullable private ExecutionVertex[] taskVertices;
 
-    private final IntermediateResult[] producedDataSets;
+    @Nullable private IntermediateResult[] producedDataSets;
 
-    private final List<IntermediateResult> inputs;
+    @Nullable private List<IntermediateResult> inputs;
 
     private final VertexParallelismInformation parallelismInfo;
 
@@ -101,7 +102,7 @@ public class ExecutionJobVertex
 
     @Nullable private final CoLocationGroup coLocationGroup;
 
-    private final InputSplit[] inputSplits;
+    @Nullable private InputSplit[] inputSplits;
 
     private final ResourceProfile resourceProfile;
 
@@ -115,19 +116,15 @@ public class ExecutionJobVertex
     private Either<SerializedValue<TaskInformation>, PermanentBlobKey> taskInformationOrBlobKey =
             null;
 
-    private final Collection<OperatorCoordinatorHolder> operatorCoordinators;
+    @Nullable private Collection<OperatorCoordinatorHolder> operatorCoordinators;
 
-    private InputSplitAssigner splitAssigner;
+    @Nullable private InputSplitAssigner splitAssigner;
 
     @VisibleForTesting
     public ExecutionJobVertex(
             InternalExecutionGraphAccessor graph,
             JobVertex jobVertex,
-            int maxPriorAttemptsHistoryLength,
-            Time timeout,
-            long createTimestamp,
-            VertexParallelismInformation parallelismInfo,
-            SubtaskAttemptNumberStore initialAttemptCounts)
+            VertexParallelismInformation parallelismInfo)
             throws JobException {
 
         if (graph == null || jobVertex == null) {
@@ -152,13 +149,24 @@ public class ExecutionJobVertex
         this.resourceProfile =
                 ResourceProfile.fromResourceSpec(jobVertex.getMinResources(), MemorySize.ZERO);
 
-        this.taskVertices = new ExecutionVertex[this.parallelismInfo.getParallelism()];
-
-        this.inputs = new ArrayList<>(jobVertex.getInputs().size());
-
         // take the sharing group
         this.slotSharingGroup = checkNotNull(jobVertex.getSlotSharingGroup());
         this.coLocationGroup = jobVertex.getCoLocationGroup();
+    }
+
+    protected void initialize(
+            int maxPriorAttemptsHistoryLength,
+            Time timeout,
+            long createTimestamp,
+            SubtaskAttemptNumberStore initialAttemptCounts)
+            throws JobException {
+
+        checkState(parallelismInfo.getParallelism() > 0);
+        checkState(!isInitialized());
+
+        this.taskVertices = new ExecutionVertex[parallelismInfo.getParallelism()];
+
+        this.inputs = new ArrayList<>(jobVertex.getInputs().size());
 
         // create the intermediate results
         this.producedDataSets =
@@ -250,6 +258,14 @@ public class ExecutionJobVertex
         }
     }
 
+    public boolean isInitialized() {
+        return taskVertices != null;
+    }
+
+    public boolean isParallelismDecided() {
+        return parallelismInfo.getParallelism() > 0;
+    }
+
     /**
      * Returns a list containing the ID pairs of all operators contained in this execution job
      * vertex.
@@ -307,14 +323,24 @@ public class ExecutionJobVertex
 
     @Override
     public ExecutionVertex[] getTaskVertices() {
+        if (taskVertices == null) {
+            // The REST/web may try to get execution vertices of an uninitialized job vertex. Using
+            // DEBUG log level to avoid flooding logs.
+            LOG.debug(
+                    "Trying to get execution vertices of an uninitialized job vertex "
+                            + getJobVertexId());
+            return new ExecutionVertex[0];
+        }
         return taskVertices;
     }
 
     public IntermediateResult[] getProducedDataSets() {
+        checkState(isInitialized());
         return producedDataSets;
     }
 
     public InputSplitAssigner getSplitAssigner() {
+        checkState(isInitialized());
         return splitAssigner;
     }
 
@@ -328,10 +354,12 @@ public class ExecutionJobVertex
     }
 
     public List<IntermediateResult> getInputs() {
+        checkState(isInitialized());
         return inputs;
     }
 
     public Collection<OperatorCoordinatorHolder> getOperatorCoordinators() {
+        checkState(isInitialized());
         return operatorCoordinators;
     }
 
@@ -367,7 +395,7 @@ public class ExecutionJobVertex
     @Override
     public ExecutionState getAggregateState() {
         int[] num = new int[ExecutionState.values().length];
-        for (ExecutionVertex vertex : this.taskVertices) {
+        for (ExecutionVertex vertex : getTaskVertices()) {
             num[vertex.getExecutionState().ordinal()]++;
         }
 
@@ -379,6 +407,7 @@ public class ExecutionJobVertex
     public void connectToPredecessors(
             Map<IntermediateDataSetID, IntermediateResult> intermediateDataSets)
             throws JobException {
+        checkState(isInitialized());
 
         List<JobEdge> inputs = jobVertex.getInputs();
 
@@ -466,6 +495,7 @@ public class ExecutionJobVertex
     }
 
     void executionVertexFinished() {
+        checkState(isInitialized());
         numExecutionVertexFinished++;
         if (numExecutionVertexFinished == parallelismInfo.getParallelism()) {
             getGraph().jobVertexFinished();
@@ -473,6 +503,7 @@ public class ExecutionJobVertex
     }
 
     void executionVertexUnFinished() {
+        checkState(isInitialized());
         if (numExecutionVertexFinished == parallelismInfo.getParallelism()) {
             getGraph().jobVertexUnFinished();
         }
@@ -486,7 +517,7 @@ public class ExecutionJobVertex
     public StringifiedAccumulatorResult[] getAggregatedUserAccumulatorsStringified() {
         Map<String, OptionalFailure<Accumulator<?, ?>>> userAccumulators = new HashMap<>();
 
-        for (ExecutionVertex vertex : taskVertices) {
+        for (ExecutionVertex vertex : getTaskVertices()) {
             Map<String, Accumulator<?, ?>> next =
                     vertex.getCurrentExecutionAttempt().getUserAccumulators();
             if (next != null) {

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/scheduler/DefaultExecutionGraphFactory.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/scheduler/DefaultExecutionGraphFactory.java
@@ -63,6 +63,7 @@ public class DefaultExecutionGraphFactory implements ExecutionGraphFactory {
     private final ShuffleMaster<?> shuffleMaster;
     private final JobMasterPartitionTracker jobMasterPartitionTracker;
     private final Supplier<CheckpointStatsTracker> checkpointStatsTrackerFactory;
+    private final boolean isDynamicGraph;
 
     public DefaultExecutionGraphFactory(
             Configuration configuration,
@@ -75,6 +76,32 @@ public class DefaultExecutionGraphFactory implements ExecutionGraphFactory {
             BlobWriter blobWriter,
             ShuffleMaster<?> shuffleMaster,
             JobMasterPartitionTracker jobMasterPartitionTracker) {
+        this(
+                configuration,
+                userCodeClassLoader,
+                executionDeploymentTracker,
+                futureExecutor,
+                ioExecutor,
+                rpcTimeout,
+                jobManagerJobMetricGroup,
+                blobWriter,
+                shuffleMaster,
+                jobMasterPartitionTracker,
+                false);
+    }
+
+    public DefaultExecutionGraphFactory(
+            Configuration configuration,
+            ClassLoader userCodeClassLoader,
+            ExecutionDeploymentTracker executionDeploymentTracker,
+            ScheduledExecutorService futureExecutor,
+            Executor ioExecutor,
+            Time rpcTimeout,
+            JobManagerJobMetricGroup jobManagerJobMetricGroup,
+            BlobWriter blobWriter,
+            ShuffleMaster<?> shuffleMaster,
+            JobMasterPartitionTracker jobMasterPartitionTracker,
+            boolean isDynamicGraph) {
         this.configuration = configuration;
         this.userCodeClassLoader = userCodeClassLoader;
         this.executionDeploymentTracker = executionDeploymentTracker;
@@ -92,6 +119,7 @@ public class DefaultExecutionGraphFactory implements ExecutionGraphFactory {
                                         configuration.getInteger(
                                                 WebOptions.CHECKPOINTS_HISTORY_SIZE),
                                         jobManagerJobMetricGroup));
+        this.isDynamicGraph = isDynamicGraph;
     }
 
     @Override
@@ -136,7 +164,8 @@ public class DefaultExecutionGraphFactory implements ExecutionGraphFactory {
                         initializationTimestamp,
                         vertexAttemptNumberStore,
                         vertexParallelismStore,
-                        checkpointStatsTrackerFactory);
+                        checkpointStatsTrackerFactory,
+                        isDynamicGraph);
 
         final CheckpointCoordinator checkpointCoordinator =
                 newExecutionGraph.getCheckpointCoordinator();

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/scheduler/DefaultScheduler.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/scheduler/DefaultScheduler.java
@@ -150,7 +150,8 @@ public class DefaultScheduler extends SchedulerBase implements SchedulerOperatio
                 initializationTimestamp,
                 mainThreadExecutor,
                 jobStatusListener,
-                executionGraphFactory);
+                executionGraphFactory,
+                computeVertexParallelismStore(jobGraph));
 
         this.log = log;
 

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/scheduler/VertexParallelismInformation.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/scheduler/VertexParallelismInformation.java
@@ -38,6 +38,14 @@ public interface VertexParallelismInformation {
     int getMaxParallelism();
 
     /**
+     * Set a given vertex's parallelism property. The parallelism can be changed only if the vertex
+     * parallelism was not decided yet (i.e. was -1).
+     *
+     * @param parallelism the parallelism for the vertex
+     */
+    void setParallelism(int parallelism);
+
+    /**
      * Changes a given vertex's max parallelism property. The caller should first check the validity
      * of the new setting via {@link #canRescaleMaxParallelism}, otherwise this operation may fail.
      *

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/scheduler/adapter/DefaultExecutionTopology.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/scheduler/adapter/DefaultExecutionTopology.java
@@ -167,7 +167,7 @@ public class DefaultExecutionTopology implements SchedulingTopology {
 
         IndexedPipelinedRegions indexedPipelinedRegions =
                 computePipelinedRegions(
-                        logicalPipelinedRegions,
+                        executionGraphIndex.sortedExecutionVerticesInPipelinedRegion.keySet(),
                         executionGraphIndex.sortedExecutionVerticesInPipelinedRegion::get,
                         executionGraphIndex.executionVerticesById::get,
                         executionGraphIndex.resultPartitionsById::get);

--- a/flink-runtime/src/test/java/org/apache/flink/runtime/executiongraph/ExecutionJobVertexTest.java
+++ b/flink-runtime/src/test/java/org/apache/flink/runtime/executiongraph/ExecutionJobVertexTest.java
@@ -21,15 +21,18 @@ package org.apache.flink.runtime.executiongraph;
 import org.apache.flink.api.common.time.Time;
 import org.apache.flink.runtime.JobException;
 import org.apache.flink.runtime.io.network.partition.ResultPartitionType;
+import org.apache.flink.runtime.jobgraph.IntermediateDataSetID;
 import org.apache.flink.runtime.jobgraph.JobVertex;
 import org.apache.flink.runtime.jobgraph.tasks.AbstractInvokable;
-import org.apache.flink.runtime.scheduler.DefaultVertexParallelismInfo;
+import org.apache.flink.runtime.scheduler.SchedulerBase;
+import org.apache.flink.runtime.scheduler.VertexParallelismInformation;
+import org.apache.flink.runtime.scheduler.VertexParallelismStore;
 
 import org.junit.Assert;
 import org.junit.Test;
 
 import java.util.Collections;
-import java.util.Optional;
+import java.util.function.Function;
 
 import static org.apache.flink.core.testutils.CommonTestUtils.assertThrows;
 import static org.hamcrest.CoreMatchers.is;
@@ -53,15 +56,13 @@ public class ExecutionJobVertexTest {
 
     @Test
     public void testLazyInitialization() throws Exception {
-        final JobVertex jobVertex = new JobVertex("testVertex");
-        jobVertex.setInvokableClass(AbstractInvokable.class);
-        jobVertex.createAndAddResultDataSet(ResultPartitionType.BLOCKING);
+        final int parallelism = 3;
+        final int configuredMaxParallelism = 12;
+        final ExecutionJobVertex ejv =
+                createDynamicExecutionJobVertex(parallelism, configuredMaxParallelism, -1);
 
-        final DefaultExecutionGraph eg = TestingDefaultExecutionGraphBuilder.newBuilder().build();
-        final DefaultVertexParallelismInfo vertexParallelismInfo =
-                new DefaultVertexParallelismInfo(3, 8, max -> Optional.empty());
-        final ExecutionJobVertex ejv = new ExecutionJobVertex(eg, jobVertex, vertexParallelismInfo);
-
+        assertThat(ejv.getParallelism(), is(parallelism));
+        assertThat(ejv.getMaxParallelism(), is(configuredMaxParallelism));
         assertThat(ejv.isInitialized(), is(false));
 
         assertThat(ejv.getTaskVertices().length, is(0));
@@ -121,6 +122,63 @@ public class ExecutionJobVertexTest {
         assertThat(ejv.getTaskVertices().length, is(3));
         assertThat(ejv.getInputs().size(), is(0));
         assertThat(ejv.getProducedDataSets().length, is(1));
+        assertThat(ejv.getOperatorCoordinators().size(), is(0));
+    }
+
+    @Test(expected = IllegalStateException.class)
+    public void testErrorIfInitializationWithoutParallelismDecided() throws Exception {
+        final ExecutionJobVertex ejv = createDynamicExecutionJobVertex();
+
+        initializeVertex(ejv);
+    }
+
+    @Test
+    public void testSetParallelismLazily() throws Exception {
+        final int parallelism = 3;
+        final int defaultMaxParallelism = 13;
+        final ExecutionJobVertex ejv =
+                createDynamicExecutionJobVertex(-1, -1, defaultMaxParallelism);
+
+        assertThat(ejv.isParallelismDecided(), is(false));
+
+        ejv.setParallelism(parallelism);
+
+        assertThat(ejv.isParallelismDecided(), is(true));
+        assertThat(ejv.getParallelism(), is(parallelism));
+
+        initializeVertex(ejv);
+
+        assertThat(ejv.getTaskVertices().length, is(parallelism));
+    }
+
+    @Test
+    public void testConfiguredMaxParallelismIsRespected() throws Exception {
+        final int configuredMaxParallelism = 12;
+        final int defaultMaxParallelism = 13;
+        final ExecutionJobVertex ejv =
+                createDynamicExecutionJobVertex(
+                        -1, configuredMaxParallelism, defaultMaxParallelism);
+
+        assertThat(ejv.getMaxParallelism(), is(configuredMaxParallelism));
+    }
+
+    @Test
+    public void testComputingMaxParallelismFromConfiguredParallelism() throws Exception {
+        final int parallelism = 300;
+        final int defaultMaxParallelism = 13;
+        final ExecutionJobVertex ejv =
+                createDynamicExecutionJobVertex(parallelism, -1, defaultMaxParallelism);
+
+        assertThat(ejv.getMaxParallelism(), is(512));
+    }
+
+    @Test
+    public void testFallingBackToDefaultMaxParallelism() throws Exception {
+        final int defaultMaxParallelism = 13;
+        final ExecutionJobVertex ejv =
+                createDynamicExecutionJobVertex(-1, -1, defaultMaxParallelism);
+
+        assertThat(ejv.getMaxParallelism(), is(defaultMaxParallelism));
     }
 
     static void initializeVertex(ExecutionJobVertex vertex) throws Exception {
@@ -129,5 +187,61 @@ public class ExecutionJobVertexTest {
                 Time.milliseconds(1L),
                 1L,
                 new DefaultSubtaskAttemptNumberStore(Collections.emptyList()));
+    }
+
+    private static ExecutionJobVertex createDynamicExecutionJobVertex() throws Exception {
+        return createDynamicExecutionJobVertex(-1, -1, 1);
+    }
+
+    private static ExecutionJobVertex createDynamicExecutionJobVertex(
+            int parallelism, int maxParallelism, int defaultMaxParallelism) throws Exception {
+        JobVertex jobVertex = new JobVertex("testVertex");
+        jobVertex.setInvokableClass(AbstractInvokable.class);
+        jobVertex.createAndAddResultDataSet(
+                new IntermediateDataSetID(), ResultPartitionType.BLOCKING);
+
+        if (maxParallelism > 0) {
+            jobVertex.setMaxParallelism(maxParallelism);
+        }
+
+        if (parallelism > 0) {
+            jobVertex.setParallelism(parallelism);
+        }
+
+        final DefaultExecutionGraph eg = TestingDefaultExecutionGraphBuilder.newBuilder().build();
+        final VertexParallelismStore vertexParallelismStore =
+                computeVertexParallelismStoreForDynamicGraph(
+                        Collections.singletonList(jobVertex), defaultMaxParallelism);
+        final VertexParallelismInformation vertexParallelismInfo =
+                vertexParallelismStore.getParallelismInfo(jobVertex.getID());
+
+        return new ExecutionJobVertex(eg, jobVertex, vertexParallelismInfo);
+    }
+
+    /**
+     * Compute the {@link VertexParallelismStore} for all given vertices in a dynamic graph, which
+     * will set defaults and ensure that the returned store contains valid parallelisms, with the
+     * configured default max parallelism.
+     *
+     * @param vertices the vertices to compute parallelism for
+     * @param defaultMaxParallelism the global default max parallelism
+     * @return the computed parallelism store
+     */
+    private static VertexParallelismStore computeVertexParallelismStoreForDynamicGraph(
+            Iterable<JobVertex> vertices, int defaultMaxParallelism) {
+        // for dynamic graph, there is no need to normalize vertex parallelism. if the max
+        // parallelism is not configured and the parallelism is a positive value, max
+        // parallelism can be computed against the parallelism, otherwise it needs to use the
+        // global default max parallelism.
+        return SchedulerBase.computeVertexParallelismStore(
+                vertices,
+                v -> {
+                    if (v.getParallelism() > 0) {
+                        return SchedulerBase.getDefaultMaxParallelism(v);
+                    } else {
+                        return defaultMaxParallelism;
+                    }
+                },
+                Function.identity());
     }
 }

--- a/flink-runtime/src/test/java/org/apache/flink/runtime/executiongraph/TestingDefaultExecutionGraphBuilder.java
+++ b/flink-runtime/src/test/java/org/apache/flink/runtime/executiongraph/TestingDefaultExecutionGraphBuilder.java
@@ -156,7 +156,8 @@ public class TestingDefaultExecutionGraphBuilder {
         return this;
     }
 
-    public DefaultExecutionGraph build() throws JobException, JobExecutionException {
+    private DefaultExecutionGraph build(boolean isDynamicGraph)
+            throws JobException, JobExecutionException {
         return DefaultExecutionGraphBuilder.buildGraph(
                 jobGraph,
                 jobMasterConfig,
@@ -179,6 +180,15 @@ public class TestingDefaultExecutionGraphBuilder {
                 new DefaultVertexAttemptNumberStore(),
                 Optional.ofNullable(vertexParallelismStore)
                         .orElseGet(() -> SchedulerBase.computeVertexParallelismStore(jobGraph)),
-                () -> new CheckpointStatsTracker(0, new UnregisteredMetricsGroup()));
+                () -> new CheckpointStatsTracker(0, new UnregisteredMetricsGroup()),
+                isDynamicGraph);
+    }
+
+    public DefaultExecutionGraph build() throws JobException, JobExecutionException {
+        return build(false);
+    }
+
+    public DefaultExecutionGraph buildDynamicGraph() throws JobException, JobExecutionException {
+        return build(true);
     }
 }

--- a/flink-runtime/src/test/java/org/apache/flink/runtime/scheduler/DefaultVertexParallelismInfoTest.java
+++ b/flink-runtime/src/test/java/org/apache/flink/runtime/scheduler/DefaultVertexParallelismInfoTest.java
@@ -41,7 +41,13 @@ public class DefaultVertexParallelismInfoTest extends TestLogger {
         assertThrows(
                 "parallelism is not in valid bounds",
                 IllegalArgumentException.class,
-                () -> new DefaultVertexParallelismInfo(-1, 1, ALWAYS_VALID));
+                () -> new DefaultVertexParallelismInfo(-2, 1, ALWAYS_VALID));
+    }
+
+    @Test
+    public void parallelismValid() {
+        new DefaultVertexParallelismInfo(10, 1, ALWAYS_VALID);
+        new DefaultVertexParallelismInfo(ExecutionConfig.PARALLELISM_DEFAULT, 1, ALWAYS_VALID);
     }
 
     @Test
@@ -50,6 +56,43 @@ public class DefaultVertexParallelismInfoTest extends TestLogger {
                 "max parallelism is not in valid bounds",
                 IllegalArgumentException.class,
                 () -> new DefaultVertexParallelismInfo(1, -1, ALWAYS_VALID));
+    }
+
+    @Test
+    public void testSetParallelism() {
+        DefaultVertexParallelismInfo info =
+                new DefaultVertexParallelismInfo(
+                        ExecutionConfig.PARALLELISM_DEFAULT, 10, ALWAYS_VALID);
+
+        // test set negative value
+        assertThrows(
+                "parallelism is not in valid bounds",
+                IllegalArgumentException.class,
+                () -> {
+                    info.setParallelism(-1);
+                    return null;
+                });
+
+        // test parallelism larger than max parallelism
+        assertThrows(
+                "Vertex's parallelism should be smaller than or equal to vertex's max parallelism.",
+                IllegalArgumentException.class,
+                () -> {
+                    info.setParallelism(11);
+                    return null;
+                });
+
+        // set valid value.
+        info.setParallelism(5);
+
+        // test set parallelism for vertex whose parallelism was decided.
+        assertThrows(
+                "Vertex's parallelism can be set only if the vertex's parallelism was not decided yet.",
+                IllegalStateException.class,
+                () -> {
+                    info.setParallelism(5);
+                    return null;
+                });
     }
 
     @Test

--- a/flink-runtime/src/test/java/org/apache/flink/runtime/scheduler/DefaultVertexParallelismStoreTest.java
+++ b/flink-runtime/src/test/java/org/apache/flink/runtime/scheduler/DefaultVertexParallelismStoreTest.java
@@ -63,6 +63,9 @@ public class DefaultVertexParallelismStoreTest extends TestLogger {
         }
 
         @Override
+        public void setParallelism(int parallelism) {}
+
+        @Override
         public void setMaxParallelism(int maxParallelism) {}
 
         @Override

--- a/flink-runtime/src/test/java/org/apache/flink/runtime/scheduler/adaptive/ExecutingTest.java
+++ b/flink-runtime/src/test/java/org/apache/flink/runtime/scheduler/adaptive/ExecutingTest.java
@@ -755,10 +755,12 @@ public class ExecutingTest extends TestLogger {
             super(
                     new MockInternalExecutionGraphAccessor(),
                     new JobVertex("test"),
+                    new DefaultVertexParallelismInfo(1, 1, max -> Optional.empty()));
+
+            initialize(
                     1,
                     Time.milliseconds(1L),
                     1L,
-                    new DefaultVertexParallelismInfo(1, 1, max -> Optional.empty()),
                     new DefaultSubtaskAttemptNumberStore(Collections.emptyList()));
             mockExecutionVertex = executionVertexSupplier.apply(this);
         }

--- a/flink-runtime/src/test/java/org/apache/flink/runtime/scheduler/adaptive/StateTrackingMockExecutionGraph.java
+++ b/flink-runtime/src/test/java/org/apache/flink/runtime/scheduler/adaptive/StateTrackingMockExecutionGraph.java
@@ -359,4 +359,10 @@ class StateTrackingMockExecutionGraph implements ExecutionGraph {
     public ComponentMainThreadExecutor getJobMasterMainThreadExecutor() {
         throw new UnsupportedOperationException();
     }
+
+    @Override
+    public void initializeJobVertex(ExecutionJobVertex ejv, long createTimestamp)
+            throws JobException {
+        throw new UnsupportedOperationException();
+    }
 }


### PR DESCRIPTION
## What is the purpose of the change
Allow to create execution vertices and execution edges lazily, for adaptive batch scheduler.

## Brief change log

53f7c09e5e67d2860ed9369315c026315c62ee51 Allow ExecutionJobVertex to be initialized lazily.
289bf47d162a83c9cf355f3fd6df42af3359e8b9 Allow parallelism of ExecutionJobVertex to be decided lazily.
b0182326e201040a6a7a1e02d2e78ce4728e2820 Enable to create a dynamic graph.

## Verifying this change
Add some unit tests in `ExecutionJobVertexTest`, `DefaultExecutionGraphConstructionTest` 

## Does this pull request potentially affect one of the following parts:

  - Dependencies (does it add or upgrade a dependency): (**no**)
  - The public API, i.e., is any changed class annotated with `@Public(Evolving)`: (**no**)
  - The serializers: (**no**)
  - The runtime per-record code paths (performance sensitive): (**no**)
  - Anything that affects deployment or recovery: JobManager (and its components), Checkpointing, Kubernetes/Yarn, ZooKeeper: (**no**)
  - The S3 file system connector: (**no**)

## Documentation

  - Does this pull request introduce a new feature? (**no**)
  - If yes, how is the feature documented? (**not applicable**)
