### PR TITLE
[FLINK-24728][tests] Add tests to ensure SQL file sink closes all created files

### DIFF
--- a/flink-core/src/test/java/org/apache/flink/testutils/TestFileSystem.java
+++ b/flink-core/src/test/java/org/apache/flink/testutils/TestFileSystem.java
@@ -19,15 +19,21 @@
 package org.apache.flink.testutils;
 
 import org.apache.flink.core.fs.FSDataInputStream;
+import org.apache.flink.core.fs.FSDataOutputStream;
 import org.apache.flink.core.fs.FileStatus;
 import org.apache.flink.core.fs.FileSystem;
 import org.apache.flink.core.fs.FileSystemFactory;
 import org.apache.flink.core.fs.Path;
+import org.apache.flink.core.fs.local.LocalDataOutputStream;
 import org.apache.flink.core.fs.local.LocalFileStatus;
 import org.apache.flink.core.fs.local.LocalFileSystem;
+import org.apache.flink.util.Preconditions;
 
 import java.io.IOException;
 import java.net.URI;
+import java.util.Map;
+import java.util.concurrent.ConcurrentHashMap;
+import java.util.concurrent.atomic.AtomicInteger;
 
 /**
  * A test file system. This also has a service entry in the test resources, to be loaded during
@@ -37,26 +43,42 @@ public class TestFileSystem extends LocalFileSystem {
 
     public static final String SCHEME = "test";
 
-    private static int streamOpenCounter;
+    // number of (input) stream opened
+    private static final AtomicInteger streamOpenCounter = new AtomicInteger(0);
+
+    // current number of created, unclosed (output) stream
+    private static final Map<Path, Integer> currentUnclosedOutputStream = new ConcurrentHashMap<>();
 
     public static int getNumtimeStreamOpened() {
-        return streamOpenCounter;
+        return streamOpenCounter.get();
     }
 
     public static void resetStreamOpenCounter() {
-        streamOpenCounter = 0;
+        streamOpenCounter.set(0);
+    }
+
+    public static int getNumberOfUnclosedOutputStream(Path path) {
+        return currentUnclosedOutputStream.getOrDefault(path, 0);
     }
 
     @Override
     public FSDataInputStream open(Path f, int bufferSize) throws IOException {
-        streamOpenCounter++;
+        streamOpenCounter.incrementAndGet();
         return super.open(f, bufferSize);
     }
 
     @Override
     public FSDataInputStream open(Path f) throws IOException {
-        streamOpenCounter++;
+        streamOpenCounter.incrementAndGet();
         return super.open(f);
+    }
+
+    @Override
+    public FSDataOutputStream create(final Path filePath, final WriteMode overwrite)
+            throws IOException {
+        currentUnclosedOutputStream.compute(filePath, (k, v) -> v == null ? 1 : v + 1);
+        LocalDataOutputStream stream = (LocalDataOutputStream) super.create(filePath, overwrite);
+        return new TestOutputStream(stream, filePath);
     }
 
     @Override
@@ -78,6 +100,51 @@ public class TestFileSystem extends LocalFileSystem {
     @Override
     public URI getUri() {
         return URI.create(SCHEME + ":///");
+    }
+
+    // ------------------------------------------------------------------------
+
+    private static final class TestOutputStream extends FSDataOutputStream {
+
+        private final LocalDataOutputStream stream;
+        private final Path path;
+
+        private TestOutputStream(LocalDataOutputStream stream, Path path) {
+            this.stream = stream;
+            this.path = path;
+        }
+
+        @Override
+        public long getPos() throws IOException {
+            return stream.getPos();
+        }
+
+        @Override
+        public void write(int b) throws IOException {
+            stream.write(b);
+        }
+
+        @Override
+        public void write(byte[] b, int off, int len) throws IOException {
+            stream.write(b, off, len);
+        }
+
+        @Override
+        public void flush() throws IOException {
+            stream.flush();
+        }
+
+        @Override
+        public void sync() throws IOException {
+            stream.sync();
+        }
+
+        @Override
+        public void close() throws IOException {
+            currentUnclosedOutputStream.compute(
+                    path, (k, v) -> Preconditions.checkNotNull(v) == 1 ? null : v - 1);
+            stream.close();
+        }
     }
 
     // ------------------------------------------------------------------------

--- a/flink-table/flink-table-planner/src/test/scala/org/apache/flink/table/planner/runtime/FileSystemITCaseBase.scala
+++ b/flink-table/flink-table-planner/src/test/scala/org/apache/flink/table/planner/runtime/FileSystemITCaseBase.scala
@@ -49,6 +49,8 @@ trait FileSystemITCaseBase {
 
   def formatProperties(): Array[String] = Array()
 
+  def getScheme: String = "file"
+
   def tableEnv: TableEnvironment
 
   def check(sqlQuery: String, expectedResult: Seq[Row]): Unit
@@ -59,7 +61,7 @@ trait FileSystemITCaseBase {
   }
 
   def open(): Unit = {
-    resultPath = fileTmpFolder.newFolder().toURI.toString
+    resultPath = fileTmpFolder.newFolder().toURI.getPath
     BatchTableEnvUtil.registerCollection(
       tableEnv,
       "originalT",
@@ -76,7 +78,7 @@ trait FileSystemITCaseBase {
          |  c as b + 1
          |) partitioned by (a, b) with (
          |  'connector' = 'filesystem',
-         |  'path' = '$resultPath',
+         |  'path' = '$getScheme://$resultPath',
          |  ${formatProperties().mkString(",\n")}
          |)
        """.stripMargin
@@ -90,7 +92,7 @@ trait FileSystemITCaseBase {
          |  b bigint
          |) with (
          |  'connector' = 'filesystem',
-         |  'path' = '$resultPath',
+         |  'path' = '$getScheme://$resultPath',
          |  ${formatProperties().mkString(",\n")}
          |)
        """.stripMargin
@@ -102,7 +104,7 @@ trait FileSystemITCaseBase {
          |  x decimal(10, 0), y int
          |) with (
          |  'connector' = 'filesystem',
-         |  'path' = '$resultPath',
+         |  'path' = '$getScheme://$resultPath',
          |  ${formatProperties().mkString(",\n")}
          |)
        """.stripMargin
@@ -114,7 +116,7 @@ trait FileSystemITCaseBase {
          |  x decimal(3, 2), y int
          |) with (
          |  'connector' = 'filesystem',
-         |  'path' = '$resultPath',
+         |  'path' = '$getScheme://$resultPath',
          |  ${formatProperties().mkString(",\n")}
          |)
        """.stripMargin
@@ -256,7 +258,7 @@ trait FileSystemITCaseBase {
       "partition(a='1', b='1') select x, y from originalT where a=1 and b=1").await()
 
     // create hidden partition dir
-    assertTrue(new File(new Path(resultPath + "/a=1/.b=2").toUri).mkdir())
+    assertTrue(new File(new Path("file:" + resultPath + "/a=1/.b=2").toUri).mkdir())
 
     check(
       "select x, y from partitionedTable",

--- a/flink-table/flink-table-planner/src/test/scala/org/apache/flink/table/planner/runtime/batch/sql/FileSystemTestCsvITCase.scala
+++ b/flink-table/flink-table-planner/src/test/scala/org/apache/flink/table/planner/runtime/batch/sql/FileSystemTestCsvITCase.scala
@@ -18,6 +18,12 @@
 
 package org.apache.flink.table.planner.runtime.batch.sql
 
+import org.apache.flink.core.fs.Path
+import org.apache.flink.testutils.TestFileSystem
+
+import org.junit.After
+import org.junit.Assert.assertEquals
+
 /**
   * Test for file system table factory with testcsv format.
   */
