### PR TITLE
[hotfix][flink-walkthrough] Fix typo in name for archetype-resources/pom.xml

### DIFF
--- a/flink-walkthroughs/flink-walkthrough-datastream-scala/src/main/resources/archetype-resources/pom.xml
+++ b/flink-walkthroughs/flink-walkthrough-datastream-scala/src/main/resources/archetype-resources/pom.xml
@@ -26,7 +26,7 @@ under the License.
 	<version>${version}</version>
 	<packaging>jar</packaging>
 
-	<name>Flink Walkthrough DataStram Scala</name>
+	<name>Flink Walkthrough DataStream Scala</name>
 	<url>https://flink.apache.org</url>
 
 	<repositories>


### PR DESCRIPTION
[hotfix][flink-walkthrough] Fix typo in name for archetype-resources/pom.xml