### PR TITLE
[FLINK-22096][tests] Fix port conflict for ServerTransportErrorHandlingTest#testRemoteClose

### DIFF
--- a/flink-runtime/src/test/java/org/apache/flink/runtime/io/network/netty/ServerTransportErrorHandlingTest.java
+++ b/flink-runtime/src/test/java/org/apache/flink/runtime/io/network/netty/ServerTransportErrorHandlingTest.java
@@ -26,6 +26,7 @@ import org.apache.flink.runtime.io.network.partition.ResultSubpartitionView;
 import org.apache.flink.runtime.io.network.partition.consumer.InputChannelID;
 import org.apache.flink.runtime.io.network.util.TestPooledBufferProvider;
 import org.apache.flink.runtime.testutils.TestingUtils;
+import org.apache.flink.util.ExceptionUtils;
 
 import org.apache.flink.shaded.netty4.io.netty.channel.Channel;
 import org.apache.flink.shaded.netty4.io.netty.channel.ChannelHandler;
@@ -36,6 +37,7 @@ import org.junit.Test;
 import org.mockito.invocation.InvocationOnMock;
 import org.mockito.stubbing.Answer;
 
+import java.net.BindException;
 import java.util.concurrent.CountDownLatch;
 import java.util.concurrent.TimeUnit;
 
@@ -50,6 +52,7 @@ import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.when;
 
 public class ServerTransportErrorHandlingTest {
+    private static final int NETTY_INIT_MAX_RETRY_TIMES = 20;
 
     /** Verifies remote closes trigger the release of all resources. */
     @Test
@@ -101,7 +104,26 @@ public class ServerTransportErrorHandlingTest {
         NettyTestUtil.NettyServerAndClient serverAndClient = null;
 
         try {
-            serverAndClient = initServerAndClient(protocol, createConfig());
+            for (int retry = 0; retry < NETTY_INIT_MAX_RETRY_TIMES; retry++) {
+                try {
+                    serverAndClient = initServerAndClient(protocol, createConfig());
+                    break;
+                } catch (Exception e) {
+                    if (retry >= NETTY_INIT_MAX_RETRY_TIMES - 1) {
+                        throw new RuntimeException(
+                                "Failed to initialize netty server and client, retried "
+                                        + retry
+                                        + " times.",
+                                e);
+                    }
+                    if (e instanceof BindException
+                            || ExceptionUtils.findThrowableWithMessage(e, "Address already in use")
+                                    .isPresent()) {
+                        continue;
+                    }
+                    throw e;
+                }
+            }
 
             Channel ch = connect(serverAndClient);
 


### PR DESCRIPTION

<!--
*Thank you very much for contributing to Apache Flink - we are happy that you want to help us improve Flink. To help the community review your contribution in the best possible way, please go through the checklist below, which will get the contribution into a shape in which it can be best reviewed.*

*Please understand that we do not do this to make contributions to Flink a hassle. In order to uphold a high standard of quality for code contributions, while at the same time managing a large number of contributions, we need contributors to prepare the contributions well, and give reviewers enough contextual information for the review. Please also understand that contributions that do not follow this guide will take longer to review and thus typically be picked up with lower priority by the community.*

## Contribution Checklist

  - Make sure that the pull request corresponds to a [JIRA issue](https://issues.apache.org/jira/projects/FLINK/issues). Exceptions are made for typos in JavaDoc or documentation files, which need no JIRA issue.
  
  - Name the pull request in the form "[FLINK-XXXX] [component] Title of the pull request", where *FLINK-XXXX* should be replaced by the actual issue number. Skip *component* if you are unsure about which is the best component.
  Typo fixes that have no associated JIRA issue should be named following this pattern: `[hotfix] [docs] Fix typo in event time introduction` or `[hotfix] [javadocs] Expand JavaDoc for PuncuatedWatermarkGenerator`.

  - Fill out the template below to describe the changes contributed by the pull request. That will give reviewers the context they need to do the review.
  
  - Make sure that the change passes the automated tests, i.e., `mvn clean verify` passes. You can set up Azure Pipelines CI to do that following [this guide](https://cwiki.apache.org/confluence/display/FLINK/Azure+Pipelines#AzurePipelines-Tutorial:SettingupAzurePipelinesforaforkoftheFlinkrepository).

  - Each pull request should address only one issue, not mix up code from multiple issues.
  
  - Each commit in the pull request has a meaningful commit message (including the JIRA id)

  - Once all items of the checklist are addressed, remove the above text and this checklist, leaving only the filled out template below.


**(The sections below can be removed for hotfixes of typos)**
-->

## What is the purpose of the change

Fix port conflict in `ServerTransportErrorHandlingTest#testRemoteClose`. In the test case, a `BindException`  may be thrown when init Netty server. When initializing Netty server, `NetUtils.getAvailablePort()` is called in `createConfig()`. After obtaining the available port, the port may be used by other processes, which may lead to `BindException`. To resolve the issue, a retry is added when calling `initServerAndClient` method.

## Brief change log
  - *Add the number of retries when initializing the Netty server in the test case*

## Verifying this change
  - *Initializing  the Netty server successfully in the test case*

## Does this pull request potentially affect one of the following parts:

  - Dependencies (does it add or upgrade a dependency): (yes / **no**)
  - The public API, i.e., is any changed class annotated with `@Public(Evolving)`: (yes / **no**)
  - The serializers: (yes / **no** / don't know)
  - The runtime per-record code paths (performance sensitive): (yes / **no** / don't know)
  - Anything that affects deployment or recovery: JobManager (and its components), Checkpointing, Kubernetes/Yarn, ZooKeeper: (yes / **no** / don't know)
  - The S3 file system connector: (yes / **no** / don't know)

## Documentation

  - Does this pull request introduce a new feature? (yes / **no**)
  - If yes, how is the feature documented? (**not applicable** / docs / JavaDocs / not documented)
