### PR TITLE
[FLINK-25227][table-runtime] Boxed numeric type should be considered when generating code for equality checking

### DIFF
--- a/flink-table/flink-table-planner/src/main/scala/org/apache/flink/table/planner/codegen/CodeGenUtils.scala
+++ b/flink-table/flink-table-planner/src/main/scala/org/apache/flink/table/planner/codegen/CodeGenUtils.scala
@@ -34,6 +34,7 @@ import org.apache.flink.table.data.utils.JoinedRowData
 import org.apache.flink.table.functions.UserDefinedFunction
 import org.apache.flink.table.planner.codegen.GenerateUtils.{generateInputFieldUnboxing, generateNonNullField}
 import org.apache.flink.table.runtime.dataview.StateDataViewStore
+import org.apache.flink.table.runtime.functions.NumericUtils
 import org.apache.flink.table.runtime.generated.{AggsHandleFunction, HashFunction, NamespaceAggsHandleFunction, TableAggsHandleFunction}
 import org.apache.flink.table.runtime.types.LogicalTypeDataTypeConverter.fromDataTypeToLogicalType
 import org.apache.flink.table.runtime.types.PlannerTypeUtils.isInteroperable
@@ -47,6 +48,10 @@ import org.apache.flink.table.types.logical.utils.LogicalTypeChecks.{getFieldCou
 import org.apache.flink.table.types.logical.utils.LogicalTypeUtils.toInternalConversionClass
 import org.apache.flink.table.types.utils.DataTypeUtils.isInternal
 import org.apache.flink.types.{Row, RowKind}
+
+import java.lang.reflect.Method
+import java.lang.{Boolean => JBoolean, Byte => JByte, Double => JDouble, Float => JFloat, Integer => JInt, Long => JLong, Object => JObject, Short => JShort}
+import java.util.concurrent.atomic.AtomicLong
 
 import scala.annotation.tailrec
 
@@ -95,6 +100,8 @@ object CodeGenUtils {
   val GENERIC_ROW: String = className[GenericRowData]
 
   val ROW_KIND: String = className[RowKind]
+
+  val NUMERIC_UTIL: String = className[NumericUtils]
 
   val DECIMAL_UTIL: String = className[DecimalDataUtils]
 

--- a/flink-table/flink-table-planner/src/main/scala/org/apache/flink/table/planner/codegen/calls/ScalarOperatorGens.scala
+++ b/flink-table/flink-table-planner/src/main/scala/org/apache/flink/table/planner/codegen/calls/ScalarOperatorGens.scala
@@ -607,7 +607,11 @@ object ScalarOperatorGens {
       }
       // both sides are numeric
       else if (isNumeric(left.resultType) && isNumeric(right.resultType)) {
-        (leftTerm, rightTerm) => s"$leftTerm $operator $rightTerm"
+        operator match {
+          case "==" => (leftTerm, rightTerm) => s"$NUMERIC_UTIL.equals($leftTerm, $rightTerm)"
+          case "!=" => (leftTerm, rightTerm) => s"!$NUMERIC_UTIL.equals($leftTerm, $rightTerm)"
+          case _ => (leftTerm, rightTerm) => s"$leftTerm $operator $rightTerm"
+        }
       }
 
       // both sides are timestamp
@@ -626,7 +630,11 @@ object ScalarOperatorGens {
       // both sides are temporal of same type
       else if (isTemporal(left.resultType) &&
           isInteroperable(left.resultType, right.resultType)) {
-        (leftTerm, rightTerm) => s"$leftTerm $operator $rightTerm"
+        operator match {
+          case "==" => (leftTerm, rightTerm) => s"$NUMERIC_UTIL.equals($leftTerm, $rightTerm)"
+          case "!=" => (leftTerm, rightTerm) => s"!$NUMERIC_UTIL.equals($leftTerm, $rightTerm)"
+          case _ => (leftTerm, rightTerm) => s"$leftTerm $operator $rightTerm"
+        }
       }
       // both sides are boolean
       else if (isBoolean(left.resultType) &&

--- a/flink-table/flink-table-runtime/src/main/java/org/apache/flink/table/runtime/functions/NumericUtils.java
+++ b/flink-table/flink-table-runtime/src/main/java/org/apache/flink/table/runtime/functions/NumericUtils.java
@@ -1,0 +1,46 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.	See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.	You may obtain a copy of the License at
+ *
+ *		http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.flink.table.runtime.functions;
+
+/** Utility functions for numeric types: tinyint, smallint, int, long, float and double. */
+public class NumericUtils {
+
+    public static boolean equals(byte a, byte b) {
+        return a == b;
+    }
+
+    public static boolean equals(short a, short b) {
+        return a == b;
+    }
+
+    public static boolean equals(int a, int b) {
+        return a == b;
+    }
+
+    public static boolean equals(long a, long b) {
+        return a == b;
+    }
+
+    public static boolean equals(float a, float b) {
+        return a == b;
+    }
+
+    public static boolean equals(double a, double b) {
+        return a == b;
+    }
+}


### PR DESCRIPTION
## What is the purpose of the change

Currently generated Java code for equality checking does not consider boxed Java types. This PR fixes this issue.

## Brief change log

 - Boxed numeric type should be considered when generating code for equality checking

## Verifying this change

This change added tests and can be verified by running the added tests.

## Does this pull request potentially affect one of the following parts:

  - Dependencies (does it add or upgrade a dependency): no
  - The public API, i.e., is any changed class annotated with `@Public(Evolving)`: no
  - The serializers: no
  - The runtime per-record code paths (performance sensitive): no
  - Anything that affects deployment or recovery: JobManager (and its components), Checkpointing, Kubernetes/Yarn, ZooKeeper: no
  - The S3 file system connector: no

## Documentation

  - Does this pull request introduce a new feature? no
  - If yes, how is the feature documented? not applicable
