### PR TITLE
[FLINK-25341][table-planner] Add StructuredToStringCastRule to support user POJO toString implementation

### DIFF
--- a/flink-table/flink-table-planner/src/main/java/org/apache/flink/table/planner/functions/casting/ArrayToArrayCastRule.java
+++ b/flink-table/flink-table-planner/src/main/java/org/apache/flink/table/planner/functions/casting/ArrayToArrayCastRule.java
@@ -78,12 +78,11 @@ class ArrayToArrayCastRule extends AbstractNullAwareCodeGeneratorCastRule<ArrayD
                         arraySize,
                         (index, loopWriter) -> {
                             CastCodeBlock codeBlock =
-                                    CastRuleProvider.generateCodeBlock(
+                                    // Null check is done at the array access level
+                                    CastRuleProvider.generateAlwaysNonNullCodeBlock(
                                             context,
                                             rowFieldReadAccess(index, inputTerm, innerInputType),
-                                            "false",
-                                            // Null check is done at the array access level
-                                            innerInputType.copy(false),
+                                            innerInputType,
                                             innerTargetType);
 
                             if (innerTargetType.isNullable()) {

--- a/flink-table/flink-table-planner/src/main/java/org/apache/flink/table/planner/functions/casting/ArrayToStringCastRule.java
+++ b/flink-table/flink-table-planner/src/main/java/org/apache/flink/table/planner/functions/casting/ArrayToStringCastRule.java
@@ -135,13 +135,11 @@ class ArrayToStringCastRule extends AbstractNullAwareCodeGeneratorCastRule<Array
                                     String elementIsNullTerm = newName("elementIsNull");
 
                                     CastCodeBlock codeBlock =
-                                            CastRuleProvider.generateCodeBlock(
+                                            // Null check is done at the array access level
+                                            CastRuleProvider.generateAlwaysNonNullCodeBlock(
                                                     context,
                                                     elementTerm,
-                                                    "false",
-                                                    // Null check is done at the array
-                                                    // access level
-                                                    innerInputType.copy(false),
+                                                    innerInputType,
                                                     STRING_TYPE);
 
                                     if (!context.legacyBehaviour() && couldTrim(length)) {

--- a/flink-table/flink-table-planner/src/main/java/org/apache/flink/table/planner/functions/casting/CastRuleProvider.java
+++ b/flink-table/flink-table-planner/src/main/java/org/apache/flink/table/planner/functions/casting/CastRuleProvider.java
@@ -64,6 +64,7 @@ public class CastRuleProvider {
                 .addRule(IntervalToStringCastRule.INSTANCE)
                 .addRule(ArrayToStringCastRule.INSTANCE)
                 .addRule(MapAndMultisetToStringCastRule.INSTANCE)
+                .addRule(StructuredToStringCastRule.INSTANCE)
                 .addRule(RowToStringCastRule.INSTANCE)
                 .addRule(RawToStringCastRule.INSTANCE)
                 // From string rules

--- a/flink-table/flink-table-planner/src/main/java/org/apache/flink/table/planner/functions/casting/CastRuleProvider.java
+++ b/flink-table/flink-table-planner/src/main/java/org/apache/flink/table/planner/functions/casting/CastRuleProvider.java
@@ -24,6 +24,7 @@ import org.apache.flink.table.types.logical.DistinctType;
 import org.apache.flink.table.types.logical.LogicalType;
 import org.apache.flink.table.types.logical.LogicalTypeFamily;
 import org.apache.flink.table.types.logical.LogicalTypeRoot;
+import org.apache.flink.table.types.logical.NullType;
 
 import javax.annotation.Nullable;
 
@@ -142,6 +143,25 @@ public class CastRuleProvider {
         return ((CodeGeneratorCastRule) rule)
                 .generateCodeBlock(
                         context, inputTerm, inputIsNullTerm, inputLogicalType, targetLogicalType);
+    }
+
+    /**
+     * This method wraps {@link #generateCodeBlock(CodeGeneratorCastRule.Context, String, String,
+     * LogicalType, LogicalType)}, but adding the assumption that the inputTerm is always non-null.
+     * Used by {@link CodeGeneratorCastRule}s which checks for nullability, rather than deferring
+     * the check to the rules.
+     */
+    static @Nullable CastCodeBlock generateAlwaysNonNullCodeBlock(
+            CodeGeneratorCastRule.Context context,
+            String inputTerm,
+            LogicalType inputLogicalType,
+            LogicalType targetLogicalType) {
+        if (inputLogicalType instanceof NullType) {
+            return generateCodeBlock(
+                    context, inputTerm, "true", inputLogicalType, targetLogicalType);
+        }
+        return generateCodeBlock(
+                context, inputTerm, "false", inputLogicalType.copy(false), targetLogicalType);
     }
 
     /* ------ Implementation ------ */

--- a/flink-table/flink-table-planner/src/main/java/org/apache/flink/table/planner/functions/casting/CodeGeneratorCastRule.java
+++ b/flink-table/flink-table-planner/src/main/java/org/apache/flink/table/planner/functions/casting/CodeGeneratorCastRule.java
@@ -48,7 +48,7 @@ public interface CodeGeneratorCastRule<IN, OUT> extends CastRule<IN, OUT> {
         @Deprecated
         boolean legacyBehaviour();
 
-        /** @return the session time zone term */
+        /** @return the session time zone term. */
         String getSessionTimeZoneTerm();
 
         /**
@@ -59,7 +59,7 @@ public interface CodeGeneratorCastRule<IN, OUT> extends CastRule<IN, OUT> {
          */
         String declareVariable(String type, String variablePrefix);
 
-        /** @return the term for the type serializer */
+        /** @return the term for the type serializer. */
         String declareTypeSerializer(LogicalType type);
 
         /** @return field term. The field is going to be declared as final. */

--- a/flink-table/flink-table-planner/src/main/java/org/apache/flink/table/planner/functions/casting/MapAndMultisetToStringCastRule.java
+++ b/flink-table/flink-table-planner/src/main/java/org/apache/flink/table/planner/functions/casting/MapAndMultisetToStringCastRule.java
@@ -176,23 +176,13 @@ class MapAndMultisetToStringCastRule
                                     String valueIsNullTerm = newName("valueIsNull");
 
                                     CastCodeBlock keyCast =
-                                            CastRuleProvider.generateCodeBlock(
-                                                    context,
-                                                    keyTerm,
-                                                    keyIsNullTerm,
-                                                    // Null check is done at the key array
-                                                    // access level
-                                                    keyType.copy(false),
-                                                    STRING_TYPE);
+                                            // Null check is done at the key array access level
+                                            CastRuleProvider.generateAlwaysNonNullCodeBlock(
+                                                    context, keyTerm, keyType, STRING_TYPE);
                                     CastCodeBlock valueCast =
-                                            CastRuleProvider.generateCodeBlock(
-                                                    context,
-                                                    valueTerm,
-                                                    valueIsNullTerm,
-                                                    // Null check is done at the value array
-                                                    // access level
-                                                    valueType.copy(false),
-                                                    STRING_TYPE);
+                                            // Null check is done at the value array access level
+                                            CastRuleProvider.generateAlwaysNonNullCodeBlock(
+                                                    context, valueTerm, valueType, STRING_TYPE);
 
                                     Consumer<CastRuleUtils.CodeWriter> appendNonNullValue =
                                             bodyWriter ->

--- a/flink-table/flink-table-planner/src/main/java/org/apache/flink/table/planner/functions/casting/RowToRowCastRule.java
+++ b/flink-table/flink-table-planner/src/main/java/org/apache/flink/table/planner/functions/casting/RowToRowCastRule.java
@@ -184,13 +184,9 @@ class RowToRowCastRule extends AbstractNullAwareCodeGeneratorCastRule<RowData, R
             final String fieldIsNullTerm = newName("f" + indexTerm + "IsNull");
 
             final CastCodeBlock codeBlock =
-                    CastRuleProvider.generateCodeBlock(
-                            context,
-                            fieldTerm,
-                            fieldIsNullTerm,
-                            // Null check is done at the row access level
-                            inputFieldType.copy(false),
-                            targetFieldType);
+                    // Null check is done at the row access level
+                    CastRuleProvider.generateAlwaysNonNullCodeBlock(
+                            context, fieldTerm, inputFieldType, targetFieldType);
 
             final String readField = rowFieldReadAccess(indexTerm, inputTerm, inputFieldType);
             final String writeField =

--- a/flink-table/flink-table-planner/src/main/java/org/apache/flink/table/planner/functions/casting/RowToStringCastRule.java
+++ b/flink-table/flink-table-planner/src/main/java/org/apache/flink/table/planner/functions/casting/RowToStringCastRule.java
@@ -36,10 +36,7 @@ import static org.apache.flink.table.planner.functions.casting.CastRuleUtils.met
 import static org.apache.flink.table.planner.functions.casting.CastRuleUtils.nullLiteral;
 import static org.apache.flink.table.planner.functions.casting.CastRuleUtils.strLiteral;
 
-/**
- * {@link LogicalTypeRoot#ROW} and {@link LogicalTypeRoot#STRUCTURED_TYPE} to {@link
- * LogicalTypeFamily#CHARACTER_STRING} cast rule.
- */
+/** {@link LogicalTypeRoot#ROW} to {@link LogicalTypeFamily#CHARACTER_STRING} cast rule. */
 class RowToStringCastRule extends AbstractNullAwareCodeGeneratorCastRule<ArrayData, String> {
 
     static final RowToStringCastRule INSTANCE = new RowToStringCastRule();

--- a/flink-table/flink-table-planner/src/main/java/org/apache/flink/table/planner/functions/casting/RowToStringCastRule.java
+++ b/flink-table/flink-table-planner/src/main/java/org/apache/flink/table/planner/functions/casting/RowToStringCastRule.java
@@ -139,13 +139,9 @@ class RowToStringCastRule extends AbstractNullAwareCodeGeneratorCastRule<ArrayDa
             final String fieldIsNullTerm = newName("f" + fieldIndex + "IsNull");
 
             final CastCodeBlock codeBlock =
-                    CastRuleProvider.generateCodeBlock(
-                            context,
-                            fieldTerm,
-                            fieldIsNullTerm,
-                            // Null check is done at the row access level
-                            fieldType.copy(false),
-                            targetTypeForElementCast);
+                    // Null check is done at the row access level
+                    CastRuleProvider.generateAlwaysNonNullCodeBlock(
+                            context, fieldTerm, fieldType, targetTypeForElementCast);
 
             // Write the comma
             if (fieldIndex != 0) {

--- a/flink-table/flink-table-planner/src/main/java/org/apache/flink/table/planner/functions/casting/StructuredToStringCastRule.java
+++ b/flink-table/flink-table-planner/src/main/java/org/apache/flink/table/planner/functions/casting/StructuredToStringCastRule.java
@@ -166,13 +166,9 @@ class StructuredToStringCastRule extends AbstractNullAwareCodeGeneratorCastRule<
             final String fieldIsNullTerm = newName("f" + fieldIndex + "IsNull");
 
             final CastCodeBlock codeBlock =
-                    CastRuleProvider.generateCodeBlock(
-                            context,
-                            fieldTerm,
-                            fieldIsNullTerm,
-                            // Null check is done at the row access level
-                            attribute.getType().copy(false),
-                            VarCharType.STRING_TYPE);
+                    // Null check is done at the row access level
+                    CastRuleProvider.generateAlwaysNonNullCodeBlock(
+                            context, fieldTerm, attribute.getType(), VarCharType.STRING_TYPE);
 
             // Write the comma
             if (fieldIndex != 0) {

--- a/flink-table/flink-table-planner/src/main/java/org/apache/flink/table/planner/functions/casting/StructuredToStringCastRule.java
+++ b/flink-table/flink-table-planner/src/main/java/org/apache/flink/table/planner/functions/casting/StructuredToStringCastRule.java
@@ -1,0 +1,237 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.flink.table.planner.functions.casting;
+
+import org.apache.flink.table.data.ArrayData;
+import org.apache.flink.table.planner.codegen.CodeGenUtils;
+import org.apache.flink.table.types.logical.LogicalType;
+import org.apache.flink.table.types.logical.LogicalTypeFamily;
+import org.apache.flink.table.types.logical.LogicalTypeRoot;
+import org.apache.flink.table.types.logical.StructuredType;
+import org.apache.flink.table.types.logical.VarCharType;
+import org.apache.flink.table.types.logical.utils.LogicalTypeChecks;
+
+import static org.apache.flink.table.planner.codegen.CodeGenUtils.className;
+import static org.apache.flink.table.planner.codegen.CodeGenUtils.newName;
+import static org.apache.flink.table.planner.codegen.calls.BuiltInMethods.BINARY_STRING_DATA_FROM_STRING;
+import static org.apache.flink.table.planner.functions.casting.CastRuleUtils.constructorCall;
+import static org.apache.flink.table.planner.functions.casting.CastRuleUtils.methodCall;
+import static org.apache.flink.table.planner.functions.casting.CastRuleUtils.nullLiteral;
+import static org.apache.flink.table.planner.functions.casting.CastRuleUtils.strLiteral;
+
+/**
+ * {@link LogicalTypeRoot#STRUCTURED_TYPE} to {@link LogicalTypeFamily#CHARACTER_STRING} cast rule.
+ */
+class StructuredToStringCastRule extends AbstractNullAwareCodeGeneratorCastRule<ArrayData, String> {
+
+    static final StructuredToStringCastRule INSTANCE = new StructuredToStringCastRule();
+
+    private StructuredToStringCastRule() {
+        super(CastRulePredicate.builder().predicate(StructuredToStringCastRule::matches).build());
+    }
+
+    private static boolean matches(LogicalType input, LogicalType target) {
+        return target.is(LogicalTypeFamily.CHARACTER_STRING)
+                && input.is(LogicalTypeRoot.STRUCTURED_TYPE)
+                && LogicalTypeChecks.getFieldTypes(input).stream()
+                        .allMatch(fieldType -> CastRuleProvider.exists(fieldType, target));
+    }
+
+    /* Example generated code for MyStructuredType in CastRulesTest:
+
+    builder$287.setLength(0);
+    builder$287.append("{");
+    long f0Value$289 = -1L;
+    boolean f0IsNull$290 = _myInput.isNullAt(0);
+    if (!f0IsNull$290) {
+        f0Value$289 = _myInput.getLong(0);
+        isNull$2 = f0IsNull$290;
+        if (!isNull$2) {
+            result$3 = org.apache.flink.table.data.binary.BinaryStringData.fromString("" + f0Value$289);
+            isNull$2 = result$3 == null;
+        } else {
+            result$3 = org.apache.flink.table.data.binary.BinaryStringData.EMPTY_UTF8;
+        }
+        builder$287.append("a=" + result$3);
+    } else {
+        builder$287.append("a=" + "NULL");
+    }
+    builder$287.append(", ");
+    long f1Value$291 = -1L;
+    boolean f1IsNull$292 = _myInput.isNullAt(1);
+    if (!f1IsNull$292) {
+        f1Value$291 = _myInput.getLong(1);
+        isNull$4 = f1IsNull$292;
+        if (!isNull$4) {
+            result$5 = org.apache.flink.table.data.binary.BinaryStringData.fromString("" + f1Value$291);
+            isNull$4 = result$5 == null;
+        } else {
+            result$5 = org.apache.flink.table.data.binary.BinaryStringData.EMPTY_UTF8;
+        }
+        builder$287.append("b=" + result$5);
+    } else {
+        builder$287.append("b=" + "NULL");
+    }
+    builder$287.append(", ");
+    org.apache.flink.table.data.binary.BinaryStringData f2Value$293 = org.apache.flink.table.data.binary.BinaryStringData.EMPTY_UTF8;
+    boolean f2IsNull$294 = _myInput.isNullAt(2);
+    if (!f2IsNull$294) {
+        f2Value$293 = ((org.apache.flink.table.data.binary.BinaryStringData) _myInput.getString(2));
+        builder$287.append("c=" + f2Value$293);
+    } else {
+        builder$287.append("c=" + "NULL");
+    }
+    builder$287.append(", ");
+    org.apache.flink.table.data.ArrayData f3Value$295 = null;
+    boolean f3IsNull$296 = _myInput.isNullAt(3);
+    if (!f3IsNull$296) {
+        f3Value$295 = _myInput.getArray(3);
+        isNull$6 = f3IsNull$296;
+        if (!isNull$6) {
+            builder$297.setLength(0);
+            builder$297.append("[");
+            for (int i$299 = 0; i$299 < f3Value$295.size(); i$299++) {
+                if (i$299 != 0) {
+                    builder$297.append(", ");
+                }
+                org.apache.flink.table.data.binary.BinaryStringData element$300 = org.apache.flink.table.data.binary.BinaryStringData.EMPTY_UTF8;
+                boolean elementIsNull$301 = f3Value$295.isNullAt(i$299);
+                if (!elementIsNull$301) {
+                    element$300 = ((org.apache.flink.table.data.binary.BinaryStringData) f3Value$295.getString(i$299));
+                    builder$297.append(element$300);
+                } else {
+                    builder$297.append("NULL");
+                }
+            }
+            builder$297.append("]");
+            java.lang.String resultString$298;
+            resultString$298 = builder$297.toString();
+            result$7 = org.apache.flink.table.data.binary.BinaryStringData.fromString(resultString$298);
+            isNull$6 = result$7 == null;
+        } else {
+            result$7 = org.apache.flink.table.data.binary.BinaryStringData.EMPTY_UTF8;
+        }
+        builder$287.append("d=" + result$7);
+    } else {
+        builder$287.append("d=" + "NULL");
+    }
+    builder$287.append("}");
+    java.lang.String resultString$288;
+    resultString$288 = builder$287.toString();
+    result$1 = org.apache.flink.table.data.binary.BinaryStringData.fromString(resultString$288);
+
+     */
+    @Override
+    protected String generateCodeBlockInternal(
+            CodeGeneratorCastRule.Context context,
+            String inputTerm,
+            String returnVariable,
+            LogicalType inputLogicalType,
+            LogicalType targetLogicalType) {
+        StructuredType inputStructuredType = (StructuredType) inputLogicalType;
+
+        final String builderTerm = newName("builder");
+        context.declareClassField(
+                className(StringBuilder.class), builderTerm, constructorCall(StringBuilder.class));
+
+        final String resultStringTerm = newName("resultString");
+        final int length = LogicalTypeChecks.getLength(targetLogicalType);
+        final CastRuleUtils.CodeWriter writer =
+                new CastRuleUtils.CodeWriter()
+                        .stmt(methodCall(builderTerm, "setLength", 0))
+                        .stmt(methodCall(builderTerm, "append", strLiteral("{")));
+
+        for (int i = 0; i < inputStructuredType.getAttributes().size(); i++) {
+            final int fieldIndex = i;
+            final StructuredType.StructuredAttribute attribute =
+                    inputStructuredType.getAttributes().get(fieldIndex);
+
+            final String fieldTerm = newName("f" + fieldIndex + "Value");
+            final String fieldIsNullTerm = newName("f" + fieldIndex + "IsNull");
+
+            final CastCodeBlock codeBlock =
+                    CastRuleProvider.generateCodeBlock(
+                            context,
+                            fieldTerm,
+                            fieldIsNullTerm,
+                            // Null check is done at the row access level
+                            attribute.getType().copy(false),
+                            VarCharType.STRING_TYPE);
+
+            // Write the comma
+            if (fieldIndex != 0) {
+                writer.stmt(methodCall(builderTerm, "append", strLiteral(", ")));
+            }
+
+            writer
+                    // Extract value from row
+                    .declPrimitiveStmt(attribute.getType(), fieldTerm)
+                    .declStmt(
+                            boolean.class,
+                            fieldIsNullTerm,
+                            methodCall(inputTerm, "isNullAt", fieldIndex))
+                    .ifStmt(
+                            "!" + fieldIsNullTerm,
+                            thenBodyWriter ->
+                                    thenBodyWriter
+                                            // If attribute not null, extract it and execute the
+                                            // cast
+                                            .assignStmt(
+                                                    fieldTerm,
+                                                    CodeGenUtils.rowFieldReadAccess(
+                                                            fieldIndex,
+                                                            inputTerm,
+                                                            attribute.getType()))
+                                            .append(codeBlock)
+                                            .stmt(
+                                                    methodCall(
+                                                            builderTerm,
+                                                            "append",
+                                                            strLiteral(attribute.getName() + "=")
+                                                                    + " + "
+                                                                    + codeBlock.getReturnTerm())),
+                            elseBodyWriter ->
+                                    // If attribute is null, just write NULL
+                                    elseBodyWriter.stmt(
+                                            methodCall(
+                                                    builderTerm,
+                                                    "append",
+                                                    strLiteral(attribute.getName() + "=")
+                                                            + " + "
+                                                            + nullLiteral(
+                                                                    context.legacyBehaviour()))));
+        }
+
+        writer.stmt(methodCall(builderTerm, "append", strLiteral("}")));
+
+        return CharVarCharTrimPadCastRule.padAndTrimStringIfNeeded(
+                        writer,
+                        targetLogicalType,
+                        context.legacyBehaviour(),
+                        length,
+                        resultStringTerm,
+                        builderTerm)
+                // Assign the result value
+                .assignStmt(
+                        returnVariable,
+                        CastRuleUtils.staticCall(
+                                BINARY_STRING_DATA_FROM_STRING(), resultStringTerm))
+                .toString();
+    }
+}

--- a/flink-table/flink-table-planner/src/main/java/org/apache/flink/table/planner/functions/casting/StructuredToStringCastRule.java
+++ b/flink-table/flink-table-planner/src/main/java/org/apache/flink/table/planner/functions/casting/StructuredToStringCastRule.java
@@ -155,7 +155,7 @@ class StructuredToStringCastRule extends AbstractNullAwareCodeGeneratorCastRule<
         final CastRuleUtils.CodeWriter writer =
                 new CastRuleUtils.CodeWriter()
                         .stmt(methodCall(builderTerm, "setLength", 0))
-                        .stmt(methodCall(builderTerm, "append", strLiteral("{")));
+                        .stmt(methodCall(builderTerm, "append", strLiteral("(")));
 
         for (int i = 0; i < inputStructuredType.getAttributes().size(); i++) {
             final int fieldIndex = i;
@@ -214,7 +214,7 @@ class StructuredToStringCastRule extends AbstractNullAwareCodeGeneratorCastRule<
                                                                     context.legacyBehaviour()))));
         }
 
-        writer.stmt(methodCall(builderTerm, "append", strLiteral("}")));
+        writer.stmt(methodCall(builderTerm, "append", strLiteral(")")));
 
         return CharVarCharTrimPadCastRule.padAndTrimStringIfNeeded(
                         writer,

--- a/flink-table/flink-table-planner/src/test/java/org/apache/flink/table/planner/functions/casting/CastRulesTest.java
+++ b/flink-table/flink-table-planner/src/test/java/org/apache/flink/table/planner/functions/casting/CastRulesTest.java
@@ -663,7 +663,7 @@ class CastRulesTest {
                                                     fromString("b"),
                                                     fromString("c")
                                                 })),
-                                fromString("{a=10, b=NULL, c=12:34:56.123, d=[a, b, c]}"))
+                                fromString("(a=10, b=NULL, c=12:34:56.123, d=[a, b, c])"))
                         .fromCase(
                                 MY_STRUCTURED_TYPE_WITHOUT_IMPLEMENTATION_CLASS,
                                 GenericRowData.of(
@@ -676,7 +676,7 @@ class CastRulesTest {
                                                     fromString("b"),
                                                     fromString("c")
                                                 })),
-                                fromString("{a=10, b=NULL, c=12:34:56.123, d=[a, b, c]}")),
+                                fromString("(a=10, b=NULL, c=12:34:56.123, d=[a, b, c])")),
                 CastTestSpecBuilder.testCastTo(CHAR(6))
                         .fromCase(STRING(), null, EMPTY_UTF8)
                         .fromCaseLegacy(STRING(), null, EMPTY_UTF8)

--- a/flink-table/flink-table-planner/src/test/java/org/apache/flink/table/planner/functions/casting/CastRulesTest.java
+++ b/flink-table/flink-table-planner/src/test/java/org/apache/flink/table/planner/functions/casting/CastRulesTest.java
@@ -20,7 +20,9 @@ package org.apache.flink.table.planner.functions.casting;
 
 import org.apache.flink.api.common.typeutils.base.LocalDateSerializer;
 import org.apache.flink.api.common.typeutils.base.LocalDateTimeSerializer;
+import org.apache.flink.table.api.DataTypes;
 import org.apache.flink.table.api.TableException;
+import org.apache.flink.table.catalog.ObjectIdentifier;
 import org.apache.flink.table.data.GenericArrayData;
 import org.apache.flink.table.data.GenericMapData;
 import org.apache.flink.table.data.GenericRowData;
@@ -32,6 +34,7 @@ import org.apache.flink.table.data.binary.BinaryStringDataUtil;
 import org.apache.flink.table.data.utils.CastExecutor;
 import org.apache.flink.table.planner.functions.CastFunctionITCase;
 import org.apache.flink.table.types.DataType;
+import org.apache.flink.table.types.logical.StructuredType;
 import org.apache.flink.table.utils.DateTimeUtils;
 
 import org.junit.jupiter.api.DynamicTest;
@@ -134,6 +137,20 @@ class CastRulesTest {
                     FIELD("b", BIGINT()),
                     FIELD("c", STRING()),
                     FIELD("d", ARRAY(STRING())));
+    private static final DataType MY_STRUCTURED_TYPE_WITHOUT_IMPLEMENTATION_CLASS =
+            DataTypes.of(
+                    StructuredType.newBuilder(ObjectIdentifier.of("a", "b", "c"))
+                            .attributes(
+                                    Arrays.asList(
+                                            new StructuredType.StructuredAttribute(
+                                                    "a", BIGINT().notNull().getLogicalType()),
+                                            new StructuredType.StructuredAttribute(
+                                                    "b", BIGINT().getLogicalType()),
+                                            new StructuredType.StructuredAttribute(
+                                                    "c", STRING().getLogicalType()),
+                                            new StructuredType.StructuredAttribute(
+                                                    "d", ARRAY(STRING()).getLogicalType())))
+                            .build());
 
     Stream<CastTestSpecBuilder> testCases() {
         return Stream.of(
@@ -646,7 +663,20 @@ class CastRulesTest {
                                                     fromString("b"),
                                                     fromString("c")
                                                 })),
-                                fromString("(10, NULL, 12:34:56.123, [a, b, c])")),
+                                fromString("{a=10, b=NULL, c=12:34:56.123, d=[a, b, c]}"))
+                        .fromCase(
+                                MY_STRUCTURED_TYPE_WITHOUT_IMPLEMENTATION_CLASS,
+                                GenericRowData.of(
+                                        10L,
+                                        null,
+                                        TIME_STRING,
+                                        new GenericArrayData(
+                                                new Object[] {
+                                                    fromString("a"),
+                                                    fromString("b"),
+                                                    fromString("c")
+                                                })),
+                                fromString("{a=10, b=NULL, c=12:34:56.123, d=[a, b, c]}")),
                 CastTestSpecBuilder.testCastTo(CHAR(6))
                         .fromCase(STRING(), null, EMPTY_UTF8)
                         .fromCaseLegacy(STRING(), null, EMPTY_UTF8)
