### PR TITLE
[FLINK-25390][table] Add API to support merging options from catalog table

### DIFF
--- a/flink-connectors/flink-connector-elasticsearch-base/src/test/java/org/apache/flink/connector/elasticsearch/table/TestContext.java
+++ b/flink-connectors/flink-connector-elasticsearch-base/src/test/java/org/apache/flink/connector/elasticsearch/table/TestContext.java
@@ -59,6 +59,7 @@ class TestContext {
                                 Collections.emptyList(),
                                 options),
                         schema),
+                Collections.emptyMap(),
                 new Configuration(),
                 TestContext.class.getClassLoader(),
                 false);

--- a/flink-connectors/flink-connector-kafka/src/main/java/org/apache/flink/streaming/connectors/kafka/table/KafkaConnectorOptionsUtil.java
+++ b/flink-connectors/flink-connector-kafka/src/main/java/org/apache/flink/streaming/connectors/kafka/table/KafkaConnectorOptionsUtil.java
@@ -519,6 +519,7 @@ class KafkaConnectorOptionsUtil {
             return new FactoryUtil.DefaultDynamicTableContext(
                     context.getObjectIdentifier(),
                     context.getCatalogTable().copy(newOptions),
+                    context.mergeableOptions(),
                     context.getConfiguration(),
                     context.getClassLoader(),
                     context.isTemporary());

--- a/flink-connectors/flink-connector-kafka/src/main/java/org/apache/flink/streaming/connectors/kafka/table/KafkaConnectorOptionsUtil.java
+++ b/flink-connectors/flink-connector-kafka/src/main/java/org/apache/flink/streaming/connectors/kafka/table/KafkaConnectorOptionsUtil.java
@@ -519,7 +519,7 @@ class KafkaConnectorOptionsUtil {
             return new FactoryUtil.DefaultDynamicTableContext(
                     context.getObjectIdentifier(),
                     context.getCatalogTable().copy(newOptions),
-                    context.mergeableOptions(),
+                    context.getEnrichmentOptions(),
                     context.getConfiguration(),
                     context.getClassLoader(),
                     context.isTemporary());

--- a/flink-connectors/flink-connector-kafka/src/main/java/org/apache/flink/streaming/connectors/kafka/table/KafkaDynamicTableFactory.java
+++ b/flink-connectors/flink-connector-kafka/src/main/java/org/apache/flink/streaming/connectors/kafka/table/KafkaDynamicTableFactory.java
@@ -145,16 +145,22 @@ public class KafkaDynamicTableFactory
     }
 
     @Override
+    public Set<ConfigOption<?>> forwardOptions() {
+        final Set<ConfigOption<?>> options = new HashSet<>();
+        options.add(TOPIC);
+        options.add(TOPIC_PATTERN);
+        options.add(SCAN_STARTUP_MODE);
+        options.add(SCAN_STARTUP_SPECIFIC_OFFSETS);
+        options.add(SCAN_TOPIC_PARTITION_DISCOVERY);
+        options.add(SCAN_STARTUP_TIMESTAMP_MILLIS);
+        return options;
+    }
+
+    @Override
     public DynamicTableSource createDynamicTableSource(Context context) {
         final TableFactoryHelper helper = FactoryUtil.createTableFactoryHelper(this, context);
 
-        helper.forwardOptions(
-                TOPIC,
-                TOPIC_PATTERN,
-                SCAN_STARTUP_MODE,
-                SCAN_STARTUP_SPECIFIC_OFFSETS,
-                SCAN_TOPIC_PARTITION_DISCOVERY,
-                SCAN_STARTUP_TIMESTAMP_MILLIS);
+        helper.forwardOptions();
 
         final Optional<DecodingFormat<DeserializationSchema<RowData>>> keyDecodingFormat =
                 getKeyDecodingFormat(helper);
@@ -215,15 +221,7 @@ public class KafkaDynamicTableFactory
                 FactoryUtil.createTableFactoryHelper(
                         this, autoCompleteSchemaRegistrySubject(context));
 
-        final ReadableConfig tableOptions =
-                helper.forwardOptions(
-                                TOPIC,
-                                TOPIC_PATTERN,
-                                SCAN_STARTUP_MODE,
-                                SCAN_STARTUP_SPECIFIC_OFFSETS,
-                                SCAN_TOPIC_PARTITION_DISCOVERY,
-                                SCAN_STARTUP_TIMESTAMP_MILLIS)
-                        .getOptions();
+        helper.forwardOptions();
 
         final Optional<EncodingFormat<SerializationSchema<RowData>>> keyEncodingFormat =
                 getKeyEncodingFormat(helper);
@@ -232,6 +230,8 @@ public class KafkaDynamicTableFactory
                 getValueEncodingFormat(helper);
 
         helper.validateExcept(PROPERTIES_PREFIX);
+
+        final ReadableConfig tableOptions = helper.getOptions();
 
         final DeliveryGuarantee deliveryGuarantee = validateDeprecatedSemantic(tableOptions);
         validateTableSinkOptions(tableOptions);

--- a/flink-connectors/flink-connector-kafka/src/main/java/org/apache/flink/streaming/connectors/kafka/table/KafkaDynamicTableFactory.java
+++ b/flink-connectors/flink-connector-kafka/src/main/java/org/apache/flink/streaming/connectors/kafka/table/KafkaDynamicTableFactory.java
@@ -148,15 +148,13 @@ public class KafkaDynamicTableFactory
     public DynamicTableSource createDynamicTableSource(Context context) {
         final TableFactoryHelper helper = FactoryUtil.createTableFactoryHelper(this, context);
 
-        final ReadableConfig tableOptions =
-                helper.forwardOptions(
-                                TOPIC,
-                                TOPIC_PATTERN,
-                                SCAN_STARTUP_MODE,
-                                SCAN_STARTUP_SPECIFIC_OFFSETS,
-                                SCAN_TOPIC_PARTITION_DISCOVERY,
-                                SCAN_STARTUP_TIMESTAMP_MILLIS)
-                        .getOptions();
+        helper.forwardOptions(
+                TOPIC,
+                TOPIC_PATTERN,
+                SCAN_STARTUP_MODE,
+                SCAN_STARTUP_SPECIFIC_OFFSETS,
+                SCAN_TOPIC_PARTITION_DISCOVERY,
+                SCAN_STARTUP_TIMESTAMP_MILLIS);
 
         final Optional<DecodingFormat<DeserializationSchema<RowData>>> keyDecodingFormat =
                 getKeyDecodingFormat(helper);
@@ -165,6 +163,8 @@ public class KafkaDynamicTableFactory
                 getValueDecodingFormat(helper);
 
         helper.validateExcept(PROPERTIES_PREFIX);
+
+        final ReadableConfig tableOptions = helper.getOptions();
 
         validateTableSourceOptions(tableOptions);
 

--- a/flink-connectors/flink-connector-kafka/src/main/java/org/apache/flink/streaming/connectors/kafka/table/KafkaDynamicTableFactory.java
+++ b/flink-connectors/flink-connector-kafka/src/main/java/org/apache/flink/streaming/connectors/kafka/table/KafkaDynamicTableFactory.java
@@ -160,8 +160,6 @@ public class KafkaDynamicTableFactory
     public DynamicTableSource createDynamicTableSource(Context context) {
         final TableFactoryHelper helper = FactoryUtil.createTableFactoryHelper(this, context);
 
-        helper.forwardOptions();
-
         final Optional<DecodingFormat<DeserializationSchema<RowData>>> keyDecodingFormat =
                 getKeyDecodingFormat(helper);
 
@@ -220,8 +218,6 @@ public class KafkaDynamicTableFactory
         final TableFactoryHelper helper =
                 FactoryUtil.createTableFactoryHelper(
                         this, autoCompleteSchemaRegistrySubject(context));
-
-        helper.forwardOptions();
 
         final Optional<EncodingFormat<SerializationSchema<RowData>>> keyEncodingFormat =
                 getKeyEncodingFormat(helper);

--- a/flink-connectors/flink-connector-kafka/src/main/java/org/apache/flink/streaming/connectors/kafka/table/KafkaDynamicTableFactory.java
+++ b/flink-connectors/flink-connector-kafka/src/main/java/org/apache/flink/streaming/connectors/kafka/table/KafkaDynamicTableFactory.java
@@ -148,7 +148,15 @@ public class KafkaDynamicTableFactory
     public DynamicTableSource createDynamicTableSource(Context context) {
         final TableFactoryHelper helper = FactoryUtil.createTableFactoryHelper(this, context);
 
-        final ReadableConfig tableOptions = helper.getOptions();
+        final ReadableConfig tableOptions =
+                helper.forwardOptions(
+                                TOPIC,
+                                TOPIC_PATTERN,
+                                SCAN_STARTUP_MODE,
+                                SCAN_STARTUP_SPECIFIC_OFFSETS,
+                                SCAN_TOPIC_PARTITION_DISCOVERY,
+                                SCAN_STARTUP_TIMESTAMP_MILLIS)
+                        .getOptions();
 
         final Optional<DecodingFormat<DeserializationSchema<RowData>>> keyDecodingFormat =
                 getKeyDecodingFormat(helper);
@@ -207,7 +215,15 @@ public class KafkaDynamicTableFactory
                 FactoryUtil.createTableFactoryHelper(
                         this, autoCompleteSchemaRegistrySubject(context));
 
-        final ReadableConfig tableOptions = helper.getOptions();
+        final ReadableConfig tableOptions =
+                helper.forwardOptions(
+                                TOPIC,
+                                TOPIC_PATTERN,
+                                SCAN_STARTUP_MODE,
+                                SCAN_STARTUP_SPECIFIC_OFFSETS,
+                                SCAN_TOPIC_PARTITION_DISCOVERY,
+                                SCAN_STARTUP_TIMESTAMP_MILLIS)
+                        .getOptions();
 
         final Optional<EncodingFormat<SerializationSchema<RowData>>> keyEncodingFormat =
                 getKeyEncodingFormat(helper);

--- a/flink-formats/flink-json/src/main/java/org/apache/flink/formats/json/JsonFormatFactory.java
+++ b/flink-formats/flink-json/src/main/java/org/apache/flink/formats/json/JsonFormatFactory.java
@@ -153,7 +153,7 @@ public class JsonFormatFactory implements DeserializationFormatFactory, Serializ
     }
 
     @Override
-    public Set<ConfigOption<?>> mergeableOptions() {
+    public Set<ConfigOption<?>> forwardOptions() {
         Set<ConfigOption<?>> options = new HashSet<>();
         options.add(IGNORE_PARSE_ERRORS);
         options.add(TIMESTAMP_FORMAT);

--- a/flink-formats/flink-json/src/main/java/org/apache/flink/formats/json/JsonFormatFactory.java
+++ b/flink-formats/flink-json/src/main/java/org/apache/flink/formats/json/JsonFormatFactory.java
@@ -151,4 +151,15 @@ public class JsonFormatFactory implements DeserializationFormatFactory, Serializ
         options.add(ENCODE_DECIMAL_AS_PLAIN_NUMBER);
         return options;
     }
+
+    @Override
+    public Set<ConfigOption<?>> mergeableOptions() {
+        Set<ConfigOption<?>> options = new HashSet<>();
+        options.add(IGNORE_PARSE_ERRORS);
+        options.add(TIMESTAMP_FORMAT);
+        options.add(MAP_NULL_KEY_MODE);
+        options.add(MAP_NULL_KEY_LITERAL);
+        options.add(ENCODE_DECIMAL_AS_PLAIN_NUMBER);
+        return options;
+    }
 }

--- a/flink-formats/flink-json/src/test/java/org/apache/flink/formats/json/JsonFormatFactoryTest.java
+++ b/flink-formats/flink-json/src/test/java/org/apache/flink/formats/json/JsonFormatFactoryTest.java
@@ -26,37 +26,33 @@ import org.apache.flink.table.connector.sink.DynamicTableSink;
 import org.apache.flink.table.connector.source.DynamicTableSource;
 import org.apache.flink.table.data.RowData;
 import org.apache.flink.table.factories.TestDynamicTableFactory;
+import org.apache.flink.table.factories.utils.FactoryMocks;
 import org.apache.flink.table.runtime.connector.sink.SinkRuntimeProviderContext;
 import org.apache.flink.table.runtime.connector.source.ScanRuntimeProviderContext;
 import org.apache.flink.table.runtime.typeutils.InternalTypeInfo;
-import org.apache.flink.util.TestLogger;
 
-import org.junit.Rule;
-import org.junit.Test;
-import org.junit.rules.ExpectedException;
+import org.assertj.core.api.AbstractThrowableAssert;
+import org.junit.jupiter.api.Test;
 
 import java.util.HashMap;
 import java.util.Map;
 import java.util.function.Consumer;
 
-import static org.apache.flink.core.testutils.FlinkMatchers.containsCause;
+import static org.apache.flink.core.testutils.FlinkAssertions.anyCauseMatches;
 import static org.apache.flink.table.factories.utils.FactoryMocks.PHYSICAL_DATA_TYPE;
 import static org.apache.flink.table.factories.utils.FactoryMocks.PHYSICAL_TYPE;
 import static org.apache.flink.table.factories.utils.FactoryMocks.SCHEMA;
-import static org.apache.flink.table.factories.utils.FactoryMocks.createTableSink;
-import static org.apache.flink.table.factories.utils.FactoryMocks.createTableSource;
-import static org.junit.Assert.assertEquals;
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
 
 /** Tests for the {@link JsonFormatFactory}. */
-public class JsonFormatFactoryTest extends TestLogger {
-    @Rule public ExpectedException thrown = ExpectedException.none();
+public class JsonFormatFactoryTest {
 
     @Test
     public void testSeDeSchema() {
         final Map<String, String> tableOptions = getAllOptions();
 
         testSchemaSerializationSchema(tableOptions);
-
         testSchemaDeserializationSchema(tableOptions);
     }
 
@@ -65,12 +61,11 @@ public class JsonFormatFactoryTest extends TestLogger {
         final Map<String, String> tableOptions =
                 getModifyOptions(options -> options.put("json.fail-on-missing-field", "true"));
 
-        thrown.expect(ValidationException.class);
-        thrown.expect(
-                containsCause(
-                        new ValidationException(
-                                "fail-on-missing-field and ignore-parse-errors shouldn't both be true.")));
-        testSchemaDeserializationSchema(tableOptions);
+        assertThatCreateRuntimeDecoder(tableOptions)
+                .satisfies(
+                        anyCauseMatches(
+                                ValidationException.class,
+                                "fail-on-missing-field and ignore-parse-errors shouldn't both be true."));
     }
 
     @Test
@@ -78,12 +73,11 @@ public class JsonFormatFactoryTest extends TestLogger {
         final Map<String, String> tableOptions =
                 getModifyOptions(options -> options.put("json.ignore-parse-errors", "abc"));
 
-        thrown.expect(ValidationException.class);
-        thrown.expect(
-                containsCause(
-                        new IllegalArgumentException(
-                                "Unrecognized option for boolean: abc. Expected either true or false(case insensitive)")));
-        testSchemaDeserializationSchema(tableOptions);
+        assertThatCreateRuntimeDecoder(tableOptions)
+                .satisfies(
+                        anyCauseMatches(
+                                IllegalArgumentException.class,
+                                "Unrecognized option for boolean: abc. Expected either true or false(case insensitive)"));
     }
 
     @Test
@@ -91,12 +85,11 @@ public class JsonFormatFactoryTest extends TestLogger {
         final Map<String, String> tableOptions =
                 getModifyOptions(options -> options.put("json.timestamp-format.standard", "test"));
 
-        thrown.expect(ValidationException.class);
-        thrown.expect(
-                containsCause(
-                        new ValidationException(
-                                "Unsupported value 'test' for timestamp-format.standard. Supported values are [SQL, ISO-8601].")));
-        testSchemaDeserializationSchema(tableOptions);
+        assertThatCreateRuntimeDecoder(tableOptions)
+                .satisfies(
+                        anyCauseMatches(
+                                ValidationException.class,
+                                "Unsupported value 'test' for timestamp-format.standard. Supported values are [SQL, ISO-8601]."));
     }
 
     @Test
@@ -105,12 +98,11 @@ public class JsonFormatFactoryTest extends TestLogger {
                 getModifyOptions(
                         options -> options.put("json.timestamp-format.standard", "iso-8601"));
 
-        thrown.expect(ValidationException.class);
-        thrown.expect(
-                containsCause(
-                        new ValidationException(
-                                "Unsupported value 'iso-8601' for timestamp-format.standard. Supported values are [SQL, ISO-8601].")));
-        testSchemaDeserializationSchema(tableOptions);
+        assertThatCreateRuntimeDecoder(tableOptions)
+                .satisfies(
+                        anyCauseMatches(
+                                ValidationException.class,
+                                "Unsupported value 'iso-8601' for timestamp-format.standard. Supported values are [SQL, ISO-8601]."));
     }
 
     @Test
@@ -118,12 +110,11 @@ public class JsonFormatFactoryTest extends TestLogger {
         final Map<String, String> tableOptions =
                 getModifyOptions(options -> options.put("json.map-null-key.mode", "invalid"));
 
-        thrown.expect(ValidationException.class);
-        thrown.expect(
-                containsCause(
-                        new ValidationException(
-                                "Unsupported value 'invalid' for option map-null-key.mode. Supported values are [LITERAL, FAIL, DROP].")));
-        testSchemaSerializationSchema(tableOptions);
+        assertThatCreateRuntimeEncoder(tableOptions)
+                .satisfies(
+                        anyCauseMatches(
+                                ValidationException.class,
+                                "Unsupported value 'invalid' for option map-null-key.mode. Supported values are [LITERAL, FAIL, DROP]."));
     }
 
     @Test
@@ -138,6 +129,27 @@ public class JsonFormatFactoryTest extends TestLogger {
     //  Utilities
     // ------------------------------------------------------------------------
 
+    private AbstractThrowableAssert<?, ? extends Throwable> assertThatCreateRuntimeDecoder(
+            Map<String, String> options) {
+        return assertThatThrownBy(
+                () ->
+                        createTableSource(options)
+                                .valueFormat
+                                .createRuntimeDecoder(
+                                        ScanRuntimeProviderContext.INSTANCE,
+                                        SCHEMA.toPhysicalRowDataType()));
+    }
+
+    private AbstractThrowableAssert<?, ? extends Throwable> assertThatCreateRuntimeEncoder(
+            Map<String, String> options) {
+        return assertThatThrownBy(
+                () ->
+                        createTableSink(options)
+                                .valueFormat
+                                .createRuntimeEncoder(
+                                        new SinkRuntimeProviderContext(false), PHYSICAL_DATA_TYPE));
+    }
+
     private void testSchemaDeserializationSchema(Map<String, String> options) {
         final JsonRowDataDeserializationSchema expectedDeser =
                 new JsonRowDataDeserializationSchema(
@@ -147,16 +159,14 @@ public class JsonFormatFactoryTest extends TestLogger {
                         true,
                         TimestampFormat.ISO_8601);
 
-        final DynamicTableSource actualSource = createTableSource(SCHEMA, options);
-        assert actualSource instanceof TestDynamicTableFactory.DynamicTableSourceMock;
-        TestDynamicTableFactory.DynamicTableSourceMock scanSourceMock =
-                (TestDynamicTableFactory.DynamicTableSourceMock) actualSource;
-
         DeserializationSchema<RowData> actualDeser =
-                scanSourceMock.valueFormat.createRuntimeDecoder(
-                        ScanRuntimeProviderContext.INSTANCE, SCHEMA.toPhysicalRowDataType());
+                createTableSource(options)
+                        .valueFormat
+                        .createRuntimeDecoder(
+                                ScanRuntimeProviderContext.INSTANCE,
+                                SCHEMA.toPhysicalRowDataType());
 
-        assertEquals(expectedDeser, actualDeser);
+        assertThat(actualDeser).isEqualTo(expectedDeser);
     }
 
     private void testSchemaSerializationSchema(Map<String, String> options) {
@@ -168,16 +178,29 @@ public class JsonFormatFactoryTest extends TestLogger {
                         "null",
                         true);
 
-        final DynamicTableSink actualSink = createTableSink(SCHEMA, options);
-        assert actualSink instanceof TestDynamicTableFactory.DynamicTableSinkMock;
-        TestDynamicTableFactory.DynamicTableSinkMock sinkMock =
-                (TestDynamicTableFactory.DynamicTableSinkMock) actualSink;
-
         SerializationSchema<RowData> actualSer =
-                sinkMock.valueFormat.createRuntimeEncoder(
-                        new SinkRuntimeProviderContext(false), PHYSICAL_DATA_TYPE);
+                createTableSink(options)
+                        .valueFormat
+                        .createRuntimeEncoder(
+                                new SinkRuntimeProviderContext(false), PHYSICAL_DATA_TYPE);
 
-        assertEquals(expectedSer, actualSer);
+        assertThat(actualSer).isEqualTo(expectedSer);
+    }
+
+    private TestDynamicTableFactory.DynamicTableSinkMock createTableSink(
+            Map<String, String> options) {
+        final DynamicTableSink actualSink = FactoryMocks.createTableSink(SCHEMA, options);
+        assertThat(actualSink).isInstanceOf(TestDynamicTableFactory.DynamicTableSinkMock.class);
+
+        return (TestDynamicTableFactory.DynamicTableSinkMock) actualSink;
+    }
+
+    private TestDynamicTableFactory.DynamicTableSourceMock createTableSource(
+            Map<String, String> options) {
+        final DynamicTableSource actualSource = FactoryMocks.createTableSource(SCHEMA, options);
+        assertThat(actualSource).isInstanceOf(TestDynamicTableFactory.DynamicTableSourceMock.class);
+
+        return (TestDynamicTableFactory.DynamicTableSourceMock) actualSource;
     }
 
     /**

--- a/flink-table/flink-table-api-java/src/main/java/org/apache/flink/table/catalog/ManagedTableListener.java
+++ b/flink-table/flink-table-api-java/src/main/java/org/apache/flink/table/catalog/ManagedTableListener.java
@@ -28,6 +28,7 @@ import org.apache.flink.util.StringUtils;
 
 import javax.annotation.Nullable;
 
+import java.util.Collections;
 import java.util.Map;
 
 import static org.apache.flink.table.factories.ManagedTableFactory.discoverManagedTableFactory;
@@ -134,6 +135,6 @@ public class ManagedTableListener {
     private DynamicTableFactory.Context createTableFactoryContext(
             ObjectIdentifier identifier, ResolvedCatalogTable table, boolean isTemporary) {
         return new FactoryUtil.DefaultDynamicTableContext(
-                identifier, table, config, classLoader, isTemporary);
+                identifier, table, Collections.emptyMap(), config, classLoader, isTemporary);
     }
 }

--- a/flink-table/flink-table-common/src/main/java/org/apache/flink/table/factories/DecodingFormatFactory.java
+++ b/flink-table/flink-table-common/src/main/java/org/apache/flink/table/factories/DecodingFormatFactory.java
@@ -39,7 +39,7 @@ import org.apache.flink.table.connector.source.ScanTableSource;
  * @param <I> runtime interface needed by the table source
  */
 @PublicEvolving
-public interface DecodingFormatFactory<I> extends Factory {
+public interface DecodingFormatFactory<I> extends FormatFactory {
 
     /**
      * Creates a format from the given context and format options.

--- a/flink-table/flink-table-common/src/main/java/org/apache/flink/table/factories/DynamicTableFactory.java
+++ b/flink-table/flink-table-common/src/main/java/org/apache/flink/table/factories/DynamicTableFactory.java
@@ -19,6 +19,7 @@
 package org.apache.flink.table.factories;
 
 import org.apache.flink.annotation.PublicEvolving;
+import org.apache.flink.configuration.ConfigOption;
 import org.apache.flink.configuration.ReadableConfig;
 import org.apache.flink.table.catalog.Catalog;
 import org.apache.flink.table.catalog.ObjectIdentifier;
@@ -27,6 +28,8 @@ import org.apache.flink.table.catalog.ResolvedSchema;
 import org.apache.flink.table.connector.sink.DynamicTableSink;
 import org.apache.flink.table.connector.source.DynamicTableSource;
 import org.apache.flink.table.types.DataType;
+
+import java.util.Map;
 
 /**
  * Base interface for configuring a dynamic table connector for an external storage system from
@@ -74,6 +77,17 @@ public interface DynamicTableFactory extends Factory {
          * depending on the implemented ability interfaces.
          */
         ResolvedCatalogTable getCatalogTable();
+
+        /**
+         * This method returns a map of options that should be merged with the options in {@link
+         * #getCatalogTable()}. The returned map is empty if {@code PLAN_RESTORE_CATALOG_OBJECTS} is
+         * not set to {@code ALL}.
+         *
+         * <p>It's highly recommended using the {@link
+         * FactoryUtil.TableFactoryHelper#forwardOptions(ConfigOption[])} to merge the options and
+         * then get the result with {@link FactoryUtil.TableFactoryHelper#getOptions()}.
+         */
+        Map<String, String> mergeableOptions();
 
         /** Gives read-only access to the configuration of the current session. */
         ReadableConfig getConfiguration();

--- a/flink-table/flink-table-common/src/main/java/org/apache/flink/table/factories/DynamicTableFactory.java
+++ b/flink-table/flink-table-common/src/main/java/org/apache/flink/table/factories/DynamicTableFactory.java
@@ -27,9 +27,15 @@ import org.apache.flink.table.catalog.ResolvedCatalogTable;
 import org.apache.flink.table.catalog.ResolvedSchema;
 import org.apache.flink.table.connector.sink.DynamicTableSink;
 import org.apache.flink.table.connector.source.DynamicTableSource;
+import org.apache.flink.table.connector.source.abilities.SupportsFilterPushDown;
+import org.apache.flink.table.connector.source.abilities.SupportsProjectionPushDown;
+import org.apache.flink.table.connector.source.abilities.SupportsReadingMetadata;
+import org.apache.flink.table.factories.FactoryUtil.TableFactoryHelper;
 import org.apache.flink.table.types.DataType;
 
+import java.util.Collections;
 import java.util.Map;
+import java.util.Set;
 
 /**
  * Base interface for configuring a dynamic table connector for an external storage system from
@@ -79,13 +85,25 @@ public interface DynamicTableFactory extends Factory {
         ResolvedCatalogTable getCatalogTable();
 
         /**
-         * This method returns a map of options that should be merged with the options in {@link
-         * #getCatalogTable()}. The returned map is empty if {@code PLAN_RESTORE_CATALOG_OBJECTS} is
-         * not set to {@code ALL}.
+         * Returns a map of options that can enrich the options of the original {@link
+         * #getCatalogTable()} during a plan restore.
          *
-         * <p>It's highly recommended using the {@link
-         * FactoryUtil.TableFactoryHelper#forwardOptions(ConfigOption[])} to merge the options and
-         * then get the result with {@link FactoryUtil.TableFactoryHelper#getOptions()}.
+         * <p>By default, the options persisted in the plan are used to reconstruct the {@link
+         * #getCatalogTable()} if available. This method always the options retrieved from the
+         * {@link Catalog}. If and only if {@code table.plan.restore.catalog-objects} is set to
+         * {@code ALL}, there might be information from both the plan and a catalog lookup. Only the
+         * {@link DynamicTableFactory} is able to decide which options are safe to be forwarded
+         * without affecting the original topology.
+         *
+         * <p>Since a restored topology is static, an implementer has to ensure that the declared
+         * options don't affect fundamental abilities. The planner might not react to changed
+         * abilities anymore.
+         *
+         * <p>It's highly recommended using the {@link TableFactoryHelper#forwardOptions()} to merge
+         * the options and then get the result with {@link TableFactoryHelper#getOptions()}. The
+         * helper considers {@link #forwardOptions()} and formats.
+         *
+         * @see TableFactoryHelper
          */
         Map<String, String> getEnrichmentOptions();
 
@@ -145,5 +163,27 @@ public interface DynamicTableFactory extends Factory {
         default int[] getPrimaryKeyIndexes() {
             return getCatalogTable().getResolvedSchema().getPrimaryKeyIndexes();
         }
+    }
+
+    /**
+     * Returns a set of {@link ConfigOption} that are directly forwarded to the runtime
+     * implementation but don't affect the final execution topology.
+     *
+     * <p>Options declared here can override options of the persisted plan during an enrichment
+     * phase. Since a restored topology is static, an implementer has to ensure that the declared
+     * options don't affect fundamental abilities such as {@link SupportsProjectionPushDown} or
+     * {@link SupportsFilterPushDown}.
+     *
+     * <p>For example, given a database connector, if an option defines the connection timeout,
+     * changing this value does not affect the pipeline topology and can be allowed. However, an
+     * option that defines whether the connector supports {@link SupportsReadingMetadata} or not is
+     * not allowed. The planner might not react to changed abilities anymore.
+     *
+     * @see DynamicTableFactory.Context#getEnrichmentOptions()
+     * @see TableFactoryHelper#forwardOptions()
+     * @see FormatFactory#forwardOptions()
+     */
+    default Set<ConfigOption<?>> forwardOptions() {
+        return Collections.emptySet();
     }
 }

--- a/flink-table/flink-table-common/src/main/java/org/apache/flink/table/factories/DynamicTableFactory.java
+++ b/flink-table/flink-table-common/src/main/java/org/apache/flink/table/factories/DynamicTableFactory.java
@@ -87,7 +87,7 @@ public interface DynamicTableFactory extends Factory {
          * FactoryUtil.TableFactoryHelper#forwardOptions(ConfigOption[])} to merge the options and
          * then get the result with {@link FactoryUtil.TableFactoryHelper#getOptions()}.
          */
-        Map<String, String> mergeableOptions();
+        Map<String, String> getEnrichmentOptions();
 
         /** Gives read-only access to the configuration of the current session. */
         ReadableConfig getConfiguration();

--- a/flink-table/flink-table-common/src/main/java/org/apache/flink/table/factories/EncodingFormatFactory.java
+++ b/flink-table/flink-table-common/src/main/java/org/apache/flink/table/factories/EncodingFormatFactory.java
@@ -37,7 +37,7 @@ import org.apache.flink.table.connector.sink.DynamicTableSink;
  * @param <I> runtime interface needed by the table sink
  */
 @PublicEvolving
-public interface EncodingFormatFactory<I> extends Factory {
+public interface EncodingFormatFactory<I> extends FormatFactory {
 
     /**
      * Creates a format from the given context and format options.

--- a/flink-table/flink-table-common/src/main/java/org/apache/flink/table/factories/FactoryUtil.java
+++ b/flink-table/flink-table-common/src/main/java/org/apache/flink/table/factories/FactoryUtil.java
@@ -55,6 +55,7 @@ import java.util.HashSet;
 import java.util.LinkedList;
 import java.util.List;
 import java.util.Map;
+import java.util.Objects;
 import java.util.Optional;
 import java.util.Set;
 import java.util.stream.Collectors;
@@ -135,12 +136,18 @@ public final class FactoryUtil {
             @Nullable DynamicTableSourceFactory preferredFactory,
             ObjectIdentifier objectIdentifier,
             ResolvedCatalogTable catalogTable,
+            Map<String, String> mergeableOptions,
             ReadableConfig configuration,
             ClassLoader classLoader,
             boolean isTemporary) {
         final DefaultDynamicTableContext context =
                 new DefaultDynamicTableContext(
-                        objectIdentifier, catalogTable, configuration, classLoader, isTemporary);
+                        objectIdentifier,
+                        catalogTable,
+                        mergeableOptions,
+                        configuration,
+                        classLoader,
+                        isTemporary);
         try {
             final DynamicTableSourceFactory factory =
                     preferredFactory != null
@@ -163,12 +170,34 @@ public final class FactoryUtil {
     }
 
     /**
+     * @deprecated Use {@link #createDynamicTableSource(DynamicTableSourceFactory, ObjectIdentifier,
+     *     ResolvedCatalogTable, Map, ReadableConfig, ClassLoader, boolean)}
+     */
+    @Deprecated
+    public static DynamicTableSource createDynamicTableSource(
+            @Nullable DynamicTableSourceFactory preferredFactory,
+            ObjectIdentifier objectIdentifier,
+            ResolvedCatalogTable catalogTable,
+            ReadableConfig configuration,
+            ClassLoader classLoader,
+            boolean isTemporary) {
+        return createDynamicTableSource(
+                preferredFactory,
+                objectIdentifier,
+                catalogTable,
+                Collections.emptyMap(),
+                configuration,
+                classLoader,
+                isTemporary);
+    }
+
+    /**
      * Creates a {@link DynamicTableSource} from a {@link CatalogTable}.
      *
      * <p>It considers {@link Catalog#getFactory()} if provided.
      *
      * @deprecated Use {@link #createDynamicTableSource(DynamicTableSourceFactory, ObjectIdentifier,
-     *     ResolvedCatalogTable, ReadableConfig, ClassLoader, boolean)} instead.
+     *     ResolvedCatalogTable, Map, ReadableConfig, ClassLoader, boolean)} instead.
      */
     @Deprecated
     public static DynamicTableSource createTableSource(
@@ -180,12 +209,18 @@ public final class FactoryUtil {
             boolean isTemporary) {
         final DefaultDynamicTableContext context =
                 new DefaultDynamicTableContext(
-                        objectIdentifier, catalogTable, configuration, classLoader, isTemporary);
+                        objectIdentifier,
+                        catalogTable,
+                        Collections.emptyMap(),
+                        configuration,
+                        classLoader,
+                        isTemporary);
 
         return createDynamicTableSource(
                 getDynamicTableFactory(DynamicTableSourceFactory.class, catalog, context),
                 objectIdentifier,
                 catalogTable,
+                Collections.emptyMap(),
                 configuration,
                 classLoader,
                 isTemporary);
@@ -202,12 +237,18 @@ public final class FactoryUtil {
             @Nullable DynamicTableSinkFactory preferredFactory,
             ObjectIdentifier objectIdentifier,
             ResolvedCatalogTable catalogTable,
+            Map<String, String> mergeableOptions,
             ReadableConfig configuration,
             ClassLoader classLoader,
             boolean isTemporary) {
         final DefaultDynamicTableContext context =
                 new DefaultDynamicTableContext(
-                        objectIdentifier, catalogTable, configuration, classLoader, isTemporary);
+                        objectIdentifier,
+                        catalogTable,
+                        mergeableOptions,
+                        configuration,
+                        classLoader,
+                        isTemporary);
 
         try {
             final DynamicTableSinkFactory factory =
@@ -232,12 +273,34 @@ public final class FactoryUtil {
     }
 
     /**
+     * @deprecated Use {@link #createDynamicTableSink(DynamicTableSinkFactory, ObjectIdentifier,
+     *     ResolvedCatalogTable, Map, ReadableConfig, ClassLoader, boolean)}
+     */
+    @Deprecated
+    public static DynamicTableSink createDynamicTableSink(
+            @Nullable DynamicTableSinkFactory preferredFactory,
+            ObjectIdentifier objectIdentifier,
+            ResolvedCatalogTable catalogTable,
+            ReadableConfig configuration,
+            ClassLoader classLoader,
+            boolean isTemporary) {
+        return createDynamicTableSink(
+                preferredFactory,
+                objectIdentifier,
+                catalogTable,
+                Collections.emptyMap(),
+                configuration,
+                classLoader,
+                isTemporary);
+    }
+
+    /**
      * Creates a {@link DynamicTableSink} from a {@link CatalogTable}.
      *
      * <p>It considers {@link Catalog#getFactory()} if provided.
      *
      * @deprecated Use {@link #createDynamicTableSink(DynamicTableSinkFactory, ObjectIdentifier,
-     *     ResolvedCatalogTable, ReadableConfig, ClassLoader, boolean)} instead.
+     *     ResolvedCatalogTable, Map, ReadableConfig, ClassLoader, boolean)} instead.
      */
     @Deprecated
     public static DynamicTableSink createTableSink(
@@ -249,12 +312,18 @@ public final class FactoryUtil {
             boolean isTemporary) {
         final DefaultDynamicTableContext context =
                 new DefaultDynamicTableContext(
-                        objectIdentifier, catalogTable, configuration, classLoader, isTemporary);
+                        objectIdentifier,
+                        catalogTable,
+                        Collections.emptyMap(),
+                        configuration,
+                        classLoader,
+                        isTemporary);
 
         return createDynamicTableSink(
                 getDynamicTableFactory(DynamicTableSinkFactory.class, catalog, context),
                 objectIdentifier,
                 catalogTable,
+                Collections.emptyMap(),
                 configuration,
                 classLoader,
                 isTemporary);
@@ -1046,6 +1115,7 @@ public final class FactoryUtil {
 
         private final ObjectIdentifier objectIdentifier;
         private final ResolvedCatalogTable catalogTable;
+        private final Map<String, String> mergeableOptions;
         private final ReadableConfig configuration;
         private final ClassLoader classLoader;
         private final boolean isTemporary;
@@ -1053,11 +1123,13 @@ public final class FactoryUtil {
         public DefaultDynamicTableContext(
                 ObjectIdentifier objectIdentifier,
                 ResolvedCatalogTable catalogTable,
+                Map<String, String> mergeableOptions,
                 ReadableConfig configuration,
                 ClassLoader classLoader,
                 boolean isTemporary) {
             this.objectIdentifier = objectIdentifier;
             this.catalogTable = catalogTable;
+            this.mergeableOptions = mergeableOptions;
             this.configuration = configuration;
             this.classLoader = classLoader;
             this.isTemporary = isTemporary;
@@ -1071,6 +1143,11 @@ public final class FactoryUtil {
         @Override
         public ResolvedCatalogTable getCatalogTable() {
             return catalogTable;
+        }
+
+        @Override
+        public Map<String, String> mergeableOptions() {
+            return mergeableOptions;
         }
 
         @Override

--- a/flink-table/flink-table-common/src/main/java/org/apache/flink/table/factories/FactoryUtil.java
+++ b/flink-table/flink-table-common/src/main/java/org/apache/flink/table/factories/FactoryUtil.java
@@ -669,7 +669,6 @@ public final class FactoryUtil {
     // Helper methods
     // --------------------------------------------------------------------------------------------
 
-    @SuppressWarnings("unchecked")
     private static <T extends DynamicTableFactory> T getDynamicTableFactory(
             Class<T> factoryClass, @Nullable Catalog catalog, DynamicTableFactory.Context context) {
         return getDynamicTableFactory(factoryClass, catalog)
@@ -991,17 +990,17 @@ public final class FactoryUtil {
         }
 
         /**
-         * Forward the provided {@code configOptions} from the {@link
+         * Forwards the options declared in {@link DynamicTableFactory#forwardOptions()} and
+         * possibly {@link FormatFactory#forwardOptions()} from {@link
          * DynamicTableFactory.Context#getEnrichmentOptions()} to the final options, if present.
          */
         @SuppressWarnings({"unchecked"})
-        public TableFactoryHelper forwardOptions(ConfigOption<?>... configOptions) {
-            for (ConfigOption<?> option : configOptions) {
+        public void forwardOptions() {
+            for (ConfigOption<?> option : factory.forwardOptions()) {
                 enrichingOptions
                         .getOptional(option)
                         .ifPresent(o -> allOptions.set((ConfigOption<? super Object>) option, o));
             }
-            return this;
         }
 
         /**

--- a/flink-table/flink-table-common/src/main/java/org/apache/flink/table/factories/FormatFactory.java
+++ b/flink-table/flink-table-common/src/main/java/org/apache/flink/table/factories/FormatFactory.java
@@ -18,16 +18,18 @@
 
 package org.apache.flink.table.factories;
 
+import org.apache.flink.annotation.PublicEvolving;
 import org.apache.flink.configuration.ConfigOption;
 
 import java.util.Collections;
 import java.util.Set;
 
 /** Base interface for {@link DecodingFormatFactory} and {@link EncodingFormatFactory}. */
+@PublicEvolving
 public interface FormatFactory extends Factory {
 
-    /** Returns the list of {@link ConfigOption} that can be merged from the catalog table. */
-    default Set<ConfigOption<?>> mergeableOptions() {
+    /** Returns the list of {@link ConfigOption} that can be merged from the enriching table. */
+    default Set<ConfigOption<?>> forwardOptions() {
         return Collections.emptySet();
     }
 }

--- a/flink-table/flink-table-common/src/main/java/org/apache/flink/table/factories/FormatFactory.java
+++ b/flink-table/flink-table-common/src/main/java/org/apache/flink/table/factories/FormatFactory.java
@@ -20,6 +20,8 @@ package org.apache.flink.table.factories;
 
 import org.apache.flink.annotation.PublicEvolving;
 import org.apache.flink.configuration.ConfigOption;
+import org.apache.flink.table.connector.ChangelogMode;
+import org.apache.flink.table.connector.format.ProjectableDecodingFormat;
 
 import java.util.Collections;
 import java.util.Set;
@@ -28,7 +30,23 @@ import java.util.Set;
 @PublicEvolving
 public interface FormatFactory extends Factory {
 
-    /** Returns the list of {@link ConfigOption} that can be merged from the enriching table. */
+    /**
+     * Returns a set of {@link ConfigOption} that are directly forwarded to the runtime
+     * implementation but don't affect the final execution topology.
+     *
+     * <p>Options declared here can override options of the persisted plan during an enrichment
+     * phase. Since a restored topology is static, an implementer has to ensure that the declared
+     * options don't affect fundamental abilities such as {@link ChangelogMode}.
+     *
+     * <p>For example, given a JSON format, if an option defines how to parse timestamps, changing
+     * the parsing behavior does not affect the pipeline topology and can be allowed. However, an
+     * option that defines whether the format results in a {@link ProjectableDecodingFormat} or not
+     * is not allowed. The wrapping connector and planner might not react to the changed abilities
+     * anymore.
+     *
+     * @see DynamicTableFactory.Context#getEnrichmentOptions()
+     * @see FactoryUtil.TableFactoryHelper#forwardOptions()
+     */
     default Set<ConfigOption<?>> forwardOptions() {
         return Collections.emptySet();
     }

--- a/flink-table/flink-table-common/src/main/java/org/apache/flink/table/factories/FormatFactory.java
+++ b/flink-table/flink-table-common/src/main/java/org/apache/flink/table/factories/FormatFactory.java
@@ -1,0 +1,33 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.flink.table.factories;
+
+import org.apache.flink.configuration.ConfigOption;
+
+import java.util.Collections;
+import java.util.Set;
+
+/** Base interface for {@link DecodingFormatFactory} and {@link EncodingFormatFactory}. */
+public interface FormatFactory extends Factory {
+
+    /** Returns the list of {@link ConfigOption} that can be merged from the catalog table. */
+    default Set<ConfigOption<?>> mergeableOptions() {
+        return Collections.emptySet();
+    }
+}

--- a/flink-table/flink-table-common/src/main/java/org/apache/flink/table/factories/FormatFactory.java
+++ b/flink-table/flink-table-common/src/main/java/org/apache/flink/table/factories/FormatFactory.java
@@ -45,7 +45,6 @@ public interface FormatFactory extends Factory {
      * anymore.
      *
      * @see DynamicTableFactory.Context#getEnrichmentOptions()
-     * @see FactoryUtil.TableFactoryHelper#forwardOptions()
      */
     default Set<ConfigOption<?>> forwardOptions() {
         return Collections.emptySet();

--- a/flink-table/flink-table-common/src/test/java/org/apache/flink/table/factories/FactoryUtilTest.java
+++ b/flink-table/flink-table-common/src/test/java/org/apache/flink/table/factories/FactoryUtilTest.java
@@ -404,8 +404,7 @@ public class FactoryUtilTest {
                         new TestDynamicTableFactory(),
                         FactoryMocks.createTableContext(SCHEMA, options, enrichment));
 
-        helper.forwardOptions(
-                TestDynamicTableFactory.BUFFER_SIZE, TestDynamicTableFactory.PASSWORD);
+        helper.forwardOptions();
 
         helper.validate();
 
@@ -447,8 +446,7 @@ public class FactoryUtilTest {
                         FactoryMocks.createTableContext(SCHEMA, options, enrichment));
 
         // Forward table options
-        helper.forwardOptions(
-                TestDynamicTableFactory.BUFFER_SIZE, TestDynamicTableFactory.PASSWORD);
+        helper.forwardOptions();
 
         // Get resulting format mocks from key and value
         // Note: the only forwardable option for the test format is the delimiter
@@ -555,8 +553,7 @@ public class FactoryUtilTest {
                         new TestDynamicTableFactory(),
                         FactoryMocks.createTableContext(SCHEMA, options));
 
-        helper.forwardOptions(
-                TestDynamicTableFactory.BUFFER_SIZE, TestDynamicTableFactory.PASSWORD);
+        helper.forwardOptions();
 
         helper.validate();
 

--- a/flink-table/flink-table-common/src/test/java/org/apache/flink/table/factories/FactoryUtilTest.java
+++ b/flink-table/flink-table-common/src/test/java/org/apache/flink/table/factories/FactoryUtilTest.java
@@ -404,8 +404,6 @@ public class FactoryUtilTest {
                         new TestDynamicTableFactory(),
                         FactoryMocks.createTableContext(SCHEMA, options, enrichment));
 
-        helper.forwardOptions();
-
         helper.validate();
 
         assertThat(helper.getOptions().get(TestDynamicTableFactory.TARGET)).isEqualTo("abc");
@@ -444,9 +442,6 @@ public class FactoryUtilTest {
                 FactoryUtil.createTableFactoryHelper(
                         new TestDynamicTableFactory(),
                         FactoryMocks.createTableContext(SCHEMA, options, enrichment));
-
-        // Forward table options
-        helper.forwardOptions();
 
         // Get resulting format mocks from key and value
         // Note: the only forwardable option for the test format is the delimiter
@@ -552,8 +547,6 @@ public class FactoryUtilTest {
                 FactoryUtil.createTableFactoryHelper(
                         new TestDynamicTableFactory(),
                         FactoryMocks.createTableContext(SCHEMA, options));
-
-        helper.forwardOptions();
 
         helper.validate();
 

--- a/flink-table/flink-table-common/src/test/java/org/apache/flink/table/factories/FactoryUtilTest.java
+++ b/flink-table/flink-table-common/src/test/java/org/apache/flink/table/factories/FactoryUtilTest.java
@@ -390,19 +390,19 @@ public class FactoryUtilTest {
     }
 
     @Test
-    public void testFactoryHelperWithMergeableOptions() {
+    public void testFactoryHelperWithEnrichmentOptions() {
         final Map<String, String> options = new HashMap<>();
         options.put(TestDynamicTableFactory.TARGET.key(), "abc");
         options.put(TestDynamicTableFactory.BUFFER_SIZE.key(), "1000");
 
-        final Map<String, String> mergeable = new HashMap<>();
-        mergeable.put(TestDynamicTableFactory.TARGET.key(), "xyz");
-        mergeable.put(TestDynamicTableFactory.BUFFER_SIZE.key(), "2000");
+        final Map<String, String> enrichment = new HashMap<>();
+        enrichment.put(TestDynamicTableFactory.TARGET.key(), "xyz");
+        enrichment.put(TestDynamicTableFactory.BUFFER_SIZE.key(), "2000");
 
         final FactoryUtil.TableFactoryHelper helper =
                 FactoryUtil.createTableFactoryHelper(
                         new TestDynamicTableFactory(),
-                        FactoryMocks.createTableContext(SCHEMA, options, mergeable));
+                        FactoryMocks.createTableContext(SCHEMA, options, enrichment));
 
         helper.forwardOptions(
                 TestDynamicTableFactory.BUFFER_SIZE, TestDynamicTableFactory.PASSWORD);
@@ -414,7 +414,7 @@ public class FactoryUtilTest {
     }
 
     @Test
-    public void testFactoryHelperWithMergeableOptionsAndFormat() {
+    public void testFactoryHelperWithEnrichmentOptionsAndFormat() {
         String keyFormatPrefix =
                 FactoryUtil.getFormatPrefix(
                         TestDynamicTableFactory.KEY_FORMAT, TestFormatFactory.IDENTIFIER);
@@ -432,19 +432,19 @@ public class FactoryUtilTest {
         options.put(valueFormatPrefix + TestFormatFactory.DELIMITER.key(), "|");
         options.put(valueFormatPrefix + TestFormatFactory.FAIL_ON_MISSING.key(), "true");
 
-        final Map<String, String> mergeable = new HashMap<>();
-        mergeable.put(TestDynamicTableFactory.TARGET.key(), "xyz");
-        mergeable.put(TestDynamicTableFactory.BUFFER_SIZE.key(), "2000");
-        mergeable.put(TestDynamicTableFactory.KEY_FORMAT.key(), TestFormatFactory.IDENTIFIER);
-        mergeable.put(keyFormatPrefix + TestFormatFactory.DELIMITER.key(), ",");
-        mergeable.put(keyFormatPrefix + TestFormatFactory.FAIL_ON_MISSING.key(), "true");
-        mergeable.put(TestDynamicTableFactory.VALUE_FORMAT.key(), TestFormatFactory.IDENTIFIER);
-        mergeable.put(valueFormatPrefix + TestFormatFactory.DELIMITER.key(), "|");
+        final Map<String, String> enrichment = new HashMap<>();
+        enrichment.put(TestDynamicTableFactory.TARGET.key(), "xyz");
+        enrichment.put(TestDynamicTableFactory.BUFFER_SIZE.key(), "2000");
+        enrichment.put(TestDynamicTableFactory.KEY_FORMAT.key(), TestFormatFactory.IDENTIFIER);
+        enrichment.put(keyFormatPrefix + TestFormatFactory.DELIMITER.key(), ",");
+        enrichment.put(keyFormatPrefix + TestFormatFactory.FAIL_ON_MISSING.key(), "true");
+        enrichment.put(TestDynamicTableFactory.VALUE_FORMAT.key(), TestFormatFactory.IDENTIFIER);
+        enrichment.put(valueFormatPrefix + TestFormatFactory.DELIMITER.key(), "|");
 
         final FactoryUtil.TableFactoryHelper helper =
                 FactoryUtil.createTableFactoryHelper(
                         new TestDynamicTableFactory(),
-                        FactoryMocks.createTableContext(SCHEMA, options, mergeable));
+                        FactoryMocks.createTableContext(SCHEMA, options, enrichment));
 
         // Forward table options
         helper.forwardOptions(
@@ -477,14 +477,14 @@ public class FactoryUtilTest {
     }
 
     @Test
-    public void testFactoryHelperWithMergeableOptionsMissingFormatIdentifier() {
+    public void testFactoryHelperWithEnrichmentOptionsMissingFormatIdentifier() {
         final Map<String, String> options = new HashMap<>();
         options.put(TestDynamicTableFactory.TARGET.key(), "abc");
 
-        final Map<String, String> mergeable = new HashMap<>();
-        mergeable.put(TestDynamicTableFactory.TARGET.key(), "xyz");
-        mergeable.put(TestDynamicTableFactory.KEY_FORMAT.key(), TestFormatFactory.IDENTIFIER);
-        mergeable.put(
+        final Map<String, String> enrichment = new HashMap<>();
+        enrichment.put(TestDynamicTableFactory.TARGET.key(), "xyz");
+        enrichment.put(TestDynamicTableFactory.KEY_FORMAT.key(), TestFormatFactory.IDENTIFIER);
+        enrichment.put(
                 FactoryUtil.getFormatPrefix(
                                 TestDynamicTableFactory.KEY_FORMAT, TestFormatFactory.IDENTIFIER)
                         + TestFormatFactory.DELIMITER.key(),
@@ -493,7 +493,7 @@ public class FactoryUtilTest {
         final FactoryUtil.TableFactoryHelper helper =
                 FactoryUtil.createTableFactoryHelper(
                         new TestDynamicTableFactory(),
-                        FactoryMocks.createTableContext(SCHEMA, options, mergeable));
+                        FactoryMocks.createTableContext(SCHEMA, options, enrichment));
 
         assertThatThrownBy(
                         () ->
@@ -508,7 +508,7 @@ public class FactoryUtilTest {
     }
 
     @Test
-    public void testFactoryHelperWithMergeableOptionsFormatMismatch() {
+    public void testFactoryHelperWithEnrichmentOptionsFormatMismatch() {
         String keyFormatPrefix =
                 FactoryUtil.getFormatPrefix(
                         TestDynamicTableFactory.KEY_FORMAT, TestFormatFactory.IDENTIFIER);
@@ -519,15 +519,15 @@ public class FactoryUtilTest {
         options.put(keyFormatPrefix + TestFormatFactory.DELIMITER.key(), "|");
         options.put(keyFormatPrefix + TestFormatFactory.FAIL_ON_MISSING.key(), "true");
 
-        final Map<String, String> mergeable = new HashMap<>();
-        mergeable.put(TestDynamicTableFactory.TARGET.key(), "xyz");
-        mergeable.put(TestDynamicTableFactory.BUFFER_SIZE.key(), "2000");
-        mergeable.put(TestDynamicTableFactory.KEY_FORMAT.key(), "another-format");
+        final Map<String, String> enrichment = new HashMap<>();
+        enrichment.put(TestDynamicTableFactory.TARGET.key(), "xyz");
+        enrichment.put(TestDynamicTableFactory.BUFFER_SIZE.key(), "2000");
+        enrichment.put(TestDynamicTableFactory.KEY_FORMAT.key(), "another-format");
 
         final FactoryUtil.TableFactoryHelper helper =
                 FactoryUtil.createTableFactoryHelper(
                         new TestDynamicTableFactory(),
-                        FactoryMocks.createTableContext(SCHEMA, options, mergeable));
+                        FactoryMocks.createTableContext(SCHEMA, options, enrichment));
 
         assertThatThrownBy(
                         () ->
@@ -545,7 +545,7 @@ public class FactoryUtilTest {
     }
 
     @Test
-    public void testFactoryHelperWithEmptyMergeableOptions() {
+    public void testFactoryHelperWithEmptyEnrichmentOptions() {
         final Map<String, String> options = new HashMap<>();
         options.put(TestDynamicTableFactory.TARGET.key(), "abc");
         options.put(TestDynamicTableFactory.BUFFER_SIZE.key(), "1000");

--- a/flink-table/flink-table-common/src/test/java/org/apache/flink/table/factories/TestDynamicTableFactory.java
+++ b/flink-table/flink-table-common/src/test/java/org/apache/flink/table/factories/TestDynamicTableFactory.java
@@ -133,6 +133,14 @@ public final class TestDynamicTableFactory
         return options;
     }
 
+    @Override
+    public Set<ConfigOption<?>> forwardOptions() {
+        final Set<ConfigOption<?>> options = new HashSet<>();
+        options.add(BUFFER_SIZE);
+        options.add(PASSWORD);
+        return options;
+    }
+
     // --------------------------------------------------------------------------------------------
     // Table source
     // --------------------------------------------------------------------------------------------

--- a/flink-table/flink-table-common/src/test/java/org/apache/flink/table/factories/TestFormatFactory.java
+++ b/flink-table/flink-table-common/src/test/java/org/apache/flink/table/factories/TestFormatFactory.java
@@ -129,7 +129,7 @@ public class TestFormatFactory implements DeserializationFormatFactory, Serializ
     }
 
     @Override
-    public Set<ConfigOption<?>> mergeableOptions() {
+    public Set<ConfigOption<?>> forwardOptions() {
         final Set<ConfigOption<?>> options = new HashSet<>();
         options.add(DELIMITER);
         return options;

--- a/flink-table/flink-table-common/src/test/java/org/apache/flink/table/factories/TestFormatFactory.java
+++ b/flink-table/flink-table-common/src/test/java/org/apache/flink/table/factories/TestFormatFactory.java
@@ -128,6 +128,13 @@ public class TestFormatFactory implements DeserializationFormatFactory, Serializ
         return options;
     }
 
+    @Override
+    public Set<ConfigOption<?>> mergeableOptions() {
+        final Set<ConfigOption<?>> options = new HashSet<>();
+        options.add(DELIMITER);
+        return options;
+    }
+
     private static Map<String, DataType> convertToMetadataMap(
             Map<String, String> metadataOption, ClassLoader classLoader) {
         return metadataOption.keySet().stream()

--- a/flink-table/flink-table-common/src/test/java/org/apache/flink/table/factories/utils/FactoryMocks.java
+++ b/flink-table/flink-table-common/src/test/java/org/apache/flink/table/factories/utils/FactoryMocks.java
@@ -65,6 +65,7 @@ public final class FactoryMocks {
                                 Collections.emptyList(),
                                 options),
                         schema),
+                Collections.emptyMap(),
                 new Configuration(),
                 FactoryMocks.class.getClassLoader(),
                 false);
@@ -103,6 +104,7 @@ public final class FactoryMocks {
                                 Collections.emptyList(),
                                 options),
                         schema),
+                Collections.emptyMap(),
                 new Configuration(),
                 FactoryMocks.class.getClassLoader(),
                 false);

--- a/flink-table/flink-table-common/src/test/java/org/apache/flink/table/factories/utils/FactoryMocks.java
+++ b/flink-table/flink-table-common/src/test/java/org/apache/flink/table/factories/utils/FactoryMocks.java
@@ -95,6 +95,13 @@ public final class FactoryMocks {
 
     public static DynamicTableFactory.Context createTableContext(
             ResolvedSchema schema, Map<String, String> options) {
+        return createTableContext(schema, options, Collections.emptyMap());
+    }
+
+    public static DynamicTableFactory.Context createTableContext(
+            ResolvedSchema schema,
+            Map<String, String> options,
+            Map<String, String> mergeableOptions) {
         return new FactoryUtil.DefaultDynamicTableContext(
                 IDENTIFIER,
                 new ResolvedCatalogTable(
@@ -104,7 +111,7 @@ public final class FactoryMocks {
                                 Collections.emptyList(),
                                 options),
                         schema),
-                Collections.emptyMap(),
+                mergeableOptions,
                 new Configuration(),
                 FactoryMocks.class.getClassLoader(),
                 false);

--- a/flink-table/flink-table-common/src/test/java/org/apache/flink/table/factories/utils/FactoryMocks.java
+++ b/flink-table/flink-table-common/src/test/java/org/apache/flink/table/factories/utils/FactoryMocks.java
@@ -101,7 +101,7 @@ public final class FactoryMocks {
     public static DynamicTableFactory.Context createTableContext(
             ResolvedSchema schema,
             Map<String, String> options,
-            Map<String, String> mergeableOptions) {
+            Map<String, String> enrichmentOptions) {
         return new FactoryUtil.DefaultDynamicTableContext(
                 IDENTIFIER,
                 new ResolvedCatalogTable(
@@ -111,7 +111,7 @@ public final class FactoryMocks {
                                 Collections.emptyList(),
                                 options),
                         schema),
-                mergeableOptions,
+                enrichmentOptions,
                 new Configuration(),
                 FactoryMocks.class.getClassLoader(),
                 false);


### PR DESCRIPTION
## What is the purpose of the change

This PR adds the required new APIs to expose merging the options from the catalog table, when restoring a plan.

## Brief change log

* Added `DynamicTableFactory.Context#mergeableOptions` to expose options from the catalog table.
* Added `FormatFactory` as base interface for `DecodingFormatFactory` and `EncodingFormatFactory`. Added `FormatFactory#mergeableOptions()` to declaratively define which options can be merged from the catalog table.
* Added `FactoryUtil#forwardOptions` to perform the merge
* Added some validation code to verify the catalog table is correct
* Show how to use the new APIs in json and connector-kafka

## Verifying this change

Added tests in `FactoryUtil` to verify the merging process.

## Does this pull request potentially affect one of the following parts:

  - Dependencies (does it add or upgrade a dependency): no
  - The public API, i.e., is any changed class annotated with `@Public(Evolving)`: yes

## Documentation

  - Does this pull request introduce a new feature? yes
  - If yes, how is the feature documented? JavaDocs
