### PR TITLE
[FLINK-25315][tests] add new extensions and utils to help the Junit5 migration

### DIFF
--- a/flink-test-utils-parent/flink-test-utils-junit/src/main/java/org/apache/flink/testutils/junit/extensions/parameterized/Parameter.java
+++ b/flink-test-utils-parent/flink-test-utils-junit/src/main/java/org/apache/flink/testutils/junit/extensions/parameterized/Parameter.java
@@ -1,0 +1,36 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.flink.testutils.junit.extensions.parameterized;
+
+import org.junit.runners.Parameterized;
+
+import java.lang.annotation.ElementType;
+import java.lang.annotation.Retention;
+import java.lang.annotation.RetentionPolicy;
+import java.lang.annotation.Target;
+
+/**
+ * The annotation is used to replace {@link Parameterized.Parameter} for Junit 5 parameterized
+ * tests.
+ */
+@Target(ElementType.FIELD)
+@Retention(RetentionPolicy.RUNTIME)
+public @interface Parameter {
+    int value() default 0;
+}

--- a/flink-test-utils-parent/flink-test-utils-junit/src/main/java/org/apache/flink/testutils/junit/extensions/parameterized/ParameterizedTestExtension.java
+++ b/flink-test-utils-parent/flink-test-utils-junit/src/main/java/org/apache/flink/testutils/junit/extensions/parameterized/ParameterizedTestExtension.java
@@ -1,0 +1,250 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.flink.testutils.junit.extensions.parameterized;
+
+import org.junit.jupiter.api.TestTemplate;
+import org.junit.jupiter.api.extension.BeforeEachCallback;
+import org.junit.jupiter.api.extension.Extension;
+import org.junit.jupiter.api.extension.ExtensionContext;
+import org.junit.jupiter.api.extension.ParameterContext;
+import org.junit.jupiter.api.extension.ParameterResolutionException;
+import org.junit.jupiter.api.extension.ParameterResolver;
+import org.junit.jupiter.api.extension.TestTemplateInvocationContext;
+import org.junit.jupiter.api.extension.TestTemplateInvocationContextProvider;
+import org.junit.platform.commons.support.AnnotationSupport;
+import org.junit.platform.commons.support.HierarchyTraversalMode;
+import org.junit.runners.Parameterized;
+
+import java.lang.reflect.Field;
+import java.lang.reflect.Method;
+import java.text.MessageFormat;
+import java.util.Arrays;
+import java.util.Collection;
+import java.util.Collections;
+import java.util.List;
+import java.util.function.Function;
+import java.util.stream.Stream;
+
+/**
+ * This extension is used to implement parameterized tests for Junit 5 to replace {@link
+ * Parameterized}.
+ *
+ * <p>When use this extension, all tests must be annotated by {@link TestTemplate}.
+ */
+public class ParameterizedTestExtension implements TestTemplateInvocationContextProvider {
+
+    private static final ExtensionContext.Namespace NAMESPACE =
+            ExtensionContext.Namespace.create("parameterized");
+    private static final String PARAMETERS_STORE_KEY = "parameters";
+    private static final String PARAMETER_FIELD_STORE_KEY_PREFIX = "parameterField_";
+
+    @Override
+    public boolean supportsTestTemplate(ExtensionContext context) {
+        return true;
+    }
+
+    @Override
+    public Stream<TestTemplateInvocationContext> provideTestTemplateInvocationContexts(
+            ExtensionContext context) {
+
+        // Search method annotated with @Parameters
+        final List<Method> parameterProviders =
+                AnnotationSupport.findAnnotatedMethods(
+                        context.getRequiredTestClass(),
+                        Parameters.class,
+                        HierarchyTraversalMode.TOP_DOWN);
+        if (parameterProviders.isEmpty()) {
+            throw new IllegalStateException("Cannot find any parameter provider");
+        }
+        if (parameterProviders.size() > 1) {
+            throw new IllegalStateException("Multiple parameter providers are found");
+        }
+
+        // Get potential test name
+        String testNameTemplate = parameterProviders.get(0).getAnnotation(Parameters.class).name();
+
+        // Get parameter values
+        final Object parameterValues;
+        try {
+            parameterValues = parameterProviders.get(0).invoke(null);
+            context.getStore(NAMESPACE).put(PARAMETERS_STORE_KEY, parameterValues);
+        } catch (Exception e) {
+            throw new IllegalStateException("Failed to invoke parameter provider", e);
+        }
+        assert parameterValues != null;
+
+        // Parameter values could be Object[][]
+        if (parameterValues instanceof Object[][]) {
+            Object[][] typedParameterValues = (Object[][]) parameterValues;
+            return createContextForParameters(
+                    Arrays.stream(typedParameterValues), testNameTemplate, context);
+        }
+
+        // or a Collection
+        if (parameterValues instanceof Collection) {
+            final Collection<?> typedParameterValues = (Collection<?>) parameterValues;
+            final Stream<Object[]> parameterValueStream =
+                    typedParameterValues.stream()
+                            .map(
+                                    (Function<Object, Object[]>)
+                                            parameterValue -> {
+                                                if (parameterValue instanceof Object[]) {
+                                                    return (Object[]) parameterValue;
+                                                } else {
+                                                    return new Object[] {parameterValue};
+                                                }
+                                            });
+            return createContextForParameters(parameterValueStream, testNameTemplate, context);
+        }
+
+        throw new IllegalStateException(
+                String.format(
+                        "Return type of @Parameters annotated method \"%s\" should be either Object[][] or Collection",
+                        parameterProviders.get(0)));
+    }
+
+    private static class FieldInjectingInvocationContext implements TestTemplateInvocationContext {
+
+        private final String testNameTemplate;
+        private final Object[] parameterValues;
+
+        public FieldInjectingInvocationContext(String testNameTemplate, Object[] parameterValues) {
+            this.testNameTemplate = testNameTemplate;
+            this.parameterValues = parameterValues;
+        }
+
+        @Override
+        public String getDisplayName(int invocationIndex) {
+            if (testNameTemplate.equals("{index}")) {
+                return TestTemplateInvocationContext.super.getDisplayName(invocationIndex);
+            } else {
+                return MessageFormat.format(testNameTemplate, parameterValues);
+            }
+        }
+
+        @Override
+        public List<Extension> getAdditionalExtensions() {
+            return Collections.singletonList(new FieldInjectingHook(parameterValues));
+        }
+
+        private static class FieldInjectingHook implements BeforeEachCallback {
+
+            private final Object[] parameterValues;
+
+            public FieldInjectingHook(Object[] parameterValues) {
+                this.parameterValues = parameterValues;
+            }
+
+            @Override
+            public void beforeEach(ExtensionContext context) throws Exception {
+                for (int i = 0; i < parameterValues.length; i++) {
+                    getParameterField(i, context)
+                            .set(context.getRequiredTestInstance(), parameterValues[i]);
+                }
+            }
+        }
+    }
+
+    private static class ConstructorParameterResolverInvocationContext
+            implements TestTemplateInvocationContext {
+
+        private final String testNameTemplate;
+        private final Object[] parameterValues;
+
+        public ConstructorParameterResolverInvocationContext(
+                String testNameTemplate, Object[] parameterValues) {
+            this.testNameTemplate = testNameTemplate;
+            this.parameterValues = parameterValues;
+        }
+
+        @Override
+        public String getDisplayName(int invocationIndex) {
+            if (testNameTemplate.equals("{index}")) {
+                return TestTemplateInvocationContext.super.getDisplayName(invocationIndex);
+            } else {
+                return MessageFormat.format(testNameTemplate, parameterValues);
+            }
+        }
+
+        @Override
+        public List<Extension> getAdditionalExtensions() {
+            return Collections.singletonList(new ConstructorParameterResolver(parameterValues));
+        }
+
+        private static class ConstructorParameterResolver implements ParameterResolver {
+
+            private final Object[] parameterValues;
+
+            public ConstructorParameterResolver(Object[] parameterValues) {
+                this.parameterValues = parameterValues;
+            }
+
+            @Override
+            public boolean supportsParameter(
+                    ParameterContext parameterContext, ExtensionContext extensionContext)
+                    throws ParameterResolutionException {
+                return true;
+            }
+
+            @Override
+            public Object resolveParameter(
+                    ParameterContext parameterContext, ExtensionContext extensionContext)
+                    throws ParameterResolutionException {
+                return parameterValues[parameterContext.getIndex()];
+            }
+        }
+    }
+
+    // -------------------------------- Helper functions -------------------------------------------
+
+    private Stream<TestTemplateInvocationContext> createContextForParameters(
+            Stream<Object[]> parameterValueStream,
+            String testNameTemplate,
+            ExtensionContext context) {
+        // Search fields annotated by @Parameter
+        final List<Field> parameterFields =
+                AnnotationSupport.findAnnotatedFields(
+                        context.getRequiredTestClass(), Parameter.class);
+
+        // Use constructor parameter style
+        if (parameterFields.isEmpty()) {
+            return parameterValueStream.map(
+                    parameterValue ->
+                            new ConstructorParameterResolverInvocationContext(
+                                    testNameTemplate, parameterValue));
+        }
+
+        // Use field injection style
+        for (Field parameterField : parameterFields) {
+            final int index = parameterField.getAnnotation(Parameter.class).value();
+            context.getStore(NAMESPACE).put(getParameterFieldStoreKey(index), parameterField);
+        }
+        return parameterValueStream.map(
+                parameterValue ->
+                        new FieldInjectingInvocationContext(testNameTemplate, parameterValue));
+    }
+
+    private static String getParameterFieldStoreKey(int parameterIndex) {
+        return PARAMETER_FIELD_STORE_KEY_PREFIX + parameterIndex;
+    }
+
+    private static Field getParameterField(int parameterIndex, ExtensionContext context) {
+        return (Field) context.getStore(NAMESPACE).get(getParameterFieldStoreKey(parameterIndex));
+    }
+}

