### PR TITLE
[hotfix][runtime/source] fix comment typo

### DIFF
--- a/flink-runtime/src/main/java/org/apache/flink/runtime/source/coordinator/SourceCoordinator.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/source/coordinator/SourceCoordinator.java
@@ -116,7 +116,7 @@ public class SourceCoordinator<SplitT extends SourceSplit, EnumChkT>
         // 'start()' wasn't called and where 'start()' failed.
         started = true;
 
-        // there are two ways the coordinator can get created:
+        // there are two ways the splitEnumerator can get created:
         //  (1) Source.restoreEnumerator(), in which case the 'resetToCheckpoint()' method creates
         // it
         //  (2) Source.createEnumerator, in which case it has not been created, yet, and we create


### PR DESCRIPTION
## What is the purpose of the change

fix a typo found in comment.


## Brief change log

  - replace "coordinator" with "splitEnumerator"


## Verifying this change

This change is a trivial typo fix in comment without any test coverage.


## Does this pull request potentially affect one of the following parts:

  - Dependencies (does it add or upgrade a dependency): (yes / **no**)
  - The public API, i.e., is any changed class annotated with `@Public(Evolving)`: (yes / **no**)
  - The serializers: (yes / **no** / don't know)
  - The runtime per-record code paths (performance sensitive): (yes / **no** / don't know)
  - Anything that affects deployment or recovery: JobManager (and its components), Checkpointing, Kubernetes/Yarn, ZooKeeper: (yes / **no** / don't know)
  - The S3 file system connector: (yes / **no** / don't know)

## Documentation

  - Does this pull request introduce a new feature? (yes / **no**)