@@ -25,5 +31,16 @@ class FileSystemTestCsvITCase extends BatchFileSystemITCaseBase {
 
   override def formatProperties(): Array[String] = {
     super.formatProperties() ++ Seq("'format' = 'testcsv'")
+  }
+
+  override def getScheme: String = "test"
+
+  @After
+  def close(): Unit = {
+    val path = new Path(resultPath)
+    assertEquals(
+      s"File $resultPath is not closed",
+      0,
+      TestFileSystem.getNumberOfUnclosedOutputStream(path))
   }
 }

--- a/flink-table/flink-table-planner/src/test/scala/org/apache/flink/table/planner/runtime/stream/sql/StreamFileSystemTestCsvITCase.scala
+++ b/flink-table/flink-table-planner/src/test/scala/org/apache/flink/table/planner/runtime/stream/sql/StreamFileSystemTestCsvITCase.scala
@@ -18,6 +18,12 @@
 
 package org.apache.flink.table.planner.runtime.stream.sql
 
+import org.apache.flink.core.fs.Path
+import org.apache.flink.testutils.TestFileSystem
+
+import org.junit.After
+import org.junit.Assert.assertEquals
+
 import scala.collection.Seq
 
 /**
@@ -27,5 +33,16 @@ class StreamFileSystemTestCsvITCase extends StreamFileSystemITCaseBase {
 
   override def formatProperties(): Array[String] = {
     super.formatProperties() ++ Seq("'format' = 'testcsv'")
+  }
+
+  override def getScheme: String = "test"
+
+  @After
+  def close(): Unit = {
+    val path = new Path(resultPath)
+    assertEquals(
+      s"File $resultPath is not closed",
+      0,
+      TestFileSystem.getNumberOfUnclosedOutputStream(path))
   }
 }


### PR DESCRIPTION
(This PR is cherry-picked from #17655)

## What is the purpose of the change

This PR adds tests for the change in #17638.

## Brief change log

 - Add tests to ensure SQL file sink closes all created files

## Verifying this change

This change added tests and can be verified by running the added tests.

## Does this pull request potentially affect one of the following parts:

  - Dependencies (does it add or upgrade a dependency): no
  - The public API, i.e., is any changed class annotated with `@Public(Evolving)`: no
  - The serializers: no
  - The runtime per-record code paths (performance sensitive): no
  - Anything that affects deployment or recovery: JobManager (and its components), Checkpointing, Kubernetes/Yarn, ZooKeeper: no
  - The S3 file system connector: no

## Documentation

  - Does this pull request introduce a new feature? no
  - If yes, how is the feature documented? not applicable
