### PR TITLE
[FLINK-25206] Add configuration option to disable configuration in user programs

### DIFF
--- a/docs/layouts/shortcodes/generated/deployment_configuration.html
+++ b/docs/layouts/shortcodes/generated/deployment_configuration.html
@@ -9,6 +9,12 @@
     </thead>
     <tbody>
         <tr>
+            <td><h5>execution.allow-client-job-configurations</h5></td>
+            <td style="word-wrap: break-word;">true</td>
+            <td>Boolean</td>
+            <td>Determines whether configurations in the user program are allowed when running with Application mode. Has no effect for other deployment modes.</td>
+        </tr>
+        <tr>
             <td><h5>execution.attached</h5></td>
             <td style="word-wrap: break-word;">false</td>
             <td>Boolean</td>

--- a/flink-clients/src/main/java/org/apache/flink/client/program/MutatedConfigurationException.java
+++ b/flink-clients/src/main/java/org/apache/flink/client/program/MutatedConfigurationException.java
@@ -1,0 +1,38 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.flink.client.program;
+
+import org.apache.flink.annotation.Internal;
+
+import java.util.Collection;
+
+/**
+ * If {@link org.apache.flink.configuration.DeploymentOptions#ALLOW_CLIENT_JOB_CONFIGURATIONS} is
+ * disabled configurations in the user jar will throw this exception.
+ */
+@Internal
+public class MutatedConfigurationException extends Exception {
+
+    /** Serial version UID for serialization interoperability. */
+    private static final long serialVersionUID = -2417524218857151612L;
+
+    public MutatedConfigurationException(Collection<String> errorMessages) {
+        super(String.join("\n", errorMessages));
+    }
+}

--- a/flink-clients/src/main/java/org/apache/flink/client/program/StreamContextEnvironment.java
+++ b/flink-clients/src/main/java/org/apache/flink/client/program/StreamContextEnvironment.java
@@ -17,6 +17,7 @@
 
 package org.apache.flink.client.program;
 
+import org.apache.flink.annotation.Internal;
 import org.apache.flink.annotation.PublicEvolving;
 import org.apache.flink.api.common.JobExecutionResult;
 import org.apache.flink.api.java.ExecutionEnvironment;
@@ -26,6 +27,7 @@ import org.apache.flink.core.execution.DetachedJobExecutionResult;
 import org.apache.flink.core.execution.JobClient;
 import org.apache.flink.core.execution.JobListener;
 import org.apache.flink.core.execution.PipelineExecutorServiceLoader;
+import org.apache.flink.runtime.dispatcher.ConfigurationNotAllowedMessage;
 import org.apache.flink.streaming.api.environment.StreamExecutionEnvironment;
 import org.apache.flink.streaming.api.environment.StreamExecutionEnvironmentFactory;
 import org.apache.flink.streaming.api.graph.StreamGraph;
@@ -33,9 +35,20 @@ import org.apache.flink.util.ExceptionUtils;
 import org.apache.flink.util.FlinkRuntimeException;
 import org.apache.flink.util.ShutdownHookUtil;
 
+import org.apache.flink.shaded.guava30.com.google.common.collect.MapDifference;
+import org.apache.flink.shaded.guava30.com.google.common.collect.Maps;
+
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
+import java.io.ByteArrayOutputStream;
+import java.io.IOException;
+import java.io.ObjectOutputStream;
+import java.io.Serializable;
+import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.Collection;
+import java.util.Collections;
 import java.util.List;
 import java.util.concurrent.CompletableFuture;
 import java.util.concurrent.TimeUnit;
