### PR TITLE
[FLINK-25173][table][hive] Introduce CatalogLock and implement HiveCatalogLock

### DIFF
--- a/flink-connectors/flink-connector-hive/src/main/java/org/apache/flink/table/catalog/hive/HiveCatalogLock.java
+++ b/flink-connectors/flink-connector-hive/src/main/java/org/apache/flink/table/catalog/hive/HiveCatalogLock.java
@@ -1,0 +1,175 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.flink.table.catalog.hive;
+
+import org.apache.flink.configuration.ConfigOption;
+import org.apache.flink.connectors.hive.JobConfWrapper;
+import org.apache.flink.connectors.hive.util.HiveConfUtils;
+import org.apache.flink.connectors.hive.util.JobConfUtils;
+import org.apache.flink.table.catalog.CatalogLock;
+import org.apache.flink.table.catalog.hive.client.HiveMetastoreClientFactory;
+import org.apache.flink.table.catalog.hive.client.HiveMetastoreClientWrapper;
+import org.apache.flink.table.catalog.hive.factories.HiveCatalogFactoryOptions;
+import org.apache.flink.util.TimeUtils;
+
+import org.apache.hadoop.hive.conf.HiveConf;
+import org.apache.hadoop.hive.metastore.api.LockComponent;
+import org.apache.hadoop.hive.metastore.api.LockLevel;
+import org.apache.hadoop.hive.metastore.api.LockRequest;
+import org.apache.hadoop.hive.metastore.api.LockResponse;
+import org.apache.hadoop.hive.metastore.api.LockState;
+import org.apache.hadoop.hive.metastore.api.LockType;
+import org.apache.hadoop.mapred.JobConf;
+import org.apache.thrift.TException;
+
+import java.net.InetAddress;
+import java.net.UnknownHostException;
+import java.time.Duration;
+import java.util.Collections;
+import java.util.concurrent.Callable;
+
+import static org.apache.flink.configuration.ConfigOptions.key;
+
+/** Hive {@link CatalogLock}. */
+public class HiveCatalogLock implements CatalogLock {
+
+    // lock options in hive conf, start with CatalogPropertiesUtil.FLINK_PROPERTY_PREFIX
+
+    public static final ConfigOption<Duration> LOCK_CHECK_MAX_SLEEP =
+            key("flink.hive.lock-check-max-sleep")
+                    .durationType()
+                    .defaultValue(Duration.ofSeconds(8))
+                    .withDescription("the maximum sleep time when retrying to check the lock.");
+
+    public static final ConfigOption<Duration> LOCK_ACQUIRE_TIMEOUT =
+            key("flink.hive.lock-acquire-timeout")
+                    .durationType()
+                    .defaultValue(Duration.ofMinutes(8))
+                    .withDescription("The maximum time to wait for acquiring the lock.");
+
+    private final HiveMetastoreClientWrapper client;
+    private final long checkMaxSleep;
+    private final long acquireTimeout;
+
+    public HiveCatalogLock(
+            HiveMetastoreClientWrapper client, long checkMaxSleep, long acquireTimeout) {
+        this.client = client;
+        this.checkMaxSleep = checkMaxSleep;
+        this.acquireTimeout = acquireTimeout;
+    }
+
+    @Override
+    public <T> T runWithLock(String database, String table, Callable<T> callable) throws Exception {
+        long lockId = lock(database, table);
+        try {
+            return callable.call();
+        } finally {
+            unlock(lockId);
+        }
+    }
+
+    private long lock(String database, String table)
+            throws UnknownHostException, TException, InterruptedException {
+        final LockComponent lockComponent =
+                new LockComponent(LockType.EXCLUSIVE, LockLevel.TABLE, database);
+        lockComponent.setTablename(table);
+        lockComponent.unsetOperationType();
+        final LockRequest lockRequest =
+                new LockRequest(
+                        Collections.singletonList(lockComponent),
+                        System.getProperty("user.name"),
+                        InetAddress.getLocalHost().getHostName());
+        LockResponse lockResponse = this.client.lock(lockRequest);
+
+        long nextSleep = 50;
+        long startRetry = System.currentTimeMillis();
+        while (lockResponse.getState() == LockState.WAITING) {
+            nextSleep *= 2;
+            if (nextSleep > checkMaxSleep) {
+                nextSleep = checkMaxSleep;
+            }
+            Thread.sleep(nextSleep);
+
+            lockResponse = client.checkLock(lockResponse.getLockid());
+            if (System.currentTimeMillis() - startRetry > acquireTimeout) {
+                break;
+            }
+        }
+        long retryDuration = System.currentTimeMillis() - startRetry;
+
+        if (lockResponse.getState() != LockState.ACQUIRED) {
+            if (lockResponse.getState() == LockState.WAITING) {
+                client.unlock(lockResponse.getLockid());
+            }
+            throw new RuntimeException(
+                    "Acquire lock failed with time: " + Duration.ofMillis(retryDuration));
+        }
+        return lockResponse.getLockid();
+    }
+
+    private void unlock(long lockId) throws TException {
+        client.unlock(lockId);
+    }
+
+    @Override
+    public void close() {
+        this.client.close();
+    }
+
+    /** Create a hive lock factory. */
+    public static CatalogLock.Factory createFactory(HiveConf hiveConf) {
+        return new HiveCatalogLockFactory(hiveConf);
+    }
+
+    private static class HiveCatalogLockFactory implements CatalogLock.Factory {
+
+        private static final long serialVersionUID = 1L;
+
+        private final JobConfWrapper confWrapper;
+
+        public HiveCatalogLockFactory(HiveConf hiveConf) {
+            this.confWrapper =
+                    new JobConfWrapper(JobConfUtils.createJobConfWithCredentials(hiveConf));
+        }
+
+        @Override
+        public CatalogLock create() {
+            JobConf conf = confWrapper.conf();
+            String version = conf.get(HiveCatalogFactoryOptions.HIVE_VERSION.key());
+            long checkMaxSleep =
+                    TimeUtils.parseDuration(
+                                    conf.get(
+                                            LOCK_CHECK_MAX_SLEEP.key(),
+                                            TimeUtils.getStringInMillis(
+                                                    LOCK_CHECK_MAX_SLEEP.defaultValue())))
+                            .toMillis();
+            long acquireTimeout =
+                    TimeUtils.parseDuration(
+                                    conf.get(
+                                            LOCK_ACQUIRE_TIMEOUT.key(),
+                                            TimeUtils.getStringInMillis(
+                                                    LOCK_ACQUIRE_TIMEOUT.defaultValue())))
+                            .toMillis();
+            return new HiveCatalogLock(
+                    HiveMetastoreClientFactory.create(HiveConfUtils.create(conf), version),
+                    checkMaxSleep,
+                    acquireTimeout);
+        }
+    }
+}

