### PR TITLE
[FLINK-20286][connector-files] Support directory watching in filesystem table source

### DIFF
--- a/docs/content/docs/connectors/table/filesystem.md
+++ b/docs/content/docs/connectors/table/filesystem.md
@@ -127,12 +127,15 @@ You can modify the watch interval using the following option.
   <tbody>
     <tr>
         <td><h5>source.monitor-interval</h5></td>
-        <td style="word-wrap: break-word;">1 min</td>
+        <td style="word-wrap: break-word;">(none)</td>
         <td>Duration</td>
         <td>The interval in which the source checks for new files. 
+        Each file is uniquely identified by its path, and will be processed once, as soon as it's discovered. 
+        The set of files already processed is kept in state during the whole lifecycle of the source, 
+        so it's persisted in checkpoints and savepoints together with the source state. 
         Shorter intervals mean that files are discovered more quickly, 
         but also imply more frequent listing or directory traversal of the file system / object store. 
-        This option is used only if the execution mode is STREAMING.</td>
+        If this config option is empty, the provided path will be scanned once, hence the source will be bounded.</td>
     </tr>
   </tbody>
 </table>

--- a/docs/content/docs/connectors/table/filesystem.md
+++ b/docs/content/docs/connectors/table/filesystem.md
@@ -109,6 +109,34 @@ The file system connector can be used to read single files or entire directories
 
 When using a directory as the source path, there is **no defined order of ingestion** for the files inside the directory.
 
+### Directory watching
+
+The file system connector automatically watches the input directory when the runtime mode is configured as STREAMING.
+
+You can modify the watch interval using the following option.
+
+<table class="table table-bordered">
+  <thead>
+    <tr>
+        <th class="text-left" style="width: 20%">Key</th>
+        <th class="text-left" style="width: 15%">Default</th>
+        <th class="text-left" style="width: 10%">Type</th>
+        <th class="text-left" style="width: 55%">Description</th>
+    </tr>
+  </thead>
+  <tbody>
+    <tr>
+        <td><h5>source.monitor-interval</h5></td>
+        <td style="word-wrap: break-word;">1 min</td>
+        <td>Duration</td>
+        <td>The interval in which the source checks for new files. 
+        Shorter intervals mean that files are discovered more quickly, 
+        but also imply more frequent listing or directory traversal of the file system / object store. 
+        This option is used only if the execution mode is STREAMING.</td>
+    </tr>
+  </tbody>
+</table>
+
 ### Available Metadata
 
 The following connector metadata can be accessed as metadata columns in a table definition. All the metadata are read only.

--- a/docs/content/docs/connectors/table/filesystem.md
+++ b/docs/content/docs/connectors/table/filesystem.md
@@ -129,13 +129,13 @@ You can modify the watch interval using the following option.
         <td><h5>source.monitor-interval</h5></td>
         <td style="word-wrap: break-word;">(none)</td>
         <td>Duration</td>
-        <td>The interval in which the source checks for new files. 
+        <td>The interval in which the source checks for new files. The interval must be greater than 0. 
         Each file is uniquely identified by its path, and will be processed once, as soon as it's discovered. 
         The set of files already processed is kept in state during the whole lifecycle of the source, 
         so it's persisted in checkpoints and savepoints together with the source state. 
         Shorter intervals mean that files are discovered more quickly, 
         but also imply more frequent listing or directory traversal of the file system / object store. 
-        If this config option is empty, the provided path will be scanned once, hence the source will be bounded.</td>
+        If this config option is not set, the provided path will be scanned once, hence the source will be bounded.</td>
     </tr>
   </tbody>
 </table>

