### PR TITLE
[FLINK-25731][connectors/kinesis] Deprecated FlinkKinesisConsumer / F…

### DIFF
--- a/flink-connectors/flink-connector-kinesis/src/main/java/org/apache/flink/streaming/connectors/kinesis/FlinkKinesisProducer.java
+++ b/flink-connectors/flink-connector-kinesis/src/main/java/org/apache/flink/streaming/connectors/kinesis/FlinkKinesisProducer.java
@@ -61,7 +61,13 @@ import static org.apache.flink.util.Preconditions.checkNotNull;
  * The FlinkKinesisProducer allows to produce from a Flink DataStream into Kinesis.
  *
  * @param <OUT> Data type to produce into Kinesis Streams
+ * @deprecated This producer based on the Kinesis Producer Library KPL has been superseded. The new
+ *     sink can be found in the module {@code
+ *     flink-connectors/flink-connector-aws-kinesis-data-streams} and package {@link
+ *     org.apache.flink.connector.kinesis.sink.KinesisDataStreamsSink}. It is based on the AWS SDK
+ *     for Java 2.x. The work to replace this sink was carried out in FLINK-24227.
  */
+@Deprecated
 @PublicEvolving
 public class FlinkKinesisProducer<OUT> extends RichSinkFunction<OUT>
         implements CheckpointedFunction {


### PR DESCRIPTION
…linkKinesisProducer

<!--
*Thank you very much for contributing to Apache Flink - we are happy that you want to help us improve Flink. To help the community review your contribution in the best possible way, please go through the checklist below, which will get the contribution into a shape in which it can be best reviewed.*

*Please understand that we do not do this to make contributions to Flink a hassle. In order to uphold a high standard of quality for code contributions, while at the same time managing a large number of contributions, we need contributors to prepare the contributions well, and give reviewers enough contextual information for the review. Please also understand that contributions that do not follow this guide will take longer to review and thus typically be picked up with lower priority by the community.*

## Contribution Checklist

  - Make sure that the pull request corresponds to a [JIRA issue](https://issues.apache.org/jira/projects/FLINK/issues). Exceptions are made for typos in JavaDoc or documentation files, which need no JIRA issue.
  
  - Name the pull request in the form "[FLINK-XXXX] [component] Title of the pull request", where *FLINK-XXXX* should be replaced by the actual issue number. Skip *component* if you are unsure about which is the best component.
  Typo fixes that have no associated JIRA issue should be named following this pattern: `[hotfix] [docs] Fix typo in event time introduction` or `[hotfix] [javadocs] Expand JavaDoc for PuncuatedWatermarkGenerator`.

  - Fill out the template below to describe the changes contributed by the pull request. That will give reviewers the context they need to do the review.
  
  - Make sure that the change passes the automated tests, i.e., `mvn clean verify` passes. You can set up Azure Pipelines CI to do that following [this guide](https://cwiki.apache.org/confluence/display/FLINK/Azure+Pipelines#AzurePipelines-Tutorial:SettingupAzurePipelinesforaforkoftheFlinkrepository).

  - Each pull request should address only one issue, not mix up code from multiple issues.
  
  - Each commit in the pull request has a meaningful commit message (including the JIRA id)

  - Once all items of the checklist are addressed, remove the above text and this checklist, leaving only the filled out template below.


**(The sections below can be removed for hotfixes of typos)**
-->

## What is the purpose of the change

To deprecate the FlinkKinesisConsumer / FlinkKinesisProducer in favour of:
 * This consumer based on the Kinesis Consumer Library (KCL) has been deprecated, a Jira to create an equivalent consumer based on AWS SDK for Java 2.x has been raised in FLINK-25729 and planned for Flink 1.16.

 * This producer based on the Kinesis Producer Library KPL has been superseded. The new sink can be found in the module flink-connectors/flink-connector-aws-kinesis-data-streams and package org.apache.flink.connector.kinesis.sink.KinesisDataStreamsSink. It is based on the AWS SDK for Java 2.x. The work to replace this sink was carried out in FLINK-24227.


## Brief change log

- Deprecated FlinkKinesisConsumer / FlinkKinesisProducer with message.


## Verifying this change

This change is a trivial rework / code cleanup without any test coverage.

## Does this pull request potentially affect one of the following parts:

  - Dependencies (does it add or upgrade a dependency): (yes / no)n
  - The public API, i.e., is any changed class annotated with `@Public(Evolving)`: (yes / no)n
  - The serializers: (yes / no / don't know)n
  - The runtime per-record code paths (performance sensitive): (yes / no / don't know)n
  - Anything that affects deployment or recovery: JobManager (and its components), Checkpointing, Kubernetes/Yarn, ZooKeeper: (yes / no / don't know)n
  - The S3 file system connector: (yes / no / don't know)n

## Documentation

  - Does this pull request introduce a new feature? (yes / no)n
  - If yes, how is the feature documented? (not applicable / docs / JavaDocs / not documented)
