### PR TITLE
[DO NOT MERGE][FLINK-25085] Add scheduled executor service in MainThreadExecutor and close it when the server reaches termination

### DIFF
--- a/flink-rpc/flink-rpc-core/src/main/java/org/apache/flink/runtime/concurrent/ComponentMainThreadExecutor.java
+++ b/flink-rpc/flink-rpc-core/src/main/java/org/apache/flink/runtime/concurrent/ComponentMainThreadExecutor.java
@@ -35,6 +35,9 @@ public interface ComponentMainThreadExecutor extends ScheduledExecutor {
     /** Returns true if the method was called in the thread of this executor. */
     void assertRunningInMainThread();
 
+    /** Returns the scheduled executor for scheduled tasks. */
+    ScheduledExecutor getMainScheduledExecutor();
+
     /** Dummy implementation of ComponentMainThreadExecutor. */
     final class DummyComponentMainThreadExecutor implements ComponentMainThreadExecutor {
 
@@ -47,6 +50,11 @@ public interface ComponentMainThreadExecutor extends ScheduledExecutor {
 
         @Override
         public void assertRunningInMainThread() {
+            throw createException();
+        }
+
+        @Override
+        public ScheduledExecutor getMainScheduledExecutor() {
             throw createException();
         }
 

--- a/flink-rpc/flink-rpc-core/src/main/java/org/apache/flink/runtime/concurrent/MainScheduledExecutor.java
+++ b/flink-rpc/flink-rpc-core/src/main/java/org/apache/flink/runtime/concurrent/MainScheduledExecutor.java
@@ -1,0 +1,120 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.flink.runtime.concurrent;
+
+import org.apache.flink.runtime.rpc.MainThreadExecutable;
+import org.apache.flink.util.concurrent.ScheduledExecutor;
+
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import javax.annotation.Nonnull;
+
+import java.io.Closeable;
+import java.util.concurrent.Callable;
+import java.util.concurrent.Executors;
+import java.util.concurrent.FutureTask;
+import java.util.concurrent.ScheduledExecutorService;
+import java.util.concurrent.ScheduledFuture;
+import java.util.concurrent.TimeUnit;
+
+/**
+ * The main scheduled executor will manage the scheduled tasks. When the specified time arrives, the
+ * executor will send these tasks to gateway and execute them.
+ */
+public class MainScheduledExecutor implements ScheduledExecutor, Closeable {
+    private static final Logger log = LoggerFactory.getLogger(MainScheduledExecutor.class);
+
+    private final ScheduledExecutorService scheduledExecutorService;
+    private final MainThreadExecutable gateway;
+
+    public MainScheduledExecutor(MainThreadExecutable gateway) {
+        this.gateway = gateway;
+        this.scheduledExecutorService = Executors.newSingleThreadScheduledExecutor();
+    }
+
+    /**
+     * {@link ScheduledExecutorService} manages the task and sends it to the gateway after the given
+     * delay.
+     *
+     * @param command the task to execute in the future
+     * @param delay the time from now to delay the execution
+     * @param unit the time unit of the delay parameter
+     * @return a ScheduledFuture representing the completion of the scheduled task
+     */
+    @Override
+    public ScheduledFuture<?> schedule(Runnable command, long delay, TimeUnit unit) {
+        if (scheduledExecutorService.isShutdown()) {
+            log.warn("The scheduled executor for periodic tasks is shutdown.");
+            return ThrowingScheduledFuture.create();
+        } else {
+            return this.scheduledExecutorService.schedule(
+                    () -> gateway.runAsync(command), delay, unit);
+        }
+    }
+
+    /**
+     * {@link ScheduledExecutorService} manages the given callable and sends it to the gateway after
+     * the given delay. The result of the callable is returned as a {@link ScheduledFuture}.
+     *
+     * @param callable the callable to execute
+     * @param delay the time from now to delay the execution
+     * @param unit the time unit of the delay parameter
+     * @param <V> result type of the callable
+     * @return a ScheduledFuture which holds the future value of the given callable
+     */
+    @Override
+    public <V> ScheduledFuture<V> schedule(Callable<V> callable, long delay, TimeUnit unit) {
+        if (scheduledExecutorService.isShutdown()) {
+            log.warn("The scheduled executor for periodic tasks is shutdown.");
+            return ThrowingScheduledFuture.create();
+        } else {
+            final long delayMillis = TimeUnit.MILLISECONDS.convert(delay, unit);
+            FutureTask<V> ft = new FutureTask<>(callable);
+            this.scheduledExecutorService.schedule(() -> gateway.runAsync(ft), delay, unit);
+            return new ScheduledFutureAdapter<>(ft, delayMillis, TimeUnit.MILLISECONDS);
+        }
+    }
+
+    @Override
+    public ScheduledFuture<?> scheduleAtFixedRate(
+            Runnable command, long initialDelay, long period, TimeUnit unit) {
+        throw new UnsupportedOperationException(
+                "Not implemented because the method is currently not required.");
+    }
+
+    @Override
+    public ScheduledFuture<?> scheduleWithFixedDelay(
+            Runnable command, long initialDelay, long delay, TimeUnit unit) {
+        throw new UnsupportedOperationException(
+                "Not implemented because the method is currently not required.");
+    }
+
+    @Override
+    public void execute(@Nonnull Runnable command) {
+        throw new UnsupportedOperationException(
+                "Not implemented because the method is currently not required.");
+    }
+
+    /** Shutdown the {@link ScheduledExecutorService} and remove all the pending tasks. */
+    @Override
+    public void close() {
+        scheduledExecutorService.shutdownNow().clear();
+    }
+}

--- a/flink-rpc/flink-rpc-core/src/main/java/org/apache/flink/runtime/concurrent/ThrowingScheduledFuture.java
+++ b/flink-rpc/flink-rpc-core/src/main/java/org/apache/flink/runtime/concurrent/ThrowingScheduledFuture.java
@@ -1,0 +1,78 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.flink.runtime.concurrent;
+
+import javax.annotation.Nonnull;
+
+import java.util.concurrent.Delayed;
+import java.util.concurrent.ExecutionException;
+import java.util.concurrent.ScheduledFuture;
+import java.util.concurrent.TimeUnit;
+import java.util.concurrent.TimeoutException;
+
+/**
+ * Completed {@link ScheduledFuture} implementation.
+ *
+ * @param <T> type of the {@link ScheduledFuture}
+ */
+public final class ThrowingScheduledFuture<T> implements ScheduledFuture<T> {
+    private static final ThrowingScheduledFuture instance = new ThrowingScheduledFuture();
+
+    private ThrowingScheduledFuture() {}
+
+    @Override
+    public long getDelay(@Nonnull TimeUnit unit) {
+        throw new UnsupportedOperationException();
+    }
+
+    @Override
+    public int compareTo(Delayed o) {
+        return Long.compare(getDelay(TimeUnit.MILLISECONDS), o.getDelay(TimeUnit.MILLISECONDS));
+    }
+
+    @Override
+    public boolean cancel(boolean mayInterruptIfRunning) {
+        return true;
+    }
+
+    @Override
+    public boolean isCancelled() {
+        return true;
+    }
+
+    @Override
+    public boolean isDone() {
+        return true;
+    }
+
+    @Override
+    public T get() throws InterruptedException, ExecutionException {
+        throw new UnsupportedOperationException();
+    }
+
+    @Override
+    public T get(long timeout, @Nonnull TimeUnit unit)
+            throws InterruptedException, ExecutionException, TimeoutException {
+        throw new UnsupportedOperationException();
+    }
+
+    public static <T> ThrowingScheduledFuture<T> create() {
+        return instance;
+    }
+}

--- a/flink-rpc/flink-rpc-core/src/test/java/org/apache/flink/runtime/concurrent/MainScheduledExecutorTest.java
+++ b/flink-rpc/flink-rpc-core/src/test/java/org/apache/flink/runtime/concurrent/MainScheduledExecutorTest.java
@@ -1,0 +1,109 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.flink.runtime.concurrent;
+
+import org.apache.flink.api.common.time.Time;
+import org.apache.flink.runtime.rpc.MainThreadExecutable;
+
+import org.junit.Test;
+
+import java.util.concurrent.Callable;
+import java.util.concurrent.CompletableFuture;
+import java.util.concurrent.ScheduledFuture;
+import java.util.concurrent.TimeUnit;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertTrue;
+
+/** Unit tests for {@link MainScheduledExecutor}. */
+public class MainScheduledExecutorTest {
+    /** Test schedule runnable. */
+    @Test
+    public void testScheduleRunnable() throws Exception {
+        MainScheduledExecutor mainScheduledExecutor =
+                new MainScheduledExecutor(new TestRunnableMainThreadExecutable());
+        final int timeDelay = 1;
+        CompletableFuture<Integer> future = new CompletableFuture<>();
+        mainScheduledExecutor.schedule(
+                () -> {
+                    future.complete(timeDelay);
+                },
+                timeDelay,
+                TimeUnit.SECONDS);
+        assertEquals(timeDelay, (int) future.get(timeDelay * 2, TimeUnit.SECONDS));
+    }
+
+    /** Test schedule runnable after close. */
+    @Test
+    public void testScheduleRunnableAfterClose() {
+        MainScheduledExecutor mainScheduledExecutor =
+                new MainScheduledExecutor(new TestRunnableMainThreadExecutable());
+        final int timeDelay = 1;
+        CompletableFuture<Integer> future = new CompletableFuture<>();
+        mainScheduledExecutor.close();
+        ScheduledFuture<?> scheduledFuture =
+                mainScheduledExecutor.schedule(
+                        () -> {
+                            future.complete(timeDelay);
+                        },
+                        timeDelay,
+                        TimeUnit.SECONDS);
+        assertTrue(scheduledFuture instanceof ThrowingScheduledFuture);
+    }
+
+    /** Test schedule callable. */
+    @Test
+    public void testScheduleCallable() throws Exception {
+        MainScheduledExecutor mainScheduledExecutor =
+                new MainScheduledExecutor(new TestRunnableMainThreadExecutable());
+        final int timeDelay = 1;
+        ScheduledFuture<Integer> scheduledFuture =
+                mainScheduledExecutor.schedule(() -> timeDelay, timeDelay, TimeUnit.SECONDS);
+        assertEquals(timeDelay, (int) scheduledFuture.get(timeDelay * 2, TimeUnit.SECONDS));
+    }
+
+    /** Test schedule callable after close. */
+    @Test
+    public void testScheduleCallableAfterClose() {
+        MainScheduledExecutor mainScheduledExecutor =
+                new MainScheduledExecutor(new TestRunnableMainThreadExecutable());
+        mainScheduledExecutor.close();
+        final int timeDelay = 1;
+        ScheduledFuture<Integer> scheduledFuture =
+                mainScheduledExecutor.schedule(() -> timeDelay, timeDelay, TimeUnit.SECONDS);
+        assertTrue(scheduledFuture instanceof ThrowingScheduledFuture);
+    }
+
+    private static class TestRunnableMainThreadExecutable implements MainThreadExecutable {
+        @Override
+        public void runAsync(Runnable runnable) {
+            runnable.run();
+        }
+
+        @Override
+        public <V> CompletableFuture<V> callAsync(Callable<V> callable, Time callTimeout) {
+            throw new UnsupportedOperationException();
+        }
+
+        @Override
+        public void scheduleRunAsync(Runnable runnable, long delay) {
+            throw new UnsupportedOperationException();
+        }
+    }
+}

--- a/flink-runtime/src/test/java/org/apache/flink/runtime/concurrent/ComponentMainThreadExecutorServiceAdapter.java
+++ b/flink-runtime/src/test/java/org/apache/flink/runtime/concurrent/ComponentMainThreadExecutorServiceAdapter.java
@@ -87,6 +87,11 @@ public class ComponentMainThreadExecutorServiceAdapter implements ComponentMainT
     }
 
     @Override
+    public ScheduledExecutor getMainScheduledExecutor() {
+        throw new UnsupportedOperationException();
+    }
+
+    @Override
     public ScheduledFuture<?> schedule(
             final Runnable command, final long delay, final TimeUnit unit) {
         return scheduledExecutor.schedule(command, delay, unit);

--- a/flink-runtime/src/test/java/org/apache/flink/runtime/concurrent/ManuallyTriggeredComponentMainThreadExecutor.java
+++ b/flink-runtime/src/test/java/org/apache/flink/runtime/concurrent/ManuallyTriggeredComponentMainThreadExecutor.java
@@ -18,6 +18,8 @@
 
 package org.apache.flink.runtime.concurrent;
 
+import org.apache.flink.util.concurrent.ScheduledExecutor;
+
 /** Testing ComponentMainThreadExecutor which can be manually triggered. */
 public class ManuallyTriggeredComponentMainThreadExecutor
         extends ManuallyTriggeredScheduledExecutorService implements ComponentMainThreadExecutor {
@@ -31,6 +33,11 @@ public class ManuallyTriggeredComponentMainThreadExecutor
     @Override
     public void assertRunningInMainThread() {
         assert Thread.currentThread() == executorThread;
+    }
+
+    @Override
+    public ScheduledExecutor getMainScheduledExecutor() {
+        throw new UnsupportedOperationException();
     }
 
     @Override

--- a/flink-runtime/src/test/java/org/apache/flink/runtime/rpc/EndpointCloseableRegistryTest.java
+++ b/flink-runtime/src/test/java/org/apache/flink/runtime/rpc/EndpointCloseableRegistryTest.java
@@ -1,0 +1,51 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.flink.runtime.rpc;
+
+import org.apache.flink.core.fs.CloseableRegistry;
+import org.apache.flink.util.TestLogger;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertFalse;
+import static org.junit.Assert.assertTrue;
+
+/** Validate the given {@link CloseableRegistry} in test case. */
+public abstract class EndpointCloseableRegistryTest extends TestLogger {
+    /**
+     * Validate the registered closeable resource count of the given {@link CloseableRegistry}.
+     *
+     * @param registeredCount registered closeable resource count in given {@link CloseableRegistry}
+     * @param closeableRegistry the given {@link CloseableRegistry}
+     */
+    protected void validateRegisteredResourceCount(
+            int registeredCount, CloseableRegistry closeableRegistry) {
+        assertFalse(closeableRegistry.isClosed());
+        assertEquals(registeredCount, closeableRegistry.getNumberOfRegisteredCloseables());
+    }
+
+    /**
+     * Validate if the given {@link CloseableRegistry} is closed.
+     *
+     * @param closeableRegistry the given {@link CloseableRegistry}
+     */
+    protected void validateRegistryClosed(CloseableRegistry closeableRegistry) {
+        assertTrue(closeableRegistry.isClosed());
+        assertEquals(0, closeableRegistry.getNumberOfRegisteredCloseables());
+    }
+}


### PR DESCRIPTION
<!--
*Thank you very much for contributing to Apache Flink - we are happy that you want to help us improve Flink. To help the community review your contribution in the best possible way, please go through the checklist below, which will get the contribution into a shape in which it can be best reviewed.*

*Please understand that we do not do this to make contributions to Flink a hassle. In order to uphold a high standard of quality for code contributions, while at the same time managing a large number of contributions, we need contributors to prepare the contributions well, and give reviewers enough contextual information for the review. Please also understand that contributions that do not follow this guide will take longer to review and thus typically be picked up with lower priority by the community.*

## Contribution Checklist

  - Make sure that the pull request corresponds to a [JIRA issue](https://issues.apache.org/jira/projects/FLINK/issues). Exceptions are made for typos in JavaDoc or documentation files, which need no JIRA issue.
  
  - Name the pull request in the form "[FLINK-XXXX] [component] Title of the pull request", where *FLINK-XXXX* should be replaced by the actual issue number. Skip *component* if you are unsure about which is the best component.
  Typo fixes that have no associated JIRA issue should be named following this pattern: `[hotfix] [docs] Fix typo in event time introduction` or `[hotfix] [javadocs] Expand JavaDoc for PuncuatedWatermarkGenerator`.

  - Fill out the template below to describe the changes contributed by the pull request. That will give reviewers the context they need to do the review.
  
  - Make sure that the change passes the automated tests, i.e., `mvn clean verify` passes. You can set up Azure Pipelines CI to do that following [this guide](https://cwiki.apache.org/confluence/display/FLINK/Azure+Pipelines#AzurePipelines-Tutorial:SettingupAzurePipelinesforaforkoftheFlinkrepository).

  - Each pull request should address only one issue, not mix up code from multiple issues.
  
  - Each commit in the pull request has a meaningful commit message (including the JIRA id)

  - Once all items of the checklist are addressed, remove the above text and this checklist, leaving only the filled out template below.


**(The sections below can be removed for hotfixes of typos)**
-->

## What is the purpose of the change

*(For example: This pull request makes task deployment go through the blob server, rather than through RPC. That way we avoid re-transferring them on each deployment (during recovery).)*


## Brief change log

*(for example:)*
  - *The TaskInfo is stored in the blob store on job creation time as a persistent artifact*
  - *Deployments RPC transmits only the blob storage reference*
  - *TaskManagers retrieve the TaskInfo from the blob cache*


## Verifying this change

Please make sure both new and modified tests in this PR follows the conventions defined in our code quality guide: https://flink.apache.org/contributing/code-style-and-quality-common.html#testing

*(Please pick either of the following options)*

This change is a trivial rework / code cleanup without any test coverage.

*(or)*

This change is already covered by existing tests, such as *(please describe tests)*.

*(or)*

This change added tests and can be verified as follows:

*(example:)*
  - *Added integration tests for end-to-end deployment with large payloads (100MB)*
  - *Extended integration test for recovery after master (JobManager) failure*
  - *Added test that validates that TaskInfo is transferred only once across recoveries*
  - *Manually verified the change by running a 4 node cluser with 2 JobManagers and 4 TaskManagers, a stateful streaming program, and killing one JobManager and two TaskManagers during the execution, verifying that recovery happens correctly.*

## Does this pull request potentially affect one of the following parts:

  - Dependencies (does it add or upgrade a dependency): (yes / no)
  - The public API, i.e., is any changed class annotated with `@Public(Evolving)`: (yes / no)
  - The serializers: (yes / no / don't know)
  - The runtime per-record code paths (performance sensitive): (yes / no / don't know)
  - Anything that affects deployment or recovery: JobManager (and its components), Checkpointing, Kubernetes/Yarn, ZooKeeper: (yes / no / don't know)
  - The S3 file system connector: (yes / no / don't know)

## Documentation

  - Does this pull request introduce a new feature? (yes / no)
  - If yes, how is the feature documented? (not applicable / docs / JavaDocs / not documented)
