### PR TITLE
[FLINK-25758][flink-gs-fs-hadoop] Fix licensing issues

### DIFF
--- a/flink-filesystems/flink-gs-fs-hadoop/pom.xml
+++ b/flink-filesystems/flink-gs-fs-hadoop/pom.xml
@@ -124,6 +124,11 @@ under the License.
 					<groupId>org.codehaus.mojo</groupId>
 					<artifactId>animal-sniffer-annotations</artifactId>
 				</exclusion>
+				<!-- exclude dependency because of its GPLv2 license, see https://github.com/apache/flink/pull/15599#issuecomment-850241316 -->
+				<exclusion>
+					<groupId>javax.annotation</groupId>
+					<artifactId>javax.annotation-api</artifactId>
+				</exclusion>
 			</exclusions>
 		</dependency>
 
@@ -214,8 +219,6 @@ under the License.
 										<exclude>META-INF/*.SF</exclude>
 										<exclude>META-INF/*.DSA</exclude>
 										<exclude>META-INF/*.RSA</exclude>
-										<!-- exclude javax.annotation because of GPLv2 license, see https://github.com/apache/flink/pull/15599#issuecomment-850241316 -->
-										<exclude>javax/annotation/**</exclude>
 									</excludes>
 								</filter>
 							</filters>

--- a/flink-filesystems/flink-gs-fs-hadoop/pom.xml
+++ b/flink-filesystems/flink-gs-fs-hadoop/pom.xml
@@ -86,6 +86,11 @@ under the License.
 					<groupId>com.google.guava</groupId>
 					<artifactId>failureaccess</artifactId>
 				</exclusion>
+				<!-- exclude dependency because of its GPLv2 license, see https://github.com/apache/flink/pull/15599#issuecomment-850241316 -->
+				<exclusion>
+					<groupId>javax.annotation</groupId>
+					<artifactId>javax.annotation-api</artifactId>
+				</exclusion>
 			</exclusions>
 		</dependency>
 

--- a/flink-filesystems/flink-gs-fs-hadoop/pom.xml
+++ b/flink-filesystems/flink-gs-fs-hadoop/pom.xml
@@ -86,11 +86,6 @@ under the License.
 					<groupId>com.google.guava</groupId>
 					<artifactId>failureaccess</artifactId>
 				</exclusion>
-				<!-- exclude dependency because of its GPLv2 license, see https://github.com/apache/flink/pull/15599#issuecomment-850241316 -->
-				<exclusion>
-					<groupId>javax.annotation</groupId>
-					<artifactId>javax.annotation-api</artifactId>
-				</exclusion>
 			</exclusions>
 		</dependency>
 
@@ -214,6 +209,8 @@ under the License.
 										<exclude>META-INF/*.SF</exclude>
 										<exclude>META-INF/*.DSA</exclude>
 										<exclude>META-INF/*.RSA</exclude>
+										<!-- exclude javax.annotation because of GPLv2 license, see https://github.com/apache/flink/pull/15599#issuecomment-850241316 -->
+										<exclude>javax/annotation/**</exclude>
 									</excludes>
 								</filter>
 							</filters>


### PR DESCRIPTION
## What is the purpose of the change

Fix licensing issues in Java 11 build.

## Brief change log

Exclude javax.annotation.* in flink-gs-fs-hadoop via filter in pom.xml.

## Verifying this change

This change is a trivial rework / code cleanup without any test coverage.

## Does this pull request potentially affect one of the following parts:

  - Dependencies (does it add or upgrade a dependency): (yes / no) No
  - The public API, i.e., is any changed class annotated with `@Public(Evolving)`: (yes / no) No
  - The serializers: (yes / no / don't know) No
  - The runtime per-record code paths (performance sensitive): (yes / no / don't know) No
  - Anything that affects deployment or recovery: JobManager (and its components), Checkpointing, Kubernetes/Yarn, ZooKeeper: (yes / no / don't know) No
  - The S3 file system connector: (yes / no / don't know) No

## Documentation

  - Does this pull request introduce a new feature? (yes / no) No
  - If yes, how is the feature documented? (not applicable / docs / JavaDocs / not documented)
