### PR TITLE
[hotfix][doc]There is a link redirection problem in the Chinese document of Checkpointing

### DIFF
--- a/docs/content.zh/docs/dev/datastream/fault-tolerance/checkpointing.md
+++ b/docs/content.zh/docs/dev/datastream/fault-tolerance/checkpointing.md
@@ -8,7 +8,7 @@ aliases:
 ---
 <!--
 Licensed to the Apache Software Foundation (ASF) under one
-or more contributor license agreements.  See the NOTICE file
+or more contributor license agreements-a.  See the NOTICE file
 distributed with this work for additional information
 regarding copyright ownership.  The ASF licenses this file
 to you under the Apache License, Version 2.0 (the

--- a/docs/content.zh/docs/dev/datastream/fault-tolerance/checkpointing.md
+++ b/docs/content.zh/docs/dev/datastream/fault-tolerance/checkpointing.md
@@ -27,7 +27,7 @@ under the License.
 
 # Checkpointing
 
-Flink 中的每个方法或算子都能够是**有状态的**（阅读 [working with state](state.html) 了解更多）。
+Flink 中的每个方法或算子都能够是**有状态的**（阅读 [working with state]({{< ref "docs/concepts/stateful-stream-processing" >}})  了解更多）。
 状态化的方法在处理单个 元素/事件 的时候存储数据，让状态成为使各个类型的算子更加精细的重要部分。
 为了让状态容错，Flink 需要为状态添加 **checkpoint（检查点）**。Checkpoint 使得 Flink 能够恢复状态和在流中的位置，从而向应用提供和无故障执行时一样的语义。
 


### PR DESCRIPTION
There is a link redirection problem in the Chinese document of Checkpointing.
When I wanted to click on the link of 'working with state' in the Chinese document to get more information, the page jumped to 404, but when I checked the English document, I found that turn to correct page. So i fix the link of 'working with state' in the Chinese document.
![image](https://user-images.githubusercontent.com/35768015/146921716-9d9f75b0-8f6e-48f6-998a-1f20585c6140.png)
