### PR TITLE
[FLINK-25310][Documentation] Fix the incorrect description for output network buffers in buffer debloat documenation

### DIFF
--- a/docs/content/docs/deployment/memory/network_mem_tuning.md
+++ b/docs/content/docs/deployment/memory/network_mem_tuning.md
@@ -114,7 +114,7 @@ Unlike the input buffer pool, the output buffer pool has only one type of buffer
 
 In order to avoid excessive data skew, the number of buffers for each subpartition is limited by the `taskmanager.network.memory.max-buffers-per-channel` setting.
 
-Like the input buffer pool, the configured amount of exclusive buffers and floating buffers is only treated as recommended values. If there are not enough buffers available, Flink can make progress with only a single exclusive buffer per output subpartition and zero floating buffers.
+Unlike the input buffer pool, the configured amount of exclusive buffers and floating buffers is only treated as recommended values. If there are not enough buffers available, Flink can make progress with only a single exclusive buffer per output subpartition and zero floating buffers.
 
 ## The number of in-flight buffers 
 


### PR DESCRIPTION
## What is the purpose of the change

*Change the desc "Like the input buffer pool, the configured amount of exclusive buffers and floating buffers is only treated as recommended values." to "Unlike the input buffer pool, the configured amount of exclusive buffers and floating buffers is only treated as recommended values."*


## Brief change log

  - *Change the word like to unlike to fix the mistake.*


## Verifying this change

This change is a trivial rework / code cleanup without any test coverage.


## Does this pull request potentially affect one of the following parts:

  - Dependencies (does it add or upgrade a dependency): (no)
  - The public API, i.e., is any changed class annotated with `@Public(Evolving)`: (no)
  - The serializers: (no)
  - The runtime per-record code paths (performance sensitive): (no)
  - Anything that affects deployment or recovery: JobManager (and its components), Checkpointing, Kubernetes/Yarn, ZooKeeper: (no)
  - The S3 file system connector: (no)

## Documentation

  - Does this pull request introduce a new feature? (no)
