### PR TITLE
[hotfix][doc] fix typo of 'note that' and 'now that' 

### DIFF
--- a/flink-core/src/main/java/org/apache/flink/api/common/state/CheckpointListener.java
+++ b/flink-core/src/main/java/org/apache/flink/api/common/state/CheckpointListener.java
@@ -117,7 +117,7 @@ public interface CheckpointListener {
      *
      * @param checkpointId The ID of the checkpoint that has been completed.
      * @throws Exception This method can propagate exceptions, which leads to a failure/recovery for
-     *     the task. Not that this will NOT lead to the checkpoint being revoked.
+     *     the task. Note that this will NOT lead to the checkpoint being revoked.
      */
     void notifyCheckpointComplete(long checkpointId) throws Exception;
 

--- a/flink-runtime/src/test/java/org/apache/flink/runtime/operators/testutils/BinaryOperatorTestBase.java
+++ b/flink-runtime/src/test/java/org/apache/flink/runtime/operators/testutils/BinaryOperatorTestBase.java
@@ -287,7 +287,7 @@ public abstract class BinaryOperatorTestBase<S extends Function, IN, OUT> extend
         this.running = false;
 
         // compensate for races, where cancel is called before the driver is set
-        // not that this is an artifact of a bad design of this test base, where the setup
+        // note that this is an artifact of a bad design of this test base, where the setup
         // of the basic properties is not separated from the invocation of the execution logic
         while (this.driver == null) {
             Thread.sleep(200);

--- a/flink-runtime/src/test/java/org/apache/flink/runtime/operators/testutils/DriverTestBase.java
+++ b/flink-runtime/src/test/java/org/apache/flink/runtime/operators/testutils/DriverTestBase.java
@@ -294,7 +294,7 @@ public abstract class DriverTestBase<S extends Function> extends TestLogger
         this.running = false;
 
         // compensate for races, where cancel is called before the driver is set
-        // not that this is an artifact of a bad design of this test base, where the setup
+        // note that this is an artifact of a bad design of this test base, where the setup
         // of the basic properties is not separated from the invocation of the execution logic
         while (this.driver == null) {
             Thread.sleep(200);

--- a/flink-state-backends/flink-statebackend-changelog/src/main/java/org/apache/flink/state/changelog/StateChangeLogger.java
+++ b/flink-state-backends/flink-statebackend-changelog/src/main/java/org/apache/flink/state/changelog/StateChangeLogger.java
@@ -28,7 +28,7 @@ import java.io.IOException;
  * Logs changes to a state created by {@link ChangelogKeyedStateBackend}. The changes are intended
  * to be stored durably, included into a checkpoint and replayed on recovery in case of failure.
  *
- * <p>Not that the order of updating the delegated state and logging it using this class usually
+ * <p>Note that the order of updating the delegated state and logging it using this class usually
  * doesn't matter. However in some cases an already updated state needs to be logged. Besides that,
  * delegated state update is usually local and would fail faster. Therefore, consider updating the
  * delegated state first and logging the change second.

--- a/flink-streaming-java/src/main/java/org/apache/flink/streaming/api/datastream/DataStreamUtils.java
+++ b/flink-streaming-java/src/main/java/org/apache/flink/streaming/api/datastream/DataStreamUtils.java
@@ -122,7 +122,7 @@ public final class DataStreamUtils {
         final ClientAndIterator<E> clientAndIterator = collectWithClient(stream, jobName);
         final List<E> result = collectRecordsFromUnboundedStream(clientAndIterator, numElements);
 
-        // cancel the job not that we have received enough elements
+        // cancel the job now that we have received enough elements
         clientAndIterator.client.cancel().get();
 
         return result;

--- a/flink-streaming-scala/src/main/scala/org/apache/flink/streaming/api/scala/AllWindowedStream.scala
+++ b/flink-streaming-scala/src/main/scala/org/apache/flink/streaming/api/scala/AllWindowedStream.scala
@@ -395,7 +395,7 @@ class AllWindowedStream[T, W <: Window](javaStream: JavaAllWStream[T, W]) {
    * evaluation of the window for each key individually. The output of the window function is
    * interpreted as a regular non-windowed stream.
    *
-   * Not that this function requires that all data in the windows is buffered until the window
+   * Note that this function requires that all data in the windows is buffered until the window
    * is evaluated, as the function provides no means of pre-aggregation.
    *
    * @param function The process window function.
@@ -416,7 +416,7 @@ class AllWindowedStream[T, W <: Window](javaStream: JavaAllWStream[T, W]) {
    * evaluation of the window for each key individually. The output of the window function is
    * interpreted as a regular non-windowed stream.
    *
-   * Not that this function requires that all data in the windows is buffered until the window
+   * Note that this function requires that all data in the windows is buffered until the window
    * is evaluated, as the function provides no means of pre-aggregation.
    *
    * @param function The window function.
@@ -436,7 +436,7 @@ class AllWindowedStream[T, W <: Window](javaStream: JavaAllWStream[T, W]) {
    * evaluation of the window for each key individually. The output of the window function is
    * interpreted as a regular non-windowed stream.
    *
-   * Not that this function requires that all data in the windows is buffered until the window
+   * Note that this function requires that all data in the windows is buffered until the window
    * is evaluated, as the function provides no means of pre-aggregation.
    *
    * @param function The window function.

--- a/flink-streaming-scala/src/main/scala/org/apache/flink/streaming/api/scala/WindowedStream.scala
+++ b/flink-streaming-scala/src/main/scala/org/apache/flink/streaming/api/scala/WindowedStream.scala
@@ -374,7 +374,7 @@ class WindowedStream[T, K, W <: Window](javaStream: JavaWStream[T, K, W]) {
     * evaluation of the window for each key individually. The output of the window function is
     * interpreted as a regular non-windowed stream.
     *
-    * Not that this function requires that all data in the windows is buffered until the window
+    * Note that this function requires that all data in the windows is buffered until the window
     * is evaluated, as the function provides no means of pre-aggregation.
     *
     * @param function The window function.
@@ -394,7 +394,7 @@ class WindowedStream[T, K, W <: Window](javaStream: JavaWStream[T, K, W]) {
    * evaluation of the window for each key individually. The output of the window function is
    * interpreted as a regular non-windowed stream.
    *
-   * Not that this function requires that all data in the windows is buffered until the window
+   * Note that this function requires that all data in the windows is buffered until the window
    * is evaluated, as the function provides no means of pre-aggregation.
    *
    * @param function The window function.
@@ -413,7 +413,7 @@ class WindowedStream[T, K, W <: Window](javaStream: JavaWStream[T, K, W]) {
    * evaluation of the window for each key individually. The output of the window function is
    * interpreted as a regular non-windowed stream.
    *
-   * Not that this function requires that all data in the windows is buffered until the window
+   * Note that this function requires that all data in the windows is buffered until the window
    * is evaluated, as the function provides no means of pre-aggregation.
    *
    * @param function The window function.


### PR DESCRIPTION
<!--
*Thank you very much for contributing to Apache Flink - we are happy that you want to help us improve Flink. To help the community review your contribution in the best possible way, please go through the checklist below, which will get the contribution into a shape in which it can be best reviewed.*

*Please understand that we do not do this to make contributions to Flink a hassle. In order to uphold a high standard of quality for code contributions, while at the same time managing a large number of contributions, we need contributors to prepare the contributions well, and give reviewers enough contextual information for the review. Please also understand that contributions that do not follow this guide will take longer to review and thus typically be picked up with lower priority by the community.*

## Contribution Checklist

  - Make sure that the pull request corresponds to a [JIRA issue](https://issues.apache.org/jira/projects/FLINK/issues). Exceptions are made for typos in JavaDoc or documentation files, which need no JIRA issue.
  
  - Name the pull request in the form "[FLINK-XXXX] [component] Title of the pull request", where *FLINK-XXXX* should be replaced by the actual issue number. Skip *component* if you are unsure about which is the best component.
  Typo fixes that have no associated JIRA issue should be named following this pattern: `[hotfix] [docs] Fix typo in event time introduction` or `[hotfix] [javadocs] Expand JavaDoc for PuncuatedWatermarkGenerator`.

  - Fill out the template below to describe the changes contributed by the pull request. That will give reviewers the context they need to do the review.
  
  - Make sure that the change passes the automated tests, i.e., `mvn clean verify` passes. You can set up Azure Pipelines CI to do that following [this guide](https://cwiki.apache.org/confluence/display/FLINK/Azure+Pipelines#AzurePipelines-Tutorial:SettingupAzurePipelinesforaforkoftheFlinkrepository).

  - Each pull request should address only one issue, not mix up code from multiple issues.
  
  - Each commit in the pull request has a meaningful commit message (including the JIRA id)

  - Once all items of the checklist are addressed, remove the above text and this checklist, leaving only the filled out template below.


**(The sections below can be removed for hotfixes of typos)**
-->

## What is the purpose of the change

*I found some spelling errors,  Some 'note that' words was written as 'not that' and som 'now that' words was written as 'no that' .  If not corrected, it may cause misunderstandings*


## Brief change log

  - b3736ea54f18c499c3c4d8bbf24bbce17e02adbc  


## Verifying this change
Just a hotfix , no need to add test. 
 
## Does this pull request potentially affect one of the following parts:

  - Dependencies (does it add or upgrade a dependency): (no)
  - The public API, i.e., is any changed class annotated with `@Public(Evolving)`: (no)
  - The serializers: (no)
  - The runtime per-record code paths (performance sensitive): (no)
  - Anything that affects deployment or recovery: JobManager (and its components), Checkpointing, Kubernetes/Yarn, ZooKeeper: (no)
  - The S3 file system connector: (no)

## Documentation

  - Does this pull request introduce a new feature? (no)