### PR TITLE
[FLINK-25223][connectors/elasticsearch] Limit Elasticsearch testcontainer memory allocation

### DIFF
--- a/flink-connectors/flink-connector-elasticsearch-base/src/test/java/org/apache/flink/connector/elasticsearch/ElasticsearchUtil.java
+++ b/flink-connectors/flink-connector-elasticsearch-base/src/test/java/org/apache/flink/connector/elasticsearch/ElasticsearchUtil.java
@@ -1,0 +1,64 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.flink.connector.elasticsearch;
+
+import org.apache.flink.annotation.Internal;
+
+import org.slf4j.Logger;
+import org.testcontainers.containers.output.Slf4jLogConsumer;
+import org.testcontainers.elasticsearch.ElasticsearchContainer;
+import org.testcontainers.utility.DockerImageName;
+
+/** Collection of utility methods for Elasticsearch tests. */
+@Internal
+public class ElasticsearchUtil {
+
+    private ElasticsearchUtil() {}
+
+    /**
+     * Creates a preconfigured {@link ElasticsearchContainer} with limited memory allocation and
+     * aligns the internal Elasticsearch log levels with the ones used by the capturing logger.
+     *
+     * @param dockerImageVersion describing the Elasticsearch image
+     * @param log to derive the log level from
+     * @return configured Elasticsearch container
+     */
+    public static ElasticsearchContainer createElasticsearchContainer(
+            String dockerImageVersion, Logger log) {
+        String logLevel;
+        if (log.isTraceEnabled()) {
+            logLevel = "TRACE";
+        } else if (log.isDebugEnabled()) {
+            logLevel = "DEBUG";
+        } else if (log.isInfoEnabled()) {
+            logLevel = "INFO";
+        } else if (log.isWarnEnabled()) {
+            logLevel = "WARN";
+        } else if (log.isErrorEnabled()) {
+            logLevel = "ERROR";
+        } else {
+            logLevel = "OFF";
+        }
+
+        return new ElasticsearchContainer(DockerImageName.parse(dockerImageVersion))
+                .withEnv("ES_JAVA_OPTS", "-Xms2g -Xmx2g")
+                .withEnv("logger.org.elasticsearch", logLevel)
+                .withLogConsumer(new Slf4jLogConsumer(log));
+    }
+}

--- a/flink-connectors/flink-connector-elasticsearch-base/src/test/java/org/apache/flink/connector/elasticsearch/sink/ElasticsearchWriterITCase.java
+++ b/flink-connectors/flink-connector-elasticsearch-base/src/test/java/org/apache/flink/connector/elasticsearch/sink/ElasticsearchWriterITCase.java
@@ -19,6 +19,7 @@ package org.apache.flink.connector.elasticsearch.sink;
 
 import org.apache.flink.api.common.operators.MailboxExecutor;
 import org.apache.flink.api.java.tuple.Tuple2;
+import org.apache.flink.connector.elasticsearch.ElasticsearchUtil;
 import org.apache.flink.connectors.test.common.junit.extensions.TestLoggerExtension;
 import org.apache.flink.metrics.Counter;
 import org.apache.flink.metrics.Gauge;
@@ -47,16 +48,13 @@ import org.elasticsearch.common.unit.ByteSizeValue;
 import org.elasticsearch.core.TimeValue;
 import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.BeforeEach;
-import org.junit.jupiter.api.Disabled;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
-import org.testcontainers.containers.output.Slf4jLogConsumer;
 import org.testcontainers.elasticsearch.ElasticsearchContainer;
 import org.testcontainers.junit.jupiter.Container;
 import org.testcontainers.junit.jupiter.Testcontainers;
-import org.testcontainers.utility.DockerImageName;
 
 import java.io.IOException;
 import java.util.Collections;
@@ -70,7 +68,6 @@ import static org.junit.jupiter.api.Assertions.assertTrue;
 
 /** Tests for {@link ElasticsearchWriter}. */
 @Testcontainers
