### PR TITLE
[FLINK-25533] Forward preferred allocations into the DeclarativeSlotPoolBridge

### DIFF
--- a/flink-runtime/src/main/java/org/apache/flink/runtime/clusterframework/types/SlotProfile.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/clusterframework/types/SlotProfile.java
@@ -122,4 +122,20 @@ public class SlotProfile {
                 priorAllocations,
                 reservedAllocations);
     }
+
+    @Override
+    public String toString() {
+        return "SlotProfile{"
+                + "taskResourceProfile="
+                + taskResourceProfile
+                + ", physicalSlotResourceProfile="
+                + physicalSlotResourceProfile
+                + ", preferredLocations="
+                + preferredLocations
+                + ", preferredAllocations="
+                + preferredAllocations
+                + ", reservedAllocations="
+                + reservedAllocations
+                + '}';
+    }
 }

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/executiongraph/Execution.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/executiongraph/Execution.java
@@ -554,10 +554,11 @@ public class Execution
             }
 
             LOG.info(
-                    "Deploying {} (attempt #{}) with attempt id {} to {} with allocation id {}",
+                    "Deploying {} (attempt #{}) with attempt id {} and vertex id {} to {} with allocation id {}",
                     vertex.getTaskNameWithSubtaskIndex(),
                     attemptNumber,
                     vertex.getCurrentExecutionAttempt().getAttemptId(),
+                    vertex.getID(),
                     getAssignedResourceLocation(),
                     slot.getAllocationId());
 

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/jobmaster/slotpool/DeclarativeSlotPoolBridgeServiceFactory.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/jobmaster/slotpool/DeclarativeSlotPoolBridgeServiceFactory.java
@@ -27,12 +27,16 @@ import javax.annotation.Nonnull;
 /** Factory for {@link DeclarativeSlotPoolBridge}. */
 public class DeclarativeSlotPoolBridgeServiceFactory extends AbstractSlotPoolServiceFactory {
 
+    private final RequestSlotMatchingStrategy requestSlotMatchingStrategy;
+
     public DeclarativeSlotPoolBridgeServiceFactory(
             @Nonnull Clock clock,
             @Nonnull Time rpcTimeout,
             @Nonnull Time slotIdleTimeout,
-            @Nonnull Time batchSlotTimeout) {
+            @Nonnull Time batchSlotTimeout,
+            @Nonnull RequestSlotMatchingStrategy requestSlotMatchingStrategy) {
         super(clock, rpcTimeout, slotIdleTimeout, batchSlotTimeout);
+        this.requestSlotMatchingStrategy = requestSlotMatchingStrategy;
     }
 
     @Nonnull
@@ -44,6 +48,7 @@ public class DeclarativeSlotPoolBridgeServiceFactory extends AbstractSlotPoolSer
                 clock,
                 rpcTimeout,
                 slotIdleTimeout,
-                batchSlotTimeout);
+                batchSlotTimeout,
+                requestSlotMatchingStrategy);
     }
 }

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/jobmaster/slotpool/PendingRequest.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/jobmaster/slotpool/PendingRequest.java
@@ -1,0 +1,132 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.flink.runtime.jobmaster.slotpool;
+
+import org.apache.flink.runtime.clusterframework.types.AllocationID;
+import org.apache.flink.runtime.clusterframework.types.ResourceProfile;
+import org.apache.flink.runtime.jobmaster.SlotRequestId;
+
+import java.util.Collection;
+import java.util.HashSet;
+import java.util.Set;
+import java.util.concurrent.CompletableFuture;
+
+final class PendingRequest {
+
+    private final SlotRequestId slotRequestId;
+
+    private final ResourceProfile resourceProfile;
+
+    private final HashSet<AllocationID> preferredAllocations;
+
+    private final CompletableFuture<PhysicalSlot> slotFuture;
+
+    private final boolean isBatchRequest;
+
+    private long unfulfillableSince;
+
+    private PendingRequest(
+            SlotRequestId slotRequestId,
+            ResourceProfile resourceProfile,
+            Collection<AllocationID> preferredAllocations,
+            boolean isBatchRequest) {
+        this.slotRequestId = slotRequestId;
+        this.resourceProfile = resourceProfile;
+        this.preferredAllocations = new HashSet<>(preferredAllocations);
+        this.isBatchRequest = isBatchRequest;
+        this.slotFuture = new CompletableFuture<>();
+        this.unfulfillableSince = Long.MAX_VALUE;
+    }
+
+    static PendingRequest createBatchRequest(
+            SlotRequestId slotRequestId,
+            ResourceProfile resourceProfile,
+            Collection<AllocationID> preferredAllocations) {
+        return new PendingRequest(slotRequestId, resourceProfile, preferredAllocations, true);
+    }
+
+    static PendingRequest createNormalRequest(
+            SlotRequestId slotRequestId,
+            ResourceProfile resourceProfile,
+            Collection<AllocationID> preferredAllocations) {
+        return new PendingRequest(slotRequestId, resourceProfile, preferredAllocations, false);
+    }
+
+    SlotRequestId getSlotRequestId() {
+        return slotRequestId;
+    }
+
+    ResourceProfile getResourceProfile() {
+        return resourceProfile;
+    }
+
+    Set<AllocationID> getPreferredAllocations() {
+        return preferredAllocations;
+    }
+
+    CompletableFuture<PhysicalSlot> getSlotFuture() {
+        return slotFuture;
+    }
+
+    void failRequest(Exception cause) {
+        slotFuture.completeExceptionally(cause);
+    }
+
+    boolean isBatchRequest() {
+        return isBatchRequest;
+    }
+
+    void markFulfillable() {
+        this.unfulfillableSince = Long.MAX_VALUE;
+    }
+
+    void markUnfulfillable(long currentTimestamp) {
+        if (isFulfillable()) {
+            this.unfulfillableSince = currentTimestamp;
+        }
+    }
+
+    private boolean isFulfillable() {
+        return this.unfulfillableSince == Long.MAX_VALUE;
+    }
+
+    long getUnfulfillableSince() {
+        return unfulfillableSince;
+    }
+
+    boolean fulfill(PhysicalSlot slot) {
+        return slotFuture.complete(slot);
+    }
+
+    @Override
+    public String toString() {
+        return "PendingRequest{"
+                + "slotRequestId="
+                + slotRequestId
+                + ", resourceProfile="
+                + resourceProfile
+                + ", preferredAllocations="
+                + preferredAllocations
+                + ", isBatchRequest="
+                + isBatchRequest
+                + ", unfulfillableSince="
+                + unfulfillableSince
+                + '}';
+    }
+}

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/jobmaster/slotpool/PhysicalSlotProviderImpl.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/jobmaster/slotpool/PhysicalSlotProviderImpl.java
@@ -18,6 +18,7 @@
 
 package org.apache.flink.runtime.jobmaster.slotpool;
 