--- a/flink-connectors/flink-connector-hive/src/main/java/org/apache/flink/table/catalog/hive/HiveCatalogLock.java
+++ b/flink-connectors/flink-connector-hive/src/main/java/org/apache/flink/table/catalog/hive/HiveCatalogLock.java
@@ -18,7 +18,6 @@
 
 package org.apache.flink.table.catalog.hive;
 
-import org.apache.flink.configuration.ConfigOption;
 import org.apache.flink.connectors.hive.JobConfWrapper;
 import org.apache.flink.connectors.hive.util.HiveConfUtils;
 import org.apache.flink.connectors.hive.util.JobConfUtils;
@@ -44,24 +43,11 @@ import java.time.Duration;
 import java.util.Collections;
 import java.util.concurrent.Callable;
 
-import static org.apache.flink.configuration.ConfigOptions.key;
+import static org.apache.flink.table.catalog.hive.HiveConfOptions.LOCK_ACQUIRE_TIMEOUT;
+import static org.apache.flink.table.catalog.hive.HiveConfOptions.LOCK_CHECK_MAX_SLEEP;
 
 /** Hive {@link CatalogLock}. */
 public class HiveCatalogLock implements CatalogLock {
-
-    // lock options in hive conf, start with CatalogPropertiesUtil.FLINK_PROPERTY_PREFIX
-
-    public static final ConfigOption<Duration> LOCK_CHECK_MAX_SLEEP =
-            key("flink.hive.lock-check-max-sleep")
-                    .durationType()
-                    .defaultValue(Duration.ofSeconds(8))
-                    .withDescription("the maximum sleep time when retrying to check the lock.");
-
-    public static final ConfigOption<Duration> LOCK_ACQUIRE_TIMEOUT =
-            key("flink.hive.lock-acquire-timeout")
-                    .durationType()
-                    .defaultValue(Duration.ofMinutes(8))
-                    .withDescription("The maximum time to wait for acquiring the lock.");
 
     private final HiveMetastoreClientWrapper client;
     private final long checkMaxSleep;

--- a/flink-connectors/flink-connector-hive/src/main/java/org/apache/flink/table/catalog/hive/HiveConfOptions.java
+++ b/flink-connectors/flink-connector-hive/src/main/java/org/apache/flink/table/catalog/hive/HiveConfOptions.java
@@ -1,0 +1,47 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.flink.table.catalog.hive;
+
+import org.apache.flink.configuration.ConfigOption;
+import org.apache.flink.table.catalog.CatalogPropertiesUtil;
+
+import org.apache.hadoop.hive.conf.HiveConf;
+
+import java.time.Duration;
+
+import static org.apache.flink.configuration.ConfigOptions.key;
+
+/**
+ * Options in {@link HiveConf}. Options are start with {@link
+ * CatalogPropertiesUtil#FLINK_PROPERTY_PREFIX}.
+ */
+public class HiveConfOptions {
+
+    public static final ConfigOption<Duration> LOCK_CHECK_MAX_SLEEP =
+            key("flink.hive.lock-check-max-sleep")
+                    .durationType()
+                    .defaultValue(Duration.ofSeconds(8))
+                    .withDescription("the maximum sleep time when retrying to check the lock.");
+
+    public static final ConfigOption<Duration> LOCK_ACQUIRE_TIMEOUT =
+            key("flink.hive.lock-acquire-timeout")
+                    .durationType()
+                    .defaultValue(Duration.ofMinutes(8))
+                    .withDescription("The maximum time to wait for acquiring the lock.");
+}

--- a/flink-connectors/flink-connector-hive/src/main/java/org/apache/flink/table/catalog/hive/HiveConfOptions.java
+++ b/flink-connectors/flink-connector-hive/src/main/java/org/apache/flink/table/catalog/hive/HiveConfOptions.java
@@ -37,7 +37,7 @@ public class HiveConfOptions {
             key("flink.hive.lock-check-max-sleep")
                     .durationType()
                     .defaultValue(Duration.ofSeconds(8))
-                    .withDescription("the maximum sleep time when retrying to check the lock.");
+                    .withDescription("The maximum sleep time when retrying to check the lock.");
 
     public static final ConfigOption<Duration> LOCK_ACQUIRE_TIMEOUT =
             key("flink.hive.lock-acquire-timeout")

--- a/flink-connectors/flink-connector-hive/src/main/java/org/apache/flink/table/catalog/hive/client/HiveMetastoreClientWrapper.java
+++ b/flink-connectors/flink-connector-hive/src/main/java/org/apache/flink/table/catalog/hive/client/HiveMetastoreClientWrapper.java
@@ -35,10 +35,16 @@ import org.apache.hadoop.hive.metastore.api.Function;
 import org.apache.hadoop.hive.metastore.api.InvalidInputException;
 import org.apache.hadoop.hive.metastore.api.InvalidObjectException;
 import org.apache.hadoop.hive.metastore.api.InvalidOperationException;
+import org.apache.hadoop.hive.metastore.api.LockRequest;
+import org.apache.hadoop.hive.metastore.api.LockResponse;
 import org.apache.hadoop.hive.metastore.api.MetaException;
+import org.apache.hadoop.hive.metastore.api.NoSuchLockException;
 import org.apache.hadoop.hive.metastore.api.NoSuchObjectException;
+import org.apache.hadoop.hive.metastore.api.NoSuchTxnException;
 import org.apache.hadoop.hive.metastore.api.Partition;
 import org.apache.hadoop.hive.metastore.api.Table;
+import org.apache.hadoop.hive.metastore.api.TxnAbortedException;
+import org.apache.hadoop.hive.metastore.api.TxnOpenException;
 import org.apache.hadoop.hive.metastore.api.UnknownDBException;
 import org.apache.hadoop.hive.metastore.partition.spec.PartitionSpecProxy;
 import org.apache.thrift.TException;
@@ -315,5 +321,19 @@ public class HiveMetastoreClientWrapper implements AutoCloseable {
             List<Byte> nnTraits) {
         hiveShim.createTableWithConstraints(
                 client, table, conf, pk, pkTraits, notNullCols, nnTraits);
+    }
+
+    public LockResponse checkLock(long lockid)
+            throws NoSuchTxnException, TxnAbortedException, NoSuchLockException, TException {
+        return client.checkLock(lockid);
+    }
+
+    public LockResponse lock(LockRequest request)
+            throws NoSuchTxnException, TxnAbortedException, TException {
+        return client.lock(request);
+    }
+
+    public void unlock(long lockid) throws NoSuchLockException, TxnOpenException, TException {
+        client.unlock(lockid);
     }
 }

--- a/flink-connectors/flink-connector-hive/src/test/java/org/apache/flink/connectors/hive/HiveRunnerITCase.java
+++ b/flink-connectors/flink-connector-hive/src/test/java/org/apache/flink/connectors/hive/HiveRunnerITCase.java
@@ -81,14 +81,13 @@ public class HiveRunnerITCase {
     private static final HiveRunnerConfig CONFIG =
             new HiveRunnerConfig() {
                 {
-                    if (HiveShimLoader.getHiveVersion().startsWith("3.")) {
-                        // hive-3.x requires a proper txn manager to create ACID table
-                        getHiveConfSystemOverride()
-                                .put(HIVE_TXN_MANAGER.varname, DbTxnManager.class.getName());
-                        getHiveConfSystemOverride().put(HIVE_SUPPORT_CONCURRENCY.varname, "true");
-                        // tell TxnHandler to prepare txn DB
-                        getHiveConfSystemOverride().put(HIVE_IN_TEST.varname, "true");
-                    }
+                    // catalog lock needs txn manager
+                    // hive-3.x requires a proper txn manager to create ACID table
+                    getHiveConfSystemOverride()
+                            .put(HIVE_TXN_MANAGER.varname, DbTxnManager.class.getName());
+                    getHiveConfSystemOverride().put(HIVE_SUPPORT_CONCURRENCY.varname, "true");
+                    // tell TxnHandler to prepare txn DB
+                    getHiveConfSystemOverride().put(HIVE_IN_TEST.varname, "true");
                 }
             };
 
@@ -768,5 +767,25 @@ public class HiveRunnerITCase {
                             return res;
                         })
                 .collect(Collectors.joining(","));
+    }
+
+    @Test
+    public void testCatalogLock() throws Exception {
+        TableEnvironment tableEnv = HiveTestUtils.createTableEnvInBatchMode(SqlDialect.DEFAULT);
+        tableEnv.registerCatalog(hiveCatalog.getName(), hiveCatalog);
+        tableEnv.useCatalog(hiveCatalog.getName());
+
+        tableEnv.executeSql("create database db1");
+        try {
+            tableEnv.useDatabase("db1");
+            tableEnv.executeSql(
+                    "create table src (x int) with ('connector'='datagen','number-of-rows'='2')");
+            tableEnv.executeSql("create table lock_t (x int) with ('connector'='test-lock')");
+
+            // see TestLockTableSinkFactory
+            tableEnv.executeSql("insert into lock_t select * from src").await();
+        } finally {
+            tableEnv.executeSql("drop database db1 cascade");
+        }
     }
 }

