### PR TITLE
[FLINK-24270][checkpoint] Refactor the tests related to the VertexFinishedStateChecker

### DIFF
--- a/flink-runtime/src/test/java/org/apache/flink/runtime/checkpoint/CheckpointCoordinatorRestoringTest.java
+++ b/flink-runtime/src/test/java/org/apache/flink/runtime/checkpoint/CheckpointCoordinatorRestoringTest.java
@@ -22,13 +22,9 @@ import org.apache.flink.api.common.JobStatus;
 import org.apache.flink.api.java.tuple.Tuple2;
 import org.apache.flink.runtime.OperatorIDPair;
 import org.apache.flink.runtime.checkpoint.CheckpointCoordinatorTestingUtils.CheckpointCoordinatorBuilder;
-import org.apache.flink.runtime.checkpoint.VertexFinishedStateChecker.VertexFinishedState;
 import org.apache.flink.runtime.executiongraph.Execution;
 import org.apache.flink.runtime.executiongraph.ExecutionGraph;
 import org.apache.flink.runtime.executiongraph.ExecutionJobVertex;
-import org.apache.flink.runtime.io.network.partition.ResultPartitionType;
-import org.apache.flink.runtime.jobgraph.DistributionPattern;
-import org.apache.flink.runtime.jobgraph.JobVertex;
 import org.apache.flink.runtime.jobgraph.JobVertexID;
 import org.apache.flink.runtime.jobgraph.OperatorID;
 import org.apache.flink.runtime.jobgraph.tasks.CheckpointCoordinatorConfiguration.CheckpointCoordinatorConfigurationBuilder;
@@ -40,9 +36,7 @@ import org.apache.flink.runtime.state.KeyedStateHandle;
 import org.apache.flink.runtime.state.OperatorStateHandle;
 import org.apache.flink.runtime.state.SharedStateRegistry;
 import org.apache.flink.runtime.state.testutils.TestCompletedCheckpointStorageLocation;
-import org.apache.flink.runtime.testtasks.NoOpInvokable;
 import org.apache.flink.runtime.testutils.CommonTestUtils;
-import org.apache.flink.util.FlinkRuntimeException;
 import org.apache.flink.util.TestLogger;
 import org.apache.flink.util.concurrent.Executors;
 import org.apache.flink.util.concurrent.ManuallyTriggeredScheduledExecutor;
@@ -53,7 +47,6 @@ import org.junit.Assert;
 import org.junit.Before;
 import org.junit.Rule;
 import org.junit.Test;
-import org.junit.rules.ExpectedException;
 import org.junit.rules.TemporaryFolder;
 
 import java.util.ArrayList;
