### PR TITLE
[FLINK-24077][hbase2/HBaseConnectorITCase] fix flaky tests backport to 1.12

### DIFF
--- a/flink-connectors/flink-connector-hbase-2.2/src/test/java/org/apache/flink/connector/hbase2/HBaseConnectorITCase.java
+++ b/flink-connectors/flink-connector-hbase-2.2/src/test/java/org/apache/flink/connector/hbase2/HBaseConnectorITCase.java
@@ -25,6 +25,7 @@ import org.apache.flink.api.java.DataSet;
 import org.apache.flink.api.java.ExecutionEnvironment;
 import org.apache.flink.api.java.tuple.Tuple1;
 import org.apache.flink.api.java.typeutils.RowTypeInfo;
+import org.apache.flink.configuration.Configuration;
 import org.apache.flink.connector.hbase.util.HBaseTableSchema;
 import org.apache.flink.connector.hbase.util.PlannerType;
 import org.apache.flink.connector.hbase2.source.AbstractTableInputFormat;
@@ -33,6 +34,7 @@ import org.apache.flink.connector.hbase2.source.HBaseRowDataInputFormat;
 import org.apache.flink.connector.hbase2.source.HBaseRowInputFormat;
 import org.apache.flink.connector.hbase2.source.HBaseTableSource;
 import org.apache.flink.connector.hbase2.util.HBaseTestBase;
+import org.apache.flink.runtime.testutils.MiniClusterResourceConfiguration;
 import org.apache.flink.streaming.api.datastream.DataStream;
 import org.apache.flink.streaming.api.environment.StreamExecutionEnvironment;
 import org.apache.flink.table.api.DataTypes;
@@ -46,6 +48,7 @@ import org.apache.flink.table.api.internal.TableEnvironmentInternal;
 import org.apache.flink.table.descriptors.HBase;
 import org.apache.flink.table.descriptors.Schema;
 import org.apache.flink.table.functions.ScalarFunction;
+import org.apache.flink.test.util.MiniClusterWithClientResource;
 import org.apache.flink.test.util.TestBaseUtils;
 import org.apache.flink.types.Row;
 import org.apache.flink.types.RowKind;
@@ -57,6 +60,7 @@ import org.apache.hadoop.hbase.TableName;
 import org.apache.hadoop.hbase.client.Result;
 import org.apache.hadoop.hbase.client.Scan;
 import org.apache.hadoop.hbase.util.Bytes;
+import org.junit.ClassRule;
 import org.junit.Test;
 import org.junit.runner.RunWith;
 import org.junit.runners.Parameterized;
