### PR TITLE
[FLINK-25284][Table SQL / API] Add proportion of null values to generate with datagen

### DIFF
--- a/docs/content.zh/docs/connectors/table/datagen.md
+++ b/docs/content.zh/docs/connectors/table/datagen.md
@@ -152,5 +152,12 @@ CREATE TABLE datagen (
       <td>(Type of field)</td>
       <td>序列生成器的结束值。</td>
     </tr>
+    <tr>
+      <td><h5>fields.#.null-rate</h5></td>
+      <td>optional</td>
+      <td style="word-wrap: break-word;">(none)</td>
+      <td>(Type of field)</td>
+      <td>The proportion of null values.</td>
+    </tr>
     </tbody>
 </table>

--- a/docs/content/docs/connectors/table/datagen.md
+++ b/docs/content/docs/connectors/table/datagen.md
@@ -297,5 +297,12 @@ Connector Options
       <td>(Type of field)</td>
       <td>End value of sequence generator.</td>
     </tr>
+    <tr>
+      <td><h5>fields.#.null-rate</h5></td>
+      <td>optional</td>
+      <td style="word-wrap: break-word;">(none)</td>
+      <td>(Type of field)</td>
+      <td>The proportion of null values.</td>
+    </tr>
     </tbody>
 </table>

--- a/flink-streaming-java/src/main/java/org/apache/flink/streaming/api/functions/source/datagen/RandomGenerator.java
+++ b/flink-streaming-java/src/main/java/org/apache/flink/streaming/api/functions/source/datagen/RandomGenerator.java
@@ -26,18 +26,33 @@ import org.apache.commons.math3.random.RandomDataGenerator;
 
 import java.util.HashMap;
 import java.util.Map;
+import java.util.concurrent.ThreadLocalRandom;
+import java.util.function.Supplier;
 
 /** Random generator. */
 @Experimental
 public abstract class RandomGenerator<T> implements DataGenerator<T> {
 
     protected transient RandomDataGenerator random;
+    protected float nullRate;
 
     @Override
     public void open(
             String name, FunctionInitializationContext context, RuntimeContext runtimeContext)
             throws Exception {
         this.random = new RandomDataGenerator();
+    }
+
+    public RandomGenerator<T> withNullRate(float nullRate) {
+        this.nullRate = nullRate;
+        return this;
+    }
+
+    protected T nextWithNullRate(Supplier<T> supplier) {
+        if (nullRate == 0f || nullRate < ThreadLocalRandom.current().nextFloat()) {
+            return supplier.get();
+        }
+        return null;
     }
 
     @Override
@@ -49,7 +64,7 @@ public abstract class RandomGenerator<T> implements DataGenerator<T> {
         return new RandomGenerator<Long>() {
             @Override
             public Long next() {
-                return random.nextLong(min, max);
+                return nextWithNullRate(() -> random.nextLong(min, max));
             }
         };
     }
@@ -58,7 +73,7 @@ public abstract class RandomGenerator<T> implements DataGenerator<T> {
         return new RandomGenerator<Integer>() {
             @Override
             public Integer next() {
-                return random.nextInt(min, max);
+                return nextWithNullRate(() -> random.nextInt(min, max));
             }
         };
     }
@@ -67,7 +82,7 @@ public abstract class RandomGenerator<T> implements DataGenerator<T> {
         return new RandomGenerator<Short>() {
             @Override
             public Short next() {
-                return (short) random.nextInt(min, max);
+                return nextWithNullRate(() -> (short) random.nextInt(min, max));
             }
         };
     }
@@ -76,7 +91,7 @@ public abstract class RandomGenerator<T> implements DataGenerator<T> {
         return new RandomGenerator<Byte>() {
             @Override
             public Byte next() {
-                return (byte) random.nextInt(min, max);
+                return nextWithNullRate(() -> (byte) random.nextInt(min, max));
             }
         };
     }
@@ -85,7 +100,7 @@ public abstract class RandomGenerator<T> implements DataGenerator<T> {
         return new RandomGenerator<Float>() {
             @Override
             public Float next() {
-                return (float) random.nextUniform(min, max);
+                return nextWithNullRate(() -> (float) random.nextUniform(min, max));
             }
         };
     }
@@ -94,7 +109,7 @@ public abstract class RandomGenerator<T> implements DataGenerator<T> {
         return new RandomGenerator<Double>() {
             @Override
             public Double next() {
-                return random.nextUniform(min, max);
+                return nextWithNullRate(() -> random.nextUniform(min, max));
             }
         };
     }
@@ -103,7 +118,7 @@ public abstract class RandomGenerator<T> implements DataGenerator<T> {
         return new RandomGenerator<String>() {
             @Override
             public String next() {
-                return random.nextHexString(len);
+                return nextWithNullRate(() -> random.nextHexString(len));
             }
         };
     }
@@ -112,7 +127,7 @@ public abstract class RandomGenerator<T> implements DataGenerator<T> {
         return new RandomGenerator<Boolean>() {
             @Override
             public Boolean next() {
-                return random.nextInt(0, 1) == 0;
+                return nextWithNullRate(() -> random.nextInt(0, 1) == 0);
             }
         };
     }

--- a/flink-table/flink-sql-client/src/test/resources/sql/table.q
+++ b/flink-table/flink-sql-client/src/test/resources/sql/table.q
@@ -441,13 +441,17 @@ connector
 fields.amount.kind
 fields.amount.max
 fields.amount.min
+fields.amount.null-rate
 fields.product.kind
 fields.product.length
+fields.product.null-rate
 fields.ts.kind
 fields.ts.max-past
+fields.ts.null-rate
 fields.user.kind
 fields.user.max
 fields.user.min
+fields.user.null-rate
 number-of-rows
 rows-per-second
 !error

--- a/flink-table/flink-sql-gateway/src/test/resources/sql/table.q
+++ b/flink-table/flink-sql-gateway/src/test/resources/sql/table.q
@@ -396,13 +396,17 @@ connector
 fields.amount.kind
 fields.amount.max
 fields.amount.min
+fields.amount.null-rate
 fields.product.kind
 fields.product.length
+fields.product.null-rate
 fields.ts.kind
 fields.ts.max-past
+fields.ts.null-rate
 fields.user.kind
 fields.user.max
 fields.user.min
+fields.user.null-rate
 number-of-rows
 rows-per-second
 !error

--- a/flink-table/flink-table-api-java-bridge/src/main/java/org/apache/flink/connector/datagen/table/DataGenConnectorOptions.java
+++ b/flink-table/flink-table-api-java-bridge/src/main/java/org/apache/flink/connector/datagen/table/DataGenConnectorOptions.java
@@ -24,7 +24,6 @@ import org.apache.flink.configuration.ConfigOptions;
 
 import java.time.Duration;
 
-import static org.apache.flink.configuration.ConfigOptions.key;
 import static org.apache.flink.connector.datagen.table.DataGenConnectorOptionsUtil.END;
 import static org.apache.flink.connector.datagen.table.DataGenConnectorOptionsUtil.FIELDS;
 import static org.apache.flink.connector.datagen.table.DataGenConnectorOptionsUtil.KIND;
@@ -32,6 +31,7 @@ import static org.apache.flink.connector.datagen.table.DataGenConnectorOptionsUt
 import static org.apache.flink.connector.datagen.table.DataGenConnectorOptionsUtil.MAX;
 import static org.apache.flink.connector.datagen.table.DataGenConnectorOptionsUtil.MAX_PAST;
 import static org.apache.flink.connector.datagen.table.DataGenConnectorOptionsUtil.MIN;
+import static org.apache.flink.connector.datagen.table.DataGenConnectorOptionsUtil.NULL_RATE;
 import static org.apache.flink.connector.datagen.table.DataGenConnectorOptionsUtil.ROWS_PER_SECOND_DEFAULT_VALUE;
 import static org.apache.flink.connector.datagen.table.DataGenConnectorOptionsUtil.START;
 
@@ -40,13 +40,13 @@ import static org.apache.flink.connector.datagen.table.DataGenConnectorOptionsUt
 public class DataGenConnectorOptions {
 
     public static final ConfigOption<Long> ROWS_PER_SECOND =
-            key("rows-per-second")
+            ConfigOptions.key("rows-per-second")
                     .longType()
                     .defaultValue(ROWS_PER_SECOND_DEFAULT_VALUE)
                     .withDescription("Rows per second to control the emit rate.");
 
     public static final ConfigOption<Long> NUMBER_OF_ROWS =
-            key("number-of-rows")
+            ConfigOptions.key("number-of-rows")
                     .longType()
                     .noDefaultValue()
                     .withDescription(
@@ -108,6 +108,13 @@ public class DataGenConnectorOptions {
                     .stringType()
                     .noDefaultValue()
                     .withDescription("End value of sequence generator.");
+
+    /** Placeholder {@link ConfigOption}. Not used for retrieving values. */
+    public static final ConfigOption<Float> FIELD_NULL_RATE =
+            ConfigOptions.key(String.format("%s.#.%s", FIELDS, NULL_RATE))
+                    .floatType()
+                    .defaultValue(0f)
+                    .withDescription("The proportion of null values.");
 
     private DataGenConnectorOptions() {}
 }

--- a/flink-table/flink-table-api-java-bridge/src/main/java/org/apache/flink/connector/datagen/table/DataGenConnectorOptionsUtil.java
+++ b/flink-table/flink-table-api-java-bridge/src/main/java/org/apache/flink/connector/datagen/table/DataGenConnectorOptionsUtil.java
@@ -34,6 +34,7 @@ public class DataGenConnectorOptionsUtil {
     public static final String MAX = "max";
     public static final String MAX_PAST = "max-past";
     public static final String LENGTH = "length";
+    public static final String NULL_RATE = "null-rate";
 
     public static final String SEQUENCE = "sequence";
     public static final String RANDOM = "random";

--- a/flink-table/flink-table-api-java-bridge/src/main/java/org/apache/flink/connector/datagen/table/DataGenTableSource.java
+++ b/flink-table/flink-table-api-java-bridge/src/main/java/org/apache/flink/connector/datagen/table/DataGenTableSource.java
@@ -68,7 +68,7 @@ public class DataGenTableSource implements ScanTableSource, SupportsLimitPushDow
     @VisibleForTesting
     public DataGeneratorSource<RowData> createSource() {
         return new DataGeneratorSource<>(
-                new RowDataGenerator(fieldGenerators, DataType.getFieldNames(rowDataType)),
+                new RowDataGenerator(fieldGenerators, DataType.getFieldNames(rowDataType), 0),
                 rowsPerSecond,
                 numberOfRows);
     }

--- a/flink-table/flink-table-api-java-bridge/src/main/java/org/apache/flink/connector/datagen/table/DataGenTableSourceFactory.java
+++ b/flink-table/flink-table-api-java-bridge/src/main/java/org/apache/flink/connector/datagen/table/DataGenTableSourceFactory.java
@@ -68,6 +68,7 @@ public class DataGenTableSourceFactory implements DynamicTableSourceFactory {
         options.add(DataGenConnectorOptions.FIELD_LENGTH);
         options.add(DataGenConnectorOptions.FIELD_START);
         options.add(DataGenConnectorOptions.FIELD_END);
+        options.add(DataGenConnectorOptions.FIELD_NULL_RATE);
 
         return options;
     }

--- a/flink-table/flink-table-api-java-bridge/src/main/java/org/apache/flink/connector/datagen/table/RandomGeneratorVisitor.java
+++ b/flink-table/flink-table-api-java-bridge/src/main/java/org/apache/flink/connector/datagen/table/RandomGeneratorVisitor.java
@@ -59,6 +59,7 @@ import java.time.Duration;
 import java.util.List;
 import java.util.Map;
 import java.util.Set;
+import java.util.concurrent.ThreadLocalRandom;
 import java.util.stream.Collectors;
 
 import static org.apache.flink.configuration.ConfigOptions.key;
@@ -74,11 +75,15 @@ public class RandomGeneratorVisitor extends DataGenVisitorBase {
 
     private static final int RANDOM_COLLECTION_LENGTH_DEFAULT = 3;
 
+    private static final float NULL_RATE_DEFAULT = 0f;
+
     private final ConfigOptions.OptionBuilder minKey;
 
     private final ConfigOptions.OptionBuilder maxKey;
 
     private final ConfigOptions.OptionBuilder maxPastKey;
+
+    private final ConfigOptions.OptionBuilder nullRate;
 
     public RandomGeneratorVisitor(String name, ReadableConfig config) {
         super(name, config);
@@ -104,11 +109,21 @@ public class RandomGeneratorVisitor extends DataGenVisitorBase {
                                 + name
                                 + "."
                                 + DataGenConnectorOptionsUtil.MAX_PAST);
+
+        this.nullRate =
+                key(
+                        DataGenConnectorOptionsUtil.FIELDS
+                                + "."
+                                + name
+                                + "."
+                                + DataGenConnectorOptionsUtil.NULL_RATE);
     }
 
     @Override
     public DataGeneratorContainer visit(BooleanType booleanType) {
-        return DataGeneratorContainer.of(RandomGenerator.booleanGenerator());
+        ConfigOption<Float> nr = nullRate.floatType().defaultValue(NULL_RATE_DEFAULT);
+        return DataGeneratorContainer.of(
+                RandomGenerator.booleanGenerator().withNullRate(config.get(nr)), nr);
     }
 
     @Override
@@ -121,8 +136,11 @@ public class RandomGeneratorVisitor extends DataGenVisitorBase {
                                 + DataGenConnectorOptionsUtil.LENGTH)
                         .intType()
                         .defaultValue(RANDOM_STRING_LENGTH_DEFAULT);
+        ConfigOption<Float> nr = nullRate.floatType().defaultValue(NULL_RATE_DEFAULT);
         return DataGeneratorContainer.of(
-                getRandomStringGenerator(config.get(lenOption)), lenOption);
+                getRandomStringGenerator(config.get(lenOption)).withNullRate(config.get(nr)),
+                lenOption,
+                nr);
     }
 
     @Override
@@ -135,8 +153,11 @@ public class RandomGeneratorVisitor extends DataGenVisitorBase {
                                 + DataGenConnectorOptionsUtil.LENGTH)
                         .intType()
                         .defaultValue(RANDOM_STRING_LENGTH_DEFAULT);
+        ConfigOption<Float> nr = nullRate.floatType().defaultValue(NULL_RATE_DEFAULT);
         return DataGeneratorContainer.of(
-                getRandomStringGenerator(config.get(lenOption)), lenOption);
+                getRandomStringGenerator(config.get(lenOption)).withNullRate(config.get(nr)),
+                lenOption,
+                nr);
     }
 
     @Override
@@ -169,109 +190,159 @@ public class RandomGeneratorVisitor extends DataGenVisitorBase {
     public DataGeneratorContainer visit(TinyIntType tinyIntType) {
         ConfigOption<Integer> min = minKey.intType().defaultValue((int) Byte.MIN_VALUE);
         ConfigOption<Integer> max = maxKey.intType().defaultValue((int) Byte.MAX_VALUE);
+        ConfigOption<Float> nr = nullRate.floatType().defaultValue(NULL_RATE_DEFAULT);
         return DataGeneratorContainer.of(
                 RandomGenerator.byteGenerator(
-                        config.get(min).byteValue(), config.get(max).byteValue()),
+                                config.get(min).byteValue(), config.get(max).byteValue())
+                        .withNullRate(config.get(nr)),
                 min,
-                max);
+                max,
+                nr);
     }
 
     @Override
     public DataGeneratorContainer visit(SmallIntType smallIntType) {
         ConfigOption<Integer> min = minKey.intType().defaultValue((int) Short.MIN_VALUE);
         ConfigOption<Integer> max = maxKey.intType().defaultValue((int) Short.MAX_VALUE);
+        ConfigOption<Float> nr = nullRate.floatType().defaultValue(NULL_RATE_DEFAULT);
         return DataGeneratorContainer.of(
                 RandomGenerator.shortGenerator(
-                        config.get(min).shortValue(), config.get(max).shortValue()),
+                                config.get(min).shortValue(), config.get(max).shortValue())
+                        .withNullRate(config.get(nr)),
                 min,
-                max);
+                max,
+                nr);
     }
 
     @Override
     public DataGeneratorContainer visit(IntType integerType) {
         ConfigOption<Integer> min = minKey.intType().defaultValue(Integer.MIN_VALUE);
         ConfigOption<Integer> max = maxKey.intType().defaultValue(Integer.MAX_VALUE);
+        ConfigOption<Float> nr = nullRate.floatType().defaultValue(NULL_RATE_DEFAULT);
         return DataGeneratorContainer.of(
-                RandomGenerator.intGenerator(config.get(min), config.get(max)), min, max);
+                RandomGenerator.intGenerator(config.get(min), config.get(max))
+                        .withNullRate(config.get(nr)),
+                min,
+                max,
+                nr);
     }
 
     @Override
     public DataGeneratorContainer visit(BigIntType bigIntType) {
         ConfigOption<Long> min = minKey.longType().defaultValue(Long.MIN_VALUE);
         ConfigOption<Long> max = maxKey.longType().defaultValue(Long.MAX_VALUE);
+        ConfigOption<Float> nr = nullRate.floatType().defaultValue(NULL_RATE_DEFAULT);
         return DataGeneratorContainer.of(
-                RandomGenerator.longGenerator(config.get(min), config.get(max)), min, max);
+                RandomGenerator.longGenerator(config.get(min), config.get(max))
+                        .withNullRate(config.get(nr)),
+                min,
+                max,
+                nr);
     }
 
     @Override
     public DataGeneratorContainer visit(FloatType floatType) {
         ConfigOption<Float> min = minKey.floatType().defaultValue(Float.MIN_VALUE);
         ConfigOption<Float> max = maxKey.floatType().defaultValue(Float.MAX_VALUE);
+        ConfigOption<Float> nr = nullRate.floatType().defaultValue(NULL_RATE_DEFAULT);
         return DataGeneratorContainer.of(
-                RandomGenerator.floatGenerator(config.get(min), config.get(max)), min, max);
+                RandomGenerator.floatGenerator(config.get(min), config.get(max))
+                        .withNullRate(config.get(nr)),
+                min,
+                max,
+                nr);
     }
 
     @Override
     public DataGeneratorContainer visit(DoubleType doubleType) {
         ConfigOption<Double> min = minKey.doubleType().defaultValue(Double.MIN_VALUE);
         ConfigOption<Double> max = maxKey.doubleType().defaultValue(Double.MAX_VALUE);
+        ConfigOption<Float> nr = nullRate.floatType().defaultValue(NULL_RATE_DEFAULT);
         return DataGeneratorContainer.of(
-                RandomGenerator.doubleGenerator(config.get(min), config.get(max)), min, max);
+                RandomGenerator.doubleGenerator(config.get(min), config.get(max))
+                        .withNullRate(config.get(nr)),
+                min,
+                max,
+                nr);
     }
 
     @Override
     public DataGeneratorContainer visit(DecimalType decimalType) {
         ConfigOption<Double> min = minKey.doubleType().defaultValue(Double.MIN_VALUE);
         ConfigOption<Double> max = maxKey.doubleType().defaultValue(Double.MAX_VALUE);
+        ConfigOption<Float> nr = nullRate.floatType().defaultValue(NULL_RATE_DEFAULT);
         return DataGeneratorContainer.of(
                 new DecimalDataRandomGenerator(
-                        decimalType.getPrecision(), decimalType.getScale(),
-                        config.get(min), config.get(max)),
+                        decimalType.getPrecision(),
+                        decimalType.getScale(),
+                        config.get(min),
+                        config.get(max),
+                        config.get(nr)),
                 min,
-                max);
+                max,
+                nr);
     }
 
     @Override
     public DataGeneratorContainer visit(YearMonthIntervalType yearMonthIntervalType) {
         ConfigOption<Integer> min = minKey.intType().defaultValue(0);
         ConfigOption<Integer> max = maxKey.intType().defaultValue(120000); // Period max
+        ConfigOption<Float> nr = nullRate.floatType().defaultValue(NULL_RATE_DEFAULT);
         return DataGeneratorContainer.of(
-                RandomGenerator.intGenerator(config.get(min), config.get(max)), min, max);
+                RandomGenerator.intGenerator(config.get(min), config.get(max))
+                        .withNullRate(config.get(nr)),
+                min,
+                max,
+                nr);
     }
 
     @Override
     public DataGeneratorContainer visit(DayTimeIntervalType dayTimeIntervalType) {
         ConfigOption<Long> min = minKey.longType().defaultValue(Long.MIN_VALUE);
         ConfigOption<Long> max = maxKey.longType().defaultValue(Long.MAX_VALUE);
+        ConfigOption<Float> nr = nullRate.floatType().defaultValue(NULL_RATE_DEFAULT);
         return DataGeneratorContainer.of(
-                RandomGenerator.longGenerator(config.get(min), config.get(max)), min, max);
+                RandomGenerator.longGenerator(config.get(min), config.get(max))
+                        .withNullRate(config.get(nr)),
+                min,
+                max,
+                nr);
     }
 
     @Override
     public DataGeneratorContainer visit(TimestampType timestampType) {
         ConfigOption<Duration> maxPastOption =
                 maxPastKey.durationType().defaultValue(Duration.ZERO);
-
+        ConfigOption<Float> nr = nullRate.floatType().defaultValue(NULL_RATE_DEFAULT);
         return DataGeneratorContainer.of(
-                getRandomPastTimestampGenerator(config.get(maxPastOption)), maxPastOption);
+                getRandomPastTimestampGenerator(config.get(maxPastOption))
+                        .withNullRate(config.get(nr)),
+                maxPastOption,
+                nr);
     }
 
     @Override
     public DataGeneratorContainer visit(ZonedTimestampType zonedTimestampType) {
         ConfigOption<Duration> maxPastOption =
                 maxPastKey.durationType().defaultValue(Duration.ZERO);
-
+        ConfigOption<Float> nr = nullRate.floatType().defaultValue(NULL_RATE_DEFAULT);
         return DataGeneratorContainer.of(
-                getRandomPastTimestampGenerator(config.get(maxPastOption)), maxPastOption);
+                getRandomPastTimestampGenerator(config.get(maxPastOption))
+                        .withNullRate(config.get(nr)),
+                maxPastOption,
+                nr);
     }
 
     @Override
     public DataGeneratorContainer visit(LocalZonedTimestampType localZonedTimestampType) {
         ConfigOption<Duration> maxPastOption =
                 maxPastKey.durationType().defaultValue(Duration.ZERO);
-
+        ConfigOption<Float> nr = nullRate.floatType().defaultValue(NULL_RATE_DEFAULT);
         return DataGeneratorContainer.of(
-                getRandomPastTimestampGenerator(config.get(maxPastOption)), maxPastOption);
+                getRandomPastTimestampGenerator(config.get(maxPastOption))
+                        .withNullRate(config.get(nr)),
+                maxPastOption,
+                nr);
     }
 
     @Override
