### PR TITLE
[FLINK-24674][kubernetes] Create corresponding resouces for task manager Pods

### DIFF
--- a/flink-kubernetes/src/main/java/org/apache/flink/kubernetes/kubeclient/FlinkKubeClient.java
+++ b/flink-kubernetes/src/main/java/org/apache/flink/kubernetes/kubeclient/FlinkKubeClient.java
@@ -36,8 +36,8 @@ import java.util.function.Function;
 /**
  * The client to talk with kubernetes. The interfaces will be called both in Client and
  * ResourceManager. To avoid potentially blocking the execution of RpcEndpoint's main thread, these
- * interfaces {@link #createTaskManagerPod(KubernetesPod)}, {@link #stopPod(String)} should be
- * implemented asynchronously.
+ * interfaces {@link #createTaskManagerPod(KubernetesTaskManagerSpecification)}, {@link
+ * #stopPod(String)} should be implemented asynchronously.
  */
 public interface FlinkKubeClient extends AutoCloseable {
 
@@ -52,10 +52,11 @@ public interface FlinkKubeClient extends AutoCloseable {
     /**
      * Create task manager pod.
      *
-     * @param kubernetesPod taskmanager pod
+     * @param kubernetesTMSpec taskmanager specification
      * @return Return the taskmanager pod creation future
      */
-    CompletableFuture<Void> createTaskManagerPod(KubernetesPod kubernetesPod);
+    CompletableFuture<Void> createTaskManagerPod(
+            KubernetesTaskManagerSpecification kubernetesTMSpec);
 
     /**
      * Stop a specified pod by name.

--- a/flink-kubernetes/src/main/java/org/apache/flink/kubernetes/kubeclient/KubernetesTaskManagerSpecification.java
+++ b/flink-kubernetes/src/main/java/org/apache/flink/kubernetes/kubeclient/KubernetesTaskManagerSpecification.java
@@ -1,0 +1,46 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.flink.kubernetes.kubeclient;
+
+import org.apache.flink.kubernetes.kubeclient.resources.KubernetesPod;
+
+import io.fabric8.kubernetes.api.model.HasMetadata;
+
+import java.util.List;
+
+/** Composition of the created Kubernetes components that represents a Flink Task Manager. */
+public class KubernetesTaskManagerSpecification {
+    private KubernetesPod kubernetesPod;
+
+    private List<HasMetadata> accompanyingResources;
+
+    public KubernetesTaskManagerSpecification(
+            KubernetesPod kubernetesPod, List<HasMetadata> accompanyingResources) {
+        this.kubernetesPod = kubernetesPod;
+        this.accompanyingResources = accompanyingResources;
+    }
+
+    public KubernetesPod getKubernetesPod() {
+        return kubernetesPod;
+    }
+
+    public List<HasMetadata> getAccompanyingResources() {
+        return accompanyingResources;
+    }
+}

--- a/flink-kubernetes/src/test/java/org/apache/flink/kubernetes/kubeclient/Fabric8FlinkKubeClientTest.java
+++ b/flink-kubernetes/src/test/java/org/apache/flink/kubernetes/kubeclient/Fabric8FlinkKubeClientTest.java
@@ -51,6 +51,7 @@ import org.junit.Test;
 
 import java.util.ArrayList;
 import java.util.Arrays;
+import java.util.Collections;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
@@ -185,7 +186,9 @@ public class Fabric8FlinkKubeClientTest extends KubernetesClientTestBase {
                                 .editOrNewSpec()
                                 .endSpec()
                                 .build());
-        this.flinkKubeClient.createTaskManagerPod(kubernetesPod).get();
+        final KubernetesTaskManagerSpecification taskManagerSpecification =
+                new KubernetesTaskManagerSpecification(kubernetesPod, Collections.EMPTY_LIST);
+        this.flinkKubeClient.createTaskManagerPod(taskManagerSpecification).get();
 
         final Pod resultTaskManagerPod =
                 this.kubeClient.pods().inNamespace(NAMESPACE).withName(TASKMANAGER_POD_NAME).get();
@@ -335,7 +338,9 @@ public class Fabric8FlinkKubeClientTest extends KubernetesClientTestBase {
                                 .editOrNewSpec()
                                 .endSpec()
                                 .build());
-        this.flinkKubeClient.createTaskManagerPod(kubernetesPod).get();
+        final KubernetesTaskManagerSpecification taskManagerSpecification =
+                new KubernetesTaskManagerSpecification(kubernetesPod, Collections.EMPTY_LIST);
+        this.flinkKubeClient.createTaskManagerPod(taskManagerSpecification).get();
 
         assertEquals(
                 1,

--- a/flink-kubernetes/src/test/java/org/apache/flink/kubernetes/kubeclient/TestingFlinkKubeClient.java
+++ b/flink-kubernetes/src/test/java/org/apache/flink/kubernetes/kubeclient/TestingFlinkKubeClient.java
@@ -123,8 +123,9 @@ public class TestingFlinkKubeClient implements FlinkKubeClient {
     }
 
     @Override
-    public CompletableFuture<Void> createTaskManagerPod(KubernetesPod kubernetesPod) {
-        return createTaskManagerPodFunction.apply(kubernetesPod);
+    public CompletableFuture<Void> createTaskManagerPod(
+            KubernetesTaskManagerSpecification kubernetesTMSpec) {
+        return createTaskManagerPodFunction.apply(kubernetesTMSpec.getKubernetesPod());
     }
 
     @Override

--- a/flink-kubernetes/src/test/java/org/apache/flink/kubernetes/kubeclient/factory/KubernetesTaskManagerFactoryWithPodTemplateTest.java
+++ b/flink-kubernetes/src/test/java/org/apache/flink/kubernetes/kubeclient/factory/KubernetesTaskManagerFactoryWithPodTemplateTest.java
@@ -23,6 +23,7 @@ import org.apache.flink.kubernetes.kubeclient.FlinkPod;
 
 import io.fabric8.kubernetes.api.model.Pod;
 
+import java.io.IOException;
 import java.util.UUID;
 
 /** General tests for the {@link KubernetesTaskManagerFactory} with pod template. */
@@ -30,11 +31,12 @@ public class KubernetesTaskManagerFactoryWithPodTemplateTest
         extends KubernetesFactoryWithPodTemplateTestBase {
 
     @Override
-    protected Pod getResultPod(FlinkPod podTemplate) {
-        return KubernetesTaskManagerFactory.buildTaskManagerKubernetesPod(
+    protected Pod getResultPod(FlinkPod podTemplate) throws IOException {
+        return KubernetesTaskManagerFactory.buildKubernetesTaskManagerSpecification(
                         podTemplate,
                         KubernetesTestUtils.createTaskManagerParameters(
                                 flinkConfig, "taskmanager-" + UUID.randomUUID().toString()))
+                .getKubernetesPod()
                 .getInternalResource();
     }
 }


### PR DESCRIPTION
This is a rebased version of #17582 to the latest master branch to trigger CI runs, as the CI seems to be consistently producing seemingly unrelated [failures](https://github.com/apache/flink/pull/17582#issuecomment-996521399) on the original PR.

Fyi @viirya @gyfora 