### PR TITLE
[FLINK-25119][runtime] Modify the name of freeSlots parameter in SlotSharingSlotAllocator#determineParallelism method.

### DIFF
--- a/flink-runtime/src/main/java/org/apache/flink/runtime/scheduler/adaptive/allocator/SlotSharingSlotAllocator.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/scheduler/adaptive/allocator/SlotSharingSlotAllocator.java
@@ -93,17 +93,17 @@ public class SlotSharingSlotAllocator implements SlotAllocator {
 
     @Override
     public Optional<VertexParallelismWithSlotSharing> determineParallelism(
-            JobInformation jobInformation, Collection<? extends SlotInfo> freeSlots) {
+            JobInformation jobInformation, Collection<? extends SlotInfo> slots) {
         // TODO: This can waste slots if the max parallelism for slot sharing groups is not equal
         final int slotsPerSlotSharingGroup =
-                freeSlots.size() / jobInformation.getSlotSharingGroups().size();
+                slots.size() / jobInformation.getSlotSharingGroups().size();
 
         if (slotsPerSlotSharingGroup == 0) {
             // => less slots than slot-sharing groups
             return Optional.empty();
         }
 
-        final Iterator<? extends SlotInfo> slotIterator = freeSlots.iterator();
+        final Iterator<? extends SlotInfo> slotIterator = slots.iterator();
 
         final Collection<ExecutionSlotSharingGroupAndSlot> assignments = new ArrayList<>();
         final Map<JobVertexID, Integer> allVertexParallelism = new HashMap<>();


### PR DESCRIPTION
## What is the purpose of the change

*This pull request modify the name of freeSlot parameter in SlotSharingSlotAllocator#determineParallelism method*


## Brief change log

  - *This pull request modify the name of freeSlot parameter in SlotSharingSlotAllocator#determineParallelism method*


## Verifying this change

  - *This change is a trivial rework / code cleanup without any test coverage*

## Does this pull request potentially affect one of the following parts:

  - Dependencies (does it add or upgrade a dependency): (no)
  - The public API, i.e., is any changed class annotated with `@Public(Evolving)`: (no)
  - The serializers: (no)
  - The runtime per-record code paths (performance sensitive): (no)
  - Anything that affects deployment or recovery: JobManager (and its components), Checkpointing, Kubernetes/Yarn, ZooKeeper: (no)
  - The S3 file system connector: (no)

## Documentation

  - Does this pull request introduce a new feature? (no)
  - If yes, how is the feature documented? (not applicable / docs / JavaDocs / not documented)
