### PR TITLE
[FLINK-25642] The standalone deployment mode should also support the parameter pipeline.jars

### DIFF
--- a/flink-container/src/test/java/org/apache/flink/container/entrypoint/StandaloneApplicationClusterConfigurationParserFactoryTest.java
+++ b/flink-container/src/test/java/org/apache/flink/container/entrypoint/StandaloneApplicationClusterConfigurationParserFactoryTest.java
@@ -22,6 +22,7 @@ import org.apache.flink.api.common.JobID;
 import org.apache.flink.configuration.Configuration;
 import org.apache.flink.configuration.DeploymentOptions;
 import org.apache.flink.configuration.GlobalConfiguration;
+import org.apache.flink.configuration.PipelineOptions;
 import org.apache.flink.configuration.PipelineOptionsInternal;
 import org.apache.flink.configuration.RestOptions;
 import org.apache.flink.runtime.entrypoint.FlinkParseException;
@@ -37,6 +38,8 @@ import org.junit.rules.TemporaryFolder;
 
 import java.io.File;
 import java.io.IOException;
+import java.util.Collections;
+import java.util.List;
 import java.util.Optional;
 import java.util.Properties;
 
@@ -82,6 +85,7 @@ public class StandaloneApplicationClusterConfigurationParserFactoryTest extends 
         final int restPort = 1234;
         final String arg1 = "arg1";
         final String arg2 = "arg2";
+        final String jarPath = "file:///opt/flink/examples/streaming/WindowJoin.jar";
         final String[] args = {
             "--configDir",
             confDirPath,
@@ -107,6 +111,10 @@ public class StandaloneApplicationClusterConfigurationParserFactoryTest extends 
         final Configuration configuration =
                 StandaloneApplicationClusterEntryPoint.loadConfigurationFromClusterConfig(
                         clusterConfiguration);
+
+        configuration.set(PipelineOptions.JARS, Collections.singletonList(jarPath));
+        List<File> jars = StandaloneApplicationClusterEntryPoint.checkJarFileForApplicationMode(configuration);
+        assertThat(new File(jarPath).toURI().getScheme(), is(equalTo(jars.get(0).toURI().getScheme())));
 
         final String strJobId = configuration.get(PipelineOptionsInternal.PIPELINE_FIXED_JOB_ID);
         assertThat(JobID.fromHexString(strJobId), is(equalTo(jobID)));


### PR DESCRIPTION
## What is the purpose of the change
The standalone deployment mode should also support the parameter pipeline.jars. Although we can put the jar package in the lib directory or usrlib, it is still not flexible enough. I think it is necessary to support the parameter pipeline.jars. Especially when we deploy jobs on kubernetes.


## Brief change log
  - When constructing PackagedProgramRetriever in StandaloneApplicationClusterEntryPoint, the parameter pipeline.jars is read from the configuration file. If there is a value, we set it as the jarFile property of PackagedProgramRetriever.

## Verifying this change
 - Test passed in StandaloneApplicationClusterConfigurationParserFactoryTest。

## Does this pull request potentially affect one of the following parts:

  - Dependencies (does it add or upgrade a dependency): (no)
  - The public API, i.e., is any changed class annotated with `@Public(Evolving)`: (no)
  - The serializers: (yes / no / don't know)
  - The runtime per-record code paths (performance sensitive): (no)
  - Anything that affects deployment or recovery: JobManager (and its components), Checkpointing, Kubernetes/Yarn, ZooKeeper: (no)
  - The S3 file system connector: (no)

## Documentation

  - Does this pull request introduce a new feature? (no)
  - If yes, how is the feature documented? (no)
