### PR TITLE
[FLINK-14902][code] Supports jdbc async lookup join

### DIFF
--- a/flink-connectors/flink-connector-jdbc/src/main/java/org/apache/flink/connector/jdbc/internal/connection/JdbcConnectionEntry.java
+++ b/flink-connectors/flink-connector-jdbc/src/main/java/org/apache/flink/connector/jdbc/internal/connection/JdbcConnectionEntry.java
@@ -1,0 +1,49 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.flink.connector.jdbc.internal.connection;
+
+import org.apache.flink.connector.jdbc.statement.FieldNamedPreparedStatement;
+
+import java.io.Serializable;
+
+/** jdbc connection pool entry. */
+public class JdbcConnectionEntry implements Serializable {
+
+    private static final long serialVersionUID = 1L;
+
+    private JdbcConnectionProvider connectionProvider;
+    private FieldNamedPreparedStatement statement;
+
+    public JdbcConnectionEntry(
+            JdbcConnectionProvider connectionProvider, FieldNamedPreparedStatement statement) {
+        this.connectionProvider = connectionProvider;
+        this.statement = statement;
+    }
+
+    public JdbcConnectionProvider getConnectionProvider() {
+        return connectionProvider;
+    }
+
+    public FieldNamedPreparedStatement getStatement() {
+        return statement;
+    }
+
+    public void setStatement(FieldNamedPreparedStatement statement) {
+        this.statement = statement;
+    }
+}

--- a/flink-connectors/flink-connector-jdbc/src/main/java/org/apache/flink/connector/jdbc/internal/connection/JdbcConnectionPoolManager.java
+++ b/flink-connectors/flink-connector-jdbc/src/main/java/org/apache/flink/connector/jdbc/internal/connection/JdbcConnectionPoolManager.java
@@ -1,0 +1,110 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.flink.connector.jdbc.internal.connection;
+
+import org.apache.flink.connector.jdbc.JdbcConnectionOptions;
+import org.apache.flink.connector.jdbc.statement.FieldNamedPreparedStatement;
+
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import javax.annotation.concurrent.NotThreadSafe;
+
+import java.io.Serializable;
+import java.sql.Connection;
+import java.sql.SQLException;
+import java.util.concurrent.LinkedBlockingQueue;
+
+/** create and save jdbcConnection int the queue. */
+@NotThreadSafe
+public class JdbcConnectionPoolManager implements Serializable {
+
+    private static final Logger LOG = LoggerFactory.getLogger(JdbcConnectionPoolManager.class);
+
+    private static final long serialVersionUID = 1L;
+
+    private LinkedBlockingQueue<JdbcConnectionEntry> connectionEntries;
+
+    private final JdbcConnectionOptions jdbcOptions;
+
+    private String[] keyNames;
+    private String query;
+
+    public JdbcConnectionPoolManager(
+            JdbcConnectionOptions jdbcOptions,
+            int connectionPoolSize,
+            String[] keyNames,
+            String query) {
+        LOG.info("The max connectionPoolSize is {} ", connectionPoolSize);
+        this.connectionEntries = new LinkedBlockingQueue<>(connectionPoolSize);
+        this.jdbcOptions = jdbcOptions;
+        this.keyNames = keyNames;
+        this.query = query;
+    }
+
+    public JdbcConnectionEntry createConnectionEntry() throws SQLException, ClassNotFoundException {
+        JdbcConnectionProvider connectionProvider = new SimpleJdbcConnectionProvider(jdbcOptions);
+        Connection dbConn = connectionProvider.getOrEstablishConnection();
+        FieldNamedPreparedStatement statement =
+                FieldNamedPreparedStatement.prepareStatement(dbConn, query, keyNames);
+        return new JdbcConnectionEntry(connectionProvider, statement);
+    }
+
+    public void createAndAddConnectionEntry()
+            throws SQLException, ClassNotFoundException, InterruptedException {
+        connectionEntries.put(createConnectionEntry());
+    }
+
+    public FieldNamedPreparedStatement getStatement()
+            throws InterruptedException, SQLException, ClassNotFoundException {
+        return getConnectionEntry().getStatement();
+    }
+
+    public JdbcConnectionEntry getConnectionEntry()
+            throws InterruptedException, SQLException, ClassNotFoundException {
+        JdbcConnectionEntry entry = connectionEntries.take();
+        return checkAndCreateConnection(entry);
+    }
+
+    public void returnConnectionEntry(JdbcConnectionEntry entry) throws InterruptedException {
+        connectionEntries.put(entry);
+    }
+
+    public boolean isConnectionValid(JdbcConnectionEntry entry) throws SQLException {
+        return entry.getConnectionProvider().isConnectionValid();
+    }
+
+    public JdbcConnectionEntry checkAndCreateConnection(JdbcConnectionEntry entry)
+            throws SQLException, ClassNotFoundException, InterruptedException {
+        if (!isConnectionValid(entry)) {
+            entry.getStatement().close();
+            entry.getConnectionProvider().closeConnection();
+            entry = createConnectionEntry();
+        }
+        return entry;
+    }
+
+    public void closeAll() {
+        connectionEntries.stream()
+                .forEach(
+                        entry -> {
+                            entry.getConnectionProvider().closeConnection();
+                        });
+        connectionEntries.clear();
+    }
+}

