### PR TITLE
[FLINK-25307][Test] Print the curl logs is querying dispatcher startup failed

### DIFF
--- a/flink-end-to-end-tests/test-scripts/common.sh
+++ b/flink-end-to-end-tests/test-scripts/common.sh
@@ -276,19 +276,21 @@ function wait_rest_endpoint_up {
   for i in $(seq 1 ${TIMEOUT}); do
     local log_file=$(mktemp)
     # without the || true this would exit our script if the endpoint is not yet up
-    QUERY_RESULT=$(curl -v ${CURL_SSL_ARGS} "$query_url" 2>${log_file} || true)
+    QUERY_RESULT=$(curl -v ${CURL_SSL_ARGS} "$query_url" 2> ${log_file} || true)
 
     # ensure the response adapts with the successful regex
     if [[ ${QUERY_RESULT} =~ ${successful_response_regex} ]]; then
       echo "${endpoint_name} REST endpoint is up."
       return
-    elif [ -f $log_file ];then
+    else
       echo "***************** Curl detailed output *****************"
       echo "QUERY_RESULT is ${QUERY_RESULT}"
       cat ${log_file}
       echo "********************************************************"
-      rm ${log_file}
     fi
+
+    # Remove the temporary file
+    rm ${log_file}
 
     echo "Waiting for ${endpoint_name} REST endpoint to come up..."
     sleep 1

--- a/flink-end-to-end-tests/test-scripts/common.sh
+++ b/flink-end-to-end-tests/test-scripts/common.sh
@@ -274,13 +274,20 @@ function wait_rest_endpoint_up {
   # wait at most 30 seconds until the endpoint is up
   local TIMEOUT=30
   for i in $(seq 1 ${TIMEOUT}); do
+    local log_file=$(mktemp)
     # without the || true this would exit our script if the endpoint is not yet up
-    QUERY_RESULT=$(curl ${CURL_SSL_ARGS} "$query_url" 2> /dev/null || true)
+    QUERY_RESULT=$(curl -v ${CURL_SSL_ARGS} "$query_url" 2>${log_file} || true)
 
     # ensure the response adapts with the successful regex
     if [[ ${QUERY_RESULT} =~ ${successful_response_regex} ]]; then
       echo "${endpoint_name} REST endpoint is up."
       return
+    elif [ -f $log_file ];then
+      echo "***************** Curl detailed output *****************"
+      echo "QUERY_RESULT is ${QUERY_RESULT}"
+      cat ${log_file}
+      echo "********************************************************"
+      rm ${log_file}
     fi
 
     echo "Waiting for ${endpoint_name} REST endpoint to come up..."


### PR DESCRIPTION
## What is the purpose of the change

This PR outputs the detailed `curl` log if the querying to dispatcher failed. 

## Brief change log

- 80b4a2f2d56846b57a9244a9c855539cc248415e added the log.


## Verifying this change


This change is a trivial rework / code cleanup without any test coverage.

## Does this pull request potentially affect one of the following parts:

  - Dependencies (does it add or upgrade a dependency): **no**
  - The public API, i.e., is any changed class annotated with `@Public(Evolving)`: **no**
  - The serializers: **no**
  - The runtime per-record code paths (performance sensitive): **no**
  - Anything that affects deployment or recovery: JobManager (and its components), Checkpointing, Kubernetes/Yarn, ZooKeeper: **no**
  - The S3 file system connector: **no**

## Documentation

  - Does this pull request introduce a new feature? **no**
  - If yes, how is the feature documented? **not applicable**
