### PR TITLE
[FLINK-25423][state-processor-api] Enable loading state backend via configuration in state processor api

### DIFF
--- a/flink-libraries/flink-state-processing-api/src/main/java/org/apache/flink/state/api/BootstrapTransformation.java
+++ b/flink-libraries/flink-state-processing-api/src/main/java/org/apache/flink/state/api/BootstrapTransformation.java
@@ -142,7 +142,7 @@ public class BootstrapTransformation<T> {
      */
     DataSet<OperatorState> writeOperatorState(
             OperatorID operatorID,
-            StateBackend stateBackend,
+            @Nullable StateBackend stateBackend,
             Configuration config,
             int globalMaxParallelism,
             Path savepointPath) {
@@ -157,7 +157,7 @@ public class BootstrapTransformation<T> {
     @VisibleForTesting
     MapPartitionOperator<T, TaggedOperatorSubtaskState> writeOperatorSubtaskStates(
             OperatorID operatorID,
-            StateBackend stateBackend,
+            @Nullable StateBackend stateBackend,
             Path savepointPath,
             int localMaxParallelism) {
         return writeOperatorSubtaskStates(
@@ -166,7 +166,7 @@ public class BootstrapTransformation<T> {
 
     private MapPartitionOperator<T, TaggedOperatorSubtaskState> writeOperatorSubtaskStates(
             OperatorID operatorID,
-            StateBackend stateBackend,
+            @Nullable StateBackend stateBackend,
             Configuration additionalConfig,
             Path savepointPath,
             int localMaxParallelism) {
@@ -205,7 +205,7 @@ public class BootstrapTransformation<T> {
     @VisibleForTesting
     StreamConfig getConfig(
             OperatorID operatorID,
-            StateBackend stateBackend,
+            @Nullable StateBackend stateBackend,
             Configuration additionalConfig,
             StreamOperator<TaggedOperatorSubtaskState> operator) {
         // Eagerly perform a deep copy of the configuration, otherwise it will result in undefined

--- a/flink-libraries/flink-state-processing-api/src/main/java/org/apache/flink/state/api/EvictingWindowReader.java
+++ b/flink-libraries/flink-state-processing-api/src/main/java/org/apache/flink/state/api/EvictingWindowReader.java
@@ -38,6 +38,8 @@ import org.apache.flink.streaming.api.windowing.windows.Window;
 import org.apache.flink.streaming.runtime.streamrecord.StreamRecord;
 import org.apache.flink.util.Preconditions;
 
+import javax.annotation.Nullable;
+
 import java.io.IOException;
 
 /**
@@ -64,7 +66,7 @@ public class EvictingWindowReader<W extends Window> {
      * savepoint. This is also the state backend that will be used when writing again this existing
      * savepoint.
      */
-    private final StateBackend stateBackend;
+    @Nullable private final StateBackend stateBackend;
 
     /** The window serializer used to write the window operator. */
     private final TypeSerializer<W> windowSerializer;
@@ -72,11 +74,10 @@ public class EvictingWindowReader<W extends Window> {
     EvictingWindowReader(
             ExecutionEnvironment env,
             SavepointMetadata metadata,
-            StateBackend stateBackend,
+            @Nullable StateBackend stateBackend,
             TypeSerializer<W> windowSerializer) {
         Preconditions.checkNotNull(env, "The execution environment must not be null");
         Preconditions.checkNotNull(metadata, "The savepoint metadata must not be null");
-        Preconditions.checkNotNull(stateBackend, "The state backend must not be null");
         Preconditions.checkNotNull(windowSerializer, "The window serializer must not be null");
 
         this.env = env;

--- a/flink-libraries/flink-state-processing-api/src/main/java/org/apache/flink/state/api/EvictingWindowSavepointReader.java
+++ b/flink-libraries/flink-state-processing-api/src/main/java/org/apache/flink/state/api/EvictingWindowSavepointReader.java
@@ -40,6 +40,8 @@ import org.apache.flink.streaming.api.windowing.windows.Window;
 import org.apache.flink.streaming.runtime.streamrecord.StreamRecord;
 import org.apache.flink.util.Preconditions;
 
+import javax.annotation.Nullable;
+
 import java.io.IOException;
 
 /**
@@ -62,10 +64,10 @@ public class EvictingWindowSavepointReader<W extends Window> {
 
     /**
      * The state backend that was previously used to write existing operator states in this
-     * savepoint. This is also the state backend that will be used when writing again this existing
-     * savepoint.
+     * savepoint. If null, the reader will use the state backend defined via the cluster
+     * configuration.
      */
-    private final StateBackend stateBackend;
+    @Nullable private final StateBackend stateBackend;
 
     /** The window serializer used to write the window operator. */
     private final TypeSerializer<W> windowSerializer;
@@ -73,11 +75,10 @@ public class EvictingWindowSavepointReader<W extends Window> {
     EvictingWindowSavepointReader(
             StreamExecutionEnvironment env,
             SavepointMetadataV2 metadata,
-            StateBackend stateBackend,
+            @Nullable StateBackend stateBackend,
             TypeSerializer<W> windowSerializer) {
         Preconditions.checkNotNull(env, "The execution environment must not be null");
         Preconditions.checkNotNull(metadata, "The savepoint metadata must not be null");
-        Preconditions.checkNotNull(stateBackend, "The state backend must not be null");
         Preconditions.checkNotNull(windowSerializer, "The window serializer must not be null");
 
         this.env = env;

--- a/flink-libraries/flink-state-processing-api/src/main/java/org/apache/flink/state/api/EvictingWindowSavepointReader.java
+++ b/flink-libraries/flink-state-processing-api/src/main/java/org/apache/flink/state/api/EvictingWindowSavepointReader.java
@@ -33,7 +33,7 @@ import org.apache.flink.state.api.input.operator.window.PassThroughReader;
 import org.apache.flink.state.api.input.operator.window.ProcessEvictingWindowReader;
 import org.apache.flink.state.api.input.operator.window.ReduceEvictingWindowReaderFunction;
 import org.apache.flink.state.api.runtime.MutableConfig;
-import org.apache.flink.state.api.runtime.metadata.SavepointMetadata;
+import org.apache.flink.state.api.runtime.metadata.SavepointMetadataV2;
 import org.apache.flink.streaming.api.datastream.DataStream;
 import org.apache.flink.streaming.api.environment.StreamExecutionEnvironment;
 import org.apache.flink.streaming.api.windowing.windows.Window;
@@ -58,7 +58,7 @@ public class EvictingWindowSavepointReader<W extends Window> {
      * The savepoint metadata, which maintains the current set of existing / newly added operator
      * states.
      */
-    private final SavepointMetadata metadata;
+    private final SavepointMetadataV2 metadata;
 
     /**
      * The state backend that was previously used to write existing operator states in this
@@ -72,7 +72,7 @@ public class EvictingWindowSavepointReader<W extends Window> {
 
     EvictingWindowSavepointReader(
             StreamExecutionEnvironment env,
-            SavepointMetadata metadata,
+            SavepointMetadataV2 metadata,
             StateBackend stateBackend,
             TypeSerializer<W> windowSerializer) {
         Preconditions.checkNotNull(env, "The execution environment must not be null");

--- a/flink-libraries/flink-state-processing-api/src/main/java/org/apache/flink/state/api/ExistingSavepoint.java
+++ b/flink-libraries/flink-state-processing-api/src/main/java/org/apache/flink/state/api/ExistingSavepoint.java
@@ -30,6 +30,7 @@ import org.apache.flink.api.java.operators.DataSource;
 import org.apache.flink.api.java.tuple.Tuple2;
 import org.apache.flink.api.java.typeutils.TupleTypeInfo;
 import org.apache.flink.api.java.typeutils.TypeExtractor;
+import org.apache.flink.configuration.Configuration;
 import org.apache.flink.runtime.checkpoint.OperatorState;
 import org.apache.flink.runtime.state.StateBackend;
 import org.apache.flink.runtime.state.VoidNamespace;
@@ -111,7 +112,8 @@ public class ExistingSavepoint extends WritableSavepoint<ExistingSavepoint> {
             throws IOException {
         OperatorState operatorState = metadata.getOperatorState(uid);
         ListStateDescriptor<T> descriptor = new ListStateDescriptor<>(name, typeInfo);
-        ListStateInputFormat<T> inputFormat = new ListStateInputFormat<>(operatorState, descriptor);
+        ListStateInputFormat<T> inputFormat =
+                new ListStateInputFormat<>(operatorState, new Configuration(), null, descriptor);
         return env.createInput(inputFormat, typeInfo);
     }
 
@@ -134,7 +136,8 @@ public class ExistingSavepoint extends WritableSavepoint<ExistingSavepoint> {
 
         OperatorState operatorState = metadata.getOperatorState(uid);
         ListStateDescriptor<T> descriptor = new ListStateDescriptor<>(name, serializer);
-        ListStateInputFormat<T> inputFormat = new ListStateInputFormat<>(operatorState, descriptor);
+        ListStateInputFormat<T> inputFormat =
+                new ListStateInputFormat<>(operatorState, new Configuration(), null, descriptor);
         return env.createInput(inputFormat, typeInfo);
     }
 
@@ -153,7 +156,7 @@ public class ExistingSavepoint extends WritableSavepoint<ExistingSavepoint> {
         OperatorState operatorState = metadata.getOperatorState(uid);
         ListStateDescriptor<T> descriptor = new ListStateDescriptor<>(name, typeInfo);
         UnionStateInputFormat<T> inputFormat =
-                new UnionStateInputFormat<>(operatorState, descriptor);
+                new UnionStateInputFormat<>(operatorState, new Configuration(), null, descriptor);
         return env.createInput(inputFormat, typeInfo);
     }
 
@@ -177,7 +180,7 @@ public class ExistingSavepoint extends WritableSavepoint<ExistingSavepoint> {
         OperatorState operatorState = metadata.getOperatorState(uid);
         ListStateDescriptor<T> descriptor = new ListStateDescriptor<>(name, serializer);
         UnionStateInputFormat<T> inputFormat =
-                new UnionStateInputFormat<>(operatorState, descriptor);
+                new UnionStateInputFormat<>(operatorState, new Configuration(), null, descriptor);
         return env.createInput(inputFormat, typeInfo);
     }
 
@@ -204,7 +207,8 @@ public class ExistingSavepoint extends WritableSavepoint<ExistingSavepoint> {
         MapStateDescriptor<K, V> descriptor =
                 new MapStateDescriptor<>(name, keyTypeInfo, valueTypeInfo);
         BroadcastStateInputFormat<K, V> inputFormat =
-                new BroadcastStateInputFormat<>(operatorState, descriptor);
+                new BroadcastStateInputFormat<>(
+                        operatorState, new Configuration(), null, descriptor);
         return env.createInput(inputFormat, new TupleTypeInfo<>(keyTypeInfo, valueTypeInfo));
     }
 
@@ -237,7 +241,8 @@ public class ExistingSavepoint extends WritableSavepoint<ExistingSavepoint> {
         MapStateDescriptor<K, V> descriptor =
                 new MapStateDescriptor<>(name, keySerializer, valueSerializer);
         BroadcastStateInputFormat<K, V> inputFormat =
-                new BroadcastStateInputFormat<>(operatorState, descriptor);
+                new BroadcastStateInputFormat<>(
+                        operatorState, new Configuration(), null, descriptor);
         return env.createInput(inputFormat, new TupleTypeInfo<>(keyTypeInfo, valueTypeInfo));
     }
 

--- a/flink-libraries/flink-state-processing-api/src/main/java/org/apache/flink/state/api/SavepointReader.java
+++ b/flink-libraries/flink-state-processing-api/src/main/java/org/apache/flink/state/api/SavepointReader.java
@@ -42,7 +42,7 @@ import org.apache.flink.state.api.input.UnionStateInputFormat;
 import org.apache.flink.state.api.input.operator.KeyedStateReaderOperator;
 import org.apache.flink.state.api.runtime.MutableConfig;
 import org.apache.flink.state.api.runtime.SavepointLoader;
-import org.apache.flink.state.api.runtime.metadata.SavepointMetadata;
+import org.apache.flink.state.api.runtime.metadata.SavepointMetadataV2;
 import org.apache.flink.streaming.api.datastream.DataStream;
 import org.apache.flink.streaming.api.environment.StreamExecutionEnvironment;
 import org.apache.flink.streaming.api.windowing.assigners.WindowAssigner;
@@ -77,8 +77,8 @@ public class SavepointReader {
                                         new RuntimeException(
                                                 "Savepoint must contain at least one operator state."));
 
-        SavepointMetadata savepointMetadata =
-                new SavepointMetadata(
+        SavepointMetadataV2 savepointMetadata =
+                new SavepointMetadataV2(
                         maxParallelism, metadata.getMasterStates(), metadata.getOperatorStates());
         return new SavepointReader(env, savepointMetadata, stateBackend);
     }
@@ -90,7 +90,7 @@ public class SavepointReader {
      * The savepoint metadata, which maintains the current set of existing / newly added operator
      * states.
      */
-    private final SavepointMetadata metadata;
+    private final SavepointMetadataV2 metadata;
 
     /**
      * The state backend that was previously used to write existing operator states in this
@@ -100,7 +100,7 @@ public class SavepointReader {
     private final StateBackend stateBackend;
 
     SavepointReader(
-            StreamExecutionEnvironment env, SavepointMetadata metadata, StateBackend stateBackend) {
+            StreamExecutionEnvironment env, SavepointMetadataV2 metadata, StateBackend stateBackend) {
         Preconditions.checkNotNull(env, "The execution environment must not be null");
         Preconditions.checkNotNull(metadata, "The savepoint metadata must not be null");
         Preconditions.checkNotNull(stateBackend, "The state backend must not be null");

--- a/flink-libraries/flink-state-processing-api/src/main/java/org/apache/flink/state/api/SavepointReader.java
+++ b/flink-libraries/flink-state-processing-api/src/main/java/org/apache/flink/state/api/SavepointReader.java
@@ -49,6 +49,8 @@ import org.apache.flink.streaming.api.windowing.assigners.WindowAssigner;
 import org.apache.flink.streaming.api.windowing.windows.Window;
 import org.apache.flink.util.Preconditions;
 
+import javax.annotation.Nullable;
+
 import java.io.IOException;
 import java.util.Comparator;
 
@@ -57,11 +59,41 @@ import java.util.Comparator;
 public class SavepointReader {
 
     /**
-     * Loads an existing savepoint. Useful if you want to querythe state of an existing application.
+     * Loads an existing savepoint. Useful if you want to query the state of an existing
+     * application. The savepoint will be read using the state backend defined via the clusters
+     * configuration.
+     *
+     * @param env The execution environment used to transform the savepoint.
+     * @param path The path to an existing savepoint on disk.
+     * @return A {@link SavepointReader}.
+     */
+    public static SavepointReader read(StreamExecutionEnvironment env, String path)
+            throws IOException {
+        CheckpointMetadata metadata = SavepointLoader.loadSavepointMetadata(path);
+
+        int maxParallelism =
+                metadata.getOperatorStates().stream()
+                        .map(OperatorState::getMaxParallelism)
+                        .max(Comparator.naturalOrder())
+                        .orElseThrow(
+                                () ->
+                                        new RuntimeException(
+                                                "Savepoint must contain at least one operator state."));
+
+        SavepointMetadataV2 savepointMetadata =
+                new SavepointMetadataV2(
+                        maxParallelism, metadata.getMasterStates(), metadata.getOperatorStates());
+        return new SavepointReader(env, savepointMetadata, null);
+    }
+
+    /**
+     * Loads an existing savepoint. Useful if you want to query the state of an existing
+     * application.
      *
      * @param env The execution environment used to transform the savepoint.
      * @param path The path to an existing savepoint on disk.
      * @param stateBackend The state backend of the savepoint.
+     * @return A {@link SavepointReader}.
      */
     public static SavepointReader read(
             StreamExecutionEnvironment env, String path, StateBackend stateBackend)
@@ -94,16 +126,17 @@ public class SavepointReader {
 
     /**
      * The state backend that was previously used to write existing operator states in this
-     * savepoint. This is also the state backend that will be used when writing again this existing
-     * savepoint.
+     * savepoint. If null, the reader will use the state backend defined via the cluster
+     * configuration.
      */
-    private final StateBackend stateBackend;
+    @Nullable private final StateBackend stateBackend;
 
     SavepointReader(
-            StreamExecutionEnvironment env, SavepointMetadataV2 metadata, StateBackend stateBackend) {
+            StreamExecutionEnvironment env,
+            SavepointMetadataV2 metadata,
+            @Nullable StateBackend stateBackend) {
         Preconditions.checkNotNull(env, "The execution environment must not be null");
         Preconditions.checkNotNull(metadata, "The savepoint metadata must not be null");
-        Preconditions.checkNotNull(stateBackend, "The state backend must not be null");
 
         this.env = env;
         this.metadata = metadata;
@@ -124,7 +157,12 @@ public class SavepointReader {
             throws IOException {
         OperatorState operatorState = metadata.getOperatorState(uid);
         ListStateDescriptor<T> descriptor = new ListStateDescriptor<>(name, typeInfo);
-        ListStateInputFormat<T> inputFormat = new ListStateInputFormat<>(operatorState, descriptor);
+        ListStateInputFormat<T> inputFormat =
+                new ListStateInputFormat<>(
+                        operatorState,
+                        MutableConfig.of(env.getConfiguration()),
+                        stateBackend,
+                        descriptor);
         return SourceBuilder.fromFormat(env, inputFormat, typeInfo);
     }
 
@@ -147,7 +185,12 @@ public class SavepointReader {
 
         OperatorState operatorState = metadata.getOperatorState(uid);
         ListStateDescriptor<T> descriptor = new ListStateDescriptor<>(name, serializer);
-        ListStateInputFormat<T> inputFormat = new ListStateInputFormat<>(operatorState, descriptor);
+        ListStateInputFormat<T> inputFormat =
+                new ListStateInputFormat<>(
+                        operatorState,
+                        MutableConfig.of(env.getConfiguration()),
+                        stateBackend,
+                        descriptor);
         return SourceBuilder.fromFormat(env, inputFormat, typeInfo);
     }
 
@@ -166,7 +209,11 @@ public class SavepointReader {
         OperatorState operatorState = metadata.getOperatorState(uid);
         ListStateDescriptor<T> descriptor = new ListStateDescriptor<>(name, typeInfo);
         UnionStateInputFormat<T> inputFormat =
-                new UnionStateInputFormat<>(operatorState, descriptor);
+                new UnionStateInputFormat<>(
+                        operatorState,
+                        MutableConfig.of(env.getConfiguration()),
+                        stateBackend,
+                        descriptor);
         return SourceBuilder.fromFormat(env, inputFormat, typeInfo);
     }
 
@@ -190,7 +237,11 @@ public class SavepointReader {
         OperatorState operatorState = metadata.getOperatorState(uid);
         ListStateDescriptor<T> descriptor = new ListStateDescriptor<>(name, serializer);
         UnionStateInputFormat<T> inputFormat =
-                new UnionStateInputFormat<>(operatorState, descriptor);
+                new UnionStateInputFormat<>(
+                        operatorState,
+                        MutableConfig.of(env.getConfiguration()),
+                        stateBackend,
+                        descriptor);
         return SourceBuilder.fromFormat(env, inputFormat, typeInfo);
     }
 
@@ -217,7 +268,11 @@ public class SavepointReader {
         MapStateDescriptor<K, V> descriptor =
                 new MapStateDescriptor<>(name, keyTypeInfo, valueTypeInfo);
         BroadcastStateInputFormat<K, V> inputFormat =
-                new BroadcastStateInputFormat<>(operatorState, descriptor);
+                new BroadcastStateInputFormat<>(
+                        operatorState,
+                        MutableConfig.of(env.getConfiguration()),
+                        stateBackend,
+                        descriptor);
         return SourceBuilder.fromFormat(
                 env, inputFormat, new TupleTypeInfo<>(keyTypeInfo, valueTypeInfo));
     }
@@ -251,7 +306,11 @@ public class SavepointReader {
         MapStateDescriptor<K, V> descriptor =
                 new MapStateDescriptor<>(name, keySerializer, valueSerializer);
         BroadcastStateInputFormat<K, V> inputFormat =
-                new BroadcastStateInputFormat<>(operatorState, descriptor);
+                new BroadcastStateInputFormat<>(
+                        operatorState,
+                        MutableConfig.of(env.getConfiguration()),
+                        stateBackend,
+                        descriptor);
         return SourceBuilder.fromFormat(
                 env, inputFormat, new TupleTypeInfo<>(keyTypeInfo, valueTypeInfo));
     }

--- a/flink-libraries/flink-state-processing-api/src/main/java/org/apache/flink/state/api/StateBootstrapTransformation.java
+++ b/flink-libraries/flink-state-processing-api/src/main/java/org/apache/flink/state/api/StateBootstrapTransformation.java
@@ -197,8 +197,7 @@ public class StateBootstrapTransformation<T> {
             Configuration additionalConfig,
             StreamOperator<TaggedOperatorSubtaskState> operator) {
         // Eagerly perform a deep copy of the configuration, otherwise it will result in undefined
-        // behavior
-        // when deploying with multiple bootstrap transformations.
+        // behavior when deploying with multiple bootstrap transformations.
         Configuration deepCopy =
                 new Configuration(
                         MutableConfig.of(stream.getExecutionEnvironment().getConfiguration()));

--- a/flink-libraries/flink-state-processing-api/src/main/java/org/apache/flink/state/api/WindowReader.java
+++ b/flink-libraries/flink-state-processing-api/src/main/java/org/apache/flink/state/api/WindowReader.java
@@ -34,6 +34,8 @@ import org.apache.flink.state.api.runtime.metadata.SavepointMetadata;
 import org.apache.flink.streaming.api.windowing.windows.Window;
 import org.apache.flink.util.Preconditions;
 
+import javax.annotation.Nullable;
+
 import java.io.IOException;
 
 /**
@@ -60,7 +62,7 @@ public class WindowReader<W extends Window> {
      * savepoint. This is also the state backend that will be used when writing again this existing
      * savepoint.
      */
-    private final StateBackend stateBackend;
+    @Nullable private final StateBackend stateBackend;
 
     /** The window serializer used to write the window operator. */
     private final TypeSerializer<W> windowSerializer;
@@ -68,11 +70,10 @@ public class WindowReader<W extends Window> {
     WindowReader(
             ExecutionEnvironment env,
             SavepointMetadata metadata,
-            StateBackend stateBackend,
+            @Nullable StateBackend stateBackend,
             TypeSerializer<W> windowSerializer) {
         Preconditions.checkNotNull(env, "The execution environment must not be null");
         Preconditions.checkNotNull(metadata, "The savepoint metadata must not be null");
-        Preconditions.checkNotNull(stateBackend, "The state backend must not be null");
         Preconditions.checkNotNull(windowSerializer, "The window serializer must not be null");
 
         this.env = env;

--- a/flink-libraries/flink-state-processing-api/src/main/java/org/apache/flink/state/api/WindowSavepointReader.java
+++ b/flink-libraries/flink-state-processing-api/src/main/java/org/apache/flink/state/api/WindowSavepointReader.java
@@ -30,7 +30,7 @@ import org.apache.flink.state.api.input.SourceBuilder;
 import org.apache.flink.state.api.input.operator.WindowReaderOperator;
 import org.apache.flink.state.api.input.operator.window.PassThroughReader;
 import org.apache.flink.state.api.runtime.MutableConfig;
-import org.apache.flink.state.api.runtime.metadata.SavepointMetadata;
+import org.apache.flink.state.api.runtime.metadata.SavepointMetadataV2;
 import org.apache.flink.streaming.api.datastream.DataStream;
 import org.apache.flink.streaming.api.environment.StreamExecutionEnvironment;
 import org.apache.flink.streaming.api.windowing.windows.Window;
@@ -54,7 +54,7 @@ public class WindowSavepointReader<W extends Window> {
      * The savepoint metadata, which maintains the current set of existing / newly added operator
      * states.
      */
-    private final SavepointMetadata metadata;
+    private final SavepointMetadataV2 metadata;
 
     /**
      * The state backend that was previously used to write existing operator states in this
@@ -68,7 +68,7 @@ public class WindowSavepointReader<W extends Window> {
 
     WindowSavepointReader(
             StreamExecutionEnvironment env,
-            SavepointMetadata metadata,
+            SavepointMetadataV2 metadata,
             StateBackend stateBackend,
             TypeSerializer<W> windowSerializer) {
         Preconditions.checkNotNull(env, "The execution environment must not be null");

--- a/flink-libraries/flink-state-processing-api/src/main/java/org/apache/flink/state/api/WindowSavepointReader.java
+++ b/flink-libraries/flink-state-processing-api/src/main/java/org/apache/flink/state/api/WindowSavepointReader.java
@@ -36,6 +36,8 @@ import org.apache.flink.streaming.api.environment.StreamExecutionEnvironment;
 import org.apache.flink.streaming.api.windowing.windows.Window;
 import org.apache.flink.util.Preconditions;
 
+import javax.annotation.Nullable;
+
 import java.io.IOException;
 
 /**
@@ -58,10 +60,10 @@ public class WindowSavepointReader<W extends Window> {
 
     /**
      * The state backend that was previously used to write existing operator states in this
-     * savepoint. This is also the state backend that will be used when writing again this existing
-     * savepoint.
+     * savepoint. If null, the reader will use the state backend defined via the cluster
+     * configuration.
      */
-    private final StateBackend stateBackend;
+    @Nullable private final StateBackend stateBackend;
 
     /** The window serializer used to write the window operator. */
     private final TypeSerializer<W> windowSerializer;
@@ -69,11 +71,10 @@ public class WindowSavepointReader<W extends Window> {
     WindowSavepointReader(
             StreamExecutionEnvironment env,
             SavepointMetadataV2 metadata,
-            StateBackend stateBackend,
+            @Nullable StateBackend stateBackend,
             TypeSerializer<W> windowSerializer) {
         Preconditions.checkNotNull(env, "The execution environment must not be null");
         Preconditions.checkNotNull(metadata, "The savepoint metadata must not be null");
-        Preconditions.checkNotNull(stateBackend, "The state backend must not be null");
         Preconditions.checkNotNull(windowSerializer, "The window serializer must not be null");
 
         this.env = env;

--- a/flink-libraries/flink-state-processing-api/src/main/java/org/apache/flink/state/api/WritableSavepoint.java
+++ b/flink-libraries/flink-state-processing-api/src/main/java/org/apache/flink/state/api/WritableSavepoint.java
@@ -32,6 +32,8 @@ import org.apache.flink.state.api.runtime.BootstrapTransformationWithID;
 import org.apache.flink.state.api.runtime.metadata.SavepointMetadata;
 import org.apache.flink.util.Preconditions;
 
+import javax.annotation.Nullable;
+
 import java.util.List;
 
 /**
@@ -54,13 +56,12 @@ public abstract class WritableSavepoint<F extends WritableSavepoint> {
     protected final SavepointMetadata metadata;
 
     /** The state backend to use when writing this savepoint. */
-    protected final StateBackend stateBackend;
+    @Nullable protected final StateBackend stateBackend;
 
     private final Configuration configuration;
 
-    WritableSavepoint(SavepointMetadata metadata, StateBackend stateBackend) {
+    WritableSavepoint(SavepointMetadata metadata, @Nullable StateBackend stateBackend) {
         Preconditions.checkNotNull(metadata, "The savepoint metadata must not be null");
-        Preconditions.checkNotNull(stateBackend, "The state backend must not be null");
         this.metadata = metadata;
         this.stateBackend = stateBackend;
         this.configuration = new Configuration();

--- a/flink-libraries/flink-state-processing-api/src/main/java/org/apache/flink/state/api/input/BroadcastStateInputFormat.java
+++ b/flink-libraries/flink-state-processing-api/src/main/java/org/apache/flink/state/api/input/BroadcastStateInputFormat.java
@@ -21,9 +21,13 @@ package org.apache.flink.state.api.input;
 import org.apache.flink.annotation.Internal;
 import org.apache.flink.api.common.state.MapStateDescriptor;
 import org.apache.flink.api.java.tuple.Tuple2;
+import org.apache.flink.configuration.Configuration;
 import org.apache.flink.runtime.checkpoint.OperatorState;
 import org.apache.flink.runtime.state.OperatorStateBackend;
+import org.apache.flink.runtime.state.StateBackend;
 import org.apache.flink.util.Preconditions;
+
+import javax.annotation.Nullable;
 
 import java.util.Map;
 import java.util.stream.StreamSupport;
@@ -45,11 +49,16 @@ public class BroadcastStateInputFormat<K, V> extends OperatorStateInputFormat<Tu
      * Creates an input format for reading broadcast state from an operator in a savepoint.
      *
      * @param operatorState The state to be queried.
+     * @param configuration The cluster configuration for restoring the backend.
+     * @param backend The state backend used to restore the state.
      * @param descriptor The descriptor for this state, providing a name and serializer.
      */
     public BroadcastStateInputFormat(
-            OperatorState operatorState, MapStateDescriptor<K, V> descriptor) {
-        super(operatorState, true);
+            OperatorState operatorState,
+            Configuration configuration,
+            @Nullable StateBackend backend,
+            MapStateDescriptor<K, V> descriptor) {
+        super(operatorState, configuration, backend, true);
 
         this.descriptor =
                 Preconditions.checkNotNull(descriptor, "The state descriptor must not be null");

--- a/flink-libraries/flink-state-processing-api/src/main/java/org/apache/flink/state/api/input/KeyedStateInputFormat.java
+++ b/flink-libraries/flink-state-processing-api/src/main/java/org/apache/flink/state/api/input/KeyedStateInputFormat.java
@@ -48,6 +48,7 @@ import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
 import javax.annotation.Nonnull;
+import javax.annotation.Nullable;
 
 import java.io.IOException;
 import java.util.Comparator;
@@ -69,7 +70,7 @@ public class KeyedStateInputFormat<K, N, OUT>
 
     private final OperatorState operatorState;
 
-    private final StateBackend stateBackend;
+    @Nullable private final StateBackend stateBackend;
 
     private final Configuration configuration;
 
@@ -90,7 +91,7 @@ public class KeyedStateInputFormat<K, N, OUT>
      */
     public KeyedStateInputFormat(
             OperatorState operatorState,
-            StateBackend stateBackend,
+            @Nullable StateBackend stateBackend,
             Configuration configuration,
             StateReaderOperator<?, K, N, OUT> operator) {
         Preconditions.checkNotNull(operatorState, "The operator state cannot be null");

--- a/flink-libraries/flink-state-processing-api/src/main/java/org/apache/flink/state/api/input/KeyedStateInputFormat.java
+++ b/flink-libraries/flink-state-processing-api/src/main/java/org/apache/flink/state/api/input/KeyedStateInputFormat.java
@@ -28,7 +28,6 @@ import org.apache.flink.core.fs.CloseableRegistry;
 import org.apache.flink.core.io.InputSplitAssigner;
 import org.apache.flink.runtime.checkpoint.OperatorState;
 import org.apache.flink.runtime.checkpoint.StateAssignmentOperation;
-import org.apache.flink.runtime.execution.Environment;
 import org.apache.flink.runtime.state.AbstractKeyedStateBackend;
 import org.apache.flink.runtime.state.DefaultKeyedStateStore;
 import org.apache.flink.runtime.state.KeyGroupRange;
@@ -37,17 +36,16 @@ import org.apache.flink.runtime.state.StateBackend;
 import org.apache.flink.state.api.functions.KeyedStateReaderFunction;
 import org.apache.flink.state.api.input.operator.StateReaderOperator;
 import org.apache.flink.state.api.input.splits.KeyGroupRangeInputSplit;
-import org.apache.flink.state.api.runtime.NeverFireProcessingTimeService;
-import org.apache.flink.state.api.runtime.SavepointEnvironment;
 import org.apache.flink.state.api.runtime.SavepointRuntimeContext;
 import org.apache.flink.streaming.api.operators.InternalTimeServiceManager;
 import org.apache.flink.streaming.api.operators.StreamOperatorStateContext;
-import org.apache.flink.streaming.api.operators.StreamTaskStateInitializer;
-import org.apache.flink.streaming.api.operators.StreamTaskStateInitializerImpl;
 import org.apache.flink.util.CloseableIterator;
 import org.apache.flink.util.CollectionUtil;
 import org.apache.flink.util.IOUtils;
 import org.apache.flink.util.Preconditions;
+
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 
 import javax.annotation.Nonnull;
 
@@ -66,6 +64,8 @@ public class KeyedStateInputFormat<K, N, OUT>
         extends RichInputFormat<OUT, KeyGroupRangeInputSplit> {
 
     private static final long serialVersionUID = 8230460226049597182L;
+
+    private static final Logger LOG = LoggerFactory.getLogger(KeyedStateInputFormat.class);
 
     private final OperatorState operatorState;
 
@@ -94,7 +94,6 @@ public class KeyedStateInputFormat<K, N, OUT>
             Configuration configuration,
             StateReaderOperator<?, K, N, OUT> operator) {
         Preconditions.checkNotNull(operatorState, "The operator state cannot be null");
-        Preconditions.checkNotNull(stateBackend, "The state backend cannot be null");
         Preconditions.checkNotNull(configuration, "The configuration cannot be null");
         Preconditions.checkNotNull(operator, "The operator cannot be null");
 
@@ -144,15 +143,20 @@ public class KeyedStateInputFormat<K, N, OUT>
     public void open(KeyGroupRangeInputSplit split) throws IOException {
         registry = new CloseableRegistry();
 
-        final Environment environment =
-                new SavepointEnvironment.Builder(getRuntimeContext(), split.getNumKeyGroups())
-                        .setConfiguration(configuration)
-                        .setSubtaskIndex(split.getSplitNumber())
-                        .setPrioritizedOperatorSubtaskState(
-                                split.getPrioritizedOperatorSubtaskState())
-                        .build();
-
-        final StreamOperatorStateContext context = getStreamOperatorStateContext(environment);
+        final StreamOperatorStateContext context =
+                new StreamOperatorContextBuilder(
+                                getRuntimeContext(),
+                                configuration,
+                                operatorState,
+                                split,
+                                registry,
+                                stateBackend)
+                        .withMaxParallelism(split.getNumKeyGroups())
+                        .withKey(
+                                operator,
+                                operator.getKeyType()
+                                        .createSerializer(getRuntimeContext().getExecutionConfig()))
+                        .build(LOG);
 
         AbstractKeyedStateBackend<K> keyedStateBackend =
                 (AbstractKeyedStateBackend<K>) context.keyedStateBackend();
@@ -175,27 +179,6 @@ public class KeyedStateInputFormat<K, N, OUT>
             keysAndNamespaces = operator.getKeysAndNamespaces(ctx);
         } catch (Exception e) {
             throw new IOException("Failed to restore timer state", e);
-        }
-    }
-
-    private StreamOperatorStateContext getStreamOperatorStateContext(Environment environment)
-            throws IOException {
-        StreamTaskStateInitializer initializer =
-                new StreamTaskStateInitializerImpl(environment, stateBackend);
-
-        try {
-            return initializer.streamOperatorStateContext(
-                    operatorState.getOperatorID(),
-                    operatorState.getOperatorID().toString(),
-                    new NeverFireProcessingTimeService(),
-                    operator,
-                    operator.getKeyType().createSerializer(environment.getExecutionConfig()),
-                    registry,
-                    getRuntimeContext().getMetricGroup(),
-                    1.0,
-                    false);
-        } catch (Exception e) {
-            throw new IOException("Failed to restore state backend", e);
         }
     }
 

--- a/flink-libraries/flink-state-processing-api/src/main/java/org/apache/flink/state/api/input/ListStateInputFormat.java
+++ b/flink-libraries/flink-state-processing-api/src/main/java/org/apache/flink/state/api/input/ListStateInputFormat.java
@@ -20,9 +20,13 @@ package org.apache.flink.state.api.input;
 
 import org.apache.flink.annotation.Internal;
 import org.apache.flink.api.common.state.ListStateDescriptor;
+import org.apache.flink.configuration.Configuration;
 import org.apache.flink.runtime.checkpoint.OperatorState;
 import org.apache.flink.runtime.state.OperatorStateBackend;
+import org.apache.flink.runtime.state.StateBackend;
 import org.apache.flink.util.Preconditions;
+
+import javax.annotation.Nullable;
 
 /**
  * Input format for reading operator list state.
@@ -40,10 +44,16 @@ public class ListStateInputFormat<OT> extends OperatorStateInputFormat<OT> {
      * Creates an input format for reading list state from an operator in a savepoint.
      *
      * @param operatorState The state to be queried.
+     * @param configuration The cluster configuration for restoring the backend.
+     * @param backend The state backend used to restore the state.
      * @param descriptor The descriptor for this state, providing a name and serializer.
      */
-    public ListStateInputFormat(OperatorState operatorState, ListStateDescriptor<OT> descriptor) {
-        super(operatorState, false);
+    public ListStateInputFormat(
+            OperatorState operatorState,
+            Configuration configuration,
+            @Nullable StateBackend backend,
+            ListStateDescriptor<OT> descriptor) {
+        super(operatorState, configuration, backend, false);
 
         this.descriptor =
                 Preconditions.checkNotNull(descriptor, "The state descriptor must not be null");

--- a/flink-libraries/flink-state-processing-api/src/main/java/org/apache/flink/state/api/input/OperatorStateInputFormat.java
+++ b/flink-libraries/flink-state-processing-api/src/main/java/org/apache/flink/state/api/input/OperatorStateInputFormat.java
@@ -19,7 +19,6 @@
 package org.apache.flink.state.api.input;
 
 import org.apache.flink.annotation.Internal;
-import org.apache.flink.api.common.functions.RuntimeContext;
 import org.apache.flink.api.common.io.DefaultInputSplitAssigner;
 import org.apache.flink.api.common.io.RichInputFormat;
 import org.apache.flink.api.common.io.statistics.BaseStatistics;
@@ -32,19 +31,19 @@ import org.apache.flink.runtime.checkpoint.RoundRobinOperatorStateRepartitioner;
 import org.apache.flink.runtime.checkpoint.StateObjectCollection;
 import org.apache.flink.runtime.checkpoint.metadata.CheckpointMetadata;
 import org.apache.flink.runtime.jobgraph.OperatorInstanceID;
-import org.apache.flink.runtime.state.BackendBuildingException;
-import org.apache.flink.runtime.state.DefaultOperatorStateBackendBuilder;
 import org.apache.flink.runtime.state.OperatorStateBackend;
 import org.apache.flink.runtime.state.OperatorStateHandle;
 import org.apache.flink.state.api.input.splits.OperatorStateInputSplit;
-import org.apache.flink.streaming.api.operators.BackendRestorerProcedure;
+import org.apache.flink.streaming.api.operators.StreamOperatorStateContext;
 import org.apache.flink.util.CollectionUtil;
 import org.apache.flink.util.IOUtils;
 import org.apache.flink.util.Preconditions;
 
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
 import java.io.IOException;
 import java.util.ArrayList;
-import java.util.Collection;
 import java.util.HashMap;
 import java.util.Iterator;
 import java.util.List;
@@ -62,6 +61,8 @@ import static org.apache.flink.runtime.checkpoint.StateAssignmentOperation.reDis
 abstract class OperatorStateInputFormat<OT> extends RichInputFormat<OT, OperatorStateInputSplit> {
 
     private static final long serialVersionUID = -2286490341042373742L;
+
+    private static final Logger LOG = LoggerFactory.getLogger(OperatorStateInputFormat.class);
 
     private final OperatorState operatorState;
 
@@ -117,7 +118,7 @@ abstract class OperatorStateInputFormat<OT> extends RichInputFormat<OT, Operator
         // sub-partitioned for better data distribution across the cluster.
         return CollectionUtil.mapWithIndex(
                         CollectionUtil.partition(
-                                splits[0].getPrioritizedManagedOperatorState().get(0).asList(),
+                                splits[0].getPrioritizedManagedOperatorState().asList(),
                                 minNumSplits),
                         (state, index) ->
                                 new OperatorStateInputSplit(
@@ -147,19 +148,17 @@ abstract class OperatorStateInputFormat<OT> extends RichInputFormat<OT, Operator
     public void open(OperatorStateInputSplit split) throws IOException {
         registry = new CloseableRegistry();
 
-        final BackendRestorerProcedure<OperatorStateBackend, OperatorStateHandle> backendRestorer =
-                new BackendRestorerProcedure<>(
-                        (handles) ->
-                                createOperatorStateBackend(getRuntimeContext(), handles, registry),
-                        registry,
-                        operatorState.getOperatorID().toString());
+        final StreamOperatorStateContext context =
+                new StreamOperatorContextBuilder(
+                                getRuntimeContext(),
+                                new Configuration(),
+                                operatorState,
+                                split,
+                                registry,
+                                null)
+                        .build(LOG);
 
-        try {
-            restoredBackend =
-                    backendRestorer.createAndRestore(split.getPrioritizedManagedOperatorState());
-        } catch (Exception exception) {
-            throw new IOException("Failed to restore state backend", exception);
-        }
+        restoredBackend = context.operatorStateBackend();
 
         try {
             elements = getElements(restoredBackend).iterator();
@@ -187,23 +186,5 @@ abstract class OperatorStateInputFormat<OT> extends RichInputFormat<OT, Operator
     @Override
     public OT nextRecord(OT reuse) {
         return elements.next();
-    }
-
-    private static OperatorStateBackend createOperatorStateBackend(
-            RuntimeContext runtimeContext,
-            Collection<OperatorStateHandle> stateHandles,
-            CloseableRegistry cancelStreamRegistry) {
-
-        try {
-            return new DefaultOperatorStateBackendBuilder(
-                            runtimeContext.getUserCodeClassLoader(),
-                            runtimeContext.getExecutionConfig(),
-                            false,
-                            stateHandles,
-                            cancelStreamRegistry)
-                    .build();
-        } catch (BackendBuildingException e) {
-            throw new RuntimeException(e);
-        }
     }
 }

--- a/flink-libraries/flink-state-processing-api/src/main/java/org/apache/flink/state/api/input/StreamOperatorContextBuilder.java
+++ b/flink-libraries/flink-state-processing-api/src/main/java/org/apache/flink/state/api/input/StreamOperatorContextBuilder.java
@@ -1,0 +1,146 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.flink.state.api.input;
+
+import org.apache.flink.annotation.Internal;
+import org.apache.flink.api.common.functions.RuntimeContext;
+import org.apache.flink.api.common.typeutils.TypeSerializer;
+import org.apache.flink.configuration.Configuration;
+import org.apache.flink.core.fs.CloseableRegistry;
+import org.apache.flink.runtime.checkpoint.OperatorState;
+import org.apache.flink.runtime.execution.Environment;
+import org.apache.flink.runtime.state.StateBackend;
+import org.apache.flink.runtime.state.StateBackendLoader;
+import org.apache.flink.state.api.input.splits.PrioritizedOperatorSubtaskStateInputSplit;
+import org.apache.flink.state.api.runtime.NeverFireProcessingTimeService;
+import org.apache.flink.state.api.runtime.SavepointEnvironment;
+import org.apache.flink.streaming.api.operators.KeyContext;
+import org.apache.flink.streaming.api.operators.StreamOperatorStateContext;
+import org.apache.flink.streaming.api.operators.StreamTaskStateInitializer;
+import org.apache.flink.streaming.api.operators.StreamTaskStateInitializerImpl;
+import org.apache.flink.util.DynamicCodeLoadingException;
+import org.apache.flink.util.TernaryBoolean;
+
+import org.slf4j.Logger;
+
+import javax.annotation.Nullable;
+
+import java.io.IOException;
+
+/** Utility for creating a {@link StreamOperatorStateContext}. */
+@Internal
+class StreamOperatorContextBuilder {
+
+    private final RuntimeContext ctx;
+
+    private final Configuration configuration;
+
+    private final OperatorState operatorState;
+
+    private int maxParallelism;
+
+    private final PrioritizedOperatorSubtaskStateInputSplit split;
+
+    private final CloseableRegistry registry;
+
+    @Nullable private final StateBackend applicationStateBackend;
+
+    private KeyContext keyContext = new VoidKeyContext();
+
+    @Nullable private TypeSerializer<?> keySerializer;
+
+    StreamOperatorContextBuilder(
+            RuntimeContext ctx,
+            Configuration configuration,
+            OperatorState operatorState,
+            PrioritizedOperatorSubtaskStateInputSplit split,
+            CloseableRegistry registry,
+            @Nullable StateBackend applicationStateBackend) {
+        this.ctx = ctx;
+        this.maxParallelism = ctx.getMaxNumberOfParallelSubtasks();
+        this.configuration = configuration;
+        this.operatorState = operatorState;
+        this.split = split;
+        this.registry = registry;
+        this.applicationStateBackend = applicationStateBackend;
+    }
+
+    StreamOperatorContextBuilder withMaxParallelism(int maxParallelism) {
+        this.maxParallelism = maxParallelism;
+        return this;
+    }
+
+    StreamOperatorContextBuilder withKey(KeyContext keyContext, TypeSerializer<?> keySerializer) {
+        this.keyContext = keyContext;
+        this.keySerializer = keySerializer;
+        return this;
+    }
+
+    StreamOperatorStateContext build(Logger logger) throws IOException {
+        final Environment environment =
+                new SavepointEnvironment.Builder(ctx, maxParallelism)
+                        .setConfiguration(configuration)
+                        .setSubtaskIndex(split.getSplitNumber())
+                        .setPrioritizedOperatorSubtaskState(
+                                split.getPrioritizedOperatorSubtaskState())
+                        .build();
+
+        StateBackend stateBackend;
+        try {
+            stateBackend =
+                    StateBackendLoader.fromApplicationOrConfigOrDefault(
+                            applicationStateBackend,
+                            TernaryBoolean.FALSE,
+                            configuration,
+                            ctx.getUserCodeClassLoader(),
+                            logger);
+        } catch (DynamicCodeLoadingException e) {
+            throw new IOException("Failed to load state backend", e);
+        }
+
+        StreamTaskStateInitializer initializer =
+                new StreamTaskStateInitializerImpl(environment, stateBackend);
+
+        try {
+            return initializer.streamOperatorStateContext(
+                    operatorState.getOperatorID(),
+                    operatorState.getOperatorID().toString(),
+                    new NeverFireProcessingTimeService(),
+                    keyContext,
+                    keySerializer,
+                    registry,
+                    ctx.getMetricGroup(),
+                    1.0,
+                    false);
+        } catch (Exception e) {
+            throw new IOException("Failed to restore state backend", e);
+        }
+    }
+
+    private static class VoidKeyContext implements KeyContext {
+
+        @Override
+        public void setCurrentKey(Object key) {}
+
+        @Override
+        public Object getCurrentKey() {
+            return null;
+        }
+    }
+}

--- a/flink-libraries/flink-state-processing-api/src/main/java/org/apache/flink/state/api/input/UnionStateInputFormat.java
+++ b/flink-libraries/flink-state-processing-api/src/main/java/org/apache/flink/state/api/input/UnionStateInputFormat.java
@@ -20,9 +20,13 @@ package org.apache.flink.state.api.input;
 
 import org.apache.flink.annotation.Internal;
 import org.apache.flink.api.common.state.ListStateDescriptor;
+import org.apache.flink.configuration.Configuration;
 import org.apache.flink.runtime.checkpoint.OperatorState;
 import org.apache.flink.runtime.state.OperatorStateBackend;
+import org.apache.flink.runtime.state.StateBackend;
 import org.apache.flink.util.Preconditions;
+
+import javax.annotation.Nullable;
 
 /**
  * Input format for reading operator union state.
@@ -40,10 +44,16 @@ public class UnionStateInputFormat<OT> extends OperatorStateInputFormat<OT> {
      * Creates an input format for reading union state from an operator in a savepoint.
      *
      * @param operatorState The state to be queried.
+     * @param configuration The cluster configuration for restoring the backend.
+     * @param backend The state backend used to restore the state.
      * @param descriptor The descriptor for this state, providing a name and serializer.
      */
-    public UnionStateInputFormat(OperatorState operatorState, ListStateDescriptor<OT> descriptor) {
-        super(operatorState, true);
+    public UnionStateInputFormat(
+            OperatorState operatorState,
+            Configuration configuration,
+            @Nullable StateBackend backend,
+            ListStateDescriptor<OT> descriptor) {
+        super(operatorState, configuration, backend, true);
 
         this.descriptor =
                 Preconditions.checkNotNull(descriptor, "The state descriptor must not be null");

--- a/flink-libraries/flink-state-processing-api/src/main/java/org/apache/flink/state/api/input/splits/KeyGroupRangeInputSplit.java
+++ b/flink-libraries/flink-state-processing-api/src/main/java/org/apache/flink/state/api/input/splits/KeyGroupRangeInputSplit.java
@@ -19,7 +19,6 @@
 package org.apache.flink.state.api.input.splits;
 
 import org.apache.flink.annotation.Internal;
-import org.apache.flink.core.io.InputSplit;
 import org.apache.flink.runtime.checkpoint.OperatorSubtaskState;
 import org.apache.flink.runtime.checkpoint.PrioritizedOperatorSubtaskState;
 import org.apache.flink.runtime.checkpoint.StateObjectCollection;
@@ -30,7 +29,7 @@ import java.util.List;
 
 /** An input split representing a key-group range from a savepoint. */
 @Internal
-public final class KeyGroupRangeInputSplit implements InputSplit {
+public final class KeyGroupRangeInputSplit implements PrioritizedOperatorSubtaskStateInputSplit {
 
     private static final long serialVersionUID = -3715297712294815706L;
 
@@ -60,6 +59,7 @@ public final class KeyGroupRangeInputSplit implements InputSplit {
         return split;
     }
 
+    @Override
     public PrioritizedOperatorSubtaskState getPrioritizedOperatorSubtaskState() {
         final OperatorSubtaskState subtaskState =
                 OperatorSubtaskState.builder()

--- a/flink-libraries/flink-state-processing-api/src/main/java/org/apache/flink/state/api/input/splits/OperatorStateInputSplit.java
+++ b/flink-libraries/flink-state-processing-api/src/main/java/org/apache/flink/state/api/input/splits/OperatorStateInputSplit.java
@@ -19,28 +19,28 @@
 package org.apache.flink.state.api.input.splits;
 
 import org.apache.flink.annotation.Internal;
-import org.apache.flink.core.io.InputSplit;
+import org.apache.flink.runtime.checkpoint.OperatorSubtaskState;
+import org.apache.flink.runtime.checkpoint.PrioritizedOperatorSubtaskState;
 import org.apache.flink.runtime.checkpoint.StateObjectCollection;
 import org.apache.flink.runtime.state.OperatorStateHandle;
 
 import javax.annotation.Nonnull;
 
 import java.util.Collections;
-import java.util.List;
 
 /** An input split containing state handles for operator state. */
 @Internal
-public final class OperatorStateInputSplit implements InputSplit {
+public final class OperatorStateInputSplit implements PrioritizedOperatorSubtaskStateInputSplit {
 
     private static final long serialVersionUID = -1892383531558135420L;
 
-    private final List<StateObjectCollection<OperatorStateHandle>> managedOperatorState;
+    private final StateObjectCollection<OperatorStateHandle> managedOperatorState;
 
     private final int splitNum;
 
     public OperatorStateInputSplit(
             StateObjectCollection<OperatorStateHandle> managedOperatorState, int splitNum) {
-        this.managedOperatorState = Collections.singletonList(managedOperatorState);
+        this.managedOperatorState = managedOperatorState;
         this.splitNum = splitNum;
     }
 
@@ -50,7 +50,17 @@ public final class OperatorStateInputSplit implements InputSplit {
     }
 
     @Nonnull
-    public List<StateObjectCollection<OperatorStateHandle>> getPrioritizedManagedOperatorState() {
+    public StateObjectCollection<OperatorStateHandle> getPrioritizedManagedOperatorState() {
         return this.managedOperatorState;
+    }
+
+    @Override
+    public PrioritizedOperatorSubtaskState getPrioritizedOperatorSubtaskState() {
+        final OperatorSubtaskState subtaskState =
+                OperatorSubtaskState.builder()
+                        .setManagedOperatorState(managedOperatorState)
+                        .build();
+        return new PrioritizedOperatorSubtaskState.Builder(subtaskState, Collections.emptyList())
+                .build();
     }
 }

--- a/flink-libraries/flink-state-processing-api/src/main/java/org/apache/flink/state/api/input/splits/PrioritizedOperatorSubtaskStateInputSplit.java
+++ b/flink-libraries/flink-state-processing-api/src/main/java/org/apache/flink/state/api/input/splits/PrioritizedOperatorSubtaskStateInputSplit.java
@@ -1,0 +1,30 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.flink.state.api.input.splits;
+
+import org.apache.flink.annotation.Internal;
+import org.apache.flink.core.io.InputSplit;
+import org.apache.flink.runtime.checkpoint.PrioritizedOperatorSubtaskState;
+
+/** An input split that returns {@link PrioritizedOperatorSubtaskState}. */
+@Internal
+public interface PrioritizedOperatorSubtaskStateInputSplit extends InputSplit {
+
+    PrioritizedOperatorSubtaskState getPrioritizedOperatorSubtaskState();
+}

--- a/flink-libraries/flink-state-processing-api/src/main/java/org/apache/flink/state/api/runtime/metadata/SavepointMetadataV2.java
+++ b/flink-libraries/flink-state-processing-api/src/main/java/org/apache/flink/state/api/runtime/metadata/SavepointMetadataV2.java
@@ -28,6 +28,7 @@ import org.apache.flink.state.api.runtime.StateBootstrapTransformationWithID;
 import org.apache.flink.util.Preconditions;
 
 import java.io.IOException;
+import java.util.ArrayList;
 import java.util.Collection;
 import java.util.HashMap;
 import java.util.List;
@@ -56,11 +57,12 @@ public class SavepointMetadataV2 {
                         + UPPER_BOUND_MAX_PARALLELISM
                         + ". Found: "
                         + maxParallelism);
+        Preconditions.checkNotNull(masterStates);
+
         this.maxParallelism = maxParallelism;
-
-        this.masterStates = Preconditions.checkNotNull(masterStates);
-
+        this.masterStates = new ArrayList<>(masterStates);
         this.operatorStateIndex = new HashMap<>(initialStates.size());
+
         initialStates.forEach(
                 existingState ->
                         operatorStateIndex.put(

--- a/flink-libraries/flink-state-processing-api/src/test/java/org/apache/flink/state/api/SavepointWriterITCase.java
+++ b/flink-libraries/flink-state-processing-api/src/test/java/org/apache/flink/state/api/SavepointWriterITCase.java
@@ -85,6 +85,11 @@ public class SavepointWriterITCase extends AbstractTestBase {
     @Rule public StreamCollector collector = new StreamCollector();
 
     @Test
+    public void testDefaultStateBackend() throws Exception {
+        testStateBootstrapAndModification(null);
+    }
+
+    @Test
     public void testHashMapStateBackend() throws Exception {
         testStateBootstrapAndModification(new HashMapStateBackend());
     }
@@ -121,8 +126,12 @@ public class SavepointWriterITCase extends AbstractTestBase {
                 OperatorTransformation.bootstrapWith(env.fromCollection(currencyRates))
                         .transform(new CurrencyBootstrapFunction());
 
-        SavepointWriter.newSavepoint(backend, 128)
-                .withOperator(ACCOUNT_UID, transformation)
+        SavepointWriter writer =
+                backend == null
+                        ? SavepointWriter.newSavepoint(128)
+                        : SavepointWriter.newSavepoint(backend, 128);
+
+        writer.withOperator(ACCOUNT_UID, transformation)
                 .withOperator(CURRENCY_UID, broadcastTransformation)
                 .write(savepointPath);
 
@@ -131,7 +140,10 @@ public class SavepointWriterITCase extends AbstractTestBase {
 
     private void validateBootstrap(StateBackend backend, String savepointPath) throws Exception {
         StreamExecutionEnvironment env = StreamExecutionEnvironment.getExecutionEnvironment();
-        env.setStateBackend(backend);
+
+        if (backend != null) {
+            env.setStateBackend(backend);
+        }
 
         DataStream<Account> stream =
                 env.fromCollection(accounts)
@@ -174,8 +186,12 @@ public class SavepointWriterITCase extends AbstractTestBase {
                 OperatorTransformation.bootstrapWith(env.fromElements(1, 2, 3))
                         .transform(new ModifyProcessFunction());
 
-        SavepointWriter.fromExistingSavepoint(savepointPath, backend)
-                .removeOperator(CURRENCY_UID)
+        SavepointWriter writer =
+                backend == null
+                        ? SavepointWriter.fromExistingSavepoint(savepointPath)
+                        : SavepointWriter.fromExistingSavepoint(savepointPath, backend);
+
+        writer.removeOperator(CURRENCY_UID)
                 .withOperator(MODIFY_UID, transformation)
                 .write(modifyPath);
 
@@ -184,7 +200,9 @@ public class SavepointWriterITCase extends AbstractTestBase {
 
     private void validateModification(StateBackend backend, String savepointPath) throws Exception {
         StreamExecutionEnvironment sEnv = StreamExecutionEnvironment.getExecutionEnvironment();
-        sEnv.setStateBackend(backend);
+        if (backend != null) {
+            sEnv.setStateBackend(backend);
+        }
 
         DataStream<Account> stream =
                 sEnv.fromCollection(accounts)

--- a/flink-libraries/flink-state-processing-api/src/test/java/org/apache/flink/state/api/SavepointWriterTest.java
+++ b/flink-libraries/flink-state-processing-api/src/test/java/org/apache/flink/state/api/SavepointWriterTest.java
@@ -1,0 +1,64 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.flink.state.api;
+
+import org.apache.flink.api.common.RuntimeExecutionMode;
+import org.apache.flink.configuration.Configuration;
+import org.apache.flink.configuration.ExecutionOptions;
+import org.apache.flink.configuration.StateBackendOptions;
+import org.apache.flink.state.api.functions.KeyedStateBootstrapFunction;
+import org.apache.flink.state.api.utils.CustomStateBackendFactory;
+import org.apache.flink.streaming.api.datastream.DataStream;
+import org.apache.flink.streaming.api.environment.StreamExecutionEnvironment;
+
+import org.junit.Test;
+
+/** Tests for the savepoint writer. */
+public class SavepointWriterTest {
+
+    @Test(expected = CustomStateBackendFactory.ExpectedException.class)
+    public void testCustomStateBackend() throws Exception {
+        StreamExecutionEnvironment env = StreamExecutionEnvironment.getExecutionEnvironment();
+        Configuration configuration = new Configuration();
+        configuration.set(
+                StateBackendOptions.STATE_BACKEND,
+                CustomStateBackendFactory.class.getCanonicalName());
+        configuration.set(ExecutionOptions.RUNTIME_MODE, RuntimeExecutionMode.BATCH);
+        env.configure(configuration);
+
+        DataStream<String> input = env.fromElements("");
+
+        StateBootstrapTransformation<String> transformation =
+                OperatorTransformation.bootstrapWith(input)
+                        .keyBy(element -> element)
+                        .transform(new Bootstrapper());
+
+        SavepointWriter.newSavepoint(128)
+                .withOperator("uid", transformation)
+                .write("file:///tmp/path");
+
+        env.execute();
+    }
+
+    private static class Bootstrapper extends KeyedStateBootstrapFunction<String, String> {
+
+        @Override
+        public void processElement(String value, Context ctx) throws Exception {}
+    }
+}

--- a/flink-libraries/flink-state-processing-api/src/test/java/org/apache/flink/state/api/input/BroadcastStateInputFormatTest.java
+++ b/flink-libraries/flink-state-processing-api/src/test/java/org/apache/flink/state/api/input/BroadcastStateInputFormatTest.java
@@ -21,6 +21,7 @@ package org.apache.flink.state.api.input;
 import org.apache.flink.api.common.state.MapStateDescriptor;
 import org.apache.flink.api.common.typeinfo.Types;
 import org.apache.flink.api.java.tuple.Tuple2;
+import org.apache.flink.configuration.Configuration;
 import org.apache.flink.runtime.checkpoint.OperatorState;
 import org.apache.flink.runtime.checkpoint.OperatorSubtaskState;
 import org.apache.flink.state.api.input.splits.OperatorStateInputSplit;
@@ -62,7 +63,7 @@ public class BroadcastStateInputFormatTest {
                     new OperatorStateInputSplit(subtaskState.getManagedOperatorState(), 0);
 
             BroadcastStateInputFormat<Integer, Integer> format =
-                    new BroadcastStateInputFormat<>(state, descriptor);
+                    new BroadcastStateInputFormat<>(state, new Configuration(), null, descriptor);
 
             format.setRuntimeContext(new MockStreamingRuntimeContext(false, 1, 0));
             format.open(split);

--- a/flink-libraries/flink-state-processing-api/src/test/java/org/apache/flink/state/api/input/ListStateInputFormatTest.java
+++ b/flink-libraries/flink-state-processing-api/src/test/java/org/apache/flink/state/api/input/ListStateInputFormatTest.java
@@ -23,6 +23,7 @@ import org.apache.flink.api.common.state.ListState;
 import org.apache.flink.api.common.state.ListStateDescriptor;
 import org.apache.flink.api.common.typeinfo.Types;
 import org.apache.flink.api.common.typeutils.base.IntSerializer;
+import org.apache.flink.configuration.Configuration;
 import org.apache.flink.runtime.checkpoint.OperatorState;
 import org.apache.flink.runtime.checkpoint.OperatorSubtaskState;
 import org.apache.flink.runtime.state.FunctionInitializationContext;
@@ -64,7 +65,8 @@ public class ListStateInputFormatTest {
             OperatorStateInputSplit split =
                     new OperatorStateInputSplit(subtaskState.getManagedOperatorState(), 0);
 
-            ListStateInputFormat<Integer> format = new ListStateInputFormat<>(state, descriptor);
+            ListStateInputFormat<Integer> format =
+                    new ListStateInputFormat<>(state, new Configuration(), null, descriptor);
 
             format.setRuntimeContext(new MockStreamingRuntimeContext(false, 1, 0));
             format.open(split);

--- a/flink-libraries/flink-state-processing-api/src/test/java/org/apache/flink/state/api/input/StreamOperatorContextBuilderTest.java
+++ b/flink-libraries/flink-state-processing-api/src/test/java/org/apache/flink/state/api/input/StreamOperatorContextBuilderTest.java
@@ -1,0 +1,70 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.flink.state.api.input;
+
+import org.apache.flink.configuration.Configuration;
+import org.apache.flink.configuration.StateBackendOptions;
+import org.apache.flink.core.fs.CloseableRegistry;
+import org.apache.flink.runtime.checkpoint.OperatorState;
+import org.apache.flink.runtime.checkpoint.PrioritizedOperatorSubtaskState;
+import org.apache.flink.runtime.jobgraph.OperatorID;
+import org.apache.flink.state.api.input.splits.PrioritizedOperatorSubtaskStateInputSplit;
+import org.apache.flink.state.api.utils.CustomStateBackendFactory;
+import org.apache.flink.streaming.util.MockStreamingRuntimeContext;
+
+import org.junit.Test;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+/** Tests for the stream operator context builder. */
+public class StreamOperatorContextBuilderTest {
+
+    private static final Logger LOG =
+            LoggerFactory.getLogger(StreamOperatorContextBuilderTest.class);
+
+    @Test(expected = CustomStateBackendFactory.ExpectedException.class)
+    public void testStateBackendLoading() throws Exception {
+        Configuration configuration = new Configuration();
+        configuration.set(
+                StateBackendOptions.STATE_BACKEND,
+                CustomStateBackendFactory.class.getCanonicalName());
+
+        StreamOperatorContextBuilder builder =
+                new StreamOperatorContextBuilder(
+                        new MockStreamingRuntimeContext(true, 1, 0),
+                        configuration,
+                        new OperatorState(new OperatorID(), 1, 128),
+                        new PrioritizedOperatorSubtaskStateInputSplit() {
+                            @Override
+                            public PrioritizedOperatorSubtaskState
+                                    getPrioritizedOperatorSubtaskState() {
+                                return PrioritizedOperatorSubtaskState.emptyNotRestored();
+                            }
+
+                            @Override
+                            public int getSplitNumber() {
+                                return 0;
+                            }
+                        },
+                        new CloseableRegistry(),
+                        null);
+
+        builder.build(LOG);
+    }
+}

--- a/flink-libraries/flink-state-processing-api/src/test/java/org/apache/flink/state/api/input/UnionStateInputFormatTest.java
+++ b/flink-libraries/flink-state-processing-api/src/test/java/org/apache/flink/state/api/input/UnionStateInputFormatTest.java
@@ -23,6 +23,7 @@ import org.apache.flink.api.common.state.ListState;
 import org.apache.flink.api.common.state.ListStateDescriptor;
 import org.apache.flink.api.common.typeinfo.Types;
 import org.apache.flink.api.common.typeutils.base.IntSerializer;
+import org.apache.flink.configuration.Configuration;
 import org.apache.flink.runtime.checkpoint.OperatorState;
 import org.apache.flink.runtime.checkpoint.OperatorSubtaskState;
 import org.apache.flink.runtime.state.FunctionInitializationContext;
@@ -64,7 +65,8 @@ public class UnionStateInputFormatTest {
             OperatorStateInputSplit split =
                     new OperatorStateInputSplit(subtaskState.getManagedOperatorState(), 0);
 
-            UnionStateInputFormat<Integer> format = new UnionStateInputFormat<>(state, descriptor);
+            UnionStateInputFormat<Integer> format =
+                    new UnionStateInputFormat<>(state, new Configuration(), null, descriptor);
 
             format.setRuntimeContext(new MockStreamingRuntimeContext(false, 1, 0));
             format.open(split);

--- a/flink-libraries/flink-state-processing-api/src/test/java/org/apache/flink/state/api/utils/CustomStateBackendFactory.java
+++ b/flink-libraries/flink-state-processing-api/src/test/java/org/apache/flink/state/api/utils/CustomStateBackendFactory.java
@@ -1,0 +1,39 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.flink.state.api.utils;
+
+import org.apache.flink.configuration.IllegalConfigurationException;
+import org.apache.flink.configuration.ReadableConfig;
+import org.apache.flink.runtime.state.StateBackend;
+import org.apache.flink.runtime.state.StateBackendFactory;
+
+import java.io.IOException;
+
+/** A simple custom {@link StateBackendFactory} that throws an exception. */
+public class CustomStateBackendFactory implements StateBackendFactory<StateBackend> {
+
+    @Override
+    public StateBackend createFromConfig(ReadableConfig config, ClassLoader classLoader)
+            throws IllegalConfigurationException, IOException {
+        throw new ExpectedException();
+    }
+
+    /** An expected exception. Used to verify this factory is used at runtime. */
+    public static class ExpectedException extends RuntimeException {}
+}


### PR DESCRIPTION
## What is the purpose of the change

Support loading the configured state backend in the state-proc-api via the clusters configuration.

## Brief change log

- see above 

## Verifying this change

This change is covered by new unit tests.

## Does this pull request potentially affect one of the following parts:

  - Dependencies (does it add or upgrade a dependency): (yes / **no**)
  - The public API, i.e., is any changed class annotated with `@Public(Evolving)`: (**yes** / no)
  - The serializers: (yes / **no** / don't know)
  - The runtime per-record code paths (performance sensitive): (yes / **no** / don't know)
  - Anything that affects deployment or recovery: JobManager (and its components), Checkpointing, Kubernetes/Yarn, ZooKeeper: (yes / **no** / don't know)
  - The S3 file system connector: (yes / **no** / don't know)

## Documentation

  - Does this pull request introduce a new feature? (**yes** / no)
  - If yes, how is the feature documented? (not applicable / docs / **JavaDocs** / not documented)
