### PR TITLE
[FLINK-24947] Support hostNetwork for native K8s integration on session mode

### DIFF
--- a/docs/layouts/shortcodes/generated/kubernetes_config_configuration.html
+++ b/docs/layouts/shortcodes/generated/kubernetes_config_configuration.html
@@ -27,6 +27,12 @@
             <td>The cluster-id, which should be no more than 45 characters, is used for identifying a unique Flink cluster. The id must only contain lowercase alphanumeric characters and "-". The required format is <code class="highlighter-rouge">[a-z]([-a-z0-9]*[a-z0-9])</code>. If not set, the client will automatically generate it with a random ID.</td>
         </tr>
         <tr>
+            <td><h5>kubernetes.hostnetwork.enabled</h5></td>
+            <td style="word-wrap: break-word;">false</td>
+            <td>Boolean</td>
+            <td>Whether to enable HostNetwork mode. The HostNetwork allows the pod could use the node network namespace instead of the individual pod network namespace. Please note that the JobManager service account should have the permission to update Kubernetes service.</td>
+        </tr>
+        <tr>
             <td><h5>kubernetes.config.file</h5></td>
             <td style="word-wrap: break-word;">(none)</td>
             <td>String</td>

--- a/flink-kubernetes/src/main/java/org/apache/flink/kubernetes/KubernetesClusterDescriptor.java
+++ b/flink-kubernetes/src/main/java/org/apache/flink/kubernetes/KubernetesClusterDescriptor.java
@@ -44,6 +44,7 @@ import org.apache.flink.kubernetes.kubeclient.FlinkPod;
 import org.apache.flink.kubernetes.kubeclient.KubernetesJobManagerSpecification;
 import org.apache.flink.kubernetes.kubeclient.factory.KubernetesJobManagerFactory;
 import org.apache.flink.kubernetes.kubeclient.parameters.KubernetesJobManagerParameters;
+import org.apache.flink.kubernetes.kubeclient.resources.KubernetesService;
 import org.apache.flink.kubernetes.utils.Constants;
 import org.apache.flink.kubernetes.utils.KubernetesUtils;
 import org.apache.flink.runtime.entrypoint.ClusterEntrypoint;
@@ -175,7 +176,7 @@ public class KubernetesClusterDescriptor implements ClusterDescriptor<String> {
             final ClusterSpecification clusterSpecification,
             final ApplicationConfiguration applicationConfiguration)
             throws ClusterDeploymentException {
-        if (client.getRestService(clusterId).isPresent()) {
+        if (client.getService(KubernetesService.ServiceType.REST_SERVICE, clusterId).isPresent()) {
             throw new ClusterDeploymentException(
                     "The Flink cluster " + clusterId + " already exists.");
         }

--- a/flink-kubernetes/src/main/java/org/apache/flink/kubernetes/KubernetesResourceManagerDriver.java
+++ b/flink-kubernetes/src/main/java/org/apache/flink/kubernetes/KubernetesResourceManagerDriver.java
@@ -18,8 +18,10 @@
 
 package org.apache.flink.kubernetes;
 
+import org.apache.flink.configuration.BlobServerOptions;
 import org.apache.flink.configuration.Configuration;
 import org.apache.flink.configuration.GlobalConfiguration;
+import org.apache.flink.configuration.JobManagerOptions;
 import org.apache.flink.configuration.TaskManagerOptions;
 import org.apache.flink.kubernetes.configuration.KubernetesConfigOptions;
 import org.apache.flink.kubernetes.configuration.KubernetesResourceManagerDriverConfiguration;
@@ -28,6 +30,7 @@ import org.apache.flink.kubernetes.kubeclient.FlinkPod;
 import org.apache.flink.kubernetes.kubeclient.factory.KubernetesTaskManagerFactory;
 import org.apache.flink.kubernetes.kubeclient.parameters.KubernetesTaskManagerParameters;
 import org.apache.flink.kubernetes.kubeclient.resources.KubernetesPod;
+import org.apache.flink.kubernetes.kubeclient.resources.KubernetesService;
 import org.apache.flink.kubernetes.kubeclient.resources.KubernetesTooOldResourceVersionException;
 import org.apache.flink.kubernetes.kubeclient.resources.KubernetesWatch;
 import org.apache.flink.kubernetes.utils.Constants;
@@ -38,9 +41,11 @@ import org.apache.flink.runtime.clusterframework.ContaineredTaskManagerParameter
 import org.apache.flink.runtime.clusterframework.TaskExecutorProcessSpec;
 import org.apache.flink.runtime.clusterframework.types.ResourceID;
 import org.apache.flink.runtime.externalresource.ExternalResourceUtils;
+import org.apache.flink.runtime.jobmanager.HighAvailabilityMode;
 import org.apache.flink.runtime.resourcemanager.active.AbstractResourceManagerDriver;
 import org.apache.flink.runtime.resourcemanager.active.ResourceManagerDriver;
 import org.apache.flink.runtime.resourcemanager.exceptions.ResourceManagerException;
+import org.apache.flink.runtime.util.ResourceManagerUtils;
 import org.apache.flink.runtime.util.config.memory.ProcessMemoryUtils;
 import org.apache.flink.util.ExceptionUtils;
 import org.apache.flink.util.FlinkException;
@@ -66,6 +71,8 @@ public class KubernetesResourceManagerDriver
 
     private final String clusterId;
 
+    private final String webInterfaceUrl;
+
     private final FlinkKubeClient flinkKubeClient;
 
     /** Request resource futures, keyed by pod names. */
@@ -89,6 +96,7 @@ public class KubernetesResourceManagerDriver
             KubernetesResourceManagerDriverConfiguration configuration) {
         super(flinkConfig, GlobalConfiguration.loadConfiguration());
         this.clusterId = Preconditions.checkNotNull(configuration.getClusterId());
+        this.webInterfaceUrl = configuration.getWebInterfaceUrl();
         this.flinkKubeClient = Preconditions.checkNotNull(flinkKubeClient);
         this.requestResourceFutures = new HashMap<>();
         this.running = false;
@@ -109,6 +117,7 @@ public class KubernetesResourceManagerDriver
         } else {
             taskManagerPodTemplate = new FlinkPod.Builder().build();
         }
+        updateKubernetesServiceTargetPortIfNecessary();
         recoverWorkerNodesFromPreviousAttempts();
         this.running = true;
     }