@@ -55,8 +68,15 @@ public class StreamContextEnvironment extends StreamExecutionEnvironment {
     private final boolean suppressSysout;
 
     private final boolean enforceSingleJobExecution;
+    private final byte[] originalCheckpointConfigSerialized;
+    private final byte[] originalExecutionConfigSerialized;
+    private final Configuration originalConfiguration;
 
     private int jobCounter;
+
+    private final Collection<String> errorMessages;
+
+    private final boolean allowConfigurations;
 
     public StreamContextEnvironment(
             final PipelineExecutorServiceLoader executorServiceLoader,
@@ -64,15 +84,39 @@ public class StreamContextEnvironment extends StreamExecutionEnvironment {
             final ClassLoader userCodeClassLoader,
             final boolean enforceSingleJobExecution,
             final boolean suppressSysout) {
+        this(
+                executorServiceLoader,
+                configuration,
+                userCodeClassLoader,
+                enforceSingleJobExecution,
+                suppressSysout,
+                true,
+                Collections.emptyList());
+    }
+
+    @Internal
+    public StreamContextEnvironment(
+            final PipelineExecutorServiceLoader executorServiceLoader,
+            final Configuration configuration,
+            final ClassLoader userCodeClassLoader,
+            final boolean enforceSingleJobExecution,
+            final boolean suppressSysout,
+            final boolean allowConfigurations,
+            final Collection<String> errorMessages) {
         super(executorServiceLoader, configuration, userCodeClassLoader);
         this.suppressSysout = suppressSysout;
         this.enforceSingleJobExecution = enforceSingleJobExecution;
-
+        this.allowConfigurations = allowConfigurations;
+        this.originalCheckpointConfigSerialized = serializeConfig(checkpointCfg);
+        this.originalExecutionConfigSerialized = serializeConfig(config);
+        this.originalConfiguration = new Configuration(configuration);
+        this.errorMessages = errorMessages;
         this.jobCounter = 0;
     }
 
     @Override
     public JobExecutionResult execute(StreamGraph streamGraph) throws Exception {
+        checkNotAllowedConfigurations();
         final JobClient jobClient = executeAsync(streamGraph);
         final List<JobListener> jobListeners = getJobListeners();
 
@@ -90,6 +134,13 @@ public class StreamContextEnvironment extends StreamExecutionEnvironment {
 
             // never reached, only make javac happy
             return null;
+        }
+    }
+
+    private void checkNotAllowedConfigurations() throws MutatedConfigurationException {
+        errorMessages.addAll(collectNotAllowedConfigurations());
+        if (!errorMessages.isEmpty()) {
+            throw new MutatedConfigurationException(errorMessages);
         }
     }
 
@@ -161,6 +212,18 @@ public class StreamContextEnvironment extends StreamExecutionEnvironment {
             final boolean suppressSysout) {
         StreamExecutionEnvironmentFactory factory =
                 conf -> {
+                    final List<String> errors = new ArrayList<>();
+                    final boolean allowConfigurations =
+                            configuration.getBoolean(
+                                    DeploymentOptions.ALLOW_CLIENT_JOB_CONFIGURATIONS);
+                    if (!allowConfigurations && !conf.toMap().isEmpty()) {
+                        conf.toMap()
+                                .forEach(
+                                        (k, v) ->
+                                                errors.add(
+                                                        ConfigurationNotAllowedMessage
+                                                                .ofConfigurationKeyAndValue(k, v)));
+                    }
                     Configuration mergedConfiguration = new Configuration();
                     mergedConfiguration.addAll(configuration);
                     mergedConfiguration.addAll(conf);
@@ -169,12 +232,65 @@ public class StreamContextEnvironment extends StreamExecutionEnvironment {
                             mergedConfiguration,
                             userCodeClassLoader,
                             enforceSingleJobExecution,
-                            suppressSysout);
+                            suppressSysout,
+                            allowConfigurations,
+                            errors);
                 };
         initializeContextEnvironment(factory);
     }
 
     public static void unsetAsContext() {
         resetContextEnvironment();
+    }
+
+    private List<String> collectNotAllowedConfigurations() {
+        final List<String> errors = new ArrayList<>();
+        if (allowConfigurations) {
+            return errors;
+        }
+        final MapDifference<String, String> diff =
+                Maps.difference(originalConfiguration.toMap(), configuration.toMap());
+        diff.entriesOnlyOnRight()
+                .forEach(
+                        (k, v) ->
+                                errors.add(
+                                        ConfigurationNotAllowedMessage.ofConfigurationKeyAndValue(
+                                                k, v)));
+        diff.entriesOnlyOnLeft()
+                .forEach(
+                        (k, v) ->
+                                errors.add(
+                                        ConfigurationNotAllowedMessage.ofConfigurationRemoved(
+                                                k, v)));
+        diff.entriesDiffering()
+                .forEach(
+                        (k, v) ->
+                                errors.add(
+                                        ConfigurationNotAllowedMessage.ofConfigurationChange(
+                                                k, v)));
+
+        if (!Arrays.equals(originalCheckpointConfigSerialized, serializeConfig(checkpointCfg))) {
+            errors.add(
+                    ConfigurationNotAllowedMessage.ofConfigurationObject(
+                            checkpointCfg.getClass().getSimpleName()));
+        }
+
+        if (!Arrays.equals(originalExecutionConfigSerialized, serializeConfig(config))) {
+            errors.add(
+                    ConfigurationNotAllowedMessage.ofConfigurationObject(
+                            config.getClass().getSimpleName()));
+        }
+        return errors;
+    }
+
+    private static byte[] serializeConfig(Serializable config) {
+        try (final ByteArrayOutputStream bos = new ByteArrayOutputStream();
+                final ObjectOutputStream oos = new ObjectOutputStream(bos)) {
+            oos.writeObject(config);
+            oos.flush();
+            return bos.toByteArray();
+        } catch (IOException e) {
+            throw new FlinkRuntimeException("Cannot serialize configuration.", e);
+        }
     }
 }

