### PR TITLE
[FLINK-25669][runtime] Support register operator coordinators for newly initialized ExecutionJobVertex

### DIFF
--- a/flink-runtime/src/main/java/org/apache/flink/runtime/scheduler/DefaultOperatorCoordinatorHandler.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/scheduler/DefaultOperatorCoordinatorHandler.java
@@ -18,6 +18,7 @@
 
 package org.apache.flink.runtime.scheduler;
 
+import org.apache.flink.annotation.VisibleForTesting;
 import org.apache.flink.runtime.concurrent.ComponentMainThreadExecutor;
 import org.apache.flink.runtime.execution.ExecutionState;
 import org.apache.flink.runtime.executiongraph.Execution;
@@ -38,10 +39,11 @@ import org.apache.flink.util.FlinkRuntimeException;
 import org.apache.flink.util.IOUtils;
 
 import java.util.Collection;
-import java.util.HashMap;
 import java.util.Map;
 import java.util.concurrent.CompletableFuture;
 import java.util.function.Consumer;
+import java.util.function.Function;
+import java.util.stream.Collectors;
 
 /** Default handler for the {@link OperatorCoordinator OperatorCoordinators}. */
 public class DefaultOperatorCoordinatorHandler implements OperatorCoordinatorHandler {
@@ -61,13 +63,12 @@ public class DefaultOperatorCoordinatorHandler implements OperatorCoordinatorHan
 
     private static Map<OperatorID, OperatorCoordinatorHolder> createCoordinatorMap(
             ExecutionGraph executionGraph) {
-        Map<OperatorID, OperatorCoordinatorHolder> coordinatorMap = new HashMap<>();
-        for (ExecutionJobVertex vertex : executionGraph.getAllVertices().values()) {
-            for (OperatorCoordinatorHolder holder : vertex.getOperatorCoordinators()) {
-                coordinatorMap.put(holder.operatorId(), holder);
-            }
-        }
-        return coordinatorMap;
+        return executionGraph.getAllVertices().values().stream()
+                .filter(ExecutionJobVertex::isInitialized)
+                .flatMap(v -> v.getOperatorCoordinators().stream())
+                .collect(
+                        Collectors.toMap(
+                                OperatorCoordinatorHolder::operatorId, Function.identity()));
     }
 
     @Override
@@ -79,16 +80,7 @@ public class DefaultOperatorCoordinatorHandler implements OperatorCoordinatorHan
 
     @Override
     public void startAllOperatorCoordinators() {
-        final Collection<OperatorCoordinatorHolder> coordinators = coordinatorMap.values();
-        try {
-            for (OperatorCoordinatorHolder coordinator : coordinators) {
-                coordinator.start();
-            }
-        } catch (Throwable t) {
-            ExceptionUtils.rethrowIfFatalErrorOrOOM(t);
-            coordinators.forEach(IOUtils::closeQuietly);
-            throw new FlinkRuntimeException("Failed to start the operator coordinators", t);
-        }
+        startOperatorCoordinators(coordinatorMap.values());
     }
 
     @Override
@@ -140,7 +132,10 @@ public class DefaultOperatorCoordinatorHandler implements OperatorCoordinatorHan
 
         final OperatorCoordinatorHolder coordinatorHolder = coordinatorMap.get(operator);
         if (coordinatorHolder == null) {
-            throw new FlinkException("Coordinator of operator " + operator + " does not exist");
+            throw new FlinkException(
+                    "Coordinator of operator "
+                            + operator
+                            + " does not exist or the job vertex this operator belongs to is not initialized.");
         }
 
         final OperatorCoordinator coordinator = coordinatorHolder.coordinator();
@@ -150,5 +145,34 @@ public class DefaultOperatorCoordinatorHandler implements OperatorCoordinatorHan
             throw new FlinkException(
                     "Coordinator of operator " + operator + " cannot handle client event");
         }