--- a/flink-test-utils-parent/flink-test-utils-junit/src/main/java/org/apache/flink/testutils/junit/extensions/parameterized/Parameters.java
+++ b/flink-test-utils-parent/flink-test-utils-junit/src/main/java/org/apache/flink/testutils/junit/extensions/parameterized/Parameters.java
@@ -1,0 +1,36 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.flink.testutils.junit.extensions.parameterized;
+
+import org.junit.runners.Parameterized;
+
+import java.lang.annotation.ElementType;
+import java.lang.annotation.Retention;
+import java.lang.annotation.RetentionPolicy;
+import java.lang.annotation.Target;
+
+/**
+ * The annotation is used to replace {@link Parameterized.Parameters} for Junit 5 parameterized
+ * tests.
+ */
+@Retention(RetentionPolicy.RUNTIME)
+@Target(ElementType.METHOD)
+public @interface Parameters {
+    String name() default "{index}";
+}

--- a/flink-test-utils-parent/flink-test-utils-junit/src/main/java/org/apache/flink/testutils/junit/utils/TempDirUtils.java
+++ b/flink-test-utils-parent/flink-test-utils-junit/src/main/java/org/apache/flink/testutils/junit/utils/TempDirUtils.java
@@ -1,0 +1,96 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.flink.testutils.junit.utils;
+
+import java.io.File;
+import java.io.IOException;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.nio.file.attribute.FileAttribute;
+
+/** The utils contains some methods same as {@link org.junit.rules.TemporaryFolder}. */
+public class TempDirUtils {
+    private static final String TMP_PREFIX = "junit";
+
+    public static File newFolder(Path path) throws IOException {
+        Path tempPath;
+        if (path != null) {
+            tempPath = Files.createTempDirectory(path, TMP_PREFIX, new FileAttribute[0]);
+        } else {
+            tempPath = Files.createTempDirectory(TMP_PREFIX, new FileAttribute[0]);
+        }
+        return tempPath.toFile();
+    }
+
+    public static File newFile(Path path) throws IOException {
+        return File.createTempFile(TMP_PREFIX, null, path.toFile());
+    }
+
+    public static File newFolder(Path base, String... paths) throws IOException {
+        if (paths.length == 0) {
+            throw new IllegalArgumentException("must pass at least one path");
+        }
+
+        /*
+         * Before checking if the paths are absolute paths, check if create() was ever called,
+         * and if it wasn't, throw IllegalStateException.
+         */
+        File root = base.toFile();
+        for (String path : paths) {
+            if (new File(path).isAbsolute()) {
+                throw new IOException("folder path \'" + path + "\' is not a relative path");
+            }
+        }
+
+        File relativePath = null;
+        File file = root;
+        boolean lastMkdirsCallSuccessful = true;
+        for (String path : paths) {
+            relativePath = new File(relativePath, path);
+            file = new File(root, relativePath.getPath());
+
+            lastMkdirsCallSuccessful = file.mkdirs();
+            if (!lastMkdirsCallSuccessful && !file.isDirectory()) {
+                if (file.exists()) {
+                    throw new IOException(
+                            "a file with the path \'" + relativePath.getPath() + "\' exists");
+                } else {
+                    throw new IOException(
+                            "could not create a folder with the path \'"
+                                    + relativePath.getPath()
+                                    + "\'");
+                }
+            }
+        }
+        if (!lastMkdirsCallSuccessful) {
+            throw new IOException(
+                    "a folder with the path \'" + relativePath.getPath() + "\' already exists");
+        }
+        return file;
+    }
+
+    public static File newFile(Path folder, String fileName) throws IOException {
+        File file = new File(folder.toFile(), fileName);
+        if (!file.createNewFile()) {
+            throw new IOException(
+                    "a file with the name \'" + fileName + "\' already exists in the test folder");
+        }
+        return file;
+    }
+}


### PR DESCRIPTION
## What is the purpose of the change

This pull request adds new extensions and utils to help the Junit5 migration.

## Brief change log

  - Add `ParameterizedTestExtension` and two annotations to help to migrate the Junit4 parameterized test
  - Add `TempDirUtils` to provide some common methods in `org.junit.rules.TemporaryFolder`
  - Migrate `LongHashTableTest` to Junit5 as an example to show how to use the new extension

## Verifying this change

This change is already covered by existing tests.

## Does this pull request potentially affect one of the following parts:

  - Dependencies (does it add or upgrade a dependency):  no
  - The public API, i.e., is any changed class annotated with `@Public(Evolving)`:  no
  - The serializers: no 
  - The runtime per-record code paths (performance sensitive): no
  - Anything that affects deployment or recovery: JobManager (and its components), Checkpointing, Kubernetes/Yarn, ZooKeeper: no
  - The S3 file system connector: no

## Documentation

  - Does this pull request introduce a new feature? no
