### PR TITLE
[hotfix][flink-annotations] Add v1.15 as the next Flink version to master

### DIFF
--- a/flink-annotations/src/main/java/org/apache/flink/FlinkVersion.java
+++ b/flink-annotations/src/main/java/org/apache/flink/FlinkVersion.java
@@ -51,7 +51,8 @@ public enum FlinkVersion {
     v1_11("1.11"),
     v1_12("1.12"),
     v1_13("1.13"),
-    v1_14("1.14");
+    v1_14("1.14"),
+    v1_15("1.15");
 
     private final String versionStr;
 


### PR DESCRIPTION
The upcoming version to be released need to exist already in master so that
when the new release branch is created from master the version of the release
is already there.

Follows: #18340
