### PR TITLE
[hotfix][rpc] Use AtomicLong#getAndIncrement to simplify increment number

### DIFF
--- a/flink-rpc/flink-rpc-core/src/main/java/org/apache/flink/runtime/rpc/RpcServiceUtils.java
+++ b/flink-rpc/flink-rpc-core/src/main/java/org/apache/flink/runtime/rpc/RpcServiceUtils.java
@@ -34,12 +34,8 @@ public class RpcServiceUtils {
     public static String createRandomName(String prefix) {
         Preconditions.checkNotNull(prefix, "Prefix must not be null.");
 
-        long nameOffset;
-
         // obtain the next name offset by incrementing it atomically
-        do {
-            nameOffset = nextNameOffset.get();
-        } while (!nextNameOffset.compareAndSet(nameOffset, nameOffset + 1L));
+        long nameOffset = nextNameOffset.getAndIncrement();
 
         return prefix + '_' + nameOffset;
     }

--- a/flink-rpc/flink-rpc-core/src/test/java/org/apache/flink/runtime/rpc/RpcServiceUtilsTest.java
+++ b/flink-rpc/flink-rpc-core/src/test/java/org/apache/flink/runtime/rpc/RpcServiceUtilsTest.java
@@ -1,0 +1,34 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.flink.runtime.rpc;
+
+import org.junit.jupiter.api.Test;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+
+class RpcServiceUtilsTest {
+
+    @Test
+    void createRandomName() {
+        String randomName0 = RpcServiceUtils.createRandomName("Flink");
+        String randomName1 = RpcServiceUtils.createRandomName("Flink");
+        assertEquals("Flink_0", randomName0);
+        assertEquals("Flink_1", randomName1);
+    }
+}


### PR DESCRIPTION
## What is the purpose of the change

* Directly use AtomicLong#getAndIncrement to get and increase number.


## Brief change log

* Use AtomicLong.getAndIncrement() to replace compareAndSet.


## Verifying this change

This change added tests and can be verified as follows:

* RpcServiceUtilsTest#createRandomName

## Does this pull request potentially affect one of the following parts:

  - Dependencies (does it add or upgrade a dependency):  no
  - The public API, i.e., is any changed class annotated with `@Public(Evolving)`: no
  - The serializers: no
  - The runtime per-record code paths (performance sensitive): no
  - Anything that affects deployment or recovery: JobManager (and its components), Checkpointing, Kubernetes/Yarn, ZooKeeper: no
  - The S3 file system connector: no

## Documentation

  - Does this pull request introduce a new feature? no
  - If yes, how is the feature documented? not applicable
