### PR TITLE
[FLINK-25590][metrics] Introduce RequestedMemoryUsage and log warnings if usage exceeds 100%

### DIFF
--- a/docs/content.zh/docs/ops/metrics.md
+++ b/docs/content.zh/docs/ops/metrics.md
@@ -884,8 +884,8 @@ Metrics related to data exchange between task executors using netty network comm
   </thead>
   <tbody>
     <tr>
-      <th rowspan="6"><strong>TaskManager</strong></th>
-      <td rowspan="6">Status.Shuffle.Netty</td>
+      <th rowspan="7"><strong>TaskManager</strong></th>
+      <td rowspan="7">Status.Shuffle.Netty</td>
       <td>AvailableMemorySegments</td>
       <td>The number of unused memory segments.</td>
       <td>Gauge</td>
@@ -913,6 +913,11 @@ Metrics related to data exchange between task executors using netty network comm
     <tr>
       <td>TotalMemory</td>
       <td>The amount of allocated memory in bytes.</td>
+      <td>Gauge</td>
+    </tr>
+    <tr>
+      <td>RequestedMemoryUsage</td>
+      <td>Experimental: The usage of the network memory. Shows (as percentage) the total amount of requested memory from all of the subtasks. It can exceed 100% as not all requested memory is required for subtask to make progress. However if usage exceeds 100% throughput can suffer greatly and please consider increasing available network memory, or decreasing configured size of network buffer pools.</td>
       <td>Gauge</td>
     </tr>
     <tr>

--- a/docs/content/docs/ops/metrics.md
+++ b/docs/content/docs/ops/metrics.md
@@ -884,8 +884,8 @@ Metrics related to data exchange between task executors using netty network comm
   </thead>
   <tbody>
     <tr>
-      <th rowspan="6"><strong>TaskManager</strong></th>
-      <td rowspan="6">Status.Shuffle.Netty</td>
+      <th rowspan="7"><strong>TaskManager</strong></th>
+      <td rowspan="7">Status.Shuffle.Netty</td>
       <td>AvailableMemorySegments</td>
       <td>The number of unused memory segments.</td>
       <td>Gauge</td>
@@ -913,6 +913,11 @@ Metrics related to data exchange between task executors using netty network comm
     <tr>
       <td>TotalMemory</td>
       <td>The amount of allocated memory in bytes.</td>
+      <td>Gauge</td>
+    </tr>
+    <tr>
+      <td>RequestedMemoryUsage</td>
+      <td>Experimental: The usage of the network memory. Shows (as percentage) the total amount of requested memory from all of the subtasks. It can exceed 100% as not all requested memory is required for subtask to make progress. However if usage exceeds 100% throughput can suffer greatly and please consider increasing available network memory, or decreasing configured size of network buffer pools.</td>
       <td>Gauge</td>
     </tr>
     <tr>

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/io/network/buffer/LocalBufferPool.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/io/network/buffer/LocalBufferPool.java
@@ -269,6 +269,19 @@ class LocalBufferPool implements BufferPool {
         return maxNumberOfMemorySegments;
     }
 
+    /**
+     * @return the same value as {@link #getMaxNumberOfMemorySegments()} for bounded pools. For
+     *     unbounded pools it returns an approximation based upon {@link
+     *     #getNumberOfRequiredMemorySegments()}
+     */
+    public int getNumberOfRequestedMemorySegments() {
+        if (maxNumberOfMemorySegments < NetworkBufferPool.UNBOUNDED_POOL_SIZE) {
+            return maxNumberOfMemorySegments;
+        } else {
+            return getNumberOfRequiredMemorySegments() * 2;
+        }
+    }
+
     @Override
     public int getNumberOfAvailableMemorySegments() {
         synchronized (availableMemorySegments) {

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/shuffle/NettyShuffleUtils.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/shuffle/NettyShuffleUtils.java
@@ -18,6 +18,7 @@
 
 package org.apache.flink.runtime.shuffle;
 
+import org.apache.flink.runtime.io.network.buffer.NetworkBufferPool;
 import org.apache.flink.runtime.io.network.partition.ResultPartitionType;
 import org.apache.flink.runtime.jobgraph.IntermediateDataSetID;
 
@@ -71,7 +72,7 @@ public class NettyShuffleUtils {
                 type.isBounded()
                         ? numSubpartitions * configuredNetworkBuffersPerChannel
                                 + numFloatingBuffersPerGate
-                        : Integer.MAX_VALUE;
+                        : NetworkBufferPool.UNBOUNDED_POOL_SIZE;
         // for each upstream hash-based blocking/pipelined subpartition, at least one buffer is
         // needed even the configured network buffers per channel is 0 and this behavior is for
         // performance. If it's not guaranteed that each subpartition can get at least one buffer,

--- a/flink-runtime/src/test/java/org/apache/flink/runtime/io/network/buffer/NetworkBufferPoolTest.java
+++ b/flink-runtime/src/test/java/org/apache/flink/runtime/io/network/buffer/NetworkBufferPoolTest.java
@@ -305,7 +305,7 @@ public class NetworkBufferPoolTest extends TestLogger {
             MatcherAssert.assertThat(globalPool.getUsageWarning(), equalTo(Optional.empty()));
 
             closeableRegistry.registerCloseable(
-                    (globalPool.createBufferPool(10, Integer.MAX_VALUE))::lazyDestroy);
+                    (globalPool.createBufferPool(5, Integer.MAX_VALUE))::lazyDestroy);
 
             assertEquals(30, globalPool.getNumberOfRequestedMemorySegments());
             assertEquals(60, globalPool.getRequestedSegmentsUsage());


### PR DESCRIPTION
Right now, if exclusive buffers for the input channel and one buffer for each subpartition would be allocated on start successfully but there would be not enough memory for the rest of the buffers(floating buffers, rest buffers for subpartitions), then we see nothing in the log about that(as I understand).
So first of all, we need to check what logs we have right now about situations when flink doesn't have enough memory for all configured buffers. And if we have nothing (or not enough) we should add such a log.

## Verifying this change

Added a dedicated unit test
Manually tested in an end to end example.

## Does this pull request potentially affect one of the following parts:

  - Dependencies (does it add or upgrade a dependency): (yes / **no**)
  - The public API, i.e., is any changed class annotated with `@Public(Evolving)`: (yes / **no**)
  - The serializers: (yes / **no** / don't know)
  - The runtime per-record code paths (performance sensitive): (yes / **no** / don't know)
  - Anything that affects deployment or recovery: JobManager (and its components), Checkpointing, Kubernetes/Yarn, ZooKeeper: (yes / **no** / don't know)
  - The S3 file system connector: (yes / **no** / don't know)

## Documentation

  - Does this pull request introduce a new feature? (**yes** / no)
  - If yes, how is the feature documented? (not applicable / **docs** / JavaDocs / not documented)
