### PR TITLE
Atlas changes

### DIFF
--- a/flink-clients/src/main/java/org/apache/flink/client/deployment/ClusterClientJobClientAdapter.java
+++ b/flink-clients/src/main/java/org/apache/flink/client/deployment/ClusterClientJobClientAdapter.java
@@ -21,6 +21,7 @@ package org.apache.flink.client.deployment;
 import org.apache.flink.api.common.JobExecutionResult;
 import org.apache.flink.api.common.JobID;
 import org.apache.flink.api.common.JobStatus;
+import org.apache.flink.api.dag.Pipeline;
 import org.apache.flink.client.program.ClusterClient;
 import org.apache.flink.client.program.ClusterClientProvider;
 import org.apache.flink.client.program.ProgramInvocationException;
@@ -47,14 +48,23 @@ public class ClusterClientJobClientAdapter<ClusterID> implements JobClient {
 
 	private final JobID jobID;
 
-	public ClusterClientJobClientAdapter(final ClusterClientProvider<ClusterID> clusterClientProvider, final JobID jobID) {
+	private final Pipeline pipeline;
+
+	public ClusterClientJobClientAdapter(final ClusterClientProvider<ClusterID> clusterClientProvider, final JobID jobID,
+		final Pipeline pipeline) {
 		this.jobID = checkNotNull(jobID);
 		this.clusterClientProvider = checkNotNull(clusterClientProvider);
+		this.pipeline = checkNotNull(pipeline);
 	}
 
 	@Override
 	public JobID getJobID() {
 		return jobID;
+	}
+
+	@Override
+	public Pipeline getPipeline() {
+		return pipeline;
 	}
 
 	@Override

--- a/flink-clients/src/main/java/org/apache/flink/client/deployment/executors/AbstractJobClusterExecutor.java
+++ b/flink-clients/src/main/java/org/apache/flink/client/deployment/executors/AbstractJobClusterExecutor.java
@@ -71,7 +71,7 @@ public class AbstractJobClusterExecutor<ClusterID, ClientFactory extends Cluster
 			LOG.info("Job has been submitted with JobID " + jobGraph.getJobID());
 
 			return CompletableFuture.completedFuture(
-					new ClusterClientJobClientAdapter<>(clusterClientProvider, jobGraph.getJobID()));
+					new ClusterClientJobClientAdapter<>(clusterClientProvider, jobGraph.getJobID(), pipeline));
 		}
 	}
 }

--- a/flink-clients/src/main/java/org/apache/flink/client/deployment/executors/AbstractSessionClusterExecutor.java
+++ b/flink-clients/src/main/java/org/apache/flink/client/deployment/executors/AbstractSessionClusterExecutor.java
@@ -66,7 +66,8 @@ public class AbstractSessionClusterExecutor<ClusterID, ClientFactory extends Clu
 					.submitJob(jobGraph)
 					.thenApplyAsync(jobID -> (JobClient) new ClusterClientJobClientAdapter<>(
 							clusterClientProvider,
-							jobID))
+							jobID,
+							pipeline))
 					.whenComplete((ignored1, ignored2) -> clusterClient.close());
 		}
 	}

--- a/flink-clients/src/main/java/org/apache/flink/client/deployment/executors/LocalExecutor.java
+++ b/flink-clients/src/main/java/org/apache/flink/client/deployment/executors/LocalExecutor.java
@@ -70,7 +70,7 @@ public class LocalExecutor implements PipelineExecutor {
 				.thenAccept((jobResult) -> clusterClient.shutDownCluster());
 
 		return jobIdFuture.thenApply(jobID ->
-				new ClusterClientJobClientAdapter<>(() -> clusterClient, jobID));
+				new ClusterClientJobClientAdapter<>(() -> clusterClient, jobID, pipeline));
 	}
 
 	private JobGraph getJobGraph(Pipeline pipeline, Configuration configuration) {

--- a/flink-clients/src/test/java/org/apache/flink/client/program/ClientTest.java
+++ b/flink-clients/src/test/java/org/apache/flink/client/program/ClientTest.java
@@ -379,7 +379,7 @@ public class ClientTest extends TestLogger {
 						jobGraph.setClasspaths(accessor.getClasspaths());
 
 						final JobID jobID = ClientUtils.submitJob(clusterClient, jobGraph).getJobID();
-						return CompletableFuture.completedFuture(new ClusterClientJobClientAdapter<>(() -> clusterClient, jobID));
+						return CompletableFuture.completedFuture(new ClusterClientJobClientAdapter<>(() -> clusterClient, jobID, pipeline));
 					};
 				}
 			};

