### PR TITLE
[hotfix][docs] Fixing multiple internal and external 404 links

### DIFF
--- a/docs/content.zh/docs/connectors/datastream/kafka.md
+++ b/docs/content.zh/docs/connectors/datastream/kafka.md
@@ -419,7 +419,7 @@ Flink 通过 Kafka 连接器提供了一流的支持，可以对 Kerberos 配置
 - 将 `security.protocol` 设置为 `SASL_PLAINTEXT`（默认为 `NONE`）：用于与 Kafka broker 进行通信的协议。使用独立 Flink 部署时，也可以使用 `SASL_SSL`；请在[此处](https://kafka.apache.org/documentation/#security_configclients)查看如何为 SSL 配置 Kafka 客户端。
 - 将 `sasl.kerberos.service.name` 设置为 `kafka`（默认为 `kafka`）：此值应与用于 Kafka broker 配置的 `sasl.kerberos.service.name` 相匹配。客户端和服务器配置之间的服务名称不匹配将导致身份验证失败。
 
-有关 Kerberos 安全性 Flink 配置的更多信息，请参见[这里]({{< ref "docs/deployment/config" >}}})。你也可以在[这里]({{< ref "docs/deployment/security/security-kerberos" >}})进一步了解 Flink 如何在内部设置基于 kerberos 的安全性。
+有关 Kerberos 安全性 Flink 配置的更多信息，请参见[这里]({{< ref "docs/deployment/config" >}})。你也可以在[这里]({{< ref "docs/deployment/security/security-kerberos" >}})进一步了解 Flink 如何在内部设置基于 kerberos 的安全性。
 
 <a name="upgrading-to-the-latest-connector-version"></a>
 

