### PR TITLE
[FLINK-25580][State Backends]Improve the logic of over fraction calcu…

### DIFF
--- a/flink-state-backends/flink-statebackend-rocksdb/src/main/java/org/apache/flink/contrib/streaming/state/restore/RocksDBIncrementalRestoreOperation.java
+++ b/flink-state-backends/flink-statebackend-rocksdb/src/main/java/org/apache/flink/contrib/streaming/state/restore/RocksDBIncrementalRestoreOperation.java
@@ -239,7 +239,7 @@ public class RocksDBIncrementalRestoreOperation<K> implements RocksDBRestoreOper
                 backendUID);
 
         this.rocksHandle.openDB(
-                createlumnFamilyDescriptors(stateMetaInfoSnapshots, true),
+                createColumnFamilyDescriptors(stateMetaInfoSnapshots, true),
                 stateMetaInfoSnapshots,
                 restoreSourcePath);
     }
@@ -457,7 +457,7 @@ public class RocksDBIncrementalRestoreOperation<K> implements RocksDBRestoreOper
                 serializationProxy.getStateMetaInfoSnapshots();
 
         List<ColumnFamilyDescriptor> columnFamilyDescriptors =
-                createlumnFamilyDescriptors(stateMetaInfoSnapshots, false);
+                createColumnFamilyDescriptors(stateMetaInfoSnapshots, false);
 
         List<ColumnFamilyHandle> columnFamilyHandles =
                 new ArrayList<>(stateMetaInfoSnapshots.size() + 1);
@@ -479,7 +479,7 @@ public class RocksDBIncrementalRestoreOperation<K> implements RocksDBRestoreOper
      * This method recreates and registers all {@link ColumnFamilyDescriptor} from Flink's state
      * meta data snapshot.
      */
-    private List<ColumnFamilyDescriptor> createlumnFamilyDescriptors(
+    private List<ColumnFamilyDescriptor> createColumnFamilyDescriptors(
             List<StateMetaInfoSnapshot> stateMetaInfoSnapshots, boolean registerTtlCompactFilter) {
 
         List<ColumnFamilyDescriptor> columnFamilyDescriptors =

--- a/flink-state-backends/flink-statebackend-rocksdb/src/test/java/org/apache/flink/contrib/streaming/state/RocksDBIncrementalCheckpointUtilsTest.java
+++ b/flink-state-backends/flink-statebackend-rocksdb/src/test/java/org/apache/flink/contrib/streaming/state/RocksDBIncrementalCheckpointUtilsTest.java
@@ -108,11 +108,18 @@ public class RocksDBIncrementalCheckpointUtilsTest extends TestLogger {
                         keyedStateHandles, new KeyGroupRange(3, 6)));
 
         // both keyedStateHandle2 & keyedStateHandle3's key-group range satisfies the overlap
-        // fraction, but keyedStateHandle3's overlap fraction is better.
+        // fraction, but keyedStateHandle3's key group range is better.
         Assert.assertEquals(
                 keyedStateHandle3,
                 RocksDBIncrementalCheckpointUtils.chooseTheBestStateHandleForInitial(
                         keyedStateHandles, new KeyGroupRange(5, 12)));
+
+        // The intersect key group number of keyedStateHandle2 & keyedStateHandle3's with [4, 11]
+        // are 4. But the over fraction of keyedStateHandle2 is better.
+        Assert.assertEquals(
+                keyedStateHandle2,
+                RocksDBIncrementalCheckpointUtils.chooseTheBestStateHandleForInitial(
+                        keyedStateHandles, new KeyGroupRange(4, 11)));
 
         // both keyedStateHandle2 & keyedStateHandle3's key-group range are covered by [3, 12],
         // but this should choose the keyedStateHandle3, because keyedStateHandle3's key-group is


### PR DESCRIPTION
…late

## What is the purpose of the change

When I check the logic of rescale part of the rocksDB. I found that we do not have to multiply `overlapFraction` twice to evaluate the best score handle. So this pr is to remove the duplicate `* overlapFraction` and fix one typo.


## Verifying this change

I add an extra test to verify that: If two handles have the same number of intersect group, The higher `overlapFraction` will win.
