### PR TITLE
Revert "[FLINK-25399][tests] Disable changelog backend in tests"

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -1553,8 +1553,7 @@ under the License.
 							random: enable it randomly, unless explicitly set
 							unset: don't alter the configuration
 						-->
-						<!-- Changelog backend is disabled until FLINK-25399 is resolved -->
-                        <checkpointing.changelog>unset</checkpointing.changelog>
+						<checkpointing.changelog>random</checkpointing.changelog>
 						<project.basedir>${project.basedir}</project.basedir>
 						<!--suppress MavenModelInspection -->
 						<test.randomization.seed>${test.randomization.seed}</test.randomization.seed>


### PR DESCRIPTION
```
This reverts commit 1d1e72f0c4677e27d19345e5465c6d4a0ef6408f.

The issue has been fixed in FLINK-25395 by commits:
- 4691b66545010ed812624a259869c7a522663720
- e28f4e2c5d4d54f5f727b9557024c537becfd054
```
