### PR TITLE
[FLINK-25466][state] Enable state descriptor to handle StateTtlConfig#DISABLED

### DIFF
--- a/flink-core/src/main/java/org/apache/flink/api/common/state/StateDescriptor.java
+++ b/flink-core/src/main/java/org/apache/flink/api/common/state/StateDescriptor.java
@@ -264,10 +264,11 @@ public abstract class StateDescriptor<S extends State, T> implements Serializabl
      */
     public void enableTimeToLive(StateTtlConfig ttlConfig) {
         Preconditions.checkNotNull(ttlConfig);
-        Preconditions.checkArgument(
-                ttlConfig.getUpdateType() != StateTtlConfig.UpdateType.Disabled
-                        && queryableStateName == null,
-                "Queryable state is currently not supported with TTL");
+        if (ttlConfig.isEnabled()) {
+            Preconditions.checkArgument(
+                    queryableStateName == null,
+                    "Queryable state is currently not supported with TTL");
+        }
         this.ttlConfig = ttlConfig;
     }
 

--- a/flink-core/src/test/java/org/apache/flink/api/common/state/StateDescriptorTest.java
+++ b/flink-core/src/test/java/org/apache/flink/api/common/state/StateDescriptorTest.java
@@ -19,8 +19,10 @@
 package org.apache.flink.api.common.state;
 
 import org.apache.flink.api.common.ExecutionConfig;
+import org.apache.flink.api.common.time.Time;
 import org.apache.flink.api.common.typeinfo.TypeInformation;
 import org.apache.flink.api.common.typeutils.TypeSerializer;
+import org.apache.flink.api.common.typeutils.base.IntSerializer;
 import org.apache.flink.api.common.typeutils.base.StringSerializer;
 import org.apache.flink.api.java.typeutils.PojoTypeInfo;
 import org.apache.flink.api.java.typeutils.runtime.kryo.KryoSerializer;
@@ -249,6 +251,17 @@ public class StateDescriptorTest {
                 1,
                 serializers.size());
         threads.clear();
+    }
+
+    @Test
+    public void testStateTTlConfig() {
+        ValueStateDescriptor<Integer> stateDescriptor =
+                new ValueStateDescriptor<>("test-state", IntSerializer.INSTANCE);
+        stateDescriptor.enableTimeToLive(StateTtlConfig.newBuilder(Time.minutes(60)).build());
+        assertTrue(stateDescriptor.getTtlConfig().isEnabled());
+
+        stateDescriptor.enableTimeToLive(StateTtlConfig.DISABLED);
+        assertFalse(stateDescriptor.getTtlConfig().isEnabled());
     }
 
     // ------------------------------------------------------------------------


### PR DESCRIPTION
## What is the purpose of the change

Enable state descriptor to handle StateTtlConfig#DISABLED.


## Brief change log

Modify current implementation to let state descriptor could handle `StateTtlConfig.DISABLED`.


## Verifying this change

This change added tests and can be verified as follows:

Added StateDescriptorTest#testStateTTlConfig

## Does this pull request potentially affect one of the following parts:

  - Dependencies (does it add or upgrade a dependency):  no
  - The public API, i.e., is any changed class annotated with `@Public(Evolving)`:  no
  - The serializers:  no
  - The runtime per-record code paths (performance sensitive):  no
  - Anything that affects deployment or recovery: JobManager (and its components), Checkpointing, Kubernetes/Yarn, ZooKeeper:  no
  - The S3 file system connector:  no

## Documentation

  - Does this pull request introduce a new feature?  no
  - If yes, how is the feature documented? not applicable
