### PR TITLE
[FLINK-25565][Formats][Parquet] write and read parquet int64 timestamp

### DIFF
--- a/docs/content.zh/docs/connectors/table/formats/parquet.md
+++ b/docs/content.zh/docs/connectors/table/formats/parquet.md
@@ -84,6 +84,20 @@ Format 参数
       <td>Boolean</td>
       <td>使用 UTC 时区或本地时区在纪元时间和 LocalDateTime 之间进行转换。Hive 0.x/1.x/2.x 使用本地时区，但 Hive 3.x 使用 UTC 时区。</td>
     </tr>
+    <tr>
+      <td><h5>timestamp.time.unit</h5></td>
+      <td>optional</td>
+      <td style="word-wrap: break-word;">micros</td>
+      <td>String</td>
+      <td>根据TimeUnit在Timestamp和int64之间进行转换，可选值nanos/micros/millis。</td>
+    </tr>
+    <tr>
+      <td><h5>write.int64.timestamp</h5></td>
+      <td>optional</td>
+      <td style="word-wrap: break-word;">false</td>
+      <td>Boolean</td>
+      <td>以int64替代int96存储parquet Timestamp。 注意：Timestamp将于时区无关（从不转换为不同时区）。</td>
+    </tr>
     </tbody>
 </table>
 

--- a/docs/content/docs/connectors/table/formats/parquet.md
+++ b/docs/content/docs/connectors/table/formats/parquet.md
@@ -84,6 +84,20 @@ Format Options
       <td>Boolean</td>
       <td>Use UTC timezone or local timezone to the conversion between epoch time and LocalDateTime. Hive 0.x/1.x/2.x use local timezone. But Hive 3.x use UTC timezone.</td>
     </tr>
+    <tr>
+      <td><h5>timestamp.time.unit</h5></td>
+      <td>optional</td>
+      <td style="word-wrap: break-word;">micros</td>
+      <td>String</td>
+      <td>Store parquet int64/LogicalTypes timestamps in this time unit, value is nanos/micros/millis.</td>
+    </tr>
+    <tr>
+      <td><h5>write.int64.timestamp</h5></td>
+      <td>optional</td>
+      <td style="word-wrap: break-word;">false</td>
+      <td>Boolean</td>
+      <td>Write parquet timestamp as int64/LogicalTypes instead of int96/OriginalTypes. Note: Timestamp will be time zone agnostic (NEVER converted to a different time zone).</td>
+    </tr>
     </tbody>
 </table>
 

--- a/flink-formats/flink-parquet/src/main/java/org/apache/flink/formats/parquet/ParquetFileFormatFactory.java
+++ b/flink-formats/flink-parquet/src/main/java/org/apache/flink/formats/parquet/ParquetFileFormatFactory.java
@@ -68,6 +68,21 @@ public class ParquetFileFormatFactory implements BulkReaderFormatFactory, BulkWr
                                     + " time and LocalDateTime. Hive 0.x/1.x/2.x use local timezone. But Hive 3.x"
                                     + " use UTC timezone");
 
