### PR TITLE
[FLINK-25525][FLINK-25487][table] Various fixed related to the new planner-loader

### DIFF
--- a/flink-core/src/main/java/org/apache/flink/core/classloading/SubmoduleClassLoader.java
+++ b/flink-core/src/main/java/org/apache/flink/core/classloading/SubmoduleClassLoader.java
@@ -20,6 +20,7 @@ package org.apache.flink.core.classloading;
 import org.apache.flink.configuration.CoreOptions;
 
 import java.net.URL;
+import java.util.Collections;
 
 /**
  * Loads all classes from the submodule jar, except for explicitly white-listed packages.
@@ -39,6 +40,7 @@ public class SubmoduleClassLoader extends ComponentClassLoader {
                 classpath,
                 parentClassLoader,
                 CoreOptions.PARENT_FIRST_LOGGING_PATTERNS,
-                new String[] {"org.apache.flink"});
+                new String[] {"org.apache.flink"},
+                Collections.emptyMap());
     }
 }

--- a/flink-core/src/main/java/org/apache/flink/core/plugin/PluginLoader.java
+++ b/flink-core/src/main/java/org/apache/flink/core/plugin/PluginLoader.java
@@ -31,6 +31,7 @@ import javax.annotation.concurrent.ThreadSafe;
 import java.io.IOException;
 import java.net.URL;
 import java.net.URLClassLoader;
+import java.util.Collections;
 import java.util.Iterator;
 import java.util.ServiceLoader;
 
@@ -151,7 +152,12 @@ public class PluginLoader implements AutoCloseable {
                 URL[] pluginResourceURLs,
                 ClassLoader flinkClassLoader,
                 String[] allowedFlinkPackages) {
-            super(pluginResourceURLs, flinkClassLoader, allowedFlinkPackages, new String[0]);
+            super(
+                    pluginResourceURLs,
+                    flinkClassLoader,
+                    allowedFlinkPackages,
+                    new String[0],
+                    Collections.emptyMap());
         }
     }
 }

--- a/flink-core/src/test/java/org/apache/flink/core/classloading/ComponentClassLoaderTest.java
+++ b/flink-core/src/test/java/org/apache/flink/core/classloading/ComponentClassLoaderTest.java
@@ -67,7 +67,8 @@ public class ComponentClassLoaderTest extends TestLogger {
                 new TestUrlClassLoader(NON_EXISTENT_CLASS_NAME, CLASS_RETURNED_BY_OWNER);
 
         final ComponentClassLoader componentClassLoader =
-                new ComponentClassLoader(new URL[0], owner, new String[0], new String[0]);
+                new ComponentClassLoader(
+                        new URL[0], owner, new String[0], new String[0], Collections.emptyMap());
 
         componentClassLoader.loadClass(NON_EXISTENT_CLASS_NAME);
     }
@@ -79,7 +80,11 @@ public class ComponentClassLoaderTest extends TestLogger {
 
         final ComponentClassLoader componentClassLoader =
                 new ComponentClassLoader(
-                        new URL[0], owner, new String[] {CLASS_TO_LOAD.getName()}, new String[0]);
+                        new URL[0],
+                        owner,
+                        new String[] {CLASS_TO_LOAD.getName()},
+                        new String[0],
+                        Collections.emptyMap());
 
         final Class<?> loadedClass = componentClassLoader.loadClass(CLASS_TO_LOAD.getName());
         assertThat(loadedClass, sameInstance(CLASS_RETURNED_BY_OWNER));
@@ -91,7 +96,11 @@ public class ComponentClassLoaderTest extends TestLogger {
 
         final ComponentClassLoader componentClassLoader =
                 new ComponentClassLoader(
-                        new URL[0], owner, new String[] {CLASS_TO_LOAD.getName()}, new String[0]);
+                        new URL[0],
+                        owner,
+                        new String[] {CLASS_TO_LOAD.getName()},
+                        new String[0],
+                        Collections.emptyMap());
 
         final Class<?> loadedClass = componentClassLoader.loadClass(CLASS_TO_LOAD.getName());
         assertThat(loadedClass, sameInstance(CLASS_TO_LOAD));
@@ -104,7 +113,11 @@ public class ComponentClassLoaderTest extends TestLogger {
 
         final ComponentClassLoader componentClassLoader =
                 new ComponentClassLoader(
-                        new URL[0], owner, new String[0], new String[] {CLASS_TO_LOAD.getName()});
+                        new URL[0],
+                        owner,
+                        new String[0],
+                        new String[] {CLASS_TO_LOAD.getName()},
+                        Collections.emptyMap());
 
         final Class<?> loadedClass = componentClassLoader.loadClass(CLASS_TO_LOAD.getName());
         assertThat(loadedClass, sameInstance(CLASS_TO_LOAD));
@@ -117,7 +130,11 @@ public class ComponentClassLoaderTest extends TestLogger {
 
         final ComponentClassLoader componentClassLoader =
                 new ComponentClassLoader(
-                        new URL[0], owner, new String[0], new String[] {NON_EXISTENT_CLASS_NAME});
+                        new URL[0],
+                        owner,
+                        new String[0],
+                        new String[] {NON_EXISTENT_CLASS_NAME},
+                        Collections.emptyMap());
 
         final Class<?> loadedClass = componentClassLoader.loadClass(NON_EXISTENT_CLASS_NAME);
         assertThat(loadedClass, sameInstance(CLASS_RETURNED_BY_OWNER));
@@ -132,7 +149,8 @@ public class ComponentClassLoaderTest extends TestLogger {
         TestUrlClassLoader owner = new TestUrlClassLoader();
 
         final ComponentClassLoader componentClassLoader =
-                new ComponentClassLoader(new URL[0], owner, new String[0], new String[0]);
+                new ComponentClassLoader(
+                        new URL[0], owner, new String[0], new String[0], Collections.emptyMap());
 
         assertThat(componentClassLoader.getResource(NON_EXISTENT_RESOURCE_NAME), nullValue());
         assertThat(
@@ -147,7 +165,11 @@ public class ComponentClassLoaderTest extends TestLogger {
 
         final ComponentClassLoader componentClassLoader =
                 new ComponentClassLoader(
-                        new URL[] {}, owner, new String[] {resourceToLoad}, new String[0]);
+                        new URL[] {},
+                        owner,
+                        new String[] {resourceToLoad},
+                        new String[0],
+                        Collections.emptyMap());
 
         final URL loadedResource = componentClassLoader.getResource(resourceToLoad);
         assertThat(loadedResource, sameInstance(RESOURCE_RETURNED_BY_OWNER));
@@ -162,7 +184,8 @@ public class ComponentClassLoaderTest extends TestLogger {
                         new URL[] {TMP.getRoot().toURI().toURL()},
                         owner,
                         new String[] {resourceToLoad},
-                        new String[0]);
+                        new String[0],
+                        Collections.emptyMap());
 
         final URL loadedResource = componentClassLoader.getResource(resourceToLoad);
         assertThat(loadedResource.toString(), containsString(resourceToLoad));
@@ -178,7 +201,8 @@ public class ComponentClassLoaderTest extends TestLogger {
                         new URL[] {TMP.getRoot().toURI().toURL()},
                         owner,
                         new String[0],
-                        new String[] {resourceToLoad});
+                        new String[] {resourceToLoad},
+                        Collections.emptyMap());
 
         final URL loadedResource = componentClassLoader.getResource(resourceToLoad);
         assertThat(loadedResource.toString(), containsString(resourceToLoad));
@@ -194,7 +218,8 @@ public class ComponentClassLoaderTest extends TestLogger {
                         new URL[0],
                         owner,
                         new String[0],
-                        new String[] {NON_EXISTENT_RESOURCE_NAME});
+                        new String[] {NON_EXISTENT_RESOURCE_NAME},
+                        Collections.emptyMap());
 
         final URL loadedResource = componentClassLoader.getResource(NON_EXISTENT_RESOURCE_NAME);
         assertThat(loadedResource, sameInstance(RESOURCE_RETURNED_BY_OWNER));

--- a/flink-examples/flink-examples-table/pom.xml
+++ b/flink-examples/flink-examples-table/pom.xml
@@ -52,6 +52,29 @@ under the License.
 			<artifactId>flink-table-api-scala-bridge_${scala.binary.version}</artifactId>
 			<version>${project.version}</version>
 		</dependency>
+		<!-- The following two dependencies are not required to define a SQL job pipeline,
+		but only to execute it.
+
+		In particular, here we're forced to use flink-table-planner_${scala.binary.version} instead of
+		flink-table-planner-loader, because otherwise we hit this bug https://youtrack.jetbrains.com/issue/IDEA-93855
+		when trying to run the examples from within Intellij IDEA. This is only relevant to this specific
+		examples project, as it's in the same build tree of flink-parent.
+
+		In a real environment, you need flink-table-runtime and flink-table-planner-loader either
+		at test scope, for executing tests, or at provided scope, to run the main directly.
+		 -->
+		<dependency>
+			<groupId>org.apache.flink</groupId>
+			<artifactId>flink-table-runtime</artifactId>
+			<version>${project.version}</version>
+			<scope>provided</scope>
+		</dependency>
+		<dependency>
+			<groupId>org.apache.flink</groupId>
+			<artifactId>flink-table-planner_${scala.binary.version}</artifactId>
+			<version>${project.version}</version>
+			<scope>provided</scope>
+		</dependency>
 
 		<!-- Table connectors and formats -->
 		<dependency>
@@ -69,18 +92,6 @@ under the License.
 		<dependency>
 			<groupId>org.apache.flink</groupId>
 			<artifactId>flink-test-utils</artifactId>
-			<version>${project.version}</version>
-			<scope>test</scope>
-		</dependency>
-		<dependency>
-			<groupId>org.apache.flink</groupId>
-			<artifactId>flink-table-runtime</artifactId>
-			<version>${project.version}</version>
-			<scope>test</scope>
-		</dependency>
-		<dependency>
-			<groupId>org.apache.flink</groupId>
-			<artifactId>flink-table-planner-loader</artifactId>
 			<version>${project.version}</version>
 			<scope>test</scope>
 		</dependency>

--- a/flink-python/src/main/java/org/apache/flink/python/env/beam/ProcessPythonEnvironmentManager.java
+++ b/flink-python/src/main/java/org/apache/flink/python/env/beam/ProcessPythonEnvironmentManager.java
@@ -35,7 +35,6 @@ import org.apache.flink.util.function.FunctionWithException;
 
 import org.apache.flink.shaded.guava30.com.google.common.base.Strings;
 
-import org.codehaus.commons.nullanalysis.NotNull;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
@@ -96,16 +95,16 @@ public final class ProcessPythonEnvironmentManager implements PythonEnvironmentM
 
     private transient PythonEnvResources.PythonLeasedResource resource;
 
-    @NotNull private final PythonDependencyInfo dependencyInfo;
-    @NotNull private final Map<String, String> systemEnv;
-    @NotNull private final String[] tmpDirectories;
-    @NotNull private final JobID jobID;
+    private final PythonDependencyInfo dependencyInfo;
+    private final Map<String, String> systemEnv;
+    private final String[] tmpDirectories;
+    private final JobID jobID;
 
     public ProcessPythonEnvironmentManager(
-            @NotNull PythonDependencyInfo dependencyInfo,
-            @NotNull String[] tmpDirectories,
-            @NotNull Map<String, String> systemEnv,
-            @NotNull JobID jobID) {
+            PythonDependencyInfo dependencyInfo,
+            String[] tmpDirectories,
+            Map<String, String> systemEnv,
+            JobID jobID) {
         this.dependencyInfo = Objects.requireNonNull(dependencyInfo);
         this.tmpDirectories = Objects.requireNonNull(tmpDirectories);
         this.systemEnv = Objects.requireNonNull(systemEnv);

--- a/flink-table/flink-table-planner/pom.xml
+++ b/flink-table/flink-table-planner/pom.xml
@@ -102,15 +102,6 @@ under the License.
 			<version>${project.version}</version>
 		</dependency>
 
-		<!-- Flink dependencies (not included in the uber) -->
-
-		<dependency>
-			<groupId>org.apache.flink</groupId>
-			<artifactId>flink-cep</artifactId>
-			<version>${project.version}</version>
-			<scope>provided</scope>
-		</dependency>
-
 		<!-- Other 3rd party dependencies (included in the uber) -->
 
 		<dependency>
@@ -341,6 +332,7 @@ under the License.
 				<configuration>
 					<!-- Base config -->
 					<createDependencyReducedPom>true</createDependencyReducedPom>
+					<keepDependenciesWithProvidedScope>false</keepDependenciesWithProvidedScope>
 					<dependencyReducedPomLocation>${project.basedir}/target/dependency-reduced-pom.xml</dependencyReducedPomLocation>
 					<filters combine.children="append">
 						<filter>
@@ -398,14 +390,6 @@ under the License.
 							<shadedPattern>org.apache.flink.calcite.shaded.com.google</shadedPattern>
 						</relocation>
 						<relocation>
-							<pattern>com.jayway</pattern>
-							<shadedPattern>org.apache.flink.calcite.shaded.com.jayway</shadedPattern>
-						</relocation>
-						<relocation>
-							<pattern>com.fasterxml</pattern>
-							<shadedPattern>org.apache.flink.shaded.jackson2.com.fasterxml</shadedPattern>
-						</relocation>
-						<relocation>
 							<pattern>org.apache.commons.codec</pattern>
 							<shadedPattern>org.apache.flink.calcite.shaded.org.apache.commons.codec</shadedPattern>
 						</relocation>
@@ -414,11 +398,23 @@ under the License.
 							<shadedPattern>org.apache.flink.calcite.shaded.org.apache.commons.io</shadedPattern>
 						</relocation>
 
+						<!-- These are relocated to match package names, but not included in this jar -->
+						<relocation>
+							<pattern>com.fasterxml</pattern>
+							<!-- From flink-shaded-jackson -->
+							<shadedPattern>org.apache.flink.shaded.jackson2.com.fasterxml</shadedPattern>
+						</relocation>
+						<relocation>
+							<pattern>com.jayway</pattern>
+							<!-- From flink-table-runtime -->
+							<shadedPattern>org.apache.flink.table.shaded.com.jayway</shadedPattern>
+						</relocation>
+
+						<!-- Other table dependencies -->
 						<relocation>
 							<pattern>org.reflections</pattern>
 							<shadedPattern>org.apache.flink.table.shaded.org.reflections</shadedPattern>
 						</relocation>
-
 						<relocation>
 							<!-- icu4j's dependencies -->
 							<pattern>com.ibm.icu</pattern>

--- a/flink-table/flink-table-runtime/pom.xml
+++ b/flink-table/flink-table-runtime/pom.xml
@@ -146,6 +146,7 @@ under the License.
 							<goal>shade</goal>
 						</goals>
 						<configuration>
+							<keepDependenciesWithProvidedScope>false</keepDependenciesWithProvidedScope>
 							<artifactSet>
 								<includes combine.children="append">
 									<include>com.jayway.jsonpath:json-path</include>
@@ -157,7 +158,7 @@ under the License.
 								<!-- Make sure com.jayway and com.fasterxml relocations match the relocations in planner pom  -->
 								<relocation>
 									<pattern>com.jayway</pattern>
-									<shadedPattern>org.apache.flink.calcite.shaded.com.jayway</shadedPattern>
+									<shadedPattern>org.apache.flink.table.shaded.com.jayway</shadedPattern>
 								</relocation>
 								<relocation>
 									<pattern>com.fasterxml</pattern>


### PR DESCRIPTION
## What is the purpose of the change

This PR contains a couple of fixes and leftovers from the planner-loader PR.

## Brief change log

* Fix FLINK-25525
* Fix FLINK-25487
* Fix bad shading path for com.jayway

## Verifying this change

This change is a trivial rework / code cleanup without any test coverage.

## Does this pull request potentially affect one of the following parts:

  - Dependencies (does it add or upgrade a dependency): no
  - The public API, i.e., is any changed class annotated with `@Public(Evolving)`: no
  - The serializers: no
  - The runtime per-record code paths (performance sensitive): no
  - Anything that affects deployment or recovery: JobManager (and its components), Checkpointing, Kubernetes/Yarn, ZooKeeper: no
  - The S3 file system connector: no

## Documentation

  - Does this pull request introduce a new feature? no
  - If yes, how is the feature documented? not applicable
