### PR TITLE
[BP-1.13][FLINK-24334][k8s] Set FLINK_LOG_DIR environment for JobManager and TaskManager pod if configured via options

### DIFF
--- a/docs/layouts/shortcodes/generated/kubernetes_config_configuration.html
+++ b/docs/layouts/shortcodes/generated/kubernetes_config_configuration.html
@@ -76,9 +76,9 @@
         </tr>
         <tr>
             <td><h5>kubernetes.flink.log.dir</h5></td>
-            <td style="word-wrap: break-word;">"/opt/flink/log"</td>
+            <td style="word-wrap: break-word;">(none)</td>
             <td>String</td>
-            <td>The directory that logs of jobmanager and taskmanager be saved in the pod.</td>
+            <td>The directory that logs of jobmanager and taskmanager be saved in the pod. The default value is $FLINK_HOME/log.</td>
         </tr>
         <tr>
             <td><h5>kubernetes.hadoop.conf.config-map.name</h5></td>

--- a/flink-kubernetes/src/main/java/org/apache/flink/kubernetes/configuration/KubernetesConfigOptions.java
+++ b/flink-kubernetes/src/main/java/org/apache/flink/kubernetes/configuration/KubernetesConfigOptions.java
@@ -245,9 +245,10 @@ public class KubernetesConfigOptions {
     public static final ConfigOption<String> FLINK_LOG_DIR =
             key("kubernetes.flink.log.dir")
                     .stringType()
-                    .defaultValue("/opt/flink/log")
+                    .noDefaultValue()
                     .withDescription(
-                            "The directory that logs of jobmanager and taskmanager be saved in the pod.");
+                            "The directory that logs of jobmanager and taskmanager be saved in the pod. "
+                                    + "The default value is $FLINK_HOME/log.");
 
     public static final ConfigOption<String> HADOOP_CONF_CONFIG_MAP =
             key("kubernetes.hadoop.conf.config-map.name")

--- a/flink-kubernetes/src/main/java/org/apache/flink/kubernetes/kubeclient/decorators/InitJobManagerDecorator.java
+++ b/flink-kubernetes/src/main/java/org/apache/flink/kubernetes/kubeclient/decorators/InitJobManagerDecorator.java
@@ -39,6 +39,7 @@ import io.fabric8.kubernetes.api.model.ResourceRequirements;
 import java.util.Arrays;
 import java.util.Collections;
 import java.util.List;
+import java.util.Optional;
 import java.util.stream.Collectors;
 
 import static org.apache.flink.kubernetes.utils.Constants.API_VERSION;
@@ -149,6 +150,7 @@ public class InitJobManagerDecorator extends AbstractKubernetesStepDecorator {
                                 .withNewFieldRef(API_VERSION, POD_IP_FIELD_PATH)
                                 .build())
                 .endEnv();
+        getFlinkLogDirEnv().ifPresent(mainContainerBuilder::addToEnv);
         return mainContainerBuilder.build();
     }
 
@@ -177,5 +179,11 @@ public class InitJobManagerDecorator extends AbstractKubernetesStepDecorator {
                                         .withValue(kv.getValue())
                                         .build())
                 .collect(Collectors.toList());
+    }
+
+    private Optional<EnvVar> getFlinkLogDirEnv() {
+        return kubernetesJobManagerParameters
+                .getFlinkLogDirInPod()
+                .map(logDir -> new EnvVar(Constants.ENV_FLINK_LOG_DIR, logDir, null));
     }
 }

--- a/flink-kubernetes/src/main/java/org/apache/flink/kubernetes/kubeclient/decorators/InitTaskManagerDecorator.java
+++ b/flink-kubernetes/src/main/java/org/apache/flink/kubernetes/kubeclient/decorators/InitTaskManagerDecorator.java
@@ -34,6 +34,7 @@ import io.fabric8.kubernetes.api.model.PodBuilder;
 import io.fabric8.kubernetes.api.model.ResourceRequirements;
 
 import java.util.List;
+import java.util.Optional;
 import java.util.stream.Collectors;
 
 import static org.apache.flink.util.Preconditions.checkNotNull;
@@ -144,6 +145,7 @@ public class InitTaskManagerDecorator extends AbstractKubernetesStepDecorator {
                                 .withContainerPort(kubernetesTaskManagerParameters.getRPCPort())
                                 .build())
                 .addAllToEnv(getCustomizedEnvs());
+        getFlinkLogDirEnv().ifPresent(mainContainerBuilder::addToEnv);
 
         return mainContainerBuilder.build();
     }
