### PR TITLE
[FLINK-25817] Use working directory to persist local state

### DIFF
--- a/flink-runtime/src/main/java/org/apache/flink/runtime/clusterframework/types/AllocationID.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/clusterframework/types/AllocationID.java
@@ -19,6 +19,7 @@
 package org.apache.flink.runtime.clusterframework.types;
 
 import org.apache.flink.util.AbstractID;
+import org.apache.flink.util.StringUtils;
 
 /**
  * Unique identifier for a physical slot allocated by a JobManager via the ResourceManager from a
@@ -41,6 +42,10 @@ public class AllocationID extends AbstractID {
         super();
     }
 
+    private AllocationID(byte[] bytes) {
+        super(bytes);
+    }
+
     /**
      * Constructs a new AllocationID with the given parts.
      *
@@ -49,5 +54,9 @@ public class AllocationID extends AbstractID {
      */
     public AllocationID(long lowerPart, long upperPart) {
         super(lowerPart, upperPart);
+    }
+
+    public static AllocationID fromHexString(String hexString) {
+        return new AllocationID(StringUtils.hexStringToByte(hexString));
     }
 }

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/entrypoint/ClusterEntrypoint.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/entrypoint/ClusterEntrypoint.java
@@ -181,6 +181,29 @@ public abstract class ClusterEntrypoint implements AutoCloseableAsync, FatalErro
                         () -> this.closeAsync().join(), getClass().getSimpleName(), LOG);
     }
 
