### PR TITLE
[FLINK-25178][table] Throw exception when managed table sink needs checkpointing

### DIFF
--- a/flink-python/src/main/java/org/apache/flink/table/executor/python/ChainingOptimizingExecutor.java
+++ b/flink-python/src/main/java/org/apache/flink/table/executor/python/ChainingOptimizingExecutor.java
@@ -72,4 +72,9 @@ public class ChainingOptimizingExecutor implements Executor {
     public JobClient executeAsync(Pipeline pipeline) throws Exception {
         return executor.executeAsync(pipeline);
     }
+
+    @Override
+    public boolean isCheckpointingEnabled() {
+        return executor.isCheckpointingEnabled();
+    }
 }

--- a/flink-table/flink-table-api-java/src/main/java/org/apache/flink/table/delegation/Executor.java
+++ b/flink-table/flink-table-api-java/src/main/java/org/apache/flink/table/delegation/Executor.java
@@ -79,4 +79,11 @@ public interface Executor {
      * @throws Exception which occurs during job execution.
      */
     JobClient executeAsync(Pipeline pipeline) throws Exception;
+
+    /**
+     * Checks whether checkpointing is enabled.
+     *
+     * @return True if checkpointing is enables, false otherwise.
+     */
+    boolean isCheckpointingEnabled();
 }

--- a/flink-table/flink-table-api-java/src/test/java/org/apache/flink/table/utils/ExecutorMock.java
+++ b/flink-table/flink-table-api-java/src/test/java/org/apache/flink/table/utils/ExecutorMock.java
@@ -54,4 +54,9 @@ public class ExecutorMock implements Executor {
     public JobClient executeAsync(Pipeline pipeline) {
         return null;
     }
+
+    @Override
+    public boolean isCheckpointingEnabled() {
+        return false;
+    }
 }

--- a/flink-table/flink-table-common/src/test/java/org/apache/flink/table/factories/TestManagedTableFactory.java
+++ b/flink-table/flink-table-common/src/test/java/org/apache/flink/table/factories/TestManagedTableFactory.java
@@ -22,6 +22,7 @@ import org.apache.flink.configuration.ConfigOption;
 import org.apache.flink.table.api.TableException;
 import org.apache.flink.table.catalog.ObjectIdentifier;
 import org.apache.flink.table.connector.ChangelogMode;
+import org.apache.flink.table.connector.sink.DynamicTableSink;
 import org.apache.flink.table.connector.source.DynamicTableSource;
 import org.apache.flink.table.connector.source.ScanTableSource;
 
@@ -33,7 +34,8 @@ import java.util.concurrent.ConcurrentHashMap;
 import java.util.concurrent.atomic.AtomicReference;
 
 /** A test {@link ManagedTableFactory}. */
