### PR TITLE
[FLINK-25536] Adjust the order of variable declaration and…

### DIFF
--- a/flink-runtime/src/main/java/org/apache/flink/runtime/checkpoint/StateAssignmentOperation.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/checkpoint/StateAssignmentOperation.java
@@ -91,13 +91,13 @@ public class StateAssignmentOperation {
         this.tasks = Preconditions.checkNotNull(tasks);
         this.operatorStates = Preconditions.checkNotNull(operatorStates);
         this.allowNonRestoredState = allowNonRestoredState;
-        vertexAssignments = new HashMap<>(tasks.size());
+        this.vertexAssignments = new HashMap<>(tasks.size());
     }
 
     public void assignStates() {
-        Map<OperatorID, OperatorState> localOperators = new HashMap<>(operatorStates);
-
         checkStateMappingCompleteness(allowNonRestoredState, operatorStates, tasks);
+
+        Map<OperatorID, OperatorState> localOperators = new HashMap<>(operatorStates);
 
         // find the states of all operators belonging to this task and compute additional
         // information in first pass
@@ -167,7 +167,7 @@ public class StateAssignmentOperation {
          * 		parallelism0 parallelism1 parallelism2
          * op0   states0,0    state0,1	   state0,2
          * op1
-         * op2   states2,0    state2,1	   state1,2
+         * op2   states2,0    state2,1	   state2,2
          * op3   states3,0    state3,1     state3,2
          *
          * The new ManagedOperatorStates with new parallelism 4:
@@ -712,11 +712,13 @@ public class StateAssignmentOperation {
         }
         for (Map.Entry<OperatorID, OperatorState> operatorGroupStateEntry :
                 operatorStates.entrySet()) {
-            OperatorState operatorState = operatorGroupStateEntry.getValue();
             // ----------------------------------------find operator for
             // state---------------------------------------------
 
             if (!allOperatorIDs.contains(operatorGroupStateEntry.getKey())) {
+
+                OperatorState operatorState = operatorGroupStateEntry.getValue();
+
                 if (allowNonRestoredState) {
                     LOG.info(
                             "Skipped checkpoint state for operator {}.",


### PR DESCRIPTION
… comment in StateAssignmentOperation


## What is the purpose of the change

Just to adjust the order of variable declaration and comment in StateAssignmentOperation

## Brief change log



## Verifying this change



## Does this pull request potentially affect one of the following parts:


## Documentation
