### PR TITLE
[FLINK-25601][state backends][config] Update the 'state.backend' option

### DIFF
--- a/flink-dist/src/main/resources/flink-conf.yaml
+++ b/flink-dist/src/main/resources/flink-conf.yaml
@@ -120,10 +120,10 @@ parallelism.default: 1
 # execution.checkpointing.tolerable-failed-checkpoints: 0
 # execution.checkpointing.unaligned: false
 #
-# Supported backends are 'jobmanager', 'filesystem', 'rocksdb', or the
+# Supported backends are 'hashmap', 'rocksdb', or the
 # <class-name-of-factory>.
 #
-# state.backend: filesystem
+# state.backend: hashmap
 
 # Directory for checkpoints filesystem, when using any of the default bundled
 # state backends.


### PR DESCRIPTION
## What is the purpose of the change

The value and comments of 'state.backend' in flink-conf.yaml is deprecated.

## Brief change log

  - *Change the 'state.backend' option to new value*

## Verifying this change

This change is a trivial rework / code cleanup without any test coverage.

## Does this pull request potentially affect one of the following parts:

  - Dependencies (does it add or upgrade a dependency): (no)
  - The public API, i.e., is any changed class annotated with `@Public(Evolving)`: (no)
  - The serializers: (no)
  - The runtime per-record code paths (performance sensitive): (no)
  - Anything that affects deployment or recovery: JobManager (and its components), Checkpointing, Kubernetes/Yarn, ZooKeeper: (no)
  - The S3 file system connector: (no)

## Documentation

  - Does this pull request introduce a new feature? (no)
  - If yes, how is the feature documented? (no)
