### PR TITLE
[FLINK-25702][Kafka] Use the configure feature provided by the kafka Serializer/Deserializer.

### DIFF
--- a/flink-connectors/flink-connector-kafka/src/main/java/org/apache/flink/connector/kafka/sink/KafkaRecordSerializationSchema.java
+++ b/flink-connectors/flink-connector-kafka/src/main/java/org/apache/flink/connector/kafka/sink/KafkaRecordSerializationSchema.java
@@ -63,11 +63,11 @@ public interface KafkaRecordSerializationSchema<T> extends Serializable {
     interface KafkaSinkContext {
 
         /**
-         * Get the number of the subtask the KafkaSink is running on. The numbering starts from 0
-         * and goes up to parallelism-1. (parallelism as returned by {@link
+         * Get the ID of the subtask the KafkaSink is running on. The numbering starts from 0 and
+         * goes up to parallelism-1. (parallelism as returned by {@link
          * #getNumberOfParallelInstances()}
          *
-         * @return number of subtask
+         * @return ID of subtask
          */
         int getParallelInstanceId();
 

--- a/flink-connectors/flink-connector-kafka/src/main/java/org/apache/flink/connector/kafka/sink/KafkaRecordSerializationSchemaBuilder.java
+++ b/flink-connectors/flink-connector-kafka/src/main/java/org/apache/flink/connector/kafka/sink/KafkaRecordSerializationSchemaBuilder.java
@@ -21,7 +21,6 @@ import org.apache.flink.api.common.serialization.SerializationSchema;
 import org.apache.flink.streaming.connectors.kafka.partitioner.FlinkKafkaPartitioner;
 
 import org.apache.kafka.clients.producer.ProducerRecord;
-import org.apache.kafka.common.Configurable;
 import org.apache.kafka.common.serialization.Serializer;
 
 import javax.annotation.Nullable;
@@ -150,7 +149,8 @@ public class KafkaRecordSerializationSchemaBuilder<IN> {
             Class<? extends Serializer<? super T>> keySerializer) {
         checkKeySerializerNotSet();
         KafkaRecordSerializationSchemaBuilder<T> self = self();
-        self.keySerializationSchema = new KafkaSerializerWrapper<>(keySerializer, topicSelector);
+        self.keySerializationSchema =
+                new KafkaSerializerWrapper<>(keySerializer, true, topicSelector);
         return self;
     }
 
@@ -158,19 +158,18 @@ public class KafkaRecordSerializationSchemaBuilder<IN> {
      * Sets a configurable Kafka {@link Serializer} and pass a configuration to serialize incoming
      * elements to the key of the {@link ProducerRecord}.
      *
-     * @param keySerializerWithConfiguration
+     * @param keySerializer
      * @param configuration
      * @param <S> type of the used serializer class
      * @return {@code this}
      */
-    public <T extends IN, S extends Configurable & Serializer<? super T>>
+    public <T extends IN, S extends Serializer<? super T>>
             KafkaRecordSerializationSchemaBuilder<T> setKafkaKeySerializer(
-                    Class<S> keySerializerWithConfiguration, Map<String, String> configuration) {
+                    Class<S> keySerializer, Map<String, String> configuration) {
         checkKeySerializerNotSet();
         KafkaRecordSerializationSchemaBuilder<T> self = self();
         self.keySerializationSchema =
-                new KafkaSerializerWrapper<>(
-                        keySerializerWithConfiguration, configuration, topicSelector);
+                new KafkaSerializerWrapper<>(keySerializer, true, configuration, topicSelector);
         return self;
     }
 
@@ -206,7 +205,7 @@ public class KafkaRecordSerializationSchemaBuilder<IN> {
         checkValueSerializerNotSet();
         KafkaRecordSerializationSchemaBuilder<T> self = self();
         self.valueSerializationSchema =
-                new KafkaSerializerWrapper<>(valueSerializer, topicSelector);
+                new KafkaSerializerWrapper<>(valueSerializer, false, topicSelector);
         return self;
     }
 
@@ -214,19 +213,18 @@ public class KafkaRecordSerializationSchemaBuilder<IN> {
      * Sets a configurable Kafka {@link Serializer} and pass a configuration to serialize incoming
      * elements to the value of the {@link ProducerRecord}.
      *
-     * @param valueSerializerWithConfiguration
+     * @param valueSerializer
      * @param configuration
      * @param <S> type of the used serializer class
      * @return {@code this}
      */
-    public <T extends IN, S extends Configurable & Serializer<? super T>>
+    public <T extends IN, S extends Serializer<? super T>>
             KafkaRecordSerializationSchemaBuilder<T> setKafkaValueSerializer(
-                    Class<S> valueSerializerWithConfiguration, Map<String, String> configuration) {
+                    Class<S> valueSerializer, Map<String, String> configuration) {
         checkValueSerializerNotSet();
         KafkaRecordSerializationSchemaBuilder<T> self = self();
         self.valueSerializationSchema =
-                new KafkaSerializerWrapper<>(
-                        valueSerializerWithConfiguration, configuration, topicSelector);
+                new KafkaSerializerWrapper<>(valueSerializer, false, configuration, topicSelector);
         return self;
     }
 

--- a/flink-connectors/flink-connector-kafka/src/main/java/org/apache/flink/connector/kafka/sink/KafkaSerializerWrapper.java
+++ b/flink-connectors/flink-connector-kafka/src/main/java/org/apache/flink/connector/kafka/sink/KafkaSerializerWrapper.java
@@ -32,8 +32,12 @@ import java.util.function.Function;
 import static org.apache.flink.util.Preconditions.checkNotNull;
 import static org.apache.flink.util.Preconditions.checkState;
 
+/** Wrapper for Kafka {@link Serializer}. */
 class KafkaSerializerWrapper<IN> implements SerializationSchema<IN> {
+
     private final Class<? extends Serializer<? super IN>> serializerClass;
+    // Whether the serializer is for key or value
+    private final boolean isKey;
     private final Map<String, String> config;
     private final Function<? super IN, String> topicSelector;
 
@@ -41,17 +45,20 @@ class KafkaSerializerWrapper<IN> implements SerializationSchema<IN> {
 
     KafkaSerializerWrapper(
             Class<? extends Serializer<? super IN>> serializerClass,
+            boolean isKey,
             Map<String, String> config,
             Function<? super IN, String> topicSelector) {
         this.serializerClass = checkNotNull(serializerClass);
+        this.isKey = isKey;
         this.config = checkNotNull(config);
         this.topicSelector = checkNotNull(topicSelector);
     }
 
     KafkaSerializerWrapper(
             Class<? extends Serializer<? super IN>> serializerClass,
+            boolean isKey,
             Function<? super IN, String> topicSelector) {
-        this(serializerClass, Collections.emptyMap(), topicSelector);
+        this(serializerClass, isKey, Collections.emptyMap(), topicSelector);
     }
 
     @SuppressWarnings("unchecked")
@@ -65,8 +72,11 @@ class KafkaSerializerWrapper<IN> implements SerializationSchema<IN> {
                             serializerClass.getName(),
                             Serializer.class,
                             getClass().getClassLoader());
+
             if (serializer instanceof Configurable) {
                 ((Configurable) serializer).configure(config);
+            } else {
+                serializer.configure(config, isKey);
             }
         } catch (Exception e) {
             throw new IOException("Failed to instantiate the serializer of class " + serializer, e);

--- a/flink-connectors/flink-connector-kafka/src/main/java/org/apache/flink/connector/kafka/source/reader/deserializer/KafkaRecordDeserializationSchema.java
+++ b/flink-connectors/flink-connector-kafka/src/main/java/org/apache/flink/connector/kafka/source/reader/deserializer/KafkaRecordDeserializationSchema.java
@@ -25,7 +25,6 @@ import org.apache.flink.streaming.connectors.kafka.KafkaDeserializationSchema;
 import org.apache.flink.util.Collector;
 
 import org.apache.kafka.clients.consumer.ConsumerRecord;
-import org.apache.kafka.common.Configurable;
 import org.apache.kafka.common.serialization.Deserializer;
 
 import java.io.IOException;
@@ -108,24 +107,24 @@ public interface KafkaRecordDeserializationSchema<T> extends Serializable, Resul
      */
     static <V> KafkaRecordDeserializationSchema<V> valueOnly(
             Class<? extends Deserializer<V>> valueDeserializerClass) {
-        return new KafkaValueOnlyDeserializerWrapper<>(
-                valueDeserializerClass, Collections.emptyMap());
+        return valueOnly(valueDeserializerClass, Collections.emptyMap());
     }
 
     /**
      * Wraps a Kafka {@link Deserializer} to a {@link KafkaRecordDeserializationSchema}.
      *
      * @param valueDeserializerClass the deserializer class used to deserialize the value.
-     * @param config the configuration of the value deserializer, only valid when the deserializer
-     *     is an implementation of {@code Configurable}.
+     * @param config the configuration of the value deserializer. If the deserializer is an
+     *     implementation of {@code Configurable}, the configuring logic will be handled by {@link
+     *     org.apache.kafka.common.Configurable#configure(Map)} with the given {@link config},
+     *     otherwise {@link Deserializer#configure(Map, boolean)} will be invoked.
      * @param <V> the value type.
      * @param <D> the type of the deserializer.
      * @return A {@link KafkaRecordDeserializationSchema} that deserialize the value with the given
      *     deserializer.
      */
-    static <V, D extends Configurable & Deserializer<V>>
-            KafkaRecordDeserializationSchema<V> valueOnly(
-                    Class<D> valueDeserializerClass, Map<String, String> config) {
+    static <V, D extends Deserializer<V>> KafkaRecordDeserializationSchema<V> valueOnly(
+            Class<D> valueDeserializerClass, Map<String, String> config) {
         return new KafkaValueOnlyDeserializerWrapper<>(valueDeserializerClass, config);
     }
 }

--- a/flink-connectors/flink-connector-kafka/src/main/java/org/apache/flink/connector/kafka/source/reader/deserializer/KafkaValueOnlyDeserializerWrapper.java
+++ b/flink-connectors/flink-connector-kafka/src/main/java/org/apache/flink/connector/kafka/source/reader/deserializer/KafkaValueOnlyDeserializerWrapper.java
@@ -36,10 +36,14 @@ import java.util.Map;
 
 /** A package private class to wrap {@link Deserializer}. */
 class KafkaValueOnlyDeserializerWrapper<T> implements KafkaRecordDeserializationSchema<T> {
+
     private static final long serialVersionUID = 5409547407386004054L;
+
     private static final Logger LOG =
             LoggerFactory.getLogger(KafkaValueOnlyDeserializerWrapper.class);
+
     private final Class<? extends Deserializer<T>> deserializerClass;
+
     private final Map<String, String> config;
 
     private transient Deserializer<T> deserializer;
@@ -62,8 +66,12 @@ class KafkaValueOnlyDeserializerWrapper<T> implements KafkaRecordDeserialization
                                     deserializerClass.getName(),
                                     Deserializer.class,
                                     getClass().getClassLoader());
+
             if (deserializer instanceof Configurable) {
                 ((Configurable) deserializer).configure(config);
+            } else {
+                // Always be false since this Deserializer is only used for value.
+                deserializer.configure(config, false);
             }
         } catch (Exception e) {
             throw new IOException(


### PR DESCRIPTION
## What is the purpose of the change

The PR updated the kafka connector Seriliazer/Deseriliazer Schema to use the configure feature provided by the kafka Serializer/Deserializer.


## Brief change log

-  use the configure feature provided by the kafka Serializer/Deserializer
-  javadoc fix


## Verifying this change


This change is covered by new tests in:

- KafkaRecordSerializationSchemaBuilderTest
- KafkaRecordDeserializationSchemaTest

## Does this pull request potentially affect one of the following parts:

  - Dependencies (does it add or upgrade a dependency): (yes / **no**)
  - The public API, i.e., is any changed class annotated with `@Public(Evolving)`: (yes / **no**)
  - The serializers: (yes / **no** / don't know)
  - The runtime per-record code paths (performance sensitive): (yes / **no** / don't know)
  - Anything that affects deployment or recovery: JobManager (and its components), Checkpointing, Kubernetes/Yarn, ZooKeeper: (yes / **no** / don't know)
  - The S3 file system connector: (yes / **no** / don't know)

## Documentation

  - Does this pull request introduce a new feature? (yes / **no**)
