### PR TITLE
[FLINK-25305][checkpoint] Always wait for input channel state and result partition state get completed in AsyncRunnable

### DIFF
--- a/flink-streaming-java/src/main/java/org/apache/flink/streaming/runtime/tasks/AsyncCheckpointRunnable.java
+++ b/flink-streaming-java/src/main/java/org/apache/flink/streaming/runtime/tasks/AsyncCheckpointRunnable.java
@@ -119,10 +119,7 @@ final class AsyncCheckpointRunnable implements Runnable, Closeable {
 
             SnapshotsFinalizeResult snapshotsFinalizeResult =
                     isTaskDeployedAsFinished
-                            ? new SnapshotsFinalizeResult(
-                                    TaskStateSnapshot.FINISHED_ON_RESTORE,
-                                    TaskStateSnapshot.FINISHED_ON_RESTORE,
-                                    0L)
+                            ? finalizedFinishedSnapshots()
                             : finalizeNonFinishedSnapshots();
 
             final long asyncEndNanos = System.nanoTime();
@@ -160,6 +157,20 @@ final class AsyncCheckpointRunnable implements Runnable, Closeable {
             unregisterConsumer.accept(this);
             FileSystemSafetyNet.closeSafetyNetAndGuardedResourcesForThread();
         }
+    }
+
+    private SnapshotsFinalizeResult finalizedFinishedSnapshots() throws Exception {
+        for (Map.Entry<OperatorID, OperatorSnapshotFutures> entry :
+                operatorSnapshotsInProgress.entrySet()) {
+            OperatorSnapshotFutures snapshotInProgress = entry.getValue();
+            // We should wait for the channels states get completed before continuing,
+            // otherwise the alignment of barriers might have not finished yet.
+            snapshotInProgress.getInputChannelStateFuture().get();
+            snapshotInProgress.getResultSubpartitionStateFuture().get();
+        }
+
+        return new SnapshotsFinalizeResult(
+                TaskStateSnapshot.FINISHED_ON_RESTORE, TaskStateSnapshot.FINISHED_ON_RESTORE, 0L);
     }
 
     private SnapshotsFinalizeResult finalizeNonFinishedSnapshots() throws Exception {

--- a/flink-streaming-java/src/main/java/org/apache/flink/streaming/runtime/tasks/FinishedOperatorChain.java
+++ b/flink-streaming-java/src/main/java/org/apache/flink/streaming/runtime/tasks/FinishedOperatorChain.java
@@ -20,6 +20,7 @@ package org.apache.flink.streaming.runtime.tasks;
 import org.apache.flink.annotation.Internal;
 import org.apache.flink.runtime.checkpoint.CheckpointMetaData;
 import org.apache.flink.runtime.checkpoint.CheckpointOptions;
+import org.apache.flink.runtime.checkpoint.StateObjectCollection;
 import org.apache.flink.runtime.checkpoint.channel.ChannelStateWriter;
 import org.apache.flink.runtime.io.network.api.StopMode;
 import org.apache.flink.runtime.io.network.api.writer.RecordWriterDelegate;
@@ -27,6 +28,7 @@ import org.apache.flink.runtime.jobgraph.OperatorID;
 import org.apache.flink.runtime.operators.coordination.OperatorEvent;
 import org.apache.flink.runtime.plugable.SerializationDelegate;
 import org.apache.flink.runtime.state.CheckpointStreamFactory;
+import org.apache.flink.runtime.state.SnapshotResult;
 import org.apache.flink.runtime.state.TaskStateManager;
 import org.apache.flink.streaming.api.operators.OperatorSnapshotFutures;
 import org.apache.flink.streaming.api.operators.StreamOperator;
@@ -99,5 +101,29 @@ public class FinishedOperatorChain<OUT, OP extends StreamOperator<OUT>>
             Supplier<Boolean> isRunning,
             ChannelStateWriter.ChannelStateWriteResult channelStateWriteResult,
             CheckpointStreamFactory storage)
-            throws Exception {}
+            throws Exception {
+        for (StreamOperatorWrapper<?, ?> operatorWrapper : getAllOperators(true)) {
+            StreamOperator<?> operator = operatorWrapper.getStreamOperator();
+
+            if (operator == getMainOperator() || operator == getTailOperator()) {
+                OperatorSnapshotFutures snapshotInProgress = new OperatorSnapshotFutures();
+                if (operator == getMainOperator()) {
+                    snapshotInProgress.setInputChannelStateFuture(
+                            channelStateWriteResult
+                                    .getInputChannelStateHandles()
+                                    .thenApply(StateObjectCollection::new)
+                                    .thenApply(SnapshotResult::of));
+                }
+                if (operator == getTailOperator()) {
+                    snapshotInProgress.setResultSubpartitionStateFuture(
+                            channelStateWriteResult
+                                    .getResultSubpartitionStateHandles()
+                                    .thenApply(StateObjectCollection::new)
+                                    .thenApply(SnapshotResult::of));
+                }
+                operatorSnapshotsInProgress.put(
+                        operatorWrapper.getStreamOperator().getOperatorID(), snapshotInProgress);
+            }
+        }
+    }
 }

