### PR TITLE
[FLINK-25531][connectors/kafka] Force immediate shutdown of FlinkInternalKafkaProducer to speed up testRetryComittableOnRetriableError

### DIFF
--- a/flink-connectors/flink-connector-kafka/src/test/java/org/apache/flink/connector/kafka/sink/KafkaCommitterTest.java
+++ b/flink-connectors/flink-connector-kafka/src/test/java/org/apache/flink/connector/kafka/sink/KafkaCommitterTest.java
@@ -27,6 +27,7 @@ import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
 
 import java.io.IOException;
+import java.time.Duration;
 import java.util.Collections;
 import java.util.List;
 import java.util.Properties;
@@ -62,6 +63,8 @@ public class KafkaCommitterTest {
             List<KafkaCommittable> recovered = committer.commit(committables);
             assertThat(recovered, contains(committables.toArray()));
             assertThat(recyclable.isRecycled(), equalTo(false));
+            // FLINK-25531: force the producer to close immediately, else it would take 1 hour
+            producer.close(Duration.ZERO);
         }
     }
 


### PR DESCRIPTION
## What is the purpose of the change

testRetryComittableORetriableError is taking over an hour on CI runs. We want to speed up the test.
The issue is that `FlinkInternalKafkaProducer` has a closing timeout of 1 hour if it was not in a transaction. This PR forces the producer to shutdown immediately to prevent idleness.

## Brief change log

- force immediate closing of the producer

## Verifying this change

This change added tests and can be verified as follows:
 * CI run for test_ci_build kafka_gelly should be significantly faster. Compare with previous runs (> 1hr)

## Does this pull request potentially affect one of the following parts:

  - Dependencies (does it add or upgrade a dependency): (no)
  - The public API, i.e., is any changed class annotated with `@Public(Evolving)`: (no)
  - The serializers: (no)
  - The runtime per-record code paths (performance sensitive): (no)
  - Anything that affects deployment or recovery: JobManager (and its components), Checkpointing, Kubernetes/Yarn, ZooKeeper: (no)
  - The S3 file system connector: (no)

## Documentation

  - Does this pull request introduce a new feature? (no)
  - If yes, how is the feature documented? (JavaDocs)
