### PR TITLE
[FLINK-25471][streaming-java] Wrong result if table transforms to Dat…

### DIFF
--- a/flink-streaming-java/src/main/java/org/apache/flink/streaming/api/operators/BatchGroupedReduceOperator.java
+++ b/flink-streaming-java/src/main/java/org/apache/flink/streaming/api/operators/BatchGroupedReduceOperator.java
@@ -35,7 +35,9 @@ import org.apache.flink.streaming.runtime.streamrecord.StreamRecord;
 @Internal
 public class BatchGroupedReduceOperator<IN, KEY>
         extends AbstractUdfStreamOperator<IN, ReduceFunction<IN>>
-        implements OneInputStreamOperator<IN, IN>, Triggerable<KEY, VoidNamespace> {
+        implements OneInputStreamOperator<IN, IN>,
+                Triggerable<KEY, VoidNamespace>,
+                BoundedOneInput {
 
     private static final long serialVersionUID = 1L;
 
@@ -82,9 +84,15 @@ public class BatchGroupedReduceOperator<IN, KEY>
         IN currentValue = values.value();
         if (currentValue != null) {
             output.collect(new StreamRecord<>(currentValue, Long.MAX_VALUE));
+            values.clear();
         }
     }
 
     @Override
     public void onProcessingTime(InternalTimer<KEY, VoidNamespace> timer) throws Exception {}
+
+    @Override
+    public void endInput() throws Exception {
+        onEventTime(null);
+    }
 }


### PR DESCRIPTION
…aStream and then keyBy sum in Batch Mode

## What is the purpose of the change

Fix BatchGroupedReduceOperator does not output latest value right before task manager exits.

## Brief change log

- flink-streaming-java/src/main/java/org/apache/flink/streaming/api/operators/BatchGroupedReduceOperator.java

## Verifying this change

This change is a trivial rework / code cleanup without any test coverage.

## Does this pull request potentially affect one of the following parts:

  - Dependencies (does it add or upgrade a dependency): no
  - The public API, i.e., is any changed class annotated with `@Public(Evolving)`: no
  - The serializers: no
  - The runtime per-record code paths (performance sensitive): no
  - Anything that affects deployment or recovery: JobManager (and its components), Checkpointing, Kubernetes/Yarn, ZooKeeper: no
  - The S3 file system connector: no

## Documentation

  - Does this pull request introduce a new feature? no
