### PR TITLE
[FLINK-25280][connector/kafka] Disable log deletion in KafkaTestEnvironmentImpl to prevent records from being deleted during test run

### DIFF
--- a/flink-connectors/flink-connector-kafka/src/test/java/org/apache/flink/streaming/connectors/kafka/KafkaTestEnvironmentImpl.java
+++ b/flink-connectors/flink-connector-kafka/src/test/java/org/apache/flink/streaming/connectors/kafka/KafkaTestEnvironmentImpl.java
@@ -419,6 +419,8 @@ public class KafkaTestEnvironmentImpl extends KafkaTestEnvironment {
         kafkaProperties.put("replica.fetch.max.bytes", String.valueOf(50 * 1024 * 1024));
         kafkaProperties.put(
                 "transaction.max.timeout.ms", Integer.toString(1000 * 60 * 60 * 2)); // 2hours
+        // Disable log deletion to prevent records from being deleted during test run
+        kafkaProperties.put("log.retention.ms", "-1");
 
         // for CI stability, increase zookeeper session timeout
         kafkaProperties.put("zookeeper.session.timeout.ms", zkTimeout);


### PR DESCRIPTION
## What is the purpose of the change

This pull request disables log deletion in KafkaTestEnvironmentImpl to prevent records from being deleted during test run


## Brief change log

- Set broker property "log.retention.ms" to -1 in KafkaTestEnvironmentImpl


## Verifying this change

This change is already covered by existing Kafka connector tests.

## Does this pull request potentially affect one of the following parts:

  - Dependencies (does it add or upgrade a dependency): (yes / **no**)
  - The public API, i.e., is any changed class annotated with `@Public(Evolving)`: (yes / **no**)
  - The serializers: (yes / **no** / don't know)
  - The runtime per-record code paths (performance sensitive): (yes / **no** / don't know)
  - Anything that affects deployment or recovery: JobManager (and its components), Checkpointing, Kubernetes/Yarn, ZooKeeper: (yes / **no** / don't know)
  - The S3 file system connector: (yes / **no** / don't know)

## Documentation

  - Does this pull request introduce a new feature? (yes / **no**)
  - If yes, how is the feature documented? (**not applicable** / docs / JavaDocs / not documented)
