### PR TITLE
[FLINK-22643][network] Reuse tpc connections between taskmanagers

### DIFF
--- a/docs/layouts/shortcodes/generated/all_taskmanager_network_section.html
+++ b/docs/layouts/shortcodes/generated/all_taskmanager_network_section.html
@@ -27,6 +27,12 @@
             <td>Boolean flag to enable/disable more detailed metrics about inbound/outbound network queue lengths.</td>
         </tr>
         <tr>
+            <td><h5>taskmanager.network.max-num-tcp-connections</h5></td>
+            <td style="word-wrap: break-word;">1</td>
+            <td>Integer</td>
+            <td>The maximum number of tpc connections between taskmanagers for data communication.</td>
+        </tr>
+        <tr>
             <td><h5>taskmanager.network.memory.buffers-per-channel</h5></td>
             <td style="word-wrap: break-word;">2</td>
             <td>Integer</td>

--- a/docs/layouts/shortcodes/generated/netty_shuffle_environment_configuration.html
+++ b/docs/layouts/shortcodes/generated/netty_shuffle_environment_configuration.html
@@ -45,6 +45,12 @@
             <td>Boolean flag to enable/disable more detailed metrics about inbound/outbound network queue lengths.</td>
         </tr>
         <tr>
+            <td><h5>taskmanager.network.max-num-tcp-connections</h5></td>
+            <td style="word-wrap: break-word;">1</td>
+            <td>Integer</td>
+            <td>The maximum number of tpc connections between taskmanagers for data communication.</td>
+        </tr>
+        <tr>
             <td><h5>taskmanager.network.memory.buffers-per-channel</h5></td>
             <td style="word-wrap: break-word;">2</td>
             <td>Integer</td>

