### PR TITLE
[FLINK-25155] Implement claim snapshot mode

### DIFF
--- a/docs/layouts/shortcodes/generated/rest_v1_dispatcher.html
+++ b/docs/layouts/shortcodes/generated/rest_v1_dispatcher.html
@@ -869,6 +869,10 @@ Using 'curl' you can upload a jar via 'curl -X POST -H "Expect:" -F "jarfile=@pa
         "type" : "string"
       }
     },
+    "restoreMode" : {
+      "type" : "string",
+      "enum" : [ "CLAIM", "LEGACY" ]
+    },
     "savepointPath" : {
       "type" : "string"
     }
@@ -1028,6 +1032,9 @@ Using 'curl' you can upload a jar via 'curl -X POST -H "Expect:" -F "jarfile=@pa
         "type" : "object",
         "id" : "urn:jsonschema:org:apache:flink:runtime:rest:messages:LogInfo",
         "properties" : {
+          "mtime" : {
+            "type" : "integer"
+          },
           "name" : {
             "type" : "string"
           },
@@ -5729,6 +5736,9 @@ Using 'curl' you can upload a jar via 'curl -X POST -H "Expect:" -F "jarfile=@pa
         "type" : "object",
         "id" : "urn:jsonschema:org:apache:flink:runtime:rest:messages:LogInfo",
         "properties" : {
+          "mtime" : {
+            "type" : "integer"
+          },
           "name" : {
             "type" : "string"
           },

--- a/docs/layouts/shortcodes/generated/savepoint_config_configuration.html
+++ b/docs/layouts/shortcodes/generated/savepoint_config_configuration.html
@@ -9,6 +9,12 @@
     </thead>
     <tbody>
         <tr>
+            <td><h5>execution.savepoint-restore-mode</h5></td>
+            <td style="word-wrap: break-word;">LEGACY</td>
+            <td><p>Enum</p></td>
+            <td>Describes the mode how Flink should restore from the given savepoint or retained checkpoint.<br /><br />Possible values:<ul><li>"CLAIM": Flink will take ownership of the given snapshot. It will clean the snapshot once it is subsumed by newer ones.</li><li>"LEGACY": Flink will not claim ownership of the snapshot and will not delete the files. However, it can directly depend on the existence of the files of the restored checkpoint. It might not be safe to delete checkpoints that were restored in legacy mode </li></ul></td>
+        </tr>
+        <tr>
             <td><h5>execution.savepoint.ignore-unclaimed-state</h5></td>
             <td style="word-wrap: break-word;">false</td>
             <td>Boolean</td>

--- a/flink-clients/src/main/java/org/apache/flink/client/cli/CliFrontendParser.java
+++ b/flink-clients/src/main/java/org/apache/flink/client/cli/CliFrontendParser.java
@@ -19,6 +19,9 @@
 package org.apache.flink.client.cli;
 
 import org.apache.flink.configuration.CheckpointingOptions;
+import org.apache.flink.configuration.ConfigurationUtils;
+import org.apache.flink.runtime.jobgraph.RestoreMode;
+import org.apache.flink.runtime.jobgraph.SavepointConfigOptions;
 import org.apache.flink.runtime.jobgraph.SavepointRestoreSettings;
 
 import org.apache.commons.cli.CommandLine;
@@ -128,6 +131,15 @@ public class CliFrontendParser {
                     "Allow to skip savepoint state that cannot be restored. "
                             + "You need to allow this if you removed an operator from your "
                             + "program that was part of the program when the savepoint was triggered.");
+
+    public static final Option SAVEPOINT_RESTORE_MODE =
+            new Option(
+                    "restoreMode",
+                    true,
+                    "Defines how should we restore from the given savepoint. Supported options: "
+                            + "[claim - claim ownership of the savepoint and delete once it is"
+                            + " subsumed, legacy (default) - do not assume ownership of the"
+                            + " savepoint files.");
 
     static final Option SAVEPOINT_DISPOSE_OPTION =
             new Option("d", "dispose", true, "Path of savepoint to dispose.");
@@ -286,6 +298,7 @@ public class CliFrontendParser {
         SAVEPOINT_PATH_OPTION.setArgName("savepointPath");
 
         SAVEPOINT_ALLOW_NON_RESTORED_OPTION.setRequired(false);
+        SAVEPOINT_RESTORE_MODE.setRequired(false);
 
         ZOOKEEPER_NAMESPACE_OPTION.setRequired(false);
         ZOOKEEPER_NAMESPACE_OPTION.setArgName("zookeeperNamespace");
@@ -363,10 +376,10 @@ public class CliFrontendParser {
     }
 
     public static Options getRunCommandOptions() {
-        Options options = buildGeneralOptions(new Options());
-        options = getProgramSpecificOptions(options);
-        options.addOption(SAVEPOINT_PATH_OPTION);
-        return options.addOption(SAVEPOINT_ALLOW_NON_RESTORED_OPTION);
+        return getProgramSpecificOptions(buildGeneralOptions(new Options()))
+                .addOption(SAVEPOINT_PATH_OPTION)
+                .addOption(SAVEPOINT_ALLOW_NON_RESTORED_OPTION)
+                .addOption(SAVEPOINT_RESTORE_MODE);
     }
 
     static Options getInfoCommandOptions() {
@@ -403,9 +416,10 @@ public class CliFrontendParser {
     // --------------------------------------------------------------------------------------------
 
     private static Options getRunOptionsWithoutDeprecatedOptions(Options options) {
-        Options o = getProgramSpecificOptionsWithoutDeprecatedOptions(options);
-        o.addOption(SAVEPOINT_PATH_OPTION);
-        return o.addOption(SAVEPOINT_ALLOW_NON_RESTORED_OPTION);
+        return getProgramSpecificOptionsWithoutDeprecatedOptions(options)
+                .addOption(SAVEPOINT_PATH_OPTION)
+                .addOption(SAVEPOINT_ALLOW_NON_RESTORED_OPTION)
+                .addOption(SAVEPOINT_RESTORE_MODE);
     }
 
     private static Options getInfoOptionsWithoutDeprecatedOptions(Options options) {
@@ -593,7 +607,17 @@ public class CliFrontendParser {
             String savepointPath = commandLine.getOptionValue(SAVEPOINT_PATH_OPTION.getOpt());
             boolean allowNonRestoredState =
                     commandLine.hasOption(SAVEPOINT_ALLOW_NON_RESTORED_OPTION.getOpt());
-            return SavepointRestoreSettings.forPath(savepointPath, allowNonRestoredState);
+            final RestoreMode restoreMode;
+            if (commandLine.hasOption(SAVEPOINT_RESTORE_MODE)) {
+                restoreMode =
+                        ConfigurationUtils.convertValue(
+                                commandLine.getOptionValue(SAVEPOINT_RESTORE_MODE),
+                                RestoreMode.class);
+            } else {
+                restoreMode = SavepointConfigOptions.RESTORE_MODE.defaultValue();
+            }
+            return SavepointRestoreSettings.forPath(
+                    savepointPath, allowNonRestoredState, restoreMode);
         } else {
             return SavepointRestoreSettings.none();
         }

--- a/flink-clients/src/test/java/org/apache/flink/client/cli/CliFrontendRunTest.java
+++ b/flink-clients/src/test/java/org/apache/flink/client/cli/CliFrontendRunTest.java
@@ -166,7 +166,7 @@ public class CliFrontendRunTest extends CliFrontendTestBase {
 
         SavepointRestoreSettings savepointSettings = executionOptions.getSavepointRestoreSettings();
         assertTrue(savepointSettings.restoreSavepoint());
-        assertEquals(RestoreMode.NO_CLAIM, savepointSettings.getRestoreMode());
+        assertEquals(RestoreMode.LEGACY, savepointSettings.getRestoreMode());
         assertEquals("expectedSavepointPath", savepointSettings.getRestorePath());
         assertTrue(savepointSettings.allowNonRestoredState());
     }

--- a/flink-clients/src/test/java/org/apache/flink/client/cli/CliFrontendRunTest.java
+++ b/flink-clients/src/test/java/org/apache/flink/client/cli/CliFrontendRunTest.java
@@ -22,6 +22,7 @@ import org.apache.flink.client.deployment.ClusterClientServiceLoader;
 import org.apache.flink.client.deployment.DefaultClusterClientServiceLoader;
 import org.apache.flink.client.program.PackagedProgram;
 import org.apache.flink.configuration.Configuration;
+import org.apache.flink.runtime.jobgraph.RestoreMode;
 import org.apache.flink.runtime.jobgraph.SavepointRestoreSettings;
 
 import org.apache.commons.cli.CommandLine;
@@ -128,6 +129,46 @@ public class CliFrontendRunTest extends CliFrontendTestBase {
             assertEquals("--arg2", programOptions.getProgramArgs()[3]);
             assertEquals("value2", programOptions.getProgramArgs()[4]);
         }
+    }
+
+    @Test
+    public void testClaimRestoreModeParsing() throws Exception {
+        // test configure savepoint with claim mode
+        String[] parameters = {
+            "-s", "expectedSavepointPath", "-n", "-restoreMode", "claim", getTestJarPath()
+        };
+
+        CommandLine commandLine =
+                CliFrontendParser.parse(CliFrontendParser.RUN_OPTIONS, parameters, true);
+        ProgramOptions programOptions = ProgramOptions.create(commandLine);
+        ExecutionConfigAccessor executionOptions =
+                ExecutionConfigAccessor.fromProgramOptions(programOptions, Collections.emptyList());
+
+        SavepointRestoreSettings savepointSettings = executionOptions.getSavepointRestoreSettings();
+        assertTrue(savepointSettings.restoreSavepoint());
+        assertEquals(RestoreMode.CLAIM, savepointSettings.getRestoreMode());
+        assertEquals("expectedSavepointPath", savepointSettings.getRestorePath());
+        assertTrue(savepointSettings.allowNonRestoredState());
+    }
+
+    @Test
+    public void testLegacyRestoreModeParsing() throws Exception {
+        // test configure savepoint with claim mode
+        String[] parameters = {
+            "-s", "expectedSavepointPath", "-n", "-restoreMode", "legacy", getTestJarPath()
+        };
+
+        CommandLine commandLine =
+                CliFrontendParser.parse(CliFrontendParser.RUN_OPTIONS, parameters, true);
+        ProgramOptions programOptions = ProgramOptions.create(commandLine);
+        ExecutionConfigAccessor executionOptions =
+                ExecutionConfigAccessor.fromProgramOptions(programOptions, Collections.emptyList());
+
+        SavepointRestoreSettings savepointSettings = executionOptions.getSavepointRestoreSettings();
+        assertTrue(savepointSettings.restoreSavepoint());
+        assertEquals(RestoreMode.NO_CLAIM, savepointSettings.getRestoreMode());
+        assertEquals("expectedSavepointPath", savepointSettings.getRestorePath());
+        assertTrue(savepointSettings.allowNonRestoredState());
     }
 
     @Test(expected = CliArgsException.class)

--- a/flink-runtime-web/src/main/java/org/apache/flink/runtime/webmonitor/handlers/JarRunHandler.java
+++ b/flink-runtime-web/src/main/java/org/apache/flink/runtime/webmonitor/handlers/JarRunHandler.java
@@ -26,6 +26,8 @@ import org.apache.flink.client.program.PackagedProgram;
 import org.apache.flink.configuration.Configuration;
 import org.apache.flink.configuration.DeploymentOptions;
 import org.apache.flink.runtime.dispatcher.DispatcherGateway;
+import org.apache.flink.runtime.jobgraph.RestoreMode;
+import org.apache.flink.runtime.jobgraph.SavepointConfigOptions;
 import org.apache.flink.runtime.jobgraph.SavepointRestoreSettings;
 import org.apache.flink.runtime.rest.handler.AbstractRestHandler;
 import org.apache.flink.runtime.rest.handler.HandlerRequest;
@@ -40,6 +42,7 @@ import javax.annotation.Nonnull;
 
 import java.nio.file.Path;
 import java.util.Map;
+import java.util.Optional;
 import java.util.concurrent.CompletableFuture;
 import java.util.concurrent.CompletionException;
 import java.util.concurrent.Executor;
@@ -142,10 +145,14 @@ public class JarRunHandler
                                                 request, SavepointPathQueryParameter.class)),
                         null,
                         log);
+        final RestoreMode restoreMode =
+                Optional.ofNullable(requestBody.getRestoreMode())
+                        .orElseGet(SavepointConfigOptions.RESTORE_MODE::defaultValue);
         final SavepointRestoreSettings savepointRestoreSettings;
         if (savepointPath != null) {
             savepointRestoreSettings =
-                    SavepointRestoreSettings.forPath(savepointPath, allowNonRestoredState);
+                    SavepointRestoreSettings.forPath(
+                            savepointPath, allowNonRestoredState, restoreMode);
         } else {
             savepointRestoreSettings = SavepointRestoreSettings.none();
         }

--- a/flink-runtime-web/src/main/java/org/apache/flink/runtime/webmonitor/handlers/JarRunRequestBody.java
+++ b/flink-runtime-web/src/main/java/org/apache/flink/runtime/webmonitor/handlers/JarRunRequestBody.java
@@ -19,6 +19,7 @@
 package org.apache.flink.runtime.webmonitor.handlers;
 
 import org.apache.flink.api.common.JobID;
+import org.apache.flink.runtime.jobgraph.RestoreMode;
 import org.apache.flink.runtime.rest.messages.RequestBody;
 
 import org.apache.flink.shaded.jackson2.com.fasterxml.jackson.annotation.JsonCreator;
@@ -35,6 +36,7 @@ import java.util.List;
 public class JarRunRequestBody extends JarRequestBody {
     private static final String FIELD_NAME_ALLOW_NON_RESTORED_STATE = "allowNonRestoredState";
     private static final String FIELD_NAME_SAVEPOINT_PATH = "savepointPath";
+    private static final String FIELD_NAME_SAVEPOINT_RESTORE_MODE = "restoreMode";
 
     @JsonProperty(FIELD_NAME_ALLOW_NON_RESTORED_STATE)
     @Nullable
@@ -44,8 +46,12 @@ public class JarRunRequestBody extends JarRequestBody {
     @Nullable
     private String savepointPath;
 
+    @JsonProperty(FIELD_NAME_SAVEPOINT_RESTORE_MODE)
+    @Nullable
+    private RestoreMode restoreMode;
+
     public JarRunRequestBody() {
-        this(null, null, null, null, null, null, null);
+        this(null, null, null, null, null, null, null, null);
     }
 
     @JsonCreator
@@ -58,10 +64,12 @@ public class JarRunRequestBody extends JarRequestBody {
             @Nullable @JsonProperty(FIELD_NAME_JOB_ID) JobID jobId,
             @Nullable @JsonProperty(FIELD_NAME_ALLOW_NON_RESTORED_STATE)
                     Boolean allowNonRestoredState,
-            @Nullable @JsonProperty(FIELD_NAME_SAVEPOINT_PATH) String savepointPath) {
+            @Nullable @JsonProperty(FIELD_NAME_SAVEPOINT_PATH) String savepointPath,
+            @Nullable @JsonProperty(FIELD_NAME_SAVEPOINT_RESTORE_MODE) RestoreMode restoreMode) {
         super(entryClassName, programArguments, programArgumentsList, parallelism, jobId);
         this.allowNonRestoredState = allowNonRestoredState;
         this.savepointPath = savepointPath;
+        this.restoreMode = restoreMode;
     }
 
     @Nullable
@@ -74,5 +82,11 @@ public class JarRunRequestBody extends JarRequestBody {
     @JsonIgnore
     public String getSavepointPath() {
         return savepointPath;
+    }
+
+    @Nullable
+    @JsonIgnore
+    public RestoreMode getRestoreMode() {
+        return restoreMode;
     }
 }

--- a/flink-runtime-web/src/test/java/org/apache/flink/runtime/webmonitor/handlers/JarRunHandlerParameterTest.java
+++ b/flink-runtime-web/src/test/java/org/apache/flink/runtime/webmonitor/handlers/JarRunHandlerParameterTest.java
@@ -28,6 +28,7 @@ import org.apache.flink.configuration.Configuration;
 import org.apache.flink.configuration.DeploymentOptions;
 import org.apache.flink.runtime.dispatcher.DispatcherGateway;
 import org.apache.flink.runtime.jobgraph.JobGraph;
+import org.apache.flink.runtime.jobgraph.RestoreMode;
 import org.apache.flink.runtime.jobgraph.SavepointRestoreSettings;
 import org.apache.flink.runtime.rest.handler.HandlerRequest;
 import org.apache.flink.runtime.rest.handler.RestHandlerException;
@@ -182,12 +183,13 @@ public class JarRunHandlerParameterTest
                 PARALLELISM,
                 null,
                 ALLOW_NON_RESTORED_STATE_QUERY,
-                RESTORE_PATH);
+                RESTORE_PATH,
+                RestoreMode.CLAIM);
     }
 
     @Override
     JarRunRequestBody getJarRequestBodyWithJobId(JobID jobId) {
-        return new JarRunRequestBody(null, null, null, null, jobId, null, null);
+        return new JarRunRequestBody(null, null, null, null, jobId, null, null, null);
     }
 
     @Test

--- a/flink-runtime-web/src/test/java/org/apache/flink/runtime/webmonitor/handlers/JarRunRequestBodyTest.java
+++ b/flink-runtime-web/src/test/java/org/apache/flink/runtime/webmonitor/handlers/JarRunRequestBodyTest.java
@@ -19,6 +19,7 @@
 package org.apache.flink.runtime.webmonitor.handlers;
 
 import org.apache.flink.api.common.JobID;
+import org.apache.flink.runtime.jobgraph.RestoreMode;
 import org.apache.flink.runtime.rest.messages.RestRequestMarshallingTestBase;
 
 import java.util.Arrays;
@@ -36,7 +37,14 @@ public class JarRunRequestBodyTest extends RestRequestMarshallingTestBase<JarRun
     @Override
     protected JarRunRequestBody getTestRequestInstance() {
         return new JarRunRequestBody(
-                "hello", "world", Arrays.asList("boo", "far"), 4, new JobID(), true, "foo/bar");
+                "hello",
+                "world",
+                Arrays.asList("boo", "far"),
+                4,
+                new JobID(),
+                true,
+                "foo/bar",
+                RestoreMode.CLAIM);
     }
 
     @Override
