### PR TITLE
[FLINK-25576][Connectors][JDBC] Upgrade com.h2database:h2 to 2.0.206

### DIFF
--- a/flink-connectors/flink-connector-jdbc/pom.xml
+++ b/flink-connectors/flink-connector-jdbc/pom.xml
@@ -164,7 +164,8 @@ under the License.
 		<dependency>
 			<groupId>com.h2database</groupId>
 			<artifactId>h2</artifactId>
-			<version>1.4.200</version>
+			<version>2.0.206</version>
+			<scope>test</scope>
 		</dependency>
 
 		<dependency>


### PR DESCRIPTION
## What is the purpose of the change

* Update com.h2database:h2 to latest version, 2.0.206

## Brief change log

* Updated POM with new version number

## Verifying this change

This change is a trivial rework / code cleanup without any test coverage.

## Does this pull request potentially affect one of the following parts:

  - Dependencies (does it add or upgrade a dependency): yes
  - The public API, i.e., is any changed class annotated with `@Public(Evolving)`: no
  - The serializers: no
  - The runtime per-record code paths (performance sensitive): no
  - Anything that affects deployment or recovery: JobManager (and its components), Checkpointing, Kubernetes/Yarn, ZooKeeper: no
  - The S3 file system connector: no

## Documentation

  - Does this pull request introduce a new feature? no
  - If yes, how is the feature documented? not applicable 
