### PR TITLE
[FLINK-25335][Runtime/Coordination, Connectors/Hive] Improvement of task deployment by enable source split asynchronous enumerate

### DIFF
--- a/flink-connectors/flink-connector-files/src/main/java/org/apache/flink/connector/file/src/AbstractFileSource.java
+++ b/flink-connectors/flink-connector-files/src/main/java/org/apache/flink/connector/file/src/AbstractFileSource.java
@@ -42,6 +42,7 @@ import javax.annotation.Nullable;
 
 import java.io.IOException;
 import java.time.Duration;
+import java.util.ArrayList;
 import java.util.Collection;
 import java.util.HashSet;
 import java.util.stream.Collectors;
@@ -134,16 +135,17 @@ public abstract class AbstractFileSource<T, SplitT extends FileSourceSplit>
 
         // read the initial set of splits (which is also the total set of splits for bounded
         // sources)
-        final Collection<FileSourceSplit> splits;
+        Collection<FileSourceSplit> splits = new ArrayList<>();
+        SplitEnumerator splitEnumerator = createSplitEnumerator(enumContext, enumerator, splits, null);
         try {
             // TODO - in the next cleanup pass, we should try to remove the need to "wrap unchecked"
             // here
-            splits = enumerator.enumerateSplits(inputPaths, enumContext.currentParallelism());
+            enumerator.enumerateSplitsAsync(inputPaths, enumContext.currentParallelism(), splitEnumerator);
         } catch (IOException e) {
             throw new FlinkRuntimeException("Could not enumerate file splits", e);
         }
 
-        return createSplitEnumerator(enumContext, enumerator, splits, null);
+        return splitEnumerator;
     }
 
     @Override

--- a/flink-connectors/flink-connector-files/src/main/java/org/apache/flink/connector/file/src/assigners/FileSplitAssigner.java
+++ b/flink-connectors/flink-connector-files/src/main/java/org/apache/flink/connector/file/src/assigners/FileSplitAssigner.java
@@ -51,6 +51,20 @@ public interface FileSplitAssigner {
     /** Gets the remaining splits that this assigner has pending. */
     Collection<FileSourceSplit> remainingSplits();
 
+    /**
+     * set all splits ready.
+     * @param ready
+     */
+    default void setAllSplitsReady(boolean ready) {}
+
+    /**
+     * get whether all splits is ready.
+     * @return
+     */
+    default boolean isAllSplitsReady() {
+        return true;
+    }
+
     // ------------------------------------------------------------------------
 
     /**

--- a/flink-connectors/flink-connector-files/src/main/java/org/apache/flink/connector/file/src/enumerate/FileEnumerator.java
+++ b/flink-connectors/flink-connector-files/src/main/java/org/apache/flink/connector/file/src/enumerate/FileEnumerator.java
@@ -19,6 +19,7 @@
 package org.apache.flink.connector.file.src.enumerate;
 
 import org.apache.flink.annotation.PublicEvolving;
+import org.apache.flink.api.connector.source.SplitEnumerator;
 import org.apache.flink.connector.file.src.FileSourceSplit;
 import org.apache.flink.core.fs.Path;
 
@@ -43,6 +44,9 @@ public interface FileEnumerator {
      */
     Collection<FileSourceSplit> enumerateSplits(Path[] paths, int minDesiredSplits)
             throws IOException;
+
+    default void enumerateSplitsAsync(Path[] paths, int minDesiredSplits, SplitEnumerator splitEnumerator)
+            throws IOException {}
 
     // ------------------------------------------------------------------------
 

--- a/flink-connectors/flink-connector-files/src/main/java/org/apache/flink/connector/file/src/impl/FileSourceReader.java
+++ b/flink-connectors/flink-connector-files/src/main/java/org/apache/flink/connector/file/src/impl/FileSourceReader.java
@@ -69,4 +69,9 @@ public final class FileSourceReader<T, SplitT extends FileSourceSplit>
     protected SplitT toSplitType(String splitId, FileSourceSplitState<SplitT> splitState) {
         return splitState.toFileSourceSplit();
     }
+
+    @Override
+    public void sendSplitRequest() {
+        context.sendSplitRequest();
+    }
 }

