### PR TITLE
[FLINK-25696][datastream] Introduce metadataConsumer to InitContext in Sink

### DIFF
--- a/flink-connectors/flink-connector-kafka/src/test/java/org/apache/flink/connector/kafka/sink/KafkaWriterITCase.java
+++ b/flink-connectors/flink-connector-kafka/src/test/java/org/apache/flink/connector/kafka/sink/KafkaWriterITCase.java
@@ -40,6 +40,7 @@ import org.apache.flink.shaded.guava30.com.google.common.collect.ImmutableList;
 
 import org.apache.kafka.clients.consumer.ConsumerRecord;
 import org.apache.kafka.clients.producer.ProducerRecord;
+import org.apache.kafka.clients.producer.RecordMetadata;
 import org.apache.kafka.common.serialization.ByteArraySerializer;
 import org.junit.jupiter.api.AfterAll;
 import org.junit.jupiter.api.Assertions;
@@ -54,8 +55,11 @@ import org.slf4j.LoggerFactory;
 import org.testcontainers.containers.KafkaContainer;
 import org.testcontainers.containers.Network;
 
+import javax.annotation.Nullable;
+
 import java.io.IOException;
 import java.nio.ByteBuffer;
+import java.util.ArrayList;
 import java.util.Collection;
 import java.util.Comparator;
 import java.util.List;
@@ -64,6 +68,7 @@ import java.util.OptionalLong;
 import java.util.PriorityQueue;
 import java.util.Properties;
 import java.util.concurrent.ScheduledFuture;
+import java.util.function.Consumer;
 import java.util.stream.IntStream;
 
 import static org.apache.flink.connector.kafka.testutils.KafkaUtil.createKafkaContainer;
@@ -177,6 +182,25 @@ public class KafkaWriterITCase extends TestLogger {
                                 }
                             });
             assertThat(currentSendTime.get().getValue(), greaterThan(0L));
+        }
+    }
+
+    @Test
+    public void testMetadataPublisher() throws Exception {
+        List<String> metadataList = new ArrayList<>();
+        try (final KafkaWriter<Integer> writer =
+                createWriterWithConfiguration(
+                        getKafkaClientConfiguration(),
+                        DeliveryGuarantee.AT_LEAST_ONCE,
+                        InternalSinkWriterMetricGroup.mock(metricListener.getMetricGroup()),
+                        meta -> metadataList.add(meta.toString()))) {
+            List<String> expected = new ArrayList<>();
+            for (int i = 0; i < 100; i++) {
+                writer.write(1, SINK_WRITER_CONTEXT);
+                expected.add("testMetadataPublisher-0@" + i);
+            }
+            writer.prepareCommit();
+            org.assertj.core.api.Assertions.assertThat(metadataList).isEqualTo(expected);
         }
     }
 
