### PR TITLE
[FLINK-25362][docs] fix incorrect dependencies in Table Confluent/Avro docs

### DIFF
--- a/docs/content.zh/docs/connectors/table/formats/avro-confluent.md
+++ b/docs/content.zh/docs/connectors/table/formats/avro-confluent.md
@@ -44,6 +44,8 @@ Avro Schema Registry 格式只能与 [Apache Kafka SQL 连接器]({{< ref "docs/
 
 {{< sql_download_table "avro-confluent" >}}
 
+For Maven, SBT, Gradle, or other build automation tools, please also ensure that Confluent's maven repository at `https://packages.confluent.io/maven/` is configured in your project's build files.
+
 如何创建使用 Avro-Confluent 格式的表
 ----------------
 

--- a/docs/content/docs/connectors/table/formats/avro-confluent.md
+++ b/docs/content/docs/connectors/table/formats/avro-confluent.md
@@ -42,6 +42,8 @@ Dependencies
 
 {{< sql_download_table "avro-confluent" >}}
 
+For Maven, SBT, Gradle, or other build automation tools, please also ensure that Confluent's maven repository at `https://packages.confluent.io/maven/` is configured in your project's build files.
+
 How to create tables with Avro-Confluent format
 --------------
 

--- a/docs/data/sql_connectors.yml
+++ b/docs/data/sql_connectors.yml
@@ -38,7 +38,7 @@
 
 avro:
     name: Avro
-    maven: flink-sql-avro
+    maven: flink-avro
     category: format
     sql_url: https://repo.maven.apache.org/maven2/org/apache/flink/flink-sql-avro/$version/flink-sql-avro-$version.jar
 

--- a/docs/data/sql_connectors.yml
+++ b/docs/data/sql_connectors.yml
@@ -44,7 +44,9 @@ avro:
 
 avro-confluent:
     name: Avro Schema Registry
-    maven: flink-avro-confluent-registry
+    maven:
+      - flink-avro-confluent-registry
+      - flink-avro
     category: format
     sql_url: https://repo.maven.apache.org/maven2/org/apache/flink/flink-sql-avro-confluent-registry/$version/flink-sql-avro-confluent-registry-$version.jar
 

--- a/docs/layouts/shortcodes/sql_download_table.html
+++ b/docs/layouts/shortcodes/sql_download_table.html
@@ -89,11 +89,16 @@ and SQL Client with SQL JAR bundles.</p>
   rendered documentation. 
 */}}
 {{ define "maven-artifact" }}{{/* (dict "ArtifactId" .ArtifactId */}}
-<div id="{{ .ArtifactId }}" onclick="selectTextAndCopy('{{ .ArtifactId }}')" class="highlight"><pre class="chroma"><code class="language-xml" data-lang="xml"><span class="nt">&ltdependency&gt</span>
+<div id="{{ .ArtifactId }}" onclick="selectTextAndCopy('{{ .ArtifactId }}')" class="highlight"><pre class="chroma"><code class="language-xml" data-lang="xml">
+{{- $artifacts := cond (eq (printf "%T" .ArtifactId) "string") (slice .ArtifactId) .ArtifactId -}}
+{{- range $artifact := $artifacts -}}
+  <span class="nt">&ltdependency&gt</span>
   <span class="nt">&ltgroupId&gt</span>org.apache.flink<span class="nt">&lt/groupId&gt</span>
-  <span class="nt">&ltartifactId&gt</span>{{- partial "docs/interpolate" .ArtifactId -}}<span class="nt">&lt/artifactId&gt</span>
+  <span class="nt">&ltartifactId&gt</span>{{- partial "docs/interpolate" $artifact -}}<span class="nt">&lt/artifactId&gt</span>
   <span class="nt">&ltversion&gt</span>{{- site.Params.Version -}}<span class="nt">&lt/version&gt</span>
-<span class="nt">&lt/dependency&gt</span></code></pre></div>
+<span class="nt">&lt/dependency&gt</span>
+{{- end -}}
+</code></pre></div>
 <div class="book-hint info" style="text-align:center;display:none" copyable="flink-module" copyattribute="{{ .ArtifactId }}">
 Copied to clipboard!
 </div>


### PR DESCRIPTION
## What is the purpose of the change

This PR fixes missing dependency instructions for the Table API connector doc pages on "Confluent Avro Format" and "Avro Format".

## Brief change log

- extend Hugo shortcode for `sql_download_table` to support multiple maven artifacts for a single connector
- "Confluent Avro Format" page:
  - add the dependency to `flink-avro`
  - add a note on having Confluent's maven repository in your build files as well
- "Avro Format":
  - fix maven dependency to point to `flink-avro` and not `flink-sql-avro` which is shaded and should only be used by the SQL client

## Verifying this change

I built and verified at the rendered docs site locally

## Does this pull request potentially affect one of the following parts:

  - Dependencies (does it add or upgrade a dependency): **no**
  - The public API, i.e., is any changed class annotated with `@Public(Evolving)`: **no**
  - The serializers: **no**
  - The runtime per-record code paths (performance sensitive): **no**
  - Anything that affects deployment or recovery: JobManager (and its components), Checkpointing, Kubernetes/Yarn, ZooKeeper: **no**
  - The S3 file system connector: **no**

## Documentation

  - Does this pull request introduce a new feature? **no**
  - If yes, how is the feature documented? **not applicable**
