### PR TITLE
[FLINK-25329][runtime] Support memory execution graph store in session cluster

### DIFF
--- a/docs/layouts/shortcodes/generated/all_jobmanager_section.html
+++ b/docs/layouts/shortcodes/generated/all_jobmanager_section.html
@@ -120,7 +120,13 @@
             <td><h5>jobstore.max-capacity</h5></td>
             <td style="word-wrap: break-word;">2147483647</td>
             <td>Integer</td>
-            <td>The max number of completed jobs that can be kept in the job store.</td>
+            <td>The max number of completed jobs that can be kept in the job store. NOTICE: if memory store keeps too many jobs in session cluster, it may cause FullGC or OOM in jm.</td>
+        </tr>
+        <tr>
+            <td><h5>jobstore.type</h5></td>
+            <td style="word-wrap: break-word;">File</td>
+            <td><p>Enum</p></td>
+            <td>Determines which job store implementation is used in session cluster. Accepted values are:<ul><li>'File': the file job store keeps the archived execution graphs in files</li><li>'Memory': the memory job store keeps the archived execution graphs in memory. You may need to limit the <code class="highlighter-rouge">jobstore.max-capacity</code> to mitigate FullGC or OOM when there are too many graphs</li></ul><br /><br />Possible values:<ul><li>"File"</li><li>"Memory"</li></ul></td>
         </tr>
         <tr>
             <td><h5>web.exception-history-size</h5></td>

--- a/docs/layouts/shortcodes/generated/job_manager_configuration.html
+++ b/docs/layouts/shortcodes/generated/job_manager_configuration.html
@@ -186,7 +186,13 @@
             <td><h5>jobstore.max-capacity</h5></td>
             <td style="word-wrap: break-word;">2147483647</td>
             <td>Integer</td>
-            <td>The max number of completed jobs that can be kept in the job store.</td>
+            <td>The max number of completed jobs that can be kept in the job store. NOTICE: if memory store keeps too many jobs in session cluster, it may cause FullGC or OOM in jm.</td>
+        </tr>
+        <tr>
+            <td><h5>jobstore.type</h5></td>
+            <td style="word-wrap: break-word;">File</td>
+            <td><p>Enum</p></td>
+            <td>Determines which job store implementation is used in session cluster. Accepted values are:<ul><li>'File': the file job store keeps the archived execution graphs in files</li><li>'Memory': the memory job store keeps the archived execution graphs in memory. You may need to limit the <code class="highlighter-rouge">jobstore.max-capacity</code> to mitigate FullGC or OOM when there are too many graphs</li></ul><br /><br />Possible values:<ul><li>"File"</li><li>"Memory"</li></ul></td>
         </tr>
         <tr>
             <td><h5>scheduler-mode</h5></td>