@@ -49,5 +57,6 @@ public class JarRunRequestBodyTest extends RestRequestMarshallingTestBase<JarRun
         assertEquals(expected.getJobId(), actual.getJobId());
         assertEquals(expected.getAllowNonRestoredState(), actual.getAllowNonRestoredState());
         assertEquals(expected.getSavepointPath(), actual.getSavepointPath());
+        assertEquals(expected.getRestoreMode(), actual.getRestoreMode());
     }
 }

--- a/flink-runtime-web/src/test/resources/rest_api_v1.snapshot
+++ b/flink-runtime-web/src/test/resources/rest_api_v1.snapshot
@@ -435,6 +435,10 @@
         },
         "savepointPath" : {
           "type" : "string"
+        },
+        "restoreMode" : {
+          "type" : "string",
+          "enum" : [ "CLAIM", "LEGACY" ]
         }
       }
     },

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/checkpoint/Checkpoints.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/checkpoint/Checkpoints.java
@@ -122,7 +122,8 @@ public class Checkpoints {
             Map<JobVertexID, ExecutionJobVertex> tasks,
             CompletedCheckpointStorageLocation location,
             ClassLoader classLoader,
-            boolean allowNonRestoredState)
+            boolean allowNonRestoredState,
+            CheckpointProperties checkpointProperties)
             throws IOException {
 
         checkNotNull(jobId, "jobId");
@@ -202,9 +203,6 @@ public class Checkpoints {
             }
         }
 
