### PR TITLE
[FLINK-25295][core] Update log4j2 dependency to 2.16.0

### DIFF
--- a/docs/content.zh/docs/dev/datastream/project-configuration.md
+++ b/docs/content.zh/docs/dev/datastream/project-configuration.md
@@ -331,7 +331,7 @@ ext {
     flinkVersion = '1.13-SNAPSHOT'
     scalaBinaryVersion = '2.11'
     slf4jVersion = '1.7.15'
-    log4jVersion = '2.15.0'
+    log4jVersion = '2.16.0'
 }
 
 

--- a/docs/content/docs/dev/datastream/project-configuration.md
+++ b/docs/content/docs/dev/datastream/project-configuration.md
@@ -330,7 +330,7 @@ ext {
     flinkVersion = '1.13-SNAPSHOT'
     scalaBinaryVersion = '2.11'
     slf4jVersion = '1.7.15'
-    log4jVersion = '2.15.0'
+    log4jVersion = '2.16.0'
 }
 
 

--- a/pom.xml
+++ b/pom.xml
@@ -108,7 +108,7 @@ under the License.
 		<guava.version>18.0</guava.version>
 		<target.java.version>1.8</target.java.version>
 		<slf4j.version>1.7.15</slf4j.version>
-		<log4j.version>2.15.0</log4j.version>
+		<log4j.version>2.16.0</log4j.version>
 		<!-- Overwrite default values from parent pom.
 			 Intellij is (sometimes?) using those values to choose target language level
 			 and thus is changing back to java 1.6 on each maven re-import -->

--- a/tools/releasing/NOTICE-binary_PREAMBLE.txt
+++ b/tools/releasing/NOTICE-binary_PREAMBLE.txt
@@ -8,10 +8,10 @@ Copyright 2014-2021 The Apache Software Foundation
 
 This project bundles the following dependencies under the Apache Software License 2.0 (http://www.apache.org/licenses/LICENSE-2.0.txt)
 
-- org.apache.logging.log4j:log4j-api:2.15.0
-- org.apache.logging.log4j:log4j-core:2.15.0
-- org.apache.logging.log4j:log4j-slf4j-impl:2.15.0
-- org.apache.logging.log4j:log4j-1.2-api:2.15.0
+- org.apache.logging.log4j:log4j-api:2.16.0
+- org.apache.logging.log4j:log4j-core:2.16.0
+- org.apache.logging.log4j:log4j-slf4j-impl:2.16.0
+- org.apache.logging.log4j:log4j-1.2-api:2.16.0
 
 This project bundles the following dependencies under the BSD license.
 See bundled license files for details.


### PR DESCRIPTION
## What is the purpose of the change

Update log4j dependency to version 2.16.0. This version removes message lookups and disables JNDI by default and results in a hardening of the default behaviour and configuration. 

## Brief change log

* Updated log4j2 dependency in main POM
* Updated version number in NOTICE-binary_PREAMBLE

## Verifying this change

This change is a trivial rework / code cleanup without any test coverage.

## Does this pull request potentially affect one of the following parts:

  - Dependencies (does it add or upgrade a dependency): yes
  - The public API, i.e., is any changed class annotated with `@Public(Evolving)`: no
  - The serializers: no
  - The runtime per-record code paths (performance sensitive): no
  - Anything that affects deployment or recovery: JobManager (and its components), Checkpointing, Kubernetes/Yarn, ZooKeeper: no
  - The S3 file system connector: no

## Documentation

  - Does this pull request introduce a new feature? no
  - If yes, how is the feature documented? not applicable