--- a/flink-core/src/main/java/org/apache/flink/configuration/NettyShuffleEnvironmentOptions.java
+++ b/flink-core/src/main/java/org/apache/flink/configuration/NettyShuffleEnvironmentOptions.java
@@ -152,6 +152,15 @@ public class NettyShuffleEnvironmentOptions {
                     .defaultValue("1gb")
                     .withDescription("Maximum memory size for network buffers.");
 
+    /** The maximum number of tpc connections between taskmanagers for data communication. */
+    @Documentation.Section(Documentation.Sections.ALL_TASK_MANAGER_NETWORK)
+    public static final ConfigOption<Integer> MAX_NUM_TCP_CONNECTIONS =
+            key("taskmanager.network.max-num-tcp-connections")
+                    .intType()
+                    .defaultValue(1)
+                    .withDescription(
+                            "The maximum number of tpc connections between taskmanagers for data communication.");
+
     /**
      * Number of network buffers to use for each outgoing/incoming channel (subpartition/input
      * channel).

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/io/network/NettyShuffleServiceFactory.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/io/network/NettyShuffleServiceFactory.java
@@ -115,7 +115,10 @@ public class NettyShuffleServiceFactory
         ConnectionManager connectionManager =
                 nettyConfig != null
                         ? new NettyConnectionManager(
-                                resultPartitionManager, taskEventPublisher, nettyConfig)
+                                resultPartitionManager,
+                                taskEventPublisher,
+                                nettyConfig,
+                                config.getMaxNumberOfConnections())
                         : new LocalConnectionManager();
 
         NetworkBufferPool networkBufferPool =

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/io/network/netty/NettyConnectionManager.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/io/network/netty/NettyConnectionManager.java
@@ -43,14 +43,16 @@ public class NettyConnectionManager implements ConnectionManager {
     public NettyConnectionManager(
             ResultPartitionProvider partitionProvider,
             TaskEventPublisher taskEventPublisher,
-            NettyConfig nettyConfig) {
+            NettyConfig nettyConfig,
+            int maxNumberOfConnections) {
 
         this.server = new NettyServer(nettyConfig);
         this.client = new NettyClient(nettyConfig);
         this.bufferPool = new NettyBufferPool(nettyConfig.getNumberOfArenas());
 
         this.partitionRequestClientFactory =
-                new PartitionRequestClientFactory(client, nettyConfig.getNetworkRetries());
+                new PartitionRequestClientFactory(
+                        client, nettyConfig.getNetworkRetries(), maxNumberOfConnections);
 
         this.nettyProtocol =
                 new NettyProtocol(

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/taskmanager/NettyShuffleEnvironmentConfiguration.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/taskmanager/NettyShuffleEnvironmentConfiguration.java
@@ -87,6 +87,9 @@ public class NettyShuffleEnvironmentConfiguration {
 
     private final int maxBuffersPerChannel;
 
+    /** The maximum number of tpc connections between taskmanagers for data communication. */
+    private final int maxNumberOfConnections;
+
     public NettyShuffleEnvironmentConfiguration(
             int numNetworkBuffers,
             int networkBufferSize,
@@ -104,7 +107,8 @@ public class NettyShuffleEnvironmentConfiguration {
             int maxBuffersPerChannel,
             long batchShuffleReadMemoryBytes,
             int sortShuffleMinBuffers,
-            int sortShuffleMinParallelism) {
+            int sortShuffleMinParallelism,
+            int maxNumberOfConnections) {
 
         this.numNetworkBuffers = numNetworkBuffers;
         this.networkBufferSize = networkBufferSize;
@@ -123,6 +127,7 @@ public class NettyShuffleEnvironmentConfiguration {
         this.batchShuffleReadMemoryBytes = batchShuffleReadMemoryBytes;
         this.sortShuffleMinBuffers = sortShuffleMinBuffers;
         this.sortShuffleMinParallelism = sortShuffleMinParallelism;
+        this.maxNumberOfConnections = maxNumberOfConnections;
     }
 
     // ------------------------------------------------------------------------
@@ -197,6 +202,10 @@ public class NettyShuffleEnvironmentConfiguration {
 
     public int getMaxBuffersPerChannel() {
         return maxBuffersPerChannel;
+    }
+
+    public int getMaxNumberOfConnections() {
+        return maxNumberOfConnections;
     }
 
     // ------------------------------------------------------------------------
@@ -280,6 +289,11 @@ public class NettyShuffleEnvironmentConfiguration {
         String compressionCodec =
                 configuration.getString(NettyShuffleEnvironmentOptions.SHUFFLE_COMPRESSION_CODEC);
 
+        int maxNumConnections =
+                Math.max(
+                        1,
+                        configuration.getInteger(
+                                NettyShuffleEnvironmentOptions.MAX_NUM_TCP_CONNECTIONS));
         return new NettyShuffleEnvironmentConfiguration(
                 numberOfNetworkBuffers,
                 pageSize,
@@ -297,7 +311,8 @@ public class NettyShuffleEnvironmentConfiguration {
                 maxBuffersPerChannel,
                 batchShuffleReadMemoryBytes,
                 sortShuffleMinBuffers,
-                sortShuffleMinParallelism);
+                sortShuffleMinParallelism,
+                maxNumConnections);
     }
 
     /**
@@ -434,6 +449,7 @@ public class NettyShuffleEnvironmentConfiguration {
         result = 31 * result + Objects.hashCode(batchShuffleReadMemoryBytes);
         result = 31 * result + sortShuffleMinBuffers;
         result = 31 * result + sortShuffleMinParallelism;
+        result = 31 * result + maxNumberOfConnections;
         return result;
     }
 
@@ -464,7 +480,8 @@ public class NettyShuffleEnvironmentConfiguration {
                     && this.blockingShuffleCompressionEnabled
                             == that.blockingShuffleCompressionEnabled
                     && this.maxBuffersPerChannel == that.maxBuffersPerChannel
-                    && Objects.equals(this.compressionCodec, that.compressionCodec);
+                    && Objects.equals(this.compressionCodec, that.compressionCodec)
+                    && this.maxNumberOfConnections == that.maxNumberOfConnections;
         }
     }
 
@@ -501,6 +518,8 @@ public class NettyShuffleEnvironmentConfiguration {
                 + sortShuffleMinBuffers
                 + ", sortShuffleMinParallelism="
                 + sortShuffleMinParallelism
+                + ", maxNumberOfConnections="
+                + maxNumberOfConnections
                 + '}';
     }
 }

--- a/flink-runtime/src/test/java/org/apache/flink/runtime/io/network/NettyShuffleEnvironmentBuilder.java
+++ b/flink-runtime/src/test/java/org/apache/flink/runtime/io/network/NettyShuffleEnvironmentBuilder.java
@@ -77,6 +77,8 @@ public class NettyShuffleEnvironmentBuilder {
 
     private Executor ioExecutor = Executors.directExecutor();
 
+    private int maxNumberOfConnections = 1;
+
     public NettyShuffleEnvironmentBuilder setTaskManagerLocation(ResourceID taskManagerLocation) {
         this.taskManagerLocation = taskManagerLocation;
         return this;
@@ -170,6 +172,11 @@ public class NettyShuffleEnvironmentBuilder {
         return this;
     }
 
+    public NettyShuffleEnvironmentBuilder setMaxNumberOfConnections(int maxNumberOfConnections) {
+        this.maxNumberOfConnections = maxNumberOfConnections;
+        return this;
+    }
+
     public NettyShuffleEnvironment build() {
         return NettyShuffleServiceFactory.createNettyShuffleEnvironment(
                 new NettyShuffleEnvironmentConfiguration(
@@ -189,7 +196,8 @@ public class NettyShuffleEnvironmentBuilder {
                         maxBuffersPerChannel,
                         batchShuffleReadMemoryBytes,
                         sortShuffleMinBuffers,
-                        sortShuffleMinParallelism),
+                        sortShuffleMinParallelism,
+                        maxNumberOfConnections),
                 taskManagerLocation,
                 new TaskEventDispatcher(),
                 resultPartitionManager,

--- a/flink-runtime/src/test/java/org/apache/flink/runtime/io/network/netty/NettyConnectionManagerTest.java
+++ b/flink-runtime/src/test/java/org/apache/flink/runtime/io/network/netty/NettyConnectionManagerTest.java
@@ -163,6 +163,6 @@ public class NettyConnectionManagerTest {
 
     private NettyConnectionManager createNettyConnectionManager(NettyConfig config) {
         return new NettyConnectionManager(
-                new ResultPartitionManager(), new TaskEventDispatcher(), config);
+                new ResultPartitionManager(), new TaskEventDispatcher(), config, 1);
     }
 }

--- a/flink-runtime/src/test/java/org/apache/flink/runtime/io/network/netty/PartitionRequestClientFactoryTest.java
+++ b/flink-runtime/src/test/java/org/apache/flink/runtime/io/network/netty/PartitionRequestClientFactoryTest.java
@@ -34,13 +34,16 @@ import java.io.IOException;
 import java.net.InetAddress;
 import java.net.InetSocketAddress;
 import java.util.ArrayList;
+import java.util.HashSet;
 import java.util.List;
+import java.util.Set;
 import java.util.concurrent.CompletableFuture;
 import java.util.concurrent.ExecutorService;
 import java.util.concurrent.Executors;
 import java.util.concurrent.Future;
 
 import static org.junit.Assert.assertNotNull;
+import static org.junit.Assert.assertTrue;
 import static org.junit.Assert.fail;
 import static org.mockito.Mockito.mock;
 
@@ -113,6 +116,36 @@ public class PartitionRequestClientFactoryTest extends TestLogger {
             nettyServerAndClient.client().shutdown();
             nettyServerAndClient.server().shutdown();
         }
+    }
+
+    @Test
+    public void testReuseNettyPartitionRequestClient() throws Exception {
+        NettyTestUtil.NettyServerAndClient nettyServerAndClient = createNettyServerAndClient();
+        try {
+            checkReuseNettyPartitionRequestClient(nettyServerAndClient, 1);
+            checkReuseNettyPartitionRequestClient(nettyServerAndClient, 2);
+            checkReuseNettyPartitionRequestClient(nettyServerAndClient, 5);
+            checkReuseNettyPartitionRequestClient(nettyServerAndClient, 10);
+        } finally {
+            nettyServerAndClient.client().shutdown();
+            nettyServerAndClient.server().shutdown();
+        }
+    }
+
+    private void checkReuseNettyPartitionRequestClient(
+            NettyTestUtil.NettyServerAndClient nettyServerAndClient, int maxNumberOfConnections)
+            throws Exception {
+        final Set<NettyPartitionRequestClient> set = new HashSet<>();
+
+        final PartitionRequestClientFactory factory =
+                new PartitionRequestClientFactory(
+                        nettyServerAndClient.client(), 0, maxNumberOfConnections);
+        for (int i = 0; i < Math.max(100, maxNumberOfConnections); i++) {
+            final ConnectionID connectionID =
+                    nettyServerAndClient.getConnectionID((int) (Math.random() * Integer.MAX_VALUE));
+            set.add(factory.createPartitionRequestClient(connectionID));
+        }
+        assertTrue(set.size() <= maxNumberOfConnections);
     }
 
     @Test


### PR DESCRIPTION
## What is the purpose of the change

Reuse tpc connections between taskmanagers

## Brief change log

Reuse tpc connections between taskmanagers.

## Verifying this change

Please make sure both new and modified tests in this PR follows the conventions defined in our code quality guide: https://flink.apache.org/contributing/code-style-and-quality-common.html#testing

*(Please pick either of the following options)*

This change added tests and can be verified as follows:

Added test that PartitionRequestClientFactoryTest#testReuseNettyPartitionRequestClient.

## Does this pull request potentially affect one of the following parts:

  - Dependencies (does it add or upgrade a dependency): no
  - The public API, i.e., is any changed class annotated with `@Public(Evolving)`: no
  - The serializers: no
  - The runtime per-record code paths (performance sensitive): no
  - Anything that affects deployment or recovery: JobManager (and its components), Checkpointing, Kubernetes/Yarn, ZooKeeper: no
  - The S3 file system connector: no

## Documentation

  - Does this pull request introduce a new feature? yes
  - If yes, how is the feature documented? JavaDocs
