### PR TITLE
[hotfix][docs] Fix incorrect Python tableEnvironment attribute reference

### DIFF
--- a/docs/content.zh/docs/dev/python/datastream/intro_to_datastream_api.md
+++ b/docs/content.zh/docs/dev/python/datastream/intro_to_datastream_api.md
@@ -265,9 +265,9 @@ It also supports to convert a `DataStream` to a `Table` and vice verse.
 table = t_env.from_data_stream(ds, 'a, b, c')
 
 # convert a Table to a DataStream
-ds = table.to_append_stream(table, Types.ROW([Types.INT(), Types.STRING()]))
+ds = t_env.to_append_stream(table, Types.ROW([Types.INT(), Types.STRING()]))
 # or
-ds = table.to_retract_stream(table, Types.ROW([Types.INT(), Types.STRING()]))
+ds = t_env.to_retract_stream(table, Types.ROW([Types.INT(), Types.STRING()]))
 ```
 
 {{< top >}}

--- a/docs/content/docs/dev/python/datastream/intro_to_datastream_api.md
+++ b/docs/content/docs/dev/python/datastream/intro_to_datastream_api.md
@@ -265,9 +265,9 @@ It also supports to convert a `DataStream` to a `Table` and vice verse.
 table = t_env.from_data_stream(ds, 'a, b, c')
 
 # convert a Table to a DataStream
-ds = table.to_append_stream(table, Types.ROW([Types.INT(), Types.STRING()]))
+ds = t_env.to_append_stream(table, Types.ROW([Types.INT(), Types.STRING()]))
 # or
-ds = table.to_retract_stream(table, Types.ROW([Types.INT(), Types.STRING()]))
+ds = t_env.to_retract_stream(table, Types.ROW([Types.INT(), Types.STRING()]))
 ```
 
 {{< top >}}


### PR DESCRIPTION
## What is the purpose of the change

This PR fixes the problem with the Python DataStream API documentation page variable "t_env" being written as "table". On this page: https://nightlies.apache.org/flink/flink-docs-master/docs/dev/python/datastream/intro_to_datastream_api/

![1640152803226](https://user-images.githubusercontent.com/55094781/147046455-8d423226-dea2-4ba9-afcf-b0d269740b51.jpg)

## Verifying this change

Please make sure both new and modified tests in this PR follows the conventions defined in our code quality guide: https://flink.apache.org/contributing/code-style-and-quality-common.html#testing

This change is a trivial rework / code cleanup without any test coverage.

## Does this pull request potentially affect one of the following parts:

  - Dependencies (does it add or upgrade a dependency): no
  - The public API, i.e., is any changed class annotated with `@Public(Evolving)`: no
  - The serializers: no
  - The runtime per-record code paths (performance sensitive): no
  - Anything that affects deployment or recovery: JobManager (and its components), Checkpointing, Kubernetes/Yarn, ZooKeeper: no
  - The S3 file system connector: no

## Documentation

  - Does this pull request introduce a new feature? no
  - If yes, how is the feature documented? docs
