### PR TITLE
[FLINK-24880][python] Fix PeriodicThread to handle properly for negative wait timeout value

### DIFF
--- a/flink-python/pyflink/fn_execution/beam/beam_stream_fast.pyx
+++ b/flink-python/pyflink/fn_execution/beam/beam_stream_fast.pyx
@@ -23,7 +23,7 @@
 from libc.stdlib cimport realloc
 from libc.string cimport memcpy
 
-from apache_beam.runners.worker.data_plane import PeriodicThread
+from pyflink.fn_execution.utils.operation_utils import PeriodicThread
 
 cdef class BeamInputStream(LengthPrefixInputStream):
     def __cinit__(self, input_stream, size):

--- a/flink-python/pyflink/fn_execution/beam/beam_stream_slow.py
+++ b/flink-python/pyflink/fn_execution/beam/beam_stream_slow.py
@@ -16,9 +16,9 @@
 # limitations under the License.
 ################################################################################
 from apache_beam.coders.coder_impl import create_InputStream, create_OutputStream
-from apache_beam.runners.worker.data_plane import PeriodicThread
 
 from pyflink.fn_execution.stream_slow import InputStream
+from pyflink.fn_execution.utils.operation_utils import PeriodicThread
 
 
 class BeamInputStream(InputStream):

--- a/flink-python/pyflink/fn_execution/utils/operation_utils.py
+++ b/flink-python/pyflink/fn_execution/utils/operation_utils.py
@@ -283,8 +283,7 @@ class PeriodicThread(threading.Thread):
                  function,
                  args=None,
                  kwargs=None
-                 ):
-        # type: (...) -> None
+                 ) -> None:
         threading.Thread.__init__(self)
         self._interval = interval
         self._function = function
@@ -292,18 +291,18 @@ class PeriodicThread(threading.Thread):
         self._kwargs = kwargs if kwargs is not None else {}
         self._finished = threading.Event()
 
-    def run(self):
-        # type: () -> None
-        next_call = time.time() + self._interval
+    def run(self) -> None:
         now = time.time()
+        next_call = now + self._interval
         while (next_call <= now and not self._finished.is_set()) or \
                 (not self._finished.wait(next_call - now)):
-            next_call = next_call + self._interval
+            if next_call <= now:
+                next_call = now + self._interval
+            else:
+                next_call = next_call + self._interval
             self._function(*self._args, **self._kwargs)
             now = time.time()
 
-    def cancel(self):
-        # type: () -> None
-
+    def cancel(self) -> None:
         """Stop the thread if it hasn't finished yet."""
         self._finished.set()


### PR DESCRIPTION
## What is the purpose of the change

* This pull request fixes the PeriodicThread to handle properly for negative wait timeout value. Negative timeout value causes problems in windows platform. *


## Verifying this change

This change is a trivial rework without any test coverage.

## Does this pull request potentially affect one of the following parts:

  - Dependencies (does it add or upgrade a dependency): (no)
  - The public API, i.e., is any changed class annotated with `@Public(Evolving)`: (no)
  - The serializers: (no)
  - The runtime per-record code paths (performance sensitive): (no )
  - Anything that affects deployment or recovery: JobManager (and its components), Checkpointing, Kubernetes/Yarn, ZooKeeper: (no)
  - The S3 file system connector: ( no)

## Documentation

  - Does this pull request introduce a new feature? (no)
  - If yes, how is the feature documented? (not applicable)
