### PR TITLE
[hotfix][docs] Fix typo in textLines parameter for Map transformation

### DIFF
--- a/docs/content.zh/docs/dev/dataset/transformations.md
+++ b/docs/content.zh/docs/dev/dataset/transformations.md
@@ -140,7 +140,7 @@ DataSet<Long> counts = textLines.mapPartition(new PartitionCounter());
 val textLines: DataSet[String] = // [...]
 // Some is required because the return value must be a Collection.
 // There is an implicit conversion from Option to a Collection.
-val counts = texLines.mapPartition { in => Some(in.size) }
+val counts = textLines.mapPartition { in => Some(in.size) }
 ```
 
 {{< /tab >}}

--- a/docs/content/docs/dev/dataset/transformations.md
+++ b/docs/content/docs/dev/dataset/transformations.md
@@ -138,7 +138,7 @@ DataSet<Long> counts = textLines.mapPartition(new PartitionCounter());
 val textLines: DataSet[String] = // [...]
 // Some is required because the return value must be a Collection.
 // There is an implicit conversion from Option to a Collection.
-val counts = texLines.mapPartition { in => Some(in.size) }
+val counts = textLines.mapPartition { in => Some(in.size) }
 ```
 
 {{< /tab >}}


### PR DESCRIPTION
Fix dateset related doc typo. 