### PR TITLE
[FLINK-25631][table] Support enhanced `show tables` syntax

### DIFF
--- a/docs/content.zh/docs/dev/table/sql/show.md
+++ b/docs/content.zh/docs/dev/table/sql/show.md
@@ -118,7 +118,7 @@ tEnv.executeSql("SHOW CURRENT DATABASE").print();
 // create a table
 tEnv.executeSql("CREATE TABLE my_table (...) WITH (...)");
 // show tables
-tEnv.executeSql("SHOW TABLES").print();
+tEnv.executeSql("SHOW TABLES FROM default_database LIKE 'm%'").print();
 // +------------+
 // | table name |
 // +------------+
@@ -222,7 +222,7 @@ tEnv.executeSql("SHOW DATABASES").print()
 // create a table
 tEnv.executeSql("CREATE TABLE my_table (...) WITH (...)")
 // show tables
-tEnv.executeSql("SHOW TABLES").print()
+tEnv.executeSql("SHOW TABLES FROM default_database LIKE 'm%'").print()
 // +------------+
 // | table name |
 // +------------+
@@ -324,7 +324,7 @@ table_env.execute_sql("SHOW DATABASES").print()
 # create a table
 table_env.execute_sql("CREATE TABLE my_table (...) WITH (...)")
 # show tables
-table_env.execute_sql("SHOW TABLES").print()
+table_env.execute_sql("SHOW TABLES FROM default_database LIKE 'm%'").print()
 # +------------+
 # | table name |
 # +------------+
@@ -414,7 +414,7 @@ default_database
 Flink SQL> CREATE TABLE my_table (...) WITH (...);
 [INFO] Table has been created.
 
-Flink SQL> SHOW TABLES;
+Flink SQL> "SHOW TABLES FROM default_database LIKE 'm%'";
 my_table
 
 Flink SQL> SHOW CREATE TABLE my_table;
@@ -520,10 +520,17 @@ SHOW CURRENT DATABASE
 ## SHOW TABLES
 
 ```sql
-SHOW TABLES
+SHOW TABLES [ ( FROM | IN ) [catalog_name.]database_name ] [ [NOT] LIKE regex_pattern ]
 ```
 
-展示当前 catalog 和当前 database 中所有的表。
+展示指定库的所有表，如果没有指定库则展示当前库的所有表。另外返回的结果能被一个可选的匹配字符串过滤。
+
+**LIKE**
+根据可选的 `LIKE` 语句展示给定库中与 `<sql_like_pattern>` 是否模糊相似的所有表。
+
+`LIKE` 子句中 sql 正则式的语法与 `MySQL` 方言中的语法相同。
+* `%` 匹配任意数量的字符, 也包括0数量字符, `\%` 匹配一个 `%` 字符.
+* `_` 只匹配一个字符, `\_` 匹配一个 `_` 字符.
 
 ## SHOW CREATE TABLE
 

--- a/docs/content.zh/docs/dev/table/sql/show.md
+++ b/docs/content.zh/docs/dev/table/sql/show.md
@@ -118,7 +118,7 @@ tEnv.executeSql("SHOW CURRENT DATABASE").print();
 // create a table
 tEnv.executeSql("CREATE TABLE my_table (...) WITH (...)");
 // show tables
-tEnv.executeSql("SHOW TABLES FROM default_database LIKE 'm%'").print();
+tEnv.executeSql("SHOW TABLES").print();
 // +------------+
 // | table name |
 // +------------+
@@ -222,7 +222,7 @@ tEnv.executeSql("SHOW DATABASES").print()
 // create a table
 tEnv.executeSql("CREATE TABLE my_table (...) WITH (...)")
 // show tables
-tEnv.executeSql("SHOW TABLES FROM default_database LIKE 'm%'").print()
+tEnv.executeSql("SHOW TABLES").print()
 // +------------+
 // | table name |
 // +------------+
@@ -324,7 +324,7 @@ table_env.execute_sql("SHOW DATABASES").print()
 # create a table
 table_env.execute_sql("CREATE TABLE my_table (...) WITH (...)")
 # show tables
-table_env.execute_sql("SHOW TABLES FROM default_database LIKE 'm%'").print()
+table_env.execute_sql("SHOW TABLES").print()
 # +------------+
 # | table name |
 # +------------+
@@ -414,7 +414,7 @@ default_database
 Flink SQL> CREATE TABLE my_table (...) WITH (...);
 [INFO] Table has been created.
 
-Flink SQL> "SHOW TABLES FROM default_database LIKE 'm%'";
+Flink SQL> SHOW TABLES;
 my_table
 
 Flink SQL> SHOW CREATE TABLE my_table;

--- a/docs/content.zh/docs/dev/table/sql/show.md
+++ b/docs/content.zh/docs/dev/table/sql/show.md
@@ -520,7 +520,7 @@ SHOW CURRENT DATABASE
 ## SHOW TABLES
 
 ```sql
-SHOW TABLES [ ( FROM | IN ) [catalog_name.]database_name ] [ [NOT] LIKE regex_pattern ]
+SHOW TABLES [ ( FROM | IN ) [catalog_name.]database_name ] [ [NOT] LIKE <sql_like_pattern> ]
 ```
 
 展示指定库的所有表，如果没有指定库则展示当前库的所有表。另外返回的结果能被一个可选的匹配字符串过滤。
