### PR TITLE
[FLINK-25654][network] Remove the redundant locks in SortMergeResultPartition

### DIFF
--- a/flink-runtime/src/main/java/org/apache/flink/runtime/io/network/partition/SortMergeResultPartition.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/io/network/partition/SortMergeResultPartition.java
@@ -79,10 +79,8 @@ public class SortMergeResultPartition extends ResultPartition {
     private PartitionedFile resultFile;
 
     /** Buffers cut from the network buffer pool for data writing. */
-    @GuardedBy("lock")
     private final List<MemorySegment> writeSegments = new ArrayList<>();
 
-    @GuardedBy("lock")
     private boolean hasNotifiedEndOfUserRecords;
 
     /** Size of network buffer and write buffer. */
@@ -174,16 +172,14 @@ public class SortMergeResultPartition extends ResultPartition {
         }
         numBuffersForSort = numRequiredBuffer - numWriteBuffers;
 
-        synchronized (lock) {
-            try {
-                for (int i = 0; i < numWriteBuffers; ++i) {
-                    MemorySegment segment = bufferPool.requestMemorySegmentBlocking();
-                    writeSegments.add(segment);
-                }
-            } catch (InterruptedException exception) {
-                // the setup method does not allow InterruptedException
-                throw new IOException(exception);
+        try {
+            for (int i = 0; i < numWriteBuffers; ++i) {
+                MemorySegment segment = bufferPool.requestMemorySegmentBlocking();
+                writeSegments.add(segment);
             }
+        } catch (InterruptedException exception) {
+            // the setup method does not allow InterruptedException
+            throw new IOException(exception);
         }
 
         LOG.info(
@@ -277,7 +273,6 @@ public class SortMergeResultPartition extends ResultPartition {
 
         unicastSortBuffer =
                 new PartitionSortedBuffer(
-                        lock,
                         bufferPool,
                         numSubpartitions,
                         networkBufferSize,
@@ -295,7 +290,6 @@ public class SortMergeResultPartition extends ResultPartition {
 
         broadcastSortBuffer =
                 new PartitionSortedBuffer(
-                        lock,
                         bufferPool,
                         numSubpartitions,
                         networkBufferSize,
@@ -344,10 +338,8 @@ public class SortMergeResultPartition extends ResultPartition {
     }
 
     private Queue<MemorySegment> getWriteSegments() {
-        synchronized (lock) {
-            checkState(!writeSegments.isEmpty(), "Task has been canceled.");
-            return new ArrayDeque<>(writeSegments);
-        }
+        checkState(!writeSegments.isEmpty(), "Task has been canceled.");
+        return new ArrayDeque<>(writeSegments);
     }
 
     private BufferWithChannel compressBufferIfPossible(BufferWithChannel bufferWithChannel) {
@@ -400,11 +392,9 @@ public class SortMergeResultPartition extends ResultPartition {
 
     @Override
     public void notifyEndOfData(StopMode mode) throws IOException {
-        synchronized (lock) {
-            if (!hasNotifiedEndOfUserRecords) {
-                broadcastEvent(new EndOfData(mode), false);
-                hasNotifiedEndOfUserRecords = true;
-            }
+        if (!hasNotifiedEndOfUserRecords) {
+            broadcastEvent(new EndOfData(mode), false);
+            hasNotifiedEndOfUserRecords = true;
         }
     }
 
@@ -427,13 +417,11 @@ public class SortMergeResultPartition extends ResultPartition {
     }
 
     private void releaseWriteBuffers() {
-        synchronized (lock) {
-            if (bufferPool != null) {
-                for (MemorySegment segment : writeSegments) {
-                    bufferPool.recycle(segment);
-                }
-                writeSegments.clear();
+        if (bufferPool != null) {
+            for (MemorySegment segment : writeSegments) {
+                bufferPool.recycle(segment);
             }
+            writeSegments.clear();
         }
     }
 

--- a/flink-runtime/src/test/java/org/apache/flink/runtime/io/network/partition/PartitionSortedBufferTest.java
+++ b/flink-runtime/src/test/java/org/apache/flink/runtime/io/network/partition/PartitionSortedBufferTest.java
@@ -319,8 +319,7 @@ public class PartitionSortedBufferTest {
         BufferPool bufferPool = globalPool.createBufferPool(bufferPoolSize, bufferPoolSize);
 
         SortBuffer sortBuffer =
-                new PartitionSortedBuffer(
-                        new Object(), bufferPool, 1, bufferSize, bufferPoolSize, null);
+                new PartitionSortedBuffer(bufferPool, 1, bufferSize, bufferPoolSize, null);
         sortBuffer.append(ByteBuffer.allocate(recordSize), 0, Buffer.DataType.DATA_BUFFER);
 
         assertEquals(bufferPoolSize, bufferPool.bestEffortGetNumOfUsedBuffers());
@@ -348,12 +347,7 @@ public class PartitionSortedBufferTest {
         BufferPool bufferPool = globalPool.createBufferPool(bufferPoolSize, bufferPoolSize);
 
         return new PartitionSortedBuffer(
-                new Object(),
-                bufferPool,
-                numSubpartitions,
-                bufferSize,
-                bufferPoolSize,
-                customReadOrder);
+                bufferPool, numSubpartitions, bufferSize, bufferPoolSize, customReadOrder);
     }
 
     public static int[] getRandomSubpartitionOrder(int numSubpartitions) {


### PR DESCRIPTION


<!--
*Thank you very much for contributing to Apache Flink - we are happy that you want to help us improve Flink. To help the community review your contribution in the best possible way, please go through the checklist below, which will get the contribution into a shape in which it can be best reviewed.*

*Please understand that we do not do this to make contributions to Flink a hassle. In order to uphold a high standard of quality for code contributions, while at the same time managing a large number of contributions, we need contributors to prepare the contributions well, and give reviewers enough contextual information for the review. Please also understand that contributions that do not follow this guide will take longer to review and thus typically be picked up with lower priority by the community.*

## Contribution Checklist

  - Make sure that the pull request corresponds to a [JIRA issue](https://issues.apache.org/jira/projects/FLINK/issues). Exceptions are made for typos in JavaDoc or documentation files, which need no JIRA issue.
  
  - Name the pull request in the form "[FLINK-XXXX] [component] Title of the pull request", where *FLINK-XXXX* should be replaced by the actual issue number. Skip *component* if you are unsure about which is the best component.
  Typo fixes that have no associated JIRA issue should be named following this pattern: `[hotfix] [docs] Fix typo in event time introduction` or `[hotfix] [javadocs] Expand JavaDoc for PuncuatedWatermarkGenerator`.

  - Fill out the template below to describe the changes contributed by the pull request. That will give reviewers the context they need to do the review.
  
  - Make sure that the change passes the automated tests, i.e., `mvn clean verify` passes. You can set up Azure Pipelines CI to do that following [this guide](https://cwiki.apache.org/confluence/display/FLINK/Azure+Pipelines#AzurePipelines-Tutorial:SettingupAzurePipelinesforaforkoftheFlinkrepository).

  - Each pull request should address only one issue, not mix up code from multiple issues.
  
  - Each commit in the pull request has a meaningful commit message (including the JIRA id)

  - Once all items of the checklist are addressed, remove the above text and this checklist, leaving only the filled out template below.


**(The sections below can be removed for hotfixes of typos)**
-->

## What is the purpose of the change

After [FLINK-2372](https://issues.apache.org/jira/browse/FLINK-2372), the task canceler will never call the close method of ResultPartition, this can reduce some race conditions and simplify the code. This PR aims to remove some redundant locks in SortMergeResultPartition.


## Brief change log

  - *Remove the lock of SortMergeResultPartition#writeSegments*
  - *Remove the lock of SortMergeResultPartition#hasNotifiedEndOfUserRecords*
  - *Remove the lock in PartitionSortedBuffer*

## Verifying this change

Please make sure both new and modified tests in this PR follows the conventions defined in our code quality guide: https://flink.apache.org/contributing/code-style-and-quality-common.html#testing

This change is already covered by existing tests, such as *SortMergeResultPartitionTest and PartitionSortedBufferTest*.

## Does this pull request potentially affect one of the following parts:

  - Dependencies (does it add or upgrade a dependency): (yes / **no**)
  - The public API, i.e., is any changed class annotated with `@Public(Evolving)`: (yes / **no**)
  - The serializers: (yes / **no** / don't know)
  - The runtime per-record code paths (performance sensitive): (yes / **no** / don't know)
  - Anything that affects deployment or recovery: JobManager (and its components), Checkpointing, Kubernetes/Yarn, ZooKeeper: (yes / **no** / don't know)
  - The S3 file system connector: (yes / **no** / don't know)

## Documentation

  - Does this pull request introduce a new feature? (yes / **no**)
  - If yes, how is the feature documented? (**not applicable** / docs / JavaDocs / not documented)