@@ -152,5 +154,11 @@ public class InitTaskManagerDecorator extends AbstractKubernetesStepDecorator {
         return kubernetesTaskManagerParameters.getEnvironments().entrySet().stream()
                 .map(kv -> new EnvVar(kv.getKey(), kv.getValue(), null))
                 .collect(Collectors.toList());
+    }
+
+    private Optional<EnvVar> getFlinkLogDirEnv() {
+        return kubernetesTaskManagerParameters
+                .getFlinkLogDirInPod()
+                .map(logDir -> new EnvVar(Constants.ENV_FLINK_LOG_DIR, logDir, null));
     }
 }

--- a/flink-kubernetes/src/main/java/org/apache/flink/kubernetes/kubeclient/parameters/AbstractKubernetesParameters.java
+++ b/flink-kubernetes/src/main/java/org/apache/flink/kubernetes/kubeclient/parameters/AbstractKubernetesParameters.java
@@ -131,8 +131,8 @@ public abstract class AbstractKubernetesParameters implements KubernetesParamete
     }
 
     @Override
-    public String getFlinkLogDirInPod() {
-        return flinkConfig.getString(KubernetesConfigOptions.FLINK_LOG_DIR);
+    public Optional<String> getFlinkLogDirInPod() {
+        return Optional.ofNullable(flinkConfig.getString(KubernetesConfigOptions.FLINK_LOG_DIR));
     }
 
     @Override

--- a/flink-kubernetes/src/main/java/org/apache/flink/kubernetes/kubeclient/parameters/KubernetesParameters.java
+++ b/flink-kubernetes/src/main/java/org/apache/flink/kubernetes/kubeclient/parameters/KubernetesParameters.java
@@ -82,7 +82,7 @@ public interface KubernetesParameters {
     String getFlinkConfDirInPod();
 
     /** Directory in Pod that saves the log files. */
-    String getFlinkLogDirInPod();
+    Optional<String> getFlinkLogDirInPod();
 
     /** The docker entrypoint that starts processes in the container. */
     String getContainerEntrypoint();

--- a/flink-kubernetes/src/main/java/org/apache/flink/kubernetes/utils/Constants.java
+++ b/flink-kubernetes/src/main/java/org/apache/flink/kubernetes/utils/Constants.java
@@ -27,6 +27,7 @@ public class Constants {
 
     public static final String CONFIG_FILE_LOGBACK_NAME = "logback-console.xml";
     public static final String CONFIG_FILE_LOG4J_NAME = "log4j-console.properties";
+    public static final String ENV_FLINK_LOG_DIR = "FLINK_LOG_DIR";
 
     public static final String MAIN_CONTAINER_NAME = "flink-main-container";
 

--- a/flink-kubernetes/src/test/java/org/apache/flink/kubernetes/kubeclient/decorators/InitJobManagerDecoratorTest.java
+++ b/flink-kubernetes/src/test/java/org/apache/flink/kubernetes/kubeclient/decorators/InitJobManagerDecoratorTest.java
@@ -67,6 +67,8 @@ public class InitJobManagerDecoratorTest extends KubernetesJobManagerTestBase {
                     new Toleration("NoSchedule", "key1", "Equal", null, "value1"),
                     new Toleration("NoExecute", "key2", "Exists", 6000L, null));
 
+    private static final String USER_DEFINED_FLINK_LOG_DIR = "/path/of/flink-log";
+
     private Pod resultPod;
     private Container resultMainContainer;
 
@@ -81,6 +83,7 @@ public class InitJobManagerDecoratorTest extends KubernetesJobManagerTestBase {
         this.flinkConfig.set(KubernetesConfigOptions.JOB_MANAGER_ANNOTATIONS, ANNOTATIONS);
         this.flinkConfig.setString(
                 KubernetesConfigOptions.JOB_MANAGER_TOLERATIONS.key(), TOLERATION_STRING);
+        this.flinkConfig.set(KubernetesConfigOptions.FLINK_LOG_DIR, USER_DEFINED_FLINK_LOG_DIR);
     }
 
     @Override
@@ -209,5 +212,18 @@ public class InitJobManagerDecoratorTest extends KubernetesJobManagerTestBase {
         assertThat(
                 this.resultPod.getSpec().getTolerations(),
                 Matchers.containsInAnyOrder(TOLERATION.toArray()));
+    }
+
+    @Test
+    public void testFlinkLogDirEnvShouldBeSetIfConfiguredViaOptions() {
+        final List<EnvVar> envVars = this.resultMainContainer.getEnv();
+        assertThat(
+                envVars.stream()
+                        .anyMatch(
+                                envVar ->
+                                        envVar.getName().equals(Constants.ENV_FLINK_LOG_DIR)
+                                                && envVar.getValue()
+                                                        .equals(USER_DEFINED_FLINK_LOG_DIR)),
+                is(true));
     }
 }


### PR DESCRIPTION
Backport #17503 to release-1.13.