### PR TITLE
[FLINK-25709] Always delete non-deterministic working directories

### DIFF
--- a/flink-runtime/src/main/java/org/apache/flink/runtime/entrypoint/ClusterEntrypointUtils.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/entrypoint/ClusterEntrypointUtils.java
@@ -140,14 +140,18 @@ public final class ClusterEntrypointUtils {
      * working directory exists.
      *
      * @param configuration to extract the required settings from
-     * @param resourceId identifying the TaskManager process
+     * @param envelopedResourceId identifying the TaskManager process
      * @return working directory
      * @throws IOException if the working directory could not be created
      */
-    public static WorkingDirectory createTaskManagerWorkingDirectory(
-            Configuration configuration, ResourceID resourceId) throws IOException {
-        return WorkingDirectory.create(
-                generateTaskManagerWorkingDirectoryFile(configuration, resourceId));
+    public static DeterminismEnvelope<WorkingDirectory> createTaskManagerWorkingDirectory(
+            Configuration configuration, DeterminismEnvelope<ResourceID> envelopedResourceId)
+            throws IOException {
+        return envelopedResourceId.map(
+                resourceId ->
+                        WorkingDirectory.create(
+                                generateTaskManagerWorkingDirectoryFile(
+                                        configuration, resourceId)));
     }
 
     /**
@@ -225,13 +229,16 @@ public final class ClusterEntrypointUtils {
      * working diretory exists.
      *
      * @param configuration to extract the required settings from
-     * @param resourceId identifying the TaskManager process
+     * @param envelopedResourceId identifying the TaskManager process
      * @return working directory
      * @throws IOException if the working directory could not be created
      */
-    public static WorkingDirectory createJobManagerWorkingDirectory(
-            Configuration configuration, ResourceID resourceId) throws IOException {
-        return WorkingDirectory.create(
-                generateJobManagerWorkingDirectoryFile(configuration, resourceId));
+    public static DeterminismEnvelope<WorkingDirectory> createJobManagerWorkingDirectory(
+            Configuration configuration, DeterminismEnvelope<ResourceID> envelopedResourceId)
+            throws IOException {
+        return envelopedResourceId.map(
+                resourceId ->
+                        WorkingDirectory.create(
+                                generateJobManagerWorkingDirectoryFile(configuration, resourceId)));
     }
 }

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/entrypoint/DeterminismEnvelope.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/entrypoint/DeterminismEnvelope.java
@@ -1,0 +1,70 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.flink.runtime.entrypoint;
+
+import org.apache.flink.util.function.FunctionWithException;
+
+/**
+ * Envelope that carries whether the wrapped value is deterministic or not.
+ *
+ * @param <T> type of the wrapped value
+ */
+public class DeterminismEnvelope<T> {
+
+    private final T value;
+
+    private final boolean isDeterministic;
+
+    private DeterminismEnvelope(T value, boolean isDeterministic) {
+        this.value = value;
+        this.isDeterministic = isDeterministic;
+    }
+
+    public boolean isDeterministic() {
+        return isDeterministic;
+    }
+
+    public T unwrap() {
+        return value;
+    }
+
+    public <V, E extends Exception> DeterminismEnvelope<V> map(
+            FunctionWithException<? super T, ? extends V, E> mapper) throws E {
+        final V newValue = mapper.apply(value);
+
+        if (isDeterministic) {
+            return deterministicValue(newValue);
+        } else {
+            return nondeterministicValue(newValue);
+        }
+    }
+
+    public static <T> DeterminismEnvelope<T> deterministicValue(T value) {
+        return new DeterminismEnvelope<>(value, true);
+    }
+
+    public static <T> DeterminismEnvelope<T> nondeterministicValue(T value) {
+        return new DeterminismEnvelope<>(value, false);
+    }
+
+    @Override
+    public String toString() {
+        return value.toString();
+    }
+}

--- a/flink-runtime/src/test/java/org/apache/flink/runtime/taskexecutor/TaskManagerRunnerTest.java
+++ b/flink-runtime/src/test/java/org/apache/flink/runtime/taskexecutor/TaskManagerRunnerTest.java
@@ -109,7 +109,7 @@ public class TaskManagerRunnerTest extends TestLogger {
         final String metadata = "test";
         configuration.set(TaskManagerOptionsInternal.TASK_MANAGER_RESOURCE_ID_METADATA, metadata);
         final ResourceID taskManagerResourceID =
-                TaskManagerRunner.getTaskManagerResourceID(configuration, "", -1);
+                TaskManagerRunner.getTaskManagerResourceID(configuration, "", -1).unwrap();
 
         assertThat(taskManagerResourceID.getMetadata(), equalTo(metadata));
     }
@@ -120,7 +120,7 @@ public class TaskManagerRunnerTest extends TestLogger {
         final String resourceID = "test";
         configuration.set(TaskManagerOptions.TASK_MANAGER_RESOURCE_ID, resourceID);
         final ResourceID taskManagerResourceID =
-                TaskManagerRunner.getTaskManagerResourceID(configuration, "", -1);
+                TaskManagerRunner.getTaskManagerResourceID(configuration, "", -1).unwrap();
 
         assertThat(taskManagerResourceID.getMetadata(), equalTo(""));
         assertThat(taskManagerResourceID.getStringWithMetadata(), equalTo("test"));
@@ -132,7 +132,7 @@ public class TaskManagerRunnerTest extends TestLogger {
         final String resourceID = "test";
         configuration.set(TaskManagerOptions.TASK_MANAGER_RESOURCE_ID, resourceID);
         final ResourceID taskManagerResourceID =
-                TaskManagerRunner.getTaskManagerResourceID(configuration, "", -1);
+                TaskManagerRunner.getTaskManagerResourceID(configuration, "", -1).unwrap();
 
         assertThat(taskManagerResourceID.getResourceIdString(), equalTo(resourceID));
     }
@@ -143,7 +143,8 @@ public class TaskManagerRunnerTest extends TestLogger {
         final String rpcAddress = "flink";
         final int rpcPort = 9090;
         final ResourceID taskManagerResourceID =
-                TaskManagerRunner.getTaskManagerResourceID(configuration, rpcAddress, rpcPort);
+                TaskManagerRunner.getTaskManagerResourceID(configuration, rpcAddress, rpcPort)
+                        .unwrap();
 
         assertThat(taskManagerResourceID, notNullValue());
         assertThat(
@@ -157,7 +158,8 @@ public class TaskManagerRunnerTest extends TestLogger {
         final String rpcAddress = "";
         final int rpcPort = -1;
         final ResourceID taskManagerResourceID =
-                TaskManagerRunner.getTaskManagerResourceID(configuration, rpcAddress, rpcPort);
+                TaskManagerRunner.getTaskManagerResourceID(configuration, rpcAddress, rpcPort)
+                        .unwrap();
 
         assertThat(taskManagerResourceID, notNullValue());
         assertThat(

--- a/flink-tests/src/test/java/org/apache/flink/test/recovery/TaskManagerRunnerITCase.java
+++ b/flink-tests/src/test/java/org/apache/flink/test/recovery/TaskManagerRunnerITCase.java
@@ -31,13 +31,20 @@ import org.apache.flink.runtime.testutils.CommonTestUtils;
 import org.apache.flink.test.util.TestProcessBuilder;
 import org.apache.flink.util.TestLogger;
 
+import org.apache.flink.shaded.guava30.com.google.common.collect.Iterables;
+
 import org.junit.ClassRule;
 import org.junit.Test;
 import org.junit.rules.TemporaryFolder;
 
 import java.io.File;
+import java.nio.file.Files;
+import java.nio.file.Path;
 import java.time.Duration;
+import java.util.stream.Collectors;
+import java.util.stream.Stream;
 
+import static org.junit.Assert.assertFalse;
 import static org.junit.Assert.assertTrue;
 
 /** Integration tests for the {@link TaskManagerRunner}. */
@@ -46,7 +53,7 @@ public class TaskManagerRunnerITCase extends TestLogger {
     @ClassRule public static final TemporaryFolder TEMPORARY_FOLDER = new TemporaryFolder();
 
     @Test
-    public void testWorkingDirIsNotDeletedInCaseOfProcessFailure() throws Exception {
+    public void testDeterministicWorkingDirIsNotDeletedInCaseOfProcessFailure() throws Exception {
         final File workingDirBase = TEMPORARY_FOLDER.newFolder();
         final ResourceID resourceId = ResourceID.generate();
 
@@ -79,6 +86,54 @@ public class TaskManagerRunnerITCase extends TestLogger {
             taskManagerProcess.getProcess().waitFor();
 
             assertTrue(workingDirectory.exists());
+            success = true;
+        } finally {
+            if (!success) {
+                AbstractTaskManagerProcessFailureRecoveryTest.printProcessLog(
+                        "TaskManager", taskManagerProcess);
+            }
+        }
+    }
+
+    @Test
+    public void testNondeterministicWorkingDirIsDeletedInCaseOfProcessFailure() throws Exception {
+        final File workingDirBase = TEMPORARY_FOLDER.newFolder();
+
+        final Configuration configuration = new Configuration();
+        configuration.set(
+                ClusterOptions.PROCESS_WORKING_DIR_BASE, workingDirBase.getAbsolutePath());
+        configuration.set(JobManagerOptions.ADDRESS, "localhost");
+        configuration.set(AkkaOptions.LOOKUP_TIMEOUT_DURATION, Duration.ZERO);
+
+        final TestProcessBuilder.TestProcess taskManagerProcess =
+                new TestProcessBuilder(
+                                AbstractTaskManagerProcessFailureRecoveryTest
+                                        .TaskExecutorProcessEntryPoint.class
+                                        .getName())
+                        .addConfigAsMainClassArgs(configuration)
+                        .start();
+
+        boolean success = false;
+        try {
+            CommonTestUtils.waitUntilCondition(
+                    () -> {
+                        try (Stream<Path> files = Files.list(workingDirBase.toPath())) {
+                            return files.findAny().isPresent();
+                        }
+                    },
+                    Deadline.fromNow(Duration.ofMinutes(1L)));
+
+            final File workingDirectory =
+                    Iterables.getOnlyElement(
+                                    Files.list(workingDirBase.toPath())
+                                            .collect(Collectors.toList()))
+                            .toFile();
+
+            taskManagerProcess.getProcess().destroy();
+
+            taskManagerProcess.getProcess().waitFor();
+
+            assertFalse(workingDirectory.exists());
             success = true;
         } finally {
             if (!success) {


### PR DESCRIPTION
This commit introduces the distinction between deterministic and non-deterministic
working directories. The former have an explicit configured ResourceID. The latter
will always be deleted because the assumption is that the user won't want to recover
from them. Otherwise, he would have given a deterministic ResourceID.