### PR TITLE
[FLINK-25395][state] Fix TM error handling when uploading shared state

### DIFF
--- a/flink-tests/src/test/java/org/apache/flink/runtime/operators/lifecycle/TestJobExecutor.java
+++ b/flink-tests/src/test/java/org/apache/flink/runtime/operators/lifecycle/TestJobExecutor.java
@@ -58,7 +58,7 @@ import static org.junit.Assert.fail;
  * A helper class to control {@link TestJobWithDescription} execution using {@link
  * TestCommandDispatcher} and {@link TestEventQueue}.
  */
-class TestJobExecutor {
+public class TestJobExecutor {
     private static final Logger LOG = LoggerFactory.getLogger(TestJobExecutor.class);
     private final MiniClusterWithClientResource miniClusterResource;
     private final TestJobWithDescription testJob;
@@ -110,12 +110,13 @@ class TestJobExecutor {
         return this;
     }
 
-    public void triggerFailover() throws Exception {
+    public void triggerFailover(String operatorID) throws Exception {
         LOG.debug("sendCommand: {}", FAIL);
         BlockingQueue<TestEvent> queue = new LinkedBlockingQueue<>();
         Consumer<TestEvent> listener = queue::add;
         testJob.eventQueue.addListener(listener);
-        testJob.commandQueue.broadcast(FAIL, SINGLE_SUBTASK);
+        // only fail a single subtask to avoid failing more subtasks after recovery
+        testJob.commandQueue.dispatch(FAIL, SINGLE_SUBTASK, operatorID);
         try {
             waitForFailover(queue);
         } catch (TimeoutException e) {

--- a/flink-tests/src/test/java/org/apache/flink/runtime/operators/lifecycle/command/TestCommand.java
+++ b/flink-tests/src/test/java/org/apache/flink/runtime/operators/lifecycle/command/TestCommand.java
@@ -22,6 +22,30 @@ package org.apache.flink.runtime.operators.lifecycle.command;
  * {@link org.apache.flink.runtime.operators.lifecycle.event.TestCommandAckEvent Ack} event.
  */
 public interface TestCommand {
+    TestCommand DELAY_SNAPSHOT =
+            new TestCommand() {
+                @Override
+                public boolean isTerminal() {
+                    return false;
+                }
+
+                @Override
+                public String toString() {
+                    return "DELAY_SNAPSHOT";
+                }
+            };
+    TestCommand FAIL_SNAPSHOT =
+            new TestCommand() {
+                @Override
+                public boolean isTerminal() {
+                    return true;
+                }
+
+                @Override
+                public String toString() {
+                    return "FAIL_SNAPSHOT";
+                }
+            };
     TestCommand FAIL =
             new TestCommand() {
                 @Override

--- a/flink-tests/src/test/java/org/apache/flink/runtime/operators/lifecycle/command/TestCommandDispatcherImpl.java
+++ b/flink-tests/src/test/java/org/apache/flink/runtime/operators/lifecycle/command/TestCommandDispatcherImpl.java
@@ -27,6 +27,7 @@ import java.util.concurrent.CopyOnWriteArrayList;
 import java.util.stream.Collectors;
 
 import static java.util.Collections.emptyList;
+import static org.apache.flink.util.Preconditions.checkState;
 
 class TestCommandDispatcherImpl implements TestCommandDispatcher {
     private final Map<String, List<CommandExecutor>> subscribers = new ConcurrentHashMap<>();
@@ -53,6 +54,7 @@ class TestCommandDispatcherImpl implements TestCommandDispatcher {
 
     private void executeInternal(
             TestCommand command, TestCommandScope scope, List<CommandExecutor> executors) {
+        checkState(!executors.isEmpty(), "no executors for command: " + command);
         Set<CommandExecutor> toRemove = new HashSet<>();
         for (CommandExecutor executor : executors) {
             executor.execute(command);

--- a/flink-tests/src/test/java/org/apache/flink/runtime/operators/lifecycle/graph/OneInputTestStreamOperator.java
+++ b/flink-tests/src/test/java/org/apache/flink/runtime/operators/lifecycle/graph/OneInputTestStreamOperator.java
@@ -18,13 +18,17 @@
 package org.apache.flink.runtime.operators.lifecycle.graph;
 
 import org.apache.flink.api.common.operators.ProcessingTimeService.ProcessingTimeCallback;
+import org.apache.flink.api.common.state.ListState;
+import org.apache.flink.api.common.state.ListStateDescriptor;
 import org.apache.flink.runtime.operators.lifecycle.command.TestCommand;
+import org.apache.flink.runtime.operators.lifecycle.command.TestCommandDispatcher;
 import org.apache.flink.runtime.operators.lifecycle.event.CheckpointCompletedEvent;
 import org.apache.flink.runtime.operators.lifecycle.event.CheckpointStartedEvent;
 import org.apache.flink.runtime.operators.lifecycle.event.InputEndedEvent;
 import org.apache.flink.runtime.operators.lifecycle.event.OperatorFinishedEvent;
 import org.apache.flink.runtime.operators.lifecycle.event.OperatorFinishedEvent.LastVertexDataInfo;
 import org.apache.flink.runtime.operators.lifecycle.event.OperatorStartedEvent;
+import org.apache.flink.runtime.operators.lifecycle.event.TestCommandAckEvent;
 import org.apache.flink.runtime.operators.lifecycle.event.TestEvent;
 import org.apache.flink.runtime.operators.lifecycle.event.TestEventQueue;
 import org.apache.flink.runtime.operators.lifecycle.event.WatermarkReceivedEvent;
@@ -36,7 +40,14 @@ import org.apache.flink.streaming.api.watermark.Watermark;
 import org.apache.flink.streaming.runtime.streamrecord.StreamRecord;
 
 import java.util.HashMap;
+import java.util.HashSet;
 import java.util.Map;
+import java.util.Set;
+
+import static java.util.Collections.singletonList;
+import static org.apache.flink.runtime.operators.lifecycle.command.TestCommand.DELAY_SNAPSHOT;
+import static org.apache.flink.runtime.operators.lifecycle.command.TestCommand.FAIL;
+import static org.apache.flink.runtime.operators.lifecycle.command.TestCommand.FAIL_SNAPSHOT;
 
 /**
  * {@link OneInputStreamOperator} that emits {@link TestEvent}s and reacts to {@link TestCommand}s.
@@ -51,10 +62,16 @@ class OneInputTestStreamOperator extends AbstractStreamOperator<TestDataElement>
     private final Map<String, LastVertexDataInfo> lastDataReceived = new HashMap<>();
     private boolean timerRegistered;
     private final TestEventQueue eventQueue;
+    private final Set<TestCommand> receivedCommands;
+    private final TestCommandDispatcher dispatcher;
+    private transient ListState<String> state;
 
-    OneInputTestStreamOperator(String operatorID, TestEventQueue eventQueue) {
+    OneInputTestStreamOperator(
+            String operatorID, TestEventQueue eventQueue, TestCommandDispatcher dispatcher) {
         this.operatorID = operatorID;
         this.eventQueue = eventQueue;
+        this.receivedCommands = new HashSet<>();
+        this.dispatcher = dispatcher;
     }
 
     @Override
@@ -65,10 +82,23 @@ class OneInputTestStreamOperator extends AbstractStreamOperator<TestDataElement>
                         operatorID,
                         getRuntimeContext().getIndexOfThisSubtask(),
                         getRuntimeContext().getAttemptNumber()));
+        this.dispatcher.subscribe(receivedCommands::add, operatorID);
+        this.state =
+                getKeyedStateBackend() != null
+                        ? getRuntimeContext()
+                                .getListState(new ListStateDescriptor<>("test", String.class))
+                        : getOperatorStateBackend()
+                                .getListState(new ListStateDescriptor<>("test", String.class));
     }
 
     @Override
     public void snapshotState(StateSnapshotContext context) throws Exception {
+        if (receivedCommands.remove(DELAY_SNAPSHOT)) {
+            Thread.sleep(10);
+        }
+        if (receivedCommands.remove(FAIL_SNAPSHOT)) {
+            ackAndFail(FAIL_SNAPSHOT);
+        }
         eventQueue.add(
                 new CheckpointStartedEvent(
                         operatorID,
@@ -103,7 +133,11 @@ class OneInputTestStreamOperator extends AbstractStreamOperator<TestDataElement>
 
     @Override
     public void processElement(StreamRecord<TestDataElement> element) throws Exception {
+        if (receivedCommands.remove(FAIL)) {
+            ackAndFail(FAIL);
+        }
         TestDataElement e = element.getValue();
+        state.update(singletonList(String.valueOf(e.seq)));
         lastDataReceived
                 .computeIfAbsent(e.operatorId, ign -> new LastVertexDataInfo())
                 .bySubtask
@@ -150,5 +184,20 @@ class OneInputTestStreamOperator extends AbstractStreamOperator<TestDataElement>
     private void registerTimer() {
         getProcessingTimeService()
                 .registerTimer(getProcessingTimeService().getCurrentProcessingTime() + 1, this);
+    }
+
+    private void ack(TestCommand cmd) {
+        LOG.info("Executed command: {}", cmd);
+        eventQueue.add(
+                new TestCommandAckEvent(
+                        operatorID,
+                        getRuntimeContext().getIndexOfThisSubtask(),
+                        getRuntimeContext().getAttemptNumber(),
+                        cmd));
+    }
+
+    private void ackAndFail(TestCommand failSnapshot) {
+        ack(failSnapshot);
+        throw new RuntimeException("requested to fail");
     }
 }

--- a/flink-tests/src/test/java/org/apache/flink/runtime/operators/lifecycle/graph/OneInputTestStreamOperatorFactory.java
+++ b/flink-tests/src/test/java/org/apache/flink/runtime/operators/lifecycle/graph/OneInputTestStreamOperatorFactory.java
@@ -17,6 +17,7 @@
 
 package org.apache.flink.runtime.operators.lifecycle.graph;
 
+import org.apache.flink.runtime.operators.lifecycle.command.TestCommandDispatcher;
 import org.apache.flink.runtime.operators.lifecycle.event.TestEventQueue;
 import org.apache.flink.streaming.api.operators.ChainingStrategy;
 import org.apache.flink.streaming.api.operators.OneInputStreamOperatorFactory;
@@ -25,17 +26,21 @@ import org.apache.flink.streaming.api.operators.StreamOperatorParameters;
 import org.apache.flink.streaming.runtime.tasks.ProcessingTimeService;
 import org.apache.flink.streaming.runtime.tasks.ProcessingTimeServiceAware;
 
-class OneInputTestStreamOperatorFactory
+/** {@link OneInputTestStreamOperator} factory. */
+public class OneInputTestStreamOperatorFactory
         implements OneInputStreamOperatorFactory<TestDataElement, TestDataElement>,
                 ProcessingTimeServiceAware {
     private ChainingStrategy strategy = ChainingStrategy.DEFAULT_CHAINING_STRATEGY;
     private ProcessingTimeService processingTimeService;
     private final String operatorID;
     private final TestEventQueue eventQueue;
+    private final TestCommandDispatcher commandDispatcher;
 
-    OneInputTestStreamOperatorFactory(String operatorID, TestEventQueue eventQueue) {
+    public OneInputTestStreamOperatorFactory(
+            String operatorID, TestEventQueue eventQueue, TestCommandDispatcher commandDispatcher) {
         this.operatorID = operatorID;
         this.eventQueue = eventQueue;
+        this.commandDispatcher = commandDispatcher;
     }
 
     @Override
@@ -43,7 +48,7 @@ class OneInputTestStreamOperatorFactory
     public <T extends StreamOperator<TestDataElement>> T createStreamOperator(
             StreamOperatorParameters<TestDataElement> parameters) {
         OneInputTestStreamOperator operator =
-                new OneInputTestStreamOperator(operatorID, eventQueue);
+                new OneInputTestStreamOperator(operatorID, eventQueue, commandDispatcher);
         operator.setup(
                 parameters.getContainingTask(),
                 parameters.getStreamConfig(),

--- a/flink-tests/src/test/java/org/apache/flink/runtime/operators/lifecycle/graph/TestEventSource.java
+++ b/flink-tests/src/test/java/org/apache/flink/runtime/operators/lifecycle/graph/TestEventSource.java
@@ -38,7 +38,7 @@ import static org.apache.flink.runtime.operators.lifecycle.command.TestCommand.F
  * {@link SourceFunction} that emits {@link TestEvent}s and reacts to {@link TestCommand}s. It emits
  * {@link TestDataElement} to its output.
  */
-class TestEventSource extends RichSourceFunction<TestDataElement>
+public class TestEventSource extends RichSourceFunction<TestDataElement>
         implements ParallelSourceFunction<TestDataElement> {
     private final String operatorID;
     private final TestCommandDispatcher commandQueue;
@@ -46,7 +46,7 @@ class TestEventSource extends RichSourceFunction<TestDataElement>
     private transient volatile boolean isRunning = true;
     private final TestEventQueue eventQueue;
 
-    TestEventSource(
+    public TestEventSource(
             String operatorID, TestEventQueue eventQueue, TestCommandDispatcher commandQueue) {
         this.operatorID = operatorID;
         this.eventQueue = eventQueue;

--- a/flink-tests/src/test/java/org/apache/flink/runtime/operators/lifecycle/graph/TestJobBuilders.java
+++ b/flink-tests/src/test/java/org/apache/flink/runtime/operators/lifecycle/graph/TestJobBuilders.java
@@ -92,7 +92,7 @@ public class TestJobBuilders {
                                             "transform-1-forward",
                                             TypeInformation.of(TestDataElement.class),
                                             new OneInputTestStreamOperatorFactory(
-                                                    mapForward, eventQueue))
+                                                    mapForward, eventQueue, commandQueue))
                                     .setUidHash(mapForward);
 
                     forwardTransform.addSink(new DiscardingSink<>());
@@ -190,7 +190,7 @@ public class TestJobBuilders {
                                             "transform-1-forward",
                                             TypeInformation.of(TestDataElement.class),
                                             new OneInputTestStreamOperatorFactory(
-                                                    mapForward, eventQueue))
+                                                    mapForward, eventQueue, commandQueue))
                                     .setUidHash(mapForward);
 
                     SingleOutputStreamOperator<TestDataElement> keyedTransform =
@@ -201,7 +201,7 @@ public class TestJobBuilders {
                                             "transform-2-keyed",
                                             TypeInformation.of(TestDataElement.class),
                                             new OneInputTestStreamOperatorFactory(
-                                                    mapKeyed, eventQueue))
+                                                    mapKeyed, eventQueue, commandQueue))
                                     .setUidHash(mapKeyed);
 
                     SingleOutputStreamOperator<TestDataElement> twoInputTransform =

--- a/flink-tests/src/test/java/org/apache/flink/test/checkpointing/IncrementalStateReuseAfterFailureITCase.java
+++ b/flink-tests/src/test/java/org/apache/flink/test/checkpointing/IncrementalStateReuseAfterFailureITCase.java
@@ -1,0 +1,172 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.flink.test.checkpointing;
+
+import org.apache.flink.api.common.restartstrategy.RestartStrategies;
+import org.apache.flink.api.common.typeinfo.TypeInformation;
+import org.apache.flink.changelog.fs.FsStateChangelogStorageFactory;
+import org.apache.flink.configuration.Configuration;
+import org.apache.flink.runtime.operators.lifecycle.TestJobExecutor;
+import org.apache.flink.runtime.operators.lifecycle.TestJobWithDescription;
+import org.apache.flink.runtime.operators.lifecycle.command.TestCommandDispatcher;
+import org.apache.flink.runtime.operators.lifecycle.event.CheckpointCompletedEvent;
+import org.apache.flink.runtime.operators.lifecycle.event.OperatorStartedEvent;
+import org.apache.flink.runtime.operators.lifecycle.event.TestEventQueue;
+import org.apache.flink.runtime.operators.lifecycle.graph.OneInputTestStreamOperatorFactory;
+import org.apache.flink.runtime.operators.lifecycle.graph.TestDataElement;
+import org.apache.flink.runtime.operators.lifecycle.graph.TestEventSource;
+import org.apache.flink.runtime.testutils.MiniClusterResourceConfiguration;
+import org.apache.flink.streaming.api.datastream.DataStream;
+import org.apache.flink.streaming.api.datastream.DataStreamUtils;
+import org.apache.flink.streaming.api.datastream.SingleOutputStreamOperator;
+import org.apache.flink.streaming.api.environment.StreamExecutionEnvironment;
+import org.apache.flink.streaming.api.functions.sink.DiscardingSink;
+import org.apache.flink.test.util.MiniClusterWithClientResource;
+import org.apache.flink.testutils.junit.SharedObjects;
+
+import org.junit.After;
+import org.junit.Before;
+import org.junit.Rule;
+import org.junit.Test;
+import org.junit.rules.TemporaryFolder;
+
+import static java.util.Collections.emptyMap;
+import static java.util.Collections.emptySet;
+import static org.apache.flink.runtime.operators.lifecycle.command.TestCommand.DELAY_SNAPSHOT;
+import static org.apache.flink.runtime.operators.lifecycle.command.TestCommand.FAIL_SNAPSHOT;
+import static org.apache.flink.runtime.operators.lifecycle.command.TestCommand.FINISH_SOURCES;
+import static org.apache.flink.runtime.operators.lifecycle.command.TestCommandDispatcher.TestCommandScope.ALL_SUBTASKS;
+import static org.apache.flink.runtime.operators.lifecycle.command.TestCommandDispatcher.TestCommandScope.SINGLE_SUBTASK;
+
+/**
+ * A test suite to check the ability to recover from incremental checkpoint after the next one
+ * failed, potentially discarding shared state. A chain of two keyed operators is created and
+ * checkpointed as follows:
+ *
+ * <pre>
+ * |                  | Head op.   | Tail op.    |
+ * | Checkpoint 1     | empty      | File 1      |
+ * | Checkpoint 2     | fail       | File 1 + 2  |
+ * | Recover from CP1 |            | read File 1 |
+ * </pre>
+ */
+public class IncrementalStateReuseAfterFailureITCase {
+
+    @Test
+    public void testChangelogStateReuse() throws Exception {
+        TestJobExecutor.execute(createJob(), miniClusterResource)
+                .waitForAllRunning()
+
+                // 1st checkpoint: accumulate some state and snapshot it
+                .waitForEvent(CheckpointCompletedEvent.class)
+
+                // 2nd checkpoint: try to discard incremental state of the 1st checkpoint
+                // First, delay the 1st operator in chain (which is snapshotted last); this allows
+                // uploads to start. Otherwise, upload futures are cancelled and state is not
+                // discarded (see StateUtil.discardStateFuture)
+                .sendOperatorCommand(UID_OP1, DELAY_SNAPSHOT, SINGLE_SUBTASK)
+                // Now fail this operator snapshot - and discard other operators snapshots
+                // (SubtaskCheckpointCoordinatorImpl.cleanup and AsyncCheckpointRunnable.cleanup)
+                .sendOperatorCommand(UID_OP1, FAIL_SNAPSHOT, SINGLE_SUBTASK)
+
+                // Expect successful recovery from the 1st checkpoint.
+                .waitForEvent(OperatorStartedEvent.class)
+                .waitForAllRunning()
+                .waitForEvent(CheckpointCompletedEvent.class)
+                .sendBroadcastCommand(FINISH_SOURCES, ALL_SUBTASKS)
+                .waitForTermination()
+                .assertFinishedSuccessfully();
+    }
+
+    private TestJobWithDescription createJob() {
+        StreamExecutionEnvironment env = StreamExecutionEnvironment.getExecutionEnvironment();
+        env.enableCheckpointing(200);
+
+        // reliably fails Changelog with FLINK-25395, but might affect any incremental backend
+        env.enableChangelogStateBackend(true);
+        env.setRestartStrategy(RestartStrategies.fixedDelayRestart(1, 1));
+        env.setMaxParallelism(1); // simplify debugging
+        env.setParallelism(1); // simplify debugging
+
+        TestEventQueue evQueue = TestEventQueue.createShared(sharedObjects);
+        TestCommandDispatcher cmdQueue = TestCommandDispatcher.createShared(sharedObjects);
+
+        DataStream<TestDataElement> src =
+                env.addSource(new TestEventSource(UID_SRC, evQueue, cmdQueue)).setUidHash(UID_SRC);
+
+        SingleOutputStreamOperator<TestDataElement> transform1 =
+                src.keyBy(x -> x)
+                        .transform(
+                                "transform-1",
+                                TypeInformation.of(TestDataElement.class),
+                                new OneInputTestStreamOperatorFactory(UID_OP1, evQueue, cmdQueue))
+                        .setUidHash(UID_OP1);
+
+        SingleOutputStreamOperator<TestDataElement> transform2 =
+                // chain two keyed operators, so that one is checkpointed and the other one fails
+                DataStreamUtils.reinterpretAsKeyedStream(transform1, x -> x)
+                        .transform(
+                                "transform-2",
+                                TypeInformation.of(TestDataElement.class),
+                                new OneInputTestStreamOperatorFactory(UID_OP2, evQueue, cmdQueue))
+                        .setUidHash(UID_OP2);
+
+        transform2.addSink(new DiscardingSink<>());
+
+        return new TestJobWithDescription(
+                env.getStreamGraph().getJobGraph(),
+                emptySet(),
+                emptySet(),
+                emptySet(),
+                emptyMap(),
+                evQueue,
+                cmdQueue);
+    }
+
+    private static final String UID_SRC = asUidHash(0);
+    private static final String UID_OP1 = asUidHash(1);
+    private static final String UID_OP2 = asUidHash(2);
+
+    @Rule public final TemporaryFolder temporaryFolder = new TemporaryFolder();
+    @Rule public final SharedObjects sharedObjects = SharedObjects.create();
+
+    private MiniClusterWithClientResource miniClusterResource;
+
+    @Before
+    public void before() throws Exception {
+        Configuration configuration = new Configuration();
+        FsStateChangelogStorageFactory.configure(configuration, temporaryFolder.newFolder());
+        miniClusterResource =
+                new MiniClusterWithClientResource(
+                        new MiniClusterResourceConfiguration.Builder()
+                                .setConfiguration(configuration)
+                                .setNumberTaskManagers(1)
+                                .setNumberSlotsPerTaskManager(1)
+                                .build());
+        miniClusterResource.before();
+    }
+
+    @After
+    public void after() {
+        miniClusterResource.after();
+    }
+
+    private static String asUidHash(int num) {
+        return String.format("%032X", num);
+    }
+}


### PR DESCRIPTION
## What is the purpose of the change

After FLINK-25395, shared (incremental) state can be re-used
by state backends regardless of the confirmation by JM.
JM will only discard it on checkpoint subsumption or job termination.

However, state can also be discarded by TM in case of failures:
 - AsyncCheckpointRunnable.cleanup
 - StreamOperatorStateHandler.snapshotState
 - SubtaskCheckpointCoordinatorImpl.cleanup

Those cleanups might render previous checkpoints invalid.

This change fixes it by:
1. Reverting changes to RocksDB incremental snapshotting (i.e. re-upload state unless it was confirmed by JM)
1.  Removing discard calls from the changelog state handle (this may leave more orphaned state artefacts on DFS; this issue will be addressed later)

## Verifying this change

- added `IncrementalStateReuseAfterFailureITCase` that reproduces the original FileNotFoundException if changes to handles are reverted

## Does this pull request potentially affect one of the following parts:

  - Dependencies (does it add or upgrade a dependency): no
  - The public API, i.e., is any changed class annotated with `@Public(Evolving)`: no
  - The serializers: no
  - The runtime per-record code paths (performance sensitive): no
  - Anything that affects deployment or recovery: JobManager (and its components), Checkpointing, Kubernetes/Yarn, ZooKeeper: yes
  - The S3 file system connector: no

## Documentation

  - Does this pull request introduce a new feature? no
  - If yes, how is the feature documented? no
