### PR TITLE
[FLINK-17151][table] Align Calcite's and Flink's SYMBOL types

### DIFF
--- a/flink-table/flink-table-common/src/main/java/org/apache/flink/table/types/logical/SymbolType.java
+++ b/flink-table/flink-table-common/src/main/java/org/apache/flink/table/types/logical/SymbolType.java
@@ -21,52 +21,57 @@ package org.apache.flink.table.types.logical;
 import org.apache.flink.annotation.PublicEvolving;
 import org.apache.flink.table.api.TableException;
 import org.apache.flink.table.expressions.TableSymbol;
-import org.apache.flink.util.Preconditions;
 
 import java.util.Collections;
 import java.util.List;
-import java.util.Objects;
 
 /**
  * Logical type for representing symbol values. The symbol type is an extension to the SQL standard
  * and only serves as a helper type within the expression stack.
  *
- * <p>A symbol type only accepts conversions from and to its enum class.
+ * <p>A symbol type accepts conversions from and to {@link Enum}. But note that this is not an enum
+ * type for users.
  *
  * <p>This type has no serializable string representation.
  *
- * @param <T> table symbol
+ * @param <T> Legacy generic that will be dropped in the next major version. If we dropped it
+ *     earlier, we would break {@link LogicalTypeVisitor} implementation.
  */
