### PR TITLE
[hotfix][doc]Fixed an issue where clicking Window Assigner and Window…

### DIFF
--- a/docs/content.zh/docs/dev/datastream/operators/windows.md
+++ b/docs/content.zh/docs/dev/datastream/operators/windows.md
@@ -86,8 +86,8 @@ Apart from the above, you can specify an `Evictor` (see [Evictors](#evictors)) w
 elements from the window after the trigger fires and before and/or after the function is applied.
 
 In the following we go into more detail for each of the components above. We start with the required parts in the above
-snippet (see [Keyed vs Non-Keyed Windows](#keyed-vs-non-keyed-windows), [Window Assigner](#window-assigner), and
-[Window Function](#window-function)) before moving to the optional ones.
+snippet (see [Keyed vs Non-Keyed Windows](#keyed-vs-non-keyed-windows), [Window Assigners](#window-assigners), and
+[Window Functions](#window-functions)) before moving to the optional ones.
 
 ## Keyed vs Non-Keyed Windows
 

--- a/docs/content/docs/dev/datastream/operators/windows.md
+++ b/docs/content/docs/dev/datastream/operators/windows.md
@@ -86,8 +86,8 @@ Apart from the above, you can specify an `Evictor` (see [Evictors](#evictors)) w
 elements from the window after the trigger fires and before and/or after the function is applied.
 
 In the following we go into more detail for each of the components above. We start with the required parts in the above
-snippet (see [Keyed vs Non-Keyed Windows](#keyed-vs-non-keyed-windows), [Window Assigner](#window-assigner), and
-[Window Function](#window-function)) before moving to the optional ones.
+snippet (see [Keyed vs Non-Keyed Windows](#keyed-vs-non-keyed-windows), [Window Assigners](#window-assigners), and
+[Window Functions](#window-functions)) before moving to the optional ones.
 
 ## Keyed vs Non-Keyed Windows
 


### PR DESCRIPTION

## What is the purpose of the change
When I was reading the Windows document, I found that clicking Window Assigner and Window Function in the red circle in the figure could not jump to the correct position, and then I tried to fix it.
![image](https://user-images.githubusercontent.com/50078045/147530390-bfdb51da-03a0-44f9-ad0c-201b70ed0a67.png)

## Brief change log

Modify Window Assigner and Window Function to the correct title


## Verifying this change

Please make sure both new and modified tests in this PR follows the conventions defined in our code quality guide: https://flink.apache.org/contributing/code-style-and-quality-common.html#testing

*(Please pick either of the following options)*

This change is a trivial rework / code cleanup without any test coverage.


## Does this pull request potentially affect one of the following parts:

  - Dependencies (does it add or upgrade a dependency): (yes / no) no
  - The public API, i.e., is any changed class annotated with `@Public(Evolving)`: (yes / no) no
  - The serializers: (yes / no / don't know) no
  - The runtime per-record code paths (performance sensitive): (yes / no / don't know) no
  - Anything that affects deployment or recovery: JobManager (and its components), Checkpointing, Kubernetes/Yarn, ZooKeeper: (yes / no / don't know) no
  - The S3 file system connector: (yes / no / don't know) no

## Documentation

  - Does this pull request introduce a new feature? (yes / no) no
  - If yes, how is the feature documented? (not applicable / docs / JavaDocs / not documented) no
