### PR TITLE
[FLINK-25326][connectors/kafka] Fix application of log levels in KafkaUtils.createKafkacontainer

### DIFF
--- a/flink-connectors/flink-connector-kafka/src/test/java/org/apache/flink/connector/kafka/sink/KafkaUtil.java
+++ b/flink-connectors/flink-connector-kafka/src/test/java/org/apache/flink/connector/kafka/sink/KafkaUtil.java
@@ -56,16 +56,16 @@ public class KafkaUtil {
      */
     public static KafkaContainer createKafkaContainer(String dockerImageVersion, Logger logger) {
         String logLevel;
-        if (logger.isErrorEnabled()) {
-            logLevel = "ERROR";
-        } else if (logger.isTraceEnabled()) {
+        if (logger.isTraceEnabled()) {
             logLevel = "TRACE";
         } else if (logger.isDebugEnabled()) {
             logLevel = "DEBUG";
-        } else if (logger.isWarnEnabled()) {
-            logLevel = "WARN";
         } else if (logger.isInfoEnabled()) {
             logLevel = "INFO";
+        } else if (logger.isWarnEnabled()) {
+            logLevel = "WARN";
+        } else if (logger.isErrorEnabled()) {
+            logLevel = "ERROR";
         } else {
             logLevel = "OFF";
         }


### PR DESCRIPTION
## What is the purpose of the change

The order of log levels in the `createKafkaContainer` method was wrong causing incorrect log levels to be applied.


## Brief change log
- fixed the log level hierarchy


## Verifying this change

This change is a trivial rework / code cleanup without any test coverage. To confirm it works please edit the log4j2-test.properties and confirm the log output of the started container for any unit test starting the testcontainer.


## Does this pull request potentially affect one of the following parts:

  - Dependencies (does it add or upgrade a dependency): (yes / **no**)
  - The public API, i.e., is any changed class annotated with `@Public(Evolving)`: (yes / **no**)
  - The serializers: (yes / **no** / don't know)
  - The runtime per-record code paths (performance sensitive): (yes / **no** / don't know)
  - Anything that affects deployment or recovery: JobManager (and its components), Checkpointing, Kubernetes/Yarn, ZooKeeper: (yes / **no** / don't know)
  - The S3 file system connector: (yes / **no** / don't know)

## Documentation

  - Does this pull request introduce a new feature? (yes / **no**)
  - If yes, how is the feature documented? (**not applicable** / docs / JavaDocs / not documented)