@@ -1177,6 +1207,28 @@ class CastRulesTest {
         public Long b;
         public String c;
         public String[] d;
+
+        public MyStructuredType(long a, Long b, String c, String[] d) {
+            this.a = a;
+            this.b = b;
+            this.c = c;
+            this.d = d;
+        }
+
+        @Override
+        public String toString() {
+            return "My fancy string representation{"
+                    + "a="
+                    + a
+                    + ", b="
+                    + b
+                    + ", c='"
+                    + c
+                    + '\''
+                    + ", d="
+                    + Arrays.toString(d)
+                    + '}';
+        }
     }
 
     @SuppressWarnings({"rawtypes"})


### PR DESCRIPTION
## What is the purpose of the change

Add a new cast rule to properly support `STRUCTURED` type, adding support for the user POJO `toString` and, when it's not available, fallback to a map like representation

## Brief change log

* Fix `LogicalTypeDataTypeConverter#toDataType` to pass through the implementation class of the structured type, if available
* Add `CodeGeneratorCastRule.Context#declareDataStructureConverter` to declare reusable data structure converters 
* Add `StructuredToStringCastRule` to properly support `STRUCTURED` types

## Verifying this change

This PR includes two test cases for the new cast rule.

## Does this pull request potentially affect one of the following parts:

  - Dependencies (does it add or upgrade a dependency): no
  - The public API, i.e., is any changed class annotated with `@Public(Evolving)`: no
  - The serializers: no
  - The runtime per-record code paths (performance sensitive): no
  - Anything that affects deployment or recovery: JobManager (and its components), Checkpointing, Kubernetes/Yarn, ZooKeeper: no
  - The S3 file system connector: no

## Documentation

  - Does this pull request introduce a new feature? no
  - If yes, how is the feature documented? not applicable
