### PR TITLE
[FLINK-24439][source] Introduce CoordinatorStore

### DIFF
--- a/flink-runtime/src/main/java/org/apache/flink/runtime/executiongraph/DefaultExecutionGraph.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/executiongraph/DefaultExecutionGraph.java
@@ -60,6 +60,8 @@ import org.apache.flink.runtime.jobgraph.JobVertex;
 import org.apache.flink.runtime.jobgraph.JobVertexID;
 import org.apache.flink.runtime.jobgraph.tasks.CheckpointCoordinatorConfiguration;
 import org.apache.flink.runtime.jobmanager.scheduler.SlotSharingGroup;
+import org.apache.flink.runtime.operators.coordination.CoordinatorStore;
+import org.apache.flink.runtime.operators.coordination.CoordinatorStoreImpl;
 import org.apache.flink.runtime.query.KvStateLocationRegistry;
 import org.apache.flink.runtime.scheduler.InternalFailuresListener;
 import org.apache.flink.runtime.scheduler.SsgNetworkMemoryCalculationUtils;
@@ -130,6 +132,9 @@ public class DefaultExecutionGraph implements ExecutionGraph, InternalExecutionG
 
     /** The executor which is used to execute blocking io operations. */
     private final Executor ioExecutor;
+
+    /** {@link CoordinatorStore} shared across all operator coordinators within this execution. */
+    private final CoordinatorStore coordinatorStore = new CoordinatorStoreImpl();
 
     /** Executor that runs tasks in the job manager's main thread. */
     @Nonnull private ComponentMainThreadExecutor jobMasterMainThreadExecutor;
@@ -845,7 +850,8 @@ public class DefaultExecutionGraph implements ExecutionGraph, InternalExecutionG
                 maxPriorAttemptsHistoryLength,
                 rpcTimeout,
                 createTimestamp,
-                this.initialAttemptCounts.getAttemptCounts(ejv.getJobVertexId()));
+                this.initialAttemptCounts.getAttemptCounts(ejv.getJobVertexId()),
+                coordinatorStore);
 
         ejv.connectToPredecessors(this.intermediateResults);
 

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/executiongraph/ExecutionJobVertex.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/executiongraph/ExecutionJobVertex.java
@@ -42,6 +42,7 @@ import org.apache.flink.runtime.jobgraph.JobVertex;
 import org.apache.flink.runtime.jobgraph.JobVertexID;
 import org.apache.flink.runtime.jobmanager.scheduler.CoLocationGroup;
 import org.apache.flink.runtime.jobmanager.scheduler.SlotSharingGroup;
+import org.apache.flink.runtime.operators.coordination.CoordinatorStore;
 import org.apache.flink.runtime.operators.coordination.OperatorCoordinator;
 import org.apache.flink.runtime.operators.coordination.OperatorCoordinatorHolder;
 import org.apache.flink.runtime.scheduler.VertexParallelismInformation;
@@ -158,7 +159,8 @@ public class ExecutionJobVertex
             int maxPriorAttemptsHistoryLength,
             Time timeout,
             long createTimestamp,