@@ -531,6 +531,76 @@ SHOW TABLES [ ( FROM | IN ) [catalog_name.]database_name ] [ [NOT] LIKE regex_pa
 `LIKE` 子句中 sql 正则式的语法与 `MySQL` 方言中的语法相同。
 * `%` 匹配任意数量的字符, 也包括0数量字符, `\%` 匹配一个 `%` 字符.
 * `_` 只匹配一个字符, `\_` 匹配一个 `_` 字符.
+
+
+### SHOW TABLES 示例
+
+假定在 `catalog1` 的 `db1` 库有如下表：
+* person
+* dim
+
+在会话的当前库下有如下表：
+* fights
+* orders
+
+- 显示指定库的所有表。
+
+```sql
+show tables from db1;
+-- show tables from catalog1.db1;
+-- show tables in db1;
+-- show tables in catalog1.db1;
++------------+
+| table name |
++------------+
+|        dim |
+|     person |
++------------+
+2 rows in set
+```
+
+- 显示指定库中相似于指定 SQL 正则式的所有表。
+
+```sql
+show tables from db1 like '%n';
+-- show tables from catalog1.db1 like '%n';
+-- show tables in db1 like '%n';
+-- show tables in catalog1.db1 like '%n';
++------------+
+| table name |
++------------+
+|     person |
++------------+
+1 row in set
+```
+
+- 显示指定库中不相似于指定 SQL 正则式的所有表。
+
+```sql
+show tables from db1 not like '%n';
+-- show tables from catalog1.db1 not like '%n';
+-- show tables in db1 not like '%n';
+-- show tables in catalog1.db1 not like '%n';
++------------+
+| table name |
++------------+
+|        dim |
++------------+
+1 row in set
+```
+
+- 显示当前库中的所有表。
+
+```sql
+show tables;
++------------+
+| table name |
++------------+
+|      items |
+|     orders |
++------------+
+2 rows in set
+```
 
 ## SHOW CREATE TABLE
 

--- a/docs/content/docs/dev/table/sql/show.md
+++ b/docs/content/docs/dev/table/sql/show.md
@@ -118,7 +118,7 @@ tEnv.executeSql("SHOW CURRENT DATABASE").print();
 // create a table
 tEnv.executeSql("CREATE TABLE my_table (...) WITH (...)");
 // show tables
-tEnv.executeSql("SHOW TABLES FROM default_database LIKE 'm%'").print();
+tEnv.executeSql("SHOW TABLES").print();
 // +------------+
 // | table name |
 // +------------+
@@ -222,7 +222,7 @@ tEnv.executeSql("SHOW DATABASES").print()
 // create a table
 tEnv.executeSql("CREATE TABLE my_table (...) WITH (...)")
 // show tables
-tEnv.executeSql("SHOW TABLES FROM default_database LIKE 'm%'").print()
+tEnv.executeSql("SHOW TABLES").print()
 // +------------+
 // | table name |
 // +------------+
@@ -324,7 +324,7 @@ table_env.execute_sql("SHOW DATABASES").print()
 # create a table
 table_env.execute_sql("CREATE TABLE my_table (...) WITH (...)")
 # show tables
-table_env.execute_sql("SHOW TABLES FROM default_database LIKE 'm%'").print()
+table_env.execute_sql("SHOW TABLES").print()
 # +------------+
 # | table name |
 # +------------+
@@ -414,7 +414,7 @@ default_database
 Flink SQL> CREATE TABLE my_table (...) WITH (...);
 [INFO] Table has been created.
 
-Flink SQL> SHOW TABLES FROM default_database LIKE 'm%';
+Flink SQL> SHOW TABLES;
 my_table
 
 Flink SQL> SHOW CREATE TABLE my_table;
@@ -523,7 +523,7 @@ Show current database.
 SHOW TABLES [ ( FROM | IN ) [catalog_name.]database_name ] [ [NOT] LIKE <sql_like_pattern> ]
 ```
 
-Show all the tables for an optionally specified database. If no database is specified then the tables are returned from the current database. Additionally, the output of this statement may be filtered by an optional matching pattern.
+Show all tables for an optionally specified database. If no database is specified then the tables are returned from the current database. Additionally, the output of this statement may be filtered by an optional matching pattern.
 
 **LIKE**
 Show all tables with given table name and optional `LIKE` clause, whose name is whether similar to the `<sql_like_pattern>`.

--- a/docs/content/docs/dev/table/sql/show.md
+++ b/docs/content/docs/dev/table/sql/show.md
@@ -118,7 +118,7 @@ tEnv.executeSql("SHOW CURRENT DATABASE").print();
 // create a table
 tEnv.executeSql("CREATE TABLE my_table (...) WITH (...)");
 // show tables
-tEnv.executeSql("SHOW TABLES").print();
+tEnv.executeSql("SHOW TABLES FROM default_database LIKE 'm%'").print();
 // +------------+
 // | table name |
 // +------------+
@@ -222,7 +222,7 @@ tEnv.executeSql("SHOW DATABASES").print()
 // create a table
 tEnv.executeSql("CREATE TABLE my_table (...) WITH (...)")
 // show tables
-tEnv.executeSql("SHOW TABLES").print()
+tEnv.executeSql("SHOW TABLES FROM default_database LIKE 'm%'").print()
 // +------------+
 // | table name |
 // +------------+
@@ -324,7 +324,7 @@ table_env.execute_sql("SHOW DATABASES").print()
 # create a table
 table_env.execute_sql("CREATE TABLE my_table (...) WITH (...)")
 # show tables
-table_env.execute_sql("SHOW TABLES").print()
+table_env.execute_sql("SHOW TABLES FROM default_database LIKE 'm%'").print()
 # +------------+
 # | table name |
 # +------------+
@@ -414,7 +414,7 @@ default_database
 Flink SQL> CREATE TABLE my_table (...) WITH (...);
 [INFO] Table has been created.
 
-Flink SQL> SHOW TABLES;
+Flink SQL> SHOW TABLES FROM default_database LIKE 'm%';
 my_table
 
 Flink SQL> SHOW CREATE TABLE my_table;
@@ -520,10 +520,17 @@ Show current database.
 ## SHOW TABLES
 
 ```sql
-SHOW TABLES
+SHOW TABLES [ ( FROM | IN ) [catalog_name.]database_name ] [ [NOT] LIKE regex_pattern ]
 ```
 
-Show all tables in the current catalog and the current database.
+Show all the tables for an optionally specified database. If no database is specified then the tables are returned from the current database. Additionally, the output of this statement may be filtered by an optional matching pattern.
+
+**LIKE**
+Show all tables with given table name and optional `LIKE` clause, whose name is whether similar to the `<sql_like_pattern>`.
+
+The syntax of sql pattern in `LIKE` clause is the same as that of `MySQL` dialect.
+* `%` matches any number of characters, even zero characters, `\%` matches one `%` character.
+* `_` matches exactly one character, `\_` matches one `_` character.
 
 
 ## SHOW CREATE TABLE

--- a/docs/content/docs/dev/table/sql/show.md
+++ b/docs/content/docs/dev/table/sql/show.md
@@ -520,7 +520,7 @@ Show current database.
 ## SHOW TABLES
 
 ```sql
-SHOW TABLES [ ( FROM | IN ) [catalog_name.]database_name ] [ [NOT] LIKE regex_pattern ]
+SHOW TABLES [ ( FROM | IN ) [catalog_name.]database_name ] [ [NOT] LIKE <sql_like_pattern> ]
 ```
 
 Show all the tables for an optionally specified database. If no database is specified then the tables are returned from the current database. Additionally, the output of this statement may be filtered by an optional matching pattern.
@@ -531,6 +531,75 @@ Show all tables with given table name and optional `LIKE` clause, whose name is 
 The syntax of sql pattern in `LIKE` clause is the same as that of `MySQL` dialect.
 * `%` matches any number of characters, even zero characters, `\%` matches one `%` character.
 * `_` matches exactly one character, `\_` matches one `_` character.
+
+### SHOW TABLES EXAMPLES
+
+Assumes that the `db1` database located in `catalog1` catalog has the following tables:
+* person
+* dim
+
+the current database in session has the following tables:
+* fights
+* orders
+
+- Shows all tables of the given database.
+
+```sql
+show tables from db1;
+-- show tables from catalog1.db1;
+-- show tables in db1;
+-- show tables in catalog1.db1;
++------------+
+| table name |
++------------+
+|        dim |
+|     person |
++------------+
+2 rows in set
+```
+
+- Shows all tables of the given database, which are similar to the given sql pattern.
+
+```sql
+show tables from db1 like '%n';
+-- show tables from catalog1.db1 like '%n';
+-- show tables in db1 like '%n';
+-- show tables in catalog1.db1 like '%n';
++------------+
+| table name |
++------------+
+|     person |
++------------+
+1 row in set
+```
+
+- Shows all tables of the given database, which are not similar to the given sql pattern.
+
+```sql
+show tables from db1 not like '%n';
+-- show tables from catalog1.db1 not like '%n';
+-- show tables in db1 not like '%n';
+-- show tables in catalog1.db1 not like '%n';
++------------+
+| table name |
++------------+
+|        dim |
++------------+
+1 row in set
+```
+
+- Shows all tables of the current database.
+
+```sql
+show tables;
++------------+
+| table name |
++------------+
+|      items |
+|     orders |
++------------+
+2 rows in set
+```
 
 
 ## SHOW CREATE TABLE

--- a/flink-table/flink-sql-client/src/test/resources/sql/catalog_database.q
+++ b/flink-table/flink-sql-client/src/test/resources/sql/catalog_database.q
@@ -522,3 +522,76 @@ show tables;
 +------------+
 2 rows in set
 !ok
+
+# ==========================================================================
+# test enhanced show tables
+# ==========================================================================
+
+create catalog catalog1 with ('type'='generic_in_memory');
+[INFO] Execute statement succeed.
+!info
+
+create database catalog1.db1;
+[INFO] Execute statement succeed.
+!info
+
+create table catalog1.db1.person (a int, b string) with ('connector' = 'datagen');
+[INFO] Execute statement succeed.
+!info
+
+create table catalog1.db1.dim (a int, b string) with ('connector' = 'datagen');
+[INFO] Execute statement succeed.
+!info
+
+create table catalog1.db1.address (a int, b string) with ('connector' = 'datagen');
+[INFO] Execute statement succeed.
+!info
+
+create view catalog1.db1.v_person as select * from catalog1.db1.person;
+[INFO] Execute statement succeed.
+!info
+
+show tables from catalog1.db1;
++------------+
+| table name |
++------------+
+|    address |
+|        dim |
+|     person |
+|   v_person |
++------------+
+4 rows in set
+!ok
+
+show tables from catalog1.db1 like '%person%';
++------------+
+| table name |
++------------+
+|     person |
+|   v_person |
++------------+
+2 rows in set
+!ok
+
+show tables in catalog1.db1 not like '%person%';
++------------+
+| table name |
++------------+
+|    address |
+|        dim |
++------------+
+2 rows in set
+!ok
+
+use catalog catalog1;
+[INFO] Execute statement succeed.
+!info
+
+show tables from db1 like 'p_r%';
++------------+
+| table name |
++------------+
+|     person |
++------------+
+1 row in set
+!ok

--- a/flink-table/flink-sql-parser/src/main/codegen/includes/parserImpls.ftl
+++ b/flink-table/flink-sql-parser/src/main/codegen/includes/parserImpls.ftl
@@ -414,34 +414,19 @@ SqlShowViews SqlShowViews() :
 */
 SqlShowTables SqlShowTables() :
 {
-    SqlIdentifier databaseName;
+    SqlIdentifier databaseName = null;
     SqlCharStringLiteral likeLiteral = null;
-    String prep = "FROM";
+    String prep = null;
     boolean notLike = false;
     SqlParserPos pos;
 }
 {
     <SHOW> <TABLES>
+    { pos = getPos(); }
     [
-        [( <FROM> | <IN> { prep = "IN"; } )]
+        ( <FROM> { prep = "FROM"; } | <IN> { prep = "IN"; } )
         { pos = getPos(); }
         databaseName = CompoundIdentifier()
-        [
-            [
-                <NOT>
-                {
-                    notLike = true;
-                }
-            ]
-            <LIKE>  <QUOTED_STRING>
-            {
-                String likeCondition = SqlParserUtil.parseString(token.image);
-                likeLiteral = SqlLiteral.createCharString(likeCondition, getPos());
-            }
-        ]
-        {
-            return new SqlShowTables(pos, prep, databaseName, notLike, likeLiteral);
-        }
     ]
     [
         [
@@ -457,7 +442,7 @@ SqlShowTables SqlShowTables() :
         }
     ]
     {
-        return new SqlShowTables(getPos(), notLike, likeLiteral);
+        return new SqlShowTables(pos, prep, databaseName, notLike, likeLiteral);
     }
 }
 

--- a/flink-table/flink-sql-parser/src/main/java/org/apache/flink/sql/parser/dql/SqlShowTables.java
+++ b/flink-table/flink-sql-parser/src/main/java/org/apache/flink/sql/parser/dql/SqlShowTables.java
@@ -53,14 +53,6 @@ public class SqlShowTables extends SqlCall {
         this.likeLiteral = null;
     }
 
-    public SqlShowTables(SqlParserPos pos, boolean notLike, SqlCharStringLiteral likeLiteral) {
-        super(pos);
-        this.preposition = null;
-        this.databaseName = null;
-        this.notLike = notLike;
-        this.likeLiteral = likeLiteral;
-    }
-
     public SqlShowTables(
             SqlParserPos pos,
             String preposition,
@@ -68,9 +60,8 @@ public class SqlShowTables extends SqlCall {
             boolean notLike,
             SqlCharStringLiteral likeLiteral) {
         super(pos);
-        this.preposition =
-                requireNonNull(preposition, "Preposition of 'SHOW TABLES' must be 'FROM' or 'IN'.");
-        this.databaseName = requireNonNull(databaseName, "databaseName should not be null.");
+        this.preposition = preposition;
+        this.databaseName = preposition != null ? requireNonNull(databaseName, "Database name must not be null.") : null;
         this.notLike = notLike;
         this.likeLiteral = likeLiteral;
     }

--- a/flink-table/flink-sql-parser/src/main/java/org/apache/flink/sql/parser/dql/SqlShowTables.java
+++ b/flink-table/flink-sql-parser/src/main/java/org/apache/flink/sql/parser/dql/SqlShowTables.java
@@ -61,7 +61,10 @@ public class SqlShowTables extends SqlCall {
             SqlCharStringLiteral likeLiteral) {
         super(pos);
         this.preposition = preposition;
-        this.databaseName = preposition != null ? requireNonNull(databaseName, "Database name must not be null.") : null;
+        this.databaseName =
+                preposition != null
+                        ? requireNonNull(databaseName, "Database name must not be null.")
+                        : null;
         this.notLike = notLike;
         this.likeLiteral = likeLiteral;
     }

--- a/flink-table/flink-sql-parser/src/main/java/org/apache/flink/sql/parser/dql/SqlShowTables.java
+++ b/flink-table/flink-sql-parser/src/main/java/org/apache/flink/sql/parser/dql/SqlShowTables.java
@@ -19,6 +19,8 @@
 package org.apache.flink.sql.parser.dql;
 
 import org.apache.calcite.sql.SqlCall;
+import org.apache.calcite.sql.SqlCharStringLiteral;
+import org.apache.calcite.sql.SqlIdentifier;
 import org.apache.calcite.sql.SqlKind;
 import org.apache.calcite.sql.SqlNode;
 import org.apache.calcite.sql.SqlOperator;
@@ -28,6 +30,9 @@ import org.apache.calcite.sql.parser.SqlParserPos;
 
 import java.util.Collections;
 import java.util.List;
+import java.util.Objects;
+
+import static java.util.Objects.requireNonNull;
 
 /** SHOW Tables sql call. */
 public class SqlShowTables extends SqlCall {
@@ -35,8 +40,59 @@ public class SqlShowTables extends SqlCall {
     public static final SqlSpecialOperator OPERATOR =
             new SqlSpecialOperator("SHOW TABLES", SqlKind.OTHER);
 
+    protected final SqlIdentifier databaseName;
+    protected final String preposition;
+    protected final boolean notLike;
+    protected final SqlCharStringLiteral likeLiteral;
+
     public SqlShowTables(SqlParserPos pos) {
         super(pos);
+        this.preposition = null;
+        this.databaseName = null;
+        this.notLike = false;
+        this.likeLiteral = null;
+    }
+
+    public SqlShowTables(SqlParserPos pos, boolean notLike, SqlCharStringLiteral likeLiteral) {
+        super(pos);
+        this.preposition = null;
+        this.databaseName = null;
+        this.notLike = notLike;
+        this.likeLiteral = likeLiteral;
+    }
+
+    public SqlShowTables(
+            SqlParserPos pos,
+            String preposition,
+            SqlIdentifier databaseName,
+            boolean notLike,
+            SqlCharStringLiteral likeLiteral) {
+        super(pos);
+        this.preposition =
+                requireNonNull(preposition, "Preposition of 'SHOW TABLES' must be 'FROM' or 'IN'.");
+        this.databaseName = requireNonNull(databaseName, "databaseName should not be null.");
+        this.notLike = notLike;
+        this.likeLiteral = likeLiteral;
+    }
+
+    public String getLikeSqlPattern() {
+        return Objects.isNull(this.likeLiteral) ? null : likeLiteral.getValueAs(String.class);
+    }
+
+    public boolean isNotLike() {
+        return notLike;
+    }
+
+    public SqlCharStringLiteral getLikeLiteral() {
+        return likeLiteral;
+    }
+
+    public boolean isWithLike() {
+        return Objects.nonNull(likeLiteral);
+    }
+
+    public String getPreposition() {
+        return preposition;
     }
 
     @Override
@@ -46,11 +102,31 @@ public class SqlShowTables extends SqlCall {
 
     @Override
     public List<SqlNode> getOperandList() {
-        return Collections.emptyList();
+        return Objects.isNull(this.databaseName)
+                ? Collections.emptyList()
+                : Collections.singletonList(databaseName);
+    }
+
+    public String[] fullDatabaseName() {
+        return Objects.isNull(this.databaseName)
+                ? new String[] {}
+                : databaseName.names.toArray(new String[0]);
     }
 
     @Override
     public void unparse(SqlWriter writer, int leftPrec, int rightPrec) {
-        writer.keyword("SHOW TABLES");
+        if (this.preposition == null) {
+            writer.keyword("SHOW TABLES");
+        } else if (databaseName != null) {
+            writer.keyword("SHOW TABLES " + this.preposition);
+            databaseName.unparse(writer, leftPrec, rightPrec);
+        }
+        if (isWithLike()) {
+            if (isNotLike()) {
+                writer.keyword(String.format("NOT LIKE '%s'", getLikeSqlPattern()));
+            } else {
+                writer.keyword(String.format("LIKE '%s'", getLikeSqlPattern()));
+            }
+        }
     }
 }

--- a/flink-table/flink-sql-parser/src/test/java/org/apache/flink/sql/parser/FlinkSqlParserImplTest.java
+++ b/flink-table/flink-sql-parser/src/test/java/org/apache/flink/sql/parser/FlinkSqlParserImplTest.java
@@ -193,6 +193,28 @@ public class FlinkSqlParserImplTest extends SqlParserTest {
     @Test
     public void testShowTables() {
         sql("show tables").ok("SHOW TABLES");
+        sql("show tables not like '%'").ok("SHOW TABLES NOT LIKE '%'");
+
+        sql("show tables from db1").ok("SHOW TABLES FROM `DB1`");
+        sql("show tables in db1").ok("SHOW TABLES IN `DB1`");
+
+        sql("show tables from catalog1.db1").ok("SHOW TABLES FROM `CATALOG1`.`DB1`");
+        sql("show tables in catalog1.db1").ok("SHOW TABLES IN `CATALOG1`.`DB1`");
+
+        sql("show tables from db1 like '%'").ok("SHOW TABLES FROM `DB1` LIKE '%'");
+        sql("show tables in db1 like '%'").ok("SHOW TABLES IN `DB1` LIKE '%'");
+
+        sql("show tables from catalog1.db1 like '%'")
+                .ok("SHOW TABLES FROM `CATALOG1`.`DB1` LIKE '%'");
+        sql("show tables in catalog1.db1 like '%'").ok("SHOW TABLES IN `CATALOG1`.`DB1` LIKE '%'");
+
+        sql("show tables from db1 not like '%'").ok("SHOW TABLES FROM `DB1` NOT LIKE '%'");
+        sql("show tables in db1 not like '%'").ok("SHOW TABLES IN `DB1` NOT LIKE '%'");
+
+        sql("show tables from catalog1.db1 not like '%'")
+                .ok("SHOW TABLES FROM `CATALOG1`.`DB1` NOT LIKE '%'");
+        sql("show tables in catalog1.db1 not like '%'")
+                .ok("SHOW TABLES IN `CATALOG1`.`DB1` NOT LIKE '%'");
     }
 
     @Test

--- a/flink-table/flink-sql-parser/src/test/java/org/apache/flink/sql/parser/FlinkSqlParserImplTest.java
+++ b/flink-table/flink-sql-parser/src/test/java/org/apache/flink/sql/parser/FlinkSqlParserImplTest.java
@@ -220,11 +220,11 @@ public class FlinkSqlParserImplTest extends SqlParserTest {
         sql("show tables ^catalog1^.db1")
                 .fails("(?s).*Encountered \"catalog1\" at line 1, column 13.\n.*");
 
-        sql("show tables ^search^ db1").fails("(?s).*Encountered \"search\" at line 1, column 13.\n.*");
+        sql("show tables ^search^ db1")
+                .fails("(?s).*Encountered \"search\" at line 1, column 13.\n.*");
 
         sql("show tables from db1 ^likes^ '%t'")
                 .fails("(?s).*Encountered \"likes\" at line 1, column 22.\n.*");
-
     }
 
     @Test

--- a/flink-table/flink-sql-parser/src/test/java/org/apache/flink/sql/parser/FlinkSqlParserImplTest.java
+++ b/flink-table/flink-sql-parser/src/test/java/org/apache/flink/sql/parser/FlinkSqlParserImplTest.java
@@ -215,6 +215,16 @@ public class FlinkSqlParserImplTest extends SqlParserTest {
                 .ok("SHOW TABLES FROM `CATALOG1`.`DB1` NOT LIKE '%'");
         sql("show tables in catalog1.db1 not like '%'")
                 .ok("SHOW TABLES IN `CATALOG1`.`DB1` NOT LIKE '%'");
+
+        sql("show tables ^db1^").fails("(?s).*Encountered \"db1\" at line 1, column 13.\n.*");
+        sql("show tables ^catalog1^.db1")
+                .fails("(?s).*Encountered \"catalog1\" at line 1, column 13.\n.*");
+
+        sql("show tables ^search^ db1").fails("(?s).*Encountered \"search\" at line 1, column 13.\n.*");
+
+        sql("show tables from db1 ^likes^ '%t'")
+                .fails("(?s).*Encountered \"likes\" at line 1, column 22.\n.*");
+
     }
 
     @Test

--- a/flink-table/flink-table-api-java/src/main/java/org/apache/flink/table/api/TableEnvironment.java
+++ b/flink-table/flink-table-api-java/src/main/java/org/apache/flink/table/api/TableEnvironment.java
@@ -798,6 +798,17 @@ public interface TableEnvironment {
     String[] listTables();
 
     /**
+     * Gets the names of all tables available in the given namespace (the given database of the
+     * given catalog). It returns both temporary and permanent tables and views.
+     *
+     * @return A list of the names of all registered tables in the given database of the given
+     *     catalog.
+     * @see #listTemporaryTables()
+     * @see #listTemporaryViews()
+     */
+    String[] listTables(String catalogName, String databaseName);
+
+    /**
      * Gets the names of all views available in the current namespace (the current database of the
      * current catalog). It returns both temporary and permanent views.
      *

--- a/flink-table/flink-table-api-java/src/main/java/org/apache/flink/table/operations/ShowTablesOperation.java
+++ b/flink-table/flink-table-api-java/src/main/java/org/apache/flink/table/operations/ShowTablesOperation.java
@@ -18,6 +18,8 @@
 
 package org.apache.flink.table.operations;
 
+import static org.apache.flink.util.Preconditions.checkNotNull;
+
 /** Operation to describe a SHOW TABLES statement. */
 public class ShowTablesOperation implements ShowOperation {
 
@@ -40,7 +42,7 @@ public class ShowTablesOperation implements ShowOperation {
     public ShowTablesOperation(String likePattern, boolean useLike, boolean notLike) {
         this.catalogName = null;
         this.databaseName = null;
-        this.likePattern = likePattern;
+        this.likePattern = useLike ? checkNotNull(likePattern, "Like pattern must not be null") : null;
         this.useLike = useLike;
         this.notLike = notLike;
         this.preposition = null;
@@ -53,12 +55,12 @@ public class ShowTablesOperation implements ShowOperation {
             boolean useLike,
             boolean notLike,
             String preposition) {
-        this.catalogName = catalogName;
-        this.databaseName = databaseName;
-        this.likePattern = likePattern;
+        this.catalogName = checkNotNull(catalogName, "Catalog name must not be null");
+        this.databaseName = checkNotNull(databaseName, "Database name must not be null");
+        this.likePattern = useLike ? checkNotNull(likePattern, "Like pattern must not be null") : null;
         this.useLike = useLike;
         this.notLike = notLike;
-        this.preposition = preposition;
+        this.preposition = checkNotNull(preposition, "Preposition must not be null");
     }
 
     public String getLikePattern() {

--- a/flink-table/flink-table-api-java/src/main/java/org/apache/flink/table/operations/ShowTablesOperation.java
+++ b/flink-table/flink-table-api-java/src/main/java/org/apache/flink/table/operations/ShowTablesOperation.java
@@ -42,7 +42,8 @@ public class ShowTablesOperation implements ShowOperation {
     public ShowTablesOperation(String likePattern, boolean useLike, boolean notLike) {
         this.catalogName = null;
         this.databaseName = null;
-        this.likePattern = useLike ? checkNotNull(likePattern, "Like pattern must not be null") : null;
+        this.likePattern =
+                useLike ? checkNotNull(likePattern, "Like pattern must not be null") : null;
         this.useLike = useLike;
         this.notLike = notLike;
         this.preposition = null;
@@ -57,7 +58,8 @@ public class ShowTablesOperation implements ShowOperation {
             String preposition) {
         this.catalogName = checkNotNull(catalogName, "Catalog name must not be null");
         this.databaseName = checkNotNull(databaseName, "Database name must not be null");
-        this.likePattern = useLike ? checkNotNull(likePattern, "Like pattern must not be null") : null;
+        this.likePattern =
+                useLike ? checkNotNull(likePattern, "Like pattern must not be null") : null;
         this.useLike = useLike;
         this.notLike = notLike;
         this.preposition = checkNotNull(preposition, "Preposition must not be null");

--- a/flink-table/flink-table-api-java/src/main/java/org/apache/flink/table/operations/ShowTablesOperation.java
+++ b/flink-table/flink-table-api-java/src/main/java/org/apache/flink/table/operations/ShowTablesOperation.java
@@ -21,8 +21,83 @@ package org.apache.flink.table.operations;
 /** Operation to describe a SHOW TABLES statement. */
 public class ShowTablesOperation implements ShowOperation {
 
+    private final String catalogName;
+    private final String databaseName;
+    private final boolean useLike;
+    private final boolean notLike;
+    private final String likePattern;
+    private final String preposition;
+
+    public ShowTablesOperation() {
+        this.catalogName = null;
+        this.databaseName = null;
+        this.likePattern = null;
+        this.useLike = false;
+        this.notLike = false;
+        this.preposition = null;
+    }
+
+    public ShowTablesOperation(String likePattern, boolean useLike, boolean notLike) {
+        this.catalogName = null;
+        this.databaseName = null;
+        this.likePattern = likePattern;
+        this.useLike = useLike;
+        this.notLike = notLike;
+        this.preposition = null;
+    }
+
+    public ShowTablesOperation(
+            String catalogName,
+            String databaseName,
+            String likePattern,
+            boolean useLike,
+            boolean notLike,
+            String preposition) {
+        this.catalogName = catalogName;
+        this.databaseName = databaseName;
+        this.likePattern = likePattern;
+        this.useLike = useLike;
+        this.notLike = notLike;
+        this.preposition = preposition;
+    }
+
+    public String getLikePattern() {
+        return likePattern;
+    }
+
+    public String getPreposition() {
+        return preposition;
+    }
+
+    public boolean isUseLike() {
+        return useLike;
+    }
+
+    public boolean isNotLike() {
+        return notLike;
+    }
+
+    public String getCatalogName() {
+        return catalogName;
+    }
+
+    public String getDatabaseName() {
+        return databaseName;
+    }
+
     @Override
     public String asSummaryString() {
-        return "SHOW TABLES";
+        StringBuilder builder = new StringBuilder().append("SHOW TABLES");
+        if (this.preposition != null) {
+            builder.append(String.format(" %s %s.%s", preposition, catalogName, databaseName));
+        }
+        if (this.useLike) {
+            if (notLike) {
+                builder.append(String.format(" %s LIKE %s", "NOT", likePattern));
+            } else {
+                builder.append(String.format(" LIKE %s", likePattern));
+            }
+        }
+        return builder.toString();
     }
 }

--- a/flink-table/flink-table-planner/src/main/java/org/apache/flink/table/planner/operations/SqlToOperationConverter.java
+++ b/flink-table/flink-table-planner/src/main/java/org/apache/flink/table/planner/operations/SqlToOperationConverter.java
@@ -184,7 +184,6 @@ import org.apache.calcite.sql.dialect.CalciteSqlDialect;
 import org.apache.calcite.sql.parser.SqlParser;
 
 import java.util.ArrayList;
-import java.util.Arrays;
 import java.util.Collections;
 import java.util.HashMap;
 import java.util.HashSet;
@@ -948,7 +947,10 @@ public class SqlToOperationConverter {
         }
         String[] fullDatabaseName = sqlShowTables.fullDatabaseName();
         if (fullDatabaseName.length > 2) {
-            throw new ValidationException(String.format("show tables from/in identifier [ %s ] format error", String.join(".", fullDatabaseName)));
+            throw new ValidationException(
+                    String.format(
+                            "show tables from/in identifier [ %s ] format error",
+                            String.join(".", fullDatabaseName)));
         }
         String catalogName =
                 (fullDatabaseName.length == 1)

--- a/flink-table/flink-table-planner/src/main/java/org/apache/flink/table/planner/operations/SqlToOperationConverter.java
+++ b/flink-table/flink-table-planner/src/main/java/org/apache/flink/table/planner/operations/SqlToOperationConverter.java
@@ -184,6 +184,7 @@ import org.apache.calcite.sql.dialect.CalciteSqlDialect;
 import org.apache.calcite.sql.parser.SqlParser;
 
 import java.util.ArrayList;
+import java.util.Arrays;
 import java.util.Collections;
 import java.util.HashMap;
 import java.util.HashSet;
@@ -947,7 +948,7 @@ public class SqlToOperationConverter {
         }
         String[] fullDatabaseName = sqlShowTables.fullDatabaseName();
         if (fullDatabaseName.length > 2) {
-            throw new ValidationException("show tables from/in identifier format error");
+            throw new ValidationException(String.format("show tables from/in identifier [ %s ] format error", String.join(".", fullDatabaseName)));
         }
         String catalogName =
                 (fullDatabaseName.length == 1)

--- a/flink-table/flink-table-planner/src/main/java/org/apache/flink/table/planner/operations/SqlToOperationConverter.java
+++ b/flink-table/flink-table-planner/src/main/java/org/apache/flink/table/planner/operations/SqlToOperationConverter.java
@@ -939,7 +939,29 @@ public class SqlToOperationConverter {
 
     /** Convert SHOW TABLES statement. */
     private Operation convertShowTables(SqlShowTables sqlShowTables) {
-        return new ShowTablesOperation();
+        if (sqlShowTables.getPreposition() == null) {
+            return new ShowTablesOperation(
+                    sqlShowTables.getLikeSqlPattern(),
+                    sqlShowTables.isWithLike(),
+                    sqlShowTables.isNotLike());
+        }
+        String[] fullDatabaseName = sqlShowTables.fullDatabaseName();
+        if (fullDatabaseName.length > 2) {
+            throw new ValidationException("show tables from/in identifier format error");
+        }
+        String catalogName =
+                (fullDatabaseName.length == 1)
+                        ? catalogManager.getCurrentCatalog()
+                        : fullDatabaseName[0];
+        String databaseName =
+                (fullDatabaseName.length == 1) ? fullDatabaseName[0] : fullDatabaseName[1];
+        return new ShowTablesOperation(
+                catalogName,
+                databaseName,
+                sqlShowTables.getLikeSqlPattern(),
+                sqlShowTables.isWithLike(),
+                sqlShowTables.isNotLike(),
+                sqlShowTables.getPreposition());
     }
 
     /** Convert SHOW COLUMNS statement. */

--- a/flink-table/flink-table-planner/src/test/java/org/apache/flink/table/planner/operations/SqlToOperationConverterTest.java
+++ b/flink-table/flink-table-planner/src/test/java/org/apache/flink/table/planner/operations/SqlToOperationConverterTest.java
@@ -61,6 +61,7 @@ import org.apache.flink.table.operations.QueryOperation;
 import org.apache.flink.table.operations.ShowFunctionsOperation;
 import org.apache.flink.table.operations.ShowFunctionsOperation.FunctionScope;
 import org.apache.flink.table.operations.ShowModulesOperation;
+import org.apache.flink.table.operations.ShowTablesOperation;
 import org.apache.flink.table.operations.SinkModifyOperation;
 import org.apache.flink.table.operations.SourceQueryOperation;
 import org.apache.flink.table.operations.StatementSetOperation;
@@ -385,6 +386,34 @@ public class SqlToOperationConverterTest {
 
         assertThat(showModulesOperation.requireFull()).isFalse();
         assertThat(showModulesOperation.asSummaryString()).isEqualTo("SHOW MODULES");
+    }
+
+    @Test
+    public void testShowTables() {
+        final String sql = "SHOW TABLES from cat1.db1 not like 't%'";
+        Operation operation = parse(sql, SqlDialect.DEFAULT);
+        assert operation instanceof ShowTablesOperation;
+
+        ShowTablesOperation showTablesOperation = (ShowTablesOperation) operation;
+        assertThat(showTablesOperation.getCatalogName()).isEqualTo("cat1");
+        assertThat(showTablesOperation.getDatabaseName()).isEqualTo("db1");
+        assertThat(showTablesOperation.getPreposition()).isEqualTo("FROM");
+        assertThat(showTablesOperation.isUseLike()).isTrue();
+        assertThat(showTablesOperation.isNotLike()).isTrue();
+
+        final String sql2 = "SHOW TABLES in db2";
+        showTablesOperation = (ShowTablesOperation) parse(sql2, SqlDialect.DEFAULT);
+        assertThat(showTablesOperation.getCatalogName()).isEqualTo("builtin");
+        assertThat(showTablesOperation.getDatabaseName()).isEqualTo("db2");
+        assertThat(showTablesOperation.getPreposition()).isEqualTo("IN");
+        assertThat(showTablesOperation.isUseLike()).isFalse();
+        assertThat(showTablesOperation.isNotLike()).isFalse();
+
+        final String sql3 = "SHOW TABLES";
+        showTablesOperation = (ShowTablesOperation) parse(sql3, SqlDialect.DEFAULT);
+        assertThat(showTablesOperation.getCatalogName()).isNull();
+        assertThat(showTablesOperation.getDatabaseName()).isNull();
+        assertThat(showTablesOperation.getPreposition()).isNull();
     }
 
     @Test

--- a/flink-table/flink-table-planner/src/test/scala/org/apache/flink/table/api/TableEnvironmentTest.scala
+++ b/flink-table/flink-table-planner/src/test/scala/org/apache/flink/table/api/TableEnvironmentTest.scala
@@ -690,6 +690,50 @@ class TableEnvironmentTest {
   }
 
   @Test
+  def testExecuteSqlWithEnhancedShowTables(): Unit = {
+    val createCatalogResult = tableEnv.executeSql("CREATE CATALOG catalog1 WITH('type'='generic_in_memory')")
+    assertEquals(ResultKind.SUCCESS, createCatalogResult.getResultKind)
+
+    val createDbResult = tableEnv.executeSql("CREATE database catalog1.db1")
+    assertEquals(ResultKind.SUCCESS, createDbResult.getResultKind)
+
+    val createTableStmt =
+      """
+        |CREATE TABLE catalog1.db1.person (
+        |  a bigint,
+        |  b int,
+        |  c varchar
+        |) with (
+        |  'connector' = 'COLLECTION',
+        |  'is-bounded' = 'false'
+        |)
+      """.stripMargin
+    val tableResult1 = tableEnv.executeSql(createTableStmt)
+    assertEquals(ResultKind.SUCCESS, tableResult1.getResultKind)
+
+    val createTableStmt2 =
+      """
+        |CREATE TABLE catalog1.db1.dim (
+        |  a bigint
+        |) with (
+        |  'connector' = 'COLLECTION',
+        |  'is-bounded' = 'false'
+        |)
+      """.stripMargin
+    val tableResult2 = tableEnv.executeSql(createTableStmt2)
+    assertEquals(ResultKind.SUCCESS, tableResult2.getResultKind)
+
+    val tableResult3 = tableEnv.executeSql("SHOW TABLES FROM catalog1.db1 like 'p_r%'")
+    assertEquals(ResultKind.SUCCESS_WITH_CONTENT, tableResult3.getResultKind)
+    assertEquals(
+      ResolvedSchema.of(Column.physical("table name", DataTypes.STRING())),
+      tableResult3.getResolvedSchema)
+    checkData(
+      util.Arrays.asList(Row.of("person")).iterator(),
+      tableResult3.collect())
+  }
+
+  @Test
   def testExecuteSqlWithShowFunctions(): Unit = {
     val tableResult = tableEnv.executeSql("SHOW FUNCTIONS")
     assertEquals(ResultKind.SUCCESS_WITH_CONTENT, tableResult.getResultKind)

--- a/flink-table/flink-table-planner/src/test/scala/org/apache/flink/table/api/TableEnvironmentTest.scala
+++ b/flink-table/flink-table-planner/src/test/scala/org/apache/flink/table/api/TableEnvironmentTest.scala
@@ -691,10 +691,12 @@ class TableEnvironmentTest {
 
   @Test
   def testExecuteSqlWithEnhancedShowTables(): Unit = {
-    val createCatalogResult = tableEnv.executeSql("CREATE CATALOG catalog1 WITH('type'='generic_in_memory')")
+    val createCatalogResult = tableEnv.executeSql(
+      "CREATE CATALOG catalog1 WITH('type'='generic_in_memory')")
     assertEquals(ResultKind.SUCCESS, createCatalogResult.getResultKind)
 
-    val createDbResult = tableEnv.executeSql("CREATE database catalog1.db1")
+    val createDbResult = tableEnv.executeSql(
+      "CREATE database catalog1.db1")
     assertEquals(ResultKind.SUCCESS, createDbResult.getResultKind)
 
     val createTableStmt =


### PR DESCRIPTION
## What is the purpose of the change

Support enhanced `show tables` syntax like `show tables from catalog1.db1 like 't%'`

## Brief change log

* SHOW TABLES [ ( FROM | IN ) [catalog.]db ] [ [NOT] LIKE regex_pattern ]

## Verifying this change

This change added tests and can be verified as follows:

flink-table/flink-sql-client/src/test/resources/sql/catalog_database.q

## Does this pull request potentially affect one of the following parts:

  - Dependencies (does it add or upgrade a dependency): no
  - The public API, i.e., is any changed class annotated with `@Public(Evolving)`: no
  - The serializers: no
  - The runtime per-record code paths (performance sensitive): no
  - Anything that affects deployment or recovery: JobManager (and its components), Checkpointing, Kubernetes/Yarn/Mesos, ZooKeeper: no
  - The S3 file system connector: no

## Documentation

  - Does this pull request introduce a new feature? yes
  - If yes, how is the feature documented? yes