### PR TITLE
[hotfix][javadocs] Updated javadoc to refer to pom.xml file

### DIFF
--- a/flink-quickstart/flink-quickstart-java/src/main/resources/archetype-resources/src/main/java/DataStreamJob.java
+++ b/flink-quickstart/flink-quickstart-java/src/main/resources/archetype-resources/src/main/java/DataStreamJob.java
@@ -30,7 +30,7 @@ import org.apache.flink.streaming.api.environment.StreamExecutionEnvironment;
  * 'mvn clean package' on the command line.
  *
  * <p>If you change the name of the main class (with the public static void main(String[] args))
- * method, change the respective entry in the POM.xml file (simply search for 'mainClass').
+ * method, change the respective entry in the pom.xml file (simply search for 'mainClass').
  */
 public class DataStreamJob {
 

--- a/flink-quickstart/flink-quickstart-scala/src/main/resources/archetype-resources/src/main/scala/DataStreamJob.scala
+++ b/flink-quickstart/flink-quickstart-scala/src/main/resources/archetype-resources/src/main/scala/DataStreamJob.scala
@@ -30,7 +30,7 @@ import org.apache.flink.streaming.api.scala._
  * 'mvn clean package' on the command line.
  *
  * <p>If you change the name of the main class (with the public static void main(String[] args))
- * method, change the respective entry in the POM.xml file (simply search for 'mainClass').
+ * method, change the respective entry in the pom.xml file (simply search for 'mainClass').
  */
 object DataStreamJob {
   def main(args: Array[String]) {


### PR DESCRIPTION

## What is the purpose of the change

* The quickstart main class javadoc refers to `POM.xml` file.

## Brief change log

* Updated javadoc to refer to `pom.xml` file to be consistent with the references to the file

## Verifying this change

This change is a trivial rework / code cleanup without any test coverage.

## Does this pull request potentially affect one of the following parts:

  - Dependencies (does it add or upgrade a dependency): no
  - The public API, i.e., is any changed class annotated with `@Public(Evolving)`: no
  - The serializers: no 
  - The runtime per-record code paths (performance sensitive): no
  - Anything that affects deployment or recovery: JobManager (and its components), Checkpointing, Kubernetes/Yarn, ZooKeeper: no
  - The S3 file system connector: no

## Documentation

  - Does this pull request introduce a new feature? no
  - If yes, how is the feature documented? not applicable