### PR TITLE
[FLINK-25034][runtime] Support flexible number of subpartitions in IntermediateResultPartition

### DIFF
--- a/flink-optimizer/src/main/java/org/apache/flink/optimizer/plantranslate/JobGraphGenerator.java
+++ b/flink-optimizer/src/main/java/org/apache/flink/optimizer/plantranslate/JobGraphGenerator.java
@@ -1403,6 +1403,7 @@ public class JobGraphGenerator implements Visitor<PlanNode> {
                 channel.getTempMode() == TempMode.NONE ? null : channel.getTempMode().toString();
 
         edge.setShipStrategyName(shipStrategy);
+        edge.setBroadcast(isBroadcast);
         edge.setPreProcessingOperationName(localStrategy);
         edge.setOperatorLevelCachingDescription(caching);
 

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/deployment/SubpartitionIndexRange.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/deployment/SubpartitionIndexRange.java
@@ -1,0 +1,50 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.flink.runtime.deployment;
+
+import java.io.Serializable;
+
+import static org.apache.flink.util.Preconditions.checkArgument;
+
+/** This class represents the range of subpartition index. The range is inclusive. */
+public class SubpartitionIndexRange implements Serializable {
+    private final int startIndex;
+    private final int endIndex;
+
+    SubpartitionIndexRange(int startIndex, int endIndex) {
+        checkArgument(startIndex >= 0);
+        checkArgument(endIndex >= startIndex);
+
+        this.startIndex = startIndex;
+        this.endIndex = endIndex;
+    }
+
+    public int getStartIndex() {
+        return startIndex;
+    }
+
+    public int getEndIndex() {
+        return endIndex;
+    }
+
+    @Override
+    public String toString() {
+        return String.format("[%d, %d]", startIndex, endIndex);
+    }
+}

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/deployment/TaskDeploymentDescriptorFactory.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/deployment/TaskDeploymentDescriptorFactory.java
@@ -127,7 +127,6 @@ public class TaskDeploymentDescriptorFactory {
                     resultPartitionRetriever.apply(consumedPartitionGroup.getFirst());
 
             int numConsumers = resultPartition.getConsumerVertexGroup().size();
-
             int queueToRequest = subtaskIndex % numConsumers;
             IntermediateResult consumedIntermediateResult = resultPartition.getIntermediateResult();
             IntermediateDataSetID resultId = consumedIntermediateResult.getId();

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/deployment/TaskDeploymentDescriptorFactory.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/deployment/TaskDeploymentDescriptorFactory.java
@@ -55,6 +55,8 @@ import java.util.List;
 import java.util.Optional;
 import java.util.function.Function;
 
+import static org.apache.flink.util.Preconditions.checkArgument;
+
 /**
  * Factory of {@link TaskDeploymentDescriptor} to deploy {@link
  * org.apache.flink.runtime.taskmanager.Task} from {@link Execution}.
@@ -127,8 +129,17 @@ public class TaskDeploymentDescriptorFactory {
                     resultPartitionRetriever.apply(consumedPartitionGroup.getFirst());
 
             int numConsumers = resultPartition.getConsumerVertexGroup().size();
-            int queueToRequest = subtaskIndex % numConsumers;
             IntermediateResult consumedIntermediateResult = resultPartition.getIntermediateResult();
+            int consumerIndex = subtaskIndex % numConsumers;
+            int numSubpartitions = resultPartition.getNumberOfSubpartitions();
+            SubpartitionIndexRange consumedSubpartitionRange =
+                    computeConsumedSubpartitionRange(
+                            consumerIndex,
+                            numConsumers,
+                            numSubpartitions,
+                            consumedIntermediateResult.getProducer().getGraph().isDynamic(),
+                            consumedIntermediateResult.isBroadcast());
+
             IntermediateDataSetID resultId = consumedIntermediateResult.getId();
             ResultPartitionType partitionType = consumedIntermediateResult.getResultType();
 
@@ -136,12 +147,41 @@ public class TaskDeploymentDescriptorFactory {
                     new InputGateDeploymentDescriptor(
                             resultId,
                             partitionType,
-                            queueToRequest,
+                            consumedSubpartitionRange,
                             getConsumedPartitionShuffleDescriptors(
                                     consumedIntermediateResult, consumedPartitionGroup)));
         }
 
         return inputGates;
+    }
+
+    @VisibleForTesting
+    static SubpartitionIndexRange computeConsumedSubpartitionRange(
+            int consumerIndex,
+            int numConsumers,
+            int numSubpartitions,
+            boolean isDynamicGraph,
+            boolean isBroadcast) {
+
+        if (!isDynamicGraph) {
+            checkArgument(numConsumers == numSubpartitions);
+            return new SubpartitionIndexRange(consumerIndex, consumerIndex);
+        } else {
+            if (isBroadcast) {
+                // broadcast result should have only one subpartition, and be consumed multiple
+                // times.
+                checkArgument(numSubpartitions == 1);
+                return new SubpartitionIndexRange(0, 0);
+            } else {
+                checkArgument(consumerIndex < numConsumers);
+                checkArgument(numConsumers <= numSubpartitions);
+
+                int start = consumerIndex * numSubpartitions / numConsumers;
+                int nextStart = (consumerIndex + 1) * numSubpartitions / numConsumers;
+
+                return new SubpartitionIndexRange(start, nextStart - 1);
+            }
+        }
     }
 
     private MaybeOffloaded<ShuffleDescriptor[]> getConsumedPartitionShuffleDescriptors(

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/executiongraph/DefaultExecutionGraph.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/executiongraph/DefaultExecutionGraph.java
@@ -1537,4 +1537,9 @@ public class DefaultExecutionGraph implements ExecutionGraph, InternalExecutionG
     public ExecutionDeploymentListener getExecutionDeploymentListener() {
         return executionDeploymentListener;
     }
+
+    @Override
+    public boolean isDynamic() {
+        return isDynamic;
+    }
 }

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/executiongraph/Execution.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/executiongraph/Execution.java
@@ -453,10 +453,7 @@ public class Execution
 
         for (IntermediateResultPartition partition : partitions) {
             PartitionDescriptor partitionDescriptor = PartitionDescriptor.from(partition);
-            int maxParallelism =
-                    getPartitionMaxParallelism(
-                            partition,
-                            vertex.getExecutionGraphAccessor()::getExecutionVertexOrThrow);
+            int maxParallelism = getPartitionMaxParallelism(partition);
             CompletableFuture<? extends ShuffleDescriptor> shuffleDescriptorFuture =
                     vertex.getExecutionGraphAccessor()
                             .getShuffleMaster()
@@ -485,13 +482,10 @@ public class Execution
                         });
     }
 
-    private static int getPartitionMaxParallelism(
-            IntermediateResultPartition partition,
-            Function<ExecutionVertexID, ExecutionVertex> getVertexById) {
-        final ConsumerVertexGroup consumerVertexGroup = partition.getConsumerVertexGroup();
-        return getVertexById
-                .apply(consumerVertexGroup.getFirst())
-                .getJobVertex()
+    private static int getPartitionMaxParallelism(IntermediateResultPartition partition) {
+        return partition
+                .getIntermediateResult()
+                .getConsumerExecutionJobVertex()
                 .getMaxParallelism();
     }
 

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/executiongraph/ExecutionJobVertex.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/executiongraph/ExecutionJobVertex.java
@@ -177,7 +177,7 @@ public class ExecutionJobVertex
 
             this.producedDataSets[i] =
                     new IntermediateResult(
-                            result.getId(),
+                            result,
                             this,
                             this.parallelismInfo.getParallelism(),
                             result.getResultType());

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/executiongraph/IntermediateResult.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/executiongraph/IntermediateResult.java
@@ -23,8 +23,12 @@ import org.apache.flink.runtime.blob.PermanentBlobKey;
 import org.apache.flink.runtime.deployment.TaskDeploymentDescriptor.MaybeOffloaded;
 import org.apache.flink.runtime.deployment.TaskDeploymentDescriptor.Offloaded;
 import org.apache.flink.runtime.io.network.partition.ResultPartitionType;
+import org.apache.flink.runtime.jobgraph.DistributionPattern;
+import org.apache.flink.runtime.jobgraph.IntermediateDataSet;
 import org.apache.flink.runtime.jobgraph.IntermediateDataSetID;
 import org.apache.flink.runtime.jobgraph.IntermediateResultPartitionID;
+import org.apache.flink.runtime.jobgraph.JobEdge;
+import org.apache.flink.runtime.jobgraph.JobVertexID;
 import org.apache.flink.runtime.scheduler.strategy.ConsumedPartitionGroup;
 import org.apache.flink.runtime.shuffle.ShuffleDescriptor;
 
@@ -36,6 +40,8 @@ import static org.apache.flink.util.Preconditions.checkArgument;
 import static org.apache.flink.util.Preconditions.checkNotNull;
 
 public class IntermediateResult {
+
+    private final IntermediateDataSet intermediateDataSet;
 
     private final IntermediateDataSetID id;
 
@@ -63,12 +69,14 @@ public class IntermediateResult {
             shuffleDescriptorCache;
 
     public IntermediateResult(
-            IntermediateDataSetID id,
+            IntermediateDataSet intermediateDataSet,
             ExecutionJobVertex producer,
             int numParallelProducers,
             ResultPartitionType resultType) {
 
-        this.id = checkNotNull(id);
+        this.intermediateDataSet = checkNotNull(intermediateDataSet);
+        this.id = checkNotNull(intermediateDataSet.getId());
+
         this.producer = checkNotNull(producer);
 
         checkArgument(numParallelProducers >= 1);
@@ -148,6 +156,26 @@ public class IntermediateResult {
 
     public ResultPartitionType getResultType() {
         return resultType;
+    }
+
+    int getNumParallelProducers() {
+        return numParallelProducers;
+    }
+
+    ExecutionJobVertex getConsumerExecutionJobVertex() {
+        final JobEdge consumer = checkNotNull(intermediateDataSet.getConsumer());
+        final JobVertexID consumerJobVertexId = consumer.getTarget().getID();
+        return checkNotNull(getProducer().getGraph().getJobVertex(consumerJobVertexId));
+    }
+
+    DistributionPattern getConsumingDistributionPattern() {
+        final JobEdge consumer = checkNotNull(intermediateDataSet.getConsumer());
+        return consumer.getDistributionPattern();
+    }
+
+    boolean isBroadcast() {
+        final JobEdge consumer = checkNotNull(intermediateDataSet.getConsumer());
+        return consumer.isBroadcast();
     }
 
     public int getConnectionIndex() {

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/executiongraph/IntermediateResult.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/executiongraph/IntermediateResult.java
@@ -173,7 +173,7 @@ public class IntermediateResult {
         return consumer.getDistributionPattern();
     }
 
-    boolean isBroadcast() {
+    public boolean isBroadcast() {
         final JobEdge consumer = checkNotNull(intermediateDataSet.getConsumer());
         return consumer.isBroadcast();
     }

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/executiongraph/IntermediateResultPartition.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/executiongraph/IntermediateResultPartition.java
@@ -19,6 +19,7 @@
 package org.apache.flink.runtime.executiongraph;
 
 import org.apache.flink.runtime.io.network.partition.ResultPartitionType;
+import org.apache.flink.runtime.jobgraph.DistributionPattern;
 import org.apache.flink.runtime.jobgraph.IntermediateResultPartitionID;
 import org.apache.flink.runtime.scheduler.strategy.ConsumedPartitionGroup;
 import org.apache.flink.runtime.scheduler.strategy.ConsumerVertexGroup;
@@ -26,8 +27,11 @@ import org.apache.flink.runtime.scheduler.strategy.ConsumerVertexGroup;
 import java.util.List;
 
 import static org.apache.flink.util.Preconditions.checkNotNull;
+import static org.apache.flink.util.Preconditions.checkState;
 
 public class IntermediateResultPartition {
+
+    private static final int UNKNOWN = -1;
 
     private final IntermediateResult totalResult;
 
@@ -36,6 +40,9 @@ public class IntermediateResultPartition {
     private final IntermediateResultPartitionID partitionId;
 
     private final EdgeManager edgeManager;
+
+    /** Number of subpartitions. Initialized lazily and will not change once set. */
+    private int numberOfSubpartitions = UNKNOWN;
 
     /** Whether this partition has produced some data. */
     private boolean hasDataProduced = false;
@@ -77,6 +84,60 @@ public class IntermediateResultPartition {
 
     public List<ConsumedPartitionGroup> getConsumedPartitionGroups() {
         return getEdgeManager().getConsumedPartitionGroupsById(partitionId);
+    }
+
+    public int getNumberOfSubpartitions() {
+        if (numberOfSubpartitions == UNKNOWN) {
+            numberOfSubpartitions = computeNumberOfSubpartitions();
+            checkState(
+                    numberOfSubpartitions > 0,
+                    "Number of subpartitions is an unexpected value: " + numberOfSubpartitions);
+        }
+
+        return numberOfSubpartitions;
+    }
+
+    private int computeNumberOfSubpartitions() {
+        if (!getProducer().getExecutionGraphAccessor().isDynamic()) {
+            ConsumerVertexGroup consumerVertexGroup = getConsumerVertexGroup();
+            checkState(consumerVertexGroup.size() > 0);
+
+            // The produced data is partitioned among a number of subpartitions, one for each
+            // consuming sub task.
+            return consumerVertexGroup.size();
+        } else {
+            if (totalResult.isBroadcast()) {
+                // for dynamic graph and broadcast result, we only produced one subpartition,
+                // and all the downstream vertices should consume this subpartition.
+                return 1;
+            } else {
+                return computeNumberOfMaxPossiblePartitionConsumers();
+            }
+        }
+    }
+
+    private int computeNumberOfMaxPossiblePartitionConsumers() {
+        final ExecutionJobVertex consumerJobVertex =
+                getIntermediateResult().getConsumerExecutionJobVertex();
+        final DistributionPattern distributionPattern =
+                getIntermediateResult().getConsumingDistributionPattern();
+
+        // decide the max possible consumer job vertex parallelism
+        int maxConsumerJobVertexParallelism = consumerJobVertex.getParallelism();
+        if (maxConsumerJobVertexParallelism <= 0) {
+            checkState(
+                    consumerJobVertex.getMaxParallelism() > 0,
+                    "Neither the parallelism nor the max parallelism of a job vertex is set");
+            maxConsumerJobVertexParallelism = consumerJobVertex.getMaxParallelism();
+        }
+
+        // compute number of subpartitions according to the distribution pattern
+        if (distributionPattern == DistributionPattern.ALL_TO_ALL) {
+            return maxConsumerJobVertexParallelism;
+        } else {
+            int numberOfPartitions = getIntermediateResult().getNumParallelProducers();
+            return (int) Math.ceil(((double) maxConsumerJobVertexParallelism) / numberOfPartitions);
+        }
     }
 
     public void markDataProduced() {

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/executiongraph/InternalExecutionGraphAccessor.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/executiongraph/InternalExecutionGraphAccessor.java
@@ -27,6 +27,7 @@ import org.apache.flink.runtime.execution.ExecutionState;
 import org.apache.flink.runtime.executiongraph.failover.flip1.partitionrelease.PartitionGroupReleaseStrategy;
 import org.apache.flink.runtime.io.network.partition.JobMasterPartitionTracker;
 import org.apache.flink.runtime.jobgraph.IntermediateResultPartitionID;
+import org.apache.flink.runtime.jobgraph.JobVertexID;
 import org.apache.flink.runtime.scheduler.strategy.ExecutionVertexID;
 import org.apache.flink.runtime.shuffle.ShuffleMaster;
 import org.apache.flink.types.Either;
@@ -106,4 +107,8 @@ public interface InternalExecutionGraphAccessor {
     IntermediateResultPartition getResultPartitionOrThrow(final IntermediateResultPartitionID id);
 
     void deleteBlobs(List<PermanentBlobKey> blobKeys);
+
+    ExecutionJobVertex getJobVertex(JobVertexID id);
+
+    boolean isDynamic();
 }

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/jobgraph/JobEdge.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/jobgraph/JobEdge.java
@@ -55,6 +55,8 @@ public class JobEdge implements java.io.Serializable {
      */
     private String shipStrategyName;
 
+    private boolean isBroadcast;
+
     /**
      * Optional name for the pre-processing operation (sort, combining sort, ...), to be displayed
      * in the JSON plan.
@@ -162,6 +164,16 @@ public class JobEdge implements java.io.Serializable {
      */
     public void setShipStrategyName(String shipStrategyName) {
         this.shipStrategyName = shipStrategyName;
+    }
+
+    /** Gets whether the edge is broadcast edge. */
+    public boolean isBroadcast() {
+        return isBroadcast;
+    }
+
+    /** Sets whether the edge is broadcast edge. */
+    public void setBroadcast(boolean broadcast) {
+        isBroadcast = broadcast;
     }
 
     /**

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/shuffle/PartitionDescriptor.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/shuffle/PartitionDescriptor.java
@@ -24,13 +24,11 @@ import org.apache.flink.runtime.executiongraph.IntermediateResultPartition;
 import org.apache.flink.runtime.io.network.partition.ResultPartitionType;
 import org.apache.flink.runtime.jobgraph.IntermediateDataSetID;
 import org.apache.flink.runtime.jobgraph.IntermediateResultPartitionID;
-import org.apache.flink.runtime.scheduler.strategy.ConsumerVertexGroup;
 
 import java.io.Serializable;
 
 import static org.apache.flink.util.Preconditions.checkArgument;
 import static org.apache.flink.util.Preconditions.checkNotNull;
-import static org.apache.flink.util.Preconditions.checkState;
 
 /** Partition descriptor for {@link ShuffleMaster} to obtain {@link ShuffleDescriptor}. */
 public class PartitionDescriptor implements Serializable {
@@ -108,20 +106,13 @@ public class PartitionDescriptor implements Serializable {
     public static PartitionDescriptor from(IntermediateResultPartition partition) {
         checkNotNull(partition);
 
-        ConsumerVertexGroup consumerVertexGroup = partition.getConsumerVertexGroup();
-        checkState(consumerVertexGroup.size() > 0);
-
-        // The produced data is partitioned among a number of subpartitions, one for each consuming
-        // sub task.
-        int numberOfSubpartitions = consumerVertexGroup.size();
-
         IntermediateResult result = partition.getIntermediateResult();
         return new PartitionDescriptor(
                 result.getId(),
                 partition.getIntermediateResult().getNumberOfAssignedPartitions(),
                 partition.getPartitionId(),
                 result.getResultType(),
-                numberOfSubpartitions,
+                partition.getNumberOfSubpartitions(),
                 result.getConnectionIndex());
     }
 }

--- a/flink-runtime/src/test/java/org/apache/flink/runtime/deployment/TaskDeploymentDescriptorFactoryTest.java
+++ b/flink-runtime/src/test/java/org/apache/flink/runtime/deployment/TaskDeploymentDescriptorFactoryTest.java
@@ -51,6 +51,8 @@ import java.util.Arrays;
 import java.util.Collections;
 import java.util.List;
 
+import static org.hamcrest.CoreMatchers.is;
+import static org.hamcrest.MatcherAssert.assertThat;
 import static org.junit.Assert.assertEquals;
 
 /** Tests for {@link TaskDeploymentDescriptorFactory}. */
@@ -176,5 +178,91 @@ public class TaskDeploymentDescriptorFactoryTest extends TestLogger {
                                             .serializedValueKey));
             return compressedSerializedValue.deserializeValue(ClassLoader.getSystemClassLoader());
         }
+    }
+
+    @Test
+    public void testComputeConsumedSubpartitionRange3to1() {
+        final SubpartitionIndexRange range = computeConsumedSubpartitionRange(0, 1, 3);
+        assertThat(range.getStartIndex(), is(0));
+        assertThat(range.getEndIndex(), is(2));
+    }
+
+    @Test
+    public void testComputeConsumedSubpartitionRange3to2() {
+        final SubpartitionIndexRange range1 = computeConsumedSubpartitionRange(0, 2, 3);
+        assertThat(range1.getStartIndex(), is(0));
+        assertThat(range1.getEndIndex(), is(0));
+
+        final SubpartitionIndexRange range2 = computeConsumedSubpartitionRange(1, 2, 3);
+        assertThat(range2.getStartIndex(), is(1));
+        assertThat(range2.getEndIndex(), is(2));
+    }
+
+    @Test
+    public void testComputeConsumedSubpartitionRange6to4() {
+        final SubpartitionIndexRange range1 = computeConsumedSubpartitionRange(0, 4, 6);
+        assertThat(range1.getStartIndex(), is(0));
+        assertThat(range1.getEndIndex(), is(0));
+
+        final SubpartitionIndexRange range2 = computeConsumedSubpartitionRange(1, 4, 6);
+        assertThat(range2.getStartIndex(), is(1));
+        assertThat(range2.getEndIndex(), is(2));
+
+        final SubpartitionIndexRange range3 = computeConsumedSubpartitionRange(2, 4, 6);
+        assertThat(range3.getStartIndex(), is(3));
+        assertThat(range3.getEndIndex(), is(3));
+
+        final SubpartitionIndexRange range4 = computeConsumedSubpartitionRange(3, 4, 6);
+        assertThat(range4.getStartIndex(), is(4));
+        assertThat(range4.getEndIndex(), is(5));
+    }
+
+    @Test
+    public void testComputeBroadcastConsumedSubpartitionRange() {
+        final SubpartitionIndexRange range1 = computeConsumedSubpartitionRange(0, 3, 1, true, true);
+        assertThat(range1.getStartIndex(), is(0));
+        assertThat(range1.getEndIndex(), is(0));
+
+        final SubpartitionIndexRange range2 = computeConsumedSubpartitionRange(1, 3, 1, true, true);
+        assertThat(range2.getStartIndex(), is(0));
+        assertThat(range2.getEndIndex(), is(0));
+
+        final SubpartitionIndexRange range3 = computeConsumedSubpartitionRange(2, 3, 1, true, true);
+        assertThat(range3.getStartIndex(), is(0));
+        assertThat(range3.getEndIndex(), is(0));
+    }
+
+    @Test
+    public void testComputeConsumedSubpartitionRangeForNonDynamicGraph() {
+        final SubpartitionIndexRange range1 =
+                computeConsumedSubpartitionRange(0, 3, 3, false, false);
+        assertThat(range1.getStartIndex(), is(0));
+        assertThat(range1.getEndIndex(), is(0));
+
+        final SubpartitionIndexRange range2 =
+                computeConsumedSubpartitionRange(1, 3, 3, false, false);
+        assertThat(range2.getStartIndex(), is(1));
+        assertThat(range2.getEndIndex(), is(1));
+
+        final SubpartitionIndexRange range3 =
+                computeConsumedSubpartitionRange(2, 3, 3, false, false);
+        assertThat(range3.getStartIndex(), is(2));
+        assertThat(range3.getEndIndex(), is(2));
+    }
+
+    private static SubpartitionIndexRange computeConsumedSubpartitionRange(
+            int consumerIndex, int numConsumers, int numSubpartitions) {
+        return computeConsumedSubpartitionRange(
+                consumerIndex, numConsumers, numSubpartitions, true, false);
+    }
+
+    private static SubpartitionIndexRange computeConsumedSubpartitionRange(
+            int consumerIndex,
+            int numConsumers,
+            int numSubpartitions,
+            boolean isDynamicGraph,
+            boolean isBroadcast) {
+        return TaskDeploymentDescriptorFactory.computeConsumedSubpartitionRange(
+                consumerIndex, numConsumers, numSubpartitions, isDynamicGraph, isBroadcast);
     }
 }

--- a/flink-runtime/src/test/java/org/apache/flink/runtime/executiongraph/ExecutionJobVertexTest.java
+++ b/flink-runtime/src/test/java/org/apache/flink/runtime/executiongraph/ExecutionJobVertexTest.java
@@ -227,7 +227,7 @@ public class ExecutionJobVertexTest {
      * @param defaultMaxParallelism the global default max parallelism
      * @return the computed parallelism store
      */
-    private static VertexParallelismStore computeVertexParallelismStoreForDynamicGraph(
+    static VertexParallelismStore computeVertexParallelismStoreForDynamicGraph(
             Iterable<JobVertex> vertices, int defaultMaxParallelism) {
         // for dynamic graph, there is no need to normalize vertex parallelism. if the max
         // parallelism is not configured and the parallelism is a positive value, max

--- a/flink-runtime/src/test/java/org/apache/flink/runtime/executiongraph/IntermediateResultPartitionTest.java
+++ b/flink-runtime/src/test/java/org/apache/flink/runtime/executiongraph/IntermediateResultPartitionTest.java
@@ -18,14 +18,17 @@
 
 package org.apache.flink.runtime.executiongraph;
 
+import org.apache.flink.configuration.Configuration;
 import org.apache.flink.runtime.concurrent.ComponentMainThreadExecutorServiceAdapter;
 import org.apache.flink.runtime.io.network.partition.ResultPartitionType;
 import org.apache.flink.runtime.jobgraph.DistributionPattern;
 import org.apache.flink.runtime.jobgraph.JobGraph;
+import org.apache.flink.runtime.jobgraph.JobGraphBuilder;
 import org.apache.flink.runtime.jobgraph.JobGraphTestUtils;
 import org.apache.flink.runtime.jobgraph.JobVertex;
 import org.apache.flink.runtime.scheduler.SchedulerBase;
 import org.apache.flink.runtime.scheduler.SchedulerTestingUtils;
+import org.apache.flink.runtime.scheduler.VertexParallelismStore;
 import org.apache.flink.runtime.scheduler.strategy.ConsumedPartitionGroup;
 import org.apache.flink.runtime.testtasks.NoOpInvokable;
 import org.apache.flink.runtime.testutils.DirectScheduledExecutorService;
@@ -33,8 +36,15 @@ import org.apache.flink.util.TestLogger;
 
 import org.junit.Test;
 
+import java.util.Arrays;
+import java.util.Iterator;
+import java.util.List;
 import java.util.concurrent.ScheduledExecutorService;
+import java.util.stream.Collectors;
 
+import static org.hamcrest.CoreMatchers.is;
+import static org.hamcrest.MatcherAssert.assertThat;
+import static org.hamcrest.Matchers.equalTo;
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertFalse;
 import static org.junit.Assert.assertTrue;
@@ -138,6 +148,133 @@ public class IntermediateResultPartitionTest extends TestLogger {
         assertFalse(partition1.isConsumable());
         assertFalse(partition2.isConsumable());
         assertFalse(consumedPartitionGroup.areAllPartitionsFinished());
+    }
+
+    @Test
+    public void testGetNumberOfSubpartitionsForNonDynamicAllToAllGraph() throws Exception {
+        testGetNumberOfSubpartitions(7, DistributionPattern.ALL_TO_ALL, false, Arrays.asList(7, 7));
+    }
+
+    @Test
+    public void testGetNumberOfSubpartitionsForNonDynamicPointwiseGraph() throws Exception {
+        testGetNumberOfSubpartitions(7, DistributionPattern.POINTWISE, false, Arrays.asList(4, 3));
+    }
+
+    @Test
+    public void testGetNumberOfSubpartitionsFromConsumerParallelismForDynamicAllToAllGraph()
+            throws Exception {
+        testGetNumberOfSubpartitions(7, DistributionPattern.ALL_TO_ALL, true, Arrays.asList(7, 7));
+    }
+
+    @Test
+    public void testGetNumberOfSubpartitionsFromConsumerParallelismForDynamicPointwiseGraph()
+            throws Exception {
+        testGetNumberOfSubpartitions(7, DistributionPattern.POINTWISE, true, Arrays.asList(4, 4));
+    }
+
+    @Test
+    public void testGetNumberOfSubpartitionsFromConsumerMaxParallelismForDynamicAllToAllGraph()
+            throws Exception {
+        testGetNumberOfSubpartitions(
+                -1, DistributionPattern.ALL_TO_ALL, true, Arrays.asList(13, 13));
+    }
+
+    @Test
+    public void testGetNumberOfSubpartitionsFromConsumerMaxParallelismForDynamicPointwiseGraph()
+            throws Exception {
+        testGetNumberOfSubpartitions(-1, DistributionPattern.POINTWISE, true, Arrays.asList(7, 7));
+    }
+
+    private void testGetNumberOfSubpartitions(
+            int consumerParallelism,
+            DistributionPattern distributionPattern,
+            boolean isDynamicGraph,
+            List<Integer> expectedNumSubpartitions)
+            throws Exception {
+
+        final int producerParallelism = 2;
+        final int consumerMaxParallelism = 13;
+
+        final ExecutionGraph eg =
+                createExecutionGraph(
+                        producerParallelism,
+                        consumerParallelism,
+                        consumerMaxParallelism,
+                        distributionPattern,
+                        isDynamicGraph);
+
+        final Iterator<ExecutionJobVertex> vertexIterator =
+                eg.getVerticesTopologically().iterator();
+        final ExecutionJobVertex producer = vertexIterator.next();
+
+        if (isDynamicGraph) {
+            ExecutionJobVertexTest.initializeVertex(producer);
+        }
+
+        final IntermediateResult result = producer.getProducedDataSets()[0];
+
+        assertThat(expectedNumSubpartitions.size(), is(producerParallelism));
+        assertThat(
+                Arrays.stream(result.getPartitions())
+                        .map(IntermediateResultPartition::getNumberOfSubpartitions)
+                        .collect(Collectors.toList()),
+                equalTo(expectedNumSubpartitions));
+    }
+
+    private static ExecutionGraph createExecutionGraph(
+            int producerParallelism,
+            int consumerParallelism,
+            int consumerMaxParallelism,
+            DistributionPattern distributionPattern,
+            boolean isDynamicGraph)
+            throws Exception {
+
+        final JobVertex v1 = new JobVertex("v1");
+        v1.setInvokableClass(NoOpInvokable.class);
+        v1.setParallelism(producerParallelism);
+
+        final JobVertex v2 = new JobVertex("v2");
+        v2.setInvokableClass(NoOpInvokable.class);
+        if (consumerParallelism > 0) {
+            v2.setParallelism(consumerParallelism);
+        }
+        if (consumerMaxParallelism > 0) {
+            v2.setMaxParallelism(consumerMaxParallelism);
+        }
+
+        v2.connectNewDataSetAsInput(v1, distributionPattern, ResultPartitionType.BLOCKING);
+
+        final JobGraph jobGraph =
+                JobGraphBuilder.newBatchJobGraphBuilder()
+                        .addJobVertices(Arrays.asList(v1, v2))
+                        .build();
+
+        final Configuration configuration = new Configuration();
+
+        TestingDefaultExecutionGraphBuilder builder =
+                TestingDefaultExecutionGraphBuilder.newBuilder()
+                        .setJobGraph(jobGraph)
+                        .setJobMasterConfig(configuration)
+                        .setVertexParallelismStore(
+                                computeVertexParallelismStoreConsideringDynamicGraph(
+                                        jobGraph.getVertices(),
+                                        isDynamicGraph,
+                                        consumerMaxParallelism));
+        if (isDynamicGraph) {
+            return builder.buildDynamicGraph();
+        } else {
+            return builder.build();
+        }
+    }
+
+    public static VertexParallelismStore computeVertexParallelismStoreConsideringDynamicGraph(
+            Iterable<JobVertex> vertices, boolean isDynamicGraph, int defaultMaxParallelism) {
+        if (isDynamicGraph) {
+            return ExecutionJobVertexTest.computeVertexParallelismStoreForDynamicGraph(
+                    vertices, defaultMaxParallelism);
+        } else {
+            return SchedulerBase.computeVertexParallelismStore(vertices);
+        }
     }
 
     private static IntermediateResult createResult(

--- a/flink-runtime/src/test/java/org/apache/flink/runtime/scheduler/adaptive/ExecutingTest.java
+++ b/flink-runtime/src/test/java/org/apache/flink/runtime/scheduler/adaptive/ExecutingTest.java
@@ -51,6 +51,7 @@ import org.apache.flink.runtime.executiongraph.failover.flip1.partitionrelease.P
 import org.apache.flink.runtime.io.network.partition.JobMasterPartitionTracker;
 import org.apache.flink.runtime.jobgraph.IntermediateResultPartitionID;
 import org.apache.flink.runtime.jobgraph.JobVertex;
+import org.apache.flink.runtime.jobgraph.JobVertexID;
 import org.apache.flink.runtime.scheduler.DefaultVertexParallelismInfo;
 import org.apache.flink.runtime.scheduler.ExecutionGraphHandler;
 import org.apache.flink.runtime.scheduler.OperatorCoordinatorHandler;
@@ -935,6 +936,18 @@ public class ExecutingTest extends TestLogger {
 
         @Override
         public void deleteBlobs(List<PermanentBlobKey> blobKeys) {
+            throw new UnsupportedOperationException(
+                    "This method is not supported by the MockInternalExecutionGraphAccessor.");
+        }
+
+        @Override
+        public ExecutionJobVertex getJobVertex(JobVertexID id) {
+            throw new UnsupportedOperationException(
+                    "This method is not supported by the MockInternalExecutionGraphAccessor.");
+        }
+
+        @Override
+        public boolean isDynamic() {
             throw new UnsupportedOperationException(
                     "This method is not supported by the MockInternalExecutionGraphAccessor.");
         }

--- a/flink-streaming-java/src/main/java/org/apache/flink/streaming/api/graph/StreamingJobGraphGenerator.java
+++ b/flink-streaming-java/src/main/java/org/apache/flink/streaming/api/graph/StreamingJobGraphGenerator.java
@@ -814,6 +814,7 @@ public class StreamingJobGraphGenerator {
         }
         // set strategy name so that web interface can show it.
         jobEdge.setShipStrategyName(partitioner.toString());
+        jobEdge.setBroadcast(partitioner.isBroadcast());
         jobEdge.setDownstreamSubtaskStateMapper(partitioner.getDownstreamSubtaskStateMapper());
         jobEdge.setUpstreamSubtaskStateMapper(partitioner.getUpstreamSubtaskStateMapper());
 


### PR DESCRIPTION
## What is the purpose of the change

Support flexible number of subpartitions in IntermediateResultPartition. When the consumer parallelism is decided,  number of subpartitions should be the **parallelism** of consumer job vertex(all to all). When the consumer parallelism is not decided, number of subpartitions should be the **max parallelism** of consumer job vertex.

## Brief change log
 4dc4300e58a2ff798c0cae8c8af0103d7c650eb4 Support flexible number of subpartitions in IntermediateResultPartition.
 73c2ecd546c2ad9be7ee20382716edc9f6c6c574 Let InputGateDeploymentDescriptor supports subpartition range.

## Verifying this change
Unit tests.

## Does this pull request potentially affect one of the following parts:

  - Dependencies (does it add or upgrade a dependency): (**no**)
  - The public API, i.e., is any changed class annotated with `@Public(Evolving)`: (**no**)
  - The serializers: (**no**)
  - The runtime per-record code paths (performance sensitive): (**no**)
  - Anything that affects deployment or recovery: JobManager (and its components), Checkpointing, Kubernetes/Yarn, ZooKeeper: (**no**)
  - The S3 file system connector: (**no**)

## Documentation

  - Does this pull request introduce a new feature? (**no**)
  - If yes, how is the feature documented? (**not applicable**)