@@ -288,12 +359,14 @@ public class RandomGeneratorVisitor extends DataGenVisitorBase {
         String fieldName = name + "." + "element";
         DataGeneratorContainer container =
                 arrayType.getElementType().accept(new RandomGeneratorVisitor(fieldName, config));
-
+        ConfigOption<Float> nr = nullRate.floatType().defaultValue(NULL_RATE_DEFAULT);
         DataGenerator<Object[]> generator =
                 RandomGenerator.arrayGenerator(container.getGenerator(), config.get(lenOption));
+        Set<ConfigOption<?>> options = container.getOptions();
+        options.add(nr);
         return DataGeneratorContainer.of(
-                new DataGeneratorMapper<>(generator, (GenericArrayData::new)),
-                container.getOptions().toArray(new ConfigOption<?>[0]));
+                new DataGeneratorMapper<>(generator, (GenericArrayData::new), config.get(nr)),
+                options.toArray(new ConfigOption<?>[0]));
     }
 
     @Override
@@ -317,9 +390,13 @@ public class RandomGeneratorVisitor extends DataGenVisitorBase {
                         RandomGenerator.intGenerator(0, 10),
                         config.get(lenOption));
 
+        Set<ConfigOption<?>> options = container.getOptions();
+        ConfigOption<Float> nr = nullRate.floatType().defaultValue(NULL_RATE_DEFAULT);
+        options.add(nr);
+
         return DataGeneratorContainer.of(
-                new DataGeneratorMapper<>(mapGenerator, GenericMapData::new),
-                container.getOptions().toArray(new ConfigOption<?>[0]));
+                new DataGeneratorMapper<>(mapGenerator, GenericMapData::new, config.get(nr)),
+                options.toArray(new ConfigOption<?>[0]));
     }
 
     @Override