+    public int getRestPort() {
+        synchronized (lock) {
+            assertClusterEntrypointIsStarted();
+
+            return clusterComponent.getRestPort();
+        }
+    }
+
+    public int getRpcPort() {
+        synchronized (lock) {
+            assertClusterEntrypointIsStarted();
+
+            return commonRpcService.getPort();
+        }
+    }
+
+    @GuardedBy("lock")
+    private void assertClusterEntrypointIsStarted() {
+        Preconditions.checkNotNull(
+                commonRpcService,
+                String.format("%s has not been started yet.", getClass().getSimpleName()));
+    }
+
     public CompletableFuture<ApplicationStatus> getTerminationFuture() {
         return terminationFuture;
     }

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/entrypoint/WorkingDirectory.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/entrypoint/WorkingDirectory.java
@@ -32,6 +32,7 @@ public class WorkingDirectory {
     private final File tmp;
     private final File localState;
     private final File blobStorage;
+    private final File slotAllocationSnapshotDirectory;
 
     private WorkingDirectory(File root) throws IOException {
         this.root = root;
@@ -46,6 +47,9 @@ public class WorkingDirectory {
 
         blobStorage = new File(root, "blobStorage");
         createDirectory(blobStorage);
+
+        slotAllocationSnapshotDirectory = new File(root, "slotAllocationSnapshots");
+        createDirectory(slotAllocationSnapshotDirectory);
     }
 
     private static void createDirectory(File directory) throws IOException {
@@ -65,6 +69,10 @@ public class WorkingDirectory {
 
     public File getLocalStateDirectory() {
         return localState;
+    }
+
+    public File getSlotAllocationSnapshotDirectory() {
+        return slotAllocationSnapshotDirectory;
     }
 
     public WorkingDirectory createSubWorkingDirectory(String directoryName) throws IOException {

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/entrypoint/component/DispatcherResourceManagerComponent.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/entrypoint/component/DispatcherResourceManagerComponent.java
@@ -25,6 +25,7 @@ import org.apache.flink.runtime.dispatcher.runner.DispatcherRunner;
 import org.apache.flink.runtime.leaderretrieval.LeaderRetrievalService;
 import org.apache.flink.runtime.resourcemanager.ResourceManager;
 import org.apache.flink.runtime.resourcemanager.ResourceManagerService;
+import org.apache.flink.runtime.rest.RestService;
 import org.apache.flink.runtime.rpc.FatalErrorHandler;
 import org.apache.flink.runtime.webmonitor.WebMonitorEndpoint;
 import org.apache.flink.util.AutoCloseableAsync;
@@ -61,7 +62,7 @@ public class DispatcherResourceManagerComponent implements AutoCloseableAsync {
 
     @Nonnull private final LeaderRetrievalService resourceManagerRetrievalService;
 
-    @Nonnull private final AutoCloseableAsync webMonitorEndpoint;
+    @Nonnull private final RestService webMonitorEndpoint;
 
     private final CompletableFuture<Void> terminationFuture;
 
@@ -78,7 +79,7 @@ public class DispatcherResourceManagerComponent implements AutoCloseableAsync {
             @Nonnull ResourceManagerService resourceManagerService,
             @Nonnull LeaderRetrievalService dispatcherLeaderRetrievalService,
             @Nonnull LeaderRetrievalService resourceManagerRetrievalService,
-            @Nonnull AutoCloseableAsync webMonitorEndpoint,
+            @Nonnull RestService webMonitorEndpoint,
             @Nonnull FatalErrorHandler fatalErrorHandler,
             @Nonnull DispatcherOperationCaches dispatcherOperationCaches) {
         this.dispatcherRunner = dispatcherRunner;
@@ -216,5 +217,9 @@ public class DispatcherResourceManagerComponent implements AutoCloseableAsync {
     public CompletableFuture<Void> closeAsync() {
         return stopApplication(
                 ApplicationStatus.CANCELED, "DispatcherResourceManagerComponent has been closed.");
+    }
+
+    public int getRestPort() {
+        return webMonitorEndpoint.getRestPort();
     }
 }

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/rest/RestService.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/rest/RestService.java
@@ -1,0 +1,32 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.flink.runtime.rest;
+
+import org.apache.flink.util.AutoCloseableAsync;
+
+/** Rest service interface. */
+public interface RestService extends AutoCloseableAsync {
+
+    /**
+     * Port of the running rest service.
+     *
+     * @return port of the rest service if running; otherwise -1
+     */
+    int getRestPort();
+}

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/state/TaskExecutorLocalStateStoresManager.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/state/TaskExecutorLocalStateStoresManager.java
@@ -78,6 +78,11 @@ public class TaskExecutorLocalStateStoresManager {
             @Nonnull Executor discardExecutor)
             throws IOException {
 
+        LOG.debug(
+                "Start {} with local state root directories {}.",
+                getClass().getSimpleName(),
+                localStateRootDirectories);
+
         this.taskStateStoresByAllocationID = new HashMap<>();
         this.localRecoveryEnabled = localRecoveryEnabled;
         this.localStateRootDirectories = localStateRootDirectories;
@@ -193,7 +198,6 @@ public class TaskExecutorLocalStateStoresManager {
     }
 
     public void releaseLocalStateForAllocationId(@Nonnull AllocationID allocationID) {
-
         if (LOG.isDebugEnabled()) {
             LOG.debug("Releasing local state under allocation id {}.", allocationID);
         }

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/state/TaskLocalStateStoreImpl.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/state/TaskLocalStateStoreImpl.java
@@ -87,7 +87,7 @@ public class TaskLocalStateStoreImpl implements OwnedTaskLocalStateStore {
     @Nonnull private final Executor discardExecutor;
 
     /** Lock for synchronisation on the storage map and the discarded status. */
-    @Nonnull private final Object lock;
+    @Nonnull private final Object lock = new Object();
 
     /** Status flag if this store was already discarded. */
     @GuardedBy("lock")
@@ -106,36 +106,13 @@ public class TaskLocalStateStoreImpl implements OwnedTaskLocalStateStore {
             @Nonnull LocalRecoveryConfig localRecoveryConfig,
             @Nonnull Executor discardExecutor) {
 
-        this(
-                jobID,
-                allocationID,
-                jobVertexID,
-                subtaskIndex,
-                localRecoveryConfig,
-                discardExecutor,
-                new TreeMap<>(),
-                new Object());
-    }
-
-    @VisibleForTesting
-    TaskLocalStateStoreImpl(
-            @Nonnull JobID jobID,
-            @Nonnull AllocationID allocationID,
-            @Nonnull JobVertexID jobVertexID,
-            @Nonnegative int subtaskIndex,
-            @Nonnull LocalRecoveryConfig localRecoveryConfig,
-            @Nonnull Executor discardExecutor,
-            @Nonnull SortedMap<Long, TaskStateSnapshot> storedTaskStateByCheckpointID,
-            @Nonnull Object lock) {
-
         this.jobID = jobID;
         this.allocationID = allocationID;
         this.jobVertexID = jobVertexID;
         this.subtaskIndex = subtaskIndex;
         this.discardExecutor = discardExecutor;
         this.localRecoveryConfig = localRecoveryConfig;
-        this.storedTaskStateByCheckpointID = storedTaskStateByCheckpointID;
-        this.lock = lock;
+        this.storedTaskStateByCheckpointID = new TreeMap<>();
         this.disposed = false;
     }
 

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/taskexecutor/TaskExecutor.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/taskexecutor/TaskExecutor.java
@@ -115,8 +115,9 @@ import org.apache.flink.runtime.taskexecutor.rpc.RpcKvStateRegistryListener;
 import org.apache.flink.runtime.taskexecutor.rpc.RpcPartitionStateChecker;
 import org.apache.flink.runtime.taskexecutor.rpc.RpcResultPartitionConsumableNotifier;
 import org.apache.flink.runtime.taskexecutor.rpc.RpcTaskOperatorEventGateway;
-import org.apache.flink.runtime.taskexecutor.slot.LocalSlotAllocationSnapshot;
 import org.apache.flink.runtime.taskexecutor.slot.SlotActions;
+import org.apache.flink.runtime.taskexecutor.slot.SlotAllocationSnapshot;
+import org.apache.flink.runtime.taskexecutor.slot.SlotAllocationSnapshotPersistenceService;
 import org.apache.flink.runtime.taskexecutor.slot.SlotNotActiveException;
 import org.apache.flink.runtime.taskexecutor.slot.SlotNotFoundException;
 import org.apache.flink.runtime.taskexecutor.slot.SlotOffer;
@@ -130,7 +131,6 @@ import org.apache.flink.runtime.taskmanager.UnresolvedTaskManagerLocation;
 import org.apache.flink.runtime.webmonitor.threadinfo.ThreadInfoSamplesRequest;
 import org.apache.flink.types.SerializableOptional;
 import org.apache.flink.util.ExceptionUtils;
-import org.apache.flink.util.FileUtils;
 import org.apache.flink.util.FlinkException;
 import org.apache.flink.util.OptionalConsumer;
 import org.apache.flink.util.Preconditions;
@@ -147,11 +147,8 @@ import javax.annotation.Nullable;
 
 import java.io.File;
 import java.io.FileInputStream;
-import java.io.FileOutputStream;
 import java.io.IOException;
 import java.io.InputStream;
-import java.io.ObjectInputStream;
-import java.io.ObjectOutputStream;
 import java.net.InetSocketAddress;
 import java.util.ArrayList;
 import java.util.Arrays;
@@ -241,8 +238,7 @@ public class TaskExecutor extends RpcEndpoint implements TaskExecutorGateway {
 
     private final LeaderRetrievalService resourceManagerLeaderRetriever;
 
-    /** Directory to read/write allocation files. */
-    private final File allocationsDirectory;
+    private final SlotAllocationSnapshotPersistenceService slotAllocationSnapshotPersistenceService;
 
     // ------------------------------------------------------------------------
 
@@ -343,7 +339,8 @@ public class TaskExecutor extends RpcEndpoint implements TaskExecutorGateway {
                 Executors.newSingleThreadScheduledExecutor(sampleThreadFactory);
         this.threadInfoSampleService = new ThreadInfoSampleService(sampleExecutor);
 
-        this.allocationsDirectory = null;
+        this.slotAllocationSnapshotPersistenceService =
+                taskExecutorServices.getSlotAllocationSnapshotPersistenceService();
     }
 
     private HeartbeatManager<Void, TaskExecutorHeartbeatPayload>
@@ -1078,7 +1075,9 @@ public class TaskExecutor extends RpcEndpoint implements TaskExecutorGateway {
             return FutureUtils.completedExceptionally(new TaskManagerException(message));
         }
 
-        tryPersistAllocationSnapshot(slotId, jobId, targetAddress, allocationId, resourceProfile);
+        tryPersistAllocationSnapshot(
+                new SlotAllocationSnapshot(
+                        slotId, jobId, targetAddress, allocationId, resourceProfile));
 
         try {
             allocateSlot(slotId, jobId, allocationId, resourceProfile);
@@ -1915,7 +1914,7 @@ public class TaskExecutor extends RpcEndpoint implements TaskExecutorGateway {
 
             final int slotIndex = taskSlotTable.freeSlot(allocationId, cause);
 
-            tryCleanupSlotAllocationSnapshot(slotIndex);
+            slotAllocationSnapshotPersistenceService.deleteAllocationSnapshot(slotIndex);
 
             if (slotIndex != -1) {
 
@@ -2031,66 +2030,13 @@ public class TaskExecutor extends RpcEndpoint implements TaskExecutorGateway {
         }
     }
 
-    private void tryPersistAllocationSnapshot(
-            SlotID slotId,
-            JobID jobId,
-            String jobTargetAddress,
-            AllocationID allocationId,
-            ResourceProfile resourceProfile) {
-        if (!allocationsDirectory.exists() && !allocationsDirectory.mkdirs()) {
-            log.debug(
-                    "Allocations directory {} doesn't exist and cannot be created.",
-                    allocationsDirectory.toPath());
-            return;
-        }
-
-        // Let's try to write the slot allocations on file
-        final File slotAllocationSnapshotFile = slotAllocationFile(slotId.getSlotNumber());
-        try (ObjectOutputStream oos =
-                new ObjectOutputStream(new FileOutputStream(slotAllocationSnapshotFile))) {
-            oos.writeObject(
-                    new LocalSlotAllocationSnapshot(
-                            slotId, jobId, jobTargetAddress, allocationId, resourceProfile));
-            log.debug(
-                    "Successfully written allocation state metadata file {} for job {} and allocation {}.",
-                    slotAllocationSnapshotFile.toPath(),
-                    jobId,
-                    allocationId);
-        } catch (IOException e) {
-            log.debug(
-                    "Cannot write the local allocations state. File {} for job {} and allocation {}.",
-                    slotAllocationSnapshotFile.toPath(),
-                    jobId,
-                    allocationId,
-                    e);
-        }
-    }
-
-    private void tryCleanupSlotAllocationSnapshot(int requestedIndex) {
-        if (!allocationsDirectory.exists()) {
-            log.debug(
-                    "There is no local allocations snapshot directory to cleanup {}.",
-                    allocationsDirectory.toPath());
-            return;
-        }
-
-        // Let's try to write the slot allocations on file
-        final File slotAllocationSnapshotFile = slotAllocationFile(requestedIndex);
+    private void tryPersistAllocationSnapshot(SlotAllocationSnapshot slotAllocationSnapshot) {
         try {
-            FileUtils.deleteFileOrDirectory(slotAllocationSnapshotFile);
-            log.debug(
-                    "Successfully deleted allocation state metadata file {}.",
-                    slotAllocationSnapshotFile.toPath());
+            slotAllocationSnapshotPersistenceService.persistAllocationSnapshot(
+                    slotAllocationSnapshot);
         } catch (IOException e) {
-            log.debug(
-                    "Cannot delete the local allocations state file {}.",
-                    slotAllocationSnapshotFile.toPath(),
-                    e);
+            log.debug("Cannot persist the slot allocation snapshot {}.", slotAllocationSnapshot, e);
         }
-    }
-
-    private File slotAllocationFile(int slotIndex) {
-        return new File(allocationsDirectory.getAbsolutePath(), slotIndex + ".bin");
     }
 
     /**
@@ -2098,52 +2044,27 @@ public class TaskExecutor extends RpcEndpoint implements TaskExecutorGateway {
      * filesystem in a best-effort manner.
      */
     private void tryLoadLocalAllocationSnapshots() {
-        if (!allocationsDirectory.exists()) {
-            log.debug(
-                    "There is no local allocations snapshot directory to load from {}.",
-                    allocationsDirectory.toPath());
-            return;
-        }
+        Collection<SlotAllocationSnapshot> slotAllocationSnapshots =
+                slotAllocationSnapshotPersistenceService.loadAllocationSnapshots();
 
-        // Let's try to populate the slot allocation from local file
-        final File[] slotAllocationFiles = allocationsDirectory.listFiles();
-        if (slotAllocationFiles == null) {
-            log.debug("No allocation files to load.");
-            return;
-        }
+        log.debug("Recovered slot allocation snapshots {}.", slotAllocationSnapshots);
 
-        List<LocalSlotAllocationSnapshot> allocations = new ArrayList<>(slotAllocationFiles.length);
-
-        for (File allocationFile : slotAllocationFiles) {
-            try (ObjectInputStream ois =
-                    new ObjectInputStream(new FileInputStream(allocationFile))) {
-                allocations.add((LocalSlotAllocationSnapshot) ois.readObject());
-            } catch (IOException | ClassNotFoundException e) {
-                log.debug(
-                        "Cannot read the local allocations state file {}.",
-                        allocationFile.toPath(),
-                        e);
-            }
-        }
-
-        log.debug("Resolved allocation files {}.", allocations);
-
-        for (LocalSlotAllocationSnapshot allocationSnapshot : allocations) {
+        for (SlotAllocationSnapshot slotAllocationSnapshot : slotAllocationSnapshots) {
             try {
                 allocateSlot(
-                        allocationSnapshot.getSlotID(),
-                        allocationSnapshot.getJobId(),
-                        allocationSnapshot.getAllocationId(),
-                        allocationSnapshot.getResourceProfile());
+                        slotAllocationSnapshot.getSlotID(),
+                        slotAllocationSnapshot.getJobId(),
+                        slotAllocationSnapshot.getAllocationId(),
+                        slotAllocationSnapshot.getResourceProfile());
 
                 jobTable.getOrCreateJob(
-                        allocationSnapshot.getJobId(),
+                        slotAllocationSnapshot.getJobId(),
                         () ->
                                 registerNewJobAndCreateServices(
-                                        allocationSnapshot.getJobId(),
-                                        allocationSnapshot.getJobTargetAddress()));
+                                        slotAllocationSnapshot.getJobId(),
+                                        slotAllocationSnapshot.getJobTargetAddress()));
             } catch (Exception e) {
-                log.debug("Cannot reallocate restored slot {}.", allocationSnapshot, e);
+                log.debug("Cannot reallocate restored slot {}.", slotAllocationSnapshot, e);
             }
         }
     }

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/taskexecutor/TaskExecutor.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/taskexecutor/TaskExecutor.java
@@ -2049,6 +2049,7 @@ public class TaskExecutor extends RpcEndpoint implements TaskExecutorGateway {
 
         log.debug("Recovered slot allocation snapshots {}.", slotAllocationSnapshots);
 
+        final Set<AllocationID> allocatedSlots = new HashSet<>();
         for (SlotAllocationSnapshot slotAllocationSnapshot : slotAllocationSnapshots) {
             try {
                 allocateSlot(
@@ -2066,7 +2067,11 @@ public class TaskExecutor extends RpcEndpoint implements TaskExecutorGateway {
             } catch (Exception e) {
                 log.debug("Cannot reallocate restored slot {}.", slotAllocationSnapshot, e);
             }
+
+            allocatedSlots.add(slotAllocationSnapshot.getAllocationId());
         }
+
+        localStateStoresManager.retainLocalStateForAllocations(allocatedSlots);
     }
 
     // ------------------------------------------------------------------------

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/taskexecutor/TaskManagerRunner.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/taskexecutor/TaskManagerRunner.java
@@ -622,7 +622,8 @@ public class TaskManagerRunner implements FatalErrorHandler {
                         taskExecutorBlobService.getPermanentBlobService(),
                         taskManagerMetricGroup.f1,
                         ioExecutor,
-                        fatalErrorHandler);
+                        fatalErrorHandler,
+                        workingDirectory);
 
         MetricUtils.instantiateFlinkMemoryMetricGroup(
                 taskManagerMetricGroup.f1,

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/taskexecutor/TaskManagerServices.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/taskexecutor/TaskManagerServices.java
@@ -323,9 +323,6 @@ public class TaskManagerServices {
                         unresolvedTaskManagerLocation,
                         taskManagerServicesConfiguration.getRetryingRegistrationConfiguration());
 
-        final File[] stateRootDirectoryStrings =
-                taskManagerServicesConfiguration.getLocalRecoveryStateDirectories();
-
         final TaskExecutorLocalStateStoresManager taskStateManager =
                 new TaskExecutorLocalStateStoresManager(
                         taskManagerServicesConfiguration.isLocalRecoveryEnabled(),

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/taskexecutor/TaskManagerServices.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/taskexecutor/TaskManagerServices.java
@@ -18,7 +18,6 @@
 
 package org.apache.flink.runtime.taskexecutor;
 
-import org.apache.flink.annotation.VisibleForTesting;
 import org.apache.flink.configuration.CoreOptions;
 import org.apache.flink.metrics.MetricGroup;
 import org.apache.flink.runtime.blob.PermanentBlobService;
@@ -66,8 +65,6 @@ import java.util.concurrent.ScheduledThreadPoolExecutor;
  */
 public class TaskManagerServices {
     private static final Logger LOG = LoggerFactory.getLogger(TaskManagerServices.class);
-
-    @VisibleForTesting public static final String LOCAL_STATE_SUB_DIRECTORY_ROOT = "localState";
 
     /** TaskManager services. */
     private final UnresolvedTaskManagerLocation unresolvedTaskManagerLocation;
@@ -326,20 +323,13 @@ public class TaskManagerServices {
                         unresolvedTaskManagerLocation,
                         taskManagerServicesConfiguration.getRetryingRegistrationConfiguration());
 
-        final String[] stateRootDirectoryStrings =
-                taskManagerServicesConfiguration.getLocalRecoveryStateRootDirectories();
-
-        final File[] stateRootDirectoryFiles = new File[stateRootDirectoryStrings.length];
-
-        for (int i = 0; i < stateRootDirectoryStrings.length; ++i) {
-            stateRootDirectoryFiles[i] =
-                    new File(stateRootDirectoryStrings[i], LOCAL_STATE_SUB_DIRECTORY_ROOT);
-        }
+        final File[] stateRootDirectoryStrings =
+                taskManagerServicesConfiguration.getLocalRecoveryStateDirectories();
 
         final TaskExecutorLocalStateStoresManager taskStateManager =
                 new TaskExecutorLocalStateStoresManager(
                         taskManagerServicesConfiguration.isLocalRecoveryEnabled(),
-                        stateRootDirectoryFiles,
+                        taskManagerServicesConfiguration.getLocalRecoveryStateDirectories(),
                         ioExecutor);
 
         final TaskExecutorStateChangelogStoragesManager changelogStoragesManager =

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/taskexecutor/TaskManagerServicesConfiguration.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/taskexecutor/TaskManagerServicesConfiguration.java
@@ -50,6 +50,8 @@ import static org.apache.flink.util.Preconditions.checkNotNull;
  */
 public class TaskManagerServicesConfiguration {
 
+    private static final String LOCAL_STATE_SUB_DIRECTORY_ROOT = "localState_";
+
     private final Configuration configuration;
 
     private final ResourceID resourceID;
@@ -64,7 +66,7 @@ public class TaskManagerServicesConfiguration {
 
     private final String[] tmpDirPaths;
 
-    private final String[] localRecoveryStateRootDirectories;
+    private final File[] localRecoveryStateDirectories;
 
     private final int numberOfSlots;
 
@@ -96,7 +98,7 @@ public class TaskManagerServicesConfiguration {
             int externalDataPort,
             boolean localCommunicationOnly,
             String[] tmpDirPaths,
-            String[] localRecoveryStateRootDirectories,
+            File[] localRecoveryStateDirectories,
             boolean localRecoveryEnabled,
             @Nullable QueryableStateConfiguration queryableStateConfig,
             int numberOfSlots,
@@ -116,7 +118,7 @@ public class TaskManagerServicesConfiguration {
         this.externalDataPort = externalDataPort;
         this.localCommunicationOnly = localCommunicationOnly;
         this.tmpDirPaths = checkNotNull(tmpDirPaths);
-        this.localRecoveryStateRootDirectories = checkNotNull(localRecoveryStateRootDirectories);
+        this.localRecoveryStateDirectories = checkNotNull(localRecoveryStateDirectories);
         this.localRecoveryEnabled = checkNotNull(localRecoveryEnabled);
         this.queryableStateConfig = queryableStateConfig;
         this.numberOfSlots = checkNotNull(numberOfSlots);
@@ -170,8 +172,8 @@ public class TaskManagerServicesConfiguration {
         return tmpDirPaths;
     }
 
-    String[] getLocalRecoveryStateRootDirectories() {
-        return localRecoveryStateRootDirectories;
+    File[] getLocalRecoveryStateDirectories() {
+        return localRecoveryStateDirectories;
     }
 
     boolean isLocalRecoveryEnabled() {
@@ -253,12 +255,18 @@ public class TaskManagerServicesConfiguration {
             TaskExecutorResourceSpec taskExecutorResourceSpec,
             WorkingDirectory workingDirectory)
             throws Exception {
-        String[] localStateRootDir = ConfigurationUtils.parseLocalStateDirectories(configuration);
+        String[] localStateRootDirs = ConfigurationUtils.parseLocalStateDirectories(configuration);
+        final File[] localStateDirs;
 
-        if (localStateRootDir.length == 0) {
-            final File localStateDir = workingDirectory.getLocalStateDirectory();
+        if (localStateRootDirs.length == 0) {
+            localStateDirs = new File[] {workingDirectory.getLocalStateDirectory()};
+        } else {
+            localStateDirs = new File[localStateRootDirs.length];
+            final String localStateDirectoryName = LOCAL_STATE_SUB_DIRECTORY_ROOT + resourceID;
 
-            localStateRootDir = new String[] {localStateDir.getAbsolutePath()};
+            for (int i = 0; i < localStateRootDirs.length; i++) {
+                localStateDirs[i] = new File(localStateRootDirs[i], localStateDirectoryName);
+            }
         }
 
         boolean localRecoveryMode = configuration.getBoolean(CheckpointingOptions.LOCAL_RECOVERY);
@@ -298,7 +306,7 @@ public class TaskManagerServicesConfiguration {
                 externalDataPort,
                 localCommunicationOnly,
                 tmpDirs,
-                localStateRootDir,
+                localStateDirs,
                 localRecoveryMode,
                 queryableStateConfig,
                 ConfigurationParserUtils.getSlot(configuration),

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/taskexecutor/slot/FileSlotAllocationSnapshotPersistenceService.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/taskexecutor/slot/FileSlotAllocationSnapshotPersistenceService.java
@@ -1,0 +1,136 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.flink.runtime.taskexecutor.slot;
+
+import org.apache.flink.util.FileUtils;
+
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import java.io.File;
+import java.io.FileInputStream;
+import java.io.FileOutputStream;
+import java.io.IOException;
+import java.io.ObjectInputStream;
+import java.io.ObjectOutputStream;
+import java.util.ArrayList;
+import java.util.Collection;
+import java.util.Collections;
+
+/**
+ * File based {@link SlotAllocationSnapshotPersistenceService} that persists the {@link
+ * SlotAllocationSnapshot} as local files.
+ */
+public class FileSlotAllocationSnapshotPersistenceService
+        implements SlotAllocationSnapshotPersistenceService {
+    private static final Logger LOG =
+            LoggerFactory.getLogger(FileSlotAllocationSnapshotPersistenceService.class);
+
+    private static final String SUFFIX = ".bin";
+    private final File slotAllocationSnapshotDirectory;
+
+    public FileSlotAllocationSnapshotPersistenceService(File slotAllocationSnapshotDirectory) {
+        this.slotAllocationSnapshotDirectory = slotAllocationSnapshotDirectory;
+
+        if (!slotAllocationSnapshotDirectory.exists()
+                && !slotAllocationSnapshotDirectory.mkdirs()) {
+            throw new IllegalStateException(
+                    String.format(
+                            "Cannot create the slot allocation snapshot directory %s.",
+                            slotAllocationSnapshotDirectory));
+        }
+    }
+
+    @Override
+    public void persistAllocationSnapshot(SlotAllocationSnapshot slotAllocationSnapshot)
+            throws IOException {
+        // Let's try to write the slot allocations on file
+        final File slotAllocationSnapshotFile =
+                slotAllocationFile(slotAllocationSnapshot.getSlotID().getSlotNumber());
+
+        try (ObjectOutputStream oos =
+                new ObjectOutputStream(new FileOutputStream(slotAllocationSnapshotFile))) {
+            oos.writeObject(slotAllocationSnapshot);
+
+            LOG.debug(
+                    "Successfully written allocation state metadata file {} for job {} and allocation {}.",
+                    slotAllocationSnapshotFile.toPath(),
+                    slotAllocationSnapshot.getJobId(),
+                    slotAllocationSnapshot.getAllocationId());
+        }
+    }
+
+    private File slotAllocationFile(int slotIndex) {
+        return new File(
+                slotAllocationSnapshotDirectory.getAbsolutePath(), slotIndexToFilename(slotIndex));
+    }
+
+    private static String slotIndexToFilename(int slotIndex) {
+        return slotIndex + SUFFIX;
+    }
+
+    private static int filenameToSlotIndex(String filename) {
+        return Integer.parseInt(filename.substring(0, filename.length() - SUFFIX.length()));
+    }
+
+    @Override
+    public void deleteAllocationSnapshot(int slotIndex) {
+        // Let's try to write the slot allocations on file
+        final File slotAllocationSnapshotFile = slotAllocationFile(slotIndex);
+        try {
+            FileUtils.deleteFileOrDirectory(slotAllocationSnapshotFile);
+            LOG.debug(
+                    "Successfully deleted allocation state metadata file {}.",
+                    slotAllocationSnapshotFile.toPath());
+        } catch (IOException ioe) {
+            LOG.warn(
+                    "Cannot delete the local allocations state file {}.",
+                    slotAllocationSnapshotFile.toPath(),
+                    ioe);
+        }
+    }
+
+    @Override
+    public Collection<SlotAllocationSnapshot> loadAllocationSnapshots() {
+        // Let's try to populate the slot allocation from local file
+        final File[] slotAllocationFiles = slotAllocationSnapshotDirectory.listFiles();
+        if (slotAllocationFiles == null) {
+            LOG.debug("No allocation files to load.");
+            return Collections.emptyList();
+        }
+
+        Collection<SlotAllocationSnapshot> slotAllocationSnapshots =
+                new ArrayList<>(slotAllocationFiles.length);
+
+        for (File allocationFile : slotAllocationFiles) {
+            try (ObjectInputStream ois =
+                    new ObjectInputStream(new FileInputStream(allocationFile))) {
+                slotAllocationSnapshots.add((SlotAllocationSnapshot) ois.readObject());
+            } catch (IOException | ClassNotFoundException e) {
+                LOG.debug(
+                        "Cannot read the local allocations state file {}. Deleting it now.",
+                        allocationFile.toPath(),
+                        e);
+                deleteAllocationSnapshot(filenameToSlotIndex(allocationFile.getName()));
+            }
+        }
+
+        return slotAllocationSnapshots;
+    }
+}

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/taskexecutor/slot/LocalSlotAllocationSnapshot.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/taskexecutor/slot/LocalSlotAllocationSnapshot.java
@@ -1,0 +1,86 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.flink.runtime.taskexecutor.slot;
+
+import org.apache.flink.api.common.JobID;
+import org.apache.flink.runtime.clusterframework.types.AllocationID;
+import org.apache.flink.runtime.clusterframework.types.ResourceProfile;
+import org.apache.flink.runtime.clusterframework.types.SlotID;
+
+/** Model to save local slot allocation info. */
+public class LocalSlotAllocationSnapshot implements java.io.Serializable {
+
+    private static final long serialVersionUID = 1L;
+
+    private final SlotID slotID;
+    private final JobID jobId;
+    private final String jobTargetAddress;
+    private final AllocationID allocationId;
+    private final ResourceProfile resourceProfile;
+
+    public LocalSlotAllocationSnapshot(
+            SlotID slotID,
+            JobID jobId,
+            String jobTargetAddress,
+            AllocationID allocationId,
+            ResourceProfile resourceProfile) {
+        this.slotID = slotID;
+        this.jobId = jobId;
+        this.jobTargetAddress = jobTargetAddress;
+        this.allocationId = allocationId;
+        this.resourceProfile = resourceProfile;
+    }
+
+    public SlotID getSlotID() {
+        return slotID;
+    }
+
+    public JobID getJobId() {
+        return jobId;
+    }
+
+    public String getJobTargetAddress() {
+        return jobTargetAddress;
+    }
+
+    public AllocationID getAllocationId() {
+        return allocationId;
+    }
+
+    public ResourceProfile getResourceProfile() {
+        return resourceProfile;
+    }
+
+    @Override
+    public String toString() {
+        return "LocalSlotAllocationSnapshot{"
+                + "slotID="
+                + slotID
+                + ", jobId="
+                + jobId
+                + ", jobTargetAddress='"
+                + jobTargetAddress
+                + '\''
+                + ", allocationId="
+                + allocationId
+                + ", resourceProfile="
+                + resourceProfile
+                + '}';
+    }
+}

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/taskexecutor/slot/NoOpSlotAllocationSnapshotPersistenceService.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/taskexecutor/slot/NoOpSlotAllocationSnapshotPersistenceService.java
@@ -1,0 +1,41 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.flink.runtime.taskexecutor.slot;
+
+import java.io.IOException;
+import java.util.Collection;
+import java.util.Collections;
+
+/** {@link SlotAllocationSnapshotPersistenceService} that does nothing. */
+public enum NoOpSlotAllocationSnapshotPersistenceService
+        implements SlotAllocationSnapshotPersistenceService {
+    INSTANCE;
+
+    @Override
+    public void persistAllocationSnapshot(SlotAllocationSnapshot slotAllocationSnapshot)
+            throws IOException {}
+
+    @Override
+    public void deleteAllocationSnapshot(int slotIndex) {}
+
+    @Override
+    public Collection<SlotAllocationSnapshot> loadAllocationSnapshots() {
+        return Collections.emptyList();
+    }
+}

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/taskexecutor/slot/SlotAllocationSnapshot.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/taskexecutor/slot/SlotAllocationSnapshot.java
@@ -23,8 +23,10 @@ import org.apache.flink.runtime.clusterframework.types.AllocationID;
 import org.apache.flink.runtime.clusterframework.types.ResourceProfile;
 import org.apache.flink.runtime.clusterframework.types.SlotID;
 
+import java.util.Objects;
+
 /** Model to save local slot allocation info. */
-public class LocalSlotAllocationSnapshot implements java.io.Serializable {
+public class SlotAllocationSnapshot implements java.io.Serializable {
 
     private static final long serialVersionUID = 1L;
 
@@ -34,7 +36,7 @@ public class LocalSlotAllocationSnapshot implements java.io.Serializable {
     private final AllocationID allocationId;
     private final ResourceProfile resourceProfile;
 
-    public LocalSlotAllocationSnapshot(
+    public SlotAllocationSnapshot(
             SlotID slotID,
             JobID jobId,
             String jobTargetAddress,
@@ -67,9 +69,13 @@ public class LocalSlotAllocationSnapshot implements java.io.Serializable {
         return resourceProfile;
     }
 
+    public int getSlotIndex() {
+        return slotID.getSlotNumber();
+    }
+
     @Override
     public String toString() {
-        return "LocalSlotAllocationSnapshot{"
+        return "SlotAllocationSnapshot{"
                 + "slotID="
                 + slotID
                 + ", jobId="
@@ -82,5 +88,26 @@ public class LocalSlotAllocationSnapshot implements java.io.Serializable {
                 + ", resourceProfile="
                 + resourceProfile
                 + '}';
+    }
+
+    @Override
+    public boolean equals(Object o) {
+        if (this == o) {
+            return true;
+        }
+        if (o == null || getClass() != o.getClass()) {
+            return false;
+        }
+        SlotAllocationSnapshot that = (SlotAllocationSnapshot) o;
+        return slotID.equals(that.slotID)
+                && jobId.equals(that.jobId)
+                && jobTargetAddress.equals(that.jobTargetAddress)
+                && allocationId.equals(that.allocationId)
+                && resourceProfile.equals(that.resourceProfile);
+    }
+
+    @Override
+    public int hashCode() {
+        return Objects.hash(slotID, jobId, jobTargetAddress, allocationId, resourceProfile);
     }
 }

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/taskexecutor/slot/SlotAllocationSnapshotPersistenceService.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/taskexecutor/slot/SlotAllocationSnapshotPersistenceService.java
@@ -1,0 +1,49 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.flink.runtime.taskexecutor.slot;
+
+import java.io.IOException;
+import java.util.Collection;
+
+/** Service for persisting {@link SlotAllocationSnapshot}. */
+public interface SlotAllocationSnapshotPersistenceService {
+
+    /**
+     * Persist the given slot allocation snapshot.
+     *
+     * @param slotAllocationSnapshot slot allocation snapshot to persist
+     * @throws IOException if the slot allocation snapshot cannot be persisted
+     */
+    void persistAllocationSnapshot(SlotAllocationSnapshot slotAllocationSnapshot)
+            throws IOException;
+
+    /**
+     * Delete the slot allocation snapshot identified by the slot index.
+     *
+     * @param slotIndex identifying the slot allocation snapshot to delete
+     */
+    void deleteAllocationSnapshot(int slotIndex);
+
+    /**
+     * Load all persisted slot allocation snapshots.
+     *
+     * @return loaded slot allocations snapshots
+     */
+    Collection<SlotAllocationSnapshot> loadAllocationSnapshots();
+}

--- a/flink-runtime/src/test/java/org/apache/flink/runtime/entrypoint/component/DispatcherResourceManagerComponentTest.java
+++ b/flink-runtime/src/test/java/org/apache/flink/runtime/entrypoint/component/DispatcherResourceManagerComponentTest.java
@@ -23,6 +23,7 @@ import org.apache.flink.runtime.dispatcher.DispatcherOperationCaches;
 import org.apache.flink.runtime.dispatcher.runner.TestingDispatcherRunner;
 import org.apache.flink.runtime.leaderretrieval.SettableLeaderRetrievalService;
 import org.apache.flink.runtime.resourcemanager.ResourceManagerService;
+import org.apache.flink.runtime.rest.ClosedRestService;
 import org.apache.flink.runtime.util.TestingFatalErrorHandler;
 import org.apache.flink.util.FlinkException;
 import org.apache.flink.util.TestLogger;
@@ -69,7 +70,7 @@ public class DispatcherResourceManagerComponentTest extends TestLogger {
                 resourceManagerService,
                 new SettableLeaderRetrievalService(),
                 new SettableLeaderRetrievalService(),
-                FutureUtils::completedVoidFuture,
+                ClosedRestService.INSTANCE,
                 fatalErrorHandler,
                 new DispatcherOperationCaches());
     }

--- a/flink-runtime/src/test/java/org/apache/flink/runtime/rest/ClosedRestService.java
+++ b/flink-runtime/src/test/java/org/apache/flink/runtime/rest/ClosedRestService.java
@@ -1,0 +1,38 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.flink.runtime.rest;
+
+import org.apache.flink.util.concurrent.FutureUtils;
+
+import java.util.concurrent.CompletableFuture;
+
+/** Closed {@link RestService} implementation for testing purposes. */
+public enum ClosedRestService implements RestService {
+    INSTANCE;
+
+    @Override
+    public CompletableFuture<Void> closeAsync() {
+        return FutureUtils.completedVoidFuture();
+    }
+
+    @Override
+    public int getRestPort() {
+        return -1;
+    }
+}

--- a/flink-runtime/src/test/java/org/apache/flink/runtime/rpc/TestingRpcServiceExtension.java
+++ b/flink-runtime/src/test/java/org/apache/flink/runtime/rpc/TestingRpcServiceExtension.java
@@ -1,0 +1,65 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.flink.runtime.rpc;
+
+import org.apache.flink.core.testutils.CustomExtension;
+import org.apache.flink.util.Preconditions;
+
+import org.junit.jupiter.api.extension.ExtensionContext;
+
+import javax.annotation.Nullable;
+
+import java.util.concurrent.CompletableFuture;
+
+/** Custom extension that starts a {@link TestingRpcService}. */
+public class TestingRpcServiceExtension implements CustomExtension {
+
+    @Nullable private TestingRpcService testingRpcService;
+
+    public TestingRpcServiceExtension() {
+        this.testingRpcService = null;
+    }
+
+    public TestingRpcService getTestingRpcService() {
+        Preconditions.checkNotNull(testingRpcService);
+        return testingRpcService;
+    }
+
+    @Override
+    public void before(ExtensionContext extensionContext) {
+        if (testingRpcService != null) {
+            terminateRpcService(testingRpcService);
+        }
+
+        testingRpcService = new TestingRpcService();
+    }
+
+    @Override
+    public void after(ExtensionContext extensionContext) {
+        if (testingRpcService != null) {
+            terminateRpcService(testingRpcService);
+            testingRpcService = null;
+        }
+    }
+
+    private void terminateRpcService(TestingRpcService testingRpcService) {
+        CompletableFuture<Void> terminationFuture = testingRpcService.stopService();
+        terminationFuture.join();
+    }
+}

--- a/flink-runtime/src/test/java/org/apache/flink/runtime/state/TaskExecutorLocalStateStoresManagerTest.java
+++ b/flink-runtime/src/test/java/org/apache/flink/runtime/state/TaskExecutorLocalStateStoresManagerTest.java
@@ -74,10 +74,12 @@ public class TaskExecutorLocalStateStoresManagerTest extends TestLogger {
         // test configuration of the local state mode
         config.setBoolean(CheckpointingOptions.LOCAL_RECOVERY, true);
 
+        final WorkingDirectory workingDirectory =
+                WORKING_DIRECTORY_RESOURCE.createNewWorkingDirectory();
         TaskManagerServices taskManagerServices =
                 createTaskManagerServices(
-                        createTaskManagerServiceConfiguration(
-                                config, WORKING_DIRECTORY_RESOURCE.createNewWorkingDirectory()));
+                        createTaskManagerServiceConfiguration(config, workingDirectory),
+                        workingDirectory);
 
         try {
             TaskExecutorLocalStateStoresManager taskStateManager =
@@ -119,7 +121,7 @@ public class TaskExecutorLocalStateStoresManagerTest extends TestLogger {
                 createTaskManagerServiceConfiguration(config, workingDirectory);
 
         TaskManagerServices taskManagerServices =
-                createTaskManagerServices(taskManagerServicesConfiguration);
+                createTaskManagerServices(taskManagerServicesConfiguration, workingDirectory);
 
         try {
             TaskExecutorLocalStateStoresManager taskStateManager =
@@ -288,13 +290,15 @@ public class TaskExecutorLocalStateStoresManagerTest extends TestLogger {
                 workingDirectory);
     }
 
-    private TaskManagerServices createTaskManagerServices(TaskManagerServicesConfiguration config)
+    private TaskManagerServices createTaskManagerServices(
+            TaskManagerServicesConfiguration config, WorkingDirectory workingDirectory)
             throws Exception {
         return TaskManagerServices.fromConfiguration(
                 config,
                 VoidPermanentBlobService.INSTANCE,
                 UnregisteredMetricGroups.createUnregisteredTaskManagerMetricGroup(),
                 Executors.newDirectExecutorService(),
-                throwable -> {});
+                throwable -> {},
+                workingDirectory);
     }
 }

--- a/flink-runtime/src/test/java/org/apache/flink/runtime/state/TaskExecutorLocalStateStoresManagerTest.java
+++ b/flink-runtime/src/test/java/org/apache/flink/runtime/state/TaskExecutorLocalStateStoresManagerTest.java
@@ -42,6 +42,9 @@ import org.junit.rules.TemporaryFolder;
 
 import java.io.File;
 import java.net.InetAddress;
+import java.nio.file.Paths;
+
+import static org.assertj.core.api.Assertions.assertThat;
 
 /** Test for {@link TaskExecutorLocalStateStoresManager}. */
 public class TaskExecutorLocalStateStoresManagerTest extends TestLogger {
@@ -89,15 +92,12 @@ public class TaskExecutorLocalStateStoresManagerTest extends TestLogger {
             String[] split = rootDirString.split(",");
             File[] rootDirectories = taskStateManager.getLocalStateRootDirectories();
             for (int i = 0; i < split.length; ++i) {
-                Assert.assertEquals(
-                        new File(split[i], TaskManagerServices.LOCAL_STATE_SUB_DIRECTORY_ROOT),
-                        rootDirectories[i]);
+                assertThat(rootDirectories[i].toPath()).startsWith(Paths.get(split[i]));
             }
 
             // verify local recovery mode
             Assert.assertTrue(taskStateManager.isLocalRecoveryEnabled());
 
-            Assert.assertEquals("localState", TaskManagerServices.LOCAL_STATE_SUB_DIRECTORY_ROOT);
             for (File rootDirectory : rootDirectories) {
                 FileUtils.deleteFileOrDirectory(rootDirectory);
             }
@@ -131,10 +131,7 @@ public class TaskExecutorLocalStateStoresManagerTest extends TestLogger {
 
             for (int i = 0; i < localStateRootDirectories.length; ++i) {
                 Assert.assertEquals(
-                        new File(
-                                workingDirectory.getLocalStateDirectory(),
-                                TaskManagerServices.LOCAL_STATE_SUB_DIRECTORY_ROOT),
-                        localStateRootDirectories[i]);
+                        workingDirectory.getLocalStateDirectory(), localStateRootDirectories[i]);
             }
 
             Assert.assertFalse(taskStateManager.isLocalRecoveryEnabled());

--- a/flink-runtime/src/test/java/org/apache/flink/runtime/taskexecutor/TaskExecutorBuilder.java
+++ b/flink-runtime/src/test/java/org/apache/flink/runtime/taskexecutor/TaskExecutorBuilder.java
@@ -1,0 +1,176 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.flink.runtime.taskexecutor;
+
+import org.apache.flink.api.common.resources.CPUResource;
+import org.apache.flink.configuration.Configuration;
+import org.apache.flink.configuration.MemorySize;
+import org.apache.flink.runtime.blob.BlobCacheService;
+import org.apache.flink.runtime.blob.NoOpTaskExecutorBlobService;
+import org.apache.flink.runtime.blob.TaskExecutorBlobService;
+import org.apache.flink.runtime.blob.VoidPermanentBlobService;
+import org.apache.flink.runtime.clusterframework.types.ResourceID;
+import org.apache.flink.runtime.entrypoint.WorkingDirectory;
+import org.apache.flink.runtime.externalresource.ExternalResourceInfoProvider;
+import org.apache.flink.runtime.heartbeat.HeartbeatServices;
+import org.apache.flink.runtime.highavailability.HighAvailabilityServices;
+import org.apache.flink.runtime.io.network.partition.TaskExecutorPartitionTracker;
+import org.apache.flink.runtime.io.network.partition.TestingTaskExecutorPartitionTracker;
+import org.apache.flink.runtime.metrics.groups.TaskManagerMetricGroup;
+import org.apache.flink.runtime.metrics.groups.UnregisteredMetricGroups;
+import org.apache.flink.runtime.rest.util.NoOpFatalErrorHandler;
+import org.apache.flink.runtime.rpc.FatalErrorHandler;
+import org.apache.flink.runtime.rpc.RpcService;
+import org.apache.flink.util.concurrent.Executors;
+
+import javax.annotation.Nullable;
+
+import java.util.Collections;
+
+/** Builder for testing {@link TaskExecutor}. */
+public class TaskExecutorBuilder {
+
+    private final RpcService rpcService;
+
+    private final HighAvailabilityServices haServices;
+
+    private ResourceID resourceId = ResourceID.generate();
+
+    private Configuration configuration = new Configuration();
+
+    @Nullable private TaskManagerConfiguration taskManagerConfiguration = null;
+
+    @Nullable private TaskManagerServices taskManagerServices = null;
+
+    private ExternalResourceInfoProvider externalResourceInfoProvider =
+            ExternalResourceInfoProvider.NO_EXTERNAL_RESOURCES;
+
+    private HeartbeatServices heartbeatServices = new HeartbeatServices(1 << 20, 1 << 20);
+
+    private TaskManagerMetricGroup taskManagerMetricGroup =
+            UnregisteredMetricGroups.createUnregisteredTaskManagerMetricGroup();
+
+    @Nullable private String metricQueryServiceAddress = null;
+
+    @Nullable private BlobCacheService taskExecutorBlobService = null;
+
+    private FatalErrorHandler fatalErrorHandler = NoOpFatalErrorHandler.INSTANCE;
+
+    private TaskExecutorPartitionTracker partitionTracker =
+            new TestingTaskExecutorPartitionTracker();
+
+    private TaskExecutorResourceSpec taskExecutorResourceSpec =
+            new TaskExecutorResourceSpec(
+                    new CPUResource(1.0),
+                    MemorySize.ofMebiBytes(1024),
+                    MemorySize.ofMebiBytes(1024),
+                    MemorySize.ofMebiBytes(1024),
+                    MemorySize.ofMebiBytes(1024),
+                    Collections.emptyList());
+
+    private final WorkingDirectory workingDirectory;
+
+    private TaskExecutorBuilder(
+            RpcService rpcService,
+            HighAvailabilityServices haServices,
+            WorkingDirectory workingDirectory) {
+        this.rpcService = rpcService;
+        this.haServices = haServices;
+        this.workingDirectory = workingDirectory;
+    }
+
+    public TaskExecutorBuilder setConfiguration(Configuration configuration) {
+        this.configuration = configuration;
+        return this;
+    }
+
+    public TaskExecutorBuilder setResourceId(ResourceID resourceId) {
+        this.resourceId = resourceId;
+        return this;
+    }
+
+    public TaskExecutor build() throws Exception {
+
+        final TaskExecutorBlobService resolvedTaskExecutorBlobService;
+
+        TaskExecutorResourceUtils.adjustForLocalExecution(configuration);
+
+        if (taskExecutorBlobService == null) {
+            resolvedTaskExecutorBlobService = NoOpTaskExecutorBlobService.INSTANCE;
+        } else {
+            resolvedTaskExecutorBlobService = taskExecutorBlobService;
+        }
+
+        final TaskManagerConfiguration resolvedTaskManagerConfiguration;
+
+        if (taskManagerConfiguration == null) {
+            resolvedTaskManagerConfiguration =
+                    TaskManagerConfiguration.fromConfiguration(
+                            configuration,
+                            taskExecutorResourceSpec,
+                            rpcService.getAddress(),
+                            workingDirectory.getTmpDirectory());
+        } else {
+            resolvedTaskManagerConfiguration = taskManagerConfiguration;
+        }
+
+        final TaskManagerServices resolvedTaskManagerServices;
+
+        if (taskManagerServices == null) {
+            final TaskManagerServicesConfiguration taskManagerServicesConfiguration =
+                    TaskManagerServicesConfiguration.fromConfiguration(
+                            configuration,
+                            resourceId,
+                            rpcService.getAddress(),
+                            true,
+                            taskExecutorResourceSpec,
+                            workingDirectory);
+            resolvedTaskManagerServices =
+                    TaskManagerServices.fromConfiguration(
+                            taskManagerServicesConfiguration,
+                            VoidPermanentBlobService.INSTANCE,
+                            UnregisteredMetricGroups.createUnregisteredTaskManagerMetricGroup(),
+                            Executors.newDirectExecutorService(),
+                            throwable -> {},
+                            workingDirectory);
+        } else {
+            resolvedTaskManagerServices = taskManagerServices;
+        }
+
+        return new TaskExecutor(
+                rpcService,
+                resolvedTaskManagerConfiguration,
+                haServices,
+                resolvedTaskManagerServices,
+                externalResourceInfoProvider,
+                heartbeatServices,
+                taskManagerMetricGroup,
+                metricQueryServiceAddress,
+                resolvedTaskExecutorBlobService,
+                fatalErrorHandler,
+                partitionTracker);
+    }
+
+    public static TaskExecutorBuilder newBuilder(
+            RpcService rpcService,
+            HighAvailabilityServices highAvailabilityServices,
+            WorkingDirectory workingDirectory) {
+        return new TaskExecutorBuilder(rpcService, highAvailabilityServices, workingDirectory);
+    }
+}

--- a/flink-runtime/src/test/java/org/apache/flink/runtime/taskexecutor/TaskExecutorPartitionLifecycleTest.java
+++ b/flink-runtime/src/test/java/org/apache/flink/runtime/taskexecutor/TaskExecutorPartitionLifecycleTest.java
@@ -67,6 +67,7 @@ import org.apache.flink.runtime.taskmanager.Task;
 import org.apache.flink.runtime.util.TestingFatalErrorHandler;
 import org.apache.flink.testutils.TestFileUtils;
 import org.apache.flink.testutils.executor.TestExecutorResource;
+import org.apache.flink.util.Reference;
 import org.apache.flink.util.SerializedValue;
 import org.apache.flink.util.TestLogger;
 import org.apache.flink.util.concurrent.Executors;
@@ -434,7 +435,9 @@ public class TaskExecutorPartitionLifecycleTest extends TestLogger {
 
         final TaskExecutorLocalStateStoresManager localStateStoresManager =
                 new TaskExecutorLocalStateStoresManager(
-                        false, new File[] {tmp.newFolder()}, Executors.directExecutor());
+                        false,
+                        Reference.owned(new File[] {tmp.newFolder()}),
+                        Executors.directExecutor());
 
         final TaskManagerServices taskManagerServices =
                 new TaskManagerServicesBuilder()

--- a/flink-runtime/src/test/java/org/apache/flink/runtime/taskexecutor/TaskExecutorRecoveryTest.java
+++ b/flink-runtime/src/test/java/org/apache/flink/runtime/taskexecutor/TaskExecutorRecoveryTest.java
@@ -1,0 +1,206 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.flink.runtime.taskexecutor;
+
+import org.apache.flink.api.common.JobID;
+import org.apache.flink.api.common.time.Time;
+import org.apache.flink.configuration.CheckpointingOptions;
+import org.apache.flink.configuration.Configuration;
+import org.apache.flink.configuration.TaskManagerOptions;
+import org.apache.flink.core.testutils.EachCallbackWrapper;
+import org.apache.flink.runtime.clusterframework.types.AllocationID;
+import org.apache.flink.runtime.clusterframework.types.ResourceID;
+import org.apache.flink.runtime.clusterframework.types.SlotID;
+import org.apache.flink.runtime.entrypoint.WorkingDirectory;
+import org.apache.flink.runtime.highavailability.TestingHighAvailabilityServices;
+import org.apache.flink.runtime.jobmaster.utils.TestingJobMasterGateway;
+import org.apache.flink.runtime.jobmaster.utils.TestingJobMasterGatewayBuilder;
+import org.apache.flink.runtime.leaderretrieval.SettableLeaderRetrievalService;
+import org.apache.flink.runtime.messages.Acknowledge;
+import org.apache.flink.runtime.resourcemanager.utils.TestingResourceManagerGateway;
+import org.apache.flink.runtime.rpc.TestingRpcService;
+import org.apache.flink.runtime.rpc.TestingRpcServiceExtension;
+import org.apache.flink.runtime.taskexecutor.slot.SlotOffer;
+import org.apache.flink.util.TestLoggerExtension;
+
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.junit.jupiter.api.extension.RegisterExtension;
+import org.junit.jupiter.api.io.TempDir;
+
+import java.io.File;
+import java.util.Collection;
+import java.util.HashSet;
+import java.util.concurrent.ArrayBlockingQueue;
+import java.util.concurrent.BlockingQueue;
+import java.util.concurrent.CompletableFuture;
+
+import static org.hamcrest.MatcherAssert.assertThat;
+import static org.hamcrest.Matchers.hasSize;
+import static org.hamcrest.Matchers.is;
+import static org.hamcrest.Matchers.nullValue;
+
+/** Recovery tests for {@link TaskExecutor}. */
+@ExtendWith(TestLoggerExtension.class)
+class TaskExecutorRecoveryTest {
+    private final TestingRpcServiceExtension rpcServiceExtension = new TestingRpcServiceExtension();
+
+    @RegisterExtension
+    private final EachCallbackWrapper<TestingRpcServiceExtension> eachWrapper =
+            new EachCallbackWrapper<>(rpcServiceExtension);
+
+    @Test
+    public void testRecoveredTaskExecutorWillRestoreAllocationState(@TempDir File tempDir)
+            throws Exception {
+        final ResourceID resourceId = ResourceID.generate();
+
+        final Configuration configuration = new Configuration();
+        configuration.set(TaskManagerOptions.NUM_TASK_SLOTS, 2);
+        configuration.set(CheckpointingOptions.LOCAL_RECOVERY, true);
+
+        final TestingResourceManagerGateway testingResourceManagerGateway =
+                new TestingResourceManagerGateway();
+        final ArrayBlockingQueue<TaskExecutorSlotReport> queue = new ArrayBlockingQueue<>(2);
+        testingResourceManagerGateway.setSendSlotReportFunction(
+                slotReportInformation -> {
+                    queue.offer(
+                            TaskExecutorSlotReport.create(
+                                    slotReportInformation.f0, slotReportInformation.f2));
+                    return CompletableFuture.completedFuture(Acknowledge.get());
+                });
+
+        final TestingRpcService rpcService = rpcServiceExtension.getTestingRpcService();
+        rpcService.registerGateway(
+                testingResourceManagerGateway.getAddress(), testingResourceManagerGateway);
+
+        final JobID jobId = new JobID();
+
+        final TestingHighAvailabilityServices highAvailabilityServices =
+                new TestingHighAvailabilityServices();
+
+        highAvailabilityServices.setResourceManagerLeaderRetriever(
+                new SettableLeaderRetrievalService(
+                        testingResourceManagerGateway.getAddress(),
+                        testingResourceManagerGateway.getFencingToken().toUUID()));
+        final SettableLeaderRetrievalService jobMasterLeaderRetriever =
+                new SettableLeaderRetrievalService();
+        highAvailabilityServices.setJobMasterLeaderRetriever(jobId, jobMasterLeaderRetriever);
+
+        final WorkingDirectory workingDirectory = WorkingDirectory.create(tempDir);
+        final TaskExecutor taskExecutor =
+                TaskExecutorBuilder.newBuilder(
+                                rpcService, highAvailabilityServices, workingDirectory)
+                        .setConfiguration(configuration)
+                        .setResourceId(resourceId)
+                        .build();
+
+        taskExecutor.start();
+
+        final TaskExecutorGateway taskExecutorGateway =
+                taskExecutor.getSelfGateway(TaskExecutorGateway.class);
+
+        final TaskExecutorSlotReport taskExecutorSlotReport = queue.take();
+
+        final SlotReport slotReport = taskExecutorSlotReport.getSlotReport();
+
+        assertThat(slotReport.getNumSlotStatus(), is(2));
+
+        final SlotStatus slotStatus = slotReport.iterator().next();
+        final SlotID allocatedSlotID = slotStatus.getSlotID();
+
+        final AllocationID allocationId = new AllocationID();
+        taskExecutorGateway
+                .requestSlot(
+                        allocatedSlotID,
+                        jobId,
+                        allocationId,
+                        slotStatus.getResourceProfile(),
+                        "localhost",
+                        testingResourceManagerGateway.getFencingToken(),
+                        Time.seconds(10L))
+                .join();
+
+        taskExecutor.close();
+
+        final BlockingQueue<Collection<SlotOffer>> offeredSlots = new ArrayBlockingQueue<>(1);
+
+        final TestingJobMasterGateway jobMasterGateway =
+                new TestingJobMasterGatewayBuilder()
+                        .setOfferSlotsFunction(
+                                (resourceID, slotOffers) -> {
+                                    offeredSlots.offer(new HashSet<>(slotOffers));
+                                    return CompletableFuture.completedFuture(slotOffers);
+                                })
+                        .build();
+        rpcService.registerGateway(jobMasterGateway.getAddress(), jobMasterGateway);
+        jobMasterLeaderRetriever.notifyListener(
+                jobMasterGateway.getAddress(), jobMasterGateway.getFencingToken().toUUID());
+
+        // recover the TaskExecutor
+        final TaskExecutor recoveredTaskExecutor =
+                TaskExecutorBuilder.newBuilder(
+                                rpcService, highAvailabilityServices, workingDirectory)
+                        .setConfiguration(configuration)
+                        .setResourceId(resourceId)
+                        .build();
+
+        recoveredTaskExecutor.start();
+
+        final TaskExecutorSlotReport recoveredSlotReport = queue.take();
+
+        for (SlotStatus status : recoveredSlotReport.getSlotReport()) {
+            if (status.getSlotID().equals(allocatedSlotID)) {
+                assertThat(status.getJobID(), is(jobId));
+                assertThat(status.getAllocationID(), is(allocationId));
+            } else {
+                assertThat(status.getJobID(), is(nullValue()));
+            }
+        }
+
+        final Collection<SlotOffer> take = offeredSlots.take();
+
+        assertThat(take, hasSize(1));
+        final SlotOffer offeredSlot = take.iterator().next();
+
+        assertThat(offeredSlot.getAllocationId(), is(allocationId));
+    }
+
+    private static final class TaskExecutorSlotReport {
+        private final ResourceID taskExecutorResourceId;
+        private final SlotReport slotReport;
+
+        private TaskExecutorSlotReport(ResourceID taskExecutorResourceId, SlotReport slotReport) {
+            this.taskExecutorResourceId = taskExecutorResourceId;
+            this.slotReport = slotReport;
+        }
+
+        public ResourceID getTaskExecutorResourceId() {
+            return taskExecutorResourceId;
+        }
+
+        public SlotReport getSlotReport() {
+            return slotReport;
+        }
+
+        public static TaskExecutorSlotReport create(
+                ResourceID taskExecutorResourceId, SlotReport slotReport) {
+            return new TaskExecutorSlotReport(taskExecutorResourceId, slotReport);
+        }
+    }
+}

--- a/flink-runtime/src/test/java/org/apache/flink/runtime/taskexecutor/TaskExecutorTest.java
+++ b/flink-runtime/src/test/java/org/apache/flink/runtime/taskexecutor/TaskExecutorTest.java
@@ -106,6 +106,7 @@ import org.apache.flink.util.ExceptionUtils;
 import org.apache.flink.util.ExecutorUtils;
 import org.apache.flink.util.FlinkException;
 import org.apache.flink.util.NetUtils;
+import org.apache.flink.util.Reference;
 import org.apache.flink.util.TestLogger;
 import org.apache.flink.util.TimeUtils;
 import org.apache.flink.util.concurrent.Executors;
@@ -266,7 +267,9 @@ public class TaskExecutorTest extends TestLogger {
 
         final TaskExecutorLocalStateStoresManager localStateStoresManager =
                 new TaskExecutorLocalStateStoresManager(
-                        false, ioManager.getSpillingDirectories(), Executors.directExecutor());
+                        false,
+                        Reference.borrowed(ioManager.getSpillingDirectories()),
+                        Executors.directExecutor());
 
         nettyShuffleEnvironment.start();
 
@@ -2707,7 +2710,7 @@ public class TaskExecutorTest extends TestLogger {
     private TaskExecutorLocalStateStoresManager createTaskExecutorLocalStateStoresManager()
             throws IOException {
         return new TaskExecutorLocalStateStoresManager(
-                false, new File[] {tmp.newFolder()}, Executors.directExecutor());
+                false, Reference.owned(new File[] {tmp.newFolder()}), Executors.directExecutor());
     }
 
     private TaskExecutor createTaskExecutor(int numberOFSlots) throws IOException {

--- a/flink-runtime/src/test/java/org/apache/flink/runtime/taskexecutor/TaskManagerServicesBuilder.java
+++ b/flink-runtime/src/test/java/org/apache/flink/runtime/taskexecutor/TaskManagerServicesBuilder.java
@@ -29,6 +29,8 @@ import org.apache.flink.runtime.registration.RetryingRegistrationConfiguration;
 import org.apache.flink.runtime.shuffle.ShuffleEnvironment;
 import org.apache.flink.runtime.state.TaskExecutorLocalStateStoresManager;
 import org.apache.flink.runtime.state.TaskExecutorStateChangelogStoragesManager;
+import org.apache.flink.runtime.taskexecutor.slot.NoOpSlotAllocationSnapshotPersistenceService;
+import org.apache.flink.runtime.taskexecutor.slot.SlotAllocationSnapshotPersistenceService;
 import org.apache.flink.runtime.taskexecutor.slot.TaskSlotTable;
 import org.apache.flink.runtime.taskexecutor.slot.TestingTaskSlotTable;
 import org.apache.flink.runtime.taskmanager.LocalUnresolvedTaskManagerLocation;
@@ -60,6 +62,7 @@ public class TaskManagerServicesBuilder {
     private ExecutorService ioExecutor;
     private LibraryCacheManager libraryCacheManager;
     private long managedMemorySize;
+    private SlotAllocationSnapshotPersistenceService slotAllocationSnapshotPersistenceService;
 
     public TaskManagerServicesBuilder() {
         unresolvedTaskManagerLocation = new LocalUnresolvedTaskManagerLocation();
@@ -82,6 +85,8 @@ public class TaskManagerServicesBuilder {
         ioExecutor = TestingUtils.defaultExecutor();
         libraryCacheManager = TestingLibraryCacheManager.newBuilder().build();
         managedMemorySize = MemoryManager.MIN_PAGE_SIZE;
+        this.slotAllocationSnapshotPersistenceService =
+                NoOpSlotAllocationSnapshotPersistenceService.INSTANCE;
     }
 
     public TaskManagerServicesBuilder setUnresolvedTaskManagerLocation(
@@ -155,6 +160,12 @@ public class TaskManagerServicesBuilder {
         return this;
     }
 
+    public TaskManagerServicesBuilder setSlotAllocationSnapshotPersistenceService(
+            SlotAllocationSnapshotPersistenceService slotAllocationSnapshotPersistenceService) {
+        this.slotAllocationSnapshotPersistenceService = slotAllocationSnapshotPersistenceService;
+        return this;
+    }
+
     public TaskManagerServices build() {
         return new TaskManagerServices(
                 unresolvedTaskManagerLocation,
@@ -170,6 +181,7 @@ public class TaskManagerServicesBuilder {
                 taskChangelogStoragesManager,
                 taskEventDispatcher,
                 ioExecutor,
-                libraryCacheManager);
+                libraryCacheManager,
+                slotAllocationSnapshotPersistenceService);
     }
 }

--- a/flink-runtime/src/test/java/org/apache/flink/runtime/taskexecutor/TaskSubmissionTestEnvironment.java
+++ b/flink-runtime/src/test/java/org/apache/flink/runtime/taskexecutor/TaskSubmissionTestEnvironment.java
@@ -62,6 +62,7 @@ import org.apache.flink.runtime.util.TestingFatalErrorHandler;
 import org.apache.flink.testutils.TestFileUtils;
 import org.apache.flink.testutils.TestingUtils;
 import org.apache.flink.util.FlinkRuntimeException;
+import org.apache.flink.util.Reference;
 import org.apache.flink.util.concurrent.Executors;
 
 import org.junit.rules.TemporaryFolder;
@@ -150,7 +151,7 @@ class TaskSubmissionTestEnvironment implements AutoCloseable {
         TaskExecutorLocalStateStoresManager localStateStoresManager =
                 new TaskExecutorLocalStateStoresManager(
                         false,
-                        new File[] {temporaryFolder.newFolder()},
+                        Reference.owned(new File[] {temporaryFolder.newFolder()}),
                         Executors.directExecutor());
 
         final TaskManagerServices taskManagerServices =

--- a/flink-runtime/src/test/java/org/apache/flink/runtime/taskexecutor/slot/FileSlotAllocationSnapshotPersistenceServiceTest.java
+++ b/flink-runtime/src/test/java/org/apache/flink/runtime/taskexecutor/slot/FileSlotAllocationSnapshotPersistenceServiceTest.java
@@ -1,0 +1,161 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.flink.runtime.taskexecutor.slot;
+
+import org.apache.flink.api.common.JobID;
+import org.apache.flink.runtime.clusterframework.types.AllocationID;
+import org.apache.flink.runtime.clusterframework.types.ResourceID;
+import org.apache.flink.runtime.clusterframework.types.ResourceProfile;
+import org.apache.flink.runtime.clusterframework.types.SlotID;
+import org.apache.flink.util.TestLoggerExtension;
+
+import org.apache.flink.shaded.guava30.com.google.common.collect.Iterables;
+
+import org.apache.commons.io.FileUtils;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.junit.jupiter.api.io.TempDir;
+
+import javax.annotation.Nonnull;
+
+import java.io.File;
+import java.io.IOException;
+import java.util.ArrayList;
+import java.util.Collection;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.junit.jupiter.api.Assumptions.assumeTrue;
+
+/** Tests for the {@link FileSlotAllocationSnapshotPersistenceService}. */
+@ExtendWith(TestLoggerExtension.class)
+class FileSlotAllocationSnapshotPersistenceServiceTest {
+
+    @TempDir private File tempDirectory;
+
+    @Test
+    public void loadNoSlotAllocationSnapshotsIfDirectoryIsEmpty() throws IOException {
+        assumeTrue(FileUtils.isEmptyDirectory(tempDirectory));
+
+        final FileSlotAllocationSnapshotPersistenceService persistenceService =
+                new FileSlotAllocationSnapshotPersistenceService(tempDirectory);
+
+        assertThat(persistenceService.loadAllocationSnapshots()).isEmpty();
+    }
+
+    @Test
+    public void loadPersistedSlotAllocationSnapshots() throws IOException {
+        final FileSlotAllocationSnapshotPersistenceService persistenceService =
+                new FileSlotAllocationSnapshotPersistenceService(tempDirectory);
+
+        final Collection<SlotAllocationSnapshot> slotAllocationSnapshots =
+                createRandomSlotAllocationSnapshots(3);
+
+        for (SlotAllocationSnapshot slotAllocationSnapshot : slotAllocationSnapshots) {
+            persistenceService.persistAllocationSnapshot(slotAllocationSnapshot);
+        }
+
+        final Collection<SlotAllocationSnapshot> loadedSlotAllocationSnapshots =
+                persistenceService.loadAllocationSnapshots();
+
+        assertThat(loadedSlotAllocationSnapshots)
+                .containsAll(slotAllocationSnapshots)
+                .usingRecursiveComparison();
+    }
+
+    @Test
+    public void newInstanceLoadsPersistedSlotAllocationSnapshots() throws IOException {
+        final FileSlotAllocationSnapshotPersistenceService persistenceService =
+                new FileSlotAllocationSnapshotPersistenceService(tempDirectory);
+
+        final Collection<SlotAllocationSnapshot> slotAllocationSnapshots =
+                createRandomSlotAllocationSnapshots(3);
+
+        for (SlotAllocationSnapshot slotAllocationSnapshot : slotAllocationSnapshots) {
+            persistenceService.persistAllocationSnapshot(slotAllocationSnapshot);
+        }
+
+        final FileSlotAllocationSnapshotPersistenceService newPersistenceService =
+                new FileSlotAllocationSnapshotPersistenceService(tempDirectory);
+
+        final Collection<SlotAllocationSnapshot> loadedSlotAllocationSnapshots =
+                newPersistenceService.loadAllocationSnapshots();
+
+        assertThat(loadedSlotAllocationSnapshots)
+                .containsAll(slotAllocationSnapshots)
+                .usingRecursiveComparison();
+    }
+
+    @Test
+    public void deletePersistedSlotAllocationSnapshot() throws IOException {
+        final FileSlotAllocationSnapshotPersistenceService persistenceService =
+                new FileSlotAllocationSnapshotPersistenceService(tempDirectory);
+
+        final SlotAllocationSnapshot singleSlotAllocationSnapshot =
+                createSingleSlotAllocationSnapshot();
+
+        persistenceService.persistAllocationSnapshot(singleSlotAllocationSnapshot);
+        persistenceService.deleteAllocationSnapshot(singleSlotAllocationSnapshot.getSlotIndex());
+
+        assertThat(persistenceService.loadAllocationSnapshots()).isEmpty();
+    }
+
+    @Test
+    public void deleteCorruptedSlotAllocationSnapshots() throws IOException {
+        final FileSlotAllocationSnapshotPersistenceService persistenceService =
+                new FileSlotAllocationSnapshotPersistenceService(tempDirectory);
+
+        final SlotAllocationSnapshot singleSlotAllocationSnapshot =
+                createSingleSlotAllocationSnapshot();
+
+        persistenceService.persistAllocationSnapshot(singleSlotAllocationSnapshot);
+
+        final File[] files = tempDirectory.listFiles();
+
+        assertThat(files).hasSize(1);
+
+        final File file = files[0];
+
+        // corrupt the file
+        FileUtils.writeByteArrayToFile(file, new byte[] {1, 2, 3, 4});
+
+        assertThat(persistenceService.loadAllocationSnapshots()).isEmpty();
+        assertThat(tempDirectory).isEmptyDirectory();
+    }
+
+    @Nonnull
+    private Collection<SlotAllocationSnapshot> createRandomSlotAllocationSnapshots(int number) {
+        final Collection<SlotAllocationSnapshot> result = new ArrayList<>();
+        final ResourceID resourceId = ResourceID.generate();
+        for (int slotIndex = 0; slotIndex < number; slotIndex++) {
+            result.add(
+                    new SlotAllocationSnapshot(
+                            new SlotID(resourceId, slotIndex),
+                            new JobID(),
+                            "foobar",
+                            new AllocationID(),
+                            ResourceProfile.UNKNOWN));
+        }
+
+        return result;
+    }
+
+    private SlotAllocationSnapshot createSingleSlotAllocationSnapshot() {
+        return Iterables.getOnlyElement(createRandomSlotAllocationSnapshots(1));
+    }
+}

--- a/flink-runtime/src/test/java/org/apache/flink/runtime/testutils/CommonTestUtils.java
+++ b/flink-runtime/src/test/java/org/apache/flink/runtime/testutils/CommonTestUtils.java
@@ -114,7 +114,7 @@ public class CommonTestUtils {
 
     public static void printLog4jDebugConfig(File file) throws IOException {
         try (PrintWriter writer = new PrintWriter(new FileWriter(file))) {
-            writer.println("rootLogger.level = INFO");
+            writer.println("rootLogger.level = DEBUG");
             writer.println("rootLogger.appenderRef.console.ref = ConsoleAppender");
             writer.println("appender.console.name = ConsoleAppender");
             writer.println("appender.console.type = CONSOLE");

--- a/flink-runtime/src/test/java/org/apache/flink/runtime/testutils/WorkingDirectoryExtension.java
+++ b/flink-runtime/src/test/java/org/apache/flink/runtime/testutils/WorkingDirectoryExtension.java
@@ -21,16 +21,18 @@ package org.apache.flink.runtime.testutils;
 import org.apache.flink.core.testutils.CustomExtension;
 import org.apache.flink.runtime.entrypoint.WorkingDirectory;
 
-import org.junit.jupiter.api.io.TempDir;
-
 import java.io.File;
 import java.io.IOException;
 
 /** Extension to generate {@link WorkingDirectory}. */
 public class WorkingDirectoryExtension implements CustomExtension {
-    @TempDir File tmpDirectory;
+    private final File tmpDirectory;
 
     private int counter = 0;
+
+    public WorkingDirectoryExtension(File tmpDirectory) {
+        this.tmpDirectory = tmpDirectory;
+    }
 
     public WorkingDirectory createNewWorkingDirectory() throws IOException {
         return WorkingDirectory.create(new File(tmpDirectory, "working_directory_" + counter++));

--- a/flink-tests/src/test/java/org/apache/flink/test/recovery/LocalRecoveryITCase.java
+++ b/flink-tests/src/test/java/org/apache/flink/test/recovery/LocalRecoveryITCase.java
@@ -1,0 +1,347 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.flink.test.recovery;
+
+import org.apache.flink.api.common.JobID;
+import org.apache.flink.api.common.state.ListState;
+import org.apache.flink.api.common.state.ListStateDescriptor;
+import org.apache.flink.api.common.time.Deadline;
+import org.apache.flink.configuration.CheckpointingOptions;
+import org.apache.flink.configuration.ClusterOptions;
+import org.apache.flink.configuration.Configuration;
+import org.apache.flink.configuration.HeartbeatManagerOptions;
+import org.apache.flink.configuration.JobManagerOptions;
+import org.apache.flink.configuration.RestOptions;
+import org.apache.flink.configuration.TaskManagerOptions;
+import org.apache.flink.core.execution.JobClient;
+import org.apache.flink.runtime.entrypoint.StandaloneSessionClusterEntrypoint;
+import org.apache.flink.runtime.rest.RestClient;
+import org.apache.flink.runtime.rest.messages.EmptyRequestBody;
+import org.apache.flink.runtime.rest.messages.JobMessageParameters;
+import org.apache.flink.runtime.rest.messages.checkpoints.CheckpointingStatistics;
+import org.apache.flink.runtime.rest.messages.checkpoints.CheckpointingStatisticsHeaders;
+import org.apache.flink.runtime.state.FunctionInitializationContext;
+import org.apache.flink.runtime.state.FunctionSnapshotContext;
+import org.apache.flink.runtime.testutils.CommonTestUtils;
+import org.apache.flink.streaming.api.CheckpointingMode;
+import org.apache.flink.streaming.api.checkpoint.CheckpointedFunction;
+import org.apache.flink.streaming.api.environment.StreamExecutionEnvironment;
+import org.apache.flink.streaming.api.functions.sink.DiscardingSink;
+import org.apache.flink.streaming.api.functions.source.RichParallelSourceFunction;
+import org.apache.flink.streaming.api.operators.StreamingRuntimeContext;
+import org.apache.flink.test.recovery.utils.TaskExecutorProcessEntryPoint;
+import org.apache.flink.test.util.TestProcessBuilder;
+import org.apache.flink.util.Preconditions;
+import org.apache.flink.util.TestLoggerExtension;
+import org.apache.flink.util.concurrent.Executors;
+
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.junit.jupiter.api.io.TempDir;
+
+import javax.annotation.Nonnull;
+
+import java.io.File;
+import java.io.IOException;
+import java.time.Duration;
+import java.util.ArrayList;
+import java.util.Collection;
+import java.util.Collections;
+import java.util.Iterator;
+import java.util.List;
+import java.util.Optional;
+import java.util.concurrent.TimeUnit;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+/** Tests local recovery by restarting Flink processes. */
+@ExtendWith(TestLoggerExtension.class)
+class LocalRecoveryITCase {
+
+    @TempDir private File tmpDirectory;
+
+    @Test
+    public void testRecoverLocallyFromProcessCrashWithWorkingDirectory() throws Exception {
+        final Configuration configuration = new Configuration();
+        configuration.set(JobManagerOptions.ADDRESS, "localhost");
+        configuration.set(JobManagerOptions.PORT, 0);
+        configuration.set(RestOptions.BIND_PORT, "0");
+        configuration.set(HeartbeatManagerOptions.HEARTBEAT_TIMEOUT, 10000L);
+        configuration.set(HeartbeatManagerOptions.HEARTBEAT_INTERVAL, 1000L);
+        configuration.set(HeartbeatManagerOptions.HEARTBEAT_RPC_FAILURE_THRESHOLD, 1);
+        configuration.set(ClusterOptions.PROCESS_WORKING_DIR_BASE, tmpDirectory.getAbsolutePath());
+        configuration.set(CheckpointingOptions.LOCAL_RECOVERY, true);
+        configuration.set(TaskManagerOptions.SLOT_TIMEOUT, Duration.ofSeconds(30L));
+
+        final int parallelism = 3;
+
+        boolean success = false;
+        Collection<TaskManagerProcess> taskManagerProcesses = Collections.emptyList();
+        try (final StandaloneSessionClusterEntrypoint clusterEntrypoint =
+                new StandaloneSessionClusterEntrypoint(configuration)) {
+            clusterEntrypoint.startCluster();
+
+            final Configuration configurationTemplate = new Configuration(configuration);
+            configurationTemplate.set(JobManagerOptions.PORT, clusterEntrypoint.getRpcPort());
+            taskManagerProcesses = startTaskManagerProcesses(parallelism, configurationTemplate);
+
+            final JobClient jobClient = submitJob(parallelism, clusterEntrypoint);
+
+            final long waitingTimeInSeconds = 45L;
+            waitUntilCheckpointCompleted(
+                    configuration,
+                    clusterEntrypoint.getRestPort(),
+                    jobClient.getJobID(),
+                    Deadline.fromNow(Duration.ofSeconds(waitingTimeInSeconds)));
+
+            restartTaskManagerProcesses(taskManagerProcesses, parallelism - 1);
+
+            jobClient.getJobExecutionResult().get(waitingTimeInSeconds, TimeUnit.SECONDS);
+
+            success = true;
+        } finally {
+            if (!success) {
+                for (TaskManagerProcess taskManagerProcess : taskManagerProcesses) {
+                    printLogOutput(taskManagerProcess);
+                }
+            }
+
+            for (TaskManagerProcess taskManagerProcess : taskManagerProcesses) {
+                taskManagerProcess.terminate();
+            }
+        }
+    }
+
+    private static void printLogOutput(TaskManagerProcess taskManagerProcess) {
+        for (TestProcessBuilder.TestProcess testProcess : taskManagerProcess.getProcessHistory()) {
+            AbstractTaskManagerProcessFailureRecoveryTest.printProcessLog(
+                    taskManagerProcess.getName(), testProcess);
+        }
+    }
+
+    private static void restartTaskManagerProcesses(
+            Collection<TaskManagerProcess> taskManagerProcesses, int numberRestarts)
+            throws IOException, InterruptedException {
+        Preconditions.checkArgument(numberRestarts <= taskManagerProcesses.size());
+
+        final Iterator<TaskManagerProcess> iterator = taskManagerProcesses.iterator();
+
+        for (int i = 0; i < numberRestarts; i++) {
+            iterator.next().restartProcess(createTaskManagerProcessBuilder());
+        }
+    }
+
+    private static Collection<TaskManagerProcess> startTaskManagerProcesses(
+            int numberTaskManagers, Configuration configurationTemplate) throws IOException {
+        final Collection<TaskManagerProcess> result = new ArrayList<>();
+
+        for (int i = 0; i < numberTaskManagers; i++) {
+            final Configuration effectiveConfiguration = new Configuration(configurationTemplate);
+            effectiveConfiguration.set(
+                    TaskManagerOptions.TASK_MANAGER_RESOURCE_ID, "taskManager_" + i);
+
+            final TestProcessBuilder.TestProcess process =
+                    startTaskManagerProcess(effectiveConfiguration);
+
+            result.add(new TaskManagerProcess(effectiveConfiguration, process));
+        }
+
+        return result;
+    }
+
+    private static TestProcessBuilder.TestProcess startTaskManagerProcess(
+            Configuration effectiveConfiguration) throws IOException {
+        final TestProcessBuilder taskManagerProcessBuilder = createTaskManagerProcessBuilder();
+        taskManagerProcessBuilder.addConfigAsMainClassArgs(effectiveConfiguration);
+
+        final TestProcessBuilder.TestProcess process = taskManagerProcessBuilder.start();
+        return process;
+    }
+
+    @Nonnull
+    private static TestProcessBuilder createTaskManagerProcessBuilder() throws IOException {
+        return new TestProcessBuilder(TaskExecutorProcessEntryPoint.class.getName());
+    }
+
+    private static class TaskManagerProcess {
+        private final Configuration configuration;
+        private final List<TestProcessBuilder.TestProcess> processHistory;
+
+        private TaskManagerProcess(
+                Configuration configuration, TestProcessBuilder.TestProcess process) {
+            this.configuration = configuration;
+            this.processHistory = new ArrayList<>();
+            processHistory.add(process);
+        }
+
+        Iterable<TestProcessBuilder.TestProcess> getProcessHistory() {
+            return processHistory;
+        }
+
+        void restartProcess(TestProcessBuilder builder) throws IOException, InterruptedException {
+            final TestProcessBuilder.TestProcess runningProcess = getRunningProcess();
+            runningProcess.destroy();
+            runningProcess.getProcess().waitFor();
+
+            builder.addConfigAsMainClassArgs(configuration);
+            final TestProcessBuilder.TestProcess restartedProcess = builder.start();
+
+            processHistory.add(restartedProcess);
+        }
+
+        private TestProcessBuilder.TestProcess getRunningProcess() {
+            return processHistory.get(processHistory.size() - 1);
+        }
+
+        public String getName() {
+            return configuration.get(TaskManagerOptions.TASK_MANAGER_RESOURCE_ID);
+        }
+
+        public void terminate() {
+            getRunningProcess().destroy();
+        }
+    }
+
+    private void waitUntilCheckpointCompleted(
+            Configuration configuration, int restPort, JobID jobId, Deadline deadline)
+            throws Exception {
+        final RestClient restClient = new RestClient(configuration, Executors.directExecutor());
+        final JobMessageParameters messageParameters = new JobMessageParameters();
+        messageParameters.jobPathParameter.resolve(jobId);
+
+        CommonTestUtils.waitUntilCondition(
+                () -> {
+                    final CheckpointingStatistics checkpointingStatistics =
+                            restClient
+                                    .sendRequest(
+                                            "localhost",
+                                            restPort,
+                                            CheckpointingStatisticsHeaders.getInstance(),
+                                            messageParameters,
+                                            EmptyRequestBody.getInstance())
+                                    .join();
+                    return checkpointingStatistics.getCounts().getNumberCompletedCheckpoints() > 0;
+                },
+                deadline);
+    }
+
+    private JobClient submitJob(
+            int parallelism, StandaloneSessionClusterEntrypoint clusterEntrypoint)
+            throws Exception {
+        final StreamExecutionEnvironment env =
+                StreamExecutionEnvironment.createRemoteEnvironment(
+                        "localhost", clusterEntrypoint.getRestPort(), new Configuration());
+        env.setParallelism(parallelism);
+
+        env.enableCheckpointing(100, CheckpointingMode.EXACTLY_ONCE);
+
+        env.addSource(new LocalRecoverySource()).keyBy(x -> x).addSink(new DiscardingSink<>());
+        final JobClient jobClient = env.executeAsync();
+        return jobClient;
+    }
+
+    private static class LocalRecoverySource extends RichParallelSourceFunction<Integer>
+            implements CheckpointedFunction {
+        private volatile boolean running = true;
+
+        private transient ListState<TaskNameAllocationID> previousAllocations;
+
+        @Override
+        public void run(SourceContext<Integer> ctx) throws Exception {
+            while (running) {
+                synchronized (ctx.getCheckpointLock()) {
+                    ctx.collect(1);
+                }
+
+                Thread.sleep(5L);
+            }
+        }
+
+        @Override
+        public void cancel() {
+            running = false;
+        }
+
+        @Override
+        public void snapshotState(FunctionSnapshotContext context) throws Exception {}
+
+        @Override
+        public void initializeState(FunctionInitializationContext context) throws Exception {
+            StreamingRuntimeContext runtimeContext = (StreamingRuntimeContext) getRuntimeContext();
+            String allocationId = runtimeContext.getAllocationIDAsString();
+            // Pattern of the name: "Flat Map -> Sink: Unnamed (4/4)#0". Remove "#0" part:
+            String myName = runtimeContext.getTaskNameWithSubtasks().split("#")[0];
+
+            ListStateDescriptor<TaskNameAllocationID> previousAllocationsStateDescriptor =
+                    new ListStateDescriptor<>("sourceState", TaskNameAllocationID.class);
+            previousAllocations =
+                    context.getOperatorStateStore()
+                            .getUnionListState(previousAllocationsStateDescriptor);
+
+            if (context.isRestored()) {
+                final Iterable<TaskNameAllocationID> taskNameAllocationIds =
+                        previousAllocations.get();
+
+                Optional<TaskNameAllocationID> optionalMyTaskNameAllocationId = Optional.empty();
+
+                for (TaskNameAllocationID taskNameAllocationId : taskNameAllocationIds) {
+                    if (taskNameAllocationId.getName().equals(myName)) {
+                        optionalMyTaskNameAllocationId = Optional.of(taskNameAllocationId);
+                        break;
+                    }
+                }
+
+                final TaskNameAllocationID myTaskNameAllocationId =
+                        optionalMyTaskNameAllocationId.orElseThrow(
+                                () ->
+                                        new IllegalStateException(
+                                                "Could not find corresponding TaskNameAllocationID information."));
+
+                assertThat(myTaskNameAllocationId.getAllocationId())
+                        .withFailMessage(
+                                "The task was deployed to AllocationID(%s) but it should have been deployed to AllocationID(%s) for local recovery.",
+                                allocationId, myTaskNameAllocationId.getAllocationId())
+                        .isEqualTo(allocationId);
+                // terminate
+                running = false;
+            }
+
+            previousAllocations.clear();
+            previousAllocations.add(new TaskNameAllocationID(myName, allocationId));
+        }
+    }
+
+    private static class TaskNameAllocationID {
+        private final String name;
+        private final String allocationId;
+
+        private TaskNameAllocationID(String name, String allocationId) {
+            this.name = name;
+            this.allocationId = allocationId;
+        }
+
+        public String getName() {
+            return name;
+        }
+
+        public String getAllocationId() {
+            return allocationId;
+        }
+    }
+}


### PR DESCRIPTION
This PR implements [FLIP-201](https://cwiki.apache.org/confluence/display/FLINK/FLIP-201%3A+Persist+local+state+in+working+directory). The goal is to use the working directory to store local state information so that a process can recover from process/node failures as long as the working directory is available after the restart.

The important commits are:

68200f5caa6187f267b288925fdc5bae811e0a8b: This commit lets the `TaskLocalStateStoreImpl` persist the `TaskStateSnapshot` to the working directory. This is required to recover any local state after a process failure.

ed11d5fc78748dc48db18a608dc08062be9dfd4c and 65479221d6cfde6ce89f79f53cbbe0e2b3f26dae: These two commits let the `TaskExecutor` persist the current slot allocations in the working directory. Upon restart of a `TaskExecutor`, it will read this information and recover the last slot allocation state. That way we can couple the clean up of local state to the slot allocation because the local state and slot allocation can both be recovered from the working directory.

This PR is based on #18542.