### PR TITLE
[FLINK-24372][connectors/elasticsearch] Deprecate old (pre FLIP-143) Elasticsearch connector

### DIFF
--- a/flink-connectors/flink-connector-elasticsearch-base/src/main/java/org/apache/flink/streaming/connectors/elasticsearch/ActionRequestFailureHandler.java
+++ b/flink-connectors/flink-connector-elasticsearch-base/src/main/java/org/apache/flink/streaming/connectors/elasticsearch/ActionRequestFailureHandler.java
@@ -59,7 +59,10 @@ import java.io.Serializable;
  * exact type could not be retrieved through the older version Java client APIs (thus, the types
  * will be general {@link Exception}s and only differ in the failure message). In this case, it is
  * recommended to match on the provided REST status code.
+ *
+ * @deprecated This has been deprecated and will be removed in the future.
  */
+@Deprecated
 @PublicEvolving
 public interface ActionRequestFailureHandler extends Serializable {
 

--- a/flink-connectors/flink-connector-elasticsearch-base/src/main/java/org/apache/flink/streaming/connectors/elasticsearch/ElasticsearchSinkFunction.java
+++ b/flink-connectors/flink-connector-elasticsearch-base/src/main/java/org/apache/flink/streaming/connectors/elasticsearch/ElasticsearchSinkFunction.java
@@ -56,7 +56,9 @@ import java.io.Serializable;
  * }</pre>
  *
  * @param <T> The type of the element handled by this {@code ElasticsearchSinkFunction}
+ * @deprecated This has been deprecated and will be removed in the future.
  */
