### PR TITLE
[FLINK-25118][streaming] Add vertex topology index prefix in vertex name

### DIFF
--- a/docs/layouts/shortcodes/generated/pipeline_configuration.html
+++ b/docs/layouts/shortcodes/generated/pipeline_configuration.html
@@ -122,5 +122,11 @@
             <td><p>Enum</p></td>
             <td>The mode how we organize description of a job vertex.<br /><br />Possible values:<ul><li>"TREE"</li><li>"CASCADING"</li></ul></td>
         </tr>
+        <tr>
+            <td><h5>pipeline.vertex-name-include-index-prefix</h5></td>
+            <td style="word-wrap: break-word;">false</td>
+            <td>Boolean</td>
+            <td>Whether name of vertex includes topological index or not. When it is true, the name will have a prefix of index of the vertex, like '[vertex-0]Source: source'. It is false by default</td>
+        </tr>
     </tbody>
 </table>

--- a/flink-core/src/main/java/org/apache/flink/configuration/PipelineOptions.java
+++ b/flink-core/src/main/java/org/apache/flink/configuration/PipelineOptions.java
@@ -274,4 +274,12 @@ public class PipelineOptions {
         /** Organizes the description in a single line cascading mode, which is similar to name. */
         CASCADING
     }
+
+    public static final ConfigOption<Boolean> VERTEX_NAME_INCLUDE_INDEX_PREFIX =
+            key("pipeline.vertex-name-include-index-prefix")
+                    .booleanType()
+                    .defaultValue(false)
+                    .withDescription(
+                            "Whether name of vertex includes topological index or not. "
+                                    + "When it is true, the name will have a prefix of index of the vertex, like '[vertex-0]Source: source'. It is false by default");
 }