+    }
+
+    @Override
+    public void registerAndStartNewCoordinators(
+            Collection<OperatorCoordinatorHolder> coordinators,
+            ComponentMainThreadExecutor mainThreadExecutor) {
+
+        for (OperatorCoordinatorHolder coordinator : coordinators) {
+            coordinatorMap.put(coordinator.operatorId(), coordinator);
+            coordinator.lazyInitialize(globalFailureHandler, mainThreadExecutor);
+        }
+        startOperatorCoordinators(coordinators);
+    }
+
+    private void startOperatorCoordinators(Collection<OperatorCoordinatorHolder> coordinators) {
+        try {
+            for (OperatorCoordinatorHolder coordinator : coordinators) {
+                coordinator.start();
+            }
+        } catch (Throwable t) {
+            ExceptionUtils.rethrowIfFatalErrorOrOOM(t);
+            coordinators.forEach(IOUtils::closeQuietly);
+            throw new FlinkRuntimeException("Failed to start the operator coordinators", t);
+        }
+    }
+
+    @VisibleForTesting
+    Map<OperatorID, OperatorCoordinatorHolder> getCoordinatorMap() {
+        return coordinatorMap;
     }
 }

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/scheduler/OperatorCoordinatorHandler.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/scheduler/OperatorCoordinatorHandler.java
@@ -24,9 +24,11 @@ import org.apache.flink.runtime.jobgraph.OperatorID;
 import org.apache.flink.runtime.operators.coordination.CoordinationRequest;
 import org.apache.flink.runtime.operators.coordination.CoordinationResponse;
 import org.apache.flink.runtime.operators.coordination.OperatorCoordinator;
+import org.apache.flink.runtime.operators.coordination.OperatorCoordinatorHolder;
 import org.apache.flink.runtime.operators.coordination.OperatorEvent;
 import org.apache.flink.util.FlinkException;
 
+import java.util.Collection;
 import java.util.concurrent.CompletableFuture;
 
 /** Handler for the {@link OperatorCoordinator OperatorCoordinators}. */
