### PR TITLE
[FLINK-25274][TableSQL/API] Remove usage of deprecated TableSchema from DataGen

### DIFF
--- a/flink-table/flink-table-api-java-bridge/src/main/java/org/apache/flink/connector/datagen/table/DataGenTableSource.java
+++ b/flink-table/flink-table-api-java-bridge/src/main/java/org/apache/flink/connector/datagen/table/DataGenTableSource.java
@@ -24,7 +24,7 @@ import org.apache.flink.connector.datagen.table.types.RowDataGenerator;
 import org.apache.flink.streaming.api.functions.source.StatefulSequenceSource;
 import org.apache.flink.streaming.api.functions.source.datagen.DataGenerator;
 import org.apache.flink.streaming.api.functions.source.datagen.DataGeneratorSource;
-import org.apache.flink.table.api.TableSchema;
+import org.apache.flink.table.catalog.ResolvedSchema;
 import org.apache.flink.table.connector.ChangelogMode;
 import org.apache.flink.table.connector.source.DynamicTableSource;
 import org.apache.flink.table.connector.source.ScanTableSource;
@@ -41,14 +41,14 @@ public class DataGenTableSource implements ScanTableSource {
 
     private final DataGenerator<?>[] fieldGenerators;
     private final String tableName;
-    private final TableSchema schema;
+    private final ResolvedSchema schema;
     private final long rowsPerSecond;
     private final Long numberOfRows;
 
     public DataGenTableSource(
             DataGenerator<?>[] fieldGenerators,
             String tableName,
-            TableSchema schema,
+            ResolvedSchema schema,
             long rowsPerSecond,
             Long numberOfRows) {
         this.fieldGenerators = fieldGenerators;
@@ -67,7 +67,7 @@ public class DataGenTableSource implements ScanTableSource {
     @VisibleForTesting
     public DataGeneratorSource<RowData> createSource() {
         return new DataGeneratorSource<>(
-                new RowDataGenerator(fieldGenerators, schema.getFieldNames()),
+                new RowDataGenerator(fieldGenerators, schema.getColumnNames()),
                 rowsPerSecond,
                 numberOfRows);
     }

--- a/flink-table/flink-table-api-java-bridge/src/main/java/org/apache/flink/connector/datagen/table/DataGenTableSource.java
+++ b/flink-table/flink-table-api-java-bridge/src/main/java/org/apache/flink/connector/datagen/table/DataGenTableSource.java
@@ -24,13 +24,13 @@ import org.apache.flink.connector.datagen.table.types.RowDataGenerator;
 import org.apache.flink.streaming.api.functions.source.StatefulSequenceSource;
 import org.apache.flink.streaming.api.functions.source.datagen.DataGenerator;
 import org.apache.flink.streaming.api.functions.source.datagen.DataGeneratorSource;
-import org.apache.flink.table.catalog.ResolvedSchema;
 import org.apache.flink.table.connector.ChangelogMode;
 import org.apache.flink.table.connector.source.DynamicTableSource;
 import org.apache.flink.table.connector.source.ScanTableSource;
 import org.apache.flink.table.connector.source.SourceFunctionProvider;
 import org.apache.flink.table.data.RowData;
 import org.apache.flink.table.sources.StreamTableSource;
+import org.apache.flink.table.types.DataType;
 
 /**
  * A {@link StreamTableSource} that emits each number from a given interval exactly once, possibly
@@ -41,19 +41,19 @@ public class DataGenTableSource implements ScanTableSource {
 
     private final DataGenerator<?>[] fieldGenerators;
     private final String tableName;
-    private final ResolvedSchema schema;
+    private final DataType rowDataType;
     private final long rowsPerSecond;
     private final Long numberOfRows;
 
     public DataGenTableSource(
             DataGenerator<?>[] fieldGenerators,
             String tableName,
-            ResolvedSchema schema,
+            DataType rowDataType,
             long rowsPerSecond,
             Long numberOfRows) {
         this.fieldGenerators = fieldGenerators;
         this.tableName = tableName;
-        this.schema = schema;
+        this.rowDataType = rowDataType;
         this.rowsPerSecond = rowsPerSecond;
         this.numberOfRows = numberOfRows;
     }
@@ -67,7 +67,7 @@ public class DataGenTableSource implements ScanTableSource {
     @VisibleForTesting
     public DataGeneratorSource<RowData> createSource() {
         return new DataGeneratorSource<>(
-                new RowDataGenerator(fieldGenerators, schema.getColumnNames()),
+                new RowDataGenerator(fieldGenerators, DataType.getFieldNames(rowDataType)),
                 rowsPerSecond,
                 numberOfRows);
     }
@@ -75,7 +75,7 @@ public class DataGenTableSource implements ScanTableSource {
     @Override
     public DynamicTableSource copy() {
         return new DataGenTableSource(
-                fieldGenerators, tableName, schema, rowsPerSecond, numberOfRows);
+                fieldGenerators, tableName, rowDataType, rowsPerSecond, numberOfRows);
     }
 
     @Override

--- a/flink-table/flink-table-api-java-bridge/src/main/java/org/apache/flink/connector/datagen/table/DataGenTableSourceFactory.java
+++ b/flink-table/flink-table-api-java-bridge/src/main/java/org/apache/flink/connector/datagen/table/DataGenTableSourceFactory.java
@@ -24,13 +24,13 @@ import org.apache.flink.configuration.Configuration;
 import org.apache.flink.configuration.ReadableConfig;
 import org.apache.flink.streaming.api.functions.source.datagen.DataGenerator;
 import org.apache.flink.table.api.ValidationException;
-import org.apache.flink.table.catalog.ResolvedSchema;
 import org.apache.flink.table.connector.source.DynamicTableSource;
 import org.apache.flink.table.factories.DynamicTableSourceFactory;
 import org.apache.flink.table.factories.FactoryUtil;
 import org.apache.flink.table.types.DataType;
 
 import java.util.HashSet;
+import java.util.List;
 import java.util.Set;
 
 import static org.apache.flink.configuration.ConfigOptions.key;
@@ -77,13 +77,15 @@ public class DataGenTableSourceFactory implements DynamicTableSourceFactory {
         Configuration options = new Configuration();
         context.getCatalogTable().getOptions().forEach(options::setString);
 
-        ResolvedSchema schema = context.getCatalogTable().getResolvedSchema();
-        DataGenerator<?>[] fieldGenerators = new DataGenerator[schema.getColumnCount()];
+        DataType rowDataType = context.getPhysicalRowDataType();
+        DataGenerator<?>[] fieldGenerators = new DataGenerator[DataType.getFieldCount(rowDataType)];
         Set<ConfigOption<?>> optionalOptions = new HashSet<>();
 
+        List<String> fieldNames = DataType.getFieldNames(rowDataType);
+        List<DataType> fieldDataTypes = DataType.getFieldDataTypes(rowDataType);
         for (int i = 0; i < fieldGenerators.length; i++) {
-            String name = schema.getColumnNames().get(i);
-            DataType type = schema.getColumnDataTypes().get(i);
+            String name = fieldNames.get(i);
+            DataType type = fieldDataTypes.get(i);
 
             ConfigOption<String> kind =
                     key(DataGenConnectorOptionsUtil.FIELDS
@@ -115,7 +117,7 @@ public class DataGenTableSourceFactory implements DynamicTableSourceFactory {
         return new DataGenTableSource(
                 fieldGenerators,
                 name,
-                schema,
+                rowDataType,
                 options.get(DataGenConnectorOptions.ROWS_PER_SECOND),
                 options.get(DataGenConnectorOptions.NUMBER_OF_ROWS));
     }

--- a/flink-table/flink-table-api-java-bridge/src/main/java/org/apache/flink/connector/datagen/table/DataGenTableSourceFactory.java
+++ b/flink-table/flink-table-api-java-bridge/src/main/java/org/apache/flink/connector/datagen/table/DataGenTableSourceFactory.java
@@ -23,13 +23,12 @@ import org.apache.flink.configuration.ConfigOption;
 import org.apache.flink.configuration.Configuration;
 import org.apache.flink.configuration.ReadableConfig;
 import org.apache.flink.streaming.api.functions.source.datagen.DataGenerator;
-import org.apache.flink.table.api.TableSchema;
 import org.apache.flink.table.api.ValidationException;
+import org.apache.flink.table.catalog.ResolvedSchema;
 import org.apache.flink.table.connector.source.DynamicTableSource;
 import org.apache.flink.table.factories.DynamicTableSourceFactory;
 import org.apache.flink.table.factories.FactoryUtil;
 import org.apache.flink.table.types.DataType;
-import org.apache.flink.table.utils.TableSchemaUtils;
 
 import java.util.HashSet;
 import java.util.Set;
@@ -78,14 +77,13 @@ public class DataGenTableSourceFactory implements DynamicTableSourceFactory {
         Configuration options = new Configuration();
         context.getCatalogTable().getOptions().forEach(options::setString);
 
-        TableSchema schema =
-                TableSchemaUtils.getPhysicalSchema(context.getCatalogTable().getSchema());
-        DataGenerator<?>[] fieldGenerators = new DataGenerator[schema.getFieldCount()];
+        ResolvedSchema schema = context.getCatalogTable().getResolvedSchema();
+        DataGenerator<?>[] fieldGenerators = new DataGenerator[schema.getColumnCount()];
         Set<ConfigOption<?>> optionalOptions = new HashSet<>();
 
         for (int i = 0; i < fieldGenerators.length; i++) {
-            String name = schema.getFieldNames()[i];
-            DataType type = schema.getFieldDataTypes()[i];
+            String name = schema.getColumnNames().get(i);
+            DataType type = schema.getColumnDataTypes().get(i);
 
             ConfigOption<String> kind =
                     key(DataGenConnectorOptionsUtil.FIELDS

--- a/flink-table/flink-table-api-java-bridge/src/main/java/org/apache/flink/connector/datagen/table/RandomGeneratorVisitor.java
+++ b/flink-table/flink-table-api-java-bridge/src/main/java/org/apache/flink/connector/datagen/table/RandomGeneratorVisitor.java
@@ -348,9 +348,8 @@ public class RandomGeneratorVisitor extends DataGenVisitorBase {
                         .map(DataGeneratorContainer::getGenerator)
                         .toArray(DataGenerator[]::new);
 
-        String[] fieldNames = rowType.getFieldNames().toArray(new String[0]);
-
-        return DataGeneratorContainer.of(new RowDataGenerator(generators, fieldNames), options);
+        return DataGeneratorContainer.of(
+                new RowDataGenerator(generators, rowType.getFieldNames()), options);
     }
 
     @Override

--- a/flink-table/flink-table-api-java-bridge/src/main/java/org/apache/flink/connector/datagen/table/types/RowDataGenerator.java
+++ b/flink-table/flink-table-api-java-bridge/src/main/java/org/apache/flink/connector/datagen/table/types/RowDataGenerator.java
@@ -26,6 +26,8 @@ import org.apache.flink.streaming.api.functions.source.datagen.DataGenerator;
 import org.apache.flink.table.data.GenericRowData;
 import org.apache.flink.table.data.RowData;
 
+import java.util.List;
+
 /** Data generator for Flink's internal {@link RowData} type. */
 @Internal
 public class RowDataGenerator implements DataGenerator<RowData> {
@@ -33,9 +35,9 @@ public class RowDataGenerator implements DataGenerator<RowData> {
     private static final long serialVersionUID = 1L;
 
     private final DataGenerator<?>[] fieldGenerators;
-    private final String[] fieldNames;
+    private final List<String> fieldNames;
 
-    public RowDataGenerator(DataGenerator<?>[] fieldGenerators, String[] fieldNames) {
+    public RowDataGenerator(DataGenerator<?>[] fieldGenerators, List<String> fieldNames) {
         this.fieldGenerators = fieldGenerators;
         this.fieldNames = fieldNames;
     }
@@ -45,7 +47,7 @@ public class RowDataGenerator implements DataGenerator<RowData> {
             String name, FunctionInitializationContext context, RuntimeContext runtimeContext)
             throws Exception {
         for (int i = 0; i < fieldGenerators.length; i++) {
-            fieldGenerators[i].open(fieldNames[i], context, runtimeContext);
+            fieldGenerators[i].open(fieldNames.get(i), context, runtimeContext);
         }
     }
 
@@ -68,7 +70,7 @@ public class RowDataGenerator implements DataGenerator<RowData> {
 
     @Override
     public RowData next() {
-        GenericRowData row = new GenericRowData(fieldNames.length);
+        GenericRowData row = new GenericRowData(fieldNames.size());
         for (int i = 0; i < fieldGenerators.length; i++) {
             row.setField(i, fieldGenerators[i].next());
         }


### PR DESCRIPTION
## What is the purpose of the change

`TableSchema` is deprecated and PR replaces it with `ResolvedSchema`

## Verifying this change

This change is a trivial rework / code cleanup without any test coverage.

## Does this pull request potentially affect one of the following parts:

  - Dependencies (does it add or upgrade a dependency): (no)
  - The public API, i.e., is any changed class annotated with `@Public(Evolving)`: (no)
  - The serializers: (no)
  - The runtime per-record code paths (performance sensitive): (no)
  - Anything that affects deployment or recovery: JobManager (and its components), Checkpointing, Kubernetes/Yarn, ZooKeeper: (no)
  - The S3 file system connector: (no)

## Documentation

  - Does this pull request introduce a new feature? (no)
  - If yes, how is the feature documented? (not applicable)
