### PR TITLE
[FLINK-25681][table-planner] Remove failure test in CodeSplitITCase to avoid deep exception stack

### DIFF
--- a/flink-table/flink-table-planner/src/test/scala/org/apache/flink/table/planner/runtime/batch/sql/CodeSplitITCase.scala
+++ b/flink-table/flink-table-planner/src/test/scala/org/apache/flink/table/planner/runtime/batch/sql/CodeSplitITCase.scala
@@ -18,7 +18,6 @@
 
 package org.apache.flink.table.planner.runtime.batch.sql
 
-import org.apache.flink.core.testutils.FlinkMatchers
 import org.apache.flink.table.api.config.TableConfigOptions
 import org.apache.flink.table.planner.factories.TestValuesTableFactory
 import org.apache.flink.table.planner.runtime.utils.BatchTestBase
@@ -26,10 +25,7 @@ import org.apache.flink.table.planner.runtime.utils.BatchTestBase.row
 import org.apache.flink.table.planner.runtime.utils.TestData.{nullablesOfData3, smallData3, type3}
 import org.apache.flink.types.Row
 
-import org.hamcrest.MatcherAssert
 import org.junit.{Assert, Before, Test}
-
-import java.io.{OutputStream, PrintStream}
 
 import scala.collection.Seq
 
@@ -127,25 +123,5 @@ class CodeSplitITCase extends BatchTestBase {
     tEnv.getConfig.getConfiguration.setInteger(
       TableConfigOptions.MAX_MEMBERS_GENERATED_CODE, 10000)
     checkResult(sql.mkString, results)
-
-    tEnv.getConfig.getConfiguration.setInteger(
-      TableConfigOptions.MAX_LENGTH_GENERATED_CODE, Int.MaxValue)
-    tEnv.getConfig.getConfiguration.setInteger(
-      TableConfigOptions.MAX_MEMBERS_GENERATED_CODE, Int.MaxValue)
-    val originalStdOut = System.out
-    try {
-      // redirect stdout to a null output stream to silence compile error in CompileUtils
-      System.setOut(new PrintStream(new OutputStream {
-        override def write(b: Int): Unit = {}
-      }))
-      checkResult(sql, results)
-      Assert.fail("Expecting compiler exception")
-    } catch {
-      case e: Exception =>
-        MatcherAssert.assertThat(e, FlinkMatchers.containsMessage("grows beyond 64 KB"))
-    } finally {
-      // set stdout back
-      System.setOut(originalStdOut)
-    }
   }
 }


### PR DESCRIPTION
## What is the purpose of the change

FLINK-18356 aims to enforce memory limits for Docker containers, however failure tests in `CodeSplitITCase` will produce deep exception stack which may exceed this limit.

This PR removes the failure test (we can determine the failure by hand when constructing the test cases). I've run this fix based on #18368 on [azure](https://dev.azure.com/tsreaper96/Flink/_build/results?buildId=320&view=results) and it does not fail on flink-table module, which validates this fix.

## Brief change log

 - Remove failure test in CodeSplitITCase to avoid deep exception stack

## Verifying this change

This change is a trivial rework / code cleanup without any test coverage.

## Does this pull request potentially affect one of the following parts:

  - Dependencies (does it add or upgrade a dependency): no
  - The public API, i.e., is any changed class annotated with `@Public(Evolving)`: no
  - The serializers: no
  - The runtime per-record code paths (performance sensitive): no
  - Anything that affects deployment or recovery: JobManager (and its components), Checkpointing, Kubernetes/Yarn, ZooKeeper: no
  - The S3 file system connector: no

## Documentation

  - Does this pull request introduce a new feature? no
  - If yes, how is the feature documented? not applicable