+@Deprecated
 @PublicEvolving
 public interface ElasticsearchSinkFunction<T> extends Serializable, Function {
 

--- a/flink-connectors/flink-connector-elasticsearch-base/src/main/java/org/apache/flink/streaming/connectors/elasticsearch/RequestIndexer.java
+++ b/flink-connectors/flink-connector-elasticsearch-base/src/main/java/org/apache/flink/streaming/connectors/elasticsearch/RequestIndexer.java
@@ -28,7 +28,10 @@ import org.elasticsearch.action.update.UpdateRequest;
 /**
  * Users add multiple delete, index or update requests to a {@link RequestIndexer} to prepare them
  * for sending to an Elasticsearch cluster.
+ *
+ * @deprecated This has been deprecated and will be removed in the future.
  */
+@Deprecated
 @PublicEvolving
 public interface RequestIndexer {
 

--- a/flink-connectors/flink-connector-elasticsearch-base/src/main/java/org/apache/flink/streaming/connectors/elasticsearch/util/RetryRejectedExecutionFailureHandler.java
+++ b/flink-connectors/flink-connector-elasticsearch-base/src/main/java/org/apache/flink/streaming/connectors/elasticsearch/util/RetryRejectedExecutionFailureHandler.java
@@ -32,7 +32,10 @@ import org.slf4j.LoggerFactory;
  * An {@link ActionRequestFailureHandler} that re-adds requests that failed due to temporary {@link
  * EsRejectedExecutionException}s (which means that Elasticsearch node queues are currently full),
  * and fails for all other failures.
+ *
+ * @deprecated This hase been deprecated and will be removed in the future.
  */
+@Deprecated
 @PublicEvolving
 public class RetryRejectedExecutionFailureHandler implements ActionRequestFailureHandler {
 

--- a/flink-connectors/flink-connector-elasticsearch6/src/main/java/org/apache/flink/streaming/connectors/elasticsearch6/ElasticsearchSink.java
+++ b/flink-connectors/flink-connector-elasticsearch6/src/main/java/org/apache/flink/streaming/connectors/elasticsearch6/ElasticsearchSink.java
@@ -58,7 +58,10 @@ import java.util.Objects;
  * of {@link ElasticsearchSinkFunction} for an example.
  *
  * @param <T> Type of the elements handled by this sink
+ * @deprecated This sink has been deprecated in favor of {@link
+ *     org.apache.flink.connector.elasticsearch.sink.ElasticsearchSink}
  */
+@Deprecated
 @PublicEvolving
 public class ElasticsearchSink<T> extends ElasticsearchSinkBase<T, RestHighLevelClient> {
 
@@ -82,7 +85,10 @@ public class ElasticsearchSink<T> extends ElasticsearchSinkBase<T, RestHighLevel
      * A builder for creating an {@link ElasticsearchSink}.
      *
      * @param <T> Type of the elements handled by the sink this builder creates.
+     * @deprecated This has been deprecated, please use {@link
+     *     org.apache.flink.connector.elasticsearch.sink.Elasticsearch6SinkBuilder}.
      */
+    @Deprecated
     @PublicEvolving
     public static class Builder<T> {
 

--- a/flink-connectors/flink-connector-elasticsearch6/src/main/java/org/apache/flink/streaming/connectors/elasticsearch6/RestClientFactory.java
+++ b/flink-connectors/flink-connector-elasticsearch6/src/main/java/org/apache/flink/streaming/connectors/elasticsearch6/RestClientFactory.java
@@ -26,7 +26,10 @@ import java.io.Serializable;
 /**
  * A factory that is used to configure the {@link org.elasticsearch.client.RestHighLevelClient}
  * internally used in the {@link ElasticsearchSink}.
+ *
+ * @deprecated This has been deprecated and will be removed in the future.
  */
+@Deprecated
 @PublicEvolving
 public interface RestClientFactory extends Serializable {
 

--- a/flink-connectors/flink-connector-elasticsearch7/src/main/java/org/apache/flink/streaming/connectors/elasticsearch7/ElasticsearchSink.java
+++ b/flink-connectors/flink-connector-elasticsearch7/src/main/java/org/apache/flink/streaming/connectors/elasticsearch7/ElasticsearchSink.java
@@ -58,7 +58,10 @@ import java.util.Objects;
  * of {@link ElasticsearchSinkFunction} for an example.
  *
  * @param <T> Type of the elements handled by this sink
+ * @deprecated This sink has been deprecated in favor of {@link
+ *     org.apache.flink.connector.elasticsearch.sink.ElasticsearchSink}
  */
+@Deprecated
 @PublicEvolving
 public class ElasticsearchSink<T> extends ElasticsearchSinkBase<T, RestHighLevelClient> {
 
@@ -82,7 +85,10 @@ public class ElasticsearchSink<T> extends ElasticsearchSinkBase<T, RestHighLevel
      * A builder for creating an {@link ElasticsearchSink}.
      *
      * @param <T> Type of the elements handled by the sink this builder creates.
+     * @deprecated This has been deprecated, please use {@link
+     *     org.apache.flink.connector.elasticsearch.sink.Elasticsearch7SinkBuilder}.
      */
+    @Deprecated
     @PublicEvolving
     public static class Builder<T> {
 

--- a/flink-connectors/flink-connector-elasticsearch7/src/main/java/org/apache/flink/streaming/connectors/elasticsearch7/RestClientFactory.java
+++ b/flink-connectors/flink-connector-elasticsearch7/src/main/java/org/apache/flink/streaming/connectors/elasticsearch7/RestClientFactory.java
@@ -26,7 +26,10 @@ import java.io.Serializable;
 /**
  * A factory that is used to configure the {@link org.elasticsearch.client.RestHighLevelClient}
  * internally used in the {@link ElasticsearchSink}.
+ *
+ * @deprecated This has been deprecated and will be removed in the future.
  */
+@Deprecated
 @PublicEvolving
 public interface RestClientFactory extends Serializable {
 


### PR DESCRIPTION
## What is the purpose of the change

This pull request deprecates the old Elasticsearch connectors in favor of the new, FLIP-143 compliant one

## Verifying this change

This change is a trivial rework / code cleanup without any test coverage.

## Does this pull request potentially affect one of the following parts:

  - Dependencies (does it add or upgrade a dependency): (yes / **no**)
  - The public API, i.e., is any changed class annotated with `@Public(Evolving)`: (**yes** / no)
  - The serializers: (yes / **no** / don't know)
  - The runtime per-record code paths (performance sensitive): (yes / **no** / don't know)
  - Anything that affects deployment or recovery: JobManager (and its components), Checkpointing, Kubernetes/Yarn, ZooKeeper: (yes / **no** / don't know)
  - The S3 file system connector: (yes / **no** / don't know)

## Documentation

  - Does this pull request introduce a new feature? (yes / **no**)
  - If yes, how is the feature documented? (not applicable / docs / **JavaDocs** / not documented)