--- a/flink-clients/src/test/java/org/apache/flink/client/program/StreamContextEnvironmentTest.java
+++ b/flink-clients/src/test/java/org/apache/flink/client/program/StreamContextEnvironmentTest.java
@@ -1,0 +1,97 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.flink.client.program;
+
+import org.apache.flink.api.common.ExecutionConfig;
+import org.apache.flink.api.common.RuntimeExecutionMode;
+import org.apache.flink.configuration.Configuration;
+import org.apache.flink.configuration.DeploymentOptions;
+import org.apache.flink.configuration.ExecutionOptions;
+import org.apache.flink.core.execution.PipelineExecutorFactory;
+import org.apache.flink.core.execution.PipelineExecutorServiceLoader;
+import org.apache.flink.runtime.jobgraph.SavepointConfigOptions;
+import org.apache.flink.streaming.api.CheckpointingMode;
+import org.apache.flink.streaming.api.environment.CheckpointConfig;
+import org.apache.flink.streaming.api.functions.sink.DiscardingSink;
+
+import org.junit.jupiter.api.Test;
+
+import java.util.ArrayList;
+import java.util.Collections;
+import java.util.stream.Stream;
+
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+
+class StreamContextEnvironmentTest {
+
+    @Test
+    void testDisallowJobConfigurationChanges() {
+        final Configuration clusterConfiguration = new Configuration();
+        clusterConfiguration.set(DeploymentOptions.ALLOW_CLIENT_JOB_CONFIGURATIONS, false);
+        clusterConfiguration.set(DeploymentOptions.TARGET, "local");
+        clusterConfiguration.set(SavepointConfigOptions.SAVEPOINT_PATH, "/flink/savepoints");
+        clusterConfiguration.set(ExecutionOptions.RUNTIME_MODE, RuntimeExecutionMode.STREAMING);
+
+        final Configuration jobConfiguration = new Configuration();
+        jobConfiguration.set(DeploymentOptions.ALLOW_CLIENT_JOB_CONFIGURATIONS, false);
+        jobConfiguration.set(DeploymentOptions.TARGET, "local");
+        jobConfiguration.set(ExecutionOptions.RUNTIME_MODE, RuntimeExecutionMode.BATCH);
+        jobConfiguration.set(ExecutionOptions.SORT_INPUTS, true);
+
+        final ClassLoader classLoader = Thread.currentThread().getContextClassLoader();
+        final StreamContextEnvironment environment =
+                new StreamContextEnvironment(
+                        new MockExecutorServiceLoader(),
+                        clusterConfiguration,
+                        classLoader,
+                        true,
+                        true,
+                        false,
+                        new ArrayList<>());
+
+        // Change the CheckpointConfig
+        environment.enableCheckpointing(500, CheckpointingMode.EXACTLY_ONCE);
+        // Change the ExecutionConfig
+        environment.setParallelism(25);
+
+        // Add/mutate values in the configuration
+        environment.configure(jobConfiguration);
+
+        environment.fromCollection(Collections.singleton(1)).addSink(new DiscardingSink<>());
+        assertThatThrownBy(environment::execute)
+                .isInstanceOf(MutatedConfigurationException.class)
+                .hasMessageContainingAll(
+                        ExecutionOptions.RUNTIME_MODE.key(), ExecutionOptions.SORT_INPUTS.key(),
+                        CheckpointConfig.class.getSimpleName(),
+                                ExecutionConfig.class.getSimpleName());
+    }
+
+    private static class MockExecutorServiceLoader implements PipelineExecutorServiceLoader {
+
+        @Override
+        public PipelineExecutorFactory getExecutorFactory(Configuration configuration) {
+            throw new UnsupportedOperationException("Not implemented");
+        }
+
+        @Override
+        public Stream<String> getExecutorNames() {
+            throw new UnsupportedOperationException("Not implemented");
+        }
+    }
+}

