### PR TITLE
[hotfix][python][docs] Fix typo in a description of submitting option.

### DIFF
--- a/docs/content.zh/docs/deployment/cli.md
+++ b/docs/content.zh/docs/deployment/cli.md
@@ -442,7 +442,7 @@ related options. Here's an overview of all the Python related options for the ac
         <tr>
             <td><code class="highlighter-rouge">-py,--python</code></td>
             <td>
-                Python script with the program entry. The dependent resources can be configured
+                Python script with the program entry point. The dependent resources can be configured
                 with the <code class="highlighter-rouge">--pyFiles</code> option.
             </td>
         </tr>

--- a/docs/content/docs/deployment/cli.md
+++ b/docs/content/docs/deployment/cli.md
@@ -440,7 +440,7 @@ related options. Here's an overview of all the Python related options for the ac
         <tr>
             <td><code class="highlighter-rouge">-py,--python</code></td>
             <td>
-                Python script with the program entry. The dependent resources can be configured
+                Python script with the program entry point. The dependent resources can be configured
                 with the <code class="highlighter-rouge">--pyFiles</code> option.
             </td>
         </tr>


### PR DESCRIPTION
## What is the purpose of the change

There is a typo in following docs
https://nightlies.apache.org/flink/flink-docs-master/docs/deployment/cli/#submitting-pyflink-jobs

## Brief change log

  - *change 'entry' to 'entry point' in the description of '--py' option*

## Verifying this change

None

## Does this pull request potentially affect one of the following parts:

  - Dependencies (does it add or upgrade a dependency): (no)
  - The public API, i.e., is any changed class annotated with `@Public(Evolving)`: (no)
  - The serializers: (no)
  - The runtime per-record code paths (performance sensitive): (no)
  - Anything that affects deployment or recovery: JobManager (and its components), Checkpointing, Kubernetes/Yarn, ZooKeeper: (no)
  - The S3 file system connector: (no)

## Documentation

  - Does this pull request introduce a new feature? (no)
  - If yes, how is the feature documented? (not documented)