+@SuppressWarnings("unused")
 @PublicEvolving
 public final class SymbolType<T extends TableSymbol> extends LogicalType {
-    private static final long serialVersionUID = 1L;
+    private static final long serialVersionUID = 2L;
 
-    private static final String FORMAT = "SYMBOL('%s')";
+    private static final String FORMAT = "SYMBOL";
 
-    private final Class<T> symbolClass;
+    /** @deprecated Symbol types have been simplified to not require a class. */
+    @Deprecated
+    public SymbolType(boolean isNullable, Class<T> clazz) {
+        this(isNullable);
+    }
 
-    public SymbolType(boolean isNullable, Class<T> symbolClass) {
+    /** @deprecated Symbol types have been simplified to not require a class. */
+    @Deprecated
+    public SymbolType(Class<T> clazz) {
+        this();
+    }
+
+    public SymbolType(boolean isNullable) {
         super(isNullable, LogicalTypeRoot.SYMBOL);
-        this.symbolClass =
-                Preconditions.checkNotNull(symbolClass, "Symbol class must not be null.");
     }
 
-    public SymbolType(Class<T> symbolClass) {
-        this(true, symbolClass);
-    }
-
-    public Class<T> getSymbolClass() {
-        return symbolClass;
+    public SymbolType() {
+        this(true);
     }
 
     @Override
     public LogicalType copy(boolean isNullable) {
-        return new SymbolType<>(isNullable, symbolClass);
+        return new SymbolType<>(isNullable);
     }
 
     @Override
     public String asSummaryString() {
-        return withNullability(FORMAT, symbolClass.getName());
+        return withNullability(FORMAT);
     }
 
     @Override
@@ -76,17 +81,17 @@ public final class SymbolType<T extends TableSymbol> extends LogicalType {
 
     @Override
     public boolean supportsInputConversion(Class<?> clazz) {
-        return symbolClass.equals(clazz);
+        return Enum.class.isAssignableFrom(clazz);
     }
 
     @Override
     public boolean supportsOutputConversion(Class<?> clazz) {
-        return symbolClass.equals(clazz);
+        return Enum.class.isAssignableFrom(clazz);
     }
 
     @Override
     public Class<?> getDefaultConversion() {
-        return symbolClass;
+        return Enum.class;
     }
 
     @Override
@@ -97,25 +102,5 @@ public final class SymbolType<T extends TableSymbol> extends LogicalType {
     @Override
     public <R> R accept(LogicalTypeVisitor<R> visitor) {
         return visitor.visit(this);
-    }
-
-    @Override
-    public boolean equals(Object o) {
-        if (this == o) {
-            return true;
-        }
-        if (o == null || getClass() != o.getClass()) {
-            return false;
-        }
-        if (!super.equals(o)) {
-            return false;
-        }
-        SymbolType<?> that = (SymbolType<?>) o;
-        return symbolClass.equals(that.symbolClass);
-    }
-
-    @Override
-    public int hashCode() {
-        return Objects.hash(super.hashCode(), symbolClass);
     }
 }

--- a/flink-table/flink-table-common/src/main/java/org/apache/flink/table/types/utils/ClassDataTypeConverter.java
+++ b/flink-table/flink-table-common/src/main/java/org/apache/flink/table/types/utils/ClassDataTypeConverter.java
@@ -104,7 +104,7 @@ public final class ClassDataTypeConverter {
         }
 
         if (TableSymbol.class.isAssignableFrom(clazz)) {
-            return Optional.of(new AtomicDataType(new SymbolType(clazz)));
+            return Optional.of(new AtomicDataType(new SymbolType<>(), clazz));
         }
 
         return Optional.ofNullable(defaultDataTypes.get(clazz.getName()));

--- a/flink-table/flink-table-common/src/test/java/org/apache/flink/table/types/ClassDataTypeConverterTest.java
+++ b/flink-table/flink-table-common/src/test/java/org/apache/flink/table/types/ClassDataTypeConverterTest.java
@@ -99,8 +99,7 @@ public class ClassDataTypeConverterTest {
                     },
                     {
                         TimeIntervalUnit.class,
-                        new AtomicDataType(new SymbolType<>(TimeIntervalUnit.class))
-                                .bridgedTo(TimeIntervalUnit.class)
+                        new AtomicDataType(new SymbolType<>()).bridgedTo(TimeIntervalUnit.class)
                     },
                     {Row.class, null}
                 });

--- a/flink-table/flink-table-common/src/test/java/org/apache/flink/table/types/LogicalTypesTest.java
+++ b/flink-table/flink-table-common/src/test/java/org/apache/flink/table/types/LogicalTypesTest.java
@@ -27,7 +27,6 @@ import org.apache.flink.table.api.ValidationException;
 import org.apache.flink.table.catalog.ObjectIdentifier;
 import org.apache.flink.table.catalog.UnresolvedIdentifier;
 import org.apache.flink.table.expressions.TimeIntervalUnit;
-import org.apache.flink.table.expressions.TimePointUnit;
 import org.apache.flink.table.types.logical.ArrayType;
 import org.apache.flink.table.types.logical.BigIntType;
 import org.apache.flink.table.types.logical.BinaryType;
@@ -644,11 +643,10 @@ public class LogicalTypesTest {
 
     @Test
     public void testSymbolType() {
-        final SymbolType<?> symbolType = new SymbolType<>(TimeIntervalUnit.class);
+        final SymbolType<?> symbolType = new SymbolType<>();
 
         assertThat(symbolType)
-                .satisfies(nonEqualityCheckWithOtherType(new SymbolType<>(TimePointUnit.class)))
-                .hasSummaryString("SYMBOL('" + TimeIntervalUnit.class.getName() + "')")
+                .hasSummaryString("SYMBOL")
                 .satisfies(LogicalTypesTest::nullability)
                 .isJavaSerializable()
                 .satisfies(

--- a/flink-table/flink-table-common/src/test/java/org/apache/flink/table/types/ValueDataTypeConverterTest.java
+++ b/flink-table/flink-table-common/src/test/java/org/apache/flink/table/types/ValueDataTypeConverterTest.java
@@ -120,7 +120,10 @@ public class ValueDataTypeConverterTest {
                         },
                         DataTypes.ARRAY(DataTypes.ARRAY(DataTypes.INT()))
                     },
-                    {TimePointUnit.HOUR, new AtomicDataType(new SymbolType<>(TimePointUnit.class))},
+                    {
+                        TimePointUnit.HOUR,
+                        new AtomicDataType(new SymbolType<>(), TimePointUnit.class)
+                    },
                     {new BigDecimal[0], null}
                 });
     }

--- a/flink-table/flink-table-common/src/test/java/org/apache/flink/table/types/inference/strategies/SymbolArgumentTypeStrategyTest.java
+++ b/flink-table/flink-table-common/src/test/java/org/apache/flink/table/types/inference/strategies/SymbolArgumentTypeStrategyTest.java
@@ -37,17 +37,19 @@ import static org.apache.flink.table.types.inference.InputTypeStrategies.symbol;
 /** Tests for {@link SymbolArgumentTypeStrategy}. */
 public class SymbolArgumentTypeStrategyTest extends InputTypeStrategiesTestBase {
 
+    private static final DataType SYMBOL_TYPE = new AtomicDataType(new SymbolType<>());
+
     private static final InputTypeStrategy STRATEGY = sequence(symbol(TestEnum.class));
 
     @Parameterized.Parameters(name = "{index}: {0}")
     public static List<TestSpec> testData() {
         return asList(
                 TestSpec.forStrategy("Valid argument", STRATEGY)
-                        .calledWithArgumentTypes(makeEnumType(TestEnum.class))
+                        .calledWithArgumentTypes(SYMBOL_TYPE)
                         .calledWithLiteralAt(0, TestEnum.A)
                         .expectSignature("f(<TestEnum>)"),
                 TestSpec.forStrategy("Wrong enum", STRATEGY)
-                        .calledWithArgumentTypes(makeEnumType(InvalidEnum.class))
+                        .calledWithArgumentTypes(SYMBOL_TYPE)
                         .calledWithLiteralAt(0, InvalidEnum.A)
                         .expectErrorMessage(
                                 "Unsupported argument symbol type. "
@@ -57,10 +59,6 @@ public class SymbolArgumentTypeStrategyTest extends InputTypeStrategiesTestBase 
                         .expectErrorMessage(
                                 "Unsupported argument type. "
                                         + "Expected symbol type 'TestEnum' but actual type was 'STRING'."));
-    }
-
-    private static <T extends TableSymbol> DataType makeEnumType(Class<T> enumClass) {
-        return new AtomicDataType(new SymbolType<T>(enumClass));
     }
 
     private enum TestEnum implements TableSymbol {

--- a/flink-table/flink-table-planner/src/main/scala/org/apache/flink/table/planner/calcite/FlinkTypeFactory.scala
+++ b/flink-table/flink-table-planner/src/main/scala/org/apache/flink/table/planner/calcite/FlinkTypeFactory.scala
@@ -599,10 +599,8 @@ object FlinkTypeFactory {
       case NULL =>
         new NullType()
 
-      // symbol for special flags e.g. TRIM's BOTH, LEADING, TRAILING
-      // are represented as Enum
-      case SYMBOL => new TypeInformationRawType[Enum[_]](
-        TypeExtractor.createTypeInfo(classOf[Enum[_]]))
+      case SYMBOL =>
+        new SymbolType()
 
       // extract encapsulated Type
       case ANY if relDataType.isInstanceOf[GenericRelDataType] =>

--- a/flink-table/flink-table-planner/src/main/scala/org/apache/flink/table/planner/codegen/CodeGenUtils.scala
+++ b/flink-table/flink-table-planner/src/main/scala/org/apache/flink/table/planner/codegen/CodeGenUtils.scala
@@ -347,15 +347,11 @@ object CodeGenUtils {
   def compareEnum(term: String, enum: Enum[_]): Boolean = term == qualifyEnum(enum)
 
   def getEnum(genExpr: GeneratedExpression): Enum[_] = {
-    val split = genExpr.resultTerm.split('.')
-    val value = split.last
-    val clazz = genExpr.resultType.asInstanceOf[TypeInformationRawType[_]]
-        .getTypeInformation.getTypeClass
-    enumValueOf(clazz, value)
+   genExpr
+     .literalValue
+     .map(_.asInstanceOf[Enum[_]])
+     .getOrElse(throw new CodeGenException("Enum literal expected."))
   }
-
-  def enumValueOf[T <: Enum[T]](cls: Class[_], stringValue: String): Enum[_] =
-    Enum.valueOf(cls.asInstanceOf[Class[T]], stringValue).asInstanceOf[Enum[_]]
 
   // --------------------------- Require Check ---------------------------------------
 

--- a/flink-table/flink-table-planner/src/main/scala/org/apache/flink/table/planner/codegen/GenerateUtils.scala
+++ b/flink-table/flink-table-planner/src/main/scala/org/apache/flink/table/planner/codegen/GenerateUtils.scala
@@ -435,13 +435,8 @@ object GenerateUtils {
       case DISTINCT_TYPE =>
         generateLiteral(ctx, literalType.asInstanceOf[DistinctType].getSourceType, literalValue)
 
-      // Symbol type for special flags e.g. TRIM's BOTH, LEADING, TRAILING
-      case RAW if literalType.asInstanceOf[TypeInformationRawType[_]]
-          .getTypeInformation.getTypeClass.isAssignableFrom(classOf[Enum[_]]) =>
-        generateSymbol(literalValue.asInstanceOf[Enum[_]])
-
       case SYMBOL =>
-        throw new UnsupportedOperationException() // TODO support symbol?
+        generateSymbol(literalValue.asInstanceOf[Enum[_]])
 
       case ARRAY | MULTISET | MAP | ROW | STRUCTURED_TYPE | NULL | UNRESOLVED =>
         throw new CodeGenException(s"Type not supported: $literalType")
@@ -453,8 +448,7 @@ object GenerateUtils {
       qualifyEnum(enum),
       NEVER_NULL,
       NO_CODE,
-      new TypeInformationRawType[AnyRef](new GenericTypeInfo[AnyRef](
-        enum.getDeclaringClass.asInstanceOf[Class[AnyRef]])),
+      new SymbolType(false),
       literalValue = Some(enum))
   }
 

--- a/flink-table/flink-table-planner/src/main/scala/org/apache/flink/table/planner/codegen/calls/FunctionGenerator.scala
+++ b/flink-table/flink-table-planner/src/main/scala/org/apache/flink/table/planner/codegen/calls/FunctionGenerator.scala
@@ -402,86 +402,86 @@ class FunctionGenerator private(config: TableConfig) {
 
   addSqlFunction(
     EXTRACT,
-    Seq(RAW, BIGINT),
+    Seq(SYMBOL, BIGINT),
     new ExtractCallGen(BuiltInMethods.UNIX_DATE_EXTRACT))
 
   addSqlFunction(
     EXTRACT,
-    Seq(RAW, DATE),
+    Seq(SYMBOL, DATE),
     new ExtractCallGen(BuiltInMethods.UNIX_DATE_EXTRACT))
 
   addSqlFunction(
     EXTRACT,
-    Seq(RAW, TIME_WITHOUT_TIME_ZONE),
+    Seq(SYMBOL, TIME_WITHOUT_TIME_ZONE),
     new ExtractCallGen(BuiltInMethods.UNIX_DATE_EXTRACT))
 
   addSqlFunction(
     EXTRACT,
-    Seq(RAW, TIMESTAMP_WITHOUT_TIME_ZONE),
+    Seq(SYMBOL, TIMESTAMP_WITHOUT_TIME_ZONE),
     new ExtractCallGen(BuiltInMethods.UNIX_DATE_EXTRACT))
 
   addSqlFunction(
     EXTRACT,
-    Seq(RAW, TIMESTAMP_WITH_LOCAL_TIME_ZONE),
+    Seq(SYMBOL, TIMESTAMP_WITH_LOCAL_TIME_ZONE),
     new MethodCallGen(BuiltInMethods.EXTRACT_FROM_TIMESTAMP_TIME_ZONE))
 
   addSqlFunction(
     EXTRACT,
-    Seq(RAW, INTERVAL_DAY_TIME),
+    Seq(SYMBOL, INTERVAL_DAY_TIME),
     new ExtractCallGen(BuiltInMethods.UNIX_DATE_EXTRACT))
 
   addSqlFunction(
     EXTRACT,
-    Seq(RAW, INTERVAL_YEAR_MONTH),
+    Seq(SYMBOL, INTERVAL_YEAR_MONTH),
     new ExtractCallGen(BuiltInMethods.UNIX_DATE_EXTRACT))
 
   addSqlFunction(
     TIMESTAMP_DIFF,
     Seq(
-      RAW,
+      SYMBOL,
       TIMESTAMP_WITHOUT_TIME_ZONE,
       TIMESTAMP_WITHOUT_TIME_ZONE),
     new TimestampDiffCallGen)
 
   addSqlFunction(
     TIMESTAMP_DIFF,
-    Seq(RAW, TIMESTAMP_WITHOUT_TIME_ZONE, DATE),
+    Seq(SYMBOL, TIMESTAMP_WITHOUT_TIME_ZONE, DATE),
     new TimestampDiffCallGen)
 
   addSqlFunction(
     TIMESTAMP_DIFF,
-    Seq(RAW, DATE, TIMESTAMP_WITHOUT_TIME_ZONE),
+    Seq(SYMBOL, DATE, TIMESTAMP_WITHOUT_TIME_ZONE),
     new TimestampDiffCallGen)
 
   addSqlFunction(
     TIMESTAMP_DIFF,
-    Seq(RAW, DATE, DATE),
+    Seq(SYMBOL, DATE, DATE),
     new TimestampDiffCallGen)
 
   addSqlFunction(
     FLOOR,
-    Seq(DATE, RAW),
+    Seq(DATE, SYMBOL),
     new FloorCeilCallGen(
       BuiltInMethod.FLOOR.method,
       Some(BuiltInMethods.UNIX_DATE_FLOOR)))
 
   addSqlFunction(
     FLOOR,
-    Seq(TIME_WITHOUT_TIME_ZONE, RAW),
+    Seq(TIME_WITHOUT_TIME_ZONE, SYMBOL),
     new FloorCeilCallGen(
       BuiltInMethod.FLOOR.method,
       Some(BuiltInMethods.UNIX_DATE_FLOOR)))
 
   addSqlFunction(
     FLOOR,
-    Seq(TIMESTAMP_WITHOUT_TIME_ZONE, RAW),
+    Seq(TIMESTAMP_WITHOUT_TIME_ZONE, SYMBOL),
     new FloorCeilCallGen(
       BuiltInMethod.FLOOR.method,
       Some(BuiltInMethods.UNIX_TIMESTAMP_FLOOR)))
 
   addSqlFunction(
     FLOOR,
-    Seq(TIMESTAMP_WITH_LOCAL_TIME_ZONE, RAW),
+    Seq(TIMESTAMP_WITH_LOCAL_TIME_ZONE, SYMBOL),
     new FloorCeilCallGen(
       BuiltInMethod.FLOOR.method,
       Some(BuiltInMethods.TIMESTAMP_FLOOR_TIME_ZONE)))
@@ -490,28 +490,28 @@ class FunctionGenerator private(config: TableConfig) {
   //  https://issues.apache.org/jira/browse/CALCITE-3199
   addSqlFunction(
     CEIL,
-    Seq(DATE, RAW),
+    Seq(DATE, SYMBOL),
     new FloorCeilCallGen(
       BuiltInMethod.CEIL.method,
       Some(BuiltInMethods.UNIX_DATE_CEIL)))
 
   addSqlFunction(
     CEIL,
-    Seq(TIME_WITHOUT_TIME_ZONE, RAW),
+    Seq(TIME_WITHOUT_TIME_ZONE, SYMBOL),
     new FloorCeilCallGen(
       BuiltInMethod.CEIL.method,
       Some(BuiltInMethods.UNIX_DATE_CEIL)))
 
   addSqlFunction(
     CEIL,
-    Seq(TIMESTAMP_WITHOUT_TIME_ZONE, RAW),
+    Seq(TIMESTAMP_WITHOUT_TIME_ZONE, SYMBOL),
     new FloorCeilCallGen(
       BuiltInMethod.CEIL.method,
       Some(BuiltInMethods.UNIX_TIMESTAMP_CEIL)))
 
   addSqlFunction(
     CEIL,
-    Seq(TIMESTAMP_WITH_LOCAL_TIME_ZONE, RAW),
+    Seq(TIMESTAMP_WITH_LOCAL_TIME_ZONE, SYMBOL),
     new FloorCeilCallGen(
       BuiltInMethod.CEIL.method,
       Some(BuiltInMethods.TIMESTAMP_CEIL_TIME_ZONE)))
@@ -802,11 +802,23 @@ class FunctionGenerator private(config: TableConfig) {
 
   addSqlFunctionMethod(JSON_EXISTS, Seq(CHAR, CHAR), BuiltInMethods.JSON_EXISTS)
   addSqlFunctionMethod(JSON_EXISTS, Seq(VARCHAR, CHAR), BuiltInMethods.JSON_EXISTS)
-  addSqlFunctionMethod(JSON_EXISTS, Seq(CHAR, CHAR, RAW), BuiltInMethods.JSON_EXISTS_ON_ERROR)
-  addSqlFunctionMethod(JSON_EXISTS, Seq(VARCHAR, CHAR, RAW), BuiltInMethods.JSON_EXISTS_ON_ERROR)
+  addSqlFunctionMethod(
+    JSON_EXISTS,
+    Seq(CHAR, CHAR, SYMBOL),
+    BuiltInMethods.JSON_EXISTS_ON_ERROR)
+  addSqlFunctionMethod(
+    JSON_EXISTS,
+    Seq(VARCHAR, CHAR, SYMBOL),
+    BuiltInMethods.JSON_EXISTS_ON_ERROR)
 
-  addSqlFunctionMethod(JSON_QUERY, Seq(CHAR, CHAR, RAW, RAW, RAW), BuiltInMethods.JSON_QUERY)
-  addSqlFunctionMethod(JSON_QUERY, Seq(VARCHAR, CHAR, RAW, RAW, RAW), BuiltInMethods.JSON_QUERY)
+  addSqlFunctionMethod(
+    JSON_QUERY,
+    Seq(CHAR, CHAR, SYMBOL, SYMBOL, SYMBOL),
+    BuiltInMethods.JSON_QUERY)
+  addSqlFunctionMethod(
+    JSON_QUERY,
+    Seq(VARCHAR, CHAR, SYMBOL, SYMBOL, SYMBOL),
+    BuiltInMethods.JSON_QUERY)
 
   addSqlFunctionMethod(IS_JSON_VALUE, Seq(CHAR),
     BuiltInMethod.IS_JSON_VALUE.method, argsNullable = true)


### PR DESCRIPTION
## What is the purpose of the change

This reworks how we handle symbols throughout the stack. It removes the need for a conversion class and align the behavior with Calcite's representation of symbols. Even though we change a `@PublicEvolving` class this should have little impact for users as this type is not exposed through the API.

## Brief change log

- Simplify `SymbolType`
- Remove usages of `RAW` type for symbols.

## Verifying this change

This change is already covered by existing tests, such as *(please describe tests)*.

## Does this pull request potentially affect one of the following parts:

  - Dependencies (does it add or upgrade a dependency): no
  - The public API, i.e., is any changed class annotated with `@Public(Evolving)`: yes
  - The serializers: no
  - The runtime per-record code paths (performance sensitive): no
  - Anything that affects deployment or recovery: JobManager (and its components), Checkpointing, Kubernetes/Yarn, ZooKeeper: no
  - The S3 file system connector: no

## Documentation

  - Does this pull request introduce a new feature? no
  - If yes, how is the feature documented? JavaDocs