@@ -342,8 +419,10 @@ public class RandomGeneratorVisitor extends DataGenVisitorBase {
         DataGeneratorContainer valContainer =
                 mapType.getValueType().accept(new RandomGeneratorVisitor(valName, config));
 
+        ConfigOption<Float> nr = nullRate.floatType().defaultValue(NULL_RATE_DEFAULT);
         Set<ConfigOption<?>> options = keyContainer.getOptions();
         options.addAll(valContainer.getOptions());
+        options.add(nr);
 
         DataGenerator<Map<Object, Object>> mapGenerator =
                 RandomGenerator.mapGenerator(
@@ -352,7 +431,7 @@ public class RandomGeneratorVisitor extends DataGenVisitorBase {
                         config.get(lenOption));
 
         return DataGeneratorContainer.of(
-                new DataGeneratorMapper<>(mapGenerator, GenericMapData::new),
+                new DataGeneratorMapper<>(mapGenerator, GenericMapData::new, config.get(nr)),
                 options.toArray(new ConfigOption<?>[0]));
     }
 
@@ -368,10 +447,13 @@ public class RandomGeneratorVisitor extends DataGenVisitorBase {
                                 })
                         .collect(Collectors.toList());
 
-        ConfigOption<?>[] options =
+        List<ConfigOption<?>> fieldOptions =
                 fieldContainers.stream()
                         .flatMap(container -> container.getOptions().stream())
