### PR TITLE
[FLINK-25074][streaming] Simplify name of WindowOperator

### DIFF
--- a/flink-streaming-java/src/main/java/org/apache/flink/streaming/api/datastream/AllWindowedStream.java
+++ b/flink-streaming-java/src/main/java/org/apache/flink/streaming/api/datastream/AllWindowedStream.java
@@ -259,7 +259,8 @@ public class AllWindowedStream<T, W extends Window> {
         String callLocation = Utils.getCallLocationName();
         String udfName = "AllWindowedStream." + callLocation;
 
-        String opName;
+        String opName = windowAssigner.getClass().getSimpleName();
+        String opDescription;
         KeySelector<T, Byte> keySel = input.getKeySelector();
 
         OneInputStreamOperator<T, R> operator;
@@ -276,7 +277,7 @@ public class AllWindowedStream<T, W extends Window> {
             ListStateDescriptor<StreamRecord<T>> stateDesc =
                     new ListStateDescriptor<>("window-contents", streamRecordSerializer);
 
-            opName =
+            opDescription =
                     "TriggerWindow("
                             + windowAssigner
                             + ", "
@@ -313,7 +314,7 @@ public class AllWindowedStream<T, W extends Window> {
                             input.getType()
                                     .createSerializer(getExecutionEnvironment().getConfig()));
 
-            opName =
+            opDescription =
                     "TriggerWindow("
                             + windowAssigner
                             + ", "
@@ -339,7 +340,9 @@ public class AllWindowedStream<T, W extends Window> {
                             lateDataOutputTag);
         }
 
-        return input.transform(opName, resultType, operator).forceNonParallel();
+        return input.transform(opName, resultType, operator)
+                .setDescription(opDescription)
+                .forceNonParallel();
     }
 
     /**
@@ -808,7 +811,8 @@ public class AllWindowedStream<T, W extends Window> {
         final String callLocation = Utils.getCallLocationName();
         final String udfName = "AllWindowedStream." + callLocation;
 
-        final String opName;
+        final String opName = windowAssigner.getClass().getSimpleName();
+        final String opDescription;
         final KeySelector<T, Byte> keySel = input.getKeySelector();
 
         OneInputStreamOperator<T, R> operator;
@@ -825,7 +829,7 @@ public class AllWindowedStream<T, W extends Window> {
             ListStateDescriptor<StreamRecord<T>> stateDesc =
                     new ListStateDescriptor<>("window-contents", streamRecordSerializer);
 
-            opName =
+            opDescription =
                     "TriggerWindow("
                             + windowAssigner
                             + ", "
@@ -862,7 +866,7 @@ public class AllWindowedStream<T, W extends Window> {
                             accumulatorType.createSerializer(
                                     getExecutionEnvironment().getConfig()));
 
-            opName =
+            opDescription =
                     "TriggerWindow("
                             + windowAssigner
                             + ", "
@@ -888,7 +892,9 @@ public class AllWindowedStream<T, W extends Window> {
                             lateDataOutputTag);
         }
 
-        return input.transform(opName, resultType, operator).forceNonParallel();
+        return input.transform(opName, resultType, operator)
+                .setDescription(opDescription)
+                .forceNonParallel();
     }
 
     // ------------------------------------------------------------------------

--- a/flink-streaming-java/src/main/java/org/apache/flink/streaming/api/datastream/WindowedStream.java
+++ b/flink-streaming-java/src/main/java/org/apache/flink/streaming/api/datastream/WindowedStream.java
@@ -211,10 +211,11 @@ public class WindowedStream<T, K, W extends Window> {
         function = input.getExecutionEnvironment().clean(function);
         reduceFunction = input.getExecutionEnvironment().clean(reduceFunction);
 
-        final String opName = builder.generateOperatorName(reduceFunction, function);
+        final String opName = builder.generateOperatorName();
+        final String opDescription = builder.generateOperatorDescription(reduceFunction, function);
 
         OneInputStreamOperator<T, R> operator = builder.reduce(reduceFunction, function);
-        return input.transform(opName, resultType, operator);
+        return input.transform(opName, resultType, operator).setDescription(opDescription);
     }
 
     /**
@@ -258,10 +259,11 @@ public class WindowedStream<T, K, W extends Window> {
         function = input.getExecutionEnvironment().clean(function);
         reduceFunction = input.getExecutionEnvironment().clean(reduceFunction);
 
-        final String opName = builder.generateOperatorName(reduceFunction, function);
+        final String opName = builder.generateOperatorName();
+        final String opDescription = builder.generateOperatorDescription(reduceFunction, function);
         OneInputStreamOperator<T, R> operator = builder.reduce(reduceFunction, function);
 
-        return input.transform(opName, resultType, operator);
+        return input.transform(opName, resultType, operator).setDescription(opDescription);
     }
 
     // ------------------------------------------------------------------------
@@ -405,12 +407,14 @@ public class WindowedStream<T, K, W extends Window> {
         windowFunction = input.getExecutionEnvironment().clean(windowFunction);
         aggregateFunction = input.getExecutionEnvironment().clean(aggregateFunction);
 
-        final String opName = builder.generateOperatorName(aggregateFunction, windowFunction);
+        final String opName = builder.generateOperatorName();
+        final String opDescription =
+                builder.generateOperatorDescription(aggregateFunction, windowFunction);
 
         OneInputStreamOperator<T, R> operator =
                 builder.aggregate(aggregateFunction, windowFunction, accumulatorType);
 
-        return input.transform(opName, resultType, operator);
+        return input.transform(opName, resultType, operator).setDescription(opDescription);
     }
 
     /**
@@ -514,12 +518,14 @@ public class WindowedStream<T, K, W extends Window> {
         windowFunction = input.getExecutionEnvironment().clean(windowFunction);
         aggregateFunction = input.getExecutionEnvironment().clean(aggregateFunction);
 
-        final String opName = builder.generateOperatorName(aggregateFunction, windowFunction);
+        final String opName = builder.generateOperatorName();
+        final String opDescription =
+                builder.generateOperatorDescription(aggregateFunction, windowFunction);
 
         OneInputStreamOperator<T, R> operator =
                 builder.aggregate(aggregateFunction, windowFunction, accumulatorType);
 
-        return input.transform(opName, resultType, operator);
+        return input.transform(opName, resultType, operator).setDescription(opDescription);
     }
 
     // ------------------------------------------------------------------------
@@ -559,10 +565,11 @@ public class WindowedStream<T, K, W extends Window> {
             WindowFunction<T, R, K, W> function, TypeInformation<R> resultType) {
         function = input.getExecutionEnvironment().clean(function);
 
-        final String opName = builder.generateOperatorName(function, null);
+        final String opName = builder.generateOperatorName();
+        final String opDescription = builder.generateOperatorDescription(function, null);
         OneInputStreamOperator<T, R> operator = builder.apply(function);
 
-        return input.transform(opName, resultType, operator);
+        return input.transform(opName, resultType, operator).setDescription(opDescription);
     }
 
     /**
@@ -601,11 +608,12 @@ public class WindowedStream<T, K, W extends Window> {
             ProcessWindowFunction<T, R, K, W> function, TypeInformation<R> resultType) {
         function = input.getExecutionEnvironment().clean(function);
 
-        final String opName = builder.generateOperatorName(function, null);
+        final String opName = builder.generateOperatorName();
+        final String opDesc = builder.generateOperatorDescription(function, null);
 
         OneInputStreamOperator<T, R> operator = builder.process(function);
 
-        return input.transform(opName, resultType, operator);
+        return input.transform(opName, resultType, operator).setDescription(opDesc);
     }
 
     /**
@@ -651,11 +659,12 @@ public class WindowedStream<T, K, W extends Window> {
         function = input.getExecutionEnvironment().clean(function);
         reduceFunction = input.getExecutionEnvironment().clean(reduceFunction);
 
-        final String opName = builder.generateOperatorName(reduceFunction, function);
+        final String opName = builder.generateOperatorName();
+        final String opDesc = builder.generateOperatorDescription(reduceFunction, function);
 
         OneInputStreamOperator<T, R> operator = builder.reduce(reduceFunction, function);
 
-        return input.transform(opName, resultType, operator);
+        return input.transform(opName, resultType, operator).setDescription(opDesc);
     }
 
     // ------------------------------------------------------------------------

--- a/flink-streaming-java/src/main/java/org/apache/flink/streaming/runtime/operators/windowing/WindowOperatorBuilder.java
+++ b/flink-streaming-java/src/main/java/org/apache/flink/streaming/runtime/operators/windowing/WindowOperatorBuilder.java
@@ -326,7 +326,11 @@ public class WindowOperatorBuilder<T, K, W extends Window> {
         }
     }
 
-    public String generateOperatorName(Function function1, @Nullable Function function2) {
+    public String generateOperatorName() {
+        return windowAssigner.getClass().getSimpleName();
+    }
+
+    public String generateOperatorDescription(Function function1, @Nullable Function function2) {
         return "Window("
                 + windowAssigner
                 + ", "


### PR DESCRIPTION

## What is the purpose of the change

This pull request is part of FLIP-195: https://cwiki.apache.org/confluence/display/FLINK/FLIP-195%3A+Improve+the+name+and+structure+of+vertex+and+operator+name+for+job, supports simplify the name of WindowOperator in DataStream job.

## Brief change log

  - *use window aggigner as name of WindowOperator and keep current detailed name to description*

## Verifying this change

This change added tests and can be verified as follows:

  - *Added test in DataStreamTest*
## Does this pull request potentially affect one of the following parts:

  - Dependencies (does it add or upgrade a dependency): (no)
  - The public API, i.e., is any changed class annotated with `@Public(Evolving)`: (no)
  - The serializers: (no)
  - The runtime per-record code paths (performance sensitive): (no)
  - Anything that affects deployment or recovery: JobManager (and its components), Checkpointing, Kubernetes/Yarn, ZooKeeper: (no)
  - The S3 file system connector: (no)

## Documentation

  - Does this pull request introduce a new feature? (no)