--- a/docs/content.zh/docs/deployment/advanced/external_resources.md
+++ b/docs/content.zh/docs/deployment/advanced/external_resources.md
@@ -244,7 +244,7 @@ class FPGAInfo extends ExternalResourceInfo {
 
 我们为 GPU 提供了第一方插件。该插件利用一个脚本来发现 GPU 设备的索引，该索引可通过“index”从 `ExternalResourceInfo` 中获取。我们提供了一个默认脚本，可以用来发现 NVIDIA GPU。您还可以提供自定义脚本。
 
-我们提供了[一个示例程序](https://github.com/apache/flink/blob/master/flink-examples/flink-examples-streaming/src/main/java/org/apache/flink/streaming/examples/gpu/MatrixVectorMul.java)，展示了如何在 Flink 中使用 GPU 资源来做矩阵-向量乘法。
+我们提供了{{< gh_link file="/flink-examples/flink-examples-streaming/src/main/java/org/apache/flink/streaming/examples/gpu/MatrixVectorMul.java" name="一个示例程序" >}}，展示了如何在 Flink 中使用 GPU 资源来做矩阵-向量乘法。
 
 {{< hint info >}}
 **提示：** 目前，对于所有算子，RuntimeContext#getExternalResourceInfos 会返回同样的资源信息。也即，在同一个 TaskManager 中运行的所有算子都可以访问同一组 GPU 设备。扩展资源目前没有算子级别的隔离。

--- a/docs/content.zh/docs/deployment/resource-providers/standalone/kubernetes.md
+++ b/docs/content.zh/docs/deployment/resource-providers/standalone/kubernetes.md
@@ -116,7 +116,7 @@ $ ./bin/flink run -m localhost:8081 ./examples/streaming/TopSpeedWindowing.jar
 
 `jobmanager-job.yaml` 中的 `args` 属性必须指定用户作业的主类。也可以参考[如何设置 JobManager 参数]({{< ref "docs/deployment/resource-providers/standalone/docker" >}}#jobmanager-additional-command-line-arguments)来了解如何将额外的 `args` 传递给 `jobmanager-job.yaml` 配置中指定的 Flink 镜像。
 
-*job artifacts* 参数必须可以从 [资源定义示例](#application-cluster-resource-definitions) 中的 `job-artifacts-volume` 处获取。假如是在 minikube 集群中创建这些组件，那么定义示例中的 job-artifacts-volume 可以挂载为主机的本地目录。如果不使用 minikube 集群，那么可以使用 Kubernetes 集群中任何其它可用类型的 volume 来提供 *job artifacts*。此外，还可以构建一个已经包含 *job artifacts* 参数的[自定义镜像](({{< ref "docs/deployment/resource-providers/standalone/docker" >}}#advanced-customization))。
+*job artifacts* 参数必须可以从 [资源定义示例](#application-cluster-resource-definitions) 中的 `job-artifacts-volume` 处获取。假如是在 minikube 集群中创建这些组件，那么定义示例中的 job-artifacts-volume 可以挂载为主机的本地目录。如果不使用 minikube 集群，那么可以使用 Kubernetes 集群中任何其它可用类型的 volume 来提供 *job artifacts*。此外，还可以构建一个已经包含 *job artifacts* 参数的[自定义镜像]({{< ref "docs/deployment/resource-providers/standalone/docker" >}}#advanced-customization)。
 
 在创建[通用集群组件](#common-cluster-resource-definitions)后，指定 [Application 集群资源定义](#application-cluster-resource-definitions)文件，执行 `kubectl` 命令来启动 Flink Application 集群：
 

--- a/docs/content.zh/docs/dev/datastream/fault-tolerance/serialization/custom_serialization.md
+++ b/docs/content.zh/docs/dev/datastream/fault-tolerance/serialization/custom_serialization.md
@@ -37,7 +37,7 @@ If you're simply using Flink's own serializers, this page is irrelevant and can 
 
 When registering a managed operator or keyed state, a `StateDescriptor` is required
 to specify the state's name, as well as information about the type of the state. The type information is used by Flink's
-[type serialization framework](../../types_serialization.html) to create appropriate serializers for the state.
+[type serialization framework]({{< ref "docs/dev/datastream/fault-tolerance/serialization/types_serialization" >}}) to create appropriate serializers for the state.
 
 It is also possible to completely bypass this and let Flink use your own custom serializer to serialize managed states,
 simply by directly instantiating the `StateDescriptor` with your own `TypeSerializer` implementation:

--- a/docs/content.zh/docs/dev/datastream/overview.md
+++ b/docs/content.zh/docs/dev/datastream/overview.md
@@ -34,7 +34,7 @@ under the License.
 
 Flink 中的 DataStream 程序是对数据流（例如过滤、更新状态、定义窗口、聚合）进行转换的常规程序。数据流的起始是从各种源（例如消息队列、套接字流、文件）创建的。结果通过 sink 返回，例如可以将数据写入文件或标准输出（例如命令行终端）。Flink 程序可以在各种上下文中运行，可以独立运行，也可以嵌入到其它程序中。任务执行可以运行在本地 JVM 中，也可以运行在多台机器的集群上。
 
-为了创建你自己的 Flink DataStream 程序，我们建议你从 [Flink 程序剖析](#anatomy-of-a-flink-program)开始，然后逐渐添加自己的 [stream transformation](({{< ref "docs/dev/datastream/operators/overview" >}}))。其余部分作为附加的算子和高级特性的参考。
+为了创建你自己的 Flink DataStream 程序，我们建议你从 [Flink 程序剖析](#anatomy-of-a-flink-program)开始，然后逐渐添加自己的 [stream transformation]({{< ref "docs/dev/datastream/operators/overview" >}})。其余部分作为附加的算子和高级特性的参考。
 
 <a name="what-is-a-datastream"></a>
 

--- a/docs/content.zh/docs/dev/table/concepts/overview.md
+++ b/docs/content.zh/docs/dev/table/concepts/overview.md
@@ -34,6 +34,107 @@ Flink 的 [Table API]({{< ref "docs/dev/table/tableApi" >}}) 和 [SQL]({{< ref "
 
 下面这些页面包含了概念、实际的限制，以及流式数据处理中的一些特定的配置。
 
+State Management
+----------------
+
+Table programs that run in streaming mode leverage all capabilities of Flink as a stateful stream
+processor.
+
+In particular, a table program can be configured with a [state backend]({{< ref "docs/ops/state/state_backends" >}})
+and various [checkpointing options]({{< ref "docs/dev/datastream/fault-tolerance/checkpointing" >}})
+for handling different requirements regarding state size and fault tolerance. It is possible to take
+a savepoint of a running Table API & SQL pipeline and to restore the application's state at a later
+point in time.
+
+### State Usage
+
+Due to the declarative nature of Table API & SQL programs, it is not always obvious where and how much
+state is used within a pipeline. The planner decides whether state is necessary to compute a correct
+result. A pipeline is optimized to claim as little state as possible given the current set of optimizer
+rules.
+
+{{< hint info >}}
+Conceptually, source tables are never kept entirely in state. An implementer deals with logical tables
+(i.e. [dynamic tables]({{< ref "docs/dev/table/concepts/dynamic_tables" >}})). Their state requirements
+depend on the used operations.
+{{< /hint >}}
+
+Queries such as `SELECT ... FROM ... WHERE` which only consist of field projections or filters are usually
+stateless pipelines. However, operations such as joins, aggregations, or deduplications require keeping
+intermediate results in a fault-tolerant storage for which Flink's state abstractions are used.
+
+{{< hint info >}}
+Please refer to the individual operator documentation for more details about how much state is required
+and how to limit a potentially ever-growing state size.
+{{< /hint >}}
+
+For example, a regular SQL join of two tables requires the operator to keep both input tables in state
+entirely. For correct SQL semantics, the runtime needs to assume that a matching could occur at any
+point in time from both sides. Flink provides [optimized window and interval joins]({{< ref "docs/dev/table/sql/queries/joins" >}})
+that aim to keep the state size small by exploiting the concept of [watermarks]({{< ref "docs/dev/table/concepts/time_attributes" >}}).
+
+Another example is the following query that computes the number of clicks per session.
+
+```sql
+SELECT sessionId, COUNT(*) FROM clicks GROUP BY sessionId;
+```
+
+The `sessionId` attribute is used as a grouping key and the continuous query maintains a count
+for each `sessionId` it observes. The `sessionId` attribute is evolving over time and `sessionId`
+values are only active until the session ends, i.e., for a limited period of time. However, the
+continuous query cannot know about this property of `sessionId` and expects that every `sessionId`
+value can occur at any point of time. It maintains a count for each observed `sessionId` value.
+Consequently, the total state size of the query is continuously growing as more and more `sessionId`
+values are observed.
+
+#### Idle State Retention Time
+
+The *Idle State Retention Time* parameter [`table.exec.state.ttl`]({{< ref "docs/dev/table/config" >}}#table-exec-state-ttl)
+defines for how long the state of a key is retained without being updated before it is removed.
+For the previous example query, the count of a`sessionId` would be removed as soon as it has not
+been updated for the configured period of time.
+
+By removing the state of a key, the continuous query completely forgets that it has seen this key
+before. If a record with a key, whose state has been removed before, is processed, the record will
+be treated as if it was the first record with the respective key. For the example above this means
+that the count of a `sessionId` would start again at `0`.
+
+### Stateful Upgrades and Evolution
+
+Table programs that are executed in streaming mode are intended as *standing queries* which means they
+are defined once and are continuously evaluated as static end-to-end pipelines.
+
+In case of stateful pipelines, any change to both the query or Flink's planner might lead to a completely
+different execution plan. This makes stateful upgrades and the evolution of table programs challenging
+at the moment. The community is working on improving those shortcomings.
+
+For example, by adding a filter predicate, the optimizer might decide to reorder joins or change the
+schema of an intermediate operator. This prevents restoring from a savepoint due to either changed
+topology or different column layout within the state of an operator.
+
+The query implementer must ensure that the optimized plans before and after the change are compatible.
+Use the `EXPLAIN` command in SQL or `table.explain()` in Table API to [get insights]({{< ref "docs/dev/table/common" >}}#explaining-a-table).
+
+Since new optimizer rules are continuously added, and operators become more efficient and specialized,
+also the upgrade to a newer Flink version could lead to incompatible plans.
+
+{{< hint warning >}}
+Currently, the framework cannot guarantee that state can be mapped from a savepoint to a new table
+operator topology.
+
+In other words: Savepoints are only supported if both the query and the Flink version remain constant.
+{{< /hint >}}
+
+Since the community rejects contributions that modify the optimized plan and the operator topology
+in a patch version (e.g. from `1.13.1` to `1.13.2`), it should be safe to upgrade a Table API & SQL
+pipeline to a newer bug fix release. However, major-minor upgrades from (e.g. from `1.12` to `1.13`)
+are not supported.
+
+For both shortcomings (i.e. modified query and modified Flink version), we recommend to investigate
+whether the state of an updated table program can be "warmed up" (i.e. initialized) with historical
+data again before switching to real-time data. The Flink community is working on a [hybrid source]({{< ref "docs/connectors/datastream/hybridsource" >}})
+to make this switching as convenient as possible.
+
 接下来？
 -----------------
 

--- a/docs/content.zh/docs/dev/table/sqlClient.md
+++ b/docs/content.zh/docs/dev/table/sqlClient.md
@@ -660,6 +660,6 @@ If the option `pipeline.name` is not specified, SQL Client will generate a defau
 局限与未来
 --------------------
 
-当前的 SQL 客户端仅支持嵌入式模式。在将来，社区计划提供基于 REST 的 [SQL 客户端网关（Gateway）](sqlClient.html#limitations--future) 的功能，详见 [FLIP-24](https://cwiki.apache.org/confluence/display/FLINK/FLIP-24+-+SQL+Client) 和 [FLIP-91](https://cwiki.apache.org/confluence/display/FLINK/FLIP-91%3A+Support+SQL+Client+Gateway)。
+当前的 SQL 客户端仅支持嵌入式模式。在将来，社区计划提供基于 REST 的 SQL 客户端网关（Gateway) 的功能，详见 [FLIP-24](https://cwiki.apache.org/confluence/display/FLINK/FLIP-24+-+SQL+Client) 和 [FLIP-91](https://cwiki.apache.org/confluence/display/FLINK/FLIP-91%3A+Support+SQL+Client+Gateway)。
 
 {{< top >}}

--- a/docs/content.zh/docs/libs/gelly/graph_generators.md
+++ b/docs/content.zh/docs/libs/gelly/graph_generators.md
@@ -168,7 +168,7 @@ val graph = new CycleGraph(env.getJavaEnv, vertexCount).generate()
 
 ## Echo Graph
 
-An [echo graph](http://mathworld.wolfram.com/EchoGraph.html) is a
+An echo graph is a
 [circulant graph](#circulant-graph) with `n` vertices defined by the width of a
 single range of offsets centered at `n/2`. A vertex is connected to 'far'
 vertices, which connect to 'near' vertices, which connect to 'far' vertices, ....

--- a/docs/content.zh/docs/libs/gelly/iterative_graph_processing.md
+++ b/docs/content.zh/docs/libs/gelly/iterative_graph_processing.md
@@ -756,7 +756,7 @@ final class UpdateDistance extends ApplyFunction[Long, Double, Double] {
 
 Note that `gather` takes a `Neighbor` type as an argument. This is a convenience type which simply wraps a vertex with its neighboring edge.
 
-For more examples of how to implement algorithms with the Gather-Sum-Apply model, check the {{< gh_link file="/flink-libraries/flink-gelly/src/main/java/org/apache/flink/graph/library/GSAPageRank.java" name="GSAPageRank" >}} and {{< gh_link file="/flink-libraries/flink-gelly/src/main/java/org/apache/flink/graph/library/GSAConnectedComponents.java" name="GSAConnectedComponents" >}} library methods of Gelly.
+For more examples of how to implement algorithms with the Gather-Sum-Apply model, check the {{< gh_link file="/flink-libraries/flink-gelly-examples/src/main/java/org/apache/flink/graph/examples/GSAPageRank.java" name="GSAPageRank" >}} and {{< gh_link file="/flink-libraries/flink-gelly/src/main/java/org/apache/flink/graph/library/GSAConnectedComponents.java" name="GSAConnectedComponents" >}} library methods of Gelly.
 
 {{< top >}}
 

--- a/docs/content.zh/release-notes/flink-1.10.md
+++ b/docs/content.zh/release-notes/flink-1.10.md
@@ -179,7 +179,7 @@ If you try to reuse your previous Flink configuration without any adjustments,
 the new memory model can result in differently computed memory parameters for
 the JVM and, thus, performance changes.
 
-Please, check [the user documentation](../deployment/memory/mem_setup.html) for more details.
+Please, check [the user documentation](https://nightlies.apache.org/flink/flink-docs-release-1.10/ops/memory/mem_setup.html) for more details.
 
 ##### Deprecation and breaking changes
 The following options have been removed and have no effect anymore:

--- a/docs/content/docs/connectors/datastream/formats/azure_table_storage.md
+++ b/docs/content/docs/connectors/datastream/formats/azure_table_storage.md
@@ -27,7 +27,7 @@ under the License.
 
 # Microsoft Azure Table Storage format
 
-This example is using the `HadoopInputFormat` wrapper to use an existing Hadoop input format implementation for accessing [Azure's Table Storage](https://azure.microsoft.com/en-us/documentation/articles/storage-introduction/).
+This example is using the `HadoopInputFormat` wrapper to use an existing Hadoop input format implementation for accessing [Azure's Table Storage](https://docs.microsoft.com/en-us/azure/storage/tables/table-storage-overview).
 
 1. Download and compile the `azure-tables-hadoop` project. The input format developed by the project is not yet available in Maven Central, therefore, we have to build the project ourselves.
    Execute the following commands:

--- a/docs/content/docs/connectors/table/downloads.md
+++ b/docs/content/docs/connectors/table/downloads.md
@@ -33,7 +33,7 @@ Download links are available only for stable releases.
 {{< /hint >}}
 {{< /unstable >}}
 
-The page contains links to optional sql-client connectors and formats that are not part of the binary distribution.
+The page contains links to optional SQL Client connectors and formats that are not part of the binary distribution.
 
 # Optional SQL formats
 -------------------

--- a/docs/content/docs/connectors/table/filesystem.md
+++ b/docs/content/docs/connectors/table/filesystem.md
@@ -165,7 +165,7 @@ The file system connector supports streaming writes, based on Flink's [Streaming
 to write records to file. Row-encoded Formats are csv and json. Bulk-encoded Formats are parquet, orc and avro.
 
 You can write SQL directly, insert the stream data into the non-partitioned table.
-If it is a partitioned table, you can configure partition related operations. See [Partition Commit](filesystem.html#partition-commit) for details.
+If it is a partitioned table, you can configure partition related operations. See [Partition Commit]({{< ref "docs/connectors/table/filesystem" >}}#partition-commit) for details.
 
 ### Rolling Policy
 

--- a/docs/content/docs/deployment/advanced/external_resources.md
+++ b/docs/content/docs/deployment/advanced/external_resources.md
@@ -254,7 +254,7 @@ We provide a first-party plugin for GPU resources. The plugin leverages a discov
 be accessed from the resource *information* via the property "index". We provide a default discovery script that can be used to discover
 NVIDIA GPUs. You can also provide your custom script.
 
-We provide [an example](https://github.com/apache/flink/blob/{{ site.github_branch }}/flink-examples/flink-examples-streaming/src/main/java/org/apache/flink/streaming/examples/gpu/MatrixVectorMul.java)
+We provide {{< gh_link file="/flink-examples/flink-examples-streaming/src/main/java/org/apache/flink/streaming/examples/gpu/MatrixVectorMul.java" name="an example" >}}
 which shows how to use the GPUs to do matrix-vector multiplication in Flink.
 
 {{< hint info >}}

--- a/docs/content/docs/dev/dataset/examples.md
+++ b/docs/content/docs/dev/dataset/examples.md
@@ -124,7 +124,7 @@ The {{< gh_link file="/flink-examples/flink-examples-batch/src/main/scala/org/ap
 
 The PageRank algorithm computes the "importance" of pages in a graph defined by links, which point from one pages to another page. It is an iterative graph algorithm, which means that it repeatedly applies the same computation. In each iteration, each page distributes its current rank over all its neighbors, and compute its new rank as a taxed sum of the ranks it received from its neighbors. The PageRank algorithm was popularized by the Google search engine which uses the importance of webpages to rank the results of search queries.
 
-In this simple example, PageRank is implemented with a [bulk iteration](iterations.html) and a fixed number of iterations.
+In this simple example, PageRank is implemented with a [bulk iteration]({{< ref "docs/dev/dataset/iterations" >}}) and a fixed number of iterations.
 
 {{< tabs "09632721-7e4d-432b-bb2f-de47dc985aee" >}}
 {{< tab "Java" >}}
@@ -286,7 +286,7 @@ For this simple implementation it is required that each page has at least one in
 
 The Connected Components algorithm identifies parts of a larger graph which are connected by assigning all vertices in the same connected part the same component ID. Similar to PageRank, Connected Components is an iterative algorithm. In each step, each vertex propagates its current component ID to all its neighbors. A vertex accepts the component ID from a neighbor, if it is smaller than its own component ID.
 
-This implementation uses a [delta iteration](iterations.html): Vertices that have not changed their component ID do not participate in the next step. This yields much better performance, because the later iterations typically deal only with a few outlier vertices.
+This implementation uses a [delta iteration]({{< ref "docs/dev/dataset/iterations" >}}): Vertices that have not changed their component ID do not participate in the next step. This yields much better performance, because the later iterations typically deal only with a few outlier vertices.
 
 {{< tabs "8e65facc-4a70-4102-9204-d66b30644ad9" >}}
 {{< tab "Java" >}}

--- a/docs/content/docs/dev/dataset/hadoop_map_reduce.md
+++ b/docs/content/docs/dev/dataset/hadoop_map_reduce.md
@@ -32,10 +32,10 @@ reusing code that was implemented for Hadoop MapReduce.
 You can:
 
 - use Hadoop's `Writable` [data types]({{< ref "docs/dev/datastream/fault-tolerance/serialization/types_serialization" >}}#supported-data-types) in Flink programs.
-- use any Hadoop `InputFormat` as a [DataSource]({{ ref "docs/dev/connectors/formats/hadoop.html" >}}#data-sources).
-- use any Hadoop `OutputFormat` as a [DataSink]({{ ref "docs/dev/connectors/formats/hadoop.html" >}}#data-sinks).
-- use a Hadoop `Mapper` as [FlatMapFunction]({{ ref "docs/dev/dataset/transformations" >}}#flatmap).
-- use a Hadoop `Reducer` as [GroupReduceFunction]({{ ref "docs/dev/dataset/transformations" >}}#groupreduce-on-grouped-dataset).
+- use any Hadoop `InputFormat` as a [DataSource]({{< ref "docs/connectors/dataset/formats/hadoop" >}}#using-hadoop-inputformats).
+- use any Hadoop `OutputFormat` as a [DataSink]({{< ref "docs/connectors/dataset/formats/hadoop" >}}#using-hadoop-outputformats).
+- use a Hadoop `Mapper` as [FlatMapFunction]({{< ref "docs/dev/dataset/transformations" >}}#flatmap).
+- use a Hadoop `Reducer` as [GroupReduceFunction]({{< ref "docs/dev/dataset/transformations" >}}#groupreduce-on-grouped-dataset).
 
 This document shows how to use existing Hadoop MapReduce code with Flink. Please refer to the
 [Connecting to other systems]({{< ref "docs/deployment/filesystems/overview" >}}#hadoop-file-system-hdfs-and-its-other-implementations) guide for reading from Hadoop supported file systems.
@@ -69,7 +69,7 @@ a `hadoop-client` dependency such as:
 
 ## Using Hadoop Mappers and Reducers
 
-Hadoop Mappers are semantically equivalent to Flink's [FlatMapFunctions](dataset_transformations.html#flatmap) and Hadoop Reducers are equivalent to Flink's [GroupReduceFunctions](dataset_transformations.html#groupreduce-on-grouped-dataset). Flink provides wrappers for implementations of Hadoop MapReduce's `Mapper` and `Reducer` interfaces, i.e., you can reuse your Hadoop Mappers and Reducers in regular Flink programs. At the moment, only the Mapper and Reduce interfaces of Hadoop's mapred API (`org.apache.hadoop.mapred`) are supported.
+Hadoop Mappers are semantically equivalent to Flink's [FlatMapFunctions]({{< ref "docs/dev/dataset/transformations" >}}#flatmap) and Hadoop Reducers are equivalent to Flink's [GroupReduceFunctions]({{< ref "docs/dev/dataset/transformations" >}}#groupreduce-on-grouped-dataset). Flink provides wrappers for implementations of Hadoop MapReduce's `Mapper` and `Reducer` interfaces, i.e., you can reuse your Hadoop Mappers and Reducers in regular Flink programs. At the moment, only the Mapper and Reduce interfaces of Hadoop's mapred API (`org.apache.hadoop.mapred`) are supported.
 
 The wrappers take a `DataSet<Tuple2<KEYIN,VALUEIN>>` as input and produce a `DataSet<Tuple2<KEYOUT,VALUEOUT>>` as output where `KEYIN` and `KEYOUT` are the keys and `VALUEIN` and `VALUEOUT` are the values of the Hadoop key-value pairs that are processed by the Hadoop functions. For Reducers, Flink offers a wrapper for a GroupReduceFunction with (`HadoopReduceCombineFunction`) and without a Combiner (`HadoopReduceFunction`). The wrappers accept an optional `JobConf` object to configure the Hadoop Mapper or Reducer.
 
@@ -79,7 +79,7 @@ Flink's function wrappers are
 - `org.apache.flink.hadoopcompatibility.mapred.HadoopReduceFunction`, and
 - `org.apache.flink.hadoopcompatibility.mapred.HadoopReduceCombineFunction`.
 
-and can be used as regular Flink [FlatMapFunctions](dataset_transformations.html#flatmap) or [GroupReduceFunctions](dataset_transformations.html#groupreduce-on-grouped-dataset).
+and can be used as regular Flink [FlatMapFunctions]({{< ref "docs/dev/dataset/transformations" >}}#flatmap) or [GroupReduceFunctions]({{< ref "docs/dev/dataset/transformations" >}}#groupreduce-on-grouped-dataset).
 
 The following example shows how to use Hadoop `Mapper` and `Reducer` functions.
 
@@ -99,7 +99,7 @@ DataSet<Tuple2<Text, LongWritable>> result = text
   ));
 ```
 
-**Please note:** The Reducer wrapper works on groups as defined by Flink's [groupBy()](dataset_transformations.html#transformations-on-grouped-dataset) operation. It does not consider any custom partitioners, sort or grouping comparators you might have set in the `JobConf`.
+**Please note:** The Reducer wrapper works on groups as defined by Flink's [groupBy()]({{< ref "docs/dev/dataset/transformations" >}}#groupreduce-on-grouped-dataset) operation. It does not consider any custom partitioners, sort or grouping comparators you might have set in the `JobConf`.
 
 ## Complete Hadoop WordCount Example
 

--- a/docs/content/docs/dev/dataset/iterations.md
+++ b/docs/content/docs/dev/dataset/iterations.md
@@ -30,7 +30,7 @@ Iterative algorithms occur in many domains of data analysis, such as *machine le
 
 Flink programs implement iterative algorithms by defining a **step function** and embedding it into a special iteration operator. There are two  variants of this operator: **Iterate** and **Delta Iterate**. Both operators repeatedly invoke the step function on the current iteration state until a certain termination condition is reached.
 
-Here, we provide background on both operator variants and outline their usage. The [programming guide](index.html) explains how to implement the operators in both Scala and Java. We also support both **vertex-centric and gather-sum-apply iterations** through Flink's graph processing API, [Gelly]({{< ref "docs/libs/gelly/overview" >}}).
+Here, we provide background on both operator variants and outline their usage. The [programming guide]({{< ref "docs/dev/dataset/overview" >}}) explains how to implement the operators in both Scala and Java. We also support both **vertex-centric and gather-sum-apply iterations** through Flink's graph processing API, [Gelly]({{< ref "docs/libs/gelly/overview" >}}).
 
 The following table provides an overview of both operators:
 

--- a/docs/content/docs/dev/dataset/transformations.md
+++ b/docs/content/docs/dev/dataset/transformations.md
@@ -28,9 +28,9 @@ under the License.
 # DataSet Transformations
 
 This document gives a deep-dive into the available transformations on DataSets. For a general introduction to the
-Flink Java API, please refer to the [Programming Guide](index.html).
+Flink Java API, please refer to the [Programming Guide]({{< ref "docs/dev/dataset/overview" >}}).
 
-For zipping elements in a data set with a dense index, please refer to the [Zip Elements Guide](zip_elements_guide.html).
+For zipping elements in a data set with a dense index, please refer to the [Zip Elements Guide]({{< ref "docs/dev/dataset/zip_elements_guide" >}}).
 
 ### Map
 

--- a/docs/content/docs/dev/table/config.md
+++ b/docs/content/docs/dev/table/config.md
@@ -33,8 +33,6 @@ Depending on the requirements of a table program, it might be necessary to adjus
 certain parameters for optimization. For example, unbounded streaming programs may need to ensure
 that the required state size is capped (see [streaming concepts]({{< ref "docs/dev/table/concepts/overview" >}})).
 
-
-
 ### Overview
 
 In every table environment, the `TableConfig` offers options for configuring the current session.

--- a/docs/content/docs/libs/gelly/graph_generators.md
+++ b/docs/content/docs/libs/gelly/graph_generators.md
@@ -168,7 +168,7 @@ val graph = new CycleGraph(env.getJavaEnv, vertexCount).generate()
 
 ## Echo Graph
 
-An [echo graph](http://mathworld.wolfram.com/EchoGraph.html) is a
+An echo graph is a
 [circulant graph](#circulant-graph) with `n` vertices defined by the width of a
 single range of offsets centered at `n/2`. A vertex is connected to 'far'
 vertices, which connect to 'near' vertices, which connect to 'far' vertices, ....

--- a/docs/content/docs/libs/gelly/iterative_graph_processing.md
+++ b/docs/content/docs/libs/gelly/iterative_graph_processing.md
@@ -756,7 +756,7 @@ final class UpdateDistance extends ApplyFunction[Long, Double, Double] {
 
 Note that `gather` takes a `Neighbor` type as an argument. This is a convenience type which simply wraps a vertex with its neighboring edge.
 
-For more examples of how to implement algorithms with the Gather-Sum-Apply model, check the {{< gh_link file="/flink-libraries/flink-gelly/src/main/java/org/apache/flink/graph/library/GSAPageRank.java" name="GSAPageRank" >}} and {{< gh_link file="/flink-libraries/flink-gelly/src/main/java/org/apache/flink/graph/library/GSAConnectedComponents.java" name="GSAConnectedComponents" >}} library methods of Gelly.
+For more examples of how to implement algorithms with the Gather-Sum-Apply model, check the {{< gh_link file="/flink-libraries/flink-gelly-examples/src/main/java/org/apache/flink/graph/examples/GSAPageRank.java" name="GSAPageRank" >}} and {{< gh_link file="/flink-libraries/flink-gelly/src/main/java/org/apache/flink/graph/library/GSAConnectedComponents.java" name="GSAConnectedComponents" >}} library methods of Gelly.
 
 {{< top >}}
 

--- a/docs/content/release-notes/flink-1.10.md
+++ b/docs/content/release-notes/flink-1.10.md
@@ -180,7 +180,7 @@ If you try to reuse your previous Flink configuration without any adjustments,
 the new memory model can result in differently computed memory parameters for
 the JVM and, thus, performance changes.
 
-Please, check [the user documentation](../deployment/memory/mem_setup.html) for more details.
+Please, check [the user documentation](https://nightlies.apache.org/flink/flink-docs-release-1.10/ops/memory/mem_setup.html) for more details.
 
 ##### Deprecation and breaking changes
 The following options have been removed and have no effect anymore:

--- a/docs/layouts/shortcodes/query_state_warning.html
+++ b/docs/layouts/shortcodes/query_state_warning.html
@@ -16,5 +16,7 @@ KIND, either express or implied.  See the License for the
 specific language governing permissions and limitations
 under the License.
 */}}
-For streaming queries the required state to compute the query result might grow infinitely depending on the type of aggregation and the number of distinct grouping keys. Please provide a query configuration with valid retention interval to prevent excessive state size.
-See <a href="/docs/dev/table/streaming/query_configuration">Query Configuration</a> for details.
+For streaming queries the required state to compute the query result might grow infinitely depending
+on the type of aggregation and the number of distinct grouping keys. Please provide an idle state
+retention time to prevent excessive state size.
+See <a href="{{.Site.BaseURL}}{{.Site.LanguagePrefix}}/docs/dev/table/concepts/overview/#idle-state-retention-time">Idle State Retention Time</a> for details.

--- a/docs/layouts/shortcodes/sql_optional_connectors.html
+++ b/docs/layouts/shortcodes/sql_optional_connectors.html
@@ -35,9 +35,13 @@ under the License.
                 <td style="text-align: left">{{- .name -}}</td>
                 <td></td>
                 <td style="text-align: left">
-                    <a href="{{- partial "docs/interpolate" .sql_url -}}">Download</a> 
-                    (<a href="{{- partial "docs/interpolate" .sql_url -}}.asc">asc</a>, 
-                    <a href="{{- partial "docs/interpolate" .sql_url -}}.sha1">sha1</a>) </td>
+                    {{ if $.Site.Params.IsStable }}
+                        <a href="{{- partial "docs/interpolate" .sql_url -}}">Download</a>
+                        (<a href="{{- partial "docs/interpolate" .sql_url -}}.asc">asc</a>,
+                        <a href="{{- partial "docs/interpolate" .sql_url -}}.sha1">sha1</a>) </td>
+                    {{ else }}
+                        Only available for stable versions.</td>
+                    {{ end }}
             </tr>
             {{ else }}
                 {{ $name := .name }}
@@ -46,9 +50,13 @@ under the License.
                         <td style="text-align: left">{{- $name -}}</td>
                         <td>{{- .version -}}</td>
                         <td style="text-align: left">
-                            <a href="{{- partial "docs/interpolate" .sql_url -}}">Download</a> 
-                            (<a href="{{- partial "docs/interpolate" .sql_url -}}.asc">asc</a>, 
-                            <a href="{{- partial "docs/interpolate" .sql_url -}}.sha1">sha1</a>) </td>
+                            {{ if $.Site.Params.IsStable }}
+                                <a href="{{- partial "docs/interpolate" .sql_url -}}">Download</a>
+                                (<a href="{{- partial "docs/interpolate" .sql_url -}}.asc">asc</a>,
+                                <a href="{{- partial "docs/interpolate" .sql_url -}}.sha1">sha1</a>) </td>
+                            {{ else }}
+                                Only available for stable versions.</td>
+                            {{ end }}
                     </tr>
                 {{ end }}
             {{ end }}

--- a/docs/layouts/shortcodes/sql_optional_formats.html
+++ b/docs/layouts/shortcodes/sql_optional_formats.html
@@ -32,9 +32,13 @@ under the License.
             <tr>
                 <td style="text-align: left">{{- .name -}}</td>
                 <td style="text-align: left">
-                    <a href="{{- partial "docs/interpolate" .sql_url -}}">Download</a> 
-                    (<a href="{{- partial "docs/interpolate" .sql_url -}}.asc">asc</a>, 
-                    <a href="{{- partial "docs/interpolate" .sql_url -}}.sha1">sha1</a>) </td>
+                    {{ if $.Site.Params.IsStable }}
+                        <a href="{{- partial "docs/interpolate" .sql_url -}}">Download</a>
+                        (<a href="{{- partial "docs/interpolate" .sql_url -}}.asc">asc</a>,
+                        <a href="{{- partial "docs/interpolate" .sql_url -}}.sha1">sha1</a>) </td>
+                    {{ else }}
+                        Only available for stable versions.</td>
+                    {{ end }}
             </tr>
             {{ end }}{{ end }}
         {{ end }}


### PR DESCRIPTION
## What is the purpose of the change

* This PR addresses multiple broken links (404s) existing throughout the English and Chinese documentation. 

## Brief change log

* Fixed outdated links to new links
* Re-introduced `Idle State Retention Time` in Table/SQL configuration to fix numerous links to this doc

## Verifying this change

This change is a trivial rework / code cleanup without any test coverage.

## Does this pull request potentially affect one of the following parts:

  - Dependencies (does it add or upgrade a dependency): no
  - The public API, i.e., is any changed class annotated with `@Public(Evolving)`: no
  - The serializers: no
  - The runtime per-record code paths (performance sensitive): no
  - Anything that affects deployment or recovery: JobManager (and its components), Checkpointing, Kubernetes/Yarn, ZooKeeper: no
  - The S3 file system connector: no

## Documentation

  - Does this pull request introduce a new feature? no
  - If yes, how is the feature documented? not applicable 