-public class TestManagedTableFactory implements DynamicTableSourceFactory, ManagedTableFactory {
+public class TestManagedTableFactory
+        implements DynamicTableSourceFactory, DynamicTableSinkFactory, ManagedTableFactory {
 
     public static final String ENRICHED_KEY = "ENRICHED_KEY";
 
@@ -94,6 +96,11 @@ public class TestManagedTableFactory implements DynamicTableSourceFactory, Manag
         return new TestManagedTableSource();
     }
 
+    @Override
+    public DynamicTableSink createDynamicTableSink(Context context) {
+        return new TestManagedTableSink();
+    }
+
     /** Managed {@link DynamicTableSource} for testing. */
     public static class TestManagedTableSource implements ScanTableSource {
 
@@ -109,6 +116,40 @@ public class TestManagedTableFactory implements DynamicTableSourceFactory, Manag
 
         @Override
         public DynamicTableSource copy() {
+            throw new UnsupportedOperationException();
+        }
+
+        @Override
+        public String asSummaryString() {
+            throw new UnsupportedOperationException();
+        }
+
+        @Override
+        public boolean equals(Object o) {
+            throw new UnsupportedOperationException();
+        }
+
+        @Override
+        public int hashCode() {
+            throw new UnsupportedOperationException();
+        }
+    }
+
+    /** Managed {@link DynamicTableSink} for testing. */
+    public static class TestManagedTableSink implements DynamicTableSink {
+
+        @Override
+        public ChangelogMode getChangelogMode(ChangelogMode requestedMode) {
+            return requestedMode;
+        }
+
+        @Override
+        public SinkRuntimeProvider getSinkRuntimeProvider(Context context) {
+            throw new UnsupportedOperationException();
+        }
+
+        @Override
+        public DynamicTableSink copy() {
             throw new UnsupportedOperationException();
         }
 

--- a/flink-table/flink-table-planner/src/main/java/org/apache/flink/table/planner/delegation/DefaultExecutor.java
+++ b/flink-table/flink-table-planner/src/main/java/org/apache/flink/table/planner/delegation/DefaultExecutor.java
@@ -95,6 +95,11 @@ public class DefaultExecutor implements Executor {
         return executionEnvironment.executeAsync((StreamGraph) pipeline);
     }
 
+    @Override
+    public boolean isCheckpointingEnabled() {
+        return executionEnvironment.getCheckpointConfig().isCheckpointingEnabled();
+    }
+
     private void configureBatchSpecificProperties() {
         executionEnvironment.getConfig().enableObjectReuse();
     }

--- a/flink-table/flink-table-planner/src/main/scala/org/apache/flink/table/planner/delegation/PlannerBase.scala
+++ b/flink-table/flink-table-planner/src/main/scala/org/apache/flink/table/planner/delegation/PlannerBase.scala
@@ -386,7 +386,7 @@ abstract class PlannerBase(
         val catalog = toScala(catalogManager.getCatalog(objectIdentifier.getCatalogName))
         val isTemporary = lookupResult.isTemporary
 
-        if (isManagedTable(catalog.get, resolvedTable) &&
+        if (isStreamingMode && isManagedTable(catalog.get, resolvedTable) &&
           !executor.isCheckpointingEnabled) {
           throw new TableException(
             s"You should enable the checkpointing for sinking to managed table " +

--- a/flink-table/flink-table-planner/src/main/scala/org/apache/flink/table/planner/delegation/PlannerBase.scala
+++ b/flink-table/flink-table-planner/src/main/scala/org/apache/flink/table/planner/delegation/PlannerBase.scala
@@ -25,6 +25,7 @@ import org.apache.flink.streaming.api.environment.StreamExecutionEnvironment
 import org.apache.flink.table.api.config.{ExecutionConfigOptions, TableConfigOptions}
 import org.apache.flink.table.api._
 import org.apache.flink.table.catalog._
+import org.apache.flink.table.catalog.ManagedTableListener.isManagedTable
 import org.apache.flink.table.connector.sink.DynamicTableSink
 import org.apache.flink.table.delegation.{Executor, Parser, Planner}
 import org.apache.flink.table.descriptors.{ConnectorDescriptorValidator, DescriptorProperties}
@@ -384,6 +385,15 @@ abstract class PlannerBase(
         }
         val catalog = toScala(catalogManager.getCatalog(objectIdentifier.getCatalogName))
         val isTemporary = lookupResult.isTemporary
+
+        if (isManagedTable(catalog.get, resolvedTable) &&
+          !executor.isCheckpointingEnabled) {
+          throw new TableException(
+            s"You should enable the checkpointing for sinking to managed table " +
+              s"${objectIdentifier}, managed table relies on checkpoint to commit and " +
+              s"the data is visible only after commit.")
+        }
+
         if (isLegacyConnectorOptions(objectIdentifier, resolvedTable.getOrigin, isTemporary)) {
           val tableSink = TableFactoryUtil.findAndCreateTableSink(
             catalog.orNull,

--- a/flink-table/flink-table-planner/src/test/scala/org/apache/flink/table/planner/plan/batch/sql/TableSinkTest.scala
+++ b/flink-table/flink-table-planner/src/test/scala/org/apache/flink/table/planner/plan/batch/sql/TableSinkTest.scala
@@ -149,13 +149,7 @@ class TableSinkTest extends TableTestBase {
          |""".stripMargin)
     val stmtSet = util.tableEnv.createStatementSet()
     stmtSet.addInsertSql("INSERT INTO sink SELECT * FROM MyTable")
-
-    expectedException.expect(classOf[TableException])
-    expectedException.expectMessage(
-      s"You should enable the checkpointing for sinking to managed table " +
-        s"`default_catalog`.`default_database`.`sink`, " +
-        s"managed table relies on checkpoint to commit and " +
-        s"the data is visible only after commit.")
+    
     util.verifyAstPlan(stmtSet)
   }
 

--- a/flink-table/flink-table-planner/src/test/scala/org/apache/flink/table/planner/plan/stream/sql/TableSinkTest.scala
+++ b/flink-table/flink-table-planner/src/test/scala/org/apache/flink/table/planner/plan/stream/sql/TableSinkTest.scala
@@ -623,6 +623,32 @@ class TableSinkTest extends TableTestBase {
     // source and sink has same parallelism, but sink shuffle by pk is enforced
     util.verifyExplain(stmtSet, ExplainDetail.JSON_EXECUTION_PLAN)
   }
+
+  @Test
+  def testManagedTableSinkWithDisableCheckpointing(): Unit = {
+    util.addTable(
+      s"""
+         |CREATE TABLE source (person String, votes BIGINT) WITH(
+         |  'connector' = 'values'
+         |)
+         |""".stripMargin)
+    util.addTable(
+      s"""
+         |CREATE TABLE sink (person String, votes BIGINT) WITH(
+         |)
+         |""".stripMargin)
+    val stmtSet = util.tableEnv.createStatementSet()
+    stmtSet.addInsertSql(
+      "INSERT INTO sink SELECT * FROM source")
+
+    expectedException.expect(classOf[TableException])
+    expectedException.expectMessage(
+      s"You should enable the checkpointing for sinking to managed table " +
+        s"`default_catalog`.`default_database`.`sink`, " +
+        s"managed table relies on checkpoint to commit and " +
+        s"the data is visible only after commit.")
+    util.verifyRelPlan(stmtSet, ExplainDetail.CHANGELOG_MODE)
+  }
 }
 
 /** tests table factory use ParallelSourceFunction which support parallelism by env*/

--- a/flink-table/flink-table-planner/src/test/scala/org/apache/flink/table/planner/utils/TableTestBase.scala
+++ b/flink-table/flink-table-planner/src/test/scala/org/apache/flink/table/planner/utils/TableTestBase.scala
@@ -396,6 +396,30 @@ abstract class TableTestUtilBase(test: TableTestBase, isStreamingMode: Boolean) 
   }
 
   /**
+   * Verify the AST (abstract syntax tree).
+   */
+  def verifyAstPlan(stmtSet: StatementSet): Unit = {
+    doVerifyPlan(
+      stmtSet,
+      Array.empty[ExplainDetail],
+      withRowType = false,
+      Array(PlanKind.AST),
+      () => Unit)
+  }
+
+  /**
+   * Verify the AST (abstract syntax tree). The plans will contain the extra [[ExplainDetail]]s.
+   */
+  def verifyAstPlan(stmtSet: StatementSet, extraDetails: ExplainDetail*): Unit = {
+    doVerifyPlan(
+      stmtSet,
+      extraDetails.toArray,
+      withRowType = false,
+      Array(PlanKind.AST),
+      () => Unit)
+  }
+
+  /**
    * Verify the AST (abstract syntax tree) and the optimized rel plan for the given SELECT query.
    */
   def verifyRelPlan(query: String): Unit = {


### PR DESCRIPTION
## What is the purpose of the change

*In the past, many users encountered the problem that the sink did not output because they did not open the checkpoint. For the managed table: The planner will throw an exception if the checkpoint is not turned on. (Later we can add public connector interface, including Filesystem, Hive, Iceberg, Hudi need it). `PlannerBase` adds the check whether the managed table sink is enabled to checkpointing.*

## Brief change log

  - *`PlannerBase` adds the `checkManagedTableCheckpointing` to check whether the managed table sink is enabled to checkpointing. If the managed table sink disables checkpointing, this could throw the `TableException`.*

## Verifying this change

## Does this pull request potentially affect one of the following parts:

  - Dependencies (does it add or upgrade a dependency): (yes / **no**)
  - The public API, i.e., is any changed class annotated with `@Public(Evolving)`: (yes / **no**)
  - The serializers: (yes / **no** / don't know)
  - The runtime per-record code paths (performance sensitive): (yes / **no** / don't know)
  - Anything that affects deployment or recovery: JobManager (and its components), Checkpointing, Kubernetes/Yarn, ZooKeeper: (yes / **no** / don't know)
  - The S3 file system connector: (yes / **no** / don't know)

## Documentation

  - Does this pull request introduce a new feature? (yes / **no**)
  - If yes, how is the feature documented? (**not applicable** / docs / JavaDocs / not documented)