### PR TITLE
[FLINK-25192][checkpointing] Implement no-claim mode support

### DIFF
--- a/docs/layouts/shortcodes/generated/rest_v1_dispatcher.html
+++ b/docs/layouts/shortcodes/generated/rest_v1_dispatcher.html
@@ -871,7 +871,7 @@ Using 'curl' you can upload a jar via 'curl -X POST -H "Expect:" -F "jarfile=@pa
     },
     "restoreMode" : {
       "type" : "string",
-      "enum" : [ "CLAIM", "LEGACY" ]
+      "enum" : [ "CLAIM", "NO_CLAIM", "LEGACY" ]
     },
     "savepointPath" : {
       "type" : "string"

--- a/docs/layouts/shortcodes/generated/savepoint_config_configuration.html
+++ b/docs/layouts/shortcodes/generated/savepoint_config_configuration.html
@@ -10,9 +10,9 @@
     <tbody>
         <tr>
             <td><h5>execution.savepoint-restore-mode</h5></td>
-            <td style="word-wrap: break-word;">LEGACY</td>
+            <td style="word-wrap: break-word;">NO_CLAIM</td>
             <td><p>Enum</p></td>
-            <td>Describes the mode how Flink should restore from the given savepoint or retained checkpoint.<br /><br />Possible values:<ul><li>"CLAIM": Flink will take ownership of the given snapshot. It will clean the snapshot once it is subsumed by newer ones.</li><li>"LEGACY": Flink will not claim ownership of the snapshot and will not delete the files. However, it can directly depend on the existence of the files of the restored checkpoint. It might not be safe to delete checkpoints that were restored in legacy mode </li></ul></td>
+            <td>Describes the mode how Flink should restore from the given savepoint or retained checkpoint.<br /><br />Possible values:<ul><li>"CLAIM": Flink will take ownership of the given snapshot. It will clean the snapshot once it is subsumed by newer ones.</li><li>"NO_CLAIM": Flink will not claim ownership of the snapshot files. However it will make sure it does not depend on any artefacts from the restored snapshot. In order to do that, Flink will take the first checkpoint as a full one, which means it might reupload/duplicate files that are part of the restored checkpoint.</li><li>"LEGACY": This is the mode in which Flink worked so far. It will not claim ownership of the snapshot and will not delete the files. However, it can directly depend on the existence of the files of the restored checkpoint. It might not be safe to delete checkpoints that were restored in legacy mode </li></ul></td>
         </tr>
         <tr>
             <td><h5>execution.savepoint.ignore-unclaimed-state</h5></td>

--- a/flink-clients/src/main/java/org/apache/flink/client/cli/CliFrontendParser.java
+++ b/flink-clients/src/main/java/org/apache/flink/client/cli/CliFrontendParser.java
@@ -138,8 +138,10 @@ public class CliFrontendParser {
                     true,
                     "Defines how should we restore from the given savepoint. Supported options: "
                             + "[claim - claim ownership of the savepoint and delete once it is"
-                            + " subsumed, legacy (default) - do not assume ownership of the"
-                            + " savepoint files.");
+                            + " subsumed, no_claim (default) - do not claim ownership, the first"
+                            + " checkpoint will not reuse any files from the restored one, legacy "
+                            + "- the old behaviour, do not assume ownership of the savepoint files,"
+                            + " but can reuse some shared files.");
 
     static final Option SAVEPOINT_DISPOSE_OPTION =
             new Option("d", "dispose", true, "Path of savepoint to dispose.");

--- a/flink-clients/src/test/java/org/apache/flink/client/cli/CliFrontendRunTest.java
+++ b/flink-clients/src/test/java/org/apache/flink/client/cli/CliFrontendRunTest.java
@@ -171,6 +171,26 @@ public class CliFrontendRunTest extends CliFrontendTestBase {
         assertTrue(savepointSettings.allowNonRestoredState());
     }
 
+    @Test
+    public void testNoClaimRestoreModeParsing() throws Exception {
+        // test configure savepoint with claim mode
+        String[] parameters = {
+            "-s", "expectedSavepointPath", "-n", "-restoreMode", "no_claim", getTestJarPath()
+        };
+
+        CommandLine commandLine =
+                CliFrontendParser.parse(CliFrontendParser.RUN_OPTIONS, parameters, true);
+        ProgramOptions programOptions = ProgramOptions.create(commandLine);
+        ExecutionConfigAccessor executionOptions =
+                ExecutionConfigAccessor.fromProgramOptions(programOptions, Collections.emptyList());
+
+        SavepointRestoreSettings savepointSettings = executionOptions.getSavepointRestoreSettings();
+        assertTrue(savepointSettings.restoreSavepoint());
+        assertEquals(RestoreMode.NO_CLAIM, savepointSettings.getRestoreMode());
+        assertEquals("expectedSavepointPath", savepointSettings.getRestorePath());
+        assertTrue(savepointSettings.allowNonRestoredState());
+    }
+
     @Test(expected = CliArgsException.class)
     public void testUnrecognizedOption() throws Exception {
         // test unrecognized option

--- a/flink-end-to-end-tests/flink-stream-state-ttl-test/src/main/java/org/apache/flink/streaming/tests/StubStateBackend.java
+++ b/flink-end-to-end-tests/flink-stream-state-ttl-test/src/main/java/org/apache/flink/streaming/tests/StubStateBackend.java
@@ -94,4 +94,9 @@ final class StubStateBackend implements StateBackend {
         return backend.createOperatorStateBackend(
                 env, operatorIdentifier, stateHandles, cancelStreamRegistry);
     }
+
+    @Override
+    public boolean supportsNoClaimRestoreMode() {
+        return backend.supportsNoClaimRestoreMode();
+    }
 }

