### PR TITLE
[FLINK-25033][runtime] Let some scheduler components updatable

### DIFF
--- a/flink-runtime/src/main/java/org/apache/flink/runtime/executiongraph/failover/flip1/RestartPipelinedRegionFailoverStrategy.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/executiongraph/failover/flip1/RestartPipelinedRegionFailoverStrategy.java
@@ -242,11 +242,12 @@ public class RestartPipelinedRegionFailoverStrategy implements FailoverStrategy 
 
         for (SchedulingExecutionVertex vertex : regionToRestart.getVertices()) {
             for (SchedulingResultPartition producedPartition : vertex.getProducedResults()) {
-                final ConsumerVertexGroup consumerVertexGroup =
+                final Optional<ConsumerVertexGroup> consumerVertexGroup =
                         producedPartition.getConsumerVertexGroup();
-                if (!visitedConsumerVertexGroups.contains(consumerVertexGroup)) {
-                    visitedConsumerVertexGroups.add(consumerVertexGroup);
-                    consumerVertexGroupsToVisit.add(consumerVertexGroup);
+                if (consumerVertexGroup.isPresent()
+                        && !visitedConsumerVertexGroups.contains(consumerVertexGroup.get())) {
+                    visitedConsumerVertexGroups.add(consumerVertexGroup.get());
+                    consumerVertexGroupsToVisit.add(consumerVertexGroup.get());
                 }
             }
         }

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/executiongraph/failover/flip1/SchedulingPipelinedRegionComputeUtil.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/executiongraph/failover/flip1/SchedulingPipelinedRegionComputeUtil.java
@@ -32,6 +32,7 @@ import java.util.HashSet;
 import java.util.IdentityHashMap;
 import java.util.List;
 import java.util.Map;
+import java.util.Optional;
 import java.util.Set;
 import java.util.function.Function;
 
@@ -114,9 +115,13 @@ public final class SchedulingPipelinedRegionComputeUtil {
                     if (!producedResult.getResultType().isReconnectable()) {
                         continue;
                     }
-                    final ConsumerVertexGroup consumerVertexGroup =
+                    final Optional<ConsumerVertexGroup> consumerVertexGroup =
                             producedResult.getConsumerVertexGroup();
-                    for (ExecutionVertexID consumerVertexId : consumerVertexGroup) {
+                    if (!consumerVertexGroup.isPresent()) {
+                        continue;
+                    }
+
+                    for (ExecutionVertexID consumerVertexId : consumerVertexGroup.get()) {
                         SchedulingExecutionVertex consumerVertex =
                                 executionVertexRetriever.apply(consumerVertexId);
                         // Skip the ConsumerVertexGroup if its vertices are outside current

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/executiongraph/failover/flip1/partitionrelease/ConsumerRegionGroupExecutionViewMaintainer.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/executiongraph/failover/flip1/partitionrelease/ConsumerRegionGroupExecutionViewMaintainer.java
@@ -42,9 +42,8 @@ class ConsumerRegionGroupExecutionViewMaintainer {
     private final Map<SchedulingPipelinedRegion, Set<ConsumerRegionGroupExecutionView>>
             executionViewByRegion = new HashMap<>();
 
-    ConsumerRegionGroupExecutionViewMaintainer(
+    void notifyNewRegionGroupExecutionViews(
             Iterable<ConsumerRegionGroupExecutionView> executionViews) {
-
         for (ConsumerRegionGroupExecutionView executionView : executionViews) {
             for (SchedulingPipelinedRegion region : executionView) {
                 executionViewByRegion

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/scheduler/SchedulingTopologyListener.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/scheduler/SchedulingTopologyListener.java
@@ -1,0 +1,37 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.flink.runtime.scheduler;
+
+import org.apache.flink.runtime.scheduler.strategy.ExecutionVertexID;
+import org.apache.flink.runtime.scheduler.strategy.SchedulingTopology;
+
+import java.util.List;
+
+/** This listener will be notified whenever the scheduling topology is updated. */
+public interface SchedulingTopologyListener {
+
+    /**
+     * Notifies that the scheduling topology is just updated.
+     *
+     * @param schedulingTopology the scheduling topology which is just updated
+     * @param newExecutionVertices the newly added execution vertices.
+     */
+    void notifySchedulingTopologyUpdated(
+            SchedulingTopology schedulingTopology, List<ExecutionVertexID> newExecutionVertices);
+}

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/scheduler/adapter/DefaultExecutionTopology.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/scheduler/adapter/DefaultExecutionTopology.java
@@ -26,7 +26,9 @@ import org.apache.flink.runtime.executiongraph.ExecutionVertex;
 import org.apache.flink.runtime.executiongraph.IntermediateResultPartition;
 import org.apache.flink.runtime.executiongraph.failover.flip1.SchedulingPipelinedRegionComputeUtil;
 import org.apache.flink.runtime.jobgraph.DistributionPattern;
+import org.apache.flink.runtime.jobgraph.IntermediateDataSet;
 import org.apache.flink.runtime.jobgraph.IntermediateResultPartitionID;
+import org.apache.flink.runtime.jobgraph.JobEdge;
 import org.apache.flink.runtime.jobgraph.JobVertex;
 import org.apache.flink.runtime.jobgraph.JobVertexID;
 import org.apache.flink.runtime.jobgraph.topology.DefaultLogicalPipelinedRegion;
@@ -56,7 +58,9 @@ import java.util.Map;
 import java.util.Objects;
 import java.util.Set;
 import java.util.function.Function;
+import java.util.function.Supplier;
 import java.util.stream.Collectors;
+import java.util.stream.Stream;
 
 import static org.apache.flink.util.Preconditions.checkNotNull;
 import static org.apache.flink.util.Preconditions.checkState;
@@ -78,19 +82,25 @@ public class DefaultExecutionTopology implements SchedulingTopology {
 
     private final EdgeManager edgeManager;
 
+    private final Supplier<List<ExecutionVertexID>> sortedExecutionVertexIds;
+
+    private final Map<JobVertexID, DefaultLogicalPipelinedRegion>
+            logicalPipelinedRegionsByJobVertexId;
+
     private DefaultExecutionTopology(
-            Map<ExecutionVertexID, DefaultExecutionVertex> executionVerticesById,
-            List<DefaultExecutionVertex> executionVerticesList,
-            Map<IntermediateResultPartitionID, DefaultResultPartition> resultPartitionsById,
-            Map<ExecutionVertexID, DefaultSchedulingPipelinedRegion> pipelinedRegionsByVertex,
-            List<DefaultSchedulingPipelinedRegion> pipelinedRegions,
-            EdgeManager edgeManager) {
-        this.executionVerticesById = checkNotNull(executionVerticesById);
-        this.executionVerticesList = checkNotNull(executionVerticesList);
-        this.resultPartitionsById = checkNotNull(resultPartitionsById);
-        this.pipelinedRegionsByVertex = checkNotNull(pipelinedRegionsByVertex);
-        this.pipelinedRegions = checkNotNull(pipelinedRegions);
-        this.edgeManager = edgeManager;
+            Supplier<List<ExecutionVertexID>> sortedExecutionVertexIds,
+            EdgeManager edgeManager,
+            Map<JobVertexID, DefaultLogicalPipelinedRegion> logicalPipelinedRegionsByJobVertexId) {
+        this.sortedExecutionVertexIds = checkNotNull(sortedExecutionVertexIds);
+        this.edgeManager = checkNotNull(edgeManager);
+        this.logicalPipelinedRegionsByJobVertexId =
+                checkNotNull(logicalPipelinedRegionsByJobVertexId);
+
+        this.executionVerticesById = new HashMap<>();
+        this.executionVerticesList = new ArrayList<>();
+        this.resultPartitionsById = new HashMap<>();
+        this.pipelinedRegionsByVertex = new HashMap<>();
+        this.pipelinedRegions = new ArrayList<>();
     }
 
     @Override
@@ -143,12 +153,8 @@ public class DefaultExecutionTopology implements SchedulingTopology {
         return edgeManager;
     }
 
-    public static DefaultExecutionTopology fromExecutionGraph(
-            DefaultExecutionGraph executionGraph) {
-        checkNotNull(executionGraph, "execution graph can not be null");
-
-        EdgeManager edgeManager = executionGraph.getEdgeManager();
-
+    private static Map<JobVertexID, DefaultLogicalPipelinedRegion>
+            computeLogicalPipelinedRegionsByJobVertexId(final ExecutionGraph executionGraph) {
         List<JobVertex> topologicallySortedJobVertices =
                 IterableUtils.toStream(executionGraph.getVerticesTopologically())
                         .map(ExecutionJobVertex::getJobVertex)
@@ -159,51 +165,78 @@ public class DefaultExecutionTopology implements SchedulingTopology {
                                 topologicallySortedJobVertices)
                         .getAllPipelinedRegions();
 
-        ExecutionGraphIndex executionGraphIndex =
-                computeExecutionGraphIndex(
-                        executionGraph.getAllExecutionVertices(),
-                        logicalPipelinedRegions,
-                        edgeManager);
-
-        IndexedPipelinedRegions indexedPipelinedRegions =
-                computePipelinedRegions(
-                        executionGraphIndex.sortedExecutionVerticesInPipelinedRegion.keySet(),
-                        executionGraphIndex.sortedExecutionVerticesInPipelinedRegion::get,
-                        executionGraphIndex.executionVerticesById::get,
-                        executionGraphIndex.resultPartitionsById::get);
-
-        ensureCoLocatedVerticesInSameRegion(
-                indexedPipelinedRegions.pipelinedRegions, executionGraph);
-
-        return new DefaultExecutionTopology(
-                executionGraphIndex.executionVerticesById,
-                executionGraphIndex.executionVerticesList,
-                executionGraphIndex.resultPartitionsById,
-                indexedPipelinedRegions.pipelinedRegionsByVertex,
-                indexedPipelinedRegions.pipelinedRegions,
-                edgeManager);
-    }
-
-    private static ExecutionGraphIndex computeExecutionGraphIndex(
-            Iterable<ExecutionVertex> executionVertices,
-            Iterable<DefaultLogicalPipelinedRegion> logicalPipelinedRegions,
-            EdgeManager edgeManager) {
-        Map<ExecutionVertexID, DefaultExecutionVertex> executionVerticesById = new HashMap<>();
-        List<DefaultExecutionVertex> executionVerticesList = new ArrayList<>();
-        Map<IntermediateResultPartitionID, DefaultResultPartition> resultPartitionsById =
-                new HashMap<>();
-        Map<DefaultLogicalPipelinedRegion, List<DefaultExecutionVertex>>
-                sortedExecutionVerticesInPipelinedRegion = new IdentityHashMap<>();
-
-        Map<JobVertexID, DefaultLogicalPipelinedRegion> logicalPipelinedRegionByJobVertexId =
+        Map<JobVertexID, DefaultLogicalPipelinedRegion> logicalPipelinedRegionsByJobVertexId =
                 new HashMap<>();
         for (DefaultLogicalPipelinedRegion logicalPipelinedRegion : logicalPipelinedRegions) {
             for (LogicalVertex vertex : logicalPipelinedRegion.getVertices()) {
-                logicalPipelinedRegionByJobVertexId.put(vertex.getId(), logicalPipelinedRegion);
+                logicalPipelinedRegionsByJobVertexId.put(vertex.getId(), logicalPipelinedRegion);
             }
         }
 
-        for (ExecutionVertex vertex : executionVertices) {
+        return logicalPipelinedRegionsByJobVertexId;
+    }
+
+    public void notifyExecutionGraphUpdated(
+            final DefaultExecutionGraph executionGraph,
+            final List<ExecutionJobVertex> newlyInitializedJobVertices) {
+
+        checkNotNull(executionGraph, "execution graph can not be null");
+
+        final Set<JobVertexID> newJobVertexIds =
+                newlyInitializedJobVertices.stream()
+                        .map(ExecutionJobVertex::getJobVertexId)
+                        .collect(Collectors.toSet());
+
+        // any PIPELINED input should be from within this new set so that existing pipelined regions
+        // will not change
+        newlyInitializedJobVertices.stream()
+                .map(ExecutionJobVertex::getJobVertex)
+                .flatMap(v -> v.getInputs().stream())
+                .map(JobEdge::getSource)
+                .filter(r -> r.getResultType().isPipelined())
+                .map(IntermediateDataSet::getProducer)
+                .map(JobVertex::getID)
+                .forEach(id -> checkState(newJobVertexIds.contains(id)));
+
+        final Iterable<ExecutionVertex> newExecutionVertices =
+                newlyInitializedJobVertices.stream()
+                        .flatMap(jobVertex -> Stream.of(jobVertex.getTaskVertices()))
+                        .collect(Collectors.toList());
+
+        generateNewExecutionVerticesAndResultPartitions(newExecutionVertices);
+
+        generateNewPipelinedRegions(newExecutionVertices);
+
+        ensureCoLocatedVerticesInSameRegion(pipelinedRegions, executionGraph);
+    }
+
+    public static DefaultExecutionTopology fromExecutionGraph(
+            DefaultExecutionGraph executionGraph) {
+        checkNotNull(executionGraph, "execution graph can not be null");
+
+        EdgeManager edgeManager = executionGraph.getEdgeManager();
+
+        DefaultExecutionTopology schedulingTopology =
+                new DefaultExecutionTopology(
+                        () ->
+                                IterableUtils.toStream(executionGraph.getAllExecutionVertices())
+                                        .map(ExecutionVertex::getID)
+                                        .collect(Collectors.toList()),
+                        edgeManager,
+                        computeLogicalPipelinedRegionsByJobVertexId(executionGraph));
+
+        schedulingTopology.notifyExecutionGraphUpdated(
+                executionGraph,
+                IterableUtils.toStream(executionGraph.getVerticesTopologically())
+                        .filter(ExecutionJobVertex::isInitialized)
+                        .collect(Collectors.toList()));
+
+        return schedulingTopology;
+    }
+
+    private void generateNewExecutionVerticesAndResultPartitions(
+            Iterable<ExecutionVertex> newExecutionVertices) {
+        for (ExecutionVertex vertex : newExecutionVertices) {
             List<DefaultResultPartition> producedPartitions =
                     generateProducedSchedulingResultPartition(
                             vertex.getProducedPartitions(),
@@ -219,19 +252,12 @@ public class DefaultExecutionTopology implements SchedulingTopology {
                             edgeManager.getConsumedPartitionGroupsForVertex(vertex.getID()),
                             resultPartitionsById::get);
             executionVerticesById.put(schedulingVertex.getId(), schedulingVertex);
-            sortedExecutionVerticesInPipelinedRegion
-                    .computeIfAbsent(
-                            logicalPipelinedRegionByJobVertexId.get(
-                                    schedulingVertex.getId().getJobVertexId()),
-                            ignore -> new ArrayList<>())
-                    .add(schedulingVertex);
-            executionVerticesList.add(schedulingVertex);
         }
-        return new ExecutionGraphIndex(
-                executionVerticesById,
-                executionVerticesList,
-                sortedExecutionVerticesInPipelinedRegion,
-                resultPartitionsById);
+
+        executionVerticesList.clear();
+        for (ExecutionVertexID vertexID : sortedExecutionVertexIds.get()) {
+            executionVerticesList.add(executionVerticesById.get(vertexID));
+        }
     }
 
     private static List<DefaultResultPartition> generateProducedSchedulingResultPartition(
@@ -256,8 +282,9 @@ public class DefaultExecutionTopology implements SchedulingTopology {
                                                         irp.isConsumable()
                                                                 ? ResultPartitionState.CONSUMABLE
                                                                 : ResultPartitionState.CREATED,
-                                                partitionConsumerVertexGroupRetriever.apply(
-                                                        irp.getPartitionId()),
+                                                () ->
+                                                        partitionConsumerVertexGroupRetriever.apply(
+                                                                irp.getPartitionId()),
                                                 irp::getConsumedPartitionGroups)));
 
         return producedSchedulingPartitions;
@@ -283,13 +310,25 @@ public class DefaultExecutionTopology implements SchedulingTopology {
         return schedulingVertex;
     }
 
-    private static IndexedPipelinedRegions computePipelinedRegions(
-            Iterable<DefaultLogicalPipelinedRegion> logicalPipelinedRegions,
-            Function<DefaultLogicalPipelinedRegion, List<DefaultExecutionVertex>>
-                    sortedExecutionVerticesInPipelinedRegion,
-            Function<ExecutionVertexID, DefaultExecutionVertex> executionVertexRetriever,
-            Function<IntermediateResultPartitionID, DefaultResultPartition>
-                    resultPartitionRetriever) {
+    private void generateNewPipelinedRegions(Iterable<ExecutionVertex> newExecutionVertices) {
+
+        final Iterable<DefaultExecutionVertex> newSchedulingExecutionVertices =
+                IterableUtils.toStream(newExecutionVertices)
+                        .map(ExecutionVertex::getID)
+                        .map(executionVerticesById::get)
+                        .collect(Collectors.toList());
+
+        Map<DefaultLogicalPipelinedRegion, List<DefaultExecutionVertex>>
+                sortedExecutionVerticesInPipelinedRegion = new IdentityHashMap<>();
+
+        for (DefaultExecutionVertex schedulingVertex : newSchedulingExecutionVertices) {
+            sortedExecutionVerticesInPipelinedRegion
+                    .computeIfAbsent(
+                            logicalPipelinedRegionsByJobVertexId.get(
+                                    schedulingVertex.getId().getJobVertexId()),
+                            ignore -> new ArrayList<>())
+                    .add(schedulingVertex);
+        }
 
         long buildRegionsStartTime = System.nanoTime();
 
@@ -300,10 +339,11 @@ public class DefaultExecutionTopology implements SchedulingTopology {
         // Thus, we can traverse all LogicalPipelinedRegions and convert them into
         // SchedulingPipelinedRegions one by one. The LogicalPipelinedRegions and
         // SchedulingPipelinedRegions are both connected with inter-region blocking edges.
-        for (DefaultLogicalPipelinedRegion logicalPipelinedRegion : logicalPipelinedRegions) {
+        for (Map.Entry<DefaultLogicalPipelinedRegion, List<DefaultExecutionVertex>> entry :
+                sortedExecutionVerticesInPipelinedRegion.entrySet()) {
 
-            List<DefaultExecutionVertex> schedulingExecutionVertices =
-                    sortedExecutionVerticesInPipelinedRegion.apply(logicalPipelinedRegion);
+            DefaultLogicalPipelinedRegion logicalPipelinedRegion = entry.getKey();
+            List<DefaultExecutionVertex> schedulingExecutionVertices = entry.getValue();
 
             if (containsIntraRegionAllToAllEdge(logicalPipelinedRegion)) {
                 // For edges inside one LogicalPipelinedRegion, if there is any all-to-all edge, it
@@ -331,21 +371,17 @@ public class DefaultExecutionTopology implements SchedulingTopology {
                 rawPipelinedRegions.addAll(
                         SchedulingPipelinedRegionComputeUtil.computePipelinedRegions(
                                 schedulingExecutionVertices,
-                                executionVertexRetriever,
-                                resultPartitionRetriever));
+                                executionVerticesById::get,
+                                resultPartitionsById::get));
             }
         }
-
-        Map<ExecutionVertexID, DefaultSchedulingPipelinedRegion> pipelinedRegionsByVertex =
-                new HashMap<>();
-        List<DefaultSchedulingPipelinedRegion> pipelinedRegions = new ArrayList<>();
 
         for (Set<? extends SchedulingExecutionVertex> rawPipelinedRegion : rawPipelinedRegions) {
             //noinspection unchecked
             final DefaultSchedulingPipelinedRegion pipelinedRegion =
                     new DefaultSchedulingPipelinedRegion(
                             (Set<DefaultExecutionVertex>) rawPipelinedRegion,
-                            resultPartitionRetriever);
+                            resultPartitionsById::get);
             pipelinedRegions.add(pipelinedRegion);
 
             for (SchedulingExecutionVertex executionVertex : rawPipelinedRegion) {
@@ -355,11 +391,10 @@ public class DefaultExecutionTopology implements SchedulingTopology {
 
         long buildRegionsDuration = (System.nanoTime() - buildRegionsStartTime) / 1_000_000;
         LOG.info(
-                "Built {} pipelined regions in {} ms",
-                pipelinedRegions.size(),
-                buildRegionsDuration);
-
-        return new IndexedPipelinedRegions(pipelinedRegionsByVertex, pipelinedRegions);
+                "Built {} new pipelined regions in {} ms, total {} pipelined regions currently.",
+                rawPipelinedRegions.size(),
+                buildRegionsDuration,
+                pipelinedRegions.size());
     }
 
     /**
@@ -415,40 +450,5 @@ public class DefaultExecutionTopology implements SchedulingTopology {
         return coLocationGroup == null
                 ? null
                 : coLocationGroup.getLocationConstraint(executionVertexId.getSubtaskIndex());
-    }
-
-    private static class ExecutionGraphIndex {
-        private final Map<ExecutionVertexID, DefaultExecutionVertex> executionVerticesById;
-        private final List<DefaultExecutionVertex> executionVerticesList;
-        private final Map<DefaultLogicalPipelinedRegion, List<DefaultExecutionVertex>>
-                sortedExecutionVerticesInPipelinedRegion;
-        private final Map<IntermediateResultPartitionID, DefaultResultPartition>
-                resultPartitionsById;
-
-        private ExecutionGraphIndex(
-                Map<ExecutionVertexID, DefaultExecutionVertex> executionVerticesById,
-                List<DefaultExecutionVertex> executionVerticesList,
-                Map<DefaultLogicalPipelinedRegion, List<DefaultExecutionVertex>>
-                        sortedExecutionVerticesInPipelinedRegion,
-                Map<IntermediateResultPartitionID, DefaultResultPartition> resultPartitionsById) {
-            this.executionVerticesById = checkNotNull(executionVerticesById);
-            this.executionVerticesList = checkNotNull(executionVerticesList);
-            this.sortedExecutionVerticesInPipelinedRegion =
-                    checkNotNull(sortedExecutionVerticesInPipelinedRegion);
-            this.resultPartitionsById = checkNotNull(resultPartitionsById);
-        }
-    }
-
-    private static class IndexedPipelinedRegions {
-        private final Map<ExecutionVertexID, DefaultSchedulingPipelinedRegion>
-                pipelinedRegionsByVertex;
-        private final List<DefaultSchedulingPipelinedRegion> pipelinedRegions;
-
-        private IndexedPipelinedRegions(
-                Map<ExecutionVertexID, DefaultSchedulingPipelinedRegion> pipelinedRegionsByVertex,
-                List<DefaultSchedulingPipelinedRegion> pipelinedRegions) {
-            this.pipelinedRegionsByVertex = checkNotNull(pipelinedRegionsByVertex);
-            this.pipelinedRegions = checkNotNull(pipelinedRegions);
-        }
     }
 }

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/scheduler/adapter/DefaultExecutionVertex.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/scheduler/adapter/DefaultExecutionVertex.java
@@ -18,7 +18,6 @@
 
 package org.apache.flink.runtime.scheduler.adapter;
 
-import org.apache.flink.annotation.VisibleForTesting;
 import org.apache.flink.runtime.execution.ExecutionState;
 import org.apache.flink.runtime.jobgraph.IntermediateResultPartitionID;
 import org.apache.flink.runtime.scheduler.strategy.ConsumedPartitionGroup;
@@ -56,16 +55,8 @@ class DefaultExecutionVertex implements SchedulingExecutionVertex {
         this.executionVertexId = checkNotNull(executionVertexId);
         this.stateSupplier = checkNotNull(stateSupplier);
         this.producedResults = checkNotNull(producedPartitions);
-        this.consumedPartitionGroups = consumedPartitionGroups;
-        this.resultPartitionRetriever = resultPartitionRetriever;
-    }
-
-    @VisibleForTesting
-    DefaultExecutionVertex(
-            ExecutionVertexID executionVertexId,
-            List<DefaultResultPartition> producedPartitions,
-            Supplier<ExecutionState> stateSupplier) {
-        this(executionVertexId, producedPartitions, stateSupplier, null, null);
+        this.consumedPartitionGroups = checkNotNull(consumedPartitionGroups);
+        this.resultPartitionRetriever = checkNotNull(resultPartitionRetriever);
     }
 
     @Override

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/scheduler/adapter/DefaultResultPartition.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/scheduler/adapter/DefaultResultPartition.java
@@ -27,6 +27,7 @@ import org.apache.flink.runtime.scheduler.strategy.ResultPartitionState;
 import org.apache.flink.runtime.scheduler.strategy.SchedulingResultPartition;
 
 import java.util.List;
+import java.util.Optional;
 import java.util.function.Supplier;
 
 import static org.apache.flink.util.Preconditions.checkNotNull;
@@ -44,7 +45,7 @@ class DefaultResultPartition implements SchedulingResultPartition {
 
     private DefaultExecutionVertex producer;
 
-    private final ConsumerVertexGroup consumerVertexGroup;
+    private final Supplier<ConsumerVertexGroup> consumerVertexGroupSupplier;
 
     private final Supplier<List<ConsumedPartitionGroup>> consumerPartitionGroupSupplier;
 
@@ -53,13 +54,13 @@ class DefaultResultPartition implements SchedulingResultPartition {
             IntermediateDataSetID intermediateDataSetId,
             ResultPartitionType partitionType,
             Supplier<ResultPartitionState> resultPartitionStateSupplier,
-            ConsumerVertexGroup consumerVertexGroup,
+            Supplier<ConsumerVertexGroup> consumerVertexGroupSupplier,
             Supplier<List<ConsumedPartitionGroup>> consumerPartitionGroupSupplier) {
         this.resultPartitionId = checkNotNull(partitionId);
         this.intermediateDataSetId = checkNotNull(intermediateDataSetId);
         this.partitionType = checkNotNull(partitionType);
         this.resultPartitionStateSupplier = checkNotNull(resultPartitionStateSupplier);
-        this.consumerVertexGroup = consumerVertexGroup;
+        this.consumerVertexGroupSupplier = checkNotNull(consumerVertexGroupSupplier);
         this.consumerPartitionGroupSupplier = checkNotNull(consumerPartitionGroupSupplier);
     }
 
@@ -89,8 +90,8 @@ class DefaultResultPartition implements SchedulingResultPartition {
     }
 
     @Override
-    public ConsumerVertexGroup getConsumerVertexGroup() {
-        return consumerVertexGroup;
+    public Optional<ConsumerVertexGroup> getConsumerVertexGroup() {
+        return Optional.ofNullable(consumerVertexGroupSupplier.get());
     }
 
     @Override

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/scheduler/adapter/DefaultResultPartition.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/scheduler/adapter/DefaultResultPartition.java
@@ -18,7 +18,6 @@
 
 package org.apache.flink.runtime.scheduler.adapter;
 
-import org.apache.flink.annotation.VisibleForTesting;
 import org.apache.flink.runtime.io.network.partition.ResultPartitionType;
 import org.apache.flink.runtime.jobgraph.IntermediateDataSetID;
 import org.apache.flink.runtime.jobgraph.IntermediateResultPartitionID;
@@ -61,22 +60,7 @@ class DefaultResultPartition implements SchedulingResultPartition {
         this.partitionType = checkNotNull(partitionType);
         this.resultPartitionStateSupplier = checkNotNull(resultPartitionStateSupplier);
         this.consumerVertexGroup = consumerVertexGroup;
-        this.consumerPartitionGroupSupplier = consumerPartitionGroupSupplier;
-    }
-
-    @VisibleForTesting
-    DefaultResultPartition(
-            IntermediateResultPartitionID partitionId,
-            IntermediateDataSetID intermediateDataSetId,
-            ResultPartitionType partitionType,
-            Supplier<ResultPartitionState> resultPartitionStateSupplier) {
-        this(
-                partitionId,
-                intermediateDataSetId,
-                partitionType,
-                resultPartitionStateSupplier,
-                null,
-                null);
+        this.consumerPartitionGroupSupplier = checkNotNull(consumerPartitionGroupSupplier);
     }
 
     @Override

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/scheduler/strategy/SchedulingResultPartition.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/scheduler/strategy/SchedulingResultPartition.java
@@ -24,6 +24,7 @@ import org.apache.flink.runtime.jobgraph.IntermediateResultPartitionID;
 import org.apache.flink.runtime.topology.Result;
 
 import java.util.List;
+import java.util.Optional;
 
 /** Representation of {@link IntermediateResultPartition}. */
 public interface SchedulingResultPartition
@@ -50,9 +51,9 @@ public interface SchedulingResultPartition
     /**
      * Gets the {@link ConsumerVertexGroup}.
      *
-     * @return {@link ConsumerVertexGroup}
+     * @return {@link ConsumerVertexGroup} if consumers exists, otherwise {@link Optional#empty()}.
      */
-    ConsumerVertexGroup getConsumerVertexGroup();
+    Optional<ConsumerVertexGroup> getConsumerVertexGroup();
 
     /**
      * Gets the {@link ConsumedPartitionGroup}s this partition belongs to.

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/scheduler/strategy/SchedulingTopology.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/scheduler/strategy/SchedulingTopology.java
@@ -19,7 +19,10 @@
 package org.apache.flink.runtime.scheduler.strategy;
 
 import org.apache.flink.runtime.jobgraph.IntermediateResultPartitionID;
+import org.apache.flink.runtime.scheduler.SchedulingTopologyListener;
 import org.apache.flink.runtime.topology.Topology;
+
+import java.util.List;
 
 /** Topology of {@link SchedulingExecutionVertex}. */
 public interface SchedulingTopology
@@ -49,4 +52,13 @@ public interface SchedulingTopology
      */
     SchedulingResultPartition getResultPartition(
             IntermediateResultPartitionID intermediateResultPartitionId);
+
+    /**
+     * Register a scheduling topology listener. The listener will be notified by {@link
+     * SchedulingTopologyListener#notifySchedulingTopologyUpdated(SchedulingTopology, List)} when
+     * the scheduling topology is updated.
+     *
+     * @param listener the registered listener.
+     */
+    void registerSchedulingTopologyListener(SchedulingTopologyListener listener);
 }

--- a/flink-runtime/src/test/java/org/apache/flink/runtime/executiongraph/failover/flip1/partitionrelease/ConsumerRegionGroupExecutionViewMaintainerTest.java
+++ b/flink-runtime/src/test/java/org/apache/flink/runtime/executiongraph/failover/flip1/partitionrelease/ConsumerRegionGroupExecutionViewMaintainerTest.java
@@ -108,7 +108,8 @@ public class ConsumerRegionGroupExecutionViewMaintainerTest extends TestLogger {
         consumerRegionGroupExecutionView.add(consumerRegion);
 
         consumerRegionGroupExecutionViewMaintainer =
-                new ConsumerRegionGroupExecutionViewMaintainer(
-                        Collections.singletonList(consumerRegionGroupExecutionView));
+                new ConsumerRegionGroupExecutionViewMaintainer();
+        consumerRegionGroupExecutionViewMaintainer.notifyNewRegionGroupExecutionViews(
+                Collections.singletonList(consumerRegionGroupExecutionView));
     }
 }

--- a/flink-runtime/src/test/java/org/apache/flink/runtime/scheduler/adapter/DefaultExecutionTopologyTest.java
+++ b/flink-runtime/src/test/java/org/apache/flink/runtime/scheduler/adapter/DefaultExecutionTopologyTest.java
@@ -18,11 +18,16 @@
 
 package org.apache.flink.runtime.scheduler.adapter;
 
+import org.apache.flink.api.common.JobID;
 import org.apache.flink.runtime.executiongraph.DefaultExecutionGraph;
 import org.apache.flink.runtime.executiongraph.ExecutionGraph;
+import org.apache.flink.runtime.executiongraph.ExecutionJobVertex;
 import org.apache.flink.runtime.executiongraph.ExecutionVertex;
 import org.apache.flink.runtime.executiongraph.IntermediateResultPartition;
+import org.apache.flink.runtime.executiongraph.TestingDefaultExecutionGraphBuilder;
+import org.apache.flink.runtime.io.network.partition.ResultPartitionType;
 import org.apache.flink.runtime.jobgraph.IntermediateResultPartitionID;
+import org.apache.flink.runtime.jobgraph.JobGraph;
 import org.apache.flink.runtime.jobgraph.JobVertex;
 import org.apache.flink.runtime.jobgraph.JobVertexID;
 import org.apache.flink.runtime.jobmanager.scheduler.SlotSharingGroup;
@@ -30,6 +35,7 @@ import org.apache.flink.runtime.scheduler.strategy.ConsumedPartitionGroup;
 import org.apache.flink.runtime.scheduler.strategy.ConsumerVertexGroup;
 import org.apache.flink.runtime.scheduler.strategy.ExecutionVertexID;
 import org.apache.flink.runtime.scheduler.strategy.ResultPartitionState;
+import org.apache.flink.runtime.scheduler.strategy.SchedulingPipelinedRegion;
 import org.apache.flink.util.IterableUtils;
 import org.apache.flink.util.TestLogger;
 
@@ -41,16 +47,22 @@ import org.junit.Test;
 
 import java.util.ArrayList;
 import java.util.Collection;
+import java.util.Collections;
 import java.util.Iterator;
 import java.util.List;
 import java.util.Map;
+import java.util.Optional;
 import java.util.Set;
 
+import static junit.framework.TestCase.assertSame;
 import static junit.framework.TestCase.assertTrue;
 import static org.apache.flink.runtime.executiongraph.ExecutionGraphTestUtils.createNoOpVertex;
 import static org.apache.flink.runtime.executiongraph.ExecutionGraphTestUtils.createSimpleTestGraph;
+import static org.apache.flink.runtime.io.network.partition.ResultPartitionType.BLOCKING;
 import static org.apache.flink.runtime.io.network.partition.ResultPartitionType.PIPELINED;
 import static org.apache.flink.runtime.jobgraph.DistributionPattern.ALL_TO_ALL;
+import static org.hamcrest.MatcherAssert.assertThat;
+import static org.hamcrest.core.Is.is;
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertFalse;
 import static org.junit.Assert.fail;
@@ -161,6 +173,81 @@ public class DefaultExecutionTopologyTest extends TestLogger {
         DefaultExecutionTopology.fromExecutionGraph(executionGraph);
     }
 
+    @Test
+    public void testUpdateTopology() throws Exception {
+        final JobVertex[] jobVertices = createJobVertices(BLOCKING);
+        executionGraph = createDynamicGraph(jobVertices);
+        adapter = DefaultExecutionTopology.fromExecutionGraph(executionGraph);
+
+        final ExecutionJobVertex ejv1 = executionGraph.getJobVertex(jobVertices[0].getID());
+        final ExecutionJobVertex ejv2 = executionGraph.getJobVertex(jobVertices[1].getID());
+
+        executionGraph.initializeJobVertex(ejv1, 0L);
+        adapter.notifyExecutionGraphUpdated(executionGraph, Collections.singletonList(ejv1));
+        assertThat(IterableUtils.toStream(adapter.getVertices()).count(), is(3L));
+
+        executionGraph.initializeJobVertex(ejv2, 0L);
+        adapter.notifyExecutionGraphUpdated(executionGraph, Collections.singletonList(ejv2));
+        assertThat(IterableUtils.toStream(adapter.getVertices()).count(), is(6L));
+
+        assertGraphEquals(executionGraph, adapter);
+    }
+
+    @Test(expected = IllegalStateException.class)
+    public void testErrorIfUpdateTopologyWithNewVertexPipelinedConnectedToOldOnes()
+            throws Exception {
+        final JobVertex[] jobVertices = createJobVertices(PIPELINED);
+        executionGraph = createDynamicGraph(jobVertices);
+        adapter = DefaultExecutionTopology.fromExecutionGraph(executionGraph);
+
+        final ExecutionJobVertex ejv1 = executionGraph.getJobVertex(jobVertices[0].getID());
+        final ExecutionJobVertex ejv2 = executionGraph.getJobVertex(jobVertices[1].getID());
+
+        executionGraph.initializeJobVertex(ejv1, 0L);
+        adapter.notifyExecutionGraphUpdated(executionGraph, Collections.singletonList(ejv1));
+
+        executionGraph.initializeJobVertex(ejv2, 0L);
+        adapter.notifyExecutionGraphUpdated(executionGraph, Collections.singletonList(ejv2));
+    }
+
+    @Test
+    public void testExistingRegionsAreNotAffectedDuringTopologyUpdate() throws Exception {
+        final JobVertex[] jobVertices = createJobVertices(BLOCKING);
+        executionGraph = createDynamicGraph(jobVertices);
+        adapter = DefaultExecutionTopology.fromExecutionGraph(executionGraph);
+
+        final ExecutionJobVertex ejv1 = executionGraph.getJobVertex(jobVertices[0].getID());
+        final ExecutionJobVertex ejv2 = executionGraph.getJobVertex(jobVertices[1].getID());
+
+        executionGraph.initializeJobVertex(ejv1, 0L);
+        adapter.notifyExecutionGraphUpdated(executionGraph, Collections.singletonList(ejv1));
+        SchedulingPipelinedRegion regionOld =
+                adapter.getPipelinedRegionOfVertex(new ExecutionVertexID(ejv1.getJobVertexId(), 0));
+
+        executionGraph.initializeJobVertex(ejv2, 0L);
+        adapter.notifyExecutionGraphUpdated(executionGraph, Collections.singletonList(ejv2));
+        SchedulingPipelinedRegion regionNew =
+                adapter.getPipelinedRegionOfVertex(new ExecutionVertexID(ejv1.getJobVertexId(), 0));
+
+        assertSame(regionOld, regionNew);
+    }
+
+    private JobVertex[] createJobVertices(ResultPartitionType resultPartitionType) {
+        final JobVertex[] jobVertices = new JobVertex[2];
+        final int parallelism = 3;
+        jobVertices[0] = createNoOpVertex(parallelism);
+        jobVertices[1] = createNoOpVertex(parallelism);
+        jobVertices[1].connectNewDataSetAsInput(jobVertices[0], ALL_TO_ALL, resultPartitionType);
+
+        return jobVertices;
+    }
+
+    private DefaultExecutionGraph createDynamicGraph(JobVertex... jobVertices) throws Exception {
+        return TestingDefaultExecutionGraphBuilder.newBuilder()
+                .setJobGraph(new JobGraph(new JobID(), "TestJob", jobVertices))
+                .buildDynamicGraph();
+    }
+
     private void assertRegionContainsAllVertices(
             final DefaultSchedulingPipelinedRegion pipelinedRegionOfVertex) {
         final Set<DefaultExecutionVertex> allVertices =
@@ -234,8 +321,9 @@ public class DefaultExecutionTopologyTest extends TestLogger {
             assertPartitionEquals(originalPartition, adaptedPartition);
 
             ConsumerVertexGroup consumerVertexGroup = originalPartition.getConsumerVertexGroup();
-            Iterable<ExecutionVertexID> adaptedConsumers =
+            Optional<ConsumerVertexGroup> adaptedConsumers =
                     adaptedPartition.getConsumerVertexGroup();
+            assertTrue(adaptedConsumers.isPresent());
             for (ExecutionVertexID originalId : consumerVertexGroup) {
                 // it is sufficient to verify that some vertex exists with the correct ID here,
                 // since deep equality is verified later in the main loop
@@ -243,7 +331,7 @@ public class DefaultExecutionTopologyTest extends TestLogger {
                 // the topology are
                 // identical to those stored in the partition
                 assertTrue(
-                        IterableUtils.toStream(adaptedConsumers)
+                        IterableUtils.toStream(adaptedConsumers.get())
                                 .anyMatch(adaptedConsumer -> adaptedConsumer.equals(originalId)));
             }
         }

--- a/flink-runtime/src/test/java/org/apache/flink/runtime/scheduler/adapter/DefaultExecutionVertexTest.java
+++ b/flink-runtime/src/test/java/org/apache/flink/runtime/scheduler/adapter/DefaultExecutionVertexTest.java
@@ -62,7 +62,9 @@ public class DefaultExecutionVertexTest extends TestLogger {
                         new IntermediateDataSetID(),
                         BLOCKING,
                         () -> ResultPartitionState.CREATED,
-                        null,
+                        () -> {
+                            throw new UnsupportedOperationException();
+                        },
                         () -> {
                             throw new UnsupportedOperationException();
                         });

--- a/flink-runtime/src/test/java/org/apache/flink/runtime/scheduler/adapter/DefaultExecutionVertexTest.java
+++ b/flink-runtime/src/test/java/org/apache/flink/runtime/scheduler/adapter/DefaultExecutionVertexTest.java
@@ -61,12 +61,20 @@ public class DefaultExecutionVertexTest extends TestLogger {
                         intermediateResultPartitionId,
                         new IntermediateDataSetID(),
                         BLOCKING,
-                        () -> ResultPartitionState.CREATED);
+                        () -> ResultPartitionState.CREATED,
+                        null,
+                        () -> {
+                            throw new UnsupportedOperationException();
+                        });
         producerVertex =
                 new DefaultExecutionVertex(
                         new ExecutionVertexID(new JobVertexID(), 0),
                         Collections.singletonList(schedulingResultPartition),
-                        stateSupplier);
+                        stateSupplier,
+                        Collections.emptyList(),
+                        partitionID -> {
+                            throw new UnsupportedOperationException();
+                        });
         schedulingResultPartition.setProducer(producerVertex);
 
         List<ConsumedPartitionGroup> consumedPartitionGroups =

--- a/flink-runtime/src/test/java/org/apache/flink/runtime/scheduler/adapter/DefaultResultPartitionTest.java
+++ b/flink-runtime/src/test/java/org/apache/flink/runtime/scheduler/adapter/DefaultResultPartitionTest.java
@@ -47,7 +47,14 @@ public class DefaultResultPartitionTest extends TestLogger {
     public void setUp() {
         resultPartition =
                 new DefaultResultPartition(
-                        resultPartitionId, intermediateResultId, BLOCKING, resultPartitionState);
+                        resultPartitionId,
+                        intermediateResultId,
+                        BLOCKING,
+                        resultPartitionState,
+                        null,
+                        () -> {
+                            throw new UnsupportedOperationException();
+                        });
     }
 
     @Test

--- a/flink-runtime/src/test/java/org/apache/flink/runtime/scheduler/adapter/DefaultResultPartitionTest.java
+++ b/flink-runtime/src/test/java/org/apache/flink/runtime/scheduler/adapter/DefaultResultPartitionTest.java
@@ -20,16 +20,25 @@ package org.apache.flink.runtime.scheduler.adapter;
 
 import org.apache.flink.runtime.jobgraph.IntermediateDataSetID;
 import org.apache.flink.runtime.jobgraph.IntermediateResultPartitionID;
+import org.apache.flink.runtime.jobgraph.JobVertexID;
+import org.apache.flink.runtime.scheduler.strategy.ConsumerVertexGroup;
+import org.apache.flink.runtime.scheduler.strategy.ExecutionVertexID;
 import org.apache.flink.runtime.scheduler.strategy.ResultPartitionState;
 import org.apache.flink.util.TestLogger;
 
 import org.junit.Before;
 import org.junit.Test;
 
+import java.util.HashMap;
+import java.util.Map;
 import java.util.function.Supplier;
 
 import static org.apache.flink.runtime.io.network.partition.ResultPartitionType.BLOCKING;
+import static org.hamcrest.MatcherAssert.assertThat;
+import static org.hamcrest.Matchers.contains;
 import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertFalse;
+import static org.junit.Assert.assertTrue;
 
 /** Unit tests for {@link DefaultResultPartition}. */
 public class DefaultResultPartitionTest extends TestLogger {
@@ -43,6 +52,9 @@ public class DefaultResultPartitionTest extends TestLogger {
 
     private DefaultResultPartition resultPartition;
 
+    private final Map<IntermediateResultPartitionID, ConsumerVertexGroup> consumerVertexGroups =
+            new HashMap<>();
+
     @Before
     public void setUp() {
         resultPartition =
@@ -51,7 +63,7 @@ public class DefaultResultPartitionTest extends TestLogger {
                         intermediateResultId,
                         BLOCKING,
                         resultPartitionState,
-                        null,
+                        () -> consumerVertexGroups.get(resultPartitionId),
                         () -> {
                             throw new UnsupportedOperationException();
                         });
@@ -63,6 +75,19 @@ public class DefaultResultPartitionTest extends TestLogger {
             resultPartitionState.setResultPartitionState(state);
             assertEquals(state, resultPartition.getState());
         }
+    }
+
+    @Test
+    public void testGetConsumerVertexGroup() {
+
+        assertFalse(resultPartition.getConsumerVertexGroup().isPresent());
+
+        // test update consumers
+        ExecutionVertexID executionVertexId = new ExecutionVertexID(new JobVertexID(), 0);
+        consumerVertexGroups.put(
+                resultPartition.getId(), ConsumerVertexGroup.fromSingleVertex(executionVertexId));
+        assertTrue(resultPartition.getConsumerVertexGroup().isPresent());
+        assertThat(resultPartition.getConsumerVertexGroup().get(), contains(executionVertexId));
     }
 
     /** A test {@link ResultPartitionState} supplier. */

--- a/flink-runtime/src/test/java/org/apache/flink/runtime/scheduler/adapter/DefaultSchedulingPipelinedRegionTest.java
+++ b/flink-runtime/src/test/java/org/apache/flink/runtime/scheduler/adapter/DefaultSchedulingPipelinedRegionTest.java
@@ -73,7 +73,11 @@ public class DefaultSchedulingPipelinedRegionTest extends TestLogger {
                 new DefaultExecutionVertex(
                         new ExecutionVertexID(new JobVertexID(), 0),
                         Collections.emptyList(),
-                        () -> ExecutionState.CREATED);
+                        () -> ExecutionState.CREATED,
+                        Collections.emptyList(),
+                        partitionID -> {
+                            throw new UnsupportedOperationException();
+                        });
 
         final Set<DefaultExecutionVertex> vertices = Collections.singleton(vertex);
         final Map<IntermediateResultPartitionID, DefaultResultPartition> resultPartitionById =

--- a/flink-runtime/src/test/java/org/apache/flink/runtime/scheduler/strategy/TestingSchedulingResultPartition.java
+++ b/flink-runtime/src/test/java/org/apache/flink/runtime/scheduler/strategy/TestingSchedulingResultPartition.java
@@ -28,6 +28,7 @@ import java.util.ArrayList;
 import java.util.Collection;
 import java.util.Collections;
 import java.util.List;
+import java.util.Optional;
 import java.util.stream.Collectors;
 
 import static org.apache.flink.util.Preconditions.checkNotNull;
@@ -89,9 +90,8 @@ public class TestingSchedulingResultPartition implements SchedulingResultPartiti
     }
 
     @Override
-    public ConsumerVertexGroup getConsumerVertexGroup() {
-        checkNotNull(consumerVertexGroup);
-        return consumerVertexGroup;
+    public Optional<ConsumerVertexGroup> getConsumerVertexGroup() {
+        return Optional.of(consumerVertexGroup);
     }
 
     @Override

--- a/flink-runtime/src/test/java/org/apache/flink/runtime/scheduler/strategy/TestingSchedulingTopology.java
+++ b/flink-runtime/src/test/java/org/apache/flink/runtime/scheduler/strategy/TestingSchedulingTopology.java
@@ -25,6 +25,7 @@ import org.apache.flink.runtime.jobgraph.DistributionPattern;
 import org.apache.flink.runtime.jobgraph.IntermediateDataSetID;
 import org.apache.flink.runtime.jobgraph.IntermediateResultPartitionID;
 import org.apache.flink.runtime.jobgraph.JobVertexID;
+import org.apache.flink.runtime.scheduler.SchedulingTopologyListener;
 
 import java.util.ArrayList;
 import java.util.Collections;
@@ -77,6 +78,9 @@ public class TestingSchedulingTopology implements SchedulingTopology {
         }
         return resultPartition;
     }
+
+    @Override
+    public void registerSchedulingTopologyListener(SchedulingTopologyListener listener) {}
 
     @Override
     public Iterable<SchedulingPipelinedRegion> getAllPipelinedRegions() {


### PR DESCRIPTION
## What is the purpose of the change

Let some scheduler components updatable, including DefaultExecutionTopology, SchedulingStrategy, PartitionReleaseStrategy and SlotSharingStrategy.

## Brief change log
 ca7544446ab6ca1aebf38c3b338bc5bdf3864d14 DefaultExecutionTopology supports update.
 9294b67a0f8f7b6881e581a41cf3895a8196ff98 RegionPartitionGroupReleaseStrategy and LocalInputPreferredSlotSharingStrategy support update.

## Verifying this change
unit tests.

## Does this pull request potentially affect one of the following parts:

  - Dependencies (does it add or upgrade a dependency): (**no**)
  - The public API, i.e., is any changed class annotated with `@Public(Evolving)`: (**no**)
  - The serializers: (**no**)
  - The runtime per-record code paths (performance sensitive): (**no**)
  - Anything that affects deployment or recovery: JobManager (and its components), Checkpointing, Kubernetes/Yarn, ZooKeeper: (**no**)
  - The S3 file system connector: (**no**)

## Documentation

  - Does this pull request introduce a new feature? (**no**)
  - If yes, how is the feature documented? (**not applicable**)
