### PR TITLE
[FLINK-25504][Kafka] Upgrade Kafka Client to 2.8.1 and Confluent Platform to 6.2.2

### DIFF
--- a/flink-end-to-end-tests/flink-end-to-end-tests-common-kafka/pom.xml
+++ b/flink-end-to-end-tests/flink-end-to-end-tests-common-kafka/pom.xml
@@ -115,14 +115,14 @@ under the License.
 			<!-- https://mvnrepository.com/artifact/io.confluent/kafka-avro-serializer -->
 			<groupId>io.confluent</groupId>
 			<artifactId>kafka-avro-serializer</artifactId>
-			<version>5.5.2</version>
+			<version>6.2.2</version>
 			<scope>test</scope>
 		</dependency>
 
 		<dependency>
 			<groupId>io.confluent</groupId>
 			<artifactId>kafka-schema-registry-client</artifactId>
-			<version>5.5.2</version>
+			<version>6.2.2</version>
 			<scope>test</scope>
 			<exclusions>
 				<exclusion>
@@ -143,6 +143,12 @@ under the License.
 			<groupId>org.apache.flink</groupId>
 			<artifactId>flink-connector-testing</artifactId>
 			<version>${project.version}</version>
+			<exclusions>
+				<exclusion>
+					<groupId>com.google.guava</groupId>
+					<artifactId>guava</artifactId>
+				</exclusion>
+			</exclusions>
 		</dependency>
 
 		<dependency>
@@ -221,7 +227,7 @@ under the License.
 						<artifactItem>
 							<groupId>org.apache.kafka</groupId>
 							<artifactId>kafka-clients</artifactId>
-							<version>2.4.1</version>
+							<version>2.8.1</version>
 							<destFileName>kafka-clients.jar</destFileName>
 							<type>jar</type>
 							<outputDirectory>${project.build.directory}/dependencies</outputDirectory>

