### PR TITLE
[FLINK-25676][python] Support set_description in DataStream API

### DIFF
--- a/flink-python/pyflink/datastream/data_stream.py
+++ b/flink-python/pyflink/datastream/data_stream.py
@@ -231,6 +231,24 @@ class DataStream(object):
             self._j_data_stream.slotSharingGroup(slot_sharing_group)
         return self
 
+    def set_description(self, description: str):
+        """
+        Sets the description for this operator.
+
+        Description is used in json plan and web ui, but not in logging and metrics where only
+        name is available. Description is expected to provide detailed information about the
+        operator, while name is expected to be more simple, providing summary information only,
+        so that we can have more user-friendly logging messages and metric tags without losing
+        useful messages for debugging.
+
+        :param description: The description for this operator.
+        :return: The sink with new description.
+
+        .. versionadded:: 1.11.0
+        """
+        self._j_data_stream.setDescription(description)
+        return self
+
     def map(self, func: Union[Callable, MapFunction], output_type: TypeInformation = None) \
             -> 'DataStream':
         """
@@ -885,6 +903,24 @@ class DataStreamSink(object):
         :return: The operator with set parallelism.
         """
         self._j_data_stream_sink.setParallelism(parallelism)
+        return self
+
+    def set_description(self, description: str) -> 'DataStreamSink':
+        """
+        Sets the description for this sink.
+
+        Description is used in json plan and web ui, but not in logging and metrics where only
+        name is available. Description is expected to provide detailed information about the sink,
+        while name is expected to be more simple, providing summary information only, so that we can
+        have more user-friendly logging messages and metric tags without losing useful messages for
+        debugging.
+
+        :param description: The description for this sink.
+        :return: The sink with new description.
+
+        .. versionadded:: 1.11.0
+        """
+        self._j_data_stream_sink.setDescription(description)
         return self
 
     def disable_chaining(self) -> 'DataStreamSink':

--- a/flink-python/src/main/java/org/apache/flink/python/chain/PythonOperatorChainingOptimizer.java
+++ b/flink-python/src/main/java/org/apache/flink/python/chain/PythonOperatorChainingOptimizer.java
@@ -365,6 +365,15 @@ public class PythonOperatorChainingOptimizer {
         if (upTransform.getSlotSharingGroup().isPresent()) {
             chainedTransformation.setSlotSharingGroup(upTransform.getSlotSharingGroup().get());
         }
+
+        if (upTransform.getDescription() != null && downTransform.getDescription() != null) {
+            chainedTransformation.setDescription(
+                    upTransform.getDescription() + ", " + downTransform.getDescription());
+        } else if (upTransform.getDescription() != null) {
+            chainedTransformation.setDescription(upTransform.getDescription());
+        } else {
+            chainedTransformation.setDescription(downTransform.getDescription());
+        }
         return chainedTransformation;
     }
 

--- a/flink-python/src/main/java/org/apache/flink/python/chain/PythonOperatorChainingOptimizer.java
+++ b/flink-python/src/main/java/org/apache/flink/python/chain/PythonOperatorChainingOptimizer.java
@@ -371,7 +371,7 @@ public class PythonOperatorChainingOptimizer {
                     upTransform.getDescription() + ", " + downTransform.getDescription());
         } else if (upTransform.getDescription() != null) {
             chainedTransformation.setDescription(upTransform.getDescription());
-        } else {
+        } else if (downTransform.getDescription() != null) {
             chainedTransformation.setDescription(downTransform.getDescription());
         }
         return chainedTransformation;


### PR DESCRIPTION

## What is the purpose of the change

*This pull request add support of set_description in DataStream API*



## Verifying this change

This change is a trivial rework without any test coverage.


## Does this pull request potentially affect one of the following parts:

  - Dependencies (does it add or upgrade a dependency): (no)
  - The public API, i.e., is any changed class annotated with `@Public(Evolving)`: (no)
  - The serializers: (no)
  - The runtime per-record code paths (performance sensitive): (no)
  - Anything that affects deployment or recovery: JobManager (and its components), Checkpointing, Kubernetes/Yarn, ZooKeeper: (no)
  - The S3 file system connector: ( no)

## Documentation

  - Does this pull request introduce a new feature? (yes)
  - If yes, how is the feature documented? (not documented)