--- a/flink-streaming-java/src/main/java/org/apache/flink/streaming/api/graph/StreamGraph.java
+++ b/flink-streaming-java/src/main/java/org/apache/flink/streaming/api/graph/StreamGraph.java
@@ -131,6 +131,7 @@ public class StreamGraph implements Pipeline {
     private Map<String, ResourceProfile> slotSharingGroupResources;
     private PipelineOptions.VertexDescriptionMode descriptionMode =
             PipelineOptions.VertexDescriptionMode.TREE;
+    private boolean vertexNameIncludeIndexPrefix = false;
 
     public StreamGraph(
             ExecutionConfig executionConfig,
@@ -991,5 +992,13 @@ public class StreamGraph implements Pipeline {
 
     public void setVertexDescriptionMode(PipelineOptions.VertexDescriptionMode mode) {
         this.descriptionMode = mode;
+    }
+
+    public void setVertexNameIncludeIndexPrefix(boolean includePrefix) {
+        this.vertexNameIncludeIndexPrefix = includePrefix;
+    }
+
+    public boolean isVertexNameIncludeIndexPrefix() {
+        return this.vertexNameIncludeIndexPrefix;
     }
 }

--- a/flink-streaming-java/src/main/java/org/apache/flink/streaming/api/graph/StreamGraphGenerator.java
+++ b/flink-streaming-java/src/main/java/org/apache/flink/streaming/api/graph/StreamGraphGenerator.java
@@ -349,6 +349,8 @@ public class StreamGraphGenerator {
         graph.setUserArtifacts(userArtifacts);
         graph.setTimeCharacteristic(timeCharacteristic);
         graph.setVertexDescriptionMode(configuration.get(PipelineOptions.VERTEX_DESCRIPTION_MODE));
+        graph.setVertexNameIncludeIndexPrefix(
+                configuration.get(PipelineOptions.VERTEX_NAME_INCLUDE_INDEX_PREFIX));
 
         if (shouldExecuteInBatchMode) {
             configureStreamGraphBatch(graph);

--- a/flink-streaming-java/src/main/java/org/apache/flink/streaming/api/graph/StreamingJobGraphGenerator.java
+++ b/flink-streaming-java/src/main/java/org/apache/flink/streaming/api/graph/StreamingJobGraphGenerator.java
@@ -94,6 +94,7 @@ import java.util.List;
 import java.util.Map;
 import java.util.Optional;
 import java.util.Set;
+import java.util.concurrent.atomic.AtomicInteger;
 import java.util.stream.Collectors;
 
 import static org.apache.flink.runtime.jobgraph.tasks.CheckpointCoordinatorConfiguration.MINIMAL_CHECKPOINT_TIME;
@@ -213,9 +214,26 @@ public class StreamingJobGraphGenerator {
                             + "This indicates that non-serializable types (like custom serializers) were registered");
         }
 
+        addVertexIndexPrefixInVertexName();
+
         setVertexDescription();
 
         return jobGraph;
+    }
+
+    private void addVertexIndexPrefixInVertexName() {
+        if (!streamGraph.isVertexNameIncludeIndexPrefix()) {
+            return;
+        }
+        final AtomicInteger vertexIndexId = new AtomicInteger(0);
+        jobGraph.getVerticesSortedTopologicallyFromSources()
+                .forEach(
+                        vertex ->
+                                vertex.setName(
+                                        String.format(
+                                                "[vertex-%d]%s",
+                                                vertexIndexId.getAndIncrement(),
+                                                vertex.getName())));
     }
 
     private void setVertexDescription() {

--- a/flink-streaming-java/src/test/java/org/apache/flink/streaming/api/graph/StreamingJobGraphGeneratorTest.java
+++ b/flink-streaming-java/src/test/java/org/apache/flink/streaming/api/graph/StreamingJobGraphGeneratorTest.java
@@ -1207,7 +1207,7 @@ public class StreamingJobGraphGeneratorTest extends TestLogger {
 
     @Test
     public void testSlotSharingOnAllVerticesInSameSlotSharingGroupByDefaultEnabled() {
-        final StreamGraph streamGraph = createStreamGraphForSlotSharingTest();
+        final StreamGraph streamGraph = createStreamGraphForSlotSharingTest(new Configuration());
         // specify slot sharing group for map1
         streamGraph.getStreamNodes().stream()
                 .filter(n -> "map1".equals(n.getOperatorName()))
@@ -1234,7 +1234,7 @@ public class StreamingJobGraphGeneratorTest extends TestLogger {
 
     @Test
     public void testSlotSharingOnAllVerticesInSameSlotSharingGroupByDefaultDisabled() {
-        final StreamGraph streamGraph = createStreamGraphForSlotSharingTest();
+        final StreamGraph streamGraph = createStreamGraphForSlotSharingTest(new Configuration());
         streamGraph.setAllVerticesInSameSlotSharingGroupByDefault(false);
         final JobGraph jobGraph = StreamingJobGraphGenerator.createJobGraph(streamGraph);
 
@@ -1438,6 +1438,30 @@ public class StreamingJobGraphGeneratorTest extends TestLogger {
                 allVertices[0].getOperatorPrettyName());
     }
 
+    @Test
+    public void testNamingWithoutIndex() {
+        JobGraph job = createStreamGraphForSlotSharingTest(new Configuration()).getJobGraph();
+        List<JobVertex> allVertices = job.getVerticesSortedTopologicallyFromSources();
+        assertEquals(4, allVertices.size());
+        assertEquals("Source: source1", allVertices.get(0).getName());
+        assertEquals("Source: source2", allVertices.get(1).getName());
+        assertEquals("map1", allVertices.get(2).getName());
+        assertEquals("map2", allVertices.get(3).getName());
+    }
+
+    @Test
+    public void testNamingWithIndex() {
+        Configuration config = new Configuration();
+        config.setBoolean(PipelineOptions.VERTEX_NAME_INCLUDE_INDEX_PREFIX, true);
+        JobGraph job = createStreamGraphForSlotSharingTest(config).getJobGraph();
+        List<JobVertex> allVertices = job.getVerticesSortedTopologicallyFromSources();
+        assertEquals(4, allVertices.size());
+        assertEquals("[vertex-0]Source: source1", allVertices.get(0).getName());
+        assertEquals("[vertex-1]Source: source2", allVertices.get(1).getName());
+        assertEquals("[vertex-2]map1", allVertices.get(2).getName());
+        assertEquals("[vertex-3]map2", allVertices.get(3).getName());
+    }
+
     private JobGraph createJobGraphWithDescription(
             StreamExecutionEnvironment env, String... inputNames) {
         env.setParallelism(1);
@@ -1506,8 +1530,9 @@ public class StreamingJobGraphGeneratorTest extends TestLogger {
      *
      * <p>source2 --(rebalance & blocking)--> Map2
      */
-    private StreamGraph createStreamGraphForSlotSharingTest() {
-        final StreamExecutionEnvironment env = StreamExecutionEnvironment.getExecutionEnvironment();
+    private StreamGraph createStreamGraphForSlotSharingTest(Configuration config) {
+        final StreamExecutionEnvironment env =
+                StreamExecutionEnvironment.getExecutionEnvironment(config);
         env.setBufferTimeout(-1);
 
         final DataStream<Integer> source1 = env.fromElements(1, 2, 3).name("source1");


### PR DESCRIPTION
## What is the purpose of the change
this is part of This PR is part of https://cwiki.apache.org/confluence/display/FLINK/FLIP-195%3A+Improve+the+name+and+structure+of+vertex+and+operator+name+for+job , aims at to support add a vertex index prefix in name of job vertex, which make it easier to match the log / metrics tag to the vertex when debugging at runtime.


## Brief change log
- add an optional prefix in name of job vertex, which is in format '[vertext-$index]', index is the topological order of the job vertex.
- add an option to enable the prefix or not. 

## Verifying this change

This change added tests and can be verified as follows:
  - *added new test in StreamingJobGraphGeneratorTest*

## Does this pull request potentially affect one of the following parts:

  - Dependencies (does it add or upgrade a dependency): (no)
  - The public API, i.e., is any changed class annotated with `@Public(Evolving)`: (no)
  - The serializers: (no)
  - The runtime per-record code paths (performance sensitive): (no)
  - Anything that affects deployment or recovery: JobManager (and its components), Checkpointing, Kubernetes/Yarn, ZooKeeper: (no)
  - The S3 file system connector: (no)

## Documentation

  - Does this pull request introduce a new feature? (no)
  - If yes, how is the feature documented? (docs)