@@ -238,6 +247,39 @@ public class KubernetesResourceManagerDriver
         // Should not invoke resource event handler on the main thread executor.
         // We are in the initializing thread. The main thread executor is not yet ready.
         getResourceEventHandler().onPreviousAttemptWorkersRecovered(recoveredWorkers);
+    }
+
+    private void updateKubernetesServiceTargetPortIfNecessary() throws Exception {
+        if (!KubernetesUtils.isHostNetwork(flinkConfig)) {
+            return;
+        }
+        final int restPort =
+                ResourceManagerUtils.parseRestBindPortFromWebInterfaceUrl(webInterfaceUrl);
+        Preconditions.checkArgument(
+                restPort > 0, "Failed to parse rest port from " + webInterfaceUrl);
+        flinkKubeClient
+                .updateServiceTargetPort(
+                        KubernetesService.ServiceType.REST_SERVICE,
+                        clusterId,
+                        Constants.REST_PORT_NAME,
+                        restPort)
+                .get();
+        if (!HighAvailabilityMode.isHighAvailabilityModeActivated(flinkConfig)) {
+            flinkKubeClient
+                    .updateServiceTargetPort(
+                            KubernetesService.ServiceType.INTERNAL_SERVICE,
+                            clusterId,
+                            Constants.BLOB_SERVER_PORT_NAME,
+                            Integer.parseInt(flinkConfig.getString(BlobServerOptions.PORT)))
+                    .get();
+            flinkKubeClient
+                    .updateServiceTargetPort(
+                            KubernetesService.ServiceType.INTERNAL_SERVICE,
+                            clusterId,
+                            Constants.JOB_MANAGER_RPC_PORT_NAME,
+                            flinkConfig.getInteger(JobManagerOptions.PORT))
+                    .get();
+        }
     }
 
     private KubernetesTaskManagerParameters createKubernetesTaskManagerParameters(

--- a/flink-kubernetes/src/main/java/org/apache/flink/kubernetes/cli/KubernetesSessionCli.java
+++ b/flink-kubernetes/src/main/java/org/apache/flink/kubernetes/cli/KubernetesSessionCli.java
@@ -36,6 +36,7 @@ import org.apache.flink.configuration.UnmodifiableConfiguration;
 import org.apache.flink.kubernetes.executors.KubernetesSessionClusterExecutor;
 import org.apache.flink.kubernetes.kubeclient.FlinkKubeClient;
 import org.apache.flink.kubernetes.kubeclient.FlinkKubeClientFactory;
+import org.apache.flink.kubernetes.kubeclient.resources.KubernetesService;
 import org.apache.flink.runtime.security.SecurityUtils;
 import org.apache.flink.util.FlinkException;
 
@@ -106,7 +107,10 @@ public class KubernetesSessionCli {
                     FlinkKubeClientFactory.getInstance().fromConfiguration(configuration, "client");
 
             // Retrieve or create a session cluster.
-            if (clusterId != null && kubeClient.getRestService(clusterId).isPresent()) {
+            if (clusterId != null
+                    && kubeClient
+                            .getService(KubernetesService.ServiceType.REST_SERVICE, clusterId)
+                            .isPresent()) {
                 clusterClient = kubernetesClusterDescriptor.retrieve(clusterId).getClusterClient();
             } else {
                 clusterClient =

--- a/flink-kubernetes/src/main/java/org/apache/flink/kubernetes/configuration/KubernetesConfigOptions.java
+++ b/flink-kubernetes/src/main/java/org/apache/flink/kubernetes/configuration/KubernetesConfigOptions.java
@@ -485,6 +485,14 @@ public class KubernetesConfigOptions {
                                     + "It will help to achieve faster recovery. "
                                     + "Notice that high availability should be enabled when starting standby JobManagers.");
 
+    public static final ConfigOption<Boolean> KUBERNETES_HOSTNETWORK_ENABLED =
+            key("kubernetes.hostnetwork.enabled")
+                    .booleanType()
+                    .defaultValue(false)
+                    .withDescription(
+                            "Whether to enable HostNetwork mode. "
+                                    + "The HostNetwork allows the pod could use the node network namespace instead of the individual pod network namespace. Please note that the JobManager service account should have the permission to update Kubernetes service.");
+
     private static String getDefaultFlinkImage() {
         // The default container image that ties to the exact needed versions of both Flink and
         // Scala.

--- a/flink-kubernetes/src/main/java/org/apache/flink/kubernetes/configuration/KubernetesResourceManagerDriverConfiguration.java
+++ b/flink-kubernetes/src/main/java/org/apache/flink/kubernetes/configuration/KubernetesResourceManagerDriverConfiguration.java
@@ -18,6 +18,8 @@
 
 package org.apache.flink.kubernetes.configuration;
 
+import javax.annotation.Nullable;
+
 /**
  * Configuration specific to {@link org.apache.flink.kubernetes.KubernetesResourceManagerDriver}.
  */
@@ -25,11 +27,20 @@ public class KubernetesResourceManagerDriverConfiguration {
 
     private final String clusterId;
 
-    public KubernetesResourceManagerDriverConfiguration(String clusterId) {
+    @Nullable private final String webInterfaceUrl;
+
+    public KubernetesResourceManagerDriverConfiguration(
+            String clusterId, @Nullable String webInterfaceUrl) {
         this.clusterId = clusterId;
+        this.webInterfaceUrl = webInterfaceUrl;
     }
 
     public String getClusterId() {
         return clusterId;
+    }
+
+    @Nullable
+    public String getWebInterfaceUrl() {
+        return webInterfaceUrl;
     }
 }

--- a/flink-kubernetes/src/main/java/org/apache/flink/kubernetes/entrypoint/KubernetesEntrypointUtils.java
+++ b/flink-kubernetes/src/main/java/org/apache/flink/kubernetes/entrypoint/KubernetesEntrypointUtils.java
@@ -18,13 +18,17 @@
 
 package org.apache.flink.kubernetes.entrypoint;
 
+import org.apache.flink.configuration.BlobServerOptions;
 import org.apache.flink.configuration.ConfigConstants;
 import org.apache.flink.configuration.Configuration;
 import org.apache.flink.configuration.GlobalConfiguration;
+import org.apache.flink.configuration.HighAvailabilityOptions;
 import org.apache.flink.configuration.JobManagerOptions;
 import org.apache.flink.configuration.RestOptions;
+import org.apache.flink.configuration.TaskManagerOptions;
 import org.apache.flink.kubernetes.KubernetesClusterDescriptor;
 import org.apache.flink.kubernetes.utils.Constants;
+import org.apache.flink.kubernetes.utils.KubernetesUtils;
 import org.apache.flink.runtime.jobmanager.HighAvailabilityMode;
 import org.apache.flink.util.Preconditions;
 
@@ -54,6 +58,14 @@ class KubernetesEntrypointUtils {
 
         final Configuration configuration =
                 GlobalConfiguration.loadConfiguration(configDir, dynamicParameters);
+
+        if (KubernetesUtils.isHostNetwork(configuration)) {
+            configuration.setString(RestOptions.BIND_PORT, "0");
+            configuration.setInteger(JobManagerOptions.PORT, 0);
+            configuration.setString(BlobServerOptions.PORT, "0");
+            configuration.setString(HighAvailabilityOptions.HA_JOB_MANAGER_PORT_RANGE, "0");
+            configuration.setString(TaskManagerOptions.RPC_PORT, "0");
+        }
 
         if (HighAvailabilityMode.isHighAvailabilityModeActivated(configuration)) {
             final String ipAddress = System.getenv().get(Constants.ENV_FLINK_POD_IP_ADDRESS);

--- a/flink-kubernetes/src/main/java/org/apache/flink/kubernetes/entrypoint/KubernetesResourceManagerFactory.java
+++ b/flink-kubernetes/src/main/java/org/apache/flink/kubernetes/entrypoint/KubernetesResourceManagerFactory.java
@@ -54,7 +54,8 @@ public class KubernetesResourceManagerFactory
         final KubernetesResourceManagerDriverConfiguration
                 kubernetesResourceManagerDriverConfiguration =
                         new KubernetesResourceManagerDriverConfiguration(
-                                configuration.getString(KubernetesConfigOptions.CLUSTER_ID));
+                                configuration.getString(KubernetesConfigOptions.CLUSTER_ID),
+                                webInterfaceUrl);
 
         return new KubernetesResourceManagerDriver(
                 configuration,

--- a/flink-kubernetes/src/main/java/org/apache/flink/kubernetes/kubeclient/Fabric8FlinkKubeClient.java
+++ b/flink-kubernetes/src/main/java/org/apache/flink/kubernetes/kubeclient/Fabric8FlinkKubeClient.java
@@ -22,6 +22,7 @@ import org.apache.flink.configuration.Configuration;
 import org.apache.flink.kubernetes.configuration.KubernetesConfigOptions;
 import org.apache.flink.kubernetes.configuration.KubernetesLeaderElectionConfiguration;
 import org.apache.flink.kubernetes.kubeclient.decorators.ExternalServiceDecorator;
+import org.apache.flink.kubernetes.kubeclient.decorators.InternalServiceDecorator;
 import org.apache.flink.kubernetes.kubeclient.resources.KubernetesConfigMap;
 import org.apache.flink.kubernetes.kubeclient.resources.KubernetesConfigMapSharedInformer;
 import org.apache.flink.kubernetes.kubeclient.resources.KubernetesException;
@@ -40,12 +41,14 @@ import org.apache.flink.util.concurrent.FutureUtils;
 
 import io.fabric8.kubernetes.api.model.ConfigMap;
 import io.fabric8.kubernetes.api.model.HasMetadata;
+import io.fabric8.kubernetes.api.model.IntOrString;
 import io.fabric8.kubernetes.api.model.LoadBalancerStatus;
 import io.fabric8.kubernetes.api.model.NodeAddress;
 import io.fabric8.kubernetes.api.model.OwnerReference;
 import io.fabric8.kubernetes.api.model.OwnerReferenceBuilder;
 import io.fabric8.kubernetes.api.model.Pod;
 import io.fabric8.kubernetes.api.model.Service;
+import io.fabric8.kubernetes.api.model.ServiceBuilder;
 import io.fabric8.kubernetes.api.model.ServicePort;
 import io.fabric8.kubernetes.api.model.apps.Deployment;
 import io.fabric8.kubernetes.client.KubernetesClientException;
@@ -169,7 +172,8 @@ public class Fabric8FlinkKubeClient implements FlinkKubeClient {
 
     @Override
     public Optional<Endpoint> getRestEndpoint(String clusterId) {
-        Optional<KubernetesService> restService = getRestService(clusterId);
+        Optional<KubernetesService> restService =
+                getService(KubernetesService.ServiceType.REST_SERVICE, clusterId);
         if (!restService.isPresent()) {
             return Optional.empty();
         }
@@ -213,17 +217,15 @@ public class Fabric8FlinkKubeClient implements FlinkKubeClient {
     }
 
     @Override
-    public Optional<KubernetesService> getRestService(String clusterId) {
-        final String serviceName = ExternalServiceDecorator.getExternalServiceName(clusterId);
-
+    public Optional<KubernetesService> getService(
+            KubernetesService.ServiceType serviceType, String clusterId) {
+        final String serviceName = getServiceName(serviceType, clusterId);
         final Service service =
                 this.internalClient.services().withName(serviceName).fromServer().get();
-
         if (service == null) {
             LOG.debug("Service {} does not exist", serviceName);
             return Optional.empty();
         }
-
         return Optional.of(new KubernetesService(service));
     }
 
@@ -371,6 +373,62 @@ public class Fabric8FlinkKubeClient implements FlinkKubeClient {
                     String.format("Pod template file %s does not exist.", file));
         }
         return new KubernetesPod(this.internalClient.pods().load(file).get());
+    }
+
+    @Override
+    public CompletableFuture<Void> updateServiceTargetPort(
+            KubernetesService.ServiceType serviceType,
+            String clusterId,
+            String portName,
+            int targetPort) {
+        LOG.debug("Update {} target port to {}", portName, targetPort);
+        return CompletableFuture.runAsync(
+                () ->
+                        getService(serviceType, clusterId)
+                                .ifPresent(
+                                        service -> {
+                                            final Service updatedService =
+                                                    new ServiceBuilder(
+                                                                    service.getInternalResource())
+                                                            .editSpec()
+                                                            .editMatchingPort(
+                                                                    servicePortBuilder ->
+                                                                            servicePortBuilder
+                                                                                    .build()
+                                                                                    .getName()
+                                                                                    .equals(
+                                                                                            portName))
+                                                            .withTargetPort(
+                                                                    new IntOrString(targetPort))
+                                                            .endPort()
+                                                            .endSpec()
+                                                            .build();
+                                            this.internalClient
+                                                    .services()
+                                                    .withName(
+                                                            getServiceName(serviceType, clusterId))
+                                                    .replace(updatedService);
+                                        }),
+                kubeClientExecutorService);
+    }
+
+    /**
+     * Get the Kubernetes service name.
+     *
+     * @param serviceType The service type
+     * @param clusterId The cluster id
+     * @return Return the Kubernetes service name if the service type is known.
+     */
+    private String getServiceName(KubernetesService.ServiceType serviceType, String clusterId) {
+        switch (serviceType) {
+            case REST_SERVICE:
+                return ExternalServiceDecorator.getExternalServiceName(clusterId);
+            case INTERNAL_SERVICE:
+                return InternalServiceDecorator.getInternalServiceName(clusterId);
+            default:
+                throw new IllegalArgumentException(
+                        "Unrecognized service type: " + serviceType.name());
+        }
     }
 
     private void setOwnerReference(Deployment deployment, List<HasMetadata> resources) {

--- a/flink-kubernetes/src/main/java/org/apache/flink/kubernetes/kubeclient/FlinkKubeClient.java
+++ b/flink-kubernetes/src/main/java/org/apache/flink/kubernetes/kubeclient/FlinkKubeClient.java
@@ -74,12 +74,14 @@ public interface FlinkKubeClient extends AutoCloseable {
     void stopAndCleanupCluster(String clusterId);
 
     /**
-     * Get the kubernetes rest service of the given flink clusterId.
+     * Get the kubernetes service of the given flink clusterId.
      *
+     * @param serviceType Internal/Rest
      * @param clusterId cluster id
      * @return Return the optional rest service of the specified cluster id.
      */
-    Optional<KubernetesService> getRestService(String clusterId);
+    Optional<KubernetesService> getService(
+            KubernetesService.ServiceType serviceType, String clusterId);
 
     /**
      * Get the rest endpoint for access outside cluster.
@@ -200,6 +202,20 @@ public interface FlinkKubeClient extends AutoCloseable {
      * @return Return a Kubernetes pod loaded from the template.
      */
     KubernetesPod loadPodFromTemplateFile(File podTemplateFile);
+
+    /**
+     * Update the target ports of the given Kubernetes service.
+     *
+     * @param serviceType The service type which needs to be updated
+     * @param portName The port name which needs to be updated
+     * @param targetPort The updated target port
+     * @return Return the update service target port future
+     */
+    CompletableFuture<Void> updateServiceTargetPort(
+            KubernetesService.ServiceType serviceType,
+            String clusterId,
+            String portName,
+            int targetPort);
 
     /** Callback handler for kubernetes resources. */
     interface WatchCallbackHandler<T> {

--- a/flink-kubernetes/src/main/java/org/apache/flink/kubernetes/kubeclient/decorators/InitJobManagerDecorator.java
+++ b/flink-kubernetes/src/main/java/org/apache/flink/kubernetes/kubeclient/decorators/InitJobManagerDecorator.java
@@ -43,6 +43,8 @@ import java.util.Optional;
 import java.util.stream.Collectors;
 
 import static org.apache.flink.kubernetes.utils.Constants.API_VERSION;
+import static org.apache.flink.kubernetes.utils.Constants.DNS_PLOICY_DEFAULT;
+import static org.apache.flink.kubernetes.utils.Constants.DNS_PLOICY_HOSTNETWORK;
 import static org.apache.flink.kubernetes.utils.Constants.ENV_FLINK_POD_IP_ADDRESS;
 import static org.apache.flink.kubernetes.utils.Constants.POD_IP_FIELD_PATH;
 import static org.apache.flink.util.Preconditions.checkNotNull;
@@ -80,6 +82,11 @@ public class InitJobManagerDecorator extends AbstractKubernetesStepDecorator {
                 .editOrNewSpec()
                 .withServiceAccount(serviceAccountName)
                 .withServiceAccountName(serviceAccountName)
+                .withHostNetwork(kubernetesJobManagerParameters.isHostNetworkEnabled())
+                .withDnsPolicy(
+                        kubernetesJobManagerParameters.isHostNetworkEnabled()
+                                ? DNS_PLOICY_HOSTNETWORK
+                                : DNS_PLOICY_DEFAULT)
                 .endSpec();
 
         // Merge fields
@@ -157,6 +164,9 @@ public class InitJobManagerDecorator extends AbstractKubernetesStepDecorator {
     }
 
     private List<ContainerPort> getContainerPorts() {
+        if (kubernetesJobManagerParameters.isHostNetworkEnabled()) {
+            return Collections.emptyList();
+        }
         return Arrays.asList(
                 new ContainerPortBuilder()
                         .withName(Constants.REST_PORT_NAME)

--- a/flink-kubernetes/src/main/java/org/apache/flink/kubernetes/kubeclient/decorators/InitTaskManagerDecorator.java
+++ b/flink-kubernetes/src/main/java/org/apache/flink/kubernetes/kubeclient/decorators/InitTaskManagerDecorator.java
@@ -28,15 +28,19 @@ import org.apache.flink.kubernetes.utils.KubernetesUtils;
 
 import io.fabric8.kubernetes.api.model.Container;
 import io.fabric8.kubernetes.api.model.ContainerBuilder;
+import io.fabric8.kubernetes.api.model.ContainerPort;
 import io.fabric8.kubernetes.api.model.ContainerPortBuilder;
 import io.fabric8.kubernetes.api.model.EnvVar;
 import io.fabric8.kubernetes.api.model.PodBuilder;
 import io.fabric8.kubernetes.api.model.ResourceRequirements;
 
+import java.util.Collections;
 import java.util.List;
 import java.util.Optional;
 import java.util.stream.Collectors;
 
+import static org.apache.flink.kubernetes.utils.Constants.DNS_PLOICY_DEFAULT;
+import static org.apache.flink.kubernetes.utils.Constants.DNS_PLOICY_HOSTNETWORK;
 import static org.apache.flink.util.Preconditions.checkNotNull;
 
 /** An initializer for the TaskManager {@link org.apache.flink.kubernetes.kubeclient.FlinkPod}. */
@@ -77,6 +81,11 @@ public class InitTaskManagerDecorator extends AbstractKubernetesStepDecorator {
                 .withServiceAccount(serviceAccountName)
                 .withServiceAccountName(serviceAccountName)
                 .withRestartPolicy(Constants.RESTART_POLICY_OF_NEVER)
+                .withHostNetwork(kubernetesTaskManagerParameters.isHostNetworkEnabled())
+                .withDnsPolicy(
+                        kubernetesTaskManagerParameters.isHostNetworkEnabled()
+                                ? DNS_PLOICY_HOSTNETWORK
+                                : DNS_PLOICY_DEFAULT)
                 .endSpec();
 
         // Merge fields
@@ -140,16 +149,21 @@ public class InitTaskManagerDecorator extends AbstractKubernetesStepDecorator {
                 .withResources(resourceRequirements);
 
         // Merge fields
-        mainContainerBuilder
-                .addToPorts(
-                        new ContainerPortBuilder()
-                                .withName(Constants.TASK_MANAGER_RPC_PORT_NAME)
-                                .withContainerPort(kubernetesTaskManagerParameters.getRPCPort())
-                                .build())
-                .addAllToEnv(getCustomizedEnvs());
+        mainContainerBuilder.addAllToPorts(getContainerPorts()).addAllToEnv(getCustomizedEnvs());
         getFlinkLogDirEnv().ifPresent(mainContainerBuilder::addToEnv);
 
         return mainContainerBuilder.build();
+    }
+
+    private List<ContainerPort> getContainerPorts() {
+        if (kubernetesTaskManagerParameters.isHostNetworkEnabled()) {
+            return Collections.emptyList();
+        }
+        return Collections.singletonList(
+                new ContainerPortBuilder()
+                        .withName(Constants.TASK_MANAGER_RPC_PORT_NAME)
+                        .withContainerPort(kubernetesTaskManagerParameters.getRPCPort())
+                        .build());
     }
 
     private List<EnvVar> getCustomizedEnvs() {

--- a/flink-kubernetes/src/main/java/org/apache/flink/kubernetes/kubeclient/parameters/AbstractKubernetesParameters.java
+++ b/flink-kubernetes/src/main/java/org/apache/flink/kubernetes/kubeclient/parameters/AbstractKubernetesParameters.java
@@ -202,4 +202,8 @@ public abstract class AbstractKubernetesParameters implements KubernetesParamete
                 .getOptional(KubernetesConfigOptions.KUBERNETES_ENV_SECRET_KEY_REF)
                 .orElse(Collections.emptyList());
     }
+
+    public boolean isHostNetworkEnabled() {
+        return flinkConfig.getBoolean(KubernetesConfigOptions.KUBERNETES_HOSTNETWORK_ENABLED);
+    }
 }

--- a/flink-kubernetes/src/main/java/org/apache/flink/kubernetes/kubeclient/resources/KubernetesService.java
+++ b/flink-kubernetes/src/main/java/org/apache/flink/kubernetes/kubeclient/resources/KubernetesService.java
@@ -26,4 +26,10 @@ public class KubernetesService extends KubernetesResource<Service> {
     public KubernetesService(Service internalResource) {
         super(internalResource);
     }
+
+    /** The flink service type. */
+    public enum ServiceType {
+        REST_SERVICE,
+        INTERNAL_SERVICE,
+    }
 }

--- a/flink-kubernetes/src/main/java/org/apache/flink/kubernetes/utils/Constants.java
+++ b/flink-kubernetes/src/main/java/org/apache/flink/kubernetes/utils/Constants.java
@@ -25,6 +25,9 @@ public class Constants {
     public static final String API_VERSION = "v1";
     public static final String APPS_API_VERSION = "apps/v1";
 
+    public static final String DNS_PLOICY_DEFAULT = "ClusterFirst";
+    public static final String DNS_PLOICY_HOSTNETWORK = "ClusterFirstWithHostNet";
+
     public static final String CONFIG_FILE_LOGBACK_NAME = "logback-console.xml";
     public static final String CONFIG_FILE_LOG4J_NAME = "log4j-console.properties";
     public static final String ENV_FLINK_LOG_DIR = "FLINK_LOG_DIR";

--- a/flink-kubernetes/src/main/java/org/apache/flink/kubernetes/utils/KubernetesUtils.java
+++ b/flink-kubernetes/src/main/java/org/apache/flink/kubernetes/utils/KubernetesUtils.java
@@ -23,6 +23,7 @@ import org.apache.flink.client.program.PackagedProgramUtils;
 import org.apache.flink.configuration.ConfigOption;
 import org.apache.flink.configuration.Configuration;
 import org.apache.flink.configuration.PipelineOptions;
+import org.apache.flink.kubernetes.configuration.KubernetesConfigOptions;
 import org.apache.flink.kubernetes.highavailability.KubernetesCheckpointStoreUtil;
 import org.apache.flink.kubernetes.highavailability.KubernetesJobGraphStoreUtil;
 import org.apache.flink.kubernetes.highavailability.KubernetesStateHandleStore;
@@ -499,6 +500,11 @@ public class KubernetesUtils {
                     "Failed to get the pretty print yaml, fallback to {}", kubernetesResource, ex);
             return kubernetesResource.toString();
         }
+    }
+
+    /** Checks if hostNetwork is enabled. */
+    public static boolean isHostNetwork(Configuration configuration) {
+        return configuration.getBoolean(KubernetesConfigOptions.KUBERNETES_HOSTNETWORK_ENABLED);
     }
 
     /** Cluster components. */

--- a/flink-kubernetes/src/test/java/org/apache/flink/kubernetes/KubernetesResourceManagerDriverTest.java
+++ b/flink-kubernetes/src/test/java/org/apache/flink/kubernetes/KubernetesResourceManagerDriverTest.java
@@ -62,7 +62,7 @@ public class KubernetesResourceManagerDriverTest
     private static final String CLUSTER_ID = "testing-flink-cluster";
     private static final KubernetesResourceManagerDriverConfiguration
             KUBERNETES_RESOURCE_MANAGER_CONFIGURATION =
-                    new KubernetesResourceManagerDriverConfiguration(CLUSTER_ID);
+                    new KubernetesResourceManagerDriverConfiguration(CLUSTER_ID, "localhost:9000");
 
     @Test
     public void testOnPodAdded() throws Exception {

--- a/flink-kubernetes/src/test/java/org/apache/flink/kubernetes/kubeclient/TestingFlinkKubeClient.java
+++ b/flink-kubernetes/src/test/java/org/apache/flink/kubernetes/kubeclient/TestingFlinkKubeClient.java
@@ -138,7 +138,8 @@ public class TestingFlinkKubeClient implements FlinkKubeClient {
     }
 
     @Override
-    public Optional<KubernetesService> getRestService(String clusterId) {
+    public Optional<KubernetesService> getService(
+            KubernetesService.ServiceType serviceType, String clusterId) {
         throw new UnsupportedOperationException();
     }
 
@@ -205,6 +206,15 @@ public class TestingFlinkKubeClient implements FlinkKubeClient {
 
     @Override
     public KubernetesPod loadPodFromTemplateFile(File file) {
+        throw new UnsupportedOperationException();
+    }
+
+    @Override
+    public CompletableFuture<Void> updateServiceTargetPort(
+            KubernetesService.ServiceType serviceType,
+            String clusterId,
+            String portName,
+            int targetPort) {
         throw new UnsupportedOperationException();
     }
 

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/entrypoint/ClusterEntrypoint.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/entrypoint/ClusterEntrypoint.java
@@ -19,6 +19,7 @@
 package org.apache.flink.runtime.entrypoint;
 
 import org.apache.flink.api.common.time.Time;
+import org.apache.flink.configuration.BlobServerOptions;
 import org.apache.flink.configuration.ClusterOptions;
 import org.apache.flink.configuration.ConfigOption;
 import org.apache.flink.configuration.ConfigOptions;
@@ -355,6 +356,7 @@ public abstract class ClusterEntrypoint implements AutoCloseableAsync, FatalErro
                             Reference.borrowed(workingDirectory.unwrap().getBlobStorageDirectory()),
                             haServices.createBlobStore());
             blobServer.start();
+            configuration.setString(BlobServerOptions.PORT, String.valueOf(blobServer.getPort()));
             heartbeatServices = createHeartbeatServices(configuration);
             metricRegistry = createMetricRegistry(configuration, pluginManager, rpcSystem);
 

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/util/ResourceManagerUtils.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/util/ResourceManagerUtils.java
@@ -1,0 +1,47 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.flink.runtime.util;
+
+/** Common utils for ResourceManager. */
+public class ResourceManagerUtils {
+
+    /**
+     * Parse the port from the webInterfaceUrl.
+     *
+     * @param webInterfaceUrl The web interface url to be parsed
+     * @return the parsed rest port or -1 if failed
+     */
+    public static Integer parseRestBindPortFromWebInterfaceUrl(String webInterfaceUrl) {
+        if (webInterfaceUrl != null) {
+            final int lastColon = webInterfaceUrl.lastIndexOf(':');
+
+            if (lastColon == -1) {
+                return -1;
+            } else {
+                try {
+                    return Integer.parseInt(webInterfaceUrl.substring(lastColon + 1));
+                } catch (NumberFormatException e) {
+                    return -1;
+                }
+            }
+        } else {
+            return -1;
+        }
+    }
+}

--- a/flink-runtime/src/test/java/org/apache/flink/runtime/util/ResourceManagerUtilsTest.java
+++ b/flink-runtime/src/test/java/org/apache/flink/runtime/util/ResourceManagerUtilsTest.java
@@ -1,0 +1,58 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.flink.runtime.util;
+
+import org.junit.Test;
+
+import static org.hamcrest.CoreMatchers.is;
+import static org.hamcrest.MatcherAssert.assertThat;
+
+public class ResourceManagerUtilsTest {
+
+    @Test
+    public void testParseRestBindPortFromWebInterfaceUrlWithEmptyUrl() {
+        assertThat(ResourceManagerUtils.parseRestBindPortFromWebInterfaceUrl(""), is(-1));
+    }
+
+    @Test
+    public void testParseRestBindPortFromWebInterfaceUrlWithNullUrl() {
+        assertThat(ResourceManagerUtils.parseRestBindPortFromWebInterfaceUrl(null), is(-1));
+    }
+
+    @Test
+    public void testParseRestBindPortFromWebInterfaceUrlWithInvalidSchema() {
+        assertThat(
+                ResourceManagerUtils.parseRestBindPortFromWebInterfaceUrl("localhost:8080//"),
+                is(-1));
+    }
+
+    @Test
+    public void testParseRestBindPortFromWebInterfaceUrlWithInvalidPort() {
+        assertThat(
+                ResourceManagerUtils.parseRestBindPortFromWebInterfaceUrl("localhost:port1"),
+                is(-1));
+    }
+
+    @Test
+    public void testParseRestBindPortFromWebInterfaceUrlWithValidPort() {
+        assertThat(
+                ResourceManagerUtils.parseRestBindPortFromWebInterfaceUrl("localhost:8080"),
+                is(8080));
+    }
+}

--- a/flink-yarn/src/main/java/org/apache/flink/yarn/YarnResourceManagerDriver.java
+++ b/flink-yarn/src/main/java/org/apache/flink/yarn/YarnResourceManagerDriver.java
@@ -32,6 +32,7 @@ import org.apache.flink.runtime.externalresource.ExternalResourceUtils;
 import org.apache.flink.runtime.resourcemanager.active.AbstractResourceManagerDriver;
 import org.apache.flink.runtime.resourcemanager.active.ResourceManagerDriver;
 import org.apache.flink.runtime.resourcemanager.exceptions.ResourceManagerException;
+import org.apache.flink.runtime.util.ResourceManagerUtils;
 import org.apache.flink.runtime.webmonitor.history.HistoryServerUtils;
 import org.apache.flink.util.ExceptionUtils;
 import org.apache.flink.util.Preconditions;
@@ -492,24 +493,11 @@ public class YarnResourceManagerDriver extends AbstractResourceManagerDriver<Yar
     }
 
     private RegisterApplicationMasterResponse registerApplicationMaster() throws Exception {
-        final int restPort;
-        final String webInterfaceUrl = configuration.getWebInterfaceUrl();
-        final String rpcAddress = configuration.getRpcAddress();
-
-        if (webInterfaceUrl != null) {
-            final int lastColon = webInterfaceUrl.lastIndexOf(':');
-
-            if (lastColon == -1) {
-                restPort = -1;
-            } else {
-                restPort = Integer.parseInt(webInterfaceUrl.substring(lastColon + 1));
-            }
-        } else {
-            restPort = -1;
-        }
-
         return resourceManagerClient.registerApplicationMaster(
-                rpcAddress, restPort, webInterfaceUrl);
+                configuration.getRpcAddress(),
+                ResourceManagerUtils.parseRestBindPortFromWebInterfaceUrl(
+                        configuration.getWebInterfaceUrl()),
+                configuration.getWebInterfaceUrl());
     }
 
     private void getContainersFromPreviousAttempts(


### PR DESCRIPTION
<!--
*Thank you very much for contributing to Apache Flink - we are happy that you want to help us improve Flink. To help the community review your contribution in the best possible way, please go through the checklist below, which will get the contribution into a shape in which it can be best reviewed.*

*Please understand that we do not do this to make contributions to Flink a hassle. In order to uphold a high standard of quality for code contributions, while at the same time managing a large number of contributions, we need contributors to prepare the contributions well, and give reviewers enough contextual information for the review. Please also understand that contributions that do not follow this guide will take longer to review and thus typically be picked up with lower priority by the community.*

## Contribution Checklist

  - Make sure that the pull request corresponds to a [JIRA issue](https://issues.apache.org/jira/projects/FLINK/issues). Exceptions are made for typos in JavaDoc or documentation files, which need no JIRA issue.
  
  - Name the pull request in the form "[FLINK-XXXX] [component] Title of the pull request", where *FLINK-XXXX* should be replaced by the actual issue number. Skip *component* if you are unsure about which is the best component.
  Typo fixes that have no associated JIRA issue should be named following this pattern: `[hotfix] [docs] Fix typo in event time introduction` or `[hotfix] [javadocs] Expand JavaDoc for PuncuatedWatermarkGenerator`.

  - Fill out the template below to describe the changes contributed by the pull request. That will give reviewers the context they need to do the review.
  
  - Make sure that the change passes the automated tests, i.e., `mvn clean verify` passes. You can set up Azure Pipelines CI to do that following [this guide](https://cwiki.apache.org/confluence/display/FLINK/Azure+Pipelines#AzurePipelines-Tutorial:SettingupAzurePipelinesforaforkoftheFlinkrepository).

  - Each pull request should address only one issue, not mix up code from multiple issues.
  
  - Each commit in the pull request has a meaningful commit message (including the JIRA id)

  - Once all items of the checklist are addressed, remove the above text and this checklist, leaving only the filled out template below.


**(The sections below can be removed for hotfixes of typos)**
-->

## What is the purpose of the change

Provide hostnetwork network mode for jobs running in native kubernetes mode to obtain better performance in unmanaged clusters(for session mode)

## Brief change log

When a job is running in session mode, you can start the hostnetwork mode by configuring "kubernetes.hostnetwork.enabled=true". After it is turned on, the pod of JobManager and TaskManager will use the host network instead of the third-party CNI plug-in.
1. Use a random port when starting a session
2. Update the targetPort of the corresponding ports of InternalService and ExternalService to the real value whenever the session starts successfully 


## Verifying this change


The session and job are started when "kubernetes.hostnetwork.enabled=true" is configured. When the task is running normally, the JobManager is killed. After the JobManager is automatically started, the TaskManager will be correctly connected to the JobManager and can be connected to the session through flink-client

## Does this pull request potentially affect one of the following parts:

  - Dependencies (does it add or upgrade a dependency): (no)
  - The public API, i.e., is any changed class annotated with `@Public(Evolving)`: (no)
  - The serializers: ( no)
  - The runtime per-record code paths (performance sensitive): (no )
  - Anything that affects deployment or recovery: JobManager (and its components), Checkpointing, Kubernetes/Yarn, ZooKeeper: (yes )
  - The S3 file system connector: (no )

## Documentation

  - Does this pull request introduce a new feature? (yes )
  - If yes, how is the feature documented? (docs)