--- a/flink-connectors/flink-connector-hive/src/test/java/org/apache/flink/table/catalog/hive/factories/TestLockTableSinkFactory.java
+++ b/flink-connectors/flink-connector-hive/src/test/java/org/apache/flink/table/catalog/hive/factories/TestLockTableSinkFactory.java
@@ -32,12 +32,12 @@ import org.apache.flink.table.connector.sink.SinkFunctionProvider;
 import org.apache.flink.table.data.RowData;
 import org.apache.flink.table.factories.DynamicTableSinkFactory;
 
-import org.junit.jupiter.api.Assertions;
-
 import java.util.HashSet;
 import java.util.Optional;
 import java.util.Set;
 import java.util.concurrent.atomic.AtomicReference;
+
+import static org.assertj.core.api.Assertions.assertThat;
 
 /** Factory for testing {@link HiveCatalogLock}. */
 public class TestLockTableSinkFactory implements DynamicTableSinkFactory {
@@ -139,7 +139,7 @@ public class TestLockTableSinkFactory implements DynamicTableSinkFactory {
                     () -> {
                         REFERENCE.set(TestLockSink.this);
                         Thread.sleep(5000);
-                        Assertions.assertSame(TestLockSink.this, REFERENCE.get());
+                        assertThat(REFERENCE.get()).isSameAs(TestLockSink.this);
                         return null;
                     });
         }

