### PR TITLE
[FLINK-25526][table-common] Deprecate the interfaces of the old factory stack

### DIFF
--- a/flink-table/flink-table-common/src/main/java/org/apache/flink/table/factories/DeserializationSchemaFactory.java
+++ b/flink-table/flink-table-common/src/main/java/org/apache/flink/table/factories/DeserializationSchemaFactory.java
@@ -27,7 +27,10 @@ import java.util.Map;
  * Factory for creating configured instances of {@link DeserializationSchema}.
  *
  * @param <T> record type that the format produces or consumes.
+ * @deprecated This interface has been replaced by {@link DeserializationFormatFactory}, used in the
+ *     new sink/source stack. See FLIP-95 for more information.
  */
+@Deprecated
 @PublicEvolving
 public interface DeserializationSchemaFactory<T> extends TableFormatFactory<T> {
 

--- a/flink-table/flink-table-common/src/main/java/org/apache/flink/table/factories/SerializationSchemaFactory.java
+++ b/flink-table/flink-table-common/src/main/java/org/apache/flink/table/factories/SerializationSchemaFactory.java
@@ -27,7 +27,10 @@ import java.util.Map;
  * Factory for creating configured instances of {@link SerializationSchema}.
  *
  * @param <T> record type that the format produces or consumes.
+ * @deprecated This interface has been replaced by {@link SerializationFormatFactory}, used in the
+ *     new sink/source stack. See FLIP-95 for more information.
  */
+@Deprecated
 @PublicEvolving
 public interface SerializationSchemaFactory<T> extends TableFormatFactory<T> {
 

--- a/flink-table/flink-table-common/src/main/java/org/apache/flink/table/factories/TableFactory.java
+++ b/flink-table/flink-table-common/src/main/java/org/apache/flink/table/factories/TableFactory.java
@@ -33,8 +33,9 @@ import java.util.Map;
  * "META_INF/services/org.apache.flink.table.factories.TableFactory" file of a JAR file in the
  * current classpath to be found.
  *
- * @see TableFormatFactory
+ * @deprecated This interface has been replaced by {@link Factory}.
  */
+@Deprecated
 @PublicEvolving
 public interface TableFactory {
 

--- a/flink-table/flink-table-common/src/main/java/org/apache/flink/table/factories/TableFactoryService.java
+++ b/flink-table/flink-table-common/src/main/java/org/apache/flink/table/factories/TableFactoryService.java
@@ -43,6 +43,7 @@ import java.util.stream.Collectors;
 import static org.apache.flink.table.descriptors.ConnectorDescriptorValidator.CONNECTOR_PROPERTY_VERSION;
 
 /** Unified class to search for a {@link TableFactory} of provided type and properties. */
+@Deprecated
 @Internal
 public class TableFactoryService {
 

--- a/flink-table/flink-table-common/src/main/java/org/apache/flink/table/factories/TableFormatFactory.java
+++ b/flink-table/flink-table-common/src/main/java/org/apache/flink/table/factories/TableFormatFactory.java
@@ -29,7 +29,10 @@ import java.util.List;
  * @see DeserializationSchemaFactory
  * @see SerializationSchemaFactory
  * @param <T> record type that the format produces or consumes.
+ * @deprecated This interface has been replaced by {@link EncodingFormatFactory} and {@link
+ *     DecodingFormatFactory}, used in the new sink/source stack. See FLIP-95 for more information.
  */
+@Deprecated
 @PublicEvolving
 public interface TableFormatFactory<T> extends TableFactory {
 

--- a/flink-table/flink-table-common/src/main/java/org/apache/flink/table/factories/TableFormatFactoryBase.java
+++ b/flink-table/flink-table-common/src/main/java/org/apache/flink/table/factories/TableFormatFactoryBase.java
@@ -40,7 +40,11 @@ import static org.apache.flink.table.descriptors.DescriptorProperties.WATERMARK_
  * Base class for {@link TableFormatFactory}s.
  *
  * @param <T> record type that the format produces or consumes.
+ * @deprecated This base class is not required anymore, implement either {@link
+ *     DynamicTableSourceFactory} or {@link DynamicTableSinkFactory} directly. See FLIP-95 for more
+ *     information.
  */
+@Deprecated
 @PublicEvolving
 public abstract class TableFormatFactoryBase<T> implements TableFormatFactory<T> {
 

--- a/flink-table/flink-table-common/src/main/java/org/apache/flink/table/factories/TableSinkFactory.java
+++ b/flink-table/flink-table-common/src/main/java/org/apache/flink/table/factories/TableSinkFactory.java
@@ -33,7 +33,10 @@ import java.util.Map;
  * string-based properties. See also {@link TableFactory} for more information.
  *
  * @param <T> type of records that the factory produces
+ * @deprecated This interface has been replaced by {@link DynamicTableSinkFactory}. The new
+ *     interface consumes internal data structures. See FLIP-95 for more information.
  */
+@Deprecated
 @PublicEvolving
 public interface TableSinkFactory<T> extends TableFactory {
 

--- a/flink-table/flink-table-common/src/main/java/org/apache/flink/table/factories/TableSinkFactoryContextImpl.java
+++ b/flink-table/flink-table-common/src/main/java/org/apache/flink/table/factories/TableSinkFactoryContextImpl.java
@@ -26,6 +26,7 @@ import org.apache.flink.table.catalog.ObjectIdentifier;
 import static org.apache.flink.util.Preconditions.checkNotNull;
 
 /** Implementation of {@link TableSinkFactory.Context}. */
+@Deprecated
 @Internal
 public class TableSinkFactoryContextImpl implements TableSinkFactory.Context {
 

--- a/flink-table/flink-table-common/src/main/java/org/apache/flink/table/factories/TableSourceFactory.java
+++ b/flink-table/flink-table-common/src/main/java/org/apache/flink/table/factories/TableSourceFactory.java
@@ -32,7 +32,10 @@ import java.util.Map;
  * string-based properties. See also {@link TableFactory} for more information.
  *
  * @param <T> type of records that the factory produces
+ * @deprecated This interface has been replaced by {@link DynamicTableSourceFactory}. The new
+ *     interface produces internal data structures. See FLIP-95 for more information.
  */
+@Deprecated
 @PublicEvolving
 public interface TableSourceFactory<T> extends TableFactory {
 

--- a/flink-table/flink-table-common/src/main/java/org/apache/flink/table/factories/TableSourceFactoryContextImpl.java
+++ b/flink-table/flink-table-common/src/main/java/org/apache/flink/table/factories/TableSourceFactoryContextImpl.java
@@ -26,6 +26,7 @@ import org.apache.flink.table.catalog.ObjectIdentifier;
 import static org.apache.flink.util.Preconditions.checkNotNull;
 
 /** Implementation of {@link TableSourceFactory.Context}. */
+@Deprecated
 @Internal
 public class TableSourceFactoryContextImpl implements TableSourceFactory.Context {
 

--- a/flink-table/flink-table-common/src/main/java/org/apache/flink/table/sinks/TableSink.java
+++ b/flink-table/flink-table-common/src/main/java/org/apache/flink/table/sinks/TableSink.java
@@ -37,6 +37,7 @@ import static org.apache.flink.table.types.utils.TypeConversions.fromLegacyInfoT
  * @deprecated This interface has been replaced by {@link DynamicTableSink}. The new interface
  *     consumes internal data structures. See FLIP-95 for more information.
  */
+@Deprecated
 @PublicEvolving
 public interface TableSink<T> {
 

--- a/flink-table/flink-table-common/src/main/java/org/apache/flink/table/sinks/TableSinkBase.java
+++ b/flink-table/flink-table-common/src/main/java/org/apache/flink/table/sinks/TableSinkBase.java
@@ -20,6 +20,7 @@ package org.apache.flink.table.sinks;
 
 import org.apache.flink.annotation.Internal;
 import org.apache.flink.api.common.typeinfo.TypeInformation;
+import org.apache.flink.table.connector.sink.DynamicTableSink;
 
 import java.util.Optional;
 
@@ -27,7 +28,10 @@ import java.util.Optional;
  * Base class for {@link TableSink}.
  *
  * @param <T> The return type of the {@link TableSinkBase}.
+ * @deprecated This class is implementing the deprecated {@link TableSink} interface. Implement
+ *     {@link DynamicTableSink} directly instead.
  */
+@Deprecated
 @Internal
 public abstract class TableSinkBase<T> implements TableSink<T> {
 


### PR DESCRIPTION
## What is the purpose of the change

Deprecate the interfaces and related classes of the old factory stack and source/sink stack  

## Brief change log

* Deprecate interfaces

## Verifying this change

This change is a trivial rework / code cleanup without any test coverage.

## Does this pull request potentially affect one of the following parts:

  - Dependencies (does it add or upgrade a dependency): no
  - The public API, i.e., is any changed class annotated with `@Public(Evolving)`: yes
  - The serializers: no
  - The runtime per-record code paths (performance sensitive): no
  - Anything that affects deployment or recovery: JobManager (and its components), Checkpointing, Kubernetes/Yarn, ZooKeeper: no
  - The S3 file system connector: no

## Documentation

  - Does this pull request introduce a new feature? no
  - If yes, how is the feature documented? not applicable
