### PR TITLE
[FLINK-25656][Kinesis] Upgrade software.amazon.glue:schema-registry-common and software.amazon.glue:schema-registry-serde dependency from 1.1.5 to 1.1.8

### DIFF
--- a/flink-formats/flink-avro-glue-schema-registry/pom.xml
+++ b/flink-formats/flink-avro-glue-schema-registry/pom.xml
@@ -34,7 +34,7 @@ under the License.
 	<packaging>jar</packaging>
 
 	<properties>
-		<glue.schema.registry.version>1.1.5</glue.schema.registry.version>
+		<glue.schema.registry.version>1.1.8</glue.schema.registry.version>
 		<aws.sdkv2.version>2.17.52</aws.sdkv2.version>
 		<netty.version>4.1.68.Final</netty.version>
 		<kotlin.version>1.3.50</kotlin.version>

--- a/flink-formats/flink-json-glue-schema-registry/pom.xml
+++ b/flink-formats/flink-json-glue-schema-registry/pom.xml
@@ -33,7 +33,7 @@ under the License.
 	<packaging>jar</packaging>
 
 	<properties>
-		<glue.schema.registry.version>1.1.5</glue.schema.registry.version>
+		<glue.schema.registry.version>1.1.8</glue.schema.registry.version>
 		<aws.sdkv2.version>2.17.52</aws.sdkv2.version>
 		<netty.version>4.1.68.Final</netty.version>
 		<kotlin.version>1.3.50</kotlin.version>


### PR DESCRIPTION
## What is the purpose of the change

* Update Glue schema registry dependencies

## Brief change log

* Updated POM file

## Verifying this change

This change is a trivial rework / code cleanup without any test coverage.

## Does this pull request potentially affect one of the following parts:

  - Dependencies (does it add or upgrade a dependency): yes
  - The public API, i.e., is any changed class annotated with `@Public(Evolving)`: no
  - The serializers: no
  - The runtime per-record code paths (performance sensitive): no
  - Anything that affects deployment or recovery: JobManager (and its components), Checkpointing, Kubernetes/Yarn, ZooKeeper: no
  - The S3 file system connector: no

## Documentation

  - Does this pull request introduce a new feature? no
  - If yes, how is the feature documented? not applicable