--- a/flink-connectors/flink-connector-kafka-base/src/main/java/org/apache/flink/streaming/connectors/kafka/FlinkKafkaConsumerBase.java
+++ b/flink-connectors/flink-connector-kafka-base/src/main/java/org/apache/flink/streaming/connectors/kafka/FlinkKafkaConsumerBase.java
@@ -1031,6 +1031,10 @@ public abstract class FlinkKafkaConsumerBase<T> extends RichParallelSourceFuncti
 			Collection<KafkaTopicPartition> partitions,
 			long timestamp);
 
+	public KafkaTopicsDescriptor getTopicsDescriptor() {
+		return topicsDescriptor;
+	}
+
 	// ------------------------------------------------------------------------
 	//  ResultTypeQueryable methods
 	// ------------------------------------------------------------------------

--- a/flink-connectors/flink-connector-kafka-base/src/main/java/org/apache/flink/streaming/connectors/kafka/internals/KafkaTopicsDescriptor.java
+++ b/flink-connectors/flink-connector-kafka-base/src/main/java/org/apache/flink/streaming/connectors/kafka/internals/KafkaTopicsDescriptor.java
@@ -38,6 +38,7 @@ public class KafkaTopicsDescriptor implements Serializable {
 	private static final long serialVersionUID = -3807227764764900975L;
 
 	private final List<String> fixedTopics;
+
 	private final Pattern topicPattern;
 
 	public KafkaTopicsDescriptor(@Nullable List<String> fixedTopics, @Nullable Pattern topicPattern) {
@@ -75,6 +76,10 @@ public class KafkaTopicsDescriptor implements Serializable {
 
 	public List<String> getFixedTopics() {
 		return fixedTopics;
+	}
+
+	public Pattern getTopicPattern() {
+		return topicPattern;
 	}
 
 	@Override

--- a/flink-connectors/flink-connector-kafka/src/main/java/org/apache/flink/streaming/connectors/kafka/FlinkKafkaConsumer.java
+++ b/flink-connectors/flink-connector-kafka/src/main/java/org/apache/flink/streaming/connectors/kafka/FlinkKafkaConsumer.java
@@ -293,6 +293,10 @@ public class FlinkKafkaConsumer<T> extends FlinkKafkaConsumerBase<T> {
 			PropertiesUtil.getLong(properties, ConsumerConfig.AUTO_COMMIT_INTERVAL_MS_CONFIG, 5000) > 0;
 	}
 
+	public Properties getProperties() {
+		return properties;
+	}
+
 	/**
 	 * Makes sure that the ByteArrayDeserializer is registered in the Kafka properties.
 	 *

--- a/flink-core/src/main/java/org/apache/flink/configuration/ExecutionOptions.java
+++ b/flink-core/src/main/java/org/apache/flink/configuration/ExecutionOptions.java
@@ -23,6 +23,7 @@ import org.apache.flink.configuration.description.Description;
 import org.apache.flink.configuration.description.TextElement;
 
 import java.time.Duration;
+import java.util.List;
 
 /**
  * {@link ConfigOption}s specific for a single execution of a user program.
@@ -55,4 +56,12 @@ public class ExecutionOptions {
 						"throughput")
 				)
 				.build());
+
+	public static final ConfigOption<List<String>> JOB_LISTENERS =
+		ConfigOptions.key("execution.job-listeners")
+			.stringType()
+			.asList()
+			.noDefaultValue()
+			.withDescription("JobListenerFactories to be registered for the execution.");
+
 }

--- a/flink-core/src/main/java/org/apache/flink/core/execution/JobClient.java
+++ b/flink-core/src/main/java/org/apache/flink/core/execution/JobClient.java
@@ -22,6 +22,7 @@ import org.apache.flink.annotation.PublicEvolving;
 import org.apache.flink.api.common.JobExecutionResult;
 import org.apache.flink.api.common.JobID;
 import org.apache.flink.api.common.JobStatus;
+import org.apache.flink.api.dag.Pipeline;
 
 import javax.annotation.Nullable;
 
@@ -38,6 +39,11 @@ public interface JobClient {
 	 * Returns the {@link JobID} that uniquely identifies the job this client is scoped to.
 	 */
 	JobID getJobID();
+
+	/**
+	 * Returns the {@link Pipeline} instance of the job.
+	 */
+	Pipeline getPipeline();
 
 	/**
 	 * Requests the {@link JobStatus} of the associated job.

--- a/flink-core/src/main/java/org/apache/flink/core/execution/JobListenerFactory.java
+++ b/flink-core/src/main/java/org/apache/flink/core/execution/JobListenerFactory.java
@@ -1,0 +1,28 @@
+package org.apache.flink.core.execution;
+
+import org.apache.flink.annotation.PublicEvolving;
+import org.apache.flink.configuration.IllegalConfigurationException;
+import org.apache.flink.configuration.ReadableConfig;
+
+/**
+ * A factory to create a specific job listener. The job listener creation gets a Configuration
+ * object that can be used to read further config values.
+ *
+ * <p>The job listener factory is typically specified in the configuration to produce a
+ * configured job listener.
+ *
+ * @param <T> The type of the job listener created.
+ */
+@PublicEvolving
+public interface JobListenerFactory<T extends JobListener> {
+
+	/**
+	 * Creates the job listener, optionally using the given configuration.
+	 *
+	 * @param config      The Flink configuration (loaded by the TaskManager).
+	 * @param classLoader The class loader that should be used to load the job listener.
+	 * @return The created job listener.
+	 * @throws IllegalConfigurationException If the configuration misses critical values, or specifies invalid values
+	 */
+	T createFromConfig(ReadableConfig config, ClassLoader classLoader) throws IllegalConfigurationException;
+}

--- a/flink-java/src/test/java/org/apache/flink/api/java/TestingJobClient.java
+++ b/flink-java/src/test/java/org/apache/flink/api/java/TestingJobClient.java
@@ -21,6 +21,7 @@ package org.apache.flink.api.java;
 import org.apache.flink.api.common.JobExecutionResult;
 import org.apache.flink.api.common.JobID;
 import org.apache.flink.api.common.JobStatus;
+import org.apache.flink.api.dag.Pipeline;
 import org.apache.flink.core.execution.JobClient;
 
 import javax.annotation.Nullable;
@@ -37,6 +38,11 @@ public class TestingJobClient implements JobClient {
 	@Override
 	public JobID getJobID() {
 		return new JobID();
+	}
+
+	@Override
+	public Pipeline getPipeline() {
+		return null;
 	}
 
 	@Override

--- a/flink-streaming-java/src/main/java/org/apache/flink/streaming/api/functions/sink/filesystem/StreamingFileSink.java
+++ b/flink-streaming-java/src/main/java/org/apache/flink/streaming/api/functions/sink/filesystem/StreamingFileSink.java
@@ -153,6 +153,10 @@ public class StreamingFileSink<IN>
 		this.bucketCheckInterval = bucketCheckInterval;
 	}
 
+	public BucketsBuilder<IN, ?, ? extends BucketsBuilder<IN, ?, ?>> getBucketsBuilder() {
+		return bucketsBuilder;
+	}
+
 	// ------------------------------------------------------------------------
 
 	// --------------------------- Sink Builders  -----------------------------
@@ -186,7 +190,7 @@ public class StreamingFileSink<IN>
 	/**
 	 * The base abstract class for the {@link RowFormatBuilder} and {@link BulkFormatBuilder}.
 	 */
-	private abstract static class BucketsBuilder<IN, BucketID, T extends BucketsBuilder<IN, BucketID, T>> implements Serializable {
+	public abstract static class BucketsBuilder<IN, BucketID, T extends BucketsBuilder<IN, BucketID, T>> implements Serializable {
 
 		private static final long serialVersionUID = 1L;
 
@@ -198,6 +202,8 @@ public class StreamingFileSink<IN>
 		}
 
 		abstract Buckets<IN, BucketID> createBuckets(final int subtaskIndex) throws IOException;
+
+		public abstract Path getBasePath();
 	}
 
 	/**
@@ -293,6 +299,11 @@ public class StreamingFileSink<IN>
 					rollingPolicy,
 					subtaskIndex,
 					outputFileConfig);
+		}
+
+		@Override
+		public Path getBasePath() {
+			return basePath;
 		}
 	}
 
@@ -391,6 +402,11 @@ public class StreamingFileSink<IN>
 					rollingPolicy,
 					subtaskIndex,
 					outputFileConfig);
+		}
+
+		@Override
+		public Path getBasePath() {
+			return basePath;
 		}
 	}
 

--- a/flink-streaming-java/src/main/java/org/apache/flink/streaming/api/functions/source/ContinuousFileMonitoringFunction.java
+++ b/flink-streaming-java/src/main/java/org/apache/flink/streaming/api/functions/source/ContinuousFileMonitoringFunction.java
@@ -132,6 +132,10 @@ public class ContinuousFileMonitoringFunction<OUT>
 		return this.globalModificationTime;
 	}
 
+	public String getMonitoredPath() {
+		return path;
+	}
+
 	@Override
 	public void initializeState(FunctionInitializationContext context) throws Exception {
 

--- a/flink-streaming-java/src/test/java/org/apache/flink/streaming/api/environment/RemoteStreamExecutionEnvironmentTest.java
+++ b/flink-streaming-java/src/test/java/org/apache/flink/streaming/api/environment/RemoteStreamExecutionEnvironmentTest.java
@@ -156,7 +156,7 @@ public class RemoteStreamExecutionEnvironmentTest extends TestLogger {
 						clusterClient = new TestClusterClient(configuration, jobID);
 
 						return CompletableFuture.completedFuture(
-								new ClusterClientJobClientAdapter<>(() -> clusterClient, jobID));
+								new ClusterClientJobClientAdapter<>(() -> clusterClient, jobID, pipeline));
 					};
 				}
 			};

--- a/flink-streaming-java/src/test/java/org/apache/flink/streaming/environment/TestingJobClient.java
+++ b/flink-streaming-java/src/test/java/org/apache/flink/streaming/environment/TestingJobClient.java
@@ -21,6 +21,7 @@ package org.apache.flink.streaming.environment;
 import org.apache.flink.api.common.JobExecutionResult;
 import org.apache.flink.api.common.JobID;
 import org.apache.flink.api.common.JobStatus;
+import org.apache.flink.api.dag.Pipeline;
 import org.apache.flink.core.execution.JobClient;
 
 import javax.annotation.Nullable;
@@ -37,6 +38,11 @@ public class TestingJobClient implements JobClient {
 	@Override
 	public JobID getJobID() {
 		return new JobID();
+	}
+
+	@Override
+	public Pipeline getPipeline() {
+		return null;
 	}
 
 	@Override


### PR DESCRIPTION
If Flink 1.10 is used, this JobListener is not used after it is created, so the Hook does not take effect. It can take effect after adding the following code.
JobListener listener = factory.createFromConfig(configuration, classLoader);
registerJobListener(listener);


If you use Flink 1.12, the option of execution.job-listeners has been officially supported, and the listeners have been added to env, so this PR is not required