-@Disabled
 @ExtendWith(TestLoggerExtension.class)
 class ElasticsearchWriterITCase {
 
@@ -78,8 +75,8 @@ class ElasticsearchWriterITCase {
 
     @Container
     private static final ElasticsearchContainer ES_CONTAINER =
-            new ElasticsearchContainer(DockerImageName.parse(DockerImageVersions.ELASTICSEARCH_7))
-                    .withLogConsumer(new Slf4jLogConsumer(LOG));
+            ElasticsearchUtil.createElasticsearchContainer(
+                    DockerImageVersions.ELASTICSEARCH_7, LOG);
 
     private RestHighLevelClient client;
     private TestClientBase context;

--- a/flink-connectors/flink-connector-elasticsearch6/src/test/java/org/apache/flink/connector/elasticsearch/sink/Elasticsearch6SinkITCase.java
+++ b/flink-connectors/flink-connector-elasticsearch6/src/test/java/org/apache/flink/connector/elasticsearch/sink/Elasticsearch6SinkITCase.java
@@ -18,14 +18,13 @@
 package org.apache.flink.connector.elasticsearch.sink;
 
 import org.apache.flink.api.java.tuple.Tuple2;
+import org.apache.flink.connector.elasticsearch.ElasticsearchUtil;
 import org.apache.flink.util.DockerImageVersions;
 
 import org.elasticsearch.client.RestHighLevelClient;
-import org.testcontainers.containers.output.Slf4jLogConsumer;
 import org.testcontainers.elasticsearch.ElasticsearchContainer;
 import org.testcontainers.junit.jupiter.Container;
 import org.testcontainers.junit.jupiter.Testcontainers;
-import org.testcontainers.utility.DockerImageName;
 
 /** Tests for {@link ElasticsearchSink}. */
 @Testcontainers
@@ -33,9 +32,8 @@ class Elasticsearch6SinkITCase extends ElasticsearchSinkBaseITCase {
 
     @Container
     private static final ElasticsearchContainer ES_CONTAINER =
-            new ElasticsearchContainer(DockerImageName.parse(DockerImageVersions.ELASTICSEARCH_6))
-                    .withPassword(ELASTICSEARCH_PASSWORD)
-                    .withLogConsumer(new Slf4jLogConsumer(LOG));
+            ElasticsearchUtil.createElasticsearchContainer(DockerImageVersions.ELASTICSEARCH_6, LOG)
+                    .withPassword(ELASTICSEARCH_PASSWORD);
 
     @Override
     String getElasticsearchHttpHostAddress() {

--- a/flink-connectors/flink-connector-elasticsearch6/src/test/java/org/apache/flink/connector/elasticsearch/table/Elasticsearch6DynamicSinkITCase.java
+++ b/flink-connectors/flink-connector-elasticsearch6/src/test/java/org/apache/flink/connector/elasticsearch/table/Elasticsearch6DynamicSinkITCase.java
@@ -18,12 +18,15 @@
 
 package org.apache.flink.connector.elasticsearch.table;
 
+import org.apache.flink.connector.elasticsearch.ElasticsearchUtil;
 import org.apache.flink.util.DockerImageVersions;
 
 import org.elasticsearch.action.get.GetRequest;
 import org.elasticsearch.action.search.SearchRequest;
 import org.elasticsearch.client.RestHighLevelClient;
 import org.elasticsearch.search.SearchHits;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 import org.testcontainers.elasticsearch.ElasticsearchContainer;
 import org.testcontainers.junit.jupiter.Container;
 import org.testcontainers.junit.jupiter.Testcontainers;
@@ -37,11 +40,15 @@ import static org.apache.flink.connector.elasticsearch.table.TestContext.context
 @Testcontainers
 public class Elasticsearch6DynamicSinkITCase extends ElasticsearchDynamicSinkBaseITCase {
 
+    private static final Logger LOG =
+            LoggerFactory.getLogger(Elasticsearch6DynamicSinkITCase.class);
+
     private static final String DOCUMENT_TYPE = "MyType";
 
     @Container
     private static final ElasticsearchContainer ES_CONTAINER =
-            new ElasticsearchContainer(DockerImageVersions.ELASTICSEARCH_6);
+            ElasticsearchUtil.createElasticsearchContainer(
+                    DockerImageVersions.ELASTICSEARCH_6, LOG);
 
     @Override
     String getElasticsearchHttpHostAddress() {

--- a/flink-connectors/flink-connector-elasticsearch6/src/test/java/org/apache/flink/streaming/connectors/elasticsearch6/ElasticsearchSinkITCase.java
+++ b/flink-connectors/flink-connector-elasticsearch6/src/test/java/org/apache/flink/streaming/connectors/elasticsearch6/ElasticsearchSinkITCase.java
@@ -19,6 +19,7 @@
 package org.apache.flink.streaming.connectors.elasticsearch6;
 
 import org.apache.flink.api.java.tuple.Tuple2;
+import org.apache.flink.connector.elasticsearch.ElasticsearchUtil;
 import org.apache.flink.streaming.connectors.elasticsearch.ElasticsearchSinkBase;
 import org.apache.flink.streaming.connectors.elasticsearch.ElasticsearchSinkFunction;
 import org.apache.flink.streaming.connectors.elasticsearch.ElasticsearchSinkTestBase;
@@ -32,8 +33,9 @@ import org.elasticsearch.common.transport.TransportAddress;
 import org.elasticsearch.transport.client.PreBuiltTransportClient;
 import org.junit.ClassRule;
 import org.junit.Test;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 import org.testcontainers.elasticsearch.ElasticsearchContainer;
-import org.testcontainers.utility.DockerImageName;
 
 import java.util.ArrayList;
 import java.util.List;
@@ -42,9 +44,12 @@ import java.util.List;
 public class ElasticsearchSinkITCase
         extends ElasticsearchSinkTestBase<RestHighLevelClient, HttpHost> {
 
+    private static final Logger LOG = LoggerFactory.getLogger(ElasticsearchSinkITCase.class);
+
     @ClassRule
     public static ElasticsearchContainer elasticsearchContainer =
-            new ElasticsearchContainer(DockerImageName.parse(DockerImageVersions.ELASTICSEARCH_6));
+            ElasticsearchUtil.createElasticsearchContainer(
+                    DockerImageVersions.ELASTICSEARCH_6, LOG);
 
     @Override
     protected String getClusterName() {

--- a/flink-connectors/flink-connector-elasticsearch7/src/test/java/org/apache/flink/connector/elasticsearch/sink/Elasticsearch7SinkITCase.java
+++ b/flink-connectors/flink-connector-elasticsearch7/src/test/java/org/apache/flink/connector/elasticsearch/sink/Elasticsearch7SinkITCase.java
@@ -18,26 +18,22 @@
 package org.apache.flink.connector.elasticsearch.sink;
 
 import org.apache.flink.api.java.tuple.Tuple2;
+import org.apache.flink.connector.elasticsearch.ElasticsearchUtil;
 import org.apache.flink.util.DockerImageVersions;
 
 import org.elasticsearch.client.RestHighLevelClient;
-import org.junit.jupiter.api.Disabled;
-import org.testcontainers.containers.output.Slf4jLogConsumer;
 import org.testcontainers.elasticsearch.ElasticsearchContainer;
 import org.testcontainers.junit.jupiter.Container;
 import org.testcontainers.junit.jupiter.Testcontainers;
-import org.testcontainers.utility.DockerImageName;
 
 /** Tests for {@link ElasticsearchSink}. */
 @Testcontainers
-@Disabled
 class Elasticsearch7SinkITCase extends ElasticsearchSinkBaseITCase {
 
     @Container
     private static final ElasticsearchContainer ES_CONTAINER =
-            new ElasticsearchContainer(DockerImageName.parse(DockerImageVersions.ELASTICSEARCH_7))
-                    .withPassword(ELASTICSEARCH_PASSWORD)
-                    .withLogConsumer(new Slf4jLogConsumer(LOG));
+            ElasticsearchUtil.createElasticsearchContainer(DockerImageVersions.ELASTICSEARCH_7, LOG)
+                    .withPassword(ELASTICSEARCH_PASSWORD);
 
     @Override
     String getElasticsearchHttpHostAddress() {

--- a/flink-connectors/flink-connector-elasticsearch7/src/test/java/org/apache/flink/connector/elasticsearch/table/Elasticsearch7DynamicSinkITCase.java
+++ b/flink-connectors/flink-connector-elasticsearch7/src/test/java/org/apache/flink/connector/elasticsearch/table/Elasticsearch7DynamicSinkITCase.java
@@ -18,6 +18,7 @@
 
 package org.apache.flink.connector.elasticsearch.table;
 
+import org.apache.flink.connector.elasticsearch.ElasticsearchUtil;
 import org.apache.flink.util.DockerImageVersions;
 
 import org.elasticsearch.action.get.GetRequest;
@@ -25,7 +26,8 @@ import org.elasticsearch.action.search.SearchRequest;
 import org.elasticsearch.client.RequestOptions;
 import org.elasticsearch.client.RestHighLevelClient;
 import org.elasticsearch.search.SearchHits;
-import org.junit.jupiter.api.Disabled;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 import org.testcontainers.elasticsearch.ElasticsearchContainer;
 import org.testcontainers.junit.jupiter.Container;
 import org.testcontainers.junit.jupiter.Testcontainers;
@@ -37,12 +39,15 @@ import static org.apache.flink.connector.elasticsearch.table.TestContext.context
 
 /** IT tests for {@link ElasticsearchDynamicSink}. */
 @Testcontainers
-@Disabled
 public class Elasticsearch7DynamicSinkITCase extends ElasticsearchDynamicSinkBaseITCase {
+
+    private static final Logger LOG =
+            LoggerFactory.getLogger(Elasticsearch7DynamicSinkITCase.class);
 
     @Container
     private static final ElasticsearchContainer ES_CONTAINER =
-            new ElasticsearchContainer(DockerImageVersions.ELASTICSEARCH_7);
+            ElasticsearchUtil.createElasticsearchContainer(
+                    DockerImageVersions.ELASTICSEARCH_7, LOG);
 
     @Override
     String getElasticsearchHttpHostAddress() {

--- a/flink-connectors/flink-connector-elasticsearch7/src/test/java/org/apache/flink/streaming/connectors/elasticsearch7/ElasticsearchSinkITCase.java
+++ b/flink-connectors/flink-connector-elasticsearch7/src/test/java/org/apache/flink/streaming/connectors/elasticsearch7/ElasticsearchSinkITCase.java
@@ -19,6 +19,7 @@
 package org.apache.flink.streaming.connectors.elasticsearch7;
 
 import org.apache.flink.api.java.tuple.Tuple2;
+import org.apache.flink.connector.elasticsearch.ElasticsearchUtil;
 import org.apache.flink.streaming.connectors.elasticsearch.ElasticsearchSinkBase;
 import org.apache.flink.streaming.connectors.elasticsearch.ElasticsearchSinkFunction;
 import org.apache.flink.streaming.connectors.elasticsearch.ElasticsearchSinkTestBase;
@@ -31,22 +32,24 @@ import org.elasticsearch.common.settings.Settings;
 import org.elasticsearch.common.transport.TransportAddress;
 import org.elasticsearch.transport.client.PreBuiltTransportClient;
 import org.junit.ClassRule;
-import org.junit.Ignore;
 import org.junit.Test;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 import org.testcontainers.elasticsearch.ElasticsearchContainer;
-import org.testcontainers.utility.DockerImageName;
 
 import java.util.ArrayList;
 import java.util.List;
 
 /** IT cases for the {@link ElasticsearchSink}. */
-@Ignore
 public class ElasticsearchSinkITCase
         extends ElasticsearchSinkTestBase<RestHighLevelClient, HttpHost> {
 
+    private static final Logger LOG = LoggerFactory.getLogger(ElasticsearchSinkITCase.class);
+
     @ClassRule
     public static ElasticsearchContainer elasticsearchContainer =
-            new ElasticsearchContainer(DockerImageName.parse(DockerImageVersions.ELASTICSEARCH_7));
+            ElasticsearchUtil.createElasticsearchContainer(
+                    DockerImageVersions.ELASTICSEARCH_7, LOG);
 
     @Override
     protected String getClusterName() {


### PR DESCRIPTION
## What is the purpose of the change

This PR limits the memory allocation of the Elasticsearch testcontainers to prevent them getting OOM killed in the CI

## Brief change log

* (re-)enabled Elasticsearch tests using testcontainers
* created `MemoryRestrictedElasticsearchContainer` helper class with a 2GB memory limit
* updated existing tests to use the new helper class for both Elasticsearch v6 and v7


## Verifying this change

This change can be verified by running the affected tests from the commit.

## Does this pull request potentially affect one of the following parts:

  - Dependencies (does it add or upgrade a dependency): (yes / **no**)
  - The public API, i.e., is any changed class annotated with `@Public(Evolving)`: (yes / **no**)
  - The serializers: (yes / **no** / don't know)
  - The runtime per-record code paths (performance sensitive): (yes / **no** / don't know)
  - Anything that affects deployment or recovery: JobManager (and its components), Checkpointing, Kubernetes/Yarn, ZooKeeper: (yes / **no** / don't know)
  - The S3 file system connector: (yes / **no** / don't know)

## Documentation

  - Does this pull request introduce a new feature? (yes / **no**)
  - If yes, how is the feature documented? (not applicable / docs / **JavaDocs** / not documented)
