### PR TITLE
[FLINK-25187][table-planner] Apply padding when CASTing to BINARY(<length>)

### DIFF
--- a/flink-table/flink-table-planner/src/main/java/org/apache/flink/table/planner/functions/casting/BinaryToBinaryCastRule.java
+++ b/flink-table/flink-table-planner/src/main/java/org/apache/flink/table/planner/functions/casting/BinaryToBinaryCastRule.java
@@ -63,6 +63,7 @@ class BinaryToBinaryCastRule extends AbstractExpressionCodeGeneratorCastRule<byt
         if (context.legacyBehaviour()) {
             return inputTerm;
         } else {
+            // Assume input length is respected by the source
             if (inputLength <= targetLength) {
                 return inputTerm;
             } else {

--- a/flink-table/flink-table-planner/src/test/java/org/apache/flink/table/planner/functions/CastFunctionITCase.java
+++ b/flink-table/flink-table-planner/src/test/java/org/apache/flink/table/planner/functions/CastFunctionITCase.java
@@ -301,12 +301,17 @@ public class CastFunctionITCase extends BuiltInFunctionTestBase {
                         .fromCase(CHAR(3), "foo", new byte[] {102, 111})
                         .fromCase(VARCHAR(5), "Flink", new byte[] {70, 108})
                         .fromCase(STRING(), "Apache", new byte[] {65, 112})
+                        .fromCase(VARCHAR(5), "f", new byte[] {102, 0})
+                        .fromCase(STRING(), "f", new byte[] {102, 0})
                         // Not supported - no fix
                         .fail(BOOLEAN(), true)
                         //
                         .fromCase(BINARY(2), DEFAULT_BINARY, DEFAULT_BINARY)
                         .fromCase(VARBINARY(3), DEFAULT_VARBINARY, new byte[] {0, 1})
                         .fromCase(BYTES(), DEFAULT_BYTES, new byte[] {0, 1})
+                        .fromCase(BINARY(1), new byte[] {111}, new byte[] {111, 0})
+                        .fromCase(VARBINARY(1), new byte[] {111}, new byte[] {111, 0})
+                        .fromCase(BYTES(), new byte[] {11}, new byte[] {11, 0})
                         // Not supported - no fix
                         .fail(DECIMAL(5, 3), 12.345)
                         .fail(TINYINT(), DEFAULT_NEGATIVE_TINY_INT)

--- a/flink-table/flink-table-planner/src/test/java/org/apache/flink/table/planner/functions/CastFunctionMiscITCase.java
+++ b/flink-table/flink-table-planner/src/test/java/org/apache/flink/table/planner/functions/CastFunctionMiscITCase.java
@@ -169,6 +169,16 @@ public class CastFunctionMiscITCase extends BuiltInFunctionTestBase {
                                 BYTES()),
                 TestSpec.forFunction(
                                 BuiltInFunctionDefinitions.CAST,
+                                "cast from RAW(Integer) to BINARY(6)")
+                        .onFieldsWithData(123456)
+                        .andDataTypes(INT())
+                        .withFunction(IntegerToRaw.class)
+                        .testTableApiResult(
+                                call("IntegerToRaw", $("f0")).cast(BINARY(6)),
+                                new byte[] {0, 1, -30, 64, 0, 0},
+                                BINARY(6)),
+                TestSpec.forFunction(
+                                BuiltInFunctionDefinitions.CAST,
                                 "cast from RAW(UserPojo) to VARBINARY")
                         .onFieldsWithData(123456, "Flink")
                         .andDataTypes(INT(), STRING())

--- a/flink-table/flink-table-planner/src/test/java/org/apache/flink/table/planner/functions/casting/CastRulesTest.java
+++ b/flink-table/flink-table-planner/src/test/java/org/apache/flink/table/planner/functions/casting/CastRulesTest.java
@@ -771,6 +771,13 @@ class CastRulesTest {
                         .fromCaseLegacy(CHAR(6), fromString("Apache"), fromString("Apache"))
                         .fromCase(VARCHAR(5), fromString("Flink"), fromString("Fli"))
                         .fromCaseLegacy(VARCHAR(5), fromString("Flink"), fromString("Flink"))
+                        // We assume that the input length is respected, therefore, no trimming is
+                        // applied
+                        .fromCase(CHAR(2), fromString("Apache"), fromString("Apache"))
+                        .fromCaseLegacy(CHAR(2), fromString("Apache"), fromString("Apache"))
+                        .fromCase(VARCHAR(2), fromString("Apache"), fromString("Apache"))
+                        .fromCaseLegacy(VARCHAR(2), fromString("Apache"), fromString("Apache"))
+                        //
                         .fromCase(STRING(), fromString("Apache Flink"), fromString("Apa"))
                         .fromCaseLegacy(
                                 STRING(), fromString("Apache Flink"), fromString("Apache Flink"))
@@ -962,7 +969,13 @@ class CastRulesTest {
                         .fromCaseLegacy(
                                 STRING(),
                                 fromString("Apache"),
-                                new byte[] {65, 112, 97, 99, 104, 101}),
+                                new byte[] {65, 112, 97, 99, 104, 101})
+                        // We assume that the input length is respected, therefore, no trimming is
+                        // applied
+                        .fromCase(BINARY(2), new byte[] {1, 2, 3}, new byte[] {1, 2, 3})
+                        .fromCaseLegacy(BINARY(2), new byte[] {1, 2, 3}, new byte[] {1, 2, 3})
+                        .fromCase(VARBINARY(2), new byte[] {1, 2, 3}, new byte[] {1, 2, 3})
+                        .fromCaseLegacy(VARBINARY(2), new byte[] {1, 2, 3}, new byte[] {1, 2, 3}),
                 CastTestSpecBuilder.testCastTo(VARBINARY(4))
                         .fromCase(CHAR(3), fromString("foo"), new byte[] {102, 111, 111})
                         .fromCaseLegacy(
@@ -974,7 +987,20 @@ class CastRulesTest {
                         .fromCaseLegacy(
                                 STRING(),
                                 fromString("Apache"),
-                                new byte[] {65, 112, 97, 99, 104, 101}),
+                                new byte[] {65, 112, 97, 99, 104, 101})
+                        // We assume that the input length is respected, therefore, no trimming is
+                        // applied
+                        .fromCase(BINARY(2), new byte[] {1, 2, 3, 4, 5}, new byte[] {1, 2, 3, 4, 5})
+                        .fromCaseLegacy(
+                                BINARY(2), new byte[] {1, 2, 3, 4, 5}, new byte[] {1, 2, 3, 4, 5})
+                        .fromCase(
+                                VARBINARY(2),
+                                new byte[] {1, 2, 3, 4, 5},
+                                new byte[] {1, 2, 3, 4, 5})
+                        .fromCaseLegacy(
+                                VARBINARY(2),
+                                new byte[] {1, 2, 3, 4, 5},
+                                new byte[] {1, 2, 3, 4, 5}),
                 CastTestSpecBuilder.testCastTo(BYTES())
                         .fromCase(CHAR(3), fromString("foo"), new byte[] {102, 111, 111})
                         .fromCase(

--- a/flink-table/flink-table-planner/src/test/java/org/apache/flink/table/planner/functions/casting/CastRulesTest.java
+++ b/flink-table/flink-table-planner/src/test/java/org/apache/flink/table/planner/functions/casting/CastRulesTest.java
@@ -632,7 +632,7 @@ class CastRulesTest {
                                 fromString("(null,abc)"))
                         .fromCase(ROW(), GenericRowData.of(), fromString("()"))
                         .fromCase(
-                                RAW(LocalDateTime.class, new LocalDateTimeSerializer()),
+                                RAW(LocalDateTime.class, LocalDateTimeSerializer.INSTANCE),
                                 RawValueData.fromObject(
                                         LocalDateTime.parse("2020-11-11T18:08:01.123")),
                                 fromString("2020-11-11T18:08:01.123"))
@@ -749,19 +749,21 @@ class CastRulesTest {
                                 null,
                                 EMPTY_UTF8)
                         .fromCase(
-                                RAW(LocalDate.class, new LocalDateSerializer()),
+                                RAW(LocalDate.class, LocalDateSerializer.INSTANCE),
                                 RawValueData.fromObject(LocalDate.parse("2020-12-09")),
                                 fromString("2020-12-09  "))
                         .fromCaseLegacy(
-                                RAW(LocalDate.class, new LocalDateSerializer()),
+                                RAW(LocalDate.class, LocalDateSerializer.INSTANCE),
                                 RawValueData.fromObject(LocalDate.parse("2020-12-09")),
                                 fromString("2020-12-09"))
                         .fromCase(
-                                RAW(LocalDateTime.class, new LocalDateTimeSerializer()).nullable(),
+                                RAW(LocalDateTime.class, LocalDateTimeSerializer.INSTANCE)
+                                        .nullable(),
                                 null,
                                 EMPTY_UTF8)
                         .fromCaseLegacy(
-                                RAW(LocalDateTime.class, new LocalDateTimeSerializer()).nullable(),
+                                RAW(LocalDateTime.class, LocalDateTimeSerializer.INSTANCE)
+                                        .nullable(),
                                 null,
                                 EMPTY_UTF8),
                 CastTestSpecBuilder.testCastTo(VARCHAR(3))
@@ -906,21 +908,23 @@ class CastRulesTest {
                                 null,
                                 EMPTY_UTF8)
                         .fromCase(
-                                RAW(LocalDateTime.class, new LocalDateTimeSerializer()),
+                                RAW(LocalDateTime.class, LocalDateTimeSerializer.INSTANCE),
                                 RawValueData.fromObject(
                                         LocalDateTime.parse("2020-11-11T18:08:01.123")),
                                 fromString("202"))
                         .fromCaseLegacy(
-                                RAW(LocalDateTime.class, new LocalDateTimeSerializer()),
+                                RAW(LocalDateTime.class, LocalDateTimeSerializer.INSTANCE),
                                 RawValueData.fromObject(
                                         LocalDateTime.parse("2020-11-11T18:08:01.123")),
                                 fromString("2020-11-11T18:08:01.123"))
                         .fromCase(
-                                RAW(LocalDateTime.class, new LocalDateTimeSerializer()).nullable(),
+                                RAW(LocalDateTime.class, LocalDateTimeSerializer.INSTANCE)
+                                        .nullable(),
                                 null,
                                 EMPTY_UTF8)
                         .fromCaseLegacy(
-                                RAW(LocalDateTime.class, new LocalDateTimeSerializer()).nullable(),
+                                RAW(LocalDateTime.class, LocalDateTimeSerializer.INSTANCE)
+                                        .nullable(),
                                 null,
                                 EMPTY_UTF8),
                 CastTestSpecBuilder.testCastTo(BOOLEAN())
@@ -955,27 +959,31 @@ class CastRulesTest {
                         .fromCase(FLOAT(), 1.1234f, true)
                         .fromCase(DOUBLE(), 0.0d, false)
                         .fromCase(DOUBLE(), -0.12345678d, true),
-                CastTestSpecBuilder.testCastTo(BINARY(2))
+                CastTestSpecBuilder.testCastTo(BINARY(4))
+                        .fromCase(CHAR(3), fromString("foo"), new byte[] {102, 111, 111, 0})
                         .fromCaseLegacy(CHAR(3), fromString("foo"), new byte[] {102, 111, 111})
-                        .fromCase(CHAR(3), fromString("foo"), new byte[] {102, 111})
-                        .fromCase(CHAR(1), fromString("f"), new byte[] {102})
-                        .fromCase(CHAR(3), fromString("f"), new byte[] {102})
-                        .fromCase(VARCHAR(5), fromString("Flink"), new byte[] {70, 108})
+                        .fromCase(CHAR(1), fromString("f"), new byte[] {102, 0, 0, 0})
+                        .fromCaseLegacy(CHAR(1), fromString("f"), new byte[] {102})
+                        .fromCase(CHAR(3), fromString("f"), new byte[] {102, 0, 0, 0})
+                        .fromCaseLegacy(CHAR(3), fromString("f"), new byte[] {102})
+                        .fromCase(VARCHAR(5), fromString("Flink"), new byte[] {70, 108, 105, 110})
                         .fromCaseLegacy(
                                 VARCHAR(5),
                                 fromString("Flink"),
                                 new byte[] {70, 108, 105, 110, 107})
-                        .fromCase(STRING(), fromString("Apache"), new byte[] {65, 112})
+                        .fromCase(STRING(), fromString("Apache"), new byte[] {65, 112, 97, 99})
                         .fromCaseLegacy(
                                 STRING(),
                                 fromString("Apache"),
                                 new byte[] {65, 112, 97, 99, 104, 101})
-                        // We assume that the input length is respected, therefore, no trimming is
-                        // applied
-                        .fromCase(BINARY(2), new byte[] {1, 2, 3}, new byte[] {1, 2, 3})
-                        .fromCaseLegacy(BINARY(2), new byte[] {1, 2, 3}, new byte[] {1, 2, 3})
-                        .fromCase(VARBINARY(2), new byte[] {1, 2, 3}, new byte[] {1, 2, 3})
-                        .fromCaseLegacy(VARBINARY(2), new byte[] {1, 2, 3}, new byte[] {1, 2, 3}),
+                        .fromCase(STRING(), fromString("bar"), new byte[] {98, 97, 114, 0})
+                        .fromCaseLegacy(STRING(), fromString("bar"), new byte[] {98, 97, 114})
+                        .fromCase(BINARY(2), new byte[] {1, 2}, new byte[] {1, 2, 0, 0})
+                        .fromCaseLegacy(BINARY(2), new byte[] {1, 2}, new byte[] {1, 2})
+                        .fromCase(VARBINARY(3), new byte[] {1, 2, 3}, new byte[] {1, 2, 3, 0})
+                        .fromCaseLegacy(VARBINARY(3), new byte[] {1, 2, 3}, new byte[] {1, 2, 3})
+                        .fromCase(BYTES(), new byte[] {1, 2, 3}, new byte[] {1, 2, 3, 0})
+                        .fromCaseLegacy(BYTES(), new byte[] {1, 2, 3}, new byte[] {1, 2, 3}),
                 CastTestSpecBuilder.testCastTo(VARBINARY(4))
                         .fromCase(CHAR(3), fromString("foo"), new byte[] {102, 111, 111})
                         .fromCaseLegacy(


### PR DESCRIPTION
## What is the purpose of the change

Similarly to `CHAR(<length>)` when casting to a `BINARY(<length>)`
apply padding with 0 bytes to the right so that the resulting `byte[]`
matches exaxctly the specified length.


## Verifying this change

This change added tests and can be verified as follows:

 - Added tests in `CastRulesTest`
 - Added tests in `CastFunctionITCase`
 - Added tests in `CastFunctionMiscITCase`


## Does this pull request potentially affect one of the following parts:

  - Dependencies (does it add or upgrade a dependency): **no**
  - The public API, i.e., is any changed class annotated with `@Public(Evolving)`:  **no**
  - The serializers:  **no**
  - The runtime per-record code paths (performance sensitive):  **no**
  - Anything that affects deployment or recovery: JobManager (and its components), Checkpointing, Kubernetes/Yarn, ZooKeeper:  **no**
  - The S3 file system connector:  **no**

## Documentation

  - Does this pull request introduce a new feature?  **no**
  - If yes, how is the feature documented? **not applicable**
