### PR TITLE
FLINK-25762 - [Deployment/kubernetes] Move JVM system properties args after log_settings

### DIFF
--- a/flink-dist/src/main/flink-bin/bin/flink-console.sh
+++ b/flink-dist/src/main/flink-bin/bin/flink-console.sh
@@ -111,4 +111,13 @@ echo $$ >> "$pid" 2>/dev/null
 # Evaluate user options for local variable expansion
 FLINK_ENV_JAVA_OPTS=$(eval echo ${FLINK_ENV_JAVA_OPTS})
 
-exec "$JAVA_RUN" $JVM_ARGS ${FLINK_ENV_JAVA_OPTS} "${log_setting[@]}" -classpath "`manglePathList "$FLINK_TM_CLASSPATH:$INTERNAL_HADOOP_CLASSPATHS"`" ${CLASS_TO_RUN} "${ARGS[@]}"
+echo "JAVA_RUN-> ${JAVA_RUN}"
+echo "JVM_ARGS-> ${JVM_ARGS}"
+echo "log_settings-> ${log_setting[*]}"
+echo "FLINK_ENV_JAVA_OPTS-> ${FLINK_ENV_JAVA_OPTS}"
+echo "FLINK_TM_CLASSPATH-> $FLINK_TM_CLASSPATH"
+echo "INTERNAL_HADOOP_CLASSPATHS-> ${INTERNAL_HADOOP_CLASSPATHS}"
+echo "CLASS_TO_RUN-> ${CLASS_TO_RUN}"
+echo "args-> ${ARGS[*]}"
+
+exec "$JAVA_RUN" $JVM_ARGS "${FLINK_ENV_JAVA_OPTS}" "${log_setting[@]}" -classpath "`manglePathList "$FLINK_TM_CLASSPATH:$INTERNAL_HADOOP_CLASSPATHS"`" ${CLASS_TO_RUN} "${ARGS[@]}"


### PR DESCRIPTION
exec command in flink-console.sh has been modified

From 

exec "$JAVA_RUN" $JVM_ARGS ${FLINK_ENV_JAVA_OPTS} "${log_setting[@]}" -classpath "`manglePathList "$FLINK_TM_CLASSPATH:$INTERNAL_HADOOP_CLASSPATHS"`" ${CLASS_TO_RUN} "${ARGS[@]}"

To

exec "$JAVA_RUN" $JVM_ARGS "${log_setting[@]}" "${FLINK_ENV_JAVA_OPTS}" -classpath "`manglePathList "$FLINK_TM_CLASSPATH:$INTERNAL_HADOOP_CLASSPATHS"`" ${CLASS_TO_RUN} "${ARGS[@]}" 

In that way we prioritize  User desired properties log related.