### PR TITLE
[FLINK-25478][chaneglog] Correct the state register logic of ChangelogStateBackendHandle

### DIFF
--- a/flink-runtime/src/main/java/org/apache/flink/runtime/checkpoint/metadata/MetadataV2V3SerializerBase.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/checkpoint/metadata/MetadataV2V3SerializerBase.java
@@ -370,6 +370,7 @@ public abstract class MetadataV2V3SerializerBase {
                 serializeStreamStateHandle(streamHandleAndOffset.f0, dos);
             }
             dos.writeLong(handle.getStateSize());
+            dos.writeLong(handle.getCheckpointedSize());
 
         } else {
             throw new IllegalStateException(
@@ -458,8 +459,9 @@ public abstract class MetadataV2V3SerializerBase {
                 streamHandleAndOffset.add(Tuple2.of(h, o));
             }
             long size = dis.readLong();
-            return new ChangelogStateHandleStreamImpl(streamHandleAndOffset, keyGroupRange, size);
-
+            long checkpointedSize = dis.readLong();
+            return new ChangelogStateHandleStreamImpl(
+                    streamHandleAndOffset, keyGroupRange, size, checkpointedSize);
         } else {
             throw new IllegalStateException("Reading invalid KeyedStateHandle, type: " + type);
         }

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/checkpoint/metadata/MetadataV2V3SerializerBase.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/checkpoint/metadata/MetadataV2V3SerializerBase.java
@@ -19,6 +19,7 @@
 package org.apache.flink.runtime.checkpoint.metadata;
 
 import org.apache.flink.annotation.Internal;
+import org.apache.flink.annotation.VisibleForTesting;
 import org.apache.flink.api.java.tuple.Tuple2;
 import org.apache.flink.core.fs.Path;
 import org.apache.flink.runtime.checkpoint.MasterState;
@@ -39,8 +40,10 @@ import org.apache.flink.runtime.state.StateHandleID;
 import org.apache.flink.runtime.state.StateObject;
 import org.apache.flink.runtime.state.StreamStateHandle;
 import org.apache.flink.runtime.state.changelog.ChangelogStateBackendHandle;
+import org.apache.flink.runtime.state.changelog.ChangelogStateBackendHandle.ChangelogStateBackendHandleImpl;
 import org.apache.flink.runtime.state.changelog.ChangelogStateHandle;
 import org.apache.flink.runtime.state.changelog.ChangelogStateHandleStreamImpl;
+import org.apache.flink.runtime.state.changelog.SequenceNumber;
 import org.apache.flink.runtime.state.changelog.StateChange;
 import org.apache.flink.runtime.state.changelog.inmemory.InMemoryChangelogStateHandle;
 import org.apache.flink.runtime.state.filesystem.AbstractFsCheckpointStorageAccess;
@@ -50,6 +53,9 @@ import org.apache.flink.runtime.state.memory.ByteStreamStateHandle;
 import org.apache.flink.util.IOUtils;
 import org.apache.flink.util.function.BiConsumerWithException;
 import org.apache.flink.util.function.BiFunctionWithException;
+
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 
 import javax.annotation.Nullable;
 
@@ -90,6 +96,7 @@ import static org.apache.flink.runtime.state.IncrementalRemoteKeyedStateHandle.U
  */
 @Internal
 public abstract class MetadataV2V3SerializerBase {
+    private static final Logger LOG = LoggerFactory.getLogger(MetadataV2V3SerializerBase.class);
 
     /** Random magic number for consistency checks. */
     private static final int MASTER_STATE_MAGIC_NUMBER = 0xc96b1696;
@@ -105,7 +112,11 @@ public abstract class MetadataV2V3SerializerBase {
     private static final byte CHANGELOG_HANDLE = 8;
     private static final byte CHANGELOG_BYTE_INCREMENT_HANDLE = 9;
     private static final byte CHANGELOG_FILE_INCREMENT_HANDLE = 10;
-    private static final byte INCREMENTAL_STATE_HANDLE = 11;
+    // INCREMENTAL_KEY_GROUPS_HANDLE_V2 is introduced to add field of checkpointedSize and
+    // stateHandleId.
+    private static final byte INCREMENTAL_KEY_GROUPS_HANDLE_V2 = 11;
+    // KEY_GROUPS_HANDLE_V2 is introduced to add new field of stateHandleId.
+    private static final byte KEY_GROUPS_HANDLE_V2 = 12;
 
     // ------------------------------------------------------------------------
     //  (De)serialization entry points
@@ -288,7 +299,8 @@ public abstract class MetadataV2V3SerializerBase {
     //  keyed state
     // ------------------------------------------------------------------------
 
-    void serializeKeyedStateHandle(KeyedStateHandle stateHandle, DataOutputStream dos)
+    @VisibleForTesting
+    static void serializeKeyedStateHandle(KeyedStateHandle stateHandle, DataOutputStream dos)
             throws IOException {
         if (stateHandle == null) {
             dos.writeByte(NULL_HANDLE);
@@ -298,7 +310,7 @@ public abstract class MetadataV2V3SerializerBase {
             if (stateHandle instanceof KeyGroupsSavepointStateHandle) {
                 dos.writeByte(SAVEPOINT_KEY_GROUPS_HANDLE);
             } else {
-                dos.writeByte(KEY_GROUPS_HANDLE);
+                dos.writeByte(KEY_GROUPS_HANDLE_V2);
             }
             dos.writeInt(keyGroupsStateHandle.getKeyGroupRange().getStartKeyGroup());
             dos.writeInt(keyGroupsStateHandle.getKeyGroupRange().getNumberOfKeyGroups());
@@ -306,11 +318,16 @@ public abstract class MetadataV2V3SerializerBase {
                 dos.writeLong(keyGroupsStateHandle.getOffsetForKeyGroup(keyGroup));
             }
             serializeStreamStateHandle(keyGroupsStateHandle.getDelegateStateHandle(), dos);
+
+            // savepoint state handle would not need to persist state handle id out.
+            if (!(stateHandle instanceof KeyGroupsSavepointStateHandle)) {
+                writeStateHandleId(stateHandle, dos);
+            }
         } else if (stateHandle instanceof IncrementalRemoteKeyedStateHandle) {
             IncrementalRemoteKeyedStateHandle incrementalKeyedStateHandle =
                     (IncrementalRemoteKeyedStateHandle) stateHandle;
 
-            dos.writeByte(INCREMENTAL_STATE_HANDLE);
+            dos.writeByte(INCREMENTAL_KEY_GROUPS_HANDLE_V2);
 
             dos.writeLong(incrementalKeyedStateHandle.getCheckpointId());
             dos.writeUTF(String.valueOf(incrementalKeyedStateHandle.getBackendIdentifier()));
@@ -322,19 +339,20 @@ public abstract class MetadataV2V3SerializerBase {
 
             serializeStreamStateHandleMap(incrementalKeyedStateHandle.getSharedState(), dos);
             serializeStreamStateHandleMap(incrementalKeyedStateHandle.getPrivateState(), dos);
+
+            writeStateHandleId(incrementalKeyedStateHandle, dos);
         } else if (stateHandle instanceof ChangelogStateBackendHandle) {
             ChangelogStateBackendHandle handle = (ChangelogStateBackendHandle) stateHandle;
 
             dos.writeByte(CHANGELOG_HANDLE);
-
             dos.writeInt(handle.getKeyGroupRange().getStartKeyGroup());
             dos.writeInt(handle.getKeyGroupRange().getNumberOfKeyGroups());
 
             dos.writeLong(handle.getCheckpointedSize());
 
             dos.writeInt(handle.getMaterializedStateHandles().size());
-            for (KeyedStateHandle k : handle.getMaterializedStateHandles()) {
-                serializeKeyedStateHandle(k, dos);
+            for (KeyedStateHandle keyedStateHandle : handle.getMaterializedStateHandles()) {
+                serializeKeyedStateHandle(keyedStateHandle, dos);
             }
 
             dos.writeInt(handle.getNonMaterializedStateHandles().size());
@@ -343,6 +361,7 @@ public abstract class MetadataV2V3SerializerBase {
             }
 
             dos.writeLong(handle.getMaterializationID());
+            writeStateHandleId(handle, dos);
 
         } else if (stateHandle instanceof InMemoryChangelogStateHandle) {
             InMemoryChangelogStateHandle handle = (InMemoryChangelogStateHandle) stateHandle;
@@ -357,7 +376,7 @@ public abstract class MetadataV2V3SerializerBase {
                 dos.writeInt(change.getChange().length);
                 dos.write(change.getChange());
             }
-
+            writeStateHandleId(handle, dos);
         } else if (stateHandle instanceof ChangelogStateHandleStreamImpl) {
             ChangelogStateHandleStreamImpl handle = (ChangelogStateHandleStreamImpl) stateHandle;
             dos.writeByte(CHANGELOG_FILE_INCREMENT_HANDLE);
@@ -371,6 +390,7 @@ public abstract class MetadataV2V3SerializerBase {
             }
             dos.writeLong(handle.getStateSize());
             dos.writeLong(handle.getCheckpointedSize());
+            writeStateHandleId(handle, dos);
 
         } else {
             throw new IllegalStateException(
@@ -378,15 +398,23 @@ public abstract class MetadataV2V3SerializerBase {
         }
     }
 
+    private static void writeStateHandleId(KeyedStateHandle keyedStateHandle, DataOutputStream dos)
+            throws IOException {
+        dos.writeUTF(keyedStateHandle.getStateHandleId().getKeyString());
+    }
+
+    @VisibleForTesting
     @Nullable
-    KeyedStateHandle deserializeKeyedStateHandle(
+    static KeyedStateHandle deserializeKeyedStateHandle(
             DataInputStream dis, @Nullable DeserializationContext context) throws IOException {
 
         final int type = dis.readByte();
         if (NULL_HANDLE == type) {
 
             return null;
-        } else if (KEY_GROUPS_HANDLE == type || SAVEPOINT_KEY_GROUPS_HANDLE == type) {
+        } else if (KEY_GROUPS_HANDLE == type
+                || KEY_GROUPS_HANDLE_V2 == type
+                || SAVEPOINT_KEY_GROUPS_HANDLE == type) {
             int startKeyGroup = dis.readInt();
             int numKeyGroups = dis.readInt();
             KeyGroupRange keyGroupRange =
@@ -401,9 +429,15 @@ public abstract class MetadataV2V3SerializerBase {
             if (SAVEPOINT_KEY_GROUPS_HANDLE == type) {
                 return new KeyGroupsSavepointStateHandle(keyGroupRangeOffsets, stateHandle);
             } else {
-                return new KeyGroupsStateHandle(keyGroupRangeOffsets, stateHandle);
+                StateHandleID stateHandleID =
+                        KEY_GROUPS_HANDLE_V2 == type
+                                ? new StateHandleID(dis.readUTF())
+                                : StateHandleID.randomStateHandleId();
+                return KeyGroupsStateHandle.restore(
+                        keyGroupRangeOffsets, stateHandle, stateHandleID);
             }
-        } else if (INCREMENTAL_KEY_GROUPS_HANDLE == type || INCREMENTAL_STATE_HANDLE == type) {
+        } else if (INCREMENTAL_KEY_GROUPS_HANDLE == type
+                || INCREMENTAL_KEY_GROUPS_HANDLE_V2 == type) {
             return deserializeIncrementalStateHandle(dis, context, type);
         } else if (CHANGELOG_HANDLE == type) {
 
@@ -416,7 +450,13 @@ public abstract class MetadataV2V3SerializerBase {
             int baseSize = dis.readInt();
             List<KeyedStateHandle> base = new ArrayList<>(baseSize);
             for (int i = 0; i < baseSize; i++) {
-                base.add(deserializeKeyedStateHandle(dis, context));
+                KeyedStateHandle handle = deserializeKeyedStateHandle(dis, context);
+                if (handle != null) {
+                    base.add(handle);
+                } else {
+                    LOG.warn(
+                            "Unexpected null keyed state handle of materialized part when deserializing changelog state-backend handle");
+                }
             }
             int deltaSize = dis.readInt();
             List<ChangelogStateHandle> delta = new ArrayList<>(deltaSize);
@@ -425,9 +465,9 @@ public abstract class MetadataV2V3SerializerBase {
             }
 
             long materializationID = dis.readLong();
-
-            return new ChangelogStateBackendHandle.ChangelogStateBackendHandleImpl(
-                    base, delta, keyGroupRange, materializationID, checkpointedSize);
+            StateHandleID stateHandleId = new StateHandleID(dis.readUTF());
+            return ChangelogStateBackendHandleImpl.restore(
+                    base, delta, keyGroupRange, materializationID, checkpointedSize, stateHandleId);
 
         } else if (CHANGELOG_BYTE_INCREMENT_HANDLE == type) {
             int start = dis.readInt();
@@ -444,7 +484,13 @@ public abstract class MetadataV2V3SerializerBase {
                 IOUtils.readFully(dis, bytes, 0, bytesSize);
                 changes.add(new StateChange(keyGroup, bytes));
             }
-            return new InMemoryChangelogStateHandle(changes, from, to, keyGroupRange);
+            StateHandleID stateHandleId = new StateHandleID(dis.readUTF());
+            return InMemoryChangelogStateHandle.restore(
+                    changes,
+                    SequenceNumber.of(from),
+                    SequenceNumber.of(to),
+                    keyGroupRange,
+                    stateHandleId);
 
         } else if (CHANGELOG_FILE_INCREMENT_HANDLE == type) {
             int start = dis.readInt();
@@ -460,24 +506,23 @@ public abstract class MetadataV2V3SerializerBase {
             }
             long size = dis.readLong();
             long checkpointedSize = dis.readLong();
-            return new ChangelogStateHandleStreamImpl(
-                    streamHandleAndOffset, keyGroupRange, size, checkpointedSize);
+            StateHandleID stateHandleId = new StateHandleID(dis.readUTF());
+            return ChangelogStateHandleStreamImpl.restore(
+                    streamHandleAndOffset, keyGroupRange, size, checkpointedSize, stateHandleId);
         } else {
             throw new IllegalStateException("Reading invalid KeyedStateHandle, type: " + type);
         }
     }
 
-    private IncrementalRemoteKeyedStateHandle deserializeIncrementalStateHandle(
+    private static IncrementalRemoteKeyedStateHandle deserializeIncrementalStateHandle(
             DataInputStream dis, @Nullable DeserializationContext context, int stateHandleType)
             throws IOException {
+        boolean isV2Format = INCREMENTAL_KEY_GROUPS_HANDLE_V2 == stateHandleType;
         long checkpointId = dis.readLong();
         String backendId = dis.readUTF();
         int startKeyGroup = dis.readInt();
         int numKeyGroups = dis.readInt();
-        long checkpointedSize =
-                INCREMENTAL_STATE_HANDLE == stateHandleType
-                        ? dis.readLong()
-                        : UNKNOWN_CHECKPOINTED_SIZE;
+        long checkpointedSize = isV2Format ? dis.readLong() : UNKNOWN_CHECKPOINTED_SIZE;
 
         KeyGroupRange keyGroupRange =
                 KeyGroupRange.of(startKeyGroup, startKeyGroup + numKeyGroups - 1);
@@ -497,14 +542,17 @@ public abstract class MetadataV2V3SerializerBase {
             uuid = UUID.nameUUIDFromBytes(backendId.getBytes(StandardCharsets.UTF_8));
         }
 
-        return new IncrementalRemoteKeyedStateHandle(
+        StateHandleID stateHandleId =
+                isV2Format ? new StateHandleID(dis.readUTF()) : StateHandleID.randomStateHandleId();
+        return IncrementalRemoteKeyedStateHandle.restore(
                 uuid,
                 keyGroupRange,
                 checkpointId,
                 sharedStates,
                 privateStates,
                 metaDataStateHandle,
-                checkpointedSize);
+                checkpointedSize,
+                stateHandleId);
     }
 
     void serializeOperatorStateHandle(OperatorStateHandle stateHandle, DataOutputStream dos)

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/state/DirectoryKeyedStateHandle.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/state/DirectoryKeyedStateHandle.java
@@ -34,12 +34,15 @@ public class DirectoryKeyedStateHandle implements KeyedStateHandle {
     /** The key-group range. */
     @Nonnull private final KeyGroupRange keyGroupRange;
 
+    private final StateHandleID stateHandleId;
+
     public DirectoryKeyedStateHandle(
             @Nonnull DirectoryStateHandle directoryStateHandle,
             @Nonnull KeyGroupRange keyGroupRange) {
 
         this.directoryStateHandle = directoryStateHandle;
         this.keyGroupRange = keyGroupRange;
+        this.stateHandleId = StateHandleID.randomStateHandleId();
     }
 
     @Nonnull
@@ -73,6 +76,11 @@ public class DirectoryKeyedStateHandle implements KeyedStateHandle {
         return this.keyGroupRange.getIntersection(otherKeyGroupRange).getNumberOfKeyGroups() > 0
                 ? this
                 : null;
+    }
+
+    @Override
+    public StateHandleID getStateHandleId() {
+        return stateHandleId;
     }
 
     @Override

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/state/KeyGroupsStateHandle.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/state/KeyGroupsStateHandle.java
@@ -23,6 +23,7 @@ import org.apache.flink.util.Preconditions;
 
 import java.io.IOException;
 import java.util.Optional;
+import java.util.UUID;
 
 /**
  * A handle to the partitioned stream operator state after it has been checkpointed. This state
@@ -39,17 +40,35 @@ public class KeyGroupsStateHandle implements StreamStateHandle, KeyedStateHandle
     /** Inner stream handle to the actual states of the key-groups in the range */
     private final StreamStateHandle stateHandle;
 
+    private final StateHandleID stateHandleId;
+
     /**
      * @param groupRangeOffsets range of key-group ids that in the state of this handle
      * @param streamStateHandle handle to the actual state of the key-groups
      */
     public KeyGroupsStateHandle(
             KeyGroupRangeOffsets groupRangeOffsets, StreamStateHandle streamStateHandle) {
+        this(groupRangeOffsets, streamStateHandle, new StateHandleID(UUID.randomUUID().toString()));
+    }
+
+    private KeyGroupsStateHandle(
+            KeyGroupRangeOffsets groupRangeOffsets,
+            StreamStateHandle streamStateHandle,
+            StateHandleID stateHandleId) {
         Preconditions.checkNotNull(groupRangeOffsets);
         Preconditions.checkNotNull(streamStateHandle);
+        Preconditions.checkNotNull(stateHandleId);
 
         this.groupRangeOffsets = groupRangeOffsets;
         this.stateHandle = streamStateHandle;
+        this.stateHandleId = stateHandleId;
+    }
+
+    public static KeyGroupsStateHandle restore(
+            KeyGroupRangeOffsets groupRangeOffsets,
+            StreamStateHandle streamStateHandle,
+            StateHandleID stateHandleId) {
+        return new KeyGroupsStateHandle(groupRangeOffsets, streamStateHandle, stateHandleId);
     }
 
     /** @return the internal key-group range to offsets metadata */
@@ -83,7 +102,12 @@ public class KeyGroupsStateHandle implements StreamStateHandle, KeyedStateHandle
         if (offsets.getKeyGroupRange().getNumberOfKeyGroups() <= 0) {
             return null;
         }
-        return new KeyGroupsStateHandle(offsets, stateHandle);
+        return new KeyGroupsStateHandle(offsets, stateHandle, stateHandleId);
+    }
+
+    @Override
+    public StateHandleID getStateHandleId() {
+        return stateHandleId;
     }
 
     @Override

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/state/KeyedStateHandle.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/state/KeyedStateHandle.java
@@ -18,6 +18,8 @@
 
 package org.apache.flink.runtime.state;
 
+import org.apache.flink.runtime.state.changelog.ChangelogStateBackendHandle;
+
 import javax.annotation.Nullable;
 
 /**
@@ -38,4 +40,15 @@ public interface KeyedStateHandle extends CompositeStateHandle {
      */
     @Nullable
     KeyedStateHandle getIntersection(KeyGroupRange keyGroupRange);
+
+    /**
+     * Returns a unique state handle id to distinguish with other keyed state handles.
+     *
+     * <p><Note>If this state handle would be used as materialized part of {@link
+     * ChangelogStateBackendHandle}, it should persist this state handle id when serializing of
+     * checkpoint and deserialize it back to ensure the state handle id is constant.
+     *
+     * @return A unique state handle id.
+     */
+    StateHandleID getStateHandleId();
 }

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/state/StateHandleID.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/state/StateHandleID.java
@@ -20,6 +20,8 @@ package org.apache.flink.runtime.state;
 
 import org.apache.flink.util.StringBasedID;
 
+import java.util.UUID;
+
 /**
  * Unique ID that allows for logical comparison between state handles.
  *
@@ -33,5 +35,9 @@ public class StateHandleID extends StringBasedID {
 
     public StateHandleID(String keyString) {
         super(keyString);
+    }
+
+    public static StateHandleID randomStateHandleId() {
+        return new StateHandleID(UUID.randomUUID().toString());
     }
 }

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/state/changelog/ChangelogStateBackendHandle.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/state/changelog/ChangelogStateBackendHandle.java
@@ -18,19 +18,21 @@
 package org.apache.flink.runtime.state.changelog;
 
 import org.apache.flink.annotation.Internal;
+import org.apache.flink.core.fs.FSDataInputStream;
 import org.apache.flink.runtime.state.KeyGroupRange;
 import org.apache.flink.runtime.state.KeyedStateHandle;
 import org.apache.flink.runtime.state.SharedStateRegistry;
+import org.apache.flink.runtime.state.SharedStateRegistryKey;
+import org.apache.flink.runtime.state.StateHandleID;
 import org.apache.flink.runtime.state.StateObject;
-import org.apache.flink.util.ExceptionUtils;
-
-import org.apache.flink.shaded.guava30.com.google.common.io.Closer;
+import org.apache.flink.runtime.state.StreamStateHandle;
 
 import javax.annotation.Nullable;
 
-import java.io.Closeable;
+import java.io.IOException;
 import java.util.List;
 import java.util.Objects;
+import java.util.Optional;
 import java.util.stream.Collectors;
 
 import static java.util.Collections.unmodifiableList;
@@ -52,12 +54,14 @@ public interface ChangelogStateBackendHandle extends KeyedStateHandle {
 
     class ChangelogStateBackendHandleImpl implements ChangelogStateBackendHandle {
         private static final long serialVersionUID = 1L;
+
         private final List<KeyedStateHandle> materialized;
         private final List<ChangelogStateHandle> nonMaterialized;
         private final KeyGroupRange keyGroupRange;
 
         private final long materializationID;
         private final long persistedSizeOfThisCheckpoint;
+        private final StateHandleID stateHandleID;
 
         public ChangelogStateBackendHandleImpl(
                 List<KeyedStateHandle> materialized,
@@ -65,26 +69,68 @@ public interface ChangelogStateBackendHandle extends KeyedStateHandle {
                 KeyGroupRange keyGroupRange,
                 long materializationID,
                 long persistedSizeOfThisCheckpoint) {
+            this(
+                    materialized,
+                    nonMaterialized,
+                    keyGroupRange,
+                    persistedSizeOfThisCheckpoint,
+                    materializationID,
+                    StateHandleID.randomStateHandleId());
+        }
+
+        private ChangelogStateBackendHandleImpl(
+                List<KeyedStateHandle> materialized,
+                List<ChangelogStateHandle> nonMaterialized,
+                KeyGroupRange keyGroupRange,
+                long materializationID,
+                long persistedSizeOfThisCheckpoint,
+                StateHandleID stateHandleId) {
             this.materialized = unmodifiableList(materialized);
             this.nonMaterialized = unmodifiableList(nonMaterialized);
             this.keyGroupRange = keyGroupRange;
             this.persistedSizeOfThisCheckpoint = persistedSizeOfThisCheckpoint;
             checkArgument(keyGroupRange.getNumberOfKeyGroups() > 0);
             this.materializationID = materializationID;
+            this.stateHandleID = stateHandleId;
+        }
+
+        public static ChangelogStateBackendHandleImpl restore(
+                List<KeyedStateHandle> materialized,
+                List<ChangelogStateHandle> nonMaterialized,
+                KeyGroupRange keyGroupRange,
+                long materializationID,
+                long persistedSizeOfThisCheckpoint,
+                StateHandleID stateHandleId) {
+            return new ChangelogStateBackendHandleImpl(
+                    materialized,
+                    nonMaterialized,
+                    keyGroupRange,
+                    materializationID,
+                    persistedSizeOfThisCheckpoint,
+                    stateHandleId);
         }
 
         @Override
         public void registerSharedStates(SharedStateRegistry stateRegistry, long checkpointID) {
+            for (KeyedStateHandle keyedStateHandle : materialized) {
+                // Use the unique and invariant UUID as the state registry key for a specific keyed
+                // state handle. To avoid unexpected unregister, this registry key would not change
+                // even rescaled.
+                stateRegistry.registerReference(
+                        new SharedStateRegistryKey(keyedStateHandle.getStateHandleId().toString()),
+                        new StreamStateHandleWrapper(keyedStateHandle),
+                        checkpointID);
+            }
             stateRegistry.registerAll(materialized, checkpointID);
             stateRegistry.registerAll(nonMaterialized, checkpointID);
         }
 
         @Override
         public void discardState() throws Exception {
-            try (Closer closer = Closer.create()) {
-                materialized.forEach(h -> closer.register(asCloseable(h)));
-                nonMaterialized.forEach(h -> closer.register(asCloseable(h)));
-            }
+            // Do nothing: state will be discarded by SharedStateRegistry once JM receives it and a
+            // newer checkpoint completes without using it.
+            // if the checkpoints always failed, it would leave orphan files there.
+            // The above cases will be addressed by FLINK-23139 and/or FLINK-24852.
         }
 
         @Override
@@ -102,7 +148,7 @@ public interface ChangelogStateBackendHandle extends KeyedStateHandle {
             }
             List<KeyedStateHandle> basePart =
                     this.materialized.stream()
-                            .map(handle -> handle.getIntersection(keyGroupRange))
+                            .map(entry -> entry.getIntersection(keyGroupRange))
                             .filter(Objects::nonNull)
                             .collect(Collectors.toList());
             List<ChangelogStateHandle> deltaPart =
@@ -119,6 +165,11 @@ public interface ChangelogStateBackendHandle extends KeyedStateHandle {
                     intersection,
                     materializationID,
                     persistedSizeOfThisCheckpoint);
+        }
+
+        @Override
+        public StateHandleID getStateHandleId() {
+            return stateHandleID;
         }
 
         @Override
@@ -154,14 +205,38 @@ public interface ChangelogStateBackendHandle extends KeyedStateHandle {
                     keyGroupRange, materialized.size(), nonMaterialized.size());
         }
 
-        private static Closeable asCloseable(KeyedStateHandle h) {
-            return () -> {
-                try {
-                    h.discardState();
-                } catch (Exception e) {
-                    ExceptionUtils.rethrowIOException(e);
-                }
-            };
+        /**
+         * This wrapper class is introduced as current {@link SharedStateRegistry} only accept
+         * StreamStateHandle to register, remove it once FLINK-25862 is resolved.
+         */
+        private static class StreamStateHandleWrapper implements StreamStateHandle {
+            private static final long serialVersionUID = 1L;
+
+            private final KeyedStateHandle keyedStateHandle;
+
+            StreamStateHandleWrapper(KeyedStateHandle keyedStateHandle) {
+                this.keyedStateHandle = keyedStateHandle;
+            }
+
+            @Override
+            public void discardState() throws Exception {
+                keyedStateHandle.discardState();
+            }
+
+            @Override
+            public long getStateSize() {
+                return keyedStateHandle.getStateSize();
+            }
+
+            @Override
+            public FSDataInputStream openInputStream() throws IOException {
+                throw new UnsupportedOperationException("Should not call here.");
+            }
+
+            @Override
+            public Optional<byte[]> asBytesIfInMemory() {
+                throw new UnsupportedOperationException("Should not call here.");
+            }
         }
     }
 }

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/state/changelog/ChangelogStateHandleStreamImpl.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/state/changelog/ChangelogStateHandleStreamImpl.java
@@ -48,13 +48,6 @@ public final class ChangelogStateHandleStreamImpl implements ChangelogStateHandl
     public ChangelogStateHandleStreamImpl(
             List<Tuple2<StreamStateHandle, Long>> handlesAndOffsets,
             KeyGroupRange keyGroupRange,
-            long size) {
-        this(handlesAndOffsets, keyGroupRange, size, size);
-    }
-
-    public ChangelogStateHandleStreamImpl(
-            List<Tuple2<StreamStateHandle, Long>> handlesAndOffsets,
-            KeyGroupRange keyGroupRange,
             long size,
             long incrementalSize) {
         this.handlesAndOffsets = handlesAndOffsets;
@@ -83,7 +76,7 @@ public final class ChangelogStateHandleStreamImpl implements ChangelogStateHandl
         if (offsets.getNumberOfKeyGroups() == 0) {
             return null;
         }
-        return new ChangelogStateHandleStreamImpl(handlesAndOffsets, offsets, 0L /* unknown */);
+        return new ChangelogStateHandleStreamImpl(handlesAndOffsets, offsets, 0L, 0L /* unknown */);
     }
 
     @Override

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/state/changelog/inmemory/InMemoryChangelogStateHandle.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/state/changelog/inmemory/InMemoryChangelogStateHandle.java
@@ -21,6 +21,7 @@ import org.apache.flink.annotation.Internal;
 import org.apache.flink.runtime.state.KeyGroupRange;
 import org.apache.flink.runtime.state.KeyedStateHandle;
 import org.apache.flink.runtime.state.SharedStateRegistry;
+import org.apache.flink.runtime.state.StateHandleID;
 import org.apache.flink.runtime.state.changelog.ChangelogStateHandle;
 import org.apache.flink.runtime.state.changelog.SequenceNumber;
 import org.apache.flink.runtime.state.changelog.StateChange;
@@ -29,6 +30,7 @@ import javax.annotation.Nullable;
 
 import java.util.Collections;
 import java.util.List;
+import java.util.UUID;
 
 /** In-memory {@link ChangelogStateHandle}. */
 @Internal
@@ -40,21 +42,36 @@ public class InMemoryChangelogStateHandle implements ChangelogStateHandle {
     private final SequenceNumber from; // for debug purposes
     private final SequenceNumber to; // for debug purposes
     private final KeyGroupRange keyGroupRange;
-
-    public InMemoryChangelogStateHandle(
-            List<StateChange> changes, long from, long to, KeyGroupRange keyGroupRange) {
-        this(changes, SequenceNumber.of(from), SequenceNumber.of(to), keyGroupRange);
-    }
+    private final StateHandleID stateHandleID;
 
     public InMemoryChangelogStateHandle(
             List<StateChange> changes,
             SequenceNumber from,
             SequenceNumber to,
             KeyGroupRange keyGroupRange) {
+        this(changes, from, to, keyGroupRange, new StateHandleID(UUID.randomUUID().toString()));
+    }
+
+    private InMemoryChangelogStateHandle(
+            List<StateChange> changes,
+            SequenceNumber from,
+            SequenceNumber to,
+            KeyGroupRange keyGroupRange,
+            StateHandleID stateHandleId) {
         this.changes = changes;
         this.from = from;
         this.to = to;
         this.keyGroupRange = keyGroupRange;
+        this.stateHandleID = stateHandleId;
+    }
+
+    public static InMemoryChangelogStateHandle restore(
+            List<StateChange> changes,
+            SequenceNumber from,
+            SequenceNumber to,
+            KeyGroupRange keyGroupRange,
+            StateHandleID stateHandleId) {
+        return new InMemoryChangelogStateHandle(changes, from, to, keyGroupRange, stateHandleId);
     }
 
     @Override
@@ -86,6 +103,11 @@ public class InMemoryChangelogStateHandle implements ChangelogStateHandle {
         return changes.stream().mapToInt(StateChange::getKeyGroup).anyMatch(keyGroupRange::contains)
                 ? this
                 : null;
+    }
+
+    @Override
+    public StateHandleID getStateHandleId() {
+        return stateHandleID;
     }
 
     @Override

--- a/flink-runtime/src/test/java/org/apache/flink/runtime/checkpoint/StateHandleDummyUtil.java
+++ b/flink-runtime/src/test/java/org/apache/flink/runtime/checkpoint/StateHandleDummyUtil.java
@@ -27,6 +27,7 @@ import org.apache.flink.runtime.state.OperatorStateHandle;
 import org.apache.flink.runtime.state.OperatorStreamStateHandle;
 import org.apache.flink.runtime.state.ResultSubpartitionStateHandle;
 import org.apache.flink.runtime.state.SharedStateRegistry;
+import org.apache.flink.runtime.state.StateHandleID;
 import org.apache.flink.runtime.state.memory.ByteStreamStateHandle;
 
 import java.util.ArrayList;
@@ -169,9 +170,11 @@ public class StateHandleDummyUtil {
         private static final long serialVersionUID = 1L;
 
         private final KeyGroupRange keyGroupRange;
+        private final StateHandleID stateHandleId;
 
         private DummyKeyedStateHandle(KeyGroupRange keyGroupRange) {
             this.keyGroupRange = keyGroupRange;
+            this.stateHandleId = StateHandleID.randomStateHandleId();
         }
 
         @Override
@@ -182,6 +185,11 @@ public class StateHandleDummyUtil {
         @Override
         public KeyedStateHandle getIntersection(KeyGroupRange keyGroupRange) {
             return new DummyKeyedStateHandle(this.keyGroupRange.getIntersection(keyGroupRange));
+        }
+
+        @Override
+        public StateHandleID getStateHandleId() {
+            return stateHandleId;
         }
 
         @Override

--- a/flink-runtime/src/test/java/org/apache/flink/runtime/checkpoint/metadata/CheckpointTestUtils.java
+++ b/flink-runtime/src/test/java/org/apache/flink/runtime/checkpoint/metadata/CheckpointTestUtils.java
@@ -247,10 +247,15 @@ public class CheckpointTestUtils {
 
     public static IncrementalRemoteKeyedStateHandle createDummyIncrementalKeyedStateHandle(
             Random rnd) {
+        return createDummyIncrementalKeyedStateHandle(42L, rnd);
+    }
+
+    public static IncrementalRemoteKeyedStateHandle createDummyIncrementalKeyedStateHandle(
+            long checkpointId, Random rnd) {
         return new IncrementalRemoteKeyedStateHandle(
                 createRandomUUID(rnd),
                 new KeyGroupRange(1, 1),
-                42L,
+                checkpointId,
                 createRandomStateHandleMap(rnd),
                 createRandomStateHandleMap(rnd),
                 createDummyStreamStateHandle(rnd, null));

--- a/flink-runtime/src/test/java/org/apache/flink/runtime/checkpoint/metadata/MetadataV3SerializerTest.java
+++ b/flink-runtime/src/test/java/org/apache/flink/runtime/checkpoint/metadata/MetadataV3SerializerTest.java
@@ -27,9 +27,13 @@ import org.apache.flink.core.memory.DataInputViewStreamWrapper;
 import org.apache.flink.core.memory.DataOutputViewStreamWrapper;
 import org.apache.flink.runtime.checkpoint.MasterState;
 import org.apache.flink.runtime.checkpoint.OperatorState;
+import org.apache.flink.runtime.state.ChangelogTestUtils;
 import org.apache.flink.runtime.state.KeyGroupRangeOffsets;
 import org.apache.flink.runtime.state.KeyGroupsStateHandle;
+import org.apache.flink.runtime.state.KeyedStateHandle;
 import org.apache.flink.runtime.state.StreamStateHandle;
+import org.apache.flink.runtime.state.changelog.ChangelogStateBackendHandle;
+import org.apache.flink.runtime.state.changelog.ChangelogStateBackendHandle.ChangelogStateBackendHandleImpl;
 import org.apache.flink.runtime.state.memory.ByteStreamStateHandle;
 
 import org.junit.Rule;
@@ -46,6 +50,7 @@ import java.util.Collection;
 import java.util.Collections;
 import java.util.Iterator;
 import java.util.Random;
+import java.util.concurrent.ThreadLocalRandom;
 import java.util.stream.Collectors;
 
 import static org.junit.Assert.assertArrayEquals;
@@ -280,5 +285,42 @@ public class MetadataV3SerializerTest {
                 }
             }
         }
+    }
+
+    @Test
+    public void testSerializeIncrementalChangelogStateBackendHandle() throws IOException {
+        testSerializeChangelogStateBackendHandle(false);
+    }
+
+    @Test
+    public void testSerializeFullChangelogStateBackendHandle() throws IOException {
+        testSerializeChangelogStateBackendHandle(true);
+    }
+
+    private void testSerializeChangelogStateBackendHandle(boolean fullSnapshot) throws IOException {
+        ChangelogStateBackendHandle handle = createChangelogStateBackendHandle(fullSnapshot);
+        try (ByteArrayOutputStreamWithPos out = new ByteArrayOutputStreamWithPos()) {
+            MetadataV2V3SerializerBase.serializeKeyedStateHandle(handle, new DataOutputStream(out));
+            try (ByteArrayInputStream in = new ByteArrayInputStream(out.toByteArray())) {
+                KeyedStateHandle deserialized =
+                        MetadataV2V3SerializerBase.deserializeKeyedStateHandle(
+                                new DataInputStream(in), null);
+                assertTrue(deserialized instanceof ChangelogStateBackendHandleImpl);
+                assertEquals(
+                        ((ChangelogStateBackendHandleImpl) deserialized)
+                                .getMaterializedStateHandles(),
+                        handle.getMaterializedStateHandles());
+            }
+        }
+    }
+
+    private ChangelogStateBackendHandle createChangelogStateBackendHandle(boolean fullSnapshot) {
+        KeyedStateHandle keyedStateHandle =
+                fullSnapshot
+                        ? CheckpointTestUtils.createDummyKeyGroupStateHandle(
+                                ThreadLocalRandom.current(), null)
+                        : CheckpointTestUtils.createDummyIncrementalKeyedStateHandle(
+                                ThreadLocalRandom.current());
+        return ChangelogTestUtils.createChangelogStateBackendHandle(keyedStateHandle);
     }
 }

--- a/flink-runtime/src/test/java/org/apache/flink/runtime/state/ChangelogTestUtils.java
+++ b/flink-runtime/src/test/java/org/apache/flink/runtime/state/ChangelogTestUtils.java
@@ -1,0 +1,141 @@
+/*
+
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+
+*/
+
+package org.apache.flink.runtime.state;
+
+import org.apache.flink.core.fs.FSDataInputStream;
+import org.apache.flink.runtime.checkpoint.metadata.CheckpointTestUtils;
+import org.apache.flink.runtime.state.changelog.ChangelogStateBackendHandle;
+import org.apache.flink.runtime.state.changelog.ChangelogStateBackendHandle.ChangelogStateBackendHandleImpl;
+import org.apache.flink.runtime.state.changelog.SequenceNumber;
+import org.apache.flink.runtime.state.changelog.inmemory.InMemoryChangelogStateHandle;
+
+import java.io.IOException;
+import java.util.Collections;
+import java.util.Optional;
+import java.util.concurrent.ThreadLocalRandom;
+
+/** Test utils for changelog * */
+public class ChangelogTestUtils {
+
+    public static ChangelogStateBackendHandle createChangelogStateBackendHandle(
+            KeyedStateHandle keyedStateHandle) {
+        return new ChangelogStateBackendHandleImpl(
+                Collections.singletonList(keyedStateHandle),
+                Collections.emptyList(),
+                new KeyGroupRange(0, 1),
+                1L,
+                0L);
+    }
+
+    public static IncrementalStateHandleWrapper createDummyIncrementalStateHandle(
+            long checkpointId) {
+        return new IncrementalStateHandleWrapper(
+                CheckpointTestUtils.createDummyIncrementalKeyedStateHandle(
+                        checkpointId, ThreadLocalRandom.current()));
+    }
+
+    public static ChangelogStateHandleWrapper createDummyChangelogStateHandle(long from, long to) {
+        return new ChangelogStateHandleWrapper(
+                new InMemoryChangelogStateHandle(
+                        Collections.emptyList(),
+                        SequenceNumber.of(from),
+                        SequenceNumber.of(to),
+                        new KeyGroupRange(1, 1)));
+    }
+
+    public static class IncrementalStateHandleWrapper extends IncrementalRemoteKeyedStateHandle {
+        private static final long serialVersionUID = 1L;
+        private final IncrementalRemoteKeyedStateHandle stateHandle;
+        private volatile boolean isDiscarded;
+
+        IncrementalStateHandleWrapper(IncrementalRemoteKeyedStateHandle stateHandle) {
+            super(
+                    stateHandle.getBackendIdentifier(),
+                    stateHandle.getKeyGroupRange(),
+                    stateHandle.getCheckpointId(),
+                    stateHandle.getSharedState(),
+                    stateHandle.getPrivateState(),
+                    stateHandle.getMetaStateHandle(),
+                    stateHandle.getCheckpointedSize(),
+                    stateHandle.getStateHandleId());
+            this.stateHandle = stateHandle;
+        }
+
+        @Override
+        public void discardState() throws Exception {
+            super.discardState();
+            isDiscarded = true;
+        }
+
+        boolean isDiscarded() {
+            return isDiscarded;
+        }
+
+        IncrementalStateHandleWrapper copy() {
+            return new IncrementalStateHandleWrapper(stateHandle.copy());
+        }
+    }
+
+    public static class ChangelogStateHandleWrapper extends InMemoryChangelogStateHandle
+            implements StreamStateHandle {
+        private static final long serialVersionUID = 1L;
+        private volatile boolean isDiscarded;
+
+        public ChangelogStateHandleWrapper(InMemoryChangelogStateHandle stateHandle) {
+            super(
+                    stateHandle.getChanges(),
+                    SequenceNumber.of(stateHandle.getFrom()),
+                    SequenceNumber.of(stateHandle.getTo()),
+                    stateHandle.getKeyGroupRange());
+        }
+
+        @Override
+        public void registerSharedStates(SharedStateRegistry stateRegistry, long checkpointID) {
+            // unlike original InMemoryChangelogStateHandle, register the reference here
+            // to verify #isDiscarded
+            stateRegistry.registerReference(getSharedStateRegistryKey(), this, checkpointID);
+        }
+
+        private SharedStateRegistryKey getSharedStateRegistryKey() {
+            return new SharedStateRegistryKey(getKeyGroupRange() + "_" + getFrom() + "_" + getTo());
+        }
+
+        @Override
+        public void discardState() {
+            super.discardState();
+            isDiscarded = true;
+        }
+
+        @Override
+        public FSDataInputStream openInputStream() throws IOException {
+            throw new UnsupportedOperationException();
+        }
+
+        @Override
+        public Optional<byte[]> asBytesIfInMemory() {
+            throw new UnsupportedOperationException();
+        }
+
+        boolean isDiscarded() {
+            return isDiscarded;
+        }
+    }
+}

--- a/flink-runtime/src/test/java/org/apache/flink/runtime/state/IncrementalRemoteKeyedStateHandleTest.java
+++ b/flink-runtime/src/test/java/org/apache/flink/runtime/state/IncrementalRemoteKeyedStateHandleTest.java
@@ -28,6 +28,8 @@ import java.util.Random;
 import java.util.UUID;
 import java.util.concurrent.ThreadLocalRandom;
 
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertTrue;
 import static org.junit.Assert.fail;
 import static org.mockito.Mockito.never;
 import static org.mockito.Mockito.times;
@@ -228,6 +230,16 @@ public class IncrementalRemoteKeyedStateHandleTest {
         IncrementalRemoteKeyedStateHandle stateHandle2 =
                 create(ThreadLocalRandom.current(), checkpointedSize);
         Assert.assertEquals(checkpointedSize, stateHandle2.getCheckpointedSize());
+    }
+
+    @Test
+    public void testNonEmptyIntersection() {
+        IncrementalRemoteKeyedStateHandle handle = create(ThreadLocalRandom.current());
+
+        KeyGroupRange expectedRange = new KeyGroupRange(0, 3);
+        KeyedStateHandle newHandle = handle.getIntersection(expectedRange);
+        assertTrue(newHandle instanceof IncrementalRemoteKeyedStateHandle);
+        assertEquals(handle.getStateHandleId(), newHandle.getStateHandleId());
     }
 
     private static IncrementalRemoteKeyedStateHandle create(Random rnd) {

--- a/flink-runtime/src/test/java/org/apache/flink/runtime/state/KeyGroupsStateHandleTest.java
+++ b/flink-runtime/src/test/java/org/apache/flink/runtime/state/KeyGroupsStateHandleTest.java
@@ -41,6 +41,7 @@ public class KeyGroupsStateHandleTest {
         assertNotNull(newHandle);
         assertEquals(streamHandle, newHandle.getDelegateStateHandle());
         assertEquals(expectedRange, newHandle.getKeyGroupRange());
+        assertEquals(handle.getStateHandleId(), newHandle.getStateHandleId());
     }
 
     @Test

--- a/flink-runtime/src/test/java/org/apache/flink/runtime/state/ttl/mock/MockKeyedStateBackend.java
+++ b/flink-runtime/src/test/java/org/apache/flink/runtime/state/ttl/mock/MockKeyedStateBackend.java
@@ -40,6 +40,7 @@ import org.apache.flink.runtime.state.PriorityComparator;
 import org.apache.flink.runtime.state.SavepointResources;
 import org.apache.flink.runtime.state.SharedStateRegistry;
 import org.apache.flink.runtime.state.SnapshotResult;
+import org.apache.flink.runtime.state.StateHandleID;
 import org.apache.flink.runtime.state.StateSnapshotTransformer;
 import org.apache.flink.runtime.state.StateSnapshotTransformer.StateSnapshotTransformFactory;
 import org.apache.flink.runtime.state.StateSnapshotTransformers;
@@ -304,9 +305,11 @@ public class MockKeyedStateBackend<K> extends AbstractKeyedStateBackend<K> {
         private static final long serialVersionUID = 1L;
 
         final Map<String, Map<K, Map<Object, Object>>> snapshotStates;
+        private final StateHandleID stateHandleId;
 
         MockKeyedStateHandle(Map<String, Map<K, Map<Object, Object>>> snapshotStates) {
             this.snapshotStates = snapshotStates;
+            this.stateHandleId = StateHandleID.randomStateHandleId();
         }
 
         @Override
@@ -335,6 +338,11 @@ public class MockKeyedStateBackend<K> extends AbstractKeyedStateBackend<K> {
         @Override
         public KeyedStateHandle getIntersection(KeyGroupRange keyGroupRange) {
             throw new UnsupportedOperationException();
+        }
+
+        @Override
+        public StateHandleID getStateHandleId() {
+            return stateHandleId;
         }
     }
 

--- a/flink-state-backends/flink-statebackend-changelog/src/main/java/org/apache/flink/state/changelog/ChangelogKeyedStateBackend.java
+++ b/flink-state-backends/flink-statebackend-changelog/src/main/java/org/apache/flink/state/changelog/ChangelogKeyedStateBackend.java
@@ -413,12 +413,9 @@ public class ChangelogKeyedStateBackend<K>
                 && changelogStateBackendStateCopy.getMaterializedSnapshot().isEmpty()) {
             return SnapshotResult.empty();
         } else {
-            List<KeyedStateHandle> materializedSnapshot =
-                    changelogStateBackendStateCopy.getMaterializedSnapshot();
-
             return SnapshotResult.of(
                     new ChangelogStateBackendHandleImpl(
-                            materializedSnapshot,
+                            changelogStateBackendStateCopy.getMaterializedSnapshot(),
                             prevDeltaCopy,
                             getKeyGroupRange(),
                             changelogStateBackendStateCopy.materializationID,

--- a/flink-state-backends/flink-statebackend-changelog/src/main/java/org/apache/flink/state/changelog/ChangelogStateBackend.java
+++ b/flink-state-backends/flink-statebackend-changelog/src/main/java/org/apache/flink/state/changelog/ChangelogStateBackend.java
@@ -218,11 +218,12 @@ public class ChangelogStateBackend implements DelegatingStateBackend, Configurab
         String subtaskName = env.getTaskInfo().getTaskNameWithSubtasks();
         ExecutionConfig executionConfig = env.getExecutionConfig();
 
+        Collection<ChangelogStateBackendHandle> stateBackendHandles = castHandles(stateHandles);
         ChangelogKeyedStateBackend<K> keyedStateBackend =
                 ChangelogBackendRestoreOperation.restore(
                         changelogStorage.createReader(),
                         env.getUserCodeClassLoader().asClassLoader(),
-                        castHandles(stateHandles),
+                        stateBackendHandles,
                         baseBackendBuilder,
                         (baseBackend, baseState) ->
                                 new ChangelogKeyedStateBackend(

--- a/flink-streaming-java/src/test/java/org/apache/flink/streaming/runtime/tasks/StreamTaskTest.java
+++ b/flink-streaming-java/src/test/java/org/apache/flink/streaming/runtime/tasks/StreamTaskTest.java
@@ -82,6 +82,7 @@ import org.apache.flink.runtime.state.OperatorStreamStateHandle;
 import org.apache.flink.runtime.state.SharedStateRegistry;
 import org.apache.flink.runtime.state.SnapshotResult;
 import org.apache.flink.runtime.state.StateBackendFactory;
+import org.apache.flink.runtime.state.StateHandleID;
 import org.apache.flink.runtime.state.StateInitializationContext;
 import org.apache.flink.runtime.state.StatePartitionStreamProvider;
 import org.apache.flink.runtime.state.StreamStateHandle;
@@ -2381,6 +2382,8 @@ public class StreamTaskTest extends TestLogger {
 
         private final transient CompletableFuture<Void> discardFuture = new CompletableFuture<>();
 
+        private final StateHandleID stateHandleId = StateHandleID.randomStateHandleId();
+
         public CompletableFuture<Void> getDiscardFuture() {
             return discardFuture;
         }
@@ -2393,6 +2396,11 @@ public class StreamTaskTest extends TestLogger {
         @Override
         public TestingKeyedStateHandle getIntersection(KeyGroupRange keyGroupRange) {
             return this;
+        }
+
+        @Override
+        public StateHandleID getStateHandleId() {
+            return stateHandleId;
         }
 
         @Override


### PR DESCRIPTION
## What is the purpose of the change

Correct the state register logic of ChangelogStateBackendHandle.

## Brief change log

  - Refactor register logic of `ChangelogStateBackendHandleImpl`.


## Verifying this change

This change added tests and can be verified as follows:

  - Added SharedStateRegistryTest#testRegisterChangelogStateBackendHandles

## Does this pull request potentially affect one of the following parts:

  - Dependencies (does it add or upgrade a dependency): no
  - The public API, i.e., is any changed class annotated with `@Public(Evolving)`: no
  - The serializers: no
  - The runtime per-record code paths (performance sensitive): no
  - Anything that affects deployment or recovery: JobManager (and its components), Checkpointing, Kubernetes/Yarn, ZooKeeper: no
  - The S3 file system connector: no

## Documentation

  - Does this pull request introduce a new feature? no
  - If yes, how is the feature documented? not applicable