--- a/flink-connectors/flink-connector-jdbc/src/main/java/org/apache/flink/connector/jdbc/internal/options/JdbcLookupOptions.java
+++ b/flink-connectors/flink-connector-jdbc/src/main/java/org/apache/flink/connector/jdbc/internal/options/JdbcLookupOptions.java
@@ -30,13 +30,30 @@ public class JdbcLookupOptions implements Serializable {
     private final long cacheExpireMs;
     private final int maxRetryTimes;
     private final boolean cacheMissingKey;
+    private int lookupAsyncParallelism;
+    private boolean lookupAsync;
 
     public JdbcLookupOptions(
-            long cacheMaxSize, long cacheExpireMs, int maxRetryTimes, boolean cacheMissingKey) {
+            long cacheMaxSize,
+            long cacheExpireMs,
+            int maxRetryTimes,
+            boolean cacheMissingKey,
+            int lookupAsyncParallelism,
+            boolean lookupAsync) {
         this.cacheMaxSize = cacheMaxSize;
         this.cacheExpireMs = cacheExpireMs;
         this.maxRetryTimes = maxRetryTimes;
         this.cacheMissingKey = cacheMissingKey;
+        this.lookupAsyncParallelism = lookupAsyncParallelism;
+        this.lookupAsync = lookupAsync;
+    }
+
+    public boolean isLookupAsync() {
+        return lookupAsync;
+    }
+
+    public int getLookupAsyncParallelism() {
+        return lookupAsyncParallelism;
     }
 
     public long getCacheMaxSize() {
@@ -78,6 +95,8 @@ public class JdbcLookupOptions implements Serializable {
         private long cacheExpireMs = -1L;
         private int maxRetryTimes = JdbcExecutionOptions.DEFAULT_MAX_RETRY_TIMES;
         private boolean cacheMissingKey = true;
+        private int lookupAsyncParallelism = 1;
+        private boolean lookupAsync = false;
 
         /** optional, lookup cache max size, over this value, the old data will be eliminated. */
         public Builder setCacheMaxSize(long cacheMaxSize) {
@@ -103,9 +122,26 @@ public class JdbcLookupOptions implements Serializable {
             return this;
         }
 
+        /** optional, async join lookup parallelism. */
+        public Builder setLookupAsyncParallelism(int lookupAsyncParallelism) {
+            this.lookupAsyncParallelism = lookupAsyncParallelism;
+            return this;
+        }
+
+        /** optional, is open async lookup join,false is default. */
+        public Builder setLookupAsync(boolean lookupAsync) {
+            this.lookupAsync = lookupAsync;
+            return this;
+        }
+
         public JdbcLookupOptions build() {
             return new JdbcLookupOptions(
-                    cacheMaxSize, cacheExpireMs, maxRetryTimes, cacheMissingKey);
+                    cacheMaxSize,
+                    cacheExpireMs,
+                    maxRetryTimes,
+                    cacheMissingKey,
+                    lookupAsyncParallelism,
+                    lookupAsync);
         }
     }
 }

--- a/flink-connectors/flink-connector-jdbc/src/main/java/org/apache/flink/connector/jdbc/table/JdbcConnectorOptions.java
+++ b/flink-connectors/flink-connector-jdbc/src/main/java/org/apache/flink/connector/jdbc/table/JdbcConnectorOptions.java
@@ -143,6 +143,20 @@ public class JdbcConnectorOptions {
                     .defaultValue(true)
                     .withDescription("Flag to cache missing key. true by default");
 
+    public static final ConfigOption<Boolean> LOOKUP_ASYNC =
+            ConfigOptions.key("lookup.async")
+                    .booleanType()
+                    .defaultValue(false)
+                    .withDescription("Flag to run async loop up join, false by default");
+
+    public static final ConfigOption<Integer> LOOKUP_ASYNC_PARALLELISM =
+            ConfigOptions.key("lookup.async.parallelism")
+                    .intType()
+                    .defaultValue(4)
+                    .withDescription(
+                            "The max jdbc connections."
+                                    + "it's should less than the 'table.exec.async-lookup.buffer-capacity'");
+
     // write config options
     public static final ConfigOption<Integer> SINK_BUFFER_FLUSH_MAX_ROWS =
             ConfigOptions.key("sink.buffer-flush.max-rows")

--- a/flink-connectors/flink-connector-jdbc/src/main/java/org/apache/flink/connector/jdbc/table/JdbcDynamicTableFactory.java
+++ b/flink-connectors/flink-connector-jdbc/src/main/java/org/apache/flink/connector/jdbc/table/JdbcDynamicTableFactory.java
@@ -44,6 +44,8 @@ import java.util.Optional;
 import java.util.Set;
 
 import static org.apache.flink.connector.jdbc.table.JdbcConnectorOptions.DRIVER;
+import static org.apache.flink.connector.jdbc.table.JdbcConnectorOptions.LOOKUP_ASYNC;
+import static org.apache.flink.connector.jdbc.table.JdbcConnectorOptions.LOOKUP_ASYNC_PARALLELISM;
 import static org.apache.flink.connector.jdbc.table.JdbcConnectorOptions.LOOKUP_CACHE_MAX_ROWS;
 import static org.apache.flink.connector.jdbc.table.JdbcConnectorOptions.LOOKUP_CACHE_MISSING_KEY;
 import static org.apache.flink.connector.jdbc.table.JdbcConnectorOptions.LOOKUP_CACHE_TTL;
@@ -152,7 +154,9 @@ public class JdbcDynamicTableFactory implements DynamicTableSourceFactory, Dynam
                 readableConfig.get(LOOKUP_CACHE_MAX_ROWS),
                 readableConfig.get(LOOKUP_CACHE_TTL).toMillis(),
                 readableConfig.get(LOOKUP_MAX_RETRIES),
-                readableConfig.get(LOOKUP_CACHE_MISSING_KEY));
+                readableConfig.get(LOOKUP_CACHE_MISSING_KEY),
+                readableConfig.get(LOOKUP_ASYNC_PARALLELISM),
+                readableConfig.get(LOOKUP_ASYNC));
     }
 
     private JdbcExecutionOptions getJdbcExecutionOptions(ReadableConfig config) {
@@ -208,6 +212,8 @@ public class JdbcDynamicTableFactory implements DynamicTableSourceFactory, Dynam
         optionalOptions.add(LOOKUP_CACHE_TTL);
         optionalOptions.add(LOOKUP_MAX_RETRIES);
         optionalOptions.add(LOOKUP_CACHE_MISSING_KEY);
+        optionalOptions.add(LOOKUP_ASYNC_PARALLELISM);
+        optionalOptions.add(LOOKUP_ASYNC);
         optionalOptions.add(SINK_BUFFER_FLUSH_MAX_ROWS);
         optionalOptions.add(SINK_BUFFER_FLUSH_INTERVAL);
         optionalOptions.add(SINK_MAX_RETRIES);
@@ -253,6 +259,17 @@ public class JdbcDynamicTableFactory implements DynamicTableSourceFactory, Dynam
                     String.format(
                             "The value of '%s' option shouldn't be negative, but is %s.",
                             LOOKUP_MAX_RETRIES.key(), config.get(LOOKUP_MAX_RETRIES)));
