### PR TITLE
[FLINK-24809][table-common][table-planner] Fix precision for aggs on DECIMAL types

### DIFF
--- a/flink-table/flink-table-common/src/main/java/org/apache/flink/table/functions/BuiltInFunctionDefinitions.java
+++ b/flink-table/flink-table-common/src/main/java/org/apache/flink/table/functions/BuiltInFunctionDefinitions.java
@@ -762,10 +762,10 @@ public final class BuiltInFunctionDefinitions {
                     .build();
 
     /**
-     * Special "+" operator used internally by {@code SumAggFunction} to implement SUM aggregation
-     * on a Decimal type. Uses the {@link LogicalTypeMerging#findSumAggType(LogicalType)} to avoid
-     * the normal {@link #PLUS} override the special calculation for precision and scale needed by
-     * SUM.
+     * Special "+" operator used internally for implementing SUM/AVG aggregations (with and without
+     * retractions) on a Decimal type. Uses the {@link
+     * LogicalTypeMerging#findSumAggType(LogicalType)} to prevent the normal {@link #PLUS} from
+     * overriding the special calculation for precision and scale needed by the aggregate function.
      */
     public static final BuiltInFunctionDefinition AGG_DECIMAL_PLUS =
             BuiltInFunctionDefinition.newBuilder()
@@ -800,6 +800,24 @@ public final class BuiltInFunctionDefinitions {
                                             logical(LogicalTypeFamily.INTERVAL))))
                     .outputTypeStrategy(
                             nullableIfArgs(first(SpecificTypeStrategies.DECIMAL_PLUS, COMMON)))
+                    .build();
+
+    /**
+     * Special "-" operator used internally for implementing SUM/AVG aggregations (with and without
+     * retractions) on a Decimal type. Uses the {@link
+     * LogicalTypeMerging#findSumAggType(LogicalType)} to prevent the normal {@link #MINUS} from
+     * overriding the special calculation for precision and scale needed by the aggregate function.
+     */
+    public static final BuiltInFunctionDefinition AGG_DECIMAL_MINUS =
+            BuiltInFunctionDefinition.newBuilder()
+                    .name("AGG_DECIMAL_MINUS")
+                    .kind(SCALAR)
+                    .inputTypeStrategy(
+                            sequence(
+                                    logical(LogicalTypeRoot.DECIMAL),
+                                    logical(LogicalTypeRoot.DECIMAL)))
+                    .outputTypeStrategy(SpecificTypeStrategies.AGG_DECIMAL_PLUS)
+                    .runtimeProvided()
                     .build();
 
     public static final BuiltInFunctionDefinition DIVIDE =