@@ -76,6 +80,13 @@ import static org.junit.Assert.assertNull;
 /** IT cases for HBase connector (including HBaseTableSource and HBaseTableSink). */
 @RunWith(Parameterized.class)
 public class HBaseConnectorITCase extends HBaseTestBase {
+
+    @ClassRule
+    public static final MiniClusterWithClientResource MINI_CLUSTER =
+            new MiniClusterWithClientResource(
+                    new MiniClusterResourceConfiguration.Builder()
+                            .setConfiguration(new Configuration())
+                            .build());
 
     @Parameterized.Parameter public PlannerType planner;
 
@@ -436,8 +447,6 @@ public class HBaseConnectorITCase extends HBaseTestBase {
                                 + " AS h");
 
         TableResult tableResult2 = table.execute();
-        // wait to finish
-        tableResult2.getJobClient().get().getJobExecutionResult().get();
 
         List<Row> results = CollectionUtil.iteratorToList(tableResult2.collect());
 
@@ -529,8 +538,6 @@ public class HBaseConnectorITCase extends HBaseTestBase {
                         + " AS h";
 
         TableResult tableResult3 = batchEnv.executeSql(query);
-        // wait to finish
-        tableResult3.getJobClient().get().getJobExecutionResult().get();
 
         List<String> result =
                 Lists.newArrayList(tableResult3.collect()).stream()

--- a/flink-connectors/flink-connector-hbase-2.2/src/test/java/org/apache/flink/connector/hbase2/HBaseConnectorITCase.java
+++ b/flink-connectors/flink-connector-hbase-2.2/src/test/java/org/apache/flink/connector/hbase2/HBaseConnectorITCase.java
@@ -39,6 +39,7 @@ import org.apache.flink.table.api.DataTypes;
 import org.apache.flink.table.api.Table;
 import org.apache.flink.table.api.TableConfig;
 import org.apache.flink.table.api.TableEnvironment;
+import org.apache.flink.table.api.TableResult;
 import org.apache.flink.table.api.bridge.java.BatchTableEnvironment;
 import org.apache.flink.table.api.bridge.java.StreamTableEnvironment;
 import org.apache.flink.table.api.internal.TableEnvironmentInternal;
@@ -47,6 +48,7 @@ import org.apache.flink.table.descriptors.Schema;
 import org.apache.flink.table.functions.ScalarFunction;
 import org.apache.flink.test.util.TestBaseUtils;
 import org.apache.flink.types.Row;
+import org.apache.flink.types.RowKind;
 import org.apache.flink.util.CollectionUtil;
 
 import org.apache.flink.shaded.guava18.com.google.common.collect.Lists;
@@ -392,12 +394,32 @@ public class HBaseConnectorITCase extends HBaseTestBase {
                         + " FROM "
                         + TEST_TABLE_1;
 
+        TableResult tableResult = tEnv.executeSql(query);
+
         // wait to finish
-        tEnv.executeSql(query).await();
+        tableResult.await();
+
+        assertEquals(
+                "Expected INSERT rowKind", RowKind.INSERT, tableResult.collect().next().getKind());
 
         // start a batch scan job to verify contents in HBase table
         TableEnvironment batchEnv = createBatchTableEnv();
         batchEnv.executeSql(table2DDL);
+
+        List<String> expected = new ArrayList<>();
+        expected.add("1,10,Hello-1,100,1.01,false,Welt-1\n");
+        expected.add("2,20,Hello-2,200,2.02,true,Welt-2\n");
+        expected.add("3,30,Hello-3,300,3.03,false,Welt-3\n");
+        expected.add("4,40,null,400,4.04,true,Welt-4\n");
+        expected.add("5,50,Hello-5,500,5.05,false,Welt-5\n");
+        expected.add("6,60,Hello-6,600,6.06,true,Welt-6\n");
+        expected.add("7,70,Hello-7,700,7.07,false,Welt-7\n");
+        expected.add("8,80,null,800,8.08,true,Welt-8\n");
+
+        Table countTable =
+                batchEnv.sqlQuery("SELECT COUNT(h.rowkey) FROM " + TEST_TABLE_2 + " AS h");
+
+        assertEquals(new Long(expected.size()), countTable.execute().collect().next().getField(0));
 
         Table table =
                 batchEnv.sqlQuery(
@@ -412,18 +434,14 @@ public class HBaseConnectorITCase extends HBaseTestBase {
                                 + "FROM "
                                 + TEST_TABLE_2
                                 + " AS h");
-        List<Row> results = CollectionUtil.iteratorToList(table.execute().collect());
-        String expected =
-                "1,10,Hello-1,100,1.01,false,Welt-1\n"
-                        + "2,20,Hello-2,200,2.02,true,Welt-2\n"
-                        + "3,30,Hello-3,300,3.03,false,Welt-3\n"
-                        + "4,40,null,400,4.04,true,Welt-4\n"
-                        + "5,50,Hello-5,500,5.05,false,Welt-5\n"
-                        + "6,60,Hello-6,600,6.06,true,Welt-6\n"
-                        + "7,70,Hello-7,700,7.07,false,Welt-7\n"
-                        + "8,80,null,800,8.08,true,Welt-8\n";
 
-        TestBaseUtils.compareResultAsText(results, expected);
+        TableResult tableResult2 = table.execute();
+        // wait to finish
+        tableResult2.getJobClient().get().getJobExecutionResult().get();
+
+        List<Row> results = CollectionUtil.iteratorToList(tableResult2.collect());
+
+        TestBaseUtils.compareResultAsText(results, String.join("", expected));
     }
 
     @Test
@@ -457,34 +475,18 @@ public class HBaseConnectorITCase extends HBaseTestBase {
                         + " family4"
                         + " from "
                         + TEST_TABLE_1;
+
+        TableResult tableResult = tEnv.executeSql(insertStatement);
+
         // wait to finish
-        tEnv.executeSql(insertStatement).await();
+        tableResult.await();
+
+        assertEquals(
+                "Expected INSERT rowKind", RowKind.INSERT, tableResult.collect().next().getKind());
 
         // start a batch scan job to verify contents in HBase table
         TableEnvironment batchEnv = createBatchTableEnv();
         batchEnv.executeSql(table3DDL);
-        String query =
-                "SELECT "
-                        + "  h.rowkey, "
-                        + "  h.family1.col1, "
-                        + "  h.family2.col1, "
-                        + "  h.family2.col2, "
-                        + "  h.family3.col1, "
-                        + "  h.family3.col2, "
-                        + "  h.family3.col3, "
-                        + "  h.family4.col1, "
-                        + "  h.family4.col2, "
-                        + "  h.family4.col3, "
-                        + "  h.family4.col4 "
-                        + " FROM "
-                        + TEST_TABLE_3
-                        + " AS h";
-        Iterator<Row> collected = tEnv.executeSql(query).collect();
-        List<String> result =
-                Lists.newArrayList(collected).stream()
-                        .map(Row::toString)
-                        .sorted()
-                        .collect(Collectors.toList());
 
         List<String> expected = new ArrayList<>();
         expected.add(
@@ -503,6 +505,39 @@ public class HBaseConnectorITCase extends HBaseTestBase {
                 "7,70,Hello-7,700,7.07,false,Welt-7,2019-08-19T19:30,2019-08-19,19:30,12345678.0007");
         expected.add(
                 "8,80,null,800,8.08,true,Welt-8,2019-08-19T19:40,2019-08-19,19:40,12345678.0008");
+
+        Table countTable =
+                batchEnv.sqlQuery("SELECT COUNT(h.rowkey) FROM " + TEST_TABLE_3 + " AS h");
+
+        assertEquals(new Long(expected.size()), countTable.execute().collect().next().getField(0));
+
+        String query =
+                "SELECT "
+                        + "  h.rowkey, "
+                        + "  h.family1.col1, "
+                        + "  h.family2.col1, "
+                        + "  h.family2.col2, "
+                        + "  h.family3.col1, "
+                        + "  h.family3.col2, "
+                        + "  h.family3.col3, "
+                        + "  h.family4.col1, "
+                        + "  h.family4.col2, "
+                        + "  h.family4.col3, "
+                        + "  h.family4.col4 "
+                        + " FROM "
+                        + TEST_TABLE_3
+                        + " AS h";
+
+        TableResult tableResult3 = batchEnv.executeSql(query);
+        // wait to finish
+        tableResult3.getJobClient().get().getJobExecutionResult().get();
+
+        List<String> result =
+                Lists.newArrayList(tableResult3.collect()).stream()
+                        .map(Row::toString)
+                        .sorted()
+                        .collect(Collectors.toList());
+
         assertEquals(expected, result);
     }
 


### PR DESCRIPTION
## What is the purpose of the change

there are multiple failing tests during CI only happened for `hbase2`. The potential reason might be some race conditions while running the CI on azure. This PR adds some additional checks and explicitly method calls to make sure the result has been fetched before doing the assertions. Local checks haven been done multiple times and none failing test happened.

## Brief change log

  - add check of row count after insert
  - use `MiniClusterWithClientResource` as a `ClassRule`

## Verifying this change

This change is a trivial rework / test case improvement.

## Does this pull request potentially affect one of the following parts:

  - Dependencies (does it add or upgrade a dependency): (yes / **no**)
  - The public API, i.e., is any changed class annotated with `@Public(Evolving)`: (yes / **no**)
  - The serializers: (yes / **no** / don't know)
  - The runtime per-record code paths (performance sensitive): (yes / **no** / don't know)
  - Anything that affects deployment or recovery: JobManager (and its components), Checkpointing, Kubernetes/Yarn, ZooKeeper: (yes / **no** / don't know)
  - The S3 file system connector: (yes / **no** / don't know)

## Documentation

  - Does this pull request introduce a new feature? (yes / **no**)
