### PR TITLE
[FLINK-25754] Drop KeyExtractor.ColumnWithIndex

### DIFF
--- a/flink-connectors/flink-connector-elasticsearch-base/src/main/java/org/apache/flink/connector/elasticsearch/table/KeyExtractor.java
+++ b/flink-connectors/flink-connector-elasticsearch-base/src/main/java/org/apache/flink/connector/elasticsearch/table/KeyExtractor.java
@@ -19,7 +19,6 @@
 package org.apache.flink.connector.elasticsearch.table;
 
 import org.apache.flink.annotation.Internal;
-import org.apache.flink.table.api.TableColumn;
 import org.apache.flink.table.data.RowData;
 import org.apache.flink.table.types.logical.DistinctType;
 import org.apache.flink.table.types.logical.LogicalType;
@@ -58,24 +57,6 @@ class KeyExtractor implements SerializableFunction<RowData, String> {
             builder.append(value);
         }
         return builder.toString();
-    }
-
-    private static class ColumnWithIndex {
-        public TableColumn column;
-        public int index;
-
-        public ColumnWithIndex(TableColumn column, int index) {
-            this.column = column;
-            this.index = index;
-        }
-
-        public LogicalType getType() {
-            return column.getType().getLogicalType();
-        }
-
-        public int getIndex() {
-            return index;
-        }
     }
 
     public static SerializableFunction<RowData, String> createKeyExtractor(


### PR DESCRIPTION
## What is the purpose of the change

This is a trivial PR removing private `KeyExtractor.ColumnWithIndex` non-used class

## Does this pull request potentially affect one of the following parts:

  - Dependencies (does it add or upgrade a dependency): (no)
  - The public API, i.e., is any changed class annotated with `@Public(Evolving)`: (no)
  - The serializers: (no)
  - The runtime per-record code paths (performance sensitive): (no)
  - Anything that affects deployment or recovery: JobManager (and its components), Checkpointing, Kubernetes/Yarn, ZooKeeper: ( no)
  - The S3 file system connector: ( no)

## Documentation

  - Does this pull request introduce a new feature? ( no)
  - If yes, how is the feature documented? (not applicable)
