### PR TITLE
[hotfix][connector/pulsar] Fix typo in JavaDocs  example.

### DIFF
--- a/flink-connectors/flink-connector-pulsar/src/main/java/org/apache/flink/connector/pulsar/source/PulsarSource.java
+++ b/flink-connectors/flink-connector-pulsar/src/main/java/org/apache/flink/connector/pulsar/source/PulsarSource.java
@@ -57,7 +57,7 @@ import org.apache.flink.core.io.SimpleVersionedSerializer;
  *     .setAdminUrl(getAdminUrl())
  *     .setSubscriptionName("test")
  *     .setDeserializationSchema(PulsarDeserializationSchema.flinkSchema(new SimpleStringSchema()))
- *     .setBounded(StopCursor::defaultStopCursor)
+ *     .setBoundedStopCursor(StopCursor::defaultStopCursor)
  *     .build();
  * }</pre>
  *

--- a/flink-connectors/flink-connector-pulsar/src/main/java/org/apache/flink/connector/pulsar/source/PulsarSourceBuilder.java
+++ b/flink-connectors/flink-connector-pulsar/src/main/java/org/apache/flink/connector/pulsar/source/PulsarSourceBuilder.java
@@ -100,7 +100,7 @@ import static org.apache.flink.util.Preconditions.checkState;
  *     .setSubscriptionName("flink-source-1")
  *     .setTopics(Arrays.asList(TOPIC1, TOPIC2))
  *     .setDeserializationSchema(PulsarDeserializationSchema.flinkSchema(new SimpleStringSchema()))
- *     .setUnbounded(StopCursor.atEventTime(System.currentTimeMillis()))
+ *     .setBoundedStopCursor(StopCursor.atEventTime(System.currentTimeMillis()))
  *     .build();
  * }</pre>
  *


### PR DESCRIPTION
## What is the purpose of the change

Fix typo in JavaDocs  example.  PulsarSourceBuilder have not setBounded method.

## Brief change log

  - *Change setBounded to  setBoundedStopCursor in PulsarSourceBuilder and PulsarSource JavaDoc example.*

## Verifying this change

This change is a trivial rework / code cleanup without any test coverage.

## Does this pull request potentially affect one of the following parts:

  - Dependencies (does it add or upgrade a dependency): (no)
  - The public API, i.e., is any changed class annotated with `@Public(Evolving)`: (no)
  - The serializers: (no)
  - The runtime per-record code paths (performance sensitive): (no)
  - Anything that affects deployment or recovery: JobManager (and its components), Checkpointing, Kubernetes/Yarn, ZooKeeper: (no)
  - The S3 file system connector: (no)

## Documentation

  - Does this pull request introduce a new feature? (no)
  - If yes, how is the feature documented? (not documented)