@@ -169,8 +162,6 @@ public class CheckpointCoordinatorRestoringTest extends TestLogger {
     private ManuallyTriggeredScheduledExecutor manuallyTriggeredScheduledExecutor;
 
     @Rule public TemporaryFolder tmpFolder = new TemporaryFolder();
-
-    @Rule public ExpectedException thrown = ExpectedException.none();
 
     @Before
     public void setUp() throws Exception {
@@ -1115,301 +1106,5 @@ public class CheckpointCoordinatorRestoringTest extends TestLogger {
                         .getTaskRestore()
                         .getTaskStateSnapshot();
         assertTrue(restoredState.isTaskDeployedAsFinished());
-    }
-
-    @Test
-    public void testRestoringPartiallyFinishedChainsFailsWithoutUidHash() throws Exception {
-        // If useUidHash is set to false, the operator states would still be keyed with the
-        // generated ID, which simulates the case of restoring a checkpoint taken after jobs
-        // started. The checker should still be able to access the stored state correctly, otherwise
-        // it would mark op1 as running and pass the check wrongly.
-        testRestoringPartiallyFinishedChainsFails(false);
-    }
-
-    @Test
-    public void testRestoringPartiallyFinishedChainsFailsWithUidHash() throws Exception {
-        testRestoringPartiallyFinishedChainsFails(true);
-    }
-
-    private void testRestoringPartiallyFinishedChainsFails(boolean useUidHash) throws Exception {
-        final JobVertexID jobVertexID1 = new JobVertexID();
-        final JobVertexID jobVertexID2 = new JobVertexID();
-        // The op1 has uidHash set.
-        OperatorIDPair op1 = OperatorIDPair.of(new OperatorID(), new OperatorID());
-        OperatorIDPair op2 = OperatorIDPair.generatedIDOnly(new OperatorID());
-        OperatorIDPair op3 = OperatorIDPair.generatedIDOnly(new OperatorID());
-
-        final ExecutionGraph graph =
-                new CheckpointCoordinatorTestingUtils.CheckpointExecutionGraphBuilder()
-                        .addJobVertex(jobVertexID2, 1, 1, singletonList(op3), true)
-                        .addJobVertex(jobVertexID1, 1, 1, Arrays.asList(op1, op2), true)
-                        .build();
-
-        Map<OperatorID, OperatorState> operatorStates = new HashMap<>();
-        operatorStates.put(
-                useUidHash ? op1.getUserDefinedOperatorID().get() : op1.getGeneratedOperatorID(),
-                new FullyFinishedOperatorState(op1.getGeneratedOperatorID(), 1, 1));
-        operatorStates.put(
-                op2.getGeneratedOperatorID(),
-                new OperatorState(op2.getGeneratedOperatorID(), 1, 1));
-        CompletedCheckpointStore store = new EmbeddedCompletedCheckpointStore();
-        store.addCheckpointAndSubsumeOldestOne(
-                new CompletedCheckpoint(
-                        graph.getJobID(),
-                        2,
-                        System.currentTimeMillis(),
-                        System.currentTimeMillis() + 3000,
-                        operatorStates,
-                        Collections.emptyList(),
-                        CheckpointProperties.forCheckpoint(
-                                CheckpointRetentionPolicy.NEVER_RETAIN_AFTER_TERMINATION),
-                        new TestCompletedCheckpointStorageLocation()),
-                new CheckpointsCleaner(),
-                () -> {});
-
-        // set up the coordinator and validate the initial state
-        CheckpointCoordinator coord =
-                new CheckpointCoordinatorBuilder()
-                        .setExecutionGraph(graph)
-                        .setCompletedCheckpointStore(store)
-                        .setTimer(manuallyTriggeredScheduledExecutor)
-                        .build();
-
-        Set<ExecutionJobVertex> vertices = new HashSet<>();
-        vertices.add(graph.getJobVertex(jobVertexID1));
-
-        thrown.expect(FlinkRuntimeException.class);
-        thrown.expectMessage(
-                "Can not restore vertex "
-                        + "anon("
-                        + jobVertexID1
-                        + ")"
-                        + " which contain mixed operator finished state: [ALL_RUNNING, FULLY_FINISHED]");
-        coord.restoreInitialCheckpointIfPresent(vertices);
-    }
-
-    @Test
-    public void testAddingRunningOperatorBeforeFinishedOneFails() throws Exception {
-        JobVertexID jobVertexID2 = new JobVertexID();
-
-        testAddingOperatorsBeforePartiallyOrFullyFinishedOne(
-                new JobVertexID(),
-                "vert1",
-                VertexFinishedState.ALL_RUNNING,
-                jobVertexID2,
-                "vert2",
-                VertexFinishedState.FULLY_FINISHED,
-                new DistributionPattern[] {DistributionPattern.ALL_TO_ALL},
-                FlinkRuntimeException.class,
-                "Illegal JobGraph modification. Cannot run a program with fully finished vertices"
-                        + " predeceased with the ones not fully finished. Task vertex vert2"
-                        + "("
-                        + jobVertexID2
-                        + ")"
-                        + " has a predecessor not fully finished");
-    }
-
-    @Test
-    public void testAddingPartiallyFinishedOperatorBeforeFinishedOneFails() throws Exception {
-        JobVertexID jobVertexID2 = new JobVertexID();
-
-        testAddingOperatorsBeforePartiallyOrFullyFinishedOne(
-                new JobVertexID(),
-                "vert1",
-                VertexFinishedState.PARTIALLY_FINISHED,
-                jobVertexID2,
-                "vert2",
-                VertexFinishedState.FULLY_FINISHED,
-                new DistributionPattern[] {DistributionPattern.ALL_TO_ALL},
-                FlinkRuntimeException.class,
-                "Illegal JobGraph modification. Cannot run a program with fully finished vertices"
-                        + " predeceased with the ones not fully finished. Task vertex vert2"
-                        + "("
-                        + jobVertexID2
-                        + ")"
-                        + " has a predecessor not fully finished");
-    }
-
-    @Test
-    public void testAddingAllRunningOperatorBeforePartiallyFinishedOneWithAllToAllFails()
-            throws Exception {
-        JobVertexID jobVertexID2 = new JobVertexID();
-
-        testAddingOperatorsBeforePartiallyOrFullyFinishedOne(
-                new JobVertexID(),
-                "vert1",
-                VertexFinishedState.ALL_RUNNING,
-                jobVertexID2,
-                "vert2",
-                VertexFinishedState.PARTIALLY_FINISHED,
-                new DistributionPattern[] {DistributionPattern.ALL_TO_ALL},
-                FlinkRuntimeException.class,
-                "Illegal JobGraph modification. Cannot run a program with partially finished vertices"
-                        + " predeceased with running or partially finished ones and connected via the ALL_TO_ALL edges. "
-                        + "Task vertex vert2"
-                        + "("
-                        + jobVertexID2
-                        + ")"
-                        + " has a all running predecessor");
-    }
-
-    @Test
-    public void testAddingPartiallyFinishedOperatorBeforePartiallyFinishedOneWithAllToAllFails()
-            throws Exception {
-        JobVertexID jobVertexID2 = new JobVertexID();
-
-        testAddingOperatorsBeforePartiallyOrFullyFinishedOne(
-                new JobVertexID(),
-                "vert1",
-                VertexFinishedState.PARTIALLY_FINISHED,
-                jobVertexID2,
-                "vert2",
-                VertexFinishedState.PARTIALLY_FINISHED,
-                new DistributionPattern[] {DistributionPattern.ALL_TO_ALL},
-                FlinkRuntimeException.class,
-                "Illegal JobGraph modification. Cannot run a program with partially finished vertices"
-                        + " predeceased with running or partially finished ones and connected via the ALL_TO_ALL edges. "
-                        + "Task vertex vert2"
-                        + "("
-                        + jobVertexID2
-                        + ")"
-                        + " has a partially finished predecessor");
-    }
-
-    @Test
-    public void
-            testAddingPartiallyFinishedOperatorBeforePartiallyFinishedOneWithPointwiseAndAllToAllFails()
-                    throws Exception {
-        JobVertexID jobVertexID2 = new JobVertexID();
-
-        testAddingOperatorsBeforePartiallyOrFullyFinishedOne(
-                new JobVertexID(),
-                "vert1",
-                VertexFinishedState.PARTIALLY_FINISHED,
-                jobVertexID2,
-                "vert2",
-                VertexFinishedState.PARTIALLY_FINISHED,
-                new DistributionPattern[] {
-                    DistributionPattern.POINTWISE, DistributionPattern.ALL_TO_ALL
-                },
-                FlinkRuntimeException.class,
-                "Illegal JobGraph modification. Cannot run a program with partially finished vertices"
-                        + " predeceased with running or partially finished ones and connected via the ALL_TO_ALL edges. "
-                        + "Task vertex vert2"
-                        + "("
-                        + jobVertexID2
-                        + ")"
-                        + " has a partially finished predecessor");
-    }
-
-    @Test
-    public void testAddingAllRunningOperatorBeforePartiallyFinishedOneFails() throws Exception {
-        JobVertexID jobVertexID2 = new JobVertexID();
-
-        testAddingOperatorsBeforePartiallyOrFullyFinishedOne(
-                new JobVertexID(),
-                "vert1",
-                VertexFinishedState.ALL_RUNNING,
-                jobVertexID2,
-                "vert2",
-                VertexFinishedState.PARTIALLY_FINISHED,
-                new DistributionPattern[] {DistributionPattern.POINTWISE},
-                FlinkRuntimeException.class,
-                "Illegal JobGraph modification. Cannot run a program with partially finished vertices"
-                        + " predeceased with all running ones. "
-                        + "Task vertex vert2"
-                        + "("
-                        + jobVertexID2
-                        + ")"
-                        + " has a all running predecessor");
-    }
-
-    private void testAddingOperatorsBeforePartiallyOrFullyFinishedOne(
-            JobVertexID firstVertexId,
-            String firstVertexName,
-            VertexFinishedState firstOperatorFinishedState,
-            JobVertexID secondVertexId,
-            String secondVertexName,
-            VertexFinishedState secondOperatorFinishedState,
-            DistributionPattern[] distributionPatterns,
-            Class<? extends Throwable> expectedExceptionalClass,
-            String expectedMessage)
-            throws Exception {
-        OperatorIDPair op1 = OperatorIDPair.generatedIDOnly(new OperatorID());
-        OperatorIDPair op2 = OperatorIDPair.generatedIDOnly(new OperatorID());
-        JobVertex vertex1 = new JobVertex(firstVertexName, firstVertexId, singletonList(op1));
-        JobVertex vertex2 = new JobVertex(secondVertexName, secondVertexId, singletonList(op2));
-        vertex1.setInvokableClass(NoOpInvokable.class);
-        vertex2.setInvokableClass(NoOpInvokable.class);
-
-        final ExecutionGraph graph =
-                new CheckpointCoordinatorTestingUtils.CheckpointExecutionGraphBuilder()
-                        .addJobVertex(vertex1, true)
-                        .addJobVertex(vertex2, false)
-                        .setDistributionPattern(distributionPatterns[0])
-                        .build();
-
-        // Adds the additional edges
-        for (int i = 1; i < distributionPatterns.length; ++i) {
-            vertex2.connectNewDataSetAsInput(
-                    vertex1, distributionPatterns[i], ResultPartitionType.PIPELINED);
-        }
-
-        Map<OperatorID, OperatorState> operatorStates = new HashMap<>();
-        operatorStates.put(
-                op1.getGeneratedOperatorID(),
-                createOperatorState(op1.getGeneratedOperatorID(), firstOperatorFinishedState));
-        operatorStates.put(
-                op2.getGeneratedOperatorID(),
-                createOperatorState(op2.getGeneratedOperatorID(), secondOperatorFinishedState));
-
-        CompletedCheckpointStore store = new EmbeddedCompletedCheckpointStore();
-        store.addCheckpointAndSubsumeOldestOne(
-                new CompletedCheckpoint(
-                        graph.getJobID(),
-                        2,
-                        System.currentTimeMillis(),
-                        System.currentTimeMillis() + 3000,
-                        operatorStates,
-                        Collections.emptyList(),
-                        CheckpointProperties.forCheckpoint(
-                                CheckpointRetentionPolicy.NEVER_RETAIN_AFTER_TERMINATION),
-                        new TestCompletedCheckpointStorageLocation()),
-                new CheckpointsCleaner(),
-                () -> {});
-
-        // set up the coordinator and validate the initial state
-        CheckpointCoordinator coord =
-                new CheckpointCoordinatorBuilder()
-                        .setExecutionGraph(graph)
-                        .setCompletedCheckpointStore(store)
-                        .setTimer(manuallyTriggeredScheduledExecutor)
-                        .build();
-
-        Set<ExecutionJobVertex> vertices = new HashSet<>();
-        vertices.add(graph.getJobVertex(vertex1.getID()));
-        vertices.add(graph.getJobVertex(vertex2.getID()));
-
-        thrown.expect(expectedExceptionalClass);
-        thrown.expectMessage(expectedMessage);
-
-        coord.restoreInitialCheckpointIfPresent(vertices);
-    }
-
-    private OperatorState createOperatorState(
-            OperatorID operatorId, VertexFinishedState finishedState) {
-        switch (finishedState) {
-            case ALL_RUNNING:
-                return new OperatorState(operatorId, 2, 2);
-            case PARTIALLY_FINISHED:
-                OperatorState operatorState = new OperatorState(operatorId, 2, 2);
-                operatorState.putState(0, FinishedOperatorSubtaskState.INSTANCE);
-                return operatorState;
-            case FULLY_FINISHED:
-                return new FullyFinishedOperatorState(operatorId, 2, 2);
-            default:
-                throw new UnsupportedOperationException(
-                        "Not supported finished state: " + finishedState);
-        }
     }
 }

--- a/flink-runtime/src/test/java/org/apache/flink/runtime/checkpoint/VertexFinishedStateCheckerTest.java
+++ b/flink-runtime/src/test/java/org/apache/flink/runtime/checkpoint/VertexFinishedStateCheckerTest.java
@@ -1,0 +1,302 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.flink.runtime.checkpoint;
+
+import org.apache.flink.runtime.OperatorIDPair;
+import org.apache.flink.runtime.executiongraph.ExecutionGraph;
+import org.apache.flink.runtime.executiongraph.ExecutionJobVertex;
+import org.apache.flink.runtime.io.network.partition.ResultPartitionType;
+import org.apache.flink.runtime.jobgraph.DistributionPattern;
+import org.apache.flink.runtime.jobgraph.JobVertex;
+import org.apache.flink.runtime.jobgraph.JobVertexID;
+import org.apache.flink.runtime.jobgraph.OperatorID;
+import org.apache.flink.runtime.testtasks.NoOpInvokable;
+import org.apache.flink.util.FlinkRuntimeException;
+
+import org.junit.Rule;
+import org.junit.Test;
+import org.junit.rules.ExpectedException;
+
+import java.util.Arrays;
+import java.util.HashMap;
+import java.util.HashSet;
+import java.util.Map;
+import java.util.Set;
+
+import static java.util.Collections.singletonList;
+
+/** This tests verifies the checking logic of {@link VertexFinishedStateChecker}. */
+public class VertexFinishedStateCheckerTest {
+
+    @Rule public ExpectedException thrown = ExpectedException.none();
+
+    @Test
+    public void testRestoringPartiallyFinishedChainsFailsWithoutUidHash() throws Exception {
+        // If useUidHash is set to false, the operator states would still be keyed with the
+        // generated ID, which simulates the case of restoring a checkpoint taken after jobs
+        // started. The checker should still be able to access the stored state correctly, otherwise
+        // it would mark op1 as running and pass the check wrongly.
+        testRestoringPartiallyFinishedChainsFails(false);
+    }
+
+    @Test
+    public void testRestoringPartiallyFinishedChainsFailsWithUidHash() throws Exception {
+        testRestoringPartiallyFinishedChainsFails(true);
+    }
+
+    private void testRestoringPartiallyFinishedChainsFails(boolean useUidHash) throws Exception {
+        final JobVertexID jobVertexID1 = new JobVertexID();
+        final JobVertexID jobVertexID2 = new JobVertexID();
+        // The op1 has uidHash set.
+        OperatorIDPair op1 = OperatorIDPair.of(new OperatorID(), new OperatorID());
+        OperatorIDPair op2 = OperatorIDPair.generatedIDOnly(new OperatorID());
+        OperatorIDPair op3 = OperatorIDPair.generatedIDOnly(new OperatorID());
+
+        final ExecutionGraph graph =
+                new CheckpointCoordinatorTestingUtils.CheckpointExecutionGraphBuilder()
+                        .addJobVertex(jobVertexID2, 1, 1, singletonList(op3), true)
+                        .addJobVertex(jobVertexID1, 1, 1, Arrays.asList(op1, op2), true)
+                        .build();
+
+        Map<OperatorID, OperatorState> operatorStates = new HashMap<>();
+        operatorStates.put(
+                useUidHash ? op1.getUserDefinedOperatorID().get() : op1.getGeneratedOperatorID(),
+                new FullyFinishedOperatorState(op1.getGeneratedOperatorID(), 1, 1));
+        operatorStates.put(
+                op2.getGeneratedOperatorID(),
+                new OperatorState(op2.getGeneratedOperatorID(), 1, 1));
+
+        Set<ExecutionJobVertex> vertices = new HashSet<>();
+        vertices.add(graph.getJobVertex(jobVertexID1));
+        VertexFinishedStateChecker finishedStateChecker =
+                new VertexFinishedStateChecker(vertices, operatorStates);
+
+        thrown.expect(FlinkRuntimeException.class);
+        thrown.expectMessage(
+                "Can not restore vertex "
+                        + "anon("
+                        + jobVertexID1
+                        + ")"
+                        + " which contain mixed operator finished state: [ALL_RUNNING, FULLY_FINISHED]");
+        finishedStateChecker.validateOperatorsFinishedState();
+    }
+
+    @Test
+    public void testAddingRunningOperatorBeforeFinishedOneFails() throws Exception {
+        JobVertexID jobVertexID2 = new JobVertexID();
+
+        testAddingOperatorsBeforePartiallyOrFullyFinishedOne(
+                new JobVertexID(),
+                "vert1",
+                VertexFinishedStateChecker.VertexFinishedState.ALL_RUNNING,
+                jobVertexID2,
+                "vert2",
+                VertexFinishedStateChecker.VertexFinishedState.FULLY_FINISHED,
+                new DistributionPattern[] {DistributionPattern.ALL_TO_ALL},
+                FlinkRuntimeException.class,
+                "Illegal JobGraph modification. Cannot run a program with fully finished vertices"
+                        + " predeceased with the ones not fully finished. Task vertex vert2"
+                        + "("
+                        + jobVertexID2
+                        + ")"
+                        + " has a predecessor not fully finished");
+    }
+
+    @Test
+    public void testAddingPartiallyFinishedOperatorBeforeFinishedOneFails() throws Exception {
+        JobVertexID jobVertexID2 = new JobVertexID();
+
+        testAddingOperatorsBeforePartiallyOrFullyFinishedOne(
+                new JobVertexID(),
+                "vert1",
+                VertexFinishedStateChecker.VertexFinishedState.PARTIALLY_FINISHED,
+                jobVertexID2,
+                "vert2",
+                VertexFinishedStateChecker.VertexFinishedState.FULLY_FINISHED,
+                new DistributionPattern[] {DistributionPattern.ALL_TO_ALL},
+                FlinkRuntimeException.class,
+                "Illegal JobGraph modification. Cannot run a program with fully finished vertices"
+                        + " predeceased with the ones not fully finished. Task vertex vert2"
+                        + "("
+                        + jobVertexID2
+                        + ")"
+                        + " has a predecessor not fully finished");
+    }
+
+    @Test
+    public void testAddingAllRunningOperatorBeforePartiallyFinishedOneWithAllToAllFails()
+            throws Exception {
+        JobVertexID jobVertexID2 = new JobVertexID();
+
+        testAddingOperatorsBeforePartiallyOrFullyFinishedOne(
+                new JobVertexID(),
+                "vert1",
+                VertexFinishedStateChecker.VertexFinishedState.ALL_RUNNING,
+                jobVertexID2,
+                "vert2",
+                VertexFinishedStateChecker.VertexFinishedState.PARTIALLY_FINISHED,
+                new DistributionPattern[] {DistributionPattern.ALL_TO_ALL},
+                FlinkRuntimeException.class,
+                "Illegal JobGraph modification. Cannot run a program with partially finished vertices"
+                        + " predeceased with running or partially finished ones and connected via the ALL_TO_ALL edges. "
+                        + "Task vertex vert2"
+                        + "("
+                        + jobVertexID2
+                        + ")"
+                        + " has a all running predecessor");
+    }
+
+    @Test
+    public void testAddingPartiallyFinishedOperatorBeforePartiallyFinishedOneWithAllToAllFails()
+            throws Exception {
+        JobVertexID jobVertexID2 = new JobVertexID();
+
+        testAddingOperatorsBeforePartiallyOrFullyFinishedOne(
+                new JobVertexID(),
+                "vert1",
+                VertexFinishedStateChecker.VertexFinishedState.PARTIALLY_FINISHED,
+                jobVertexID2,
+                "vert2",
+                VertexFinishedStateChecker.VertexFinishedState.PARTIALLY_FINISHED,
+                new DistributionPattern[] {DistributionPattern.ALL_TO_ALL},
+                FlinkRuntimeException.class,
+                "Illegal JobGraph modification. Cannot run a program with partially finished vertices"
+                        + " predeceased with running or partially finished ones and connected via the ALL_TO_ALL edges. "
+                        + "Task vertex vert2"
+                        + "("
+                        + jobVertexID2
+                        + ")"
+                        + " has a partially finished predecessor");
+    }
+
+    @Test
+    public void
+            testAddingPartiallyFinishedOperatorBeforePartiallyFinishedOneWithPointwiseAndAllToAllFails()
+                    throws Exception {
+        JobVertexID jobVertexID2 = new JobVertexID();
+
+        testAddingOperatorsBeforePartiallyOrFullyFinishedOne(
+                new JobVertexID(),
+                "vert1",
+                VertexFinishedStateChecker.VertexFinishedState.PARTIALLY_FINISHED,
+                jobVertexID2,
+                "vert2",
+                VertexFinishedStateChecker.VertexFinishedState.PARTIALLY_FINISHED,
+                new DistributionPattern[] {
+                    DistributionPattern.POINTWISE, DistributionPattern.ALL_TO_ALL
+                },
+                FlinkRuntimeException.class,
+                "Illegal JobGraph modification. Cannot run a program with partially finished vertices"
+                        + " predeceased with running or partially finished ones and connected via the ALL_TO_ALL edges. "
+                        + "Task vertex vert2"
+                        + "("
+                        + jobVertexID2
+                        + ")"
+                        + " has a partially finished predecessor");
+    }
+
+    @Test
+    public void testAddingAllRunningOperatorBeforePartiallyFinishedOneFails() throws Exception {
+        JobVertexID jobVertexID2 = new JobVertexID();
+
+        testAddingOperatorsBeforePartiallyOrFullyFinishedOne(
+                new JobVertexID(),
+                "vert1",
+                VertexFinishedStateChecker.VertexFinishedState.ALL_RUNNING,
+                jobVertexID2,
+                "vert2",
+                VertexFinishedStateChecker.VertexFinishedState.PARTIALLY_FINISHED,
+                new DistributionPattern[] {DistributionPattern.POINTWISE},
+                FlinkRuntimeException.class,
+                "Illegal JobGraph modification. Cannot run a program with partially finished vertices"
+                        + " predeceased with all running ones. "
+                        + "Task vertex vert2"
+                        + "("
+                        + jobVertexID2
+                        + ")"
+                        + " has a all running predecessor");
+    }
+
+    private void testAddingOperatorsBeforePartiallyOrFullyFinishedOne(
+            JobVertexID firstVertexId,
+            String firstVertexName,
+            VertexFinishedStateChecker.VertexFinishedState firstOperatorFinishedState,
+            JobVertexID secondVertexId,
+            String secondVertexName,
+            VertexFinishedStateChecker.VertexFinishedState secondOperatorFinishedState,
+            DistributionPattern[] distributionPatterns,
+            Class<? extends Throwable> expectedExceptionalClass,
+            String expectedMessage)
+            throws Exception {
+        OperatorIDPair op1 = OperatorIDPair.generatedIDOnly(new OperatorID());
+        OperatorIDPair op2 = OperatorIDPair.generatedIDOnly(new OperatorID());
+        JobVertex vertex1 = new JobVertex(firstVertexName, firstVertexId, singletonList(op1));
+        JobVertex vertex2 = new JobVertex(secondVertexName, secondVertexId, singletonList(op2));
+        vertex1.setInvokableClass(NoOpInvokable.class);
+        vertex2.setInvokableClass(NoOpInvokable.class);
+
+        final ExecutionGraph graph =
+                new CheckpointCoordinatorTestingUtils.CheckpointExecutionGraphBuilder()
+                        .addJobVertex(vertex1, true)
+                        .addJobVertex(vertex2, false)
+                        .setDistributionPattern(distributionPatterns[0])
+                        .build();
+
+        // Adds the additional edges
+        for (int i = 1; i < distributionPatterns.length; ++i) {
+            vertex2.connectNewDataSetAsInput(
+                    vertex1, distributionPatterns[i], ResultPartitionType.PIPELINED);
+        }
+
+        Map<OperatorID, OperatorState> operatorStates = new HashMap<>();
+        operatorStates.put(
+                op1.getGeneratedOperatorID(),
+                createOperatorState(op1.getGeneratedOperatorID(), firstOperatorFinishedState));
+        operatorStates.put(
+                op2.getGeneratedOperatorID(),
+                createOperatorState(op2.getGeneratedOperatorID(), secondOperatorFinishedState));
+
+        Set<ExecutionJobVertex> vertices = new HashSet<>();
+        vertices.add(graph.getJobVertex(vertex1.getID()));
+        vertices.add(graph.getJobVertex(vertex2.getID()));
+        VertexFinishedStateChecker finishedStateChecker =
+                new VertexFinishedStateChecker(vertices, operatorStates);
+
+        thrown.expect(expectedExceptionalClass);
+        thrown.expectMessage(expectedMessage);
+        finishedStateChecker.validateOperatorsFinishedState();
+    }
+
+    private OperatorState createOperatorState(
+            OperatorID operatorId, VertexFinishedStateChecker.VertexFinishedState finishedState) {
+        switch (finishedState) {
+            case ALL_RUNNING:
+                return new OperatorState(operatorId, 2, 2);
+            case PARTIALLY_FINISHED:
+                OperatorState operatorState = new OperatorState(operatorId, 2, 2);
+                operatorState.putState(0, FinishedOperatorSubtaskState.INSTANCE);
+                return operatorState;
+            case FULLY_FINISHED:
+                return new FullyFinishedOperatorState(operatorId, 2, 2);
+            default:
+                throw new UnsupportedOperationException(
+                        "Not supported finished state: " + finishedState);
+        }
+    }
+}

--- a/flink-runtime/src/test/java/org/apache/flink/runtime/checkpoint/VertexFinishedStateCheckerTest.java
+++ b/flink-runtime/src/test/java/org/apache/flink/runtime/checkpoint/VertexFinishedStateCheckerTest.java
@@ -29,9 +29,7 @@ import org.apache.flink.runtime.jobgraph.OperatorID;
 import org.apache.flink.runtime.testtasks.NoOpInvokable;
 import org.apache.flink.util.FlinkRuntimeException;
 
-import org.junit.Rule;
 import org.junit.Test;
-import org.junit.rules.ExpectedException;
 
 import java.util.Arrays;
 import java.util.HashMap;
@@ -40,11 +38,13 @@ import java.util.Map;
 import java.util.Set;
 
 import static java.util.Collections.singletonList;
+import static org.hamcrest.CoreMatchers.equalTo;
+import static org.hamcrest.MatcherAssert.assertThat;
+import static org.hamcrest.Matchers.is;
+import static org.junit.jupiter.api.Assertions.assertThrows;
 
 /** This tests verifies the checking logic of {@link VertexFinishedStateChecker}. */
 public class VertexFinishedStateCheckerTest {
-
-    @Rule public ExpectedException thrown = ExpectedException.none();
 
     @Test
     public void testRestoringPartiallyFinishedChainsFailsWithoutUidHash() throws Exception {
@@ -87,14 +87,19 @@ public class VertexFinishedStateCheckerTest {
         VertexFinishedStateChecker finishedStateChecker =
                 new VertexFinishedStateChecker(vertices, operatorStates);
 
-        thrown.expect(FlinkRuntimeException.class);
-        thrown.expectMessage(
-                "Can not restore vertex "
-                        + "anon("
-                        + jobVertexID1
-                        + ")"
-                        + " which contain mixed operator finished state: [ALL_RUNNING, FULLY_FINISHED]");
-        finishedStateChecker.validateOperatorsFinishedState();
+        FlinkRuntimeException exception =
+                assertThrows(
+                        FlinkRuntimeException.class,
+                        finishedStateChecker::validateOperatorsFinishedState);
+        assertThat(
+                exception.getMessage(),
+                is(
+                        equalTo(
+                                "Can not restore vertex "
+                                        + "anon("
+                                        + jobVertexID1
+                                        + ")"
+                                        + " which contain mixed operator finished state: [ALL_RUNNING, FULLY_FINISHED]")));
     }
 
     @Test
@@ -278,9 +283,11 @@ public class VertexFinishedStateCheckerTest {
         VertexFinishedStateChecker finishedStateChecker =
                 new VertexFinishedStateChecker(vertices, operatorStates);
 
-        thrown.expect(expectedExceptionalClass);
-        thrown.expectMessage(expectedMessage);
-        finishedStateChecker.validateOperatorsFinishedState();
+        Throwable exception =
+                assertThrows(
+                        expectedExceptionalClass,
+                        finishedStateChecker::validateOperatorsFinishedState);
+        assertThat(exception.getMessage(), is(equalTo(expectedMessage)));
     }
 
     private OperatorState createOperatorState(


### PR DESCRIPTION
## What is the purpose of the change

This PR refactors the tests related to the checking of restoring states for graph with finished vertices to directly tests the most atomic component, namely `VertexFinishedStateChecker`.

## Brief change log

- 68d4546ad8600dc12959a90aa338e3f91537db24 moved the related tests to a separate file and refactored the tests.


## Verifying this change

This change is a trivial rework / code cleanup without any test coverage.


## Does this pull request potentially affect one of the following parts:

  - Dependencies (does it add or upgrade a dependency): **no**
  - The public API, i.e., is any changed class annotated with `@Public(Evolving)`: **no**
  - The serializers: **no**
  - The runtime per-record code paths (performance sensitive): **no**
  - Anything that affects deployment or recovery: JobManager (and its components), Checkpointing, Kubernetes/Yarn, ZooKeeper: **no**
  - The S3 file system connector: **no**

## Documentation

  - Does this pull request introduce a new feature? **no**
  - If yes, how is the feature documented? **not applicable**
