### PR TITLE
[FLINK-25141][connector/elasticsearch][docs] Add sink parallelism option

### DIFF
--- a/docs/content.zh/docs/connectors/table/elasticsearch.md
+++ b/docs/content.zh/docs/connectors/table/elasticsearch.md
@@ -204,6 +204,13 @@ CREATE TABLE myUserTable (
       <td>每次回退尝试之间的延迟。对于 <code>CONSTANT</code> 回退策略，该值是每次重试之间的延迟。对于 <code>EXPONENTIAL</code> 回退策略，该值是初始的延迟。</td>
     </tr>
     <tr>
+      <td><h5>sink.parallelism</h5></td>
+      <td>可选</td>
+      <td style="word-wrap: break-word;">（无）</td>
+      <td>Integer</td>
+      <td>定义 Elasticsearch sink 算子的并行度。默认情况下，并行度由框架定义为与上游串联的算子相同。</td>
+    </tr>
+    <tr>
       <td><h5>connection.max-retry-timeout</h5></td>
       <td>可选</td>
       <td style="word-wrap: break-word;">(none)</td>

--- a/docs/content/docs/connectors/table/elasticsearch.md
+++ b/docs/content/docs/connectors/table/elasticsearch.md
@@ -191,6 +191,13 @@ Connector Options
       <td>Delay between each backoff attempt. For <code>CONSTANT</code> backoff, this is simply the delay between each retry. For <code>EXPONENTIAL</code> backoff, this is the initial base delay.</td>
     </tr>
     <tr>
+      <td><h5>sink.parallelism</h5></td>
+      <td>optional</td>
+      <td style="word-wrap: break-word;">(none)</td>
+      <td>Integer</td>
+      <td>Defines the parallelism of the Elasticsearch sink operator. By default, the parallelism is determined by the framework using the same parallelism of the upstream chained operator.</td>
+    </tr>
+    <tr>
       <td><h5>connection.path-prefix</h5></td>
       <td>optional</td>
       <td style="word-wrap: break-word;">(none)</td>

--- a/flink-connectors/flink-connector-elasticsearch-base/src/main/java/org/apache/flink/connector/elasticsearch/table/ElasticsearchConfiguration.java
+++ b/flink-connectors/flink-connector-elasticsearch-base/src/main/java/org/apache/flink/connector/elasticsearch/table/ElasticsearchConfiguration.java
@@ -48,6 +48,7 @@ import static org.apache.flink.connector.elasticsearch.table.ElasticsearchConnec
 import static org.apache.flink.connector.elasticsearch.table.ElasticsearchConnectorOptions.PASSWORD_OPTION;
 import static org.apache.flink.connector.elasticsearch.table.ElasticsearchConnectorOptions.SOCKET_TIMEOUT;
 import static org.apache.flink.connector.elasticsearch.table.ElasticsearchConnectorOptions.USERNAME_OPTION;
+import static org.apache.flink.table.factories.FactoryUtil.SINK_PARALLELISM;
 import static org.apache.flink.util.Preconditions.checkNotNull;
 
 /** Elasticsearch base configuration. */
@@ -123,6 +124,10 @@ class ElasticsearchConfiguration {
         return config.get(HOSTS_OPTION).stream()
                 .map(ElasticsearchConfiguration::validateAndParseHostsString)
                 .collect(Collectors.toList());
+    }
+
+    public Optional<Integer> getParallelism() {
+        return config.getOptional(SINK_PARALLELISM);
     }
 
     private static HttpHost validateAndParseHostsString(String host) {

--- a/flink-connectors/flink-connector-elasticsearch-base/src/main/java/org/apache/flink/connector/elasticsearch/table/ElasticsearchDynamicSink.java
+++ b/flink-connectors/flink-connector-elasticsearch-base/src/main/java/org/apache/flink/connector/elasticsearch/table/ElasticsearchDynamicSink.java
@@ -157,7 +157,7 @@ class ElasticsearchDynamicSink implements DynamicTableSink {
             builder.setSocketTimeout((int) config.getSocketTimeout().get().getSeconds());
         }
 
-        return SinkProvider.of(builder.build());
+        return SinkProvider.of(builder.build(), config.getParallelism().orElse(null));
     }
 
     @Override

--- a/flink-connectors/flink-connector-elasticsearch-base/src/main/java/org/apache/flink/connector/elasticsearch/table/ElasticsearchDynamicSinkFactoryBase.java
+++ b/flink-connectors/flink-connector-elasticsearch-base/src/main/java/org/apache/flink/connector/elasticsearch/table/ElasticsearchDynamicSinkFactoryBase.java
@@ -64,6 +64,7 @@ import static org.apache.flink.connector.elasticsearch.table.ElasticsearchConnec
 import static org.apache.flink.connector.elasticsearch.table.ElasticsearchConnectorOptions.PASSWORD_OPTION;
 import static org.apache.flink.connector.elasticsearch.table.ElasticsearchConnectorOptions.SOCKET_TIMEOUT;
 import static org.apache.flink.connector.elasticsearch.table.ElasticsearchConnectorOptions.USERNAME_OPTION;
+import static org.apache.flink.table.factories.FactoryUtil.SINK_PARALLELISM;
 import static org.apache.flink.util.Preconditions.checkNotNull;
 import static org.elasticsearch.common.Strings.capitalize;
 
@@ -218,7 +219,8 @@ abstract class ElasticsearchDynamicSinkFactoryBase implements DynamicTableSinkFa
                         FORMAT_OPTION,
                         DELIVERY_GUARANTEE_OPTION,
                         PASSWORD_OPTION,
-                        USERNAME_OPTION)
+                        USERNAME_OPTION,
+                        SINK_PARALLELISM)
                 .collect(Collectors.toSet());
     }
 

