### PR TITLE
[FLINK-25052][table-planner] Port Row to row casting to cast rule

### DIFF
--- a/flink-table/flink-table-common/src/test/java/org/apache/flink/table/test/TableAssertions.java
+++ b/flink-table/flink-table-common/src/test/java/org/apache/flink/table/test/TableAssertions.java
@@ -28,7 +28,7 @@ public class TableAssertions {
 
     private TableAssertions() {}
 
-    // --- Internal data types
+    // --- Internal data structures
 
     public static RowDataAssert assertThat(RowData actual) {
         return new RowDataAssert(actual);

--- a/flink-table/flink-table-common/src/test/java/org/apache/flink/table/test/TableAssertions.java
+++ b/flink-table/flink-table-common/src/test/java/org/apache/flink/table/test/TableAssertions.java
@@ -28,6 +28,8 @@ public class TableAssertions {
 
     private TableAssertions() {}
 
+    // --- Internal data types
+
     public static RowDataAssert assertThat(RowData actual) {
         return new RowDataAssert(actual);
     }
@@ -35,6 +37,8 @@ public class TableAssertions {
     public static StringDataAssert assertThat(StringData actual) {
         return new StringDataAssert(actual);
     }
+
+    // --- Types
 
     public static DataTypeAssert assertThat(DataType actual) {
         return new DataTypeAssert(actual);

--- a/flink-table/flink-table-planner/src/main/java/org/apache/flink/table/planner/functions/casting/AbstractCodeGeneratorCastRule.java
+++ b/flink-table/flink-table-planner/src/main/java/org/apache/flink/table/planner/functions/casting/AbstractCodeGeneratorCastRule.java
@@ -76,13 +76,14 @@ abstract class AbstractCodeGeneratorCastRule<IN, OUT> extends AbstractCastRule<I
         // Class fields can contain type serializers
         final String classFieldDecls =
                 Stream.concat(
-                                ctx.getDeclaredTypeSerializers().stream()
+                                ctx.typeSerializers.values().stream()
                                         .map(
-                                                name ->
+                                                entry ->
                                                         "private final "
-                                                                + className(TypeSerializer.class)
+                                                                + className(
+                                                                        entry.getValue().getClass())
                                                                 + " "
-                                                                + name
+                                                                + entry.getKey()
                                                                 + ";"),
                                 ctx.getClassFields().stream())
                         .collect(Collectors.joining("\n"));
@@ -91,8 +92,12 @@ abstract class AbstractCodeGeneratorCastRule<IN, OUT> extends AbstractCastRule<I
                 "public "
                         + castExecutorClassName
                         + "("
-                        + ctx.getDeclaredTypeSerializers().stream()
-                                .map(name -> className(TypeSerializer.class) + " " + name)
+                        + ctx.typeSerializers.values().stream()
+                                .map(
+                                        entry ->
+                                                className(entry.getValue().getClass())
+                                                        + " "
+                                                        + entry.getKey())
                                 .collect(Collectors.joining(", "))
                         + ")";
         final String constructorBody =
@@ -144,7 +149,7 @@ abstract class AbstractCodeGeneratorCastRule<IN, OUT> extends AbstractCastRule<I
                         + constructorBody
                         + "}\n"
                         + functionSignature
-                        + "{\n"
+                        + " {\n"
                         + bodyWriter
                         + "}\n}";
 

--- a/flink-table/flink-table-planner/src/main/java/org/apache/flink/table/planner/functions/casting/CastRuleProvider.java
+++ b/flink-table/flink-table-planner/src/main/java/org/apache/flink/table/planner/functions/casting/CastRuleProvider.java
@@ -75,6 +75,7 @@ public class CastRuleProvider {
                 .addRule(StringToBinaryCastRule.INSTANCE)
                 // Collection rules
                 .addRule(ArrayToArrayCastRule.INSTANCE)
+                .addRule(RowToRowCastRule.INSTANCE)
                 // Special rules
                 .addRule(IdentityCastRule.INSTANCE);
     }

--- a/flink-table/flink-table-planner/src/main/java/org/apache/flink/table/planner/functions/casting/CastRuleUtils.java
+++ b/flink-table/flink-table-planner/src/main/java/org/apache/flink/table/planner/functions/casting/CastRuleUtils.java
@@ -144,6 +144,25 @@ final class CastRuleUtils {
         return term;
     }
 
+    static String binaryWriterWriteField(
+            CodeGeneratorCastRule.Context context,
+            String writerTerm,
+            LogicalType logicalType,
+            String indexTerm,
+            String fieldValTerm) {
+        return CodeGenUtils.binaryWriterWriteField(
+                context::declareTypeSerializer,
+                String.valueOf(indexTerm),
+                fieldValTerm,
+                writerTerm,
+                logicalType);
+    }
+
+    static String binaryWriterWriteNull(
+            String writerTerm, LogicalType logicalType, String indexTerm) {
+        return CodeGenUtils.binaryWriterWriteNull(indexTerm, writerTerm, logicalType);
+    }
+
     static final class CodeWriter {
         StringBuilder builder = new StringBuilder();
 

--- a/flink-table/flink-table-planner/src/main/java/org/apache/flink/table/planner/functions/casting/RowToRowCastRule.java
+++ b/flink-table/flink-table-planner/src/main/java/org/apache/flink/table/planner/functions/casting/RowToRowCastRule.java
@@ -1,0 +1,232 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.flink.table.planner.functions.casting;
+
+import org.apache.flink.table.data.ArrayData;
+import org.apache.flink.table.data.binary.BinaryRowData;
+import org.apache.flink.table.data.writer.BinaryRowWriter;
+import org.apache.flink.table.types.logical.LogicalType;
+import org.apache.flink.table.types.logical.LogicalTypeRoot;
+import org.apache.flink.table.types.logical.RowType;
+
+import java.util.List;
+import java.util.stream.Collectors;
+import java.util.stream.IntStream;
+
+import static org.apache.flink.table.planner.codegen.CodeGenUtils.className;
+import static org.apache.flink.table.planner.codegen.CodeGenUtils.newName;
+import static org.apache.flink.table.planner.codegen.CodeGenUtils.rowFieldReadAccess;
+import static org.apache.flink.table.planner.functions.casting.CastRuleUtils.binaryWriterWriteField;
+import static org.apache.flink.table.planner.functions.casting.CastRuleUtils.binaryWriterWriteNull;
+import static org.apache.flink.table.planner.functions.casting.CastRuleUtils.constructorCall;
+import static org.apache.flink.table.planner.functions.casting.CastRuleUtils.methodCall;
+
+/** {@link LogicalTypeRoot#ROW} to {@link LogicalTypeRoot#ROW} cast rule. */
+class RowToRowCastRule extends AbstractNullAwareCodeGeneratorCastRule<ArrayData, String> {
+
+    static final RowToRowCastRule INSTANCE = new RowToRowCastRule();
+
+    private RowToRowCastRule() {
+        super(CastRulePredicate.builder().predicate(RowToRowCastRule::matches).build());
+    }
+
+    private static boolean matches(LogicalType input, LogicalType target) {
+        if (!(input.is(LogicalTypeRoot.ROW) && target.is(LogicalTypeRoot.ROW))) {
+            return false;
+        }
+
+        final List<LogicalType> inputFields = extractFields(input);
+        final List<LogicalType> targetFields = extractFields(target);
+
+        if (inputFields.size() < targetFields.size()) {
+            return false;
+        }
+
+        return IntStream.range(0, targetFields.size())
+                .allMatch(i -> CastRuleProvider.exists(inputFields.get(i), targetFields.get(i)));
+    }
+
+    /* Example generated code for ROW<`f0` BIGINT, `f1` BIGINT, `f2` STRING, `f3` ARRAY<STRING>>:
+
+    isNull$29 = false;
+    if (!isNull$29) {
+        writer$32.reset();
+        boolean f0IsNull$34 = row$26.isNullAt(0);
+        if (!f0IsNull$34) {
+            int f0Value$33 = row$26.getInt(0);
+            result$35 = ((long) (f0Value$33));
+            if (!false) {
+                writer$32.writeLong(0, result$35);
+            } else {
+                writer$32.setNullAt(0);
+            }
+        } else {
+            writer$32.setNullAt(0);
+        }
+        boolean f1IsNull$37 = row$26.isNullAt(1);
+        if (!f1IsNull$37) {
+            int f1Value$36 = row$26.getInt(1);
+            result$38 = ((long) (f1Value$36));
+            if (!false) {
+                writer$32.writeLong(1, result$38);
+            } else {
+                writer$32.setNullAt(1);
+            }
+        } else {
+            writer$32.setNullAt(1);
+        }
+        boolean f2IsNull$40 = row$26.isNullAt(2);
+        if (!f2IsNull$40) {
+            int f2Value$39 = row$26.getInt(2);
+            isNull$41 = f2IsNull$40;
+            if (!isNull$41) {
+                result$42 =
+                        org.apache.flink.table.data.binary.BinaryStringData.fromString(
+                                org.apache.flink.table.utils.DateTimeUtils
+                                        .formatTimestampMillis(f2Value$39, 0));
+                isNull$41 = result$42 == null;
+            } else {
+                result$42 = org.apache.flink.table.data.binary.BinaryStringData.EMPTY_UTF8;
+            }
+            if (!isNull$41) {
+                writer$32.writeString(2, result$42);
+            } else {
+                writer$32.setNullAt(2);
+            }
+        } else {
+            writer$32.setNullAt(2);
+        }
+        boolean f3IsNull$44 = row$26.isNullAt(3);
+        if (!f3IsNull$44) {
+            org.apache.flink.table.data.ArrayData f3Value$43 = row$26.getArray(3);
+            isNull$45 = f3IsNull$44;
+            if (!isNull$45) {
+                Object[] objArray$47 = new Object[f3Value$43.size()];
+                for (int i$48 = 0; i$48 < f3Value$43.size(); i$48++) {
+                    if (!f3Value$43.isNullAt(i$48)) {
+                        objArray$47[i$48] =
+                                ((org.apache.flink.table.data.binary.BinaryStringData)
+                                        f3Value$43.getString(i$48));
+                    }
+                }
+                result$46 = new org.apache.flink.table.data.GenericArrayData(objArray$47);
+                isNull$45 = result$46 == null;
+            } else {
+                result$46 = null;
+            }
+            if (!isNull$45) {
+                writer$32.writeArray(3, result$46, typeSerializer$49);
+            } else {
+                writer$32.setNullAt(3);
+            }
+        } else {
+            writer$32.setNullAt(3);
+        }
+        writer$32.complete();
+        result$30 = row$31;
+        isNull$29 = result$30 == null;
+    } else {
+        result$30 = null;
+    }
+
+     */
+    @Override
+    protected String generateCodeBlockInternal(
+            CodeGeneratorCastRule.Context context,
+            String inputTerm,
+            String returnVariable,
+            LogicalType inputLogicalType,
+            LogicalType targetLogicalType) {
+        final List<LogicalType> inputFields = extractFields(inputLogicalType);
+        final List<LogicalType> targetFields = extractFields(targetLogicalType);
+
+        // Declare the row and row data
+        final String rowTerm = newName("row");
+        final String writerTerm = newName("writer");
+        context.declareClassField(
+                className(BinaryRowData.class),
+                rowTerm,
+                constructorCall(BinaryRowData.class, inputFields.size()));
+        context.declareClassField(
+                className(BinaryRowWriter.class),
+                writerTerm,
+                constructorCall(BinaryRowWriter.class, rowTerm));
+
+        final CastRuleUtils.CodeWriter writer =
+                new CastRuleUtils.CodeWriter().stmt(methodCall(writerTerm, "reset"));
+
+        for (int i = 0; i < targetFields.size(); i++) {
+            final LogicalType inputFieldType = inputFields.get(i);
+            final LogicalType targetFieldType = targetFields.get(i);
+            final String indexTerm = String.valueOf(i);
+
+            final String fieldTerm = newName("f" + indexTerm + "Value");
+            final String fieldIsNullTerm = newName("f" + indexTerm + "IsNull");
+
+            final CastCodeBlock codeBlock =
+                    CastRuleProvider.generateCodeBlock(
+                            context,
+                            fieldTerm,
+                            fieldIsNullTerm,
+                            // Null check is done at the row access level
+                            inputFieldType.copy(false),
+                            targetFieldType);
+
+            final String readField = rowFieldReadAccess(indexTerm, inputTerm, inputFieldType);
+            final String writeField =
+                    binaryWriterWriteField(
+                            context,
+                            writerTerm,
+                            targetFieldType,
+                            indexTerm,
+                            codeBlock.getReturnTerm());
+            final String writeNull = binaryWriterWriteNull(writerTerm, targetFieldType, indexTerm);
+
+            writer.declStmt(
+                            boolean.class,
+                            fieldIsNullTerm,
+                            methodCall(inputTerm, "isNullAt", indexTerm))
+                    .ifStmt(
+                            "!" + fieldIsNullTerm,
+                            thenBodyWriter ->
+                                    thenBodyWriter
+                                            // If element not null, extract it and
+                                            // execute the cast and then write it with the writer
+                                            .declPrimitiveStmt(inputFieldType, fieldTerm, readField)
+                                            .append(codeBlock)
+                                            .ifStmt(
+                                                    "!" + codeBlock.getIsNullTerm(),
+                                                    thenCastResultWriter ->
+                                                            thenCastResultWriter.stmt(writeField),
+                                                    elseCastResultWriter ->
+                                                            elseCastResultWriter.stmt(writeNull)),
+                            elseBodyWriter ->
+                                    // If element is null, just write NULL
+                                    elseBodyWriter.stmt(writeNull));
+        }
+
+        writer.stmt(methodCall(writerTerm, "complete")).assignStmt(returnVariable, rowTerm);
+        return writer.toString();
+    }
+
+    private static List<LogicalType> extractFields(LogicalType type) {
+        return ((RowType) type)
+                .getFields().stream().map(RowType.RowField::getType).collect(Collectors.toList());
+    }
+}

--- a/flink-table/flink-table-planner/src/main/java/org/apache/flink/table/planner/functions/casting/RowToRowCastRule.java
+++ b/flink-table/flink-table-planner/src/main/java/org/apache/flink/table/planner/functions/casting/RowToRowCastRule.java
@@ -18,7 +18,7 @@
 
 package org.apache.flink.table.planner.functions.casting;
 
-import org.apache.flink.table.data.ArrayData;
+import org.apache.flink.table.data.RowData;
 import org.apache.flink.table.data.binary.BinaryRowData;
 import org.apache.flink.table.data.writer.BinaryRowWriter;
 import org.apache.flink.table.types.logical.LogicalType;
@@ -40,7 +40,7 @@ import static org.apache.flink.table.planner.functions.casting.CastRuleUtils.met
  * {@link LogicalTypeRoot#ROW} and {@link LogicalTypeRoot#STRUCTURED_TYPE} to {@link
  * LogicalTypeRoot#ROW} and {@link LogicalTypeRoot#STRUCTURED_TYPE} cast rule.
  */
-class RowToRowCastRule extends AbstractNullAwareCodeGeneratorCastRule<ArrayData, String> {
+class RowToRowCastRule extends AbstractNullAwareCodeGeneratorCastRule<RowData, RowData> {
 
     static final RowToRowCastRule INSTANCE = new RowToRowCastRule();
 

--- a/flink-table/flink-table-planner/src/main/scala/org/apache/flink/table/planner/codegen/calls/ScalarOperatorGens.scala
+++ b/flink-table/flink-table-planner/src/main/scala/org/apache/flink/table/planner/codegen/calls/ScalarOperatorGens.scala
@@ -37,7 +37,6 @@ import org.apache.flink.table.runtime.typeutils.TypeCheckUtils._
 import org.apache.flink.table.types.logical.LogicalTypeFamily.DATETIME
 import org.apache.flink.table.types.logical.LogicalTypeRoot._
 import org.apache.flink.table.types.logical._
-import org.apache.flink.table.types.logical.utils.LogicalTypeCasts.supportsExplicitCast
 import org.apache.flink.table.types.logical.utils.LogicalTypeChecks.getFieldTypes
 import org.apache.flink.table.types.logical.utils.LogicalTypeMerging.findCommonType
 import org.apache.flink.table.utils.DateTimeUtils
@@ -46,7 +45,6 @@ import org.apache.flink.util.Preconditions.checkArgument
 
 import java.time.ZoneId
 import java.util.Arrays.asList
-
 import scala.collection.JavaConversions._
 
 /**
@@ -1249,10 +1247,6 @@ object ScalarOperatorGens {
            | (INTERVAL_YEAR_MONTH, BIGINT) =>
         internalExprCasting(operand, targetType)
 
-      case (ROW | STRUCTURED_TYPE, ROW | STRUCTURED_TYPE)
-        if supportsExplicitCast(operand.resultType, targetType) =>
-        generateCastRowToRow(ctx, operand, targetType)
-
       case (_, _) =>
         throw new CodeGenException(
           s"Unsupported cast from '${operand.resultType}' to '$targetType'.")
@@ -1899,35 +1893,6 @@ object ScalarOperatorGens {
   // ----------------------------------------------------------------------------------------
   // private generate utils
   // ----------------------------------------------------------------------------------------
-
-  private def generateCastRowToRow(
-      ctx: CodeGeneratorContext,
-      operand: GeneratedExpression,
-      targetRowType: LogicalType)
-    : GeneratedExpression = {
-    // assumes that the arity has been checked before
-    generateCallWithStmtIfArgsNotNull(ctx, targetRowType, Seq(operand)) { case Seq(rowTerm) =>
-      val fieldExprs = operand
-        .resultType
-        .getChildren
-        .zip(targetRowType.getChildren)
-        .zipWithIndex
-        .map { case ((sourceType, targetType), idx) =>
-          val sourceTypeTerm = primitiveTypeTermForType(sourceType)
-          val sourceTerm = newName("field")
-          val sourceAccessCode = rowFieldReadAccess(idx, rowTerm, sourceType)
-          val sourceExpr = GeneratedExpression(
-            sourceTerm,
-            s"$rowTerm.isNullAt($idx)",
-            s"$sourceTypeTerm $sourceTerm = ($sourceTypeTerm) $sourceAccessCode;",
-            sourceType)
-          generateCast(ctx, sourceExpr, targetType)
-        }
-
-      val generateRowExpr = generateRow(ctx, targetRowType, fieldExprs)
-      (generateRowExpr.code, generateRowExpr.resultTerm)
-    }
-  }
 
   /**
    * This method supports casting literals to non-composite types (primitives, strings, date time).

--- a/flink-table/flink-table-planner/src/test/java/org/apache/flink/table/planner/functions/CastFunctionITCase.java
+++ b/flink-table/flink-table-planner/src/test/java/org/apache/flink/table/planner/functions/CastFunctionITCase.java
@@ -116,7 +116,7 @@ public class CastFunctionITCase extends BuiltInFunctionTestBase {
         specs.addAll(allTypesBasic());
         specs.addAll(decimalCasts());
         specs.addAll(numericBounds());
-        specs.addAll(structuredTypes());
+        specs.addAll(collectionTypes());
         return specs;
     }
 
@@ -1132,13 +1132,12 @@ public class CastFunctionITCase extends BuiltInFunctionTestBase {
                         .build());
     }
 
-    public static List<TestSpec> structuredTypes() {
+    public static List<TestSpec> collectionTypes() {
         return Arrays.asList(
-                // Cast to structuredTypes
+                // Cast to collection Types
                 // https://issues.apache.org/jira/browse/FLINK-17321
                 // MULTISET
                 // MAP
-                // RAW
                 CastTestSpecBuilder.testCastTo(ARRAY(INT()))
                         .fromCase(ARRAY(INT()), null, null)
                         // https://issues.apache.org/jira/browse/FLINK-17321

--- a/flink-table/flink-table-planner/src/test/java/org/apache/flink/table/planner/functions/CastFunctionITCase.java
+++ b/flink-table/flink-table-planner/src/test/java/org/apache/flink/table/planner/functions/CastFunctionITCase.java
@@ -26,6 +26,7 @@ import org.apache.flink.table.types.DataType;
 import org.apache.flink.table.types.logical.LogicalType;
 import org.apache.flink.table.types.logical.LogicalTypeFamily;
 import org.apache.flink.table.types.logical.LogicalTypeRoot;
+import org.apache.flink.types.Row;
 
 import org.junit.runners.Parameterized;
 
@@ -57,6 +58,7 @@ import static org.apache.flink.table.api.DataTypes.FLOAT;
 import static org.apache.flink.table.api.DataTypes.INT;
 import static org.apache.flink.table.api.DataTypes.INTERVAL;
 import static org.apache.flink.table.api.DataTypes.MONTH;
+import static org.apache.flink.table.api.DataTypes.ROW;
 import static org.apache.flink.table.api.DataTypes.SECOND;
 import static org.apache.flink.table.api.DataTypes.SMALLINT;
 import static org.apache.flink.table.api.DataTypes.STRING;
@@ -114,6 +116,7 @@ public class CastFunctionITCase extends BuiltInFunctionTestBase {
         specs.addAll(allTypesBasic());
         specs.addAll(decimalCasts());
         specs.addAll(numericBounds());
+        specs.addAll(structuredTypes());
         return specs;
     }
 
@@ -1049,51 +1052,14 @@ public class CastFunctionITCase extends BuiltInFunctionTestBase {
                         // .fromCase(INTERVAL(DAY()), Duration.ofDays(300), Period.of(0, 0, 0))
                         // .fromCase(INTERVAL(DAY()), Duration.ofDays(400), Period.of(1, 0, 0))
                         // .fromCase(INTERVAL(HOUR()), Duration.ofDays(400), Period.of(1, 0, 0))
-                        .build(),
+                        .build()
                 // CastTestSpecBuilder
                 // .testCastTo(INTERVAL(DAY()))
                 // https://issues.apache.org/jira/browse/FLINK-24426 allow cast from string
                 // .fromCase(STRING(), "+41 10:17:36.789", Duration.of(...))
                 // https://issues.apache.org/jira/browse/FLINK-24428
                 // .build()
-                CastTestSpecBuilder.testCastTo(ARRAY(INT()))
-                        .fromCase(ARRAY(INT()), null, null)
-                        // https://issues.apache.org/jira/browse/FLINK-17321
-                        // .fromCase(ARRAY(STRING()), new String[] {'1', '2', '3'}, new Integer[]
-                        // {1, 2, 3})
-                        // https://issues.apache.org/jira/browse/FLINK-24425 Cast from corresponding
-                        // single type
-                        // .fromCase(INT(), DEFAULT_POSITIVE_INT, new int[] {DEFAULT_POSITIVE_INT})
-                        .fromCase(ARRAY(INT()), new int[] {1, 2, 3}, new Integer[] {1, 2, 3})
-                        .build(),
-                CastTestSpecBuilder.testCastTo(ARRAY(STRING().nullable()))
-                        .fromCase(
-                                ARRAY(TIMESTAMP(4).nullable()),
-                                new LocalDateTime[] {
-                                    LocalDateTime.parse("2021-09-24T12:34:56.123456"),
-                                    null,
-                                    LocalDateTime.parse("2021-09-24T14:34:56.123456")
-                                },
-                                new String[] {
-                                    "2021-09-24 12:34:56.1234", null, "2021-09-24 14:34:56.1234"
-                                })
-                        .build(),
-                CastTestSpecBuilder.testCastTo(ARRAY(BIGINT().nullable()))
-                        .fromCase(
-                                ARRAY(INT().nullable()),
-                                new Integer[] {1, null, 2},
-                                new Long[] {1L, null, 2L})
-                        .build(),
-                CastTestSpecBuilder.testCastTo(ARRAY(BIGINT().notNull()))
-                        .fromCase(ARRAY(INT().notNull()), new Integer[] {1, 2}, new Long[] {1L, 2L})
-                        .build()
                 //
-                // Cast to structuredTypes
-                // https://issues.apache.org/jira/browse/FLINK-17321
-                // MULTISET
-                // MAP
-                // RAW
-                // ROW
                 );
     }
 
@@ -1163,6 +1129,52 @@ public class CastFunctionITCase extends BuiltInFunctionTestBase {
                         .fromCase(FLOAT(), Float.MAX_VALUE, null)
                         .fromCase(DOUBLE(), -Double.MAX_VALUE, null)
                         .fromCase(DOUBLE(), Double.MAX_VALUE, null)
+                        .build());
+    }
+
+    public static List<TestSpec> structuredTypes() {
+        return Arrays.asList(
+                // Cast to structuredTypes
+                // https://issues.apache.org/jira/browse/FLINK-17321
+                // MULTISET
+                // MAP
+                // RAW
+                CastTestSpecBuilder.testCastTo(ARRAY(INT()))
+                        .fromCase(ARRAY(INT()), null, null)
+                        // https://issues.apache.org/jira/browse/FLINK-17321
+                        // .fromCase(ARRAY(STRING()), new String[] {'1', '2', '3'}, new Integer[]
+                        // {1, 2, 3})
+                        // https://issues.apache.org/jira/browse/FLINK-24425 Cast from corresponding
+                        // single type
+                        // .fromCase(INT(), DEFAULT_POSITIVE_INT, new int[] {DEFAULT_POSITIVE_INT})
+                        .fromCase(ARRAY(INT()), new int[] {1, 2, 3}, new Integer[] {1, 2, 3})
+                        .build(),
+                CastTestSpecBuilder.testCastTo(ARRAY(STRING().nullable()))
+                        .fromCase(
+                                ARRAY(TIMESTAMP(4).nullable()),
+                                new LocalDateTime[] {
+                                    LocalDateTime.parse("2021-09-24T12:34:56.123456"),
+                                    null,
+                                    LocalDateTime.parse("2021-09-24T14:34:56.123456")
+                                },
+                                new String[] {
+                                    "2021-09-24 12:34:56.1234", null, "2021-09-24 14:34:56.1234"
+                                })
+                        .build(),
+                CastTestSpecBuilder.testCastTo(ARRAY(BIGINT().nullable()))
+                        .fromCase(
+                                ARRAY(INT().nullable()),
+                                new Integer[] {1, null, 2},
+                                new Long[] {1L, null, 2L})
+                        .build(),
+                CastTestSpecBuilder.testCastTo(ARRAY(BIGINT().notNull()))
+                        .fromCase(ARRAY(INT().notNull()), new Integer[] {1, 2}, new Long[] {1L, 2L})
+                        .build(),
+                CastTestSpecBuilder.testCastTo(ROW(BIGINT(), BIGINT(), STRING(), ARRAY(STRING())))
+                        .fromCase(
+                                ROW(INT(), INT(), TIME(), ARRAY(CHAR(1))),
+                                Row.of(10, null, DEFAULT_TIME, new String[] {"a", "b", "c"}),
+                                Row.of(10L, null, "12:34:56", new String[] {"a", "b", "c"}))
                         .build());
     }
 

--- a/flink-table/flink-table-planner/src/test/java/org/apache/flink/table/planner/functions/casting/CastRulesTest.java
+++ b/flink-table/flink-table-planner/src/test/java/org/apache/flink/table/planner/functions/casting/CastRulesTest.java
@@ -825,42 +825,10 @@ class CastRulesTest {
     }
 
     public static class MyStructuredType {
-        private long a;
-        private Long b;
-        private String c;
-        private String[] d;
-
-        public long getA() {
-            return a;
-        }
-
-        public void setA(long a) {
-            this.a = a;
-        }
-
-        public Long getB() {
-            return b;
-        }
-
-        public void setB(Long b) {
-            this.b = b;
-        }
-
-        public String getC() {
-            return c;
-        }
-
-        public void setC(String c) {
-            this.c = c;
-        }
-
-        public String[] getD() {
-            return d;
-        }
-
-        public void setD(String[] d) {
-            this.d = d;
-        }
+        public long a;
+        public Long b;
+        public String c;
+        public String[] d;
     }
 
     @SuppressWarnings({"rawtypes"})

--- a/flink-table/flink-table-planner/src/test/java/org/apache/flink/table/planner/functions/casting/CastRulesTest.java
+++ b/flink-table/flink-table-planner/src/test/java/org/apache/flink/table/planner/functions/casting/CastRulesTest.java
@@ -20,14 +20,16 @@ package org.apache.flink.table.planner.functions.casting;
 
 import org.apache.flink.api.common.typeutils.base.LocalDateTimeSerializer;
 import org.apache.flink.table.api.TableException;
-import org.apache.flink.table.data.DecimalData;
 import org.apache.flink.table.data.GenericArrayData;
 import org.apache.flink.table.data.GenericMapData;
 import org.apache.flink.table.data.GenericRowData;
 import org.apache.flink.table.data.MapData;
 import org.apache.flink.table.data.RawValueData;
+import org.apache.flink.table.data.RowData;
 import org.apache.flink.table.data.StringData;
 import org.apache.flink.table.data.TimestampData;
+import org.apache.flink.table.data.conversion.DataStructureConverter;
+import org.apache.flink.table.data.conversion.DataStructureConverters;
 import org.apache.flink.table.data.utils.CastExecutor;
 import org.apache.flink.table.planner.functions.CastFunctionITCase;
 import org.apache.flink.table.types.DataType;
@@ -81,9 +83,9 @@ import static org.apache.flink.table.api.DataTypes.TINYINT;
 import static org.apache.flink.table.api.DataTypes.VARBINARY;
 import static org.apache.flink.table.api.DataTypes.VARCHAR;
 import static org.apache.flink.table.api.DataTypes.YEAR;
-import static org.junit.jupiter.api.Assertions.assertArrayEquals;
-import static org.junit.jupiter.api.Assertions.assertEquals;
-import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.apache.flink.table.data.DecimalData.fromBigDecimal;
+import static org.apache.flink.table.data.StringData.fromString;
+import static org.assertj.core.api.Assertions.assertThat;
 import static org.junit.jupiter.api.Assertions.assertThrows;
 
 /**
@@ -112,35 +114,33 @@ class CastRulesTest {
 
     private static final int DATE = DateTimeUtils.toInternal(LocalDate.parse("2021-09-24"));
     private static final int TIME = DateTimeUtils.toInternal(LocalTime.parse("12:34:56.123"));
-    private static final StringData DATE_STRING = StringData.fromString("2021-09-24");
-    private static final StringData TIME_STRING = StringData.fromString("12:34:56.123");
+    private static final StringData DATE_STRING = fromString("2021-09-24");
+    private static final StringData TIME_STRING = fromString("12:34:56.123");
 
     private static final TimestampData TIMESTAMP =
             TimestampData.fromLocalDateTime(LocalDateTime.parse("2021-09-24T12:34:56.123456"));
-    private static final StringData TIMESTAMP_STRING =
-            StringData.fromString("2021-09-24 12:34:56.123456");
-    private static final StringData TIMESTAMP_STRING_CET =
-            StringData.fromString("2021-09-24 14:34:56.123456");
+    private static final StringData TIMESTAMP_STRING = fromString("2021-09-24 12:34:56.123456");
+    private static final StringData TIMESTAMP_STRING_CET = fromString("2021-09-24 14:34:56.123456");
 
     Stream<CastTestSpecBuilder> testCases() {
         return Stream.of(
                 CastTestSpecBuilder.testCastTo(TINYINT())
                         .fromCase(TINYINT(), null, null)
-                        .fail(CHAR(3), StringData.fromString("foo"), TableException.class)
-                        .fail(VARCHAR(5), StringData.fromString("Flink"), TableException.class)
-                        .fail(STRING(), StringData.fromString("Apache"), TableException.class)
-                        .fromCase(STRING(), StringData.fromString("1.234"), (byte) 1)
-                        .fromCase(STRING(), StringData.fromString("123"), (byte) 123)
-                        .fail(STRING(), StringData.fromString("-130"), TableException.class)
+                        .fail(CHAR(3), fromString("foo"), TableException.class)
+                        .fail(VARCHAR(5), fromString("Flink"), TableException.class)
+                        .fail(STRING(), fromString("Apache"), TableException.class)
+                        .fromCase(STRING(), fromString("1.234"), (byte) 1)
+                        .fromCase(STRING(), fromString("123"), (byte) 123)
+                        .fail(STRING(), fromString("-130"), TableException.class)
                         .fromCase(
                                 DECIMAL(4, 3),
-                                DecimalData.fromBigDecimal(new BigDecimal("9.87"), 4, 3),
+                                fromBigDecimal(new BigDecimal("9.87"), 4, 3),
                                 (byte) 9)
                         // https://issues.apache.org/jira/browse/FLINK-24420 - Check out of range
                         // instead of overflow
                         .fromCase(
                                 DECIMAL(10, 3),
-                                DecimalData.fromBigDecimal(new BigDecimal("9123.87"), 10, 3),
+                                fromBigDecimal(new BigDecimal("9123.87"), 10, 3),
                                 (byte) -93)
                         .fromCase(TINYINT(), DEFAULT_POSITIVE_TINY_INT, DEFAULT_POSITIVE_TINY_INT)
                         .fromCase(TINYINT(), DEFAULT_NEGATIVE_TINY_INT, DEFAULT_NEGATIVE_TINY_INT)
@@ -160,21 +160,21 @@ class CastRulesTest {
                         .fromCase(BOOLEAN(), false, (byte) 0),
                 CastTestSpecBuilder.testCastTo(SMALLINT())
                         .fromCase(SMALLINT(), null, null)
-                        .fail(CHAR(3), StringData.fromString("foo"), TableException.class)
-                        .fail(VARCHAR(5), StringData.fromString("Flink"), TableException.class)
-                        .fail(STRING(), StringData.fromString("Apache"), TableException.class)
-                        .fromCase(STRING(), StringData.fromString("1.234"), (short) 1)
-                        .fromCase(STRING(), StringData.fromString("123"), (short) 123)
-                        .fail(STRING(), StringData.fromString("-32769"), TableException.class)
+                        .fail(CHAR(3), fromString("foo"), TableException.class)
+                        .fail(VARCHAR(5), fromString("Flink"), TableException.class)
+                        .fail(STRING(), fromString("Apache"), TableException.class)
+                        .fromCase(STRING(), fromString("1.234"), (short) 1)
+                        .fromCase(STRING(), fromString("123"), (short) 123)
+                        .fail(STRING(), fromString("-32769"), TableException.class)
                         .fromCase(
                                 DECIMAL(4, 3),
-                                DecimalData.fromBigDecimal(new BigDecimal("9.87"), 4, 3),
+                                fromBigDecimal(new BigDecimal("9.87"), 4, 3),
                                 (short) 9)
                         // https://issues.apache.org/jira/browse/FLINK-24420 - Check out of range
                         // instead of overflow
                         .fromCase(
                                 DECIMAL(10, 3),
-                                DecimalData.fromBigDecimal(new BigDecimal("91235.87"), 10, 3),
+                                fromBigDecimal(new BigDecimal("91235.87"), 10, 3),
                                 (short) 25699)
                         .fromCase(
                                 TINYINT(),
@@ -204,25 +204,18 @@ class CastRulesTest {
                         .fromCase(BOOLEAN(), true, (short) 1)
                         .fromCase(BOOLEAN(), false, (short) 0),
                 CastTestSpecBuilder.testCastTo(INT())
-                        .fail(CHAR(3), StringData.fromString("foo"), TableException.class)
-                        .fail(VARCHAR(5), StringData.fromString("Flink"), TableException.class)
-                        .fail(STRING(), StringData.fromString("Apache"), TableException.class)
-                        .fromCase(STRING(), StringData.fromString("1.234"), 1)
-                        .fromCase(STRING(), StringData.fromString("123"), 123)
-                        .fail(
-                                STRING(),
-                                StringData.fromString("-3276913443134"),
-                                TableException.class)
-                        .fromCase(
-                                DECIMAL(4, 3),
-                                DecimalData.fromBigDecimal(new BigDecimal("9.87"), 4, 3),
-                                9)
+                        .fail(CHAR(3), fromString("foo"), TableException.class)
+                        .fail(VARCHAR(5), fromString("Flink"), TableException.class)
+                        .fail(STRING(), fromString("Apache"), TableException.class)
+                        .fromCase(STRING(), fromString("1.234"), 1)
+                        .fromCase(STRING(), fromString("123"), 123)
+                        .fail(STRING(), fromString("-3276913443134"), TableException.class)
+                        .fromCase(DECIMAL(4, 3), fromBigDecimal(new BigDecimal("9.87"), 4, 3), 9)
                         // https://issues.apache.org/jira/browse/FLINK-24420 - Check out of range
                         // instead of overflow
                         .fromCase(
                                 DECIMAL(20, 3),
-                                DecimalData.fromBigDecimal(
-                                        new BigDecimal("3276913443134.87"), 20, 3),
+                                fromBigDecimal(new BigDecimal("3276913443134.87"), 20, 3),
                                 -146603714)
                         .fromCase(
                                 TINYINT(),
@@ -257,21 +250,16 @@ class CastRulesTest {
                         .fromCase(BOOLEAN(), false, 0),
                 CastTestSpecBuilder.testCastTo(BIGINT())
                         .fromCase(BIGINT(), null, null)
-                        .fail(CHAR(3), StringData.fromString("foo"), TableException.class)
-                        .fail(VARCHAR(5), StringData.fromString("Flink"), TableException.class)
-                        .fail(STRING(), StringData.fromString("Apache"), TableException.class)
-                        .fromCase(STRING(), StringData.fromString("1.234"), 1L)
-                        .fromCase(STRING(), StringData.fromString("123"), 123L)
-                        .fromCase(
-                                STRING(), StringData.fromString("-3276913443134"), -3276913443134L)
-                        .fromCase(
-                                DECIMAL(4, 3),
-                                DecimalData.fromBigDecimal(new BigDecimal("9.87"), 4, 3),
-                                9L)
+                        .fail(CHAR(3), fromString("foo"), TableException.class)
+                        .fail(VARCHAR(5), fromString("Flink"), TableException.class)
+                        .fail(STRING(), fromString("Apache"), TableException.class)
+                        .fromCase(STRING(), fromString("1.234"), 1L)
+                        .fromCase(STRING(), fromString("123"), 123L)
+                        .fromCase(STRING(), fromString("-3276913443134"), -3276913443134L)
+                        .fromCase(DECIMAL(4, 3), fromBigDecimal(new BigDecimal("9.87"), 4, 3), 9L)
                         .fromCase(
                                 DECIMAL(20, 3),
-                                DecimalData.fromBigDecimal(
-                                        new BigDecimal("3276913443134.87"), 20, 3),
+                                fromBigDecimal(new BigDecimal("3276913443134.87"), 20, 3),
                                 3276913443134L)
                         .fromCase(
                                 TINYINT(),
@@ -303,23 +291,19 @@ class CastRulesTest {
                         .fromCase(BOOLEAN(), false, 0L),
                 CastTestSpecBuilder.testCastTo(FLOAT())
                         .fromCase(FLOAT(), null, null)
-                        .fail(CHAR(3), StringData.fromString("foo"), TableException.class)
-                        .fail(VARCHAR(5), StringData.fromString("Flink"), TableException.class)
-                        .fail(STRING(), StringData.fromString("Apache"), TableException.class)
-                        .fromCase(STRING(), StringData.fromString("1.234"), 1.234f)
-                        .fromCase(STRING(), StringData.fromString("123"), 123.0f)
+                        .fail(CHAR(3), fromString("foo"), TableException.class)
+                        .fail(VARCHAR(5), fromString("Flink"), TableException.class)
+                        .fail(STRING(), fromString("Apache"), TableException.class)
+                        .fromCase(STRING(), fromString("1.234"), 1.234f)
+                        .fromCase(STRING(), fromString("123"), 123.0f)
+                        .fromCase(STRING(), fromString("-3276913443134"), -3.27691351E12f)
                         .fromCase(
-                                STRING(), StringData.fromString("-3276913443134"), -3.27691351E12f)
-                        .fromCase(
-                                DECIMAL(4, 3),
-                                DecimalData.fromBigDecimal(new BigDecimal("9.87"), 4, 3),
-                                9.87f)
+                                DECIMAL(4, 3), fromBigDecimal(new BigDecimal("9.87"), 4, 3), 9.87f)
                         // https://issues.apache.org/jira/browse/FLINK-24420 - Check out of range
                         // instead of overflow
                         .fromCase(
                                 DECIMAL(20, 3),
-                                DecimalData.fromBigDecimal(
-                                        new BigDecimal("3276913443134.87"), 20, 3),
+                                fromBigDecimal(new BigDecimal("3276913443134.87"), 20, 3),
                                 3.27691351E12f)
                         .fromCase(
                                 TINYINT(),
@@ -353,27 +337,21 @@ class CastRulesTest {
                         .fromCase(BOOLEAN(), false, 0.0f),
                 CastTestSpecBuilder.testCastTo(DOUBLE())
                         .fromCase(DOUBLE(), null, null)
-                        .fail(CHAR(3), StringData.fromString("foo"), TableException.class)
-                        .fail(VARCHAR(5), StringData.fromString("Flink"), TableException.class)
-                        .fail(STRING(), StringData.fromString("Apache"), TableException.class)
-                        .fromCase(STRING(), StringData.fromString("1.234"), 1.234d)
-                        .fromCase(STRING(), StringData.fromString("123"), 123.0d)
+                        .fail(CHAR(3), fromString("foo"), TableException.class)
+                        .fail(VARCHAR(5), fromString("Flink"), TableException.class)
+                        .fail(STRING(), fromString("Apache"), TableException.class)
+                        .fromCase(STRING(), fromString("1.234"), 1.234d)
+                        .fromCase(STRING(), fromString("123"), 123.0d)
+                        .fromCase(STRING(), fromString("-3276913443134"), -3.276913443134E12d)
                         .fromCase(
-                                STRING(),
-                                StringData.fromString("-3276913443134"),
-                                -3.276913443134E12d)
-                        .fromCase(
-                                DECIMAL(4, 3),
-                                DecimalData.fromBigDecimal(new BigDecimal("9.87"), 4, 3),
-                                9.87d)
+                                DECIMAL(4, 3), fromBigDecimal(new BigDecimal("9.87"), 4, 3), 9.87d)
                         .fromCase(
                                 DECIMAL(20, 3),
-                                DecimalData.fromBigDecimal(
-                                        new BigDecimal("3276913443134.87"), 20, 3),
+                                fromBigDecimal(new BigDecimal("3276913443134.87"), 20, 3),
                                 3.27691344313487E12d)
                         .fromCase(
                                 DECIMAL(30, 20),
-                                DecimalData.fromBigDecimal(
+                                fromBigDecimal(
                                         new BigDecimal("123456789.123456789123456789"), 30, 20),
                                 1.2345678912345679E8d)
                         .fromCase(
@@ -407,68 +385,65 @@ class CastRulesTest {
                         .fromCase(BOOLEAN(), true, 1.0d)
                         .fromCase(BOOLEAN(), false, 0.0d),
                 CastTestSpecBuilder.testCastTo(DATE())
-                        .fail(CHAR(3), StringData.fromString("foo"), TableException.class)
-                        .fail(VARCHAR(5), StringData.fromString("Flink"), TableException.class)
+                        .fail(CHAR(3), fromString("foo"), TableException.class)
+                        .fail(VARCHAR(5), fromString("Flink"), TableException.class)
                         .fromCase(
                                 STRING(),
-                                StringData.fromString("123"),
+                                fromString("123"),
                                 DateTimeUtils.toInternal(LocalDate.of(123, 1, 1)))
                         .fromCase(
                                 STRING(),
-                                StringData.fromString("2021-09-27"),
+                                fromString("2021-09-27"),
                                 DateTimeUtils.toInternal(LocalDate.of(2021, 9, 27)))
                         .fromCase(
                                 STRING(),
-                                StringData.fromString("2021-09-27 12:34:56.123456789"),
+                                fromString("2021-09-27 12:34:56.123456789"),
                                 DateTimeUtils.toInternal(LocalDate.of(2021, 9, 27)))
-                        .fail(STRING(), StringData.fromString("2021/09/27"), TableException.class),
+                        .fail(STRING(), fromString("2021/09/27"), TableException.class),
                 CastTestSpecBuilder.testCastTo(TIME())
-                        .fail(CHAR(3), StringData.fromString("foo"), TableException.class)
-                        .fail(VARCHAR(5), StringData.fromString("Flink"), TableException.class)
+                        .fail(CHAR(3), fromString("foo"), TableException.class)
+                        .fail(VARCHAR(5), fromString("Flink"), TableException.class)
                         .fromCase(
                                 STRING(),
-                                StringData.fromString("23"),
+                                fromString("23"),
                                 DateTimeUtils.toInternal(LocalTime.of(23, 0, 0)))
                         .fromCase(
                                 STRING(),
-                                StringData.fromString("23:45"),
+                                fromString("23:45"),
                                 DateTimeUtils.toInternal(LocalTime.of(23, 45, 0)))
-                        .fail(STRING(), StringData.fromString("2021-09-27"), TableException.class)
-                        .fail(
-                                STRING(),
-                                StringData.fromString("2021-09-27 12:34:56"),
-                                TableException.class)
+                        .fail(STRING(), fromString("2021-09-27"), TableException.class)
+                        .fail(STRING(), fromString("2021-09-27 12:34:56"), TableException.class)
                         .fromCase(
                                 STRING(),
-                                StringData.fromString("12:34:56.123456789"),
+                                fromString("12:34:56.123456789"),
                                 DateTimeUtils.toInternal(LocalTime.of(12, 34, 56, 123_000_000)))
                         .fail(
                                 STRING(),
-                                StringData.fromString("2021-09-27 12:34:56.123456789"),
+                                fromString("2021-09-27 12:34:56.123456789"),
                                 TableException.class),
                 CastTestSpecBuilder.testCastTo(TIMESTAMP(9))
-                        .fail(CHAR(3), StringData.fromString("foo"), TableException.class)
-                        .fail(VARCHAR(5), StringData.fromString("Flink"), TableException.class)
-                        .fail(STRING(), StringData.fromString("123"), TableException.class)
+                        .fail(CHAR(3), fromString("foo"), TableException.class)
+                        .fail(VARCHAR(5), fromString("Flink"), TableException.class)
+                        .fail(STRING(), fromString("123"), TableException.class)
                         .fromCase(
                                 STRING(),
-                                StringData.fromString("2021-09-27"),
+                                fromString("2021-09-27"),
                                 TimestampData.fromLocalDateTime(
                                         LocalDateTime.of(2021, 9, 27, 0, 0, 0, 0)))
-                        .fail(STRING(), StringData.fromString("2021/09/27"), TableException.class)
+                        .fail(STRING(), fromString("2021/09/27"), TableException.class)
                         .fromCase(
                                 STRING(),
-                                StringData.fromString("2021-09-27 12:34:56.123456789"),
+                                fromString("2021-09-27 12:34:56.123456789"),
                                 TimestampData.fromLocalDateTime(
                                         LocalDateTime.of(2021, 9, 27, 12, 34, 56, 123456789))),
                 CastTestSpecBuilder.testCastTo(TIMESTAMP_LTZ(9))
-                        .fail(CHAR(3), StringData.fromString("foo"), TableException.class)
-                        .fail(VARCHAR(5), StringData.fromString("Flink"), TableException.class)
-                        .fail(STRING(), StringData.fromString("123"), TableException.class)
+                        .fail(CHAR(3), fromString("foo"), TableException.class)
+                        .fail(VARCHAR(5), fromString("Flink"), TableException.class)
+                        .fail(STRING(), fromString("123"), TableException.class)
                         .fromCase(
                                 STRING(),
                                 CET_CONTEXT,
-                                StringData.fromString("2021-09-27"),
+                                fromString("2021-09-27"),
                                 TimestampData.fromInstant(
                                         LocalDateTime.of(2021, 9, 27, 0, 0, 0, 0)
                                                 .atZone(CET)
@@ -476,7 +451,7 @@ class CastRulesTest {
                         .fromCase(
                                 STRING(),
                                 CET_CONTEXT,
-                                StringData.fromString("2021-09-27 12:34:56.123"),
+                                fromString("2021-09-27 12:34:56.123"),
                                 TimestampData.fromInstant(
                                         LocalDateTime.of(2021, 9, 27, 12, 34, 56, 123000000)
                                                 .atZone(CET)
@@ -486,170 +461,140 @@ class CastRulesTest {
                         .fromCase(
                                 STRING(),
                                 CET_CONTEXT,
-                                StringData.fromString("2021-09-27 12:34:56.123456789"),
+                                fromString("2021-09-27 12:34:56.123456789"),
                                 TimestampData.fromInstant(
                                         LocalDateTime.of(2021, 9, 27, 12, 34, 56, 0)
                                                 .atZone(CET)
                                                 .toInstant())),
                 CastTestSpecBuilder.testCastTo(STRING())
                         .fromCase(STRING(), null, null)
-                        .fromCase(
-                                CHAR(3), StringData.fromString("foo"), StringData.fromString("foo"))
-                        .fromCase(
-                                VARCHAR(5),
-                                StringData.fromString("Flink"),
-                                StringData.fromString("Flink"))
-                        .fromCase(
-                                VARCHAR(10),
-                                StringData.fromString("Flink"),
-                                StringData.fromString("Flink"))
-                        .fromCase(
-                                STRING(),
-                                StringData.fromString("Apache Flink"),
-                                StringData.fromString("Apache Flink"))
-                        .fromCase(BOOLEAN(), true, StringData.fromString("true"))
-                        .fromCase(BOOLEAN(), false, StringData.fromString("false"))
-                        .fromCase(
-                                BINARY(2), new byte[] {0, 1}, StringData.fromString("\u0000\u0001"))
+                        .fromCase(CHAR(3), fromString("foo"), fromString("foo"))
+                        .fromCase(VARCHAR(5), fromString("Flink"), fromString("Flink"))
+                        .fromCase(VARCHAR(10), fromString("Flink"), fromString("Flink"))
+                        .fromCase(STRING(), fromString("Apache Flink"), fromString("Apache Flink"))
+                        .fromCase(BOOLEAN(), true, fromString("true"))
+                        .fromCase(BOOLEAN(), false, fromString("false"))
+                        .fromCase(BINARY(2), new byte[] {0, 1}, fromString("\u0000\u0001"))
                         .fromCase(
                                 VARBINARY(3),
                                 new byte[] {0, 1, 2},
-                                StringData.fromString("\u0000\u0001\u0002"))
+                                fromString("\u0000\u0001\u0002"))
                         .fromCase(
                                 VARBINARY(5),
                                 new byte[] {0, 1, 2},
-                                StringData.fromString("\u0000\u0001\u0002"))
+                                fromString("\u0000\u0001\u0002"))
                         .fromCase(
                                 BYTES(),
                                 new byte[] {0, 1, 2, 3, 4},
-                                StringData.fromString("\u0000\u0001\u0002\u0003\u0004"))
+                                fromString("\u0000\u0001\u0002\u0003\u0004"))
                         .fromCase(
                                 DECIMAL(4, 3),
-                                DecimalData.fromBigDecimal(new BigDecimal("9.87"), 4, 3),
-                                StringData.fromString("9.870"))
+                                fromBigDecimal(new BigDecimal("9.87"), 4, 3),
+                                fromString("9.870"))
                         .fromCase(
                                 DECIMAL(5, 3),
-                                DecimalData.fromBigDecimal(new BigDecimal("9.87"), 5, 3),
-                                StringData.fromString("9.870"))
-                        .fromCase(TINYINT(), (byte) -125, StringData.fromString("-125"))
-                        .fromCase(SMALLINT(), (short) 32767, StringData.fromString("32767"))
-                        .fromCase(INT(), -12345678, StringData.fromString("-12345678"))
-                        .fromCase(BIGINT(), 1234567891234L, StringData.fromString("1234567891234"))
-                        .fromCase(FLOAT(), -123.456f, StringData.fromString("-123.456"))
-                        .fromCase(DOUBLE(), 12345.678901d, StringData.fromString("12345.678901"))
+                                fromBigDecimal(new BigDecimal("9.87"), 5, 3),
+                                fromString("9.870"))
+                        .fromCase(TINYINT(), (byte) -125, fromString("-125"))
+                        .fromCase(SMALLINT(), (short) 32767, fromString("32767"))
+                        .fromCase(INT(), -12345678, fromString("-12345678"))
+                        .fromCase(BIGINT(), 1234567891234L, fromString("1234567891234"))
+                        .fromCase(FLOAT(), -123.456f, fromString("-123.456"))
+                        .fromCase(DOUBLE(), 12345.678901d, fromString("12345.678901"))
                         .fromCase(
                                 FLOAT(),
                                 Float.MAX_VALUE,
-                                StringData.fromString(String.valueOf(Float.MAX_VALUE)))
+                                fromString(String.valueOf(Float.MAX_VALUE)))
                         .fromCase(
                                 DOUBLE(),
                                 Double.MAX_VALUE,
-                                StringData.fromString(String.valueOf(Double.MAX_VALUE)))
-                        .fromCase(
-                                STRING(),
-                                StringData.fromString("Hello"),
-                                StringData.fromString("Hello"))
+                                fromString(String.valueOf(Double.MAX_VALUE)))
+                        .fromCase(STRING(), fromString("Hello"), fromString("Hello"))
                         .fromCase(TIMESTAMP(), TIMESTAMP, TIMESTAMP_STRING)
                         .fromCase(TIMESTAMP_LTZ(), CET_CONTEXT, TIMESTAMP, TIMESTAMP_STRING_CET)
                         .fromCase(DATE(), DATE, DATE_STRING)
                         .fromCase(TIME(5), TIME, TIME_STRING)
-                        .fromCase(INTERVAL(YEAR()), 84, StringData.fromString("+7-00"))
-                        .fromCase(INTERVAL(MONTH()), 5, StringData.fromString("+0-05"))
-                        .fromCase(INTERVAL(MONTH()), 123, StringData.fromString("+10-03"))
-                        .fromCase(INTERVAL(MONTH()), 12334, StringData.fromString("+1027-10"))
-                        .fromCase(INTERVAL(DAY()), 10L, StringData.fromString("+0 00:00:00.010"))
-                        .fromCase(
-                                INTERVAL(DAY()),
-                                123456789L,
-                                StringData.fromString("+1 10:17:36.789"))
+                        .fromCase(INTERVAL(YEAR()), 84, fromString("+7-00"))
+                        .fromCase(INTERVAL(MONTH()), 5, fromString("+0-05"))
+                        .fromCase(INTERVAL(MONTH()), 123, fromString("+10-03"))
+                        .fromCase(INTERVAL(MONTH()), 12334, fromString("+1027-10"))
+                        .fromCase(INTERVAL(DAY()), 10L, fromString("+0 00:00:00.010"))
+                        .fromCase(INTERVAL(DAY()), 123456789L, fromString("+1 10:17:36.789"))
                         .fromCase(
                                 INTERVAL(DAY()),
                                 Duration.ofHours(36).toMillis(),
-                                StringData.fromString("+1 12:00:00.000"))
+                                fromString("+1 12:00:00.000"))
                         .fromCase(
                                 ARRAY(INTERVAL(MONTH())),
                                 new GenericArrayData(new int[] {-123, 123}),
-                                StringData.fromString("[-10-03, +10-03]"))
+                                fromString("[-10-03, +10-03]"))
                         .fromCase(
                                 ARRAY(INT()),
                                 new GenericArrayData(new int[] {-123, 456}),
-                                StringData.fromString("[-123, 456]"))
+                                fromString("[-123, 456]"))
                         .fromCase(
                                 ARRAY(INT().nullable()),
                                 new GenericArrayData(new Integer[] {null, 456}),
-                                StringData.fromString("[null, 456]"))
+                                fromString("[null, 456]"))
                         .fromCase(
                                 ARRAY(INT()),
                                 new GenericArrayData(new Integer[] {}),
-                                StringData.fromString("[]"))
+                                fromString("[]"))
                         .fromCase(
                                 MAP(STRING(), INTERVAL(MONTH())),
-                                mapData(
-                                        entry(StringData.fromString("a"), -123),
-                                        entry(StringData.fromString("b"), 123)),
-                                StringData.fromString("{a=-10-03, b=+10-03}"))
+                                mapData(entry(fromString("a"), -123), entry(fromString("b"), 123)),
+                                fromString("{a=-10-03, b=+10-03}"))
                         .fromCase(
                                 MULTISET(STRING()),
-                                mapData(
-                                        entry(StringData.fromString("a"), 1),
-                                        entry(StringData.fromString("b"), 1)),
-                                StringData.fromString("{a=1, b=1}"))
+                                mapData(entry(fromString("a"), 1), entry(fromString("b"), 1)),
+                                fromString("{a=1, b=1}"))
                         .fromCase(
                                 MAP(STRING().nullable(), INTERVAL(MONTH()).nullable()),
-                                mapData(entry(null, -123), entry(StringData.fromString("b"), null)),
-                                StringData.fromString("{null=-10-03, b=null}"))
+                                mapData(entry(null, -123), entry(fromString("b"), null)),
+                                fromString("{null=-10-03, b=null}"))
                         .fromCase(
                                 MAP(STRING().nullable(), INTERVAL(MONTH()).nullable()),
                                 mapData(entry(null, null)),
-                                StringData.fromString("{null=null}"))
-                        .fromCase(
-                                MAP(STRING(), INTERVAL(MONTH())),
-                                mapData(),
-                                StringData.fromString("{}"))
+                                fromString("{null=null}"))
+                        .fromCase(MAP(STRING(), INTERVAL(MONTH())), mapData(), fromString("{}"))
                         .fromCase(
                                 ROW(FIELD("f0", INT()), FIELD("f1", STRING())),
-                                GenericRowData.of(123, StringData.fromString("abc")),
-                                StringData.fromString("(123, abc)"))
+                                GenericRowData.of(123, fromString("abc")),
+                                fromString("(123, abc)"))
                         .fromCase(
                                 ROW(FIELD("f0", STRING()), FIELD("f1", STRING())),
-                                GenericRowData.of(
-                                        StringData.fromString("abc"), StringData.fromString("def")),
-                                StringData.fromString("(abc, def)"),
+                                GenericRowData.of(fromString("abc"), fromString("def")),
+                                fromString("(abc, def)"),
                                 false)
                         .fromCase(
                                 ROW(FIELD("f0", STRING()), FIELD("f1", STRING())),
-                                GenericRowData.of(
-                                        StringData.fromString("abc"), StringData.fromString("def")),
-                                StringData.fromString("(abc,def)"),
+                                GenericRowData.of(fromString("abc"), fromString("def")),
+                                fromString("(abc,def)"),
                                 true)
                         .fromCase(
                                 ROW(FIELD("f0", INT().nullable()), FIELD("f1", STRING())),
-                                GenericRowData.of(null, StringData.fromString("abc")),
-                                StringData.fromString("(null, abc)"))
-                        .fromCase(ROW(), GenericRowData.of(), StringData.fromString("()"))
+                                GenericRowData.of(null, fromString("abc")),
+                                fromString("(null, abc)"))
+                        .fromCase(ROW(), GenericRowData.of(), fromString("()"))
                         .fromCase(
                                 RAW(LocalDateTime.class, new LocalDateTimeSerializer()),
                                 RawValueData.fromObject(
                                         LocalDateTime.parse("2020-11-11T18:08:01.123")),
-                                StringData.fromString("2020-11-11T18:08:01.123")),
+                                fromString("2020-11-11T18:08:01.123")),
                 CastTestSpecBuilder.testCastTo(BOOLEAN())
                         .fromCase(BOOLEAN(), null, null)
-                        .fail(CHAR(3), StringData.fromString("foo"), TableException.class)
-                        .fromCase(CHAR(4), StringData.fromString("true"), true)
-                        .fromCase(VARCHAR(5), StringData.fromString("FalsE"), false)
-                        .fail(STRING(), StringData.fromString("Apache Flink"), TableException.class)
-                        .fromCase(STRING(), StringData.fromString("TRUE"), true)
-                        .fail(STRING(), StringData.fromString(""), TableException.class)
+                        .fail(CHAR(3), fromString("foo"), TableException.class)
+                        .fromCase(CHAR(4), fromString("true"), true)
+                        .fromCase(VARCHAR(5), fromString("FalsE"), false)
+                        .fail(STRING(), fromString("Apache Flink"), TableException.class)
+                        .fromCase(STRING(), fromString("TRUE"), true)
+                        .fail(STRING(), fromString(""), TableException.class)
                         // Should fail when https://issues.apache.org/jira/browse/FLINK-24576 is
                         // fixed
                         .fromCase(
-                                DECIMAL(5, 3),
-                                DecimalData.fromBigDecimal(new BigDecimal("0.000"), 5, 3),
-                                false)
+                                DECIMAL(5, 3), fromBigDecimal(new BigDecimal("0.000"), 5, 3), false)
                         .fromCase(
-                                DECIMAL(4, 3),
-                                DecimalData.fromBigDecimal(new BigDecimal("1.987"), 4, 3),
-                                true)
+                                DECIMAL(4, 3), fromBigDecimal(new BigDecimal("1.987"), 4, 3), true)
                         .fromCase(TINYINT(), DEFAULT_POSITIVE_TINY_INT, true)
                         .fromCase(TINYINT(), DEFAULT_NEGATIVE_TINY_INT, true)
                         .fromCase(TINYINT(), (byte) 0, false)
@@ -669,84 +614,70 @@ class CastRulesTest {
                         .fromCase(DOUBLE(), 0.0d, false)
                         .fromCase(DOUBLE(), -0.12345678d, true),
                 CastTestSpecBuilder.testCastTo(BINARY(2))
-                        .fromCase(CHAR(3), StringData.fromString("foo"), new byte[] {102, 111, 111})
+                        .fromCase(CHAR(3), fromString("foo"), new byte[] {102, 111, 111})
                         .fromCase(
                                 VARCHAR(5),
-                                StringData.fromString("Flink"),
+                                fromString("Flink"),
                                 new byte[] {70, 108, 105, 110, 107})
                         // https://issues.apache.org/jira/browse/FLINK-24419 - not trimmed to 2
                         // bytes
                         .fromCase(
                                 STRING(),
-                                StringData.fromString("Apache"),
+                                fromString("Apache"),
                                 new byte[] {65, 112, 97, 99, 104, 101}),
                 CastTestSpecBuilder.testCastTo(VARBINARY(4))
-                        .fromCase(CHAR(3), StringData.fromString("foo"), new byte[] {102, 111, 111})
+                        .fromCase(CHAR(3), fromString("foo"), new byte[] {102, 111, 111})
                         .fromCase(
                                 VARCHAR(5),
-                                StringData.fromString("Flink"),
+                                fromString("Flink"),
                                 new byte[] {70, 108, 105, 110, 107})
                         // https://issues.apache.org/jira/browse/FLINK-24419 - not trimmed to 2
                         // bytes
                         .fromCase(
                                 STRING(),
-                                StringData.fromString("Apache"),
+                                fromString("Apache"),
                                 new byte[] {65, 112, 97, 99, 104, 101}),
                 CastTestSpecBuilder.testCastTo(BYTES())
-                        .fromCase(CHAR(3), StringData.fromString("foo"), new byte[] {102, 111, 111})
+                        .fromCase(CHAR(3), fromString("foo"), new byte[] {102, 111, 111})
                         .fromCase(
                                 VARCHAR(5),
-                                StringData.fromString("Flink"),
+                                fromString("Flink"),
                                 new byte[] {70, 108, 105, 110, 107})
                         .fromCase(
                                 STRING(),
-                                StringData.fromString("Apache"),
+                                fromString("Apache"),
                                 new byte[] {65, 112, 97, 99, 104, 101}),
                 CastTestSpecBuilder.testCastTo(DECIMAL(5, 3))
-                        .fail(CHAR(3), StringData.fromString("foo"), TableException.class)
-                        .fail(VARCHAR(5), StringData.fromString("Flink"), TableException.class)
-                        .fail(STRING(), StringData.fromString("Apache"), TableException.class)
+                        .fail(CHAR(3), fromString("foo"), TableException.class)
+                        .fail(VARCHAR(5), fromString("Flink"), TableException.class)
+                        .fail(STRING(), fromString("Apache"), TableException.class)
                         .fromCase(
                                 STRING(),
-                                StringData.fromString("1.234"),
-                                DecimalData.fromBigDecimal(new BigDecimal("1.234"), 5, 3))
+                                fromString("1.234"),
+                                fromBigDecimal(new BigDecimal("1.234"), 5, 3))
                         .fromCase(
                                 STRING(),
-                                StringData.fromString("1.2"),
-                                DecimalData.fromBigDecimal(new BigDecimal("1.200"), 5, 3))
+                                fromString("1.2"),
+                                fromBigDecimal(new BigDecimal("1.200"), 5, 3))
                         .fromCase(
                                 DECIMAL(4, 3),
-                                DecimalData.fromBigDecimal(new BigDecimal("9.87"), 4, 3),
-                                DecimalData.fromBigDecimal(new BigDecimal("9.870"), 5, 3))
+                                fromBigDecimal(new BigDecimal("9.87"), 4, 3),
+                                fromBigDecimal(new BigDecimal("9.870"), 5, 3))
                         .fromCase(
                                 TINYINT(),
                                 (byte) -1,
-                                DecimalData.fromBigDecimal(new BigDecimal("-1.000"), 5, 3))
+                                fromBigDecimal(new BigDecimal("-1.000"), 5, 3))
                         .fromCase(
                                 SMALLINT(),
                                 (short) 3,
-                                DecimalData.fromBigDecimal(new BigDecimal("3.000"), 5, 3))
+                                fromBigDecimal(new BigDecimal("3.000"), 5, 3))
+                        .fromCase(INT(), 42, fromBigDecimal(new BigDecimal("42.000"), 5, 3))
+                        .fromCase(BIGINT(), 8L, fromBigDecimal(new BigDecimal("8.000"), 5, 3))
                         .fromCase(
-                                INT(),
-                                42,
-                                DecimalData.fromBigDecimal(new BigDecimal("42.000"), 5, 3))
-                        .fromCase(
-                                BIGINT(),
-                                8L,
-                                DecimalData.fromBigDecimal(new BigDecimal("8.000"), 5, 3))
-                        .fromCase(
-                                FLOAT(),
-                                -12.345f,
-                                DecimalData.fromBigDecimal(new BigDecimal("-12.345"), 5, 3))
-                        .fromCase(
-                                DOUBLE(),
-                                12.678d,
-                                DecimalData.fromBigDecimal(new BigDecimal("12.678"), 5, 3))
-                        .fromCase(BOOLEAN(), true, DecimalData.fromBigDecimal(BigDecimal.ONE, 5, 3))
-                        .fromCase(
-                                BOOLEAN(),
-                                false,
-                                DecimalData.fromBigDecimal(BigDecimal.ZERO, 5, 3)),
+                                FLOAT(), -12.345f, fromBigDecimal(new BigDecimal("-12.345"), 5, 3))
+                        .fromCase(DOUBLE(), 12.678d, fromBigDecimal(new BigDecimal("12.678"), 5, 3))
+                        .fromCase(BOOLEAN(), true, fromBigDecimal(BigDecimal.ONE, 5, 3))
+                        .fromCase(BOOLEAN(), false, fromBigDecimal(BigDecimal.ZERO, 5, 3)),
                 CastTestSpecBuilder.testCastTo(ARRAY(STRING().nullable()))
                         .fromCase(
                                 ARRAY(TIMESTAMP().nullable()),
@@ -762,7 +693,7 @@ class CastRulesTest {
                                         new Object[] {
                                             TIMESTAMP_STRING,
                                             null,
-                                            StringData.fromString("2021-09-24 14:34:56.123456")
+                                            fromString("2021-09-24 14:34:56.123456")
                                         })),
                 CastTestSpecBuilder.testCastTo(ARRAY(BIGINT().nullable()))
                         .fromCase(
@@ -782,7 +713,50 @@ class CastRulesTest {
                                             new GenericArrayData(new Integer[] {1, 2, null}),
                                             new GenericArrayData(new Integer[] {3})
                                         }),
-                                NullPointerException.class));
+                                NullPointerException.class),
+                CastTestSpecBuilder.testCastTo(
+                                ROW(BIGINT().notNull(), BIGINT(), STRING(), ARRAY(STRING())))
+                        .fromCase(
+                                ROW(INT().notNull(), INT(), TIME(5), ARRAY(TIMESTAMP())),
+                                GenericRowData.of(
+                                        10,
+                                        null,
+                                        TIME,
+                                        new GenericArrayData(
+                                                new Object[] {TIMESTAMP, TIMESTAMP, TIMESTAMP})),
+                                GenericRowData.of(
+                                        10L,
+                                        null,
+                                        TIME_STRING,
+                                        new GenericArrayData(
+                                                new Object[] {
+                                                    TIMESTAMP_STRING,
+                                                    TIMESTAMP_STRING,
+                                                    TIMESTAMP_STRING
+                                                })))
+                        .fromCase(
+                                ROW(INT().notNull(), INT(), DATE(), ARRAY(STRING()), TIME(5)),
+                                GenericRowData.of(
+                                        10,
+                                        100,
+                                        DATE,
+                                        new GenericArrayData(
+                                                new Object[] {
+                                                    fromString("a"),
+                                                    fromString("b"),
+                                                    fromString("c")
+                                                }),
+                                        TIME),
+                                GenericRowData.of(
+                                        10L,
+                                        100L,
+                                        DATE_STRING,
+                                        new GenericArrayData(
+                                                new Object[] {
+                                                    fromString("a"),
+                                                    fromString("b"),
+                                                    fromString("c")
+                                                }))));
     }
 
     @TestFactory
@@ -836,12 +810,13 @@ class CastRulesTest {
                             this.castContext,
                             this.inputType.getLogicalType(),
                             this.targetType.getLogicalType());
-            assertNotNull(
-                    executor,
-                    "Cannot resolve an executor for input "
-                            + this.inputType
-                            + " and target "
-                            + this.targetType);
+            assertThat(executor)
+                    .as(
+                            "Cannot resolve an executor for input "
+                                    + this.inputType
+                                    + " and target "
+                                    + this.targetType)
+                    .isNotNull();
 
             this.assertionExecutor.accept(executor);
         }
@@ -871,9 +846,9 @@ class CastRulesTest {
         }
 
         private CastTestSpecBuilder fromCase(
-                DataType dataType, Object src, Object target, boolean legacyBehaviour) {
+                DataType srcDataType, Object src, Object target, boolean legacyBehaviour) {
             return fromCase(
-                    dataType,
+                    srcDataType,
                     CastRule.Context.create(
                             legacyBehaviour,
                             DateTimeUtils.UTC_ZONE.toZoneId(),
@@ -883,25 +858,18 @@ class CastRulesTest {
         }
 
         private CastTestSpecBuilder fromCase(
-                DataType dataType, CastRule.Context castContext, Object src, Object target) {
-            this.inputTypes.add(dataType);
+                DataType srcDataType, CastRule.Context castContext, Object src, Object target) {
+            this.inputTypes.add(srcDataType);
             this.assertionExecutors.add(
                     executor -> {
-                        if (target instanceof byte[]) {
-                            assertArrayEquals((byte[]) target, (byte[]) executor.cast(src));
-                            // Run twice to make sure rules are reusable without causing issues
-                            assertArrayEquals(
-                                    (byte[]) target,
-                                    (byte[]) executor.cast(src),
-                                    "Error when reusing the rule. Perhaps there is some state that needs to be reset");
-                        } else {
-                            assertEquals(target, executor.cast(src));
-                            // Run twice to make sure rules are reusable without causing issues
-                            assertEquals(
-                                    target,
-                                    executor.cast(src),
-                                    "Error when reusing the rule. Perhaps there is some state that needs to be reset");
-                        }
+                        Object expected = sanitizeTestData(targetType, target);
+
+                        assertThat(sanitizeTestData(targetType, executor.cast(src)))
+                                .isEqualTo(expected);
+                        assertThat(sanitizeTestData(targetType, executor.cast(src)))
+                                .as(
+                                        "Error when reusing the rule. Perhaps there is some state that needs to be reset")
+                                .isEqualTo(expected);
                     });
             this.descriptions.add("{" + src + " => " + target + "}");
             this.castContexts.add(castContext);
@@ -945,6 +913,18 @@ class CastRulesTest {
                                 castContexts.get(i));
             }
             return Arrays.stream(testSpecs);
+        }
+
+        // This method makes sure that we can correctly compare rows
+        private Object sanitizeTestData(DataType dataType, Object value) {
+            if (value instanceof RowData) {
+                // Convert to GenericRowData using the DataStructureConverter
+                DataStructureConverter<Object, Object> converter =
+                        DataStructureConverters.getConverter(dataType);
+                converter.open(Thread.currentThread().getContextClassLoader());
+                return converter.toInternalOrNull(converter.toExternalOrNull(value));
+            }
+            return value;
         }
     }
 }


### PR DESCRIPTION
## What is the purpose of the change

Port row to row casting logic to `CastRule` stack.

## Brief change log

* Fix `AbstractCodeGeneratorCastRule` to properly write the serializers
* Port row to row casting logic to `CastRule` stack.

## Verifying this change

This change adds some test cases to `CastRule` and `CastFunctionsITCase`

## Does this pull request potentially affect one of the following parts:

  - Dependencies (does it add or upgrade a dependency): no
  - The public API, i.e., is any changed class annotated with `@Public(Evolving)`: no
  - The serializers: no
  - The runtime per-record code paths (performance sensitive): no
  - Anything that affects deployment or recovery: JobManager (and its components), Checkpointing, Kubernetes/Yarn, ZooKeeper: no
  - The S3 file system connector: no

## Documentation

  - Does this pull request introduce a new feature? no
  - If yes, how is the feature documented? not applicable
