### PR TITLE
[FLINK-18295] Rework IntermediateDataSet and IntermediateResultPartition to explicitly have one consumer

### DIFF
--- a/flink-runtime/src/main/java/org/apache/flink/runtime/deployment/TaskDeploymentDescriptorFactory.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/deployment/TaskDeploymentDescriptorFactory.java
@@ -126,7 +126,7 @@ public class TaskDeploymentDescriptorFactory {
             IntermediateResultPartition resultPartition =
                     resultPartitionRetriever.apply(consumedPartitionGroup.getFirst());
 
-            int numConsumers = resultPartition.getConsumerVertexGroups().get(0).size();
+            int numConsumers = resultPartition.getConsumerVertexGroup().size();
 
             int queueToRequest = subtaskIndex % numConsumers;
             IntermediateResult consumedIntermediateResult = resultPartition.getIntermediateResult();

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/executiongraph/IntermediateResultPartition.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/executiongraph/IntermediateResultPartition.java
@@ -25,6 +25,8 @@ import org.apache.flink.runtime.scheduler.strategy.ConsumerVertexGroup;
 
 import java.util.List;
 
+import static org.apache.flink.util.Preconditions.checkNotNull;
+
 public class IntermediateResultPartition {
 
     private final IntermediateResult totalResult;
@@ -69,8 +71,8 @@ public class IntermediateResultPartition {
         return totalResult.getResultType();
     }
 
-    public List<ConsumerVertexGroup> getConsumerVertexGroups() {
-        return getEdgeManager().getConsumerVertexGroupsForPartition(partitionId);
+    public ConsumerVertexGroup getConsumerVertexGroup() {
+        return checkNotNull(getEdgeManager().getConsumerVertexGroupForPartition(partitionId));
     }
 
     public List<ConsumedPartitionGroup> getConsumedPartitionGroups() {

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/executiongraph/failover/flip1/RestartPipelinedRegionFailoverStrategy.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/executiongraph/failover/flip1/RestartPipelinedRegionFailoverStrategy.java
@@ -242,12 +242,11 @@ public class RestartPipelinedRegionFailoverStrategy implements FailoverStrategy 
 
         for (SchedulingExecutionVertex vertex : regionToRestart.getVertices()) {
             for (SchedulingResultPartition producedPartition : vertex.getProducedResults()) {
-                for (ConsumerVertexGroup consumerVertexGroup :
-                        producedPartition.getConsumerVertexGroups()) {
-                    if (!visitedConsumerVertexGroups.contains(consumerVertexGroup)) {
-                        visitedConsumerVertexGroups.add(consumerVertexGroup);
-                        consumerVertexGroupsToVisit.add(consumerVertexGroup);
-                    }
+                final ConsumerVertexGroup consumerVertexGroup =
+                        producedPartition.getConsumerVertexGroup();
+                if (!visitedConsumerVertexGroups.contains(consumerVertexGroup)) {
+                    visitedConsumerVertexGroups.add(consumerVertexGroup);
+                    consumerVertexGroupsToVisit.add(consumerVertexGroup);
                 }
             }
         }

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/executiongraph/failover/flip1/SchedulingPipelinedRegionComputeUtil.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/executiongraph/failover/flip1/SchedulingPipelinedRegionComputeUtil.java
@@ -114,20 +114,19 @@ public final class SchedulingPipelinedRegionComputeUtil {
                     if (!producedResult.getResultType().isReconnectable()) {
                         continue;
                     }
-                    for (ConsumerVertexGroup consumerVertexGroup :
-                            producedResult.getConsumerVertexGroups()) {
-                        for (ExecutionVertexID consumerVertexId : consumerVertexGroup) {
-                            SchedulingExecutionVertex consumerVertex =
-                                    executionVertexRetriever.apply(consumerVertexId);
-                            // Skip the ConsumerVertexGroup if its vertices are outside current
-                            // regions and cannot be merged
-                            if (!vertexToRegion.containsKey(consumerVertex)) {
-                                break;
-                            }
-                            if (!currentRegion.contains(consumerVertex)) {
-                                currentRegionOutEdges.add(
-                                        regionIndices.get(vertexToRegion.get(consumerVertex)));
-                            }
+                    final ConsumerVertexGroup consumerVertexGroup =
+                            producedResult.getConsumerVertexGroup();
+                    for (ExecutionVertexID consumerVertexId : consumerVertexGroup) {
+                        SchedulingExecutionVertex consumerVertex =
+                                executionVertexRetriever.apply(consumerVertexId);
+                        // Skip the ConsumerVertexGroup if its vertices are outside current
+                        // regions and cannot be merged
+                        if (!vertexToRegion.containsKey(consumerVertex)) {
+                            break;
+                        }
+                        if (!currentRegion.contains(consumerVertex)) {
+                            currentRegionOutEdges.add(
+                                    regionIndices.get(vertexToRegion.get(consumerVertex)));
                         }
                     }
                 }

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/jobgraph/IntermediateDataSet.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/jobgraph/IntermediateDataSet.java
@@ -20,10 +20,10 @@ package org.apache.flink.runtime.jobgraph;
 
 import org.apache.flink.runtime.io.network.partition.ResultPartitionType;
 
-import java.util.ArrayList;
-import java.util.List;
+import javax.annotation.Nullable;
 
 import static org.apache.flink.util.Preconditions.checkNotNull;
+import static org.apache.flink.util.Preconditions.checkState;
 
 /**
  * An intermediate data set is the data set produced by an operator - either a source or any
@@ -39,7 +39,7 @@ public class IntermediateDataSet implements java.io.Serializable {
 
     private final JobVertex producer; // the operation that produced this data set
 
-    private final List<JobEdge> consumers = new ArrayList<JobEdge>();
+    @Nullable private JobEdge consumer;
 
     // The type of partition to use at runtime
     private final ResultPartitionType resultType;
@@ -63,8 +63,9 @@ public class IntermediateDataSet implements java.io.Serializable {
         return producer;
     }
 
-    public List<JobEdge> getConsumers() {
-        return this.consumers;
+    @Nullable
+    public JobEdge getConsumer() {
+        return consumer;
     }
 
     public ResultPartitionType getResultType() {
@@ -74,7 +75,10 @@ public class IntermediateDataSet implements java.io.Serializable {
     // --------------------------------------------------------------------------------------------
 
     public void addConsumer(JobEdge edge) {
-        this.consumers.add(edge);
+        checkState(
+                this.consumer == null,
+                "Currently one IntermediateDataSet can have at most one consumer.");
+        this.consumer = edge;
     }
 
     // --------------------------------------------------------------------------------------------

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/jobgraph/JobGraph.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/jobgraph/JobGraph.java
@@ -452,9 +452,10 @@ public class JobGraph implements Serializable {
     private void addNodesThatHaveNoNewPredecessors(
             JobVertex start, List<JobVertex> target, Set<JobVertex> remaining) {
 
-        // forward traverse over all produced data sets and all their consumers
+        // forward traverse over all produced data sets
         for (IntermediateDataSet dataSet : start.getProducedDataSets()) {
-            for (JobEdge edge : dataSet.getConsumers()) {
+            JobEdge edge = dataSet.getConsumer();
+            if (edge != null) {
 
                 // a vertex can be added, if it has no predecessors that are still in the
                 // 'remaining' set

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/jobgraph/JobVertex.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/jobgraph/JobVertex.java
@@ -467,8 +467,7 @@ public class JobVertex implements java.io.Serializable {
     }
 
     // --------------------------------------------------------------------------------------------
-
-    public IntermediateDataSet createAndAddResultDataSet(ResultPartitionType partitionType) {
+    private IntermediateDataSet createAndAddResultDataSet(ResultPartitionType partitionType) {
         return createAndAddResultDataSet(new IntermediateDataSetID(), partitionType);
     }
 
@@ -478,14 +477,6 @@ public class JobVertex implements java.io.Serializable {
         IntermediateDataSet result = new IntermediateDataSet(id, partitionType, this);
         this.results.add(result);
         return result;
-    }
-
-    public JobEdge connectDataSetAsInput(
-            IntermediateDataSet dataSet, DistributionPattern distPattern) {
-        JobEdge edge = new JobEdge(dataSet, this, distPattern);
-        this.inputs.add(edge);
-        dataSet.addConsumer(edge);
-        return edge;
     }
 
     public JobEdge connectNewDataSetAsInput(

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/jobgraph/topology/DefaultLogicalResult.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/jobgraph/topology/DefaultLogicalResult.java
@@ -21,12 +21,9 @@ package org.apache.flink.runtime.jobgraph.topology;
 import org.apache.flink.runtime.io.network.partition.ResultPartitionType;
 import org.apache.flink.runtime.jobgraph.IntermediateDataSet;
 import org.apache.flink.runtime.jobgraph.IntermediateDataSetID;
-import org.apache.flink.runtime.jobgraph.JobEdge;
-import org.apache.flink.runtime.jobgraph.JobVertex;
 import org.apache.flink.runtime.jobgraph.JobVertexID;
 
 import java.util.function.Function;
-import java.util.stream.Collectors;
 
 import static org.apache.flink.util.Preconditions.checkNotNull;
 
@@ -60,14 +57,5 @@ public class DefaultLogicalResult implements LogicalResult {
     @Override
     public DefaultLogicalVertex getProducer() {
         return vertexRetriever.apply(intermediateDataSet.getProducer().getID());
-    }
-
-    @Override
-    public Iterable<DefaultLogicalVertex> getConsumers() {
-        return intermediateDataSet.getConsumers().stream()
-                .map(JobEdge::getTarget)
-                .map(JobVertex::getID)
-                .map(vertexRetriever)
-                .collect(Collectors.toList());
     }
 }

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/scheduler/SsgNetworkMemoryCalculationUtils.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/scheduler/SsgNetworkMemoryCalculationUtils.java
@@ -38,6 +38,7 @@ import java.util.List;
 import java.util.Map;
 import java.util.function.Function;
 
+import static org.apache.flink.util.Preconditions.checkNotNull;
 import static org.apache.flink.util.Preconditions.checkState;
 
 /**
@@ -128,12 +129,7 @@ public class SsgNetworkMemoryCalculationUtils {
 
         for (int i = 0; i < producedDataSets.size(); i++) {
             IntermediateDataSet producedDataSet = producedDataSets.get(i);
-
-            checkState(
-                    producedDataSet.getConsumers().size() == 1,
-                    "Currently a result should have exactly one consumer job vertex.");
-
-            JobEdge outputEdge = producedDataSet.getConsumers().get(0);
+            JobEdge outputEdge = checkNotNull(producedDataSet.getConsumer());
             ExecutionJobVertex consumerJobVertex = ejvs.apply(outputEdge.getTarget().getID());
             int maxNum =
                     EdgeManagerBuildUtil.computeMaxEdgesToTargetExecutionVertex(

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/scheduler/adapter/DefaultExecutionTopology.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/scheduler/adapter/DefaultExecutionTopology.java
@@ -207,7 +207,7 @@ public class DefaultExecutionTopology implements SchedulingTopology {
             List<DefaultResultPartition> producedPartitions =
                     generateProducedSchedulingResultPartition(
                             vertex.getProducedPartitions(),
-                            edgeManager::getConsumerVertexGroupsForPartition,
+                            edgeManager::getConsumerVertexGroupForPartition,
                             executionVerticesById::get);
 
             producedPartitions.forEach(
@@ -238,8 +238,8 @@ public class DefaultExecutionTopology implements SchedulingTopology {
     private static List<DefaultResultPartition> generateProducedSchedulingResultPartition(
             Map<IntermediateResultPartitionID, IntermediateResultPartition>
                     producedIntermediatePartitions,
-            Function<IntermediateResultPartitionID, List<ConsumerVertexGroup>>
-                    partitionConsumerVertexGroups,
+            Function<IntermediateResultPartitionID, ConsumerVertexGroup>
+                    partitionConsumerVertexGroupRetriever,
             Function<ExecutionVertexID, DefaultExecutionVertex> executionVertexRetriever) {
 
         List<DefaultResultPartition> producedSchedulingPartitions =
@@ -258,7 +258,7 @@ public class DefaultExecutionTopology implements SchedulingTopology {
                                                         irp.isConsumable()
                                                                 ? ResultPartitionState.CONSUMABLE
                                                                 : ResultPartitionState.CREATED,
-                                                partitionConsumerVertexGroups.apply(
+                                                partitionConsumerVertexGroupRetriever.apply(
                                                         irp.getPartitionId()),
                                                 executionVertexRetriever,
                                                 irp::getConsumedPartitionGroups)));

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/scheduler/adapter/DefaultExecutionTopology.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/scheduler/adapter/DefaultExecutionTopology.java
@@ -207,8 +207,7 @@ public class DefaultExecutionTopology implements SchedulingTopology {
             List<DefaultResultPartition> producedPartitions =
                     generateProducedSchedulingResultPartition(
                             vertex.getProducedPartitions(),
-                            edgeManager::getConsumerVertexGroupForPartition,
-                            executionVerticesById::get);
+                            edgeManager::getConsumerVertexGroupForPartition);
 
             producedPartitions.forEach(
                     partition -> resultPartitionsById.put(partition.getId(), partition));
@@ -239,8 +238,7 @@ public class DefaultExecutionTopology implements SchedulingTopology {
             Map<IntermediateResultPartitionID, IntermediateResultPartition>
                     producedIntermediatePartitions,
             Function<IntermediateResultPartitionID, ConsumerVertexGroup>
-                    partitionConsumerVertexGroupRetriever,
-            Function<ExecutionVertexID, DefaultExecutionVertex> executionVertexRetriever) {
+                    partitionConsumerVertexGroupRetriever) {
 
         List<DefaultResultPartition> producedSchedulingPartitions =
                 new ArrayList<>(producedIntermediatePartitions.size());
@@ -260,7 +258,6 @@ public class DefaultExecutionTopology implements SchedulingTopology {
                                                                 : ResultPartitionState.CREATED,
                                                 partitionConsumerVertexGroupRetriever.apply(
                                                         irp.getPartitionId()),
-                                                executionVertexRetriever,
                                                 irp::getConsumedPartitionGroups)));
 
         return producedSchedulingPartitions;

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/scheduler/adapter/DefaultResultPartition.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/scheduler/adapter/DefaultResultPartition.java
@@ -24,15 +24,11 @@ import org.apache.flink.runtime.jobgraph.IntermediateDataSetID;
 import org.apache.flink.runtime.jobgraph.IntermediateResultPartitionID;
 import org.apache.flink.runtime.scheduler.strategy.ConsumedPartitionGroup;
 import org.apache.flink.runtime.scheduler.strategy.ConsumerVertexGroup;
-import org.apache.flink.runtime.scheduler.strategy.ExecutionVertexID;
 import org.apache.flink.runtime.scheduler.strategy.ResultPartitionState;
 import org.apache.flink.runtime.scheduler.strategy.SchedulingResultPartition;
-import org.apache.flink.util.IterableUtils;
 
 import java.util.List;
-import java.util.function.Function;
 import java.util.function.Supplier;
-import java.util.stream.Collectors;
 
 import static org.apache.flink.util.Preconditions.checkNotNull;
 
@@ -51,8 +47,6 @@ class DefaultResultPartition implements SchedulingResultPartition {
 
     private final ConsumerVertexGroup consumerVertexGroup;
 
-    private final Function<ExecutionVertexID, DefaultExecutionVertex> executionVertexRetriever;
-
     private final Supplier<List<ConsumedPartitionGroup>> consumerPartitionGroupSupplier;
 
     DefaultResultPartition(
@@ -61,14 +55,12 @@ class DefaultResultPartition implements SchedulingResultPartition {
             ResultPartitionType partitionType,
             Supplier<ResultPartitionState> resultPartitionStateSupplier,
             ConsumerVertexGroup consumerVertexGroup,
-            Function<ExecutionVertexID, DefaultExecutionVertex> executionVertexRetriever,
             Supplier<List<ConsumedPartitionGroup>> consumerPartitionGroupSupplier) {
         this.resultPartitionId = checkNotNull(partitionId);
         this.intermediateDataSetId = checkNotNull(intermediateDataSetId);
         this.partitionType = checkNotNull(partitionType);
         this.resultPartitionStateSupplier = checkNotNull(resultPartitionStateSupplier);
         this.consumerVertexGroup = consumerVertexGroup;
-        this.executionVertexRetriever = executionVertexRetriever;
         this.consumerPartitionGroupSupplier = consumerPartitionGroupSupplier;
     }
 
@@ -83,7 +75,6 @@ class DefaultResultPartition implements SchedulingResultPartition {
                 intermediateDataSetId,
                 partitionType,
                 resultPartitionStateSupplier,
-                null,
                 null,
                 null);
     }
@@ -111,13 +102,6 @@ class DefaultResultPartition implements SchedulingResultPartition {
     @Override
     public DefaultExecutionVertex getProducer() {
         return producer;
-    }
-
-    @Override
-    public Iterable<DefaultExecutionVertex> getConsumers() {
-        return IterableUtils.toStream(consumerVertexGroup)
-                .map(executionVertexRetriever)
-                .collect(Collectors.toList());
     }
 
     @Override

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/scheduler/adapter/DefaultSchedulingPipelinedRegion.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/scheduler/adapter/DefaultSchedulingPipelinedRegion.java
@@ -34,7 +34,6 @@ import java.util.Set;
 import java.util.function.Function;
 
 import static org.apache.flink.util.Preconditions.checkNotNull;
-import static org.apache.flink.util.Preconditions.checkState;
 
 /** Default implementation of {@link SchedulingPipelinedRegion}. */
 public class DefaultSchedulingPipelinedRegion implements SchedulingPipelinedRegion {
@@ -83,10 +82,6 @@ public class DefaultSchedulingPipelinedRegion implements SchedulingPipelinedRegi
                     executionVertex.getConsumedPartitionGroups()) {
                 SchedulingResultPartition consumedPartition =
                         resultPartitionRetriever.apply(consumedPartitionGroup.getFirst());
-
-                checkState(
-                        consumedPartition.getConsumerVertexGroups().size() <= 1,
-                        "Currently there has to be exactly one consumer for each partition in real jobs.");
 
                 if (consumedPartition.getResultType().isBlocking()) {
                     consumedPartitionGroupSet.add(consumedPartitionGroup);

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/scheduler/strategy/SchedulingResultPartition.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/scheduler/strategy/SchedulingResultPartition.java
@@ -48,11 +48,11 @@ public interface SchedulingResultPartition
     ResultPartitionState getState();
 
     /**
-     * Gets the {@link ConsumerVertexGroup}s.
+     * Gets the {@link ConsumerVertexGroup}.
      *
-     * @return list of {@link ConsumerVertexGroup}s
+     * @return {@link ConsumerVertexGroup}
      */
-    List<ConsumerVertexGroup> getConsumerVertexGroups();
+    ConsumerVertexGroup getConsumerVertexGroup();
 
     /**
      * Gets the {@link ConsumedPartitionGroup}s this partition belongs to.

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/topology/Result.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/topology/Result.java
@@ -35,6 +35,4 @@ public interface Result<
     ResultPartitionType getResultType();
 
     V getProducer();
-
-    Iterable<? extends V> getConsumers();
 }

--- a/flink-runtime/src/test/java/org/apache/flink/runtime/executiongraph/DefaultExecutionGraphConstructionTest.java
+++ b/flink-runtime/src/test/java/org/apache/flink/runtime/executiongraph/DefaultExecutionGraphConstructionTest.java
@@ -26,7 +26,6 @@ import org.apache.flink.core.io.InputSplitSource;
 import org.apache.flink.runtime.JobException;
 import org.apache.flink.runtime.io.network.partition.ResultPartitionType;
 import org.apache.flink.runtime.jobgraph.DistributionPattern;
-import org.apache.flink.runtime.jobgraph.IntermediateDataSet;
 import org.apache.flink.runtime.jobgraph.IntermediateResultPartitionID;
 import org.apache.flink.runtime.jobgraph.JobGraph;
 import org.apache.flink.runtime.jobgraph.JobVertex;
@@ -46,8 +45,6 @@ import java.util.HashSet;
 import java.util.List;
 import java.util.Objects;
 import java.util.Set;
-import java.util.stream.Collectors;
-import java.util.stream.Stream;
 
 import static org.hamcrest.MatcherAssert.assertThat;
 import static org.hamcrest.Matchers.containsInAnyOrder;
@@ -153,72 +150,6 @@ public class DefaultExecutionGraphConstructionTest {
             fail("Job failed with exception: " + e.getMessage());
         }
 
-        verifyTestGraph(eg, v1, v2, v3, v4, v5);
-    }
-
-    @Test
-    public void testAttachViaDataSets() throws Exception {
-        // construct part one of the execution graph
-        JobVertex v1 = new JobVertex("vertex1");
-        JobVertex v2 = new JobVertex("vertex2");
-        JobVertex v3 = new JobVertex("vertex3");
-
-        v1.setParallelism(5);
-        v2.setParallelism(7);
-        v3.setParallelism(2);
-
-        v1.setInvokableClass(AbstractInvokable.class);
-        v2.setInvokableClass(AbstractInvokable.class);
-        v3.setInvokableClass(AbstractInvokable.class);
-
-        // this creates an intermediate result for v1
-        v2.connectNewDataSetAsInput(
-                v1, DistributionPattern.ALL_TO_ALL, ResultPartitionType.PIPELINED);
-
-        // create results for v2 and v3
-        IntermediateDataSet v2result = v2.createAndAddResultDataSet(ResultPartitionType.PIPELINED);
-        IntermediateDataSet v3Result1 = v3.createAndAddResultDataSet(ResultPartitionType.PIPELINED);
-        IntermediateDataSet v3Result2 = v3.createAndAddResultDataSet(ResultPartitionType.PIPELINED);
-
-        JobVertex v4 = new JobVertex("vertex4");
-        JobVertex v5 = new JobVertex("vertex5");
-        v4.setParallelism(11);
-        v5.setParallelism(4);
-
-        v4.setInvokableClass(AbstractInvokable.class);
-        v5.setInvokableClass(AbstractInvokable.class);
-
-        v4.connectDataSetAsInput(v2result, DistributionPattern.ALL_TO_ALL);
-        v4.connectDataSetAsInput(v3Result1, DistributionPattern.ALL_TO_ALL);
-        v5.connectNewDataSetAsInput(
-                v4, DistributionPattern.ALL_TO_ALL, ResultPartitionType.PIPELINED);
-        v5.connectDataSetAsInput(v3Result2, DistributionPattern.ALL_TO_ALL);
-
-        List<JobVertex> ordered = Arrays.asList(v1, v2, v3);
-
-        List<JobVertex> ordered2 = Arrays.asList(v4, v5);
-
-        ExecutionGraph eg =
-                createDefaultExecutionGraph(
-                        Stream.concat(ordered.stream(), ordered2.stream())
-                                .collect(Collectors.toList()));
-        try {
-            eg.attachJobGraph(ordered);
-        } catch (JobException e) {
-            e.printStackTrace();
-            fail("Job failed with exception: " + e.getMessage());
-        }
-
-        // attach the second part of the graph
-
-        try {
-            eg.attachJobGraph(ordered2);
-        } catch (JobException e) {
-            e.printStackTrace();
-            fail("Job failed with exception: " + e.getMessage());
-        }
-
-        // verify
         verifyTestGraph(eg, v1, v2, v3, v4, v5);
     }
 
@@ -349,38 +280,6 @@ public class DefaultExecutionGraphConstructionTest {
 
             assertEquals(assigner1, eg.getAllVertices().get(v3.getID()).getSplitAssigner());
             assertEquals(assigner2, eg.getAllVertices().get(v5.getID()).getSplitAssigner());
-        } catch (Exception e) {
-            e.printStackTrace();
-            fail(e.getMessage());
-        }
-    }
-
-    @Test
-    public void testMoreThanOneConsumerForIntermediateResult() {
-        try {
-            JobVertex v1 = new JobVertex("vertex1");
-            JobVertex v2 = new JobVertex("vertex2");
-            JobVertex v3 = new JobVertex("vertex3");
-
-            v1.setParallelism(5);
-            v2.setParallelism(7);
-            v3.setParallelism(2);
-
-            IntermediateDataSet result =
-                    v1.createAndAddResultDataSet(ResultPartitionType.PIPELINED);
-            v2.connectDataSetAsInput(result, DistributionPattern.ALL_TO_ALL);
-            v3.connectDataSetAsInput(result, DistributionPattern.ALL_TO_ALL);
-
-            List<JobVertex> ordered = new ArrayList<JobVertex>(Arrays.asList(v1, v2, v3));
-
-            ExecutionGraph eg = createDefaultExecutionGraph(ordered);
-
-            try {
-                eg.attachJobGraph(ordered);
-                fail("Should not be possible");
-            } catch (RuntimeException e) {
-                // expected
-            }
         } catch (Exception e) {
             e.printStackTrace();
             fail(e.getMessage());

--- a/flink-runtime/src/test/java/org/apache/flink/runtime/executiongraph/EdgeManagerBuildUtilTest.java
+++ b/flink-runtime/src/test/java/org/apache/flink/runtime/executiongraph/EdgeManagerBuildUtilTest.java
@@ -78,9 +78,7 @@ public class EdgeManagerBuildUtilTest {
 
             IntermediateResultPartition partition =
                     ev.getProducedPartitions().values().iterator().next();
-            assertEquals(1, partition.getConsumerVertexGroups().size());
-
-            ConsumerVertexGroup consumerVertexGroup = partition.getConsumerVertexGroups().get(0);
+            ConsumerVertexGroup consumerVertexGroup = partition.getConsumerVertexGroup();
             int actual = consumerVertexGroup.size();
             if (actual > actualMaxForUpstream) {
                 actualMaxForUpstream = actual;

--- a/flink-runtime/src/test/java/org/apache/flink/runtime/jobgraph/JobTaskVertexTest.java
+++ b/flink-runtime/src/test/java/org/apache/flink/runtime/jobgraph/JobTaskVertexTest.java
@@ -61,32 +61,7 @@ public class JobTaskVertexTest {
 
         assertEquals(target.getInputs().get(0).getSource(), source.getProducedDataSets().get(0));
 
-        assertEquals(1, source.getProducedDataSets().get(0).getConsumers().size());
-        assertEquals(target, source.getProducedDataSets().get(0).getConsumers().get(0).getTarget());
-    }
-
-    @Test
-    public void testConnectMultipleTargets() {
-        JobVertex source = new JobVertex("source");
-        JobVertex target1 = new JobVertex("target1");
-        JobVertex target2 = new JobVertex("target2");
-        target1.connectNewDataSetAsInput(
-                source, DistributionPattern.POINTWISE, ResultPartitionType.PIPELINED);
-        target2.connectDataSetAsInput(
-                source.getProducedDataSets().get(0), DistributionPattern.ALL_TO_ALL);
-
-        assertTrue(source.isInputVertex());
-        assertFalse(source.isOutputVertex());
-        assertFalse(target1.isInputVertex());
-        assertTrue(target1.isOutputVertex());
-        assertFalse(target2.isInputVertex());
-        assertTrue(target2.isOutputVertex());
-
-        assertEquals(1, source.getNumberOfProducedIntermediateDataSets());
-        assertEquals(2, source.getProducedDataSets().get(0).getConsumers().size());
-
-        assertEquals(target1.getInputs().get(0).getSource(), source.getProducedDataSets().get(0));
-        assertEquals(target2.getInputs().get(0).getSource(), source.getProducedDataSets().get(0));
+        assertEquals(target, source.getProducedDataSets().get(0).getConsumer().getTarget());
     }
 
     @Test

--- a/flink-runtime/src/test/java/org/apache/flink/runtime/scheduler/adapter/DefaultExecutionTopologyTest.java
+++ b/flink-runtime/src/test/java/org/apache/flink/runtime/scheduler/adapter/DefaultExecutionTopologyTest.java
@@ -233,16 +233,9 @@ public class DefaultExecutionTopologyTest extends TestLogger {
 
             assertPartitionEquals(originalPartition, adaptedPartition);
 
-            List<ExecutionVertexID> originalConsumerIds = new ArrayList<>();
-            for (ConsumerVertexGroup consumerVertexGroup :
-                    originalPartition.getConsumerVertexGroups()) {
-                for (ExecutionVertexID executionVertexId : consumerVertexGroup) {
-                    originalConsumerIds.add(executionVertexId);
-                }
-            }
+            ConsumerVertexGroup consumerVertexGroup = originalPartition.getConsumerVertexGroup();
             Iterable<DefaultExecutionVertex> adaptedConsumers = adaptedPartition.getConsumers();
-
-            for (ExecutionVertexID originalId : originalConsumerIds) {
+            for (ExecutionVertexID originalId : consumerVertexGroup) {
                 // it is sufficient to verify that some vertex exists with the correct ID here,
                 // since deep equality is verified later in the main loop
                 // this DOES rely on an implicit assumption that the vertices objects returned by

--- a/flink-runtime/src/test/java/org/apache/flink/runtime/scheduler/adapter/DefaultExecutionTopologyTest.java
+++ b/flink-runtime/src/test/java/org/apache/flink/runtime/scheduler/adapter/DefaultExecutionTopologyTest.java
@@ -234,7 +234,8 @@ public class DefaultExecutionTopologyTest extends TestLogger {
             assertPartitionEquals(originalPartition, adaptedPartition);
 
             ConsumerVertexGroup consumerVertexGroup = originalPartition.getConsumerVertexGroup();
-            Iterable<DefaultExecutionVertex> adaptedConsumers = adaptedPartition.getConsumers();
+            Iterable<ExecutionVertexID> adaptedConsumers =
+                    adaptedPartition.getConsumerVertexGroup();
             for (ExecutionVertexID originalId : consumerVertexGroup) {
                 // it is sufficient to verify that some vertex exists with the correct ID here,
                 // since deep equality is verified later in the main loop
@@ -243,9 +244,7 @@ public class DefaultExecutionTopologyTest extends TestLogger {
                 // identical to those stored in the partition
                 assertTrue(
                         IterableUtils.toStream(adaptedConsumers)
-                                .anyMatch(
-                                        adaptedConsumer ->
-                                                adaptedConsumer.getId().equals(originalId)));
+                                .anyMatch(adaptedConsumer -> adaptedConsumer.equals(originalId)));
             }
         }
     }

--- a/flink-runtime/src/test/java/org/apache/flink/runtime/scheduler/strategy/TestingSchedulingResultPartition.java
+++ b/flink-runtime/src/test/java/org/apache/flink/runtime/scheduler/strategy/TestingSchedulingResultPartition.java
@@ -21,16 +21,13 @@ package org.apache.flink.runtime.scheduler.strategy;
 import org.apache.flink.runtime.io.network.partition.ResultPartitionType;
 import org.apache.flink.runtime.jobgraph.IntermediateDataSetID;
 import org.apache.flink.runtime.jobgraph.IntermediateResultPartitionID;
-import org.apache.flink.util.IterableUtils;
 
 import javax.annotation.Nullable;
 
 import java.util.ArrayList;
 import java.util.Collection;
 import java.util.Collections;
-import java.util.HashMap;
 import java.util.List;
-import java.util.Map;
 import java.util.stream.Collectors;
 
 import static org.apache.flink.util.Preconditions.checkNotNull;
@@ -51,8 +48,6 @@ public class TestingSchedulingResultPartition implements SchedulingResultPartiti
 
     private final List<ConsumedPartitionGroup> consumedPartitionGroups;
 
-    private final Map<ExecutionVertexID, TestingSchedulingExecutionVertex> executionVerticesById;
-
     private ResultPartitionState state;
 
     private TestingSchedulingResultPartition(
@@ -66,7 +61,6 @@ public class TestingSchedulingResultPartition implements SchedulingResultPartiti
         this.intermediateResultPartitionID =
                 new IntermediateResultPartitionID(dataSetID, partitionNum);
         this.consumedPartitionGroups = new ArrayList<>();
-        this.executionVerticesById = new HashMap<>();
     }
 
     @Override
@@ -95,14 +89,6 @@ public class TestingSchedulingResultPartition implements SchedulingResultPartiti
     }
 
     @Override
-    public Iterable<TestingSchedulingExecutionVertex> getConsumers() {
-        checkNotNull(consumerVertexGroup);
-        return IterableUtils.toStream(consumerVertexGroup)
-                .map(executionVerticesById::get)
-                .collect(Collectors.toList());
-    }
-
-    @Override
     public ConsumerVertexGroup getConsumerVertexGroup() {
         checkNotNull(consumerVertexGroup);
         return consumerVertexGroup;
@@ -121,8 +107,6 @@ public class TestingSchedulingResultPartition implements SchedulingResultPartiti
                         consumerVertices.stream()
                                 .map(TestingSchedulingExecutionVertex::getId)
                                 .collect(Collectors.toList()));
-
-        consumerVertices.forEach(v -> this.executionVerticesById.put(v.getId(), v));
 
         this.consumerVertexGroup = consumerVertexGroup;
     }

--- a/flink-runtime/src/test/java/org/apache/flink/runtime/scheduler/strategy/TestingSchedulingTopology.java
+++ b/flink-runtime/src/test/java/org/apache/flink/runtime/scheduler/strategy/TestingSchedulingTopology.java
@@ -190,7 +190,7 @@ public class TestingSchedulingTopology implements SchedulingTopology {
                         .withResultPartitionType(resultPartitionType)
                         .build();
 
-        resultPartition.addConsumer(consumer);
+        resultPartition.addConsumerGroup(Collections.singleton(consumer));
         resultPartition.setProducer(producer);
 
         producer.addProducedPartition(resultPartition);
@@ -300,7 +300,7 @@ public class TestingSchedulingTopology implements SchedulingTopology {
                 resultPartition.setProducer(producer);
                 producer.addProducedPartition(resultPartition);
                 consumer.addConsumedPartition(resultPartition);
-                resultPartition.addConsumer(consumer);
+                resultPartition.addConsumerGroup(Collections.singleton(consumer));
                 resultPartitions.add(resultPartition);
             }
 
@@ -326,19 +326,6 @@ public class TestingSchedulingTopology implements SchedulingTopology {
             final List<TestingSchedulingResultPartition> resultPartitions = new ArrayList<>();
             final IntermediateDataSetID intermediateDataSetId = new IntermediateDataSetID();
 
-            ConsumerVertexGroup consumerVertexGroup =
-                    ConsumerVertexGroup.fromMultipleVertices(
-                            consumers.stream()
-                                    .map(TestingSchedulingExecutionVertex::getId)
-                                    .collect(Collectors.toList()));
-
-            Map<ExecutionVertexID, TestingSchedulingExecutionVertex> consumerVertexById =
-                    consumers.stream()
-                            .collect(
-                                    Collectors.toMap(
-                                            TestingSchedulingExecutionVertex::getId,
-                                            Function.identity()));
-
             TestingSchedulingResultPartition.Builder resultPartitionBuilder =
                     initTestingSchedulingResultPartitionBuilder()
                             .withIntermediateDataSetID(intermediateDataSetId)
@@ -353,7 +340,7 @@ public class TestingSchedulingTopology implements SchedulingTopology {
                 resultPartition.setProducer(producer);
                 producer.addProducedPartition(resultPartition);
 
-                resultPartition.addConsumerGroup(consumerVertexGroup, consumerVertexById);
+                resultPartition.addConsumerGroup(consumers);
                 resultPartitions.add(resultPartition);
             }
 

--- a/flink-tests/src/test/java/org/apache/flink/runtime/operators/lifecycle/validation/TestJobDataFlowValidator.java
+++ b/flink-tests/src/test/java/org/apache/flink/runtime/operators/lifecycle/validation/TestJobDataFlowValidator.java
@@ -55,26 +55,24 @@ public class TestJobDataFlowValidator {
 
         for (JobVertex upstream : testJob.jobGraph.getVertices()) {
             for (IntermediateDataSet produced : upstream.getProducedDataSets()) {
-                for (JobEdge edge : produced.getConsumers()) {
-                    Optional<String> upstreamIDOptional =
-                            getTrackedOperatorID(upstream, true, testJob);
-                    Optional<String> downstreamIDOptional =
-                            getTrackedOperatorID(edge.getTarget(), false, testJob);
-                    if (upstreamIDOptional.isPresent() && downstreamIDOptional.isPresent()) {
-                        final String upstreamID = upstreamIDOptional.get();
-                        final String downstreamID = downstreamIDOptional.get();
-                        if (testJob.sources.contains(upstreamID)) {
-                            // TODO: if we add tests for FLIP-27 sources we might need to adjust
-                            // this condition
-                            LOG.debug(
-                                    "Legacy sources do not have the finish() method and thus do not"
-                                            + " emit FinishEvent");
-                        } else {
-                            checkDataFlow(upstreamID, downstreamID, edge, finishEvents, withDrain);
-                        }
+                JobEdge edge = produced.getConsumer();
+                Optional<String> upstreamIDOptional = getTrackedOperatorID(upstream, true, testJob);
+                Optional<String> downstreamIDOptional =
+                        getTrackedOperatorID(edge.getTarget(), false, testJob);
+                if (upstreamIDOptional.isPresent() && downstreamIDOptional.isPresent()) {
+                    final String upstreamID = upstreamIDOptional.get();
+                    final String downstreamID = downstreamIDOptional.get();
+                    if (testJob.sources.contains(upstreamID)) {
+                        // TODO: if we add tests for FLIP-27 sources we might need to adjust
+                        // this condition
+                        LOG.debug(
+                                "Legacy sources do not have the finish() method and thus do not"
+                                        + " emit FinishEvent");
                     } else {
-                        LOG.debug("Ignoring edge (untracked operator): {}", edge);
+                        checkDataFlow(upstreamID, downstreamID, edge, finishEvents, withDrain);
                     }
+                } else {
+                    LOG.debug("Ignoring edge (untracked operator): {}", edge);
                 }
             }
         }


### PR DESCRIPTION
## What is the purpose of the change

This change is to rework IntermediateDataSet and IntermediateResultPartition to explicitly have one consumer.
This can help to get rid of the hack logics to check there is only one consumer for IntermediateDataSet and IntermediateResultPartition.

## Verifying this change

This change is already covered by existing tests.

## Does this pull request potentially affect one of the following parts:

  - Dependencies (does it add or upgrade a dependency): (yes / **no**)
  - The public API, i.e., is any changed class annotated with `@Public(Evolving)`: (yes / **no**)
  - The serializers: (yes / **no** / don't know)
  - The runtime per-record code paths (performance sensitive): (yes / **no** / don't know)
  - Anything that affects deployment or recovery: JobManager (and its components), Checkpointing, Kubernetes/Yarn, ZooKeeper: (yes / **no** / don't know)
  - The S3 file system connector: (yes / **no** / don't know)

## Documentation

  - Does this pull request introduce a new feature? (yes / **no**)
  - If yes, how is the feature documented? (**not applicable** / docs / JavaDocs / not documented)