--- a/flink-connectors/flink-connector-files/src/main/java/org/apache/flink/connector/file/src/impl/StaticFileSplitEnumerator.java
+++ b/flink-connectors/flink-connector-files/src/main/java/org/apache/flink/connector/file/src/impl/StaticFileSplitEnumerator.java
@@ -101,8 +101,13 @@ public class StaticFileSplitEnumerator
             context.assignSplit(split, subtask);
             LOG.info("Assigned split to subtask {} : {}", subtask, split);
         } else {
-            context.signalNoMoreSplits(subtask);
-            LOG.info("No more splits available for subtask {}", subtask);
+            if (splitAssigner.isAllSplitsReady()) {
+                context.signalNoMoreSplits(subtask);
+                LOG.info("No more splits available for subtask {}", subtask);
+            } else {
+                context.signalSplitNotReady(subtask);
+                LOG.info("splits not ready for subtask {}", subtask);
+            }
         }
     }
 
@@ -120,5 +125,10 @@ public class StaticFileSplitEnumerator
     @Override
     public PendingSplitsCheckpoint<FileSourceSplit> snapshotState(long checkpointId) {
         return PendingSplitsCheckpoint.fromCollectionSnapshot(splitAssigner.remainingSplits());
+    }
+
+    @Override
+    public void notifyAllSplitsReady() {
+        splitAssigner.setAllSplitsReady(true);
     }
 }

--- a/flink-core/src/main/java/org/apache/flink/api/connector/source/SourceReader.java
+++ b/flink-core/src/main/java/org/apache/flink/api/connector/source/SourceReader.java
@@ -132,4 +132,7 @@ public interface SourceReader<T, SplitT extends SourceSplit>
      */
     @Override
     default void notifyCheckpointComplete(long checkpointId) throws Exception {}
+
+    /** send split request. */
+    default void sendSplitRequest() {}
 }

--- a/flink-core/src/main/java/org/apache/flink/api/connector/source/SplitEnumerator.java
+++ b/flink-core/src/main/java/org/apache/flink/api/connector/source/SplitEnumerator.java
@@ -118,4 +118,7 @@ public interface SplitEnumerator<SplitT extends SourceSplit, CheckpointT>
      * @param sourceEvent the source event from the source reader.
      */
     default void handleSourceEvent(int subtaskId, SourceEvent sourceEvent) {}
+
+    /** notify all splits is ready. */
+    default void notifyAllSplitsReady() {}
 }

