### PR TITLE
[FLINK-25686][pulsar]: add schema evolution support for pulsar source connector

### DIFF
--- a/docs/content.zh/docs/connectors/datastream/pulsar.md
+++ b/docs/content.zh/docs/connectors/datastream/pulsar.md
@@ -155,6 +155,19 @@ Pulsar Source 提供了两种订阅 Topic 或 Topic 分区的方式。
   PulsarDeserializationSchema.flinkTypeInfo(TypeInformation, ExecutionConfig);
   ```
 
+如果使用 KeyValue 或者 Struct 类型的Schema, 那么 pulsar `Schema` 讲不会含有类型类信息， 但 `PulsarSchemaTypeInformation` 需要通过传入类型类信息来构造。因此我们提供的API支持用户传入类型类信息。
+
+例子如下:
+
+```java
+  // Primitive 类型: 不需要提供类型信息
+  PulsarDeserializationSchema.pulsarSchema(Schema.INT32);
+  // Struct 类型 (JSON, Protobuf, Avro, 等等.)
+  PulsarDeserializationSchema.pulsarSchema(Schema.AVRO(SomeClass), SomeClass.class);
+  // KeyValue 类型
+  PulsarDeserializationSchema.pulsarSchema(Schema.KeyValue(Schema.INT32, Schema.AVRO(SomeClass)), Integer.class, SomeClass.class);
+```
+
 Pulsar 的 `Message<byte[]>` 包含了很多 [额外的属性](https://pulsar.apache.org/docs/zh-CN/concepts-messaging/#%E6%B6%88%E6%81%AF)。例如，消息的 key、消息发送时间、消息生产时间、用户在消息上自定义的键值对属性等。可以使用 `Message<byte[]>` 接口来获取这些属性。
 
 如果用户需要基于这些额外的属性来解析一条消息，可以实现 `PulsarDeserializationSchema` 接口。并一定要确保 `PulsarDeserializationSchema.getProducedType()` 方法返回的 `TypeInformation` 是正确的结果。Flink 使用 `TypeInformation` 将解析出来的结果序列化传递到下游算子。

--- a/docs/content/docs/connectors/datastream/pulsar.md
+++ b/docs/content/docs/connectors/datastream/pulsar.md
@@ -176,6 +176,21 @@ you can use the predefined `PulsarDeserializationSchema`. Pulsar connector provi
   ```java
   PulsarDeserializationSchema.flinkTypeInfo(TypeInformation, ExecutionConfig);
   ```
+If using KeyValue type or Struct types, the pulsar `Schema` does not contain type class info which is 
+needed by `PulsarSchemaTypeInformation`. So the two APIs provides 2 parameter to pass the type info.
+
+A example would be:
+
+```java
+  // Primitive types: do not need to provide type class info
+  PulsarDeserializationSchema.pulsarSchema(Schema.INT32);
+
+  // Struct types (JSON, Protobuf, Avro, etc.)
+  PulsarDeserializationSchema.pulsarSchema(Schema.AVRO(SomeClass), SomeClass.class);
+
+  // KeyValue type
+  PulsarDeserializationSchema.pulsarSchema(Schema.KeyValue(Schema.INT32, Schema.AVRO(SomeClass)), Integer.class, SomeClass.class);
+```
 
 Pulsar `Message<byte[]>` contains some [extra properties](https://pulsar.apache.org/docs/en/concepts-messaging/#messages),
 such as message key, message publish time, message time, and application-defined key/value pairs etc.

--- a/docs/layouts/shortcodes/generated/pulsar_source_configuration.html
+++ b/docs/layouts/shortcodes/generated/pulsar_source_configuration.html
@@ -21,6 +21,12 @@
             <td>Flink commits the consuming position with pulsar transactions on checkpoint. However, if you have disabled the Flink checkpoint or disabled transaction for your Pulsar cluster, ensure that you have set this option to <code class="highlighter-rouge">true</code>.<br />The source would use pulsar client's internal mechanism and commit cursor in two ways.<ul><li>For <code class="highlighter-rouge">Key_Shared</code> and <code class="highlighter-rouge">Shared</code> subscription, the cursor would be committed once the message is consumed.</li><li>For <code class="highlighter-rouge">Exclusive</code> and <code class="highlighter-rouge">Failover</code> subscription, the cursor would be committed in a given interval.</li></ul></td>
         </tr>
         <tr>
+            <td><h5>pulsar.source.enableSchemaEvolution</h5></td>
+            <td style="word-wrap: break-word;">false</td>
+            <td>Boolean</td>
+            <td>If you enable this option, we would consume and deserialize the message by using Pulsar's <code class="highlighter-rouge">Schema</code>.</td>
+        </tr>
+        <tr>
             <td><h5>pulsar.source.maxFetchRecords</h5></td>
             <td style="word-wrap: break-word;">100</td>
             <td>Integer</td>

--- a/flink-connectors/flink-connector-pulsar/src/main/java/org/apache/flink/connector/pulsar/common/schema/factories/AvroSchemaFactory.java
+++ b/flink-connectors/flink-connector-pulsar/src/main/java/org/apache/flink/connector/pulsar/common/schema/factories/AvroSchemaFactory.java
@@ -18,6 +18,9 @@
 
 package org.apache.flink.connector.pulsar.common.schema.factories;
 
+import org.apache.flink.api.common.typeinfo.TypeInformation;
+import org.apache.flink.api.java.typeutils.AvroUtils;
+
 import org.apache.pulsar.client.api.Schema;
 import org.apache.pulsar.client.api.schema.SchemaDefinition;
 import org.apache.pulsar.client.impl.schema.AvroSchema;
@@ -44,5 +47,15 @@ public class AvroSchemaFactory<T> extends BaseStructSchemaFactory<T> {
                         .build();
 
         return AvroSchema.of(definition);
+    }
+
+    @Override
+    public TypeInformation<T> createTypeInfo(SchemaInfo info) {
+        try {
+            Class<T> decodeClassInfo = decodeClassInfo(info);
+            return AvroUtils.getAvroUtils().createAvroTypeInfo(decodeClassInfo);
+        } catch (Exception e) {
+            return super.createTypeInfo(info);
+        }
     }
 }

--- a/flink-connectors/flink-connector-pulsar/src/main/java/org/apache/flink/connector/pulsar/common/schema/factories/JSONSchemaFactory.java
+++ b/flink-connectors/flink-connector-pulsar/src/main/java/org/apache/flink/connector/pulsar/common/schema/factories/JSONSchemaFactory.java
@@ -18,6 +18,9 @@
 
 package org.apache.flink.connector.pulsar.common.schema.factories;
 
+import org.apache.flink.api.common.typeinfo.TypeInformation;
+import org.apache.flink.api.java.typeutils.AvroUtils;
+
 import org.apache.pulsar.client.api.Schema;
 import org.apache.pulsar.client.impl.schema.JSONSchema;
 import org.apache.pulsar.common.schema.SchemaInfo;
@@ -37,5 +40,15 @@ public class JSONSchemaFactory<T> extends BaseStructSchemaFactory<T> {
     public Schema<T> createSchema(SchemaInfo info) {
         Class<T> typeClass = decodeClassInfo(info);
         return JSONSchema.of(typeClass, info.getProperties());
+    }
+
+    @Override
+    public TypeInformation<T> createTypeInfo(SchemaInfo info) {
+        try {
+            Class<T> decodeClassInfo = decodeClassInfo(info);
+            return AvroUtils.getAvroUtils().createAvroTypeInfo(decodeClassInfo);
+        } catch (Exception e) {
+            return super.createTypeInfo(info);
+        }
     }
 }

--- a/flink-connectors/flink-connector-pulsar/src/main/java/org/apache/flink/connector/pulsar/common/schema/factories/KeyValueSchemaFactory.java
+++ b/flink-connectors/flink-connector-pulsar/src/main/java/org/apache/flink/connector/pulsar/common/schema/factories/KeyValueSchemaFactory.java
@@ -69,11 +69,8 @@ public class KeyValueSchemaFactory<K, V> implements PulsarSchemaFactory<KeyValue
     public TypeInformation<KeyValue<K, V>> createTypeInfo(SchemaInfo info) {
         KeyValue<SchemaInfo, SchemaInfo> kvSchemaInfo = decodeKeyValueSchemaInfo(info);
 
-        Schema<K> keySchema = PulsarSchemaUtils.createSchema(kvSchemaInfo.getKey());
-        Class<K> keyClass = decodeClassInfo(keySchema.getSchemaInfo());
-
-        Schema<V> valueSchema = PulsarSchemaUtils.createSchema(kvSchemaInfo.getValue());
-        Class<V> valueClass = decodeClassInfo(valueSchema.getSchemaInfo());
+        Class<K> keyClass = decodeClassInfo(kvSchemaInfo.getKey());
+        Class<V> valueClass = decodeClassInfo(kvSchemaInfo.getValue());
 
         Schema<KeyValue<K, V>> schema = createSchema(info);
         PulsarSchema<KeyValue<K, V>> pulsarSchema =

--- a/flink-connectors/flink-connector-pulsar/src/main/java/org/apache/flink/connector/pulsar/source/PulsarSourceOptions.java
+++ b/flink-connectors/flink-connector-pulsar/src/main/java/org/apache/flink/connector/pulsar/source/PulsarSourceOptions.java
@@ -188,6 +188,17 @@ public final class PulsarSourceOptions {
                                             " A possible solution is to adjust the retention settings in Pulsar or ignoring the check result.")
                                     .build());
 
+    public static final ConfigOption<Boolean> PULSAR_READ_SCHEMA_EVOLUTION =
+            ConfigOptions.key(SOURCE_CONFIG_PREFIX + "enableSchemaEvolution")
+                    .booleanType()
+                    .defaultValue(false)
+                    .withDescription(
+                            Description.builder()
+                                    .text(
+                                            "If you enable this option, we would consume and deserialize the message by using Pulsar's %s.",
+                                            code("Schema"))
+                                    .build());
+
     ///////////////////////////////////////////////////////////////////////////////
     //
     // The configuration for ConsumerConfigurationData part.

--- a/flink-connectors/flink-connector-pulsar/src/main/java/org/apache/flink/connector/pulsar/source/config/SourceConfiguration.java
+++ b/flink-connectors/flink-connector-pulsar/src/main/java/org/apache/flink/connector/pulsar/source/config/SourceConfiguration.java
@@ -23,10 +23,12 @@ import org.apache.flink.api.connector.source.SourceReaderContext;
 import org.apache.flink.configuration.Configuration;
 import org.apache.flink.connector.base.source.reader.RecordsWithSplitIds;
 import org.apache.flink.connector.pulsar.common.config.PulsarConfiguration;
+import org.apache.flink.connector.pulsar.sink.writer.serializer.PulsarSchemaWrapper;
 import org.apache.flink.connector.pulsar.source.enumerator.cursor.CursorPosition;
 import org.apache.flink.connector.pulsar.source.enumerator.cursor.StartCursor;
 
 import org.apache.pulsar.client.api.ConsumerBuilder;
+import org.apache.pulsar.client.api.Schema;
 import org.apache.pulsar.client.api.SubscriptionMode;
 import org.apache.pulsar.client.api.SubscriptionType;
 
@@ -39,6 +41,7 @@ import static org.apache.flink.connector.pulsar.source.PulsarSourceOptions.PULSA
 import static org.apache.flink.connector.pulsar.source.PulsarSourceOptions.PULSAR_MAX_FETCH_RECORDS;
 import static org.apache.flink.connector.pulsar.source.PulsarSourceOptions.PULSAR_MAX_FETCH_TIME;
 import static org.apache.flink.connector.pulsar.source.PulsarSourceOptions.PULSAR_PARTITION_DISCOVERY_INTERVAL_MS;
+import static org.apache.flink.connector.pulsar.source.PulsarSourceOptions.PULSAR_READ_SCHEMA_EVOLUTION;
 import static org.apache.flink.connector.pulsar.source.PulsarSourceOptions.PULSAR_READ_TRANSACTION_TIMEOUT;
 import static org.apache.flink.connector.pulsar.source.PulsarSourceOptions.PULSAR_SUBSCRIPTION_MODE;
 import static org.apache.flink.connector.pulsar.source.PulsarSourceOptions.PULSAR_SUBSCRIPTION_NAME;
@@ -53,6 +56,7 @@ public class SourceConfiguration extends PulsarConfiguration {
     private final int messageQueueCapacity;
     private final long partitionDiscoveryIntervalMs;
     private final boolean enableAutoAcknowledgeMessage;
+    private final boolean enableSchemaEvolution;
     private final long autoCommitCursorInterval;
     private final long transactionTimeoutMillis;
     private final Duration maxFetchTime;
@@ -68,6 +72,7 @@ public class SourceConfiguration extends PulsarConfiguration {
         this.messageQueueCapacity = getInteger(ELEMENT_QUEUE_CAPACITY);
         this.partitionDiscoveryIntervalMs = get(PULSAR_PARTITION_DISCOVERY_INTERVAL_MS);
         this.enableAutoAcknowledgeMessage = get(PULSAR_ENABLE_AUTO_ACKNOWLEDGE_MESSAGE);
+        this.enableSchemaEvolution = get(PULSAR_READ_SCHEMA_EVOLUTION);
         this.autoCommitCursorInterval = get(PULSAR_AUTO_COMMIT_CURSOR_INTERVAL);
         this.transactionTimeoutMillis = get(PULSAR_READ_TRANSACTION_TIMEOUT);
         this.maxFetchTime = get(PULSAR_MAX_FETCH_TIME, Duration::ofMillis);
@@ -105,6 +110,14 @@ public class SourceConfiguration extends PulsarConfiguration {
      */
     public boolean isEnableAutoAcknowledgeMessage() {
         return enableAutoAcknowledgeMessage;
+    }
+
+    /**
+     * If we should deserialize the message with a specified Pulsar {@link Schema} instead the
+     * default {@link Schema#BYTES}. This switch is only used for {@link PulsarSchemaWrapper}.
+     */
+    public boolean isEnableSchemaEvolution() {
+        return enableSchemaEvolution;
     }
 
     /**

--- a/flink-connectors/flink-connector-pulsar/src/main/java/org/apache/flink/connector/pulsar/source/enumerator/subscriber/impl/BasePulsarSubscriber.java
+++ b/flink-connectors/flink-connector-pulsar/src/main/java/org/apache/flink/connector/pulsar/source/enumerator/subscriber/impl/BasePulsarSubscriber.java
@@ -20,7 +20,6 @@ package org.apache.flink.connector.pulsar.source.enumerator.subscriber.impl;
 
 import org.apache.flink.connector.pulsar.source.enumerator.subscriber.PulsarSubscriber;
 import org.apache.flink.connector.pulsar.source.enumerator.topic.TopicMetadata;
-import org.apache.flink.connector.pulsar.source.enumerator.topic.TopicNameUtils;
 import org.apache.flink.connector.pulsar.source.enumerator.topic.TopicPartition;
 import org.apache.flink.connector.pulsar.source.enumerator.topic.TopicRange;
 
@@ -32,6 +31,7 @@ import java.util.ArrayList;
 import java.util.List;
 
 import static java.util.stream.Collectors.toList;
+import static org.apache.flink.connector.pulsar.source.enumerator.topic.TopicNameUtils.topicName;
 
 /** PulsarSubscriber abstract class to simplify Pulsar admin related operations. */
 public abstract class BasePulsarSubscriber implements PulsarSubscriber {
@@ -39,7 +39,7 @@ public abstract class BasePulsarSubscriber implements PulsarSubscriber {
 
     protected TopicMetadata queryTopicMetadata(PulsarAdmin pulsarAdmin, String topicName) {
         // Drop the complete topic name for a clean partitioned topic name.
-        String completeTopicName = TopicNameUtils.topicName(topicName);
+        String completeTopicName = topicName(topicName);
         try {
             PartitionedTopicMetadata metadata =
                     pulsarAdmin.topics().getPartitionedTopicMetadata(completeTopicName);

--- a/flink-connectors/flink-connector-pulsar/src/main/java/org/apache/flink/connector/pulsar/source/reader/deserializer/PulsarDeserializationSchema.java
+++ b/flink-connectors/flink-connector-pulsar/src/main/java/org/apache/flink/connector/pulsar/source/reader/deserializer/PulsarDeserializationSchema.java
@@ -76,7 +76,13 @@ public interface PulsarDeserializationSchema<T> extends Serializable, ResultType
      * @param message The message decoded by pulsar.
      * @param out The collector to put the resulting messages.
      */
-    void deserialize(Message<byte[]> message, Collector<T> out) throws Exception;
+    void deserialize(Message<?> message, Collector<T> out) throws Exception;
+
+    /** @return The related Pulsar Schema for this serializer. */
+    default Schema<T> schema() {
+        throw new UnsupportedOperationException(
+                "Implement this method if you need Pulsar schema evolution.");
+    }
 
     /**
      * Create a PulsarDeserializationSchema by using the flink's {@link DeserializationSchema}. It

--- a/flink-connectors/flink-connector-pulsar/src/main/java/org/apache/flink/connector/pulsar/source/reader/deserializer/PulsarDeserializationSchema.java
+++ b/flink-connectors/flink-connector-pulsar/src/main/java/org/apache/flink/connector/pulsar/source/reader/deserializer/PulsarDeserializationSchema.java
@@ -78,10 +78,13 @@ public interface PulsarDeserializationSchema<T> extends Serializable, ResultType
      */
     void deserialize(Message<?> message, Collector<T> out) throws Exception;
 
-    /** @return The related Pulsar Schema for this serializer. */
-    default Schema<T> schema() {
-        throw new UnsupportedOperationException(
-                "Implement this method if you need Pulsar schema evolution.");
+    /**
+     * By default, deserializers will decode bytes array message.
+     *
+     * @return The related Pulsar Schema for this serializer.
+     */
+    default Schema<?> schema() {
+        return Schema.BYTES;
     }
 
     /**

--- a/flink-connectors/flink-connector-pulsar/src/main/java/org/apache/flink/connector/pulsar/source/reader/deserializer/PulsarDeserializationSchemaWrapper.java
+++ b/flink-connectors/flink-connector-pulsar/src/main/java/org/apache/flink/connector/pulsar/source/reader/deserializer/PulsarDeserializationSchemaWrapper.java
@@ -52,7 +52,7 @@ class PulsarDeserializationSchemaWrapper<T> implements PulsarDeserializationSche
     }
 
     @Override
-    public void deserialize(Message<byte[]> message, Collector<T> out) throws Exception {
+    public void deserialize(Message<?> message, Collector<T> out) throws Exception {
         byte[] bytes = message.getData();
         T instance = deserializationSchema.deserialize(bytes);
 

--- a/flink-connectors/flink-connector-pulsar/src/main/java/org/apache/flink/connector/pulsar/source/reader/deserializer/PulsarDeserializationSchemaWrapper.java
+++ b/flink-connectors/flink-connector-pulsar/src/main/java/org/apache/flink/connector/pulsar/source/reader/deserializer/PulsarDeserializationSchemaWrapper.java
@@ -55,7 +55,6 @@ class PulsarDeserializationSchemaWrapper<T> implements PulsarDeserializationSche
     public void deserialize(Message<?> message, Collector<T> out) throws Exception {
         byte[] bytes = message.getData();
         T instance = deserializationSchema.deserialize(bytes);
-
         out.collect(instance);
     }
 

--- a/flink-connectors/flink-connector-pulsar/src/main/java/org/apache/flink/connector/pulsar/source/reader/deserializer/PulsarSchemaWrapper.java
+++ b/flink-connectors/flink-connector-pulsar/src/main/java/org/apache/flink/connector/pulsar/source/reader/deserializer/PulsarSchemaWrapper.java
@@ -46,7 +46,7 @@ class PulsarSchemaWrapper<T> implements PulsarDeserializationSchema<T> {
     }
 
     @Override
-    public void deserialize(Message<byte[]> message, Collector<T> out) throws Exception {
+    public void deserialize(Message<?> message, Collector<T> out) throws Exception {
         Schema<T> schema = this.pulsarSchema.getPulsarSchema();
         byte[] bytes = message.getData();
         T instance = schema.decode(bytes);
@@ -58,5 +58,10 @@ class PulsarSchemaWrapper<T> implements PulsarDeserializationSchema<T> {
     public TypeInformation<T> getProducedType() {
         SchemaInfo info = pulsarSchema.getSchemaInfo();
         return createTypeInformation(info);
+    }
+
+    @Override
+    public Schema<T> schema() {
+        return pulsarSchema.getPulsarSchema();
     }
 }

--- a/flink-connectors/flink-connector-pulsar/src/main/java/org/apache/flink/connector/pulsar/source/reader/deserializer/PulsarSchemaWrapper.java
+++ b/flink-connectors/flink-connector-pulsar/src/main/java/org/apache/flink/connector/pulsar/source/reader/deserializer/PulsarSchemaWrapper.java
@@ -18,8 +18,10 @@
 package org.apache.flink.connector.pulsar.source.reader.deserializer;
 
 import org.apache.flink.annotation.Internal;
+import org.apache.flink.api.common.serialization.DeserializationSchema;
 import org.apache.flink.api.common.typeinfo.TypeInformation;
 import org.apache.flink.connector.pulsar.common.schema.PulsarSchema;
+import org.apache.flink.connector.pulsar.source.config.SourceConfiguration;
 import org.apache.flink.util.Collector;
 
 import org.apache.pulsar.client.api.Message;
@@ -41,17 +43,31 @@ class PulsarSchemaWrapper<T> implements PulsarDeserializationSchema<T> {
     /** The serializable pulsar schema, it wrap the schema with type class. */
     private final PulsarSchema<T> pulsarSchema;
 
+    private boolean isSchemaEvolutionEnabled;
+
     public PulsarSchemaWrapper(PulsarSchema<T> pulsarSchema) {
         this.pulsarSchema = pulsarSchema;
     }
 
     @Override
-    public void deserialize(Message<?> message, Collector<T> out) throws Exception {
-        Schema<T> schema = this.pulsarSchema.getPulsarSchema();
-        byte[] bytes = message.getData();
-        T instance = schema.decode(bytes);
+    public void open(
+            DeserializationSchema.InitializationContext context, SourceConfiguration configuration)
+            throws Exception {
+        this.isSchemaEvolutionEnabled = configuration.isEnableSchemaEvolution();
+    }
 
-        out.collect(instance);
+    @Override
+    public void deserialize(Message<?> message, Collector<T> out) throws Exception {
+        if (isSchemaEvolutionEnabled) {
+            @SuppressWarnings("unchecked")
+            T value = (T) message.getValue();
+            out.collect(value);
+        } else {
+            Schema<T> schema = this.pulsarSchema.getPulsarSchema();
+            byte[] bytes = message.getData();
+            T instance = schema.decode(bytes);
+            out.collect(instance);
+        }
     }
 
     @Override
@@ -61,7 +77,11 @@ class PulsarSchemaWrapper<T> implements PulsarDeserializationSchema<T> {
     }
 
     @Override
-    public Schema<T> schema() {
-        return pulsarSchema.getPulsarSchema();
+    public Schema<?> schema() {
+        if (isSchemaEvolutionEnabled) {
+            return pulsarSchema.getPulsarSchema();
+        } else {
+            return Schema.BYTES;
+        }
     }
 }

--- a/flink-connectors/flink-connector-pulsar/src/main/java/org/apache/flink/connector/pulsar/source/reader/deserializer/PulsarTypeInformationWrapper.java
+++ b/flink-connectors/flink-connector-pulsar/src/main/java/org/apache/flink/connector/pulsar/source/reader/deserializer/PulsarTypeInformationWrapper.java
@@ -51,7 +51,7 @@ public class PulsarTypeInformationWrapper<T> implements PulsarDeserializationSch
     }
 
     @Override
-    public void deserialize(Message<byte[]> message, Collector<T> out) throws Exception {
+    public void deserialize(Message<?> message, Collector<T> out) throws Exception {
         DataInputDeserializer dis = DESERIALIZER.get();
         dis.setBuffer(message.getData());
         T instance = serializer.deserialize(dis);

--- a/flink-connectors/flink-connector-pulsar/src/main/java/org/apache/flink/connector/pulsar/source/reader/split/PulsarOrderedPartitionSplitReader.java
+++ b/flink-connectors/flink-connector-pulsar/src/main/java/org/apache/flink/connector/pulsar/source/reader/split/PulsarOrderedPartitionSplitReader.java
@@ -61,12 +61,12 @@ public class PulsarOrderedPartitionSplitReader<OUT> extends PulsarPartitionSplit
     }
 
     @Override
-    protected Message<byte[]> pollMessage(Duration timeout) throws PulsarClientException {
+    protected Message<?> pollMessage(Duration timeout) throws PulsarClientException {
         return pulsarConsumer.receive(Math.toIntExact(timeout.toMillis()), TimeUnit.MILLISECONDS);
     }
 
     @Override
-    protected void finishedPollMessage(Message<byte[]> message) {
+    protected void finishedPollMessage(Message<?> message) {
         // Nothing to do here.
         LOG.debug("Finished polling message {}", message);
 
@@ -75,7 +75,7 @@ public class PulsarOrderedPartitionSplitReader<OUT> extends PulsarPartitionSplit
     }
 
     @Override
-    protected void startConsumer(PulsarPartitionSplit split, Consumer<byte[]> consumer) {
+    protected void startConsumer(PulsarPartitionSplit split, Consumer<?> consumer) {
         MessageId latestConsumedId = split.getLatestConsumedId();
 
         // Reset the start position for ordered pulsar consumer.

--- a/flink-connectors/flink-connector-pulsar/src/main/java/org/apache/flink/connector/pulsar/source/reader/split/PulsarPartitionSplitReaderBase.java
+++ b/flink-connectors/flink-connector-pulsar/src/main/java/org/apache/flink/connector/pulsar/source/reader/split/PulsarPartitionSplitReaderBase.java
@@ -120,13 +120,7 @@ abstract class PulsarPartitionSplitReaderBase<OUT>
                 collector.setMessage(message);
 
                 // Deserialize message by DeserializationSchema or Pulsar Schema.
-                if (sourceConfiguration.isEnableSchemaEvolution()) {
-                    @SuppressWarnings("unchecked")
-                    OUT value = (OUT) message.getValue();
-                    collector.collect(value);
-                } else {
-                    deserializationSchema.deserialize(message, collector);
-                }
+                deserializationSchema.deserialize(message, collector);
 
                 // Acknowledge message if needed.
                 finishedPollMessage(message);
@@ -221,12 +215,7 @@ abstract class PulsarPartitionSplitReaderBase<OUT>
     }
 
     protected Consumer<?> createPulsarConsumer(TopicPartition partition) {
-        Schema<?> schema;
-        if (sourceConfiguration.isEnableSchemaEvolution()) {
-            schema = deserializationSchema.schema();
-        } else {
-            schema = Schema.BYTES;
-        }
+        Schema<?> schema = deserializationSchema.schema();
 
         ConsumerBuilder<?> consumerBuilder =
                 createConsumerBuilder(pulsarClient, schema, sourceConfiguration);

--- a/flink-connectors/flink-connector-pulsar/src/main/java/org/apache/flink/connector/pulsar/source/reader/split/PulsarUnorderedPartitionSplitReader.java
+++ b/flink-connectors/flink-connector-pulsar/src/main/java/org/apache/flink/connector/pulsar/source/reader/split/PulsarUnorderedPartitionSplitReader.java
@@ -75,9 +75,9 @@ public class PulsarUnorderedPartitionSplitReader<OUT> extends PulsarPartitionSpl
     }
 
     @Override
-    protected Message<byte[]> pollMessage(Duration timeout)
+    protected Message<?> pollMessage(Duration timeout)
             throws ExecutionException, InterruptedException, PulsarClientException {
-        Message<byte[]> message =
+        Message<?> message =
                 pulsarConsumer.receive(Math.toIntExact(timeout.toMillis()), TimeUnit.MILLISECONDS);
 
         // Skip the message when receive timeout
@@ -116,7 +116,7 @@ public class PulsarUnorderedPartitionSplitReader<OUT> extends PulsarPartitionSpl
     }
 
     @Override
-    protected void finishedPollMessage(Message<byte[]> message) {
+    protected void finishedPollMessage(Message<?> message) {
         if (sourceConfiguration.isEnableAutoAcknowledgeMessage()) {
             sneakyClient(() -> pulsarConsumer.acknowledge(message));
         }
@@ -126,7 +126,7 @@ public class PulsarUnorderedPartitionSplitReader<OUT> extends PulsarPartitionSpl
     }
 
     @Override
-    protected void startConsumer(PulsarPartitionSplit split, Consumer<byte[]> consumer) {
+    protected void startConsumer(PulsarPartitionSplit split, Consumer<?> consumer) {
         TxnID uncommittedTransactionId = split.getUncommittedTransactionId();
 
         // Abort the uncommitted pulsar transaction.

--- a/flink-connectors/flink-connector-pulsar/src/test/java/org/apache/flink/connector/pulsar/common/schema/factories/JSONSchemaFactoryTest.java
+++ b/flink-connectors/flink-connector-pulsar/src/test/java/org/apache/flink/connector/pulsar/common/schema/factories/JSONSchemaFactoryTest.java
@@ -20,9 +20,9 @@ package org.apache.flink.connector.pulsar.common.schema.factories;
 
 import org.apache.flink.api.common.typeinfo.TypeInformation;
 import org.apache.flink.connector.pulsar.common.schema.PulsarSchema;
-import org.apache.flink.connector.pulsar.common.schema.PulsarSchemaTypeInformation;
 import org.apache.flink.connector.pulsar.testutils.SampleData.FL;
 import org.apache.flink.connector.pulsar.testutils.SampleData.Foo;
+import org.apache.flink.formats.avro.typeutils.AvroTypeInfo;
 import org.apache.flink.util.InstantiationUtil;
 
 import org.apache.pulsar.client.api.Schema;
@@ -62,7 +62,7 @@ class JSONSchemaFactoryTest {
         TypeInformation<FL> typeInfo = factory.createTypeInfo(pulsarSchema.getSchemaInfo());
 
         assertThat(typeInfo)
-                .isInstanceOf(PulsarSchemaTypeInformation.class)
+                .isInstanceOf(AvroTypeInfo.class)
                 .hasFieldOrPropertyWithValue("typeClass", FL.class);
 
         // TypeInformation serialization.

--- a/flink-connectors/flink-connector-pulsar/src/test/java/org/apache/flink/connector/pulsar/source/reader/deserializer/PulsarDeserializationSchemaTest.java
+++ b/flink-connectors/flink-connector-pulsar/src/test/java/org/apache/flink/connector/pulsar/source/reader/deserializer/PulsarDeserializationSchemaTest.java
@@ -18,13 +18,21 @@
 
 package org.apache.flink.connector.pulsar.source.reader.deserializer;
 
+import org.apache.flink.api.common.eventtime.WatermarkStrategy;
 import org.apache.flink.api.common.serialization.SimpleStringSchema;
 import org.apache.flink.api.common.typeinfo.Types;
 import org.apache.flink.connector.pulsar.SampleMessage.TestMessage;
+import org.apache.flink.connector.pulsar.source.PulsarSource;
+import org.apache.flink.connector.pulsar.source.PulsarSourceOptions;
 import org.apache.flink.connector.pulsar.source.config.SourceConfiguration;
+import org.apache.flink.connector.pulsar.source.enumerator.cursor.StopCursor;
+import org.apache.flink.connector.pulsar.source.enumerator.topic.TopicNameUtils;
+import org.apache.flink.connector.pulsar.testutils.PulsarTestSuiteBase;
 import org.apache.flink.connector.testutils.source.deserialization.TestingDeserializationContext;
 import org.apache.flink.core.memory.DataOutputSerializer;
+import org.apache.flink.streaming.api.environment.StreamExecutionEnvironment;
 import org.apache.flink.types.StringValue;
+import org.apache.flink.util.CloseableIterator;
 import org.apache.flink.util.Collector;
 import org.apache.flink.util.InstantiationUtil;
 import org.apache.flink.util.function.FunctionWithException;
@@ -33,9 +41,12 @@ import org.apache.pulsar.client.api.Message;
 import org.apache.pulsar.client.api.Schema;
 import org.apache.pulsar.client.impl.MessageImpl;
 import org.apache.pulsar.common.api.proto.MessageMetadata;
+import org.apache.pulsar.common.schema.KeyValue;
 import org.junit.jupiter.api.Test;
 
+import java.io.Serializable;
 import java.nio.ByteBuffer;
+import java.util.Objects;
 import java.util.concurrent.ThreadLocalRandom;
 
 import static org.apache.commons.lang3.RandomStringUtils.randomAlphabetic;
@@ -44,13 +55,16 @@ import static org.apache.flink.connector.pulsar.source.reader.deserializer.Pulsa
 import static org.apache.flink.connector.pulsar.source.reader.deserializer.PulsarDeserializationSchema.pulsarSchema;
 import static org.apache.flink.util.Preconditions.checkState;
 import static org.apache.pulsar.client.api.Schema.PROTOBUF_NATIVE;
+import static org.apache.pulsar.client.api.SubscriptionType.Exclusive;
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatCode;
 import static org.junit.jupiter.api.Assertions.assertDoesNotThrow;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertNotNull;
 import static org.mockito.Mockito.mock;
 
 /** Unit tests for {@link PulsarDeserializationSchema}. */
-class PulsarDeserializationSchemaTest {
+class PulsarDeserializationSchemaTest extends PulsarTestSuiteBase {
 
     @Test
     void createFromFlinkDeserializationSchema() throws Exception {
@@ -106,6 +120,243 @@ class PulsarDeserializationSchemaTest {
 
         assertNotNull(collector.result);
         assertEquals(collector.result, "test-content");
+    }
+
+    @Test
+    void primitiveStringPulsarSchema() {
+        final String topicName =
+                "primitiveString-" + ThreadLocalRandom.current().nextLong(0, Long.MAX_VALUE);
+        operator().createTopic(topicName, 1);
+        String expectedMessage = randomAlphabetic(10);
+        operator()
+                .sendMessage(
+                        TopicNameUtils.topicNameWithPartition(topicName, 0),
+                        Schema.STRING,
+                        expectedMessage);
+        PulsarSource<String> source = createSource(topicName, pulsarSchema(Schema.STRING));
+        assertThatCode(() -> runPipeline(source, expectedMessage)).doesNotThrowAnyException();
+    }
+
+    @Test
+    void unversionedJsonStructPulsarSchema() {
+        final String topicName =
+                "unversionedJsonStruct-" + ThreadLocalRandom.current().nextLong(0, Long.MAX_VALUE);
+        operator().createTopic(topicName, 1);
+        TestingUser expectedMessage = createRandomUser();
+        operator()
+                .sendMessage(
+                        TopicNameUtils.topicNameWithPartition(topicName, 0),
+                        Schema.JSON(TestingUser.class),
+                        expectedMessage);
+        PulsarSource<TestingUser> source =
+                createSource(
+                        topicName, pulsarSchema(Schema.JSON(TestingUser.class), TestingUser.class));
+        assertThatCode(() -> runPipeline(source, expectedMessage)).doesNotThrowAnyException();
+    }
+
+    @Test
+    void keyValueJsonStructPulsarSchema() {
+        final String topicName =
+                "keyValueJsonStruct-" + ThreadLocalRandom.current().nextLong(0, Long.MAX_VALUE);
+        operator().createTopic(topicName, 1);
+        KeyValue<TestingUser, TestingUser> expectedMessage =
+                new KeyValue<>(createRandomUser(), createRandomUser());
+        operator()
+                .sendMessage(
+                        TopicNameUtils.topicNameWithPartition(topicName, 0),
+                        Schema.KeyValue(
+                                Schema.JSON(TestingUser.class), Schema.JSON(TestingUser.class)),
+                        expectedMessage);
+        PulsarSource<KeyValue<TestingUser, TestingUser>> source =
+                createSource(
+                        topicName,
+                        pulsarSchema(
+                                Schema.KeyValue(
+                                        Schema.JSON(TestingUser.class),
+                                        Schema.JSON(TestingUser.class)),
+                                TestingUser.class,
+                                TestingUser.class));
+        assertThatCode(() -> runPipeline(source, expectedMessage)).doesNotThrowAnyException();
+    }
+
+    @Test
+    void keyValueAvroStructPulsarSchema() {
+        final String topicName =
+                "keyValueAvroStruct-" + ThreadLocalRandom.current().nextLong(0, Long.MAX_VALUE);
+        operator().createTopic(topicName, 1);
+        KeyValue<TestingUser, TestingUser> expectedMessage =
+                new KeyValue<>(createRandomUser(), createRandomUser());
+        operator()
+                .sendMessage(
+                        TopicNameUtils.topicNameWithPartition(topicName, 0),
+                        Schema.KeyValue(
+                                Schema.AVRO(TestingUser.class), Schema.AVRO(TestingUser.class)),
+                        expectedMessage);
+        PulsarSource<KeyValue<TestingUser, TestingUser>> source =
+                createSource(
+                        topicName,
+                        pulsarSchema(
+                                Schema.KeyValue(
+                                        Schema.AVRO(TestingUser.class),
+                                        Schema.AVRO(TestingUser.class)),
+                                TestingUser.class,
+                                TestingUser.class));
+        assertThatCode(() -> runPipeline(source, expectedMessage)).doesNotThrowAnyException();
+    }
+
+    @Test
+    void keyValuePrimitivePulsarSchema() {
+        final String topicName =
+                "keyValuePrimitive-" + ThreadLocalRandom.current().nextLong(0, Long.MAX_VALUE);
+        operator().createTopic(topicName, 1);
+        KeyValue<String, Integer> expectedMessage = new KeyValue<>(randomAlphabetic(5), 5);
+        operator()
+                .sendMessage(
+                        TopicNameUtils.topicNameWithPartition(topicName, 0),
+                        Schema.KeyValue(Schema.STRING, Schema.INT32),
+                        expectedMessage);
+        PulsarSource<KeyValue<String, Integer>> source =
+                createSource(
+                        topicName,
+                        pulsarSchema(
+                                Schema.KeyValue(Schema.STRING, Schema.INT32),
+                                String.class,
+                                Integer.class));
+        assertThatCode(() -> runPipeline(source, expectedMessage)).doesNotThrowAnyException();
+    }
+
+    @Test
+    void keyValuePrimitiveKeyStructValuePulsarSchema() {
+        final String topicName =
+                "primitiveKeyStructValue-"
+                        + ThreadLocalRandom.current().nextLong(0, Long.MAX_VALUE);
+        operator().createTopic(topicName, 1);
+        KeyValue<String, TestingUser> expectedMessage =
+                new KeyValue<>(randomAlphabetic(5), createRandomUser());
+        operator()
+                .sendMessage(
+                        TopicNameUtils.topicNameWithPartition(topicName, 0),
+                        Schema.KeyValue(Schema.STRING, Schema.JSON(TestingUser.class)),
+                        expectedMessage);
+        PulsarSource<KeyValue<String, TestingUser>> source =
+                createSource(
+                        topicName,
+                        pulsarSchema(
+                                Schema.KeyValue(Schema.STRING, Schema.JSON(TestingUser.class)),
+                                String.class,
+                                TestingUser.class));
+        assertThatCode(() -> runPipeline(source, expectedMessage)).doesNotThrowAnyException();
+    }
+
+    @Test
+    void keyValueStructKeyPrimitiveValuePulsarSchema() {
+        final String topicName =
+                "structKeyPrimitiveValue-"
+                        + ThreadLocalRandom.current().nextLong(0, Long.MAX_VALUE);
+        operator().createTopic(topicName, 1);
+        KeyValue<TestingUser, String> expectedMessage =
+                new KeyValue<>(createRandomUser(), randomAlphabetic(5));
+        operator()
+                .sendMessage(
+                        TopicNameUtils.topicNameWithPartition(topicName, 0),
+                        Schema.KeyValue(Schema.JSON(TestingUser.class), Schema.STRING),
+                        expectedMessage);
+        PulsarSource<KeyValue<TestingUser, String>> source =
+                createSource(
+                        topicName,
+                        pulsarSchema(
+                                Schema.KeyValue(Schema.JSON(TestingUser.class), Schema.STRING),
+                                TestingUser.class,
+                                String.class));
+        assertThatCode(() -> runPipeline(source, expectedMessage)).doesNotThrowAnyException();
+    }
+
+    @Test
+    void simpleFlinkSchema() {
+        final String topicName =
+                "simpleFlinkSchema-" + ThreadLocalRandom.current().nextLong(0, Long.MAX_VALUE);
+        operator().createTopic(topicName, 1);
+        String expectedMessage = randomAlphabetic(5);
+        operator()
+                .sendMessage(
+                        TopicNameUtils.topicNameWithPartition(topicName, 0),
+                        Schema.STRING,
+                        expectedMessage);
+        PulsarSource<String> source =
+                createSource(topicName, flinkSchema(new SimpleStringSchema()));
+        assertThatCode(() -> runPipeline(source, expectedMessage)).doesNotThrowAnyException();
+    }
+
+    private PulsarSource createSource(
+            String topicName, PulsarDeserializationSchema<?> deserializationSchema) {
+        return PulsarSource.builder()
+                .setDeserializationSchema(deserializationSchema)
+                .setServiceUrl(operator().serviceUrl())
+                .setAdminUrl(operator().adminUrl())
+                .setTopics(topicName)
+                .setSubscriptionType(Exclusive)
+                .setSubscriptionName(topicName + "-subscription")
+                .setBoundedStopCursor(StopCursor.latest())
+                .setConfig(PulsarSourceOptions.PULSAR_PARTITION_DISCOVERY_INTERVAL_MS, -1L)
+                .build();
+    }
+
+    private <T> void runPipeline(PulsarSource<T> source, T expected) throws Exception {
+        try (CloseableIterator<T> iterator =
+                StreamExecutionEnvironment.getExecutionEnvironment()
+                        .setParallelism(1)
+                        .fromSource(source, WatermarkStrategy.noWatermarks(), "testSource")
+                        .executeAndCollect()) {
+            assertThat(iterator).hasNext();
+            assertThat(iterator.next()).isEqualTo(expected);
+        }
+    }
+
+    /** A test POJO class. */
+    public static class TestingUser implements Serializable {
+        private static final long serialVersionUID = -1123545861004770003L;
+        public String name;
+        public Integer age;
+
+        public String getName() {
+            return name;
+        }
+
+        public void setName(String name) {
+            this.name = name;
+        }
+
+        public Integer getAge() {
+            return age;
+        }
+
+        public void setAge(Integer age) {
+            this.age = age;
+        }
+
+        @Override
+        public boolean equals(Object o) {
+            if (this == o) {
+                return true;
+            }
+            if (o == null || getClass() != o.getClass()) {
+                return false;
+            }
+            TestingUser that = (TestingUser) o;
+            return Objects.equals(name, that.name) && Objects.equals(age, that.age);
+        }
+
+        @Override
+        public int hashCode() {
+            return Objects.hash(name, age);
+        }
+    }
+
+    private TestingUser createRandomUser() {
+        TestingUser user = new TestingUser();
+        user.setName(randomAlphabetic(5));
+        user.setAge(ThreadLocalRandom.current().nextInt(0, Integer.MAX_VALUE));
+        return user;
     }
 
     /** Create a test message by given bytes. The message don't contains any meta data. */

--- a/flink-connectors/flink-connector-pulsar/src/test/java/org/apache/flink/connector/pulsar/source/reader/split/PulsarPartitionSplitReaderTestBase.java
+++ b/flink-connectors/flink-connector-pulsar/src/test/java/org/apache/flink/connector/pulsar/source/reader/split/PulsarPartitionSplitReaderTestBase.java
@@ -136,7 +136,8 @@ public abstract class PulsarPartitionSplitReaderTestBase extends PulsarTestSuite
         SplitsAddition<PulsarPartitionSplit> addition = new SplitsAddition<>(singletonList(split));
 
         // create consumer and seek before split changes
-        try (Consumer<byte[]> consumer = reader.createPulsarConsumer(partition)) {
+        try (Consumer<byte[]> consumer =
+                (Consumer<byte[]>) reader.createPulsarConsumer(partition)) {
             // inclusive messageId
             StartCursor startCursor = StartCursor.fromMessageId(startPosition);
             startCursor.seekPosition(partition.getTopic(), partition.getPartitionId(), consumer);


### PR DESCRIPTION
## What is the purpose of the change

Currently the source connector reads all messages as Message<byte[]>, and implements a deserialization abstraction to deserialize the byte array message. This deserialization abstraction supports both flink schema and pulsar schema. However because of this extra layer of abstraction, even when using pulsar schema, the schema info is not provided to the consumer (client), so it is not using any pulsar’s schema validation mechanism. (If pulsar client has a schema, it will send the schema to broker on connect and broker will validate if it is a valid schema according to a preset compatibility rule : https://pulsar.apache.org/docs/en/schema-evolution-compatibility/).



## Brief change log


- added tests for different schemas
- changed PulsarSchemaWrapper#decode() method
-  use <?> generic in method signature
- pass in schema when creating consumer 
- KeyValueSchemaFactory changed one implementation (needs Yufan's review)


## Verifying this change


This change added tests and can be verified as follows:

  - Added tests in PulsarDeserializationSchemaTest
## Does this pull request potentially affect one of the following parts:

  - The serializers:  Yes, used a custom serializer for AVRO based structs
 - Others : No

## Documentation

  - Documentation should should be added in a different commit 
