### PR TITLE
[FLINK-25239][connector/jdbc] Delete useless variables

### DIFF
--- a/flink-connectors/flink-connector-jdbc/src/main/java/org/apache/flink/connector/jdbc/internal/JdbcOutputFormat.java
+++ b/flink-connectors/flink-connector-jdbc/src/main/java/org/apache/flink/connector/jdbc/internal/JdbcOutputFormat.java
@@ -68,9 +68,6 @@ import static org.apache.flink.util.Preconditions.checkNotNull;
 public class JdbcOutputFormat<In, JdbcIn, JdbcExec extends JdbcBatchStatementExecutor<JdbcIn>>
         extends RichOutputFormat<In> implements Flushable, InputTypeConfigurable {
 
-    public static final int DEFAULT_FLUSH_MAX_SIZE = 5000;
-    public static final long DEFAULT_FLUSH_INTERVAL_MILLS = 0L;
-
     protected final JdbcConnectionProvider connectionProvider;
     @Nullable private TypeSerializer<In> serializer;
 


### PR DESCRIPTION
## What is the purpose of the change

DEFAULT_FLUSH_MAX_SIZE and DEFAULT_FLUSH_INTERVAL_MILLS is useless in JdbcBatchingOutputFormat class. 

## Brief change log

  - *Delete DEFAULT_FLUSH_MAX_SIZE and DEFAULT_FLUSH_INTERVAL_MILLS is useless in JdbcBatchingOutputFormat class.*

## Verifying this change

This change is a trivial rework / code cleanup without any test coverage.

## Does this pull request potentially affect one of the following parts:

  - Dependencies (does it add or upgrade a dependency): (no)
  - The public API, i.e., is any changed class annotated with `@Public(Evolving)`: (no)
  - The serializers: (no)
  - The runtime per-record code paths (performance sensitive): (no)
  - Anything that affects deployment or recovery: JobManager (and its components), Checkpointing, Kubernetes/Yarn, ZooKeeper: (no)
  - The S3 file system connector: (no)

## Documentation

  - Does this pull request introduce a new feature? (no)
  - If yes, how is the feature documented? (not documented)
