### PR TITLE
[FLINK-24859][doc][formats] Make new formats name coherent: introduce previous names classes to indicate deprecation to the users

### DIFF
--- a/flink-connectors/flink-connector-files/src/main/java/org/apache/flink/connector/file/src/reader/TextLineFormat.java
+++ b/flink-connectors/flink-connector-files/src/main/java/org/apache/flink/connector/file/src/reader/TextLineFormat.java
@@ -1,0 +1,23 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.flink.connector.file.src.reader;
+
+/** @deprecated Please use {@link TextLineInputFormat}. */
+@Deprecated
+public class TextLineFormat extends TextLineInputFormat {}

--- a/flink-connectors/flink-connector-hive/src/main/java/org/apache/flink/connectors/hive/read/HiveBulkFormatAdapter.java
+++ b/flink-connectors/flink-connector-hive/src/main/java/org/apache/flink/connectors/hive/read/HiveBulkFormatAdapter.java
@@ -1,0 +1,48 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.flink.connectors.hive.read;
+
+import org.apache.flink.connectors.hive.JobConfWrapper;
+import org.apache.flink.table.types.DataType;
+import org.apache.flink.table.types.logical.RowType;
+
+import java.util.List;
+
+/** @deprecated Please use {@link HiveInputFormat}. */
+@Deprecated
+public class HiveBulkFormatAdapter extends HiveInputFormat {
+
+    public HiveBulkFormatAdapter(
+            JobConfWrapper jobConfWrapper,
+            List<String> partitionKeys,
+            String[] fieldNames,
+            DataType[] fieldTypes,
+            String hiveVersion,
+            RowType producedRowType,
+            boolean useMapRedReader) {
+        super(
+                jobConfWrapper,
+                partitionKeys,
+                fieldNames,
+                fieldTypes,
+                hiveVersion,
+                producedRowType,
+                useMapRedReader);
+    }
+}

--- a/flink-formats/flink-orc/src/main/java/org/apache/flink/orc/OrcColumnarRowFileInputFormat.java
+++ b/flink-formats/flink-orc/src/main/java/org/apache/flink/orc/OrcColumnarRowFileInputFormat.java
@@ -1,0 +1,55 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.flink.orc;
+
+import org.apache.flink.api.common.typeinfo.TypeInformation;
+import org.apache.flink.connector.file.src.FileSourceSplit;
+import org.apache.flink.orc.shim.OrcShim;
+import org.apache.flink.orc.vector.ColumnBatchFactory;
+
+import org.apache.hadoop.conf.Configuration;
+import org.apache.orc.TypeDescription;
+
+import java.util.List;
+
+/** @deprecated Please use {@link OrcColumnarRowInputFormat}. */
+@Deprecated
+public class OrcColumnarRowFileInputFormat<BatchT, SplitT extends FileSourceSplit>
+        extends OrcColumnarRowInputFormat<BatchT, SplitT> {
+
+    public OrcColumnarRowFileInputFormat(
+            OrcShim shim,
+            Configuration hadoopConfig,
+            TypeDescription schema,
+            int[] selectedFields,
+            List conjunctPredicates,
+            int batchSize,
+            ColumnBatchFactory batchFactory,
+            TypeInformation producedTypeInfo) {
+        super(
+                shim,
+                hadoopConfig,
+                schema,
+                selectedFields,
+                conjunctPredicates,
+                batchSize,
+                batchFactory,
+                producedTypeInfo);
+    }
+}


### PR DESCRIPTION
This is linked to [this PR](https://github.com/apache/flink/pull/17839). It adds deprecation notices on the old format names for the users.
As discussed R: @AHeise 