### PR TITLE
[FLINK-25460][core] Update slf4j-api dependency to 1.7.32

### DIFF
--- a/docs/content.zh/docs/dev/datastream/project-configuration.md
+++ b/docs/content.zh/docs/dev/datastream/project-configuration.md
@@ -330,7 +330,7 @@ ext {
     javaVersion = '1.8'
     flinkVersion = '1.13-SNAPSHOT'
     scalaBinaryVersion = '2.11'
-    slf4jVersion = '1.7.15'
+    slf4jVersion = '1.7.32'
     log4jVersion = '2.17.1'
 }
 

--- a/docs/content/docs/dev/datastream/project-configuration.md
+++ b/docs/content/docs/dev/datastream/project-configuration.md
@@ -329,7 +329,7 @@ ext {
     javaVersion = '1.8'
     flinkVersion = '1.13-SNAPSHOT'
     scalaBinaryVersion = '2.11'
-    slf4jVersion = '1.7.15'
+    slf4jVersion = '1.7.32'
     log4jVersion = '2.17.1'
 }
 

--- a/flink-dist/src/main/resources/META-INF/NOTICE
+++ b/flink-dist/src/main/resources/META-INF/NOTICE
@@ -29,7 +29,7 @@ See bundled license files for details.
 This project bundles the following dependencies under the MIT/X11 license.
 See bundled license files for details.
 
-- org.slf4j:slf4j-api:1.7.15
+- org.slf4j:slf4j-api:1.7.32
 
 This project bundles the following dependencies under the CDDL 1.1 license.
 See bundled license files for details.

--- a/pom.xml
+++ b/pom.xml
@@ -107,7 +107,7 @@ under the License.
 		<flink.shaded.jackson.version>2.12.4</flink.shaded.jackson.version>
 		<guava.version>18.0</guava.version>
 		<target.java.version>1.8</target.java.version>
-		<slf4j.version>1.7.15</slf4j.version>
+		<slf4j.version>1.7.32</slf4j.version>
 		<log4j.version>2.17.1</log4j.version>
 		<!-- Overwrite default values from parent pom.
 			 Intellij is (sometimes?) using those values to choose target language level


### PR DESCRIPTION
## What is the purpose of the change

* Update slf4j-api from 1.7.15 to 1.7.32

## Brief change log

* Updated POM, license file and other references to outdated version

## Verifying this change

This change is a trivial rework / code cleanup without any test coverage.

## Does this pull request potentially affect one of the following parts:

  - Dependencies (does it add or upgrade a dependency): yes
  - The public API, i.e., is any changed class annotated with `@Public(Evolving)`: no
  - The serializers: no
  - The runtime per-record code paths (performance sensitive): no
  - Anything that affects deployment or recovery: JobManager (and its components), Checkpointing, Kubernetes/Yarn, ZooKeeper: no
  - The S3 file system connector: no

## Documentation

  - Does this pull request introduce a new feature? no
  - If yes, how is the feature documented? not applicable