--- a/flink-core/src/main/java/org/apache/flink/configuration/JobManagerOptions.java
+++ b/flink-core/src/main/java/org/apache/flink/configuration/JobManagerOptions.java
@@ -314,7 +314,33 @@ public class JobManagerOptions {
             key("jobstore.max-capacity")
                     .defaultValue(Integer.MAX_VALUE)
                     .withDescription(
-                            "The max number of completed jobs that can be kept in the job store.");
+                            "The max number of completed jobs that can be kept in the job store. "
+                                    + "NOTICE: if memory store keeps too many jobs in session cluster, it may cause FullGC or OOM in jm.");
+
+    /** Config parameter determining the job store implementation in session cluster. */
+    @Documentation.Section(Documentation.Sections.ALL_JOB_MANAGER)
+    public static final ConfigOption<JobStoreType> JOB_STORE_TYPE =
+            key("jobstore.type")
+                    .enumType(JobStoreType.class)
+                    .defaultValue(JobStoreType.File)
+                    .withDescription(
+                            Description.builder()
+                                    .text(
+                                            "Determines which job store implementation is used in session cluster. Accepted values are:")
+                                    .list(
+                                            text(
+                                                    "'File': the file job store keeps the archived execution graphs in files"),
+                                            text(
+                                                    "'Memory': the memory job store keeps the archived execution graphs in memory. You"
+                                                            + " may need to limit the %s to mitigate FullGC or OOM when there are too many graphs",
+                                                    code(JOB_STORE_MAX_CAPACITY.key())))
+                                    .build());
+
+    /** Type of job store implementation. */
+    public enum JobStoreType {
+        File,
+        Memory
+    }
 
     /**
      * Flag indicating whether JobManager would retrieve canonical host name of TaskManager during

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/entrypoint/SessionClusterEntrypoint.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/entrypoint/SessionClusterEntrypoint.java
@@ -24,6 +24,7 @@ import org.apache.flink.configuration.ConfigurationUtils;
 import org.apache.flink.configuration.JobManagerOptions;
 import org.apache.flink.runtime.dispatcher.ExecutionGraphInfoStore;
 import org.apache.flink.runtime.dispatcher.FileExecutionGraphInfoStore;
+import org.apache.flink.runtime.dispatcher.MemoryExecutionGraphInfoStore;
 import org.apache.flink.util.concurrent.ScheduledExecutor;
 
 import org.apache.flink.shaded.guava30.com.google.common.base.Ticker;
@@ -41,21 +42,42 @@ public abstract class SessionClusterEntrypoint extends ClusterEntrypoint {
     @Override
     protected ExecutionGraphInfoStore createSerializableExecutionGraphStore(
             Configuration configuration, ScheduledExecutor scheduledExecutor) throws IOException {
-        final File tmpDir = new File(ConfigurationUtils.parseTempDirectories(configuration)[0]);
-
+        final JobManagerOptions.JobStoreType jobStoreType =
+                configuration.get(JobManagerOptions.JOB_STORE_TYPE);
         final Time expirationTime =
                 Time.seconds(configuration.getLong(JobManagerOptions.JOB_STORE_EXPIRATION_TIME));
         final int maximumCapacity =
                 configuration.getInteger(JobManagerOptions.JOB_STORE_MAX_CAPACITY);
-        final long maximumCacheSizeBytes =
-                configuration.getLong(JobManagerOptions.JOB_STORE_CACHE_SIZE);
 
-        return new FileExecutionGraphInfoStore(
-                tmpDir,
-                expirationTime,
-                maximumCapacity,
-                maximumCacheSizeBytes,
-                scheduledExecutor,
-                Ticker.systemTicker());
+        switch (jobStoreType) {
+            case File:
+                {
+                    final File tmpDir =
+                            new File(ConfigurationUtils.parseTempDirectories(configuration)[0]);
+                    final long maximumCacheSizeBytes =
+                            configuration.getLong(JobManagerOptions.JOB_STORE_CACHE_SIZE);
+
+                    return new FileExecutionGraphInfoStore(
+                            tmpDir,
+                            expirationTime,
+                            maximumCapacity,
+                            maximumCacheSizeBytes,
+                            scheduledExecutor,
+                            Ticker.systemTicker());
+                }
+            case Memory:
+                {
+                    return new MemoryExecutionGraphInfoStore(
+                            expirationTime,
+                            maximumCapacity,
+                            scheduledExecutor,
+                            Ticker.systemTicker());
+                }
+            default:
+                {
+                    throw new IllegalArgumentException(
+                            "Unsupported job store type " + jobStoreType);
+                }
+        }
     }
 }

--- a/flink-runtime/src/test/java/org/apache/flink/runtime/dispatcher/ExecutionGraphInfoStoreTestUtils.java
+++ b/flink-runtime/src/test/java/org/apache/flink/runtime/dispatcher/ExecutionGraphInfoStoreTestUtils.java
@@ -21,6 +21,7 @@ package org.apache.flink.runtime.dispatcher;
 import org.apache.flink.api.common.JobStatus;
 import org.apache.flink.api.common.time.Time;
 import org.apache.flink.configuration.Configuration;
+import org.apache.flink.configuration.JobManagerOptions;
 import org.apache.flink.core.testutils.OneShotLatch;
 import org.apache.flink.runtime.blob.BlobServer;
 import org.apache.flink.runtime.clusterframework.types.ResourceID;
@@ -203,8 +204,26 @@ public class ExecutionGraphInfoStoreTestUtils {
                                     .createSessionComponentFactory(
                                             StandaloneResourceManagerFactory.getInstance());
 
-            final ExecutionGraphInfoStore executionGraphInfoStore =
-                    createDefaultExecutionGraphInfoStore(rootDir);
+            JobManagerOptions.JobStoreType jobStoreType =
+                    configuration.get(JobManagerOptions.JOB_STORE_TYPE);
+            final ExecutionGraphInfoStore executionGraphInfoStore;
+            switch (jobStoreType) {
+                case File:
+                    {
+                        executionGraphInfoStore = createDefaultExecutionGraphInfoStore(rootDir);
+                        break;
+                    }
+                case Memory:
+                    {
+                        executionGraphInfoStore = new MemoryExecutionGraphInfoStore();
+                        break;
+                    }
+                default:
+                    {
+                        throw new UnsupportedOperationException(
+                                "Unsupported job store type " + jobStoreType);
+                    }
+            }
 
             return Collections.singleton(
                     dispatcherResourceManagerComponentFactory.create(

--- a/flink-runtime/src/test/java/org/apache/flink/runtime/dispatcher/ExecutionGraphInfoStoreTestUtils.java
+++ b/flink-runtime/src/test/java/org/apache/flink/runtime/dispatcher/ExecutionGraphInfoStoreTestUtils.java
@@ -1,0 +1,235 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.flink.runtime.dispatcher;
+
+import org.apache.flink.api.common.JobStatus;
+import org.apache.flink.api.common.time.Time;
+import org.apache.flink.configuration.Configuration;
+import org.apache.flink.core.testutils.OneShotLatch;
+import org.apache.flink.runtime.blob.BlobServer;
+import org.apache.flink.runtime.clusterframework.types.ResourceID;
+import org.apache.flink.runtime.entrypoint.component.DefaultDispatcherResourceManagerComponentFactory;
+import org.apache.flink.runtime.entrypoint.component.DispatcherResourceManagerComponent;
+import org.apache.flink.runtime.entrypoint.component.DispatcherResourceManagerComponentFactory;
+import org.apache.flink.runtime.execution.Environment;
+import org.apache.flink.runtime.executiongraph.ArchivedExecutionGraph;
+import org.apache.flink.runtime.heartbeat.HeartbeatServices;
+import org.apache.flink.runtime.highavailability.HighAvailabilityServices;
+import org.apache.flink.runtime.jobgraph.tasks.AbstractInvokable;
+import org.apache.flink.runtime.messages.webmonitor.JobDetails;
+import org.apache.flink.runtime.metrics.MetricRegistry;
+import org.apache.flink.runtime.minicluster.MiniCluster;
+import org.apache.flink.runtime.minicluster.MiniClusterConfiguration;
+import org.apache.flink.runtime.resourcemanager.StandaloneResourceManagerFactory;
+import org.apache.flink.runtime.rest.handler.legacy.utils.ArchivedExecutionGraphBuilder;
+import org.apache.flink.runtime.rpc.FatalErrorHandler;
+import org.apache.flink.runtime.scheduler.ExecutionGraphInfo;
+import org.apache.flink.runtime.webmonitor.retriever.MetricQueryServiceRetriever;
+import org.apache.flink.testutils.TestingUtils;
+import org.apache.flink.util.Preconditions;
+
+import org.apache.flink.shaded.guava30.com.google.common.base.Ticker;
+
+import org.hamcrest.BaseMatcher;
+import org.hamcrest.Description;
+
+import javax.annotation.Nullable;
+
+import java.io.File;
+import java.io.IOException;
+import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.Collection;
+import java.util.Collections;
+import java.util.List;
+import java.util.Objects;
+import java.util.concurrent.ThreadLocalRandom;
+import java.util.stream.Collectors;
+
+/** Test utils class for {@link FileExecutionGraphInfoStore}. */
+public class ExecutionGraphInfoStoreTestUtils {
+
+    static final List<JobStatus> GLOBALLY_TERMINAL_JOB_STATUS =
+            Arrays.stream(JobStatus.values())
+                    .filter(JobStatus::isGloballyTerminalState)
+                    .collect(Collectors.toList());
+
+    /**
+     * Generate a specified of ExecutionGraphInfo.
+     *
+     * @param number the given number
+     * @return the result ExecutionGraphInfo collection
+     */
+    static Collection<ExecutionGraphInfo> generateTerminalExecutionGraphInfos(int number) {
+        final Collection<ExecutionGraphInfo> executionGraphInfos = new ArrayList<>(number);
+
+        for (int i = 0; i < number; i++) {
+            final JobStatus state =
+                    GLOBALLY_TERMINAL_JOB_STATUS.get(
+                            ThreadLocalRandom.current()
+                                    .nextInt(GLOBALLY_TERMINAL_JOB_STATUS.size()));
+            executionGraphInfos.add(
+                    new ExecutionGraphInfo(
+                            new ArchivedExecutionGraphBuilder().setState(state).build()));
+        }
+
+        return executionGraphInfos;
+    }
+
+    /** Compare whether two ExecutionGraphInfo instances are equivalent. */
+    static final class PartialExecutionGraphInfoMatcher extends BaseMatcher<ExecutionGraphInfo> {
+
+        private final ExecutionGraphInfo expectedExecutionGraphInfo;
+
+        PartialExecutionGraphInfoMatcher(ExecutionGraphInfo expectedExecutionGraphInfo) {
+            this.expectedExecutionGraphInfo =
+                    Preconditions.checkNotNull(expectedExecutionGraphInfo);
+        }
+
+        @Override
+        public boolean matches(Object o) {
+            if (expectedExecutionGraphInfo == o) {
+                return true;
+            }
+            if (o == null || expectedExecutionGraphInfo.getClass() != o.getClass()) {
+                return false;
+            }
+            ExecutionGraphInfo that = (ExecutionGraphInfo) o;
+
+            ArchivedExecutionGraph thisExecutionGraph =
+                    expectedExecutionGraphInfo.getArchivedExecutionGraph();
+            ArchivedExecutionGraph thatExecutionGraph = that.getArchivedExecutionGraph();
+            return thisExecutionGraph.isStoppable() == thatExecutionGraph.isStoppable()
+                    && Objects.equals(thisExecutionGraph.getJobID(), thatExecutionGraph.getJobID())
+                    && Objects.equals(
+                            thisExecutionGraph.getJobName(), thatExecutionGraph.getJobName())
+                    && thisExecutionGraph.getState() == thatExecutionGraph.getState()
+                    && Objects.equals(
+                            thisExecutionGraph.getJsonPlan(), thatExecutionGraph.getJsonPlan())
+                    && Objects.equals(
+                            thisExecutionGraph.getAccumulatorsSerialized(),
+                            thatExecutionGraph.getAccumulatorsSerialized())
+                    && Objects.equals(
+                            thisExecutionGraph.getCheckpointCoordinatorConfiguration(),
+                            thatExecutionGraph.getCheckpointCoordinatorConfiguration())
+                    && thisExecutionGraph.getAllVertices().size()
+                            == thatExecutionGraph.getAllVertices().size()
+                    && Objects.equals(
+                            expectedExecutionGraphInfo.getExceptionHistory(),
+                            that.getExceptionHistory());
+        }
+
+        @Override
+        public void describeTo(Description description) {
+            description.appendText(
+                    "Matches against " + ExecutionGraphInfo.class.getSimpleName() + '.');
+        }
+    }
+
+    static Collection<JobDetails> generateJobDetails(
+            Collection<ExecutionGraphInfo> executionGraphInfos) {
+        return executionGraphInfos.stream()
+                .map(ExecutionGraphInfo::getArchivedExecutionGraph)
+                .map(JobDetails::createDetailsForJob)
+                .collect(Collectors.toList());
+    }
+
+    /**
+     * Invokable which signals with {@link
+     * ExecutionGraphInfoStoreTestUtils.SignallingBlockingNoOpInvokable#LATCH} when it is invoked
+     * and blocks forever afterwards.
+     */
+    public static class SignallingBlockingNoOpInvokable extends AbstractInvokable {
+
+        /** Latch used to signal an initial invocation. */
+        public static final OneShotLatch LATCH = new OneShotLatch();
+
+        public SignallingBlockingNoOpInvokable(Environment environment) {
+            super(environment);
+        }
+
+        @Override
+        public void invoke() throws Exception {
+            LATCH.trigger();
+            Thread.sleep(Long.MAX_VALUE);
+        }
+    }
+
+    /** MiniCluster with specified {@link ExecutionGraphInfoStore}. */
+    static class PersistingMiniCluster extends MiniCluster {
+        @Nullable private final File rootDir;
+
+        PersistingMiniCluster(MiniClusterConfiguration miniClusterConfiguration) {
+            this(miniClusterConfiguration, null);
+        }
+
+        PersistingMiniCluster(
+                MiniClusterConfiguration miniClusterConfiguration, @Nullable File rootDir) {
+            super(miniClusterConfiguration);
+            this.rootDir = rootDir;
+        }
+
+        @Override
+        protected Collection<? extends DispatcherResourceManagerComponent>
+                createDispatcherResourceManagerComponents(
+                        Configuration configuration,
+                        RpcServiceFactory rpcServiceFactory,
+                        HighAvailabilityServices haServices,
+                        BlobServer blobServer,
+                        HeartbeatServices heartbeatServices,
+                        MetricRegistry metricRegistry,
+                        MetricQueryServiceRetriever metricQueryServiceRetriever,
+                        FatalErrorHandler fatalErrorHandler)
+                        throws Exception {
+            final DispatcherResourceManagerComponentFactory
+                    dispatcherResourceManagerComponentFactory =
+                            DefaultDispatcherResourceManagerComponentFactory
+                                    .createSessionComponentFactory(
+                                            StandaloneResourceManagerFactory.getInstance());
+
+            final ExecutionGraphInfoStore executionGraphInfoStore =
+                    createDefaultExecutionGraphInfoStore(rootDir);
+
+            return Collections.singleton(
+                    dispatcherResourceManagerComponentFactory.create(
+                            configuration,
+                            ResourceID.generate(),
+                            getIOExecutor(),
+                            rpcServiceFactory.createRpcService(),
+                            haServices,
+                            blobServer,
+                            heartbeatServices,
+                            metricRegistry,
+                            executionGraphInfoStore,
+                            metricQueryServiceRetriever,
+                            fatalErrorHandler));
+        }
+    }
+
+    static FileExecutionGraphInfoStore createDefaultExecutionGraphInfoStore(File storageDirectory)
+            throws IOException {
+        return new FileExecutionGraphInfoStore(
+                storageDirectory,
+                Time.hours(1L),
+                Integer.MAX_VALUE,
+                10000L,
+                TestingUtils.defaultScheduledExecutor(),
+                Ticker.systemTicker());
+    }
+}