@@ -341,11 +365,19 @@ public class KafkaWriterITCase extends TestLogger {
             Properties config,
             DeliveryGuarantee guarantee,
             SinkWriterMetricGroup sinkWriterMetricGroup) {
+        return createWriterWithConfiguration(config, guarantee, sinkWriterMetricGroup, null);
+    }
+
+    private KafkaWriter<Integer> createWriterWithConfiguration(
+            Properties config,
+            DeliveryGuarantee guarantee,
+            SinkWriterMetricGroup sinkWriterMetricGroup,
+            @Nullable Consumer<RecordMetadata> metadataConsumer) {
         return new KafkaWriter<>(
                 guarantee,
                 config,
                 "test-prefix",
-                new SinkInitContext(sinkWriterMetricGroup, timeService),
+                new SinkInitContext(sinkWriterMetricGroup, timeService, metadataConsumer),
                 new DummyRecordSerializer(),
                 new DummySchemaContext(),
                 ImmutableList.of());
@@ -366,10 +398,15 @@ public class KafkaWriterITCase extends TestLogger {
 
         private final SinkWriterMetricGroup metricGroup;
         private final ProcessingTimeService timeService;
+        @Nullable private final Consumer<RecordMetadata> metadataConsumer;
 
-        SinkInitContext(SinkWriterMetricGroup metricGroup, ProcessingTimeService timeService) {
+        SinkInitContext(
+                SinkWriterMetricGroup metricGroup,
+                ProcessingTimeService timeService,
+                @Nullable Consumer<RecordMetadata> metadataConsumer) {
             this.metricGroup = metricGroup;
             this.timeService = timeService;
+            this.metadataConsumer = metadataConsumer;
         }
 
         @Override
@@ -411,6 +448,11 @@ public class KafkaWriterITCase extends TestLogger {
         public SerializationSchema.InitializationContext
                 asSerializationSchemaInitializationContext() {
             return null;
+        }
+
+        @Override
+        public <MetaT> Optional<Consumer<MetaT>> metadataConsumer() {
+            return Optional.ofNullable((Consumer<MetaT>) metadataConsumer);
         }
     }
 

--- a/flink-core/src/main/java/org/apache/flink/api/connector/sink2/Sink.java
+++ b/flink-core/src/main/java/org/apache/flink/api/connector/sink2/Sink.java
@@ -18,6 +18,7 @@
 
 package org.apache.flink.api.connector.sink2;
 
+import org.apache.flink.annotation.Experimental;
 import org.apache.flink.annotation.PublicEvolving;
 import org.apache.flink.api.common.operators.MailboxExecutor;
 import org.apache.flink.api.common.operators.ProcessingTimeService;
@@ -27,7 +28,9 @@ import org.apache.flink.util.UserCodeClassLoader;
 
 import java.io.IOException;
 import java.io.Serializable;
+import java.util.Optional;
 import java.util.OptionalLong;
+import java.util.function.Consumer;
 
 /**
  * Base interface for developing a sink. A basic {@link Sink} is a stateless sink that can flush
@@ -105,5 +108,18 @@ public interface Sink<InputT> extends Serializable {
          * Provides a view on this context as a {@link SerializationSchema.InitializationContext}.
          */
         SerializationSchema.InitializationContext asSerializationSchemaInitializationContext();
+
+        /**
+         * Returns a metadata consumer, the {@link SinkWriter} can publish metadata events of type
+         * {@link MetaT} to the consumer.
+         *
+         * <p>It is recommended to use a separate thread pool to publish the metadata because
+         * enqueuing a lot of these messages in the mailbox may lead to a performance decrease.
+         * thread, and the {@link Consumer#accept} method is executed very fast.
+         */
+        @Experimental
+        default <MetaT> Optional<Consumer<MetaT>> metadataConsumer() {
+            return Optional.empty();
+        }
     }
 }


### PR DESCRIPTION
## What is the purpose of the change

In Table Store, we want to get the offsets of kafka writer, only the offset returned by the callback inside the KafkaWriter is accurate, so we need this callback mechanism.

This ticket wants to add metadataConsumer to InitContext in Sink:
```
/**
 * Returns a metadata consumer, the {@link SinkWriter} can publish metadata events of type
 * {@link MetaT} to the consumer. The consumer can accept metadata events in an asynchronous
 * thread, and the {@link Consumer#accept} method is executed very fast.
 */
default <MetaT> Optional<Consumer<MetaT>> metadataConsumer() {
    return Optional.empty();
}
```
SinkWriter can get this consumer, and publish metadata to the consumer implemented by table store sink.

## Brief change log

- Introduce metadataConsumer method
- KafkaWriter get metadataConsumer

## Verifying this change

`KafkaWriterITCase.testMetadataPublisher`

## Does this pull request potentially affect one of the following parts:

  - Dependencies (does it add or upgrade a dependency): (yes / **no**)
  - The public API, i.e., is any changed class annotated with `@Public(Evolving)`: (yes / **no**)
  - The serializers: (yes / **no** / don't know)
  - The runtime per-record code paths (performance sensitive): (yes / **no** / don't know)
  - Anything that affects deployment or recovery: JobManager (and its components), Checkpointing, Kubernetes/Yarn, ZooKeeper: (yes / **no** / don't know)
  - The S3 file system connector: (yes / **no** / don't know)

## Documentation

  - Does this pull request introduce a new feature? (**yes** / no)
  - If yes, how is the feature documented? (not applicable / docs / **JavaDocs** / not documented)
