### PR TITLE
[FLINK-25763][match-recognize][docs] Updated docs to use code tag consistent with other tables

### DIFF
--- a/docs/content.zh/docs/dev/table/sql/queries/match_recognize.md
+++ b/docs/content.zh/docs/dev/table/sql/queries/match_recognize.md
@@ -632,9 +632,7 @@ _Logical offsets_ 在映射到指定模式变量的事件启用导航。这可�
   <tbody>
   <tr>
     <td>
-```text
-LAST(variable.field, n)
-```
+      <code>LAST(variable.field, n)</code>
     </td>
     <td>
       <p>返回映射到变量最后 n 个元素的事件中的字段值。计数从映射的最后一个元素开始。</p>
@@ -642,9 +640,7 @@ LAST(variable.field, n)
   </tr>
   <tr>
     <td>
-```text
-FIRST(variable.field, n)
-```
+      <code>FIRST(variable.field, n)</code>
     </td>
     <td>
       <p>返回映射到变量的第 <i>n</i> 个元素的事件中的字段值。计数从映射的第一个元素开始。</p>

--- a/docs/content/docs/dev/table/sql/queries/match_recognize.md
+++ b/docs/content/docs/dev/table/sql/queries/match_recognize.md
@@ -723,9 +723,7 @@ variable. This can be expressed with two corresponding functions:
   <tbody>
   <tr>
     <td>
-```text
-LAST(variable.field, n)
-```
+        <code>LAST(variable.field, n)</code>
     </td>
     <td>
       <p>Returns the value of the field from the event that was mapped to the <i>n</i>-th
@@ -734,9 +732,7 @@ LAST(variable.field, n)
   </tr>
   <tr>
     <td>
-```text
-FIRST(variable.field, n)
-```
+        <code>FIRST(variable.field, n)</code>
     </td>
     <td>
       <p>Returns the value of the field from the event that was mapped to the <i>n</i>-th element


### PR DESCRIPTION
## What is the purpose of the change

* The match recognize functions were displayed with triple backticks in the table.

## Brief change log

* Updated docs to use <code>...</code> like in other tables in the docs.

## Verifying this change

Please make sure both new and modified tests in this PR follows the conventions defined in our code quality guide: https://flink.apache.org/contributing/code-style-and-quality-common.html#testing

This change is a trivial rework / code cleanup without any test coverage.

## Does this pull request potentially affect one of the following parts:

  - Dependencies (does it add or upgrade a dependency): no
  - The public API, i.e., is any changed class annotated with `@Public(Evolving)`: no
  - The serializers: no
  - The runtime per-record code paths (performance sensitive): no
  - Anything that affects deployment or recovery: JobManager (and its components), Checkpointing, Kubernetes/Yarn, ZooKeeper: no
  - The S3 file system connector: no

## Documentation

  - Does this pull request introduce a new feature? no
  - If yes, how is the feature documented? not applicable
