### PR TITLE
[FLINK-21186][network] Wrap IOException in UncheckedIOException in RecordWriterOutput

### DIFF
--- a/flink-streaming-java/src/main/java/org/apache/flink/streaming/runtime/io/RecordWriterOutput.java
+++ b/flink-streaming-java/src/main/java/org/apache/flink/streaming/runtime/io/RecordWriterOutput.java
@@ -36,6 +36,7 @@ import org.apache.flink.streaming.runtime.watermarkstatus.WatermarkStatus;
 import org.apache.flink.util.OutputTag;
 
 import java.io.IOException;
+import java.io.UncheckedIOException;
 
 import static org.apache.flink.util.Preconditions.checkNotNull;
 
@@ -101,8 +102,8 @@ public class RecordWriterOutput<OUT> implements WatermarkGaugeExposingOutput<Str
 
         try {
             recordWriter.emit(serializationDelegate);
-        } catch (Exception e) {
-            throw new RuntimeException(e.getMessage(), e);
+        } catch (IOException e) {
+            throw new UncheckedIOException(e.getMessage(), e);
         }
     }
 
@@ -117,8 +118,8 @@ public class RecordWriterOutput<OUT> implements WatermarkGaugeExposingOutput<Str
 
         try {
             recordWriter.broadcastEmit(serializationDelegate);
-        } catch (Exception e) {
-            throw new RuntimeException(e.getMessage(), e);
+        } catch (IOException e) {
+            throw new UncheckedIOException(e.getMessage(), e);
         }
     }
 
@@ -129,8 +130,8 @@ public class RecordWriterOutput<OUT> implements WatermarkGaugeExposingOutput<Str
             serializationDelegate.setInstance(watermarkStatus);
             try {
                 recordWriter.broadcastEmit(serializationDelegate);
-            } catch (Exception e) {
-                throw new RuntimeException(e.getMessage(), e);
+            } catch (IOException e) {
+                throw new UncheckedIOException(e.getMessage(), e);
             }
         }
     }
@@ -141,8 +142,8 @@ public class RecordWriterOutput<OUT> implements WatermarkGaugeExposingOutput<Str
 
         try {
             recordWriter.randomEmit(serializationDelegate);
-        } catch (Exception e) {
-            throw new RuntimeException(e.getMessage(), e);
+        } catch (IOException e) {
+            throw new UncheckedIOException(e.getMessage(), e);
         }
     }
 


### PR DESCRIPTION
This is a simple hotfix that explicitly narrows down what exceptions can be wrapped to unchecked in RecordWriterOutput.

## Does this pull request potentially affect one of the following parts:

  - Dependencies (does it add or upgrade a dependency): (yes / **no**)
  - The public API, i.e., is any changed class annotated with `@Public(Evolving)`: (yes / **no**)
  - The serializers: (yes / **no** / don't know)
  - The runtime per-record code paths (performance sensitive): (yes / **no** / don't know)
  - Anything that affects deployment or recovery: JobManager (and its components), Checkpointing, Kubernetes/Yarn, ZooKeeper: (yes / **no** / don't know)
  - The S3 file system connector: (yes / **no** / don't know)

## Documentation

  - Does this pull request introduce a new feature? (yes / **no**)
  - If yes, how is the feature documented? (**not applicable** / docs / JavaDocs / not documented)