--- a/flink-streaming-java/src/main/java/org/apache/flink/streaming/runtime/tasks/OperatorChain.java
+++ b/flink-streaming-java/src/main/java/org/apache/flink/streaming/runtime/tasks/OperatorChain.java
@@ -427,6 +427,11 @@ public abstract class OperatorChain<OUT, OP extends StreamOperator<OUT>>
         return (mainOperatorWrapper == null) ? null : mainOperatorWrapper.getStreamOperator();
     }
 
+    @Nullable
+    protected StreamOperator<?> getTailOperator() {
+        return (tailOperatorWrapper == null) ? null : tailOperatorWrapper.getStreamOperator();
+    }
+
     public boolean isClosed() {
         return isClosed;
     }

--- a/flink-streaming-java/src/main/java/org/apache/flink/streaming/runtime/tasks/OperatorChain.java
+++ b/flink-streaming-java/src/main/java/org/apache/flink/streaming/runtime/tasks/OperatorChain.java
@@ -24,6 +24,7 @@ import org.apache.flink.api.java.tuple.Tuple2;
 import org.apache.flink.metrics.groups.OperatorMetricGroup;
 import org.apache.flink.runtime.checkpoint.CheckpointMetaData;
 import org.apache.flink.runtime.checkpoint.CheckpointOptions;
+import org.apache.flink.runtime.checkpoint.StateObjectCollection;
 import org.apache.flink.runtime.checkpoint.channel.ChannelStateWriter;
 import org.apache.flink.runtime.event.AbstractEvent;
 import org.apache.flink.runtime.execution.Environment;
@@ -37,6 +38,7 @@ import org.apache.flink.runtime.operators.coordination.OperatorEvent;
 import org.apache.flink.runtime.operators.coordination.OperatorEventDispatcher;
 import org.apache.flink.runtime.plugable.SerializationDelegate;
 import org.apache.flink.runtime.state.CheckpointStreamFactory;
+import org.apache.flink.runtime.state.SnapshotResult;
 import org.apache.flink.streaming.api.graph.StreamConfig;
 import org.apache.flink.streaming.api.graph.StreamEdge;
 import org.apache.flink.streaming.api.operators.BoundedMultiInput;
@@ -430,6 +432,26 @@ public abstract class OperatorChain<OUT, OP extends StreamOperator<OUT>>
     @Nullable
     protected StreamOperator<?> getTailOperator() {
         return (tailOperatorWrapper == null) ? null : tailOperatorWrapper.getStreamOperator();
+    }
+
+    protected void snapshotChannelStates(
+            StreamOperator<?> op,
+            ChannelStateWriter.ChannelStateWriteResult channelStateWriteResult,
+            OperatorSnapshotFutures snapshotInProgress) {
+        if (op == getMainOperator()) {
+            snapshotInProgress.setInputChannelStateFuture(
+                    channelStateWriteResult
+                            .getInputChannelStateHandles()
+                            .thenApply(StateObjectCollection::new)
+                            .thenApply(SnapshotResult::of));
+        }
+        if (op == getTailOperator()) {
+            snapshotInProgress.setResultSubpartitionStateFuture(
+                    channelStateWriteResult
+                            .getResultSubpartitionStateHandles()
+                            .thenApply(StateObjectCollection::new)
+                            .thenApply(SnapshotResult::of));
+        }
     }
 
     public boolean isClosed() {

--- a/flink-streaming-java/src/main/java/org/apache/flink/streaming/runtime/tasks/RegularOperatorChain.java
+++ b/flink-streaming-java/src/main/java/org/apache/flink/streaming/runtime/tasks/RegularOperatorChain.java
@@ -21,7 +21,6 @@ import org.apache.flink.annotation.Internal;
 import org.apache.flink.annotation.VisibleForTesting;
 import org.apache.flink.runtime.checkpoint.CheckpointMetaData;
 import org.apache.flink.runtime.checkpoint.CheckpointOptions;
-import org.apache.flink.runtime.checkpoint.StateObjectCollection;
 import org.apache.flink.runtime.checkpoint.channel.ChannelStateWriter;
 import org.apache.flink.runtime.io.network.api.StopMode;
 import org.apache.flink.runtime.io.network.api.writer.RecordWriterDelegate;
@@ -29,7 +28,6 @@ import org.apache.flink.runtime.jobgraph.OperatorID;
 import org.apache.flink.runtime.operators.coordination.OperatorEvent;
 import org.apache.flink.runtime.plugable.SerializationDelegate;
 import org.apache.flink.runtime.state.CheckpointStreamFactory;
-import org.apache.flink.runtime.state.SnapshotResult;
 import org.apache.flink.streaming.api.operators.OperatorSnapshotFutures;
 import org.apache.flink.streaming.api.operators.StreamOperator;
 import org.apache.flink.streaming.api.operators.StreamTaskStateInitializer;
@@ -200,20 +198,8 @@ public class RegularOperatorChain<OUT, OP extends StreamOperator<OUT>>
         OperatorSnapshotFutures snapshotInProgress =
                 checkpointStreamOperator(
                         op, checkpointMetaData, checkpointOptions, storage, isRunning);
-        if (op == getMainOperator()) {
-            snapshotInProgress.setInputChannelStateFuture(
-                    channelStateWriteResult
-                            .getInputChannelStateHandles()
-                            .thenApply(StateObjectCollection::new)
-                            .thenApply(SnapshotResult::of));
-        }
-        if (op == getTailOperator()) {
-            snapshotInProgress.setResultSubpartitionStateFuture(
-                    channelStateWriteResult
-                            .getResultSubpartitionStateHandles()
-                            .thenApply(StateObjectCollection::new)
-                            .thenApply(SnapshotResult::of));
-        }
+        snapshotChannelStates(op, channelStateWriteResult, snapshotInProgress);
+
         return snapshotInProgress;
     }
 

