### PR TITLE
 [FLINK-25190] Actively report the number of TaskManagers that have not yet been registered with JobManager

### DIFF
--- a/docs/content.zh/docs/ops/metrics.md
+++ b/docs/content.zh/docs/ops/metrics.md
@@ -1032,6 +1032,11 @@ Metrics related to data exchange between task executors using netty network comm
       <td>Gauge</td>
     </tr>
     <tr>
+      <td>numPendingTaskManagers</td>
+      <td>(only applicable to Native Kubernetes / YARN) The number of outstanding taskmanagers that Flink has requested.</td>
+      <td>Gauge</td>
+    </tr>
+    <tr>
       <td>numRunningJobs</td>
       <td>The number of running jobs.</td>
       <td>Gauge</td>

--- a/docs/content/docs/ops/metrics.md
+++ b/docs/content/docs/ops/metrics.md
@@ -1032,6 +1032,11 @@ Metrics related to data exchange between task executors using netty network comm
       <td>Gauge</td>
     </tr>
     <tr>
+      <td>numPendingTaskManagers</td>
+      <td>(only applicable to Native Kubernetes / YARN) The number of outstanding taskmanagers that Flink has requested.</td>
+      <td>Gauge</td>
+    </tr>
+    <tr>
       <td>numRunningJobs</td>
       <td>The number of running jobs.</td>
       <td>Gauge</td>

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/metrics/MetricNames.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/metrics/MetricNames.java
@@ -48,6 +48,7 @@ public class MetricNames {
     public static final String TASK_SLOTS_AVAILABLE = "taskSlotsAvailable";
     public static final String TASK_SLOTS_TOTAL = "taskSlotsTotal";
     public static final String NUM_REGISTERED_TASK_MANAGERS = "numRegisteredTaskManagers";
+    public static final String NUM_PENDING_TASK_MANAGERS = "numPendingTaskManagers";
 
     public static final String NUM_RESTARTS = "numRestarts";
 

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/resourcemanager/active/ActiveResourceManager.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/resourcemanager/active/ActiveResourceManager.java
@@ -220,6 +220,8 @@ public class ActiveResourceManager<WorkerType extends ResourceIDRetrievable>
         super.registerMetrics();
         resourceManagerMetricGroup.meter(
                 MetricNames.START_WORKER_FAILURE_RATE, startWorkerFailureRater);
+        resourceManagerMetricGroup.gauge(
+                MetricNames.NUM_PENDING_TASK_MANAGERS, pendingWorkerCounter::getTotalNum);
     }
 
     // ------------------------------------------------------------------------


### PR DESCRIPTION
## What is the purpose of the change

The number of TaskManagers whose status is Pending should be reported. In the case of insufficient resources, let the external sense as soon as possible.


## Brief change log

- Add indicator name numPendingTaskManagers
- Report the number of unregistered taskManagers after the worker registration is successful

## Does this pull request potentially affect one of the following parts:

  - Dependencies (does it add or upgrade a dependency): (no)
  - The public API, i.e., is any changed class annotated with `@Public(Evolving)`: (no)
  - The serializers: (yes / no / don't know)
  - The runtime per-record code paths (performance sensitive): (no)
  - Anything that affects deployment or recovery: JobManager (and its components), Checkpointing, Kubernetes/Yarn, ZooKeeper: (no)
  - The S3 file system connector: (no)

## Documentation

  - Does this pull request introduce a new feature? (no)
