### PR TITLE
 [FLINK-25191] Skip savepoints for recovery 

### DIFF
--- a/docs/content/docs/ops/state/savepoints.md
+++ b/docs/content/docs/ops/state/savepoints.md
@@ -130,9 +130,23 @@ Unlike savepoints, checkpoints cannot generally be moved to a different location
 
 If you use `JobManagerCheckpointStorage`, metadata *and* savepoint state will be stored in the `_metadata` file, so don't be confused by the absence of additional data files.
 
-{{< hint warning  >}}
-It is discouraged to move or delete the last savepoint of a running job, because this might interfere with failure-recovery. Savepoints have side-effects on exactly-once sinks, therefore 
-to ensure exactly-once semantics, if there is no checkpoint after the last savepoint, the savepoint will be used for recovery. 
+{{< hint warning  >}} 
+Starting from Flink 1.15 intermediate savepoints (savepoints other than
+created with [stop-with-savepoint](#stopping-a-job-with-savepoint)) are not used for recovery and do
+not commit any side effects.
+
+This has to be taken into consideration, especially when running multiple jobs in the same
+checkpointing timeline. It is possible in that solution that if the original job (after taking a
+savepoint) fails, then it will fall back to a checkpoint prior to the savepoint. However, if we now
+resume a job from the savepoint, then we might commit transactions that might’ve never happened
+because of falling back to a checkpoint before the savepoint (assuming non-determinism).
+
+If one wants to be safe in those scenarios, we advise dropping the state of transactional sinks, by
+changing sinks [uids](#assigning-operator-ids).
+
+It should not require any additional steps if there is just a single job running in the same
+checkpointing timeline, which means that you stop the original job before running a new job from the
+savepoint. 
 {{< /hint >}}
 
 #### Trigger a Savepoint

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/checkpoint/CheckpointCoordinator.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/checkpoint/CheckpointCoordinator.java
@@ -1206,7 +1206,8 @@ public class CheckpointCoordinator {
         final CheckpointProperties props = pendingCheckpoint.getProps();
 
         // As a first step to complete the checkpoint, we register its state with the registry
-        // we do not
+        // we do not register savepoints' shared state, as Flink is not in charge of savepoints'
+        // lifecycle
         if (!props.isSavepoint()) {
             registerSharedStates(pendingCheckpoint);
         }

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/checkpoint/CheckpointCoordinator.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/checkpoint/CheckpointCoordinator.java
@@ -1234,9 +1234,20 @@ public class CheckpointCoordinator {
         // the 'min delay between checkpoints'
         lastCheckpointCompletionRelativeTime = clock.relativeTimeMillis();
 
+        logCheckpointInfo(completedCheckpoint);
+
+        // send the "notify complete" call to all vertices, coordinators, etc.
+        sendAcknowledgeMessages(
+                pendingCheckpoint.getCheckpointPlan().getTasksToCommitTo(),
+                checkpointId,
+                completedCheckpoint.getTimestamp(),
+                extractIdIfDiscardedOnSubsumed(lastSubsumed));
+    }
+
+    private void logCheckpointInfo(CompletedCheckpoint completedCheckpoint) {
         LOG.info(
                 "Completed checkpoint {} for job {} ({} bytes, checkpointDuration={} ms, finalizationTime={} ms).",
-                checkpointId,
+                completedCheckpoint.getCheckpointID(),
                 job,
                 completedCheckpoint.getStateSize(),
                 completedCheckpoint.getCompletionTimestamp() - completedCheckpoint.getTimestamp(),
@@ -1254,13 +1265,6 @@ public class CheckpointCoordinator {
 
             LOG.debug(builder.toString());
         }
-
-        // send the "notify complete" call to all vertices, coordinators, etc.
-        sendAcknowledgeMessages(
-                pendingCheckpoint.getCheckpointPlan().getTasksToCommitTo(),
-                checkpointId,
-                completedCheckpoint.getTimestamp(),
-                extractIdIfDiscardedOnSubsumed(lastSubsumed));
     }
 
     private CompletedCheckpoint finalizeCheckpoint(PendingCheckpoint pendingCheckpoint)

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/checkpoint/CheckpointCoordinator.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/checkpoint/CheckpointCoordinator.java
@@ -1200,14 +1200,16 @@ public class CheckpointCoordinator {
      */
     private void completePendingCheckpoint(PendingCheckpoint pendingCheckpoint)
             throws CheckpointException {
-        final long checkpointId = pendingCheckpoint.getCheckpointId();
+        final long checkpointId = pendingCheckpoint.getCheckpointID();
         final CompletedCheckpoint completedCheckpoint;
         final CompletedCheckpoint lastSubsumed;
+        final CheckpointProperties props = pendingCheckpoint.getProps();
 
         // As a first step to complete the checkpoint, we register its state with the registry
-        Map<OperatorID, OperatorState> operatorStates = pendingCheckpoint.getOperatorStates();
-        SharedStateRegistry sharedStateRegistry = completedCheckpointStore.getSharedStateRegistry();
-        sharedStateRegistry.registerAll(operatorStates.values());
+        // we do not
+        if (!props.isSavepoint()) {
+            registerSharedStates(pendingCheckpoint);
+        }
 
         try {
             completedCheckpoint = finalizeCheckpoint(pendingCheckpoint);
@@ -1215,20 +1217,22 @@ public class CheckpointCoordinator {
             // the pending checkpoint must be discarded after the finalization
             Preconditions.checkState(pendingCheckpoint.isDisposed() && completedCheckpoint != null);
 
-            lastSubsumed =
-                    addCompletedCheckpointToStoreAndSubsumeOldest(
-                            checkpointId,
-                            completedCheckpoint,
-                            pendingCheckpoint.getCheckpointPlan().getTasksToCommitTo());
+            if (!props.isSavepoint()) {
+                lastSubsumed =
+                        addCompletedCheckpointToStoreAndSubsumeOldest(
+                                checkpointId,
+                                completedCheckpoint,
+                                pendingCheckpoint.getCheckpointPlan().getTasksToCommitTo());
+            } else {
+                lastSubsumed = null;
+            }
         } finally {
             pendingCheckpoints.remove(checkpointId);
             scheduleTriggerRequest();
         }
 
+        // remember recent checkpoint id for debugging purposes
         rememberRecentCheckpointId(checkpointId);
-
-        // drop those pending checkpoints that are at prior to the completed one
-        dropSubsumedCheckpoints(checkpointId);
 
         // record the time when this was completed, to calculate
         // the 'min delay between checkpoints'
@@ -1236,12 +1240,23 @@ public class CheckpointCoordinator {
 
         logCheckpointInfo(completedCheckpoint);
 
-        // send the "notify complete" call to all vertices, coordinators, etc.
-        sendAcknowledgeMessages(
-                pendingCheckpoint.getCheckpointPlan().getTasksToCommitTo(),
-                checkpointId,
-                completedCheckpoint.getTimestamp(),
-                extractIdIfDiscardedOnSubsumed(lastSubsumed));
+        if (!props.isSavepoint() || props.isSynchronous()) {
+            // drop those pending checkpoints that are at prior to the completed one
+            dropSubsumedCheckpoints(checkpointId);
+
+            // send the "notify complete" call to all vertices, coordinators, etc.
+            sendAcknowledgeMessages(
+                    pendingCheckpoint.getCheckpointPlan().getTasksToCommitTo(),
+                    checkpointId,
+                    completedCheckpoint.getTimestamp(),
+                    extractIdIfDiscardedOnSubsumed(lastSubsumed));
+        }
+    }
+
+    private void registerSharedStates(PendingCheckpoint pendingCheckpoint) {
+        Map<OperatorID, OperatorState> operatorStates = pendingCheckpoint.getOperatorStates();
+        SharedStateRegistry sharedStateRegistry = completedCheckpointStore.getSharedStateRegistry();
+        sharedStateRegistry.registerAll(operatorStates.values());
     }
 
     private void logCheckpointInfo(CompletedCheckpoint completedCheckpoint) {

--- a/flink-runtime/src/test/java/org/apache/flink/runtime/checkpoint/CheckpointCoordinatorFailureTest.java
+++ b/flink-runtime/src/test/java/org/apache/flink/runtime/checkpoint/CheckpointCoordinatorFailureTest.java
@@ -41,9 +41,7 @@ import org.apache.flink.util.TestLogger;
 import org.apache.flink.util.concurrent.Executors;
 import org.apache.flink.util.concurrent.ManuallyTriggeredScheduledExecutor;
 
-import org.junit.Rule;
 import org.junit.Test;
-import org.junit.rules.TemporaryFolder;
 
 import java.util.Collections;
 import java.util.List;
@@ -64,8 +62,6 @@ import static org.mockito.Mockito.when;
 
 /** Tests for failure of checkpoint coordinator. */
 public class CheckpointCoordinatorFailureTest extends TestLogger {
-
-    @Rule public TemporaryFolder tmpFolder = new TemporaryFolder();
 
     /**
      * Tests that a failure while storing a completed checkpoint in the completed checkpoint store
@@ -231,7 +227,7 @@ public class CheckpointCoordinatorFailureTest extends TestLogger {
                         .setCompletedCheckpointStore(completedCheckpointStore)
                         .setTimer(manuallyTriggeredScheduledExecutor)
                         .build();
-        checkpointCoordinator.triggerSavepoint(tmpFolder.newFolder().getAbsolutePath());
+        checkpointCoordinator.triggerCheckpoint(false);
         manuallyTriggeredScheduledExecutor.triggerAll();
 
         try {

--- a/flink-tests/src/test/resources/META-INF/services/org.apache.flink.core.fs.FileSystemFactory
+++ b/flink-tests/src/test/resources/META-INF/services/org.apache.flink.core.fs.FileSystemFactory
@@ -1,0 +1,16 @@
+# Licensed to the Apache Software Foundation (ASF) under one or more
+# contributor license agreements.  See the NOTICE file distributed with
+# this work for additional information regarding copyright ownership.
+# The ASF licenses this file to You under the Apache License, Version 2.0
+# (the "License"); you may not use this file except in compliance with
+# the License.  You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+org.apache.flink.test.checkpointing.SavepointITCase$PathFailingFileSystemFactory


### PR DESCRIPTION
## What is the purpose of the change

We do no longer register savepoints in the `CompletedCheckpointStore`. Moreover we do not send `notifyCheckpointComplete` 

## Verifying this change

All tests pass. Adjusted tests in `CheckpointCoordinatorTest`
## Does this pull request potentially affect one of the following parts:

  - Dependencies (does it add or upgrade a dependency): (yes / **no**)
  - The public API, i.e., is any changed class annotated with `@Public(Evolving)`: (yes / **no**)
  - The serializers: (yes / **no** / don't know)
  - The runtime per-record code paths (performance sensitive): (yes / **no** / don't know)
  - Anything that affects deployment or recovery: JobManager (and its components), Checkpointing, Kubernetes/Yarn, ZooKeeper: (**yes** / no / don't know)
  - The S3 file system connector: (yes / **no** / don't know)

## Documentation

  - Does this pull request introduce a new feature? (yes / **no**)
  - If yes, how is the feature documented? (not applicable / **docs** / **JavaDocs** / not documented)