-                        .toArray(ConfigOption[]::new);
+                        .collect(Collectors.toList());
+
+        ConfigOption<Float> nr = nullRate.floatType().defaultValue(NULL_RATE_DEFAULT);
+        fieldOptions.add(nr);
 
         DataGenerator[] generators =
                 fieldContainers.stream()
@@ -379,7 +461,8 @@ public class RandomGeneratorVisitor extends DataGenVisitorBase {
                         .toArray(DataGenerator[]::new);
 
         return DataGeneratorContainer.of(
-                new RowDataGenerator(generators, rowType.getFieldNames()), options);
+                new RowDataGenerator(generators, rowType.getFieldNames(), config.get(nr)),
+                fieldOptions.toArray(new ConfigOption[0]));
     }
 
     @Override
@@ -391,7 +474,11 @@ public class RandomGeneratorVisitor extends DataGenVisitorBase {
         return new RandomGenerator<StringData>() {
             @Override
             public StringData next() {
-                return StringData.fromString(random.nextHexString(length));
+                if (nullRate == NULL_RATE_DEFAULT
+                        || ThreadLocalRandom.current().nextFloat() > nullRate) {
+                    return StringData.fromString(random.nextHexString(length));
+                }
+                return null;
             }
         };
     }
@@ -401,9 +488,13 @@ public class RandomGeneratorVisitor extends DataGenVisitorBase {
         return new RandomGenerator<TimestampData>() {
             @Override
             public TimestampData next() {
-                long maxPastMillis = maxPast.toMillis();
-                long past = maxPastMillis > 0 ? random.nextLong(0, maxPastMillis) : 0;
-                return TimestampData.fromEpochMillis(System.currentTimeMillis() - past);
+                if (nullRate == NULL_RATE_DEFAULT
+                        || ThreadLocalRandom.current().nextFloat() > nullRate) {
+                    long maxPastMillis = maxPast.toMillis();
+                    long past = maxPastMillis > 0 ? random.nextLong(0, maxPastMillis) : 0;
+                    return TimestampData.fromEpochMillis(System.currentTimeMillis() - past);
+                }
+                return null;
             }
         };
     }

