### PR TITLE
[FLINK-25474][table-planner] Fix Idea Scala plugin can not compile RexExplainUtil

### DIFF
--- a/flink-table/flink-table-planner/src/main/scala/org/apache/flink/table/planner/plan/utils/FlinkRexUtil.scala
+++ b/flink-table/flink-table-planner/src/main/scala/org/apache/flink/table/planner/plan/utils/FlinkRexUtil.scala
@@ -21,8 +21,9 @@ import org.apache.flink.annotation.Experimental
 import org.apache.flink.configuration.ConfigOption
 import org.apache.flink.configuration.ConfigOptions.key
 import org.apache.flink.table.planner.JList
-import org.apache.flink.table.planner.plan.utils.ExpressionFormat.ExpressionFormat
 import org.apache.flink.table.planner.plan.utils.ExpressionDetail.ExpressionDetail
+import org.apache.flink.table.planner.plan.utils.ExpressionFormat.ExpressionFormat
+
 import com.google.common.base.Function
 import com.google.common.collect.{ImmutableList, Lists}
 import org.apache.calcite.avatica.util.ByteString
@@ -30,8 +31,8 @@ import org.apache.calcite.plan.{RelOptPredicateList, RelOptUtil}
 import org.apache.calcite.rel.`type`.RelDataType
 import org.apache.calcite.rex._
 import org.apache.calcite.sql.`type`.SqlTypeName
-import org.apache.calcite.sql.fun.{SqlCastFunction, SqlStdOperatorTable}
 import org.apache.calcite.sql.fun.SqlStdOperatorTable._
+import org.apache.calcite.sql.fun.{SqlCastFunction, SqlStdOperatorTable}
 import org.apache.calcite.sql.{SqlAsOperator, SqlKind, SqlOperator}
 import org.apache.calcite.util.{ControlFlowException, DateString, ImmutableBitSet, NlsString, Sarg, TimeString, TimestampString, Util}
 
@@ -39,6 +40,7 @@ import java.lang.{Iterable => JIterable}
 import java.math.BigDecimal
 import java.util
 import java.util.function.Predicate
+
 import scala.collection.JavaConversions._
 import scala.collection.mutable
 

--- a/flink-table/flink-table-planner/src/main/scala/org/apache/flink/table/planner/plan/utils/RelExplainUtil.scala
+++ b/flink-table/flink-table-planner/src/main/scala/org/apache/flink/table/planner/plan/utils/RelExplainUtil.scala
@@ -21,8 +21,8 @@ import org.apache.flink.table.api.TableException
 import org.apache.flink.table.functions.{AggregateFunction, UserDefinedFunction}
 import org.apache.flink.table.planner.CalcitePair
 import org.apache.flink.table.planner.functions.aggfunctions.DeclarativeAggregateFunction
-import org.apache.flink.table.planner.plan.utils.ExpressionFormat.ExpressionFormat
 import org.apache.flink.table.planner.plan.utils.ExpressionDetail.ExpressionDetail
+import org.apache.flink.table.planner.plan.utils.ExpressionFormat.ExpressionFormat
 import org.apache.flink.table.runtime.groupwindow.NamedWindowProperty
 
 import com.google.common.collect.ImmutableMap
@@ -32,8 +32,8 @@ import org.apache.calcite.rel.core.{AggregateCall, Window}
 import org.apache.calcite.rel.hint.RelHint
 import org.apache.calcite.rel.{RelCollation, RelWriter}
 import org.apache.calcite.rex._
-import org.apache.calcite.sql.{SqlExplainLevel, SqlKind}
 import org.apache.calcite.sql.SqlMatchRecognize.AfterOption
+import org.apache.calcite.sql.{SqlExplainLevel, SqlKind}
 
 import java.util
 import java.util.{SortedSet => JSortedSet}
@@ -510,7 +510,7 @@ object RelExplainUtil {
     val outputFieldNames = outputRowType.getFieldNames
 
     val aggStrings = namedAggregates.map(_.getKey).map(
-      a => s"${a.getAggregation}(${
+      a => s"""${a.getAggregation}(${
         val prefix = if (a.isDistinct) {
           "DISTINCT "
         } else {
@@ -530,7 +530,8 @@ object RelExplainUtil {
         } else {
           "*"
         })
-      })")
+      })""".stripMargin
+    )
 
     val output = if (outputInputName) inputFieldNames ++ aggStrings else aggStrings
     output.zip(outputFieldNames.drop(rowTypeOffset)).map {


### PR DESCRIPTION

## What is the purpose of the change

*Fix Idea Scala plugin can not compile RexExplainUtil, see the description in FLINK-25474*


## Brief change log

  - *Use Multiline String in RexExplainUtil#overAggregationToString method*


## Verifying this change

This change is a trivial rework / code cleanup without any test coverage.


## Does this pull request potentially affect one of the following parts:

  - Dependencies (does it add or upgrade a dependency): (yes / **no**)
  - The public API, i.e., is any changed class annotated with `@Public(Evolving)`: (yes / **no**)
  - The serializers: (yes / **no** / don't know)
  - The runtime per-record code paths (performance sensitive): (yes / **no** / don't know)
  - Anything that affects deployment or recovery: JobManager (and its components), Checkpointing, Kubernetes/Yarn, ZooKeeper: (yes / **no** / don't know)
  - The S3 file system connector: (yes / **no** / don't know)

## Documentation

  - Does this pull request introduce a new feature? (yes / **no**)
  - If yes, how is the feature documented? (not applicable / docs / JavaDocs / **not documented**)