--- a/flink-connectors/flink-connector-hive/src/test/java/org/apache/flink/table/catalog/hive/factories/TestLockTableSinkFactory.java
+++ b/flink-connectors/flink-connector-hive/src/test/java/org/apache/flink/table/catalog/hive/factories/TestLockTableSinkFactory.java
@@ -1,0 +1,147 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.flink.table.catalog.hive.factories;
+
+import org.apache.flink.configuration.ConfigOption;
+import org.apache.flink.configuration.Configuration;
+import org.apache.flink.streaming.api.functions.sink.RichSinkFunction;
+import org.apache.flink.streaming.api.functions.sink.SinkFunction;
+import org.apache.flink.table.catalog.CatalogLock;
+import org.apache.flink.table.catalog.ObjectIdentifier;
+import org.apache.flink.table.catalog.hive.HiveCatalogLock;
+import org.apache.flink.table.connector.ChangelogMode;
+import org.apache.flink.table.connector.RequireCatalogLock;
+import org.apache.flink.table.connector.sink.DynamicTableSink;
+import org.apache.flink.table.connector.sink.SinkFunctionProvider;
+import org.apache.flink.table.data.RowData;
+import org.apache.flink.table.factories.DynamicTableSinkFactory;
+
+import org.junit.jupiter.api.Assertions;
+
+import java.util.HashSet;
+import java.util.Optional;
+import java.util.Set;
+import java.util.concurrent.atomic.AtomicReference;
+
+/** Factory for testing {@link HiveCatalogLock}. */
+public class TestLockTableSinkFactory implements DynamicTableSinkFactory {
+
+    @Override
+    public String factoryIdentifier() {
+        return "test-lock";
+    }
+
+    @Override
+    public Set<ConfigOption<?>> requiredOptions() {
+        return new HashSet<>();
+    }
+
+    @Override
+    public Set<ConfigOption<?>> optionalOptions() {
+        return new HashSet<>();
+    }
+
+    @Override
+    public DynamicTableSink createDynamicTableSink(Context context) {
+        return new TestLockTableSink(context.getObjectIdentifier());
+    }
+
+    private static class TestLockTableSink implements DynamicTableSink, RequireCatalogLock {
+
+        private final ObjectIdentifier tableIdentifier;
+
+        private CatalogLock.Factory lockFactory;
+
+        private TestLockTableSink(ObjectIdentifier tableIdentifier) {
+            this.tableIdentifier = tableIdentifier;
+        }
+
+        @Override
+        public ChangelogMode getChangelogMode(ChangelogMode requestedMode) {
+            return ChangelogMode.insertOnly();
+        }
+
+        @Override
+        public SinkRuntimeProvider getSinkRuntimeProvider(Context context) {
+            return new SinkFunctionProvider() {
+
+                @Override
+                public Optional<Integer> getParallelism() {
+                    // 3 tasks acquire lock
+                    return Optional.of(3);
+                }
+
+                @Override
+                public SinkFunction<RowData> createSinkFunction() {
+                    return new TestLockSink(tableIdentifier, lockFactory);
+                }
+            };
+        }
+
+        @Override
+        public DynamicTableSink copy() {
+            TestLockTableSink sink = new TestLockTableSink(tableIdentifier);
+            sink.lockFactory = lockFactory;
+            return sink;
+        }
+
+        @Override
+        public String asSummaryString() {
+            return "test-lock";
+        }
+
+        @Override
+        public void setLockFactory(CatalogLock.Factory lockFactory) {
+            this.lockFactory = lockFactory;
+        }
+    }
+
+    private static class TestLockSink extends RichSinkFunction<RowData> {
+
+        private static final AtomicReference<TestLockSink> REFERENCE = new AtomicReference<>();
+
+        private final ObjectIdentifier tableIdentifier;
+        private final CatalogLock.Factory lockFactory;
+
+        private transient CatalogLock lock;
+
+        private TestLockSink(ObjectIdentifier tableIdentifier, CatalogLock.Factory lockFactory) {
+            this.tableIdentifier = tableIdentifier;
+            this.lockFactory = lockFactory;
+        }
+
+        @Override
+        public void open(Configuration parameters) throws Exception {
+            this.lock = lockFactory.create();
+        }
+
+        @Override
+        public void invoke(RowData value, Context context) throws Exception {
+            lock.runWithLock(
+                    tableIdentifier.getDatabaseName(),
+                    tableIdentifier.getObjectName(),
+                    () -> {
+                        REFERENCE.set(TestLockSink.this);
+                        Thread.sleep(5000);
+                        Assertions.assertSame(TestLockSink.this, REFERENCE.get());
+                        return null;
+                    });
+        }
+    }
+}