--- a/flink-table/flink-table-api-java-bridge/src/main/java/org/apache/flink/connector/datagen/table/types/DecimalDataRandomGenerator.java
+++ b/flink-table/flink-table-api-java-bridge/src/main/java/org/apache/flink/connector/datagen/table/types/DecimalDataRandomGenerator.java
@@ -42,7 +42,10 @@ public class DecimalDataRandomGenerator implements DataGenerator<DecimalData> {
 
     private final double max;
 
-    public DecimalDataRandomGenerator(int precision, int scale, double min, double max) {
+    private final float nullRate;
+
+    public DecimalDataRandomGenerator(
+            int precision, int scale, double min, double max, float nullRate) {
         Preconditions.checkState(
                 min < max, String.format("min bound must be less than max [%f, %f]", min, max));
         double largest = Math.pow(10, precision - scale) - Math.pow(10, -scale);
@@ -50,6 +53,7 @@ public class DecimalDataRandomGenerator implements DataGenerator<DecimalData> {
         this.scale = scale;
         this.min = Math.max(-1 * largest, min);
         this.max = Math.min(largest, max);
+        this.nullRate = nullRate;
     }
 
     @Override
@@ -64,10 +68,13 @@ public class DecimalDataRandomGenerator implements DataGenerator<DecimalData> {
 
     @Override
     public DecimalData next() {
-        BigDecimal decimal =
-                new BigDecimal(
-                        ThreadLocalRandom.current().nextDouble(min, max),
-                        new MathContext(precision, RoundingMode.DOWN));
-        return DecimalData.fromBigDecimal(decimal, precision, scale);
+        if (nullRate == 0f || ThreadLocalRandom.current().nextFloat() > nullRate) {
+            BigDecimal decimal =
+                    new BigDecimal(
+                            ThreadLocalRandom.current().nextDouble(min, max),
+                            new MathContext(precision, RoundingMode.DOWN));
+            return DecimalData.fromBigDecimal(decimal, precision, scale);
+        }
+        return null;
     }
 }

--- a/flink-table/flink-table-api-java-bridge/src/test/java/org/apache/flink/connector/datagen/table/types/DecimalDataRandomGeneratorTest.java
+++ b/flink-table/flink-table-api-java-bridge/src/test/java/org/apache/flink/connector/datagen/table/types/DecimalDataRandomGeneratorTest.java
@@ -35,7 +35,7 @@ class DecimalDataRandomGeneratorTest {
             for (int scale = 0; scale <= precision; scale++) {
                 DecimalDataRandomGenerator gen =
                         new DecimalDataRandomGenerator(
-                                precision, scale, Double.MIN_VALUE, Double.MAX_VALUE);
+                                precision, scale, Double.MIN_VALUE, Double.MAX_VALUE, 0f);
 
                 DecimalData value = gen.next();
                 assertThat(value)
@@ -50,7 +50,7 @@ class DecimalDataRandomGeneratorTest {
 
                 if (scale != precision) {
                     // need to account for decimal . and potential leading zeros
-                    assertThat(strRepr.length())
+                    assertThat(strRepr)
                             .as(
                                     "Wrong length for DECIMAL("
                                             + precision
@@ -58,10 +58,10 @@ class DecimalDataRandomGeneratorTest {
                                             + scale
                                             + ") = "
                                             + strRepr)
-                            .isLessThanOrEqualTo(precision + 1);
+                            .hasSizeLessThanOrEqualTo(precision + 1);
                 } else {
                     // need to account for decimal . and potential leading zeros
-                    assertThat(strRepr.length())
+                    assertThat(strRepr)
                             .as(
                                     "Wrong length for DECIMAL("
                                             + precision
@@ -69,11 +69,11 @@ class DecimalDataRandomGeneratorTest {
                                             + scale
                                             + ") = "
                                             + strRepr)
-                            .isLessThanOrEqualTo(precision + 2);
+                            .hasSizeLessThanOrEqualTo(precision + 2);
                 }
                 if (scale != 0) {
                     String decimalPart = strRepr.split("\\.")[1];
-                    assertThat(decimalPart.length())
+                    assertThat(decimalPart)
                             .as(
                                     "Wrong length for DECIMAL("
                                             + precision
@@ -81,7 +81,7 @@ class DecimalDataRandomGeneratorTest {
                                             + scale
                                             + ") = "
                                             + strRepr)
-                            .isEqualTo(scale);
+                            .hasSize(scale);
                 }
             }
         }
@@ -96,7 +96,7 @@ class DecimalDataRandomGeneratorTest {
 
                 DecimalDataRandomGenerator gen =
                         new DecimalDataRandomGenerator(
-                                precision, scale, min.doubleValue(), max.doubleValue());
+                                precision, scale, min.doubleValue(), max.doubleValue(), 0f);
                 DecimalData result = gen.next();
 
                 assertThat(result)
@@ -104,8 +104,7 @@ class DecimalDataRandomGeneratorTest {
                         .isNotNull();
                 assertThat(result.toBigDecimal())
                         .as("value must be greater than or equal to min")
-                        .isGreaterThanOrEqualTo(min);
-                assertThat(result.toBigDecimal())
+                        .isGreaterThanOrEqualTo(min)
                         .as("value must be less than or equal to max")
                         .isLessThanOrEqualTo(max);
             }


### PR DESCRIPTION
## What is the purpose of the change

The PR allows to specify the proportion of null values to generate with DataGen per field,
like 
```sql
CREATE TABLE Orders (
    order_number STRING,
    price        DECIMAL(32,2),
    buyer        ROW<id INT, last_name STRING>,
    order_time   TIMESTAMP(3),
    my_map       MAP<INT,STRING>,
    my_array     ARRAY<STRING>
) WITH (
   'connector' = 'datagen',
   'fields.order_number.null-rate' = '0.7',
   'fields.price.null-rate' = '1.0',
   'fields.order_time.null-rate' = '0.5',
   'fields.buyer.id.null-rate' = '0.5',
   'fields.buyer.null-rate' = '0.5',
   'fields.my_map.key.null-rate' = '0.5',
   'fields.my_map.null-rate' = '0.5',
   'fields.my_array.element.null-rate' = '0.1',
   'fields.my_array.null-rate' = '0.5'
);
```

## Verifying this change

There have been added test cases to 
_flink-table/flink-table-api-java-bridge/src/test/java/org/apache/flink/connector/datagen/table/types/DecimalDataRandomGeneratorTest.java_ 

## Does this pull request potentially affect one of the following parts:

  - Dependencies (does it add or upgrade a dependency): (no)
  - The public API, i.e., is any changed class annotated with `@Public(Evolving)`: (no)
  - The serializers: (no)
  - The runtime per-record code paths (performance sensitive): (no)
  - Anything that affects deployment or recovery: JobManager (and its components), Checkpointing, Kubernetes/Yarn, ZooKeeper: (no)
  - The S3 file system connector: (no)

## Documentation

  - Does this pull request introduce a new feature? (yes)
  - If yes, how is the feature documented? (docs)
