### PR TITLE
[FLINK-25436] Let Dispatcher only retain recovered jobs in BlobServer

### DIFF
--- a/flink-runtime/src/main/java/org/apache/flink/runtime/blob/BlobServer.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/blob/BlobServer.java
@@ -907,6 +907,18 @@ public class BlobServer extends Thread
         }
     }
 
+    public void retainJobs(Collection<JobID> jobsToRetain) throws IOException {
+        if (storageDir.deref().exists()) {
+            final Set<JobID> jobsToRemove = BlobUtils.listExistingJobs(storageDir.deref().toPath());
+
+            jobsToRemove.removeAll(jobsToRetain);
+
+            for (JobID jobToRemove : jobsToRemove) {
+                cleanupJob(jobToRemove, true);
+            }
+        }
+    }
+
     @Override
     public PermanentBlobService getPermanentBlobService() {
         return this;

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/blob/BlobUtils.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/blob/BlobUtils.java
@@ -582,6 +582,15 @@ public class BlobUtils {
                 .collect(Collectors.toList());
     }
 
+    @Nonnull
+    static Collection<PermanentBlob> listPermanentBlobsInDirectory(java.nio.file.Path directory)
+            throws IOException {
+        return listBlobsInDirectory(directory).stream()
+                .filter(blob -> blob.getBlobKey() instanceof PermanentBlobKey)
+                .map(blob -> (PermanentBlob) blob)
+                .collect(Collectors.toList());
+    }
+
     abstract static class Blob<T extends BlobKey> {
         private final T blobKey;
         private final java.nio.file.Path path;

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/blob/BlobUtils.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/blob/BlobUtils.java
@@ -50,7 +50,9 @@ import java.security.MessageDigest;
 import java.security.NoSuchAlgorithmException;
 import java.util.Arrays;
 import java.util.Collection;
+import java.util.Objects;
 import java.util.Random;
+import java.util.Set;
 import java.util.UUID;
 import java.util.stream.Collectors;
 
@@ -589,6 +591,13 @@ public class BlobUtils {
                 .filter(blob -> blob.getBlobKey() instanceof PermanentBlobKey)
                 .map(blob -> (PermanentBlob) blob)
                 .collect(Collectors.toList());
+    }
+
+    static Set<JobID> listExistingJobs(java.nio.file.Path directory) throws IOException {
+        return listBlobsInDirectory(directory).stream()
+                .map(Blob::getJobId)
+                .filter(Objects::nonNull)
+                .collect(Collectors.toSet());
     }
 
     abstract static class Blob<T extends BlobKey> {

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/blob/PermanentBlobCache.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/blob/PermanentBlobCache.java
@@ -40,10 +40,8 @@ import java.util.HashMap;
 import java.util.Iterator;
 import java.util.List;
 import java.util.Map;
-import java.util.Objects;
 import java.util.Timer;
 import java.util.TimerTask;
-import java.util.stream.Collectors;
 
 import static org.apache.flink.util.Preconditions.checkNotNull;
 
@@ -166,14 +164,8 @@ public class PermanentBlobCache extends AbstractBlobCache implements JobPermanen
 
     private void registerDetectedJobs() throws IOException {
         if (storageDir.deref().exists()) {
-            final Collection<BlobUtils.PermanentBlob> permanentBlobs =
-                    BlobUtils.listPermanentBlobsInDirectory(storageDir.deref().toPath());
-
             final Collection<JobID> jobIds =
-                    permanentBlobs.stream()
-                            .map(BlobUtils.PermanentBlob::getJobId)
-                            .filter(Objects::nonNull)
-                            .collect(Collectors.toSet());
+                    BlobUtils.listExistingJobs(storageDir.deref().toPath());
 
             final long expiryTimeout = System.currentTimeMillis() + cleanupInterval;
             for (JobID jobId : jobIds) {

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/dispatcher/Dispatcher.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/dispatcher/Dispatcher.java
@@ -195,6 +195,8 @@ public abstract class Dispatcher extends PermanentlyFencedRpcEndpoint<Dispatcher
         this.dispatcherBootstrapFactory = checkNotNull(dispatcherBootstrapFactory);
 
         this.recoveredJobs = new HashSet<>(recoveredJobs);
+        this.blobServer.retainJobs(
+                recoveredJobs.stream().map(JobGraph::getJobID).collect(Collectors.toSet()));
 
         this.dispatcherCachedOperationsHandler =
                 new DispatcherCachedOperationsHandler(

--- a/flink-runtime/src/test/java/org/apache/flink/runtime/blob/BlobUtilsTest.java
+++ b/flink-runtime/src/test/java/org/apache/flink/runtime/blob/BlobUtilsTest.java
@@ -36,6 +36,7 @@ import java.io.FileNotFoundException;
 import java.io.IOException;
 import java.nio.charset.StandardCharsets;
 import java.nio.file.Files;
+import java.util.List;
 import java.util.UUID;
 import java.util.stream.Collectors;
 
@@ -100,10 +101,11 @@ public class BlobUtilsTest extends TestLogger {
 
         BlobUtils.checkAndDeleteCorruptedBlobs(storageDir.toPath(), log);
 
-        assertThat(
-                        BlobUtils.listBlobsInDirectory(storageDir.toPath()).stream()
-                                .map(BlobUtils.Blob::getBlobKey)
-                                .collect(Collectors.toList()))
+        final List<BlobKey> blobKeys =
+                BlobUtils.listBlobsInDirectory(storageDir.toPath()).stream()
+                        .map(BlobUtils.Blob::getBlobKey)
+                        .collect(Collectors.toList());
+        assertThat(blobKeys)
                 .containsExactlyInAnyOrder(validPermanentBlobKey, validTransientBlobKey);
     }
 

--- a/flink-runtime/src/test/java/org/apache/flink/runtime/dispatcher/AbstractDispatcherTest.java
+++ b/flink-runtime/src/test/java/org/apache/flink/runtime/dispatcher/AbstractDispatcherTest.java
@@ -122,6 +122,10 @@ public class AbstractDispatcherTest extends TestLogger {
         }
     }
 
+    protected BlobServer getBlobServer() {
+        return blobServer;
+    }
+
     /** A convenient builder for the {@link TestingDispatcher}. */
     public class TestingDispatcherBuilder {
 

--- a/flink-runtime/src/test/java/org/apache/flink/runtime/dispatcher/runner/ZooKeeperDefaultDispatcherRunnerTest.java
+++ b/flink-runtime/src/test/java/org/apache/flink/runtime/dispatcher/runner/ZooKeeperDefaultDispatcherRunnerTest.java
@@ -173,8 +173,6 @@ public class ZooKeeperDefaultDispatcherRunnerTest extends TestLogger {
                             ForkJoinPool.commonPool(),
                             new DispatcherOperationCaches());
 
-            final JobGraph jobGraph = createJobGraphWithBlobs();
-
             final DefaultDispatcherRunnerFactory defaultDispatcherRunnerFactory =
                     DefaultDispatcherRunnerFactory.createSessionRunner(
                             SessionDispatcherFactory.INSTANCE);
@@ -191,6 +189,7 @@ public class ZooKeeperDefaultDispatcherRunnerTest extends TestLogger {
                 DispatcherGateway dispatcherGateway =
                         grantLeadership(dispatcherLeaderElectionService);
 
+                final JobGraph jobGraph = createJobGraphWithBlobs();
                 LOG.info("Initial job submission {}.", jobGraph.getJobID());
                 dispatcherGateway.submitJob(jobGraph, TESTING_TIMEOUT).get();
 


### PR DESCRIPTION
## What is the purpose of the change

376550f61e2ec34a563b3bd715474ed388a427d3: Let the `TransientBlobCache` register expiry times for recovered transient blobs.

2aeb94c5b2a5d90599f9f3e73312c63e911c3579: Let the `PermanentBlobCache` register expiry times for recovered jobs

fa65cf9c54425f141bab1960c1894a1fcfbd9f65: Let the `BlobServer` register expiry times for the recovered transient blobs.

d111c3d078423a6a90e33d91fe2a8cbc1a4d1bbc: Let the `Dispatcher` tell the `BlobServer` which job blobs to retain after a recovery.

This PR is based on #18192.

## Does this pull request potentially affect one of the following parts:

  - Dependencies (does it add or upgrade a dependency): (yes / **no**)
  - The public API, i.e., is any changed class annotated with `@Public(Evolving)`: (yes / **no**)
  - The serializers: (yes / **no** / don't know)
  - The runtime per-record code paths (performance sensitive): (yes / **no** / don't know)
  - Anything that affects deployment or recovery: JobManager (and its components), Checkpointing, Kubernetes/Yarn, ZooKeeper: (**yes** / no / don't know)
  - The S3 file system connector: (yes / **no** / don't know)

## Documentation

  - Does this pull request introduce a new feature? (yes / no)
  - If yes, how is the feature documented? (not applicable / docs / JavaDocs / not documented)
