### PR TITLE
 [FLINK-18356][Azure] Enforce memory limits for docker containers 

### DIFF
--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -41,7 +41,10 @@ resources:
   - container: flink-build-container
     image: chesnay/flink-ci:java_8_11_17
     # On AZP provided machines, set this flag to allow writing coredumps in docker
-    options: --privileged
+    # Limit memory to 6 GB (7GB is the memory available to the host)
+    # Set the swap to the same value as memory to disable using swap
+    # (see: https://docs.docker.com/config/containers/resource_constraints/)
+    options: --privileged --memory=6G --memory-swap=6G
 
 # Define variables:
 # - See tools/azure-pipelines/jobs-template.yml for a short summary of the caching

--- a/flink-end-to-end-tests/run-nightly-tests.sh
+++ b/flink-end-to-end-tests/run-nightly-tests.sh
@@ -257,7 +257,7 @@ function run_group_2 {
     LOG4J_PROPERTIES=${END_TO_END_DIR}/../tools/ci/log4j.properties
 
     MVN_LOGGING_OPTIONS="-Dlog.dir=${DEBUG_FILES_OUTPUT_DIR} -DlogBackupDir=${DEBUG_FILES_OUTPUT_DIR} -Dlog4j.configurationFile=file://$LOG4J_PROPERTIES"
-    MVN_COMMON_OPTIONS="-Dflink.forkCount=2 -Dflink.forkCountTestPackage=2 -Dfast -Pskip-webui-build"
+    MVN_COMMON_OPTIONS="-Dflink.forkCount=2 -Dflink.forkCountTestPackage=1 -Dflink.forkCountTablePlanner=1 -Dfast -Pskip-webui-build"
     e2e_modules=$(find flink-end-to-end-tests -mindepth 2 -maxdepth 5 -name 'pom.xml' -printf '%h\n' | sort -u | tr '\n' ',')
     e2e_modules="${e2e_modules},$(find flink-walkthroughs -mindepth 2 -maxdepth 2 -name 'pom.xml' -printf '%h\n' | sort -u | tr '\n' ',')"
 

--- a/flink-table/flink-table-planner/pom.xml
+++ b/flink-table/flink-table-planner/pom.xml
@@ -500,6 +500,7 @@ under the License.
 							</includes>
 							<!-- override reuseForks to true to reduce testing time -->
 							<reuseForks>true</reuseForks>
+							<forkCount>${flink.forkCountTablePlanner}</forkCount>
 						</configuration>
 					</execution>
 				</executions>

--- a/pom.xml
+++ b/pom.xml
@@ -102,6 +102,7 @@ under the License.
 		<!-- Allow overriding the fork behaviour for the expensive tests in flink-tests
 			 to avoid process kills due to container limits on TravisCI -->
 		<flink.forkCountTestPackage>${flink.forkCount}</flink.forkCountTestPackage>
+		<flink.forkCountTablePlanner>${flink.forkCount}</flink.forkCountTablePlanner>
 		<flink.reuseForks>true</flink.reuseForks>
 		<flink.shaded.version>14.0</flink.shaded.version>
 		<flink.shaded.jackson.version>2.12.4</flink.shaded.jackson.version>

--- a/pom.xml
+++ b/pom.xml
@@ -1559,7 +1559,7 @@ under the License.
 						<!--suppress MavenModelInspection -->
 						<test.randomization.seed>${test.randomization.seed}</test.randomization.seed>
 					</systemPropertyVariables>
-					<argLine>-Xms256m -Xmx2048m -Dmvn.forkNumber=${surefire.forkNumber} -XX:+UseG1GC -Duser.country=US -Duser.language=en</argLine>
+					<argLine>-Xms256m -Xmx2048m -XX:MaxDirectMemorySize=2048m -Dmvn.forkNumber=${surefire.forkNumber} -XX:+UseG1GC -Duser.country=US -Duser.language=en</argLine>
 				</configuration>
 				<executions>
 					<!--execute all the unit tests-->

--- a/tools/azure-pipelines/build-apache-repo.yml
+++ b/tools/azure-pipelines/build-apache-repo.yml
@@ -40,6 +40,10 @@ resources:
   # see https://github.com/flink-ci/flink-ci-docker
   - container: flink-build-container
     image: chesnay/flink-ci:java_8_11_17
+    # 6GB is the memory limit we have on Azure hosted VMs. Enforce the same limit on the custom CI servers.
+    # Set the swap to the same value as memory to disable using swap
+    # (see: https://docs.docker.com/config/containers/resource_constraints/)
+    options: --memory=6G --memory-swap=6G
 
 variables:
   MAVEN_CACHE_FOLDER: $(Pipeline.Workspace)/.m2/repository

--- a/tools/ci/compile.sh
+++ b/tools/ci/compile.sh
@@ -47,8 +47,7 @@ echo "==========================================================================
 
 EXIT_CODE=0
 
-run_mvn clean deploy -DaltDeploymentRepository=validation_repository::default::file:$MVN_VALIDATION_DIR -Dflink.convergence.phase=install -Pcheck-convergence -Dflink.forkCount=2 \
-    -Dflink.forkCountTestPackage=2 -Dmaven.javadoc.skip=true -U -DskipTests | tee $MVN_CLEAN_COMPILE_OUT
+run_mvn clean deploy -DaltDeploymentRepository=validation_repository::default::file:$MVN_VALIDATION_DIR -Dflink.convergence.phase=install -Pcheck-convergence -Dmaven.javadoc.skip=true -U -DskipTests | tee $MVN_CLEAN_COMPILE_OUT
 
 EXIT_CODE=${PIPESTATUS[0]}
 

--- a/tools/ci/test_controller.sh
+++ b/tools/ci/test_controller.sh
@@ -80,7 +80,7 @@ source "${HERE}/watchdog.sh"
 export LOG4J_PROPERTIES=${HERE}/log4j.properties
 MVN_LOGGING_OPTIONS="-Dlog.dir=${DEBUG_FILES_OUTPUT_DIR} -Dlog4j.configurationFile=file://$LOG4J_PROPERTIES"
 
-MVN_COMMON_OPTIONS="-Dflink.forkCount=2 -Dflink.forkCountTestPackage=2 -Dfast -Pskip-webui-build $MVN_LOGGING_OPTIONS"
+MVN_COMMON_OPTIONS="-Dflink.forkCount=2 -Dflink.forkCountTestPackage=1 -Dflink.forkCountTablePlanner=1 -Dfast -Pskip-webui-build $MVN_LOGGING_OPTIONS"
 MVN_COMPILE_OPTIONS="-DskipTests"
 MVN_COMPILE_MODULES=$(get_compile_modules_for_stage ${STAGE})
 


### PR DESCRIPTION
## What is the purpose of the change

I took over after #15509.

This PR imposes hard limits on the memory available to docker containers. With the limits in place in case of an increased memory consumption docker will kill the java process, instead of the system killing the docker container, which should result in more insights into what is really going on.

## Brief change log

  - Added hard memory limits to docker containers (6GB + no swap)
  - Decreased the number of forks for table tests (Table tests & flink-tests fail reliably with the limits in place. It is worth investigating separately if we can do anything about that)

## Does this pull request potentially affect one of the following parts:

  - Dependencies (does it add or upgrade a dependency): (yes / **no**)
  - The public API, i.e., is any changed class annotated with `@Public(Evolving)`: (yes / **no**)
  - The serializers: (yes / **no** / don't know)
  - The runtime per-record code paths (performance sensitive): (yes / **no** / don't know)
  - Anything that affects deployment or recovery: JobManager (and its components), Checkpointing, Kubernetes/Yarn, ZooKeeper: (yes / **no** / don't know)
  - The S3 file system connector: (yes / **no** / don't know)

## Documentation

  - Does this pull request introduce a new feature? (yes / **no**)
  - If yes, how is the feature documented? (**not applicable** / docs / JavaDocs / not documented)
