### PR TITLE
[FLINK-24907] Support side out late data for interval join

### DIFF
--- a/flink-streaming-java/src/main/java/org/apache/flink/streaming/api/datastream/KeyedStream.java
+++ b/flink-streaming-java/src/main/java/org/apache/flink/streaming/api/datastream/KeyedStream.java
@@ -68,6 +68,7 @@ import org.apache.flink.streaming.api.windowing.windows.TimeWindow;
 import org.apache.flink.streaming.api.windowing.windows.Window;
 import org.apache.flink.streaming.runtime.partitioner.KeyGroupStreamPartitioner;
 import org.apache.flink.streaming.runtime.partitioner.StreamPartitioner;
+import org.apache.flink.util.OutputTag;
 import org.apache.flink.util.Preconditions;
 
 import org.apache.commons.lang3.StringUtils;
@@ -540,6 +541,9 @@ public class KeyedStream<T, KEY> extends DataStream<T> {
         private boolean lowerBoundInclusive;
         private boolean upperBoundInclusive;
 
+        private OutputTag<IN1> leftLateDataOutputTag;
+        private OutputTag<IN2> rightLateDataOutputTag;
+
         public IntervalJoined(
                 KeyedStream<IN1, KEY> left,
                 KeyedStream<IN2, KEY> right,
@@ -572,6 +576,28 @@ public class KeyedStream<T, KEY> extends DataStream<T> {
         @PublicEvolving
         public IntervalJoined<IN1, IN2, KEY> lowerBoundExclusive() {
             this.lowerBoundInclusive = false;
+            return this;
+        }
+
+        /**
+         * Send late arriving left-side data to the side output identified by the given {@link
+         * OutputTag}. Data is considered late after the watermark
+         */
+        @PublicEvolving
+        public IntervalJoined<IN1, IN2, KEY> sideOutputLeftLateData(OutputTag<IN1> outputTag) {
+            outputTag = left.getExecutionEnvironment().clean(outputTag);
+            this.leftLateDataOutputTag = outputTag;
+            return this;
+        }
+
+        /**
+         * Send late arriving right-side data to the side output identified by the given {@link
+         * OutputTag}. Data is considered late after the watermark
+         */
+        @PublicEvolving
+        public IntervalJoined<IN1, IN2, KEY> sideOutputRightLateData(OutputTag<IN2> outputTag) {
+            outputTag = right.getExecutionEnvironment().clean(outputTag);
+            this.rightLateDataOutputTag = outputTag;
             return this;
         }
 
@@ -630,6 +656,8 @@ public class KeyedStream<T, KEY> extends DataStream<T> {
                             upperBound,
                             lowerBoundInclusive,
                             upperBoundInclusive,
+                            leftLateDataOutputTag,
+                            rightLateDataOutputTag,
                             left.getType().createSerializer(left.getExecutionConfig()),
                             right.getType().createSerializer(right.getExecutionConfig()),
                             cleanedUdf);

--- a/flink-streaming-java/src/main/java/org/apache/flink/streaming/api/operators/co/IntervalJoinOperator.java
+++ b/flink-streaming-java/src/main/java/org/apache/flink/streaming/api/operators/co/IntervalJoinOperator.java
@@ -187,9 +187,9 @@ public class IntervalJoinOperator<K, T1, T2, OUT>
 
     /**
      * Process a {@link StreamRecord} from the left stream. Whenever an {@link StreamRecord} arrives
-     * at the left stream, it will get added to the left buffer. PossiblntervalJoinITCase join candidates for that
-     * element will be looked up from the right buffer and if the pair lies within the user defined
-     * boundaries, it gets passed to the {@link ProcessJoinFunction}.
+     * at the left stream, it will get added to the left buffer. PossiblntervalJoinITCase join
+     * candidates for that element will be looked up from the right buffer and if the pair lies
+     * within the user defined boundaries, it gets passed to the {@link ProcessJoinFunction}.
      *
      * @param record An incoming record to be joined
      * @throws Exception Can throw an Exception during state access

--- a/flink-streaming-java/src/main/java/org/apache/flink/streaming/api/operators/co/IntervalJoinOperator.java
+++ b/flink-streaming-java/src/main/java/org/apache/flink/streaming/api/operators/co/IntervalJoinOperator.java
@@ -100,7 +100,8 @@ public class IntervalJoinOperator<K, T1, T2, OUT>
 
     private final long lowerBound;
     private final long upperBound;
-
+    private final OutputTag<T1> leftLateDataOutputTag;
+    private final OutputTag<T2> rightLateDataOutputTag;
     private final TypeSerializer<T1> leftTypeSerializer;
     private final TypeSerializer<T2> rightTypeSerializer;
 
@@ -129,6 +130,8 @@ public class IntervalJoinOperator<K, T1, T2, OUT>
             long upperBound,
             boolean lowerBoundInclusive,
             boolean upperBoundInclusive,
+            OutputTag<T1> leftLateDataOutputTag,
+            OutputTag<T2> rightLateDataOutputTag,
             TypeSerializer<T1> leftTypeSerializer,
             TypeSerializer<T2> rightTypeSerializer,
             ProcessJoinFunction<T1, T2, OUT> udf) {
@@ -143,6 +146,8 @@ public class IntervalJoinOperator<K, T1, T2, OUT>
         this.lowerBound = (lowerBoundInclusive) ? lowerBound : lowerBound + 1L;
         this.upperBound = (upperBoundInclusive) ? upperBound : upperBound - 1L;
 
+        this.leftLateDataOutputTag = leftLateDataOutputTag;
+        this.rightLateDataOutputTag = rightLateDataOutputTag;
         this.leftTypeSerializer = Preconditions.checkNotNull(leftTypeSerializer);
         this.rightTypeSerializer = Preconditions.checkNotNull(rightTypeSerializer);
     }
@@ -182,7 +187,7 @@ public class IntervalJoinOperator<K, T1, T2, OUT>
 
     /**
      * Process a {@link StreamRecord} from the left stream. Whenever an {@link StreamRecord} arrives
-     * at the left stream, it will get added to the left buffer. Possible join candidates for that
+     * at the left stream, it will get added to the left buffer. PossiblntervalJoinITCase join candidates for that
      * element will be looked up from the right buffer and if the pair lies within the user defined
      * boundaries, it gets passed to the {@link ProcessJoinFunction}.
      *
@@ -228,6 +233,7 @@ public class IntervalJoinOperator<K, T1, T2, OUT>
         }
 
         if (isLate(ourTimestamp)) {
+            sideOutput(ourValue, ourTimestamp, isLeft);
             return;
         }
 
@@ -262,6 +268,19 @@ public class IntervalJoinOperator<K, T1, T2, OUT>
     private boolean isLate(long timestamp) {
         long currentWatermark = internalTimerService.currentWatermark();
         return timestamp < currentWatermark;
+    }
+
+    /** Write skipped late arriving element to SideOutput. */
+    protected <T> void sideOutput(T value, long timestamp, boolean isLeft) {
+        if (isLeft) {
+            if (leftLateDataOutputTag != null) {
+                output.collect(leftLateDataOutputTag, new StreamRecord<>((T1) value, timestamp));
+            }
+        } else {
+            if (rightLateDataOutputTag != null) {
+                output.collect(rightLateDataOutputTag, new StreamRecord<>((T2) value, timestamp));
+            }
+        }
     }
 
     private void collect(T1 left, T2 right, long leftTimestamp, long rightTimestamp)

--- a/flink-streaming-java/src/main/java/org/apache/flink/streaming/api/operators/co/IntervalJoinOperator.java
+++ b/flink-streaming-java/src/main/java/org/apache/flink/streaming/api/operators/co/IntervalJoinOperator.java
@@ -187,9 +187,9 @@ public class IntervalJoinOperator<K, T1, T2, OUT>
 
     /**
      * Process a {@link StreamRecord} from the left stream. Whenever an {@link StreamRecord} arrives
-     * at the left stream, it will get added to the left buffer. PossiblntervalJoinITCase join
-     * candidates for that element will be looked up from the right buffer and if the pair lies
-     * within the user defined boundaries, it gets passed to the {@link ProcessJoinFunction}.
+     * at the left stream, it will get added to the left buffer. Possible join candidates for that
+     * element will be looked up from the right buffer and if the pair lies within the user defined
+     * boundaries, it gets passed to the {@link ProcessJoinFunction}.
      *
      * @param record An incoming record to be joined
      * @throws Exception Can throw an Exception during state access

--- a/flink-streaming-java/src/test/java/org/apache/flink/streaming/api/operators/co/IntervalJoinOperatorTest.java
+++ b/flink-streaming-java/src/test/java/org/apache/flink/streaming/api/operators/co/IntervalJoinOperatorTest.java
@@ -390,6 +390,8 @@ public class IntervalJoinOperatorTest {
                         1,
                         true,
                         true,
+                        null,
+                        null,
                         TestElem.serializer(),
                         TestElem.serializer(),
                         new ProcessJoinFunction<TestElem, TestElem, Tuple2<TestElem, TestElem>>() {
@@ -426,6 +428,8 @@ public class IntervalJoinOperatorTest {
                         1,
                         true,
                         true,
+                        null,
+                        null,
                         TestElem.serializer(),
                         TestElem.serializer(),
                         new ProcessJoinFunction<TestElem, TestElem, Tuple2<TestElem, TestElem>>() {
@@ -467,6 +471,8 @@ public class IntervalJoinOperatorTest {
                         1,
                         true,
                         true,
+                        null,
+                        null,
                         TestElem.serializer(),
                         TestElem.serializer(),
                         new ProcessJoinFunction<TestElem, TestElem, Tuple2<TestElem, TestElem>>() {
@@ -608,6 +614,8 @@ public class IntervalJoinOperatorTest {
                         upperBound,
                         lowerBoundInclusive,
                         upperBoundInclusive,
+                        null,
+                        null,
                         TestElem.serializer(),
                         TestElem.serializer(),
                         new PassthroughFunction());
@@ -632,6 +640,8 @@ public class IntervalJoinOperatorTest {
                         upperBound,
                         lowerBoundInclusive,
                         upperBoundInclusive,
+                        null,
+                        null,
                         TestElem.serializer(),
                         TestElem.serializer(),
                         new PassthroughFunction());

--- a/flink-tests/src/test/java/org/apache/flink/test/streaming/runtime/IntervalJoinITCase.java
+++ b/flink-tests/src/test/java/org/apache/flink/test/streaming/runtime/IntervalJoinITCase.java
@@ -181,6 +181,21 @@ public class IntervalJoinITCase {
         long serialVersionUID = 1L;
     }
 
+    private void addSinkToSideOutput(
+            SingleOutputStreamOperator<String> streamOperator,
+            OutputTag<Tuple2<String, Integer>> outputTag) {
+        streamOperator
+                .getSideOutput(outputTag)
+                .addSink(
+                        new SinkFunction<Tuple2<String, Integer>>() {
+                            @Override
+                            public void invoke(Tuple2<String, Integer> value, Context context)
+                                    throws Exception {
+                                testResults.add(value.toString());
+                            }
+                        });
+    }
+
     @Test
     public void testIntervalJoinSideOutputLeftLateData() throws Exception {
 
@@ -217,15 +232,7 @@ public class IntervalJoinITCase {
                         .sideOutputLeftLateData(late)
                         .process(new CombineToStringJoinFunction());
 
-        process.getSideOutput(late)
-                .addSink(
-                        new SinkFunction<Tuple2<String, Integer>>() {
-                            @Override
-                            public void invoke(Tuple2<String, Integer> value, Context context)
-                                    throws Exception {
-                                testResults.add(value.toString());
-                            }
-                        });
+        addSinkToSideOutput(process, late);
         env.execute();
 
         expectInAnyOrder("(key,1)");
@@ -267,15 +274,7 @@ public class IntervalJoinITCase {
                         .sideOutputRightLateData(late)
                         .process(new CombineToStringJoinFunction());
 
-        process.getSideOutput(late)
-                .addSink(
-                        new SinkFunction<Tuple2<String, Integer>>() {
-                            @Override
-                            public void invoke(Tuple2<String, Integer> value, Context context)
-                                    throws Exception {
-                                testResults.add(value.toString());
-                            }
-                        });
+        addSinkToSideOutput(process, late);
         env.execute();
 
         expectInAnyOrder("(key,2)");


### PR DESCRIPTION
## What is the purpose of the change
This pull requst makes interval-join support side out late data.


## Brief change log
   Add `OutputTag` for left and right stream in `org.apache.flink.streaming.api.operators.co.IntervalJoinOperator`, and emit late data  when `isLate(ourTimestamp) = true`



## Verifying this change

`IntervalJoinITCase.testIntervalJoinSideOutputLeftLateData`
`IntervalJoinITCase.testIntervalJoinSideOutputRightLateData`

## Does this pull request potentially affect one of the following parts:

  - Dependencies (does it add or upgrade a dependency): (yes / **no**)
  - The public API, i.e., is any changed class annotated with `@Public(Evolving)`: (**yes**/ no)
  - The serializers: (yes / **no** / don't know)
  - The runtime per-record code paths (performance sensitive): (yes / **no** / don't know)
  - Anything that affects deployment or recovery: JobManager (and its components), Checkpointing, Kubernetes/Yarn, ZooKeeper: (yes / **no** / don't know)
  - The S3 file system connector: (yes / **no** / don't know)

## Documentation

  - Does this pull request introduce a new feature? (yes / **no**)
  - If yes, how is the feature documented? (not applicable / docs / JavaDocs / **not documented**)