-            SubtaskAttemptNumberStore initialAttemptCounts)
+            SubtaskAttemptNumberStore initialAttemptCounts,
+            CoordinatorStore coordinatorStore)
             throws JobException {
 
         checkState(parallelismInfo.getParallelism() > 0);
@@ -219,7 +221,7 @@ public class ExecutionJobVertex
                         coordinatorProviders) {
                     coordinators.add(
                             OperatorCoordinatorHolder.create(
-                                    provider, this, graph.getUserClassLoader()));
+                                    provider, this, graph.getUserClassLoader(), coordinatorStore));
                 }
             } catch (Exception | LinkageError e) {
                 IOUtils.closeAllQuietly(coordinators);

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/operators/coordination/CoordinatorStore.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/operators/coordination/CoordinatorStore.java
@@ -1,0 +1,45 @@
+/*
+Licensed to the Apache Software Foundation (ASF) under one
+or more contributor license agreements.  See the NOTICE file
+distributed with this work for additional information
+regarding copyright ownership.  The ASF licenses this file
+to you under the Apache License, Version 2.0 (the
+"License"); you may not use this file except in compliance
+with the License.  You may obtain a copy of the License at
+
+      http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package org.apache.flink.runtime.operators.coordination;
+
+import org.apache.flink.annotation.Internal;
+
+import javax.annotation.concurrent.ThreadSafe;
+
+import java.util.function.BiFunction;
+import java.util.function.Function;
+
+/**
+ * {@link CoordinatorStore} can be used for sharing some information among {@link
+ * OperatorCoordinator} instances. Motivating example is/was combining/aggregating latest watermark
+ * emitted by different sources in order to do the watermark alignment.
+ */
+@ThreadSafe
+@Internal
+public interface CoordinatorStore {
+    boolean containsKey(Object key);
+
+    Object get(Object key);
+
+    Object putIfAbsent(Object key, Object value);
+
+    Object computeIfPresent(Object key, BiFunction<Object, Object, Object> remappingFunction);
+
+    <R> R apply(Object key, Function<Object, R> consumer);
+}

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/operators/coordination/CoordinatorStoreImpl.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/operators/coordination/CoordinatorStoreImpl.java
@@ -1,0 +1,61 @@
+/*
+Licensed to the Apache Software Foundation (ASF) under one
+or more contributor license agreements.  See the NOTICE file
+distributed with this work for additional information
+regarding copyright ownership.  The ASF licenses this file
+to you under the Apache License, Version 2.0 (the
+"License"); you may not use this file except in compliance
+with the License.  You may obtain a copy of the License at
+
+      http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package org.apache.flink.runtime.operators.coordination;
+
+import org.apache.flink.annotation.Internal;
+
+import javax.annotation.concurrent.ThreadSafe;
+
+import java.util.Map;
+import java.util.concurrent.ConcurrentHashMap;
+import java.util.function.BiFunction;
+import java.util.function.Function;
+
+/** Basic implementation of {@link CoordinatorStore}. */
+@ThreadSafe
+@Internal
+public class CoordinatorStoreImpl implements CoordinatorStore {
+    private final Map<Object, Object> store = new ConcurrentHashMap<>();
+
+    @Override
+    public boolean containsKey(Object key) {
+        return store.containsKey(key);
+    }
+
+    @Override
+    public Object get(Object key) {
+        return store.get(key);
+    }
+
+    @Override
+    public Object putIfAbsent(Object key, Object value) {
+        return store.putIfAbsent(key, value);
+    }
+
+    @Override
+    public Object computeIfPresent(
+            Object key, BiFunction<Object, Object, Object> remappingFunction) {
+        return store.computeIfPresent(key, remappingFunction);
+    }
+
+    @Override
+    public <R> R apply(Object key, Function<Object, R> consumer) {
+        return consumer.apply(store.get(key));
+    }
+}

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/operators/coordination/OperatorCoordinator.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/operators/coordination/OperatorCoordinator.java
@@ -254,6 +254,12 @@ public interface OperatorCoordinator extends CheckpointListener, AutoCloseable {
          * JVM's classpath.
          */
         ClassLoader getUserCodeClassloader();
+
+        /**
+         * Get the {@link CoordinatorStore} instance for sharring information between {@link
+         * OperatorCoordinator}s.
+         */
+        CoordinatorStore getCoordinatorStore();
     }
 
     // ------------------------------------------------------------------------

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/operators/coordination/RecreateOnResetOperatorCoordinator.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/operators/coordination/RecreateOnResetOperatorCoordinator.java
@@ -233,6 +233,11 @@ public class RecreateOnResetOperatorCoordinator implements OperatorCoordinator {
             return context.getUserCodeClassloader();
         }
 
+        @Override
+        public CoordinatorStore getCoordinatorStore() {
+            return context.getCoordinatorStore();
+        }
+
         @VisibleForTesting
         synchronized void quiesce() {
             quiesced = true;

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/source/coordinator/SourceCoordinator.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/source/coordinator/SourceCoordinator.java
@@ -28,6 +28,7 @@ import org.apache.flink.api.connector.source.SplitEnumerator;
 import org.apache.flink.core.io.SimpleVersionedSerializer;
 import org.apache.flink.core.memory.DataInputViewStreamWrapper;
 import org.apache.flink.core.memory.DataOutputViewStreamWrapper;
+import org.apache.flink.runtime.operators.coordination.CoordinatorStore;
 import org.apache.flink.runtime.operators.coordination.OperatorCoordinator;
 import org.apache.flink.runtime.operators.coordination.OperatorEvent;
 import org.apache.flink.runtime.source.event.ReaderRegistrationEvent;
@@ -88,6 +89,8 @@ public class SourceCoordinator<SplitT extends SourceSplit, EnumChkT>
     private final SimpleVersionedSerializer<EnumChkT> enumCheckpointSerializer;
     /** The context containing the states of the coordinator. */
     private final SourceCoordinatorContext<SplitT> context;
+
+    private final CoordinatorStore coordinatorStore;
     /**
      * The split enumerator created from the associated Source. This one is created either during
      * resetting the coordinator to a checkpoint, or when the coordinator is started.
@@ -100,12 +103,14 @@ public class SourceCoordinator<SplitT extends SourceSplit, EnumChkT>
             String operatorName,
             ExecutorService coordinatorExecutor,
             Source<?, SplitT, EnumChkT> source,
-            SourceCoordinatorContext<SplitT> context) {
+            SourceCoordinatorContext<SplitT> context,
+            CoordinatorStore coordinatorStore) {
         this.operatorName = operatorName;
         this.coordinatorExecutor = coordinatorExecutor;
         this.source = source;
         this.enumCheckpointSerializer = source.getEnumeratorCheckpointSerializer();
         this.context = context;
+        this.coordinatorStore = coordinatorStore;
     }
 
     @Override

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/source/coordinator/SourceCoordinatorProvider.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/source/coordinator/SourceCoordinatorProvider.java
@@ -83,7 +83,11 @@ public class SourceCoordinatorProvider<SplitT extends SourceSplit>
                         context,
                         splitSerializer);
         return new SourceCoordinator<>(
-                operatorName, coordinatorExecutor, source, sourceCoordinatorContext);
+                operatorName,
+                coordinatorExecutor,
+                source,
+                sourceCoordinatorContext,
+                context.getCoordinatorStore());
     }
 
     /** A thread factory class that provides some helper methods. */

--- a/flink-runtime/src/test/java/org/apache/flink/runtime/executiongraph/ExecutionJobVertexTest.java
+++ b/flink-runtime/src/test/java/org/apache/flink/runtime/executiongraph/ExecutionJobVertexTest.java
@@ -24,6 +24,7 @@ import org.apache.flink.runtime.io.network.partition.ResultPartitionType;
 import org.apache.flink.runtime.jobgraph.IntermediateDataSetID;
 import org.apache.flink.runtime.jobgraph.JobVertex;
 import org.apache.flink.runtime.jobgraph.tasks.AbstractInvokable;
+import org.apache.flink.runtime.operators.coordination.CoordinatorStoreImpl;
 import org.apache.flink.runtime.scheduler.VertexParallelismInformation;
 import org.apache.flink.runtime.scheduler.VertexParallelismStore;
 import org.apache.flink.runtime.scheduler.adaptivebatch.AdaptiveBatchScheduler;
@@ -185,7 +186,8 @@ public class ExecutionJobVertexTest {
                 1,
                 Time.milliseconds(1L),
                 1L,
-                new DefaultSubtaskAttemptNumberStore(Collections.emptyList()));
+                new DefaultSubtaskAttemptNumberStore(Collections.emptyList()),
+                new CoordinatorStoreImpl());
     }
 
     private static ExecutionJobVertex createDynamicExecutionJobVertex() throws Exception {

--- a/flink-runtime/src/test/java/org/apache/flink/runtime/operators/coordination/MockOperatorCoordinatorContext.java
+++ b/flink-runtime/src/test/java/org/apache/flink/runtime/operators/coordination/MockOperatorCoordinatorContext.java
@@ -26,6 +26,7 @@ public class MockOperatorCoordinatorContext implements OperatorCoordinator.Conte
     private final OperatorID operatorID;
     private final ClassLoader userCodeClassLoader;
     private final int numSubtasks;
+    private final CoordinatorStore coordinatorStore = new CoordinatorStoreImpl();
 
     private boolean jobFailed;
     private Throwable jobFailureReason;
@@ -66,6 +67,11 @@ public class MockOperatorCoordinatorContext implements OperatorCoordinator.Conte
     @Override
     public ClassLoader getUserCodeClassloader() {
         return userCodeClassLoader;
+    }
+
+    @Override
+    public CoordinatorStore getCoordinatorStore() {
+        return coordinatorStore;
     }
 
     // -------------------------------

--- a/flink-runtime/src/test/java/org/apache/flink/runtime/operators/coordination/OperatorCoordinatorHolderTest.java
+++ b/flink-runtime/src/test/java/org/apache/flink/runtime/operators/coordination/OperatorCoordinatorHolderTest.java
@@ -506,6 +506,7 @@ public class OperatorCoordinatorHolderTest extends TestLogger {
                 OperatorCoordinatorHolder.create(
                         opId,
                         provider,
+                        new CoordinatorStoreImpl(),
                         "test-coordinator-name",
                         getClass().getClassLoader(),
                         3,

--- a/flink-runtime/src/test/java/org/apache/flink/runtime/scheduler/adaptive/ExecutingTest.java
+++ b/flink-runtime/src/test/java/org/apache/flink/runtime/scheduler/adaptive/ExecutingTest.java
@@ -53,6 +53,7 @@ import org.apache.flink.runtime.io.network.partition.JobMasterPartitionTracker;
 import org.apache.flink.runtime.jobgraph.IntermediateResultPartitionID;
 import org.apache.flink.runtime.jobgraph.JobVertex;
 import org.apache.flink.runtime.jobgraph.JobVertexID;
+import org.apache.flink.runtime.operators.coordination.CoordinatorStoreImpl;
 import org.apache.flink.runtime.scheduler.DefaultVertexParallelismInfo;
 import org.apache.flink.runtime.scheduler.ExecutionGraphHandler;
 import org.apache.flink.runtime.scheduler.OperatorCoordinatorHandler;
@@ -763,7 +764,8 @@ public class ExecutingTest extends TestLogger {
                     1,
                     Time.milliseconds(1L),
                     1L,
-                    new DefaultSubtaskAttemptNumberStore(Collections.emptyList()));
+                    new DefaultSubtaskAttemptNumberStore(Collections.emptyList()),
+                    new CoordinatorStoreImpl());
             mockExecutionVertex = executionVertexSupplier.apply(this);
         }
 

--- a/flink-runtime/src/test/java/org/apache/flink/runtime/source/coordinator/SourceCoordinatorTest.java
+++ b/flink-runtime/src/test/java/org/apache/flink/runtime/source/coordinator/SourceCoordinatorTest.java
@@ -33,6 +33,7 @@ import org.apache.flink.api.connector.source.mocks.MockSplitEnumeratorContext;
 import org.apache.flink.core.io.SimpleVersionedSerializer;
 import org.apache.flink.core.memory.DataOutputSerializer;
 import org.apache.flink.runtime.jobgraph.OperatorID;
+import org.apache.flink.runtime.operators.coordination.CoordinatorStoreImpl;
 import org.apache.flink.runtime.operators.coordination.MockOperatorCoordinatorContext;
 import org.apache.flink.runtime.operators.coordination.OperatorCoordinator;
 import org.apache.flink.runtime.source.event.SourceEventWrapper;
@@ -244,7 +245,8 @@ public class SourceCoordinatorTest extends SourceCoordinatorTestBase {
                                 OPERATOR_NAME,
                                 coordinatorExecutor,
                                 new EnumeratorCreatingSource<>(() -> splitEnumerator),
-                                context)) {
+                                context,
+                                new CoordinatorStoreImpl())) {
 
             coordinator.start();
             waitUtil(
@@ -267,7 +269,8 @@ public class SourceCoordinatorTest extends SourceCoordinatorTestBase {
                                 () -> {
                                     throw failureReason;
                                 }),
-                        context);
+                        context,
+                        new CoordinatorStoreImpl());
 
         coordinator.start();
 
