### PR TITLE
[BP-1.13][FLINK-25096] Fixes empty exception history for JobInitializationException

### DIFF
--- a/flink-runtime/src/main/java/org/apache/flink/runtime/scheduler/ExecutionGraphInfo.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/scheduler/ExecutionGraphInfo.java
@@ -38,7 +38,13 @@ public class ExecutionGraphInfo implements Serializable {
     private final Iterable<RootExceptionHistoryEntry> exceptionHistory;
 
     public ExecutionGraphInfo(ArchivedExecutionGraph executionGraph) {
-        this(executionGraph, Collections.emptyList());
+        this(
+                executionGraph,
+                executionGraph.getFailureInfo() != null
+                        ? Collections.singleton(
+                                RootExceptionHistoryEntry.fromGlobalFailure(
+                                        executionGraph.getFailureInfo()))
+                        : Collections.emptyList());
     }
 
     public ExecutionGraphInfo(

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/scheduler/exceptionhistory/RootExceptionHistoryEntry.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/scheduler/exceptionhistory/RootExceptionHistoryEntry.java
@@ -19,11 +19,14 @@
 package org.apache.flink.runtime.scheduler.exceptionhistory;
 
 import org.apache.flink.annotation.VisibleForTesting;
+import org.apache.flink.runtime.executiongraph.ErrorInfo;
 import org.apache.flink.runtime.executiongraph.Execution;
 import org.apache.flink.runtime.taskmanager.TaskManagerLocation;
+import org.apache.flink.util.Preconditions;
 
 import javax.annotation.Nullable;
 
+import java.util.Collections;
 import java.util.Set;
 import java.util.stream.Collectors;
 import java.util.stream.StreamSupport;
@@ -82,6 +85,24 @@ public class RootExceptionHistoryEntry extends ExceptionHistoryEntry {
     public static RootExceptionHistoryEntry fromGlobalFailure(
             Throwable cause, long timestamp, Iterable<Execution> executions) {
         return createRootExceptionHistoryEntry(cause, timestamp, null, null, executions);
+    }
+
+    /**
+     * Creates a {@code RootExceptionHistoryEntry} based on the passed {@link ErrorInfo}. No
+     * concurrent failures will be added.
+     *
+     * @param errorInfo The failure information that shall be used to initialize the {@code
+     *     RootExceptionHistoryEntry}.
+     * @return The {@code RootExceptionHistoryEntry} instance.
+     * @throws NullPointerException if {@code errorInfo} is {@code null} or the passed info does not
+     *     contain a {@code Throwable}.
+     * @throws IllegalArgumentException if the passed {@code timestamp} is not bigger than {@code
+     *     0}.
+     */
+    public static RootExceptionHistoryEntry fromGlobalFailure(ErrorInfo errorInfo) {
+        Preconditions.checkNotNull(errorInfo, "errorInfo");
+        return fromGlobalFailure(
+                errorInfo.getException(), errorInfo.getTimestamp(), Collections.emptyList());
     }
 
     private static RootExceptionHistoryEntry createRootExceptionHistoryEntry(

--- a/flink-runtime/src/test/java/org/apache/flink/runtime/scheduler/ExecutionGraphInfoTest.java
+++ b/flink-runtime/src/test/java/org/apache/flink/runtime/scheduler/ExecutionGraphInfoTest.java
@@ -1,0 +1,66 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.flink.runtime.scheduler;
+
+import org.apache.flink.api.common.JobID;
+import org.apache.flink.api.common.JobStatus;
+import org.apache.flink.runtime.executiongraph.ArchivedExecutionGraph;
+import org.apache.flink.runtime.executiongraph.ErrorInfo;
+import org.apache.flink.runtime.scheduler.exceptionhistory.RootExceptionHistoryEntry;
+
+import org.apache.flink.shaded.guava18.com.google.common.collect.Iterables;
+
+import org.junit.Test;
+
+import static org.hamcrest.CoreMatchers.is;
+import static org.hamcrest.CoreMatchers.notNullValue;
+import static org.hamcrest.CoreMatchers.nullValue;
+import static org.hamcrest.MatcherAssert.assertThat;
+
+/** {@code ExecutionGraphInfoTest} tests the proper initialization of {@link ExecutionGraphInfo}. */
+public class ExecutionGraphInfoTest {
+
+    @Test
+    public void testExecutionGraphHistoryBeingDerivedFromFailedExecutionGraph() {
+        final ArchivedExecutionGraph executionGraph =
+                ArchivedExecutionGraph.createFromInitializingJob(
+                        new JobID(),
+                        "test job name",
+                        JobStatus.FAILED,
+                        new RuntimeException("Expected RuntimeException"),
+                        null,
+                        System.currentTimeMillis());
+
+        final ExecutionGraphInfo executionGraphInfo = new ExecutionGraphInfo(executionGraph);
+
+        final ErrorInfo failureInfo =
+                executionGraphInfo.getArchivedExecutionGraph().getFailureInfo();
+
+        final RootExceptionHistoryEntry actualEntry =
+                Iterables.getOnlyElement(executionGraphInfo.getExceptionHistory());
+
+        assertThat(failureInfo, is(notNullValue()));
+        assertThat(failureInfo.getException(), is(actualEntry.getException()));
+        assertThat(failureInfo.getTimestamp(), is(actualEntry.getTimestamp()));
+
+        assertThat(actualEntry.isGlobal(), is(true));
+        assertThat(actualEntry.getFailingTaskName(), is(nullValue()));
+        assertThat(actualEntry.getTaskManagerLocation(), is(nullValue()));
+    }
+}


### PR DESCRIPTION
1.13 Backport for #17967 

I cherry-picked [7ac7db2](https://github.com/apache/flink/commit/7ac7db2966f39a281692b6cf8c48700b7173bcc9) from the corresponding 1.14 backport PR #18035 but still had to fix some imports (junit4 instead of junit5, guava18 instead of guava30)