--- a/flink-clients/src/test/java/org/apache/flink/client/testjar/ForbidConfigurationJob.java
+++ b/flink-clients/src/test/java/org/apache/flink/client/testjar/ForbidConfigurationJob.java
@@ -1,0 +1,43 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.flink.client.testjar;
+
+import org.apache.flink.configuration.Configuration;
+import org.apache.flink.runtime.jobgraph.SavepointConfigOptions;
+import org.apache.flink.streaming.api.environment.StreamExecutionEnvironment;
+import org.apache.flink.streaming.api.functions.sink.DiscardingSink;
+
+import org.apache.flink.shaded.guava30.com.google.common.collect.Lists;
+
+/** Simulate a class setting a configuration. */
+public class ForbidConfigurationJob {
+
+    /** Configured savepoint path. */
+    public static final String SAVEPOINT_PATH = "/flink/savepoints";
+
+    public static void main(String[] args) throws Exception {
+        final Configuration config = new Configuration();
+        config.set(SavepointConfigOptions.SAVEPOINT_PATH, SAVEPOINT_PATH);
+        final StreamExecutionEnvironment env =
+                StreamExecutionEnvironment.getExecutionEnvironment(config);
+
+        env.fromCollection(Lists.newArrayList(1, 2, 3)).addSink(new DiscardingSink<>());
+        env.execute();
+    }
+}

--- a/flink-core/src/main/java/org/apache/flink/configuration/DeploymentOptions.java
+++ b/flink-core/src/main/java/org/apache/flink/configuration/DeploymentOptions.java
@@ -104,4 +104,14 @@ public class DeploymentOptions {
                                             TextElement.text(SHUTDOWN_ON_APPLICATION_FINISH.key()),
                                             TextElement.text(HighAvailabilityOptions.HA_MODE.key()))
                                     .build());
+
+    @Experimental
+    public static final ConfigOption<Boolean> ALLOW_CLIENT_JOB_CONFIGURATIONS =
+            ConfigOptions.key("execution.allow-client-job-configurations")
+                    .booleanType()
+                    .defaultValue(true)
+                    .withDescription(
+                            "Determines whether configurations in the user program are "
+                                    + "allowed when running with Application mode. Has no effect for other "
+                                    + "deployment modes.");
 }

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/dispatcher/ConfigurationNotAllowedMessage.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/dispatcher/ConfigurationNotAllowedMessage.java
@@ -1,0 +1,52 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.flink.runtime.dispatcher;
+
+import org.apache.flink.annotation.Internal;
+
+import org.apache.flink.shaded.guava30.com.google.common.collect.MapDifference;
+
+/**
+ * If {@link org.apache.flink.configuration.DeploymentOptions#ALLOW_CLIENT_JOB_CONFIGURATIONS} is
+ * disabled this error denotes the not allowed configuration.
+ */
+@Internal
+public class ConfigurationNotAllowedMessage {
+
+    private ConfigurationNotAllowedMessage() {}
+
+    public static String ofConfigurationKeyAndValue(String configkey, String configValue) {
+        return String.format("Configuration %s:%s not allowed.", configkey, configValue);
+    }
+
+    public static String ofConfigurationRemoved(String configkey, String configValue) {
+        return String.format("Configuration %s:%s was removed.", configkey, configValue);
+    }
+
+    public static String ofConfigurationChange(
+            String configkey, MapDifference.ValueDifference<String> change) {
+        return String.format(
+                "Configuration %s was changed from %s to %s.",
+                configkey, change.leftValue(), change.rightValue());
+    }
+
+    public static String ofConfigurationObject(String configurationObject) {
+        return String.format("Configuration object %s changed.", configurationObject);
+    }
+}

