### PR TITLE
[FLINK-25390][table-common] Introduce ReloadableFactory and add validation code

### DIFF
--- a/flink-table/flink-table-common/src/main/java/org/apache/flink/table/factories/DecodingFormatFactory.java
+++ b/flink-table/flink-table-common/src/main/java/org/apache/flink/table/factories/DecodingFormatFactory.java
@@ -39,7 +39,7 @@ import org.apache.flink.table.connector.source.ScanTableSource;
  * @param <I> runtime interface needed by the table source
  */
 @PublicEvolving
-public interface DecodingFormatFactory<I> extends Factory {
+public interface DecodingFormatFactory<I> extends ReloadableFactory {
 
     /**
      * Creates a format from the given context and format options.

--- a/flink-table/flink-table-common/src/main/java/org/apache/flink/table/factories/DynamicTableFactory.java
+++ b/flink-table/flink-table-common/src/main/java/org/apache/flink/table/factories/DynamicTableFactory.java
@@ -43,7 +43,7 @@ import org.apache.flink.table.types.DataType;
  * implicitly added and must not be declared.
  */
 @PublicEvolving
-public interface DynamicTableFactory extends Factory {
+public interface DynamicTableFactory extends ReloadableFactory {
 
     /** Provides catalog and session information describing the dynamic table to be accessed. */
     @PublicEvolving

--- a/flink-table/flink-table-common/src/main/java/org/apache/flink/table/factories/EncodingFormatFactory.java
+++ b/flink-table/flink-table-common/src/main/java/org/apache/flink/table/factories/EncodingFormatFactory.java
@@ -37,7 +37,7 @@ import org.apache.flink.table.connector.sink.DynamicTableSink;
  * @param <I> runtime interface needed by the table sink
  */
 @PublicEvolving
-public interface EncodingFormatFactory<I> extends Factory {
+public interface EncodingFormatFactory<I> extends ReloadableFactory {
 
     /**
      * Creates a format from the given context and format options.

--- a/flink-table/flink-table-common/src/main/java/org/apache/flink/table/factories/Factory.java
+++ b/flink-table/flink-table-common/src/main/java/org/apache/flink/table/factories/Factory.java
@@ -72,7 +72,7 @@ public interface Factory {
      * Returns a set of {@link ConfigOption} that an implementation of this factory requires in
      * addition to {@link #optionalOptions()}.
      *
-     * <p>See the documentation of {@link Factory} for more information.
+     * @see Factory
      */
     Set<ConfigOption<?>> requiredOptions();
 
@@ -80,7 +80,7 @@ public interface Factory {
      * Returns a set of {@link ConfigOption} that an implementation of this factory consumes in
      * addition to {@link #requiredOptions()}.
      *
-     * <p>See the documentation of {@link Factory} for more information.
+     * @see Factory
      */
     Set<ConfigOption<?>> optionalOptions();
 }

--- a/flink-table/flink-table-common/src/main/java/org/apache/flink/table/factories/FactoryUtil.java
+++ b/flink-table/flink-table-common/src/main/java/org/apache/flink/table/factories/FactoryUtil.java
@@ -499,6 +499,22 @@ public final class FactoryUtil {
      */
     public static void validateFactoryOptions(Factory factory, ReadableConfig options) {
         validateFactoryOptions(factory.requiredOptions(), factory.optionalOptions(), options);
+
+        if (factory instanceof ReloadableFactory) {
+            // Validate that mutableOptionKeys are all included within either requiredOptions or
+            // optionalOptions
+            Set<String> definedOptionKeys =
+                    Stream.concat(
+                                    factory.requiredOptions().stream(),
+                                    factory.optionalOptions().stream())
+                            .map(ConfigOption::key)
+                            .collect(Collectors.toSet());
+            if (!definedOptionKeys.containsAll(((ReloadableFactory) factory).mutableOptionKeys())) {
+                throw new TableException(
+                        "One or more mutable options are not defined among required or optional options. "
+                                + "This is a Factory bug, please contact the developers.");
+            }
+        }
     }
 
     /**

--- a/flink-table/flink-table-common/src/main/java/org/apache/flink/table/factories/ReloadableFactory.java
+++ b/flink-table/flink-table-common/src/main/java/org/apache/flink/table/factories/ReloadableFactory.java
@@ -1,0 +1,46 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.flink.table.factories;
+
+import org.apache.flink.annotation.PublicEvolving;
+import org.apache.flink.configuration.ConfigOption;
+
+import java.util.Collections;
+import java.util.Set;
+
+/**
+ * Extension of the {@link Factory} interface containing information required to reload the built
+ * objects from a stored plan.
+ *
+ * @see <a href="https://cwiki.apache.org/confluence/x/KZBnCw">FLIP-190</a>
+ */
+@PublicEvolving
+public interface ReloadableFactory extends Factory {
+
+    /**
+     * Returns a set of {@link ConfigOption} keys that can be safely mutated when redeploying a
+     * query plan across Flink versions, e.g. options that don't mutate the query plan.
+     *
+     * <p>Each entry of the returned set must correspond to a key (and not a fallback key) of a
+     * {@link ConfigOption} either in {@link #requiredOptions()} or in {@link #optionalOptions()}.
+     */
+    default Set<String> mutableOptionKeys() {
+        return Collections.emptySet();
+    }
+}


### PR DESCRIPTION
## What is the purpose of the change

Introduce a sub interface of `Factory` that includes a method to define which option keys can be mutated across redeployments over different flink versions

## Brief change log

* Add `ReloadableFactory`
* Add validation code in `FactoryUtil`

## Verifying this change

TODO

## Does this pull request potentially affect one of the following parts:

  - Dependencies (does it add or upgrade a dependency): no
  - The public API, i.e., is any changed class annotated with `@Public(Evolving)`: yes
  - The serializers: no
  - The runtime per-record code paths (performance sensitive): no
  - Anything that affects deployment or recovery: JobManager (and its components), Checkpointing, Kubernetes/Yarn, ZooKeeper: no
  - The S3 file system connector: no

## Documentation

  - Does this pull request introduce a new feature? yes
  - If yes, how is the feature documented? JavaDocs
