### PR TITLE
[FLINK-25465][state] Correct the logic of materizating wrapped changelog state

### DIFF
--- a/flink-state-backends/flink-statebackend-changelog/src/main/java/org/apache/flink/state/changelog/ChangelogKeyedStateBackend.java
+++ b/flink-state-backends/flink-statebackend-changelog/src/main/java/org/apache/flink/state/changelog/ChangelogKeyedStateBackend.java
@@ -141,16 +141,16 @@ public class ChangelogKeyedStateBackend<K>
      * This is the cache maintained by the DelegateKeyedStateBackend itself. It is not the same as
      * the underlying delegated keyedStateBackend. InternalKvState is a delegated state.
      */
-    private final HashMap<String, InternalKvState<K, ?, ?>> keyValueStatesByName;
+    private final Map<String, InternalKvState<K, ?, ?>> keyValueStatesByName;
 
     /**
      * Unwrapped changelog states used for recovery (not wrapped into e.g. TTL).
      *
      * <p>WARN: cleared upon recovery completion.
      */
-    private final HashMap<String, ChangelogState> changelogStates;
+    private final Map<String, ChangelogState> changelogStates;
 
-    private final HashMap<String, ChangelogKeyGroupedPriorityQueue<?>> priorityQueueStatesByName;
+    private final Map<String, ChangelogKeyGroupedPriorityQueue<?>> priorityQueueStatesByName;
 
     private final ExecutionConfig executionConfig;
 

--- a/flink-state-backends/flink-statebackend-changelog/src/test/java/org/apache/flink/state/changelog/ChangelogDelegateEmbeddedRocksDBStateBackendTest.java
+++ b/flink-state-backends/flink-statebackend-changelog/src/test/java/org/apache/flink/state/changelog/ChangelogDelegateEmbeddedRocksDBStateBackendTest.java
@@ -18,7 +18,11 @@
 
 package org.apache.flink.state.changelog;
 
+import org.apache.flink.api.common.state.StateTtlConfig;
+import org.apache.flink.api.common.time.Time;
 import org.apache.flink.api.common.typeutils.TypeSerializer;
+import org.apache.flink.configuration.Configuration;
+import org.apache.flink.configuration.StateBackendOptions;
 import org.apache.flink.contrib.streaming.state.EmbeddedRocksDBStateBackend;
 import org.apache.flink.contrib.streaming.state.EmbeddedRocksDBStateBackendTest;
 import org.apache.flink.runtime.execution.Environment;
@@ -26,6 +30,7 @@ import org.apache.flink.runtime.state.CheckpointStreamFactory;
 import org.apache.flink.runtime.state.CheckpointableKeyedStateBackend;
 import org.apache.flink.runtime.state.ConfigurableStateBackend;
 import org.apache.flink.runtime.state.KeyGroupRange;
+import org.apache.flink.runtime.state.StateBackend;
 import org.apache.flink.runtime.state.TestTaskStateManager;
 
 import org.junit.Ignore;
@@ -91,7 +96,23 @@ public class ChangelogDelegateEmbeddedRocksDBStateBackendTest
         CheckpointStreamFactory streamFactory = createStreamFactory();
 
         ChangelogStateBackendTestUtils.testMaterializedRestore(
-                getStateBackend(), env, streamFactory);
+                getStateBackend(), StateTtlConfig.DISABLED, env, streamFactory);
+    }
+
+    @Test
+    public void testMaterializedRestoreWithWrappedState() throws Exception {
+        CheckpointStreamFactory streamFactory = createStreamFactory();
+
+        Configuration configuration = new Configuration();
+        configuration.set(StateBackendOptions.LATENCY_TRACK_ENABLED, true);
+        StateBackend stateBackend =
+                getStateBackend()
+                        .configure(configuration, Thread.currentThread().getContextClassLoader());
+        ChangelogStateBackendTestUtils.testMaterializedRestore(
+                stateBackend,
+                StateTtlConfig.newBuilder(Time.minutes(1)).build(),
+                env,
+                streamFactory);
     }
 
     @Test

--- a/flink-state-backends/flink-statebackend-changelog/src/test/java/org/apache/flink/state/changelog/ChangelogDelegateFileStateBackendTest.java
+++ b/flink-state-backends/flink-statebackend-changelog/src/test/java/org/apache/flink/state/changelog/ChangelogDelegateFileStateBackendTest.java
@@ -18,7 +18,11 @@
 
 package org.apache.flink.state.changelog;
 
+import org.apache.flink.api.common.state.StateTtlConfig;
+import org.apache.flink.api.common.time.Time;
 import org.apache.flink.api.common.typeutils.TypeSerializer;
+import org.apache.flink.configuration.Configuration;
+import org.apache.flink.configuration.StateBackendOptions;
 import org.apache.flink.runtime.execution.Environment;
 import org.apache.flink.runtime.state.CheckpointStorage;
 import org.apache.flink.runtime.state.CheckpointStreamFactory;
