### PR TITLE
[FLINK-25406] Let FileSystemBlobStore sync output stream

### DIFF
--- a/flink-runtime/src/main/java/org/apache/flink/runtime/blob/FileSystemBlobStore.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/blob/FileSystemBlobStore.java
@@ -19,6 +19,7 @@
 package org.apache.flink.runtime.blob;
 
 import org.apache.flink.api.common.JobID;
+import org.apache.flink.core.fs.FSDataOutputStream;
 import org.apache.flink.core.fs.FileSystem;
 import org.apache.flink.core.fs.Path;
 
@@ -31,7 +32,6 @@ import java.io.File;
 import java.io.FileOutputStream;
 import java.io.IOException;
 import java.io.InputStream;
-import java.io.OutputStream;
 import java.security.MessageDigest;
 import java.util.Arrays;
 
@@ -73,10 +73,12 @@ public class FileSystemBlobStore implements BlobStoreService {
     }
 
     private boolean put(File fromFile, String toBlobPath) throws IOException {
-        try (OutputStream os =
+        try (FSDataOutputStream os =
                 fileSystem.create(new Path(toBlobPath), FileSystem.WriteMode.OVERWRITE)) {
             LOG.debug("Copying from {} to {}.", fromFile, toBlobPath);
             Files.copy(fromFile, os);
+
+            os.sync();
         }
         return true;
     }

--- a/flink-runtime/src/test/java/org/apache/flink/runtime/blob/BlobUtilsTest.java
+++ b/flink-runtime/src/test/java/org/apache/flink/runtime/blob/BlobUtilsTest.java
@@ -22,6 +22,7 @@ import org.apache.flink.api.common.JobID;
 import org.apache.flink.configuration.BlobServerOptions;
 import org.apache.flink.configuration.Configuration;
 import org.apache.flink.configuration.CoreOptions;
+import org.apache.flink.core.fs.local.LocalFileSystem;
 import org.apache.flink.util.FileUtils;
 import org.apache.flink.util.Reference;
 import org.apache.flink.util.TestLogger;
@@ -31,15 +32,15 @@ import org.junit.Test;
 import org.junit.rules.TemporaryFolder;
 
 import java.io.File;
+import java.io.FileNotFoundException;
 import java.io.IOException;
 import java.nio.charset.StandardCharsets;
+import java.nio.file.Files;
+import java.util.UUID;
 import java.util.stream.Collectors;
 
-import static org.hamcrest.CoreMatchers.equalTo;
-import static org.hamcrest.CoreMatchers.is;
-import static org.hamcrest.CoreMatchers.startsWith;
-import static org.hamcrest.MatcherAssert.assertThat;
-import static org.hamcrest.Matchers.containsInAnyOrder;
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
 
 /** Tests for {@link BlobUtils}. */
 public class BlobUtilsTest extends TestLogger {
@@ -58,7 +59,7 @@ public class BlobUtilsTest extends TestLogger {
         config.setString(CoreOptions.TMP_DIRS, temporaryFolder.newFolder().getAbsolutePath());
 
         File dir = BlobUtils.createBlobStorageDirectory(config, null).deref();
-        assertThat(dir.getAbsolutePath(), startsWith(blobStorageDir));
+        assertThat(dir.getAbsolutePath()).startsWith(blobStorageDir);
     }
 
     /** Tests {@link BlobUtils#createBlobStorageDirectory}'s fallback to the fall back directory. */
@@ -70,7 +71,7 @@ public class BlobUtilsTest extends TestLogger {
         File dir =
                 BlobUtils.createBlobStorageDirectory(config, Reference.borrowed(fallbackDirectory))
                         .deref();
-        assertThat(dir, is(equalTo(fallbackDirectory)));
+        assertThat(dir).isEqualTo(fallbackDirectory);
     }
 
     @Test(expected = IOException.class)
@@ -100,9 +101,75 @@ public class BlobUtilsTest extends TestLogger {
         BlobUtils.checkAndDeleteCorruptedBlobs(storageDir.toPath(), log);
 
         assertThat(
-                BlobUtils.listBlobsInDirectory(storageDir.toPath()).stream()
-                        .map(BlobUtils.Blob::getBlobKey)
-                        .collect(Collectors.toList()),
-                containsInAnyOrder(validPermanentBlobKey, validTransientBlobKey));
+                        BlobUtils.listBlobsInDirectory(storageDir.toPath()).stream()
+                                .map(BlobUtils.Blob::getBlobKey)
+                                .collect(Collectors.toList()))
+                .containsExactlyInAnyOrder(validPermanentBlobKey, validTransientBlobKey);
+    }
+
+    @Test
+    public void testMoveTempFileToStoreSucceeds() throws IOException {
+        final FileSystemBlobStore blobStore =
+                new FileSystemBlobStore(
+                        new LocalFileSystem(), temporaryFolder.newFolder().toString());
+        final JobID jobId = new JobID();
+        final File storageFile = new File(temporaryFolder.getRoot(), UUID.randomUUID().toString());
+        final File incomingFile = temporaryFolder.newFile();
+        final byte[] fileContent = {1, 2, 3, 4};
+        final BlobKey blobKey =
+                BlobKey.createKey(
+                        BlobKey.BlobType.PERMANENT_BLOB,
+                        BlobUtils.createMessageDigest().digest(fileContent));
+        Files.write(incomingFile.toPath(), fileContent);
+
+        BlobUtils.moveTempFileToStore(incomingFile, jobId, blobKey, storageFile, log, blobStore);
+
+        assertThat(incomingFile).doesNotExist();
+        assertThat(storageFile).hasBinaryContent(fileContent);
+
+        final File blobStoreFile =
+                new File(temporaryFolder.getRoot(), UUID.randomUUID().toString());
+        assertThat(blobStore.get(jobId, blobKey, blobStoreFile)).isTrue();
+        assertThat(blobStoreFile).hasBinaryContent(fileContent);
+    }
+
+    @Test
+    public void testCleanupIfMoveTempFileToStoreFails() throws IOException {
+        final File storageFile = new File(temporaryFolder.getRoot(), UUID.randomUUID().toString());
+
+        final File incomingFile = temporaryFolder.newFile();
+        Files.write(incomingFile.toPath(), new byte[] {1, 2, 3, 4});
+
+        final FileSystemBlobStore blobStore =
+                new FileSystemBlobStore(
+                        new LocalFileSystem(), temporaryFolder.newFolder().getAbsolutePath());
+
+        final JobID jobId = new JobID();
+        final BlobKey blobKey = BlobKey.createKey(BlobKey.BlobType.PERMANENT_BLOB);
+        assertThatThrownBy(
+                        () ->
+                                BlobUtils.internalMoveTempFileToStore(
+                                        incomingFile,
+                                        jobId,
+                                        blobKey,
+                                        storageFile,
+                                        log,
+                                        blobStore,
+                                        (source, target) -> {
+                                            throw new IOException("Test Failure");
+                                        }))
+                .isInstanceOf(IOException.class);
+
+        assertThatThrownBy(
+                        () ->
+                                blobStore.get(
+                                        jobId,
+                                        blobKey,
+                                        new File(
+                                                temporaryFolder.getRoot(),
+                                                UUID.randomUUID().toString())))
+                .isInstanceOf(FileNotFoundException.class);
+        assertThat(incomingFile).doesNotExist();
+        assertThat(storageFile).doesNotExist();
     }
 }