--- a/flink-connectors/flink-connector-hive/src/test/resources/META-INF/services/org.apache.flink.table.factories.Factory
+++ b/flink-connectors/flink-connector-hive/src/test/resources/META-INF/services/org.apache.flink.table.factories.Factory
@@ -1,0 +1,16 @@
+# Licensed to the Apache Software Foundation (ASF) under one or more
+# contributor license agreements.  See the NOTICE file distributed with
+# this work for additional information regarding copyright ownership.
+# The ASF licenses this file to You under the Apache License, Version 2.0
+# (the "License"); you may not use this file except in compliance with
+# the License.  You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+org.apache.flink.table.catalog.hive.factories.TestLockTableSinkFactory

--- a/flink-table/flink-table-common/src/main/java/org/apache/flink/table/catalog/CatalogLock.java
+++ b/flink-table/flink-table-common/src/main/java/org/apache/flink/table/catalog/CatalogLock.java
@@ -1,0 +1,40 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.flink.table.catalog;
+
+import org.apache.flink.annotation.Internal;
+
+import java.io.Closeable;
+import java.io.Serializable;
+import java.util.concurrent.Callable;
+
+/**
+ * An interface that allows source and sink to use global lock to some transaction-related things.
+ */
+@Internal
+public interface CatalogLock extends Closeable {
+
+    /** Run with catalog lock. The caller should tell catalog the database and table name. */
+    <T> T runWithLock(String database, String table, Callable<T> callable) throws Exception;
+
+    /** Factory to create {@link CatalogLock}. */
+    interface Factory extends Serializable {
+        CatalogLock create();
+    }
+}

