### PR TITLE
[FLINK-25261][state] Truncate changelog upon materialization

### DIFF
--- a/flink-dstl/flink-dstl-dfs/src/main/java/org/apache/flink/changelog/fs/FsStateChangelogWriter.java
+++ b/flink-dstl/flink-dstl-dfs/src/main/java/org/apache/flink/changelog/fs/FsStateChangelogWriter.java
@@ -317,6 +317,11 @@ class FsStateChangelogWriter implements StateChangelogWriter<ChangelogStateHandl
         return activeSequenceNumber;
     }
 
+    @VisibleForTesting
+    public SequenceNumber getLowestSequenceNumber() {
+        return lowestSequenceNumber;
+    }
+
     private void ensureCanPersist(SequenceNumber from) throws IOException {
         checkNotNull(from);
         if (highestFailed != null && highestFailed.f0.compareTo(from) >= 0) {

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/state/changelog/StateChangelogWriter.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/state/changelog/StateChangelogWriter.java
@@ -18,6 +18,7 @@
 package org.apache.flink.runtime.state.changelog;
 
 import org.apache.flink.annotation.Internal;
+import org.apache.flink.annotation.VisibleForTesting;
 
 import java.io.IOException;
 import java.util.concurrent.CompletableFuture;
@@ -49,9 +50,9 @@ public interface StateChangelogWriter<Handle extends ChangelogStateHandle> exten
     CompletableFuture<Handle> persist(SequenceNumber from) throws IOException;
 
     /**
-     * Truncate this state changelog to free up resources. Called upon state materialization. Any
-     * {@link #persist(SequenceNumber) persisted} state changes will be discarded unless previously
-     * {@link #confirm confirmed}.
+     * Truncate in-memory view of this state changelog to free up resources. Called upon state
+     * materialization. Any {@link #persist(SequenceNumber) persisted} state changes will not be
+     * discarded; any ongoing persist calls will not be affected.
      *
      * @param to exclusive
      */
@@ -76,4 +77,7 @@ public interface StateChangelogWriter<Handle extends ChangelogStateHandle> exten
      * be lost.
      */
     void close();
+
+    @VisibleForTesting
+    SequenceNumber getLowestSequenceNumber();
 }

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/state/changelog/inmemory/InMemoryStateChangelogWriter.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/state/changelog/inmemory/InMemoryStateChangelogWriter.java
@@ -34,6 +34,7 @@ import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
 import java.util.NavigableMap;
+import java.util.SortedMap;
 import java.util.TreeMap;
 import java.util.concurrent.CompletableFuture;
 import java.util.stream.Collectors;
@@ -100,6 +101,15 @@ class InMemoryStateChangelogWriter implements StateChangelogWriter<InMemoryChang
     public void close() {
         Preconditions.checkState(!closed);
         closed = true;
+    }
+
+    @Override
+    public SequenceNumber getLowestSequenceNumber() {
+        return changesByKeyGroup.values().stream()
+                .filter(map -> !map.isEmpty())
+                .map(SortedMap::firstKey)
+                .min(Comparator.naturalOrder())
+                .orElse(initialSequenceNumber());
     }
 
     @Override

--- a/flink-state-backends/flink-statebackend-changelog/src/main/java/org/apache/flink/state/changelog/ChangelogKeyedStateBackend.java
+++ b/flink-state-backends/flink-statebackend-changelog/src/main/java/org/apache/flink/state/changelog/ChangelogKeyedStateBackend.java
@@ -645,6 +645,8 @@ public class ChangelogKeyedStateBackend<K>
         changelogSnapshotState =
                 new ChangelogSnapshotState(
                         getMaterializedResult(materializedSnapshot), Collections.emptyList(), upTo);
+
+        stateChangelogWriter.truncate(upTo);
     }
 
     // TODO: this method may change after the ownership PR
@@ -781,5 +783,10 @@ public class ChangelogKeyedStateBackend<K>
         public List<ChangelogStateHandle> getRestoredNonMaterialized() {
             return restoredNonMaterialized;
         }
+    }
+
+    @VisibleForTesting
+    StateChangelogWriter<ChangelogStateHandle> getChangelogWriter() {
+        return stateChangelogWriter;
     }
 }

--- a/flink-state-backends/flink-statebackend-changelog/src/test/java/org/apache/flink/state/changelog/StateChangeLoggerTestBase.java
+++ b/flink-state-backends/flink-statebackend-changelog/src/test/java/org/apache/flink/state/changelog/StateChangeLoggerTestBase.java
@@ -135,5 +135,10 @@ abstract class StateChangeLoggerTestBase<Namespace> {
 
         @Override
         public void close() {}
+
+        @Override
+        public SequenceNumber getLowestSequenceNumber() {
+            return initialSequenceNumber();
+        }
     }
 }


### PR DESCRIPTION
## What is the purpose of the change

Truncate state changelog upon backend materialization.
I.e. add missing call `stateChangelogWriter.truncate` from `ChangelogKeyedStateBackend.updateChangelogSnapshotState`.

## Verifying this change

Add assertion to `ChangelogStateBackendTestUtils.materialize` used in materialization tests.

## Does this pull request potentially affect one of the following parts:

  - Dependencies (does it add or upgrade a dependency): no
  - The public API, i.e., is any changed class annotated with `@Public(Evolving)`: no
  - The serializers: no
  - The runtime per-record code paths (performance sensitive): no
  - Anything that affects deployment or recovery: JobManager (and its components), Checkpointing, Kubernetes/Yarn/Mesos, ZooKeeper: no
  - The S3 file system connector: no

## Documentation

  - Does this pull request introduce a new feature? no
  - If yes, how is the feature documented? no
