### PR TITLE
[BP-1.14][FLINK-25280][connector/kafka] Disable log deletion in KafkaTestEnvironmentImpl to prevent records from being deleted during test run

### DIFF
--- a/flink-connectors/flink-connector-kafka/src/test/java/org/apache/flink/streaming/connectors/kafka/KafkaTestEnvironmentImpl.java
+++ b/flink-connectors/flink-connector-kafka/src/test/java/org/apache/flink/streaming/connectors/kafka/KafkaTestEnvironmentImpl.java
@@ -419,6 +419,8 @@ public class KafkaTestEnvironmentImpl extends KafkaTestEnvironment {
         kafkaProperties.put("replica.fetch.max.bytes", String.valueOf(50 * 1024 * 1024));
         kafkaProperties.put(
                 "transaction.max.timeout.ms", Integer.toString(1000 * 60 * 60 * 2)); // 2hours
+        // Disable log deletion to prevent records from being deleted during test run
+        kafkaProperties.put("log.retention.ms", "-1");
 
         // for CI stability, increase zookeeper session timeout
         kafkaProperties.put("zookeeper.session.timeout.ms", zkTimeout);


### PR DESCRIPTION
Unchanged backport of #18311 on release-1.14