### PR TITLE
[FLINK-23687][table-planner] Introduce partitioned lookup join to enforce input of LookupJoin to hash shuffle by lookup keys

### DIFF
--- a/docs/content.zh/docs/dev/table/sql/queries/joins.md
+++ b/docs/content.zh/docs/dev/table/sql/queries/joins.md
@@ -324,6 +324,17 @@ FROM Orders AS o
 
 In the example above, the Orders table is enriched with data from the Customers table which resides in a MySQL database. The `FOR SYSTEM_TIME AS OF` clause with the subsequent processing time attribute ensures that each row of the `Orders` table is joined with those Customers rows that match the join predicate at the point in time when the `Orders` row is processed by the join operator. It also prevents that the join result is updated when a joined `Customer` row is updated in the future. The lookup join also requires a mandatory equality join predicate, in the example above `o.customer_id = c.id`.
 
+### Partitioned Lookup Join
+Some lookup source connectors use cache to reduce RPC call times. In order to raise cache hit ratio for those connectors, user could use a hint to enable partitioned lookup join which enforces input of lookup join to hash shuffle by look up keys.
+
+```sql
+-- enable partitioned lookup join by partitioned hint
+SELECT o.order_id, o.total, c.country, c.zip
+FROM Orders AS o
+  JOIN Customers /*+ PARTITIONED_JOIN */ FOR SYSTEM_TIME AS OF o.proc_time AS c
+    ON o.customer_id = c.id;
+```
+
 Array Expansion
 --------------
 

--- a/docs/content/docs/dev/table/sql/queries/joins.md
+++ b/docs/content/docs/dev/table/sql/queries/joins.md
@@ -324,6 +324,17 @@ FROM Orders AS o
 
 In the example above, the Orders table is enriched with data from the Customers table which resides in a MySQL database. The `FOR SYSTEM_TIME AS OF` clause with the subsequent processing time attribute ensures that each row of the `Orders` table is joined with those Customers rows that match the join predicate at the point in time when the `Orders` row is processed by the join operator. It also prevents that the join result is updated when a joined `Customer` row is updated in the future. The lookup join also requires a mandatory equality join predicate, in the example above `o.customer_id = c.id`.
 
+### Partitioned Lookup Join
+Some lookup source connectors use cache to reduce RPC call times. In order to raise cache hit ratio for those connectors, user could use a hint to enable partitioned lookup join which enforces input of lookup join to hash shuffle by look up keys.
+
+```sql
+-- enable partitioned lookup join by partitioned hint
+SELECT o.order_id, o.total, c.country, c.zip
+FROM Orders AS o
+  JOIN Customers /*+ PARTITIONED_JOIN */ FOR SYSTEM_TIME AS OF o.proc_time AS c
+    ON o.customer_id = c.id;
+```
+
 Array Expansion
 --------------
 

--- a/flink-table/flink-table-planner/src/main/java/org/apache/flink/table/planner/hint/FlinkHintStrategies.java
+++ b/flink-table/flink-table-planner/src/main/java/org/apache/flink/table/planner/hint/FlinkHintStrategies.java
@@ -51,6 +51,17 @@ public abstract class FlinkHintStrategies {
                         HintStrategy.builder(HintPredicates.AGGREGATE)
                                 .excludedRules(WrapJsonAggFunctionArgumentsRule.INSTANCE)
                                 .build())
+                .hintStrategy(
+                        FlinkHints.HINT_NAME_PARTITIONED_JOIN,
+                        HintStrategy.builder(HintPredicates.TABLE_SCAN)
+                                .optionChecker(
+                                        (hint, errorHandler) ->
+                                                errorHandler.check(
+                                                        hint.kvOptions.isEmpty()
+                                                                && hint.listOptions.isEmpty(),
+                                                        "Hint [{}] does not require any options",
+                                                        hint.hintName))
+                                .build())
                 .build();
     }
 }

--- a/flink-table/flink-table-planner/src/main/java/org/apache/flink/table/planner/hint/FlinkHints.java
+++ b/flink-table/flink-table-planner/src/main/java/org/apache/flink/table/planner/hint/FlinkHints.java
@@ -33,6 +33,8 @@ public abstract class FlinkHints {
 
     public static final String HINT_NAME_OPTIONS = "OPTIONS";
 
+    public static final String HINT_NAME_PARTITIONED_JOIN = "PARTITIONED_JOIN";
+
     /**
      * Internal hint that JSON aggregation function arguments have been wrapped already. See {@link
      * WrapJsonAggFunctionArgumentsRule}.

--- a/flink-table/flink-table-planner/src/main/scala/org/apache/flink/table/planner/plan/rules/physical/stream/StreamPhysicalLookupJoinRule.scala
+++ b/flink-table/flink-table-planner/src/main/scala/org/apache/flink/table/planner/plan/rules/physical/stream/StreamPhysicalLookupJoinRule.scala
@@ -22,6 +22,7 @@ import org.apache.flink.table.planner.plan.nodes.logical._
 import org.apache.flink.table.planner.plan.nodes.physical.common.CommonPhysicalLookupJoin
 import org.apache.flink.table.planner.plan.nodes.physical.stream.StreamPhysicalLookupJoin
 import org.apache.flink.table.planner.plan.rules.physical.common.{BaseSnapshotOnCalcTableScanRule, BaseSnapshotOnTableScanRule}
+import org.apache.flink.table.planner.plan.`trait`.FlinkRelDistribution
 
 import org.apache.calcite.plan.{RelOptRule, RelOptTable}
 import org.apache.calcite.rex.RexProgram
@@ -46,8 +47,9 @@ object StreamPhysicalLookupJoinRule {
         join: FlinkLogicalJoin,
         input: FlinkLogicalRel,
         temporalTable: RelOptTable,
+        enablePartitionedJoin: Boolean,
         calcProgram: Option[RexProgram]): CommonPhysicalLookupJoin = {
-      doTransform(join, input, temporalTable, calcProgram)
+      doTransform(join, input, temporalTable, enablePartitionedJoin, calcProgram)
     }
   }
 
@@ -58,8 +60,9 @@ object StreamPhysicalLookupJoinRule {
         join: FlinkLogicalJoin,
         input: FlinkLogicalRel,
         temporalTable: RelOptTable,
+        enablePartitionedJoin: Boolean,
         calcProgram: Option[RexProgram]): CommonPhysicalLookupJoin = {
-      doTransform(join, input, temporalTable, calcProgram)
+      doTransform(join, input, temporalTable, enablePartitionedJoin, calcProgram)
     }
   }
 
@@ -67,6 +70,7 @@ object StreamPhysicalLookupJoinRule {
     join: FlinkLogicalJoin,
     input: FlinkLogicalRel,
     temporalTable: RelOptTable,
+    enablePartitionedJoin: Boolean,
     calcProgram: Option[RexProgram]): StreamPhysicalLookupJoin = {
 
     val joinInfo = join.analyzeCondition
@@ -74,7 +78,12 @@ object StreamPhysicalLookupJoinRule {
     val cluster = join.getCluster
 
     val providedTrait = join.getTraitSet.replace(FlinkConventions.STREAM_PHYSICAL)
-    val requiredTrait = input.getTraitSet.replace(FlinkConventions.STREAM_PHYSICAL)
+    var requiredTrait = input.getTraitSet.replace(FlinkConventions.STREAM_PHYSICAL)
+
+    // if partitioning enabled, use the join key as partition key
+    if (enablePartitionedJoin && !joinInfo.pairs().isEmpty) {
+      requiredTrait = requiredTrait.plus(FlinkRelDistribution.hash(joinInfo.leftKeys))
+    }
 
     val convInput = RelOptRule.convert(input, requiredTrait)
     new StreamPhysicalLookupJoin(

--- a/flink-table/flink-table-planner/src/test/resources/org/apache/flink/table/planner/plan/batch/sql/join/LookupJoinTest.xml
+++ b/flink-table/flink-table-planner/src/test/resources/org/apache/flink/table/planner/plan/batch/sql/join/LookupJoinTest.xml
@@ -16,7 +16,7 @@ See the License for the specific language governing permissions and
 limitations under the License.
 -->
 <Root>
-  <TestCase name="testAvoidAggregatePushDown[LegacyTableSource=false]">
+  <TestCase name="testAvoidAggregatePushDown[LegacyTableSource=false, partitionedJoin=false]">
     <Resource name="sql">
       <![CDATA[
 SELECT b, count(a), sum(c), sum(d)
@@ -62,7 +62,54 @@ HashAggregate(isMerge=[true], groupBy=[b], select=[b, Final_COUNT(count$0) AS EX
 ]]>
     </Resource>
   </TestCase>
-  <TestCase name="testAvoidAggregatePushDown[LegacyTableSource=true]">
+  <TestCase name="testAvoidAggregatePushDown[LegacyTableSource=false, partitionedJoin=true]">
+    <Resource name="sql">
+      <![CDATA[
+SELECT b, count(a), sum(c), sum(d)
+FROM (
+SELECT T.* FROM (
+SELECT b, a, sum(c) c, sum(d) d, PROCTIME() as proctime
+FROM T1
+GROUP BY a, b
+      ) AS T
+JOIN LookupTable /*+ PARTITIONED_JOIN */ FOR SYSTEM_TIME AS OF T.proctime AS D
+ON T.a = D.id
+WHERE D.age > 10
+      ) AS T
+GROUP BY b
+      ]]>
+    </Resource>
+    <Resource name="ast">
+      <![CDATA[
+LogicalAggregate(group=[{0}], EXPR$1=[COUNT($1)], EXPR$2=[SUM($2)], EXPR$3=[SUM($3)])
++- LogicalProject(b=[$0], a=[$1], c=[$2], d=[$3])
+   +- LogicalFilter(condition=[>($7, 10)])
+      +- LogicalCorrelate(correlation=[$cor0], joinType=[inner], requiredColumns=[{1, 4}])
+         :- LogicalProject(b=[$1], a=[$0], c=[$2], d=[$3], proctime=[PROCTIME()])
+         :  +- LogicalAggregate(group=[{0, 1}], c=[SUM($2)], d=[SUM($3)])
+         :     +- LogicalTableScan(table=[[default_catalog, default_database, T1]])
+         +- LogicalFilter(condition=[=($cor0.a, $0)])
+            +- LogicalSnapshot(period=[$cor0.proctime])
+               +- LogicalTableScan(table=[[default_catalog, default_database, LookupTable]], hints=[[[PARTITIONED_JOIN inheritPath:[]]]])
+]]>
+    </Resource>
+    <Resource name="optimized exec plan">
+      <![CDATA[
+HashAggregate(isMerge=[true], groupBy=[b], select=[b, Final_COUNT(count$0) AS EXPR$1, Final_SUM(sum$1) AS EXPR$2, Final_SUM(sum$2) AS EXPR$3])
++- Exchange(distribution=[hash[b]])
+   +- LocalHashAggregate(groupBy=[b], select=[b, Partial_COUNT(a) AS count$0, Partial_SUM(c) AS sum$1, Partial_SUM(d) AS sum$2])
+      +- Calc(select=[b, a, c, d])
+         +- LookupJoin(table=[default_catalog.default_database.LookupTable], joinType=[InnerJoin], async=[false], lookup=[id=a], where=[(age > 10)], select=[b, a, c, d, id])
+            +- Exchange(distribution=[hash[a]])
+               +- Calc(select=[b, a, c, d])
+                  +- HashAggregate(isMerge=[true], groupBy=[a, b], select=[a, b, Final_SUM(sum$0) AS c, Final_SUM(sum$1) AS d])
+                     +- Exchange(distribution=[hash[a, b]])
+                        +- LocalHashAggregate(groupBy=[a, b], select=[a, b, Partial_SUM(c) AS sum$0, Partial_SUM(d) AS sum$1])
+                           +- BoundedStreamScan(table=[[default_catalog, default_database, T1]], fields=[a, b, c, d])
+]]>
+    </Resource>
+  </TestCase>
+  <TestCase name="testAvoidAggregatePushDown[LegacyTableSource=true, partitionedJoin=false]">
     <Resource name="sql">
       <![CDATA[
 SELECT b, count(a), sum(c), sum(d)
@@ -108,9 +155,59 @@ HashAggregate(isMerge=[true], groupBy=[b], select=[b, Final_COUNT(count$0) AS EX
 ]]>
     </Resource>
   </TestCase>
-  <TestCase name="testJoinTemporalTable[LegacyTableSource=false]">
+  <TestCase name="testAvoidAggregatePushDown[LegacyTableSource=true, partitionedJoin=true]">
     <Resource name="sql">
-      <![CDATA[SELECT * FROM MyTable AS T JOIN LookupTable FOR SYSTEM_TIME AS OF T.proctime AS D ON T.a = D.id]]>
+      <![CDATA[
+SELECT b, count(a), sum(c), sum(d)
+FROM (
+SELECT T.* FROM (
+SELECT b, a, sum(c) c, sum(d) d, PROCTIME() as proctime
+FROM T1
+GROUP BY a, b
+      ) AS T
+JOIN LookupTable /*+ PARTITIONED_JOIN */ FOR SYSTEM_TIME AS OF T.proctime AS D
+ON T.a = D.id
+WHERE D.age > 10
+      ) AS T
+GROUP BY b
+      ]]>
+    </Resource>
+    <Resource name="ast">
+      <![CDATA[
+LogicalAggregate(group=[{0}], EXPR$1=[COUNT($1)], EXPR$2=[SUM($2)], EXPR$3=[SUM($3)])
++- LogicalProject(b=[$0], a=[$1], c=[$2], d=[$3])
+   +- LogicalFilter(condition=[>($7, 10)])
+      +- LogicalCorrelate(correlation=[$cor0], joinType=[inner], requiredColumns=[{1, 4}])
+         :- LogicalProject(b=[$1], a=[$0], c=[$2], d=[$3], proctime=[PROCTIME()])
+         :  +- LogicalAggregate(group=[{0, 1}], c=[SUM($2)], d=[SUM($3)])
+         :     +- LogicalTableScan(table=[[default_catalog, default_database, T1]])
+         +- LogicalFilter(condition=[=($cor0.a, $0)])
+            +- LogicalSnapshot(period=[$cor0.proctime])
+               +- LogicalTableScan(table=[[default_catalog, default_database, LookupTable, source: [TestTemporalTable(id, name, age)]]], hints=[[[PARTITIONED_JOIN inheritPath:[]]]])
+]]>
+    </Resource>
+    <Resource name="optimized exec plan">
+      <![CDATA[
+HashAggregate(isMerge=[true], groupBy=[b], select=[b, Final_COUNT(count$0) AS EXPR$1, Final_SUM(sum$1) AS EXPR$2, Final_SUM(sum$2) AS EXPR$3])
++- Exchange(distribution=[hash[b]])
+   +- LocalHashAggregate(groupBy=[b], select=[b, Partial_COUNT(a) AS count$0, Partial_SUM(c) AS sum$1, Partial_SUM(d) AS sum$2])
+      +- Calc(select=[b, a, c, d])
+         +- LookupJoin(table=[default_catalog.default_database.LookupTable], joinType=[InnerJoin], async=[false], lookup=[id=a], where=[(age > 10)], select=[b, a, c, d, id])
+            +- Exchange(distribution=[hash[a]])
+               +- Calc(select=[b, a, c, d])
+                  +- HashAggregate(isMerge=[true], groupBy=[a, b], select=[a, b, Final_SUM(sum$0) AS c, Final_SUM(sum$1) AS d])
+                     +- Exchange(distribution=[hash[a, b]])
+                        +- LocalHashAggregate(groupBy=[a, b], select=[a, b, Partial_SUM(c) AS sum$0, Partial_SUM(d) AS sum$1])
+                           +- BoundedStreamScan(table=[[default_catalog, default_database, T1]], fields=[a, b, c, d])
+]]>
+    </Resource>
+  </TestCase>
+  <TestCase name="testJoinTemporalTable[LegacyTableSource=false, partitionedJoin=false]">
+    <Resource name="sql">
+      <![CDATA[
+SELECT * FROM MyTable AS T JOIN LookupTable
+FOR SYSTEM_TIME AS OF T.proctime AS D ON T.a = D.id
+]]>
     </Resource>
     <Resource name="ast">
       <![CDATA[
@@ -132,9 +229,40 @@ Calc(select=[a, b, c, PROCTIME_MATERIALIZE(proctime) AS proctime, id, name, age]
 ]]>
     </Resource>
   </TestCase>
-  <TestCase name="testJoinTemporalTable[LegacyTableSource=true]">
+  <TestCase name="testJoinTemporalTable[LegacyTableSource=false, partitionedJoin=true]">
     <Resource name="sql">
-      <![CDATA[SELECT * FROM MyTable AS T JOIN LookupTable FOR SYSTEM_TIME AS OF T.proctime AS D ON T.a = D.id]]>
+      <![CDATA[
+SELECT * FROM MyTable AS T JOIN LookupTable /*+ PARTITIONED_JOIN */
+FOR SYSTEM_TIME AS OF T.proctime AS D ON T.a = D.id
+]]>
+    </Resource>
+    <Resource name="ast">
+      <![CDATA[
+LogicalProject(a=[$0], b=[$1], c=[$2], proctime=[$3], id=[$4], name=[$5], age=[$6])
++- LogicalCorrelate(correlation=[$cor0], joinType=[inner], requiredColumns=[{0, 3}])
+   :- LogicalProject(a=[$0], b=[$1], c=[$2], proctime=[PROCTIME()])
+   :  +- LogicalTableScan(table=[[default_catalog, default_database, T0]])
+   +- LogicalFilter(condition=[=($cor0.a, $0)])
+      +- LogicalSnapshot(period=[$cor0.proctime])
+         +- LogicalTableScan(table=[[default_catalog, default_database, LookupTable]], hints=[[[PARTITIONED_JOIN inheritPath:[]]]])
+]]>
+    </Resource>
+    <Resource name="optimized exec plan">
+      <![CDATA[
+Calc(select=[a, b, c, PROCTIME_MATERIALIZE(proctime) AS proctime, id, name, age])
++- LookupJoin(table=[default_catalog.default_database.LookupTable], joinType=[InnerJoin], async=[false], lookup=[id=a], select=[a, b, c, proctime, id, name, age])
+   +- Calc(select=[a, b, c, PROCTIME() AS proctime])
+      +- Exchange(distribution=[hash[a]])
+         +- BoundedStreamScan(table=[[default_catalog, default_database, T0]], fields=[a, b, c])
+]]>
+    </Resource>
+  </TestCase>
+  <TestCase name="testJoinTemporalTable[LegacyTableSource=true, partitionedJoin=false]">
+    <Resource name="sql">
+      <![CDATA[
+SELECT * FROM MyTable AS T JOIN LookupTable
+FOR SYSTEM_TIME AS OF T.proctime AS D ON T.a = D.id
+]]>
     </Resource>
     <Resource name="ast">
       <![CDATA[
@@ -156,14 +284,43 @@ Calc(select=[a, b, c, PROCTIME_MATERIALIZE(proctime) AS proctime, id, name, age]
 ]]>
     </Resource>
   </TestCase>
-  <TestCase name="testJoinTemporalTableWithComputedColumn[LegacyTableSource=false]">
+  <TestCase name="testJoinTemporalTable[LegacyTableSource=true, partitionedJoin=true]">
+    <Resource name="sql">
+      <![CDATA[
+SELECT * FROM MyTable AS T JOIN LookupTable /*+ PARTITIONED_JOIN */
+FOR SYSTEM_TIME AS OF T.proctime AS D ON T.a = D.id
+]]>
+    </Resource>
+    <Resource name="ast">
+      <![CDATA[
+LogicalProject(a=[$0], b=[$1], c=[$2], proctime=[$3], id=[$4], name=[$5], age=[$6])
++- LogicalCorrelate(correlation=[$cor0], joinType=[inner], requiredColumns=[{0, 3}])
+   :- LogicalProject(a=[$0], b=[$1], c=[$2], proctime=[PROCTIME()])
+   :  +- LogicalTableScan(table=[[default_catalog, default_database, T0]])
+   +- LogicalFilter(condition=[=($cor0.a, $0)])
+      +- LogicalSnapshot(period=[$cor0.proctime])
+         +- LogicalTableScan(table=[[default_catalog, default_database, LookupTable, source: [TestTemporalTable(id, name, age)]]], hints=[[[PARTITIONED_JOIN inheritPath:[]]]])
+]]>
+    </Resource>
+    <Resource name="optimized exec plan">
+      <![CDATA[
+Calc(select=[a, b, c, PROCTIME_MATERIALIZE(proctime) AS proctime, id, name, age])
++- LookupJoin(table=[default_catalog.default_database.LookupTable], joinType=[InnerJoin], async=[false], lookup=[id=a], select=[a, b, c, proctime, id, name, age])
+   +- Calc(select=[a, b, c, PROCTIME() AS proctime])
+      +- Exchange(distribution=[hash[a]])
+         +- BoundedStreamScan(table=[[default_catalog, default_database, T0]], fields=[a, b, c])
+]]>
+    </Resource>
+  </TestCase>
+  <TestCase name="testJoinTemporalTableWithComputedColumn[LegacyTableSource=false, partitionedJoin=false]">
     <Resource name="sql">
       <![CDATA[
 SELECT
   T.a, T.b, T.c, D.name, D.age, D.nominal_age
 FROM
-  MyTable AS T JOIN LookupTableWithComputedColumn FOR SYSTEM_TIME AS OF T.proctime AS D
-  ON T.a = D.id
+  MyTable AS T JOIN LookupTableWithComputedColumn
+FOR SYSTEM_TIME AS OF T.proctime AS D
+ON T.a = D.id
       ]]>
     </Resource>
     <Resource name="ast">
@@ -186,14 +343,47 @@ Calc(select=[a, b, c, name, age, nominal_age])
 ]]>
     </Resource>
   </TestCase>
-  <TestCase name="testJoinTemporalTableWithComputedColumnAndPushDown[LegacyTableSource=false]">
+  <TestCase name="testJoinTemporalTableWithComputedColumn[LegacyTableSource=false, partitionedJoin=true]">
     <Resource name="sql">
       <![CDATA[
 SELECT
   T.a, T.b, T.c, D.name, D.age, D.nominal_age
 FROM
-  MyTable AS T JOIN LookupTableWithComputedColumn FOR SYSTEM_TIME AS OF T.proctime AS D
-  ON T.a = D.id and D.nominal_age > 12
+  MyTable AS T JOIN LookupTableWithComputedColumn /*+ PARTITIONED_JOIN */
+FOR SYSTEM_TIME AS OF T.proctime AS D
+ON T.a = D.id
+      ]]>
+    </Resource>
+    <Resource name="ast">
+      <![CDATA[
+LogicalProject(a=[$0], b=[$1], c=[$2], name=[$5], age=[$6], nominal_age=[$7])
++- LogicalCorrelate(correlation=[$cor0], joinType=[inner], requiredColumns=[{0, 3}])
+   :- LogicalProject(a=[$0], b=[$1], c=[$2], proctime=[PROCTIME()])
+   :  +- LogicalTableScan(table=[[default_catalog, default_database, T0]])
+   +- LogicalFilter(condition=[=($cor0.a, $0)])
+      +- LogicalSnapshot(period=[$cor0.proctime])
+         +- LogicalProject(id=[$0], name=[$1], age=[$2], nominal_age=[+($2, 1)])
+            +- LogicalTableScan(table=[[default_catalog, default_database, LookupTableWithComputedColumn]], hints=[[[PARTITIONED_JOIN inheritPath:[]]]])
+]]>
+    </Resource>
+    <Resource name="optimized exec plan">
+      <![CDATA[
+Calc(select=[a, b, c, name, age, nominal_age])
++- LookupJoin(table=[default_catalog.default_database.LookupTableWithComputedColumn], joinType=[InnerJoin], async=[false], lookup=[id=a], select=[a, b, c, id, name, age, (age + 1) AS nominal_age])
+   +- Exchange(distribution=[hash[a]])
+      +- BoundedStreamScan(table=[[default_catalog, default_database, T0]], fields=[a, b, c])
+]]>
+    </Resource>
+  </TestCase>
+  <TestCase name="testJoinTemporalTableWithComputedColumnAndPushDown[LegacyTableSource=false, partitionedJoin=false]">
+    <Resource name="sql">
+      <![CDATA[
+SELECT
+  T.a, T.b, T.c, D.name, D.age, D.nominal_age
+FROM
+  MyTable AS T JOIN LookupTableWithComputedColumn
+FOR SYSTEM_TIME AS OF T.proctime AS D
+ON T.a = D.id and D.nominal_age > 12
       ]]>
     </Resource>
     <Resource name="ast">
@@ -216,7 +406,39 @@ Calc(select=[a, b, c, name, age, nominal_age])
 ]]>
     </Resource>
   </TestCase>
