### PR TITLE
[FLINK-23493][python] Remove the calling of child process in the beam_boot.py

### DIFF
--- a/flink-python/pyflink/fn_execution/beam/beam_boot.py
+++ b/flink-python/pyflink/fn_execution/beam/beam_boot.py
@@ -29,7 +29,6 @@ harness of Apache Beam.
 """
 import argparse
 import os
-from subprocess import call
 
 import grpc
 import logging
@@ -114,5 +113,6 @@ if __name__ == "__main__":
             logging.info("Shut down Python harness due to FLINK_BOOT_TESTING is set.")
             exit(0)
 
-        call([python_exec, "-m", "pyflink.fn_execution.beam.beam_sdk_worker_main"],
-             stdout=sys.stdout, stderr=sys.stderr, env=env)
+        from pyflink.fn_execution.beam import beam_sdk_worker_main
+
+        beam_sdk_worker_main.main()

--- a/flink-python/pyflink/fn_execution/beam/beam_sdk_worker_main.py
+++ b/flink-python/pyflink/fn_execution/beam/beam_sdk_worker_main.py
@@ -54,7 +54,7 @@ class CustomPrint(object):
             self._msg_buffer.clear()
 
 
-if __name__ == '__main__':
+def main():
     import builtins
     import logging
     from functools import partial
@@ -67,5 +67,7 @@ if __name__ == '__main__':
 
     custom_print = CustomPrint(print)
     builtins.print = custom_print.print
+    # Remove all the built-in log handles
+    logging.getLogger().handlers = []
     apache_beam.runners.worker.sdk_worker_main.main(sys.argv)
     custom_print.close()


### PR DESCRIPTION
## What is the purpose of the change

*This pull request will remove the calling of child process in the beam_boot.py*


## Brief change log

  - *Remove the calling of child process in the beam_boot.py*

## Verifying this change

This change added tests and can be verified as follows:

-*Original tests*

## Does this pull request potentially affect one of the following parts:

  - Dependencies (does it add or upgrade a dependency): (no)
  - The public API, i.e., is any changed class annotated with `@Public(Evolving)`: (no)
  - The serializers: (no)
  - The runtime per-record code paths (performance sensitive): (no)
  - Anything that affects deployment or recovery: JobManager (and its components), Checkpointing, Kubernetes/Yarn, ZooKeeper: (no)
  - The S3 file system connector: (no)

## Documentation

  - Does this pull request introduce a new feature? (no)
  - If yes, how is the feature documented? (not applicable)