@@ -67,4 +69,14 @@ public interface OperatorCoordinatorHandler {
      */
     CompletableFuture<CoordinationResponse> deliverCoordinationRequestToCoordinator(
             OperatorID operator, CoordinationRequest request) throws FlinkException;
+
+    /**
+     * Register and start new operator coordinators.
+     *
+     * @param coordinators the operator coordinator to be registered.
+     * @param mainThreadExecutor Executor for submitting work to the main thread.
+     */
+    void registerAndStartNewCoordinators(
+            Collection<OperatorCoordinatorHolder> coordinators,
+            ComponentMainThreadExecutor mainThreadExecutor);
 }

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/scheduler/SchedulerBase.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/scheduler/SchedulerBase.java
@@ -465,6 +465,9 @@ public abstract class SchedulerBase implements SchedulerNG, CheckpointScheduling
 
     private void notifyCoordinatorsOfEmptyGlobalRestore() throws Exception {
         for (final ExecutionJobVertex ejv : getExecutionGraph().getAllVertices().values()) {
+            if (!ejv.isInitialized()) {
+                continue;
+            }
             for (final OperatorCoordinatorHolder coordinator : ejv.getOperatorCoordinators()) {
                 coordinator.resetToCheckpoint(OperatorCoordinator.NO_CHECKPOINT, null);
             }

--- a/flink-runtime/src/test/java/org/apache/flink/runtime/operators/coordination/TestingOperatorCoordinator.java
+++ b/flink-runtime/src/test/java/org/apache/flink/runtime/operators/coordination/TestingOperatorCoordinator.java
@@ -33,7 +33,7 @@ import java.util.concurrent.CountDownLatch;
 import java.util.concurrent.LinkedBlockingQueue;
 
 /** A simple testing implementation of the {@link OperatorCoordinator}. */
-class TestingOperatorCoordinator implements OperatorCoordinator {
+public class TestingOperatorCoordinator implements OperatorCoordinator {
 
     public static final byte[] NULL_RESTORE_VALUE = new byte[0];
 

--- a/flink-runtime/src/test/java/org/apache/flink/runtime/scheduler/DefaultOperatorCoordinatorHandlerTest.java
+++ b/flink-runtime/src/test/java/org/apache/flink/runtime/scheduler/DefaultOperatorCoordinatorHandlerTest.java
@@ -1,0 +1,99 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.flink.runtime.scheduler;
+
+import org.apache.flink.api.common.JobID;
+import org.apache.flink.runtime.concurrent.ComponentMainThreadExecutorServiceAdapter;
+import org.apache.flink.runtime.executiongraph.DefaultExecutionGraph;
+import org.apache.flink.runtime.executiongraph.ExecutionGraph;
+import org.apache.flink.runtime.executiongraph.ExecutionJobVertex;
+import org.apache.flink.runtime.executiongraph.TestingDefaultExecutionGraphBuilder;
+import org.apache.flink.runtime.io.network.partition.ResultPartitionType;
+import org.apache.flink.runtime.jobgraph.JobGraph;
+import org.apache.flink.runtime.jobgraph.JobVertex;
+import org.apache.flink.runtime.jobgraph.OperatorID;
+import org.apache.flink.runtime.operators.coordination.TestingOperatorCoordinator;
+import org.apache.flink.util.SerializedValue;
+
+import org.junit.Test;
+
+import java.io.IOException;
+
+import static org.apache.flink.runtime.executiongraph.ExecutionGraphTestUtils.createNoOpVertex;
+import static org.apache.flink.runtime.io.network.partition.ResultPartitionType.BLOCKING;
+import static org.apache.flink.runtime.jobgraph.DistributionPattern.ALL_TO_ALL;
+import static org.hamcrest.MatcherAssert.assertThat;
+import static org.hamcrest.Matchers.containsInAnyOrder;
+
+/** Test for {@link DefaultOperatorCoordinatorHandler}. */
+public class DefaultOperatorCoordinatorHandlerTest {
+
+    @Test
+    public void testRegisterAndStartNewCoordinators() throws Exception {
+
+        final JobVertex[] jobVertices = createJobVertices(BLOCKING);
+        OperatorID operatorId1 = OperatorID.fromJobVertexID(jobVertices[0].getID());
+        OperatorID operatorId2 = OperatorID.fromJobVertexID(jobVertices[1].getID());
+
+        ExecutionGraph executionGraph = createDynamicGraph(jobVertices);
+        ExecutionJobVertex ejv1 = executionGraph.getJobVertex(jobVertices[0].getID());
+        ExecutionJobVertex ejv2 = executionGraph.getJobVertex(jobVertices[1].getID());
+        executionGraph.start(ComponentMainThreadExecutorServiceAdapter.forMainThread());
+
+        executionGraph.initializeJobVertex(ejv1, 0L);
+
+        DefaultOperatorCoordinatorHandler handler =
+                new DefaultOperatorCoordinatorHandler(executionGraph, throwable -> {});
+        assertThat(handler.getCoordinatorMap().keySet(), containsInAnyOrder(operatorId1));
+
+        executionGraph.initializeJobVertex(ejv2, 0L);
+        handler.registerAndStartNewCoordinators(
+                ejv2.getOperatorCoordinators(), executionGraph.getJobMasterMainThreadExecutor());
+
+        assertThat(
+                handler.getCoordinatorMap().keySet(), containsInAnyOrder(operatorId1, operatorId2));
+    }
+
+    private JobVertex[] createJobVertices(ResultPartitionType resultPartitionType)
+            throws IOException {
+        final JobVertex[] jobVertices = new JobVertex[2];
+        final int parallelism = 3;
+        jobVertices[0] = createNoOpVertex(parallelism);
+        jobVertices[1] = createNoOpVertex(parallelism);
+        jobVertices[1].connectNewDataSetAsInput(jobVertices[0], ALL_TO_ALL, resultPartitionType);
+
+        jobVertices[0].addOperatorCoordinator(
+                new SerializedValue<>(
+                        new TestingOperatorCoordinator.Provider(
+                                OperatorID.fromJobVertexID(jobVertices[0].getID()))));
+
+        jobVertices[1].addOperatorCoordinator(
+                new SerializedValue<>(
+                        new TestingOperatorCoordinator.Provider(
+                                OperatorID.fromJobVertexID(jobVertices[1].getID()))));
+
+        return jobVertices;
+    }
+
+    private DefaultExecutionGraph createDynamicGraph(JobVertex... jobVertices) throws Exception {
+        return TestingDefaultExecutionGraphBuilder.newBuilder()
+                .setJobGraph(new JobGraph(new JobID(), "TestJob", jobVertices))
+                .buildDynamicGraph();
+    }
+}

--- a/flink-runtime/src/test/java/org/apache/flink/runtime/scheduler/adaptive/TestingOperatorCoordinatorHandler.java
+++ b/flink-runtime/src/test/java/org/apache/flink/runtime/scheduler/adaptive/TestingOperatorCoordinatorHandler.java
@@ -23,10 +23,12 @@ import org.apache.flink.runtime.executiongraph.ExecutionAttemptID;
 import org.apache.flink.runtime.jobgraph.OperatorID;
 import org.apache.flink.runtime.operators.coordination.CoordinationRequest;
 import org.apache.flink.runtime.operators.coordination.CoordinationResponse;
+import org.apache.flink.runtime.operators.coordination.OperatorCoordinatorHolder;
 import org.apache.flink.runtime.operators.coordination.OperatorEvent;
 import org.apache.flink.runtime.scheduler.OperatorCoordinatorHandler;
 import org.apache.flink.util.FlinkException;
 
+import java.util.Collection;
 import java.util.concurrent.CompletableFuture;
 
 class TestingOperatorCoordinatorHandler implements OperatorCoordinatorHandler {
@@ -61,6 +63,13 @@ class TestingOperatorCoordinatorHandler implements OperatorCoordinatorHandler {
     @Override
     public CompletableFuture<CoordinationResponse> deliverCoordinationRequestToCoordinator(
             OperatorID operator, CoordinationRequest request) throws FlinkException {
+        throw new UnsupportedOperationException();
+    }
+
+    @Override
+    public void registerAndStartNewCoordinators(
+            Collection<OperatorCoordinatorHolder> coordinators,
+            ComponentMainThreadExecutor mainThreadExecutor) {
         throw new UnsupportedOperationException();
     }
 }


### PR DESCRIPTION
## What is the purpose of the change
For dynamic graphs, the operator coordinators of execution job vertices should also be registered and started lazily.  We need to support register operator coordinators for newly initialized ExecutionJobVertex.


## Brief change log
1716622b272f2141ee4c29cf978265d8de00fa1b Support register operator coordinators for newly initialized ExecutionJobVertex


## Verifying this change
Add test `DefaultOperatorCoordinatorHandlerTest#testRegisterAndStartNewCoordinators`

## Does this pull request potentially affect one of the following parts:

  - Dependencies (does it add or upgrade a dependency): (**no**)
  - The public API, i.e., is any changed class annotated with `@Public(Evolving)`: (**no**)
  - The serializers: (**no**)
  - The runtime per-record code paths (performance sensitive): (**no**)
  - Anything that affects deployment or recovery: JobManager (and its components), Checkpointing, Kubernetes/Yarn, ZooKeeper: (**no**)
  - The S3 file system connector: (**no**)

## Documentation

  - Does this pull request introduce a new feature? (**no**)
  - If yes, how is the feature documented? (**not applicable**)