--- a/flink-connectors/flink-connector-elasticsearch-base/src/test/java/org/apache/flink/connector/elasticsearch/ElasticsearchUtil.java
+++ b/flink-connectors/flink-connector-elasticsearch-base/src/test/java/org/apache/flink/connector/elasticsearch/ElasticsearchUtil.java
@@ -19,6 +19,10 @@
 package org.apache.flink.connector.elasticsearch;
 
 import org.apache.flink.annotation.Internal;
+import org.apache.flink.api.common.typeinfo.TypeInformation;
+import org.apache.flink.table.connector.sink.DynamicTableSink;
+import org.apache.flink.table.types.DataType;
+import org.apache.flink.table.types.logical.LogicalType;
 
 import org.slf4j.Logger;
 import org.testcontainers.containers.output.Slf4jLogConsumer;
@@ -60,5 +64,29 @@ public class ElasticsearchUtil {
                 .withEnv("ES_JAVA_OPTS", "-Xms2g -Xmx2g")
                 .withEnv("logger.org.elasticsearch", logLevel)
                 .withLogConsumer(new Slf4jLogConsumer(log));
+    }
+
+    /** A mock {@link DynamicTableSink.Context} for Elasticsearch tests. */
+    public static class MockContext implements DynamicTableSink.Context {
+        @Override
+        public boolean isBounded() {
+            return false;
+        }
+
+        @Override
+        public TypeInformation<?> createTypeInformation(DataType consumedDataType) {
+            return null;
+        }
+
+        @Override
+        public TypeInformation<?> createTypeInformation(LogicalType consumedLogicalType) {
+            return null;
+        }
+
+        @Override
+        public DynamicTableSink.DataStructureConverter createDataStructureConverter(
+                DataType consumedDataType) {
+            return null;
+        }
     }
 }

--- a/flink-connectors/flink-connector-elasticsearch-base/src/test/java/org/apache/flink/connector/elasticsearch/table/ElasticsearchDynamicSinkBaseITCase.java
+++ b/flink-connectors/flink-connector-elasticsearch-base/src/test/java/org/apache/flink/connector/elasticsearch/table/ElasticsearchDynamicSinkBaseITCase.java
@@ -19,8 +19,8 @@
 package org.apache.flink.connector.elasticsearch.table;
 
 import org.apache.flink.api.common.time.Deadline;
-import org.apache.flink.api.common.typeinfo.TypeInformation;
 import org.apache.flink.api.connector.sink.Sink;
+import org.apache.flink.connector.elasticsearch.ElasticsearchUtil;
 import org.apache.flink.connectors.test.common.junit.extensions.TestLoggerExtension;
 import org.apache.flink.streaming.api.environment.StreamExecutionEnvironment;
 import org.apache.flink.table.api.DataTypes;
@@ -35,8 +35,6 @@ import org.apache.flink.table.data.GenericRowData;
 import org.apache.flink.table.data.RowData;
 import org.apache.flink.table.data.StringData;
 import org.apache.flink.table.data.TimestampData;
-import org.apache.flink.table.types.DataType;
-import org.apache.flink.table.types.logical.LogicalType;
 import org.apache.flink.types.RowKind;
 
 import org.apache.http.HttpHost;
