### PR TITLE
[FLINK-25304][table-planner][tests] Add tests for padding of fractional seconds

### DIFF
--- a/flink-table/flink-table-planner/src/test/java/org/apache/flink/table/planner/functions/CastFunctionITCase.java
+++ b/flink-table/flink-table-planner/src/test/java/org/apache/flink/table/planner/functions/CastFunctionITCase.java
@@ -210,8 +210,12 @@ public class CastFunctionITCase extends BuiltInFunctionTestBase {
                         // seconds are lost
                         .fromCase(TIME(5), DEFAULT_TIME, "12:34:56")
                         .fromCase(TIMESTAMP(), DEFAULT_TIMESTAMP, "2021-09-24 12:34:56.123456")
-                        .fromCase(TIMESTAMP(8), DEFAULT_TIMESTAMP, "2021-09-24 12:34:56.12345670")
+                        .fromCase(TIMESTAMP(9), DEFAULT_TIMESTAMP, "2021-09-24 12:34:56.123456700")
                         .fromCase(TIMESTAMP(4), DEFAULT_TIMESTAMP, "2021-09-24 12:34:56.1234")
+                        .fromCase(
+                                TIMESTAMP(3),
+                                LocalDateTime.parse("2021-09-24T12:34:56.1"),
+                                "2021-09-24 12:34:56.100")
                         .fromCase(TIMESTAMP(4).nullable(), null, null)
 
                         // https://issues.apache.org/jira/browse/FLINK-20869
@@ -221,6 +225,14 @@ public class CastFunctionITCase extends BuiltInFunctionTestBase {
                                 TIMESTAMP_LTZ(5),
                                 DEFAULT_TIMESTAMP_LTZ,
                                 "2021-09-25 07:54:56.12345")
+                        .fromCase(
+                                TIMESTAMP_LTZ(9),
+                                DEFAULT_TIMESTAMP_LTZ,
+                                "2021-09-25 07:54:56.123456700")
+                        .fromCase(
+                                TIMESTAMP_LTZ(3),
+                                fromLocalTZ("2021-09-24T22:34:56.1"),
+                                "2021-09-25 07:54:56.100")
                         .fromCase(INTERVAL(YEAR()), 84, "+7-00")
                         .fromCase(INTERVAL(MONTH()), 5, "+0-05")
                         .fromCase(INTERVAL(MONTH()), 123, "+10-03")

--- a/flink-table/flink-table-planner/src/test/java/org/apache/flink/table/planner/functions/casting/CastRulesTest.java
+++ b/flink-table/flink-table-planner/src/test/java/org/apache/flink/table/planner/functions/casting/CastRulesTest.java
@@ -523,7 +523,34 @@ class CastRulesTest {
                                 fromString(String.valueOf(Double.MAX_VALUE)))
                         .fromCase(STRING(), fromString("Hello"), fromString("Hello"))
                         .fromCase(TIMESTAMP(), TIMESTAMP, TIMESTAMP_STRING)
+                        .fromCase(
+                                TIMESTAMP(9),
+                                TIMESTAMP,
+                                fromString("2021-09-24 12:34:56.123456000"))
+                        .fromCase(
+                                TIMESTAMP(7), TIMESTAMP, fromString("2021-09-24 12:34:56.1234560"))
+                        .fromCase(
+                                TIMESTAMP(3),
+                                TimestampData.fromLocalDateTime(
+                                        LocalDateTime.parse("2021-09-24T12:34:56.1")),
+                                fromString("2021-09-24 12:34:56.100"))
                         .fromCase(TIMESTAMP_LTZ(), CET_CONTEXT, TIMESTAMP, TIMESTAMP_STRING_CET)
+                        .fromCase(
+                                TIMESTAMP_LTZ(9),
+                                CET_CONTEXT,
+                                TIMESTAMP,
+                                fromString("2021-09-24 14:34:56.123456000"))
+                        .fromCase(
+                                TIMESTAMP_LTZ(7),
+                                CET_CONTEXT,
+                                TIMESTAMP,
+                                fromString("2021-09-24 14:34:56.1234560"))
+                        .fromCase(
+                                TIMESTAMP_LTZ(3),
+                                CET_CONTEXT,
+                                TimestampData.fromLocalDateTime(
+                                        LocalDateTime.parse("2021-09-24T12:34:56.1")),
+                                fromString("2021-09-24 14:34:56.100"))
                         .fromCase(DATE(), DATE, DATE_STRING)
                         .fromCase(TIME(5), TIME, TIME_STRING)
                         .fromCase(INTERVAL(YEAR()), 84, fromString("+7-00"))


### PR DESCRIPTION
## What is the purpose of the change

Add Unit and IT tests to validate the `0` padding of the fractional seconds
when casting a `TIMESTAMP` or `TIMESTAMP_LTZ` to string, so that the length
of the fractional seconds in the resulting string matches the `precision`
specified on the source type.

## Does this pull request potentially affect one of the following parts:

  - Dependencies (does it add or upgrade a dependency): **no**
  - The public API, i.e., is any changed class annotated with `@Public(Evolving)`: **no**
  - The serializers: **no**
  - The runtime per-record code paths (performance sensitive): **no**
  - Anything that affects deployment or recovery: JobManager (and its components), Checkpointing, Kubernetes/Yarn, ZooKeeper: **no**
  - The S3 file system connector: **no**

## Documentation

  - Does this pull request introduce a new feature? **no**
  - If yes, how is the feature documented? **not applicable**
