### PR TITLE
[FLINK-25179] Add document for composite types support for parquet

### DIFF
--- a/docs/content.zh/docs/connectors/table/formats/parquet.md
+++ b/docs/content.zh/docs/connectors/table/formats/parquet.md
@@ -174,7 +174,22 @@ Parquet 格式也支持 [ParquetOutputFormat](https://www.javadoc.io/doc/org.apa
       <td>INT96</td>
       <td></td>
     </tr>
+    <tr>
+      <td>ARRAY</td>
+      <td></td>
+      <td>LIST</td>
+    </tr>
+    <tr>
+      <td>MAP</td>
+      <td></td>
+      <td>MAP</td>
+    </tr>
+    <tr>
+      <td>ROW</td>
+      <td></td>
+      <td>STRUCT</td>
+    </tr>
     </tbody>
 </table>
 
-<span class="label label-danger">注意</span> 暂不支持复合数据类型（Array、Map 与 Row）。
+<span class="label label-danger">注意</span> 复合数据类型暂只支持写不支持读（Array、Map 与 Row）。

--- a/docs/content/docs/connectors/table/formats/parquet.md
+++ b/docs/content/docs/connectors/table/formats/parquet.md
@@ -174,9 +174,24 @@ The following table lists the type mapping from Flink type to Parquet type.
       <td>INT96</td>
       <td></td>
     </tr>
+    <tr>
+      <td>ARRAY</td>
+      <td></td>
+      <td>LIST</td>
+    </tr>
+    <tr>
+      <td>MAP</td>
+      <td></td>
+      <td>MAP</td>
+    </tr>
+    <tr>
+      <td>ROW</td>
+      <td></td>
+      <td>STRUCT</td>
+    </tr>
     </tbody>
 </table>
 
 {{< hint warning >}}
-Composite data type: Array, Map and Row are not supported.
+Composite data type: Array, Map and Row are currently only supported when writing, not reading.
 {{< /hint >}}


### PR DESCRIPTION
## What is the purpose of the change

Add document for array,map,row types support for parquet row writer.

## Does this pull request potentially affect one of the following parts:

  - Dependencies (does it add or upgrade a dependency): (yes / **no**)
  - The public API, i.e., is any changed class annotated with `@Public(Evolving)`: (yes / **no**)
  - The serializers: (yes / **no** / don't know)
  - The runtime per-record code paths (performance sensitive): (yes / **no** / don't know)
  - Anything that affects deployment or recovery: JobManager (and its components), Checkpointing, Kubernetes/Yarn, ZooKeeper: (yes / **no** / don't know)
  - The S3 file system connector: (yes / **no** / don't know)

## Documentation

  - Does this pull request introduce a new feature? (yes / **no**)