+        }
+
+        if (config.get(LOOKUP_ASYNC)) {
+            if (config.get(LOOKUP_ASYNC_PARALLELISM) < 1) {
+                throw new IllegalArgumentException(
+                        String.format(
+                                "The value of '%s' option shouldn't be negative, but is %s."
+                                        + " The value should  > 1  ",
+                                LOOKUP_ASYNC_PARALLELISM.key(),
+                                config.get(LOOKUP_ASYNC_PARALLELISM)));
+            }
         }
 
         if (config.get(SINK_MAX_RETRIES) < 0) {

--- a/flink-connectors/flink-connector-jdbc/src/main/java/org/apache/flink/connector/jdbc/table/JdbcDynamicTableSource.java
+++ b/flink-connectors/flink-connector-jdbc/src/main/java/org/apache/flink/connector/jdbc/table/JdbcDynamicTableSource.java
@@ -26,6 +26,7 @@ import org.apache.flink.connector.jdbc.internal.options.JdbcReadOptions;
 import org.apache.flink.connector.jdbc.split.JdbcNumericBetweenParametersProvider;
 import org.apache.flink.table.connector.ChangelogMode;
 import org.apache.flink.table.connector.Projection;
+import org.apache.flink.table.connector.source.AsyncTableFunctionProvider;
 import org.apache.flink.table.connector.source.DynamicTableSource;
 import org.apache.flink.table.connector.source.InputFormatProvider;
 import org.apache.flink.table.connector.source.LookupTableSource;
@@ -77,6 +78,18 @@ public class JdbcDynamicTableSource
             keyNames[i] = DataType.getFieldNames(physicalRowDataType).get(innerKeyArr[0]);
         }
         final RowType rowType = (RowType) physicalRowDataType.getLogicalType();
