### PR TITLE
[FLINK-25257][TE] Let TaskExecutor use TaskExecutorBlobService interface instead of concrete BlobCacheService implementation

### DIFF
--- a/flink-runtime/src/main/java/org/apache/flink/runtime/blob/BlobCacheService.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/blob/BlobCacheService.java
@@ -28,7 +28,7 @@ import java.net.InetSocketAddress;
 import static org.apache.flink.util.Preconditions.checkNotNull;
 
 /** The BLOB cache provides access to BLOB services for permanent and transient BLOBs. */
-public class BlobCacheService implements BlobService {
+public class BlobCacheService implements TaskExecutorBlobService {
 
     /** Caching store for permanent BLOBs. */
     private final PermanentBlobCache permanentBlobCache;

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/blob/JobPermanentBlobService.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/blob/JobPermanentBlobService.java
@@ -1,0 +1,40 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.flink.runtime.blob;
+
+import org.apache.flink.api.common.JobID;
+
+/**
+ * {@link PermanentBlobService} extension that gives access to register and release job artifacts.
+ */
+public interface JobPermanentBlobService extends PermanentBlobService {
+    /**
+     * Register the given job.
+     *
+     * @param jobId job id identifying the job to register
+     */
+    void registerJob(JobID jobId);
+
+    /**
+     * Release the given job. This makes the blobs stored for this job up for cleanup.
+     *
+     * @param jobId job id identifying the job to register
+     */
+    void releaseJob(JobID jobId);
+}

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/blob/PermanentBlobCache.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/blob/PermanentBlobCache.java
@@ -54,7 +54,7 @@ import static org.apache.flink.util.Preconditions.checkNotNull;
  * <p>If files for a job are not needed any more, they will enter a staged, i.e. deferred, cleanup.
  * Files may thus still be be accessible upon recovery and do not need to be re-downloaded.
  */
-public class PermanentBlobCache extends AbstractBlobCache implements PermanentBlobService {
+public class PermanentBlobCache extends AbstractBlobCache implements JobPermanentBlobService {
 
     /** Job reference counters with a time-to-live (TTL). */
     @VisibleForTesting
@@ -138,6 +138,7 @@ public class PermanentBlobCache extends AbstractBlobCache implements PermanentBl
      * @param jobId ID of the job this blob belongs to
      * @see #releaseJob(JobID)
      */
+    @Override
     public void registerJob(JobID jobId) {
         checkNotNull(jobId);
 
@@ -160,6 +161,7 @@ public class PermanentBlobCache extends AbstractBlobCache implements PermanentBl
      * @param jobId ID of the job this blob belongs to
      * @see #registerJob(JobID)
      */
+    @Override
     public void releaseJob(JobID jobId) {
         checkNotNull(jobId);
 

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/blob/TaskExecutorBlobService.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/blob/TaskExecutorBlobService.java
@@ -1,0 +1,38 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.flink.runtime.blob;
+
+import java.net.InetSocketAddress;
+
+/**
+ * {@link BlobService} that gives access to a {@link JobPermanentBlobService} and allows to set the
+ * target blob server address.
+ */
+public interface TaskExecutorBlobService extends BlobService {
+
+    @Override
+    JobPermanentBlobService getPermanentBlobService();
+
+    /**
+     * Sets the blob server address.
+     *
+     * @param blobServerAddress blob server address
+     */
+    void setBlobServerAddress(InetSocketAddress blobServerAddress);
+}

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/taskexecutor/TaskManagerRunner.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/taskexecutor/TaskManagerRunner.java
@@ -33,6 +33,7 @@ import org.apache.flink.core.security.FlinkSecurityManager;
 import org.apache.flink.management.jmx.JMXService;
 import org.apache.flink.metrics.MetricGroup;
 import org.apache.flink.runtime.blob.BlobCacheService;
+import org.apache.flink.runtime.blob.TaskExecutorBlobService;
 import org.apache.flink.runtime.clusterframework.types.ResourceID;
 import org.apache.flink.runtime.entrypoint.ClusterEntrypointUtils;
 import org.apache.flink.runtime.entrypoint.FlinkParseException;
@@ -480,7 +481,7 @@ public class TaskManagerRunner implements FatalErrorHandler {
             HighAvailabilityServices highAvailabilityServices,
             HeartbeatServices heartbeatServices,
             MetricRegistry metricRegistry,
-            BlobCacheService blobCacheService,
+            TaskExecutorBlobService taskExecutorBlobService,
             boolean localCommunicationOnly,
             ExternalResourceInfoProvider externalResourceInfoProvider,
             FatalErrorHandler fatalErrorHandler)
@@ -521,7 +522,7 @@ public class TaskManagerRunner implements FatalErrorHandler {
         TaskManagerServices taskManagerServices =
                 TaskManagerServices.fromConfiguration(
                         taskManagerServicesConfiguration,
-                        blobCacheService.getPermanentBlobService(),
+                        taskExecutorBlobService.getPermanentBlobService(),
                         taskManagerMetricGroup.f1,
                         ioExecutor,
                         fatalErrorHandler);
@@ -546,7 +547,7 @@ public class TaskManagerRunner implements FatalErrorHandler {
                 heartbeatServices,
                 taskManagerMetricGroup.f0,
                 metricQueryServiceAddress,
-                blobCacheService,
+                taskExecutorBlobService,
                 fatalErrorHandler,
                 new TaskExecutorPartitionTrackerImpl(taskManagerServices.getShuffleEnvironment()));
     }

--- a/flink-runtime/src/test/java/org/apache/flink/runtime/blob/NoOpJobPermanentBlobService.java
+++ b/flink-runtime/src/test/java/org/apache/flink/runtime/blob/NoOpJobPermanentBlobService.java
@@ -1,0 +1,50 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.flink.runtime.blob;
+
+import org.apache.flink.api.common.JobID;
+
+import java.io.File;
+import java.io.IOException;
+
+/** No-op {@link JobPermanentBlobService} implementation for testing purposes. */
+public class NoOpJobPermanentBlobService implements JobPermanentBlobService {
+    public static final NoOpJobPermanentBlobService INSTANCE = new NoOpJobPermanentBlobService();
+
+    private NoOpJobPermanentBlobService() {}
+
+    @Override
+    public void registerJob(JobID jobId) {
+        // no-op
+    }
+
+    @Override
+    public void releaseJob(JobID jobId) {
+        // no-op
+    }
+
+    @Override
+    public File getFile(JobID jobId, PermanentBlobKey key) throws IOException {
+        throw new IOException(
+                String.format("Could not find file for job id %s and key %s.", jobId, key));
+    }
+
+    @Override
+    public void close() throws IOException {}
+}

--- a/flink-runtime/src/test/java/org/apache/flink/runtime/blob/NoOpTaskExecutorBlobService.java
+++ b/flink-runtime/src/test/java/org/apache/flink/runtime/blob/NoOpTaskExecutorBlobService.java
@@ -1,0 +1,54 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.flink.runtime.blob;
+
+import java.io.IOException;
+import java.net.InetSocketAddress;
+
+/** No-op {@link TaskExecutorBlobService} implementation for testing purposes. */
+public class NoOpTaskExecutorBlobService implements TaskExecutorBlobService {
+    public static final NoOpTaskExecutorBlobService INSTANCE = new NoOpTaskExecutorBlobService();
+
+    private NoOpTaskExecutorBlobService() {}
+
+    @Override
+    public TransientBlobService getTransientBlobService() {
+        return NoOpTransientBlobService.INSTANCE;
+    }
+
+    @Override
+    public int getPort() {
+        return 0;
+    }
+
+    @Override
+    public JobPermanentBlobService getPermanentBlobService() {
+        return NoOpJobPermanentBlobService.INSTANCE;
+    }
+
+    @Override
+    public void setBlobServerAddress(InetSocketAddress blobServerAddress) {
+        // noop
+    }
+
+    @Override
+    public void close() throws IOException {
+        // noop
+    }
+}

--- a/flink-runtime/src/test/java/org/apache/flink/runtime/taskexecutor/TaskExecutorExecutionDeploymentReconciliationTest.java
+++ b/flink-runtime/src/test/java/org/apache/flink/runtime/taskexecutor/TaskExecutorExecutionDeploymentReconciliationTest.java
@@ -22,8 +22,7 @@ import org.apache.flink.api.common.time.Time;
 import org.apache.flink.configuration.Configuration;
 import org.apache.flink.core.testutils.BlockerSync;
 import org.apache.flink.core.testutils.OneShotLatch;
-import org.apache.flink.runtime.blob.BlobCacheService;
-import org.apache.flink.runtime.blob.VoidBlobStore;
+import org.apache.flink.runtime.blob.NoOpTaskExecutorBlobService;
 import org.apache.flink.runtime.clusterframework.types.AllocationID;
 import org.apache.flink.runtime.clusterframework.types.ResourceID;
 import org.apache.flink.runtime.clusterframework.types.ResourceProfile;
@@ -227,7 +226,7 @@ public class TaskExecutorExecutionDeploymentReconciliationTest extends TestLogge
                 new HeartbeatServices(1_000L, 30_000L),
                 UnregisteredMetricGroups.createUnregisteredTaskManagerMetricGroup(),
                 null,
-                new BlobCacheService(configuration, new VoidBlobStore(), null),
+                NoOpTaskExecutorBlobService.INSTANCE,
                 testingFatalErrorHandlerResource.getFatalErrorHandler(),
                 new TestingTaskExecutorPartitionTracker());
     }

--- a/flink-runtime/src/test/java/org/apache/flink/runtime/taskexecutor/TaskExecutorPartitionLifecycleTest.java
+++ b/flink-runtime/src/test/java/org/apache/flink/runtime/taskexecutor/TaskExecutorPartitionLifecycleTest.java
@@ -23,8 +23,7 @@ import org.apache.flink.api.common.time.Time;
 import org.apache.flink.configuration.Configuration;
 import org.apache.flink.core.testutils.BlockerSync;
 import org.apache.flink.core.testutils.OneShotLatch;
-import org.apache.flink.runtime.blob.BlobCacheService;
-import org.apache.flink.runtime.blob.VoidBlobStore;
+import org.apache.flink.runtime.blob.NoOpTaskExecutorBlobService;
 import org.apache.flink.runtime.clusterframework.types.ResourceID;
 import org.apache.flink.runtime.clusterframework.types.ResourceProfile;
 import org.apache.flink.runtime.deployment.ResultPartitionDeploymentDescriptor;
@@ -602,7 +601,7 @@ public class TaskExecutorPartitionLifecycleTest extends TestLogger {
                 new HeartbeatServices(10_000L, 30_000L),
                 UnregisteredMetricGroups.createUnregisteredTaskManagerMetricGroup(),
                 null,
-                new BlobCacheService(configuration, new VoidBlobStore(), null),
+                NoOpTaskExecutorBlobService.INSTANCE,
                 new TestingFatalErrorHandler(),
                 partitionTracker);
     }

--- a/flink-runtime/src/test/java/org/apache/flink/runtime/taskexecutor/TaskExecutorSlotLifetimeTest.java
+++ b/flink-runtime/src/test/java/org/apache/flink/runtime/taskexecutor/TaskExecutorSlotLifetimeTest.java
@@ -21,8 +21,7 @@ package org.apache.flink.runtime.taskexecutor;
 import org.apache.flink.api.common.JobID;
 import org.apache.flink.configuration.Configuration;
 import org.apache.flink.core.testutils.OneShotLatch;
-import org.apache.flink.runtime.blob.BlobCacheService;
-import org.apache.flink.runtime.blob.VoidBlobStore;
+import org.apache.flink.runtime.blob.NoOpTaskExecutorBlobService;
 import org.apache.flink.runtime.clusterframework.types.AllocationID;
 import org.apache.flink.runtime.clusterframework.types.ResourceProfile;
 import org.apache.flink.runtime.clusterframework.types.SlotID;
@@ -216,7 +215,7 @@ public class TaskExecutorSlotLifetimeTest extends TestLogger {
                 new TestingHeartbeatServices(),
                 UnregisteredMetricGroups.createUnregisteredTaskManagerMetricGroup(),
                 null,
-                new BlobCacheService(configuration, new VoidBlobStore(), null),
+                NoOpTaskExecutorBlobService.INSTANCE,
                 testingFatalErrorHandlerResource.getFatalErrorHandler(),
                 new TestingTaskExecutorPartitionTracker());
     }

--- a/flink-runtime/src/test/java/org/apache/flink/runtime/taskexecutor/TaskExecutorTest.java
+++ b/flink-runtime/src/test/java/org/apache/flink/runtime/taskexecutor/TaskExecutorTest.java
@@ -30,9 +30,8 @@ import org.apache.flink.configuration.NettyShuffleEnvironmentOptions;
 import org.apache.flink.configuration.TaskManagerOptions;
 import org.apache.flink.core.testutils.MultiShotLatch;
 import org.apache.flink.core.testutils.OneShotLatch;
-import org.apache.flink.runtime.blob.BlobCacheService;
+import org.apache.flink.runtime.blob.NoOpTaskExecutorBlobService;
 import org.apache.flink.runtime.blob.TransientBlobKey;
-import org.apache.flink.runtime.blob.VoidBlobStore;
 import org.apache.flink.runtime.clusterframework.types.AllocationID;
 import org.apache.flink.runtime.clusterframework.types.ResourceID;
 import org.apache.flink.runtime.clusterframework.types.ResourceProfile;
@@ -198,8 +197,6 @@ public class TaskExecutorTest extends TestLogger {
 
     private TestingRpcService rpc;
 
-    private BlobCacheService dummyBlobCacheService;
-
     private Configuration configuration;
 
     private UnresolvedTaskManagerLocation unresolvedTaskManagerLocation;
@@ -221,9 +218,6 @@ public class TaskExecutorTest extends TestLogger {
     @Before
     public void setup() throws IOException {
         rpc = new TestingRpcService();
-
-        dummyBlobCacheService =
-                new BlobCacheService(new Configuration(), new VoidBlobStore(), null);
 
         configuration = new Configuration();
         TaskExecutorResourceUtils.adjustForLocalExecution(configuration);
@@ -250,11 +244,6 @@ public class TaskExecutorTest extends TestLogger {
         if (rpc != null) {
             RpcUtils.terminateRpcService(rpc, timeout);
             rpc = null;
-        }
-
-        if (dummyBlobCacheService != null) {
-            dummyBlobCacheService.close();
-            dummyBlobCacheService = null;
         }
 
         if (nettyShuffleEnvironment != null) {
@@ -2759,7 +2748,7 @@ public class TaskExecutorTest extends TestLogger {
                 heartbeatServices,
                 UnregisteredMetricGroups.createUnregisteredTaskManagerMetricGroup(),
                 null,
-                dummyBlobCacheService,
+                NoOpTaskExecutorBlobService.INSTANCE,
                 testingFatalErrorHandler,
                 taskExecutorPartitionTracker);
     }
@@ -2790,7 +2779,7 @@ public class TaskExecutorTest extends TestLogger {
                 heartbeatServices,
                 metricGroup,
                 null,
-                dummyBlobCacheService,
+                NoOpTaskExecutorBlobService.INSTANCE,
                 testingFatalErrorHandler,
                 new TaskExecutorPartitionTrackerImpl(taskManagerServices.getShuffleEnvironment()));
     }

--- a/flink-runtime/src/test/java/org/apache/flink/runtime/taskexecutor/TaskManagerRunnerStartupTest.java
+++ b/flink-runtime/src/test/java/org/apache/flink/runtime/taskexecutor/TaskManagerRunnerStartupTest.java
@@ -24,8 +24,7 @@ import org.apache.flink.configuration.IllegalConfigurationException;
 import org.apache.flink.configuration.MemorySize;
 import org.apache.flink.configuration.NettyShuffleEnvironmentOptions;
 import org.apache.flink.configuration.TaskManagerOptions;
-import org.apache.flink.runtime.blob.BlobCacheService;
-import org.apache.flink.runtime.blob.VoidBlobStore;
+import org.apache.flink.runtime.blob.NoOpTaskExecutorBlobService;
 import org.apache.flink.runtime.clusterframework.types.ResourceID;
 import org.apache.flink.runtime.externalresource.ExternalResourceInfoProvider;
 import org.apache.flink.runtime.heartbeat.TestingHeartbeatServices;
@@ -264,7 +263,7 @@ public class TaskManagerRunnerStartupTest extends TestLogger {
                 highAvailabilityServices,
                 new TestingHeartbeatServices(),
                 metricRegistry,
-                new BlobCacheService(configuration, new VoidBlobStore(), null),
+                NoOpTaskExecutorBlobService.INSTANCE,
                 false,
                 ExternalResourceInfoProvider.NO_EXTERNAL_RESOURCES,
                 error -> {});

--- a/flink-runtime/src/test/java/org/apache/flink/runtime/taskexecutor/TaskSubmissionTestEnvironment.java
+++ b/flink-runtime/src/test/java/org/apache/flink/runtime/taskexecutor/TaskSubmissionTestEnvironment.java
@@ -23,8 +23,8 @@ import org.apache.flink.api.common.time.Time;
 import org.apache.flink.api.java.tuple.Tuple3;
 import org.apache.flink.configuration.Configuration;
 import org.apache.flink.configuration.NettyShuffleEnvironmentOptions;
-import org.apache.flink.runtime.blob.BlobCacheService;
-import org.apache.flink.runtime.blob.VoidBlobStore;
+import org.apache.flink.runtime.blob.NoOpTaskExecutorBlobService;
+import org.apache.flink.runtime.blob.TaskExecutorBlobService;
 import org.apache.flink.runtime.clusterframework.types.AllocationID;
 import org.apache.flink.runtime.clusterframework.types.ResourceID;
 import org.apache.flink.runtime.execution.ExecutionState;
@@ -84,8 +84,8 @@ class TaskSubmissionTestEnvironment implements AutoCloseable {
 
     private final HeartbeatServices heartbeatServices = new HeartbeatServices(1000L, 1000L);
     private final TestingRpcService testingRpcService;
-    private final BlobCacheService blobCacheService =
-            new BlobCacheService(new Configuration(), new VoidBlobStore(), null);
+    private final TaskExecutorBlobService taskExecutorBlobService =
+            NoOpTaskExecutorBlobService.INSTANCE;
     private final Time timeout = Time.milliseconds(10000L);
     private final TestingFatalErrorHandler testingFatalErrorHandler =
             new TestingFatalErrorHandler();
@@ -265,7 +265,7 @@ class TaskSubmissionTestEnvironment implements AutoCloseable {
                 heartbeatServices,
                 UnregisteredMetricGroups.createUnregisteredTaskManagerMetricGroup(),
                 metricQueryServiceAddress,
-                blobCacheService,
+                taskExecutorBlobService,
                 testingFatalErrorHandler,
                 new TaskExecutorPartitionTrackerImpl(taskManagerServices.getShuffleEnvironment()));
     }
@@ -320,7 +320,7 @@ class TaskSubmissionTestEnvironment implements AutoCloseable {
 
         timerService.stop();
 
-        blobCacheService.close();
+        taskExecutorBlobService.close();
 
         temporaryFolder.delete();
 

--- a/flink-runtime/src/test/java/org/apache/flink/runtime/taskexecutor/TestingTaskExecutor.java
+++ b/flink-runtime/src/test/java/org/apache/flink/runtime/taskexecutor/TestingTaskExecutor.java
@@ -18,7 +18,7 @@
 
 package org.apache.flink.runtime.taskexecutor;
 
-import org.apache.flink.runtime.blob.BlobCacheService;
+import org.apache.flink.runtime.blob.TaskExecutorBlobService;
 import org.apache.flink.runtime.externalresource.ExternalResourceInfoProvider;
 import org.apache.flink.runtime.heartbeat.HeartbeatServices;
 import org.apache.flink.runtime.highavailability.HighAvailabilityServices;
@@ -45,7 +45,7 @@ class TestingTaskExecutor extends TaskExecutor {
             HeartbeatServices heartbeatServices,
             TaskManagerMetricGroup taskManagerMetricGroup,
             @Nullable String metricQueryServiceAddress,
-            BlobCacheService blobCacheService,
+            TaskExecutorBlobService taskExecutorBlobService,
             FatalErrorHandler fatalErrorHandler,
             TaskExecutorPartitionTracker partitionTracker) {
         super(
@@ -57,7 +57,7 @@ class TestingTaskExecutor extends TaskExecutor {
                 heartbeatServices,
                 taskManagerMetricGroup,
                 metricQueryServiceAddress,
-                blobCacheService,
+                taskExecutorBlobService,
                 fatalErrorHandler,
                 partitionTracker);
     }


### PR DESCRIPTION
## What is the purpose of the change

This commit decouples the TaskExecutor from the BlobCacheService implementation by introducing a TaskExecutorBlobService interface that abstracts the concrete implementation details away. Due to this change we also introduced a JobPermanentBlobService to decoupled the TaskExecutor from relying on the PermanentBlobCache implementation. Moreover, this commit introduces a NoOpTaskExecutorBlobService that simplifies testing.

## Verifying this change

Covered by existing tests.

## Does this pull request potentially affect one of the following parts:

  - Dependencies (does it add or upgrade a dependency): (yes / **no**)
  - The public API, i.e., is any changed class annotated with `@Public(Evolving)`: (yes / **no**)
  - The serializers: (yes / **no** / don't know)
  - The runtime per-record code paths (performance sensitive): (yes / **no** / don't know)
  - Anything that affects deployment or recovery: JobManager (and its components), Checkpointing, Kubernetes/Yarn, ZooKeeper: (**yes** / no / don't know)
  - The S3 file system connector: (yes / **no** / don't know)

## Documentation

  - Does this pull request introduce a new feature? (yes / **no**)
  - If yes, how is the feature documented? (**not applicable** / docs / JavaDocs / not documented)