+import org.apache.flink.runtime.clusterframework.types.AllocationID;
 import org.apache.flink.runtime.clusterframework.types.ResourceProfile;
 import org.apache.flink.runtime.clusterframework.types.SlotProfile;
 import org.apache.flink.runtime.jobmaster.SlotRequestId;
@@ -71,6 +72,7 @@ public class PhysicalSlotProviderImpl implements PhysicalSlotProvider {
                                         requestNewSlot(
                                                 slotRequestId,
                                                 resourceProfile,
+                                                slotProfile.getPreferredAllocations(),
                                                 physicalSlotRequest
                                                         .willSlotBeOccupiedIndefinitely()));
 
@@ -99,11 +101,14 @@ public class PhysicalSlotProviderImpl implements PhysicalSlotProvider {
     private CompletableFuture<PhysicalSlot> requestNewSlot(
             SlotRequestId slotRequestId,
             ResourceProfile resourceProfile,
+            Collection<AllocationID> preferredAllocations,
             boolean willSlotBeOccupiedIndefinitely) {
         if (willSlotBeOccupiedIndefinitely) {
-            return slotPool.requestNewAllocatedSlot(slotRequestId, resourceProfile, null);
+            return slotPool.requestNewAllocatedSlot(
+                    slotRequestId, resourceProfile, preferredAllocations, null);
         } else {
-            return slotPool.requestNewAllocatedBatchSlot(slotRequestId, resourceProfile);
+            return slotPool.requestNewAllocatedBatchSlot(
+                    slotRequestId, resourceProfile, preferredAllocations);
         }
     }
 

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/jobmaster/slotpool/PreferredAllocationRequestSlotMatchingStrategy.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/jobmaster/slotpool/PreferredAllocationRequestSlotMatchingStrategy.java
@@ -1,0 +1,103 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.flink.runtime.jobmaster.slotpool;
+
+import org.apache.flink.runtime.clusterframework.types.AllocationID;
+import org.apache.flink.runtime.jobmaster.SlotRequestId;
+
+import java.util.ArrayList;
+import java.util.Collection;
+import java.util.HashMap;
+import java.util.Iterator;
+import java.util.List;
+import java.util.Map;
+import java.util.function.Function;
+import java.util.stream.Collectors;
+
+/**
+ * {@link RequestSlotMatchingStrategy} that takes the preferred allocations into account. The
+ * strategy will try to fulfill the preferred allocations and if this is not possible, then it will
+ * fall back to {@link SimpleRequestSlotMatchingStrategy}.
+ */
+public enum PreferredAllocationRequestSlotMatchingStrategy implements RequestSlotMatchingStrategy {
+    INSTANCE;
+
+    @Override
+    public Collection<RequestSlotMatch> matchRequestsAndSlots(
+            Collection<? extends PhysicalSlot> slots, Collection<PendingRequest> pendingRequests) {
+        final Collection<RequestSlotMatch> requestSlotMatches = new ArrayList<>();
+
+        final Map<AllocationID, PhysicalSlot> freeSlots =
+                slots.stream()
+                        .collect(
+                                Collectors.toMap(
+                                        PhysicalSlot::getAllocationId, Function.identity()));
+
+        final Map<SlotRequestId, PendingRequest> pendingRequestsWithPreferredAllocations =
+                new HashMap<>();
+        final List<PendingRequest> unmatchedRequests = new ArrayList<>();
+
+        // Split requests into those that have preferred allocations and those that don't have
+        for (PendingRequest pendingRequest : pendingRequests) {
+            if (pendingRequest.getPreferredAllocations().isEmpty()) {
+                unmatchedRequests.add(pendingRequest);
+            } else {
+                pendingRequestsWithPreferredAllocations.put(
+                        pendingRequest.getSlotRequestId(), pendingRequest);
+            }
+        }
+
+        final Iterator<PhysicalSlot> freeSlotsIterator = freeSlots.values().iterator();
+        // Match slots and pending requests based on preferred allocation
+        while (freeSlotsIterator.hasNext() && !pendingRequestsWithPreferredAllocations.isEmpty()) {
+            final PhysicalSlot freeSlot = freeSlotsIterator.next();
+
+            final Iterator<PendingRequest> pendingRequestIterator =
+                    pendingRequestsWithPreferredAllocations.values().iterator();
+
+            while (pendingRequestIterator.hasNext()) {
+                final PendingRequest pendingRequest = pendingRequestIterator.next();
+
+                if (freeSlot.getResourceProfile().isMatching(pendingRequest.getResourceProfile())
+                        && pendingRequest
+                                .getPreferredAllocations()
+                                .contains(freeSlot.getAllocationId())) {
+                    requestSlotMatches.add(RequestSlotMatch.createFor(pendingRequest, freeSlot));
+                    pendingRequestIterator.remove();
+                    freeSlotsIterator.remove();
+                    break;
+                }
+            }
+        }
+
+        unmatchedRequests.addAll(pendingRequestsWithPreferredAllocations.values());
+        if (!freeSlots.isEmpty() && !unmatchedRequests.isEmpty()) {
+            requestSlotMatches.addAll(
+                    SimpleRequestSlotMatchingStrategy.INSTANCE.matchRequestsAndSlots(
+                            freeSlots.values(), unmatchedRequests));
+        }
+
+        return requestSlotMatches;
+    }
+
+    @Override
+    public String toString() {
+        return PreferredAllocationRequestSlotMatchingStrategy.class.getSimpleName();
+    }
+}

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/jobmaster/slotpool/PreviousAllocationSlotSelectionStrategy.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/jobmaster/slotpool/PreviousAllocationSlotSelectionStrategy.java
@@ -22,6 +22,9 @@ import org.apache.flink.runtime.clusterframework.types.AllocationID;
 import org.apache.flink.runtime.clusterframework.types.SlotProfile;
 import org.apache.flink.runtime.jobmanager.scheduler.Locality;
 
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
 import javax.annotation.Nonnull;
 
 import java.util.ArrayList;
@@ -36,6 +39,9 @@ import java.util.Set;
  */
 public class PreviousAllocationSlotSelectionStrategy implements SlotSelectionStrategy {
 
+    private static final Logger LOG =
+            LoggerFactory.getLogger(PreviousAllocationSlotSelectionStrategy.class);
+
     private final SlotSelectionStrategy fallbackSlotSelectionStrategy;
 
     private PreviousAllocationSlotSelectionStrategy(
@@ -47,6 +53,8 @@ public class PreviousAllocationSlotSelectionStrategy implements SlotSelectionStr
     public Optional<SlotInfoAndLocality> selectBestSlotForProfile(
             @Nonnull Collection<SlotInfoAndResources> availableSlots,
             @Nonnull SlotProfile slotProfile) {
+
+        LOG.debug("Select best slot for profile {}.", slotProfile);
 
         Collection<AllocationID> priorAllocations = slotProfile.getPreferredAllocations();
 

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/jobmaster/slotpool/RequestSlotMatchingStrategy.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/jobmaster/slotpool/RequestSlotMatchingStrategy.java
@@ -1,0 +1,58 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.flink.runtime.jobmaster.slotpool;
+
+import java.util.Collection;
+
+/** Strategy to match slot requests to slots. */
+public interface RequestSlotMatchingStrategy {
+
+    /**
+     * Match the given slots with the given collection of pending requests.
+     *
+     * @param slots slots to match
+     * @param pendingRequests slot requests to match
+     * @return resulting matches of this operation
+     */
+    Collection<RequestSlotMatch> matchRequestsAndSlots(
+            Collection<? extends PhysicalSlot> slots, Collection<PendingRequest> pendingRequests);
+
+    /** Result class representing matches. */
+    final class RequestSlotMatch {
+        private final PendingRequest pendingRequest;
+        private final PhysicalSlot matchedSlot;
+
+        private RequestSlotMatch(PendingRequest pendingRequest, PhysicalSlot matchedSlot) {
+            this.pendingRequest = pendingRequest;
+            this.matchedSlot = matchedSlot;
+        }
+
+        PhysicalSlot getSlot() {
+            return matchedSlot;
+        }
+
+        PendingRequest getPendingRequest() {
+            return pendingRequest;
+        }
+
+        static RequestSlotMatch createFor(PendingRequest pendingRequest, PhysicalSlot newSlot) {
+            return new RequestSlotMatch(pendingRequest, newSlot);
+        }
+    }
+}

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/jobmaster/slotpool/SimpleRequestSlotMatchingStrategy.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/jobmaster/slotpool/SimpleRequestSlotMatchingStrategy.java
@@ -1,0 +1,61 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.flink.runtime.jobmaster.slotpool;
+
+import java.util.ArrayList;
+import java.util.Collection;
+import java.util.Iterator;
+import java.util.LinkedList;
+
+/**
+ * Simple implementation of the {@link RequestSlotMatchingStrategy} that matches the pending
+ * requests in order as long as the resource profile can be fulfilled.
+ */
+public enum SimpleRequestSlotMatchingStrategy implements RequestSlotMatchingStrategy {
+    INSTANCE;
+
+    @Override
+    public Collection<RequestSlotMatch> matchRequestsAndSlots(
+            Collection<? extends PhysicalSlot> slots, Collection<PendingRequest> pendingRequests) {
+        final Collection<RequestSlotMatch> resultingMatches = new ArrayList<>();
+
+        // if pendingRequests has a special order, then let's preserve it
+        final LinkedList<PendingRequest> pendingRequestsIndex = new LinkedList<>(pendingRequests);
+
+        for (PhysicalSlot slot : slots) {
+            final Iterator<PendingRequest> pendingRequestIterator = pendingRequestsIndex.iterator();
+
+            while (pendingRequestIterator.hasNext()) {
+                final PendingRequest pendingRequest = pendingRequestIterator.next();
+                if (slot.getResourceProfile().isMatching(pendingRequest.getResourceProfile())) {
+                    resultingMatches.add(RequestSlotMatch.createFor(pendingRequest, slot));
+                    pendingRequestIterator.remove();
+                    break;
+                }
+            }
+        }
+
+        return resultingMatches;
+    }
+
+    @Override
+    public String toString() {
+        return SimpleRequestSlotMatchingStrategy.class.getSimpleName();
+    }
+}

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/jobmaster/slotpool/SlotPool.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/jobmaster/slotpool/SlotPool.java
@@ -32,7 +32,6 @@ import org.apache.flink.runtime.resourcemanager.ResourceManagerGateway;
 import org.apache.flink.runtime.taskexecutor.slot.SlotOffer;
 import org.apache.flink.runtime.taskmanager.TaskManagerLocation;
 
-import javax.annotation.Nonnull;
 import javax.annotation.Nullable;
 
 import java.util.Collection;
@@ -123,7 +122,6 @@ public interface SlotPool extends AllocatedSlotActions, AutoCloseable {
      * @return a list of {@link SlotInfoWithUtilization} objects about all slots that are currently
      *     available in the slot pool.
      */
-    @Nonnull
     Collection<SlotInfoWithUtilization> getAvailableSlotsInformation();
 
     /**
@@ -147,9 +145,9 @@ public interface SlotPool extends AllocatedSlotActions, AutoCloseable {
      *     allocation id exists
      */
     Optional<PhysicalSlot> allocateAvailableSlot(
-            @Nonnull SlotRequestId slotRequestId,
-            @Nonnull AllocationID allocationID,
-            @Nonnull ResourceProfile requirementProfile);
+            SlotRequestId slotRequestId,
+            AllocationID allocationID,
+            ResourceProfile requirementProfile);
 
     /**
      * Request the allocation of a new slot from the resource manager. This method will not return a
@@ -162,11 +160,8 @@ public interface SlotPool extends AllocatedSlotActions, AutoCloseable {
      * @param timeout timeout for the allocation procedure
      * @return a newly allocated slot that was previously not available.
      */
-    @Nonnull
     default CompletableFuture<PhysicalSlot> requestNewAllocatedSlot(
-            @Nonnull SlotRequestId slotRequestId,
-            @Nonnull ResourceProfile resourceProfile,
-            @Nullable Time timeout) {
+            SlotRequestId slotRequestId, ResourceProfile resourceProfile, @Nullable Time timeout) {
         return requestNewAllocatedSlot(
                 slotRequestId, resourceProfile, Collections.emptyList(), timeout);
     }
@@ -184,9 +179,9 @@ public interface SlotPool extends AllocatedSlotActions, AutoCloseable {
      * @return a newly allocated slot that was previously not available.
      */
     CompletableFuture<PhysicalSlot> requestNewAllocatedSlot(
-            @Nonnull SlotRequestId slotRequestId,
-            @Nonnull ResourceProfile resourceProfile,
-            @Nonnull Collection<AllocationID> preferredAllocations,
+            SlotRequestId slotRequestId,
+            ResourceProfile resourceProfile,
+            Collection<AllocationID> preferredAllocations,
             @Nullable Time timeout);
 
     /**
@@ -199,17 +194,15 @@ public interface SlotPool extends AllocatedSlotActions, AutoCloseable {
      *     requested batch slot
      * @return a future which is completed with newly allocated batch slot
      */
-    @Nonnull
     default CompletableFuture<PhysicalSlot> requestNewAllocatedBatchSlot(
-            @Nonnull SlotRequestId slotRequestId, @Nonnull ResourceProfile resourceProfile) {
+            SlotRequestId slotRequestId, ResourceProfile resourceProfile) {
         return requestNewAllocatedBatchSlot(
                 slotRequestId, resourceProfile, Collections.emptyList());
     }
 
-    @Nonnull
     CompletableFuture<PhysicalSlot> requestNewAllocatedBatchSlot(
-            @Nonnull SlotRequestId slotRequestId,
-            @Nonnull ResourceProfile resourceProfile,
+            SlotRequestId slotRequestId,
+            ResourceProfile resourceProfile,
             Collection<AllocationID> preferredAllocations);
 
     /**

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/jobmaster/slotpool/SlotPool.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/jobmaster/slotpool/SlotPool.java
@@ -36,6 +36,7 @@ import javax.annotation.Nonnull;
 import javax.annotation.Nullable;
 
 import java.util.Collection;
+import java.util.Collections;
 import java.util.Optional;
 import java.util.concurrent.CompletableFuture;
 
@@ -162,9 +163,30 @@ public interface SlotPool extends AllocatedSlotActions, AutoCloseable {
      * @return a newly allocated slot that was previously not available.
      */
     @Nonnull
+    default CompletableFuture<PhysicalSlot> requestNewAllocatedSlot(
+            @Nonnull SlotRequestId slotRequestId,
+            @Nonnull ResourceProfile resourceProfile,
+            @Nullable Time timeout) {
+        return requestNewAllocatedSlot(
+                slotRequestId, resourceProfile, Collections.emptyList(), timeout);
+    }
+
+    /**
+     * Request the allocation of a new slot from the resource manager. This method will not return a
+     * slot from the already available slots from the pool, but instead will add a new slot to that
+     * pool that is immediately allocated and returned.
+     *
+     * @param slotRequestId identifying the requested slot
+     * @param resourceProfile resource profile that specifies the resource requirements for the
+     *     requested slot
+     * @param preferredAllocations preferred allocations for the new allocated slot
+     * @param timeout timeout for the allocation procedure
+     * @return a newly allocated slot that was previously not available.
+     */
     CompletableFuture<PhysicalSlot> requestNewAllocatedSlot(
             @Nonnull SlotRequestId slotRequestId,
             @Nonnull ResourceProfile resourceProfile,
+            @Nonnull Collection<AllocationID> preferredAllocations,
             @Nullable Time timeout);
 
     /**
@@ -178,8 +200,17 @@ public interface SlotPool extends AllocatedSlotActions, AutoCloseable {
      * @return a future which is completed with newly allocated batch slot
      */
     @Nonnull
+    default CompletableFuture<PhysicalSlot> requestNewAllocatedBatchSlot(
+            @Nonnull SlotRequestId slotRequestId, @Nonnull ResourceProfile resourceProfile) {
+        return requestNewAllocatedBatchSlot(
+                slotRequestId, resourceProfile, Collections.emptyList());
+    }
+
+    @Nonnull
     CompletableFuture<PhysicalSlot> requestNewAllocatedBatchSlot(
-            @Nonnull SlotRequestId slotRequestId, @Nonnull ResourceProfile resourceProfile);
+            @Nonnull SlotRequestId slotRequestId,
+            @Nonnull ResourceProfile resourceProfile,
+            Collection<AllocationID> preferredAllocations);
 
     /**
      * Disables batch slot request timeout check. Invoked when someone else wants to take over the

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/scheduler/ExecutionSlotSharingGroup.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/scheduler/ExecutionSlotSharingGroup.java
@@ -52,4 +52,14 @@ class ExecutionSlotSharingGroup {
     Set<ExecutionVertexID> getExecutionVertexIds() {
         return Collections.unmodifiableSet(executionVertexIds);
     }
+
+    @Override
+    public String toString() {
+        return "ExecutionSlotSharingGroup{"
+                + "executionVertexIds="
+                + executionVertexIds
+                + ", resourceProfile="
+                + resourceProfile
+                + '}';
+    }
 }

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/scheduler/MergingSharedSlotProfileRetrieverFactory.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/scheduler/MergingSharedSlotProfileRetrieverFactory.java
@@ -35,6 +35,7 @@ import java.util.function.Supplier;
 /** Factory for {@link MergingSharedSlotProfileRetriever}. */
 class MergingSharedSlotProfileRetrieverFactory
         implements SharedSlotProfileRetriever.SharedSlotProfileRetrieverFactory {
+
     private final SyncPreferredLocationsRetriever preferredLocationsRetriever;
 
     private final Function<ExecutionVertexID, AllocationID> priorAllocationIdRetriever;
@@ -102,6 +103,7 @@ class MergingSharedSlotProfileRetrieverFactory
                         preferredLocationsRetriever.getPreferredLocations(
                                 execution, producersToIgnore));
             }
+
             return SlotProfile.priorAllocation(
                     physicalSlotResourceProfile,
                     physicalSlotResourceProfile,

--- a/flink-runtime/src/test/java/org/apache/flink/runtime/jobmaster/DefaultSlotPoolServiceSchedulerFactoryTest.java
+++ b/flink-runtime/src/test/java/org/apache/flink/runtime/jobmaster/DefaultSlotPoolServiceSchedulerFactoryTest.java
@@ -24,16 +24,16 @@ import org.apache.flink.configuration.SchedulerExecutionMode;
 import org.apache.flink.runtime.jobgraph.JobType;
 import org.apache.flink.runtime.scheduler.DefaultSchedulerFactory;
 import org.apache.flink.runtime.scheduler.adaptive.AdaptiveSchedulerFactory;
-import org.apache.flink.util.TestLogger;
+import org.apache.flink.util.TestLoggerExtension;
 
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
 
-import static org.hamcrest.Matchers.instanceOf;
-import static org.hamcrest.Matchers.is;
-import static org.junit.Assert.assertThat;
+import static org.assertj.core.api.Assertions.assertThat;
 
 /** Tests for the {@link DefaultSlotPoolServiceSchedulerFactory}. */
-public class DefaultSlotPoolServiceSchedulerFactoryTest extends TestLogger {
+@ExtendWith(TestLoggerExtension.class)
+public class DefaultSlotPoolServiceSchedulerFactoryTest {
 
     @Test
     public void testFallsBackToDefaultSchedulerIfBatchJob() {
@@ -44,12 +44,10 @@ public class DefaultSlotPoolServiceSchedulerFactoryTest extends TestLogger {
                 DefaultSlotPoolServiceSchedulerFactory.fromConfiguration(
                         configuration, JobType.BATCH);
 
-        assertThat(
-                defaultSlotPoolServiceSchedulerFactory.getSchedulerNGFactory(),
-                is(instanceOf(DefaultSchedulerFactory.class)));
-        assertThat(
-                defaultSlotPoolServiceSchedulerFactory.getSchedulerType(),
-                is(JobManagerOptions.SchedulerType.Ng));
+        assertThat(defaultSlotPoolServiceSchedulerFactory.getSchedulerNGFactory())
+                .isInstanceOf(DefaultSchedulerFactory.class);
+        assertThat(defaultSlotPoolServiceSchedulerFactory.getSchedulerType())
+                .isEqualTo(JobManagerOptions.SchedulerType.Ng);
     }
 
     @Test
@@ -61,11 +59,9 @@ public class DefaultSlotPoolServiceSchedulerFactoryTest extends TestLogger {
                 DefaultSlotPoolServiceSchedulerFactory.fromConfiguration(
                         configuration, JobType.STREAMING);
 
-        assertThat(
-                defaultSlotPoolServiceSchedulerFactory.getSchedulerNGFactory(),
-                is(instanceOf(AdaptiveSchedulerFactory.class)));
-        assertThat(
-                defaultSlotPoolServiceSchedulerFactory.getSchedulerType(),
-                is(JobManagerOptions.SchedulerType.Adaptive));
+        assertThat(defaultSlotPoolServiceSchedulerFactory.getSchedulerNGFactory())
+                .isInstanceOf(AdaptiveSchedulerFactory.class);
+        assertThat(defaultSlotPoolServiceSchedulerFactory.getSchedulerType())
+                .isEqualTo(JobManagerOptions.SchedulerType.Adaptive);
     }
 }

--- a/flink-runtime/src/test/java/org/apache/flink/runtime/jobmaster/JobMasterTest.java
+++ b/flink-runtime/src/test/java/org/apache/flink/runtime/jobmaster/JobMasterTest.java
@@ -596,6 +596,7 @@ public class JobMasterTest extends TestLogger {
         public CompletableFuture<PhysicalSlot> requestNewAllocatedSlot(
                 @Nonnull SlotRequestId slotRequestId,
                 @Nonnull ResourceProfile resourceProfile,
+                @Nonnull Collection<AllocationID> preferredAllocations,
                 @Nullable Time timeout) {
             return new CompletableFuture<>();
         }
@@ -603,7 +604,9 @@ public class JobMasterTest extends TestLogger {
         @Nonnull
         @Override
         public CompletableFuture<PhysicalSlot> requestNewAllocatedBatchSlot(
-                @Nonnull SlotRequestId slotRequestId, @Nonnull ResourceProfile resourceProfile) {
+                @Nonnull SlotRequestId slotRequestId,
+                @Nonnull ResourceProfile resourceProfile,
+                @Nonnull Collection<AllocationID> preferredAllocations) {
             return new CompletableFuture<>();
         }
 

--- a/flink-runtime/src/test/java/org/apache/flink/runtime/jobmaster/slotpool/DeclarativeSlotPoolBridgeBuilder.java
+++ b/flink-runtime/src/test/java/org/apache/flink/runtime/jobmaster/slotpool/DeclarativeSlotPoolBridgeBuilder.java
@@ -45,6 +45,9 @@ public class DeclarativeSlotPoolBridgeBuilder {
     @Nullable
     private ResourceManagerGateway resourceManagerGateway = new TestingResourceManagerGateway();
 
+    private RequestSlotMatchingStrategy requestSlotMatchingStrategy =
+            SimpleRequestSlotMatchingStrategy.INSTANCE;
+
     public DeclarativeSlotPoolBridgeBuilder setResourceManagerGateway(
             @Nullable ResourceManagerGateway resourceManagerGateway) {
         this.resourceManagerGateway = resourceManagerGateway;
@@ -71,6 +74,12 @@ public class DeclarativeSlotPoolBridgeBuilder {
         return this;
     }
 
+    public DeclarativeSlotPoolBridgeBuilder setRequestSlotMatchingStrategy(
+            RequestSlotMatchingStrategy requestSlotMatchingStrategy) {
+        this.requestSlotMatchingStrategy = requestSlotMatchingStrategy;
+        return this;
+    }
+
     public DeclarativeSlotPoolBridge build() {
         return new DeclarativeSlotPoolBridge(
                 jobId,
@@ -78,7 +87,8 @@ public class DeclarativeSlotPoolBridgeBuilder {
                 clock,
                 TestingUtils.infiniteTime(),
                 idleSlotTimeout,
-                batchSlotTimeout);
+                batchSlotTimeout,
+                requestSlotMatchingStrategy);
     }
 
     public DeclarativeSlotPoolBridge buildAndStart(

--- a/flink-runtime/src/test/java/org/apache/flink/runtime/jobmaster/slotpool/DeclarativeSlotPoolBridgePreferredAllocationsTest.java
+++ b/flink-runtime/src/test/java/org/apache/flink/runtime/jobmaster/slotpool/DeclarativeSlotPoolBridgePreferredAllocationsTest.java
@@ -1,0 +1,104 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.flink.runtime.jobmaster.slotpool;
+
+import org.apache.flink.api.common.JobID;
+import org.apache.flink.runtime.clusterframework.types.AllocationID;
+import org.apache.flink.runtime.clusterframework.types.ResourceProfile;
+import org.apache.flink.runtime.concurrent.ComponentMainThreadExecutorServiceAdapter;
+import org.apache.flink.runtime.executiongraph.utils.SimpleAckingTaskManagerGateway;
+import org.apache.flink.runtime.jobmaster.JobMasterId;
+import org.apache.flink.runtime.jobmaster.SlotRequestId;
+import org.apache.flink.runtime.taskexecutor.slot.SlotOffer;
+import org.apache.flink.runtime.taskmanager.LocalTaskManagerLocation;
+import org.apache.flink.testutils.TestingUtils;
+import org.apache.flink.util.TestLoggerExtension;
+import org.apache.flink.util.clock.SystemClock;
+
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+
+import javax.annotation.Nonnull;
+
+import java.util.ArrayList;
+import java.util.Collection;
+import java.util.Collections;
+import java.util.Set;
+import java.util.concurrent.CompletableFuture;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+@ExtendWith(TestLoggerExtension.class)
+public class DeclarativeSlotPoolBridgePreferredAllocationsTest {
+
+    @Test
+    public void testDeclarativeSlotPoolTakesPreferredAllocationsIntoAccount() throws Exception {
+        final DeclarativeSlotPoolBridge declarativeSlotPoolBridge =
+                new DeclarativeSlotPoolBridge(
+                        new JobID(),
+                        new DefaultDeclarativeSlotPoolFactory(),
+                        SystemClock.getInstance(),
+                        TestingUtils.infiniteTime(),
+                        TestingUtils.infiniteTime(),
+                        TestingUtils.infiniteTime(),
+                        PreferredAllocationRequestSlotMatchingStrategy.INSTANCE);
+
+        declarativeSlotPoolBridge.start(
+                JobMasterId.generate(),
+                "localhost",
+                ComponentMainThreadExecutorServiceAdapter.forMainThread());
+
+        final LocalTaskManagerLocation localTaskManagerLocation = new LocalTaskManagerLocation();
+
+        final AllocationID allocationId1 = new AllocationID();
+        final AllocationID allocationId2 = new AllocationID();
+
+        final CompletableFuture<PhysicalSlot> slotRequestWithPreferredAllocation1 =
+                requestSlot(declarativeSlotPoolBridge, Collections.singleton(allocationId1));
+        final CompletableFuture<PhysicalSlot> slotRequestWithEmptyPreferredAllocations =
+                requestSlot(declarativeSlotPoolBridge, Collections.emptySet());
+        final CompletableFuture<PhysicalSlot> slotRequestWithPreferredAllocation2 =
+                requestSlot(declarativeSlotPoolBridge, Collections.singleton(allocationId2));
+
+        final Collection<SlotOffer> slotOffers = new ArrayList<>();
+        slotOffers.add(new SlotOffer(allocationId2, 0, ResourceProfile.ANY));
+        final AllocationID otherAllocationId = new AllocationID();
+        slotOffers.add(new SlotOffer(otherAllocationId, 1, ResourceProfile.ANY));
+        slotOffers.add(new SlotOffer(allocationId1, 2, ResourceProfile.ANY));
+
+        declarativeSlotPoolBridge.registerTaskManager(localTaskManagerLocation.getResourceID());
+        declarativeSlotPoolBridge.offerSlots(
+                localTaskManagerLocation, new SimpleAckingTaskManagerGateway(), slotOffers);
+
+        assertThat(slotRequestWithPreferredAllocation1.join().getAllocationId())
+                .isEqualTo(allocationId1);
+        assertThat(slotRequestWithPreferredAllocation2.join().getAllocationId())
+                .isEqualTo(allocationId2);
+        assertThat(slotRequestWithEmptyPreferredAllocations.join().getAllocationId())
+                .isEqualTo(otherAllocationId);
+    }
+
+    @Nonnull
+    private CompletableFuture<PhysicalSlot> requestSlot(
+            DeclarativeSlotPoolBridge declarativeSlotPoolBridge,
+            Set<AllocationID> preferredAllocations) {
+        return declarativeSlotPoolBridge.requestNewAllocatedSlot(
+                new SlotRequestId(), ResourceProfile.UNKNOWN, preferredAllocations, null);
+    }
+}

--- a/flink-runtime/src/test/java/org/apache/flink/runtime/jobmaster/slotpool/PreferredAllocationRequestSlotMatchingStrategyTest.java
+++ b/flink-runtime/src/test/java/org/apache/flink/runtime/jobmaster/slotpool/PreferredAllocationRequestSlotMatchingStrategyTest.java
@@ -1,0 +1,77 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.flink.runtime.jobmaster.slotpool;
+
+import org.apache.flink.runtime.clusterframework.types.AllocationID;
+import org.apache.flink.runtime.clusterframework.types.ResourceProfile;
+import org.apache.flink.runtime.jobmaster.SlotRequestId;
+import org.apache.flink.runtime.scheduler.TestingPhysicalSlot;
+import org.apache.flink.util.TestLoggerExtension;
+
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+
+import java.util.Arrays;
+import java.util.Collection;
+import java.util.Collections;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+/** Tests for the {@link PreferredAllocationRequestSlotMatchingStrategy}. */
+@ExtendWith(TestLoggerExtension.class)
+public class PreferredAllocationRequestSlotMatchingStrategyTest {
+
+    /**
+     * This test ensures that new slots are matched against the preferred allocationIds of the
+     * pending requests.
+     */
+    @Test
+    public void testNewSlotsAreMatchedAgainstPreferredAllocationIDs() throws Exception {
+        final PreferredAllocationRequestSlotMatchingStrategy strategy =
+                PreferredAllocationRequestSlotMatchingStrategy.INSTANCE;
+
+        final AllocationID allocationId1 = new AllocationID();
+        final AllocationID allocationId2 = new AllocationID();
+
+        final Collection<TestingPhysicalSlot> slots =
+                Arrays.asList(
+                        TestingPhysicalSlot.builder().withAllocationID(allocationId1).build(),
+                        TestingPhysicalSlot.builder().withAllocationID(allocationId2).build());
+        final Collection<PendingRequest> pendingRequests =
+                Arrays.asList(
+                        PendingRequest.createNormalRequest(
+                                new SlotRequestId(),
+                                ResourceProfile.UNKNOWN,
+                                Collections.singleton(allocationId2)),
+                        PendingRequest.createNormalRequest(
+                                new SlotRequestId(),
+                                ResourceProfile.UNKNOWN,
+                                Collections.singleton(allocationId1)));
+
+        final Collection<RequestSlotMatchingStrategy.RequestSlotMatch> requestSlotMatches =
+                strategy.matchRequestsAndSlots(slots, pendingRequests);
+
+        assertThat(requestSlotMatches).hasSize(2);
+
+        for (RequestSlotMatchingStrategy.RequestSlotMatch requestSlotMatch : requestSlotMatches) {
+            assertThat(requestSlotMatch.getPendingRequest().getPreferredAllocations())
+                    .contains(requestSlotMatch.getSlot().getAllocationId());
+        }
+    }
+}

--- a/flink-runtime/src/test/java/org/apache/flink/runtime/jobmaster/slotpool/SimpleRequestSlotMatchingStrategyTest.java
+++ b/flink-runtime/src/test/java/org/apache/flink/runtime/jobmaster/slotpool/SimpleRequestSlotMatchingStrategyTest.java
@@ -1,0 +1,99 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.flink.runtime.jobmaster.slotpool;
+
+import org.apache.flink.runtime.clusterframework.types.ResourceProfile;
+import org.apache.flink.runtime.jobmaster.SlotRequestId;
+import org.apache.flink.runtime.scheduler.TestingPhysicalSlot;
+import org.apache.flink.util.TestLoggerExtension;
+
+import org.apache.flink.shaded.guava30.com.google.common.collect.Iterators;
+
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+
+import java.util.Arrays;
+import java.util.Collection;
+import java.util.Collections;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+/** Tests for the {@link SimpleRequestSlotMatchingStrategy}. */
+@ExtendWith(TestLoggerExtension.class)
+public class SimpleRequestSlotMatchingStrategyTest {
+
+    @Test
+    public void testSlotRequestsAreMatchedInOrder() {
+        final SimpleRequestSlotMatchingStrategy simpleRequestSlotMatchingStrategy =
+                SimpleRequestSlotMatchingStrategy.INSTANCE;
+
+        final Collection<PhysicalSlot> slots = Arrays.asList(TestingPhysicalSlot.builder().build());
+        final PendingRequest pendingRequest1 =
+                PendingRequest.createNormalRequest(
+                        new SlotRequestId(), ResourceProfile.UNKNOWN, Collections.emptyList());
+        final PendingRequest pendingRequest2 =
+                PendingRequest.createNormalRequest(
+                        new SlotRequestId(), ResourceProfile.UNKNOWN, Collections.emptyList());
+        final Collection<PendingRequest> pendingRequests =
+                Arrays.asList(pendingRequest1, pendingRequest2);
+
+        final Collection<RequestSlotMatchingStrategy.RequestSlotMatch> requestSlotMatches =
+                simpleRequestSlotMatchingStrategy.matchRequestsAndSlots(slots, pendingRequests);
+
+        assertThat(requestSlotMatches).hasSize(1);
+        assertThat(
+                        Iterators.getOnlyElement(requestSlotMatches.iterator())
+                                .getPendingRequest()
+                                .getSlotRequestId())
+                .isEqualTo(pendingRequest1.getSlotRequestId());
+    }
+
+    @Test
+    public void testSlotRequestsThatCanBeFulfilledAreMatched() {
+        final SimpleRequestSlotMatchingStrategy simpleRequestSlotMatchingStrategy =
+                SimpleRequestSlotMatchingStrategy.INSTANCE;
+
+        final ResourceProfile small = ResourceProfile.newBuilder().setCpuCores(1.0).build();
+        final ResourceProfile large = ResourceProfile.newBuilder().setCpuCores(2.0).build();
+
+        final Collection<PhysicalSlot> slots =
+                Arrays.asList(
+                        TestingPhysicalSlot.builder().withResourceProfile(small).build(),
+                        TestingPhysicalSlot.builder().withResourceProfile(small).build());
+
+        final PendingRequest pendingRequest1 =
+                PendingRequest.createNormalRequest(
+                        new SlotRequestId(), large, Collections.emptyList());
+        final PendingRequest pendingRequest2 =
+                PendingRequest.createNormalRequest(
+                        new SlotRequestId(), small, Collections.emptyList());
+        final Collection<PendingRequest> pendingRequests =
+                Arrays.asList(pendingRequest1, pendingRequest2);
+
+        final Collection<RequestSlotMatchingStrategy.RequestSlotMatch> requestSlotMatches =
+                simpleRequestSlotMatchingStrategy.matchRequestsAndSlots(slots, pendingRequests);
+
+        assertThat(requestSlotMatches).hasSize(1);
+        assertThat(
+                        Iterators.getOnlyElement(requestSlotMatches.iterator())
+                                .getPendingRequest()
+                                .getSlotRequestId())
+                .isEqualTo(pendingRequest2.getSlotRequestId());
+    }
+}


### PR DESCRIPTION
## What is the purpose of the change

This commit forwards the preferred allocations into the DeclarativeSlotPoolBridge so that
new slots can be matched against the preferred allocations.

Moreover, the commit introduces a RequestSlotMatchingStrategy that is used by the DeclarativeSlotPoolBridge
to match slots to pending requests. If local recovery is enabled, then Flink will use the
PreferredAllocationRequestSlotMatchingStrategy that first tries to match pending requests to slots based on
their preferred allocation and then falls back to SimpleRequestSlotMatchingStrategy that matches solely on the
ResourceProfile basis.

## Does this pull request potentially affect one of the following parts:

  - Dependencies (does it add or upgrade a dependency): (yes / **no**)
  - The public API, i.e., is any changed class annotated with `@Public(Evolving)`: (yes / **no**)
  - The serializers: (yes / **no** / don't know)
  - The runtime per-record code paths (performance sensitive): (yes / **no** / don't know)
  - Anything that affects deployment or recovery: JobManager (and its components), Checkpointing, Kubernetes/Yarn, ZooKeeper: (**yes** / no / don't know)
  - The S3 file system connector: (yes / **no** / don't know)

## Documentation

  - Does this pull request introduce a new feature? (yes / **no**)
  - If yes, how is the feature documented? (**not applicable** / docs / JavaDocs / not documented)
