### PR TITLE
[FLINK-20188][Connectors/FileSystem,Documentation] Add Documentation …

### DIFF
--- a/docs/content/docs/connectors/datastream/filesystem.md
+++ b/docs/content/docs/connectors/datastream/filesystem.md
@@ -477,7 +477,7 @@ String schema = ...;
 Configuration conf = ...;
 Properties writerProperties = new Properties();
 
-writerProps.setProperty("orc.compress", "LZ4");
+writerProperties.setProperty("orc.compress", "LZ4");
 // Other ORC supported properties can also be set similarly.
 
 final OrcBulkWriterFactory<Person> writerFactory = new OrcBulkWriterFactory<>(
@@ -491,7 +491,7 @@ val schema: String = ...
 val conf: Configuration = ...
 val writerProperties: Properties = new Properties()
 
-writerProps.setProperty("orc.compress", "LZ4")
+writerProperties.setProperty("orc.compress", "LZ4")
 // Other ORC supported properties can also be set similarly.
 
 val writerFactory = new OrcBulkWriterFactory(

--- a/docs/content/docs/connectors/datastream/filesystem.md
+++ b/docs/content/docs/connectors/datastream/filesystem.md
@@ -1045,7 +1045,7 @@ Internally in the file source, the readers pass batches of records from the read
 (that perform the typically blocking I/O operations) to the async mailbox threads that do the
 streaming and batch data processing. Passing records in batches (rather than one-at-a-time) much
 reduce the thread-to-thread handover overhead.
-For the {@code BulkFormat}, one batch (as returned by `BulkFormat.Reader#readBatch()`)
+For the `BulkFormat`, one batch (as returned by `BulkFormat.Reader#readBatch()`)
 is handed over as one.
 
 ## Stream format And Batch Format Interchange

--- a/docs/content/docs/connectors/datastream/filesystem.md
+++ b/docs/content/docs/connectors/datastream/filesystem.md
@@ -477,7 +477,7 @@ String schema = ...;
 Configuration conf = ...;
 Properties writerProperties = new Properties();
 
-writerProperties.setProperty("orc.compress", "LZ4");
+writerProps.setProperty("orc.compress", "LZ4");
 // Other ORC supported properties can also be set similarly.
 
 final OrcBulkWriterFactory<Person> writerFactory = new OrcBulkWriterFactory<>(
@@ -491,7 +491,7 @@ val schema: String = ...
 val conf: Configuration = ...
 val writerProperties: Properties = new Properties()
 
-writerProperties.setProperty("orc.compress", "LZ4")
+writerProps.setProperty("orc.compress", "LZ4")
 // Other ORC supported properties can also be set similarly.
 
 val writerFactory = new OrcBulkWriterFactory(
@@ -797,3 +797,208 @@ before the job is restarted. This will result in your job not being able to rest
 pending part-files are no longer there and Flink will fail with an exception as it tries to fetch them and fails.
 
 {{< top >}}
+
+# File Source
+
+This section describes the implementation of `File Source` based on the new `Source API`, a unified data source that can handle data reading files in batch mode or stream mode.
+The source supports all (distributed) file systems and object stores.
+A File Source is started by one of the following calls.
+
+```java
+// Stream mode
+FileSource.forRecordStreamFormat(StreamFormat,Path...)
+// Batch mode
+FileSource.forBulkFileFormat(BulkFormat,Path...)
+```
+
+This can be done by creating a `FileSourceBuilder` on which all relevant all properties can be configured:
+
+```java
+FileSource.FileSourceBuilder
+```
+
+The source supports bounded/batch and continuous/streaming data input. For the bounded/batch case, the file source processes all files under a given path. In the continuous/flow case, the file source periodically checks for new files in the path and starts reading them.
+When you start creating a file source, created via `FileSource.FileSourceBuilder`, the file source defaults to bounded/batch mode.
+Call `FileSource.FileSourceBuilder.monitorContinuously(Duration)` to put the source into continuous stream mode:
+```java
+// Create a new file source that will read files from a given set of directories.
+// Each file will be processed as plain text and split based on newlines.
+FileSource.FileSourceBuilder<String> builder=FileSource.forRecordStreamFormat(new TextLineFormat(),params.getInputs().get());
+
+// If a discovery interval is provided, the source will.
+// continuously watch the given directories for new files.
+params.getDiscoveryInterval().ifPresent(builder::monitorContinuously);
+env.fromSource(builder.build(),WatermarkStrategy.noWatermarks(),"file-input");
+```
+
+## Format Type
+
+StreamFormat reads the contents of a file from a file stream. It is the simplest
+format to implement, and provides many features out-of-the-box (like checkpointing logic)
+but is limited in the optimizations it can apply (such as object reuse, batching, etc.).
+
+BulkFormat reads batches of records from a file at a time. It is the most "low
+level" format to implement, but offers the greatest flexibility to optimize the
+implementation.
+
+
+### StreamFormat
+
+Reads the contents of a file from a file stream.
+The following are some examples of use:
+
+#### TextLine format
+
+```java
+final FileSource<String> source=
+        FileSource.forRecordStreamFormat(new TextLineFormat(),Path.fromLocalFile(testDir))
+        .monitorContinuously(Duration.ofMillis(5))
+        .build();
+final StreamExecutionEnvironment env=StreamExecutionEnvironment.getExecutionEnvironment();
+
+final DataStream<String> stream=
+        env.fromSource(source,WatermarkStrategy.noWatermarks(),"file-source");
+```
+#### SimpleStreamFormat Abstract Class
+
+A simple version of `StreamFormat` for indivisible formats.
+Custom reads of Array or File can be done by implementing `SimpleStreamFormat`:
+
+##### ArrayReader Format
+
+```java
+private static final class ArrayReaderFormat extends SimpleStreamFormat<byte[]> {
+    private static final long serialVersionUID = 1L;
+
+    @Override
+    public Reader<byte[]> createReader(Configuration config, FSDataInputStream stream)
+            throws IOException {
+        return new ArrayReader(stream);
+    }
+
+    @Override
+    public TypeInformation<byte[]> getProducedType() {
+        return PrimitiveArrayTypeInfo.BYTE_PRIMITIVE_ARRAY_TYPE_INFO;
+    }
+}
+
+final FileSource<byte[]> source =
+                FileSource.forRecordStreamFormat(new ArrayReaderFormat(), path).build();
+```
+
+##### File Format
+
+```java
+private static class FileFormat extends SimpleStreamFormat<RowData> {
+
+    @Override
+    public Reader<RowData> createReader(Configuration config, FSDataInputStream stream) {
+        BufferedReader reader =
+                new BufferedReader(new InputStreamReader(stream, StandardCharsets.UTF_8));
+        return new Reader<RowData>() {
+            @Override
+            public RowData read() throws IOException {
+                String line = reader.readLine();
+                if (line == null) {
+                    return null;
+                }
+                return GenericRowData.of(StringData.fromString(line));
+            }
+
+            @Override
+            public void close() throws IOException {
+                reader.close();
+            }
+        };
+    }
+    
+FileSource<RowData> fileSource =
+                    FileSource.forRecordStreamFormat(new FileFormat(), path).build();
+```
+
+### BulkFormat
+
+Read batches of records from one file at a time.
+
+#### Parquet Format
+
+To use the Parquet batch encoder in your application, you need to add the following dependencies:
+
+{{< artifact flink-parquet withScalaVersion >}}
+
+This example uses a FileSource that will read the Parquet format:
+
+```java
+
+
+```
+
+#### Orc Format
+
+To use the Orc batch encoder in your application, you need to add the following dependencies.
+
+{{< artifact flink-orc withScalaVersion >}}
+
+This example uses a FileSource that will read the orc format:
+
+```java
+protected OrcColumnarRowFileInputFormat<?, FileSourceSplit> createPartitionFormat(
+        RowType tableType, List<String> partitionKeys, int[] selectedFields) {
+        return OrcColumnarRowFileInputFormat.createPartitionedFormat(
+        OrcShim.defaultShim(),
+        new Configuration(),
+        tableType,
+        partitionKeys,
+        PartitionFieldExtractor.forFileSystem(""),
+        selectedFields,
+        new ArrayList<>(),
+        BATCH_SIZE);
+        }
+
+
+RowType tableType =
+                RowType.of(
+                        /* 0 */ DataTypes.INT().getLogicalType(),
+                        /* 1 */ DataTypes.INT().getLogicalType(), // part-1
+                        /* 2 */ DataTypes.STRING().getLogicalType(),
+                        /* 3 */ DataTypes.BIGINT().getLogicalType(), // part-2
+                        /* 4 */ DataTypes.STRING().getLogicalType(),
+                        /* 5 */ DataTypes.STRING().getLogicalType(), // part-3
+                        /* 6 */ DataTypes.STRING().getLogicalType(),
+                        /* 7 */ DataTypes.INT().getLogicalType(),
+                        /* 8 */ DataTypes.DECIMAL(10, 5).getLogicalType(), // part-4
+                        /* 9 */ DataTypes.STRING().getLogicalType(),
+                        /* 11*/ DataTypes.INT().getLogicalType(),
+                        /* 12*/ DataTypes.INT().getLogicalType(),
+                        /* 13*/ DataTypes.STRING().getLogicalType(), // part-5
+                        /* 14*/ DataTypes.INT().getLogicalType());
+
+int[] projectedFields = {8, 1, 3, 0, 5, 2};
+
+OrcColumnarRowFileInputFormat<?, FileSourceSplit> format =createPartitionFormat(tableType, new ArrayList<>(partSpec.keySet()), projectedFields);
+
+final FileSource<String> source=
+        FileSource.forRecordStreamFormat(format,Path.fromLocalFile(testDir))
+        .monitorContinuously(Duration.ofMillis(5))
+        .build();
+final StreamExecutionEnvironment env=StreamExecutionEnvironment.getExecutionEnvironment();
+
+final DataStream<String> stream=
+        env.fromSource(source,WatermarkStrategy.noWatermarks(),"file-source");
+```
+
+## Stream format And Batch Format Interchange
+
+
+## Customizing File Enumeration
+
+Implement custom SplitEnumerator and Splits.
+
+## Error Tolerance
+
+## Current Limitations
+Watermarking doesn't work particularly well for large backlogs of files, because watermarks eagerly advance within a file, and the next file might contain data later than the watermark again. 
+We are looking at ways to generate the watermarks more based on global information.
+
+For Unbounded File Sources, the enumerator currently remembers paths of all already processed files, which is a state that can in come cases grow rather large. 
+We plan to add a compressed form of tracking already processed files in the future (for example by keeping modification timestamps lower boundaries).

--- a/docs/content/docs/connectors/datastream/filesystem.md
+++ b/docs/content/docs/connectors/datastream/filesystem.md
@@ -1090,5 +1090,5 @@ public class HiveSourceFileEnumerator implements FileEnumerator {
 Watermarking doesn't work particularly well for large backlogs of files, because watermarks eagerly advance within a file, and the next file might contain data later than the watermark again. 
 We are looking at ways to generate the watermarks more based on global information.
 
-For Unbounded File Sources, the enumerator currently remembers paths of all already processed files, which is a state that can in come cases grow rather large. 
-We plan to add a compressed form of tracking already processed files in the future (for example by keeping modification timestamps lower boundaries).
+For Unbounded File Sources, the enumerator currently remembers paths of all already processed files, which is a state that can in come cases grow rather large.
+The future will be planned to add a compressed form of tracking already processed files in the future (for example by keeping modification timestamps lower boundaries).


### PR DESCRIPTION
…for new File Source

<!--
*Thank you very much for contributing to Apache Flink - we are happy that you want to help us improve Flink. To help the community review your contribution in the best possible way, please go through the checklist below, which will get the contribution into a shape in which it can be best reviewed.*

*Please understand that we do not do this to make contributions to Flink a hassle. In order to uphold a high standard of quality for code contributions, while at the same time managing a large number of contributions, we need contributors to prepare the contributions well, and give reviewers enough contextual information for the review. Please also understand that contributions that do not follow this guide will take longer to review and thus typically be picked up with lower priority by the community.*

## Contribution Checklist

  - Make sure that the pull request corresponds to a [JIRA issue](https://issues.apache.org/jira/projects/FLINK/issues). Exceptions are made for typos in JavaDoc or documentation files, which need no JIRA issue.
  
  - Name the pull request in the form "[FLINK-XXXX] [component] Title of the pull request", where *FLINK-XXXX* should be replaced by the actual issue number. Skip *component* if you are unsure about which is the best component.
  Typo fixes that have no associated JIRA issue should be named following this pattern: `[hotfix] [docs] Fix typo in event time introduction` or `[hotfix] [javadocs] Expand JavaDoc for PuncuatedWatermarkGenerator`.

  - Fill out the template below to describe the changes contributed by the pull request. That will give reviewers the context they need to do the review.
  
  - Make sure that the change passes the automated tests, i.e., `mvn clean verify` passes. You can set up Azure Pipelines CI to do that following [this guide](https://cwiki.apache.org/confluence/display/FLINK/Azure+Pipelines#AzurePipelines-Tutorial:SettingupAzurePipelinesforaforkoftheFlinkrepository).

  - Each pull request should address only one issue, not mix up code from multiple issues.
  
  - Each commit in the pull request has a meaningful commit message (including the JIRA id)

  - Once all items of the checklist are addressed, remove the above text and this checklist, leaving only the filled out template below.


**(The sections below can be removed for hotfixes of typos)**
-->

## What is the purpose of the change

*(For example: This pull request makes task deployment go through the blob server, rather than through RPC. That way we avoid re-transferring them on each deployment (during recovery).)*


## Brief change log

*(for example:)*
  - *The TaskInfo is stored in the blob store on job creation time as a persistent artifact*
  - *Deployments RPC transmits only the blob storage reference*
  - *TaskManagers retrieve the TaskInfo from the blob cache*


## Verifying this change

Please make sure both new and modified tests in this PR follows the conventions defined in our code quality guide: https://flink.apache.org/contributing/code-style-and-quality-common.html#testing

*(Please pick either of the following options)*

This change is a trivial rework / code cleanup without any test coverage.

*(or)*

This change is already covered by existing tests, such as *(please describe tests)*.

*(or)*

This change added tests and can be verified as follows:

*(example:)*
  - *Added integration tests for end-to-end deployment with large payloads (100MB)*
  - *Extended integration test for recovery after master (JobManager) failure*
  - *Added test that validates that TaskInfo is transferred only once across recoveries*
  - *Manually verified the change by running a 4 node cluser with 2 JobManagers and 4 TaskManagers, a stateful streaming program, and killing one JobManager and two TaskManagers during the execution, verifying that recovery happens correctly.*

## Does this pull request potentially affect one of the following parts:

  - Dependencies (does it add or upgrade a dependency): (yes / no)
  - The public API, i.e., is any changed class annotated with `@Public(Evolving)`: (yes / no)
  - The serializers: (yes / no / don't know)
  - The runtime per-record code paths (performance sensitive): (yes / no / don't know)
  - Anything that affects deployment or recovery: JobManager (and its components), Checkpointing, Kubernetes/Yarn, ZooKeeper: (yes / no / don't know)
  - The S3 file system connector: (yes / no / don't know)

## Documentation

  - Does this pull request introduce a new feature? (yes / no)
  - If yes, how is the feature documented? (not applicable / docs / JavaDocs / not documented)