--- a/flink-streaming-java/src/main/java/org/apache/flink/streaming/runtime/tasks/RegularOperatorChain.java
+++ b/flink-streaming-java/src/main/java/org/apache/flink/streaming/runtime/tasks/RegularOperatorChain.java
@@ -42,8 +42,6 @@ import org.apache.flink.util.SerializedValue;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
-import javax.annotation.Nullable;
-
 import java.io.IOException;
 import java.util.List;
 import java.util.Map;
@@ -139,11 +137,6 @@ public class RegularOperatorChain<OUT, OP extends StreamOperator<OUT>>
     @Override
     public void close() throws IOException {
         super.close();
-    }
-
-    @Nullable
-    StreamOperator<?> getTailOperator() {
-        return (tailOperatorWrapper == null) ? null : tailOperatorWrapper.getStreamOperator();
     }
 
     @Override

--- a/flink-streaming-java/src/test/java/org/apache/flink/streaming/runtime/tasks/TestFinishedOnRestoreStreamOperator.java
+++ b/flink-streaming-java/src/test/java/org/apache/flink/streaming/runtime/tasks/TestFinishedOnRestoreStreamOperator.java
@@ -45,6 +45,16 @@ public class TestFinishedOnRestoreStreamOperator
 
     protected static final String MESSAGE = "This should never be called";
 
+    private final OperatorID operatorId;
+
+    public TestFinishedOnRestoreStreamOperator() {
+        this.operatorId = new OperatorID();
+    }
+
+    public TestFinishedOnRestoreStreamOperator(OperatorID operatorId) {
+        this.operatorId = operatorId;
+    }
+
     @Override
     public void open() {
         throw new IllegalStateException(MESSAGE);
@@ -122,7 +132,7 @@ public class TestFinishedOnRestoreStreamOperator
 
     @Override
     public OperatorID getOperatorID() {
-        throw new IllegalStateException(MESSAGE);
+        return operatorId;
     }
 
     @Override


### PR DESCRIPTION
## What is the purpose of the change

This PR fixes the issue that when a task finished on restore taking unaligned checkpoints, currently the asynchronous part does not wait till the alignment of barriers get finished, thus throws exception due to some metrics are not set yet. 

## Brief change log

- 6bb8f5418b1dcd085b16a00f1370a88262d3e4a9 also keeps the channel states for operators finished on restore, and wait for these states get completed explicitly in the asynchronous part.


## Verifying this change

This change added tests and can be verified by the added unit test.

## Does this pull request potentially affect one of the following parts:

  - Dependencies (does it add or upgrade a dependency): **no**
  - The public API, i.e., is any changed class annotated with `@Public(Evolving)`: **no**
  - The serializers: **no**
  - The runtime per-record code paths (performance sensitive): **no**
  - Anything that affects deployment or recovery: JobManager (and its components), Checkpointing, Kubernetes/Yarn, ZooKeeper: **yes**
  - The S3 file system connector: **no**

## Documentation

  - Does this pull request introduce a new feature? **no**
  - If yes, how is the feature documented? **not applicable**