--- a/flink-core/src/main/java/org/apache/flink/api/connector/source/SplitEnumeratorContext.java
+++ b/flink-core/src/main/java/org/apache/flink/api/connector/source/SplitEnumeratorContext.java
@@ -95,6 +95,13 @@ public interface SplitEnumeratorContext<SplitT extends SourceSplit> {
     void signalNoMoreSplits(int subtask);
 
     /**
+     * signals a subtask that split not ready for its request .
+     *
+     * @param subtask The index of operator's parallel subtask that shall be signaled .
+     */
+    default void signalSplitNotReady(int subtask) {}
+
+    /**
      * Invoke the callable and handover the return value to the handler which will be executed by
      * the source coordinator. When this method is invoked multiple times, The <code>Callable</code>
      * s may be executed in a thread pool concurrently.

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/source/coordinator/SourceCoordinatorContext.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/source/coordinator/SourceCoordinatorContext.java
@@ -33,6 +33,7 @@ import org.apache.flink.runtime.operators.coordination.OperatorEvent;
 import org.apache.flink.runtime.source.event.AddSplitEvent;
 import org.apache.flink.runtime.source.event.NoMoreSplitsEvent;
 import org.apache.flink.runtime.source.event.SourceEventWrapper;
+import org.apache.flink.runtime.source.event.SplitNotReadyEvent;
 import org.apache.flink.util.ExceptionUtils;
 import org.apache.flink.util.FlinkRuntimeException;
 import org.apache.flink.util.ThrowableCatchingRunnable;
@@ -222,6 +223,17 @@ public class SourceCoordinatorContext<SplitT extends SourceSplit>
                     return null; // void return value
                 },
                 "Failed to send 'NoMoreSplits' to reader " + subtask);
+    }
+
+    @Override
+    public void signalSplitNotReady(int subtask) {
+        callInCoordinatorThread(
+                () -> {
+                    final OperatorCoordinator.SubtaskGateway gateway =
+                            getGatewayAndCheckReady(subtask);
+                    gateway.sendEvent(new SplitNotReadyEvent());
+                    return null;
+                }, "Failed to send 'SplitNotReady' to reader" + subtask);
     }
 
     @Override

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/source/event/SplitNotReadyEvent.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/source/event/SplitNotReadyEvent.java
@@ -1,0 +1,17 @@
+package org.apache.flink.runtime.source.event;
+
+import org.apache.flink.runtime.operators.coordination.OperatorEvent;
+
+/**
+ * event for split not ready.
+ */
+public class SplitNotReadyEvent implements OperatorEvent {
+
+    private static final long serialVersionUID = 1L;
+
+    @Override
+    public String toString() {
+        return "[SplitNotReadyEvent]";
+    }
+
+}

--- a/flink-streaming-java/src/main/java/org/apache/flink/streaming/api/operators/SourceOperator.java
+++ b/flink-streaming-java/src/main/java/org/apache/flink/streaming/api/operators/SourceOperator.java
@@ -44,6 +44,7 @@ import org.apache.flink.runtime.source.event.NoMoreSplitsEvent;
 import org.apache.flink.runtime.source.event.ReaderRegistrationEvent;
 import org.apache.flink.runtime.source.event.RequestSplitEvent;
 import org.apache.flink.runtime.source.event.SourceEventWrapper;
+import org.apache.flink.runtime.source.event.SplitNotReadyEvent;
 import org.apache.flink.runtime.state.StateInitializationContext;
 import org.apache.flink.runtime.state.StateSnapshotContext;
 import org.apache.flink.streaming.api.graph.StreamConfig;
@@ -481,6 +482,8 @@ public class SourceOperator<OUT, SplitT extends SourceSplit> extends AbstractStr
             sourceReader.handleSourceEvents(((SourceEventWrapper) event).getSourceEvent());
         } else if (event instanceof NoMoreSplitsEvent) {
             sourceReader.notifyNoMoreSplits();
+        } else if (event instanceof SplitNotReadyEvent) {
+            sourceReader.sendSplitRequest();
         } else {
             throw new IllegalStateException("Received unexpected operator event " + event);
         }


### PR DESCRIPTION
## What is the purpose of the change
Enable hive source file splits asynchronous enumerate in olap query ,  which would be better to the task deployment .

## Brief change log
Implements the function of source file asynchronous enumerate in HiveSourceFileEnumerator#enumerateSplitsAsync.  when submit the query and the source coordinator start, it will call the `enumerateSplitsAsync` method  to enumerate splits , which would submit a task to asynchronous enumerate splits, and meanwhile the olap query task will be deployed.  Then, the source operator(reader) will use `sendSplitRequest` to get the split, and read the data. 

## Verifying this change
Test manually by running a sql query submitted by sql client, and the hive source table has thousands of partitions. at first, the source split enumerate will block the task deployment for above 1 minute, by use this feature, it down to within 1 second.

## Does this pull request potentially affect one of the following parts:

  - Dependencies (does it add or upgrade a dependency): (no)
  - The public API, i.e., is any changed class annotated with `@Public(Evolving)`: (no)
  - The serializers: ( no )
  - The runtime per-record code paths (performance sensitive): (don't know)
  - Anything that affects deployment or recovery: JobManager (and its components), Checkpointing, Kubernetes/Yarn, ZooKeeper: (yes)
  - The S3 file system connector: (no)

## Documentation

  - Does this pull request introduce a new feature? (no)
  - If yes, how is the feature documented? (not applicable / docs / JavaDocs / not documented)
