### PR TITLE
[FLINK-25657][Kinesis] Upgrade com.amazonaws:amazon-kinesis-client dependency from 1.14.1 to 1.14.7

### DIFF
--- a/flink-connectors/flink-connector-kinesis/pom.xml
+++ b/flink-connectors/flink-connector-kinesis/pom.xml
@@ -35,7 +35,7 @@ under the License.
 	<properties>
 		<aws.sdk.version>1.12.7</aws.sdk.version>
 		<aws.sdkv2.version>2.17.52</aws.sdkv2.version>
-		<aws.kinesis-kcl.version>1.14.1</aws.kinesis-kcl.version>
+		<aws.kinesis-kcl.version>1.14.7</aws.kinesis-kcl.version>
 		<aws.kinesis-kpl.version>0.14.1</aws.kinesis-kpl.version>
 		<aws.dynamodbstreams-kinesis-adapter.version>1.5.3</aws.dynamodbstreams-kinesis-adapter.version>
 		<httpclient.version>4.5.13</httpclient.version>

--- a/flink-connectors/flink-connector-kinesis/src/main/resources/META-INF/NOTICE
+++ b/flink-connectors/flink-connector-kinesis/src/main/resources/META-INF/NOTICE
@@ -6,7 +6,7 @@ The Apache Software Foundation (http://www.apache.org/).
 
 This project bundles the following dependencies under the Apache Software License 2.0. (http://www.apache.org/licenses/LICENSE-2.0.txt) 
 
-- com.amazonaws:amazon-kinesis-client:1.14.1
+- com.amazonaws:amazon-kinesis-client:1.14.7
 - com.amazonaws:amazon-kinesis-producer:0.14.1
 - com.amazonaws:aws-java-sdk-core:1.12.7
 - com.amazonaws:aws-java-sdk-dynamodb:1.12.7
@@ -53,6 +53,8 @@ This project bundles the following dependencies under the Apache Software Licens
 - io.netty:netty-transport-native-unix-common:4.1.68.Final
 - com.typesafe.netty:netty-reactive-streams-http:2.0.5
 - com.typesafe.netty:netty-reactive-streams:2.0.5
+- commons-logging:commons-logging:1.1.3
+- com.fasterxml.jackson.core:jackson-core:2.13.0
 
 This project bundles the following dependencies under the BSD license.
 See bundled license files for details.


### PR DESCRIPTION
## What is the purpose of the change

* Update Amazon Kinesis Client dependency

## Brief change log

* Updated POM file
* Update NOTICE file

## Verifying this change

This change is a trivial rework / code cleanup without any test coverage.

## Does this pull request potentially affect one of the following parts:

  - Dependencies (does it add or upgrade a dependency): yes
  - The public API, i.e., is any changed class annotated with `@Public(Evolving)`: no
  - The serializers: no
  - The runtime per-record code paths (performance sensitive): no
  - Anything that affects deployment or recovery: JobManager (and its components), Checkpointing, Kubernetes/Yarn, ZooKeeper: no
  - The S3 file system connector: no

## Documentation

  - Does this pull request introduce a new feature? no
  - If yes, how is the feature documented? not applicable 