@@ -26,6 +30,7 @@ import org.apache.flink.runtime.state.CheckpointableKeyedStateBackend;
 import org.apache.flink.runtime.state.ConfigurableStateBackend;
 import org.apache.flink.runtime.state.FileStateBackendTest;
 import org.apache.flink.runtime.state.KeyGroupRange;
+import org.apache.flink.runtime.state.StateBackend;
 import org.apache.flink.runtime.state.TestTaskStateManager;
 import org.apache.flink.runtime.state.filesystem.FsStateBackend;
 import org.apache.flink.runtime.state.storage.JobManagerCheckpointStorage;
@@ -87,7 +92,23 @@ public class ChangelogDelegateFileStateBackendTest extends FileStateBackendTest 
         CheckpointStreamFactory streamFactory = createStreamFactory();
 
         ChangelogStateBackendTestUtils.testMaterializedRestore(
-                getStateBackend(), env, streamFactory);
+                getStateBackend(), StateTtlConfig.DISABLED, env, streamFactory);
+    }
+
+    @Test
+    public void testMaterializedRestoreWithWrappedState() throws Exception {
+        CheckpointStreamFactory streamFactory = createStreamFactory();
+
+        Configuration configuration = new Configuration();
+        configuration.set(StateBackendOptions.LATENCY_TRACK_ENABLED, true);
+        StateBackend stateBackend =
+                getStateBackend()
+                        .configure(configuration, Thread.currentThread().getContextClassLoader());
+        ChangelogStateBackendTestUtils.testMaterializedRestore(
+                stateBackend,
+                StateTtlConfig.newBuilder(Time.minutes(1)).build(),
+                env,
+                streamFactory);
     }
 
     @Test

--- a/flink-state-backends/flink-statebackend-changelog/src/test/java/org/apache/flink/state/changelog/ChangelogDelegateHashMapTest.java
+++ b/flink-state-backends/flink-statebackend-changelog/src/test/java/org/apache/flink/state/changelog/ChangelogDelegateHashMapTest.java
@@ -18,13 +18,18 @@
 
 package org.apache.flink.state.changelog;
 
+import org.apache.flink.api.common.state.StateTtlConfig;
+import org.apache.flink.api.common.time.Time;
 import org.apache.flink.api.common.typeutils.TypeSerializer;
+import org.apache.flink.configuration.Configuration;
+import org.apache.flink.configuration.StateBackendOptions;
 import org.apache.flink.runtime.execution.Environment;
 import org.apache.flink.runtime.state.CheckpointStreamFactory;
 import org.apache.flink.runtime.state.CheckpointableKeyedStateBackend;
 import org.apache.flink.runtime.state.ConfigurableStateBackend;
 import org.apache.flink.runtime.state.HashMapStateBackendTest;
 import org.apache.flink.runtime.state.KeyGroupRange;
+import org.apache.flink.runtime.state.StateBackend;
 import org.apache.flink.runtime.state.TestTaskStateManager;
 
 import org.junit.Rule;
@@ -78,7 +83,23 @@ public class ChangelogDelegateHashMapTest extends HashMapStateBackendTest {
         CheckpointStreamFactory streamFactory = createStreamFactory();
 
         ChangelogStateBackendTestUtils.testMaterializedRestore(
-                getStateBackend(), env, streamFactory);
+                getStateBackend(), StateTtlConfig.DISABLED, env, streamFactory);
+    }
+
+    @Test
+    public void testMaterializedRestoreWithWrappedState() throws Exception {
+        CheckpointStreamFactory streamFactory = createStreamFactory();
+
+        Configuration configuration = new Configuration();
+        configuration.set(StateBackendOptions.LATENCY_TRACK_ENABLED, true);
+        StateBackend stateBackend =
+                getStateBackend()
+                        .configure(configuration, Thread.currentThread().getContextClassLoader());
+        ChangelogStateBackendTestUtils.testMaterializedRestore(
+                stateBackend,
+                StateTtlConfig.newBuilder(Time.minutes(1)).build(),
+                env,
+                streamFactory);
     }
 
     @Test

--- a/flink-state-backends/flink-statebackend-changelog/src/test/java/org/apache/flink/state/changelog/ChangelogDelegateMemoryStateBackendTest.java
+++ b/flink-state-backends/flink-statebackend-changelog/src/test/java/org/apache/flink/state/changelog/ChangelogDelegateMemoryStateBackendTest.java
@@ -18,7 +18,11 @@
 
 package org.apache.flink.state.changelog;
 
+import org.apache.flink.api.common.state.StateTtlConfig;
+import org.apache.flink.api.common.time.Time;
 import org.apache.flink.api.common.typeutils.TypeSerializer;
+import org.apache.flink.configuration.Configuration;
+import org.apache.flink.configuration.StateBackendOptions;
 import org.apache.flink.runtime.execution.Environment;
 import org.apache.flink.runtime.state.CheckpointStorage;
 import org.apache.flink.runtime.state.CheckpointStreamFactory;
