### PR TITLE
[FLINK-25407][network] Fix the issues caused by FLINK-24035

### DIFF
--- a/flink-core/src/main/java/org/apache/flink/core/memory/MemorySegmentProvider.java
+++ b/flink-core/src/main/java/org/apache/flink/core/memory/MemorySegmentProvider.java
@@ -23,8 +23,8 @@ import java.util.Collection;
 
 /** The provider used for requesting and releasing batch of memory segments. */
 public interface MemorySegmentProvider {
-    Collection<MemorySegment> requestMemorySegments(int numberOfSegmentsToRequest)
+    Collection<MemorySegment> requestUnpooledMemorySegments(int numberOfSegmentsToRequest)
             throws IOException;
 
-    void recycleMemorySegments(Collection<MemorySegment> segments) throws IOException;
+    void recycleUnpooledMemorySegments(Collection<MemorySegment> segments) throws IOException;
 }

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/io/network/buffer/LocalBufferPool.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/io/network/buffer/LocalBufferPool.java
@@ -244,7 +244,7 @@ class LocalBufferPool implements BufferPool {
 
             if (numberOfRequestedMemorySegments < numberOfSegmentsToReserve) {
                 availableMemorySegments.addAll(
-                        networkBufferPool.requestMemorySegmentsBlocking(
+                        networkBufferPool.requestPooledMemorySegmentsBlocking(
                                 numberOfSegmentsToReserve - numberOfRequestedMemorySegments));
                 toNotify = availabilityHelper.getUnavailableToResetAvailable();
             }
@@ -408,7 +408,7 @@ class LocalBufferPool implements BufferPool {
                 !isDestroyed,
                 "Destroyed buffer pools should never acquire segments - this will lead to buffer leaks.");
 
-        MemorySegment segment = networkBufferPool.requestMemorySegment();
+        MemorySegment segment = networkBufferPool.requestPooledMemorySegment();
         if (segment != null) {
             availableMemorySegments.add(segment);
             numberOfRequestedMemorySegments++;
@@ -652,7 +652,7 @@ class LocalBufferPool implements BufferPool {
         assert Thread.holdsLock(availableMemorySegments);
 
         numberOfRequestedMemorySegments--;
-        networkBufferPool.recycle(segment);
+        networkBufferPool.recyclePooledMemorySegment(segment);
     }
 
     private void returnExcessMemorySegments() {

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/io/network/buffer/NetworkBufferPool.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/io/network/buffer/NetworkBufferPool.java
@@ -26,6 +26,7 @@ import org.apache.flink.core.memory.MemorySegment;
 import org.apache.flink.core.memory.MemorySegmentFactory;
 import org.apache.flink.core.memory.MemorySegmentProvider;
 import org.apache.flink.runtime.io.AvailabilityProvider;
+import org.apache.flink.runtime.io.network.partition.consumer.RemoteInputChannel;
 import org.apache.flink.util.ExceptionUtils;
 import org.apache.flink.util.MathUtils;
 import org.apache.flink.util.Preconditions;
@@ -149,27 +150,47 @@ public class NetworkBufferPool
                 segmentSize);
     }
 
+    /**
+     * Different from {@link #requestUnpooledMemorySegments} for unpooled segments allocation. This
+     * method and the below {@link #requestPooledMemorySegmentsBlocking} method are designed to be
+     * used from {@link LocalBufferPool} for pooled memory segments allocation. Note that these
+     * methods for pooled memory segments requesting and recycling are prohibited from acquiring the
+     * factoryLock to avoid deadlock.
+     */
     @Nullable
-    public MemorySegment requestMemorySegment() {
+    public MemorySegment requestPooledMemorySegment() {
         synchronized (availableMemorySegments) {
             return internalRequestMemorySegment();
         }
     }
 
-    public List<MemorySegment> requestMemorySegmentsBlocking(int numberOfSegmentsToRequest)
+    public List<MemorySegment> requestPooledMemorySegmentsBlocking(int numberOfSegmentsToRequest)
             throws IOException {
         return internalRequestMemorySegments(numberOfSegmentsToRequest);
     }
 
-    public void recycle(MemorySegment segment) {
+    /**
+     * Corresponding to {@link #requestPooledMemorySegmentsBlocking} and {@link
+     * #requestPooledMemorySegment}, this method is for pooled memory segments recycling.
+     */
+    public void recyclePooledMemorySegment(MemorySegment segment) {
         // Adds the segment back to the queue, which does not immediately free the memory
         // however, since this happens when references to the global pool are also released,
         // making the availableMemorySegments queue and its contained object reclaimable
         internalRecycleMemorySegments(Collections.singleton(checkNotNull(segment)));
     }
 
+    /**
+     * Unpooled memory segments are requested directly from {@link NetworkBufferPool}, as opposed to
+     * pooled segments, that are requested through {@link BufferPool} that was created from this
+     * {@link NetworkBufferPool} (see {@link #createBufferPool}). They are used for example for
+     * exclusive {@link RemoteInputChannel} credits, that are permanently assigned to that channel,
+     * and never returned to any {@link BufferPool}. As opposed to pooled segments, when requested,
+     * unpooled segments needs to be accounted against {@link #numTotalRequiredBuffers}, which might
+     * require redistribution of the segments.
+     */
     @Override
-    public List<MemorySegment> requestMemorySegments(int numberOfSegmentsToRequest)
+    public List<MemorySegment> requestUnpooledMemorySegments(int numberOfSegmentsToRequest)
             throws IOException {
         checkArgument(
                 numberOfSegmentsToRequest >= 0,
@@ -245,8 +266,12 @@ public class NetworkBufferPool
         return segment;
     }
 
+    /**
+     * Corresponding to {@link #requestUnpooledMemorySegments}, this method is for unpooled memory
+     * segments recycling.
+     */
     @Override
-    public void recycleMemorySegments(Collection<MemorySegment> segments) {
+    public void recycleUnpooledMemorySegments(Collection<MemorySegment> segments) {
         recycleMemorySegments(segments, segments.size());
     }
 

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/io/network/partition/consumer/BufferManager.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/io/network/partition/consumer/BufferManager.java
@@ -139,7 +139,8 @@ public class BufferManager implements BufferListener, BufferRecycler {
             return;
         }
 
-        Collection<MemorySegment> segments = globalPool.requestMemorySegments(numExclusiveBuffers);
+        Collection<MemorySegment> segments =
+                globalPool.requestUnpooledMemorySegments(numExclusiveBuffers);
         synchronized (bufferQueue) {
             // AvailableBufferQueue::addExclusiveBuffer may release the previously allocated
             // floating buffer, which requires the caller to recycle these released floating
@@ -213,7 +214,7 @@ public class BufferManager implements BufferListener, BufferRecycler {
                 // Similar to notifyBufferAvailable(), make sure that we never add a buffer
                 // after channel released all buffers via releaseAllResources().
                 if (inputChannel.isReleased()) {
-                    globalPool.recycleMemorySegments(Collections.singletonList(segment));
+                    globalPool.recycleUnpooledMemorySegments(Collections.singletonList(segment));
                     return;
                 } else {
                     releasedFloatingBuffer =
@@ -280,7 +281,7 @@ public class BufferManager implements BufferListener, BufferRecycler {
         }
         try {
             if (exclusiveRecyclingSegments.size() > 0) {
-                globalPool.recycleMemorySegments(exclusiveRecyclingSegments);
+                globalPool.recycleUnpooledMemorySegments(exclusiveRecyclingSegments);
             }
         } catch (Exception e) {
             err = firstOrSuppressed(e, err);

--- a/flink-runtime/src/test/java/org/apache/flink/runtime/io/network/buffer/BufferPoolFactoryTest.java
+++ b/flink-runtime/src/test/java/org/apache/flink/runtime/io/network/buffer/BufferPoolFactoryTest.java
@@ -317,7 +317,7 @@ public class BufferPoolFactoryTest {
             BufferPool first = globalPool.createBufferPool(1, 10);
             assertEquals(10, first.getNumBuffers());
 
-            List<MemorySegment> segmentList1 = globalPool.requestMemorySegments(2);
+            List<MemorySegment> segmentList1 = globalPool.requestUnpooledMemorySegments(2);
             assertEquals(2, segmentList1.size());
             assertEquals(8, first.getNumBuffers());
 
@@ -325,12 +325,12 @@ public class BufferPoolFactoryTest {
             assertEquals(4, first.getNumBuffers());
             assertEquals(4, second.getNumBuffers());
 
-            List<MemorySegment> segmentList2 = globalPool.requestMemorySegments(2);
+            List<MemorySegment> segmentList2 = globalPool.requestUnpooledMemorySegments(2);
             assertEquals(2, segmentList2.size());
             assertEquals(3, first.getNumBuffers());
             assertEquals(3, second.getNumBuffers());
 
-            List<MemorySegment> segmentList3 = globalPool.requestMemorySegments(2);
+            List<MemorySegment> segmentList3 = globalPool.requestUnpooledMemorySegments(2);
             assertEquals(2, segmentList3.size());
             assertEquals(2, first.getNumBuffers());
             assertEquals(2, second.getNumBuffers());
@@ -339,17 +339,17 @@ public class BufferPoolFactoryTest {
                     "Wrong number of available segments after creating buffer pools and requesting segments.";
             assertEquals(msg, 2, globalPool.getNumberOfAvailableMemorySegments());
 
-            globalPool.recycleMemorySegments(segmentList1);
+            globalPool.recycleUnpooledMemorySegments(segmentList1);
             assertEquals(msg, 4, globalPool.getNumberOfAvailableMemorySegments());
             assertEquals(3, first.getNumBuffers());
             assertEquals(3, second.getNumBuffers());
 
-            globalPool.recycleMemorySegments(segmentList2);
+            globalPool.recycleUnpooledMemorySegments(segmentList2);
             assertEquals(msg, 6, globalPool.getNumberOfAvailableMemorySegments());
             assertEquals(4, first.getNumBuffers());
             assertEquals(4, second.getNumBuffers());
 
-            globalPool.recycleMemorySegments(segmentList3);
+            globalPool.recycleUnpooledMemorySegments(segmentList3);
             assertEquals(msg, 8, globalPool.getNumberOfAvailableMemorySegments());
             assertEquals(5, first.getNumBuffers());
             assertEquals(5, second.getNumBuffers());

--- a/flink-runtime/src/test/java/org/apache/flink/runtime/io/network/buffer/LocalBufferPoolTest.java
+++ b/flink-runtime/src/test/java/org/apache/flink/runtime/io/network/buffer/LocalBufferPoolTest.java
@@ -127,6 +127,65 @@ public class LocalBufferPoolTest extends TestLogger {
         }
     }
 
+    @Test(timeout = 10000) // timeout can indicate a potential deadlock
+    public void testReserveSegmentsAndCancel() throws Exception {
+        int totalSegments = 4;
+        int segmentsToReserve = 2;
+
+        NetworkBufferPool globalPool = new NetworkBufferPool(totalSegments, memorySegmentSize);
+        BufferPool localPool1 = globalPool.createBufferPool(segmentsToReserve, totalSegments);
+        List<MemorySegment> segments = new ArrayList<>();
+
+        try {
+            for (int i = 0; i < totalSegments; ++i) {
+                segments.add(localPool1.requestMemorySegmentBlocking());
+            }
+
+            BufferPool localPool2 = globalPool.createBufferPool(segmentsToReserve, totalSegments);
+            // the segment reserve thread will be blocked for no buffer is available
+            Thread reserveThread =
+                    new Thread(
+                            () -> {
+                                try {
+                                    localPool2.reserveSegments(segmentsToReserve);
+                                } catch (Throwable ignored) {
+                                }
+                            });
+            reserveThread.start();
+            Thread.sleep(100); // wait to be blocked
+
+            // the cancel thread can be blocked when redistributing buffers
+            Thread cancelThread =
+                    new Thread(
+                            () -> {
+                                localPool1.lazyDestroy();
+                                localPool2.lazyDestroy();
+                            });
+            cancelThread.start();
+
+            // it is expected that the segment reserve thread can be cancelled successfully
+            Thread interruptThread =
+                    new Thread(
+                            () -> {
+                                try {
+                                    do {
+                                        reserveThread.interrupt();
+                                        Thread.sleep(100);
+                                    } while (reserveThread.isAlive() || cancelThread.isAlive());
+                                } catch (Throwable ignored) {
+                                }
+                            });
+            interruptThread.start();
+
+            interruptThread.join();
+        } finally {
+            segments.forEach(localPool1::recycle);
+            localPool1.lazyDestroy();
+            assertEquals(0, globalPool.getNumberOfUsedMemorySegments());
+            globalPool.destroy();
+        }
+    }
+
     @Test
     public void testRequestMoreThanAvailable() {
         localBufferPool.setNumBuffers(numBuffers);

--- a/flink-runtime/src/test/java/org/apache/flink/runtime/io/network/buffer/LocalBufferPoolTest.java
+++ b/flink-runtime/src/test/java/org/apache/flink/runtime/io/network/buffer/LocalBufferPoolTest.java
@@ -547,11 +547,11 @@ public class LocalBufferPoolTest extends TestLogger {
 
         @Nullable
         @Override
-        public MemorySegment requestMemorySegment() {
+        public MemorySegment requestPooledMemorySegment() {
             if (requestCounter++ == 1) {
                 return null;
             }
-            return super.requestMemorySegment();
+            return super.requestPooledMemorySegment();
         }
     }
 }

--- a/flink-runtime/src/test/java/org/apache/flink/runtime/io/network/partition/InputChannelTestUtils.java
+++ b/flink-runtime/src/test/java/org/apache/flink/runtime/io/network/partition/InputChannelTestUtils.java
@@ -254,12 +254,13 @@ public class InputChannelTestUtils {
         private StubMemorySegmentProvider() {}
 
         @Override
-        public Collection<MemorySegment> requestMemorySegments(int numberOfSegmentsToRequest) {
+        public Collection<MemorySegment> requestUnpooledMemorySegments(
+                int numberOfSegmentsToRequest) {
             return Collections.emptyList();
         }
 
         @Override
-        public void recycleMemorySegments(Collection<MemorySegment> segments) {}
+        public void recycleUnpooledMemorySegments(Collection<MemorySegment> segments) {}
     }
 
     /** {@link MemorySegmentProvider} that provides unpooled {@link MemorySegment}s. */
@@ -271,12 +272,13 @@ public class InputChannelTestUtils {
         }
 
         @Override
-        public Collection<MemorySegment> requestMemorySegments(int numberOfSegmentsToRequest) {
+        public Collection<MemorySegment> requestUnpooledMemorySegments(
+                int numberOfSegmentsToRequest) {
             return Collections.singletonList(
                     MemorySegmentFactory.allocateUnpooledSegment(pageSize));
         }
 
         @Override
-        public void recycleMemorySegments(Collection<MemorySegment> segments) {}
+        public void recycleUnpooledMemorySegments(Collection<MemorySegment> segments) {}
     }
 }


### PR DESCRIPTION
## What is the purpose of the change

This PR tries to fix the issues caused by FLINK-24035. More specifically, there are two issues, the first one is the deadlock caused by acquiring the 'factoryLock' in NetworkBufferPool and the other is the incorrect decreasing of the required segments of NetworkBufferPool. Both issues occur during exception handling of requesting segments. Actually, when reserving memory segments for LocalBufferPool, there is no need to modify the value of required segments. As a result, there is no need to acquire the 'factoryLock'. This PR fixes the issues by removing the required segments decreasing logic together with the 'factoryLock' acquiring during exception handling of requesting segments in NetworkBufferPool.

## Brief change log

  - Avoid locking 'factoryLock' for LocalBufferPool#reserveSegments method.


## Verifying this change

This change added a new test, without the fix, the test will fail.

## Does this pull request potentially affect one of the following parts:

  - Dependencies (does it add or upgrade a dependency): (yes / **no**)
  - The public API, i.e., is any changed class annotated with `@Public(Evolving)`: (yes / **no**)
  - The serializers: (yes / **no** / don't know)
  - The runtime per-record code paths (performance sensitive): (yes / **no** / don't know)
  - Anything that affects deployment or recovery: JobManager (and its components), Checkpointing, Kubernetes/Yarn, ZooKeeper: (yes / **no** / don't know)
  - The S3 file system connector: (yes / **no** / don't know)

## Documentation

  - Does this pull request introduce a new feature? (yes / **no**)
  - If yes, how is the feature documented? (**not applicable** / docs / JavaDocs / not documented)
