### PR TITLE
[FLINK-25351] Introduce `FlinkVersion` as a global enum

### DIFF
--- a/flink-annotations/src/main/java/org/apache/flink/FlinkVersion.java
+++ b/flink-annotations/src/main/java/org/apache/flink/FlinkVersion.java
@@ -16,25 +16,26 @@
  * limitations under the License.
  */
 
-package org.apache.flink.testutils.migration;
+package org.apache.flink;
 
 import java.util.Arrays;
-import java.util.List;
+import java.util.LinkedHashSet;
 import java.util.Map;
 import java.util.Optional;
+import java.util.Set;
 import java.util.function.Function;
 import java.util.stream.Collectors;
 import java.util.stream.Stream;
 
 /**
- * Enumeration for Flink versions, used in migration integration tests to indicate the migrated
- * snapshot version.
+ * Enumeration for Flink versions, used for enabling APIs versioning and SQL/TableAPI upgrades, but
+ * also used in migration integration tests to indicate the migrated snapshot version.
  */
-public enum MigrationVersion {
+public enum FlinkVersion {
 
     // NOTE: the version strings must not change,
     // as they are used to locate snapshot file paths.
-    // The definition order matters for performing version arithmetic.
+    // The definition order (enum ordinal) matters for performing version arithmetic.
     v1_3("1.3"),
     v1_4("1.4"),
     v1_5("1.5"),
@@ -50,7 +51,7 @@ public enum MigrationVersion {
 
     private final String versionStr;
 
-    MigrationVersion(String versionStr) {
+    FlinkVersion(String versionStr) {
         this.versionStr = versionStr;
     }
 
@@ -59,22 +60,22 @@ public enum MigrationVersion {
         return versionStr;
     }
 
-    public boolean isNewerVersionThan(MigrationVersion otherVersion) {
+    public boolean isNewerVersionThan(FlinkVersion otherVersion) {
         return this.ordinal() > otherVersion.ordinal();
     }
 
     /** Returns all versions equal to or higher than the selected version. */
-    public List<MigrationVersion> orHigher() {
-        return Stream.of(MigrationVersion.values())
+    public Set<FlinkVersion> orHigher() {
+        return Stream.of(FlinkVersion.values())
                 .filter(v -> this.ordinal() <= v.ordinal())
-                .collect(Collectors.toList());
+                .collect(Collectors.toCollection(LinkedHashSet::new));
     }
 
-    private static final Map<String, MigrationVersion> CODE_MAP =
+    private static final Map<String, FlinkVersion> CODE_MAP =
             Arrays.stream(values())
                     .collect(Collectors.toMap(v -> v.versionStr, Function.identity()));
 
-    public static Optional<MigrationVersion> byCode(String code) {
+    public static Optional<FlinkVersion> byCode(String code) {
         return Optional.ofNullable(CODE_MAP.get(code));
     }
 }

--- a/flink-connectors/flink-connector-jdbc/src/test/java/org/apache/flink/connector/jdbc/xa/JdbcXaSinkMigrationTest.java
+++ b/flink-connectors/flink-connector-jdbc/src/test/java/org/apache/flink/connector/jdbc/xa/JdbcXaSinkMigrationTest.java
@@ -17,6 +17,7 @@
 
 package org.apache.flink.connector.jdbc.xa;
 
+import org.apache.flink.FlinkVersion;
 import org.apache.flink.api.common.functions.RuntimeContext;
 import org.apache.flink.configuration.Configuration;
 import org.apache.flink.connector.jdbc.DbMetadata;
@@ -26,7 +27,6 @@ import org.apache.flink.connector.jdbc.JdbcTestFixture.TestEntry;
 import org.apache.flink.runtime.checkpoint.OperatorSubtaskState;
 import org.apache.flink.streaming.api.operators.StreamSink;
 import org.apache.flink.streaming.util.OneInputStreamOperatorTestHarness;
-import org.apache.flink.testutils.migration.MigrationVersion;
 import org.apache.flink.util.Preconditions;
 
 import org.junit.After;
@@ -67,16 +67,15 @@ public class JdbcXaSinkMigrationTest extends JdbcTestBase {
     }
 
     @Parameterized.Parameters
-    public static Collection<MigrationVersion> getReadVersions() {
-        //		return Collections.singleton(MigrationVersion.v1_10);
+    public static Collection<FlinkVersion> getReadVersions() {
         return Collections.emptyList();
     }
 
-    public JdbcXaSinkMigrationTest(MigrationVersion readVersion) {
+    public JdbcXaSinkMigrationTest(FlinkVersion readVersion) {
         this.readVersion = readVersion;
     }
 
-    private final MigrationVersion readVersion;
+    private final FlinkVersion readVersion;
 
     @Test
     public void testCommitFromSnapshot() throws Exception {
@@ -144,7 +143,7 @@ public class JdbcXaSinkMigrationTest extends JdbcTestBase {
         };
     }
 
-    private static String getSnapshotPath(MigrationVersion version) {
+    private static String getSnapshotPath(FlinkVersion version) {
         return String.format(
                 "src/test/resources/jdbc-exactly-once-sink-migration-%s-snapshot", version);
     }
@@ -157,14 +156,14 @@ public class JdbcXaSinkMigrationTest extends JdbcTestBase {
         return harness;
     }
 
-    private static MigrationVersion parseVersionArg(String[] args) {
+    private static FlinkVersion parseVersionArg(String[] args) {
         return (args == null || args.length == 0 ? Optional.<String>empty() : of(args[0]))
-                .flatMap(MigrationVersion::byCode)
+                .flatMap(FlinkVersion::byCode)
                 .orElseThrow(
                         () ->
                                 new IllegalArgumentException(
                                         "Please specify a version as a 1st parameter. Valid values are: "
-                                                + Arrays.toString(MigrationVersion.values())));
+                                                + Arrays.toString(FlinkVersion.values())));
     }
 
     private static JdbcXaSinkFunction<TestEntry> buildSink() {
@@ -187,7 +186,7 @@ public class JdbcXaSinkMigrationTest extends JdbcTestBase {
         }
     }
 
-    private static void writeSnapshot(MigrationVersion v) throws Exception {
+    private static void writeSnapshot(FlinkVersion v) throws Exception {
         String path = getSnapshotPath(v);
         Preconditions.checkArgument(
                 !Files.exists(Paths.get(path)),

--- a/flink-connectors/flink-connector-kafka/src/test/java/org/apache/flink/streaming/connectors/kafka/FlinkKafkaConsumerBaseMigrationTest.java
+++ b/flink-connectors/flink-connector-kafka/src/test/java/org/apache/flink/streaming/connectors/kafka/FlinkKafkaConsumerBaseMigrationTest.java
@@ -18,6 +18,7 @@
 
 package org.apache.flink.streaming.connectors.kafka;
 
+import org.apache.flink.FlinkVersion;
 import org.apache.flink.api.common.eventtime.WatermarkStrategy;
 import org.apache.flink.core.testutils.OneShotLatch;
 import org.apache.flink.metrics.MetricGroup;
@@ -35,7 +36,6 @@ import org.apache.flink.streaming.connectors.kafka.internals.KafkaTopicPartition
 import org.apache.flink.streaming.connectors.kafka.internals.KafkaTopicsDescriptor;
 import org.apache.flink.streaming.util.AbstractStreamOperatorTestHarness;
 import org.apache.flink.streaming.util.OperatorSnapshotUtil;
-import org.apache.flink.testutils.migration.MigrationVersion;
 import org.apache.flink.util.SerializedValue;
 
 import org.junit.Ignore;
@@ -73,11 +73,11 @@ public class FlinkKafkaConsumerBaseMigrationTest {
 
     /**
      * TODO change this to the corresponding savepoint version to be written (e.g. {@link
-     * MigrationVersion#v1_3} for 1.3) TODO and remove all @Ignore annotations on write*Snapshot()
+     * FlinkVersion#v1_3} for 1.3) TODO and remove all @Ignore annotations on write*Snapshot()
      * methods to generate savepoints TODO Note: You should generate the savepoint based on the
      * release branch instead of the master.
      */
-    private final MigrationVersion flinkGenerateSavepointVersion = null;
+    private final FlinkVersion flinkGenerateSavepointVersion = null;
 
     private static final HashMap<KafkaTopicPartition, Long> PARTITION_STATE = new HashMap<>();
 
@@ -90,25 +90,25 @@ public class FlinkKafkaConsumerBaseMigrationTest {
             new ArrayList<>(PARTITION_STATE.keySet())
                     .stream().map(p -> p.getTopic()).distinct().collect(Collectors.toList());
 
-    private final MigrationVersion testMigrateVersion;
+    private final FlinkVersion testMigrateVersion;
 
     @Parameterized.Parameters(name = "Migration Savepoint: {0}")
-    public static Collection<MigrationVersion> parameters() {
+    public static Collection<FlinkVersion> parameters() {
         return Arrays.asList(
-                MigrationVersion.v1_4,
-                MigrationVersion.v1_5,
-                MigrationVersion.v1_6,
-                MigrationVersion.v1_7,
-                MigrationVersion.v1_8,
-                MigrationVersion.v1_9,
-                MigrationVersion.v1_10,
-                MigrationVersion.v1_11,
-                MigrationVersion.v1_12,
-                MigrationVersion.v1_13,
-                MigrationVersion.v1_14);
+                FlinkVersion.v1_4,
+                FlinkVersion.v1_5,
+                FlinkVersion.v1_6,
+                FlinkVersion.v1_7,
+                FlinkVersion.v1_8,
+                FlinkVersion.v1_9,
+                FlinkVersion.v1_10,
+                FlinkVersion.v1_11,
+                FlinkVersion.v1_12,
+                FlinkVersion.v1_13,
+                FlinkVersion.v1_14);
     }
 
-    public FlinkKafkaConsumerBaseMigrationTest(MigrationVersion testMigrateVersion) {
+    public FlinkKafkaConsumerBaseMigrationTest(FlinkVersion testMigrateVersion) {
         this.testMigrateVersion = testMigrateVersion;
     }
 

--- a/flink-connectors/flink-connector-kafka/src/test/java/org/apache/flink/streaming/connectors/kafka/FlinkKafkaProducerMigrationOperatorTest.java
+++ b/flink-connectors/flink-connector-kafka/src/test/java/org/apache/flink/streaming/connectors/kafka/FlinkKafkaProducerMigrationOperatorTest.java
@@ -18,7 +18,7 @@
 
 package org.apache.flink.streaming.connectors.kafka;
 
-import org.apache.flink.testutils.migration.MigrationVersion;
+import org.apache.flink.FlinkVersion;
 
 import org.junit.Ignore;
 import org.junit.runners.Parameterized;
@@ -31,25 +31,22 @@ import java.util.Collection;
  * by {@link FlinkKafkaProducer011MigrationTest#writeSnapshot()}.
  *
  * <p>Warning: We need to rename the generated resource based on the file naming pattern specified
- * by the {@link #getOperatorSnapshotPath(MigrationVersion)} method then copy the resource to the
- * path also specified by the {@link #getOperatorSnapshotPath(MigrationVersion)} method.
+ * by the {@link #getOperatorSnapshotPath(FlinkVersion)} method then copy the resource to the path
+ * also specified by the {@link #getOperatorSnapshotPath(FlinkVersion)} method.
  */
 public class FlinkKafkaProducerMigrationOperatorTest extends FlinkKafkaProducerMigrationTest {
     @Parameterized.Parameters(name = "Migration Savepoint: {0}")
-    public static Collection<MigrationVersion> parameters() {
+    public static Collection<FlinkVersion> parameters() {
         return Arrays.asList(
-                MigrationVersion.v1_8,
-                MigrationVersion.v1_9,
-                MigrationVersion.v1_10,
-                MigrationVersion.v1_11);
+                FlinkVersion.v1_8, FlinkVersion.v1_9, FlinkVersion.v1_10, FlinkVersion.v1_11);
     }
 
-    public FlinkKafkaProducerMigrationOperatorTest(MigrationVersion testMigrateVersion) {
+    public FlinkKafkaProducerMigrationOperatorTest(FlinkVersion testMigrateVersion) {
         super(testMigrateVersion);
     }
 
     @Override
-    public String getOperatorSnapshotPath(MigrationVersion version) {
+    public String getOperatorSnapshotPath(FlinkVersion version) {
         return "src/test/resources/kafka-0.11-migration-kafka-producer-flink-"
                 + version
                 + "-snapshot";

--- a/flink-connectors/flink-connector-kafka/src/test/java/org/apache/flink/streaming/connectors/kafka/FlinkKafkaProducerMigrationTest.java
+++ b/flink-connectors/flink-connector-kafka/src/test/java/org/apache/flink/streaming/connectors/kafka/FlinkKafkaProducerMigrationTest.java
@@ -18,11 +18,11 @@
 
 package org.apache.flink.streaming.connectors.kafka;
 
+import org.apache.flink.FlinkVersion;
 import org.apache.flink.api.common.typeutils.base.IntSerializer;
 import org.apache.flink.runtime.jobgraph.OperatorID;
 import org.apache.flink.streaming.api.operators.StreamSink;
 import org.apache.flink.streaming.util.OneInputStreamOperatorTestHarness;
-import org.apache.flink.testutils.migration.MigrationVersion;
 
 import org.apache.kafka.clients.producer.ProducerConfig;
 import org.junit.runner.RunWith;
@@ -42,18 +42,18 @@ import java.util.Properties;
 @RunWith(Parameterized.class)
 public class FlinkKafkaProducerMigrationTest extends KafkaMigrationTestBase {
     @Parameterized.Parameters(name = "Migration Savepoint: {0}")
-    public static Collection<MigrationVersion> parameters() {
+    public static Collection<FlinkVersion> parameters() {
         return Arrays.asList(
-                MigrationVersion.v1_8,
-                MigrationVersion.v1_9,
-                MigrationVersion.v1_10,
-                MigrationVersion.v1_11,
-                MigrationVersion.v1_12,
-                MigrationVersion.v1_13,
-                MigrationVersion.v1_14);
+                FlinkVersion.v1_8,
+                FlinkVersion.v1_9,
+                FlinkVersion.v1_10,
+                FlinkVersion.v1_11,
+                FlinkVersion.v1_12,
+                FlinkVersion.v1_13,
+                FlinkVersion.v1_14);
     }
 
-    public FlinkKafkaProducerMigrationTest(MigrationVersion testMigrateVersion) {
+    public FlinkKafkaProducerMigrationTest(FlinkVersion testMigrateVersion) {
         super(testMigrateVersion);
     }
 

--- a/flink-connectors/flink-connector-kafka/src/test/java/org/apache/flink/streaming/connectors/kafka/KafkaMigrationTestBase.java
+++ b/flink-connectors/flink-connector-kafka/src/test/java/org/apache/flink/streaming/connectors/kafka/KafkaMigrationTestBase.java
@@ -17,6 +17,7 @@
 
 package org.apache.flink.streaming.connectors.kafka;
 
+import org.apache.flink.FlinkVersion;
 import org.apache.flink.api.common.ExecutionConfig;
 import org.apache.flink.api.common.serialization.TypeInformationSerializationSchema;
 import org.apache.flink.api.common.typeinfo.BasicTypeInfo;
@@ -25,7 +26,6 @@ import org.apache.flink.streaming.connectors.kafka.internals.KeyedSerializationS
 import org.apache.flink.streaming.util.OneInputStreamOperatorTestHarness;
 import org.apache.flink.streaming.util.OperatorSnapshotUtil;
 import org.apache.flink.streaming.util.serialization.KeyedSerializationSchema;
-import org.apache.flink.testutils.migration.MigrationVersion;
 
 import org.junit.AfterClass;
 import org.junit.BeforeClass;
@@ -48,7 +48,7 @@ public abstract class KafkaMigrationTestBase extends KafkaTestBase {
     protected static final Logger LOG = LoggerFactory.getLogger(KafkaMigrationTestBase.class);
     protected static final String TOPIC = "flink-kafka-producer-migration-test";
 
-    protected final MigrationVersion testMigrateVersion;
+    protected final FlinkVersion testMigrateVersion;
     protected final TypeInformationSerializationSchema<Integer> integerSerializationSchema =
             new TypeInformationSerializationSchema<>(
                     BasicTypeInfo.INT_TYPE_INFO, new ExecutionConfig());
@@ -57,13 +57,13 @@ public abstract class KafkaMigrationTestBase extends KafkaTestBase {
 
     /**
      * TODO change this to the corresponding savepoint version to be written (e.g. {@link
-     * MigrationVersion#v1_3} for 1.3) TODO and remove all @Ignore annotations on write*Snapshot()
+     * FlinkVersion#v1_3} for 1.3) TODO and remove all @Ignore annotations on write*Snapshot()
      * methods to generate savepoints TODO Note: You should generate the savepoint based on the
      * release branch instead of the master.
      */
-    protected final Optional<MigrationVersion> flinkGenerateSavepointVersion = Optional.empty();
+    protected final Optional<FlinkVersion> flinkGenerateSavepointVersion = Optional.empty();
 
-    public KafkaMigrationTestBase(MigrationVersion testMigrateVersion) {
+    public KafkaMigrationTestBase(FlinkVersion testMigrateVersion) {
         this.testMigrateVersion = checkNotNull(testMigrateVersion);
     }
 
@@ -71,7 +71,7 @@ public abstract class KafkaMigrationTestBase extends KafkaTestBase {
         return getOperatorSnapshotPath(testMigrateVersion);
     }
 
-    public String getOperatorSnapshotPath(MigrationVersion version) {
+    public String getOperatorSnapshotPath(FlinkVersion version) {
         return "src/test/resources/kafka-migration-kafka-producer-flink-" + version + "-snapshot";
     }
 

--- a/flink-connectors/flink-connector-kafka/src/test/java/org/apache/flink/streaming/connectors/kafka/KafkaSerializerUpgradeTest.java
+++ b/flink-connectors/flink-connector-kafka/src/test/java/org/apache/flink/streaming/connectors/kafka/KafkaSerializerUpgradeTest.java
@@ -18,12 +18,12 @@
 
 package org.apache.flink.streaming.connectors.kafka;
 
+import org.apache.flink.FlinkVersion;
 import org.apache.flink.api.common.typeutils.TypeSerializer;
 import org.apache.flink.api.common.typeutils.TypeSerializerMatchers;
 import org.apache.flink.api.common.typeutils.TypeSerializerSchemaCompatibility;
 import org.apache.flink.api.common.typeutils.TypeSerializerUpgradeTestBase;
 import org.apache.flink.streaming.connectors.kafka.internals.FlinkKafkaInternalProducer;
-import org.apache.flink.testutils.migration.MigrationVersion;
 
 import org.hamcrest.Matcher;
 import org.junit.runner.RunWith;
@@ -52,17 +52,17 @@ public class KafkaSerializerUpgradeTest extends TypeSerializerUpgradeTestBase<Ob
     public static Collection<TestSpecification<?, ?>> testSpecifications() throws Exception {
 
         ArrayList<TestSpecification<?, ?>> testSpecifications = new ArrayList<>();
-        for (MigrationVersion migrationVersion : MIGRATION_VERSIONS) {
+        for (FlinkVersion flinkVersion : MIGRATION_VERSIONS) {
             testSpecifications.add(
                     new TestSpecification<>(
                             "transaction-state-serializer",
-                            migrationVersion,
+                            flinkVersion,
                             TransactionStateSerializerSetup.class,
                             TransactionStateSerializerVerifier.class));
             testSpecifications.add(
                     new TestSpecification<>(
                             "context-state-serializer",
-                            migrationVersion,
+                            flinkVersion,
                             ContextStateSerializerSetup.class,
                             ContextStateSerializerVerifier.class));
         }
@@ -117,7 +117,7 @@ public class KafkaSerializerUpgradeTest extends TypeSerializerUpgradeTestBase<Ob
 
         @Override
         public Matcher<TypeSerializerSchemaCompatibility<FlinkKafkaProducer.KafkaTransactionState>>
-                schemaCompatibilityMatcher(MigrationVersion version) {
+                schemaCompatibilityMatcher(FlinkVersion version) {
             return TypeSerializerMatchers.isCompatibleAsIs();
         }
     }
@@ -174,7 +174,7 @@ public class KafkaSerializerUpgradeTest extends TypeSerializerUpgradeTestBase<Ob
         public Matcher<
                         TypeSerializerSchemaCompatibility<
                                 FlinkKafkaProducer.KafkaTransactionContext>>
-                schemaCompatibilityMatcher(MigrationVersion version) {
+                schemaCompatibilityMatcher(FlinkVersion version) {
             return TypeSerializerMatchers.isCompatibleAsIs();
         }
     }

--- a/flink-connectors/flink-connector-kinesis/src/test/java/org/apache/flink/streaming/connectors/kinesis/FlinkKinesisConsumerMigrationTest.java
+++ b/flink-connectors/flink-connector-kinesis/src/test/java/org/apache/flink/streaming/connectors/kinesis/FlinkKinesisConsumerMigrationTest.java
@@ -17,6 +17,7 @@
 
 package org.apache.flink.streaming.connectors.kinesis;
 
+import org.apache.flink.FlinkVersion;
 import org.apache.flink.api.common.functions.RuntimeContext;
 import org.apache.flink.api.common.serialization.SimpleStringSchema;
 import org.apache.flink.core.testutils.OneShotLatch;
@@ -38,7 +39,6 @@ import org.apache.flink.streaming.connectors.kinesis.testutils.TestSourceContext
 import org.apache.flink.streaming.connectors.kinesis.testutils.TestUtils;
 import org.apache.flink.streaming.util.AbstractStreamOperatorTestHarness;
 import org.apache.flink.streaming.util.OperatorSnapshotUtil;
-import org.apache.flink.testutils.migration.MigrationVersion;
 
 import com.amazonaws.services.kinesis.model.SequenceNumberRange;
 import com.amazonaws.services.kinesis.model.Shard;
@@ -74,11 +74,11 @@ public class FlinkKinesisConsumerMigrationTest {
 
     /**
      * TODO change this to the corresponding savepoint version to be written (e.g. {@link
-     * MigrationVersion#v1_3} for 1.3) TODO and remove all @Ignore annotations on the
-     * writeSnapshot() method to generate savepoints TODO Note: You should generate the savepoint
-     * based on the release branch instead of the master.
+     * FlinkVersion#v1_3} for 1.3) TODO and remove all @Ignore annotations on the writeSnapshot()
+     * method to generate savepoints TODO Note: You should generate the savepoint based on the
+     * release branch instead of the master.
      */
-    private final MigrationVersion flinkGenerateSavepointVersion = null;
+    private final FlinkVersion flinkGenerateSavepointVersion = null;
 
     private static final String TEST_STREAM_NAME = "fakeStream1";
     private static final SequenceNumber TEST_SEQUENCE_NUMBER = new SequenceNumber("987654321");
@@ -94,24 +94,24 @@ public class FlinkKinesisConsumerMigrationTest {
         TEST_STATE.put(shardMetadata, TEST_SEQUENCE_NUMBER);
     }
 
-    private final MigrationVersion testMigrateVersion;
+    private final FlinkVersion testMigrateVersion;
 
     @Parameterized.Parameters(name = "Migration Savepoint: {0}")
-    public static Collection<MigrationVersion> parameters() {
+    public static Collection<FlinkVersion> parameters() {
         return Arrays.asList(
-                MigrationVersion.v1_3,
-                MigrationVersion.v1_4,
-                MigrationVersion.v1_7,
-                MigrationVersion.v1_8,
-                MigrationVersion.v1_9,
-                MigrationVersion.v1_10,
-                MigrationVersion.v1_11,
-                MigrationVersion.v1_12,
-                MigrationVersion.v1_13,
-                MigrationVersion.v1_14);
+                FlinkVersion.v1_3,
+                FlinkVersion.v1_4,
+                FlinkVersion.v1_7,
+                FlinkVersion.v1_8,
+                FlinkVersion.v1_9,
+                FlinkVersion.v1_10,
+                FlinkVersion.v1_11,
+                FlinkVersion.v1_12,
+                FlinkVersion.v1_13,
+                FlinkVersion.v1_14);
     }
 
-    public FlinkKinesisConsumerMigrationTest(MigrationVersion testMigrateVersion) {
+    public FlinkKinesisConsumerMigrationTest(FlinkVersion testMigrateVersion) {
         this.testMigrateVersion = testMigrateVersion;
     }
 

--- a/flink-connectors/flink-hadoop-compatibility/src/test/java/org/apache/flink/api/java/typeutils/runtime/WritableSerializerUpgradeTest.java
+++ b/flink-connectors/flink-hadoop-compatibility/src/test/java/org/apache/flink/api/java/typeutils/runtime/WritableSerializerUpgradeTest.java
@@ -18,12 +18,12 @@
 
 package org.apache.flink.api.java.typeutils.runtime;
 
+import org.apache.flink.FlinkVersion;
 import org.apache.flink.api.common.typeutils.TypeSerializer;
 import org.apache.flink.api.common.typeutils.TypeSerializerMatchers;
 import org.apache.flink.api.common.typeutils.TypeSerializerSchemaCompatibility;
 import org.apache.flink.api.common.typeutils.TypeSerializerUpgradeTestBase;
 import org.apache.flink.api.java.typeutils.runtime.WritableSerializerUpgradeTest.WritableName;
-import org.apache.flink.testutils.migration.MigrationVersion;
 
 import org.apache.hadoop.io.Writable;
 import org.hamcrest.Matcher;
@@ -53,11 +53,11 @@ public class WritableSerializerUpgradeTest
     public static Collection<TestSpecification<?, ?>> testSpecifications() throws Exception {
 
         ArrayList<TestSpecification<?, ?>> testSpecifications = new ArrayList<>();
-        for (MigrationVersion migrationVersion : MIGRATION_VERSIONS) {
+        for (FlinkVersion flinkVersion : MIGRATION_VERSIONS) {
             testSpecifications.add(
                     new TestSpecification<>(
                             "writeable-serializer",
-                            migrationVersion,
+                            flinkVersion,
                             WritableSerializerSetup.class,
                             WritableSerializerVerifier.class));
         }
@@ -147,7 +147,7 @@ public class WritableSerializerUpgradeTest
 
         @Override
         public Matcher<TypeSerializerSchemaCompatibility<WritableName>> schemaCompatibilityMatcher(
-                MigrationVersion version) {
+                FlinkVersion version) {
             return TypeSerializerMatchers.isCompatibleAsIs();
         }
     }

--- a/flink-core/src/test/java/org/apache/flink/api/common/typeutils/CompositeTypeSerializerUpgradeTest.java
+++ b/flink-core/src/test/java/org/apache/flink/api/common/typeutils/CompositeTypeSerializerUpgradeTest.java
@@ -18,11 +18,11 @@
 
 package org.apache.flink.api.common.typeutils;
 
+import org.apache.flink.FlinkVersion;
 import org.apache.flink.api.common.typeutils.base.GenericArraySerializer;
 import org.apache.flink.api.common.typeutils.base.IntSerializer;
 import org.apache.flink.api.common.typeutils.base.StringSerializer;
 import org.apache.flink.api.java.typeutils.runtime.EitherSerializer;
-import org.apache.flink.testutils.migration.MigrationVersion;
 import org.apache.flink.types.Either;
 
 import org.hamcrest.Matcher;
@@ -47,17 +47,17 @@ public class CompositeTypeSerializerUpgradeTest
     public static Collection<TestSpecification<?, ?>> testSpecifications() throws Exception {
 
         ArrayList<TestSpecification<?, ?>> testSpecifications = new ArrayList<>();
-        for (MigrationVersion migrationVersion : MIGRATION_VERSIONS) {
+        for (FlinkVersion flinkVersion : MIGRATION_VERSIONS) {
             testSpecifications.add(
                     new TestSpecification<>(
                             "either-serializer",
-                            migrationVersion,
+                            flinkVersion,
                             EitherSerializerSetup.class,
                             EitherSerializerVerifier.class));
             testSpecifications.add(
                     new TestSpecification<>(
                             "generic-array-serializer",
-                            migrationVersion,
+                            flinkVersion,
                             GenericArraySerializerSetup.class,
                             GenericArraySerializerVerifier.class));
         }
@@ -103,7 +103,7 @@ public class CompositeTypeSerializerUpgradeTest
 
         @Override
         public Matcher<TypeSerializerSchemaCompatibility<Either<String, Integer>>>
-                schemaCompatibilityMatcher(MigrationVersion version) {
+                schemaCompatibilityMatcher(FlinkVersion version) {
             return TypeSerializerMatchers.isCompatibleAsIs();
         }
     }
@@ -149,7 +149,7 @@ public class CompositeTypeSerializerUpgradeTest
 
         @Override
         public Matcher<TypeSerializerSchemaCompatibility<String[]>> schemaCompatibilityMatcher(
-                MigrationVersion version) {
+                FlinkVersion version) {
             return TypeSerializerMatchers.isCompatibleAsIs();
         }
     }

--- a/flink-core/src/test/java/org/apache/flink/api/common/typeutils/base/BasicTypeSerializerUpgradeTest.java
+++ b/flink-core/src/test/java/org/apache/flink/api/common/typeutils/base/BasicTypeSerializerUpgradeTest.java
@@ -18,8 +18,8 @@
 
 package org.apache.flink.api.common.typeutils.base;
 
+import org.apache.flink.FlinkVersion;
 import org.apache.flink.api.common.typeutils.TypeSerializerUpgradeTestBase;
-import org.apache.flink.testutils.migration.MigrationVersion;
 
 import org.junit.runner.RunWith;
 import org.junit.runners.Parameterized;
@@ -39,11 +39,11 @@ public class BasicTypeSerializerUpgradeTest extends TypeSerializerUpgradeTestBas
     public static Collection<TestSpecification<?, ?>> testSpecifications() throws Exception {
 
         ArrayList<TestSpecification<?, ?>> testSpecifications = new ArrayList<>();
-        for (MigrationVersion migrationVersion : MIGRATION_VERSIONS) {
+        for (FlinkVersion flinkVersion : MIGRATION_VERSIONS) {
             testSpecifications.add(
                     new TestSpecification<>(
                             "big-dec-serializer",
-                            migrationVersion,
+                            flinkVersion,
                             BasicTypeSerializerUpgradeTestSpecifications.BigDecSerializerSetup
                                     .class,
                             BasicTypeSerializerUpgradeTestSpecifications.BigDecSerializerVerifier
@@ -51,7 +51,7 @@ public class BasicTypeSerializerUpgradeTest extends TypeSerializerUpgradeTestBas
             testSpecifications.add(
                     new TestSpecification<>(
                             "big-int-serializer",
-                            migrationVersion,
+                            flinkVersion,
                             BasicTypeSerializerUpgradeTestSpecifications.BigIntSerializerSetup
                                     .class,
                             BasicTypeSerializerUpgradeTestSpecifications.BigIntSerializerVerifier
@@ -59,7 +59,7 @@ public class BasicTypeSerializerUpgradeTest extends TypeSerializerUpgradeTestBas
             testSpecifications.add(
                     new TestSpecification<>(
                             "boolean-serializer",
-                            migrationVersion,
+                            flinkVersion,
                             BasicTypeSerializerUpgradeTestSpecifications.BooleanSerializerSetup
                                     .class,
                             BasicTypeSerializerUpgradeTestSpecifications.BooleanSerializerVerifier
@@ -67,7 +67,7 @@ public class BasicTypeSerializerUpgradeTest extends TypeSerializerUpgradeTestBas
             testSpecifications.add(
                     new TestSpecification<>(
                             "boolean-value-serializer",
-                            migrationVersion,
+                            flinkVersion,
                             BasicTypeSerializerUpgradeTestSpecifications.BooleanValueSerializerSetup
                                     .class,
                             BasicTypeSerializerUpgradeTestSpecifications
@@ -75,14 +75,14 @@ public class BasicTypeSerializerUpgradeTest extends TypeSerializerUpgradeTestBas
             testSpecifications.add(
                     new TestSpecification<>(
                             "byte-serializer",
-                            migrationVersion,
+                            flinkVersion,
                             BasicTypeSerializerUpgradeTestSpecifications.ByteSerializerSetup.class,
                             BasicTypeSerializerUpgradeTestSpecifications.ByteSerializerVerifier
                                     .class));
             testSpecifications.add(
                     new TestSpecification<>(
                             "byte-value-serializer",
-                            migrationVersion,
+                            flinkVersion,
                             BasicTypeSerializerUpgradeTestSpecifications.ByteValueSerializerSetup
                                     .class,
                             BasicTypeSerializerUpgradeTestSpecifications.ByteValueSerializerVerifier
@@ -90,14 +90,14 @@ public class BasicTypeSerializerUpgradeTest extends TypeSerializerUpgradeTestBas
             testSpecifications.add(
                     new TestSpecification<>(
                             "char-serializer",
-                            migrationVersion,
+                            flinkVersion,
                             BasicTypeSerializerUpgradeTestSpecifications.CharSerializerSetup.class,
                             BasicTypeSerializerUpgradeTestSpecifications.CharSerializerVerifier
                                     .class));
             testSpecifications.add(
                     new TestSpecification<>(
                             "char-value-serializer",
-                            migrationVersion,
+                            flinkVersion,
                             BasicTypeSerializerUpgradeTestSpecifications.CharValueSerializerSetup
                                     .class,
                             BasicTypeSerializerUpgradeTestSpecifications.CharValueSerializerVerifier
@@ -105,14 +105,14 @@ public class BasicTypeSerializerUpgradeTest extends TypeSerializerUpgradeTestBas
             testSpecifications.add(
                     new TestSpecification<>(
                             "date-serializer",
-                            migrationVersion,
+                            flinkVersion,
                             BasicTypeSerializerUpgradeTestSpecifications.DateSerializerSetup.class,
                             BasicTypeSerializerUpgradeTestSpecifications.DateSerializerVerifier
                                     .class));
             testSpecifications.add(
                     new TestSpecification<>(
                             "double-serializer",
-                            migrationVersion,
+                            flinkVersion,
                             BasicTypeSerializerUpgradeTestSpecifications.DoubleSerializerSetup
                                     .class,
                             BasicTypeSerializerUpgradeTestSpecifications.DoubleSerializerVerifier
@@ -120,7 +120,7 @@ public class BasicTypeSerializerUpgradeTest extends TypeSerializerUpgradeTestBas
             testSpecifications.add(
                     new TestSpecification<>(
                             "double-value-serializer",
-                            migrationVersion,
+                            flinkVersion,
                             BasicTypeSerializerUpgradeTestSpecifications.DoubleValueSerializerSetup
                                     .class,
                             BasicTypeSerializerUpgradeTestSpecifications
@@ -128,14 +128,14 @@ public class BasicTypeSerializerUpgradeTest extends TypeSerializerUpgradeTestBas
             testSpecifications.add(
                     new TestSpecification<>(
                             "float-serializer",
-                            migrationVersion,
+                            flinkVersion,
                             BasicTypeSerializerUpgradeTestSpecifications.FloatSerializerSetup.class,
                             BasicTypeSerializerUpgradeTestSpecifications.FloatSerializerVerifier
                                     .class));
             testSpecifications.add(
                     new TestSpecification<>(
                             "float-value-serializer",
-                            migrationVersion,
+                            flinkVersion,
                             BasicTypeSerializerUpgradeTestSpecifications.FloatValueSerializerSetup
                                     .class,
                             BasicTypeSerializerUpgradeTestSpecifications
@@ -143,14 +143,14 @@ public class BasicTypeSerializerUpgradeTest extends TypeSerializerUpgradeTestBas
             testSpecifications.add(
                     new TestSpecification<>(
                             "int-serializer",
-                            migrationVersion,
+                            flinkVersion,
                             BasicTypeSerializerUpgradeTestSpecifications.IntSerializerSetup.class,
                             BasicTypeSerializerUpgradeTestSpecifications.IntSerializerVerifier
                                     .class));
             testSpecifications.add(
                     new TestSpecification<>(
                             "int-value-serializer",
-                            migrationVersion,
+                            flinkVersion,
                             BasicTypeSerializerUpgradeTestSpecifications.IntValueSerializerSetup
                                     .class,
                             BasicTypeSerializerUpgradeTestSpecifications.IntValueSerializerVerifier
@@ -158,14 +158,14 @@ public class BasicTypeSerializerUpgradeTest extends TypeSerializerUpgradeTestBas
             testSpecifications.add(
                     new TestSpecification<>(
                             "long-serializer",
-                            migrationVersion,
+                            flinkVersion,
                             BasicTypeSerializerUpgradeTestSpecifications.LongSerializerSetup.class,
                             BasicTypeSerializerUpgradeTestSpecifications.LongSerializerVerifier
                                     .class));
             testSpecifications.add(
                     new TestSpecification<>(
                             "long-value-serializer",
-                            migrationVersion,
+                            flinkVersion,
                             BasicTypeSerializerUpgradeTestSpecifications.LongValueSerializerSetup
                                     .class,
                             BasicTypeSerializerUpgradeTestSpecifications.LongValueSerializerVerifier
@@ -173,7 +173,7 @@ public class BasicTypeSerializerUpgradeTest extends TypeSerializerUpgradeTestBas
             testSpecifications.add(
                     new TestSpecification<>(
                             "null-value-serializer",
-                            migrationVersion,
+                            flinkVersion,
                             BasicTypeSerializerUpgradeTestSpecifications.NullValueSerializerSetup
                                     .class,
                             BasicTypeSerializerUpgradeTestSpecifications.NullValueSerializerVerifier
@@ -181,14 +181,14 @@ public class BasicTypeSerializerUpgradeTest extends TypeSerializerUpgradeTestBas
             testSpecifications.add(
                     new TestSpecification<>(
                             "short-serializer",
-                            migrationVersion,
+                            flinkVersion,
                             BasicTypeSerializerUpgradeTestSpecifications.ShortSerializerSetup.class,
                             BasicTypeSerializerUpgradeTestSpecifications.ShortSerializerVerifier
                                     .class));
             testSpecifications.add(
                     new TestSpecification<>(
                             "short-value-serializer",
-                            migrationVersion,
+                            flinkVersion,
                             BasicTypeSerializerUpgradeTestSpecifications.ShortValueSerializerSetup
                                     .class,
                             BasicTypeSerializerUpgradeTestSpecifications
@@ -196,7 +196,7 @@ public class BasicTypeSerializerUpgradeTest extends TypeSerializerUpgradeTestBas
             testSpecifications.add(
                     new TestSpecification<>(
                             "sql-date-serializer",
-                            migrationVersion,
+                            flinkVersion,
                             BasicTypeSerializerUpgradeTestSpecifications.SqlDateSerializerSetup
                                     .class,
                             BasicTypeSerializerUpgradeTestSpecifications.SqlDateSerializerVerifier
@@ -204,7 +204,7 @@ public class BasicTypeSerializerUpgradeTest extends TypeSerializerUpgradeTestBas
             testSpecifications.add(
                     new TestSpecification<>(
                             "sql-time-serializer",
-                            migrationVersion,
+                            flinkVersion,
                             BasicTypeSerializerUpgradeTestSpecifications.SqlTimeSerializerSetup
                                     .class,
                             BasicTypeSerializerUpgradeTestSpecifications.SqlTimeSerializerVerifier
@@ -212,7 +212,7 @@ public class BasicTypeSerializerUpgradeTest extends TypeSerializerUpgradeTestBas
             testSpecifications.add(
                     new TestSpecification<>(
                             "sql-timestamp-serializer",
-                            migrationVersion,
+                            flinkVersion,
                             BasicTypeSerializerUpgradeTestSpecifications.SqlTimestampSerializerSetup
                                     .class,
                             BasicTypeSerializerUpgradeTestSpecifications
@@ -220,7 +220,7 @@ public class BasicTypeSerializerUpgradeTest extends TypeSerializerUpgradeTestBas
             testSpecifications.add(
                     new TestSpecification<>(
                             "string-serializer",
-                            migrationVersion,
+                            flinkVersion,
                             BasicTypeSerializerUpgradeTestSpecifications.StringSerializerSetup
                                     .class,
                             BasicTypeSerializerUpgradeTestSpecifications.StringSerializerVerifier
@@ -228,7 +228,7 @@ public class BasicTypeSerializerUpgradeTest extends TypeSerializerUpgradeTestBas
             testSpecifications.add(
                     new TestSpecification<>(
                             "string-value-serializer",
-                            migrationVersion,
+                            flinkVersion,
                             BasicTypeSerializerUpgradeTestSpecifications.StringValueSerializerSetup
                                     .class,
                             BasicTypeSerializerUpgradeTestSpecifications

--- a/flink-core/src/test/java/org/apache/flink/api/common/typeutils/base/BasicTypeSerializerUpgradeTestSpecifications.java
+++ b/flink-core/src/test/java/org/apache/flink/api/common/typeutils/base/BasicTypeSerializerUpgradeTestSpecifications.java
@@ -18,11 +18,11 @@
 
 package org.apache.flink.api.common.typeutils.base;
 
+import org.apache.flink.FlinkVersion;
 import org.apache.flink.api.common.typeutils.TypeSerializer;
 import org.apache.flink.api.common.typeutils.TypeSerializerMatchers;
 import org.apache.flink.api.common.typeutils.TypeSerializerSchemaCompatibility;
 import org.apache.flink.api.common.typeutils.TypeSerializerUpgradeTestBase;
-import org.apache.flink.testutils.migration.MigrationVersion;
 import org.apache.flink.types.BooleanValue;
 import org.apache.flink.types.ByteValue;
 import org.apache.flink.types.CharValue;
@@ -77,7 +77,7 @@ public class BasicTypeSerializerUpgradeTestSpecifications {
 
         @Override
         public Matcher<TypeSerializerSchemaCompatibility<BigDecimal>> schemaCompatibilityMatcher(
-                MigrationVersion version) {
+                FlinkVersion version) {
             return TypeSerializerMatchers.isCompatibleAsIs();
         }
     }
@@ -114,7 +114,7 @@ public class BasicTypeSerializerUpgradeTestSpecifications {
 
         @Override
         public Matcher<TypeSerializerSchemaCompatibility<BigInteger>> schemaCompatibilityMatcher(
-                MigrationVersion version) {
+                FlinkVersion version) {
             return TypeSerializerMatchers.isCompatibleAsIs();
         }
     }
@@ -151,7 +151,7 @@ public class BasicTypeSerializerUpgradeTestSpecifications {
 
         @Override
         public Matcher<TypeSerializerSchemaCompatibility<Boolean>> schemaCompatibilityMatcher(
-                MigrationVersion version) {
+                FlinkVersion version) {
             return TypeSerializerMatchers.isCompatibleAsIs();
         }
     }
@@ -188,7 +188,7 @@ public class BasicTypeSerializerUpgradeTestSpecifications {
 
         @Override
         public Matcher<TypeSerializerSchemaCompatibility<BooleanValue>> schemaCompatibilityMatcher(
-                MigrationVersion version) {
+                FlinkVersion version) {
             return TypeSerializerMatchers.isCompatibleAsIs();
         }
     }
@@ -225,7 +225,7 @@ public class BasicTypeSerializerUpgradeTestSpecifications {
 
         @Override
         public Matcher<TypeSerializerSchemaCompatibility<Byte>> schemaCompatibilityMatcher(
-                MigrationVersion version) {
+                FlinkVersion version) {
             return TypeSerializerMatchers.isCompatibleAsIs();
         }
     }
@@ -262,7 +262,7 @@ public class BasicTypeSerializerUpgradeTestSpecifications {
 
         @Override
         public Matcher<TypeSerializerSchemaCompatibility<ByteValue>> schemaCompatibilityMatcher(
-                MigrationVersion version) {
+                FlinkVersion version) {
             return TypeSerializerMatchers.isCompatibleAsIs();
         }
     }
@@ -299,7 +299,7 @@ public class BasicTypeSerializerUpgradeTestSpecifications {
 
         @Override
         public Matcher<TypeSerializerSchemaCompatibility<Character>> schemaCompatibilityMatcher(
-                MigrationVersion version) {
+                FlinkVersion version) {
             return TypeSerializerMatchers.isCompatibleAsIs();
         }
     }
@@ -336,7 +336,7 @@ public class BasicTypeSerializerUpgradeTestSpecifications {
 
         @Override
         public Matcher<TypeSerializerSchemaCompatibility<CharValue>> schemaCompatibilityMatcher(
-                MigrationVersion version) {
+                FlinkVersion version) {
             return TypeSerializerMatchers.isCompatibleAsIs();
         }
     }
@@ -373,7 +373,7 @@ public class BasicTypeSerializerUpgradeTestSpecifications {
 
         @Override
         public Matcher<TypeSerializerSchemaCompatibility<Date>> schemaCompatibilityMatcher(
-                MigrationVersion version) {
+                FlinkVersion version) {
             return TypeSerializerMatchers.isCompatibleAsIs();
         }
     }
@@ -410,7 +410,7 @@ public class BasicTypeSerializerUpgradeTestSpecifications {
 
         @Override
         public Matcher<TypeSerializerSchemaCompatibility<Double>> schemaCompatibilityMatcher(
-                MigrationVersion version) {
+                FlinkVersion version) {
             return TypeSerializerMatchers.isCompatibleAsIs();
         }
     }
@@ -447,7 +447,7 @@ public class BasicTypeSerializerUpgradeTestSpecifications {
 
         @Override
         public Matcher<TypeSerializerSchemaCompatibility<DoubleValue>> schemaCompatibilityMatcher(
-                MigrationVersion version) {
+                FlinkVersion version) {
             return TypeSerializerMatchers.isCompatibleAsIs();
         }
     }
@@ -484,7 +484,7 @@ public class BasicTypeSerializerUpgradeTestSpecifications {
 
         @Override
         public Matcher<TypeSerializerSchemaCompatibility<Float>> schemaCompatibilityMatcher(
-                MigrationVersion version) {
+                FlinkVersion version) {
             return TypeSerializerMatchers.isCompatibleAsIs();
         }
     }
@@ -521,7 +521,7 @@ public class BasicTypeSerializerUpgradeTestSpecifications {
 
         @Override
         public Matcher<TypeSerializerSchemaCompatibility<FloatValue>> schemaCompatibilityMatcher(
-                MigrationVersion version) {
+                FlinkVersion version) {
             return TypeSerializerMatchers.isCompatibleAsIs();
         }
     }
@@ -558,7 +558,7 @@ public class BasicTypeSerializerUpgradeTestSpecifications {
 
         @Override
         public Matcher<TypeSerializerSchemaCompatibility<Integer>> schemaCompatibilityMatcher(
-                MigrationVersion version) {
+                FlinkVersion version) {
             return TypeSerializerMatchers.isCompatibleAsIs();
         }
     }
@@ -595,7 +595,7 @@ public class BasicTypeSerializerUpgradeTestSpecifications {
 
         @Override
         public Matcher<TypeSerializerSchemaCompatibility<IntValue>> schemaCompatibilityMatcher(
-                MigrationVersion version) {
+                FlinkVersion version) {
             return TypeSerializerMatchers.isCompatibleAsIs();
         }
     }
@@ -632,7 +632,7 @@ public class BasicTypeSerializerUpgradeTestSpecifications {
 
         @Override
         public Matcher<TypeSerializerSchemaCompatibility<Long>> schemaCompatibilityMatcher(
-                MigrationVersion version) {
+                FlinkVersion version) {
             return TypeSerializerMatchers.isCompatibleAsIs();
         }
     }
@@ -669,7 +669,7 @@ public class BasicTypeSerializerUpgradeTestSpecifications {
 
         @Override
         public Matcher<TypeSerializerSchemaCompatibility<LongValue>> schemaCompatibilityMatcher(
-                MigrationVersion version) {
+                FlinkVersion version) {
             return TypeSerializerMatchers.isCompatibleAsIs();
         }
     }
@@ -706,7 +706,7 @@ public class BasicTypeSerializerUpgradeTestSpecifications {
 
         @Override
         public Matcher<TypeSerializerSchemaCompatibility<NullValue>> schemaCompatibilityMatcher(
-                MigrationVersion version) {
+                FlinkVersion version) {
             return TypeSerializerMatchers.isCompatibleAsIs();
         }
     }
@@ -743,7 +743,7 @@ public class BasicTypeSerializerUpgradeTestSpecifications {
 
         @Override
         public Matcher<TypeSerializerSchemaCompatibility<Short>> schemaCompatibilityMatcher(
-                MigrationVersion version) {
+                FlinkVersion version) {
             return TypeSerializerMatchers.isCompatibleAsIs();
         }
     }
@@ -780,7 +780,7 @@ public class BasicTypeSerializerUpgradeTestSpecifications {
 
         @Override
         public Matcher<TypeSerializerSchemaCompatibility<ShortValue>> schemaCompatibilityMatcher(
-                MigrationVersion version) {
+                FlinkVersion version) {
             return TypeSerializerMatchers.isCompatibleAsIs();
         }
     }
@@ -817,7 +817,7 @@ public class BasicTypeSerializerUpgradeTestSpecifications {
 
         @Override
         public Matcher<TypeSerializerSchemaCompatibility<java.sql.Date>> schemaCompatibilityMatcher(
-                MigrationVersion version) {
+                FlinkVersion version) {
             return TypeSerializerMatchers.isCompatibleAsIs();
         }
     }
@@ -854,7 +854,7 @@ public class BasicTypeSerializerUpgradeTestSpecifications {
 
         @Override
         public Matcher<TypeSerializerSchemaCompatibility<Time>> schemaCompatibilityMatcher(
-                MigrationVersion version) {
+                FlinkVersion version) {
             return TypeSerializerMatchers.isCompatibleAsIs();
         }
     }
@@ -891,7 +891,7 @@ public class BasicTypeSerializerUpgradeTestSpecifications {
 
         @Override
         public Matcher<TypeSerializerSchemaCompatibility<Timestamp>> schemaCompatibilityMatcher(
-                MigrationVersion version) {
+                FlinkVersion version) {
             return TypeSerializerMatchers.isCompatibleAsIs();
         }
     }
@@ -928,7 +928,7 @@ public class BasicTypeSerializerUpgradeTestSpecifications {
 
         @Override
         public Matcher<TypeSerializerSchemaCompatibility<String>> schemaCompatibilityMatcher(
-                MigrationVersion version) {
+                FlinkVersion version) {
             return TypeSerializerMatchers.isCompatibleAsIs();
         }
     }
@@ -965,7 +965,7 @@ public class BasicTypeSerializerUpgradeTestSpecifications {
 
         @Override
         public Matcher<TypeSerializerSchemaCompatibility<StringValue>> schemaCompatibilityMatcher(
-                MigrationVersion version) {
+                FlinkVersion version) {
             return TypeSerializerMatchers.isCompatibleAsIs();
         }
     }

--- a/flink-core/src/test/java/org/apache/flink/api/common/typeutils/base/EnumSerializerUpgradeTest.java
+++ b/flink-core/src/test/java/org/apache/flink/api/common/typeutils/base/EnumSerializerUpgradeTest.java
@@ -18,12 +18,12 @@
 
 package org.apache.flink.api.common.typeutils.base;
 
+import org.apache.flink.FlinkVersion;
 import org.apache.flink.api.common.typeutils.ClassRelocator;
 import org.apache.flink.api.common.typeutils.TypeSerializer;
 import org.apache.flink.api.common.typeutils.TypeSerializerMatchers;
 import org.apache.flink.api.common.typeutils.TypeSerializerSchemaCompatibility;
 import org.apache.flink.api.common.typeutils.TypeSerializerUpgradeTestBase;
-import org.apache.flink.testutils.migration.MigrationVersion;
 
 import org.hamcrest.Description;
 import org.hamcrest.Matcher;
@@ -51,17 +51,17 @@ public class EnumSerializerUpgradeTest extends TypeSerializerUpgradeTestBase<Tes
     public static Collection<TestSpecification<?, ?>> testSpecifications() throws Exception {
 
         ArrayList<TestSpecification<?, ?>> testSpecifications = new ArrayList<>();
-        for (MigrationVersion migrationVersion : MIGRATION_VERSIONS) {
+        for (FlinkVersion flinkVersion : MIGRATION_VERSIONS) {
             testSpecifications.add(
                     new TestSpecification<>(
                             SPEC_NAME,
-                            migrationVersion,
+                            flinkVersion,
                             EnumSerializerSetup.class,
                             EnumSerializerVerifier.class));
             testSpecifications.add(
                     new TestSpecification<>(
                             SPEC_NAME + "reconfig",
-                            migrationVersion,
+                            flinkVersion,
                             EnumSerializerReconfigSetup.class,
                             EnumSerializerReconfigVerifier.class));
         }
@@ -127,7 +127,7 @@ public class EnumSerializerUpgradeTest extends TypeSerializerUpgradeTestBase<Tes
 
         @Override
         public Matcher<TypeSerializerSchemaCompatibility<TestEnum>> schemaCompatibilityMatcher(
-                MigrationVersion version) {
+                FlinkVersion version) {
             return TypeSerializerMatchers.isCompatibleAsIs();
         }
     }
@@ -191,7 +191,7 @@ public class EnumSerializerUpgradeTest extends TypeSerializerUpgradeTestBase<Tes
 
         @Override
         public Matcher<TypeSerializerSchemaCompatibility<EnumAfter>> schemaCompatibilityMatcher(
-                MigrationVersion version) {
+                FlinkVersion version) {
             return TypeSerializerMatchers.isCompatibleWithReconfiguredSerializer();
         }
     }

--- a/flink-core/src/test/java/org/apache/flink/api/common/typeutils/base/ListSerializerUpgradeTest.java
+++ b/flink-core/src/test/java/org/apache/flink/api/common/typeutils/base/ListSerializerUpgradeTest.java
@@ -18,11 +18,11 @@
 
 package org.apache.flink.api.common.typeutils.base;
 
+import org.apache.flink.FlinkVersion;
 import org.apache.flink.api.common.typeutils.TypeSerializer;
 import org.apache.flink.api.common.typeutils.TypeSerializerMatchers;
 import org.apache.flink.api.common.typeutils.TypeSerializerSchemaCompatibility;
 import org.apache.flink.api.common.typeutils.TypeSerializerUpgradeTestBase;
-import org.apache.flink.testutils.migration.MigrationVersion;
 
 import org.hamcrest.Matcher;
 import org.junit.runner.RunWith;
@@ -50,11 +50,11 @@ public class ListSerializerUpgradeTest
     public static Collection<TestSpecification<?, ?>> testSpecifications() throws Exception {
 
         ArrayList<TestSpecification<?, ?>> testSpecifications = new ArrayList<>();
-        for (MigrationVersion migrationVersion : MIGRATION_VERSIONS) {
+        for (FlinkVersion flinkVersion : MIGRATION_VERSIONS) {
             testSpecifications.add(
                     new TestSpecification<>(
                             SPEC_NAME,
-                            migrationVersion,
+                            flinkVersion,
                             ListSerializerSetup.class,
                             ListSerializerVerifier.class));
         }
@@ -107,7 +107,7 @@ public class ListSerializerUpgradeTest
 
         @Override
         public Matcher<TypeSerializerSchemaCompatibility<List<String>>> schemaCompatibilityMatcher(
-                MigrationVersion version) {
+                FlinkVersion version) {
             return TypeSerializerMatchers.isCompatibleAsIs();
         }
     }

--- a/flink-core/src/test/java/org/apache/flink/api/common/typeutils/base/MapSerializerUpgradeTest.java
+++ b/flink-core/src/test/java/org/apache/flink/api/common/typeutils/base/MapSerializerUpgradeTest.java
@@ -18,11 +18,11 @@
 
 package org.apache.flink.api.common.typeutils.base;
 
+import org.apache.flink.FlinkVersion;
 import org.apache.flink.api.common.typeutils.TypeSerializer;
 import org.apache.flink.api.common.typeutils.TypeSerializerMatchers;
 import org.apache.flink.api.common.typeutils.TypeSerializerSchemaCompatibility;
 import org.apache.flink.api.common.typeutils.TypeSerializerUpgradeTestBase;
-import org.apache.flink.testutils.migration.MigrationVersion;
 
 import org.hamcrest.Matcher;
 import org.junit.runner.RunWith;
@@ -51,11 +51,11 @@ public class MapSerializerUpgradeTest
     public static Collection<TestSpecification<?, ?>> testSpecifications() throws Exception {
 
         ArrayList<TestSpecification<?, ?>> testSpecifications = new ArrayList<>();
-        for (MigrationVersion migrationVersion : MIGRATION_VERSIONS) {
+        for (FlinkVersion flinkVersion : MIGRATION_VERSIONS) {
             testSpecifications.add(
                     new TestSpecification<>(
                             SPEC_NAME,
-                            migrationVersion,
+                            flinkVersion,
                             MapSerializerSetup.class,
                             MapSerializerVerifier.class));
         }
@@ -109,7 +109,7 @@ public class MapSerializerUpgradeTest
 
         @Override
         public Matcher<TypeSerializerSchemaCompatibility<Map<Integer, String>>>
-                schemaCompatibilityMatcher(MigrationVersion version) {
+                schemaCompatibilityMatcher(FlinkVersion version) {
             return TypeSerializerMatchers.isCompatibleAsIs();
         }
     }

--- a/flink-core/src/test/java/org/apache/flink/api/common/typeutils/base/array/PrimitiveArraySerializerUpgradeTest.java
+++ b/flink-core/src/test/java/org/apache/flink/api/common/typeutils/base/array/PrimitiveArraySerializerUpgradeTest.java
@@ -18,8 +18,8 @@
 
 package org.apache.flink.api.common.typeutils.base.array;
 
+import org.apache.flink.FlinkVersion;
 import org.apache.flink.api.common.typeutils.TypeSerializerUpgradeTestBase;
-import org.apache.flink.testutils.migration.MigrationVersion;
 
 import org.junit.runner.RunWith;
 import org.junit.runners.Parameterized;
@@ -39,11 +39,11 @@ public class PrimitiveArraySerializerUpgradeTest
     @Parameterized.Parameters(name = "Test Specification = {0}")
     public static Collection<TestSpecification<?, ?>> testSpecifications() throws Exception {
         ArrayList<TestSpecification<?, ?>> testSpecifications = new ArrayList<>();
-        for (MigrationVersion migrationVersion : MIGRATION_VERSIONS) {
+        for (FlinkVersion flinkVersion : MIGRATION_VERSIONS) {
             testSpecifications.add(
                     new TestSpecification<>(
                             "boolean-primitive-array-serializer",
-                            migrationVersion,
+                            flinkVersion,
                             PrimitiveArraySerializerUpgradeTestSpecifications
                                     .PrimitiveBooleanArraySetup.class,
                             PrimitiveArraySerializerUpgradeTestSpecifications
@@ -51,7 +51,7 @@ public class PrimitiveArraySerializerUpgradeTest
             testSpecifications.add(
                     new TestSpecification<>(
                             "byte-primitive-array-serializer",
-                            migrationVersion,
+                            flinkVersion,
                             PrimitiveArraySerializerUpgradeTestSpecifications
                                     .PrimitiveByteArraySetup.class,
                             PrimitiveArraySerializerUpgradeTestSpecifications
@@ -59,7 +59,7 @@ public class PrimitiveArraySerializerUpgradeTest
             testSpecifications.add(
                     new TestSpecification<>(
                             "char-primitive-array-serializer",
-                            migrationVersion,
+                            flinkVersion,
                             PrimitiveArraySerializerUpgradeTestSpecifications
                                     .PrimitiveCharArraySetup.class,
                             PrimitiveArraySerializerUpgradeTestSpecifications
@@ -67,7 +67,7 @@ public class PrimitiveArraySerializerUpgradeTest
             testSpecifications.add(
                     new TestSpecification<>(
                             "double-primitive-array-serializer",
-                            migrationVersion,
+                            flinkVersion,
                             PrimitiveArraySerializerUpgradeTestSpecifications
                                     .PrimitiveDoubleArraySetup.class,
                             PrimitiveArraySerializerUpgradeTestSpecifications
@@ -75,7 +75,7 @@ public class PrimitiveArraySerializerUpgradeTest
             testSpecifications.add(
                     new TestSpecification<>(
                             "float-primitive-array-serializer",
-                            migrationVersion,
+                            flinkVersion,
                             PrimitiveArraySerializerUpgradeTestSpecifications
                                     .PrimitiveFloatArraySetup.class,
                             PrimitiveArraySerializerUpgradeTestSpecifications
@@ -83,7 +83,7 @@ public class PrimitiveArraySerializerUpgradeTest
             testSpecifications.add(
                     new TestSpecification<>(
                             "int-primitive-array-serializer",
-                            migrationVersion,
+                            flinkVersion,
                             PrimitiveArraySerializerUpgradeTestSpecifications.PrimitiveIntArraySetup
                                     .class,
                             PrimitiveArraySerializerUpgradeTestSpecifications
@@ -91,7 +91,7 @@ public class PrimitiveArraySerializerUpgradeTest
             testSpecifications.add(
                     new TestSpecification<>(
                             "long-primitive-array-serializer",
-                            migrationVersion,
+                            flinkVersion,
                             PrimitiveArraySerializerUpgradeTestSpecifications
                                     .PrimitiveLongArraySetup.class,
                             PrimitiveArraySerializerUpgradeTestSpecifications
@@ -99,7 +99,7 @@ public class PrimitiveArraySerializerUpgradeTest
             testSpecifications.add(
                     new TestSpecification<>(
                             "short-primitive-array-serializer",
-                            migrationVersion,
+                            flinkVersion,
                             PrimitiveArraySerializerUpgradeTestSpecifications
                                     .PrimitiveShortArraySetup.class,
                             PrimitiveArraySerializerUpgradeTestSpecifications
@@ -107,7 +107,7 @@ public class PrimitiveArraySerializerUpgradeTest
             testSpecifications.add(
                     new TestSpecification<>(
                             "string-array-serializer",
-                            migrationVersion,
+                            flinkVersion,
                             PrimitiveArraySerializerUpgradeTestSpecifications
                                     .PrimitiveStringArraySetup.class,
                             PrimitiveArraySerializerUpgradeTestSpecifications

--- a/flink-core/src/test/java/org/apache/flink/api/common/typeutils/base/array/PrimitiveArraySerializerUpgradeTestSpecifications.java
+++ b/flink-core/src/test/java/org/apache/flink/api/common/typeutils/base/array/PrimitiveArraySerializerUpgradeTestSpecifications.java
@@ -18,13 +18,13 @@
 
 package org.apache.flink.api.common.typeutils.base.array;
 
+import org.apache.flink.FlinkVersion;
 import org.apache.flink.api.common.ExecutionConfig;
 import org.apache.flink.api.common.typeutils.TypeSerializer;
 import org.apache.flink.api.common.typeutils.TypeSerializerMatchers;
 import org.apache.flink.api.common.typeutils.TypeSerializerSchemaCompatibility;
 import org.apache.flink.api.common.typeutils.TypeSerializerUpgradeTestBase;
 import org.apache.flink.api.java.typeutils.TypeExtractor;
-import org.apache.flink.testutils.migration.MigrationVersion;
 
 import org.hamcrest.Matcher;
 
@@ -76,7 +76,7 @@ public class PrimitiveArraySerializerUpgradeTestSpecifications {
 
         @Override
         public Matcher<TypeSerializerSchemaCompatibility<boolean[]>> schemaCompatibilityMatcher(
-                MigrationVersion version) {
+                FlinkVersion version) {
             return TypeSerializerMatchers.isCompatibleAsIs();
         }
     }
@@ -127,7 +127,7 @@ public class PrimitiveArraySerializerUpgradeTestSpecifications {
 
         @Override
         public Matcher<TypeSerializerSchemaCompatibility<byte[]>> schemaCompatibilityMatcher(
-                MigrationVersion version) {
+                FlinkVersion version) {
             return TypeSerializerMatchers.isCompatibleAsIs();
         }
     }
@@ -178,7 +178,7 @@ public class PrimitiveArraySerializerUpgradeTestSpecifications {
 
         @Override
         public Matcher<TypeSerializerSchemaCompatibility<char[]>> schemaCompatibilityMatcher(
-                MigrationVersion version) {
+                FlinkVersion version) {
             return TypeSerializerMatchers.isCompatibleAsIs();
         }
     }
@@ -229,7 +229,7 @@ public class PrimitiveArraySerializerUpgradeTestSpecifications {
 
         @Override
         public Matcher<TypeSerializerSchemaCompatibility<double[]>> schemaCompatibilityMatcher(
-                MigrationVersion version) {
+                FlinkVersion version) {
             return TypeSerializerMatchers.isCompatibleAsIs();
         }
     }
@@ -280,7 +280,7 @@ public class PrimitiveArraySerializerUpgradeTestSpecifications {
 
         @Override
         public Matcher<TypeSerializerSchemaCompatibility<float[]>> schemaCompatibilityMatcher(
-                MigrationVersion version) {
+                FlinkVersion version) {
             return TypeSerializerMatchers.isCompatibleAsIs();
         }
     }
@@ -331,7 +331,7 @@ public class PrimitiveArraySerializerUpgradeTestSpecifications {
 
         @Override
         public Matcher<TypeSerializerSchemaCompatibility<int[]>> schemaCompatibilityMatcher(
-                MigrationVersion version) {
+                FlinkVersion version) {
             return TypeSerializerMatchers.isCompatibleAsIs();
         }
     }
@@ -382,7 +382,7 @@ public class PrimitiveArraySerializerUpgradeTestSpecifications {
 
         @Override
         public Matcher<TypeSerializerSchemaCompatibility<long[]>> schemaCompatibilityMatcher(
-                MigrationVersion version) {
+                FlinkVersion version) {
             return TypeSerializerMatchers.isCompatibleAsIs();
         }
     }
@@ -433,7 +433,7 @@ public class PrimitiveArraySerializerUpgradeTestSpecifications {
 
         @Override
         public Matcher<TypeSerializerSchemaCompatibility<short[]>> schemaCompatibilityMatcher(
-                MigrationVersion version) {
+                FlinkVersion version) {
             return TypeSerializerMatchers.isCompatibleAsIs();
         }
     }
@@ -484,7 +484,7 @@ public class PrimitiveArraySerializerUpgradeTestSpecifications {
 
         @Override
         public Matcher<TypeSerializerSchemaCompatibility<String[]>> schemaCompatibilityMatcher(
-                MigrationVersion version) {
+                FlinkVersion version) {
             return TypeSerializerMatchers.isCompatibleAsIs();
         }
     }

--- a/flink-core/src/test/java/org/apache/flink/api/java/typeutils/runtime/CopyableSerializerUpgradeTest.java
+++ b/flink-core/src/test/java/org/apache/flink/api/java/typeutils/runtime/CopyableSerializerUpgradeTest.java
@@ -18,6 +18,7 @@
 
 package org.apache.flink.api.java.typeutils.runtime;
 
+import org.apache.flink.FlinkVersion;
 import org.apache.flink.api.common.typeutils.TypeSerializer;
 import org.apache.flink.api.common.typeutils.TypeSerializerMatchers;
 import org.apache.flink.api.common.typeutils.TypeSerializerSchemaCompatibility;
@@ -25,7 +26,6 @@ import org.apache.flink.api.common.typeutils.TypeSerializerUpgradeTestBase;
 import org.apache.flink.api.java.typeutils.runtime.CopyableSerializerUpgradeTest.SimpleCopyable;
 import org.apache.flink.core.memory.DataInputView;
 import org.apache.flink.core.memory.DataOutputView;
-import org.apache.flink.testutils.migration.MigrationVersion;
 import org.apache.flink.types.CopyableValue;
 
 import org.hamcrest.Matcher;
@@ -53,11 +53,11 @@ public class CopyableSerializerUpgradeTest
     @Parameterized.Parameters(name = "Test Specification = {0}")
     public static Collection<TestSpecification<?, ?>> testSpecifications() throws Exception {
         ArrayList<TestSpecification<?, ?>> testSpecifications = new ArrayList<>();
-        for (MigrationVersion migrationVersion : MIGRATION_VERSIONS) {
+        for (FlinkVersion flinkVersion : MIGRATION_VERSIONS) {
             testSpecifications.add(
                     new TestSpecification<>(
                             "copyable-value-serializer",
-                            migrationVersion,
+                            flinkVersion,
                             CopyableSerializerSetup.class,
                             CopyableSerializerVerifier.class));
         }
@@ -162,7 +162,7 @@ public class CopyableSerializerUpgradeTest
 
         @Override
         public Matcher<TypeSerializerSchemaCompatibility<SimpleCopyable>>
-                schemaCompatibilityMatcher(MigrationVersion version) {
+                schemaCompatibilityMatcher(FlinkVersion version) {
             return TypeSerializerMatchers.isCompatibleAsIs();
         }
     }

--- a/flink-core/src/test/java/org/apache/flink/api/java/typeutils/runtime/NullableSerializerUpgradeTest.java
+++ b/flink-core/src/test/java/org/apache/flink/api/java/typeutils/runtime/NullableSerializerUpgradeTest.java
@@ -18,12 +18,12 @@
 
 package org.apache.flink.api.java.typeutils.runtime;
 
+import org.apache.flink.FlinkVersion;
 import org.apache.flink.api.common.typeutils.TypeSerializer;
 import org.apache.flink.api.common.typeutils.TypeSerializerMatchers;
 import org.apache.flink.api.common.typeutils.TypeSerializerSchemaCompatibility;
 import org.apache.flink.api.common.typeutils.TypeSerializerUpgradeTestBase;
 import org.apache.flink.api.common.typeutils.base.LongSerializer;
-import org.apache.flink.testutils.migration.MigrationVersion;
 
 import org.hamcrest.Matcher;
 import org.junit.runner.RunWith;
@@ -46,18 +46,18 @@ public class NullableSerializerUpgradeTest extends TypeSerializerUpgradeTestBase
     public static Collection<TestSpecification<?, ?>> testSpecifications() throws Exception {
 
         ArrayList<TestSpecification<?, ?>> testSpecifications = new ArrayList<>();
-        for (MigrationVersion migrationVersion : MIGRATION_VERSIONS) {
+        for (FlinkVersion flinkVersion : MIGRATION_VERSIONS) {
             testSpecifications.add(
                     new TestSpecification<>(
                             "nullable-padded-serializer",
-                            migrationVersion,
+                            flinkVersion,
                             NullablePaddedSerializerSetup.class,
                             NullablePaddedSerializerVerifier.class));
 
             testSpecifications.add(
                     new TestSpecification<>(
                             "nullable-not-padded-serializer",
-                            migrationVersion,
+                            flinkVersion,
                             NullableNotPaddedSerializerSetup.class,
                             NullableNotPaddedSerializerVerifier.class));
         }
@@ -103,7 +103,7 @@ public class NullableSerializerUpgradeTest extends TypeSerializerUpgradeTestBase
 
         @Override
         public Matcher<TypeSerializerSchemaCompatibility<Long>> schemaCompatibilityMatcher(
-                MigrationVersion version) {
+                FlinkVersion version) {
             return TypeSerializerMatchers.isCompatibleAsIs();
         }
     }
@@ -147,7 +147,7 @@ public class NullableSerializerUpgradeTest extends TypeSerializerUpgradeTestBase
 
         @Override
         public Matcher<TypeSerializerSchemaCompatibility<Long>> schemaCompatibilityMatcher(
-                MigrationVersion version) {
+                FlinkVersion version) {
             return TypeSerializerMatchers.isCompatibleAsIs();
         }
     }

--- a/flink-core/src/test/java/org/apache/flink/api/java/typeutils/runtime/PojoSerializerUpgradeTest.java
+++ b/flink-core/src/test/java/org/apache/flink/api/java/typeutils/runtime/PojoSerializerUpgradeTest.java
@@ -18,8 +18,8 @@
 
 package org.apache.flink.api.java.typeutils.runtime;
 
+import org.apache.flink.FlinkVersion;
 import org.apache.flink.api.common.typeutils.TypeSerializerUpgradeTestBase;
-import org.apache.flink.testutils.migration.MigrationVersion;
 
 import org.junit.runner.RunWith;
 import org.junit.runners.Parameterized;
@@ -44,30 +44,30 @@ public class PojoSerializerUpgradeTest extends TypeSerializerUpgradeTestBase<Obj
         // for this which go beyond what we have for the usual subclasses of
         // TypeSerializerUpgradeTestBase. We don't have snapshot data for 1.10, but the
         // PojoSerializer has not been changed in quite a while anyways.
-        List<MigrationVersion> testVersions = new ArrayList<>();
-        testVersions.add(MigrationVersion.v1_7);
-        testVersions.add(MigrationVersion.v1_8);
-        testVersions.add(MigrationVersion.v1_9);
+        List<FlinkVersion> testVersions = new ArrayList<>();
+        testVersions.add(FlinkVersion.v1_7);
+        testVersions.add(FlinkVersion.v1_8);
+        testVersions.add(FlinkVersion.v1_9);
         testVersions.addAll(Arrays.asList(MIGRATION_VERSIONS));
-        for (MigrationVersion migrationVersion : testVersions) {
+        for (FlinkVersion flinkVersion : testVersions) {
             testSpecifications.add(
                     new TestSpecification<>(
                             "pojo-serializer-identical-schema",
-                            migrationVersion,
+                            flinkVersion,
                             PojoSerializerUpgradeTestSpecifications.IdenticalPojoSchemaSetup.class,
                             PojoSerializerUpgradeTestSpecifications.IdenticalPojoSchemaVerifier
                                     .class));
             testSpecifications.add(
                     new TestSpecification<>(
                             "pojo-serializer-with-modified-schema",
-                            migrationVersion,
+                            flinkVersion,
                             PojoSerializerUpgradeTestSpecifications.ModifiedPojoSchemaSetup.class,
                             PojoSerializerUpgradeTestSpecifications.ModifiedPojoSchemaVerifier
                                     .class));
             testSpecifications.add(
                     new TestSpecification<>(
                             "pojo-serializer-with-different-field-types",
-                            migrationVersion,
+                            flinkVersion,
                             PojoSerializerUpgradeTestSpecifications
                                     .DifferentFieldTypePojoSchemaSetup.class,
                             PojoSerializerUpgradeTestSpecifications
@@ -75,7 +75,7 @@ public class PojoSerializerUpgradeTest extends TypeSerializerUpgradeTestBase<Obj
             testSpecifications.add(
                     new TestSpecification<>(
                             "pojo-serializer-with-modified-schema-in-registered-subclass",
-                            migrationVersion,
+                            flinkVersion,
                             PojoSerializerUpgradeTestSpecifications
                                     .ModifiedRegisteredPojoSubclassSchemaSetup.class,
                             PojoSerializerUpgradeTestSpecifications
@@ -83,7 +83,7 @@ public class PojoSerializerUpgradeTest extends TypeSerializerUpgradeTestBase<Obj
             testSpecifications.add(
                     new TestSpecification<>(
                             "pojo-serializer-with-different-field-types-in-registered-subclass",
-                            migrationVersion,
+                            flinkVersion,
                             PojoSerializerUpgradeTestSpecifications
                                     .DifferentFieldTypePojoSubclassSchemaSetup.class,
                             PojoSerializerUpgradeTestSpecifications
@@ -91,7 +91,7 @@ public class PojoSerializerUpgradeTest extends TypeSerializerUpgradeTestBase<Obj
             testSpecifications.add(
                     new TestSpecification<>(
                             "pojo-serializer-with-non-registered-subclass",
-                            migrationVersion,
+                            flinkVersion,
                             PojoSerializerUpgradeTestSpecifications.NonRegisteredPojoSubclassSetup
                                     .class,
                             PojoSerializerUpgradeTestSpecifications
@@ -99,7 +99,7 @@ public class PojoSerializerUpgradeTest extends TypeSerializerUpgradeTestBase<Obj
             testSpecifications.add(
                     new TestSpecification<>(
                             "pojo-serializer-with-different-subclass-registration-order",
-                            migrationVersion,
+                            flinkVersion,
                             PojoSerializerUpgradeTestSpecifications
                                     .DifferentPojoSubclassRegistrationOrderSetup.class,
                             PojoSerializerUpgradeTestSpecifications
@@ -107,7 +107,7 @@ public class PojoSerializerUpgradeTest extends TypeSerializerUpgradeTestBase<Obj
             testSpecifications.add(
                     new TestSpecification<>(
                             "pojo-serializer-with-missing-registered-subclass",
-                            migrationVersion,
+                            flinkVersion,
                             PojoSerializerUpgradeTestSpecifications
                                     .MissingRegisteredPojoSubclassSetup.class,
                             PojoSerializerUpgradeTestSpecifications
@@ -115,7 +115,7 @@ public class PojoSerializerUpgradeTest extends TypeSerializerUpgradeTestBase<Obj
             testSpecifications.add(
                     new TestSpecification<>(
                             "pojo-serializer-with-new-registered-subclass",
-                            migrationVersion,
+                            flinkVersion,
                             PojoSerializerUpgradeTestSpecifications.NewRegisteredPojoSubclassSetup
                                     .class,
                             PojoSerializerUpgradeTestSpecifications
@@ -123,7 +123,7 @@ public class PojoSerializerUpgradeTest extends TypeSerializerUpgradeTestBase<Obj
             testSpecifications.add(
                     new TestSpecification<>(
                             "pojo-serializer-with-new-and-missing-registered-subclasses",
-                            migrationVersion,
+                            flinkVersion,
                             PojoSerializerUpgradeTestSpecifications
                                     .NewAndMissingRegisteredPojoSubclassesSetup.class,
                             PojoSerializerUpgradeTestSpecifications

--- a/flink-core/src/test/java/org/apache/flink/api/java/typeutils/runtime/PojoSerializerUpgradeTestSpecifications.java
+++ b/flink-core/src/test/java/org/apache/flink/api/java/typeutils/runtime/PojoSerializerUpgradeTestSpecifications.java
@@ -18,6 +18,7 @@
 
 package org.apache.flink.api.java.typeutils.runtime;
 
+import org.apache.flink.FlinkVersion;
 import org.apache.flink.api.common.ExecutionConfig;
 import org.apache.flink.api.common.typeutils.ClassRelocator;
 import org.apache.flink.api.common.typeutils.TypeSerializer;
@@ -25,7 +26,6 @@ import org.apache.flink.api.common.typeutils.TypeSerializerMatchers;
 import org.apache.flink.api.common.typeutils.TypeSerializerSchemaCompatibility;
 import org.apache.flink.api.common.typeutils.TypeSerializerUpgradeTestBase;
 import org.apache.flink.api.java.typeutils.TypeExtractor;
-import org.apache.flink.testutils.migration.MigrationVersion;
 
 import org.hamcrest.Matcher;
 
@@ -239,7 +239,7 @@ public class PojoSerializerUpgradeTestSpecifications {
 
         @Override
         public Matcher<TypeSerializerSchemaCompatibility<StaticSchemaPojo>>
-                schemaCompatibilityMatcher(MigrationVersion version) {
+                schemaCompatibilityMatcher(FlinkVersion version) {
             return TypeSerializerMatchers.isCompatibleAsIs();
         }
     }
@@ -353,7 +353,7 @@ public class PojoSerializerUpgradeTestSpecifications {
 
         @Override
         public Matcher<TypeSerializerSchemaCompatibility<PojoAfterSchemaUpgrade>>
-                schemaCompatibilityMatcher(MigrationVersion version) {
+                schemaCompatibilityMatcher(FlinkVersion version) {
             return TypeSerializerMatchers.isCompatibleAfterMigration();
         }
     }
@@ -427,7 +427,7 @@ public class PojoSerializerUpgradeTestSpecifications {
 
         @Override
         public Matcher<TypeSerializerSchemaCompatibility<PojoWithStringField>>
-                schemaCompatibilityMatcher(MigrationVersion version) {
+                schemaCompatibilityMatcher(FlinkVersion version) {
             return TypeSerializerMatchers.isIncompatible();
         }
     }
@@ -568,7 +568,7 @@ public class PojoSerializerUpgradeTestSpecifications {
 
         @Override
         public Matcher<TypeSerializerSchemaCompatibility<BasePojo>> schemaCompatibilityMatcher(
-                MigrationVersion version) {
+                FlinkVersion version) {
             return TypeSerializerMatchers.isCompatibleAfterMigration();
         }
     }
@@ -653,7 +653,7 @@ public class PojoSerializerUpgradeTestSpecifications {
 
         @Override
         public Matcher<TypeSerializerSchemaCompatibility<StaticSchemaPojo>>
-                schemaCompatibilityMatcher(MigrationVersion version) {
+                schemaCompatibilityMatcher(FlinkVersion version) {
             return TypeSerializerMatchers.isIncompatible();
         }
     }
@@ -702,7 +702,7 @@ public class PojoSerializerUpgradeTestSpecifications {
 
         @Override
         public Matcher<TypeSerializerSchemaCompatibility<StaticSchemaPojo>>
-                schemaCompatibilityMatcher(MigrationVersion version) {
+                schemaCompatibilityMatcher(FlinkVersion version) {
             return TypeSerializerMatchers.isCompatibleWithReconfiguredSerializer();
         }
     }
@@ -760,7 +760,7 @@ public class PojoSerializerUpgradeTestSpecifications {
 
         @Override
         public Matcher<TypeSerializerSchemaCompatibility<StaticSchemaPojo>>
-                schemaCompatibilityMatcher(MigrationVersion version) {
+                schemaCompatibilityMatcher(FlinkVersion version) {
             return TypeSerializerMatchers.isCompatibleWithReconfiguredSerializer();
         }
     }
@@ -816,7 +816,7 @@ public class PojoSerializerUpgradeTestSpecifications {
 
         @Override
         public Matcher<TypeSerializerSchemaCompatibility<StaticSchemaPojo>>
-                schemaCompatibilityMatcher(MigrationVersion version) {
+                schemaCompatibilityMatcher(FlinkVersion version) {
             return TypeSerializerMatchers.isCompatibleWithReconfiguredSerializer();
         }
     }
@@ -871,7 +871,7 @@ public class PojoSerializerUpgradeTestSpecifications {
 
         @Override
         public Matcher<TypeSerializerSchemaCompatibility<StaticSchemaPojo>>
-                schemaCompatibilityMatcher(MigrationVersion version) {
+                schemaCompatibilityMatcher(FlinkVersion version) {
             return TypeSerializerMatchers.isCompatibleWithReconfiguredSerializer();
         }
     }
@@ -927,7 +927,7 @@ public class PojoSerializerUpgradeTestSpecifications {
 
         @Override
         public Matcher<TypeSerializerSchemaCompatibility<StaticSchemaPojo>>
-                schemaCompatibilityMatcher(MigrationVersion version) {
+                schemaCompatibilityMatcher(FlinkVersion version) {
             return TypeSerializerMatchers.isCompatibleWithReconfiguredSerializer();
         }
     }

--- a/flink-core/src/test/java/org/apache/flink/api/java/typeutils/runtime/RowSerializerUpgradeTest.java
+++ b/flink-core/src/test/java/org/apache/flink/api/java/typeutils/runtime/RowSerializerUpgradeTest.java
@@ -18,6 +18,7 @@
 
 package org.apache.flink.api.java.typeutils.runtime;
 
+import org.apache.flink.FlinkVersion;
 import org.apache.flink.api.common.ExecutionConfig;
 import org.apache.flink.api.common.typeinfo.BasicTypeInfo;
 import org.apache.flink.api.common.typeutils.TypeSerializer;
@@ -25,7 +26,6 @@ import org.apache.flink.api.common.typeutils.TypeSerializerMatchers;
 import org.apache.flink.api.common.typeutils.TypeSerializerSchemaCompatibility;
 import org.apache.flink.api.common.typeutils.TypeSerializerUpgradeTestBase;
 import org.apache.flink.api.java.typeutils.RowTypeInfo;
-import org.apache.flink.testutils.migration.MigrationVersion;
 import org.apache.flink.types.Row;
 import org.apache.flink.types.RowKind;
 
@@ -54,14 +54,14 @@ public class RowSerializerUpgradeTest extends TypeSerializerUpgradeTestBase<Row,
         // for RowSerializer we also test against 1.10 and newer because we have snapshots
         // for this which go beyond what we have for the usual subclasses of
         // TypeSerializerUpgradeTestBase
-        List<MigrationVersion> testVersions = new ArrayList<>();
-        testVersions.add(MigrationVersion.v1_10);
+        List<FlinkVersion> testVersions = new ArrayList<>();
+        testVersions.add(FlinkVersion.v1_10);
         testVersions.addAll(Arrays.asList(MIGRATION_VERSIONS));
-        for (MigrationVersion migrationVersion : testVersions) {
+        for (FlinkVersion flinkVersion : testVersions) {
             testSpecifications.add(
                     new TestSpecification<>(
                             "row-serializer",
-                            migrationVersion,
+                            flinkVersion,
                             RowSerializerSetup.class,
                             RowSerializerVerifier.class));
         }
@@ -129,8 +129,8 @@ public class RowSerializerUpgradeTest extends TypeSerializerUpgradeTestBase<Row,
 
         @Override
         public Matcher<TypeSerializerSchemaCompatibility<Row>> schemaCompatibilityMatcher(
-                MigrationVersion version) {
-            if (version.isNewerVersionThan(MigrationVersion.v1_10)) {
+                FlinkVersion version) {
+            if (version.isNewerVersionThan(FlinkVersion.v1_10)) {
                 return TypeSerializerMatchers.isCompatibleAsIs();
             }
             return TypeSerializerMatchers.isCompatibleAfterMigration();

--- a/flink-core/src/test/java/org/apache/flink/api/java/typeutils/runtime/TupleSerializerUpgradeTest.java
+++ b/flink-core/src/test/java/org/apache/flink/api/java/typeutils/runtime/TupleSerializerUpgradeTest.java
@@ -18,6 +18,7 @@
 
 package org.apache.flink.api.java.typeutils.runtime;
 
+import org.apache.flink.FlinkVersion;
 import org.apache.flink.api.common.typeutils.TypeSerializer;
 import org.apache.flink.api.common.typeutils.TypeSerializerMatchers;
 import org.apache.flink.api.common.typeutils.TypeSerializerSchemaCompatibility;
@@ -25,7 +26,6 @@ import org.apache.flink.api.common.typeutils.TypeSerializerUpgradeTestBase;
 import org.apache.flink.api.common.typeutils.base.IntSerializer;
 import org.apache.flink.api.common.typeutils.base.StringSerializer;
 import org.apache.flink.api.java.tuple.Tuple3;
-import org.apache.flink.testutils.migration.MigrationVersion;
 
 import org.hamcrest.Matcher;
 import org.junit.runner.RunWith;
@@ -52,11 +52,11 @@ public class TupleSerializerUpgradeTest
     public static Collection<TestSpecification<?, ?>> testSpecifications() throws Exception {
 
         ArrayList<TestSpecification<?, ?>> testSpecifications = new ArrayList<>();
-        for (MigrationVersion migrationVersion : MIGRATION_VERSIONS) {
+        for (FlinkVersion flinkVersion : MIGRATION_VERSIONS) {
             testSpecifications.add(
                     new TestSpecification<>(
                             "tuple-serializer",
-                            migrationVersion,
+                            flinkVersion,
                             TupleSerializerSetup.class,
                             TupleSerializerVerifier.class));
         }
@@ -109,7 +109,7 @@ public class TupleSerializerUpgradeTest
 
         @Override
         public Matcher<TypeSerializerSchemaCompatibility<Tuple3<String, String, Integer>>>
-                schemaCompatibilityMatcher(MigrationVersion version) {
+                schemaCompatibilityMatcher(FlinkVersion version) {
             return TypeSerializerMatchers.isCompatibleAsIs();
         }
     }

--- a/flink-core/src/test/java/org/apache/flink/api/java/typeutils/runtime/ValueSerializerUpgradeTest.java
+++ b/flink-core/src/test/java/org/apache/flink/api/java/typeutils/runtime/ValueSerializerUpgradeTest.java
@@ -18,13 +18,13 @@
 
 package org.apache.flink.api.java.typeutils.runtime;
 
+import org.apache.flink.FlinkVersion;
 import org.apache.flink.api.common.typeutils.TypeSerializer;
 import org.apache.flink.api.common.typeutils.TypeSerializerMatchers;
 import org.apache.flink.api.common.typeutils.TypeSerializerSchemaCompatibility;
 import org.apache.flink.api.common.typeutils.TypeSerializerUpgradeTestBase;
 import org.apache.flink.core.memory.DataInputView;
 import org.apache.flink.core.memory.DataOutputView;
-import org.apache.flink.testutils.migration.MigrationVersion;
 import org.apache.flink.types.Value;
 
 import org.hamcrest.Matcher;
@@ -50,11 +50,11 @@ public class ValueSerializerUpgradeTest
     @Parameterized.Parameters(name = "Test Specification = {0}")
     public static Collection<TestSpecification<?, ?>> testSpecifications() throws Exception {
         ArrayList<TestSpecification<?, ?>> testSpecifications = new ArrayList<>();
-        for (MigrationVersion migrationVersion : MIGRATION_VERSIONS) {
+        for (FlinkVersion flinkVersion : MIGRATION_VERSIONS) {
             testSpecifications.add(
                     new TestSpecification<>(
                             "value-serializer",
-                            migrationVersion,
+                            flinkVersion,
                             ValueSerializerSetup.class,
                             ValueSerializerVerifier.class));
         }
@@ -93,7 +93,7 @@ public class ValueSerializerUpgradeTest
 
         @Override
         public Matcher<TypeSerializerSchemaCompatibility<NameValue>> schemaCompatibilityMatcher(
-                MigrationVersion version) {
+                FlinkVersion version) {
             return TypeSerializerMatchers.isCompatibleAsIs();
         }
     }

--- a/flink-core/src/test/java/org/apache/flink/api/java/typeutils/runtime/kryo/KryoSerializerUpgradeTest.java
+++ b/flink-core/src/test/java/org/apache/flink/api/java/typeutils/runtime/kryo/KryoSerializerUpgradeTest.java
@@ -18,6 +18,7 @@
 
 package org.apache.flink.api.java.typeutils.runtime.kryo;
 
+import org.apache.flink.FlinkVersion;
 import org.apache.flink.api.common.ExecutionConfig;
 import org.apache.flink.api.common.typeutils.TypeSerializer;
 import org.apache.flink.api.common.typeutils.TypeSerializerMatchers;
@@ -27,7 +28,6 @@ import org.apache.flink.api.java.typeutils.runtime.kryo.KryoPojosForMigrationTes
 import org.apache.flink.api.java.typeutils.runtime.kryo.KryoPojosForMigrationTests.Cat;
 import org.apache.flink.api.java.typeutils.runtime.kryo.KryoPojosForMigrationTests.Dog;
 import org.apache.flink.api.java.typeutils.runtime.kryo.KryoPojosForMigrationTests.Parrot;
-import org.apache.flink.testutils.migration.MigrationVersion;
 
 import com.esotericsoftware.kryo.serializers.DefaultSerializers;
 import org.hamcrest.Matcher;
@@ -53,29 +53,29 @@ public class KryoSerializerUpgradeTest extends TypeSerializerUpgradeTestBase<Obj
     @Parameterized.Parameters(name = "Test Specification = {0}")
     public static Collection<TestSpecification<?, ?>> testSpecifications() throws Exception {
         ArrayList<TestSpecification<?, ?>> testSpecifications = new ArrayList<>();
-        for (MigrationVersion migrationVersion : MIGRATION_VERSIONS) {
+        for (FlinkVersion flinkVersion : MIGRATION_VERSIONS) {
             testSpecifications.add(
                     new TestSpecification<>(
                             "kryo-type-serializer-empty-config",
-                            migrationVersion,
+                            flinkVersion,
                             KryoTypeSerializerEmptyConfigSetup.class,
                             KryoTypeSerializerEmptyConfigVerifier.class));
             testSpecifications.add(
                     new TestSpecification<>(
                             "kryo-type-serializer-unrelated-config-after-restore",
-                            migrationVersion,
+                            flinkVersion,
                             KryoTypeSerializerEmptyConfigSetup.class,
                             KryoTypeSerializerWithUnrelatedConfigVerifier.class));
             testSpecifications.add(
                     new TestSpecification<>(
                             "kryo-type-serializer-changed-registration-order",
-                            migrationVersion,
+                            flinkVersion,
                             KryoTypeSerializerChangedRegistrationOrderSetup.class,
                             KryoTypeSerializerChangedRegistrationOrderVerifier.class));
             testSpecifications.add(
                     new TestSpecification<>(
                             "kryo-custom-type-serializer-changed-registration-order",
-                            migrationVersion,
+                            flinkVersion,
                             KryoCustomTypeSerializerChangedRegistrationOrderSetup.class,
                             KryoCustomTypeSerializerChangedRegistrationOrderVerifier.class));
         }
@@ -116,7 +116,7 @@ public class KryoSerializerUpgradeTest extends TypeSerializerUpgradeTestBase<Obj
 
         @Override
         public Matcher<TypeSerializerSchemaCompatibility<Animal>> schemaCompatibilityMatcher(
-                MigrationVersion version) {
+                FlinkVersion version) {
             return TypeSerializerMatchers.isCompatibleAsIs();
         }
     }
@@ -145,7 +145,7 @@ public class KryoSerializerUpgradeTest extends TypeSerializerUpgradeTestBase<Obj
 
         @Override
         public Matcher<TypeSerializerSchemaCompatibility<Animal>> schemaCompatibilityMatcher(
-                MigrationVersion version) {
+                FlinkVersion version) {
             return hasSameCompatibilityAs(
                     compatibleWithReconfiguredSerializer(
                             new KryoSerializer<>(Animal.class, new ExecutionConfig())));
@@ -197,7 +197,7 @@ public class KryoSerializerUpgradeTest extends TypeSerializerUpgradeTestBase<Obj
 
         @Override
         public Matcher<TypeSerializerSchemaCompatibility<Animal>> schemaCompatibilityMatcher(
-                MigrationVersion version) {
+                FlinkVersion version) {
             return hasSameCompatibilityAs(
                     compatibleWithReconfiguredSerializer(
                             new KryoSerializer<>(Animal.class, new ExecutionConfig())));
@@ -253,7 +253,7 @@ public class KryoSerializerUpgradeTest extends TypeSerializerUpgradeTestBase<Obj
 
         @Override
         public Matcher<TypeSerializerSchemaCompatibility<Animal>> schemaCompatibilityMatcher(
-                MigrationVersion version) {
+                FlinkVersion version) {
             return hasSameCompatibilityAs(
                     compatibleWithReconfiguredSerializer(
                             new KryoSerializer<>(Animal.class, new ExecutionConfig())));

--- a/flink-formats/flink-avro/src/test/java/org/apache/flink/formats/avro/typeutils/AvroSerializerUpgradeTest.java
+++ b/flink-formats/flink-avro/src/test/java/org/apache/flink/formats/avro/typeutils/AvroSerializerUpgradeTest.java
@@ -18,12 +18,12 @@
 
 package org.apache.flink.formats.avro.typeutils;
 
+import org.apache.flink.FlinkVersion;
 import org.apache.flink.api.common.typeutils.TypeSerializer;
 import org.apache.flink.api.common.typeutils.TypeSerializerMatchers;
 import org.apache.flink.api.common.typeutils.TypeSerializerSchemaCompatibility;
 import org.apache.flink.api.common.typeutils.TypeSerializerUpgradeTestBase;
 import org.apache.flink.formats.avro.generated.Address;
-import org.apache.flink.testutils.migration.MigrationVersion;
 
 import org.apache.avro.generic.GenericData;
 import org.apache.avro.generic.GenericRecord;
@@ -47,18 +47,18 @@ public class AvroSerializerUpgradeTest extends TypeSerializerUpgradeTestBase<Obj
     @Parameterized.Parameters(name = "Test Specification = {0}")
     public static Collection<TestSpecification<?, ?>> testSpecifications() throws Exception {
         ArrayList<TestSpecification<?, ?>> testSpecifications = new ArrayList<>();
-        for (MigrationVersion migrationVersion : MIGRATION_VERSIONS) {
+        for (FlinkVersion flinkVersion : MIGRATION_VERSIONS) {
             testSpecifications.add(
                     new TestSpecification<>(
                             "generic-avro-serializer",
-                            migrationVersion,
+                            flinkVersion,
                             GenericAvroSerializerSetup.class,
                             GenericAvroSerializerVerifier.class));
 
             testSpecifications.add(
                     new TestSpecification<>(
                             "specific-avro-serializer",
-                            migrationVersion,
+                            flinkVersion,
                             SpecificAvroSerializerSetup.class,
                             SpecificAvroSerializerVerifier.class));
         }
@@ -120,7 +120,7 @@ public class AvroSerializerUpgradeTest extends TypeSerializerUpgradeTestBase<Obj
 
         @Override
         public Matcher<TypeSerializerSchemaCompatibility<GenericRecord>> schemaCompatibilityMatcher(
-                MigrationVersion version) {
+                FlinkVersion version) {
             return TypeSerializerMatchers.isCompatibleAsIs();
         }
     }
@@ -182,7 +182,7 @@ public class AvroSerializerUpgradeTest extends TypeSerializerUpgradeTestBase<Obj
 
         @Override
         public Matcher<TypeSerializerSchemaCompatibility<Address>> schemaCompatibilityMatcher(
-                MigrationVersion version) {
+                FlinkVersion version) {
             return TypeSerializerMatchers.isCompatibleAsIs();
         }
     }

--- a/flink-fs-tests/src/test/java/org/apache/flink/hdfstests/ContinuousFileProcessingMigrationTest.java
+++ b/flink-fs-tests/src/test/java/org/apache/flink/hdfstests/ContinuousFileProcessingMigrationTest.java
@@ -18,6 +18,7 @@
 
 package org.apache.flink.hdfstests;
 
+import org.apache.flink.FlinkVersion;
 import org.apache.flink.api.common.ExecutionConfig;
 import org.apache.flink.api.common.io.FileInputFormat;
 import org.apache.flink.api.common.typeinfo.TypeInformation;
@@ -40,7 +41,6 @@ import org.apache.flink.streaming.runtime.streamrecord.StreamRecord;
 import org.apache.flink.streaming.util.AbstractStreamOperatorTestHarness;
 import org.apache.flink.streaming.util.OneInputStreamOperatorTestHarness;
 import org.apache.flink.streaming.util.OperatorSnapshotUtil;
-import org.apache.flink.testutils.migration.MigrationVersion;
 import org.apache.flink.util.OperatingSystem;
 
 import org.apache.commons.io.FileUtils;
@@ -71,35 +71,35 @@ public class ContinuousFileProcessingMigrationTest {
     private static final long INTERVAL = 100;
 
     @Parameterized.Parameters(name = "Migration Savepoint / Mod Time: {0}")
-    public static Collection<Tuple2<MigrationVersion, Long>> parameters() {
+    public static Collection<Tuple2<FlinkVersion, Long>> parameters() {
         return Arrays.asList(
-                Tuple2.of(MigrationVersion.v1_3, 1496532000000L),
-                Tuple2.of(MigrationVersion.v1_4, 1516897628000L),
-                Tuple2.of(MigrationVersion.v1_5, 1533639934000L),
-                Tuple2.of(MigrationVersion.v1_6, 1534696817000L),
-                Tuple2.of(MigrationVersion.v1_7, 1544024599000L),
-                Tuple2.of(MigrationVersion.v1_8, 1555215710000L),
-                Tuple2.of(MigrationVersion.v1_9, 1567499868000L),
-                Tuple2.of(MigrationVersion.v1_10, 1594559333000L),
-                Tuple2.of(MigrationVersion.v1_11, 1594561663000L),
-                Tuple2.of(MigrationVersion.v1_12, 1613720148000L),
-                Tuple2.of(MigrationVersion.v1_13, 1627550216000L),
-                Tuple2.of(MigrationVersion.v1_14, 1633938795000L));
+                Tuple2.of(FlinkVersion.v1_3, 1496532000000L),
+                Tuple2.of(FlinkVersion.v1_4, 1516897628000L),
+                Tuple2.of(FlinkVersion.v1_5, 1533639934000L),
+                Tuple2.of(FlinkVersion.v1_6, 1534696817000L),
+                Tuple2.of(FlinkVersion.v1_7, 1544024599000L),
+                Tuple2.of(FlinkVersion.v1_8, 1555215710000L),
+                Tuple2.of(FlinkVersion.v1_9, 1567499868000L),
+                Tuple2.of(FlinkVersion.v1_10, 1594559333000L),
+                Tuple2.of(FlinkVersion.v1_11, 1594561663000L),
+                Tuple2.of(FlinkVersion.v1_12, 1613720148000L),
+                Tuple2.of(FlinkVersion.v1_13, 1627550216000L),
+                Tuple2.of(FlinkVersion.v1_14, 1633938795000L));
     }
 
     /**
      * TODO change this to the corresponding savepoint version to be written (e.g. {@link
-     * MigrationVersion#v1_3} for 1.3) TODO and remove all @Ignore annotations on write*Snapshot()
+     * FlinkVersion#v1_3} for 1.3) TODO and remove all @Ignore annotations on write*Snapshot()
      * methods to generate savepoints TODO Note: You should generate the savepoint based on the
      * release branch instead of the master.
      */
-    private final MigrationVersion flinkGenerateSavepointVersion = null;
+    private final FlinkVersion flinkGenerateSavepointVersion = null;
 
-    private final MigrationVersion testMigrateVersion;
+    private final FlinkVersion testMigrateVersion;
     private final Long expectedModTime;
 
     public ContinuousFileProcessingMigrationTest(
-            Tuple2<MigrationVersion, Long> migrationVersionAndModTime) {
+            Tuple2<FlinkVersion, Long> migrationVersionAndModTime) {
         this.testMigrateVersion = migrationVersionAndModTime.f0;
         this.expectedModTime = migrationVersionAndModTime.f1;
     }

--- a/flink-libraries/flink-cep/src/test/java/org/apache/flink/cep/NFASerializerUpgradeTest.java
+++ b/flink-libraries/flink-cep/src/test/java/org/apache/flink/cep/NFASerializerUpgradeTest.java
@@ -18,6 +18,7 @@
 
 package org.apache.flink.cep;
 
+import org.apache.flink.FlinkVersion;
 import org.apache.flink.api.common.typeutils.TypeSerializer;
 import org.apache.flink.api.common.typeutils.TypeSerializerMatchers;
 import org.apache.flink.api.common.typeutils.TypeSerializerSchemaCompatibility;
@@ -30,7 +31,6 @@ import org.apache.flink.cep.nfa.sharedbuffer.NodeId;
 import org.apache.flink.cep.nfa.sharedbuffer.SharedBufferEdge;
 import org.apache.flink.cep.nfa.sharedbuffer.SharedBufferNode;
 import org.apache.flink.cep.nfa.sharedbuffer.SharedBufferNodeSerializer;
-import org.apache.flink.testutils.migration.MigrationVersion;
 
 import org.hamcrest.Matcher;
 import org.junit.runner.RunWith;
@@ -53,35 +53,35 @@ public class NFASerializerUpgradeTest extends TypeSerializerUpgradeTestBase<Obje
     @Parameterized.Parameters(name = "Test Specification = {0}")
     public static Collection<TestSpecification<?, ?>> testSpecifications() throws Exception {
         ArrayList<TestSpecification<?, ?>> testSpecifications = new ArrayList<>();
-        for (MigrationVersion migrationVersion : MIGRATION_VERSIONS) {
+        for (FlinkVersion flinkVersion : MIGRATION_VERSIONS) {
             testSpecifications.add(
                     new TestSpecification<>(
                             "event-id-serializer",
-                            migrationVersion,
+                            flinkVersion,
                             EventIdSerializerSetup.class,
                             EventIdSerializerVerifier.class));
             testSpecifications.add(
                     new TestSpecification<>(
                             "node-id-serializer",
-                            migrationVersion,
+                            flinkVersion,
                             NodeIdSerializerSetup.class,
                             NodeIdSerializerVerifier.class));
             testSpecifications.add(
                     new TestSpecification<>(
                             "dewey-number-serializer",
-                            migrationVersion,
+                            flinkVersion,
                             DeweyNumberSerializerSetup.class,
                             DeweyNumberSerializerVerifier.class));
             testSpecifications.add(
                     new TestSpecification<>(
                             "shared-buffer-edge-serializer",
-                            migrationVersion,
+                            flinkVersion,
                             SharedBufferEdgeSerializerSetup.class,
                             SharedBufferEdgeSerializerVerifier.class));
             testSpecifications.add(
                     new TestSpecification<>(
                             "nfa-state-serializer",
-                            migrationVersion,
+                            flinkVersion,
                             NFAStateSerializerSetup.class,
                             NFAStateSerializerVerifier.class));
         }
@@ -130,7 +130,7 @@ public class NFASerializerUpgradeTest extends TypeSerializerUpgradeTestBase<Obje
 
         @Override
         public Matcher<TypeSerializerSchemaCompatibility<EventId>> schemaCompatibilityMatcher(
-                MigrationVersion version) {
+                FlinkVersion version) {
             return TypeSerializerMatchers.isCompatibleAsIs();
         }
     }
@@ -176,7 +176,7 @@ public class NFASerializerUpgradeTest extends TypeSerializerUpgradeTestBase<Obje
 
         @Override
         public Matcher<TypeSerializerSchemaCompatibility<NodeId>> schemaCompatibilityMatcher(
-                MigrationVersion version) {
+                FlinkVersion version) {
             return TypeSerializerMatchers.isCompatibleAsIs();
         }
     }
@@ -222,7 +222,7 @@ public class NFASerializerUpgradeTest extends TypeSerializerUpgradeTestBase<Obje
 
         @Override
         public Matcher<TypeSerializerSchemaCompatibility<DeweyNumber>> schemaCompatibilityMatcher(
-                MigrationVersion version) {
+                FlinkVersion version) {
             return TypeSerializerMatchers.isCompatibleAsIs();
         }
     }
@@ -271,7 +271,7 @@ public class NFASerializerUpgradeTest extends TypeSerializerUpgradeTestBase<Obje
 
         @Override
         public Matcher<TypeSerializerSchemaCompatibility<SharedBufferEdge>>
-                schemaCompatibilityMatcher(MigrationVersion version) {
+                schemaCompatibilityMatcher(FlinkVersion version) {
             return TypeSerializerMatchers.isCompatibleAsIs();
         }
     }
@@ -325,7 +325,7 @@ public class NFASerializerUpgradeTest extends TypeSerializerUpgradeTestBase<Obje
 
         @Override
         public Matcher<TypeSerializerSchemaCompatibility<SharedBufferNode>>
-                schemaCompatibilityMatcher(MigrationVersion version) {
+                schemaCompatibilityMatcher(FlinkVersion version) {
             return TypeSerializerMatchers.isCompatibleAsIs();
         }
     }
@@ -371,7 +371,7 @@ public class NFASerializerUpgradeTest extends TypeSerializerUpgradeTestBase<Obje
 
         @Override
         public Matcher<TypeSerializerSchemaCompatibility<NFAState>> schemaCompatibilityMatcher(
-                MigrationVersion version) {
+                FlinkVersion version) {
             return TypeSerializerMatchers.isCompatibleAsIs();
         }
     }

--- a/flink-libraries/flink-cep/src/test/java/org/apache/flink/cep/nfa/sharedbuffer/LockableTypeSerializerUpgradeTest.java
+++ b/flink-libraries/flink-cep/src/test/java/org/apache/flink/cep/nfa/sharedbuffer/LockableTypeSerializerUpgradeTest.java
@@ -18,12 +18,12 @@
 
 package org.apache.flink.cep.nfa.sharedbuffer;
 
+import org.apache.flink.FlinkVersion;
 import org.apache.flink.api.common.typeutils.TypeSerializer;
 import org.apache.flink.api.common.typeutils.TypeSerializerMatchers;
 import org.apache.flink.api.common.typeutils.TypeSerializerSchemaCompatibility;
 import org.apache.flink.api.common.typeutils.TypeSerializerUpgradeTestBase;
 import org.apache.flink.api.common.typeutils.base.StringSerializer;
-import org.apache.flink.testutils.migration.MigrationVersion;
 
 import org.hamcrest.Matcher;
 import org.junit.runner.RunWith;
@@ -50,11 +50,11 @@ public class LockableTypeSerializerUpgradeTest
     public static Collection<TestSpecification<?, ?>> testSpecifications() throws Exception {
 
         ArrayList<TestSpecification<?, ?>> testSpecifications = new ArrayList<>();
-        for (MigrationVersion migrationVersion : MIGRATION_VERSIONS) {
+        for (FlinkVersion flinkVersion : MIGRATION_VERSIONS) {
             testSpecifications.add(
                     new TestSpecification<>(
                             SPEC_NAME,
-                            migrationVersion,
+                            flinkVersion,
                             LockableTypeSerializerSetup.class,
                             LockableTypeSerializerVerifier.class));
         }
@@ -100,7 +100,7 @@ public class LockableTypeSerializerUpgradeTest
 
         @Override
         public Matcher<TypeSerializerSchemaCompatibility<Lockable<String>>>
-                schemaCompatibilityMatcher(MigrationVersion version) {
+                schemaCompatibilityMatcher(FlinkVersion version) {
             return TypeSerializerMatchers.isCompatibleAsIs();
         }
     }

--- a/flink-libraries/flink-cep/src/test/java/org/apache/flink/cep/operator/CEPMigrationTest.java
+++ b/flink-libraries/flink-cep/src/test/java/org/apache/flink/cep/operator/CEPMigrationTest.java
@@ -18,6 +18,7 @@
 
 package org.apache.flink.cep.operator;
 
+import org.apache.flink.FlinkVersion;
 import org.apache.flink.api.common.typeinfo.BasicTypeInfo;
 import org.apache.flink.api.java.functions.KeySelector;
 import org.apache.flink.cep.Event;
@@ -34,7 +35,6 @@ import org.apache.flink.streaming.runtime.streamrecord.StreamRecord;
 import org.apache.flink.streaming.util.KeyedOneInputStreamOperatorTestHarness;
 import org.apache.flink.streaming.util.OneInputStreamOperatorTestHarness;
 import org.apache.flink.streaming.util.OperatorSnapshotUtil;
-import org.apache.flink.testutils.migration.MigrationVersion;
 
 import org.junit.Ignore;
 import org.junit.Test;
@@ -62,29 +62,29 @@ public class CEPMigrationTest {
 
     /**
      * TODO change this to the corresponding savepoint version to be written (e.g. {@link
-     * MigrationVersion#v1_3} for 1.3) TODO and remove all @Ignore annotations on write*Snapshot()
+     * FlinkVersion#v1_3} for 1.3) TODO and remove all @Ignore annotations on write*Snapshot()
      * methods to generate savepoints TODO Note: You should generate the savepoint based on the
      * release branch instead of the master.
      */
-    private final MigrationVersion flinkGenerateSavepointVersion = null;
+    private final FlinkVersion flinkGenerateSavepointVersion = null;
 
-    private final MigrationVersion migrateVersion;
+    private final FlinkVersion migrateVersion;
 
     @Parameterized.Parameters(name = "Migration Savepoint: {0}")
-    public static Collection<MigrationVersion> parameters() {
+    public static Collection<FlinkVersion> parameters() {
         return Arrays.asList(
-                MigrationVersion.v1_6,
-                MigrationVersion.v1_7,
-                MigrationVersion.v1_8,
-                MigrationVersion.v1_9,
-                MigrationVersion.v1_10,
-                MigrationVersion.v1_11,
-                MigrationVersion.v1_12,
-                MigrationVersion.v1_13,
-                MigrationVersion.v1_14);
+                FlinkVersion.v1_6,
+                FlinkVersion.v1_7,
+                FlinkVersion.v1_8,
+                FlinkVersion.v1_9,
+                FlinkVersion.v1_10,
+                FlinkVersion.v1_11,
+                FlinkVersion.v1_12,
+                FlinkVersion.v1_13,
+                FlinkVersion.v1_14);
     }
 
-    public CEPMigrationTest(MigrationVersion migrateVersion) {
+    public CEPMigrationTest(FlinkVersion migrateVersion) {
         this.migrateVersion = migrateVersion;
     }
 

--- a/flink-libraries/flink-gelly-examples/src/test/java/org/apache/flink/graph/drivers/transform/LongValueWithProperHashCodeSerializerUpgradeTest.java
+++ b/flink-libraries/flink-gelly-examples/src/test/java/org/apache/flink/graph/drivers/transform/LongValueWithProperHashCodeSerializerUpgradeTest.java
@@ -18,11 +18,11 @@
 
 package org.apache.flink.graph.drivers.transform;
 
+import org.apache.flink.FlinkVersion;
 import org.apache.flink.api.common.typeutils.TypeSerializer;
 import org.apache.flink.api.common.typeutils.TypeSerializerMatchers;
 import org.apache.flink.api.common.typeutils.TypeSerializerSchemaCompatibility;
 import org.apache.flink.api.common.typeutils.TypeSerializerUpgradeTestBase;
-import org.apache.flink.testutils.migration.MigrationVersion;
 
 import org.hamcrest.Matcher;
 import org.junit.runner.RunWith;
@@ -52,11 +52,11 @@ public class LongValueWithProperHashCodeSerializerUpgradeTest
     public static Collection<TestSpecification<?, ?>> testSpecifications() throws Exception {
 
         ArrayList<TestSpecification<?, ?>> testSpecifications = new ArrayList<>();
-        for (MigrationVersion migrationVersion : MIGRATION_VERSIONS) {
+        for (FlinkVersion flinkVersion : MIGRATION_VERSIONS) {
             testSpecifications.add(
                     new TestSpecification<>(
                             "long-value-with-proper-hash-code-serializer",
-                            migrationVersion,
+                            flinkVersion,
                             LongValueWithProperHashCodeSerializerSetup.class,
                             LongValueWithProperHashCodeSerializerVerifier.class));
         }
@@ -102,7 +102,7 @@ public class LongValueWithProperHashCodeSerializerUpgradeTest
 
         @Override
         public Matcher<TypeSerializerSchemaCompatibility<LongValueWithProperHashCode>>
-                schemaCompatibilityMatcher(MigrationVersion version) {
+                schemaCompatibilityMatcher(FlinkVersion version) {
             return TypeSerializerMatchers.isCompatibleAsIs();
         }
     }

--- a/flink-libraries/flink-gelly/src/test/java/org/apache/flink/graph/types/valuearray/ValueArraySerializerUpgradeTest.java
+++ b/flink-libraries/flink-gelly/src/test/java/org/apache/flink/graph/types/valuearray/ValueArraySerializerUpgradeTest.java
@@ -18,11 +18,11 @@
 
 package org.apache.flink.graph.types.valuearray;
 
+import org.apache.flink.FlinkVersion;
 import org.apache.flink.api.common.typeutils.TypeSerializer;
 import org.apache.flink.api.common.typeutils.TypeSerializerMatchers;
 import org.apache.flink.api.common.typeutils.TypeSerializerSchemaCompatibility;
 import org.apache.flink.api.common.typeutils.TypeSerializerUpgradeTestBase;
-import org.apache.flink.testutils.migration.MigrationVersion;
 import org.apache.flink.types.ByteValue;
 import org.apache.flink.types.CharValue;
 import org.apache.flink.types.DoubleValue;
@@ -53,59 +53,59 @@ public class ValueArraySerializerUpgradeTest extends TypeSerializerUpgradeTestBa
     @Parameterized.Parameters(name = "Test Specification = {0}")
     public static Collection<TestSpecification<?, ?>> testSpecifications() throws Exception {
         ArrayList<TestSpecification<?, ?>> testSpecifications = new ArrayList<>();
-        for (MigrationVersion migrationVersion : MIGRATION_VERSIONS) {
+        for (FlinkVersion flinkVersion : MIGRATION_VERSIONS) {
             testSpecifications.add(
                     new TestSpecification<>(
                             "byte-value-array-serializer",
-                            migrationVersion,
+                            flinkVersion,
                             ByteValueArraySerializerSetup.class,
                             ByteValueArraySerializerVerifier.class));
             testSpecifications.add(
                     new TestSpecification<>(
                             "char-value-array-serializer",
-                            migrationVersion,
+                            flinkVersion,
                             CharValueArraySerializerSetup.class,
                             CharValueArraySerializerVerifier.class));
             testSpecifications.add(
                     new TestSpecification<>(
                             "double-value-array-serializer",
-                            migrationVersion,
+                            flinkVersion,
                             DoubleValueArraySerializerSetup.class,
                             DoubleValueArraySerializerVerifier.class));
             testSpecifications.add(
                     new TestSpecification<>(
                             "float-value-array-serializer",
-                            migrationVersion,
+                            flinkVersion,
                             FloatValueArraySerializerSetup.class,
                             FloatValueArraySerializerVerifier.class));
             testSpecifications.add(
                     new TestSpecification<>(
                             "int-value-array-serializer",
-                            migrationVersion,
+                            flinkVersion,
                             IntValueArraySerializerSetup.class,
                             IntValueArraySerializerVerifier.class));
             testSpecifications.add(
                     new TestSpecification<>(
                             "long-value-array-serializer",
-                            migrationVersion,
+                            flinkVersion,
                             LongValueArraySerializerSetup.class,
                             LongValueArraySerializerVerifier.class));
             testSpecifications.add(
                     new TestSpecification<>(
                             "null-value-array-serializer",
-                            migrationVersion,
+                            flinkVersion,
                             NullValueArraySerializerSetup.class,
                             NullValueArraySerializerVerifier.class));
             testSpecifications.add(
                     new TestSpecification<>(
                             "short-value-array-serializer",
-                            migrationVersion,
+                            flinkVersion,
                             ShortValueArraySerializerSetup.class,
                             ShortValueArraySerializerVerifier.class));
             testSpecifications.add(
                     new TestSpecification<>(
                             "string-value-array-serializer",
-                            migrationVersion,
+                            flinkVersion,
                             StringValueArraySerializerSetup.class,
                             StringValueArraySerializerVerifier.class));
         }
@@ -157,7 +157,7 @@ public class ValueArraySerializerUpgradeTest extends TypeSerializerUpgradeTestBa
 
         @Override
         public Matcher<TypeSerializerSchemaCompatibility<ByteValueArray>>
-                schemaCompatibilityMatcher(MigrationVersion version) {
+                schemaCompatibilityMatcher(FlinkVersion version) {
             return TypeSerializerMatchers.isCompatibleAsIs();
         }
     }
@@ -209,7 +209,7 @@ public class ValueArraySerializerUpgradeTest extends TypeSerializerUpgradeTestBa
 
         @Override
         public Matcher<TypeSerializerSchemaCompatibility<CharValueArray>>
-                schemaCompatibilityMatcher(MigrationVersion version) {
+                schemaCompatibilityMatcher(FlinkVersion version) {
             return TypeSerializerMatchers.isCompatibleAsIs();
         }
     }
@@ -259,7 +259,7 @@ public class ValueArraySerializerUpgradeTest extends TypeSerializerUpgradeTestBa
 
         @Override
         public Matcher<TypeSerializerSchemaCompatibility<DoubleValueArray>>
-                schemaCompatibilityMatcher(MigrationVersion version) {
+                schemaCompatibilityMatcher(FlinkVersion version) {
             return TypeSerializerMatchers.isCompatibleAsIs();
         }
     }
@@ -309,7 +309,7 @@ public class ValueArraySerializerUpgradeTest extends TypeSerializerUpgradeTestBa
 
         @Override
         public Matcher<TypeSerializerSchemaCompatibility<FloatValueArray>>
-                schemaCompatibilityMatcher(MigrationVersion version) {
+                schemaCompatibilityMatcher(FlinkVersion version) {
             return TypeSerializerMatchers.isCompatibleAsIs();
         }
     }
@@ -359,7 +359,7 @@ public class ValueArraySerializerUpgradeTest extends TypeSerializerUpgradeTestBa
 
         @Override
         public Matcher<TypeSerializerSchemaCompatibility<IntValueArray>> schemaCompatibilityMatcher(
-                MigrationVersion version) {
+                FlinkVersion version) {
             return TypeSerializerMatchers.isCompatibleAsIs();
         }
     }
@@ -409,7 +409,7 @@ public class ValueArraySerializerUpgradeTest extends TypeSerializerUpgradeTestBa
 
         @Override
         public Matcher<TypeSerializerSchemaCompatibility<LongValueArray>>
-                schemaCompatibilityMatcher(MigrationVersion version) {
+                schemaCompatibilityMatcher(FlinkVersion version) {
             return TypeSerializerMatchers.isCompatibleAsIs();
         }
     }
@@ -459,7 +459,7 @@ public class ValueArraySerializerUpgradeTest extends TypeSerializerUpgradeTestBa
 
         @Override
         public Matcher<TypeSerializerSchemaCompatibility<NullValueArray>>
-                schemaCompatibilityMatcher(MigrationVersion version) {
+                schemaCompatibilityMatcher(FlinkVersion version) {
             return TypeSerializerMatchers.isCompatibleAsIs();
         }
     }
@@ -509,7 +509,7 @@ public class ValueArraySerializerUpgradeTest extends TypeSerializerUpgradeTestBa
 
         @Override
         public Matcher<TypeSerializerSchemaCompatibility<ShortValueArray>>
-                schemaCompatibilityMatcher(MigrationVersion version) {
+                schemaCompatibilityMatcher(FlinkVersion version) {
             return TypeSerializerMatchers.isCompatibleAsIs();
         }
     }
@@ -559,7 +559,7 @@ public class ValueArraySerializerUpgradeTest extends TypeSerializerUpgradeTestBa
 
         @Override
         public Matcher<TypeSerializerSchemaCompatibility<StringValueArray>>
-                schemaCompatibilityMatcher(MigrationVersion version) {
+                schemaCompatibilityMatcher(FlinkVersion version) {
             return TypeSerializerMatchers.isCompatibleAsIs();
         }
     }

--- a/flink-runtime/src/test/java/org/apache/flink/runtime/state/ArrayListSerializerUpgradeTest.java
+++ b/flink-runtime/src/test/java/org/apache/flink/runtime/state/ArrayListSerializerUpgradeTest.java
@@ -18,12 +18,12 @@
 
 package org.apache.flink.runtime.state;
 
+import org.apache.flink.FlinkVersion;
 import org.apache.flink.api.common.typeutils.TypeSerializer;
 import org.apache.flink.api.common.typeutils.TypeSerializerMatchers;
 import org.apache.flink.api.common.typeutils.TypeSerializerSchemaCompatibility;
 import org.apache.flink.api.common.typeutils.TypeSerializerUpgradeTestBase;
 import org.apache.flink.api.common.typeutils.base.StringSerializer;
-import org.apache.flink.testutils.migration.MigrationVersion;
 
 import org.hamcrest.Matcher;
 import org.junit.runner.RunWith;
@@ -49,11 +49,11 @@ public class ArrayListSerializerUpgradeTest
     @Parameterized.Parameters(name = "Test Specification = {0}")
     public static Collection<TestSpecification<?, ?>> testSpecifications() throws Exception {
         ArrayList<TestSpecification<?, ?>> testSpecifications = new ArrayList<>();
-        for (MigrationVersion migrationVersion : MIGRATION_VERSIONS) {
+        for (FlinkVersion flinkVersion : MIGRATION_VERSIONS) {
             testSpecifications.add(
                     new TestSpecification<>(
                             SPEC_NAME,
-                            migrationVersion,
+                            flinkVersion,
                             ArrayListSerializerSetup.class,
                             ArrayListSerializerVerifier.class));
         }
@@ -105,7 +105,7 @@ public class ArrayListSerializerUpgradeTest
 
         @Override
         public Matcher<TypeSerializerSchemaCompatibility<ArrayList<String>>>
-                schemaCompatibilityMatcher(MigrationVersion version) {
+                schemaCompatibilityMatcher(FlinkVersion version) {
             return TypeSerializerMatchers.isCompatibleAsIs();
         }
     }

--- a/flink-runtime/src/test/java/org/apache/flink/runtime/state/JavaSerializerUpgradeTest.java
+++ b/flink-runtime/src/test/java/org/apache/flink/runtime/state/JavaSerializerUpgradeTest.java
@@ -18,11 +18,11 @@
 
 package org.apache.flink.runtime.state;
 
+import org.apache.flink.FlinkVersion;
 import org.apache.flink.api.common.typeutils.TypeSerializer;
 import org.apache.flink.api.common.typeutils.TypeSerializerMatchers;
 import org.apache.flink.api.common.typeutils.TypeSerializerSchemaCompatibility;
 import org.apache.flink.api.common.typeutils.TypeSerializerUpgradeTestBase;
-import org.apache.flink.testutils.migration.MigrationVersion;
 
 import org.hamcrest.Matcher;
 import org.junit.runner.RunWith;
@@ -51,11 +51,11 @@ public class JavaSerializerUpgradeTest
 
         ArrayList<TestSpecification<?, ?>> testSpecifications = new ArrayList<>();
 
-        for (MigrationVersion migrationVersion : MIGRATION_VERSIONS) {
+        for (FlinkVersion flinkVersion : MIGRATION_VERSIONS) {
             testSpecifications.add(
                     new TestSpecification<>(
                             SPEC_NAME,
-                            migrationVersion,
+                            flinkVersion,
                             JavaSerializerSetup.class,
                             JavaSerializerVerifier.class));
         }
@@ -102,7 +102,7 @@ public class JavaSerializerUpgradeTest
 
         @Override
         public Matcher<TypeSerializerSchemaCompatibility<Serializable>> schemaCompatibilityMatcher(
-                MigrationVersion version) {
+                FlinkVersion version) {
             return TypeSerializerMatchers.isCompatibleAsIs();
         }
     }

--- a/flink-runtime/src/test/java/org/apache/flink/runtime/state/VoidNamespaceSerializerUpgradeTest.java
+++ b/flink-runtime/src/test/java/org/apache/flink/runtime/state/VoidNamespaceSerializerUpgradeTest.java
@@ -18,11 +18,11 @@
 
 package org.apache.flink.runtime.state;
 
+import org.apache.flink.FlinkVersion;
 import org.apache.flink.api.common.typeutils.TypeSerializer;
 import org.apache.flink.api.common.typeutils.TypeSerializerMatchers;
 import org.apache.flink.api.common.typeutils.TypeSerializerSchemaCompatibility;
 import org.apache.flink.api.common.typeutils.TypeSerializerUpgradeTestBase;
-import org.apache.flink.testutils.migration.MigrationVersion;
 
 import org.hamcrest.Matcher;
 import org.junit.runner.RunWith;
@@ -49,11 +49,11 @@ public class VoidNamespaceSerializerUpgradeTest
     public static Collection<TestSpecification<?, ?>> testSpecifications() throws Exception {
 
         ArrayList<TestSpecification<?, ?>> testSpecifications = new ArrayList<>();
-        for (MigrationVersion migrationVersion : MIGRATION_VERSIONS) {
+        for (FlinkVersion flinkVersion : MIGRATION_VERSIONS) {
             testSpecifications.add(
                     new TestSpecification<>(
                             SPEC_NAME,
-                            migrationVersion,
+                            flinkVersion,
                             VoidNamespaceSerializerSetup.class,
                             VoidNamespaceSerializerVerifier.class));
         }
@@ -99,7 +99,7 @@ public class VoidNamespaceSerializerUpgradeTest
 
         @Override
         public Matcher<TypeSerializerSchemaCompatibility<VoidNamespace>> schemaCompatibilityMatcher(
-                MigrationVersion version) {
+                FlinkVersion version) {
             return TypeSerializerMatchers.isCompatibleAsIs();
         }
     }

--- a/flink-runtime/src/test/java/org/apache/flink/runtime/state/ttl/TtlSerializerUpgradeTest.java
+++ b/flink-runtime/src/test/java/org/apache/flink/runtime/state/ttl/TtlSerializerUpgradeTest.java
@@ -18,6 +18,7 @@
 
 package org.apache.flink.runtime.state.ttl;
 
+import org.apache.flink.FlinkVersion;
 import org.apache.flink.api.common.typeutils.TypeSerializer;
 import org.apache.flink.api.common.typeutils.TypeSerializerMatchers;
 import org.apache.flink.api.common.typeutils.TypeSerializerSchemaCompatibility;
@@ -25,7 +26,6 @@ import org.apache.flink.api.common.typeutils.TypeSerializerUpgradeTestBase;
 import org.apache.flink.api.common.typeutils.base.LongSerializer;
 import org.apache.flink.api.common.typeutils.base.StringSerializer;
 import org.apache.flink.runtime.state.ttl.TtlStateFactory.TtlSerializer;
-import org.apache.flink.testutils.migration.MigrationVersion;
 
 import org.hamcrest.Matcher;
 import org.junit.runner.RunWith;
@@ -51,11 +51,11 @@ public class TtlSerializerUpgradeTest
     public static Collection<TestSpecification<?, ?>> testSpecifications() throws Exception {
 
         ArrayList<TestSpecification<?, ?>> testSpecifications = new ArrayList<>();
-        for (MigrationVersion migrationVersion : MIGRATION_VERSIONS) {
+        for (FlinkVersion flinkVersion : MIGRATION_VERSIONS) {
             testSpecifications.add(
                     new TestSpecification<>(
                             "ttl-serializer",
-                            migrationVersion,
+                            flinkVersion,
                             TtlSerializerSetup.class,
                             TtlSerializerVerifier.class));
         }
@@ -96,7 +96,7 @@ public class TtlSerializerUpgradeTest
 
         @Override
         public Matcher<TypeSerializerSchemaCompatibility<TtlValue<String>>>
-                schemaCompatibilityMatcher(MigrationVersion version) {
+                schemaCompatibilityMatcher(FlinkVersion version) {
             return TypeSerializerMatchers.isCompatibleAsIs();
         }
     }

--- a/flink-scala/src/test/java/org/apache/flink/api/scala/typeutils/OptionSerializerUpgradeTest.java
+++ b/flink-scala/src/test/java/org/apache/flink/api/scala/typeutils/OptionSerializerUpgradeTest.java
@@ -18,12 +18,12 @@
 
 package org.apache.flink.api.scala.typeutils;
 
+import org.apache.flink.FlinkVersion;
 import org.apache.flink.api.common.typeutils.TypeSerializer;
 import org.apache.flink.api.common.typeutils.TypeSerializerMatchers;
 import org.apache.flink.api.common.typeutils.TypeSerializerSchemaCompatibility;
 import org.apache.flink.api.common.typeutils.TypeSerializerUpgradeTestBase;
 import org.apache.flink.api.common.typeutils.base.StringSerializer;
-import org.apache.flink.testutils.migration.MigrationVersion;
 
 import org.hamcrest.Matcher;
 import org.junit.runner.RunWith;
@@ -55,11 +55,11 @@ public class OptionSerializerUpgradeTest
     public static Collection<TestSpecification<?, ?>> testSpecifications() throws Exception {
 
         ArrayList<TestSpecification<?, ?>> testSpecifications = new ArrayList<>();
-        for (MigrationVersion migrationVersion : MIGRATION_VERSIONS) {
+        for (FlinkVersion flinkVersion : MIGRATION_VERSIONS) {
             testSpecifications.add(
                     new TestSpecification<>(
                             SPEC_NAME,
-                            migrationVersion,
+                            flinkVersion,
                             ScalaOptionSerializerSetup.class,
                             ScalaOptionSerializerVerifier.class));
         }
@@ -105,7 +105,7 @@ public class OptionSerializerUpgradeTest
 
         @Override
         public Matcher<TypeSerializerSchemaCompatibility<Option<String>>>
-                schemaCompatibilityMatcher(MigrationVersion version) {
+                schemaCompatibilityMatcher(FlinkVersion version) {
             return TypeSerializerMatchers.isCompatibleAsIs();
         }
     }

--- a/flink-scala/src/test/java/org/apache/flink/api/scala/typeutils/ScalaEitherSerializerUpgradeTest.java
+++ b/flink-scala/src/test/java/org/apache/flink/api/scala/typeutils/ScalaEitherSerializerUpgradeTest.java
@@ -18,13 +18,13 @@
 
 package org.apache.flink.api.scala.typeutils;
 
+import org.apache.flink.FlinkVersion;
 import org.apache.flink.api.common.typeutils.TypeSerializer;
 import org.apache.flink.api.common.typeutils.TypeSerializerMatchers;
 import org.apache.flink.api.common.typeutils.TypeSerializerSchemaCompatibility;
 import org.apache.flink.api.common.typeutils.TypeSerializerUpgradeTestBase;
 import org.apache.flink.api.common.typeutils.base.IntSerializer;
 import org.apache.flink.api.common.typeutils.base.StringSerializer;
-import org.apache.flink.testutils.migration.MigrationVersion;
 
 import org.hamcrest.Matcher;
 import org.junit.runner.RunWith;
@@ -54,11 +54,11 @@ public class ScalaEitherSerializerUpgradeTest
     public static Collection<TestSpecification<?, ?>> testSpecifications() throws Exception {
 
         ArrayList<TestSpecification<?, ?>> testSpecifications = new ArrayList<>();
-        for (MigrationVersion migrationVersion : MIGRATION_VERSIONS) {
+        for (FlinkVersion flinkVersion : MIGRATION_VERSIONS) {
             testSpecifications.add(
                     new TestSpecification<>(
                             SPEC_NAME,
-                            migrationVersion,
+                            flinkVersion,
                             EitherSerializerSetup.class,
                             EitherSerializerVerifier.class));
         }
@@ -104,7 +104,7 @@ public class ScalaEitherSerializerUpgradeTest
 
         @Override
         public Matcher<TypeSerializerSchemaCompatibility<Either<Integer, String>>>
-                schemaCompatibilityMatcher(MigrationVersion version) {
+                schemaCompatibilityMatcher(FlinkVersion version) {
             return TypeSerializerMatchers.isCompatibleAsIs();
         }
     }

--- a/flink-scala/src/test/java/org/apache/flink/api/scala/typeutils/ScalaTrySerializerUpgradeTest.java
+++ b/flink-scala/src/test/java/org/apache/flink/api/scala/typeutils/ScalaTrySerializerUpgradeTest.java
@@ -18,13 +18,13 @@
 
 package org.apache.flink.api.scala.typeutils;
 
+import org.apache.flink.FlinkVersion;
 import org.apache.flink.api.common.ExecutionConfig;
 import org.apache.flink.api.common.typeutils.TypeSerializer;
 import org.apache.flink.api.common.typeutils.TypeSerializerMatchers;
 import org.apache.flink.api.common.typeutils.TypeSerializerSchemaCompatibility;
 import org.apache.flink.api.common.typeutils.TypeSerializerUpgradeTestBase;
 import org.apache.flink.api.common.typeutils.base.StringSerializer;
-import org.apache.flink.testutils.migration.MigrationVersion;
 
 import org.hamcrest.Matcher;
 import org.junit.runner.RunWith;
@@ -55,11 +55,11 @@ public class ScalaTrySerializerUpgradeTest
     public static Collection<TestSpecification<?, ?>> testSpecifications() throws Exception {
 
         ArrayList<TestSpecification<?, ?>> testSpecifications = new ArrayList<>();
-        for (MigrationVersion migrationVersion : MIGRATION_VERSIONS) {
+        for (FlinkVersion flinkVersion : MIGRATION_VERSIONS) {
             testSpecifications.add(
                     new TestSpecification<>(
                             SPEC_NAME,
-                            migrationVersion,
+                            flinkVersion,
                             ScalaTrySerializerSetup.class,
                             ScalaTrySerializerVerifier.class));
         }
@@ -106,7 +106,7 @@ public class ScalaTrySerializerUpgradeTest
 
         @Override
         public Matcher<TypeSerializerSchemaCompatibility<Try<String>>> schemaCompatibilityMatcher(
-                MigrationVersion version) {
+                FlinkVersion version) {
             return TypeSerializerMatchers.isCompatibleAsIs();
         }
     }

--- a/flink-scala/src/test/scala/org/apache/flink/api/scala/typeutils/EnumValueSerializerUpgradeTest.scala
+++ b/flink-scala/src/test/scala/org/apache/flink/api/scala/typeutils/EnumValueSerializerUpgradeTest.scala
@@ -18,11 +18,12 @@
 
 package org.apache.flink.api.scala.typeutils
 
-import java.util
+import org.apache.flink.FlinkVersion
 
+import java.util
 import org.apache.flink.api.common.typeutils.TypeSerializerUpgradeTestBase.TestSpecification
 import org.apache.flink.api.common.typeutils.{TypeSerializer, TypeSerializerMatchers, TypeSerializerSchemaCompatibility, TypeSerializerUpgradeTestBase}
-import org.apache.flink.testutils.migration.MigrationVersion
+
 import org.hamcrest.Matcher
 import org.hamcrest.Matchers.is
 import org.junit.runner.RunWith
@@ -78,7 +79,7 @@ object EnumValueSerializerUpgradeTest {
 
     override def testDataMatcher: Matcher[Letters.Value] = is(Letters.A)
 
-    override def schemaCompatibilityMatcher(version: MigrationVersion):
+    override def schemaCompatibilityMatcher(version: FlinkVersion):
         Matcher[TypeSerializerSchemaCompatibility[Letters.Value]] =
       TypeSerializerMatchers.isCompatibleAsIs[Letters.Value]()
   }

--- a/flink-scala/src/test/scala/org/apache/flink/api/scala/typeutils/ScalaCaseClassSerializerUpgradeTest.scala
+++ b/flink-scala/src/test/scala/org/apache/flink/api/scala/typeutils/ScalaCaseClassSerializerUpgradeTest.scala
@@ -18,14 +18,15 @@
 
 package org.apache.flink.api.scala.typeutils
 
-import java.util
+import org.apache.flink.FlinkVersion
 
+import java.util
 import org.apache.flink.api.common.ExecutionConfig
 import org.apache.flink.api.common.typeutils.TypeSerializerUpgradeTestBase.TestSpecification
 import org.apache.flink.api.common.typeutils.{TypeSerializer, TypeSerializerMatchers, TypeSerializerSchemaCompatibility, TypeSerializerUpgradeTestBase}
 import org.apache.flink.api.scala.createTypeInformation
 import org.apache.flink.api.scala.types.CustomCaseClass
-import org.apache.flink.testutils.migration.MigrationVersion
+
 import org.hamcrest.Matcher
 import org.hamcrest.Matchers.is
 import org.junit.runner.RunWith
@@ -82,7 +83,7 @@ object ScalaCaseClassSerializerUpgradeTest {
 
     override def testDataMatcher: Matcher[CustomCaseClass] = is(CustomCaseClass("flink", 11))
 
-    override def schemaCompatibilityMatcher(version: MigrationVersion):
+    override def schemaCompatibilityMatcher(version: FlinkVersion):
         Matcher[TypeSerializerSchemaCompatibility[CustomCaseClass]] =
       TypeSerializerMatchers.isCompatibleAsIs[CustomCaseClass]()
   }

--- a/flink-scala/src/test/scala/org/apache/flink/api/scala/typeutils/TraversableSerializerUpgradeTest.scala
+++ b/flink-scala/src/test/scala/org/apache/flink/api/scala/typeutils/TraversableSerializerUpgradeTest.scala
@@ -18,15 +18,16 @@
 
 package org.apache.flink.api.scala.typeutils
 
+import org.apache.flink.FlinkVersion
+
 import java.util
 import java.util.function.Supplier
-
 import org.apache.flink.api.common.ExecutionConfig
 import org.apache.flink.api.common.typeinfo.TypeInformation
 import org.apache.flink.api.common.typeutils.TypeSerializerUpgradeTestBase.TestSpecification
 import org.apache.flink.api.common.typeutils.{TypeSerializer, TypeSerializerMatchers, TypeSerializerSchemaCompatibility, TypeSerializerUpgradeTestBase}
 import org.apache.flink.api.scala.createTypeInformation
-import org.apache.flink.testutils.migration.MigrationVersion
+
 import org.hamcrest.Matcher
 import org.hamcrest.Matchers.is
 import org.junit.runner.RunWith
@@ -151,7 +152,7 @@ object TraversableSerializerUpgradeTest {
 
     override def testDataMatcher: Matcher[BitSet] = is(BitSet(3, 2, 0))
 
-    override def schemaCompatibilityMatcher(version: MigrationVersion):
+    override def schemaCompatibilityMatcher(version: FlinkVersion):
     Matcher[TypeSerializerSchemaCompatibility[BitSet]] =
       TypeSerializerMatchers.isCompatibleAsIs[BitSet]()
   }
@@ -171,7 +172,7 @@ object TraversableSerializerUpgradeTest {
 
     override def testDataMatcher: Matcher[IndexedSeq[Int]] = is(IndexedSeq(1, 2, 3))
 
-    override def schemaCompatibilityMatcher(version: MigrationVersion):
+    override def schemaCompatibilityMatcher(version: FlinkVersion):
     Matcher[TypeSerializerSchemaCompatibility[IndexedSeq[Int]]] =
       TypeSerializerMatchers.isCompatibleAsIs[IndexedSeq[Int]]()
   }
@@ -191,7 +192,7 @@ object TraversableSerializerUpgradeTest {
 
     override def testDataMatcher: Matcher[LinearSeq[Int]] = is(LinearSeq(2, 3, 4))
 
-    override def schemaCompatibilityMatcher(version: MigrationVersion):
+    override def schemaCompatibilityMatcher(version: FlinkVersion):
     Matcher[TypeSerializerSchemaCompatibility[LinearSeq[Int]]] =
       TypeSerializerMatchers.isCompatibleAsIs[LinearSeq[Int]]()
   }
@@ -211,7 +212,7 @@ object TraversableSerializerUpgradeTest {
 
     override def testDataMatcher: Matcher[Map[String, Int]] = is(Map("Apache" -> 0, "Flink" -> 1))
 
-    override def schemaCompatibilityMatcher(version: MigrationVersion):
+    override def schemaCompatibilityMatcher(version: FlinkVersion):
     Matcher[TypeSerializerSchemaCompatibility[Map[String, Int]]] =
       TypeSerializerMatchers.isCompatibleAsIs[Map[String, Int]]()
   }
@@ -232,7 +233,7 @@ object TraversableSerializerUpgradeTest {
     override def testDataMatcher: Matcher[mutable.MutableList[Int]] =
       is(mutable.MutableList(1, 2, 3))
 
-    override def schemaCompatibilityMatcher(version: MigrationVersion):
+    override def schemaCompatibilityMatcher(version: FlinkVersion):
     Matcher[TypeSerializerSchemaCompatibility[mutable.MutableList[Int]]] =
       TypeSerializerMatchers.isCompatibleAsIs[mutable.MutableList[Int]]()
   }
@@ -251,7 +252,7 @@ object TraversableSerializerUpgradeTest {
 
     override def testDataMatcher: Matcher[Seq[Int]] = is(Seq(1, 2, 3))
 
-    override def schemaCompatibilityMatcher(version: MigrationVersion):
+    override def schemaCompatibilityMatcher(version: FlinkVersion):
         Matcher[TypeSerializerSchemaCompatibility[Seq[Int]]] =
       TypeSerializerMatchers.isCompatibleAsIs[Seq[Int]]()
   }
@@ -270,7 +271,7 @@ object TraversableSerializerUpgradeTest {
 
     override def testDataMatcher: Matcher[Set[Int]] = is(Set(2, 3, 4))
 
-    override def schemaCompatibilityMatcher(version: MigrationVersion):
+    override def schemaCompatibilityMatcher(version: FlinkVersion):
         Matcher[TypeSerializerSchemaCompatibility[Set[Int]]] =
       TypeSerializerMatchers.isCompatibleAsIs[Set[Int]]()
   }
@@ -290,7 +291,7 @@ object TraversableSerializerUpgradeTest {
 
     override def testDataMatcher: Matcher[Seq[(Int, String)]] = is(Seq((0, "Apache"), (1, "Flink")))
 
-    override def schemaCompatibilityMatcher(version: MigrationVersion):
+    override def schemaCompatibilityMatcher(version: FlinkVersion):
     Matcher[TypeSerializerSchemaCompatibility[Seq[(Int, String)]]] =
       TypeSerializerMatchers.isCompatibleAsIs[Seq[(Int, String)]]()
   }
@@ -309,7 +310,7 @@ object TraversableSerializerUpgradeTest {
     override def testDataMatcher: Matcher[Seq[Pojo]] =
       is(Seq(new Pojo("Apache", 0), new Pojo("Flink", 1)))
 
-    override def schemaCompatibilityMatcher(version: MigrationVersion):
+    override def schemaCompatibilityMatcher(version: FlinkVersion):
     Matcher[TypeSerializerSchemaCompatibility[Seq[Pojo]]] =
       TypeSerializerMatchers.isCompatibleAsIs[Seq[Pojo]]()
   }

--- a/flink-streaming-java/src/test/java/org/apache/flink/streaming/api/datastream/UnionSerializerUpgradeTest.java
+++ b/flink-streaming-java/src/test/java/org/apache/flink/streaming/api/datastream/UnionSerializerUpgradeTest.java
@@ -18,6 +18,7 @@
 
 package org.apache.flink.streaming.api.datastream;
 
+import org.apache.flink.FlinkVersion;
 import org.apache.flink.api.common.typeutils.TypeSerializer;
 import org.apache.flink.api.common.typeutils.TypeSerializerMatchers;
 import org.apache.flink.api.common.typeutils.TypeSerializerSchemaCompatibility;
@@ -26,7 +27,6 @@ import org.apache.flink.api.common.typeutils.base.LongSerializer;
 import org.apache.flink.api.common.typeutils.base.StringSerializer;
 import org.apache.flink.streaming.api.datastream.CoGroupedStreams.TaggedUnion;
 import org.apache.flink.streaming.api.datastream.CoGroupedStreams.UnionSerializer;
-import org.apache.flink.testutils.migration.MigrationVersion;
 
 import org.hamcrest.Matcher;
 import org.junit.runner.RunWith;
@@ -52,17 +52,17 @@ public class UnionSerializerUpgradeTest
     @Parameterized.Parameters(name = "Test Specification = {0}")
     public static Collection<TestSpecification<?, ?>> testSpecifications() throws Exception {
         ArrayList<TestSpecification<?, ?>> testSpecifications = new ArrayList<>();
-        for (MigrationVersion migrationVersion : MIGRATION_VERSIONS) {
+        for (FlinkVersion flinkVersion : MIGRATION_VERSIONS) {
             testSpecifications.add(
                     new TestSpecification<>(
                             "union-serializer-one",
-                            migrationVersion,
+                            flinkVersion,
                             UnionSerializerOneSetup.class,
                             UnionSerializerOneVerifier.class));
             testSpecifications.add(
                     new TestSpecification<>(
                             "union-serializer-two",
-                            migrationVersion,
+                            flinkVersion,
                             UnionSerializerTwoSetup.class,
                             UnionSerializerTwoVerifier.class));
         }
@@ -112,7 +112,7 @@ public class UnionSerializerUpgradeTest
 
         @Override
         public Matcher<TypeSerializerSchemaCompatibility<TaggedUnion<String, Long>>>
-                schemaCompatibilityMatcher(MigrationVersion version) {
+                schemaCompatibilityMatcher(FlinkVersion version) {
             return TypeSerializerMatchers.isCompatibleAsIs();
         }
     }
@@ -156,7 +156,7 @@ public class UnionSerializerUpgradeTest
 
         @Override
         public Matcher<TypeSerializerSchemaCompatibility<TaggedUnion<String, Long>>>
-                schemaCompatibilityMatcher(MigrationVersion version) {
+                schemaCompatibilityMatcher(FlinkVersion version) {
             return TypeSerializerMatchers.isCompatibleAsIs();
         }
     }

--- a/flink-streaming-java/src/test/java/org/apache/flink/streaming/api/functions/sink/TwoPhaseCommitSinkStateSerializerUpgradeTest.java
+++ b/flink-streaming-java/src/test/java/org/apache/flink/streaming/api/functions/sink/TwoPhaseCommitSinkStateSerializerUpgradeTest.java
@@ -17,13 +17,13 @@
 
 package org.apache.flink.streaming.api.functions.sink;
 
+import org.apache.flink.FlinkVersion;
 import org.apache.flink.api.common.typeutils.TypeSerializer;
 import org.apache.flink.api.common.typeutils.TypeSerializerMatchers;
 import org.apache.flink.api.common.typeutils.TypeSerializerSchemaCompatibility;
 import org.apache.flink.api.common.typeutils.TypeSerializerUpgradeTestBase;
 import org.apache.flink.api.common.typeutils.base.IntSerializer;
 import org.apache.flink.api.common.typeutils.base.StringSerializer;
-import org.apache.flink.testutils.migration.MigrationVersion;
 
 import org.hamcrest.Matcher;
 import org.junit.runner.RunWith;
@@ -57,11 +57,11 @@ public class TwoPhaseCommitSinkStateSerializerUpgradeTest
     public static Collection<TestSpecification<?, ?>> testSpecifications() throws Exception {
 
         ArrayList<TestSpecification<?, ?>> testSpecifications = new ArrayList<>();
-        for (MigrationVersion migrationVersion : MIGRATION_VERSIONS) {
+        for (FlinkVersion flinkVersion : MIGRATION_VERSIONS) {
             testSpecifications.add(
                     new TestSpecification<>(
                             "two-phase-commit-sink-state-serializer",
-                            migrationVersion,
+                            flinkVersion,
                             TwoPhaseCommitSinkStateSerializerSetup.class,
                             TwoPhaseCommitSinkStateSerializerVerifier.class));
         }
@@ -129,8 +129,8 @@ public class TwoPhaseCommitSinkStateSerializerUpgradeTest
         public Matcher<
                         TypeSerializerSchemaCompatibility<
                                 TwoPhaseCommitSinkFunction.State<Integer, String>>>
-                schemaCompatibilityMatcher(MigrationVersion version) {
-            if (version.isNewerVersionThan(MigrationVersion.v1_13)) {
+                schemaCompatibilityMatcher(FlinkVersion version) {
+            if (version.isNewerVersionThan(FlinkVersion.v1_13)) {
                 return TypeSerializerMatchers.isCompatibleAsIs();
             } else {
                 return TypeSerializerMatchers.isCompatibleAfterMigration();

--- a/flink-streaming-java/src/test/java/org/apache/flink/streaming/api/operators/TimerSerializerUpgradeTest.java
+++ b/flink-streaming-java/src/test/java/org/apache/flink/streaming/api/operators/TimerSerializerUpgradeTest.java
@@ -17,13 +17,13 @@
 
 package org.apache.flink.streaming.api.operators;
 
+import org.apache.flink.FlinkVersion;
 import org.apache.flink.api.common.typeutils.TypeSerializer;
 import org.apache.flink.api.common.typeutils.TypeSerializerMatchers;
 import org.apache.flink.api.common.typeutils.TypeSerializerSchemaCompatibility;
 import org.apache.flink.api.common.typeutils.TypeSerializerUpgradeTestBase;
 import org.apache.flink.api.common.typeutils.base.IntSerializer;
 import org.apache.flink.api.common.typeutils.base.StringSerializer;
-import org.apache.flink.testutils.migration.MigrationVersion;
 
 import org.hamcrest.Matcher;
 import org.junit.runner.RunWith;
@@ -53,11 +53,11 @@ public class TimerSerializerUpgradeTest
     public static Collection<TestSpecification<?, ?>> testSpecifications() throws Exception {
 
         ArrayList<TestSpecification<?, ?>> testSpecifications = new ArrayList<>();
-        for (MigrationVersion migrationVersion : MIGRATION_VERSIONS) {
+        for (FlinkVersion flinkVersion : MIGRATION_VERSIONS) {
             testSpecifications.add(
                     new TestSpecification<>(
                             "timer-serializer",
-                            migrationVersion,
+                            flinkVersion,
                             TimerSerializerSetup.class,
                             TimerSerializerVerifier.class));
         }
@@ -110,7 +110,7 @@ public class TimerSerializerUpgradeTest
 
         @Override
         public Matcher<TypeSerializerSchemaCompatibility<TimerHeapInternalTimer<String, Integer>>>
-                schemaCompatibilityMatcher(MigrationVersion version) {
+                schemaCompatibilityMatcher(FlinkVersion version) {
             return TypeSerializerMatchers.isCompatibleAsIs();
         }
     }

--- a/flink-streaming-java/src/test/java/org/apache/flink/streaming/api/operators/co/BufferEntrySerializerUpgradeTest.java
+++ b/flink-streaming-java/src/test/java/org/apache/flink/streaming/api/operators/co/BufferEntrySerializerUpgradeTest.java
@@ -18,6 +18,7 @@
 
 package org.apache.flink.streaming.api.operators.co;
 
+import org.apache.flink.FlinkVersion;
 import org.apache.flink.api.common.typeutils.TypeSerializer;
 import org.apache.flink.api.common.typeutils.TypeSerializerMatchers;
 import org.apache.flink.api.common.typeutils.TypeSerializerSchemaCompatibility;
@@ -25,7 +26,6 @@ import org.apache.flink.api.common.typeutils.TypeSerializerUpgradeTestBase;
 import org.apache.flink.api.common.typeutils.base.StringSerializer;
 import org.apache.flink.streaming.api.operators.co.IntervalJoinOperator.BufferEntry;
 import org.apache.flink.streaming.api.operators.co.IntervalJoinOperator.BufferEntrySerializer;
-import org.apache.flink.testutils.migration.MigrationVersion;
 
 import org.hamcrest.Matcher;
 import org.junit.runner.RunWith;
@@ -51,11 +51,11 @@ public class BufferEntrySerializerUpgradeTest
     public static Collection<TestSpecification<?, ?>> testSpecifications() throws Exception {
 
         ArrayList<TestSpecification<?, ?>> testSpecifications = new ArrayList<>();
-        for (MigrationVersion migrationVersion : MIGRATION_VERSIONS) {
+        for (FlinkVersion flinkVersion : MIGRATION_VERSIONS) {
             testSpecifications.add(
                     new TestSpecification<>(
                             "buffer-entry-serializer",
-                            migrationVersion,
+                            flinkVersion,
                             BufferEntrySerializerSetup.class,
                             BufferEntrySerializerVerifier.class));
         }
@@ -106,7 +106,7 @@ public class BufferEntrySerializerUpgradeTest
 
         @Override
         public Matcher<TypeSerializerSchemaCompatibility<BufferEntry<String>>>
-                schemaCompatibilityMatcher(MigrationVersion version) {
+                schemaCompatibilityMatcher(FlinkVersion version) {
             return TypeSerializerMatchers.isCompatibleAsIs();
         }
     }

--- a/flink-streaming-java/src/test/java/org/apache/flink/streaming/runtime/operators/windowing/WindowOperatorMigrationTest.java
+++ b/flink-streaming-java/src/test/java/org/apache/flink/streaming/runtime/operators/windowing/WindowOperatorMigrationTest.java
@@ -18,6 +18,7 @@
 
 package org.apache.flink.streaming.runtime.operators.windowing;
 
+import org.apache.flink.FlinkVersion;
 import org.apache.flink.api.common.ExecutionConfig;
 import org.apache.flink.api.common.functions.ReduceFunction;
 import org.apache.flink.api.common.state.ListStateDescriptor;
@@ -53,7 +54,6 @@ import org.apache.flink.streaming.util.KeyedOneInputStreamOperatorTestHarness;
 import org.apache.flink.streaming.util.OneInputStreamOperatorTestHarness;
 import org.apache.flink.streaming.util.OperatorSnapshotUtil;
 import org.apache.flink.streaming.util.TestHarnessUtil;
-import org.apache.flink.testutils.migration.MigrationVersion;
 import org.apache.flink.util.Collector;
 
 import org.junit.Ignore;
@@ -84,20 +84,20 @@ import static org.junit.Assert.fail;
 public class WindowOperatorMigrationTest {
 
     @Parameterized.Parameters(name = "Migration Savepoint: {0}")
-    public static Collection<MigrationVersion> parameters() {
+    public static Collection<FlinkVersion> parameters() {
         return Arrays.asList(
-                MigrationVersion.v1_3,
-                MigrationVersion.v1_4,
-                MigrationVersion.v1_5,
-                MigrationVersion.v1_6,
-                MigrationVersion.v1_7,
-                MigrationVersion.v1_8,
-                MigrationVersion.v1_9,
-                MigrationVersion.v1_10,
-                MigrationVersion.v1_11,
-                MigrationVersion.v1_12,
-                MigrationVersion.v1_13,
-                MigrationVersion.v1_14);
+                FlinkVersion.v1_3,
+                FlinkVersion.v1_4,
+                FlinkVersion.v1_5,
+                FlinkVersion.v1_6,
+                FlinkVersion.v1_7,
+                FlinkVersion.v1_8,
+                FlinkVersion.v1_9,
+                FlinkVersion.v1_10,
+                FlinkVersion.v1_11,
+                FlinkVersion.v1_12,
+                FlinkVersion.v1_13,
+                FlinkVersion.v1_14);
     }
 
     private static final TypeInformation<Tuple2<String, Integer>> STRING_INT_TUPLE =
@@ -105,15 +105,15 @@ public class WindowOperatorMigrationTest {
 
     /**
      * TODO change this to the corresponding savepoint version to be written (e.g. {@link
-     * MigrationVersion#v1_3} for 1.3) TODO and remove all @Ignore annotations on write*Snapshot()
+     * FlinkVersion#v1_3} for 1.3) TODO and remove all @Ignore annotations on write*Snapshot()
      * methods to generate savepoints TODO Note: You should generate the savepoint based on the
      * release branch instead of the master.
      */
-    private final MigrationVersion flinkGenerateSavepointVersion = null;
+    private final FlinkVersion flinkGenerateSavepointVersion = null;
 
-    private final MigrationVersion testMigrateVersion;
+    private final FlinkVersion testMigrateVersion;
 
-    public WindowOperatorMigrationTest(MigrationVersion testMigrateVersion) {
+    public WindowOperatorMigrationTest(FlinkVersion testMigrateVersion) {
         this.testMigrateVersion = testMigrateVersion;
     }
 

--- a/flink-streaming-java/src/test/java/org/apache/flink/streaming/runtime/operators/windowing/WindowSerializerUpgradeTest.java
+++ b/flink-streaming-java/src/test/java/org/apache/flink/streaming/runtime/operators/windowing/WindowSerializerUpgradeTest.java
@@ -18,13 +18,13 @@
 
 package org.apache.flink.streaming.runtime.operators.windowing;
 
+import org.apache.flink.FlinkVersion;
 import org.apache.flink.api.common.typeutils.TypeSerializer;
 import org.apache.flink.api.common.typeutils.TypeSerializerMatchers;
 import org.apache.flink.api.common.typeutils.TypeSerializerSchemaCompatibility;
 import org.apache.flink.api.common.typeutils.TypeSerializerUpgradeTestBase;
 import org.apache.flink.streaming.api.windowing.windows.GlobalWindow;
 import org.apache.flink.streaming.api.windowing.windows.TimeWindow;
-import org.apache.flink.testutils.migration.MigrationVersion;
 
 import org.hamcrest.Matcher;
 import org.junit.runner.RunWith;
@@ -50,17 +50,17 @@ public class WindowSerializerUpgradeTest extends TypeSerializerUpgradeTestBase<O
     public static Collection<TestSpecification<?, ?>> testSpecifications() throws Exception {
 
         ArrayList<TestSpecification<?, ?>> testSpecifications = new ArrayList<>();
-        for (MigrationVersion migrationVersion : MIGRATION_VERSIONS) {
+        for (FlinkVersion flinkVersion : MIGRATION_VERSIONS) {
             testSpecifications.add(
                     new TestSpecification<>(
                             "time-window-serializer",
-                            migrationVersion,
+                            flinkVersion,
                             TimeWindowSerializerSetup.class,
                             TimeWindowSerializerVerifier.class));
             testSpecifications.add(
                     new TestSpecification<>(
                             "global-window-serializer",
-                            migrationVersion,
+                            flinkVersion,
                             GlobalWindowSerializerSetup.class,
                             GlobalWindowSerializerVerifier.class));
         }
@@ -105,7 +105,7 @@ public class WindowSerializerUpgradeTest extends TypeSerializerUpgradeTestBase<O
 
         @Override
         public Matcher<TypeSerializerSchemaCompatibility<TimeWindow>> schemaCompatibilityMatcher(
-                MigrationVersion version) {
+                FlinkVersion version) {
             return TypeSerializerMatchers.isCompatibleAsIs();
         }
     }
@@ -148,7 +148,7 @@ public class WindowSerializerUpgradeTest extends TypeSerializerUpgradeTestBase<O
 
         @Override
         public Matcher<TypeSerializerSchemaCompatibility<GlobalWindow>> schemaCompatibilityMatcher(
-                MigrationVersion version) {
+                FlinkVersion version) {
             return TypeSerializerMatchers.isCompatibleAsIs();
         }
     }

--- a/flink-streaming-java/src/test/java/org/apache/flink/streaming/runtime/streamrecord/StreamElementSerializerUpgradeTest.java
+++ b/flink-streaming-java/src/test/java/org/apache/flink/streaming/runtime/streamrecord/StreamElementSerializerUpgradeTest.java
@@ -18,12 +18,12 @@
 
 package org.apache.flink.streaming.runtime.streamrecord;
 
+import org.apache.flink.FlinkVersion;
 import org.apache.flink.api.common.typeutils.TypeSerializer;
 import org.apache.flink.api.common.typeutils.TypeSerializerMatchers;
 import org.apache.flink.api.common.typeutils.TypeSerializerSchemaCompatibility;
 import org.apache.flink.api.common.typeutils.TypeSerializerUpgradeTestBase;
 import org.apache.flink.api.common.typeutils.base.StringSerializer;
-import org.apache.flink.testutils.migration.MigrationVersion;
 
 import org.hamcrest.Matcher;
 import org.junit.runner.RunWith;
@@ -49,11 +49,11 @@ public class StreamElementSerializerUpgradeTest
     public static Collection<TestSpecification<?, ?>> testSpecifications() throws Exception {
 
         ArrayList<TestSpecification<?, ?>> testSpecifications = new ArrayList<>();
-        for (MigrationVersion migrationVersion : MIGRATION_VERSIONS) {
+        for (FlinkVersion flinkVersion : MIGRATION_VERSIONS) {
             testSpecifications.add(
                     new TestSpecification<>(
                             "stream-element-serializer",
-                            migrationVersion,
+                            flinkVersion,
                             StreamElementSetup.class,
                             StreamElementVerifier.class));
         }
@@ -101,7 +101,7 @@ public class StreamElementSerializerUpgradeTest
 
         @Override
         public Matcher<TypeSerializerSchemaCompatibility<StreamElement>> schemaCompatibilityMatcher(
-                MigrationVersion version) {
+                FlinkVersion version) {
             return TypeSerializerMatchers.isCompatibleAsIs();
         }
     }

--- a/flink-table/flink-table-runtime/src/test/java/org/apache/flink/table/runtime/typeutils/LinkedListSerializerUpgradeTest.java
+++ b/flink-table/flink-table-runtime/src/test/java/org/apache/flink/table/runtime/typeutils/LinkedListSerializerUpgradeTest.java
@@ -18,12 +18,12 @@
 
 package org.apache.flink.table.runtime.typeutils;
 
+import org.apache.flink.FlinkVersion;
 import org.apache.flink.api.common.typeutils.TypeSerializer;
 import org.apache.flink.api.common.typeutils.TypeSerializerMatchers;
 import org.apache.flink.api.common.typeutils.TypeSerializerSchemaCompatibility;
 import org.apache.flink.api.common.typeutils.TypeSerializerUpgradeTestBase;
 import org.apache.flink.api.common.typeutils.base.LongSerializer;
-import org.apache.flink.testutils.migration.MigrationVersion;
 import org.apache.flink.util.FlinkRuntimeException;
 
 import org.hamcrest.Matcher;
@@ -48,7 +48,7 @@ public class LinkedListSerializerUpgradeTest
 
     @Parameterized.Parameters(name = "Test Specification = {0}")
     public static Collection<TestSpecification<?, ?>> testSpecifications() throws Exception {
-        return MigrationVersion.v1_13.orHigher().stream()
+        return FlinkVersion.v1_13.orHigher().stream()
                 .map(
                         version -> {
                             try {
@@ -121,8 +121,8 @@ public class LinkedListSerializerUpgradeTest
 
         @Override
         public Matcher<TypeSerializerSchemaCompatibility<LinkedList<Long>>>
-                schemaCompatibilityMatcher(MigrationVersion version) {
-            if (version.isNewerVersionThan(MigrationVersion.v1_13)) {
+                schemaCompatibilityMatcher(FlinkVersion version) {
+            if (version.isNewerVersionThan(FlinkVersion.v1_13)) {
                 return TypeSerializerMatchers.isCompatibleAsIs();
             } else {
                 return TypeSerializerMatchers.isCompatibleAfterMigration();

--- a/flink-tests/src/test/java/org/apache/flink/test/checkpointing/utils/LegacyStatefulJobSavepointMigrationITCase.java
+++ b/flink-tests/src/test/java/org/apache/flink/test/checkpointing/utils/LegacyStatefulJobSavepointMigrationITCase.java
@@ -18,6 +18,7 @@
 
 package org.apache.flink.test.checkpointing.utils;
 
+import org.apache.flink.FlinkVersion;
 import org.apache.flink.api.common.accumulators.IntCounter;
 import org.apache.flink.api.common.functions.FlatMapFunction;
 import org.apache.flink.api.common.functions.RichFlatMapFunction;
@@ -44,7 +45,6 @@ import org.apache.flink.streaming.api.operators.TimestampedCollector;
 import org.apache.flink.streaming.api.operators.Triggerable;
 import org.apache.flink.streaming.api.watermark.Watermark;
 import org.apache.flink.streaming.runtime.streamrecord.StreamRecord;
-import org.apache.flink.testutils.migration.MigrationVersion;
 import org.apache.flink.util.Collector;
 
 import org.junit.Ignore;
@@ -67,28 +67,28 @@ public class LegacyStatefulJobSavepointMigrationITCase extends SavepointMigratio
     private static final int NUM_SOURCE_ELEMENTS = 4;
 
     @Parameterized.Parameters(name = "Migrate Savepoint / Backend: {0}")
-    public static Collection<Tuple2<MigrationVersion, String>> parameters() {
+    public static Collection<Tuple2<FlinkVersion, String>> parameters() {
         return Arrays.asList(
-                Tuple2.of(MigrationVersion.v1_4, StateBackendLoader.MEMORY_STATE_BACKEND_NAME),
-                Tuple2.of(MigrationVersion.v1_4, StateBackendLoader.ROCKSDB_STATE_BACKEND_NAME));
+                Tuple2.of(FlinkVersion.v1_4, StateBackendLoader.MEMORY_STATE_BACKEND_NAME),
+                Tuple2.of(FlinkVersion.v1_4, StateBackendLoader.ROCKSDB_STATE_BACKEND_NAME));
     }
 
     /**
      * TODO to generate savepoints for a specific Flink version / backend type, TODO change these
-     * values accordingly, e.g. to generate for 1.3 with RocksDB, TODO set as
-     * (MigrationVersion.v1_3, StateBackendLoader.ROCKSDB_STATE_BACKEND_NAME) TODO Note: You should
-     * generate the savepoint based on the release branch instead of the master.
+     * values accordingly, e.g. to generate for 1.3 with RocksDB, TODO set as (FlinkVersion.v1_3,
+     * StateBackendLoader.ROCKSDB_STATE_BACKEND_NAME) TODO Note: You should generate the savepoint
+     * based on the release branch instead of the master.
      */
-    private final MigrationVersion flinkGenerateSavepointVersion = MigrationVersion.v1_4;
+    private final FlinkVersion flinkGenerateSavepointVersion = FlinkVersion.v1_4;
 
     private final String flinkGenerateSavepointBackendType =
             StateBackendLoader.ROCKSDB_STATE_BACKEND_NAME;
 
-    private final MigrationVersion testMigrateVersion;
+    private final FlinkVersion testMigrateVersion;
     private final String testStateBackend;
 
     public LegacyStatefulJobSavepointMigrationITCase(
-            Tuple2<MigrationVersion, String> testMigrateVersionAndBackend) throws Exception {
+            Tuple2<FlinkVersion, String> testMigrateVersionAndBackend) throws Exception {
         this.testMigrateVersion = testMigrateVersionAndBackend.f0;
         this.testStateBackend = testMigrateVersionAndBackend.f1;
     }
@@ -235,7 +235,7 @@ public class LegacyStatefulJobSavepointMigrationITCase extends SavepointMigratio
                         AccumulatorCountingSink.NUM_ELEMENTS_ACCUMULATOR, NUM_SOURCE_ELEMENTS));
     }
 
-    private String getSavepointPath(MigrationVersion savepointVersion, String backendType) {
+    private String getSavepointPath(FlinkVersion savepointVersion, String backendType) {
         switch (backendType) {
             case StateBackendLoader.ROCKSDB_STATE_BACKEND_NAME:
                 return "stateful-udf-migration-itcase-flink"

--- a/flink-tests/src/test/java/org/apache/flink/test/checkpointing/utils/StatefulJobSavepointMigrationITCase.java
+++ b/flink-tests/src/test/java/org/apache/flink/test/checkpointing/utils/StatefulJobSavepointMigrationITCase.java
@@ -18,6 +18,7 @@
 
 package org.apache.flink.test.checkpointing.utils;
 
+import org.apache.flink.FlinkVersion;
 import org.apache.flink.api.common.accumulators.IntCounter;
 import org.apache.flink.api.common.functions.RichFlatMapFunction;
 import org.apache.flink.api.common.restartstrategy.RestartStrategies;
@@ -39,7 +40,6 @@ import org.apache.flink.streaming.api.operators.OneInputStreamOperator;
 import org.apache.flink.streaming.api.operators.Triggerable;
 import org.apache.flink.streaming.api.watermark.Watermark;
 import org.apache.flink.streaming.runtime.streamrecord.StreamRecord;
-import org.apache.flink.testutils.migration.MigrationVersion;
 import org.apache.flink.util.Collector;
 
 import org.junit.Test;
@@ -76,37 +76,37 @@ public class StatefulJobSavepointMigrationITCase extends SavepointMigrationTestB
     private final ExecutionMode executionMode = ExecutionMode.VERIFY_SAVEPOINT;
 
     @Parameterized.Parameters(name = "Migrate Savepoint / Backend: {0}")
-    public static Collection<Tuple2<MigrationVersion, String>> parameters() {
+    public static Collection<Tuple2<FlinkVersion, String>> parameters() {
         return Arrays.asList(
-                Tuple2.of(MigrationVersion.v1_4, StateBackendLoader.MEMORY_STATE_BACKEND_NAME),
-                Tuple2.of(MigrationVersion.v1_4, StateBackendLoader.ROCKSDB_STATE_BACKEND_NAME),
-                Tuple2.of(MigrationVersion.v1_5, StateBackendLoader.MEMORY_STATE_BACKEND_NAME),
-                Tuple2.of(MigrationVersion.v1_5, StateBackendLoader.ROCKSDB_STATE_BACKEND_NAME),
-                Tuple2.of(MigrationVersion.v1_6, StateBackendLoader.MEMORY_STATE_BACKEND_NAME),
-                Tuple2.of(MigrationVersion.v1_6, StateBackendLoader.ROCKSDB_STATE_BACKEND_NAME),
-                Tuple2.of(MigrationVersion.v1_7, StateBackendLoader.MEMORY_STATE_BACKEND_NAME),
-                Tuple2.of(MigrationVersion.v1_7, StateBackendLoader.ROCKSDB_STATE_BACKEND_NAME),
-                Tuple2.of(MigrationVersion.v1_8, StateBackendLoader.MEMORY_STATE_BACKEND_NAME),
-                Tuple2.of(MigrationVersion.v1_8, StateBackendLoader.ROCKSDB_STATE_BACKEND_NAME),
-                Tuple2.of(MigrationVersion.v1_9, StateBackendLoader.MEMORY_STATE_BACKEND_NAME),
-                Tuple2.of(MigrationVersion.v1_9, StateBackendLoader.ROCKSDB_STATE_BACKEND_NAME),
-                Tuple2.of(MigrationVersion.v1_10, StateBackendLoader.MEMORY_STATE_BACKEND_NAME),
-                Tuple2.of(MigrationVersion.v1_10, StateBackendLoader.ROCKSDB_STATE_BACKEND_NAME),
-                Tuple2.of(MigrationVersion.v1_11, StateBackendLoader.MEMORY_STATE_BACKEND_NAME),
-                Tuple2.of(MigrationVersion.v1_11, StateBackendLoader.ROCKSDB_STATE_BACKEND_NAME),
-                Tuple2.of(MigrationVersion.v1_12, StateBackendLoader.MEMORY_STATE_BACKEND_NAME),
-                Tuple2.of(MigrationVersion.v1_12, StateBackendLoader.ROCKSDB_STATE_BACKEND_NAME),
-                Tuple2.of(MigrationVersion.v1_13, StateBackendLoader.MEMORY_STATE_BACKEND_NAME),
-                Tuple2.of(MigrationVersion.v1_13, StateBackendLoader.ROCKSDB_STATE_BACKEND_NAME),
-                Tuple2.of(MigrationVersion.v1_14, StateBackendLoader.MEMORY_STATE_BACKEND_NAME),
-                Tuple2.of(MigrationVersion.v1_14, StateBackendLoader.ROCKSDB_STATE_BACKEND_NAME));
+                Tuple2.of(FlinkVersion.v1_4, StateBackendLoader.MEMORY_STATE_BACKEND_NAME),
+                Tuple2.of(FlinkVersion.v1_4, StateBackendLoader.ROCKSDB_STATE_BACKEND_NAME),
+                Tuple2.of(FlinkVersion.v1_5, StateBackendLoader.MEMORY_STATE_BACKEND_NAME),
+                Tuple2.of(FlinkVersion.v1_5, StateBackendLoader.ROCKSDB_STATE_BACKEND_NAME),
+                Tuple2.of(FlinkVersion.v1_6, StateBackendLoader.MEMORY_STATE_BACKEND_NAME),
+                Tuple2.of(FlinkVersion.v1_6, StateBackendLoader.ROCKSDB_STATE_BACKEND_NAME),
+                Tuple2.of(FlinkVersion.v1_7, StateBackendLoader.MEMORY_STATE_BACKEND_NAME),
+                Tuple2.of(FlinkVersion.v1_7, StateBackendLoader.ROCKSDB_STATE_BACKEND_NAME),
+                Tuple2.of(FlinkVersion.v1_8, StateBackendLoader.MEMORY_STATE_BACKEND_NAME),
+                Tuple2.of(FlinkVersion.v1_8, StateBackendLoader.ROCKSDB_STATE_BACKEND_NAME),
+                Tuple2.of(FlinkVersion.v1_9, StateBackendLoader.MEMORY_STATE_BACKEND_NAME),
+                Tuple2.of(FlinkVersion.v1_9, StateBackendLoader.ROCKSDB_STATE_BACKEND_NAME),
+                Tuple2.of(FlinkVersion.v1_10, StateBackendLoader.MEMORY_STATE_BACKEND_NAME),
+                Tuple2.of(FlinkVersion.v1_10, StateBackendLoader.ROCKSDB_STATE_BACKEND_NAME),
+                Tuple2.of(FlinkVersion.v1_11, StateBackendLoader.MEMORY_STATE_BACKEND_NAME),
+                Tuple2.of(FlinkVersion.v1_11, StateBackendLoader.ROCKSDB_STATE_BACKEND_NAME),
+                Tuple2.of(FlinkVersion.v1_12, StateBackendLoader.MEMORY_STATE_BACKEND_NAME),
+                Tuple2.of(FlinkVersion.v1_12, StateBackendLoader.ROCKSDB_STATE_BACKEND_NAME),
+                Tuple2.of(FlinkVersion.v1_13, StateBackendLoader.MEMORY_STATE_BACKEND_NAME),
+                Tuple2.of(FlinkVersion.v1_13, StateBackendLoader.ROCKSDB_STATE_BACKEND_NAME),
+                Tuple2.of(FlinkVersion.v1_14, StateBackendLoader.MEMORY_STATE_BACKEND_NAME),
+                Tuple2.of(FlinkVersion.v1_14, StateBackendLoader.ROCKSDB_STATE_BACKEND_NAME));
     }
 
-    private final MigrationVersion testMigrateVersion;
+    private final FlinkVersion testMigrateVersion;
     private final String testStateBackend;
 
     public StatefulJobSavepointMigrationITCase(
-            Tuple2<MigrationVersion, String> testMigrateVersionAndBackend) throws Exception {
+            Tuple2<FlinkVersion, String> testMigrateVersionAndBackend) throws Exception {
         this.testMigrateVersion = testMigrateVersionAndBackend.f0;
         this.testStateBackend = testMigrateVersionAndBackend.f1;
     }
@@ -227,7 +227,7 @@ public class StatefulJobSavepointMigrationITCase extends SavepointMigrationTestB
         }
     }
 
-    private String getSavepointPath(MigrationVersion savepointVersion, String backendType) {
+    private String getSavepointPath(FlinkVersion savepointVersion, String backendType) {
         switch (backendType) {
             case StateBackendLoader.ROCKSDB_STATE_BACKEND_NAME:
                 return "new-stateful-udf-migration-itcase-flink"

--- a/flink-tests/src/test/java/org/apache/flink/test/checkpointing/utils/StatefulJobWBroadcastStateMigrationITCase.java
+++ b/flink-tests/src/test/java/org/apache/flink/test/checkpointing/utils/StatefulJobWBroadcastStateMigrationITCase.java
@@ -18,6 +18,7 @@
 
 package org.apache.flink.test.checkpointing.utils;
 
+import org.apache.flink.FlinkVersion;
 import org.apache.flink.api.common.restartstrategy.RestartStrategies;
 import org.apache.flink.api.common.state.MapStateDescriptor;
 import org.apache.flink.api.common.typeinfo.BasicTypeInfo;
@@ -32,7 +33,6 @@ import org.apache.flink.streaming.api.datastream.KeyedStream;
 import org.apache.flink.streaming.api.environment.StreamExecutionEnvironment;
 import org.apache.flink.streaming.api.functions.co.KeyedBroadcastProcessFunction;
 import org.apache.flink.streaming.api.functions.source.SourceFunction;
-import org.apache.flink.testutils.migration.MigrationVersion;
 import org.apache.flink.util.Collector;
 
 import org.junit.Assert;
@@ -62,35 +62,35 @@ public class StatefulJobWBroadcastStateMigrationITCase extends SavepointMigratio
             StatefulJobSavepointMigrationITCase.ExecutionMode.VERIFY_SAVEPOINT;
 
     @Parameterized.Parameters(name = "Migrate Savepoint / Backend: {0}")
-    public static Collection<Tuple2<MigrationVersion, String>> parameters() {
+    public static Collection<Tuple2<FlinkVersion, String>> parameters() {
         return Arrays.asList(
-                Tuple2.of(MigrationVersion.v1_5, StateBackendLoader.MEMORY_STATE_BACKEND_NAME),
-                Tuple2.of(MigrationVersion.v1_5, StateBackendLoader.ROCKSDB_STATE_BACKEND_NAME),
-                Tuple2.of(MigrationVersion.v1_6, StateBackendLoader.MEMORY_STATE_BACKEND_NAME),
-                Tuple2.of(MigrationVersion.v1_6, StateBackendLoader.ROCKSDB_STATE_BACKEND_NAME),
-                Tuple2.of(MigrationVersion.v1_7, StateBackendLoader.MEMORY_STATE_BACKEND_NAME),
-                Tuple2.of(MigrationVersion.v1_7, StateBackendLoader.ROCKSDB_STATE_BACKEND_NAME),
-                Tuple2.of(MigrationVersion.v1_8, StateBackendLoader.MEMORY_STATE_BACKEND_NAME),
-                Tuple2.of(MigrationVersion.v1_8, StateBackendLoader.ROCKSDB_STATE_BACKEND_NAME),
-                Tuple2.of(MigrationVersion.v1_9, StateBackendLoader.MEMORY_STATE_BACKEND_NAME),
-                Tuple2.of(MigrationVersion.v1_9, StateBackendLoader.ROCKSDB_STATE_BACKEND_NAME),
-                Tuple2.of(MigrationVersion.v1_10, StateBackendLoader.MEMORY_STATE_BACKEND_NAME),
-                Tuple2.of(MigrationVersion.v1_10, StateBackendLoader.ROCKSDB_STATE_BACKEND_NAME),
-                Tuple2.of(MigrationVersion.v1_11, StateBackendLoader.MEMORY_STATE_BACKEND_NAME),
-                Tuple2.of(MigrationVersion.v1_11, StateBackendLoader.ROCKSDB_STATE_BACKEND_NAME),
-                Tuple2.of(MigrationVersion.v1_12, StateBackendLoader.MEMORY_STATE_BACKEND_NAME),
-                Tuple2.of(MigrationVersion.v1_12, StateBackendLoader.ROCKSDB_STATE_BACKEND_NAME),
-                Tuple2.of(MigrationVersion.v1_13, StateBackendLoader.MEMORY_STATE_BACKEND_NAME),
-                Tuple2.of(MigrationVersion.v1_13, StateBackendLoader.ROCKSDB_STATE_BACKEND_NAME),
-                Tuple2.of(MigrationVersion.v1_14, StateBackendLoader.MEMORY_STATE_BACKEND_NAME),
-                Tuple2.of(MigrationVersion.v1_14, StateBackendLoader.ROCKSDB_STATE_BACKEND_NAME));
+                Tuple2.of(FlinkVersion.v1_5, StateBackendLoader.MEMORY_STATE_BACKEND_NAME),
+                Tuple2.of(FlinkVersion.v1_5, StateBackendLoader.ROCKSDB_STATE_BACKEND_NAME),
+                Tuple2.of(FlinkVersion.v1_6, StateBackendLoader.MEMORY_STATE_BACKEND_NAME),
+                Tuple2.of(FlinkVersion.v1_6, StateBackendLoader.ROCKSDB_STATE_BACKEND_NAME),
+                Tuple2.of(FlinkVersion.v1_7, StateBackendLoader.MEMORY_STATE_BACKEND_NAME),
+                Tuple2.of(FlinkVersion.v1_7, StateBackendLoader.ROCKSDB_STATE_BACKEND_NAME),
+                Tuple2.of(FlinkVersion.v1_8, StateBackendLoader.MEMORY_STATE_BACKEND_NAME),
+                Tuple2.of(FlinkVersion.v1_8, StateBackendLoader.ROCKSDB_STATE_BACKEND_NAME),
+                Tuple2.of(FlinkVersion.v1_9, StateBackendLoader.MEMORY_STATE_BACKEND_NAME),
+                Tuple2.of(FlinkVersion.v1_9, StateBackendLoader.ROCKSDB_STATE_BACKEND_NAME),
+                Tuple2.of(FlinkVersion.v1_10, StateBackendLoader.MEMORY_STATE_BACKEND_NAME),
+                Tuple2.of(FlinkVersion.v1_10, StateBackendLoader.ROCKSDB_STATE_BACKEND_NAME),
+                Tuple2.of(FlinkVersion.v1_11, StateBackendLoader.MEMORY_STATE_BACKEND_NAME),
+                Tuple2.of(FlinkVersion.v1_11, StateBackendLoader.ROCKSDB_STATE_BACKEND_NAME),
+                Tuple2.of(FlinkVersion.v1_12, StateBackendLoader.MEMORY_STATE_BACKEND_NAME),
+                Tuple2.of(FlinkVersion.v1_12, StateBackendLoader.ROCKSDB_STATE_BACKEND_NAME),
+                Tuple2.of(FlinkVersion.v1_13, StateBackendLoader.MEMORY_STATE_BACKEND_NAME),
+                Tuple2.of(FlinkVersion.v1_13, StateBackendLoader.ROCKSDB_STATE_BACKEND_NAME),
+                Tuple2.of(FlinkVersion.v1_14, StateBackendLoader.MEMORY_STATE_BACKEND_NAME),
+                Tuple2.of(FlinkVersion.v1_14, StateBackendLoader.ROCKSDB_STATE_BACKEND_NAME));
     }
 
-    private final MigrationVersion testMigrateVersion;
+    private final FlinkVersion testMigrateVersion;
     private final String testStateBackend;
 
     public StatefulJobWBroadcastStateMigrationITCase(
-            Tuple2<MigrationVersion, String> testMigrateVersionAndBackend) throws Exception {
+            Tuple2<FlinkVersion, String> testMigrateVersionAndBackend) throws Exception {
         this.testMigrateVersion = testMigrateVersionAndBackend.f0;
         this.testStateBackend = testMigrateVersionAndBackend.f1;
     }
@@ -278,8 +278,7 @@ public class StatefulJobWBroadcastStateMigrationITCase extends SavepointMigratio
         }
     }
 
-    private String getBroadcastSavepointPath(
-            MigrationVersion savepointVersion, String backendType) {
+    private String getBroadcastSavepointPath(FlinkVersion savepointVersion, String backendType) {
         switch (backendType) {
             case StateBackendLoader.ROCKSDB_STATE_BACKEND_NAME:
                 return "new-stateful-broadcast-udf-migration-itcase-flink"

--- a/flink-tests/src/test/java/org/apache/flink/test/migration/TypeSerializerSnapshotMigrationITCase.java
+++ b/flink-tests/src/test/java/org/apache/flink/test/migration/TypeSerializerSnapshotMigrationITCase.java
@@ -18,6 +18,7 @@
 
 package org.apache.flink.test.migration;
 
+import org.apache.flink.FlinkVersion;
 import org.apache.flink.api.common.functions.RichMapFunction;
 import org.apache.flink.api.common.restartstrategy.RestartStrategies;
 import org.apache.flink.api.common.state.ValueState;
@@ -37,7 +38,6 @@ import org.apache.flink.streaming.api.environment.StreamExecutionEnvironment;
 import org.apache.flink.streaming.api.functions.source.SourceFunction;
 import org.apache.flink.test.checkpointing.utils.MigrationTestUtils;
 import org.apache.flink.test.checkpointing.utils.SavepointMigrationTestBase;
-import org.apache.flink.testutils.migration.MigrationVersion;
 
 import org.junit.Test;
 import org.junit.runner.RunWith;
@@ -76,39 +76,39 @@ public class TypeSerializerSnapshotMigrationITCase extends SavepointMigrationTes
     private final ExecutionMode executionMode = ExecutionMode.VERIFY_SAVEPOINT;
 
     @Parameterized.Parameters(name = "Migrate Savepoint / Backend: {0}")
-    public static Collection<Tuple2<MigrationVersion, String>> parameters() {
+    public static Collection<Tuple2<FlinkVersion, String>> parameters() {
         return Arrays.asList(
-                Tuple2.of(MigrationVersion.v1_3, StateBackendLoader.MEMORY_STATE_BACKEND_NAME),
-                Tuple2.of(MigrationVersion.v1_3, StateBackendLoader.ROCKSDB_STATE_BACKEND_NAME),
-                Tuple2.of(MigrationVersion.v1_4, StateBackendLoader.MEMORY_STATE_BACKEND_NAME),
-                Tuple2.of(MigrationVersion.v1_4, StateBackendLoader.ROCKSDB_STATE_BACKEND_NAME),
-                Tuple2.of(MigrationVersion.v1_5, StateBackendLoader.MEMORY_STATE_BACKEND_NAME),
-                Tuple2.of(MigrationVersion.v1_5, StateBackendLoader.ROCKSDB_STATE_BACKEND_NAME),
-                Tuple2.of(MigrationVersion.v1_6, StateBackendLoader.MEMORY_STATE_BACKEND_NAME),
-                Tuple2.of(MigrationVersion.v1_6, StateBackendLoader.ROCKSDB_STATE_BACKEND_NAME),
-                Tuple2.of(MigrationVersion.v1_7, StateBackendLoader.MEMORY_STATE_BACKEND_NAME),
-                Tuple2.of(MigrationVersion.v1_7, StateBackendLoader.ROCKSDB_STATE_BACKEND_NAME),
-                Tuple2.of(MigrationVersion.v1_8, StateBackendLoader.MEMORY_STATE_BACKEND_NAME),
-                Tuple2.of(MigrationVersion.v1_8, StateBackendLoader.ROCKSDB_STATE_BACKEND_NAME),
-                Tuple2.of(MigrationVersion.v1_9, StateBackendLoader.MEMORY_STATE_BACKEND_NAME),
-                Tuple2.of(MigrationVersion.v1_9, StateBackendLoader.ROCKSDB_STATE_BACKEND_NAME),
-                Tuple2.of(MigrationVersion.v1_10, StateBackendLoader.MEMORY_STATE_BACKEND_NAME),
-                Tuple2.of(MigrationVersion.v1_10, StateBackendLoader.ROCKSDB_STATE_BACKEND_NAME),
-                Tuple2.of(MigrationVersion.v1_11, StateBackendLoader.MEMORY_STATE_BACKEND_NAME),
-                Tuple2.of(MigrationVersion.v1_11, StateBackendLoader.ROCKSDB_STATE_BACKEND_NAME),
-                Tuple2.of(MigrationVersion.v1_12, StateBackendLoader.MEMORY_STATE_BACKEND_NAME),
-                Tuple2.of(MigrationVersion.v1_12, StateBackendLoader.ROCKSDB_STATE_BACKEND_NAME),
-                Tuple2.of(MigrationVersion.v1_13, StateBackendLoader.MEMORY_STATE_BACKEND_NAME),
-                Tuple2.of(MigrationVersion.v1_13, StateBackendLoader.ROCKSDB_STATE_BACKEND_NAME),
-                Tuple2.of(MigrationVersion.v1_14, StateBackendLoader.MEMORY_STATE_BACKEND_NAME),
-                Tuple2.of(MigrationVersion.v1_14, StateBackendLoader.ROCKSDB_STATE_BACKEND_NAME));
+                Tuple2.of(FlinkVersion.v1_3, StateBackendLoader.MEMORY_STATE_BACKEND_NAME),
+                Tuple2.of(FlinkVersion.v1_3, StateBackendLoader.ROCKSDB_STATE_BACKEND_NAME),
+                Tuple2.of(FlinkVersion.v1_4, StateBackendLoader.MEMORY_STATE_BACKEND_NAME),
+                Tuple2.of(FlinkVersion.v1_4, StateBackendLoader.ROCKSDB_STATE_BACKEND_NAME),
+                Tuple2.of(FlinkVersion.v1_5, StateBackendLoader.MEMORY_STATE_BACKEND_NAME),
+                Tuple2.of(FlinkVersion.v1_5, StateBackendLoader.ROCKSDB_STATE_BACKEND_NAME),
+                Tuple2.of(FlinkVersion.v1_6, StateBackendLoader.MEMORY_STATE_BACKEND_NAME),
+                Tuple2.of(FlinkVersion.v1_6, StateBackendLoader.ROCKSDB_STATE_BACKEND_NAME),
+                Tuple2.of(FlinkVersion.v1_7, StateBackendLoader.MEMORY_STATE_BACKEND_NAME),
+                Tuple2.of(FlinkVersion.v1_7, StateBackendLoader.ROCKSDB_STATE_BACKEND_NAME),
+                Tuple2.of(FlinkVersion.v1_8, StateBackendLoader.MEMORY_STATE_BACKEND_NAME),
+                Tuple2.of(FlinkVersion.v1_8, StateBackendLoader.ROCKSDB_STATE_BACKEND_NAME),
+                Tuple2.of(FlinkVersion.v1_9, StateBackendLoader.MEMORY_STATE_BACKEND_NAME),
+                Tuple2.of(FlinkVersion.v1_9, StateBackendLoader.ROCKSDB_STATE_BACKEND_NAME),
+                Tuple2.of(FlinkVersion.v1_10, StateBackendLoader.MEMORY_STATE_BACKEND_NAME),
+                Tuple2.of(FlinkVersion.v1_10, StateBackendLoader.ROCKSDB_STATE_BACKEND_NAME),
+                Tuple2.of(FlinkVersion.v1_11, StateBackendLoader.MEMORY_STATE_BACKEND_NAME),
+                Tuple2.of(FlinkVersion.v1_11, StateBackendLoader.ROCKSDB_STATE_BACKEND_NAME),
+                Tuple2.of(FlinkVersion.v1_12, StateBackendLoader.MEMORY_STATE_BACKEND_NAME),
+                Tuple2.of(FlinkVersion.v1_12, StateBackendLoader.ROCKSDB_STATE_BACKEND_NAME),
+                Tuple2.of(FlinkVersion.v1_13, StateBackendLoader.MEMORY_STATE_BACKEND_NAME),
+                Tuple2.of(FlinkVersion.v1_13, StateBackendLoader.ROCKSDB_STATE_BACKEND_NAME),
+                Tuple2.of(FlinkVersion.v1_14, StateBackendLoader.MEMORY_STATE_BACKEND_NAME),
+                Tuple2.of(FlinkVersion.v1_14, StateBackendLoader.ROCKSDB_STATE_BACKEND_NAME));
     }
 
-    private final MigrationVersion testMigrateVersion;
+    private final FlinkVersion testMigrateVersion;
     private final String testStateBackend;
 
     public TypeSerializerSnapshotMigrationITCase(
-            Tuple2<MigrationVersion, String> testMigrateVersionAndBackend) throws Exception {
+            Tuple2<FlinkVersion, String> testMigrateVersionAndBackend) throws Exception {
         this.testMigrateVersion = testMigrateVersionAndBackend.f0;
         this.testStateBackend = testMigrateVersionAndBackend.f1;
     }
@@ -161,7 +161,7 @@ public class TypeSerializerSnapshotMigrationITCase extends SavepointMigrationTes
         }
     }
 
-    private String getSavepointPath(MigrationVersion savepointVersion, String backendType) {
+    private String getSavepointPath(FlinkVersion savepointVersion, String backendType) {
         switch (backendType) {
             case "rocksdb":
                 return "type-serializer-snapshot-migration-itcase-flink"

--- a/flink-tests/src/test/java/org/apache/flink/test/state/operator/restore/keyed/AbstractKeyedOperatorRestoreTestBase.java
+++ b/flink-tests/src/test/java/org/apache/flink/test/state/operator/restore/keyed/AbstractKeyedOperatorRestoreTestBase.java
@@ -18,12 +18,12 @@
 
 package org.apache.flink.test.state.operator.restore.keyed;
 
+import org.apache.flink.FlinkVersion;
 import org.apache.flink.api.java.tuple.Tuple2;
 import org.apache.flink.streaming.api.datastream.SingleOutputStreamOperator;
 import org.apache.flink.streaming.api.environment.StreamExecutionEnvironment;
 import org.apache.flink.test.state.operator.restore.AbstractOperatorRestoreTestBase;
 import org.apache.flink.test.state.operator.restore.ExecutionMode;
-import org.apache.flink.testutils.migration.MigrationVersion;
 
 import org.junit.runner.RunWith;
 import org.junit.runners.Parameterized;
@@ -35,27 +35,27 @@ import java.util.Collection;
 @RunWith(Parameterized.class)
 public abstract class AbstractKeyedOperatorRestoreTestBase extends AbstractOperatorRestoreTestBase {
 
-    private final MigrationVersion migrationVersion;
+    private final FlinkVersion flinkVersion;
 
     @Parameterized.Parameters(name = "Migrate Savepoint: {0}")
-    public static Collection<MigrationVersion> parameters() {
+    public static Collection<FlinkVersion> parameters() {
         return Arrays.asList(
-                MigrationVersion.v1_3,
-                MigrationVersion.v1_4,
-                MigrationVersion.v1_5,
-                MigrationVersion.v1_6,
-                MigrationVersion.v1_7,
-                MigrationVersion.v1_8,
-                MigrationVersion.v1_9,
-                MigrationVersion.v1_10,
-                MigrationVersion.v1_11,
-                MigrationVersion.v1_12,
-                MigrationVersion.v1_13,
-                MigrationVersion.v1_14);
+                FlinkVersion.v1_3,
+                FlinkVersion.v1_4,
+                FlinkVersion.v1_5,
+                FlinkVersion.v1_6,
+                FlinkVersion.v1_7,
+                FlinkVersion.v1_8,
+                FlinkVersion.v1_9,
+                FlinkVersion.v1_10,
+                FlinkVersion.v1_11,
+                FlinkVersion.v1_12,
+                FlinkVersion.v1_13,
+                FlinkVersion.v1_14);
     }
 
-    public AbstractKeyedOperatorRestoreTestBase(MigrationVersion migrationVersion) {
-        this.migrationVersion = migrationVersion;
+    public AbstractKeyedOperatorRestoreTestBase(FlinkVersion flinkVersion) {
+        this.flinkVersion = flinkVersion;
     }
 
     @Override
@@ -76,6 +76,6 @@ public abstract class AbstractKeyedOperatorRestoreTestBase extends AbstractOpera
 
     @Override
     protected String getMigrationSavepointName() {
-        return "complexKeyed-flink" + migrationVersion;
+        return "complexKeyed-flink" + flinkVersion;
     }
 }

--- a/flink-tests/src/test/java/org/apache/flink/test/state/operator/restore/keyed/KeyedComplexChainTest.java
+++ b/flink-tests/src/test/java/org/apache/flink/test/state/operator/restore/keyed/KeyedComplexChainTest.java
@@ -18,17 +18,17 @@
 
 package org.apache.flink.test.state.operator.restore.keyed;
 
+import org.apache.flink.FlinkVersion;
 import org.apache.flink.api.java.tuple.Tuple2;
 import org.apache.flink.streaming.api.datastream.SingleOutputStreamOperator;
 import org.apache.flink.streaming.api.environment.StreamExecutionEnvironment;
 import org.apache.flink.test.state.operator.restore.ExecutionMode;
-import org.apache.flink.testutils.migration.MigrationVersion;
 
 /** Test state restoration for a keyed operator restore tests. */
 public class KeyedComplexChainTest extends AbstractKeyedOperatorRestoreTestBase {
 
-    public KeyedComplexChainTest(MigrationVersion migrationVersion) {
-        super(migrationVersion);
+    public KeyedComplexChainTest(FlinkVersion flinkVersion) {
+        super(flinkVersion);
     }
 
     @Override

--- a/flink-tests/src/test/java/org/apache/flink/test/state/operator/restore/unkeyed/AbstractNonKeyedOperatorRestoreTestBase.java
+++ b/flink-tests/src/test/java/org/apache/flink/test/state/operator/restore/unkeyed/AbstractNonKeyedOperatorRestoreTestBase.java
@@ -18,12 +18,12 @@
 
 package org.apache.flink.test.state.operator.restore.unkeyed;
 
+import org.apache.flink.FlinkVersion;
 import org.apache.flink.streaming.api.datastream.DataStream;
 import org.apache.flink.streaming.api.datastream.SingleOutputStreamOperator;
 import org.apache.flink.streaming.api.environment.StreamExecutionEnvironment;
 import org.apache.flink.test.state.operator.restore.AbstractOperatorRestoreTestBase;
 import org.apache.flink.test.state.operator.restore.ExecutionMode;
-import org.apache.flink.testutils.migration.MigrationVersion;
 
 import org.junit.runner.RunWith;
 import org.junit.runners.Parameterized;
@@ -42,33 +42,33 @@ import static org.apache.flink.test.state.operator.restore.unkeyed.NonKeyedJob.c
 public abstract class AbstractNonKeyedOperatorRestoreTestBase
         extends AbstractOperatorRestoreTestBase {
 
-    private final MigrationVersion migrationVersion;
+    private final FlinkVersion flinkVersion;
 
     @Parameterized.Parameters(name = "Migrate Savepoint: {0}")
-    public static Collection<MigrationVersion> parameters() {
+    public static Collection<FlinkVersion> parameters() {
         return Arrays.asList(
-                MigrationVersion.v1_3,
-                MigrationVersion.v1_4,
-                MigrationVersion.v1_5,
-                MigrationVersion.v1_6,
-                MigrationVersion.v1_7,
-                MigrationVersion.v1_8,
-                MigrationVersion.v1_9,
-                MigrationVersion.v1_10,
-                MigrationVersion.v1_11,
-                MigrationVersion.v1_12,
-                MigrationVersion.v1_13,
-                MigrationVersion.v1_14);
+                FlinkVersion.v1_3,
+                FlinkVersion.v1_4,
+                FlinkVersion.v1_5,
+                FlinkVersion.v1_6,
+                FlinkVersion.v1_7,
+                FlinkVersion.v1_8,
+                FlinkVersion.v1_9,
+                FlinkVersion.v1_10,
+                FlinkVersion.v1_11,
+                FlinkVersion.v1_12,
+                FlinkVersion.v1_13,
+                FlinkVersion.v1_14);
     }
 
-    protected AbstractNonKeyedOperatorRestoreTestBase(MigrationVersion migrationVersion) {
-        this.migrationVersion = migrationVersion;
+    protected AbstractNonKeyedOperatorRestoreTestBase(FlinkVersion flinkVersion) {
+        this.flinkVersion = flinkVersion;
     }
 
     protected AbstractNonKeyedOperatorRestoreTestBase(
-            MigrationVersion migrationVersion, boolean allowNonRestoredState) {
+            FlinkVersion flinkVersion, boolean allowNonRestoredState) {
         super(allowNonRestoredState);
-        this.migrationVersion = migrationVersion;
+        this.flinkVersion = flinkVersion;
     }
 
     @Override
@@ -92,6 +92,6 @@ public abstract class AbstractNonKeyedOperatorRestoreTestBase
 
     @Override
     protected String getMigrationSavepointName() {
-        return "nonKeyed-flink" + migrationVersion;
+        return "nonKeyed-flink" + flinkVersion;
     }
 }

--- a/flink-tests/src/test/java/org/apache/flink/test/state/operator/restore/unkeyed/ChainBreakTest.java
+++ b/flink-tests/src/test/java/org/apache/flink/test/state/operator/restore/unkeyed/ChainBreakTest.java
@@ -18,11 +18,11 @@
 
 package org.apache.flink.test.state.operator.restore.unkeyed;
 
+import org.apache.flink.FlinkVersion;
 import org.apache.flink.streaming.api.datastream.DataStream;
 import org.apache.flink.streaming.api.datastream.SingleOutputStreamOperator;
 import org.apache.flink.streaming.api.environment.StreamExecutionEnvironment;
 import org.apache.flink.test.state.operator.restore.ExecutionMode;
-import org.apache.flink.testutils.migration.MigrationVersion;
 
 import static org.apache.flink.test.state.operator.restore.unkeyed.NonKeyedJob.createFirstStatefulMap;
 import static org.apache.flink.test.state.operator.restore.unkeyed.NonKeyedJob.createSecondStatefulMap;
@@ -33,8 +33,8 @@ import static org.apache.flink.test.state.operator.restore.unkeyed.NonKeyedJob.c
 /** Verifies that the state of all operators is restored if a topology change breaks up a chain. */
 public class ChainBreakTest extends AbstractNonKeyedOperatorRestoreTestBase {
 
-    public ChainBreakTest(MigrationVersion migrationVersion) {
-        super(migrationVersion);
+    public ChainBreakTest(FlinkVersion flinkVersion) {
+        super(flinkVersion);
     }
 
     @Override

--- a/flink-tests/src/test/java/org/apache/flink/test/state/operator/restore/unkeyed/ChainLengthDecreaseTest.java
+++ b/flink-tests/src/test/java/org/apache/flink/test/state/operator/restore/unkeyed/ChainLengthDecreaseTest.java
@@ -18,11 +18,11 @@
 
 package org.apache.flink.test.state.operator.restore.unkeyed;
 
+import org.apache.flink.FlinkVersion;
 import org.apache.flink.streaming.api.datastream.DataStream;
 import org.apache.flink.streaming.api.datastream.SingleOutputStreamOperator;
 import org.apache.flink.streaming.api.environment.StreamExecutionEnvironment;
 import org.apache.flink.test.state.operator.restore.ExecutionMode;
-import org.apache.flink.testutils.migration.MigrationVersion;
 
 import static org.apache.flink.test.state.operator.restore.unkeyed.NonKeyedJob.createFirstStatefulMap;
 import static org.apache.flink.test.state.operator.restore.unkeyed.NonKeyedJob.createSource;
@@ -35,8 +35,8 @@ import static org.apache.flink.test.state.operator.restore.unkeyed.NonKeyedJob.c
  */
 public class ChainLengthDecreaseTest extends AbstractNonKeyedOperatorRestoreTestBase {
 
-    public ChainLengthDecreaseTest(MigrationVersion migrationVersion) {
-        super(migrationVersion);
+    public ChainLengthDecreaseTest(FlinkVersion flinkVersion) {
+        super(flinkVersion);
     }
 
     @Override

--- a/flink-tests/src/test/java/org/apache/flink/test/state/operator/restore/unkeyed/ChainLengthIncreaseTest.java
+++ b/flink-tests/src/test/java/org/apache/flink/test/state/operator/restore/unkeyed/ChainLengthIncreaseTest.java
@@ -18,11 +18,11 @@
 
 package org.apache.flink.test.state.operator.restore.unkeyed;
 
+import org.apache.flink.FlinkVersion;
 import org.apache.flink.streaming.api.datastream.DataStream;
 import org.apache.flink.streaming.api.datastream.SingleOutputStreamOperator;
 import org.apache.flink.streaming.api.environment.StreamExecutionEnvironment;
 import org.apache.flink.test.state.operator.restore.ExecutionMode;
-import org.apache.flink.testutils.migration.MigrationVersion;
 
 import static org.apache.flink.test.state.operator.restore.unkeyed.NonKeyedJob.createFirstStatefulMap;
 import static org.apache.flink.test.state.operator.restore.unkeyed.NonKeyedJob.createSecondStatefulMap;
@@ -36,8 +36,8 @@ import static org.apache.flink.test.state.operator.restore.unkeyed.NonKeyedJob.c
  */
 public class ChainLengthIncreaseTest extends AbstractNonKeyedOperatorRestoreTestBase {
 
-    public ChainLengthIncreaseTest(MigrationVersion migrationVersion) {
-        super(migrationVersion);
+    public ChainLengthIncreaseTest(FlinkVersion flinkVersion) {
+        super(flinkVersion);
     }
 
     @Override

--- a/flink-tests/src/test/java/org/apache/flink/test/state/operator/restore/unkeyed/ChainLengthStatelessDecreaseTest.java
+++ b/flink-tests/src/test/java/org/apache/flink/test/state/operator/restore/unkeyed/ChainLengthStatelessDecreaseTest.java
@@ -18,11 +18,11 @@
 
 package org.apache.flink.test.state.operator.restore.unkeyed;
 
+import org.apache.flink.FlinkVersion;
 import org.apache.flink.streaming.api.datastream.DataStream;
 import org.apache.flink.streaming.api.datastream.SingleOutputStreamOperator;
 import org.apache.flink.streaming.api.environment.StreamExecutionEnvironment;
 import org.apache.flink.test.state.operator.restore.ExecutionMode;
-import org.apache.flink.testutils.migration.MigrationVersion;
 
 import static org.apache.flink.test.state.operator.restore.unkeyed.NonKeyedJob.createFirstStatefulMap;
 import static org.apache.flink.test.state.operator.restore.unkeyed.NonKeyedJob.createSecondStatefulMap;
@@ -38,8 +38,8 @@ import static org.apache.flink.test.state.operator.restore.unkeyed.NonKeyedJob.c
  */
 public class ChainLengthStatelessDecreaseTest extends AbstractNonKeyedOperatorRestoreTestBase {
 
-    public ChainLengthStatelessDecreaseTest(MigrationVersion migrationVersion) {
-        super(migrationVersion);
+    public ChainLengthStatelessDecreaseTest(FlinkVersion flinkVersion) {
+        super(flinkVersion);
     }
 
     @Override

--- a/flink-tests/src/test/java/org/apache/flink/test/state/operator/restore/unkeyed/ChainOrderTest.java
+++ b/flink-tests/src/test/java/org/apache/flink/test/state/operator/restore/unkeyed/ChainOrderTest.java
@@ -18,11 +18,11 @@
 
 package org.apache.flink.test.state.operator.restore.unkeyed;
 
+import org.apache.flink.FlinkVersion;
 import org.apache.flink.streaming.api.datastream.DataStream;
 import org.apache.flink.streaming.api.datastream.SingleOutputStreamOperator;
 import org.apache.flink.streaming.api.environment.StreamExecutionEnvironment;
 import org.apache.flink.test.state.operator.restore.ExecutionMode;
-import org.apache.flink.testutils.migration.MigrationVersion;
 
 import static org.apache.flink.test.state.operator.restore.unkeyed.NonKeyedJob.createFirstStatefulMap;
 import static org.apache.flink.test.state.operator.restore.unkeyed.NonKeyedJob.createSecondStatefulMap;
@@ -36,8 +36,8 @@ import static org.apache.flink.test.state.operator.restore.unkeyed.NonKeyedJob.c
  */
 public class ChainOrderTest extends AbstractNonKeyedOperatorRestoreTestBase {
 
-    public ChainOrderTest(MigrationVersion migrationVersion) {
-        super(migrationVersion);
+    public ChainOrderTest(FlinkVersion flinkVersion) {
+        super(flinkVersion);
     }
 
     @Override

--- a/flink-tests/src/test/java/org/apache/flink/test/state/operator/restore/unkeyed/ChainUnionTest.java
+++ b/flink-tests/src/test/java/org/apache/flink/test/state/operator/restore/unkeyed/ChainUnionTest.java
@@ -18,11 +18,11 @@
 
 package org.apache.flink.test.state.operator.restore.unkeyed;
 
+import org.apache.flink.FlinkVersion;
 import org.apache.flink.streaming.api.datastream.DataStream;
 import org.apache.flink.streaming.api.datastream.SingleOutputStreamOperator;
 import org.apache.flink.streaming.api.environment.StreamExecutionEnvironment;
 import org.apache.flink.test.state.operator.restore.ExecutionMode;
-import org.apache.flink.testutils.migration.MigrationVersion;
 
 import static org.apache.flink.test.state.operator.restore.unkeyed.NonKeyedJob.createFirstStatefulMap;
 import static org.apache.flink.test.state.operator.restore.unkeyed.NonKeyedJob.createSecondStatefulMap;
@@ -35,8 +35,8 @@ import static org.apache.flink.test.state.operator.restore.unkeyed.NonKeyedJob.c
  */
 public class ChainUnionTest extends AbstractNonKeyedOperatorRestoreTestBase {
 
-    public ChainUnionTest(MigrationVersion migrationVersion) {
-        super(migrationVersion);
+    public ChainUnionTest(FlinkVersion flinkVersion) {
+        super(flinkVersion);
     }
 
     @Override

--- a/flink-tests/src/test/scala/org/apache/flink/api/scala/migration/StatefulJobSavepointMigrationITCase.scala
+++ b/flink-tests/src/test/scala/org/apache/flink/api/scala/migration/StatefulJobSavepointMigrationITCase.scala
@@ -18,8 +18,9 @@
 
 package org.apache.flink.api.scala.migration
 
-import java.util
+import org.apache.flink.FlinkVersion
 
+import java.util
 import org.apache.flink.api.common.accumulators.IntCounter
 import org.apache.flink.api.common.functions.RichFlatMapFunction
 import org.apache.flink.api.common.state.{ListState, ListStateDescriptor, ValueState, ValueStateDescriptor}
@@ -40,7 +41,7 @@ import org.apache.flink.api.java.tuple.Tuple2
 import org.apache.flink.runtime.state.{FunctionInitializationContext, FunctionSnapshotContext, StateBackendLoader}
 import org.apache.flink.api.scala._
 import org.apache.flink.api.scala.migration.CustomEnum.CustomEnum
-import org.apache.flink.testutils.migration.MigrationVersion
+
 import org.junit.runner.RunWith
 import org.junit.runners.Parameterized
 import org.junit.{Ignore, Test}
@@ -50,37 +51,37 @@ import scala.util.{Failure, Try}
 object StatefulJobSavepointMigrationITCase {
 
   @Parameterized.Parameters(name = "Migrate Savepoint / Backend: {0}")
-  def parameters: util.Collection[(MigrationVersion, String)] = {
+  def parameters: util.Collection[(FlinkVersion, String)] = {
     util.Arrays.asList(
-      (MigrationVersion.v1_3, StateBackendLoader.MEMORY_STATE_BACKEND_NAME),
-      (MigrationVersion.v1_3, StateBackendLoader.ROCKSDB_STATE_BACKEND_NAME),
-      (MigrationVersion.v1_4, StateBackendLoader.MEMORY_STATE_BACKEND_NAME),
-      (MigrationVersion.v1_4, StateBackendLoader.ROCKSDB_STATE_BACKEND_NAME),
-      (MigrationVersion.v1_6, StateBackendLoader.MEMORY_STATE_BACKEND_NAME),
-      (MigrationVersion.v1_6, StateBackendLoader.ROCKSDB_STATE_BACKEND_NAME),
-      (MigrationVersion.v1_7, StateBackendLoader.MEMORY_STATE_BACKEND_NAME),
-      (MigrationVersion.v1_7, StateBackendLoader.ROCKSDB_STATE_BACKEND_NAME),
-      (MigrationVersion.v1_8, StateBackendLoader.MEMORY_STATE_BACKEND_NAME),
-      (MigrationVersion.v1_8, StateBackendLoader.ROCKSDB_STATE_BACKEND_NAME),
-      (MigrationVersion.v1_9, StateBackendLoader.MEMORY_STATE_BACKEND_NAME),
-      (MigrationVersion.v1_9, StateBackendLoader.ROCKSDB_STATE_BACKEND_NAME),
-      (MigrationVersion.v1_10, StateBackendLoader.MEMORY_STATE_BACKEND_NAME),
-      (MigrationVersion.v1_10, StateBackendLoader.ROCKSDB_STATE_BACKEND_NAME),
-      (MigrationVersion.v1_11, StateBackendLoader.MEMORY_STATE_BACKEND_NAME),
-      (MigrationVersion.v1_11, StateBackendLoader.ROCKSDB_STATE_BACKEND_NAME),
-      (MigrationVersion.v1_12, StateBackendLoader.MEMORY_STATE_BACKEND_NAME),
-      (MigrationVersion.v1_12, StateBackendLoader.ROCKSDB_STATE_BACKEND_NAME),
-      (MigrationVersion.v1_13, StateBackendLoader.MEMORY_STATE_BACKEND_NAME),
-      (MigrationVersion.v1_13, StateBackendLoader.ROCKSDB_STATE_BACKEND_NAME),
-      (MigrationVersion.v1_14, StateBackendLoader.HASHMAP_STATE_BACKEND_NAME),
-      (MigrationVersion.v1_14, StateBackendLoader.ROCKSDB_STATE_BACKEND_NAME))
+      (FlinkVersion.v1_3, StateBackendLoader.MEMORY_STATE_BACKEND_NAME),
+      (FlinkVersion.v1_3, StateBackendLoader.ROCKSDB_STATE_BACKEND_NAME),
+      (FlinkVersion.v1_4, StateBackendLoader.MEMORY_STATE_BACKEND_NAME),
+      (FlinkVersion.v1_4, StateBackendLoader.ROCKSDB_STATE_BACKEND_NAME),
+      (FlinkVersion.v1_6, StateBackendLoader.MEMORY_STATE_BACKEND_NAME),
+      (FlinkVersion.v1_6, StateBackendLoader.ROCKSDB_STATE_BACKEND_NAME),
+      (FlinkVersion.v1_7, StateBackendLoader.MEMORY_STATE_BACKEND_NAME),
+      (FlinkVersion.v1_7, StateBackendLoader.ROCKSDB_STATE_BACKEND_NAME),
+      (FlinkVersion.v1_8, StateBackendLoader.MEMORY_STATE_BACKEND_NAME),
+      (FlinkVersion.v1_8, StateBackendLoader.ROCKSDB_STATE_BACKEND_NAME),
+      (FlinkVersion.v1_9, StateBackendLoader.MEMORY_STATE_BACKEND_NAME),
+      (FlinkVersion.v1_9, StateBackendLoader.ROCKSDB_STATE_BACKEND_NAME),
+      (FlinkVersion.v1_10, StateBackendLoader.MEMORY_STATE_BACKEND_NAME),
+      (FlinkVersion.v1_10, StateBackendLoader.ROCKSDB_STATE_BACKEND_NAME),
+      (FlinkVersion.v1_11, StateBackendLoader.MEMORY_STATE_BACKEND_NAME),
+      (FlinkVersion.v1_11, StateBackendLoader.ROCKSDB_STATE_BACKEND_NAME),
+      (FlinkVersion.v1_12, StateBackendLoader.MEMORY_STATE_BACKEND_NAME),
+      (FlinkVersion.v1_12, StateBackendLoader.ROCKSDB_STATE_BACKEND_NAME),
+      (FlinkVersion.v1_13, StateBackendLoader.MEMORY_STATE_BACKEND_NAME),
+      (FlinkVersion.v1_13, StateBackendLoader.ROCKSDB_STATE_BACKEND_NAME),
+      (FlinkVersion.v1_14, StateBackendLoader.HASHMAP_STATE_BACKEND_NAME),
+      (FlinkVersion.v1_14, StateBackendLoader.ROCKSDB_STATE_BACKEND_NAME))
   }
 
   // TODO to generate savepoints for a specific Flink version / backend type,
   // TODO change these values accordingly, e.g. to generate for 1.3 with RocksDB,
-  // TODO set as (MigrationVersion.v1_3, StateBackendLoader.ROCKSDB_STATE_BACKEND_NAME)
+  // TODO set as (FlinkVersion.v1_3, StateBackendLoader.ROCKSDB_STATE_BACKEND_NAME)
   // TODO Note: You should generate the savepoint based on the release branch instead of the master.
-  val GENERATE_SAVEPOINT_VER: MigrationVersion = MigrationVersion.v1_14
+  val GENERATE_SAVEPOINT_VER: FlinkVersion = FlinkVersion.v1_14
   val GENERATE_SAVEPOINT_BACKEND_TYPE: String = StateBackendLoader.HASHMAP_STATE_BACKEND_NAME
 
   val NUM_ELEMENTS = 4
@@ -91,7 +92,7 @@ object StatefulJobSavepointMigrationITCase {
  */
 @RunWith(classOf[Parameterized])
 class StatefulJobSavepointMigrationITCase(
-    migrationVersionAndBackend: (MigrationVersion, String))
+    migrationVersionAndBackend: (FlinkVersion, String))
   extends SavepointMigrationTestBase with Serializable {
 
   @Ignore

--- a/flink-tests/src/test/scala/org/apache/flink/api/scala/migration/StatefulJobWBroadcastStateMigrationITCase.scala
+++ b/flink-tests/src/test/scala/org/apache/flink/api/scala/migration/StatefulJobWBroadcastStateMigrationITCase.scala
@@ -18,8 +18,9 @@
 
 package org.apache.flink.api.scala.migration
 
-import java.util
+import org.apache.flink.FlinkVersion
 
+import java.util
 import org.apache.flink.api.common.accumulators.IntCounter
 import org.apache.flink.api.common.functions.RichFlatMapFunction
 import org.apache.flink.api.common.state._
@@ -41,8 +42,8 @@ import org.apache.flink.streaming.api.functions.sink.RichSinkFunction
 import org.apache.flink.streaming.api.functions.source.SourceFunction
 import org.apache.flink.streaming.api.watermark.Watermark
 import org.apache.flink.test.checkpointing.utils.SavepointMigrationTestBase
-import org.apache.flink.testutils.migration.MigrationVersion
 import org.apache.flink.util.Collector
+
 import org.junit.runner.RunWith
 import org.junit.runners.Parameterized
 import org.junit.{Assert, Ignore, Test}
@@ -52,35 +53,35 @@ import scala.util.{Failure, Try}
 object StatefulJobWBroadcastStateMigrationITCase {
 
   @Parameterized.Parameters(name = "Migrate Savepoint / Backend: {0}")
-  def parameters: util.Collection[(MigrationVersion, String)] = {
+  def parameters: util.Collection[(FlinkVersion, String)] = {
     util.Arrays.asList(
-      (MigrationVersion.v1_5, StateBackendLoader.MEMORY_STATE_BACKEND_NAME),
-      (MigrationVersion.v1_5, StateBackendLoader.ROCKSDB_STATE_BACKEND_NAME),
-      (MigrationVersion.v1_6, StateBackendLoader.MEMORY_STATE_BACKEND_NAME),
-      (MigrationVersion.v1_6, StateBackendLoader.ROCKSDB_STATE_BACKEND_NAME),
-      (MigrationVersion.v1_7, StateBackendLoader.MEMORY_STATE_BACKEND_NAME),
-      (MigrationVersion.v1_7, StateBackendLoader.ROCKSDB_STATE_BACKEND_NAME),
-      (MigrationVersion.v1_8, StateBackendLoader.MEMORY_STATE_BACKEND_NAME),
-      (MigrationVersion.v1_8, StateBackendLoader.ROCKSDB_STATE_BACKEND_NAME),
-      (MigrationVersion.v1_9, StateBackendLoader.MEMORY_STATE_BACKEND_NAME),
-      (MigrationVersion.v1_9, StateBackendLoader.ROCKSDB_STATE_BACKEND_NAME),
-      (MigrationVersion.v1_10, StateBackendLoader.MEMORY_STATE_BACKEND_NAME),
-      (MigrationVersion.v1_10, StateBackendLoader.ROCKSDB_STATE_BACKEND_NAME),
-      (MigrationVersion.v1_11, StateBackendLoader.MEMORY_STATE_BACKEND_NAME),
-      (MigrationVersion.v1_11, StateBackendLoader.ROCKSDB_STATE_BACKEND_NAME),
-      (MigrationVersion.v1_12, StateBackendLoader.MEMORY_STATE_BACKEND_NAME),
-      (MigrationVersion.v1_12, StateBackendLoader.ROCKSDB_STATE_BACKEND_NAME),
-      (MigrationVersion.v1_13, StateBackendLoader.MEMORY_STATE_BACKEND_NAME),
-      (MigrationVersion.v1_13, StateBackendLoader.ROCKSDB_STATE_BACKEND_NAME),
-      (MigrationVersion.v1_14, StateBackendLoader.HASHMAP_STATE_BACKEND_NAME),
-      (MigrationVersion.v1_14, StateBackendLoader.ROCKSDB_STATE_BACKEND_NAME))
+      (FlinkVersion.v1_5, StateBackendLoader.MEMORY_STATE_BACKEND_NAME),
+      (FlinkVersion.v1_5, StateBackendLoader.ROCKSDB_STATE_BACKEND_NAME),
+      (FlinkVersion.v1_6, StateBackendLoader.MEMORY_STATE_BACKEND_NAME),
+      (FlinkVersion.v1_6, StateBackendLoader.ROCKSDB_STATE_BACKEND_NAME),
+      (FlinkVersion.v1_7, StateBackendLoader.MEMORY_STATE_BACKEND_NAME),
+      (FlinkVersion.v1_7, StateBackendLoader.ROCKSDB_STATE_BACKEND_NAME),
+      (FlinkVersion.v1_8, StateBackendLoader.MEMORY_STATE_BACKEND_NAME),
+      (FlinkVersion.v1_8, StateBackendLoader.ROCKSDB_STATE_BACKEND_NAME),
+      (FlinkVersion.v1_9, StateBackendLoader.MEMORY_STATE_BACKEND_NAME),
+      (FlinkVersion.v1_9, StateBackendLoader.ROCKSDB_STATE_BACKEND_NAME),
+      (FlinkVersion.v1_10, StateBackendLoader.MEMORY_STATE_BACKEND_NAME),
+      (FlinkVersion.v1_10, StateBackendLoader.ROCKSDB_STATE_BACKEND_NAME),
+      (FlinkVersion.v1_11, StateBackendLoader.MEMORY_STATE_BACKEND_NAME),
+      (FlinkVersion.v1_11, StateBackendLoader.ROCKSDB_STATE_BACKEND_NAME),
+      (FlinkVersion.v1_12, StateBackendLoader.MEMORY_STATE_BACKEND_NAME),
+      (FlinkVersion.v1_12, StateBackendLoader.ROCKSDB_STATE_BACKEND_NAME),
+      (FlinkVersion.v1_13, StateBackendLoader.MEMORY_STATE_BACKEND_NAME),
+      (FlinkVersion.v1_13, StateBackendLoader.ROCKSDB_STATE_BACKEND_NAME),
+      (FlinkVersion.v1_14, StateBackendLoader.HASHMAP_STATE_BACKEND_NAME),
+      (FlinkVersion.v1_14, StateBackendLoader.ROCKSDB_STATE_BACKEND_NAME))
   }
 
   // TODO to generate savepoints for a specific Flink version / backend type,
   // TODO change these values accordingly, e.g. to generate for 1.3 with RocksDB,
-  // TODO set as (MigrationVersion.v1_3, StateBackendLoader.ROCKSDB_STATE_BACKEND_NAME)
+  // TODO set as (FlinkVersion.v1_3, StateBackendLoader.ROCKSDB_STATE_BACKEND_NAME)
   // TODO Note: You should generate the savepoint based on the release branch instead of the master.
-  val GENERATE_SAVEPOINT_VER: MigrationVersion = MigrationVersion.v1_14
+  val GENERATE_SAVEPOINT_VER: FlinkVersion = FlinkVersion.v1_14
   val GENERATE_SAVEPOINT_BACKEND_TYPE: String = StateBackendLoader.HASHMAP_STATE_BACKEND_NAME
 
   val NUM_ELEMENTS = 4
@@ -91,7 +92,7 @@ object StatefulJobWBroadcastStateMigrationITCase {
   */
 @RunWith(classOf[Parameterized])
 class StatefulJobWBroadcastStateMigrationITCase(
-                                        migrationVersionAndBackend: (MigrationVersion, String))
+                                        migrationVersionAndBackend: (FlinkVersion, String))
   extends SavepointMigrationTestBase with Serializable {
 
   @Test


### PR DESCRIPTION
## What is the purpose of the change

Rename `MigrationVersion` to `FlinkVersion` and move it to
`flink-annoations` `org.apache.flink` package so that is available
globally and will facilitate the APIs and SQL/TableAPI versioning
and upgrades.

## Does this pull request potentially affect one of the following parts:

  - Dependencies (does it add or upgrade a dependency): **no**
  - The public API, i.e., is any changed class annotated with `@Public(Evolving)`: **yes**
  - The serializers: **no**
  - The runtime per-record code paths (performance sensitive): **no**
  - Anything that affects deployment or recovery: JobManager (and its components), Checkpointing, Kubernetes/Yarn, ZooKeeper:**no**
  - The S3 file system connector: **no**

## Documentation

  - Does this pull request introduce a new feature? **yes**
  - If yes, how is the feature documented? **update [release guide](https://cwiki.apache.org/confluence/display/FLINK/Creating+a+Flink+Release)**