--- a/flink-runtime/src/test/java/org/apache/flink/runtime/dispatcher/FileExecutionGraphInfoStoreTest.java
+++ b/flink-runtime/src/test/java/org/apache/flink/runtime/dispatcher/FileExecutionGraphInfoStoreTest.java
@@ -21,42 +21,24 @@ package org.apache.flink.runtime.dispatcher;
 import org.apache.flink.api.common.JobID;
 import org.apache.flink.api.common.JobStatus;
 import org.apache.flink.api.common.time.Time;
-import org.apache.flink.configuration.Configuration;
-import org.apache.flink.core.testutils.OneShotLatch;
-import org.apache.flink.runtime.blob.BlobServer;
-import org.apache.flink.runtime.clusterframework.types.ResourceID;
-import org.apache.flink.runtime.entrypoint.component.DefaultDispatcherResourceManagerComponentFactory;
-import org.apache.flink.runtime.entrypoint.component.DispatcherResourceManagerComponent;
-import org.apache.flink.runtime.entrypoint.component.DispatcherResourceManagerComponentFactory;
-import org.apache.flink.runtime.execution.Environment;
 import org.apache.flink.runtime.executiongraph.ArchivedExecutionGraph;
-import org.apache.flink.runtime.heartbeat.HeartbeatServices;
-import org.apache.flink.runtime.highavailability.HighAvailabilityServices;
 import org.apache.flink.runtime.jobgraph.JobGraph;
 import org.apache.flink.runtime.jobgraph.JobGraphTestUtils;
 import org.apache.flink.runtime.jobgraph.JobVertex;
