### PR TITLE
[FLINK-25398] Show complete stacktrace when requesting thread dump

### DIFF
--- a/docs/layouts/shortcodes/generated/cluster_configuration.html
+++ b/docs/layouts/shortcodes/generated/cluster_configuration.html
@@ -69,6 +69,12 @@
             <td>The shutdown timeout for cluster services like executors in milliseconds.</td>
         </tr>
         <tr>
+            <td><h5>cluster.thread-dump.stacktrace-max-depth</h5></td>
+            <td style="word-wrap: break-word;">8</td>
+            <td>Integer</td>
+            <td>The maximum stacktrace depth of TaskManager and JobManager's thread dump web-frontend displayed.</td>
+        </tr>
+        <tr>
             <td><h5>cluster.uncaught-exception-handling</h5></td>
             <td style="word-wrap: break-word;">LOG</td>
             <td><p>Enum</p></td>

--- a/docs/layouts/shortcodes/generated/expert_cluster_section.html
+++ b/docs/layouts/shortcodes/generated/expert_cluster_section.html
@@ -21,6 +21,12 @@
             <td>Whether processes should halt on fatal errors instead of performing a graceful shutdown. In some environments (e.g. Java 8 with the G1 garbage collector), a regular graceful shutdown can lead to a JVM deadlock. See <a href="https://issues.apache.org/jira/browse/FLINK-16510">FLINK-16510</a> for details.</td>
         </tr>
         <tr>
+            <td><h5>cluster.thread-dump.stacktrace-max-depth</h5></td>
+            <td style="word-wrap: break-word;">8</td>
+            <td>Integer</td>
+            <td>The maximum stacktrace depth of TaskManager and JobManager's thread dump web-frontend displayed.</td>
+        </tr>
+        <tr>
             <td><h5>cluster.uncaught-exception-handling</h5></td>
             <td style="word-wrap: break-word;">LOG</td>
             <td><p>Enum</p></td>

--- a/flink-core/src/main/java/org/apache/flink/configuration/ClusterOptions.java
+++ b/flink-core/src/main/java/org/apache/flink/configuration/ClusterOptions.java
@@ -121,6 +121,14 @@ public class ClusterOptions {
                                             code(HALT_ON_FATAL_ERROR.key()), code(THROW.name()))
                                     .build());
 
+    @Documentation.Section(Documentation.Sections.EXPERT_CLUSTER)
+    public static final ConfigOption<Integer> THREAD_DUMP_STACKTRACE_MAX_DEPTH =
+            key("cluster.thread-dump.stacktrace-max-depth")
+                    .intType()
+                    .defaultValue(8)
+                    .withDescription(
+                            "The maximum stacktrace depth of TaskManager and JobManager's thread dump web-frontend displayed.");
+
     @Documentation.Section(Documentation.Sections.EXPERT_SCHEDULING)
     public static final ConfigOption<Boolean> ENABLE_FINE_GRAINED_RESOURCE_MANAGEMENT =
             ConfigOptions.key("cluster.fine-grained-resource-management.enabled")

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/dispatcher/Dispatcher.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/dispatcher/Dispatcher.java
@@ -23,6 +23,7 @@ import org.apache.flink.api.common.JobStatus;
 import org.apache.flink.api.common.operators.ResourceSpec;
 import org.apache.flink.api.common.time.Time;
 import org.apache.flink.api.java.tuple.Tuple2;
+import org.apache.flink.configuration.ClusterOptions;
 import org.apache.flink.configuration.Configuration;
 import org.apache.flink.metrics.MetricGroup;
 import org.apache.flink.runtime.blob.BlobServer;
@@ -696,7 +697,8 @@ public abstract class Dispatcher extends PermanentlyFencedRpcEndpoint<Dispatcher
 
     @Override
     public CompletableFuture<ThreadDumpInfo> requestThreadDump(Time timeout) {
-        return CompletableFuture.completedFuture(ThreadDumpInfo.dumpAndCreate());
+        int stackTraceMaxDepth = configuration.get(ClusterOptions.THREAD_DUMP_STACKTRACE_MAX_DEPTH);
+        return CompletableFuture.completedFuture(ThreadDumpInfo.dumpAndCreate(stackTraceMaxDepth));
     }
 
     @Override

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/taskexecutor/TaskExecutor.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/taskexecutor/TaskExecutor.java
@@ -21,6 +21,7 @@ package org.apache.flink.runtime.taskexecutor;
 import org.apache.flink.annotation.VisibleForTesting;
 import org.apache.flink.api.common.JobID;
 import org.apache.flink.api.common.time.Time;
+import org.apache.flink.configuration.ClusterOptions;
 import org.apache.flink.management.jmx.JMXService;
 import org.apache.flink.runtime.accumulators.AccumulatorSnapshot;
 import org.apache.flink.runtime.blob.JobPermanentBlobService;
@@ -1270,7 +1271,11 @@ public class TaskExecutor extends RpcEndpoint implements TaskExecutorGateway {
 
     @Override
     public CompletableFuture<ThreadDumpInfo> requestThreadDump(Time timeout) {
-        return CompletableFuture.completedFuture(ThreadDumpInfo.dumpAndCreate());
+        int stacktraceMaxDepth =
+                taskManagerConfiguration
+                        .getConfiguration()
+                        .get(ClusterOptions.THREAD_DUMP_STACKTRACE_MAX_DEPTH);
+        return CompletableFuture.completedFuture(ThreadDumpInfo.dumpAndCreate(stacktraceMaxDepth));
     }
 
     // ------------------------------------------------------------------------


### PR DESCRIPTION

## What is the purpose of the change


Now the stacktrace is not complete when clicking the task executor's threaddump  in runtime webui. Hence it's hard to the initial calling according to the stacktrace.

Now the thread stacktrace is limited to 8, refer to openjdk: 

https://github.com/openjdk/jdk/blob/master/src/java.management/share/classes/java/lang/management/ThreadInfo.java#L597

### Solution
Using the custom stringify method to return stacktrace instead of using ThreadInfo.toString directly

## Verifying this change


## Does this pull request potentially affect one of the following parts:

  - Dependencies (does it add or upgrade a dependency): (yes / **no**)
  - The public API, i.e., is any changed class annotated with `@Public(Evolving)`: (yes / **no**)
  - The serializers: (yes / **no** / don't know)
  - The runtime per-record code paths (performance sensitive): (yes / **no** / don't know)
  - Anything that affects deployment or recovery: JobManager (and its components), Checkpointing, Kubernetes/Yarn, ZooKeeper: (yes / **no** / don't know)
  - The S3 file system connector: (yes / **no** / don't know)

## Documentation

  - Does this pull request introduce a new feature? (yes / **no**)
  - If yes, how is the feature documented? (not applicable / docs / JavaDocs / not documented)
