### PR TITLE
[FLINK-25375] [BP-1.13] Update log4j2 dependency to 2.17.0 to address

### DIFF
--- a/docs/content.zh/docs/dev/datastream/project-configuration.md
+++ b/docs/content.zh/docs/dev/datastream/project-configuration.md
@@ -331,7 +331,7 @@ ext {
     flinkVersion = '1.13-SNAPSHOT'
     scalaBinaryVersion = '2.11'
     slf4jVersion = '1.7.15'
-    log4jVersion = '2.16.0'
+    log4jVersion = '2.17.0'
 }
 
 

--- a/docs/content/docs/dev/datastream/project-configuration.md
+++ b/docs/content/docs/dev/datastream/project-configuration.md
@@ -330,7 +330,7 @@ ext {
     flinkVersion = '1.13-SNAPSHOT'
     scalaBinaryVersion = '2.11'
     slf4jVersion = '1.7.15'
-    log4jVersion = '2.16.0'
+    log4jVersion = '2.17.0'
 }
 
 

--- a/pom.xml
+++ b/pom.xml
@@ -107,7 +107,7 @@ under the License.
 		<akka.version>2.5.21</akka.version>
 		<target.java.version>1.8</target.java.version>
 		<slf4j.version>1.7.15</slf4j.version>
-		<log4j.version>2.16.0</log4j.version>
+		<log4j.version>2.17.0</log4j.version>
 		<!-- Overwrite default values from parent pom.
 			 Intellij is (sometimes?) using those values to choose target language level
 			 and thus is changing back to java 1.6 on each maven re-import -->

--- a/tools/releasing/NOTICE-binary_PREAMBLE.txt
+++ b/tools/releasing/NOTICE-binary_PREAMBLE.txt
@@ -8,10 +8,10 @@ Copyright 2014-2021 The Apache Software Foundation
 
 This project bundles the following dependencies under the Apache Software License 2.0 (http://www.apache.org/licenses/LICENSE-2.0.txt)
 
-- org.apache.logging.log4j:log4j-api:2.16.0
-- org.apache.logging.log4j:log4j-core:2.16.0
-- org.apache.logging.log4j:log4j-slf4j-impl:2.16.0
-- org.apache.logging.log4j:log4j-1.2-api:2.16.0
+- org.apache.logging.log4j:log4j-api:2.17.0
+- org.apache.logging.log4j:log4j-core:2.17.0
+- org.apache.logging.log4j:log4j-slf4j-impl:2.17.0
+- org.apache.logging.log4j:log4j-1.2-api:2.17.0
 
 This project bundles the following dependencies under the BSD license.
 See bundled license files for details.


### PR DESCRIPTION
CVE-2021-45105