@@ -117,7 +115,7 @@ abstract class ElasticsearchDynamicSinkBaseITCase {
                 sinkFactory
                         .createDynamicTableSink(
                                 getPrefilledTestContext(index).withSchema(schema).build())
-                        .getSinkRuntimeProvider(new MockContext());
+                        .getSinkRuntimeProvider(new ElasticsearchUtil.MockContext());
 
         final SinkProvider sinkProvider = (SinkProvider) runtimeProvider;
         final Sink<RowData, ?, ?, ?> sink = sinkProvider.createSink();
@@ -300,28 +298,5 @@ abstract class ElasticsearchDynamicSinkBaseITCase {
         expectedMap.put("a", 1);
         expectedMap.put("b", "2012-12-12 12:12:12");
         Assertions.assertEquals(response, expectedMap);
-    }
-
-    private static class MockContext implements DynamicTableSink.Context {
-        @Override
-        public boolean isBounded() {
-            return false;
-        }
-
-        @Override
-        public TypeInformation<?> createTypeInformation(DataType consumedDataType) {
-            return null;
-        }
-
-        @Override
-        public TypeInformation<?> createTypeInformation(LogicalType consumedLogicalType) {
-            return null;
-        }
-
-        @Override
-        public DynamicTableSink.DataStructureConverter createDataStructureConverter(
-                DataType consumedDataType) {
-            return null;
-        }
     }
 }

--- a/flink-connectors/flink-connector-elasticsearch-base/src/test/java/org/apache/flink/connector/elasticsearch/table/ElasticsearchDynamicSinkFactoryBaseTest.java
+++ b/flink-connectors/flink-connector-elasticsearch-base/src/test/java/org/apache/flink/connector/elasticsearch/table/ElasticsearchDynamicSinkFactoryBaseTest.java
@@ -19,12 +19,15 @@
 package org.apache.flink.connector.elasticsearch.table;
 
 import org.apache.flink.api.common.typeutils.base.VoidSerializer;
+import org.apache.flink.connector.elasticsearch.ElasticsearchUtil;
 import org.apache.flink.connectors.test.common.junit.extensions.TestLoggerExtension;
 import org.apache.flink.table.api.DataTypes;
 import org.apache.flink.table.api.ValidationException;
 import org.apache.flink.table.catalog.Column;
 import org.apache.flink.table.catalog.ResolvedSchema;
 import org.apache.flink.table.catalog.UniqueConstraint;
+import org.apache.flink.table.connector.sink.DynamicTableSink;
+import org.apache.flink.table.connector.sink.SinkProvider;
 
 import org.junit.jupiter.api.Assertions;
 import org.junit.jupiter.api.Test;
@@ -33,6 +36,9 @@ import org.junit.jupiter.api.function.Executable;
 
 import java.util.Arrays;
 import java.util.Collections;
+
+import static org.apache.flink.table.factories.FactoryUtil.SINK_PARALLELISM;
+import static org.assertj.core.api.Assertions.assertThat;
 
 /** Tests for validation in {@link ElasticsearchDynamicSinkFactoryBase}. */
 @ExtendWith(TestLoggerExtension.class)
@@ -226,5 +232,20 @@ abstract class ElasticsearchDynamicSinkFactoryBaseTest {
                                                 ElasticsearchConnectorOptions.PASSWORD_OPTION.key(),
                                                 "")
                                         .build()));
+    }
+
+    @Test
+    public void testSinkParallelism() {
+        ElasticsearchDynamicSinkFactoryBase sinkFactory = createSinkFactory();
+        DynamicTableSink sink =
+                sinkFactory.createDynamicTableSink(
+                        createPrefilledTestContext()
+                                .withOption(SINK_PARALLELISM.key(), "2")
+                                .build());
+        assertThat(sink).isInstanceOf(ElasticsearchDynamicSink.class);
+        ElasticsearchDynamicSink esSink = (ElasticsearchDynamicSink) sink;
+        SinkProvider provider =
+                (SinkProvider) esSink.getSinkRuntimeProvider(new ElasticsearchUtil.MockContext());
+        assertThat(2).isEqualTo(provider.getParallelism().get());
     }
 }


### PR DESCRIPTION
## What is the purpose of the change

add sink parallelism option in Elasticsearch connector.

## Brief change log

 - Inspired by JDBC and Kafka connector, add a 'sink.parallelism' option, and using SinkProvider#of(sink, sinkParallelism) to set parallelism.

## Verifying this change

This change added tests and can be verified as follows:
  - *Added test that validates that parallelism option is valid*

## Does this pull request potentially affect one of the following parts:

  - Dependencies (does it add or upgrade a dependency): (yes)
  - The public API, i.e., is any changed class annotated with `@Public(Evolving)`: (no)
  - The serializers: (no)
  - The runtime per-record code paths (performance sensitive): (no)
  - Anything that affects deployment or recovery: JobManager (and its components), Checkpointing, Kubernetes/Yarn, ZooKeeper: (no)
  - The S3 file system connector: (no)

## Documentation

  - Does this pull request introduce a new feature? (yes)
  - If yes, how is the feature documented? (docs)