--- a/flink-connectors/flink-connector-files/src/main/java/org/apache/flink/connector/file/table/FileSystemConnectorOptions.java
+++ b/flink-connectors/flink-connector-files/src/main/java/org/apache/flink/connector/file/table/FileSystemConnectorOptions.java
@@ -51,13 +51,13 @@ public class FileSystemConnectorOptions {
                     .durationType()
                     .noDefaultValue()
                     .withDescription(
-                            "The interval in which the source checks for new files. "
+                            "The interval in which the source checks for new files. The interval must be greater than 0. "
                                     + "Each file is uniquely identified by its path, and will be processed once, as soon as it's discovered. "
                                     + "The set of files already processed is kept in state during the whole lifecycle of the source, "
                                     + "so it's persisted in checkpoints and savepoints together with the source state. "
                                     + "Shorter intervals mean that files are discovered more quickly, "
                                     + "but also imply more frequent listing or directory traversal of the file system / object store. "
-                                    + "If this config option is empty, the provided path will be scanned once, hence the source will be bounded.");
+                                    + "If this config option is not set, the provided path will be scanned once, hence the source will be bounded.");
 
     public static final ConfigOption<MemorySize> SINK_ROLLING_POLICY_FILE_SIZE =
             key("sink.rolling-policy.file-size")

--- a/flink-connectors/flink-connector-files/src/main/java/org/apache/flink/connector/file/table/FileSystemConnectorOptions.java
+++ b/flink-connectors/flink-connector-files/src/main/java/org/apache/flink/connector/file/table/FileSystemConnectorOptions.java
@@ -46,15 +46,18 @@ public class FileSystemConnectorOptions {
                             "The default partition name in case the dynamic partition"
                                     + " column value is null/empty string.");
 
-    public static final ConfigOption<Duration> SOURCE_WATCH_INTERVAL =
+    public static final ConfigOption<Duration> SOURCE_MONITOR_INTERVAL =
             key("source.monitor-interval")
                     .durationType()
-                    .defaultValue(Duration.ofMinutes(1))
+                    .noDefaultValue()
                     .withDescription(
                             "The interval in which the source checks for new files. "
+                                    + "Each file is uniquely identified by its path, and will be processed once, as soon as it's discovered. "
+                                    + "The set of files already processed is kept in state during the whole lifecycle of the source, "
+                                    + "so it's persisted in checkpoints and savepoints together with the source state. "
                                     + "Shorter intervals mean that files are discovered more quickly, "
-                                    + "but also imply more frequent listing or directory traversal of the file system / object store."
-                                    + "This option is used only if the execution mode is STREAMING.");
+                                    + "but also imply more frequent listing or directory traversal of the file system / object store. "
+                                    + "If this config option is empty, the provided path will be scanned once, hence the source will be bounded.");
 
     public static final ConfigOption<MemorySize> SINK_ROLLING_POLICY_FILE_SIZE =
             key("sink.rolling-policy.file-size")

--- a/flink-connectors/flink-connector-files/src/main/java/org/apache/flink/connector/file/table/FileSystemConnectorOptions.java
+++ b/flink-connectors/flink-connector-files/src/main/java/org/apache/flink/connector/file/table/FileSystemConnectorOptions.java
@@ -46,6 +46,16 @@ public class FileSystemConnectorOptions {
                             "The default partition name in case the dynamic partition"
                                     + " column value is null/empty string.");
 
+    public static final ConfigOption<Duration> SOURCE_WATCH_INTERVAL =
+            key("source.monitor-interval")
+                    .durationType()
+                    .defaultValue(Duration.ofMinutes(1))
+                    .withDescription(
+                            "The interval in which the source checks for new files. "
+                                    + "Shorter intervals mean that files are discovered more quickly, "
+                                    + "but also imply more frequent listing or directory traversal of the file system / object store."
+                                    + "This option is used only if the execution mode is STREAMING.");
+
     public static final ConfigOption<MemorySize> SINK_ROLLING_POLICY_FILE_SIZE =
             key("sink.rolling-policy.file-size")
                     .memoryType()