--- a/flink-runtime-web/src/test/resources/rest_api_v1.snapshot
+++ b/flink-runtime-web/src/test/resources/rest_api_v1.snapshot
@@ -438,7 +438,7 @@
         },
         "restoreMode" : {
           "type" : "string",
-          "enum" : [ "CLAIM", "LEGACY" ]
+          "enum" : [ "CLAIM", "NO_CLAIM", "LEGACY" ]
         }
       }
     },

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/checkpoint/CheckpointCoordinator.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/checkpoint/CheckpointCoordinator.java
@@ -218,6 +218,7 @@ public class CheckpointCoordinator {
     private final ExecutionAttemptMappingProvider attemptMappingProvider;
 
     private boolean baseLocationsForCheckpointInitialized = false;
+    private boolean forceFullSnapshot;
 
     // --------------------------------------------------------------------------------------------
 
@@ -684,9 +685,16 @@ public class CheckpointCoordinator {
         // no exception, no discarding, everything is OK
         final long checkpointId = checkpoint.getCheckpointID();
 
+        final CheckpointType type;
+        if (this.forceFullSnapshot && !request.props.isSavepoint()) {
+            type = CheckpointType.FULL_CHECKPOINT;
+        } else {
+            type = request.props.getCheckpointType();
+        }
+
         final CheckpointOptions checkpointOptions =
                 CheckpointOptions.forConfig(
-                        request.props.getCheckpointType(),
+                        type,
                         checkpoint.getCheckpointStorageLocation().getLocationReference(),
                         isExactlyOnceMode,
                         unalignedCheckpointsEnabled,
@@ -1261,6 +1269,10 @@ public class CheckpointCoordinator {
                     completedCheckpoint.getTimestamp(),
                     extractIdIfDiscardedOnSubsumed(lastSubsumed));
         }
+
+        // reset the force full snapshot flag, we should've completed at least on full snapshot by
+        // now
+        this.forceFullSnapshot = false;
     }
 
     private void logCheckpointInfo(CompletedCheckpoint completedCheckpoint) {
@@ -1591,6 +1603,8 @@ public class CheckpointCoordinator {
 
             LOG.info("Restoring job {} from {}.", job, latest);
 
+            this.forceFullSnapshot = latest.getProperties().isUnclaimed();
+
             // re-assign the task states
             final Map<OperatorID, OperatorState> operatorStates = extractOperatorStates(latest);
 
@@ -1694,6 +1708,9 @@ public class CheckpointCoordinator {
                 break;
             case LEGACY:
                 checkpointProperties = CheckpointProperties.forSavepoint(false);
+                break;
+            case NO_CLAIM:
+                checkpointProperties = CheckpointProperties.forUnclaimedSnapshot();
                 break;
             default:
                 throw new IllegalArgumentException("Unknown snapshot restore mode");

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/checkpoint/CheckpointType.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/checkpoint/CheckpointType.java
@@ -22,16 +22,28 @@ package org.apache.flink.runtime.checkpoint;
 public enum CheckpointType {
 
     /** A checkpoint, full or incremental. */
-    CHECKPOINT(false, PostCheckpointAction.NONE, "Checkpoint"),
+    CHECKPOINT(
+            false, PostCheckpointAction.NONE, "Checkpoint", SharingFilesStrategy.FORWARD_BACKWARD),
 
     /** A regular savepoint. */
-    SAVEPOINT(true, PostCheckpointAction.NONE, "Savepoint"),
+    SAVEPOINT(true, PostCheckpointAction.NONE, "Savepoint", SharingFilesStrategy.NO_SHARING),
 
     /** A savepoint taken while suspending the job. */
-    SAVEPOINT_SUSPEND(true, PostCheckpointAction.SUSPEND, "Suspend Savepoint"),
+    SAVEPOINT_SUSPEND(
+            true,
+            PostCheckpointAction.SUSPEND,
+            "Suspend Savepoint",
+            SharingFilesStrategy.NO_SHARING),
 
     /** A savepoint taken while terminating the job. */
-    SAVEPOINT_TERMINATE(true, PostCheckpointAction.TERMINATE, "Terminate Savepoint");
+    SAVEPOINT_TERMINATE(
+            true,
+            PostCheckpointAction.TERMINATE,
+            "Terminate Savepoint",
+            SharingFilesStrategy.NO_SHARING),
+
+    FULL_CHECKPOINT(
+            false, PostCheckpointAction.NONE, "Full Checkpoint", SharingFilesStrategy.FORWARD);
 
     private final boolean isSavepoint;
 
@@ -39,14 +51,18 @@ public enum CheckpointType {
 
     private final String name;
 
+    private final SharingFilesStrategy sharingFilesStrategy;
+
     CheckpointType(
             final boolean isSavepoint,
             final PostCheckpointAction postCheckpointAction,
-            final String name) {
+            final String name,
+            SharingFilesStrategy sharingFilesStrategy) {
 
         this.isSavepoint = isSavepoint;
         this.postCheckpointAction = postCheckpointAction;
         this.name = name;
+        this.sharingFilesStrategy = sharingFilesStrategy;
     }
 
     public boolean isSavepoint() {
@@ -77,10 +93,26 @@ public enum CheckpointType {
         return name;
     }
 
+    public SharingFilesStrategy getSharingFilesStrategy() {
+        return sharingFilesStrategy;
+    }
+
     /** What's the intended action after the checkpoint (relevant for stopping with savepoint). */
     public enum PostCheckpointAction {
         NONE,
         SUSPEND,
         TERMINATE
+    }
+
+    /** Defines what files can be shared across snapshots. */
+    public enum SharingFilesStrategy {
+        // current snapshot can share files with previous snapshots.
+        // new snapshots can use files of the current snapshot
+        FORWARD_BACKWARD,
+        // later snapshots can share files with the current snapshot
+        FORWARD,
+        // current snapshot can not use files of older ones, future snapshots can
+        // not use files of the current one.
+        NO_SHARING;
     }
 }

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/checkpoint/CompletedCheckpoint.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/checkpoint/CompletedCheckpoint.java
@@ -204,7 +204,10 @@ public class CompletedCheckpoint implements Serializable, Checkpoint {
      * @param sharedStateRegistry The registry where shared states are registered
      */
     public void registerSharedStatesAfterRestored(SharedStateRegistry sharedStateRegistry) {
-        sharedStateRegistry.registerAll(operatorStates.values(), checkpointID);
+        // in claim mode we should not register any shared handles
+        if (!props.isUnclaimed()) {
+            sharedStateRegistry.registerAll(operatorStates.values(), checkpointID);
+        }
     }
 
     // ------------------------------------------------------------------------

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/io/network/api/serialization/EventSerializer.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/io/network/api/serialization/EventSerializer.java
@@ -80,6 +80,8 @@ public class EventSerializer {
 
     private static final int CHECKPOINT_TYPE_SAVEPOINT_TERMINATE = 3;
 
+    private static final int CHECKPOINT_TYPE_FULL_CHECKPOINT = 4;
+
     // ------------------------------------------------------------------------
     //  Serialization Logic
     // ------------------------------------------------------------------------
@@ -229,6 +231,8 @@ public class EventSerializer {
         final int typeInt;
         if (checkpointType == CheckpointType.CHECKPOINT) {
             typeInt = CHECKPOINT_TYPE_CHECKPOINT;
+        } else if (checkpointType == CheckpointType.FULL_CHECKPOINT) {
+            typeInt = CHECKPOINT_TYPE_FULL_CHECKPOINT;
         } else if (checkpointType == CheckpointType.SAVEPOINT) {
             typeInt = CHECKPOINT_TYPE_SAVEPOINT;
         } else if (checkpointType == CheckpointType.SAVEPOINT_SUSPEND) {
@@ -268,6 +272,8 @@ public class EventSerializer {
         final CheckpointType checkpointType;
         if (checkpointTypeCode == CHECKPOINT_TYPE_CHECKPOINT) {
             checkpointType = CheckpointType.CHECKPOINT;
+        } else if (checkpointTypeCode == CHECKPOINT_TYPE_FULL_CHECKPOINT) {
+            checkpointType = CheckpointType.FULL_CHECKPOINT;
         } else if (checkpointTypeCode == CHECKPOINT_TYPE_SAVEPOINT) {
             checkpointType = CheckpointType.SAVEPOINT;
         } else if (checkpointTypeCode == CHECKPOINT_TYPE_SAVEPOINT_SUSPEND) {

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/jobgraph/RestoreMode.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/jobgraph/RestoreMode.java
@@ -31,10 +31,16 @@ public enum RestoreMode implements DescribedEnum {
     CLAIM(
             "Flink will take ownership of the given snapshot. It will clean the"
                     + " snapshot once it is subsumed by newer ones."),
+    NO_CLAIM(
+            "Flink will not claim ownership of the snapshot files. However it will make sure it"
+                    + " does not depend on any artefacts from the restored snapshot. In order to do that,"
+                    + " Flink will take the first checkpoint as a full one, which means it might"
+                    + " reupload/duplicate files that are part of the restored checkpoint."),
     LEGACY(
-            "Flink will not claim ownership of the snapshot and will not delete the files. However, "
-                    + "it can directly depend on the existence of the files of the restored checkpoint. "
-                    + "It might not be safe to delete checkpoints that were restored in legacy mode ");
+            "This is the mode in which Flink worked so far. It will not claim ownership of the"
+                    + " snapshot and will not delete the files. However, it can directly depend on"
+                    + " the existence of the files of the restored checkpoint. It might not be safe"
+                    + " to delete checkpoints that were restored in legacy mode ");
 
     private final String description;
 

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/jobgraph/SavepointConfigOptions.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/jobgraph/SavepointConfigOptions.java
@@ -52,7 +52,7 @@ public class SavepointConfigOptions {
     public static final ConfigOption<RestoreMode> RESTORE_MODE =
             key("execution.savepoint-restore-mode")
                     .enumType(RestoreMode.class)
-                    .defaultValue(RestoreMode.LEGACY)
+                    .defaultValue(RestoreMode.NO_CLAIM)
                     .withDescription(
                             "Describes the mode how Flink should restore from the given"
                                     + " savepoint or retained checkpoint.");

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/jobgraph/SavepointRestoreSettings.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/jobgraph/SavepointRestoreSettings.java
@@ -33,7 +33,7 @@ public class SavepointRestoreSettings implements Serializable {
 
     /** No restore should happen. */
     private static final SavepointRestoreSettings NONE =
-            new SavepointRestoreSettings(null, false, RestoreMode.LEGACY);
+            new SavepointRestoreSettings(null, false, RestoreMode.NO_CLAIM);
 
     /** Savepoint restore path. */
     private final String restorePath;

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/state/StateBackend.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/state/StateBackend.java
@@ -23,7 +23,10 @@ import org.apache.flink.api.common.JobID;
 import org.apache.flink.api.common.typeutils.TypeSerializer;
 import org.apache.flink.core.fs.CloseableRegistry;
 import org.apache.flink.metrics.MetricGroup;
+import org.apache.flink.runtime.checkpoint.CheckpointOptions;
+import org.apache.flink.runtime.checkpoint.CheckpointType;
 import org.apache.flink.runtime.execution.Environment;
+import org.apache.flink.runtime.jobgraph.RestoreMode;
 import org.apache.flink.runtime.query.TaskKvStateRegistry;
 import org.apache.flink.runtime.state.ttl.TtlTimeProvider;
 
@@ -170,6 +173,19 @@ public interface StateBackend extends java.io.Serializable {
 
     /** Whether the state backend uses Flink's managed memory. */
     default boolean useManagedMemory() {
+        return false;
+    }
+
+    /**
+     * Tells if a state backend supports the {@link RestoreMode#NO_CLAIM} mode.
+     *
+     * <p>If a state backend supports {@code NO_CLAIM} mode, it should create an independent
+     * snapshot when it receives {@link CheckpointType#FULL_CHECKPOINT} in {@link
+     * Snapshotable#snapshot(long, long, CheckpointStreamFactory, CheckpointOptions)}.
+     *
+     * @return If the state backend supports {@link RestoreMode#NO_CLAIM} mode.
+     */
+    default boolean supportsNoClaimRestoreMode() {
         return false;
     }
 }

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/state/filesystem/FsStateBackend.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/state/filesystem/FsStateBackend.java
@@ -496,6 +496,12 @@ public class FsStateBackend extends AbstractFileStateBackend implements Configur
         return true;
     }
 
+    @Override
+    public boolean supportsNoClaimRestoreMode() {
+        // we never share any files, all snapshots are full
+        return true;
+    }
+
     // ------------------------------------------------------------------------
     //  Reconfiguration
     // ------------------------------------------------------------------------

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/state/hashmap/HashMapStateBackend.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/state/hashmap/HashMapStateBackend.java
@@ -92,6 +92,12 @@ public class HashMapStateBackend extends AbstractStateBackend implements Configu
     }
 
     @Override
+    public boolean supportsNoClaimRestoreMode() {
+        // we never share any files, all snapshots are full
+        return true;
+    }
+
+    @Override
     public <K> AbstractKeyedStateBackend<K> createKeyedStateBackend(
             Environment env,
             JobID jobID,

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/state/memory/MemoryStateBackend.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/state/memory/MemoryStateBackend.java
@@ -286,6 +286,12 @@ public class MemoryStateBackend extends AbstractFileStateBackend
         return true;
     }
 
+    @Override
+    public boolean supportsNoClaimRestoreMode() {
+        // we never share any files, all snapshots are full
+        return true;
+    }
+
     // ------------------------------------------------------------------------
     //  Reconfiguration
     // ------------------------------------------------------------------------

--- a/flink-runtime/src/test/java/org/apache/flink/runtime/checkpoint/CheckpointCoordinatorTriggeringTest.java
+++ b/flink-runtime/src/test/java/org/apache/flink/runtime/checkpoint/CheckpointCoordinatorTriggeringTest.java
@@ -26,6 +26,8 @@ import org.apache.flink.runtime.executiongraph.ExecutionAttemptID;
 import org.apache.flink.runtime.executiongraph.ExecutionGraph;
 import org.apache.flink.runtime.executiongraph.ExecutionVertex;
 import org.apache.flink.runtime.jobgraph.JobVertexID;
+import org.apache.flink.runtime.jobgraph.RestoreMode;
+import org.apache.flink.runtime.jobgraph.SavepointRestoreSettings;
 import org.apache.flink.runtime.jobgraph.tasks.CheckpointCoordinatorConfiguration;
 import org.apache.flink.runtime.jobgraph.tasks.CheckpointCoordinatorConfiguration.CheckpointCoordinatorConfigurationBuilder;
 import org.apache.flink.runtime.messages.checkpoint.AcknowledgeCheckpoint;
@@ -36,10 +38,13 @@ import org.apache.flink.util.concurrent.ManuallyTriggeredScheduledExecutor;
 import org.apache.flink.util.concurrent.ScheduledExecutorServiceAdapter;
 
 import org.junit.Before;
+import org.junit.Rule;
 import org.junit.Test;
+import org.junit.rules.TemporaryFolder;
 
 import javax.annotation.Nullable;
 
+import java.util.HashSet;
 import java.util.List;
 import java.util.Optional;
 import java.util.concurrent.CompletableFuture;
@@ -52,6 +57,7 @@ import java.util.function.Predicate;
 
 import static org.apache.flink.util.Preconditions.checkNotNull;
 import static org.hamcrest.CoreMatchers.instanceOf;
+import static org.hamcrest.Matchers.is;
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertFalse;
 import static org.junit.Assert.assertThat;
@@ -63,6 +69,8 @@ public class CheckpointCoordinatorTriggeringTest extends TestLogger {
     private static final String TASK_MANAGER_LOCATION_INFO = "Unknown location";
 
     private ManuallyTriggeredScheduledExecutor manuallyTriggeredScheduledExecutor;
+
+    @Rule public TemporaryFolder temporaryFolder = new TemporaryFolder();
 
     @Before
     public void setUp() throws Exception {
@@ -164,6 +172,97 @@ public class CheckpointCoordinatorTriggeringTest extends TestLogger {
             lastId = checkpoint.checkpointId;
             lastTs = checkpoint.timestamp;
         }
+    }
+
+    @Test
+    public void testTriggeringFullSnapshotAfterJobmasterFailover() throws Exception {
+        CheckpointCoordinatorTestingUtils.CheckpointRecorderTaskManagerGateway gateway =
+                new CheckpointCoordinatorTestingUtils.CheckpointRecorderTaskManagerGateway();
+
+        JobVertexID jobVertexID = new JobVertexID();
+        ExecutionGraph graph =
+                new CheckpointCoordinatorTestingUtils.CheckpointExecutionGraphBuilder()
+                        .addJobVertex(jobVertexID)
+                        .setTaskManagerGateway(gateway)
+                        .build();
+
+        ExecutionVertex vertex = graph.getJobVertex(jobVertexID).getTaskVertices()[0];
+        ExecutionAttemptID attemptID = vertex.getCurrentExecutionAttempt().getAttemptId();
+
+        // create a savepoint, we can restore from later
+        final CompletedCheckpoint savepoint = takeSavepoint(graph, attemptID);
+
+        // restore from a savepoint in NO_CLAIM mode
+        final StandaloneCompletedCheckpointStore checkpointStore =
+                new StandaloneCompletedCheckpointStore(1);
+        final StandaloneCheckpointIDCounter checkpointIDCounter =
+                new StandaloneCheckpointIDCounter();
+        CheckpointCoordinator checkpointCoordinator =
+                createCheckpointCoordinator(graph, checkpointStore, checkpointIDCounter);
+        checkpointCoordinator.restoreSavepoint(
+                SavepointRestoreSettings.forPath(
+                        savepoint.getExternalPointer(), true, RestoreMode.NO_CLAIM),
+                graph.getAllVertices(),
+                this.getClass().getClassLoader());
+        checkpointCoordinator.shutdown();
+
+        // imitate job manager failover
+        gateway.resetCount();
+        checkpointCoordinator =
+                createCheckpointCoordinator(graph, checkpointStore, checkpointIDCounter);
+        checkpointCoordinator.restoreLatestCheckpointedStateToAll(
+                new HashSet<>(graph.getAllVertices().values()), true);
+        checkpointCoordinator.startCheckpointScheduler();
+        final CompletableFuture<CompletedCheckpoint> checkpoint =
+                checkpointCoordinator.triggerCheckpoint(true);
+        manuallyTriggeredScheduledExecutor.triggerAll();
+        checkpointCoordinator.receiveAcknowledgeMessage(
+                new AcknowledgeCheckpoint(graph.getJobID(), attemptID, 2),
+                TASK_MANAGER_LOCATION_INFO);
+        checkpoint.get();
+
+        assertThat(
+                gateway.getOnlyTriggeredCheckpoint(attemptID).checkpointOptions.getCheckpointType(),
+                is(CheckpointType.FULL_CHECKPOINT));
+    }
+
+    private CompletedCheckpoint takeSavepoint(ExecutionGraph graph, ExecutionAttemptID attemptID)
+            throws Exception {
+        CheckpointCoordinator checkpointCoordinator =
+                createCheckpointCoordinator(
+                        graph,
+                        new StandaloneCompletedCheckpointStore(1),
+                        new StandaloneCheckpointIDCounter());
+        final CompletableFuture<CompletedCheckpoint> savepointFuture =
+                checkpointCoordinator.triggerSavepoint(temporaryFolder.newFolder().getPath());
+        manuallyTriggeredScheduledExecutor.triggerAll();
+        checkpointCoordinator.receiveAcknowledgeMessage(
+                new AcknowledgeCheckpoint(graph.getJobID(), attemptID, 1),
+                TASK_MANAGER_LOCATION_INFO);
+        final CompletedCheckpoint savepoint = savepointFuture.get();
+        checkpointCoordinator.shutdown();
+        return savepoint;
+    }
+
+    private CheckpointCoordinator createCheckpointCoordinator(
+            ExecutionGraph graph,
+            StandaloneCompletedCheckpointStore checkpointStore,
+            CheckpointIDCounter checkpointIDCounter)
+            throws Exception {
+        CheckpointCoordinatorConfiguration checkpointCoordinatorConfiguration =
+                new CheckpointCoordinatorConfigurationBuilder()
+                        .setCheckpointInterval(
+                                10000) // periodic is ver long, we trigger checkpoint manually
+                        .setCheckpointTimeout(200000) // timeout is very long (200 s)
+                        .setMaxConcurrentCheckpoints(Integer.MAX_VALUE)
+                        .build();
+        return new CheckpointCoordinatorBuilder()
+                .setExecutionGraph(graph)
+                .setCheckpointCoordinatorConfiguration(checkpointCoordinatorConfiguration)
+                .setCompletedCheckpointStore(checkpointStore)
+                .setCheckpointIDCounter(checkpointIDCounter)
+                .setTimer(manuallyTriggeredScheduledExecutor)
+                .build();
     }
 
     /**

--- a/flink-runtime/src/test/java/org/apache/flink/runtime/checkpoint/CheckpointOptionsTest.java
+++ b/flink-runtime/src/test/java/org/apache/flink/runtime/checkpoint/CheckpointOptionsTest.java
@@ -112,16 +112,25 @@ public class CheckpointOptionsTest {
     public void testCheckpointIsTimeoutable() {
         CheckpointStorageLocationReference location =
                 CheckpointStorageLocationReference.getDefault();
-        assertTimeoutable(CheckpointOptions.alignedWithTimeout(location, 10), false, true, 10);
         assertTimeoutable(
-                CheckpointOptions.unaligned(location), true, false, NO_ALIGNED_CHECKPOINT_TIME_OUT);
+                CheckpointOptions.alignedWithTimeout(CheckpointType.CHECKPOINT, location, 10),
+                false,
+                true,
+                10);
         assertTimeoutable(
-                CheckpointOptions.alignedWithTimeout(location, 10).withUnalignedUnsupported(),
+                CheckpointOptions.unaligned(CheckpointType.CHECKPOINT, location),
+                true,
+                false,
+                NO_ALIGNED_CHECKPOINT_TIME_OUT);
+        assertTimeoutable(
+                CheckpointOptions.alignedWithTimeout(CheckpointType.CHECKPOINT, location, 10)
+                        .withUnalignedUnsupported(),
                 false,
                 false,
                 10);
         assertTimeoutable(
-                CheckpointOptions.unaligned(location).withUnalignedUnsupported(),
+                CheckpointOptions.unaligned(CheckpointType.CHECKPOINT, location)
+                        .withUnalignedUnsupported(),
                 false,
                 false,
                 NO_ALIGNED_CHECKPOINT_TIME_OUT);
@@ -131,8 +140,10 @@ public class CheckpointOptionsTest {
     public void testForceAlignmentIsReversable() {
         CheckpointStorageLocationReference location =
                 CheckpointStorageLocationReference.getDefault();
-        assertReversable(CheckpointOptions.alignedWithTimeout(location, 10), true);
-        assertReversable(CheckpointOptions.unaligned(location), true);
+        assertReversable(
+                CheckpointOptions.alignedWithTimeout(CheckpointType.CHECKPOINT, location, 10),
+                true);
+        assertReversable(CheckpointOptions.unaligned(CheckpointType.CHECKPOINT, location), true);
 
         assertReversable(CheckpointOptions.alignedNoTimeout(CHECKPOINT, location), false);
         assertReversable(CheckpointOptions.alignedNoTimeout(SAVEPOINT, location), false);

--- a/flink-runtime/src/test/java/org/apache/flink/runtime/checkpoint/CheckpointTypeTest.java
+++ b/flink-runtime/src/test/java/org/apache/flink/runtime/checkpoint/CheckpointTypeTest.java
@@ -37,5 +37,7 @@ public class CheckpointTypeTest {
         assertEquals(0, CheckpointType.CHECKPOINT.ordinal());
         assertEquals(1, CheckpointType.SAVEPOINT.ordinal());
         assertEquals(2, CheckpointType.SAVEPOINT_SUSPEND.ordinal());
+        assertEquals(3, CheckpointType.SAVEPOINT_TERMINATE.ordinal());
+        assertEquals(4, CheckpointType.FULL_CHECKPOINT.ordinal());
     }
 }

--- a/flink-runtime/src/test/java/org/apache/flink/runtime/checkpoint/CompletedCheckpointTest.java
+++ b/flink-runtime/src/test/java/org/apache/flink/runtime/checkpoint/CompletedCheckpointTest.java
@@ -243,7 +243,7 @@ public class CompletedCheckpointTest {
 
         CheckpointProperties props =
                 new CheckpointProperties(
-                        false, CheckpointType.CHECKPOINT, true, false, false, false, false);
+                        false, CheckpointType.CHECKPOINT, true, false, false, false, false, false);
 
         CompletedCheckpoint checkpoint =
                 new CompletedCheckpoint(
@@ -289,7 +289,14 @@ public class CompletedCheckpointTest {
             // Keep
             CheckpointProperties retainProps =
                     new CheckpointProperties(
-                            false, CheckpointType.CHECKPOINT, false, false, false, false, false);
+                            false,
+                            CheckpointType.CHECKPOINT,
+                            false,
+                            false,
+                            false,
+                            false,
+                            false,
+                            false);
             CompletedCheckpoint checkpoint =
                     new CompletedCheckpoint(
                             new JobID(),
@@ -315,7 +322,7 @@ public class CompletedCheckpointTest {
             // Keep
             CheckpointProperties discardProps =
                     new CheckpointProperties(
-                            false, CheckpointType.CHECKPOINT, true, true, true, true, true);
+                            false, CheckpointType.CHECKPOINT, true, true, true, true, true, false);
 
             checkpoint =
                     new CompletedCheckpoint(

--- a/flink-runtime/src/test/java/org/apache/flink/runtime/checkpoint/PendingCheckpointTest.java
+++ b/flink-runtime/src/test/java/org/apache/flink/runtime/checkpoint/PendingCheckpointTest.java
@@ -122,7 +122,7 @@ public class PendingCheckpointTest {
         // Forced checkpoints cannot be subsumed
         CheckpointProperties forced =
                 new CheckpointProperties(
-                        true, CheckpointType.SAVEPOINT, false, false, false, false, false);
+                        true, CheckpointType.SAVEPOINT, false, false, false, false, false, false);
         PendingCheckpoint pending = createPendingCheckpoint(forced);
         assertFalse(pending.canBeSubsumed());
 
@@ -136,7 +136,7 @@ public class PendingCheckpointTest {
         // Non-forced checkpoints can be subsumed
         CheckpointProperties subsumed =
                 new CheckpointProperties(
-                        false, CheckpointType.SAVEPOINT, false, false, false, false, false);
+                        false, CheckpointType.SAVEPOINT, false, false, false, false, false, false);
         pending = createPendingCheckpoint(subsumed);
         assertFalse(pending.canBeSubsumed());
     }
@@ -164,7 +164,7 @@ public class PendingCheckpointTest {
     public void testCompletionFuture() throws Exception {
         CheckpointProperties props =
                 new CheckpointProperties(
-                        false, CheckpointType.SAVEPOINT, false, false, false, false, false);
+                        false, CheckpointType.SAVEPOINT, false, false, false, false, false, false);
 
         // Abort declined
         PendingCheckpoint pending = createPendingCheckpoint(props);
@@ -220,7 +220,7 @@ public class PendingCheckpointTest {
     public void testAbortDiscardsState() throws Exception {
         CheckpointProperties props =
                 new CheckpointProperties(
-                        false, CheckpointType.CHECKPOINT, false, false, false, false, false);
+                        false, CheckpointType.CHECKPOINT, false, false, false, false, false, false);
         QueueExecutor executor = new QueueExecutor();
 
         OperatorState state = mock(OperatorState.class);
@@ -379,7 +379,7 @@ public class PendingCheckpointTest {
     public void testSetCanceller() throws Exception {
         final CheckpointProperties props =
                 new CheckpointProperties(
-                        false, CheckpointType.CHECKPOINT, true, true, true, true, true);
+                        false, CheckpointType.CHECKPOINT, true, true, true, true, true, false);
 
         PendingCheckpoint aborted = createPendingCheckpoint(props);
         abort(aborted, CheckpointFailureReason.CHECKPOINT_DECLINED);

--- a/flink-runtime/src/test/java/org/apache/flink/runtime/checkpoint/RestoredCheckpointStatsTest.java
+++ b/flink-runtime/src/test/java/org/apache/flink/runtime/checkpoint/RestoredCheckpointStatsTest.java
@@ -31,7 +31,7 @@ public class RestoredCheckpointStatsTest {
         long triggerTimestamp = Integer.MAX_VALUE + 1L;
         CheckpointProperties props =
                 new CheckpointProperties(
-                        true, CheckpointType.SAVEPOINT, false, false, true, false, true);
+                        true, CheckpointType.SAVEPOINT, false, false, true, false, true, false);
         long restoreTimestamp = Integer.MAX_VALUE + 1L;
         String externalPath = "external-path";
 

--- a/flink-runtime/src/test/java/org/apache/flink/runtime/io/network/api/serialization/EventSerializerTest.java
+++ b/flink-runtime/src/test/java/org/apache/flink/runtime/io/network/api/serialization/EventSerializerTest.java
@@ -62,6 +62,12 @@ public class EventSerializerTest {
                 1678L,
                 4623784L,
                 new CheckpointOptions(
+                        CheckpointType.FULL_CHECKPOINT,
+                        CheckpointStorageLocationReference.getDefault())),
+        new CheckpointBarrier(
+                1678L,
+                4623784L,
+                new CheckpointOptions(
                         CheckpointType.SAVEPOINT, CheckpointStorageLocationReference.getDefault())),
         new CheckpointBarrier(
                 1678L,
@@ -82,7 +88,9 @@ public class EventSerializerTest {
                         42L,
                         1337L,
                         CheckpointOptions.alignedWithTimeout(
-                                CheckpointStorageLocationReference.getDefault(), 10)),
+                                CheckpointType.CHECKPOINT,
+                                CheckpointStorageLocationReference.getDefault(),
+                                10)),
                 44),
         new SubtaskConnectionDescriptor(23, 42),
     };

--- a/flink-runtime/src/test/java/org/apache/flink/runtime/io/network/partition/PipelinedSubpartitionWithReadViewTest.java
+++ b/flink-runtime/src/test/java/org/apache/flink/runtime/io/network/partition/PipelinedSubpartitionWithReadViewTest.java
@@ -20,6 +20,7 @@ package org.apache.flink.runtime.io.network.partition;
 
 import org.apache.flink.core.fs.CloseableRegistry;
 import org.apache.flink.runtime.checkpoint.CheckpointOptions;
+import org.apache.flink.runtime.checkpoint.CheckpointType;
 import org.apache.flink.runtime.checkpoint.channel.ChannelStateWriter;
 import org.apache.flink.runtime.checkpoint.channel.RecordingChannelStateWriter;
 import org.apache.flink.runtime.event.AbstractEvent;
@@ -363,6 +364,7 @@ public class PipelinedSubpartitionWithReadViewTest {
 
         CheckpointOptions options =
                 CheckpointOptions.unaligned(
+                        CheckpointType.CHECKPOINT,
                         new CheckpointStorageLocationReference(new byte[] {0, 1, 2}));
         channelStateWriter.start(0, options);
         BufferConsumer barrierBuffer =
@@ -406,6 +408,7 @@ public class PipelinedSubpartitionWithReadViewTest {
 
         CheckpointOptions options =
                 CheckpointOptions.unaligned(
+                        CheckpointType.CHECKPOINT,
                         new CheckpointStorageLocationReference(new byte[] {0, 1, 2}));
         BufferConsumer barrierBuffer =
                 EventSerializer.toBufferConsumer(new CheckpointBarrier(0, 0, options), true);

--- a/flink-runtime/src/test/java/org/apache/flink/runtime/io/network/partition/consumer/ChannelStatePersisterTest.java
+++ b/flink-runtime/src/test/java/org/apache/flink/runtime/io/network/partition/consumer/ChannelStatePersisterTest.java
@@ -19,6 +19,7 @@ package org.apache.flink.runtime.io.network.partition.consumer;
 
 import org.apache.flink.runtime.checkpoint.CheckpointException;
 import org.apache.flink.runtime.checkpoint.CheckpointOptions;
+import org.apache.flink.runtime.checkpoint.CheckpointType;
 import org.apache.flink.runtime.checkpoint.channel.ChannelStateWriter;
 import org.apache.flink.runtime.checkpoint.channel.InputChannelInfo;
 import org.apache.flink.runtime.checkpoint.channel.RecordingChannelStateWriter;
@@ -49,7 +50,8 @@ public class ChannelStatePersisterTest {
                 new ChannelStatePersister(channelStateWriter, channelInfo);
 
         long checkpointId = 1L;
-        channelStateWriter.start(checkpointId, CheckpointOptions.unaligned(getDefault()));
+        channelStateWriter.start(
+                checkpointId, CheckpointOptions.unaligned(CheckpointType.CHECKPOINT, getDefault()));
 
         persister.checkForBarrier(barrier(checkpointId));
         persister.startPersisting(checkpointId, Arrays.asList(buildSomeBuffer()));
@@ -115,7 +117,8 @@ public class ChannelStatePersisterTest {
             persister.stopPersisting(lateCheckpointId);
         }
         persister.checkForBarrier(barrier(lateCheckpointId));
-        channelStateWriter.start(checkpointId, CheckpointOptions.unaligned(getDefault()));
+        channelStateWriter.start(
+                checkpointId, CheckpointOptions.unaligned(CheckpointType.CHECKPOINT, getDefault()));
         persister.startPersisting(checkpointId, Arrays.asList(buildSomeBuffer()));
         persister.maybePersist(buildSomeBuffer());
         persister.checkForBarrier(barrier(checkpointId));

--- a/flink-runtime/src/test/java/org/apache/flink/runtime/io/network/partition/consumer/LocalInputChannelTest.java
+++ b/flink-runtime/src/test/java/org/apache/flink/runtime/io/network/partition/consumer/LocalInputChannelTest.java
@@ -19,6 +19,7 @@
 package org.apache.flink.runtime.io.network.partition.consumer;
 
 import org.apache.flink.runtime.checkpoint.CheckpointOptions;
+import org.apache.flink.runtime.checkpoint.CheckpointType;
 import org.apache.flink.runtime.checkpoint.channel.RecordingChannelStateWriter;
 import org.apache.flink.runtime.execution.CancelTaskException;
 import org.apache.flink.runtime.io.disk.NoOpFileChannelManager;
@@ -99,7 +100,10 @@ public class LocalInputChannelTest {
     public void testNoDataPersistedAfterReceivingAlignedBarrier() throws Exception {
         CheckpointBarrier barrier =
                 new CheckpointBarrier(
-                        1L, 0L, CheckpointOptions.alignedWithTimeout(getDefault(), 123L));
+                        1L,
+                        0L,
+                        CheckpointOptions.alignedWithTimeout(
+                                CheckpointType.CHECKPOINT, getDefault(), 123L));
         BufferConsumer barrierHolder = EventSerializer.toBufferConsumer(barrier, false);
         BufferConsumer data = createFilledFinishedBufferConsumer(1);
 
@@ -580,7 +584,8 @@ public class LocalInputChannelTest {
         channel.requestSubpartition(0);
 
         final CheckpointStorageLocationReference location = getDefault();
-        CheckpointOptions options = CheckpointOptions.unaligned(location);
+        CheckpointOptions options =
+                CheckpointOptions.unaligned(CheckpointType.CHECKPOINT, location);
         stateWriter.start(0, options);
 
         final CheckpointBarrier barrier = new CheckpointBarrier(0, 123L, options);

--- a/flink-runtime/src/test/java/org/apache/flink/runtime/io/network/partition/consumer/RecoveredInputChannelTest.java
+++ b/flink-runtime/src/test/java/org/apache/flink/runtime/io/network/partition/consumer/RecoveredInputChannelTest.java
@@ -20,6 +20,7 @@ package org.apache.flink.runtime.io.network.partition.consumer;
 
 import org.apache.flink.metrics.SimpleCounter;
 import org.apache.flink.runtime.checkpoint.CheckpointException;
+import org.apache.flink.runtime.checkpoint.CheckpointType;
 import org.apache.flink.runtime.io.network.api.CheckpointBarrier;
 import org.apache.flink.runtime.io.network.partition.ResultPartitionID;
 
@@ -45,7 +46,10 @@ public class RecoveredInputChannelTest {
 
     @Test(expected = CheckpointException.class)
     public void testCheckpointStartImpossible() throws CheckpointException {
-        buildChannel().checkpointStarted(new CheckpointBarrier(0L, 0L, unaligned(getDefault())));
+        buildChannel()
+                .checkpointStarted(
+                        new CheckpointBarrier(
+                                0L, 0L, unaligned(CheckpointType.CHECKPOINT, getDefault())));
     }
 
     private RecoveredInputChannel buildChannel() {

--- a/flink-runtime/src/test/java/org/apache/flink/runtime/io/network/partition/consumer/RemoteInputChannelTest.java
+++ b/flink-runtime/src/test/java/org/apache/flink/runtime/io/network/partition/consumer/RemoteInputChannelTest.java
@@ -23,6 +23,7 @@ import org.apache.flink.core.memory.MemorySegmentFactory;
 import org.apache.flink.core.testutils.OneShotLatch;
 import org.apache.flink.runtime.checkpoint.CheckpointException;
 import org.apache.flink.runtime.checkpoint.CheckpointOptions;
+import org.apache.flink.runtime.checkpoint.CheckpointType;
 import org.apache.flink.runtime.checkpoint.channel.ChannelStateWriter;
 import org.apache.flink.runtime.checkpoint.channel.InputChannelInfo;
 import org.apache.flink.runtime.execution.CancelTaskException;
@@ -117,9 +118,10 @@ import static org.mockito.Mockito.when;
 public class RemoteInputChannelTest {
 
     private static final long CHECKPOINT_ID = 1L;
-    private static final CheckpointOptions UNALIGNED = CheckpointOptions.unaligned(getDefault());
+    private static final CheckpointOptions UNALIGNED =
+            CheckpointOptions.unaligned(CheckpointType.CHECKPOINT, getDefault());
     private static final CheckpointOptions ALIGNED_WITH_TIMEOUT =
-            alignedWithTimeout(getDefault(), 10);
+            alignedWithTimeout(CheckpointType.CHECKPOINT, getDefault(), 10);
 
     @Test
     public void testGateNotifiedOnBarrierConversion() throws IOException, InterruptedException {
@@ -142,7 +144,12 @@ public class RemoteInputChannelTest {
             channel.onBuffer(
                     toBuffer(
                             new CheckpointBarrier(
-                                    1L, 123L, alignedWithTimeout(getDefault(), Integer.MAX_VALUE)),
+                                    1L,
+                                    123L,
+                                    alignedWithTimeout(
+                                            CheckpointType.CHECKPOINT,
+                                            getDefault(),
+                                            Integer.MAX_VALUE)),
                             false),
                     sequenceNumber,
                     0);
@@ -207,7 +214,9 @@ public class RemoteInputChannelTest {
 
         inputChannel.checkpointStarted(
                 new CheckpointBarrier(
-                        42, System.currentTimeMillis(), CheckpointOptions.unaligned(getDefault())));
+                        42,
+                        System.currentTimeMillis(),
+                        CheckpointOptions.unaligned(CheckpointType.CHECKPOINT, getDefault())));
 
         final Buffer buffer = createBuffer(TestBufferFactory.BUFFER_SIZE);
 
@@ -1437,7 +1446,12 @@ public class RemoteInputChannelTest {
         Buffer barrier =
                 EventSerializer.toBuffer(
                         new CheckpointBarrier(
-                                1L, 123L, alignedWithTimeout(getDefault(), Integer.MAX_VALUE)),
+                                1L,
+                                123L,
+                                alignedWithTimeout(
+                                        CheckpointType.CHECKPOINT,
+                                        getDefault(),
+                                        Integer.MAX_VALUE)),
                         false);
         remoteChannel1.onBuffer(barrier, 0, 0);
         remoteChannel2.onBuffer(barrier, 0, 0);

--- a/flink-runtime/src/test/java/org/apache/flink/runtime/operators/testutils/DummyEnvironment.java
+++ b/flink-runtime/src/test/java/org/apache/flink/runtime/operators/testutils/DummyEnvironment.java
@@ -70,6 +70,7 @@ public class DummyEnvironment implements Environment {
     private final AccumulatorRegistry accumulatorRegistry =
             new AccumulatorRegistry(jobId, executionId);
     private UserCodeClassLoader userClassLoader;
+    private final Configuration taskConfiguration = new Configuration();
 
     public DummyEnvironment() {
         this("Test Job", 1, 0, 1);
@@ -122,7 +123,7 @@ public class DummyEnvironment implements Environment {
 
     @Override
     public Configuration getTaskConfiguration() {
-        return new Configuration();
+        return taskConfiguration;
     }
 
     @Override

--- a/flink-runtime/src/test/java/org/apache/flink/runtime/testutils/PseudoRandomValueSelector.java
+++ b/flink-runtime/src/test/java/org/apache/flink/runtime/testutils/PseudoRandomValueSelector.java
@@ -66,14 +66,15 @@ public class PseudoRandomValueSelector {
         this.randomValueSupplier = randomValueSupplier;
     }
 
-    public <T> void select(Configuration configuration, ConfigOption<T> option, T... alternatives) {
+    public <T> T select(Configuration configuration, ConfigOption<T> option, T... alternatives) {
         if (configuration.contains(option)) {
-            return;
+            return configuration.get(option);
         }
         final int choice = randomValueSupplier.apply(alternatives.length);
         T value = alternatives[choice];
         LOG.info("Randomly selected {} for {}", value, option.key());
         configuration.set(option, value);
+        return value;
     }
 
     public static PseudoRandomValueSelector create(Object entryPointSeed) {
@@ -124,10 +125,10 @@ public class PseudoRandomValueSelector {
         return Optional.empty();
     }
 
-    public static <T> void randomize(Configuration conf, ConfigOption<T> option, T... t1) {
+    public static <T> T randomize(Configuration conf, ConfigOption<T> option, T... t1) {
         final String testName = TestNameProvider.getCurrentTestName();
         final PseudoRandomValueSelector valueSelector =
                 PseudoRandomValueSelector.create(testName != null ? testName : "unknown");
-        valueSelector.select(conf, option, t1);
+        return valueSelector.select(conf, option, t1);
     }
 }

--- a/flink-state-backends/flink-statebackend-rocksdb/src/main/java/org/apache/flink/contrib/streaming/state/EmbeddedRocksDBStateBackend.java
+++ b/flink-state-backends/flink-statebackend-rocksdb/src/main/java/org/apache/flink/contrib/streaming/state/EmbeddedRocksDBStateBackend.java
@@ -302,6 +302,13 @@ public class EmbeddedRocksDBStateBackend extends AbstractManagedMemoryStateBacke
     //  State backend methods
     // ------------------------------------------------------------------------
 
+    @Override
+    public boolean supportsNoClaimRestoreMode() {
+        // We are able to create CheckpointType#FULL_CHECKPOINT. (we might potentially reupload some
+        // shared files when taking incremental snapshots)
+        return true;
+    }
+
     private void lazyInitializeForJob(
             Environment env, @SuppressWarnings("unused") String operatorIdentifier)
             throws IOException {

--- a/flink-state-backends/flink-statebackend-rocksdb/src/main/java/org/apache/flink/contrib/streaming/state/RocksDBStateBackend.java
+++ b/flink-state-backends/flink-statebackend-rocksdb/src/main/java/org/apache/flink/contrib/streaming/state/RocksDBStateBackend.java
@@ -281,6 +281,13 @@ public class RocksDBStateBackend extends AbstractManagedMemoryStateBackend
         return checkpointStreamBackend;
     }
 
+    @Override
+    public boolean supportsNoClaimRestoreMode() {
+        // We are able to create CheckpointType#FULL_CHECKPOINT. (we might potentially reupload some
+        // shared files when taking incremental snapshots)
+        return true;
+    }
+
     // ------------------------------------------------------------------------
     //  Checkpoint initialization and persistent storage
     // ------------------------------------------------------------------------

--- a/flink-streaming-java/src/main/java/org/apache/flink/streaming/runtime/tasks/SourceOperatorStreamTask.java
+++ b/flink-streaming-java/src/main/java/org/apache/flink/streaming/runtime/tasks/SourceOperatorStreamTask.java
@@ -116,6 +116,12 @@ public class SourceOperatorStreamTask<T> extends StreamTask<T, SourceOperator<T,
             } else {
                 return super.triggerCheckpointAsync(checkpointMetaData, checkpointOptions);
             }
+        } else if (checkpointOptions.getCheckpointType() == CheckpointType.FULL_CHECKPOINT) {
+            // see FLINK-25256
+            throw new IllegalStateException(
+                    "Using externally induced sources, we can not enforce taking a full checkpoint."
+                            + "If you are restoring from a snapshot in NO_CLAIM mode, please use"
+                            + " either CLAIM or LEGACY mode.");
         } else {
             return CompletableFuture.completedFuture(isRunning());
         }

--- a/flink-streaming-java/src/main/java/org/apache/flink/streaming/runtime/tasks/SourceStreamTask.java
+++ b/flink-streaming-java/src/main/java/org/apache/flink/streaming/runtime/tasks/SourceStreamTask.java
@@ -258,6 +258,12 @@ public class SourceStreamTask<
             } else {
                 return super.triggerCheckpointAsync(checkpointMetaData, checkpointOptions);
             }
+        } else if (checkpointOptions.getCheckpointType() == CheckpointType.FULL_CHECKPOINT) {
+            // see FLINK-25256
+            throw new IllegalStateException(
+                    "Using externally induced sources, we can not enforce taking a full checkpoint."
+                            + "If you are restoring from a snapshot in NO_CLAIM mode, please use"
+                            + " either CLAIM or LEGACY mode.");
         } else {
             // we do not trigger checkpoints here, we simply state whether we can trigger them
             synchronized (lock) {

--- a/flink-streaming-java/src/test/java/org/apache/flink/streaming/runtime/io/checkpointing/AlternatingCheckpointsTest.java
+++ b/flink-streaming-java/src/test/java/org/apache/flink/streaming/runtime/io/checkpointing/AlternatingCheckpointsTest.java
@@ -115,7 +115,9 @@ public class AlternatingCheckpointsTest {
             send(
                     toBuffer(
                             new CheckpointBarrier(
-                                    1, clock.relativeTimeMillis(), unaligned(getDefault())),
+                                    1,
+                                    clock.relativeTimeMillis(),
+                                    unaligned(CheckpointType.CHECKPOINT, getDefault())),
                             true),
                     1,
                     gate);
@@ -139,7 +141,8 @@ public class AlternatingCheckpointsTest {
                     new CheckpointBarrier(
                             1,
                             clock.relativeTimeMillis(),
-                            alignedWithTimeout(getDefault(), Integer.MAX_VALUE));
+                            alignedWithTimeout(
+                                    CheckpointType.CHECKPOINT, getDefault(), Integer.MAX_VALUE));
 
             send(
                     toBuffer(new EventAnnouncement(aligned, 0), true),
@@ -210,7 +213,8 @@ public class AlternatingCheckpointsTest {
                     barrier(
                             1,
                             clock.relativeTimeMillis(),
-                            alignedWithTimeout(getDefault(), alignmentTimeOut));
+                            alignedWithTimeout(
+                                    CheckpointType.CHECKPOINT, getDefault(), alignmentTimeOut));
             ((RemoteInputChannel) gate.getChannel(0)).onBuffer(barrier1.retainBuffer(), 0, 0);
             assertAnnouncement(gate);
             clock.advanceTime(alignmentTimeOut + 1, TimeUnit.MILLISECONDS);
@@ -221,7 +225,8 @@ public class AlternatingCheckpointsTest {
                     barrier(
                             2,
                             clock.relativeTimeMillis(),
-                            alignedWithTimeout(getDefault(), alignmentTimeOut));
+                            alignedWithTimeout(
+                                    CheckpointType.CHECKPOINT, getDefault(), alignmentTimeOut));
             ((RemoteInputChannel) gate.getChannel(0)).onBuffer(barrier2.retainBuffer(), 1, 0);
             assertAnnouncement(gate);
             assertBarrier(gate);
@@ -230,8 +235,9 @@ public class AlternatingCheckpointsTest {
             assertThat(
                     target.getTriggeredCheckpointOptions(),
                     contains(
-                            unaligned(getDefault()),
-                            alignedWithTimeout(getDefault(), alignmentTimeOut)));
+                            unaligned(CheckpointType.CHECKPOINT, getDefault()),
+                            alignedWithTimeout(
+                                    CheckpointType.CHECKPOINT, getDefault(), alignmentTimeOut)));
         }
     }
 
@@ -281,7 +287,8 @@ public class AlternatingCheckpointsTest {
                     barrier(
                             1,
                             clock.relativeTimeMillis(),
-                            alignedWithTimeout(getDefault(), Integer.MAX_VALUE)),
+                            alignedWithTimeout(
+                                    CheckpointType.CHECKPOINT, getDefault(), Integer.MAX_VALUE)),
                     2,
                     gate);
 
@@ -309,7 +316,9 @@ public class AlternatingCheckpointsTest {
         assertBarrier(gate);
         assertBarrier(gate);
         assertEquals(1, target.getTriggeredCheckpointCounter());
-        assertThat(target.getTriggeredCheckpointOptions(), contains(unaligned(getDefault())));
+        assertThat(
+                target.getTriggeredCheckpointOptions(),
+                contains(unaligned(CheckpointType.CHECKPOINT, getDefault())));
         // Followed by overtaken buffers
         assertData(gate);
         assertData(gate);
@@ -464,7 +473,9 @@ public class AlternatingCheckpointsTest {
             clock.executeCallables();
             assertBarrier(gate);
             assertEquals(1, target.getTriggeredCheckpointCounter());
-            assertThat(target.getTriggeredCheckpointOptions(), contains(unaligned(getDefault())));
+            assertThat(
+                    target.getTriggeredCheckpointOptions(),
+                    contains(unaligned(CheckpointType.CHECKPOINT, getDefault())));
             // Followed by overtaken buffers
             assertData(gate);
             assertData(gate);
@@ -572,7 +583,9 @@ public class AlternatingCheckpointsTest {
         send(checkpointBarrier, 0, gate);
 
         clock.advanceTime(alignmentTimeout + 1, TimeUnit.MILLISECONDS);
-        assertThat(target.getTriggeredCheckpointOptions(), contains(unaligned(getDefault())));
+        assertThat(
+                target.getTriggeredCheckpointOptions(),
+                contains(unaligned(CheckpointType.CHECKPOINT, getDefault())));
     }
 
     @Test
@@ -591,7 +604,8 @@ public class AlternatingCheckpointsTest {
                 new CheckpointBarrier(
                         1,
                         clock.relativeTimeMillis(),
-                        alignedWithTimeout(getDefault(), alignmentTimeout));
+                        alignedWithTimeout(
+                                CheckpointType.CHECKPOINT, getDefault(), alignmentTimeout));
         Buffer checkpointBarrierBuffer = toBuffer(checkpointBarrier, false);
 
         // we set timer on announcement and test channels do not produce announcements by themselves
@@ -607,7 +621,9 @@ public class AlternatingCheckpointsTest {
         send(checkpointBarrierBuffer, 1, gate);
 
         assertThat(target.getTriggeredCheckpointOptions().size(), equalTo(1));
-        assertThat(target.getTriggeredCheckpointOptions(), contains(unaligned(getDefault())));
+        assertThat(
+                target.getTriggeredCheckpointOptions(),
+                contains(unaligned(CheckpointType.CHECKPOINT, getDefault())));
         assertFalse(((TestInputChannel) gate.getChannel(0)).isBlocked());
         assertFalse(((TestInputChannel) gate.getChannel(1)).isBlocked());
     }
@@ -630,7 +646,9 @@ public class AlternatingCheckpointsTest {
         send(checkpointBarrier, 1, gate);
         clock.advanceTime(alignmentTimeout + 1, TimeUnit.MILLISECONDS);
 
-        assertThat(target.getTriggeredCheckpointOptions(), not(contains(unaligned(getDefault()))));
+        assertThat(
+                target.getTriggeredCheckpointOptions(),
+                not(contains(unaligned(CheckpointType.CHECKPOINT, getDefault()))));
     }
 
     @Test
@@ -715,7 +733,9 @@ public class AlternatingCheckpointsTest {
             assertBarrier(gate);
             assertBarrier(gate);
             assertEquals(1, target.getTriggeredCheckpointCounter());
-            assertThat(target.getTriggeredCheckpointOptions(), contains(unaligned(getDefault())));
+            assertThat(
+                    target.getTriggeredCheckpointOptions(),
+                    contains(unaligned(CheckpointType.CHECKPOINT, getDefault())));
             // Followed by overtaken buffers
             assertData(gate);
             assertData(gate);
@@ -753,7 +773,9 @@ public class AlternatingCheckpointsTest {
             assertBarrier(gate);
             assertBarrier(gate);
             assertEquals(1, target.getTriggeredCheckpointCounter());
-            assertThat(target.getTriggeredCheckpointOptions(), contains(unaligned(getDefault())));
+            assertThat(
+                    target.getTriggeredCheckpointOptions(),
+                    contains(unaligned(CheckpointType.CHECKPOINT, getDefault())));
             // Followed by overtaken buffers
             assertData(gate);
             assertData(gate);
@@ -796,7 +818,9 @@ public class AlternatingCheckpointsTest {
             assertBarrier(gate);
             assertBarrier(gate);
             assertEquals(1, target.getTriggeredCheckpointCounter());
-            assertThat(target.getTriggeredCheckpointOptions(), contains(unaligned(getDefault())));
+            assertThat(
+                    target.getTriggeredCheckpointOptions(),
+                    contains(unaligned(CheckpointType.CHECKPOINT, getDefault())));
             // Followed by overtaken buffers
             assertData(gate);
             assertData(gate);
@@ -837,7 +861,9 @@ public class AlternatingCheckpointsTest {
             assertBarrier(gate);
 
             assertEquals(1, target.getTriggeredCheckpointCounter());
-            assertThat(target.getTriggeredCheckpointOptions(), contains(unaligned(getDefault())));
+            assertThat(
+                    target.getTriggeredCheckpointOptions(),
+                    contains(unaligned(CheckpointType.CHECKPOINT, getDefault())));
             // Followed by overtaken buffers
             assertData(gate);
         }
@@ -871,7 +897,7 @@ public class AlternatingCheckpointsTest {
                                         new CheckpointBarrier(
                                                 1,
                                                 clock.relativeTimeMillis(),
-                                                unaligned(getDefault())),
+                                                unaligned(CheckpointType.CHECKPOINT, getDefault())),
                                         true)
                                 .retainBuffer(),
                         2,
@@ -906,7 +932,10 @@ public class AlternatingCheckpointsTest {
                             barrier(
                                     1,
                                     clock.relativeTimeMillis(),
-                                    alignedWithTimeout(getDefault(), alignmentTimeOut)),
+                                    alignedWithTimeout(
+                                            CheckpointType.CHECKPOINT,
+                                            getDefault(),
+                                            alignmentTimeOut)),
                             0,
                             0);
             assertAnnouncement(gate);
@@ -928,7 +957,9 @@ public class AlternatingCheckpointsTest {
             assertEvent(gate, EndOfPartitionEvent.class);
 
             assertEquals(1, target.getTriggeredCheckpointCounter());
-            assertThat(target.getTriggeredCheckpointOptions(), contains(unaligned(getDefault())));
+            assertThat(
+                    target.getTriggeredCheckpointOptions(),
+                    contains(unaligned(CheckpointType.CHECKPOINT, getDefault())));
         }
     }
 
@@ -956,7 +987,10 @@ public class AlternatingCheckpointsTest {
                             barrier(
                                     1,
                                     clock.relativeTimeMillis(),
-                                    alignedWithTimeout(getDefault(), alignmentTimeOut)),
+                                    alignedWithTimeout(
+                                            CheckpointType.CHECKPOINT,
+                                            getDefault(),
+                                            alignmentTimeOut)),
                             0,
                             0);
             getChannel(gate, 1).onBuffer(endOfPartition(), 0, 0);
@@ -977,7 +1011,10 @@ public class AlternatingCheckpointsTest {
                             barrier(
                                     1,
                                     clock.relativeTimeMillis(),
-                                    alignedWithTimeout(getDefault(), alignmentTimeOut)),
+                                    alignedWithTimeout(
+                                            CheckpointType.CHECKPOINT,
+                                            getDefault(),
+                                            alignmentTimeOut)),
                             0,
                             0);
             assertAnnouncement(gate);
@@ -1048,13 +1085,25 @@ public class AlternatingCheckpointsTest {
 
         startNanos = clock.relativeTimeNanos();
         long checkpoint3CreationTime = clock.relativeTimeMillis() - 7;
-        send(barrier(3, checkpoint3CreationTime, unaligned(getDefault())), 0, gate);
+        send(
+                barrier(
+                        3,
+                        checkpoint3CreationTime,
+                        unaligned(CheckpointType.CHECKPOINT, getDefault())),
+                0,
+                gate);
         sendData(bufferSize, 0, gate);
         sendData(bufferSize, 1, gate);
         assertMetrics(
                 target, gate.getCheckpointBarrierHandler(), 3L, startNanos, 0L, 7_000_000L, -1L);
         clock.advanceTime(10, TimeUnit.MILLISECONDS);
-        send(barrier(3, checkpoint2CreationTime, unaligned(getDefault())), 1, gate);
+        send(
+                barrier(
+                        3,
+                        checkpoint2CreationTime,
+                        unaligned(CheckpointType.CHECKPOINT, getDefault())),
+                1,
+                gate);
         assertMetrics(
                 target,
                 gate.getCheckpointBarrierHandler(),
@@ -1260,7 +1309,7 @@ public class AlternatingCheckpointsTest {
         CheckpointOptions options =
                 checkpointType.isSavepoint()
                         ? alignedNoTimeout(checkpointType, getDefault())
-                        : unaligned(getDefault());
+                        : unaligned(CheckpointType.CHECKPOINT, getDefault());
         Buffer barrier = barrier(barrierId, 1, options);
         send(barrier.retainBuffer(), fast, checkpointedGate);
         assertEquals(checkpointType.isSavepoint(), target.triggeredCheckpoints.isEmpty());
@@ -1318,7 +1367,8 @@ public class AlternatingCheckpointsTest {
         return barrier(
                 checkpointId,
                 clock.relativeTimeMillis(),
-                alignedWithTimeout(getDefault(), alignedCheckpointTimeout));
+                alignedWithTimeout(
+                        CheckpointType.CHECKPOINT, getDefault(), alignedCheckpointTimeout));
     }
 
     private Buffer barrier(long barrierId, long barrierTimestamp, CheckpointOptions options)

--- a/flink-streaming-java/src/test/java/org/apache/flink/streaming/runtime/io/checkpointing/CheckpointedInputGateTest.java
+++ b/flink-streaming-java/src/test/java/org/apache/flink/streaming/runtime/io/checkpointing/CheckpointedInputGateTest.java
@@ -20,6 +20,7 @@ package org.apache.flink.streaming.runtime.io.checkpointing;
 import org.apache.flink.api.common.time.Deadline;
 import org.apache.flink.core.testutils.CheckedThread;
 import org.apache.flink.runtime.checkpoint.CheckpointOptions;
+import org.apache.flink.runtime.checkpoint.CheckpointType;
 import org.apache.flink.runtime.checkpoint.channel.InputChannelInfo;
 import org.apache.flink.runtime.checkpoint.channel.MockChannelStateWriter;
 import org.apache.flink.runtime.checkpoint.channel.RecordingChannelStateWriter;
@@ -270,7 +271,9 @@ public class CheckpointedInputGateTest {
         return new CheckpointBarrier(
                 barrierId,
                 barrierId,
-                CheckpointOptions.unaligned(CheckpointStorageLocationReference.getDefault()));
+                CheckpointOptions.unaligned(
+                        CheckpointType.CHECKPOINT,
+                        CheckpointStorageLocationReference.getDefault()));
     }
 
     private void assertAddedInputSize(

--- a/flink-streaming-java/src/test/java/org/apache/flink/streaming/runtime/io/checkpointing/InputProcessorUtilTest.java
+++ b/flink-streaming-java/src/test/java/org/apache/flink/streaming/runtime/io/checkpointing/InputProcessorUtilTest.java
@@ -20,6 +20,7 @@ package org.apache.flink.streaming.runtime.io.checkpointing;
 
 import org.apache.flink.core.fs.CloseableRegistry;
 import org.apache.flink.runtime.checkpoint.CheckpointOptions;
+import org.apache.flink.runtime.checkpoint.CheckpointType;
 import org.apache.flink.runtime.checkpoint.channel.InputChannelInfo;
 import org.apache.flink.runtime.checkpoint.channel.MockChannelStateWriter;
 import org.apache.flink.runtime.io.network.api.CheckpointBarrier;
@@ -105,6 +106,7 @@ public class InputProcessorUtilTest {
                                     1,
                                     42,
                                     CheckpointOptions.unaligned(
+                                            CheckpointType.CHECKPOINT,
                                             CheckpointStorageLocationReference.getDefault())),
                             new InputChannelInfo(inputGate.getGateIndex(), channelId),
                             false);

--- a/flink-streaming-java/src/test/java/org/apache/flink/streaming/runtime/io/checkpointing/UnalignedCheckpointsTest.java
+++ b/flink-streaming-java/src/test/java/org/apache/flink/streaming/runtime/io/checkpointing/UnalignedCheckpointsTest.java
@@ -21,6 +21,7 @@ import org.apache.flink.runtime.checkpoint.CheckpointException;
 import org.apache.flink.runtime.checkpoint.CheckpointMetaData;
 import org.apache.flink.runtime.checkpoint.CheckpointMetricsBuilder;
 import org.apache.flink.runtime.checkpoint.CheckpointOptions;
+import org.apache.flink.runtime.checkpoint.CheckpointType;
 import org.apache.flink.runtime.checkpoint.channel.InputChannelInfo;
 import org.apache.flink.runtime.checkpoint.channel.RecordingChannelStateWriter;
 import org.apache.flink.runtime.io.network.NettyShuffleEnvironment;
@@ -899,7 +900,9 @@ public class UnalignedCheckpointsTest {
         sizeCounter++;
         return new BufferOrEvent(
                 new CheckpointBarrier(
-                        checkpointId, timestamp, CheckpointOptions.unaligned(getDefault())),
+                        checkpointId,
+                        timestamp,
+                        CheckpointOptions.unaligned(CheckpointType.CHECKPOINT, getDefault())),
                 new InputChannelInfo(0, channel));
     }
 
@@ -1055,7 +1058,8 @@ public class UnalignedCheckpointsTest {
     }
 
     private CheckpointBarrier buildCheckpointBarrier(long id) {
-        return new CheckpointBarrier(id, 0, CheckpointOptions.unaligned(getDefault()));
+        return new CheckpointBarrier(
+                id, 0, CheckpointOptions.unaligned(CheckpointType.CHECKPOINT, getDefault()));
     }
 
     // ------------------------------------------------------------------------

--- a/flink-streaming-java/src/test/java/org/apache/flink/streaming/runtime/tasks/MultipleInputStreamTaskChainedSourcesCheckpointingTest.java
+++ b/flink-streaming-java/src/test/java/org/apache/flink/streaming/runtime/tasks/MultipleInputStreamTaskChainedSourcesCheckpointingTest.java
@@ -366,7 +366,9 @@ public class MultipleInputStreamTaskChainedSourcesCheckpointingTest {
     public void testTriggerUnalignedCheckpointWithFinishedChannelsAndSourceChain()
             throws Exception {
         testTriggerCheckpointWithFinishedChannelsAndSourceChain(
-                CheckpointOptions.unaligned(CheckpointStorageLocationReference.getDefault()));
+                CheckpointOptions.unaligned(
+                        CheckpointType.CHECKPOINT,
+                        CheckpointStorageLocationReference.getDefault()));
     }
 
     @Test
@@ -374,7 +376,9 @@ public class MultipleInputStreamTaskChainedSourcesCheckpointingTest {
             throws Exception {
         testTriggerCheckpointWithFinishedChannelsAndSourceChain(
                 CheckpointOptions.alignedWithTimeout(
-                        CheckpointStorageLocationReference.getDefault(), 10L));
+                        CheckpointType.CHECKPOINT,
+                        CheckpointStorageLocationReference.getDefault(),
+                        10L));
     }
 
     private void testTriggerCheckpointWithFinishedChannelsAndSourceChain(

--- a/flink-streaming-java/src/test/java/org/apache/flink/streaming/runtime/tasks/MultipleInputStreamTaskTest.java
+++ b/flink-streaming-java/src/test/java/org/apache/flink/streaming/runtime/tasks/MultipleInputStreamTaskTest.java
@@ -933,14 +933,18 @@ public class MultipleInputStreamTaskTest {
     @Test
     public void testTriggeringUnalignedCheckpointWithFinishedChannels() throws Exception {
         testTriggeringCheckpointWithFinishedChannels(
-                CheckpointOptions.unaligned(CheckpointStorageLocationReference.getDefault()));
+                CheckpointOptions.unaligned(
+                        CheckpointType.CHECKPOINT,
+                        CheckpointStorageLocationReference.getDefault()));
     }
 
     @Test
     public void testTriggeringAlignedWithTimeoutCheckpointWithFinishedChannels() throws Exception {
         testTriggeringCheckpointWithFinishedChannels(
                 CheckpointOptions.alignedWithTimeout(
-                        CheckpointStorageLocationReference.getDefault(), 10L));
+                        CheckpointType.CHECKPOINT,
+                        CheckpointStorageLocationReference.getDefault(),
+                        10L));
     }
 
     private void testTriggeringCheckpointWithFinishedChannels(CheckpointOptions checkpointOptions)

--- a/flink-streaming-java/src/test/java/org/apache/flink/streaming/runtime/tasks/StreamTaskFinalCheckpointsTest.java
+++ b/flink-streaming-java/src/test/java/org/apache/flink/streaming/runtime/tasks/StreamTaskFinalCheckpointsTest.java
@@ -507,14 +507,18 @@ public class StreamTaskFinalCheckpointsTest {
     @Test
     public void testTriggeringUnalignedCheckpointWithFinishedChannels() throws Exception {
         testTriggeringCheckpointWithFinishedChannels(
-                CheckpointOptions.unaligned(CheckpointStorageLocationReference.getDefault()));
+                CheckpointOptions.unaligned(
+                        CheckpointType.CHECKPOINT,
+                        CheckpointStorageLocationReference.getDefault()));
     }
 
     @Test
     public void testTriggeringAlignedWithTimeoutCheckpointWithFinishedChannels() throws Exception {
         testTriggeringCheckpointWithFinishedChannels(
                 CheckpointOptions.alignedWithTimeout(
-                        CheckpointStorageLocationReference.getDefault(), 10L));
+                        CheckpointType.CHECKPOINT,
+                        CheckpointStorageLocationReference.getDefault(),
+                        10L));
     }
 
     private void testTriggeringCheckpointWithFinishedChannels(CheckpointOptions checkpointOptions)

--- a/flink-streaming-java/src/test/java/org/apache/flink/streaming/runtime/tasks/StreamTaskTest.java
+++ b/flink-streaming-java/src/test/java/org/apache/flink/streaming/runtime/tasks/StreamTaskTest.java
@@ -86,6 +86,7 @@ import org.apache.flink.runtime.state.TaskStateManager;
 import org.apache.flink.runtime.state.TaskStateManagerImpl;
 import org.apache.flink.runtime.state.changelog.inmemory.InMemoryStateChangelogStorage;
 import org.apache.flink.runtime.state.memory.MemoryStateBackend;
+import org.apache.flink.runtime.state.ttl.mock.MockStateBackend;
 import org.apache.flink.runtime.taskmanager.AsynchronousException;
 import org.apache.flink.runtime.taskmanager.CheckpointResponder;
 import org.apache.flink.runtime.taskmanager.NoOpTaskManagerActions;
@@ -198,6 +199,7 @@ import static org.hamcrest.Matchers.lessThan;
 import static org.hamcrest.Matchers.sameInstance;
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertFalse;
+import static org.junit.Assert.assertThrows;
 import static org.junit.Assert.assertTrue;
 import static org.junit.Assert.fail;
 import static org.mockito.ArgumentMatchers.nullable;
@@ -623,6 +625,39 @@ public class StreamTaskTest extends TestLogger {
 
         streamTask.finishInput();
         task.waitForTaskCompletion(false);
+    }
+
+    @Test
+    public void testForceFullSnapshotOnIncompatibleStateBackend() throws Exception {
+        try (StreamTaskMailboxTestHarness<Integer> harness =
+                new StreamTaskMailboxTestHarnessBuilder<>(
+                                OneInputStreamTask::new, BasicTypeInfo.INT_TYPE_INFO)
+                        .modifyStreamConfig(
+                                config -> config.setStateBackend(new OnlyIncrementalStateBackend()))
+                        .addInput(BasicTypeInfo.INT_TYPE_INFO)
+                        .setupOutputForSingletonOperatorChain(new StreamMap<>(value -> null))
+                        .build()) {
+            final IllegalStateException exception =
+                    assertThrows(
+                            IllegalStateException.class,
+                            () -> {
+                                harness.streamTask.triggerCheckpointAsync(
+                                        new CheckpointMetaData(42L, 1L),
+                                        CheckpointOptions.forConfig(
+                                                CheckpointType.FULL_CHECKPOINT,
+                                                getDefault(),
+                                                true,
+                                                false,
+                                                0L));
+                            });
+            assertThat(
+                    exception.getMessage(),
+                    equalTo(
+                            "Configured state backend (OnlyIncrementalStateBackend) does not"
+                                    + " support enforcing a full snapshot. If you are restoring in"
+                                    + " NO_CLAIM mode, please consider choosing either CLAIM or"
+                                    + " LEGACY restore mode."));
+        }
     }
 
     /**
@@ -2656,6 +2691,18 @@ public class StreamTaskTest extends TestLogger {
 
         public List<Long> getNotifiedCheckpoint() {
             return notifiedCheckpoint;
+        }
+    }
+
+    private static final class OnlyIncrementalStateBackend extends MockStateBackend {
+        @Override
+        public boolean supportsNoClaimRestoreMode() {
+            return false;
+        }
+
+        @Override
+        public String toString() {
+            return "OnlyIncrementalStateBackend";
         }
     }
 }

--- a/flink-streaming-java/src/test/java/org/apache/flink/streaming/runtime/tasks/SubtaskCheckpointCoordinatorTest.java
+++ b/flink-streaming-java/src/test/java/org/apache/flink/streaming/runtime/tasks/SubtaskCheckpointCoordinatorTest.java
@@ -114,7 +114,7 @@ public class SubtaskCheckpointCoordinatorTest {
         coordinator.initInputsCheckpoint(
                 1L,
                 unalignedCheckpointEnabled
-                        ? CheckpointOptions.unaligned(locationReference)
+                        ? CheckpointOptions.unaligned(CheckpointType.CHECKPOINT, locationReference)
                         : CheckpointOptions.alignedNoTimeout(checkpointType, locationReference));
         return writer.started;
     }
@@ -216,7 +216,9 @@ public class SubtaskCheckpointCoordinatorTest {
                     };
 
             CheckpointOptions forcedAlignedOptions =
-                    CheckpointOptions.unaligned(CheckpointStorageLocationReference.getDefault())
+                    CheckpointOptions.unaligned(
+                                    CheckpointType.CHECKPOINT,
+                                    CheckpointStorageLocationReference.getDefault())
                             .withUnalignedUnsupported();
             coordinator.checkpointState(
                     new CheckpointMetaData(checkpointId, 0),

--- a/flink-table/flink-sql-client/src/test/resources/sql/set.q
+++ b/flink-table/flink-sql-client/src/test/resources/sql/set.q
@@ -39,7 +39,7 @@ CREATE TABLE hive_table (
 # list the configured configuration
 set;
 'execution.attached' = 'true'
-'execution.savepoint-restore-mode' = 'LEGACY'
+'execution.savepoint-restore-mode' = 'NO_CLAIM'
 'execution.savepoint.ignore-unclaimed-state' = 'false'
 'execution.shutdown-on-attached-exit' = 'false'
 'execution.target' = 'remote'
@@ -58,7 +58,7 @@ reset;
 
 set;
 'execution.attached' = 'true'
-'execution.savepoint-restore-mode' = 'LEGACY'
+'execution.savepoint-restore-mode' = 'NO_CLAIM'
 'execution.savepoint.ignore-unclaimed-state' = 'false'
 'execution.shutdown-on-attached-exit' = 'false'
 'execution.target' = 'remote'
@@ -92,7 +92,7 @@ Was expecting one of:
 
 set;
 'execution.attached' = 'true'
-'execution.savepoint-restore-mode' = 'LEGACY'
+'execution.savepoint-restore-mode' = 'NO_CLAIM'
 'execution.savepoint.ignore-unclaimed-state' = 'false'
 'execution.shutdown-on-attached-exit' = 'false'
 'execution.target' = 'remote'
@@ -113,7 +113,7 @@ reset 'execution.attached';
 
 set;
 'execution.attached' = 'true'
-'execution.savepoint-restore-mode' = 'LEGACY'
+'execution.savepoint-restore-mode' = 'NO_CLAIM'
 'execution.savepoint.ignore-unclaimed-state' = 'false'
 'execution.shutdown-on-attached-exit' = 'false'
 'execution.target' = 'remote'
@@ -135,7 +135,7 @@ $VAR_UDF_JAR_PATH
 
 set;
 'execution.attached' = 'true'
-'execution.savepoint-restore-mode' = 'LEGACY'
+'execution.savepoint-restore-mode' = 'NO_CLAIM'
 'execution.savepoint.ignore-unclaimed-state' = 'false'
 'execution.shutdown-on-attached-exit' = 'false'
 'execution.target' = 'remote'

--- a/flink-test-utils-parent/flink-test-utils/src/main/java/org/apache/flink/streaming/util/TestStreamEnvironment.java
+++ b/flink-test-utils-parent/flink-test-utils/src/main/java/org/apache/flink/streaming/util/TestStreamEnvironment.java
@@ -124,8 +124,13 @@ public class TestStreamEnvironment extends StreamExecutionEnvironment {
         if (isConfigurationSupportedByChangelog(miniCluster.getConfiguration())) {
             if (STATE_CHANGE_LOG_CONFIG.equalsIgnoreCase(STATE_CHANGE_LOG_CONFIG_ON)) {
                 conf.set(StateChangelogOptions.ENABLE_STATE_CHANGE_LOG, true);
+                miniCluster.overrideRestoreModeForRandomizedChangelogStateBackend();
             } else if (STATE_CHANGE_LOG_CONFIG.equalsIgnoreCase(STATE_CHANGE_LOG_CONFIG_RAND)) {
-                randomize(conf, StateChangelogOptions.ENABLE_STATE_CHANGE_LOG, true, false);
+                boolean enabled =
+                        randomize(conf, StateChangelogOptions.ENABLE_STATE_CHANGE_LOG, true, false);
+                if (enabled) {
+                    miniCluster.overrideRestoreModeForRandomizedChangelogStateBackend();
+                }
             }
         }
     }


### PR DESCRIPTION
## What is the purpose of the change

We introduce NO_CLAIM restore mode in which we do not take ownership of
the restored checkpoint. We do enforce the first, successful checkpoint
after a restore to be "full" meaning it can not share any artefacts with
the initial one.

Taking a "full" snapshot needs support from state backend, therefore we
add a method supportsNoClaimMode to the Snapshottable interface, so
that state backend can add support incrementally. If a state backend
does not support forces snapshots, user can switch to either the LEGACY
mode or CLAIM mode.


## Verifying this change

Added:
* IT test: `SavepointITCase.testTriggerSavepointAndResumeWithNoClaim`
* `StreamTaskTest.testForceFullSnapshotOnIncompatibleStateBackend`


## Does this pull request potentially affect one of the following parts:

  - Dependencies (does it add or upgrade a dependency): (yes / **no**)
  - The public API, i.e., is any changed class annotated with `@Public(Evolving)`: (**yes** / no)
  - The serializers: (yes / **no** / don't know)
  - The runtime per-record code paths (performance sensitive): (yes / **no** / don't know)
  - Anything that affects deployment or recovery: JobManager (and its components), Checkpointing, Kubernetes/Yarn, ZooKeeper: (**yes** / no / don't know)
  - The S3 file system connector: (yes / **no /** don't know)

## Documentation

  - Does this pull request introduce a new feature? (**yes** / no)
  - If yes, how is the feature documented? (not applicable / docs / **JavaDocs** / not documented): will be documented in a separate effort
