### PR TITLE
[FLINK-25209][tests] Wait until the consuming topic is ready before polling records in KafkaContainerClient#readMessages

### DIFF
--- a/flink-end-to-end-tests/flink-end-to-end-tests-common-kafka/src/main/java/org/apache/flink/tests/util/kafka/KafkaContainerClient.java
+++ b/flink-end-to-end-tests/flink-end-to-end-tests-common-kafka/src/main/java/org/apache/flink/tests/util/kafka/KafkaContainerClient.java
@@ -19,6 +19,7 @@
 package org.apache.flink.tests.util.kafka;
 
 import org.apache.flink.api.common.time.Deadline;
+import org.apache.flink.core.testutils.CommonTestUtils;
 
 import org.apache.kafka.clients.CommonClientConfigs;
 import org.apache.kafka.clients.admin.AdminClient;
@@ -32,6 +33,8 @@ import org.apache.kafka.clients.producer.KafkaProducer;
 import org.apache.kafka.clients.producer.Producer;
 import org.apache.kafka.clients.producer.ProducerConfig;
 import org.apache.kafka.clients.producer.ProducerRecord;
+import org.apache.kafka.common.PartitionInfo;
+import org.apache.kafka.common.TopicPartition;
 import org.apache.kafka.common.serialization.BytesDeserializer;
 import org.apache.kafka.common.serialization.BytesSerializer;
 import org.apache.kafka.common.serialization.Deserializer;
@@ -49,7 +52,6 @@ import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
 import java.util.Properties;
-import java.util.regex.Pattern;
 
 /** A utility class that exposes common methods over a {@link KafkaContainer}. */
 public class KafkaContainerClient {
@@ -89,7 +91,7 @@ public class KafkaContainerClient {
             String groupId,
             String topic,
             Deserializer<T> valueDeserializer)
-            throws IOException {
+            throws Exception {
         Properties props = new Properties();
         props.put(ConsumerConfig.BOOTSTRAP_SERVERS_CONFIG, container.getBootstrapServers());
         props.put(ConsumerConfig.GROUP_ID_CONFIG, groupId);
@@ -99,7 +101,8 @@ public class KafkaContainerClient {
         final List<T> messages = Collections.synchronizedList(new ArrayList<>(expectedNumMessages));
         try (Consumer<Bytes, T> consumer =
                 new KafkaConsumer<>(props, new BytesDeserializer(), valueDeserializer)) {
-            consumer.subscribe(Pattern.compile(topic));
+            waitUntilTopicAvailableThenAssign(topic, consumer, Duration.ofSeconds(60));
+            // Keep polling until getting expected number of messages
             final Deadline deadline = Deadline.fromNow(Duration.ofSeconds(120));
             while (deadline.hasTimeLeft() && messages.size() < expectedNumMessages) {
                 LOG.info(
@@ -116,5 +119,21 @@ public class KafkaContainerClient {
             }
             return messages;
         }
+    }
+
+    private void waitUntilTopicAvailableThenAssign(
+            String topic, Consumer<?, ?> consumer, Duration timeout) throws Exception {
+        // Wait until reading topic is available
+        CommonTestUtils.waitUtil(
+                () -> consumer.listTopics(Duration.ofSeconds(1)).containsKey(topic),
+                timeout,
+                String.format("Cannot get information for topic \"%s\" within timeout", topic));
+        // Assign all partitions of the reading topic
+        List<PartitionInfo> partitions = consumer.listTopics().get(topic);
+        List<TopicPartition> tps = new ArrayList<>();
+        partitions.forEach(partition -> tps.add(new TopicPartition(topic, partition.partition())));
+        consumer.assign(tps);
+        // Seek offsets to beginning in order to consume all records in topic
+        consumer.seekToBeginning(tps);
     }
 }

--- a/flink-end-to-end-tests/flink-end-to-end-tests-common-kafka/src/test/java/org/apache/flink/tests/util/kafka/SQLClientSchemaRegistryITCase.java
+++ b/flink-end-to-end-tests/flink-end-to-end-tests-common-kafka/src/test/java/org/apache/flink/tests/util/kafka/SQLClientSchemaRegistryITCase.java
@@ -37,7 +37,6 @@ import org.apache.kafka.common.serialization.StringDeserializer;
 import org.junit.After;
 import org.junit.Before;
 import org.junit.ClassRule;
-import org.junit.Ignore;
 import org.junit.Test;
 import org.junit.rules.Timeout;
 import org.slf4j.Logger;
@@ -59,7 +58,6 @@ import static org.hamcrest.CoreMatchers.equalTo;
 import static org.junit.Assert.assertThat;
 
 /** End-to-end test for SQL client using Avro Confluent Registry format. */
-@Ignore("FLINK-25209")
 public class SQLClientSchemaRegistryITCase {
     private static final Logger LOG = LoggerFactory.getLogger(SQLClientSchemaRegistryITCase.class);
     private static final Slf4jLogConsumer LOG_CONSUMER = new Slf4jLogConsumer(LOG);


### PR DESCRIPTION
## What is the purpose of the change

This pull request fixes the broken `SQLClientSchemaRegistryITCase` which possibly read records from a topic that is not set up on broker.


## Brief change log

- Wait until the consuming topic is ready before polling records in KafkaContainerClient#readMessages


## Verifying this change

This change is already covered by existing `SQLClientSchemaRegistryITCase`.

## Does this pull request potentially affect one of the following parts:

  - Dependencies (does it add or upgrade a dependency): (yes / **no**)
  - The public API, i.e., is any changed class annotated with `@Public(Evolving)`: (yes / **no**)
  - The serializers: (yes / **no** / don't know)
  - The runtime per-record code paths (performance sensitive): (yes / **no** / don't know)
  - Anything that affects deployment or recovery: JobManager (and its components), Checkpointing, Kubernetes/Yarn, ZooKeeper: (yes / **no** / don't know)
  - The S3 file system connector: (yes / **no** / don't know)

## Documentation

  - Does this pull request introduce a new feature? (yes / **no**)
  - If yes, how is the feature documented? (**not applicable** / docs / JavaDocs / not documented)
