### PR TITLE
[hotfix][flink-annotations] Add v1.15 as the next Flink version to master

### DIFF
--- a/flink-annotations/src/main/java/org/apache/flink/FlinkVersion.java
+++ b/flink-annotations/src/main/java/org/apache/flink/FlinkVersion.java
@@ -51,7 +51,8 @@ public enum FlinkVersion {
     v1_11("1.11"),
     v1_12("1.12"),
     v1_13("1.13"),
-    v1_14("1.14");
+    v1_14("1.14"),
+    v1_15("1.15");
 
     private final String versionStr;
 
@@ -68,10 +69,10 @@ public enum FlinkVersion {
         return this.ordinal() > otherVersion.ordinal();
     }
 
-    /** Returns all versions equal to or higher than the selected version. */
-    public Set<FlinkVersion> orHigher() {
+    /** Returns all versions within the defined range, inclusive both start and end. */
+    public static Set<FlinkVersion> rangeOf(FlinkVersion start, FlinkVersion end) {
         return Stream.of(FlinkVersion.values())
-                .filter(v -> this.ordinal() <= v.ordinal())
+                .filter(v -> v.ordinal() >= start.ordinal() && v.ordinal() <= end.ordinal())
                 .collect(Collectors.toCollection(LinkedHashSet::new));
     }
 

--- a/flink-core/src/test/java/org/apache/flink/api/common/typeutils/TypeSerializerUpgradeTestBase.java
+++ b/flink-core/src/test/java/org/apache/flink/api/common/typeutils/TypeSerializerUpgradeTestBase.java
@@ -36,6 +36,7 @@ import java.nio.file.Path;
 import java.nio.file.Paths;
 import java.util.Collections;
 import java.util.List;
+import java.util.Set;
 
 import static org.apache.flink.util.Preconditions.checkNotNull;
 import static org.hamcrest.CoreMatchers.not;
@@ -51,10 +52,10 @@ import static org.junit.Assume.assumeThat;
 public abstract class TypeSerializerUpgradeTestBase<PreviousElementT, UpgradedElementT>
         extends TestLogger {
 
-    public static final FlinkVersion[] MIGRATION_VERSIONS =
-            FlinkVersion.v1_11.orHigher().toArray(new FlinkVersion[0]);
-
     public static final FlinkVersion CURRENT_VERSION = FlinkVersion.v1_14;
+
+    public static final Set<FlinkVersion> MIGRATION_VERSIONS =
+            FlinkVersion.rangeOf(FlinkVersion.v1_11, CURRENT_VERSION);
 
     private final TestSpecification<PreviousElementT, UpgradedElementT> testSpecification;
 

--- a/flink-core/src/test/java/org/apache/flink/api/java/typeutils/runtime/PojoSerializerUpgradeTest.java
+++ b/flink-core/src/test/java/org/apache/flink/api/java/typeutils/runtime/PojoSerializerUpgradeTest.java
@@ -25,7 +25,6 @@ import org.junit.runner.RunWith;
 import org.junit.runners.Parameterized;
 
 import java.util.ArrayList;
-import java.util.Arrays;
 import java.util.Collection;
 import java.util.List;
 
@@ -48,7 +47,7 @@ public class PojoSerializerUpgradeTest extends TypeSerializerUpgradeTestBase<Obj
         testVersions.add(FlinkVersion.v1_7);
         testVersions.add(FlinkVersion.v1_8);
         testVersions.add(FlinkVersion.v1_9);
-        testVersions.addAll(Arrays.asList(MIGRATION_VERSIONS));
+        testVersions.addAll(MIGRATION_VERSIONS);
         for (FlinkVersion flinkVersion : testVersions) {
             testSpecifications.add(
                     new TestSpecification<>(

--- a/flink-core/src/test/java/org/apache/flink/api/java/typeutils/runtime/RowSerializerUpgradeTest.java
+++ b/flink-core/src/test/java/org/apache/flink/api/java/typeutils/runtime/RowSerializerUpgradeTest.java
@@ -34,7 +34,6 @@ import org.junit.runner.RunWith;
 import org.junit.runners.Parameterized;
 
 import java.util.ArrayList;
-import java.util.Arrays;
 import java.util.Collection;
 import java.util.List;
 
@@ -56,7 +55,7 @@ public class RowSerializerUpgradeTest extends TypeSerializerUpgradeTestBase<Row,
         // TypeSerializerUpgradeTestBase
         List<FlinkVersion> testVersions = new ArrayList<>();
         testVersions.add(FlinkVersion.v1_10);
-        testVersions.addAll(Arrays.asList(MIGRATION_VERSIONS));
+        testVersions.addAll(MIGRATION_VERSIONS);
         for (FlinkVersion flinkVersion : testVersions) {
             testSpecifications.add(
                     new TestSpecification<>(

--- a/flink-scala/src/test/scala/org/apache/flink/api/scala/typeutils/EnumValueSerializerUpgradeTest.scala
+++ b/flink-scala/src/test/scala/org/apache/flink/api/scala/typeutils/EnumValueSerializerUpgradeTest.scala
@@ -50,14 +50,13 @@ object EnumValueSerializerUpgradeTest {
     val testSpecifications =
       new util.ArrayList[TypeSerializerUpgradeTestBase.TestSpecification[_, _]]
 
-    for (migrationVersion <- TypeSerializerUpgradeTestBase.MIGRATION_VERSIONS) {
+    TypeSerializerUpgradeTestBase.MIGRATION_VERSIONS.forEach(migrationVersion =>
       testSpecifications.add(
         new TypeSerializerUpgradeTestBase.TestSpecification[Letters.Value, Letters.Value](
         "scala-enum-serializer",
           migrationVersion,
           classOf[EnumValueSerializerSetup],
-          classOf[EnumValueSerializerVerifier]))
-    }
+          classOf[EnumValueSerializerVerifier])))
 
     testSpecifications
   }

--- a/flink-scala/src/test/scala/org/apache/flink/api/scala/typeutils/ScalaCaseClassSerializerUpgradeTest.scala
+++ b/flink-scala/src/test/scala/org/apache/flink/api/scala/typeutils/ScalaCaseClassSerializerUpgradeTest.scala
@@ -55,14 +55,14 @@ object ScalaCaseClassSerializerUpgradeTest {
   def testSpecifications(): util.Collection[TestSpecification[_, _]] = {
     val testSpecifications =
       new util.ArrayList[TypeSerializerUpgradeTestBase.TestSpecification[_, _]]
-    for (migrationVersion <- TypeSerializerUpgradeTestBase.MIGRATION_VERSIONS) {
+    TypeSerializerUpgradeTestBase.MIGRATION_VERSIONS.forEach(migrationVersion =>
       testSpecifications.add(
         new TypeSerializerUpgradeTestBase.TestSpecification[CustomCaseClass, CustomCaseClass]
         ("scala-case-class-serializer",
           migrationVersion,
           classOf[ScalaCaseClassSerializerSetup],
-          classOf[ScalaCaseClassSerializerVerifier]))
-    }
+          classOf[ScalaCaseClassSerializerVerifier])))
+
     testSpecifications
   }
 

--- a/flink-scala/src/test/scala/org/apache/flink/api/scala/typeutils/TraversableSerializerUpgradeTest.scala
+++ b/flink-scala/src/test/scala/org/apache/flink/api/scala/typeutils/TraversableSerializerUpgradeTest.scala
@@ -79,7 +79,7 @@ object TraversableSerializerUpgradeTest {
 
     val testSpecifications =
       new util.ArrayList[TypeSerializerUpgradeTestBase.TestSpecification[_, _]]
-    for (migrationVersion <- TypeSerializerUpgradeTestBase.MIGRATION_VERSIONS) {
+    TypeSerializerUpgradeTestBase.MIGRATION_VERSIONS.forEach(migrationVersion => {
       testSpecifications.add(
         new TestSpecification[BitSet, BitSet](
           "traversable-serializer-bitset",
@@ -134,7 +134,7 @@ object TraversableSerializerUpgradeTest {
           migrationVersion,
           classOf[SeqWithPojoSetup],
           classOf[SeqWithPojoVerifier]))
-    }
+    })
     testSpecifications
   }
 

--- a/flink-table/flink-table-runtime/src/test/java/org/apache/flink/table/runtime/typeutils/LinkedListSerializerUpgradeTest.java
+++ b/flink-table/flink-table-runtime/src/test/java/org/apache/flink/table/runtime/typeutils/LinkedListSerializerUpgradeTest.java
@@ -48,7 +48,7 @@ public class LinkedListSerializerUpgradeTest
 
     @Parameterized.Parameters(name = "Test Specification = {0}")
     public static Collection<TestSpecification<?, ?>> testSpecifications() throws Exception {
-        return FlinkVersion.v1_13.orHigher().stream()
+        return FlinkVersion.rangeOf(FlinkVersion.v1_13, CURRENT_VERSION).stream()
                 .map(
                         version -> {
                             try {


### PR DESCRIPTION
The upcoming version to be released need to exist already in master so that
when the new release branch is created from master the version of the release
is already there.

Follows: #18340

