### PR TITLE
[hotfix][table-common] Introduce ObjectIdentifier.ofAnonymous to allow storing anonymous, but still uniquely identified, names in ObjectIdentifier

### DIFF
--- a/flink-table/flink-table-common/src/main/java/org/apache/flink/table/catalog/ObjectIdentifier.java
+++ b/flink-table/flink-table-common/src/main/java/org/apache/flink/table/catalog/ObjectIdentifier.java
@@ -19,10 +19,14 @@
 package org.apache.flink.table.catalog;
 
 import org.apache.flink.annotation.PublicEvolving;
+import org.apache.flink.table.api.TableException;
 import org.apache.flink.util.Preconditions;
+
+import javax.annotation.Nullable;
 
 import java.io.Serializable;
 import java.util.Arrays;
+import java.util.Collections;
 import java.util.List;
 import java.util.Objects;
 
@@ -42,29 +46,55 @@ import static org.apache.flink.table.utils.EncodingUtils.escapeIdentifier;
 @PublicEvolving
 public final class ObjectIdentifier implements Serializable {
 
-    private final String catalogName;
+    static final String UNKNOWN = "<UNKNOWN>";
 
-    private final String databaseName;
-
+    private final @Nullable String catalogName;
+    private final @Nullable String databaseName;
     private final String objectName;
 
     public static ObjectIdentifier of(String catalogName, String databaseName, String objectName) {
-        return new ObjectIdentifier(catalogName, databaseName, objectName);
+        if (Objects.equals(catalogName, UNKNOWN) || Objects.equals(databaseName, UNKNOWN)) {
+            throw new IllegalArgumentException(
+                    String.format("Catalog or database cannot be named '%s'", UNKNOWN));
+        }
+        return new ObjectIdentifier(
+                Preconditions.checkNotNull(catalogName, "Catalog name must not be null."),
+                Preconditions.checkNotNull(databaseName, "Database name must not be null."),
+                Preconditions.checkNotNull(objectName, "Object name must not be null."));
     }
 
-    private ObjectIdentifier(String catalogName, String databaseName, String objectName) {
-        this.catalogName =
-                Preconditions.checkNotNull(catalogName, "Catalog name must not be null.");
-        this.databaseName =
-                Preconditions.checkNotNull(databaseName, "Database name must not be null.");
-        this.objectName = Preconditions.checkNotNull(objectName, "Object name must not be null.");
+    /**
+     * This method allows to create an {@link ObjectIdentifier} without catalog and database name,
+     * in order to propagate anonymous objects unique identifiers throughout the stack.
+     *
+     * <p>This method for no reason should be exposed to the users, as this should be used only when
+     * creating anonymous tables to store a unique generated id.
+     */
+    static ObjectIdentifier ofAnonymous(String objectName) {
+        return new ObjectIdentifier(
+                null,
+                null,
+                Preconditions.checkNotNull(objectName, "Object name must not be null."));
+    }
+
+    private ObjectIdentifier(
+            @Nullable String catalogName, @Nullable String databaseName, String objectName) {
+        this.catalogName = catalogName;
+        this.databaseName = databaseName;
+        this.objectName = objectName;
     }
 
     public String getCatalogName() {
+        if (catalogName == null) {
+            return UNKNOWN;
+        }
         return catalogName;
     }
 
     public String getDatabaseName() {
+        if (catalogName == null) {
+            return UNKNOWN;
+        }
         return databaseName;
     }
 
@@ -72,20 +102,40 @@ public final class ObjectIdentifier implements Serializable {
         return objectName;
     }
 
-    public ObjectPath toObjectPath() {
+    /**
+     * Convert this {@link ObjectIdentifier} to {@link ObjectPath}.
+     *
+     * @throws IllegalStateException if the identifier cannot be converted
+     */
+    public ObjectPath toObjectPath() throws IllegalStateException {
+        if (catalogName == null) {
+            throw new TableException(
+                    "This ObjectIdentifier instance refers to an anonymous object, "
+                            + "hence it cannot be converted to ObjectPath and cannot be serialized.");
+        }
         return new ObjectPath(databaseName, objectName);
     }
 
     /** List of the component names of this object identifier. */
     public List<String> toList() {
+        if (catalogName == null) {
+            return Collections.singletonList(getObjectName());
+        }
         return Arrays.asList(getCatalogName(), getDatabaseName(), getObjectName());
     }
 
     /**
      * Returns a string that fully serializes this instance. The serialized string can be used for
      * transmitting or persisting an object identifier.
+     *
+     * @throws IllegalStateException if the identifier cannot be serialized
      */
-    public String asSerializableString() {
+    public String asSerializableString() throws IllegalStateException {
+        if (catalogName == null) {
+            throw new TableException(
+                    "This ObjectIdentifier instance refers to an anonymous object, "
+                            + "hence it cannot be converted to ObjectPath and cannot be serialized.");
+        }
         return String.format(
                 "%s.%s.%s",
                 escapeIdentifier(catalogName),
@@ -95,6 +145,9 @@ public final class ObjectIdentifier implements Serializable {
 
     /** Returns a string that summarizes this instance for printing to a console or log. */
     public String asSummaryString() {
+        if (catalogName == null) {
+            return objectName;
+        }
         return String.join(".", catalogName, databaseName, objectName);
     }
 
@@ -107,8 +160,8 @@ public final class ObjectIdentifier implements Serializable {
             return false;
         }
         ObjectIdentifier that = (ObjectIdentifier) o;
-        return catalogName.equals(that.catalogName)
-                && databaseName.equals(that.databaseName)
+        return Objects.equals(catalogName, that.catalogName)
+                && Objects.equals(databaseName, that.databaseName)
                 && objectName.equals(that.objectName);
     }
 
@@ -119,6 +172,9 @@ public final class ObjectIdentifier implements Serializable {
 
     @Override
     public String toString() {
+        if (catalogName == null) {
+            return objectName;
+        }
         return asSerializableString();
     }
 }

--- a/flink-table/flink-table-common/src/main/java/org/apache/flink/table/catalog/ObjectIdentifier.java
+++ b/flink-table/flink-table-common/src/main/java/org/apache/flink/table/catalog/ObjectIdentifier.java
@@ -65,10 +65,10 @@ public final class ObjectIdentifier implements Serializable {
 
     /**
      * This method allows to create an {@link ObjectIdentifier} without catalog and database name,
-     * in order to propagate anonymous objects unique identifiers throughout the stack.
+     * in order to propagate anonymous objects with unique identifiers throughout the stack.
      *
-     * <p>This method for no reason should be exposed to the users, as this should be used only when
-     * creating anonymous tables to store a unique generated id.
+     * <p>This method for no reason should be exposed to users, as this should be used only when
+     * creating anonymous tables with uniquely generated identifiers.
      */
     static ObjectIdentifier ofAnonymous(String objectName) {
         return new ObjectIdentifier(
@@ -105,9 +105,9 @@ public final class ObjectIdentifier implements Serializable {
     /**
      * Convert this {@link ObjectIdentifier} to {@link ObjectPath}.
      *
-     * @throws IllegalStateException if the identifier cannot be converted
+     * @throws TableException if the identifier cannot be converted
      */
-    public ObjectPath toObjectPath() throws IllegalStateException {
+    public ObjectPath toObjectPath() throws TableException {
         if (catalogName == null) {
             throw new TableException(
                     "This ObjectIdentifier instance refers to an anonymous object, "
@@ -128,9 +128,9 @@ public final class ObjectIdentifier implements Serializable {
      * Returns a string that fully serializes this instance. The serialized string can be used for
      * transmitting or persisting an object identifier.
      *
-     * @throws IllegalStateException if the identifier cannot be serialized
+     * @throws TableException if the identifier cannot be serialized
      */
-    public String asSerializableString() throws IllegalStateException {
+    public String asSerializableString() throws TableException {
         if (catalogName == null) {
             throw new TableException(
                     "This ObjectIdentifier instance refers to an anonymous object, "

--- a/flink-table/flink-table-common/src/test/java/org/apache/flink/table/catalog/ObjectIdentifierTest.java
+++ b/flink-table/flink-table-common/src/test/java/org/apache/flink/table/catalog/ObjectIdentifierTest.java
@@ -18,11 +18,14 @@
 
 package org.apache.flink.table.catalog;
 
+import org.apache.flink.table.api.TableException;
+
 import org.junit.jupiter.api.Test;
 
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.assertThatThrownBy;
 
+/** Tests for {@link ObjectIdentifier}. */
 class ObjectIdentifierTest {
 
     @Test
@@ -38,8 +41,7 @@ class ObjectIdentifierTest {
                 .isEqualTo(objectName);
 
         assertThatThrownBy(objectIdentifier::asSerializableString)
-                .isInstanceOf(IllegalStateException.class);
-        assertThatThrownBy(objectIdentifier::toObjectPath)
-                .isInstanceOf(IllegalStateException.class);
+                .isInstanceOf(TableException.class);
+        assertThatThrownBy(objectIdentifier::toObjectPath).isInstanceOf(TableException.class);
     }
 }

--- a/flink-table/flink-table-common/src/test/java/org/apache/flink/table/catalog/ObjectIdentifierTest.java
+++ b/flink-table/flink-table-common/src/test/java/org/apache/flink/table/catalog/ObjectIdentifierTest.java
@@ -1,0 +1,45 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.flink.table.catalog;
+
+import org.junit.jupiter.api.Test;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+
+class ObjectIdentifierTest {
+
+    @Test
+    void testAnonymousIdentifier() {
+        String objectName = "my_anonymous_table";
+        ObjectIdentifier objectIdentifier = ObjectIdentifier.ofAnonymous(objectName);
+
+        assertThat(objectIdentifier.getCatalogName()).isEqualTo(ObjectIdentifier.UNKNOWN);
+        assertThat(objectIdentifier.getDatabaseName()).isEqualTo(ObjectIdentifier.UNKNOWN);
+        assertThat(objectIdentifier.toList()).containsExactly(objectName);
+        assertThat(objectIdentifier.asSummaryString())
+                .isEqualTo(objectIdentifier.toString())
+                .isEqualTo(objectName);
+
+        assertThatThrownBy(objectIdentifier::asSerializableString)
+                .isInstanceOf(IllegalStateException.class);
+        assertThatThrownBy(objectIdentifier::toObjectPath)
+                .isInstanceOf(IllegalStateException.class);
+    }
+}


### PR DESCRIPTION
## What is the purpose of the change

This PR allows to store anonymous, but still uniquely identified, names in `ObjectIdentifier`. The reason for this is to simplify the implementation of https://github.com/apache/flink/pull/18349, in particular, thanks to this change we don't need to modify the assumptions both inside the planner and for connectors that `ObjectIdentifier` can be null, allowing us to remove this change: https://github.com/apache/flink/pull/18349/commits/9427c7f0b57216f26520d55a7f1817ac2b2676c9

## Brief change log

* Add `ObjectIdentifier#ofAnonymous`

## Verifying this change

This change added a unit test.

## Does this pull request potentially affect one of the following parts:

  - Dependencies (does it add or upgrade a dependency): no
  - The public API, i.e., is any changed class annotated with `@Public(Evolving)`: yes
  - The serializers: yes
  - The runtime per-record code paths (performance sensitive): yes
  - Anything that affects deployment or recovery: JobManager (and its components), Checkpointing, Kubernetes/Yarn, ZooKeeper: yes
  - The S3 file system connector: yes

## Documentation

  - Does this pull request introduce a new feature? no
  - If yes, how is the feature documented? not applicable
