### PR TITLE
[FLINK-25180][tests] Upgrade Jepsen to 0.1.19

### DIFF
--- a/flink-jepsen/project.clj
+++ b/flink-jepsen/project.clj
@@ -19,10 +19,11 @@
             :url  "http://www.apache.org/licenses/LICENSE-2.0"}
   :main jepsen.flink.flink
   :aot [jepsen.flink.flink]
-  :dependencies [[org.clojure/clojure "1.9.0"],
+  :dependencies [;; jepsen 0.1.19 is not compatible with 1.10.1+
+                 [org.clojure/clojure "1.10.0"],
                  [cheshire "5.8.0"]
                  [clj-http "3.8.0"]
-                 [jepsen "0.1.13"],
+                 [jepsen "0.1.19"],
                  [jepsen.zookeeper "0.1.0"]
                  [org.clojure/data.xml "0.0.8"]
                  [zookeeper-clj "0.9.4" :exclusions [org.slf4j/slf4j-log4j12]]]

--- a/flink-jepsen/src/jepsen/flink/db.clj
+++ b/flink-jepsen/src/jepsen/flink/db.clj
@@ -108,7 +108,12 @@
     (teardown! [_ test node]
       (c/su
         (try
-          (doseq [db (reverse dbs)] (db/teardown! db test node))
+          (doseq [db (reverse dbs)]
+            (try
+              (db/teardown! db test node)
+              ;; jepsen also calls teardown at the start of the test
+              ;; neither our dbs nor jepsen-zookeeper handle the db not existing gracefully
+              (catch Exception e (error str "Exception while tearing down" (.getMessage e)))))
           (finally (fu/stop-all-supervised-services!)))))
     db/LogFiles
     (log-files [_ test node]


### PR DESCRIPTION
Jepsen 0.1.19 is smarter when it comes to detecting already installed dependencies, where unnecessary retries to install something can result in errors.
This also required a Clojure upgrade to 1.10.0. Later patch releases are not compatible with Jepsen.

The Jepsen upgrade had an odd and undocumented behavioral change where DB#teardown is called at the start of the test, presumably to clean up stuff from previous runs. However, both our dbs and jepsen-zookeeper fail if the db hasn't been setup yet. To save time we just catch exceptions that occur during the teardown, log them, and continue as if nothing happened.

I have run the tests locally to ensure they still pass.