### PR TITLE
[FLINK-17808] Rename checkpoint meta file to "_metadata" until it has…

### DIFF
--- a/flink-core/src/main/java/org/apache/flink/core/fs/local/LocalRecoverableFsDataOutputStream.java
+++ b/flink-core/src/main/java/org/apache/flink/core/fs/local/LocalRecoverableFsDataOutputStream.java
@@ -40,7 +40,7 @@ import static org.apache.flink.util.Preconditions.checkNotNull;
 
 /** A {@link RecoverableFsDataOutputStream} for the {@link LocalFileSystem}. */
 @Internal
-class LocalRecoverableFsDataOutputStream extends RecoverableFsDataOutputStream {
+public class LocalRecoverableFsDataOutputStream extends RecoverableFsDataOutputStream {
 
     private final File targetFile;
 
@@ -50,7 +50,7 @@ class LocalRecoverableFsDataOutputStream extends RecoverableFsDataOutputStream {
 
     private final OutputStream fos;
 
-    LocalRecoverableFsDataOutputStream(File targetFile, File tempFile) throws IOException {
+    public LocalRecoverableFsDataOutputStream(File targetFile, File tempFile) throws IOException {
         this.targetFile = checkNotNull(targetFile);
         this.tempFile = checkNotNull(tempFile);
 

--- a/flink-core/src/main/java/org/apache/flink/core/fs/local/LocalRecoverableWriter.java
+++ b/flink-core/src/main/java/org/apache/flink/core/fs/local/LocalRecoverableWriter.java
@@ -116,7 +116,7 @@ public class LocalRecoverableWriter implements RecoverableWriter {
     }
 
     @VisibleForTesting
-    static File generateStagingTempFilePath(File targetFile) {
+    public static File generateStagingTempFilePath(File targetFile) {
         checkArgument(!targetFile.isDirectory(), "targetFile must not be a directory");
 
         final File parent = targetFile.getParentFile();

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/state/filesystem/FSDataOutputStreamWrapper.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/state/filesystem/FSDataOutputStreamWrapper.java
@@ -1,0 +1,64 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.flink.runtime.state.filesystem;
+
+import org.apache.flink.annotation.Internal;
+import org.apache.flink.core.fs.FSDataOutputStream;
+import org.apache.flink.core.fs.FileSystem;
+import org.apache.flink.core.fs.Path;
+
+import java.io.IOException;
+
+/**
+ * Implementation of {@link MetadataOutputStreamWrapper} encapsulates the {@link FSDataOutputStream}
+ * for {@link FsCheckpointMetadataOutputStream}.
+ */
+@Internal
+public class FSDataOutputStreamWrapper extends MetadataOutputStreamWrapper {
+    private final FileSystem fileSystem;
+    private final Path metadataFilePath;
+    private final FSDataOutputStream out;
+
+    public FSDataOutputStreamWrapper(FileSystem fileSystem, Path metadataFilePath)
+            throws IOException {
+        this.fileSystem = fileSystem;
+        this.metadataFilePath = metadataFilePath;
+        this.out = fileSystem.create(metadataFilePath, FileSystem.WriteMode.NO_OVERWRITE);
+    }
+
+    @Override
+    public FSDataOutputStream getOutput() {
+        return out;
+    }
+
+    @Override
+    public void closeForCommitAction() throws IOException {
+        out.close();
+    }
+
+    @Override
+    public void closeAction() throws IOException {
+        out.close();
+    }
+
+    @Override
+    public void cleanup() throws IOException {
+        fileSystem.delete(metadataFilePath, false);
+    }
+}

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/state/filesystem/MetadataOutputStreamWrapper.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/state/filesystem/MetadataOutputStreamWrapper.java
@@ -1,0 +1,78 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.flink.runtime.state.filesystem;
+
+import org.apache.flink.annotation.Internal;
+import org.apache.flink.core.fs.FSDataOutputStream;
+
+import java.io.IOException;
+
+/** The wrapper manages metadata output stream close and commit. */
+@Internal
+public abstract class MetadataOutputStreamWrapper {
+    private volatile boolean closed = false;
+
+    /** Returns {@link FSDataOutputStream} to write and other operations. */
+    abstract FSDataOutputStream getOutput();
+
+    /**
+     * The abstract function of once closing output stream and committing operation. It will throw
+     * {@link IOException} when failed and should be invoked by {@code closeForCommit()} indirectly
+     * instead of this function.
+     */
+    abstract void closeForCommitAction() throws IOException;
+
+    /**
+     * The abstract function of once closing output stream operation. It will throw {@link
+     * IOException} when failed and should be invoked by {@code close()} indirectly instead of this
+     * function.
+     */
+    abstract void closeAction() throws IOException;
+
+    /**
+     * The abstract function of aborting temporary files or doing nothing, which depends on the
+     * different output stream implementations. It will throw {@link IOException} when failed.
+     */
+    abstract void cleanup() throws IOException;
+
+    /**
+     * The function will check output stream valid. If it has been closed before, it will throw
+     * {@link IOException}. If not, it will invoke {@code closeForCommitAction()} and mark it
+     * closed.
+     */
+    final void closeForCommit() throws IOException {
+        if (closed) {
+            throw new IOException("The output stream has been closed. This should not happen.");
+        }
+        closeForCommitAction();
+        closed = true;
+    }
+
+    /**
+     * The function will check output stream valid. If it has been closed before, it will do
+     * nothing. If not, it will invoke {@code closeAction()} and mark it closed.
+     */
+    final void close() throws IOException {
+        if (closed) {
+            return;
+        }
+        closeAction();
+        closed = true;
+    }
+}

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/state/filesystem/RecoverableStreamWrapper.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/state/filesystem/RecoverableStreamWrapper.java
@@ -1,0 +1,56 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.flink.runtime.state.filesystem;
+
+import org.apache.flink.annotation.Internal;
+import org.apache.flink.core.fs.FSDataOutputStream;
+import org.apache.flink.core.fs.RecoverableFsDataOutputStream;
+
+import java.io.IOException;
+
+/**
+ * Implementation of {@link MetadataOutputStreamWrapper} encapsulates the {@link
+ * RecoverableFsDataOutputStream} for {@link FsCheckpointMetadataOutputStream}.
+ */
+@Internal
+public class RecoverableStreamWrapper extends MetadataOutputStreamWrapper {
+    private final RecoverableFsDataOutputStream out;
+
+    public RecoverableStreamWrapper(RecoverableFsDataOutputStream out) {
+        this.out = out;
+    }
+
+    @Override
+    public FSDataOutputStream getOutput() {
+        return out;
+    }
+
+    @Override
+    public void closeForCommitAction() throws IOException {
+        out.closeForCommit().commit();
+    }
+
+    @Override
+    public void closeAction() throws IOException {
+        out.close();
+    }
+
+    @Override
+    public void cleanup() throws IOException {}
+}

--- a/flink-runtime/src/test/java/org/apache/flink/runtime/state/filesystem/FsCheckpointMetadataOutputStreamTest.java
+++ b/flink-runtime/src/test/java/org/apache/flink/runtime/state/filesystem/FsCheckpointMetadataOutputStreamTest.java
@@ -1,0 +1,233 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.flink.runtime.state.filesystem;
+
+import org.apache.flink.core.fs.FSDataOutputStream;
+import org.apache.flink.core.fs.FileSystem;
+import org.apache.flink.core.fs.Path;
+import org.apache.flink.core.fs.RecoverableFsDataOutputStream;
+import org.apache.flink.core.fs.local.LocalDataOutputStream;
+import org.apache.flink.core.fs.local.LocalFileSystem;
+import org.apache.flink.core.fs.local.LocalRecoverableFsDataOutputStream;
+import org.apache.flink.core.fs.local.LocalRecoverableWriter;
+import org.apache.flink.util.TestLogger;
+import org.apache.flink.util.function.BiFunctionWithException;
+import org.apache.flink.util.function.FunctionWithException;
+
+import org.junit.Rule;
+import org.junit.Test;
+import org.junit.rules.TemporaryFolder;
+import org.junit.runner.RunWith;
+import org.junit.runners.Parameterized;
+
+import java.io.File;
+import java.io.IOException;
+import java.util.Arrays;
+import java.util.Collection;
+import java.util.UUID;
+
+import static org.junit.Assert.assertFalse;
+import static org.junit.Assert.assertTrue;
+import static org.junit.Assert.fail;
+
+/** Test for {@link FsCheckpointMetadataOutputStream}. */
+@RunWith(Parameterized.class)
+public class FsCheckpointMetadataOutputStreamTest extends TestLogger {
+
+    @Parameterized.Parameters
+    public static Collection<FileSystem> getFileSystems() {
+        return Arrays.asList(new FsWithRecoverableWriter(), new FsWithoutRecoverableWriter());
+    }
+
+    @Parameterized.Parameter public FileSystem fileSystem;
+
+    @Rule public final TemporaryFolder tempDir = new TemporaryFolder();
+
+    @Test
+    public void testFileExistence() throws Exception {
+        Path metaDataFilePath = baseFolder();
+        FsCheckpointMetadataOutputStream stream = createTestStream(metaDataFilePath, fileSystem);
+
+        if (fileSystem instanceof FsWithoutRecoverableWriter) {
+            assertTrue(fileSystem.exists(metaDataFilePath));
+        } else {
+            assertFalse(fileSystem.exists(metaDataFilePath));
+        }
+
+        stream.closeAndFinalizeCheckpoint();
+
+        assertTrue(fileSystem.exists(metaDataFilePath));
+    }
+
+    @Test
+    public void testCleanupWhenClosed() throws Exception {
+        Path metaDataFilePath = baseFolder();
+        FsCheckpointMetadataOutputStream stream = createTestStream(metaDataFilePath, fileSystem);
+        stream.close();
+        assertFalse(fileSystem.exists(metaDataFilePath));
+    }
+
+    @Test
+    public void testCleanupWhenClosedAndFinalizeFailed() throws Exception {
+        Path metaDataFilePath = baseFolder();
+
+        if (fileSystem instanceof FsWithoutRecoverableWriter) {
+            fileSystem =
+                    ((FsWithoutRecoverableWriter) fileSystem)
+                            .withStreamFactory(
+                                    (path) -> new FailingCloseStream(new File(path.getPath())));
+        } else {
+            fileSystem =
+                    ((FsWithRecoverableWriter) fileSystem)
+                            .withStreamFactory(
+                                    (path, temp) ->
+                                            new FailingRecoverableFsStream(
+                                                    new File(path.getPath()),
+                                                    new File(temp.getPath())));
+        }
+
+        FsCheckpointMetadataOutputStream stream = createTestStream(metaDataFilePath, fileSystem);
+        try {
+            stream.closeAndFinalizeCheckpoint();
+            fail();
+        } catch (Exception e) {
+            // ignore
+        }
+        assertFalse(fileSystem.exists(metaDataFilePath));
+
+        if (fileSystem instanceof FsWithoutRecoverableWriter) {
+            ((FsWithoutRecoverableWriter) fileSystem).resetStreamFactory();
+        } else {
+            ((FsWithRecoverableWriter) fileSystem).resetStreamFactory();
+        }
+    }
+
+    private FsCheckpointMetadataOutputStream createTestStream(
+            Path metaDataFilePath, FileSystem fileSystem) throws IOException {
+        FsCheckpointMetadataOutputStream stream =
+                new FsCheckpointMetadataOutputStream(
+                        fileSystem, metaDataFilePath, new Path("fooBarName"));
+
+        for (int i = 0; i < 100; ++i) {
+            stream.write(0x42);
+        }
+        return stream;
+    }
+
+    private Path baseFolder() throws Exception {
+        return new Path(new File(tempDir.newFolder(), UUID.randomUUID().toString()).toURI());
+    }
+
+    private static class FsWithoutRecoverableWriter extends LocalFileSystem {
+        private FunctionWithException<Path, FSDataOutputStream, IOException> streamFactory;
+
+        private FileSystem withStreamFactory(
+                FunctionWithException<Path, FSDataOutputStream, IOException> streamFactory) {
+            this.streamFactory = streamFactory;
+            return this;
+        }
+
+        private void resetStreamFactory() {
+            this.streamFactory = null;
+        }
+
+        @Override
+        public FSDataOutputStream create(Path filePath, WriteMode overwrite) throws IOException {
+            if (streamFactory == null) {
+                return super.create(filePath, overwrite);
+            }
+            return streamFactory.apply(filePath);
+        }
+
+        @Override
+        public LocalRecoverableWriter createRecoverableWriter() throws IOException {
+            throw new UnsupportedOperationException(
+                    "This file system does not support recoverable writers.");
+        }
+    }
+
+    private static class FsWithRecoverableWriter extends LocalFileSystem {
+        private BiFunctionWithException<Path, Path, LocalRecoverableFsDataOutputStream, IOException>
+                streamFactory;
+
+        private FsWithRecoverableWriter withStreamFactory(
+                BiFunctionWithException<Path, Path, LocalRecoverableFsDataOutputStream, IOException>
+                        streamFactory) {
+            this.streamFactory = streamFactory;
+            return this;
+        }
+
+        private void resetStreamFactory() {
+            this.streamFactory = null;
+        }
+
+        @Override
+        public LocalRecoverableWriter createRecoverableWriter() throws IOException {
+            if (streamFactory == null) {
+                return super.createRecoverableWriter();
+            }
+            return new FsLocalRecoverableWriter(this, streamFactory);
+        }
+    }
+
+    private static class FsLocalRecoverableWriter extends LocalRecoverableWriter {
+        private final BiFunctionWithException<
+                        Path, Path, LocalRecoverableFsDataOutputStream, IOException>
+                streamFactory;
+        private LocalFileSystem fs;
+
+        public FsLocalRecoverableWriter(
+                LocalFileSystem fs,
+                BiFunctionWithException<Path, Path, LocalRecoverableFsDataOutputStream, IOException>
+                        streamFactory) {
+            super(fs);
+            this.fs = fs;
+            this.streamFactory = streamFactory;
+        }
+
+        @Override
+        public RecoverableFsDataOutputStream open(Path filePath) throws IOException {
+            File temp = generateStagingTempFilePath(fs.pathToFile(filePath));
+            return streamFactory.apply(filePath, new Path(temp.getPath()));
+        }
+    }
+
+    private static class FailingRecoverableFsStream extends LocalRecoverableFsDataOutputStream {
+        public FailingRecoverableFsStream(File targetFile, File tempFile) throws IOException {
+            super(targetFile, tempFile);
+        }
+
+        @Override
+        public void close() throws IOException {
+            throw new IOException();
+        }
+    }
+
+    private static class FailingCloseStream extends LocalDataOutputStream {
+
+        FailingCloseStream(File file) throws IOException {
+            super(file);
+        }
+
+        @Override
+        public void close() throws IOException {
+            throw new IOException();
+        }
+    }
+}

--- a/flink-tests/src/test/java/org/apache/flink/test/checkpointing/SavepointITCase.java
+++ b/flink-tests/src/test/java/org/apache/flink/test/checkpointing/SavepointITCase.java
@@ -47,6 +47,7 @@ import org.apache.flink.core.fs.FSDataOutputStream;
 import org.apache.flink.core.fs.FileSystem;
 import org.apache.flink.core.fs.FileSystemFactory;
 import org.apache.flink.core.fs.local.LocalFileSystem;
+import org.apache.flink.core.fs.local.LocalRecoverableWriter;
 import org.apache.flink.core.testutils.OneShotLatch;
 import org.apache.flink.runtime.checkpoint.CheckpointException;
 import org.apache.flink.runtime.client.JobExecutionException;
@@ -1771,6 +1772,12 @@ public class SavepointITCase extends TestLogger {
                 throws IOException {
             failPath(filePath);
             return super.create(filePath, overwrite);
+        }
+
+        @Override
+        public LocalRecoverableWriter createRecoverableWriter() throws IOException {
+            throw new UnsupportedOperationException(
+                    "This file system does not support recoverable writers.");
         }
 
         private void failPath(org.apache.flink.core.fs.Path filePath) throws IOException {


### PR DESCRIPTION
… completed writing

## What is the purpose of the change

In order to solve the situation where the checkpoint metadata file is suspended from being written under certain abnormal conditions, but it is still visible to the outside. However the metadata file at this time is invalid.

## Brief change log

Using the `RecoverableFsDataOutputStream` close and commit to ensure the writing file atomicity. 

## Verifying this change



## Does this pull request potentially affect one of the following parts:

  - Dependencies (does it add or upgrade a dependency): (yes / **no**)
  - The public API, i.e., is any changed class annotated with `@Public(Evolving)`: (yes / **no**)
  - The serializers: (yes / **no** / don't know)
  - The runtime per-record code paths (performance sensitive): (yes / **no** / don't know)
  - Anything that affects deployment or recovery: JobManager (and its components), Checkpointing, Kubernetes/Yarn, ZooKeeper: (**yes** / no / don't know)
  - The S3 file system connector: (yes / **no** / don't know)

## Documentation

  - Does this pull request introduce a new feature? (yes / **no**)
  - If yes, how is the feature documented? (not applicable / docs / JavaDocs / not documented)