--- a/flink-table/flink-table-common/src/main/java/org/apache/flink/table/types/inference/strategies/AggDecimalPlusTypeStrategy.java
+++ b/flink-table/flink-table-common/src/main/java/org/apache/flink/table/types/inference/strategies/AggDecimalPlusTypeStrategy.java
@@ -34,10 +34,11 @@ import java.util.Optional;
 import static org.apache.flink.table.types.utils.TypeConversions.fromLogicalToDataType;
 
 /**
- * Type strategy that returns the result decimal addition used, internally by {@code SumAggFunction}
- * to implement SUM aggregation on a Decimal type. Uses the {@link
- * LogicalTypeMerging#findSumAggType(LogicalType)} and prevents the {@link DecimalPlusTypeStrategy}
- * from overriding the special calculation for precision and scale needed by SUM.
+ * Type strategy that returns the result type of a decimal addition, used internally for
+ * implementing SUM/AVG aggregations (with and without retractions) on a Decimal type. Uses the
+ * {@link LogicalTypeMerging#findSumAggType(LogicalType)} and prevents the {@link
+ * DecimalPlusTypeStrategy} from overriding the special calculation for precision and scale needed
+ * by the aggregate function.
  */
 @Internal
 class AggDecimalPlusTypeStrategy implements TypeStrategy {

--- a/flink-table/flink-table-planner/src/main/java/org/apache/flink/table/planner/expressions/ExpressionBuilder.java
+++ b/flink-table/flink-table-planner/src/main/java/org/apache/flink/table/planner/expressions/ExpressionBuilder.java
@@ -29,6 +29,7 @@ import org.apache.flink.table.types.DataType;
 
 import java.util.List;
 
+import static org.apache.flink.table.functions.BuiltInFunctionDefinitions.AGG_DECIMAL_MINUS;
 import static org.apache.flink.table.functions.BuiltInFunctionDefinitions.AGG_DECIMAL_PLUS;
 import static org.apache.flink.table.functions.BuiltInFunctionDefinitions.AND;
 import static org.apache.flink.table.functions.BuiltInFunctionDefinitions.CAST;
@@ -102,8 +103,11 @@ public class ExpressionBuilder {
         return call(PLUS, input1, input2);
     }
 
-    // Used only for implementing the SumAggFunction to avoid overriding decimal precision/scale
-    // calculation for sum with the rules applied for the normal plus
+    /**
+     * Used only for implementing SUM/AVG aggregations (with and without retractions) on a Decimal
+     * type to avoid overriding decimal precision/scale calculation for sum/avg with the rules
+     * applied for the normal plus.
+     */
     @Internal
     public static UnresolvedCallExpression aggDecimalPlus(Expression input1, Expression input2) {
         return call(AGG_DECIMAL_PLUS, input1, input2);
@@ -111,6 +115,16 @@ public class ExpressionBuilder {
 
     public static UnresolvedCallExpression minus(Expression input1, Expression input2) {
         return call(MINUS, input1, input2);
+    }
+
+    /**
+     * Used only for implementing SUM/AVG aggregations (with and without retractions) on a Decimal
+     * type to avoid overriding decimal precision/scale calculation for sum/avg with the rules
+     * applied for the normal minus.
+     */
+    @Internal
+    public static UnresolvedCallExpression aggDecimalMinus(Expression input1, Expression input2) {
+        return call(AGG_DECIMAL_MINUS, input1, input2);
     }
 
     public static UnresolvedCallExpression div(Expression input1, Expression input2) {

--- a/flink-table/flink-table-planner/src/main/java/org/apache/flink/table/planner/functions/aggfunctions/CollectAggFunction.java
+++ b/flink-table/flink-table-planner/src/main/java/org/apache/flink/table/planner/functions/aggfunctions/CollectAggFunction.java
@@ -41,7 +41,7 @@ public final class CollectAggFunction<T>
 
     private static final long serialVersionUID = -5860934997657147836L;
 
-    private transient DataType elementDataType;
+    private final transient DataType elementDataType;
 
     public CollectAggFunction(LogicalType elementType) {
         this.elementDataType = toInternalDataType(elementType);

--- a/flink-table/flink-table-planner/src/main/java/org/apache/flink/table/planner/functions/aggfunctions/Count1AggFunction.java
+++ b/flink-table/flink-table-planner/src/main/java/org/apache/flink/table/planner/functions/aggfunctions/Count1AggFunction.java
@@ -33,7 +33,8 @@ import static org.apache.flink.table.planner.expressions.ExpressionBuilder.plus;
  * [[CountAggFunction]]. It differs in that null values are also counted.
  */
 public class Count1AggFunction extends DeclarativeAggregateFunction {
-    private UnresolvedReferenceExpression count1 = unresolvedRef("count1");
+
+    private final UnresolvedReferenceExpression count1 = unresolvedRef("count1");
 
     @Override
     public int operandCount() {

--- a/flink-table/flink-table-planner/src/main/java/org/apache/flink/table/planner/functions/aggfunctions/CountAggFunction.java
+++ b/flink-table/flink-table-planner/src/main/java/org/apache/flink/table/planner/functions/aggfunctions/CountAggFunction.java
@@ -32,7 +32,8 @@ import static org.apache.flink.table.planner.expressions.ExpressionBuilder.plus;
 
 /** built-in count aggregate function. */
 public class CountAggFunction extends DeclarativeAggregateFunction {
-    private UnresolvedReferenceExpression count = unresolvedRef("count");
+
+    private final UnresolvedReferenceExpression count = unresolvedRef("count");
 
     @Override
     public int operandCount() {

--- a/flink-table/flink-table-planner/src/main/java/org/apache/flink/table/planner/functions/aggfunctions/FirstValueAggFunction.java
+++ b/flink-table/flink-table-planner/src/main/java/org/apache/flink/table/planner/functions/aggfunctions/FirstValueAggFunction.java
@@ -37,7 +37,7 @@ import static org.apache.flink.table.types.utils.DataTypeUtils.toInternalDataTyp
 @Internal
 public final class FirstValueAggFunction<T> extends BuiltInAggregateFunction<T, RowData> {
 
-    private transient DataType valueDataType;
+    private final transient DataType valueDataType;
 
     public FirstValueAggFunction(LogicalType valueType) {
         this.valueDataType = toInternalDataType(valueType);

--- a/flink-table/flink-table-planner/src/main/java/org/apache/flink/table/planner/functions/aggfunctions/FirstValueWithRetractAggFunction.java
+++ b/flink-table/flink-table-planner/src/main/java/org/apache/flink/table/planner/functions/aggfunctions/FirstValueWithRetractAggFunction.java
@@ -41,7 +41,7 @@ public final class FirstValueWithRetractAggFunction<T>
         extends BuiltInAggregateFunction<
                 T, FirstValueWithRetractAggFunction.FirstValueWithRetractAccumulator<T>> {
 
-    private transient DataType valueDataType;
+    private final transient DataType valueDataType;
 
     public FirstValueWithRetractAggFunction(LogicalType valueType) {
         this.valueDataType = toInternalDataType(valueType);

--- a/flink-table/flink-table-planner/src/main/java/org/apache/flink/table/planner/functions/aggfunctions/LagAggFunction.java
+++ b/flink-table/flink-table-planner/src/main/java/org/apache/flink/table/planner/functions/aggfunctions/LagAggFunction.java
@@ -40,7 +40,6 @@ public class LagAggFunction<T> extends BuiltInAggregateFunction<T, LagAggFunctio
 
     private final transient DataType[] valueDataTypes;
 
-    @SuppressWarnings("unchecked")
     public LagAggFunction(LogicalType[] valueTypes) {
         this.valueDataTypes =
                 Arrays.stream(valueTypes)

--- a/flink-table/flink-table-planner/src/main/java/org/apache/flink/table/planner/functions/aggfunctions/LastValueAggFunction.java
+++ b/flink-table/flink-table-planner/src/main/java/org/apache/flink/table/planner/functions/aggfunctions/LastValueAggFunction.java
@@ -37,7 +37,7 @@ import static org.apache.flink.table.types.utils.DataTypeUtils.toInternalDataTyp
 @Internal
 public final class LastValueAggFunction<T> extends BuiltInAggregateFunction<T, RowData> {
 
-    private transient DataType valueDataType;
+    private final transient DataType valueDataType;
 
     public LastValueAggFunction(LogicalType valueType) {
         this.valueDataType = toInternalDataType(valueType);

--- a/flink-table/flink-table-planner/src/main/java/org/apache/flink/table/planner/functions/aggfunctions/LastValueWithRetractAggFunction.java
+++ b/flink-table/flink-table-planner/src/main/java/org/apache/flink/table/planner/functions/aggfunctions/LastValueWithRetractAggFunction.java
@@ -41,7 +41,7 @@ public final class LastValueWithRetractAggFunction<T>
         extends BuiltInAggregateFunction<
                 T, LastValueWithRetractAggFunction.LastValueWithRetractAccumulator<T>> {
 
-    private transient DataType valueDataType;
+    private final transient DataType valueDataType;
 
     public LastValueWithRetractAggFunction(LogicalType valueType) {
         this.valueDataType = toInternalDataType(valueType);

--- a/flink-table/flink-table-planner/src/main/java/org/apache/flink/table/planner/functions/aggfunctions/LeadLagAggFunction.java
+++ b/flink-table/flink-table-planner/src/main/java/org/apache/flink/table/planner/functions/aggfunctions/LeadLagAggFunction.java
@@ -54,12 +54,12 @@ import static org.apache.flink.table.planner.expressions.ExpressionBuilder.typeL
  */
 public abstract class LeadLagAggFunction extends DeclarativeAggregateFunction {
 
-    private int operandCount;
+    private final int operandCount;
 
     // If the length of function's args is 3, then the function has the default value.
-    private boolean existDefaultValue;
+    private final boolean existDefaultValue;
 
-    private UnresolvedReferenceExpression value = unresolvedRef("leadlag");
+    private final UnresolvedReferenceExpression value = unresolvedRef("leadlag");
 
     public LeadLagAggFunction(int operandCount) {
         this.operandCount = operandCount;

--- a/flink-table/flink-table-planner/src/main/java/org/apache/flink/table/planner/functions/aggfunctions/ListAggFunction.java
+++ b/flink-table/flink-table-planner/src/main/java/org/apache/flink/table/planner/functions/aggfunctions/ListAggFunction.java
@@ -33,11 +33,12 @@ import static org.apache.flink.table.planner.expressions.ExpressionBuilder.nullO
 
 /** built-in listagg aggregate function. */
 public class ListAggFunction extends DeclarativeAggregateFunction {
-    private int operandCount;
-    private UnresolvedReferenceExpression acc = unresolvedRef("concatAcc");
-    private UnresolvedReferenceExpression accDelimiter = unresolvedRef("accDelimiter");
-    private Expression delimiter;
-    private Expression operand;
+
+    private final int operandCount;
+    private final UnresolvedReferenceExpression acc = unresolvedRef("concatAcc");
+    private final UnresolvedReferenceExpression accDelimiter = unresolvedRef("accDelimiter");
+    private final Expression delimiter;
+    private final Expression operand;
 
     public ListAggFunction(int operandCount) {
         this.operandCount = operandCount;

--- a/flink-table/flink-table-planner/src/main/java/org/apache/flink/table/planner/functions/aggfunctions/MaxAggFunction.java
+++ b/flink-table/flink-table-planner/src/main/java/org/apache/flink/table/planner/functions/aggfunctions/MaxAggFunction.java
@@ -35,7 +35,8 @@ import static org.apache.flink.table.planner.expressions.ExpressionBuilder.nullO
 
 /** built-in max aggregate function. */
 public abstract class MaxAggFunction extends DeclarativeAggregateFunction {
-    private UnresolvedReferenceExpression max = unresolvedRef("max");
+
+    private final UnresolvedReferenceExpression max = unresolvedRef("max");
 
     @Override
     public int operandCount() {
@@ -151,15 +152,15 @@ public abstract class MaxAggFunction extends DeclarativeAggregateFunction {
 
     /** Built-in Decimal Max aggregate function. */
     public static class DecimalMaxAggFunction extends MaxAggFunction {
-        private DecimalType decimalType;
+        private final DataType resultType;
 
         public DecimalMaxAggFunction(DecimalType decimalType) {
-            this.decimalType = decimalType;
+            this.resultType = DataTypes.DECIMAL(decimalType.getPrecision(), decimalType.getScale());
         }
 
         @Override
         public DataType getResultType() {
-            return DataTypes.DECIMAL(decimalType.getPrecision(), decimalType.getScale());
+            return resultType;
         }
     }
 

--- a/flink-table/flink-table-planner/src/main/java/org/apache/flink/table/planner/functions/aggfunctions/MaxWithRetractAggFunction.java
+++ b/flink-table/flink-table-planner/src/main/java/org/apache/flink/table/planner/functions/aggfunctions/MaxWithRetractAggFunction.java
@@ -40,7 +40,7 @@ public final class MaxWithRetractAggFunction<T extends Comparable<T>>
 
     private static final long serialVersionUID = -5860934997657147836L;
 
-    private transient DataType valueDataType;
+    private final transient DataType valueDataType;
 
     public MaxWithRetractAggFunction(LogicalType valueType) {
         this.valueDataType = toInternalDataType(valueType);

--- a/flink-table/flink-table-planner/src/main/java/org/apache/flink/table/planner/functions/aggfunctions/MinAggFunction.java
+++ b/flink-table/flink-table-planner/src/main/java/org/apache/flink/table/planner/functions/aggfunctions/MinAggFunction.java
@@ -35,7 +35,8 @@ import static org.apache.flink.table.planner.expressions.ExpressionBuilder.nullO
 
 /** built-in min aggregate function. */
 public abstract class MinAggFunction extends DeclarativeAggregateFunction {
-    private UnresolvedReferenceExpression min = unresolvedRef("min");
+
+    private final UnresolvedReferenceExpression min = unresolvedRef("min");
 
     @Override
     public int operandCount() {
@@ -145,15 +146,15 @@ public abstract class MinAggFunction extends DeclarativeAggregateFunction {
 
     /** Built-in Decimal Min aggregate function. */
     public static class DecimalMinAggFunction extends MinAggFunction {
-        private DecimalType decimalType;
+        private final DataType resultType;
 
         public DecimalMinAggFunction(DecimalType decimalType) {
-            this.decimalType = decimalType;
+            this.resultType = DataTypes.DECIMAL(decimalType.getPrecision(), decimalType.getScale());
         }
 
         @Override
         public DataType getResultType() {
-            return DataTypes.DECIMAL(decimalType.getPrecision(), decimalType.getScale());
+            return resultType;
         }
     }
 

--- a/flink-table/flink-table-planner/src/main/java/org/apache/flink/table/planner/functions/aggfunctions/MinWithRetractAggFunction.java
+++ b/flink-table/flink-table-planner/src/main/java/org/apache/flink/table/planner/functions/aggfunctions/MinWithRetractAggFunction.java
@@ -40,7 +40,7 @@ public final class MinWithRetractAggFunction<T extends Comparable<T>>
 
     private static final long serialVersionUID = 4253774292802374843L;
 
-    private transient DataType valueDataType;
+    private final transient DataType valueDataType;
 
     public MinWithRetractAggFunction(LogicalType valueType) {
         this.valueDataType = toInternalDataType(valueType);

--- a/flink-table/flink-table-planner/src/main/java/org/apache/flink/table/planner/functions/aggfunctions/RankAggFunction.java
+++ b/flink-table/flink-table-planner/src/main/java/org/apache/flink/table/planner/functions/aggfunctions/RankAggFunction.java
@@ -38,7 +38,7 @@ import static org.apache.flink.table.planner.expressions.ExpressionBuilder.plus;
 /** built-in rank aggregate function. */
 public class RankAggFunction extends RankLikeAggFunctionBase {
 
-    private UnresolvedReferenceExpression currNumber = unresolvedRef("currNumber");
+    private final UnresolvedReferenceExpression currNumber = unresolvedRef("currNumber");
 
     public RankAggFunction(LogicalType[] orderKeyTypes) {
         super(orderKeyTypes);

--- a/flink-table/flink-table-planner/src/main/java/org/apache/flink/table/planner/functions/aggfunctions/RankLikeAggFunctionBase.java
+++ b/flink-table/flink-table-planner/src/main/java/org/apache/flink/table/planner/functions/aggfunctions/RankLikeAggFunctionBase.java
@@ -43,6 +43,7 @@ import static org.apache.flink.table.runtime.types.LogicalTypeDataTypeConverter.
 
 /** built-in rank like aggregate function, e.g. rank, dense_rank */
 public abstract class RankLikeAggFunctionBase extends DeclarativeAggregateFunction {
+
     protected UnresolvedReferenceExpression sequence = unresolvedRef("sequence");
     protected UnresolvedReferenceExpression[] lastValues;
     protected LogicalType[] orderKeyTypes;

--- a/flink-table/flink-table-planner/src/main/java/org/apache/flink/table/planner/functions/aggfunctions/RowNumberAggFunction.java
+++ b/flink-table/flink-table-planner/src/main/java/org/apache/flink/table/planner/functions/aggfunctions/RowNumberAggFunction.java
@@ -30,7 +30,8 @@ import static org.apache.flink.table.planner.expressions.ExpressionBuilder.plus;
 
 /** built-in row_number aggregate function. */
 public class RowNumberAggFunction extends DeclarativeAggregateFunction {
-    private UnresolvedReferenceExpression sequence = unresolvedRef("seq");
+
+    private final UnresolvedReferenceExpression sequence = unresolvedRef("seq");
 
     @Override
     public int operandCount() {

--- a/flink-table/flink-table-planner/src/main/scala/org/apache/flink/table/planner/codegen/ExprCodeGenerator.scala
+++ b/flink-table/flink-table-planner/src/main/scala/org/apache/flink/table/planner/codegen/ExprCodeGenerator.scala
@@ -831,6 +831,11 @@ class ExprCodeGenerator(ctx: CodeGeneratorContext, nullableInput: Boolean)
             val right = operands(1)
             generateBinaryArithmeticOperator(ctx, "+", resultType, left, right)
 
+          case BuiltInFunctionDefinitions.AGG_DECIMAL_MINUS =>
+            val left = operands.head
+            val right = operands(1)
+            generateBinaryArithmeticOperator(ctx, "-", resultType, left, right)
+
           case _ =>
             new BridgingSqlFunctionCallGen(call).generate(ctx, operands, resultType)
         }

--- a/flink-table/flink-table-planner/src/test/scala/org/apache/flink/table/planner/runtime/stream/table/AggregateITCase.scala
+++ b/flink-table/flink-table-planner/src/test/scala/org/apache/flink/table/planner/runtime/stream/table/AggregateITCase.scala
@@ -415,6 +415,8 @@ class AggregateITCase(mode: StateBackendMode) extends StreamingWithStateTestBase
     results.addSink(sink).setParallelism(1)
     env.execute()
 
+    // Use the result precision/scale calculated for sum and don't override with the one calculated
+    // for plus(), which result in loosing a decimal digit.
     val expected = List("1.03520274,12345.03520274865300000000,12.34567890123456700000,2.22222222")
     assertEquals(expected, sink.getRetractResults)
   }

--- a/flink-table/flink-table-planner/src/test/scala/org/apache/flink/table/planner/runtime/stream/table/AggregateITCase.scala
+++ b/flink-table/flink-table-planner/src/test/scala/org/apache/flink/table/planner/runtime/stream/table/AggregateITCase.scala
@@ -420,4 +420,52 @@ class AggregateITCase(mode: StateBackendMode) extends StreamingWithStateTestBase
     val expected = List("1.03520274,12345.03520274865300000000,12.34567890123456700000,2.22222222")
     assertEquals(expected, sink.getRetractResults)
   }
+
+  @Test
+  def testPrecisionForSum0AggregationOnDecimal(): Unit = {
+    val data = new mutable.MutableList[(Double, Double, Double, Double)]
+    data.+=((1.03520274, 12345.035202748654, 12.345678901234567, 1.11111111))
+    data.+=((0, 0, 0, 1.11111111))
+    val t = failingDataSource(data).toTable(tEnv, 'a, 'b, 'c, 'd)
+
+    val results = t
+      .select('a.cast(DECIMAL(32, 8)).sum0 as 'a,
+        'b.cast(DECIMAL(30, 20)).sum0 as 'b,
+        'c.cast(DECIMAL(25, 20)).sum0 as 'c,
+        'd.cast(DECIMAL(32, 8)).sum0 as 'd)
+      .toRetractStream[Row]
+
+    val sink = new TestingRetractSink
+    results.addSink(sink).setParallelism(1)
+    env.execute()
+
+    // Use the result precision/scale calculated for sum and don't override with the one calculated
+    // for plus()/minus(), which result in loosing a decimal digit.
+    val expected = List("1.03520274,12345.03520274865300000000,12.34567890123456700000,2.22222222")
+    assertEquals(expected, sink.getRetractResults)
+  }
+
+  @Test
+  def testPrecisionForAvgAggregationOnDecimal(): Unit = {
+    val data = new mutable.MutableList[(Double, Double, Double, Double)]
+    data.+=((1.03520274, 12345.035202748654, 12.345678901234567, 1.11111111))
+    data.+=((0, 0, 0, 2.22222222))
+    val t = failingDataSource(data).toTable(tEnv, 'a, 'b, 'c, 'd)
+
+    val results = t
+      .select('a.cast(DECIMAL(32, 8)).avg as 'a,
+        'b.cast(DECIMAL(30, 20)).avg as 'b,
+        'c.cast(DECIMAL(25, 20)).avg as 'c,
+        'd.cast(DECIMAL(32, 8)).avg as 'd)
+      .toRetractStream[Row]
+
+    val sink = new TestingRetractSink
+    results.addSink(sink).setParallelism(1)
+    env.execute()
+
+    // Use the result precision/scale calculated for AvgAggFunction's SumType and don't override
+    // with the one calculated for plus()/minus(), which result in loosing a decimal digit.
+    val expected = List("0.51760137,6172.51760137432650000000,6.17283945061728350000,1.66666667")
+    assertEquals(expected, sink.getRetractResults)
+  }
 }


### PR DESCRIPTION
## What is the purpose of the change

Fix precision for agg functions on decimal types.

## Brief change log

 - Small code optimisations for aggregate functions
 - Fix existing test for `SumWithRetractAggFunction` which didn't actually use it but instead used the normal `SumAggFunction`.
 - Since `Sum0AggFunction`,`SumWithRetractAggFunction` and `AvgAggFunction` are using internally `plus()` and `minus()` operators to implement the sum and avg aggregation (`minus()` is used also for the `WithRetract`), the decimal return type calculated by `LogicalTypeMerging#findSumAggType()` (also for the `AvgAggFunction`s internal `SumType`) gets overriden by the calculation for the `plus()` (and/or `minus()`) operator done by `LogicalTypeMerging#findAdditionDecimalType()`. To prevent this add a special `aggDecimalMinus()` operator and use it together with the previously added `aggDecimalPlus()` in those aggregate functions to avoid overriding the calculated precision of their decimal return type.

## Verifying this change

This change added tests and can be verified as follows:

  - Added tests to `AggregateITCase.scala` both for SQL and TableApi.

## Does this pull request potentially affect one of the following parts:

  - Dependencies (does it add or upgrade a dependency): **no**
  - The public API, i.e., is any changed class annotated with `@Public(Evolving)`: **no**
  - The serializers: **no**
  - The runtime per-record code paths (performance sensitive): **no**
  - Anything that affects deployment or recovery: JobManager (and its components), Checkpointing, Kubernetes/Yarn, ZooKeeper: **no**
  - The S3 file system connector: **no**

## Documentation

  - Does this pull request introduce a new feature? **no**
  - If yes, how is the feature documented? **not applicable**