+
+        if (lookupOptions.isLookupAsync()) {
+            return AsyncTableFunctionProvider.of(
+                    new JdbcRowDataAsyncLookupFunction(
+                            options,
+                            lookupOptions,
+                            DataType.getFieldNames(physicalRowDataType).toArray(new String[0]),
+                            DataType.getFieldDataTypes(physicalRowDataType)
+                                    .toArray(new DataType[0]),
+                            keyNames,
+                            rowType));
+        }
 
         return TableFunctionProvider.of(
                 new JdbcRowDataLookupFunction(

--- a/flink-connectors/flink-connector-jdbc/src/main/java/org/apache/flink/connector/jdbc/table/JdbcRowDataAsyncLookupFunction.java
+++ b/flink-connectors/flink-connector-jdbc/src/main/java/org/apache/flink/connector/jdbc/table/JdbcRowDataAsyncLookupFunction.java
@@ -1,0 +1,266 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.flink.connector.jdbc.table;
+
+import org.apache.flink.annotation.Internal;
+import org.apache.flink.annotation.VisibleForTesting;
+import org.apache.flink.connector.jdbc.converter.JdbcRowConverter;
+import org.apache.flink.connector.jdbc.dialect.JdbcDialect;
+import org.apache.flink.connector.jdbc.dialect.JdbcDialectLoader;
+import org.apache.flink.connector.jdbc.internal.connection.JdbcConnectionEntry;
+import org.apache.flink.connector.jdbc.internal.connection.JdbcConnectionPoolManager;
+import org.apache.flink.connector.jdbc.internal.options.JdbcConnectorOptions;
+import org.apache.flink.connector.jdbc.internal.options.JdbcLookupOptions;
+import org.apache.flink.connector.jdbc.statement.FieldNamedPreparedStatement;
+import org.apache.flink.table.data.GenericRowData;
+import org.apache.flink.table.data.RowData;
+import org.apache.flink.table.functions.AsyncTableFunction;
+import org.apache.flink.table.functions.FunctionContext;
+import org.apache.flink.table.types.DataType;
+import org.apache.flink.table.types.logical.LogicalType;
+import org.apache.flink.table.types.logical.RowType;
+
+import org.apache.flink.shaded.guava30.com.google.common.cache.Cache;
+import org.apache.flink.shaded.guava30.com.google.common.cache.CacheBuilder;
+import org.apache.flink.shaded.guava30.com.google.common.util.concurrent.ThreadFactoryBuilder;
+
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import java.sql.ResultSet;
+import java.sql.SQLException;
+import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.Collection;
+import java.util.Collections;
+import java.util.List;
+import java.util.concurrent.CompletableFuture;
+import java.util.concurrent.ExecutorService;
+import java.util.concurrent.Executors;
+import java.util.concurrent.ThreadFactory;
+import java.util.concurrent.TimeUnit;
+
+import static org.apache.flink.util.Preconditions.checkArgument;
+import static org.apache.flink.util.Preconditions.checkNotNull;
+
+/** A lookup function for {@link JdbcDynamicTableSource}. */
+@Internal
+public class JdbcRowDataAsyncLookupFunction extends AsyncTableFunction<RowData> {
+
+    private static final Logger LOG = LoggerFactory.getLogger(JdbcRowDataAsyncLookupFunction.class);
+
+    private final String query;
+    private JdbcConnectionPoolManager jdbcConnectionPoolManager;
+    private final DataType[] keyTypes;
+    private final long cacheMaxSize;
+    private final long cacheExpireMs;
+    private final int maxRetryTimes;
+    private final boolean cacheMissingKey;
+    private final JdbcDialect jdbcDialect;
+    private final JdbcRowConverter jdbcRowConverter;
+    private final JdbcRowConverter lookupKeyRowConverter;
+    private final int lookupAsyncParallelism;
+    private transient ExecutorService asyncExecutors;
+    private transient Cache<RowData, List<RowData>> cache;
+
+    public JdbcRowDataAsyncLookupFunction(
+            JdbcConnectorOptions options,
+            JdbcLookupOptions lookupOptions,
+            String[] fieldNames,
+            DataType[] fieldTypes,
+            String[] keyNames,
+            RowType rowType) {
+        checkNotNull(options, "No JdbcOptions supplied.");
+        checkNotNull(fieldNames, "No fieldNames supplied.");
+        checkNotNull(fieldTypes, "No fieldTypes supplied.");
+        checkNotNull(keyNames, "No keyNames supplied.");
+        this.lookupAsyncParallelism = lookupOptions.getLookupAsyncParallelism();
+        List<String> nameList = Arrays.asList(fieldNames);
+        this.keyTypes =
+                Arrays.stream(keyNames)
+                        .map(
+                                s -> {
+                                    checkArgument(
+                                            nameList.contains(s),
+                                            "keyName %s can't find in fieldNames %s.",
+                                            s,
+                                            nameList);
+                                    return fieldTypes[nameList.indexOf(s)];
+                                })
+                        .toArray(DataType[]::new);
+        this.cacheMaxSize = lookupOptions.getCacheMaxSize();
+        this.cacheExpireMs = lookupOptions.getCacheExpireMs();
+        this.maxRetryTimes = lookupOptions.getMaxRetryTimes();
+        this.cacheMissingKey = lookupOptions.getCacheMissingKey();
+        this.query =
+                options.getDialect()
+                        .getSelectFromStatement(options.getTableName(), fieldNames, keyNames);
+        String dbURL = options.getDbURL();
+        this.jdbcDialect = JdbcDialectLoader.load(dbURL);
+        this.jdbcRowConverter = jdbcDialect.getRowConverter(rowType);
+        this.lookupKeyRowConverter =
+                jdbcDialect.getRowConverter(
+                        RowType.of(
+                                Arrays.stream(keyTypes)
+                                        .map(DataType::getLogicalType)
+                                        .toArray(LogicalType[]::new)));
+        this.jdbcConnectionPoolManager =
+                new JdbcConnectionPoolManager(options, lookupAsyncParallelism, keyNames, query);
+    }
+
+    @Override
+    public void open(FunctionContext context) throws Exception {
+        try {
+            establishConnectionAndStatement();
+            this.cache =
+                    cacheMaxSize == -1 || cacheExpireMs == -1
+                            ? null
+                            : CacheBuilder.newBuilder()
+                                    .expireAfterWrite(cacheExpireMs, TimeUnit.MILLISECONDS)
+                                    .maximumSize(cacheMaxSize)
+                                    .build();
+            // Create async lookup thread pool
+            ThreadFactory threadFactory =
+                    new ThreadFactoryBuilder()
+                            .setDaemon(true)
+                            .setNameFormat("Flink JDBCAsyncLookupFunction Thread %d")
+                            .build();
+            asyncExecutors = Executors.newFixedThreadPool(lookupAsyncParallelism, threadFactory);
+        } catch (SQLException sqe) {
+            throw new IllegalArgumentException("open() failed.", sqe);
+        } catch (ClassNotFoundException cnfe) {
+            throw new IllegalArgumentException("JDBC driver class not found.", cnfe);
+        }
+    }
+
+    private void establishConnectionAndStatement()
+            throws SQLException, ClassNotFoundException, InterruptedException {
+        for (int i = 0; i < lookupAsyncParallelism; i++) {
+            jdbcConnectionPoolManager.createAndAddConnectionEntry();
+        }
+    }
+
+    public void eval(CompletableFuture<Collection<RowData>> future, Object... keys) {
+        GenericRowData keyRow = GenericRowData.of(keys);
+        if (cache != null) {
+            List<RowData> cachedRows = cache.getIfPresent(keyRow);
+            if (cachedRows != null) {
+                if (cachedRows.size() == 0) {
+                    future.complete(Collections.emptyList());
+                } else {
+                    for (RowData cachedRow : cachedRows) {
+                        future.complete(Collections.singletonList(cachedRow));
+                    }
+                }
+                return;
+            }
+        }
+        // async join
+        int currentRetry = 0;
+        fetchResult(future, currentRetry, keyRow);
+    }
+
+    private void fetchResult(
+            CompletableFuture<Collection<RowData>> future,
+            int currentRetry,
+            GenericRowData keyRow) {
+        // get async join resultFuture
+        CompletableFuture<Collection<RowData>> rowDataFuture = asyncJdbcExecute(keyRow);
+
+        rowDataFuture.whenCompleteAsync(
+                ((rowData, throwable) -> {
+                    if (throwable != null) {
+                        LOG.error("async jdbc exception,", throwable);
+                        if (currentRetry >= maxRetryTimes) {
+                            future.completeExceptionally(throwable);
+                        } else {
+                            try {
+                                Thread.sleep(1000 * currentRetry);
+                            } catch (InterruptedException e) {
+                                throw new RuntimeException("Reestablish JDBC connection failed", e);
+                            }
+                            fetchResult(future, currentRetry + 1, keyRow);
+                        }
+                    } else {
+                        future.complete(rowData);
+                    }
+                }));
+    }
+
+    private CompletableFuture<Collection<RowData>> asyncJdbcExecute(GenericRowData keyRow) {
+        return CompletableFuture.supplyAsync(
+                () -> {
+                    JdbcConnectionEntry connectionEntry = null;
+                    ArrayList<RowData> rows = new ArrayList<>();
+                    try {
+                        connectionEntry = jdbcConnectionPoolManager.getConnectionEntry();
+                        FieldNamedPreparedStatement statement = connectionEntry.getStatement();
+                        statement.clearParameters();
+                        statement = lookupKeyRowConverter.toExternal(keyRow, statement);
+                        ResultSet resultSet = statement.executeQuery();
+                        while (resultSet.next()) {
+                            RowData row = jdbcRowConverter.toInternal(resultSet);
+                            rows.add(row);
+                        }
+                        rows.trimToSize();
+                        if (cache != null) {
+                            if (!rows.isEmpty() || cacheMissingKey) {
+                                cache.put(keyRow, rows);
+                            }
+                        }
+                        return rows;
+                    } catch (SQLException | InterruptedException | ClassNotFoundException e) {
+                        try {
+                            connectionEntry =
+                                    jdbcConnectionPoolManager.checkAndCreateConnection(
+                                            connectionEntry);
+                        } catch (SQLException | ClassNotFoundException | InterruptedException ex) {
+                            LOG.error(
+                                    "JDBC connection is not valid, and reestablish connection failed",
+                                    ex);
+                        }
+                        throw new RuntimeException(e.getMessage());
+                    } finally {
+                        try {
+                            jdbcConnectionPoolManager.returnConnectionEntry(connectionEntry);
+                        } catch (InterruptedException e) {
+                            throw new RuntimeException(e.getMessage());
+                        }
+                    }
+                },
+                asyncExecutors);
+    }
+
+    @Override
+    public void close() throws Exception {
+        if (cache != null) {
+            cache.cleanUp();
+            cache = null;
+        }
+        jdbcConnectionPoolManager.closeAll();
+        if (asyncExecutors != null && !asyncExecutors.isShutdown()) {
+            asyncExecutors.shutdownNow();
+        }
+    }
+
+    @VisibleForTesting
+    public Cache<RowData, List<RowData>> getCache() {
+        return cache;
+    }
+}

--- a/flink-connectors/flink-connector-jdbc/src/test/java/org/apache/flink/connector/jdbc/table/JdbcRowDataAsyncLookupFunctionTest.java
+++ b/flink-connectors/flink-connector-jdbc/src/test/java/org/apache/flink/connector/jdbc/table/JdbcRowDataAsyncLookupFunctionTest.java
@@ -1,0 +1,241 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.flink.connector.jdbc.table;
+
+import org.apache.flink.connector.jdbc.internal.options.JdbcConnectorOptions;
+import org.apache.flink.connector.jdbc.internal.options.JdbcLookupOptions;
+import org.apache.flink.table.api.DataTypes;
+import org.apache.flink.table.data.GenericRowData;
+import org.apache.flink.table.data.RowData;
+import org.apache.flink.table.data.StringData;
+import org.apache.flink.table.types.DataType;
+import org.apache.flink.table.types.logical.LogicalType;
+import org.apache.flink.table.types.logical.RowType;
+
+import org.apache.flink.shaded.guava30.com.google.common.cache.Cache;
+import org.apache.flink.shaded.guava30.com.google.common.collect.Lists;
+
+import org.junit.Test;
+
+import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.Collection;
+import java.util.Collections;
+import java.util.List;
+import java.util.concurrent.CompletableFuture;
+import java.util.concurrent.CountDownLatch;
+import java.util.stream.Collectors;
+
+import static org.apache.flink.connector.jdbc.JdbcTestFixture.DERBY_EBOOKSHOP_DB;
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertTrue;
+
+/** Test suite for {@link JdbcRowDataAsyncLookupFunction}. */
+public class JdbcRowDataAsyncLookupFunctionTest extends JdbcLookupTestBase {
+
+    private static String[] fieldNames = new String[] {"id1", "id2", "comment1", "comment2"};
+    private static DataType[] fieldDataTypes =
+            new DataType[] {
+                DataTypes.INT(), DataTypes.STRING(), DataTypes.STRING(), DataTypes.STRING()
+            };
+
+    private static String[] lookupKeys = new String[] {"id1", "id2"};
+
+    @Test
+    public void testEval() throws Exception {
+
+        JdbcLookupOptions lookupOptions = JdbcLookupOptions.builder().build();
+        JdbcRowDataAsyncLookupFunction lookupFunction =
+                buildRowDataAsyncLookupFunction(lookupOptions);
+        lookupFunction.open(null);
+        List<String> result = new ArrayList();
+        Object[][] rowKeys =
+                new Object[][] {
+                    new Object[] {1, "1"},
+                    new Object[] {2, "3"},
+                };
+
+        CountDownLatch latch = new CountDownLatch(rowKeys.length);
+
+        for (Object[] rowKey : rowKeys) {
+            CompletableFuture<Collection<RowData>> future = new CompletableFuture<>();
+            lookupFunction.eval(future, rowKey[0], StringData.fromString(rowKey[1].toString()));
+            future.whenComplete(
+                    (rs, t) -> {
+                        synchronized (result) {
+                            rs.forEach(row -> result.add(row.toString()));
+                        }
+                        latch.countDown();
+                    });
+        }
+        // this verifies lookup calls are async
+        assertTrue(result.size() < rowKeys.length);
+        latch.await();
+
+        // close connection pool
+        lookupFunction.close();
+        List<String> sortResult =
+                Lists.newArrayList(result).stream().sorted().collect(Collectors.toList());
+        List<String> expected = new ArrayList<>();
+
+        expected.add("+I(1,1,11-c1-v1,11-c2-v1)");
+        expected.add("+I(1,1,11-c1-v2,11-c2-v2)");
+        expected.add("+I(2,3,null,23-c2)");
+        Collections.sort(expected);
+
+        assertEquals(sortResult, expected);
+    }
+
+    @Test
+    public void testEvalWithCacheMissingKeyPositive() throws Exception {
+        JdbcLookupOptions lookupOptions =
+                JdbcLookupOptions.builder()
+                        .setCacheMissingKey(true)
+                        .setCacheExpireMs(60000)
+                        .setCacheMaxSize(10)
+                        .setLookupAsyncParallelism(2)
+                        .build();
+        JdbcRowDataAsyncLookupFunction lookupFunction =
+                buildRowDataAsyncLookupFunction(lookupOptions);
+        lookupFunction.open(null);
+        RowData keyRow = GenericRowData.of(4, StringData.fromString("9"));
+        List<String> result = new ArrayList();
+
+        CompletableFuture<Collection<RowData>> future = new CompletableFuture<>();
+        lookupFunction.eval(future, 4, StringData.fromString("9"));
+        future.whenCompleteAsync(
+                (rs, t) -> {
+                    rs.forEach(row -> result.add(row.toString()));
+                });
+        future.get();
+        // get cache
+        Cache<RowData, List<RowData>> cache = lookupFunction.getCache();
+
+        // empty data should cache
+        assertEquals(cache.getIfPresent(keyRow), Collections.<RowData>emptyList());
+
+        // put db entry for keyRow
+        // final cache output should also be empty till TTL expires
+        insert(
+                "INSERT INTO "
+                        + LOOKUP_TABLE
+                        + " (id1, id2, comment1, comment2) VALUES (4, '9', '49-c1', '49-c2')");
+
+        lookupFunction.eval(future, 4, StringData.fromString("9"));
+        future.whenCompleteAsync(
+                (rs, t) -> {
+                    rs.forEach(row -> result.add(row.toString()));
+                });
+        future.get();
+
+        assertEquals(cache.getIfPresent(keyRow), Collections.<RowData>emptyList());
+    }
+
+    @Test
+    public void testEvalWithCacheMissingKeyNegative() throws Exception {
+        JdbcLookupOptions lookupOptions =
+                JdbcLookupOptions.builder()
+                        .setCacheMissingKey(false)
+                        .setCacheExpireMs(60000)
+                        .setCacheMaxSize(10)
+                        .build();
+
+        JdbcRowDataAsyncLookupFunction lookupFunction =
+                buildRowDataAsyncLookupFunction(lookupOptions);
+        lookupFunction.open(null);
+        List<String> result = new ArrayList();
+        Object[][] rowKeys = new Object[][] {new Object[] {5, "1"}};
+        RowData keyRow = GenericRowData.of(5, StringData.fromString("1"));
+
+        CountDownLatch latch = new CountDownLatch(rowKeys.length);
+        for (Object[] rowKey : rowKeys) {
+            CompletableFuture<Collection<RowData>> future = new CompletableFuture<>();
+            lookupFunction.eval(future, rowKey[0], StringData.fromString(rowKey[1].toString()));
+            future.whenComplete(
+                    (rs, t) -> {
+                        synchronized (result) {
+                            rs.forEach(row -> result.add(row.toString()));
+                        }
+                        latch.countDown();
+                    });
+        }
+        latch.await();
+        Cache<RowData, List<RowData>> cache = lookupFunction.getCache();
+        // empty data should not get cached
+        assert cache.getIfPresent(keyRow) == null;
+
+        // put db entry for keyRow
+        // final cache output should contain data
+        insert(
+                "INSERT INTO "
+                        + LOOKUP_TABLE
+                        + " (id1, id2, comment1, comment2) VALUES (5, '1', '51-c1', '51-c2')");
+
+        CountDownLatch latchAfter = new CountDownLatch(rowKeys.length);
+        for (Object[] rowKey : rowKeys) {
+            CompletableFuture<Collection<RowData>> future = new CompletableFuture<>();
+            lookupFunction.eval(future, rowKey[0], StringData.fromString(rowKey[1].toString()));
+            future.whenComplete(
+                    (rs, t) -> {
+                        synchronized (result) {
+                            rs.forEach(row -> result.add(row.toString()));
+                        }
+                        latchAfter.countDown();
+                    });
+        }
+        latchAfter.await();
+
+        List<RowData> expectedOutput = new ArrayList<>();
+        expectedOutput.add(
+                GenericRowData.of(
+                        5,
+                        StringData.fromString("1"),
+                        StringData.fromString("51-c1"),
+                        StringData.fromString("51-c2")));
+        assertEquals(cache.getIfPresent(keyRow), expectedOutput);
+    }
+
+    private JdbcRowDataAsyncLookupFunction buildRowDataAsyncLookupFunction(
+            JdbcLookupOptions lookupOptions) {
+        JdbcConnectorOptions jdbcOptions =
+                JdbcConnectorOptions.builder()
+                        .setDriverName(DERBY_EBOOKSHOP_DB.getDriverClass())
+                        .setDBUrl(DB_URL)
+                        .setTableName(LOOKUP_TABLE)
+                        .build();
+
+        RowType rowType =
+                RowType.of(
+                        Arrays.stream(fieldDataTypes)
+                                .map(DataType::getLogicalType)
+                                .toArray(LogicalType[]::new),
+                        fieldNames);
+
+        JdbcRowDataAsyncLookupFunction lookupFunction =
+                new JdbcRowDataAsyncLookupFunction(
+                        jdbcOptions,
+                        lookupOptions,
+                        fieldNames,
+                        fieldDataTypes,
+                        lookupKeys,
+                        rowType);
+
+        return lookupFunction;
+    }
+}


### PR DESCRIPTION
## **What is the purpose of the change**
JdbcTableSource supports  jdbc async look up join

## **Brief change log**
1.add class JdbcRowDataAsyncLookupFunction
2.add class JdbcConnectionPoolManager,manager connection entry
3.add class JdbcConnectionEntry
4.modify JdbcConnectorOptions, add async/async.parallelism options
5.modify JdbcDynamicTableFactory, add async options
6.modify JdbcDynamicTableSource, add asyncFunction provider

## **Verifying this change**
This change added tests and can be verified as follows:

1.JdbcDynamicTableFactoryTest#testJdbcAsyncLookupProvider


## Does this pull request potentially affect one of the following parts:

  - Dependencies (does it add or upgrade a dependency): (no)
  - The public API, i.e., is any changed class annotated with `@Public(Evolving)`: (no)
  - The serializers: (don't know)
  - The runtime per-record code paths (performance sensitive): (don't know)
  - Anything that affects deployment or recovery: JobManager (and its components), Checkpointing, Kubernetes/Yarn, ZooKeeper: (no )
  - The S3 file system connector: (no)

## Documentation

  - Does this pull request introduce a new feature? (yes)
  - If yes, how is the feature documented? ( docs / JavaDocs )