-  <TestCase name="testJoinTemporalTableWithFilterPushDown[LegacyTableSource=false]">
+  <TestCase name="testJoinTemporalTableWithComputedColumnAndPushDown[LegacyTableSource=false, partitionedJoin=true]">
+    <Resource name="sql">
+      <![CDATA[
+SELECT
+  T.a, T.b, T.c, D.name, D.age, D.nominal_age
+FROM
+  MyTable AS T JOIN LookupTableWithComputedColumn /*+ PARTITIONED_JOIN */
+FOR SYSTEM_TIME AS OF T.proctime AS D
+ON T.a = D.id and D.nominal_age > 12
+      ]]>
+    </Resource>
+    <Resource name="ast">
+      <![CDATA[
+LogicalProject(a=[$0], b=[$1], c=[$2], name=[$5], age=[$6], nominal_age=[$7])
++- LogicalCorrelate(correlation=[$cor0], joinType=[inner], requiredColumns=[{0, 3}])
+   :- LogicalProject(a=[$0], b=[$1], c=[$2], proctime=[PROCTIME()])
+   :  +- LogicalTableScan(table=[[default_catalog, default_database, T0]])
+   +- LogicalFilter(condition=[AND(=($cor0.a, $0), >($3, 12))])
+      +- LogicalSnapshot(period=[$cor0.proctime])
+         +- LogicalProject(id=[$0], name=[$1], age=[$2], nominal_age=[+($2, 1)])
+            +- LogicalTableScan(table=[[default_catalog, default_database, LookupTableWithComputedColumn]], hints=[[[PARTITIONED_JOIN inheritPath:[]]]])
+]]>
+    </Resource>
+    <Resource name="optimized exec plan">
+      <![CDATA[
+Calc(select=[a, b, c, name, age, nominal_age])
++- LookupJoin(table=[default_catalog.default_database.LookupTableWithComputedColumn], joinType=[InnerJoin], async=[false], lookup=[id=a], where=[((age + 1) > 12)], select=[a, b, c, id, name, age, (age + 1) AS nominal_age])
+   +- Exchange(distribution=[hash[a]])
+      +- BoundedStreamScan(table=[[default_catalog, default_database, T0]], fields=[a, b, c])
+]]>
+    </Resource>
+  </TestCase>
+  <TestCase name="testJoinTemporalTableWithFilterPushDown[LegacyTableSource=false, partitionedJoin=false]">
     <Resource name="sql">
       <![CDATA[
 SELECT * FROM MyTable AS T
@@ -246,7 +468,38 @@ Calc(select=[a, b, c, PROCTIME_MATERIALIZE(proctime) AS proctime, id, name, CAST
 ]]>
     </Resource>
   </TestCase>
-  <TestCase name="testJoinTemporalTableWithFilterPushDown[LegacyTableSource=true]">
+  <TestCase name="testJoinTemporalTableWithFilterPushDown[LegacyTableSource=false, partitionedJoin=true]">
+    <Resource name="sql">
+      <![CDATA[
+SELECT * FROM MyTable AS T
+JOIN LookupTable /*+ PARTITIONED_JOIN */ FOR SYSTEM_TIME AS OF T.proctime AS D
+ON T.a = D.id AND D.age = 10
+WHERE T.c > 1000
+      ]]>
+    </Resource>
+    <Resource name="ast">
+      <![CDATA[
+LogicalProject(a=[$0], b=[$1], c=[$2], proctime=[$3], id=[$4], name=[$5], age=[$6])
++- LogicalFilter(condition=[>($2, 1000)])
+   +- LogicalCorrelate(correlation=[$cor0], joinType=[inner], requiredColumns=[{0, 3}])
+      :- LogicalProject(a=[$0], b=[$1], c=[$2], proctime=[PROCTIME()])
+      :  +- LogicalTableScan(table=[[default_catalog, default_database, T0]])
+      +- LogicalFilter(condition=[AND(=($cor0.a, $0), =($2, 10))])
+         +- LogicalSnapshot(period=[$cor0.proctime])
+            +- LogicalTableScan(table=[[default_catalog, default_database, LookupTable]], hints=[[[PARTITIONED_JOIN inheritPath:[]]]])
+]]>
+    </Resource>
+    <Resource name="optimized exec plan">
+      <![CDATA[
+Calc(select=[a, b, c, PROCTIME_MATERIALIZE(proctime) AS proctime, id, name, CAST(10 AS INTEGER) AS age])
++- LookupJoin(table=[default_catalog.default_database.LookupTable], joinType=[InnerJoin], async=[false], lookup=[age=10, id=a], where=[(age = 10)], select=[a, b, c, proctime, id, name])
+   +- Exchange(distribution=[hash[a]])
+      +- Calc(select=[a, b, c, PROCTIME() AS proctime], where=[(c > 1000)])
+         +- BoundedStreamScan(table=[[default_catalog, default_database, T0]], fields=[a, b, c])
+]]>
+    </Resource>
+  </TestCase>
+  <TestCase name="testJoinTemporalTableWithFilterPushDown[LegacyTableSource=true, partitionedJoin=false]">
     <Resource name="sql">
       <![CDATA[
 SELECT * FROM MyTable AS T
@@ -276,9 +529,45 @@ Calc(select=[a, b, c, PROCTIME_MATERIALIZE(proctime) AS proctime, id, name, CAST
 ]]>
     </Resource>
   </TestCase>
-  <TestCase name="testJoinTemporalTableWithNestedQuery[LegacyTableSource=false]">
+  <TestCase name="testJoinTemporalTableWithFilterPushDown[LegacyTableSource=true, partitionedJoin=true]">
     <Resource name="sql">
-      <![CDATA[SELECT * FROM (SELECT a, b, proctime FROM MyTable WHERE c > 1000) AS T JOIN LookupTable FOR SYSTEM_TIME AS OF T.proctime AS D ON T.a = D.id]]>
+      <![CDATA[
+SELECT * FROM MyTable AS T
+JOIN LookupTable /*+ PARTITIONED_JOIN */ FOR SYSTEM_TIME AS OF T.proctime AS D
+ON T.a = D.id AND D.age = 10
+WHERE T.c > 1000
+      ]]>
+    </Resource>
+    <Resource name="ast">
+      <![CDATA[
+LogicalProject(a=[$0], b=[$1], c=[$2], proctime=[$3], id=[$4], name=[$5], age=[$6])
++- LogicalFilter(condition=[>($2, 1000)])
+   +- LogicalCorrelate(correlation=[$cor0], joinType=[inner], requiredColumns=[{0, 3}])
+      :- LogicalProject(a=[$0], b=[$1], c=[$2], proctime=[PROCTIME()])
+      :  +- LogicalTableScan(table=[[default_catalog, default_database, T0]])
+      +- LogicalFilter(condition=[AND(=($cor0.a, $0), =($2, 10))])
+         +- LogicalSnapshot(period=[$cor0.proctime])
+            +- LogicalTableScan(table=[[default_catalog, default_database, LookupTable, source: [TestTemporalTable(id, name, age)]]], hints=[[[PARTITIONED_JOIN inheritPath:[]]]])
+]]>
+    </Resource>
+    <Resource name="optimized exec plan">
+      <![CDATA[
+Calc(select=[a, b, c, PROCTIME_MATERIALIZE(proctime) AS proctime, id, name, CAST(10 AS INTEGER) AS age])
++- LookupJoin(table=[default_catalog.default_database.LookupTable], joinType=[InnerJoin], async=[false], lookup=[age=10, id=a], where=[(age = 10)], select=[a, b, c, proctime, id, name])
+   +- Exchange(distribution=[hash[a]])
+      +- Calc(select=[a, b, c, PROCTIME() AS proctime], where=[(c > 1000)])
+         +- BoundedStreamScan(table=[[default_catalog, default_database, T0]], fields=[a, b, c])
+]]>
+    </Resource>
+  </TestCase>
+  <TestCase name="testJoinTemporalTableWithNestedQuery[LegacyTableSource=false, partitionedJoin=false]">
+    <Resource name="sql">
+      <![CDATA[
+SELECT * FROM
+(SELECT a, b, proctime FROM MyTable WHERE c > 1000) AS T
+JOIN LookupTable
+FOR SYSTEM_TIME AS OF T.proctime AS D ON T.a = D.id
+]]>
     </Resource>
     <Resource name="ast">
       <![CDATA[
@@ -302,9 +591,46 @@ Calc(select=[a, b, PROCTIME_MATERIALIZE(proctime) AS proctime, id, name, age])
 ]]>
     </Resource>
   </TestCase>
-  <TestCase name="testJoinTemporalTableWithNestedQuery[LegacyTableSource=true]">
+  <TestCase name="testJoinTemporalTableWithNestedQuery[LegacyTableSource=false, partitionedJoin=true]">
     <Resource name="sql">
-      <![CDATA[SELECT * FROM (SELECT a, b, proctime FROM MyTable WHERE c > 1000) AS T JOIN LookupTable FOR SYSTEM_TIME AS OF T.proctime AS D ON T.a = D.id]]>
+      <![CDATA[
+SELECT * FROM
+(SELECT a, b, proctime FROM MyTable WHERE c > 1000) AS T
+JOIN LookupTable /*+ PARTITIONED_JOIN */
+FOR SYSTEM_TIME AS OF T.proctime AS D ON T.a = D.id
+]]>
+    </Resource>
+    <Resource name="ast">
+      <![CDATA[
+LogicalProject(a=[$0], b=[$1], proctime=[$2], id=[$3], name=[$4], age=[$5])
++- LogicalCorrelate(correlation=[$cor0], joinType=[inner], requiredColumns=[{0, 2}])
+   :- LogicalProject(a=[$0], b=[$1], proctime=[$3])
+   :  +- LogicalFilter(condition=[>($2, 1000)])
+   :     +- LogicalProject(a=[$0], b=[$1], c=[$2], proctime=[PROCTIME()])
+   :        +- LogicalTableScan(table=[[default_catalog, default_database, T0]])
+   +- LogicalFilter(condition=[=($cor0.a, $0)])
+      +- LogicalSnapshot(period=[$cor0.proctime])
+         +- LogicalTableScan(table=[[default_catalog, default_database, LookupTable]], hints=[[[PARTITIONED_JOIN inheritPath:[]]]])
+]]>
+    </Resource>
+    <Resource name="optimized exec plan">
+      <![CDATA[
+Calc(select=[a, b, PROCTIME_MATERIALIZE(proctime) AS proctime, id, name, age])
++- LookupJoin(table=[default_catalog.default_database.LookupTable], joinType=[InnerJoin], async=[false], lookup=[id=a], select=[a, b, proctime, id, name, age])
+   +- Exchange(distribution=[hash[a]])
+      +- Calc(select=[a, b, PROCTIME() AS proctime], where=[(c > 1000)])
+         +- BoundedStreamScan(table=[[default_catalog, default_database, T0]], fields=[a, b, c])
+]]>
+    </Resource>
+  </TestCase>
+  <TestCase name="testJoinTemporalTableWithNestedQuery[LegacyTableSource=true, partitionedJoin=false]">
+    <Resource name="sql">
+      <![CDATA[
+SELECT * FROM
+(SELECT a, b, proctime FROM MyTable WHERE c > 1000) AS T
+JOIN LookupTable
+FOR SYSTEM_TIME AS OF T.proctime AS D ON T.a = D.id
+]]>
     </Resource>
     <Resource name="ast">
       <![CDATA[
@@ -328,7 +654,39 @@ Calc(select=[a, b, PROCTIME_MATERIALIZE(proctime) AS proctime, id, name, age])
 ]]>
     </Resource>
   </TestCase>
-  <TestCase name="testJoinTemporalTableWithProjectionPushDown[LegacyTableSource=false]">
+  <TestCase name="testJoinTemporalTableWithNestedQuery[LegacyTableSource=true, partitionedJoin=true]">
+    <Resource name="sql">
+      <![CDATA[
+SELECT * FROM
+(SELECT a, b, proctime FROM MyTable WHERE c > 1000) AS T
+JOIN LookupTable /*+ PARTITIONED_JOIN */
+FOR SYSTEM_TIME AS OF T.proctime AS D ON T.a = D.id
+]]>
+    </Resource>
+    <Resource name="ast">
+      <![CDATA[
+LogicalProject(a=[$0], b=[$1], proctime=[$2], id=[$3], name=[$4], age=[$5])
++- LogicalCorrelate(correlation=[$cor0], joinType=[inner], requiredColumns=[{0, 2}])
+   :- LogicalProject(a=[$0], b=[$1], proctime=[$3])
+   :  +- LogicalFilter(condition=[>($2, 1000)])
+   :     +- LogicalProject(a=[$0], b=[$1], c=[$2], proctime=[PROCTIME()])
+   :        +- LogicalTableScan(table=[[default_catalog, default_database, T0]])
+   +- LogicalFilter(condition=[=($cor0.a, $0)])
+      +- LogicalSnapshot(period=[$cor0.proctime])
+         +- LogicalTableScan(table=[[default_catalog, default_database, LookupTable, source: [TestTemporalTable(id, name, age)]]], hints=[[[PARTITIONED_JOIN inheritPath:[]]]])
+]]>
+    </Resource>
+    <Resource name="optimized exec plan">
+      <![CDATA[
+Calc(select=[a, b, PROCTIME_MATERIALIZE(proctime) AS proctime, id, name, age])
++- LookupJoin(table=[default_catalog.default_database.LookupTable], joinType=[InnerJoin], async=[false], lookup=[id=a], select=[a, b, proctime, id, name, age])
+   +- Exchange(distribution=[hash[a]])
+      +- Calc(select=[a, b, PROCTIME() AS proctime], where=[(c > 1000)])
+         +- BoundedStreamScan(table=[[default_catalog, default_database, T0]], fields=[a, b, c])
+]]>
+    </Resource>
+  </TestCase>
+  <TestCase name="testJoinTemporalTableWithProjectionPushDown[LegacyTableSource=false, partitionedJoin=false]">
     <Resource name="sql">
       <![CDATA[
 SELECT T.*, D.id
@@ -357,31 +715,37 @@ Calc(select=[a, b, c, PROCTIME_MATERIALIZE(proctime) AS proctime, id])
 ]]>
     </Resource>
   </TestCase>
-  <TestCase name="testLeftJoinTemporalTable[LegacyTableSource=true]">
+  <TestCase name="testJoinTemporalTableWithProjectionPushDown[LegacyTableSource=false, partitionedJoin=true]">
     <Resource name="sql">
-      <![CDATA[SELECT * FROM MyTable AS T LEFT JOIN LookupTable FOR SYSTEM_TIME AS OF T.proctime AS D ON T.a = D.id]]>
+      <![CDATA[
+SELECT T.*, D.id
+FROM MyTable AS T
+JOIN LookupTable /*+ PARTITIONED_JOIN */ FOR SYSTEM_TIME AS OF T.proctime AS D
+ON T.a = D.id
+      ]]>
     </Resource>
     <Resource name="ast">
       <![CDATA[
-LogicalProject(a=[$0], b=[$1], c=[$2], proctime=[$3], id=[$4], name=[$5], age=[$6])
-+- LogicalCorrelate(correlation=[$cor0], joinType=[left], requiredColumns=[{0, 3}])
+LogicalProject(a=[$0], b=[$1], c=[$2], proctime=[$3], id=[$4])
++- LogicalCorrelate(correlation=[$cor0], joinType=[inner], requiredColumns=[{0, 3}])
    :- LogicalProject(a=[$0], b=[$1], c=[$2], proctime=[PROCTIME()])
    :  +- LogicalTableScan(table=[[default_catalog, default_database, T0]])
    +- LogicalFilter(condition=[=($cor0.a, $0)])
       +- LogicalSnapshot(period=[$cor0.proctime])
-         +- LogicalTableScan(table=[[default_catalog, default_database, LookupTable, source: [TestTemporalTable(id, name, age)]]])
+         +- LogicalTableScan(table=[[default_catalog, default_database, LookupTable]], hints=[[[PARTITIONED_JOIN inheritPath:[]]]])
 ]]>
     </Resource>
     <Resource name="optimized exec plan">
       <![CDATA[
-Calc(select=[a, b, c, PROCTIME_MATERIALIZE(proctime) AS proctime, id, name, age])
-+- LookupJoin(table=[default_catalog.default_database.LookupTable], joinType=[LeftOuterJoin], async=[false], lookup=[id=a], select=[a, b, c, proctime, id, name, age])
+Calc(select=[a, b, c, PROCTIME_MATERIALIZE(proctime) AS proctime, id])
++- LookupJoin(table=[default_catalog.default_database.LookupTable], joinType=[InnerJoin], async=[false], lookup=[id=a], select=[a, b, c, proctime, id])
    +- Calc(select=[a, b, c, PROCTIME() AS proctime])
-      +- BoundedStreamScan(table=[[default_catalog, default_database, T0]], fields=[a, b, c])
+      +- Exchange(distribution=[hash[a]])
+         +- BoundedStreamScan(table=[[default_catalog, default_database, T0]], fields=[a, b, c])
 ]]>
     </Resource>
   </TestCase>
-  <TestCase name="testJoinTemporalTableWithProjectionPushDown[LegacyTableSource=true]">
+  <TestCase name="testJoinTemporalTableWithProjectionPushDown[LegacyTableSource=true, partitionedJoin=false]">
     <Resource name="sql">
       <![CDATA[
 SELECT T.*, D.id
@@ -410,9 +774,70 @@ Calc(select=[a, b, c, PROCTIME_MATERIALIZE(proctime) AS proctime, id])
 ]]>
     </Resource>
   </TestCase>
-  <TestCase name="testLeftJoinTemporalTable[LegacyTableSource=false]">
+  <TestCase name="testLeftJoinTemporalTable[LegacyTableSource=true, partitionedJoin=true]">
     <Resource name="sql">
-      <![CDATA[SELECT * FROM MyTable AS T LEFT JOIN LookupTable FOR SYSTEM_TIME AS OF T.proctime AS D ON T.a = D.id]]>
+      <![CDATA[
+SELECT * FROM MyTable AS T LEFT JOIN LookupTable /*+ PARTITIONED_JOIN */
+FOR SYSTEM_TIME AS OF T.proctime AS D ON T.a = D.id
+]]>
+    </Resource>
+    <Resource name="ast">
+      <![CDATA[
+LogicalProject(a=[$0], b=[$1], c=[$2], proctime=[$3], id=[$4], name=[$5], age=[$6])
++- LogicalCorrelate(correlation=[$cor0], joinType=[left], requiredColumns=[{0, 3}])
+   :- LogicalProject(a=[$0], b=[$1], c=[$2], proctime=[PROCTIME()])
+   :  +- LogicalTableScan(table=[[default_catalog, default_database, T0]])
+   +- LogicalFilter(condition=[=($cor0.a, $0)])
+      +- LogicalSnapshot(period=[$cor0.proctime])
+         +- LogicalTableScan(table=[[default_catalog, default_database, LookupTable, source: [TestTemporalTable(id, name, age)]]], hints=[[[PARTITIONED_JOIN inheritPath:[]]]])
+]]>
+    </Resource>
+    <Resource name="optimized exec plan">
+      <![CDATA[
+Calc(select=[a, b, c, PROCTIME_MATERIALIZE(proctime) AS proctime, id, name, age])
++- LookupJoin(table=[default_catalog.default_database.LookupTable], joinType=[LeftOuterJoin], async=[false], lookup=[id=a], select=[a, b, c, proctime, id, name, age])
+   +- Calc(select=[a, b, c, PROCTIME() AS proctime])
+      +- Exchange(distribution=[hash[a]])
+         +- BoundedStreamScan(table=[[default_catalog, default_database, T0]], fields=[a, b, c])
+]]>
+    </Resource>
+  </TestCase>
+  <TestCase name="testJoinTemporalTableWithProjectionPushDown[LegacyTableSource=true, partitionedJoin=true]">
+    <Resource name="sql">
+      <![CDATA[
+SELECT T.*, D.id
+FROM MyTable AS T
+JOIN LookupTable /*+ PARTITIONED_JOIN */ FOR SYSTEM_TIME AS OF T.proctime AS D
+ON T.a = D.id
+      ]]>
+    </Resource>
+    <Resource name="ast">
+      <![CDATA[
+LogicalProject(a=[$0], b=[$1], c=[$2], proctime=[$3], id=[$4])
++- LogicalCorrelate(correlation=[$cor0], joinType=[inner], requiredColumns=[{0, 3}])
+   :- LogicalProject(a=[$0], b=[$1], c=[$2], proctime=[PROCTIME()])
+   :  +- LogicalTableScan(table=[[default_catalog, default_database, T0]])
+   +- LogicalFilter(condition=[=($cor0.a, $0)])
+      +- LogicalSnapshot(period=[$cor0.proctime])
+         +- LogicalTableScan(table=[[default_catalog, default_database, LookupTable, source: [TestTemporalTable(id, name, age)]]], hints=[[[PARTITIONED_JOIN inheritPath:[]]]])
+]]>
+    </Resource>
+    <Resource name="optimized exec plan">
+      <![CDATA[
+Calc(select=[a, b, c, PROCTIME_MATERIALIZE(proctime) AS proctime, id])
++- LookupJoin(table=[default_catalog.default_database.LookupTable], joinType=[InnerJoin], async=[false], lookup=[id=a], select=[a, b, c, proctime, id])
+   +- Calc(select=[a, b, c, PROCTIME() AS proctime])
+      +- Exchange(distribution=[hash[a]])
+         +- BoundedStreamScan(table=[[default_catalog, default_database, T0]], fields=[a, b, c])
+]]>
+    </Resource>
+  </TestCase>
+  <TestCase name="testLeftJoinTemporalTable[LegacyTableSource=false, partitionedJoin=false]">
+    <Resource name="sql">
+      <![CDATA[
+SELECT * FROM MyTable AS T LEFT JOIN LookupTable
+FOR SYSTEM_TIME AS OF T.proctime AS D ON T.a = D.id
+]]>
     </Resource>
     <Resource name="ast">
       <![CDATA[
@@ -434,7 +859,62 @@ Calc(select=[a, b, c, PROCTIME_MATERIALIZE(proctime) AS proctime, id, name, age]
 ]]>
     </Resource>
   </TestCase>
-  <TestCase name="testLogicalPlan[LegacyTableSource=false]">
+  <TestCase name="testLeftJoinTemporalTable[LegacyTableSource=false, partitionedJoin=true]">
+    <Resource name="sql">
+      <![CDATA[
+SELECT * FROM MyTable AS T LEFT JOIN LookupTable /*+ PARTITIONED_JOIN */
+FOR SYSTEM_TIME AS OF T.proctime AS D ON T.a = D.id
+]]>
+    </Resource>
+    <Resource name="ast">
+      <![CDATA[
+LogicalProject(a=[$0], b=[$1], c=[$2], proctime=[$3], id=[$4], name=[$5], age=[$6])
++- LogicalCorrelate(correlation=[$cor0], joinType=[left], requiredColumns=[{0, 3}])
+   :- LogicalProject(a=[$0], b=[$1], c=[$2], proctime=[PROCTIME()])
+   :  +- LogicalTableScan(table=[[default_catalog, default_database, T0]])
+   +- LogicalFilter(condition=[=($cor0.a, $0)])
+      +- LogicalSnapshot(period=[$cor0.proctime])
+         +- LogicalTableScan(table=[[default_catalog, default_database, LookupTable]], hints=[[[PARTITIONED_JOIN inheritPath:[]]]])
+]]>
+    </Resource>
+    <Resource name="optimized exec plan">
+      <![CDATA[
+Calc(select=[a, b, c, PROCTIME_MATERIALIZE(proctime) AS proctime, id, name, age])
++- LookupJoin(table=[default_catalog.default_database.LookupTable], joinType=[LeftOuterJoin], async=[false], lookup=[id=a], select=[a, b, c, proctime, id, name, age])
+   +- Calc(select=[a, b, c, PROCTIME() AS proctime])
+      +- Exchange(distribution=[hash[a]])
+         +- BoundedStreamScan(table=[[default_catalog, default_database, T0]], fields=[a, b, c])
+]]>
+    </Resource>
+  </TestCase>
+  <TestCase name="testLeftJoinTemporalTable[LegacyTableSource=true, partitionedJoin=false]">
+    <Resource name="sql">
+      <![CDATA[
+SELECT * FROM MyTable AS T LEFT JOIN LookupTable
+FOR SYSTEM_TIME AS OF T.proctime AS D ON T.a = D.id
+]]>
+    </Resource>
+    <Resource name="ast">
+      <![CDATA[
+LogicalProject(a=[$0], b=[$1], c=[$2], proctime=[$3], id=[$4], name=[$5], age=[$6])
++- LogicalCorrelate(correlation=[$cor0], joinType=[left], requiredColumns=[{0, 3}])
+   :- LogicalProject(a=[$0], b=[$1], c=[$2], proctime=[PROCTIME()])
+   :  +- LogicalTableScan(table=[[default_catalog, default_database, T0]])
+   +- LogicalFilter(condition=[=($cor0.a, $0)])
+      +- LogicalSnapshot(period=[$cor0.proctime])
+         +- LogicalTableScan(table=[[default_catalog, default_database, LookupTable, source: [TestTemporalTable(id, name, age)]]])
+]]>
+    </Resource>
+    <Resource name="optimized exec plan">
+      <![CDATA[
+Calc(select=[a, b, c, PROCTIME_MATERIALIZE(proctime) AS proctime, id, name, age])
++- LookupJoin(table=[default_catalog.default_database.LookupTable], joinType=[LeftOuterJoin], async=[false], lookup=[id=a], select=[a, b, c, proctime, id, name, age])
+   +- Calc(select=[a, b, c, PROCTIME() AS proctime])
+      +- BoundedStreamScan(table=[[default_catalog, default_database, T0]], fields=[a, b, c])
+]]>
+    </Resource>
+  </TestCase>
+  <TestCase name="testLogicalPlan[LegacyTableSource=false, partitionedJoin=false]">
     <Resource name="sql">
       <![CDATA[
 SELECT b, count(a), sum(c), sum(d)
@@ -479,7 +959,52 @@ FlinkLogicalAggregate(group=[{0}], EXPR$1=[COUNT($1)], EXPR$2=[SUM($2)], EXPR$3=
 ]]>
     </Resource>
   </TestCase>
-  <TestCase name="testLogicalPlan[LegacyTableSource=true]">
+  <TestCase name="testLogicalPlan[LegacyTableSource=false, partitionedJoin=true]">
+    <Resource name="sql">
+      <![CDATA[
+SELECT b, count(a), sum(c), sum(d)
+FROM (
+SELECT T.* FROM (
+SELECT b, a, sum(c) c, sum(d) d, PROCTIME() as proctime
+FROM T1
+GROUP BY a, b
+      ) AS T
+JOIN LookupTable /*+ PARTITIONED_JOIN */ FOR SYSTEM_TIME AS OF T.proctime AS D
+ON T.a = D.id
+WHERE D.age > 10
+      ) AS T
+GROUP BY b
+      ]]>
+    </Resource>
+    <Resource name="ast">
+      <![CDATA[
+LogicalAggregate(group=[{0}], EXPR$1=[COUNT($1)], EXPR$2=[SUM($2)], EXPR$3=[SUM($3)])
++- LogicalProject(b=[$0], a=[$1], c=[$2], d=[$3])
+   +- LogicalFilter(condition=[>($7, 10)])
+      +- LogicalCorrelate(correlation=[$cor0], joinType=[inner], requiredColumns=[{1, 4}])
+         :- LogicalProject(b=[$1], a=[$0], c=[$2], d=[$3], proctime=[PROCTIME()])
+         :  +- LogicalAggregate(group=[{0, 1}], c=[SUM($2)], d=[SUM($3)])
+         :     +- LogicalTableScan(table=[[default_catalog, default_database, T1]])
+         +- LogicalFilter(condition=[=($cor0.a, $0)])
+            +- LogicalSnapshot(period=[$cor0.proctime])
+               +- LogicalTableScan(table=[[default_catalog, default_database, LookupTable]], hints=[[[PARTITIONED_JOIN inheritPath:[]]]])
+]]>
+    </Resource>
+    <Resource name="optimized rel plan">
+      <![CDATA[
+FlinkLogicalAggregate(group=[{0}], EXPR$1=[COUNT($1)], EXPR$2=[SUM($2)], EXPR$3=[SUM($3)])
++- FlinkLogicalCalc(select=[b, a, c, d])
+   +- FlinkLogicalJoin(condition=[=($1, $4)], joinType=[inner])
+      :- FlinkLogicalCalc(select=[b, a, c, d])
+      :  +- FlinkLogicalAggregate(group=[{0, 1}], c=[SUM($2)], d=[SUM($3)])
+      :     +- FlinkLogicalDataStreamTableScan(table=[[default_catalog, default_database, T1]], fields=[a, b, c, d])
+      +- FlinkLogicalSnapshot(period=[$cor0.proctime])
+         +- FlinkLogicalCalc(select=[id], where=[>(age, 10)])
+            +- FlinkLogicalTableSourceScan(table=[[default_catalog, default_database, LookupTable]], fields=[id, name, age], hints=[[[PARTITIONED_JOIN]]])
+]]>
+    </Resource>
+  </TestCase>
+  <TestCase name="testLogicalPlan[LegacyTableSource=true, partitionedJoin=false]">
     <Resource name="sql">
       <![CDATA[
 SELECT b, count(a), sum(c), sum(d)
@@ -524,83 +1049,52 @@ FlinkLogicalAggregate(group=[{0}], EXPR$1=[COUNT($1)], EXPR$2=[SUM($2)], EXPR$3=
 ]]>
     </Resource>
   </TestCase>
-  <TestCase name="testReusing[LegacyTableSource=true]">
+  <TestCase name="testLogicalPlan[LegacyTableSource=true, partitionedJoin=true]">
     <Resource name="sql">
       <![CDATA[
-SELECT count(T1.a), count(T1.id), sum(T2.a)
+SELECT b, count(a), sum(c), sum(d)
 FROM (
-SELECT * FROM (
+SELECT T.* FROM (
 SELECT b, a, sum(c) c, sum(d) d, PROCTIME() as proctime
 FROM T1
 GROUP BY a, b
       ) AS T
-JOIN LookupTable FOR SYSTEM_TIME AS OF T.proctime AS D
-ON T.a = D.id
-WHERE D.age > 10
-      ) AS T1, (
-SELECT id as a, b FROM (
-SELECT * FROM (
-SELECT b, a, sum(c) c, sum(d) d, PROCTIME() as proctime
-FROM T1
-GROUP BY a, b
-      ) AS T
-JOIN LookupTable FOR SYSTEM_TIME AS OF T.proctime AS D
+JOIN LookupTable /*+ PARTITIONED_JOIN */ FOR SYSTEM_TIME AS OF T.proctime AS D
 ON T.a = D.id
 WHERE D.age > 10
       ) AS T
-       ) AS T2
-WHERE T1.a = T2.a
-GROUP BY T1.b, T2.b
+GROUP BY b
       ]]>
     </Resource>
     <Resource name="ast">
       <![CDATA[
-LogicalProject(EXPR$0=[$2], EXPR$1=[$3], EXPR$2=[$4])
-+- LogicalAggregate(group=[{0, 1}], EXPR$0=[COUNT($2)], EXPR$1=[COUNT($3)], EXPR$2=[SUM($4)])
-   +- LogicalProject(b=[$0], b0=[$9], a=[$1], id=[$5], a0=[$8])
-      +- LogicalFilter(condition=[=($1, $8)])
-         +- LogicalJoin(condition=[true], joinType=[inner])
-            :- LogicalProject(b=[$0], a=[$1], c=[$2], d=[$3], proctime=[$4], id=[$5], name=[$6], age=[$7])
-            :  +- LogicalFilter(condition=[>($7, 10)])
-            :     +- LogicalCorrelate(correlation=[$cor0], joinType=[inner], requiredColumns=[{1, 4}])
-            :        :- LogicalProject(b=[$1], a=[$0], c=[$2], d=[$3], proctime=[PROCTIME()])
-            :        :  +- LogicalAggregate(group=[{0, 1}], c=[SUM($2)], d=[SUM($3)])
-            :        :     +- LogicalTableScan(table=[[default_catalog, default_database, T1]])
-            :        +- LogicalFilter(condition=[=($cor0.a, $0)])
-            :           +- LogicalSnapshot(period=[$cor0.proctime])
-            :              +- LogicalTableScan(table=[[default_catalog, default_database, LookupTable, source: [TestTemporalTable(id, name, age)]]])
-            +- LogicalProject(a=[$5], b=[$0])
-               +- LogicalFilter(condition=[>($7, 10)])
-                  +- LogicalCorrelate(correlation=[$cor1], joinType=[inner], requiredColumns=[{1, 4}])
-                     :- LogicalProject(b=[$1], a=[$0], c=[$2], d=[$3], proctime=[PROCTIME()])
-                     :  +- LogicalAggregate(group=[{0, 1}], c=[SUM($2)], d=[SUM($3)])
-                     :     +- LogicalTableScan(table=[[default_catalog, default_database, T1]])
-                     +- LogicalFilter(condition=[=($cor1.a, $0)])
-                        +- LogicalSnapshot(period=[$cor1.proctime])
-                           +- LogicalTableScan(table=[[default_catalog, default_database, LookupTable, source: [TestTemporalTable(id, name, age)]]])
+LogicalAggregate(group=[{0}], EXPR$1=[COUNT($1)], EXPR$2=[SUM($2)], EXPR$3=[SUM($3)])
++- LogicalProject(b=[$0], a=[$1], c=[$2], d=[$3])
+   +- LogicalFilter(condition=[>($7, 10)])
+      +- LogicalCorrelate(correlation=[$cor0], joinType=[inner], requiredColumns=[{1, 4}])
+         :- LogicalProject(b=[$1], a=[$0], c=[$2], d=[$3], proctime=[PROCTIME()])
+         :  +- LogicalAggregate(group=[{0, 1}], c=[SUM($2)], d=[SUM($3)])
+         :     +- LogicalTableScan(table=[[default_catalog, default_database, T1]])
+         +- LogicalFilter(condition=[=($cor0.a, $0)])
+            +- LogicalSnapshot(period=[$cor0.proctime])
+               +- LogicalTableScan(table=[[default_catalog, default_database, LookupTable, source: [TestTemporalTable(id, name, age)]]], hints=[[[PARTITIONED_JOIN inheritPath:[]]]])
 ]]>
     </Resource>
-    <Resource name="optimized exec plan">
+    <Resource name="optimized rel plan">
       <![CDATA[
-Calc(select=[EXPR$0, EXPR$1, EXPR$2])
-+- HashAggregate(isMerge=[true], groupBy=[b, b0], select=[b, b0, Final_COUNT(count$0) AS EXPR$0, Final_COUNT(count$1) AS EXPR$1, Final_SUM(sum$2) AS EXPR$2])
-   +- Exchange(distribution=[hash[b, b0]])
-      +- LocalHashAggregate(groupBy=[b, b0], select=[b, b0, Partial_COUNT(a) AS count$0, Partial_COUNT(id) AS count$1, Partial_SUM(a0) AS sum$2])
-         +- HashJoin(joinType=[InnerJoin], where=[(a = a0)], select=[b, a, id, a0, b0], build=[right])
-            :- Exchange(distribution=[hash[a]], shuffle_mode=[BATCH])
-            :  +- LookupJoin(table=[default_catalog.default_database.LookupTable], joinType=[InnerJoin], async=[false], lookup=[id=a], where=[(age > 10)], select=[b, a, id])(reuse_id=[1])
-            :     +- Calc(select=[b, a])
-            :        +- HashAggregate(isMerge=[true], groupBy=[a, b], select=[a, b])
-            :           +- Exchange(distribution=[hash[a, b]])
-            :              +- LocalHashAggregate(groupBy=[a, b], select=[a, b])
-            :                 +- BoundedStreamScan(table=[[default_catalog, default_database, T1]], fields=[a, b, c, d])
-            +- Exchange(distribution=[hash[a]])
-               +- Calc(select=[id AS a, b])
-                  +- Reused(reference_id=[1])
+FlinkLogicalAggregate(group=[{0}], EXPR$1=[COUNT($1)], EXPR$2=[SUM($2)], EXPR$3=[SUM($3)])
++- FlinkLogicalCalc(select=[b, a, c, d])
+   +- FlinkLogicalJoin(condition=[=($1, $4)], joinType=[inner])
+      :- FlinkLogicalCalc(select=[b, a, c, d])
+      :  +- FlinkLogicalAggregate(group=[{0, 1}], c=[SUM($2)], d=[SUM($3)])
+      :     +- FlinkLogicalDataStreamTableScan(table=[[default_catalog, default_database, T1]], fields=[a, b, c, d])
+      +- FlinkLogicalSnapshot(period=[$cor0.proctime])
+         +- FlinkLogicalCalc(select=[id], where=[>(age, 10)])
+            +- FlinkLogicalLegacyTableSourceScan(table=[[default_catalog, default_database, LookupTable, source: [TestTemporalTable(id, name, age)]]], fields=[id, name, age], hints=[[[PARTITIONED_JOIN]]])
 ]]>
     </Resource>
   </TestCase>
-  <TestCase name="testReusing[LegacyTableSource=false]">
+  <TestCase name="testReusing[LegacyTableSource=false, partitionedJoin=false]">
     <Resource name="sql">
       <![CDATA[
 SELECT count(T1.a), count(T1.id), sum(T2.a)
@@ -654,6 +1148,236 @@ LogicalProject(EXPR$0=[$2], EXPR$1=[$3], EXPR$2=[$4])
                      +- LogicalFilter(condition=[=($cor1.a, $0)])
                         +- LogicalSnapshot(period=[$cor1.proctime])
                            +- LogicalTableScan(table=[[default_catalog, default_database, LookupTable]])
+]]>
+    </Resource>
+    <Resource name="optimized exec plan">
+      <![CDATA[
+Calc(select=[EXPR$0, EXPR$1, EXPR$2])
++- HashAggregate(isMerge=[true], groupBy=[b, b0], select=[b, b0, Final_COUNT(count$0) AS EXPR$0, Final_COUNT(count$1) AS EXPR$1, Final_SUM(sum$2) AS EXPR$2])
+   +- Exchange(distribution=[hash[b, b0]])
+      +- LocalHashAggregate(groupBy=[b, b0], select=[b, b0, Partial_COUNT(a) AS count$0, Partial_COUNT(id) AS count$1, Partial_SUM(a0) AS sum$2])
+         +- HashJoin(joinType=[InnerJoin], where=[(a = a0)], select=[b, a, id, a0, b0], build=[right])
+            :- Exchange(distribution=[hash[a]], shuffle_mode=[BATCH])
+            :  +- LookupJoin(table=[default_catalog.default_database.LookupTable], joinType=[InnerJoin], async=[false], lookup=[id=a], where=[(age > 10)], select=[b, a, id])(reuse_id=[1])
+            :     +- Calc(select=[b, a])
+            :        +- HashAggregate(isMerge=[true], groupBy=[a, b], select=[a, b])
+            :           +- Exchange(distribution=[hash[a, b]])
+            :              +- LocalHashAggregate(groupBy=[a, b], select=[a, b])
+            :                 +- BoundedStreamScan(table=[[default_catalog, default_database, T1]], fields=[a, b, c, d])
+            +- Exchange(distribution=[hash[a]])
+               +- Calc(select=[id AS a, b])
+                  +- Reused(reference_id=[1])
+]]>
+    </Resource>
+  </TestCase>
+  <TestCase name="testReusing[LegacyTableSource=true, partitionedJoin=true]">
+    <Resource name="sql">
+      <![CDATA[
+SELECT count(T1.a), count(T1.id), sum(T2.a)
+FROM (
+SELECT * FROM (
+SELECT b, a, sum(c) c, sum(d) d, PROCTIME() as proctime
+FROM T1
+GROUP BY a, b
+      ) AS T
+JOIN LookupTable /*+ PARTITIONED_JOIN */ FOR SYSTEM_TIME AS OF T.proctime AS D
+ON T.a = D.id
+WHERE D.age > 10
+      ) AS T1, (
+SELECT id as a, b FROM (
+SELECT * FROM (
+SELECT b, a, sum(c) c, sum(d) d, PROCTIME() as proctime
+FROM T1
+GROUP BY a, b
+      ) AS T
+JOIN LookupTable /*+ PARTITIONED_JOIN */ FOR SYSTEM_TIME AS OF T.proctime AS D
+ON T.a = D.id
+WHERE D.age > 10
+      ) AS T
+       ) AS T2
+WHERE T1.a = T2.a
+GROUP BY T1.b, T2.b
+      ]]>
+    </Resource>
+    <Resource name="ast">
+      <![CDATA[
+LogicalProject(EXPR$0=[$2], EXPR$1=[$3], EXPR$2=[$4])
++- LogicalAggregate(group=[{0, 1}], EXPR$0=[COUNT($2)], EXPR$1=[COUNT($3)], EXPR$2=[SUM($4)])
+   +- LogicalProject(b=[$0], b0=[$9], a=[$1], id=[$5], a0=[$8])
+      +- LogicalFilter(condition=[=($1, $8)])
+         +- LogicalJoin(condition=[true], joinType=[inner])
+            :- LogicalProject(b=[$0], a=[$1], c=[$2], d=[$3], proctime=[$4], id=[$5], name=[$6], age=[$7])
+            :  +- LogicalFilter(condition=[>($7, 10)])
+            :     +- LogicalCorrelate(correlation=[$cor0], joinType=[inner], requiredColumns=[{1, 4}])
+            :        :- LogicalProject(b=[$1], a=[$0], c=[$2], d=[$3], proctime=[PROCTIME()])
+            :        :  +- LogicalAggregate(group=[{0, 1}], c=[SUM($2)], d=[SUM($3)])
+            :        :     +- LogicalTableScan(table=[[default_catalog, default_database, T1]])
+            :        +- LogicalFilter(condition=[=($cor0.a, $0)])
+            :           +- LogicalSnapshot(period=[$cor0.proctime])
+            :              +- LogicalTableScan(table=[[default_catalog, default_database, LookupTable, source: [TestTemporalTable(id, name, age)]]], hints=[[[PARTITIONED_JOIN inheritPath:[]]]])
+            +- LogicalProject(a=[$5], b=[$0])
+               +- LogicalFilter(condition=[>($7, 10)])
+                  +- LogicalCorrelate(correlation=[$cor1], joinType=[inner], requiredColumns=[{1, 4}])
+                     :- LogicalProject(b=[$1], a=[$0], c=[$2], d=[$3], proctime=[PROCTIME()])
+                     :  +- LogicalAggregate(group=[{0, 1}], c=[SUM($2)], d=[SUM($3)])
+                     :     +- LogicalTableScan(table=[[default_catalog, default_database, T1]])
+                     +- LogicalFilter(condition=[=($cor1.a, $0)])
+                        +- LogicalSnapshot(period=[$cor1.proctime])
+                           +- LogicalTableScan(table=[[default_catalog, default_database, LookupTable, source: [TestTemporalTable(id, name, age)]]], hints=[[[PARTITIONED_JOIN inheritPath:[]]]])
+]]>
+    </Resource>
+    <Resource name="optimized exec plan">
+      <![CDATA[
+Calc(select=[EXPR$0, EXPR$1, EXPR$2])
++- HashAggregate(isMerge=[true], groupBy=[b, b0], select=[b, b0, Final_COUNT(count$0) AS EXPR$0, Final_COUNT(count$1) AS EXPR$1, Final_SUM(sum$2) AS EXPR$2])
+   +- Exchange(distribution=[hash[b, b0]])
+      +- LocalHashAggregate(groupBy=[b, b0], select=[b, b0, Partial_COUNT(a) AS count$0, Partial_COUNT(id) AS count$1, Partial_SUM(a0) AS sum$2])
+         +- HashJoin(joinType=[InnerJoin], where=[(a = a0)], select=[b, a, id, a0, b0], build=[right])
+            :- Exchange(distribution=[hash[a]], shuffle_mode=[BATCH])
+            :  +- LookupJoin(table=[default_catalog.default_database.LookupTable], joinType=[InnerJoin], async=[false], lookup=[id=a], where=[(age > 10)], select=[b, a, id])(reuse_id=[1])
+            :     +- Exchange(distribution=[hash[a]])
+            :        +- Calc(select=[b, a])
+            :           +- HashAggregate(isMerge=[true], groupBy=[a, b], select=[a, b])
+            :              +- Exchange(distribution=[hash[a, b]])
+            :                 +- LocalHashAggregate(groupBy=[a, b], select=[a, b])
+            :                    +- BoundedStreamScan(table=[[default_catalog, default_database, T1]], fields=[a, b, c, d])
+            +- Exchange(distribution=[hash[a]])
+               +- Calc(select=[id AS a, b])
+                  +- Reused(reference_id=[1])
+]]>
+    </Resource>
+  </TestCase>
+  <TestCase name="testReusing[LegacyTableSource=false, partitionedJoin=true]">
+    <Resource name="sql">
+      <![CDATA[
+SELECT count(T1.a), count(T1.id), sum(T2.a)
+FROM (
+SELECT * FROM (
+SELECT b, a, sum(c) c, sum(d) d, PROCTIME() as proctime
+FROM T1
+GROUP BY a, b
+      ) AS T
+JOIN LookupTable /*+ PARTITIONED_JOIN */ FOR SYSTEM_TIME AS OF T.proctime AS D
+ON T.a = D.id
+WHERE D.age > 10
+      ) AS T1, (
+SELECT id as a, b FROM (
+SELECT * FROM (
+SELECT b, a, sum(c) c, sum(d) d, PROCTIME() as proctime
+FROM T1
+GROUP BY a, b
+      ) AS T
+JOIN LookupTable /*+ PARTITIONED_JOIN */ FOR SYSTEM_TIME AS OF T.proctime AS D
+ON T.a = D.id
+WHERE D.age > 10
+      ) AS T
+       ) AS T2
+WHERE T1.a = T2.a
+GROUP BY T1.b, T2.b
+      ]]>
+    </Resource>
+    <Resource name="ast">
+      <![CDATA[
+LogicalProject(EXPR$0=[$2], EXPR$1=[$3], EXPR$2=[$4])
++- LogicalAggregate(group=[{0, 1}], EXPR$0=[COUNT($2)], EXPR$1=[COUNT($3)], EXPR$2=[SUM($4)])
+   +- LogicalProject(b=[$0], b0=[$9], a=[$1], id=[$5], a0=[$8])
+      +- LogicalFilter(condition=[=($1, $8)])
+         +- LogicalJoin(condition=[true], joinType=[inner])
+            :- LogicalProject(b=[$0], a=[$1], c=[$2], d=[$3], proctime=[$4], id=[$5], name=[$6], age=[$7])
+            :  +- LogicalFilter(condition=[>($7, 10)])
+            :     +- LogicalCorrelate(correlation=[$cor0], joinType=[inner], requiredColumns=[{1, 4}])
+            :        :- LogicalProject(b=[$1], a=[$0], c=[$2], d=[$3], proctime=[PROCTIME()])
+            :        :  +- LogicalAggregate(group=[{0, 1}], c=[SUM($2)], d=[SUM($3)])
+            :        :     +- LogicalTableScan(table=[[default_catalog, default_database, T1]])
+            :        +- LogicalFilter(condition=[=($cor0.a, $0)])
+            :           +- LogicalSnapshot(period=[$cor0.proctime])
+            :              +- LogicalTableScan(table=[[default_catalog, default_database, LookupTable]], hints=[[[PARTITIONED_JOIN inheritPath:[]]]])
+            +- LogicalProject(a=[$5], b=[$0])
+               +- LogicalFilter(condition=[>($7, 10)])
+                  +- LogicalCorrelate(correlation=[$cor1], joinType=[inner], requiredColumns=[{1, 4}])
+                     :- LogicalProject(b=[$1], a=[$0], c=[$2], d=[$3], proctime=[PROCTIME()])
+                     :  +- LogicalAggregate(group=[{0, 1}], c=[SUM($2)], d=[SUM($3)])
+                     :     +- LogicalTableScan(table=[[default_catalog, default_database, T1]])
+                     +- LogicalFilter(condition=[=($cor1.a, $0)])
+                        +- LogicalSnapshot(period=[$cor1.proctime])
+                           +- LogicalTableScan(table=[[default_catalog, default_database, LookupTable]], hints=[[[PARTITIONED_JOIN inheritPath:[]]]])
+]]>
+    </Resource>
+    <Resource name="optimized exec plan">
+      <![CDATA[
+Calc(select=[EXPR$0, EXPR$1, EXPR$2])
++- HashAggregate(isMerge=[true], groupBy=[b, b0], select=[b, b0, Final_COUNT(count$0) AS EXPR$0, Final_COUNT(count$1) AS EXPR$1, Final_SUM(sum$2) AS EXPR$2])
+   +- Exchange(distribution=[hash[b, b0]])
+      +- LocalHashAggregate(groupBy=[b, b0], select=[b, b0, Partial_COUNT(a) AS count$0, Partial_COUNT(id) AS count$1, Partial_SUM(a0) AS sum$2])
+         +- HashJoin(joinType=[InnerJoin], where=[(a = a0)], select=[b, a, id, a0, b0], build=[right])
+            :- Exchange(distribution=[hash[a]], shuffle_mode=[BATCH])
+            :  +- LookupJoin(table=[default_catalog.default_database.LookupTable], joinType=[InnerJoin], async=[false], lookup=[id=a], where=[(age > 10)], select=[b, a, id])(reuse_id=[1])
+            :     +- Exchange(distribution=[hash[a]])
+            :        +- Calc(select=[b, a])
+            :           +- HashAggregate(isMerge=[true], groupBy=[a, b], select=[a, b])
+            :              +- Exchange(distribution=[hash[a, b]])
+            :                 +- LocalHashAggregate(groupBy=[a, b], select=[a, b])
+            :                    +- BoundedStreamScan(table=[[default_catalog, default_database, T1]], fields=[a, b, c, d])
+            +- Exchange(distribution=[hash[a]])
+               +- Calc(select=[id AS a, b])
+                  +- Reused(reference_id=[1])
+]]>
+    </Resource>
+  </TestCase>
+  <TestCase name="testReusing[LegacyTableSource=true, partitionedJoin=false]">
+    <Resource name="sql">
+      <![CDATA[
+SELECT count(T1.a), count(T1.id), sum(T2.a)
+FROM (
+SELECT * FROM (
+SELECT b, a, sum(c) c, sum(d) d, PROCTIME() as proctime
+FROM T1
+GROUP BY a, b
+      ) AS T
+JOIN LookupTable FOR SYSTEM_TIME AS OF T.proctime AS D
+ON T.a = D.id
+WHERE D.age > 10
+      ) AS T1, (
+SELECT id as a, b FROM (
+SELECT * FROM (
+SELECT b, a, sum(c) c, sum(d) d, PROCTIME() as proctime
+FROM T1
+GROUP BY a, b
+      ) AS T
+JOIN LookupTable FOR SYSTEM_TIME AS OF T.proctime AS D
+ON T.a = D.id
+WHERE D.age > 10
+      ) AS T
+       ) AS T2
+WHERE T1.a = T2.a
+GROUP BY T1.b, T2.b
+      ]]>
+    </Resource>
+    <Resource name="ast">
+      <![CDATA[
+LogicalProject(EXPR$0=[$2], EXPR$1=[$3], EXPR$2=[$4])
++- LogicalAggregate(group=[{0, 1}], EXPR$0=[COUNT($2)], EXPR$1=[COUNT($3)], EXPR$2=[SUM($4)])
+   +- LogicalProject(b=[$0], b0=[$9], a=[$1], id=[$5], a0=[$8])
+      +- LogicalFilter(condition=[=($1, $8)])
+         +- LogicalJoin(condition=[true], joinType=[inner])
+            :- LogicalProject(b=[$0], a=[$1], c=[$2], d=[$3], proctime=[$4], id=[$5], name=[$6], age=[$7])
+            :  +- LogicalFilter(condition=[>($7, 10)])
+            :     +- LogicalCorrelate(correlation=[$cor0], joinType=[inner], requiredColumns=[{1, 4}])
+            :        :- LogicalProject(b=[$1], a=[$0], c=[$2], d=[$3], proctime=[PROCTIME()])
+            :        :  +- LogicalAggregate(group=[{0, 1}], c=[SUM($2)], d=[SUM($3)])
+            :        :     +- LogicalTableScan(table=[[default_catalog, default_database, T1]])
+            :        +- LogicalFilter(condition=[=($cor0.a, $0)])
+            :           +- LogicalSnapshot(period=[$cor0.proctime])
+            :              +- LogicalTableScan(table=[[default_catalog, default_database, LookupTable, source: [TestTemporalTable(id, name, age)]]])
+            +- LogicalProject(a=[$5], b=[$0])
+               +- LogicalFilter(condition=[>($7, 10)])
+                  +- LogicalCorrelate(correlation=[$cor1], joinType=[inner], requiredColumns=[{1, 4}])
+                     :- LogicalProject(b=[$1], a=[$0], c=[$2], d=[$3], proctime=[PROCTIME()])
+                     :  +- LogicalAggregate(group=[{0, 1}], c=[SUM($2)], d=[SUM($3)])
+                     :     +- LogicalTableScan(table=[[default_catalog, default_database, T1]])
+                     +- LogicalFilter(condition=[=($cor1.a, $0)])
+                        +- LogicalSnapshot(period=[$cor1.proctime])
+                           +- LogicalTableScan(table=[[default_catalog, default_database, LookupTable, source: [TestTemporalTable(id, name, age)]]])
 ]]>
     </Resource>
     <Resource name="optimized exec plan">

--- a/flink-table/flink-table-planner/src/test/resources/org/apache/flink/table/planner/plan/stream/sql/join/LookupJoinTest.xml
+++ b/flink-table/flink-table-planner/src/test/resources/org/apache/flink/table/planner/plan/stream/sql/join/LookupJoinTest.xml
@@ -16,7 +16,7 @@ See the License for the specific language governing permissions and
 limitations under the License.
 -->
 <Root>
-  <TestCase name="testAvoidAggregatePushDown[LegacyTableSource=false]">
+  <TestCase name="testAvoidAggregatePushDown[LegacyTableSource=false, partitionedJoin=false]">
     <Resource name="sql">
       <![CDATA[
 SELECT b, count(a), sum(c), sum(d)
@@ -60,35 +60,52 @@ GroupAggregate(groupBy=[b], select=[b, COUNT_RETRACT(a) AS EXPR$1, SUM_RETRACT(c
 ]]>
     </Resource>
   </TestCase>
-  <TestCase name="testJoinTemporalTableWithCalcPushDown[LegacyTableSource=true]">
+  <TestCase name="testAvoidAggregatePushDown[LegacyTableSource=false, partitionedJoin=true]">
     <Resource name="sql">
       <![CDATA[
-SELECT * FROM MyTable AS T
-JOIN LookupTable FOR SYSTEM_TIME AS OF T.proctime AS D
-ON T.a = D.id AND D.age = 10
-WHERE cast(D.name as bigint) > 1000
+SELECT b, count(a), sum(c), sum(d)
+FROM (
+SELECT T.* FROM (
+SELECT b, a, sum(c) c, sum(d) d, PROCTIME() as proc
+FROM T1
+GROUP BY a, b
+      ) AS T
+JOIN LookupTable /*+ PARTITIONED_JOIN */ FOR SYSTEM_TIME AS OF T.proc AS D
+ON T.a = D.id
+WHERE D.age > 10
+      ) AS T
+GROUP BY b
       ]]>
     </Resource>
     <Resource name="ast">
       <![CDATA[
-LogicalProject(a=[$0], b=[$1], c=[$2], proctime=[$3], rowtime=[$4], id=[$5], name=[$6], age=[$7])
-+- LogicalFilter(condition=[>(CAST($6):BIGINT, 1000)])
-   +- LogicalCorrelate(correlation=[$cor0], joinType=[inner], requiredColumns=[{0, 3}])
-      :- LogicalTableScan(table=[[default_catalog, default_database, MyTable]])
-      +- LogicalFilter(condition=[AND(=($cor0.a, $0), =($2, 10))])
-         +- LogicalSnapshot(period=[$cor0.proctime])
-            +- LogicalTableScan(table=[[default_catalog, default_database, LookupTable, source: [TestTemporalTable(id, name, age)]]])
+LogicalAggregate(group=[{0}], EXPR$1=[COUNT($1)], EXPR$2=[SUM($2)], EXPR$3=[SUM($3)])
++- LogicalProject(b=[$0], a=[$1], c=[$2], d=[$3])
+   +- LogicalFilter(condition=[>($7, 10)])
+      +- LogicalCorrelate(correlation=[$cor0], joinType=[inner], requiredColumns=[{1, 4}])
+         :- LogicalProject(b=[$1], a=[$0], c=[$2], d=[$3], proc=[PROCTIME()])
+         :  +- LogicalAggregate(group=[{0, 1}], c=[SUM($2)], d=[SUM($3)])
+         :     +- LogicalTableScan(table=[[default_catalog, default_database, T1]])
+         +- LogicalFilter(condition=[=($cor0.a, $0)])
+            +- LogicalSnapshot(period=[$cor0.proc])
+               +- LogicalTableScan(table=[[default_catalog, default_database, LookupTable]], hints=[[[PARTITIONED_JOIN inheritPath:[]]]])
 ]]>
     </Resource>
     <Resource name="optimized exec plan">
       <![CDATA[
-Calc(select=[a, b, c, PROCTIME_MATERIALIZE(proctime) AS proctime, rowtime, id, name, CAST(10 AS INTEGER) AS age])
-+- LookupJoin(table=[default_catalog.default_database.LookupTable], joinType=[InnerJoin], async=[false], lookup=[age=10, id=a], where=[((age = 10) AND (CAST(name AS BIGINT) > 1000))], select=[a, b, c, proctime, rowtime, id, name])
-   +- DataStreamScan(table=[[default_catalog, default_database, MyTable]], fields=[a, b, c, proctime, rowtime])
+GroupAggregate(groupBy=[b], select=[b, COUNT_RETRACT(a) AS EXPR$1, SUM_RETRACT(c) AS EXPR$2, SUM_RETRACT(d) AS EXPR$3])
++- Exchange(distribution=[hash[b]])
+   +- Calc(select=[b, a, c, d])
+      +- LookupJoin(table=[default_catalog.default_database.LookupTable], joinType=[InnerJoin], async=[false], lookup=[id=a], where=[(age > 10)], select=[b, a, c, d, id])
+         +- Exchange(distribution=[hash[a]])
+            +- Calc(select=[b, a, c, d])
+               +- GroupAggregate(groupBy=[a, b], select=[a, b, SUM(c) AS c, SUM(d) AS d])
+                  +- Exchange(distribution=[hash[a, b]])
+                     +- DataStreamScan(table=[[default_catalog, default_database, T1]], fields=[a, b, c, d])
 ]]>
     </Resource>
   </TestCase>
-  <TestCase name="testAvoidAggregatePushDown[LegacyTableSource=true]">
+  <TestCase name="testAvoidAggregatePushDown[LegacyTableSource=true, partitionedJoin=false]">
     <Resource name="sql">
       <![CDATA[
 SELECT b, count(a), sum(c), sum(d)
@@ -132,9 +149,86 @@ GroupAggregate(groupBy=[b], select=[b, COUNT_RETRACT(a) AS EXPR$1, SUM_RETRACT(c
 ]]>
     </Resource>
   </TestCase>
-  <TestCase name="testJoinTemporalTable[LegacyTableSource=false]">
+  <TestCase name="testJoinTemporalTableWithCalcPushDown[LegacyTableSource=true, partitionedJoin=true]">
     <Resource name="sql">
-      <![CDATA[SELECT * FROM MyTable AS T JOIN LookupTable FOR SYSTEM_TIME AS OF T.proctime AS D ON T.a = D.id]]>
+      <![CDATA[
+SELECT * FROM MyTable AS T
+JOIN LookupTable /*+ PARTITIONED_JOIN */ FOR SYSTEM_TIME AS OF T.proctime AS D
+ON T.a = D.id AND D.age = 10
+WHERE cast(D.name as bigint) > 1000
+      ]]>
+    </Resource>
+    <Resource name="ast">
+      <![CDATA[
+LogicalProject(a=[$0], b=[$1], c=[$2], proctime=[$3], rowtime=[$4], id=[$5], name=[$6], age=[$7])
++- LogicalFilter(condition=[>(CAST($6):BIGINT, 1000)])
+   +- LogicalCorrelate(correlation=[$cor0], joinType=[inner], requiredColumns=[{0, 3}])
+      :- LogicalTableScan(table=[[default_catalog, default_database, MyTable]])
+      +- LogicalFilter(condition=[AND(=($cor0.a, $0), =($2, 10))])
+         +- LogicalSnapshot(period=[$cor0.proctime])
+            +- LogicalTableScan(table=[[default_catalog, default_database, LookupTable, source: [TestTemporalTable(id, name, age)]]], hints=[[[PARTITIONED_JOIN inheritPath:[]]]])
+]]>
+    </Resource>
+    <Resource name="optimized exec plan">
+      <![CDATA[
+Calc(select=[a, b, c, PROCTIME_MATERIALIZE(proctime) AS proctime, rowtime, id, name, CAST(10 AS INTEGER) AS age])
++- LookupJoin(table=[default_catalog.default_database.LookupTable], joinType=[InnerJoin], async=[false], lookup=[age=10, id=a], where=[((age = 10) AND (CAST(name AS BIGINT) > 1000))], select=[a, b, c, proctime, rowtime, id, name])
+   +- Exchange(distribution=[hash[a]])
+      +- DataStreamScan(table=[[default_catalog, default_database, MyTable]], fields=[a, b, c, proctime, rowtime])
+]]>
+    </Resource>
+  </TestCase>
+  <TestCase name="testAvoidAggregatePushDown[LegacyTableSource=true, partitionedJoin=true]">
+    <Resource name="sql">
+      <![CDATA[
+SELECT b, count(a), sum(c), sum(d)
+FROM (
+SELECT T.* FROM (
+SELECT b, a, sum(c) c, sum(d) d, PROCTIME() as proc
+FROM T1
+GROUP BY a, b
+      ) AS T
+JOIN LookupTable /*+ PARTITIONED_JOIN */ FOR SYSTEM_TIME AS OF T.proc AS D
+ON T.a = D.id
+WHERE D.age > 10
+      ) AS T
+GROUP BY b
+      ]]>
+    </Resource>
+    <Resource name="ast">
+      <![CDATA[
+LogicalAggregate(group=[{0}], EXPR$1=[COUNT($1)], EXPR$2=[SUM($2)], EXPR$3=[SUM($3)])
++- LogicalProject(b=[$0], a=[$1], c=[$2], d=[$3])
+   +- LogicalFilter(condition=[>($7, 10)])
+      +- LogicalCorrelate(correlation=[$cor0], joinType=[inner], requiredColumns=[{1, 4}])
+         :- LogicalProject(b=[$1], a=[$0], c=[$2], d=[$3], proc=[PROCTIME()])
+         :  +- LogicalAggregate(group=[{0, 1}], c=[SUM($2)], d=[SUM($3)])
+         :     +- LogicalTableScan(table=[[default_catalog, default_database, T1]])
+         +- LogicalFilter(condition=[=($cor0.a, $0)])
+            +- LogicalSnapshot(period=[$cor0.proc])
+               +- LogicalTableScan(table=[[default_catalog, default_database, LookupTable, source: [TestTemporalTable(id, name, age)]]], hints=[[[PARTITIONED_JOIN inheritPath:[]]]])
+]]>
+    </Resource>
+    <Resource name="optimized exec plan">
+      <![CDATA[
+GroupAggregate(groupBy=[b], select=[b, COUNT_RETRACT(a) AS EXPR$1, SUM_RETRACT(c) AS EXPR$2, SUM_RETRACT(d) AS EXPR$3])
++- Exchange(distribution=[hash[b]])
+   +- Calc(select=[b, a, c, d])
+      +- LookupJoin(table=[default_catalog.default_database.LookupTable], joinType=[InnerJoin], async=[false], lookup=[id=a], where=[(age > 10)], select=[b, a, c, d, id])
+         +- Exchange(distribution=[hash[a]])
+            +- Calc(select=[b, a, c, d])
+               +- GroupAggregate(groupBy=[a, b], select=[a, b, SUM(c) AS c, SUM(d) AS d])
+                  +- Exchange(distribution=[hash[a, b]])
+                     +- DataStreamScan(table=[[default_catalog, default_database, T1]], fields=[a, b, c, d])
+]]>
+    </Resource>
+  </TestCase>
+  <TestCase name="testJoinTemporalTable[LegacyTableSource=false, partitionedJoin=false]">
+    <Resource name="sql">
+      <![CDATA[
+SELECT * FROM MyTable AS T JOIN LookupTable
+FOR SYSTEM_TIME AS OF T.proctime AS D ON T.a = D.id
+]]>
     </Resource>
     <Resource name="ast">
       <![CDATA[
@@ -154,9 +248,38 @@ Calc(select=[a, b, c, PROCTIME_MATERIALIZE(proctime) AS proctime, rowtime, id, n
 ]]>
     </Resource>
   </TestCase>
-  <TestCase name="testJoinTemporalTable[LegacyTableSource=true]">
+  <TestCase name="testJoinTemporalTable[LegacyTableSource=false, partitionedJoin=true]">
     <Resource name="sql">
-      <![CDATA[SELECT * FROM MyTable AS T JOIN LookupTable FOR SYSTEM_TIME AS OF T.proctime AS D ON T.a = D.id]]>
+      <![CDATA[
+SELECT * FROM MyTable AS T JOIN LookupTable /*+ PARTITIONED_JOIN */
+FOR SYSTEM_TIME AS OF T.proctime AS D ON T.a = D.id
+]]>
+    </Resource>
+    <Resource name="ast">
+      <![CDATA[
+LogicalProject(a=[$0], b=[$1], c=[$2], proctime=[$3], rowtime=[$4], id=[$5], name=[$6], age=[$7])
++- LogicalCorrelate(correlation=[$cor0], joinType=[inner], requiredColumns=[{0, 3}])
+   :- LogicalTableScan(table=[[default_catalog, default_database, MyTable]])
+   +- LogicalFilter(condition=[=($cor0.a, $0)])
+      +- LogicalSnapshot(period=[$cor0.proctime])
+         +- LogicalTableScan(table=[[default_catalog, default_database, LookupTable]], hints=[[[PARTITIONED_JOIN inheritPath:[]]]])
+]]>
+    </Resource>
+    <Resource name="optimized exec plan">
+      <![CDATA[
+Calc(select=[a, b, c, PROCTIME_MATERIALIZE(proctime) AS proctime, rowtime, id, name, age])
++- LookupJoin(table=[default_catalog.default_database.LookupTable], joinType=[InnerJoin], async=[false], lookup=[id=a], select=[a, b, c, proctime, rowtime, id, name, age])
+   +- Exchange(distribution=[hash[a]])
+      +- DataStreamScan(table=[[default_catalog, default_database, MyTable]], fields=[a, b, c, proctime, rowtime])
+]]>
+    </Resource>
+  </TestCase>
+  <TestCase name="testJoinTemporalTable[LegacyTableSource=true, partitionedJoin=false]">
+    <Resource name="sql">
+      <![CDATA[
+SELECT * FROM MyTable AS T JOIN LookupTable
+FOR SYSTEM_TIME AS OF T.proctime AS D ON T.a = D.id
+]]>
     </Resource>
     <Resource name="ast">
       <![CDATA[
@@ -176,7 +299,33 @@ Calc(select=[a, b, c, PROCTIME_MATERIALIZE(proctime) AS proctime, rowtime, id, n
 ]]>
     </Resource>
   </TestCase>
-  <TestCase name="testJoinTemporalTableWithCalcPushDown[LegacyTableSource=false]">
+  <TestCase name="testJoinTemporalTable[LegacyTableSource=true, partitionedJoin=true]">
+    <Resource name="sql">
+      <![CDATA[
+SELECT * FROM MyTable AS T JOIN LookupTable /*+ PARTITIONED_JOIN */
+FOR SYSTEM_TIME AS OF T.proctime AS D ON T.a = D.id
+]]>
+    </Resource>
+    <Resource name="ast">
+      <![CDATA[
+LogicalProject(a=[$0], b=[$1], c=[$2], proctime=[$3], rowtime=[$4], id=[$5], name=[$6], age=[$7])
++- LogicalCorrelate(correlation=[$cor0], joinType=[inner], requiredColumns=[{0, 3}])
+   :- LogicalTableScan(table=[[default_catalog, default_database, MyTable]])
+   +- LogicalFilter(condition=[=($cor0.a, $0)])
+      +- LogicalSnapshot(period=[$cor0.proctime])
+         +- LogicalTableScan(table=[[default_catalog, default_database, LookupTable, source: [TestTemporalTable(id, name, age)]]], hints=[[[PARTITIONED_JOIN inheritPath:[]]]])
+]]>
+    </Resource>
+    <Resource name="optimized exec plan">
+      <![CDATA[
+Calc(select=[a, b, c, PROCTIME_MATERIALIZE(proctime) AS proctime, rowtime, id, name, age])
++- LookupJoin(table=[default_catalog.default_database.LookupTable], joinType=[InnerJoin], async=[false], lookup=[id=a], select=[a, b, c, proctime, rowtime, id, name, age])
+   +- Exchange(distribution=[hash[a]])
+      +- DataStreamScan(table=[[default_catalog, default_database, MyTable]], fields=[a, b, c, proctime, rowtime])
+]]>
+    </Resource>
+  </TestCase>
+  <TestCase name="testJoinTemporalTableWithCalcPushDown[LegacyTableSource=false, partitionedJoin=false]">
     <Resource name="sql">
       <![CDATA[
 SELECT * FROM MyTable AS T
@@ -204,14 +353,72 @@ Calc(select=[a, b, c, PROCTIME_MATERIALIZE(proctime) AS proctime, rowtime, id, n
 ]]>
     </Resource>
   </TestCase>
-  <TestCase name="testJoinTemporalTableWithComputedColumn[LegacyTableSource=false]">
+  <TestCase name="testJoinTemporalTableWithCalcPushDown[LegacyTableSource=false, partitionedJoin=true]">
+    <Resource name="sql">
+      <![CDATA[
+SELECT * FROM MyTable AS T
+JOIN LookupTable /*+ PARTITIONED_JOIN */ FOR SYSTEM_TIME AS OF T.proctime AS D
+ON T.a = D.id AND D.age = 10
+WHERE cast(D.name as bigint) > 1000
+      ]]>
+    </Resource>
+    <Resource name="ast">
+      <![CDATA[
+LogicalProject(a=[$0], b=[$1], c=[$2], proctime=[$3], rowtime=[$4], id=[$5], name=[$6], age=[$7])
++- LogicalFilter(condition=[>(CAST($6):BIGINT, 1000)])
+   +- LogicalCorrelate(correlation=[$cor0], joinType=[inner], requiredColumns=[{0, 3}])
+      :- LogicalTableScan(table=[[default_catalog, default_database, MyTable]])
+      +- LogicalFilter(condition=[AND(=($cor0.a, $0), =($2, 10))])
+         +- LogicalSnapshot(period=[$cor0.proctime])
+            +- LogicalTableScan(table=[[default_catalog, default_database, LookupTable]], hints=[[[PARTITIONED_JOIN inheritPath:[]]]])
+]]>
+    </Resource>
+    <Resource name="optimized exec plan">
+      <![CDATA[
+Calc(select=[a, b, c, PROCTIME_MATERIALIZE(proctime) AS proctime, rowtime, id, name, CAST(10 AS INTEGER) AS age])
++- LookupJoin(table=[default_catalog.default_database.LookupTable], joinType=[InnerJoin], async=[false], lookup=[age=10, id=a], where=[((age = 10) AND (CAST(name AS BIGINT) > 1000))], select=[a, b, c, proctime, rowtime, id, name])
+   +- Exchange(distribution=[hash[a]])
+      +- DataStreamScan(table=[[default_catalog, default_database, MyTable]], fields=[a, b, c, proctime, rowtime])
+]]>
+    </Resource>
+  </TestCase>
+  <TestCase name="testJoinTemporalTableWithCalcPushDown[LegacyTableSource=true, partitionedJoin=false]">
+    <Resource name="sql">
+      <![CDATA[
+SELECT * FROM MyTable AS T
+JOIN LookupTable FOR SYSTEM_TIME AS OF T.proctime AS D
+ON T.a = D.id AND D.age = 10
+WHERE cast(D.name as bigint) > 1000
+      ]]>
+    </Resource>
+    <Resource name="ast">
+      <![CDATA[
+LogicalProject(a=[$0], b=[$1], c=[$2], proctime=[$3], rowtime=[$4], id=[$5], name=[$6], age=[$7])
++- LogicalFilter(condition=[>(CAST($6):BIGINT, 1000)])
+   +- LogicalCorrelate(correlation=[$cor0], joinType=[inner], requiredColumns=[{0, 3}])
+      :- LogicalTableScan(table=[[default_catalog, default_database, MyTable]])
+      +- LogicalFilter(condition=[AND(=($cor0.a, $0), =($2, 10))])
+         +- LogicalSnapshot(period=[$cor0.proctime])
+            +- LogicalTableScan(table=[[default_catalog, default_database, LookupTable, source: [TestTemporalTable(id, name, age)]]])
+]]>
+    </Resource>
+    <Resource name="optimized exec plan">
+      <![CDATA[
+Calc(select=[a, b, c, PROCTIME_MATERIALIZE(proctime) AS proctime, rowtime, id, name, CAST(10 AS INTEGER) AS age])
++- LookupJoin(table=[default_catalog.default_database.LookupTable], joinType=[InnerJoin], async=[false], lookup=[age=10, id=a], where=[((age = 10) AND (CAST(name AS BIGINT) > 1000))], select=[a, b, c, proctime, rowtime, id, name])
+   +- DataStreamScan(table=[[default_catalog, default_database, MyTable]], fields=[a, b, c, proctime, rowtime])
+]]>
+    </Resource>
+  </TestCase>
+  <TestCase name="testJoinTemporalTableWithComputedColumn[LegacyTableSource=false, partitionedJoin=false]">
     <Resource name="sql">
       <![CDATA[
 SELECT
   T.a, T.b, T.c, D.name, D.age, D.nominal_age
 FROM
-  MyTable AS T JOIN LookupTableWithComputedColumn FOR SYSTEM_TIME AS OF T.proctime AS D
-  ON T.a = D.id
+  MyTable AS T JOIN LookupTableWithComputedColumn
+FOR SYSTEM_TIME AS OF T.proctime AS D
+ON T.a = D.id
 ]]>
     </Resource>
     <Resource name="ast">
@@ -234,14 +441,47 @@ Calc(select=[a, b, c, name, age, nominal_age])
 ]]>
     </Resource>
   </TestCase>
-  <TestCase name="testJoinTemporalTableWithComputedColumnAndPushDown[LegacyTableSource=false]">
+  <TestCase name="testJoinTemporalTableWithComputedColumn[LegacyTableSource=false, partitionedJoin=true]">
     <Resource name="sql">
       <![CDATA[
 SELECT
   T.a, T.b, T.c, D.name, D.age, D.nominal_age
 FROM
-  MyTable AS T JOIN LookupTableWithComputedColumn FOR SYSTEM_TIME AS OF T.proctime AS D
-  ON T.a = D.id and D.nominal_age > 12
+  MyTable AS T JOIN LookupTableWithComputedColumn /*+ PARTITIONED_JOIN */
+FOR SYSTEM_TIME AS OF T.proctime AS D
+ON T.a = D.id
+]]>
+    </Resource>
+    <Resource name="ast">
+      <![CDATA[
+LogicalProject(a=[$0], b=[$1], c=[$2], name=[$6], age=[$7], nominal_age=[$8])
++- LogicalCorrelate(correlation=[$cor0], joinType=[inner], requiredColumns=[{0, 3}])
+   :- LogicalTableScan(table=[[default_catalog, default_database, MyTable]])
+   +- LogicalFilter(condition=[=($cor0.a, $0)])
+      +- LogicalSnapshot(period=[$cor0.proctime])
+         +- LogicalProject(id=[$0], name=[$1], age=[$2], nominal_age=[+($2, 1)])
+            +- LogicalTableScan(table=[[default_catalog, default_database, LookupTableWithComputedColumn]], hints=[[[PARTITIONED_JOIN inheritPath:[]]]])
+]]>
+    </Resource>
+    <Resource name="optimized exec plan">
+      <![CDATA[
+Calc(select=[a, b, c, name, age, nominal_age])
++- LookupJoin(table=[default_catalog.default_database.LookupTableWithComputedColumn], joinType=[InnerJoin], async=[false], lookup=[id=a], select=[a, b, c, id, name, age, (age + 1) AS nominal_age])
+   +- Exchange(distribution=[hash[a]])
+      +- Calc(select=[a, b, c])
+         +- DataStreamScan(table=[[default_catalog, default_database, MyTable]], fields=[a, b, c, proctime, rowtime])
+]]>
+    </Resource>
+  </TestCase>
+  <TestCase name="testJoinTemporalTableWithComputedColumnAndPushDown[LegacyTableSource=false, partitionedJoin=false]">
+    <Resource name="sql">
+      <![CDATA[
+SELECT
+  T.a, T.b, T.c, D.name, D.age, D.nominal_age
+FROM
+  MyTable AS T JOIN LookupTableWithComputedColumn
+FOR SYSTEM_TIME AS OF T.proctime AS D
+ON T.a = D.id and D.nominal_age > 12
 ]]>
     </Resource>
     <Resource name="ast">
@@ -264,7 +504,39 @@ Calc(select=[a, b, c, name, age, nominal_age])
 ]]>
     </Resource>
   </TestCase>
-  <TestCase name="testJoinTemporalTableWithFilterPushDown[LegacyTableSource=false]">
+  <TestCase name="testJoinTemporalTableWithComputedColumnAndPushDown[LegacyTableSource=false, partitionedJoin=true]">
+    <Resource name="sql">
+      <![CDATA[
+SELECT
+  T.a, T.b, T.c, D.name, D.age, D.nominal_age
+FROM
+  MyTable AS T JOIN LookupTableWithComputedColumn /*+ PARTITIONED_JOIN */
+FOR SYSTEM_TIME AS OF T.proctime AS D
+ON T.a = D.id and D.nominal_age > 12
+]]>
+    </Resource>
+    <Resource name="ast">
+      <![CDATA[
+LogicalProject(a=[$0], b=[$1], c=[$2], name=[$6], age=[$7], nominal_age=[$8])
++- LogicalCorrelate(correlation=[$cor0], joinType=[inner], requiredColumns=[{0, 3}])
+   :- LogicalTableScan(table=[[default_catalog, default_database, MyTable]])
+   +- LogicalFilter(condition=[AND(=($cor0.a, $0), >($3, 12))])
+      +- LogicalSnapshot(period=[$cor0.proctime])
+         +- LogicalProject(id=[$0], name=[$1], age=[$2], nominal_age=[+($2, 1)])
+            +- LogicalTableScan(table=[[default_catalog, default_database, LookupTableWithComputedColumn]], hints=[[[PARTITIONED_JOIN inheritPath:[]]]])
+]]>
+    </Resource>
+    <Resource name="optimized exec plan">
+      <![CDATA[
+Calc(select=[a, b, c, name, age, nominal_age])
++- LookupJoin(table=[default_catalog.default_database.LookupTableWithComputedColumn], joinType=[InnerJoin], async=[false], lookup=[id=a], where=[((age + 1) > 12)], select=[a, b, c, id, name, age, (age + 1) AS nominal_age])
+   +- Exchange(distribution=[hash[a]])
+      +- Calc(select=[a, b, c])
+         +- DataStreamScan(table=[[default_catalog, default_database, MyTable]], fields=[a, b, c, proctime, rowtime])
+]]>
+    </Resource>
+  </TestCase>
+  <TestCase name="testJoinTemporalTableWithFilterPushDown[LegacyTableSource=false, partitionedJoin=false]">
     <Resource name="sql">
       <![CDATA[
 SELECT * FROM MyTable AS T
@@ -293,7 +565,37 @@ Calc(select=[a, b, c, PROCTIME_MATERIALIZE(proctime) AS proctime, rowtime, id, n
 ]]>
     </Resource>
   </TestCase>
-  <TestCase name="testJoinTemporalTableWithFilterPushDown[LegacyTableSource=true]">
+  <TestCase name="testJoinTemporalTableWithFilterPushDown[LegacyTableSource=false, partitionedJoin=true]">
+    <Resource name="sql">
+      <![CDATA[
+SELECT * FROM MyTable AS T
+JOIN LookupTable /*+ PARTITIONED_JOIN */ FOR SYSTEM_TIME AS OF T.proctime AS D
+ON T.a = D.id AND D.age = 10
+WHERE T.c > 1000
+      ]]>
+    </Resource>
+    <Resource name="ast">
+      <![CDATA[
+LogicalProject(a=[$0], b=[$1], c=[$2], proctime=[$3], rowtime=[$4], id=[$5], name=[$6], age=[$7])
++- LogicalFilter(condition=[>($2, 1000)])
+   +- LogicalCorrelate(correlation=[$cor0], joinType=[inner], requiredColumns=[{0, 3}])
+      :- LogicalTableScan(table=[[default_catalog, default_database, MyTable]])
+      +- LogicalFilter(condition=[AND(=($cor0.a, $0), =($2, 10))])
+         +- LogicalSnapshot(period=[$cor0.proctime])
+            +- LogicalTableScan(table=[[default_catalog, default_database, LookupTable]], hints=[[[PARTITIONED_JOIN inheritPath:[]]]])
+]]>
+    </Resource>
+    <Resource name="optimized exec plan">
+      <![CDATA[
+Calc(select=[a, b, c, PROCTIME_MATERIALIZE(proctime) AS proctime, rowtime, id, name, CAST(10 AS INTEGER) AS age])
++- LookupJoin(table=[default_catalog.default_database.LookupTable], joinType=[InnerJoin], async=[false], lookup=[age=10, id=a], where=[(age = 10)], select=[a, b, c, proctime, rowtime, id, name])
+   +- Exchange(distribution=[hash[a]])
+      +- Calc(select=[a, b, c, proctime, rowtime], where=[(c > 1000)])
+         +- DataStreamScan(table=[[default_catalog, default_database, MyTable]], fields=[a, b, c, proctime, rowtime])
+]]>
+    </Resource>
+  </TestCase>
+  <TestCase name="testJoinTemporalTableWithFilterPushDown[LegacyTableSource=true, partitionedJoin=false]">
     <Resource name="sql">
       <![CDATA[
 SELECT * FROM MyTable AS T
@@ -322,7 +624,37 @@ Calc(select=[a, b, c, PROCTIME_MATERIALIZE(proctime) AS proctime, rowtime, id, n
 ]]>
     </Resource>
   </TestCase>
-  <TestCase name="testJoinTemporalTableWithFunctionAndConstantCondition[LegacyTableSource=false]">
+  <TestCase name="testJoinTemporalTableWithFilterPushDown[LegacyTableSource=true, partitionedJoin=true]">
+    <Resource name="sql">
+      <![CDATA[
+SELECT * FROM MyTable AS T
+JOIN LookupTable /*+ PARTITIONED_JOIN */ FOR SYSTEM_TIME AS OF T.proctime AS D
+ON T.a = D.id AND D.age = 10
+WHERE T.c > 1000
+      ]]>
+    </Resource>
+    <Resource name="ast">
+      <![CDATA[
+LogicalProject(a=[$0], b=[$1], c=[$2], proctime=[$3], rowtime=[$4], id=[$5], name=[$6], age=[$7])
++- LogicalFilter(condition=[>($2, 1000)])
+   +- LogicalCorrelate(correlation=[$cor0], joinType=[inner], requiredColumns=[{0, 3}])
+      :- LogicalTableScan(table=[[default_catalog, default_database, MyTable]])
+      +- LogicalFilter(condition=[AND(=($cor0.a, $0), =($2, 10))])
+         +- LogicalSnapshot(period=[$cor0.proctime])
+            +- LogicalTableScan(table=[[default_catalog, default_database, LookupTable, source: [TestTemporalTable(id, name, age)]]], hints=[[[PARTITIONED_JOIN inheritPath:[]]]])
+]]>
+    </Resource>
+    <Resource name="optimized exec plan">
+      <![CDATA[
+Calc(select=[a, b, c, PROCTIME_MATERIALIZE(proctime) AS proctime, rowtime, id, name, CAST(10 AS INTEGER) AS age])
++- LookupJoin(table=[default_catalog.default_database.LookupTable], joinType=[InnerJoin], async=[false], lookup=[age=10, id=a], where=[(age = 10)], select=[a, b, c, proctime, rowtime, id, name])
+   +- Exchange(distribution=[hash[a]])
+      +- Calc(select=[a, b, c, proctime, rowtime], where=[(c > 1000)])
+         +- DataStreamScan(table=[[default_catalog, default_database, MyTable]], fields=[a, b, c, proctime, rowtime])
+]]>
+    </Resource>
+  </TestCase>
+  <TestCase name="testJoinTemporalTableWithFunctionAndConstantCondition[LegacyTableSource=false, partitionedJoin=false]">
     <Resource name="sql">
       <![CDATA[
 SELECT * FROM MyTable AS T
@@ -348,32 +680,34 @@ Calc(select=[a, b, c, PROCTIME_MATERIALIZE(proctime) AS proctime, rowtime, id, n
 ]]>
     </Resource>
   </TestCase>
-  <TestCase name="testJoinTemporalTableWithNestedQuery[LegacyTableSource=true]">
+  <TestCase name="testJoinTemporalTableWithFunctionAndConstantCondition[LegacyTableSource=false, partitionedJoin=true]">
     <Resource name="sql">
-      <![CDATA[SELECT * FROM (SELECT a, b, proctime FROM MyTable WHERE c > 1000) AS T JOIN LookupTable FOR SYSTEM_TIME AS OF T.proctime AS D ON T.a = D.id]]>
+      <![CDATA[
+SELECT * FROM MyTable AS T
+JOIN LookupTable /*+ PARTITIONED_JOIN */ FOR SYSTEM_TIME AS OF T.proctime AS D
+ON T.b = concat(D.name, '!') AND D.age = 11
+      ]]>
     </Resource>
     <Resource name="ast">
       <![CDATA[
-LogicalProject(a=[$0], b=[$1], proctime=[$2], id=[$3], name=[$4], age=[$5])
-+- LogicalCorrelate(correlation=[$cor0], joinType=[inner], requiredColumns=[{0, 2}])
-   :- LogicalProject(a=[$0], b=[$1], proctime=[$3])
-   :  +- LogicalFilter(condition=[>($2, 1000)])
-   :     +- LogicalTableScan(table=[[default_catalog, default_database, MyTable]])
-   +- LogicalFilter(condition=[=($cor0.a, $0)])
+LogicalProject(a=[$0], b=[$1], c=[$2], proctime=[$3], rowtime=[$4], id=[$5], name=[$6], age=[$7])
++- LogicalCorrelate(correlation=[$cor0], joinType=[inner], requiredColumns=[{1, 3}])
+   :- LogicalTableScan(table=[[default_catalog, default_database, MyTable]])
+   +- LogicalFilter(condition=[AND(=($cor0.b, CONCAT($1, _UTF-16LE'!')), =($2, 11))])
       +- LogicalSnapshot(period=[$cor0.proctime])
-         +- LogicalTableScan(table=[[default_catalog, default_database, LookupTable, source: [TestTemporalTable(id, name, age)]]])
+         +- LogicalTableScan(table=[[default_catalog, default_database, LookupTable]], hints=[[[PARTITIONED_JOIN inheritPath:[]]]])
 ]]>
     </Resource>
     <Resource name="optimized exec plan">
       <![CDATA[
-Calc(select=[a, b, PROCTIME_MATERIALIZE(proctime) AS proctime, id, name, age])
-+- LookupJoin(table=[default_catalog.default_database.LookupTable], joinType=[InnerJoin], async=[false], lookup=[id=a], select=[a, b, proctime, id, name, age])
-   +- Calc(select=[a, b, proctime], where=[(c > 1000)])
+Calc(select=[a, b, c, PROCTIME_MATERIALIZE(proctime) AS proctime, rowtime, id, name, CAST(11 AS INTEGER) AS age])
++- LookupJoin(table=[default_catalog.default_database.LookupTable], joinType=[InnerJoin], async=[false], lookup=[age=11], where=[(age = 11)], joinCondition=[(b = $f3)], select=[a, b, c, proctime, rowtime, id, name, CONCAT(name, '!') AS $f3])
+   +- Exchange(distribution=[hash[b]])
       +- DataStreamScan(table=[[default_catalog, default_database, MyTable]], fields=[a, b, c, proctime, rowtime])
 ]]>
     </Resource>
   </TestCase>
-  <TestCase name="testJoinTemporalTableWithFunctionAndConstantCondition[LegacyTableSource=true]">
+  <TestCase name="testJoinTemporalTableWithFunctionAndConstantCondition[LegacyTableSource=true, partitionedJoin=false]">
     <Resource name="sql">
       <![CDATA[
 SELECT * FROM MyTable AS T
@@ -399,7 +733,64 @@ Calc(select=[a, b, c, PROCTIME_MATERIALIZE(proctime) AS proctime, rowtime, id, n
 ]]>
     </Resource>
   </TestCase>
-  <TestCase name="testJoinTemporalTableWithFunctionAndReferenceCondition[LegacyTableSource=false]">
+  <TestCase name="testJoinTemporalTableWithNestedQuery[LegacyTableSource=true, partitionedJoin=true]">
+    <Resource name="sql">
+      <![CDATA[
+SELECT * FROM
+(SELECT a, b, proctime FROM MyTable WHERE c > 1000) AS T
+JOIN LookupTable /*+ PARTITIONED_JOIN */ FOR SYSTEM_TIME AS OF T.proctime AS D ON T.a = D.id
+]]>
+    </Resource>
+    <Resource name="ast">
+      <![CDATA[
+LogicalProject(a=[$0], b=[$1], proctime=[$2], id=[$3], name=[$4], age=[$5])
++- LogicalCorrelate(correlation=[$cor0], joinType=[inner], requiredColumns=[{0, 2}])
+   :- LogicalProject(a=[$0], b=[$1], proctime=[$3])
+   :  +- LogicalFilter(condition=[>($2, 1000)])
+   :     +- LogicalTableScan(table=[[default_catalog, default_database, MyTable]])
+   +- LogicalFilter(condition=[=($cor0.a, $0)])
+      +- LogicalSnapshot(period=[$cor0.proctime])
+         +- LogicalTableScan(table=[[default_catalog, default_database, LookupTable, source: [TestTemporalTable(id, name, age)]]], hints=[[[PARTITIONED_JOIN inheritPath:[]]]])
+]]>
+    </Resource>
+    <Resource name="optimized exec plan">
+      <![CDATA[
+Calc(select=[a, b, PROCTIME_MATERIALIZE(proctime) AS proctime, id, name, age])
++- LookupJoin(table=[default_catalog.default_database.LookupTable], joinType=[InnerJoin], async=[false], lookup=[id=a], select=[a, b, proctime, id, name, age])
+   +- Exchange(distribution=[hash[a]])
+      +- Calc(select=[a, b, proctime], where=[(c > 1000)])
+         +- DataStreamScan(table=[[default_catalog, default_database, MyTable]], fields=[a, b, c, proctime, rowtime])
+]]>
+    </Resource>
+  </TestCase>
+  <TestCase name="testJoinTemporalTableWithFunctionAndConstantCondition[LegacyTableSource=true, partitionedJoin=true]">
+    <Resource name="sql">
+      <![CDATA[
+SELECT * FROM MyTable AS T
+JOIN LookupTable /*+ PARTITIONED_JOIN */ FOR SYSTEM_TIME AS OF T.proctime AS D
+ON T.b = concat(D.name, '!') AND D.age = 11
+      ]]>
+    </Resource>
+    <Resource name="ast">
+      <![CDATA[
+LogicalProject(a=[$0], b=[$1], c=[$2], proctime=[$3], rowtime=[$4], id=[$5], name=[$6], age=[$7])
++- LogicalCorrelate(correlation=[$cor0], joinType=[inner], requiredColumns=[{1, 3}])
+   :- LogicalTableScan(table=[[default_catalog, default_database, MyTable]])
+   +- LogicalFilter(condition=[AND(=($cor0.b, CONCAT($1, _UTF-16LE'!')), =($2, 11))])
+      +- LogicalSnapshot(period=[$cor0.proctime])
+         +- LogicalTableScan(table=[[default_catalog, default_database, LookupTable, source: [TestTemporalTable(id, name, age)]]], hints=[[[PARTITIONED_JOIN inheritPath:[]]]])
+]]>
+    </Resource>
+    <Resource name="optimized exec plan">
+      <![CDATA[
+Calc(select=[a, b, c, PROCTIME_MATERIALIZE(proctime) AS proctime, rowtime, id, name, CAST(11 AS INTEGER) AS age])
++- LookupJoin(table=[default_catalog.default_database.LookupTable], joinType=[InnerJoin], async=[false], lookup=[age=11], where=[(age = 11)], joinCondition=[(b = $f3)], select=[a, b, c, proctime, rowtime, id, name, CONCAT(name, '!') AS $f3])
+   +- Exchange(distribution=[hash[b]])
+      +- DataStreamScan(table=[[default_catalog, default_database, MyTable]], fields=[a, b, c, proctime, rowtime])
+]]>
+    </Resource>
+  </TestCase>
+  <TestCase name="testJoinTemporalTableWithFunctionAndReferenceCondition[LegacyTableSource=false, partitionedJoin=false]">
     <Resource name="sql">
       <![CDATA[
 SELECT * FROM MyTable AS T
@@ -427,7 +818,36 @@ Calc(select=[a, b, c, PROCTIME_MATERIALIZE(proctime) AS proctime, rowtime, id, n
 ]]>
     </Resource>
   </TestCase>
-  <TestCase name="testJoinTemporalTableWithFunctionAndReferenceCondition[LegacyTableSource=true]">
+  <TestCase name="testJoinTemporalTableWithFunctionAndReferenceCondition[LegacyTableSource=false, partitionedJoin=true]">
+    <Resource name="sql">
+      <![CDATA[
+SELECT * FROM MyTable AS T
+JOIN LookupTable /*+ PARTITIONED_JOIN */ FOR SYSTEM_TIME AS OF T.proctime AS D
+ON T.a = D.id AND T.b = concat(D.name, '!')
+WHERE D.name LIKE 'Jack%'
+      ]]>
+    </Resource>
+    <Resource name="ast">
+      <![CDATA[
+LogicalProject(a=[$0], b=[$1], c=[$2], proctime=[$3], rowtime=[$4], id=[$5], name=[$6], age=[$7])
++- LogicalFilter(condition=[LIKE($6, _UTF-16LE'Jack%')])
+   +- LogicalCorrelate(correlation=[$cor0], joinType=[inner], requiredColumns=[{0, 1, 3}])
+      :- LogicalTableScan(table=[[default_catalog, default_database, MyTable]])
+      +- LogicalFilter(condition=[AND(=($cor0.a, $0), =($cor0.b, CONCAT($1, _UTF-16LE'!')))])
+         +- LogicalSnapshot(period=[$cor0.proctime])
+            +- LogicalTableScan(table=[[default_catalog, default_database, LookupTable]], hints=[[[PARTITIONED_JOIN inheritPath:[]]]])
+]]>
+    </Resource>
+    <Resource name="optimized exec plan">
+      <![CDATA[
+Calc(select=[a, b, c, PROCTIME_MATERIALIZE(proctime) AS proctime, rowtime, id, name, age])
++- LookupJoin(table=[default_catalog.default_database.LookupTable], joinType=[InnerJoin], async=[false], lookup=[id=a], where=[LIKE(name, 'Jack%')], joinCondition=[(b = $f3)], select=[a, b, c, proctime, rowtime, id, name, age, CONCAT(name, '!') AS $f3])
+   +- Exchange(distribution=[hash[a, b]])
+      +- DataStreamScan(table=[[default_catalog, default_database, MyTable]], fields=[a, b, c, proctime, rowtime])
+]]>
+    </Resource>
+  </TestCase>
+  <TestCase name="testJoinTemporalTableWithFunctionAndReferenceCondition[LegacyTableSource=true, partitionedJoin=false]">
     <Resource name="sql">
       <![CDATA[
 SELECT * FROM MyTable AS T
@@ -455,9 +875,41 @@ Calc(select=[a, b, c, PROCTIME_MATERIALIZE(proctime) AS proctime, rowtime, id, n
 ]]>
     </Resource>
   </TestCase>
-  <TestCase name="testJoinTemporalTableWithMultiConditionOnSameDimField[LegacyTableSource=false]">
+  <TestCase name="testJoinTemporalTableWithFunctionAndReferenceCondition[LegacyTableSource=true, partitionedJoin=true]">
     <Resource name="sql">
-      <![CDATA[SELECT * FROM MyTable AS T JOIN LookupTable FOR SYSTEM_TIME AS OF T.proctime AS D ON T.a = D.id and CAST(T.c as INT) = D.id]]>
+      <![CDATA[
+SELECT * FROM MyTable AS T
+JOIN LookupTable /*+ PARTITIONED_JOIN */ FOR SYSTEM_TIME AS OF T.proctime AS D
+ON T.a = D.id AND T.b = concat(D.name, '!')
+WHERE D.name LIKE 'Jack%'
+      ]]>
+    </Resource>
+    <Resource name="ast">
+      <![CDATA[
+LogicalProject(a=[$0], b=[$1], c=[$2], proctime=[$3], rowtime=[$4], id=[$5], name=[$6], age=[$7])
++- LogicalFilter(condition=[LIKE($6, _UTF-16LE'Jack%')])
+   +- LogicalCorrelate(correlation=[$cor0], joinType=[inner], requiredColumns=[{0, 1, 3}])
+      :- LogicalTableScan(table=[[default_catalog, default_database, MyTable]])
+      +- LogicalFilter(condition=[AND(=($cor0.a, $0), =($cor0.b, CONCAT($1, _UTF-16LE'!')))])
+         +- LogicalSnapshot(period=[$cor0.proctime])
+            +- LogicalTableScan(table=[[default_catalog, default_database, LookupTable, source: [TestTemporalTable(id, name, age)]]], hints=[[[PARTITIONED_JOIN inheritPath:[]]]])
+]]>
+    </Resource>
+    <Resource name="optimized exec plan">
+      <![CDATA[
+Calc(select=[a, b, c, PROCTIME_MATERIALIZE(proctime) AS proctime, rowtime, id, name, age])
++- LookupJoin(table=[default_catalog.default_database.LookupTable], joinType=[InnerJoin], async=[false], lookup=[id=a], where=[LIKE(name, 'Jack%')], joinCondition=[(b = $f3)], select=[a, b, c, proctime, rowtime, id, name, age, CONCAT(name, '!') AS $f3])
+   +- Exchange(distribution=[hash[a, b]])
+      +- DataStreamScan(table=[[default_catalog, default_database, MyTable]], fields=[a, b, c, proctime, rowtime])
+]]>
+    </Resource>
+  </TestCase>
+  <TestCase name="testJoinTemporalTableWithMultiConditionOnSameDimField[LegacyTableSource=false, partitionedJoin=false]">
+    <Resource name="sql">
+      <![CDATA[
+SELECT * FROM MyTable AS T JOIN LookupTable
+FOR SYSTEM_TIME AS OF T.proctime AS D ON T.a = D.id and CAST(T.c as INT) = D.id
+]]>
     </Resource>
     <Resource name="ast">
       <![CDATA[
@@ -478,9 +930,39 @@ Calc(select=[a, b, c, PROCTIME_MATERIALIZE(proctime) AS proctime, rowtime, id, n
 ]]>
     </Resource>
   </TestCase>
-  <TestCase name="testJoinTemporalTableWithMultiConditionOnSameDimField[LegacyTableSource=true]">
+  <TestCase name="testJoinTemporalTableWithMultiConditionOnSameDimField[LegacyTableSource=false, partitionedJoin=true]">
     <Resource name="sql">
-      <![CDATA[SELECT * FROM MyTable AS T JOIN LookupTable FOR SYSTEM_TIME AS OF T.proctime AS D ON T.a = D.id and CAST(T.c as INT) = D.id]]>
+      <![CDATA[
+SELECT * FROM MyTable AS T JOIN LookupTable /*+ PARTITIONED_JOIN */
+FOR SYSTEM_TIME AS OF T.proctime AS D ON T.a = D.id and CAST(T.c as INT) = D.id
+]]>
+    </Resource>
+    <Resource name="ast">
+      <![CDATA[
+LogicalProject(a=[$0], b=[$1], c=[$2], proctime=[$3], rowtime=[$4], id=[$5], name=[$6], age=[$7])
++- LogicalCorrelate(correlation=[$cor0], joinType=[inner], requiredColumns=[{0, 2, 3}])
+   :- LogicalTableScan(table=[[default_catalog, default_database, MyTable]])
+   +- LogicalFilter(condition=[AND(=($cor0.a, $0), =(CAST($cor0.c):INTEGER, $0))])
+      +- LogicalSnapshot(period=[$cor0.proctime])
+         +- LogicalTableScan(table=[[default_catalog, default_database, LookupTable]], hints=[[[PARTITIONED_JOIN inheritPath:[]]]])
+]]>
+    </Resource>
+    <Resource name="optimized exec plan">
+      <![CDATA[
+Calc(select=[a, b, c, PROCTIME_MATERIALIZE(proctime) AS proctime, rowtime, id, name, age])
++- LookupJoin(table=[default_catalog.default_database.LookupTable], joinType=[InnerJoin], async=[false], lookup=[id=c0], joinCondition=[(a = id)], select=[a, b, c, proctime, rowtime, c0, id, name, age])
+   +- Exchange(distribution=[hash[a, c0]])
+      +- Calc(select=[a, b, c, proctime, rowtime, CAST(c AS INTEGER) AS c0])
+         +- DataStreamScan(table=[[default_catalog, default_database, MyTable]], fields=[a, b, c, proctime, rowtime])
+]]>
+    </Resource>
+  </TestCase>
+  <TestCase name="testJoinTemporalTableWithMultiConditionOnSameDimField[LegacyTableSource=true, partitionedJoin=false]">
+    <Resource name="sql">
+      <![CDATA[
+SELECT * FROM MyTable AS T JOIN LookupTable
+FOR SYSTEM_TIME AS OF T.proctime AS D ON T.a = D.id and CAST(T.c as INT) = D.id
+]]>
     </Resource>
     <Resource name="ast">
       <![CDATA[
@@ -501,7 +983,34 @@ Calc(select=[a, b, c, PROCTIME_MATERIALIZE(proctime) AS proctime, rowtime, id, n
 ]]>
     </Resource>
   </TestCase>
-  <TestCase name="testJoinTemporalTableWithMultiFunctionAndConstantCondition[LegacyTableSource=false]">
+  <TestCase name="testJoinTemporalTableWithMultiConditionOnSameDimField[LegacyTableSource=true, partitionedJoin=true]">
+    <Resource name="sql">
+      <![CDATA[
+SELECT * FROM MyTable AS T JOIN LookupTable /*+ PARTITIONED_JOIN */
+FOR SYSTEM_TIME AS OF T.proctime AS D ON T.a = D.id and CAST(T.c as INT) = D.id
+]]>
+    </Resource>
+    <Resource name="ast">
+      <![CDATA[
+LogicalProject(a=[$0], b=[$1], c=[$2], proctime=[$3], rowtime=[$4], id=[$5], name=[$6], age=[$7])
++- LogicalCorrelate(correlation=[$cor0], joinType=[inner], requiredColumns=[{0, 2, 3}])
+   :- LogicalTableScan(table=[[default_catalog, default_database, MyTable]])
+   +- LogicalFilter(condition=[AND(=($cor0.a, $0), =(CAST($cor0.c):INTEGER, $0))])
+      +- LogicalSnapshot(period=[$cor0.proctime])
+         +- LogicalTableScan(table=[[default_catalog, default_database, LookupTable, source: [TestTemporalTable(id, name, age)]]], hints=[[[PARTITIONED_JOIN inheritPath:[]]]])
+]]>
+    </Resource>
+    <Resource name="optimized exec plan">
+      <![CDATA[
+Calc(select=[a, b, c, PROCTIME_MATERIALIZE(proctime) AS proctime, rowtime, id, name, age])
++- LookupJoin(table=[default_catalog.default_database.LookupTable], joinType=[InnerJoin], async=[false], lookup=[id=c0], joinCondition=[(a = id)], select=[a, b, c, proctime, rowtime, c0, id, name, age])
+   +- Exchange(distribution=[hash[a, c0]])
+      +- Calc(select=[a, b, c, proctime, rowtime, CAST(c AS INTEGER) AS c0])
+         +- DataStreamScan(table=[[default_catalog, default_database, MyTable]], fields=[a, b, c, proctime, rowtime])
+]]>
+    </Resource>
+  </TestCase>
+  <TestCase name="testJoinTemporalTableWithMultiFunctionAndConstantCondition[LegacyTableSource=false, partitionedJoin=false]">
     <Resource name="sql">
       <![CDATA[
 SELECT * FROM MyTable AS T
@@ -527,7 +1036,34 @@ Calc(select=[a, b, c, PROCTIME_MATERIALIZE(proctime) AS proctime, rowtime, id, n
 ]]>
     </Resource>
   </TestCase>
-  <TestCase name="testJoinTemporalTableWithMultiFunctionAndConstantCondition[LegacyTableSource=true]">
+  <TestCase name="testJoinTemporalTableWithMultiFunctionAndConstantCondition[LegacyTableSource=false, partitionedJoin=true]">
+    <Resource name="sql">
+      <![CDATA[
+SELECT * FROM MyTable AS T
+JOIN LookupTable /*+ PARTITIONED_JOIN */ FOR SYSTEM_TIME AS OF T.proctime AS D
+ON T.a = D.id + 1 AND T.b = concat(D.name, '!') AND D.age = 11
+      ]]>
+    </Resource>
+    <Resource name="ast">
+      <![CDATA[
+LogicalProject(a=[$0], b=[$1], c=[$2], proctime=[$3], rowtime=[$4], id=[$5], name=[$6], age=[$7])
++- LogicalCorrelate(correlation=[$cor0], joinType=[inner], requiredColumns=[{0, 1, 3}])
+   :- LogicalTableScan(table=[[default_catalog, default_database, MyTable]])
+   +- LogicalFilter(condition=[AND(=($cor0.a, +($0, 1)), =($cor0.b, CONCAT($1, _UTF-16LE'!')), =($2, 11))])
+      +- LogicalSnapshot(period=[$cor0.proctime])
+         +- LogicalTableScan(table=[[default_catalog, default_database, LookupTable]], hints=[[[PARTITIONED_JOIN inheritPath:[]]]])
+]]>
+    </Resource>
+    <Resource name="optimized exec plan">
+      <![CDATA[
+Calc(select=[a, b, c, PROCTIME_MATERIALIZE(proctime) AS proctime, rowtime, id, name, CAST(11 AS INTEGER) AS age])
++- LookupJoin(table=[default_catalog.default_database.LookupTable], joinType=[InnerJoin], async=[false], lookup=[age=11], where=[(age = 11)], joinCondition=[((a = $f3) AND (b = $f4))], select=[a, b, c, proctime, rowtime, id, name, (id + 1) AS $f3, CONCAT(name, '!') AS $f4])
+   +- Exchange(distribution=[hash[a, b]])
+      +- DataStreamScan(table=[[default_catalog, default_database, MyTable]], fields=[a, b, c, proctime, rowtime])
+]]>
+    </Resource>
+  </TestCase>
+  <TestCase name="testJoinTemporalTableWithMultiFunctionAndConstantCondition[LegacyTableSource=true, partitionedJoin=false]">
     <Resource name="sql">
       <![CDATA[
 SELECT * FROM MyTable AS T
@@ -553,7 +1089,34 @@ Calc(select=[a, b, c, PROCTIME_MATERIALIZE(proctime) AS proctime, rowtime, id, n
 ]]>
     </Resource>
   </TestCase>
-  <TestCase name="testJoinTemporalTableWithMultiIndexColumn[LegacyTableSource=false]">
+  <TestCase name="testJoinTemporalTableWithMultiFunctionAndConstantCondition[LegacyTableSource=true, partitionedJoin=true]">
+    <Resource name="sql">
+      <![CDATA[
+SELECT * FROM MyTable AS T
+JOIN LookupTable /*+ PARTITIONED_JOIN */ FOR SYSTEM_TIME AS OF T.proctime AS D
+ON T.a = D.id + 1 AND T.b = concat(D.name, '!') AND D.age = 11
+      ]]>
+    </Resource>
+    <Resource name="ast">
+      <![CDATA[
+LogicalProject(a=[$0], b=[$1], c=[$2], proctime=[$3], rowtime=[$4], id=[$5], name=[$6], age=[$7])
++- LogicalCorrelate(correlation=[$cor0], joinType=[inner], requiredColumns=[{0, 1, 3}])
+   :- LogicalTableScan(table=[[default_catalog, default_database, MyTable]])
+   +- LogicalFilter(condition=[AND(=($cor0.a, +($0, 1)), =($cor0.b, CONCAT($1, _UTF-16LE'!')), =($2, 11))])
+      +- LogicalSnapshot(period=[$cor0.proctime])
+         +- LogicalTableScan(table=[[default_catalog, default_database, LookupTable, source: [TestTemporalTable(id, name, age)]]], hints=[[[PARTITIONED_JOIN inheritPath:[]]]])
+]]>
+    </Resource>
+    <Resource name="optimized exec plan">
+      <![CDATA[
+Calc(select=[a, b, c, PROCTIME_MATERIALIZE(proctime) AS proctime, rowtime, id, name, CAST(11 AS INTEGER) AS age])
++- LookupJoin(table=[default_catalog.default_database.LookupTable], joinType=[InnerJoin], async=[false], lookup=[age=11], where=[(age = 11)], joinCondition=[((a = $f3) AND (b = $f4))], select=[a, b, c, proctime, rowtime, id, name, (id + 1) AS $f3, CONCAT(name, '!') AS $f4])
+   +- Exchange(distribution=[hash[a, b]])
+      +- DataStreamScan(table=[[default_catalog, default_database, MyTable]], fields=[a, b, c, proctime, rowtime])
+]]>
+    </Resource>
+  </TestCase>
+  <TestCase name="testJoinTemporalTableWithMultiIndexColumn[LegacyTableSource=false, partitionedJoin=false]">
     <Resource name="sql">
       <![CDATA[
 SELECT * FROM MyTable AS T
@@ -582,7 +1145,37 @@ Calc(select=[a, b, c, PROCTIME_MATERIALIZE(proctime) AS proctime, rowtime, id, C
 ]]>
     </Resource>
   </TestCase>
-  <TestCase name="testJoinTemporalTableWithMultiIndexColumn[LegacyTableSource=true]">
+  <TestCase name="testJoinTemporalTableWithMultiIndexColumn[LegacyTableSource=false, partitionedJoin=true]">
+    <Resource name="sql">
+      <![CDATA[
+SELECT * FROM MyTable AS T
+JOIN LookupTable /*+ PARTITIONED_JOIN */ FOR SYSTEM_TIME AS OF T.proctime AS D
+ON T.a = D.id AND D.age = 10 AND D.name = 'AAA'
+WHERE T.c > 1000
+      ]]>
+    </Resource>
+    <Resource name="ast">
+      <![CDATA[
+LogicalProject(a=[$0], b=[$1], c=[$2], proctime=[$3], rowtime=[$4], id=[$5], name=[$6], age=[$7])
++- LogicalFilter(condition=[>($2, 1000)])
+   +- LogicalCorrelate(correlation=[$cor0], joinType=[inner], requiredColumns=[{0, 3}])
+      :- LogicalTableScan(table=[[default_catalog, default_database, MyTable]])
+      +- LogicalFilter(condition=[AND(=($cor0.a, $0), =($2, 10), =($1, _UTF-16LE'AAA'))])
+         +- LogicalSnapshot(period=[$cor0.proctime])
+            +- LogicalTableScan(table=[[default_catalog, default_database, LookupTable]], hints=[[[PARTITIONED_JOIN inheritPath:[]]]])
+]]>
+    </Resource>
+    <Resource name="optimized exec plan">
+      <![CDATA[
+Calc(select=[a, b, c, PROCTIME_MATERIALIZE(proctime) AS proctime, rowtime, id, CAST('AAA' AS VARCHAR(2147483647)) AS name, CAST(10 AS INTEGER) AS age])
++- LookupJoin(table=[default_catalog.default_database.LookupTable], joinType=[InnerJoin], async=[false], lookup=[age=10, name=_UTF-16LE'AAA', id=a], where=[((age = 10) AND (name = 'AAA'))], select=[a, b, c, proctime, rowtime, id])
+   +- Exchange(distribution=[hash[a]])
+      +- Calc(select=[a, b, c, proctime, rowtime], where=[(c > 1000)])
+         +- DataStreamScan(table=[[default_catalog, default_database, MyTable]], fields=[a, b, c, proctime, rowtime])
+]]>
+    </Resource>
+  </TestCase>
+  <TestCase name="testJoinTemporalTableWithMultiIndexColumn[LegacyTableSource=true, partitionedJoin=false]">
     <Resource name="sql">
       <![CDATA[
 SELECT * FROM MyTable AS T
@@ -611,9 +1204,43 @@ Calc(select=[a, b, c, PROCTIME_MATERIALIZE(proctime) AS proctime, rowtime, id, C
 ]]>
     </Resource>
   </TestCase>
-  <TestCase name="testJoinTemporalTableWithNestedQuery[LegacyTableSource=false]">
+  <TestCase name="testJoinTemporalTableWithMultiIndexColumn[LegacyTableSource=true, partitionedJoin=true]">
     <Resource name="sql">
-      <![CDATA[SELECT * FROM (SELECT a, b, proctime FROM MyTable WHERE c > 1000) AS T JOIN LookupTable FOR SYSTEM_TIME AS OF T.proctime AS D ON T.a = D.id]]>
+      <![CDATA[
+SELECT * FROM MyTable AS T
+JOIN LookupTable /*+ PARTITIONED_JOIN */ FOR SYSTEM_TIME AS OF T.proctime AS D
+ON T.a = D.id AND D.age = 10 AND D.name = 'AAA'
+WHERE T.c > 1000
+      ]]>
+    </Resource>
+    <Resource name="ast">
+      <![CDATA[
+LogicalProject(a=[$0], b=[$1], c=[$2], proctime=[$3], rowtime=[$4], id=[$5], name=[$6], age=[$7])
++- LogicalFilter(condition=[>($2, 1000)])
+   +- LogicalCorrelate(correlation=[$cor0], joinType=[inner], requiredColumns=[{0, 3}])
+      :- LogicalTableScan(table=[[default_catalog, default_database, MyTable]])
+      +- LogicalFilter(condition=[AND(=($cor0.a, $0), =($2, 10), =($1, _UTF-16LE'AAA'))])
+         +- LogicalSnapshot(period=[$cor0.proctime])
+            +- LogicalTableScan(table=[[default_catalog, default_database, LookupTable, source: [TestTemporalTable(id, name, age)]]], hints=[[[PARTITIONED_JOIN inheritPath:[]]]])
+]]>
+    </Resource>
+    <Resource name="optimized exec plan">
+      <![CDATA[
+Calc(select=[a, b, c, PROCTIME_MATERIALIZE(proctime) AS proctime, rowtime, id, CAST('AAA' AS VARCHAR(2147483647)) AS name, CAST(10 AS INTEGER) AS age])
++- LookupJoin(table=[default_catalog.default_database.LookupTable], joinType=[InnerJoin], async=[false], lookup=[age=10, name=_UTF-16LE'AAA', id=a], where=[((age = 10) AND (name = 'AAA'))], select=[a, b, c, proctime, rowtime, id])
+   +- Exchange(distribution=[hash[a]])
+      +- Calc(select=[a, b, c, proctime, rowtime], where=[(c > 1000)])
+         +- DataStreamScan(table=[[default_catalog, default_database, MyTable]], fields=[a, b, c, proctime, rowtime])
+]]>
+    </Resource>
+  </TestCase>
+  <TestCase name="testJoinTemporalTableWithNestedQuery[LegacyTableSource=false, partitionedJoin=false]">
+    <Resource name="sql">
+      <![CDATA[
+SELECT * FROM
+(SELECT a, b, proctime FROM MyTable WHERE c > 1000) AS T
+JOIN LookupTable FOR SYSTEM_TIME AS OF T.proctime AS D ON T.a = D.id
+]]>
     </Resource>
     <Resource name="ast">
       <![CDATA[
@@ -636,7 +1263,66 @@ Calc(select=[a, b, PROCTIME_MATERIALIZE(proctime) AS proctime, id, name, age])
 ]]>
     </Resource>
   </TestCase>
-  <TestCase name="testJoinTemporalTableWithProjectionPushDown[LegacyTableSource=false]">
+  <TestCase name="testJoinTemporalTableWithNestedQuery[LegacyTableSource=false, partitionedJoin=true]">
+    <Resource name="sql">
+      <![CDATA[
+SELECT * FROM
+(SELECT a, b, proctime FROM MyTable WHERE c > 1000) AS T
+JOIN LookupTable /*+ PARTITIONED_JOIN */ FOR SYSTEM_TIME AS OF T.proctime AS D ON T.a = D.id
+]]>
+    </Resource>
+    <Resource name="ast">
+      <![CDATA[
+LogicalProject(a=[$0], b=[$1], proctime=[$2], id=[$3], name=[$4], age=[$5])
++- LogicalCorrelate(correlation=[$cor0], joinType=[inner], requiredColumns=[{0, 2}])
+   :- LogicalProject(a=[$0], b=[$1], proctime=[$3])
+   :  +- LogicalFilter(condition=[>($2, 1000)])
+   :     +- LogicalTableScan(table=[[default_catalog, default_database, MyTable]])
+   +- LogicalFilter(condition=[=($cor0.a, $0)])
+      +- LogicalSnapshot(period=[$cor0.proctime])
+         +- LogicalTableScan(table=[[default_catalog, default_database, LookupTable]], hints=[[[PARTITIONED_JOIN inheritPath:[]]]])
+]]>
+    </Resource>
+    <Resource name="optimized exec plan">
+      <![CDATA[
+Calc(select=[a, b, PROCTIME_MATERIALIZE(proctime) AS proctime, id, name, age])
++- LookupJoin(table=[default_catalog.default_database.LookupTable], joinType=[InnerJoin], async=[false], lookup=[id=a], select=[a, b, proctime, id, name, age])
+   +- Exchange(distribution=[hash[a]])
+      +- Calc(select=[a, b, proctime], where=[(c > 1000)])
+         +- DataStreamScan(table=[[default_catalog, default_database, MyTable]], fields=[a, b, c, proctime, rowtime])
+]]>
+    </Resource>
+  </TestCase>
+  <TestCase name="testJoinTemporalTableWithNestedQuery[LegacyTableSource=true, partitionedJoin=false]">
+    <Resource name="sql">
+      <![CDATA[
+SELECT * FROM
+(SELECT a, b, proctime FROM MyTable WHERE c > 1000) AS T
+JOIN LookupTable FOR SYSTEM_TIME AS OF T.proctime AS D ON T.a = D.id
+]]>
+    </Resource>
+    <Resource name="ast">
+      <![CDATA[
+LogicalProject(a=[$0], b=[$1], proctime=[$2], id=[$3], name=[$4], age=[$5])
++- LogicalCorrelate(correlation=[$cor0], joinType=[inner], requiredColumns=[{0, 2}])
+   :- LogicalProject(a=[$0], b=[$1], proctime=[$3])
+   :  +- LogicalFilter(condition=[>($2, 1000)])
+   :     +- LogicalTableScan(table=[[default_catalog, default_database, MyTable]])
+   +- LogicalFilter(condition=[=($cor0.a, $0)])
+      +- LogicalSnapshot(period=[$cor0.proctime])
+         +- LogicalTableScan(table=[[default_catalog, default_database, LookupTable, source: [TestTemporalTable(id, name, age)]]])
+]]>
+    </Resource>
+    <Resource name="optimized exec plan">
+      <![CDATA[
+Calc(select=[a, b, PROCTIME_MATERIALIZE(proctime) AS proctime, id, name, age])
++- LookupJoin(table=[default_catalog.default_database.LookupTable], joinType=[InnerJoin], async=[false], lookup=[id=a], select=[a, b, proctime, id, name, age])
+   +- Calc(select=[a, b, proctime], where=[(c > 1000)])
+      +- DataStreamScan(table=[[default_catalog, default_database, MyTable]], fields=[a, b, c, proctime, rowtime])
+]]>
+    </Resource>
+  </TestCase>
+  <TestCase name="testJoinTemporalTableWithProjectionPushDown[LegacyTableSource=false, partitionedJoin=false]">
     <Resource name="sql">
       <![CDATA[
 SELECT T.*, D.id
@@ -663,9 +1349,67 @@ Calc(select=[a, b, c, PROCTIME_MATERIALIZE(proctime) AS proctime, rowtime, id])
 ]]>
     </Resource>
   </TestCase>
-  <TestCase name="testLeftJoinTemporalTable[LegacyTableSource=true]">
+  <TestCase name="testJoinTemporalTableWithProjectionPushDown[LegacyTableSource=false, partitionedJoin=true]">
     <Resource name="sql">
-      <![CDATA[SELECT * FROM MyTable AS T LEFT JOIN LookupTable FOR SYSTEM_TIME AS OF T.proctime AS D ON T.a = D.id]]>
+      <![CDATA[
+SELECT T.*, D.id
+FROM MyTable AS T
+JOIN LookupTable /*+ PARTITIONED_JOIN */ FOR SYSTEM_TIME AS OF T.proctime AS D
+ON T.a = D.id
+      ]]>
+    </Resource>
+    <Resource name="ast">
+      <![CDATA[
+LogicalProject(a=[$0], b=[$1], c=[$2], proctime=[$3], rowtime=[$4], id=[$5])
++- LogicalCorrelate(correlation=[$cor0], joinType=[inner], requiredColumns=[{0, 3}])
+   :- LogicalTableScan(table=[[default_catalog, default_database, MyTable]])
+   +- LogicalFilter(condition=[=($cor0.a, $0)])
+      +- LogicalSnapshot(period=[$cor0.proctime])
+         +- LogicalTableScan(table=[[default_catalog, default_database, LookupTable]], hints=[[[PARTITIONED_JOIN inheritPath:[]]]])
+]]>
+    </Resource>
+    <Resource name="optimized exec plan">
+      <![CDATA[
+Calc(select=[a, b, c, PROCTIME_MATERIALIZE(proctime) AS proctime, rowtime, id])
++- LookupJoin(table=[default_catalog.default_database.LookupTable], joinType=[InnerJoin], async=[false], lookup=[id=a], select=[a, b, c, proctime, rowtime, id])
+   +- Exchange(distribution=[hash[a]])
+      +- DataStreamScan(table=[[default_catalog, default_database, MyTable]], fields=[a, b, c, proctime, rowtime])
+]]>
+    </Resource>
+  </TestCase>
+  <TestCase name="testJoinTemporalTableWithProjectionPushDown[LegacyTableSource=true, partitionedJoin=false]">
+    <Resource name="sql">
+      <![CDATA[
+SELECT T.*, D.id
+FROM MyTable AS T
+JOIN LookupTable FOR SYSTEM_TIME AS OF T.proctime AS D
+ON T.a = D.id
+      ]]>
+    </Resource>
+    <Resource name="ast">
+      <![CDATA[
+LogicalProject(a=[$0], b=[$1], c=[$2], proctime=[$3], rowtime=[$4], id=[$5])
++- LogicalCorrelate(correlation=[$cor0], joinType=[inner], requiredColumns=[{0, 3}])
+   :- LogicalTableScan(table=[[default_catalog, default_database, MyTable]])
+   +- LogicalFilter(condition=[=($cor0.a, $0)])
+      +- LogicalSnapshot(period=[$cor0.proctime])
+         +- LogicalTableScan(table=[[default_catalog, default_database, LookupTable, source: [TestTemporalTable(id, name, age)]]])
+]]>
+    </Resource>
+    <Resource name="optimized exec plan">
+      <![CDATA[
+Calc(select=[a, b, c, PROCTIME_MATERIALIZE(proctime) AS proctime, rowtime, id])
++- LookupJoin(table=[default_catalog.default_database.LookupTable], joinType=[InnerJoin], async=[false], lookup=[id=a], select=[a, b, c, proctime, rowtime, id])
+   +- DataStreamScan(table=[[default_catalog, default_database, MyTable]], fields=[a, b, c, proctime, rowtime])
+]]>
+    </Resource>
+  </TestCase>
+  <TestCase name="testLeftJoinTemporalTable[LegacyTableSource=true, partitionedJoin=true]">
+    <Resource name="sql">
+      <![CDATA[
+SELECT * FROM MyTable AS T LEFT JOIN LookupTable /*+ PARTITIONED_JOIN */
+FOR SYSTEM_TIME AS OF T.proctime AS D ON T.a = D.id
+]]>
     </Resource>
     <Resource name="ast">
       <![CDATA[
@@ -674,7 +1418,187 @@ LogicalProject(a=[$0], b=[$1], c=[$2], proctime=[$3], rowtime=[$4], id=[$5], nam
    :- LogicalTableScan(table=[[default_catalog, default_database, MyTable]])
    +- LogicalFilter(condition=[=($cor0.a, $0)])
       +- LogicalSnapshot(period=[$cor0.proctime])
-         +- LogicalTableScan(table=[[default_catalog, default_database, LookupTable, source: [TestTemporalTable(id, name, age)]]])
+         +- LogicalTableScan(table=[[default_catalog, default_database, LookupTable, source: [TestTemporalTable(id, name, age)]]], hints=[[[PARTITIONED_JOIN inheritPath:[]]]])
+]]>
+    </Resource>
+    <Resource name="optimized exec plan">
+      <![CDATA[
+Calc(select=[a, b, c, PROCTIME_MATERIALIZE(proctime) AS proctime, rowtime, id, name, age])
++- LookupJoin(table=[default_catalog.default_database.LookupTable], joinType=[LeftOuterJoin], async=[false], lookup=[id=a], select=[a, b, c, proctime, rowtime, id, name, age])
+   +- Exchange(distribution=[hash[a]])
+      +- DataStreamScan(table=[[default_catalog, default_database, MyTable]], fields=[a, b, c, proctime, rowtime])
+]]>
+    </Resource>
+  </TestCase>
+  <TestCase name="testJoinTemporalTableWithProjectionPushDown[LegacyTableSource=true, partitionedJoin=true]">
+    <Resource name="sql">
+      <![CDATA[
+SELECT T.*, D.id
+FROM MyTable AS T
+JOIN LookupTable /*+ PARTITIONED_JOIN */ FOR SYSTEM_TIME AS OF T.proctime AS D
+ON T.a = D.id
+      ]]>
+    </Resource>
+    <Resource name="ast">
+      <![CDATA[
+LogicalProject(a=[$0], b=[$1], c=[$2], proctime=[$3], rowtime=[$4], id=[$5])
++- LogicalCorrelate(correlation=[$cor0], joinType=[inner], requiredColumns=[{0, 3}])
+   :- LogicalTableScan(table=[[default_catalog, default_database, MyTable]])
+   +- LogicalFilter(condition=[=($cor0.a, $0)])
+      +- LogicalSnapshot(period=[$cor0.proctime])
+         +- LogicalTableScan(table=[[default_catalog, default_database, LookupTable, source: [TestTemporalTable(id, name, age)]]], hints=[[[PARTITIONED_JOIN inheritPath:[]]]])
+]]>
+    </Resource>
+    <Resource name="optimized exec plan">
+      <![CDATA[
+Calc(select=[a, b, c, PROCTIME_MATERIALIZE(proctime) AS proctime, rowtime, id])
++- LookupJoin(table=[default_catalog.default_database.LookupTable], joinType=[InnerJoin], async=[false], lookup=[id=a], select=[a, b, c, proctime, rowtime, id])
+   +- Exchange(distribution=[hash[a]])
+      +- DataStreamScan(table=[[default_catalog, default_database, MyTable]], fields=[a, b, c, proctime, rowtime])
+]]>
+    </Resource>
+  </TestCase>
+  <TestCase name="testJoinTemporalTableWithUdfEqualFilter[LegacyTableSource=false, partitionedJoin=false]">
+    <Resource name="sql">
+      <![CDATA[
+SELECT
+  T.a, T.b, T.c, D.name
+FROM
+  MyTable AS T JOIN LookupTable
+FOR SYSTEM_TIME AS OF T.proctime AS D ON T.a = D.id
+WHERE CONCAT('Hello-', D.name) = 'Hello-Jark'
+      ]]>
+    </Resource>
+    <Resource name="ast">
+      <![CDATA[
+LogicalProject(a=[$0], b=[$1], c=[$2], name=[$6])
++- LogicalFilter(condition=[=(CONCAT(_UTF-16LE'Hello-', $6), _UTF-16LE'Hello-Jark')])
+   +- LogicalCorrelate(correlation=[$cor0], joinType=[inner], requiredColumns=[{0, 3}])
+      :- LogicalTableScan(table=[[default_catalog, default_database, MyTable]])
+      +- LogicalFilter(condition=[=($cor0.a, $0)])
+         +- LogicalSnapshot(period=[$cor0.proctime])
+            +- LogicalTableScan(table=[[default_catalog, default_database, LookupTable]])
+]]>
+    </Resource>
+    <Resource name="optimized exec plan">
+      <![CDATA[
+Calc(select=[a, b, c, name])
++- LookupJoin(table=[default_catalog.default_database.LookupTable], joinType=[InnerJoin], async=[false], lookup=[id=a], where=[(CONCAT('Hello-', name) = 'Hello-Jark')], select=[a, b, c, id, name])
+   +- Calc(select=[a, b, c])
+      +- DataStreamScan(table=[[default_catalog, default_database, MyTable]], fields=[a, b, c, proctime, rowtime])
+]]>
+    </Resource>
+  </TestCase>
+  <TestCase name="testJoinTemporalTableWithUdfEqualFilter[LegacyTableSource=false, partitionedJoin=true]">
+    <Resource name="sql">
+      <![CDATA[
+SELECT
+  T.a, T.b, T.c, D.name
+FROM
+  MyTable AS T JOIN LookupTable /*+ PARTITIONED_JOIN */
+FOR SYSTEM_TIME AS OF T.proctime AS D ON T.a = D.id
+WHERE CONCAT('Hello-', D.name) = 'Hello-Jark'
+      ]]>
+    </Resource>
+    <Resource name="ast">
+      <![CDATA[
+LogicalProject(a=[$0], b=[$1], c=[$2], name=[$6])
++- LogicalFilter(condition=[=(CONCAT(_UTF-16LE'Hello-', $6), _UTF-16LE'Hello-Jark')])
+   +- LogicalCorrelate(correlation=[$cor0], joinType=[inner], requiredColumns=[{0, 3}])
+      :- LogicalTableScan(table=[[default_catalog, default_database, MyTable]])
+      +- LogicalFilter(condition=[=($cor0.a, $0)])
+         +- LogicalSnapshot(period=[$cor0.proctime])
+            +- LogicalTableScan(table=[[default_catalog, default_database, LookupTable]], hints=[[[PARTITIONED_JOIN inheritPath:[]]]])
+]]>
+    </Resource>
+    <Resource name="optimized exec plan">
+      <![CDATA[
+Calc(select=[a, b, c, name])
++- LookupJoin(table=[default_catalog.default_database.LookupTable], joinType=[InnerJoin], async=[false], lookup=[id=a], where=[(CONCAT('Hello-', name) = 'Hello-Jark')], select=[a, b, c, id, name])
+   +- Exchange(distribution=[hash[a]])
+      +- Calc(select=[a, b, c])
+         +- DataStreamScan(table=[[default_catalog, default_database, MyTable]], fields=[a, b, c, proctime, rowtime])
+]]>
+    </Resource>
+  </TestCase>
+  <TestCase name="testJoinTemporalTableWithUdfEqualFilter[LegacyTableSource=true, partitionedJoin=false]">
+    <Resource name="sql">
+      <![CDATA[
+SELECT
+  T.a, T.b, T.c, D.name
+FROM
+  MyTable AS T JOIN LookupTable
+FOR SYSTEM_TIME AS OF T.proctime AS D ON T.a = D.id
+WHERE CONCAT('Hello-', D.name) = 'Hello-Jark'
+      ]]>
+    </Resource>
+    <Resource name="ast">
+      <![CDATA[
+LogicalProject(a=[$0], b=[$1], c=[$2], name=[$6])
++- LogicalFilter(condition=[=(CONCAT(_UTF-16LE'Hello-', $6), _UTF-16LE'Hello-Jark')])
+   +- LogicalCorrelate(correlation=[$cor0], joinType=[inner], requiredColumns=[{0, 3}])
+      :- LogicalTableScan(table=[[default_catalog, default_database, MyTable]])
+      +- LogicalFilter(condition=[=($cor0.a, $0)])
+         +- LogicalSnapshot(period=[$cor0.proctime])
+            +- LogicalTableScan(table=[[default_catalog, default_database, LookupTable, source: [TestTemporalTable(id, name, age)]]])
+]]>
+    </Resource>
+    <Resource name="optimized exec plan">
+      <![CDATA[
+Calc(select=[a, b, c, name])
++- LookupJoin(table=[default_catalog.default_database.LookupTable], joinType=[InnerJoin], async=[false], lookup=[id=a], where=[(CONCAT('Hello-', name) = 'Hello-Jark')], select=[a, b, c, id, name])
+   +- Calc(select=[a, b, c])
+      +- DataStreamScan(table=[[default_catalog, default_database, MyTable]], fields=[a, b, c, proctime, rowtime])
+]]>
+    </Resource>
+  </TestCase>
+  <TestCase name="testJoinTemporalTableWithUdfEqualFilter[LegacyTableSource=true, partitionedJoin=true]">
+    <Resource name="sql">
+      <![CDATA[
+SELECT
+  T.a, T.b, T.c, D.name
+FROM
+  MyTable AS T JOIN LookupTable /*+ PARTITIONED_JOIN */
+FOR SYSTEM_TIME AS OF T.proctime AS D ON T.a = D.id
+WHERE CONCAT('Hello-', D.name) = 'Hello-Jark'
+      ]]>
+    </Resource>
+    <Resource name="ast">
+      <![CDATA[
+LogicalProject(a=[$0], b=[$1], c=[$2], name=[$6])
++- LogicalFilter(condition=[=(CONCAT(_UTF-16LE'Hello-', $6), _UTF-16LE'Hello-Jark')])
+   +- LogicalCorrelate(correlation=[$cor0], joinType=[inner], requiredColumns=[{0, 3}])
+      :- LogicalTableScan(table=[[default_catalog, default_database, MyTable]])
+      +- LogicalFilter(condition=[=($cor0.a, $0)])
+         +- LogicalSnapshot(period=[$cor0.proctime])
+            +- LogicalTableScan(table=[[default_catalog, default_database, LookupTable, source: [TestTemporalTable(id, name, age)]]], hints=[[[PARTITIONED_JOIN inheritPath:[]]]])
+]]>
+    </Resource>
+    <Resource name="optimized exec plan">
+      <![CDATA[
+Calc(select=[a, b, c, name])
++- LookupJoin(table=[default_catalog.default_database.LookupTable], joinType=[InnerJoin], async=[false], lookup=[id=a], where=[(CONCAT('Hello-', name) = 'Hello-Jark')], select=[a, b, c, id, name])
+   +- Exchange(distribution=[hash[a]])
+      +- Calc(select=[a, b, c])
+         +- DataStreamScan(table=[[default_catalog, default_database, MyTable]], fields=[a, b, c, proctime, rowtime])
+]]>
+    </Resource>
+  </TestCase>
+  <TestCase name="testLeftJoinTemporalTable[LegacyTableSource=false, partitionedJoin=false]">
+    <Resource name="sql">
+      <![CDATA[
+SELECT * FROM MyTable AS T LEFT JOIN LookupTable
+FOR SYSTEM_TIME AS OF T.proctime AS D ON T.a = D.id
+]]>
+    </Resource>
+    <Resource name="ast">
+      <![CDATA[
+LogicalProject(a=[$0], b=[$1], c=[$2], proctime=[$3], rowtime=[$4], id=[$5], name=[$6], age=[$7])
++- LogicalCorrelate(correlation=[$cor0], joinType=[left], requiredColumns=[{0, 3}])
+   :- LogicalTableScan(table=[[default_catalog, default_database, MyTable]])
+   +- LogicalFilter(condition=[=($cor0.a, $0)])
+      +- LogicalSnapshot(period=[$cor0.proctime])
+         +- LogicalTableScan(table=[[default_catalog, default_database, LookupTable]])
 ]]>
     </Resource>
     <Resource name="optimized exec plan">
@@ -685,96 +1609,12 @@ Calc(select=[a, b, c, PROCTIME_MATERIALIZE(proctime) AS proctime, rowtime, id, n
 ]]>
     </Resource>
   </TestCase>
-  <TestCase name="testJoinTemporalTableWithProjectionPushDown[LegacyTableSource=true]">
+  <TestCase name="testLeftJoinTemporalTable[LegacyTableSource=false, partitionedJoin=true]">
     <Resource name="sql">
       <![CDATA[
-SELECT T.*, D.id
-FROM MyTable AS T
-JOIN LookupTable FOR SYSTEM_TIME AS OF T.proctime AS D
-ON T.a = D.id
-      ]]>
-    </Resource>
-    <Resource name="ast">
-      <![CDATA[
-LogicalProject(a=[$0], b=[$1], c=[$2], proctime=[$3], rowtime=[$4], id=[$5])
-+- LogicalCorrelate(correlation=[$cor0], joinType=[inner], requiredColumns=[{0, 3}])
-   :- LogicalTableScan(table=[[default_catalog, default_database, MyTable]])
-   +- LogicalFilter(condition=[=($cor0.a, $0)])
-      +- LogicalSnapshot(period=[$cor0.proctime])
-         +- LogicalTableScan(table=[[default_catalog, default_database, LookupTable, source: [TestTemporalTable(id, name, age)]]])
+SELECT * FROM MyTable AS T LEFT JOIN LookupTable /*+ PARTITIONED_JOIN */
+FOR SYSTEM_TIME AS OF T.proctime AS D ON T.a = D.id
 ]]>
-    </Resource>
-    <Resource name="optimized exec plan">
-      <![CDATA[
-Calc(select=[a, b, c, PROCTIME_MATERIALIZE(proctime) AS proctime, rowtime, id])
-+- LookupJoin(table=[default_catalog.default_database.LookupTable], joinType=[InnerJoin], async=[false], lookup=[id=a], select=[a, b, c, proctime, rowtime, id])
-   +- DataStreamScan(table=[[default_catalog, default_database, MyTable]], fields=[a, b, c, proctime, rowtime])
-]]>
-    </Resource>
-  </TestCase>
-  <TestCase name="testJoinTemporalTableWithUdfEqualFilter[LegacyTableSource=false]">
-    <Resource name="sql">
-      <![CDATA[
-SELECT
-  T.a, T.b, T.c, D.name
-FROM
-  MyTable AS T JOIN LookupTable FOR SYSTEM_TIME AS OF T.proctime AS D ON T.a = D.id
-WHERE CONCAT('Hello-', D.name) = 'Hello-Jark'
-      ]]>
-    </Resource>
-    <Resource name="ast">
-      <![CDATA[
-LogicalProject(a=[$0], b=[$1], c=[$2], name=[$6])
-+- LogicalFilter(condition=[=(CONCAT(_UTF-16LE'Hello-', $6), _UTF-16LE'Hello-Jark')])
-   +- LogicalCorrelate(correlation=[$cor0], joinType=[inner], requiredColumns=[{0, 3}])
-      :- LogicalTableScan(table=[[default_catalog, default_database, MyTable]])
-      +- LogicalFilter(condition=[=($cor0.a, $0)])
-         +- LogicalSnapshot(period=[$cor0.proctime])
-            +- LogicalTableScan(table=[[default_catalog, default_database, LookupTable]])
-]]>
-    </Resource>
-    <Resource name="optimized exec plan">
-      <![CDATA[
-Calc(select=[a, b, c, name])
-+- LookupJoin(table=[default_catalog.default_database.LookupTable], joinType=[InnerJoin], async=[false], lookup=[id=a], where=[(CONCAT('Hello-', name) = 'Hello-Jark')], select=[a, b, c, id, name])
-   +- Calc(select=[a, b, c])
-      +- DataStreamScan(table=[[default_catalog, default_database, MyTable]], fields=[a, b, c, proctime, rowtime])
-]]>
-    </Resource>
-  </TestCase>
-  <TestCase name="testJoinTemporalTableWithUdfEqualFilter[LegacyTableSource=true]">
-    <Resource name="sql">
-      <![CDATA[
-SELECT
-  T.a, T.b, T.c, D.name
-FROM
-  MyTable AS T JOIN LookupTable FOR SYSTEM_TIME AS OF T.proctime AS D ON T.a = D.id
-WHERE CONCAT('Hello-', D.name) = 'Hello-Jark'
-      ]]>
-    </Resource>
-    <Resource name="ast">
-      <![CDATA[
-LogicalProject(a=[$0], b=[$1], c=[$2], name=[$6])
-+- LogicalFilter(condition=[=(CONCAT(_UTF-16LE'Hello-', $6), _UTF-16LE'Hello-Jark')])
-   +- LogicalCorrelate(correlation=[$cor0], joinType=[inner], requiredColumns=[{0, 3}])
-      :- LogicalTableScan(table=[[default_catalog, default_database, MyTable]])
-      +- LogicalFilter(condition=[=($cor0.a, $0)])
-         +- LogicalSnapshot(period=[$cor0.proctime])
-            +- LogicalTableScan(table=[[default_catalog, default_database, LookupTable, source: [TestTemporalTable(id, name, age)]]])
-]]>
-    </Resource>
-    <Resource name="optimized exec plan">
-      <![CDATA[
-Calc(select=[a, b, c, name])
-+- LookupJoin(table=[default_catalog.default_database.LookupTable], joinType=[InnerJoin], async=[false], lookup=[id=a], where=[(CONCAT('Hello-', name) = 'Hello-Jark')], select=[a, b, c, id, name])
-   +- Calc(select=[a, b, c])
-      +- DataStreamScan(table=[[default_catalog, default_database, MyTable]], fields=[a, b, c, proctime, rowtime])
-]]>
-    </Resource>
-  </TestCase>
-  <TestCase name="testLeftJoinTemporalTable[LegacyTableSource=false]">
-    <Resource name="sql">
-      <![CDATA[SELECT * FROM MyTable AS T LEFT JOIN LookupTable FOR SYSTEM_TIME AS OF T.proctime AS D ON T.a = D.id]]>
     </Resource>
     <Resource name="ast">
       <![CDATA[
@@ -783,7 +1623,33 @@ LogicalProject(a=[$0], b=[$1], c=[$2], proctime=[$3], rowtime=[$4], id=[$5], nam
    :- LogicalTableScan(table=[[default_catalog, default_database, MyTable]])
    +- LogicalFilter(condition=[=($cor0.a, $0)])
       +- LogicalSnapshot(period=[$cor0.proctime])
-         +- LogicalTableScan(table=[[default_catalog, default_database, LookupTable]])
+         +- LogicalTableScan(table=[[default_catalog, default_database, LookupTable]], hints=[[[PARTITIONED_JOIN inheritPath:[]]]])
+]]>
+    </Resource>
+    <Resource name="optimized exec plan">
+      <![CDATA[
+Calc(select=[a, b, c, PROCTIME_MATERIALIZE(proctime) AS proctime, rowtime, id, name, age])
++- LookupJoin(table=[default_catalog.default_database.LookupTable], joinType=[LeftOuterJoin], async=[false], lookup=[id=a], select=[a, b, c, proctime, rowtime, id, name, age])
+   +- Exchange(distribution=[hash[a]])
+      +- DataStreamScan(table=[[default_catalog, default_database, MyTable]], fields=[a, b, c, proctime, rowtime])
+]]>
+    </Resource>
+  </TestCase>
+  <TestCase name="testLeftJoinTemporalTable[LegacyTableSource=true, partitionedJoin=false]">
+    <Resource name="sql">
+      <![CDATA[
+SELECT * FROM MyTable AS T LEFT JOIN LookupTable
+FOR SYSTEM_TIME AS OF T.proctime AS D ON T.a = D.id
+]]>
+    </Resource>
+    <Resource name="ast">
+      <![CDATA[
+LogicalProject(a=[$0], b=[$1], c=[$2], proctime=[$3], rowtime=[$4], id=[$5], name=[$6], age=[$7])
++- LogicalCorrelate(correlation=[$cor0], joinType=[left], requiredColumns=[{0, 3}])
+   :- LogicalTableScan(table=[[default_catalog, default_database, MyTable]])
+   +- LogicalFilter(condition=[=($cor0.a, $0)])
+      +- LogicalSnapshot(period=[$cor0.proctime])
+         +- LogicalTableScan(table=[[default_catalog, default_database, LookupTable, source: [TestTemporalTable(id, name, age)]]])
 ]]>
     </Resource>
     <Resource name="optimized exec plan">


### PR DESCRIPTION
## What is the purpose of the change

In order to raise cache hit ratio, we could enforce input of lookup join to shuffle by join key.
Introduce a hint to enable partitioned lookup join.


## Brief change log

  - Update `FlinkHints` and `FlinkHintStrategies` to introduce partitioned join hint
  - Update related rule, to enforce hash distribution on input, including `BatchPhysicalLookupJoinRule` and `StreamPhysicalLookupJoinRule`

## Verifying this change

  - Plan test in batch `LookupJoinTest` and stream `LookupJoinTest`
  - IT cast in batch `LookupJoinITCase` and stream `LookupJoinITCase` and `AsyncLookupJoinITCase`

## Does this pull request potentially affect one of the following parts:

  - Dependencies (does it add or upgrade a dependency): no
  - The public API, i.e., is any changed class annotated with `@Public(Evolving)`: no
  - The serializers: no
  - The runtime per-record code paths (performance sensitive): no
  - Anything that affects deployment or recovery: JobManager (and its components), Checkpointing, Kubernetes/Yarn, ZooKeeper: no
  - The S3 file system connector: no

## Documentation

  - Does this pull request introduce a new feature? yes
  - If yes, how is the feature documented? (docs)
