### PR TITLE
[FLINK-25157][table-planner] Introduce NullToStringCastRule

### DIFF
--- a/flink-table/flink-table-planner/src/main/java/org/apache/flink/table/planner/functions/casting/AbstractNullAwareCodeGeneratorCastRule.java
+++ b/flink-table/flink-table-planner/src/main/java/org/apache/flink/table/planner/functions/casting/AbstractNullAwareCodeGeneratorCastRule.java
@@ -91,6 +91,6 @@ abstract class AbstractNullAwareCodeGeneratorCastRule<IN, OUT>
             writer.appendBlock(castCodeBlock);
         }
 
-        return new CastCodeBlock(writer.toString(), returnTerm, nullTerm);
+        return CastCodeBlock.withCode(writer.toString(), returnTerm, nullTerm);
     }
 }

--- a/flink-table/flink-table-planner/src/main/java/org/apache/flink/table/planner/functions/casting/CastCodeBlock.java
+++ b/flink-table/flink-table-planner/src/main/java/org/apache/flink/table/planner/functions/casting/CastCodeBlock.java
@@ -36,10 +36,18 @@ public class CastCodeBlock {
     private final String returnTerm;
     private final String isNullTerm;
 
-    public CastCodeBlock(String code, String returnTerm, String isNullTerm) {
+    private CastCodeBlock(String code, String returnTerm, String isNullTerm) {
         this.code = code;
         this.returnTerm = returnTerm;
         this.isNullTerm = isNullTerm;
+    }
+
+    public static CastCodeBlock withoutCode(String returnTerm, String isNullTerm) {
+        return new CastCodeBlock("", returnTerm, isNullTerm);
+    }
+
+    public static CastCodeBlock withCode(String code, String returnTerm, String isNullTerm) {
+        return new CastCodeBlock(code, returnTerm, isNullTerm);
     }
 
     public String getCode() {

--- a/flink-table/flink-table-planner/src/main/java/org/apache/flink/table/planner/functions/casting/CastRuleProvider.java
+++ b/flink-table/flink-table-planner/src/main/java/org/apache/flink/table/planner/functions/casting/CastRuleProvider.java
@@ -78,6 +78,7 @@ public class CastRuleProvider {
                 .addRule(ArrayToArrayCastRule.INSTANCE)
                 .addRule(RowToRowCastRule.INSTANCE)
                 // Special rules
+                .addRule(NullToStringCastRule.INSTANCE)
                 .addRule(IdentityCastRule.INSTANCE);
     }
 

--- a/flink-table/flink-table-planner/src/main/java/org/apache/flink/table/planner/functions/casting/IdentityCastRule.java
+++ b/flink-table/flink-table-planner/src/main/java/org/apache/flink/table/planner/functions/casting/IdentityCastRule.java
@@ -80,6 +80,6 @@ class IdentityCastRule extends AbstractCodeGeneratorCastRule<Object, Object>
             String inputIsNullTerm,
             LogicalType inputLogicalType,
             LogicalType targetLogicalType) {
-        return new CastCodeBlock("", inputTerm, inputIsNullTerm);
+        return CastCodeBlock.withoutCode(inputTerm, inputIsNullTerm);
     }
 }

--- a/flink-table/flink-table-planner/src/main/java/org/apache/flink/table/planner/functions/casting/NullToStringCastRule.java
+++ b/flink-table/flink-table-planner/src/main/java/org/apache/flink/table/planner/functions/casting/NullToStringCastRule.java
@@ -46,7 +46,7 @@ class NullToStringCastRule extends AbstractCodeGeneratorCastRule<Object, StringD
             String inputIsNullTerm,
             LogicalType inputLogicalType,
             LogicalType targetLogicalType) {
-        return new CastCodeBlock(
-                "", accessStaticField(BinaryStringDataUtil.class, "NULL_STR"), "false");
+        return CastCodeBlock.withoutCode(
+                accessStaticField(BinaryStringDataUtil.class, "NULL_STRING"), "false");
     }
 }