--- a/flink-streaming-java/src/main/java/org/apache/flink/streaming/api/environment/StreamExecutionEnvironment.java
+++ b/flink-streaming-java/src/main/java/org/apache/flink/streaming/api/environment/StreamExecutionEnvironment.java
@@ -168,10 +168,10 @@ public class StreamExecutionEnvironment {
     // ------------------------------------------------------------------------
 
     /** The execution configuration for this environment. */
-    private final ExecutionConfig config = new ExecutionConfig();
+    protected final ExecutionConfig config = new ExecutionConfig();
 
     /** Settings that control the checkpointing behavior. */
-    private final CheckpointConfig checkpointCfg = new CheckpointConfig();
+    protected final CheckpointConfig checkpointCfg = new CheckpointConfig();
 
     protected final List<Transformation<?>> transformations = new ArrayList<>();
 


### PR DESCRIPTION
<!--
*Thank you very much for contributing to Apache Flink - we are happy that you want to help us improve Flink. To help the community review your contribution in the best possible way, please go through the checklist below, which will get the contribution into a shape in which it can be best reviewed.*

*Please understand that we do not do this to make contributions to Flink a hassle. In order to uphold a high standard of quality for code contributions, while at the same time managing a large number of contributions, we need contributors to prepare the contributions well, and give reviewers enough contextual information for the review. Please also understand that contributions that do not follow this guide will take longer to review and thus typically be picked up with lower priority by the community.*

## Contribution Checklist

  - Make sure that the pull request corresponds to a [JIRA issue](https://issues.apache.org/jira/projects/FLINK/issues). Exceptions are made for typos in JavaDoc or documentation files, which need no JIRA issue.
  
  - Name the pull request in the form "[FLINK-XXXX] [component] Title of the pull request", where *FLINK-XXXX* should be replaced by the actual issue number. Skip *component* if you are unsure about which is the best component.
  Typo fixes that have no associated JIRA issue should be named following this pattern: `[hotfix] [docs] Fix typo in event time introduction` or `[hotfix] [javadocs] Expand JavaDoc for PuncuatedWatermarkGenerator`.

  - Fill out the template below to describe the changes contributed by the pull request. That will give reviewers the context they need to do the review.
  
  - Make sure that the change passes the automated tests, i.e., `mvn clean verify` passes. You can set up Azure Pipelines CI to do that following [this guide](https://cwiki.apache.org/confluence/display/FLINK/Azure+Pipelines#AzurePipelines-Tutorial:SettingupAzurePipelinesforaforkoftheFlinkrepository).

  - Each pull request should address only one issue, not mix up code from multiple issues.
  
  - Each commit in the pull request has a meaningful commit message (including the JIRA id)

  - Once all items of the checklist are addressed, remove the above text and this checklist, leaving only the filled out template below.


**(The sections below can be removed for hotfixes of typos)**
-->

## What is the purpose of the change

This PR adds an option to disable programmatic configurations in a user program when running with the Application mode. In case, the option is enabled program changing the configuration will result in a failed job.
By default, this configuration is turned off to not break existing setups.

This subsumes #17995 


## Brief change log

- Introduce a new exception for failures during the execution of the user jar
- Allow the storing of failed jobs without a submission


## Verifying this change

Added tests to verify the exception is thrown in the correct scenarios and the job result is retrievable after the exception was thrown.

## Does this pull request potentially affect one of the following parts:

  - Dependencies (does it add or upgrade a dependency): (yes / **no**)
  - The public API, i.e., is any changed class annotated with `@Public(Evolving)`: (yes / **no**)
  - The serializers: (yes / **no** / don't know)
  - The runtime per-record code paths (performance sensitive): (yes / **no** / don't know)
  - Anything that affects deployment or recovery: JobManager (and its components), Checkpointing, Kubernetes/Yarn, ZooKeeper: (**yes** / no / don't know)
  - The S3 file system connector: (yes / **no** / don't know)

## Documentation

  - Does this pull request introduce a new feature? (**yes** / no)
  - If yes, how is the feature documented? (not applicable / **docs** (ConfigOption) / JavaDocs / not documented)
