### PR TITLE
[FLINK-25707] AdaptiveScheduler transitions executions to scheduled 

### DIFF
--- a/flink-runtime/src/main/java/org/apache/flink/runtime/executiongraph/Execution.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/executiongraph/Execution.java
@@ -511,9 +511,8 @@ public class Execution
         }
 
         // make sure exactly one deployment call happens from the correct state
-        // note: the transition from CREATED to DEPLOYING is for testing purposes only
         ExecutionState previous = this.state;
-        if (previous == SCHEDULED || previous == CREATED) {
+        if (previous == SCHEDULED) {
             if (!transitionState(previous, DEPLOYING)) {
                 // race condition, someone else beat us to the deploying call.
                 // this should actually not happen and indicates a race somewhere else
@@ -523,7 +522,7 @@ public class Execution
         } else {
             // vertex may have been cancelled, or it was already scheduled
             throw new IllegalStateException(
-                    "The vertex must be in CREATED or SCHEDULED state to be deployed. Found state "
+                    "The vertex must be in SCHEDULED state to be deployed. Found state "
                             + previous);
         }
 

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/scheduler/adaptive/CreatingExecutionGraph.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/scheduler/adaptive/CreatingExecutionGraph.java
@@ -19,8 +19,10 @@
 package org.apache.flink.runtime.scheduler.adaptive;
 
 import org.apache.flink.api.common.JobStatus;
+import org.apache.flink.runtime.execution.ExecutionState;
 import org.apache.flink.runtime.executiongraph.ArchivedExecutionGraph;
 import org.apache.flink.runtime.executiongraph.ExecutionGraph;
+import org.apache.flink.runtime.executiongraph.ExecutionVertex;
 import org.apache.flink.runtime.scheduler.adaptive.allocator.VertexParallelism;
 import org.apache.flink.util.Preconditions;
 import org.apache.flink.util.concurrent.FutureUtils;
@@ -79,6 +81,11 @@ public class CreatingExecutionGraph implements State {
                     throwable);
             context.goToFinished(context.getArchivedExecutionGraph(JobStatus.FAILED, throwable));
         } else {
+            for (ExecutionVertex vertex :
+                    executionGraphWithVertexParallelism.executionGraph.getAllExecutionVertices()) {
+                vertex.getCurrentExecutionAttempt().transitionState(ExecutionState.SCHEDULED);
+            }
+
             final AssignmentResult result =
                     context.tryToAssignSlots(executionGraphWithVertexParallelism);
 

--- a/flink-runtime/src/test/java/org/apache/flink/runtime/executiongraph/DefaultExecutionGraphDeploymentTest.java
+++ b/flink-runtime/src/test/java/org/apache/flink/runtime/executiongraph/DefaultExecutionGraphDeploymentTest.java
@@ -188,6 +188,7 @@ public class DefaultExecutionGraphDeploymentTest extends TestLogger {
                         .createTestingLogicalSlot();
 
         assertEquals(ExecutionState.CREATED, vertex.getExecutionState());
+        vertex.getCurrentExecutionAttempt().transitionState(ExecutionState.SCHEDULED);
 
         vertex.getCurrentExecutionAttempt()
                 .registerProducedPartitions(slot.getTaskManagerLocation(), true)

--- a/flink-runtime/src/test/java/org/apache/flink/runtime/executiongraph/DefaultExecutionGraphDeploymentWithSmallBlobCacheSizeLimitTest.java
+++ b/flink-runtime/src/test/java/org/apache/flink/runtime/executiongraph/DefaultExecutionGraphDeploymentWithSmallBlobCacheSizeLimitTest.java
@@ -130,9 +130,9 @@ public class DefaultExecutionGraphDeploymentWithSmallBlobCacheSizeLimitTest
                         new TestingLogicalSlotBuilder()
                                 .setTaskManagerGateway(taskManagerGateway)
                                 .createTestingLogicalSlot();
-                ev.getCurrentExecutionAttempt()
-                        .registerProducedPartitions(slot.getTaskManagerLocation(), true)
-                        .get();
+                final Execution execution = ev.getCurrentExecutionAttempt();
+                execution.transitionState(ExecutionState.SCHEDULED);
+                execution.registerProducedPartitions(slot.getTaskManagerLocation(), true).get();
                 ev.deployToSlot(slot);
                 assertEquals(ExecutionState.DEPLOYING, ev.getExecutionState());
 

--- a/flink-runtime/src/test/java/org/apache/flink/runtime/executiongraph/ExecutionVertexDeploymentTest.java
+++ b/flink-runtime/src/test/java/org/apache/flink/runtime/executiongraph/ExecutionVertexDeploymentTest.java
@@ -53,6 +53,7 @@ public class ExecutionVertexDeploymentTest extends TestLogger {
             final LogicalSlot slot = new TestingLogicalSlotBuilder().createTestingLogicalSlot();
 
             assertEquals(ExecutionState.CREATED, vertex.getExecutionState());
+            vertex.getCurrentExecutionAttempt().transitionState(ExecutionState.SCHEDULED);
             vertex.deployToSlot(slot);
             assertEquals(ExecutionState.DEPLOYING, vertex.getExecutionState());
 
@@ -82,6 +83,7 @@ public class ExecutionVertexDeploymentTest extends TestLogger {
             final LogicalSlot slot = new TestingLogicalSlotBuilder().createTestingLogicalSlot();
 
             assertEquals(ExecutionState.CREATED, vertex.getExecutionState());
+            vertex.getCurrentExecutionAttempt().transitionState(ExecutionState.SCHEDULED);
 
             vertex.deployToSlot(slot);
 
@@ -114,6 +116,7 @@ public class ExecutionVertexDeploymentTest extends TestLogger {
             final LogicalSlot slot = new TestingLogicalSlotBuilder().createTestingLogicalSlot();
 
             assertEquals(ExecutionState.CREATED, vertex.getExecutionState());
+            vertex.getCurrentExecutionAttempt().transitionState(ExecutionState.SCHEDULED);
 
             vertex.deployToSlot(slot);
 
@@ -156,6 +159,7 @@ public class ExecutionVertexDeploymentTest extends TestLogger {
                             .createTestingLogicalSlot();
 
             assertEquals(ExecutionState.CREATED, vertex.getExecutionState());
+            vertex.getCurrentExecutionAttempt().transitionState(ExecutionState.SCHEDULED);
 
             vertex.deployToSlot(slot);
 
@@ -186,6 +190,7 @@ public class ExecutionVertexDeploymentTest extends TestLogger {
                             .createTestingLogicalSlot();
 
             assertEquals(ExecutionState.CREATED, vertex.getExecutionState());
+            vertex.getCurrentExecutionAttempt().transitionState(ExecutionState.SCHEDULED);
 
             vertex.deployToSlot(slot);
 
@@ -226,6 +231,7 @@ public class ExecutionVertexDeploymentTest extends TestLogger {
                             .createTestingLogicalSlot();
 
             assertEquals(ExecutionState.CREATED, vertex.getExecutionState());
+            vertex.getCurrentExecutionAttempt().transitionState(ExecutionState.SCHEDULED);
             vertex.deployToSlot(testingLogicalSlot);
             assertEquals(ExecutionState.DEPLOYING, vertex.getExecutionState());
 

--- a/flink-runtime/src/test/java/org/apache/flink/runtime/executiongraph/RemoveCachedShuffleDescriptorTest.java
+++ b/flink-runtime/src/test/java/org/apache/flink/runtime/executiongraph/RemoveCachedShuffleDescriptorTest.java
@@ -406,6 +406,7 @@ public class RemoveCachedShuffleDescriptorTest extends TestLogger {
 
             Execution execution = vertex.getCurrentExecutionAttempt();
             execution.registerProducedPartitions(slot.getTaskManagerLocation(), true).get();
+            execution.transitionState(ExecutionState.SCHEDULED);
 
             vertex.tryAssignResource(slot);
             vertex.deploy();

--- a/flink-runtime/src/test/java/org/apache/flink/runtime/scheduler/ExecutionGraphToInputsLocationsRetrieverAdapterTest.java
+++ b/flink-runtime/src/test/java/org/apache/flink/runtime/scheduler/ExecutionGraphToInputsLocationsRetrieverAdapterTest.java
@@ -18,6 +18,7 @@
 
 package org.apache.flink.runtime.scheduler;
 
+import org.apache.flink.runtime.execution.ExecutionState;
 import org.apache.flink.runtime.executiongraph.ExecutionGraph;
 import org.apache.flink.runtime.executiongraph.ExecutionGraphTestUtils;
 import org.apache.flink.runtime.executiongraph.ExecutionVertex;
@@ -112,6 +113,7 @@ public class ExecutionGraphToInputsLocationsRetrieverAdapterTest extends TestLog
                 new ExecutionGraphToInputsLocationsRetrieverAdapter(eg);
 
         final ExecutionVertex onlyExecutionVertex = eg.getAllExecutionVertices().iterator().next();
+        onlyExecutionVertex.getCurrentExecutionAttempt().transitionState(ExecutionState.SCHEDULED);
         onlyExecutionVertex.deployToSlot(testingLogicalSlot);
 
         ExecutionVertexID executionVertexId = new ExecutionVertexID(jobVertex.getID(), 0);

--- a/flink-runtime/src/test/java/org/apache/flink/runtime/scheduler/benchmark/SchedulerBenchmarkUtils.java
+++ b/flink-runtime/src/test/java/org/apache/flink/runtime/scheduler/benchmark/SchedulerBenchmarkUtils.java
@@ -124,6 +124,7 @@ public class SchedulerBenchmarkUtils {
         for (ExecutionVertex vertex : executionGraph.getJobVertex(jobVertexID).getTaskVertices()) {
             LogicalSlot slot = slotBuilder.createTestingLogicalSlot();
             Execution execution = vertex.getCurrentExecutionAttempt();
+            execution.transitionState(ExecutionState.SCHEDULED);
             execution
                     .registerProducedPartitions(
                             slot.getTaskManagerLocation(), sendScheduleOrUpdateConsumersMessage)
@@ -138,9 +139,9 @@ public class SchedulerBenchmarkUtils {
 
         for (ExecutionVertex vertex : executionGraph.getAllExecutionVertices()) {
             LogicalSlot slot = slotBuilder.createTestingLogicalSlot();
-            vertex.getCurrentExecutionAttempt()
-                    .registerProducedPartitions(slot.getTaskManagerLocation(), true)
-                    .get();
+            Execution execution = vertex.getCurrentExecutionAttempt();
+            execution.transitionState(ExecutionState.SCHEDULED);
+            execution.registerProducedPartitions(slot.getTaskManagerLocation(), true).get();
             assignResourceAndDeploy(vertex, slot);
         }
     }

--- a/flink-runtime/src/test/java/org/apache/flink/runtime/scheduler/benchmark/deploying/DeployingDownstreamTasksInBatchJobBenchmark.java
+++ b/flink-runtime/src/test/java/org/apache/flink/runtime/scheduler/benchmark/deploying/DeployingDownstreamTasksInBatchJobBenchmark.java
@@ -18,6 +18,7 @@
 
 package org.apache.flink.runtime.scheduler.benchmark.deploying;
 
+import org.apache.flink.runtime.execution.ExecutionState;
 import org.apache.flink.runtime.executiongraph.Execution;
 import org.apache.flink.runtime.executiongraph.ExecutionVertex;
 import org.apache.flink.runtime.jobgraph.JobVertex;
@@ -39,6 +40,7 @@ public class DeployingDownstreamTasksInBatchJobBenchmark extends DeployingTasksB
 
         for (ExecutionVertex ev : executionGraph.getJobVertex(source.getID()).getTaskVertices()) {
             Execution execution = ev.getCurrentExecutionAttempt();
+            execution.transitionState(ExecutionState.SCHEDULED);
             execution.deploy();
         }
 
@@ -50,6 +52,8 @@ public class DeployingDownstreamTasksInBatchJobBenchmark extends DeployingTasksB
     public void deployDownstreamTasks() throws Exception {
         for (ExecutionVertex ev : vertices) {
             Execution execution = ev.getCurrentExecutionAttempt();
+
+            execution.transitionState(ExecutionState.SCHEDULED);
             execution.deploy();
         }
     }

--- a/flink-runtime/src/test/java/org/apache/flink/runtime/scheduler/benchmark/deploying/DeployingTasksInStreamingJobBenchmark.java
+++ b/flink-runtime/src/test/java/org/apache/flink/runtime/scheduler/benchmark/deploying/DeployingTasksInStreamingJobBenchmark.java
@@ -18,6 +18,7 @@
 
 package org.apache.flink.runtime.scheduler.benchmark.deploying;
 
+import org.apache.flink.runtime.execution.ExecutionState;
 import org.apache.flink.runtime.executiongraph.Execution;
 import org.apache.flink.runtime.executiongraph.ExecutionJobVertex;
 import org.apache.flink.runtime.executiongraph.ExecutionVertex;
@@ -38,6 +39,7 @@ public class DeployingTasksInStreamingJobBenchmark extends DeployingTasksBenchma
         for (ExecutionJobVertex ejv : executionGraph.getVerticesTopologically()) {
             for (ExecutionVertex ev : ejv.getTaskVertices()) {
                 Execution execution = ev.getCurrentExecutionAttempt();
+                execution.transitionState(ExecutionState.SCHEDULED);
                 execution.deploy();
             }
         }


### PR DESCRIPTION
Enforce that executions cannot be transitioned from CREATED -> DEPLOYING by skipping the SCHEDULED state.