### PR TITLE
[FLINK-25368][connectors/kafka] Substitute KafkaConsumer with AdminClient when getting offsets

### DIFF
--- a/flink-connectors/flink-connector-kafka/src/main/java/org/apache/flink/connector/kafka/source/enumerator/initializer/OffsetsInitializer.java
+++ b/flink-connectors/flink-connector-kafka/src/main/java/org/apache/flink/connector/kafka/source/enumerator/initializer/OffsetsInitializer.java
@@ -24,7 +24,6 @@ import org.apache.flink.connector.kafka.source.split.KafkaPartitionSplit;
 
 import org.apache.kafka.clients.admin.KafkaAdminClient;
 import org.apache.kafka.clients.admin.ListConsumerGroupOffsetsOptions;
-import org.apache.kafka.clients.consumer.KafkaConsumer;
 import org.apache.kafka.clients.consumer.OffsetAndTimestamp;
 import org.apache.kafka.clients.consumer.OffsetResetStrategy;
 import org.apache.kafka.common.TopicPartition;
@@ -34,7 +33,8 @@ import java.util.Collection;
 import java.util.Map;
 
 /**
- * A interface for users to specify the starting / stopping offset of a {@link KafkaPartitionSplit}.
+ * An interface for users to specify the starting / stopping offset of a {@link
+ * KafkaPartitionSplit}.
  *
  * @see ReaderHandledOffsetsInitializer
  * @see SpecifiedOffsetsInitializer
@@ -85,13 +85,13 @@ public interface OffsetsInitializer extends Serializable {
          */
         Map<TopicPartition, Long> committedOffsets(Collection<TopicPartition> partitions);
 
-        /** @see KafkaConsumer#endOffsets(Collection) */
+        /** List end offsets for the specified partitions. */
         Map<TopicPartition, Long> endOffsets(Collection<TopicPartition> partitions);
 
-        /** @see KafkaConsumer#beginningOffsets(Collection) */
+        /** List beginning offsets for the specified partitions. */
         Map<TopicPartition, Long> beginningOffsets(Collection<TopicPartition> partitions);
 
-        /** @see KafkaConsumer#offsetsForTimes(Map) */
+        /** List offsets matching a timestamp for the specified partitions. */
         Map<TopicPartition, OffsetAndTimestamp> offsetsForTimes(
                 Map<TopicPartition, Long> timestampsToSearch);
     }
@@ -130,7 +130,7 @@ public interface OffsetsInitializer extends Serializable {
      * @param timestamp the timestamp to start the consumption.
      * @return an {@link OffsetsInitializer} which initializes the offsets based on the given
      *     timestamp.
-     * @see KafkaConsumer#offsetsForTimes(Map)
+     * @see KafkaAdminClient#listOffsets(Map)
      */
     static OffsetsInitializer timestamp(long timestamp) {
         return new TimestampOffsetsInitializer(timestamp);

--- a/flink-connectors/flink-connector-kafka/src/test/java/org/apache/flink/connector/kafka/source/enumerator/KafkaEnumeratorTest.java
+++ b/flink-connectors/flink-connector-kafka/src/test/java/org/apache/flink/connector/kafka/source/enumerator/KafkaEnumeratorTest.java
@@ -32,7 +32,6 @@ import org.apache.flink.mock.Whitebox;
 import org.apache.kafka.clients.admin.AdminClient;
 import org.apache.kafka.clients.admin.NewTopic;
 import org.apache.kafka.clients.consumer.ConsumerConfig;
-import org.apache.kafka.clients.consumer.KafkaConsumer;
 import org.apache.kafka.common.TopicPartition;
 import org.apache.kafka.common.serialization.StringDeserializer;
 import org.junit.AfterClass;
@@ -313,15 +312,8 @@ public class KafkaEnumeratorTest {
                     defaultTimeoutMs,
                     Whitebox.getInternalState(adminClient, "defaultApiTimeoutMs"));
 
-            KafkaConsumer<?, ?> consumer =
-                    (KafkaConsumer<?, ?>) Whitebox.getInternalState(enumerator, "consumer");
-            assertNotNull(consumer);
-            clientId = (String) Whitebox.getInternalState(consumer, "clientId");
             assertNotNull(clientId);
             assertTrue(clientId.startsWith(clientIdPrefix));
-            assertEquals(
-                    (long) defaultTimeoutMs,
-                    Whitebox.getInternalState(consumer, "requestTimeoutMs"));
         }
     }
 