--- a/flink-connectors/flink-connector-files/src/main/java/org/apache/flink/connector/file/table/FileSystemTableFactory.java
+++ b/flink-connectors/flink-connector-files/src/main/java/org/apache/flink/connector/file/table/FileSystemTableFactory.java
@@ -101,7 +101,7 @@ public class FileSystemTableFactory implements DynamicTableSourceFactory, Dynami
     public Set<ConfigOption<?>> optionalOptions() {
         Set<ConfigOption<?>> options = new HashSet<>();
         options.add(FileSystemConnectorOptions.PARTITION_DEFAULT_NAME);
-        options.add(FileSystemConnectorOptions.SOURCE_WATCH_INTERVAL);
+        options.add(FileSystemConnectorOptions.SOURCE_MONITOR_INTERVAL);
         options.add(FileSystemConnectorOptions.SINK_ROLLING_POLICY_FILE_SIZE);
         options.add(FileSystemConnectorOptions.SINK_ROLLING_POLICY_ROLLOVER_INTERVAL);
         options.add(FileSystemConnectorOptions.SINK_ROLLING_POLICY_CHECK_INTERVAL);

--- a/flink-connectors/flink-connector-files/src/main/java/org/apache/flink/connector/file/table/FileSystemTableFactory.java
+++ b/flink-connectors/flink-connector-files/src/main/java/org/apache/flink/connector/file/table/FileSystemTableFactory.java
@@ -101,6 +101,7 @@ public class FileSystemTableFactory implements DynamicTableSourceFactory, Dynami
     public Set<ConfigOption<?>> optionalOptions() {
         Set<ConfigOption<?>> options = new HashSet<>();
         options.add(FileSystemConnectorOptions.PARTITION_DEFAULT_NAME);
+        options.add(FileSystemConnectorOptions.SOURCE_WATCH_INTERVAL);
         options.add(FileSystemConnectorOptions.SINK_ROLLING_POLICY_FILE_SIZE);
         options.add(FileSystemConnectorOptions.SINK_ROLLING_POLICY_ROLLOVER_INTERVAL);
         options.add(FileSystemConnectorOptions.SINK_ROLLING_POLICY_CHECK_INTERVAL);

--- a/flink-connectors/flink-connector-files/src/main/java/org/apache/flink/connector/file/table/FileSystemTableSource.java
+++ b/flink-connectors/flink-connector-files/src/main/java/org/apache/flink/connector/file/table/FileSystemTableSource.java
@@ -19,12 +19,10 @@
 package org.apache.flink.connector.file.table;
 
 import org.apache.flink.annotation.Internal;
-import org.apache.flink.api.common.RuntimeExecutionMode;
 import org.apache.flink.api.common.io.InputFormat;
 import org.apache.flink.api.common.serialization.DeserializationSchema;
 import org.apache.flink.api.java.io.CollectionInputFormat;
 import org.apache.flink.configuration.Configuration;
-import org.apache.flink.configuration.ExecutionOptions;
 import org.apache.flink.configuration.ReadableConfig;
 import org.apache.flink.connector.file.src.FileSource;
 import org.apache.flink.connector.file.src.FileSourceSplit;
@@ -274,15 +272,12 @@ public class FileSystemTableSource extends AbstractFileSystemTable
     }
 
     private SourceProvider createSourceProvider(BulkFormat<RowData, FileSourceSplit> bulkFormat) {
-        FileSource.FileSourceBuilder<RowData> fileSourceBuilder =
+        final FileSource.FileSourceBuilder<RowData> fileSourceBuilder =
                 FileSource.forBulkFileFormat(bulkFormat, paths());
 
-        // If streaming, enable directory watching
-        if (tableOptions.get(ExecutionOptions.RUNTIME_MODE) == RuntimeExecutionMode.STREAMING) {
-            fileSourceBuilder =
-                    fileSourceBuilder.monitorContinuously(
-                            tableOptions.get(FileSystemConnectorOptions.SOURCE_WATCH_INTERVAL));
-        }
+        tableOptions
+                .getOptional(FileSystemConnectorOptions.SOURCE_MONITOR_INTERVAL)
+                .ifPresent(fileSourceBuilder::monitorContinuously);
 
         return SourceProvider.of(fileSourceBuilder.build());
     }

--- a/flink-table/flink-table-planner/src/test/java/org/apache/flink/connector/file/table/FileSystemTableSinkStreamingTest.java
+++ b/flink-table/flink-table-planner/src/test/java/org/apache/flink/connector/file/table/FileSystemTableSinkStreamingTest.java
@@ -1,0 +1,94 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.flink.connector.file.table;
+
+import org.apache.flink.table.api.DataTypes;
+import org.apache.flink.table.api.Schema;
+import org.apache.flink.table.api.TableDescriptor;
+import org.apache.flink.table.planner.runtime.utils.StreamingTestBase;
+import org.apache.flink.types.Row;
+import org.apache.flink.util.CloseableIterator;
+
+import org.junit.Test;
+
+import java.io.File;
+import java.nio.file.Files;
+import java.nio.file.Paths;
+import java.nio.file.StandardOpenOption;
+import java.time.Duration;
+import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.List;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+/** Test of the filesystem source in streaming mode. */
+public class FileSystemTableSinkStreamingTest extends StreamingTestBase {
+
+    @Test
+    public void testMonitorContinuously() throws Exception {
+        // Create temp dir
+        File testPath = TEMPORARY_FOLDER.newFolder();
+
+        // Write first csv file out
+        Files.write(
+                Paths.get(testPath.getPath(), "input_0.csv"),
+                Arrays.asList("1", "2", "3"),
+                StandardOpenOption.CREATE);
+
+        Duration monitorInterval = Duration.ofSeconds(1);
+
+        tEnv().createTable(
+                        "my_streaming_table",
+                        TableDescriptor.forConnector("filesystem")
+                                .schema(Schema.newBuilder().column("data", DataTypes.INT()).build())
+                                .format("testcsv")
+                                .option(FileSystemConnectorOptions.PATH, testPath.getPath())
+                                .option(
+                                        FileSystemConnectorOptions.SOURCE_WATCH_INTERVAL,
+                                        monitorInterval)
+                                .build());
+
+        CloseableIterator<Row> resultsIterator =
+                tEnv().sqlQuery("SELECT * FROM my_streaming_table").execute().collect();
+
+        List<Integer> actual = new ArrayList<>();
+
+        // Iterate over the first 3 rows
+        for (int i = 0; i < 3; i++) {
+            actual.add(resultsIterator.next().<Integer>getFieldAs(0));
+        }
+
+        // Write second csv file out
+        Files.write(
+                Paths.get(testPath.getPath(), "input_1.csv"),
+                Arrays.asList("4", "5", "6"),
+                StandardOpenOption.CREATE);
+
+        // Iterate over the next 3 rows
+        for (int i = 0; i < 3; i++) {
+            actual.add(resultsIterator.next().<Integer>getFieldAs(0));
+        }
+
+        // Close the streaming query
+        resultsIterator.close();
+
+        assertThat(actual).containsExactlyInAnyOrder(1, 2, 3, 4, 5, 6);
+    }
+}


### PR DESCRIPTION
## What is the purpose of the change

This PR exposes the monitor continuously feature provided by `FileSource` when using the filesystem connector in table api

## Brief change log

* Expose the monitor continuously feature of FileSource
* Test
* Documentation 

## Verifying this change

Added an integration test.

## Does this pull request potentially affect one of the following parts:

  - Dependencies (does it add or upgrade a dependency): no
  - The public API, i.e., is any changed class annotated with `@Public(Evolving)`: yes
  - The serializers: no
  - The runtime per-record code paths (performance sensitive): no
  - Anything that affects deployment or recovery: JobManager (and its components), Checkpointing, Kubernetes/Yarn, ZooKeeper: no
  - The S3 file system connector: no

## Documentation

  - Does this pull request introduce a new feature? yes
  - If yes, how is the feature documented? docs
