### PR TITLE
[FLINK-25085][runtime] Add a scheduled thread pool for periodic tasks in RpcEndpoint

### DIFF
--- a/flink-rpc/flink-rpc-core/src/main/java/org/apache/flink/runtime/rpc/RpcEndpoint.java
+++ b/flink-rpc/flink-rpc-core/src/main/java/org/apache/flink/runtime/rpc/RpcEndpoint.java
@@ -19,21 +19,28 @@
 package org.apache.flink.runtime.rpc;
 
 import org.apache.flink.api.common.time.Time;
+import org.apache.flink.core.fs.CloseableRegistry;
 import org.apache.flink.runtime.concurrent.ComponentMainThreadExecutor;
 import org.apache.flink.runtime.concurrent.ScheduledFutureAdapter;
 import org.apache.flink.util.AutoCloseableAsync;
 import org.apache.flink.util.Preconditions;
+import org.apache.flink.util.concurrent.ExecutorThreadFactory;
 
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
 import javax.annotation.Nonnull;
 
+import java.io.Closeable;
+import java.io.IOException;
 import java.util.UUID;
 import java.util.concurrent.Callable;
 import java.util.concurrent.CompletableFuture;
+import java.util.concurrent.Executors;
 import java.util.concurrent.FutureTask;
+import java.util.concurrent.ScheduledExecutorService;
 import java.util.concurrent.ScheduledFuture;
+import java.util.concurrent.ScheduledThreadPoolExecutor;
 import java.util.concurrent.TimeUnit;
 import java.util.concurrent.TimeoutException;
 import java.util.concurrent.atomic.AtomicReference;