--- a/flink-table/flink-table-planner/src/main/java/org/apache/flink/table/planner/functions/casting/NullToStringCastRule.java
+++ b/flink-table/flink-table-planner/src/main/java/org/apache/flink/table/planner/functions/casting/NullToStringCastRule.java
@@ -1,0 +1,52 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.flink.table.planner.functions.casting;
+
+import org.apache.flink.table.data.StringData;
+import org.apache.flink.table.data.binary.BinaryStringDataUtil;
+import org.apache.flink.table.types.logical.LogicalType;
+import org.apache.flink.table.types.logical.LogicalTypeFamily;
+import org.apache.flink.table.types.logical.LogicalTypeRoot;
+
+import static org.apache.flink.table.planner.functions.casting.CastRuleUtils.accessStaticField;
+
+/** {@link LogicalTypeRoot#NULL} to {@link LogicalTypeFamily#CHARACTER_STRING} cast rule. */
+class NullToStringCastRule extends AbstractCodeGeneratorCastRule<Object, StringData> {
+
+    static final NullToStringCastRule INSTANCE = new NullToStringCastRule();
+
+    private NullToStringCastRule() {
+        super(
+                CastRulePredicate.builder()
+                        .input(LogicalTypeRoot.NULL)
+                        .target(LogicalTypeFamily.CHARACTER_STRING)
+                        .build());
+    }
+
+    @Override
+    public CastCodeBlock generateCodeBlock(
+            CodeGeneratorCastRule.Context context,
+            String inputTerm,
+            String inputIsNullTerm,
+            LogicalType inputLogicalType,
+            LogicalType targetLogicalType) {
+        return new CastCodeBlock(
+                "", accessStaticField(BinaryStringDataUtil.class, "NULL_STR"), "false");
+    }
+}

--- a/flink-table/flink-table-planner/src/test/java/org/apache/flink/table/planner/functions/casting/CastRulesTest.java
+++ b/flink-table/flink-table-planner/src/test/java/org/apache/flink/table/planner/functions/casting/CastRulesTest.java
@@ -30,6 +30,7 @@ import org.apache.flink.table.data.StringData;
 import org.apache.flink.table.data.TimestampData;
 import org.apache.flink.table.data.conversion.DataStructureConverter;
 import org.apache.flink.table.data.conversion.DataStructureConverters;
+import org.apache.flink.table.data.binary.BinaryStringDataUtil;
 import org.apache.flink.table.data.utils.CastExecutor;
 import org.apache.flink.table.planner.functions.CastFunctionITCase;
 import org.apache.flink.table.types.DataType;
@@ -71,6 +72,7 @@ import static org.apache.flink.table.api.DataTypes.INTERVAL;
 import static org.apache.flink.table.api.DataTypes.MAP;
 import static org.apache.flink.table.api.DataTypes.MONTH;
 import static org.apache.flink.table.api.DataTypes.MULTISET;
+import static org.apache.flink.table.api.DataTypes.NULL;
 import static org.apache.flink.table.api.DataTypes.RAW;
 import static org.apache.flink.table.api.DataTypes.ROW;
 import static org.apache.flink.table.api.DataTypes.SECOND;
@@ -477,6 +479,7 @@ class CastRulesTest {
                                                 .toInstant())),
                 CastTestSpecBuilder.testCastTo(STRING())
                         .fromCase(STRING(), null, null)
+                        .fromCase(NULL(), null, BinaryStringDataUtil.NULL_STR)
                         .fromCase(CHAR(3), fromString("foo"), fromString("foo"))
                         .fromCase(VARCHAR(5), fromString("Flink"), fromString("Flink"))
                         .fromCase(VARCHAR(10), fromString("Flink"), fromString("Flink"))

