### PR TITLE
[hotfix][filesystem] Fix the typo in InProgressFileWriter

### DIFF
--- a/flink-connectors/flink-file-sink-common/src/main/java/org/apache/flink/streaming/api/functions/sink/filesystem/InProgressFileWriter.java
+++ b/flink-connectors/flink-file-sink-common/src/main/java/org/apache/flink/streaming/api/functions/sink/filesystem/InProgressFileWriter.java
@@ -27,7 +27,7 @@ import java.io.IOException;
 public interface InProgressFileWriter<IN, BucketID> extends PartFileInfo<BucketID> {
 
     /**
-     * Write a element to the part file.
+     * Write an element to the part file.
      *
      * @param element the element to be written.
      * @param currentTime the writing time.


### PR DESCRIPTION
## What is the purpose of the change

This PR is trivial, nothing but fixing a typo in `InProgressFileWriter`


## Brief changelog

`InProgressFileWriter`
  - a element => an element


## Verifying this change

This change is a trivial rework/code cleanup without any test coverage.

## Does this pull request potentially affect one of the following parts:

  - Dependencies (does it add or upgrade a dependency): (yes / **no**)
  - The public API, i.e., is any changed class annotated with `@Public(Evolving)`: (yes / **no**)
  - The serializers: (yes / **no** / don't know)
  - The runtime per-record code paths (performance sensitive): (yes / **no** / don't know)
  - Anything that affects deployment or recovery: JobManager (and its components), Checkpointing, Kubernetes/Yarn, ZooKeeper: (yes / **no** / don't know)
  - The S3 file system connector: (yes / **no** / don't know)

## Documentation

  - Does this pull request introduce a new feature? (yes / **no**)
  - If yes, how is the feature documented? (**not applicable** / docs / JavaDocs / not documented)