-import org.apache.flink.runtime.jobgraph.tasks.AbstractInvokable;
 import org.apache.flink.runtime.messages.webmonitor.JobDetails;
 import org.apache.flink.runtime.messages.webmonitor.JobsOverview;
-import org.apache.flink.runtime.metrics.MetricRegistry;
 import org.apache.flink.runtime.minicluster.MiniCluster;
 import org.apache.flink.runtime.minicluster.MiniClusterConfiguration;
-import org.apache.flink.runtime.resourcemanager.StandaloneResourceManagerFactory;
 import org.apache.flink.runtime.rest.handler.legacy.utils.ArchivedExecutionGraphBuilder;
-import org.apache.flink.runtime.rpc.FatalErrorHandler;
 import org.apache.flink.runtime.scheduler.ExecutionGraphInfo;
 import org.apache.flink.runtime.util.ManualTicker;
-import org.apache.flink.runtime.webmonitor.retriever.MetricQueryServiceRetriever;
 import org.apache.flink.testutils.TestingUtils;
-import org.apache.flink.util.Preconditions;
 import org.apache.flink.util.TestLogger;
 import org.apache.flink.util.concurrent.ManuallyTriggeredScheduledExecutor;
 
 import org.apache.flink.shaded.guava30.com.google.common.base.Ticker;
 import org.apache.flink.shaded.guava30.com.google.common.cache.LoadingCache;
 
-import org.hamcrest.BaseMatcher;
-import org.hamcrest.Description;
 import org.hamcrest.Matcher;
 import org.hamcrest.Matchers;
 import org.junit.ClassRule;
@@ -66,27 +48,20 @@ import org.junit.rules.TemporaryFolder;
 import java.io.File;
 import java.io.IOException;
 import java.util.ArrayList;
-import java.util.Arrays;
 import java.util.Collection;
-import java.util.Collections;
 import java.util.List;
-import java.util.Objects;
-import java.util.concurrent.ThreadLocalRandom;
 import java.util.concurrent.TimeUnit;
 import java.util.stream.Collectors;
 