--- a/flink-table/flink-table-planner/src/test/java/org/apache/flink/table/planner/functions/casting/CastRulesTest.java
+++ b/flink-table/flink-table-planner/src/test/java/org/apache/flink/table/planner/functions/casting/CastRulesTest.java
@@ -28,9 +28,9 @@ import org.apache.flink.table.data.RawValueData;
 import org.apache.flink.table.data.RowData;
 import org.apache.flink.table.data.StringData;
 import org.apache.flink.table.data.TimestampData;
+import org.apache.flink.table.data.binary.BinaryStringDataUtil;
 import org.apache.flink.table.data.conversion.DataStructureConverter;
 import org.apache.flink.table.data.conversion.DataStructureConverters;
-import org.apache.flink.table.data.binary.BinaryStringDataUtil;
 import org.apache.flink.table.data.utils.CastExecutor;
 import org.apache.flink.table.planner.functions.CastFunctionITCase;
 import org.apache.flink.table.types.DataType;
@@ -479,7 +479,7 @@ class CastRulesTest {
                                                 .toInstant())),
                 CastTestSpecBuilder.testCastTo(STRING())
                         .fromCase(STRING(), null, null)
-                        .fromCase(NULL(), null, BinaryStringDataUtil.NULL_STR)
+                        .fromCase(NULL(), null, BinaryStringDataUtil.NULL_STRING)
                         .fromCase(CHAR(3), fromString("foo"), fromString("foo"))
                         .fromCase(VARCHAR(5), fromString("Flink"), fromString("Flink"))
                         .fromCase(VARCHAR(10), fromString("Flink"), fromString("Flink"))

--- a/flink-table/flink-table-runtime/src/main/java/org/apache/flink/table/data/binary/BinaryStringDataUtil.java
+++ b/flink-table/flink-table-runtime/src/main/java/org/apache/flink/table/data/binary/BinaryStringDataUtil.java
@@ -49,7 +49,7 @@ import static org.apache.flink.table.data.binary.BinaryStringData.numBytesForFir
 /** Util for {@link BinaryStringData}. */
 public class BinaryStringDataUtil {
 
-    public static final BinaryStringData NULL_STR = fromString("NULL");
+    public static final BinaryStringData NULL_STRING = fromString("NULL");
 
     public static final BinaryStringData[] EMPTY_STRING_ARRAY = new BinaryStringData[0];
     private static final List<BinaryStringData> TRUE_STRINGS =

--- a/flink-table/flink-table-runtime/src/main/java/org/apache/flink/table/data/binary/BinaryStringDataUtil.java
+++ b/flink-table/flink-table-runtime/src/main/java/org/apache/flink/table/data/binary/BinaryStringDataUtil.java
@@ -49,6 +49,8 @@ import static org.apache.flink.table.data.binary.BinaryStringData.numBytesForFir
 /** Util for {@link BinaryStringData}. */
 public class BinaryStringDataUtil {
 
+    public static final BinaryStringData NULL_STR = fromString("NULL");
+
     public static final BinaryStringData[] EMPTY_STRING_ARRAY = new BinaryStringData[0];
     private static final List<BinaryStringData> TRUE_STRINGS =
             Stream.of("t", "true", "y", "yes", "1")


### PR DESCRIPTION
## What is the purpose of the change

Introduce `NullToStringCastRule` to cast NULL to STRING


## Brief change log

* Introduce `NullToStringCastRule` to cast NULL to STRING


## Verifying this change

Added a test case in `CastRulesTest`.

## Does this pull request potentially affect one of the following parts:

  - Dependencies (does it add or upgrade a dependency): no
  - The public API, i.e., is any changed class annotated with `@Public(Evolving)`: no
  - The serializers: no
  - The runtime per-record code paths (performance sensitive): no
  - Anything that affects deployment or recovery: JobManager (and its components), Checkpointing, Kubernetes/Yarn, ZooKeeper: no
  - The S3 file system connector: no

## Documentation

  - Does this pull request introduce a new feature? no
  - If yes, how is the feature documented? not applicable
