### PR TITLE
[FLINK-25199][network] Make sure StreamEdges are unique

### DIFF
--- a/flink-streaming-java/src/main/java/org/apache/flink/streaming/api/graph/StreamEdge.java
+++ b/flink-streaming-java/src/main/java/org/apache/flink/streaming/api/graph/StreamEdge.java
@@ -44,6 +44,15 @@ public class StreamEdge implements Serializable {
     private final int sourceId;
     private final int targetId;
 
+    /**
+     * Note that this field doesn't have to be unique among all {@link StreamEdge}s. It's enough if
+     * this field ensures that all logical instances of {@link StreamEdge} are unique, and {@link
+     * #hashCode()} are different and {@link #equals(Object)} returns false, for every possible pair
+     * of {@link StreamEdge}. Especially among two different {@link StreamEdge}s that are connecting
+     * the same pair of nodes.
+     */
+    private final int uniqueId;
+
     /** The type number of the input for co-tasks. */
     private final int typeNumber;
     /** The side-output tag (if any) of this {@link StreamEdge}. */
@@ -78,7 +87,8 @@ public class StreamEdge implements Serializable {
                 ALWAYS_FLUSH_BUFFER_TIMEOUT,
                 outputPartitioner,
                 outputTag,
-                StreamExchangeMode.UNDEFINED);
+                StreamExchangeMode.UNDEFINED,
+                0);
     }
 
     public StreamEdge(
@@ -87,7 +97,8 @@ public class StreamEdge implements Serializable {
             int typeNumber,
             StreamPartitioner<?> outputPartitioner,
             OutputTag outputTag,
-            StreamExchangeMode exchangeMode) {
+            StreamExchangeMode exchangeMode,
+            int uniqueId) {
 
         this(
                 sourceVertex,
@@ -96,7 +107,8 @@ public class StreamEdge implements Serializable {
                 sourceVertex.getBufferTimeout(),
                 outputPartitioner,
                 outputTag,
-                exchangeMode);
+                exchangeMode,
+                uniqueId);
     }
 
     public StreamEdge(
@@ -106,10 +118,12 @@ public class StreamEdge implements Serializable {
             long bufferTimeout,
             StreamPartitioner<?> outputPartitioner,
             OutputTag outputTag,
-            StreamExchangeMode exchangeMode) {
+            StreamExchangeMode exchangeMode,
+            int uniqueId) {
 
         this.sourceId = sourceVertex.getId();
         this.targetId = targetVertex.getId();
+        this.uniqueId = uniqueId;
         this.typeNumber = typeNumber;
         this.bufferTimeout = bufferTimeout;
         this.outputPartitioner = outputPartitioner;
@@ -118,7 +132,15 @@ public class StreamEdge implements Serializable {
         this.targetOperatorName = targetVertex.getOperatorName();
         this.exchangeMode = checkNotNull(exchangeMode);
         this.edgeId =
-                sourceVertex + "_" + targetVertex + "_" + typeNumber + "_" + outputPartitioner;
+                sourceVertex
+                        + "_"
+                        + targetVertex
+                        + "_"
+                        + typeNumber
+                        + "_"
+                        + outputPartitioner
+                        + "_"
+                        + uniqueId;
     }
 
     public int getSourceId() {
@@ -200,6 +222,8 @@ public class StreamEdge implements Serializable {
                 + bufferTimeout
                 + ", outputTag="
                 + outputTag
+                + ", uniqueId="
+                + uniqueId
                 + ')';
     }
 }

--- a/flink-streaming-java/src/main/java/org/apache/flink/streaming/api/graph/StreamGraph.java
+++ b/flink-streaming-java/src/main/java/org/apache/flink/streaming/api/graph/StreamGraph.java
@@ -640,50 +640,75 @@ public class StreamGraph implements Pipeline {
                     outputTag,
                     exchangeMode);
         } else {
-            StreamNode upstreamNode = getStreamNode(upStreamVertexID);
-            StreamNode downstreamNode = getStreamNode(downStreamVertexID);
-
-            // If no partitioner was specified and the parallelism of upstream and downstream
-            // operator matches use forward partitioning, use rebalance otherwise.
-            if (partitioner == null
-                    && upstreamNode.getParallelism() == downstreamNode.getParallelism()) {
-                partitioner = new ForwardPartitioner<Object>();
-            } else if (partitioner == null) {
-                partitioner = new RebalancePartitioner<Object>();
-            }
-
-            if (partitioner instanceof ForwardPartitioner) {
-                if (upstreamNode.getParallelism() != downstreamNode.getParallelism()) {
-                    throw new UnsupportedOperationException(
-                            "Forward partitioning does not allow "
-                                    + "change of parallelism. Upstream operation: "
-                                    + upstreamNode
-                                    + " parallelism: "
-                                    + upstreamNode.getParallelism()
-                                    + ", downstream operation: "
-                                    + downstreamNode
-                                    + " parallelism: "
-                                    + downstreamNode.getParallelism()
-                                    + " You must use another partitioning strategy, such as broadcast, rebalance, shuffle or global.");
-                }
-            }
-
-            if (exchangeMode == null) {
-                exchangeMode = StreamExchangeMode.UNDEFINED;
-            }
-
-            StreamEdge edge =
-                    new StreamEdge(
-                            upstreamNode,
-                            downstreamNode,
-                            typeNumber,
-                            partitioner,
-                            outputTag,
-                            exchangeMode);
-
-            getStreamNode(edge.getSourceId()).addOutEdge(edge);
-            getStreamNode(edge.getTargetId()).addInEdge(edge);
+            createActualEdge(
+                    upStreamVertexID,
+                    downStreamVertexID,
+                    typeNumber,
+                    partitioner,
+                    outputTag,
+                    exchangeMode);
         }
+    }
+
+    private void createActualEdge(
+            Integer upStreamVertexID,
+            Integer downStreamVertexID,
+            int typeNumber,
+            StreamPartitioner<?> partitioner,
+            OutputTag outputTag,
+            StreamExchangeMode exchangeMode) {
+        StreamNode upstreamNode = getStreamNode(upStreamVertexID);
+        StreamNode downstreamNode = getStreamNode(downStreamVertexID);
+
+        // If no partitioner was specified and the parallelism of upstream and downstream
+        // operator matches use forward partitioning, use rebalance otherwise.
+        if (partitioner == null
+                && upstreamNode.getParallelism() == downstreamNode.getParallelism()) {
+            partitioner = new ForwardPartitioner<Object>();
+        } else if (partitioner == null) {
+            partitioner = new RebalancePartitioner<Object>();
+        }
+
+        if (partitioner instanceof ForwardPartitioner) {
+            if (upstreamNode.getParallelism() != downstreamNode.getParallelism()) {
+                throw new UnsupportedOperationException(
+                        "Forward partitioning does not allow "
+                                + "change of parallelism. Upstream operation: "
+                                + upstreamNode
+                                + " parallelism: "
+                                + upstreamNode.getParallelism()
+                                + ", downstream operation: "
+                                + downstreamNode
+                                + " parallelism: "
+                                + downstreamNode.getParallelism()
+                                + " You must use another partitioning strategy, such as broadcast, rebalance, shuffle or global.");
+            }
+        }
+
+        if (exchangeMode == null) {
+            exchangeMode = StreamExchangeMode.UNDEFINED;
+        }
+
+        /**
+         * Just make sure that {@link StreamEdge} connecting same nodes (for example as a result of
+         * self unioning a {@link DataStream}) are distinct and unique. Otherwise it would be
+         * difficult on the {@link StreamTask} to assign {@link RecordWriter}s to correct {@link
+         * StreamEdge}.
+         */
+        int uniqueId = getStreamEdges(upstreamNode.getId(), downstreamNode.getId()).size();
+
+        StreamEdge edge =
+                new StreamEdge(
+                        upstreamNode,
+                        downstreamNode,
+                        typeNumber,
+                        partitioner,
+                        outputTag,
+                        exchangeMode,
+                        uniqueId);
+
+        getStreamNode(edge.getSourceId()).addOutEdge(edge);
+        getStreamNode(edge.getTargetId()).addInEdge(edge);
     }
 
     public void setParallelism(Integer vertexID, int parallelism) {

--- a/flink-streaming-java/src/main/java/org/apache/flink/streaming/api/graph/StreamNode.java
+++ b/flink-streaming-java/src/main/java/org/apache/flink/streaming/api/graph/StreamNode.java
@@ -45,6 +45,7 @@ import java.util.Optional;
 import java.util.Set;
 
 import static org.apache.flink.util.Preconditions.checkArgument;
+import static org.apache.flink.util.Preconditions.checkState;
 
 /** Class representing the operators in the streaming programs, with all their properties. */
 @Internal
@@ -122,6 +123,11 @@ public class StreamNode {
     }
 
     public void addInEdge(StreamEdge inEdge) {
+        checkState(
+                outEdges.stream().noneMatch(inEdge::equals),
+                "Adding not unique edge = %s to existing outEdges = %s",
+                inEdge,
+                inEdges);
         if (inEdge.getTargetId() != getId()) {
             throw new IllegalArgumentException("Destination id doesn't match the StreamNode id");
         } else {
@@ -130,6 +136,11 @@ public class StreamNode {
     }
 
     public void addOutEdge(StreamEdge outEdge) {
+        checkState(
+                outEdges.stream().noneMatch(outEdge::equals),
+                "Adding not unique edge = %s to existing outEdges = %s",
+                outEdge,
+                outEdges);
         if (outEdge.getSourceId() != getId()) {
             throw new IllegalArgumentException("Source id doesn't match the StreamNode id");
         } else {


### PR DESCRIPTION
Previously, if there was a node that was self-unioned with itself,
it was creating a situation with two identical StreamEdges. Both
with the same partitioning, from the same source node to the same
target node.

This was causing issues when constructing output collectors and
picking the correct RecordWriters, as StreamTask was not able to
uniquely identify given StreamEdge and was assigning the same
RecordWriter to both of the edges. As a result all stream elements
were sent twice through the same RecordWriter. It was actually pretty
harmless apart of calculating the combined watermark downstream,
since all watermarks were always comming just from one single
edge/inputgate, and the unused edges were always stuck with
min watermark.

As a solution we are making sure that StreamEdges are unique
by introducing a uniqueId field, incremented for every pair
of StreamEdges connecting the same node.

## Verifying this change

This change adds a new `checkState` for early detection of similar problems and a new ITCase.

## Does this pull request potentially affect one of the following parts:

  - Dependencies (does it add or upgrade a dependency): (yes / **no**)
  - The public API, i.e., is any changed class annotated with `@Public(Evolving)`: (yes / **no**)
  - The serializers: (yes / **no** / don't know)
  - The runtime per-record code paths (performance sensitive): (yes / **no** / don't know)
  - Anything that affects deployment or recovery: JobManager (and its components), Checkpointing, Kubernetes/Yarn, ZooKeeper: (yes / **no** / don't know)
  - The S3 file system connector: (yes / **no** / don't know)

## Documentation

  - Does this pull request introduce a new feature? (yes / **no**)
  - If yes, how is the feature documented? (**not applicable** / docs / JavaDocs / not documented)
