### PR TITLE
[hotfix][docs] Fix type name for INTERVAL in Data Type Extraction section of types.md

### DIFF
--- a/docs/content.zh/docs/dev/table/types.md
+++ b/docs/content.zh/docs/dev/table/types.md
@@ -1530,7 +1530,7 @@ information similar to `java.util.Map[java.lang.Object, java.lang.Object]`.
 | `java.time.LocalDateTime`   | `TIMESTAMP(9)`                      |
 | `java.time.OffsetDateTime`  | `TIMESTAMP(9) WITH TIME ZONE`       |
 | `java.time.Instant`         | `TIMESTAMP_LTZ(9)`                  |
-| `java.time.Duration`        | `INVERVAL SECOND(9)`                |
+| `java.time.Duration`        | `INTERVAL SECOND(9)`                |
 | `java.time.Period`          | `INTERVAL YEAR(4) TO MONTH`         |
 | `byte[]`                    | `BYTES`                             |
 | `T[]`                       | `ARRAY<T>`                          |

--- a/docs/content/docs/dev/table/types.md
+++ b/docs/content/docs/dev/table/types.md
@@ -1530,7 +1530,7 @@ information similar to `java.util.Map[java.lang.Object, java.lang.Object]`.
 | `java.time.LocalDateTime`   | `TIMESTAMP(9)`                      |
 | `java.time.OffsetDateTime`  | `TIMESTAMP(9) WITH TIME ZONE`       |
 | `java.time.Instant`         | `TIMESTAMP_LTZ(9)`                  |
-| `java.time.Duration`        | `INVERVAL SECOND(9)`                |
+| `java.time.Duration`        | `INTERVAL SECOND(9)`                |
 | `java.time.Period`          | `INTERVAL YEAR(4) TO MONTH`         |
 | `byte[]`                    | `BYTES`                             |
 | `T[]`                       | `ARRAY<T>`                          |


### PR DESCRIPTION
## What is the purpose of the change
Trivial misprint fix `Data Type Extraction` of 
_docs/content.zh/docs/dev/table/types.md_
and
_docs/content/docs/dev/table/types.md_

`INVERVAL` => `INTERVAL`

## Verifying this change
This change is a trivial rework / code cleanup without any test coverage.