@@ -292,7 +295,8 @@ public class SourceCoordinatorTest extends SourceCoordinatorTestBase {
                                 OPERATOR_NAME,
                                 coordinatorExecutor,
                                 new EnumeratorCreatingSource<>(() -> splitEnumerator),
-                                context)) {
+                                context,
+                                new CoordinatorStoreImpl())) {
 
             coordinator.start();
             coordinator.handleEventFromOperator(1, new SourceEventWrapper(new SourceEvent() {}));

--- a/flink-runtime/src/test/java/org/apache/flink/runtime/source/coordinator/SourceCoordinatorTestBase.java
+++ b/flink-runtime/src/test/java/org/apache/flink/runtime/source/coordinator/SourceCoordinatorTestBase.java
@@ -23,6 +23,7 @@ import org.apache.flink.api.connector.source.mocks.MockSourceSplit;
 import org.apache.flink.api.connector.source.mocks.MockSourceSplitSerializer;
 import org.apache.flink.api.connector.source.mocks.MockSplitEnumeratorCheckpointSerializer;
 import org.apache.flink.runtime.jobgraph.OperatorID;
+import org.apache.flink.runtime.operators.coordination.CoordinatorStoreImpl;
 import org.apache.flink.runtime.operators.coordination.EventReceivingTasks;
 import org.apache.flink.runtime.operators.coordination.MockOperatorCoordinatorContext;
 import org.apache.flink.runtime.source.event.ReaderRegistrationEvent;
@@ -153,7 +154,11 @@ public abstract class SourceCoordinatorTestBase {
                         new MockSplitEnumeratorCheckpointSerializer());
 
         return new SourceCoordinator<>(
-                OPERATOR_NAME, coordinatorExecutor, mockSource, getNewSourceCoordinatorContext());
+                OPERATOR_NAME,
+                coordinatorExecutor,
+                mockSource,
+                getNewSourceCoordinatorContext(),
+                new CoordinatorStoreImpl());
     }
 
     protected SourceCoordinatorContext<MockSourceSplit> getNewSourceCoordinatorContext() {


### PR DESCRIPTION
In order to allow `SourceCoordinators`s from different `Source`s (for example two different Kafka sources, or Kafka and Kinesis) to align watermarks, they have to be able to exchange information/aggregate watermarks from those different Sources. To enable this, we need to provide some CoordinatorStore concept, that would be a thread safe singleton.

## Does this pull request potentially affect one of the following parts:

  - Dependencies (does it add or upgrade a dependency): (yes / **no**)
  - The public API, i.e., is any changed class annotated with `@Public(Evolving)`: (yes / **no**)
  - The serializers: (yes / **no** / don't know)
  - The runtime per-record code paths (performance sensitive): (yes / **no** / don't know)
  - Anything that affects deployment or recovery: JobManager (and its components), Checkpointing, Kubernetes/Yarn, ZooKeeper: (yes / **no** / don't know)
  - The S3 file system connector: (yes / **no** / don't know)

## Documentation

  - Does this pull request introduce a new feature? (**yes** / no)
  - If yes, how is the feature documented? (not applicable / docs / **JavaDocs** / not documented)