--- a/flink-end-to-end-tests/flink-end-to-end-tests-common-kafka/src/test/java/org/apache/flink/tests/util/kafka/SQLClientKafkaITCase.java
+++ b/flink-end-to-end-tests/flink-end-to-end-tests-common-kafka/src/test/java/org/apache/flink/tests/util/kafka/SQLClientKafkaITCase.java
@@ -74,7 +74,7 @@ public class SQLClientKafkaITCase extends TestLogger {
 
     @Parameterized.Parameters(name = "{index}: kafka-version:{0} kafka-sql-version:{1}")
     public static Collection<Object[]> data() {
-        return Arrays.asList(new Object[][] {{"2.4.1", "universal", "kafka", ".*kafka.jar"}});
+        return Arrays.asList(new Object[][] {{"2.8.1", "universal", "kafka", ".*kafka.jar"}});
     }
 
     private static Configuration getConfiguration() {

--- a/flink-end-to-end-tests/flink-end-to-end-tests-common-kafka/src/test/java/org/apache/flink/tests/util/kafka/SQLClientSchemaRegistryITCase.java
+++ b/flink-end-to-end-tests/flink-end-to-end-tests-common-kafka/src/test/java/org/apache/flink/tests/util/kafka/SQLClientSchemaRegistryITCase.java
@@ -84,7 +84,7 @@ public class SQLClientSchemaRegistryITCase {
 
     @ClassRule
     public static final SchemaRegistryContainer REGISTRY =
-            new SchemaRegistryContainer("5.5.2")
+            new SchemaRegistryContainer("6.2.2")
                     .withKafka(INTER_CONTAINER_KAFKA_ALIAS + ":9092")
                     .withNetwork(NETWORK)
                     .withNetworkAliases(INTER_CONTAINER_REGISTRY_ALIAS)

--- a/flink-end-to-end-tests/test-scripts/test_confluent_schema_registry.sh
+++ b/flink-end-to-end-tests/test-scripts/test_confluent_schema_registry.sh
@@ -19,9 +19,9 @@
 
 set -Eeuo pipefail
 
-KAFKA_VERSION="2.6.0"
-CONFLUENT_VERSION="6.0.4"
-CONFLUENT_MAJOR_VERSION="6.0"
+KAFKA_VERSION="2.8.1"
+CONFLUENT_VERSION="6.2.2"
+CONFLUENT_MAJOR_VERSION="6.2"
 # Check the Confluent Platform <> Apache Kafka compatibility matrix when updating KAFKA_VERSION
 KAFKA_SQL_VERSION="universal"
 

--- a/flink-end-to-end-tests/test-scripts/test_pyflink.sh
+++ b/flink-end-to-end-tests/test-scripts/test_pyflink.sh
@@ -19,9 +19,9 @@
 
 set -Eeuo pipefail
 
-KAFKA_VERSION="2.2.0"
-CONFLUENT_VERSION="5.2.6"
-CONFLUENT_MAJOR_VERSION="5.2"
+KAFKA_VERSION="2.8.1"
+CONFLUENT_VERSION="6.2.2"
+CONFLUENT_MAJOR_VERSION="6.2"
 # Check the Confluent Platform <> Apache Kafka compatibility matrix when updating KAFKA_VERSION
 KAFKA_SQL_VERSION="universal"
 SQL_JARS_DIR=${END_TO_END_DIR}/flink-sql-client-test/target/sql-jars

--- a/flink-end-to-end-tests/test-scripts/test_sql_client.sh
+++ b/flink-end-to-end-tests/test-scripts/test_sql_client.sh
@@ -19,9 +19,9 @@
 
 set -Eeuo pipefail
 
-KAFKA_VERSION="2.2.2"
-CONFLUENT_VERSION="5.2.6"
-CONFLUENT_MAJOR_VERSION="5.2"
+KAFKA_VERSION="2.8.1"
+CONFLUENT_VERSION="6.2.2"
+CONFLUENT_MAJOR_VERSION="6.2"
 # Check the Confluent Platform <> Apache Kafka compatibility matrix when updating KAFKA_VERSION
 KAFKA_SQL_VERSION="universal"
 ELASTICSEARCH_VERSION=7

--- a/flink-formats/flink-avro-confluent-registry/pom.xml
+++ b/flink-formats/flink-avro-confluent-registry/pom.xml
@@ -32,8 +32,8 @@ under the License.
 	<name>Flink : Formats : Avro confluent registry</name>
 
 	<properties>
-		<kafka.version>2.4.1</kafka.version>
-		<confluent.version>5.5.2</confluent.version>
+		<kafka.version>2.8.1</kafka.version>
+		<confluent.version>6.2.2</confluent.version>
 	</properties>
 
 	<repositories>

--- a/flink-formats/flink-sql-avro-confluent-registry/src/main/resources/META-INF/NOTICE
+++ b/flink-formats/flink-sql-avro-confluent-registry/src/main/resources/META-INF/NOTICE
@@ -11,10 +11,10 @@ This project bundles the following dependencies under the Apache Software Licens
 - com.fasterxml.jackson.core:jackson-databind:2.13.0
 - com.fasterxml.jackson.core:jackson-annotations:2.13.0
 - org.apache.commons:commons-compress:1.21
-- io.confluent:kafka-schema-registry-client:5.5.2
-- org.apache.kafka:kafka-clients:5.5.2-ccs
-- io.confluent:common-config:5.5.2
-- io.confluent:common-utils:5.5.2
+- io.confluent:kafka-schema-registry-client:6.2.2
+- org.apache.kafka:kafka-clients:6.2.2-ccs
+- io.confluent:common-config:6.2.2
+- io.confluent:common-utils:6.2.2
 - org.glassfish.jersey.core:jersey-common:2.30
 
 The binary distribution of this product bundles these dependencies under the Eclipse Public License - v 2.0 (https://www.eclipse.org/org/documents/epl-2.0/EPL-2.0.txt)

--- a/flink-test-utils-parent/flink-test-utils-junit/src/main/java/org/apache/flink/util/DockerImageVersions.java
+++ b/flink-test-utils-parent/flink-test-utils-junit/src/main/java/org/apache/flink/util/DockerImageVersions.java
@@ -31,7 +31,7 @@ public class DockerImageVersions {
     public static final String ELASTICSEARCH_6 =
             "docker.elastic.co/elasticsearch/elasticsearch:6.8.20";
 
-    public static final String KAFKA = "confluentinc/cp-kafka:6.2.1";
+    public static final String KAFKA = "confluentinc/cp-kafka:6.2.2";
 
     public static final String RABBITMQ = "rabbitmq:3.9.8-management-alpine";
 


### PR DESCRIPTION
## What is the purpose of the change

The Flink codebases uses Kafka Client and Confluent Platform in multiple places:

- AVRO Confluent Schema Registry
- Flink end-to-end tests (Bash e2e tests)
- Flink end-to-end tests common (Java e2e tests)
- SQL AVRO Confluent Schema Registry
- Flink Test Utils
- Flink Tests

The used versions are currently not in sync, which could result in unexpected results. 

## Brief change log

* Updated `flink-end-to-end-tests/flink-end-to-end-tests-common-kafka/pom.xml` from Confluent Platform 5.5.2 to 6.2.2 and Kafka Client from 2.4.1 to 2.8.1
* Updated `flink-end-to-end-tests/flink-end-to-end-tests-common-kafka/src/test/java/org/apache/flink/tests/util/kafka/SQLClientKafkaITCase.java` and `flink-end-to-end-tests/flink-end-to-end-tests-common-kafka/src/test/java/org/apache/flink/tests/util/kafka/StreamingKafkaITCase.java` from Kafka Client 2.4.1 to 2.8.1
* Updated `flink-end-to-end-tests/flink-end-to-end-tests-common-kafka/src/test/java/org/apache/flink/tests/util/kafka/SQLClientSchemaRegistryITCase.java` from Confluent Platform 5.5.2 to 6.2.2
* Updated `flink-end-to-end-tests/flink-end-to-end-tests-common-kafka/pom.xml` to exclude `com.google.guava:guava` from `org.apache.flink:flink-connector-testing` to prevent the following dependency convergence error:
```
Dependency convergence error for com.google.guava:guava:30.1.1-jre paths to dependency are:
+-org.apache.flink:flink-end-to-end-tests-common-kafka:1.15-SNAPSHOT
  +-io.confluent:kafka-schema-registry-client:6.2.2
    +-com.google.guava:guava:30.1.1-jre
and
+-org.apache.flink:flink-end-to-end-tests-common-kafka:1.15-SNAPSHOT
  +-org.apache.flink:flink-connector-testing:1.15-SNAPSHOT
    +-org.apache.flink:flink-test-utils:1.15-SNAPSHOT
      +-org.apache.curator:curator-test:2.12.0
        +-com.google.guava:guava:16.0.1
```
* Updated `flink-end-to-end-tests/test-scripts/test_confluent_schema_registry.sh` from Kafka Client 2.6.0 to 2.8.1 and Confluent Platform from 6.0.4 to 6.2.2
* Updated `flink-end-to-end-tests/test-scripts/test_pyflink.sh` from Kafka Client 2.2.0 to 2.8.1 and Confluent Platform from 5.2.6 to 6.2.2
* Updated `flink-end-to-end-tests/test-scripts/test_sql_client.sh` from Kafka Client 2.2.2 to 2.8.1 and Confluent Platform 5.2.6 to 6.2.2
* Updated `flink-formats/flink-avro-confluent-registry/pom.xml` from Kafka Client 2.4.1 to 2.8.1 and Confluent Platform from 5.5.2 to 6.2.2
* Updated `flink-test-utils-parent/flink-test-utils-junit/src/main/java/org/apache/flink/util/DockerImageVersions.java` testcontainers version for Confluent Platform from 6.2.1 to 6.2.2
* Updated `flink-formats/flink-sql-avro-confluent-registry/src/main/resources/META-INF/NOTICE` license information from 5.5.2 to 6.2.2 for Kafka Client dependencies

## Verifying this change

This change is a trivial rework / code cleanup without any test coverage.

## Does this pull request potentially affect one of the following parts:

  - Dependencies (does it add or upgrade a dependency): yes
  - The public API, i.e., is any changed class annotated with `@Public(Evolving)`: no
  - The serializers: no
  - The runtime per-record code paths (performance sensitive): no
  - Anything that affects deployment or recovery: JobManager (and its components), Checkpointing, Kubernetes/Yarn, ZooKeeper: no
  - The S3 file system connector: no

## Documentation

  - Does this pull request introduce a new feature? no
  - If yes, how is the feature documented? not applicable