@@ -26,6 +30,7 @@ import org.apache.flink.runtime.state.CheckpointableKeyedStateBackend;
 import org.apache.flink.runtime.state.ConfigurableStateBackend;
 import org.apache.flink.runtime.state.KeyGroupRange;
 import org.apache.flink.runtime.state.MemoryStateBackendTest;
+import org.apache.flink.runtime.state.StateBackend;
 import org.apache.flink.runtime.state.TestTaskStateManager;
 import org.apache.flink.runtime.state.memory.MemoryStateBackend;
 import org.apache.flink.runtime.state.storage.JobManagerCheckpointStorage;
@@ -87,7 +92,23 @@ public class ChangelogDelegateMemoryStateBackendTest extends MemoryStateBackendT
         CheckpointStreamFactory streamFactory = createStreamFactory();
 
         ChangelogStateBackendTestUtils.testMaterializedRestore(
-                getStateBackend(), env, streamFactory);
+                getStateBackend(), StateTtlConfig.DISABLED, env, streamFactory);
+    }
+
+    @Test
+    public void testMaterializedRestoreWithWrappedState() throws Exception {
+        CheckpointStreamFactory streamFactory = createStreamFactory();
+
+        Configuration configuration = new Configuration();
+        configuration.set(StateBackendOptions.LATENCY_TRACK_ENABLED, true);
+        StateBackend stateBackend =
+                getStateBackend()
+                        .configure(configuration, Thread.currentThread().getContextClassLoader());
+        ChangelogStateBackendTestUtils.testMaterializedRestore(
+                stateBackend,
+                StateTtlConfig.newBuilder(Time.minutes(1)).build(),
+                env,
+                streamFactory);
     }
 
     @Test

--- a/flink-state-backends/flink-statebackend-changelog/src/test/java/org/apache/flink/state/changelog/ChangelogStateBackendTestUtils.java
+++ b/flink-state-backends/flink-statebackend-changelog/src/test/java/org/apache/flink/state/changelog/ChangelogStateBackendTestUtils.java
@@ -19,6 +19,7 @@
 package org.apache.flink.state.changelog;
 
 import org.apache.flink.api.common.JobID;
+import org.apache.flink.api.common.state.StateTtlConfig;
 import org.apache.flink.api.common.state.ValueState;
 import org.apache.flink.api.common.state.ValueStateDescriptor;
 import org.apache.flink.api.common.typeinfo.TypeInformation;
@@ -139,7 +140,10 @@ public class ChangelogStateBackendTestUtils {
     }
 
     public static void testMaterializedRestore(
-            StateBackend stateBackend, Environment env, CheckpointStreamFactory streamFactory)
+            StateBackend stateBackend,
+            StateTtlConfig stateTtlConfig,
+            Environment env,
+            CheckpointStreamFactory streamFactory)
             throws Exception {
         SharedStateRegistry sharedStateRegistry = new SharedStateRegistryImpl();
 
@@ -147,6 +151,9 @@ public class ChangelogStateBackendTestUtils {
                 new GenericTypeInfo<>(StateBackendTestBase.TestPojo.class);
         ValueStateDescriptor<StateBackendTestBase.TestPojo> kvId =
                 new ValueStateDescriptor<>("id", pojoType);
+        if (stateTtlConfig.isEnabled()) {
+            kvId.enableTimeToLive(stateTtlConfig);
+        }
 
         ChangelogKeyedStateBackend<Integer> keyedBackend =
                 (ChangelogKeyedStateBackend<Integer>) createKeyedBackend(stateBackend, env);


### PR DESCRIPTION
## What is the purpose of the change

ChangelogKeyedStateBackend#keyValueStatesByName would store wrapped state, such as TTL state or latency tracking state. It will throw exception on initMaterialization if wrapped:

~~~java
for (InternalKvState<K, ?, ?> changelogState : keyValueStatesByName.values()) {
           checkState(changelogState instanceof ChangelogState);
           ((ChangelogState) changelogState).resetWritingMetaFlag();
}
~~~


## Brief change log

  - Correct the logic in changelog keyed state backend.


## Verifying this change

This change added tests and can be verified as follows:

  - Added test `testMaterializedRestoreWithWrappedState`

## Does this pull request potentially affect one of the following parts:

  - Dependencies (does it add or upgrade a dependency): no
  - The public API, i.e., is any changed class annotated with `@Public(Evolving)`: no
  - The serializers: no
  - The runtime per-record code paths (performance sensitive): no
  - Anything that affects deployment or recovery: JobManager (and its components), Checkpointing, Kubernetes/Yarn, ZooKeeper: no
  - The S3 file system connector: no

## Documentation

  - Does this pull request introduce a new feature? no
  - If yes, how is the feature documented? not applicable