--- a/flink-runtime/src/test/java/org/apache/flink/runtime/blob/FileSystemBlobStoreTest.java
+++ b/flink-runtime/src/test/java/org/apache/flink/runtime/blob/FileSystemBlobStoreTest.java
@@ -1,0 +1,94 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.flink.runtime.blob;
+
+import org.apache.flink.api.common.JobID;
+import org.apache.flink.core.fs.FSDataOutputStream;
+import org.apache.flink.core.fs.local.LocalDataOutputStream;
+import org.apache.flink.runtime.state.filesystem.TestFs;
+import org.apache.flink.util.TestLoggerExtension;
+import org.apache.flink.util.function.FunctionWithException;
+
+import org.apache.commons.io.FileUtils;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.junit.jupiter.api.io.TempDir;
+
+import java.io.File;
+import java.io.IOException;
+import java.nio.charset.StandardCharsets;
+import java.nio.file.Path;
+import java.util.concurrent.atomic.AtomicReference;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+/** Tests for the {@link FileSystemBlobStore}. */
+@ExtendWith(TestLoggerExtension.class)
+class FileSystemBlobStoreTest {
+
+    @Test
+    public void fileSystemBlobStoreCallsSyncOnPut(@TempDir Path storageDirectory)
+            throws IOException {
+        final Path blobStoreDirectory = storageDirectory.resolve("blobStore");
+
+        final AtomicReference<TestingLocalDataOutputStream> createdOutputStream =
+                new AtomicReference<>();
+        final FunctionWithException<org.apache.flink.core.fs.Path, FSDataOutputStream, IOException>
+                outputStreamFactory =
+                        value -> {
+                            final File file = new File(value.toString());
+                            FileUtils.createParentDirectories(file);
+                            final TestingLocalDataOutputStream outputStream =
+                                    new TestingLocalDataOutputStream(file);
+                            createdOutputStream.compareAndSet(null, outputStream);
+                            return outputStream;
+                        };
+        try (FileSystemBlobStore fileSystemBlobStore =
+                new FileSystemBlobStore(
+                        new TestFs(outputStreamFactory), blobStoreDirectory.toString())) {
+            final BlobKey blobKey = BlobKey.createKey(BlobKey.BlobType.PERMANENT_BLOB);
+            final File localFile = storageDirectory.resolve("localFile").toFile();
+            FileUtils.createParentDirectories(localFile);
+            FileUtils.writeStringToFile(localFile, "foobar", StandardCharsets.UTF_8);
+
+            fileSystemBlobStore.put(localFile, new JobID(), blobKey);
+
+            assertThat(createdOutputStream.get().hasSyncBeenCalled()).isTrue();
+        }
+    }
+
+    private static class TestingLocalDataOutputStream extends LocalDataOutputStream {
+
+        private boolean hasSyncBeenCalled = false;
+
+        private TestingLocalDataOutputStream(File file) throws IOException {
+            super(file);
+        }
+
+        @Override
+        public void sync() throws IOException {
+            hasSyncBeenCalled = true;
+            super.sync();
+        }
+
+        public boolean hasSyncBeenCalled() {
+            return hasSyncBeenCalled;
+        }
+    }
+}