+import static org.apache.flink.runtime.dispatcher.ExecutionGraphInfoStoreTestUtils.createDefaultExecutionGraphInfoStore;
+import static org.apache.flink.runtime.dispatcher.ExecutionGraphInfoStoreTestUtils.generateJobDetails;
+import static org.apache.flink.runtime.dispatcher.ExecutionGraphInfoStoreTestUtils.generateTerminalExecutionGraphInfos;
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertThat;
 import static org.junit.Assert.assertTrue;
 
 /** Tests for the {@link FileExecutionGraphInfoStore}. */
 public class FileExecutionGraphInfoStoreTest extends TestLogger {
-
-    private static final List<JobStatus> GLOBALLY_TERMINAL_JOB_STATUS =
-            Arrays.stream(JobStatus.values())
-                    .filter(JobStatus::isGloballyTerminalState)
-                    .collect(Collectors.toList());
-
     @ClassRule public static TemporaryFolder temporaryFolder = new TemporaryFolder();
 
     /**
@@ -346,157 +321,19 @@ public class FileExecutionGraphInfoStoreTest extends TestLogger {
     /** Tests that a session cluster can terminate gracefully when jobs are still running. */
     @Test
     public void testPutSuspendedJobOnClusterShutdown() throws Exception {
+        File rootDir = temporaryFolder.newFolder();
         try (final MiniCluster miniCluster =
-                new PersistingMiniCluster(new MiniClusterConfiguration.Builder().build())) {
+                new ExecutionGraphInfoStoreTestUtils.PersistingMiniCluster(
+                        new MiniClusterConfiguration.Builder().build(), rootDir)) {
             miniCluster.start();
             final JobVertex vertex = new JobVertex("blockingVertex");
             // The adaptive scheduler expects that every vertex has a configured parallelism
             vertex.setParallelism(1);
-            vertex.setInvokableClass(SignallingBlockingNoOpInvokable.class);
+            vertex.setInvokableClass(
+                    ExecutionGraphInfoStoreTestUtils.SignallingBlockingNoOpInvokable.class);
             final JobGraph jobGraph = JobGraphTestUtils.streamingJobGraph(vertex);
             miniCluster.submitJob(jobGraph);
-            SignallingBlockingNoOpInvokable.LATCH.await();
-        }
-    }
-
-    /**
-     * Invokable which signals with {@link SignallingBlockingNoOpInvokable#LATCH} when it is invoked
-     * and blocks forever afterwards.
-     */
-    public static class SignallingBlockingNoOpInvokable extends AbstractInvokable {
-
-        /** Latch used to signal an initial invocation. */
-        public static final OneShotLatch LATCH = new OneShotLatch();
-
-        public SignallingBlockingNoOpInvokable(Environment environment) {
-            super(environment);
-        }
-
-        @Override
-        public void invoke() throws Exception {
-            LATCH.trigger();
-            Thread.sleep(Long.MAX_VALUE);
-        }
-    }
-
-    private class PersistingMiniCluster extends MiniCluster {
-
-        PersistingMiniCluster(MiniClusterConfiguration miniClusterConfiguration) {
-            super(miniClusterConfiguration);
-        }
-
-        @Override
-        protected Collection<? extends DispatcherResourceManagerComponent>
-                createDispatcherResourceManagerComponents(
-                        Configuration configuration,
-                        RpcServiceFactory rpcServiceFactory,
-                        HighAvailabilityServices haServices,
-                        BlobServer blobServer,
-                        HeartbeatServices heartbeatServices,
-                        MetricRegistry metricRegistry,
-                        MetricQueryServiceRetriever metricQueryServiceRetriever,
-                        FatalErrorHandler fatalErrorHandler)
-                        throws Exception {
-            final DispatcherResourceManagerComponentFactory
-                    dispatcherResourceManagerComponentFactory =
-                            DefaultDispatcherResourceManagerComponentFactory
-                                    .createSessionComponentFactory(
-                                            StandaloneResourceManagerFactory.getInstance());
-
-            final File rootDir = temporaryFolder.newFolder();
-            final ExecutionGraphInfoStore executionGraphInfoStore =
-                    createDefaultExecutionGraphInfoStore(rootDir);
-
-            return Collections.singleton(
-                    dispatcherResourceManagerComponentFactory.create(
-                            configuration,
-                            ResourceID.generate(),
-                            getIOExecutor(),
-                            rpcServiceFactory.createRpcService(),
-                            haServices,
-                            blobServer,
-                            heartbeatServices,
-                            metricRegistry,
-                            executionGraphInfoStore,
-                            metricQueryServiceRetriever,
-                            fatalErrorHandler));
-        }
-    }
-
-    private Collection<ExecutionGraphInfo> generateTerminalExecutionGraphInfos(int number) {
-        final Collection<ExecutionGraphInfo> executionGraphInfos = new ArrayList<>(number);
-
-        for (int i = 0; i < number; i++) {
-            final JobStatus state =
-                    GLOBALLY_TERMINAL_JOB_STATUS.get(
-                            ThreadLocalRandom.current()
-                                    .nextInt(GLOBALLY_TERMINAL_JOB_STATUS.size()));
-            executionGraphInfos.add(
-                    new ExecutionGraphInfo(
-                            new ArchivedExecutionGraphBuilder().setState(state).build()));
-        }
-
-        return executionGraphInfos;
-    }
-
-    private FileExecutionGraphInfoStore createDefaultExecutionGraphInfoStore(File storageDirectory)
-            throws IOException {
-        return new FileExecutionGraphInfoStore(
-                storageDirectory,
-                Time.hours(1L),
-                Integer.MAX_VALUE,
-                10000L,
-                TestingUtils.defaultScheduledExecutor(),
-                Ticker.systemTicker());
-    }
-
-    private static final class PartialExecutionGraphInfoMatcher
-            extends BaseMatcher<ExecutionGraphInfo> {
-
-        private final ExecutionGraphInfo expectedExecutionGraphInfo;
-
-        private PartialExecutionGraphInfoMatcher(ExecutionGraphInfo expectedExecutionGraphInfo) {
-            this.expectedExecutionGraphInfo =
-                    Preconditions.checkNotNull(expectedExecutionGraphInfo);
-        }
-
-        @Override
-        public boolean matches(Object o) {
-            if (expectedExecutionGraphInfo == o) {
-                return true;
-            }
-            if (o == null || expectedExecutionGraphInfo.getClass() != o.getClass()) {
-                return false;
-            }
-            ExecutionGraphInfo that = (ExecutionGraphInfo) o;
-
-            ArchivedExecutionGraph thisExecutionGraph =
-                    expectedExecutionGraphInfo.getArchivedExecutionGraph();
-            ArchivedExecutionGraph thatExecutionGraph = that.getArchivedExecutionGraph();
-            return thisExecutionGraph.isStoppable() == thatExecutionGraph.isStoppable()
-                    && Objects.equals(thisExecutionGraph.getJobID(), thatExecutionGraph.getJobID())
-                    && Objects.equals(
-                            thisExecutionGraph.getJobName(), thatExecutionGraph.getJobName())
-                    && thisExecutionGraph.getState() == thatExecutionGraph.getState()
-                    && Objects.equals(
-                            thisExecutionGraph.getJsonPlan(), thatExecutionGraph.getJsonPlan())
-                    && Objects.equals(
-                            thisExecutionGraph.getAccumulatorsSerialized(),
-                            thatExecutionGraph.getAccumulatorsSerialized())
-                    && Objects.equals(
-                            thisExecutionGraph.getCheckpointCoordinatorConfiguration(),
-                            thatExecutionGraph.getCheckpointCoordinatorConfiguration())
-                    && thisExecutionGraph.getAllVertices().size()
-                            == thatExecutionGraph.getAllVertices().size()
-                    && Objects.equals(
-                            expectedExecutionGraphInfo.getExceptionHistory(),
-                            that.getExceptionHistory());
-        }
-
-        @Override
-        public void describeTo(Description description) {
-            description.appendText(
-                    "Matches against " + ExecutionGraphInfo.class.getSimpleName() + '.');
+            ExecutionGraphInfoStoreTestUtils.SignallingBlockingNoOpInvokable.LATCH.await();
         }
     }
 
@@ -521,20 +358,14 @@ public class FileExecutionGraphInfoStoreTest extends TestLogger {
 
             assertThat(
                     executionGraphStore.get(dummyExecutionGraphInfo.getJobId()),
-                    new PartialExecutionGraphInfoMatcher(dummyExecutionGraphInfo));
+                    new ExecutionGraphInfoStoreTestUtils.PartialExecutionGraphInfoMatcher(
+                            dummyExecutionGraphInfo));
         }
     }
 
     private static Matcher<ExecutionGraphInfo> matchesPartiallyWith(
             ExecutionGraphInfo executionGraphInfo) {
-        return new PartialExecutionGraphInfoMatcher(executionGraphInfo);
-    }
-
-    private static Collection<JobDetails> generateJobDetails(
-            Collection<ExecutionGraphInfo> executionGraphInfos) {
-        return executionGraphInfos.stream()
-                .map(ExecutionGraphInfo::getArchivedExecutionGraph)
-                .map(JobDetails::createDetailsForJob)
-                .collect(Collectors.toList());
+        return new ExecutionGraphInfoStoreTestUtils.PartialExecutionGraphInfoMatcher(
+                executionGraphInfo);
     }
 }