--- a/flink-table/flink-table-common/src/main/java/org/apache/flink/table/connector/RequireCatalogLock.java
+++ b/flink-table/flink-table-common/src/main/java/org/apache/flink/table/connector/RequireCatalogLock.java
@@ -1,0 +1,30 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.flink.table.connector;
+
+import org.apache.flink.annotation.Internal;
+import org.apache.flink.table.catalog.CatalogLock;
+
+/** Source and sink implement this interface if they require {@link CatalogLock}. */
+@Internal
+public interface RequireCatalogLock {
+
+    /** Set catalog lock factory to the connector. */
+    void setLockFactory(CatalogLock.Factory lockFactory);
+}


### PR DESCRIPTION

## What is the purpose of the change

Introduce `CatalogLock` for connectors, source & sink can use this lock to do some global sync.
```
/**
 * An interface that allows source and sink to use global lock to some transaction-related things.
 */
@Internal
public interface CatalogLock extends Closeable {
 
    /** Run with catalog lock. The caller should tell catalog the database and table name. */
    <T> T runWithLock(String database, String table, Callable<T> callable) throws Exception;
 
    /** Factory to create {@link CatalogLock}. */
    interface Factory extends Serializable {
        CatalogLock create();
    }
} 
```

And we need a interface to set lock to source&sink by catalog:
```
/**
 * Source and sink implement this interface if they require {@link CatalogLock}.
 */
@Internal
public interface RequireCatalogLock {
 
    void setLockFactory(CatalogLock.Factory lockFactory);
} 
```

## Brief change log

- Introduce `CatalogLock` and `RequireCatalogLock`
- Implement `HiveCatalogLock`

## Verifying this change

`HiveRunnerITCase.testCatalogLock`

## Does this pull request potentially affect one of the following parts:

  - Dependencies (does it add or upgrade a dependency): (yes / **no**)
  - The public API, i.e., is any changed class annotated with `@Public(Evolving)`: (yes / **no**)
  - The serializers: (yes / **no** / don't know)
  - The runtime per-record code paths (performance sensitive): (yes / **no** / don't know)
  - Anything that affects deployment or recovery: JobManager (and its components), Checkpointing, Kubernetes/Yarn, ZooKeeper: (yes / **no** / don't know)
  - The S3 file system connector: (yes / **no** / don't know)

## Documentation

  - Does this pull request introduce a new feature? (**yes** / no)
  - If yes, how is the feature documented? (not applicable / docs / **JavaDocs** / not documented)
