### PR TITLE
[hotfix][connectors][docs] Use big M letters for month in date format

### DIFF
--- a/docs/content.zh/docs/connectors/table/filesystem.md
+++ b/docs/content.zh/docs/connectors/table/filesystem.md
@@ -280,7 +280,7 @@ file sink 支持文件合并，以允许应用程序可以使用较小的检查�
         <td><h5>partition.time-extractor.timestamp-pattern</h5></td>
         <td style="word-wrap: break-word;">(none)</td>
         <td>String</td>
-        <td> 'default' 时间提取器允许用户从分区字段中提取合法的时间戳模式。默认支持从第一个字段按 'yyyy-mm-dd hh:mm:ss' 时间戳模式提取。
+        <td> 'default' 时间提取器允许用户从分区字段中提取合法的时间戳模式。默认支持从第一个字段按 'yyyy-MM-dd hh:mm:ss' 时间戳模式提取。
         如果需要从一个分区字段比如 ‘dt’ 提取时间戳，可以配置为: '$dt';
         如果需要从多个分区字段，比如 'year', 'month', 'day' 和 'hour'提取时间戳，可以配置为：'$year-$month-$day $hour:00:00';
         如果需要从两字分区字段，比如 'dt' 和 'hour' 提取时间戳，可以配置为：'$dt $hour:00:00'.</td>

--- a/docs/content/docs/connectors/table/filesystem.md
+++ b/docs/content/docs/connectors/table/filesystem.md
@@ -348,7 +348,7 @@ Time extractors define extracting time from partition values.
         <td><h5>partition.time-extractor.timestamp-pattern</h5></td>
         <td style="word-wrap: break-word;">(none)</td>
         <td>String</td>
-        <td>The 'default' construction way allows users to use partition fields to get a legal timestamp pattern. Default support 'yyyy-mm-dd hh:mm:ss' from first field. If timestamp should be extracted from a single partition field 'dt', can configure: '$dt'. If timestamp should be extracted from multiple partition fields, say 'year', 'month', 'day' and 'hour', can configure: '$year-$month-$day $hour:00:00'. If timestamp should be extracted from two partition fields 'dt' and 'hour', can configure: '$dt $hour:00:00'.</td>
+        <td>The 'default' construction way allows users to use partition fields to get a legal timestamp pattern. Default support 'yyyy-MM-dd hh:mm:ss' from first field. If timestamp should be extracted from a single partition field 'dt', can configure: '$dt'. If timestamp should be extracted from multiple partition fields, say 'year', 'month', 'day' and 'hour', can configure: '$year-$month-$day $hour:00:00'. If timestamp should be extracted from two partition fields 'dt' and 'hour', can configure: '$dt $hour:00:00'.</td>
     </tr>
   </tbody>
 </table>

--- a/flink-connectors/flink-connector-files/src/main/java/org/apache/flink/connector/file/table/FileSystemConnectorOptions.java
+++ b/flink-connectors/flink-connector-files/src/main/java/org/apache/flink/connector/file/table/FileSystemConnectorOptions.java
@@ -167,7 +167,7 @@ public class FileSystemConnectorOptions {
                                                     + "you can specify a pattern to get a timestamp from partitions.")
                                     .list(
                                             text(
-                                                    "By default, a format of 'yyyy-mm-dd hh:mm:ss' is read from the first field."),
+                                                    "By default, a format of 'yyyy-MM-dd hh:mm:ss' is read from the first field."),
                                             text(
                                                     "If the timestamp in the partition is a single field called 'dt', you can use '$dt'."),
                                             text(

--- a/flink-table/flink-table-planner/src/test/scala/org/apache/flink/table/planner/expressions/TemporalTypesTest.scala
+++ b/flink-table/flink-table-planner/src/test/scala/org/apache/flink/table/planner/expressions/TemporalTypesTest.scala
@@ -737,7 +737,7 @@ class TemporalTypesTest extends ExpressionTestBase {
     )
 
     testSqlApi(
-      "TO_TIMESTAMP(f14, 'yyyy-mm-dd')",
+      "TO_TIMESTAMP(f14, 'yyyy-MM-dd')",
       "NULL"
     )
   }
@@ -1065,7 +1065,7 @@ class TemporalTypesTest extends ExpressionTestBase {
   def testInvalidInputCase(): Unit = {
     val invalidStr = "invalid value"
     testSqlApi(s"DATE_FORMAT('$invalidStr', 'yyyy/MM/dd HH:mm:ss')", nullable)
-    testSqlApi(s"TO_TIMESTAMP('$invalidStr', 'yyyy-mm-dd')", nullable)
+    testSqlApi(s"TO_TIMESTAMP('$invalidStr', 'yyyy-MM-dd')", nullable)
     testSqlApi(s"TO_DATE('$invalidStr')", nullable)
     testSqlApi(
       s"CONVERT_TZ('$invalidStr', 'UTC', 'Asia/Shanghai')",
@@ -1077,7 +1077,7 @@ class TemporalTypesTest extends ExpressionTestBase {
     val invalidStr = "invalid value"
     val cases = Seq(
       s"DATE_FORMAT('$invalidStr', 'yyyy/MM/dd HH:mm:ss')",
-      s"TO_TIMESTAMP('$invalidStr', 'yyyy-mm-dd')",
+      s"TO_TIMESTAMP('$invalidStr', 'yyyy-MM-dd')",
       s"TO_DATE('$invalidStr')",
       s"CONVERT_TZ('$invalidStr', 'UTC', 'Asia/Shanghai')")
 


### PR DESCRIPTION
## What is the purpose of the change
Use big `M` for month in date format for `partition.time-extractor.timestamp-pattern`

## Verifying this change

This change is a trivial rework / code cleanup without any test coverage.

## Does this pull request potentially affect one of the following parts:

  - Dependencies (does it add or upgrade a dependency): ( no)
  - The public API, i.e., is any changed class annotated with `@Public(Evolving)`: ( no)
  - The serializers: ( no )
  - The runtime per-record code paths (performance sensitive): ( no )
  - Anything that affects deployment or recovery: JobManager (and its components), Checkpointing, Kubernetes/Yarn, ZooKeeper: ( no )
  - The S3 file system connector: ( no)

## Documentation

  - Does this pull request introduce a new feature? ( no)
  - If yes, how is the feature documented? (not applicable )