+    public static final ConfigOption<String> TIMESTAMP_TIME_UNIT =
+            key("timestamp.time.unit")
+                    .stringType()
+                    .defaultValue("micros")
+                    .withDescription(
+                            "Store parquet int64/LogicalTypes timestamps in this time unit, value is nanos/micros/millis");
+
+    public static final ConfigOption<Boolean> WRITE_INT64_TIMESTAMP =
+            key("write.int64.timestamp")
+                    .booleanType()
+                    .defaultValue(false)
+                    .withDescription(
+                            "Write parquet timestamp as int64/LogicalTypes instead of int96/OriginalTypes. "
+                                    + "Note: Timestamp will be time zone agnostic (NEVER converted to a different time zone).");
+
     @Override
     public BulkDecodingFormat<RowData> createDecodingFormat(
             DynamicTableFactory.Context context, ReadableConfig formatOptions) {

--- a/flink-formats/flink-parquet/src/main/java/org/apache/flink/formats/parquet/row/ParquetRowDataBuilder.java
+++ b/flink-formats/flink-parquet/src/main/java/org/apache/flink/formats/parquet/row/ParquetRowDataBuilder.java
@@ -65,13 +65,19 @@ public class ParquetRowDataBuilder extends ParquetWriter.Builder<RowData, Parque
 
     @Override
     protected WriteSupport<RowData> getWriteSupport(Configuration conf) {
-        return new ParquetWriteSupport();
+        return new ParquetWriteSupport(conf);
     }
 
     private class ParquetWriteSupport extends WriteSupport<RowData> {
 
-        private MessageType schema = convertToParquetMessageType("flink_schema", rowType);
+        private MessageType schema = null;
         private ParquetRowDataWriter writer;
+        private Configuration conf;
+
+        private ParquetWriteSupport(Configuration conf) {
+            this.conf = conf;
+            schema = convertToParquetMessageType("flink_schema", rowType, conf);
+        }
 
         @Override
         public WriteContext init(Configuration configuration) {
@@ -80,7 +86,8 @@ public class ParquetRowDataBuilder extends ParquetWriter.Builder<RowData, Parque
 
         @Override
         public void prepareForWrite(RecordConsumer recordConsumer) {
-            this.writer = new ParquetRowDataWriter(recordConsumer, rowType, schema, utcTimestamp);
+            this.writer =
+                    new ParquetRowDataWriter(recordConsumer, rowType, schema, utcTimestamp, conf);
         }
 
         @Override

--- a/flink-formats/flink-parquet/src/main/java/org/apache/flink/formats/parquet/vector/ParquetSplitReaderUtil.java
+++ b/flink-formats/flink-parquet/src/main/java/org/apache/flink/formats/parquet/vector/ParquetSplitReaderUtil.java
@@ -483,7 +483,8 @@ public class ParquetSplitReaderUtil {
             case TIMESTAMP_WITHOUT_TIME_ZONE:
             case TIMESTAMP_WITH_LOCAL_TIME_ZONE:
                 checkArgument(
-                        typeName == PrimitiveType.PrimitiveTypeName.INT96,
+                        typeName == PrimitiveType.PrimitiveTypeName.INT96
+                                || typeName == PrimitiveType.PrimitiveTypeName.INT64,
                         "Unexpected type: %s",
                         typeName);
                 return new HeapTimestampVector(batchSize);

--- a/flink-formats/flink-parquet/src/main/java/org/apache/flink/formats/parquet/vector/reader/AbstractColumnReader.java
+++ b/flink-formats/flink-parquet/src/main/java/org/apache/flink/formats/parquet/vector/reader/AbstractColumnReader.java
@@ -173,7 +173,7 @@ public abstract class AbstractColumnReader<VECTOR extends WritableColumnVector>
                     // We can't do this if rowId != 0 AND the column doesn't have a dictionary (i.e.
                     // some
                     // non-dictionary encoded values have already been added).
-                    vector.setDictionary(new ParquetDictionary(dictionary));
+                    vector.setDictionary(new ParquetDictionary(dictionary, descriptor));
                 } else {
                     readBatchFromDictionaryIds(rowId, num, vector, dictionaryIds);
                 }

--- a/flink-formats/flink-parquet/src/main/java/org/apache/flink/formats/parquet/vector/reader/TimestampColumnReader.java
+++ b/flink-formats/flink-parquet/src/main/java/org/apache/flink/formats/parquet/vector/reader/TimestampColumnReader.java
@@ -25,6 +25,7 @@ import org.apache.parquet.Preconditions;
 import org.apache.parquet.column.ColumnDescriptor;
 import org.apache.parquet.column.page.PageReader;
 import org.apache.parquet.io.api.Binary;
+import org.apache.parquet.schema.LogicalTypeAnnotation;
 import org.apache.parquet.schema.PrimitiveType;
 
 import java.io.IOException;
@@ -34,9 +35,9 @@ import java.sql.Timestamp;
 import java.util.concurrent.TimeUnit;
 
 /**
- * Timestamp {@link ColumnReader}. We only support INT96 bytes now, julianDay(4) + nanosOfDay(8).
- * See https://github.com/apache/parquet-format/blob/master/LogicalTypes.md#timestamp
- * TIMESTAMP_MILLIS and TIMESTAMP_MICROS are the deprecated ConvertedType.
+ * Timestamp {@link ColumnReader}. We support INT96 and INT64 now, julianDay(4) + nanosOfDay(8). See
+ * https://github.com/apache/parquet-format/blob/master/LogicalTypes.md#timestamp TIMESTAMP_MILLIS
+ * and TIMESTAMP_MICROS are the deprecated ConvertedType.
  */
 public class TimestampColumnReader extends AbstractColumnReader<WritableTimestampVector> {
 
@@ -44,15 +45,40 @@ public class TimestampColumnReader extends AbstractColumnReader<WritableTimestam
     public static final long MILLIS_IN_DAY = TimeUnit.DAYS.toMillis(1);
     public static final long NANOS_PER_MILLISECOND = TimeUnit.MILLISECONDS.toNanos(1);
     public static final long NANOS_PER_SECOND = TimeUnit.SECONDS.toNanos(1);
+    public static final long MICROS_PER_MILLISECOND = TimeUnit.MILLISECONDS.toMicros(1);
+    public static final long NANOS_PER_MICROSECONDS = TimeUnit.MICROSECONDS.toNanos(1);
+    public static final long MILLIS_PER_SECOND = TimeUnit.SECONDS.toMillis(1);
+    public static final long MICROS_PER_SECOND = TimeUnit.SECONDS.toMicros(1);
 
     private final boolean utcTimestamp;
+    private final PrimitiveType.PrimitiveTypeName actualName;
+    private final LogicalTypeAnnotation.TimeUnit timeUnit;
 
     public TimestampColumnReader(
             boolean utcTimestamp, ColumnDescriptor descriptor, PageReader pageReader)
             throws IOException {
         super(descriptor, pageReader);
         this.utcTimestamp = utcTimestamp;
-        checkTypeName(PrimitiveType.PrimitiveTypeName.INT96);
+        actualName = descriptor.getPrimitiveType().getPrimitiveTypeName();
+        checkTypeName();
+        if (actualName == PrimitiveType.PrimitiveTypeName.INT64) {
+            timeUnit =
+                    ((LogicalTypeAnnotation.TimestampLogicalTypeAnnotation)
+                                    descriptor.getPrimitiveType().getLogicalTypeAnnotation())
+                            .getUnit();
+        } else {
+            timeUnit = null;
+        }
+    }
+
+    private void checkTypeName() {
+        Preconditions.checkArgument(
+                actualName == PrimitiveType.PrimitiveTypeName.INT96
+                        || actualName == PrimitiveType.PrimitiveTypeName.INT64,
+                "Expected type name: %s or %s, actual type name: %s",
+                PrimitiveType.PrimitiveTypeName.INT64,
+                actualName == PrimitiveType.PrimitiveTypeName.INT96,
+                actualName);
     }
 
     @Override
@@ -64,10 +90,16 @@ public class TimestampColumnReader extends AbstractColumnReader<WritableTimestam
     protected void readBatch(int rowId, int num, WritableTimestampVector column) {
         for (int i = 0; i < num; i++) {
             if (runLenDecoder.readInteger() == maxDefLevel) {
-                ByteBuffer buffer = readDataBuffer(12);
-                column.setTimestamp(
-                        rowId + i,
-                        int96ToTimestamp(utcTimestamp, buffer.getLong(), buffer.getInt()));
+                if (actualName == PrimitiveType.PrimitiveTypeName.INT64) {
+                    ByteBuffer buffer = readDataBuffer(8);
+                    column.setTimestamp(
+                            rowId + i, int64ToTimestamp(utcTimestamp, buffer.getLong(), timeUnit));
+                } else {
+                    ByteBuffer buffer = readDataBuffer(12);
+                    column.setTimestamp(
+                            rowId + i,
+                            int96ToTimestamp(utcTimestamp, buffer.getLong(), buffer.getInt()));
+                }
             } else {
                 column.setNullAt(rowId + i);
             }
@@ -79,11 +111,27 @@ public class TimestampColumnReader extends AbstractColumnReader<WritableTimestam
             int rowId, int num, WritableTimestampVector column, WritableIntVector dictionaryIds) {
         for (int i = rowId; i < rowId + num; ++i) {
             if (!column.isNullAt(i)) {
-                column.setTimestamp(
-                        i,
-                        decodeInt96ToTimestamp(utcTimestamp, dictionary, dictionaryIds.getInt(i)));
+                if (actualName == PrimitiveType.PrimitiveTypeName.INT64) {
+                    column.setTimestamp(
+                            i,
+                            decodeInt64ToTimestamp(
+                                    utcTimestamp, dictionary, dictionaryIds.getInt(i), timeUnit));
+                } else {
+                    column.setTimestamp(
+                            i,
+                            decodeInt96ToTimestamp(
+                                    utcTimestamp, dictionary, dictionaryIds.getInt(i)));
+                }
             }
         }
+    }
+
+    public static TimestampData decodeInt64ToTimestamp(
+            boolean utcTimestamp,
+            org.apache.parquet.column.Dictionary dictionary,
+            int id,
+            LogicalTypeAnnotation.TimeUnit timeUnit) {
+        return int64ToTimestamp(utcTimestamp, dictionary.decodeToLong(id), timeUnit);
     }
 
     public static TimestampData decodeInt96ToTimestamp(
@@ -107,6 +155,37 @@ public class TimestampColumnReader extends AbstractColumnReader<WritableTimestam
             timestamp.setNanos((int) (nanosOfDay % NANOS_PER_SECOND));
             return TimestampData.fromTimestamp(timestamp);
         }
+    }
+
+    public static TimestampData int64ToTimestamp(
+            boolean utcTimestamp, long value, LogicalTypeAnnotation.TimeUnit timeUnit) {
+        long nanosOfMillisecond = 0L;
+        long milliseconds = 0L;
+
+        switch (timeUnit) {
+            case MILLIS:
+                milliseconds = value;
+                nanosOfMillisecond = value % MILLIS_PER_SECOND * NANOS_PER_MILLISECOND;
+                break;
+            case MICROS:
+                milliseconds = value / MICROS_PER_MILLISECOND;
+                nanosOfMillisecond = (value % MICROS_PER_SECOND) * NANOS_PER_MICROSECONDS;
+                break;
+            case NANOS:
+                milliseconds = value / NANOS_PER_MILLISECOND;
+                nanosOfMillisecond = value % NANOS_PER_SECOND;
+                break;
+            default:
+                break;
+        }
+
+        if (utcTimestamp) {
+            return TimestampData.fromEpochMillis(
+                    milliseconds, (int) (nanosOfMillisecond % NANOS_PER_MILLISECOND));
+        }
+        Timestamp timestamp = new Timestamp(milliseconds);
+        timestamp.setNanos((int) nanosOfMillisecond);
+        return TimestampData.fromTimestamp(timestamp);
     }
 
     private static long julianDayToMillis(int julianDay) {

--- a/flink-formats/flink-parquet/src/test/java/org/apache/flink/formats/parquet/ParquetTimestampITCase.java
+++ b/flink-formats/flink-parquet/src/test/java/org/apache/flink/formats/parquet/ParquetTimestampITCase.java
@@ -1,0 +1,280 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.flink.formats.parquet;
+
+import org.apache.flink.api.common.typeinfo.TypeInformation;
+import org.apache.flink.api.common.typeinfo.Types;
+import org.apache.flink.api.java.typeutils.RowTypeInfo;
+import org.apache.flink.streaming.api.scala.DataStream;
+import org.apache.flink.table.planner.runtime.stream.FiniteTestSource;
+import org.apache.flink.table.planner.runtime.stream.FsStreamingSinkITCaseBase;
+import org.apache.flink.table.planner.runtime.utils.TestSinkUtil;
+import org.apache.flink.table.planner.utils.JavaScalaConversionUtil;
+import org.apache.flink.types.Row;
+import org.apache.flink.util.CollectionUtil;
+
+import org.apache.parquet.Strings;
+import org.junit.runner.RunWith;
+import org.junit.runners.Parameterized;
+
+import java.sql.Timestamp;
+import java.time.LocalDateTime;
+import java.util.ArrayList;
+import java.util.List;
+import java.util.TimeZone;
+import java.util.stream.Collectors;
+
+import scala.Function1;
+import scala.collection.Seq;
+
+import static org.apache.flink.connector.file.table.FileSystemConnectorOptions.PARTITION_TIME_EXTRACTOR_KIND;
+import static org.apache.flink.connector.file.table.FileSystemConnectorOptions.PARTITION_TIME_EXTRACTOR_TIMESTAMP_FORMATTER;
+import static org.apache.flink.connector.file.table.FileSystemConnectorOptions.PARTITION_TIME_EXTRACTOR_TIMESTAMP_PATTERN;
+import static org.apache.flink.connector.file.table.FileSystemConnectorOptions.SINK_PARTITION_COMMIT_DELAY;
+import static org.apache.flink.connector.file.table.FileSystemConnectorOptions.SINK_PARTITION_COMMIT_POLICY_KIND;
+import static org.apache.flink.connector.file.table.FileSystemConnectorOptions.SINK_PARTITION_COMMIT_SUCCESS_FILE_NAME;
+import static org.apache.flink.connector.file.table.FileSystemConnectorOptions.SINK_PARTITION_COMMIT_TRIGGER;
+import static org.apache.flink.formats.parquet.ParquetFileFormatFactory.TIMESTAMP_TIME_UNIT;
+import static org.apache.flink.formats.parquet.ParquetFileFormatFactory.UTC_TIMEZONE;
+import static org.apache.flink.formats.parquet.ParquetFileFormatFactory.WRITE_INT64_TIMESTAMP;
+import static org.junit.Assert.assertEquals;
+
+/** Test int64 timestamp. */
+@RunWith(Parameterized.class)
+public class ParquetTimestampITCase extends FsStreamingSinkITCaseBase {
+    @Parameterized.Parameter public static boolean useInt64;
+
+    @Parameterized.Parameter(1)
+    public static String timeunit;
+
+    @Parameterized.Parameter(2)
+    public static boolean timezone;
+
+    @Parameterized.Parameters(name = "useInt64 = {0}, timeunit = {1}, timezone = {2}")
+    public static Object[] parameters() {
+        return new Object[][] {
+            new Object[] {false, "millis", false},
+            new Object[] {true, "millis", false},
+            new Object[] {true, "micros", false},
+            new Object[] {true, "nanos", false},
+            new Object[] {true, "millis", true},
+            new Object[] {true, "micros", true},
+            new Object[] {true, "nanos", true}
+        };
+    }
+
+    @Override
+    public Seq<Row> getData() {
+        return JavaScalaConversionUtil.toScala(
+                new ArrayList<Row>() {
+                    {
+                        add(
+                                Row.of(
+                                        Integer.valueOf(1),
+                                        "a",
+                                        Timestamp.valueOf("2020-05-03 07:00:00.000000000"),
+                                        "05-03-2020",
+                                        "07"));
+                        add(
+                                Row.of(
+                                        Integer.valueOf(2),
+                                        "p",
+                                        Timestamp.valueOf("2020-05-03 08:01:01.111111111"),
+                                        "05-03-2020",
+                                        "08"));
+                        add(
+                                Row.of(
+                                        Integer.valueOf(3),
+                                        "x",
+                                        Timestamp.valueOf("2020-05-03 09:02:02.222222222"),
+                                        "05-03-2020",
+                                        "09"));
+                        add(
+                                Row.of(
+                                        Integer.valueOf(4),
+                                        "x",
+                                        Timestamp.valueOf("2020-05-03 10:03:03.333333333"),
+                                        "05-03-2020",
+                                        "10"));
+                        add(
+                                Row.of(
+                                        Integer.valueOf(5),
+                                        "x",
+                                        Timestamp.valueOf("2020-05-03 11:04:04.444444444"),
+                                        "05-03-2020",
+                                        "11"));
+                    }
+                });
+    }
+
+    @Override
+    public Seq<Row> getData2() {
+        return JavaScalaConversionUtil.toScala(
+                new ArrayList<Row>() {
+                    {
+                        add(
+                                Row.of(
+                                        Integer.valueOf(1),
+                                        "a",
+                                        Timestamp.valueOf("2020-05-03 07:00:00.000000000"),
+                                        "20200503",
+                                        "07"));
+                        add(
+                                Row.of(
+                                        Integer.valueOf(2),
+                                        "p",
+                                        Timestamp.valueOf("2020-05-03 08:01:01.111111111"),
+                                        "20200503",
+                                        "08"));
+                        add(
+                                Row.of(
+                                        Integer.valueOf(3),
+                                        "x",
+                                        Timestamp.valueOf("2020-05-03 09:02:02.222222222"),
+                                        "20200503",
+                                        "09"));
+                        add(
+                                Row.of(
+                                        Integer.valueOf(4),
+                                        "x",
+                                        Timestamp.valueOf("2020-05-04 10:03:03.333333333"),
+                                        "20200504",
+                                        "10"));
+                        add(
+                                Row.of(
+                                        Integer.valueOf(5),
+                                        "x",
+                                        Timestamp.valueOf("2020-05-04 11:04:04.444444444"),
+                                        "20200504",
+                                        "11"));
+                    }
+                });
+    }
+
+    @Override
+    public DataStream<Row> getDataStream2(Function1<Row, Object> fun) {
+        return new DataStream<Row>(
+                env().getJavaEnv()
+                        .addSource(
+                                new FiniteTestSource(getData2(), fun),
+                                new RowTypeInfo(
+                                        new TypeInformation[] {
+                                            Types.INT,
+                                            Types.STRING,
+                                            Types.SQL_TIMESTAMP,
+                                            Types.STRING,
+                                            Types.STRING
+                                        },
+                                        new String[] {"a", "b", "c", "d", "e"})));
+    }
+
+    @Override
+    public DataStream<Row> getDataStream(Function1<Row, Object> fun) {
+        return new DataStream<Row>(
+                env().getJavaEnv()
+                        .addSource(
+                                new FiniteTestSource(getData(), fun),
+                                new RowTypeInfo(
+                                        new TypeInformation[] {
+                                            Types.INT,
+                                            Types.STRING,
+                                            Types.SQL_TIMESTAMP,
+                                            Types.STRING,
+                                            Types.STRING
+                                        },
+                                        new String[] {"a", "b", "c", "d", "e"})));
+    }
+
+    @Override
+    public String getDDL(
+            String timeExtractorKind,
+            String timeExtractorFormatterPattern,
+            String timeExtractorPattern,
+            String partition,
+            String commitTrigger,
+            String commitDelay,
+            String policy,
+            String successFileName) {
+        StringBuffer ddl = new StringBuffer("create table sink_table (");
+        ddl.append("  a int, ");
+        ddl.append(" b string, ");
+        ddl.append(" c timestamp(3), ");
+        ddl.append(" d string,");
+        ddl.append(" e string");
+        ddl.append(") ");
+        if (!Strings.isNullOrEmpty(partition)) {
+            ddl.append("partitioned by ( " + partition + " ) ");
+        }
+        ddl.append("with ( ");
+        ddl.append(" 'connector' = 'filesystem', ");
+        ddl.append(" 'path' = '" + resultPath() + "', ");
+        ddl.append(
+                " '" + PARTITION_TIME_EXTRACTOR_KIND.key() + "' = '" + timeExtractorKind + "', ");
+        if (!Strings.isNullOrEmpty(timeExtractorFormatterPattern)) {
+            ddl.append(
+                    " '"
+                            + PARTITION_TIME_EXTRACTOR_TIMESTAMP_FORMATTER.key()
+                            + "' = '"
+                            + timeExtractorFormatterPattern
+                            + "', ");
+        }
+        ddl.append(
+                " '"
+                        + PARTITION_TIME_EXTRACTOR_TIMESTAMP_PATTERN.key()
+                        + "' = '"
+                        + timeExtractorPattern
+                        + "', ");
+        ddl.append(" '" + SINK_PARTITION_COMMIT_TRIGGER.key() + "' = '" + commitTrigger + "', ");
+        ddl.append(" '" + SINK_PARTITION_COMMIT_DELAY.key() + "' = '" + commitDelay + "', ");
+        ddl.append(" '" + SINK_PARTITION_COMMIT_POLICY_KIND.key() + "' = '" + policy + "', ");
+        ddl.append(
+                " '"
+                        + SINK_PARTITION_COMMIT_SUCCESS_FILE_NAME.key()
+                        + "' = '"
+                        + successFileName
+                        + "', ");
+        ddl.append(" 'format'='parquet', ");
+        ddl.append(" 'parquet." + UTC_TIMEZONE.key() + "' = '" + timezone + "', ");
+        ddl.append(" 'parquet." + TIMESTAMP_TIME_UNIT.key() + "' = '" + timeunit + "', ");
+        ddl.append(" 'parquet." + WRITE_INT64_TIMESTAMP.key() + "' = '" + useInt64 + "'");
+        ddl.append(") ");
+        return ddl.toString();
+    }
+
+    @Override
+    public void check(String sqlQuery, Seq<Row> expectedResult) {
+        List<Row> result =
+                CollectionUtil.iteratorToList(tEnv().sqlQuery(sqlQuery).execute().collect());
+        assertEquals(
+                JavaScalaConversionUtil.toJava(expectedResult).stream()
+                        .map(row -> TestSinkUtil.rowToString(row, TimeZone.getTimeZone("UTC")))
+                        .sorted()
+                        .collect(Collectors.toList()),
+                result.stream()
+                        .map(
+                                row -> {
+                                    row.setField(
+                                            2, Timestamp.valueOf((LocalDateTime) row.getField(2)));
+                                    return TestSinkUtil.rowToString(
+                                            row, TimeZone.getTimeZone("UTC"));
+                                })
+                        .sorted()
+                        .collect(Collectors.toList()));
+    }
+}

--- a/flink-formats/flink-parquet/src/test/java/org/apache/flink/formats/parquet/ParquetTimestampITCase.java
+++ b/flink-formats/flink-parquet/src/test/java/org/apache/flink/formats/parquet/ParquetTimestampITCase.java
@@ -26,12 +26,14 @@ import org.apache.flink.table.planner.runtime.stream.FiniteTestSource;
 import org.apache.flink.table.planner.runtime.stream.FsStreamingSinkITCaseBase;
 import org.apache.flink.table.planner.runtime.utils.TestSinkUtil;
 import org.apache.flink.table.planner.utils.JavaScalaConversionUtil;
+import org.apache.flink.testutils.junit.extensions.parameterized.Parameter;
+import org.apache.flink.testutils.junit.extensions.parameterized.ParameterizedTestExtension;
+import org.apache.flink.testutils.junit.extensions.parameterized.Parameters;
 import org.apache.flink.types.Row;
 import org.apache.flink.util.CollectionUtil;
 
 import org.apache.parquet.Strings;
-import org.junit.runner.RunWith;
-import org.junit.runners.Parameterized;
+import org.junit.jupiter.api.extension.ExtendWith;
 
 import java.sql.Timestamp;
 import java.time.LocalDateTime;
@@ -56,17 +58,15 @@ import static org.apache.flink.formats.parquet.ParquetFileFormatFactory.WRITE_IN
 import static org.junit.Assert.assertEquals;
 
 /** Test int64 timestamp. */
-@RunWith(Parameterized.class)
+@ExtendWith(ParameterizedTestExtension.class)
 public class ParquetTimestampITCase extends FsStreamingSinkITCaseBase {
-    @Parameterized.Parameter public static boolean useInt64;
+    @Parameter public static boolean useInt64;
 
-    @Parameterized.Parameter(1)
-    public static String timeunit;
+    @Parameter public static String timeunit;
 
-    @Parameterized.Parameter(2)
-    public static boolean timezone;
+    @Parameter public static boolean timezone;
 
-    @Parameterized.Parameters(name = "useInt64 = {0}, timeunit = {1}, timezone = {2}")
+    @Parameters(name = "useInt64 = {0}, timeunit = {1}, timezone = {2}")
     public static Object[] parameters() {
         return new Object[][] {
             new Object[] {false, "millis", false},

--- a/flink-formats/flink-parquet/src/test/java/org/apache/flink/formats/parquet/row/ParquetRowDataWriterTest.java
+++ b/flink-formats/flink-parquet/src/test/java/org/apache/flink/formats/parquet/row/ParquetRowDataWriterTest.java
@@ -68,6 +68,9 @@ import java.util.Map;
 import java.util.UUID;
 import java.util.stream.IntStream;
 
+import static org.apache.flink.formats.parquet.ParquetFileFormatFactory.IDENTIFIER;
+import static org.apache.flink.formats.parquet.ParquetFileFormatFactory.TIMESTAMP_TIME_UNIT;
+import static org.apache.flink.formats.parquet.ParquetFileFormatFactory.WRITE_INT64_TIMESTAMP;
 import static org.assertj.core.api.Assertions.assertThat;
 
 /** Test for {@link ParquetRowDataBuilder} and {@link ParquetRowDataWriter}. */
@@ -121,6 +124,17 @@ class ParquetRowDataWriterTest {
     void testCompression(@TempDir java.nio.file.Path folder) throws Exception {
         Configuration conf = new Configuration();
         conf.set(ParquetOutputFormat.COMPRESSION, "GZIP");
+        innerTest(folder, conf, true);
+        innerTest(folder, conf, false);
+        complexTypeTest(folder, conf, true);
+        complexTypeTest(folder, conf, false);
+    }
+
+    @Test
+    public void testInt64Timestamp(@TempDir java.nio.file.Path folder) throws Exception {
+        Configuration conf = new Configuration();
+        conf.set(IDENTIFIER + "." + WRITE_INT64_TIMESTAMP.key(), "true");
+        conf.set(IDENTIFIER + "." + TIMESTAMP_TIME_UNIT.key(), "nanos");
         innerTest(folder, conf, true);
         innerTest(folder, conf, false);
         complexTypeTest(folder, conf, true);

--- a/flink-formats/flink-parquet/src/test/java/org/apache/flink/formats/parquet/vector/ParquetInt64TimestampReaderTest.java
+++ b/flink-formats/flink-parquet/src/test/java/org/apache/flink/formats/parquet/vector/ParquetInt64TimestampReaderTest.java
@@ -1,0 +1,69 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.flink.formats.parquet.vector;
+
+import org.apache.flink.formats.parquet.vector.reader.TimestampColumnReader;
+import org.apache.flink.table.data.TimestampData;
+
+import org.apache.parquet.schema.LogicalTypeAnnotation;
+import org.junit.Test;
+
+import java.time.LocalDateTime;
+import java.time.OffsetDateTime;
+
+import static org.junit.Assert.assertEquals;
+
+/** Test for {@link TimestampColumnReader}. */
+public class ParquetInt64TimestampReaderTest {
+    @Test
+    public void testReadInt64TimestampMicros() {
+        LocalDateTime localDateTime = LocalDateTime.of(2021, 11, 22, 17, 50, 20, 112233);
+        long time =
+                localDateTime.toEpochSecond(OffsetDateTime.now().getOffset()) * 1_000_000
+                        + localDateTime.getNano() / 1_000;
+        TimestampData timestampData =
+                TimestampColumnReader.int64ToTimestamp(
+                        false, time, LogicalTypeAnnotation.TimeUnit.MICROS);
+        assertEquals("2021-11-22T17:50:20.000112", timestampData.toString());
+    }
+
+    @Test
+    public void testReadInt64TimestampMillis() {
+        LocalDateTime localDateTime = LocalDateTime.of(2021, 11, 22, 17, 50, 20, 112233);
+        long time =
+                localDateTime.toEpochSecond(OffsetDateTime.now().getOffset()) * 1_000
+                        + localDateTime.getNano() / 1_000_000;
+        TimestampData timestampData =
+                TimestampColumnReader.int64ToTimestamp(
+                        false, time, LogicalTypeAnnotation.TimeUnit.MILLIS);
+        assertEquals("2021-11-22T17:50:20", timestampData.toString());
+    }
+
+    @Test
+    public void testReadInt64TimestampNanos() {
+        LocalDateTime localDateTime = LocalDateTime.of(2021, 11, 22, 17, 50, 20, 112233);
+        long time =
+                localDateTime.toEpochSecond(OffsetDateTime.now().getOffset()) * 1_000_000_000
+                        + localDateTime.getNano();
+        TimestampData timestampData =
+                TimestampColumnReader.int64ToTimestamp(
+                        false, time, LogicalTypeAnnotation.TimeUnit.NANOS);
+        assertEquals("2021-11-22T17:50:20.000112233", timestampData.toString());
+    }
+}

--- a/flink-table/flink-table-planner/src/test/scala/org/apache/flink/table/planner/runtime/stream/FsStreamingSinkITCaseBase.scala
+++ b/flink-table/flink-table-planner/src/test/scala/org/apache/flink/table/planner/runtime/stream/FsStreamingSinkITCaseBase.scala
@@ -50,7 +50,7 @@ abstract class FsStreamingSinkITCaseBase extends StreamingTestBase {
   protected var resultPath: String = _
 
   // iso date
-  private val data: Seq[Row] = Seq(
+  def getData: Seq[Row] = Seq(
     Row.of(Integer.valueOf(1), "a", "b", "05-03-2020", "07"),
     Row.of(Integer.valueOf(2), "p", "q", "05-03-2020", "08"),
     Row.of(Integer.valueOf(3), "x", "y", "05-03-2020", "09"),
@@ -59,7 +59,7 @@ abstract class FsStreamingSinkITCaseBase extends StreamingTestBase {
   )
 
   // basic iso date
-  private val data2 = Seq(
+  def getData2 = Seq(
     Row.of(Integer.valueOf(1), "a", "b", "20200503", "07"),
     Row.of(Integer.valueOf(2), "p", "q", "20200503", "08"),
     Row.of(Integer.valueOf(3), "x", "y", "20200503", "09"),
@@ -103,6 +103,13 @@ abstract class FsStreamingSinkITCaseBase extends StreamingTestBase {
           " You can only configure 'metastore' partition commit policy for a hive table.")
   }
 
+  def getDataStream2(fun: Row => Long) = {
+    new DataStream(
+      env.getJavaEnv.addSource(
+        new FiniteTestSource(getData2, fun),
+        new RowTypeInfo(Types.INT, Types.STRING, Types.STRING, Types.STRING, Types.STRING)))
+  }
+
   @Test
   def testPartitionWithBasicDate(): Unit = {
 
@@ -114,19 +121,21 @@ abstract class FsStreamingSinkITCaseBase extends StreamingTestBase {
       TimestampData.fromLocalDateTime(localDateTime).getMillisecond
     }
 
-    val stream: DataStream[Row] = new DataStream(
-      env.getJavaEnv.addSource(
-        new FiniteTestSource(data2, fun),
-        new RowTypeInfo(Types.INT, Types.STRING, Types.STRING, Types.STRING, Types.STRING)))
-
     // write out the data
-    test(stream, "default", "yyyyMMdd", "$d", "d", "partition-time", "1d", data2)
+    test(getDataStream2(fun), "default", "yyyyMMdd", "$d", "d", "partition-time", "1d", getData2)
 
     // verify that the written data is correct
     val basePath = new File(new URI(resultPath).getPath)
     assertThat(basePath.list()).hasSize(2)
     assertThat(new File(new File(basePath, "d=20200503"), "_MY_SUCCESS")).exists()
     assertThat(new File(new File(basePath, "d=20200504"), "_MY_SUCCESS")).exists()
+  }
+
+  def getDataStream(fun: Row => Long): DataStream[Row] = {
+    new DataStream(
+      env.getJavaEnv.addSource(
+        new FiniteTestSource(getData, fun),
+        new RowTypeInfo(Types.INT, Types.STRING, Types.STRING, Types.STRING, Types.STRING)))
   }
 
   def testPartitionCustomFormatDate(partition: Boolean, policy: String = "success-file"): Unit = {
@@ -138,20 +147,15 @@ abstract class FsStreamingSinkITCaseBase extends StreamingTestBase {
       TimestampData.fromLocalDateTime(localDateTime).getMillisecond
     }
 
-    val stream = new DataStream(
-      env.getJavaEnv.addSource(
-        new FiniteTestSource(data, fun),
-        new RowTypeInfo(Types.INT, Types.STRING, Types.STRING, Types.STRING, Types.STRING)))
-
     test(
-      stream,
+      getDataStream(fun),
       "default",
       "MM-dd-yyyy HH:mm:ss",
       "$d $e:00:00",
       if (partition) "d,e" else "",
       "process-time",
       "1h",
-      data,
+      getData,
       policy)
   }
 
@@ -171,6 +175,31 @@ abstract class FsStreamingSinkITCaseBase extends StreamingTestBase {
 
     tEnv.createTemporaryView("my_table", dataStream, $("a"), $("b"), $("c"), $("d"), $("e"))
 
+    val ddl: String = getDDL(
+      timeExtractorKind,
+      timeExtractorFormatterPattern,
+      timeExtractorPattern,
+      partition,
+      commitTrigger,
+      commitDelay,
+      policy,
+      successFileName)
+    tEnv.executeSql(ddl)
+
+    tEnv.sqlQuery("select * from my_table").executeInsert("sink_table").await()
+
+    check("select * from sink_table", dataTest)
+  }
+
+  def getDDL(
+      timeExtractorKind: String,
+      timeExtractorFormatterPattern: String,
+      timeExtractorPattern: String,
+      partition: String,
+      commitTrigger: String,
+      commitDelay: String,
+      policy: String,
+      successFileName: String) = {
     val ddl =
       s"""
          |create table sink_table (
@@ -200,11 +229,7 @@ abstract class FsStreamingSinkITCaseBase extends StreamingTestBase {
          |  ${additionalProperties().mkString(",\n")}
          |)
        """.stripMargin
-    tEnv.executeSql(ddl)
-
-    tEnv.sqlQuery("select * from my_table").executeInsert("sink_table").await()
-
-    check("select * from sink_table", dataTest)
+    ddl
   }
 
   def check(sqlQuery: String, expectedResult: Seq[Row]): Unit = {


### PR DESCRIPTION
<!--
*Thank you very much for contributing to Apache Flink - we are happy that you want to help us improve Flink. To help the community review your contribution in the best possible way, please go through the checklist below, which will get the contribution into a shape in which it can be best reviewed.*

*Please understand that we do not do this to make contributions to Flink a hassle. In order to uphold a high standard of quality for code contributions, while at the same time managing a large number of contributions, we need contributors to prepare the contributions well, and give reviewers enough contextual information for the review. Please also understand that contributions that do not follow this guide will take longer to review and thus typically be picked up with lower priority by the community.*

## Contribution Checklist

  - Make sure that the pull request corresponds to a [JIRA issue](https://issues.apache.org/jira/projects/FLINK/issues). Exceptions are made for typos in JavaDoc or documentation files, which need no JIRA issue.
  
  - Name the pull request in the form "[FLINK-XXXX] [component] Title of the pull request", where *FLINK-XXXX* should be replaced by the actual issue number. Skip *component* if you are unsure about which is the best component.
  Typo fixes that have no associated JIRA issue should be named following this pattern: `[hotfix] [docs] Fix typo in event time introduction` or `[hotfix] [javadocs] Expand JavaDoc for PuncuatedWatermarkGenerator`.

  - Fill out the template below to describe the changes contributed by the pull request. That will give reviewers the context they need to do the review.
  
  - Make sure that the change passes the automated tests, i.e., `mvn clean verify` passes. You can set up Azure Pipelines CI to do that following [this guide](https://cwiki.apache.org/confluence/display/FLINK/Azure+Pipelines#AzurePipelines-Tutorial:SettingupAzurePipelinesforaforkoftheFlinkrepository).

  - Each pull request should address only one issue, not mix up code from multiple issues.
  
  - Each commit in the pull request has a meaningful commit message (including the JIRA id)

  - Once all items of the checklist are addressed, remove the above text and this checklist, leaving only the filled out template below.


**(The sections below can be removed for hotfixes of typos)**
-->

## What is the purpose of the change

*(For example: This pull request makes task deployment go through the blob server, rather than through RPC. That way we avoid re-transferring them on each deployment (during recovery).)*


## Brief change log

*(for example:)*
  - *The TaskInfo is stored in the blob store on job creation time as a persistent artifact*
  - *Deployments RPC transmits only the blob storage reference*
  - *TaskManagers retrieve the TaskInfo from the blob cache*


## Verifying this change

Please make sure both new and modified tests in this PR follows the conventions defined in our code quality guide: https://flink.apache.org/contributing/code-style-and-quality-common.html#testing

*(Please pick either of the following options)*

This change is a trivial rework / code cleanup without any test coverage.

*(or)*

This change is already covered by existing tests, such as *(please describe tests)*.

*(or)*

This change added tests and can be verified as follows:

*(example:)*
  - *Added integration tests for end-to-end deployment with large payloads (100MB)*
  - *Extended integration test for recovery after master (JobManager) failure*
  - *Added test that validates that TaskInfo is transferred only once across recoveries*
  - *Manually verified the change by running a 4 node cluser with 2 JobManagers and 4 TaskManagers, a stateful streaming program, and killing one JobManager and two TaskManagers during the execution, verifying that recovery happens correctly.*

## Does this pull request potentially affect one of the following parts:

  - Dependencies (does it add or upgrade a dependency): (yes / no)
  - The public API, i.e., is any changed class annotated with `@Public(Evolving)`: (yes / no)
  - The serializers: (yes / no / don't know)
  - The runtime per-record code paths (performance sensitive): (yes / no / don't know)
  - Anything that affects deployment or recovery: JobManager (and its components), Checkpointing, Kubernetes/Yarn, ZooKeeper: (yes / no / don't know)
  - The S3 file system connector: (yes / no / don't know)

## Documentation

  - Does this pull request introduce a new feature? (yes / no)
  - If yes, how is the feature documented? (not applicable / docs / JavaDocs / not documented)