--- a/flink-runtime/src/test/java/org/apache/flink/runtime/state/filesystem/CheckpointStateOutputStreamTest.java
+++ b/flink-runtime/src/test/java/org/apache/flink/runtime/state/filesystem/CheckpointStateOutputStreamTest.java
@@ -23,11 +23,9 @@ import org.apache.flink.core.fs.FSDataOutputStream;
 import org.apache.flink.core.fs.FileSystem;
 import org.apache.flink.core.fs.Path;
 import org.apache.flink.core.fs.local.LocalDataOutputStream;
-import org.apache.flink.core.fs.local.LocalFileSystem;
 import org.apache.flink.core.testutils.CheckedThread;
 import org.apache.flink.core.testutils.OneShotLatch;
 import org.apache.flink.util.TestLogger;
-import org.apache.flink.util.function.FunctionWithException;
 
 import org.junit.Rule;
 import org.junit.Test;
@@ -329,20 +327,6 @@ public class CheckpointStateOutputStreamTest extends TestLogger {
         @Override
         public void close() throws IOException {
             throw new IOException();
-        }
-    }
-
-    private static class TestFs extends LocalFileSystem {
-
-        private final FunctionWithException<Path, FSDataOutputStream, IOException> streamFactory;
-
-        TestFs(FunctionWithException<Path, FSDataOutputStream, IOException> streamFactory) {
-            this.streamFactory = streamFactory;
-        }
-
-        @Override
-        public FSDataOutputStream create(Path filePath, WriteMode overwrite) throws IOException {
-            return streamFactory.apply(filePath);
         }
     }
 }

--- a/flink-runtime/src/test/java/org/apache/flink/runtime/state/filesystem/TestFs.java
+++ b/flink-runtime/src/test/java/org/apache/flink/runtime/state/filesystem/TestFs.java
@@ -1,0 +1,41 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.flink.runtime.state.filesystem;
+
+import org.apache.flink.core.fs.FSDataOutputStream;
+import org.apache.flink.core.fs.Path;
+import org.apache.flink.core.fs.local.LocalFileSystem;
+import org.apache.flink.util.function.FunctionWithException;
+
+import java.io.IOException;
+
+/** Test {@link LocalFileSystem} for testing purposes. */
+public class TestFs extends LocalFileSystem {
+
+    private final FunctionWithException<Path, FSDataOutputStream, IOException> streamFactory;
+
+    public TestFs(FunctionWithException<Path, FSDataOutputStream, IOException> streamFactory) {
+        this.streamFactory = streamFactory;
+    }
+
+    @Override
+    public FSDataOutputStream create(Path filePath, WriteMode overwrite) throws IOException {
+        return streamFactory.apply(filePath);
+    }
+}


### PR DESCRIPTION
## What is the purpose of the change

In order to avoid losing data the FileSystemBlobStore should call FSDataOutputStream.sync() when putting new results. This will ensure that no data is kept in caches and might be lost in case of a node crash.

This PR is based on #18191.

## Verifying this change

Added `BlobUtilsTest` and `FileSystemBlobStoreTest`.

## Does this pull request potentially affect one of the following parts:

  - Dependencies (does it add or upgrade a dependency): (yes / **no**)
  - The public API, i.e., is any changed class annotated with `@Public(Evolving)`: (yes / **no**)
  - The serializers: (yes / **no** / don't know)
  - The runtime per-record code paths (performance sensitive): (yes / **no** / don't know)
  - Anything that affects deployment or recovery: JobManager (and its components), Checkpointing, Kubernetes/Yarn, ZooKeeper: (**yes** / no / don't know)
  - The S3 file system connector: (yes / **no** / don't know)

## Documentation

  - Does this pull request introduce a new feature? (yes / **no**)
  - If yes, how is the feature documented? (**not applicable** / docs / JavaDocs / not documented)