-        // (3) convert to checkpoint so the system can fall back to it
-        CheckpointProperties props = CheckpointProperties.forSavepoint(false);
-
         return new CompletedCheckpoint(
                 jobId,
                 checkpointMetadata.getCheckpointId(),
@@ -212,7 +210,7 @@ public class Checkpoints {
                 0L,
                 operatorStates,
                 checkpointMetadata.getMasterStates(),
-                props,
+                checkpointProperties,
                 location);
     }
 

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/jobgraph/RestoreMode.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/jobgraph/RestoreMode.java
@@ -1,0 +1,50 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.flink.runtime.jobgraph;
+
+import org.apache.flink.annotation.Internal;
+import org.apache.flink.annotation.PublicEvolving;
+import org.apache.flink.configuration.DescribedEnum;
+import org.apache.flink.configuration.description.InlineElement;
+
+import static org.apache.flink.configuration.description.TextElement.text;
+
+/** Defines how Flink should restore from a given savepoint or retained checkpoint. */
+@PublicEvolving
+public enum RestoreMode implements DescribedEnum {
+    CLAIM(
+            "Flink will take ownership of the given snapshot. It will clean the"
+                    + " snapshot once it is subsumed by newer ones."),
+    LEGACY(
+            "Flink will not claim ownership of the snapshot and will not delete the files. However, "
+                    + "it can directly depend on the existence of the files of the restored checkpoint. "
+                    + "It might not be safe to delete checkpoints that were restored in legacy mode ");
+
+    private final String description;
+
+    RestoreMode(String description) {
+        this.description = description;
+    }
+
+    @Override
+    @Internal
+    public InlineElement getDescription() {
+        return text(description);
+    }
+}

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/jobgraph/SavepointConfigOptions.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/jobgraph/SavepointConfigOptions.java
@@ -46,4 +46,14 @@ public class SavepointConfigOptions {
                     .withDescription(
                             "Allow to skip savepoint state that cannot be restored. "
                                     + "Allow this if you removed an operator from your pipeline after the savepoint was triggered.");
+    /**
+     * Describes the mode how Flink should restore from the given savepoint or retained checkpoint.
+     */
+    public static final ConfigOption<RestoreMode> RESTORE_MODE =
+            key("execution.savepoint-restore-mode")
+                    .enumType(RestoreMode.class)
+                    .defaultValue(RestoreMode.LEGACY)
+                    .withDescription(
+                            "Describes the mode how Flink should restore from the given"
+                                    + " savepoint or retained checkpoint.");
 }

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/jobgraph/SavepointRestoreSettings.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/jobgraph/SavepointRestoreSettings.java
@@ -32,10 +32,8 @@ public class SavepointRestoreSettings implements Serializable {
     private static final long serialVersionUID = 87377506900849777L;
 
     /** No restore should happen. */
-    private static final SavepointRestoreSettings NONE = new SavepointRestoreSettings(null, false);
-
-    /** By default, be strict when restoring from a savepoint. */
-    private static final boolean DEFAULT_ALLOW_NON_RESTORED_STATE = false;
+    private static final SavepointRestoreSettings NONE =
+            new SavepointRestoreSettings(null, false, RestoreMode.LEGACY);
 
     /** Savepoint restore path. */
     private final String restorePath;
@@ -46,15 +44,20 @@ public class SavepointRestoreSettings implements Serializable {
      */
     private final boolean allowNonRestoredState;
 
+    private final RestoreMode restoreMode;
+
     /**
      * Creates the restore settings.
      *
      * @param restorePath Savepoint restore path.
      * @param allowNonRestoredState Ignore unmapped state.
+     * @param restoreMode how to restore from the savepoint
      */
-    private SavepointRestoreSettings(String restorePath, boolean allowNonRestoredState) {
+    private SavepointRestoreSettings(
+            String restorePath, boolean allowNonRestoredState, RestoreMode restoreMode) {
         this.restorePath = restorePath;
         this.allowNonRestoredState = allowNonRestoredState;
+        this.restoreMode = restoreMode;
     }
 
     /**
@@ -84,6 +87,11 @@ public class SavepointRestoreSettings implements Serializable {
      */
     public boolean allowNonRestoredState() {
         return allowNonRestoredState;
+    }
+
+    /** Tells how to restore from the given savepoint. */
+    public RestoreMode getRestoreMode() {
+        return restoreMode;
     }
 
     @Override
@@ -129,13 +137,24 @@ public class SavepointRestoreSettings implements Serializable {
     }
 
     public static SavepointRestoreSettings forPath(String savepointPath) {
-        return forPath(savepointPath, DEFAULT_ALLOW_NON_RESTORED_STATE);
+        return forPath(
+                savepointPath,
+                SavepointConfigOptions.SAVEPOINT_IGNORE_UNCLAIMED_STATE.defaultValue());
     }
 
     public static SavepointRestoreSettings forPath(
             String savepointPath, boolean allowNonRestoredState) {
         checkNotNull(savepointPath, "Savepoint restore path.");
-        return new SavepointRestoreSettings(savepointPath, allowNonRestoredState);
+        return new SavepointRestoreSettings(
+                savepointPath,
+                allowNonRestoredState,
+                SavepointConfigOptions.RESTORE_MODE.defaultValue());
+    }
+
+    public static SavepointRestoreSettings forPath(
+            String savepointPath, boolean allowNonRestoredState, RestoreMode restoreMode) {
+        checkNotNull(savepointPath, "Savepoint restore path.");
+        return new SavepointRestoreSettings(savepointPath, allowNonRestoredState, restoreMode);
     }
 
     // -------------------------- Parsing to and from a configuration object
@@ -144,9 +163,11 @@ public class SavepointRestoreSettings implements Serializable {
     public static void toConfiguration(
             final SavepointRestoreSettings savepointRestoreSettings,
             final Configuration configuration) {
-        configuration.setBoolean(
+        configuration.set(
                 SavepointConfigOptions.SAVEPOINT_IGNORE_UNCLAIMED_STATE,
                 savepointRestoreSettings.allowNonRestoredState());
+        configuration.set(
+                SavepointConfigOptions.RESTORE_MODE, savepointRestoreSettings.getRestoreMode());
         final String savepointPath = savepointRestoreSettings.getRestorePath();
         if (savepointPath != null) {
             configuration.setString(SavepointConfigOptions.SAVEPOINT_PATH, savepointPath);
@@ -157,8 +178,9 @@ public class SavepointRestoreSettings implements Serializable {
         final String savepointPath = configuration.get(SavepointConfigOptions.SAVEPOINT_PATH);
         final boolean allowNonRestored =
                 configuration.get(SavepointConfigOptions.SAVEPOINT_IGNORE_UNCLAIMED_STATE);
+        final RestoreMode restoreMode = configuration.get(SavepointConfigOptions.RESTORE_MODE);
         return savepointPath == null
                 ? SavepointRestoreSettings.none()
-                : SavepointRestoreSettings.forPath(savepointPath, allowNonRestored);
+                : SavepointRestoreSettings.forPath(savepointPath, allowNonRestored, restoreMode);
     }
 }

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/scheduler/DefaultExecutionGraphFactory.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/scheduler/DefaultExecutionGraphFactory.java
@@ -173,8 +173,7 @@ public class DefaultExecutionGraphFactory implements ExecutionGraphFactory {
                     executionGraphToRestore.getCheckpointCoordinator();
             if (checkpointCoordinator != null) {
                 checkpointCoordinator.restoreSavepoint(
-                        savepointRestoreSettings.getRestorePath(),
-                        savepointRestoreSettings.allowNonRestoredState(),
+                        savepointRestoreSettings,
                         executionGraphToRestore.getAllVertices(),
                         userCodeClassLoader);
             }

--- a/flink-runtime/src/test/java/org/apache/flink/runtime/checkpoint/CheckpointMetadataLoadingTest.java
+++ b/flink-runtime/src/test/java/org/apache/flink/runtime/checkpoint/CheckpointMetadataLoadingTest.java
@@ -71,7 +71,13 @@ public class CheckpointMetadataLoadingTest {
                 createTasks(operatorId, parallelism, parallelism);
 
         final CompletedCheckpoint loaded =
-                Checkpoints.loadAndValidateCheckpoint(jobId, tasks, testSavepoint, cl, false);
+                Checkpoints.loadAndValidateCheckpoint(
+                        jobId,
+                        tasks,
+                        testSavepoint,
+                        cl,
+                        false,
+                        CheckpointProperties.forSavepoint(false));
 
         assertEquals(jobId, loaded.getJobId());
         assertEquals(checkpointId, loaded.getCheckpointID());
@@ -89,7 +95,13 @@ public class CheckpointMetadataLoadingTest {
                 createTasks(operatorId, parallelism, parallelism + 1);
 
         try {
-            Checkpoints.loadAndValidateCheckpoint(new JobID(), tasks, testSavepoint, cl, false);
+            Checkpoints.loadAndValidateCheckpoint(
+                    new JobID(),
+                    tasks,
+                    testSavepoint,
+                    cl,
+                    false,
+                    CheckpointProperties.forSavepoint(false));
             fail("Did not throw expected Exception");
         } catch (IllegalStateException expected) {
             assertTrue(expected.getMessage().contains("Max parallelism mismatch"));
@@ -109,7 +121,13 @@ public class CheckpointMetadataLoadingTest {
         final Map<JobVertexID, ExecutionJobVertex> tasks = Collections.emptyMap();
 
         try {
-            Checkpoints.loadAndValidateCheckpoint(new JobID(), tasks, testSavepoint, cl, false);
+            Checkpoints.loadAndValidateCheckpoint(
+                    new JobID(),
+                    tasks,
+                    testSavepoint,
+                    cl,
+                    false,
+                    CheckpointProperties.forSavepoint(false));
             fail("Did not throw expected Exception");
         } catch (IllegalStateException expected) {
             assertTrue(expected.getMessage().contains("allowNonRestoredState"));
@@ -129,7 +147,13 @@ public class CheckpointMetadataLoadingTest {
         final Map<JobVertexID, ExecutionJobVertex> tasks = Collections.emptyMap();
 
         final CompletedCheckpoint loaded =
-                Checkpoints.loadAndValidateCheckpoint(new JobID(), tasks, testSavepoint, cl, true);
+                Checkpoints.loadAndValidateCheckpoint(
+                        new JobID(),
+                        tasks,
+                        testSavepoint,
+                        cl,
+                        true,
+                        CheckpointProperties.forSavepoint(false));
 
         assertTrue(loaded.getOperatorStates().isEmpty());
     }
@@ -152,7 +176,13 @@ public class CheckpointMetadataLoadingTest {
         final Map<JobVertexID, ExecutionJobVertex> tasks = Collections.emptyMap();
 
         try {
-            Checkpoints.loadAndValidateCheckpoint(new JobID(), tasks, testSavepoint, cl, false);
+            Checkpoints.loadAndValidateCheckpoint(
+                    new JobID(),
+                    tasks,
+                    testSavepoint,
+                    cl,
+                    false,
+                    CheckpointProperties.forSavepoint(false));
             fail("Did not throw expected Exception");
         } catch (IllegalStateException expected) {
             assertTrue(expected.getMessage().contains("allowNonRestoredState"));

--- a/flink-table/flink-sql-client/src/test/resources/sql/set.q
+++ b/flink-table/flink-sql-client/src/test/resources/sql/set.q
@@ -39,6 +39,7 @@ CREATE TABLE hive_table (
 # list the configured configuration
 set;
 'execution.attached' = 'true'
+'execution.savepoint-restore-mode' = 'LEGACY'
 'execution.savepoint.ignore-unclaimed-state' = 'false'
 'execution.shutdown-on-attached-exit' = 'false'
 'execution.target' = 'remote'
@@ -56,6 +57,7 @@ reset;
 
 set;
 'execution.attached' = 'true'
+'execution.savepoint-restore-mode' = 'LEGACY'
 'execution.savepoint.ignore-unclaimed-state' = 'false'
 'execution.shutdown-on-attached-exit' = 'false'
 'execution.target' = 'remote'
@@ -88,6 +90,7 @@ Was expecting one of:
 
 set;
 'execution.attached' = 'true'
+'execution.savepoint-restore-mode' = 'LEGACY'
 'execution.savepoint.ignore-unclaimed-state' = 'false'
 'execution.shutdown-on-attached-exit' = 'false'
 'execution.target' = 'remote'
@@ -107,6 +110,7 @@ reset 'execution.attached';
 
 set;
 'execution.attached' = 'true'
+'execution.savepoint-restore-mode' = 'LEGACY'
 'execution.savepoint.ignore-unclaimed-state' = 'false'
 'execution.shutdown-on-attached-exit' = 'false'
 'execution.target' = 'remote'
@@ -127,6 +131,7 @@ $VAR_UDF_JAR_PATH
 
 set;
 'execution.attached' = 'true'
+'execution.savepoint-restore-mode' = 'LEGACY'
 'execution.savepoint.ignore-unclaimed-state' = 'false'
 'execution.shutdown-on-attached-exit' = 'false'
 'execution.target' = 'remote'


### PR DESCRIPTION

## What is the purpose of the change

This PR adds a `RestoreMode` flag to be passed along with savepoint path. It determines the way a snapshot should be restored from. If a `CLAIM` mode is specified Flink will take ownership of the initial snapshot and will treat it as if it was created as a regular checkpoint and it might delete it at a certain point in time.

## Verifying this change

* Added tests for passing the flag in CLI
* Added tests for passing the flag in REST API
* Added tests in SavepointITCase for the `CLAIM` behaviour

## Does this pull request potentially affect one of the following parts:

  - Dependencies (does it add or upgrade a dependency): (yes / **no**)
  - The public API, i.e., is any changed class annotated with `@Public(Evolving)`: (**yes** / no)
  - The serializers: (yes / **no** / don't know)
  - The runtime per-record code paths (performance sensitive): (yes / **no** / don't know)
  - Anything that affects deployment or recovery: JobManager (and its components), Checkpointing, Kubernetes/Yarn, ZooKeeper: (**yes** / no / don't know)
  - The S3 file system connector: (yes / **no** / don't know)

## Documentation

  - Does this pull request introduce a new feature? (**yes** / no)
  - If yes, how is the feature documented? (not applicable / docs / JavaDocs / not documented): the option is documented in javadocs and generated documentation. The entire snapshots ownership requires a separate page/entry.