--- a/flink-connectors/flink-connector-kafka/src/test/java/org/apache/flink/connector/kafka/source/enumerator/initializer/OffsetsInitializerTest.java
+++ b/flink-connectors/flink-connector-kafka/src/test/java/org/apache/flink/connector/kafka/source/enumerator/initializer/OffsetsInitializerTest.java
@@ -51,9 +51,7 @@ public class OffsetsInitializerTest {
         KafkaSourceTestEnv.setupTopic(TOPIC2, false, false, KafkaSourceTestEnv::getRecordsForTopic);
         retriever =
                 new KafkaSourceEnumerator.PartitionOffsetsRetrieverImpl(
-                        KafkaSourceTestEnv.getConsumer(),
-                        KafkaSourceTestEnv.getAdminClient(),
-                        KafkaSourceTestEnv.GROUP_ID);
+                        KafkaSourceTestEnv.getAdminClient(), KafkaSourceTestEnv.GROUP_ID);
     }
 
     @AfterClass

--- a/flink-connectors/flink-connector-kafka/src/test/java/org/apache/flink/streaming/connectors/kafka/KafkaTestBase.java
+++ b/flink-connectors/flink-connector-kafka/src/test/java/org/apache/flink/streaming/connectors/kafka/KafkaTestBase.java
@@ -152,7 +152,7 @@ public abstract class KafkaTestBase extends TestLogger {
 
     public static void startClusters(KafkaTestEnvironment.Config environmentConfig)
             throws Exception {
-        kafkaServer = constructKafkaTestEnvionment();
+        kafkaServer = constructKafkaTestEnvironment();
 
         LOG.info("Starting KafkaTestBase.prepare() for Kafka " + kafkaServer.getVersion());
 
@@ -171,7 +171,7 @@ public abstract class KafkaTestBase extends TestLogger {
         }
     }
 
-    public static KafkaTestEnvironment constructKafkaTestEnvionment() throws Exception {
+    public static KafkaTestEnvironment constructKafkaTestEnvironment() throws Exception {
         Class<?> clazz =
                 Class.forName(
                         "org.apache.flink.streaming.connectors.kafka.KafkaTestEnvironmentImpl");


### PR DESCRIPTION
## What is the purpose of the change
`AdminClient.listOffsets` is provided in Kafka 2.7, In the future more `OffsetSpce` types will be added to it, for example, OffsetSpec.MaxTimestampSpec is added in Kafka 3.0.0. so it's better to substitute `KafkaConsumer` with `AdminClient`.


## Brief change log

  - Substitute KafkaConsumer with AdminClient in OffsetsInitializer
  - Substitute KafkaConsumer with AdminClient in FlinkKafkaConsumer
  - Totally remove KafkaConsumer from KafkaSourceEnumerator.


## Verifying this change

Please make sure both new and modified tests in this PR follows the conventions defined in our code quality guide: https://flink.apache.org/contributing/code-style-and-quality-common.html#testing


This change is already covered by existing tests `OffsetsInitializerTest`.

## Does this pull request potentially affect one of the following parts:

  - Dependencies (does it add or upgrade a dependency): no
  - The public API, i.e., is any changed class annotated with `@Public(Evolving)`: no
  - The serializers: no
  - The runtime per-record code paths (performance sensitive): no
  - Anything that affects deployment or recovery: JobManager (and its components), Checkpointing, Kubernetes/Yarn, ZooKeeper: no
  - The S3 file system connector: no

## Documentation
  - Does this pull request introduce a new feature? no
