### PR TITLE
[FLINK-25683][streaming-java] wrong result if table transfrom to Data…

### DIFF
--- a/flink-table/flink-table-planner/src/test/java/org/apache/flink/table/planner/runtime/stream/sql/DataStreamJavaITCase.java
+++ b/flink-table/flink-table-planner/src/test/java/org/apache/flink/table/planner/runtime/stream/sql/DataStreamJavaITCase.java
@@ -22,6 +22,7 @@ import org.apache.flink.api.common.RuntimeExecutionMode;
 import org.apache.flink.api.common.eventtime.WatermarkStrategy;
 import org.apache.flink.api.common.state.ValueState;
 import org.apache.flink.api.common.state.ValueStateDescriptor;
+import org.apache.flink.api.common.typeinfo.TypeHint;
 import org.apache.flink.api.common.typeinfo.TypeInformation;
 import org.apache.flink.api.common.typeinfo.Types;
 import org.apache.flink.api.java.tuple.Tuple2;
@@ -31,6 +32,8 @@ import org.apache.flink.api.java.typeutils.GenericTypeInfo;
 import org.apache.flink.api.java.typeutils.TupleTypeInfo;
 import org.apache.flink.configuration.Configuration;
 import org.apache.flink.streaming.api.datastream.DataStream;
+import org.apache.flink.streaming.api.datastream.DataStreamSource;
+import org.apache.flink.streaming.api.datastream.SingleOutputStreamOperator;
 import org.apache.flink.streaming.api.environment.StreamExecutionEnvironment;
 import org.apache.flink.streaming.api.functions.KeyedProcessFunction;
 import org.apache.flink.streaming.api.functions.ProcessFunction;
@@ -574,6 +577,39 @@ public class DataStreamJavaITCase extends AbstractTestBase {
         final Table resultTable = getComplexUnifiedPipeline(env);
 
         testResult(resultTable.execute(), Row.of("Bob", 1L), Row.of("Alice", 1L));
+    }
+
+    @Test
+    public void testTableStreamConversionBatch() throws Exception {
+        env.setRuntimeMode(RuntimeExecutionMode.BATCH);
+
+        DataStreamSource<Row> streamSource =
+                env.fromElements(
+                        Row.of("Alice"),
+                        Row.of("alice"),
+                        Row.of("lily"),
+                        Row.of("Bob"),
+                        Row.of("lily"),
+                        Row.of("lily"));
+        StreamTableEnvironment tableEnvironment = StreamTableEnvironment.create(env);
+        Table sourceTable = tableEnvironment.fromDataStream(streamSource).as("word");
+        tableEnvironment.createTemporaryView("tmp_table", sourceTable);
+        Table resultTable = tableEnvironment.sqlQuery("select UPPER(word) as word from tmp_table");
+        SingleOutputStreamOperator<Tuple2<String, Integer>> resultStream =
+                tableEnvironment
+                        .toDataStream(resultTable)
+                        .map(row -> (String) row.getField("word"))
+                        .returns(TypeInformation.of(String.class))
+                        .map(s -> new Tuple2<String, Integer>(s, 1))
+                        .returns(TypeInformation.of(new TypeHint<Tuple2<String, Integer>>() {}))
+                        .keyBy(tuple -> tuple.f0)
+                        .sum(1);
+
+        testResult(
+                resultStream,
+                new Tuple2<String, Integer>("ALICE", 2),
+                new Tuple2<String, Integer>("BOB", 1),
+                new Tuple2<String, Integer>("LILY", 3));
     }
 
     @Test

--- a/flink-table/flink-table-runtime/src/main/java/org/apache/flink/table/runtime/operators/source/InputConversionOperator.java
+++ b/flink-table/flink-table-runtime/src/main/java/org/apache/flink/table/runtime/operators/source/InputConversionOperator.java
@@ -78,7 +78,7 @@ public final class InputConversionOperator<E> extends TableStreamOperator<RowDat
 
     @Override
     public void processWatermark(Watermark mark) throws Exception {
-        if (propagateWatermark) {
+        if (propagateWatermark || Watermark.MAX_WATERMARK.equals(mark)) {
             super.processWatermark(mark);
         }
     }

--- a/flink-table/flink-table-runtime/src/test/java/org/apache/flink/table/runtime/operators/source/InputConversionOperatorTest.java
+++ b/flink-table/flink-table-runtime/src/test/java/org/apache/flink/table/runtime/operators/source/InputConversionOperatorTest.java
@@ -98,6 +98,20 @@ public class InputConversionOperatorTest {
         operator.processWatermark(new Watermark(1000));
     }
 
+    @Test(expected = NullPointerException.class)
+    public void testReceiveMaxWatermark() throws Exception {
+        final InputConversionOperator<Row> operator =
+                new InputConversionOperator<>(
+                        createConverter(DataTypes.ROW(DataTypes.FIELD("f", DataTypes.INT()))),
+                        false,
+                        false,
+                        false,
+                        true);
+
+        // would throw an exception because it always emits Watermark.MAX_WATERMARK
+        operator.processWatermark(Watermark.MAX_WATERMARK);
+    }
+
     private static DynamicTableSource.DataStructureConverter createConverter(DataType dataType) {
         final DataStructureConverter<Object, Object> converter =
                 DataStructureConverters.getConverter(dataType);


### PR DESCRIPTION
…Stream then window process in batch mode

## What is the purpose of the change

Changed InputConversionOperator#processWatermark, making it to processing Watermark.MAX_WATERMARK unconditionally.

## Brief change log

- flink-table/flink-table-runtime/src/main/java/org/apache/flink/table/runtime/operators/source/InputConversionOperator.java
- flink-table/flink-table-planner/src/test/java/org/apache/flink/table/planner/runtime/stream/sql/DataStreamJavaITCase.java
- flink-table/flink-table-runtime/src/test/java/org/apache/flink/table/runtime/operators/source/InputConversionOperatorTest.java

## Verifying this change

This change added tests and can be verified as follows:

- Added test that verifies InputConversionOperator#processWatermark processes Watermark.MAX_WATERMARK.
- Added test that ensures that no data is missing when it runs in batch mode using stream API to read data from Flink table.

## Does this pull request potentially affect one of the following parts:

  - Dependencies (does it add or upgrade a dependency): no
  - The public API, i.e., is any changed class annotated with `@Public(Evolving)`: no
  - The serializers: no
  - The runtime per-record code paths (performance sensitive): no
  - Anything that affects deployment or recovery: JobManager (and its components), Checkpointing, Kubernetes/Yarn, ZooKeeper: no
  - The S3 file system connector: no

## Documentation

  - Does this pull request introduce a new feature? no
