### PR TITLE
[hotfix][quickstarts] Fix misprints in DataStreamJob.java and DataStreamJob.scala

### DIFF
--- a/flink-quickstart/flink-quickstart-java/src/main/resources/archetype-resources/src/main/java/DataStreamJob.java
+++ b/flink-quickstart/flink-quickstart-java/src/main/resources/archetype-resources/src/main/java/DataStreamJob.java
@@ -43,7 +43,7 @@ public class DataStreamJob {
 		 * Here, you can start creating your execution plan for Flink.
 		 *
 		 * Start with getting some data from the environment, like
-		 * 	env.fromSequece(1, 10);
+		 * 	env.fromSequence(1, 10);
 		 *
 		 * then, transform the resulting DataStream<Long> using operations
 		 * like
@@ -59,7 +59,7 @@ public class DataStreamJob {
 		 *
 		 */
 
-		// Execute program, begining computation.
+		// Execute program, beginning computation.
 		env.execute("Flink Java API Skeleton");
 	}
 }

--- a/flink-quickstart/flink-quickstart-scala/src/main/resources/archetype-resources/src/main/scala/DataStreamJob.scala
+++ b/flink-quickstart/flink-quickstart-scala/src/main/resources/archetype-resources/src/main/scala/DataStreamJob.scala
@@ -42,7 +42,7 @@ object DataStreamJob {
      * Here, you can start creating your execution plan for Flink.
      *
      * Start with getting some data from the environment, like
-     * 	env.fromSequece(1, 10);
+     * 	env.fromSequence(1, 10);
      *
      * then, transform the resulting DataStream<Long> using operations
      * like
@@ -58,7 +58,7 @@ object DataStreamJob {
      *
      */
 
-    // Execute program, begining computation.
+    // Execute program, beginning computation.
     env.execute("Flink Scala API Skeleton")
   }
 }


### PR DESCRIPTION
## What is the purpose of the change
The PR fixes 2 misprints in 
_flink-quickstart/flink-quickstart-java/src/main/resources/archetype-resources/src/main/java/DataStreamJob.java_
and
_flink-quickstart/flink-quickstart-scala/src/main/resources/archetype-resources/src/main/scala/DataStreamJob.scala_

`begining` => `beginning`
`fromSequece` => `fromSequence`  
(The existing method is called `fromSequence` https://github.com/apache/flink/blob/d08a1d0f4035485283f10611113d4d0fc0a8aaca/flink-streaming-java/src/main/java/org/apache/flink/streaming/api/environment/StreamExecutionEnvironment.java#L1095)

## Verifying this change

This change is a trivial rework / code cleanup without any test coverage.

## Does this pull request potentially affect one of the following parts:

  - Dependencies (does it add or upgrade a dependency): ( no)
  - The public API, i.e., is any changed class annotated with `@Public(Evolving)`: ( no)
  - The serializers: (no )
  - The runtime per-record code paths (performance sensitive): ( no)
  - Anything that affects deployment or recovery: JobManager (and its components), Checkpointing, Kubernetes/Yarn, ZooKeeper: ( no)
  - The S3 file system connector: ( no)

## Documentation

  - Does this pull request introduce a new feature? ( no)
  - If yes, how is the feature documented? (not applicable)