@@ -107,6 +114,12 @@ public abstract class RpcEndpoint implements RpcGateway, AutoCloseableAsync {
     private final MainThreadExecutor mainThreadExecutor;
 
     /**
+     * Register endpoint closeable resource to the registry and close them when the server is
+     * stopped.
+     */
+    private final CloseableRegistry resourceRegistry;
+
+    /**
      * Indicates whether the RPC endpoint is started and not stopped or being stopped.
      *
      * <p>IMPORTANT: the running state is not thread safe and can be used only in the main thread of
@@ -125,8 +138,11 @@ public abstract class RpcEndpoint implements RpcGateway, AutoCloseableAsync {
         this.endpointId = checkNotNull(endpointId, "endpointId");
 
         this.rpcServer = rpcService.startServer(this);
+        this.resourceRegistry = new CloseableRegistry();
 
-        this.mainThreadExecutor = new MainThreadExecutor(rpcServer, this::validateRunsInMainThread);
+        this.mainThreadExecutor =
+                new MainThreadExecutor(rpcServer, this::validateRunsInMainThread, endpointId);
+        registerResource(this.mainThreadExecutor);
     }
 
     /**
@@ -211,9 +227,41 @@ public abstract class RpcEndpoint implements RpcGateway, AutoCloseableAsync {
      */
     public final CompletableFuture<Void> internalCallOnStop() {
         validateRunsInMainThread();
-        CompletableFuture<Void> stopFuture = onStop();
+        CompletableFuture<Void> stopFuture = new CompletableFuture<>();
+        try {
+            resourceRegistry.close();
+            stopFuture.complete(null);
+        } catch (IOException e) {
+            stopFuture.completeExceptionally(
+                    new RuntimeException("Close resource registry fail", e));
+        }
+        stopFuture = CompletableFuture.allOf(stopFuture, onStop());
         isRunning = false;
         return stopFuture;
+    }
+
+    /**
+     * Register the given closeable resource to {@link CloseableRegistry}.
+     *
+     * @param closeableResource the given closeable resource
+     */
+    protected void registerResource(Closeable closeableResource) {
+        try {
+            resourceRegistry.registerCloseable(closeableResource);
+        } catch (IOException e) {
+            throw new RuntimeException(
+                    "Registry closeable resource " + closeableResource + " fail", e);
+        }
+    }
+
+    /**
+     * Unregister the given closeable resource from {@link CloseableRegistry}.
+     *
+     * @param closeableResource the given closeable resource
+     * @return true if the given resource unregister successful, otherwise false
+     */
+    protected boolean unregisterResource(Closeable closeableResource) {
+        return resourceRegistry.unregisterCloseable(closeableResource);
     }
 
     /**
@@ -395,23 +443,38 @@ public abstract class RpcEndpoint implements RpcGateway, AutoCloseableAsync {
         assert MainThreadValidatorUtil.isRunningInExpectedThread(currentMainThread.get());
     }
 
+    /**
+     * Validate whether all the resources are closed.
+     *
+     * @return true if all the resources are closed, otherwise false
+     */
+    boolean validateResourceClosed() {
+        return mainThreadExecutor.validateScheduledExecutorClosed() && resourceRegistry.isClosed();
+    }
+
     // ------------------------------------------------------------------------
     //  Utilities
     // ------------------------------------------------------------------------
 
     /** Executor which executes runnables in the main thread context. */
-    protected static class MainThreadExecutor implements ComponentMainThreadExecutor {
+    protected static class MainThreadExecutor implements ComponentMainThreadExecutor, Closeable {
+        private static final Logger log = LoggerFactory.getLogger(MainThreadExecutor.class);
 
         private final MainThreadExecutable gateway;
         private final Runnable mainThreadCheck;
+        /**
+         * The main scheduled executor manages the scheduled tasks and send them to gateway when
+         * they should be executed.
+         */
+        private final ScheduledExecutorService mainScheduledExecutor;
 
-        MainThreadExecutor(MainThreadExecutable gateway, Runnable mainThreadCheck) {
+        MainThreadExecutor(
+                MainThreadExecutable gateway, Runnable mainThreadCheck, String endpointId) {
             this.gateway = Preconditions.checkNotNull(gateway);
             this.mainThreadCheck = Preconditions.checkNotNull(mainThreadCheck);
-        }
-
-        private void scheduleRunAsync(Runnable runnable, long delayMillis) {
-            gateway.scheduleRunAsync(runnable, delayMillis);
+            this.mainScheduledExecutor =
+                    Executors.newSingleThreadScheduledExecutor(
+                            new ExecutorThreadFactory(endpointId + "-main-scheduler"));
         }
 
         @Override
@@ -419,19 +482,52 @@ public abstract class RpcEndpoint implements RpcGateway, AutoCloseableAsync {
             gateway.runAsync(command);
         }
 
+        /**
+         * The mainScheduledExecutor manages the task and sends it to the gateway after the given
+         * delay.
+         *
+         * @param command the task to execute in the future
+         * @param delay the time from now to delay the execution
+         * @param unit the time unit of the delay parameter
+         * @return a ScheduledFuture representing the completion of the scheduled task
+         */
         @Override
         public ScheduledFuture<?> schedule(Runnable command, long delay, TimeUnit unit) {
             final long delayMillis = TimeUnit.MILLISECONDS.convert(delay, unit);
             FutureTask<Void> ft = new FutureTask<>(command, null);
-            scheduleRunAsync(ft, delayMillis);
+            if (mainScheduledExecutor.isShutdown()) {
+                log.warn(
+                        "The scheduled executor service is shutdown and ignores the command {}",
+                        command);
+            } else {
+                mainScheduledExecutor.schedule(
+                        () -> gateway.runAsync(ft), delayMillis, TimeUnit.MILLISECONDS);
+            }
             return new ScheduledFutureAdapter<>(ft, delayMillis, TimeUnit.MILLISECONDS);
         }
 
+        /**
+         * The mainScheduledExecutor manages the given callable and sends it to the gateway after
+         * the given delay.
+         *
+         * @param callable the callable to execute
+         * @param delay the time from now to delay the execution
+         * @param unit the time unit of the delay parameter
+         * @param <V> result type of the callable
+         * @return a ScheduledFuture which holds the future value of the given callable
+         */
         @Override
         public <V> ScheduledFuture<V> schedule(Callable<V> callable, long delay, TimeUnit unit) {
             final long delayMillis = TimeUnit.MILLISECONDS.convert(delay, unit);
             FutureTask<V> ft = new FutureTask<>(callable);
-            scheduleRunAsync(ft, delayMillis);
+            if (mainScheduledExecutor.isShutdown()) {
+                log.warn(
+                        "The scheduled executor service is shutdown and ignores the callable {}",
+                        callable);
+            } else {
+                mainScheduledExecutor.schedule(
+                        () -> gateway.runAsync(ft), delayMillis, TimeUnit.MILLISECONDS);
+            }
             return new ScheduledFutureAdapter<>(ft, delayMillis, TimeUnit.MILLISECONDS);
         }
 
@@ -452,6 +548,23 @@ public abstract class RpcEndpoint implements RpcGateway, AutoCloseableAsync {
         @Override
         public void assertRunningInMainThread() {
             mainThreadCheck.run();
+        }
+
+        /** Shutdown the {@link ScheduledThreadPoolExecutor} and remove all the pending tasks. */
+        @Override
+        public void close() {
+            if (!mainScheduledExecutor.isShutdown()) {
+                mainScheduledExecutor.shutdownNow();
+            }
+        }
+
+        /**
+         * Validate whether the scheduled executor is closed.
+         *
+         * @return true if the scheduled executor is shutdown, otherwise false
+         */
+        final boolean validateScheduledExecutorClosed() {
+            return mainScheduledExecutor.isShutdown();
         }
     }
 }

--- a/flink-rpc/flink-rpc-core/src/test/java/org/apache/flink/runtime/concurrent/ScheduledFutureAdapterTest.java
+++ b/flink-rpc/flink-rpc-core/src/test/java/org/apache/flink/runtime/concurrent/ScheduledFutureAdapterTest.java
@@ -18,24 +18,28 @@
 
 package org.apache.flink.runtime.concurrent;
 
-import org.apache.flink.util.TestLogger;
+import org.apache.flink.util.TestLoggerExtension;
 
-import org.junit.Assert;
-import org.junit.Before;
-import org.junit.Test;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
 
 import javax.annotation.Nonnull;
 
 import java.util.concurrent.Future;
 import java.util.concurrent.TimeUnit;
 
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNotEquals;
+
 /** Unit tests for {@link ScheduledFutureAdapter}. */
-public class ScheduledFutureAdapterTest extends TestLogger {
+@ExtendWith(TestLoggerExtension.class)
+public class ScheduledFutureAdapterTest {
 
     private ScheduledFutureAdapter<Integer> objectUnderTest;
     private TestFuture innerDelegate;
 
-    @Before
+    @BeforeEach
     public void before() {
         this.innerDelegate = new TestFuture();
         this.objectUnderTest =
@@ -45,62 +49,62 @@ public class ScheduledFutureAdapterTest extends TestLogger {
     @Test
     public void testForwardedMethods() throws Exception {
 
-        Assert.assertEquals((Integer) 4711, objectUnderTest.get());
-        Assert.assertEquals(1, innerDelegate.getGetInvocationCount());
+        assertEquals((Integer) 4711, objectUnderTest.get());
+        assertEquals(1, innerDelegate.getGetInvocationCount());
 
-        Assert.assertEquals((Integer) 4711, objectUnderTest.get(42L, TimeUnit.SECONDS));
-        Assert.assertEquals(1, innerDelegate.getGetTimeoutInvocationCount());
+        assertEquals((Integer) 4711, objectUnderTest.get(42L, TimeUnit.SECONDS));
+        assertEquals(1, innerDelegate.getGetTimeoutInvocationCount());
 
-        Assert.assertEquals(innerDelegate.isCancelExpected(), objectUnderTest.cancel(true));
-        Assert.assertEquals(1, innerDelegate.getCancelInvocationCount());
+        assertEquals(innerDelegate.isCancelExpected(), objectUnderTest.cancel(true));
+        assertEquals(1, innerDelegate.getCancelInvocationCount());
 
         innerDelegate.setCancelResult(!innerDelegate.isCancelExpected());
-        Assert.assertEquals(innerDelegate.isCancelExpected(), objectUnderTest.cancel(true));
-        Assert.assertEquals(2, innerDelegate.getCancelInvocationCount());
+        assertEquals(innerDelegate.isCancelExpected(), objectUnderTest.cancel(true));
+        assertEquals(2, innerDelegate.getCancelInvocationCount());
 
-        Assert.assertEquals(innerDelegate.isCancelledExpected(), objectUnderTest.isCancelled());
-        Assert.assertEquals(1, innerDelegate.getIsCancelledInvocationCount());
+        assertEquals(innerDelegate.isCancelledExpected(), objectUnderTest.isCancelled());
+        assertEquals(1, innerDelegate.getIsCancelledInvocationCount());
 
         innerDelegate.setIsCancelledResult(!innerDelegate.isCancelledExpected());
-        Assert.assertEquals(innerDelegate.isCancelledExpected(), objectUnderTest.isCancelled());
-        Assert.assertEquals(2, innerDelegate.getIsCancelledInvocationCount());
+        assertEquals(innerDelegate.isCancelledExpected(), objectUnderTest.isCancelled());
+        assertEquals(2, innerDelegate.getIsCancelledInvocationCount());
 
-        Assert.assertEquals(innerDelegate.isDoneExpected(), objectUnderTest.isDone());
-        Assert.assertEquals(1, innerDelegate.getIsDoneInvocationCount());
+        assertEquals(innerDelegate.isDoneExpected(), objectUnderTest.isDone());
+        assertEquals(1, innerDelegate.getIsDoneInvocationCount());
 
         innerDelegate.setIsDoneExpected(!innerDelegate.isDoneExpected());
-        Assert.assertEquals(innerDelegate.isDoneExpected(), objectUnderTest.isDone());
-        Assert.assertEquals(2, innerDelegate.getIsDoneInvocationCount());
+        assertEquals(innerDelegate.isDoneExpected(), objectUnderTest.isDone());
+        assertEquals(2, innerDelegate.getIsDoneInvocationCount());
     }
 
     @Test
     public void testCompareToEqualsHashCode() {
 
-        Assert.assertEquals(0, objectUnderTest.compareTo(objectUnderTest));
-        Assert.assertEquals(objectUnderTest, objectUnderTest);
+        assertEquals(0, objectUnderTest.compareTo(objectUnderTest));
+        assertEquals(objectUnderTest, objectUnderTest);
 
         ScheduledFutureAdapter<?> other =
                 getDeepCopyWithAdjustedTime(0L, objectUnderTest.getTieBreakerUid());
 
-        Assert.assertEquals(0, objectUnderTest.compareTo(other));
-        Assert.assertEquals(0, other.compareTo(objectUnderTest));
-        Assert.assertEquals(objectUnderTest, other);
-        Assert.assertEquals(objectUnderTest.hashCode(), other.hashCode());
+        assertEquals(0, objectUnderTest.compareTo(other));
+        assertEquals(0, other.compareTo(objectUnderTest));
+        assertEquals(objectUnderTest, other);
+        assertEquals(objectUnderTest.hashCode(), other.hashCode());
 
         other = getDeepCopyWithAdjustedTime(0L, objectUnderTest.getTieBreakerUid() + 1L);
-        Assert.assertEquals(-1, Integer.signum(objectUnderTest.compareTo(other)));
-        Assert.assertEquals(+1, Integer.signum(other.compareTo(objectUnderTest)));
-        Assert.assertNotEquals(objectUnderTest, other);
+        assertEquals(-1, Integer.signum(objectUnderTest.compareTo(other)));
+        assertEquals(+1, Integer.signum(other.compareTo(objectUnderTest)));
+        assertNotEquals(objectUnderTest, other);
 
         other = getDeepCopyWithAdjustedTime(+1L, objectUnderTest.getTieBreakerUid());
-        Assert.assertEquals(-1, Integer.signum(objectUnderTest.compareTo(other)));
-        Assert.assertEquals(+1, Integer.signum(other.compareTo(objectUnderTest)));
-        Assert.assertNotEquals(objectUnderTest, other);
+        assertEquals(-1, Integer.signum(objectUnderTest.compareTo(other)));
+        assertEquals(+1, Integer.signum(other.compareTo(objectUnderTest)));
+        assertNotEquals(objectUnderTest, other);
 
         other = getDeepCopyWithAdjustedTime(-1L, objectUnderTest.getTieBreakerUid());
-        Assert.assertEquals(+1, Integer.signum(objectUnderTest.compareTo(other)));
-        Assert.assertEquals(-1, Integer.signum(other.compareTo(objectUnderTest)));
-        Assert.assertNotEquals(objectUnderTest, other);
+        assertEquals(+1, Integer.signum(objectUnderTest.compareTo(other)));
+        assertEquals(-1, Integer.signum(other.compareTo(objectUnderTest)));
+        assertNotEquals(objectUnderTest, other);
     }
 
     private ScheduledFutureAdapter<Integer> getDeepCopyWithAdjustedTime(long nanoAdjust, long uid) {

--- a/flink-runtime/src/test/java/org/apache/flink/runtime/rpc/FencedRpcEndpointTest.java
+++ b/flink-runtime/src/test/java/org/apache/flink/runtime/rpc/FencedRpcEndpointTest.java
@@ -25,11 +25,12 @@ import org.apache.flink.runtime.rpc.exceptions.FencingTokenException;
 import org.apache.flink.runtime.rpc.exceptions.RpcRuntimeException;
 import org.apache.flink.util.ExceptionUtils;
 import org.apache.flink.util.FlinkException;
-import org.apache.flink.util.TestLogger;
+import org.apache.flink.util.TestLoggerExtension;
 
-import org.junit.AfterClass;
-import org.junit.BeforeClass;
-import org.junit.Test;
+import org.junit.jupiter.api.AfterAll;
+import org.junit.jupiter.api.BeforeAll;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
 
 import java.util.UUID;
 import java.util.concurrent.CompletableFuture;
@@ -38,24 +39,26 @@ import java.util.concurrent.ExecutionException;
 import java.util.concurrent.TimeUnit;
 import java.util.concurrent.TimeoutException;
 
-import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertFalse;
-import static org.junit.Assert.assertNotEquals;
-import static org.junit.Assert.assertNull;
-import static org.junit.Assert.assertTrue;
-import static org.junit.Assert.fail;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertNotEquals;
+import static org.junit.jupiter.api.Assertions.assertNull;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+import static org.junit.jupiter.api.Assertions.fail;
 
-public class FencedRpcEndpointTest extends TestLogger {
+/** Tests for the FencedRpcEndpoint. */
+@ExtendWith(TestLoggerExtension.class)
+public class FencedRpcEndpointTest {
 
     private static final Time timeout = Time.seconds(10L);
     private static RpcService rpcService;
 
-    @BeforeClass
+    @BeforeAll
     public static void setup() {
         rpcService = new TestingRpcService();
     }
 
-    @AfterClass
+    @AfterAll
     public static void teardown()
             throws ExecutionException, InterruptedException, TimeoutException {
         if (rpcService != null) {
@@ -92,8 +95,8 @@ public class FencedRpcEndpointTest extends TestLogger {
             }
 
             assertFalse(
-                    "Setting fencing token from outside the main thread did not fail as expected.",
-                    failed);
+                    failed,
+                    "Setting fencing token from outside the main thread did not fail as expected.");
             assertNull(fencedTestingEndpoint.getFencingToken());
 
             CompletableFuture<Acknowledge> setFencingFuture =

--- a/flink-runtime/src/test/java/org/apache/flink/runtime/rpc/FencedRpcEndpointTest.java
+++ b/flink-runtime/src/test/java/org/apache/flink/runtime/rpc/FencedRpcEndpointTest.java
@@ -110,6 +110,7 @@ public class FencedRpcEndpointTest {
             assertEquals(newFencingToken, fencedTestingEndpoint.getFencingToken());
         } finally {
             RpcUtils.terminateRpcEndpoint(fencedTestingEndpoint, timeout);
+            fencedTestingEndpoint.validateResourceClosed();
         }
     }
 
@@ -178,6 +179,7 @@ public class FencedRpcEndpointTest {
 
         } finally {
             RpcUtils.terminateRpcEndpoint(fencedTestingEndpoint, timeout);
+            fencedTestingEndpoint.validateResourceClosed();
         }
     }
 
@@ -245,6 +247,7 @@ public class FencedRpcEndpointTest {
             }
         } finally {
             RpcUtils.terminateRpcEndpoint(fencedTestingEndpoint, timeout);
+            fencedTestingEndpoint.validateResourceClosed();
         }
     }
 
@@ -294,6 +297,7 @@ public class FencedRpcEndpointTest {
 
         } finally {
             RpcUtils.terminateRpcEndpoint(fencedTestingEndpoint, timeout);
+            fencedTestingEndpoint.validateResourceClosed();
         }
     }
 
@@ -335,6 +339,7 @@ public class FencedRpcEndpointTest {
             }
         } finally {
             RpcUtils.terminateRpcEndpoint(fencedTestingEndpoint, timeout);
+            fencedTestingEndpoint.validateResourceClosed();
         }
     }
 


### PR DESCRIPTION
## What is the purpose of the change
This PR adds a scheduled thread pool which will used to hold the periodic tasks and send them to akka with gateway when they should be executed.  The thread pool will be shutdown when the RpcEndpoint is stopped.

## Brief change log

  -* Add a scheduled thread pool to hold the periodic tasks and send them to akka with gateway when they should be executed
  -* Add closeable resource registry in RpcEndpoint and close all the resources which are registered in it.
  -* The thread pool in RpcEndpoint will register itself to the closeable resource registry

## Verifying this change

This change added tests and can be verified as follows:
  -* Add PeriodicTaskScheduledExecutorTest to test schedule runnable and callable task in the thread pool
  -* Add validation in JobMasterTest to check if the thread pool is closed

## Does this pull request potentially affect one of the following parts:

  - Dependencies (does it add or upgrade a dependency): (yes / no) no
  - The public API, i.e., is any changed class annotated with `@Public(Evolving)`: (yes / no) no
  - The serializers: (yes / no / don't know) no
  - The runtime per-record code paths (performance sensitive): (yes / no / don't know) no
  - Anything that affects deployment or recovery: JobManager (and its components), Checkpointing, Kubernetes/Yarn, ZooKeeper: (yes / no / don't know) no
  - The S3 file system connector: (yes / no / don't know) no

## Documentation

  - Does this pull request introduce a new feature? (yes / no) no
  - If yes, how is the feature documented? (not applicable / docs / JavaDocs / not documented)
