### PR TITLE
[FLINK-25311][core] Fix deal with delimited compressed file not correctly

### DIFF
--- a/flink-core/src/main/java/org/apache/flink/api/common/io/FileInputFormat.java
+++ b/flink-core/src/main/java/org/apache/flink/api/common/io/FileInputFormat.java
@@ -899,6 +899,8 @@ public abstract class FileInputFormat<OT> extends RichInputFormat<OT, FileInputS
         InflaterInputStreamFactory<?> inflaterInputStreamFactory =
                 getInflaterInputStreamFactory(fileSplit.getPath());
         if (inflaterInputStreamFactory != null) {
+            // compressed format should use splitLength specially
+            this.splitLength = -1;
             return new InputStreamFSInputWrapper(inflaterInputStreamFactory.create(stream));
         }
 


### PR DESCRIPTION
## What is the purpose of the change
This pull request fix the issue about DelimitedInputFormat can not deal with compressed file correctly

## Brief change log
The splitLength should be set to -1 to read whole split for compressed file

## Verifying this change

This change added tests and can be verified as follows:
Add test that compressed file can be deal with correctly by org.apache.flink.api.common.io.DelimitedInputFormat

## Does this pull request potentially affect one of the following parts:

  - Dependencies (does it add or upgrade a dependency): (no)
  - The public API, i.e., is any changed class annotated with `@Public(Evolving)`: ( no)
  - The serializers: (no)
  - The runtime per-record code paths (performance sensitive): (no)
  - Anything that affects deployment or recovery: JobManager (and its components), Checkpointing, Kubernetes/Yarn, ZooKeeper: (no)
  - The S3 file system connector: (no)

## Documentation

  - Does this pull request introduce a new feature? (no)