--- a/flink-runtime/src/test/java/org/apache/flink/runtime/dispatcher/MemoryExecutionGraphInfoStoreTest.java
+++ b/flink-runtime/src/test/java/org/apache/flink/runtime/dispatcher/MemoryExecutionGraphInfoStoreTest.java
@@ -1,0 +1,291 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.flink.runtime.dispatcher;
+
+import org.apache.flink.api.common.JobID;
+import org.apache.flink.api.common.JobStatus;
+import org.apache.flink.api.common.time.Time;
+import org.apache.flink.configuration.Configuration;
+import org.apache.flink.configuration.JobManagerOptions;
+import org.apache.flink.runtime.executiongraph.ArchivedExecutionGraph;
+import org.apache.flink.runtime.jobgraph.JobGraph;
+import org.apache.flink.runtime.jobgraph.JobGraphTestUtils;
+import org.apache.flink.runtime.jobgraph.JobVertex;
+import org.apache.flink.runtime.messages.webmonitor.JobDetails;
+import org.apache.flink.runtime.messages.webmonitor.JobsOverview;
+import org.apache.flink.runtime.minicluster.MiniCluster;
+import org.apache.flink.runtime.minicluster.MiniClusterConfiguration;
+import org.apache.flink.runtime.rest.handler.legacy.utils.ArchivedExecutionGraphBuilder;
+import org.apache.flink.runtime.scheduler.ExecutionGraphInfo;
+import org.apache.flink.runtime.util.ManualTicker;
+import org.apache.flink.testutils.TestingUtils;
+import org.apache.flink.util.TestLogger;
+import org.apache.flink.util.concurrent.ManuallyTriggeredScheduledExecutor;
+
+import org.apache.flink.shaded.guava30.com.google.common.base.Ticker;
+
+import org.hamcrest.Matchers;
+import org.junit.Test;
+
+import java.io.IOException;
+import java.util.Collection;
+import java.util.List;
+import java.util.concurrent.TimeUnit;
+import java.util.stream.Collectors;
+
+import static org.apache.flink.runtime.dispatcher.ExecutionGraphInfoStoreTestUtils.generateJobDetails;
+import static org.apache.flink.runtime.dispatcher.ExecutionGraphInfoStoreTestUtils.generateTerminalExecutionGraphInfos;
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertThat;
+import static org.junit.Assert.assertTrue;
+
+/** Tests for the {@link MemoryExecutionGraphInfoStore}. */
+public class MemoryExecutionGraphInfoStoreTest extends TestLogger {
+
+    /**
+     * Tests that we can put {@link ExecutionGraphInfo} into the {@link
+     * MemoryExecutionGraphInfoStore} and that the graph is persisted.
+     */
+    @Test
+    public void testPut() throws IOException {
+        assertPutJobGraphWithStatus(JobStatus.FINISHED);
+    }
+
+    /** Tests that a SUSPENDED job can be persisted. */
+    @Test
+    public void testPutSuspendedJob() throws IOException {
+        assertPutJobGraphWithStatus(JobStatus.SUSPENDED);
+    }
+
+    /** Tests that null is returned if we request an unknown JobID. */
+    @Test
+    public void testUnknownGet() throws IOException {
+
+        try (final MemoryExecutionGraphInfoStore executionGraphStore =
+                createMemoryExecutionGraphInfoStore()) {
+            assertThat(executionGraphStore.get(new JobID()), Matchers.nullValue());
+        }
+    }
+
+    /** Tests that we obtain the correct jobs overview. */
+    @Test
+    public void testStoredJobsOverview() throws IOException {
+        final int numberExecutionGraphs = 10;
+        final Collection<ExecutionGraphInfo> executionGraphInfos =
+                generateTerminalExecutionGraphInfos(numberExecutionGraphs);
+
+        final List<JobStatus> jobStatuses =
+                executionGraphInfos.stream()
+                        .map(ExecutionGraphInfo::getArchivedExecutionGraph)
+                        .map(ArchivedExecutionGraph::getState)
+                        .collect(Collectors.toList());
+
+        final JobsOverview expectedJobsOverview = JobsOverview.create(jobStatuses);
+
+        try (final MemoryExecutionGraphInfoStore executionGraphInfoStore =
+                createMemoryExecutionGraphInfoStore()) {
+            for (ExecutionGraphInfo executionGraphInfo : executionGraphInfos) {
+                executionGraphInfoStore.put(executionGraphInfo);
+            }
+
+            assertThat(
+                    executionGraphInfoStore.getStoredJobsOverview(),
+                    Matchers.equalTo(expectedJobsOverview));
+        }
+    }
+
+    /** Tests that we obtain the correct collection of available job details. */
+    @Test
+    public void testAvailableJobDetails() throws IOException {
+        final int numberExecutionGraphs = 10;
+        final Collection<ExecutionGraphInfo> executionGraphInfos =
+                generateTerminalExecutionGraphInfos(numberExecutionGraphs);
+
+        final Collection<JobDetails> jobDetails = generateJobDetails(executionGraphInfos);
+
+        try (final MemoryExecutionGraphInfoStore executionGraphInfoStore =
+                createMemoryExecutionGraphInfoStore()) {
+            for (ExecutionGraphInfo executionGraphInfo : executionGraphInfos) {
+                executionGraphInfoStore.put(executionGraphInfo);
+            }
+
+            assertThat(
+                    executionGraphInfoStore.getAvailableJobDetails(),
+                    Matchers.containsInAnyOrder(jobDetails.toArray()));
+        }
+    }
+
+    /** Tests that an expired execution graph is removed from the execution graph store. */
+    @Test
+    public void testExecutionGraphExpiration() throws Exception {
+        final Time expirationTime = Time.milliseconds(1L);
+
+        final ManuallyTriggeredScheduledExecutor scheduledExecutor =
+                new ManuallyTriggeredScheduledExecutor();
+
+        final ManualTicker manualTicker = new ManualTicker();
+
+        try (final MemoryExecutionGraphInfoStore executionGraphInfoStore =
+                new MemoryExecutionGraphInfoStore(
+                        expirationTime, Integer.MAX_VALUE, scheduledExecutor, manualTicker)) {
+
+            final ExecutionGraphInfo executionGraphInfo =
+                    new ExecutionGraphInfo(
+                            new ArchivedExecutionGraphBuilder()
+                                    .setState(JobStatus.FINISHED)
+                                    .build());
+
+            executionGraphInfoStore.put(executionGraphInfo);
+
+            // there should one execution graph
+            assertThat(executionGraphInfoStore.size(), Matchers.equalTo(1));
+
+            manualTicker.advanceTime(expirationTime.toMilliseconds(), TimeUnit.MILLISECONDS);
+
+            // this should trigger the cleanup after expiration
+            scheduledExecutor.triggerScheduledTasks();
+
+            assertThat(executionGraphInfoStore.size(), Matchers.equalTo(0));
+
+            assertThat(
+                    executionGraphInfoStore.get(executionGraphInfo.getJobId()),
+                    Matchers.nullValue());
+
+            // check that the store is empty
+            assertThat(executionGraphInfoStore.size(), Matchers.equalTo(0));
+        }
+    }
+
+    /** Tests that all job graphs are cleaned up after closing the store. */
+    @Test
+    public void testCloseCleansUp() throws IOException {
+        try (final MemoryExecutionGraphInfoStore executionGraphInfoStore =
+                createMemoryExecutionGraphInfoStore()) {
+
+            assertThat(executionGraphInfoStore.size(), Matchers.equalTo(0));
+
+            executionGraphInfoStore.put(
+                    new ExecutionGraphInfo(
+                            new ArchivedExecutionGraphBuilder()
+                                    .setState(JobStatus.FINISHED)
+                                    .build()));
+
+            assertThat(executionGraphInfoStore.size(), Matchers.equalTo(1));
+
+            executionGraphInfoStore.close();
+            assertThat(executionGraphInfoStore.size(), Matchers.equalTo(0));
+        }
+    }
+
+    /**
+     * Tests that the size of {@link MemoryExecutionGraphInfoStore} is no more than the configured
+     * max capacity and the old execution graphs will be purged if the total added number exceeds
+     * the max capacity.
+     */
+    @Test
+    public void testMaximumCapacity() throws IOException {
+        final int maxCapacity = 10;
+        final int numberExecutionGraphs = 10;
+
+        final Collection<ExecutionGraphInfo> oldExecutionGraphInfos =
+                generateTerminalExecutionGraphInfos(numberExecutionGraphs);
+        final Collection<ExecutionGraphInfo> newExecutionGraphInfos =
+                generateTerminalExecutionGraphInfos(numberExecutionGraphs);
+
+        final Collection<JobDetails> jobDetails = generateJobDetails(newExecutionGraphInfos);
+
+        try (final MemoryExecutionGraphInfoStore executionGraphInfoStore =
+                createMemoryExecutionGraphInfoStore(Time.hours(1L), maxCapacity)) {
+
+            for (ExecutionGraphInfo executionGraphInfo : oldExecutionGraphInfos) {
+                executionGraphInfoStore.put(executionGraphInfo);
+                // no more than the configured maximum capacity
+                assertTrue(executionGraphInfoStore.size() <= maxCapacity);
+            }
+
+            for (ExecutionGraphInfo executionGraphInfo : newExecutionGraphInfos) {
+                executionGraphInfoStore.put(executionGraphInfo);
+                // equals to the configured maximum capacity
+                assertEquals(maxCapacity, executionGraphInfoStore.size());
+            }
+
+            // the older execution graphs are purged
+            assertThat(
+                    executionGraphInfoStore.getAvailableJobDetails(),
+                    Matchers.containsInAnyOrder(jobDetails.toArray()));
+        }
+    }
+
+    /** Tests that a session cluster can terminate gracefully when jobs are still running. */
+    @Test
+    public void testPutSuspendedJobOnClusterShutdown() throws Exception {
+        Configuration configuration = new Configuration();
+        configuration.set(JobManagerOptions.JOB_STORE_TYPE, JobManagerOptions.JobStoreType.Memory);
+        try (final MiniCluster miniCluster =
+                new ExecutionGraphInfoStoreTestUtils.PersistingMiniCluster(
+                        new MiniClusterConfiguration.Builder()
+                                .setConfiguration(configuration)
+                                .build())) {
+            miniCluster.start();
+            final JobVertex vertex = new JobVertex("blockingVertex");
+            // The adaptive scheduler expects that every vertex has a configured parallelism
+            vertex.setParallelism(1);
+            vertex.setInvokableClass(
+                    ExecutionGraphInfoStoreTestUtils.SignallingBlockingNoOpInvokable.class);
+            final JobGraph jobGraph = JobGraphTestUtils.streamingJobGraph(vertex);
+            miniCluster.submitJob(jobGraph);
+            ExecutionGraphInfoStoreTestUtils.SignallingBlockingNoOpInvokable.LATCH.await();
+        }
+    }
+
+    private void assertPutJobGraphWithStatus(JobStatus jobStatus) throws IOException {
+        final ExecutionGraphInfo dummyExecutionGraphInfo =
+                new ExecutionGraphInfo(
+                        new ArchivedExecutionGraphBuilder().setState(jobStatus).build());
+        try (final MemoryExecutionGraphInfoStore executionGraphStore =
+                createMemoryExecutionGraphInfoStore()) {
+
+            // check that the graph store is empty
+            assertThat(executionGraphStore.size(), Matchers.equalTo(0));
+
+            executionGraphStore.put(dummyExecutionGraphInfo);
+
+            // check that we have persisted the given execution graph
+            assertThat(executionGraphStore.size(), Matchers.equalTo(1));
+
+            assertThat(
+                    executionGraphStore.get(dummyExecutionGraphInfo.getJobId()),
+                    new ExecutionGraphInfoStoreTestUtils.PartialExecutionGraphInfoMatcher(
+                            dummyExecutionGraphInfo));
+        }
+    }
+
+    private MemoryExecutionGraphInfoStore createMemoryExecutionGraphInfoStore() {
+        return new MemoryExecutionGraphInfoStore();
+    }
+
+    private MemoryExecutionGraphInfoStore createMemoryExecutionGraphInfoStore(
+            Time expirationTime, int maximumCapacity) {
+        return new MemoryExecutionGraphInfoStore(
+                expirationTime,
+                maximumCapacity,
+                TestingUtils.defaultScheduledExecutor(),
+                Ticker.systemTicker());
+    }
+}


### PR DESCRIPTION
## What is the purpose of the change

This PR aims to support memory execution graph store in session cluster

## Brief change log
  - * Improve MemoryExecutionGraphInfoStore to support expiration time and maximum capacity
  - * Support memory and file execution graph store in SessionClusterEntrypoint

## Verifying this change
This change added tests and can be verified as follows:
  - * Add `MemoryExecutionGraphInfoStoreTest` that test the methods in `MemoryExecutionGraphInfoStore`

## Does this pull request potentially affect one of the following parts:

  - Dependencies (does it add or upgrade a dependency): (yes / no) no
  - The public API, i.e., is any changed class annotated with `@Public(Evolving)`: (yes / no) no
  - The serializers: (yes / no / don't know) no
  - The runtime per-record code paths (performance sensitive): (yes / no / don't know) no
  - Anything that affects deployment or recovery: JobManager (and its components), Checkpointing, Kubernetes/Yarn, ZooKeeper: (yes / no / don't know) no
  - The S3 file system connector: (yes / no / don't know) no

## Documentation

  - Does this pull request introduce a new feature? (yes / no) no
  - If yes, how is the feature documented? (not applicable / docs / JavaDocs / not documented)
